### PR TITLE
Feat. return doctors details into get feedback API

### DIFF
--- a/apps/api/utils/fhirFormatter.js
+++ b/apps/api/utils/fhirFormatter.js
@@ -1,42 +1,52 @@
 class FHIRFormatter {
   static toObservationResource(feedback) {
-    return {
-      resourceType: "Observation",
-      id: feedback._id.toString(),
-      status: "final",
-      code: {
-        coding: [
-          {
-            system: "http://loinc.org",
-            code: "71007-4", // Standard code for patient satisfaction
-            display: "Patient satisfaction"
-          }
-        ],
-        text: "Feedback Rating"
-      },
-      subject: {
-        reference: `Patient/${feedback.petId}`
-      },
-      performer: [
+  return {
+    resourceType: "Observation",
+    id: feedback._id.toString(),
+    status: "final",
+    code: {
+      coding: [
         {
-          reference: `Practitioner/${feedback.doctorId}`
+          system: "http://loinc.org",
+          code: "71007-4",
+          display: "Patient satisfaction"
         }
       ],
-      effectiveDateTime: feedback.createdAt ? new Date(feedback.createdAt).toISOString() : new Date().toISOString(),
-      valueInteger: feedback.rating || 0,
-      note: feedback.feedback ? [
-        {
-          text: feedback.feedback
-        }
-      ] : [],
-      extension: [
-        {
-          url: "http://example.org/fhir/StructureDefinition/meeting-id",
-          valueString: feedback.meetingId
-        }
-      ]
-    };
-  }
+      text: "Feedback Rating"
+    },
+    subject: {
+      reference: `Patient/${feedback.petId}`
+    },
+    performer: [
+      {
+        reference: `Practitioner/${feedback.doctorId}`,
+        display: `${feedback.doctorDetails?.personalInfo?.firstName || ''} ${feedback.doctorDetails?.personalInfo?.lastName || ''}`.trim()
+      }
+    ],
+    effectiveDateTime: feedback.createdAt ? new Date(feedback.createdAt).toISOString() : new Date().toISOString(),
+    valueInteger: (feedback.rating !== undefined && feedback.rating !== null) ? feedback.rating : undefined,
+    note: feedback.feedback ? [{ text: feedback.feedback }] : [],
+    extension: [
+      {
+        url: "http://example.org/fhir/StructureDefinition/meeting-id",
+        valueString: feedback.meetingId
+      },
+      {
+        url: "http://example.org/fhir/StructureDefinition/doctor-qualification",
+        valueString: feedback.doctorDetails?.professionalBackground?.qualification || ""
+      },
+      {
+        url: "http://example.org/fhir/StructureDefinition/doctor-department",
+        valueString: feedback.department || ""
+      },
+      {
+        url: "http://example.org/fhir/StructureDefinition/doctor-image",
+        valueUrl: feedback.doctorDetails?.personalInfo?.image || ""
+      }
+    ]
+  };
+}
+
 
   static toObservationBundle(feedbackList) {
     const resources = feedbackList.map(this.toObservationResource);


### PR DESCRIPTION
<!--
We, the rest of the Yosemite community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?
The Get Feedback API currently returns only the feedback data, such as:

- feedbackId
- patientId
- rating
- comment
- doctorId

However, it does not include full doctor details like name, specialization, or profile image. To get this information, the client has to make an **additional API call** using the doctorId.


## What is the new behavior?
The updated Get Feedback API will include embedded doctor information directly in the response, allowing the frontend to display all relevant data in one call. The doctor object  include:

- doctorId
- fullName
- specialization
- profileImage
- departmentName

This change will:

- Reduce the need for multiple API calls
- Improve performance and user experience
- Simplify frontend implementation

Fixes #257 

<!-- If this PR contains a breaking change, please describe the impact for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]


