### PR TITLE
feat(ci): adding  workflow to get user overview

### DIFF
--- a/.github/workflows/repo-stats.yml
+++ b/.github/workflows/repo-stats.yml
@@ -70,14 +70,14 @@ jobs:
           text = "\n".join(parser.chunks)
 
           def extract_cumulative(label: str) -> int | None:
-            match = re.search(rf"{label}\\s*Cumulative:\\s*([0-9,]+)", text, re.IGNORECASE)
+            match = re.search(rf"{label}\s*Cumulative:\s*([0-9,]+)", text, re.IGNORECASE)
             if not match:
               return None
             return int(match.group(1).replace(",", ""))
 
           def extract_top(section_label: str, next_label: str) -> list[str]:
             match = re.search(
-              rf"{section_label}:\\s*(.*?)\\s*{next_label}:",
+              rf"{section_label}:\s*(.*?)\s*{next_label}:",
               text,
               re.IGNORECASE | re.DOTALL,
             )
@@ -86,7 +86,7 @@ jobs:
             block = match.group(1)
             items: list[str] = []
             for part in block.split(","):
-              item = re.sub(r"^\\d+\\s*:\\s*", "", part.strip())
+              item = re.sub(r"^\d+\s*:\s*", "", part.strip())
               item = item.strip("` ")
               if item:
                 items.append(item)
@@ -95,7 +95,7 @@ jobs:
           def extract_top_until(section_label: str, stop_labels: list[str]) -> list[str]:
             stop_group = "|".join(map(re.escape, stop_labels))
             match = re.search(
-              rf"{section_label}:\\s*(.*?)(?:\\s*(?:{stop_group}))",
+              rf"{section_label}:\s*(.*?)(?:\s*(?:{stop_group}))",
               text,
               re.IGNORECASE | re.DOTALL,
             )
@@ -104,14 +104,14 @@ jobs:
             block = match.group(1)
             items: list[str] = []
             for part in block.split(","):
-              item = re.sub(r"^\\d+\\s*:\\s*", "", part.strip())
+              item = re.sub(r"^\d+\s*:\s*", "", part.strip())
               item = item.strip("` ")
               if item:
                 items.append(item)
             return items
 
           generated_at = None
-          generated_match = re.search(r"Generated .* at ([0-9:\\- ]+UTC)", text)
+          generated_match = re.search(r"Generated .* at ([0-9:\- ]+UTC)", text)
           if generated_match:
             generated_at = generated_match.group(1).strip()
 

--- a/.github/workflows/sonar-cloud-analysis.yml
+++ b/.github/workflows/sonar-cloud-analysis.yml
@@ -15,10 +15,57 @@ concurrency:
 permissions: read-all
 
 jobs:
+  changes:
+    name: Detect workspace changes
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'YosemiteCrew'
+    outputs:
+      frontend: ${{ steps.filter.outputs.frontend }}
+      backend: ${{ steps.filter.outputs.backend }}
+      mobile: ${{ steps.filter.outputs.mobile }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Filter paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            frontend:
+              - 'apps/frontend/**'
+              - 'packages/types/**'
+              - 'packages/fhirtypes/**'
+              - 'pnpm-lock.yaml'
+              - 'package.json'
+              - 'turbo.json'
+            backend:
+              - 'apps/backend/**'
+              - 'packages/types/**'
+              - 'packages/fhirtypes/**'
+              - 'pnpm-lock.yaml'
+              - 'package.json'
+              - 'turbo.json'
+            mobile:
+              - 'apps/mobileAppYC/**'
+              - 'packages/types/**'
+              - 'packages/fhirtypes/**'
+              - 'pnpm-lock.yaml'
+              - 'package.json'
+              - 'turbo.json'
+
   sonarqube:
-    if: github.repository_owner == 'YosemiteCrew' # Ensure the workflow runs only in the main repository
+    if: >
+      github.repository_owner == 'YosemiteCrew' &&
+      (
+        github.event_name == 'schedule' ||
+        (matrix.app == 'frontend' && needs.changes.outputs.frontend == 'true') ||
+        (matrix.app == 'backend' && needs.changes.outputs.backend == 'true') ||
+        (matrix.app == 'mobile' && needs.changes.outputs.mobile == 'true')
+      )
     name: SonarQube Analysis - ${{ matrix.app }}
     runs-on: ubuntu-latest
+    needs: changes
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
<!--
We, the rest of the Yosemite community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## Descritpion
- This PR adds github actions workflow `jgehrcke/github-repo-stats@v1` to generate the user overview data to get idea about the activities on the repo like clones, forks, stars etc.
- This data will be added to the `github-repo-stat` branch and from then we can pull them into our UI to show the user interactions inside our `user overview` section of the website.


