### PR TITLE
Fix: time issues into get Appointments , get time slots API due to Timezone difference between live and local server

### DIFF
--- a/apps/api/services/AppointmentService.js
+++ b/apps/api/services/AppointmentService.js
@@ -14,6 +14,7 @@ const departments =  require('../models/AddDepartment');
 const DoctorsTimeSlotes  = require('../models/DoctorsSlotes');
 const helpers = require('../utils/helpers');
 const { mongoose } = require('mongoose');
+const moment = require('moment-timezone');
 
 class appointmentService {
 static async bookAppointment(data) {
@@ -52,12 +53,15 @@ static async getPetAndOwner(petId, userId) {
   return { petDetails, petOwner };
 }
 
+
+
 static async fetchAppointments(req) {
   try {
     const cognitoUserId = getCognitoUserId(req);
-    const now = new Date();
-    const today = new Date(now);
-    today.setHours(0, 0, 0, 0);
+    const timezone = 'Asia/Kolkata'; // or 'UTC' if you prefer server independence
+
+    const now = moment.tz(timezone);
+    const today = now.clone().startOf('day');
 
     const filter = req.query.type || "all";
     const limit = parseInt(req.query.limit) || 10;
@@ -80,27 +84,37 @@ static async fetchAppointments(req) {
     const hospitalIds = new Set();
 
     for (const app of rawAppointments) {
-      const datePart = new Date(app.appointmentDate);
-      datePart.setHours(0, 0, 0, 0);
+      const appointmentDate = moment.tz(app.appointmentDate, timezone).startOf('day');
 
-      const [hr = 0, min = 0] = (app.appointmentTime24 || '00:00').split(':').map(Number);
-      const fullDateTime = new Date(app.appointmentDate);
-      fullDateTime.setHours(hr, min, 0, 0);
+      let fullDateTime;
+      const timeString = app.appointmentTime24 || '12:00 AM'; // assume midnight if missing
+
+      // Handle 12-hour or 24-hour formats
+      if (timeString.toLowerCase().includes('am') || timeString.toLowerCase().includes('pm')) {
+        fullDateTime = moment.tz(`${app.appointmentDate} ${timeString}`, 'YYYY-MM-DD h:mm A', timezone);
+      } else {
+        fullDateTime = moment.tz(app.appointmentDate, timezone);
+        const [hr = 0, min = 0] = timeString.split(':').map(Number);
+        fullDateTime.hour(hr).minute(min).second(0).millisecond(0);
+      }
 
       const { appointmentStatus } = app;
 
       if (appointmentStatus === 'cancelled') {
         categories.cancel.push(app);
       } else if (appointmentStatus === 'pending') {
-        if (datePart >= today && fullDateTime >= now) {
+        if (appointmentDate.isSameOrAfter(today) && fullDateTime.isSameOrAfter(now)) {
           categories.pending.push(app);
         }
       } else if (appointmentStatus === 'booked') {
-        if (datePart > today) {
+        if (appointmentDate.isAfter(today)) {
           categories.upcoming.push(app);
-        } else if (datePart.getTime() === today.getTime()) {
-          if (fullDateTime >= now) categories.upcoming.push(app);
-          else categories.past.push(app);
+        } else if (appointmentDate.isSame(today)) {
+          if (fullDateTime.isSameOrAfter(now)) {
+            categories.upcoming.push(app);
+          } else {
+            categories.past.push(app);
+          }
         } else {
           categories.past.push(app);
         }
@@ -204,8 +218,6 @@ static async fetchAppointments(req) {
       };
     }
 
-
-
     return {
       total: totalCount,
       limit,
@@ -217,12 +229,10 @@ static async fetchAppointments(req) {
     };
 
   } catch (error) {
+    console.error('Error in fetchAppointments:', error);
     throw new Error("Failed to fetch appointments.");
   }
 }
-
-
-
 
 
   static async cancelAppointment(data) {

--- a/apps/api/services/SlotService.js
+++ b/apps/api/services/SlotService.js
@@ -1,70 +1,72 @@
-const moment = require('moment');
+const moment = require('moment-timezone');
 const DoctorsTimeSlotes  = require('../models/DoctorsSlotes');
 const { webAppointments } = require("../models/WebAppointment");
 const { createFHIRSlot } = require('../utils/fhirUtils');
 
 
 class SlotService {
-  static async getAvailableTimeSlots({ appointmentDate, doctorId }) {
-
-    const dateObj = new Date(appointmentDate);
-    if (isNaN(dateObj.getTime())) {
-      return {
-        issue: [{
-          severity: "error",
-          code: "invalid",
-          details: { text: "Invalid appointment date" }
-        }]
-      };
-    }
-
-    const validDays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
-    const day = validDays[dateObj.getDay()];
-    
-    if (!validDays.includes(day)) {
-      throw new Error("Invalid day");
-    }
-    const isToday = new Date().toDateString() === dateObj.toDateString();
-    const currentTime = new Date();
-
-    const slotsData = await DoctorsTimeSlotes.find({ doctorId, day });
-    if (!slotsData.length) {
-      return { resourceType: "Bundle", type: "collection", entry: [] };
-    }
-
-    const timeSlots = slotsData[0].timeSlots;
-    if (!Array.isArray(timeSlots)) {
-      return {
-        issue: [{
-          severity: "error",
-          code: "processing",
-          details: { text: "Time slots data is not in the expected format" }
-        }]
-      };
-    }
-
-    const bookedAppointments = await webAppointments.find({ veterinarian: doctorId, appointmentDate });
-
-    const availableSlots = timeSlots
-      .filter(slot => {
-        if (!slot.time) return false;
-        if (isToday) {
-          const slotDateTime = moment(`${appointmentDate} ${slot.time}`, "YYYY-MM-DD hh:mm A").toDate();
-          return slotDateTime > currentTime;
-        }
-        return true;
-      })
-      .map(slot => {
-        const slotObj = createFHIRSlot(slot, doctorId, bookedAppointments);
-        slotObj.start = moment(`${appointmentDate} ${slot.time}`, "YYYY-MM-DD hh:mm A").toISOString(); // ensure it's present
-        return slotObj;
-      });
+ static async getAvailableTimeSlots({ appointmentDate, doctorId }) {
+  const dateObj = moment.tz(appointmentDate, "YYYY-MM-DD", "Asia/Kolkata").toDate();
+  if (isNaN(dateObj.getTime())) {
     return {
-      resourceType: "Bundle",
-      type: "collection",
-      entry: availableSlots.map(resource => ({ resource }))
+      issue: [{
+        severity: "error",
+        code: "invalid",
+        details: { text: "Invalid appointment date" }
+      }]
     };
   }
+
+  const validDays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+  const day = validDays[dateObj.getDay()];
+
+  if (!validDays.includes(day)) {
+    throw new Error("Invalid day");
+  }
+
+  const isToday = moment().tz("Asia/Kolkata").format('YYYY-MM-DD') === moment(dateObj).tz("Asia/Kolkata").format('YYYY-MM-DD');
+  const currentTime = moment().tz("Asia/Kolkata");
+
+  const slotsData = await DoctorsTimeSlotes.find({ doctorId, day });
+  if (!slotsData.length) {
+    return { resourceType: "Bundle", type: "collection", entry: [] };
+  }
+
+  const timeSlots = slotsData[0].timeSlots;
+  if (!Array.isArray(timeSlots)) {
+    return {
+      issue: [{
+        severity: "error",
+        code: "processing",
+        details: { text: "Time slots data is not in the expected format" }
+      }]
+    };
+  }
+
+  const bookedAppointments = await webAppointments.find({ veterinarian: doctorId, appointmentDate });
+
+  const availableSlots = timeSlots
+    .filter(slot => {
+      if (!slot.time) return false;
+      if (isToday) {
+        const slotDateTime = moment.tz(`${appointmentDate} ${slot.time}`, "YYYY-MM-DD hh:mm A", "Asia/Kolkata");
+        return slotDateTime.isAfter(currentTime);
+      }
+      return true;
+    })
+    .map(slot => {
+      const slotDateTime = moment.tz(`${appointmentDate} ${slot.time}`, "YYYY-MM-DD hh:mm A", "Asia/Kolkata");
+      const slotObj = createFHIRSlot(slot, doctorId, bookedAppointments);
+      slotObj.start = slotDateTime.toISOString(); // ensure it's in ISO format
+      return slotObj;
+    });
+
+  return {
+    resourceType: "Bundle",
+    type: "collection",
+    entry: availableSlots.map(resource => ({ resource }))
+  };
+}
 }
 
 module.exports = SlotService;

--- a/apps/api/services/SlotService.js
+++ b/apps/api/services/SlotService.js
@@ -43,7 +43,17 @@ class SlotService {
     };
   }
 
-  const bookedAppointments = await webAppointments.find({ veterinarian: doctorId, appointmentDate });
+  if (typeof doctorId !== 'string' || doctorId.trim() === '') {
+   return res.status(200).json({ status: 0, message: 'Invalid doctor ID' });
+  }
+  
+  const normalizedDate = moment.tz(appointmentDate, "YYYY-MM-DD", "Asia/Kolkata").format("YYYY-MM-DD");
+
+  if (!moment(appointmentDate, "YYYY-MM-DD", true).isValid()) {
+  return res.status(200).json({ status: 0, message: 'Invalid appointment date' });
+}
+
+  const bookedAppointments = await webAppointments.find({ veterinarian: doctorId,  appointmentDate: normalizedDate });
 
   const availableSlots = timeSlots
     .filter(slot => {

--- a/apps/api/utils/fhirFormatter.js
+++ b/apps/api/utils/fhirFormatter.js
@@ -52,6 +52,7 @@ class FHIRFormatter {
     static feedbackNotFoundOutcome() {
       return {
         resourceType: "OperationOutcome",
+        data:[],
         issue: [{
           status: 0,
           severity: "information",
@@ -64,6 +65,7 @@ class FHIRFormatter {
     static errorOutcome(message = "An error occurred while retrieving feedback") {
       return {
         resourceType: "OperationOutcome",
+        data:[],
         issue: [{
           status: 0,
           severity: "error",


### PR DESCRIPTION
<!--
We, the rest of the Yosemite community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

- The getAppointments and getTimeSlots APIs return time values based on the server’s default timezone (UTC on the live server and IST locally).
- This leads to:

1. Appointments being shown at incorrect times.
2. Time slots appearing unavailable or shifted.
3. Time-based logic (e.g., checking if a slot is in the future) behaving inconsistently between environments.

- Users in IST (or any expected timezone) see incorrect or confusing time values on the frontend.


## What is the new behavior?

- All date/time values returned by the APIs should be normalized to a specific timezone (Asia/Kolkata).
- Time calculations (e.g., slot availability, appointment overlap) should be timezone-aware and consistent across all environments.
- Users should see:

1. Accurate appointment and slot times regardless of server location.
2. Reliable time comparisons and booking logic.
3. Consistent behavior on both local and live servers.


Fixes #251 

<!-- If this PR contains a breaking change, please describe the impact for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]


