### PR TITLE
Return healthservice id , Hospital Images And Website into get List API

### DIFF
--- a/apps/api/controllers/SharedDutiesController.js
+++ b/apps/api/controllers/SharedDutiesController.js
@@ -1,8 +1,17 @@
-const petDuties = require('../models/petDuties');
+const { petDuties, petCoOwner} = require('../models/petDuties');
 const mongoose = require('mongoose');
 
+class SharedDutiesController{
 
-async function handleSaveSharedDuties(req,res) {
+
+ static async savePetCoOwner(req,res){
+
+
+
+  
+ } 
+
+static async handleSaveSharedDuties(req,res) {
     const sharedData = req.body;
     const addSharedRecord = await petDuties.create({
         petId: sharedData.petId,
@@ -25,7 +34,7 @@ async function handleSaveSharedDuties(req,res) {
     
 }
 
-async function handleEditSharedDuties(req, res) {
+static async handleEditSharedDuties(req, res) {
   try {
     const updatedSharedData = req.body;
     const id = req.params.taskId;
@@ -49,16 +58,12 @@ async function handleEditSharedDuties(req, res) {
 }
 
 
-async function handleGetSharedDuties(req,res){
+static async handleGetSharedDuties(req,res){
 
     const userid = req.params.userId;
     const result = await petDuties.find({ userId : {$eq: userid } } );
     if (result.length === 0) return res.status(404).json({ message: "No Shared pet duty record found for this user" });
     res.json(result);
 }
-
-module.exports = {
-    handleSaveSharedDuties,
-    handleEditSharedDuties,
-    handleGetSharedDuties,
-  }
+}
+module.exports = SharedDutiesController

--- a/apps/api/controllers/medicalRecords.js
+++ b/apps/api/controllers/medicalRecords.js
@@ -91,7 +91,7 @@ async function handlesaveMedicalRecord(req,res) {
 
         const fhirResponse = FHIRMedicalRecordService.convertMedicalRecordToFHIR(addMedicalRecords);
 
-        return res.status(201).json(fhirResponse);
+        return res.status(200).json({ status: 1, data: fhirResponse});
 
         // return res.status(201).json({
         // message: "Medical record saved successfully",

--- a/apps/api/models/petDuties.js
+++ b/apps/api/models/petDuties.js
@@ -31,4 +31,26 @@ const sharedSchema = new mongoose.Schema({
 }, { timestamps: true});
 
 const sharedRecord = mongoose.model('YoshSharedPetDuties',sharedSchema);
-module.exports = sharedRecord;
+
+const petCoOwnerSchema = new mongoose.Schema({
+
+    firstName: {
+        type: String, 
+    },
+    lastName: {
+        type: String,
+    },
+    relationToPetOwner:{
+        type: String,
+    },
+    profileImage:[
+        {
+            url: { type: String },
+            originalname: { type: String },
+            mimetype: { type: String }
+        }
+    ],
+   
+}, { timestamps: true});
+const petCoOwner = mongoose.model('yosepetCoOwner',petCoOwnerSchema);
+module.exports = { sharedRecord, petCoOwner };

--- a/apps/api/routes/user.js
+++ b/apps/api/routes/user.js
@@ -10,6 +10,7 @@ const DetailsController = require('../controllers/DetailsController');
 const ListController = require('../controllers/ListController');
 const ImmunizationController = require("../controllers/ImmunizationController");
 const DiabetesController = require("../controllers/DiabetesController");
+const SharedDutiesController = require("../controllers/SharedDutiesController");
 
 const { handleContactUs } = require("../controllers/contact");
 
@@ -24,11 +25,7 @@ const {
   handleMedicalRecordList,
 } = require("../controllers/medicalRecords");
 
-const {
-  handleSaveSharedDuties,
-  handleEditSharedDuties,
-  handleGetSharedDuties,
-} = require("../controllers/sharedDuties");
+
 
 const router = express.Router();
 const multer = require("multer");
@@ -86,13 +83,13 @@ router.post("/saveExercisePlan",verifyTokenAndRefresh, handleExercisePlan);
 router.get("/getexercise-list/:userId",verifyTokenAndRefresh, handleGetExercisePlan);
 router.post("/savepainjournal",verifyTokenAndRefresh, handleAddPainJournal);
 router.get("/getpainjournal/:userId",verifyTokenAndRefresh, handleGetPainJournal);
-router.post("/saveMedicalRecord", verifyTokenAndRefresh,handlesaveMedicalRecord);
-router.get("/getMedicalRecordList",verifyTokenAndRefresh, handleMedicalRecordList);
+router.post("/DocumentReference/saveMedicalRecord", verifyTokenAndRefresh,handlesaveMedicalRecord);
+router.get("/DocumentReference/getMedicalRecordList",verifyTokenAndRefresh, handleMedicalRecordList);
 router.post( "/Observation/saveDiabetesRecords",verifyTokenAndRefresh,DiabetesController.handleDiabetesRecords);
 router.get("/Observation/getDiabetesLogs", verifyTokenAndRefresh,DiabetesController.handleGetDiabetesLogs);
 router.delete("/Observation/deleteDiabetesLog", verifyTokenAndRefresh,DiabetesController.handleDeleteDiabetesLog);
-router.post("/saveSharedDuties",verifyTokenAndRefresh, handleSaveSharedDuties);
-router.get("/getSharedDuties/:userId",verifyTokenAndRefresh, handleGetSharedDuties);
-router.put("/editSharedDuties/:taskId",verifyTokenAndRefresh, handleEditSharedDuties);
+router.post("/saveSharedDuties",verifyTokenAndRefresh, SharedDutiesController.handleSaveSharedDuties);
+router.get("/getSharedDuties/:userId",verifyTokenAndRefresh, SharedDutiesController.handleGetSharedDuties);
+router.put("/editSharedDuties/:taskId",verifyTokenAndRefresh, SharedDutiesController.handleEditSharedDuties);
 router.get("/", handlehome);
 module.exports = router;


### PR DESCRIPTION


<!--
We, the rest of the Yosemite community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?
The GetList API currently returns a list of hospitals or health services with basic details such as:

- Image/Logo
- Location
- Contact information

However, **it does not include:**

- healthServiceId
- hospitalImages
- website

This limits the ability of the frontend to display complete and rich information about each hospital or service.


## What is the new behavior?
The updated GetList API will return additional fields for each hospital/service entry:

- healthServiceId: The unique identifier associated with the health service.
- hospitalImages: One or more image URLs representing the hospital (e.g., logo, building).
- website: Official website URL of the hospital or service provider.

Fixes #236 

<!-- If this PR contains a breaking change, please describe the impact for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]


