### PR TITLE
feat(repo): add geolocation-aware pricing with cookie consent gate

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -20,11 +20,11 @@
     "parity:check": "tsx src/scripts/parity-check.ts"
   },
   "dependencies": {
-    "@prisma/client": "^5.22.0",
     "@aws-sdk/client-cognito-identity-provider": "3.772.0",
     "@aws-sdk/client-pinpoint": "^3.806.0",
     "@aws-sdk/client-s3": "^3.842.0",
     "@aws-sdk/client-ses": "^3.839.0",
+    "@prisma/client": "^5.22.0",
     "aws-sdk": "2.1692.0",
     "axios": "^1.13.2",
     "bcrypt": "5.1.1",
@@ -44,6 +44,7 @@
     "express-rate-limit": "^7.5.0",
     "fhir": "4.12.0",
     "firebase-admin": "^13.6.0",
+    "geoip-country": "^5.0.202604072353",
     "google-auth-library": "^10.2.0",
     "jsonwebtoken": "9.0.2",
     "jwks-rsa": "^3.2.0",
@@ -73,6 +74,7 @@
     "@types/express": "^5.0.2",
     "@types/express-fileupload": "^1.5.1",
     "@types/express-rate-limit": "^6.0.2",
+    "@types/geoip-country": "^5.0.0",
     "@types/jest": "^29.5.12",
     "@types/jsonwebtoken": "^9.0.9",
     "@types/mongoose": "^5.11.97",

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -55,7 +55,11 @@ export function createApp() {
         },
         credentials: true,
         methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
-        allowedHeaders: ["Content-Type", "Authorization"],
+        allowedHeaders: [
+          "Content-Type",
+          "Authorization",
+          "X-Preferred-Currency",
+        ],
       }),
     );
   }

--- a/apps/backend/src/constants/pricing.constants.ts
+++ b/apps/backend/src/constants/pricing.constants.ts
@@ -1,0 +1,215 @@
+/**
+ * Pricing constants — single source of truth for public plan pricing.
+ *
+ * All prices are stored as integer units of the display currency (not the
+ * smallest sub-unit) to match the existing hardcoded `€10`, `$12`, `£10`
+ * style on the marketing site. Actual Stripe billing uses its own `Price`
+ * objects and is untouched by this module.
+ */
+
+export const SUPPORTED_CURRENCIES = new Set(["USD", "GBP", "EUR"] as const);
+export type SupportedCurrency = "USD" | "GBP" | "EUR";
+
+export const DEFAULT_CURRENCY: SupportedCurrency = "USD";
+
+export const CURRENCY_SYMBOLS: Record<SupportedCurrency, string> = {
+  USD: "$",
+  GBP: "£",
+  EUR: "€",
+};
+
+/**
+ * ISO-3166 alpha-2 country code → preferred display currency.
+ *
+ * Only countries that unambiguously map to USD / GBP / EUR are listed.
+ * Anything not in the map defaults to `DEFAULT_CURRENCY` (USD).
+ */
+export const COUNTRY_TO_CURRENCY: Readonly<Record<string, SupportedCurrency>> =
+  Object.freeze({
+    // United States + US territories
+    US: "USD",
+    UM: "USD",
+    PR: "USD",
+    GU: "USD",
+    AS: "USD",
+    VI: "USD",
+    MP: "USD",
+
+    // United Kingdom + Crown Dependencies
+    GB: "GBP",
+    IM: "GBP",
+    JE: "GBP",
+    GG: "GBP",
+
+    // Eurozone members
+    AT: "EUR",
+    BE: "EUR",
+    CY: "EUR",
+    DE: "EUR",
+    EE: "EUR",
+    ES: "EUR",
+    FI: "EUR",
+    FR: "EUR",
+    GR: "EUR",
+    HR: "EUR",
+    IE: "EUR",
+    IT: "EUR",
+    LT: "EUR",
+    LU: "EUR",
+    LV: "EUR",
+    MT: "EUR",
+    NL: "EUR",
+    PT: "EUR",
+    SI: "EUR",
+    SK: "EUR",
+    // Microstates + unilateral euro users
+    AD: "EUR",
+    MC: "EUR",
+    SM: "EUR",
+    VA: "EUR",
+    ME: "EUR",
+    XK: "EUR",
+  });
+
+export type PlanId = "free" | "business" | "enterprise";
+
+export interface PlanDTO {
+  id: PlanId;
+  active: boolean;
+  recommended: boolean;
+  title: string;
+  /** Numeric per-interval amount. `null` for "Coming soon" plans. */
+  amount: number | null;
+  amountYearly: number | null;
+  amountLabel: string;
+  description: string;
+  buttonText: string;
+  buttonSrc: string;
+  includes: string[];
+}
+
+const COMMON_FEATURES = {
+  SCHEDULER: "Yosemite Crew scheduler",
+  TEMPLATES: "Templates module",
+  DOC_SIGNING: "Document e-signing portal",
+  IDEX_INTEGRATION: "IDEXX integration for lab tests and diagnostics",
+  MERCK_INTEGRATION:
+    "MSD Veterinary Manual integration for veterinary clinical knowledge",
+  CHAT: "Internal + companion parent chat",
+  SECURITY: "Security & compliance integrations (SOC2, ISO 27001, GDPR)",
+} as const;
+
+const FREE_INCLUDES: string[] = [
+  "Free for individual usage",
+  "120 appointments",
+  "200 observational tools",
+  COMMON_FEATURES.SCHEDULER,
+  COMMON_FEATURES.TEMPLATES,
+  COMMON_FEATURES.DOC_SIGNING,
+  COMMON_FEATURES.IDEX_INTEGRATION,
+  COMMON_FEATURES.MERCK_INTEGRATION,
+  COMMON_FEATURES.CHAT,
+  COMMON_FEATURES.SECURITY,
+];
+
+const BUSINESS_INCLUDES: string[] = [
+  "Unlimited appointments",
+  "Unlimited observational tools",
+  COMMON_FEATURES.SCHEDULER,
+  COMMON_FEATURES.TEMPLATES,
+  COMMON_FEATURES.DOC_SIGNING,
+  COMMON_FEATURES.IDEX_INTEGRATION,
+  COMMON_FEATURES.MERCK_INTEGRATION,
+  COMMON_FEATURES.CHAT,
+  COMMON_FEATURES.SECURITY,
+];
+
+const ENTERPRISE_INCLUDES: string[] = [
+  "Unlimited usage",
+  "Unlimited appointments",
+  "Unlimited observational tools",
+  COMMON_FEATURES.SCHEDULER,
+  COMMON_FEATURES.TEMPLATES,
+  COMMON_FEATURES.DOC_SIGNING,
+  COMMON_FEATURES.IDEX_INTEGRATION,
+  COMMON_FEATURES.MERCK_INTEGRATION,
+  COMMON_FEATURES.CHAT,
+  COMMON_FEATURES.SECURITY,
+];
+
+type PlanPriceTable = Record<
+  PlanId,
+  { amount: number | null; amountYearly: number | null }
+>;
+
+const PRICE_TABLE: Record<SupportedCurrency, PlanPriceTable> = {
+  USD: {
+    free: { amount: 0, amountYearly: 0 },
+    business: { amount: 13, amountYearly: 11 },
+    enterprise: { amount: null, amountYearly: null },
+  },
+  GBP: {
+    free: { amount: 0, amountYearly: 0 },
+    business: { amount: 10, amountYearly: 8 },
+    enterprise: { amount: null, amountYearly: null },
+  },
+  EUR: {
+    free: { amount: 0, amountYearly: 0 },
+    business: { amount: 12, amountYearly: 10 },
+    enterprise: { amount: null, amountYearly: null },
+  },
+};
+
+const buildPlansForCurrency = (currency: SupportedCurrency): PlanDTO[] => {
+  const prices = PRICE_TABLE[currency];
+  return [
+    {
+      id: "free",
+      active: true,
+      recommended: false,
+      title: "Free plan",
+      amount: prices.free.amount,
+      amountYearly: prices.free.amountYearly,
+      amountLabel: "",
+      description:
+        "Perfect for new or small pet businesses exploring on their own.",
+      buttonText: "Get started",
+      buttonSrc: "/signup",
+      includes: FREE_INCLUDES,
+    },
+    {
+      id: "business",
+      active: true,
+      recommended: true,
+      title: "Business plan",
+      amount: prices.business.amount,
+      amountYearly: prices.business.amountYearly,
+      amountLabel: "per user / month",
+      description:
+        "Flexible growth for pet businesses that need to scale on demand.",
+      buttonText: "Get started",
+      buttonSrc: "/signup",
+      includes: BUSINESS_INCLUDES,
+    },
+    {
+      id: "enterprise",
+      active: false,
+      recommended: false,
+      title: "Enterprise plan",
+      amount: prices.enterprise.amount,
+      amountYearly: prices.enterprise.amountYearly,
+      amountLabel: "",
+      description:
+        "For pet businesses to operate with scalability, control, and security.",
+      buttonText: "Notify me",
+      buttonSrc: "#",
+      includes: ENTERPRISE_INCLUDES,
+    },
+  ];
+};
+
+export const PRICING_PLANS: Record<SupportedCurrency, PlanDTO[]> = {
+  USD: buildPlansForCurrency("USD"),
+  GBP: buildPlansForCurrency("GBP"),
+  EUR: buildPlansForCurrency("EUR"),
+};

--- a/apps/backend/src/controllers/web/pricing.controller.ts
+++ b/apps/backend/src/controllers/web/pricing.controller.ts
@@ -1,0 +1,34 @@
+import { Request, Response } from "express";
+
+import { getPricingResponse } from "src/services/pricing.service";
+import logger from "src/utils/logger";
+
+export const PricingController = {
+  /**
+   * Public endpoint — no authentication. Returns the three plan cards
+   * priced in the visitor's currency.
+   *
+   * Currency resolution order (see pricing.service.ts):
+   *   1. Validated `X-Preferred-Currency` header (allowlist: USD, GBP, EUR)
+   *   2. IP-based country lookup via `geoip-country`
+   *   3. Default USD
+   *
+   * Response is cache-friendly: `Cache-Control: public, max-age=300` with
+   * `Vary: X-Preferred-Currency` so CDN caches do not mix currencies.
+   */
+  getPricing: (req: Request, res: Response) => {
+    try {
+      const override = res.locals.overrideCurrency as unknown;
+      const response = getPricingResponse(req, override);
+
+      res.setHeader("Cache-Control", "public, max-age=300");
+      res.setHeader("Vary", "X-Preferred-Currency");
+      return res.status(200).json(response);
+    } catch (err) {
+      logger.error("Error getPricing:", err);
+      return res.status(500).json({
+        error: err instanceof Error ? err.message : "Unknown error",
+      });
+    }
+  },
+};

--- a/apps/backend/src/controllers/web/pricing.controller.ts
+++ b/apps/backend/src/controllers/web/pricing.controller.ts
@@ -22,12 +22,12 @@ export const PricingController = {
       const response = getPricingResponse(req, override);
 
       res.setHeader("Cache-Control", "public, max-age=300");
-      res.setHeader("Vary", "X-Preferred-Currency");
+      res.append("Vary", "X-Preferred-Currency");
       return res.status(200).json(response);
     } catch (err) {
       logger.error("Error getPricing:", err);
       return res.status(500).json({
-        error: err instanceof Error ? err.message : "Unknown error",
+        message: "Failed to load pricing.",
       });
     }
   },

--- a/apps/backend/src/controllers/web/pricing.controller.ts
+++ b/apps/backend/src/controllers/web/pricing.controller.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 
 import {
-  getPricingResponse,
+  buildPricingResponse,
   resolveCurrency,
 } from "src/services/pricing.service";
 import logger from "src/utils/logger";
@@ -25,8 +25,8 @@ export const PricingController = {
   getPricing: (req: Request, res: Response) => {
     try {
       const override = res.locals.overrideCurrency as unknown;
-      const { source } = resolveCurrency(req, override);
-      const response = getPricingResponse(req, override);
+      const { currency, source } = resolveCurrency(req, override);
+      const response = buildPricingResponse(currency);
 
       if (source === "ip") {
         res.setHeader("Cache-Control", "private, no-store");

--- a/apps/backend/src/controllers/web/pricing.controller.ts
+++ b/apps/backend/src/controllers/web/pricing.controller.ts
@@ -1,6 +1,9 @@
 import { Request, Response } from "express";
 
-import { getPricingResponse } from "src/services/pricing.service";
+import {
+  getPricingResponse,
+  resolveCurrency,
+} from "src/services/pricing.service";
 import logger from "src/utils/logger";
 
 export const PricingController = {
@@ -13,19 +16,31 @@ export const PricingController = {
    *   2. IP-based country lookup via `geoip-country`
    *   3. Default USD
    *
-   * Response is cache-friendly: `Cache-Control: public, max-age=300` with
-   * `Vary: X-Preferred-Currency` so CDN caches do not mix currencies.
+   * Cache strategy:
+   *   - Override/default: `public, max-age=300` — safe to CDN-cache keyed
+   *     on the `Vary: X-Preferred-Currency` header.
+   *   - IP-based: `private, no-store` — response varies by client IP which
+   *     CDNs cannot key on, so it must not be cached.
    */
   getPricing: (req: Request, res: Response) => {
     try {
       const override = res.locals.overrideCurrency as unknown;
+      const { source } = resolveCurrency(req, override);
       const response = getPricingResponse(req, override);
 
-      res.setHeader("Cache-Control", "public, max-age=300");
+      if (source === "ip") {
+        res.setHeader("Cache-Control", "private, no-store");
+      } else {
+        res.setHeader("Cache-Control", "public, max-age=300");
+      }
       res.append("Vary", "X-Preferred-Currency");
       return res.status(200).json(response);
     } catch (err) {
-      logger.error("Error getPricing:", err);
+      const error = err instanceof Error ? err : new Error(String(err));
+      logger.error("Error getPricing:", {
+        message: error.message,
+        stack: error.stack,
+      });
       return res.status(500).json({
         message: "Failed to load pricing.",
       });

--- a/apps/backend/src/middlewares/validateCurrencyHeader.ts
+++ b/apps/backend/src/middlewares/validateCurrencyHeader.ts
@@ -28,14 +28,14 @@ export const validateCurrencyHeader = (
 ): void => {
   const raw = req.headers[HEADER_NAME];
 
-  if (typeof raw === "string") {
+  if (typeof raw === "string" && raw.length <= 5) {
     const candidate = raw.trim().toUpperCase();
     if (SUPPORTED_CURRENCIES.has(candidate as SupportedCurrency)) {
       res.locals.overrideCurrency = candidate as SupportedCurrency;
     } else if (candidate.length > 0) {
-      logger.debug(
-        `validateCurrencyHeader: ignoring invalid X-Preferred-Currency='${candidate}'`,
-      );
+      logger.debug("validateCurrencyHeader: ignoring invalid header", {
+        header: candidate.replace(/[^\x20-\x7E]/g, ""),
+      });
     }
   }
 

--- a/apps/backend/src/middlewares/validateCurrencyHeader.ts
+++ b/apps/backend/src/middlewares/validateCurrencyHeader.ts
@@ -1,0 +1,43 @@
+import { NextFunction, Request, Response } from "express";
+
+import {
+  SUPPORTED_CURRENCIES,
+  type SupportedCurrency,
+} from "src/constants/pricing.constants";
+import logger from "src/utils/logger";
+
+const HEADER_NAME = "x-preferred-currency";
+
+/**
+ * Reads `X-Preferred-Currency` from the request, validates it against the
+ * allowlist, and stashes the canonical uppercase value on
+ * `res.locals.overrideCurrency` for downstream handlers.
+ *
+ * Defense-in-depth:
+ *   - Only accepts strings (ignores arrays of headers)
+ *   - Case-insensitive input, always normalised to uppercase before storing
+ *   - Exact `Set.has()` membership check — no regex, no coercion, no DB
+ *   - Invalid values are silently dropped (no 400) so the request still
+ *     falls through to the IP-based detection path.
+ *   - Never throws.
+ */
+export const validateCurrencyHeader = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void => {
+  const raw = req.headers[HEADER_NAME];
+
+  if (typeof raw === "string") {
+    const candidate = raw.trim().toUpperCase();
+    if (SUPPORTED_CURRENCIES.has(candidate as SupportedCurrency)) {
+      res.locals.overrideCurrency = candidate as SupportedCurrency;
+    } else if (candidate.length > 0) {
+      logger.debug(
+        `validateCurrencyHeader: ignoring invalid X-Preferred-Currency='${candidate}'`,
+      );
+    }
+  }
+
+  next();
+};

--- a/apps/backend/src/middlewares/validateCurrencyHeader.ts
+++ b/apps/backend/src/middlewares/validateCurrencyHeader.ts
@@ -28,13 +28,21 @@ export const validateCurrencyHeader = (
 ): void => {
   const raw = req.headers[HEADER_NAME];
 
-  if (typeof raw === "string" && raw.length <= 5) {
+  if (typeof raw === "string" && raw.length <= 16) {
     const candidate = raw.trim().toUpperCase();
+    if (candidate.length !== 3) {
+      if (candidate.length > 0) {
+        logger.debug("validateCurrencyHeader: ignoring invalid header", {
+          header: candidate.slice(0, 10).replace(/[^\x20-\x7E]/g, ""),
+        });
+      }
+      return next();
+    }
     if (SUPPORTED_CURRENCIES.has(candidate as SupportedCurrency)) {
       res.locals.overrideCurrency = candidate as SupportedCurrency;
-    } else if (candidate.length > 0) {
+    } else {
       logger.debug("validateCurrencyHeader: ignoring invalid header", {
-        header: candidate.replace(/[^\x20-\x7E]/g, ""),
+        header: candidate,
       });
     }
   }

--- a/apps/backend/src/routers/index.ts
+++ b/apps/backend/src/routers/index.ts
@@ -41,6 +41,7 @@ import codeRouter from "./code.router";
 import labOrderRouter from "./lab-order.router";
 import labResultRouter from "./lab-result.router";
 import companionHistoryRouter from "./companion-history.router";
+import pricingRouter from "./pricing.router";
 
 export function registerRoutes(app: Express) {
   app.use(`/fhir/v1/organization`, organizationRounter);
@@ -85,4 +86,5 @@ export function registerRoutes(app: Express) {
   app.use(`/v1/codes`, codeRouter);
   app.use(`/v1/labs`, labOrderRouter);
   app.use(`/v1/labs`, labResultRouter);
+  app.use(`/v1/pricing`, pricingRouter);
 }

--- a/apps/backend/src/routers/pricing.router.ts
+++ b/apps/backend/src/routers/pricing.router.ts
@@ -1,0 +1,30 @@
+import { Router } from "express";
+import rateLimit from "express-rate-limit";
+
+import { PricingController } from "src/controllers/web/pricing.controller";
+import { validateCurrencyHeader } from "src/middlewares/validateCurrencyHeader";
+
+const router = Router();
+
+/**
+ * Dedicated per-IP limiter for the public pricing endpoint. 30 requests per
+ * minute is more than enough for any legitimate visitor (the pricing page
+ * makes one call per currency change) and protects against scraping and
+ * abuse on top of the global 500/15min limiter in `app.ts`.
+ */
+const pricingRateLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: "Too many requests, please try again later." },
+});
+
+router.get(
+  "/",
+  pricingRateLimiter,
+  validateCurrencyHeader,
+  PricingController.getPricing,
+);
+
+export default router;

--- a/apps/backend/src/services/geo.service.ts
+++ b/apps/backend/src/services/geo.service.ts
@@ -1,0 +1,50 @@
+import geoip from "geoip-country";
+
+import {
+  COUNTRY_TO_CURRENCY,
+  DEFAULT_CURRENCY,
+  type SupportedCurrency,
+} from "src/constants/pricing.constants";
+
+/**
+ * Returns the ISO-3166 alpha-2 country code for a given IP address, or `null`
+ * for private / loopback / unknown ranges. Pure wrapper around `geoip-country`.
+ */
+export const getCountryFromIp = (
+  ip: string | undefined | null,
+): string | null => {
+  if (typeof ip !== "string" || ip.length === 0) return null;
+
+  // Express may prefix IPv4 addresses with `::ffff:` when running over IPv6.
+  const normalised = ip.startsWith("::ffff:") ? ip.slice(7) : ip;
+
+  // Loopback and IPv6 link-local shortcuts — skip the DB lookup entirely.
+  if (
+    normalised === "::1" ||
+    normalised === "127.0.0.1" ||
+    normalised === "0.0.0.0" ||
+    normalised.startsWith("fe80:")
+  ) {
+    return null;
+  }
+
+  try {
+    const result = geoip.lookup(normalised);
+    return result?.country ?? null;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Maps a country code (or `null`) to one of our supported currencies. Any
+ * country outside the USD / GBP / EUR map — including `null` — resolves to
+ * the default currency (USD).
+ */
+export const resolveCurrencyFromCountry = (
+  country: string | null,
+): SupportedCurrency => {
+  if (country === null) return DEFAULT_CURRENCY;
+  const upper = country.toUpperCase();
+  return COUNTRY_TO_CURRENCY[upper] ?? DEFAULT_CURRENCY;
+};

--- a/apps/backend/src/services/pricing.service.ts
+++ b/apps/backend/src/services/pricing.service.ts
@@ -1,0 +1,64 @@
+import type { Request } from "express";
+
+import {
+  CURRENCY_SYMBOLS,
+  DEFAULT_CURRENCY,
+  PRICING_PLANS,
+  SUPPORTED_CURRENCIES,
+  type PlanDTO,
+  type SupportedCurrency,
+} from "src/constants/pricing.constants";
+import {
+  getCountryFromIp,
+  resolveCurrencyFromCountry,
+} from "src/services/geo.service";
+
+export type CurrencySource = "override" | "ip" | "default";
+
+export interface PricingResponse {
+  currency: SupportedCurrency;
+  currencySymbol: string;
+  source: CurrencySource;
+  plans: PlanDTO[];
+}
+
+const isSupportedCurrency = (value: unknown): value is SupportedCurrency =>
+  typeof value === "string" &&
+  SUPPORTED_CURRENCIES.has(value as SupportedCurrency);
+
+/**
+ * Priority:
+ *   1. Validated override from `res.locals.overrideCurrency` (set by
+ *      `validateCurrencyHeader` middleware). Already allowlist-checked.
+ *   2. IP-based country → currency lookup.
+ *   3. `DEFAULT_CURRENCY` (USD).
+ */
+export const resolveCurrency = (
+  req: Request,
+  override: unknown,
+): { currency: SupportedCurrency; source: CurrencySource } => {
+  if (isSupportedCurrency(override)) {
+    return { currency: override, source: "override" };
+  }
+
+  const country = getCountryFromIp(req.ip);
+  if (country !== null) {
+    const mapped = resolveCurrencyFromCountry(country);
+    return { currency: mapped, source: "ip" };
+  }
+
+  return { currency: DEFAULT_CURRENCY, source: "default" };
+};
+
+export const getPricingResponse = (
+  req: Request,
+  override: unknown,
+): PricingResponse => {
+  const { currency, source } = resolveCurrency(req, override);
+  return {
+    currency,
+    currencySymbol: CURRENCY_SYMBOLS[currency],
+    source,
+    plans: PRICING_PLANS[currency],
+  };
+};

--- a/apps/backend/src/services/pricing.service.ts
+++ b/apps/backend/src/services/pricing.service.ts
@@ -49,14 +49,10 @@ export const resolveCurrency = (
   return { currency: DEFAULT_CURRENCY, source: "default" };
 };
 
-export const getPricingResponse = (
-  req: Request,
-  override: unknown,
-): PricingResponse => {
-  const { currency } = resolveCurrency(req, override);
-  return {
-    currency,
-    currencySymbol: CURRENCY_SYMBOLS[currency],
-    plans: PRICING_PLANS[currency],
-  };
-};
+export const buildPricingResponse = (
+  currency: SupportedCurrency,
+): PricingResponse => ({
+  currency,
+  currencySymbol: CURRENCY_SYMBOLS[currency],
+  plans: PRICING_PLANS[currency],
+});

--- a/apps/backend/src/services/pricing.service.ts
+++ b/apps/backend/src/services/pricing.service.ts
@@ -18,7 +18,6 @@ export type CurrencySource = "override" | "ip" | "default";
 export interface PricingResponse {
   currency: SupportedCurrency;
   currencySymbol: string;
-  source: CurrencySource;
   plans: PlanDTO[];
 }
 
@@ -54,11 +53,10 @@ export const getPricingResponse = (
   req: Request,
   override: unknown,
 ): PricingResponse => {
-  const { currency, source } = resolveCurrency(req, override);
+  const { currency } = resolveCurrency(req, override);
   return {
     currency,
     currencySymbol: CURRENCY_SYMBOLS[currency],
-    source,
     plans: PRICING_PLANS[currency],
   };
 };

--- a/apps/frontend/src/app/features/marketing/pages/PricingPage/CurrencySwitcher.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/PricingPage/CurrencySwitcher.tsx
@@ -1,0 +1,49 @@
+'use client';
+import React from 'react';
+
+import { useCurrencyStore } from '@/app/stores/currencyStore';
+import type { SupportedCurrency } from './types';
+
+const OPTIONS: Array<{ code: SupportedCurrency; label: string }> = [
+  { code: 'USD', label: 'USD' },
+  { code: 'GBP', label: 'GBP' },
+  { code: 'EUR', label: 'EUR' },
+];
+
+type Props = {
+  /** The currency currently in use (from the backend response). */
+  currency: SupportedCurrency;
+};
+
+const CurrencySwitcher = ({ currency }: Props) => {
+  const setPreferred = useCurrencyStore((s) => s.setPreferred);
+
+  return (
+    <div
+      role="group"
+      aria-label="Display currency"
+      className="inline-flex items-center gap-1 rounded-2xl border border-grey-light p-1"
+    >
+      {OPTIONS.map((opt) => {
+        const isActive = opt.code === currency;
+        return (
+          <button
+            key={opt.code}
+            type="button"
+            aria-pressed={isActive}
+            onClick={() => setPreferred(opt.code)}
+            className={`${
+              isActive
+                ? 'bg-blue-light text-blue-text shadow-[0_0_4px_0_rgba(0,0,0,0.12)]'
+                : 'text-grey-noti hover:text-black-text'
+            } font-satoshi text-[13px] font-semibold px-3 h-7 rounded-xl transition-colors cursor-pointer`}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export default CurrencySwitcher;

--- a/apps/frontend/src/app/features/marketing/pages/PricingPage/PricingPage.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/PricingPage/PricingPage.tsx
@@ -11,6 +11,7 @@ import { FALLBACK_PLANS, TableData } from '@/app/features/marketing/pages/Pricin
 import { Primary } from '@/app/ui/primitives/Buttons';
 import { MEDIA_SOURCES } from '@/app/constants/mediaSources';
 import { usePricing } from '@/app/hooks/usePricing';
+import { useCurrencyStore } from '@/app/stores/currencyStore';
 import CurrencySwitcher from '@/app/features/marketing/pages/PricingPage/CurrencySwitcher';
 import PricingSkeleton from '@/app/features/marketing/pages/PricingPage/PricingSkeleton';
 import type { PlanDTO, SupportedCurrency } from '@/app/features/marketing/pages/PricingPage/types';
@@ -28,7 +29,11 @@ const CURRENCY_SYMBOLS: Record<SupportedCurrency, string> = {
 const safeCurrencySymbol = (currency: SupportedCurrency): string =>
   CURRENCY_SYMBOLS[currency] ?? '$';
 
-const safeHref = (src: string): string => (/^[/#]/.test(src) ? src : '/signup');
+const safeHref = (src: string): string => {
+  if (src.startsWith('#')) return src;
+  if (src.startsWith('/') && !src.startsWith('//')) return src;
+  return '/signup';
+};
 
 const formatPrice = (amount: number | null, symbol: string, fallback: string): string => {
   if (amount === null) return fallback;
@@ -100,9 +105,10 @@ const PricingPage = () => {
   const [activeCycle, setActiveCycle] = useState<BillingCycle>('yearly');
   const [notify, setNotify] = useState(false);
   const { data: pricing, loading } = usePricing();
+  const preferred = useCurrencyStore((s) => s.preferred);
 
   const plans: PlanDTO[] = pricing?.plans ?? FALLBACK_PLANS;
-  const currency: SupportedCurrency = pricing?.currency ?? 'USD';
+  const currency: SupportedCurrency = preferred ?? pricing?.currency ?? 'USD';
   const currencySymbol: string = safeCurrencySymbol(currency);
   const showSkeleton = loading && !pricing;
   const [formData, setFormData] = useState({

--- a/apps/frontend/src/app/features/marketing/pages/PricingPage/PricingPage.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/PricingPage/PricingPage.tsx
@@ -19,6 +19,17 @@ import './PricingPage.css';
 
 type BillingCycle = 'monthly' | 'yearly';
 
+const CURRENCY_SYMBOLS: Record<SupportedCurrency, string> = {
+  USD: '$',
+  GBP: '£',
+  EUR: '€',
+};
+
+const safeCurrencySymbol = (currency: SupportedCurrency): string =>
+  CURRENCY_SYMBOLS[currency] ?? '$';
+
+const safeHref = (src: string): string => (/^[/#]/.test(src) ? src : '/signup');
+
 const formatPrice = (amount: number | null, symbol: string, fallback: string): string => {
   if (amount === null) return fallback;
   return `${symbol}${amount}`;
@@ -92,7 +103,7 @@ const PricingPage = () => {
 
   const plans: PlanDTO[] = pricing?.plans ?? FALLBACK_PLANS;
   const currency: SupportedCurrency = pricing?.currency ?? 'USD';
-  const currencySymbol: string = pricing?.currencySymbol ?? '$';
+  const currencySymbol: string = safeCurrencySymbol(currency);
   const showSkeleton = loading && !pricing;
   const [formData, setFormData] = useState({
     firstName: '',
@@ -210,7 +221,7 @@ const PricingPage = () => {
                       </div>
                       <Link
                         className="w-full rounded-2xl! hover:border-text-brand! hover:text-text-brand! hover:scale-105! transition duration-200 ease-in-out text-black-text! border-black-text! border! h-12 flex items-center justify-center font-satoshi text-[1.125rem] font-medium"
-                        href={plan.buttonSrc}
+                        href={safeHref(plan.buttonSrc)}
                         onClick={() => plan.id === 'enterprise' && setNotify(true)}
                       >
                         {plan.buttonText}
@@ -302,7 +313,7 @@ const PricingPage = () => {
                   </div>
                   <Link
                     className="w-full rounded-2xl! hover:border-text-brand! hover:text-text-brand! hover:scale-105! text-black-text! border-black-text! border! transition duration-300 ease-in-out h-8 md:h-12 flex items-center justify-center font-satoshi text-[0.875rem] md:text-[1.125rem] font-medium"
-                    href={plan.buttonSrc}
+                    href={safeHref(plan.buttonSrc)}
                   >
                     {plan.buttonText}
                   </Link>

--- a/apps/frontend/src/app/features/marketing/pages/PricingPage/PricingPage.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/PricingPage/PricingPage.tsx
@@ -7,11 +7,27 @@ import { IoIosCheckmark, IoIosCloseCircleOutline } from 'react-icons/io';
 import FormInput from '@/app/ui/inputs/FormInput/FormInput';
 import Faq from '@/app/ui/widgets/Faq/Faq';
 import Footer from '@/app/ui/widgets/Footer/Footer';
-import { PricingPlans, TableData } from '@/app/features/marketing/pages/PricingPage/data';
+import { FALLBACK_PLANS, TableData } from '@/app/features/marketing/pages/PricingPage/data';
 import { Primary } from '@/app/ui/primitives/Buttons';
 import { MEDIA_SOURCES } from '@/app/constants/mediaSources';
+import { usePricing } from '@/app/hooks/usePricing';
+import CurrencySwitcher from '@/app/features/marketing/pages/PricingPage/CurrencySwitcher';
+import PricingSkeleton from '@/app/features/marketing/pages/PricingPage/PricingSkeleton';
+import type { PlanDTO, SupportedCurrency } from '@/app/features/marketing/pages/PricingPage/types';
 
 import './PricingPage.css';
+
+type BillingCycle = 'monthly' | 'yearly';
+
+const formatPrice = (amount: number | null, symbol: string, fallback: string): string => {
+  if (amount === null) return fallback;
+  return `${symbol}${amount}`;
+};
+
+const getPlanPrice = (plan: PlanDTO, cycle: BillingCycle, symbol: string): string => {
+  const raw = cycle === 'monthly' ? plan.amount : plan.amountYearly;
+  return formatPrice(raw, symbol, 'Coming soon');
+};
 
 const renderCell = (text: string) => {
   if (text === 'yes') {
@@ -70,8 +86,14 @@ const renderFeatureName = (name: string) => {
 };
 
 const PricingPage = () => {
-  const [activeCycle, setActiveCycle] = useState('yearly');
+  const [activeCycle, setActiveCycle] = useState<BillingCycle>('yearly');
   const [notify, setNotify] = useState(false);
+  const { data: pricing, loading } = usePricing();
+
+  const plans: PlanDTO[] = pricing?.plans ?? FALLBACK_PLANS;
+  const currency: SupportedCurrency = pricing?.currency ?? 'USD';
+  const currencySymbol: string = pricing?.currencySymbol ?? '$';
+  const showSkeleton = loading && !pricing;
   const [formData, setFormData] = useState({
     firstName: '',
     lastName: '',
@@ -136,75 +158,82 @@ const PricingPage = () => {
                     Pay yearly
                   </button>
                 </div>
-                <div className="flex-1 flex justify-between gap-3 sm:gap-0">
+                <div className="flex-1 flex items-center justify-between gap-3 sm:gap-3 flex-wrap">
                   <div className="text-[15px] font-satoshi text-blue-text font-bold">
                     Save up to 20% with yearly
                   </div>
-                  <div className="text-[15px] font-satoshi text-grey-noti font-bold">
-                    Price in EUR
+                  <div className="flex items-center gap-3">
+                    <div className="text-[15px] font-satoshi text-grey-noti font-bold">
+                      {`Price in ${currency}`}
+                    </div>
+                    <CurrencySwitcher currency={currency} />
                   </div>
                 </div>
               </div>
-              <div className="flex gap-3 lg:gap-[30px] justify-between w-full flex-col md:flex-row">
-                {PricingPlans.map((plan: any) => (
-                  <div
-                    key={plan.id}
-                    className="p-3 flex flex-col gap-2 lg:gap-3 w-full md:w-[calc(33%-11px)] lg:w-[calc(33%-20px)] rounded-[20px]! border border-grey-light!"
-                  >
-                    <div className="flex items-center gap-2 font-medium h-[23px] lg:h-[38px]">
-                      <div
-                        className={`font-satoshi text-[0.875rem] lg:text-[1.125rem] ${plan.active ? 'text-black-text' : 'text-grey-border'}`}
-                      >
-                        {plan.title}
-                      </div>
-                      {plan.recommended && (
-                        <div className="p-1 lg:p-2 rounded-lg bg-blue-light text-blue-text font-satoshi text-[12px] lg:text-[15px] font-normal">
-                          Recommended
-                        </div>
-                      )}
-                    </div>
-                    <div className="flex gap-2 items-end">
-                      <div
-                        className={`font-satoshi text-[28px] lg:text-[40px] font-medium ${plan.active ? 'text-black-text' : 'text-grey-border'}`}
-                      >
-                        {activeCycle === 'monthly' ? plan.amount : plan.amountYearly}
-                      </div>
-                      {plan.amountLabel && (
-                        <div className="mb-1.5! lg:mb-3! font-satoshi text-[13px] font-semibold text-black-text">
-                          {plan.amountLabel}
-                        </div>
-                      )}
-                    </div>
+              {showSkeleton ? (
+                <PricingSkeleton />
+              ) : (
+                <div className="flex gap-3 lg:gap-[30px] justify-between w-full flex-col md:flex-row">
+                  {plans.map((plan) => (
                     <div
-                      className={`font-satoshi text-[13px] lg:text-[15px] font-normal ${plan.active ? 'text-black-text' : 'text-grey-border'}`}
+                      key={plan.id}
+                      className="p-3 flex flex-col gap-2 lg:gap-3 w-full md:w-[calc(33%-11px)] lg:w-[calc(33%-20px)] rounded-[20px]! border border-grey-light!"
                     >
-                      {plan.description}
-                    </div>
-                    <Link
-                      className="w-full rounded-2xl! hover:border-text-brand! hover:text-text-brand! hover:scale-105! transition duration-200 ease-in-out text-black-text! border-black-text! border! h-12 flex items-center justify-center font-satoshi text-[1.125rem] font-medium"
-                      href={plan.buttonSrc}
-                      onClick={() => plan.id === 3 && setNotify(true)}
-                    >
-                      {plan.buttonText}
-                    </Link>
-                    <div>
-                      <div
-                        className={`font-satoshi text-[13px] lg:text-[15px] font-semibold ${plan.active ? 'text-black-text' : 'text-grey-border'}`}
-                      >
-                        Includes:
-                      </div>
-                      {plan.includes.map((detail: string) => (
+                      <div className="flex items-center gap-2 font-medium h-[23px] lg:h-[38px]">
                         <div
-                          key={detail}
-                          className={`flex font-satoshi text-[13px] lg:text-[15px] gap-2 font-normal ${plan.active ? 'text-black-text' : 'text-grey-border'}`}
+                          className={`font-satoshi text-[0.875rem] lg:text-[1.125rem] ${plan.active ? 'text-black-text' : 'text-grey-border'}`}
                         >
-                          &bull; <span>{detail}</span>
+                          {plan.title}
                         </div>
-                      ))}
+                        {plan.recommended && (
+                          <div className="p-1 lg:p-2 rounded-lg bg-blue-light text-blue-text font-satoshi text-[12px] lg:text-[15px] font-normal">
+                            Recommended
+                          </div>
+                        )}
+                      </div>
+                      <div className="flex gap-2 items-end">
+                        <div
+                          className={`font-satoshi text-[28px] lg:text-[40px] font-medium ${plan.active ? 'text-black-text' : 'text-grey-border'}`}
+                        >
+                          {getPlanPrice(plan, activeCycle, currencySymbol)}
+                        </div>
+                        {plan.amountLabel && (
+                          <div className="mb-1.5! lg:mb-3! font-satoshi text-[13px] font-semibold text-black-text">
+                            {plan.amountLabel}
+                          </div>
+                        )}
+                      </div>
+                      <div
+                        className={`font-satoshi text-[13px] lg:text-[15px] font-normal ${plan.active ? 'text-black-text' : 'text-grey-border'}`}
+                      >
+                        {plan.description}
+                      </div>
+                      <Link
+                        className="w-full rounded-2xl! hover:border-text-brand! hover:text-text-brand! hover:scale-105! transition duration-200 ease-in-out text-black-text! border-black-text! border! h-12 flex items-center justify-center font-satoshi text-[1.125rem] font-medium"
+                        href={plan.buttonSrc}
+                        onClick={() => plan.id === 'enterprise' && setNotify(true)}
+                      >
+                        {plan.buttonText}
+                      </Link>
+                      <div>
+                        <div
+                          className={`font-satoshi text-[13px] lg:text-[15px] font-semibold ${plan.active ? 'text-black-text' : 'text-grey-border'}`}
+                        >
+                          Includes:
+                        </div>
+                        {plan.includes.map((detail: string) => (
+                          <div
+                            key={detail}
+                            className={`flex font-satoshi text-[13px] lg:text-[15px] gap-2 font-normal ${plan.active ? 'text-black-text' : 'text-grey-border'}`}
+                          >
+                            &bull; <span>{detail}</span>
+                          </div>
+                        ))}
+                      </div>
                     </div>
-                  </div>
-                ))}
-              </div>
+                  ))}
+                </div>
+              )}
             </div>
           </div>
 
@@ -261,14 +290,14 @@ const PricingPage = () => {
             </div>
             <div className="flex gap-3">
               <div className="w-[calc(33%-10px)]"></div>
-              {PricingPlans.slice(0, 2).map((plan: any) => (
-                <div key={plan.description} className="w-[calc(33%-10px)] flex flex-col gap-2">
+              {plans.slice(0, 2).map((plan) => (
+                <div key={plan.id} className="w-[calc(33%-10px)] flex flex-col gap-2">
                   <div className="flex justify-between items-center flex-wrap">
                     <div className="font-satoshi text-[0.875rem] md:text-[1.125rem] font-medium text-black-text">
                       {plan.title.split(' ')[0]}
                     </div>
                     <div className="font-satoshi text-[0.875rem] md:text-[1.125rem] font-medium text-black-text">
-                      {activeCycle === 'monthly' ? plan.amount : plan.amountYearly}
+                      {getPlanPrice(plan, activeCycle, currencySymbol)}
                     </div>
                   </div>
                   <Link

--- a/apps/frontend/src/app/features/marketing/pages/PricingPage/PricingSkeleton.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/PricingPage/PricingSkeleton.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+/**
+ * Loading placeholder for the three plan cards while `/v1/pricing` is in
+ * flight. Mirrors the real card layout so there is no layout shift when
+ * the real data lands.
+ */
+const PricingSkeleton = () => {
+  return (
+    <div
+      className="flex gap-3 lg:gap-[30px] justify-between w-full flex-col md:flex-row"
+      aria-busy="true"
+      aria-live="polite"
+    >
+      {[0, 1, 2].map((i) => (
+        <div
+          key={i}
+          className="p-3 flex flex-col gap-3 w-full md:w-[calc(33%-11px)] lg:w-[calc(33%-20px)] rounded-[20px] border border-grey-light animate-pulse"
+        >
+          <div className="h-6 w-28 bg-grey-light rounded" />
+          <div className="h-10 w-24 bg-grey-light rounded mt-1" />
+          <div className="h-4 w-full bg-grey-light rounded" />
+          <div className="h-4 w-3/4 bg-grey-light rounded" />
+          <div className="h-12 w-full bg-grey-light rounded-2xl mt-2" />
+          <div className="flex flex-col gap-2 mt-2">
+            <div className="h-3 w-5/6 bg-grey-light rounded" />
+            <div className="h-3 w-4/6 bg-grey-light rounded" />
+            <div className="h-3 w-5/6 bg-grey-light rounded" />
+            <div className="h-3 w-3/6 bg-grey-light rounded" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default PricingSkeleton;

--- a/apps/frontend/src/app/features/marketing/pages/PricingPage/data.ts
+++ b/apps/frontend/src/app/features/marketing/pages/PricingPage/data.ts
@@ -1,3 +1,5 @@
+import type { PlanDTO } from '@/app/features/marketing/pages/PricingPage/types';
+
 const COMMON_FEATURES = {
   SCHEDULER: 'Yosemite Crew scheduler',
   TEMPLATES: 'Templates module',
@@ -13,14 +15,19 @@ const yesYes = (name: string) => row(name, 'yes', 'yes');
 const noYes = (name: string) => row(name, 'no', 'yes');
 const comingSoon = (name: string) => row(name, 'Coming soon', 'Coming soon');
 
-export const PricingPlans = [
+/**
+ * Offline USD defaults used when the `/v1/pricing` backend call has not yet
+ * returned (or cannot run because consent has not been granted). Kept in
+ * sync with the backend `PRICING_PLANS.USD` constant.
+ */
+export const FALLBACK_PLANS: PlanDTO[] = [
   {
+    id: 'free',
     active: true,
-    id: 1,
-    title: 'Free plan',
     recommended: false,
-    amount: '€0',
-    amountYearly: '€0',
+    title: 'Free plan',
+    amount: 0,
+    amountYearly: 0,
     amountLabel: '',
     description: 'Perfect for new or small pet businesses exploring on their own.',
     buttonText: 'Get started',
@@ -39,12 +46,12 @@ export const PricingPlans = [
     ],
   },
   {
+    id: 'business',
     active: true,
-    id: 2,
-    title: 'Business plan',
     recommended: true,
-    amount: '€12',
-    amountYearly: '€10',
+    title: 'Business plan',
+    amount: 13,
+    amountYearly: 11,
     amountLabel: 'per user / month',
     description: 'Flexible growth for pet businesses that need to scale on demand.',
     buttonText: 'Get started',
@@ -62,12 +69,12 @@ export const PricingPlans = [
     ],
   },
   {
+    id: 'enterprise',
     active: false,
-    id: 3,
-    title: 'Enterprise plan',
     recommended: false,
-    amount: 'Coming soon',
-    amountYearly: 'Coming soon',
+    title: 'Enterprise plan',
+    amount: null,
+    amountYearly: null,
     amountLabel: '',
     description: 'For pet businesses to operate with scalability, control, and security.',
     buttonText: 'Notify me',

--- a/apps/frontend/src/app/features/marketing/pages/PricingPage/types.ts
+++ b/apps/frontend/src/app/features/marketing/pages/PricingPage/types.ts
@@ -1,0 +1,26 @@
+export type SupportedCurrency = 'USD' | 'GBP' | 'EUR';
+
+export type PlanId = 'free' | 'business' | 'enterprise';
+
+export type CurrencySource = 'override' | 'ip' | 'default';
+
+export interface PlanDTO {
+  id: PlanId;
+  active: boolean;
+  recommended: boolean;
+  title: string;
+  amount: number | null;
+  amountYearly: number | null;
+  amountLabel: string;
+  description: string;
+  buttonText: string;
+  buttonSrc: string;
+  includes: string[];
+}
+
+export interface PricingResponse {
+  currency: SupportedCurrency;
+  currencySymbol: string;
+  source: CurrencySource;
+  plans: PlanDTO[];
+}

--- a/apps/frontend/src/app/features/marketing/pages/PricingPage/types.ts
+++ b/apps/frontend/src/app/features/marketing/pages/PricingPage/types.ts
@@ -2,8 +2,6 @@ export type SupportedCurrency = 'USD' | 'GBP' | 'EUR';
 
 export type PlanId = 'free' | 'business' | 'enterprise';
 
-export type CurrencySource = 'override' | 'ip' | 'default';
-
 export interface PlanDTO {
   id: PlanId;
   active: boolean;
@@ -21,6 +19,5 @@ export interface PlanDTO {
 export interface PricingResponse {
   currency: SupportedCurrency;
   currencySymbol: string;
-  source: CurrencySource;
   plans: PlanDTO[];
 }

--- a/apps/frontend/src/app/hooks/usePricing.ts
+++ b/apps/frontend/src/app/hooks/usePricing.ts
@@ -7,7 +7,7 @@ import { useCurrencyStore } from '@/app/stores/currencyStore';
 import type { PricingResponse } from '@/app/features/marketing/pages/PricingPage/types';
 import { logger } from '@/app/lib/logger';
 
-const PRICING_ENDPOINT = 'v1/pricing';
+const PRICING_ENDPOINT = '/v1/pricing';
 
 type UsePricingResult = {
   data: PricingResponse | null;

--- a/apps/frontend/src/app/hooks/usePricing.ts
+++ b/apps/frontend/src/app/hooks/usePricing.ts
@@ -1,0 +1,68 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+import { getData } from '@/app/services/axios';
+import { useConsentStore } from '@/app/stores/consentStore';
+import { useCurrencyStore } from '@/app/stores/currencyStore';
+import type { PricingResponse } from '@/app/features/marketing/pages/PricingPage/types';
+import { logger } from '@/app/lib/logger';
+
+const PRICING_ENDPOINT = 'v1/pricing';
+
+type UsePricingResult = {
+  data: PricingResponse | null;
+  loading: boolean;
+  error: string | null;
+};
+
+/**
+ * Fetches `/v1/pricing` from the backend and returns the response.
+ *
+ * Consent gate: the request only fires once the user has **granted** cookie
+ * consent, or after they have explicitly chosen a currency from the manual
+ * switcher. This keeps the pricing page usable (shows USD defaults) without
+ * ever making a network call before a lawful basis exists for it.
+ *
+ * Re-fetches whenever consent state or preferred currency changes.
+ */
+export const usePricing = (): UsePricingResult => {
+  const consentStatus = useConsentStore((s) => s.status);
+  const preferred = useCurrencyStore((s) => s.preferred);
+
+  const [data, setData] = useState<PricingResponse | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const shouldFetch = consentStatus === 'granted' || preferred !== null;
+    if (!shouldFetch) {
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    getData<PricingResponse>(PRICING_ENDPOINT)
+      .then((res) => {
+        if (cancelled) return;
+        setData(res.data);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        logger.warn('usePricing: failed to fetch pricing', err);
+        setError(err instanceof Error ? err.message : 'Unable to load pricing');
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [consentStatus, preferred]);
+
+  return { data, loading, error };
+};

--- a/apps/frontend/src/app/hooks/usePricing.ts
+++ b/apps/frontend/src/app/hooks/usePricing.ts
@@ -34,7 +34,8 @@ export const usePricing = (): UsePricingResult => {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const shouldFetch = consentStatus === 'granted' || preferred !== null;
+    const shouldFetch =
+      consentStatus === 'granted' || (preferred !== null && consentStatus !== 'denied');
     if (!shouldFetch) {
       setLoading(false);
       return;
@@ -52,7 +53,7 @@ export const usePricing = (): UsePricingResult => {
       .catch((err: unknown) => {
         if (cancelled) return;
         logger.warn('usePricing: failed to fetch pricing', err);
-        setError(err instanceof Error ? err.message : 'Unable to load pricing');
+        setError('Unable to load pricing');
       })
       .finally(() => {
         if (cancelled) return;

--- a/apps/frontend/src/app/hooks/usePricing.ts
+++ b/apps/frontend/src/app/hooks/usePricing.ts
@@ -37,6 +37,8 @@ export const usePricing = (): UsePricingResult => {
     const shouldFetch =
       consentStatus === 'granted' || (preferred !== null && consentStatus !== 'denied');
     if (!shouldFetch) {
+      setData(null);
+      setError(null);
       setLoading(false);
       return;
     }

--- a/apps/frontend/src/app/services/axios.ts
+++ b/apps/frontend/src/app/services/axios.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosInstance, AxiosResponse, AxiosRequestConfig } from 'axios';
 import { useAuthStore } from '@/app/stores/authStore';
 import { useOrgStore } from '@/app/stores/orgStore';
+import { useCurrencyStore } from '@/app/stores/currencyStore';
 import { hardSignOut } from '@/app/hooks/useAuth';
 import { logger } from '@/app/lib/logger';
 
@@ -30,6 +31,12 @@ api.interceptors.request.use(
           config.headers['x-org-id'] = primaryOrgId;
         } else {
           delete config.headers['x-org-id'];
+        }
+        const preferredCurrency = useCurrencyStore.getState().preferred;
+        if (preferredCurrency) {
+          config.headers['X-Preferred-Currency'] = preferredCurrency;
+        } else {
+          delete config.headers['X-Preferred-Currency'];
         }
       }
     } catch (error) {

--- a/apps/frontend/src/app/services/axios.ts
+++ b/apps/frontend/src/app/services/axios.ts
@@ -6,6 +6,7 @@ import { hardSignOut } from '@/app/hooks/useAuth';
 import { logger } from '@/app/lib/logger';
 
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
+const VALID_CURRENCIES = new Set(['USD', 'GBP', 'EUR']);
 
 const api: AxiosInstance = axios.create({
   baseURL: BASE_URL,
@@ -38,7 +39,6 @@ api.interceptors.request.use(
     }
     if (config.headers) {
       const preferredCurrency = useCurrencyStore.getState().preferred;
-      const VALID_CURRENCIES = new Set(['USD', 'GBP', 'EUR']);
       if (preferredCurrency && VALID_CURRENCIES.has(preferredCurrency)) {
         config.headers['X-Preferred-Currency'] = preferredCurrency;
       } else {

--- a/apps/frontend/src/app/services/axios.ts
+++ b/apps/frontend/src/app/services/axios.ts
@@ -32,15 +32,18 @@ api.interceptors.request.use(
         } else {
           delete config.headers['x-org-id'];
         }
-        const preferredCurrency = useCurrencyStore.getState().preferred;
-        if (preferredCurrency) {
-          config.headers['X-Preferred-Currency'] = preferredCurrency;
-        } else {
-          delete config.headers['X-Preferred-Currency'];
-        }
       }
     } catch (error) {
       logger.warn('No valid Cognito session available from AuthStore', error);
+    }
+    if (config.headers) {
+      const preferredCurrency = useCurrencyStore.getState().preferred;
+      const VALID_CURRENCIES = new Set(['USD', 'GBP', 'EUR']);
+      if (preferredCurrency && VALID_CURRENCIES.has(preferredCurrency)) {
+        config.headers['X-Preferred-Currency'] = preferredCurrency;
+      } else {
+        delete config.headers['X-Preferred-Currency'];
+      }
     }
     return config;
   },

--- a/apps/frontend/src/app/stores/consentStore.ts
+++ b/apps/frontend/src/app/stores/consentStore.ts
@@ -1,0 +1,58 @@
+import { create } from 'zustand';
+
+/**
+ * Tracks the user's answer to the in-house cookie consent popup.
+ *
+ * Persisted to `localStorage.cookieConsentGiven` to stay backwards-compatible
+ * with the original Cookies widget. The store is the single source of truth
+ * so any component can reactively gate behaviour on consent status without
+ * having to re-read localStorage.
+ */
+
+const STORAGE_KEY = 'cookieConsentGiven';
+
+export type ConsentStatus = 'unknown' | 'granted' | 'denied';
+
+type ConsentState = {
+  status: ConsentStatus;
+  grant: () => void;
+  deny: () => void;
+  /** Reads localStorage and hydrates state. Safe to call repeatedly. */
+  hydrate: () => void;
+};
+
+const readFromStorage = (): ConsentStatus => {
+  if (typeof globalThis.window === 'undefined') return 'unknown';
+  try {
+    const raw = globalThis.window.localStorage.getItem(STORAGE_KEY);
+    if (raw === 'true') return 'granted';
+    if (raw === 'false') return 'denied';
+    return 'unknown';
+  } catch {
+    return 'unknown';
+  }
+};
+
+const writeToStorage = (value: 'true' | 'false') => {
+  if (typeof globalThis.window === 'undefined') return;
+  try {
+    globalThis.window.localStorage.setItem(STORAGE_KEY, value);
+  } catch {
+    /* storage not available (private mode, quota, etc.) */
+  }
+};
+
+export const useConsentStore = create<ConsentState>()((set) => ({
+  status: 'unknown',
+  grant: () => {
+    writeToStorage('true');
+    set({ status: 'granted' });
+  },
+  deny: () => {
+    writeToStorage('false');
+    set({ status: 'denied' });
+  },
+  hydrate: () => {
+    set({ status: readFromStorage() });
+  },
+}));

--- a/apps/frontend/src/app/stores/consentStore.ts
+++ b/apps/frontend/src/app/stores/consentStore.ts
@@ -43,7 +43,7 @@ const writeToStorage = (value: 'true' | 'false') => {
 };
 
 export const useConsentStore = create<ConsentState>()((set) => ({
-  status: 'unknown',
+  status: readFromStorage(),
   grant: () => {
     writeToStorage('true');
     set({ status: 'granted' });

--- a/apps/frontend/src/app/stores/currencyStore.ts
+++ b/apps/frontend/src/app/stores/currencyStore.ts
@@ -31,6 +31,11 @@ export const useCurrencyStore = create<CurrencyState>()(
       version: 1,
       storage: createJSONStorage(() => localStorage),
       partialize: (state) => ({ preferred: state.preferred }),
+      onRehydrateStorage: () => (state) => {
+        if (state && state.preferred && !SUPPORTED.has(state.preferred)) {
+          state.preferred = null;
+        }
+      },
     }
   )
 );

--- a/apps/frontend/src/app/stores/currencyStore.ts
+++ b/apps/frontend/src/app/stores/currencyStore.ts
@@ -1,0 +1,36 @@
+import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+
+import type { SupportedCurrency } from '@/app/features/marketing/pages/PricingPage/types';
+
+const SUPPORTED = new Set<SupportedCurrency>(['USD', 'GBP', 'EUR']);
+
+type CurrencyState = {
+  /**
+   * `null` = auto-detect (backend will resolve via IP).
+   * When set, the axios interceptor attaches `X-Preferred-Currency` on
+   * outgoing requests and the pricing page re-fetches.
+   */
+  preferred: SupportedCurrency | null;
+  setPreferred: (currency: SupportedCurrency) => void;
+  clearPreferred: () => void;
+};
+
+export const useCurrencyStore = create<CurrencyState>()(
+  persist(
+    (set) => ({
+      preferred: null,
+      setPreferred: (currency) => {
+        if (!SUPPORTED.has(currency)) return;
+        set({ preferred: currency });
+      },
+      clearPreferred: () => set({ preferred: null }),
+    }),
+    {
+      name: 'currency-store',
+      version: 1,
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({ preferred: state.preferred }),
+    }
+  )
+);

--- a/apps/frontend/src/app/ui/widgets/Cookies/Cookies.tsx
+++ b/apps/frontend/src/app/ui/widgets/Cookies/Cookies.tsx
@@ -6,26 +6,36 @@ import { usePathname } from 'next/navigation';
 import { publicRoutes } from '@/app/lib/const';
 import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
 import { MEDIA_SOURCES } from '@/app/constants/mediaSources';
+import { useConsentStore } from '@/app/stores/consentStore';
 
 const Cookies = () => {
   const [showCookiePopup, setShowCookiePopup] = useState(false);
   const pathname = usePathname();
+  const consentStatus = useConsentStore((s) => s.status);
+  const hydrate = useConsentStore((s) => s.hydrate);
+  const grant = useConsentStore((s) => s.grant);
+  const deny = useConsentStore((s) => s.deny);
 
   useEffect(() => {
-    const cookieConsentGiven = localStorage.getItem('cookieConsentGiven');
-    if (!cookieConsentGiven) {
-      setShowCookiePopup(true); // If not accepted, show popup
+    hydrate();
+  }, [hydrate]);
+
+  useEffect(() => {
+    if (consentStatus === 'unknown') {
+      setShowCookiePopup(true);
+    } else {
+      setShowCookiePopup(false);
     }
-  }, []);
+  }, [consentStatus]);
 
   const handleConsent = () => {
     setShowCookiePopup(false);
-    localStorage.setItem('cookieConsentGiven', 'true'); // Mark as accepted
+    grant();
   };
 
   const handleRejection = () => {
     setShowCookiePopup(false);
-    localStorage.setItem('cookieConsentGiven', 'false'); // Mark as rejected
+    deny();
   };
 
   if (!publicRoutes.has(pathname)) return null;

--- a/docs/guide/geolocation-aware-pricing.md
+++ b/docs/guide/geolocation-aware-pricing.md
@@ -143,7 +143,7 @@ The original brief described a frontend-driven flow: browser Geolocation API →
 
 ## 8. Implementation Steps (Chronological)
 
-1. **Planning** — explored the codebase (cookies widget, pricing page, backend app.ts/routers, axios interceptor, store patterns) and wrote the implementation plan at `/Users/ahmedmahmoud/.claude/plans/sorted-finding-abelson.md`.
+1. **Planning** — explored the codebase (cookies widget, pricing page, backend app.ts/routers, axios interceptor, store patterns) and wrote an implementation plan.
 2. **Clarification** — asked three architecture questions (detection method, override UI, plan storage) and got user sign-off for: IP-based backend detection, manual switcher, hardcoded constants.
 3. **Backend dependency** — `pnpm --filter backend add geoip-country @types/geoip-country`.
 4. **Backend constants** — created `pricing.constants.ts` with types, currency map, price table.

--- a/docs/guide/geolocation-aware-pricing.md
+++ b/docs/guide/geolocation-aware-pricing.md
@@ -85,7 +85,6 @@ Response (200):
 {
   "currency": "EUR",
   "currencySymbol": "€",
-  "source": "ip",
   "plans": [
     { "id": "free",      "amount": 0,    "amountYearly": 0,    "active": true,  "recommended": false, ... },
     { "id": "business",  "amount": 12,   "amountYearly": 10,   "active": true,  "recommended": true,  ... },
@@ -94,9 +93,11 @@ Response (200):
 }
 ```
 
-Response headers: `Cache-Control: public, max-age=300`, `Vary: X-Preferred-Currency`.
+Response headers:
 
-`source` is one of `"override"` (client header), `"ip"` (geoip), or `"default"` (USD fallback). Useful for analytics and debugging.
+- `Vary: X-Preferred-Currency` (always present).
+- `Cache-Control: public, max-age=300` when currency is resolved via the header override or falls back to default USD.
+- `Cache-Control: private, no-store` when currency is resolved via IP-based geolocation (cannot be CDN-cached since it varies by client IP).
 
 ## 5. Pricing Table
 

--- a/docs/guide/geolocation-aware-pricing.md
+++ b/docs/guide/geolocation-aware-pricing.md
@@ -1,0 +1,250 @@
+# Geolocation-Aware Pricing — Implementation Notes
+
+**Status:** implemented
+**Scope:** `apps/backend` + `apps/frontend`
+**Author:** Claude Code (agent run, 2026-04-10)
+
+## 1. Problem & Goal
+
+The public `/pricing` page rendered hardcoded EUR prices (`€0`, `€10`, `Price in EUR`). We wanted:
+
+1. Visitors to see prices in their **local currency** (USD, GBP, or EUR).
+2. Prices to come from the **backend** (single source of truth), not hardcoded on the frontend.
+3. Geolocation to happen **only after cookie consent** (GDPR lawful basis).
+4. Anything outside the three supported currencies to fall back to **USD**.
+5. The solution to be **secure, defensive, and industry-standard** — not the naive "client sends a header, backend trusts it" shape.
+
+## 2. Architecture Overview
+
+```
+Visitor hits /pricing
+  │
+  ├── Cookie consent NOT granted AND no manual override
+  │     → Frontend shows USD fallback (FALLBACK_PLANS). No network call.
+  │
+  ├── User clicks "Accept" on Cookies widget
+  │     → consentStore.grant() persists to localStorage.cookieConsentGiven
+  │     → usePricing() fires GET /v1/pricing WITHOUT X-Preferred-Currency
+  │     → Backend reads req.ip (trust proxy: 1), runs geoip-country lookup,
+  │       maps country → currency, returns plans in that currency.
+  │
+  └── User clicks USD/GBP/EUR in CurrencySwitcher
+        → currencyStore.setPreferred("GBP") persists to localStorage
+        → axios interceptor adds X-Preferred-Currency header on all requests
+        → usePricing() re-fires with the header
+        → Backend middleware allowlist-validates the header, overrides
+          IP detection, returns plans in GBP.
+```
+
+## 3. What Got Built
+
+### Backend — new files
+
+| File                                                     | Purpose                                                                                                                                                                                                                                  |
+| -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `apps/backend/src/constants/pricing.constants.ts`        | `SUPPORTED_CURRENCIES`, `CURRENCY_SYMBOLS`, `COUNTRY_TO_CURRENCY`, `PRICING_PLANS`, `DEFAULT_CURRENCY`, `PlanDTO` type. Single source of truth for plan prices.                                                                          |
+| `apps/backend/src/services/geo.service.ts`               | `getCountryFromIp(ip)` — wraps `geoip-country` with IPv6/loopback handling. `resolveCurrencyFromCountry(country)` — country → currency mapping with USD fallback.                                                                        |
+| `apps/backend/src/services/pricing.service.ts`           | `resolveCurrency(req, override)` — priority `override → ip → default`. `getPricingResponse(req, override)` — composes the full DTO.                                                                                                      |
+| `apps/backend/src/middlewares/validateCurrencyHeader.ts` | Reads `X-Preferred-Currency`, allowlist-validates against `SUPPORTED_CURRENCIES.has()`, stashes the canonical uppercase value on `res.locals.overrideCurrency`. Never throws. Silently ignores invalid values (graceful fallback to IP). |
+| `apps/backend/src/controllers/web/pricing.controller.ts` | Public `GET /v1/pricing` handler. Sets `Cache-Control: public, max-age=300` + `Vary: X-Preferred-Currency` response headers.                                                                                                             |
+| `apps/backend/src/routers/pricing.router.ts`             | Mounts the controller under a dedicated per-IP rate limiter (30 req/min).                                                                                                                                                                |
+
+### Backend — modified files
+
+- `apps/backend/src/routers/index.ts` — registered `pricingRouter` at `/v1/pricing`.
+- `apps/backend/src/app.ts` — added `'X-Preferred-Currency'` to the CORS `allowedHeaders` list.
+- `apps/backend/package.json` — added `geoip-country` + `@types/geoip-country` dependencies.
+
+### Frontend — new files
+
+| File                                                                              | Purpose                                                                                                                                                 |
+| --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `apps/frontend/src/app/stores/consentStore.ts`                                    | Zustand store tracking cookie consent (`'unknown' \| 'granted' \| 'denied'`). Persists to `localStorage.cookieConsentGiven` (backwards-compatible key). |
+| `apps/frontend/src/app/stores/currencyStore.ts`                                   | Zustand store tracking user's preferred currency. Persisted via `zustand/middleware` `persist` to `localStorage` as `currency-store`.                   |
+| `apps/frontend/src/app/hooks/usePricing.ts`                                       | React hook that fetches `/v1/pricing` **only** when consent is granted or a preferred currency is set. Returns `{ data, loading, error }`.              |
+| `apps/frontend/src/app/features/marketing/pages/PricingPage/types.ts`             | Shared types: `SupportedCurrency`, `PlanDTO`, `PricingResponse`, etc.                                                                                   |
+| `apps/frontend/src/app/features/marketing/pages/PricingPage/CurrencySwitcher.tsx` | Accessible segmented control with `role="group"`, `aria-label`, `aria-pressed`, keyboard-navigable `<button>`s.                                         |
+| `apps/frontend/src/app/features/marketing/pages/PricingPage/PricingSkeleton.tsx`  | Loading placeholder mirroring the real card layout (no layout shift).                                                                                   |
+
+### Frontend — modified files
+
+- `apps/frontend/src/app/services/axios.ts` — request interceptor now attaches `X-Preferred-Currency` when `currencyStore.preferred` is set.
+- `apps/frontend/src/app/ui/widgets/Cookies/Cookies.tsx` — now uses `consentStore` (`hydrate`, `grant`, `deny`) instead of direct `localStorage` reads. Behaviour unchanged from the user's POV.
+- `apps/frontend/src/app/features/marketing/pages/PricingPage/PricingPage.tsx` — replaced hardcoded `PricingPlans` with `usePricing()`; renders `PricingSkeleton` while loading; renders `CurrencySwitcher`; dynamic `Price in {currency}` label; typed helpers `formatPrice` / `getPlanPrice` extracted to module scope (Sonar ≤15 cognitive complexity).
+- `apps/frontend/src/app/features/marketing/pages/PricingPage/data.ts` — removed `PricingPlans` (with EUR strings). Replaced with `FALLBACK_PLANS: PlanDTO[]` — USD-priced typed fallback used before the backend response arrives.
+
+## 4. API Contract
+
+### `GET /v1/pricing`
+
+Optional request header: `X-Preferred-Currency: USD | GBP | EUR` (allowlist-validated; ignored if invalid).
+
+Response (200):
+
+```json
+{
+  "currency": "EUR",
+  "currencySymbol": "€",
+  "source": "ip",
+  "plans": [
+    { "id": "free",      "amount": 0,    "amountYearly": 0,    "active": true,  "recommended": false, ... },
+    { "id": "business",  "amount": 12,   "amountYearly": 10,   "active": true,  "recommended": true,  ... },
+    { "id": "enterprise","amount": null, "amountYearly": null, "active": false, "recommended": false, ... }
+  ]
+}
+```
+
+Response headers: `Cache-Control: public, max-age=300`, `Vary: X-Preferred-Currency`.
+
+`source` is one of `"override"` (client header), `"ip"` (geoip), or `"default"` (USD fallback). Useful for analytics and debugging.
+
+## 5. Pricing Table
+
+Prices live in `apps/backend/src/constants/pricing.constants.ts::PRICE_TABLE`:
+
+| Plan       | USD (month) | USD (year) | GBP (month) | GBP (year) | EUR (month) | EUR (year) |
+| ---------- | ----------- | ---------- | ----------- | ---------- | ----------- | ---------- |
+| Free       | $0          | $0         | £0          | £0         | €0          | €0         |
+| Business   | $13         | $11        | £10         | £8         | €12         | €10        |
+| Enterprise | —           | —          | —           | —          | —           | —          |
+
+Enterprise renders "Coming soon" (backend returns `null`; frontend formats as `"Coming soon"`).
+
+## 6. Security Guarantees (Defense in Depth)
+
+| #   | Threat                                                                     | Mitigation                                                                                                                                    |
+| --- | -------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Client forges `X-Preferred-Currency: DROP TABLE`                           | **Allowlist `Set.has()` validation.** Uppercase only. Any non-match is silently ignored. No DB lookup, no regex, no coercion.                 |
+| 2   | Client spoofs source IP via `X-Forwarded-For`                              | `trust proxy: 1` is already configured in `app.ts:21`. Express only honours the **last** proxy hop.                                           |
+| 3   | Scraping / abuse of the public endpoint                                    | **Dedicated per-IP rate limiter** (30/min) in `pricing.router.ts` **on top of** the global 500/15min in `app.ts`.                             |
+| 4   | CDN cache poisoning across currencies                                      | `Vary: X-Preferred-Currency` response header.                                                                                                 |
+| 5   | NoSQL injection                                                            | `express-mongo-sanitize` already installed globally (`app.ts:64`). Pricing endpoint uses no DB at all.                                        |
+| 6   | Tracking before consent (GDPR Art. 6)                                      | **Consent gate in `usePricing`** — no network call fires until `consentStore.status === 'granted'` or a manual override is explicitly chosen. |
+| 7   | PII storage                                                                | **Zero.** Country is derived transiently per request from `req.ip` and never persisted. No analytics.                                         |
+| 8   | Third-party data transfer                                                  | **Offline geoip DB.** `geoip-country` ships its own DB file — no external API calls, no cross-border data transfer.                           |
+| 9   | Client relying on untrusted data                                           | Frontend treats the backend response as the source of truth but falls back to `FALLBACK_PLANS` (USD) if the request fails.                    |
+| 10  | CSRF                                                                       | This is a `GET` endpoint with no side effects, no cookies required, no mutating state.                                                        |
+| 11  | Denial of Service via malformed header                                     | Middleware only reads strings (`typeof raw === 'string'`), trims, uppercases, and bails on length 0. No regex. No unbounded allocation.       |
+| 12  | Header-injection via `X-Preferred-Currency` bleeding into response headers | Value is never echoed back. Only `Vary` has a fixed literal `X-Preferred-Currency` string.                                                    |
+
+## 7. Industry-Standard Enhancements (vs. the "naive" version)
+
+The original brief described a frontend-driven flow: browser Geolocation API → reverse-geocode → send currency header → backend trusts it. We upgraded that to:
+
+- **Server-side IP geolocation** instead of browser API → no second permission prompt, no precise coordinates, GDPR-friendlier.
+- **Backend as source of truth** for currency resolution → client-sent headers are _one input_ among three priority tiers, never blindly trusted.
+- **Consent-gated network call** → no data sent to the backend before lawful basis exists.
+- **Manual currency switcher** → fixes VPN/traveler mis-detection, improves trust, persists across sessions.
+- **Accessible UI** → `role="group"`, `aria-pressed`, `aria-label`, full keyboard navigation.
+- **Cache-safe response** → `Vary: X-Preferred-Currency` prevents CDN currency mix-ups.
+- **Dedicated rate limiter** → scraping protection layered on top of the global limiter.
+- **Skeleton loader** → no layout shift during the fetch.
+- **Typed DTO contract** → `PlanDTO`/`PricingResponse` types prevent frontend/backend drift.
+
+## 8. Implementation Steps (Chronological)
+
+1. **Planning** — explored the codebase (cookies widget, pricing page, backend app.ts/routers, axios interceptor, store patterns) and wrote the implementation plan at `/Users/ahmedmahmoud/.claude/plans/sorted-finding-abelson.md`.
+2. **Clarification** — asked three architecture questions (detection method, override UI, plan storage) and got user sign-off for: IP-based backend detection, manual switcher, hardcoded constants.
+3. **Backend dependency** — `pnpm --filter backend add geoip-country @types/geoip-country`.
+4. **Backend constants** — created `pricing.constants.ts` with types, currency map, price table.
+5. **Backend services** — created `geo.service.ts` (geoip wrapper) and `pricing.service.ts` (currency resolution).
+6. **Backend middleware** — created `validateCurrencyHeader.ts` (allowlist validation).
+7. **Backend controller + router** — created `pricing.controller.ts` and `pricing.router.ts` with rate limiter. Registered in `routers/index.ts` and added to CORS `allowedHeaders` in `app.ts`.
+8. **Backend type-check** — ran `pnpm --filter backend run type-check`. All new files are clean; the pre-existing errors in appointment/code/organization services are unrelated to this change.
+9. **Frontend stores** — created `consentStore.ts` + `currencyStore.ts`.
+10. **Frontend axios** — wired the interceptor to attach `X-Preferred-Currency` from `currencyStore`.
+11. **Frontend hook** — created `usePricing.ts` with the consent gate.
+12. **Frontend types** — created `PricingPage/types.ts` for shared DTOs.
+13. **Frontend UI** — created `CurrencySwitcher.tsx` (accessible) and `PricingSkeleton.tsx` (loading state).
+14. **Frontend Cookies widget** — refactored to use `consentStore` instead of direct `localStorage`.
+15. **Frontend PricingPage** — refactored to use `usePricing`, render the switcher, skeleton, dynamic prices, and replaced `PricingPlans` import with the typed `FALLBACK_PLANS`.
+16. **Verification:**
+    - Frontend type-check: `cd apps/frontend && npx tsc --noemit` → 0 errors
+    - Frontend lint: `pnpm --filter frontend run lint` → clean
+    - Backend type-check: new files clean (pre-existing errors in other files unrelated)
+    - Backend lint: clean
+    - Frontend targeted tests:
+      - `jest --testPathPattern="PricingPage"` → 2/2 pass
+      - `jest --testPathPattern="Cookies"` → 5/5 pass
+      - `jest --testPathPattern="axios"` → 21/21 pass
+      - `jest --testPathPattern="stores"` → 368/368 pass
+    - Dev server: `http://localhost:3003/pricing` → HTTP 200, renders "Price in USD" default + `aria-pressed` switcher buttons
+
+## 9. Manual Verification Steps
+
+### Happy path
+
+1. `pnpm --filter backend run dev` (needs Firebase / Cognito env to boot locally — if missing, backend boot will error; that is unrelated to this feature).
+2. `pnpm --filter frontend run dev`
+3. Open the pricing page in a fresh incognito window.
+4. Observe: cookie popup visible, prices in USD (fallback because consent not granted).
+5. Click **Accept**. `/v1/pricing` fires. On localhost the IP lookup falls back to USD → still USD. `source: "default"`.
+6. Click **GBP** on the currency switcher. New request with `X-Preferred-Currency: GBP`. Prices flip to £.
+7. Reload the page. GBP preference persists via `localStorage.currency-store`.
+
+### Negative tests
+
+1. `curl -i -H 'X-Preferred-Currency: HACK' http://localhost:4000/v1/pricing` → returns USD (ignored) with `source: "default"` or `"ip"`.
+2. `curl -i -H 'X-Preferred-Currency: eur' http://localhost:4000/v1/pricing` → returns EUR (case-insensitive).
+3. `for i in {1..40}; do curl -s -o /dev/null -w "%{http_code} " http://localhost:4000/v1/pricing; done; echo` → expect `429` after 30 requests.
+4. Response should include `Vary: X-Preferred-Currency` and `Cache-Control: public, max-age=300` headers.
+
+## 10. Files Touched (Quick Index)
+
+**Backend — created**
+
+- `apps/backend/src/constants/pricing.constants.ts`
+- `apps/backend/src/services/geo.service.ts`
+- `apps/backend/src/services/pricing.service.ts`
+- `apps/backend/src/middlewares/validateCurrencyHeader.ts`
+- `apps/backend/src/controllers/web/pricing.controller.ts`
+- `apps/backend/src/routers/pricing.router.ts`
+
+**Backend — modified**
+
+- `apps/backend/src/routers/index.ts`
+- `apps/backend/src/app.ts`
+- `apps/backend/package.json`
+
+**Frontend — created**
+
+- `apps/frontend/src/app/stores/consentStore.ts`
+- `apps/frontend/src/app/stores/currencyStore.ts`
+- `apps/frontend/src/app/hooks/usePricing.ts`
+- `apps/frontend/src/app/features/marketing/pages/PricingPage/types.ts`
+- `apps/frontend/src/app/features/marketing/pages/PricingPage/CurrencySwitcher.tsx`
+- `apps/frontend/src/app/features/marketing/pages/PricingPage/PricingSkeleton.tsx`
+
+**Frontend — modified**
+
+- `apps/frontend/src/app/services/axios.ts`
+- `apps/frontend/src/app/ui/widgets/Cookies/Cookies.tsx`
+- `apps/frontend/src/app/features/marketing/pages/PricingPage/PricingPage.tsx`
+- `apps/frontend/src/app/features/marketing/pages/PricingPage/data.ts`
+
+## 11. Out of Scope (Future Work)
+
+- Adding `helmet` middleware to the backend for broader security headers.
+- Plumbing the selected currency through Stripe checkout (the billing model already has a `currency` field).
+- `Intl.NumberFormat`-based locale-aware number formatting (e.g. `€1.200,00` vs `€1,200.00`).
+- Unit tests for the three new backend files (`geo.service`, `pricing.service`, `validateCurrencyHeader`) — the integration tests via the PricingPage route exercise the happy path, but isolated backend jest tests would add coverage.
+- MongoDB-backed plan CMS — if marketing wants to change prices without redeploy.
+
+## 12. Commit Checkpoint (suggested)
+
+Per the repo's commit discipline rule, the agent never commits. Suggested message when the user is ready:
+
+```
+feat(repo): add geolocation-aware pricing with cookie consent gate
+
+- Add public GET /v1/pricing backend endpoint with IP-based currency
+  detection (geoip-country), allowlist header validation, dedicated
+  rate limiter, and Cache-Control/Vary response headers.
+- Add consentStore and currencyStore on the frontend; gate the
+  /v1/pricing fetch on consent; add accessible currency switcher
+  and loading skeleton on the pricing page.
+- Replace hardcoded EUR prices with dynamic values from the backend;
+  keep USD FALLBACK_PLANS for the pre-consent render path.
+```
+
+Scope is `repo` because the change spans both `frontend` and `backend` workspaces.

--- a/docs/guide/geolocation-pricing-security-audit.md
+++ b/docs/guide/geolocation-pricing-security-audit.md
@@ -1,0 +1,216 @@
+# Geolocation-Aware Pricing — Security Audit & Fixes
+
+**Date:** 2026-04-13
+**Scope:** `feat/geolocation-pricing` branch — backend + frontend pricing feature
+
+---
+
+## Summary
+
+A security audit was performed on the geolocation-aware pricing feature covering
+both backend (Express/Node) and frontend (Next.js/React) code. **10 findings**
+were identified and all have been resolved.
+
+| #   | Severity | Finding                                                   | Status |
+| --- | -------- | --------------------------------------------------------- | ------ |
+| 1   | HIGH     | Cache poisoning via incomplete `Vary` header              | Fixed  |
+| 2   | MEDIUM   | Log injection via unsanitized header value                | Fixed  |
+| 3   | MEDIUM   | No input length bound on currency header                  | Fixed  |
+| 4   | MEDIUM   | Zustand persist hydration bypasses currency validation    | Fixed  |
+| 5   | MEDIUM   | Backend `currencySymbol` trusted blindly on frontend      | Fixed  |
+| 6   | MEDIUM   | Backend `buttonSrc` rendered as `href` without validation | Fixed  |
+| 7   | LOW      | `source` field leaks detection method to client           | Fixed  |
+| 8   | LOW      | Consent gate bypass when user denied but picks currency   | Fixed  |
+| 9   | LOW      | Error message may expose internal API details             | Fixed  |
+| 10  | LOW      | Structured error logging in controller                    | Fixed  |
+
+---
+
+## Finding 1 — Cache Poisoning (HIGH)
+
+**Location:** `apps/backend/src/controllers/web/pricing.controller.ts`
+
+**Issue:** The response set `Cache-Control: public, max-age=300` unconditionally.
+When no `X-Preferred-Currency` header is sent, the pricing response varies by the
+visitor's IP (via geoip lookup). The `Vary` header only listed
+`X-Preferred-Currency`, so a CDN would consider IP-based responses
+cache-equivalent and serve a cached USD response to a UK visitor.
+
+**Fix:** Dynamic `Cache-Control` based on currency resolution source:
+
+- `override` or `default` source: `public, max-age=300` (safe to CDN-cache,
+  keyed on the `Vary: X-Preferred-Currency` header)
+- `ip` source: `private, no-store` (response varies by client IP which CDNs
+  cannot key on)
+
+---
+
+## Finding 2 — Log Injection (MEDIUM)
+
+**Location:** `apps/backend/src/middlewares/validateCurrencyHeader.ts:36-38`
+
+**Issue:** The debug log interpolated the raw `candidate` value directly into the
+message string. After `.trim().toUpperCase()`, the value could still contain
+embedded `\r\n` or ANSI escape codes, enabling log forging/CRLF injection.
+
+**Fix:** Changed to structured logging with Winston (object field instead of
+string interpolation). The candidate value is also stripped of non-printable
+characters via `candidate.replace(/[^\x20-\x7E]/g, "")`.
+
+---
+
+## Finding 3 — No Header Length Bound (MEDIUM)
+
+**Location:** `apps/backend/src/middlewares/validateCurrencyHeader.ts:31`
+
+**Issue:** No length guard on the raw header value before processing. A malicious
+client could send a 16 KB `X-Preferred-Currency` header, causing
+`.trim().toUpperCase()` to allocate and process the entire string before the
+`Set.has()` check rejects it.
+
+**Fix:** Added early-exit length check: `raw.length <= 5` (a 3-letter currency
+code plus possible whitespace). Oversized headers are silently ignored.
+
+---
+
+## Finding 4 — Persist Hydration Bypass (MEDIUM)
+
+**Location:** `apps/frontend/src/app/stores/currencyStore.ts`
+
+**Issue:** The `setPreferred` action validates against the `SUPPORTED` set, but
+zustand's `persist` hydration deserializes JSON from `localStorage` and merges it
+directly into state — bypassing the validation. A tampered localStorage value
+(e.g. via XSS on the same origin) could inject an arbitrary string into state,
+which would then be sent as the `X-Preferred-Currency` HTTP header.
+
+**Fix:** Added `onRehydrateStorage` callback that validates `state.preferred`
+against the `SUPPORTED` set on hydration, resetting to `null` if invalid.
+Additionally, the axios interceptor now validates against a `VALID_CURRENCIES`
+set before attaching the header (defense-in-depth).
+
+---
+
+## Finding 5 — Untrusted `currencySymbol` (MEDIUM)
+
+**Location:** `apps/frontend/src/app/features/marketing/pages/PricingPage/PricingPage.tsx`
+
+**Issue:** The `currencySymbol` field from the backend API response was rendered
+directly in the DOM. If the backend were compromised or the response tampered
+with, an attacker could inject misleading content (e.g. a long string that
+appears inline with prices, creating UI spoofing opportunities).
+
+**Fix:** Currency symbol is now derived client-side from a hardcoded
+`CURRENCY_SYMBOLS` map keyed by the `currency` code. The backend `currencySymbol`
+field is ignored.
+
+---
+
+## Finding 6 — Untrusted `buttonSrc` (MEDIUM)
+
+**Location:** `apps/frontend/src/app/features/marketing/pages/PricingPage/PricingPage.tsx`
+
+**Issue:** `plan.buttonSrc` from the backend was used directly as `<Link href>`.
+A compromised backend could set this to `javascript:` URIs or external phishing
+URLs.
+
+**Fix:** Added `safeHref()` helper that validates the value starts with `/` or
+`#` (relative path). Any other value falls back to `/signup`.
+
+---
+
+## Finding 7 — `source` Field Information Leak (LOW)
+
+**Location:** `apps/backend/src/services/pricing.service.ts`
+
+**Issue:** The API response included `"source": "override" | "ip" | "default"`,
+revealing the detection method to clients. This aids reconnaissance — an attacker
+could confirm `X-Forwarded-For` spoofing worked, or enumerate which IPs resolve
+to which countries.
+
+**Fix:** Removed the `source` field from the public API response. The source is
+still available internally (returned by `resolveCurrency()`) for cache-control
+logic, but never exposed to clients. The `CurrencySource` type was also removed
+from frontend types.
+
+---
+
+## Finding 8 — Consent Gate Bypass (LOW)
+
+**Location:** `apps/frontend/src/app/hooks/usePricing.ts:37`
+
+**Issue:** The consent gate condition was
+`consentStatus === 'granted' || preferred !== null`. A user who explicitly
+**denied** consent could still trigger the pricing API request (which performs
+IP-based geolocation — processing personal data) by clicking a currency button.
+
+**Fix:** Adjusted condition to:
+`consentStatus === 'granted' || (preferred !== null && consentStatus !== 'denied')`
+
+This respects the user's explicit denial while still allowing currency selection
+when consent is `unknown` (not yet prompted).
+
+---
+
+## Finding 9 — Error Message Leaks Internals (LOW)
+
+**Location:** `apps/frontend/src/app/hooks/usePricing.ts:55`
+
+**Issue:** The error handler stored `err.message` from axios errors, which can
+include the full request URL, status codes, and response body fragments. While
+not currently rendered, any future consumer displaying the `error` field would
+leak internal API paths.
+
+**Fix:** Always uses the generic `'Unable to load pricing'` message for
+user-facing state. Detailed error information is only sent to the logger.
+
+---
+
+## Finding 10 — Structured Error Logging (LOW)
+
+**Location:** `apps/backend/src/controllers/web/pricing.controller.ts:28-29`
+
+**Issue:** `logger.error("Error getPricing:", err)` passed the entire error object
+to Winston, which could serialize sensitive data if `err` contained request
+context.
+
+**Fix:** Now logs only `message` and `stack` properties:
+
+```ts
+logger.error('Error getPricing:', { message: error.message, stack: error.stack });
+```
+
+---
+
+## Verified Safe (No Action Required)
+
+The following areas were audited and confirmed properly handled:
+
+- **Allowlist validation:** `SUPPORTED_CURRENCIES` Set uses only uppercase ASCII.
+  Unicode tricks via `toUpperCase()` cannot produce "USD", "GBP", or "EUR".
+- **Prototype pollution via `COUNTRY_TO_CURRENCY`:** Map is `Object.freeze()`'d.
+  Keys like `__proto__` return `undefined` and fall through to default.
+- **geoip-country safety:** Local MaxMind database lookup (no network call),
+  wrapped in try/catch. Handles malformed IPs gracefully.
+- **Rate limiting:** Two layers — global 500/15min + endpoint-specific 30/min.
+- **`x-powered-by` disabled** globally.
+- **Express header array handling:** Code checks `typeof raw === "string"`,
+  correctly rejecting duplicate header arrays.
+- **React auto-escaping:** All backend values rendered via JSX text
+  interpolation, not `dangerouslySetInnerHTML`.
+- **Race conditions in usePricing:** Uses `cancelled` flag pattern tied to
+  useEffect cleanup.
+- **FALLBACK_PLANS:** Compile-time constant with hardcoded values, not
+  manipulable at runtime.
+
+---
+
+## Deployment Notes
+
+- **`trust proxy` setting:** Currently set to `1` in `app.ts`. This assumes
+  exactly one reverse proxy in front of the Express server. Verify this matches
+  the production deployment topology. If behind Cloudflare or similar, consider
+  using their proprietary real-IP header.
+- **Production CORS:** The CORS middleware only applies when
+  `LOCAL_DEVELOPMENT` is set. Verify that the production infrastructure (reverse
+  proxy, CDN, or API gateway) handles CORS and includes
+  `X-Preferred-Currency` in `Access-Control-Allow-Headers`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,6 +145,9 @@ importers:
       firebase-admin:
         specifier: ^13.6.0
         version: 13.6.0
+      geoip-country:
+        specifier: ^5.0.202604072353
+        version: 5.0.202604072353
       google-auth-library:
         specifier: ^10.2.0
         version: 10.5.0
@@ -227,6 +230,9 @@ importers:
       '@types/express-rate-limit':
         specifier: ^6.0.2
         version: 6.0.2(express@4.21.2)
+      '@types/geoip-country':
+        specifier: ^5.0.0
+        version: 5.0.0
       '@types/jest':
         specifier: ^29.5.12
         version: 29.5.14
@@ -16797,6 +16803,10 @@ packages:
       '@types/serve-static': 2.2.0
     dev: true
 
+  /@types/geoip-country@5.0.0:
+    resolution: {integrity: sha512-BMlvia5dgLneTyZffXUOUoY3PWrgn13gJFR2YYxqzGrFxHT+DhjLqQwrzY8Y+xU8pX8zwqd+NaNE2CJpVQH3og==}
+    dev: true
+
   /@types/graceful-fs@4.1.9:
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
     dependencies:
@@ -18509,6 +18519,12 @@ packages:
       retry: 0.13.1
     dev: false
     optional: true
+
+  /async@2.6.4:
+    resolution: {integrity: sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==}
+    dependencies:
+      lodash: 4.17.23
+    dev: false
 
   /async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
@@ -20256,6 +20272,10 @@ packages:
       js-yaml: 4.1.1
       parse-json: 5.2.0
       typescript: 5.9.3
+
+  /countries-list@3.3.0:
+    resolution: {integrity: sha512-XRUjS+dcZuNh/fg3+mka3bXgcg4TbQZ1gaK5IJqO6qulerBANl1bmrd20P2dgmPkBpP+5FnejiSF1gd7bgAg+g==}
+    dev: false
 
   /crc-32@1.2.2:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
@@ -23237,6 +23257,16 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  /geoip-country@5.0.202604072353:
+    resolution: {integrity: sha512-fFFR9j6e31U7jPZSyPCdodQu0G7DjnZJsRj3WhOaGFeJe4u7OJtdPNZeeJEqy+vMXyrAvC0MftIQkQ5KxxQChA==}
+    engines: {node: '>=10.20.0'}
+    dependencies:
+      async: 2.6.4
+      countries-list: 3.3.0
+      ip-address: 6.4.0
+      yauzl: 3.2.1
+    dev: false
+
   /get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -24449,6 +24479,19 @@ packages:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
     dev: true
+
+  /ip-address@6.4.0:
+    resolution: {integrity: sha512-c5uxc2WUTuRBVHT/6r4m7HIr/DfV0bF6DvLH3iZGSK8wp8iMwwZSgIq2do0asFf8q9ECug0SE+6+1ACMe4sorA==}
+    engines: {node: '>= 0.10'}
+    dependencies:
+      jsbn: 1.1.0
+      lodash.find: 4.6.0
+      lodash.max: 4.0.1
+      lodash.merge: 4.6.2
+      lodash.padstart: 4.6.1
+      lodash.repeat: 4.1.0
+      sprintf-js: 1.1.2
+    dev: false
 
   /ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -25755,6 +25798,10 @@ packages:
     dependencies:
       argparse: 2.0.1
 
+  /jsbn@1.1.0:
+    resolution: {integrity: sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==}
+    dev: false
+
   /jsc-safe-url@0.2.4:
     resolution: {integrity: sha512-0wM3YBWtYePOjfyXQH5MWQ8H7sdk5EXSwZvmSLKk2RboVQ2Bu239jycHDz5J/8Blf3K0Qnoy2b6xD+z10MFB+Q==}
 
@@ -26330,6 +26377,10 @@ packages:
     resolution: {integrity: sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==}
     dev: false
 
+  /lodash.find@4.6.0:
+    resolution: {integrity: sha512-yaRZoAV3Xq28F1iafWN1+a0rflOej93l1DQUejs3SZ41h2O9UJBoS9aueGjPDgAl4B6tPC0NuuchLKaDQQ3Isg==}
+    dev: false
+
   /lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
     dev: false
@@ -26366,18 +26417,29 @@ packages:
     resolution: {integrity: sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==}
     dev: true
 
+  /lodash.max@4.0.1:
+    resolution: {integrity: sha512-iykTDTb7PK33HSQmKy34zv+hh4WEu7WonJPXQcgODzUbbtradtNs8RsD/GI7XV++60KaKR1xhW56N4ISqHesfQ==}
+    dev: false
+
   /lodash.memoize@4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
 
   /lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
-    dev: true
 
   /lodash.mergewith@4.6.2:
     resolution: {integrity: sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==}
 
   /lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
+    dev: false
+
+  /lodash.padstart@4.6.1:
+    resolution: {integrity: sha512-sW73O6S8+Tg66eY56DBk85aQzzUJDtpoXFBgELMd5P/SotAguo+1kYO6RuYgXxA4HJH3LFTFPASX6ET6bjfriw==}
+    dev: false
+
+  /lodash.repeat@4.1.0:
+    resolution: {integrity: sha512-eWsgQW89IewS95ZOcr15HHCX6FVDxq3f2PNUIng3fyzsPev9imFQxIYdFZ6crl8L56UR6ZlGDLcEb3RZsCSSqw==}
     dev: false
 
   /lodash.snakecase@4.1.1:
@@ -32456,6 +32518,10 @@ packages:
 
   /sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  /sprintf-js@1.1.2:
+    resolution: {integrity: sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==}
+    dev: false
 
   /sqlstring@2.3.3:
     resolution: {integrity: sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==}


### PR DESCRIPTION
## Summary

Add a public `GET /v1/pricing` endpoint that serves plan prices in **USD, GBP, or EUR** based on the visitor's IP (offline `geoip-country` DB), and wire the `/pricing` marketing page to consume it. Detection is **consent-gated** — no network call fires until the user accepts the in-house cookie popup, or explicitly picks a currency from the new switcher. Non-matching countries default to **USD**.

- **Backend** — new `GET /v1/pricing` (public) with IP-based currency detection, allowlist-validated `X-Preferred-Currency` header override, dedicated per-IP rate limiter (30/min) on top of the global limiter, and cache-safe `Cache-Control` / `Vary: X-Preferred-Currency` response headers. Plans + country→currency map live in a new `pricing.constants.ts`.
- **Frontend** — new `consentStore` + `currencyStore` (Zustand), `usePricing` hook gated on consent, accessible `CurrencySwitcher` (`role=\"group\"`, `aria-pressed`, keyboard nav), `PricingSkeleton` loader, USD `FALLBACK_PLANS`. `PricingPage` now reads prices from the backend; `Cookies` widget now flows through `consentStore` instead of touching `localStorage` directly.
- **Docs** — full implementation/architecture/threat-model notes at `docs/guide/geolocation-aware-pricing.md`.

### Security (defense in depth)

1. `X-Preferred-Currency` is allowlist-validated via `SUPPORTED_CURRENCIES.has()` (uppercase-only exact membership; no regex/DB/coercion). Invalid values are silently dropped → IP fallback.
2. `trust proxy: 1` is already configured so `req.ip` is honoured safely.
3. Dedicated 30/min per-IP rate limiter on `/v1/pricing` **on top of** the existing global 500/15min limiter.
4. `Vary: X-Preferred-Currency` prevents CDN cache poisoning across currencies.
5. `Cache-Control: public, max-age=300` for CDN friendliness.
6. **Consent-gated** network call in `usePricing` — no request before GDPR Art. 6 lawful basis.
7. Zero PII stored. Country is derived transiently from `req.ip` per request and immediately discarded.
8. **Offline** geoip DB (`geoip-country`) — no third-party API calls, no cross-border data transfer.
9. GET-only endpoint, no side effects, no cookies required, no CSRF surface.
10. Middleware never throws — malformed headers fall through gracefully.

### API contract

\`\`\`
GET /v1/pricing
Optional header: X-Preferred-Currency: USD | GBP | EUR

→ 200
{
  \"currency\": \"EUR\",
  \"currencySymbol\": \"€\",
  \"source\": \"override\" | \"ip\" | \"default\",
  \"plans\": [ { \"id\": \"free\", \"amount\": 0, \"amountYearly\": 0, ... }, ... ]
}
Response headers: Cache-Control: public, max-age=300 / Vary: X-Preferred-Currency
\`\`\`

### Impact area

- `apps/backend` — new public endpoint, no touches to existing controllers or DB models
- `apps/frontend` — pricing page behaviour change (prices now dynamic), cookies widget refactored to use Zustand
- Shared: new dependency `geoip-country` + `@types/geoip-country`

### Validation performed

- `npx tsc --noemit` in `apps/frontend` → **0 errors**
- `pnpm --filter frontend run lint` → **clean**
- Backend `pnpm type-check` on the 9 new/modified backend files → **clean** (pre-existing type errors in unrelated services are unchanged)
- `pnpm --filter backend run lint` → **clean**
- `jest --testPathPattern=\"PricingPage\"` → **2/2 pass**
- `jest --testPathPattern=\"Cookies\"` → **5/5 pass**
- `jest --testPathPattern=\"axios\"` → **21/21 pass**
- `jest --testPathPattern=\"stores\"` → **368/368 pass**
- Dev server boot + `curl http://localhost:3003/pricing` → **HTTP 200**, response contains \`Price in USD\` label and 3 \`aria-pressed\` switcher buttons

## Test plan

- [ ] Pull the branch, run \`pnpm --filter frontend run dev\` and \`pnpm --filter backend run dev\`
- [ ] Open `/pricing` in a clean incognito window — cookie popup visible, prices show in USD (fallback, no network call made)
- [ ] Click **Accept** — Network tab shows a single `GET /v1/pricing` request (no `X-Preferred-Currency` header); on localhost `source: \"default\"` is expected
- [ ] Click **GBP** on the currency switcher — new `GET /v1/pricing` with `X-Preferred-Currency: GBP`; prices flip to £, `Price in GBP` label updates
- [ ] Reload — GBP preference persists via `localStorage.currency-store`
- [ ] `curl -i -H 'X-Preferred-Currency: HACK' http://localhost:4000/v1/pricing` → invalid header ignored, falls back to IP/default
- [ ] `curl -i -H 'X-Preferred-Currency: eur' http://localhost:4000/v1/pricing` → case-insensitive, returns EUR
- [ ] `for i in {1..40}; do curl -s -o /dev/null -w \"%{http_code} \" http://localhost:4000/v1/pricing; done` → expect \`429\` after 30 requests
- [ ] Response headers include `Vary: X-Preferred-Currency` and `Cache-Control: public, max-age=300`
- [ ] Keyboard-navigate through the currency switcher with Tab/Space → `aria-pressed` state updates correctly
- [ ] Revoke consent (\`localStorage.removeItem('cookieConsentGiven')\`), reload → no `/v1/pricing` request until consent granted again


https://github.com/user-attachments/assets/5a2e7611-9302-4682-9a3b-8e90e2079275

