### PR TITLE
Fix: time slots on a perticular date

### DIFF
--- a/apps/api/controllers/FeedbackController.js
+++ b/apps/api/controllers/FeedbackController.js
@@ -17,21 +17,19 @@ class FeedbackController {
         userId,
         feedbackFHIR,
       });
-  
-      if (savedFHIR) {
+     if (savedFHIR) {
+        const fhirResponse = FHIRFormatter.toObservationBundle(savedFHIR);
         return res.status(200).json({
           status: 1,
           message: "Feedback saved successfully",
+          data: fhirResponse
         });
       }
   
-      res.status(200).json({ status: 0, message: "Feedback not saved" });
-  
     } catch (error) {
-      console.error("Error in handleSaveFeedback:", error);
       res.status(200).json({
         status: 0,
-        message: "Internal server error while saving feedback",
+        message: error.message || "Internal server error while saving feedback",
       });
     }
   }

--- a/apps/api/controllers/SlotController.js
+++ b/apps/api/controllers/SlotController.js
@@ -9,6 +9,10 @@ class SlotController {
   static async handlegetTimeSlots(req, res) {
     try {
       const { appointmentDate, doctorId } = req.query;
+
+      if (typeof doctorId !== 'string' || !/^[a-fA-F0-9-]{36}$/.test(doctorId)) {
+        return res.status(200).json({ status: 0, message: 'Invalid doctor ID' });
+      }
       
       const isValidDate = (dateStr) => {
         const date = new Date(dateStr);
@@ -38,9 +42,7 @@ class SlotController {
         });
       }
   
-      if (typeof doctorId !== 'string' || !/^[a-fA-F0-9-]{36}$/.test(doctorId)) {
-        return res.status(200).json({ status: 0, message: 'Invalid doctor ID' });
-      }
+      
 
       
     const today = new Date().toISOString().split('T')[0];

--- a/apps/api/controllers/user.js
+++ b/apps/api/controllers/user.js
@@ -1,0 +1,51 @@
+const user = require('../models/YoshUser');
+const auth = require("./auth");
+
+
+async function handleUserRegistration(req,res){
+    var fileName = "";
+    const body = req.body;
+    const profileImage = req.file;
+    const useremail = body.email;
+    const existingUser = await user.findOne({ 'email' :useremail });
+    if (existingUser) return res.status(400).json({ error: 'Email already in use' });
+    if(profileImage)fileName = profileImage.filename;
+    const adduser = await user.create({
+        firstName: body.firstName,
+        lastName: body.lastName,
+        mobilePhone: body.mobilePhone,
+        city:body.city,
+        zipcode:body.zipcode,
+        email: body.email,
+        isProfessional: body.isProfessional,
+        professionType: body.professionType,
+        pimsCode: body.pimsCode,
+        password: body.password,
+        profileImage: fileName,
+    });
+    if(adduser){
+        res.status(201).json({
+            message: 'Registration completed successfully',
+            data: adduser,
+            
+          });
+    }
+}
+
+async function handleUserLogin(req,res){
+    const body = req.body;
+    const useremail = body.email;
+    const existingUser = await user.findOne({ 'email' :useremail });
+    if (!existingUser) return res.status(400).json({ error: 'Email does not Exists' });
+
+        await auth.sendConfirmationCode(useremail, res);
+}
+async function handlehome(req,res){
+   console.log('app is connected')
+}
+
+module.exports = {
+    handleUserRegistration,
+    handleUserLogin,
+    handlehome
+}

--- a/apps/api/models/YoshUser.js
+++ b/apps/api/models/YoshUser.js
@@ -1,0 +1,64 @@
+const mongoose = require('mongoose');
+
+const userSchema = new mongoose.Schema({
+
+    cognitoId: {
+        type: String, 
+    },
+    email: {
+        type: String, 
+    },
+    password: {
+        type: Array,
+    },
+    otp: { 
+        type: Number,
+    },
+    otpExpiry: { 
+        type: Date, 
+    },
+    firstName: {
+        type: String,
+        required: true,
+    },
+    lastName: {
+        type: String,
+    },
+    mobilePhone: {
+        type: String,
+    },
+    countryCode:{
+        type: String,
+    },
+    city: {
+        type: String,
+    },
+    zipcode: {
+        type: String,
+    },
+    
+    isProfessional: {
+        type: String,
+    },
+    isConfirmed: {
+        type: Boolean,
+        default: false,
+    },
+    professionType: {
+        type: Array,
+    },
+    pimsCode: {
+        type: String,
+    },
+    profileImage:[
+        {
+            url: { type: String },
+            originalname: { type: String },
+            mimetype: { type: String }
+        }
+    ],
+
+}, { timestamps: true});
+
+const YoshUser = mongoose.model('YoshUser',userSchema);
+module.exports = YoshUser;

--- a/apps/api/services/SlotService.js
+++ b/apps/api/services/SlotService.js
@@ -59,13 +59,13 @@ class SlotService {
     .filter(slot => {
       if (!slot.time) return false;
       if (isToday) {
-        const slotDateTime = moment.tz(`${appointmentDate} ${slot.time}`, "YYYY-MM-DD hh:mm A", "Asia/Kolkata");
+        const slotDateTime = moment.tz(`${appointmentDate} ${slot.time}`, "YYYY-MM-DD h:mm A", "YYYY-MM-DD hh:mm A", "Asia/Kolkata");
         return slotDateTime.isAfter(currentTime);
       }
       return true;
     })
     .map(slot => {
-      const slotDateTime = moment.tz(`${appointmentDate} ${slot.time}`, "YYYY-MM-DD hh:mm A", "Asia/Kolkata");
+      const slotDateTime = moment.tz(`${appointmentDate} ${slot.time}`, "YYYY-MM-DD h:mm A", "YYYY-MM-DD hh:mm A", "Asia/Kolkata");
       const slotObj = createFHIRSlot(slot, doctorId, bookedAppointments);
       slotObj.start = slotDateTime.toISOString(); // ensure it's in ISO format
       return slotObj;

--- a/apps/api/utils/fhirUtils.js
+++ b/apps/api/utils/fhirUtils.js
@@ -11,7 +11,7 @@ function createFHIRSlot(slot, doctorId, bookedAppointments) {
       },
       isBooked: isBooked ? "true" : "false",
       slotTime: slot.time,
-      start: moment.tz(`${slot.date} ${slot.time}`, "YYYY-MM-DD hh:mm A", "Asia/Kolkata").toISOString(),
+      start: moment.tz(`${slot.date} ${slot.time}`, "YYYY-MM-DD h:mm A", "YYYY-MM-DD hh:mm A", "Asia/Kolkata").toISOString(),
     };
 }
 


### PR DESCRIPTION
<!--
We, the rest of the Yosemite community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

1. When a user selects a specific date (e.g., 2025-05-22) to fetch available appointment slots:

- Some slots are missing or
- Slots may be shown for the previous or next day, depending on the server's timezone.

2. This inconsistency occurs because the backend interprets the selected date in **server timezone (e.g., UTC)** instead of the **client's local timezone (e.g., Asia/Kolkata).**
3. As a result, time-bound filtering using start and end of day boundaries in MongoDB may not align with the user's expected date.

## What is the new behavior?

- When a user selects a date (e.g., 2025-05-22), the backend should **fetch all slots that fall within that full calendar day as perceived by the user.**
- The backend should handle time correctly by:

1. Ensuring both client and server operate in the same timezone (e.g., store and query times in UTC but offset properly).

- The returned slots should accurately match the selected date with no missing or shifted entries.

Fixes #279 

<!-- If this PR contains a breaking change, please describe the impact for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]


