### PR TITLE
Feat: return appointments as per status Upcoming,pending,past and cancel with their counts

### DIFF
--- a/apps/api/services/AppointmentService.js
+++ b/apps/api/services/AppointmentService.js
@@ -55,60 +55,63 @@ static async getPetAndOwner(petId, userId) {
 static async fetchAppointments(req) {
   try {
     const cognitoUserId = getCognitoUserId(req);
-
-    const now = new Date(); // full current date-time
-    const today = new Date();
+    const now = new Date();
+    const today = new Date(now);
     today.setHours(0, 0, 0, 0);
+
     const filter = req.query.type || "all";
     const limit = parseInt(req.query.limit) || 10;
     const offset = parseInt(req.query.offset) || 0;
-    
-    const totalCount = await webAppointments.countDocuments({ userId: cognitoUserId });
-     
-    const rawAppointments = await webAppointments
-      .find({ userId: cognitoUserId })
-      .skip(offset)
-      .limit(limit)
-      .lean();
 
-    const upcoming = [], past = [], pending = [], canceled = [];
-    const vetIds = new Set(), petIds = new Set(), hospitalIds = new Set();
+    const [totalCount, rawAppointments] = await Promise.all([
+      webAppointments.countDocuments({ userId: cognitoUserId }),
+      webAppointments.find({ userId: cognitoUserId }).skip(offset).limit(limit).lean()
+    ]);
 
-    rawAppointments.forEach(app => {
+    const categories = {
+      upcoming: [],
+      pending: [],
+      past: [],
+      cancel: []
+    };
+
+    const vetIds = new Set();
+    const petIds = new Set();
+    const hospitalIds = new Set();
+
+    for (const app of rawAppointments) {
       const datePart = new Date(app.appointmentDate);
       datePart.setHours(0, 0, 0, 0);
-      const timePart = app.appointmentTime24 || '00:00';
-      const [hours, minutes] = timePart.split(':').map(Number);
-    
-      const fullAppointmentDateTime = new Date(app.appointmentDate);
-      fullAppointmentDateTime.setHours(hours, minutes, 0, 0);
-    
-      if (app.appointmentStatus === 'pending') {
-        if (datePart >= today || (datePart.getTime() === today.getTime() && fullAppointmentDateTime >= now)) {
-          pending.push(app);
+
+      const [hr = 0, min = 0] = (app.appointmentTime24 || '00:00').split(':').map(Number);
+      const fullDateTime = new Date(app.appointmentDate);
+      fullDateTime.setHours(hr, min, 0, 0);
+
+      const { appointmentStatus } = app;
+
+      if (appointmentStatus === 'cancelled') {
+        categories.cancel.push(app);
+      } else if (appointmentStatus === 'pending') {
+        if (datePart >= today && fullDateTime >= now) {
+          categories.pending.push(app);
         }
-      } else if (app.appointmentStatus === 'cancelled') {
-        canceled.push(app);
-      }
-    
-      if (datePart < today) {
-        past.push(app);
-      } else if (datePart.getTime() === today.getTime()) {
-        if (fullAppointmentDateTime < now) {
-          past.push(app);
-        } else if (app.appointmentStatus === 'booked') {
-          upcoming.push(app);
+      } else if (appointmentStatus === 'booked') {
+        if (datePart > today) {
+          categories.upcoming.push(app);
+        } else if (datePart.getTime() === today.getTime()) {
+          if (fullDateTime >= now) categories.upcoming.push(app);
+          else categories.past.push(app);
+        } else {
+          categories.past.push(app);
         }
-      } else if (datePart > today && app.appointmentStatus === 'booked') {
-        upcoming.push(app);
       }
-    
+
       if (app.veterinarian) vetIds.add(app.veterinarian);
       if (app.petId) petIds.add(app.petId);
       if (app.hospitalId) hospitalIds.add(app.hospitalId);
-    });
-    
-    const toObjectIdSafe = (id) => {
+    }
+
+    const toObjectIdSafe = id => {
       try {
         return new mongoose.Types.ObjectId(id);
       } catch {
@@ -141,13 +144,15 @@ static async fetchAppointments(req) {
       .filter(Boolean)
       .map(id => id.toString());
 
-    const specializationMap = Object.fromEntries(
-      await departments
-        .find({ _id: { $in: specializationIds.map(toObjectIdSafe).filter(Boolean) } })
-        .select("_id departmentName")
-        .lean()
-        .then(specs => specs.map(spec => [spec._id.toString(), spec.departmentName]))
-    );
+    const specializationMap = specializationIds.length
+      ? Object.fromEntries(
+          (await departments
+            .find({ _id: { $in: specializationIds.map(toObjectIdSafe).filter(Boolean) } })
+            .select("_id departmentName")
+            .lean()
+          ).map(spec => [spec._id.toString(), spec.departmentName])
+        )
+      : {};
 
     const vetMap = Object.fromEntries(
       vets.map(v => [
@@ -162,64 +167,58 @@ static async fetchAppointments(req) {
     );
 
     const petMap = Object.fromEntries(
-      pets.map(p => [p._id.toString(), {
-        petName: p.petName || null,
-        petImage: p.petImage || null,
-      }])
+      pets.map(p => [p._id.toString(), { petName: p.petName, petImage: p.petImage }])
     );
 
     const hospitalMap = Object.fromEntries(
       hospitals.map(h => [h.userId, {
-        name: h.businessName || null,
-        latitude: h.address?.latitude || null,
-        longitude: h.address?.longitude || null
+        name: h.businessName,
+        latitude: h.address?.latitude,
+        longitude: h.address?.longitude
       }])
     );
 
-    const toFHIR = (app) => FHIRService.convertAppointmentToFHIR(app, vetMap, petMap, hospitalMap);
+    const toFHIR = app => FHIRService.convertAppointmentToFHIR(app, vetMap, petMap, hospitalMap);
 
     if (filter === 'all') {
       return {
         total: totalCount,
         limit,
         offset,
-        upcoming: upcoming.map(toFHIR),
-        pending: pending.map(toFHIR),
-        past: past.map(toFHIR),
-        cancel: canceled.map(toFHIR)
+        upcoming: {
+          count: categories.upcoming.length,
+          data: categories.upcoming.map(toFHIR)
+        },
+        pending: {
+          count: categories.pending.length,
+          data: categories.pending.map(toFHIR)
+        },
+        past: {
+          count: categories.past.length,
+          data: categories.past.map(toFHIR)
+        },
+        cancel: {
+          count: categories.cancel.length,
+          data: categories.cancel.map(toFHIR)
+        }
       };
-    }
-
-    let filteredAppointments;
-    switch (filter) {
-      case 'upcoming':
-        filteredAppointments = upcoming;
-        break;
-      case 'pending':
-        filteredAppointments = pending;
-        break;
-      case 'past':
-        filteredAppointments = past;
-        break;
-      case 'cancel':
-        filteredAppointments = canceled;
-        break;
-      default:
-        filteredAppointments = rawAppointments;
     }
 
     return {
       total: totalCount,
       limit,
       offset,
-      appointments: filteredAppointments.map(toFHIR)
+      appointments: {
+        count: categories[filter]?.length || 0,
+        data: (categories[filter] || []).map(toFHIR)
+      }
     };
 
   } catch (error) {
-    console.error("Error in fetchAppointments:", error);
     throw new Error("Failed to fetch appointments.");
   }
 }
+
 
 
 

--- a/apps/api/services/FHIRService.js
+++ b/apps/api/services/FHIRService.js
@@ -3,23 +3,20 @@ class FHIRService {
     const vet = vetMap[app.veterinarian] || {};
     const pet = petMap[app.petId] || {};
     const hospital = hospitalMap[app.hospitalId] || {};
-    let startDateTime = null;
-        if (app.appointmentDate) {
-          const time = app.appointmentTime24 || '00:00';
-          const dateTimeString = `${app.appointmentDate}T${time}:00`;
-          const date = new Date(dateTimeString);
-          if (!isNaN(date)) {
-            startDateTime = date.toISOString();
-          } else {
-            console.warn("Invalid date string:", dateTimeString);
-          }
-        }
+
+  
     return {
       resourceType: "Appointment",
       id: app._id.toString(),
       status: app.appointmentStatus,
-      start: startDateTime,
+      start: app.appointmentDate,
       reasonCode: [{ text: "Veterinary Consultation" }],
+      extension: [
+        {
+          url: "http://example.org/fhir/StructureDefinition/appointment-time-slot",
+          valueString: app.appointmentTime
+        }
+      ],
       participant: [
         {
           actor: {
@@ -80,6 +77,7 @@ class FHIRService {
       ]
     };
   }
+  
   
   }
   


### PR DESCRIPTION
<!--
We, the rest of the Yosemite community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

- The Get Appointments List API returns a flat array of all appointments.
- There is no separation by status.
- The client (frontend) is responsible for:

1. Filtering appointments into categories (e.g., by comparing dates or status fields).
2. Counting appointments in each category manually.



## What is the new behavior?

- The API will return appointments grouped by status (Upcoming, Pending, Past, Cancel).
- It will also include counts for each category.
- The backend handles classification based on status and current date.

This change **reduces frontend complexity,** improves **performance**, and makes the API more **developer-friendly**.


Fixes #244 

<!-- If this PR contains a breaking change, please describe the impact for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]


