### PR TITLE
Updated request data format for both gettimeslot api and gettimeslotsbymonth api

### DIFF
--- a/apps/api/controllers/SlotController.js
+++ b/apps/api/controllers/SlotController.js
@@ -8,24 +8,9 @@ const mongoose = require('mongoose');
 class SlotController {
   static async handlegetTimeSlots(req, res) {
     try {
-      const rawData = req.body.data;
-      let fhirData;
-      try {
-        fhirData = typeof rawData === "string" ? JSON.parse(rawData) : rawData;
-      } catch (e) {
-        return res.status(400).json({
-          issue: [{
-            severity: "error",
-            code: "invalid",
-            details: { text: "Invalid JSON format in 'data' field" }
-          }]
-        });
-      }
-    const appointmentDate = fhirData?.start?.split("T")[0];
-    const doctorParticipant = fhirData?.participant?.find(p =>
-      p.actor?.reference?.startsWith("Practitioner/")
-    );
-    const doctorId = doctorParticipant?.actor?.reference?.split("/")[1];
+     
+    const { appointmentDate, doctorId } = req.params;
+ 
       if (!appointmentDate || !doctorId) {
         return res.status(400).json({
           issue: [{
@@ -65,23 +50,8 @@ class SlotController {
 
   static async handleTimeSlotsByMonth(req, res) {
    
-    const rawData = req.body.data;
-      let fhirData;
-      try {
-        fhirData = typeof rawData === "string" ? JSON.parse(rawData) : rawData;
-      } catch (e) {
-        return res.status(400).json({
-          issue: [{
-            severity: "error",
-            code: "invalid",
-            details: { text: "Invalid JSON format in 'data' field" }
-          }]
-        });
-      }
-      const doctorId = fhirData.participant?.[0]?.actor?.reference?.split("/")[1];
-      
-      const slotMonth = fhirData.extension?.find(e => e.url.includes('slot-month'))?.valueInteger;
-      const slotYear = fhirData.extension?.find(e => e.url.includes('slot-year'))?.valueInteger;
+    const { slotMonth , slotYear , doctorId } = req.params;
+
       const issues = MonthlySlotValidator.validateRequest({ doctorId, slotMonth, slotYear });
 
     if (issues.length > 0) {

--- a/apps/api/routes/user.js
+++ b/apps/api/routes/user.js
@@ -65,8 +65,8 @@ router.post("/bookAppointment",verifyTokenAndRefresh, AppointmentController.hand
 router.get("/getappointments", verifyTokenAndRefresh, AppointmentController.handleGetAppointment);
 router.put("/cancelappointment/:appointmentID", verifyTokenAndRefresh, AppointmentController.handleCancelAppointment);
 router.put("/rescheduleAppointment/:appointmentID",verifyTokenAndRefresh, AppointmentController.handleRescheduleAppointment);
-router.post("/getTimeSlots", verifyTokenAndRefresh, SlotController.handlegetTimeSlots);
-router.post("/getTimeSlotsByMonth",verifyTokenAndRefresh,SlotController.handleTimeSlotsByMonth);
+router.get("/Slot/getTimeSlots/:appointmentDate/:doctorId", verifyTokenAndRefresh, SlotController.handlegetTimeSlots);
+router.get("/Slot/getTimeSlotsByMonth/:slotMonth/:slotYear/:doctorId",verifyTokenAndRefresh,SlotController.handleTimeSlotsByMonth);
 router.post("/saveFeedBack",verifyTokenAndRefresh,FeedbackController.handlesaveFeedBack);
 router.get("/getFeedBack",verifyTokenAndRefresh,FeedbackController.handleGetFeedback);
 router.put("/editFeedBack/:feedbackId",verifyTokenAndRefresh,FeedbackController.handleEditFeedBack);
@@ -81,7 +81,7 @@ router.post("/Organization/addPetBoarding",verifyTokenAndRefresh, DetailsControl
 
 router.post("/sendquery", verifyTokenAndRefresh,handleContactUs);
 router.post("/getLists",handleGetLists);
-router.post("/getDoctorsLists",handlegetDoctorsLists);
+router.get("/Practitioners/getDoctorsLists/:businessId/:departmentId",handlegetDoctorsLists);
 
 router.post("/getDoctorsTeam",handlegetDoctorsTeam);
 router.post("/addVaccinationRecord",verifyTokenAndRefresh,handleAddVaccination);


### PR DESCRIPTION

<!--
We, the rest of the Yosemite community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?
Currently, the API uses the POST method to retrieve data for resources like current Time slots and time slots by month, which is intended to be a read-only operation.this approach is not RESTful and does not align with FHIR guidelines, which expect GET requests with query parameters for such operations.

## What is the new behavior?
The updated implementation uses the GET method to retrieve resource data in accordance with REST and FHIR standards. Instead of sending a request body, filters are now passed as query parameters in the URL.


Fixes #186 

<!-- If this PR contains a breaking change, please describe the impact for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]


