### PR TITLE
Fix: TimeZone issue into FHIR response issue in getTimeSlots API

### DIFF
--- a/apps/api/utils/fhirUtils.js
+++ b/apps/api/utils/fhirUtils.js
@@ -1,4 +1,4 @@
-const moment = require('moment');
+const moment = require('moment-timezone');
 
 function createFHIRSlot(slot, doctorId, bookedAppointments) {
     const isBooked = bookedAppointments.some(app => app.slotsId?.toString() === slot._id?.toString());
@@ -11,8 +11,8 @@ function createFHIRSlot(slot, doctorId, bookedAppointments) {
       },
       isBooked: isBooked ? "true" : "false",
       slotTime: slot.time,
-      start: moment(`${slot.date} ${slot.time}`, "YYYY-MM-DD hh:mm A").toISOString(),
+      start: moment.tz(`${slot.date} ${slot.time}`, "YYYY-MM-DD hh:mm A", "Asia/Kolkata").toISOString(),
     };
-  }
-  
-  module.exports = { createFHIRSlot };
+}
+
+module.exports = { createFHIRSlot };


### PR DESCRIPTION
<!--
We, the rest of the Yosemite community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

- The start time in each FHIR Slot resource is generated using moment.tz() without explicitly specifying the "Asia/Kolkata" timezone.
- On environments where the server's default time zone is not IST (e.g., UTC), the slot times are incorrectly parsed and shifted.
- This causes inaccurate filtering of time slots—especially on the current day (isToday)—leading to only a partial list of available time slots (e.g., 5 instead of all 14).



## What is the new behavior?

- The createFHIRSlot() function now explicitly parses slot date and time using moment.tz(..., "Asia/Kolkata"), ensuring that time slot timestamps are consistent and accurate across environments.
- All valid time slots are now properly included in the FHIR response.
- Slot filtering works reliably, regardless of server time zone, avoiding discrepancies between local and live environments.


Fixes #272 

<!-- If this PR contains a breaking change, please describe the impact for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]


