### PR TITLE
Add API to retrieve and filter exercise list

### DIFF
--- a/apps/api/controllers/AdminController.js
+++ b/apps/api/controllers/AdminController.js
@@ -1,0 +1,96 @@
+
+const ExercisePlanModel = require('../models/YoshExercisePlans');
+const ExerciseTypeModel = require('../models/ExerciseTypeModel');
+const ExercisesModel = require('../models/YoshExercises');
+const FHIRExerciseService = require('../services/FHIRExerciseService');
+
+class AdminController {
+
+   //Retrieve all plan types added by the admin
+    static async planTypes(req, res) {
+      try {
+        const exercisePlans = await ExercisePlanModel.find({});
+        const fhirBundle = FHIRExerciseService.convertPlanTypesToFHIR(exercisePlans);
+        return res.status(200).json(fhirBundle);
+      } catch (error) {
+        res.status(500).json({ status: 0, message: 'Internal Server Error' });
+      }
+    }
+
+    //Retrieve all exercise types added by the admin
+    static async exerciseTypes(req, res) {
+      try {
+        const exerciseTypes = await ExerciseTypeModel.find({});
+        const fhirBundle = FHIRExerciseService.convertExerciseTypeToFHIR(exerciseTypes);
+        return res.status(200).json(fhirBundle);
+      } catch (error) {
+        res.status(500).json({ status: 0, message: 'Internal Server Error' });
+      }
+    }
+
+   //Retrieve all exercise according type
+   static async getExercise(req, res) {
+    try {
+      const {
+        type,
+        keyword = "",
+        page = 1,
+        limit = 10,
+        sort = "desc"
+      } = req.query;
+      const regex = new RegExp(keyword, "i");
+
+      // Build the base query
+      const query = {
+        ...(type && { exerciseType: type }),
+        ...(keyword && {
+          $or: [
+            { exerciseTitle: { $regex: regex } },
+            { exerciseSubTitle: { $regex: regex } },
+            { exerciseDescription: { $regex: regex } }
+          ]
+        })
+      };
+
+      const skip = (parseInt(page) - 1) * parseInt(limit);
+      const sortOption = sort === 'asc' ? 1 : -1;
+
+      const [exercises, total] = await Promise.all([
+        ExercisesModel.find(query)
+          .sort({ updatedAt: sortOption })
+          .skip(skip)
+          .limit(parseInt(limit)),
+        ExercisesModel.countDocuments(query)
+      ]);
+
+      const fhirBundle = FHIRExerciseService.convertExerciseToFHIR(exercises, {
+        page: parseInt(page),
+        limit: parseInt(limit),
+        total,
+        type,
+        keyword
+      });
+
+      return res.status(200).json(fhirBundle);
+    } catch (error) {
+      console.error("Error formatting FHIR:", error);
+      return res.status(500).json({
+        resourceType: "OperationOutcome",
+        issue: [
+          {
+            severity: "error",
+            code: "exception",
+            diagnostics: error.message
+          }
+        ]
+      });
+    }
+  }
+
+ 
+
+}
+
+
+
+module.exports = AdminController;

--- a/apps/api/main.js
+++ b/apps/api/main.js
@@ -8,6 +8,7 @@ const { rateLimit } = require("express-rate-limit")
 const { connectToDocumentDB } = require('./config/connect');
 const yoshmite = require('./routes/user');
 const fhirRoutes = require('./routes/fhirRoutes');
+const adminRoutes = require('./routes/adminRoutes');
 const doctorRoutes = require('./routes/addDoctorsRoutes');
 const authRoutes = require('./routes/authRoutes');
 const fhir = require('./routes/authRoutes');
@@ -83,6 +84,7 @@ app.use('/Uploads/Images', express.static(UPLOADS_DIR));
 
 // Routes
 app.use('/fhir', yoshmite);
+app.use('/fhir', adminRoutes);
 app.use('/api/auth', authRoutes);
 app.use('/api/doctors', doctorRoutes);
 app.use('/api/appointments', apointmentRoutes);

--- a/apps/api/middlewares/authMiddleware.js
+++ b/apps/api/middlewares/authMiddleware.js
@@ -3,7 +3,7 @@ const jwt = require("jsonwebtoken");
 const verifyTokenAndRefresh = (req, res, next) => {
   const token = req.headers["authorization"]?.split(" ")[1]; // Get token from the 'Authorization' header
 
-  console.log("Token:", token); // Log the token for debugging
+  //console.log("Token:", token); // Log the token for debugging
 
   if (!token) {
     console.log("No token provided");

--- a/apps/api/models/ExerciseTypeModel.js
+++ b/apps/api/models/ExerciseTypeModel.js
@@ -1,0 +1,17 @@
+const mongoose = require('mongoose');
+
+const YoshExerciseTypeSchema = new mongoose.Schema({
+
+    
+    exerciseType: {
+        type: String,
+    },
+    
+    
+    
+
+}, { timestamps: true});
+
+const YoshExerciseType = mongoose.models.YoshExerciseType || mongoose.model('YoshExerciseType', YoshExerciseTypeSchema);
+
+module.exports = YoshExerciseType;

--- a/apps/api/models/YoshExercisePlans.js
+++ b/apps/api/models/YoshExercisePlans.js
@@ -1,0 +1,20 @@
+const mongoose = require('mongoose');
+
+const YoshExercisePlansSchema = new mongoose.Schema({
+
+    
+    planType: {
+        type: String,
+    },
+    planName: {
+        type: String,
+    },
+    
+    
+    
+
+}, { timestamps: true});
+
+const YoshExercisePlans = mongoose.models.YoshExercisePlans || mongoose.model('YoshExercisePlans', YoshExercisePlansSchema);
+
+module.exports = YoshExercisePlans;

--- a/apps/api/models/YoshExercises.js
+++ b/apps/api/models/YoshExercises.js
@@ -1,0 +1,41 @@
+const mongoose = require('mongoose');
+
+const YoshExercisesSchema = new mongoose.Schema({
+
+    
+    planId: {
+        type: String,
+    },
+    planType: {
+        type: String,
+    },
+    planName: {
+        type: String,
+    },
+    exerciseType: {
+        type: String,
+    },
+    exerciseTitle: {
+        type: String,
+    },
+    exerciseSubTitle: {
+        type: String,
+    },
+    exerciseThumbnail: {
+        type: String,
+    },
+    exerciseVideo: {
+        type: String,
+    },
+    exerciseDescription: {
+        type: String,
+    },
+    
+    
+    
+
+}, { timestamps: true});
+
+const YoshExercises = mongoose.models.YoshExercises || mongoose.model('YoshExercises', YoshExercisesSchema);
+
+module.exports = YoshExercises;

--- a/apps/api/routes/adminRoutes.js
+++ b/apps/api/routes/adminRoutes.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const AdminController = require('../controllers/AdminController');
+const { verifyTokenAndRefresh } = require('../middlewares/authMiddleware');
+const router = express.Router();
+
+
+router.get('/planTypes', verifyTokenAndRefresh, AdminController.planTypes);
+router.get('/exerciseTypes', verifyTokenAndRefresh, AdminController.exerciseTypes);
+router.get('/getExercise', verifyTokenAndRefresh, AdminController.getExercise);
+
+module.exports = router;

--- a/apps/api/services/FHIRExerciseService.js
+++ b/apps/api/services/FHIRExerciseService.js
@@ -1,0 +1,173 @@
+// utils/fhir/formatExerciseToFHIR.js
+
+class formatExerciseToFHIRBundle {
+    static convertExerciseToFHIR(exercises, options = {}) {
+      const {
+        page = 1,
+        limit = 10,
+        total = exercises.length,
+        type = "",
+        keyword
+      } = options;
+  
+      const entries = exercises.map((exercise) => ({
+        fullUrl: `urn:uuid:${exercise._id}`,
+        resource: {
+          resourceType: "ActivityDefinition",
+          id: exercise._id.toString(),
+          status: "active",
+          name: exercise.exerciseTitle || "",
+          title: exercise.exerciseSubTitle || "",
+          description: exercise.exerciseDescription || "",
+          kind: "Task",
+          code: {
+            coding: [
+              {
+                system: "http://example.org/fhir/exercise-type",
+                code: exercise.exerciseType || "",
+                display: exercise.exerciseType || ""
+              }
+            ]
+          },
+          relatedArtifact: [
+            {
+              type: "documentation",
+              label: "Video",
+              url: exercise.exerciseVideo || ""
+            },
+            {
+              type: "documentation",
+              label: "Thumbnail",
+              url: exercise.exerciseThumbnail || ""
+            }
+          ],
+          extension: [
+            {
+              url: "http://example.org/fhir/StructureDefinition/planType",
+              valueString: exercise.planType || ""
+            },
+            {
+              url: "http://example.org/fhir/StructureDefinition/planName",
+              valueString: exercise.planName || ""
+            },
+            {
+              url: "http://example.org/fhir/StructureDefinition/planId",
+              valueString: exercise.planId || ""
+            }
+          ]
+        }
+      }));
+  
+      const bundle = {
+        resourceType: "Bundle",
+        type: "searchset",
+        total: total,
+        entry: entries,
+        link: this.generatePaginationLinks(page, limit, total, type, keyword)
+      };
+  
+      return bundle;
+    }
+
+    static generatePaginationLinks(page, limit, total, type = "", keyword = "") {
+        const current = parseInt(page);
+        const last = Math.ceil(total / limit);
+        const baseUrl = "/fhir/getExercise";
+      
+        const queryParams = [`limit=${limit}`];
+        if (type) queryParams.push(`type=${encodeURIComponent(type)}`);
+        if (keyword) queryParams.push(`keyword=${encodeURIComponent(keyword)}`);
+        const queryStr = queryParams.join("&");
+      
+        const links = [
+          { relation: "self", url: `${baseUrl}?page=${current}&${queryStr}` }
+        ];
+      
+        if (current > 1) {
+          links.push({
+            relation: "previous",
+            url: `${baseUrl}?page=${current - 1}&${queryStr}`
+          });
+        }
+      
+        if (current < last) {
+          links.push({
+            relation: "next",
+            url: `${baseUrl}?page=${current + 1}&${queryStr}`
+          });
+        }
+      
+        return links;
+    }
+
+    static convertPlanTypesToFHIR(exercisePlans) {
+        const entries = exercisePlans.map((planDoc) => {
+            const plan = planDoc.toObject();
+            console.log("plan",plan);
+          return {
+            fullUrl: `urn:uuid:${plan._id}`,
+            resource: {
+              resourceType: "ActivityDefinition",
+              id: plan._id.toString(),
+              status: "active",
+              name: plan.planType || "",  
+              description: plan.planName || "",
+              kind: "Task",
+              extension: [
+                {
+                  url: "http://example.org/fhir/StructureDefinition/planType",
+                  valueString: plan.planType || "Unknown Plan Type"
+                },
+                {
+                  url: "http://example.org/fhir/StructureDefinition/planName",
+                  valueString: plan.planName || "Unknown Plan Name"
+                }
+              ]
+            }
+          };
+        });
+    
+        return {
+          resourceType: "Bundle",
+          type: "searchset",
+          total: entries.length,
+          entry: entries
+        };
+      }
+
+    static convertExerciseTypeToFHIR(exerciseTypes) {
+        const entries = exerciseTypes.map((typeDoc) => {
+            const type = typeDoc.toObject(); // Convert Mongoose document to plain object
+    
+            return {
+                fullUrl: `urn:uuid:${type._id}`,
+                resource: {
+                    resourceType: "ActivityDefinition",
+                    id: type._id.toString(),
+                    status: "active",
+                    name: type.exerciseType || "",
+                    description: type.exerciseType || "",
+                    kind: "Task",
+                    extension: [
+                        {
+                            url: "http://example.org/fhir/StructureDefinition/exerciseType",
+                            valueString: type.exerciseType || ""
+                        }
+                    ]
+                }
+            };
+        });
+    
+        return {
+            resourceType: "Bundle",
+            type: "searchset",
+            total: entries.length,
+            entry: entries
+        };
+    }
+  
+    
+  }
+  
+  module.exports = formatExerciseToFHIRBundle;
+  


### PR DESCRIPTION
<!--
We, the rest of the Yosemite community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?
Currently, the exercise list API fetches exercises without any filtering or search capability. There is no way to filter exercises based on type or search them by keyword.

## What is the new behavior?
<!-- Describe the changes. -->

- Added support to filter exercises by type.
- Enabled keyword-based search functionality using exercise title.
- Response is now returned in FHIR Bundle format for improved interoperability.


Fixes #130 

<!-- If this PR contains a breaking change, please describe the impact for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]


