### PR TITLE
Fix: Task assigner and assignee both should be able to see the task

### DIFF
--- a/apps/backend/src/models/appointment.ts
+++ b/apps/backend/src/models/appointment.ts
@@ -146,10 +146,7 @@ AppointmentSchema.index({ organisationId: 1, appointmentDate: 1 });
 AppointmentSchema.index({ "companion.id": 1, appointmentDate: -1 });
 AppointmentSchema.index({ "supportStaff.id": 1 });
 AppointmentSchema.index({ status: 1 });
-AppointmentSchema.index(
-  { expiresAt: 1 },
-  { expireAfterSeconds: 0 }
-);
+AppointmentSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
 
 AppointmentSchema.index(
   {

--- a/apps/backend/test/services/appointment.service.test.ts
+++ b/apps/backend/test/services/appointment.service.test.ts
@@ -1,36 +1,36 @@
-import mongoose, { Types } from 'mongoose';
-import { AppointmentService } from '../../src/services/appointment.service';
-import AppointmentModel from '../../src/models/appointment';
-import ServiceModel from '../../src/models/service';
-import { InvoiceService } from '../../src/services/invoice.service';
-import { OccupancyModel } from '../../src/models/occupancy';
-import OrganizationModel from '../../src/models/organization';
-import UserProfileModel from '../../src/models/user-profile';
-import { NotificationService } from '../../src/services/notification.service';
-import { fromAppointmentRequestDTO } from '@yosemite-crew/types';
+import mongoose, { Types } from "mongoose";
+import { AppointmentService } from "../../src/services/appointment.service";
+import AppointmentModel from "../../src/models/appointment";
+import ServiceModel from "../../src/models/service";
+import { InvoiceService } from "../../src/services/invoice.service";
+import { OccupancyModel } from "../../src/models/occupancy";
+import OrganizationModel from "../../src/models/organization";
+import UserProfileModel from "../../src/models/user-profile";
+import { NotificationService } from "../../src/services/notification.service";
+import { fromAppointmentRequestDTO } from "@yosemite-crew/types";
 
 // --- Mocks ---
-jest.mock('../../src/models/appointment');
-jest.mock('../../src/models/service');
-jest.mock('../../src/services/invoice.service');
-jest.mock('../../src/services/stripe.service');
-jest.mock('../../src/models/occupancy');
-jest.mock('../../src/models/organization');
-jest.mock('../../src/models/user-profile');
-jest.mock('../../src/services/notification.service');
-jest.mock('../../src/services/task.service');
+jest.mock("../../src/models/appointment");
+jest.mock("../../src/models/service");
+jest.mock("../../src/services/invoice.service");
+jest.mock("../../src/services/stripe.service");
+jest.mock("../../src/models/occupancy");
+jest.mock("../../src/models/organization");
+jest.mock("../../src/models/user-profile");
+jest.mock("../../src/services/notification.service");
+jest.mock("../../src/services/task.service");
 
 // Mock the types package to control DTO parsing/mapping
-jest.mock('@yosemite-crew/types', () => ({
+jest.mock("@yosemite-crew/types", () => ({
   fromAppointmentRequestDTO: jest.fn(),
   toAppointmentResponseDTO: jest.fn((domain) => ({
     id: domain.id,
     status: domain.status,
-    organisation: domain.organisation
+    organisation: domain.organisation,
   })), // Simple pass-through
 }));
 
-describe('AppointmentService', () => {
+describe("AppointmentService", () => {
   const mockSession = {
     startTransaction: jest.fn(),
     commitTransaction: jest.fn(),
@@ -44,15 +44,15 @@ describe('AppointmentService', () => {
       session: jest.fn().mockResolvedValue(data),
       lean: jest.fn().mockResolvedValue(data),
       sort: jest.fn().mockReturnValue({
-        lean: jest.fn().mockResolvedValue(data)
+        lean: jest.fn().mockResolvedValue(data),
       }),
-      exec: jest.fn().mockResolvedValue(data)
+      exec: jest.fn().mockResolvedValue(data),
     };
   };
 
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.spyOn(mongoose, 'startSession').mockResolvedValue(mockSession as any);
+    jest.spyOn(mongoose, "startSession").mockResolvedValue(mockSession as any);
   });
 
   const validObjectId = new Types.ObjectId().toString();
@@ -63,14 +63,18 @@ describe('AppointmentService', () => {
   // Defines what fromAppointmentRequestDTO returns
   const validParsedInput = {
     organisationId: validOrgId,
-    companion: { id: validCompanionId, parent: { id: validParentId }, name: 'Buddy' },
-    appointmentType: { id: validObjectId, name: 'Consultation' },
-    startTime: new Date('2023-10-25T10:00:00Z'),
-    endTime: new Date('2023-10-25T10:30:00Z'),
+    companion: {
+      id: validCompanionId,
+      parent: { id: validParentId },
+      name: "Buddy",
+    },
+    appointmentType: { id: validObjectId, name: "Consultation" },
+    startTime: new Date("2023-10-25T10:00:00Z"),
+    endTime: new Date("2023-10-25T10:30:00Z"),
     durationMinutes: 30,
-    concern: 'Checkup',
+    concern: "Checkup",
     isEmergency: false,
-    lead: { id: validObjectId, name: 'Dr. Smith' }, // Populated for PMS flows
+    lead: { id: validObjectId, name: "Dr. Smith" }, // Populated for PMS flows
     supportStaff: [],
     room: undefined,
     attachments: [],
@@ -79,488 +83,670 @@ describe('AppointmentService', () => {
   const createMockDoc = (data: any) => ({
     _id: new Types.ObjectId(validObjectId),
     organisationId: new Types.ObjectId(validOrgId),
-    status: 'REQUESTED',
+    status: "REQUESTED",
     startTime: validParsedInput.startTime,
     endTime: validParsedInput.endTime,
     companion: {
-        id: validCompanionId,
-        name: 'Buddy',
-        parent: {
-            id: validParentId,
-            name: 'John Doe'
-        }
+      id: validCompanionId,
+      name: "Buddy",
+      parent: {
+        id: validParentId,
+        name: "John Doe",
+      },
     },
     ...data,
-    toObject: function() { return { ...this, _id: this._id }; },
+    toObject: function () {
+      return { ...this, _id: this._id };
+    },
     save: jest.fn().mockResolvedValue(true),
   });
 
-  describe('createRequestedFromMobile', () => {
-    const inputDto: any = { resourceType: 'Appointment' }; // Dummy DTO, we control the parser
+  describe("createRequestedFromMobile", () => {
+    const inputDto: any = { resourceType: "Appointment" }; // Dummy DTO, we control the parser
 
-    it('should throw if organisationId is missing', async () => {
-      (fromAppointmentRequestDTO as jest.Mock).mockReturnValue({ ...validParsedInput, organisationId: undefined });
-
-      await expect(AppointmentService.createRequestedFromMobile(inputDto))
-        .rejects.toThrow('organisationId is required');
-    });
-
-    it('should throw if companion/parent missing', async () => {
+    it("should throw if organisationId is missing", async () => {
       (fromAppointmentRequestDTO as jest.Mock).mockReturnValue({
-          ...validParsedInput,
-          companion: { id: undefined } // Missing ID
+        ...validParsedInput,
+        organisationId: undefined,
       });
 
-      await expect(AppointmentService.createRequestedFromMobile(inputDto))
-        .rejects.toThrow('Companion and parent details are required');
+      await expect(
+        AppointmentService.createRequestedFromMobile(inputDto),
+      ).rejects.toThrow("organisationId is required");
     });
 
-    it('should throw if time details are missing', async () => {
-      (fromAppointmentRequestDTO as jest.Mock).mockReturnValue({ ...validParsedInput, startTime: null });
+    it("should throw if companion/parent missing", async () => {
+      (fromAppointmentRequestDTO as jest.Mock).mockReturnValue({
+        ...validParsedInput,
+        companion: { id: undefined }, // Missing ID
+      });
 
-      await expect(AppointmentService.createRequestedFromMobile(inputDto))
-        .rejects.toThrow('startTime, endTime, durationMinutes required');
+      await expect(
+        AppointmentService.createRequestedFromMobile(inputDto),
+      ).rejects.toThrow("Companion and parent details are required");
     });
 
-    it('should throw if service not found', async () => {
-      (fromAppointmentRequestDTO as jest.Mock).mockReturnValue(validParsedInput);
+    it("should throw if time details are missing", async () => {
+      (fromAppointmentRequestDTO as jest.Mock).mockReturnValue({
+        ...validParsedInput,
+        startTime: null,
+      });
+
+      await expect(
+        AppointmentService.createRequestedFromMobile(inputDto),
+      ).rejects.toThrow("startTime, endTime, durationMinutes required");
+    });
+
+    it("should throw if service not found", async () => {
+      (fromAppointmentRequestDTO as jest.Mock).mockReturnValue(
+        validParsedInput,
+      );
       (ServiceModel.findOne as jest.Mock).mockResolvedValue(null); // Service missing
 
-      await expect(AppointmentService.createRequestedFromMobile(inputDto))
-        .rejects.toThrow('Invalid service selected');
+      await expect(
+        AppointmentService.createRequestedFromMobile(inputDto),
+      ).rejects.toThrow("Invalid service selected");
     });
   });
 
-  describe('createAppointmentFromPms', () => {
-    const inputDto: any = { resourceType: 'Appointment' };
-    it('should throw if validation fails (missing lead)', async () => {
-        (fromAppointmentRequestDTO as jest.Mock).mockReturnValue({ ...validParsedInput, lead: undefined });
+  describe("createAppointmentFromPms", () => {
+    const inputDto: any = { resourceType: "Appointment" };
+    it("should throw if validation fails (missing lead)", async () => {
+      (fromAppointmentRequestDTO as jest.Mock).mockReturnValue({
+        ...validParsedInput,
+        lead: undefined,
+      });
 
-        await expect(AppointmentService.createAppointmentFromPms(inputDto, false))
-            .rejects.toThrow('Lead veterinarian (vet) is required');
+      await expect(
+        AppointmentService.createAppointmentFromPms(inputDto, false),
+      ).rejects.toThrow("Lead veterinarian (vet) is required");
     });
 
-    it('should throw if service is invalid', async () => {
-        (fromAppointmentRequestDTO as jest.Mock).mockReturnValue(validParsedInput);
-        (ServiceModel.findOne as jest.Mock).mockReturnValue({ lean: jest.fn().mockResolvedValue(null) });
+    it("should throw if service is invalid", async () => {
+      (fromAppointmentRequestDTO as jest.Mock).mockReturnValue(
+        validParsedInput,
+      );
+      (ServiceModel.findOne as jest.Mock).mockReturnValue({
+        lean: jest.fn().mockResolvedValue(null),
+      });
 
-        await expect(AppointmentService.createAppointmentFromPms(inputDto, false))
-            .rejects.toThrow('Invalid or inactive service');
+      await expect(
+        AppointmentService.createAppointmentFromPms(inputDto, false),
+      ).rejects.toThrow("Invalid or inactive service");
     });
   });
 
-  describe('approveRequestedFromPms', () => {
+  describe("approveRequestedFromPms", () => {
     // Unlike the previous two, this function uses `extractApprovalFieldsFromFHIR` internally which uses DTO directly.
     // However, that function is INTERNAL to the service file, so we rely on the `dto` passed.
     // We must construct `dto` carefully here since we cannot mock the internal function.
     const inputDto: any = {
       id: validObjectId,
       participant: [
-        { type: [{ coding: [{ code: 'PPRF' }] }], actor: { reference: `Practitioner/${validObjectId}`, display: 'Dr. Lead' } },
-        { type: [{ coding: [{ code: 'SPRF' }] }], actor: { reference: `Practitioner/staff1`, display: 'Nurse' } },
-        { type: [{ coding: [{ code: 'LOC' }] }], actor: { reference: `Location/room1`, display: 'Room 1' } },
+        {
+          type: [{ coding: [{ code: "PPRF" }] }],
+          actor: {
+            reference: `Practitioner/${validObjectId}`,
+            display: "Dr. Lead",
+          },
+        },
+        {
+          type: [{ coding: [{ code: "SPRF" }] }],
+          actor: { reference: `Practitioner/staff1`, display: "Nurse" },
+        },
+        {
+          type: [{ coding: [{ code: "LOC" }] }],
+          actor: { reference: `Location/room1`, display: "Room 1" },
+        },
       ],
     };
 
-    it('should approve appointment and create occupancy', async () => {
-      const mockAppt = createMockDoc({ _id: validObjectId, status: 'REQUESTED' });
+    it("should approve appointment and create occupancy", async () => {
+      const mockAppt = createMockDoc({
+        _id: validObjectId,
+        status: "REQUESTED",
+      });
       (AppointmentModel.findOne as jest.Mock).mockResolvedValue(mockAppt);
-      (OccupancyModel.findOne as jest.Mock).mockReturnValue({ session: jest.fn().mockResolvedValue(null) });
+      (OccupancyModel.findOne as jest.Mock).mockReturnValue({
+        session: jest.fn().mockResolvedValue(null),
+      });
       (OccupancyModel.create as jest.Mock).mockResolvedValue([]);
-      (UserProfileModel.findOne as jest.Mock).mockResolvedValue({ personalDetails: { profilePictureUrl: 'url' } });
+      (UserProfileModel.findOne as jest.Mock).mockResolvedValue({
+        personalDetails: { profilePictureUrl: "url" },
+      });
 
       await AppointmentService.approveRequestedFromPms(validObjectId, inputDto);
 
-      expect(mockAppt.status).toBe('UPCOMING');
+      expect(mockAppt.status).toBe("UPCOMING");
       expect(OccupancyModel.create).toHaveBeenCalled();
       expect(mockSession.commitTransaction).toHaveBeenCalled();
     });
 
-    it('should fail if appointment not found', async () => {
-        (AppointmentModel.findOne as jest.Mock).mockResolvedValue(null);
-        await expect(AppointmentService.approveRequestedFromPms(validObjectId, inputDto))
-            .rejects.toThrow('Requested appointment not found');
+    it("should fail if appointment not found", async () => {
+      (AppointmentModel.findOne as jest.Mock).mockResolvedValue(null);
+      await expect(
+        AppointmentService.approveRequestedFromPms(validObjectId, inputDto),
+      ).rejects.toThrow("Requested appointment not found");
     });
 
-    it('should fail if lead vet is missing in DTO', async () => {
-        const noVetDto = { ...inputDto, participant: [] };
-        await expect(AppointmentService.approveRequestedFromPms(validObjectId, noVetDto))
-            .rejects.toThrow('Lead vet (Practitioner with code=PPRF) is required');
+    it("should fail if lead vet is missing in DTO", async () => {
+      const noVetDto = { ...inputDto, participant: [] };
+      await expect(
+        AppointmentService.approveRequestedFromPms(validObjectId, noVetDto),
+      ).rejects.toThrow("Lead vet (Practitioner with code=PPRF) is required");
     });
 
-    it('should fail if overlap exists', async () => {
-        const mockAppt = createMockDoc({ _id: validObjectId, status: 'REQUESTED' });
-        (AppointmentModel.findOne as jest.Mock).mockResolvedValue(mockAppt);
-        (OccupancyModel.findOne as jest.Mock).mockReturnValue({ session: jest.fn().mockResolvedValue({ _id: 'occ' }) });
+    it("should fail if overlap exists", async () => {
+      const mockAppt = createMockDoc({
+        _id: validObjectId,
+        status: "REQUESTED",
+      });
+      (AppointmentModel.findOne as jest.Mock).mockResolvedValue(mockAppt);
+      (OccupancyModel.findOne as jest.Mock).mockReturnValue({
+        session: jest.fn().mockResolvedValue({ _id: "occ" }),
+      });
 
-        await expect(AppointmentService.approveRequestedFromPms(validObjectId, inputDto))
-            .rejects.toThrow('Selected vet is not available');
-        expect(mockSession.abortTransaction).toHaveBeenCalled();
+      await expect(
+        AppointmentService.approveRequestedFromPms(validObjectId, inputDto),
+      ).rejects.toThrow("Selected vet is not available");
+      expect(mockSession.abortTransaction).toHaveBeenCalled();
     });
   });
 
-  describe('cancelAppointment', () => {
-    it('should cancel appointment and cleanup invoice/occupancy', async () => {
+  describe("cancelAppointment", () => {
+    it("should cancel appointment and cleanup invoice/occupancy", async () => {
       const mockAppt = createMockDoc({
-          status: 'UPCOMING',
-          lead: { id: 'vet1' },
+        status: "UPCOMING",
+        lead: { id: "vet1" },
       });
       (AppointmentModel.findById as jest.Mock).mockReturnValue({
-          session: jest.fn().mockResolvedValue(mockAppt)
+        session: jest.fn().mockResolvedValue(mockAppt),
       });
       // Mock deleteMany with session support
       (OccupancyModel.deleteMany as jest.Mock).mockReturnValue({
-          session: jest.fn().mockResolvedValue({ deletedCount: 1 })
+        session: jest.fn().mockResolvedValue({ deletedCount: 1 }),
       });
 
-      await AppointmentService.cancelAppointment(validObjectId, 'Reason');
+      await AppointmentService.cancelAppointment(validObjectId, "Reason");
 
-      expect(InvoiceService.handleAppointmentCancellation).toHaveBeenCalledWith(validObjectId, 'Reason');
+      expect(InvoiceService.handleAppointmentCancellation).toHaveBeenCalledWith(
+        validObjectId,
+        "Reason",
+      );
       expect(OccupancyModel.deleteMany).toHaveBeenCalled();
-      expect(mockAppt.status).toBe('CANCELLED');
+      expect(mockAppt.status).toBe("CANCELLED");
     });
 
-    it('should return early if already cancelled', async () => {
-        const mockAppt = createMockDoc({ status: 'CANCELLED' });
-        (AppointmentModel.findById as jest.Mock).mockReturnValue({
-            session: jest.fn().mockResolvedValue(mockAppt)
-        });
+    it("should return early if already cancelled", async () => {
+      const mockAppt = createMockDoc({ status: "CANCELLED" });
+      (AppointmentModel.findById as jest.Mock).mockReturnValue({
+        session: jest.fn().mockResolvedValue(mockAppt),
+      });
 
-        await AppointmentService.cancelAppointment(validObjectId);
-        expect(InvoiceService.handleAppointmentCancellation).not.toHaveBeenCalled();
+      await AppointmentService.cancelAppointment(validObjectId);
+      expect(
+        InvoiceService.handleAppointmentCancellation,
+      ).not.toHaveBeenCalled();
     });
 
-    it('should throw 404 if appointment not found', async () => {
-        (AppointmentModel.findById as jest.Mock).mockReturnValue({
-            session: jest.fn().mockResolvedValue(null)
-        });
-        await expect(AppointmentService.cancelAppointment(validObjectId))
-            .rejects.toThrow('Appointment not found');
+    it("should throw 404 if appointment not found", async () => {
+      (AppointmentModel.findById as jest.Mock).mockReturnValue({
+        session: jest.fn().mockResolvedValue(null),
+      });
+      await expect(
+        AppointmentService.cancelAppointment(validObjectId),
+      ).rejects.toThrow("Appointment not found");
     });
 
-    it('should handle error propagation', async () => {
-        (AppointmentModel.findById as jest.Mock).mockReturnValue({
-            session: jest.fn().mockRejectedValue(new Error('Fail'))
-        });
-        await expect(AppointmentService.cancelAppointment(validObjectId)).rejects.toThrow('Fail');
-        expect(mockSession.abortTransaction).toHaveBeenCalled();
+    it("should handle error propagation", async () => {
+      (AppointmentModel.findById as jest.Mock).mockReturnValue({
+        session: jest.fn().mockRejectedValue(new Error("Fail")),
+      });
+      await expect(
+        AppointmentService.cancelAppointment(validObjectId),
+      ).rejects.toThrow("Fail");
+      expect(mockSession.abortTransaction).toHaveBeenCalled();
     });
   });
 
-  describe('cancelAppointmentFromParent', () => {
-    it('should cancel if parent owns appointment', async () => {
+  describe("cancelAppointmentFromParent", () => {
+    it("should cancel if parent owns appointment", async () => {
       const mockAppt = createMockDoc({
-        status: 'UPCOMING',
-        lead: { id: 'vet1' },
+        status: "UPCOMING",
+        lead: { id: "vet1" },
         companion: {
-            id: validCompanionId,
-            name: 'Buddy',
-            parent: { id: validParentId }
-        }
+          id: validCompanionId,
+          name: "Buddy",
+          parent: { id: validParentId },
+        },
       });
       (AppointmentModel.findById as jest.Mock).mockResolvedValue(mockAppt);
-      (InvoiceService.handleAppointmentCancellation as jest.Mock).mockResolvedValue(true);
-      (OccupancyModel.deleteMany as jest.Mock).mockResolvedValue({ deletedCount: 1 });
+      (
+        InvoiceService.handleAppointmentCancellation as jest.Mock
+      ).mockResolvedValue(true);
+      (OccupancyModel.deleteMany as jest.Mock).mockResolvedValue({
+        deletedCount: 1,
+      });
 
-      await AppointmentService.cancelAppointmentFromParent(validObjectId, validParentId, 'Changed mind');
+      await AppointmentService.cancelAppointmentFromParent(
+        validObjectId,
+        validParentId,
+        "Changed mind",
+      );
 
-      expect(mockAppt.status).toBe('CANCELLED');
+      expect(mockAppt.status).toBe("CANCELLED");
       expect(OccupancyModel.deleteMany).toHaveBeenCalled();
     });
 
-    it('should throw if not owner', async () => {
-        const mockAppt = createMockDoc({
-            companion: { parent: { id: 'otherParent' } }
-          });
-          (AppointmentModel.findById as jest.Mock).mockResolvedValue(mockAppt);
-          await expect(AppointmentService.cancelAppointmentFromParent(validObjectId, validParentId, ''))
-            .rejects.toThrow('Not your appointment');
+    it("should throw if not owner", async () => {
+      const mockAppt = createMockDoc({
+        companion: { parent: { id: "otherParent" } },
+      });
+      (AppointmentModel.findById as jest.Mock).mockResolvedValue(mockAppt);
+      await expect(
+        AppointmentService.cancelAppointmentFromParent(
+          validObjectId,
+          validParentId,
+          "",
+        ),
+      ).rejects.toThrow("Not your appointment");
     });
 
-    it('should throw if status is invalid (e.g. COMPLETED)', async () => {
-        const mockAppt = createMockDoc({
-            status: 'COMPLETED',
-            companion: { parent: { id: validParentId } }
-          });
-          (AppointmentModel.findById as jest.Mock).mockResolvedValue(mockAppt);
-          await expect(AppointmentService.cancelAppointmentFromParent(validObjectId, validParentId, ''))
-            .rejects.toThrow('Only requested or upcoming appointments can be cancelled');
+    it("should throw if status is invalid (e.g. COMPLETED)", async () => {
+      const mockAppt = createMockDoc({
+        status: "COMPLETED",
+        companion: { parent: { id: validParentId } },
+      });
+      (AppointmentModel.findById as jest.Mock).mockResolvedValue(mockAppt);
+      await expect(
+        AppointmentService.cancelAppointmentFromParent(
+          validObjectId,
+          validParentId,
+          "",
+        ),
+      ).rejects.toThrow(
+        "Only requested or upcoming appointments can be cancelled",
+      );
     });
 
-    it('should throw if invoice cancellation fails', async () => {
-        const mockAppt = createMockDoc({
-            status: 'UPCOMING',
-            companion: { parent: { id: validParentId } }
-          });
-          (AppointmentModel.findById as jest.Mock).mockResolvedValue(mockAppt);
-          (InvoiceService.handleAppointmentCancellation as jest.Mock).mockResolvedValue(false);
+    it("should throw if invoice cancellation fails", async () => {
+      const mockAppt = createMockDoc({
+        status: "UPCOMING",
+        companion: { parent: { id: validParentId } },
+      });
+      (AppointmentModel.findById as jest.Mock).mockResolvedValue(mockAppt);
+      (
+        InvoiceService.handleAppointmentCancellation as jest.Mock
+      ).mockResolvedValue(false);
 
-          await expect(AppointmentService.cancelAppointmentFromParent(validObjectId, validParentId, ''))
-            .rejects.toThrow('Not able to cancle appointment');
-    });
-  });
-
-  describe('rejectRequestedAppointment', () => {
-    it('should reject requested appointment', async () => {
-        const mockAppt = createMockDoc({ status: 'REQUESTED' });
-        (AppointmentModel.findById as jest.Mock).mockResolvedValue(mockAppt);
-
-        await AppointmentService.rejectRequestedAppointment(validObjectId);
-
-        expect(mockAppt.status).toBe('CANCELLED');
-        expect(NotificationService.sendToUser).toHaveBeenCalled();
-    });
-
-    it('should throw if not REQUESTED', async () => {
-        const mockAppt = createMockDoc({ status: 'UPCOMING' });
-        (AppointmentModel.findById as jest.Mock).mockResolvedValue(mockAppt);
-        await expect(AppointmentService.rejectRequestedAppointment(validObjectId))
-            .rejects.toThrow('Only REQUESTED appointments can be rejected');
-    });
-
-    it('should throw 404 if not found', async () => {
-        (AppointmentModel.findById as jest.Mock).mockResolvedValue(null);
-        await expect(AppointmentService.rejectRequestedAppointment(validObjectId))
-            .rejects.toThrow('Appointment not found');
+      await expect(
+        AppointmentService.cancelAppointmentFromParent(
+          validObjectId,
+          validParentId,
+          "",
+        ),
+      ).rejects.toThrow("Not able to cancle appointment");
     });
   });
 
-  describe('updateAppointmentPMS', () => {
-      // Logic uses fromAppointmentRequestDTO, so we mock the return
-      const inputDto: any = { resourceType: 'Appointment' };
+  describe("rejectRequestedAppointment", () => {
+    it("should reject requested appointment", async () => {
+      const mockAppt = createMockDoc({ status: "REQUESTED" });
+      (AppointmentModel.findById as jest.Mock).mockResolvedValue(mockAppt);
 
-      it('should update appointment and occupancy if vet changes', async () => {
-        (fromAppointmentRequestDTO as jest.Mock).mockReturnValue({
-            ...validParsedInput,
-            lead: { id: 'newVet', name: 'Dr. New' }, // Vet changed
-            startTime: validParsedInput.startTime,
-            endTime: validParsedInput.endTime
-        });
+      await AppointmentService.rejectRequestedAppointment(validObjectId);
 
-        const mockAppt = createMockDoc({
-            status: 'UPCOMING',
-            startTime: validParsedInput.startTime,
-            endTime: validParsedInput.endTime,
-            lead: { id: 'oldVet' },
-        });
-
-        (AppointmentModel.findOne as jest.Mock).mockResolvedValue(mockAppt);
-        (OccupancyModel.findOne as jest.Mock).mockReturnValue({ session: jest.fn().mockResolvedValue(null) });
-        (OccupancyModel.deleteMany as jest.Mock).mockReturnValue({ session: jest.fn().mockResolvedValue({}) });
-        (OccupancyModel.create as jest.Mock).mockReturnValue([]);
-
-        await AppointmentService.updateAppointmentPMS(validObjectId, inputDto);
-
-        expect(OccupancyModel.deleteMany).toHaveBeenCalled();
-        expect(OccupancyModel.create).toHaveBeenCalled();
-        expect(mockAppt.lead.id).toBe('newVet');
-      });
-
-      it('should throw if overlap on new vet', async () => {
-        (fromAppointmentRequestDTO as jest.Mock).mockReturnValue({
-            ...validParsedInput,
-            lead: { id: 'newVet' }
-        });
-
-        const mockAppt = createMockDoc({
-            status: 'UPCOMING',
-            lead: { id: 'oldVet' }
-        });
-
-        (AppointmentModel.findOne as jest.Mock).mockResolvedValue(mockAppt);
-        (OccupancyModel.findOne as jest.Mock).mockReturnValue({ session: jest.fn().mockResolvedValue({ _id: 'occ' }) });
-        (OccupancyModel.deleteMany as jest.Mock).mockReturnValue({ session: jest.fn().mockResolvedValue({}) });
-
-        await expect(AppointmentService.updateAppointmentPMS(validObjectId, inputDto))
-            .rejects.toThrow('Selected vet is not available');
-      });
-
-      it('should fail if no lead provided in DTO', async () => {
-         (fromAppointmentRequestDTO as jest.Mock).mockReturnValue({
-             ...validParsedInput,
-             lead: undefined
-         });
-
-         await expect(AppointmentService.updateAppointmentPMS(validObjectId, inputDto))
-            .rejects.toThrow('Lead vet (Practitioner with code=PPRF) is required');
-      });
-  });
-
-  describe('checkIn Methods', () => {
-    it('checkInAppointment: should check in UPCOMING appointment', async () => {
-        const mockAppt = createMockDoc({ status: 'UPCOMING' });
-        (AppointmentModel.findById as jest.Mock).mockResolvedValue(mockAppt);
-
-        await AppointmentService.checkInAppointment(validObjectId);
-        expect(mockAppt.status).toBe('CHECKED_IN');
+      expect(mockAppt.status).toBe("CANCELLED");
+      expect(NotificationService.sendToUser).toHaveBeenCalled();
     });
 
-    it('checkInAppointment: should fail if not UPCOMING', async () => {
-        const mockAppt = createMockDoc({ status: 'REQUESTED' });
-        (AppointmentModel.findById as jest.Mock).mockResolvedValue(mockAppt);
-        await expect(AppointmentService.checkInAppointment(validObjectId))
-            .rejects.toThrow('Only upcoming appointments can be checked in');
+    it("should throw if not REQUESTED", async () => {
+      const mockAppt = createMockDoc({ status: "UPCOMING" });
+      (AppointmentModel.findById as jest.Mock).mockResolvedValue(mockAppt);
+      await expect(
+        AppointmentService.rejectRequestedAppointment(validObjectId),
+      ).rejects.toThrow("Only REQUESTED appointments can be rejected");
     });
 
-    it('checkInAppointmentParent: should check in if owner', async () => {
-        const mockAppt = createMockDoc({ status: 'UPCOMING' });
-        (AppointmentModel.findById as jest.Mock).mockResolvedValue(mockAppt);
-        await AppointmentService.checkInAppointmentParent(validObjectId, validParentId);
-        expect(mockAppt.status).toBe('CHECKED_IN');
-    });
-
-    it('checkInAppointmentParent: should fail if not owner', async () => {
-        const mockAppt = createMockDoc({
-            status: 'UPCOMING',
-            companion: { parent: { id: 'p2' } }
-        });
-        (AppointmentModel.findById as jest.Mock).mockResolvedValue(mockAppt);
-        await expect(AppointmentService.checkInAppointmentParent(validObjectId, validParentId))
-            .rejects.toThrow('Not your appointment');
+    it("should throw 404 if not found", async () => {
+      (AppointmentModel.findById as jest.Mock).mockResolvedValue(null);
+      await expect(
+        AppointmentService.rejectRequestedAppointment(validObjectId),
+      ).rejects.toThrow("Appointment not found");
     });
   });
 
-  describe('rescheduleFromParent', () => {
-      it('should reschedule and revert status if UPCOMING', async () => {
-        const mockAppt = createMockDoc({
-            status: 'UPCOMING',
-            companion: { parent: { id: validParentId } },
-            startTime: new Date()
-        });
-        (AppointmentModel.findById as jest.Mock).mockReturnValue({ session: jest.fn().mockResolvedValue(mockAppt) });
-        (OccupancyModel.deleteMany as jest.Mock).mockReturnValue({ session: jest.fn().mockResolvedValue({}) });
+  describe("updateAppointmentPMS", () => {
+    // Logic uses fromAppointmentRequestDTO, so we mock the return
+    const inputDto: any = { resourceType: "Appointment" };
 
-        const newStart = new Date();
-        const newEnd = new Date(newStart.getTime() + 60000);
-
-        await AppointmentService.rescheduleFromParent(validObjectId, validParentId, { startTime: newStart, endTime: newEnd });
-
-        expect(mockAppt.status).toBe('REQUESTED');
-        expect(OccupancyModel.deleteMany).toHaveBeenCalled();
+    it("should update appointment and occupancy if vet changes", async () => {
+      (fromAppointmentRequestDTO as jest.Mock).mockReturnValue({
+        ...validParsedInput,
+        lead: { id: "newVet", name: "Dr. New" }, // Vet changed
+        startTime: validParsedInput.startTime,
+        endTime: validParsedInput.endTime,
       });
 
-      it('should throw validation error if start >= end', async () => {
-          const d = new Date();
-          await expect(AppointmentService.rescheduleFromParent(validObjectId, validParentId, { startTime: d, endTime: d }))
-            .rejects.toThrow('startTime must be before endTime');
+      const mockAppt = createMockDoc({
+        status: "UPCOMING",
+        startTime: validParsedInput.startTime,
+        endTime: validParsedInput.endTime,
+        lead: { id: "oldVet" },
       });
 
-      it('should throw if appointment not found', async () => {
-        (AppointmentModel.findById as jest.Mock).mockReturnValue({ session: jest.fn().mockResolvedValue(null) });
-        await expect(AppointmentService.rescheduleFromParent(validObjectId, validParentId, { startTime: new Date(), endTime: new Date(Date.now()+1000) }))
-            .rejects.toThrow('Appointment not found');
+      (AppointmentModel.findOne as jest.Mock).mockResolvedValue(mockAppt);
+      (OccupancyModel.findOne as jest.Mock).mockReturnValue({
+        session: jest.fn().mockResolvedValue(null),
+      });
+      (OccupancyModel.deleteMany as jest.Mock).mockReturnValue({
+        session: jest.fn().mockResolvedValue({}),
+      });
+      (OccupancyModel.create as jest.Mock).mockReturnValue([]);
+
+      await AppointmentService.updateAppointmentPMS(validObjectId, inputDto);
+
+      expect(OccupancyModel.deleteMany).toHaveBeenCalled();
+      expect(OccupancyModel.create).toHaveBeenCalled();
+      expect(mockAppt.lead.id).toBe("newVet");
+    });
+
+    it("should throw if overlap on new vet", async () => {
+      (fromAppointmentRequestDTO as jest.Mock).mockReturnValue({
+        ...validParsedInput,
+        lead: { id: "newVet" },
       });
 
-      it('should throw if status is COMPLETED', async () => {
-        const mockAppt = createMockDoc({ status: 'COMPLETED', companion: { parent: { id: validParentId } } });
-        (AppointmentModel.findById as jest.Mock).mockReturnValue({ session: jest.fn().mockResolvedValue(mockAppt) });
-        await expect(AppointmentService.rescheduleFromParent(validObjectId, validParentId, { startTime: new Date(), endTime: new Date(Date.now()+1000) }))
-            .rejects.toThrow('Completed or cancelled appointments cannot be rescheduled');
+      const mockAppt = createMockDoc({
+        status: "UPCOMING",
+        lead: { id: "oldVet" },
       });
+
+      (AppointmentModel.findOne as jest.Mock).mockResolvedValue(mockAppt);
+      (OccupancyModel.findOne as jest.Mock).mockReturnValue({
+        session: jest.fn().mockResolvedValue({ _id: "occ" }),
+      });
+      (OccupancyModel.deleteMany as jest.Mock).mockReturnValue({
+        session: jest.fn().mockResolvedValue({}),
+      });
+
+      await expect(
+        AppointmentService.updateAppointmentPMS(validObjectId, inputDto),
+      ).rejects.toThrow("Selected vet is not available");
+    });
+
+    it("should fail if no lead provided in DTO", async () => {
+      (fromAppointmentRequestDTO as jest.Mock).mockReturnValue({
+        ...validParsedInput,
+        lead: undefined,
+      });
+
+      await expect(
+        AppointmentService.updateAppointmentPMS(validObjectId, inputDto),
+      ).rejects.toThrow("Lead vet (Practitioner with code=PPRF) is required");
+    });
   });
 
-  describe('Getters and Search', () => {
-      it('getAppointmentsForCompanion: should attach organization details', async () => {
-          const apptData = createMockDoc({ organisationId: validOrgId });
-          // Ensure structure matches toDomainLean
-          const leanAppt = { ...apptData, _id: new Types.ObjectId(validObjectId) };
-          delete leanAppt.toObject;
-          delete leanAppt.save;
+  describe("checkIn Methods", () => {
+    it("checkInAppointment: should check in UPCOMING appointment", async () => {
+      const mockAppt = createMockDoc({ status: "UPCOMING" });
+      (AppointmentModel.findById as jest.Mock).mockResolvedValue(mockAppt);
 
-          (AppointmentModel.find as jest.Mock).mockReturnValue(mockMongooseChain([leanAppt]));
-          (OrganizationModel.find as jest.Mock).mockReturnValue({ lean: jest.fn().mockResolvedValue([{ _id: new Types.ObjectId(validOrgId), name: 'Clinic' }]) });
+      await AppointmentService.checkInAppointment(validObjectId);
+      expect(mockAppt.status).toBe("CHECKED_IN");
+    });
 
-          const res = await AppointmentService.getAppointmentsForCompanion('comp1');
-          // Update: Optional chaining in case DTO mapping changes
-          expect(res[0].organisation?.name).toBe('Clinic');
+    it("checkInAppointment: should fail if not UPCOMING", async () => {
+      const mockAppt = createMockDoc({ status: "REQUESTED" });
+      (AppointmentModel.findById as jest.Mock).mockResolvedValue(mockAppt);
+      await expect(
+        AppointmentService.checkInAppointment(validObjectId),
+      ).rejects.toThrow("Only upcoming appointments can be checked in");
+    });
+
+    it("checkInAppointmentParent: should check in if owner", async () => {
+      const mockAppt = createMockDoc({ status: "UPCOMING" });
+      (AppointmentModel.findById as jest.Mock).mockResolvedValue(mockAppt);
+      await AppointmentService.checkInAppointmentParent(
+        validObjectId,
+        validParentId,
+      );
+      expect(mockAppt.status).toBe("CHECKED_IN");
+    });
+
+    it("checkInAppointmentParent: should fail if not owner", async () => {
+      const mockAppt = createMockDoc({
+        status: "UPCOMING",
+        companion: { parent: { id: "p2" } },
       });
-
-      it('getAppointmentsForCompanion: should return empty if no docs', async () => {
-         (AppointmentModel.find as jest.Mock).mockReturnValue(mockMongooseChain([]));
-         const res = await AppointmentService.getAppointmentsForCompanion('comp1');
-         expect(res).toEqual([]);
-      });
-
-      it('getById: should return domain object', async () => {
-        (AppointmentModel.findById as jest.Mock).mockResolvedValue(createMockDoc({}));
-        const res = await AppointmentService.getById(validObjectId);
-        expect(res.id).toBe(validObjectId);
-      });
-
-      it('getById: should throw if not found', async () => {
-        (AppointmentModel.findById as jest.Mock).mockResolvedValue(null);
-        await expect(AppointmentService.getById(validObjectId)).rejects.toThrow('Appointment not found');
-      });
-
-      it('getById: should throw if id invalid', async () => {
-        await expect(AppointmentService.getById('invalid-id')).rejects.toThrow('Invalid AppointmentId');
-      });
-
-      it('getAppointmentsForOrganisation: should filter by date', async () => {
-          (AppointmentModel.find as jest.Mock).mockReturnValue(mockMongooseChain([]));
-          await AppointmentService.getAppointmentsForOrganisation(validOrgId, { startDate: new Date(), endDate: new Date() });
-          expect(AppointmentModel.find).toHaveBeenCalledWith(expect.objectContaining({ startTime: expect.anything() }));
-      });
-
-      it('getAppointmentsByDateRange: should query range', async () => {
-          (AppointmentModel.find as jest.Mock).mockReturnValue(mockMongooseChain([]));
-          await AppointmentService.getAppointmentsByDateRange(validOrgId, new Date(), new Date(), ['UPCOMING']);
-          expect(AppointmentModel.find).toHaveBeenCalledWith(expect.objectContaining({ status: { $in: ['UPCOMING'] } }));
-      });
-
-      it('searchAppointments: should build complex query', async () => {
-          (AppointmentModel.find as jest.Mock).mockReturnValue(mockMongooseChain([]));
-          await AppointmentService.searchAppointments({
-              companionId: 'c1',
-              leadId: 'l1',
-              startDate: new Date(),
-              endDate: new Date(),
-              status: ['UPCOMING']
-          });
-
-          expect(AppointmentModel.find).toHaveBeenCalledWith(expect.objectContaining({
-              "companion.id": "c1",
-              "lead.id": "l1",
-              "status": { $in: ['UPCOMING'] }
-          }));
-      });
-
-      it('getAppointmentsForParent: should return list', async () => {
-         (AppointmentModel.find as jest.Mock).mockReturnValue(mockMongooseChain([]));
-         await AppointmentService.getAppointmentsForParent('p1');
-         expect(AppointmentModel.find).toHaveBeenCalled();
-      });
-
-      it('getAppointmentsForLead: should return list', async () => {
-        (AppointmentModel.find as jest.Mock).mockReturnValue(mockMongooseChain([]));
-        await AppointmentService.getAppointmentsForLead('l1', validOrgId);
-        expect(AppointmentModel.find).toHaveBeenCalled();
-      });
-
-      it('getAppointmentsForSupportStaff: should return list', async () => {
-        (AppointmentModel.find as jest.Mock).mockReturnValue(mockMongooseChain([]));
-        await AppointmentService.getAppointmentsForSupportStaff('s1', validOrgId);
-        expect(AppointmentModel.find).toHaveBeenCalled();
-      });
+      (AppointmentModel.findById as jest.Mock).mockResolvedValue(mockAppt);
+      await expect(
+        AppointmentService.checkInAppointmentParent(
+          validObjectId,
+          validParentId,
+        ),
+      ).rejects.toThrow("Not your appointment");
+    });
   });
 
-  describe('Edge Case: Internal Helpers', () => {
-      it('getAppointmentsForCompanion should handle lean objects in toDomainLean', async () => {
-          const leanAppt = createMockDoc({ _id: validObjectId });
-          const { toObject, save, ...leanData } = leanAppt;
-
-          (AppointmentModel.find as jest.Mock).mockReturnValue(mockMongooseChain([leanData]));
-          (OrganizationModel.find as jest.Mock).mockReturnValue({ lean: jest.fn().mockResolvedValue([]) });
-
-          const res = await AppointmentService.getAppointmentsForCompanion('comp1');
-          expect(res[0].appointment.id).toBe(leanData._id.toString());
+  describe("rescheduleFromParent", () => {
+    it("should reschedule and revert status if UPCOMING", async () => {
+      const mockAppt = createMockDoc({
+        status: "UPCOMING",
+        companion: { parent: { id: validParentId } },
+        startTime: new Date(),
+      });
+      (AppointmentModel.findById as jest.Mock).mockReturnValue({
+        session: jest.fn().mockResolvedValue(mockAppt),
+      });
+      (OccupancyModel.deleteMany as jest.Mock).mockReturnValue({
+        session: jest.fn().mockResolvedValue({}),
       });
 
-      it('getById should accept Types.ObjectId directly', async () => {
-        const objId = new Types.ObjectId(validObjectId);
-        (AppointmentModel.findById as jest.Mock).mockResolvedValue(createMockDoc({ _id: objId }));
-        const res = await AppointmentService.getById(objId as any);
-        expect(res.id).toBe(objId.toString());
+      const newStart = new Date();
+      const newEnd = new Date(newStart.getTime() + 60000);
+
+      await AppointmentService.rescheduleFromParent(
+        validObjectId,
+        validParentId,
+        { startTime: newStart, endTime: newEnd },
+      );
+
+      expect(mockAppt.status).toBe("REQUESTED");
+      expect(OccupancyModel.deleteMany).toHaveBeenCalled();
+    });
+
+    it("should throw validation error if start >= end", async () => {
+      const d = new Date();
+      await expect(
+        AppointmentService.rescheduleFromParent(validObjectId, validParentId, {
+          startTime: d,
+          endTime: d,
+        }),
+      ).rejects.toThrow("startTime must be before endTime");
+    });
+
+    it("should throw if appointment not found", async () => {
+      (AppointmentModel.findById as jest.Mock).mockReturnValue({
+        session: jest.fn().mockResolvedValue(null),
       });
+      await expect(
+        AppointmentService.rescheduleFromParent(validObjectId, validParentId, {
+          startTime: new Date(),
+          endTime: new Date(Date.now() + 1000),
+        }),
+      ).rejects.toThrow("Appointment not found");
+    });
+
+    it("should throw if status is COMPLETED", async () => {
+      const mockAppt = createMockDoc({
+        status: "COMPLETED",
+        companion: { parent: { id: validParentId } },
+      });
+      (AppointmentModel.findById as jest.Mock).mockReturnValue({
+        session: jest.fn().mockResolvedValue(mockAppt),
+      });
+      await expect(
+        AppointmentService.rescheduleFromParent(validObjectId, validParentId, {
+          startTime: new Date(),
+          endTime: new Date(Date.now() + 1000),
+        }),
+      ).rejects.toThrow(
+        "Completed or cancelled appointments cannot be rescheduled",
+      );
+    });
+  });
+
+  describe("Getters and Search", () => {
+    it("getAppointmentsForCompanion: should attach organization details", async () => {
+      const apptData = createMockDoc({ organisationId: validOrgId });
+      // Ensure structure matches toDomainLean
+      const leanAppt = { ...apptData, _id: new Types.ObjectId(validObjectId) };
+      delete leanAppt.toObject;
+      delete leanAppt.save;
+
+      (AppointmentModel.find as jest.Mock).mockReturnValue(
+        mockMongooseChain([leanAppt]),
+      );
+      (OrganizationModel.find as jest.Mock).mockReturnValue({
+        lean: jest
+          .fn()
+          .mockResolvedValue([
+            { _id: new Types.ObjectId(validOrgId), name: "Clinic" },
+          ]),
+      });
+
+      const res = await AppointmentService.getAppointmentsForCompanion("comp1");
+      // Update: Optional chaining in case DTO mapping changes
+      expect(res[0].organisation?.name).toBe("Clinic");
+    });
+
+    it("getAppointmentsForCompanion: should return empty if no docs", async () => {
+      (AppointmentModel.find as jest.Mock).mockReturnValue(
+        mockMongooseChain([]),
+      );
+      const res = await AppointmentService.getAppointmentsForCompanion("comp1");
+      expect(res).toEqual([]);
+    });
+
+    it("getById: should return domain object", async () => {
+      (AppointmentModel.findById as jest.Mock).mockResolvedValue(
+        createMockDoc({}),
+      );
+      const res = await AppointmentService.getById(validObjectId);
+      expect(res.id).toBe(validObjectId);
+    });
+
+    it("getById: should throw if not found", async () => {
+      (AppointmentModel.findById as jest.Mock).mockResolvedValue(null);
+      await expect(AppointmentService.getById(validObjectId)).rejects.toThrow(
+        "Appointment not found",
+      );
+    });
+
+    it("getById: should throw if id invalid", async () => {
+      await expect(AppointmentService.getById("invalid-id")).rejects.toThrow(
+        "Invalid AppointmentId",
+      );
+    });
+
+    it("getAppointmentsForOrganisation: should filter by date", async () => {
+      (AppointmentModel.find as jest.Mock).mockReturnValue(
+        mockMongooseChain([]),
+      );
+      await AppointmentService.getAppointmentsForOrganisation(validOrgId, {
+        startDate: new Date(),
+        endDate: new Date(),
+      });
+      expect(AppointmentModel.find).toHaveBeenCalledWith(
+        expect.objectContaining({ startTime: expect.anything() }),
+      );
+    });
+
+    it("getAppointmentsByDateRange: should query range", async () => {
+      (AppointmentModel.find as jest.Mock).mockReturnValue(
+        mockMongooseChain([]),
+      );
+      await AppointmentService.getAppointmentsByDateRange(
+        validOrgId,
+        new Date(),
+        new Date(),
+        ["UPCOMING"],
+      );
+      expect(AppointmentModel.find).toHaveBeenCalledWith(
+        expect.objectContaining({ status: { $in: ["UPCOMING"] } }),
+      );
+    });
+
+    it("searchAppointments: should build complex query", async () => {
+      (AppointmentModel.find as jest.Mock).mockReturnValue(
+        mockMongooseChain([]),
+      );
+      await AppointmentService.searchAppointments({
+        companionId: "c1",
+        leadId: "l1",
+        startDate: new Date(),
+        endDate: new Date(),
+        status: ["UPCOMING"],
+      });
+
+      expect(AppointmentModel.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          "companion.id": "c1",
+          "lead.id": "l1",
+          status: { $in: ["UPCOMING"] },
+        }),
+      );
+    });
+
+    it("getAppointmentsForParent: should return list", async () => {
+      (AppointmentModel.find as jest.Mock).mockReturnValue(
+        mockMongooseChain([]),
+      );
+      await AppointmentService.getAppointmentsForParent("p1");
+      expect(AppointmentModel.find).toHaveBeenCalled();
+    });
+
+    it("getAppointmentsForLead: should return list", async () => {
+      (AppointmentModel.find as jest.Mock).mockReturnValue(
+        mockMongooseChain([]),
+      );
+      await AppointmentService.getAppointmentsForLead("l1", validOrgId);
+      expect(AppointmentModel.find).toHaveBeenCalled();
+    });
+
+    it("getAppointmentsForSupportStaff: should return list", async () => {
+      (AppointmentModel.find as jest.Mock).mockReturnValue(
+        mockMongooseChain([]),
+      );
+      await AppointmentService.getAppointmentsForSupportStaff("s1", validOrgId);
+      expect(AppointmentModel.find).toHaveBeenCalled();
+    });
+  });
+
+  describe("Edge Case: Internal Helpers", () => {
+    it("getAppointmentsForCompanion should handle lean objects in toDomainLean", async () => {
+      const leanAppt = createMockDoc({ _id: validObjectId });
+      const { toObject, save, ...leanData } = leanAppt;
+
+      (AppointmentModel.find as jest.Mock).mockReturnValue(
+        mockMongooseChain([leanData]),
+      );
+      (OrganizationModel.find as jest.Mock).mockReturnValue({
+        lean: jest.fn().mockResolvedValue([]),
+      });
+
+      const res = await AppointmentService.getAppointmentsForCompanion("comp1");
+      expect(res[0].appointment.id).toBe(leanData._id.toString());
+    });
+
+    it("getById should accept Types.ObjectId directly", async () => {
+      const objId = new Types.ObjectId(validObjectId);
+      (AppointmentModel.findById as jest.Mock).mockResolvedValue(
+        createMockDoc({ _id: objId }),
+      );
+      const res = await AppointmentService.getById(objId as any);
+      expect(res.id).toBe(objId.toString());
+    });
   });
 });

--- a/apps/backend/test/services/authUserMobile.service.test.ts
+++ b/apps/backend/test/services/authUserMobile.service.test.ts
@@ -1,19 +1,19 @@
-import { Types } from 'mongoose';
-import { AuthUserMobileService } from '../../src/services/authUserMobile.service';
-import { AuthUserMobileModel } from '../../src/models/authUserMobile';
-import { ParentModel } from '../../src/models/parent';
-import logger from '../../src/utils/logger';
+import { Types } from "mongoose";
+import { AuthUserMobileService } from "../../src/services/authUserMobile.service";
+import { AuthUserMobileModel } from "../../src/models/authUserMobile";
+import { ParentModel } from "../../src/models/parent";
+import logger from "../../src/utils/logger";
 
 // --- Mocks ---
-jest.mock('../../src/models/authUserMobile');
-jest.mock('../../src/models/parent');
-jest.mock('../../src/utils/logger');
+jest.mock("../../src/models/authUserMobile");
+jest.mock("../../src/models/parent");
+jest.mock("../../src/utils/logger");
 // We do NOT mock assertSafeString to ensure real validation logic runs,
 // assuming it's a pure function that won't block testing if inputs are valid.
 
-describe('AuthUserMobileService', () => {
-  const mockProviderId = 'google-123';
-  const mockEmail = 'test@example.com';
+describe("AuthUserMobileService", () => {
+  const mockProviderId = "google-123";
+  const mockEmail = "test@example.com";
   const validObjectId = new Types.ObjectId().toString();
 
   beforeEach(() => {
@@ -26,63 +26,90 @@ describe('AuthUserMobileService', () => {
   });
 
   // 1. createOrGetAuthUser
-  describe('createOrGetAuthUser', () => {
-    it('should return existing user if found', async () => {
+  describe("createOrGetAuthUser", () => {
+    it("should return existing user if found", async () => {
       const existingUser = { providerUserId: mockProviderId, email: mockEmail };
 
-      (AuthUserMobileModel.findOne as jest.Mock).mockReturnValue(mockExec(existingUser));
+      (AuthUserMobileModel.findOne as jest.Mock).mockReturnValue(
+        mockExec(existingUser),
+      );
 
-      const result = await AuthUserMobileService.createOrGetAuthUser('cognito', mockProviderId, mockEmail);
+      const result = await AuthUserMobileService.createOrGetAuthUser(
+        "cognito",
+        mockProviderId,
+        mockEmail,
+      );
 
-      expect(AuthUserMobileModel.findOne).toHaveBeenCalledWith({ providerUserId: mockProviderId });
+      expect(AuthUserMobileModel.findOne).toHaveBeenCalledWith({
+        providerUserId: mockProviderId,
+      });
       expect(AuthUserMobileModel.create).not.toHaveBeenCalled();
       expect(result).toEqual(existingUser);
     });
 
-    it('should create and return new user if not found', async () => {
-      const newUser = { providerUserId: mockProviderId, email: mockEmail, authProvider: 'cognito' };
+    it("should create and return new user if not found", async () => {
+      const newUser = {
+        providerUserId: mockProviderId,
+        email: mockEmail,
+        authProvider: "cognito",
+      };
 
       // findOne returns null
-      (AuthUserMobileModel.findOne as jest.Mock).mockReturnValue(mockExec(null));
+      (AuthUserMobileModel.findOne as jest.Mock).mockReturnValue(
+        mockExec(null),
+      );
       // create returns new user
       (AuthUserMobileModel.create as jest.Mock).mockResolvedValue(newUser);
 
-      const result = await AuthUserMobileService.createOrGetAuthUser('cognito', mockProviderId, mockEmail);
+      const result = await AuthUserMobileService.createOrGetAuthUser(
+        "cognito",
+        mockProviderId,
+        mockEmail,
+      );
 
-      expect(AuthUserMobileModel.create).toHaveBeenCalledWith(expect.objectContaining({
-        authProvider: 'cognito',
-        providerUserId: mockProviderId,
-        email: mockEmail,
-      }));
+      expect(AuthUserMobileModel.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authProvider: "cognito",
+          providerUserId: mockProviderId,
+          email: mockEmail,
+        }),
+      );
       expect(result).toEqual(newUser);
     });
   });
 
   // 2. linkParent
-  describe('linkParent', () => {
-    it('should throw error if parentId is invalid', async () => {
-      await expect(AuthUserMobileService.linkParent(mockProviderId, 'invalid-id'))
-        .rejects.toThrow('Invalid parent ID');
+  describe("linkParent", () => {
+    it("should throw error if parentId is invalid", async () => {
+      await expect(
+        AuthUserMobileService.linkParent(mockProviderId, "invalid-id"),
+      ).rejects.toThrow("Invalid parent ID");
     });
 
-    it('should throw error if AuthUserMobile not found', async () => {
-      (AuthUserMobileModel.findOne as jest.Mock).mockReturnValue(mockExec(null));
+    it("should throw error if AuthUserMobile not found", async () => {
+      (AuthUserMobileModel.findOne as jest.Mock).mockReturnValue(
+        mockExec(null),
+      );
 
-      await expect(AuthUserMobileService.linkParent(mockProviderId, validObjectId))
-        .rejects.toThrow('AuthUserMobile not found');
+      await expect(
+        AuthUserMobileService.linkParent(mockProviderId, validObjectId),
+      ).rejects.toThrow("AuthUserMobile not found");
     });
 
-    it('should throw error if Parent not found', async () => {
+    it("should throw error if Parent not found", async () => {
       // Mock AuthUser found
-      (AuthUserMobileModel.findOne as jest.Mock).mockReturnValue(mockExec({ providerUserId: mockProviderId }));
+      (AuthUserMobileModel.findOne as jest.Mock).mockReturnValue(
+        mockExec({ providerUserId: mockProviderId }),
+      );
       // Mock Parent NOT found
       (ParentModel.findById as jest.Mock).mockReturnValue(mockExec(null));
 
-      await expect(AuthUserMobileService.linkParent(mockProviderId, validObjectId))
-        .rejects.toThrow('Parent not found');
+      await expect(
+        AuthUserMobileService.linkParent(mockProviderId, validObjectId),
+      ).rejects.toThrow("Parent not found");
     });
 
-    it('should successfully link user and parent', async () => {
+    it("should successfully link user and parent", async () => {
       // Mock User Document with save method
       const mockUserDoc = {
         _id: new Types.ObjectId(),
@@ -98,10 +125,17 @@ describe('AuthUserMobileService', () => {
         save: jest.fn().mockResolvedValue(true),
       };
 
-      (AuthUserMobileModel.findOne as jest.Mock).mockReturnValue(mockExec(mockUserDoc));
-      (ParentModel.findById as jest.Mock).mockReturnValue(mockExec(mockParentDoc));
+      (AuthUserMobileModel.findOne as jest.Mock).mockReturnValue(
+        mockExec(mockUserDoc),
+      );
+      (ParentModel.findById as jest.Mock).mockReturnValue(
+        mockExec(mockParentDoc),
+      );
 
-      const result = await AuthUserMobileService.linkParent(mockProviderId, validObjectId);
+      const result = await AuthUserMobileService.linkParent(
+        mockProviderId,
+        validObjectId,
+      );
 
       // Verify User was updated
       expect(mockUserDoc.parentId).toEqual(mockParentDoc._id);
@@ -116,69 +150,95 @@ describe('AuthUserMobileService', () => {
   });
 
   // 3. autoLinkParentByEmail
-  describe('autoLinkParentByEmail', () => {
-    const mockAuthUser: any = { providerUserId: mockProviderId, email: mockEmail };
+  describe("autoLinkParentByEmail", () => {
+    const mockAuthUser: any = {
+      providerUserId: mockProviderId,
+      email: mockEmail,
+    };
 
-    it('should return null if no parent found with matching email', async () => {
+    it("should return null if no parent found with matching email", async () => {
       (ParentModel.findOne as jest.Mock).mockReturnValue(mockExec(null));
 
-      const result = await AuthUserMobileService.autoLinkParentByEmail(mockAuthUser);
+      const result =
+        await AuthUserMobileService.autoLinkParentByEmail(mockAuthUser);
 
       expect(result).toBeNull();
       expect(AuthUserMobileModel.updateOne).not.toHaveBeenCalled();
     });
 
-    it('should update user and return parent if parent found', async () => {
+    it("should update user and return parent if parent found", async () => {
       const mockParent = { _id: new Types.ObjectId(), email: mockEmail };
 
       (ParentModel.findOne as jest.Mock).mockReturnValue(mockExec(mockParent));
-      (AuthUserMobileModel.updateOne as jest.Mock).mockReturnValue(mockExec({ modifiedCount: 1 }));
+      (AuthUserMobileModel.updateOne as jest.Mock).mockReturnValue(
+        mockExec({ modifiedCount: 1 }),
+      );
 
-      const result = await AuthUserMobileService.autoLinkParentByEmail(mockAuthUser);
+      const result =
+        await AuthUserMobileService.autoLinkParentByEmail(mockAuthUser);
 
       expect(AuthUserMobileModel.updateOne).toHaveBeenCalledWith(
         { providerUserId: mockProviderId },
-        { parentId: mockParent._id }
+        { parentId: mockParent._id },
       );
       expect(result).toEqual(mockParent);
     });
   });
 
   // 4. getByProviderUserId
-  describe('getByProviderUserId', () => {
-    it('should return the user document', async () => {
+  describe("getByProviderUserId", () => {
+    it("should return the user document", async () => {
       const mockUser = { providerUserId: mockProviderId };
-      (AuthUserMobileModel.findOne as jest.Mock).mockReturnValue(mockExec(mockUser));
+      (AuthUserMobileModel.findOne as jest.Mock).mockReturnValue(
+        mockExec(mockUser),
+      );
 
-      const result = await AuthUserMobileService.getByProviderUserId(mockProviderId);
+      const result =
+        await AuthUserMobileService.getByProviderUserId(mockProviderId);
 
-      expect(AuthUserMobileModel.findOne).toHaveBeenCalledWith({ providerUserId: mockProviderId });
+      expect(AuthUserMobileModel.findOne).toHaveBeenCalledWith({
+        providerUserId: mockProviderId,
+      });
       expect(result).toEqual(mockUser);
     });
   });
 
   // 5. getAuthUserMobileIdByProviderId
-  describe('getAuthUserMobileIdByProviderId', () => {
-    it('should return _id if user found', async () => {
+  describe("getAuthUserMobileIdByProviderId", () => {
+    it("should return _id if user found", async () => {
       const mockId = new Types.ObjectId();
-      (AuthUserMobileModel.findOne as jest.Mock).mockReturnValue(mockExec({ _id: mockId }));
+      (AuthUserMobileModel.findOne as jest.Mock).mockReturnValue(
+        mockExec({ _id: mockId }),
+      );
 
-      const result = await AuthUserMobileService.getAuthUserMobileIdByProviderId(mockProviderId);
+      const result =
+        await AuthUserMobileService.getAuthUserMobileIdByProviderId(
+          mockProviderId,
+        );
 
-      expect(AuthUserMobileModel.findOne).toHaveBeenCalledWith({ providerUserId: mockProviderId }, { _id: 1 });
+      expect(AuthUserMobileModel.findOne).toHaveBeenCalledWith(
+        { providerUserId: mockProviderId },
+        { _id: 1 },
+      );
       expect(result).toEqual(mockId);
     });
 
-    it('should log warning and return null if user not found', async () => {
-      (AuthUserMobileModel.findOne as jest.Mock).mockReturnValue(mockExec(null));
+    it("should log warning and return null if user not found", async () => {
+      (AuthUserMobileModel.findOne as jest.Mock).mockReturnValue(
+        mockExec(null),
+      );
 
-      const result = await AuthUserMobileService.getAuthUserMobileIdByProviderId(mockProviderId);
+      const result =
+        await AuthUserMobileService.getAuthUserMobileIdByProviderId(
+          mockProviderId,
+        );
 
       expect(logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining(`AuthUserMobile not found for providerUserId: ${mockProviderId}`)
+        expect.stringContaining(
+          `AuthUserMobile not found for providerUserId: ${mockProviderId}`,
+        ),
       );
       expect(result).toBeNull();
     });
   });
-
 });

--- a/apps/backend/test/services/availability.service.test.ts
+++ b/apps/backend/test/services/availability.service.test.ts
@@ -1,25 +1,28 @@
-import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc';
-import customParseFormat from 'dayjs/plugin/customParseFormat';
-import { AvailabilityService, generateBookableWindows } from '../../src/services/availability.service';
-import BaseAvailabilityModel from '../../src/models/base-availability';
-import WeeklyAvailabilityOverrideModel from '../../src/models/weekly-availablity-override';
-import { OccupancyModel } from '../../src/models/occupancy';
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import customParseFormat from "dayjs/plugin/customParseFormat";
+import {
+  AvailabilityService,
+  generateBookableWindows,
+} from "../../src/services/availability.service";
+import BaseAvailabilityModel from "../../src/models/base-availability";
+import WeeklyAvailabilityOverrideModel from "../../src/models/weekly-availablity-override";
+import { OccupancyModel } from "../../src/models/occupancy";
 
 // Register plugins required by the service logic
 dayjs.extend(utc);
 dayjs.extend(customParseFormat);
 
 // --- Mocks ---
-jest.mock('../../src/models/base-availability');
-jest.mock('../../src/models/weekly-availablity-override');
-jest.mock('../../src/models/occupancy');
+jest.mock("../../src/models/base-availability");
+jest.mock("../../src/models/weekly-availablity-override");
+jest.mock("../../src/models/occupancy");
 
-describe('AvailabilityService', () => {
-  const mockOrgId = 'org-123';
-  const mockUserId = 'user-123';
+describe("AvailabilityService", () => {
+  const mockOrgId = "org-123";
+  const mockUserId = "user-123";
   // Use a string to ensure strict UTC interpretation by dayjs
-  const referenceDateStr = '2023-10-23T00:00:00Z';
+  const referenceDateStr = "2023-10-23T00:00:00Z";
   const referenceDate = new Date(referenceDateStr); // Monday
 
   beforeEach(() => {
@@ -27,341 +30,536 @@ describe('AvailabilityService', () => {
   });
 
   // 1. generateBookableWindows (Exported Helper)
-  describe('generateBookableWindows', () => {
-    it('should split a long slot into multiple bookable windows', () => {
-      const slots = [{ startTime: '09:00', endTime: '10:00', isAvailable: true }];
-      const windows = generateBookableWindows('2023-10-23', slots, 30);
+  describe("generateBookableWindows", () => {
+    it("should split a long slot into multiple bookable windows", () => {
+      const slots = [
+        { startTime: "09:00", endTime: "10:00", isAvailable: true },
+      ];
+      const windows = generateBookableWindows("2023-10-23", slots, 30);
 
       expect(windows).toHaveLength(2);
-      expect(windows[0]).toEqual(expect.objectContaining({ startTime: '09:00', endTime: '09:30' }));
-      expect(windows[1]).toEqual(expect.objectContaining({ startTime: '09:30', endTime: '10:00' }));
+      expect(windows[0]).toEqual(
+        expect.objectContaining({ startTime: "09:00", endTime: "09:30" }),
+      );
+      expect(windows[1]).toEqual(
+        expect.objectContaining({ startTime: "09:30", endTime: "10:00" }),
+      );
     });
 
-    it('should ignore remaining time less than window size', () => {
-      const slots = [{ startTime: '09:00', endTime: '09:45', isAvailable: true }];
-      const windows = generateBookableWindows('2023-10-23', slots, 30);
+    it("should ignore remaining time less than window size", () => {
+      const slots = [
+        { startTime: "09:00", endTime: "09:45", isAvailable: true },
+      ];
+      const windows = generateBookableWindows("2023-10-23", slots, 30);
 
       // Only 09:00-09:30 fits. 09:30-09:45 is too short.
       expect(windows).toHaveLength(1);
-      expect(windows[0].endTime).toBe('09:30');
+      expect(windows[0].endTime).toBe("09:30");
     });
 
-    it('should return empty array if no slots fit', () => {
-      const slots = [{ startTime: '09:00', endTime: '09:10', isAvailable: true }];
-      const windows = generateBookableWindows('2023-10-23', slots, 30);
+    it("should return empty array if no slots fit", () => {
+      const slots = [
+        { startTime: "09:00", endTime: "09:10", isAvailable: true },
+      ];
+      const windows = generateBookableWindows("2023-10-23", slots, 30);
       expect(windows).toEqual([]);
     });
   });
 
   // 2. Base Availability CRUD
-  describe('Base Availability', () => {
-    it('setAllBaseAvailability: should delete existing and insert new', async () => {
-      const input = [{ dayOfWeek: 'MONDAY' as any, slots: [] }];
+  describe("Base Availability", () => {
+    it("setAllBaseAvailability: should delete existing and insert new", async () => {
+      const input = [{ dayOfWeek: "MONDAY" as any, slots: [] }];
       (BaseAvailabilityModel.insertMany as jest.Mock).mockResolvedValue(input);
 
-      await AvailabilityService.setAllBaseAvailability(mockOrgId, mockUserId, input);
+      await AvailabilityService.setAllBaseAvailability(
+        mockOrgId,
+        mockUserId,
+        input,
+      );
 
-      expect(BaseAvailabilityModel.deleteMany).toHaveBeenCalledWith({ userId: mockUserId, organisationId: mockOrgId });
-      expect(BaseAvailabilityModel.insertMany).toHaveBeenCalledWith(expect.arrayContaining([
-        expect.objectContaining({ dayOfWeek: 'MONDAY' })
-      ]));
+      expect(BaseAvailabilityModel.deleteMany).toHaveBeenCalledWith({
+        userId: mockUserId,
+        organisationId: mockOrgId,
+      });
+      expect(BaseAvailabilityModel.insertMany).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ dayOfWeek: "MONDAY" }),
+        ]),
+      );
     });
 
-    it('getBaseAvailability: should find documents', async () => {
-      const mockResult = [{ dayOfWeek: 'MONDAY' }];
+    it("getBaseAvailability: should find documents", async () => {
+      const mockResult = [{ dayOfWeek: "MONDAY" }];
       (BaseAvailabilityModel.find as jest.Mock).mockResolvedValue(mockResult);
 
-      const result = await AvailabilityService.getBaseAvailability(mockOrgId, mockUserId);
+      const result = await AvailabilityService.getBaseAvailability(
+        mockOrgId,
+        mockUserId,
+      );
       expect(result).toEqual(mockResult);
     });
 
-    it('deleteBaseAvailability: should delete documents', async () => {
+    it("deleteBaseAvailability: should delete documents", async () => {
       await AvailabilityService.deleteBaseAvailability(mockOrgId, mockUserId);
-      expect(BaseAvailabilityModel.deleteMany).toHaveBeenCalledWith({ organisationId: mockOrgId, userId: mockUserId });
+      expect(BaseAvailabilityModel.deleteMany).toHaveBeenCalledWith({
+        organisationId: mockOrgId,
+        userId: mockUserId,
+      });
     });
   });
 
   // 3. Weekly Overrides
-  describe('Weekly Overrides', () => {
-    const overrideInput = { dayOfWeek: 'TUESDAY' as any, slots: [] };
+  describe("Weekly Overrides", () => {
+    const overrideInput = { dayOfWeek: "TUESDAY" as any, slots: [] };
 
-    it('addWeeklyAvailabilityOverride: should create new if not exists', async () => {
-      (WeeklyAvailabilityOverrideModel.findOne as jest.Mock).mockResolvedValue(null);
+    it("addWeeklyAvailabilityOverride: should create new if not exists", async () => {
+      (WeeklyAvailabilityOverrideModel.findOne as jest.Mock).mockResolvedValue(
+        null,
+      );
 
-      await AvailabilityService.addWeeklyAvailabilityOverride(mockOrgId, mockUserId, referenceDate, overrideInput);
+      await AvailabilityService.addWeeklyAvailabilityOverride(
+        mockOrgId,
+        mockUserId,
+        referenceDate,
+        overrideInput,
+      );
 
-      expect(WeeklyAvailabilityOverrideModel.create).toHaveBeenCalledWith(expect.objectContaining({
-        userId: mockUserId,
-        overrides: [overrideInput]
-      }));
+      expect(WeeklyAvailabilityOverrideModel.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: mockUserId,
+          overrides: [overrideInput],
+        }),
+      );
     });
 
-    it('addWeeklyAvailabilityOverride: should update existing overrides (push new day)', async () => {
+    it("addWeeklyAvailabilityOverride: should update existing overrides (push new day)", async () => {
       const existingDoc = {
-        overrides: [{ dayOfWeek: 'MONDAY' }],
-        save: jest.fn()
+        overrides: [{ dayOfWeek: "MONDAY" }],
+        save: jest.fn(),
       };
-      (WeeklyAvailabilityOverrideModel.findOne as jest.Mock).mockResolvedValue(existingDoc);
+      (WeeklyAvailabilityOverrideModel.findOne as jest.Mock).mockResolvedValue(
+        existingDoc,
+      );
 
-      await AvailabilityService.addWeeklyAvailabilityOverride(mockOrgId, mockUserId, referenceDate, overrideInput);
+      await AvailabilityService.addWeeklyAvailabilityOverride(
+        mockOrgId,
+        mockUserId,
+        referenceDate,
+        overrideInput,
+      );
 
       expect(existingDoc.overrides).toHaveLength(2); // Monday + Tuesday
       expect(existingDoc.save).toHaveBeenCalled();
     });
 
-    it('addWeeklyAvailabilityOverride: should update existing overrides (replace same day)', async () => {
+    it("addWeeklyAvailabilityOverride: should update existing overrides (replace same day)", async () => {
       const existingDoc = {
-        overrides: [{ dayOfWeek: 'TUESDAY', slots: ['old'] }],
-        save: jest.fn()
+        overrides: [{ dayOfWeek: "TUESDAY", slots: ["old"] }],
+        save: jest.fn(),
       };
-      (WeeklyAvailabilityOverrideModel.findOne as jest.Mock).mockResolvedValue(existingDoc);
+      (WeeklyAvailabilityOverrideModel.findOne as jest.Mock).mockResolvedValue(
+        existingDoc,
+      );
 
-      await AvailabilityService.addWeeklyAvailabilityOverride(mockOrgId, mockUserId, referenceDate, overrideInput);
+      await AvailabilityService.addWeeklyAvailabilityOverride(
+        mockOrgId,
+        mockUserId,
+        referenceDate,
+        overrideInput,
+      );
 
       expect(existingDoc.overrides).toHaveLength(1);
       expect(existingDoc.overrides[0].slots).toEqual([]); // Replaced with empty
       expect(existingDoc.save).toHaveBeenCalled();
     });
 
-    it('getWeeklyAvailabilityOverride: should return document', async () => {
-      const mockDoc = { _id: '1' };
-      (WeeklyAvailabilityOverrideModel.findOne as jest.Mock).mockResolvedValue(mockDoc);
-      const res = await AvailabilityService.getWeeklyAvailabilityOverride(mockOrgId, mockUserId, referenceDate);
+    it("getWeeklyAvailabilityOverride: should return document", async () => {
+      const mockDoc = { _id: "1" };
+      (WeeklyAvailabilityOverrideModel.findOne as jest.Mock).mockResolvedValue(
+        mockDoc,
+      );
+      const res = await AvailabilityService.getWeeklyAvailabilityOverride(
+        mockOrgId,
+        mockUserId,
+        referenceDate,
+      );
       expect(res).toEqual(mockDoc);
     });
 
-    it('deleteWeeklyAvailabilityOverride: should delete document', async () => {
-      await AvailabilityService.deleteWeeklyAvailabilityOverride(mockOrgId, mockUserId, referenceDate);
+    it("deleteWeeklyAvailabilityOverride: should delete document", async () => {
+      await AvailabilityService.deleteWeeklyAvailabilityOverride(
+        mockOrgId,
+        mockUserId,
+        referenceDate,
+      );
       expect(WeeklyAvailabilityOverrideModel.deleteOne).toHaveBeenCalled();
     });
   });
 
   // 4. Occupancies
-  describe('Occupancies', () => {
-    it('addOccupancy: should create document', async () => {
-      await AvailabilityService.addOccupancy(mockOrgId, mockUserId, new Date(), new Date(), 'BLOCKED');
+  describe("Occupancies", () => {
+    it("addOccupancy: should create document", async () => {
+      await AvailabilityService.addOccupancy(
+        mockOrgId,
+        mockUserId,
+        new Date(),
+        new Date(),
+        "BLOCKED",
+      );
       expect(OccupancyModel.create).toHaveBeenCalled();
     });
 
-    it('addAllOccupancies: should insert many', async () => {
-      await AvailabilityService.addAllOccupancies(mockOrgId, mockUserId, [{ startTime: new Date(), endTime: new Date(), sourceType: 'BLOCKED' }]);
+    it("addAllOccupancies: should insert many", async () => {
+      await AvailabilityService.addAllOccupancies(mockOrgId, mockUserId, [
+        { startTime: new Date(), endTime: new Date(), sourceType: "BLOCKED" },
+      ]);
       expect(OccupancyModel.insertMany).toHaveBeenCalled();
     });
 
-    it('getOccupancy: should find and return lean', async () => {
+    it("getOccupancy: should find and return lean", async () => {
       const mockChain = { lean: jest.fn().mockResolvedValue([]) };
       (OccupancyModel.find as jest.Mock).mockReturnValue(mockChain);
 
-      await AvailabilityService.getOccupancy(mockOrgId, mockUserId, new Date(), new Date());
+      await AvailabilityService.getOccupancy(
+        mockOrgId,
+        mockUserId,
+        new Date(),
+        new Date(),
+      );
       expect(OccupancyModel.find).toHaveBeenCalled();
       expect(mockChain.lean).toHaveBeenCalled();
     });
   });
 
   // 5. Logic: Merging & Splitting (getWeeklyFinalAvailability)
-  describe('Merging Logic (getWeeklyFinalAvailability)', () => {
-
-    it('should return base availability if no overrides and no occupancy', async () => {
-      const baseSlots = [{ startTime: '09:00', endTime: '17:00', isAvailable: true }];
+  describe("Merging Logic (getWeeklyFinalAvailability)", () => {
+    it("should return base availability if no overrides and no occupancy", async () => {
+      const baseSlots = [
+        { startTime: "09:00", endTime: "17:00", isAvailable: true },
+      ];
       (BaseAvailabilityModel.find as jest.Mock).mockResolvedValue([
-        { dayOfWeek: 'MONDAY', slots: baseSlots }
+        { dayOfWeek: "MONDAY", slots: baseSlots },
       ]);
-      (WeeklyAvailabilityOverrideModel.findOne as jest.Mock).mockResolvedValue(null);
-      (OccupancyModel.find as jest.Mock).mockReturnValue({ lean: jest.fn().mockResolvedValue([]) });
+      (WeeklyAvailabilityOverrideModel.findOne as jest.Mock).mockResolvedValue(
+        null,
+      );
+      (OccupancyModel.find as jest.Mock).mockReturnValue({
+        lean: jest.fn().mockResolvedValue([]),
+      });
 
-      const result = await AvailabilityService.getWeeklyFinalAvailability(mockOrgId, mockUserId, referenceDate); // referenceDate is Monday
+      const result = await AvailabilityService.getWeeklyFinalAvailability(
+        mockOrgId,
+        mockUserId,
+        referenceDate,
+      ); // referenceDate is Monday
 
-      const monday = result.find(d => d.dayOfWeek === 'MONDAY');
+      const monday = result.find((d) => d.dayOfWeek === "MONDAY");
       expect(monday?.slots).toEqual(baseSlots);
     });
 
-    it('should prioritize weekly override over base availability', async () => {
+    it("should prioritize weekly override over base availability", async () => {
       (BaseAvailabilityModel.find as jest.Mock).mockResolvedValue([
-        { dayOfWeek: 'MONDAY', slots: [{ startTime: '09:00', endTime: '10:00' }] }
+        {
+          dayOfWeek: "MONDAY",
+          slots: [{ startTime: "09:00", endTime: "10:00" }],
+        },
       ]);
       (WeeklyAvailabilityOverrideModel.findOne as jest.Mock).mockResolvedValue({
-        overrides: [{ dayOfWeek: 'MONDAY', slots: [{ startTime: '12:00', endTime: '13:00', isAvailable: true }] }]
+        overrides: [
+          {
+            dayOfWeek: "MONDAY",
+            slots: [
+              { startTime: "12:00", endTime: "13:00", isAvailable: true },
+            ],
+          },
+        ],
       });
-      (OccupancyModel.find as jest.Mock).mockReturnValue({ lean: jest.fn().mockResolvedValue([]) });
+      (OccupancyModel.find as jest.Mock).mockReturnValue({
+        lean: jest.fn().mockResolvedValue([]),
+      });
 
-      const result = await AvailabilityService.getWeeklyFinalAvailability(mockOrgId, mockUserId, referenceDate);
+      const result = await AvailabilityService.getWeeklyFinalAvailability(
+        mockOrgId,
+        mockUserId,
+        referenceDate,
+      );
 
-      const monday = result.find(d => d.dayOfWeek === 'MONDAY');
-      expect(monday?.slots[0].startTime).toBe('12:00'); // Override applied
+      const monday = result.find((d) => d.dayOfWeek === "MONDAY");
+      expect(monday?.slots[0].startTime).toBe("12:00"); // Override applied
     });
 
-    it('should split slots correctly around an occupancy (Middle overlap)', async () => {
+    it("should split slots correctly around an occupancy (Middle overlap)", async () => {
       // Base: 09:00 - 12:00
       // Occupancy: 10:00 - 11:00
       // Expected: 09:00-10:00, 11:00-12:00
-      const baseSlots = [{ startTime: '09:00', endTime: '12:00', isAvailable: true }];
+      const baseSlots = [
+        { startTime: "09:00", endTime: "12:00", isAvailable: true },
+      ];
       (BaseAvailabilityModel.find as jest.Mock).mockResolvedValue([
-        { dayOfWeek: 'MONDAY', slots: baseSlots }
+        { dayOfWeek: "MONDAY", slots: baseSlots },
       ]);
-      (WeeklyAvailabilityOverrideModel.findOne as jest.Mock).mockResolvedValue(null);
+      (WeeklyAvailabilityOverrideModel.findOne as jest.Mock).mockResolvedValue(
+        null,
+      );
 
       // FIX: Use dayjs.utc() to ensure the date aligns with the service's UTC logic
       const occStart = dayjs.utc(referenceDateStr).hour(10).minute(0).toDate();
       const occEnd = dayjs.utc(referenceDateStr).hour(11).minute(0).toDate();
 
       (OccupancyModel.find as jest.Mock).mockReturnValue({
-        lean: jest.fn().mockResolvedValue([{ startTime: occStart, endTime: occEnd }])
+        lean: jest
+          .fn()
+          .mockResolvedValue([{ startTime: occStart, endTime: occEnd }]),
       });
 
-      const result = await AvailabilityService.getWeeklyFinalAvailability(mockOrgId, mockUserId, referenceDate);
-      const monday = result.find(d => d.dayOfWeek === 'MONDAY');
+      const result = await AvailabilityService.getWeeklyFinalAvailability(
+        mockOrgId,
+        mockUserId,
+        referenceDate,
+      );
+      const monday = result.find((d) => d.dayOfWeek === "MONDAY");
 
       expect(monday?.slots).toHaveLength(2);
-      expect(monday?.slots[0]).toMatchObject({ startTime: '09:00', endTime: '10:00' });
-      expect(monday?.slots[1]).toMatchObject({ startTime: '11:00', endTime: '12:00' });
+      expect(monday?.slots[0]).toMatchObject({
+        startTime: "09:00",
+        endTime: "10:00",
+      });
+      expect(monday?.slots[1]).toMatchObject({
+        startTime: "11:00",
+        endTime: "12:00",
+      });
     });
 
-    it('should remove slot entirely if occupancy fully covers it', async () => {
+    it("should remove slot entirely if occupancy fully covers it", async () => {
       // Base: 10:00 - 11:00
       // Occupancy: 09:00 - 12:00 (Covers it completely)
-      const baseSlots = [{ startTime: '10:00', endTime: '11:00', isAvailable: true }];
-      (BaseAvailabilityModel.find as jest.Mock).mockResolvedValue([{ dayOfWeek: 'MONDAY', slots: baseSlots }]);
-      (WeeklyAvailabilityOverrideModel.findOne as jest.Mock).mockResolvedValue(null);
+      const baseSlots = [
+        { startTime: "10:00", endTime: "11:00", isAvailable: true },
+      ];
+      (BaseAvailabilityModel.find as jest.Mock).mockResolvedValue([
+        { dayOfWeek: "MONDAY", slots: baseSlots },
+      ]);
+      (WeeklyAvailabilityOverrideModel.findOne as jest.Mock).mockResolvedValue(
+        null,
+      );
 
       // FIX: Use dayjs.utc()
       const occStart = dayjs.utc(referenceDateStr).hour(9).toDate();
       const occEnd = dayjs.utc(referenceDateStr).hour(12).toDate();
 
       (OccupancyModel.find as jest.Mock).mockReturnValue({
-        lean: jest.fn().mockResolvedValue([{ startTime: occStart, endTime: occEnd }])
+        lean: jest
+          .fn()
+          .mockResolvedValue([{ startTime: occStart, endTime: occEnd }]),
       });
 
-      const result = await AvailabilityService.getWeeklyFinalAvailability(mockOrgId, mockUserId, referenceDate);
-      const monday = result.find(d => d.dayOfWeek === 'MONDAY');
+      const result = await AvailabilityService.getWeeklyFinalAvailability(
+        mockOrgId,
+        mockUserId,
+        referenceDate,
+      );
+      const monday = result.find((d) => d.dayOfWeek === "MONDAY");
       expect(monday?.slots).toHaveLength(0);
     });
 
-    it('should ignore occupancy if it does not overlap slot', async () => {
-        // Base: 10:00 - 11:00
-        // Occupancy: 12:00 - 13:00 (No overlap)
-        const baseSlots = [{ startTime: '10:00', endTime: '11:00', isAvailable: true }];
-        (BaseAvailabilityModel.find as jest.Mock).mockResolvedValue([{ dayOfWeek: 'MONDAY', slots: baseSlots }]);
-        (WeeklyAvailabilityOverrideModel.findOne as jest.Mock).mockResolvedValue(null);
+    it("should ignore occupancy if it does not overlap slot", async () => {
+      // Base: 10:00 - 11:00
+      // Occupancy: 12:00 - 13:00 (No overlap)
+      const baseSlots = [
+        { startTime: "10:00", endTime: "11:00", isAvailable: true },
+      ];
+      (BaseAvailabilityModel.find as jest.Mock).mockResolvedValue([
+        { dayOfWeek: "MONDAY", slots: baseSlots },
+      ]);
+      (WeeklyAvailabilityOverrideModel.findOne as jest.Mock).mockResolvedValue(
+        null,
+      );
 
-        // FIX: Use dayjs.utc()
-        const occStart = dayjs.utc(referenceDateStr).hour(12).toDate();
-        const occEnd = dayjs.utc(referenceDateStr).hour(13).toDate();
+      // FIX: Use dayjs.utc()
+      const occStart = dayjs.utc(referenceDateStr).hour(12).toDate();
+      const occEnd = dayjs.utc(referenceDateStr).hour(13).toDate();
 
-        (OccupancyModel.find as jest.Mock).mockReturnValue({
-          lean: jest.fn().mockResolvedValue([{ startTime: occStart, endTime: occEnd }])
-        });
+      (OccupancyModel.find as jest.Mock).mockReturnValue({
+        lean: jest
+          .fn()
+          .mockResolvedValue([{ startTime: occStart, endTime: occEnd }]),
+      });
 
-        const result = await AvailabilityService.getWeeklyFinalAvailability(mockOrgId, mockUserId, referenceDate);
-        const monday = result.find(d => d.dayOfWeek === 'MONDAY');
-        expect(monday?.slots).toHaveLength(1); // Unchanged
+      const result = await AvailabilityService.getWeeklyFinalAvailability(
+        mockOrgId,
+        mockUserId,
+        referenceDate,
+      );
+      const monday = result.find((d) => d.dayOfWeek === "MONDAY");
+      expect(monday?.slots).toHaveLength(1); // Unchanged
     });
   });
 
   // 6. getFinalAvailabilityForDate
-  describe('getFinalAvailabilityForDate', () => {
-    it('should return single day object', async () => {
+  describe("getFinalAvailabilityForDate", () => {
+    it("should return single day object", async () => {
       (BaseAvailabilityModel.find as jest.Mock).mockResolvedValue([]);
-      (WeeklyAvailabilityOverrideModel.findOne as jest.Mock).mockResolvedValue(null);
-      (OccupancyModel.find as jest.Mock).mockReturnValue({ lean: jest.fn().mockResolvedValue([]) });
+      (WeeklyAvailabilityOverrideModel.findOne as jest.Mock).mockResolvedValue(
+        null,
+      );
+      (OccupancyModel.find as jest.Mock).mockReturnValue({
+        lean: jest.fn().mockResolvedValue([]),
+      });
 
-      const result = await AvailabilityService.getFinalAvailabilityForDate(mockOrgId, mockUserId, referenceDate);
+      const result = await AvailabilityService.getFinalAvailabilityForDate(
+        mockOrgId,
+        mockUserId,
+        referenceDate,
+      );
 
-      expect(result.dayOfWeek).toBe('MONDAY');
+      expect(result.dayOfWeek).toBe("MONDAY");
       expect(result.slots).toEqual([]);
     });
   });
 
   // 7. getCurrentStatus
-  describe('getCurrentStatus', () => {
-    it('should return Consulting if occupancy exists now', async () => {
+  describe("getCurrentStatus", () => {
+    it("should return Consulting if occupancy exists now", async () => {
       (OccupancyModel.exists as jest.Mock).mockResolvedValue(true);
-      const status = await AvailabilityService.getCurrentStatus(mockOrgId, mockUserId);
-      expect(status).toBe('Consulting');
+      const status = await AvailabilityService.getCurrentStatus(
+        mockOrgId,
+        mockUserId,
+      );
+      expect(status).toBe("Consulting");
     });
 
-    it('should return Available if currently inside a slot', async () => {
-        (OccupancyModel.exists as jest.Mock).mockResolvedValue(false);
+    it("should return Available if currently inside a slot", async () => {
+      (OccupancyModel.exists as jest.Mock).mockResolvedValue(false);
 
-        // FIX: Ensure slot times align with "now".
-        // dayjs() uses local system time. We construct slots relative to it.
-        const now = dayjs();
-        const start = now.subtract(10, 'minute').format('HH:mm');
-        const end = now.add(10, 'minute').format('HH:mm');
+      // FIX: Ensure slot times align with "now".
+      // dayjs() uses local system time. We construct slots relative to it.
+      const now = dayjs();
+      const start = now.subtract(10, "minute").format("HH:mm");
+      const end = now.add(10, "minute").format("HH:mm");
 
-        (BaseAvailabilityModel.find as jest.Mock).mockResolvedValue([
-            {
-                dayOfWeek: now.format('dddd').toUpperCase(),
-                slots: [{ startTime: start, endTime: end }]
-            }
-        ]);
-        (WeeklyAvailabilityOverrideModel.findOne as jest.Mock).mockResolvedValue(null);
-        (OccupancyModel.find as jest.Mock).mockReturnValue({ lean: jest.fn().mockResolvedValue([]) });
+      (BaseAvailabilityModel.find as jest.Mock).mockResolvedValue([
+        {
+          dayOfWeek: now.format("dddd").toUpperCase(),
+          slots: [{ startTime: start, endTime: end }],
+        },
+      ]);
+      (WeeklyAvailabilityOverrideModel.findOne as jest.Mock).mockResolvedValue(
+        null,
+      );
+      (OccupancyModel.find as jest.Mock).mockReturnValue({
+        lean: jest.fn().mockResolvedValue([]),
+      });
 
-        const status = await AvailabilityService.getCurrentStatus(mockOrgId, mockUserId);
-        expect(status).toBe('Available');
+      const status = await AvailabilityService.getCurrentStatus(
+        mockOrgId,
+        mockUserId,
+      );
+      expect(status).toBe("Available");
     });
 
-    it('should return Off-Duty if no slots today', async () => {
-        (OccupancyModel.exists as jest.Mock).mockResolvedValue(false);
-        (BaseAvailabilityModel.find as jest.Mock).mockResolvedValue([]);
-        (WeeklyAvailabilityOverrideModel.findOne as jest.Mock).mockResolvedValue(null);
-        (OccupancyModel.find as jest.Mock).mockReturnValue({ lean: jest.fn().mockResolvedValue([]) });
+    it("should return Off-Duty if no slots today", async () => {
+      (OccupancyModel.exists as jest.Mock).mockResolvedValue(false);
+      (BaseAvailabilityModel.find as jest.Mock).mockResolvedValue([]);
+      (WeeklyAvailabilityOverrideModel.findOne as jest.Mock).mockResolvedValue(
+        null,
+      );
+      (OccupancyModel.find as jest.Mock).mockReturnValue({
+        lean: jest.fn().mockResolvedValue([]),
+      });
 
-        const status = await AvailabilityService.getCurrentStatus(mockOrgId, mockUserId);
-        expect(status).toBe('Off-Duty');
+      const status = await AvailabilityService.getCurrentStatus(
+        mockOrgId,
+        mockUserId,
+      );
+      expect(status).toBe("Off-Duty");
     });
 
-    it('should return Requested if slots exist but not currently active', async () => {
-        (OccupancyModel.exists as jest.Mock).mockResolvedValue(false);
+    it("should return Requested if slots exist but not currently active", async () => {
+      (OccupancyModel.exists as jest.Mock).mockResolvedValue(false);
 
-        const now = dayjs();
-        // Slot is strictly in the future relative to "now"
-        const start = now.add(2, 'hour').format('HH:mm');
-        const end = now.add(3, 'hour').format('HH:mm');
+      const now = dayjs();
+      // Slot is strictly in the future relative to "now"
+      const start = now.add(2, "hour").format("HH:mm");
+      const end = now.add(3, "hour").format("HH:mm");
 
-        (BaseAvailabilityModel.find as jest.Mock).mockResolvedValue([
-            {
-                dayOfWeek: now.format('dddd').toUpperCase(),
-                slots: [{ startTime: start, endTime: end }]
-            }
-        ]);
-        (WeeklyAvailabilityOverrideModel.findOne as jest.Mock).mockResolvedValue(null);
-        (OccupancyModel.find as jest.Mock).mockReturnValue({ lean: jest.fn().mockResolvedValue([]) });
+      (BaseAvailabilityModel.find as jest.Mock).mockResolvedValue([
+        {
+          dayOfWeek: now.format("dddd").toUpperCase(),
+          slots: [{ startTime: start, endTime: end }],
+        },
+      ]);
+      (WeeklyAvailabilityOverrideModel.findOne as jest.Mock).mockResolvedValue(
+        null,
+      );
+      (OccupancyModel.find as jest.Mock).mockReturnValue({
+        lean: jest.fn().mockResolvedValue([]),
+      });
 
-        const status = await AvailabilityService.getCurrentStatus(mockOrgId, mockUserId);
-        expect(status).toBe('Requested');
+      const status = await AvailabilityService.getCurrentStatus(
+        mockOrgId,
+        mockUserId,
+      );
+      expect(status).toBe("Requested");
     });
   });
 
   // 8. getBookableSlotsForDate
-  describe('getBookableSlotsForDate', () => {
-    it('should return windows based on final availability', async () => {
-        const slots = [{ startTime: '09:00', endTime: '10:00', isAvailable: true }];
-        (BaseAvailabilityModel.find as jest.Mock).mockResolvedValue([{ dayOfWeek: 'MONDAY', slots }]);
-        (WeeklyAvailabilityOverrideModel.findOne as jest.Mock).mockResolvedValue(null);
-        (OccupancyModel.find as jest.Mock).mockReturnValue({ lean: jest.fn().mockResolvedValue([]) });
+  describe("getBookableSlotsForDate", () => {
+    it("should return windows based on final availability", async () => {
+      const slots = [
+        { startTime: "09:00", endTime: "10:00", isAvailable: true },
+      ];
+      (BaseAvailabilityModel.find as jest.Mock).mockResolvedValue([
+        { dayOfWeek: "MONDAY", slots },
+      ]);
+      (WeeklyAvailabilityOverrideModel.findOne as jest.Mock).mockResolvedValue(
+        null,
+      );
+      (OccupancyModel.find as jest.Mock).mockReturnValue({
+        lean: jest.fn().mockResolvedValue([]),
+      });
 
-        const result = await AvailabilityService.getBookableSlotsForDate(mockOrgId, mockUserId, 30, referenceDate);
+      const result = await AvailabilityService.getBookableSlotsForDate(
+        mockOrgId,
+        mockUserId,
+        30,
+        referenceDate,
+      );
 
-        expect(result.windows).toHaveLength(2);
-        expect(result.windows[0].startTime).toBe('09:00');
+      expect(result.windows).toHaveLength(2);
+      expect(result.windows[0].startTime).toBe("09:00");
     });
   });
 
   // 9. getWeeklyWorkingHours
-  describe('getWeeklyWorkingHours', () => {
-    it('should calculate total hours correctly', async () => {
-        (BaseAvailabilityModel.find as jest.Mock).mockResolvedValue([
-            { dayOfWeek: 'MONDAY', slots: [{ startTime: '09:00', endTime: '10:00' }] }, // 60 mins
-            { dayOfWeek: 'TUESDAY', slots: [{ startTime: '09:00', endTime: '11:00' }] } // 120 mins
-        ]);
-        (WeeklyAvailabilityOverrideModel.findOne as jest.Mock).mockResolvedValue(null);
-        (OccupancyModel.find as jest.Mock).mockReturnValue({ lean: jest.fn().mockResolvedValue([]) });
+  describe("getWeeklyWorkingHours", () => {
+    it("should calculate total hours correctly", async () => {
+      (BaseAvailabilityModel.find as jest.Mock).mockResolvedValue([
+        {
+          dayOfWeek: "MONDAY",
+          slots: [{ startTime: "09:00", endTime: "10:00" }],
+        }, // 60 mins
+        {
+          dayOfWeek: "TUESDAY",
+          slots: [{ startTime: "09:00", endTime: "11:00" }],
+        }, // 120 mins
+      ]);
+      (WeeklyAvailabilityOverrideModel.findOne as jest.Mock).mockResolvedValue(
+        null,
+      );
+      (OccupancyModel.find as jest.Mock).mockReturnValue({
+        lean: jest.fn().mockResolvedValue([]),
+      });
 
-        const hours = await AvailabilityService.getWeeklyWorkingHours(mockOrgId, mockUserId, referenceDate);
+      const hours = await AvailabilityService.getWeeklyWorkingHours(
+        mockOrgId,
+        mockUserId,
+        referenceDate,
+      );
 
-        // Total 180 mins = 3 hours
-        expect(hours).toBe(3);
+      // Total 180 mins = 3 hours
+      expect(hours).toBe(3);
     });
   });
 });

--- a/apps/backend/test/services/base-availability.service.test.ts
+++ b/apps/backend/test/services/base-availability.service.test.ts
@@ -1,156 +1,259 @@
-import { BaseAvailabilityService } from '../../src/services/base-availability.service';
-import BaseAvailabilityModel from '../../src/models/base-availability';
+import { BaseAvailabilityService } from "../../src/services/base-availability.service";
+import BaseAvailabilityModel from "../../src/models/base-availability";
 
 // --- Mocks ---
-jest.mock('../../src/models/base-availability');
+jest.mock("../../src/models/base-availability");
 
-describe('BaseAvailabilityService', () => {
-  const mockUserId = 'user_123';
-  const validSlot = { startTime: '09:00', endTime: '17:00', isAvailable: true };
+describe("BaseAvailabilityService", () => {
+  const mockUserId = "user_123";
+  const validSlot = { startTime: "09:00", endTime: "17:00", isAvailable: true };
   const validAvailability = [
-    { dayOfWeek: 'MONDAY', slots: [validSlot] },
-    { dayOfWeek: 'TUESDAY', slots: [validSlot] }
+    { dayOfWeek: "MONDAY", slots: [validSlot] },
+    { dayOfWeek: "TUESDAY", slots: [validSlot] },
   ];
 
   // Helper to create mock Mongoose documents
   const createMockDoc = (data: any) => ({
     ...data,
-    _id: 'doc_id_123',
+    _id: "doc_id_123",
     createdAt: new Date(),
     updatedAt: new Date(),
-    toObject: jest.fn().mockReturnValue({ ...data, _id: 'doc_id_123' }),
+    toObject: jest.fn().mockReturnValue({ ...data, _id: "doc_id_123" }),
   });
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  describe('Validation Helpers (via Public Methods)', () => {
-
+  describe("Validation Helpers (via Public Methods)", () => {
     // Testing requireUserId via getByUserId
-    it('should throw if userId is not a string', async () => {
-      await expect(BaseAvailabilityService.getByUserId(123)).rejects.toThrow('User id is required.');
+    it("should throw if userId is not a string", async () => {
+      await expect(BaseAvailabilityService.getByUserId(123)).rejects.toThrow(
+        "User id is required.",
+      );
     });
 
-    it('should throw if userId contains query operators ($)', async () => {
-      await expect(BaseAvailabilityService.getByUserId('user$id')).rejects.toThrow('Invalid character in User id.');
+    it("should throw if userId contains query operators ($)", async () => {
+      await expect(
+        BaseAvailabilityService.getByUserId("user$id"),
+      ).rejects.toThrow("Invalid character in User id.");
     });
 
-    it('should throw if userId has invalid format', async () => {
-      await expect(BaseAvailabilityService.getByUserId('user id')).rejects.toThrow('Invalid user id format.'); // spaces not allowed
+    it("should throw if userId has invalid format", async () => {
+      await expect(
+        BaseAvailabilityService.getByUserId("user id"),
+      ).rejects.toThrow("Invalid user id format."); // spaces not allowed
     });
 
     // Testing payload validation via create()
-    it('create: should throw if payload.availability is not an array', async () => {
-      await expect(BaseAvailabilityService.create({ userId: mockUserId, availability: {} }))
-        .rejects.toThrow('Availability must be an array.');
+    it("create: should throw if payload.availability is not an array", async () => {
+      await expect(
+        BaseAvailabilityService.create({
+          userId: mockUserId,
+          availability: {},
+        }),
+      ).rejects.toThrow("Availability must be an array.");
     });
 
-    it('create: should throw if payload.availability is empty', async () => {
-      await expect(BaseAvailabilityService.create({ userId: mockUserId, availability: [] }))
-        .rejects.toThrow('Availability cannot be empty.');
+    it("create: should throw if payload.availability is empty", async () => {
+      await expect(
+        BaseAvailabilityService.create({
+          userId: mockUserId,
+          availability: [],
+        }),
+      ).rejects.toThrow("Availability cannot be empty.");
     });
 
     // Testing deep slot validation via create()
-    it('create: should throw if a slot item is not an object', async () => {
-      const payload = { userId: mockUserId, availability: [{ dayOfWeek: 'MONDAY', slots: ['string'] }] };
-      await expect(BaseAvailabilityService.create(payload)).rejects.toThrow('Slot[0] must be an object.');
+    it("create: should throw if a slot item is not an object", async () => {
+      const payload = {
+        userId: mockUserId,
+        availability: [{ dayOfWeek: "MONDAY", slots: ["string"] }],
+      };
+      await expect(BaseAvailabilityService.create(payload)).rejects.toThrow(
+        "Slot[0] must be an object.",
+      );
     });
 
-    it('create: should throw if slot time is invalid format', async () => {
-      const payload = { userId: mockUserId, availability: [{ dayOfWeek: 'MONDAY', slots: [{ startTime: '25:00', endTime: '10:00' }] }] };
-      await expect(BaseAvailabilityService.create(payload)).rejects.toThrow('Slot[0] times must be in HH:MM format.');
+    it("create: should throw if slot time is invalid format", async () => {
+      const payload = {
+        userId: mockUserId,
+        availability: [
+          {
+            dayOfWeek: "MONDAY",
+            slots: [{ startTime: "25:00", endTime: "10:00" }],
+          },
+        ],
+      };
+      await expect(BaseAvailabilityService.create(payload)).rejects.toThrow(
+        "Slot[0] times must be in HH:MM format.",
+      );
     });
 
-    it('create: should throw if startTime is after endTime', async () => {
-      const payload = { userId: mockUserId, availability: [{ dayOfWeek: 'MONDAY', slots: [{ startTime: '10:00', endTime: '09:00' }] }] };
-      await expect(BaseAvailabilityService.create(payload)).rejects.toThrow('Slot[0].startTime must be before endTime.');
+    it("create: should throw if startTime is after endTime", async () => {
+      const payload = {
+        userId: mockUserId,
+        availability: [
+          {
+            dayOfWeek: "MONDAY",
+            slots: [{ startTime: "10:00", endTime: "09:00" }],
+          },
+        ],
+      };
+      await expect(BaseAvailabilityService.create(payload)).rejects.toThrow(
+        "Slot[0].startTime must be before endTime.",
+      );
     });
 
-    it('create: should throw if isAvailable is not boolean', async () => {
-        const payload = { userId: mockUserId, availability: [{ dayOfWeek: 'MONDAY', slots: [{ startTime: '09:00', endTime: '10:00', isAvailable: 'yes' }] }] };
-        await expect(BaseAvailabilityService.create(payload)).rejects.toThrow('Slot[0].isAvailable must be a boolean.');
+    it("create: should throw if isAvailable is not boolean", async () => {
+      const payload = {
+        userId: mockUserId,
+        availability: [
+          {
+            dayOfWeek: "MONDAY",
+            slots: [
+              { startTime: "09:00", endTime: "10:00", isAvailable: "yes" },
+            ],
+          },
+        ],
+      };
+      await expect(BaseAvailabilityService.create(payload)).rejects.toThrow(
+        "Slot[0].isAvailable must be a boolean.",
+      );
     });
 
-    it('create: should default isAvailable to true if missing', async () => {
-        const payload = { userId: mockUserId, availability: [{ dayOfWeek: 'MONDAY', slots: [{ startTime: '09:00', endTime: '10:00' }] }] };
-        (BaseAvailabilityModel.findOne as jest.Mock).mockResolvedValue(null);
-        (BaseAvailabilityModel.insertMany as jest.Mock).mockResolvedValue([createMockDoc({ ...payload.availability[0], userId: mockUserId, slots: [{ ...payload.availability[0].slots[0], isAvailable: true }] })]);
+    it("create: should default isAvailable to true if missing", async () => {
+      const payload = {
+        userId: mockUserId,
+        availability: [
+          {
+            dayOfWeek: "MONDAY",
+            slots: [{ startTime: "09:00", endTime: "10:00" }],
+          },
+        ],
+      };
+      (BaseAvailabilityModel.findOne as jest.Mock).mockResolvedValue(null);
+      (BaseAvailabilityModel.insertMany as jest.Mock).mockResolvedValue([
+        createMockDoc({
+          ...payload.availability[0],
+          userId: mockUserId,
+          slots: [{ ...payload.availability[0].slots[0], isAvailable: true }],
+        }),
+      ]);
 
-        const result = await BaseAvailabilityService.create(payload);
-        expect(result[0].slots[0].isAvailable).toBe(true);
+      const result = await BaseAvailabilityService.create(payload);
+      expect(result[0].slots[0].isAvailable).toBe(true);
     });
 
     // Testing availability entry validation
-    it('create: should throw if dayOfWeek is missing', async () => {
-        const payload = { userId: mockUserId, availability: [{ slots: [] }] };
-        await expect(BaseAvailabilityService.create(payload)).rejects.toThrow('Availability[0].dayOfWeek is required.');
+    it("create: should throw if dayOfWeek is missing", async () => {
+      const payload = { userId: mockUserId, availability: [{ slots: [] }] };
+      await expect(BaseAvailabilityService.create(payload)).rejects.toThrow(
+        "Availability[0].dayOfWeek is required.",
+      );
     });
 
-    it('create: should throw if dayOfWeek is invalid enum', async () => {
-        const payload = { userId: mockUserId, availability: [{ dayOfWeek: 'FUNDAY', slots: [] }] };
-        await expect(BaseAvailabilityService.create(payload)).rejects.toThrow('Availability[0].dayOfWeek must be one of');
+    it("create: should throw if dayOfWeek is invalid enum", async () => {
+      const payload = {
+        userId: mockUserId,
+        availability: [{ dayOfWeek: "FUNDAY", slots: [] }],
+      };
+      await expect(BaseAvailabilityService.create(payload)).rejects.toThrow(
+        "Availability[0].dayOfWeek must be one of",
+      );
     });
 
-    it('create: should throw if slots is not an array', async () => {
-        const payload = { userId: mockUserId, availability: [{ dayOfWeek: 'MONDAY', slots: 'invalid' }] };
-        await expect(BaseAvailabilityService.create(payload)).rejects.toThrow('Availability[0].slots must be an array.');
+    it("create: should throw if slots is not an array", async () => {
+      const payload = {
+        userId: mockUserId,
+        availability: [{ dayOfWeek: "MONDAY", slots: "invalid" }],
+      };
+      await expect(BaseAvailabilityService.create(payload)).rejects.toThrow(
+        "Availability[0].slots must be an array.",
+      );
     });
 
-    it('create: should throw if slots array is empty', async () => {
-        const payload = { userId: mockUserId, availability: [{ dayOfWeek: 'MONDAY', slots: [] }] };
-        await expect(BaseAvailabilityService.create(payload)).rejects.toThrow('Availability[0] must contain at least one slot.');
+    it("create: should throw if slots array is empty", async () => {
+      const payload = {
+        userId: mockUserId,
+        availability: [{ dayOfWeek: "MONDAY", slots: [] }],
+      };
+      await expect(BaseAvailabilityService.create(payload)).rejects.toThrow(
+        "Availability[0] must contain at least one slot.",
+      );
     });
   });
 
-  describe('create', () => {
-    it('should create new availability if user does not exist', async () => {
+  describe("create", () => {
+    it("should create new availability if user does not exist", async () => {
       (BaseAvailabilityModel.findOne as jest.Mock).mockResolvedValue(null);
       (BaseAvailabilityModel.insertMany as jest.Mock).mockResolvedValue(
-        validAvailability.map(a => createMockDoc({ ...a, userId: mockUserId }))
+        validAvailability.map((a) =>
+          createMockDoc({ ...a, userId: mockUserId }),
+        ),
       );
 
-      const result = await BaseAvailabilityService.create({ userId: mockUserId, availability: validAvailability });
+      const result = await BaseAvailabilityService.create({
+        userId: mockUserId,
+        availability: validAvailability,
+      });
 
-      expect(BaseAvailabilityModel.findOne).toHaveBeenCalledWith({ userId: mockUserId }, null, { sanitizeFilter: true });
+      expect(BaseAvailabilityModel.findOne).toHaveBeenCalledWith(
+        { userId: mockUserId },
+        null,
+        { sanitizeFilter: true },
+      );
       expect(BaseAvailabilityModel.insertMany).toHaveBeenCalled();
       expect(result).toHaveLength(2);
-      expect(result[0].dayOfWeek).toBe('MONDAY');
+      expect(result[0].dayOfWeek).toBe("MONDAY");
     });
 
-    it('should throw 409 if availability already exists', async () => {
-      (BaseAvailabilityModel.findOne as jest.Mock).mockResolvedValue({ _id: 'existing' });
+    it("should throw 409 if availability already exists", async () => {
+      (BaseAvailabilityModel.findOne as jest.Mock).mockResolvedValue({
+        _id: "existing",
+      });
 
-      await expect(BaseAvailabilityService.create({ userId: mockUserId, availability: validAvailability }))
-        .rejects.toThrow('Base availability already exists for this user.');
+      await expect(
+        BaseAvailabilityService.create({
+          userId: mockUserId,
+          availability: validAvailability,
+        }),
+      ).rejects.toThrow("Base availability already exists for this user.");
     });
   });
 
-  describe('update', () => {
-    it('should delete old and insert new availability', async () => {
+  describe("update", () => {
+    it("should delete old and insert new availability", async () => {
       // Mock insertMany return
       (BaseAvailabilityModel.insertMany as jest.Mock).mockResolvedValue(
-        validAvailability.map(a => createMockDoc({ ...a, userId: mockUserId }))
+        validAvailability.map((a) =>
+          createMockDoc({ ...a, userId: mockUserId }),
+        ),
       );
 
-      const result = await BaseAvailabilityService.update(mockUserId, { availability: validAvailability });
+      const result = await BaseAvailabilityService.update(mockUserId, {
+        availability: validAvailability,
+      });
 
-      expect(BaseAvailabilityModel.deleteMany).toHaveBeenCalledWith({ userId: mockUserId });
+      expect(BaseAvailabilityModel.deleteMany).toHaveBeenCalledWith({
+        userId: mockUserId,
+      });
       expect(BaseAvailabilityModel.insertMany).toHaveBeenCalled();
       expect(result).toHaveLength(2);
     });
 
-    it('should throw validation error if userId is invalid during update', async () => {
-        await expect(BaseAvailabilityService.update('', { availability: [] }))
-            .rejects.toThrow('User id cannot be empty.');
+    it("should throw validation error if userId is invalid during update", async () => {
+      await expect(
+        BaseAvailabilityService.update("", { availability: [] }),
+      ).rejects.toThrow("User id cannot be empty.");
     });
   });
 
-  describe('getByUserId', () => {
-    it('should return availability sorted by day order', async () => {
+  describe("getByUserId", () => {
+    it("should return availability sorted by day order", async () => {
       const unsortedDocs = [
-        createMockDoc({ dayOfWeek: 'WEDNESDAY', slots: [] }),
-        createMockDoc({ dayOfWeek: 'MONDAY', slots: [] })
+        createMockDoc({ dayOfWeek: "WEDNESDAY", slots: [] }),
+        createMockDoc({ dayOfWeek: "MONDAY", slots: [] }),
       ];
 
       // Mock finding docs. Note: Service manually sorts using `sortByDayOrder` AFTER DB sort?
@@ -160,84 +263,94 @@ describe('BaseAvailabilityService', () => {
       // However, `create` and `update` use `sortByDayOrder`.
 
       const mockFindChain = {
-          sort: jest.fn().mockResolvedValue(unsortedDocs)
+        sort: jest.fn().mockResolvedValue(unsortedDocs),
       };
       (BaseAvailabilityModel.find as jest.Mock).mockReturnValue(mockFindChain);
 
       const result = await BaseAvailabilityService.getByUserId(mockUserId);
 
-      expect(BaseAvailabilityModel.find).toHaveBeenCalledWith({ userId: mockUserId });
+      expect(BaseAvailabilityModel.find).toHaveBeenCalledWith({
+        userId: mockUserId,
+      });
       expect(result).toHaveLength(2);
     });
   });
 
-  describe('Internal Utilities (Coverage for pruneUndefined & buildDomainAvailability)', () => {
-      // We can trigger `pruneUndefined` logic by passing objects with undefined fields in `toObject` mock
-      it('should prune undefined values from domain object', async () => {
-          (BaseAvailabilityModel.findOne as jest.Mock).mockResolvedValue(null);
+  describe("Internal Utilities (Coverage for pruneUndefined & buildDomainAvailability)", () => {
+    // We can trigger `pruneUndefined` logic by passing objects with undefined fields in `toObject` mock
+    it("should prune undefined values from domain object", async () => {
+      (BaseAvailabilityModel.findOne as jest.Mock).mockResolvedValue(null);
 
-          const mockDocWithUndefined = {
-              userId: mockUserId,
-              dayOfWeek: 'MONDAY',
-              slots: undefined, // Should be pruned if logic hits array branch? No, slots is array usually.
-              extra: undefined,
-              nested: { val: undefined, keep: 1 },
-              list: [undefined, 1]
-          };
+      const mockDocWithUndefined = {
+        userId: mockUserId,
+        dayOfWeek: "MONDAY",
+        slots: undefined, // Should be pruned if logic hits array branch? No, slots is array usually.
+        extra: undefined,
+        nested: { val: undefined, keep: 1 },
+        list: [undefined, 1],
+      };
 
-          const doc = {
-              ...createMockDoc({}),
-              toObject: jest.fn().mockReturnValue(mockDocWithUndefined)
-          };
+      const doc = {
+        ...createMockDoc({}),
+        toObject: jest.fn().mockReturnValue(mockDocWithUndefined),
+      };
 
-          (BaseAvailabilityModel.insertMany as jest.Mock).mockResolvedValue([doc]);
+      (BaseAvailabilityModel.insertMany as jest.Mock).mockResolvedValue([doc]);
 
-          const result = await BaseAvailabilityService.create({
-              userId: mockUserId,
-              availability: [{ dayOfWeek: 'MONDAY', slots: [validSlot] }]
-          });
-
-          // Verify pruning logic via the result of buildDomainAvailability called inside create
-          // Although buildDomainAvailability maps specific fields, `pruneUndefined` is recursive.
-          // Since strict typing usually prevents random fields, we trust the function coverage from normal execution.
-          // But to be sure, let's test specific prune branches if possible.
-
-          // Actually, `buildDomainAvailability` calls `pruneUndefined` on the constructed object.
-          // The constructed object has known keys.
-          expect(result[0]).toBeDefined();
+      const result = await BaseAvailabilityService.create({
+        userId: mockUserId,
+        availability: [{ dayOfWeek: "MONDAY", slots: [validSlot] }],
       });
 
-      // Explicitly testing `pruneUndefined` recursion via a manipulated test if needed,
-      // but standard flows cover standard objects.
-      // Let's ensure Array pruning is covered.
-      it('should handle Date objects in pruneUndefined', async () => {
-          // Date objects are preserved
-          const doc = createMockDoc({ dayOfWeek: 'MONDAY', slots: [] });
-          // Force toObject to return Date in a field (e.g. createdAt is already there)
-          (BaseAvailabilityModel.insertMany as jest.Mock).mockResolvedValue([doc]);
+      // Verify pruning logic via the result of buildDomainAvailability called inside create
+      // Although buildDomainAvailability maps specific fields, `pruneUndefined` is recursive.
+      // Since strict typing usually prevents random fields, we trust the function coverage from normal execution.
+      // But to be sure, let's test specific prune branches if possible.
 
-          const result = await BaseAvailabilityService.create({ userId: mockUserId, availability: validAvailability });
-          expect(result[0].createdAt).toBeInstanceOf(Date);
+      // Actually, `buildDomainAvailability` calls `pruneUndefined` on the constructed object.
+      // The constructed object has known keys.
+      expect(result[0]).toBeDefined();
+    });
+
+    // Explicitly testing `pruneUndefined` recursion via a manipulated test if needed,
+    // but standard flows cover standard objects.
+    // Let's ensure Array pruning is covered.
+    it("should handle Date objects in pruneUndefined", async () => {
+      // Date objects are preserved
+      const doc = createMockDoc({ dayOfWeek: "MONDAY", slots: [] });
+      // Force toObject to return Date in a field (e.g. createdAt is already there)
+      (BaseAvailabilityModel.insertMany as jest.Mock).mockResolvedValue([doc]);
+
+      const result = await BaseAvailabilityService.create({
+        userId: mockUserId,
+        availability: validAvailability,
       });
+      expect(result[0].createdAt).toBeInstanceOf(Date);
+    });
   });
 
-  describe('Sorting Logic (sortByDayOrder)', () => {
-      // This is used in Create and Update
-      it('should sort days correctly (Monday -> Sunday)', async () => {
-          const inputDocs = [
-              createMockDoc({ dayOfWeek: 'SUNDAY', slots: [] }),
-              createMockDoc({ dayOfWeek: 'TUESDAY', slots: [] }),
-              createMockDoc({ dayOfWeek: 'MONDAY', slots: [] })
-          ];
+  describe("Sorting Logic (sortByDayOrder)", () => {
+    // This is used in Create and Update
+    it("should sort days correctly (Monday -> Sunday)", async () => {
+      const inputDocs = [
+        createMockDoc({ dayOfWeek: "SUNDAY", slots: [] }),
+        createMockDoc({ dayOfWeek: "TUESDAY", slots: [] }),
+        createMockDoc({ dayOfWeek: "MONDAY", slots: [] }),
+      ];
 
-          (BaseAvailabilityModel.findOne as jest.Mock).mockResolvedValue(null);
-          (BaseAvailabilityModel.insertMany as jest.Mock).mockResolvedValue(inputDocs);
+      (BaseAvailabilityModel.findOne as jest.Mock).mockResolvedValue(null);
+      (BaseAvailabilityModel.insertMany as jest.Mock).mockResolvedValue(
+        inputDocs,
+      );
 
-          const result = await BaseAvailabilityService.create({ userId: mockUserId, availability: validAvailability });
-
-          expect(result[0].dayOfWeek).toBe('MONDAY');
-          expect(result[1].dayOfWeek).toBe('TUESDAY');
-          expect(result[2].dayOfWeek).toBe('SUNDAY');
+      const result = await BaseAvailabilityService.create({
+        userId: mockUserId,
+        availability: validAvailability,
       });
+
+      expect(result[0].dayOfWeek).toBe("MONDAY");
+      expect(result[1].dayOfWeek).toBe("TUESDAY");
+      expect(result[2].dayOfWeek).toBe("SUNDAY");
+    });
   });
 });

--- a/apps/backend/test/services/companion-organisation.service.test.ts
+++ b/apps/backend/test/services/companion-organisation.service.test.ts
@@ -1,21 +1,21 @@
-import { Types } from 'mongoose';
-import { CompanionOrganisationService } from '../../src/services/companion-organisation.service';
-import CompanionOrganisationModel from '../../src/models/companion-organisation';
-import ParentCompanionModel from '../../src/models/parent-companion';
-import CompanionModel from '../../src/models/companion';
-import { ParentModel } from '../../src/models/parent';
-import { toFHIR as toFHIRCompanion } from '../../src/services/companion.service';
-import { toFHIR as toFHIRParent } from '../../src/services/parent.service';
+import { Types } from "mongoose";
+import { CompanionOrganisationService } from "../../src/services/companion-organisation.service";
+import CompanionOrganisationModel from "../../src/models/companion-organisation";
+import ParentCompanionModel from "../../src/models/parent-companion";
+import CompanionModel from "../../src/models/companion";
+import { ParentModel } from "../../src/models/parent";
+import { toFHIR as toFHIRCompanion } from "../../src/services/companion.service";
+import { toFHIR as toFHIRParent } from "../../src/services/parent.service";
 
 // --- Mocks ---
-jest.mock('../../src/models/companion-organisation');
-jest.mock('../../src/models/parent-companion');
-jest.mock('../../src/models/companion');
-jest.mock('../../src/models/parent');
-jest.mock('../../src/services/companion.service');
-jest.mock('../../src/services/parent.service');
+jest.mock("../../src/models/companion-organisation");
+jest.mock("../../src/models/parent-companion");
+jest.mock("../../src/models/companion");
+jest.mock("../../src/models/parent");
+jest.mock("../../src/services/companion.service");
+jest.mock("../../src/services/parent.service");
 
-describe('CompanionOrganisationService', () => {
+describe("CompanionOrganisationService", () => {
   const validObjectId = new Types.ObjectId().toString();
   const validParentId = new Types.ObjectId();
   const validCompanionId = new Types.ObjectId();
@@ -32,336 +32,443 @@ describe('CompanionOrganisationService', () => {
     jest.clearAllMocks();
   });
 
-  describe('Validation (ensureObjectId)', () => {
-    it('should throw if ID is invalid string', async () => {
-      await expect(CompanionOrganisationService.linkByParent({
-        parentId: 'invalid',
-        companionId: validCompanionId,
-        organisationId: validOrgId,
-        organisationType: 'HOSPITAL'
-      })).rejects.toThrow('Invalid parentId');
-    });
-
-    it('should throw if ID contains injection chars ($)', async () => {
-        await expect(CompanionOrganisationService.linkByParent({
-          parentId: '$invalid',
+  describe("Validation (ensureObjectId)", () => {
+    it("should throw if ID is invalid string", async () => {
+      await expect(
+        CompanionOrganisationService.linkByParent({
+          parentId: "invalid",
           companionId: validCompanionId,
           organisationId: validOrgId,
-          organisationType: 'HOSPITAL'
-        })).rejects.toThrow('Invalid parentId');
+          organisationType: "HOSPITAL",
+        }),
+      ).rejects.toThrow("Invalid parentId");
     });
 
-    it('should throw if ID is not a string or ObjectId', async () => {
-        // @ts-ignore
-        await expect(CompanionOrganisationService.linkByParent({ parentId: 123 }))
-            .rejects.toThrow('Invalid parentId');
+    it("should throw if ID contains injection chars ($)", async () => {
+      await expect(
+        CompanionOrganisationService.linkByParent({
+          parentId: "$invalid",
+          companionId: validCompanionId,
+          organisationId: validOrgId,
+          organisationType: "HOSPITAL",
+        }),
+      ).rejects.toThrow("Invalid parentId");
+    });
+
+    it("should throw if ID is not a string or ObjectId", async () => {
+      await expect(
+        CompanionOrganisationService.linkByParent({
+          parentId: 123 as unknown as Types.ObjectId,
+          companionId: validCompanionId,
+          organisationId: validOrgId,
+          organisationType: "HOSPITAL",
+        }),
+      ).rejects.toThrow("Invalid parentId");
     });
   });
 
-  describe('linkByParent', () => {
-    it('should return existing active link if found', async () => {
-      const existing = { _id: '1', status: 'ACTIVE' };
-      (CompanionOrganisationModel.findOne as jest.Mock).mockResolvedValue(existing);
+  describe("linkByParent", () => {
+    it("should return existing active link if found", async () => {
+      const existing = { _id: "1", status: "ACTIVE" };
+      (CompanionOrganisationModel.findOne as jest.Mock).mockResolvedValue(
+        existing,
+      );
 
       const result = await CompanionOrganisationService.linkByParent({
         parentId: validParentId,
         companionId: validCompanionId,
         organisationId: validOrgId,
-        organisationType: 'HOSPITAL'
+        organisationType: "HOSPITAL",
       });
 
       expect(result).toEqual(existing);
       expect(CompanionOrganisationModel.create).not.toHaveBeenCalled();
     });
 
-    it('should create new link if not found', async () => {
+    it("should create new link if not found", async () => {
       (CompanionOrganisationModel.findOne as jest.Mock).mockResolvedValue(null);
-      (CompanionOrganisationModel.create as jest.Mock).mockResolvedValue({ _id: 'new' });
+      (CompanionOrganisationModel.create as jest.Mock).mockResolvedValue({
+        _id: "new",
+      });
 
       const result = await CompanionOrganisationService.linkByParent({
         parentId: validParentId,
         companionId: validCompanionId,
         organisationId: validOrgId,
-        organisationType: 'HOSPITAL'
+        organisationType: "HOSPITAL",
       });
 
-      expect(CompanionOrganisationModel.create).toHaveBeenCalledWith(expect.objectContaining({
-        status: 'ACTIVE',
-        role: 'ORGANISATION'
-      }));
-      expect(result).toEqual({ _id: 'new' });
+      expect(CompanionOrganisationModel.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: "ACTIVE",
+          role: "ORGANISATION",
+        }),
+      );
+      expect(result).toEqual({ _id: "new" });
     });
   });
 
-  describe('linkByPmsUser', () => {
-    it('should return existing link', async () => {
-      (CompanionOrganisationModel.findOne as jest.Mock).mockResolvedValue({ _id: '1' });
-      const res = await CompanionOrganisationService.linkByPmsUser({
-          pmsUserId: 'pms1',
-          companionId: validCompanionId,
-          organisationId: validOrgId,
-          organisationType: 'HOSPITAL'
+  describe("linkByPmsUser", () => {
+    it("should return existing link", async () => {
+      (CompanionOrganisationModel.findOne as jest.Mock).mockResolvedValue({
+        _id: "1",
       });
-      expect(res._id).toBe('1');
-    });
-
-    it('should create pending link if new', async () => {
-      (CompanionOrganisationModel.findOne as jest.Mock).mockResolvedValue(null);
-      (CompanionOrganisationModel.create as jest.Mock).mockResolvedValue({ _id: 'new', status: 'PENDING' });
-
       const res = await CompanionOrganisationService.linkByPmsUser({
-        pmsUserId: 'pms1',
+        pmsUserId: "pms1",
         companionId: validCompanionId,
         organisationId: validOrgId,
-        organisationType: 'HOSPITAL'
+        organisationType: "HOSPITAL",
+      });
+      expect(res._id).toBe("1");
+    });
+
+    it("should create pending link if new", async () => {
+      (CompanionOrganisationModel.findOne as jest.Mock).mockResolvedValue(null);
+      (CompanionOrganisationModel.create as jest.Mock).mockResolvedValue({
+        _id: "new",
+        status: "PENDING",
       });
 
-      expect(res.status).toBe('PENDING');
+      const res = await CompanionOrganisationService.linkByPmsUser({
+        pmsUserId: "pms1",
+        companionId: validCompanionId,
+        organisationId: validOrgId,
+        organisationType: "HOSPITAL",
+      });
+
+      expect(res.status).toBe("PENDING");
     });
   });
 
-  describe('sendInvite', () => {
-    it('should throw if neither email nor name provided', async () => {
-      await expect(CompanionOrganisationService.sendInvite({
-        parentId: validParentId,
-        companionId: validCompanionId,
-        organisationType: 'HOSPITAL'
-      })).rejects.toThrow('Email required or Name');
+  describe("sendInvite", () => {
+    it("should throw if neither email nor name provided", async () => {
+      await expect(
+        CompanionOrganisationService.sendInvite({
+          parentId: validParentId,
+          companionId: validCompanionId,
+          organisationType: "HOSPITAL",
+        }),
+      ).rejects.toThrow("Email required or Name");
     });
 
-    it('should create invite', async () => {
-      (CompanionOrganisationModel.create as jest.Mock).mockResolvedValue({ inviteToken: 'uuid' });
+    it("should create invite", async () => {
+      (CompanionOrganisationModel.create as jest.Mock).mockResolvedValue({
+        inviteToken: "uuid",
+      });
 
       const res = await CompanionOrganisationService.sendInvite({
         parentId: validParentId,
         companionId: validCompanionId,
-        organisationType: 'HOSPITAL',
-        email: 'test@example.com'
+        organisationType: "HOSPITAL",
+        email: "test@example.com",
       });
 
       expect(res.inviteToken).toBeDefined();
     });
   });
 
-  describe('validateInvite', () => {
-    it('should throw if token missing', async () => {
-      await expect(CompanionOrganisationService.validateInvite('')).rejects.toThrow('Invite token missing');
+  describe("validateInvite", () => {
+    it("should throw if token missing", async () => {
+      await expect(
+        CompanionOrganisationService.validateInvite(""),
+      ).rejects.toThrow("Invite token missing");
     });
 
-    it('should return invite if valid', async () => {
-      (CompanionOrganisationModel.findOne as jest.Mock).mockResolvedValue({ _id: '1' });
-      const res = await CompanionOrganisationService.validateInvite('token');
+    it("should return invite if valid", async () => {
+      (CompanionOrganisationModel.findOne as jest.Mock).mockResolvedValue({
+        _id: "1",
+      });
+      const res = await CompanionOrganisationService.validateInvite("token");
       expect(res).toBeDefined();
     });
 
-    it('should throw 404 if invalid', async () => {
+    it("should throw 404 if invalid", async () => {
       (CompanionOrganisationModel.findOne as jest.Mock).mockResolvedValue(null);
-      await expect(CompanionOrganisationService.validateInvite('token')).rejects.toThrow('Invalid or expired invite');
+      await expect(
+        CompanionOrganisationService.validateInvite("token"),
+      ).rejects.toThrow("Invalid or expired invite");
     });
   });
 
-  describe('acceptInvite', () => {
-    it('should activate invite', async () => {
-      const invite = createMockDoc({ status: 'PENDING' });
-      (CompanionOrganisationModel.findOne as jest.Mock).mockResolvedValue(invite);
+  describe("acceptInvite", () => {
+    it("should activate invite", async () => {
+      const invite = createMockDoc({ status: "PENDING" });
+      (CompanionOrganisationModel.findOne as jest.Mock).mockResolvedValue(
+        invite,
+      );
 
-      await CompanionOrganisationService.acceptInvite({ token: 't', organisationId: validOrgId });
+      await CompanionOrganisationService.acceptInvite({
+        token: "t",
+        organisationId: validOrgId,
+      });
 
-      expect(invite.status).toBe('ACTIVE');
+      expect(invite.status).toBe("ACTIVE");
       expect(invite.save).toHaveBeenCalled();
     });
 
-    it('should throw 404 if invite not found', async () => {
+    it("should throw 404 if invite not found", async () => {
       (CompanionOrganisationModel.findOne as jest.Mock).mockResolvedValue(null);
-      await expect(CompanionOrganisationService.acceptInvite({ token: 't', organisationId: validOrgId }))
-        .rejects.toThrow('Invalid invite token');
+      await expect(
+        CompanionOrganisationService.acceptInvite({
+          token: "t",
+          organisationId: validOrgId,
+        }),
+      ).rejects.toThrow("Invalid invite token");
     });
   });
 
-  describe('rejectInvite', () => {
-    it('should revoke invite', async () => {
-      const invite = createMockDoc({ status: 'PENDING' });
-      (CompanionOrganisationModel.findOne as jest.Mock).mockResolvedValue(invite);
+  describe("rejectInvite", () => {
+    it("should revoke invite", async () => {
+      const invite = createMockDoc({ status: "PENDING" });
+      (CompanionOrganisationModel.findOne as jest.Mock).mockResolvedValue(
+        invite,
+      );
 
-      await CompanionOrganisationService.rejectInvite({ token: 't', organisationId: validOrgId });
+      await CompanionOrganisationService.rejectInvite({
+        token: "t",
+        organisationId: validOrgId,
+      });
 
-      expect(invite.status).toBe('REVOKED');
+      expect(invite.status).toBe("REVOKED");
       expect(invite.save).toHaveBeenCalled();
     });
 
-    it('should throw 404 if invite not found', async () => {
+    it("should throw 404 if invite not found", async () => {
       (CompanionOrganisationModel.findOne as jest.Mock).mockResolvedValue(null);
-      await expect(CompanionOrganisationService.rejectInvite({ token: 't', organisationId: validOrgId }))
-        .rejects.toThrow('Invalid invite token');
+      await expect(
+        CompanionOrganisationService.rejectInvite({
+          token: "t",
+          organisationId: validOrgId,
+        }),
+      ).rejects.toThrow("Invalid invite token");
     });
   });
 
-  describe('Helpers (linkOn...)', () => {
-    it('linkOnCompanionCreatedByPms should call linkByPmsUser', async () => {
-        const spy = jest.spyOn(CompanionOrganisationService, 'linkByPmsUser').mockResolvedValue({} as any);
-        await CompanionOrganisationService.linkOnCompanionCreatedByPms({
-            companionId: validCompanionId,
-            organisationId: validOrgId,
-            pmsUserId: 'u1',
-            organisationType: 'HOSPITAL'
-        });
-        expect(spy).toHaveBeenCalled();
+  describe("Helpers (linkOn...)", () => {
+    it("linkOnCompanionCreatedByPms should call linkByPmsUser", async () => {
+      const spy = jest
+        .spyOn(CompanionOrganisationService, "linkByPmsUser")
+        .mockResolvedValue({} as any);
+      await CompanionOrganisationService.linkOnCompanionCreatedByPms({
+        companionId: validCompanionId,
+        organisationId: validOrgId,
+        pmsUserId: "u1",
+        organisationType: "HOSPITAL",
+      });
+      expect(spy).toHaveBeenCalled();
     });
 
-    it('linkOnAppointmentBooked should create active link if not exists', async () => {
-        (CompanionOrganisationModel.findOne as jest.Mock).mockResolvedValue(null);
-        (CompanionOrganisationModel.create as jest.Mock).mockResolvedValue({ status: 'ACTIVE' });
+    it("linkOnAppointmentBooked should create active link if not exists", async () => {
+      (CompanionOrganisationModel.findOne as jest.Mock).mockResolvedValue(null);
+      (CompanionOrganisationModel.create as jest.Mock).mockResolvedValue({
+        status: "ACTIVE",
+      });
 
-        const res = await CompanionOrganisationService.linkOnAppointmentBooked({
-            companionId: validCompanionId,
-            organisationId: validOrgId,
-            organisationType: 'HOSPITAL'
-        });
-        expect(res.status).toBe('ACTIVE');
+      const res = await CompanionOrganisationService.linkOnAppointmentBooked({
+        companionId: validCompanionId,
+        organisationId: validOrgId,
+        organisationType: "HOSPITAL",
+      });
+      expect(res.status).toBe("ACTIVE");
     });
 
-    it('linkOnAppointmentBooked should return existing', async () => {
-        (CompanionOrganisationModel.findOne as jest.Mock).mockResolvedValue({ _id: 'exist' });
-        const res = await CompanionOrganisationService.linkOnAppointmentBooked({
-            companionId: validCompanionId,
-            organisationId: validOrgId,
-            organisationType: 'HOSPITAL'
-        });
-        expect(res._id).toBe('exist');
-    });
-  });
-
-  describe('revokeLink', () => {
-      it('should revoke link', async () => {
-          const deleted = { _id: validObjectId, status: 'ACTIVE' };
-          (CompanionOrganisationModel.findByIdAndDelete as jest.Mock).mockResolvedValue(deleted);
-          const res = await CompanionOrganisationService.revokeLink(validObjectId);
-          expect(res).toBe(deleted);
-          expect(CompanionOrganisationModel.findByIdAndDelete).toHaveBeenCalledWith(expect.any(Types.ObjectId));
-          const calledWithId = (CompanionOrganisationModel.findByIdAndDelete as jest.Mock).mock.calls[0][0];
-          expect(calledWithId.toString()).toBe(validObjectId);
+    it("linkOnAppointmentBooked should return existing", async () => {
+      (CompanionOrganisationModel.findOne as jest.Mock).mockResolvedValue({
+        _id: "exist",
       });
-
-      it('should throw if not found', async () => {
-          (CompanionOrganisationModel.findByIdAndDelete as jest.Mock).mockResolvedValue(null);
-          await expect(CompanionOrganisationService.revokeLink(validObjectId)).rejects.toThrow('Link not found');
+      const res = await CompanionOrganisationService.linkOnAppointmentBooked({
+        companionId: validCompanionId,
+        organisationId: validOrgId,
+        organisationType: "HOSPITAL",
       });
-  });
-
-  describe('Parent Approval (parentApproveLink / parentRejectLink)', () => {
-      it('parentApproveLink: should activate pending link', async () => {
-          const link = createMockDoc({ status: 'PENDING' });
-          (CompanionOrganisationModel.findOne as jest.Mock).mockResolvedValue(link);
-
-          await CompanionOrganisationService.parentApproveLink(validParentId, validObjectId);
-          expect(link.status).toBe('ACTIVE');
-          expect(link.linkedByParentId).toBe(validParentId);
-          expect(link.save).toHaveBeenCalled();
-      });
-
-      it('parentApproveLink: should throw if not found', async () => {
-          (CompanionOrganisationModel.findOne as jest.Mock).mockResolvedValue(null);
-          await expect(CompanionOrganisationService.parentApproveLink(validParentId, validObjectId))
-            .rejects.toThrow('Pending link not found.');
-      });
-
-      it('parentRejectLink: should revoke pending link', async () => {
-          const link = createMockDoc({ status: 'PENDING' });
-          (CompanionOrganisationModel.findOne as jest.Mock).mockResolvedValue(link);
-
-          await CompanionOrganisationService.parentRejectLink(validParentId, validObjectId);
-          expect(link.status).toBe('REVOKED');
-      });
-
-      it('parentRejectLink: should throw if not found', async () => {
-        (CompanionOrganisationModel.findOne as jest.Mock).mockResolvedValue(null);
-        await expect(CompanionOrganisationService.parentRejectLink(validParentId, validObjectId))
-          .rejects.toThrow('Pending link not found.');
+      expect(res._id).toBe("exist");
     });
   });
 
-  describe('Getters', () => {
-      it('getLinksForCompanion: should find links', async () => {
-          (CompanionOrganisationModel.find as jest.Mock).mockResolvedValue([]);
-          await CompanionOrganisationService.getLinksForCompanion(validCompanionId);
-          expect(CompanionOrganisationModel.find).toHaveBeenCalled();
+  describe("revokeLink", () => {
+    it("should revoke link", async () => {
+      const deleted = { _id: validObjectId, status: "ACTIVE" };
+      (
+        CompanionOrganisationModel.findByIdAndDelete as jest.Mock
+      ).mockResolvedValue(deleted);
+      const res = await CompanionOrganisationService.revokeLink(validObjectId);
+      expect(res).toBe(deleted);
+      expect(CompanionOrganisationModel.findByIdAndDelete).toHaveBeenCalledWith(
+        expect.any(Types.ObjectId),
+      );
+      const calledWithId = (
+        CompanionOrganisationModel.findByIdAndDelete as jest.Mock
+      ).mock.calls[0][0];
+      expect(calledWithId.toString()).toBe(validObjectId);
+    });
+
+    it("should throw if not found", async () => {
+      (
+        CompanionOrganisationModel.findByIdAndDelete as jest.Mock
+      ).mockResolvedValue(null);
+      await expect(
+        CompanionOrganisationService.revokeLink(validObjectId),
+      ).rejects.toThrow("Link not found");
+    });
+  });
+
+  describe("Parent Approval (parentApproveLink / parentRejectLink)", () => {
+    it("parentApproveLink: should activate pending link", async () => {
+      const link = createMockDoc({ status: "PENDING" });
+      (CompanionOrganisationModel.findOne as jest.Mock).mockResolvedValue(link);
+
+      await CompanionOrganisationService.parentApproveLink(
+        validParentId,
+        validObjectId,
+      );
+      expect(link.status).toBe("ACTIVE");
+      expect(link.linkedByParentId).toBe(validParentId);
+      expect(link.save).toHaveBeenCalled();
+    });
+
+    it("parentApproveLink: should throw if not found", async () => {
+      (CompanionOrganisationModel.findOne as jest.Mock).mockResolvedValue(null);
+      await expect(
+        CompanionOrganisationService.parentApproveLink(
+          validParentId,
+          validObjectId,
+        ),
+      ).rejects.toThrow("Pending link not found.");
+    });
+
+    it("parentRejectLink: should revoke pending link", async () => {
+      const link = createMockDoc({ status: "PENDING" });
+      (CompanionOrganisationModel.findOne as jest.Mock).mockResolvedValue(link);
+
+      await CompanionOrganisationService.parentRejectLink(
+        validParentId,
+        validObjectId,
+      );
+      expect(link.status).toBe("REVOKED");
+    });
+
+    it("parentRejectLink: should throw if not found", async () => {
+      (CompanionOrganisationModel.findOne as jest.Mock).mockResolvedValue(null);
+      await expect(
+        CompanionOrganisationService.parentRejectLink(
+          validParentId,
+          validObjectId,
+        ),
+      ).rejects.toThrow("Pending link not found.");
+    });
+  });
+
+  describe("Getters", () => {
+    it("getLinksForCompanion: should find links", async () => {
+      (CompanionOrganisationModel.find as jest.Mock).mockResolvedValue([]);
+      await CompanionOrganisationService.getLinksForCompanion(validCompanionId);
+      expect(CompanionOrganisationModel.find).toHaveBeenCalled();
+    });
+
+    it("getLinksForCompanionByOrganisationTye: should return enriched data", async () => {
+      // Mock Find with populate
+      const mockPopulate = jest.fn().mockReturnValue([]);
+      (CompanionOrganisationModel.find as jest.Mock).mockReturnValue({
+        populate: mockPopulate,
       });
 
-      it('getLinksForCompanionByOrganisationTye: should return enriched data', async () => {
-          // Mock Find with populate
-          const mockPopulate = jest.fn().mockReturnValue([]);
-          (CompanionOrganisationModel.find as jest.Mock).mockReturnValue({ populate: mockPopulate });
-
-          // Mock ParentCompanion, Companion, Parent lookups
-          const mockExec = jest.fn().mockResolvedValue({ parentId: validParentId });
-          (ParentCompanionModel.findOne as jest.Mock).mockReturnValue({ exec: mockExec });
-          (CompanionModel.findById as jest.Mock).mockResolvedValue({ name: 'Buddy' });
-          (ParentModel.findById as jest.Mock).mockResolvedValue({ firstName: 'John', lastName: 'Doe' });
-
-          // FIX: Pass validCompanionId.toString() to satisfy assertSafeString
-          const res = await CompanionOrganisationService.getLinksForCompanionByOrganisationTye(
-              validCompanionId.toString(),
-              'HOSPITAL'
-          );
-
-          expect(res.parentName).toBe('John Doe');
-          expect(res.companionName).toBe('Buddy');
-          expect(res.links).toEqual([]);
+      // Mock ParentCompanion, Companion, Parent lookups
+      const mockExec = jest.fn().mockResolvedValue({ parentId: validParentId });
+      (ParentCompanionModel.findOne as jest.Mock).mockReturnValue({
+        exec: mockExec,
+      });
+      (CompanionModel.findById as jest.Mock).mockResolvedValue({
+        name: "Buddy",
+      });
+      (ParentModel.findById as jest.Mock).mockResolvedValue({
+        firstName: "John",
+        lastName: "Doe",
       });
 
-      it('getLinksForOrganisation: should return mapped data', async () => {
-          // 1. Mock finding links
-          const mockLink = {
-              _id: 'link1',
-              companionId: validCompanionId,
-              organisationId: validOrgId,
-              organisationType: 'HOSPITAL',
-              status: 'ACTIVE'
-          };
-          (CompanionOrganisationModel.find as jest.Mock).mockResolvedValue([mockLink]);
+      // FIX: Pass validCompanionId.toString() to satisfy assertSafeString
+      const res =
+        await CompanionOrganisationService.getLinksForCompanionByOrganisationTye(
+          validCompanionId.toString(),
+          "HOSPITAL",
+        );
 
-          // 2. Mock Companion lookup
-          (CompanionModel.findById as jest.Mock).mockResolvedValue({ _id: validCompanionId, name: 'Dog' });
+      expect(res.parentName).toBe("John Doe");
+      expect(res.companionName).toBe("Buddy");
+      expect(res.links).toEqual([]);
+    });
 
-          // 3. Mock Parent Link lookup
-          (ParentCompanionModel.findOne as jest.Mock).mockResolvedValue({ parentId: validParentId });
+    it("getLinksForOrganisation: should return mapped data", async () => {
+      // 1. Mock finding links
+      const mockLink = {
+        _id: "link1",
+        companionId: validCompanionId,
+        organisationId: validOrgId,
+        organisationType: "HOSPITAL",
+        status: "ACTIVE",
+      };
+      (CompanionOrganisationModel.find as jest.Mock).mockResolvedValue([
+        mockLink,
+      ]);
 
-          // 4. Mock Parent lookup
-          (ParentModel.findById as jest.Mock).mockResolvedValue({ _id: validParentId, name: 'Parent' });
-
-          // 5. Mock Transformers
-          (toFHIRCompanion as jest.Mock).mockReturnValue({ id: 'c1' });
-          (toFHIRParent as jest.Mock).mockReturnValue({ id: 'p1' });
-
-          const res = await CompanionOrganisationService.getLinksForOrganisation(validOrgId);
-
-          expect(res).toHaveLength(1);
-          expect(res[0]!.companion.id).toBe('c1');
-          expect(res[0]!.parent?.id).toBe('p1');
+      // 2. Mock Companion lookup
+      (CompanionModel.findById as jest.Mock).mockResolvedValue({
+        _id: validCompanionId,
+        name: "Dog",
       });
 
-      it('getLinksForOrganisation: should filter out orphaned links (no companion)', async () => {
-          const mockLink = { companionId: validCompanionId };
-          (CompanionOrganisationModel.find as jest.Mock).mockResolvedValue([mockLink]);
-          (CompanionModel.findById as jest.Mock).mockResolvedValue(null); // Companion deleted
-
-          const res = await CompanionOrganisationService.getLinksForOrganisation(validOrgId);
-          expect(res).toHaveLength(0); // Filtered out
+      // 3. Mock Parent Link lookup
+      (ParentCompanionModel.findOne as jest.Mock).mockResolvedValue({
+        parentId: validParentId,
       });
 
-      it('getLinksForOrganisation: should handle companion with no parent (null parent)', async () => {
-        const mockLink = {
-            _id: 'link1',
-            companionId: validCompanionId,
-            status: 'ACTIVE'
-        };
-        (CompanionOrganisationModel.find as jest.Mock).mockResolvedValue([mockLink]);
-        (CompanionModel.findById as jest.Mock).mockResolvedValue({ _id: validCompanionId });
-        (ParentCompanionModel.findOne as jest.Mock).mockResolvedValue(null); // No parent link
-
-        const res = await CompanionOrganisationService.getLinksForOrganisation(validOrgId);
-        expect(res).toHaveLength(1);
-        expect(res[0]!.parent).toBeNull();
+      // 4. Mock Parent lookup
+      (ParentModel.findById as jest.Mock).mockResolvedValue({
+        _id: validParentId,
+        name: "Parent",
       });
+
+      // 5. Mock Transformers
+      (toFHIRCompanion as jest.Mock).mockReturnValue({ id: "c1" });
+      (toFHIRParent as jest.Mock).mockReturnValue({ id: "p1" });
+
+      const res =
+        await CompanionOrganisationService.getLinksForOrganisation(validOrgId);
+
+      expect(res).toHaveLength(1);
+      expect(res[0]!.companion.id).toBe("c1");
+      expect(res[0]!.parent?.id).toBe("p1");
+    });
+
+    it("getLinksForOrganisation: should filter out orphaned links (no companion)", async () => {
+      const mockLink = { companionId: validCompanionId };
+      (CompanionOrganisationModel.find as jest.Mock).mockResolvedValue([
+        mockLink,
+      ]);
+      (CompanionModel.findById as jest.Mock).mockResolvedValue(null); // Companion deleted
+
+      const res =
+        await CompanionOrganisationService.getLinksForOrganisation(validOrgId);
+      expect(res).toHaveLength(0); // Filtered out
+    });
+
+    it("getLinksForOrganisation: should handle companion with no parent (null parent)", async () => {
+      const mockLink = {
+        _id: "link1",
+        companionId: validCompanionId,
+        status: "ACTIVE",
+      };
+      (CompanionOrganisationModel.find as jest.Mock).mockResolvedValue([
+        mockLink,
+      ]);
+      (CompanionModel.findById as jest.Mock).mockResolvedValue({
+        _id: validCompanionId,
+      });
+      (ParentCompanionModel.findOne as jest.Mock).mockResolvedValue(null); // No parent link
+
+      const res =
+        await CompanionOrganisationService.getLinksForOrganisation(validOrgId);
+      expect(res).toHaveLength(1);
+      expect(res[0]!.parent).toBeNull();
+    });
   });
 });

--- a/apps/backend/test/services/companion.service.test.ts
+++ b/apps/backend/test/services/companion.service.test.ts
@@ -1,23 +1,29 @@
-import { Types } from 'mongoose';
-import { CompanionService, CompanionServiceError } from '../../src/services/companion.service';
-import CompanionModel from '../../src/models/companion';
-import CompanionOrganisationModel from '../../src/models/companion-organisation';
-import { ParentService } from '../../src/services/parent.service';
-import { ParentCompanionService, ParentCompanionServiceError } from '../../src/services/parent-companion.service';
-import * as UploadMiddleware from '../../src/middlewares/upload';
+import { Types } from "mongoose";
 import {
-  fromCompanionRequestDTO,
-} from '@yosemite-crew/types';
+  CompanionService,
+  CompanionServiceError,
+} from "../../src/services/companion.service";
+import CompanionModel from "../../src/models/companion";
+import CompanionOrganisationModel from "../../src/models/companion-organisation";
+import { ParentService } from "../../src/services/parent.service";
+import {
+  ParentCompanionService,
+  ParentCompanionServiceError,
+} from "../../src/services/parent-companion.service";
+import * as UploadMiddleware from "../../src/middlewares/upload";
+import { fromCompanionRequestDTO } from "@yosemite-crew/types";
 
 // --- Mocks ---
-jest.mock('../../src/models/companion');
-jest.mock('../../src/models/companion-organisation');
-jest.mock('../../src/services/parent.service');
-jest.mock('../../src/middlewares/upload');
+jest.mock("../../src/models/companion");
+jest.mock("../../src/models/companion-organisation");
+jest.mock("../../src/services/parent.service");
+jest.mock("../../src/middlewares/upload");
 
 // Partial Mock for ParentCompanionService to keep the Error class real
-jest.mock('../../src/services/parent-companion.service', () => {
-  const actual = jest.requireActual('../../src/services/parent-companion.service');
+jest.mock("../../src/services/parent-companion.service", () => {
+  const actual = jest.requireActual(
+    "../../src/services/parent-companion.service",
+  );
   return {
     ...actual,
     ParentCompanionService: {
@@ -30,24 +36,27 @@ jest.mock('../../src/services/parent-companion.service', () => {
 });
 
 // Mock DTO mappers
-jest.mock('@yosemite-crew/types', () => ({
+jest.mock("@yosemite-crew/types", () => ({
   fromCompanionRequestDTO: jest.fn(),
-  toCompanionResponseDTO: jest.fn((data) => ({ resourceType: 'Companion', ...data })),
+  toCompanionResponseDTO: jest.fn((data) => ({
+    resourceType: "Companion",
+    ...data,
+  })),
 }));
 
-describe('CompanionService', () => {
+describe("CompanionService", () => {
   const validObjectId = new Types.ObjectId().toString();
   const validParentId = new Types.ObjectId().toString();
   const validCompanionId = new Types.ObjectId().toString();
 
   // Base persistable object returned by fromCompanionRequestDTO
   const mockPersistableBase = {
-    name: 'Buddy',
-    type: 'DOG',
-    breed: 'Labrador',
-    dateOfBirth: '2020-01-01',
-    gender: 'MALE',
-    status: 'ACTIVE',
+    name: "Buddy",
+    type: "DOG",
+    breed: "Labrador",
+    dateOfBirth: "2020-01-01",
+    gender: "MALE",
+    status: "ACTIVE",
     photoUrl: null,
     isInsured: false,
     insurance: null,
@@ -71,307 +80,408 @@ describe('CompanionService', () => {
     jest.clearAllMocks();
   });
 
-  describe('create', () => {
-    const payload: any = { resourceType: 'Patient', name: [{ text: 'Buddy' }] };
+  describe("create", () => {
+    const payload: any = { resourceType: "Patient", name: [{ text: "Buddy" }] };
 
-    it('should throw if context is missing', async () => {
+    it("should throw if context is missing", async () => {
       await expect(CompanionService.create(payload, undefined)).rejects.toThrow(
-        'Parent context is required'
+        "Parent context is required",
       );
     });
 
-    it('should throw if parent not found for authUserId (Mobile Flow)', async () => {
+    it("should throw if parent not found for authUserId (Mobile Flow)", async () => {
       (ParentService.findByLinkedUserId as jest.Mock).mockResolvedValue(null);
 
-      await expect(CompanionService.create(payload, { authUserId: 'user123' }))
-        .rejects.toThrow('Parent record not found');
+      await expect(
+        CompanionService.create(payload, { authUserId: "user123" }),
+      ).rejects.toThrow("Parent record not found");
     });
 
-    it('should throw if parentMongoId cannot be determined', async () => {
-      await expect(CompanionService.create(payload, {}))
-        .rejects.toThrow('Unable to determine parent');
+    it("should throw if parentMongoId cannot be determined", async () => {
+      await expect(CompanionService.create(payload, {})).rejects.toThrow(
+        "Unable to determine parent",
+      );
     });
 
-    it('should successfully create companion and link to parent', async () => {
-      (fromCompanionRequestDTO as jest.Mock).mockReturnValue({ ...mockPersistableBase });
-      (ParentService.findByLinkedUserId as jest.Mock).mockResolvedValue({ _id: validParentId });
+    it("should successfully create companion and link to parent", async () => {
+      (fromCompanionRequestDTO as jest.Mock).mockReturnValue({
+        ...mockPersistableBase,
+      });
+      (ParentService.findByLinkedUserId as jest.Mock).mockResolvedValue({
+        _id: validParentId,
+      });
 
       const mockDoc = createMockDoc();
       (CompanionModel.create as jest.Mock).mockResolvedValue(mockDoc);
       (ParentCompanionService.linkParent as jest.Mock).mockResolvedValue(true);
 
-      const result = await CompanionService.create(payload, { authUserId: 'user123' });
+      const result = await CompanionService.create(payload, {
+        authUserId: "user123",
+      });
 
       expect(CompanionModel.create).toHaveBeenCalled();
       expect(ParentCompanionService.linkParent).toHaveBeenCalledWith({
         parentId: validParentId,
         companionId: mockDoc._id,
-        role: 'PRIMARY',
+        role: "PRIMARY",
       });
-      expect(result.response.name).toBe('Buddy');
+      expect(result.response.name).toBe("Buddy");
     });
 
-    it('should handle photo upload if photoUrl is present', async () => {
+    it("should handle photo upload if photoUrl is present", async () => {
       (fromCompanionRequestDTO as jest.Mock).mockReturnValue({
         ...mockPersistableBase,
-        photoUrl: 'temp/path.jpg'
+        photoUrl: "temp/path.jpg",
       });
 
-      const mockDoc = createMockDoc({ photoUrl: 'temp/path.jpg' });
+      const mockDoc = createMockDoc({ photoUrl: "temp/path.jpg" });
       (CompanionModel.create as jest.Mock).mockResolvedValue(mockDoc);
 
-      (UploadMiddleware.buildS3Key as jest.Mock).mockReturnValue('s3-key');
-      (UploadMiddleware.moveFile as jest.Mock).mockResolvedValue('https://s3.url/img.jpg');
+      (UploadMiddleware.buildS3Key as jest.Mock).mockReturnValue("s3-key");
+      (UploadMiddleware.moveFile as jest.Mock).mockResolvedValue(
+        "https://s3.url/img.jpg",
+      );
 
-      await CompanionService.create(payload, { parentMongoId: new Types.ObjectId(validParentId) });
+      await CompanionService.create(payload, {
+        parentMongoId: new Types.ObjectId(validParentId),
+      });
 
       expect(UploadMiddleware.moveFile).toHaveBeenCalled();
-      expect(mockDoc.photoUrl).toBe('https://s3.url/img.jpg');
+      expect(mockDoc.photoUrl).toBe("https://s3.url/img.jpg");
       expect(mockDoc.save).toHaveBeenCalled();
     });
 
-    it('should rollback (delete companion) if linking fails', async () => {
-      (fromCompanionRequestDTO as jest.Mock).mockReturnValue({ ...mockPersistableBase });
+    it("should rollback (delete companion) if linking fails", async () => {
+      (fromCompanionRequestDTO as jest.Mock).mockReturnValue({
+        ...mockPersistableBase,
+      });
 
       const mockDoc = createMockDoc();
       (CompanionModel.create as jest.Mock).mockResolvedValue(mockDoc);
 
       // Simulate generic error
-      (ParentCompanionService.linkParent as jest.Mock).mockRejectedValue(new Error('Link Failed'));
+      (ParentCompanionService.linkParent as jest.Mock).mockRejectedValue(
+        new Error("Link Failed"),
+      );
 
-      await expect(CompanionService.create(payload, { parentMongoId: new Types.ObjectId(validParentId) }))
-        .rejects.toThrow('Link Failed');
+      await expect(
+        CompanionService.create(payload, {
+          parentMongoId: new Types.ObjectId(validParentId),
+        }),
+      ).rejects.toThrow("Link Failed");
 
-      expect(CompanionModel.deleteOne).toHaveBeenCalledWith({ _id: mockDoc._id });
+      expect(CompanionModel.deleteOne).toHaveBeenCalledWith({
+        _id: mockDoc._id,
+      });
     });
 
-    it('should rethrow ParentCompanionServiceError correctly', async () => {
-      (fromCompanionRequestDTO as jest.Mock).mockReturnValue({ ...mockPersistableBase });
+    it("should rethrow ParentCompanionServiceError correctly", async () => {
+      (fromCompanionRequestDTO as jest.Mock).mockReturnValue({
+        ...mockPersistableBase,
+      });
       const mockDoc = createMockDoc();
       (CompanionModel.create as jest.Mock).mockResolvedValue(mockDoc);
 
       // Since we used requireActual, this error will be an instance of the real class
-      const pcError = new ParentCompanionServiceError('PC Error', 409);
-      (ParentCompanionService.linkParent as jest.Mock).mockRejectedValue(pcError);
+      const pcError = new ParentCompanionServiceError("PC Error", 409);
+      (ParentCompanionService.linkParent as jest.Mock).mockRejectedValue(
+        pcError,
+      );
 
-      await expect(CompanionService.create(payload, { parentMongoId: new Types.ObjectId(validParentId) }))
-        .rejects.toThrow('PC Error');
+      await expect(
+        CompanionService.create(payload, {
+          parentMongoId: new Types.ObjectId(validParentId),
+        }),
+      ).rejects.toThrow("PC Error");
     });
   });
 
-  describe('listByParent', () => {
-    it('should throw if parentId is invalid', async () => {
-      await expect(CompanionService.listByParent('invalid')).rejects.toThrow('Invalid Parent Document Id');
+  describe("listByParent", () => {
+    it("should throw if parentId is invalid", async () => {
+      await expect(CompanionService.listByParent("invalid")).rejects.toThrow(
+        "Invalid Parent Document Id",
+      );
     });
 
-    it('should return empty list if parent has no active companions', async () => {
-      (ParentCompanionService.getActiveCompanionIdsForParent as jest.Mock).mockResolvedValue([]);
+    it("should return empty list if parent has no active companions", async () => {
+      (
+        ParentCompanionService.getActiveCompanionIdsForParent as jest.Mock
+      ).mockResolvedValue([]);
 
       const result = await CompanionService.listByParent(validParentId);
       expect(result.responses).toEqual([]);
     });
 
-    it('should return mapped companions', async () => {
-      (ParentCompanionService.getActiveCompanionIdsForParent as jest.Mock).mockResolvedValue([validCompanionId]);
+    it("should return mapped companions", async () => {
+      (
+        ParentCompanionService.getActiveCompanionIdsForParent as jest.Mock
+      ).mockResolvedValue([validCompanionId]);
       (CompanionModel.find as jest.Mock).mockResolvedValue([createMockDoc()]);
 
       const result = await CompanionService.listByParent(validParentId);
       expect(result.responses).toHaveLength(1);
-      expect(result.responses[0].name).toBe('Buddy');
+      expect(result.responses[0].name).toBe("Buddy");
     });
   });
 
-  describe('listByParentNotInOrganisation', () => {
+  describe("listByParentNotInOrganisation", () => {
     const validOrgId = new Types.ObjectId().toString();
 
-    it('should throw if parentId is invalid', async () => {
-      await expect(CompanionService.listByParentNotInOrganisation('inv', validOrgId))
-        .rejects.toThrow('Invalid Parent Document Id');
+    it("should throw if parentId is invalid", async () => {
+      await expect(
+        CompanionService.listByParentNotInOrganisation("inv", validOrgId),
+      ).rejects.toThrow("Invalid Parent Document Id");
     });
 
-    it('should throw if organisationId is invalid', async () => {
-      await expect(CompanionService.listByParentNotInOrganisation(validParentId, 'inv'))
-        .rejects.toThrow('Invalid Organisation Document Id');
+    it("should throw if organisationId is invalid", async () => {
+      await expect(
+        CompanionService.listByParentNotInOrganisation(validParentId, "inv"),
+      ).rejects.toThrow("Invalid Organisation Document Id");
     });
 
-    it('should return empty if parent has no active companions', async () => {
-      (ParentCompanionService.getActiveCompanionIdsForParent as jest.Mock).mockResolvedValue([]);
-      const res = await CompanionService.listByParentNotInOrganisation(validParentId, validOrgId);
+    it("should return empty if parent has no active companions", async () => {
+      (
+        ParentCompanionService.getActiveCompanionIdsForParent as jest.Mock
+      ).mockResolvedValue([]);
+      const res = await CompanionService.listByParentNotInOrganisation(
+        validParentId,
+        validOrgId,
+      );
       expect(res.responses).toEqual([]);
     });
 
-    it('should filter out companions already linked to the org', async () => {
+    it("should filter out companions already linked to the org", async () => {
       const c1 = new Types.ObjectId(); // Linked
       const c2 = new Types.ObjectId(); // Unlinked
 
-      (ParentCompanionService.getActiveCompanionIdsForParent as jest.Mock).mockResolvedValue([c1, c2]);
+      (
+        ParentCompanionService.getActiveCompanionIdsForParent as jest.Mock
+      ).mockResolvedValue([c1, c2]);
 
       // Mock finding existing links
       (CompanionOrganisationModel.find as jest.Mock).mockReturnValue({
-        lean: jest.fn().mockResolvedValue([{ companionId: c1 }])
+        lean: jest.fn().mockResolvedValue([{ companionId: c1 }]),
       });
 
-      (CompanionModel.find as jest.Mock).mockResolvedValue([createMockDoc({ _id: c2, name: 'Unlinked' })]);
+      (CompanionModel.find as jest.Mock).mockResolvedValue([
+        createMockDoc({ _id: c2, name: "Unlinked" }),
+      ]);
 
-      const res = await CompanionService.listByParentNotInOrganisation(validParentId, validOrgId);
+      const res = await CompanionService.listByParentNotInOrganisation(
+        validParentId,
+        validOrgId,
+      );
 
       expect(CompanionModel.find).toHaveBeenCalledWith({ _id: { $in: [c2] } });
       expect(res.responses).toHaveLength(1);
-      expect(res.responses[0].name).toBe('Unlinked');
+      expect(res.responses[0].name).toBe("Unlinked");
     });
 
-    it('should return empty if all companions are already linked', async () => {
+    it("should return empty if all companions are already linked", async () => {
       const c1 = new Types.ObjectId();
-      (ParentCompanionService.getActiveCompanionIdsForParent as jest.Mock).mockResolvedValue([c1]);
+      (
+        ParentCompanionService.getActiveCompanionIdsForParent as jest.Mock
+      ).mockResolvedValue([c1]);
       (CompanionOrganisationModel.find as jest.Mock).mockReturnValue({
-        lean: jest.fn().mockResolvedValue([{ companionId: c1 }])
+        lean: jest.fn().mockResolvedValue([{ companionId: c1 }]),
       });
 
-      const res = await CompanionService.listByParentNotInOrganisation(validParentId, validOrgId);
+      const res = await CompanionService.listByParentNotInOrganisation(
+        validParentId,
+        validOrgId,
+      );
       expect(res.responses).toEqual([]);
     });
   });
 
-  describe('getById', () => {
-    it('should return null if ID is invalid', async () => {
-      expect(await CompanionService.getById('invalid')).toBeNull();
+  describe("getById", () => {
+    it("should return null if ID is invalid", async () => {
+      expect(await CompanionService.getById("invalid")).toBeNull();
     });
 
-    it('should return null if document not found', async () => {
+    it("should return null if document not found", async () => {
       (CompanionModel.findById as jest.Mock).mockResolvedValue(null);
       expect(await CompanionService.getById(validObjectId)).toBeNull();
     });
 
-    it('should return mapped DTO if found', async () => {
+    it("should return mapped DTO if found", async () => {
       (CompanionModel.findById as jest.Mock).mockResolvedValue(createMockDoc());
       const res = await CompanionService.getById(validObjectId);
-      expect(res?.response.name).toBe('Buddy');
+      expect(res?.response.name).toBe("Buddy");
     });
   });
 
-  describe('getByName', () => {
-    it('should throw if name is empty', async () => {
-      await expect(CompanionService.getByName('')).rejects.toThrow('Name is required');
+  describe("getByName", () => {
+    it("should throw if name is empty", async () => {
+      await expect(CompanionService.getByName("")).rejects.toThrow(
+        "Name is required",
+      );
     });
 
-    it('should return list of matching companions', async () => {
+    it("should return list of matching companions", async () => {
       (CompanionModel.find as jest.Mock).mockResolvedValue([createMockDoc()]);
-      const res = await CompanionService.getByName('Buddy');
+      const res = await CompanionService.getByName("Buddy");
       expect(res.responses).toHaveLength(1);
     });
   });
 
-  describe('update', () => {
-    const payload: any = { resourceType: 'Companion' };
+  describe("update", () => {
+    const payload: any = { resourceType: "Companion" };
 
-    it('should return null if ID is invalid', async () => {
-      expect(await CompanionService.update('invalid', payload)).toBeNull();
+    it("should return null if ID is invalid", async () => {
+      expect(await CompanionService.update("invalid", payload)).toBeNull();
     });
 
-    it('should update and return doc if found', async () => {
-      (fromCompanionRequestDTO as jest.Mock).mockReturnValue({ ...mockPersistableBase, name: 'Updated' });
-      const updatedDoc = createMockDoc({ name: 'Updated' });
+    it("should update and return doc if found", async () => {
+      (fromCompanionRequestDTO as jest.Mock).mockReturnValue({
+        ...mockPersistableBase,
+        name: "Updated",
+      });
+      const updatedDoc = createMockDoc({ name: "Updated" });
 
-      (CompanionModel.findByIdAndUpdate as jest.Mock).mockResolvedValue(updatedDoc);
+      (CompanionModel.findByIdAndUpdate as jest.Mock).mockResolvedValue(
+        updatedDoc,
+      );
 
       const res = await CompanionService.update(validObjectId, payload);
 
-      expect(res?.response.name).toBe('Updated');
+      expect(res?.response.name).toBe("Updated");
       expect(CompanionModel.findByIdAndUpdate).toHaveBeenCalledWith(
         validObjectId,
-        { $set: expect.objectContaining({ name: 'Updated' }) },
-        expect.anything()
+        { $set: expect.objectContaining({ name: "Updated" }) },
+        expect.anything(),
       );
     });
 
-    it('should return null if document not found during update', async () => {
-      (fromCompanionRequestDTO as jest.Mock).mockReturnValue({ ...mockPersistableBase });
+    it("should return null if document not found during update", async () => {
+      (fromCompanionRequestDTO as jest.Mock).mockReturnValue({
+        ...mockPersistableBase,
+      });
       (CompanionModel.findByIdAndUpdate as jest.Mock).mockResolvedValue(null);
       expect(await CompanionService.update(validObjectId, payload)).toBeNull();
     });
   });
 
-  describe('delete', () => {
-    const context = { authUserId: 'user123' };
+  describe("delete", () => {
+    const context = { authUserId: "user123" };
 
-    it('should throw if ID is invalid', async () => {
-      await expect(CompanionService.delete('invalid', context)).rejects.toThrow('Invalid companion identifier');
+    it("should throw if ID is invalid", async () => {
+      await expect(CompanionService.delete("invalid", context)).rejects.toThrow(
+        "Invalid companion identifier",
+      );
     });
 
-    it('should throw if authUserId is missing (security check)', async () => {
-      await expect(CompanionService.delete(validObjectId, {})).rejects.toThrow('Authenticated user is required');
+    it("should throw if authUserId is missing (security check)", async () => {
+      await expect(CompanionService.delete(validObjectId, {})).rejects.toThrow(
+        "Authenticated user is required",
+      );
     });
 
-    it('should throw if parent record not found for user', async () => {
+    it("should throw if parent record not found for user", async () => {
       (ParentService.findByLinkedUserId as jest.Mock).mockResolvedValue(null);
-      await expect(CompanionService.delete(validObjectId, context)).rejects.toThrow('Parent record not found');
+      await expect(
+        CompanionService.delete(validObjectId, context),
+      ).rejects.toThrow("Parent record not found");
     });
 
-    it('should throw if companion not found', async () => {
-      (ParentService.findByLinkedUserId as jest.Mock).mockResolvedValue({ _id: validParentId });
+    it("should throw if companion not found", async () => {
+      (ParentService.findByLinkedUserId as jest.Mock).mockResolvedValue({
+        _id: validParentId,
+      });
       (CompanionModel.findById as jest.Mock).mockResolvedValue(null);
 
-      await expect(CompanionService.delete(validObjectId, context)).rejects.toThrow('Companion not found');
+      await expect(
+        CompanionService.delete(validObjectId, context),
+      ).rejects.toThrow("Companion not found");
     });
 
-    it('should successfully delete companion and links', async () => {
-      (ParentService.findByLinkedUserId as jest.Mock).mockResolvedValue({ _id: validParentId });
+    it("should successfully delete companion and links", async () => {
+      (ParentService.findByLinkedUserId as jest.Mock).mockResolvedValue({
+        _id: validParentId,
+      });
       const mockDoc = createMockDoc();
       (CompanionModel.findById as jest.Mock).mockResolvedValue(mockDoc);
-      (ParentCompanionService.ensurePrimaryOwnership as jest.Mock).mockResolvedValue(true);
+      (
+        ParentCompanionService.ensurePrimaryOwnership as jest.Mock
+      ).mockResolvedValue(true);
 
       await CompanionService.delete(validObjectId, context);
 
       expect(ParentCompanionService.ensurePrimaryOwnership).toHaveBeenCalled();
-      expect(ParentCompanionService.deleteLinksForCompanion).toHaveBeenCalledWith(mockDoc._id);
-      expect(CompanionModel.deleteOne).toHaveBeenCalledWith({ _id: mockDoc._id });
+      expect(
+        ParentCompanionService.deleteLinksForCompanion,
+      ).toHaveBeenCalledWith(mockDoc._id);
+      expect(CompanionModel.deleteOne).toHaveBeenCalledWith({
+        _id: mockDoc._id,
+      });
     });
 
-    it('should rethrow ParentCompanionServiceError (e.g. ownership check)', async () => {
-      (ParentService.findByLinkedUserId as jest.Mock).mockResolvedValue({ _id: validParentId });
+    it("should rethrow ParentCompanionServiceError (e.g. ownership check)", async () => {
+      (ParentService.findByLinkedUserId as jest.Mock).mockResolvedValue({
+        _id: validParentId,
+      });
       (CompanionModel.findById as jest.Mock).mockResolvedValue(createMockDoc());
 
-      const error = new ParentCompanionServiceError('Not Owner', 403);
-      (ParentCompanionService.ensurePrimaryOwnership as jest.Mock).mockRejectedValue(error);
+      const error = new ParentCompanionServiceError("Not Owner", 403);
+      (
+        ParentCompanionService.ensurePrimaryOwnership as jest.Mock
+      ).mockRejectedValue(error);
 
-      await expect(CompanionService.delete(validObjectId, context)).rejects.toThrow('Not Owner');
+      await expect(
+        CompanionService.delete(validObjectId, context),
+      ).rejects.toThrow("Not Owner");
     });
 
-    it('should rethrow generic errors', async () => {
-      (ParentService.findByLinkedUserId as jest.Mock).mockResolvedValue({ _id: validParentId });
-      (CompanionModel.findById as jest.Mock).mockRejectedValue(new Error('DB Error'));
+    it("should rethrow generic errors", async () => {
+      (ParentService.findByLinkedUserId as jest.Mock).mockResolvedValue({
+        _id: validParentId,
+      });
+      (CompanionModel.findById as jest.Mock).mockRejectedValue(
+        new Error("DB Error"),
+      );
 
-      await expect(CompanionService.delete(validObjectId, context)).rejects.toThrow('DB Error');
+      await expect(
+        CompanionService.delete(validObjectId, context),
+      ).rejects.toThrow("DB Error");
     });
   });
 
-  describe('Logic: computeIsProfileComplete', () => {
-    it('should calculate isProfileComplete = false if required fields missing', async () => {
-        const incomplete = { ...mockPersistableBase, breed: undefined, gender: undefined };
-        (fromCompanionRequestDTO as jest.Mock).mockReturnValue(incomplete);
+  describe("Logic: computeIsProfileComplete", () => {
+    it("should calculate isProfileComplete = false if required fields missing", async () => {
+      const incomplete = {
+        ...mockPersistableBase,
+        breed: undefined,
+        gender: undefined,
+      };
+      (fromCompanionRequestDTO as jest.Mock).mockReturnValue(incomplete);
 
-        const spy = jest.fn().mockResolvedValue(createMockDoc());
-        (CompanionModel.findByIdAndUpdate as jest.Mock).mockImplementation(spy);
+      const spy = jest.fn().mockResolvedValue(createMockDoc());
+      (CompanionModel.findByIdAndUpdate as jest.Mock).mockImplementation(spy);
 
-        await CompanionService.update(validObjectId, {} as any);
+      await CompanionService.update(validObjectId, {} as any);
 
-        const updateCall = spy.mock.calls[0];
-        const updatePayload = updateCall[1].$set;
+      const updateCall = spy.mock.calls[0];
+      const updatePayload = updateCall[1].$set;
 
-        expect(updatePayload.isProfileComplete).toBe(false);
+      expect(updatePayload.isProfileComplete).toBe(false);
     });
 
-    it('should calculate isProfileComplete = true if all fields present', async () => {
-        const complete = { ...mockPersistableBase, breed: 'Mix', gender: 'MALE', status: 'ACTIVE' };
-        (fromCompanionRequestDTO as jest.Mock).mockReturnValue(complete);
+    it("should calculate isProfileComplete = true if all fields present", async () => {
+      const complete = {
+        ...mockPersistableBase,
+        breed: "Mix",
+        gender: "MALE",
+        status: "ACTIVE",
+      };
+      (fromCompanionRequestDTO as jest.Mock).mockReturnValue(complete);
 
-        const spy = jest.fn().mockResolvedValue(createMockDoc());
-        (CompanionModel.findByIdAndUpdate as jest.Mock).mockImplementation(spy);
+      const spy = jest.fn().mockResolvedValue(createMockDoc());
+      (CompanionModel.findByIdAndUpdate as jest.Mock).mockImplementation(spy);
 
-        await CompanionService.update(validObjectId, {} as any);
+      await CompanionService.update(validObjectId, {} as any);
 
-        const updatePayload = spy.mock.calls[0][1].$set;
-        expect(updatePayload.isProfileComplete).toBe(true);
+      const updatePayload = spy.mock.calls[0][1].$set;
+      expect(updatePayload.isProfileComplete).toBe(true);
     });
   });
 });

--- a/apps/backend/test/services/contact-us.service.test.ts
+++ b/apps/backend/test/services/contact-us.service.test.ts
@@ -1,164 +1,200 @@
-import { ContactService, ContactServiceError } from '../../src/services/contact-us.service';
-import ContactRequestModel from '../../src/models/contect-us';
+import {
+  ContactService,
+  ContactServiceError,
+} from "../../src/services/contact-us.service";
+import ContactRequestModel from "../../src/models/contect-us";
 
 // --- Mocks ---
-jest.mock('../../src/models/contect-us');
+jest.mock("../../src/models/contect-us");
 
-describe('ContactService', () => {
-
+describe("ContactService", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   // 1. createRequest
-  describe('createRequest', () => {
+  describe("createRequest", () => {
     const baseInput: any = {
-      type: 'GENERAL_INQUIRY',
-      source: 'MOBILE_APP',
-      subject: 'Help',
-      message: 'I need help',
+      type: "GENERAL_INQUIRY",
+      source: "MOBILE_APP",
+      subject: "Help",
+      message: "I need help",
     };
 
-    it('should throw error if subject or message is missing', async () => {
-      await expect(ContactService.createRequest({ ...baseInput, subject: '' }))
-        .rejects.toThrow('subject and message are required');
+    it("should throw error if subject or message is missing", async () => {
+      await expect(
+        ContactService.createRequest({ ...baseInput, subject: "" }),
+      ).rejects.toThrow("subject and message are required");
 
-      await expect(ContactService.createRequest({ ...baseInput, message: '' }))
-        .rejects.toThrow('subject and message are required');
+      await expect(
+        ContactService.createRequest({ ...baseInput, message: "" }),
+      ).rejects.toThrow("subject and message are required");
     });
 
-    it('should successfully create a general request', async () => {
-      (ContactRequestModel.create as jest.Mock).mockResolvedValue({ ...baseInput, status: 'OPEN', _id: '123' });
+    it("should successfully create a general request", async () => {
+      (ContactRequestModel.create as jest.Mock).mockResolvedValue({
+        ...baseInput,
+        status: "OPEN",
+        _id: "123",
+      });
 
       const result = await ContactService.createRequest(baseInput);
 
-      expect(ContactRequestModel.create).toHaveBeenCalledWith(expect.objectContaining({
-        status: 'OPEN',
-        subject: 'Help'
-      }));
-      expect(result).toEqual(expect.objectContaining({ _id: '123' }));
+      expect(ContactRequestModel.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: "OPEN",
+          subject: "Help",
+        }),
+      );
+      expect(result).toEqual(expect.objectContaining({ _id: "123" }));
     });
 
-    describe('DSAR Validations', () => {
-        const dsarInput: any = {
-            ...baseInput,
-            type: 'DSAR',
-            dsarDetails: {
-                requesterType: 'DATA_SUBJECT',
-                declarationAccepted: true
-            }
+    describe("DSAR Validations", () => {
+      const dsarInput: any = {
+        ...baseInput,
+        type: "DSAR",
+        dsarDetails: {
+          requesterType: "DATA_SUBJECT",
+          declarationAccepted: true,
+        },
+      };
+
+      it("should throw if dsarDetails.requesterType is missing", async () => {
+        const invalidDsar = { ...dsarInput, dsarDetails: {} };
+        await expect(ContactService.createRequest(invalidDsar)).rejects.toThrow(
+          "DSAR requests must include dsarDetails.requesterType",
+        );
+      });
+
+      it("should throw if declarationAccepted is false", async () => {
+        const invalidDsar = {
+          ...dsarInput,
+          dsarDetails: {
+            requesterType: "DATA_SUBJECT",
+            declarationAccepted: false,
+          },
         };
+        await expect(ContactService.createRequest(invalidDsar)).rejects.toThrow(
+          "DSAR declaration must be accepted",
+        );
+      });
 
-        it('should throw if dsarDetails.requesterType is missing', async () => {
-            const invalidDsar = { ...dsarInput, dsarDetails: {} };
-            await expect(ContactService.createRequest(invalidDsar))
-                .rejects.toThrow('DSAR requests must include dsarDetails.requesterType');
+      it("should auto-populate declarationAcceptedAt if missing", async () => {
+        (ContactRequestModel.create as jest.Mock).mockResolvedValue({
+          ...dsarInput,
+          status: "OPEN",
         });
 
-        it('should throw if declarationAccepted is false', async () => {
-            const invalidDsar = { ...dsarInput, dsarDetails: { requesterType: 'DATA_SUBJECT', declarationAccepted: false } };
-            await expect(ContactService.createRequest(invalidDsar))
-                .rejects.toThrow('DSAR declaration must be accepted');
-        });
+        await ContactService.createRequest(dsarInput);
 
-        it('should auto-populate declarationAcceptedAt if missing', async () => {
-            (ContactRequestModel.create as jest.Mock).mockResolvedValue({ ...dsarInput, status: 'OPEN' });
+        expect(ContactRequestModel.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            dsarDetails: expect.objectContaining({
+              declarationAcceptedAt: expect.any(Date),
+            }),
+          }),
+        );
+      });
 
-            await ContactService.createRequest(dsarInput);
+      it("should respect provided declarationAcceptedAt", async () => {
+        const date = new Date("2023-01-01");
+        const input = {
+          ...dsarInput,
+          dsarDetails: {
+            ...dsarInput.dsarDetails,
+            declarationAcceptedAt: date,
+          },
+        };
+        (ContactRequestModel.create as jest.Mock).mockResolvedValue(input);
 
-            expect(ContactRequestModel.create).toHaveBeenCalledWith(expect.objectContaining({
-                dsarDetails: expect.objectContaining({
-                    declarationAcceptedAt: expect.any(Date)
-                })
-            }));
-        });
+        await ContactService.createRequest(input);
 
-        it('should respect provided declarationAcceptedAt', async () => {
-            const date = new Date('2023-01-01');
-            const input = {
-                ...dsarInput,
-                dsarDetails: { ...dsarInput.dsarDetails, declarationAcceptedAt: date }
-            };
-            (ContactRequestModel.create as jest.Mock).mockResolvedValue(input);
-
-            await ContactService.createRequest(input);
-
-            expect(ContactRequestModel.create).toHaveBeenCalledWith(expect.objectContaining({
-                dsarDetails: expect.objectContaining({
-                    declarationAcceptedAt: date
-                })
-            }));
-        });
+        expect(ContactRequestModel.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            dsarDetails: expect.objectContaining({
+              declarationAcceptedAt: date,
+            }),
+          }),
+        );
+      });
     });
   });
 
   // 2. listRequests
-  describe('listRequests', () => {
-    it('should build query based on filters', async () => {
+  describe("listRequests", () => {
+    it("should build query based on filters", async () => {
       const mockChain = {
-          sort: jest.fn().mockReturnValue({
-              limit: jest.fn().mockResolvedValue(['doc1', 'doc2'])
-          })
+        sort: jest.fn().mockReturnValue({
+          limit: jest.fn().mockResolvedValue(["doc1", "doc2"]),
+        }),
       };
       (ContactRequestModel.find as jest.Mock).mockReturnValue(mockChain);
 
-      const filter = { status: 'OPEN' as const, type: 'DSAR' as const, organisationId: 'org1' };
+      const filter = {
+        status: "OPEN" as const,
+        type: "DSAR" as const,
+        organisationId: "org1",
+      };
       const result = await ContactService.listRequests(filter);
 
       expect(ContactRequestModel.find).toHaveBeenCalledWith({
-          status: 'OPEN',
-          type: 'DSAR',
-          organisationId: 'org1'
+        status: "OPEN",
+        type: "DSAR",
+        organisationId: "org1",
       });
-      expect(result).toEqual(['doc1', 'doc2']);
+      expect(result).toEqual(["doc1", "doc2"]);
     });
 
-    it('should handle empty filters', async () => {
-        const mockChain = {
-            sort: jest.fn().mockReturnValue({
-                limit: jest.fn().mockResolvedValue([])
-            })
-        };
-        (ContactRequestModel.find as jest.Mock).mockReturnValue(mockChain);
+    it("should handle empty filters", async () => {
+      const mockChain = {
+        sort: jest.fn().mockReturnValue({
+          limit: jest.fn().mockResolvedValue([]),
+        }),
+      };
+      (ContactRequestModel.find as jest.Mock).mockReturnValue(mockChain);
 
-        await ContactService.listRequests({});
+      await ContactService.listRequests({});
 
-        expect(ContactRequestModel.find).toHaveBeenCalledWith({});
+      expect(ContactRequestModel.find).toHaveBeenCalledWith({});
     });
   });
 
   // 3. getById
-  describe('getById', () => {
-    it('should return document by ID', async () => {
-      (ContactRequestModel.findById as jest.Mock).mockResolvedValue({ _id: '123' });
-      const res = await ContactService.getById('123');
-      expect(res).toEqual({ _id: '123' });
+  describe("getById", () => {
+    it("should return document by ID", async () => {
+      (ContactRequestModel.findById as jest.Mock).mockResolvedValue({
+        _id: "123",
+      });
+      const res = await ContactService.getById("123");
+      expect(res).toEqual({ _id: "123" });
     });
   });
 
   // 4. updateStatus
-  describe('updateStatus', () => {
-    it('should update status and return new doc', async () => {
-      (ContactRequestModel.findByIdAndUpdate as jest.Mock).mockResolvedValue({ _id: '123', status: 'CLOSED' });
+  describe("updateStatus", () => {
+    it("should update status and return new doc", async () => {
+      (ContactRequestModel.findByIdAndUpdate as jest.Mock).mockResolvedValue({
+        _id: "123",
+        status: "CLOSED",
+      });
 
-      const res = await ContactService.updateStatus('123', 'CLOSED');
+      const res = await ContactService.updateStatus("123", "CLOSED");
 
       expect(ContactRequestModel.findByIdAndUpdate).toHaveBeenCalledWith(
-          '123',
-          { status: 'CLOSED' },
-          { new: true }
+        "123",
+        { status: "CLOSED" },
+        { new: true },
       );
-      expect(res).toEqual({ _id: '123', status: 'CLOSED' });
+      expect(res).toEqual({ _id: "123", status: "CLOSED" });
     });
   });
 
   // 5. Error Class
-  describe('ContactServiceError', () => {
-      it('should default status code to 400', () => {
-          const err = new ContactServiceError('msg');
-          expect(err.statusCode).toBe(400);
-          expect(err.name).toBe('ContactServiceError');
-      });
+  describe("ContactServiceError", () => {
+    it("should default status code to 400", () => {
+      const err = new ContactServiceError("msg");
+      expect(err.statusCode).toBe(400);
+      expect(err.name).toBe("ContactServiceError");
+    });
   });
-
 });

--- a/apps/backend/test/services/coparentInvite.service.test.ts
+++ b/apps/backend/test/services/coparentInvite.service.test.ts
@@ -1,21 +1,21 @@
-import { Types } from 'mongoose';
-import { CoParentInviteService } from '../../src/services/coparentInvite.service';
-import { CoParentInviteModel } from '../../src/models/coparentInvite';
-import { ParentModel } from '../../src/models/parent';
-import CompanionModel from '../../src/models/companion';
-import ParentCompanionModel from '../../src/models/parent-companion';
-import { ParentService } from '../../src/services/parent.service';
-import { ParentCompanionService } from '../../src/services/parent-companion.service';
+import { Types } from "mongoose";
+import { CoParentInviteService } from "../../src/services/coparentInvite.service";
+import { CoParentInviteModel } from "../../src/models/coparentInvite";
+import { ParentModel } from "../../src/models/parent";
+import CompanionModel from "../../src/models/companion";
+import ParentCompanionModel from "../../src/models/parent-companion";
+import { ParentService } from "../../src/services/parent.service";
+import { ParentCompanionService } from "../../src/services/parent-companion.service";
 
 // --- Mocks ---
-jest.mock('../../src/models/coparentInvite');
-jest.mock('../../src/models/parent');
-jest.mock('../../src/models/companion');
-jest.mock('../../src/models/parent-companion');
-jest.mock('../../src/services/parent.service');
-jest.mock('../../src/services/parent-companion.service');
+jest.mock("../../src/models/coparentInvite");
+jest.mock("../../src/models/parent");
+jest.mock("../../src/models/companion");
+jest.mock("../../src/models/parent-companion");
+jest.mock("../../src/services/parent.service");
+jest.mock("../../src/services/parent-companion.service");
 
-describe('CoParentInviteService', () => {
+describe("CoParentInviteService", () => {
   const validObjectId = new Types.ObjectId().toString();
   const validParentId = new Types.ObjectId();
   const validCompanionId = new Types.ObjectId();
@@ -28,280 +28,366 @@ describe('CoParentInviteService', () => {
     jest.clearAllMocks();
   });
 
-  describe('sendInvite', () => {
+  describe("sendInvite", () => {
     const input = {
-      email: 'test@example.com',
+      email: "test@example.com",
       companionId: validCompanionId.toString(),
       invitedByParentId: validInviterId.toString(),
-      inviteeName: 'Invitee',
+      inviteeName: "Invitee",
     };
 
-    it('should create an invite successfully', async () => {
+    it("should create an invite successfully", async () => {
       (CoParentInviteModel.create as jest.Mock).mockResolvedValue({});
 
       const result = await CoParentInviteService.sendInvite(input);
 
-      expect(CoParentInviteModel.create).toHaveBeenCalledWith(expect.objectContaining({
-        email: 'test@example.com',
-        companionId: validCompanionId,
-        invitedByParentId: validInviterId,
-      }));
+      expect(CoParentInviteModel.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          email: "test@example.com",
+          companionId: validCompanionId,
+          invitedByParentId: validInviterId,
+        }),
+      );
       expect(result.inviteToken).toBeDefined();
-      expect(result.email).toBe('test@example.com');
+      expect(result.email).toBe("test@example.com");
     });
 
-    it('should throw if email is missing', async () => {
-      await expect(CoParentInviteService.sendInvite({ ...input, email: '' }))
-        .rejects.toThrow('Email is required.');
+    it("should throw if email is missing", async () => {
+      await expect(
+        CoParentInviteService.sendInvite({ ...input, email: "" }),
+      ).rejects.toThrow("Email is required.");
     });
 
-    it('should throw if companionId is invalid', async () => {
-      await expect(CoParentInviteService.sendInvite({ ...input, companionId: 'invalid' }))
-        .rejects.toThrow('Invalid companionId.');
+    it("should throw if companionId is invalid", async () => {
+      await expect(
+        CoParentInviteService.sendInvite({ ...input, companionId: "invalid" }),
+      ).rejects.toThrow("Invalid companionId.");
     });
 
-    it('should throw if invitedByParentId is invalid', async () => {
-      await expect(CoParentInviteService.sendInvite({ ...input, invitedByParentId: 'invalid' }))
-        .rejects.toThrow('Invalid invitedByParentId.');
+    it("should throw if invitedByParentId is invalid", async () => {
+      await expect(
+        CoParentInviteService.sendInvite({
+          ...input,
+          invitedByParentId: "invalid",
+        }),
+      ).rejects.toThrow("Invalid invitedByParentId.");
     });
   });
 
-  describe('validateInvite', () => {
+  describe("validateInvite", () => {
     const mockInvite = {
       _id: validObjectId,
-      email: 'test@example.com',
-      inviteToken: 'valid-token',
+      email: "test@example.com",
+      inviteToken: "valid-token",
       consumed: false,
       expiresAt: mockDateFuture,
       invitedByParentId: validInviterId,
       companionId: validCompanionId,
-      inviteeName: 'John',
+      inviteeName: "John",
     };
 
-    const mockInviter = { _id: validInviterId, firstName: 'Jane', lastName: 'Doe', profileImageUrl: 'url' };
-    const mockCompanion = { _id: validCompanionId, name: 'Buddy', photoUrl: 'url' };
+    const mockInviter = {
+      _id: validInviterId,
+      firstName: "Jane",
+      lastName: "Doe",
+      profileImageUrl: "url",
+    };
+    const mockCompanion = {
+      _id: validCompanionId,
+      name: "Buddy",
+      photoUrl: "url",
+    };
 
-    it('should validate and return popup data', async () => {
+    it("should validate and return popup data", async () => {
       (CoParentInviteModel.findOne as jest.Mock).mockResolvedValue(mockInvite);
       (ParentModel.findById as jest.Mock).mockResolvedValue(mockInviter);
       (CompanionModel.findById as jest.Mock).mockResolvedValue(mockCompanion);
 
-      const result = await CoParentInviteService.validateInvite('valid-token');
+      const result = await CoParentInviteService.validateInvite("valid-token");
 
       expect(result.email).toBe(mockInvite.email);
-      expect(result.invitedBy.fullName).toBe('Jane Doe');
-      expect(result.companion.name).toBe('Buddy');
+      expect(result.invitedBy.fullName).toBe("Jane Doe");
+      expect(result.companion.name).toBe("Buddy");
     });
 
-    it('should throw if token is missing', async () => {
-      await expect(CoParentInviteService.validateInvite('')).rejects.toThrow('Invite token is required.');
+    it("should throw if token is missing", async () => {
+      await expect(CoParentInviteService.validateInvite("")).rejects.toThrow(
+        "Invite token is required.",
+      );
     });
 
-    it('should throw if invite not found', async () => {
+    it("should throw if invite not found", async () => {
       (CoParentInviteModel.findOne as jest.Mock).mockResolvedValue(null);
-      await expect(CoParentInviteService.validateInvite('token')).rejects.toThrow('Invalid invite token.');
+      await expect(
+        CoParentInviteService.validateInvite("token"),
+      ).rejects.toThrow("Invalid invite token.");
     });
 
-    it('should throw if invite consumed', async () => {
-      (CoParentInviteModel.findOne as jest.Mock).mockResolvedValue({ ...mockInvite, consumed: true });
-      await expect(CoParentInviteService.validateInvite('token')).rejects.toThrow('This invite has already been used.');
+    it("should throw if invite consumed", async () => {
+      (CoParentInviteModel.findOne as jest.Mock).mockResolvedValue({
+        ...mockInvite,
+        consumed: true,
+      });
+      await expect(
+        CoParentInviteService.validateInvite("token"),
+      ).rejects.toThrow("This invite has already been used.");
     });
 
-    it('should throw if invite expired', async () => {
-      (CoParentInviteModel.findOne as jest.Mock).mockResolvedValue({ ...mockInvite, expiresAt: mockDatePast });
-      await expect(CoParentInviteService.validateInvite('token')).rejects.toThrow('This invite has expired.');
+    it("should throw if invite expired", async () => {
+      (CoParentInviteModel.findOne as jest.Mock).mockResolvedValue({
+        ...mockInvite,
+        expiresAt: mockDatePast,
+      });
+      await expect(
+        CoParentInviteService.validateInvite("token"),
+      ).rejects.toThrow("This invite has expired.");
     });
 
-    it('should throw if inviter not found', async () => {
+    it("should throw if inviter not found", async () => {
       (CoParentInviteModel.findOne as jest.Mock).mockResolvedValue(mockInvite);
       (ParentModel.findById as jest.Mock).mockResolvedValue(null);
-      await expect(CoParentInviteService.validateInvite('token')).rejects.toThrow('Inviter parent not found.');
+      await expect(
+        CoParentInviteService.validateInvite("token"),
+      ).rejects.toThrow("Inviter parent not found.");
     });
 
-    it('should throw if companion not found', async () => {
+    it("should throw if companion not found", async () => {
       (CoParentInviteModel.findOne as jest.Mock).mockResolvedValue(mockInvite);
       (ParentModel.findById as jest.Mock).mockResolvedValue(mockInviter);
       (CompanionModel.findById as jest.Mock).mockResolvedValue(null);
-      await expect(CoParentInviteService.validateInvite('token')).rejects.toThrow('Companion not found.');
+      await expect(
+        CoParentInviteService.validateInvite("token"),
+      ).rejects.toThrow("Companion not found.");
     });
   });
 
-  describe('acceptInvite', () => {
-    const token = 'token';
-    const authUserId = 'auth-user';
+  describe("acceptInvite", () => {
+    const token = "token";
+    const authUserId = "auth-user";
     const mockInviteDoc = {
-        _id: validObjectId,
-        consumed: false,
-        save: jest.fn()
+      _id: validObjectId,
+      consumed: false,
+      save: jest.fn(),
     };
     const mockParentDoc = { _id: validParentId };
 
     // Reuse mock setup helper since logic overlaps with validateInvite
     const setupValidateMocks = () => {
-        (CoParentInviteModel.findOne as jest.Mock).mockResolvedValue({
-            _id: validObjectId,
-            inviteToken: token,
-            consumed: false,
-            expiresAt: mockDateFuture,
-            invitedByParentId: validInviterId,
-            companionId: validCompanionId,
-        });
-        (ParentModel.findById as jest.Mock).mockResolvedValue({ _id: validInviterId, firstName: 'Inviter' });
-        (CompanionModel.findById as jest.Mock).mockResolvedValue({ _id: validCompanionId, name: 'Pet' });
-    };
-
-    it('should accept invite successfully', async () => {
-      setupValidateMocks();
-      (CoParentInviteModel.findById as jest.Mock).mockResolvedValue(mockInviteDoc);
-      (ParentService.findByLinkedUserId as jest.Mock).mockResolvedValue(mockParentDoc);
-      (ParentCompanionModel.findOne as jest.Mock).mockResolvedValue(null); // No existing link
-
-      const result = await CoParentInviteService.acceptInvite(token, authUserId);
-
-      expect(ParentCompanionService.linkParent).toHaveBeenCalledWith(expect.objectContaining({
-        parentId: mockParentDoc._id,
-        role: 'CO_PARENT'
-      }));
-      expect(mockInviteDoc.consumed).toBe(true);
-      expect(mockInviteDoc.save).toHaveBeenCalled();
-      expect(result.message).toBe('Invite accepted successfully.');
-    });
-
-    it('should throw if token missing', async () => {
-        await expect(CoParentInviteService.acceptInvite('', authUserId)).rejects.toThrow('Invite token is required.');
-    });
-
-    it('should throw if authUserId missing', async () => {
-        await expect(CoParentInviteService.acceptInvite(token, '')).rejects.toThrow('Authenticated user required.');
-    });
-
-    it('should throw if invite doc not found (after validation)', async () => {
-        setupValidateMocks();
-        (CoParentInviteModel.findById as jest.Mock).mockResolvedValue(null);
-        await expect(CoParentInviteService.acceptInvite(token, authUserId)).rejects.toThrow('Invalid invite');
-    });
-
-    it('should throw if parent profile not found for user', async () => {
-        setupValidateMocks();
-        (CoParentInviteModel.findById as jest.Mock).mockResolvedValue(mockInviteDoc);
-        (ParentService.findByLinkedUserId as jest.Mock).mockResolvedValue(null);
-        await expect(CoParentInviteService.acceptInvite(token, authUserId)).rejects.toThrow('Parent profile not found');
-    });
-
-    it('should throw if already linked', async () => {
-        setupValidateMocks();
-        (CoParentInviteModel.findById as jest.Mock).mockResolvedValue(mockInviteDoc);
-        (ParentService.findByLinkedUserId as jest.Mock).mockResolvedValue(mockParentDoc);
-        (ParentCompanionModel.findOne as jest.Mock).mockResolvedValue({ status: 'ACTIVE' }); // Existing link
-
-        await expect(CoParentInviteService.acceptInvite(token, authUserId)).rejects.toThrow('You are already linked to this companion.');
-    });
-  });
-
-  describe('declineInvite', () => {
-    const mockInviteDoc = {
-        email: 'test@mail.com',
-        companionId: validCompanionId,
-        invitedByParentId: validInviterId,
+      (CoParentInviteModel.findOne as jest.Mock).mockResolvedValue({
+        _id: validObjectId,
+        inviteToken: token,
         consumed: false,
         expiresAt: mockDateFuture,
-        save: jest.fn()
+        invitedByParentId: validInviterId,
+        companionId: validCompanionId,
+      });
+      (ParentModel.findById as jest.Mock).mockResolvedValue({
+        _id: validInviterId,
+        firstName: "Inviter",
+      });
+      (CompanionModel.findById as jest.Mock).mockResolvedValue({
+        _id: validCompanionId,
+        name: "Pet",
+      });
     };
 
-    it('should decline invite successfully', async () => {
-        (CoParentInviteModel.findOne as jest.Mock).mockResolvedValue(mockInviteDoc);
+    it("should accept invite successfully", async () => {
+      setupValidateMocks();
+      (CoParentInviteModel.findById as jest.Mock).mockResolvedValue(
+        mockInviteDoc,
+      );
+      (ParentService.findByLinkedUserId as jest.Mock).mockResolvedValue(
+        mockParentDoc,
+      );
+      (ParentCompanionModel.findOne as jest.Mock).mockResolvedValue(null); // No existing link
 
-        const res = await CoParentInviteService.declineInvite('token');
+      const result = await CoParentInviteService.acceptInvite(
+        token,
+        authUserId,
+      );
 
-        expect(mockInviteDoc.consumed).toBe(true);
-        expect(mockInviteDoc.save).toHaveBeenCalled();
-        expect(res.message).toBe('Invite declined successfully.');
+      expect(ParentCompanionService.linkParent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          parentId: mockParentDoc._id,
+          role: "CO_PARENT",
+        }),
+      );
+      expect(mockInviteDoc.consumed).toBe(true);
+      expect(mockInviteDoc.save).toHaveBeenCalled();
+      expect(result.message).toBe("Invite accepted successfully.");
     });
 
-    it('should throw if token missing', async () => {
-        await expect(CoParentInviteService.declineInvite('')).rejects.toThrow('Invite token is required.');
+    it("should throw if token missing", async () => {
+      await expect(
+        CoParentInviteService.acceptInvite("", authUserId),
+      ).rejects.toThrow("Invite token is required.");
     });
 
-    it('should throw if invite not found', async () => {
-        (CoParentInviteModel.findOne as jest.Mock).mockResolvedValue(null);
-        await expect(CoParentInviteService.declineInvite('token')).rejects.toThrow('Invalid invite token.');
+    it("should throw if authUserId missing", async () => {
+      await expect(
+        CoParentInviteService.acceptInvite(token, ""),
+      ).rejects.toThrow("Authenticated user required.");
     });
 
-    it('should throw if already consumed', async () => {
-        (CoParentInviteModel.findOne as jest.Mock).mockResolvedValue({ ...mockInviteDoc, consumed: true });
+    it("should throw if invite doc not found (after validation)", async () => {
+      setupValidateMocks();
+      (CoParentInviteModel.findById as jest.Mock).mockResolvedValue(null);
+      await expect(
+        CoParentInviteService.acceptInvite(token, authUserId),
+      ).rejects.toThrow("Invalid invite");
     });
 
-    it('should throw if expired', async () => {
-        (CoParentInviteModel.findOne as jest.Mock).mockResolvedValue({ ...mockInviteDoc, expiresAt: mockDatePast });
+    it("should throw if parent profile not found for user", async () => {
+      setupValidateMocks();
+      (CoParentInviteModel.findById as jest.Mock).mockResolvedValue(
+        mockInviteDoc,
+      );
+      (ParentService.findByLinkedUserId as jest.Mock).mockResolvedValue(null);
+      await expect(
+        CoParentInviteService.acceptInvite(token, authUserId),
+      ).rejects.toThrow("Parent profile not found");
+    });
+
+    it("should throw if already linked", async () => {
+      setupValidateMocks();
+      (CoParentInviteModel.findById as jest.Mock).mockResolvedValue(
+        mockInviteDoc,
+      );
+      (ParentService.findByLinkedUserId as jest.Mock).mockResolvedValue(
+        mockParentDoc,
+      );
+      (ParentCompanionModel.findOne as jest.Mock).mockResolvedValue({
+        status: "ACTIVE",
+      }); // Existing link
+
+      await expect(
+        CoParentInviteService.acceptInvite(token, authUserId),
+      ).rejects.toThrow("You are already linked to this companion.");
     });
   });
 
-  describe('getPendingInvitesForEmail', () => {
-    const email = 'test@example.com';
-    const mockInvite = {
-        inviteToken: 'tok',
-        email,
-        inviteeName: 'Me',
-        expiresAt: mockDateFuture,
-        invitedByParentId: validInviterId,
-        companionId: validCompanionId,
+  describe("declineInvite", () => {
+    const mockInviteDoc = {
+      email: "test@mail.com",
+      companionId: validCompanionId,
+      invitedByParentId: validInviterId,
+      consumed: false,
+      expiresAt: mockDateFuture,
+      save: jest.fn(),
     };
 
-    it('should return pending invites', async () => {
-        (CoParentInviteModel.find as jest.Mock).mockReturnValue({
-            lean: jest.fn().mockResolvedValue([mockInvite])
-        });
-        (ParentModel.findById as jest.Mock).mockReturnValue({
-            lean: jest.fn().mockResolvedValue({ _id: validInviterId, firstName: 'Dad' })
-        });
-        (CompanionModel.findById as jest.Mock).mockReturnValue({
-            lean: jest.fn().mockResolvedValue({ _id: validCompanionId, name: 'Dog' })
-        });
+    it("should decline invite successfully", async () => {
+      (CoParentInviteModel.findOne as jest.Mock).mockResolvedValue(
+        mockInviteDoc,
+      );
 
-        const res = await CoParentInviteService.getPendingInvitesForEmail(email);
+      const res = await CoParentInviteService.declineInvite("token");
 
-        expect(res.pendingInvites).toHaveLength(1);
-        expect(res.pendingInvites[0].invitedBy.firstName).toBe('Dad');
-        expect(res.pendingInvites[0].companion.name).toBe('Dog');
+      expect(mockInviteDoc.consumed).toBe(true);
+      expect(mockInviteDoc.save).toHaveBeenCalled();
+      expect(res.message).toBe("Invite declined successfully.");
     });
 
-    it('should return empty if no invites found', async () => {
-        (CoParentInviteModel.find as jest.Mock).mockReturnValue({
-            lean: jest.fn().mockResolvedValue([])
-        });
-        const res = await CoParentInviteService.getPendingInvitesForEmail(email);
-        expect(res.pendingInvites).toEqual([]);
+    it("should throw if token missing", async () => {
+      await expect(CoParentInviteService.declineInvite("")).rejects.toThrow(
+        "Invite token is required.",
+      );
     });
 
-    it('should skip invite if inviter not found', async () => {
-        (CoParentInviteModel.find as jest.Mock).mockReturnValue({
-            lean: jest.fn().mockResolvedValue([mockInvite])
-        });
-        (ParentModel.findById as jest.Mock).mockReturnValue({
-            lean: jest.fn().mockResolvedValue(null) // Inviter deleted
-        });
-
-        const res = await CoParentInviteService.getPendingInvitesForEmail(email);
-        expect(res.pendingInvites).toHaveLength(0);
+    it("should throw if invite not found", async () => {
+      (CoParentInviteModel.findOne as jest.Mock).mockResolvedValue(null);
+      await expect(
+        CoParentInviteService.declineInvite("token"),
+      ).rejects.toThrow("Invalid invite token.");
     });
 
-    it('should skip invite if companion not found', async () => {
-        (CoParentInviteModel.find as jest.Mock).mockReturnValue({
-            lean: jest.fn().mockResolvedValue([mockInvite])
-        });
-        (ParentModel.findById as jest.Mock).mockReturnValue({
-            lean: jest.fn().mockResolvedValue({ _id: validInviterId })
-        });
-        (CompanionModel.findById as jest.Mock).mockReturnValue({
-            lean: jest.fn().mockResolvedValue(null) // Companion deleted
-        });
-
-        const res = await CoParentInviteService.getPendingInvitesForEmail(email);
-        expect(res.pendingInvites).toHaveLength(0);
+    it("should throw if already consumed", async () => {
+      (CoParentInviteModel.findOne as jest.Mock).mockResolvedValue({
+        ...mockInviteDoc,
+        consumed: true,
+      });
     });
 
-    it('should throw if email missing', async () => {
-        await expect(CoParentInviteService.getPendingInvitesForEmail('')).rejects.toThrow('Email is required.');
+    it("should throw if expired", async () => {
+      (CoParentInviteModel.findOne as jest.Mock).mockResolvedValue({
+        ...mockInviteDoc,
+        expiresAt: mockDatePast,
+      });
+    });
+  });
+
+  describe("getPendingInvitesForEmail", () => {
+    const email = "test@example.com";
+    const mockInvite = {
+      inviteToken: "tok",
+      email,
+      inviteeName: "Me",
+      expiresAt: mockDateFuture,
+      invitedByParentId: validInviterId,
+      companionId: validCompanionId,
+    };
+
+    it("should return pending invites", async () => {
+      (CoParentInviteModel.find as jest.Mock).mockReturnValue({
+        lean: jest.fn().mockResolvedValue([mockInvite]),
+      });
+      (ParentModel.findById as jest.Mock).mockReturnValue({
+        lean: jest
+          .fn()
+          .mockResolvedValue({ _id: validInviterId, firstName: "Dad" }),
+      });
+      (CompanionModel.findById as jest.Mock).mockReturnValue({
+        lean: jest
+          .fn()
+          .mockResolvedValue({ _id: validCompanionId, name: "Dog" }),
+      });
+
+      const res = await CoParentInviteService.getPendingInvitesForEmail(email);
+
+      expect(res.pendingInvites).toHaveLength(1);
+      expect(res.pendingInvites[0].invitedBy.firstName).toBe("Dad");
+      expect(res.pendingInvites[0].companion.name).toBe("Dog");
+    });
+
+    it("should return empty if no invites found", async () => {
+      (CoParentInviteModel.find as jest.Mock).mockReturnValue({
+        lean: jest.fn().mockResolvedValue([]),
+      });
+      const res = await CoParentInviteService.getPendingInvitesForEmail(email);
+      expect(res.pendingInvites).toEqual([]);
+    });
+
+    it("should skip invite if inviter not found", async () => {
+      (CoParentInviteModel.find as jest.Mock).mockReturnValue({
+        lean: jest.fn().mockResolvedValue([mockInvite]),
+      });
+      (ParentModel.findById as jest.Mock).mockReturnValue({
+        lean: jest.fn().mockResolvedValue(null), // Inviter deleted
+      });
+
+      const res = await CoParentInviteService.getPendingInvitesForEmail(email);
+      expect(res.pendingInvites).toHaveLength(0);
+    });
+
+    it("should skip invite if companion not found", async () => {
+      (CoParentInviteModel.find as jest.Mock).mockReturnValue({
+        lean: jest.fn().mockResolvedValue([mockInvite]),
+      });
+      (ParentModel.findById as jest.Mock).mockReturnValue({
+        lean: jest.fn().mockResolvedValue({ _id: validInviterId }),
+      });
+      (CompanionModel.findById as jest.Mock).mockReturnValue({
+        lean: jest.fn().mockResolvedValue(null), // Companion deleted
+      });
+
+      const res = await CoParentInviteService.getPendingInvitesForEmail(email);
+      expect(res.pendingInvites).toHaveLength(0);
+    });
+
+    it("should throw if email missing", async () => {
+      await expect(
+        CoParentInviteService.getPendingInvitesForEmail(""),
+      ).rejects.toThrow("Email is required.");
     });
   });
 });

--- a/apps/backend/test/services/dashboard.service.test.ts
+++ b/apps/backend/test/services/dashboard.service.test.ts
@@ -1,12 +1,18 @@
-import { DashboardService, SummaryRange } from '../../src/services/dashboard.service';
-import AppointmentModel from '../../src/models/appointment';
-import TaskModel from '../../src/models/task';
-import { InventoryItemModel, StockMovementModel } from '../../src/models/inventory';
+import {
+  DashboardService,
+  SummaryRange,
+} from "../../src/services/dashboard.service";
+import AppointmentModel from "../../src/models/appointment";
+import TaskModel from "../../src/models/task";
+import {
+  InventoryItemModel,
+  StockMovementModel,
+} from "../../src/models/inventory";
 
 // --- Mocks ---
-jest.mock('../../src/models/appointment');
-jest.mock('../../src/models/task');
-jest.mock('../../src/models/inventory', () => ({
+jest.mock("../../src/models/appointment");
+jest.mock("../../src/models/task");
+jest.mock("../../src/models/inventory", () => ({
   InventoryItemModel: {
     find: jest.fn(),
   },
@@ -15,21 +21,22 @@ jest.mock('../../src/models/inventory', () => ({
   },
 }));
 
-describe('DashboardService', () => {
-  const mockOrgId = 'org-123';
+describe("DashboardService", () => {
+  const mockOrgId = "org-123";
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   // --- 1. getSummary ---
-  describe('getSummary', () => {
-    it('should throw if organisationId is missing', async () => {
-      await expect(DashboardService.getSummary({ organisationId: '', range: 'today' }))
-        .rejects.toThrow('organisationId is required');
+  describe("getSummary", () => {
+    it("should throw if organisationId is missing", async () => {
+      await expect(
+        DashboardService.getSummary({ organisationId: "", range: "today" }),
+      ).rejects.toThrow("organisationId is required");
     });
 
-    it('should return summary data correctly', async () => {
+    it("should return summary data correctly", async () => {
       // Mock Appointment Aggregation
       const mockAgg = [{ _id: null, revenue: 1000, count: 5 }];
       (AppointmentModel.aggregate as jest.Mock).mockResolvedValue(mockAgg);
@@ -38,7 +45,10 @@ describe('DashboardService', () => {
       const mockTaskCount = { exec: jest.fn().mockResolvedValue(10) };
       (TaskModel.countDocuments as jest.Mock).mockReturnValue(mockTaskCount);
 
-      const result = await DashboardService.getSummary({ organisationId: mockOrgId, range: 'today' });
+      const result = await DashboardService.getSummary({
+        organisationId: mockOrgId,
+        range: "today",
+      });
 
       expect(AppointmentModel.aggregate).toHaveBeenCalled();
       expect(result).toEqual({
@@ -49,236 +59,285 @@ describe('DashboardService', () => {
       });
     });
 
-    it('should handle empty aggregation results (defaults to 0)', async () => {
+    it("should handle empty aggregation results (defaults to 0)", async () => {
       (AppointmentModel.aggregate as jest.Mock).mockResolvedValue([]);
-      (TaskModel.countDocuments as jest.Mock).mockReturnValue({ exec: jest.fn().mockResolvedValue(0) });
+      (TaskModel.countDocuments as jest.Mock).mockReturnValue({
+        exec: jest.fn().mockResolvedValue(0),
+      });
 
-      const result = await DashboardService.getSummary({ organisationId: mockOrgId, range: 'today' });
+      const result = await DashboardService.getSummary({
+        organisationId: mockOrgId,
+        range: "today",
+      });
 
       expect(result.revenue).toBe(0);
       expect(result.appointments).toBe(0);
     });
 
     // Test different ranges to cover switch case in resolveRange
-    const ranges: SummaryRange[] = ['today', 'yesterday', 'last_7_days', 'last_30_days', 'this_week', 'last_week', 'this_month', 'last_month'];
-    test.each(ranges)('should resolve date range for %s', async (range) => {
-        (AppointmentModel.aggregate as jest.Mock).mockResolvedValue([]);
-        (TaskModel.countDocuments as jest.Mock).mockReturnValue({ exec: jest.fn().mockResolvedValue(0) });
+    const ranges: SummaryRange[] = [
+      "today",
+      "yesterday",
+      "last_7_days",
+      "last_30_days",
+      "this_week",
+      "last_week",
+      "this_month",
+      "last_month",
+    ];
+    test.each(ranges)("should resolve date range for %s", async (range) => {
+      (AppointmentModel.aggregate as jest.Mock).mockResolvedValue([]);
+      (TaskModel.countDocuments as jest.Mock).mockReturnValue({
+        exec: jest.fn().mockResolvedValue(0),
+      });
 
-        await DashboardService.getSummary({ organisationId: mockOrgId, range });
-        // Implicitly checks execution path without throwing
-        expect(AppointmentModel.aggregate).toHaveBeenCalled();
+      await DashboardService.getSummary({ organisationId: mockOrgId, range });
+      // Implicitly checks execution path without throwing
+      expect(AppointmentModel.aggregate).toHaveBeenCalled();
     });
 
-    it('should fallback to default range logic for unknown inputs', async () => {
-         // @ts-ignore - testing runtime fallback
-         await DashboardService.getSummary({ organisationId: mockOrgId, range: 'unknown' });
-         expect(AppointmentModel.aggregate).toHaveBeenCalled();
+    it("should fallback to default range logic for unknown inputs", async () => {
+      await DashboardService.getSummary({
+        organisationId: mockOrgId,
+        range: "unknown" as SummaryRange,
+      });
+      expect(AppointmentModel.aggregate).toHaveBeenCalled();
     });
   });
 
   // --- 2. getAppointmentsTrend ---
-  describe('getAppointmentsTrend', () => {
-    it('should throw if organisationId is missing', async () => {
-      await expect(DashboardService.getAppointmentsTrend({ organisationId: '' }))
-        .rejects.toThrow('organisationId is required');
+  describe("getAppointmentsTrend", () => {
+    it("should throw if organisationId is missing", async () => {
+      await expect(
+        DashboardService.getAppointmentsTrend({ organisationId: "" }),
+      ).rejects.toThrow("organisationId is required");
     });
 
-    it('should return trend data', async () => {
+    it("should return trend data", async () => {
       const mockAgg = [
         { _id: { year: 2023, month: 1 }, completed: 10, cancelled: 2 },
         { _id: { year: 2023, month: 2 }, completed: 15, cancelled: 0 },
       ];
       (AppointmentModel.aggregate as jest.Mock).mockResolvedValue(mockAgg);
 
-      const result = await DashboardService.getAppointmentsTrend({ organisationId: mockOrgId });
+      const result = await DashboardService.getAppointmentsTrend({
+        organisationId: mockOrgId,
+      });
 
       expect(result).toHaveLength(2);
-      expect(result[0].label).toBe('Jan');
+      expect(result[0].label).toBe("Jan");
       expect(result[0].completed).toBe(10);
     });
 
-    it('should handle empty aggregation fields (defaults)', async () => {
-        const mockAgg = [{ _id: { year: 2023, month: 1 } }]; // missing completed/cancelled
-        (AppointmentModel.aggregate as jest.Mock).mockResolvedValue(mockAgg);
+    it("should handle empty aggregation fields (defaults)", async () => {
+      const mockAgg = [{ _id: { year: 2023, month: 1 } }]; // missing completed/cancelled
+      (AppointmentModel.aggregate as jest.Mock).mockResolvedValue(mockAgg);
 
-        const result = await DashboardService.getAppointmentsTrend({ organisationId: mockOrgId });
-        expect(result[0].completed).toBe(0);
-        expect(result[0].cancelled).toBe(0);
+      const result = await DashboardService.getAppointmentsTrend({
+        organisationId: mockOrgId,
+      });
+      expect(result[0].completed).toBe(0);
+      expect(result[0].cancelled).toBe(0);
     });
   });
 
   // --- 3. getRevenueTrend ---
-  describe('getRevenueTrend', () => {
-    it('should throw if organisationId is missing', async () => {
-        await expect(DashboardService.getRevenueTrend({ organisationId: '' }))
-          .rejects.toThrow('organisationId is required');
+  describe("getRevenueTrend", () => {
+    it("should throw if organisationId is missing", async () => {
+      await expect(
+        DashboardService.getRevenueTrend({ organisationId: "" }),
+      ).rejects.toThrow("organisationId is required");
     });
 
-    it('should return revenue trend', async () => {
-        const mockAgg = [{ _id: { year: 2023, month: 1 }, revenue: 5000 }];
-        (AppointmentModel.aggregate as jest.Mock).mockResolvedValue(mockAgg);
+    it("should return revenue trend", async () => {
+      const mockAgg = [{ _id: { year: 2023, month: 1 }, revenue: 5000 }];
+      (AppointmentModel.aggregate as jest.Mock).mockResolvedValue(mockAgg);
 
-        const result = await DashboardService.getRevenueTrend({ organisationId: mockOrgId });
-        expect(result[0].revenue).toBe(5000);
-        expect(result[0].label).toBe('Jan');
+      const result = await DashboardService.getRevenueTrend({
+        organisationId: mockOrgId,
+      });
+      expect(result[0].revenue).toBe(5000);
+      expect(result[0].label).toBe("Jan");
     });
   });
 
   // --- 4. getAppointmentLeaders ---
-  describe('getAppointmentLeaders', () => {
-    it('should throw if organisationId is missing', async () => {
-        await expect(DashboardService.getAppointmentLeaders({ organisationId: '' }))
-          .rejects.toThrow('organisationId is required');
+  describe("getAppointmentLeaders", () => {
+    it("should throw if organisationId is missing", async () => {
+      await expect(
+        DashboardService.getAppointmentLeaders({ organisationId: "" }),
+      ).rejects.toThrow("organisationId is required");
     });
 
-    it('should return leaders', async () => {
-        const mockAgg = [
-            { _id: 'staff-1', completedAppointments: 20 },
-            { _id: null, completedAppointments: 5 } // Unknown staff
-        ];
-        (AppointmentModel.aggregate as jest.Mock).mockResolvedValue(mockAgg);
+    it("should return leaders", async () => {
+      const mockAgg = [
+        { _id: "staff-1", completedAppointments: 20 },
+        { _id: null, completedAppointments: 5 }, // Unknown staff
+      ];
+      (AppointmentModel.aggregate as jest.Mock).mockResolvedValue(mockAgg);
 
-        const result = await DashboardService.getAppointmentLeaders({ organisationId: mockOrgId });
+      const result = await DashboardService.getAppointmentLeaders({
+        organisationId: mockOrgId,
+      });
 
-        expect(result).toHaveLength(2);
-        expect(result[0].staffId).toBe('staff-1');
-        expect(result[1].staffId).toBe('unknown');
+      expect(result).toHaveLength(2);
+      expect(result[0].staffId).toBe("staff-1");
+      expect(result[1].staffId).toBe("unknown");
     });
   });
 
   // --- 5. getRevenueLeaders ---
-  describe('getRevenueLeaders', () => {
-    it('should throw if organisationId is missing', async () => {
-        await expect(DashboardService.getRevenueLeaders({ organisationId: '' }))
-          .rejects.toThrow('organisationId is required');
+  describe("getRevenueLeaders", () => {
+    it("should throw if organisationId is missing", async () => {
+      await expect(
+        DashboardService.getRevenueLeaders({ organisationId: "" }),
+      ).rejects.toThrow("organisationId is required");
     });
 
-    it('should return revenue leaders', async () => {
-        const mockAgg = [
-            { _id: 'SOP-A', revenue: 1000 },
-            { _id: null, revenue: 500 }
-        ];
-        (AppointmentModel.aggregate as jest.Mock).mockResolvedValue(mockAgg);
+    it("should return revenue leaders", async () => {
+      const mockAgg = [
+        { _id: "SOP-A", revenue: 1000 },
+        { _id: null, revenue: 500 },
+      ];
+      (AppointmentModel.aggregate as jest.Mock).mockResolvedValue(mockAgg);
 
-        const result = await DashboardService.getRevenueLeaders({ organisationId: mockOrgId });
+      const result = await DashboardService.getRevenueLeaders({
+        organisationId: mockOrgId,
+      });
 
-        expect(result[0].serviceKey).toBe('SOP-A');
-        expect(result[1].label).toBe('Unknown');
-        expect(result[1].revenue).toBe(500);
+      expect(result[0].serviceKey).toBe("SOP-A");
+      expect(result[1].label).toBe("Unknown");
+      expect(result[1].revenue).toBe(500);
     });
   });
 
   // --- 6. getInventoryTurnover ---
-  describe('getInventoryTurnover', () => {
-    it('should throw if organisationId is missing', async () => {
-        await expect(DashboardService.getInventoryTurnover({ organisationId: '' }))
-          .rejects.toThrow('organisationId is required');
+  describe("getInventoryTurnover", () => {
+    it("should throw if organisationId is missing", async () => {
+      await expect(
+        DashboardService.getInventoryTurnover({ organisationId: "" }),
+      ).rejects.toThrow("organisationId is required");
     });
 
-    it('should calculate turnover correctly', async () => {
-        // Mock Consumption Aggregation
-        (StockMovementModel.aggregate as jest.Mock)
-          .mockResolvedValueOnce([{ totalConsumed: 100 }]) // First call: total consumption
-          .mockResolvedValueOnce([ // Second call: monthly trend
-              { _id: { year: 2023, month: 1 }, consumed: 10 }
-          ]);
+    it("should calculate turnover correctly", async () => {
+      // Mock Consumption Aggregation
+      (StockMovementModel.aggregate as jest.Mock)
+        .mockResolvedValueOnce([{ totalConsumed: 100 }]) // First call: total consumption
+        .mockResolvedValueOnce([
+          // Second call: monthly trend
+          { _id: { year: 2023, month: 1 }, consumed: 10 },
+        ]);
 
-        // Mock Inventory Items (for onHand average)
-        // totalOnHand = 10 + 0 = 10. Avg = 10.
-        (InventoryItemModel.find as jest.Mock).mockReturnValue({
-            lean: jest.fn().mockReturnValue({
-                exec: jest.fn().mockResolvedValue([{ onHand: 10 }, { onHand: undefined }])
-            })
-        });
+      // Mock Inventory Items (for onHand average)
+      // totalOnHand = 10 + 0 = 10. Avg = 10.
+      (InventoryItemModel.find as jest.Mock).mockReturnValue({
+        lean: jest.fn().mockReturnValue({
+          exec: jest
+            .fn()
+            .mockResolvedValue([{ onHand: 10 }, { onHand: undefined }]),
+        }),
+      });
 
-        const result = await DashboardService.getInventoryTurnover({ organisationId: mockOrgId });
+      const result = await DashboardService.getInventoryTurnover({
+        organisationId: mockOrgId,
+      });
 
-        // Turns = TotalConsumed (100) / TotalOnHand (10) = 10
-        expect(result.turnsPerYear).toBe(10);
-        // Days = 365 / 10 = 36.5 -> 37
-        expect(result.restockCycleDays).toBe(37);
-        // Trend calculation: 10 (consumed) / 10 (avgOnHand) = 1
-        expect(result.trend[0].turnover).toBe(1);
+      // Turns = TotalConsumed (100) / TotalOnHand (10) = 10
+      expect(result.turnsPerYear).toBe(10);
+      // Days = 365 / 10 = 36.5 -> 37
+      expect(result.restockCycleDays).toBe(37);
+      // Trend calculation: 10 (consumed) / 10 (avgOnHand) = 1
+      expect(result.trend[0].turnover).toBe(1);
     });
 
-    it('should handle zero onHand (avoid division by zero)', async () => {
-        (StockMovementModel.aggregate as jest.Mock)
-           .mockResolvedValueOnce([{ totalConsumed: 100 }])
-           .mockResolvedValueOnce([]); // No monthly trend
+    it("should handle zero onHand (avoid division by zero)", async () => {
+      (StockMovementModel.aggregate as jest.Mock)
+        .mockResolvedValueOnce([{ totalConsumed: 100 }])
+        .mockResolvedValueOnce([]); // No monthly trend
 
-        (InventoryItemModel.find as jest.Mock).mockReturnValue({
-            lean: jest.fn().mockReturnValue({
-                exec: jest.fn().mockResolvedValue([]) // No items
-            })
-        });
+      (InventoryItemModel.find as jest.Mock).mockReturnValue({
+        lean: jest.fn().mockReturnValue({
+          exec: jest.fn().mockResolvedValue([]), // No items
+        }),
+      });
 
-        const result = await DashboardService.getInventoryTurnover({ organisationId: mockOrgId });
+      const result = await DashboardService.getInventoryTurnover({
+        organisationId: mockOrgId,
+      });
 
-        // totalOnHand = 0 -> avgOnHand defaults to 1
-        expect(result.turnsPerYear).toBe(100);
+      // totalOnHand = 0 -> avgOnHand defaults to 1
+      expect(result.turnsPerYear).toBe(100);
     });
 
-    it('should handle zero turnover', async () => {
-         (StockMovementModel.aggregate as jest.Mock)
-            .mockResolvedValueOnce([]) // No consumption
-            .mockResolvedValueOnce([]);
+    it("should handle zero turnover", async () => {
+      (StockMovementModel.aggregate as jest.Mock)
+        .mockResolvedValueOnce([]) // No consumption
+        .mockResolvedValueOnce([]);
 
-         (InventoryItemModel.find as jest.Mock).mockReturnValue({
-             lean: jest.fn().mockReturnValue({
-                 exec: jest.fn().mockResolvedValue([{ onHand: 10 }])
-             })
-         });
+      (InventoryItemModel.find as jest.Mock).mockReturnValue({
+        lean: jest.fn().mockReturnValue({
+          exec: jest.fn().mockResolvedValue([{ onHand: 10 }]),
+        }),
+      });
 
-         const result = await DashboardService.getInventoryTurnover({ organisationId: mockOrgId });
-         expect(result.turnsPerYear).toBe(0);
-         expect(result.restockCycleDays).toBeNull();
+      const result = await DashboardService.getInventoryTurnover({
+        organisationId: mockOrgId,
+      });
+      expect(result.turnsPerYear).toBe(0);
+      expect(result.restockCycleDays).toBeNull();
     });
   });
 
   // --- 7. getProductTurnover ---
-  describe('getProductTurnover', () => {
-      it('should throw if organisationId is missing', async () => {
-          await expect(DashboardService.getProductTurnover({ organisationId: '' }))
-            .rejects.toThrow('organisationId is required');
+  describe("getProductTurnover", () => {
+    it("should throw if organisationId is missing", async () => {
+      await expect(
+        DashboardService.getProductTurnover({ organisationId: "" }),
+      ).rejects.toThrow("organisationId is required");
+    });
+
+    it("should calculate product turnover", async () => {
+      const itemId = "item-1";
+      // Mock Aggregation
+      const aggResult = [{ _id: itemId, consumed: 50 }];
+      (StockMovementModel.aggregate as jest.Mock).mockResolvedValue(aggResult);
+
+      // Mock Item Lookup
+      const items = [{ _id: itemId, name: "Product A", onHand: 5 }];
+      (InventoryItemModel.find as jest.Mock).mockReturnValue({
+        lean: jest.fn().mockReturnValue({
+          exec: jest.fn().mockResolvedValue(items),
+        }),
       });
 
-      it('should calculate product turnover', async () => {
-          const itemId = 'item-1';
-          // Mock Aggregation
-          const aggResult = [{ _id: itemId, consumed: 50 }];
-          (StockMovementModel.aggregate as jest.Mock).mockResolvedValue(aggResult);
-
-          // Mock Item Lookup
-          const items = [{ _id: itemId, name: 'Product A', onHand: 5 }];
-          (InventoryItemModel.find as jest.Mock).mockReturnValue({
-              lean: jest.fn().mockReturnValue({
-                  exec: jest.fn().mockResolvedValue(items)
-              })
-          });
-
-          const result = await DashboardService.getProductTurnover({ organisationId: mockOrgId });
-
-          // Turnover = 50 (consumed) / 5 (onHand) = 10
-          expect(result[0].turnover).toBe(10);
-          expect(result[0].name).toBe('Product A');
+      const result = await DashboardService.getProductTurnover({
+        organisationId: mockOrgId,
       });
 
-      it('should handle unknown items and zero onHand', async () => {
-          const itemId = 'item-unknown';
-          (StockMovementModel.aggregate as jest.Mock).mockResolvedValue([{ _id: itemId, consumed: 10 }]);
+      // Turnover = 50 (consumed) / 5 (onHand) = 10
+      expect(result[0].turnover).toBe(10);
+      expect(result[0].name).toBe("Product A");
+    });
 
-          (InventoryItemModel.find as jest.Mock).mockReturnValue({
-              lean: jest.fn().mockReturnValue({
-                  exec: jest.fn().mockResolvedValue([]) // Item not found in DB
-              })
-          });
+    it("should handle unknown items and zero onHand", async () => {
+      const itemId = "item-unknown";
+      (StockMovementModel.aggregate as jest.Mock).mockResolvedValue([
+        { _id: itemId, consumed: 10 },
+      ]);
 
-          const result = await DashboardService.getProductTurnover({ organisationId: mockOrgId });
-
-          expect(result[0].name).toBe('Unknown');
-          // onHand defaults to 0 -> avg defaults to 1. Turnover = 10 / 1 = 10.
-          expect(result[0].turnover).toBe(10);
+      (InventoryItemModel.find as jest.Mock).mockReturnValue({
+        lean: jest.fn().mockReturnValue({
+          exec: jest.fn().mockResolvedValue([]), // Item not found in DB
+        }),
       });
+
+      const result = await DashboardService.getProductTurnover({
+        organisationId: mockOrgId,
+      });
+
+      expect(result[0].name).toBe("Unknown");
+      // onHand defaults to 0 -> avg defaults to 1. Turnover = 10 / 1 = 10.
+      expect(result[0].turnover).toBe(10);
+    });
   });
 });

--- a/apps/backend/test/services/deviceToken.service.test.ts
+++ b/apps/backend/test/services/deviceToken.service.test.ts
@@ -6,7 +6,7 @@ jest.mock("../../src/models/deviceToken", () => ({
     updateOne: jest.fn(),
     find: jest.fn(),
     deleteOne: jest.fn(),
-  },    
+  },
 }));
 
 const mockedDeviceTokenModel = DeviceTokenModel as unknown as {

--- a/apps/backend/test/services/document.service.test.ts
+++ b/apps/backend/test/services/document.service.test.ts
@@ -1,18 +1,18 @@
-import { Types } from 'mongoose';
-import { DocumentService } from '../../src/services/document.service';
-import DocumentModel from '../../src/models/document';
-import * as UploadMiddleware from '../../src/middlewares/upload';
+import { Types } from "mongoose";
+import { DocumentService } from "../../src/services/document.service";
+import DocumentModel from "../../src/models/document";
+import * as UploadMiddleware from "../../src/middlewares/upload";
 
 // --- Mocks ---
-jest.mock('../../src/models/document');
-jest.mock('../../src/middlewares/upload');
+jest.mock("../../src/models/document");
+jest.mock("../../src/middlewares/upload");
 
-describe('DocumentService', () => {
+describe("DocumentService", () => {
   const validObjectId = new Types.ObjectId().toString();
   const validParentId = new Types.ObjectId().toString();
   const validCompanionId = new Types.ObjectId().toString();
 
-  const mockDate = new Date('2023-01-01T00:00:00.000Z');
+  const mockDate = new Date("2023-01-01T00:00:00.000Z");
 
   // Helper to create a mock document structure
   const createMockDoc = (overrides = {}) => {
@@ -20,10 +20,10 @@ describe('DocumentService', () => {
       _id: new Types.ObjectId(validObjectId),
       companionId: new Types.ObjectId(validCompanionId),
       uploadedByParentId: new Types.ObjectId(validParentId),
-      category: 'HEALTH',
-      subcategory: 'HOSPITAL_VISITS',
-      title: 'Test Doc',
-      attachments: [{ key: 'k1', mimeType: 'application/pdf', size: 1024 }],
+      category: "HEALTH",
+      subcategory: "HOSPITAL_VISITS",
+      title: "Test Doc",
+      attachments: [{ key: "k1", mimeType: "application/pdf", size: 1024 }],
       pmsVisible: true,
       syncedFromPms: false,
       createdAt: mockDate,
@@ -42,269 +42,354 @@ describe('DocumentService', () => {
   });
 
   // 1. Validation & Input Handling
-  describe('Input Validation', () => {
+  describe("Input Validation", () => {
     const validInput: any = {
       companionId: validCompanionId,
-      category: 'HEALTH',
-      subcategory: 'HOSPITAL_VISITS',
-      title: 'Report',
-      attachments: [{ key: 'k1', mimeType: 'pdf' }],
-      issueDate: '2023-01-01'
+      category: "HEALTH",
+      subcategory: "HOSPITAL_VISITS",
+      title: "Report",
+      attachments: [{ key: "k1", mimeType: "pdf" }],
+      issueDate: "2023-01-01",
     };
 
-    it('should throw if title is empty', async () => {
-      await expect(DocumentService.create({ ...validInput, title: ' ' }, { parentId: validParentId }))
-        .rejects.toThrow('Document title is required.');
+    it("should throw if title is empty", async () => {
+      await expect(
+        DocumentService.create(
+          { ...validInput, title: " " },
+          { parentId: validParentId },
+        ),
+      ).rejects.toThrow("Document title is required.");
     });
 
-    it('should throw if attachments are empty', async () => {
-      await expect(DocumentService.create({ ...validInput, attachments: [] }, { parentId: validParentId }))
-        .rejects.toThrow('At least one attachment is required.');
+    it("should throw if attachments are empty", async () => {
+      await expect(
+        DocumentService.create(
+          { ...validInput, attachments: [] },
+          { parentId: validParentId },
+        ),
+      ).rejects.toThrow("At least one attachment is required.");
     });
 
-    it('should throw if ID is invalid format', async () => {
-      await expect(DocumentService.create({ ...validInput, companionId: 'invalid' }, { parentId: validParentId }))
-        .rejects.toThrow('Invalid companionId');
+    it("should throw if ID is invalid format", async () => {
+      await expect(
+        DocumentService.create(
+          { ...validInput, companionId: "invalid" },
+          { parentId: validParentId },
+        ),
+      ).rejects.toThrow("Invalid companionId");
     });
 
-    it('should throw if category is invalid', async () => {
-      await expect(DocumentService.create({ ...validInput, category: 'INVALID' }, { parentId: validParentId }))
-        .rejects.toThrow('Invalid document category: INVALID');
+    it("should throw if category is invalid", async () => {
+      await expect(
+        DocumentService.create(
+          { ...validInput, category: "INVALID" },
+          { parentId: validParentId },
+        ),
+      ).rejects.toThrow("Invalid document category: INVALID");
     });
 
-    it('should throw if subcategory is invalid for category', async () => {
-      await expect(DocumentService.create({
-          ...validInput,
-          category: 'HEALTH',
-          subcategory: 'PASSPORT' // PASSPORT is ADMIN, not HEALTH
-        }, { parentId: validParentId }))
-        .rejects.toThrow("Invalid subcategory 'PASSPORT' for category 'HEALTH'");
+    it("should throw if subcategory is invalid for category", async () => {
+      await expect(
+        DocumentService.create(
+          {
+            ...validInput,
+            category: "HEALTH",
+            subcategory: "PASSPORT", // PASSPORT is ADMIN, not HEALTH
+          },
+          { parentId: validParentId },
+        ),
+      ).rejects.toThrow("Invalid subcategory 'PASSPORT' for category 'HEALTH'");
     });
   });
 
   // 2. Create Document
-  describe('create', () => {
+  describe("create", () => {
     const input: any = {
-        companionId: validCompanionId,
-        category: 'HEALTH',
-        subcategory: 'HOSPITAL_VISITS',
-        title: 'Report',
-        attachments: [{ key: 'k1', mimeType: 'pdf' }],
-        issueDate: mockDate
+      companionId: validCompanionId,
+      category: "HEALTH",
+      subcategory: "HOSPITAL_VISITS",
+      title: "Report",
+      attachments: [{ key: "k1", mimeType: "pdf" }],
+      issueDate: mockDate,
     };
 
-    it('should create document from Parent source', async () => {
-        const mockDoc = createMockDoc();
-        (DocumentModel.create as jest.Mock).mockResolvedValue(mockDoc);
+    it("should create document from Parent source", async () => {
+      const mockDoc = createMockDoc();
+      (DocumentModel.create as jest.Mock).mockResolvedValue(mockDoc);
 
-        const res = await DocumentService.create(input, { parentId: validParentId });
+      const res = await DocumentService.create(input, {
+        parentId: validParentId,
+      });
 
-        expect(DocumentModel.create).toHaveBeenCalledWith(expect.objectContaining({
-            uploadedByParentId: expect.any(Types.ObjectId),
-            syncedFromPms: false
-        }));
-        expect(res.id).toBe(validObjectId);
+      expect(DocumentModel.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          uploadedByParentId: expect.any(Types.ObjectId),
+          syncedFromPms: false,
+        }),
+      );
+      expect(res.id).toBe(validObjectId);
     });
 
-    it('should create document from PMS source', async () => {
-        const mockDoc = createMockDoc({ uploadedByPmsUserId: 'pms1', uploadedByParentId: null });
-        (DocumentModel.create as jest.Mock).mockResolvedValue(mockDoc);
+    it("should create document from PMS source", async () => {
+      const mockDoc = createMockDoc({
+        uploadedByPmsUserId: "pms1",
+        uploadedByParentId: null,
+      });
+      (DocumentModel.create as jest.Mock).mockResolvedValue(mockDoc);
 
-        const res = await DocumentService.create(input, { pmsUserId: 'pms1' });
+      const res = await DocumentService.create(input, { pmsUserId: "pms1" });
 
-        expect(DocumentModel.create).toHaveBeenCalledWith(expect.objectContaining({
-            uploadedByPmsUserId: 'pms1',
-            syncedFromPms: true
-        }));
-        expect(res.uploadedByPmsUserId).toBe('pms1');
+      expect(DocumentModel.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          uploadedByPmsUserId: "pms1",
+          syncedFromPms: true,
+        }),
+      );
+      expect(res.uploadedByPmsUserId).toBe("pms1");
     });
 
-    it('should handle string date input', async () => {
-        const mockDoc = createMockDoc();
-        (DocumentModel.create as jest.Mock).mockResolvedValue(mockDoc);
+    it("should handle string date input", async () => {
+      const mockDoc = createMockDoc();
+      (DocumentModel.create as jest.Mock).mockResolvedValue(mockDoc);
 
-        await DocumentService.create({ ...input, issueDate: '2023-01-01' }, { parentId: validParentId });
+      await DocumentService.create(
+        { ...input, issueDate: "2023-01-01" },
+        { parentId: validParentId },
+      );
 
-        expect(DocumentModel.create).toHaveBeenCalledWith(expect.objectContaining({
-            issueDate: new Date('2023-01-01')
-        }));
+      expect(DocumentModel.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          issueDate: new Date("2023-01-01"),
+        }),
+      );
     });
   });
 
   // 3. List Methods
-  describe('List Operations', () => {
+  describe("List Operations", () => {
     const mockFindChain = (docs: any[]) => ({
-        sort: jest.fn().mockReturnValue({
-            exec: jest.fn().mockResolvedValue(docs)
-        })
+      sort: jest.fn().mockReturnValue({
+        exec: jest.fn().mockResolvedValue(docs),
+      }),
     });
 
-    it('listForParent: should filter by companion and optional categories', async () => {
-        (DocumentModel.find as jest.Mock).mockReturnValue(mockFindChain([createMockDoc()]));
+    it("listForParent: should filter by companion and optional categories", async () => {
+      (DocumentModel.find as jest.Mock).mockReturnValue(
+        mockFindChain([createMockDoc()]),
+      );
 
-        await DocumentService.listForParent({
-            companionId: validCompanionId,
-            category: 'HEALTH',
-            subcategory: 'HOSPITAL_VISITS'
-        });
+      await DocumentService.listForParent({
+        companionId: validCompanionId,
+        category: "HEALTH",
+        subcategory: "HOSPITAL_VISITS",
+      });
 
-        expect(DocumentModel.find).toHaveBeenCalledWith({
-            companionId: expect.any(Types.ObjectId),
-            category: 'HEALTH',
-            subcategory: 'HOSPITAL_VISITS'
-        });
+      expect(DocumentModel.find).toHaveBeenCalledWith({
+        companionId: expect.any(Types.ObjectId),
+        category: "HEALTH",
+        subcategory: "HOSPITAL_VISITS",
+      });
     });
 
-    it('listForPms: should filter only pmsVisible documents', async () => {
-        (DocumentModel.find as jest.Mock).mockReturnValue(mockFindChain([createMockDoc()]));
+    it("listForPms: should filter only pmsVisible documents", async () => {
+      (DocumentModel.find as jest.Mock).mockReturnValue(
+        mockFindChain([createMockDoc()]),
+      );
 
-        await DocumentService.listForPms({ companionId: validCompanionId });
+      await DocumentService.listForPms({ companionId: validCompanionId });
 
-        expect(DocumentModel.find).toHaveBeenCalledWith(expect.objectContaining({
-            pmsVisible: true
-        }));
+      expect(DocumentModel.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pmsVisible: true,
+        }),
+      );
     });
 
-    it('listForAppointmentParent: should filter by appointmentId', async () => {
-        (DocumentModel.find as jest.Mock).mockReturnValue(mockFindChain([createMockDoc()]));
+    it("listForAppointmentParent: should filter by appointmentId", async () => {
+      (DocumentModel.find as jest.Mock).mockReturnValue(
+        mockFindChain([createMockDoc()]),
+      );
 
-        await DocumentService.listForAppointmentParent(validObjectId);
+      await DocumentService.listForAppointmentParent(validObjectId);
 
-        expect(DocumentModel.find).toHaveBeenCalledWith({ appointmentId: expect.any(Types.ObjectId) });
+      expect(DocumentModel.find).toHaveBeenCalledWith({
+        appointmentId: expect.any(Types.ObjectId),
+      });
     });
 
-    it('listForAppointmentPms: should filter by appointmentId AND pmsVisible', async () => {
-        (DocumentModel.find as jest.Mock).mockReturnValue(mockFindChain([createMockDoc()]));
+    it("listForAppointmentPms: should filter by appointmentId AND pmsVisible", async () => {
+      (DocumentModel.find as jest.Mock).mockReturnValue(
+        mockFindChain([createMockDoc()]),
+      );
 
-        await DocumentService.listForAppointmentPms({
-            companionId: validCompanionId,
-            appointmentId: validObjectId
-        });
+      await DocumentService.listForAppointmentPms({
+        companionId: validCompanionId,
+        appointmentId: validObjectId,
+      });
 
-        expect(DocumentModel.find).toHaveBeenCalledWith(expect.objectContaining({
-            pmsVisible: true,
-            appointmentId: expect.any(Types.ObjectId)
-        }));
+      expect(DocumentModel.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pmsVisible: true,
+          appointmentId: expect.any(Types.ObjectId),
+        }),
+      );
     });
   });
 
   // 4. Get By ID
-  describe('getById', () => {
-      it('getByIdForParent: returns null if not found', async () => {
-          (DocumentModel.findById as jest.Mock).mockReturnValue({ exec: jest.fn().mockResolvedValue(null) });
-          expect(await DocumentService.getByIdForParent(validObjectId)).toBeNull();
+  describe("getById", () => {
+    it("getByIdForParent: returns null if not found", async () => {
+      (DocumentModel.findById as jest.Mock).mockReturnValue({
+        exec: jest.fn().mockResolvedValue(null),
       });
+      expect(await DocumentService.getByIdForParent(validObjectId)).toBeNull();
+    });
 
-      it('getByIdForParent: returns dto if found', async () => {
-          (DocumentModel.findById as jest.Mock).mockReturnValue({ exec: jest.fn().mockResolvedValue(createMockDoc()) });
-          const res = await DocumentService.getByIdForParent(validObjectId);
-          expect(res?.id).toBe(validObjectId);
+    it("getByIdForParent: returns dto if found", async () => {
+      (DocumentModel.findById as jest.Mock).mockReturnValue({
+        exec: jest.fn().mockResolvedValue(createMockDoc()),
       });
+      const res = await DocumentService.getByIdForParent(validObjectId);
+      expect(res?.id).toBe(validObjectId);
+    });
 
-      it('getByIdForPms: returns null if not found or not visible', async () => {
-        (DocumentModel.findOne as jest.Mock).mockReturnValue({ exec: jest.fn().mockResolvedValue(null) });
-        expect(await DocumentService.getByIdForPms(validObjectId)).toBeNull();
+    it("getByIdForPms: returns null if not found or not visible", async () => {
+      (DocumentModel.findOne as jest.Mock).mockReturnValue({
+        exec: jest.fn().mockResolvedValue(null),
       });
+      expect(await DocumentService.getByIdForPms(validObjectId)).toBeNull();
+    });
   });
 
   // 5. Delete
-  describe('deleteForParent', () => {
-      it('should throw 404 if document does not exist or parent does not own it', async () => {
-          (DocumentModel.findOne as jest.Mock).mockReturnValue({ exec: jest.fn().mockResolvedValue(null) });
-
-          await expect(DocumentService.deleteForParent(validObjectId, validParentId))
-            .rejects.toThrow('Document not found or not deletable.');
+  describe("deleteForParent", () => {
+    it("should throw 404 if document does not exist or parent does not own it", async () => {
+      (DocumentModel.findOne as jest.Mock).mockReturnValue({
+        exec: jest.fn().mockResolvedValue(null),
       });
 
-      it('should delete from S3 and DB if valid', async () => {
-          const doc = createMockDoc({ attachments: [{ key: 'k1' }, { key: 'k2' }] });
-          (DocumentModel.findOne as jest.Mock).mockReturnValue({ exec: jest.fn().mockResolvedValue(doc) });
-          (DocumentModel.deleteOne as jest.Mock).mockReturnValue({ exec: jest.fn().mockResolvedValue({}) });
+      await expect(
+        DocumentService.deleteForParent(validObjectId, validParentId),
+      ).rejects.toThrow("Document not found or not deletable.");
+    });
 
-          await DocumentService.deleteForParent(validObjectId, validParentId);
-
-          expect(UploadMiddleware.deleteFromS3).toHaveBeenCalledTimes(2);
-          expect(DocumentModel.deleteOne).toHaveBeenCalled();
+    it("should delete from S3 and DB if valid", async () => {
+      const doc = createMockDoc({
+        attachments: [{ key: "k1" }, { key: "k2" }],
       });
+      (DocumentModel.findOne as jest.Mock).mockReturnValue({
+        exec: jest.fn().mockResolvedValue(doc),
+      });
+      (DocumentModel.deleteOne as jest.Mock).mockReturnValue({
+        exec: jest.fn().mockResolvedValue({}),
+      });
+
+      await DocumentService.deleteForParent(validObjectId, validParentId);
+
+      expect(UploadMiddleware.deleteFromS3).toHaveBeenCalledTimes(2);
+      expect(DocumentModel.deleteOne).toHaveBeenCalled();
+    });
   });
 
   // 6. Update
-  describe('update', () => {
-      it('should throw 404 if not found', async () => {
-          (DocumentModel.findById as jest.Mock).mockResolvedValue(null);
-          await expect(DocumentService.update(validObjectId, {}, {}))
-            .rejects.toThrow('Document not found');
+  describe("update", () => {
+    it("should throw 404 if not found", async () => {
+      (DocumentModel.findById as jest.Mock).mockResolvedValue(null);
+      await expect(
+        DocumentService.update(validObjectId, {}, {}),
+      ).rejects.toThrow("Document not found");
+    });
+
+    it("should throw 403 if parent tries to update others doc", async () => {
+      const doc = createMockDoc({ uploadedByParentId: new Types.ObjectId() }); // different parent
+      (DocumentModel.findById as jest.Mock).mockResolvedValue(doc);
+
+      await expect(
+        DocumentService.update(validObjectId, {}, { parentId: validParentId }),
+      ).rejects.toThrow("Parent is not allowed to update this document");
+    });
+
+    it("should throw 403 if PMS tries to update parent doc", async () => {
+      const doc = createMockDoc({ syncedFromPms: false });
+      (DocumentModel.findById as jest.Mock).mockResolvedValue(doc);
+
+      await expect(
+        DocumentService.update(validObjectId, {}, { pmsUserId: "pms1" }),
+      ).rejects.toThrow("PMS cannot update documents uploaded by parent");
+    });
+
+    it("should update fields and save", async () => {
+      const doc = createMockDoc({
+        uploadedByParentId: new Types.ObjectId(validParentId),
+      });
+      (DocumentModel.findById as jest.Mock).mockResolvedValue(doc);
+
+      const updates: any = {
+        title: "New Title",
+        category: "ADMIN",
+        subcategory: "PASSPORT",
+        attachments: [{ key: "new", mimeType: "img", size: 10 }],
+      };
+
+      await DocumentService.update(validObjectId, updates, {
+        parentId: validParentId,
       });
 
-      it('should throw 403 if parent tries to update others doc', async () => {
-          const doc = createMockDoc({ uploadedByParentId: new Types.ObjectId() }); // different parent
-          (DocumentModel.findById as jest.Mock).mockResolvedValue(doc);
-
-          await expect(DocumentService.update(validObjectId, {}, { parentId: validParentId }))
-            .rejects.toThrow('Parent is not allowed to update this document');
-      });
-
-      it('should throw 403 if PMS tries to update parent doc', async () => {
-        const doc = createMockDoc({ syncedFromPms: false });
-        (DocumentModel.findById as jest.Mock).mockResolvedValue(doc);
-
-        await expect(DocumentService.update(validObjectId, {}, { pmsUserId: 'pms1' }))
-          .rejects.toThrow('PMS cannot update documents uploaded by parent');
-      });
-
-      it('should update fields and save', async () => {
-          const doc = createMockDoc({ uploadedByParentId: new Types.ObjectId(validParentId) });
-          (DocumentModel.findById as jest.Mock).mockResolvedValue(doc);
-
-          const updates: any = {
-              title: 'New Title',
-              category: 'ADMIN',
-              subcategory: 'PASSPORT',
-              attachments: [{ key: 'new', mimeType: 'img', size: 10 }]
-          };
-
-          await DocumentService.update(validObjectId, updates, { parentId: validParentId });
-
-          expect(doc.title).toBe('New Title');
-          expect(doc.category).toBe('ADMIN');
-          expect(doc.attachments[0].key).toBe('new');
-          expect(doc.save).toHaveBeenCalled();
-      });
+      expect(doc.title).toBe("New Title");
+      expect(doc.category).toBe("ADMIN");
+      expect(doc.attachments[0].key).toBe("new");
+      expect(doc.save).toHaveBeenCalled();
+    });
   });
 
   // 7. Search & Attachments
-  describe('Misc', () => {
-      it('getAllAttachmentUrls: should throw if no attachments', async () => {
-          const doc = createMockDoc({ attachments: [] });
-          (DocumentModel.findById as jest.Mock).mockReturnValue({ exec: jest.fn().mockResolvedValue(doc) });
-
-          await expect(DocumentService.getAllAttachmentUrls(validObjectId)).rejects.toThrow('No attachments found');
+  describe("Misc", () => {
+    it("getAllAttachmentUrls: should throw if no attachments", async () => {
+      const doc = createMockDoc({ attachments: [] });
+      (DocumentModel.findById as jest.Mock).mockReturnValue({
+        exec: jest.fn().mockResolvedValue(doc),
       });
 
-      it('getAllAttachmentUrls: should return presigned urls', async () => {
-          const doc = createMockDoc();
-          (DocumentModel.findById as jest.Mock).mockReturnValue({ exec: jest.fn().mockResolvedValue(doc) });
-          (UploadMiddleware.generatePresignedDownloadUrl as jest.Mock).mockResolvedValue('http://url');
+      await expect(
+        DocumentService.getAllAttachmentUrls(validObjectId),
+      ).rejects.toThrow("No attachments found");
+    });
 
-          const res = await DocumentService.getAllAttachmentUrls(validObjectId);
-          expect(res[0].url).toBe('http://url');
+    it("getAllAttachmentUrls: should return presigned urls", async () => {
+      const doc = createMockDoc();
+      (DocumentModel.findById as jest.Mock).mockReturnValue({
+        exec: jest.fn().mockResolvedValue(doc),
       });
+      (
+        UploadMiddleware.generatePresignedDownloadUrl as jest.Mock
+      ).mockResolvedValue("http://url");
 
-      it('searchByTitleForParent: should return matching docs', async () => {
-          const mockChain = {
-             sort: jest.fn().mockReturnValue({
-                 exec: jest.fn().mockResolvedValue([createMockDoc()])
-             })
-          };
-          (DocumentModel.find as jest.Mock).mockReturnValue(mockChain);
+      const res = await DocumentService.getAllAttachmentUrls(validObjectId);
+      expect(res[0].url).toBe("http://url");
+    });
 
-          const res = await DocumentService.searchByTitleForParent({ companionId: validCompanionId, title: 'Test' });
-          expect(res).toHaveLength(1);
+    it("searchByTitleForParent: should return matching docs", async () => {
+      const mockChain = {
+        sort: jest.fn().mockReturnValue({
+          exec: jest.fn().mockResolvedValue([createMockDoc()]),
+        }),
+      };
+      (DocumentModel.find as jest.Mock).mockReturnValue(mockChain);
+
+      const res = await DocumentService.searchByTitleForParent({
+        companionId: validCompanionId,
+        title: "Test",
       });
+      expect(res).toHaveLength(1);
+    });
 
-      it('searchByTitleForParent: should throw if title missing', async () => {
-         await expect(DocumentService.searchByTitleForParent({ companionId: validCompanionId, title: '' }))
-            .rejects.toThrow('Search title is required');
-      });
+    it("searchByTitleForParent: should throw if title missing", async () => {
+      await expect(
+        DocumentService.searchByTitleForParent({
+          companionId: validCompanionId,
+          title: "",
+        }),
+      ).rejects.toThrow("Search title is required");
+    });
   });
 });

--- a/apps/backend/test/services/expense.service.test.ts
+++ b/apps/backend/test/services/expense.service.test.ts
@@ -1,15 +1,15 @@
-import { Types } from 'mongoose';
-import { ExpenseService } from '../../src/services/expense.service';
-import ExternalExpenseModel from '../../src/models/expense';
-import InvoiceModel from '../../src/models/invoice';
-import OrganizationModel from '../../src/models/organization';
+import { Types } from "mongoose";
+import { ExpenseService } from "../../src/services/expense.service";
+import ExternalExpenseModel from "../../src/models/expense";
+import InvoiceModel from "../../src/models/invoice";
+import OrganizationModel from "../../src/models/organization";
 
 // --- Mocks ---
-jest.mock('../../src/models/expense');
-jest.mock('../../src/models/invoice');
-jest.mock('../../src/models/organization');
+jest.mock("../../src/models/expense");
+jest.mock("../../src/models/invoice");
+jest.mock("../../src/models/organization");
 
-describe('ExpenseService', () => {
+describe("ExpenseService", () => {
   const validObjectId = new Types.ObjectId().toString();
   const validCompanionId = new Types.ObjectId().toString();
 
@@ -26,15 +26,15 @@ describe('ExpenseService', () => {
   // Helper for Mongoose chains: find().sort().lean()
   const mockMongooseChain = (data: any) => ({
     sort: jest.fn().mockReturnValue({
-      lean: jest.fn().mockResolvedValue(data)
+      lean: jest.fn().mockResolvedValue(data),
     }),
     lean: jest.fn().mockResolvedValue(data),
     select: jest.fn().mockReturnValue({
-        lean: jest.fn().mockReturnValue({
-            catch: jest.fn().mockResolvedValue(data)
-        })
+      lean: jest.fn().mockReturnValue({
+        catch: jest.fn().mockResolvedValue(data),
+      }),
     }),
-    exec: jest.fn().mockResolvedValue(data)
+    exec: jest.fn().mockResolvedValue(data),
   });
 
   beforeEach(() => {
@@ -42,302 +42,373 @@ describe('ExpenseService', () => {
   });
 
   // 1. createExpense
-  describe('createExpense', () => {
+  describe("createExpense", () => {
     const input: any = {
       companionId: validCompanionId,
       parentId: validObjectId,
-      category: 'Food',
-      expenseName: 'Dog Food',
+      category: "Food",
+      expenseName: "Dog Food",
       amount: 50,
-      currency: 'USD',
+      currency: "USD",
       date: new Date(),
     };
 
-    it('should throw if companionId is missing', async () => {
-      await expect(ExpenseService.createExpense({ ...input, companionId: '' }))
-        .rejects.toThrow('companionId is required');
+    it("should throw if companionId is missing", async () => {
+      await expect(
+        ExpenseService.createExpense({ ...input, companionId: "" }),
+      ).rejects.toThrow("companionId is required");
     });
 
-    it('should throw if parentId is missing', async () => {
-      await expect(ExpenseService.createExpense({ ...input, parentId: '' }))
-        .rejects.toThrow('parentId is required');
+    it("should throw if parentId is missing", async () => {
+      await expect(
+        ExpenseService.createExpense({ ...input, parentId: "" }),
+      ).rejects.toThrow("parentId is required");
     });
 
-    it('should throw if category is missing', async () => {
-      await expect(ExpenseService.createExpense({ ...input, category: '' }))
-        .rejects.toThrow('category is required');
+    it("should throw if category is missing", async () => {
+      await expect(
+        ExpenseService.createExpense({ ...input, category: "" }),
+      ).rejects.toThrow("category is required");
     });
 
-    it('should throw if expenseName is missing', async () => {
-      await expect(ExpenseService.createExpense({ ...input, expenseName: '' }))
-        .rejects.toThrow('expenseName is required');
+    it("should throw if expenseName is missing", async () => {
+      await expect(
+        ExpenseService.createExpense({ ...input, expenseName: "" }),
+      ).rejects.toThrow("expenseName is required");
     });
 
-    it('should throw if amount is missing or negative', async () => {
-      await expect(ExpenseService.createExpense({ ...input, amount: -10 }))
-        .rejects.toThrow('amount must be a positive number');
+    it("should throw if amount is missing or negative", async () => {
+      await expect(
+        ExpenseService.createExpense({ ...input, amount: -10 }),
+      ).rejects.toThrow("amount must be a positive number");
     });
 
-    it('should create expense successfully', async () => {
+    it("should create expense successfully", async () => {
       const mockDoc = createMockDoc(input);
       (ExternalExpenseModel.create as jest.Mock).mockResolvedValue(mockDoc);
 
       const result = await ExpenseService.createExpense(input);
 
-      expect(ExternalExpenseModel.create).toHaveBeenCalledWith(expect.objectContaining({
-          expenseName: 'Dog Food',
-          currency: 'USD'
-      }));
+      expect(ExternalExpenseModel.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          expenseName: "Dog Food",
+          currency: "USD",
+        }),
+      );
       expect(result).toEqual(mockDoc);
     });
 
-    it('should default currency to USD if missing', async () => {
-        const noCurrency = { ...input, currency: undefined };
-        const mockDoc = createMockDoc(input);
-        (ExternalExpenseModel.create as jest.Mock).mockResolvedValue(mockDoc);
+    it("should default currency to USD if missing", async () => {
+      const noCurrency = { ...input, currency: undefined };
+      const mockDoc = createMockDoc(input);
+      (ExternalExpenseModel.create as jest.Mock).mockResolvedValue(mockDoc);
 
-        await ExpenseService.createExpense(noCurrency);
+      await ExpenseService.createExpense(noCurrency);
 
-        expect(ExternalExpenseModel.create).toHaveBeenCalledWith(expect.objectContaining({
-            currency: 'USD'
-        }));
-      });
+      expect(ExternalExpenseModel.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          currency: "USD",
+        }),
+      );
+    });
   });
 
   // 2. getExpensesByCompanion (Unified List)
-  describe('getExpensesByCompanion', () => {
-    it('should throw if companionId is missing', async () => {
-        await expect(ExpenseService.getExpensesByCompanion('')).rejects.toThrow('companionId is required');
+  describe("getExpensesByCompanion", () => {
+    it("should throw if companionId is missing", async () => {
+      await expect(ExpenseService.getExpensesByCompanion("")).rejects.toThrow(
+        "companionId is required",
+      );
     });
 
-    it('should return combined sorted expenses', async () => {
-        const date1 = new Date('2023-01-01');
-        const date2 = new Date('2023-01-02');
+    it("should return combined sorted expenses", async () => {
+      const date1 = new Date("2023-01-01");
+      const date2 = new Date("2023-01-02");
 
-        // Mock External Expenses
-        const mockExternal = [{
-            _id: 'ext1',
-            date: date1,
-            amount: 50,
-            expenseName: 'Ext Expense',
-            notes: 'Note',
-            category: 'Food',
-            currency: 'USD'
-        }];
+      // Mock External Expenses
+      const mockExternal = [
+        {
+          _id: "ext1",
+          date: date1,
+          amount: 50,
+          expenseName: "Ext Expense",
+          notes: "Note",
+          category: "Food",
+          currency: "USD",
+        },
+      ];
 
-        // Setup Mongoose Chain for External
-        (ExternalExpenseModel.find as jest.Mock).mockReturnValue(mockMongooseChain(mockExternal));
+      // Setup Mongoose Chain for External
+      (ExternalExpenseModel.find as jest.Mock).mockReturnValue(
+        mockMongooseChain(mockExternal),
+      );
 
-        // Mock Invoices
-        const mockInvoices = [{
-            _id: 'inv1',
-            createdAt: date2,
-            totalAmount: 100,
-            appointmentId: 'appt1',
-            items: [{ name: 'Service A' }],
-            status: 'PAID',
-            currency: 'USD',
-            organisationId: 'org1'
-        }];
+      // Mock Invoices
+      const mockInvoices = [
+        {
+          _id: "inv1",
+          createdAt: date2,
+          totalAmount: 100,
+          appointmentId: "appt1",
+          items: [{ name: "Service A" }],
+          status: "PAID",
+          currency: "USD",
+          organisationId: "org1",
+        },
+      ];
 
-        // Setup Mongoose Chain for Invoice
-        (InvoiceModel.find as jest.Mock).mockReturnValue(mockMongooseChain(mockInvoices));
+      // Setup Mongoose Chain for Invoice
+      (InvoiceModel.find as jest.Mock).mockReturnValue(
+        mockMongooseChain(mockInvoices),
+      );
 
-        // Mock Organization Lookup
-        (OrganizationModel.findById as jest.Mock).mockReturnValue({
-            lean: jest.fn().mockResolvedValue({ name: 'Vet Clinic' })
-        });
+      // Mock Organization Lookup
+      (OrganizationModel.findById as jest.Mock).mockReturnValue({
+        lean: jest.fn().mockResolvedValue({ name: "Vet Clinic" }),
+      });
 
-        const result: any[] = await ExpenseService.getExpensesByCompanion(validCompanionId);
+      const result: any[] =
+        await ExpenseService.getExpensesByCompanion(validCompanionId);
 
-        expect(result).toHaveLength(2);
-        // Sort order: date2 (newer) first
-        expect(result[0].title).toBe('Invoice');
-        expect(result[0].businessName).toBe('Vet Clinic');
+      expect(result).toHaveLength(2);
+      // Sort order: date2 (newer) first
+      expect(result[0].title).toBe("Invoice");
+      expect(result[0].businessName).toBe("Vet Clinic");
 
-        expect(result[1].title).toBe('Ext Expense');
-        expect(result[1].source).toBe('EXTERNAL');
+      expect(result[1].title).toBe("Ext Expense");
+      expect(result[1].source).toBe("EXTERNAL");
     });
 
-    it('should handle invoice with unknown organization', async () => {
-        (ExternalExpenseModel.find as jest.Mock).mockReturnValue(mockMongooseChain([]));
+    it("should handle invoice with unknown organization", async () => {
+      (ExternalExpenseModel.find as jest.Mock).mockReturnValue(
+        mockMongooseChain([]),
+      );
 
-        const mockInvoices = [{
-            _id: 'inv1',
-            createdAt: new Date(),
-            totalAmount: 100,
-            organisationId: 'missingOrg',
-            items: []
-        }];
-        (InvoiceModel.find as jest.Mock).mockReturnValue(mockMongooseChain(mockInvoices));
+      const mockInvoices = [
+        {
+          _id: "inv1",
+          createdAt: new Date(),
+          totalAmount: 100,
+          organisationId: "missingOrg",
+          items: [],
+        },
+      ];
+      (InvoiceModel.find as jest.Mock).mockReturnValue(
+        mockMongooseChain(mockInvoices),
+      );
 
-        (OrganizationModel.findById as jest.Mock).mockReturnValue({ lean: jest.fn().mockResolvedValue(null) });
+      (OrganizationModel.findById as jest.Mock).mockReturnValue({
+        lean: jest.fn().mockResolvedValue(null),
+      });
 
-        const result: any[] = await ExpenseService.getExpensesByCompanion(validCompanionId);
-        expect(result[0].businessName).toBe('Unknown Organization');
+      const result: any[] =
+        await ExpenseService.getExpensesByCompanion(validCompanionId);
+      expect(result[0].businessName).toBe("Unknown Organization");
     });
   });
 
   // 3. getExpenseById
-  describe('getExpenseById', () => {
-    it('should throw if id is invalid', async () => {
-        await expect(ExpenseService.getExpenseById('invalid')).rejects.toThrow('Invalid expenseId');
+  describe("getExpenseById", () => {
+    it("should throw if id is invalid", async () => {
+      await expect(ExpenseService.getExpenseById("invalid")).rejects.toThrow(
+        "Invalid expenseId",
+      );
     });
 
-    it('should return external expense if found', async () => {
-        const mockExt = { _id: validObjectId, expenseName: 'Found' };
-        (ExternalExpenseModel.findById as jest.Mock).mockReturnValue({
-            lean: jest.fn().mockResolvedValue(mockExt)
-        });
+    it("should return external expense if found", async () => {
+      const mockExt = { _id: validObjectId, expenseName: "Found" };
+      (ExternalExpenseModel.findById as jest.Mock).mockReturnValue({
+        lean: jest.fn().mockResolvedValue(mockExt),
+      });
 
-        const res: any = await ExpenseService.getExpenseById(validObjectId);
-        expect(res.expenseName).toBe('Found');
+      const res: any = await ExpenseService.getExpenseById(validObjectId);
+      expect(res.expenseName).toBe("Found");
     });
 
-    it('should return mapped invoice if found (when external not found)', async () => {
-        (ExternalExpenseModel.findById as jest.Mock).mockReturnValue({
-            lean: jest.fn().mockResolvedValue(null)
-        });
+    it("should return mapped invoice if found (when external not found)", async () => {
+      (ExternalExpenseModel.findById as jest.Mock).mockReturnValue({
+        lean: jest.fn().mockResolvedValue(null),
+      });
 
-        const mockInv = {
-            _id: validObjectId,
-            createdAt: new Date(),
-            totalAmount: 200,
-            organisationId: 'org1',
-            items: [{ name: 'Item 1' }],
-            status: 'PAID',
-            currency: 'USD',
-            appointmentId: 'appt1'
-        };
+      const mockInv = {
+        _id: validObjectId,
+        createdAt: new Date(),
+        totalAmount: 200,
+        organisationId: "org1",
+        items: [{ name: "Item 1" }],
+        status: "PAID",
+        currency: "USD",
+        appointmentId: "appt1",
+      };
 
-        (InvoiceModel.findById as jest.Mock).mockReturnValue({
-            lean: jest.fn().mockResolvedValue(mockInv)
-        });
+      (InvoiceModel.findById as jest.Mock).mockReturnValue({
+        lean: jest.fn().mockResolvedValue(mockInv),
+      });
 
-        // Mock Org chain: findById().select().lean().catch()
-        const mockOrgChain = {
-            select: jest.fn().mockReturnValue({
-                lean: jest.fn().mockReturnValue({
-                    catch: jest.fn().mockResolvedValue({ name: 'Clinic' })
-                })
-            })
-        };
-        (OrganizationModel.findById as jest.Mock).mockReturnValue(mockOrgChain);
+      // Mock Org chain: findById().select().lean().catch()
+      const mockOrgChain = {
+        select: jest.fn().mockReturnValue({
+          lean: jest.fn().mockReturnValue({
+            catch: jest.fn().mockResolvedValue({ name: "Clinic" }),
+          }),
+        }),
+      };
+      (OrganizationModel.findById as jest.Mock).mockReturnValue(mockOrgChain);
 
-        const res: any = await ExpenseService.getExpenseById(validObjectId);
+      const res: any = await ExpenseService.getExpenseById(validObjectId);
 
-        expect(res.source).toBe('IN_APP');
-        expect(res.title).toBe('Invoice');
-        expect(res.businessName).toBe('Clinic');
+      expect(res.source).toBe("IN_APP");
+      expect(res.title).toBe("Invoice");
+      expect(res.businessName).toBe("Clinic");
     });
 
-    it('should handle invoice organization fetch failure', async () => {
-        (ExternalExpenseModel.findById as jest.Mock).mockReturnValue({ lean: jest.fn().mockResolvedValue(null) });
-        (InvoiceModel.findById as jest.Mock).mockReturnValue({ lean: jest.fn().mockResolvedValue({ _id: validObjectId, organisationId: 'org1' }) });
+    it("should handle invoice organization fetch failure", async () => {
+      (ExternalExpenseModel.findById as jest.Mock).mockReturnValue({
+        lean: jest.fn().mockResolvedValue(null),
+      });
+      (InvoiceModel.findById as jest.Mock).mockReturnValue({
+        lean: jest
+          .fn()
+          .mockResolvedValue({ _id: validObjectId, organisationId: "org1" }),
+      });
 
-        // Mock Org chain to return null via catch
-        const mockOrgChain = {
-            select: jest.fn().mockReturnValue({
-                lean: jest.fn().mockReturnValue({
-                    catch: jest.fn().mockResolvedValue(null)
-                })
-            })
-        };
-        (OrganizationModel.findById as jest.Mock).mockReturnValue(mockOrgChain);
+      // Mock Org chain to return null via catch
+      const mockOrgChain = {
+        select: jest.fn().mockReturnValue({
+          lean: jest.fn().mockReturnValue({
+            catch: jest.fn().mockResolvedValue(null),
+          }),
+        }),
+      };
+      (OrganizationModel.findById as jest.Mock).mockReturnValue(mockOrgChain);
 
-        const res: any = await ExpenseService.getExpenseById(validObjectId);
-        expect(res.businessName).toBe('Unknown Organization');
+      const res: any = await ExpenseService.getExpenseById(validObjectId);
+      expect(res.businessName).toBe("Unknown Organization");
     });
 
-    it('should set invoice status to undefined if not PAID/AWAITING', async () => {
-         (ExternalExpenseModel.findById as jest.Mock).mockReturnValue({ lean: jest.fn().mockResolvedValue(null) });
-         (InvoiceModel.findById as jest.Mock).mockReturnValue({
-             lean: jest.fn().mockResolvedValue({ _id: validObjectId, status: 'DRAFT' })
-         });
-         (OrganizationModel.findById as jest.Mock).mockReturnValue({ select: jest.fn().mockReturnValue({ lean: jest.fn().mockReturnValue({ catch: jest.fn().mockResolvedValue({}) }) }) });
+    it("should set invoice status to undefined if not PAID/AWAITING", async () => {
+      (ExternalExpenseModel.findById as jest.Mock).mockReturnValue({
+        lean: jest.fn().mockResolvedValue(null),
+      });
+      (InvoiceModel.findById as jest.Mock).mockReturnValue({
+        lean: jest
+          .fn()
+          .mockResolvedValue({ _id: validObjectId, status: "DRAFT" }),
+      });
+      (OrganizationModel.findById as jest.Mock).mockReturnValue({
+        select: jest
+          .fn()
+          .mockReturnValue({
+            lean: jest
+              .fn()
+              .mockReturnValue({ catch: jest.fn().mockResolvedValue({}) }),
+          }),
+      });
 
-         const res: any = await ExpenseService.getExpenseById(validObjectId);
-         expect(res.status).toBeUndefined();
+      const res: any = await ExpenseService.getExpenseById(validObjectId);
+      expect(res.status).toBeUndefined();
     });
 
-    it('should throw 404 if neither found', async () => {
-        (ExternalExpenseModel.findById as jest.Mock).mockReturnValue({ lean: jest.fn().mockResolvedValue(null) });
-        (InvoiceModel.findById as jest.Mock).mockReturnValue({ lean: jest.fn().mockResolvedValue(null) });
+    it("should throw 404 if neither found", async () => {
+      (ExternalExpenseModel.findById as jest.Mock).mockReturnValue({
+        lean: jest.fn().mockResolvedValue(null),
+      });
+      (InvoiceModel.findById as jest.Mock).mockReturnValue({
+        lean: jest.fn().mockResolvedValue(null),
+      });
 
-        await expect(ExpenseService.getExpenseById(validObjectId)).rejects.toThrow('Expense not found');
+      await expect(
+        ExpenseService.getExpenseById(validObjectId),
+      ).rejects.toThrow("Expense not found");
     });
   });
 
   // 4. deleteExpense
-  describe('deleteExpense', () => {
-      it('should throw if id is invalid', async () => {
-          await expect(ExpenseService.deleteExpense('invalid')).rejects.toThrow('Invalid expenseId');
+  describe("deleteExpense", () => {
+    it("should throw if id is invalid", async () => {
+      await expect(ExpenseService.deleteExpense("invalid")).rejects.toThrow(
+        "Invalid expenseId",
+      );
+    });
+
+    it("should delete successfully", async () => {
+      (ExternalExpenseModel.deleteOne as jest.Mock).mockReturnValue({
+        exec: jest.fn().mockResolvedValue({ deletedCount: 1 }),
       });
 
-      it('should delete successfully', async () => {
-          (ExternalExpenseModel.deleteOne as jest.Mock).mockReturnValue({
-              exec: jest.fn().mockResolvedValue({ deletedCount: 1 })
-          });
-
-          await ExpenseService.deleteExpense(validObjectId);
-          expect(ExternalExpenseModel.deleteOne).toHaveBeenCalledWith({ _id: validObjectId });
+      await ExpenseService.deleteExpense(validObjectId);
+      expect(ExternalExpenseModel.deleteOne).toHaveBeenCalledWith({
+        _id: validObjectId,
       });
+    });
 
-      it('should throw 404 if not found', async () => {
-        (ExternalExpenseModel.deleteOne as jest.Mock).mockReturnValue({
-            exec: jest.fn().mockResolvedValue({ deletedCount: 0 })
-        });
-        await expect(ExpenseService.deleteExpense(validObjectId)).rejects.toThrow('Expense not found');
+    it("should throw 404 if not found", async () => {
+      (ExternalExpenseModel.deleteOne as jest.Mock).mockReturnValue({
+        exec: jest.fn().mockResolvedValue({ deletedCount: 0 }),
       });
+      await expect(ExpenseService.deleteExpense(validObjectId)).rejects.toThrow(
+        "Expense not found",
+      );
+    });
   });
 
   // 5. updateExpense
-  describe('updateExpense', () => {
-      it('should throw if id is invalid', async () => {
-          await expect(ExpenseService.updateExpense('invalid', {})).rejects.toThrow('Invalid expenseId');
+  describe("updateExpense", () => {
+    it("should throw if id is invalid", async () => {
+      await expect(ExpenseService.updateExpense("invalid", {})).rejects.toThrow(
+        "Invalid expenseId",
+      );
+    });
+
+    it("should update and return doc", async () => {
+      const mockDoc = { _id: validObjectId, expenseName: "Updated" };
+      (ExternalExpenseModel.findByIdAndUpdate as jest.Mock).mockReturnValue({
+        exec: jest.fn().mockResolvedValue(mockDoc),
       });
 
-      it('should update and return doc', async () => {
-          const mockDoc = { _id: validObjectId, expenseName: 'Updated' };
-          (ExternalExpenseModel.findByIdAndUpdate as jest.Mock).mockReturnValue({
-              exec: jest.fn().mockResolvedValue(mockDoc)
-          });
-
-          const res = await ExpenseService.updateExpense(validObjectId, { expenseName: 'Updated' });
-          expect(res.expenseName).toBe('Updated');
+      const res = await ExpenseService.updateExpense(validObjectId, {
+        expenseName: "Updated",
       });
+      expect(res.expenseName).toBe("Updated");
+    });
 
-      it('should throw 404 if doc not found', async () => {
-        (ExternalExpenseModel.findByIdAndUpdate as jest.Mock).mockReturnValue({
-            exec: jest.fn().mockResolvedValue(null)
-        });
-        await expect(ExpenseService.updateExpense(validObjectId, {})).rejects.toThrow('Expense not found');
+    it("should throw 404 if doc not found", async () => {
+      (ExternalExpenseModel.findByIdAndUpdate as jest.Mock).mockReturnValue({
+        exec: jest.fn().mockResolvedValue(null),
       });
+      await expect(
+        ExpenseService.updateExpense(validObjectId, {}),
+      ).rejects.toThrow("Expense not found");
+    });
   });
 
   // 6. getTotalExpenseForCompanion
-  describe('getTotalExpenseForCompanion', () => {
-      it('should aggregate totals correctly', async () => {
-          (InvoiceModel.aggregate as jest.Mock).mockResolvedValue([{ total: 100 }]);
-          (ExternalExpenseModel.aggregate as jest.Mock).mockResolvedValue([{ total: 50 }]);
+  describe("getTotalExpenseForCompanion", () => {
+    it("should aggregate totals correctly", async () => {
+      (InvoiceModel.aggregate as jest.Mock).mockResolvedValue([{ total: 100 }]);
+      (ExternalExpenseModel.aggregate as jest.Mock).mockResolvedValue([
+        { total: 50 },
+      ]);
 
-          const res = await ExpenseService.getTotalExpenseForCompanion(validCompanionId);
+      const res =
+        await ExpenseService.getTotalExpenseForCompanion(validCompanionId);
 
-          expect(res).toEqual({
-              companionId: validCompanionId,
-              invoiceTotal: 100,
-              externalTotal: 50,
-              totalExpense: 150
-          });
+      expect(res).toEqual({
+        companionId: validCompanionId,
+        invoiceTotal: 100,
+        externalTotal: 50,
+        totalExpense: 150,
       });
+    });
 
-      it('should handle empty aggregations (defaults to 0)', async () => {
-        (InvoiceModel.aggregate as jest.Mock).mockResolvedValue([]);
-        (ExternalExpenseModel.aggregate as jest.Mock).mockResolvedValue([]);
+    it("should handle empty aggregations (defaults to 0)", async () => {
+      (InvoiceModel.aggregate as jest.Mock).mockResolvedValue([]);
+      (ExternalExpenseModel.aggregate as jest.Mock).mockResolvedValue([]);
 
-        const res = await ExpenseService.getTotalExpenseForCompanion(validCompanionId);
+      const res =
+        await ExpenseService.getTotalExpenseForCompanion(validCompanionId);
 
-        expect(res.totalExpense).toBe(0);
-      });
+      expect(res.totalExpense).toBe(0);
+    });
   });
 });

--- a/apps/backend/test/services/task.service.test.ts
+++ b/apps/backend/test/services/task.service.test.ts
@@ -451,7 +451,7 @@ describe("TaskService", () => {
 
       expect(mockedTaskModel.find).toHaveBeenCalledWith({
         audience: "PARENT_TASK",
-        assignedTo: "parent-1",
+        $or: [{ assignedTo: "parent-1" }, { createdBy: "parent-1" }],
         companionId: "comp-1",
         status: { $in: ["PENDING"] },
         dueAt: {

--- a/apps/backend/test/utils/helper.test.ts
+++ b/apps/backend/test/utils/helper.test.ts
@@ -1,20 +1,19 @@
-import helpers from '../../src/utils/helper';
-import axios from 'axios';
+import helpers from "../../src/utils/helper";
+import axios from "axios";
 
 // Mock axios specifically for this test file
-jest.mock('axios');
+jest.mock("axios");
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
-describe('Helper Utils', () => {
-
+describe("Helper Utils", () => {
   // 1. calculateAge
-  describe('calculateAge', () => {
-    it('should correctly calculate age from a string date', () => {
+  describe("calculateAge", () => {
+    it("should correctly calculate age from a string date", () => {
       // Mock Date.now to ensure consistent results regardless of when test runs
-      const mockNow = new Date('2023-10-01T00:00:00Z').getTime();
-      jest.spyOn(Date, 'now').mockReturnValue(mockNow);
+      const mockNow = new Date("2023-10-01T00:00:00Z").getTime();
+      jest.spyOn(Date, "now").mockReturnValue(mockNow);
 
-      const dob = '1990-01-01';
+      const dob = "1990-01-01";
       const age = helpers.calculateAge(dob);
       // 1990 to 2023 is 33 years
       expect(age).toBe(33);
@@ -22,11 +21,11 @@ describe('Helper Utils', () => {
       jest.restoreAllMocks();
     });
 
-    it('should correctly calculate age from a Date object', () => {
-      const mockNow = new Date('2023-10-01T00:00:00Z').getTime();
-      jest.spyOn(Date, 'now').mockReturnValue(mockNow);
+    it("should correctly calculate age from a Date object", () => {
+      const mockNow = new Date("2023-10-01T00:00:00Z").getTime();
+      jest.spyOn(Date, "now").mockReturnValue(mockNow);
 
-      const dob = new Date('2000-01-01');
+      const dob = new Date("2000-01-01");
       const age = helpers.calculateAge(dob);
       expect(age).toBe(23);
 
@@ -35,31 +34,36 @@ describe('Helper Utils', () => {
   });
 
   // 2. capitalizeFirstLetter
-  describe('capitalizeFirstLetter', () => {
-    it('should capitalize the first letter and lowercase the rest', () => {
-      expect(helpers.capitalizeFirstLetter('hello')).toBe('Hello');
-      expect(helpers.capitalizeFirstLetter('HELLO')).toBe('Hello');
-      expect(helpers.capitalizeFirstLetter('hElLo')).toBe('Hello');
+  describe("capitalizeFirstLetter", () => {
+    it("should capitalize the first letter and lowercase the rest", () => {
+      expect(helpers.capitalizeFirstLetter("hello")).toBe("Hello");
+      expect(helpers.capitalizeFirstLetter("HELLO")).toBe("Hello");
+      expect(helpers.capitalizeFirstLetter("hElLo")).toBe("Hello");
     });
 
-    it('should handle single character strings', () => {
-      expect(helpers.capitalizeFirstLetter('a')).toBe('A');
+    it("should handle single character strings", () => {
+      expect(helpers.capitalizeFirstLetter("a")).toBe("A");
     });
   });
 
   // 3. operationOutcome
-  describe('operationOutcome', () => {
-    it('should return the correct OperationOutcome object structure', () => {
-      const result = helpers.operationOutcome('error', 'fatal', '404', 'Not Found');
+  describe("operationOutcome", () => {
+    it("should return the correct OperationOutcome object structure", () => {
+      const result = helpers.operationOutcome(
+        "error",
+        "fatal",
+        "404",
+        "Not Found",
+      );
 
       expect(result).toEqual({
-        resourceType: 'OperationOutcome',
+        resourceType: "OperationOutcome",
         issue: [
           {
-            status: 'error',
-            severity: 'fatal',
-            code: '404',
-            diagnostics: 'Not Found',
+            status: "error",
+            severity: "fatal",
+            code: "404",
+            diagnostics: "Not Found",
           },
         ],
       });
@@ -67,38 +71,38 @@ describe('Helper Utils', () => {
   });
 
   // 4. convertTo24Hour
-  describe('convertTo24Hour', () => {
-    it('should convert PM hours (other than 12) correctly', () => {
+  describe("convertTo24Hour", () => {
+    it("should convert PM hours (other than 12) correctly", () => {
       // 02:30 PM -> 14:30
-      expect(helpers.convertTo24Hour('02:30 PM')).toBe('14:30');
+      expect(helpers.convertTo24Hour("02:30 PM")).toBe("14:30");
     });
 
-    it('should handle 12 PM (Noon) correctly', () => {
+    it("should handle 12 PM (Noon) correctly", () => {
       // 12:30 PM -> 12:30 (Should not add 12)
-      expect(helpers.convertTo24Hour('12:30 PM')).toBe('12:30');
+      expect(helpers.convertTo24Hour("12:30 PM")).toBe("12:30");
     });
 
-    it('should handle 12 AM (Midnight) correctly', () => {
+    it("should handle 12 AM (Midnight) correctly", () => {
       // 12:30 AM -> 00:30
-      expect(helpers.convertTo24Hour('12:30 AM')).toBe('00:30');
+      expect(helpers.convertTo24Hour("12:30 AM")).toBe("00:30");
     });
 
-    it('should convert AM hours (other than 12) correctly', () => {
+    it("should convert AM hours (other than 12) correctly", () => {
       // 11:30 AM -> 11:30
-      expect(helpers.convertTo24Hour('11:30 AM')).toBe('11:30');
+      expect(helpers.convertTo24Hour("11:30 AM")).toBe("11:30");
     });
   });
 
   // 5. formatAppointmentDateTime
-  describe('formatAppointmentDateTime', () => {
-    it('should format date and time correctly using Asia/Kolkata timezone', () => {
+  describe("formatAppointmentDateTime", () => {
+    it("should format date and time correctly using Asia/Kolkata timezone", () => {
       // Input date containing a specific offset or UTC
-      const rawDate = '2023-10-25T14:30:00+05:30';
+      const rawDate = "2023-10-25T14:30:00+05:30";
 
       const result = helpers.formatAppointmentDateTime(rawDate);
 
       // 1. Date part extracted from split
-      expect(result.appointmentDate).toBe('2023-10-25');
+      expect(result.appointmentDate).toBe("2023-10-25");
 
       // 2. 12h format checks (Asia/Kolkata)
       // Note: precise string match depends on node environment locales,
@@ -106,24 +110,24 @@ describe('Helper Utils', () => {
       expect(result.appointmentTime).toMatch(/2:30 PM/);
 
       // 3. 24h format checks (Asia/Kolkata)
-      expect(result.appointmentTime24).toBe('14:30');
+      expect(result.appointmentTime24).toBe("14:30");
     });
   });
 
   // 6. getGeoLocation
-  describe('getGeoLocation', () => {
+  describe("getGeoLocation", () => {
     const originalEnv = process.env;
 
     beforeEach(() => {
       jest.resetModules();
-      process.env = { ...originalEnv, GOOGLE_API_KEY: 'TEST_KEY' };
+      process.env = { ...originalEnv, GOOGLE_API_KEY: "TEST_KEY" };
     });
 
     afterEach(() => {
       process.env = originalEnv;
     });
 
-    it('should return lat and lng when API call is successful', async () => {
+    it("should return lat and lng when API call is successful", async () => {
       const mockResponse = {
         data: {
           results: [
@@ -138,10 +142,12 @@ describe('Helper Utils', () => {
 
       mockedAxios.get.mockResolvedValueOnce(mockResponse);
 
-      const result = await helpers.getGeoLocation('New York');
+      const result = await helpers.getGeoLocation("New York");
 
       expect(mockedAxios.get).toHaveBeenCalledWith(
-        expect.stringContaining('https://maps.googleapis.com/maps/api/geocode/json?address=New%20York&key=TEST_KEY')
+        expect.stringContaining(
+          "https://maps.googleapis.com/maps/api/geocode/json?address=New%20York&key=TEST_KEY",
+        ),
       );
       expect(result).toEqual({ lat: 40.7128, lng: -74.006 });
     });
@@ -155,14 +161,18 @@ describe('Helper Utils', () => {
 
       mockedAxios.get.mockResolvedValueOnce(mockResponse);
 
-      await expect(helpers.getGeoLocation('Unknown Place')).rejects.toThrow('Location not found');
+      await expect(helpers.getGeoLocation("Unknown Place")).rejects.toThrow(
+        "Location not found",
+      );
     });
 
-    it('should propagate axios errors if the request fails', async () => {
-      const errorMessage = 'Network Error';
+    it("should propagate axios errors if the request fails", async () => {
+      const errorMessage = "Network Error";
       mockedAxios.get.mockRejectedValueOnce(new Error(errorMessage));
 
-      await expect(helpers.getGeoLocation('Error Place')).rejects.toThrow(errorMessage);
+      await expect(helpers.getGeoLocation("Error Place")).rejects.toThrow(
+        errorMessage,
+      );
     });
   });
 });

--- a/apps/backend/test/utils/notificationTemplates.test.ts
+++ b/apps/backend/test/utils/notificationTemplates.test.ts
@@ -1,180 +1,207 @@
-import { NotificationTemplates } from '../../src/utils/notificationTemplates';
+import { NotificationTemplates } from "../../src/utils/notificationTemplates";
 
-describe('NotificationTemplates', () => {
-
+describe("NotificationTemplates", () => {
   // 1. Appointment Notifications
-  describe('Appointment', () => {
-    it('REQUESTED: should return correct payload', () => {
-      const result = NotificationTemplates.Appointment.REQUESTED('Buddy', '10:00 AM');
+  describe("Appointment", () => {
+    it("REQUESTED: should return correct payload", () => {
+      const result = NotificationTemplates.Appointment.REQUESTED(
+        "Buddy",
+        "10:00 AM",
+      );
       expect(result).toEqual({
-        title: 'Appointment Request Sent! 🐾',
-        body: 'Buddy is all set! Your appointment request for 10:00 AM has been sent to the clinic.',
-        type: 'APPOINTMENTS',
+        title: "Appointment Request Sent! 🐾",
+        body: "Buddy is all set! Your appointment request for 10:00 AM has been sent to the clinic.",
+        type: "APPOINTMENTS",
       });
     });
 
-    it('APPROVED: should return correct payload', () => {
-      const result = NotificationTemplates.Appointment.APPROVED('Buddy', '10:00 AM');
+    it("APPROVED: should return correct payload", () => {
+      const result = NotificationTemplates.Appointment.APPROVED(
+        "Buddy",
+        "10:00 AM",
+      );
       expect(result).toEqual({
-        title: 'Appointment Confirmed! 🎉',
+        title: "Appointment Confirmed! 🎉",
         body: "Great news! Buddy's appointment is confirmed for 10:00 AM. See you soon!",
-        type: 'APPOINTMENTS',
+        type: "APPOINTMENTS",
       });
     });
 
-    it('CANCELLED: should return correct payload', () => {
-      const result = NotificationTemplates.Appointment.CANCELLED('Buddy');
+    it("CANCELLED: should return correct payload", () => {
+      const result = NotificationTemplates.Appointment.CANCELLED("Buddy");
       expect(result).toEqual({
-        title: 'Appointment Cancelled ❌',
+        title: "Appointment Cancelled ❌",
         body: "Your appointment for Buddy has been cancelled. We're here if you need to rebook.",
-        type: 'APPOINTMENTS',
+        type: "APPOINTMENTS",
       });
     });
 
-    it('REMINDER: should return correct payload', () => {
-      const result = NotificationTemplates.Appointment.REMINDER('Buddy', '10:00 AM');
+    it("REMINDER: should return correct payload", () => {
+      const result = NotificationTemplates.Appointment.REMINDER(
+        "Buddy",
+        "10:00 AM",
+      );
       expect(result).toEqual({
-        title: 'Upcoming Appointment ⏰',
+        title: "Upcoming Appointment ⏰",
         body: "A little nudge! Buddy has an appointment at 10:00 AM. Don’t forget!",
-        type: 'APPOINTMENTS',
+        type: "APPOINTMENTS",
       });
     });
 
-    it('RESCHEDULED: should return correct payload', () => {
-      const result = NotificationTemplates.Appointment.RESCHEDULED('Buddy', '11:00 AM');
+    it("RESCHEDULED: should return correct payload", () => {
+      const result = NotificationTemplates.Appointment.RESCHEDULED(
+        "Buddy",
+        "11:00 AM",
+      );
       expect(result).toEqual({
-        title: 'Appointment Rescheduled 🔁',
+        title: "Appointment Rescheduled 🔁",
         body: "Buddy's appointment has been moved to 11:00 AM. Thanks for staying flexible!",
-        type: 'APPOINTMENTS',
+        type: "APPOINTMENTS",
       });
     });
   });
 
   // 2. Payment Notifications
-  describe('Payment', () => {
-    it('PAYMENT_PENDING: should return correct payload', () => {
-      const result = NotificationTemplates.Payment.PAYMENT_PENDING(500, 'INR');
+  describe("Payment", () => {
+    it("PAYMENT_PENDING: should return correct payload", () => {
+      const result = NotificationTemplates.Payment.PAYMENT_PENDING(500, "INR");
       expect(result).toEqual({
-        title: 'Payment Pending 💳',
-        body: 'A quick reminder! You have a pending payment of ₹500. Tap to complete it.',
-        type: 'PAYMENTS',
+        title: "Payment Pending 💳",
+        body: "A quick reminder! You have a pending payment of ₹500. Tap to complete it.",
+        type: "PAYMENTS",
       });
     });
 
-    it('PAYMENT_SUCCESS: should return correct payload', () => {
-      const result = NotificationTemplates.Payment.PAYMENT_SUCCESS(500, 'INR');
+    it("PAYMENT_SUCCESS: should return correct payload", () => {
+      const result = NotificationTemplates.Payment.PAYMENT_SUCCESS(500, "INR");
       expect(result).toEqual({
-        title: 'Payment Successful! 🥳',
-        body: 'Woohoo! Your payment of ₹500 went through. Thanks for taking great care of your companion!',
-        type: 'PAYMENTS',
+        title: "Payment Successful! 🥳",
+        body: "Woohoo! Your payment of ₹500 went through. Thanks for taking great care of your companion!",
+        type: "PAYMENTS",
       });
     });
 
-    it('PAYMENT_FAILED: should return correct payload', () => {
+    it("PAYMENT_FAILED: should return correct payload", () => {
       const result = NotificationTemplates.Payment.PAYMENT_FAILED();
       expect(result).toEqual({
-        title: 'Payment Failed ⚠️',
-        body: 'Oops! Something went wrong with your payment. Try again when you’re ready.',
-        type: 'PAYMENTS',
+        title: "Payment Failed ⚠️",
+        body: "Oops! Something went wrong with your payment. Try again when you’re ready.",
+        type: "PAYMENTS",
       });
     });
 
-    it('REFUND_ISSUED: should return correct payload', () => {
-      const result = NotificationTemplates.Payment.REFUND_ISSUED(200, 'INR');
+    it("REFUND_ISSUED: should return correct payload", () => {
+      const result = NotificationTemplates.Payment.REFUND_ISSUED(200, "INR");
       expect(result).toEqual({
-        title: 'Refund Processed 💸',
-        body: 'A refund of 200 has been processed. Check your bank for updates.',
-        type: 'PAYMENTS',
+        title: "Refund Processed 💸",
+        body: "A refund of 200 has been processed. Check your bank for updates.",
+        type: "PAYMENTS",
       });
     });
   });
 
   // 3. Expense Notifications
-  describe('Expense', () => {
-    it('EXPENSE_ADDED: should return correct payload', () => {
-      const result = NotificationTemplates.Expense.EXPENSE_ADDED('Buddy', 'Food');
+  describe("Expense", () => {
+    it("EXPENSE_ADDED: should return correct payload", () => {
+      const result = NotificationTemplates.Expense.EXPENSE_ADDED(
+        "Buddy",
+        "Food",
+      );
       expect(result).toEqual({
-        title: 'New Expense Added 📘',
-        body: 'You added a new food expense for Buddy.',
+        title: "New Expense Added 📘",
+        body: "You added a new food expense for Buddy.",
       });
     });
 
-    it('EXPENSE_UPDATED: should return correct payload', () => {
-      const result = NotificationTemplates.Expense.EXPENSE_UPDATED('Buddy');
+    it("EXPENSE_UPDATED: should return correct payload", () => {
+      const result = NotificationTemplates.Expense.EXPENSE_UPDATED("Buddy");
       expect(result).toEqual({
-        title: 'Expense Updated ✏️',
-        body: 'An expense for Buddy has been updated.',
+        title: "Expense Updated ✏️",
+        body: "An expense for Buddy has been updated.",
       });
     });
   });
 
   // 4. Care Notifications
-  describe('Care', () => {
-    it('VACCINE_REMINDER: should return correct payload', () => {
-      const result = NotificationTemplates.Care.VACCINE_REMINDER('Buddy');
+  describe("Care", () => {
+    it("VACCINE_REMINDER: should return correct payload", () => {
+      const result = NotificationTemplates.Care.VACCINE_REMINDER("Buddy");
       expect(result).toEqual({
-        title: 'Vaccination Due 🩺',
-        body: 'Buddy is due for a vaccination. Staying protected is the best treat!',
+        title: "Vaccination Due 🩺",
+        body: "Buddy is due for a vaccination. Staying protected is the best treat!",
       });
     });
 
-    it('MEDICATION_REMINDER: should return correct payload', () => {
-      const result = NotificationTemplates.Care.MEDICATION_REMINDER('Buddy');
+    it("MEDICATION_REMINDER: should return correct payload", () => {
+      const result = NotificationTemplates.Care.MEDICATION_REMINDER("Buddy");
       expect(result).toEqual({
-        title: 'Medication Reminder 💊',
+        title: "Medication Reminder 💊",
         body: "Time for Buddy's meds. Healthy companions = happy parents!",
       });
     });
   });
 
   // 5. Auth Notifications
-  describe('Auth', () => {
-    it('OTP: should return correct payload', () => {
-      const result = NotificationTemplates.Auth.OTP('123456');
+  describe("Auth", () => {
+    it("OTP: should return correct payload", () => {
+      const result = NotificationTemplates.Auth.OTP("123456");
       expect(result).toEqual({
-        title: 'Your OTP is Ready! 🔐',
-        body: 'Use this code to continue: 123456. It’s valid for the next 10 minutes!',
+        title: "Your OTP is Ready! 🔐",
+        body: "Use this code to continue: 123456. It’s valid for the next 10 minutes!",
       });
     });
   });
 
   // 6. Task Notifications
-  describe('Task', () => {
-    it('TASK_ASSIGNED: should return correct payload', () => {
-      const result = NotificationTemplates.Task.TASK_ASSIGNED('Buddy', 'Walking', '5:00 PM');
+  describe("Task", () => {
+    it("TASK_ASSIGNED: should return correct payload", () => {
+      const result = NotificationTemplates.Task.TASK_ASSIGNED(
+        "Buddy",
+        "Walking",
+        "5:00 PM",
+      );
       expect(result).toEqual({
-        title: 'New Task Assigned 🐾',
-        body: 'A new task for Buddy — "Walking" — is assigned to you. It\'s due by 5:00 PM. You\'ve got this! 💪',
-        type: 'TASKS',
+        title: "New Task Assigned 🐾",
+        body: "A new task for Buddy — \"Walking\" — is assigned to you. It's due by 5:00 PM. You've got this! 💪",
+        type: "TASKS",
       });
     });
 
-    it('TASK_DUE_REMINDER: should return correct payload', () => {
-      const result = NotificationTemplates.Task.TASK_DUE_REMINDER('Buddy', 'Walking', '5:00 PM');
+    it("TASK_DUE_REMINDER: should return correct payload", () => {
+      const result = NotificationTemplates.Task.TASK_DUE_REMINDER(
+        "Buddy",
+        "Walking",
+        "5:00 PM",
+      );
       expect(result).toEqual({
-        title: 'Task Reminder ⏰',
+        title: "Task Reminder ⏰",
         body: 'Just a friendly nudge — "Walking" for Buddy is due at 5:00 PM. Thanks for staying on top of things! 💚',
-        type: 'TASKS',
+        type: "TASKS",
       });
     });
 
-    it('TASK_COMPLETED: should return correct payload', () => {
-      const result = NotificationTemplates.Task.TASK_COMPLETED('Buddy', 'Walking');
+    it("TASK_COMPLETED: should return correct payload", () => {
+      const result = NotificationTemplates.Task.TASK_COMPLETED(
+        "Buddy",
+        "Walking",
+      );
       expect(result).toEqual({
-        title: 'Task Completed 🎉',
+        title: "Task Completed 🎉",
         body: 'Great job! You’ve marked "Walking" for Buddy as completed. Keep up the amazing work! 🐶✨',
-        type: 'TASKS',
+        type: "TASKS",
       });
     });
 
-    it('TASK_OVERDUE: should return correct payload', () => {
-      const result = NotificationTemplates.Task.TASK_OVERDUE('Buddy', 'Walking');
+    it("TASK_OVERDUE: should return correct payload", () => {
+      const result = NotificationTemplates.Task.TASK_OVERDUE(
+        "Buddy",
+        "Walking",
+      );
       expect(result).toEqual({
-        title: 'Task Overdue ⚠️',
+        title: "Task Overdue ⚠️",
         body: 'Looks like "Walking" for Buddy is now overdue. Don\'t worry — you can still complete it anytime.',
-        type: 'TASKS',
+        type: "TASKS",
       });
     });
   });
-
 });

--- a/apps/backend/test/utils/sanitize.test.ts
+++ b/apps/backend/test/utils/sanitize.test.ts
@@ -1,52 +1,54 @@
-import { sanitizeInput, assertSafeString, assertEmail } from '../../src/utils/sanitize';
+import {
+  sanitizeInput,
+  assertSafeString,
+  assertEmail,
+} from "../../src/utils/sanitize";
 
-describe('Sanitize Utils', () => {
-
+describe("Sanitize Utils", () => {
   // 1. sanitizeInput
-  describe('sanitizeInput', () => {
-    it('should sanitize strings (escape, stripLow, trim)', () => {
+  describe("sanitizeInput", () => {
+    it("should sanitize strings (escape, stripLow, trim)", () => {
       // Updated expectation: Validator escapes '/' to '&#x2F;'
-      const dirty = '  <div>Hello\x00</div>  ';
+      const dirty = "  <div>Hello\x00</div>  ";
       const clean = sanitizeInput(dirty);
-      expect(clean).toBe('&lt;div&gt;Hello&lt;&#x2F;div&gt;');
+      expect(clean).toBe("&lt;div&gt;Hello&lt;&#x2F;div&gt;");
     });
 
-    it('should recursively sanitize arrays', () => {
-      const dirtyArray = ['  <a>Link</a>  ', '  <b>Bold</b>  '];
+    it("should recursively sanitize arrays", () => {
+      const dirtyArray = ["  <a>Link</a>  ", "  <b>Bold</b>  "];
       const cleanArray = sanitizeInput(dirtyArray);
       // Updated expectation: Validator escapes '/' to '&#x2F;'
-      expect(cleanArray).toEqual(['&lt;a&gt;Link&lt;&#x2F;a&gt;', '&lt;b&gt;Bold&lt;&#x2F;b&gt;']);
+      expect(cleanArray).toEqual([
+        "&lt;a&gt;Link&lt;&#x2F;a&gt;",
+        "&lt;b&gt;Bold&lt;&#x2F;b&gt;",
+      ]);
     });
 
-    it('should recursively sanitize objects', () => {
+    it("should recursively sanitize objects", () => {
       const dirtyObj = {
-        name: '  <script>alert(1)</script>  ',
-        bio: '  Simple  ',
+        name: "  <script>alert(1)</script>  ",
+        bio: "  Simple  ",
       };
       const cleanObj = sanitizeInput(dirtyObj);
       // Updated expectation: Validator escapes '/' to '&#x2F;'
       expect(cleanObj).toEqual({
-        name: '&lt;script&gt;alert(1)&lt;&#x2F;script&gt;',
-        bio: 'Simple',
+        name: "&lt;script&gt;alert(1)&lt;&#x2F;script&gt;",
+        bio: "Simple",
       });
     });
 
-    it('should handle deeply nested structures (Object in Array in Object)', () => {
+    it("should handle deeply nested structures (Object in Array in Object)", () => {
       const complex = {
-        list: [
-          { tag: '  <h1>Title</h1>  ' }
-        ]
+        list: [{ tag: "  <h1>Title</h1>  " }],
       };
       const clean = sanitizeInput(complex);
       // Updated expectation: Validator escapes '/' to '&#x2F;'
       expect(clean).toEqual({
-        list: [
-          { tag: '&lt;h1&gt;Title&lt;&#x2F;h1&gt;' }
-        ]
+        list: [{ tag: "&lt;h1&gt;Title&lt;&#x2F;h1&gt;" }],
       });
     });
 
-    it('should return non-string/non-object values as is', () => {
+    it("should return non-string/non-object values as is", () => {
       expect(sanitizeInput(123)).toBe(123);
       expect(sanitizeInput(true)).toBe(true);
       expect(sanitizeInput(null)).toBe(null);
@@ -55,64 +57,72 @@ describe('Sanitize Utils', () => {
   });
 
   // 2. assertSafeString
-  describe('assertSafeString', () => {
-    it('should throw if input is not a string', () => {
-      expect(() => assertSafeString(123, 'username')).toThrow('username must be a string');
+  describe("assertSafeString", () => {
+    it("should throw if input is not a string", () => {
+      expect(() => assertSafeString(123, "username")).toThrow(
+        "username must be a string",
+      );
     });
 
     it('should return input directly if field is "email" (Bypass logic)', () => {
-      const email = 'user.name@example.com';
-      expect(assertSafeString(email, 'email')).toBe(email);
+      const email = "user.name@example.com";
+      expect(assertSafeString(email, "email")).toBe(email);
     });
 
     it('should throw if input contains "$"', () => {
-      expect(() => assertSafeString('user$name', 'username'))
-        .toThrow('username contains invalid characters');
+      expect(() => assertSafeString("user$name", "username")).toThrow(
+        "username contains invalid characters",
+      );
     });
 
     it('should throw if input contains "." (excluding email field)', () => {
-      expect(() => assertSafeString('user.name', 'username'))
-        .toThrow('username contains invalid characters');
+      expect(() => assertSafeString("user.name", "username")).toThrow(
+        "username contains invalid characters",
+      );
     });
 
-    it('should throw if input contains invalid regex characters (e.g., spaces)', () => {
-      expect(() => assertSafeString('user name', 'username'))
-        .toThrow('username contains invalid format');
+    it("should throw if input contains invalid regex characters (e.g., spaces)", () => {
+      expect(() => assertSafeString("user name", "username")).toThrow(
+        "username contains invalid format",
+      );
     });
 
-    it('should return valid input', () => {
-      const valid = 'Username123';
-      expect(assertSafeString(valid, 'username')).toBe(valid);
+    it("should return valid input", () => {
+      const valid = "Username123";
+      expect(assertSafeString(valid, "username")).toBe(valid);
     });
   });
 
   // 3. assertEmail
-  describe('assertEmail', () => {
-    it('should throw if input is not a string', () => {
-      expect(() => assertEmail(123)).toThrow('email must be a string');
+  describe("assertEmail", () => {
+    it("should throw if input is not a string", () => {
+      expect(() => assertEmail(123)).toThrow("email must be a string");
     });
 
     it('should throw if input starts with "$"', () => {
-      expect(() => assertEmail('$injection@test.com'))
-        .toThrow("email cannot start with '$'");
+      expect(() => assertEmail("$injection@test.com")).toThrow(
+        "email cannot start with '$'",
+      );
     });
 
-    it('should throw if input is not a valid email format', () => {
-      expect(() => assertEmail('not-an-email'))
-        .toThrow('email must be a valid email');
+    it("should throw if input is not a valid email format", () => {
+      expect(() => assertEmail("not-an-email")).toThrow(
+        "email must be a valid email",
+      );
     });
 
-    it('should sanitize (trim + lowercase) and return valid email', () => {
+    it("should sanitize (trim + lowercase) and return valid email", () => {
       // NOTE: Validator checks format BEFORE trim.
       // Input must be valid email format first (no spaces), then we test lowercase logic.
-      const input = 'TEST@Example.com';
+      const input = "TEST@Example.com";
       const output = assertEmail(input);
-      expect(output).toBe('test@example.com');
+      expect(output).toBe("test@example.com");
     });
 
-    it('should use custom field name in error messages', () => {
-      expect(() => assertEmail('bad-email', 'secondaryEmail'))
-        .toThrow('secondaryEmail must be a valid email');
+    it("should use custom field name in error messages", () => {
+      expect(() => assertEmail("bad-email", "secondaryEmail")).toThrow(
+        "secondaryEmail must be a valid email",
+      );
     });
   });
 });


### PR DESCRIPTION
<!--
We, the rest of the Yosemite community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?
- Currently parents are only able to see the tasks which are assigned to them.

## What is the new behavior?
- Now parent will be able to see the task which are assigned to them as well as the task which they have created.

## Related Issue(s)
Fixes #1317


