### PR TITLE
feat(backend): enhance contact-us with priority, assignment, Prisma dual-write

### DIFF
--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -30,6 +30,13 @@ enum ContactStatus {
   CLOSED
 }
 
+enum ContactPriority {
+  LOW
+  MEDIUM
+  HIGH
+  CRITICAL
+}
+
 enum CompanionType {
   dog
   cat
@@ -215,7 +222,13 @@ model ContactRequest {
   dsarDetails      Json?
   complaintContext Json?
   attachments      Json?
+  fullName         String?
+  phone            String?
   status           ContactStatus @default(OPEN)
+  priority         ContactPriority @default(MEDIUM)
+  assigneeId       String?
+  assigneeName     String?
+  category         String?
   internalNotes    String?
   createdAt        DateTime      @default(now())
   updatedAt        DateTime      @updatedAt

--- a/apps/backend/src/controllers/app/contact-us.controller.ts
+++ b/apps/backend/src/controllers/app/contact-us.controller.ts
@@ -9,7 +9,32 @@ import {
 import { generatePresignedUrl, getURLForKey } from "src/middlewares/upload";
 import { AuthenticatedRequest } from "src/middlewares/auth";
 import { AuthUserMobileService } from "src/services/authUserMobile.service";
-import { type ContactType, type ContactStatus } from "src/models/contect-us";
+import {
+  type ContactType,
+  type ContactStatus,
+  type ContactPriority,
+} from "src/models/contect-us";
+
+const CONTACT_PRIORITIES = new Set<ContactPriority>([
+  "LOW",
+  "MEDIUM",
+  "HIGH",
+  "CRITICAL",
+]);
+
+const toContactPriority = (value: unknown): ContactPriority | undefined =>
+  typeof value === "string" && CONTACT_PRIORITIES.has(value as ContactPriority)
+    ? (value as ContactPriority)
+    : undefined;
+
+type UpdateContactPriorityBody = {
+  priority: ContactPriority;
+};
+
+type AssignContactBody = {
+  assigneeId: string;
+  assigneeName: string;
+};
 
 const resolveMobileUserId = (req: Request): string | undefined => {
   const authReq = req as AuthenticatedRequest;
@@ -245,15 +270,21 @@ export const ContactController = {
     }
   },
 
-  async updatePriority(this: void, req: Request, res: Response) {
+  async updatePriority(
+    this: void,
+    req: Request<{ id: string }, unknown, UpdateContactPriorityBody>,
+    res: Response,
+  ) {
     try {
-      const { id } = req.params;
-      const { priority } = req.body;
-      if (!['LOW', 'MEDIUM', 'HIGH', 'CRITICAL'].includes(priority)) {
-        return res.status(400).json({ message: 'Invalid priority value' });
+      const priority = toContactPriority(req.body.priority);
+      if (!priority) {
+        return res.status(400).json({ message: "Invalid priority value" });
       }
-      const result = await ContactService.updatePriority(id, priority);
-      if (!result) return res.status(404).json({ message: 'Not found' });
+      const result = await ContactService.updatePriority(
+        req.params.id,
+        priority,
+      );
+      if (!result) return res.status(404).json({ message: "Not found" });
       return res.json(result);
     } catch (err) {
       console.error("Error updating contact request priority", err);
@@ -261,15 +292,29 @@ export const ContactController = {
     }
   },
 
-  async assignRequest(this: void, req: Request, res: Response) {
+  async assignRequest(
+    this: void,
+    req: Request<{ id: string }, unknown, AssignContactBody>,
+    res: Response,
+  ) {
     try {
-      const { id } = req.params;
       const { assigneeId, assigneeName } = req.body;
-      if (!assigneeId || !assigneeName) {
-        return res.status(400).json({ message: 'assigneeId and assigneeName are required' });
+      if (
+        typeof assigneeId !== "string" ||
+        typeof assigneeName !== "string" ||
+        !assigneeId ||
+        !assigneeName
+      ) {
+        return res
+          .status(400)
+          .json({ message: "assigneeId and assigneeName are required" });
       }
-      const result = await ContactService.assignRequest(id, assigneeId, assigneeName);
-      if (!result) return res.status(404).json({ message: 'Not found' });
+      const result = await ContactService.assignRequest(
+        req.params.id,
+        assigneeId,
+        assigneeName,
+      );
+      if (!result) return res.status(404).json({ message: "Not found" });
       return res.json(result);
     } catch (err) {
       console.error("Error assigning contact request", err);

--- a/apps/backend/src/controllers/app/contact-us.controller.ts
+++ b/apps/backend/src/controllers/app/contact-us.controller.ts
@@ -83,12 +83,16 @@ export const ContactController = {
         subject,
         message,
         email,
+        fullName,
+        phone,
         organisationId,
         companionId,
         parentId: bodyParentId,
         dsarDetails,
         attachments,
         userId: bodyUserId,
+        priority,
+        category,
       } = req.body;
 
       const payload = {
@@ -97,12 +101,16 @@ export const ContactController = {
         subject,
         message,
         email,
+        fullName,
+        phone,
         organisationId,
         companionId,
         parentId: parentId ?? bodyParentId,
         userId: userId ?? bodyUserId,
         dsarDetails,
         attachments,
+        priority,
+        category,
       };
 
       const doc = await ContactService.createRequest(payload);
@@ -237,5 +245,32 @@ export const ContactController = {
       console.error("Error updating contact request status", err);
       res.status(500).json({ message: "Internal server error" });
     }
+  },
+
+  async updatePriority(this: void, req: Request, res: Response) {
+    const { id } = req.params;
+    const { priority } = req.body;
+    if (!['LOW', 'MEDIUM', 'HIGH', 'CRITICAL'].includes(priority)) {
+      return res.status(400).json({ error: 'Invalid priority' });
+    }
+    const result = await ContactService.updatePriority(id, priority);
+    if (!result) return res.status(404).json({ error: 'Request not found' });
+    return res.json(result);
+  },
+
+  async assignRequest(this: void, req: Request, res: Response) {
+    const { id } = req.params;
+    const { assigneeId, assigneeName } = req.body;
+    if (!assigneeId || !assigneeName) {
+      return res.status(400).json({ error: 'assigneeId and assigneeName are required' });
+    }
+    const result = await ContactService.assignRequest(id, assigneeId, assigneeName);
+    if (!result) return res.status(404).json({ error: 'Request not found' });
+    return res.json(result);
+  },
+
+  async getDashboardStats(this: void, req: Request, res: Response) {
+    const stats = await ContactService.getDashboardStats();
+    return res.json(stats);
   },
 };

--- a/apps/backend/src/controllers/app/contact-us.controller.ts
+++ b/apps/backend/src/controllers/app/contact-us.controller.ts
@@ -91,7 +91,6 @@ export const ContactController = {
         dsarDetails,
         attachments,
         userId: bodyUserId,
-        priority,
         category,
       } = req.body;
 
@@ -109,7 +108,6 @@ export const ContactController = {
         userId: userId ?? bodyUserId,
         dsarDetails,
         attachments,
-        priority,
         category,
       };
 
@@ -248,29 +246,44 @@ export const ContactController = {
   },
 
   async updatePriority(this: void, req: Request, res: Response) {
-    const { id } = req.params;
-    const { priority } = req.body;
-    if (!['LOW', 'MEDIUM', 'HIGH', 'CRITICAL'].includes(priority)) {
-      return res.status(400).json({ error: 'Invalid priority' });
+    try {
+      const { id } = req.params;
+      const { priority } = req.body;
+      if (!['LOW', 'MEDIUM', 'HIGH', 'CRITICAL'].includes(priority)) {
+        return res.status(400).json({ message: 'Invalid priority value' });
+      }
+      const result = await ContactService.updatePriority(id, priority);
+      if (!result) return res.status(404).json({ message: 'Not found' });
+      return res.json(result);
+    } catch (err) {
+      console.error("Error updating contact request priority", err);
+      res.status(500).json({ message: "Internal server error" });
     }
-    const result = await ContactService.updatePriority(id, priority);
-    if (!result) return res.status(404).json({ error: 'Request not found' });
-    return res.json(result);
   },
 
   async assignRequest(this: void, req: Request, res: Response) {
-    const { id } = req.params;
-    const { assigneeId, assigneeName } = req.body;
-    if (!assigneeId || !assigneeName) {
-      return res.status(400).json({ error: 'assigneeId and assigneeName are required' });
+    try {
+      const { id } = req.params;
+      const { assigneeId, assigneeName } = req.body;
+      if (!assigneeId || !assigneeName) {
+        return res.status(400).json({ message: 'assigneeId and assigneeName are required' });
+      }
+      const result = await ContactService.assignRequest(id, assigneeId, assigneeName);
+      if (!result) return res.status(404).json({ message: 'Not found' });
+      return res.json(result);
+    } catch (err) {
+      console.error("Error assigning contact request", err);
+      res.status(500).json({ message: "Internal server error" });
     }
-    const result = await ContactService.assignRequest(id, assigneeId, assigneeName);
-    if (!result) return res.status(404).json({ error: 'Request not found' });
-    return res.json(result);
   },
 
   async getDashboardStats(this: void, req: Request, res: Response) {
-    const stats = await ContactService.getDashboardStats();
-    return res.json(stats);
+    try {
+      const stats = await ContactService.getDashboardStats();
+      return res.json(stats);
+    } catch (err) {
+      console.error("Error fetching dashboard stats", err);
+      res.status(500).json({ message: "Internal server error" });
+    }
   },
 };

--- a/apps/backend/src/controllers/app/contact-us.controller.ts
+++ b/apps/backend/src/controllers/app/contact-us.controller.ts
@@ -13,6 +13,7 @@ import {
   type ContactType,
   type ContactStatus,
   type ContactPriority,
+  type ContactCategory,
 } from "src/models/contect-us";
 
 const CONTACT_PRIORITIES = new Set<ContactPriority>([
@@ -53,6 +54,15 @@ const CONTACT_STATUSES = new Set<ContactStatus>([
 
 const CONTACT_TYPES = new Set<ContactType>([
   "GENERAL_ENQUIRY",
+  "FEATURE_REQUEST",
+  "DSAR",
+  "COMPLAINT",
+]);
+
+const CONTACT_CATEGORIES = new Set<ContactCategory>([
+  "GENERAL_ENQUIRY",
+  "TECHNICAL",
+  "BILLING",
   "FEATURE_REQUEST",
   "DSAR",
   "COMPLAINT",
@@ -118,6 +128,10 @@ export const ContactController = {
         userId: bodyUserId,
         category,
       } = req.body;
+
+      if (category && !CONTACT_CATEGORIES.has(category as ContactCategory)) {
+        return res.status(400).json({ message: "Invalid category value" });
+      }
 
       const payload = {
         type,

--- a/apps/backend/src/middlewares/auth.ts
+++ b/apps/backend/src/middlewares/auth.ts
@@ -157,12 +157,16 @@ const verifyTokenMobile = (token: string): Promise<JwtPayload> => {
 
 // Firebase Config
 
-if (!admin.apps.length) {
-  admin.initializeApp({
-    credential: admin.credential.cert(
-      process.env.GOOGLE_APPLICATION_CREDENTIALS!,
-    ),
-  });
+if (!admin.apps.length && process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+  try {
+    admin.initializeApp({
+      credential: admin.credential.cert(
+        process.env.GOOGLE_APPLICATION_CREDENTIALS,
+      ),
+    });
+  } catch (err) {
+    logger.warn("Firebase initialization failed — Firebase auth will be unavailable", err);
+  }
 }
 
 const verifyFirebaseToken = async (token: string): Promise<JwtPayload> => {

--- a/apps/backend/src/models/contect-us.ts
+++ b/apps/backend/src/models/contect-us.ts
@@ -104,6 +104,16 @@ const DsraSchema = new Schema<DsraDetails>(
   { _id: false },
 );
 
+export type ContactPriority = 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL';
+
+export type ContactCategory =
+  | 'GENERAL_ENQUIRY'
+  | 'TECHNICAL'
+  | 'BILLING'
+  | 'FEATURE_REQUEST'
+  | 'DSAR'
+  | 'COMPLAINT';
+
 export interface ContactRequestMongo {
   type: ContactType;
   source: ContactSource;
@@ -116,6 +126,8 @@ export interface ContactRequestMongo {
   // who is talking, optional depending on whether user is logged in
   userId?: string;
   email?: string;
+  fullName?: string;
+  phone?: string;
 
   // domain context
   organisationId?: string;
@@ -134,6 +146,10 @@ export interface ContactRequestMongo {
   attachments?: ContactAttachment[];
 
   status: ContactStatus;
+  priority: ContactPriority;
+  assigneeId?: string;
+  assigneeName?: string;
+  category: ContactCategory;
   internalNotes?: string;
 
   createdAt?: Date;
@@ -175,11 +191,33 @@ const ContactRequestSchema = new Schema<ContactRequestMongo>(
 
     attachments: { type: [AttachmentSchema], default: [] },
 
+    fullName: { type: String },
+    phone: { type: String },
+
     status: {
       type: String,
       enum: ["OPEN", "IN_PROGRESS", "RESOLVED", "CLOSED"],
       default: "OPEN",
       index: true,
+    },
+    priority: {
+      type: String,
+      enum: ["LOW", "MEDIUM", "HIGH", "CRITICAL"],
+      default: "MEDIUM",
+    },
+    assigneeId: { type: String, default: null },
+    assigneeName: { type: String, default: null },
+    category: {
+      type: String,
+      enum: [
+        "GENERAL_ENQUIRY",
+        "TECHNICAL",
+        "BILLING",
+        "FEATURE_REQUEST",
+        "DSAR",
+        "COMPLAINT",
+      ],
+      default: "GENERAL_ENQUIRY",
     },
     internalNotes: String,
   },

--- a/apps/backend/src/models/contect-us.ts
+++ b/apps/backend/src/models/contect-us.ts
@@ -104,15 +104,15 @@ const DsraSchema = new Schema<DsraDetails>(
   { _id: false },
 );
 
-export type ContactPriority = 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL';
+export type ContactPriority = "LOW" | "MEDIUM" | "HIGH" | "CRITICAL";
 
 export type ContactCategory =
-  | 'GENERAL_ENQUIRY'
-  | 'TECHNICAL'
-  | 'BILLING'
-  | 'FEATURE_REQUEST'
-  | 'DSAR'
-  | 'COMPLAINT';
+  | "GENERAL_ENQUIRY"
+  | "TECHNICAL"
+  | "BILLING"
+  | "FEATURE_REQUEST"
+  | "DSAR"
+  | "COMPLAINT";
 
 export interface ContactRequestMongo {
   type: ContactType;
@@ -126,8 +126,6 @@ export interface ContactRequestMongo {
   // who is talking, optional depending on whether user is logged in
   userId?: string;
   email?: string;
-  fullName?: string;
-  phone?: string;
 
   // domain context
   organisationId?: string;
@@ -190,9 +188,6 @@ const ContactRequestSchema = new Schema<ContactRequestMongo>(
     },
 
     attachments: { type: [AttachmentSchema], default: [] },
-
-    fullName: { type: String },
-    phone: { type: String },
 
     status: {
       type: String,

--- a/apps/backend/src/models/contect-us.ts
+++ b/apps/backend/src/models/contect-us.ts
@@ -144,10 +144,10 @@ export interface ContactRequestMongo {
   attachments?: ContactAttachment[];
 
   status: ContactStatus;
-  priority: ContactPriority;
+  priority?: ContactPriority;
   assigneeId?: string | null;
   assigneeName?: string | null;
-  category: ContactCategory;
+  category?: ContactCategory;
   internalNotes?: string;
 
   createdAt?: Date;

--- a/apps/backend/src/models/contect-us.ts
+++ b/apps/backend/src/models/contect-us.ts
@@ -147,8 +147,8 @@ export interface ContactRequestMongo {
 
   status: ContactStatus;
   priority: ContactPriority;
-  assigneeId?: string;
-  assigneeName?: string;
+  assigneeId?: string | null;
+  assigneeName?: string | null;
   category: ContactCategory;
   internalNotes?: string;
 

--- a/apps/backend/src/queues/index.ts
+++ b/apps/backend/src/queues/index.ts
@@ -6,6 +6,10 @@ import { registerLabStatusScheduler } from "./lab-status.scheduler";
 import { registerLabResultsScheduler } from "./lab-results.scheduler";
 
 export async function initQueues() {
+  if (process.env.USE_INMEMORY_DB === "true") {
+    logger.info("📬 Skipping BullMQ queues (in-memory mode)");
+    return;
+  }
   await registerTaskSchedulers();
   await registerAppointmentSchedulers();
   await registerIdexxReferenceScheduler();

--- a/apps/backend/src/routers/contact-us.router.ts
+++ b/apps/backend/src/routers/contact-us.router.ts
@@ -1,11 +1,23 @@
-import { Router } from "express";
+import { Router, type RequestHandler } from "express";
 import { ContactController } from "src/controllers/app/contact-us.controller";
 import { authorizeCognito, authorizeCognitoMobile } from "src/middlewares/auth";
 
 const router = Router();
 
-// Mobile/web public endpoint (user may or may not be logged in)
-router.post("/contact", authorizeCognitoMobile, ContactController.create);
+// In local dev (in-memory DB), skip auth for admin routes
+const adminAuth: RequestHandler =
+  process.env.USE_INMEMORY_DB === "true" && process.env.NODE_ENV === "development"
+    ? (_req, _res, next) => next()
+    : authorizeCognito;
+
+// Authenticated endpoint for mobile users
+const publicAuth: RequestHandler =
+  process.env.USE_INMEMORY_DB === "true"
+    ? (_req, _res, next) => next()
+    : authorizeCognitoMobile;
+
+// Mobile/web endpoint (authenticated via mobile auth)
+router.post("/contact", publicAuth, ContactController.create);
 router.post("/contact-web", ContactController.createWeb);
 router.post(
   "/attachments/presigned-url",
@@ -13,13 +25,23 @@ router.post(
 );
 
 // Internal admin / support tools
-// router.use(requireAdminAuth);
-router.get("/requests", authorizeCognito, ContactController.list);
-router.get("/requests/:id", authorizeCognito, ContactController.getById);
+router.get("/requests", adminAuth, ContactController.list);
+router.get("/requests/:id", adminAuth, ContactController.getById);
+router.patch("/requests/:id/status", adminAuth, ContactController.updateStatus);
 router.patch(
-  "/requests/:id/status",
-  authorizeCognito,
-  ContactController.updateStatus,
+  "/requests/:id/priority",
+  adminAuth,
+  ContactController.updatePriority,
+);
+router.patch(
+  "/requests/:id/assign",
+  adminAuth,
+  ContactController.assignRequest,
+);
+router.get(
+  "/dashboard/stats",
+  adminAuth,
+  ContactController.getDashboardStats,
 );
 
 export default router;

--- a/apps/backend/src/routers/contact-us.router.ts
+++ b/apps/backend/src/routers/contact-us.router.ts
@@ -4,17 +4,14 @@ import { authorizeCognito, authorizeCognitoMobile } from "src/middlewares/auth";
 
 const router = Router();
 
-// In local dev (in-memory DB), skip auth for admin routes
-const adminAuth: RequestHandler =
-  process.env.USE_INMEMORY_DB === "true" && process.env.NODE_ENV === "development"
-    ? (_req, _res, next) => next()
-    : authorizeCognito;
+// In local dev (in-memory DB + development), skip auth for admin routes
+const skipAuth: RequestHandler = (_req, _res, next) => next();
+const isLocalDev =
+  process.env.USE_INMEMORY_DB === "true" &&
+  process.env.NODE_ENV === "development";
 
-// Authenticated endpoint for mobile users
-const publicAuth: RequestHandler =
-  process.env.USE_INMEMORY_DB === "true"
-    ? (_req, _res, next) => next()
-    : authorizeCognitoMobile;
+const adminAuth = isLocalDev ? skipAuth : authorizeCognito;
+const publicAuth = isLocalDev ? skipAuth : authorizeCognitoMobile;
 
 // Mobile/web endpoint (authenticated via mobile auth)
 router.post("/contact", publicAuth, ContactController.create);
@@ -38,10 +35,6 @@ router.patch(
   adminAuth,
   ContactController.assignRequest,
 );
-router.get(
-  "/dashboard/stats",
-  adminAuth,
-  ContactController.getDashboardStats,
-);
+router.get("/dashboard/stats", adminAuth, ContactController.getDashboardStats);
 
 export default router;

--- a/apps/backend/src/services/chat.service.ts
+++ b/apps/backend/src/services/chat.service.ts
@@ -324,7 +324,7 @@ export const ChatService = {
         throw new ChatServiceError("Parent not found in appointment", 404);
       }
 
-      await streamServer.upsertUser({
+      await getStreamServer().upsertUser({
         id: parentId,
         name: companion?.parent?.name || "Pet Owner",
         role: "user",
@@ -333,7 +333,7 @@ export const ChatService = {
       const lead = appointment.lead as { id?: string; name?: string } | null;
       const vetId = lead?.id ?? null;
       if (vetId) {
-        await streamServer.upsertUser({
+        await getStreamServer().upsertUser({
           id: vetId,
           name: lead?.name || "Vet",
           role: "user",
@@ -346,7 +346,7 @@ export const ChatService = {
       const members = [parentId];
       if (vetId) members.push(vetId);
 
-      await streamServer.upsertUser({
+      await getStreamServer().upsertUser({
         id: SYSTEM_USER_ID,
         name: "Yosemite System",
         role: "admin",
@@ -369,7 +369,7 @@ export const ChatService = {
         members,
       };
 
-      await streamServer.channel("messaging", channelId, channelData).create();
+      await getStreamServer().channel("messaging", channelId, channelData).create();
 
       const session = await prisma.chatSession.create({
         data: {
@@ -511,7 +511,7 @@ export const ChatService = {
 
     const channelId = `od_${hash}`;
 
-    await streamServer
+    await getStreamServer()
       .channel("team", channelId, {
         members,
         created_by_id: userA,
@@ -669,7 +669,7 @@ export const ChatService = {
       });
       if (!session) return;
 
-      const channel = streamServer.channel(
+      const channel = getStreamServer().channel(
         getStreamChannelType(session.type as ChatSessionType),
         session.channelId,
       );
@@ -748,7 +748,7 @@ export const ChatService = {
         );
         const user = await UserService.getById(userId);
 
-        await streamServer.upsertUser({
+        await getStreamServer().upsertUser({
           name: user?.firstName + " " + user?.lastName || "User",
           id: userId,
           image:
@@ -764,7 +764,7 @@ export const ChatService = {
         data: { members: updatedMembers },
       });
 
-      const channel = streamServer.channel("team", session.channelId);
+      const channel = getStreamServer().channel("team", session.channelId);
       await channel.addMembers(newMembers);
 
       return updated as unknown as ChatSessionDocument;
@@ -841,7 +841,7 @@ export const ChatService = {
         data: { members: nextMembers },
       });
 
-      const channel = streamServer.channel("team", session.channelId);
+      const channel = getStreamServer().channel("team", session.channelId);
       await channel.removeMembers(memberIds);
 
       return updated as unknown as ChatSessionDocument;
@@ -903,7 +903,7 @@ export const ChatService = {
         },
       });
 
-      const channel = streamServer.channel("team", session.channelId);
+      const channel = getStreamServer().channel("team", session.channelId);
 
       const data: YosemiteChannelResponse = {
         name: updates.title,
@@ -952,7 +952,7 @@ export const ChatService = {
 
       assertGroupAdminPrisma(session, actorUserId);
 
-      const channel = streamServer.channel("team", session.channelId);
+      const channel = getStreamServer().channel("team", session.channelId);
 
       try {
         await channel.delete();

--- a/apps/backend/src/services/chat.service.ts
+++ b/apps/backend/src/services/chat.service.ts
@@ -28,6 +28,13 @@ if (STREAM_KEY && STREAM_SECRET) {
   streamServer = StreamChat.getInstance(STREAM_KEY, STREAM_SECRET);
 }
 
+function getStreamServer(): StreamChat {
+  if (!streamServer) {
+    throw new Error("Stream Chat is not configured. Set STREAM_API_KEY and STREAM_API_SECRET.");
+  }
+  return streamServer;
+}
+
 // Appointment chat window
 const PRE_WINDOW_MINUTES = 60 * 24;
 const POST_WINDOW_MINUTES = 120;
@@ -275,13 +282,13 @@ export const ChatService = {
     if (!userId) throw new ChatServiceError("userId is required");
 
     return {
-      token: streamServer.createToken(userId),
+      token: getStreamServer().createToken(userId),
       expiresAt: Date.now() + 24 * 60 * 60 * 1000,
     };
   },
 
   async initSystemUserOnce() {
-    await streamServer.upsertUser({
+    await getStreamServer().upsertUser({
       id: SYSTEM_USER_ID,
       name: "Yosemite System",
       role: "admin",
@@ -393,7 +400,7 @@ export const ChatService = {
 
     const parentId = appointment.companion.parent.id;
     //Upsert parent user in Stream
-    await streamServer.upsertUser({
+    await getStreamServer().upsertUser({
       id: parentId,
       name: appointment.companion.parent.name || "Pet Owner",
       role: "user",
@@ -401,7 +408,7 @@ export const ChatService = {
 
     const vetId = appointment.lead?.id ?? null;
     // Upsert vet user in Stream if assigned
-    await streamServer.upsertUser({
+    await getStreamServer().upsertUser({
       id: vetId!,
       name: appointment.lead?.name || "Vet",
       role: "user",
@@ -413,7 +420,7 @@ export const ChatService = {
     const members = [parentId];
     if (vetId) members.push(vetId);
 
-    await streamServer.upsertUser({
+    await getStreamServer().upsertUser({
       id: SYSTEM_USER_ID,
       name: "Yosemite System",
       role: "admin",
@@ -433,7 +440,7 @@ export const ChatService = {
     };
 
     // IMPORTANT: include created_by_id (or created_by)
-    const channel = streamServer.channel("messaging", channelId, {
+    const channel = getStreamServer().channel("messaging", channelId, {
       ...data,
       created_by_id: parentId,
     });
@@ -491,7 +498,7 @@ export const ChatService = {
       );
       const user = await UserService.getById(userId);
 
-      await streamServer.upsertUser({
+      await getStreamServer().upsertUser({
         name: user?.firstName + " " + user?.lastName || "User",
         id: userId,
         image:
@@ -553,7 +560,7 @@ export const ChatService = {
       );
       const user = await UserService.getById(userId);
 
-      await streamServer.upsertUser({
+      await getStreamServer().upsertUser({
         name: user?.firstName + " " + user?.lastName || "User",
         id: userId,
         image:
@@ -571,7 +578,7 @@ export const ChatService = {
       created_by_id: createdBy,
     };
 
-    await streamServer.channel("team", channelId, channelData).create();
+    await getStreamServer().channel("team", channelId, channelData).create();
 
     const session = await ChatSessionModel.create({
       type: "ORG_GROUP",
@@ -689,7 +696,7 @@ export const ChatService = {
     const session = await ChatSessionModel.findById(sessionId);
     if (!session) return;
 
-    const channel = streamServer.channel(
+    const channel = getStreamServer().channel(
       getStreamChannelType(session.type),
       session.channelId,
     );
@@ -782,7 +789,7 @@ export const ChatService = {
       );
       const user = await UserService.getById(userId);
 
-      await streamServer.upsertUser({
+      await getStreamServer().upsertUser({
         name: user?.firstName + " " + user?.lastName || "User",
         id: userId,
         image:
@@ -795,7 +802,7 @@ export const ChatService = {
     await session.save();
     await syncChatSessionToPostgres(session);
 
-    const channel = streamServer.channel("team", session.channelId);
+    const channel = getStreamServer().channel("team", session.channelId);
     await channel.addMembers(newMembers);
 
     return session;
@@ -861,7 +868,7 @@ export const ChatService = {
     await session.save();
     await syncChatSessionToPostgres(session);
 
-    const channel = streamServer.channel("team", session.channelId);
+    const channel = getStreamServer().channel("team", session.channelId);
     await channel.removeMembers(memberIds);
 
     return session;
@@ -925,7 +932,7 @@ export const ChatService = {
     await session.save();
     await syncChatSessionToPostgres(session);
 
-    const channel = streamServer.channel("team", session.channelId);
+    const channel = getStreamServer().channel("team", session.channelId);
 
     const data: YosemiteChannelResponse = {
       name: updates.title,
@@ -962,7 +969,7 @@ export const ChatService = {
 
     assertGroupAdmin(session, actorUserId);
 
-    const channel = streamServer.channel("team", session.channelId);
+    const channel = getStreamServer().channel("team", session.channelId);
 
     try {
       await channel.delete();

--- a/apps/backend/src/services/chat.service.ts
+++ b/apps/backend/src/services/chat.service.ts
@@ -23,11 +23,10 @@ const STREAM_KEY = process.env.STREAM_API_KEY!;
 const STREAM_SECRET = process.env.STREAM_API_SECRET!;
 const SYSTEM_USER_ID = "system-yosemite";
 
-if (!STREAM_KEY || !STREAM_SECRET) {
-  throw new Error("Stream Chat credentials missing in env");
+let streamServer: StreamChat | null = null;
+if (STREAM_KEY && STREAM_SECRET) {
+  streamServer = StreamChat.getInstance(STREAM_KEY, STREAM_SECRET);
 }
-
-const streamServer = StreamChat.getInstance(STREAM_KEY, STREAM_SECRET);
 
 // Appointment chat window
 const PRE_WINDOW_MINUTES = 60 * 24;

--- a/apps/backend/src/services/contact-us.service.ts
+++ b/apps/backend/src/services/contact-us.service.ts
@@ -103,6 +103,8 @@ export const ContactService = {
           message: input.message,
           userId: input.userId ?? undefined,
           email: input.email ?? undefined,
+          fullName: input.fullName ?? undefined,
+          phone: input.phone ?? undefined,
           organisationId: input.organisationId ?? undefined,
           companionId: input.companionId ?? undefined,
           parentId: input.parentId ?? undefined,
@@ -110,6 +112,8 @@ export const ContactService = {
           complaintContext: undefined,
           attachments,
           status: "OPEN",
+          priority: input.priority ?? undefined,
+          category: input.category ?? undefined,
           internalNotes: undefined,
         },
       });
@@ -134,6 +138,8 @@ export const ContactService = {
             message: input.message,
             userId: input.userId,
             email: input.email,
+            fullName: input.fullName,
+            phone: input.phone,
             organisationId: input.organisationId,
             companionId: input.companionId,
             parentId: input.parentId,
@@ -141,6 +147,8 @@ export const ContactService = {
             complaintContext: undefined,
             attachments,
             status: "OPEN",
+            priority: input.priority,
+            category: input.category,
             internalNotes: undefined,
             createdAt: doc.createdAt ?? undefined,
             updatedAt: doc.updatedAt ?? undefined,
@@ -179,7 +187,10 @@ export const ContactService = {
           source: input.source,
           subject: input.type,
           message: input.message.trim(),
+          fullName: input.fullName.trim(),
           email: input.email.trim(),
+          phone: input.phone?.trim(),
+          organisationId: input.organisationId ?? undefined,
           dsarDetails,
           attachments,
           status: "OPEN",
@@ -196,6 +207,35 @@ export const ContactService = {
       phone: input.phone?.trim(),
       status: "OPEN",
     });
+
+    if (shouldDualWrite) {
+      try {
+        const dsarDetails = toPrismaJson(input.dsarDetails);
+        const attachments = toPrismaJson(input.attachments);
+
+        await prisma.contactRequest.create({
+          data: {
+            id: doc._id.toString(),
+            type: input.type,
+            source: input.source,
+            subject: input.type,
+            message: input.message.trim(),
+            fullName: input.fullName.trim(),
+            email: input.email.trim(),
+            phone: input.phone?.trim(),
+            organisationId: input.organisationId,
+            dsarDetails,
+            attachments,
+            status: "OPEN",
+            createdAt: doc.createdAt ?? undefined,
+            updatedAt: doc.updatedAt ?? undefined,
+          },
+        });
+      } catch (err) {
+        handleDualWriteError("ContactRequest", err);
+      }
+    }
+
     return doc;
   },
 
@@ -256,23 +296,109 @@ export const ContactService = {
   },
 
   async updatePriority(id: string, priority: ContactPriority) {
-    return ContactRequestModel.findByIdAndUpdate(id, { priority }, { new: true, runValidators: true });
+    if (isReadFromPostgres()) {
+      return prisma.contactRequest.update({
+        where: { id },
+        data: { priority },
+      });
+    }
+
+    const updated = await ContactRequestModel.findByIdAndUpdate(
+      id,
+      { priority },
+      { new: true, runValidators: true },
+    );
+
+    if (updated && shouldDualWrite) {
+      try {
+        await prisma.contactRequest.updateMany({
+          where: { id },
+          data: { priority },
+        });
+      } catch (err) {
+        handleDualWriteError("ContactRequest", err);
+      }
+    }
+
+    return updated;
   },
 
   async assignRequest(id: string, assigneeId: string, assigneeName: string) {
-    return ContactRequestModel.findByIdAndUpdate(id, { assigneeId, assigneeName }, { new: true, runValidators: true });
+    if (isReadFromPostgres()) {
+      return prisma.contactRequest.update({
+        where: { id },
+        data: { assigneeId, assigneeName },
+      });
+    }
+
+    const updated = await ContactRequestModel.findByIdAndUpdate(
+      id,
+      { assigneeId, assigneeName },
+      { new: true, runValidators: true },
+    );
+
+    if (updated && shouldDualWrite) {
+      try {
+        await prisma.contactRequest.updateMany({
+          where: { id },
+          data: { assigneeId, assigneeName },
+        });
+      } catch (err) {
+        handleDualWriteError("ContactRequest", err);
+      }
+    }
+
+    return updated;
   },
 
   async getDashboardStats() {
-    const [total, open, inProgress, resolved, closed, byType, byPriority] = await Promise.all([
-      ContactRequestModel.countDocuments(),
-      ContactRequestModel.countDocuments({ status: 'OPEN' }),
-      ContactRequestModel.countDocuments({ status: 'IN_PROGRESS' }),
-      ContactRequestModel.countDocuments({ status: 'RESOLVED' }),
-      ContactRequestModel.countDocuments({ status: 'CLOSED' }),
-      ContactRequestModel.aggregate([{ $group: { _id: '$type', count: { $sum: 1 } } }]),
-      ContactRequestModel.aggregate([{ $group: { _id: '$priority', count: { $sum: 1 } } }]),
-    ]);
+    if (isReadFromPostgres()) {
+      const [total, open, inProgress, resolved, closed] = await Promise.all([
+        prisma.contactRequest.count(),
+        prisma.contactRequest.count({ where: { status: "OPEN" } }),
+        prisma.contactRequest.count({ where: { status: "IN_PROGRESS" } }),
+        prisma.contactRequest.count({ where: { status: "RESOLVED" } }),
+        prisma.contactRequest.count({ where: { status: "CLOSED" } }),
+      ]);
+
+      const byType = await prisma.contactRequest.groupBy({
+        by: ["type"],
+        _count: true,
+      });
+
+      const byPriority = await prisma.contactRequest.groupBy({
+        by: ["priority"],
+        _count: true,
+      });
+
+      return {
+        total,
+        open,
+        inProgress,
+        resolved,
+        closed,
+        byType: byType.map((t) => ({ _id: t.type, count: t._count })),
+        byPriority: byPriority.map((p) => ({
+          _id: p.priority,
+          count: p._count,
+        })),
+      };
+    }
+
+    const [total, open, inProgress, resolved, closed, byType, byPriority] =
+      await Promise.all([
+        ContactRequestModel.countDocuments(),
+        ContactRequestModel.countDocuments({ status: "OPEN" }),
+        ContactRequestModel.countDocuments({ status: "IN_PROGRESS" }),
+        ContactRequestModel.countDocuments({ status: "RESOLVED" }),
+        ContactRequestModel.countDocuments({ status: "CLOSED" }),
+        ContactRequestModel.aggregate([
+          { $group: { _id: "$type", count: { $sum: 1 } } },
+        ]),
+        ContactRequestModel.aggregate([
+          { $group: { _id: "$priority", count: { $sum: 1 } } },
+        ]),
+      ]);
     return { total, open, inProgress, resolved, closed, byType, byPriority };
   },
 };

--- a/apps/backend/src/services/contact-us.service.ts
+++ b/apps/backend/src/services/contact-us.service.ts
@@ -297,10 +297,12 @@ export const ContactService = {
 
   async updatePriority(id: string, priority: ContactPriority) {
     if (isReadFromPostgres()) {
-      return prisma.contactRequest.update({
+      const { count } = await prisma.contactRequest.updateMany({
         where: { id },
         data: { priority },
       });
+      if (count === 0) return null;
+      return prisma.contactRequest.findUnique({ where: { id } });
     }
 
     const updated = await ContactRequestModel.findByIdAndUpdate(
@@ -325,10 +327,12 @@ export const ContactService = {
 
   async assignRequest(id: string, assigneeId: string, assigneeName: string) {
     if (isReadFromPostgres()) {
-      return prisma.contactRequest.update({
+      const { count } = await prisma.contactRequest.updateMany({
         where: { id },
         data: { assigneeId, assigneeName },
       });
+      if (count === 0) return null;
+      return prisma.contactRequest.findUnique({ where: { id } });
     }
 
     const updated = await ContactRequestModel.findByIdAndUpdate(
@@ -363,12 +367,12 @@ export const ContactService = {
 
       const byType = await prisma.contactRequest.groupBy({
         by: ["type"],
-        _count: true,
+        _count: { _all: true },
       });
 
       const byPriority = await prisma.contactRequest.groupBy({
         by: ["priority"],
-        _count: true,
+        _count: { _all: true },
       });
 
       return {
@@ -377,10 +381,10 @@ export const ContactService = {
         inProgress,
         resolved,
         closed,
-        byType: byType.map((t) => ({ _id: t.type, count: t._count })),
+        byType: byType.map((t) => ({ _id: t.type, count: t._count._all })),
         byPriority: byPriority.map((p) => ({
           _id: p.priority,
-          count: p._count,
+          count: p._count._all,
         })),
       };
     }

--- a/apps/backend/src/services/contact-us.service.ts
+++ b/apps/backend/src/services/contact-us.service.ts
@@ -1,6 +1,8 @@
 import { RootFilterQuery } from "mongoose";
 import ContactRequestModel, {
   ContactAttachment,
+  ContactCategory,
+  ContactPriority,
   ContactRequestMongo,
   ContactSource,
   ContactStatus,
@@ -29,11 +31,15 @@ export type CreateContactRequestInput = {
   message: string;
   userId?: string;
   email?: string;
+  fullName?: string;
+  phone?: string;
   organisationId?: string;
   companionId?: string;
   parentId?: string;
   dsarDetails?: DsraDetails;
   attachments?: ContactAttachment[];
+  priority?: ContactPriority;
+  category?: ContactCategory;
 };
 
 export type CreateWebContactRequestInput = {
@@ -247,5 +253,26 @@ export const ContactService = {
     }
 
     return updated;
+  },
+
+  async updatePriority(id: string, priority: string) {
+    return ContactRequestModel.findByIdAndUpdate(id, { priority }, { new: true });
+  },
+
+  async assignRequest(id: string, assigneeId: string, assigneeName: string) {
+    return ContactRequestModel.findByIdAndUpdate(id, { assigneeId, assigneeName }, { new: true });
+  },
+
+  async getDashboardStats() {
+    const [total, open, inProgress, resolved, closed, byType, byPriority] = await Promise.all([
+      ContactRequestModel.countDocuments(),
+      ContactRequestModel.countDocuments({ status: 'OPEN' }),
+      ContactRequestModel.countDocuments({ status: 'IN_PROGRESS' }),
+      ContactRequestModel.countDocuments({ status: 'RESOLVED' }),
+      ContactRequestModel.countDocuments({ status: 'CLOSED' }),
+      ContactRequestModel.aggregate([{ $group: { _id: '$type', count: { $sum: 1 } } }]),
+      ContactRequestModel.aggregate([{ $group: { _id: '$priority', count: { $sum: 1 } } }]),
+    ]);
+    return { total, open, inProgress, resolved, closed, byType, byPriority };
   },
 };

--- a/apps/backend/src/services/contact-us.service.ts
+++ b/apps/backend/src/services/contact-us.service.ts
@@ -255,12 +255,12 @@ export const ContactService = {
     return updated;
   },
 
-  async updatePriority(id: string, priority: string) {
-    return ContactRequestModel.findByIdAndUpdate(id, { priority }, { new: true });
+  async updatePriority(id: string, priority: ContactPriority) {
+    return ContactRequestModel.findByIdAndUpdate(id, { priority }, { new: true, runValidators: true });
   },
 
   async assignRequest(id: string, assigneeId: string, assigneeName: string) {
-    return ContactRequestModel.findByIdAndUpdate(id, { assigneeId, assigneeName }, { new: true });
+    return ContactRequestModel.findByIdAndUpdate(id, { assigneeId, assigneeName }, { new: true, runValidators: true });
   },
 
   async getDashboardStats() {

--- a/apps/backend/src/workers/index.ts
+++ b/apps/backend/src/workers/index.ts
@@ -1,9 +1,18 @@
-import "./taskReminder.worker";
-import "./taskRecurrence.worker";
-import "./appointment.worker";
-import "./idexx-reference.worker";
-import "./lab-status.worker";
-import "./lab-results.worker";
 import logger from "src/utils/logger";
 
-logger.info("👷 BullMQ workers running...");
+if (process.env.USE_INMEMORY_DB !== "true") {
+  Promise.all([
+    import("./taskReminder.worker"),
+    import("./taskRecurrence.worker"),
+    import("./appointment.worker"),
+    import("./idexx-reference.worker"),
+    import("./lab-status.worker"),
+    import("./lab-results.worker"),
+  ]).then(() => {
+    logger.info("👷 BullMQ workers running...");
+  }).catch((err) => {
+    logger.error("Failed to load BullMQ workers", err);
+  });
+} else {
+  logger.info("👷 Skipping BullMQ workers (in-memory mode)");
+}


### PR DESCRIPTION
## Summary

Extends the contact-us system to support the Super Admin dashboard with full Prisma dual-write parity.

### Model Changes (MongoDB + Prisma)
- Added `priority` field (LOW/MEDIUM/HIGH/CRITICAL) with default MEDIUM
- Added `assigneeId` and `assigneeName` fields for ticket assignment
- Added `fullName`, `phone`, and `category` fields from the contact form
- Added `ContactPriority` enum to Prisma schema

### New Endpoints
- `PATCH /v1/contact-us/requests/:id/priority` — Update ticket priority
- `PATCH /v1/contact-us/requests/:id/assign` — Assign ticket to team member
- `GET /v1/contact-us/dashboard/stats` — Aggregated dashboard statistics

### Prisma Dual-Write
- `updatePriority`: read-switch + dual-write matching existing `updateStatus` pattern
- `assignRequest`: read-switch + dual-write
- `getDashboardStats`: read-switch with Prisma `count()` and `groupBy()` queries
- `createRequest`: includes new fields in both Postgres-read and dual-write paths
- `createWebRequest`: added missing dual-write block

### Code Quality
- Type-safe controller handlers with typed Request signatures
- Validator helpers (`toContactPriority`) matching existing pattern
- try/catch on all async handlers with consistent `{ message }` error shape
- Stream Chat null-guard (`getStreamServer()`) across all code paths
- BullMQ skip in in-memory mode (no Redis required for local dev)
- Firebase init guard for missing credentials

### Local Development
- Backend starts with `USE_INMEMORY_DB=true` without Firebase/Redis/Cognito
- Auth bypass gated on `NODE_ENV === "development"` (not just in-memory flag)

## Test plan
- [x] Backend starts clean with in-memory MongoDB
- [x] All CRUD endpoints work (create, list, get, update status/priority/assign)
- [x] Dashboard stats return correct aggregations
- [x] TypeScript compiles with zero errors in modified files
- [x] ESLint passes with zero warnings
- [x] Priority not accepted from public create endpoint (admin-only)

Replaces #1417 (closed due to branch recreation)
