### PR TITLE
Potential fix for code scanning alert no. 299: Database query built from user-controlled sources

### DIFF
--- a/apps/api/controllers/vaccination.js
+++ b/apps/api/controllers/vaccination.js
@@ -31,20 +31,35 @@ async function handleAddVaccination(req,res){
 
 async function handleEditVaccination(req,res) {
     try {
-    const updatedData = req.body;
+    const rawData = req.body;
     const id = req.params.id;
-    const document =  req.file;
-    if(document) {
+    const document = req.file;
+    const allowedFields = [
+        "manufacturerName",
+        "vaccineName",
+        "batchNumber",
+        "expiryDate",
+        "vaccinationDate",
+        "hospitalName",
+        "nextdueDate"
+    ];
+    const updatedData = {};
+    for (const key of allowedFields) {
+        if (rawData[key]) {
+            updatedData[key] = rawData[key];
+        }
+    }
+    if (document) {
         updatedData.vaccineImage = document.filename;
     }
     if (!mongoose.Types.ObjectId.isValid(id)) {
-      throw new Error('Invalid ID format');
+        throw new Error('Invalid ID format');
     }
     const editVaccination = await vaccination.findOneAndUpdate(
-       { _id: id }, 
-        updatedData,
+        { _id: id },
+        { $set: updatedData },
         { new: true }
-      );
+    );
     if (!editVaccination) {
         return res.status(404).json({ message: "Vaccination record not found" });
       }


### PR DESCRIPTION
Potential fix for [https://github.com/YosemiteCrew/Yosemite-Crew/security/code-scanning/299](https://github.com/YosemiteCrew/Yosemite-Crew/security/code-scanning/299)

To fix the issue, we need to ensure that the `updatedData` object is sanitized and validated before being used in the `findOneAndUpdate` query. This can be achieved by:
1. Validating the structure and content of `updatedData` to ensure it only contains expected fields with valid values.
2. Using MongoDB's `$set` operator to explicitly specify which fields should be updated, rather than passing the entire `updatedData` object directly.

The fix involves:
- Adding a validation step to filter and validate the fields in `updatedData`.
- Modifying the `findOneAndUpdate` query to use the `$set` operator with the validated data.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
