### PR TITLE
Fix: updated the code for time slot issue with timeslots api

### DIFF
--- a/apps/api/services/SlotService.js
+++ b/apps/api/services/SlotService.js
@@ -59,13 +59,13 @@ class SlotService {
     .filter(slot => {
       if (!slot.time) return false;
       if (isToday) {
-        const slotDateTime = moment.tz(`${appointmentDate} ${slot.time}`, "YYYY-MM-DD h:mm A", "YYYY-MM-DD hh:mm A", "Asia/Kolkata");
+        const slotDateTime = moment.tz(`${appointmentDate} ${slot.time}`, ["YYYY-MM-DD h:mm A", "YYYY-MM-DD hh:mm A"], "Asia/Kolkata");
         return slotDateTime.isAfter(currentTime);
       }
       return true;
     })
     .map(slot => {
-      const slotDateTime = moment.tz(`${appointmentDate} ${slot.time}`, "YYYY-MM-DD h:mm A", "YYYY-MM-DD hh:mm A", "Asia/Kolkata");
+      const slotDateTime = moment.tz(`${appointmentDate} ${slot.time}`, ["YYYY-MM-DD h:mm A", "YYYY-MM-DD hh:mm A"], "Asia/Kolkata");
       const slotObj = createFHIRSlot(slot, doctorId, bookedAppointments);
       slotObj.start = slotDateTime.toISOString(); // ensure it's in ISO format
       return slotObj;

--- a/apps/api/utils/fhirUtils.js
+++ b/apps/api/utils/fhirUtils.js
@@ -11,7 +11,7 @@ function createFHIRSlot(slot, doctorId, bookedAppointments) {
       },
       isBooked: isBooked ? "true" : "false",
       slotTime: slot.time,
-      start: moment.tz(`${slot.date} ${slot.time}`, "YYYY-MM-DD h:mm A", "YYYY-MM-DD hh:mm A", "Asia/Kolkata").toISOString(),
+      start: moment.tz(`${slot.date} ${slot.time}`, ["YYYY-MM-DD h:mm A", "YYYY-MM-DD hh:mm A"], "Asia/Kolkata").toISOString(),
     };
 }
 


### PR DESCRIPTION
<!--
We, the rest of the Yosemite community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

- The getTimeSlots API does **not return all slots** for the selected date.
- Slots may appear for the **wrong date** (e.g., previous or next day) or some slots may be **missing entirely.**
- This happens due to **timezone mismatches** — the server uses UTC or a different timezone than the client when querying time-based data.



## What is the new behavior?

- The getTimeSlots API now returns **all time slots correctly** for the selected date, as expected by the user.
- The date range filtering logic has been updated to:

1. Properly calculate **start and end of the selected day** based on the **client's local timezone** or standardized UTC offset.
2. Ensure all slots falling within the correct 24-hour window are returned.


Fixes #281 

<!-- If this PR contains a breaking change, please describe the impact for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]


