### PR TITLE
Improve sonar analysis runtime by perfoming app specific analysis

### DIFF
--- a/.github/workflows/sonar-cloud-analysis.yml
+++ b/.github/workflows/sonar-cloud-analysis.yml
@@ -7,10 +7,34 @@ on:
   schedule:
     - cron: '0 4 * * *'
   pull_request:
+    branches:
+      - main
+      - dev
     types: [opened, synchronize, reopened]
+
 permissions: read-all
+
 jobs:
-  sonarqube:
+
+  #job for analysing Frontend
+  sonarqube-frontend:
+    name: SonarQube
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v5
+        with:
+          projectBaseDir: apps/frontend
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_FRONTEND }}
+  
+  #job for analysing APIs
+  sonarqube-api:
     name: SonarQube
     runs-on: ubuntu-latest
     steps:
@@ -19,6 +43,24 @@ jobs:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@v5
+        with:
+          projectBaseDir: apps/api
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_API }}
+
+  #job for analysing MobileApp
+  sonarqube-mobile:
+    name: SonarQube
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v5
+        with:
+          projectBaseDir: apps/mobileApp
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_MOBILE }}

--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ yarn-error.log
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+# local sonar reports
+**/.scannerwork

--- a/apps/api/sonar-project.properties
+++ b/apps/api/sonar-project.properties
@@ -1,0 +1,19 @@
+sonar.projectKey=YosemiteCrew_Yosemite-Crew_API
+sonar.organization=yosemitecrew
+
+# Source settings
+sonar.sources=.
+sonar.test.inclusions=**/*.test.ts,**/*.spec.ts
+
+# Coverage (assuming Jest with lcov)
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
+
+# Exclusions (speed up scan massively)
+sonar.exclusions=**/node_modules/**,**/dist/**,**/build/**,**/coverage/**,**/*.d.ts
+sonar.test.exclusions=**/node_modules/**,**/dist/**,**/build/**,**/coverage/**
+sonar.coverage.exclusions=**/*.test.ts,**/*.spec.ts,**/tests/**
+
+# Ignore non-relevant languages
+sonar.c.file.suffixes=-
+sonar.cpp.file.suffixes=-
+sonar.objc.file.suffixes=-

--- a/apps/frontend/sonar-project.properties
+++ b/apps/frontend/sonar-project.properties
@@ -1,0 +1,19 @@
+sonar.projectKey=yosemitecrew_Yosemite-Crew_Frontend
+sonar.organization=yosemitecrew
+
+# Source settings
+sonar.sources=src
+sonar.test.inclusions=**/*.test.ts,**/*.spec.ts
+
+# Coverage (assuming Jest with lcov)
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
+
+# Exclusions (speed up scan massively)
+sonar.exclusions=**/node_modules/**,**/dist/**,**/build/**,**/coverage/**,**/*.d.ts
+sonar.test.exclusions=**/node_modules/**,**/dist/**,**/build/**,**/coverage/**
+sonar.coverage.exclusions=**/*.test.ts,**/*.spec.ts,**/tests/**
+
+# Ignore non-relevant languages
+sonar.c.file.suffixes=-
+sonar.cpp.file.suffixes=-
+sonar.objc.file.suffixes=-

--- a/apps/mobileApp/sonar-project.properties
+++ b/apps/mobileApp/sonar-project.properties
@@ -1,0 +1,19 @@
+sonar.projectKey=yosemitecrew_Yosemite-Crew_MobileApp
+sonar.organization=yosemitecrew
+
+# Source settings
+sonar.sources=src
+sonar.test.inclusions=**/*.test.ts,**/*.spec.ts
+
+# Coverage (assuming Jest with lcov)
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
+
+# Exclusions (speed up scan massively)
+sonar.exclusions=**/node_modules/**,**/dist/**,**/build/**,**/coverage/**,**/*.d.ts
+sonar.test.exclusions=**/node_modules/**,**/dist/**,**/build/**,**/coverage/**
+sonar.coverage.exclusions=**/*.test.ts,**/*.spec.ts,**/tests/**
+
+# Ignore non-relevant languages
+sonar.c.file.suffixes=-
+sonar.cpp.file.suffixes=-
+sonar.objc.file.suffixes=-

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,0 @@
-sonar.projectKey=YosemiteCrew_Yosemite-Crew
-sonar.organization=yosemitecrew
-
-# Avoid analyzing C/C++
-sonar.c.file.suffixes=-
-sonar.cpp.file.suffixes=-
-sonar.objc.file.suffixes=-


### PR DESCRIPTION

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?
- Due to mono repo structure sonar cloud analysis is taking too much time and it's even difficult to look for app specific issue raised by the analysis.

## What is the new behavior?
- This PR improved `sonar-cloud-analysis` workflow run time by introducing parallel analysis running for `api`, `frontend` and `mobileApp`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
Fixes #786 


