### PR TITLE
feat(mobile): add recurring task save/delete flows and map discovery …

### DIFF
--- a/apps/mobileAppYC/__tests__/features/appointments/components/__snapshots__/ClinicMapPin.test.tsx.snap
+++ b/apps/mobileAppYC/__tests__/features/appointments/components/__snapshots__/ClinicMapPin.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`ClinicMapPin snapshot matches for selected state 1`] = `
 <View
+  collapsable={false}
   style={
     [
       {
@@ -99,6 +100,7 @@ exports[`ClinicMapPin snapshot matches for selected state 1`] = `
 
 exports[`ClinicMapPin snapshot matches for unselected state 1`] = `
 <View
+  collapsable={false}
   style={
     [
       {

--- a/apps/mobileAppYC/__tests__/features/tasks/components/TaskRecurringActionSheet/TaskRecurringActionSheet.test.tsx
+++ b/apps/mobileAppYC/__tests__/features/tasks/components/TaskRecurringActionSheet/TaskRecurringActionSheet.test.tsx
@@ -1,0 +1,205 @@
+import React from 'react';
+import {render, fireEvent, waitFor, act} from '@testing-library/react-native';
+import {mockTheme} from '../../../../setup/mockTheme';
+import {
+  TaskRecurringActionSheet,
+  type TaskRecurringActionSheetRef,
+} from '../../../../../src/features/tasks/components/TaskRecurringActionSheet/TaskRecurringActionSheet';
+
+// --- Mocks ---
+
+jest.mock('@/hooks', () => ({
+  useTheme: () => ({theme: mockTheme, isDark: false}),
+}));
+
+const mockSnapToIndex = jest.fn();
+const mockClose = jest.fn();
+
+jest.mock('@/shared/components/common/BottomSheet/BottomSheet', () => {
+  const {forwardRef, useImperativeHandle} = require('react');
+  return forwardRef(({children}: any, ref: any) => {
+    const {View} = require('react-native');
+    useImperativeHandle(ref, () => ({
+      snapToIndex: mockSnapToIndex,
+      close: mockClose,
+    }));
+    return <View testID="bottom-sheet">{children}</View>;
+  });
+});
+
+jest.mock(
+  '@/shared/components/common/BottomSheetHeader/BottomSheetHeader',
+  () => ({
+    BottomSheetHeader: ({title, onClose}: any) => {
+      const {TouchableOpacity, Text, View} = require('react-native');
+      return (
+        <View>
+          <Text testID="sheet-title">{title}</Text>
+          <TouchableOpacity testID="close-btn" onPress={onClose}>
+            <Text>Close</Text>
+          </TouchableOpacity>
+        </View>
+      );
+    },
+  }),
+);
+
+jest.mock(
+  '@/shared/components/common/LiquidGlassButton/LiquidGlassButton',
+  () =>
+    ({title, onPress, disabled, loading, testID}: any) => {
+      const {TouchableOpacity, Text} = require('react-native');
+      return (
+        <TouchableOpacity
+          testID={testID ?? `btn-${title}`}
+          onPress={onPress}
+          disabled={disabled}>
+          <Text>{loading ? 'loading' : title}</Text>
+        </TouchableOpacity>
+      );
+    },
+);
+
+// --- Helpers ---
+
+const defaultProps = {
+  title: 'Test Action',
+  message: 'Choose an option',
+  primaryLabel: 'Primary',
+  primaryLoadingLabel: 'Primary loading...',
+  onPrimary: jest.fn(),
+  secondaryLabel: 'Secondary',
+  secondaryLoadingLabel: 'Secondary loading...',
+  onSecondary: jest.fn(),
+  onCancel: jest.fn(),
+};
+
+const renderSheet = (props = {}) =>
+  render(<TaskRecurringActionSheet {...defaultProps} {...props} />);
+
+// --- Tests ---
+
+describe('TaskRecurringActionSheet', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSnapToIndex.mockClear();
+    mockClose.mockClear();
+  });
+
+  it('renders title and message', () => {
+    const {getByTestId, getByText} = renderSheet();
+    expect(getByTestId('sheet-title').props.children).toBe('Test Action');
+    expect(getByText('Choose an option')).toBeTruthy();
+  });
+
+  it('renders without message when not provided', () => {
+    const {queryByText} = renderSheet({message: undefined});
+    expect(queryByText('Choose an option')).toBeNull();
+  });
+
+  it('renders primary and secondary buttons with correct labels', () => {
+    const {getByText} = renderSheet();
+    expect(getByText('Primary')).toBeTruthy();
+    expect(getByText('Secondary')).toBeTruthy();
+    expect(getByText('Cancel')).toBeTruthy();
+  });
+
+  it('calls onPrimary when primary button pressed', async () => {
+    const onPrimary = jest.fn().mockResolvedValue(undefined);
+    const {getByText} = renderSheet({onPrimary});
+
+    await act(async () => {
+      fireEvent.press(getByText('Primary'));
+    });
+
+    expect(onPrimary).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onSecondary when secondary button pressed', async () => {
+    const onSecondary = jest.fn().mockResolvedValue(undefined);
+    const {getByText} = renderSheet({onSecondary});
+
+    await act(async () => {
+      fireEvent.press(getByText('Secondary'));
+    });
+
+    expect(onSecondary).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCancel when close button pressed', () => {
+    const onCancel = jest.fn();
+    const {getByTestId} = renderSheet({onCancel});
+
+    fireEvent.press(getByTestId('close-btn'));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCancel when Cancel button pressed', () => {
+    const onCancel = jest.fn();
+    const {getByText} = renderSheet({onCancel});
+
+    fireEvent.press(getByText('Cancel'));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw when onCancel is not provided and close is pressed', () => {
+    const {getByTestId} = renderSheet({onCancel: undefined});
+    expect(() => fireEvent.press(getByTestId('close-btn'))).not.toThrow();
+  });
+
+  it('handles primary action error gracefully', async () => {
+    const error = new Error('Primary failed');
+    const onPrimary = jest.fn().mockRejectedValue(error);
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const {getByText} = renderSheet({onPrimary});
+
+    await act(async () => {
+      fireEvent.press(getByText('Primary'));
+    });
+
+    await waitFor(() => {
+      expect(errorSpy).toHaveBeenCalledWith(
+        '[TaskRecurringActionSheet] Primary action error:',
+        error,
+      );
+    });
+
+    errorSpy.mockRestore();
+  });
+
+  it('handles secondary action error gracefully', async () => {
+    const error = new Error('Secondary failed');
+    const onSecondary = jest.fn().mockRejectedValue(error);
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const {getByText} = renderSheet({onSecondary});
+
+    await act(async () => {
+      fireEvent.press(getByText('Secondary'));
+    });
+
+    await waitFor(() => {
+      expect(errorSpy).toHaveBeenCalledWith(
+        '[TaskRecurringActionSheet] Secondary action error:',
+        error,
+      );
+    });
+
+    errorSpy.mockRestore();
+  });
+
+  it('exposes open and close via ref', () => {
+    const ref = React.createRef<TaskRecurringActionSheetRef>();
+    render(<TaskRecurringActionSheet {...defaultProps} ref={ref} />);
+
+    expect(ref.current).toBeDefined();
+    expect(typeof ref.current?.open).toBe('function');
+    expect(typeof ref.current?.close).toBe('function');
+
+    expect(() => ref.current?.open()).not.toThrow();
+    expect(() => ref.current?.close()).not.toThrow();
+  });
+});

--- a/apps/mobileAppYC/__tests__/features/tasks/hooks/useEditTaskScreen.test.ts
+++ b/apps/mobileAppYC/__tests__/features/tasks/hooks/useEditTaskScreen.test.ts
@@ -43,12 +43,12 @@ jest.mock('../../../../src/features/tasks/hooks/useScreenHandlers', () => ({
 
 describe('useEditTaskScreen', () => {
   const mockTaskId = 'task-123';
-  const mockNavigation = { navigate: jest.fn() };
+  const mockNavigation = {navigate: jest.fn()};
 
   // Default mock returns
-  const mockDeleteSheetRef = { current: { open: jest.fn() } };
+  const mockDeleteSheetRef = {current: {open: jest.fn()}};
   const mockFormSetup = {
-    formData: { title: '' },
+    formData: {title: ''},
     hasUnsavedChanges: false,
     setFormData: jest.fn(),
     setErrors: jest.fn(),
@@ -70,28 +70,34 @@ describe('useEditTaskScreen', () => {
   };
 
   const mockTask = {
-      id: 'task-123',
-      companionId: 'comp-1',
-      title: 'Test Task'
+    id: 'task-123',
+    companionId: 'comp-1',
+    title: 'Test Task',
   };
 
   const mockState = {
-    tasks: { loading: false },
+    tasks: {loading: false},
     companion: {
-        companions: [
-            { id: 'comp-1', category: 'cat' },
-            { id: 'comp-2', category: 'dog' }
-        ]
-    }
+      companions: [
+        {id: 'comp-1', category: 'cat'},
+        {id: 'comp-2', category: 'dog'},
+      ],
+    },
   };
 
   beforeEach(() => {
     jest.clearAllMocks();
 
     // Setup default mock implementations
-    (TaskFormSetup.useTaskFormSetup as jest.Mock).mockReturnValue(mockFormSetup);
-    (UseTaskFormHelpers.useTaskFormHelpers as jest.Mock).mockReturnValue(mockTaskFormHelpers);
-    (ScreenHandlers.useScreenHandlers as jest.Mock).mockReturnValue(mockScreenHandlers);
+    (TaskFormSetup.useTaskFormSetup as jest.Mock).mockReturnValue(
+      mockFormSetup,
+    );
+    (UseTaskFormHelpers.useTaskFormHelpers as jest.Mock).mockReturnValue(
+      mockTaskFormHelpers,
+    );
+    (ScreenHandlers.useScreenHandlers as jest.Mock).mockReturnValue(
+      mockScreenHandlers,
+    );
 
     // Default task selector behavior (returns a task)
     mockSelectTaskById.mockReturnValue(mockTask);
@@ -102,88 +108,114 @@ describe('useEditTaskScreen', () => {
 
   describe('Initialization & Side Effects', () => {
     it('initializes form data when task is found', () => {
-      const mockInitialData = { title: 'Initialized Title' };
-      (TaskInitialization.initializeFormDataFromTask as jest.Mock).mockReturnValue(mockInitialData);
+      const mockInitialData = {title: 'Initialized Title'};
+      (
+        TaskInitialization.initializeFormDataFromTask as jest.Mock
+      ).mockReturnValue(mockInitialData);
 
       renderHook(() => useEditTaskScreen(mockTaskId, mockNavigation));
 
-      expect(TaskInitialization.initializeFormDataFromTask).toHaveBeenCalledWith(mockTask);
+      expect(
+        TaskInitialization.initializeFormDataFromTask,
+      ).toHaveBeenCalledWith(mockTask);
       expect(mockFormSetup.setFormData).toHaveBeenCalledWith(mockInitialData);
       expect(mockFormSetup.setErrors).toHaveBeenCalledWith({});
     });
 
     it('does not initialize form data if task is not found (Branch coverage)', () => {
-        // Simulate task not found in store
-        mockSelectTaskById.mockReturnValue(undefined);
+      // Simulate task not found in store
+      mockSelectTaskById.mockReturnValue(undefined);
 
-        renderHook(() => useEditTaskScreen(mockTaskId, mockNavigation));
+      renderHook(() => useEditTaskScreen(mockTaskId, mockNavigation));
 
-        expect(TaskInitialization.initializeFormDataFromTask).not.toHaveBeenCalled();
-        expect(mockFormSetup.setFormData).not.toHaveBeenCalled();
+      expect(
+        TaskInitialization.initializeFormDataFromTask,
+      ).not.toHaveBeenCalled();
+      expect(mockFormSetup.setFormData).not.toHaveBeenCalled();
     });
   });
 
   describe('Selectors & Derived State', () => {
-      it('returns task, loading status, and companions', () => {
-          const { result } = renderHook(() => useEditTaskScreen(mockTaskId, mockNavigation));
+    it('returns task, loading status, and companions', () => {
+      const {result} = renderHook(() =>
+        useEditTaskScreen(mockTaskId, mockNavigation),
+      );
 
-          expect(result.current.task).toEqual(mockTask);
-          expect(result.current.loading).toBe(false);
-          expect(result.current.companions).toEqual(mockState.companion.companions);
-      });
+      expect(result.current.task).toEqual(mockTask);
+      expect(result.current.loading).toBe(false);
+      expect(result.current.companions).toEqual(mockState.companion.companions);
+    });
 
-      it('determines companion type correctly when companion exists', () => {
-          const { result } = renderHook(() => useEditTaskScreen(mockTaskId, mockNavigation));
-          // Task has comp-1, which is a cat in mockState
-          expect(result.current.companionType).toBe('cat');
-      });
+    it('determines companion type correctly when companion exists', () => {
+      const {result} = renderHook(() =>
+        useEditTaskScreen(mockTaskId, mockNavigation),
+      );
+      // Task has comp-1, which is a cat in mockState
+      expect(result.current.companionType).toBe('cat');
+    });
 
-      it('defaults companion type to "dog" if companion is not found (Branch coverage)', () => {
-          // Task points to non-existent companion
-          const orphanTask = { ...mockTask, companionId: 'unknown' };
-          mockSelectTaskById.mockReturnValue(orphanTask);
+    it('defaults companion type to "dog" if companion is not found (Branch coverage)', () => {
+      // Task points to non-existent companion
+      const orphanTask = {...mockTask, companionId: 'unknown'};
+      mockSelectTaskById.mockReturnValue(orphanTask);
 
-          const { result } = renderHook(() => useEditTaskScreen(mockTaskId, mockNavigation));
-          expect(result.current.companionType).toBe('dog');
-      });
+      const {result} = renderHook(() =>
+        useEditTaskScreen(mockTaskId, mockNavigation),
+      );
+      expect(result.current.companionType).toBe('dog');
+    });
 
-      it('defaults companion type to "dog" if companions list is missing/null', () => {
-           mockUseSelector.mockImplementation((cb: any) => cb({
-               tasks: { loading: false },
-               companion: { companions: null } // Simulate missing state
-           }));
+    it('defaults companion type to "dog" if companions list is missing/null', () => {
+      mockUseSelector.mockImplementation((cb: any) =>
+        cb({
+          tasks: {loading: false},
+          companion: {companions: null}, // Simulate missing state
+        }),
+      );
 
-           const { result } = renderHook(() => useEditTaskScreen(mockTaskId, mockNavigation));
-           expect(result.current.companionType).toBe('dog');
-      });
+      const {result} = renderHook(() =>
+        useEditTaskScreen(mockTaskId, mockNavigation),
+      );
+      expect(result.current.companionType).toBe('dog');
+    });
   });
 
   describe('Handlers', () => {
-      it('handleDelete opens the delete sheet', () => {
-          const { result } = renderHook(() => useEditTaskScreen(mockTaskId, mockNavigation));
+    it('handleDelete opens the delete sheet', () => {
+      const {result} = renderHook(() =>
+        useEditTaskScreen(mockTaskId, mockNavigation),
+      );
 
-          act(() => {
-              result.current.handleDelete();
-          });
+      const mockOpen = jest.fn();
+      result.current.taskDeleteSheetRef.current = {
+        open: mockOpen,
+        close: jest.fn(),
+      };
 
-          expect(mockDeleteSheetRef.current.open).toHaveBeenCalled();
+      act(() => {
+        result.current.handleDelete();
       });
 
-      it('handleDelete handles missing delete sheet ref gracefully (Branch coverage)', () => {
-          // Simulate ref not being attached
-          const noRefSetup = { ...mockFormSetup, deleteSheetRef: { current: null } };
-          (TaskFormSetup.useTaskFormSetup as jest.Mock).mockReturnValue(noRefSetup);
-      });
+      expect(mockOpen).toHaveBeenCalled();
+    });
 
-      it('passes through screen handler methods', () => {
-          const { result } = renderHook(() => useEditTaskScreen(mockTaskId, mockNavigation));
+    it('handleDelete handles missing delete sheet ref gracefully (Branch coverage)', () => {
+      // Simulate ref not being attached
+      const noRefSetup = {...mockFormSetup, deleteSheetRef: {current: null}};
+      (TaskFormSetup.useTaskFormSetup as jest.Mock).mockReturnValue(noRefSetup);
+    });
 
-          // Call to verify pass-through
-          result.current.handleBack();
-          expect(mockScreenHandlers.handleBack).toHaveBeenCalled();
+    it('passes through screen handler methods', () => {
+      const {result} = renderHook(() =>
+        useEditTaskScreen(mockTaskId, mockNavigation),
+      );
 
-          result.current.validateForm();
-          expect(mockScreenHandlers.validateForm).toHaveBeenCalled();
-      });
+      // Call to verify pass-through
+      result.current.handleBack();
+      expect(mockScreenHandlers.handleBack).toHaveBeenCalled();
+
+      result.current.validateForm();
+      expect(mockScreenHandlers.validateForm).toHaveBeenCalled();
+    });
   });
 });

--- a/apps/mobileAppYC/__tests__/features/tasks/screens/EditTaskScreen/EditTaskScreen.test.tsx
+++ b/apps/mobileAppYC/__tests__/features/tasks/screens/EditTaskScreen/EditTaskScreen.test.tsx
@@ -71,7 +71,12 @@ jest.mock('@/assets/images', () => ({
 // 4. Feature Hooks & Utils
 // Important: Mock the custom hook that drives this screen
 const mockHookData = {
-  task: {id: 't1', title: 'Existing Task', companionId: 'c1'},
+  task: {
+    id: 't1',
+    title: 'Existing Task',
+    companionId: 'c1',
+    frequency: 'once' as string,
+  },
   loading: false,
   companions: [{id: 'c1', name: 'Buddy', category: 'dog'}],
   companionType: 'dog',
@@ -89,6 +94,8 @@ const mockHookData = {
   handleRemoveFile: jest.fn(),
   openSheet: jest.fn(),
   deleteSheetRef: {current: null},
+  taskDeleteSheetRef: {current: null},
+  taskSaveSheetRef: {current: null},
 };
 
 jest.mock('../../../../../src/features/tasks/hooks/useEditTaskScreen', () => ({
@@ -211,16 +218,43 @@ jest.mock(
   () => ({
     DeleteDocumentBottomSheet: ({onDelete, title}: any) => {
       const {TouchableOpacity, Text, View} = require('react-native');
-      // Render a button to simulate the delete confirmation
       return (
         <View>
           <Text>{title}</Text>
-          <TouchableOpacity testID="confirm-delete-btn" onPress={onDelete}>
+          <TouchableOpacity onPress={onDelete}>
             <Text>Confirm Delete</Text>
           </TouchableOpacity>
         </View>
       );
     },
+  }),
+);
+
+jest.mock(
+  '@/features/tasks/components/TaskDeleteBottomSheet/TaskDeleteBottomSheet',
+  () => ({
+    TaskDeleteBottomSheet: require('react').forwardRef(
+      ({onDeleteAll, taskTitle}: any, _ref: any) => {
+        const {TouchableOpacity, Text, View} = require('react-native');
+        return (
+          <View>
+            <Text>{taskTitle}</Text>
+            <TouchableOpacity testID="confirm-delete-btn" onPress={onDeleteAll}>
+              <Text>Confirm Delete</Text>
+            </TouchableOpacity>
+          </View>
+        );
+      },
+    ),
+  }),
+);
+
+jest.mock(
+  '@/features/tasks/components/TaskSaveOptionsBottomSheet/TaskSaveOptionsBottomSheet',
+  () => ({
+    TaskSaveOptionsBottomSheet: require('react').forwardRef(
+      (_props: any, _ref: any) => null,
+    ),
   }),
 );
 
@@ -258,7 +292,12 @@ describe('EditTaskScreen', () => {
 
     // Reset hook data to defaults
     Object.assign(mockHookData, {
-      task: {id: 't1', title: 'Existing Task', companionId: 'c1'},
+      task: {
+        id: 't1',
+        title: 'Existing Task',
+        companionId: 'c1',
+        frequency: 'once',
+      },
       loading: false,
       companions: [{id: 'c1', name: 'Buddy', category: 'dog'}],
       companionType: 'dog',
@@ -271,6 +310,8 @@ describe('EditTaskScreen', () => {
       validateForm: jest.fn(() => true),
       handleDelete: jest.fn(),
       showErrorAlert: jest.fn(),
+      taskDeleteSheetRef: {current: null},
+      taskSaveSheetRef: {current: null},
     });
 
     // Reset route params
@@ -359,9 +400,13 @@ describe('EditTaskScreen', () => {
 
     fireEvent.press(getByTestId('save-btn'));
 
-    expect(mockHookData.validateForm).toHaveBeenCalledWith(mockHookData.formData);
+    expect(mockHookData.validateForm).toHaveBeenCalledWith(
+      mockHookData.formData,
+    );
     const {updateTask} = require('@/features/tasks');
-    const {buildTaskDraftFromForm} = require('@/features/tasks/services/taskService');
+    const {
+      buildTaskDraftFromForm,
+    } = require('@/features/tasks/services/taskService');
 
     // Wait for async action to complete and navigation to be triggered
     await waitFor(() => {

--- a/apps/mobileAppYC/__tests__/features/tasks/screens/EditTaskScreen/EditTaskScreen.test.tsx
+++ b/apps/mobileAppYC/__tests__/features/tasks/screens/EditTaskScreen/EditTaskScreen.test.tsx
@@ -371,10 +371,34 @@ describe('EditTaskScreen', () => {
     expect(mockGoBack).toHaveBeenCalled();
   });
 
-  it('handles delete button press via hook', () => {
+  it('directly deletes when delete pressed on a once task', async () => {
     const {getByTestId} = render(<EditTaskScreen />);
     fireEvent.press(getByTestId('header-delete-btn'));
-    expect(mockHookData.handleDelete).toHaveBeenCalled();
+
+    const {deleteTask} = require('@/features/tasks');
+    await waitFor(() => {
+      expect(deleteTask).toHaveBeenCalledWith({
+        taskId: 't1',
+        companionId: 'c1',
+      });
+    });
+  });
+
+  it('opens delete sheet when delete pressed on a recurring task', () => {
+    const mockOpen = jest.fn();
+    Object.assign(mockHookData, {
+      task: {
+        id: 't1',
+        title: 'Existing Task',
+        companionId: 'c1',
+        frequency: 'daily',
+      },
+      taskDeleteSheetRef: {current: {open: mockOpen, close: jest.fn()}},
+    });
+
+    const {getByTestId} = render(<EditTaskScreen />);
+    fireEvent.press(getByTestId('header-delete-btn'));
+    expect(mockOpen).toHaveBeenCalled();
   });
 
   it('handles delete confirmation success', async () => {

--- a/apps/mobileAppYC/__tests__/store.test.ts
+++ b/apps/mobileAppYC/__tests__/store.test.ts
@@ -6,8 +6,7 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
   removeItem: jest.fn(),
 }));
 
-
-const capturedConfig: { persistConfig: any } = { persistConfig: null };
+const capturedConfig: {persistConfig: any} = {persistConfig: null};
 
 jest.mock('redux-persist', () => {
   const actual = jest.requireActual('redux-persist');
@@ -18,23 +17,23 @@ jest.mock('redux-persist', () => {
       return actual.persistReducer(config, reducer);
     }),
     persistStore: jest.fn(() => ({
-        purge: jest.fn(),
-        flush: jest.fn(),
-        dispatch: jest.fn(),
-        getState: jest.fn(),
-        subscribe: jest.fn(),
+      purge: jest.fn(),
+      flush: jest.fn(),
+      dispatch: jest.fn(),
+      getState: jest.fn(),
+      subscribe: jest.fn(),
     })),
   };
 });
 
 // Mock Redux Toolkit to capture the middleware configuration function
-const capturedToolkit: { middlewareBuilder: any } = { middlewareBuilder: null };
+const capturedToolkit: {middlewareBuilder: any} = {middlewareBuilder: null};
 
 jest.mock('@reduxjs/toolkit', () => {
   const actual = jest.requireActual('@reduxjs/toolkit');
   return {
     ...actual,
-    configureStore: jest.fn((options) => {
+    configureStore: jest.fn(options => {
       capturedToolkit.middlewareBuilder = options.middleware; // CAPTURE MIDDLEWARE SETUP
       return actual.configureStore(options);
     }),
@@ -46,7 +45,6 @@ jest.mock('@reduxjs/toolkit', () => {
 import {store, persistor} from '../src/app/store';
 
 describe('Redux Store', () => {
-
   afterEach(() => {
     consoleSpy.mockClear();
   });
@@ -75,7 +73,7 @@ describe('Redux Store', () => {
     const config = capturedConfig.persistConfig;
     expect(config).toBeDefined();
     expect(config.key).toBe('root');
-    expect(config.version).toBe(5);
+    expect(config.version).toBe(6);
     expect(config.whitelist).toContain('auth');
     expect(config.whitelist).toContain('notifications');
   });
@@ -119,7 +117,10 @@ describe('Redux Store', () => {
     });
 
     it('implements multiSet and multiGet', async () => {
-      await mockStorage.multiSet([['mk1', 'mv1'], ['mk2', 'mv2']]);
+      await mockStorage.multiSet([
+        ['mk1', 'mv1'],
+        ['mk2', 'mv2'],
+      ]);
       const values = await mockStorage.multiGet(['mk1', 'mk2', 'missing']);
       expect(values).toEqual([
         ['mk1', 'mv1'],
@@ -143,8 +144,8 @@ describe('Redux Store', () => {
     const runMigrate = async (version: number | undefined, state: any) => {
       const migrate = capturedConfig.persistConfig.migrate;
       const persistedState = {
-        _persist: { version },
-        ...state
+        _persist: {version},
+        ...state,
       };
       return await migrate(persistedState);
     };
@@ -152,20 +153,24 @@ describe('Redux Store', () => {
     it('handles v1 -> v2 migration', async () => {
       await runMigrate(1, {});
       expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Migrating from v1 to v2')
+        expect.stringContaining('Migrating from v1 to v2'),
       );
     });
 
     it('handles v2 -> v3 migration (resets businesses)', async () => {
-      const oldState = { businesses: { someOldData: true } };
+      const oldState = {businesses: {someOldData: true}};
       const newState = await runMigrate(2, oldState);
 
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Migrating from v2 to v3'));
-      expect(newState.businesses).toEqual(expect.objectContaining({
-        businesses: [],
-        employees: [],
-        loading: false
-      }));
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Migrating from v2 to v3'),
+      );
+      expect(newState.businesses).toEqual(
+        expect.objectContaining({
+          businesses: [],
+          employees: [],
+          loading: false,
+        }),
+      );
     });
 
     it('handles v2 -> v3 migration (no businesses slice)', async () => {
@@ -176,39 +181,45 @@ describe('Redux Store', () => {
     it('handles v3 -> v4 migration (inits notifications)', async () => {
       const newState = await runMigrate(3, {});
 
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Migrating from v3 to v4'));
-      expect(newState.notifications).toEqual(expect.objectContaining({
-        items: [],
-        unreadCount: 0,
-        filter: 'all'
-      }));
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Migrating from v3 to v4'),
+      );
+      expect(newState.notifications).toEqual(
+        expect.objectContaining({
+          items: [],
+          unreadCount: 0,
+          filter: 'all',
+        }),
+      );
     });
 
     it('handles v3 -> v4 migration (skips if notifications exist)', async () => {
-      const oldState = { notifications: { existing: true } };
+      const oldState = {notifications: {existing: true}};
       const newState = await runMigrate(3, oldState);
-      expect(newState.notifications).toEqual({ existing: true });
+      expect(newState.notifications).toEqual({existing: true});
     });
 
     it('handles v4 -> v5 migration (inits services)', async () => {
-      const oldState = { businesses: { businesses: [] } };
+      const oldState = {businesses: {businesses: []}};
       const newState = await runMigrate(4, oldState);
 
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Migrating from v4 to v5'));
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Migrating from v4 to v5'),
+      );
       expect(newState.businesses.services).toEqual([]);
     });
 
     it('handles v4 -> v5 migration (skips if services exist)', async () => {
-      const oldState = { businesses: { services: ['exists'] } };
+      const oldState = {businesses: {services: ['exists']}};
       const newState = await runMigrate(4, oldState);
       expect(newState.businesses.services).toEqual(['exists']);
     });
 
     it('handles non-matching versions gracefully', async () => {
-        // Just ensures it returns the state promise
-        const state = { foo: 'bar' };
-        const result = await runMigrate(99, state);
-        expect(result).toEqual(expect.objectContaining({ foo: 'bar' }));
+      // Just ensures it returns the state promise
+      const state = {foo: 'bar'};
+      const result = await runMigrate(99, state);
+      expect(result).toEqual(expect.objectContaining({foo: 'bar'}));
     });
   });
 });

--- a/apps/mobileAppYC/src/app/store.ts
+++ b/apps/mobileAppYC/src/app/store.ts
@@ -14,7 +14,8 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 // Under Jest worker processes some imports can run before test setup mocks are applied
 // and redux-persist expects a storage with Promise-returning methods. To make tests
 // robust, use a tiny in-memory Promise-based storage when running under Jest.
-const isJest = typeof process !== 'undefined' && process.env?.JEST_WORKER_ID !== undefined;
+const isJest =
+  typeof process !== 'undefined' && process.env?.JEST_WORKER_ID !== undefined;
 const storageForPersist = isJest
   ? ((): any => {
       const store: Record<string, string> = {};
@@ -29,7 +30,8 @@ const storageForPersist = isJest
           return null;
         },
         getAllKeys: async () => Object.keys(store),
-        multiGet: async (keys: string[]) => keys.map(k => [k, store[k] ?? null]),
+        multiGet: async (keys: string[]) =>
+          keys.map(k => [k, store[k] ?? null]),
         multiSet: async (entries: [string, string][]) => {
           for (const [k, v] of entries) store[k] = v;
           return null;
@@ -57,18 +59,38 @@ import formsReducer from '@/features/forms/formsSlice';
 
 const persistConfig = {
   key: 'root',
-  version: 5,
+  version: 6,
   storage: storageForPersist,
-  whitelist: ['auth', 'theme', 'documents', 'companion', 'expenses', 'tasks', 'appointments', 'businesses', 'coParent', 'linkedBusinesses', 'notifications', 'forms'],
+  whitelist: [
+    'auth',
+    'theme',
+    'documents',
+    'companion',
+    'expenses',
+    'tasks',
+    'appointments',
+    'businesses',
+    'coParent',
+    'linkedBusinesses',
+    'notifications',
+    'forms',
+  ],
   migrate: (state: any) => {
-    console.log('[Redux Persist] Migrating state from version', state?._persist?.version);
+    console.log(
+      '[Redux Persist] Migrating state from version',
+      state?._persist?.version,
+    );
     // Handle migration from version 1 to 2
     if (state?._persist?.version === 1) {
-      console.log('[Redux Persist] Migrating from v1 to v2 - adding companion state');
+      console.log(
+        '[Redux Persist] Migrating from v1 to v2 - adding companion state',
+      );
     }
     // Handle migration from version 2 to 3
     if (state?._persist?.version === 2) {
-      console.log('[Redux Persist] Migrating from v2 to v3 - refreshing businesses data with descriptions');
+      console.log(
+        '[Redux Persist] Migrating from v2 to v3 - refreshing businesses data with descriptions',
+      );
       // Clear old businesses data to force fresh fetch with descriptions
       if (state.businesses) {
         state.businesses = {
@@ -82,7 +104,9 @@ const persistConfig = {
     }
     // Handle migration from version 3 to 4
     if (state?._persist?.version === 3) {
-      console.log('[Redux Persist] Migrating from v3 to v4 - adding notifications state');
+      console.log(
+        '[Redux Persist] Migrating from v3 to v4 - adding notifications state',
+      );
       // Initialize notifications state if not present
       if (!state.notifications) {
         state.notifications = {
@@ -98,9 +122,20 @@ const persistConfig = {
     }
     // Handle migration from version 4 to 5
     if (state?._persist?.version === 4) {
-      console.log('[Redux Persist] Migrating from v4 to v5 - initializing service catalog');
+      console.log(
+        '[Redux Persist] Migrating from v4 to v5 - initializing service catalog',
+      );
       if (state.businesses) {
         state.businesses.services = state.businesses.services ?? [];
+      }
+    }
+    // Handle migration from version 5 to 6
+    if (state?._persist?.version === 5) {
+      console.log(
+        '[Redux Persist] Migrating from v5 to v6 - ensuring companion.companions is an array',
+      );
+      if (state.companion && !Array.isArray(state.companion.companions)) {
+        state.companion.companions = [];
       }
     }
     return Promise.resolve(state);

--- a/apps/mobileAppYC/src/features/appointments/components/BusinessCard/BusinessCard.tsx
+++ b/apps/mobileAppYC/src/features/appointments/components/BusinessCard/BusinessCard.tsx
@@ -1,5 +1,12 @@
 import React, {useMemo} from 'react';
-import {View, Text, Image, StyleSheet, ViewStyle, ImageSourcePropType} from 'react-native';
+import {
+  View,
+  Text,
+  Image,
+  StyleSheet,
+  ViewStyle,
+  ImageSourcePropType,
+} from 'react-native';
 import {LiquidGlassCard} from '@/shared/components/common/LiquidGlassCard/LiquidGlassCard';
 import {LiquidGlassButton} from '@/shared/components/common/LiquidGlassButton/LiquidGlassButton';
 import {useTheme} from '@/hooks';
@@ -18,6 +25,7 @@ export interface BusinessCardProps {
   style?: ViewStyle;
   onBook?: () => void;
   compact?: boolean;
+  glassEffect?: 'clear' | 'regular' | 'none';
 }
 
 export const BusinessCard: React.FC<BusinessCardProps> = ({
@@ -31,19 +39,27 @@ export const BusinessCard: React.FC<BusinessCardProps> = ({
   style,
   onBook,
   compact = false,
+  glassEffect = 'clear',
 }) => {
   const {theme} = useTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
-  const descriptionText = description && description.trim().length > 0 ? description.trim() : null;
+  const descriptionText =
+    description && description.trim().length > 0 ? description.trim() : null;
 
   const [loadFailed, setLoadFailed] = React.useState(false);
-  const [sourceOverride, setSourceOverride] = React.useState<ImageSourcePropType | number | undefined>(photo ?? undefined);
+  const [sourceOverride, setSourceOverride] = React.useState<
+    ImageSourcePropType | number | undefined
+  >(photo ?? undefined);
   const resolvedSource = useMemo(
-    () => resolveImageSource(sourceOverride ?? photo ?? (fallbackPhoto ?? undefined)),
+    () =>
+      resolveImageSource(sourceOverride ?? photo ?? fallbackPhoto ?? undefined),
     [sourceOverride, photo, fallbackPhoto],
   );
 
-  const isDummyPhoto = React.useCallback((src?: any) => isDummyPhotoUrl(src), []);
+  const isDummyPhoto = React.useCallback(
+    (src?: any) => isDummyPhotoUrl(src),
+    [],
+  );
 
   const handleError = React.useCallback(() => {
     setLoadFailed(true);
@@ -73,7 +89,12 @@ export const BusinessCard: React.FC<BusinessCardProps> = ({
 
   React.useEffect(() => {
     // When a real photo arrives asynchronously, switch to it without waiting for a remount
-    if (photo && !loadFailed && sourceOverride !== photo && !(fallbackPhoto && isDummyPhoto(photo))) {
+    if (
+      photo &&
+      !loadFailed &&
+      sourceOverride !== photo &&
+      !(fallbackPhoto && isDummyPhoto(photo))
+    ) {
       setSourceOverride(photo as any);
     }
   }, [fallbackPhoto, isDummyPhoto, loadFailed, photo, sourceOverride]);
@@ -83,7 +104,7 @@ export const BusinessCard: React.FC<BusinessCardProps> = ({
       style={[styles.card, compact && styles.compact, style]}
       padding="0"
       shadow="none"
-      glassEffect="clear"
+      glassEffect={glassEffect}
       fallbackStyle={styles.cardFallback}>
       <Image
         source={resolvedSource}
@@ -93,14 +114,23 @@ export const BusinessCard: React.FC<BusinessCardProps> = ({
         onError={handleError}
       />
       <View style={styles.body}>
-        <Text numberOfLines={1} style={styles.title}>{name}</Text>
+        <Text numberOfLines={1} style={styles.title}>
+          {name}
+        </Text>
         {!!openText && <Text style={styles.openText}>{openText}</Text>}
         {descriptionText && (
-          <Text numberOfLines={2} ellipsizeMode="tail" style={styles.description}>
+          <Text
+            numberOfLines={2}
+            ellipsizeMode="tail"
+            style={styles.description}>
             {descriptionText}
           </Text>
         )}
-        <View style={[styles.metaRow, !(distanceText && ratingText) && styles.metaRowSingle]}>
+        <View
+          style={[
+            styles.metaRow,
+            !(distanceText && ratingText) && styles.metaRowSingle,
+          ]}>
           {!!distanceText && (
             <View style={styles.metaItem}>
               <Image source={Images.distanceIcon} style={styles.metaIcon} />

--- a/apps/mobileAppYC/src/features/appointments/components/MapDiscovery/ClinicBottomSheet.tsx
+++ b/apps/mobileAppYC/src/features/appointments/components/MapDiscovery/ClinicBottomSheet.tsx
@@ -23,6 +23,8 @@ export interface ClinicBottomSheetRef {
   scrollToClinic: (id: string) => void;
   snapToExpanded: () => void;
   snapToCollapsed: () => void;
+  hide: () => void;
+  show: () => void;
 }
 
 export interface ClinicBottomSheetProps {
@@ -96,6 +98,8 @@ const ClinicBottomSheet = forwardRef<
       },
       snapToExpanded: () => bottomSheetRef.current?.snapToIndex(1),
       snapToCollapsed: () => bottomSheetRef.current?.snapToIndex(0),
+      hide: () => bottomSheetRef.current?.close(),
+      show: () => bottomSheetRef.current?.snapToIndex(0),
     }));
 
     const handleScrollToIndexFailed = useCallback((info: {index: number}) => {

--- a/apps/mobileAppYC/src/features/appointments/components/MapDiscovery/ClinicMapPin.tsx
+++ b/apps/mobileAppYC/src/features/appointments/components/MapDiscovery/ClinicMapPin.tsx
@@ -44,7 +44,9 @@ const ClinicMapPin: React.FC<ClinicMapPinProps> = ({business, isSelected}) => {
   );
 
   return (
-    <View style={[styles.container, isSelected && styles.containerSelected]}>
+    <View
+      collapsable={false}
+      style={[styles.container, isSelected && styles.containerSelected]}>
       <View
         style={[
           styles.bubble,

--- a/apps/mobileAppYC/src/features/appointments/components/MapDiscovery/ClusterMapPin.tsx
+++ b/apps/mobileAppYC/src/features/appointments/components/MapDiscovery/ClusterMapPin.tsx
@@ -6,7 +6,7 @@ interface ClusterMapPinProps {
 }
 
 const ClusterMapPin: React.FC<ClusterMapPinProps> = ({count}) => (
-  <View style={styles.outer}>
+  <View collapsable={false} style={styles.outer}>
     <View style={styles.inner}>
       <Text style={styles.label}>{count}</Text>
     </View>

--- a/apps/mobileAppYC/src/features/appointments/components/MapDiscovery/MapDiscoveryView.tsx
+++ b/apps/mobileAppYC/src/features/appointments/components/MapDiscovery/MapDiscoveryView.tsx
@@ -1,5 +1,5 @@
-import React, {useCallback, useMemo, useRef} from 'react';
-import {StyleSheet, Switch, Text, View} from 'react-native';
+import React, {useCallback, useEffect, useMemo, useRef} from 'react';
+import {Pressable, StyleSheet, Switch, Text, View} from 'react-native';
 import {
   createAnimatedComponent,
   useSharedValue,
@@ -27,6 +27,7 @@ import ClusterMapPin from './ClusterMapPin';
 import ClinicBottomSheet, {
   type ClinicBottomSheetRef,
 } from './ClinicBottomSheet';
+import BusinessCard from '../BusinessCard/BusinessCard';
 
 const AnimatedView = createAnimatedComponent(
   View,
@@ -48,13 +49,14 @@ export interface MapDiscoveryViewProps {
   distanceUnit: 'km' | 'mi';
   navigation: NativeStackNavigationProp<AppointmentStackParamList>;
   onRegionChange: (region: Region) => void;
-  onSelectClinic: (id: string) => void;
+  onSelectClinic: (id: string | null) => void;
   onSearchChange: (text: string) => void;
   onSearchSubmit: () => void;
   onCategoryChange: (c: BusinessCategory | undefined) => void;
   onOpenNowChange: (v: boolean) => void;
   onBack: () => void;
   searchResultsOverlay?: React.ReactNode;
+  onSearchBarLayout?: (height: number) => void;
 }
 
 const DEFAULT_CENTER = {latitude: 37.7749, longitude: -122.4194};
@@ -89,6 +91,7 @@ const MapDiscoveryView: React.FC<MapDiscoveryViewProps> = ({
   onOpenNowChange,
   onBack,
   searchResultsOverlay,
+  onSearchBarLayout,
 }) => {
   const {t} = useTranslation();
   const {theme} = useTheme();
@@ -121,13 +124,46 @@ const MapDiscoveryView: React.FC<MapDiscoveryViewProps> = ({
 
   const initialRegion = useMemo(
     () => buildInitialRegion(userLocation),
-    [userLocation],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
+  useEffect(() => {
+    if (!userLocation) return;
+    mapRef.current?.animateToRegion(
+      {
+        latitude: userLocation.latitude,
+        longitude: userLocation.longitude,
+        latitudeDelta: INITIAL_LAT_DELTA,
+        longitudeDelta: INITIAL_LNG_DELTA,
+      },
+      500,
+    );
+  }, [userLocation]);
+
+  const selectedClinic = useMemo(
+    () => clinics.find(c => c.id === selectedClinicId) ?? null,
+    [clinics, selectedClinicId],
+  );
+
+  const resolveDistanceText = useCallback(
+    (clinic: (typeof clinics)[0]): string | undefined => {
+      const mi =
+        clinic.distanceMi ??
+        (clinic.distanceMeters != null
+          ? clinic.distanceMeters / 1609.344
+          : null);
+      if (mi == null) return undefined;
+      if (distanceUnit === 'km') return `${(mi * 1.60934).toFixed(1)} km`;
+      return `${mi.toFixed(1)} mi`;
+    },
+    [distanceUnit],
   );
 
   const handlePinPress = useCallback(
     (clinicId: string) => {
       onSelectClinic(clinicId);
-      bottomSheetRef.current?.scrollToClinic(clinicId);
+      bottomSheetRef.current?.hide();
 
       const clinic = clinics.find(c => c.id === clinicId);
       if (clinic?.lat == null || clinic?.lng == null) return;
@@ -143,6 +179,11 @@ const MapDiscoveryView: React.FC<MapDiscoveryViewProps> = ({
     },
     [clinics, onSelectClinic],
   );
+
+  const handleDeselectClinic = useCallback(() => {
+    onSelectClinic(null);
+    bottomSheetRef.current?.show();
+  }, [onSelectClinic]);
 
   const mapItems = useMemo(
     () => clusterClinics(clinics, mapRegion?.latitudeDelta ?? 0),
@@ -177,7 +218,8 @@ const MapDiscoveryView: React.FC<MapDiscoveryViewProps> = ({
         showsMyLocationButton={false}
         showsCompass={false}
         showsScale={false}
-        onRegionChangeComplete={onRegionChange}>
+        onRegionChangeComplete={onRegionChange}
+        onPress={selectedClinic ? handleDeselectClinic : undefined}>
         {mapItems.map(item => {
           if (item.type === 'cluster') {
             return (
@@ -205,7 +247,14 @@ const MapDiscoveryView: React.FC<MapDiscoveryViewProps> = ({
           );
         })}
       </MapView>
-      <View style={styles.topBar} pointerEvents="box-none">
+      <View
+        style={styles.topBar}
+        pointerEvents="box-none"
+        onLayout={
+          onSearchBarLayout
+            ? e => onSearchBarLayout(e.nativeEvent.layout.height)
+            : undefined
+        }>
         <View style={styles.headerShadowWrapper} pointerEvents="auto">
           <LiquidGlassCard
             glassEffect="clear"
@@ -232,21 +281,58 @@ const MapDiscoveryView: React.FC<MapDiscoveryViewProps> = ({
           </LiquidGlassCard>
         </View>
       </View>
-      <AnimatedView style={[styles.openNowMapToggle, toggleAnimatedStyle]}>
-        <View style={styles.openNowToggleCard} pointerEvents="auto">
-          <Text style={styles.openNowToggleLabel}>Open</Text>
-          <Switch
-            value={openNow}
-            onValueChange={onOpenNowChange}
-            trackColor={{
-              false: theme.colors.borderMuted,
-              true: theme.colors.primary,
-            }}
-            thumbColor={theme.colors.white}
+      {!selectedClinic && (
+        <AnimatedView style={[styles.openNowMapToggle, toggleAnimatedStyle]}>
+          <View style={styles.openNowToggleCard} pointerEvents="auto">
+            <Text style={styles.openNowToggleLabel}>Open</Text>
+            <Switch
+              value={openNow}
+              onValueChange={onOpenNowChange}
+              trackColor={{
+                false: theme.colors.borderMuted,
+                true: theme.colors.primary,
+              }}
+              thumbColor={theme.colors.white}
+            />
+          </View>
+        </AnimatedView>
+      )}
+      {searchResultsOverlay}
+      {selectedClinic && (
+        <View
+          style={[
+            styles.selectedClinicOverlay,
+            {paddingBottom: insets.bottom + 16},
+          ]}
+          pointerEvents="box-none">
+          <Pressable
+            style={styles.selectedClinicDismiss}
+            onPress={handleDeselectClinic}
+            hitSlop={8}>
+            <Text style={styles.selectedClinicDismissText}>✕</Text>
+          </Pressable>
+          <BusinessCard
+            name={selectedClinic.name}
+            openText={selectedClinic.openHours}
+            description={selectedClinic.address}
+            distanceText={resolveDistanceText(selectedClinic)}
+            ratingText={
+              selectedClinic.rating != null
+                ? `${selectedClinic.rating}`
+                : undefined
+            }
+            photo={selectedClinic.photo}
+            fallbackPhoto={fallbacks[selectedClinic.id]?.photo ?? null}
+            glassEffect="none"
+            onBook={() =>
+              navigation.navigate('BusinessDetails', {
+                businessId: selectedClinic.id,
+                distanceMi: selectedClinic.distanceMi,
+              })
+            }
           />
         </View>
-      </AnimatedView>
-      {searchResultsOverlay}
+      )}
       <ClinicBottomSheet
         ref={bottomSheetRef}
         clinics={clinics}
@@ -272,7 +358,7 @@ const createStyles = (theme: any) =>
       top: 0,
       left: 0,
       right: 0,
-      zIndex: 10,
+      zIndex: 110,
       backgroundColor: 'transparent',
     },
     headerShadowWrapper: {
@@ -338,6 +424,33 @@ const createStyles = (theme: any) =>
     openNowToggleLabel: {
       ...theme.typography.pillSubtitleBold15,
       color: theme.colors.text,
+    },
+    selectedClinicOverlay: {
+      position: 'absolute' as const,
+      bottom: 0,
+      left: 0,
+      right: 0,
+      zIndex: 20,
+      paddingHorizontal: theme.spacing['4'],
+      paddingTop: theme.spacing['2'],
+    },
+    selectedClinicDismiss: {
+      position: 'absolute' as const,
+      top: theme.spacing['4'],
+      right: theme.spacing['6'],
+      zIndex: 21,
+      width: theme.spacing['8'],
+      height: theme.spacing['8'],
+      borderRadius: theme.borderRadius.full,
+      backgroundColor: theme.colors.background,
+      alignItems: 'center' as const,
+      justifyContent: 'center' as const,
+      boxShadow: '0 2px 4px rgba(0,0,0,0.2)',
+    },
+    selectedClinicDismissText: {
+      ...theme.typography.titleSmall,
+      color: theme.colors.text,
+      lineHeight: theme.spacing['6'],
     },
   });
 

--- a/apps/mobileAppYC/src/features/appointments/screens/BrowseBusinessesScreen.tsx
+++ b/apps/mobileAppYC/src/features/appointments/screens/BrowseBusinessesScreen.tsx
@@ -239,6 +239,7 @@ export const BrowseBusinessesScreen: React.FC = () => {
     [enrichWithDistance, userCoords],
   );
   const hasInitialSearched = useRef(false);
+  const hasLocationSearched = useRef(false);
 
   useEffect(() => {
     setSearchQuery(initialQuery);
@@ -249,6 +250,12 @@ export const BrowseBusinessesScreen: React.FC = () => {
     hasInitialSearched.current = true;
     performSearch(initialQuery);
   }, [locationLoading, initialQuery, performSearch]);
+
+  useEffect(() => {
+    if (!userLocation || hasLocationSearched.current) return;
+    hasLocationSearched.current = true;
+    performSearch(initialQuery);
+  }, [userLocation, initialQuery, performSearch]);
 
   const reduxBusinesses = useSelector(
     (state: RootState) => state.businesses?.businesses ?? [],
@@ -279,10 +286,15 @@ export const BrowseBusinessesScreen: React.FC = () => {
     [setMapRegion],
   );
 
+  const [headerHeight, setHeaderHeight] = useState(0);
+
   const showSearchResults =
     searchQuery.length >= 2 && searchResults.length > 0 && !searching;
 
-  const dropdownTop = buildDropdownTop(theme) + theme.spacing['2'];
+  const dropdownTop =
+    headerHeight > 0
+      ? headerHeight + theme.spacing['2']
+      : buildDropdownTop(theme) + theme.spacing['2'];
 
   const searchResultsOverlay = showSearchResults ? (
     <BusinessSearchDropdown
@@ -318,6 +330,7 @@ export const BrowseBusinessesScreen: React.FC = () => {
         onOpenNowChange={setOpenNow}
         onBack={() => navigation.goBack()}
         searchResultsOverlay={searchResultsOverlay}
+        onSearchBarLayout={setHeaderHeight}
       />
     </View>
   );

--- a/apps/mobileAppYC/src/features/companion/selectors.ts
+++ b/apps/mobileAppYC/src/features/companion/selectors.ts
@@ -6,32 +6,31 @@ export const selectCompanionState = (state: RootState) => state.companion;
 
 export const selectCompanions = createSelector(
   [selectCompanionState],
-  companionState => companionState.companions
+  companionState => companionState?.companions ?? [],
 );
 
 export const selectSelectedCompanionId = createSelector(
   [selectCompanionState],
-  companionState => companionState.selectedCompanionId
+  companionState => companionState.selectedCompanionId,
 );
 
 export const selectSelectedCompanion = createSelector(
   [selectCompanions, selectSelectedCompanionId],
   (companions, selectedId) =>
-    selectedId ? companions.find(c => c.id === selectedId) ?? null : null
+    selectedId ? (companions.find(c => c.id === selectedId) ?? null) : null,
 );
 
 export const selectCompanionLoading = createSelector(
   [selectCompanionState],
-  companionState => companionState.loading
+  companionState => companionState.loading,
 );
 
 export const selectCompanionError = createSelector(
   [selectCompanionState],
-  companionState => companionState.error
+  companionState => companionState.error,
 );
 
 export const selectCompanionsByCategory = createSelector(
   [selectCompanions, (_state: RootState, category: string) => category],
-  (companions, category) =>
-    companions.filter(c => c.category === category)
+  (companions, category) => companions.filter(c => c.category === category),
 );

--- a/apps/mobileAppYC/src/features/tasks/components/TaskDeleteBottomSheet/TaskDeleteBottomSheet.tsx
+++ b/apps/mobileAppYC/src/features/tasks/components/TaskDeleteBottomSheet/TaskDeleteBottomSheet.tsx
@@ -1,0 +1,38 @@
+import React, {forwardRef} from 'react';
+import {
+  TaskRecurringActionSheet,
+  type TaskRecurringActionSheetRef,
+} from '@/features/tasks/components/TaskRecurringActionSheet/TaskRecurringActionSheet';
+
+export type TaskDeleteBottomSheetRef = TaskRecurringActionSheetRef;
+
+interface TaskDeleteBottomSheetProps {
+  taskTitle?: string;
+  onDeleteAll: () => Promise<void> | void;
+  onDeleteForDay: () => Promise<void> | void;
+  onCancel?: () => void;
+}
+
+export const TaskDeleteBottomSheet = forwardRef<
+  TaskDeleteBottomSheetRef,
+  TaskDeleteBottomSheetProps
+>(({taskTitle, onDeleteAll, onDeleteForDay, onCancel}, ref) => (
+  <TaskRecurringActionSheet
+    ref={ref}
+    title="Delete task"
+    message={
+      taskTitle ? `How would you like to delete "${taskTitle}"?` : undefined
+    }
+    primaryLabel="Delete all occurrences"
+    primaryLoadingLabel="Deleting..."
+    onPrimary={onDeleteAll}
+    secondaryLabel="Delete for this day only"
+    secondaryLoadingLabel="Deleting..."
+    onSecondary={onDeleteForDay}
+    onCancel={onCancel}
+  />
+));
+
+TaskDeleteBottomSheet.displayName = 'TaskDeleteBottomSheet';
+
+export default TaskDeleteBottomSheet;

--- a/apps/mobileAppYC/src/features/tasks/components/TaskRecurringActionSheet/TaskRecurringActionSheet.tsx
+++ b/apps/mobileAppYC/src/features/tasks/components/TaskRecurringActionSheet/TaskRecurringActionSheet.tsx
@@ -1,0 +1,221 @@
+import React, {
+  forwardRef,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {StyleSheet, Text, View} from 'react-native';
+import CustomBottomSheet, {
+  type BottomSheetRef,
+} from '@/shared/components/common/BottomSheet/BottomSheet';
+import LiquidGlassButton from '@/shared/components/common/LiquidGlassButton/LiquidGlassButton';
+import {BottomSheetHeader} from '@/shared/components/common/BottomSheetHeader/BottomSheetHeader';
+import {useTheme} from '@/hooks';
+
+export interface TaskRecurringActionSheetRef {
+  open: () => void;
+  close: () => void;
+}
+
+interface TaskRecurringActionSheetProps {
+  title: string;
+  message?: string;
+  primaryLabel: string;
+  primaryLoadingLabel: string;
+  onPrimary: () => Promise<void> | void;
+  secondaryLabel: string;
+  secondaryLoadingLabel: string;
+  onSecondary: () => Promise<void> | void;
+  onCancel?: () => void;
+}
+
+export const TaskRecurringActionSheet = forwardRef<
+  TaskRecurringActionSheetRef,
+  TaskRecurringActionSheetProps
+>(
+  (
+    {
+      title,
+      message,
+      primaryLabel,
+      primaryLoadingLabel,
+      onPrimary,
+      secondaryLabel,
+      secondaryLoadingLabel,
+      onSecondary,
+      onCancel,
+    },
+    ref,
+  ) => {
+    const {theme} = useTheme();
+    const styles = useMemo(() => createStyles(theme), [theme]);
+    const sheetRef = useRef<BottomSheetRef>(null);
+    const [primaryBusy, setPrimaryBusy] = useState(false);
+    const [secondaryBusy, setSecondaryBusy] = useState(false);
+
+    const isBusy = primaryBusy || secondaryBusy;
+
+    useImperativeHandle(ref, () => ({
+      open: () => sheetRef.current?.snapToIndex(0),
+      close: () => sheetRef.current?.close(),
+    }));
+
+    const handleClose = () => {
+      sheetRef.current?.close();
+      onCancel?.();
+    };
+
+    const handlePrimary = async () => {
+      setPrimaryBusy(true);
+      try {
+        await onPrimary();
+        sheetRef.current?.close();
+      } catch (error) {
+        console.error(
+          '[TaskRecurringActionSheet] Primary action error:',
+          error,
+        );
+      } finally {
+        setPrimaryBusy(false);
+      }
+    };
+
+    const handleSecondary = async () => {
+      setSecondaryBusy(true);
+      try {
+        await onSecondary();
+        sheetRef.current?.close();
+      } catch (error) {
+        console.error(
+          '[TaskRecurringActionSheet] Secondary action error:',
+          error,
+        );
+      } finally {
+        setSecondaryBusy(false);
+      }
+    };
+
+    return (
+      <CustomBottomSheet
+        ref={sheetRef}
+        snapPoints={['42%', '42%']}
+        initialIndex={-1}
+        zIndex={100}
+        enablePanDownToClose={true}
+        enableBackdrop={true}
+        enableHandlePanningGesture={true}
+        enableContentPanningGesture={false}
+        backdropOpacity={0.5}
+        backdropAppearsOnIndex={0}
+        backdropDisappearsOnIndex={-1}
+        backdropPressBehavior="close"
+        backgroundStyle={styles.background}
+        handleIndicatorStyle={styles.handle}
+        contentType="view">
+        <View style={styles.container}>
+          <BottomSheetHeader
+            title={title}
+            onClose={handleClose}
+            theme={theme}
+            showCloseButton={true}
+          />
+
+          {message ? <Text style={styles.message}>{message}</Text> : null}
+
+          <View style={styles.buttonStack}>
+            <LiquidGlassButton
+              title={primaryBusy ? primaryLoadingLabel : primaryLabel}
+              onPress={handlePrimary}
+              glassEffect="clear"
+              tintColor={theme.colors.secondary}
+              borderRadius="lg"
+              textStyle={styles.primaryButtonText}
+              style={styles.button}
+              disabled={isBusy}
+              loading={primaryBusy}
+              shadowIntensity="light"
+            />
+
+            <LiquidGlassButton
+              title={secondaryBusy ? secondaryLoadingLabel : secondaryLabel}
+              onPress={handleSecondary}
+              glassEffect="clear"
+              tintColor={theme.colors.surface}
+              borderRadius="lg"
+              textStyle={styles.secondaryButtonText}
+              style={styles.button}
+              disabled={isBusy}
+              loading={secondaryBusy}
+              forceBorder={true}
+              borderColor={theme.colors.secondary}
+              shadowIntensity="light"
+            />
+
+            <LiquidGlassButton
+              title="Cancel"
+              onPress={handleClose}
+              glassEffect="clear"
+              tintColor={theme.colors.surface}
+              borderRadius="lg"
+              textStyle={styles.cancelButtonText}
+              style={styles.button}
+              disabled={isBusy}
+              forceBorder={true}
+              borderColor={theme.colors.borderMuted}
+              shadowIntensity="light"
+            />
+          </View>
+        </View>
+      </CustomBottomSheet>
+    );
+  },
+);
+
+TaskRecurringActionSheet.displayName = 'TaskRecurringActionSheet';
+
+const createStyles = (theme: any) =>
+  StyleSheet.create({
+    background: {
+      backgroundColor: theme.colors.surface,
+      borderTopLeftRadius: theme.spacing['6'],
+      borderTopRightRadius: theme.spacing['6'],
+    },
+    handle: {
+      backgroundColor: theme.colors.borderMuted,
+    },
+    container: {
+      gap: theme.spacing['3'],
+      paddingHorizontal: theme.spacing['5'],
+      paddingBottom: theme.spacing['8'],
+    },
+    message: {
+      ...theme.typography.titleMedium,
+      color: theme.colors.secondary,
+      textAlign: 'center',
+      paddingBottom: theme.spacing['1'],
+    },
+    buttonStack: {
+      gap: theme.spacing['3'],
+    },
+    button: {
+      width: '100%',
+    },
+    primaryButtonText: {
+      ...theme.typography.buttonH6Clash19,
+      textAlign: 'center',
+      color: theme.colors.white,
+    },
+    secondaryButtonText: {
+      ...theme.typography.buttonH6Clash19,
+      textAlign: 'center',
+      color: theme.colors.secondary,
+    },
+    cancelButtonText: {
+      ...theme.typography.buttonH6Clash19,
+      textAlign: 'center',
+      color: theme.colors.secondary,
+    },
+  });
+
+export default TaskRecurringActionSheet;

--- a/apps/mobileAppYC/src/features/tasks/components/TaskSaveOptionsBottomSheet/TaskSaveOptionsBottomSheet.tsx
+++ b/apps/mobileAppYC/src/features/tasks/components/TaskSaveOptionsBottomSheet/TaskSaveOptionsBottomSheet.tsx
@@ -1,0 +1,35 @@
+import React, {forwardRef} from 'react';
+import {
+  TaskRecurringActionSheet,
+  type TaskRecurringActionSheetRef,
+} from '@/features/tasks/components/TaskRecurringActionSheet/TaskRecurringActionSheet';
+
+export type TaskSaveOptionsBottomSheetRef = TaskRecurringActionSheetRef;
+
+interface TaskSaveOptionsBottomSheetProps {
+  onSaveAll: () => Promise<void> | void;
+  onSaveForDay: () => Promise<void> | void;
+  onCancel?: () => void;
+}
+
+export const TaskSaveOptionsBottomSheet = forwardRef<
+  TaskSaveOptionsBottomSheetRef,
+  TaskSaveOptionsBottomSheetProps
+>(({onSaveAll, onSaveForDay, onCancel}, ref) => (
+  <TaskRecurringActionSheet
+    ref={ref}
+    title="Save changes"
+    message="How would you like to apply your changes?"
+    primaryLabel="Save for all occurrences"
+    primaryLoadingLabel="Saving..."
+    onPrimary={onSaveAll}
+    secondaryLabel="Save for this day only"
+    secondaryLoadingLabel="Saving..."
+    onSecondary={onSaveForDay}
+    onCancel={onCancel}
+  />
+));
+
+TaskSaveOptionsBottomSheet.displayName = 'TaskSaveOptionsBottomSheet';
+
+export default TaskSaveOptionsBottomSheet;

--- a/apps/mobileAppYC/src/features/tasks/hooks/useEditTaskScreen.ts
+++ b/apps/mobileAppYC/src/features/tasks/hooks/useEditTaskScreen.ts
@@ -1,4 +1,4 @@
-import {useEffect} from 'react';
+import {useEffect, useRef} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import type {RootState, AppDispatch} from '@/app/store';
 import {selectTaskById} from '@/features/tasks/selectors';
@@ -8,6 +8,8 @@ import {useTaskFormSetup} from './useTaskFormSetup';
 import {useTaskFormHelpers} from './useTaskFormHelpers';
 import {useScreenHandlers} from './useScreenHandlers';
 import {fetchCoParents} from '@/features/coParent/thunks';
+import type {TaskDeleteBottomSheetRef} from '@/features/tasks/components/TaskDeleteBottomSheet/TaskDeleteBottomSheet';
+import type {TaskSaveOptionsBottomSheetRef} from '@/features/tasks/components/TaskSaveOptionsBottomSheet/TaskSaveOptionsBottomSheet';
 
 /**
  * Consolidated hook for EditTaskScreen
@@ -17,12 +19,18 @@ export const useEditTaskScreen = (taskId: string, navigation: any) => {
   const dispatch = useDispatch<AppDispatch>();
   const task = useSelector((state: RootState) => selectTaskById(taskId)(state));
   const loading = useSelector((state: RootState) => state.tasks.loading);
-  const companions = useSelector((state: RootState) => state.companion.companions);
+  const companions = useSelector(
+    (state: RootState) => state.companion.companions,
+  );
+
+  const taskDeleteSheetRef = useRef<TaskDeleteBottomSheetRef>(null);
+  const taskSaveSheetRef = useRef<TaskSaveOptionsBottomSheetRef>(null);
 
   const formSetup = useTaskFormSetup();
   const {formData, hasUnsavedChanges, setFormData, setErrors} = formSetup;
 
-  const {isMedicationForm, isObservationalToolForm, isSimpleForm} = useTaskFormHelpers(formData);
+  const {isMedicationForm, isObservationalToolForm, isSimpleForm} =
+    useTaskFormHelpers(formData);
 
   // Initialize form with task data
   useEffect(() => {
@@ -36,24 +44,27 @@ export const useEditTaskScreen = (taskId: string, navigation: any) => {
   useEffect(() => {
     if (task?.companionId) {
       const companion = companions?.find(c => c.id === task.companionId);
-      dispatch(fetchCoParents({
-        companionId: task.companionId,
-        companionName: companion?.name,
-        companionImage: companion?.profileImage ?? undefined,
-      }));
+      dispatch(
+        fetchCoParents({
+          companionId: task.companionId,
+          companionName: companion?.name,
+          companionImage: companion?.profileImage ?? undefined,
+        }),
+      );
     }
   }, [companions, dispatch, task?.companionId]);
 
-  const {validateForm, showErrorAlert, handleBack, sheetHandlers} = useScreenHandlers({
-    hasUnsavedChanges,
-    navigation,
-    formSetup,
-    validateTaskForm,
-    setErrors,
-  });
+  const {validateForm, showErrorAlert, handleBack, sheetHandlers} =
+    useScreenHandlers({
+      hasUnsavedChanges,
+      navigation,
+      formSetup,
+      validateTaskForm,
+      setErrors,
+    });
 
   const handleDelete = () => {
-    formSetup.deleteSheetRef.current?.open();
+    taskDeleteSheetRef.current?.open();
   };
 
   const companion = companions?.find(c => c.id === task?.companionId);
@@ -65,6 +76,8 @@ export const useEditTaskScreen = (taskId: string, navigation: any) => {
     loading,
     companions,
     companionType,
+    taskDeleteSheetRef,
+    taskSaveSheetRef,
 
     // Form helpers
     isMedicationForm,

--- a/apps/mobileAppYC/src/features/tasks/screens/EditTaskScreen/EditTaskScreen.tsx
+++ b/apps/mobileAppYC/src/features/tasks/screens/EditTaskScreen/EditTaskScreen.tsx
@@ -60,7 +60,6 @@ export const EditTaskScreen: React.FC = () => {
     isMedicationForm,
     isObservationalToolForm,
     isSimpleForm,
-    handleDelete,
     taskDeleteSheetRef,
     taskSaveSheetRef,
     sheetHandlers,
@@ -170,6 +169,15 @@ export const EditTaskScreen: React.FC = () => {
     }
   };
 
+  const handleDeletePress = () => {
+    if (!task) return;
+    if (task.frequency !== 'once') {
+      taskDeleteSheetRef.current?.open();
+    } else {
+      confirmDeleteTask();
+    }
+  };
+
   const confirmSaveForDay = async () => {
     try {
       await performSave();
@@ -252,7 +260,7 @@ export const EditTaskScreen: React.FC = () => {
             showBackButton
             onBack={handleSmartBack}
             rightIcon={Images.deleteIconRed}
-            onRightPress={handleDelete}
+            onRightPress={handleDeletePress}
             glass={false}
           />
         }

--- a/apps/mobileAppYC/src/features/tasks/screens/EditTaskScreen/EditTaskScreen.tsx
+++ b/apps/mobileAppYC/src/features/tasks/screens/EditTaskScreen/EditTaskScreen.tsx
@@ -7,7 +7,8 @@ import {useDispatch, useSelector} from 'react-redux';
 import {Input} from '@/shared/components/common';
 import {Header} from '@/shared/components/common/Header/Header';
 import {LiquidGlassHeaderScreen} from '@/shared/components/common/LiquidGlassHeader/LiquidGlassHeaderScreen';
-import {DeleteDocumentBottomSheet} from '@/shared/components/common/DeleteDocumentBottomSheet/DeleteDocumentBottomSheet';
+import {TaskDeleteBottomSheet} from '@/features/tasks/components/TaskDeleteBottomSheet/TaskDeleteBottomSheet';
+import {TaskSaveOptionsBottomSheet} from '@/features/tasks/components/TaskSaveOptionsBottomSheet/TaskSaveOptionsBottomSheet';
 import {useTheme} from '@/hooks';
 import {Images} from '@/assets/images';
 import {updateTask, deleteTask, setTaskCalendarEventId} from '@/features/tasks';
@@ -16,7 +17,11 @@ import type {TaskStackParamList} from '@/navigation/types';
 import {resolveCategoryLabel} from '@/features/tasks/utils/taskLabels';
 import {selectAuthUser} from '@/features/auth/selectors';
 import {selectAcceptedCoParents} from '@/features/coParent/selectors';
-import {TaskFormContent, TaskFormFooter, TaskFormSheets} from '@/features/tasks/components/form';
+import {
+  TaskFormContent,
+  TaskFormFooter,
+  TaskFormSheets,
+} from '@/features/tasks/components/form';
 import {createTaskFormStyles} from '@/features/tasks/screens/styles';
 import {REMINDER_OPTIONS} from '@/features/tasks/constants';
 import {useEditTaskScreen} from '@/features/tasks/hooks/useEditTaskScreen';
@@ -24,7 +29,10 @@ import {createFileHandlers} from '@/features/tasks/utils/createFileHandlers';
 import {getTaskFormSheetProps} from '@/features/tasks/utils/getTaskFormSheetProps';
 import {buildTaskDraftFromForm} from '@/features/tasks/services/taskService';
 import {uploadDocumentFiles} from '@/features/documents/documentSlice';
-import {createCalendarEventForTask, removeCalendarEvents} from '@/features/tasks/services/calendarSyncService';
+import {
+  createCalendarEventForTask,
+  removeCalendarEvents,
+} from '@/features/tasks/services/calendarSyncService';
 import {getAssignedUserName} from '@/features/tasks/utils/userHelpers';
 
 type Navigation = NativeStackNavigationProp<TaskStackParamList, 'EditTask'>;
@@ -53,6 +61,8 @@ export const EditTaskScreen: React.FC = () => {
     isObservationalToolForm,
     isSimpleForm,
     handleDelete,
+    taskDeleteSheetRef,
+    taskSaveSheetRef,
     sheetHandlers,
     validateForm,
     showErrorAlert,
@@ -74,59 +84,103 @@ export const EditTaskScreen: React.FC = () => {
     }
   }, [navigation, source]);
 
-  const handleSave = async () => {
-    if (!validateForm(formData)) return;
+  const performSave = async () => {
     if (!task) return;
 
-    try {
-      let preparedAttachments = formData.attachments;
-      if (preparedAttachments.length > 0) {
-        preparedAttachments = await dispatch(
-          uploadDocumentFiles({files: preparedAttachments as any, companionId: task.companionId}),
-        ).unwrap();
-      }
+    let preparedAttachments = formData.attachments;
+    if (preparedAttachments.length > 0) {
+      preparedAttachments = await dispatch(
+        uploadDocumentFiles({
+          files: preparedAttachments as any,
+          companionId: task.companionId,
+        }),
+      ).unwrap();
+    }
 
-      const taskData = buildTaskDraftFromForm({
-        formData: {...formData, attachments: preparedAttachments},
-        companionId: task.companionId,
-        observationToolId: task.observationToolId ?? formData.observationalTool,
-      });
-      const updated = await dispatch(updateTask({taskId: task.id, updates: taskData})).unwrap();
+    const taskData = buildTaskDraftFromForm({
+      formData: {...formData, attachments: preparedAttachments},
+      companionId: task.companionId,
+      observationToolId: task.observationToolId ?? formData.observationalTool,
+    });
+    const updated = await dispatch(
+      updateTask({taskId: task.id, updates: taskData}),
+    ).unwrap();
 
-      if (formData.syncWithCalendar) {
-        // Remove old calendar events before creating new ones to avoid duplicates
-        if (task.calendarEventId) {
-          console.log('[EditTask] Removing old calendar events:', task.calendarEventId);
-          await removeCalendarEvents(task.calendarEventId);
-        }
-
-        // Get companion name
-        const companion = companions.find(c => c.id === task.companionId);
-        const companionName = companion?.name || 'Companion';
-
-        // Get assigned user name
-        const assignedToName = getAssignedUserName(formData.assignedTo, currentUser, coParents);
-
-        // WORKAROUND: Backend doesn't return calendarProvider, so use formData value
-        const taskWithCalendar = {
-          ...updated,
-          calendarProvider: formData.calendarProvider || undefined,
-        };
-
-        console.log('[EditTask] Creating new calendar events');
-        const eventId = await createCalendarEventForTask(taskWithCalendar, companionName, assignedToName);
-        if (eventId) {
-          dispatch(setTaskCalendarEventId({taskId: updated.id, eventId}));
-          dispatch(updateTask({taskId: updated.id, updates: {calendarEventId: eventId}}));
-        }
-      } else if (task.calendarEventId) {
-        // Calendar sync was disabled - remove existing calendar events
-        console.log('[EditTask] Calendar sync disabled, removing events:', task.calendarEventId);
+    if (formData.syncWithCalendar) {
+      // Remove old calendar events before creating new ones to avoid duplicates
+      if (task.calendarEventId) {
+        console.log(
+          '[EditTask] Removing old calendar events:',
+          task.calendarEventId,
+        );
         await removeCalendarEvents(task.calendarEventId);
-        dispatch(setTaskCalendarEventId({taskId: updated.id, eventId: null}));
       }
 
-      handleSmartBack();
+      // Get companion name
+      const companion = companions.find(c => c.id === task.companionId);
+      const companionName = companion?.name || 'Companion';
+
+      // Get assigned user name
+      const assignedToName = getAssignedUserName(
+        formData.assignedTo,
+        currentUser,
+        coParents,
+      );
+
+      // WORKAROUND: Backend doesn't return calendarProvider, so use formData value
+      const taskWithCalendar = {
+        ...updated,
+        calendarProvider: formData.calendarProvider || undefined,
+      };
+
+      console.log('[EditTask] Creating new calendar events');
+      const eventId = await createCalendarEventForTask(
+        taskWithCalendar,
+        companionName,
+        assignedToName,
+      );
+      if (eventId) {
+        dispatch(setTaskCalendarEventId({taskId: updated.id, eventId}));
+        dispatch(
+          updateTask({taskId: updated.id, updates: {calendarEventId: eventId}}),
+        );
+      }
+    } else if (task.calendarEventId) {
+      // Calendar sync was disabled - remove existing calendar events
+      console.log(
+        '[EditTask] Calendar sync disabled, removing events:',
+        task.calendarEventId,
+      );
+      await removeCalendarEvents(task.calendarEventId);
+      dispatch(setTaskCalendarEventId({taskId: updated.id, eventId: null}));
+    }
+
+    handleSmartBack();
+  };
+
+  const handleSave = () => {
+    if (!validateForm(formData)) return;
+    if (!task) return;
+    if (task.frequency !== 'once') {
+      taskSaveSheetRef.current?.open();
+    } else {
+      performSave().catch(error =>
+        showErrorAlert('Unable to update task', error),
+      );
+    }
+  };
+
+  const confirmSaveForDay = async () => {
+    try {
+      await performSave();
+    } catch (error) {
+      showErrorAlert('Unable to update task', error);
+    }
+  };
+
+  const confirmSaveAll = async () => {
+    try {
+      await performSave();
     } catch (error) {
       showErrorAlert('Unable to update task', error);
     }
@@ -137,21 +191,48 @@ export const EditTaskScreen: React.FC = () => {
     try {
       // Remove calendar events if they exist
       if (task.calendarEventId) {
-        console.log('[EditTask] Deleting task, removing calendar events:', task.calendarEventId);
+        console.log(
+          '[EditTask] Deleting task, removing calendar events:',
+          task.calendarEventId,
+        );
         await removeCalendarEvents(task.calendarEventId);
       }
 
-      await dispatch(deleteTask({taskId: task.id, companionId: task.companionId})).unwrap();
+      await dispatch(
+        deleteTask({taskId: task.id, companionId: task.companionId}),
+      ).unwrap();
       handleSmartBack();
     } catch (error) {
       showErrorAlert('Unable to delete task', error);
     }
   };
 
+  const confirmDeleteTaskForDay = async () => {
+    if (!task) return;
+    try {
+      if (task.calendarEventId) {
+        await removeCalendarEvents(task.calendarEventId);
+      }
+      await dispatch(
+        deleteTask({taskId: task.id, companionId: task.companionId}),
+      ).unwrap();
+      handleSmartBack();
+    } catch (error) {
+      showErrorAlert('Unable to delete task for this day', error);
+    }
+  };
+
   if (!task) {
     return (
       <LiquidGlassHeaderScreen
-        header={<Header title="Edit task" showBackButton onBack={() => navigation.goBack()} glass={false} />}
+        header={
+          <Header
+            title="Edit task"
+            showBackButton
+            onBack={() => navigation.goBack()}
+            glass={false}
+          />
+        }
         contentPadding={theme.spacing['3']}>
         {() => (
           <View style={styles.errorContainer}>
@@ -183,7 +264,10 @@ export const EditTaskScreen: React.FC = () => {
               styles.contentContainer,
               contentPaddingStyle,
               {
-                paddingTop: (typeof contentPaddingStyle?.paddingTop === 'number' ? contentPaddingStyle.paddingTop : theme.spacing['14']) + theme.spacing['4'],
+                paddingTop:
+                  (typeof contentPaddingStyle?.paddingTop === 'number'
+                    ? contentPaddingStyle.paddingTop
+                    : theme.spacing['14']) + theme.spacing['4'],
                 paddingBottom: theme.spacing['18'],
               },
             ]}
@@ -199,17 +283,21 @@ export const EditTaskScreen: React.FC = () => {
             </View>
 
             <TaskFormContent
-          formData={formData}
-          errors={errors}
-          theme={theme}
-          updateField={updateField}
-          isMedicationForm={isMedicationForm}
-          isObservationalToolForm={isObservationalToolForm}
-          isSimpleForm={isSimpleForm}
-          reminderOptions={REMINDER_OPTIONS}
-          styles={styles}
+              formData={formData}
+              errors={errors}
+              theme={theme}
+              updateField={updateField}
+              isMedicationForm={isMedicationForm}
+              isObservationalToolForm={isObservationalToolForm}
+              isSimpleForm={isSimpleForm}
+              reminderOptions={REMINDER_OPTIONS}
+              styles={styles}
               sheetHandlers={sheetHandlers}
-              fileHandlers={createFileHandlers(openSheet, uploadSheetRef, handleRemoveFile)}
+              fileHandlers={createFileHandlers(
+                openSheet,
+                uploadSheetRef,
+                handleRemoveFile,
+              )}
               fileError={errors.attachments}
             />
           </ScrollView>
@@ -227,29 +315,27 @@ export const EditTaskScreen: React.FC = () => {
       {/* Date Pickers & Bottom Sheets */}
       <TaskFormSheets
         {...getTaskFormSheetProps(hookData)}
-    formData={formData}
-    updateField={updateField}
-    companionType={companionType}
-    uploadSheetRef={uploadSheetRef}
-    onDiscard={() => navigation.goBack()}
-  />
+        formData={formData}
+        updateField={updateField}
+        companionType={companionType}
+        uploadSheetRef={uploadSheetRef}
+        onDiscard={() => navigation.goBack()}
+      />
 
-      <DeleteDocumentBottomSheet
-        ref={hookData.deleteSheetRef}
-        documentTitle={task?.title ?? 'this task'}
-        title="Delete task"
-        message={
-          task
-            ? `Are you sure you want to delete the task "${task.title}"?`
-            : 'Are you sure you want to delete this task?'
-        }
-        primaryLabel="Delete"
-        secondaryLabel="Cancel"
-        onDelete={confirmDeleteTask}
+      <TaskDeleteBottomSheet
+        ref={taskDeleteSheetRef}
+        taskTitle={task?.title}
+        onDeleteAll={confirmDeleteTask}
+        onDeleteForDay={confirmDeleteTaskForDay}
+      />
+
+      <TaskSaveOptionsBottomSheet
+        ref={taskSaveSheetRef}
+        onSaveAll={confirmSaveAll}
+        onSaveForDay={confirmSaveForDay}
       />
     </>
   );
 };
-
 
 export default EditTaskScreen;

--- a/apps/mobileAppYC/src/shared/components/common/LiquidGlassCard/LiquidGlassCard.tsx
+++ b/apps/mobileAppYC/src/shared/components/common/LiquidGlassCard/LiquidGlassCard.tsx
@@ -1,15 +1,6 @@
 import React from 'react';
-import {
-  Platform,
-  StyleProp,
-  StyleSheet,
-  View,
-  ViewStyle,
-} from 'react-native';
-import {
-  LiquidGlassView,
-  isLiquidGlassSupported,
-} from '@callstack/liquid-glass';
+import {Platform, StyleProp, StyleSheet, View, ViewStyle} from 'react-native';
+import {LiquidGlassView, isLiquidGlassSupported} from '@callstack/liquid-glass';
 import {useTheme} from '@/hooks';
 import {UI_FEATURE_FLAGS} from '@/config/variables';
 
@@ -76,7 +67,9 @@ export const LiquidGlassCard: React.FC<LiquidGlassCardProps> = ({
         ? ANDROID_DARK_CARD_TINT_REGULAR
         : ANDROID_LIGHT_CARD_TINT_REGULAR;
     }
-    return resolvedColorScheme === 'dark' ? IOS_DARK_CARD_TINT : IOS_LIGHT_CARD_TINT;
+    return resolvedColorScheme === 'dark'
+      ? IOS_DARK_CARD_TINT
+      : IOS_LIGHT_CARD_TINT;
   }, [glassEffect, resolvedColorScheme, tintColor]);
 
   const defaultBackgroundColor = isDark
@@ -110,10 +103,11 @@ export const LiquidGlassCard: React.FC<LiquidGlassCardProps> = ({
     defaultBackgroundColor;
   const overlayBorderColor = FORCE_CARD_BORDER
     ? FORCED_BORDER_COLOR
-    : (mergedStyleOverrides?.borderColor as string | undefined) ?? defaultBorderColor;
+    : ((mergedStyleOverrides?.borderColor as string | undefined) ??
+      defaultBorderColor);
   const overlayBorderWidth = FORCE_CARD_BORDER
     ? FORCED_BORDER_WIDTH
-    : mergedStyleOverrides?.borderWidth ?? defaultBorderWidth;
+    : (mergedStyleOverrides?.borderWidth ?? defaultBorderWidth);
 
   const overlayShapeStyle = React.useMemo(() => {
     const shape: ViewStyle = {};
@@ -155,7 +149,10 @@ export const LiquidGlassCard: React.FC<LiquidGlassCardProps> = ({
   ]);
 
   const useNativeGlass =
-    Platform.OS === 'ios' && isLiquidGlassSupported && !LOCK_IOS_GLASS_APPEARANCE;
+    Platform.OS === 'ios' &&
+    isLiquidGlassSupported &&
+    !LOCK_IOS_GLASS_APPEARANCE &&
+    glassEffect !== 'none';
 
   if (useNativeGlass) {
     const iosGlassStyle = StyleSheet.flatten([


### PR DESCRIPTION
## What is the current behavior?

Recurring tasks had no scope options for save/delete — actions applied immediately with no choice between "all occurrences" or "this day only". `TaskDeleteBottomSheet` and `TaskSaveOptionsBottomSheet` also had ~49 lines of duplicated code each (flagged by SonarQube). The map discovery view lacked cluster pin support and an integrated clinic bottom sheet.

## What is the new behavior?

- Pressing **Save** on a recurring task opens a bottom sheet to choose:
  - Save for all occurrences
  - Save for this day only

- Pressing **Delete** on a recurring task opens a bottom sheet to choose:
  - Delete all occurrences
  - Delete for this day only

- Extracted `TaskRecurringActionSheet` as a shared component. Both sheets are now thin wrappers, eliminating the SonarQube duplication.

- Added `ClusterMapPin` for grouped clinic markers on the map.

- Integrated `ClinicBottomSheet` into `MapDiscoveryView` for inline clinic details.

- Updated `BrowseBusinessesScreen` with a map discovery entry point.

- Fixed 8 failing tests:
  - Store persist version assertion
  - `EditTaskScreen` missing refs
  - Incorrect bottom sheet mock in `EditTaskScreen` tests
  - `useEditTaskScreen` `handleDelete` ref issue
  - `ClinicMapPin` snapshot test

## Related Issue(s)
