### PR TITLE
fix(api): add typescript types to ChatMessage model

### DIFF
--- a/apps/api/models/ChatModel.ts
+++ b/apps/api/models/ChatModel.ts
@@ -1,6 +1,7 @@
-const mongoose = require('mongoose');
+import mongoose, { Schema, Model } from 'mongoose';
+import type { IMessage } from '@yosemite-crew/types';
 
-const messageSchema = new mongoose.Schema({
+const messageSchema: Schema<IMessage> = new mongoose.Schema({
   sender: { type: String, required: true },
   receiver: { type: String, required: true },
   content: { type: String, default: '' }, // Text message
@@ -15,7 +16,7 @@ const messageSchema = new mongoose.Schema({
     type: String,
     required: true,
   },
-});
+}, { timestamps: true });
 
-const Message = mongoose.model('Message', messageSchema);
-module.exports = Message;
+const Message: Model<IMessage> = mongoose.model<IMessage>('Message', messageSchema);
+export default Message

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -18,6 +18,7 @@ export type { UploadedFile } from "./files/express.files.types";
 
 export type { contact } from "./models/contact";
 export type { breeder } from "./models/breeder";
+export type { IMessage } from "./models/message";
 export type { timeSlot, doctorSlot } from "./models/doctors-slotes";
 export type { medicalDoc, medicalRecord } from "./models/medical-record";
 export type { assessment } from "./models/assessment";

--- a/packages/types/src/models/message.ts
+++ b/packages/types/src/models/message.ts
@@ -1,0 +1,15 @@
+import { Document } from 'mongoose';
+
+export interface IMessage extends Document {
+  sender: string;
+  receiver: string;
+  content?: string;
+  fileUrl?: string;
+  type: MessageType;
+  timestamp : Date;
+  time: string;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+export type MessageType = 'text' | 'image' | 'video' | 'document';


### PR DESCRIPTION
<!--
We, the rest of the Yosemite community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [X] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] All existing tests and lints pass.

## What is the current behavior?
- The messaging model uses CommonJS module syntax and lacks comprehensive TypeScript types, which reduces type safety and can lead to potential bugs and developer inefficiencies.
- The current syntax of the file follows CommonJS convention.

## What is the new behavior?
- Introduced TypeScript interfaces such as `IMessage` into a centralized `packages/types` folder for improved consistency and reuse.
- Migrated the ChatModel file from CommonJS to ES Module syntax.
- Enhanced type safety and alignment between schema and TypeScript interfaces.
- Maintained backward compatibility with existing functionalities and persistence.

## Related Issue(s)
Fixes #459 

<!-- If this PR contains a breaking change, please describe the impact for existing applications below. -->

<!-- 
BREAKING CHANGES:

No breaking changes introduced. The migration to ES Modules and addition of types do not affect existing functionality or data persistence.
-->

