### PR TITLE
Fix: Add properties to avoid C/C++ code analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,2 +1,7 @@
 sonar.projectKey=YosemiteCrew_Yosemite-Crew
 sonar.organization=yosemitecrew
+
+# Avoid analyzing C/C++
+sonar.c.file.suffixes=-
+sonar.cpp.file.suffixes=-
+sonar.objc.file.suffixes=-


### PR DESCRIPTION
<!--
We, the rest of the Yosemite community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?
- Currently our `sonar-cloud-analysis` workflow fails because it tries to analyse C/C++ based code which requires some pre-setup.

## What is the new behavior?
- New properties added to the `sonar-project.properties` file will avoid analysing this C/C++ based code.



