### PR TITLE
validated FHIR response in getTimeSlots and getTimeSlotsByMonth

### DIFF
--- a/apps/api/controllers/PetController.js
+++ b/apps/api/controllers/PetController.js
@@ -114,8 +114,6 @@ static async handleEditPet(req, res) {
     const updatedPetData = await FHIRMapperService.convertFHIRToPet(parsedData);
 
     // Handle file uploads (optional)
-    let imageUrls = '';
-
     if (req.files && req.files.files) {
       const files = Array.isArray(req.files.files)
         ? req.files.files
@@ -124,10 +122,10 @@ static async handleEditPet(req, res) {
       const imageFiles = files.filter(file => file.mimetype && file.mimetype.startsWith("image/"));
     
       if (imageFiles.length > 0) {
-        imageUrls = await PetService.uploadFiles(imageFiles);
+        const imageUrls = await PetService.uploadFiles(imageFiles);
+        updatedPetData.petImage = imageUrls;
       }
     }
-    updatedPetData.petImage = imageUrls;
 
     // Securely update the pet record
     const editPetData = await PetService.updatePetById(id, updatedPetData);
@@ -137,7 +135,7 @@ static async handleEditPet(req, res) {
 
     const fhirFormattedResponse = await FHIRMapper.convertPetToFHIR(editPetData, process.env.BASE_URL);
 
-    res.json({ status: 0, data: fhirFormattedResponse });
+    res.json({ status: 1, data: fhirFormattedResponse });
   } catch (error) {
     console.error("Update error:", error);
     res.status(500).json({
@@ -146,6 +144,7 @@ static async handleEditPet(req, res) {
     });
   }
 }
+
 
 
 // Remove a pet record from the database

--- a/apps/api/controllers/SlotController.js
+++ b/apps/api/controllers/SlotController.js
@@ -1,10 +1,14 @@
 const SlotService = require('../services/SlotService');
 const MonthlySlotService = require("../services/MonthlySlotService");
+const  FHIRSlotValidator  = require('../validators/FHIRSlotValidator');
+const  MonthlySlotValidator  = require('../validators/MonthlySlotValidator');
+const FHIRValidator = require("../validators/FHIRValidator");
 
 class SlotController {
   static async handlegetTimeSlots(req, res) {
     try {
-      const { appointmentDate, doctorId } = req.body;
+      const appointmentDate = req.params.appointmentDate;
+      const doctorId = req.params.doctorId;
 
       if (!appointmentDate || !doctorId) {
         return res.status(400).json({
@@ -17,6 +21,16 @@ class SlotController {
       }
 
       const result = await SlotService.getAvailableTimeSlots({ appointmentDate, doctorId });
+      const validationErrors = FHIRSlotValidator.validateBundle(result);
+    if (validationErrors.length > 0) {
+      return res.status(400).json({
+        issue: validationErrors.map(msg => ({
+          severity: "error",
+          code: "invalid",
+          details: { text: msg }
+        }))
+      });
+    }
       return res.status(200).json(result);
     } catch (error) {
       console.error("SlotController Error:", error);
@@ -31,10 +45,23 @@ class SlotController {
   }
 
   static async handleTimeSlotsByMonth(req, res) {
-    const { doctorId, slotMonth, slotYear } = req.body;
+    const { slotMonth, slotYear, doctorId } = req.params;
 
+    const issues = MonthlySlotValidator.validateRequest({ doctorId, slotMonth, slotYear });
+
+    if (issues.length > 0) {
+      return res.status(400).json({ issue: issues });
+    }
+    
     try {
       const result = await MonthlySlotService.generateMonthlySlotSummary({ doctorId, slotMonth, slotYear });
+
+      const fhirIssues = FHIRValidator.validateFHIRBundle(result);
+
+      if (fhirIssues.length > 0) {
+        return res.status(400).json({ issue: fhirIssues });
+      }
+
       return res.json(result);
     } catch (error) {
       console.error("MonthlySlotController Error:", error);

--- a/apps/api/mappers/FHIRMapper.js
+++ b/apps/api/mappers/FHIRMapper.js
@@ -48,7 +48,7 @@ class FHIRMapper {
         { url: `${baseUrl}/fhir/extensions/pet-from`, valueString: pet.petFrom, title: 'petFrom' },
         {
           url: `${baseUrl}/fhir/StructureDefinition/pet-images`,
-          valueString: Array.isArray(pet.petImage) ? pet.petImage.join(', ') : pet.petImage,
+          valueString: pet.petImage[0],
           title: 'petImage'
         }
       ],

--- a/apps/api/middlewares/upload.js
+++ b/apps/api/middlewares/upload.js
@@ -15,7 +15,7 @@ const s3 = new AWS.S3({
 async function uploadToS3(fileName, fileContent, mimeType) {
     const params = {
         Bucket: process.env.AWS_S3_BUCKET_NAME,
-        Key: fileName,
+        Key: `${fileName}`,
         Body: fileContent,
         ContentType: mimeType,
         ContentDisposition: 'inline',
@@ -30,7 +30,7 @@ async function uploadToS3(fileName, fileContent, mimeType) {
 }
 
 // Handle single file upload to S3
-async function handleFileUpload(file) {
+async function handleFileUpload(file,folderName) {
     try {
         if (!file) {
             throw new Error('No file uploaded.');
@@ -43,7 +43,7 @@ async function handleFileUpload(file) {
 
         const safeFileName = sanitizeFilename(file.name) || 'file';
         const fileExtension = path.extname(safeFileName);
-        const fileName = `${uuidv4()}${fileExtension}`;
+        const fileName = `${folderName}/${uuidv4()}${fileExtension}`;
 
         const fileContent = file.data; // file.data should be a Buffer
         const mimeType = file.mimetype;
@@ -65,8 +65,8 @@ async function handleFileUpload(file) {
 }
 
 // Handle multiple files upload to S3
-async function handleMultipleFileUpload(files) {
-    const uploadPromises = files.map(file => handleFileUpload(file));
+async function handleMultipleFileUpload(files,folderName="Images") {
+    const uploadPromises = files.map(file => handleFileUpload(file,folderName));
     return Promise.all(uploadPromises);
 }
 

--- a/apps/api/models/YoshPet.js
+++ b/apps/api/models/YoshPet.js
@@ -58,9 +58,13 @@ const patSchema = new mongoose.Schema({
     petFrom:{
         type: String,
     },
-    petImage:{
-        type: [String],
-    },
+    petImage:[
+        {
+            url: { type: String },
+            originalname: { type: String },
+            mimetype: { type: String }
+        }
+    ],
 
 }, { timestamps: true});
 

--- a/apps/api/routes/user.js
+++ b/apps/api/routes/user.js
@@ -65,8 +65,8 @@ router.post("/bookAppointment",verifyTokenAndRefresh, AppointmentController.hand
 router.get("/getappointments", verifyTokenAndRefresh, AppointmentController.handleGetAppointment);
 router.put("/cancelappointment/:appointmentID", verifyTokenAndRefresh, AppointmentController.handleCancelAppointment);
 router.put("/rescheduleAppointment/:appointmentID",verifyTokenAndRefresh, AppointmentController.handleRescheduleAppointment);
-router.post("/getTimeSlots", verifyTokenAndRefresh, SlotController.handlegetTimeSlots);
-router.post("/getTimeSlotsByMonth",verifyTokenAndRefresh,SlotController.handleTimeSlotsByMonth);
+router.get("/getTimeSlots/:appointmentDate/:doctorId", verifyTokenAndRefresh, SlotController.handlegetTimeSlots);
+router.get("/getTimeSlotsByMonth/:slotMonth/:slotYear/:doctorId",verifyTokenAndRefresh,SlotController.handleTimeSlotsByMonth);
 router.post("/saveFeedBack",verifyTokenAndRefresh,FeedbackController.handlesaveFeedBack);
 router.get("/getFeedBack",verifyTokenAndRefresh,FeedbackController.handleGetFeedback);
 router.put("/editFeedBack/:feedbackId",verifyTokenAndRefresh,FeedbackController.handleEditFeedBack);

--- a/apps/api/services/PetService.js
+++ b/apps/api/services/PetService.js
@@ -5,7 +5,7 @@ const {  handleMultipleFileUpload } = require('../middlewares/upload'); // assum
 class PetService {
   static async uploadFiles(files) {
     const fileArray = Array.isArray(files) ? files : [files];
-    return await handleMultipleFileUpload(fileArray);
+    return await handleMultipleFileUpload(fileArray,'Images');
   }
 
   static async createPet(data) {

--- a/apps/api/services/SlotService.js
+++ b/apps/api/services/SlotService.js
@@ -22,8 +22,8 @@ class SlotService {
       };
     }
 
-    const days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
-    const day = days[dateObj.getDay()];
+    const validDays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+    const day = validDays[dateObj.getDay()];
     
     if (!validDays.includes(day)) {
       throw new Error("Invalid day");

--- a/apps/api/validators/FHIRSlotValidator.js
+++ b/apps/api/validators/FHIRSlotValidator.js
@@ -1,0 +1,65 @@
+
+class FHIRSlotValidator {
+    static validateBundle(bundle) {
+      const errors = [];
+  
+      if (!bundle || bundle.resourceType !== "Bundle" || bundle.type !== "collection") {
+        errors.push("Invalid bundle structure");
+        return errors;
+      }
+  
+      if (!Array.isArray(bundle.entry)) {
+        errors.push("Bundle entry must be an array");
+        return errors;
+      }
+  
+      bundle.entry.forEach((entry, index) => {
+        const slot = entry?.resource;
+        const path = `entry[${index}].resource`;
+  
+        if (!slot) {
+          errors.push(`${path} is missing`);
+          return;
+        }
+  
+        errors.push(...this.validateSlot(slot, path));
+      });
+  
+      return errors;
+    }
+  
+    static validateSlot(slot, path = 'resource') {
+      const errors = [];
+  
+      if (slot.resourceType !== "Slot") {
+        errors.push(`${path}.resourceType must be 'Slot'`);
+      }
+  
+      if (!slot.id || typeof slot.id !== "string") {
+        errors.push(`${path}.id must be a string`);
+      }
+  
+      if (
+        !slot.schedule ||
+        !slot.schedule.reference ||
+        typeof slot.schedule.reference !== "string" ||
+        !slot.schedule.reference.startsWith("Schedule/")
+      ) {
+        errors.push(`${path}.schedule.reference must be a string starting with 'Schedule/'`);
+      }
+  
+      if (typeof slot.isBooked !== "string" || !["true", "false"].includes(slot.isBooked.toLowerCase())) {
+        errors.push(`${path}.isBooked must be 'true' or 'false' as string`);
+      }
+  
+      const timeRegex = /^(0?[1-9]|1[0-2]):[0-5][0-9] (AM|PM)$/;
+      if (!slot.slotTime || typeof slot.slotTime !== "string" || !timeRegex.test(slot.slotTime)) {
+        errors.push(`${path}.slotTime must be in format like '11:45 AM'`);
+      }
+  
+      return errors;
+    }
+  }
+  
+  module.exports = FHIRSlotValidator;
+  

--- a/apps/api/validators/FHIRValidator.js
+++ b/apps/api/validators/FHIRValidator.js
@@ -1,0 +1,89 @@
+// validators/FHIRValidator.js
+class FHIRValidator {
+    static validateFHIRBundle(bundle) {
+      const issues = [];
+  
+      // Check if the bundle is correctly structured
+      if (!bundle || bundle.resourceType !== "Bundle" || bundle.type !== "collection") {
+        issues.push({
+          severity: "error",
+          code: "invalid",
+          details: { text: "Invalid FHIR Bundle structure" },
+        });
+      }
+  
+      // Validate each entry in the bundle
+      if (Array.isArray(bundle.entry)) {
+        bundle.entry.forEach((entry, index) => {
+          if (!entry.resource) {
+            issues.push({
+              severity: "error",
+              code: "invalid",
+              details: { text: `Missing resource in entry ${index + 1}` },
+            });
+          }
+  
+          // Validate Schedule
+          if (entry.resource.resourceType === "Schedule") {
+            if (!entry.resource.id) {
+              issues.push({
+                severity: "error",
+                code: "invalid",
+                details: { text: `Missing Schedule id in entry ${index + 1}` },
+              });
+            }
+            if (!entry.resource.identifier || entry.resource.identifier.length === 0) {
+              issues.push({
+                severity: "error",
+                code: "invalid",
+                details: { text: `Missing Schedule identifier in entry ${index + 1}` },
+              });
+            }
+            if (!entry.resource.actor || entry.resource.actor.length === 0) {
+              issues.push({
+                severity: "error",
+                code: "invalid",
+                details: { text: `Missing actor in Schedule entry ${index + 1}` },
+              });
+            }
+          }
+  
+          // Validate Observation
+          if (entry.resource.resourceType === "Observation") {
+            if (!entry.resource.code || !entry.resource.code.coding || entry.resource.code.coding.length === 0) {
+              issues.push({
+                severity: "error",
+                code: "invalid",
+                details: { text: `Missing Observation code in entry ${index + 1}` },
+              });
+            }
+            if (!entry.resource.subject) {
+              issues.push({
+                severity: "error",
+                code: "invalid",
+                details: { text: `Missing subject in Observation entry ${index + 1}` },
+              });
+            }
+            if (!entry.resource.component || entry.resource.component.length === 0) {
+              issues.push({
+                severity: "error",
+                code: "invalid",
+                details: { text: `Missing component in Observation entry ${index + 1}` },
+              });
+            }
+          }
+        });
+      } else {
+        issues.push({
+          severity: "error",
+          code: "invalid",
+          details: { text: "Missing or invalid 'entry' array in the FHIR Bundle" },
+        });
+      }
+  
+      return issues;
+    }
+  }
+  
+  module.exports = FHIRValidator;
+  

--- a/apps/api/validators/MonthlySlotValidator.js
+++ b/apps/api/validators/MonthlySlotValidator.js
@@ -1,0 +1,35 @@
+// validators/MonthlySlotValidator.js
+class MonthlySlotValidator {
+    static validateRequest({ doctorId, slotMonth, slotYear }) {
+      const issues = [];
+  
+      if (!doctorId) {
+        issues.push({
+          severity: "error",
+          code: "invalid",
+          details: { text: "Doctor ID is required" }
+        });
+      }
+  
+      if (!slotMonth || isNaN(slotMonth) || slotMonth < 1 || slotMonth > 12) {
+        issues.push({
+          severity: "error",
+          code: "invalid",
+          details: { text: "Valid month (1-12) is required" }
+        });
+      }
+  
+      if (!slotYear || isNaN(slotYear) || slotYear.toString().length !== 4) {
+        issues.push({
+          severity: "error",
+          code: "invalid",
+          details: { text: "Valid 4-digit year is required" }
+        });
+      }
+  
+      return issues;
+    }
+  }
+  
+  module.exports = MonthlySlotValidator;
+  


### PR DESCRIPTION
<!--
We, the rest of the Yosemite community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

1. The getTimeSlots and getTimeSlotsByMonth endpoints return time slot data without strict validation against FHIR standards.
2. The response may include time slot information in a custom or loosely structured format.

## What is the new behavior?

1. The responses from both getTimeSlots and getTimeSlotsByMonth are now validated and formatted as per the FHIR Slot resource.
2. The responses are now interoperable with other FHIR-compatible systems and tools.
3. Ensures consistency, reliability, and correctness of data being exchanged across systems using the FHIR standard.


Fixes #140 

<!-- If this PR contains a breaking change, please describe the impact for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]


