### PR TITLE
Create APIs for `User Availability`

### DIFF
--- a/apps/backend/jest.config.cjs
+++ b/apps/backend/jest.config.cjs
@@ -16,7 +16,8 @@ module.exports = {
     }
   },
   moduleNameMapper: {
-    "^@yosemite-crew/(.*)$": "<rootDir>/../../packages/$1/src"
+    "^@yosemite-crew/(.*)$": "<rootDir>/../../packages/$1/src",
+    "^src/(.*)$": "<rootDir>/src/$1"
   },
   transform: {
     "^.+\\.tsx?$": ["ts-jest", { tsconfig: "<rootDir>/tsconfig.json" }]

--- a/apps/backend/src/controllers/web/availability.controller.ts
+++ b/apps/backend/src/controllers/web/availability.controller.ts
@@ -1,0 +1,412 @@
+import { Request, Response } from 'express';
+import { AvailabilityService } from 'src/services/availability.service';
+import { AuthenticatedRequest } from '../../middlewares/auth'
+import logger from 'src/utils/logger';
+import { AvailabilitySlotMongo, DayOfWeek } from 'src/models/base-availability';
+import { WeeklyOverrideDay } from 'src/models/weekly-availablity-override';
+import type { OccupancyMongo } from 'src/models/occupancy';
+
+type OrgParams = { orgId: string };
+
+type AvailabilityBody = {
+    availabilities?: {
+        dayOfWeek: DayOfWeek;
+        slots: AvailabilitySlotMongo[];
+    }[];
+};
+
+type WeeklyOverrideBody = {
+    weekStartDate?: string | number | Date;
+    overrides?: WeeklyOverrideDay;
+};
+
+type WeeklyOverrideQuery = {
+    weekStartDate?: string;
+};
+
+type AddOccupancyBody = {
+    startTime?: string | number | Date;
+    endTime?: string | number | Date;
+    sourceType?: OccupancyMongo['sourceType'];
+    referenceId?: string;
+};
+
+type AddAllOccupanciesBody = {
+    organisationId?: string;
+    userId?: string;
+    occupancies?: {
+        startTime: string | number | Date;
+        endTime: string | number | Date;
+        sourceType: OccupancyMongo['sourceType'];
+        referenceId?: string;
+    }[];
+};
+
+type OccupancyQuery = {
+    startDate?: string;
+    endDate?: string;
+};
+
+type FinalAvailabilityQuery = {
+    referenceDate?: string;
+};
+
+const safeDate = (value?: string | number | Date): Date | undefined => {
+    if (value === undefined || value === null) return undefined;
+    const parsed = value instanceof Date ? new Date(value.getTime()) : new Date(value);
+    return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+};
+
+const resolveUserIdFromRequest = (req: Request): string | undefined => {
+    const authRequest = req as AuthenticatedRequest
+    const headerUserId = req.headers['x-user-id']
+    if (headerUserId && typeof headerUserId === 'string') {
+        return headerUserId
+    }
+    return authRequest.userId
+}
+
+export const AvailabilityController = {
+
+  // Controllers for Base Availability
+
+  async setAllBaseAvailability(
+    req: Request<OrgParams, unknown, AvailabilityBody>,
+    res: Response
+  ) {
+    try {
+      const organisationId = req.params.orgId;
+      const userId = resolveUserIdFromRequest(req);
+      const { availabilities } = req.body;
+
+      if (!organisationId || !userId || !availabilities) {
+        return res.status(400).json({ message: 'Missing required fields' });
+      }
+
+      const result = await AvailabilityService.setAllBaseAvailability(
+        organisationId,
+        userId,
+        availabilities
+      );
+
+      return res.status(201).json({
+        message: 'Base availability set successfully',
+        data: result,
+      });
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      logger.error('Error in setAllBaseAvailability:', error);
+      return res.status(500).json({ message: 'Internal server error', error: message });
+    }
+  },
+
+  async getBaseAvailability(req: Request<OrgParams>, res: Response) {
+    try {
+      const organisationId = req.params.orgId;
+      const userId = resolveUserIdFromRequest(req);
+
+      if (!organisationId || !userId) {
+        return res.status(400).json({ message: 'Missing required parameters' });
+      }
+
+      const result = await AvailabilityService.getBaseAvailability(
+        String(organisationId),
+        String(userId)
+      );
+
+      return res.status(200).json({ data: result });
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      logger.error('Error in getBaseAvailability:', error);
+      return res.status(500).json({ message: 'Internal server error', error: message });
+    }
+  },
+
+  async deleteBaseAvailability(req: Request<OrgParams>, res: Response) {
+    try {
+      const organisationId = req.params.orgId;
+      const userId = resolveUserIdFromRequest(req);
+
+      if (!organisationId || !userId) {
+        return res.status(400).json({ message: 'Missing required parameters' });
+      }
+
+      await AvailabilityService.deleteBaseAvailability(
+        String(organisationId),
+        String(userId)
+      );
+
+      return res.status(200).json({ message: 'Base availability deleted successfully' });
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      logger.error('Error in deleteBaseAvailability:', error);
+      return res.status(500).json({ message: 'Internal server error', error: message });
+    }
+  },
+
+  // Contollers for Weekly Availability Overrides
+
+  async addWeeklyAvailabilityOverride(
+    req: Request<OrgParams, unknown, WeeklyOverrideBody>,
+    res: Response
+  ) {
+    try {
+      const organisationId = req.params.orgId;
+      const userId = resolveUserIdFromRequest(req);
+      const { weekStartDate, overrides } = req.body;
+
+      if (!organisationId || !userId || !weekStartDate || !overrides) {
+        return res.status(400).json({ message: 'Missing required fields' });
+      }
+
+      const parsedDate = safeDate(weekStartDate);
+
+      if (!parsedDate) {
+        return res.status(400).json({ message: 'Invalid weekStartDate' });
+      }
+
+      await AvailabilityService.addWeeklyAvailabilityOverride(
+        organisationId,
+        userId,
+        parsedDate,
+        overrides
+      );
+
+      return res.status(201).json({ message: 'Weekly override added successfully' });
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      logger.error('Error in addWeeklyAvailabilityOverride:', error);
+      return res.status(500).json({ message: 'Internal server error', error: message });
+    }
+  },
+
+  async getWeeklyAvailabilityOverride(
+    req: Request<OrgParams, unknown, unknown, WeeklyOverrideQuery>,
+    res: Response
+  ) {
+    try {
+      const organisationId = req.params.orgId;
+      const userId = resolveUserIdFromRequest(req);
+      const { weekStartDate } = req.query;
+
+      if (!organisationId || !userId || !weekStartDate) {
+        return res.status(400).json({ message: 'Missing required parameters' });
+      }
+
+      const parsedDate = safeDate(weekStartDate);
+
+      if (!parsedDate) {
+        return res.status(400).json({ message: 'Invalid weekStartDate' });
+      }
+
+      const result = await AvailabilityService.getWeeklyAvailabilityOverride(
+        String(organisationId),
+        String(userId),
+        parsedDate
+      );
+
+      if (!result) return res.status(404).json({ message: 'No weekly override found' });
+
+      return res.status(200).json({ data: result });
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      logger.error('Error in getWeeklyAvailabilityOverride:', error);
+      return res.status(500).json({ message: 'Internal server error', error: message });
+    }
+  },
+
+  async deleteWeeklyAvailabilityOverride(
+    req: Request<OrgParams, unknown, unknown, WeeklyOverrideQuery>,
+    res: Response
+  ) {
+    try {
+      const organisationId = req.params.orgId;
+      const userId = resolveUserIdFromRequest(req);
+      const { weekStartDate } = req.query;
+
+      if (!organisationId || !userId || !weekStartDate) {
+        return res.status(400).json({ message: 'Missing required parameters' });
+      }
+
+      const parsedDate = safeDate(weekStartDate);
+
+      if (!parsedDate) {
+        return res.status(400).json({ message: 'Invalid weekStartDate' });
+      }
+
+      await AvailabilityService.deleteWeeklyAvailabilityOverride(
+        String(organisationId),
+        String(userId),
+        parsedDate
+      );
+
+      return res.status(200).json({ message: 'Weekly override deleted successfully' });
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      logger.error('Error in deleteWeeklyAvailabilityOverride:', error);
+      return res.status(500).json({ message: 'Internal server error', error: message });
+    }
+  },
+
+  // Controllers for Occupancy
+
+  async addOccupancy(
+    req: Request<OrgParams, unknown, AddOccupancyBody>,
+    res: Response
+  ) {
+    try {
+      const organisationId = req.params.orgId;
+      const userId = resolveUserIdFromRequest(req);
+      const { startTime, endTime, sourceType, referenceId } = req.body;
+
+      const parsedStart = safeDate(startTime);
+      const parsedEnd = safeDate(endTime);
+
+      if (!organisationId || !userId || !parsedStart || !parsedEnd || !sourceType) {
+        return res.status(400).json({ message: 'Missing required fields' });
+      }
+
+      await AvailabilityService.addOccupancy(
+        organisationId,
+        userId,
+        parsedStart,
+        parsedEnd,
+        sourceType,
+        referenceId
+      );
+
+      return res.status(201).json({ message: 'Occupancy added successfully' });
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      logger.error('Error in addOccupancy:', error);
+      return res.status(500).json({ message: 'Internal server error', error: message });
+    }
+  },
+
+  async addAllOccupancies(
+    req: Request<unknown, unknown, AddAllOccupanciesBody>,
+    res: Response
+  ) {
+    try {
+      const { organisationId, userId, occupancies } = req.body;
+
+      if (!organisationId || !userId || !Array.isArray(occupancies) || !occupancies.length) {
+        return res.status(400).json({ message: 'Missing required fields' });
+      }
+
+      const normalized = [];
+
+      for (const occupancy of occupancies) {
+        const parsedStart = safeDate(occupancy.startTime);
+        const parsedEnd = safeDate(occupancy.endTime);
+
+        if (!parsedStart || !parsedEnd || !occupancy.sourceType) {
+          return res.status(400).json({ message: 'Invalid occupancy payload' });
+        }
+
+        normalized.push({
+          startTime: parsedStart,
+          endTime: parsedEnd,
+          sourceType: occupancy.sourceType,
+          referenceId: occupancy.referenceId,
+        });
+      }
+
+      await AvailabilityService.addAllOccupancies(organisationId, userId, normalized);
+
+      return res.status(201).json({ message: 'All occupancies added successfully' });
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      logger.error('Error in addAllOccupancies:', error);
+      return res.status(500).json({ message: 'Internal server error', error: message });
+    }
+  },
+
+  async getOccupancy(
+    req: Request<OrgParams, unknown, unknown, OccupancyQuery>,
+    res: Response
+  ) {
+    try {
+      const organisationId = req.params.orgId;
+      const userId = resolveUserIdFromRequest(req);
+      const { startDate, endDate } = req.query;
+
+      const parsedStart = safeDate(startDate);
+      const parsedEnd = safeDate(endDate);
+
+      if (!organisationId || !userId || !parsedStart || !parsedEnd) {
+        
+        return res.status(400).json({ message: 'Missing required parameters' });
+      }
+
+      const result = await AvailabilityService.getOccupancy(
+        String(organisationId),
+        String(userId),
+        parsedStart,
+        parsedEnd
+      );
+
+      return res.status(200).json({ data: result });
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      logger.error('Error in getOccupancy:', error);
+      return res.status(500).json({ message: 'Internal server error', error: message });
+    }
+  },
+
+  // Controllers for Final Availability and Current Status
+
+  async getFinalAvailability(
+    req: Request<OrgParams, unknown, unknown, FinalAvailabilityQuery>,
+    res: Response
+  ) {
+    try {
+      const organisationId = req.params.orgId;
+      const userId = resolveUserIdFromRequest(req);
+      const { referenceDate } = req.query;
+
+      logger.info(`Received getFinalAvailability request with orgId: ${organisationId}, userId: ${userId}, referenceDate: ${referenceDate}`);
+
+      const parsedDate = safeDate(referenceDate);
+
+      if (!organisationId || !userId || !parsedDate) {
+        
+        return res.status(400).json({ message: 'Missing required parameters' });
+      }
+
+      const result = await AvailabilityService.getFinalAvailabilityForDate(
+        String(organisationId),
+        String(userId),
+        parsedDate
+      );
+
+      return res.status(200).json({ data: result });
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      logger.error('Error in getFinalAvailability:', error);
+      return res.status(500).json({ message: 'Internal server error', error: message });
+    }
+  },
+
+  async getCurrentStatus(req: Request<OrgParams>, res: Response) {
+    try {
+      const organisationId = req.params.orgId;
+      const userId = resolveUserIdFromRequest(req);
+
+      if (!organisationId || !userId) {
+        return res.status(400).json({ message: 'Missing required parameters' });
+      }
+
+      const status = await AvailabilityService.getCurrentStatus(
+        String(organisationId),
+        String(userId)
+      );
+
+      return res.status(200).json({ status });
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      logger.error('Error in getCurrentStatus:', error);
+      return res.status(500).json({ message: 'Internal server error', error: message });
+    }
+  },
+};

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -8,7 +8,7 @@ import parentRouter from "./routers/parent.router";
 import userOrganizationRouter from "./routers/user-organization.router";
 import userRouter from "./routers/user.router";
 import userProfileRouter from "./routers/user-profile.router";
-import baseAvailabilityRouter from "./routers/base-availability.router";
+import availabilityRouter from "./routers/availability.router";
 import { MongoMemoryServer } from "mongodb-memory-server";
 import specialtyRouter from "./routers/speciality.router";
 import organisationRoomRouter from "./routers/organisation-room.router";
@@ -26,10 +26,10 @@ app.use(`/fhir/v1/parent`, parentRouter);
 app.use(`/fhir/v1/user-organization`, userOrganizationRouter);
 app.use(`/fhir/v1/user`, userRouter);
 app.use(`/fhir/v1/user-profile`, userProfileRouter);
-app.use(`/fhir/v1/base-availability`, baseAvailabilityRouter);
 app.use(`/fhir/v1/speciality`, specialtyRouter);
 app.use(`/fhir/v1/organisation-room`, organisationRoomRouter);
 app.use(`/fhir/v1/organisation-invites`, organisationInviteRouter);
+app.use(`/fhir/v1/availability`, availabilityRouter);
 
 let mongoUri: string;
 

--- a/apps/backend/src/models/base-availability.ts
+++ b/apps/backend/src/models/base-availability.ts
@@ -1,5 +1,14 @@
 import { Schema, model, type HydratedDocument } from 'mongoose'
 
+export type DayOfWeek =
+  | 'MONDAY'
+  | 'TUESDAY'
+  | 'WEDNESDAY'
+  | 'THURSDAY'
+  | 'FRIDAY'
+  | 'SATURDAY'
+  | 'SUNDAY';
+
 export interface AvailabilitySlotMongo {
     startTime: string
     endTime: string
@@ -8,7 +17,8 @@ export interface AvailabilitySlotMongo {
 
 export interface BaseAvailabilityMongo {
     userId: string
-    dayOfWeek: 'MONDAY' | 'TUESDAY' | 'WEDNESDAY' | 'THURSDAY' | 'FRIDAY' | 'SATURDAY' | 'SUNDAY'
+    organisationId?: string
+    dayOfWeek: DayOfWeek
     slots: AvailabilitySlotMongo[]
     createdAt?: Date
     updatedAt?: Date
@@ -26,11 +36,8 @@ const AvailabilitySlotSchema = new Schema<AvailabilitySlotMongo>(
 const BaseAvailabilitySchema = new Schema<BaseAvailabilityMongo>(
     {
         userId: { type: String, required: true, trim: true, index: true },
-        dayOfWeek: {
-            type: String,
-            required: true,
-            enum: ['MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY', 'SATURDAY', 'SUNDAY'],
-        },
+        organisationId: { type: String, required: true },
+        dayOfWeek: { type: String, required: true},
         slots: { type: [AvailabilitySlotSchema], default: [] },
     },
     {
@@ -38,7 +45,7 @@ const BaseAvailabilitySchema = new Schema<BaseAvailabilityMongo>(
     }
 )
 
-BaseAvailabilitySchema.index({ userId: 1, dayOfWeek: 1 }, { unique: true })
+BaseAvailabilitySchema.index({ userId: 1, organisationId: 1, dayOfWeek: 1 }, { unique: true })
 
 export type BaseAvailabilityDocument = HydratedDocument<BaseAvailabilityMongo>
 

--- a/apps/backend/src/models/occupancy.ts
+++ b/apps/backend/src/models/occupancy.ts
@@ -1,0 +1,28 @@
+import mongoose, { Schema, Document } from 'mongoose';
+
+export interface OccupancyMongo extends Document {
+  userId: string;
+  organisationId: string;
+  startTime: Date;
+  endTime: Date;
+  sourceType: 'APPOINTMENT' | 'BLOCKED' | 'SURGERY';
+  referenceId?: string;
+}
+
+const OccupancySchema = new Schema<OccupancyMongo>(
+  {
+    userId: { type: String, required: true },
+    organisationId: { type: String, required: true },
+    startTime: { type: Date, required: true },
+    endTime: { type: Date, required: true },
+    sourceType: { type: String, enum: ['APPOINTMENT', 'BLOCKED', 'SURGERY'], default: 'APPOINTMENT' },
+    referenceId: { type: String },
+  },
+  { timestamps: true }
+);
+
+OccupancySchema.index({ userId: 1, startTime: 1, endTime: 1 });
+
+export type OccupancyDocument = mongoose.HydratedDocument<OccupancyMongo>;
+
+export default mongoose.model<OccupancyMongo>('Occupancy', OccupancySchema);

--- a/apps/backend/src/models/weekly-availablity-override.ts
+++ b/apps/backend/src/models/weekly-availablity-override.ts
@@ -1,0 +1,56 @@
+import { Schema, Document, model, type HydratedDocument } from 'mongoose';
+import { DayOfWeek } from './base-availability';
+
+export interface OverrideSlot {
+  startTime: string;
+  endTime: string;
+  isAvailable: boolean;
+}
+
+export interface WeeklyOverrideDay {
+  dayOfWeek: DayOfWeek;
+  slots: OverrideSlot[];
+}
+
+export interface WeeklyAvailabilityOverrideMongo extends Document {
+  userId: string;
+  organisationId: string;
+  weekStartDate: Date;
+  overrides: WeeklyOverrideDay[];
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+const WeeklyAvailabilityOverrideSchema = new Schema<WeeklyAvailabilityOverrideMongo>(
+  {
+    userId: { type: String, required: true },
+    organisationId: { type: String, required: true },
+    weekStartDate: { type: Date, required: true },
+    overrides: [
+      {
+        dayOfWeek: String,
+        slots: [
+          {
+            startTime: String,
+            endTime: String,
+            isAvailable: Boolean,
+          },
+        ],
+      },
+    ],
+  },
+  { timestamps: true }
+);
+
+
+WeeklyAvailabilityOverrideSchema.index({ userId: 1, organisationId: 1, weekStartDate: 1 }, { unique: true });
+
+export type WeeklyAvailabilityOverrideDocument = HydratedDocument<WeeklyAvailabilityOverrideMongo>;
+
+const WeeklyAvailabilityOverrideModel =
+  model<WeeklyAvailabilityOverrideMongo>(
+    'WeeklyAvailabilityOverride',
+    WeeklyAvailabilityOverrideSchema
+  );
+
+export default WeeklyAvailabilityOverrideModel;

--- a/apps/backend/src/routers/availability.router.ts
+++ b/apps/backend/src/routers/availability.router.ts
@@ -1,0 +1,28 @@
+import { Router } from 'express';
+import { AvailabilityController } from 'src/controllers/web/availability.controller';
+import authorizeCognito from 'src/middlewares/auth';
+
+const router = Router();
+
+router.use(authorizeCognito);
+
+// Base
+router.post('/:orgId/base', (req, res) => AvailabilityController.setAllBaseAvailability(req, res));
+router.get('/:orgId/base', (req, res) => AvailabilityController.getBaseAvailability(req, res));
+router.delete('/:orgId/base', (req, res) => AvailabilityController.deleteBaseAvailability(req, res));
+
+// Weekly overrides
+router.post('/:orgId/weekly', (req, res) => AvailabilityController.addWeeklyAvailabilityOverride(req, res));
+router.get('/:orgId/weekly', (req, res) => AvailabilityController.getWeeklyAvailabilityOverride(req, res));
+router.delete('/:orgId/weekly', (req, res) => AvailabilityController.deleteWeeklyAvailabilityOverride(req, res));
+
+// Occupancy
+router.post('/:orgId/occupancy', (req, res) => AvailabilityController.addOccupancy(req, res));
+router.post('/:orgId/occupancy/bulk', (req, res) => AvailabilityController.addAllOccupancies(req, res));
+router.get('/:orgId/occupancy', (req, res) => AvailabilityController.getOccupancy(req, res));
+
+// Computed availability and status
+router.get('/:orgId/final', (req, res) => AvailabilityController.getFinalAvailability(req, res));
+router.get('/:orgId/status', (req, res) => AvailabilityController.getCurrentStatus(req, res));
+
+export default router;

--- a/apps/backend/src/services/availability.service.ts
+++ b/apps/backend/src/services/availability.service.ts
@@ -1,0 +1,310 @@
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import BaseAvailabilityModel, {
+    BaseAvailabilityDocument,
+    DayOfWeek,
+    AvailabilitySlotMongo
+} from 'src/models/base-availability';
+import WeeklyAvailabilityOverrideModel, { WeeklyOverrideDay, WeeklyAvailabilityOverrideDocument } from 'src/models/weekly-availablity-override';
+import OccupancyModel, { OccupancyDocument } from 'src/models/occupancy';
+import logger from 'src/utils/logger';
+
+dayjs.extend(utc);
+
+export const AvailabilityService = {
+
+    // Services for base availability for a user in an organisation
+
+    async setAllBaseAvailability(
+        organisationId: string,
+        userId: string,
+        availabilities: {
+            dayOfWeek: DayOfWeek;
+            slots: AvailabilitySlotMongo[];
+        }[]
+    ): Promise<BaseAvailabilityDocument[]> {
+        // Delete existing availabilities for the user
+        await BaseAvailabilityModel.deleteMany({ userId, organisationId });
+
+        // Prepare new availabilities with userId and organisationId
+        const newAvailabilities = availabilities.map((availability) => ({
+            ...availability,
+            userId,
+            organisationId,
+        }));
+
+        // Insert new availabilities
+        const createdAvailabilities = await BaseAvailabilityModel.insertMany(newAvailabilities);
+
+        return createdAvailabilities;
+    },
+
+    async getBaseAvailability(
+        organisationId: string,
+        userId: string,
+    ): Promise<BaseAvailabilityDocument[]> {
+        const availabilities = await BaseAvailabilityModel.find({ userId, organisationId });
+        return availabilities;
+    },
+
+    async deleteBaseAvailability(
+        organisationId: string,
+        userId: string,
+    ): Promise<void> {
+        await BaseAvailabilityModel.deleteMany({ userId, organisationId });
+    },
+
+
+    // Services for Weekly Availability 
+    
+    async addWeeklyAvailabilityOverride(
+        organisationId: string,
+        userId: string,
+        weekStartDate: Date,
+        overrides: WeeklyOverrideDay
+    ): Promise<void> {
+        const existingOverride = await WeeklyAvailabilityOverrideModel.findOne({ userId, organisationId, weekStartDate });
+
+        if (existingOverride) {
+            // Update existing override
+            existingOverride.overrides.push(overrides);
+            await existingOverride.save();
+        } else {
+            // Create new override
+            const newOverride = new WeeklyAvailabilityOverrideModel({
+                userId,
+                organisationId,
+                weekStartDate,
+                overrides: [overrides],
+            });
+            await newOverride.save();
+        }
+
+    },
+
+    async getWeeklyAvailabilityOverride(
+        organisationId: string,
+        userId: string,
+        weekStartDate: Date,
+    ): Promise< WeeklyAvailabilityOverrideDocument | null> {
+        const override = await WeeklyAvailabilityOverrideModel.findOne({ userId, organisationId, weekStartDate });
+        logger.info(
+            `Fetched weekly override for user ${userId} for week starting ${weekStartDate.toISOString()}: ${JSON.stringify(
+                override,
+                null,
+                2
+            )}`
+        );
+        return override ?? null;
+    },
+
+    async deleteWeeklyAvailabilityOverride(
+        organisationId: string,
+        userId: string,
+        weekStartDate: Date,
+    ): Promise<void> {
+        await WeeklyAvailabilityOverrideModel.deleteOne({ userId, organisationId, weekStartDate });
+    },
+
+    // Service for Occupancy
+
+    async addOccupancy(
+        organisationId: string,
+        userId: string,
+        startTime: Date,
+        endTime: Date,
+        sourceType: 'APPOINTMENT' | 'BLOCKED' | 'SURGERY',
+        referenceId?: string
+    ): Promise<void> {
+        // Implementation for adding occupancy
+        const occupancy = new OccupancyModel({
+            userId,
+            organisationId,
+            startTime,
+            endTime,
+            sourceType,
+            referenceId,
+        });
+        await occupancy.save();
+    },
+
+    async addAllOccupancies(
+        organisationId: string,
+        userId: string,
+        occupancies: {
+            startTime: Date;
+            endTime: Date;
+            sourceType: 'APPOINTMENT' | 'BLOCKED' | 'SURGERY';
+            referenceId?: string;
+        }[]
+    ): Promise<void> {
+        const occupancyDocs = occupancies.map((occupancy) => ({
+            ...occupancy,
+            userId,
+            organisationId,
+        }));
+        await OccupancyModel.insertMany(occupancyDocs);
+    },
+
+    async getOccupancy(
+        organisationId: string,
+        userId: string,
+        startDate: Date,
+        endDate: Date,
+    ): Promise<OccupancyDocument[]> {
+        const occupancies = await OccupancyModel.find({
+            userId,
+            organisationId,
+            startTime: { $gte: startDate },
+            endTime: { $lte: endDate },
+        });
+        return occupancies;
+    },
+
+    // Logics for merging base availability, weekly overrides, and occupancy
+
+    async getWeeklyFinalAvailability(
+        organisationId: string,
+        userId: string,
+        referenceDate: Date // any date in the desired week
+    ): Promise<{
+        dayOfWeek: DayOfWeek;
+        slots: AvailabilitySlotMongo[];
+    }[]> {
+        const weekStartDate = dayjs(referenceDate).utc().startOf('week').add(1, 'day').startOf('day').toDate()// Monday start
+        const baseAvailabilities = await this.getBaseAvailability(organisationId, userId);
+        const weeklyOverride = await this.getWeeklyAvailabilityOverride(organisationId, userId, weekStartDate);
+
+        logger.info(`Calculating final availability for user ${userId} for week starting ${weekStartDate.toISOString()}`);
+        logger.info(`Base Availabilities: ${JSON.stringify(baseAvailabilities, null, 2)}`);
+        logger.info(`Weekly Override: ${JSON.stringify(weeklyOverride, null, 2)}`);
+
+        const startOfWeek = dayjs(weekStartDate).startOf('day');
+        const endOfWeek = dayjs(weekStartDate).add(6, 'day').endOf('day');
+        const occupancies = await this.getOccupancy(
+            organisationId,
+            userId,
+            startOfWeek.toDate(),
+            endOfWeek.toDate()
+        );
+
+        logger.info(`Occupancies: ${JSON.stringify(occupancies, null, 2)}`);
+
+        // Build a base map for quick access
+        const availabilityMap = new Map<DayOfWeek, AvailabilitySlotMongo[]>();
+        for(const a of baseAvailabilities) {
+            availabilityMap.set(a.dayOfWeek, a.slots);
+        }
+
+        logger.info(`Initial Availability Map: ${JSON.stringify(Array.from(availabilityMap.entries()), null, 2)}`);
+
+        // Apply weekly overrides (if available)
+        if (weeklyOverride) {
+            for (const dayOverride of weeklyOverride.overrides) {
+                availabilityMap.set(dayOverride.dayOfWeek, dayOverride.slots);
+            }
+        }
+
+        // Apply occupancy removal
+        for (const occ of occupancies) {
+            const occStart = dayjs(occ.startTime);
+            const occEnd = dayjs(occ.endTime);
+            const dayOfWeek = occStart.format('dddd').toUpperCase() as DayOfWeek // adjust for Sunday if needed
+
+            const existingSlots = availabilityMap.get(dayOfWeek) || [];
+
+            // Remove overlapping slots
+            const filteredSlots = existingSlots.filter(slot => {
+                const slotStart = dayjs(slot.startTime);
+                const slotEnd = dayjs(slot.endTime);
+
+                const overlaps = occStart.isBefore(slotEnd) && occEnd.isAfter(slotStart);
+                return !overlaps; // keep non-overlapping slots
+            });
+
+            availabilityMap.set(dayOfWeek, filteredSlots);
+        }
+
+        // 6️⃣ Return normalized structure
+        const finalAvailability = Array.from(availabilityMap.entries()).map(([dayOfWeek, slots]) => ({
+            dayOfWeek,
+            slots
+        }));
+
+        return finalAvailability;
+    },
+
+   async getFinalAvailabilityForDate(
+     organisationId: string,
+     userId: string,
+     referenceDate: Date
+    ): Promise<{ date: string; dayOfWeek: DayOfWeek; slots: AvailabilitySlotMongo[] }> {
+      const allWeek = await this.getWeeklyFinalAvailability(organisationId, userId, referenceDate);
+
+      const dayOfWeek = dayjs(referenceDate).format('dddd').toUpperCase() as DayOfWeek;
+      const slots = allWeek.find(d => d.dayOfWeek === dayOfWeek)?.slots || [];
+
+      return {
+        date: dayjs(referenceDate).format('YYYY-MM-DD'),
+        dayOfWeek,
+        slots,
+      };
+    },
+
+  // Helper to get weekly overrides in a date range
+
+  getStartDateOfWeek(date: Date) : Date {
+    const day = date.getDay(); // Sunday=0, Monday=1, ..., Saturday=6
+    const diff = (day === 0 ? -6 : 1) - day; // Adjust to get Monday
+    const startOfWeek = new Date(date);
+    startOfWeek.setDate(date.getDate() + diff);
+    startOfWeek.setHours(0, 0, 0, 0); // Optional: reset time
+
+    return startOfWeek;
+  },
+
+  calculateWeeklyHours(slotsByDate: Record<string, AvailabilitySlotMongo[]>) {
+    let totalHours = 0
+    for (const slots of Object.values(slotsByDate)) {
+      for (const slot of slots) {
+        const start = dayjs(`2025-11-10T${slot.startTime}`)
+        const end = dayjs(`2025-11-10T${slot.endTime}`)
+        if (slot.isAvailable) totalHours += end.diff(start, 'hour', true)
+      }
+    }
+    return totalHours
+  },
+
+
+  async getCurrentStatus(organisationId: string, userId: string) {
+    const now = dayjs();
+    const today = now.format('YYYY-MM-DD');
+
+    // Pass a Date, not a string
+    const todayAvailability = await this.getFinalAvailabilityForDate(
+        organisationId,
+        userId,
+        now.toDate()
+    );
+
+    const slots = todayAvailability?.slots || [];
+
+    const occupiedNow = await OccupancyModel.exists({
+      organisationId,
+      userId,
+      startTime: { $lte: now.toDate() },
+      endTime: { $gte: now.toDate() },
+    })
+
+    const activeSlot = slots.find(
+      (slot) =>
+        now.isAfter(dayjs(`${today}T${slot.startTime}`)) &&
+        now.isBefore(dayjs(`${today}T${slot.endTime}`)),
+    )
+
+    if (occupiedNow) return 'Consulting'
+    if (activeSlot) return 'Available'
+    if (!slots.length) return 'Off-Duty'
+    return 'Requested'
+  },
+}

--- a/apps/backend/test/services/availability.service.test.ts
+++ b/apps/backend/test/services/availability.service.test.ts
@@ -1,0 +1,337 @@
+import BaseAvailabilityModel from "../../src/models/base-availability";
+import WeeklyAvailabilityOverrideModel from "../../src/models/weekly-availablity-override";
+import OccupancyModel from "../../src/models/occupancy";
+import { AvailabilityService } from "../../src/services/availability.service";
+
+type MockedBaseAvailabilityModel = {
+  deleteMany: jest.Mock;
+  insertMany: jest.Mock;
+  find: jest.Mock;
+};
+
+type MockedWeeklyOverrideModel = jest.Mock & {
+  findOne: jest.Mock;
+  deleteOne: jest.Mock;
+};
+
+type MockedOccupancyModel = jest.Mock & {
+  insertMany: jest.Mock;
+  find: jest.Mock;
+  exists: jest.Mock;
+};
+
+jest.mock("../../src/models/base-availability", () => ({
+  __esModule: true,
+  default: {
+    deleteMany: jest.fn(),
+    insertMany: jest.fn(),
+    find: jest.fn(),
+  },
+}));
+
+jest.mock("../../src/models/weekly-availablity-override", () => {
+  const mockConstructor = Object.assign(jest.fn(), {
+    findOne: jest.fn(),
+    deleteOne: jest.fn(),
+  });
+  return {
+    __esModule: true,
+    default: mockConstructor,
+  };
+});
+
+jest.mock("../../src/models/occupancy", () => {
+  const mockConstructor = Object.assign(jest.fn(), {
+    insertMany: jest.fn(),
+    find: jest.fn(),
+    exists: jest.fn(),
+  });
+  return {
+    __esModule: true,
+    default: mockConstructor,
+  };
+});
+
+const mockedBaseAvailabilityModel =
+  BaseAvailabilityModel as unknown as MockedBaseAvailabilityModel;
+const mockedWeeklyOverrideModel =
+  WeeklyAvailabilityOverrideModel as unknown as MockedWeeklyOverrideModel;
+const mockedOccupancyModel =
+  OccupancyModel as unknown as MockedOccupancyModel;
+
+describe("AvailabilityService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedWeeklyOverrideModel.mockImplementation(() => ({ save: jest.fn() }));
+    mockedOccupancyModel.mockImplementation(() => ({ save: jest.fn() }));
+  });
+
+  describe("setAllBaseAvailability", () => {
+    it("replaces base availability with the provided slots", async () => {
+      const newDocs = [{ _id: "doc-1" }];
+      mockedBaseAvailabilityModel.insertMany.mockResolvedValueOnce(newDocs);
+
+      const result = await AvailabilityService.setAllBaseAvailability(
+        "org-1",
+        "user-1",
+        [
+          {
+            dayOfWeek: "MONDAY",
+            slots: [{ startTime: "09:00", endTime: "17:00", isAvailable: true }],
+          },
+        ],
+      );
+
+      expect(mockedBaseAvailabilityModel.deleteMany).toHaveBeenCalledWith({
+        userId: "user-1",
+        organisationId: "org-1",
+      });
+      expect(mockedBaseAvailabilityModel.insertMany).toHaveBeenCalledWith([
+        {
+          dayOfWeek: "MONDAY",
+          slots: [{ startTime: "09:00", endTime: "17:00", isAvailable: true }],
+          userId: "user-1",
+          organisationId: "org-1",
+        },
+      ]);
+      expect(result).toBe(newDocs);
+    });
+  });
+
+  describe("addWeeklyAvailabilityOverride", () => {
+    it("updates an existing override when found", async () => {
+      const existingOverride = {
+        overrides: [],
+        save: jest.fn(),
+      };
+      mockedWeeklyOverrideModel.findOne.mockResolvedValueOnce(existingOverride);
+
+      const overridePayload = {
+        dayOfWeek: "MONDAY" as const,
+        slots: [{ startTime: "10:00", endTime: "12:00", isAvailable: true }],
+      };
+
+      await AvailabilityService.addWeeklyAvailabilityOverride(
+        "org-1",
+        "user-1",
+        new Date("2025-01-06"),
+        overridePayload,
+      );
+
+      expect(existingOverride.overrides).toHaveLength(1);
+      expect(existingOverride.overrides[0]).toBe(overridePayload);
+      expect(existingOverride.save).toHaveBeenCalledTimes(1);
+    });
+
+    it("creates a new override document when none exists", async () => {
+      const saveMock = jest.fn();
+      mockedWeeklyOverrideModel.findOne.mockResolvedValueOnce(null);
+      mockedWeeklyOverrideModel.mockImplementationOnce(() => ({
+        save: saveMock,
+      }));
+
+      const overridePayload = {
+        dayOfWeek: "TUESDAY" as const,
+        slots: [{ startTime: "11:00", endTime: "13:00", isAvailable: true }],
+      };
+
+      await AvailabilityService.addWeeklyAvailabilityOverride(
+        "org-2",
+        "user-2",
+        new Date("2025-01-07"),
+        overridePayload,
+      );
+
+      expect(mockedWeeklyOverrideModel).toHaveBeenCalledWith({
+        organisationId: "org-2",
+        userId: "user-2",
+        weekStartDate: new Date("2025-01-07"),
+        overrides: [overridePayload],
+      });
+      expect(saveMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("getFinalAvailability", () => {
+    it("merges base availability, overrides, and occupancy blocks", async () => {
+      mockedBaseAvailabilityModel.find.mockResolvedValueOnce([
+        {
+          dayOfWeek: "MONDAY",
+          slots: [
+            {
+              startTime: "2025-01-06T09:00:00.000Z",
+              endTime: "2025-01-06T11:00:00.000Z",
+              isAvailable: true,
+            },
+            {
+              startTime: "2025-01-06T13:00:00.000Z",
+              endTime: "2025-01-06T15:00:00.000Z",
+              isAvailable: true,
+            },
+          ],
+        },
+        {
+          dayOfWeek: "TUESDAY",
+          slots: [{ startTime: "10:00", endTime: "12:00", isAvailable: true }],
+        },
+      ]);
+
+      mockedWeeklyOverrideModel.findOne.mockResolvedValueOnce({
+        overrides: [
+          {
+            dayOfWeek: "TUESDAY",
+            slots: [
+              {
+                startTime: "2025-01-07T14:00:00.000Z",
+                endTime: "2025-01-07T16:00:00.000Z",
+                isAvailable: true,
+              },
+            ],
+          },
+        ],
+      });
+
+      mockedOccupancyModel.find.mockResolvedValueOnce([
+        {
+          startTime: new Date("2025-01-06T09:30:00.000Z"),
+          endTime: new Date("2025-01-06T10:30:00.000Z"),
+        },
+      ]);
+
+      const availability = await AvailabilityService.getWeeklyFinalAvailability(
+        "org-1",
+        "user-1",
+        new Date("2025-01-08"),
+      );
+
+      expect(availability).toEqual([
+        {
+          dayOfWeek: "MONDAY",
+          slots: [
+            {
+              startTime: "2025-01-06T13:00:00.000Z",
+              endTime: "2025-01-06T15:00:00.000Z",
+              isAvailable: true,
+            },
+          ],
+        },
+        {
+          dayOfWeek: "TUESDAY",
+          slots: [
+            {
+              startTime: "2025-01-07T14:00:00.000Z",
+              endTime: "2025-01-07T16:00:00.000Z",
+              isAvailable: true,
+            },
+          ],
+        },
+      ]);
+    });
+  });
+
+  describe("calculateWeeklyHours", () => {
+    it("sums only available slot durations", () => {
+      const total = AvailabilityService.calculateWeeklyHours({
+        "2025-01-06": [
+          { startTime: "09:00", endTime: "10:30", isAvailable: true },
+          { startTime: "11:00", endTime: "12:00", isAvailable: false },
+        ],
+        "2025-01-07": [
+          { startTime: "14:00", endTime: "18:00", isAvailable: true },
+        ],
+      });
+
+      expect(total).toBeCloseTo(5.5);
+    });
+  });
+
+  describe("getCurrentStatus", () => {
+    const mondayMorning = new Date(2025, 0, 6, 10, 0, 0);
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it("returns Consulting when an occupancy exists", async () => {
+      jest.useFakeTimers().setSystemTime(mondayMorning);
+      const availability = [
+        {
+          dayOfWeek: "MONDAY" as const,
+          slots: [{ startTime: "09:00", endTime: "11:00", isAvailable: true }],
+        },
+      ];
+      const spy = jest
+        .spyOn(AvailabilityService, "getWeeklyFinalAvailability")
+        .mockResolvedValueOnce(availability);
+      mockedOccupancyModel.exists.mockResolvedValueOnce(true);
+
+      const status = await AvailabilityService.getCurrentStatus(
+        "org-1",
+        "user-1",
+      );
+
+      expect(status).toBe("Consulting");
+      spy.mockRestore();
+    });
+
+    it("returns Available when within an active slot", async () => {
+      jest.useFakeTimers().setSystemTime(mondayMorning);
+      const availability = [
+        {
+          dayOfWeek: "MONDAY" as const,
+          slots: [{ startTime: "09:00", endTime: "11:00", isAvailable: true }],
+        },
+      ];
+      const spy = jest
+        .spyOn(AvailabilityService, "getWeeklyFinalAvailability")
+        .mockResolvedValueOnce(availability);
+      mockedOccupancyModel.exists.mockResolvedValueOnce(false);
+
+      const status = await AvailabilityService.getCurrentStatus(
+        "org-1",
+        "user-1",
+      );
+
+      expect(status).toBe("Available");
+      spy.mockRestore();
+    });
+
+    it("returns Off-Duty when no slots exist", async () => {
+      jest.useFakeTimers().setSystemTime(mondayMorning);
+      const spy = jest
+        .spyOn(AvailabilityService, "getWeeklyFinalAvailability")
+        .mockResolvedValueOnce([]);
+      mockedOccupancyModel.exists.mockResolvedValueOnce(false);
+
+      const status = await AvailabilityService.getCurrentStatus(
+        "org-1",
+        "user-1",
+      );
+
+      expect(status).toBe("Off-Duty");
+      spy.mockRestore();
+    });
+
+    it("returns Requested when no slot is active", async () => {
+      jest.useFakeTimers().setSystemTime(mondayMorning);
+      const availability = [
+        {
+          dayOfWeek: "MONDAY" as const,
+          slots: [{ startTime: "12:00", endTime: "13:00", isAvailable: true }],
+        },
+      ];
+      const spy = jest
+        .spyOn(AvailabilityService, "getWeeklyFinalAvailability")
+        .mockResolvedValueOnce(availability);
+      mockedOccupancyModel.exists.mockResolvedValueOnce(false);
+
+      const status = await AvailabilityService.getCurrentStatus(
+        "org-1",
+        "user-1",
+      );
+
+      expect(status).toBe("Requested");
+      spy.mockRestore();
+    });
+  });
+});

--- a/packages/types/src/appointment.ts
+++ b/packages/types/src/appointment.ts
@@ -7,15 +7,36 @@ export type AppointmentStatus =
   | 'CANCELLED';
 
 export type Appointment = {
-  _id?: string;
-  userId: string;              // Vet or practitioner being booked
+  id: string;
+  companion : {
+    id: string;
+    name: string;
+    species: string;  
+    breed: string;
+    parent: {
+      id: string;
+      name: string;
+    };
+  }
+  lead: {
+    id: string;
+    name: string;
+  }                           // Vet or practitioner being booked
+  supportStaff: {
+    id: string;
+    name: string;
+  }[]
+  room: {
+    id: string;
+    name: string;
+  }
   organisationId: string;      // Org / clinic
-  companionId: string;         // pet's id
-  petOwnerId: string;          // Owner making booking
-  startTime: Date;             // Booking start timestamp
+  appointmentDate: Date;       // Date of the appointment
+  timeSlot: string;            // Time Slot for the appointment
+  durationMinutes: number;     // Duration in minutes
   endTime: Date;               // Booking end timestamp
   status: AppointmentStatus;
-  notes?: string;              // Optional
+  concern?: string;            // Reason for the appointment
   createdAt?: Date;
   updatedAt?: Date;
 };


### PR DESCRIPTION

<!--
We, the rest of the Yosemite community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests and lints pass.

## Description
- This PR adds APIs for to determine user's availability and free slots.
- These APIs will allow users to add their `BaseAvailability`, `WeeklyAvailabilityOverride` and `Occupancy`. Base on all three   we'll be able to determine user's final availability.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #1182 

<!-- If this PR contains a breaking change, please describe the impact for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]


