### PR TITLE
placeholder, toast issues fixed

### DIFF
--- a/apps/api/controllers/diabetes-controller.ts
+++ b/apps/api/controllers/diabetes-controller.ts
@@ -100,6 +100,7 @@ const diabetesController = {
   
       if (records.length === 0) {
          res.status(200).json({status: 1, entry: [], message: "No Diabetes logs found" });
+         return
       }
   
       const fhirObservations = records.map(record =>
@@ -109,6 +110,8 @@ const diabetesController = {
       );
 
       const bundle = {
+        message:"Diabetes logs found successfully!",
+        status:1,
         resourceType: "Bundle",
         type: "collection",
         entry: fhirObservations.map((obs: Record<string, unknown>) => ({ resource: obs }))

--- a/apps/api/controllers/immunization-controller.ts
+++ b/apps/api/controllers/immunization-controller.ts
@@ -344,10 +344,12 @@ const immunizationController =  {
 
 
       if (results.length === 0) {
-         res.status(200).json({ status: 0, message: 'No vaccination record found for this user' });
+        //  res.status(200).json({ status: 0, message: 'No vaccination record found for this user' });
+
+        res.status(200).json({status: 1,data: { entry: [] } })
          return;
       }
-     
+     console.log(results,'resultsresults');
         
       const transformed: VaccinationDoc[] = results.map((doc) => ({
         _id: doc._id,
@@ -369,13 +371,14 @@ const immunizationController =  {
           : '',
         reminder: doc.reminder ?? false,
         vaccineImage: doc.vaccineImage || [],
-        petImageUrl: doc.petImageUrl[0].url
+        petImageUrl: doc?.vaccineImage[0]?.url
       }));
       const fhirBundle = toFHIRBundleImmunization(transformed);
        res.status(200).json({ status: 1, data: fhirBundle });
     } catch (err: unknown) {
       console.error(err);
-       res.status(500).json({ status: 0, message: 'Internal Server Error' });
+      const message = err instanceof Error ? err.message :'Internal Server Error'
+       res.status(200).json({ status: 0, message:message  });
     }
   }
 }

--- a/apps/api/controllers/list-controller.ts
+++ b/apps/api/controllers/list-controller.ts
@@ -253,7 +253,6 @@ console.log(today, currentTime);
           }
         }
       ]);
-console.log(fhirDoctors,'fhirDoctors');
       const fhirPractitioners = fhirDoctors.map((doc) => {
         const practitioner = {
           resourceType: "Practitioner",

--- a/apps/frontend/src/app/Components/Header/Header.tsx
+++ b/apps/frontend/src/app/Components/Header/Header.tsx
@@ -275,7 +275,7 @@ const PublicHeader = () => {
   useEffect(() => {
     document.body.classList.toggle("mobile-nav-active", mobileOpen);
   }, [mobileOpen]);
-
+console.log(pathname,'pathnamepathnamepathname');
   return (
     <div className="container-fluid container-xl d-flex align-items-center justify-content-between">
       <Link href="/" className="logo d-flex align-items-center me-auto me-lg-0">
@@ -303,9 +303,9 @@ const PublicHeader = () => {
         </button>
       </nav>
 
-      <Link href="/signup" className="HeaderSign">
+      { (pathname !== '/signup' && pathname !== '/signin') && <Link href="/signup" className="HeaderSign">
         <Icon icon="carbon:checkmark-filled" width="20" height="20" /> Sign Up
-      </Link>
+      </Link> }
     </div>
   );
 };

--- a/apps/frontend/src/app/Pages/Sign/SignIn.tsx
+++ b/apps/frontend/src/app/Pages/Sign/SignIn.tsx
@@ -26,7 +26,7 @@ function useErrorTost() {
       errortext,
       iconElement,
       className = "",
-      // duration = 2000
+      duration = 2000
     }: {
       message: string;
       errortext: string;
@@ -36,7 +36,7 @@ function useErrorTost() {
     }
   ) => {
     setErrorTost({ show: true, message, errortext, iconElement, className });
-    // setTimeout(() => setErrorTost({ show: false }), duration);
+    setTimeout(() => setErrorTost({ show: false }), duration);
   };
 
   const ErrorTostPopup = errorTost.show ? (
@@ -297,6 +297,7 @@ if(isVerified){
                   />
                   
                   <FormInputPass
+                    inPlaceHolder='Enter your password'
                     intype="password"
                     inname="password"
                     value={password}
@@ -370,8 +371,8 @@ if(isVerified){
                 <Form>
                   <div className="TopSignInner">
                     <h2>Set <span>new password</span> </h2>
-                    <FormInputPass intype="Enter New Password" inname="password" value={password} inlabel="Password" onChange={(e) => setPassword(e.target.value)} />
-                    <FormInputPass intype="Confirm Password" inname="confirmPassword" value={confirmPassword} inlabel="Password" onChange={(e) => setConfirmPassword(e.target.value)} />
+                    <FormInputPass  intype="password" inPlaceHolder="Enter New Password" inname="password" value={password} inlabel="Enter New Password" onChange={(e) => setPassword(e.target.value)} />
+                    <FormInputPass  intype="password" inPlaceHolder="Confirm Password" inname="confirmPassword" value={confirmPassword} inlabel="Confirm Password" onChange={(e) => setConfirmPassword(e.target.value)} />
                   </div>
                   <div className="Signbtn">
                     <MainBtn btnicon={<GoCheckCircleFill />} btnname="Reset Password" iconPosition="left" onClick={handleVerifyOtp} />

--- a/apps/frontend/src/app/Pages/Sign/SignUp.tsx
+++ b/apps/frontend/src/app/Pages/Sign/SignUp.tsx
@@ -28,7 +28,7 @@ function useErrorTost() {
       errortext,
       iconElement,
       className = "",
-      // duration = 2000
+      duration = 2000
     }: {
       message: string;
       errortext: string;
@@ -38,7 +38,7 @@ function useErrorTost() {
     }
   ) => {
     setErrorTost({ show: true, message, errortext, iconElement, className });
-    // setTimeout(() => setErrorTost({ show: false }), duration);
+    setTimeout(() => setErrorTost({ show: false }), duration);
   };
 
   const ErrorTostPopup = errorTost.show ? (
@@ -780,6 +780,7 @@ type FormInputPassProps = {
   value: string;
   inlabel: string;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  inPlaceHolder?:string
 };
 export function FormInputPass({
   intype,
@@ -788,6 +789,7 @@ export function FormInputPass({
   value,
   onChange,
   error,
+  inPlaceHolder
 }: FormInputPassProps & { error?: string }) {
   const [showPassword, setShowPassword] = useState(false);
   const [isFocused, setIsFocused] = useState(false);
@@ -809,7 +811,7 @@ export function FormInputPass({
           autoComplete="new-password"
           onChange={onChange}
           required
-          placeholder=" "
+          placeholder={isFocused ? inPlaceHolder :''}
           onFocus={() => setIsFocused(true)}
           onBlur={() => setIsFocused(false)}
           className={error ? 'is-invalid' : ''}


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

   - The code should be slightly more prominent, with improved highlighting and a slightly increased font size for better readability.
   - All OTP input fields should be cleared automatically when a new code is requested.
   -  The "OTP sent" message should disappear automatically after a few seconds or once the user begins entering the OTP code.
   -  On the set new password, Clicking the eye icon should toggle the password field between hidden and visible (text) states.
   -  Update the placeholders to "Enter New Password" and "Confirm Password".


## What is the new behavior?
- Increased OTP code font size and applied improved highlighting for better readability.
- OTP input fields now automatically clear when a new code is requested.
- The "OTP sent" message automatically disappears after a few seconds or once the user begins entering the OTP.
- Added toggle functionality to the password fields (eye icon) so users can switch between hidden and visible text.
- Updated placeholders:
    - Enter New Password
    - Confirm Password

## Related Issue(s) #673 

