### PR TITLE
fix(frontend): reduce image loading shift on marketing pages

### DIFF
--- a/apps/frontend/src/app/features/marketing/components/LandingPage/LandingCard.tsx
+++ b/apps/frontend/src/app/features/marketing/components/LandingPage/LandingCard.tsx
@@ -27,7 +27,14 @@ const LandingCard = ({ item }: { item: InfoCard }) => {
             </div>
           </div>
           <TextFade direction="up" className="RightLanding">
-            <Image aria-hidden src={item.image} alt="landingimg1" width={884} height={600} />
+            <Image
+              aria-hidden
+              src={item.image}
+              alt="landingimg1"
+              width={884}
+              height={600}
+              sizes="(max-width: 1280px) 100vw, 60vw"
+            />
           </TextFade>
         </div>
       </div>

--- a/apps/frontend/src/app/features/marketing/pages/HomePage/FeatureBox/FeatureBox.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/HomePage/FeatureBox/FeatureBox.tsx
@@ -1,7 +1,7 @@
-import React from "react";
-import Image from "next/image";
+import React from 'react';
+import Image from 'next/image';
 
-import "./FeatureBox.css";
+import './FeatureBox.css';
 
 interface BoxPractProps {
   Bpimg: string;
@@ -13,7 +13,7 @@ interface BoxPractProps {
 const FeatureBox = ({ Bpimg, BpTxt1, BpTxt2, BpPara }: BoxPractProps) => {
   return (
     <div className="PracBox">
-      <Image aria-hidden src={Bpimg} alt="Hero" width={72} height={72} />
+      <Image aria-hidden src={Bpimg} alt="Hero" width={72} height={72} sizes="72px" />
       <div className="text-heading-2 text-text-primary pracTitle">
         {BpTxt1} {BpTxt2}
       </div>

--- a/apps/frontend/src/app/features/marketing/pages/HomePage/FocusCard/FocusCard.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/HomePage/FocusCard/FocusCard.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image';
-import React from 'react'
+import React from 'react';
 
-import './FocusCard.css'
+import './FocusCard.css';
 
 interface FocusCardProps {
   Focimg: string;
@@ -12,7 +12,7 @@ interface FocusCardProps {
 const FocusCard: React.FC<FocusCardProps> = ({ Focimg, focname, focpara }) => {
   return (
     <div className="FocusItem">
-      <Image aria-hidden src={Focimg} alt="Hero" width={110} height={110} />
+      <Image aria-hidden src={Focimg} alt="Hero" width={110} height={110} sizes="110px" />
       <div className="focusText">
         <div className="text-heading-2 text-text-primary focusTitle">{focname}</div>
         <div className="text-body-4 text-text-secondary focusDesc">{focpara}</div>
@@ -21,4 +21,4 @@ const FocusCard: React.FC<FocusCardProps> = ({ Focimg, focname, focpara }) => {
   );
 };
 
-export default FocusCard
+export default FocusCard;

--- a/apps/frontend/src/app/features/marketing/pages/HomePage/HomePage.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/HomePage/HomePage.tsx
@@ -68,6 +68,8 @@ const HomePage = () => {
                 alt="Hero"
                 width={733}
                 height={564}
+                priority
+                sizes="(max-width: 1024px) 100vw, 55vw"
               />
             </div>
           </div>
@@ -276,6 +278,7 @@ const HomePage = () => {
                 alt="betterimg"
                 width={507}
                 height={433}
+                sizes="(max-width: 1024px) 100vw, 45vw"
               />
             </div>
           </div>

--- a/apps/frontend/src/app/features/marketing/pages/LandingPage.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/LandingPage.tsx
@@ -77,6 +77,8 @@ const NewHeroSection = () => {
           alt="Dog"
           width={200}
           height={200}
+          priority
+          sizes="(max-width: 768px) 9.6vw, 8vw"
           style={{ objectFit: 'contain' }}
         />
       </motion.div>
@@ -93,6 +95,7 @@ const NewHeroSection = () => {
           alt="Horse"
           width={250}
           height={250}
+          sizes="(max-width: 768px) 27.5vw, 25vw"
           style={{ objectFit: 'contain' }}
           priority
         />
@@ -147,7 +150,13 @@ const OldHeroSection = ({
             {SlidesData.map((slide) => (
               <Carousel.Item key={slide.id}>
                 <div className="LandingCarouselDiv">
-                  <Image src={slide.image} alt={slide.alt} width={887} height={565} />
+                  <Image
+                    src={slide.image}
+                    alt={slide.alt}
+                    width={887}
+                    height={565}
+                    sizes="(max-width: 768px) 100vw, 50vw"
+                  />
                   <div className="carousel-text">
                     <div className="text-heading-1 text-text-primary">{slide.text}</div>
                   </div>

--- a/apps/frontend/src/app/features/marketing/pages/PetOwner/PetOwner.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/PetOwner/PetOwner.tsx
@@ -34,6 +34,7 @@ const PetOwner = () => {
                 quality={100}
                 src={MEDIA_SOURCES.petOwner.hero}
                 priority
+                sizes="(max-width: 1024px) 100vw, 50vw"
               />
             </div>
           </div>
@@ -130,6 +131,7 @@ const PetOwner = () => {
                   alt="glimpsimg"
                   width={1291}
                   height={917}
+                  sizes="(max-width: 768px) 100vw, 85vw"
                 />
               </div>
             </div>
@@ -159,6 +161,7 @@ const PetOwner = () => {
                   alt="petapppic"
                   width={569}
                   height={569}
+                  sizes="(max-width: 1024px) 100vw, 35vw"
                 />
               </div>
             </div>


### PR DESCRIPTION
<!--
We, the rest of the Yosemite community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?
The marketing pages load several large images without strong sizing hints, which can cause slower perceived loading and layout shift as the browser discovers the correct image sizes.

## What is the new behavior?
This PR adds responsive `sizes` hints and `priority` to the most visible marketing images so the browser can select more appropriate assets earlier and reserve space more predictably.

The affected surfaces include:
- Home page hero and secondary imagery
- Landing page hero imagery and carousel fallback image
- Reusable landing cards
- Feature and focus cards
- Pet owner landing page imagery

## Related Issue(s)
Fixes #1160

<!-- If this PR contains a breaking change, please describe the impact for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]
-->
