### PR TITLE
fix(pms): responsive layout for PMS page (#759)

### DIFF
--- a/apps/frontend/src/app/Components/Footer/Footer.css
+++ b/apps/frontend/src/app/Components/Footer/Footer.css
@@ -2,6 +2,9 @@
     background-color: var(--lightblue);
     padding: 0px 50px 25px 50px;
     position: relative;
+    box-sizing: border-box;
+    width: 100%;
+    overflow-x: hidden;
 }
 .Footersec::after{
     position: absolute;
@@ -20,13 +23,20 @@
     display: flex;
     flex-direction: column;
     gap: 13px;
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
 }
+
 .FootTopData{
     display: grid;
     grid-template-columns: 1fr 1fr;
     padding: 70px 0px 20px 0px;
     gap: 32px;
+    width: 100%;
+    box-sizing: border-box;
 }
+
 .leftFooter{
     max-width: 354px;
     padding: 12px;
@@ -35,7 +45,19 @@
     flex-direction: column;
     justify-content: space-between;
     align-items: flex-start;
+    box-sizing: border-box;
+    width: 100%;
 }
+
+.RytFooter {
+    display: flex;
+    justify-content: flex-end;
+    gap: 100px;
+    flex-wrap: wrap;
+    width: 100%;
+    box-sizing: border-box;
+}
+
 .leftFooter .ClientLogo{
    display: flex;
    align-items: center;
@@ -43,11 +65,11 @@
    gap: 12px;
    flex-wrap: wrap;
 }
-.RytFooter {
-    display: flex;
-    justify-content: flex-end;
-    gap: 100px;
-    flex-wrap: wrap;
+
+.leftFooter .ClientLogo img {
+    max-width: 100%;
+    height: auto;
+    object-fit: contain;
 }
 
 .FtDiv{
@@ -61,6 +83,40 @@
     font-size: 23px;
     font-weight: 500;
     line-height: 120%;
+}
+
+.FtLinks a {
+    padding: 0;
+    font-size: 15px;
+    font-weight: 400;
+    line-height: 120%;
+    font-family: var(--satoshi-font);
+    color: var(--black-text);
+    position: relative;
+    display: inline-block;
+    text-decoration: none;
+    transition: color 0.3s cubic-bezier(0.4,0,0.2,1), transform 0.3s cubic-bezier(0.4,0,0.2,1);
+}
+
+.Bootom_Foot h4{
+    font-family: var(--satoshi-font);
+    color: var(--black-text);
+    font-size: 15px;
+    font-weight: 700;
+    line-height: 18px;
+    letter-spacing: -0.02em;
+    margin: 0;
+}
+
+.Bootom_Foot p{
+    font-family: var(--satoshi-font);
+    color: var(--black-text);
+    font-size: 13px;
+    font-weight: 400;
+    line-height: 18.6px;
+    letter-spacing: -0.03em;
+    margin: 0;
+    text-align: center;
 }
 .footer-divider {
     border: none;
@@ -121,13 +177,19 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    width: 100%;
+    box-sizing: border-box;
+    margin-top: auto;
 }
 .Bootom_Foot {
     display: flex;
     flex-direction: column;
     align-items: center;
     gap: 2px;
-
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
+    text-align: center;
 }
 .Bootom_Foot h4{
     font-family: var(--satoshi-font);
@@ -150,6 +212,27 @@
     text-align: center;
 }
 
+@media (max-width: 1200px) {
+    .Footersec {
+        padding: 0px 30px 25px 30px;
+    }
+    .RytFooter {
+        gap: 60px;
+    }
+}
+
+@media (max-width: 1024px) {
+    .Footersec {
+        padding: 0px 25px 25px 25px;
+    }
+    .FootTopData {
+        padding: 50px 0px 20px 0px;
+    }
+    .RytFooter {
+        gap: 40px;
+    }
+}
+
 @media (max-width: 900px) {
     .FootTopData {
         grid-template-columns: 1fr;
@@ -163,21 +246,45 @@
     .leftFooter {
         min-height: unset;
         align-items: flex-start;
+        max-width: 100%;
+    }
+}
+
+@media (max-width: 768px) {
+    .Footersec {
+        padding: 0px 20px 20px 20px;
+    }
+    .FootTopData {
+        padding: 40px 0px 16px 0px;
+        gap: 24px;
+    }
+    .RytFooter {
+        gap: 32px;
+    }
+    .FtDiv h5 {
+        font-size: 20px;
+    }
+    .FtLinks a {
+        font-size: 14px;
     }
 }
 
 @media (max-width: 600px) {
     .Footersec {
-        padding: 0 10px 20px 10px;
+        padding: 0 15px 15px 15px;
+    }
+    .FootTopData {
+        padding: 30px 0px 12px 0px;
     }
     .RytFooter {
         flex-direction: column;
         gap: 24px;
         width: 100%;
-        overflow-x: auto;
+        overflow-x: hidden;
     }
     .FtDiv {
         min-width: 180px;
+        width: 100%;
     }
     .footer-divider {
         margin: 24px 0 16px 0;
@@ -185,14 +292,88 @@
     .leftFooter .ClientLogo {
         gap: 8px;
         flex-wrap: wrap;
+        justify-content: flex-start;
     }
 }
 
-@media (max-width: 400px) {
+@media (max-width: 480px) {
+    .Footersec {
+        padding: 0 12px 12px 12px;
+    }
+    .Footersec::after {
+        width: 60px;
+        height: 60px;
+        top: -25px;
+    }
+    .FootTopData {
+        padding: 25px 0px 10px 0px;
+        gap: 20px;
+    }
     .FtDiv {
         min-width: 140px;
+        width: 100%;
+    }
+    .FtDiv h5 {
+        font-size: 18px;
+    }
+    .FtLinks a {
+        font-size: 13px;
     }
     .leftFooter {
-        padding: 6px;
+        padding: 4px;
+    }
+    .leftFooter .ClientLogo {
+        gap: 6px;
+        justify-content: center;
+    }
+    .Bootom_Foot h4 {
+        font-size: 13px;
+    }
+    .Bootom_Foot p {
+        font-size: 11px;
+        line-height: 16px;
+    }
+}
+
+@media (max-width: 350px) {
+    .Footersec {
+        padding: 0 8px 8px 8px;
+    }
+    .Footersec::after {
+        width: 50px;
+        height: 50px;
+        top: -20px;
+    }
+    .FootTopData {
+        padding: 20px 0px 8px 0px;
+        gap: 16px;
+    }
+    .FtDiv h5 {
+        font-size: 16px;
+    }
+    .FtLinks a {
+        font-size: 12px;
+    }
+    .leftFooter {
+        padding: 2px;
+    }
+    .leftFooter .ClientLogo {
+        gap: 4px;
+        justify-content: center;
+        flex-direction: column;
+        align-items: center;
+    }
+    .Bootom_Foot h4 {
+        font-size: 12px;
+    }
+    .Bootom_Foot p {
+        font-size: 10px;
+        line-height: 14px;
+    }
+    .RytFooter {
+        gap: 16px;
+    }
+    .FtDiv {
+        gap: 12px;
     }
 }

--- a/apps/frontend/src/app/Components/Header/Header.css
+++ b/apps/frontend/src/app/Components/Header/Header.css
@@ -12,16 +12,24 @@
   );
   border-image-slice: 1;
   max-height: 100px;
+  width: 100%;
+  box-sizing: border-box;
+  overflow-x: hidden;
 }
 .header .logo {
   padding: 0px;
   width: 80px;
   height: 80px;
+  min-width: 50px;
+  min-height: 50px;
+  box-sizing: border-box;
 }
 
 .header .logo img {
   width: 100%;
   height: auto;
+  max-width: 100%;
+  object-fit: contain;
 }
 
 .public-header {
@@ -37,6 +45,11 @@
     rgba(255, 255, 255, 0) 100%
   );
   border-image-slice: 1;
+  width: 100%;
+  box-sizing: border-box;
+  top: 0;
+  left: 0;
+  right: 0;
 }
 .public-header-mobile-menu {
   background: #fff;
@@ -50,6 +63,9 @@
   width: 100vw;
   overflow: hidden;
   padding: 30px 48px;
+  box-sizing: border-box;
+  max-height: calc(100vh - 100px);
+  overflow-y: auto;
 }
 .mobile-menu-item a {
   color: var(--notibg);
@@ -89,7 +105,10 @@
   display: flex;
   align-items: center;
   gap: 24px;
+  flex-shrink: 0;
+  min-width: 0;
 }
+
 .UserInfoHeader .Notify {
   width: 24px;
   height: 24px;
@@ -97,11 +116,14 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-shrink: 0;
 }
+
 .UserInfoHeader .Notify svg {
   font-size: 18px;
   color: var(--notibg);
 }
+
 .UserInfoHeader .Notify .count {
   position: absolute;
   top: 0;
@@ -117,6 +139,8 @@
   display: flex;
   align-items: center;
   gap: 10px;
+  min-width: 0;
+  flex-shrink: 0;
 }
 
 .NavUL {
@@ -165,6 +189,9 @@
   line-height: 120%;
   margin: 0;
   max-width: 142px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .NavUL .nav-profile .userHostDiv .Tier {
   color: var(--blue-text);
@@ -188,6 +215,7 @@
   top: 100%;
   left: 0;
   min-width: 200px !important;
+  max-width: 300px;
   padding: 16px 0;
   background: var(--whitebg);
   border: 1px solid var(--lightgrey);
@@ -197,6 +225,7 @@
   transition: all 0.3s ease;
   z-index: 999;
   list-style-type: none;
+  box-sizing: border-box;
 }
 .profileUl .ProfDiv {
   display: flex;
@@ -310,7 +339,10 @@
   font-size: 19px;
   line-height: 120%;
   transition: 0.5s ease;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
+
 .HeaderSign:hover {
   background: var(--black-hover);
 }
@@ -332,6 +364,8 @@
   line-height: 120%;
   margin-top: 23px;
   transition: 0.5s ease;
+  width: 100%;
+  box-sizing: border-box;
 }
 .HeaderSign-mobile:hover {
   background: var(--black-hover);
@@ -374,6 +408,7 @@
 
 .navmenu {
   padding: 0;
+  overflow: hidden;
 }
 
 .navmenu ul {
@@ -382,6 +417,14 @@
   display: flex;
   list-style: none;
   align-items: center;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.navmenu ul::-webkit-scrollbar {
+  display: none;
 }
 
 .navmenu li {
@@ -470,6 +513,7 @@
   top: 100%;
   left: 0;
   min-width: 200px;
+  max-width: 300px;
   padding: 10px 0;
   background: var(--whitebg);
   border: 1px solid var(--lightgrey);
@@ -478,6 +522,7 @@
   transform: translateY(10px);
   transition: all 0.3s ease;
   z-index: 999;
+  box-sizing: border-box;
 }
 
 .navmenu li:hover > ul.dropdown {
@@ -528,5 +573,223 @@
   }
   .HeaderSign {
     display: none;
+  }
+}
+
+/* Tablet responsiveness */
+@media (max-width: 768px) {
+  .header {
+    max-height: 80px;
+  }
+  
+  .header .logo {
+    width: 60px;
+    height: 60px;
+  }
+  
+  .public-header {
+    padding: 8px 0px;
+  }
+  
+  .public-header-mobile-menu {
+    padding: 20px 24px;
+    gap: 15px;
+  }
+  
+  .UserInfoHeader {
+    gap: 16px;
+  }
+  
+  .nav-profile .user {
+    width: 35px;
+    height: 35px;
+  }
+  
+  .NavUL .nav-profile .userHostDiv .userName p {
+    font-size: 12px;
+    max-width: 120px;
+  }
+  
+  .NavUL .nav-profile .userHostDiv .Tier {
+    font-size: 11px;
+    padding: 3px 6px;
+  }
+  
+  .menu-toggle {
+    height: 35px;
+    width: 35px;
+  }
+  
+  .hamburger-icon span {
+    width: 12px;
+  }
+}
+
+/* Mobile responsiveness */
+@media (max-width: 480px) {
+  .header {
+    max-height: 70px;
+  }
+  
+  .header .logo {
+    width: 50px;
+    height: 50px;
+  }
+  
+  .public-header {
+    padding: 6px 0px;
+  }
+  
+  .public-header-mobile-menu {
+    padding: 15px 16px;
+    gap: 12px;
+  }
+  
+  .mobile-menu-item a {
+    font-size: 14px;
+  }
+  
+  .UserInfoHeader {
+    gap: 12px;
+  }
+  
+  .UserInfoHeader .Notify {
+    width: 20px;
+    height: 20px;
+  }
+  
+  .UserInfoHeader .Notify svg {
+    font-size: 16px;
+  }
+  
+  .nav-profile .user {
+    width: 32px;
+    height: 32px;
+  }
+  
+  .NavUL .nav-profile .userHostDiv .userName p {
+    font-size: 11px;
+    max-width: 100px;
+  }
+  
+  .NavUL .nav-profile .userHostDiv .Tier {
+    font-size: 10px;
+    padding: 2px 4px;
+  }
+  
+  .menu-toggle {
+    height: 32px;
+    width: 32px;
+  }
+  
+  .hamburger-icon {
+    gap: 2px;
+  }
+  
+  .hamburger-icon span {
+    width: 10px;
+    height: 1.5px;
+  }
+  
+  .profileUl {
+    min-width: 180px !important;
+    right: 0;
+    left: auto;
+  }
+  
+  .navmenu li ul.dropdown {
+    min-width: 180px;
+    right: 0;
+    left: auto;
+  }
+}
+
+/* Small mobile responsiveness */
+@media (max-width: 375px) {
+  .header {
+    max-height: 60px;
+  }
+  
+  .header .logo {
+    width: 45px;
+    height: 45px;
+  }
+  
+  .public-header {
+    padding: 5px 0px;
+  }
+  
+  .public-header-mobile-menu {
+    padding: 12px 12px;
+    gap: 10px;
+  }
+  
+  .mobile-menu-item a {
+    font-size: 13px;
+  }
+  
+  .UserInfoHeader {
+    gap: 8px;
+  }
+  
+  .nav-profile .user {
+    width: 28px;
+    height: 28px;
+  }
+  
+  .NavUL .nav-profile .userHostDiv {
+    display: none;
+  }
+  
+  .menu-toggle {
+    height: 28px;
+    width: 28px;
+  }
+  
+  .hamburger-icon span {
+    width: 8px;
+    height: 1px;
+  }
+  
+  .profileUl {
+    min-width: 160px !important;
+  }
+  
+  .navmenu li ul.dropdown {
+    min-width: 160px;
+  }
+}
+
+/* Extra small mobile responsiveness */
+@media (max-width: 320px) {
+  .header .logo {
+    width: 40px;
+    height: 40px;
+  }
+  
+  .public-header-mobile-menu {
+    padding: 10px 8px;
+  }
+  
+  .UserInfoHeader {
+    gap: 6px;
+  }
+  
+  .nav-profile .user {
+    width: 24px;
+    height: 24px;
+  }
+  
+  .menu-toggle {
+    height: 24px;
+    width: 24px;
+  }
+  
+  .profileUl {
+    min-width: 140px !important;
+  }
+  
+  .navmenu li ul.dropdown {
+    min-width: 140px;
   }
 }

--- a/apps/frontend/src/app/Pages/HomePage/HomePage.css
+++ b/apps/frontend/src/app/Pages/HomePage/HomePage.css
@@ -3,16 +3,38 @@
   padding: 80px 0px;
   display: flex;
   align-items: center;
+  width: 100%;
+  box-sizing: border-box;
+  overflow-x: hidden;
 }
 .HomeHeroSection .HeroData {
   display: grid;
   grid-template-columns: 1fr 1fr;
   align-items: center;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
 }
 .HomeHeroSection .HeroData .LeftHeroDiv {
   display: flex;
   flex-direction: column;
   gap: 15px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.RytHeroDiv {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+}
+
+.RytHeroDiv img {
+  max-width: 100%;
+  height: auto;
+  object-fit: contain;
 }
 .LeftHeroDiv .herotext h1 {
   font-size: 48px;
@@ -117,11 +139,17 @@ a.UnFillbtn {
 
 .PracticedSection {
   padding: 80px 0px;
+  width: 100%;
+  box-sizing: border-box;
+  overflow-x: hidden;
 }
 .PracticedData {
   display: flex;
   flex-direction: column;
   gap: 28px;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
 }
 .PractHeading h2 {
   font-family: var(--grotesk-font);
@@ -272,7 +300,8 @@ a.UnFillbtn {
   color: var(--black-text);
 }
 .TrustExpertData {
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
   justify-content: center;
   gap: 32px;
   padding: 50px 0px;
@@ -474,4 +503,711 @@ a.UnFillbtn {
 }
 .lftbetter img {
   width: 100%;
+  height: auto;
+  object-fit: contain;
+  max-height: 400px;
+}
+
+/* Responsive Styles */
+
+/* Tablet Styles (768px - 1024px) */
+@media screen and (max-width: 1024px) {
+  .HomeHeroSection .HeroData {
+    grid-template-columns: 1fr;
+    gap: 40px;
+    text-align: center;
+  }
+  
+  .RytHeroDiv {
+    order: -1;
+  }
+  
+  .LeftHeroDiv {
+    order: 1;
+  }
+  
+  .LeftHeroDiv .herotext h1 {
+    font-size: 42px;
+  }
+  
+  .Practice_Box_Data {
+    grid-template-columns: repeat(3, 1fr);
+    gap: 20px;
+  }
+  .FocusSection{
+    padding: 80px 0px;
+    align-items: center;
+  }
+  .Focus_data {
+    grid-template-columns: repeat(3, 1fr);
+    gap: 20px;
+  }
+  .TrustExpertSec{
+    padding: 80px 0px;
+    align-items: center;
+  }
+  .TrustExpertData {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 20px;
+  }
+  
+  .Expertitems {
+    max-width: 100%;
+    min-width: auto;
+  }
+  
+  .whocareData {
+    grid-template-columns: 1fr 1fr;
+    gap: 40px;
+    text-align: left;
+    align-items: flex-start;
+  }
+  
+  .whocareData .rytcare .carelog {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 15px;
+    max-width: 300px;
+  }
+  
+  .BettercareBox {
+    grid-template-columns: 1fr 1fr;
+    max-width: 90%;
+  }
+  
+  .lftbetter:first-child {
+    order: 1;
+  }
+  
+  .lftbetter:last-child {
+    order: 2;
+  }
+  
+  .betInner {
+    max-width: 100%;
+    text-align: left;
+    padding: 30px 20px;
+  }
+  
+  .lftbetter img {
+    max-height: 280px;
+    width: auto;
+    max-width: 100%;
+    object-fit: contain;
+  }
+}
+
+/* Mobile Styles (max-width: 768px) */
+@media screen and (max-width: 768px) {
+  .HomeHeroSection {
+    padding: 30px 0px;
+  }
+  
+  .HomeHeroSection .HeroData {
+    grid-template-columns: 1fr;
+    gap: 20px;
+  }
+  
+  .RytHeroDiv {
+    order: -1;
+  }
+  
+  .RytHeroDiv img {
+    max-width: 100%;
+    height: auto;
+    max-height: 300px;
+    object-fit: contain;
+  }
+  
+  .LeftHeroDiv {
+    order: 1;
+  }
+  
+  .LeftHeroDiv .herotext h1 {
+    font-size: 32px;
+    white-space: normal;
+    animation: none;
+    width: auto;
+    overflow: visible;
+    line-height: 1.2;
+  }
+  
+  .LeftHeroDiv .heroPara {
+    gap: 12px;
+  }
+  
+  .LeftHeroDiv .heroPara .paraitem p {
+    font-size: 15px;
+    line-height: 1.4;
+  }
+  
+  .LeftHeroDiv .HeroBtn {
+    flex-direction: column;
+    gap: 12px;
+    padding-top: 20px;
+    width: 100%;
+  }
+  
+  a.Fillbtn, a.UnFillbtn {
+    width: 100%;
+    font-size: 16px;
+    padding: 12px 20px;
+    min-height: 45px;
+    box-sizing: border-box;
+  }
+  
+  .PracticedSection {
+    padding: 60px 0px;
+  }
+  
+  .PractHeading h2 {
+    font-size: 32px;
+    text-align: center;
+  }
+  
+  .Practice_Box_Data {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 16px;
+    justify-items: center;
+  }
+  
+  .PracBox {
+    max-width: 100%;
+    width: 100%;
+    min-height: auto;
+    padding: 20px 16px;
+    margin: 0;
+    border-radius: 24px;
+    box-sizing: border-box;
+  }
+  
+  .PracBox h4 {
+    font-size: 20px;
+    padding-top: 10px;
+  }
+  .FocusSection{
+    padding: 60px 0px;
+  }
+  .FocusTexted {
+    min-width: auto;
+    width: 100%;
+  }
+  
+  .FocusTexted h2 {
+    font-size: 32px;
+  }
+  
+  .Focus_data {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 16px;
+    justify-items: center;
+  }
+  
+  .FocusItem {
+    max-width: 100%;
+    width: 100%;
+    min-height: auto;
+    padding: 24px 16px;
+    border-radius: 20px;
+    box-sizing: border-box;
+  }
+  
+  .focusText h4 {
+    font-size: 24px;
+  }
+  
+  .TrustExpertSec {
+    padding: 60px 0px;
+  }
+  
+  .ExprtTexted h4 {
+    font-size: 32px;
+  }
+  
+  .TrustExpertData {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 16px;
+    padding: 30px 0px;
+    justify-items: center;
+  }
+  
+  .TrustExpertData::after {
+    display: none;
+  }
+  
+  .Expertitems {
+    max-width: 100%;
+    width: 100%;
+    min-height: 280px;
+    padding: 12px;
+    box-sizing: border-box;
+  }
+  
+  .expertPara {
+    min-height: 200px;
+  }
+  
+  .expertPara p {
+    font-size: 16px;
+  }
+  
+  .WhoCareSection {
+    padding: 40px 0px;
+  }
+  
+  .whocareData {
+    grid-template-columns: 1fr;
+    gap: 30px;
+  }
+  
+  .whocareData .lftcare h2 {
+    font-size: 32px;
+    text-align: center;
+  }
+  
+  .whocareData .lftcare p {
+    font-size: 16px;
+    max-width: 100%;
+    text-align: center;
+  }
+  
+  .whocareData .rytcare {
+    align-items: center;
+  }
+  
+  .whocareData .rytcare .carelog {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 15px;
+    max-width: 100%;
+    width: 100%;
+    margin: 0 auto;
+    justify-items: center;
+  }
+  
+  .whocareData .rytcare .carelog img {
+    max-width: 100%;
+    height: auto;
+    object-fit: contain;
+  }
+  
+  .BetterCareSec {
+    padding: 60px 0px 120px 0px;
+  }
+  
+  .BettercareBox {
+    grid-template-columns: 1fr;
+    max-width: 95%;
+    border-radius: 24px;
+    overflow: hidden;
+  }
+  
+  .lftbetter:first-child {
+    order: 1;
+    padding: 30px 20px;
+  }
+  
+  .lftbetter:last-child {
+    order: 2;
+    padding: 0;
+  }
+  
+  .betInner {
+    max-width: 100%;
+    gap: 30px;
+    text-align: center;
+    width: 100%;
+  }
+  
+  .betInner h2 {
+    font-size: 32px;
+  }
+  
+  .betInner p {
+    font-size: 16px;
+  }
+  
+  .lftbetter img {
+    max-height: 250px;
+    width: 100%;
+    max-width: 100%;
+    object-fit: cover;
+    display: block;
+  }
+}
+
+/* Medium Small Mobile Styles (max-width: 480px) */
+@media screen and (max-width: 480px) {
+  .lftbetter img {
+    max-height: 220px;
+    width: 100%;
+    max-width: 100%;
+    object-fit: cover;
+    display: block;
+  }
+}
+
+/* Small Mobile Styles (max-width: 375px) */
+@media screen and (max-width: 375px) {
+  .HomeHeroSection {
+    padding: 20px 0px;
+  }
+  
+  .HomeHeroSection .HeroData {
+    gap: 15px;
+  }
+  
+  .RytHeroDiv img {
+    max-height: 220px;
+    width: 100%;
+    object-fit: contain;
+  }
+  
+  .LeftHeroDiv .herotext h1 {
+    font-size: 24px;
+    line-height: 1.1;
+  }
+  
+  .LeftHeroDiv .heroPara {
+    gap: 8px;
+  }
+  
+  .LeftHeroDiv .heroPara .paraitem p {
+    font-size: 13px;
+    line-height: 1.3;
+  }
+  
+  .LeftHeroDiv .HeroBtn {
+    padding-top: 15px;
+    gap: 10px;
+  }
+  
+  a.Fillbtn, a.UnFillbtn {
+    font-size: 14px;
+    padding: 10px 16px;
+    min-height: 40px;
+  }
+  
+  .PracticedSection{
+    padding: 30px 0px;
+  }
+  
+  .PractHeading h2 {
+    font-size: 24px;
+    text-align: center;
+  }
+  
+  .Practice_Box_Data {
+    grid-template-columns: 1fr;
+    gap: 12px;
+    justify-items: center;
+  }
+  
+  .PracBox {
+    padding: 16px;
+    width: 100%;
+    box-sizing: border-box;
+  }
+  
+  .PracBox h4 {
+    font-size: 18px;
+  }
+  
+  .FocusTexted h2 {
+    font-size: 24px;
+  }
+  
+  .Focus_data {
+    grid-template-columns: 1fr;
+    gap: 12px;
+    justify-items: center;
+  }
+  
+  .FocusItem {
+    padding: 16px 12px;
+    width: 100%;
+    box-sizing: border-box;
+  }
+  
+  .focusText h4 {
+    font-size: 20px;
+  }
+  
+  .ExprtTexted h4 {
+    font-size: 24px;
+  }
+  
+  .TrustExpertData {
+    grid-template-columns: 1fr;
+    gap: 12px;
+    justify-items: center;
+  }
+  
+  .Expertitems {
+    min-height: 220px;
+    padding: 10px;
+    width: 100%;
+    box-sizing: border-box;
+  }
+  
+  .whocareData .lftcare h2 {
+    font-size: 24px;
+  }
+  
+  .whocareData .rytcare .carelog {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 10px;
+    width: 100%;
+    justify-items: center;
+  }
+  
+  .betInner h2 {
+    font-size: 24px;
+  }
+  
+  .betInner {
+    padding: 20px 12px;
+  }
+  
+  .lftbetter img {
+    max-height: 200px;
+    width: 100%;
+    object-fit: cover;
+  }
+}
+
+/* Extra Small Mobile and Short Screens (max-width: 320px or short height) */
+@media screen and (max-width: 320px), screen and (max-height: 600px) {
+  .HomeHeroSection {
+    padding: 15px 0px;
+  }
+  
+  .HomeHeroSection .HeroData {
+    gap: 12px;
+  }
+  
+  .RytHeroDiv img {
+    max-height: 180px;
+    width: 100%;
+    object-fit: contain;
+  }
+  
+  .LeftHeroDiv .herotext h1 {
+    font-size: 20px;
+    line-height: 1.1;
+    margin-bottom: 8px;
+  }
+  
+  .LeftHeroDiv .heroPara {
+    gap: 6px;
+  }
+  
+  .LeftHeroDiv .heroPara .paraitem p {
+    font-size: 12px;
+    line-height: 1.2;
+  }
+  
+  .LeftHeroDiv .heroPara .paraitem p img {
+    width: 16px;
+    height: 16px;
+  }
+  
+  .LeftHeroDiv .HeroBtn {
+    padding-top: 12px;
+    gap: 8px;
+  }
+  
+  a.Fillbtn, a.UnFillbtn {
+    font-size: 13px;
+    padding: 8px 14px;
+    min-height: 36px;
+  }
+  
+  .PracticedSection {
+    padding: 25px 0px;
+  }
+  
+  .PractHeading h2 {
+    font-size: 20px;
+    line-height: 1.2;
+  }
+  
+  .PracBox {
+    padding: 12px;
+    min-height: auto;
+  }
+  
+  .PracBox h4 {
+    font-size: 16px;
+    line-height: 1.2;
+  }
+  
+  .PracBox p {
+    font-size: 13px;
+    line-height: 1.3;
+  }
+  
+  .Practice_Box_Data {
+    grid-template-columns: repeat(2, 1fr);
+    grid-gap: 15px 10px;
+  }
+  
+  .FocusSection {
+    padding: 25px 0px;
+  }
+  
+  .FocusTexted h2 {
+    font-size: 20px;
+    line-height: 1.2;
+  }
+  
+  .FocusTexted p {
+    font-size: 13px;
+  }
+  
+  .FocusItem {
+    padding: 12px 10px;
+    min-height: auto;
+  }
+  
+  .focusText h4 {
+    font-size: 18px;
+  }
+  
+  .focusText p {
+    font-size: 13px;
+  }
+  
+  .Focus_data {
+    grid-template-columns: repeat(2, 1fr);
+    grid-gap: 15px 10px;
+  }
+  
+  .TrustExpertSec {
+    padding: 25px 0px;
+  }
+  
+  .ExprtTexted h4 {
+    font-size: 20px;
+  }
+  
+  .TrustExpertData {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 12px 8px;
+  }
+  
+  .Expertitems {
+    min-height: 200px;
+    padding: 8px;
+  }
+  
+  .expertPara {
+    min-height: 140px;
+  }
+  
+  .expertPara p {
+    font-size: 13px;
+    line-height: 1.3;
+  }
+  
+  .WhoCareSection {
+    padding: 25px 0px;
+  }
+  
+  .whocareData .lftcare h2 {
+    font-size: 20px;
+    line-height: 1.2;
+  }
+  
+  .whocareData .lftcare p {
+    font-size: 13px;
+  }
+  
+  .whocareData .rytcare p {
+    font-size: 13px;
+  }
+  
+  .BetterCareSec {
+    padding: 25px 0px 60px 0px;
+  }
+  
+  .betInner h2 {
+    font-size: 20px;
+    line-height: 1.2;
+  }
+  
+  .betInner p {
+    font-size: 13px;
+  }
+  
+  .betInner {
+    padding: 15px 10px;
+    gap: 15px;
+  }
+  
+  .lftbetter img {
+    max-height: 160px;
+  }
+}
+
+/* Landscape Mobile and Very Short Height Screens */
+@media screen and (max-height: 500px) and (orientation: landscape) {
+  .HomeHeroSection {
+    padding: 10px 0px;
+  }
+  
+  .HomeHeroSection .HeroData {
+    gap: 10px;
+  }
+  
+  .RytHeroDiv img {
+    max-height: 120px;
+  }
+  
+  .LeftHeroDiv .herotext h1 {
+    font-size: 18px;
+    line-height: 1;
+    margin: 0;
+  }
+  
+  .LeftHeroDiv .heroPara {
+    gap: 4px;
+  }
+  
+  .LeftHeroDiv .heroPara .paraitem p {
+    font-size: 11px;
+    line-height: 1.2;
+  }
+  
+  .LeftHeroDiv .HeroBtn {
+    padding-top: 8px;
+    gap: 6px;
+  }
+  
+  a.Fillbtn, a.UnFillbtn {
+    font-size: 12px;
+    padding: 6px 12px;
+    min-height: 32px;
+  }
+  
+  .PracticedSection, .FocusSection, .TrustExpertSec, .WhoCareSection, .BetterCareSec {
+    padding: 15px 0px;
+  }
+  
+  .Practice_Box_Data {
+    grid-template-columns: repeat(2, 1fr);
+    grid-gap: 12px 8px;
+  }
+  
+  .Focus_data {
+    grid-template-columns: repeat(2, 1fr);
+    grid-gap: 12px 8px;
+  }
+  
+  .TrustExpertData {
+    grid-template-columns: repeat(2, 1fr);
+    grid-gap: 12px 8px;
+  }
 }


### PR DESCRIPTION
This PR fixes #759 by making the PMS page fully responsive.

### Changes made
- Updated layout and components for responsiveness
- Fixed scaling of titles, headings, and body
- Improved footer and navigation for smaller screens
- Ensured consistency across devices

### Checklist
- [x] Ran `pnpm run lint` with no errors
- [x] Verified responsiveness on multiple screen sizes
- [x] Linked issue #759