### PR TITLE
Update Appointment_Slot_Availability

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -25,6 +25,7 @@
     "next": "15.3.3",
     "react": "^19.0.0",
     "react-bootstrap": "^2.10.9",
+    "react-calendar": "^5.1.0",
     "react-chartjs-2": "^5.3.0",
     "react-datepicker": "^8.2.1",
     "react-dom": "^19.0.0",

--- a/apps/frontend/src/app/Pages/DoctorDashboard/DoctorDashboard.css
+++ b/apps/frontend/src/app/Pages/DoctorDashboard/DoctorDashboard.css
@@ -194,7 +194,6 @@
 .AvailabityDivDoctor .AvltyFor .avldate input.AvlDatepicker:focus{
   border-color: var(--lightgrey);
 }
-
 .AvailabityDivDoctor .AvltyFor .Avlswitch{
   display: flex;
   flex-direction: column;
@@ -288,8 +287,124 @@
   padding: 10px 24px;
   border-radius: 36px;
 }
+.AvailDateSlotDiv{
+  display: flex;
+  align-items: flex-start;
+  gap: 24px;
+}
+.AvailDateSlotDiv .left-calendar , .AvailDateSlotDiv .right-slots {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.AvailDateSlotDiv .left-calendar {
+  min-width: 330px;
+}
+.AvailDateSlotDiv .left-calendar .react-calendar{
+  min-width: 330px;
+  box-shadow: 0px 0px 8px 0px #55413414 !important;
+  border-radius: 24px !important;
+  border: 1px solid var(--lightgrey) !important;
+  min-height: 358px !important;
+  padding: 10px !important;
+
+}
+.AvailDateSlotDiv .left-calendar .react-calendar__navigation{
+  margin: 0 !important;
+}
+.AvailDateSlotDiv .left-calendar  .react-calendar__navigation button:enabled:hover, .AvailDateSlotDiv .left-calendar  .react-calendar__navigation button:enabled:focus {
+  background-color: transparent !important;
+}
+.AvailDateSlotDiv .left-calendar .react-calendar__navigation button:disabled {
+  background-color: transparent !important;
+}
+.AvailDateSlotDiv .left-calendar .react-calendar__navigation button{
+  color: var(--black-text);
+  font-family: var(--satoshi-font);
+  font-weight: 700;
+  font-size: 13px;
+  margin: 0;
+}
+.AvailDateSlotDiv .left-calendar .react-calendar__month-view__weekdays__weekday{
+  color: var(--greyborder);
+  font-weight: 400;
+  font-size: 13px;
+  line-height: 120%;
+  font-family: var(--satoshi-font);
+}
+.AvailDateSlotDiv .left-calendar .react-calendar__month-view__weekdays__weekday abbr[title]{
+  text-decoration: none !important;
+}
+.AvailDateSlotDiv .left-calendar .react-calendar__month-view__days{
+  gap: 24px !important;
+  padding: 0.5em !important;
+}
+.AvailDateSlotDiv .left-calendar .react-calendar__month-view__days button{
+  padding: 0 !important;
+  width: fit-content !important;
+  background: transparent !important;
+  margin: 0 !important;
+  flex: none !important;
+  padding: 0.5em !important;
+  border-radius: 50% !important;
+  color: var(--black-text) !important;
+  width: 33px !important;
+  height: 33px !important;
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+}
+.AvailDateSlotDiv .left-calendar .react-calendar__tile--active:enabled:hover, .react-calendar__tile--active:enabled:focus , .AvailDateSlotDiv .left-calendar .react-calendar__tile--active {
+  background: var(--light-blue) !important;
+}
 
 
+
+
+.AvailDateSlotDiv .left-calendar .SlotInfo , .AvailDateSlotDiv .right-slots .SlotInfo{
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.AvailDateSlotDiv .left-calendar .SlotInfo h6 , .AvailDateSlotDiv .right-slots .SlotInfo h6{
+  margin: 0;
+  color: var(--black-text);
+  font-family: var(--satoshi-font);
+  font-weight: 700;
+  font-size: 18px;
+  line-height: 120%;
+}
+.AvailDateSlotDiv .right-slots .slot-grid{
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 10px;
+}
+.AvailDateSlotDiv .right-slots .slot-grid button{
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-width: 103px;
+  min-height: 48px;
+  border: 1px solid var(--notibg);
+  border-radius: 28px;
+  background: var(--whitebg);
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 120%;
+  color: var(--black-text);
+  font-family: var(--satoshi-font);
+  padding: 0 !important;
+}
+.AvailDateSlotDiv .right-slots .slot-grid button.unavailable  {
+  color: var(--greytext);
+  border: 1px solid var(--greyborder);
+}
+.AvailDateSlotDiv .right-slots .slot-grid button.selected {
+  background: var(--blue-text);
+  color: var(--white-text);
+  border: 1px solid var(--blue-text);
+}
 
 
 

--- a/apps/frontend/src/app/Pages/DoctorDashboard/DoctorDashboard.tsx
+++ b/apps/frontend/src/app/Pages/DoctorDashboard/DoctorDashboard.tsx
@@ -22,6 +22,10 @@ import { useAuthStore } from "@/app/stores/authStore";
 import { putData } from "@/app/axios-services/services";
 import Swal from "sweetalert2";
 
+
+
+import DoctorSlots from "./DoctorSlots";
+
 function DoctorDashboard() {
   const { vetAndTeamsProfile, userId, fetchVetAndTeamsProfile } =
     useAuthStore();
@@ -53,11 +57,8 @@ function DoctorDashboard() {
     }
   };
 
-  const [status, setStatus] = useState<string>("30 mins");
-
-  const handleDropdownSelect = (eventKey: string | null) => {
-    setStatus(eventKey as string);
-  };
+ 
+  
 
   
 
@@ -134,72 +135,7 @@ const image:any = vetAndTeamsProfile?.image ||
             </div>
           </div>
         ) : (
-          <div className="DoctorAvailabilty">
-            <h2>Appointment Slot Availability</h2>
-           
-            <div className="AvailabityDivDoctor">
-
-              <div className="AvltyFor">
-                <div className="avldate">
-                  <h5>Availability for</h5>
-                  <Form.Control
-                    className="AvlDatepicker"
-                    type="date"
-                    id="appointmentDate"
-                    title="Choose your date"
-                  />
-                </div>
-                <div className="Avlswitch">
-                  <p>Availability Status</p>
-                  <div className="custom-toggle-container">
-                    <label className="custom-switch">
-                      <input
-                        type="checkbox"
-                        checked={available}
-                        onChange={() => setAvailable(!available)}
-                      />
-                      <span className="slider" />
-                    </label>
-                    <span className={`status-text ${available ? "available" : "not-available"}`}>
-                      {available ? "Available" : "Not Available"}
-                    </span>
-                  </div>
-                </div>
-              </div>
-              
-              <div className="appointselect">
-                <div className="lft">
-                  <h6>Set Appointment Duration</h6>
-                  <p>Set the default time for appointments.</p>
-                </div>
-                <div className="ryt">
-                  <Dropdown onSelect={handleDropdownSelect}>
-                    <Dropdown.Toggle className="custom-status-dropdown" id="dropdown-status">
-                      {status}
-                    </Dropdown.Toggle>
-                    <Dropdown.Menu>
-                      {["15 mins", "30 mins", "45 mins", "60 mins"].map((opt) => (
-                        <Dropdown.Item key={opt} eventKey={opt} active={status === opt}>
-                          {opt}
-                        </Dropdown.Item>
-                      ))}
-                    </Dropdown.Menu>
-                  </Dropdown>
-                </div>
-              </div>
-
-             
-
-              <Button  className="updateBtn">
-                Update <FaCircleCheck size={20} />
-              </Button>
-
-
-            </div>
-           
-              
-           
-          </div>
+          <DoctorSlots/>
         )}
       </Container>
     </section>

--- a/apps/frontend/src/app/Pages/DoctorDashboard/DoctorSlots.tsx
+++ b/apps/frontend/src/app/Pages/DoctorDashboard/DoctorSlots.tsx
@@ -1,0 +1,273 @@
+"use client";
+import React, {  useState } from "react";
+import { Button, Dropdown, Form } from 'react-bootstrap';
+import { FaCircleCheck } from 'react-icons/fa6';
+import "./DoctorDashboard.css";
+
+import Calendar from 'react-calendar';
+import 'react-calendar/dist/Calendar.css';
+
+function DoctorSlots() {
+
+
+    const [status, setStatus] = useState<string>("30 mins");
+    const handleDropdownSelect = (eventKey: string | null) => {
+        setStatus(eventKey as string);
+    };
+    const [available, setAvailable] = useState(true);
+
+
+
+    
+
+  // sdknsdkn
+
+
+  const timeSlots = [
+    "10:00 AM", "10:30 AM", "11:00 AM", "11:30 AM", "12:00 PM", "12:30 PM", "01:00 PM",
+    "01:30 PM", "02:00 PM", "02:30 PM", "03:00 PM", "03:30 PM", "04:00 PM",
+    "04:30 PM", "05:00 PM", "05:30 PM", "06:00 PM", "06:30 PM", "07:00 PM", "07:30 PM"
+  ];
+
+
+  const [selectedDates, setSelectedDates] = useState<string[]>([]);
+  const [selectedSlots, setSelectedSlots] = useState<{ [date: string]: string[] }>({});
+
+  const [selectAll, setSelectAll] = useState(false);
+  const [selectUnavailable, setSelectUnavailable] = useState(false);
+
+  const toggleDate = (date: string) => {
+    setSelectedDates((prev) =>
+      prev.includes(date)
+        ? prev.filter((d) => d !== date)
+        : [...prev, date]
+    );
+  };
+
+  const handleSlotToggle = (date: string, slot: string) => {
+    setSelectedSlots((prev) => {
+      const currentSlots = prev[date] || [];
+      const isSelected = currentSlots.includes(slot);
+      const updatedSlots = isSelected
+        ? currentSlots.filter((s) => s !== slot)
+        : [...currentSlots, slot];
+      return { ...prev, [date]: updatedSlots };
+    });
+  };
+
+  // const handleDropdownSelect = (value) => {
+  //   setStatus(value);
+  // };
+
+  const handleSelectAll = () => {
+    setSelectAll(!selectAll);
+    const allDates = ["2025-12-27", "2025-12-28", "2025-12-29", "2025-12-30", "2025-12-31"];
+    setSelectedDates(selectAll ? [] : allDates);
+  };
+
+
+
+
+  // Get all days of current visible month
+  const getAllDatesOfMonth = (year: number, month: number) => {
+    const dates: string[] = [];
+    const date = new Date(year, month, 1);
+    while (date.getMonth() === month) {
+      dates.push(date.toISOString().slice(0, 10));
+      date.setDate(date.getDate() + 1);
+    }
+    return dates;
+  };
+
+  
+
+  const [currentDate, setCurrentDate] = useState(new Date());
+
+
+
+  // sdknsdkn
+
+
+
+
+  return (
+    <>
+
+    <div className="DoctorAvailabilty">
+            <h2>Appointment Slot Availability</h2>
+           
+            <div className="AvailabityDivDoctor">
+
+              <div className="AvltyFor">
+                <div className="avldate">
+                  <h5>Availability for</h5>
+                  <Form.Control
+                    className="AvlDatepicker"
+                    type="date"
+                    id="appointmentDate"
+                    title="Choose your date"
+                  />
+                </div>
+                <div className="Avlswitch">
+                  <p>Availability Status</p>
+                  <div className="custom-toggle-container">
+                    <label className="custom-switch">
+                      <input
+                        type="checkbox"
+                        checked={available}
+                        onChange={() => setAvailable(!available)}
+                      />
+                      <span className="slider" />
+                    </label>
+                    <span className={`status-text ${available ? "available" : "not-available"}`}>
+                      {available ? "Available" : "Not Available"}
+                    </span>
+                  </div>
+                </div>
+              </div>
+              
+              <div className="appointselect">
+                <div className="lft">
+                  <h6>Set Appointment Duration</h6>
+                  <p>Set the default time for appointments.</p>
+                </div>
+                <div className="ryt">
+                  <Dropdown onSelect={handleDropdownSelect}>
+                    <Dropdown.Toggle className="custom-status-dropdown" id="dropdown-status">
+                      {status}
+                    </Dropdown.Toggle>
+                    <Dropdown.Menu>
+                      {["15 mins", "30 mins", "45 mins", "60 mins"].map((opt) => (
+                        <Dropdown.Item key={opt} eventKey={opt} active={status === opt}>
+                          {opt}
+                        </Dropdown.Item>
+                      ))}
+                    </Dropdown.Menu>
+                  </Dropdown>
+                </div>
+              </div>
+
+
+
+
+              {/* Date & Slot Section */}
+              <div className="AvailDateSlotDiv">
+
+                {/* Left Column: Calendar & checkboxes */}
+                <div className="left-calendar">
+                  <div className="SlotInfo">
+                    <h6>Select Date</h6>
+                    <Form.Check
+                      type="checkbox"
+                      label="Select All"
+                      checked={selectAll}
+                      onChange={handleSelectAll}
+                    />
+                  </div>
+                  <div className="SlotClender">
+                    <Calendar
+                      // Allow user to select up to 4 dates
+                      onClickDay={(date) => {
+                        const iso = date.toISOString().slice(0, 10);
+                        setSelectedDates((prev) => {
+                          if (prev.includes(iso)) {
+                            return prev.filter((d) => d !== iso);
+                          } else if (prev.length < 4) {
+                            return [...prev, iso];
+                          }
+                          return prev;
+                        });
+                      }}
+                      tileClassName={({ date, view }) => {
+                        if (view === "month" && selectedDates.includes(date.toISOString().slice(0, 10))) {
+                          return "calendar-date selected";
+                        }
+                        return "calendar-date";
+                      }}
+                      minDetail="month"
+                      maxDetail="month"
+                      showNeighboringMonth={false}
+                      // Optionally, disable past dates
+                      tileDisabled={({ date }) => {
+                        const today = new Date();
+                        today.setHours(0,0,0,0);
+                        return date < today;
+                      }}
+                      formatShortWeekday={(locale, date) =>
+                        date.toLocaleDateString(locale, { weekday: "short" }).charAt(0)
+                      }
+                    />
+                  </div>
+
+                    
+
+
+
+
+
+                </div>
+
+                {/* Right Column: Slot Select */}
+                <div className="right-slots">
+                  <div className="SlotInfo">
+                    <h6>Select Slot</h6>
+                    <Form.Check
+                      type="checkbox"
+                      label="Select Unavailable"
+                      checked={selectUnavailable}
+                      onChange={() => setSelectUnavailable(!selectUnavailable)}
+                    />
+                  </div>
+
+                  <div className="slot-grid ">
+
+                    {timeSlots.map((slot, idx) => {
+                      const selectedDate = selectedDates[0]; // For simplicity, just one
+                      const isSelected = selectedSlots[selectedDate]?.includes(slot);
+                      const isUnavailable = ["10:00 AM", "10:30 AM"].includes(slot);
+
+                      return (
+                        <Button
+                          key={idx}
+                          className={`slot-btn ${isUnavailable ? "unavailable" : ""} ${isSelected ? "selected" : ""}`}
+                          disabled={isUnavailable}
+                          onClick={() => handleSlotToggle(selectedDate, slot)}>
+                          {slot}
+                        </Button>
+                      );
+                    })}
+                  </div>
+
+
+                </div>
+
+              </div>
+
+
+
+
+              
+
+
+
+
+              
+
+             
+
+              <Button  className="updateBtn">
+                Update <FaCircleCheck size={20} />
+              </Button>
+
+
+            </div>
+           
+              
+           
+          </div>
+        
+    </>
+  )
+}
+
+export default DoctorSlots

--- a/apps/frontend/src/app/Pages/Sign/Sign.css
+++ b/apps/frontend/src/app/Pages/Sign/Sign.css
@@ -8,6 +8,8 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    position: relative;
+    padding: 150px 0px 100px 0px;
 }
 
 .BuildEveryone{
@@ -196,7 +198,7 @@
     gap: 20px;
 }
 .Signbtn h6{
-    color: var(--blue-text);
+    color: var(--black-text);
     font-weight: 500;
     font-size: 19px;
     line-height: 120%;
@@ -204,7 +206,7 @@
     margin: 0;
 }
 .Signbtn h6 a{
-    color: var(--black-text);
+    color: var(--blue-text);
 }
 
 /* Sign Up Page Ended */
@@ -461,3 +463,85 @@
 }
 
 /* Sign In Ended */
+
+
+
+/* SignError Started  */
+
+.SignError{
+    width: 100%;
+    min-height: 85px;
+    position: absolute;
+    top: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 16px 10px;
+    border-radius: 0px 0px 20px 20px;
+}
+.SignError.errofoundbg{
+    background: var(--foungbg);
+}
+.SignError.oppsbg{
+    background: var(--opsbg);
+}
+.SignError.CongratsBg{
+    background: var(--greenbg);
+}
+.SignError .ErroItemDiv{
+    position: relative;
+}
+.SignError .ErroItemDiv .errortopbar{
+    display: flex;
+    align-items: center;
+    flex-direction: column;
+    justify-content: center;
+    text-align: center;
+    gap: 8px;
+    position: relative;
+}
+.SignError .ErroItemDiv .errortopbar .Errortexted{
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+.SignError .ErroItemDiv .errortopbar .Errortexted h6{
+    margin: 0;
+    font-weight: 500;
+    font-family: var(--grotesk-font);
+    font-size: 19px;
+    line-height: 120%;
+    color: var(--black-text);
+}
+.SignError .ErroItemDiv .errortopbar p{
+    margin: 0;
+    font-weight: 400;
+    font-family: var(--satoshi-font);
+    font-size: 18px;
+    line-height: 120%;
+    color: var(--black-text);
+}
+.SignError .ErroItemDiv button{
+    position: absolute;
+    right: 0;
+    top: 0;
+    padding: 0;
+    background: transparent !important;
+    border: none !important;
+}
+.SignError .ErroItemDiv button svg{
+    color: var(--black-bg);
+}
+
+
+
+
+
+
+
+
+
+
+
+/* SignError Ended */

--- a/apps/frontend/src/app/Pages/Sign/SignUp.tsx
+++ b/apps/frontend/src/app/Pages/Sign/SignUp.tsx
@@ -10,6 +10,55 @@ import { getData, postData } from "@/app/axios-services/services";
 import { AxiosError } from "axios";
 import { useRouter } from "next/navigation";
 import { useAuthStore } from "@/app/stores/authStore";
+import { Icon } from "@iconify/react/dist/iconify.js";
+
+
+
+
+// Error Tost Started 
+
+type ErrorTostProps = {
+  message?: string;
+  iconElement?: React.ReactNode;
+  errortext: string;
+  className?: string; 
+  onClose?: () => void;
+};
+
+const ErrorTost: React.FC<ErrorTostProps> = ({
+  message,
+  iconElement,
+  errortext,
+  className = "",
+  onClose
+}) => {
+
+  return (
+    <div className={`SignError ${className}`}>
+      <Container>
+        <div className="ErroItemDiv">
+          <div className="errortopbar">
+            <div className="Errortexted">
+              {iconElement}
+              <h6>{errortext}</h6>
+            </div>
+            <p>{message}</p>
+          </div>
+          <Button onClick={onClose} variant="light">
+            <Icon icon="solar:close-circle-bold" width="24" height="24" />
+          </Button>
+        </div>
+      </Container>
+    </div>
+  );
+};
+
+// Error Tost Started 
+
+
+
+
+
 
 type SignUpProps = {
   inviteCode?: string
@@ -302,6 +351,9 @@ function SignUp({ inviteCode }: SignUpProps) {
 
   return (
     <>
+      
+
+
 
       {!inviteCode ? <section className="MainSignUpSec">
         <Container>
@@ -320,11 +372,8 @@ function SignUp({ inviteCode }: SignUpProps) {
                       </span>
                     </div>
                     <div className="CloudText">
-                      <h4>Cloud or Self-Hosted — You Decide.</h4>
-                      <p>
-                        Use our managed cloud service or deploy on your own
-                        infrastructure. Total flexibility, no lock-in.
-                      </p>
+                      <h4>Enjoy Cloud Hosting with us!</h4>
+                      <p>Website are hosted on a network of servers, offering greater, scalability, reliability, and flexibility.</p>
                     </div>
                   </div>
 
@@ -336,10 +385,7 @@ function SignUp({ inviteCode }: SignUpProps) {
                     </div>
                     <div className="CloudText">
                       <h4>Start Free. Pay as You Grow.</h4>
-                      <p>
-                        Enjoy generous free usage on cloud hosting. Upgrade only
-                        when you need more power.
-                      </p>
+                      <p>Enjoy generous free usage on cloud hosting. Upgrade only when you need more power.</p>
                     </div>
                   </div>
 
@@ -351,10 +397,7 @@ function SignUp({ inviteCode }: SignUpProps) {
                     </div>
                     <div className="CloudText">
                       <h4>GDPR-Ready, EU-Based Servers.</h4>
-                      <p>
-                        All cloud data is securely hosted in the EU with full
-                        GDPR compliance.
-                      </p>
+                      <p>All cloud data is securely hosted in the EU with full GDPR compliance.</p>
                     </div>
                   </div>
                 </div>
@@ -366,7 +409,7 @@ function SignUp({ inviteCode }: SignUpProps) {
                 <Form>
                   <div className="TopSignUp">
                     <div className="Headingtext">
-                      <h2>Sign up now </h2>
+                      <h2>Sign up for Cloud </h2>
                     </div>
 
                     <div className="SignFormItems">
@@ -444,6 +487,25 @@ function SignUp({ inviteCode }: SignUpProps) {
             </Col>
           </Row>
         </Container>
+
+        <ErrorTost
+          className="errofoundbg"
+          message="Seems like You did not enter your Email or Password. Enter email and password to create your profile."
+          errortext="Error Found!"
+          iconElement={<Icon icon="solar:danger-triangle-bold" width="20" height="20" color="#EA3729" />}/>
+
+        <ErrorTost
+          className="oppsbg"
+          message="Something went wrong. We will inform you shortly"
+          errortext="Opps"
+          iconElement={<Icon icon="solar:danger-triangle-bold" width="20" height="20" color="#F68523" />}/>
+
+        <ErrorTost
+          className="CongratsBg"
+          message="You have successfully created your profile"
+          errortext="🎉 Congratulations!"/>
+        
+
       </section> :
 
         <section className="CompleteSignUpSec">
@@ -580,6 +642,8 @@ function SignUp({ inviteCode }: SignUpProps) {
       </Modal>
     </>
   );
+
+
 }
 
 export default SignUp;

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -120,6 +120,8 @@
   --lightwhiteText:#EAEAEA;
   --slectedbg:#76767617;
   --opacityBlue:#F8FBFF;
+  --opsbg:#FCD9BB;
+  --foungbg:#F8C1BD;
   
   
   --popupbg:#EAEAEA;
@@ -249,7 +251,7 @@ input[type=checkbox]:checked::after {
   top: 45%;
   width: 5px;
   height: 10px;
-  border: solid var(--whitebg);
+  /* border: solid var(--whitebg); */
   border-width: 0 3px 3px 0;
   transform: translate(-50%, -50%) rotate(45deg);
 }
@@ -257,6 +259,18 @@ input[type=checkbox]:checked::after {
 
 .form-check-input:focus {
     box-shadow: none !important;
+}
+.form-check-label {
+  color: var(--black-text);
+  font-family: var(--satoshi-font);
+  font-weight: 700;
+  font-size: 16px;
+  line-height: 120%;
+  vertical-align: middle;
+  padding-left: 3px;
+}
+.form-check {
+ margin: 0;
 }
 /* Chrome, Safari, Edge, Opera */
 input::-webkit-outer-spin-button,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,6 +230,9 @@ importers:
       react-bootstrap:
         specifier: ^2.10.9
         version: 2.10.10(@types/react@19.1.8)(react-dom@19.1.0)(react@19.1.0)
+      react-calendar:
+        specifier: ^5.1.0
+        version: 5.1.0(@types/react@19.1.8)(react-dom@19.1.0)(react@19.1.0)
       react-chartjs-2:
         specifier: ^5.3.0
         version: 5.3.0(chart.js@4.5.0)(react@19.1.0)


### PR DESCRIPTION

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

- Users can view appointment slots only one day at a time (or limited date range).
- To find availability across multiple days, they have to manually navigate day‑by‑day.
- There is no consolidated view showing all open slots over the week or fortnight, making it tedious to find suitable times.

## What is the new behavior?

Add a multi‐day availability overview (e.g., 7‑day or 14‑day grid) with highlighted free slots.
Allow filtering by appointment duration (e.g., 15 min, 30 min).
Enable users to select a slot directly from the overview, which opens the booking interface.
Implement smooth navigation between weeks without full page reloads.
Offer a "jump to next available slot" shortcut to speed up booking.

## Why this matters

Saves time: Users no longer need to click through daily views.
Improves UX: Clearer visibility across days helps users choose convenient slots faster.
Competitive parity: Aligns with features found in tools like Calendly and Google Calendar.

## Related Issue(s)

Fixes #442 




