### PR TITLE
fix(frontend): forward ResponsiveContainer sizes to recharts

### DIFF
--- a/apps/frontend/src/app/(routes)/(public)/insights/page.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/insights/page.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import OverviewPage from '@/app/features/overview/pages/OverviewPage';
+
+export const metadata = {
+  title: 'Insights | Yosemite Crew',
+  description: 'Project health, code quality, and community statistics for Yosemite Crew.',
+};
+
+export default function Page() {
+  return <OverviewPage />;
+}

--- a/apps/frontend/src/app/(routes)/(public)/overview/page.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/overview/page.tsx
@@ -1,11 +1,5 @@
-import React from 'react';
-import OverviewPage from '@/app/features/overview/pages/OverviewPage';
-
-export const metadata = {
-  title: 'Overview | Yosemite Crew',
-  description: 'Project health, code quality, and community statistics for Yosemite Crew.',
-};
+import { redirect } from 'next/navigation';
 
 export default function Page() {
-  return <OverviewPage />;
+  redirect('/insights');
 }

--- a/apps/frontend/src/app/ui/widgets/DynamicChart/DynamicChartCard.tsx
+++ b/apps/frontend/src/app/ui/widgets/DynamicChart/DynamicChartCard.tsx
@@ -11,7 +11,7 @@ import {
   Tooltip,
   CartesianGrid,
 } from 'recharts';
-import { LayoutType } from 'recharts/types/util/types';
+import type { LayoutType } from 'recharts/types/util/types';
 
 type ChartProps = {
   data: any[];
@@ -58,6 +58,8 @@ const getYAxisLabel = (
 
 type LineChartContentProps = {
   data: any[];
+  width?: number;
+  height?: number;
   chartMargin: { top: number; right: number; left: number; bottom: number };
   keys: ChartKey[];
   yTickFormatter?: (value: number) => string;
@@ -67,13 +69,15 @@ type LineChartContentProps = {
 
 const LineChartContent = ({
   data,
+  width,
+  height,
   chartMargin,
   keys,
   yTickFormatter,
   xAxisLabel,
   yAxisLabel,
 }: LineChartContentProps) => (
-  <LineChart data={data} margin={chartMargin}>
+  <LineChart data={data} margin={chartMargin} width={width} height={height}>
     <XAxis dataKey="month" label={getXAxisLabel(xAxisLabel)} />
     <YAxis
       tickFormatter={yTickFormatter}
@@ -99,6 +103,8 @@ const LineChartContent = ({
 
 type BarChartContentProps = {
   data: any[];
+  width?: number;
+  height?: number;
   layout?: LayoutType;
   isVerticalLayout: boolean;
   chartMargin: { top: number; right: number; left: number; bottom: number };
@@ -112,6 +118,8 @@ type BarChartContentProps = {
 
 const BarChartContent = ({
   data,
+  width,
+  height,
   layout,
   isVerticalLayout,
   chartMargin,
@@ -127,6 +135,8 @@ const BarChartContent = ({
     layout={layout}
     style={{ height: '100%', maxHeight: '100%', width: '100%', maxWidth: '100%' }}
     margin={chartMargin}
+    width={width}
+    height={height}
   >
     <CartesianGrid strokeDasharray="4 4" vertical={false} />
     <XAxis

--- a/apps/frontend/src/app/ui/widgets/Footer/Footer.tsx
+++ b/apps/frontend/src/app/ui/widgets/Footer/Footer.tsx
@@ -30,7 +30,7 @@ const footerLinks = [
         label: 'GitHub',
         href: 'https://github.com/YosemiteCrew/Yosemite-Crew',
       },
-      { label: 'Insights', href: '/overview' },
+      { label: 'Insights', href: '/insights' },
     ],
   },
   {


### PR DESCRIPTION
<!--
We, the rest of the Yosemite community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## Description
- Fixes empty charts on `overview` section and `/insights` url for the insights page.


