### PR TITLE
Feat:  Add middleware for authorisation and granting the permissions

### DIFF
--- a/apps/api/middlewares/authorization.ts
+++ b/apps/api/middlewares/authorization.ts
@@ -1,0 +1,56 @@
+import { Request, Response, NextFunction } from "express";
+import { WebUser as User } from "../models/WebUser";
+import { Role } from "../models/role";
+
+export async function loadPermissions(
+    req: Request & { user?: any }, 
+    res: Response, 
+    next: NextFunction) {
+  if (!req.user) return res.status(401).json({ message: "Unauthorized" });
+
+  const user = await User.findOne({ cognitoId: req.user.sub })
+  if (!user) return res.status(403).json({ message: "User not found" });
+
+  const role = await Role.findOne({name : user.role});
+  if (!role) return res.status(403).json({ message: "Role not found" });
+
+  const merged: Record<string, Set<string>> = {};
+
+  // Add role permissions
+  for (const [resource, actions] of Object.entries(role.permissions)) {
+    if (!merged[resource]) merged[resource] = new Set();
+    (actions as string[]).forEach((a) => merged[resource].add(a));
+  }
+
+  // Add extra user-specific permissions
+  for (const [resource, actions] of Object.entries(user.extraPermissions || {})) {
+    if (!merged[resource]) merged[resource] = new Set();
+    (actions as string[]).forEach((a) => merged[resource].add(a));
+  }
+
+  req.user.permissions = Object.fromEntries(
+    Object.entries(merged).map(([k, v]) => [k, Array.from(v)])
+  );
+
+  next();
+}
+
+export function authorize (resource: string, action: string) {
+
+    return (
+        req : Request & { user?: any }, 
+        res : Response, 
+        next : NextFunction
+    ) => {
+        if (!req.user) return res.status(401).json({ message: "Unauthorized" });
+
+        // Check if user is allowed to perform a given operation on a given resource
+        const perms = req.user.permissions[resource] || [];
+        if (!perms.includes(action)) {
+        return res.status(403).json({ message: "Forbidden" });
+        }
+
+        next();
+    }
+    
+}

--- a/apps/api/models/WebUser.ts
+++ b/apps/api/models/WebUser.ts
@@ -14,8 +14,8 @@ const WebUserSchema = new Schema<IWebUser>({
   subscribe:{type:Boolean},
   department:{type:String},
   lastLogin: { type: Date },
-  isVerified:{type:Number, default:0} // 0 unverified 1 verified
-  
+  isVerified:{type:Number, default:0}, // 0 unverified 1 verified
+  extraPermissions: { type: Map, of: [String], default: {} }
 },{
   timestamps: true,});
 

--- a/apps/api/models/role.ts
+++ b/apps/api/models/role.ts
@@ -1,0 +1,11 @@
+import { Schema, model } from "mongoose";
+import { IRole } from "@yosemite-crew/types"
+
+const roleSchema = new Schema<IRole>({
+  name: { type: String, required: true, unique: true },
+  description: { type: String },
+  permissions: { type: Map, of: [String], default: {} },
+});
+
+export const Role = model<IRole>("Role", roleSchema);
+

--- a/packages/types/src/HospitalProfile/hospital.profile.model.ts
+++ b/packages/types/src/HospitalProfile/hospital.profile.model.ts
@@ -37,5 +37,6 @@ export interface IWebUser {
   subscribe?:boolean;
   department?:string
   lastLogin?: Date;
-  isVerified?:number
+  isVerified?:number;
+  extraPermissions: Record<string, string[]>;
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -66,3 +66,4 @@ export type {FHIRMedicalRecord ,FhirDocumentReference, MedicalRecordRequestBody,
 export type {adminDepartment,AdminDepartmentItem,AdminFHIRHealthcareService} from './models/admin-department'
 export type {NormalBlog,FHIRBlog} from './Blog/BlogTypes'
 export type {ITask,FormTaskData,UploadedFileForCreateTask} from './models/create-task';
+export type {IRole} from './models/role'

--- a/packages/types/src/models/role.ts
+++ b/packages/types/src/models/role.ts
@@ -1,0 +1,7 @@
+import { Document } from "mongoose";
+
+export interface IRole extends Document {
+  name: string;
+  description?: string;
+  permissions: Record<string, string[]>; // e.g. { posts: ["view", "edit"] }
+}


### PR DESCRIPTION

<!--
We, the rest of the Yosemite community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?
- Currently we don't have any middleware to check user permissions and to provide access to the resource based on their permissions.

## What is the new behavior?
- This PR add a new middlewear called `authorisation` which will allow us to load the user' permissions based on their role and extra permissions given to them.
- Then we can check wether a user is allowed to access particular resource or not based on the permissions.

## Related Issue(s)

Fixes #869 #851 



