### PR TITLE
Fix: Fix failing SonarCloud workflow on PRs

### DIFF
--- a/.github/workflows/sonar-cloud-analysis.yml
+++ b/.github/workflows/sonar-cloud-analysis.yml
@@ -6,13 +6,15 @@ on:
       - dev
   schedule:
     - cron: '0 4 * * *'
-  pull_request:
+  pull_request_target:
     branches:
       - main
       - dev
     types: [opened, synchronize, reopened]
 
-permissions: read-all
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
 
@@ -30,10 +32,14 @@ jobs:
         with:
           projectBaseDir: apps/frontend
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_FRONTEND }}
+          SONAR_SCANNER_OPTS: >
+            -Dsonar.pullrequest.key=${{ github.event.pull_request.number }}
+            -Dsonar.pullrequest.branch=${{ github.head_ref }}
+            -Dsonar.pullrequest.base=${{ github.base_ref }}
 
-  #job for analysing APIs
+  #job for analysing Backend
   sonarqube-api:
     name: SonarQube
     runs-on: ubuntu-latest
@@ -46,8 +52,12 @@ jobs:
         with:
           projectBaseDir: apps/backend
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_API }}
+          SONAR_SCANNER_OPTS: >
+            -Dsonar.pullrequest.key=${{ github.event.pull_request.number }}
+            -Dsonar.pullrequest.branch=${{ github.head_ref }}
+            -Dsonar.pullrequest.base=${{ github.base_ref }}
 
   #job for analysing MobileApp
   sonarqube-mobile:
@@ -62,5 +72,9 @@ jobs:
         with:
           projectBaseDir: apps/mobileAppYC
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_MOBILE }}
+          SONAR_SCANNER_OPTS: >
+            -Dsonar.pullrequest.key=${{ github.event.pull_request.number }}
+            -Dsonar.pullrequest.branch=${{ github.head_ref }}
+            -Dsonar.pullrequest.base=${{ github.base_ref }}


### PR DESCRIPTION
<!--
We, the rest of the Yosemite community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?
- Currently on every `pull_request` workflow `sonar-cloud-analysis` fails.
- The error shows it's not able to extract `SONAR_TOKEN` from the `secrets` so there was some permission issues.

## What is the new behavior?
- This PR adds right permission for the PR workflows so that on a `pull_request` it can extract `SONAR_TOKEN` and can run  the workflow.

## Related Issue(s)
Fixes #1168


