### PR TITLE
Fix: Appointment creation is failing if there is no consent form linked to that service

### DIFF
--- a/apps/backend/src/services/appointment.service.ts
+++ b/apps/backend/src/services/appointment.service.ts
@@ -21,7 +21,7 @@ import UserProfileModel from "src/models/user-profile";
 import { NotificationTemplates } from "src/utils/notificationTemplates";
 import { NotificationService } from "./notification.service";
 import { TaskService } from "./task.service";
-import { FormService } from "./form.service";
+import { FormService, FormServiceError } from "./form.service";
 
 export class AppointmentServiceError extends Error {
   constructor(
@@ -197,12 +197,20 @@ export const AppointmentService = {
       throw new AppointmentServiceError("Invalid service selected", 404);
     }
 
-    const consentForm = await FormService.getConsentFormForParent(
-      organisationId.toString(),
-      {
-        serviceId: serviceId.toString(),
-      },
-    );
+    let consentForm = null;
+
+    try {
+      consentForm = await FormService.getConsentFormForParent(
+        organisationId.toString(),
+        { serviceId: serviceId.toString() },
+      );
+    } catch (err) {
+      if (err instanceof FormServiceError && err.statusCode === 404) {
+        consentForm = null; // expected case
+      } else {
+        throw err; // real error
+      }
+    }
 
     if (consentForm) {
       input.formIds?.push(consentForm.id!);
@@ -314,12 +322,20 @@ export const AppointmentService = {
       );
     }
 
-    const consentForm = await FormService.getConsentFormForParent(
-      organisationId.toString(),
-      {
-        serviceId: serviceId.toString(),
-      },
-    );
+    let consentForm = null;
+
+    try {
+      consentForm = await FormService.getConsentFormForParent(
+        organisationId.toString(),
+        { serviceId: serviceId.toString() },
+      );
+    } catch (err) {
+      if (err instanceof FormServiceError && err.statusCode === 404) {
+        consentForm = null; // expected case
+      } else {
+        throw err; // real error
+      }
+    }
 
     if (consentForm) {
       input.formIds?.push(consentForm.id!);

--- a/apps/backend/test/services/expense.service.test.ts
+++ b/apps/backend/test/services/expense.service.test.ts
@@ -296,13 +296,11 @@ describe("ExpenseService", () => {
           .mockResolvedValue({ _id: validObjectId, status: "DRAFT" }),
       });
       (OrganizationModel.findById as jest.Mock).mockReturnValue({
-        select: jest
-          .fn()
-          .mockReturnValue({
-            lean: jest
-              .fn()
-              .mockReturnValue({ catch: jest.fn().mockResolvedValue({}) }),
-          }),
+        select: jest.fn().mockReturnValue({
+          lean: jest
+            .fn()
+            .mockReturnValue({ catch: jest.fn().mockResolvedValue({}) }),
+        }),
       });
 
       const res: any = await ExpenseService.getExpenseById(validObjectId);


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?
- We are not able to create appointment for a service if there is no consent form is present for that service.

## What is the new behavior?
- It is now allowing to create appointment even if there is no consent form for the service for which appointment is getting booked.

## Related Issue(s)
Fixes #1320 


