### PR TITLE
Fix: generated wrong day from given date

### DIFF
--- a/apps/api/services/SlotService.js
+++ b/apps/api/services/SlotService.js
@@ -6,24 +6,24 @@ const { createFHIRSlot } = require('../utils/fhirUtils');
 
 class SlotService {
  static async getAvailableTimeSlots({ appointmentDate, doctorId }) {
-  const dateObj = moment.tz(appointmentDate, "YYYY-MM-DD", "Asia/Kolkata").toDate();
-  if (isNaN(dateObj.getTime())) {
-    return {
-      issue: [{
-        severity: "error",
-        code: "invalid",
-        details: { text: "Invalid appointment date" }
-      }]
-    };
-  }
+  const dateObj = moment.tz(appointmentDate, "YYYY-MM-DD", "Asia/Kolkata");
 
-  const validDays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
-  const day = validDays[dateObj.getDay()];
-
-  if (!validDays.includes(day)) {
-    throw new Error("Invalid day");
-  }
-
+    if (!dateObj.isValid()) {
+      return {
+        issue: [{
+          severity: "error",
+          code: "invalid",
+          details: { text: "Invalid appointment date" }
+        }]
+      };
+    }
+    const validDays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+    const dayIndex = dateObj.day();
+    const day = validDays[dayIndex];
+   
+    if (dayIndex < 0 || dayIndex > 6) {
+      throw new Error("Invalid day extracted from appointment date");
+    }
   const isToday = moment().tz("Asia/Kolkata").format('YYYY-MM-DD') === moment(dateObj).tz("Asia/Kolkata").format('YYYY-MM-DD');
   const currentTime = moment().tz("Asia/Kolkata");
 


### PR DESCRIPTION
<!--
We, the rest of the Yosemite community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

- This internally converts the date to a JavaScript Date object, which uses UTC internally.
- As a result, **the calculated day is sometimes incorrect** — for example, "2025-05-27" (Tuesday) is incorrectly recognized as **Monday**.
- This causes the API to return time slots for the wrong day or even no slots, depending on availability in the database.

## What is the new behavior?

- The day is calculated directly using Moment-Timezone in Asia/Kolkata, avoiding native Date conversion
- This ensures **the correct weekday is selected** for the given date in Asia/Kolkata timezone.
- The API now returns the **correct set of time slots** for the actual day, fixing the mismatch between frontend date and backend slots.



Fixes #283 

<!-- If this PR contains a breaking change, please describe the impact for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]


