### PR TITLE
Fix: timezone Package issue

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -25,6 +25,7 @@
     "fhir": "4.12.0",
     "jsonwebtoken": "9.0.2",
     "moment": "2.30.1",
+    "moment-timezone": "^0.5.48",
     "mongoose": "8.12.2",
     "multer": "1.4.5-lts.2",
     "sanitize-filename": "^1.6.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       moment:
         specifier: 2.30.1
         version: 2.30.1
+      moment-timezone:
+        specifier: ^0.5.48
+        version: 0.5.48
       mongoose:
         specifier: 8.12.2
         version: 8.12.2


### PR DESCRIPTION
<!--
We, the rest of the Yosemite community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

- The application attempts to use a timezone-handling package like moment-timezone without having it installed.
- As a result, the application crashes at runtime with an error such as: Error: Cannot find module 'moment-timezone'


## What is the new behavior?

- The required timezone package is properly installed and imported 
- The application now runs without crashing, and timezone conversions work as expected
- The code now handles timezones reliably, with all required packages included in package.json.

Fixes #255 

<!-- If this PR contains a breaking change, please describe the impact for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]


