### PR TITLE
Update getTimeSlot API And getTimeSlot api request data to FHIR

### DIFF
--- a/apps/api/routes/user.js
+++ b/apps/api/routes/user.js
@@ -65,8 +65,8 @@ router.post("/bookAppointment",verifyTokenAndRefresh, AppointmentController.hand
 router.get("/getappointments", verifyTokenAndRefresh, AppointmentController.handleGetAppointment);
 router.put("/cancelappointment/:appointmentID", verifyTokenAndRefresh, AppointmentController.handleCancelAppointment);
 router.put("/rescheduleAppointment/:appointmentID",verifyTokenAndRefresh, AppointmentController.handleRescheduleAppointment);
-router.get("/getTimeSlots/:appointmentDate/:doctorId", verifyTokenAndRefresh, SlotController.handlegetTimeSlots);
-router.get("/getTimeSlotsByMonth/:slotMonth/:slotYear/:doctorId",verifyTokenAndRefresh,SlotController.handleTimeSlotsByMonth);
+router.post("/getTimeSlots", verifyTokenAndRefresh, SlotController.handlegetTimeSlots);
+router.post("/getTimeSlotsByMonth",verifyTokenAndRefresh,SlotController.handleTimeSlotsByMonth);
 router.post("/saveFeedBack",verifyTokenAndRefresh,FeedbackController.handlesaveFeedBack);
 router.get("/getFeedBack",verifyTokenAndRefresh,FeedbackController.handleGetFeedback);
 router.put("/editFeedBack/:feedbackId",verifyTokenAndRefresh,FeedbackController.handleEditFeedBack);

--- a/apps/api/services/SlotService.js
+++ b/apps/api/services/SlotService.js
@@ -2,14 +2,10 @@ const moment = require('moment');
 const DoctorsTimeSlotes  = require('../models/DoctorsSlotes');
 const { webAppointments } = require("../models/WebAppointment");
 const { createFHIRSlot } = require('../utils/fhirUtils');
-const mongoose = require('mongoose');
+
 
 class SlotService {
   static async getAvailableTimeSlots({ appointmentDate, doctorId }) {
-
-    if (!mongoose.Types.ObjectId.isValid(doctorId)) {
-      throw new Error("Invalid doctor ID");
-    }
 
     const dateObj = new Date(appointmentDate);
     if (isNaN(dateObj.getTime())) {


### PR DESCRIPTION
<!--
We, the rest of the Yosemite community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?
The current getTimeSlot API and getTimeSlotByMonth likely returns time slot data in a custom or non-FHIR format

## What is the new behavior?

- Accept parameters in a FHIR-compliant way (e.g., schedule, start, end).
- Return results in FHIR Slot resource format


Fixes #143 

<!-- If this PR contains a breaking change, please describe the impact for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]


