### PR TITLE
fix(api): fix syntax to ESM

### DIFF
--- a/apps/api/controllers/ApiAdminControllers.ts
+++ b/apps/api/controllers/ApiAdminControllers.ts
@@ -1012,4 +1012,4 @@ const AdminController = {
   },
 };
 
-module.exports = { AdminController };
+export default AdminController;

--- a/apps/api/controllers/HospitalControllers.ts
+++ b/apps/api/controllers/HospitalControllers.ts
@@ -2698,4 +2698,4 @@ const HospitalController = {
   // },
 }
 
-module.exports = HospitalController;
+export default HospitalController;

--- a/apps/api/routes/AdminApiRoutes.ts
+++ b/apps/api/routes/AdminApiRoutes.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 import { verifyToken } from '../middlewares/authMiddleware';
-const { AdminController } = require("../controllers/ApiAdminControllers");
-const { verifyTokenAndRefresh } = require('../middlewares/authMiddleware');
+import  AdminController  from "../controllers/ApiAdminControllers";
+import {verifyTokenAndRefresh} from '../middlewares/authMiddleware';
 
 const router = express.Router();
 
@@ -17,5 +17,6 @@ router.post("/visits",AdminController.PurposeOfVisit)
 router.get("/visits",AdminController.PurposeOfVisitList)
 router.post("/AppointmentType",AdminController.AppointmentType)
 router.get("/AppointmentType",AdminController.Appointments)
-module.exports = router;
+
+export default router;
 

--- a/apps/api/routes/HospitalRoutes.ts
+++ b/apps/api/routes/HospitalRoutes.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 import { verifyToken } from '../middlewares/authMiddleware';
-const HospitalController = require('../controllers/HospitalControllers');
-const { verifyTokenAndRefresh } = require('../middlewares/authMiddleware');
+import HospitalController from '../controllers/HospitalControllers';
+import { verifyTokenAndRefresh } from '../middlewares/authMiddleware';
 const router = express.Router();
 
 // router.get('/getAllAppointments', verifyTokenAndRefresh,HospitalController.getAllAppointments);
@@ -46,4 +46,4 @@ router.all('/List',verifyToken,HospitalController.AppointmentGraphs)
 
 // router.get('/getMessages',verifyTokenAndRefresh,HospitalController.getMessages)
 
-module.exports = router;
+export default router;

--- a/apps/api/routes/NewsletterRoutes.ts
+++ b/apps/api/routes/NewsletterRoutes.ts
@@ -20,4 +20,4 @@ router.post('/subscribe', NewsletterController.subscribe);
 router.get('/unsubscribe', NewsletterController.unsubscribe)
 router.post('/upload-batch', upload.single('file'), NewsletterController.batchUpload);
 
-module.exports = router;
+export default router;


### PR DESCRIPTION
<!--
We, the rest of the Yosemite community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [X] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] All existing tests and lints pass.

## What is the current behavior?
currently many files use CommonJS syntax with ESM which causes import errors in main.ts in api folder


## What is the new behavior?
Fixed the code to use ESM convention. Now files can be imported in `main.ts` with no import errors. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #469 

<!-- If this PR contains a breaking change, please describe the impact for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]


