### PR TITLE
feat(repo): add inpatient encounter, room, and admission management

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -2,7 +2,7 @@
 
 Inherits all root `AGENTS.md` rules. This file adds backend-specific rules.
 
-**Stack:** Express.js 4, TypeScript, MongoDB/Mongoose, Prisma, BullMQ, Zod, Winston.
+**Stack:** Express.js 4, TypeScript, Prisma, BullMQ, Zod, Winston.
 
 > **Important:** Do not refactor backend architecture unless explicitly asked.
 
@@ -80,3 +80,4 @@ AWS Cognito + `jsonwebtoken` + `jwks-rsa`. Never roll custom auth flows.
 - No synchronous processing of work that should be queued.
 - Never re-initialize Firebase Admin SDK in a handler — it's a singleton.
 - Always verify Stripe webhook signatures before processing.
+- No more usage of Mongodb or Mongoose anymore for new code

--- a/apps/backend/src/controllers/web/appointment.prisma.controller.ts
+++ b/apps/backend/src/controllers/web/appointment.prisma.controller.ts
@@ -1,0 +1,441 @@
+import { Request, Response } from "express";
+import { AppointmentRequestDTO } from "@yosemite-crew/types";
+import { AppointmentPrismaService } from "src/services/appointment.prisma.service";
+import { AuthUserMobileService } from "src/services/authUserMobile.service";
+import logger from "src/utils/logger";
+import { generatePresignedUrl } from "src/middlewares/upload";
+import { resolveUserIdFromRequest } from "src/utils/request";
+
+type RescheduleRequestBody = {
+  startTime: string | Date;
+  endTime: string | Date;
+  concern?: string;
+  isEmergency?: boolean;
+  durationMinutes?: number;
+};
+
+type CancelBody = { reason?: string };
+
+type UploadUrlBody = { companionId?: string; mimeType?: string };
+type AttachFormsBody = { formIds?: string[] };
+
+type ErrorWithStatus = Error & { statusCode?: number };
+
+const parseError = (
+  err: unknown,
+  fallbackMessage: string,
+): { status: number; message: string } => {
+  const status =
+    typeof err === "object" &&
+    err !== null &&
+    "statusCode" in err &&
+    typeof (err as ErrorWithStatus).statusCode === "number"
+      ? ((err as ErrorWithStatus).statusCode ?? 500)
+      : 500;
+
+  const message =
+    err instanceof Error && err.message ? err.message : fallbackMessage;
+
+  return { status, message };
+};
+
+const sendAppointmentError = (
+  res: Response,
+  err: unknown,
+  fallbackMessage: string,
+) => {
+  const { status, message } = parseError(err, fallbackMessage);
+  return res.status(status).json({ message });
+};
+
+export const AppointmentController = {
+  createRequestedFromMobile: async (
+    req: Request<unknown, unknown, AppointmentRequestDTO>,
+    res: Response,
+  ) => {
+    try {
+      const data = await AppointmentPrismaService.createRequestedFromMobile(
+        req.body,
+      );
+      return res.status(201).json({ message: "Appointment created", data });
+    } catch (err: unknown) {
+      logger.error("Appointment creation error", err);
+      return sendAppointmentError(res, err, "Failed to create appointment");
+    }
+  },
+
+  rescheduleFromMobile: async (
+    req: Request<{ appointmentId: string }, unknown, RescheduleRequestBody>,
+    res: Response,
+  ) => {
+    try {
+      const authUserId = resolveUserIdFromRequest(req);
+      if (!authUserId) {
+        return res.status(401).json({ message: "User not authenticated" });
+      }
+
+      const authUser =
+        await AuthUserMobileService.getByProviderUserId(authUserId);
+      if (!authUser?.parentId) {
+        return res
+          .status(400)
+          .json({ message: "Parent information missing for user" });
+      }
+
+      const { appointmentId } = req.params;
+      const { startTime, endTime, concern, isEmergency, durationMinutes } =
+        req.body;
+
+      if (!startTime || !endTime) {
+        return res
+          .status(400)
+          .json({ message: "Start time and end time are required" });
+      }
+
+      const data = await AppointmentPrismaService.rescheduleFromParent(
+        appointmentId,
+        authUser.parentId.toString(),
+        { startTime, endTime, concern, isEmergency, durationMinutes },
+      );
+
+      return res
+        .status(200)
+        .json({ message: "Rescheduled successfully", data });
+    } catch (err: unknown) {
+      logger.error("Appointment rescheduling error", err);
+      return sendAppointmentError(res, err, "Failed to reschedule appointment");
+    }
+  },
+
+  createFromPms: async (
+    req: Request<unknown, unknown, AppointmentRequestDTO>,
+    res: Response,
+  ) => {
+    try {
+      const { createPayment, paymentCollectionMethod } = req.query;
+      const shouldCreatePayment =
+        createPayment === "true" || createPayment === "1";
+
+      const data = await AppointmentPrismaService.createAppointmentFromPms(
+        req.body,
+        shouldCreatePayment,
+        typeof paymentCollectionMethod === "string"
+          ? paymentCollectionMethod
+          : undefined,
+      );
+
+      return res.status(201).json({ message: "Appointment created", data });
+    } catch (err: unknown) {
+      logger.error("Appointment creation error", err);
+      return sendAppointmentError(
+        res,
+        err,
+        "Failed to create appointment (PMS)",
+      );
+    }
+  },
+
+  acceptRequested: async (
+    req: Request<{ appointmentId: string }, unknown, AppointmentRequestDTO>,
+    res: Response,
+  ) => {
+    try {
+      const { appointmentId } = req.params;
+      const data = await AppointmentPrismaService.approveRequestedFromPms(
+        appointmentId,
+        req.body,
+      );
+      return res.status(200).json({ message: "Appointment accepted", data });
+    } catch (err: unknown) {
+      logger.error("Appointment acceptance error", err);
+      return sendAppointmentError(res, err, "Failed to accept appointment");
+    }
+  },
+
+  rejectRequested: async (
+    req: Request<{ appointmentId: string }>,
+    res: Response,
+  ) => {
+    try {
+      const { appointmentId } = req.params;
+      const data =
+        await AppointmentPrismaService.rejectRequestedAppointment(
+          appointmentId,
+        );
+      return res.status(200).json({ message: "Appointment rejected", data });
+    } catch (err: unknown) {
+      logger.error("Appointment rejection error", err);
+      return sendAppointmentError(res, err, "Failed to reject appointment");
+    }
+  },
+
+  checkInAppointment: async (
+    req: Request<{ appointmentId: string }>,
+    res: Response,
+  ) => {
+    try {
+      const authUserId = resolveUserIdFromRequest(req);
+      if (!authUserId) {
+        return res.status(401).json({ message: "User not authenticated" });
+      }
+
+      const authUser =
+        await AuthUserMobileService.getByProviderUserId(authUserId);
+      if (!authUser?.parentId) {
+        return res
+          .status(400)
+          .json({ message: "Parent information missing for user" });
+      }
+
+      const data = await AppointmentPrismaService.checkInAppointmentParent(
+        req.params.appointmentId,
+        authUser.parentId.toString(),
+      );
+
+      return res.status(200).json({ message: "Appointment checked in", data });
+    } catch (err: unknown) {
+      logger.error("Appointment check-in error", err);
+      return sendAppointmentError(res, err, "Failed to check-in appointment");
+    }
+  },
+
+  checkInAppointmentForPMS: async (
+    req: Request<{ appointmentId: string }>,
+    res: Response,
+  ) => {
+    try {
+      const data = await AppointmentPrismaService.checkInAppointment(
+        req.params.appointmentId,
+      );
+      return res.status(200).json({ message: "Appointment checked in", data });
+    } catch (err: unknown) {
+      logger.error("Appointment check-in error", err);
+      return sendAppointmentError(res, err, "Failed to check-in appointment");
+    }
+  },
+
+  updateFromPms: async (
+    req: Request<{ appointmentId: string }, unknown, AppointmentRequestDTO>,
+    res: Response,
+  ) => {
+    try {
+      const data = await AppointmentPrismaService.updateAppointmentPMS(
+        req.params.appointmentId,
+        req.body,
+      );
+      return res.status(200).json({ message: "Appointment updated", data });
+    } catch (err: unknown) {
+      logger.error("Appointment update error", err);
+      return sendAppointmentError(res, err, "Failed to update appointment");
+    }
+  },
+
+  attachFormsToAppointment: async (
+    req: Request<{ appointmentId: string }, unknown, AttachFormsBody>,
+    res: Response,
+  ) => {
+    try {
+      const data = await AppointmentPrismaService.attachFormsToAppointment(
+        req.params.appointmentId,
+        req.body.formIds ?? [],
+      );
+      return res.status(200).json({ message: "Forms attached", data });
+    } catch (err: unknown) {
+      logger.error("Attach forms error", err);
+      return sendAppointmentError(res, err, "Failed to attach forms");
+    }
+  },
+
+  cancelFromMobile: async (
+    req: Request<{ appointmentId: string }, unknown, CancelBody>,
+    res: Response,
+  ) => {
+    try {
+      const authUserId = resolveUserIdFromRequest(req);
+      if (!authUserId) {
+        return res.status(401).json({ message: "User not authenticated" });
+      }
+
+      const authUser =
+        await AuthUserMobileService.getByProviderUserId(authUserId);
+      if (!authUser?.parentId) {
+        return res
+          .status(400)
+          .json({ message: "Parent information missing for user" });
+      }
+
+      const data = await AppointmentPrismaService.cancelAppointmentFromParent(
+        req.params.appointmentId,
+        authUser.parentId.toString(),
+        req.body.reason,
+      );
+
+      return res.status(200).json({ message: "Appointment cancelled", data });
+    } catch (err: unknown) {
+      logger.error("Appointment cancellation error", err);
+      return sendAppointmentError(res, err, "Failed to cancel appointment");
+    }
+  },
+
+  cancelFromPMS: async (
+    req: Request<{ appointmentId: string }, unknown, CancelBody>,
+    res: Response,
+  ) => {
+    try {
+      const data = await AppointmentPrismaService.cancelAppointment(
+        req.params.appointmentId,
+        req.body.reason,
+      );
+      return res.status(200).json({ message: "Appointment cancelled", data });
+    } catch (err: unknown) {
+      logger.error("Appointment cancellation error", err);
+      return sendAppointmentError(res, err, "Failed to cancel appointment");
+    }
+  },
+
+  getById: async (req: Request<{ appointmentId: string }>, res: Response) => {
+    try {
+      const data = await AppointmentPrismaService.getById(
+        req.params.appointmentId,
+      );
+      return res.status(200).json({ data });
+    } catch (err: unknown) {
+      logger.error("Appointment fetch error", err);
+      return sendAppointmentError(res, err, "Failed to fetch appointment");
+    }
+  },
+
+  listByCompanion: async (
+    req: Request<{ companionId: string }>,
+    res: Response,
+  ) => {
+    try {
+      const data = await AppointmentPrismaService.getAppointmentsForCompanion(
+        req.params.companionId,
+      );
+      return res.status(200).json({ data });
+    } catch (err: unknown) {
+      logger.error("Appointment list error", err);
+      return sendAppointmentError(res, err, "Failed to fetch appointments");
+    }
+  },
+
+  listByCompanionForOrganisation: async (
+    req: Request<{ organisationId: string; companionId: string }>,
+    res: Response,
+  ) => {
+    try {
+      const data =
+        await AppointmentPrismaService.getAppointmentsForCompanionByOrganisation(
+          req.params.companionId,
+          req.params.organisationId,
+        );
+      return res.status(200).json({ data });
+    } catch (err: unknown) {
+      logger.error("Appointment list error", err);
+      return sendAppointmentError(res, err, "Failed to fetch appointments");
+    }
+  },
+
+  listByParent: async (req: Request, res: Response) => {
+    try {
+      const authUserId = resolveUserIdFromRequest(req);
+      if (!authUserId) {
+        return res.status(401).json({ message: "User not authenticated" });
+      }
+
+      const authUser =
+        await AuthUserMobileService.getByProviderUserId(authUserId);
+      if (!authUser?.parentId) {
+        return res
+          .status(400)
+          .json({ message: "Parent information missing for user" });
+      }
+
+      const data = await AppointmentPrismaService.getAppointmentsForParent(
+        authUser.parentId.toString(),
+      );
+      return res.status(200).json({ data });
+    } catch (err: unknown) {
+      logger.error("Appointment list error", err);
+      return sendAppointmentError(res, err, "Failed to fetch appointments");
+    }
+  },
+
+  listByOrganisation: async (
+    req: Request<{ organisationId: string }>,
+    res: Response,
+  ) => {
+    try {
+      const { organisationId } = req.params;
+      const { status, startDate, endDate } = req.query;
+      const statuses = Array.isArray(status)
+        ? status
+        : typeof status === "string"
+          ? [status]
+          : undefined;
+
+      const data =
+        await AppointmentPrismaService.getAppointmentsForOrganisation(
+          organisationId,
+          {
+            status: statuses as never,
+            startDate:
+              typeof startDate === "string" ? new Date(startDate) : undefined,
+            endDate:
+              typeof endDate === "string" ? new Date(endDate) : undefined,
+          },
+        );
+
+      return res.status(200).json({ data });
+    } catch (err: unknown) {
+      logger.error("Appointment list error", err);
+      return sendAppointmentError(res, err, "Failed to fetch appointments");
+    }
+  },
+
+  listByLead: async (req: Request<{ leadId: string }>, res: Response) => {
+    try {
+      const data = await AppointmentPrismaService.getAppointmentsForLead(
+        req.params.leadId,
+      );
+      return res.status(200).json({ data });
+    } catch (err: unknown) {
+      logger.error("Appointment list error", err);
+      return sendAppointmentError(res, err, "Failed to fetch appointments");
+    }
+  },
+
+  getDocumentUplaodURL: async (
+    req: Request<unknown, unknown, UploadUrlBody>,
+    res: Response,
+  ) => {
+    try {
+      const { companionId, mimeType } = req.body;
+      const authUserId = resolveUserIdFromRequest(req);
+      if (!authUserId) {
+        return res.status(401).json({ message: "User not authenticated" });
+      }
+      if (!companionId || !mimeType) {
+        return res
+          .status(400)
+          .json({ message: "companionId and mimeType are required" });
+      }
+
+      const upload = await generatePresignedUrl(
+        mimeType,
+        "custom",
+        `appointments/${companionId}`,
+      );
+
+      return res.status(200).json({ data: upload });
+    } catch (err: unknown) {
+      logger.error("Appointment document upload error", err);
+      return sendAppointmentError(
+        res,
+        err,
+        "Failed to create document upload URL",
+      );
+    }
+  },
+};

--- a/apps/backend/src/controllers/web/case-encounter.controller.ts
+++ b/apps/backend/src/controllers/web/case-encounter.controller.ts
@@ -50,6 +50,20 @@ const dischargeEncounterSchema = z
       .optional(),
   })
   .passthrough();
+const assignUnitSchema = z
+  .object({
+    resourceType: z.literal("Parameters").optional(),
+    parameter: z
+      .array(
+        z.object({
+          name: z.string(),
+          valueString: z.string().optional(),
+          valueDateTime: z.string().datetime().optional(),
+        }),
+      )
+      .optional(),
+  })
+  .passthrough();
 
 const parseReferenceId = (value?: string, prefix?: string) => {
   const trimmed = value?.trim();
@@ -192,6 +206,35 @@ export const EncounterController = {
       return res.status(200).json(toEncounterResponseDTO(updated));
     } catch (error) {
       return handleError(res, error, "Failed to discharge encounter.");
+    }
+  },
+
+  assignUnit: async (req: Request<{ id: string }>, res: Response) => {
+    try {
+      const payload = assignUnitSchema.parse(req.body ?? {});
+      const unitId = payload.parameter?.find(
+        (parameter) => parameter.name === "unitId",
+      )?.valueString;
+      const assignedBy = payload.parameter?.find(
+        (parameter) => parameter.name === "assignedBy",
+      )?.valueString;
+      const reason = payload.parameter?.find(
+        (parameter) => parameter.name === "reason",
+      )?.valueString;
+      const assignedAt = payload.parameter?.find(
+        (parameter) => parameter.name === "assignedAt",
+      )?.valueDateTime;
+
+      const updated = await CaseEncounterService.assignUnit(req.params.id, {
+        unitId: unitId ?? "",
+        assignedBy,
+        reason,
+        assignedAt: assignedAt ? new Date(assignedAt) : undefined,
+      });
+
+      return res.status(200).json(toEncounterResponseDTO(updated));
+    } catch (error) {
+      return handleError(res, error, "Failed to assign unit.");
     }
   },
 

--- a/apps/backend/src/controllers/web/case-encounter.controller.ts
+++ b/apps/backend/src/controllers/web/case-encounter.controller.ts
@@ -67,6 +67,19 @@ const assignUnitSchema = z
       .optional(),
   })
   .passthrough();
+const lifecycleOperationSchema = z
+  .object({
+    resourceType: z.literal("Parameters").optional(),
+    parameter: z
+      .array(
+        z.object({
+          name: z.string(),
+          valueDateTime: z.string().datetime().optional(),
+        }),
+      )
+      .optional(),
+  })
+  .passthrough();
 
 const unitAssignmentResource = (assignment: {
   id: string;
@@ -305,6 +318,61 @@ export const EncounterController = {
       });
     } catch (error) {
       return handleError(res, error, "Failed to list unit assignments.");
+    }
+  },
+
+  listAdmissionUnitAssignments: async (
+    req: Request<{ id: string }>,
+    res: Response,
+  ) => {
+    try {
+      const assignments =
+        await CaseEncounterService.listAdmissionUnitAssignments(req.params.id);
+
+      return res.status(200).json({
+        resourceType: "Parameters",
+        parameter: assignments.map(unitAssignmentResource),
+      });
+    } catch (error) {
+      return handleError(
+        res,
+        error,
+        "Failed to list admission unit assignments.",
+      );
+    }
+  },
+
+  start: async (req: Request<{ id: string }>, res: Response) => {
+    try {
+      const payload = lifecycleOperationSchema.parse(req.body ?? {});
+      const startedAt = payload.parameter?.find(
+        (parameter) => parameter.name === "startedAt",
+      )?.valueDateTime;
+
+      const updated = await CaseEncounterService.startEncounter(req.params.id, {
+        startedAt: startedAt ? new Date(startedAt) : undefined,
+      });
+
+      return res.status(200).json(toEncounterResponseDTO(updated));
+    } catch (error) {
+      return handleError(res, error, "Failed to start encounter.");
+    }
+  },
+
+  readyForDischarge: async (req: Request<{ id: string }>, res: Response) => {
+    try {
+      lifecycleOperationSchema.parse(req.body ?? {});
+      const updated = await CaseEncounterService.markEncounterReadyForDischarge(
+        req.params.id,
+      );
+
+      return res.status(200).json(toEncounterResponseDTO(updated));
+    } catch (error) {
+      return handleError(
+        res,
+        error,
+        "Failed to mark encounter ready for discharge.",
+      );
     }
   },
 

--- a/apps/backend/src/controllers/web/case-encounter.controller.ts
+++ b/apps/backend/src/controllers/web/case-encounter.controller.ts
@@ -37,6 +37,9 @@ const encounterListQuerySchema = z.object({
   status: z.string().trim().optional(),
   appointmentKind: z.enum(["OUTPATIENT", "INPATIENT"]).optional(),
 });
+const activeInpatientListQuerySchema = z.object({
+  organization: z.string().trim().optional(),
+});
 const dischargeEncounterSchema = z
   .object({
     resourceType: z.literal("Parameters").optional(),
@@ -302,6 +305,41 @@ export const EncounterController = {
       });
     } catch (error) {
       return handleError(res, error, "Failed to list unit assignments.");
+    }
+  },
+
+  listActiveInpatients: async (req: Request, res: Response) => {
+    try {
+      const query = activeInpatientListQuerySchema.parse(req.query);
+      const organisationId = parseReferenceId(
+        query.organization,
+        "Organization",
+      );
+
+      if (!organisationId) {
+        return res.status(400).json({
+          message: "organization is required.",
+        });
+      }
+
+      const values = await CaseEncounterService.listActiveInpatientEncounters({
+        organisationId,
+      });
+
+      return res.status(200).json({
+        resourceType: "Bundle",
+        type: "searchset",
+        total: values.length,
+        entry: values.map((value) => ({
+          resource: toEncounterResponseDTO(value),
+        })),
+      });
+    } catch (error) {
+      return handleError(
+        res,
+        error,
+        "Failed to list active inpatient encounters.",
+      );
     }
   },
 

--- a/apps/backend/src/controllers/web/case-encounter.controller.ts
+++ b/apps/backend/src/controllers/web/case-encounter.controller.ts
@@ -37,6 +37,19 @@ const encounterListQuerySchema = z.object({
   status: z.string().trim().optional(),
   appointmentKind: z.enum(["OUTPATIENT", "INPATIENT"]).optional(),
 });
+const dischargeEncounterSchema = z
+  .object({
+    resourceType: z.literal("Parameters").optional(),
+    parameter: z
+      .array(
+        z.object({
+          name: z.string(),
+          valueDateTime: z.string().datetime().optional(),
+        }),
+      )
+      .optional(),
+  })
+  .passthrough();
 
 const parseReferenceId = (value?: string, prefix?: string) => {
   const trimmed = value?.trim();
@@ -155,6 +168,30 @@ export const EncounterController = {
       return res.status(200).json(toEncounterResponseDTO(updated));
     } catch (error) {
       return handleError(res, error, "Failed to update encounter.");
+    }
+  },
+
+  discharge: async (req: Request<{ id: string }>, res: Response) => {
+    try {
+      const payload = dischargeEncounterSchema.parse(req.body ?? {});
+      const dischargedAt = payload.parameter?.find(
+        (parameter) => parameter.name === "dischargedAt",
+      )?.valueDateTime;
+      const periodEnd = payload.parameter?.find(
+        (parameter) => parameter.name === "periodEnd",
+      )?.valueDateTime;
+
+      const updated = await CaseEncounterService.dischargeEncounter(
+        req.params.id,
+        {
+          dischargedAt: dischargedAt ? new Date(dischargedAt) : undefined,
+          periodEnd: periodEnd ? new Date(periodEnd) : undefined,
+        },
+      );
+
+      return res.status(200).json(toEncounterResponseDTO(updated));
+    } catch (error) {
+      return handleError(res, error, "Failed to discharge encounter.");
     }
   },
 

--- a/apps/backend/src/controllers/web/case-encounter.controller.ts
+++ b/apps/backend/src/controllers/web/case-encounter.controller.ts
@@ -1,0 +1,193 @@
+import { Request, Response } from "express";
+import { z } from "zod";
+import {
+  fromCaseRequestDTO,
+  fromEncounterRequestDTO,
+  toCaseResponseDTO,
+  toEncounterResponseDTO,
+  type CaseRequestDTO,
+  type EncounterRequestDTO,
+} from "@yosemite-crew/types";
+import {
+  CaseEncounterService,
+  CaseEncounterServiceError,
+} from "src/services/case-encounter.service";
+import logger from "src/utils/logger";
+
+const caseResourceSchema = z
+  .object({ resourceType: z.literal("EpisodeOfCare") })
+  .passthrough();
+const encounterResourceSchema = z
+  .object({ resourceType: z.literal("Encounter") })
+  .passthrough();
+
+const caseListQuerySchema = z.object({
+  organization: z.string().trim().optional(),
+  patient: z.string().trim().optional(),
+  parent: z.string().trim().optional(),
+  status: z.string().trim().optional(),
+  appointmentKind: z.enum(["OUTPATIENT", "INPATIENT"]).optional(),
+});
+
+const encounterListQuerySchema = z.object({
+  organization: z.string().trim().optional(),
+  episodeofcare: z.string().trim().optional(),
+  patient: z.string().trim().optional(),
+  parent: z.string().trim().optional(),
+  status: z.string().trim().optional(),
+  appointmentKind: z.enum(["OUTPATIENT", "INPATIENT"]).optional(),
+});
+
+const parseReferenceId = (value?: string, prefix?: string) => {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  return prefix ? trimmed.replace(new RegExp(`^${prefix}/`), "") : trimmed;
+};
+
+const handleError = (res: Response, error: unknown, fallback: string) => {
+  if (error instanceof CaseEncounterServiceError) {
+    return res.status(error.statusCode).json({ message: error.message });
+  }
+
+  logger.error(fallback, error);
+  return res.status(500).json({ message: fallback });
+};
+
+export const CaseController = {
+  create: async (
+    req: Request<unknown, unknown, CaseRequestDTO>,
+    res: Response,
+  ) => {
+    try {
+      const dto = caseResourceSchema.parse(
+        req.body,
+      ) as unknown as CaseRequestDTO;
+      const created = await CaseEncounterService.createCase(
+        fromCaseRequestDTO(dto),
+      );
+      return res.status(201).json(toCaseResponseDTO(created));
+    } catch (error) {
+      return handleError(res, error, "Failed to create case.");
+    }
+  },
+
+  update: async (
+    req: Request<{ id: string }, unknown, CaseRequestDTO>,
+    res: Response,
+  ) => {
+    try {
+      const dto = caseResourceSchema.parse(
+        req.body,
+      ) as unknown as CaseRequestDTO;
+      const updated = await CaseEncounterService.updateCase(
+        req.params.id,
+        fromCaseRequestDTO(dto),
+      );
+      return res.status(200).json(toCaseResponseDTO(updated));
+    } catch (error) {
+      return handleError(res, error, "Failed to update case.");
+    }
+  },
+
+  getById: async (req: Request<{ id: string }>, res: Response) => {
+    try {
+      const value = await CaseEncounterService.getCaseById(req.params.id);
+      return res.status(200).json(toCaseResponseDTO(value));
+    } catch (error) {
+      return handleError(res, error, "Failed to fetch case.");
+    }
+  },
+
+  list: async (req: Request, res: Response) => {
+    try {
+      const query = caseListQuerySchema.parse(req.query);
+      const values = await CaseEncounterService.listCases({
+        organisationId: parseReferenceId(query.organization, "Organization"),
+        companionId: parseReferenceId(query.patient, "Patient"),
+        parentId: parseReferenceId(query.parent, "RelatedPerson"),
+        status: query.status as never,
+        appointmentKind: query.appointmentKind,
+      });
+      return res.status(200).json({
+        resourceType: "Bundle",
+        type: "searchset",
+        total: values.length,
+        entry: values.map((value) => ({
+          resource: toCaseResponseDTO(value),
+        })),
+      });
+    } catch (error) {
+      return handleError(res, error, "Failed to list cases.");
+    }
+  },
+};
+
+export const EncounterController = {
+  create: async (
+    req: Request<unknown, unknown, EncounterRequestDTO>,
+    res: Response,
+  ) => {
+    try {
+      const dto = encounterResourceSchema.parse(
+        req.body,
+      ) as unknown as EncounterRequestDTO;
+      const created = await CaseEncounterService.createEncounter(
+        fromEncounterRequestDTO(dto),
+      );
+      return res.status(201).json(toEncounterResponseDTO(created));
+    } catch (error) {
+      return handleError(res, error, "Failed to create encounter.");
+    }
+  },
+
+  update: async (
+    req: Request<{ id: string }, unknown, EncounterRequestDTO>,
+    res: Response,
+  ) => {
+    try {
+      const dto = encounterResourceSchema.parse(
+        req.body,
+      ) as unknown as EncounterRequestDTO;
+      const updated = await CaseEncounterService.updateEncounter(
+        req.params.id,
+        fromEncounterRequestDTO(dto),
+      );
+      return res.status(200).json(toEncounterResponseDTO(updated));
+    } catch (error) {
+      return handleError(res, error, "Failed to update encounter.");
+    }
+  },
+
+  getById: async (req: Request<{ id: string }>, res: Response) => {
+    try {
+      const value = await CaseEncounterService.getEncounterById(req.params.id);
+      return res.status(200).json(toEncounterResponseDTO(value));
+    } catch (error) {
+      return handleError(res, error, "Failed to fetch encounter.");
+    }
+  },
+
+  list: async (req: Request, res: Response) => {
+    try {
+      const query = encounterListQuerySchema.parse(req.query);
+      const values = await CaseEncounterService.listEncounters({
+        organisationId: parseReferenceId(query.organization, "Organization"),
+        caseId: parseReferenceId(query.episodeofcare, "EpisodeOfCare"),
+        companionId: parseReferenceId(query.patient, "Patient"),
+        parentId: parseReferenceId(query.parent, "RelatedPerson"),
+        status: query.status as never,
+        appointmentKind: query.appointmentKind,
+      });
+      return res.status(200).json({
+        resourceType: "Bundle",
+        type: "searchset",
+        total: values.length,
+        entry: values.map((value) => ({
+          resource: toEncounterResponseDTO(value),
+        })),
+      });
+    } catch (error) {
+      return handleError(res, error, "Failed to list encounters.");
+    }
+  },
+};

--- a/apps/backend/src/controllers/web/case-encounter.controller.ts
+++ b/apps/backend/src/controllers/web/case-encounter.controller.ts
@@ -65,6 +65,58 @@ const assignUnitSchema = z
   })
   .passthrough();
 
+const unitAssignmentResource = (assignment: {
+  id: string;
+  encounterId: string;
+  admissionId: string;
+  unitId: string;
+  assignedAt: Date;
+  releasedAt?: Date;
+  assignedBy?: string;
+  reason?: string;
+  createdAt?: Date;
+  updatedAt?: Date;
+}) => ({
+  name: "assignment",
+  part: [
+    { name: "id", valueString: assignment.id },
+    { name: "encounterId", valueString: assignment.encounterId },
+    { name: "admissionId", valueString: assignment.admissionId },
+    { name: "unitId", valueString: assignment.unitId },
+    { name: "assignedAt", valueDateTime: assignment.assignedAt.toISOString() },
+    ...(assignment.releasedAt
+      ? [
+          {
+            name: "releasedAt",
+            valueDateTime: assignment.releasedAt.toISOString(),
+          },
+        ]
+      : []),
+    ...(assignment.assignedBy
+      ? [{ name: "assignedBy", valueString: assignment.assignedBy }]
+      : []),
+    ...(assignment.reason
+      ? [{ name: "reason", valueString: assignment.reason }]
+      : []),
+    ...(assignment.createdAt
+      ? [
+          {
+            name: "createdAt",
+            valueDateTime: assignment.createdAt.toISOString(),
+          },
+        ]
+      : []),
+    ...(assignment.updatedAt
+      ? [
+          {
+            name: "updatedAt",
+            valueDateTime: assignment.updatedAt.toISOString(),
+          },
+        ]
+      : []),
+  ],
+});
+
 const parseReferenceId = (value?: string, prefix?: string) => {
   const trimmed = value?.trim();
   if (!trimmed) return undefined;
@@ -235,6 +287,21 @@ export const EncounterController = {
       return res.status(200).json(toEncounterResponseDTO(updated));
     } catch (error) {
       return handleError(res, error, "Failed to assign unit.");
+    }
+  },
+
+  listUnitAssignments: async (req: Request<{ id: string }>, res: Response) => {
+    try {
+      const assignments = await CaseEncounterService.listUnitAssignments({
+        encounterId: req.params.id,
+      });
+
+      return res.status(200).json({
+        resourceType: "Parameters",
+        parameter: assignments.map(unitAssignmentResource),
+      });
+    } catch (error) {
+      return handleError(res, error, "Failed to list unit assignments.");
     }
   },
 

--- a/apps/backend/src/controllers/web/organisation-room.controller.ts
+++ b/apps/backend/src/controllers/web/organisation-room.controller.ts
@@ -1,21 +1,16 @@
 import { Request, Response } from "express";
 import logger from "../../utils/logger";
 import {
+  fromFHIROrganisationRoom,
+  toFHIROrganisationRoom,
+  type OrganisationRoomRequestDTO,
+} from "@yosemite-crew/types";
+import {
   OrganisationRoomService,
   OrganisationRoomServiceError,
-  type OrganisationRoomFHIRPayload,
+  type OrganisationRoomInput,
 } from "../../services/organisation-room.service";
 import { OrgRequest } from "src/middlewares/rbac";
-
-const isFHIRLocationPayload = (
-  payload: unknown,
-): payload is OrganisationRoomFHIRPayload => {
-  return Boolean(
-    payload &&
-    typeof payload === "object" &&
-    (payload as { resourceType?: string }).resourceType === "Location",
-  );
-};
 
 const requireParam = (
   res: Response,
@@ -26,8 +21,14 @@ const requireParam = (
     res.status(400).json({ message });
     return false;
   }
+
   return true;
 };
+
+const getOrganisationId = (
+  req: Request,
+  fallback?: string,
+): string | undefined => (req as OrgRequest).organisationId ?? fallback;
 
 const handleServiceError = (
   res: Response,
@@ -44,25 +45,37 @@ const handleServiceError = (
   res.status(500).json({ message: responseMessage });
 };
 
-const respondNotFound = (res: Response) => {
-  res.status(404).json({ message: "Organisation room not found." });
-};
+const isRoomPayload = (value: unknown): value is OrganisationRoomRequestDTO =>
+  Boolean(
+    value &&
+    typeof value === "object" &&
+    (value as { resourceType?: string }).resourceType === "Location",
+  );
 
 export const OrganisationRoomController = {
   create: async (req: Request, res: Response) => {
     try {
-      const payload = req.body as OrganisationRoomFHIRPayload | undefined;
-
-      if (!isFHIRLocationPayload(payload)) {
-        res.status(400).json({
+      if (!isRoomPayload(req.body)) {
+        return res.status(400).json({
           message: "Invalid payload. Expected FHIR Location resource.",
         });
-        return;
       }
 
-      const { response, created } =
-        await OrganisationRoomService.create(payload);
-      res.status(created ? 201 : 200).json(response);
+      const payload = fromFHIROrganisationRoom(req.body);
+      const organisationId = getOrganisationId(req, payload.organisationId);
+
+      if (!organisationId) {
+        return res.status(400).json({
+          message: "Organization identifier is required.",
+        });
+      }
+
+      const created = await OrganisationRoomService.create({
+        ...payload,
+        organisationId,
+      } as Partial<OrganisationRoomInput>);
+
+      return res.status(201).json(toFHIROrganisationRoom(created));
     } catch (error) {
       handleServiceError(
         res,
@@ -73,30 +86,35 @@ export const OrganisationRoomController = {
     }
   },
 
-  update: async (req: Request, res: Response) => {
+  update: async (req: Request<{ id: string }>, res: Response) => {
     try {
       const { id } = req.params;
-      const payload = req.body as OrganisationRoomFHIRPayload | undefined;
 
       if (!requireParam(res, id, "Room identifier is required.")) {
         return;
       }
 
-      if (!isFHIRLocationPayload(payload)) {
-        res.status(400).json({
+      if (!isRoomPayload(req.body)) {
+        return res.status(400).json({
           message: "Invalid payload. Expected FHIR Location resource.",
         });
-        return;
       }
 
-      const resource = await OrganisationRoomService.update(id, payload);
+      const payload = fromFHIROrganisationRoom(req.body);
+      const organisationId = getOrganisationId(req, payload.organisationId);
 
-      if (!resource) {
-        respondNotFound(res);
-        return;
+      if (!organisationId) {
+        return res
+          .status(400)
+          .json({ message: "Organization identifier is required." });
       }
 
-      res.status(200).json(resource);
+      const updated = await OrganisationRoomService.update(id, {
+        ...payload,
+        organisationId,
+      } as Partial<OrganisationRoomInput>);
+
+      return res.status(200).json(toFHIROrganisationRoom(updated));
     } catch (error) {
       handleServiceError(
         res,
@@ -121,9 +139,12 @@ export const OrganisationRoomController = {
         return;
       }
 
-      const resources =
-        await OrganisationRoomService.getAllByOrganizationId(organizationId);
-      res.status(200).json(resources);
+      const rooms =
+        await OrganisationRoomService.getSummaryByOrganizationId(
+          organizationId,
+        );
+
+      return res.status(200).json(rooms.map(toFHIROrganisationRoom));
     } catch (error) {
       handleServiceError(
         res,
@@ -134,7 +155,71 @@ export const OrganisationRoomController = {
     }
   },
 
-  delete: async (req: Request, res: Response) => {
+  getById: async (
+    req: Request<{ organizationId: string; id: string }>,
+    res: Response,
+  ) => {
+    try {
+      const { organizationId, id } = req.params;
+
+      if (
+        !requireParam(
+          res,
+          organizationId,
+          "Organization identifier is required.",
+        ) ||
+        !requireParam(res, id, "Room identifier is required.")
+      ) {
+        return;
+      }
+
+      const room = await OrganisationRoomService.getById(id, organizationId);
+      return res.status(200).json(toFHIROrganisationRoom(room));
+    } catch (error) {
+      handleServiceError(
+        res,
+        error,
+        "Failed to retrieve organisation room",
+        "Unable to retrieve organisation room.",
+      );
+    }
+  },
+
+  toggleAvailability: async (
+    req: Request<{ organizationId: string; id: string }>,
+    res: Response,
+  ) => {
+    try {
+      const { organizationId, id } = req.params;
+
+      if (
+        !requireParam(
+          res,
+          organizationId,
+          "Organization identifier is required.",
+        ) ||
+        !requireParam(res, id, "Room identifier is required.")
+      ) {
+        return;
+      }
+
+      const room = await OrganisationRoomService.toggleAvailability(
+        id,
+        organizationId,
+      );
+
+      return res.status(200).json(toFHIROrganisationRoom(room));
+    } catch (error) {
+      handleServiceError(
+        res,
+        error,
+        "Failed to toggle organisation room availability",
+        "Unable to toggle organisation room availability.",
+      );
+    }
+  },
+
+  delete: async (req: Request<{ id: string }>, res: Response) => {
     try {
       const { id } = req.params;
       const { organisationId } = req as OrgRequest;
@@ -153,14 +238,8 @@ export const OrganisationRoomController = {
         return;
       }
 
-      const resource = await OrganisationRoomService.delete(id, organisationId);
-
-      if (!resource) {
-        respondNotFound(res);
-        return;
-      }
-
-      res.status(200).json(resource);
+      const deleted = await OrganisationRoomService.delete(id, organisationId);
+      return res.status(200).json(toFHIROrganisationRoom(deleted));
     } catch (error) {
       handleServiceError(
         res,

--- a/apps/backend/src/controllers/web/room-unit-group.controller.ts
+++ b/apps/backend/src/controllers/web/room-unit-group.controller.ts
@@ -1,14 +1,13 @@
 import { Request, Response } from "express";
 import logger from "src/utils/logger";
 import {
-  fromRoomUnitRequestDTO,
-  toRoomUnitResponseDTO,
-  type RoomUnitRequestDTO,
+  fromFHIRRoomUnitGroup,
+  toFHIRRoomUnitGroup,
 } from "@yosemite-crew/types";
 import {
-  RoomUnitService,
-  RoomUnitServiceError,
-} from "src/services/room-unit.service";
+  RoomUnitGroupService,
+  RoomUnitGroupServiceError,
+} from "src/services/room-unit-group.service";
 import { OrgRequest } from "src/middlewares/rbac";
 
 const requireParam = (
@@ -30,7 +29,7 @@ const getOrganisationId = (
 ): string | undefined => (req as OrgRequest).organisationId ?? fallback;
 
 const handleError = (res: Response, error: unknown, fallback: string) => {
-  if (error instanceof RoomUnitServiceError) {
+  if (error instanceof RoomUnitGroupServiceError) {
     return res.status(error.statusCode).json({ message: error.message });
   }
 
@@ -38,23 +37,24 @@ const handleError = (res: Response, error: unknown, fallback: string) => {
   return res.status(500).json({ message: fallback });
 };
 
-const isRoomUnitPayload = (value: unknown): value is RoomUnitRequestDTO =>
+const isRoomUnitGroupPayload = (value: unknown): boolean =>
   Boolean(
     value &&
     typeof value === "object" &&
     (value as { resourceType?: string }).resourceType === "Location",
   );
 
-export const RoomUnitController = {
+export const RoomUnitGroupController = {
   create: async (req: Request, res: Response) => {
     try {
-      const rawBody: unknown = req.body;
-      if (!isRoomUnitPayload(rawBody)) {
+      if (!isRoomUnitGroupPayload(req.body)) {
         return res.status(400).json({
           message: "Invalid payload. Expected FHIR Location resource.",
         });
       }
-      const payload = fromRoomUnitRequestDTO(rawBody);
+
+      const dto = req.body as Parameters<typeof fromFHIRRoomUnitGroup>[0];
+      const payload = fromFHIRRoomUnitGroup(dto);
       const organisationId = getOrganisationId(req, payload.organisationId);
 
       if (!organisationId) {
@@ -63,29 +63,30 @@ export const RoomUnitController = {
         });
       }
 
-      const created = await RoomUnitService.create({
+      const created = await RoomUnitGroupService.create({
         ...payload,
         organisationId,
       });
 
-      return res.status(201).json(toRoomUnitResponseDTO(created));
+      return res.status(201).json(toFHIRRoomUnitGroup(created));
     } catch (error) {
-      return handleError(res, error, "Failed to create room unit.");
+      return handleError(res, error, "Failed to create room unit group.");
     }
   },
 
   update: async (req: Request<{ id: string }>, res: Response) => {
     try {
-      const rawBody: unknown = req.body;
-      if (!isRoomUnitPayload(rawBody)) {
+      if (!isRoomUnitGroupPayload(req.body)) {
         return res.status(400).json({
           message: "Invalid payload. Expected FHIR Location resource.",
         });
       }
-      const payload = fromRoomUnitRequestDTO(rawBody);
+
+      const dto = req.body as Parameters<typeof fromFHIRRoomUnitGroup>[0];
+      const payload = fromFHIRRoomUnitGroup(dto);
       const organisationId = getOrganisationId(req, payload.organisationId);
 
-      if (!requireParam(res, req.params.id, "Unit identifier is required.")) {
+      if (!requireParam(res, req.params.id, "Group identifier is required.")) {
         return;
       }
 
@@ -95,39 +96,35 @@ export const RoomUnitController = {
         });
       }
 
-      const updated = await RoomUnitService.update(req.params.id, {
+      const updated = await RoomUnitGroupService.update(req.params.id, {
         ...payload,
         organisationId,
       });
 
-      return res.status(200).json(toRoomUnitResponseDTO(updated));
+      return res.status(200).json(toFHIRRoomUnitGroup(updated));
     } catch (error) {
-      return handleError(res, error, "Failed to update room unit.");
+      return handleError(res, error, "Failed to update room unit group.");
     }
   },
 
   list: async (req: Request, res: Response) => {
     try {
-      const values = await RoomUnitService.list({
+      const values = await RoomUnitGroupService.list({
         organisationId:
           typeof req.query.organizationId === "string"
             ? req.query.organizationId
             : undefined,
         roomId:
           typeof req.query.roomId === "string" ? req.query.roomId : undefined,
-        unitGroupId:
-          typeof req.query.unitGroupId === "string"
-            ? req.query.unitGroupId
-            : undefined,
         isActive:
           typeof req.query.isActive === "string"
             ? req.query.isActive === "true"
             : undefined,
       });
 
-      return res.status(200).json(values.map(toRoomUnitResponseDTO));
+      return res.status(200).json(values.map(toFHIRRoomUnitGroup));
     } catch (error) {
-      return handleError(res, error, "Failed to list room units.");
+      return handleError(res, error, "Failed to list room unit groups.");
     }
   },
 
@@ -136,7 +133,7 @@ export const RoomUnitController = {
       const { id } = req.params;
       const { organisationId } = req as OrgRequest;
 
-      if (!requireParam(res, id, "Unit identifier is required.")) {
+      if (!requireParam(res, id, "Group identifier is required.")) {
         return;
       }
 
@@ -146,10 +143,10 @@ export const RoomUnitController = {
         });
       }
 
-      const deleted = await RoomUnitService.delete(id, organisationId);
-      return res.status(200).json(toRoomUnitResponseDTO(deleted));
+      const deleted = await RoomUnitGroupService.delete(id, organisationId);
+      return res.status(200).json(toFHIRRoomUnitGroup(deleted));
     } catch (error) {
-      return handleError(res, error, "Failed to delete room unit.");
+      return handleError(res, error, "Failed to delete room unit group.");
     }
   },
 };

--- a/apps/backend/src/controllers/web/room-unit.controller.ts
+++ b/apps/backend/src/controllers/web/room-unit.controller.ts
@@ -1,0 +1,96 @@
+import { Request, Response } from "express";
+import {
+  fromRoomUnitRequestDTO,
+  toRoomUnitResponseDTO,
+  type RoomUnitRequestDTO,
+} from "@yosemite-crew/types";
+import logger from "src/utils/logger";
+import {
+  RoomUnitService,
+  RoomUnitServiceError,
+} from "src/services/room-unit.service";
+
+const isFHIRLocationPayload = (
+  payload: unknown,
+): payload is RoomUnitRequestDTO =>
+  Boolean(
+    payload &&
+    typeof payload === "object" &&
+    (payload as { resourceType?: string }).resourceType === "Location",
+  );
+
+const handleError = (res: Response, error: unknown, fallback: string) => {
+  if (error instanceof RoomUnitServiceError) {
+    return res.status(error.statusCode).json({ message: error.message });
+  }
+
+  logger.error(fallback, error);
+  return res.status(500).json({ message: fallback });
+};
+
+export const RoomUnitController = {
+  create: async (req: Request, res: Response) => {
+    try {
+      if (!isFHIRLocationPayload(req.body)) {
+        return res.status(400).json({
+          message: "Invalid payload. Expected FHIR Location resource.",
+        });
+      }
+
+      const created = await RoomUnitService.create(
+        fromRoomUnitRequestDTO(req.body),
+      );
+      return res.status(201).json(toRoomUnitResponseDTO(created));
+    } catch (error) {
+      return handleError(res, error, "Failed to create room unit.");
+    }
+  },
+
+  update: async (req: Request<{ id: string }>, res: Response) => {
+    try {
+      if (!isFHIRLocationPayload(req.body)) {
+        return res.status(400).json({
+          message: "Invalid payload. Expected FHIR Location resource.",
+        });
+      }
+
+      const updated = await RoomUnitService.update(
+        req.params.id,
+        fromRoomUnitRequestDTO(req.body),
+      );
+      return res.status(200).json(toRoomUnitResponseDTO(updated));
+    } catch (error) {
+      return handleError(res, error, "Failed to update room unit.");
+    }
+  },
+
+  list: async (req: Request, res: Response) => {
+    try {
+      const values = await RoomUnitService.list({
+        organisationId:
+          typeof req.query.organizationId === "string"
+            ? req.query.organizationId
+            : undefined,
+        roomId:
+          typeof req.query.roomId === "string" ? req.query.roomId : undefined,
+        isActive:
+          typeof req.query.isActive === "string"
+            ? req.query.isActive === "true"
+            : undefined,
+      });
+
+      return res.status(200).json(values.map(toRoomUnitResponseDTO));
+    } catch (error) {
+      return handleError(res, error, "Failed to list room units.");
+    }
+  },
+
+  delete: async (req: Request<{ id: string }>, res: Response) => {
+    try {
+      const deleted = await RoomUnitService.delete(req.params.id);
+      return res.status(200).json(toRoomUnitResponseDTO(deleted));
+    } catch (error) {
+      return handleError(res, error, "Failed to delete room unit.");
+    }
+  },
+};

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -1,3 +1,4 @@
+import "dotenv/config";
 import { createApp } from "./app";
 import { connectDB } from "./config/db";
 import { initQueues } from "./queues";

--- a/apps/backend/src/routers/appointment.router.ts
+++ b/apps/backend/src/routers/appointment.router.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { AppointmentController } from "../controllers/web/appointment.controller";
+import { AppointmentController } from "../controllers/web/appointment.prisma.controller";
 import { authorizeCognito, authorizeCognitoMobile } from "src/middlewares/auth";
 import { withOrgPermissions, requirePermission } from "src/middlewares/rbac";
 

--- a/apps/backend/src/routers/encounter.router.ts
+++ b/apps/backend/src/routers/encounter.router.ts
@@ -46,6 +46,14 @@ router.get(
 );
 
 router.get(
+  "/$active-inpatients",
+  authorizeCognito,
+  withOrgPermissions(),
+  requirePermission("appointments:view:any"),
+  EncounterController.listActiveInpatients,
+);
+
+router.get(
   "/:id",
   authorizeCognito,
   withOrgPermissions(),

--- a/apps/backend/src/routers/encounter.router.ts
+++ b/apps/backend/src/routers/encounter.router.ts
@@ -1,0 +1,40 @@
+import { Router } from "express";
+import { authorizeCognito } from "src/middlewares/auth";
+import { requirePermission, withOrgPermissions } from "src/middlewares/rbac";
+import { EncounterController } from "src/controllers/web/case-encounter.controller";
+
+const router = Router();
+
+router.post(
+  "/",
+  authorizeCognito,
+  withOrgPermissions(),
+  requirePermission("appointments:edit:any"),
+  EncounterController.create,
+);
+
+router.patch(
+  "/:id",
+  authorizeCognito,
+  withOrgPermissions(),
+  requirePermission("appointments:edit:any"),
+  EncounterController.update,
+);
+
+router.get(
+  "/:id",
+  authorizeCognito,
+  withOrgPermissions(),
+  requirePermission("appointments:view:any"),
+  EncounterController.getById,
+);
+
+router.get(
+  "/",
+  authorizeCognito,
+  withOrgPermissions(),
+  requirePermission("appointments:view:any"),
+  EncounterController.list,
+);
+
+export default router;

--- a/apps/backend/src/routers/encounter.router.ts
+++ b/apps/backend/src/routers/encounter.router.ts
@@ -46,6 +46,30 @@ router.get(
 );
 
 router.get(
+  "/:id/$admission-unit-assignments",
+  authorizeCognito,
+  withOrgPermissions(),
+  requirePermission("appointments:view:any"),
+  EncounterController.listAdmissionUnitAssignments,
+);
+
+router.post(
+  "/:id/$start",
+  authorizeCognito,
+  withOrgPermissions(),
+  requirePermission("appointments:edit:any"),
+  EncounterController.start,
+);
+
+router.post(
+  "/:id/$ready-for-discharge",
+  authorizeCognito,
+  withOrgPermissions(),
+  requirePermission("appointments:edit:any"),
+  EncounterController.readyForDischarge,
+);
+
+router.get(
   "/$active-inpatients",
   authorizeCognito,
   withOrgPermissions(),

--- a/apps/backend/src/routers/encounter.router.ts
+++ b/apps/backend/src/routers/encounter.router.ts
@@ -21,6 +21,14 @@ router.patch(
   EncounterController.update,
 );
 
+router.post(
+  "/:id/$discharge",
+  authorizeCognito,
+  withOrgPermissions(),
+  requirePermission("appointments:edit:any"),
+  EncounterController.discharge,
+);
+
 router.get(
   "/:id",
   authorizeCognito,

--- a/apps/backend/src/routers/encounter.router.ts
+++ b/apps/backend/src/routers/encounter.router.ts
@@ -29,6 +29,14 @@ router.post(
   EncounterController.discharge,
 );
 
+router.post(
+  "/:id/$assign-unit",
+  authorizeCognito,
+  withOrgPermissions(),
+  requirePermission("appointments:edit:any"),
+  EncounterController.assignUnit,
+);
+
 router.get(
   "/:id",
   authorizeCognito,

--- a/apps/backend/src/routers/encounter.router.ts
+++ b/apps/backend/src/routers/encounter.router.ts
@@ -38,6 +38,14 @@ router.post(
 );
 
 router.get(
+  "/:id/$unit-assignments",
+  authorizeCognito,
+  withOrgPermissions(),
+  requirePermission("appointments:view:any"),
+  EncounterController.listUnitAssignments,
+);
+
+router.get(
   "/:id",
   authorizeCognito,
   withOrgPermissions(),

--- a/apps/backend/src/routers/episode-of-care.router.ts
+++ b/apps/backend/src/routers/episode-of-care.router.ts
@@ -1,0 +1,40 @@
+import { Router } from "express";
+import { authorizeCognito } from "src/middlewares/auth";
+import { requirePermission, withOrgPermissions } from "src/middlewares/rbac";
+import { CaseController } from "src/controllers/web/case-encounter.controller";
+
+const router = Router();
+
+router.post(
+  "/",
+  authorizeCognito,
+  withOrgPermissions(),
+  requirePermission("appointments:edit:any"),
+  CaseController.create,
+);
+
+router.patch(
+  "/:id",
+  authorizeCognito,
+  withOrgPermissions(),
+  requirePermission("appointments:edit:any"),
+  CaseController.update,
+);
+
+router.get(
+  "/:id",
+  authorizeCognito,
+  withOrgPermissions(),
+  requirePermission("appointments:view:any"),
+  CaseController.getById,
+);
+
+router.get(
+  "/",
+  authorizeCognito,
+  withOrgPermissions(),
+  requirePermission("appointments:view:any"),
+  CaseController.list,
+);
+
+export default router;

--- a/apps/backend/src/routers/healthcare-service.router.ts
+++ b/apps/backend/src/routers/healthcare-service.router.ts
@@ -59,7 +59,7 @@ router.get(
 );
 
 router.post(
-  "/$resolve-selection",
+  String.raw`/\$resolve-selection`,
   authorizeCognito,
   attachOrganisationIdFromQuery,
   withOrgPermissions(),
@@ -68,7 +68,7 @@ router.post(
 );
 
 router.post(
-  "/$search-components",
+  String.raw`/\$search-components`,
   authorizeCognito,
   attachOrganisationIdFromQuery,
   withOrgPermissions(),

--- a/apps/backend/src/routers/index.ts
+++ b/apps/backend/src/routers/index.ts
@@ -46,6 +46,7 @@ import catalogRouter from "./catalog.router";
 import healthcareServiceRouter from "./healthcare-service.router";
 import episodeOfCareRouter from "./episode-of-care.router";
 import encounterRouter from "./encounter.router";
+import roomUnitRouter from "./room-unit.router";
 
 export function registerRoutes(app: Express) {
   app.use(`/fhir/v1/organization`, organizationRounter);
@@ -56,6 +57,7 @@ export function registerRoutes(app: Express) {
   app.use(`/fhir/v1/user-profile`, userProfileRouter);
   app.use(`/fhir/v1/speciality`, specialtyRouter);
   app.use(`/fhir/v1/organisation-room`, organisationRoomRouter);
+  app.use(`/fhir/v1/room-unit`, roomUnitRouter);
   app.use(`/fhir/v1/organisation-invites`, organisationInviteRouter);
   app.use(`/fhir/v1/availability`, availabilityRouter);
   app.use(`/v1/authUser`, authUserMobileRouter);

--- a/apps/backend/src/routers/index.ts
+++ b/apps/backend/src/routers/index.ts
@@ -47,6 +47,7 @@ import healthcareServiceRouter from "./healthcare-service.router";
 import episodeOfCareRouter from "./episode-of-care.router";
 import encounterRouter from "./encounter.router";
 import roomUnitRouter from "./room-unit.router";
+import roomUnitGroupRouter from "./room-unit-group.router";
 
 export function registerRoutes(app: Express) {
   app.use(`/fhir/v1/organization`, organizationRounter);
@@ -58,6 +59,7 @@ export function registerRoutes(app: Express) {
   app.use(`/fhir/v1/speciality`, specialtyRouter);
   app.use(`/fhir/v1/organisation-room`, organisationRoomRouter);
   app.use(`/fhir/v1/room-unit`, roomUnitRouter);
+  app.use(`/fhir/v1/room-unit-group`, roomUnitGroupRouter);
   app.use(`/fhir/v1/organisation-invites`, organisationInviteRouter);
   app.use(`/fhir/v1/availability`, availabilityRouter);
   app.use(`/v1/authUser`, authUserMobileRouter);

--- a/apps/backend/src/routers/index.ts
+++ b/apps/backend/src/routers/index.ts
@@ -44,6 +44,8 @@ import companionHistoryRouter from "./companion-history.router";
 import authRouter from "./auth.router";
 import catalogRouter from "./catalog.router";
 import healthcareServiceRouter from "./healthcare-service.router";
+import episodeOfCareRouter from "./episode-of-care.router";
+import encounterRouter from "./encounter.router";
 
 export function registerRoutes(app: Express) {
   app.use(`/fhir/v1/organization`, organizationRounter);
@@ -64,6 +66,8 @@ export function registerRoutes(app: Express) {
   app.use(`/fhir/v1/service`, serviceRouter);
   app.use(`/fhir/v1/healthcare-service`, healthcareServiceRouter);
   app.use(`/fhir/v1/appointment`, appointmentRouter);
+  app.use(`/fhir/v1/episode-of-care`, episodeOfCareRouter);
+  app.use(`/fhir/v1/encounter`, encounterRouter);
   app.use(`/v1/stripe`, stripeRouter);
   app.use(`/v1/documenso`, documensoRouter);
   app.use(`/v1/organisation-rating`, ratingRouter);

--- a/apps/backend/src/routers/organisation-room.router.ts
+++ b/apps/backend/src/routers/organisation-room.router.ts
@@ -36,6 +36,30 @@ router.get(
   OrganisationRoomController.getAllByOrganizationId,
 );
 
+router.get(
+  "/organization/:organizationId/:id",
+  authorizeCognito,
+  withOrgPermissions(),
+  requirePermission("room:view:any"),
+  OrganisationRoomController.getById,
+);
+
+router.get(
+  "/organization/:organizationId/summary",
+  authorizeCognito,
+  withOrgPermissions(),
+  requirePermission("room:view:any"),
+  OrganisationRoomController.getAllByOrganizationId,
+);
+
+router.patch(
+  "/organization/:organizationId/:id/availability",
+  authorizeCognito,
+  withOrgPermissions(),
+  requirePermission("room:edit:any"),
+  OrganisationRoomController.toggleAvailability,
+);
+
 // Delete room
 router.delete(
   "/:id",

--- a/apps/backend/src/routers/room-unit-group.router.ts
+++ b/apps/backend/src/routers/room-unit-group.router.ts
@@ -1,0 +1,40 @@
+import { Router } from "express";
+import { authorizeCognito } from "src/middlewares/auth";
+import { requirePermission, withOrgPermissions } from "src/middlewares/rbac";
+import { RoomUnitGroupController } from "src/controllers/web/room-unit-group.controller";
+
+const router = Router();
+
+router.post(
+  "/",
+  authorizeCognito,
+  withOrgPermissions(),
+  requirePermission("room:edit:any"),
+  RoomUnitGroupController.create,
+);
+
+router.put(
+  "/:id",
+  authorizeCognito,
+  withOrgPermissions(),
+  requirePermission("room:edit:any"),
+  RoomUnitGroupController.update,
+);
+
+router.get(
+  "/",
+  authorizeCognito,
+  withOrgPermissions(),
+  requirePermission("room:view:any"),
+  RoomUnitGroupController.list,
+);
+
+router.delete(
+  "/:id",
+  authorizeCognito,
+  withOrgPermissions(),
+  requirePermission("room:edit:any"),
+  RoomUnitGroupController.delete,
+);
+
+export default router;

--- a/apps/backend/src/routers/room-unit.router.ts
+++ b/apps/backend/src/routers/room-unit.router.ts
@@ -1,0 +1,40 @@
+import { Router } from "express";
+import { authorizeCognito } from "src/middlewares/auth";
+import { requirePermission, withOrgPermissions } from "src/middlewares/rbac";
+import { RoomUnitController } from "src/controllers/web/room-unit.controller";
+
+const router = Router();
+
+router.post(
+  "/",
+  authorizeCognito,
+  withOrgPermissions(),
+  requirePermission("room:edit:any"),
+  RoomUnitController.create,
+);
+
+router.put(
+  "/:id",
+  authorizeCognito,
+  withOrgPermissions(),
+  requirePermission("room:edit:any"),
+  RoomUnitController.update,
+);
+
+router.get(
+  "/",
+  authorizeCognito,
+  withOrgPermissions(),
+  requirePermission("room:view:any"),
+  RoomUnitController.list,
+);
+
+router.delete(
+  "/:id",
+  authorizeCognito,
+  withOrgPermissions(),
+  requirePermission("room:edit:any"),
+  RoomUnitController.delete,
+);
+
+export default router;

--- a/apps/backend/src/scripts/migrate-all.helpers.ts
+++ b/apps/backend/src/scripts/migrate-all.helpers.ts
@@ -1,0 +1,26 @@
+export const modelsRequiringCompanionId = new Set([
+  "CompanionOrganisation",
+  "Document",
+  "ParentCompanion",
+]);
+
+export const getMissingCompanionForeignKeyReason = (
+  prismaName: string,
+  data: Record<string, unknown>,
+  existingCompanionIds: Set<string>,
+): string | null => {
+  if (!modelsRequiringCompanionId.has(prismaName)) {
+    return null;
+  }
+
+  const companionId = data.companionId;
+  if (typeof companionId !== "string" || companionId.trim().length === 0) {
+    return "missing companionId";
+  }
+
+  if (!existingCompanionIds.has(companionId)) {
+    return `unknown companionId ${companionId}`;
+  }
+
+  return null;
+};

--- a/apps/backend/src/scripts/migrate-all.ts
+++ b/apps/backend/src/scripts/migrate-all.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import mongoose from "mongoose";
 import { PrismaClient } from "@prisma/client";
+import { getMissingCompanionForeignKeyReason } from "./migrate-all.helpers";
 
 dotenv.config();
 
@@ -234,8 +235,11 @@ const migrateModel = async (
   let userProfileAddressBatch: Record<string, unknown>[] = [];
   let processed = 0;
   let skipped = 0;
+  let skippedMissingForm = 0;
+  let skippedMissingCompanionFk = 0;
 
   let existingFormIds: Set<string> | null = null;
+  let existingCompanionIds: Set<string> | null = null;
   if (
     prismaName === "FormField" ||
     prismaName === "FormVersion" ||
@@ -243,6 +247,16 @@ const migrateModel = async (
   ) {
     const forms = await prisma.form.findMany({ select: { id: true } });
     existingFormIds = new Set(forms.map((form) => form.id));
+  }
+  if (
+    prismaName === "Document" ||
+    prismaName === "CompanionOrganisation" ||
+    prismaName === "ParentCompanion"
+  ) {
+    const companions = await prisma.companion.findMany({
+      select: { id: true },
+    });
+    existingCompanionIds = new Set(companions.map((companion) => companion.id));
   }
 
   const cursor = model.find().sort({ _id: 1 }).cursor();
@@ -269,8 +283,20 @@ const migrateModel = async (
       const formId = data.formId;
       if (typeof formId !== "string" || !existingFormIds?.has(formId)) {
         skipped += 1;
+        skippedMissingForm += 1;
         continue;
       }
+    }
+
+    const missingCompanionFkReason = getMissingCompanionForeignKeyReason(
+      prismaName,
+      data,
+      existingCompanionIds ?? new Set(),
+    );
+    if (missingCompanionFkReason) {
+      skipped += 1;
+      skippedMissingCompanionFk += 1;
+      continue;
     }
 
     batch.push(data);
@@ -408,16 +434,22 @@ const migrateModel = async (
   }
 
   if (skipped > 0) {
-    console.log(
-      `\nSkipped ${skipped} ${mongooseName} rows due to missing Form.`,
-    );
+    if (skippedMissingCompanionFk > 0) {
+      console.log(
+        `\nSkipped ${skippedMissingCompanionFk} ${mongooseName} rows due to missing Companion references.`,
+      );
+    }
+    if (skippedMissingForm > 0) {
+      console.log(
+        `\nSkipped ${skippedMissingForm} ${mongooseName} rows due to missing Form.`,
+      );
+    }
   }
   console.log(`\nDone. ${mongooseName}: ${processed}`);
 };
 
 const main = async () => {
-  process.env.MONO;
-  const mongoUri = "mongodb://localhost:27017/yosemitecrew";
+  const mongoUri = process.env.MONGODB_URI;
   if (!mongoUri) {
     throw new Error("MONGODB_URI is not set");
   }

--- a/apps/backend/src/services/appointment.prisma.service.ts
+++ b/apps/backend/src/services/appointment.prisma.service.ts
@@ -10,6 +10,7 @@ import {
   toAppointmentResponseDTO,
 } from "@yosemite-crew/types";
 import { prisma } from "src/config/prisma";
+import { CatalogService, CatalogServiceError } from "./catalog.service";
 
 type AppointmentStatus = AppointmentDomain["status"];
 
@@ -58,6 +59,11 @@ type RescheduleChanges = {
   durationMinutes?: number;
 };
 
+type CatalogSelection = Awaited<
+  ReturnType<typeof CatalogService.resolveSelection>
+>;
+type TransactionClient = Prisma.TransactionClient;
+
 type AppointmentListFilters = {
   organisationId?: string;
   companionId?: string;
@@ -87,6 +93,12 @@ const toNullableJsonValue = (
   value: Prisma.JsonValue | null | undefined,
 ): Prisma.InputJsonValue | Prisma.NullableJsonNullValueInput | undefined =>
   value == null ? Prisma.JsonNull : (value as Prisma.InputJsonValue);
+
+const normalizeOptionalString = (value?: string | null) => {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
 
 const normalizeAppointmentKind = (
   value?: AppointmentKind | null,
@@ -121,6 +133,161 @@ const assertAppointmentTransition = (
       409,
     );
   }
+};
+
+const assertValidTimeRange = (startTime: Date, endTime: Date) => {
+  if (Number.isNaN(startTime.getTime()) || Number.isNaN(endTime.getTime())) {
+    throw new AppointmentPrismaServiceError(
+      "Valid startTime and endTime are required.",
+      400,
+    );
+  }
+
+  if (endTime <= startTime) {
+    throw new AppointmentPrismaServiceError(
+      "endTime must be after startTime.",
+      400,
+    );
+  }
+};
+
+const assertCaseEncounterConsistency = (input: {
+  appointmentKind: AppointmentKind;
+  caseId?: string;
+  encounterId?: string;
+}) => {
+  if (input.appointmentKind === "INPATIENT" && !input.caseId) {
+    throw new AppointmentPrismaServiceError(
+      "caseId is required for inpatient appointments.",
+      400,
+    );
+  }
+
+  if (input.encounterId && !input.caseId) {
+    throw new AppointmentPrismaServiceError(
+      "caseId is required when encounterId is provided.",
+      400,
+    );
+  }
+};
+
+const resolveCatalogSelectionForAppointment = async (input: {
+  appointmentType?: AppointmentDomain["appointmentType"];
+  organisationId: string;
+}) => {
+  const selectionId = input.appointmentType?.id?.trim();
+  if (!selectionId) {
+    throw new AppointmentPrismaServiceError(
+      "Appointment type is required.",
+      400,
+    );
+  }
+
+  try {
+    return await CatalogService.resolveSelection(
+      selectionId,
+      input.organisationId,
+    );
+  } catch (error) {
+    if (error instanceof CatalogServiceError) {
+      throw new AppointmentPrismaServiceError(error.message, error.statusCode);
+    }
+
+    throw error;
+  }
+};
+
+const assertSelectionSupportsAppointmentKind = (
+  selection: CatalogSelection,
+  appointmentKind: AppointmentKind,
+) => {
+  if (!selection.isBookable) {
+    throw new AppointmentPrismaServiceError(
+      "Selected product is not bookable.",
+      400,
+    );
+  }
+
+  if (!selection.appointmentKinds.includes(appointmentKind)) {
+    throw new AppointmentPrismaServiceError(
+      `Selected product is not bookable for ${appointmentKind.toLowerCase()} appointments.`,
+      400,
+    );
+  }
+};
+
+const assertLeadAvailability = async (args: {
+  tx: TransactionClient;
+  organisationId: string;
+  leadId: string;
+  startTime: Date;
+  endTime: Date;
+  excludeAppointmentId?: string;
+}) => {
+  const overlapping = await args.tx.occupancy.findFirst({
+    where: {
+      userId: args.leadId,
+      organisationId: args.organisationId,
+      startTime: { lt: args.endTime },
+      endTime: { gt: args.startTime },
+      ...(args.excludeAppointmentId
+        ? {
+            NOT: {
+              sourceType: "APPOINTMENT",
+              referenceId: args.excludeAppointmentId,
+            },
+          }
+        : {}),
+    },
+  });
+
+  if (overlapping) {
+    throw new AppointmentPrismaServiceError(
+      "Selected vet is not available for this slot.",
+      409,
+    );
+  }
+};
+
+const upsertAppointmentOccupancy = async (args: {
+  tx: TransactionClient;
+  appointmentId: string;
+  organisationId: string;
+  leadId?: string;
+  startTime: Date;
+  endTime: Date;
+}) => {
+  await args.tx.occupancy.deleteMany({
+    where: {
+      organisationId: args.organisationId,
+      sourceType: "APPOINTMENT",
+      referenceId: args.appointmentId,
+    },
+  });
+
+  if (!args.leadId) {
+    return;
+  }
+
+  await assertLeadAvailability({
+    tx: args.tx,
+    organisationId: args.organisationId,
+    leadId: args.leadId,
+    startTime: args.startTime,
+    endTime: args.endTime,
+    excludeAppointmentId: args.appointmentId,
+  });
+
+  await args.tx.occupancy.create({
+    data: {
+      userId: args.leadId,
+      organisationId: args.organisationId,
+      startTime: args.startTime,
+      endTime: args.endTime,
+      sourceType: "APPOINTMENT",
+      referenceId: args.appointmentId,
+    },
+  });
 };
 
 const buildWhereFromFilters = (
@@ -232,6 +399,8 @@ const toDomain = (
   paymentStatus?: AppointmentPaymentStatus,
 ): AppointmentDomain => ({
   id: row.id,
+  caseId: row.caseId ?? undefined,
+  encounterId: row.encounterId ?? undefined,
   companion: row.companion as AppointmentDomain["companion"],
   lead: (row.lead as AppointmentDomain["lead"]) ?? undefined,
   supportStaff:
@@ -281,39 +450,71 @@ const toResponseList = async (
   );
 };
 
+const getLeadIdFromRow = (row: AppointmentRow): string | undefined => {
+  const lead = row.lead as { id?: string } | null;
+  return typeof lead?.id === "string" && lead.id.trim() ? lead.id : undefined;
+};
+
 const createAppointment = async (
   dto: AppointmentRequestDTO,
   status: AppointmentStatus,
 ): Promise<AppointmentResponseDTO> => {
   const input = fromAppointmentRequestDTO(dto);
-  const created = await prisma.appointment.create({
-    data: {
-      companion: toJsonValue(input.companion),
-      lead: input.lead ? toJsonValue(input.lead) : Prisma.JsonNull,
-      supportStaff: input.supportStaff ? toJsonValue(input.supportStaff) : [],
-      room: input.room ? toJsonValue(input.room) : Prisma.JsonNull,
-      appointmentType: input.appointmentType
-        ? toJsonValue(input.appointmentType)
-        : Prisma.JsonNull,
-      appointmentKind: normalizeAppointmentKind(input.appointmentKind),
-      organisationId: input.organisationId,
-      appointmentDate: input.appointmentDate,
-      startTime: input.startTime,
-      endTime: input.endTime,
-      timeSlot: input.timeSlot,
-      durationMinutes: input.durationMinutes,
-      status,
-      isEmergency: input.isEmergency ?? false,
-      concern: input.concern ?? null,
-      attachments: input.attachments
-        ? toJsonValue(input.attachments)
-        : Prisma.JsonNull,
-      formIds: input.formIds ?? [],
-      caseId: null,
-      encounterId: null,
-      productItemId: null,
-      expiresAt: null,
-    },
+  const appointmentKind = normalizeAppointmentKind(input.appointmentKind);
+  const caseId = normalizeOptionalString(input.caseId);
+  const encounterId = normalizeOptionalString(input.encounterId);
+  assertValidTimeRange(input.startTime, input.endTime);
+  assertCaseEncounterConsistency({ appointmentKind, caseId, encounterId });
+
+  const selection = await resolveCatalogSelectionForAppointment({
+    appointmentType: input.appointmentType,
+    organisationId: input.organisationId,
+  });
+  assertSelectionSupportsAppointmentKind(selection, appointmentKind);
+
+  const created = await prisma.$transaction(async (tx) => {
+    const appointment = await tx.appointment.create({
+      data: {
+        companion: toJsonValue(input.companion),
+        lead: input.lead ? toJsonValue(input.lead) : Prisma.JsonNull,
+        supportStaff: input.supportStaff ? toJsonValue(input.supportStaff) : [],
+        room: input.room ? toJsonValue(input.room) : Prisma.JsonNull,
+        appointmentType: input.appointmentType
+          ? toJsonValue(input.appointmentType)
+          : Prisma.JsonNull,
+        appointmentKind,
+        organisationId: input.organisationId,
+        appointmentDate: input.appointmentDate,
+        startTime: input.startTime,
+        endTime: input.endTime,
+        timeSlot: input.timeSlot,
+        durationMinutes: input.durationMinutes,
+        status,
+        isEmergency: input.isEmergency ?? false,
+        concern: input.concern ?? null,
+        attachments: input.attachments
+          ? toJsonValue(input.attachments)
+          : Prisma.JsonNull,
+        formIds: input.formIds ?? [],
+        caseId: caseId ?? null,
+        encounterId: encounterId ?? null,
+        productItemId: selection.productItemId,
+        expiresAt: null,
+      },
+    });
+
+    if (status === "UPCOMING") {
+      await upsertAppointmentOccupancy({
+        tx,
+        appointmentId: appointment.id,
+        organisationId: appointment.organisationId,
+        leadId: input.lead?.id,
+        startTime: appointment.startTime,
+        endTime: appointment.endTime,
+      });
+    }
+
+    return appointment;
   });
 
   return toResponse(created as AppointmentRow);
@@ -327,6 +528,14 @@ const applyDtoPatch = (
   const input = fromAppointmentRequestDTO(dto);
 
   return {
+    caseId:
+      input.caseId === undefined
+        ? normalizeOptionalString(current.caseId)
+        : (normalizeOptionalString(input.caseId) ?? null),
+    encounterId:
+      input.encounterId === undefined
+        ? normalizeOptionalString(current.encounterId)
+        : (normalizeOptionalString(input.encounterId) ?? null),
     companion: toJsonValue(input.companion),
     lead:
       input.lead === undefined
@@ -399,13 +608,32 @@ export const AppointmentPrismaService = {
       "approveRequestedFromPms",
     );
 
+    const input = fromAppointmentRequestDTO(dto);
+    if (!input.lead?.id) {
+      throw new AppointmentPrismaServiceError(
+        "Lead vet is required to approve an appointment.",
+        400,
+      );
+    }
+
     const patch = applyDtoPatch(row, dto, "UPCOMING");
-    const updated = await prisma.appointment.update({
-      where: { id: appointmentId },
-      data: {
-        ...patch,
-        updatedAt: new Date(),
-      },
+    const updated = await prisma.$transaction(async (tx) => {
+      await upsertAppointmentOccupancy({
+        tx,
+        appointmentId,
+        organisationId: row.organisationId,
+        leadId: input.lead?.id,
+        startTime: patch.startTime,
+        endTime: patch.endTime,
+      });
+
+      return tx.appointment.update({
+        where: { id: appointmentId },
+        data: {
+          ...patch,
+          updatedAt: new Date(),
+        },
+      });
     });
 
     return toResponse(updated as AppointmentRow);
@@ -534,39 +762,52 @@ export const AppointmentPrismaService = {
     const newEnd = toDate(changes.endTime);
     const nextStatus = row.status === "UPCOMING" ? "REQUESTED" : row.status;
     assertAppointmentTransition(row.status, nextStatus, "rescheduleFromParent");
+    assertValidTimeRange(newStart, newEnd);
 
-    const updated = await prisma.appointment.update({
-      where: { id: appointmentId },
-      data: {
-        startTime: newStart,
-        endTime: newEnd,
-        appointmentDate: newStart,
-        timeSlot: dayjs(newStart).format("HH:mm"),
-        durationMinutes:
-          typeof changes.durationMinutes === "number"
-            ? changes.durationMinutes
-            : dayjs(newEnd).diff(dayjs(newStart), "minute"),
-        concern:
-          typeof changes.concern === "string" ? changes.concern : row.concern,
-        isEmergency:
-          typeof changes.isEmergency === "boolean"
-            ? changes.isEmergency
-            : row.isEmergency,
-        status: nextStatus,
-        lead:
-          nextStatus === "REQUESTED"
-            ? Prisma.JsonNull
-            : toNullableJsonValue(row.lead),
-        supportStaff:
-          nextStatus === "REQUESTED"
-            ? []
-            : toNullableJsonValue(row.supportStaff),
-        room:
-          nextStatus === "REQUESTED"
-            ? Prisma.JsonNull
-            : toNullableJsonValue(row.room),
-        updatedAt: new Date(),
-      },
+    const updated = await prisma.$transaction(async (tx) => {
+      if (nextStatus === "REQUESTED") {
+        await upsertAppointmentOccupancy({
+          tx,
+          appointmentId,
+          organisationId: row.organisationId,
+          startTime: newStart,
+          endTime: newEnd,
+        });
+      }
+
+      return tx.appointment.update({
+        where: { id: appointmentId },
+        data: {
+          startTime: newStart,
+          endTime: newEnd,
+          appointmentDate: newStart,
+          timeSlot: dayjs(newStart).format("HH:mm"),
+          durationMinutes:
+            typeof changes.durationMinutes === "number"
+              ? changes.durationMinutes
+              : dayjs(newEnd).diff(dayjs(newStart), "minute"),
+          concern:
+            typeof changes.concern === "string" ? changes.concern : row.concern,
+          isEmergency:
+            typeof changes.isEmergency === "boolean"
+              ? changes.isEmergency
+              : row.isEmergency,
+          status: nextStatus,
+          lead:
+            nextStatus === "REQUESTED"
+              ? Prisma.JsonNull
+              : toNullableJsonValue(row.lead),
+          supportStaff:
+            nextStatus === "REQUESTED"
+              ? []
+              : toNullableJsonValue(row.supportStaff),
+          room:
+            nextStatus === "REQUESTED"
+              ? Prisma.JsonNull
+              : toNullableJsonValue(row.room),
+          updatedAt: new Date(),
+        },
+      });
     });
 
     return toResponse(updated as AppointmentRow);
@@ -587,14 +828,61 @@ export const AppointmentPrismaService = {
       current as AppointmentRow | null,
       "Appointment not found",
     );
+    const input = fromAppointmentRequestDTO(dto);
+    const appointmentKind = normalizeAppointmentKind(
+      input.appointmentKind ?? row.appointmentKind,
+    );
+    const caseId =
+      input.caseId === undefined
+        ? normalizeOptionalString(row.caseId)
+        : normalizeOptionalString(input.caseId);
+    const encounterId =
+      input.encounterId === undefined
+        ? normalizeOptionalString(row.encounterId)
+        : normalizeOptionalString(input.encounterId);
+    assertValidTimeRange(
+      input.startTime ?? row.startTime,
+      input.endTime ?? row.endTime,
+    );
+    assertCaseEncounterConsistency({ appointmentKind, caseId, encounterId });
+    const selection = await resolveCatalogSelectionForAppointment({
+      appointmentType:
+        input.appointmentType ??
+        (row.appointmentType as AppointmentDomain["appointmentType"]),
+      organisationId: row.organisationId,
+    });
+    assertSelectionSupportsAppointmentKind(selection, appointmentKind);
     const patch = applyDtoPatch(row, dto, row.status);
+    const updated = await prisma.$transaction(async (tx) => {
+      if (patch.status === "UPCOMING") {
+        await upsertAppointmentOccupancy({
+          tx,
+          appointmentId,
+          organisationId: row.organisationId,
+          leadId: input.lead?.id ?? getLeadIdFromRow(row),
+          startTime: patch.startTime,
+          endTime: patch.endTime,
+        });
+      } else {
+        await upsertAppointmentOccupancy({
+          tx,
+          appointmentId,
+          organisationId: row.organisationId,
+          startTime: patch.startTime,
+          endTime: patch.endTime,
+        });
+      }
 
-    const updated = await prisma.appointment.update({
-      where: { id: appointmentId },
-      data: {
-        ...patch,
-        updatedAt: new Date(),
-      },
+      return tx.appointment.update({
+        where: { id: appointmentId },
+        data: {
+          ...patch,
+          caseId: caseId ?? null,
+          encounterId: encounterId ?? null,
+          productItemId: selection.productItemId,
+          updatedAt: new Date(),
+        },
+      });
     });
 
     return toResponse(updated as AppointmentRow);
@@ -634,9 +922,19 @@ export const AppointmentPrismaService = {
       "cancelAppointmentFromParent",
     );
 
-    const updated = await prisma.appointment.update({
-      where: { id: appointmentId },
-      data: { status: "CANCELLED", updatedAt: new Date() },
+    const updated = await prisma.$transaction(async (tx) => {
+      await upsertAppointmentOccupancy({
+        tx,
+        appointmentId,
+        organisationId: row.organisationId,
+        startTime: row.startTime,
+        endTime: row.endTime,
+      });
+
+      return tx.appointment.update({
+        where: { id: appointmentId },
+        data: { status: "CANCELLED", updatedAt: new Date() },
+      });
     });
 
     return toResponse(updated as AppointmentRow);
@@ -657,9 +955,19 @@ export const AppointmentPrismaService = {
     );
     assertAppointmentTransition(row.status, "CANCELLED", "cancelAppointment");
 
-    const updated = await prisma.appointment.update({
-      where: { id: appointmentId },
-      data: { status: "CANCELLED", updatedAt: new Date() },
+    const updated = await prisma.$transaction(async (tx) => {
+      await upsertAppointmentOccupancy({
+        tx,
+        appointmentId,
+        organisationId: row.organisationId,
+        startTime: row.startTime,
+        endTime: row.endTime,
+      });
+
+      return tx.appointment.update({
+        where: { id: appointmentId },
+        data: { status: "CANCELLED", updatedAt: new Date() },
+      });
     });
 
     return toResponse(updated as AppointmentRow);

--- a/apps/backend/src/services/appointment.prisma.service.ts
+++ b/apps/backend/src/services/appointment.prisma.service.ts
@@ -63,6 +63,17 @@ type CatalogSelection = Awaited<
   ReturnType<typeof CatalogService.resolveSelection>
 >;
 type TransactionClient = Prisma.TransactionClient;
+type CaseRow = {
+  id: string;
+  organisationId: string;
+  companionId: string;
+};
+type EncounterLinkRow = {
+  id: string;
+  caseId: string;
+  organisationId: string;
+  companionId: string;
+};
 
 type AppointmentListFilters = {
   organisationId?: string;
@@ -156,13 +167,6 @@ const assertCaseEncounterConsistency = (input: {
   caseId?: string;
   encounterId?: string;
 }) => {
-  if (input.appointmentKind === "INPATIENT" && !input.caseId) {
-    throw new AppointmentPrismaServiceError(
-      "caseId is required for inpatient appointments.",
-      400,
-    );
-  }
-
   if (input.encounterId && !input.caseId) {
     throw new AppointmentPrismaServiceError(
       "caseId is required when encounterId is provided.",
@@ -214,6 +218,177 @@ const assertSelectionSupportsAppointmentKind = (
       400,
     );
   }
+};
+
+const getCompanionId = (
+  companion: AppointmentDomain["companion"] | Prisma.JsonValue,
+): string => ((companion as { id?: string } | null)?.id ?? "").trim();
+
+const getParentIdFromCompanion = (
+  companion: AppointmentDomain["companion"] | Prisma.JsonValue,
+): string | undefined =>
+  (
+    (companion as { parent?: { id?: string } } | null)?.parent?.id ?? ""
+  ).trim() || undefined;
+
+const resolveCaseContext = async (args: {
+  tx: TransactionClient;
+  appointmentKind: AppointmentKind;
+  caseId?: string;
+  organisationId: string;
+  companionId: string;
+  parentId?: string;
+  concern?: string;
+}): Promise<string | undefined> => {
+  const existingCaseId = normalizeOptionalString(args.caseId);
+
+  if (existingCaseId) {
+    const caseRow = (await args.tx.case.findUnique({
+      where: { id: existingCaseId },
+    })) as CaseRow | null;
+
+    if (!caseRow) {
+      throw new AppointmentPrismaServiceError("Case not found.", 404);
+    }
+
+    if (caseRow.organisationId !== args.organisationId) {
+      throw new AppointmentPrismaServiceError(
+        "Appointment case organisation mismatch.",
+        409,
+      );
+    }
+
+    if (caseRow.companionId !== args.companionId) {
+      throw new AppointmentPrismaServiceError(
+        "Appointment case companion mismatch.",
+        409,
+      );
+    }
+
+    return caseRow.id;
+  }
+
+  if (args.appointmentKind !== "INPATIENT") {
+    return undefined;
+  }
+
+  const created = await args.tx.case.create({
+    data: {
+      organisationId: args.organisationId,
+      companionId: args.companionId,
+      parentId: normalizeOptionalString(args.parentId) ?? null,
+      status: "active",
+      appointmentKind: args.appointmentKind,
+      title: "Inpatient case",
+      description: normalizeOptionalString(args.concern) ?? null,
+    },
+    select: { id: true },
+  });
+
+  return created.id;
+};
+
+const assertEncounterMatchesAppointmentContext = async (args: {
+  tx: TransactionClient;
+  encounterId?: string;
+  caseId?: string;
+  organisationId: string;
+  companionId: string;
+}) => {
+  const encounterId = normalizeOptionalString(args.encounterId);
+  if (!encounterId) {
+    return;
+  }
+
+  const encounter = (await args.tx.encounter.findUnique({
+    where: { id: encounterId },
+  })) as EncounterLinkRow | null;
+
+  if (!encounter) {
+    throw new AppointmentPrismaServiceError("Encounter not found.", 404);
+  }
+
+  if (encounter.caseId !== args.caseId) {
+    throw new AppointmentPrismaServiceError(
+      "Appointment encounter must belong to the selected case.",
+      409,
+    );
+  }
+
+  if (encounter.organisationId !== args.organisationId) {
+    throw new AppointmentPrismaServiceError(
+      "Appointment encounter organisation mismatch.",
+      409,
+    );
+  }
+
+  if (encounter.companionId !== args.companionId) {
+    throw new AppointmentPrismaServiceError(
+      "Appointment encounter companion mismatch.",
+      409,
+    );
+  }
+};
+
+const ensureEncounterOnCheckIn = async (args: {
+  tx: TransactionClient;
+  appointmentId: string;
+  current: AppointmentRow;
+}) => {
+  if (args.current.encounterId) {
+    return args.current.encounterId;
+  }
+
+  const companionId = getCompanionId(args.current.companion);
+  const caseId =
+    normalizeOptionalString(args.current.caseId) ??
+    (await resolveCaseContext({
+      tx: args.tx,
+      appointmentKind: normalizeAppointmentKind(args.current.appointmentKind),
+      organisationId: args.current.organisationId,
+      companionId,
+      parentId: getParentIdFromCompanion(args.current.companion),
+      concern: args.current.concern ?? undefined,
+    }));
+
+  if (!caseId) {
+    throw new AppointmentPrismaServiceError(
+      "caseId could not be resolved for check-in.",
+      400,
+    );
+  }
+
+  const createdEncounter = await args.tx.encounter.create({
+    data: {
+      caseId,
+      organisationId: args.current.organisationId,
+      companionId,
+      parentId: getParentIdFromCompanion(args.current.companion) ?? null,
+      status: "arrived",
+      encounterClass:
+        normalizeAppointmentKind(args.current.appointmentKind) === "INPATIENT"
+          ? "IMP"
+          : "AMB",
+      appointmentKind: normalizeAppointmentKind(args.current.appointmentKind),
+      title:
+        (args.current.appointmentType as { name?: string } | null)?.name ??
+        null,
+      reason: args.current.concern ?? null,
+      periodStart: args.current.startTime,
+      periodEnd: args.current.endTime,
+    },
+    select: { id: true },
+  });
+
+  await args.tx.appointment.update({
+    where: { id: args.appointmentId },
+    data: {
+      caseId,
+      encounterId: createdEncounter.id,
+    },
+  });
+
+  return createdEncounter.id;
 };
 
 const assertLeadAvailability = async (args: {
@@ -473,6 +648,25 @@ const createAppointment = async (
   assertSelectionSupportsAppointmentKind(selection, appointmentKind);
 
   const created = await prisma.$transaction(async (tx) => {
+    const companionId = getCompanionId(input.companion);
+    const resolvedCaseId = await resolveCaseContext({
+      tx,
+      appointmentKind,
+      caseId,
+      organisationId: input.organisationId,
+      companionId,
+      parentId: input.companion.parent?.id,
+      concern: input.concern,
+    });
+
+    await assertEncounterMatchesAppointmentContext({
+      tx,
+      encounterId,
+      caseId: resolvedCaseId,
+      organisationId: input.organisationId,
+      companionId,
+    });
+
     const appointment = await tx.appointment.create({
       data: {
         companion: toJsonValue(input.companion),
@@ -496,7 +690,7 @@ const createAppointment = async (
           ? toJsonValue(input.attachments)
           : Prisma.JsonNull,
         formIds: input.formIds ?? [],
-        caseId: caseId ?? null,
+        caseId: resolvedCaseId ?? null,
         encounterId: encounterId ?? null,
         productItemId: selection.productItemId,
         expiresAt: null,
@@ -618,6 +812,25 @@ export const AppointmentPrismaService = {
 
     const patch = applyDtoPatch(row, dto, "UPCOMING");
     const updated = await prisma.$transaction(async (tx) => {
+      const companionId = getCompanionId(input.companion);
+      const resolvedCaseId = await resolveCaseContext({
+        tx,
+        appointmentKind: patch.appointmentKind,
+        caseId: patch.caseId ?? undefined,
+        organisationId: row.organisationId,
+        companionId,
+        parentId: input.companion.parent?.id,
+        concern: input.concern,
+      });
+
+      await assertEncounterMatchesAppointmentContext({
+        tx,
+        encounterId: patch.encounterId ?? undefined,
+        caseId: resolvedCaseId,
+        organisationId: row.organisationId,
+        companionId,
+      });
+
       await upsertAppointmentOccupancy({
         tx,
         appointmentId,
@@ -631,6 +844,7 @@ export const AppointmentPrismaService = {
         where: { id: appointmentId },
         data: {
           ...patch,
+          caseId: resolvedCaseId ?? null,
           updatedAt: new Date(),
         },
       });
@@ -694,9 +908,21 @@ export const AppointmentPrismaService = {
       "checkInAppointmentParent",
     );
 
-    const updated = await prisma.appointment.update({
-      where: { id: appointmentId },
-      data: { status: "CHECKED_IN", updatedAt: new Date() },
+    const updated = await prisma.$transaction(async (tx) => {
+      const encounterId = await ensureEncounterOnCheckIn({
+        tx,
+        appointmentId,
+        current: row,
+      });
+
+      return tx.appointment.update({
+        where: { id: appointmentId },
+        data: {
+          status: "CHECKED_IN",
+          encounterId,
+          updatedAt: new Date(),
+        },
+      });
     });
 
     return toResponse(updated as AppointmentRow);
@@ -716,9 +942,21 @@ export const AppointmentPrismaService = {
     );
     assertAppointmentTransition(row.status, "CHECKED_IN", "checkInAppointment");
 
-    const updated = await prisma.appointment.update({
-      where: { id: appointmentId },
-      data: { status: "CHECKED_IN", updatedAt: new Date() },
+    const updated = await prisma.$transaction(async (tx) => {
+      const encounterId = await ensureEncounterOnCheckIn({
+        tx,
+        appointmentId,
+        current: row,
+      });
+
+      return tx.appointment.update({
+        where: { id: appointmentId },
+        data: {
+          status: "CHECKED_IN",
+          encounterId,
+          updatedAt: new Date(),
+        },
+      });
     });
 
     return toResponse(updated as AppointmentRow);
@@ -854,6 +1092,25 @@ export const AppointmentPrismaService = {
     assertSelectionSupportsAppointmentKind(selection, appointmentKind);
     const patch = applyDtoPatch(row, dto, row.status);
     const updated = await prisma.$transaction(async (tx) => {
+      const companionId = getCompanionId(input.companion);
+      const resolvedCaseId = await resolveCaseContext({
+        tx,
+        appointmentKind,
+        caseId,
+        organisationId: row.organisationId,
+        companionId,
+        parentId: input.companion.parent?.id,
+        concern: input.concern,
+      });
+
+      await assertEncounterMatchesAppointmentContext({
+        tx,
+        encounterId,
+        caseId: resolvedCaseId,
+        organisationId: row.organisationId,
+        companionId,
+      });
+
       if (patch.status === "UPCOMING") {
         await upsertAppointmentOccupancy({
           tx,
@@ -877,7 +1134,7 @@ export const AppointmentPrismaService = {
         where: { id: appointmentId },
         data: {
           ...patch,
-          caseId: caseId ?? null,
+          caseId: resolvedCaseId ?? null,
           encounterId: encounterId ?? null,
           productItemId: selection.productItemId,
           updatedAt: new Date(),

--- a/apps/backend/src/services/appointment.prisma.service.ts
+++ b/apps/backend/src/services/appointment.prisma.service.ts
@@ -1,0 +1,822 @@
+import dayjs from "dayjs";
+import { Prisma } from "@prisma/client";
+import {
+  Appointment as AppointmentDomain,
+  AppointmentKind,
+  AppointmentPaymentStatus,
+  AppointmentRequestDTO,
+  AppointmentResponseDTO,
+  fromAppointmentRequestDTO,
+  toAppointmentResponseDTO,
+} from "@yosemite-crew/types";
+import { prisma } from "src/config/prisma";
+
+type AppointmentStatus = AppointmentDomain["status"];
+
+type AppointmentRow = {
+  id: string;
+  companion: Prisma.JsonValue;
+  lead: Prisma.JsonValue | null;
+  supportStaff: Prisma.JsonValue | null;
+  room: Prisma.JsonValue | null;
+  appointmentType: Prisma.JsonValue | null;
+  appointmentKind: AppointmentKind;
+  caseId: string | null;
+  encounterId: string | null;
+  productItemId: string | null;
+  organisationId: string;
+  appointmentDate: Date;
+  startTime: Date;
+  endTime: Date;
+  timeSlot: string;
+  durationMinutes: number;
+  status: AppointmentStatus;
+  isEmergency: boolean;
+  concern: string | null;
+  attachments: Prisma.JsonValue | null;
+  formIds: string[];
+  expiresAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export class AppointmentPrismaServiceError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode: number,
+  ) {
+    super(message);
+    this.name = "AppointmentPrismaServiceError";
+  }
+}
+
+type RescheduleChanges = {
+  startTime: string | Date;
+  endTime: string | Date;
+  concern?: string;
+  isEmergency?: boolean;
+  durationMinutes?: number;
+};
+
+type AppointmentListFilters = {
+  organisationId?: string;
+  companionId?: string;
+  parentId?: string;
+  leadId?: string;
+  status?: AppointmentStatus[];
+  startDate?: Date;
+  endDate?: Date;
+};
+
+const DEFAULT_KIND: AppointmentKind = "OUTPATIENT";
+const BOOKABLE_INVOICE_STATUSES = [
+  "PAID",
+  "PENDING",
+  "AWAITING_PAYMENT",
+  "FAILED",
+  "REFUNDED",
+] as const;
+
+const toDate = (value: string | Date) =>
+  value instanceof Date ? value : new Date(value);
+
+const toJsonValue = <T>(value: T): Prisma.InputJsonValue =>
+  value as unknown as Prisma.InputJsonValue;
+
+const toNullableJsonValue = (
+  value: Prisma.JsonValue | null | undefined,
+): Prisma.InputJsonValue | Prisma.NullableJsonNullValueInput | undefined =>
+  value == null ? Prisma.JsonNull : (value as Prisma.InputJsonValue);
+
+const normalizeAppointmentKind = (
+  value?: AppointmentKind | null,
+): AppointmentKind => (value === "INPATIENT" ? "INPATIENT" : DEFAULT_KIND);
+
+const assertExists = <T>(value: T | null | undefined, message: string): T => {
+  if (value == null) {
+    throw new AppointmentPrismaServiceError(message, 404);
+  }
+  return value;
+};
+
+const assertAppointmentTransition = (
+  current: AppointmentStatus,
+  next: AppointmentStatus,
+  context: string,
+) => {
+  const transitions: Record<AppointmentStatus, AppointmentStatus[]> = {
+    REQUESTED: ["UPCOMING", "CANCELLED"],
+    UPCOMING: ["CHECKED_IN", "CANCELLED", "NO_SHOW", "REQUESTED"],
+    CHECKED_IN: ["IN_PROGRESS", "CANCELLED"],
+    IN_PROGRESS: ["COMPLETED", "CANCELLED"],
+    COMPLETED: [],
+    CANCELLED: [],
+    NO_SHOW: [],
+  };
+
+  if (current === next) return;
+  if (!transitions[current].includes(next)) {
+    throw new AppointmentPrismaServiceError(
+      `Appointment cannot transition from ${current} to ${next} in ${context}.`,
+      409,
+    );
+  }
+};
+
+const buildWhereFromFilters = (
+  filters: AppointmentListFilters,
+): Prisma.AppointmentWhereInput => {
+  const where: Prisma.AppointmentWhereInput = {};
+  const and: Prisma.AppointmentWhereInput[] = [];
+
+  if (filters.organisationId) {
+    where.organisationId = filters.organisationId;
+  }
+
+  if (filters.status?.length) {
+    where.status = { in: filters.status };
+  }
+
+  if (filters.startDate || filters.endDate) {
+    where.startTime = {
+      gte: filters.startDate ?? undefined,
+      lte: filters.endDate ?? undefined,
+    };
+  }
+
+  if (filters.companionId) {
+    and.push({
+      companion: {
+        path: ["id"],
+        equals: filters.companionId,
+      } as never,
+    });
+  }
+
+  if (filters.parentId) {
+    and.push({
+      companion: {
+        path: ["parent", "id"],
+        equals: filters.parentId,
+      } as never,
+    });
+  }
+
+  if (filters.leadId) {
+    and.push({
+      lead: {
+        path: ["id"],
+        equals: filters.leadId,
+      } as never,
+    });
+  }
+
+  if (and.length) {
+    where.AND = and;
+  }
+
+  return where;
+};
+
+const resolvePaymentStatusMap = async (
+  appointmentIds: string[],
+): Promise<Map<string, AppointmentPaymentStatus>> => {
+  const uniqueIds = [...new Set(appointmentIds.filter(Boolean))];
+  const paymentStatusMap = new Map<string, AppointmentPaymentStatus>();
+
+  if (!uniqueIds.length) {
+    return paymentStatusMap;
+  }
+
+  const invoices = await prisma.invoice.findMany({
+    where: {
+      appointmentId: { in: uniqueIds },
+      status: { in: [...BOOKABLE_INVOICE_STATUSES] },
+    },
+    select: {
+      appointmentId: true,
+      status: true,
+    },
+  });
+
+  const tracker = new Map<string, { hasPaid: boolean; hasUnpaid: boolean }>();
+
+  for (const invoice of invoices) {
+    if (!invoice.appointmentId) continue;
+    const entry = tracker.get(invoice.appointmentId) ?? {
+      hasPaid: false,
+      hasUnpaid: false,
+    };
+
+    if (invoice.status === "PAID") {
+      entry.hasPaid = true;
+    } else {
+      entry.hasUnpaid = true;
+    }
+
+    tracker.set(invoice.appointmentId, entry);
+  }
+
+  for (const [appointmentId, entry] of tracker) {
+    paymentStatusMap.set(
+      appointmentId,
+      entry.hasPaid && !entry.hasUnpaid ? "PAID" : "UNPAID",
+    );
+  }
+
+  return paymentStatusMap;
+};
+
+const toDomain = (
+  row: AppointmentRow,
+  paymentStatus?: AppointmentPaymentStatus,
+): AppointmentDomain => ({
+  id: row.id,
+  companion: row.companion as AppointmentDomain["companion"],
+  lead: (row.lead as AppointmentDomain["lead"]) ?? undefined,
+  supportStaff:
+    (row.supportStaff as AppointmentDomain["supportStaff"]) ?? undefined,
+  room: (row.room as AppointmentDomain["room"]) ?? undefined,
+  appointmentType:
+    (row.appointmentType as AppointmentDomain["appointmentType"]) ?? undefined,
+  appointmentKind: normalizeAppointmentKind(row.appointmentKind),
+  organisationId: row.organisationId,
+  appointmentDate: new Date(row.appointmentDate),
+  startTime: new Date(row.startTime),
+  timeSlot: row.timeSlot,
+  durationMinutes: row.durationMinutes,
+  endTime: new Date(row.endTime),
+  status: row.status,
+  paymentStatus,
+  isEmergency: row.isEmergency,
+  concern: row.concern ?? undefined,
+  createdAt: new Date(row.createdAt),
+  updatedAt: new Date(row.updatedAt),
+  attachments:
+    (row.attachments as AppointmentDomain["attachments"]) ?? undefined,
+  formIds: row.formIds ?? [],
+});
+
+const toResponse = async (
+  row: AppointmentRow,
+): Promise<AppointmentResponseDTO> => {
+  const paymentStatusMap = await resolvePaymentStatusMap([row.id]);
+  return toAppointmentResponseDTO(
+    toDomain(row, paymentStatusMap.get(row.id) ?? "UNPAID"),
+  );
+};
+
+const toResponseList = async (
+  rows: AppointmentRow[],
+): Promise<AppointmentResponseDTO[]> => {
+  if (!rows.length) return [];
+
+  const paymentStatusMap = await resolvePaymentStatusMap(
+    rows.map((row) => row.id),
+  );
+  return rows.map((row) =>
+    toAppointmentResponseDTO(
+      toDomain(row, paymentStatusMap.get(row.id) ?? "UNPAID"),
+    ),
+  );
+};
+
+const createAppointment = async (
+  dto: AppointmentRequestDTO,
+  status: AppointmentStatus,
+): Promise<AppointmentResponseDTO> => {
+  const input = fromAppointmentRequestDTO(dto);
+  const created = await prisma.appointment.create({
+    data: {
+      companion: toJsonValue(input.companion),
+      lead: input.lead ? toJsonValue(input.lead) : Prisma.JsonNull,
+      supportStaff: input.supportStaff ? toJsonValue(input.supportStaff) : [],
+      room: input.room ? toJsonValue(input.room) : Prisma.JsonNull,
+      appointmentType: input.appointmentType
+        ? toJsonValue(input.appointmentType)
+        : Prisma.JsonNull,
+      appointmentKind: normalizeAppointmentKind(input.appointmentKind),
+      organisationId: input.organisationId,
+      appointmentDate: input.appointmentDate,
+      startTime: input.startTime,
+      endTime: input.endTime,
+      timeSlot: input.timeSlot,
+      durationMinutes: input.durationMinutes,
+      status,
+      isEmergency: input.isEmergency ?? false,
+      concern: input.concern ?? null,
+      attachments: input.attachments
+        ? toJsonValue(input.attachments)
+        : Prisma.JsonNull,
+      formIds: input.formIds ?? [],
+      caseId: null,
+      encounterId: null,
+      productItemId: null,
+      expiresAt: null,
+    },
+  });
+
+  return toResponse(created as AppointmentRow);
+};
+
+const applyDtoPatch = (
+  current: AppointmentRow,
+  dto: AppointmentRequestDTO,
+  nextStatus?: AppointmentStatus,
+) => {
+  const input = fromAppointmentRequestDTO(dto);
+
+  return {
+    companion: toJsonValue(input.companion),
+    lead:
+      input.lead === undefined
+        ? toNullableJsonValue(current.lead)
+        : toJsonValue(input.lead),
+    supportStaff:
+      input.supportStaff === undefined
+        ? toNullableJsonValue(current.supportStaff)
+        : toJsonValue(input.supportStaff),
+    room:
+      input.room === undefined
+        ? toNullableJsonValue(current.room)
+        : toJsonValue(input.room),
+    appointmentType:
+      input.appointmentType === undefined
+        ? toNullableJsonValue(current.appointmentType)
+        : toJsonValue(input.appointmentType),
+    appointmentKind: normalizeAppointmentKind(
+      input.appointmentKind ?? current.appointmentKind,
+    ),
+    appointmentDate: input.appointmentDate ?? current.appointmentDate,
+    startTime: input.startTime ?? current.startTime,
+    endTime: input.endTime ?? current.endTime,
+    timeSlot: input.timeSlot || current.timeSlot,
+    durationMinutes: input.durationMinutes || current.durationMinutes,
+    status: nextStatus ?? input.status ?? current.status,
+    isEmergency: input.isEmergency ?? current.isEmergency,
+    concern: input.concern ?? current.concern,
+    attachments:
+      input.attachments === undefined
+        ? toNullableJsonValue(current.attachments)
+        : toJsonValue(input.attachments),
+    formIds: input.formIds ?? current.formIds,
+  };
+};
+
+export const AppointmentPrismaService = {
+  async createRequestedFromMobile(dto: AppointmentRequestDTO) {
+    return createAppointment(dto, "REQUESTED");
+  },
+
+  async createAppointmentFromPms(
+    dto: AppointmentRequestDTO,
+    _createPayment = false,
+    _paymentCollectionMethod?: string,
+  ) {
+    void _createPayment;
+    void _paymentCollectionMethod;
+    return createAppointment(dto, "UPCOMING");
+  },
+
+  async approveRequestedFromPms(
+    appointmentId: string,
+    dto: AppointmentRequestDTO,
+  ) {
+    if (!appointmentId) {
+      throw new AppointmentPrismaServiceError("appointmentId is required", 400);
+    }
+
+    const current = await prisma.appointment.findUnique({
+      where: { id: appointmentId },
+    });
+    const row = assertExists(
+      current as AppointmentRow | null,
+      "Appointment not found",
+    );
+    assertAppointmentTransition(
+      row.status,
+      "UPCOMING",
+      "approveRequestedFromPms",
+    );
+
+    const patch = applyDtoPatch(row, dto, "UPCOMING");
+    const updated = await prisma.appointment.update({
+      where: { id: appointmentId },
+      data: {
+        ...patch,
+        updatedAt: new Date(),
+      },
+    });
+
+    return toResponse(updated as AppointmentRow);
+  },
+
+  async rejectRequestedAppointment(appointmentId: string) {
+    if (!appointmentId) {
+      throw new AppointmentPrismaServiceError("appointmentId is required", 400);
+    }
+
+    const current = await prisma.appointment.findUnique({
+      where: { id: appointmentId },
+    });
+    const row = assertExists(
+      current as AppointmentRow | null,
+      "Appointment not found",
+    );
+    assertAppointmentTransition(
+      row.status,
+      "CANCELLED",
+      "rejectRequestedAppointment",
+    );
+
+    const updated = await prisma.appointment.update({
+      where: { id: appointmentId },
+      data: { status: "CANCELLED", updatedAt: new Date() },
+    });
+
+    return toResponse(updated as AppointmentRow);
+  },
+
+  async checkInAppointmentParent(appointmentId: string, parentId: string) {
+    if (!appointmentId) {
+      throw new AppointmentPrismaServiceError("appointmentId is required", 400);
+    }
+    if (!parentId) {
+      throw new AppointmentPrismaServiceError("parentId is required", 400);
+    }
+
+    const current = await prisma.appointment.findUnique({
+      where: { id: appointmentId },
+    });
+    const row = assertExists(
+      current as AppointmentRow | null,
+      "Appointment not found",
+    );
+    const ownerId = (row.companion as { parent?: { id?: string } }).parent?.id;
+    if (ownerId !== parentId) {
+      throw new AppointmentPrismaServiceError(
+        "You are not allowed to modify this appointment.",
+        403,
+      );
+    }
+
+    assertAppointmentTransition(
+      row.status,
+      "CHECKED_IN",
+      "checkInAppointmentParent",
+    );
+
+    const updated = await prisma.appointment.update({
+      where: { id: appointmentId },
+      data: { status: "CHECKED_IN", updatedAt: new Date() },
+    });
+
+    return toResponse(updated as AppointmentRow);
+  },
+
+  async checkInAppointment(appointmentId: string) {
+    if (!appointmentId) {
+      throw new AppointmentPrismaServiceError("appointmentId is required", 400);
+    }
+
+    const current = await prisma.appointment.findUnique({
+      where: { id: appointmentId },
+    });
+    const row = assertExists(
+      current as AppointmentRow | null,
+      "Appointment not found",
+    );
+    assertAppointmentTransition(row.status, "CHECKED_IN", "checkInAppointment");
+
+    const updated = await prisma.appointment.update({
+      where: { id: appointmentId },
+      data: { status: "CHECKED_IN", updatedAt: new Date() },
+    });
+
+    return toResponse(updated as AppointmentRow);
+  },
+
+  async rescheduleFromParent(
+    appointmentId: string,
+    parentId: string,
+    changes: RescheduleChanges,
+  ) {
+    if (!appointmentId) {
+      throw new AppointmentPrismaServiceError("appointmentId is required", 400);
+    }
+    if (!parentId) {
+      throw new AppointmentPrismaServiceError("parentId is required", 400);
+    }
+
+    const current = await prisma.appointment.findUnique({
+      where: { id: appointmentId },
+    });
+    const row = assertExists(
+      current as AppointmentRow | null,
+      "Appointment not found",
+    );
+    const ownerId = (row.companion as { parent?: { id?: string } }).parent?.id;
+    if (ownerId !== parentId) {
+      throw new AppointmentPrismaServiceError(
+        "You are not allowed to modify this appointment.",
+        403,
+      );
+    }
+
+    if (row.status === "COMPLETED" || row.status === "CANCELLED") {
+      throw new AppointmentPrismaServiceError(
+        "Completed or cancelled appointments cannot be rescheduled.",
+        400,
+      );
+    }
+
+    const newStart = toDate(changes.startTime);
+    const newEnd = toDate(changes.endTime);
+    const nextStatus = row.status === "UPCOMING" ? "REQUESTED" : row.status;
+    assertAppointmentTransition(row.status, nextStatus, "rescheduleFromParent");
+
+    const updated = await prisma.appointment.update({
+      where: { id: appointmentId },
+      data: {
+        startTime: newStart,
+        endTime: newEnd,
+        appointmentDate: newStart,
+        timeSlot: dayjs(newStart).format("HH:mm"),
+        durationMinutes:
+          typeof changes.durationMinutes === "number"
+            ? changes.durationMinutes
+            : dayjs(newEnd).diff(dayjs(newStart), "minute"),
+        concern:
+          typeof changes.concern === "string" ? changes.concern : row.concern,
+        isEmergency:
+          typeof changes.isEmergency === "boolean"
+            ? changes.isEmergency
+            : row.isEmergency,
+        status: nextStatus,
+        lead:
+          nextStatus === "REQUESTED"
+            ? Prisma.JsonNull
+            : toNullableJsonValue(row.lead),
+        supportStaff:
+          nextStatus === "REQUESTED"
+            ? []
+            : toNullableJsonValue(row.supportStaff),
+        room:
+          nextStatus === "REQUESTED"
+            ? Prisma.JsonNull
+            : toNullableJsonValue(row.room),
+        updatedAt: new Date(),
+      },
+    });
+
+    return toResponse(updated as AppointmentRow);
+  },
+
+  async updateAppointmentPMS(
+    appointmentId: string,
+    dto: AppointmentRequestDTO,
+  ) {
+    if (!appointmentId) {
+      throw new AppointmentPrismaServiceError("appointmentId is required", 400);
+    }
+
+    const current = await prisma.appointment.findUnique({
+      where: { id: appointmentId },
+    });
+    const row = assertExists(
+      current as AppointmentRow | null,
+      "Appointment not found",
+    );
+    const patch = applyDtoPatch(row, dto, row.status);
+
+    const updated = await prisma.appointment.update({
+      where: { id: appointmentId },
+      data: {
+        ...patch,
+        updatedAt: new Date(),
+      },
+    });
+
+    return toResponse(updated as AppointmentRow);
+  },
+
+  async cancelAppointmentFromParent(
+    appointmentId: string,
+    parentId: string,
+    _reason?: string,
+  ) {
+    void _reason;
+    if (!appointmentId) {
+      throw new AppointmentPrismaServiceError("appointmentId is required", 400);
+    }
+    if (!parentId) {
+      throw new AppointmentPrismaServiceError("parentId is required", 400);
+    }
+
+    const current = await prisma.appointment.findUnique({
+      where: { id: appointmentId },
+    });
+    const row = assertExists(
+      current as AppointmentRow | null,
+      "Appointment not found",
+    );
+    const ownerId = (row.companion as { parent?: { id?: string } }).parent?.id;
+    if (ownerId !== parentId) {
+      throw new AppointmentPrismaServiceError(
+        "You are not allowed to modify this appointment.",
+        403,
+      );
+    }
+
+    assertAppointmentTransition(
+      row.status,
+      "CANCELLED",
+      "cancelAppointmentFromParent",
+    );
+
+    const updated = await prisma.appointment.update({
+      where: { id: appointmentId },
+      data: { status: "CANCELLED", updatedAt: new Date() },
+    });
+
+    return toResponse(updated as AppointmentRow);
+  },
+
+  async cancelAppointment(appointmentId: string, _reason?: string) {
+    void _reason;
+    if (!appointmentId) {
+      throw new AppointmentPrismaServiceError("appointmentId is required", 400);
+    }
+
+    const current = await prisma.appointment.findUnique({
+      where: { id: appointmentId },
+    });
+    const row = assertExists(
+      current as AppointmentRow | null,
+      "Appointment not found",
+    );
+    assertAppointmentTransition(row.status, "CANCELLED", "cancelAppointment");
+
+    const updated = await prisma.appointment.update({
+      where: { id: appointmentId },
+      data: { status: "CANCELLED", updatedAt: new Date() },
+    });
+
+    return toResponse(updated as AppointmentRow);
+  },
+
+  async getById(appointmentId: string): Promise<AppointmentResponseDTO> {
+    if (!appointmentId) {
+      throw new AppointmentPrismaServiceError(
+        "Appointment ID is required",
+        400,
+      );
+    }
+
+    const row = await prisma.appointment.findUnique({
+      where: { id: appointmentId },
+    });
+    if (!row) {
+      throw new AppointmentPrismaServiceError("Appointment not found", 404);
+    }
+
+    return toResponse(row as AppointmentRow);
+  },
+
+  async getAppointmentsForCompanion(
+    companionId: string,
+  ): Promise<AppointmentResponseDTO[]> {
+    if (!companionId) {
+      throw new AppointmentPrismaServiceError("companionId is required", 400);
+    }
+
+    const rows = (await prisma.appointment.findMany({
+      where: {
+        companion: { path: ["id"], equals: companionId } as never,
+      },
+      orderBy: { startTime: "desc" },
+    })) as AppointmentRow[];
+
+    return toResponseList(rows);
+  },
+
+  async getAppointmentsForCompanionByOrganisation(
+    companionId: string,
+    organisationId: string,
+  ): Promise<AppointmentResponseDTO[]> {
+    if (!companionId) {
+      throw new AppointmentPrismaServiceError("companionId is required", 400);
+    }
+    if (!organisationId) {
+      throw new AppointmentPrismaServiceError(
+        "organisationId is required",
+        400,
+      );
+    }
+
+    const rows = (await prisma.appointment.findMany({
+      where: {
+        organisationId,
+        companion: { path: ["id"], equals: companionId } as never,
+      },
+      orderBy: { startTime: "desc" },
+    })) as AppointmentRow[];
+
+    return toResponseList(rows);
+  },
+
+  async getAppointmentsForParent(
+    parentId: string,
+  ): Promise<AppointmentResponseDTO[]> {
+    if (!parentId) {
+      throw new AppointmentPrismaServiceError("parentId is required", 400);
+    }
+
+    const rows = (await prisma.appointment.findMany({
+      where: {
+        companion: { path: ["parent", "id"], equals: parentId } as never,
+      },
+      orderBy: { startTime: "desc" },
+    })) as AppointmentRow[];
+
+    return toResponseList(rows);
+  },
+
+  async getAppointmentsForOrganisation(
+    organisationId: string,
+    filters?: {
+      status?: AppointmentStatus[];
+      startDate?: Date;
+      endDate?: Date;
+    },
+  ): Promise<AppointmentResponseDTO[]> {
+    if (!organisationId) {
+      throw new AppointmentPrismaServiceError(
+        "organisationId is required",
+        400,
+      );
+    }
+
+    const where = buildWhereFromFilters({
+      organisationId,
+      status: filters?.status,
+      startDate: filters?.startDate,
+      endDate: filters?.endDate,
+    });
+
+    const rows = (await prisma.appointment.findMany({
+      where,
+      orderBy: { startTime: "desc" },
+    })) as AppointmentRow[];
+
+    return toResponseList(rows);
+  },
+
+  async getAppointmentsForLead(
+    leadId: string,
+    organisationId?: string,
+  ): Promise<AppointmentResponseDTO[]> {
+    if (!leadId) {
+      throw new AppointmentPrismaServiceError("leadId is required", 400);
+    }
+
+    const where = buildWhereFromFilters({
+      leadId,
+      organisationId,
+    });
+
+    const rows = (await prisma.appointment.findMany({
+      where,
+      orderBy: { startTime: "desc" },
+    })) as AppointmentRow[];
+
+    return toResponseList(rows);
+  },
+
+  async attachFormsToAppointment(
+    appointmentId: string,
+    formIds: string[],
+  ): Promise<AppointmentResponseDTO> {
+    if (!appointmentId) {
+      throw new AppointmentPrismaServiceError("appointmentId is required", 400);
+    }
+
+    const current = await prisma.appointment.findUnique({
+      where: { id: appointmentId },
+    });
+    const row = assertExists(
+      current as AppointmentRow | null,
+      "Appointment not found",
+    );
+    const nextFormIds = Array.from(
+      new Set([...(row.formIds ?? []), ...(formIds ?? [])]),
+    ).filter(Boolean);
+
+    const updated = await prisma.appointment.update({
+      where: { id: appointmentId },
+      data: { formIds: nextFormIds, updatedAt: new Date() },
+    });
+
+    return toResponse(updated as AppointmentRow);
+  },
+};

--- a/apps/backend/src/services/appointment.prisma.service.ts
+++ b/apps/backend/src/services/appointment.prisma.service.ts
@@ -63,6 +63,18 @@ type CatalogSelection = Awaited<
   ReturnType<typeof CatalogService.resolveSelection>
 >;
 type TransactionClient = Prisma.TransactionClient;
+type AdmissionUpsertDelegate = {
+  upsert(args: {
+    where: { encounterId: string };
+    update: Record<string, never>;
+    create: {
+      encounterId: string;
+      organisationId: string;
+      companionId: string;
+      admittedAt: Date;
+    };
+  }): Promise<unknown>;
+};
 type CaseRow = {
   id: string;
   organisationId: string;
@@ -387,6 +399,23 @@ const ensureEncounterOnCheckIn = async (args: {
       encounterId: createdEncounter.id,
     },
   });
+
+  if (normalizeAppointmentKind(args.current.appointmentKind) === "INPATIENT") {
+    const admissionDelegate = (
+      args.tx as unknown as { admission: AdmissionUpsertDelegate }
+    ).admission;
+
+    await admissionDelegate.upsert({
+      where: { encounterId: createdEncounter.id },
+      update: {},
+      create: {
+        encounterId: createdEncounter.id,
+        organisationId: args.current.organisationId,
+        companionId,
+        admittedAt: args.current.startTime,
+      },
+    });
+  }
 
   return createdEncounter.id;
 };

--- a/apps/backend/src/services/case-encounter.service.ts
+++ b/apps/backend/src/services/case-encounter.service.ts
@@ -1,0 +1,603 @@
+import { prisma } from "src/config/prisma";
+import type {
+  AppointmentKind,
+  Case as CaseDomain,
+  CaseStatus,
+  Encounter as EncounterDomain,
+  EncounterClass,
+  EncounterStatus,
+} from "@yosemite-crew/types";
+
+type CaseRow = {
+  id: string;
+  organisationId: string;
+  companionId: string;
+  parentId: string | null;
+  status: string;
+  appointmentKind: AppointmentKind;
+  title: string | null;
+  description: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type EncounterRow = {
+  id: string;
+  caseId: string;
+  organisationId: string;
+  companionId: string;
+  parentId: string | null;
+  status: string;
+  encounterClass: string;
+  appointmentKind: AppointmentKind;
+  title: string | null;
+  reason: string | null;
+  periodStart: Date | null;
+  periodEnd: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type AppointmentLinkRow = {
+  id: string;
+  caseId: string | null;
+  encounterId: string | null;
+  organisationId: string;
+  companion: unknown;
+};
+
+export class CaseEncounterServiceError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode: number,
+  ) {
+    super(message);
+    this.name = "CaseEncounterServiceError";
+  }
+}
+
+const CASE_STATUSES = new Set<CaseStatus>([
+  "planned",
+  "waitlist",
+  "active",
+  "onhold",
+  "finished",
+  "cancelled",
+  "entered-in-error",
+]);
+
+const ENCOUNTER_STATUSES = new Set<EncounterStatus>([
+  "planned",
+  "arrived",
+  "triaged",
+  "in-progress",
+  "onleave",
+  "finished",
+  "cancelled",
+]);
+
+const ENCOUNTER_CLASSES = new Set<EncounterClass>([
+  "AMB",
+  "IMP",
+  "EMER",
+  "OBSENC",
+  "VR",
+]);
+
+const requireString = (value: string | undefined, field: string) => {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    throw new CaseEncounterServiceError(`${field} is required.`, 400);
+  }
+  return trimmed;
+};
+
+const normalizeOptionalString = (value?: string | null) => {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+const toCaseStatus = (status: string): CaseStatus => {
+  if (!CASE_STATUSES.has(status as CaseStatus)) {
+    throw new CaseEncounterServiceError("Invalid case status.", 400);
+  }
+
+  return status as CaseStatus;
+};
+
+const toEncounterStatus = (status: string): EncounterStatus => {
+  if (!ENCOUNTER_STATUSES.has(status as EncounterStatus)) {
+    throw new CaseEncounterServiceError("Invalid encounter status.", 400);
+  }
+
+  return status as EncounterStatus;
+};
+
+const toEncounterClass = (value: string): EncounterClass => {
+  if (!ENCOUNTER_CLASSES.has(value as EncounterClass)) {
+    throw new CaseEncounterServiceError("Invalid encounter class.", 400);
+  }
+
+  return value as EncounterClass;
+};
+
+const assertPeriod = (start?: Date, end?: Date) => {
+  if (start && Number.isNaN(start.getTime())) {
+    throw new CaseEncounterServiceError("Invalid encounter periodStart.", 400);
+  }
+
+  if (end && Number.isNaN(end.getTime())) {
+    throw new CaseEncounterServiceError("Invalid encounter periodEnd.", 400);
+  }
+
+  if (start && end && end < start) {
+    throw new CaseEncounterServiceError(
+      "periodEnd must be after periodStart.",
+      400,
+    );
+  }
+};
+
+const toCaseDomain = (row: CaseRow): CaseDomain => ({
+  id: row.id,
+  organisationId: row.organisationId,
+  companionId: row.companionId,
+  parentId: row.parentId ?? undefined,
+  status: row.status as CaseStatus,
+  appointmentKind: row.appointmentKind,
+  title: row.title ?? undefined,
+  description: row.description ?? undefined,
+  createdAt: row.createdAt,
+  updatedAt: row.updatedAt,
+});
+
+const toEncounterDomain = (row: EncounterRow): EncounterDomain => ({
+  id: row.id,
+  caseId: row.caseId,
+  organisationId: row.organisationId,
+  companionId: row.companionId,
+  parentId: row.parentId ?? undefined,
+  status: row.status as EncounterStatus,
+  encounterClass: row.encounterClass as EncounterClass,
+  appointmentKind: row.appointmentKind,
+  title: row.title ?? undefined,
+  reason: row.reason ?? undefined,
+  periodStart: row.periodStart ?? undefined,
+  periodEnd: row.periodEnd ?? undefined,
+  createdAt: row.createdAt,
+  updatedAt: row.updatedAt,
+});
+
+const toAppointmentCompanionId = (value: unknown): string =>
+  ((value as { id?: string } | null)?.id ?? "").trim();
+
+const attachEncounterAppointmentIds = async (
+  encounters: EncounterDomain[],
+): Promise<EncounterDomain[]> => {
+  if (encounters.length === 0) {
+    return encounters;
+  }
+
+  const appointmentLinks = (await prisma.appointment.findMany({
+    where: {
+      encounterId: {
+        in: encounters
+          .map((encounter) => encounter.id)
+          .filter((value): value is string => Boolean(value)),
+      },
+    },
+    select: {
+      id: true,
+      encounterId: true,
+    },
+  })) as Array<{ id: string; encounterId: string | null }>;
+
+  const appointmentIdByEncounterId = new Map<string, string>();
+  for (const appointment of appointmentLinks) {
+    if (appointment.encounterId) {
+      appointmentIdByEncounterId.set(appointment.encounterId, appointment.id);
+    }
+  }
+
+  return encounters.map((encounter) => ({
+    ...encounter,
+    appointmentId:
+      encounter.id == null
+        ? encounter.appointmentId
+        : (appointmentIdByEncounterId.get(encounter.id) ??
+          encounter.appointmentId),
+  }));
+};
+
+export const CaseEncounterService = {
+  async createCase(input: CaseDomain): Promise<CaseDomain> {
+    const organisationId = requireString(
+      input.organisationId,
+      "organisationId",
+    );
+    const companionId = requireString(input.companionId, "companionId");
+    const status = toCaseStatus(input.status);
+
+    const created = await prisma.case.create({
+      data: {
+        organisationId,
+        companionId,
+        parentId: normalizeOptionalString(input.parentId) ?? null,
+        status,
+        appointmentKind: input.appointmentKind,
+        title: normalizeOptionalString(input.title) ?? null,
+        description: normalizeOptionalString(input.description) ?? null,
+      },
+    });
+
+    return toCaseDomain(created as CaseRow);
+  },
+
+  async updateCase(
+    caseId: string,
+    input: Partial<CaseDomain>,
+  ): Promise<CaseDomain> {
+    const id = requireString(caseId, "caseId");
+    const status = input.status ? toCaseStatus(input.status) : undefined;
+
+    const existing = await prisma.case.findUnique({ where: { id } });
+    if (!existing) {
+      throw new CaseEncounterServiceError("Case not found.", 404);
+    }
+
+    const updated = await prisma.case.update({
+      where: { id },
+      data: {
+        status,
+        appointmentKind: input.appointmentKind ?? undefined,
+        parentId:
+          input.parentId === undefined
+            ? undefined
+            : (normalizeOptionalString(input.parentId) ?? null),
+        title:
+          input.title === undefined
+            ? undefined
+            : (normalizeOptionalString(input.title) ?? null),
+        description:
+          input.description === undefined
+            ? undefined
+            : (normalizeOptionalString(input.description) ?? null),
+      },
+    });
+
+    return toCaseDomain(updated as CaseRow);
+  },
+
+  async getCaseById(caseId: string): Promise<CaseDomain> {
+    const id = requireString(caseId, "caseId");
+    const row = await prisma.case.findUnique({ where: { id } });
+    if (!row) {
+      throw new CaseEncounterServiceError("Case not found.", 404);
+    }
+    return toCaseDomain(row as CaseRow);
+  },
+
+  async listCases(filters: {
+    organisationId?: string;
+    companionId?: string;
+    parentId?: string;
+    status?: CaseStatus;
+    appointmentKind?: AppointmentKind;
+  }) {
+    const rows = (await prisma.case.findMany({
+      where: {
+        organisationId: normalizeOptionalString(filters.organisationId),
+        companionId: normalizeOptionalString(filters.companionId),
+        parentId: normalizeOptionalString(filters.parentId),
+        status: filters.status,
+        appointmentKind: filters.appointmentKind,
+      },
+      orderBy: { updatedAt: "desc" },
+    })) as CaseRow[];
+
+    return rows.map(toCaseDomain);
+  },
+
+  async createEncounter(input: EncounterDomain): Promise<EncounterDomain> {
+    const caseId = requireString(input.caseId, "caseId");
+    const organisationId = requireString(
+      input.organisationId,
+      "organisationId",
+    );
+    const companionId = requireString(input.companionId, "companionId");
+    const status = toEncounterStatus(input.status);
+    const encounterClass = toEncounterClass(input.encounterClass);
+    assertPeriod(input.periodStart, input.periodEnd);
+
+    const created = await prisma.$transaction(async (tx) => {
+      const caseRow = await tx.case.findUnique({ where: { id: caseId } });
+      if (!caseRow) {
+        throw new CaseEncounterServiceError("Case not found.", 404);
+      }
+
+      if (caseRow.organisationId !== organisationId) {
+        throw new CaseEncounterServiceError(
+          "Encounter organisationId must match case organisationId.",
+          409,
+        );
+      }
+
+      if (caseRow.companionId !== companionId) {
+        throw new CaseEncounterServiceError(
+          "Encounter companionId must match case companionId.",
+          409,
+        );
+      }
+
+      const appointmentId = normalizeOptionalString(input.appointmentId);
+      if (appointmentId) {
+        const appointment = (await tx.appointment.findUnique({
+          where: { id: appointmentId },
+          select: {
+            id: true,
+            caseId: true,
+            encounterId: true,
+            organisationId: true,
+            companion: true,
+          },
+        })) as AppointmentLinkRow | null;
+
+        if (!appointment) {
+          throw new CaseEncounterServiceError("Appointment not found.", 404);
+        }
+
+        if (appointment.organisationId !== organisationId) {
+          throw new CaseEncounterServiceError(
+            "Encounter appointment organisation mismatch.",
+            409,
+          );
+        }
+
+        if (toAppointmentCompanionId(appointment.companion) !== companionId) {
+          throw new CaseEncounterServiceError(
+            "Encounter appointment companion mismatch.",
+            409,
+          );
+        }
+
+        if (appointment.caseId && appointment.caseId !== caseId) {
+          throw new CaseEncounterServiceError(
+            "Appointment is already linked to a different case.",
+            409,
+          );
+        }
+
+        if (appointment.encounterId) {
+          throw new CaseEncounterServiceError(
+            "Appointment is already linked to a different encounter.",
+            409,
+          );
+        }
+      }
+
+      const createdEncounter = await tx.encounter.create({
+        data: {
+          caseId,
+          organisationId,
+          companionId,
+          parentId: normalizeOptionalString(input.parentId) ?? null,
+          status,
+          encounterClass,
+          appointmentKind: input.appointmentKind,
+          title: normalizeOptionalString(input.title) ?? null,
+          reason: normalizeOptionalString(input.reason) ?? null,
+          periodStart: input.periodStart ?? null,
+          periodEnd: input.periodEnd ?? null,
+        },
+      });
+
+      if (appointmentId) {
+        await tx.appointment.update({
+          where: { id: appointmentId },
+          data: {
+            caseId,
+            encounterId: createdEncounter.id,
+          },
+        });
+      }
+
+      return createdEncounter;
+    });
+
+    return {
+      ...toEncounterDomain(created as EncounterRow),
+      appointmentId: normalizeOptionalString(input.appointmentId),
+    };
+  },
+
+  async updateEncounter(
+    encounterId: string,
+    input: Partial<EncounterDomain>,
+  ): Promise<EncounterDomain> {
+    const id = requireString(encounterId, "encounterId");
+    const status = input.status ? toEncounterStatus(input.status) : undefined;
+    const encounterClass = input.encounterClass
+      ? toEncounterClass(input.encounterClass)
+      : undefined;
+    assertPeriod(input.periodStart, input.periodEnd);
+
+    const updatedEncounter = await prisma.$transaction(async (tx) => {
+      const row = (await tx.encounter.findUnique({
+        where: { id },
+      })) as EncounterRow | null;
+      if (!row) {
+        throw new CaseEncounterServiceError("Encounter not found.", 404);
+      }
+
+      const nextCaseId = normalizeOptionalString(input.caseId) ?? row.caseId;
+      const nextOrganisationId =
+        normalizeOptionalString(input.organisationId) ?? row.organisationId;
+      const nextCompanionId =
+        normalizeOptionalString(input.companionId) ?? row.companionId;
+
+      if (
+        nextCaseId !== row.caseId ||
+        nextOrganisationId !== row.organisationId ||
+        nextCompanionId !== row.companionId
+      ) {
+        throw new CaseEncounterServiceError(
+          "caseId, organisationId and companionId cannot be changed for an encounter.",
+          400,
+        );
+      }
+
+      const currentAppointment = (await tx.appointment.findFirst({
+        where: { encounterId: id },
+        select: {
+          id: true,
+          caseId: true,
+          encounterId: true,
+          organisationId: true,
+          companion: true,
+        },
+      })) as AppointmentLinkRow | null;
+
+      const nextAppointmentId =
+        input.appointmentId === undefined
+          ? undefined
+          : (normalizeOptionalString(input.appointmentId) ?? null);
+
+      if (
+        nextAppointmentId !== undefined &&
+        nextAppointmentId !== currentAppointment?.id
+      ) {
+        if (currentAppointment) {
+          await tx.appointment.update({
+            where: { id: currentAppointment.id },
+            data: {
+              encounterId: null,
+            },
+          });
+        }
+
+        if (nextAppointmentId) {
+          const nextAppointment = (await tx.appointment.findUnique({
+            where: { id: nextAppointmentId },
+            select: {
+              id: true,
+              caseId: true,
+              encounterId: true,
+              organisationId: true,
+              companion: true,
+            },
+          })) as AppointmentLinkRow | null;
+
+          if (!nextAppointment) {
+            throw new CaseEncounterServiceError("Appointment not found.", 404);
+          }
+
+          if (nextAppointment.organisationId !== row.organisationId) {
+            throw new CaseEncounterServiceError(
+              "Encounter appointment organisation mismatch.",
+              409,
+            );
+          }
+
+          if (
+            toAppointmentCompanionId(nextAppointment.companion) !==
+            row.companionId
+          ) {
+            throw new CaseEncounterServiceError(
+              "Encounter appointment companion mismatch.",
+              409,
+            );
+          }
+
+          if (nextAppointment.caseId && nextAppointment.caseId !== row.caseId) {
+            throw new CaseEncounterServiceError(
+              "Appointment is already linked to a different case.",
+              409,
+            );
+          }
+
+          if (
+            nextAppointment.encounterId &&
+            nextAppointment.encounterId !== id
+          ) {
+            throw new CaseEncounterServiceError(
+              "Appointment is already linked to a different encounter.",
+              409,
+            );
+          }
+
+          await tx.appointment.update({
+            where: { id: nextAppointmentId },
+            data: {
+              caseId: row.caseId,
+              encounterId: id,
+            },
+          });
+        }
+      }
+
+      return (await tx.encounter.update({
+        where: { id },
+        data: {
+          status,
+          encounterClass,
+          appointmentKind: input.appointmentKind ?? undefined,
+          parentId:
+            input.parentId === undefined
+              ? undefined
+              : (normalizeOptionalString(input.parentId) ?? null),
+          title:
+            input.title === undefined
+              ? undefined
+              : (normalizeOptionalString(input.title) ?? null),
+          reason:
+            input.reason === undefined
+              ? undefined
+              : (normalizeOptionalString(input.reason) ?? null),
+          periodStart: input.periodStart ?? undefined,
+          periodEnd: input.periodEnd ?? undefined,
+        },
+      })) as EncounterRow;
+    });
+
+    return (
+      await attachEncounterAppointmentIds([toEncounterDomain(updatedEncounter)])
+    )[0];
+  },
+
+  async getEncounterById(encounterId: string): Promise<EncounterDomain> {
+    const id = requireString(encounterId, "encounterId");
+    const row = await prisma.encounter.findUnique({ where: { id } });
+    if (!row) {
+      throw new CaseEncounterServiceError("Encounter not found.", 404);
+    }
+    return (
+      await attachEncounterAppointmentIds([
+        toEncounterDomain(row as EncounterRow),
+      ])
+    )[0];
+  },
+
+  async listEncounters(filters: {
+    organisationId?: string;
+    caseId?: string;
+    companionId?: string;
+    parentId?: string;
+    status?: EncounterStatus;
+    appointmentKind?: AppointmentKind;
+  }) {
+    const rows = (await prisma.encounter.findMany({
+      where: {
+        organisationId: normalizeOptionalString(filters.organisationId),
+        caseId: normalizeOptionalString(filters.caseId),
+        companionId: normalizeOptionalString(filters.companionId),
+        parentId: normalizeOptionalString(filters.parentId),
+        status: filters.status,
+        appointmentKind: filters.appointmentKind,
+      },
+      orderBy: { updatedAt: "desc" },
+    })) as EncounterRow[];
+
+    return attachEncounterAppointmentIds(rows.map(toEncounterDomain));
+  },
+};

--- a/apps/backend/src/services/case-encounter.service.ts
+++ b/apps/backend/src/services/case-encounter.service.ts
@@ -69,6 +69,18 @@ type AdmissionFindManyDelegate = {
   }): Promise<AdmissionRow[]>;
 };
 
+type AdmissionMutationDelegate = {
+  findUnique(args: {
+    where: { encounterId: string };
+  }): Promise<AdmissionRow | null>;
+  update(args: {
+    where: { encounterId: string };
+    data: {
+      dischargedAt?: Date;
+    };
+  }): Promise<AdmissionRow>;
+};
+
 export class CaseEncounterServiceError extends Error {
   constructor(
     message: string,
@@ -616,6 +628,69 @@ export const CaseEncounterService = {
               : (normalizeOptionalString(input.reason) ?? null),
           periodStart: input.periodStart ?? undefined,
           periodEnd: input.periodEnd ?? undefined,
+        },
+      })) as EncounterRow;
+    });
+
+    return (
+      await attachEncounterAppointmentIds([toEncounterDomain(updatedEncounter)])
+    )[0];
+  },
+
+  async dischargeEncounter(
+    encounterId: string,
+    input?: { dischargedAt?: Date; periodEnd?: Date },
+  ): Promise<EncounterDomain> {
+    const id = requireString(encounterId, "encounterId");
+    assertPeriod(undefined, input?.dischargedAt);
+    assertPeriod(undefined, input?.periodEnd);
+
+    const updatedEncounter = await prisma.$transaction(async (tx) => {
+      const encounter = (await tx.encounter.findUnique({
+        where: { id },
+      })) as EncounterRow | null;
+
+      if (!encounter) {
+        throw new CaseEncounterServiceError("Encounter not found.", 404);
+      }
+
+      const admissionDelegate = (
+        tx as unknown as { admission: AdmissionMutationDelegate }
+      ).admission;
+      const admission = await admissionDelegate.findUnique({
+        where: { encounterId: id },
+      });
+
+      if (!admission) {
+        throw new CaseEncounterServiceError(
+          "Admission not found for encounter.",
+          404,
+        );
+      }
+
+      if (admission.dischargedAt) {
+        throw new CaseEncounterServiceError(
+          "Admission is already discharged.",
+          409,
+        );
+      }
+
+      const dischargedAt = input?.dischargedAt ?? new Date();
+      const nextPeriodEnd = input?.periodEnd ?? dischargedAt;
+      assertPeriod(encounter.periodStart ?? undefined, nextPeriodEnd);
+
+      await admissionDelegate.update({
+        where: { encounterId: id },
+        data: {
+          dischargedAt,
+        },
+      });
+
+      return (await tx.encounter.update({
+        where: { id },
+        data: {
+          status: "finished",
+          periodEnd: nextPeriodEnd,
         },
       })) as EncounterRow;
     });

--- a/apps/backend/src/services/case-encounter.service.ts
+++ b/apps/backend/src/services/case-encounter.service.ts
@@ -51,7 +51,7 @@ type AdmissionRow = {
   encounterId: string;
   organisationId: string;
   companionId: string;
-  bedUnitId: string | null;
+  unitId: string | null;
   expectedStayDays: number | null;
   admittedAt: Date;
   dischargedAt: Date | null;
@@ -76,9 +76,64 @@ type AdmissionMutationDelegate = {
   update(args: {
     where: { encounterId: string };
     data: {
+      unitId?: string;
       dischargedAt?: Date;
     };
   }): Promise<AdmissionRow>;
+};
+
+type RoomUnitRow = {
+  id: string;
+  organisationId: string;
+  roomId: string;
+  code: string;
+  displayName: string;
+  size: string | null;
+  speciesConstraints: unknown;
+  isActive: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type RoomUnitDelegate = {
+  findUnique(args: { where: { id: string } }): Promise<RoomUnitRow | null>;
+};
+
+type RoomUnitAssignmentRow = {
+  id: string;
+  encounterId: string;
+  admissionId: string;
+  unitId: string;
+  assignedAt: Date;
+  releasedAt: Date | null;
+  assignedBy: string | null;
+  reason: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type RoomUnitAssignmentDelegate = {
+  findFirst(args: {
+    where: {
+      admissionId: string;
+      releasedAt: null;
+    };
+    orderBy: { assignedAt: "desc" };
+  }): Promise<RoomUnitAssignmentRow | null>;
+  update(args: {
+    where: { id: string };
+    data: { releasedAt: Date };
+  }): Promise<RoomUnitAssignmentRow>;
+  create(args: {
+    data: {
+      encounterId: string;
+      admissionId: string;
+      unitId: string;
+      assignedAt: Date;
+      assignedBy: string | null;
+      reason: string | null;
+    };
+  }): Promise<RoomUnitAssignmentRow>;
 };
 
 export class CaseEncounterServiceError extends Error {
@@ -208,7 +263,7 @@ const toAdmissionDomain = (row: AdmissionRow): AdmissionDomain => ({
   encounterId: row.encounterId,
   organisationId: row.organisationId,
   companionId: row.companionId,
-  bedUnitId: row.bedUnitId ?? undefined,
+  unitId: row.unitId ?? undefined,
   expectedStayDays: row.expectedStayDays ?? undefined,
   admittedAt: row.admittedAt,
   dischargedAt: row.dischargedAt ?? undefined,
@@ -693,6 +748,118 @@ export const CaseEncounterService = {
           periodEnd: nextPeriodEnd,
         },
       })) as EncounterRow;
+    });
+
+    return (
+      await attachEncounterAppointmentIds([toEncounterDomain(updatedEncounter)])
+    )[0];
+  },
+
+  async assignUnit(
+    encounterId: string,
+    input: {
+      unitId: string;
+      assignedAt?: Date;
+      assignedBy?: string;
+      reason?: string;
+    },
+  ): Promise<EncounterDomain> {
+    const id = requireString(encounterId, "encounterId");
+    const unitId = requireString(input.unitId, "unitId");
+    const assignedAt = input.assignedAt ?? new Date();
+
+    if (Number.isNaN(assignedAt.getTime())) {
+      throw new CaseEncounterServiceError("Invalid assignedAt.", 400);
+    }
+
+    const updatedEncounter = await prisma.$transaction(async (tx) => {
+      const encounter = (await tx.encounter.findUnique({
+        where: { id },
+      })) as EncounterRow | null;
+
+      if (!encounter) {
+        throw new CaseEncounterServiceError("Encounter not found.", 404);
+      }
+
+      const admissionDelegate = (
+        tx as unknown as { admission: AdmissionMutationDelegate }
+      ).admission;
+      const roomUnitDelegate = (tx as unknown as { roomUnit: RoomUnitDelegate })
+        .roomUnit;
+      const assignmentDelegate = (
+        tx as unknown as { roomUnitAssignment: RoomUnitAssignmentDelegate }
+      ).roomUnitAssignment;
+
+      const admission = await admissionDelegate.findUnique({
+        where: { encounterId: id },
+      });
+
+      if (!admission) {
+        throw new CaseEncounterServiceError(
+          "Admission not found for encounter.",
+          404,
+        );
+      }
+
+      if (admission.dischargedAt) {
+        throw new CaseEncounterServiceError(
+          "Cannot assign unit to a discharged admission.",
+          409,
+        );
+      }
+
+      const unit = await roomUnitDelegate.findUnique({
+        where: { id: unitId },
+      });
+
+      if (!unit) {
+        throw new CaseEncounterServiceError("Room unit not found.", 404);
+      }
+
+      if (unit.organisationId !== encounter.organisationId) {
+        throw new CaseEncounterServiceError("Unit organisation mismatch.", 409);
+      }
+
+      if (!unit.isActive) {
+        throw new CaseEncounterServiceError("Selected unit is inactive.", 409);
+      }
+
+      const activeAssignment = await assignmentDelegate.findFirst({
+        where: {
+          admissionId: id,
+          releasedAt: null,
+        },
+        orderBy: { assignedAt: "desc" },
+      });
+
+      if (activeAssignment && activeAssignment.unitId !== unitId) {
+        await assignmentDelegate.update({
+          where: { id: activeAssignment.id },
+          data: { releasedAt: assignedAt },
+        });
+      }
+
+      if (!activeAssignment || activeAssignment.unitId !== unitId) {
+        await assignmentDelegate.create({
+          data: {
+            encounterId: id,
+            admissionId: id,
+            unitId,
+            assignedAt,
+            assignedBy: normalizeOptionalString(input.assignedBy) ?? null,
+            reason: normalizeOptionalString(input.reason) ?? null,
+          },
+        });
+      }
+
+      await admissionDelegate.update({
+        where: { encounterId: id },
+        data: {
+          unitId,
+        },
+      });
+
+      return encounter;
     });
 
     return (

--- a/apps/backend/src/services/case-encounter.service.ts
+++ b/apps/backend/src/services/case-encounter.service.ts
@@ -80,6 +80,7 @@ type RoomUnitRow = {
   id: string;
   organisationId: string;
   roomId: string;
+  unitGroupId: string | null;
   code: string;
   displayName: string;
   size: string | null;
@@ -91,6 +92,32 @@ type RoomUnitRow = {
 
 type RoomUnitDelegate = {
   findUnique(args: { where: { id: string } }): Promise<RoomUnitRow | null>;
+};
+
+type RoomUnitGroupRow = {
+  id: string;
+  organisationId: string;
+  roomId: string;
+  name: string;
+  size: string | null;
+  unitCount: number;
+  speciesConstraints: unknown;
+  capabilities: string[];
+  isActive: boolean;
+};
+
+type RoomUnitGroupDelegate = {
+  findUnique(args: { where: { id: string } }): Promise<RoomUnitGroupRow | null>;
+};
+
+type CompanionRow = {
+  id: string;
+  type: string;
+  speciesCode: string | null;
+};
+
+type CompanionDelegate = {
+  findUnique(args: { where: { id: string } }): Promise<CompanionRow | null>;
 };
 
 type RoomUnitAssignmentRow = {
@@ -250,6 +277,92 @@ const assertPeriod = (start?: Date, end?: Date) => {
     throw new CaseEncounterServiceError(
       "periodEnd must be after periodStart.",
       400,
+    );
+  }
+};
+
+const normalizeStringTokens = (value: unknown): string[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return [
+    ...new Set(
+      value
+        .map((item) =>
+          typeof item === "string" ? item.trim().toLowerCase() : "",
+        )
+        .filter((item) => item.length > 0),
+    ),
+  ];
+};
+
+const getCompanionSpeciesTokens = (companion: CompanionRow) => {
+  const tokens = new Set<string>();
+  const type = companion.type.trim().toLowerCase();
+
+  if (type) {
+    tokens.add(type);
+  }
+
+  if (companion.speciesCode?.trim()) {
+    tokens.add(companion.speciesCode.trim().toLowerCase());
+  }
+
+  const aliases: Record<string, string[]> = {
+    dog: ["canine"],
+    cat: ["feline"],
+    horse: ["equine"],
+    other: ["other"],
+  };
+
+  for (const alias of aliases[type] ?? []) {
+    tokens.add(alias);
+  }
+
+  return tokens;
+};
+
+const assertRoomUnitSpeciesCompatibility = (
+  unit: RoomUnitRow,
+  companion: CompanionRow,
+) => {
+  const constraints = normalizeStringTokens(unit.speciesConstraints);
+  if (constraints.length === 0) {
+    return;
+  }
+
+  const allowedSpecies = getCompanionSpeciesTokens(companion);
+  const isCompatible = constraints.some((constraint) =>
+    allowedSpecies.has(constraint),
+  );
+
+  if (!isCompatible) {
+    throw new CaseEncounterServiceError(
+      "Room unit is not compatible with this companion's species.",
+      409,
+    );
+  }
+};
+
+const assertRoomUnitGroupSpeciesCompatibility = (
+  group: RoomUnitGroupRow,
+  companion: CompanionRow,
+) => {
+  const constraints = normalizeStringTokens(group.speciesConstraints);
+  if (constraints.length === 0) {
+    return;
+  }
+
+  const allowedSpecies = getCompanionSpeciesTokens(companion);
+  const isCompatible = constraints.some((constraint) =>
+    allowedSpecies.has(constraint),
+  );
+
+  if (!isCompatible) {
+    throw new CaseEncounterServiceError(
+      "Room unit group is not compatible with this companion's species.",
+      409,
     );
   }
 };
@@ -846,6 +959,14 @@ export const CaseEncounterService = {
       ).admission;
       const roomUnitDelegate = (tx as unknown as { roomUnit: RoomUnitDelegate })
         .roomUnit;
+      const roomUnitGroupDelegate = (
+        tx as unknown as { roomUnitGroup: RoomUnitGroupDelegate }
+      ).roomUnitGroup;
+      const companionDelegate = (
+        tx as unknown as {
+          companion: CompanionDelegate;
+        }
+      ).companion;
       const assignmentDelegate = (
         tx as unknown as { roomUnitAssignment: RoomUnitAssignmentDelegate }
       ).roomUnitAssignment;
@@ -884,6 +1005,38 @@ export const CaseEncounterService = {
         throw new CaseEncounterServiceError("Selected unit is inactive.", 409);
       }
 
+      const companion = await companionDelegate.findUnique({
+        where: { id: encounter.companionId },
+      });
+
+      if (!companion) {
+        throw new CaseEncounterServiceError("Companion not found.", 404);
+      }
+
+      assertRoomUnitSpeciesCompatibility(unit, companion);
+
+      if (unit.unitGroupId) {
+        const group = await roomUnitGroupDelegate.findUnique({
+          where: { id: unit.unitGroupId },
+        });
+
+        if (!group) {
+          throw new CaseEncounterServiceError(
+            "Room unit group not found.",
+            404,
+          );
+        }
+
+        if (group.organisationId !== encounter.organisationId) {
+          throw new CaseEncounterServiceError(
+            "Room unit group organisation mismatch.",
+            409,
+          );
+        }
+
+        assertRoomUnitGroupSpeciesCompatibility(group, companion);
+      }
+
       const conflictingAssignment = await assignmentDelegate.findFirst({
         where: {
           unitId,
@@ -914,7 +1067,7 @@ export const CaseEncounterService = {
         });
       }
 
-      if (!activeAssignment || activeAssignment.unitId !== unitId) {
+      if (activeAssignment?.unitId !== unitId) {
         await assignmentDelegate.create({
           data: {
             encounterId: id,

--- a/apps/backend/src/services/case-encounter.service.ts
+++ b/apps/backend/src/services/case-encounter.service.ts
@@ -1,5 +1,6 @@
 import { prisma } from "src/config/prisma";
 import type {
+  Admission as AdmissionDomain,
   AppointmentKind,
   Case as CaseDomain,
   CaseStatus,
@@ -44,6 +45,28 @@ type AppointmentLinkRow = {
   encounterId: string | null;
   organisationId: string;
   companion: unknown;
+};
+
+type AdmissionRow = {
+  encounterId: string;
+  organisationId: string;
+  companionId: string;
+  bedUnitId: string | null;
+  expectedStayDays: number | null;
+  admittedAt: Date;
+  dischargedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type AdmissionFindManyDelegate = {
+  findMany(args: {
+    where: {
+      encounterId: {
+        in: string[];
+      };
+    };
+  }): Promise<AdmissionRow[]>;
 };
 
 export class CaseEncounterServiceError extends Error {
@@ -169,6 +192,18 @@ const toEncounterDomain = (row: EncounterRow): EncounterDomain => ({
   updatedAt: row.updatedAt,
 });
 
+const toAdmissionDomain = (row: AdmissionRow): AdmissionDomain => ({
+  encounterId: row.encounterId,
+  organisationId: row.organisationId,
+  companionId: row.companionId,
+  bedUnitId: row.bedUnitId ?? undefined,
+  expectedStayDays: row.expectedStayDays ?? undefined,
+  admittedAt: row.admittedAt,
+  dischargedAt: row.dischargedAt ?? undefined,
+  createdAt: row.createdAt,
+  updatedAt: row.updatedAt,
+});
+
 const toAppointmentCompanionId = (value: unknown): string =>
   ((value as { id?: string } | null)?.id ?? "").trim();
 
@@ -200,6 +235,27 @@ const attachEncounterAppointmentIds = async (
     }
   }
 
+  const admissionDelegate = (
+    prisma as unknown as { admission: AdmissionFindManyDelegate }
+  ).admission;
+
+  const admissions = await admissionDelegate.findMany({
+    where: {
+      encounterId: {
+        in: encounters
+          .map((encounter) => encounter.id)
+          .filter((value): value is string => Boolean(value)),
+      },
+    },
+  });
+
+  const admissionByEncounterId = new Map(
+    admissions.map((admission) => [
+      admission.encounterId,
+      toAdmissionDomain(admission),
+    ]),
+  );
+
   return encounters.map((encounter) => ({
     ...encounter,
     appointmentId:
@@ -207,6 +263,10 @@ const attachEncounterAppointmentIds = async (
         ? encounter.appointmentId
         : (appointmentIdByEncounterId.get(encounter.id) ??
           encounter.appointmentId),
+    admission:
+      encounter.id == null
+        ? encounter.admission
+        : admissionByEncounterId.get(encounter.id),
   }));
 };
 

--- a/apps/backend/src/services/case-encounter.service.ts
+++ b/apps/backend/src/services/case-encounter.service.ts
@@ -115,11 +115,21 @@ type RoomUnitAssignmentRow = {
 type RoomUnitAssignmentDelegate = {
   findFirst(args: {
     where: {
-      admissionId: string;
+      admissionId?: string;
+      unitId?: string;
       releasedAt: null;
     };
     orderBy: { assignedAt: "desc" };
   }): Promise<RoomUnitAssignmentRow | null>;
+  findMany(args: {
+    where: {
+      encounterId?: string;
+      admissionId?: string;
+      unitId?: string;
+      releasedAt?: Date | null;
+    };
+    orderBy: { assignedAt: "asc" | "desc" };
+  }): Promise<RoomUnitAssignmentRow[]>;
   update(args: {
     where: { id: string };
     data: { releasedAt: Date };
@@ -267,6 +277,19 @@ const toAdmissionDomain = (row: AdmissionRow): AdmissionDomain => ({
   expectedStayDays: row.expectedStayDays ?? undefined,
   admittedAt: row.admittedAt,
   dischargedAt: row.dischargedAt ?? undefined,
+  createdAt: row.createdAt,
+  updatedAt: row.updatedAt,
+});
+
+const toRoomUnitAssignmentDomain = (row: RoomUnitAssignmentRow) => ({
+  id: row.id,
+  encounterId: row.encounterId,
+  admissionId: row.admissionId,
+  unitId: row.unitId,
+  assignedAt: row.assignedAt,
+  releasedAt: row.releasedAt ?? undefined,
+  assignedBy: row.assignedBy ?? undefined,
+  reason: row.reason ?? undefined,
   createdAt: row.createdAt,
   updatedAt: row.updatedAt,
 });
@@ -824,6 +847,21 @@ export const CaseEncounterService = {
         throw new CaseEncounterServiceError("Selected unit is inactive.", 409);
       }
 
+      const conflictingAssignment = await assignmentDelegate.findFirst({
+        where: {
+          unitId,
+          releasedAt: null,
+        },
+        orderBy: { assignedAt: "desc" },
+      });
+
+      if (conflictingAssignment && conflictingAssignment.admissionId !== id) {
+        throw new CaseEncounterServiceError(
+          "Room unit is already occupied.",
+          409,
+        );
+      }
+
       const activeAssignment = await assignmentDelegate.findFirst({
         where: {
           admissionId: id,
@@ -865,6 +903,29 @@ export const CaseEncounterService = {
     return (
       await attachEncounterAppointmentIds([toEncounterDomain(updatedEncounter)])
     )[0];
+  },
+
+  async listUnitAssignments(filters: {
+    encounterId?: string;
+    admissionId?: string;
+    unitId?: string;
+    activeOnly?: boolean;
+  }) {
+    const assignmentDelegate = (
+      prisma as unknown as { roomUnitAssignment: RoomUnitAssignmentDelegate }
+    ).roomUnitAssignment;
+
+    const rows = await assignmentDelegate.findMany({
+      where: {
+        encounterId: normalizeOptionalString(filters.encounterId),
+        admissionId: normalizeOptionalString(filters.admissionId),
+        unitId: normalizeOptionalString(filters.unitId),
+        releasedAt: filters.activeOnly ? null : undefined,
+      },
+      orderBy: { assignedAt: "asc" },
+    });
+
+    return rows.map(toRoomUnitAssignmentDomain);
   },
 
   async getEncounterById(encounterId: string): Promise<EncounterDomain> {

--- a/apps/backend/src/services/case-encounter.service.ts
+++ b/apps/backend/src/services/case-encounter.service.ts
@@ -70,7 +70,7 @@ type AdmissionMutationDelegate = {
   update(args: {
     where: { encounterId: string };
     data: {
-      unitId?: string;
+      unitId?: string | null;
       dischargedAt?: Date;
     };
   }): Promise<AdmissionRow>;
@@ -185,6 +185,11 @@ const ACTIVE_INPATIENT_STATUSES = new Set<EncounterStatus>([
   "onleave",
 ]);
 
+const TERMINAL_ENCOUNTER_STATUSES = new Set<EncounterStatus>([
+  "finished",
+  "cancelled",
+]);
+
 const requireString = (value: string | undefined, field: string) => {
   const trimmed = value?.trim();
   if (!trimmed) {
@@ -221,6 +226,15 @@ const toEncounterClass = (value: string): EncounterClass => {
   }
 
   return value as EncounterClass;
+};
+
+const assertEncounterIsOpen = (encounter: EncounterRow, operation: string) => {
+  if (TERMINAL_ENCOUNTER_STATUSES.has(encounter.status as EncounterStatus)) {
+    throw new CaseEncounterServiceError(
+      `Cannot ${operation} a closed encounter.`,
+      409,
+    );
+  }
 };
 
 const assertPeriod = (start?: Date, end?: Date) => {
@@ -758,10 +772,32 @@ export const CaseEncounterService = {
       const nextPeriodEnd = input?.periodEnd ?? dischargedAt;
       assertPeriod(encounter.periodStart ?? undefined, nextPeriodEnd);
 
+      const activeAssignment = await (
+        tx as unknown as { roomUnitAssignment: RoomUnitAssignmentDelegate }
+      ).roomUnitAssignment.findFirst({
+        where: {
+          admissionId: id,
+          releasedAt: null,
+        },
+        orderBy: { assignedAt: "desc" },
+      });
+
+      if (activeAssignment) {
+        await (
+          tx as unknown as { roomUnitAssignment: RoomUnitAssignmentDelegate }
+        ).roomUnitAssignment.update({
+          where: { id: activeAssignment.id },
+          data: {
+            releasedAt: dischargedAt,
+          },
+        });
+      }
+
       await admissionDelegate.update({
         where: { encounterId: id },
         data: {
           dischargedAt,
+          unitId: null,
         },
       });
 
@@ -927,6 +963,98 @@ export const CaseEncounterService = {
     });
 
     return rows.map(toRoomUnitAssignmentDomain);
+  },
+
+  async listAdmissionUnitAssignments(admissionId: string) {
+    const id = requireString(admissionId, "admissionId");
+    const admission = await prisma.admission.findUnique({
+      where: { encounterId: id },
+    });
+
+    if (!admission) {
+      throw new CaseEncounterServiceError(
+        "Admission not found for encounter.",
+        404,
+      );
+    }
+
+    const assignmentDelegate = (
+      prisma as unknown as { roomUnitAssignment: RoomUnitAssignmentDelegate }
+    ).roomUnitAssignment;
+
+    const rows = await assignmentDelegate.findMany({
+      where: {
+        admissionId: id,
+      },
+      orderBy: { assignedAt: "asc" },
+    });
+
+    return rows.map(toRoomUnitAssignmentDomain);
+  },
+
+  async startEncounter(
+    encounterId: string,
+    input?: { startedAt?: Date },
+  ): Promise<EncounterDomain> {
+    const id = requireString(encounterId, "encounterId");
+    const startedAt = input?.startedAt ?? new Date();
+
+    if (Number.isNaN(startedAt.getTime())) {
+      throw new CaseEncounterServiceError("Invalid startedAt.", 400);
+    }
+
+    const updatedEncounter = await prisma.$transaction(async (tx) => {
+      const encounter = (await tx.encounter.findUnique({
+        where: { id },
+      })) as EncounterRow | null;
+
+      if (!encounter) {
+        throw new CaseEncounterServiceError("Encounter not found.", 404);
+      }
+
+      assertEncounterIsOpen(encounter, "start");
+
+      return (await tx.encounter.update({
+        where: { id },
+        data: {
+          status: "in-progress",
+          periodStart: encounter.periodStart ?? startedAt,
+        },
+      })) as EncounterRow;
+    });
+
+    return (
+      await attachEncounterAppointmentIds([toEncounterDomain(updatedEncounter)])
+    )[0];
+  },
+
+  async markEncounterReadyForDischarge(
+    encounterId: string,
+  ): Promise<EncounterDomain> {
+    const id = requireString(encounterId, "encounterId");
+
+    const updatedEncounter = await prisma.$transaction(async (tx) => {
+      const encounter = (await tx.encounter.findUnique({
+        where: { id },
+      })) as EncounterRow | null;
+
+      if (!encounter) {
+        throw new CaseEncounterServiceError("Encounter not found.", 404);
+      }
+
+      assertEncounterIsOpen(encounter, "mark ready for discharge");
+
+      return (await tx.encounter.update({
+        where: { id },
+        data: {
+          status: "onleave",
+        },
+      })) as EncounterRow;
+    });
+
+    return (
+      await attachEncounterAppointmentIds([toEncounterDomain(updatedEncounter)])
+    )[0];
   },
 
   async listActiveInpatientEncounters(filters: { organisationId?: string }) {

--- a/apps/backend/src/services/case-encounter.service.ts
+++ b/apps/backend/src/services/case-encounter.service.ts
@@ -60,13 +60,7 @@ type AdmissionRow = {
 };
 
 type AdmissionFindManyDelegate = {
-  findMany(args: {
-    where: {
-      encounterId: {
-        in: string[];
-      };
-    };
-  }): Promise<AdmissionRow[]>;
+  findMany(args: { where: Record<string, unknown> }): Promise<AdmissionRow[]>;
 };
 
 type AdmissionMutationDelegate = {
@@ -182,6 +176,13 @@ const ENCOUNTER_CLASSES = new Set<EncounterClass>([
   "EMER",
   "OBSENC",
   "VR",
+]);
+
+const ACTIVE_INPATIENT_STATUSES = new Set<EncounterStatus>([
+  "arrived",
+  "triaged",
+  "in-progress",
+  "onleave",
 ]);
 
 const requireString = (value: string | undefined, field: string) => {
@@ -926,6 +927,53 @@ export const CaseEncounterService = {
     });
 
     return rows.map(toRoomUnitAssignmentDomain);
+  },
+
+  async listActiveInpatientEncounters(filters: { organisationId?: string }) {
+    const organisationId = requireString(
+      filters.organisationId,
+      "organisationId",
+    );
+
+    const admissionDelegate = (
+      prisma as unknown as { admission: AdmissionFindManyDelegate }
+    ).admission;
+
+    const admissions = await admissionDelegate.findMany({
+      where: {
+        organisationId,
+        dischargedAt: null,
+      },
+    });
+
+    if (admissions.length === 0) {
+      return [];
+    }
+
+    const encounterIds = admissions.map((admission) => admission.encounterId);
+    const rows = (await prisma.encounter.findMany({
+      where: {
+        id: {
+          in: encounterIds,
+        },
+        organisationId,
+        appointmentKind: "INPATIENT",
+        status: {
+          in: [...ACTIVE_INPATIENT_STATUSES],
+        },
+      },
+      orderBy: { periodStart: "asc" },
+    })) as EncounterRow[];
+
+    const encounterById = new Map(
+      rows.map((row) => [row.id, toEncounterDomain(row)]),
+    );
+
+    const orderedEncounters = admissions
+      .map((admission) => encounterById.get(admission.encounterId))
+      .filter((value): value is EncounterDomain => Boolean(value));
+
+    return attachEncounterAppointmentIds(orderedEncounters);
   },
 
   async getEncounterById(encounterId: string): Promise<EncounterDomain> {

--- a/apps/backend/src/services/catalog.service.ts
+++ b/apps/backend/src/services/catalog.service.ts
@@ -898,7 +898,7 @@ const ensureSpecialityDeletionAllowed = async (
   specialityId: string,
   organisationId: string,
 ) => {
-  const [products, appointments, invoices] = await Promise.all([
+  const [products, appointments, matchingAppointments] = await Promise.all([
     prisma.productItem.findMany({
       where: {
         organisationId,
@@ -919,11 +919,30 @@ const ensureSpecialityDeletionAllowed = async (
         },
       },
     }),
-    prisma.invoice.findMany({
-      where: { organisationId },
-      select: { id: true, items: true },
+    prisma.appointment.findMany({
+      where: {
+        organisationId,
+        appointmentType: {
+          path: ["speciality", "id"],
+          equals: specialityId,
+        },
+      },
+      select: {
+        id: true,
+      },
     }),
   ]);
+
+  const invoiceUsageCount = matchingAppointments.length
+    ? await prisma.invoice.count({
+        where: {
+          organisationId,
+          appointmentId: {
+            in: matchingAppointments.map((appointment) => appointment.id),
+          },
+        },
+      })
+    : 0;
 
   const dependencyDetails = {
     activeServices: products.filter(
@@ -939,7 +958,7 @@ const ensureSpecialityDeletionAllowed = async (
       (item) => item.kind === "PACKAGE" && !item.isActive,
     ).length,
     appointments,
-    invoices: invoices.length,
+    invoices: invoiceUsageCount,
   };
 
   if (Object.values(dependencyDetails).some((value) => value > 0)) {

--- a/apps/backend/src/services/organisation-room.service.ts
+++ b/apps/backend/src/services/organisation-room.service.ts
@@ -1,22 +1,86 @@
-import { isValidObjectId, Types } from "mongoose";
-import OrganisationRoomModel, {
-  type OrganisationRoomDocument,
-  type OrganisationRoomMongo,
-} from "../models/organisation-room";
-import {
-  fromOrganisationRoomRequestDTO,
-  toOrganisationRoomResponseDTO,
-  type OrganisationRoomDTOAttributes,
-  type OrganisationRoomRequestDTO,
-  type OrganisationRoomResponseDTO,
-  type OrganisationRoom as OrganisationRoomDomain,
-} from "@yosemite-crew/types";
+import { RoomOccupancyStatus, RoomType } from "@yosemite-crew/database";
+import type { RoomReferenceMapping } from "@yosemite-crew/types";
 import { prisma } from "src/config/prisma";
-import { handleDualWriteError, shouldDualWrite } from "src/utils/dual-write";
-import { RoomType } from "@prisma/client";
-import { isReadFromPostgres } from "src/config/read-switch";
+import {
+  normalizeRoomOccupancyStatus,
+  normalizeRoomType,
+  normalizeReferenceMappings,
+  normalizeStrictStringList,
+  requireNonEmptyString,
+  RoomValidationError,
+} from "./room-management.helpers";
 
-export type OrganisationRoomFHIRPayload = OrganisationRoomRequestDTO;
+export type OrganisationRoomInput = {
+  organisationId: string;
+  name: string;
+  code: string;
+  description?: string | null;
+  type: RoomType;
+  occupancyStatus?: RoomOccupancyStatus;
+  assignedSpecialiteis?: RoomReferenceMapping[];
+  assignedStaffs?: RoomReferenceMapping[];
+  availableNow?: boolean;
+  availabilityMode?: "WORKING_HOURS" | "ALL_DAY" | "CUSTOM";
+  availabilityDays?: string[];
+  availabilityStartTime?: string | null;
+  availabilityEndTime?: string | null;
+  capabilities?: string[];
+};
+
+export type OrganisationRoomRecord = {
+  id: string;
+  organisationId: string;
+  name: string;
+  code: string;
+  description?: string;
+  type: RoomType;
+  occupancyStatus: RoomOccupancyStatus;
+  assignedSpecialiteis: RoomReferenceMapping[];
+  assignedStaffs: RoomReferenceMapping[];
+  availableNow: boolean;
+  availabilityMode: "WORKING_HOURS" | "ALL_DAY" | "CUSTOM";
+  availabilityDays: string[];
+  availabilityStartTime?: string;
+  availabilityEndTime?: string;
+  capabilities: string[];
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type OrganisationRoomSummaryUnit = {
+  id: string;
+  code: string;
+  displayName: string;
+  size: string | null;
+  speciesConstraints: string[];
+  isActive: boolean;
+  isOccupied: boolean;
+};
+
+export type OrganisationRoomSummaryGroup = {
+  id: string;
+  name: string;
+  size: string | null;
+  unitCount: number;
+  occupiedCount: number;
+  vacantCount: number;
+  speciesConstraints: string[];
+  capabilities: string[];
+  isActive: boolean;
+};
+
+export type OrganisationRoomSummaryItem = OrganisationRoomRecord & {
+  totalUnits: number;
+  occupiedUnits: number;
+  vacantUnits: number;
+  occupancyDisplay: string;
+  unitGroups: OrganisationRoomSummaryGroup[];
+  units: OrganisationRoomSummaryUnit[];
+};
+
+export type OrganisationRoomDetail = OrganisationRoomSummaryItem & {
+  occupancySource: "UNITS" | "ROOM";
+};
 
 export class OrganisationRoomServiceError extends Error {
   constructor(
@@ -28,418 +92,984 @@ export class OrganisationRoomServiceError extends Error {
   }
 }
 
-const ROOM_TYPES = new Set<OrganisationRoomDomain["type"]>([
-  "CONSULTATION",
-  "WAITING_AREA",
-  "SURGERY",
-  "ICU",
-]);
-
-const pruneUndefined = <T>(value: T): T => {
-  if (Array.isArray(value)) {
-    const cleaned = (value as unknown[])
-      .map((item) => pruneUndefined(item))
-      .filter((item) => item !== undefined);
-    return cleaned as unknown as T;
-  }
-
-  if (value && typeof value === "object") {
-    if (value instanceof Date) {
-      return value;
-    }
-
-    const record = value as Record<string, unknown>;
-    const cleanedRecord: Record<string, unknown> = {};
-
-    for (const [key, entryValue] of Object.entries(record)) {
-      const next = pruneUndefined(entryValue);
-
-      if (next !== undefined) {
-        cleanedRecord[key] = next;
-      }
-    }
-
-    return cleanedRecord as unknown as T;
-  }
-
-  return value;
-};
-
-const requireSafeString = (value: unknown, fieldName: string): string => {
-  if (value == null) {
-    throw new OrganisationRoomServiceError(`${fieldName} is required.`, 400);
-  }
-
-  if (typeof value !== "string") {
-    throw new OrganisationRoomServiceError(
-      `${fieldName} must be a string.`,
-      400,
-    );
-  }
-
-  const trimmed = value.trim();
-
-  if (!trimmed) {
-    throw new OrganisationRoomServiceError(
-      `${fieldName} cannot be empty.`,
-      400,
-    );
-  }
-
-  if (trimmed.includes("$")) {
-    throw new OrganisationRoomServiceError(
-      `Invalid character in ${fieldName}.`,
-      400,
-    );
-  }
-
-  return trimmed;
-};
-
-const optionalSafeString = (
-  value: unknown,
-  fieldName: string,
-): string | undefined => {
-  if (value == null) {
-    return undefined;
-  }
-
-  if (typeof value !== "string") {
-    throw new OrganisationRoomServiceError(
-      `${fieldName} must be a string.`,
-      400,
-    );
-  }
-
-  const trimmed = value.trim();
-
-  if (!trimmed) {
-    return undefined;
-  }
-
-  if (trimmed.includes("$")) {
-    throw new OrganisationRoomServiceError(
-      `Invalid character in ${fieldName}.`,
-      400,
-    );
-  }
-
-  return trimmed;
-};
-
-const ensureSafeIdentifier = (value: unknown): string | undefined => {
-  const identifier = optionalSafeString(value, "Identifier");
-
-  if (!identifier) {
-    return undefined;
-  }
-
-  if (
-    !isValidObjectId(identifier) &&
-    !/^[A-Za-z0-9\-.]{1,64}$/.test(identifier)
-  ) {
-    throw new OrganisationRoomServiceError("Invalid identifier format.", 400);
-  }
-
-  return identifier;
-};
-
-const requireOrganizationId = (value: unknown): string => {
-  const identifier = requireSafeString(value, "Organisation identifier");
-
-  if (
-    !isValidObjectId(identifier) &&
-    !/^[A-Za-z0-9\-.]{1,64}$/.test(identifier)
-  ) {
-    throw new OrganisationRoomServiceError(
-      "Invalid organisation identifier format.",
-      400,
-    );
-  }
-
-  return identifier;
-};
-
-const requireRoomType = (value: unknown): OrganisationRoomDomain["type"] => {
-  if (typeof value !== "string") {
-    throw new OrganisationRoomServiceError("Room type must be a string.", 400);
-  }
-
-  const upper = value.toUpperCase() as OrganisationRoomDomain["type"];
-
-  if (!ROOM_TYPES.has(upper)) {
-    throw new OrganisationRoomServiceError(
-      `Room type must be one of: ${Array.from(ROOM_TYPES).join(", ")}.`,
-      400,
-    );
-  }
-
-  return upper;
-};
-
-const sanitizeIdList = (
-  values: unknown,
-  fieldName: string,
-): string[] | undefined => {
-  if (!Array.isArray(values)) {
-    return undefined;
-  }
-
-  const cleaned = values
-    .map((value, index) =>
-      optionalSafeString(value, `${fieldName} at index ${index}`),
-    )
-    .filter((value): value is string => Boolean(value));
-
-  return cleaned.length ? cleaned : undefined;
-};
-
-const sanitizeRoomAttributes = (
-  dto: OrganisationRoomDTOAttributes,
-): OrganisationRoomMongo => {
-  const organisationId = requireOrganizationId(dto.organisationId);
-  const name = requireSafeString(dto.name, "Room name");
-  const type = requireRoomType(dto.type);
-
-  return {
-    fhirId: ensureSafeIdentifier(dto.id),
-    organisationId,
-    name,
-    type,
-    assignedSpecialiteis: sanitizeIdList(
-      dto.assignedSpecialiteis,
-      "Assigned speciality",
-    ),
-    assignedStaffs: sanitizeIdList(dto.assignedStaffs, "Assigned staff"),
-  };
-};
-
-const buildDomainRoom = (
-  document: OrganisationRoomDocument,
-): OrganisationRoomDomain => {
-  const { _id, ...rest } = document.toObject({
-    virtuals: false,
-  }) as OrganisationRoomMongo & {
-    _id: Types.ObjectId;
-  };
-
-  return {
-    id: rest.fhirId ?? _id.toString(),
-    name: rest.name,
-    organisationId: rest.organisationId,
-    type: rest.type,
-    assignedSpecialiteis: rest.assignedSpecialiteis,
-    assignedStaffs: rest.assignedStaffs,
-  };
-};
-
-const buildFHIRResponse = (
-  document: OrganisationRoomDocument,
-): OrganisationRoomResponseDTO =>
-  toOrganisationRoomResponseDTO(buildDomainRoom(document));
-
-const buildFHIRResponseFromPrisma = (room: {
+type RoomRow = {
   id: string;
-  fhirId: string | null;
   organisationId: string;
   name: string;
+  code: string;
+  description: string | null;
   type: RoomType;
-  assignedSpecialiteis: string[];
-  assignedStaffs: string[];
-}): OrganisationRoomResponseDTO =>
-  toOrganisationRoomResponseDTO({
-    id: room.fhirId ?? room.id,
-    name: room.name,
-    organisationId: room.organisationId,
-    type: room.type,
-    assignedSpecialiteis: room.assignedSpecialiteis ?? [],
-    assignedStaffs: room.assignedStaffs ?? [],
-  });
-
-const createPersistableFromFHIR = (payload: OrganisationRoomFHIRPayload) => {
-  if (payload?.resourceType !== "Location") {
-    throw new OrganisationRoomServiceError(
-      "Invalid payload. Expected FHIR Location resource.",
-      400,
-    );
-  }
-
-  const attributes = fromOrganisationRoomRequestDTO(payload);
-  const persistable = pruneUndefined(sanitizeRoomAttributes(attributes));
-
-  return { attributes, persistable };
+  occupancyStatus: RoomOccupancyStatus;
+  availableNow: boolean;
+  availabilityMode: "WORKING_HOURS" | "ALL_DAY" | "CUSTOM";
+  availabilityDays: string[];
+  availabilityStartTime: string | null;
+  availabilityEndTime: string | null;
+  capabilities: string[];
+  createdAt: Date;
+  updatedAt: Date;
 };
 
-const resolveIdQuery = (id: unknown): { _id?: string; fhirId?: string } => {
-  const identifier = optionalSafeString(id, "Room identifier");
+type RoomSpecialityRow = {
+  roomId: string;
+  specialityId: string;
+};
 
-  if (!identifier) {
-    throw new OrganisationRoomServiceError("Room identifier is required.", 400);
+type RoomStaffRow = {
+  roomId: string;
+  staffUserId: string;
+};
+
+type SpecialityRow = {
+  id: string;
+  name: string;
+};
+
+type UserRow = {
+  userId: string;
+  firstName: string | null;
+  lastName: string | null;
+};
+
+type RoomUnitRow = {
+  id: string;
+  roomId: string;
+  unitGroupId: string | null;
+  code: string;
+  displayName: string;
+  size: string | null;
+  speciesConstraints: unknown;
+  isActive: boolean;
+};
+
+type RoomUnitGroupRow = {
+  id: string;
+  roomId: string;
+  name: string;
+  size: string | null;
+  unitCount: number;
+  speciesConstraints: unknown;
+  capabilities: string[];
+  isActive: boolean;
+};
+
+type AdmissionRow = {
+  unitId: string | null;
+};
+
+const normalizeAvailabilityMode = (
+  value: unknown,
+): OrganisationRoomRecord["availabilityMode"] | undefined => {
+  if (value == null) {
+    return undefined;
   }
 
-  if (isValidObjectId(identifier)) {
-    return { _id: identifier };
+  if (typeof value !== "string") {
+    throw new RoomValidationError("Availability mode must be a string.");
   }
 
-  if (/^[A-Za-z0-9\-.]{1,64}$/.test(identifier)) {
-    return { fhirId: identifier };
+  const normalized = value.trim().toUpperCase();
+  if (!normalized) {
+    return undefined;
   }
 
-  throw new OrganisationRoomServiceError(
-    "Invalid room identifier format.",
-    400,
+  if (!["WORKING_HOURS", "ALL_DAY", "CUSTOM"].includes(normalized)) {
+    throw new RoomValidationError("Invalid availability mode.");
+  }
+
+  return normalized as OrganisationRoomRecord["availabilityMode"];
+};
+
+const normalizeOptionalString = (value: unknown) => {
+  if (value == null) {
+    return undefined;
+  }
+
+  if (typeof value !== "string") {
+    throw new RoomValidationError("Invalid string value.");
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+const normalizeSpeciesConstraints = (value: unknown): string[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return [
+    ...new Set(
+      value
+        .map((entry) =>
+          typeof entry === "string" ? entry.trim().toLowerCase() : "",
+        )
+        .filter((entry) => entry.length > 0),
+    ),
+  ];
+};
+
+const wrapValidationError = (error: unknown): never => {
+  if (error instanceof RoomValidationError) {
+    throw new OrganisationRoomServiceError(error.message, 400);
+  }
+
+  throw error;
+};
+
+const displayNameFromUser = (user: UserRow) =>
+  [user.firstName, user.lastName].filter(Boolean).join(" ").trim() ||
+  user.userId;
+
+const uniqueById = <T extends { id: string }>(values: T[]) => {
+  const deduped = new Map<string, T>();
+  for (const value of values) {
+    deduped.set(value.id, value);
+  }
+  return [...deduped.values()];
+};
+
+const toRecord = (
+  row: RoomRow,
+  specialities: RoomReferenceMapping[] = [],
+  staff: RoomReferenceMapping[] = [],
+): OrganisationRoomRecord => ({
+  id: row.id,
+  organisationId: row.organisationId,
+  name: row.name,
+  code: row.code,
+  description: row.description ?? undefined,
+  type: row.type,
+  occupancyStatus: row.occupancyStatus,
+  assignedSpecialiteis: specialities,
+  assignedStaffs: staff,
+  availableNow: row.availableNow,
+  availabilityMode: row.availabilityMode,
+  availabilityDays: row.availabilityDays ?? [],
+  availabilityStartTime: row.availabilityStartTime ?? undefined,
+  availabilityEndTime: row.availabilityEndTime ?? undefined,
+  capabilities: row.capabilities ?? [],
+  createdAt: row.createdAt,
+  updatedAt: row.updatedAt,
+});
+
+const getOrganisationRoomDelegate = () =>
+  (
+    prisma as unknown as {
+      organisationRoom: {
+        create(args: {
+          data: Omit<RoomRow, "id" | "createdAt" | "updatedAt">;
+        }): Promise<RoomRow>;
+        findUnique(args: {
+          where: { id: string };
+          select?: Record<string, unknown>;
+        }): Promise<RoomRow | null>;
+        findFirst(args: {
+          where: Record<string, unknown>;
+          select?: Record<string, unknown>;
+        }): Promise<RoomRow | null>;
+        findMany(args: {
+          where: Record<string, unknown>;
+          orderBy?:
+            | Record<string, "asc" | "desc">
+            | Array<Record<string, "asc" | "desc">>;
+          select?: Record<string, unknown>;
+        }): Promise<RoomRow[]>;
+        update(args: {
+          where: { id: string };
+          data: Partial<
+            Omit<RoomRow, "id" | "organisationId" | "createdAt" | "updatedAt">
+          >;
+        }): Promise<RoomRow>;
+        delete(args: { where: { id: string } }): Promise<RoomRow>;
+        deleteMany(args: { where: { organisationId: string } }): Promise<{
+          count: number;
+        }>;
+      };
+      organisationRoomSpeciality: {
+        createMany(args: {
+          data: Array<{
+            organisationId: string;
+            roomId: string;
+            specialityId: string;
+          }>;
+        }): Promise<unknown>;
+        deleteMany(args: {
+          where: { organisationId?: string; roomId?: string };
+        }): Promise<{ count: number }>;
+        findMany(args: {
+          where: { organisationId: string };
+          orderBy: Array<Record<string, "asc" | "desc">>;
+        }): Promise<RoomSpecialityRow[]>;
+      };
+      organisationRoomStaff: {
+        createMany(args: {
+          data: Array<{
+            organisationId: string;
+            roomId: string;
+            staffUserId: string;
+          }>;
+        }): Promise<unknown>;
+        deleteMany(args: {
+          where: { organisationId?: string; roomId?: string };
+        }): Promise<{ count: number }>;
+        findMany(args: {
+          where: { organisationId: string };
+          orderBy: Array<Record<string, "asc" | "desc">>;
+        }): Promise<RoomStaffRow[]>;
+      };
+      speciality: {
+        findMany(args: {
+          where: { id: { in: string[] } };
+          select: { id: true; name: true };
+        }): Promise<SpecialityRow[]>;
+      };
+      user: {
+        findMany(args: {
+          where: { userId: { in: string[] } };
+          select: { userId: true; firstName: true; lastName: true };
+        }): Promise<UserRow[]>;
+      };
+      roomUnit: {
+        findMany(args: {
+          where: { organisationId: string };
+          orderBy: Array<Record<string, "asc" | "desc">>;
+        }): Promise<RoomUnitRow[]>;
+      };
+      roomUnitGroup: {
+        findMany(args: {
+          where: { organisationId: string };
+          orderBy: Array<Record<string, "asc" | "desc">>;
+        }): Promise<RoomUnitGroupRow[]>;
+      };
+      admission: {
+        findMany(args: {
+          where: {
+            organisationId: string;
+            dischargedAt: null;
+            unitId: { not: null };
+          };
+          select: { unitId: true };
+        }): Promise<AdmissionRow[]>;
+      };
+    }
+  ).organisationRoom;
+
+const assertOrganisationRoomExists = async (
+  id: string,
+  organisationId: string,
+) => {
+  const room = await getOrganisationRoomDelegate().findUnique({
+    where: { id },
+    select: { id: true, organisationId: true },
+  });
+
+  if (!room) {
+    throw new OrganisationRoomServiceError("Organisation room not found.", 404);
+  }
+
+  if (room.organisationId !== organisationId) {
+    throw new OrganisationRoomServiceError(
+      "Organisation room does not belong to the requested organisation.",
+      403,
+    );
+  }
+};
+
+const assertRoomCodeIsUnique = async (
+  organisationId: string,
+  code: string,
+  excludeId?: string,
+) => {
+  const room = await getOrganisationRoomDelegate().findFirst({
+    where: {
+      organisationId,
+      code,
+      ...(excludeId ? { id: { not: excludeId } } : {}),
+    },
+    select: { id: true },
+  });
+
+  if (room) {
+    throw new OrganisationRoomServiceError(
+      "Room code must be unique within the organisation.",
+      409,
+    );
+  }
+};
+
+type BuiltRoomInput = {
+  room: Omit<RoomRow, "id" | "createdAt" | "updatedAt">;
+  assignedSpecialiteis: RoomReferenceMapping[];
+  assignedStaffs: RoomReferenceMapping[];
+};
+
+const buildRoomInput = (
+  input: Partial<OrganisationRoomInput>,
+): BuiltRoomInput => {
+  try {
+    const organisationId = requireNonEmptyString(
+      input.organisationId,
+      "organisationId",
+    );
+    const name = requireNonEmptyString(input.name, "name");
+    const code = requireNonEmptyString(input.code, "code");
+    const type = normalizeRoomType(input.type);
+
+    return {
+      room: {
+        organisationId,
+        name,
+        code,
+        description: normalizeOptionalString(input.description) ?? null,
+        type,
+        occupancyStatus:
+          input.occupancyStatus == null
+            ? "VACANT"
+            : normalizeRoomOccupancyStatus(input.occupancyStatus),
+        availableNow:
+          typeof input.availableNow === "boolean" ? input.availableNow : true,
+        availabilityMode:
+          normalizeAvailabilityMode(input.availabilityMode) ?? "ALL_DAY",
+        availabilityDays: normalizeStrictStringList(
+          input.availabilityDays,
+          "availabilityDays",
+        ),
+        availabilityStartTime:
+          normalizeOptionalString(input.availabilityStartTime) ?? null,
+        availabilityEndTime:
+          normalizeOptionalString(input.availabilityEndTime) ?? null,
+        capabilities: normalizeStrictStringList(
+          input.capabilities,
+          "capabilities",
+        ),
+      },
+      assignedSpecialiteis: normalizeReferenceMappings(
+        input.assignedSpecialiteis,
+        "assignedSpecialiteis",
+      ),
+      assignedStaffs: normalizeReferenceMappings(
+        input.assignedStaffs,
+        "assignedStaffs",
+      ),
+    };
+  } catch (error) {
+    return wrapValidationError(error);
+  }
+};
+
+const groupRowsByRoom = <T extends { roomId: string }>(rows: T[]) => {
+  const grouped = new Map<string, T[]>();
+
+  for (const row of rows) {
+    const current = grouped.get(row.roomId) ?? [];
+    current.push(row);
+    grouped.set(row.roomId, current);
+  }
+
+  return grouped;
+};
+
+const normalizeSummaryStringList = (value: unknown): string[] =>
+  normalizeSpeciesConstraints(value);
+
+const resolveSpecialityMappings = (
+  links: RoomSpecialityRow[],
+  specialities: Array<{ id: string; name: string }>,
+): RoomReferenceMapping[] => {
+  const byId = new Map(specialities.map((row) => [row.id, row]));
+
+  return uniqueById(
+    links.map((link) => {
+      const row = byId.get(link.specialityId);
+      return row
+        ? { id: row.id, name: row.name }
+        : { id: link.specialityId, name: link.specialityId };
+    }),
   );
 };
 
-const toPrismaOrganisationRoomData = (doc: OrganisationRoomDocument) => {
-  const obj = doc.toObject() as OrganisationRoomMongo & {
-    _id: Types.ObjectId;
-    createdAt?: Date;
-    updatedAt?: Date;
-  };
+const resolveStaffMappings = (
+  links: RoomStaffRow[],
+  users: UserRow[],
+): RoomReferenceMapping[] => {
+  const byUserId = new Map(users.map((user) => [user.userId, user]));
+
+  return uniqueById(
+    links.map((link) => {
+      const user = byUserId.get(link.staffUserId);
+      if (!user) {
+        return {
+          id: link.staffUserId,
+          name: link.staffUserId,
+        };
+      }
+
+      return {
+        id: user.userId,
+        name: displayNameFromUser(user),
+      };
+    }),
+  );
+};
+
+const syncRoomReferenceLinks = async (params: {
+  roomId: string;
+  organisationId: string;
+  specialities: RoomReferenceMapping[];
+  staff: RoomReferenceMapping[];
+}): Promise<{
+  specialities: RoomReferenceMapping[];
+  staff: RoomReferenceMapping[];
+}> => {
+  const orgId = params.organisationId;
+  const roomId = params.roomId;
+
+  await prisma.organisationRoomSpeciality.deleteMany({
+    where: { roomId, organisationId: orgId },
+  });
+  await prisma.organisationRoomStaff.deleteMany({
+    where: { roomId, organisationId: orgId },
+  });
+
+  const specialityIds = params.specialities.map((entry) => entry.id);
+  let resolvedSpecialities: RoomReferenceMapping[] = [];
+  if (specialityIds.length) {
+    const specialityRows = await prisma.speciality.findMany({
+      where: { id: { in: specialityIds } },
+      select: { id: true, name: true, organisationId: true },
+    });
+
+    const specialityById = new Map(specialityRows.map((row) => [row.id, row]));
+    const invalidSpecialities = specialityIds.filter(
+      (id) => !specialityById.has(id),
+    );
+    if (invalidSpecialities.length) {
+      throw new OrganisationRoomServiceError(
+        `Invalid speciality reference(s): ${invalidSpecialities.join(", ")}`,
+        400,
+      );
+    }
+
+    const invalidOrgSpecialities = specialityRows.filter(
+      (row) => row.organisationId !== orgId,
+    );
+    if (invalidOrgSpecialities.length) {
+      throw new OrganisationRoomServiceError(
+        `Speciality must belong to the organisation: ${invalidOrgSpecialities
+          .map((row) => row.id)
+          .join(", ")}`,
+        400,
+      );
+    }
+
+    await prisma.organisationRoomSpeciality.createMany({
+      data: specialityRows.map((row) => ({
+        organisationId: orgId,
+        roomId,
+        specialityId: row.id,
+      })),
+    });
+
+    resolvedSpecialities = resolveSpecialityMappings(
+      specialityRows.map((row) => ({ roomId, specialityId: row.id })),
+      specialityRows.map((row) => ({ id: row.id, name: row.name })),
+    );
+  }
+
+  const staffIds = params.staff.map((entry) => entry.id);
+  let resolvedStaff: RoomReferenceMapping[] = [];
+  if (staffIds.length) {
+    const users = await prisma.user.findMany({
+      where: { userId: { in: staffIds } },
+      select: { userId: true, firstName: true, lastName: true },
+    });
+
+    const userById = new Map(users.map((user) => [user.userId, user]));
+    const invalidStaff = staffIds.filter((id) => !userById.has(id));
+    if (invalidStaff.length) {
+      throw new OrganisationRoomServiceError(
+        `Invalid staff reference(s): ${invalidStaff.join(", ")}`,
+        400,
+      );
+    }
+
+    const orgMemberships = await prisma.userOrganization.findMany({
+      where: {
+        organizationReference: {
+          in: [orgId, `Organization/${orgId}`],
+        },
+        practitionerReference: {
+          in: staffIds.flatMap((id) => [
+            id,
+            `Practitioner/${id}`,
+            `User/${id}`,
+          ]),
+        },
+        active: true,
+      },
+      select: { practitionerReference: true },
+    });
+
+    const activeStaffIds = new Set(
+      orgMemberships
+        .map((membership) => membership.practitionerReference)
+        .map((reference) => reference.split("/").pop() ?? reference),
+    );
+
+    const invalidMemberships = staffIds.filter((id) => !activeStaffIds.has(id));
+    if (invalidMemberships.length) {
+      throw new OrganisationRoomServiceError(
+        `Staff must belong to the organisation: ${invalidMemberships.join(", ")}`,
+        400,
+      );
+    }
+
+    await prisma.organisationRoomStaff.createMany({
+      data: users.map((user) => ({
+        organisationId: orgId,
+        roomId,
+        staffUserId: user.userId,
+      })),
+    });
+
+    resolvedStaff = resolveStaffMappings(
+      users.map((user) => ({ roomId, staffUserId: user.userId })),
+      users,
+    );
+  }
 
   return {
-    id: obj._id.toString(),
-    fhirId: obj.fhirId ?? undefined,
-    organisationId: obj.organisationId,
-    name: obj.name,
-    type: obj.type as RoomType,
-    assignedSpecialiteis: obj.assignedSpecialiteis ?? [],
-    assignedStaffs: obj.assignedStaffs ?? [],
-    createdAt: obj.createdAt ?? undefined,
-    updatedAt: obj.updatedAt ?? undefined,
+    specialities: resolvedSpecialities,
+    staff: resolvedStaff,
   };
 };
 
-const syncOrganisationRoomToPostgres = async (
-  doc: OrganisationRoomDocument,
-) => {
-  if (!shouldDualWrite) return;
-  try {
-    const data = toPrismaOrganisationRoomData(doc);
-    await prisma.organisationRoom.upsert({
-      where: { id: data.id },
-      create: data,
-      update: data,
+const loadRoomReferenceMaps = async (organisationId: string) => {
+  const [specialityLinks, staffLinks] = await Promise.all([
+    prisma.organisationRoomSpeciality.findMany({
+      where: { organisationId },
+      orderBy: [{ roomId: "asc" }, { specialityId: "asc" }],
+    }),
+    prisma.organisationRoomStaff.findMany({
+      where: { organisationId },
+      orderBy: [{ roomId: "asc" }, { staffUserId: "asc" }],
+    }),
+  ]);
+
+  const specialityIds = [
+    ...new Set(specialityLinks.map((link) => link.specialityId)),
+  ];
+  const staffIds = [...new Set(staffLinks.map((link) => link.staffUserId))];
+
+  const [specialities, users] = await Promise.all([
+    specialityIds.length
+      ? prisma.speciality.findMany({
+          where: { id: { in: specialityIds } },
+          select: { id: true, name: true },
+        })
+      : Promise.resolve([] as Array<{ id: string; name: string }>),
+    staffIds.length
+      ? prisma.user.findMany({
+          where: { userId: { in: staffIds } },
+          select: { userId: true, firstName: true, lastName: true },
+        })
+      : Promise.resolve([] as UserRow[]),
+  ]);
+
+  const specialitiesByRoom = new Map<string, RoomReferenceMapping[]>();
+  const staffByRoom = new Map<string, RoomReferenceMapping[]>();
+
+  const specialityById = new Map(specialities.map((row) => [row.id, row]));
+  for (const link of specialityLinks) {
+    const roomMappings = specialitiesByRoom.get(link.roomId) ?? [];
+    const speciality = specialityById.get(link.specialityId);
+    roomMappings.push({
+      id: link.specialityId,
+      name: speciality?.name ?? link.specialityId,
     });
-  } catch (err) {
-    handleDualWriteError("OrganisationRoom", err);
+    specialitiesByRoom.set(link.roomId, roomMappings);
   }
+
+  const userById = new Map(users.map((row) => [row.userId, row]));
+  for (const link of staffLinks) {
+    const roomMappings = staffByRoom.get(link.roomId) ?? [];
+    const user = userById.get(link.staffUserId);
+    roomMappings.push({
+      id: link.staffUserId,
+      name: user ? displayNameFromUser(user) : link.staffUserId,
+    });
+    staffByRoom.set(link.roomId, roomMappings);
+  }
+
+  return {
+    specialitiesByRoom,
+    staffByRoom,
+  };
+};
+
+const buildSummary = (
+  room: RoomRow,
+  roomUnits: RoomUnitRow[],
+  roomGroups: RoomUnitGroupRow[],
+  occupiedUnitIds: Set<string>,
+  specialities: RoomReferenceMapping[] = [],
+  staff: RoomReferenceMapping[] = [],
+): OrganisationRoomSummaryItem => {
+  const totalUnits = roomGroups.length
+    ? roomGroups.reduce(
+        (total, group) => total + Math.max(group.unitCount, 0),
+        0,
+      )
+    : roomUnits.length;
+
+  const occupiedUnits = roomUnits.filter((unit) =>
+    occupiedUnitIds.has(unit.id),
+  ).length;
+  const vacantUnits = Math.max(totalUnits - occupiedUnits, 0);
+  const occupancyDisplay =
+    totalUnits > 0
+      ? vacantUnits === 0
+        ? "Occupied"
+        : `Vacant (${vacantUnits})`
+      : room.occupancyStatus;
+
+  return {
+    ...toRecord(room, specialities, staff),
+    totalUnits,
+    occupiedUnits,
+    vacantUnits,
+    occupancyDisplay,
+    unitGroups: roomGroups.map((group) => {
+      const occupiedCount = roomUnits.filter(
+        (unit) =>
+          unit.unitGroupId === group.id &&
+          unit.isActive &&
+          occupiedUnitIds.has(unit.id),
+      ).length;
+
+      return {
+        id: group.id,
+        name: group.name,
+        size: group.size,
+        unitCount: group.unitCount,
+        occupiedCount,
+        vacantCount: Math.max(group.unitCount - occupiedCount, 0),
+        speciesConstraints: normalizeSummaryStringList(
+          group.speciesConstraints,
+        ),
+        capabilities: group.capabilities ?? [],
+        isActive: group.isActive,
+      };
+    }),
+    units: roomUnits.map((unit) => ({
+      id: unit.id,
+      code: unit.code,
+      displayName: unit.displayName,
+      size: unit.size,
+      speciesConstraints: normalizeSummaryStringList(unit.speciesConstraints),
+      isActive: unit.isActive,
+      isOccupied: occupiedUnitIds.has(unit.id),
+    })),
+  };
 };
 
 export const OrganisationRoomService = {
-  async create(payload: OrganisationRoomFHIRPayload) {
-    const { persistable, attributes } = createPersistableFromFHIR(payload);
+  async create(
+    input: Partial<OrganisationRoomInput>,
+  ): Promise<OrganisationRoomRecord> {
+    const roomInput = buildRoomInput(input);
+    await assertRoomCodeIsUnique(
+      roomInput.room.organisationId,
+      roomInput.room.code,
+    );
 
-    const identifier =
-      ensureSafeIdentifier(attributes.id) ?? ensureSafeIdentifier(payload.id);
+    const created = await getOrganisationRoomDelegate().create({
+      data: roomInput.room,
+    });
 
-    let document: OrganisationRoomDocument | null = null;
-    let created = false;
+    const resolvedLinks = await syncRoomReferenceLinks({
+      roomId: created.id,
+      organisationId: created.organisationId,
+      specialities: roomInput.assignedSpecialiteis,
+      staff: roomInput.assignedStaffs,
+    });
 
-    if (identifier) {
-      document = await OrganisationRoomModel.findOneAndUpdate(
-        { fhirId: identifier },
-        { $set: persistable },
-        { new: true, sanitizeFilter: true },
+    return toRecord(created, resolvedLinks.specialities, resolvedLinks.staff);
+  },
+
+  async update(
+    id: string,
+    input: Partial<OrganisationRoomInput>,
+  ): Promise<OrganisationRoomRecord> {
+    const roomId = requireNonEmptyString(id, "id");
+    const existing = await getOrganisationRoomDelegate().findUnique({
+      where: { id: roomId },
+    });
+
+    if (!existing) {
+      throw new OrganisationRoomServiceError(
+        "Organisation room not found.",
+        404,
       );
     }
 
-    if (!document) {
-      document = await OrganisationRoomModel.create(persistable);
-      created = true;
+    const currentLinks = await loadRoomReferenceMaps(existing.organisationId);
+    const next = buildRoomInput({
+      organisationId: existing.organisationId,
+      name: input.name ?? existing.name,
+      code: input.code ?? existing.code,
+      description:
+        input.description === undefined
+          ? existing.description
+          : input.description,
+      type: input.type ?? existing.type,
+      occupancyStatus:
+        input.occupancyStatus === undefined
+          ? existing.occupancyStatus
+          : input.occupancyStatus,
+      assignedSpecialiteis:
+        input.assignedSpecialiteis === undefined
+          ? (currentLinks.specialitiesByRoom.get(existing.id) ?? [])
+          : input.assignedSpecialiteis,
+      assignedStaffs:
+        input.assignedStaffs === undefined
+          ? (currentLinks.staffByRoom.get(existing.id) ?? [])
+          : input.assignedStaffs,
+      availableNow:
+        input.availableNow === undefined
+          ? existing.availableNow
+          : input.availableNow,
+      availabilityMode:
+        input.availabilityMode === undefined
+          ? existing.availabilityMode
+          : input.availabilityMode,
+      availabilityDays:
+        input.availabilityDays === undefined
+          ? existing.availabilityDays
+          : input.availabilityDays,
+      availabilityStartTime:
+        input.availabilityStartTime === undefined
+          ? existing.availabilityStartTime
+          : input.availabilityStartTime,
+      availabilityEndTime:
+        input.availabilityEndTime === undefined
+          ? existing.availabilityEndTime
+          : input.availabilityEndTime,
+      capabilities:
+        input.capabilities === undefined
+          ? existing.capabilities
+          : input.capabilities,
+    });
+
+    if (next.room.code !== existing.code) {
+      await assertRoomCodeIsUnique(
+        existing.organisationId,
+        next.room.code,
+        existing.id,
+      );
     }
 
-    await syncOrganisationRoomToPostgres(document);
+    const updated = await getOrganisationRoomDelegate().update({
+      where: { id: roomId },
+      data: next.room,
+    });
 
-    const response = buildFHIRResponse(document);
-    return { response, created };
-  },
+    const resolvedLinks = await syncRoomReferenceLinks({
+      roomId: updated.id,
+      organisationId: updated.organisationId,
+      specialities: next.assignedSpecialiteis,
+      staff: next.assignedStaffs,
+    });
 
-  async update(id: string, payload: OrganisationRoomFHIRPayload) {
-    const query = resolveIdQuery(id);
-    const { persistable } = createPersistableFromFHIR(payload);
-
-    const document = await OrganisationRoomModel.findOneAndUpdate(
-      query,
-      { $set: persistable },
-      { new: true, sanitizeFilter: true },
-    );
-
-    if (!document) {
-      return null;
-    }
-
-    await syncOrganisationRoomToPostgres(document);
-
-    return buildFHIRResponse(document);
+    return toRecord(updated, resolvedLinks.specialities, resolvedLinks.staff);
   },
 
   async getAllByOrganizationId(organisationId: string) {
-    const orgId = requireOrganizationId(organisationId);
-
-    if (isReadFromPostgres()) {
-      const rooms = await prisma.organisationRoom.findMany({
-        where: { organisationId: orgId },
-      });
-      return rooms.map((room) => buildFHIRResponseFromPrisma(room));
-    }
-
-    const documents = await OrganisationRoomModel.find({
-      organisationId: orgId,
-    }).exec();
-
-    return documents.map(buildFHIRResponse);
+    return this.getSummaryByOrganizationId(organisationId);
   },
 
-  async deleteAllByOrganizationId(organisationId: string) {
-    const orgId = requireOrganizationId(organisationId);
+  async getSummaryByOrganizationId(
+    organisationId: string,
+  ): Promise<OrganisationRoomSummaryItem[]> {
+    const orgId = requireNonEmptyString(organisationId, "organisationId");
+    const referenceMaps = await loadRoomReferenceMaps(orgId);
 
-    const result = await OrganisationRoomModel.deleteMany({
-      organisationId: orgId,
-    }).exec();
-    if (result.acknowledged !== true) {
+    const [rooms, units, groups, admissions] = (await Promise.all([
+      getOrganisationRoomDelegate().findMany({
+        where: { organisationId: orgId },
+        orderBy: [{ name: "asc" }],
+      }),
+      (
+        prisma as unknown as {
+          roomUnit: { findMany: typeof prisma.roomUnit.findMany };
+        }
+      ).roomUnit.findMany({
+        where: { organisationId: orgId },
+        orderBy: [{ roomId: "asc" }, { displayName: "asc" }],
+      }),
+      (
+        prisma as unknown as {
+          roomUnitGroup: { findMany: typeof prisma.roomUnitGroup.findMany };
+        }
+      ).roomUnitGroup.findMany({
+        where: { organisationId: orgId },
+        orderBy: [{ roomId: "asc" }, { name: "asc" }],
+      }),
+      (
+        prisma as unknown as {
+          admission: { findMany: typeof prisma.admission.findMany };
+        }
+      ).admission.findMany({
+        where: {
+          organisationId: orgId,
+          dischargedAt: null,
+          unitId: { not: null },
+        },
+        select: { unitId: true },
+      }),
+    ])) as [RoomRow[], RoomUnitRow[], RoomUnitGroupRow[], AdmissionRow[]];
+
+    const occupiedUnitIds = new Set(
+      admissions
+        .map((admission) => admission.unitId)
+        .filter((unitId): unitId is string => Boolean(unitId)),
+    );
+
+    const unitsByRoomId = groupRowsByRoom(units);
+    const groupsByRoomId = groupRowsByRoom(groups);
+
+    return rooms.map((room) =>
+      buildSummary(
+        room,
+        unitsByRoomId.get(room.id) ?? [],
+        groupsByRoomId.get(room.id) ?? [],
+        occupiedUnitIds,
+        referenceMaps.specialitiesByRoom.get(room.id) ?? [],
+        referenceMaps.staffByRoom.get(room.id) ?? [],
+      ),
+    );
+  },
+
+  async getById(
+    id: string,
+    organisationId: string,
+  ): Promise<OrganisationRoomDetail> {
+    const roomId = requireNonEmptyString(id, "id");
+    const orgId = requireNonEmptyString(organisationId, "organisationId");
+    const referenceMaps = await loadRoomReferenceMaps(orgId);
+    const [room, summary] = await Promise.all([
+      getOrganisationRoomDelegate().findUnique({
+        where: { id: roomId },
+      }),
+      this.getSummaryByOrganizationId(orgId),
+    ]);
+
+    if (!room) {
       throw new OrganisationRoomServiceError(
-        "Failed to delete organisation rooms.",
-        500,
+        "Organisation room not found.",
+        404,
       );
     }
 
-    if (shouldDualWrite) {
-      try {
-        await prisma.organisationRoom.deleteMany({
-          where: { organisationId: orgId },
-        });
-      } catch (err) {
-        handleDualWriteError("OrganisationRoom deleteAllByOrganizationId", err);
-      }
+    if (room.organisationId !== orgId) {
+      throw new OrganisationRoomServiceError(
+        "Organisation room does not belong to the requested organisation.",
+        403,
+      );
     }
+
+    const detail = summary.find((item) => item.id === roomId);
+
+    if (!detail) {
+      return {
+        ...buildSummary(
+          room,
+          [],
+          [],
+          new Set(),
+          referenceMaps.specialitiesByRoom.get(roomId) ?? [],
+          referenceMaps.staffByRoom.get(roomId) ?? [],
+        ),
+        occupancySource: "ROOM",
+      };
+    }
+
+    return {
+      ...detail,
+      occupancySource: detail.totalUnits > 0 ? "UNITS" : "ROOM",
+    };
   },
 
-  async delete(id: string, organisationId: string) {
-    const query = {
-      ...resolveIdQuery(id),
-      organisationId: requireOrganizationId(organisationId),
-    };
+  async toggleAvailability(
+    id: string,
+    organisationId: string,
+  ): Promise<OrganisationRoomRecord> {
+    const roomId = requireNonEmptyString(id, "id");
+    const orgId = requireNonEmptyString(organisationId, "organisationId");
+    await assertOrganisationRoomExists(roomId, orgId);
 
-    const document = await OrganisationRoomModel.findOneAndDelete(query, {
-      sanitizeFilter: true,
+    const room = await getOrganisationRoomDelegate().findUnique({
+      where: { id: roomId },
     });
 
-    if (!document) {
-      return null;
+    if (!room) {
+      throw new OrganisationRoomServiceError(
+        "Organisation room not found.",
+        404,
+      );
     }
 
-    if (shouldDualWrite) {
-      try {
-        await prisma.organisationRoom.deleteMany({
-          where: { id: document._id.toString() },
-        });
-      } catch (err) {
-        handleDualWriteError("OrganisationRoom delete", err);
-      }
+    const updated = await getOrganisationRoomDelegate().update({
+      where: { id: roomId },
+      data: {
+        availableNow: !room.availableNow,
+      },
+    });
+
+    const referenceMaps = await loadRoomReferenceMaps(orgId);
+    return toRecord(
+      updated,
+      referenceMaps.specialitiesByRoom.get(roomId) ?? [],
+      referenceMaps.staffByRoom.get(roomId) ?? [],
+    );
+  },
+
+  async delete(
+    id: string,
+    organisationId: string,
+  ): Promise<OrganisationRoomRecord> {
+    const roomId = requireNonEmptyString(id, "id");
+    const orgId = requireNonEmptyString(organisationId, "organisationId");
+    const room = await getOrganisationRoomDelegate().findUnique({
+      where: { id: roomId },
+    });
+
+    if (!room) {
+      throw new OrganisationRoomServiceError(
+        "Organisation room not found.",
+        404,
+      );
     }
 
-    return buildFHIRResponse(document);
+    if (room.organisationId !== orgId) {
+      throw new OrganisationRoomServiceError(
+        "Organisation room does not belong to the requested organisation.",
+        403,
+      );
+    }
+
+    const deleted = await getOrganisationRoomDelegate().delete({
+      where: { id: roomId },
+    });
+
+    return toRecord(deleted, [], []);
+  },
+
+  async deleteAllByOrganizationId(organisationId: string) {
+    const orgId = requireNonEmptyString(organisationId, "organisationId");
+    await getOrganisationRoomDelegate().deleteMany({
+      where: { organisationId: orgId },
+    });
   },
 };

--- a/apps/backend/src/services/room-management.helpers.ts
+++ b/apps/backend/src/services/room-management.helpers.ts
@@ -1,0 +1,234 @@
+import { RoomOccupancyStatus, RoomType } from "@yosemite-crew/database";
+import type { RoomReferenceMapping } from "@yosemite-crew/types";
+
+const normalizeToken = (value: string) =>
+  value
+    .trim()
+    .toUpperCase()
+    .replace(/[\s-]+/g, "_")
+    .replace(/__+/g, "_");
+
+export class RoomValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RoomValidationError";
+  }
+}
+
+const normalizeReferenceMapping = (
+  value: unknown,
+  fieldName: string,
+  index: number,
+): RoomReferenceMapping => {
+  if (!value || typeof value !== "object") {
+    throw new RoomValidationError(
+      `${fieldName} at index ${index} must be an object.`,
+    );
+  }
+
+  const record = value as Record<string, unknown>;
+  const id = typeof record.id === "string" ? record.id.trim() : "";
+  const name = typeof record.name === "string" ? record.name.trim() : "";
+
+  if (!id) {
+    throw new RoomValidationError(
+      `${fieldName} at index ${index} must have an id.`,
+    );
+  }
+
+  if (!name) {
+    throw new RoomValidationError(
+      `${fieldName} at index ${index} must have a name.`,
+    );
+  }
+
+  return { id, name };
+};
+
+const ROOM_TYPE_ALIASES: Record<string, RoomType> = {
+  EXAM: "EXAM_ROOM",
+  EXAM_ROOM: "EXAM_ROOM",
+  EXAMROOM: "EXAM_ROOM",
+  TREATMENT: "TREATMENT",
+  SURGERY: "SURGERY",
+  DENTAL: "DENTAL",
+  IMAGING: "IMAGING",
+  WAITING: "WAITING",
+  WAITING_AREA: "WAITING",
+  WAITINGAREA: "WAITING",
+  GROOMING: "GROOMING",
+  ICU: "ICU",
+  INPATIENT: "INPATIENT",
+  ISOLATION: "ISOLATION",
+  BOARDING: "BOARDING",
+  RECEPTION: "RECEPTION",
+  CONSULTATION: "CONSULTATION",
+};
+
+export const ROOM_TYPES = new Set<RoomType>([
+  "EXAM_ROOM",
+  "TREATMENT",
+  "SURGERY",
+  "DENTAL",
+  "IMAGING",
+  "WAITING",
+  "GROOMING",
+  "ICU",
+  "INPATIENT",
+  "ISOLATION",
+  "BOARDING",
+  "RECEPTION",
+  "CONSULTATION",
+]);
+
+export const UNIT_SUPPORTED_ROOM_TYPES = new Set<RoomType>([
+  "ICU",
+  "INPATIENT",
+  "ISOLATION",
+  "BOARDING",
+]);
+
+export const ROOM_OCCUPANCY_STATUSES = new Set<RoomOccupancyStatus>([
+  "VACANT",
+  "OCCUPIED",
+]);
+
+export const requireNonEmptyString = (value: unknown, fieldName: string) => {
+  if (typeof value !== "string") {
+    throw new RoomValidationError(`${fieldName} is required.`);
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new RoomValidationError(`${fieldName} is required.`);
+  }
+
+  if (trimmed.includes("$")) {
+    throw new RoomValidationError(`Invalid character in ${fieldName}.`);
+  }
+
+  return trimmed;
+};
+
+export const optionalNonEmptyString = (value: unknown) => {
+  if (value == null) {
+    return undefined;
+  }
+
+  if (typeof value !== "string") {
+    throw new RoomValidationError("Invalid string value.");
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+export const normalizeStringList = (value: unknown): string[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return [
+    ...new Set(
+      value
+        .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+        .filter((entry) => entry.length > 0),
+    ),
+  ];
+};
+
+export const normalizeStrictStringList = (
+  value: unknown,
+  fieldName: string,
+): string[] => {
+  if (value == null) {
+    return [];
+  }
+
+  if (!Array.isArray(value)) {
+    throw new RoomValidationError(`${fieldName} must be an array.`);
+  }
+
+  const cleaned = value.map((entry, index) => {
+    if (typeof entry !== "string") {
+      throw new RoomValidationError(
+        `${fieldName} at index ${index} must be a string.`,
+      );
+    }
+
+    const trimmed = entry.trim();
+    if (!trimmed) {
+      throw new RoomValidationError(
+        `${fieldName} at index ${index} cannot be empty.`,
+      );
+    }
+
+    return trimmed;
+  });
+
+  return [...new Set(cleaned)];
+};
+
+export const normalizeReferenceMappings = (
+  value: unknown,
+  fieldName: string,
+): RoomReferenceMapping[] => {
+  if (value == null) {
+    return [];
+  }
+
+  if (!Array.isArray(value)) {
+    throw new RoomValidationError(`${fieldName} must be an array.`);
+  }
+
+  const cleaned = value.map((entry, index) =>
+    normalizeReferenceMapping(entry, fieldName, index),
+  );
+
+  const deduped = new Map<string, RoomReferenceMapping>();
+  for (const entry of cleaned) {
+    deduped.set(entry.id, entry);
+  }
+
+  return [...deduped.values()];
+};
+
+export const normalizeRoomType = (value: unknown): RoomType => {
+  if (typeof value !== "string") {
+    throw new RoomValidationError("Room type is required.");
+  }
+
+  const normalized = normalizeToken(value);
+  const roomType = ROOM_TYPE_ALIASES[normalized];
+
+  if (!roomType || !ROOM_TYPES.has(roomType)) {
+    throw new RoomValidationError(
+      `Room type must be one of: ${Array.from(ROOM_TYPES).join(", ")}.`,
+    );
+  }
+
+  return roomType;
+};
+
+export const normalizeRoomOccupancyStatus = (
+  value: unknown,
+): RoomOccupancyStatus => {
+  if (typeof value !== "string") {
+    throw new RoomValidationError("Occupancy status is required.");
+  }
+
+  const normalized = normalizeToken(value);
+
+  if (!ROOM_OCCUPANCY_STATUSES.has(normalized as RoomOccupancyStatus)) {
+    throw new RoomValidationError(
+      `Occupancy status must be one of: ${Array.from(
+        ROOM_OCCUPANCY_STATUSES,
+      ).join(", ")}.`,
+    );
+  }
+
+  return normalized as RoomOccupancyStatus;
+};
+
+export const roomTypeSupportsUnits = (value: RoomType) =>
+  UNIT_SUPPORTED_ROOM_TYPES.has(value);

--- a/apps/backend/src/services/room-unit-group.service.ts
+++ b/apps/backend/src/services/room-unit-group.service.ts
@@ -1,0 +1,300 @@
+import { type RoomType } from "@yosemite-crew/database";
+import { prisma } from "src/config/prisma";
+import type { RoomUnitGroup } from "@yosemite-crew/types";
+import {
+  normalizeStrictStringList,
+  optionalNonEmptyString,
+  requireNonEmptyString,
+  roomTypeSupportsUnits,
+  RoomValidationError,
+} from "./room-management.helpers";
+
+type RoomRow = {
+  id: string;
+  organisationId: string;
+  type: RoomType;
+};
+
+type RoomUnitGroupRow = {
+  id: string;
+  organisationId: string;
+  roomId: string;
+  name: string;
+  size: string | null;
+  unitCount: number;
+  speciesConstraints: unknown;
+  capabilities: string[];
+  isActive: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type RoomUnitGroupDelegate = {
+  create(args: {
+    data: {
+      organisationId: string;
+      roomId: string;
+      name: string;
+      size?: string | null;
+      unitCount: number;
+      speciesConstraints?: unknown;
+      capabilities?: string[];
+      isActive: boolean;
+    };
+  }): Promise<RoomUnitGroupRow>;
+  findUnique(args: { where: { id: string } }): Promise<RoomUnitGroupRow | null>;
+  findMany(args: {
+    where: {
+      organisationId?: string;
+      roomId?: string;
+      isActive?: boolean;
+    };
+    orderBy: [{ roomId: "asc" }, { name: "asc" }];
+  }): Promise<RoomUnitGroupRow[]>;
+  update(args: {
+    where: { id: string };
+    data: {
+      roomId?: string;
+      name?: string;
+      size?: string | null;
+      unitCount?: number;
+      speciesConstraints?: unknown;
+      capabilities?: string[];
+      isActive?: boolean;
+    };
+  }): Promise<RoomUnitGroupRow>;
+  delete(args: { where: { id: string } }): Promise<RoomUnitGroupRow>;
+};
+
+export class RoomUnitGroupServiceError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode: number,
+  ) {
+    super(message);
+    this.name = "RoomUnitGroupServiceError";
+  }
+}
+
+const requireString = (value: string | undefined, field: string) => {
+  try {
+    return requireNonEmptyString(value, field);
+  } catch (error) {
+    if (error instanceof RoomValidationError) {
+      throw new RoomUnitGroupServiceError(error.message, 400);
+    }
+
+    throw error;
+  }
+};
+
+const normalizeOptionalString = (value?: string | null) => {
+  try {
+    return optionalNonEmptyString(value);
+  } catch (error) {
+    if (error instanceof RoomValidationError) {
+      throw new RoomUnitGroupServiceError(error.message, 400);
+    }
+
+    throw error;
+  }
+};
+
+const toDomain = (row: RoomUnitGroupRow): RoomUnitGroup => ({
+  id: row.id,
+  organisationId: row.organisationId,
+  roomId: row.roomId,
+  name: row.name,
+  size: row.size ?? undefined,
+  unitCount: row.unitCount,
+  speciesConstraints: Array.isArray(row.speciesConstraints)
+    ? row.speciesConstraints.filter(
+        (value): value is string =>
+          typeof value === "string" && value.trim().length > 0,
+      )
+    : undefined,
+  capabilities: row.capabilities ?? [],
+  isActive: row.isActive,
+});
+
+const getRoomUnitGroupDelegate = (): RoomUnitGroupDelegate =>
+  (prisma as unknown as { roomUnitGroup: RoomUnitGroupDelegate }).roomUnitGroup;
+
+const assertRoomExists = async (roomId: string, organisationId: string) => {
+  const room = (await prisma.organisationRoom.findUnique({
+    where: { id: roomId },
+    select: { id: true, organisationId: true, type: true },
+  })) as RoomRow | null;
+
+  if (!room) {
+    throw new RoomUnitGroupServiceError("Organisation room not found.", 404);
+  }
+
+  if (room.organisationId !== organisationId) {
+    throw new RoomUnitGroupServiceError("Room organisation mismatch.", 409);
+  }
+
+  if (!roomTypeSupportsUnits(room.type)) {
+    throw new RoomUnitGroupServiceError(
+      "Units are only supported for ICU, Inpatient, Isolation and Boarding rooms.",
+      409,
+    );
+  }
+};
+
+export const RoomUnitGroupService = {
+  async create(input: RoomUnitGroup): Promise<RoomUnitGroup> {
+    try {
+      const organisationId = requireString(
+        input.organisationId,
+        "organisationId",
+      );
+      const roomId = requireString(input.roomId, "roomId");
+      const name = requireString(input.name, "name");
+      const unitCount = Number.isInteger(input.unitCount) ? input.unitCount : 0;
+
+      if (unitCount <= 0) {
+        throw new RoomUnitGroupServiceError(
+          "unitCount must be greater than 0.",
+          400,
+        );
+      }
+
+      await assertRoomExists(roomId, organisationId);
+
+      const created = await getRoomUnitGroupDelegate().create({
+        data: {
+          organisationId,
+          roomId,
+          name,
+          size: optionalNonEmptyString(input.size) ?? null,
+          unitCount,
+          speciesConstraints: normalizeStrictStringList(
+            input.speciesConstraints,
+            "speciesConstraints",
+          ),
+          capabilities: normalizeStrictStringList(
+            input.capabilities,
+            "capabilities",
+          ),
+          isActive: input.isActive ?? true,
+        },
+      });
+
+      return toDomain(created);
+    } catch (error) {
+      if (error instanceof RoomValidationError) {
+        throw new RoomUnitGroupServiceError(error.message, 400);
+      }
+
+      throw error;
+    }
+  },
+
+  async update(
+    id: string,
+    input: Partial<RoomUnitGroup>,
+  ): Promise<RoomUnitGroup> {
+    try {
+      const groupId = requireString(id, "groupId");
+      const current = await getRoomUnitGroupDelegate().findUnique({
+        where: { id: groupId },
+      });
+
+      if (!current) {
+        throw new RoomUnitGroupServiceError("Room unit group not found.", 404);
+      }
+
+      const roomId = optionalNonEmptyString(input.roomId) ?? current.roomId;
+      await assertRoomExists(roomId, current.organisationId);
+
+      const unitCount =
+        input.unitCount == null
+          ? undefined
+          : Number.isInteger(input.unitCount)
+            ? input.unitCount
+            : current.unitCount;
+
+      if (unitCount !== undefined && unitCount <= 0) {
+        throw new RoomUnitGroupServiceError(
+          "unitCount must be greater than 0.",
+          400,
+        );
+      }
+
+      const updated = await getRoomUnitGroupDelegate().update({
+        where: { id: groupId },
+        data: {
+          roomId,
+          name:
+            input.name === undefined
+              ? undefined
+              : requireString(input.name, "name"),
+          size:
+            input.size === undefined
+              ? undefined
+              : (optionalNonEmptyString(input.size) ?? null),
+          unitCount,
+          speciesConstraints:
+            input.speciesConstraints === undefined
+              ? undefined
+              : normalizeStrictStringList(
+                  input.speciesConstraints,
+                  "speciesConstraints",
+                ),
+          capabilities:
+            input.capabilities === undefined
+              ? undefined
+              : normalizeStrictStringList(input.capabilities, "capabilities"),
+          isActive: input.isActive,
+        },
+      });
+
+      return toDomain(updated);
+    } catch (error) {
+      if (error instanceof RoomValidationError) {
+        throw new RoomUnitGroupServiceError(error.message, 400);
+      }
+
+      throw error;
+    }
+  },
+
+  async list(filters: {
+    organisationId?: string;
+    roomId?: string;
+    isActive?: boolean;
+  }): Promise<RoomUnitGroup[]> {
+    const rows = await getRoomUnitGroupDelegate().findMany({
+      where: {
+        organisationId: normalizeOptionalString(filters.organisationId),
+        roomId: normalizeOptionalString(filters.roomId),
+        isActive: filters.isActive,
+      },
+      orderBy: [{ roomId: "asc" }, { name: "asc" }],
+    });
+
+    return rows.map(toDomain);
+  },
+
+  async delete(id: string, organisationId?: string): Promise<RoomUnitGroup> {
+    const groupId = requireString(id, "groupId");
+    const existing = await getRoomUnitGroupDelegate().findUnique({
+      where: { id: groupId },
+    });
+
+    if (!existing) {
+      throw new RoomUnitGroupServiceError("Room unit group not found.", 404);
+    }
+
+    if (organisationId && existing.organisationId !== organisationId) {
+      throw new RoomUnitGroupServiceError("Room organisation mismatch.", 409);
+    }
+
+    const deleted = await getRoomUnitGroupDelegate().delete({
+      where: { id: groupId },
+    });
+
+    return toDomain(deleted);
+  },
+};

--- a/apps/backend/src/services/room-unit.service.ts
+++ b/apps/backend/src/services/room-unit.service.ts
@@ -1,0 +1,209 @@
+import { prisma } from "src/config/prisma";
+import type { RoomUnit } from "@yosemite-crew/types";
+
+type RoomRow = {
+  id: string;
+  organisationId: string;
+};
+
+type RoomUnitRow = {
+  id: string;
+  organisationId: string;
+  roomId: string;
+  code: string;
+  displayName: string;
+  size: string | null;
+  speciesConstraints: unknown;
+  isActive: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type RoomUnitDelegate = {
+  create(args: {
+    data: {
+      organisationId: string;
+      roomId: string;
+      code: string;
+      displayName: string;
+      size: string | null;
+      speciesConstraints: unknown;
+      isActive: boolean;
+    };
+  }): Promise<RoomUnitRow>;
+  findUnique(args: { where: { id: string } }): Promise<RoomUnitRow | null>;
+  findMany(args: {
+    where: {
+      organisationId?: string;
+      roomId?: string;
+      isActive?: boolean;
+    };
+    orderBy: { displayName: "asc" };
+  }): Promise<RoomUnitRow[]>;
+  update(args: {
+    where: { id: string };
+    data: {
+      roomId?: string;
+      code?: string;
+      displayName?: string;
+      size?: string | null;
+      speciesConstraints?: unknown;
+      isActive?: boolean;
+    };
+  }): Promise<RoomUnitRow>;
+  delete(args: { where: { id: string } }): Promise<RoomUnitRow>;
+};
+
+export class RoomUnitServiceError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode: number,
+  ) {
+    super(message);
+    this.name = "RoomUnitServiceError";
+  }
+}
+
+const normalizeOptionalString = (value?: string | null) => {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+const requireString = (value: string | undefined, field: string) => {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    throw new RoomUnitServiceError(`${field} is required.`, 400);
+  }
+
+  return trimmed;
+};
+
+const toDomain = (row: RoomUnitRow): RoomUnit => ({
+  id: row.id,
+  organisationId: row.organisationId,
+  roomId: row.roomId,
+  code: row.code,
+  displayName: row.displayName,
+  size: row.size ?? undefined,
+  speciesConstraints: Array.isArray(row.speciesConstraints)
+    ? row.speciesConstraints.filter(
+        (value): value is string =>
+          typeof value === "string" && value.trim().length > 0,
+      )
+    : undefined,
+  isActive: row.isActive,
+});
+
+const getRoomUnitDelegate = (): RoomUnitDelegate =>
+  (prisma as unknown as { roomUnit: RoomUnitDelegate }).roomUnit;
+
+const assertRoomExists = async (roomId: string, organisationId: string) => {
+  const room = (await prisma.organisationRoom.findUnique({
+    where: { id: roomId },
+    select: { id: true, organisationId: true },
+  })) as RoomRow | null;
+
+  if (!room) {
+    throw new RoomUnitServiceError("Organisation room not found.", 404);
+  }
+
+  if (room.organisationId !== organisationId) {
+    throw new RoomUnitServiceError("Room organisation mismatch.", 409);
+  }
+};
+
+export const RoomUnitService = {
+  async create(input: RoomUnit): Promise<RoomUnit> {
+    const organisationId = requireString(
+      input.organisationId,
+      "organisationId",
+    );
+    const roomId = requireString(input.roomId, "roomId");
+    const code = requireString(input.code, "code");
+    const displayName = requireString(input.displayName, "displayName");
+    await assertRoomExists(roomId, organisationId);
+
+    const created = await getRoomUnitDelegate().create({
+      data: {
+        organisationId,
+        roomId,
+        code,
+        displayName,
+        size: normalizeOptionalString(input.size) ?? null,
+        speciesConstraints: input.speciesConstraints ?? [],
+        isActive: input.isActive ?? true,
+      },
+    });
+
+    return toDomain(created);
+  },
+
+  async update(id: string, input: Partial<RoomUnit>): Promise<RoomUnit> {
+    const unitId = requireString(id, "unitId");
+    const current = await getRoomUnitDelegate().findUnique({
+      where: { id: unitId },
+    });
+
+    if (!current) {
+      throw new RoomUnitServiceError("Room unit not found.", 404);
+    }
+
+    const roomId = normalizeOptionalString(input.roomId) ?? current.roomId;
+    const organisationId = current.organisationId;
+    await assertRoomExists(roomId, organisationId);
+
+    const updated = await getRoomUnitDelegate().update({
+      where: { id: unitId },
+      data: {
+        roomId,
+        code: input.code ? requireString(input.code, "code") : undefined,
+        displayName: input.displayName
+          ? requireString(input.displayName, "displayName")
+          : undefined,
+        size:
+          input.size === undefined
+            ? undefined
+            : (normalizeOptionalString(input.size) ?? null),
+        speciesConstraints: input.speciesConstraints ?? undefined,
+        isActive: input.isActive,
+      },
+    });
+
+    return toDomain(updated);
+  },
+
+  async list(filters: {
+    organisationId?: string;
+    roomId?: string;
+    isActive?: boolean;
+  }): Promise<RoomUnit[]> {
+    const rows = await getRoomUnitDelegate().findMany({
+      where: {
+        organisationId: normalizeOptionalString(filters.organisationId),
+        roomId: normalizeOptionalString(filters.roomId),
+        isActive: filters.isActive,
+      },
+      orderBy: { displayName: "asc" },
+    });
+
+    return rows.map(toDomain);
+  },
+
+  async delete(id: string): Promise<RoomUnit> {
+    const unitId = requireString(id, "unitId");
+    const existing = await getRoomUnitDelegate().findUnique({
+      where: { id: unitId },
+    });
+
+    if (!existing) {
+      throw new RoomUnitServiceError("Room unit not found.", 404);
+    }
+
+    const deleted = await getRoomUnitDelegate().delete({
+      where: { id: unitId },
+    });
+
+    return toDomain(deleted);
+  },
+};

--- a/apps/backend/src/services/room-unit.service.ts
+++ b/apps/backend/src/services/room-unit.service.ts
@@ -1,15 +1,24 @@
+import { type RoomType } from "@yosemite-crew/database";
 import { prisma } from "src/config/prisma";
 import type { RoomUnit } from "@yosemite-crew/types";
+import {
+  optionalNonEmptyString,
+  requireNonEmptyString,
+  roomTypeSupportsUnits,
+  RoomValidationError,
+} from "./room-management.helpers";
 
 type RoomRow = {
   id: string;
   organisationId: string;
+  type: RoomType;
 };
 
 type RoomUnitRow = {
   id: string;
   organisationId: string;
   roomId: string;
+  unitGroupId: string | null;
   code: string;
   displayName: string;
   size: string | null;
@@ -24,6 +33,7 @@ type RoomUnitDelegate = {
     data: {
       organisationId: string;
       roomId: string;
+      unitGroupId?: string | null;
       code: string;
       displayName: string;
       size: string | null;
@@ -36,6 +46,7 @@ type RoomUnitDelegate = {
     where: {
       organisationId?: string;
       roomId?: string;
+      unitGroupId?: string;
       isActive?: boolean;
     };
     orderBy: { displayName: "asc" };
@@ -44,6 +55,7 @@ type RoomUnitDelegate = {
     where: { id: string };
     data: {
       roomId?: string;
+      unitGroupId?: string | null;
       code?: string;
       displayName?: string;
       size?: string | null;
@@ -65,24 +77,34 @@ export class RoomUnitServiceError extends Error {
 }
 
 const normalizeOptionalString = (value?: string | null) => {
-  if (typeof value !== "string") return undefined;
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : undefined;
+  try {
+    return optionalNonEmptyString(value);
+  } catch (error) {
+    if (error instanceof RoomValidationError) {
+      throw new RoomUnitServiceError(error.message, 400);
+    }
+
+    throw error;
+  }
 };
 
 const requireString = (value: string | undefined, field: string) => {
-  const trimmed = value?.trim();
-  if (!trimmed) {
-    throw new RoomUnitServiceError(`${field} is required.`, 400);
-  }
+  try {
+    return requireNonEmptyString(value, field);
+  } catch (error) {
+    if (error instanceof RoomValidationError) {
+      throw new RoomUnitServiceError(error.message, 400);
+    }
 
-  return trimmed;
+    throw error;
+  }
 };
 
 const toDomain = (row: RoomUnitRow): RoomUnit => ({
   id: row.id,
   organisationId: row.organisationId,
   roomId: row.roomId,
+  unitGroupId: row.unitGroupId ?? undefined,
   code: row.code,
   displayName: row.displayName,
   size: row.size ?? undefined,
@@ -101,7 +123,7 @@ const getRoomUnitDelegate = (): RoomUnitDelegate =>
 const assertRoomExists = async (roomId: string, organisationId: string) => {
   const room = (await prisma.organisationRoom.findUnique({
     where: { id: roomId },
-    select: { id: true, organisationId: true },
+    select: { id: true, organisationId: true, type: true },
   })) as RoomRow | null;
 
   if (!room) {
@@ -110,6 +132,39 @@ const assertRoomExists = async (roomId: string, organisationId: string) => {
 
   if (room.organisationId !== organisationId) {
     throw new RoomUnitServiceError("Room organisation mismatch.", 409);
+  }
+
+  if (!roomTypeSupportsUnits(room.type)) {
+    throw new RoomUnitServiceError(
+      "Units are only supported for ICU, Inpatient, Isolation and Boarding rooms.",
+      409,
+    );
+  }
+};
+
+const assertRoomUnitGroupExists = async (
+  unitGroupId: string,
+  roomId: string,
+  organisationId: string,
+) => {
+  const group = (await prisma.roomUnitGroup.findUnique({
+    where: { id: unitGroupId },
+    select: { id: true, roomId: true, organisationId: true },
+  })) as { id: string; roomId: string; organisationId: string } | null;
+
+  if (!group) {
+    throw new RoomUnitServiceError("Room unit group not found.", 404);
+  }
+
+  if (group.organisationId !== organisationId) {
+    throw new RoomUnitServiceError(
+      "Room unit group organisation mismatch.",
+      409,
+    );
+  }
+
+  if (group.roomId !== roomId) {
+    throw new RoomUnitServiceError("Room unit group room mismatch.", 409);
   }
 };
 
@@ -123,11 +178,19 @@ export const RoomUnitService = {
     const code = requireString(input.code, "code");
     const displayName = requireString(input.displayName, "displayName");
     await assertRoomExists(roomId, organisationId);
+    if (input.unitGroupId) {
+      await assertRoomUnitGroupExists(
+        input.unitGroupId,
+        roomId,
+        organisationId,
+      );
+    }
 
     const created = await getRoomUnitDelegate().create({
       data: {
         organisationId,
         roomId,
+        unitGroupId: normalizeOptionalString(input.unitGroupId) ?? null,
         code,
         displayName,
         size: normalizeOptionalString(input.size) ?? null,
@@ -150,17 +213,29 @@ export const RoomUnitService = {
     }
 
     const roomId = normalizeOptionalString(input.roomId) ?? current.roomId;
+    const unitGroupId =
+      input.unitGroupId === undefined
+        ? (current.unitGroupId ?? undefined)
+        : (normalizeOptionalString(input.unitGroupId) ?? undefined);
     const organisationId = current.organisationId;
     await assertRoomExists(roomId, organisationId);
+    if (unitGroupId) {
+      await assertRoomUnitGroupExists(unitGroupId, roomId, organisationId);
+    }
 
     const updated = await getRoomUnitDelegate().update({
       where: { id: unitId },
       data: {
         roomId,
-        code: input.code ? requireString(input.code, "code") : undefined,
-        displayName: input.displayName
-          ? requireString(input.displayName, "displayName")
-          : undefined,
+        unitGroupId: unitGroupId ?? null,
+        code:
+          input.code === undefined
+            ? undefined
+            : requireString(input.code, "code"),
+        displayName:
+          input.displayName === undefined
+            ? undefined
+            : requireString(input.displayName, "displayName"),
         size:
           input.size === undefined
             ? undefined
@@ -176,12 +251,14 @@ export const RoomUnitService = {
   async list(filters: {
     organisationId?: string;
     roomId?: string;
+    unitGroupId?: string;
     isActive?: boolean;
   }): Promise<RoomUnit[]> {
     const rows = await getRoomUnitDelegate().findMany({
       where: {
         organisationId: normalizeOptionalString(filters.organisationId),
         roomId: normalizeOptionalString(filters.roomId),
+        unitGroupId: normalizeOptionalString(filters.unitGroupId),
         isActive: filters.isActive,
       },
       orderBy: { displayName: "asc" },
@@ -190,7 +267,7 @@ export const RoomUnitService = {
     return rows.map(toDomain);
   },
 
-  async delete(id: string): Promise<RoomUnit> {
+  async delete(id: string, organisationId?: string): Promise<RoomUnit> {
     const unitId = requireString(id, "unitId");
     const existing = await getRoomUnitDelegate().findUnique({
       where: { id: unitId },
@@ -198,6 +275,10 @@ export const RoomUnitService = {
 
     if (!existing) {
       throw new RoomUnitServiceError("Room unit not found.", 404);
+    }
+
+    if (organisationId && existing.organisationId !== organisationId) {
+      throw new RoomUnitServiceError("Unit organisation mismatch.", 409);
     }
 
     const deleted = await getRoomUnitDelegate().delete({

--- a/apps/backend/src/services/speciality.service.ts
+++ b/apps/backend/src/services/speciality.service.ts
@@ -11,7 +11,6 @@ import {
   type SpecialityResponseDTO,
 } from "@yosemite-crew/types";
 import { ServiceService } from "./service.service";
-import OrganisationRoomModel from "src/models/organisation-room";
 import UserModel from "src/models/user";
 import OrganizationModel from "src/models/organization";
 import { sendEmailTemplate } from "src/utils/email";
@@ -623,12 +622,6 @@ export const SpecialityService = {
 
     await ServiceService.deleteAllBySpecialityId(document._id.toString());
 
-    await OrganisationRoomModel.updateMany(
-      { assignedSpecialiteis: query._id ?? query.fhirId },
-      { $pull: { assignedSpecialiteis: specialityId } },
-      { sanitizeFilter: true },
-    );
-
     if (shouldDualWrite) {
       try {
         await prisma.speciality.deleteMany({
@@ -637,25 +630,13 @@ export const SpecialityService = {
       } catch (err) {
         handleDualWriteError("Speciality delete", err);
       }
-
-      try {
-        const rooms = await prisma.organisationRoom.findMany({
-          where: {
-            assignedSpecialiteis: { has: specialityId },
-          },
-        });
-        for (const room of rooms) {
-          const next = (room.assignedSpecialiteis ?? []).filter(
-            (id) => id !== specialityId,
-          );
-          await prisma.organisationRoom.update({
-            where: { id: room.id },
-            data: { assignedSpecialiteis: next },
-          });
-        }
-      } catch (err) {
-        handleDualWriteError("OrganisationRoom updateSpeciality", err);
-      }
     }
+
+    await prisma.organisationRoomSpeciality.deleteMany({
+      where: {
+        organisationId: orgId,
+        specialityId,
+      },
+    });
   },
 };

--- a/apps/backend/test/auth/supertokens.config.test.ts
+++ b/apps/backend/test/auth/supertokens.config.test.ts
@@ -1,0 +1,56 @@
+const ORIGINAL_ENV = {
+  AUTH_API_DOMAIN: process.env.AUTH_API_DOMAIN,
+  AUTH_WEBSITE_DOMAIN: process.env.AUTH_WEBSITE_DOMAIN,
+  SUPERTOKENS_CONNECTION_URI: process.env.SUPERTOKENS_CONNECTION_URI,
+  SMTP_HOST: process.env.SMTP_HOST,
+  SMTP_PORT: process.env.SMTP_PORT,
+  SMTP_SECURE: process.env.SMTP_SECURE,
+  SMTP_USER: process.env.SMTP_USER,
+  SMTP_PASSWORD: process.env.SMTP_PASSWORD,
+  SMTP_FROM_NAME: process.env.SMTP_FROM_NAME,
+  SMTP_FROM_EMAIL: process.env.SMTP_FROM_EMAIL,
+};
+
+const restoreEnv = () => {
+  for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+};
+
+describe("@yosemite-crew/auth supertokens config", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    process.env.AUTH_API_DOMAIN = "https://api.example.com";
+    process.env.AUTH_WEBSITE_DOMAIN = "https://app.example.com";
+    process.env.SUPERTOKENS_CONNECTION_URI = "http://localhost:3567";
+    delete process.env.SMTP_HOST;
+    delete process.env.SMTP_PORT;
+    delete process.env.SMTP_SECURE;
+    delete process.env.SMTP_USER;
+    delete process.env.SMTP_PASSWORD;
+    delete process.env.SMTP_FROM_NAME;
+    delete process.env.SMTP_FROM_EMAIL;
+  });
+
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  it("can be imported without SMTP env vars present", () => {
+    expect(() => {
+      require("@yosemite-crew/auth");
+    }).not.toThrow();
+  });
+
+  it("throws when SMTP env vars are missing at config build time", () => {
+    const { getSuperTokensConfig } = require("@yosemite-crew/auth");
+
+    expect(() => getSuperTokensConfig()).toThrow(
+      "[auth] Missing required environment variable: SMTP_HOST",
+    );
+  });
+});

--- a/apps/backend/test/controllers/web/appointment.prisma.controller.test.ts
+++ b/apps/backend/test/controllers/web/appointment.prisma.controller.test.ts
@@ -139,4 +139,165 @@ describe("AppointmentPrismaController", () => {
     expect(res.status).toHaveBeenCalledWith(400);
     expect(res.json).toHaveBeenCalledWith({ message: "Bad" });
   });
+
+  it("creates PMS appointments with payment options", async () => {
+    req.query = { createPayment: "1", paymentCollectionMethod: "clinic" };
+    req.body = { resourceType: "Appointment" } as any;
+    mockedService.createAppointmentFromPms.mockResolvedValue({
+      id: "appt_2",
+    } as any);
+
+    await AppointmentController.createFromPms(req as any, res as any);
+
+    expect(mockedService.createAppointmentFromPms).toHaveBeenCalledWith(
+      req.body,
+      true,
+      "clinic",
+    );
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+
+  it("accepts and rejects requested appointments", async () => {
+    req.params = { appointmentId: "appt_1" };
+    req.body = { resourceType: "Appointment" } as any;
+    mockedService.approveRequestedFromPms.mockResolvedValue({
+      id: "appt_1",
+    } as any);
+    mockedService.rejectRequestedAppointment.mockResolvedValue({
+      id: "appt_2",
+    } as any);
+
+    await AppointmentController.acceptRequested(req as any, res as any);
+    await AppointmentController.rejectRequested(req as any, res as any);
+
+    expect(mockedService.approveRequestedFromPms).toHaveBeenCalledWith(
+      "appt_1",
+      req.body,
+    );
+    expect(mockedService.rejectRequestedAppointment).toHaveBeenCalledWith(
+      "appt_1",
+    );
+  });
+
+  it("checks in and updates appointments from PMS", async () => {
+    req.params = { appointmentId: "appt_1" };
+    req.body = { resourceType: "Appointment" } as any;
+    mockedService.checkInAppointment.mockResolvedValue({ id: "appt_1" } as any);
+    mockedService.updateAppointmentPMS.mockResolvedValue({
+      id: "appt_1",
+    } as any);
+
+    await AppointmentController.checkInAppointmentForPMS(
+      req as any,
+      res as any,
+    );
+    await AppointmentController.updateFromPms(req as any, res as any);
+
+    expect(mockedService.checkInAppointment).toHaveBeenCalledWith("appt_1");
+    expect(mockedService.updateAppointmentPMS).toHaveBeenCalledWith(
+      "appt_1",
+      req.body,
+    );
+  });
+
+  it("attaches forms, cancels, and fetches appointments", async () => {
+    req.params = { appointmentId: "appt_1" };
+    req.body = { formIds: ["form_1", "form_2"] };
+    mockedService.attachFormsToAppointment.mockResolvedValue({
+      id: "appt_1",
+    } as any);
+    mockedService.cancelAppointmentFromParent.mockResolvedValue({
+      id: "appt_1",
+    } as any);
+    mockedService.cancelAppointment.mockResolvedValue({ id: "appt_1" } as any);
+    mockedService.getById.mockResolvedValue({ id: "appt_1" } as any);
+    mockedService.getAppointmentsForCompanion.mockResolvedValue([
+      { id: "appt_1" },
+    ] as any);
+    mockedService.getAppointmentsForCompanionByOrganisation.mockResolvedValue([
+      { id: "appt_1" },
+    ] as any);
+    mockedService.getAppointmentsForParent.mockResolvedValue([
+      { id: "appt_1" },
+    ] as any);
+    mockedService.getAppointmentsForLead.mockResolvedValue([
+      { id: "appt_1" },
+    ] as any);
+
+    (req as any).userId = "user_1";
+    mockedAuth.getByProviderUserId.mockResolvedValue({
+      parentId: "parent_1",
+    } as any);
+
+    await AppointmentController.attachFormsToAppointment(
+      req as any,
+      res as any,
+    );
+    await AppointmentController.cancelFromMobile(req as any, res as any);
+    await AppointmentController.cancelFromPMS(req as any, res as any);
+    await AppointmentController.getById(req as any, res as any);
+    await AppointmentController.listByCompanion(
+      { params: { companionId: "comp_1" } } as any,
+      res as any,
+    );
+    await AppointmentController.listByCompanionForOrganisation(
+      { params: { companionId: "comp_1", organisationId: "org_1" } } as any,
+      res as any,
+    );
+    await AppointmentController.listByParent(req as any, res as any);
+    await AppointmentController.listByLead(
+      { params: { leadId: "lead_1" } } as any,
+      res as any,
+    );
+
+    expect(mockedService.attachFormsToAppointment).toHaveBeenCalledWith(
+      "appt_1",
+      ["form_1", "form_2"],
+    );
+    expect(mockedService.cancelAppointmentFromParent).toHaveBeenCalledWith(
+      "appt_1",
+      "parent_1",
+      undefined,
+    );
+    expect(mockedService.cancelAppointment).toHaveBeenCalledWith(
+      "appt_1",
+      undefined,
+    );
+    expect(mockedService.getById).toHaveBeenCalledWith("appt_1");
+    expect(mockedService.getAppointmentsForCompanion).toHaveBeenCalledWith(
+      "comp_1",
+    );
+    expect(
+      mockedService.getAppointmentsForCompanionByOrganisation,
+    ).toHaveBeenCalledWith("comp_1", "org_1");
+    expect(mockedService.getAppointmentsForParent).toHaveBeenCalledWith(
+      "parent_1",
+    );
+    expect(mockedService.getAppointmentsForLead).toHaveBeenCalledWith("lead_1");
+  });
+
+  it("handles mobile auth and upload validation errors", async () => {
+    await AppointmentController.cancelFromMobile(req as any, res as any);
+    expect(res.status).toHaveBeenCalledWith(401);
+
+    await AppointmentController.listByParent(req as any, res as any);
+    expect(res.status).toHaveBeenCalledWith(401);
+
+    await AppointmentController.getDocumentUplaodURL(
+      { body: {} } as any,
+      res as any,
+    );
+    expect(res.status).toHaveBeenCalledWith(401);
+
+    (req as any).userId = "user_1";
+    mockedAuth.getByProviderUserId.mockResolvedValueOnce({} as any);
+    await AppointmentController.rescheduleFromMobile(req as any, res as any);
+    expect(res.status).toHaveBeenCalledWith(400);
+
+    await AppointmentController.getDocumentUplaodURL(
+      { body: { companionId: "comp_1" }, userId: "user_1" } as any,
+      res as any,
+    );
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
 });

--- a/apps/backend/test/controllers/web/appointment.prisma.controller.test.ts
+++ b/apps/backend/test/controllers/web/appointment.prisma.controller.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, jest, it } from "@jest/globals";
+import { Request, Response } from "express";
+import { AppointmentController } from "../../../src/controllers/web/appointment.prisma.controller";
+import { AppointmentPrismaService } from "../../../src/services/appointment.prisma.service";
+import { AuthUserMobileService } from "../../../src/services/authUserMobile.service";
+import { generatePresignedUrl } from "../../../src/middlewares/upload";
+import logger from "../../../src/utils/logger";
+
+jest.mock("../../../src/services/appointment.prisma.service");
+jest.mock("../../../src/services/authUserMobile.service");
+jest.mock("../../../src/middlewares/upload");
+jest.mock("../../../src/utils/logger", () => ({
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+}));
+
+const mockedService = jest.mocked(AppointmentPrismaService);
+const mockedAuth = jest.mocked(AuthUserMobileService);
+const mockedUpload = jest.mocked(generatePresignedUrl);
+const mockedLogger = jest.mocked(logger);
+
+const buildResponse = () => {
+  const json = jest.fn();
+  const status = jest.fn().mockReturnValue({ json });
+  return { json, status } as unknown as Response & {
+    json: jest.Mock;
+    status: jest.Mock;
+  };
+};
+
+describe("AppointmentPrismaController", () => {
+  let req: Partial<Request>;
+  let res: ReturnType<typeof buildResponse>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    req = { headers: {}, params: {}, body: {}, query: {} };
+    res = buildResponse();
+  });
+
+  it("creates a requested appointment", async () => {
+    mockedService.createRequestedFromMobile.mockResolvedValue({
+      id: "appt_1",
+    } as any);
+
+    await AppointmentController.createRequestedFromMobile(
+      req as any,
+      res as any,
+    );
+
+    expect(mockedService.createRequestedFromMobile).toHaveBeenCalledWith(
+      req.body,
+    );
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith({
+      message: "Appointment created",
+      data: { id: "appt_1" },
+    });
+  });
+
+  it("reschedules mobile appointments after auth lookup", async () => {
+    (req as any).userId = "user_1";
+    req.params = { appointmentId: "appt_1" };
+    req.body = {
+      startTime: "2026-06-10T11:00:00.000Z",
+      endTime: "2026-06-10T11:30:00.000Z",
+    };
+    mockedAuth.getByProviderUserId.mockResolvedValue({
+      parentId: "parent_1",
+    } as any);
+    mockedService.rescheduleFromParent.mockResolvedValue({
+      id: "appt_1",
+    } as any);
+
+    await AppointmentController.rescheduleFromMobile(req as any, res as any);
+
+    expect(mockedService.rescheduleFromParent).toHaveBeenCalledWith(
+      "appt_1",
+      "parent_1",
+      expect.objectContaining({
+        startTime: "2026-06-10T11:00:00.000Z",
+        endTime: "2026-06-10T11:30:00.000Z",
+      }),
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it("returns 401 when mobile user is missing", async () => {
+    await AppointmentController.rescheduleFromMobile(req as any, res as any);
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  it("lists appointments for organisation", async () => {
+    req.params = { organisationId: "org_1" };
+    req.query = { status: "REQUESTED" };
+    mockedService.getAppointmentsForOrganisation.mockResolvedValue([
+      { id: "appt_1" },
+    ] as any);
+
+    await AppointmentController.listByOrganisation(req as any, res as any);
+
+    expect(mockedService.getAppointmentsForOrganisation).toHaveBeenCalledWith(
+      "org_1",
+      expect.objectContaining({ status: ["REQUESTED"] }),
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it("creates document upload urls", async () => {
+    (req as any).userId = "user_1";
+    req.body = { companionId: "comp_1", mimeType: "image/png" };
+    mockedUpload.mockResolvedValue({
+      url: "https://upload-url",
+      key: "appointments/comp_1/file",
+    } as any);
+
+    await AppointmentController.getDocumentUplaodURL(req as any, res as any);
+
+    expect(mockedUpload).toHaveBeenCalledWith(
+      "image/png",
+      "custom",
+      "appointments/comp_1",
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it("logs and surfaces service errors", async () => {
+    mockedService.createRequestedFromMobile.mockRejectedValue(
+      Object.assign(new Error("Bad"), { statusCode: 400 }),
+    );
+
+    await AppointmentController.createRequestedFromMobile(
+      req as any,
+      res as any,
+    );
+
+    expect(mockedLogger.error).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ message: "Bad" });
+  });
+});

--- a/apps/backend/test/controllers/web/case-encounter.controller.test.ts
+++ b/apps/backend/test/controllers/web/case-encounter.controller.test.ts
@@ -25,6 +25,7 @@ jest.mock("../../../src/services/case-encounter.service", () => {
       createEncounter: jest.fn(),
       updateEncounter: jest.fn(),
       dischargeEncounter: jest.fn(),
+      assignUnit: jest.fn(),
       getEncounterById: jest.fn(),
       listEncounters: jest.fn(),
     },
@@ -213,6 +214,45 @@ describe("CaseEncounterController", () => {
     expect(mockedService.dischargeEncounter).toHaveBeenCalledWith("enc_1", {
       dischargedAt: new Date("2026-06-11T12:00:00.000Z"),
       periodEnd: undefined,
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it("assigns a unit from Parameters payload", async () => {
+    req.params = { id: "enc_1" };
+    req.body = {
+      resourceType: "Parameters",
+      parameter: [
+        { name: "unitId", valueString: "unit_1" },
+        { name: "assignedBy", valueString: "user_1" },
+        { name: "reason", valueString: "Transfer to ICU unit" },
+        { name: "assignedAt", valueDateTime: "2026-06-11T11:00:00.000Z" },
+      ],
+    };
+    mockedService.assignUnit.mockResolvedValue({
+      id: "enc_1",
+      caseId: "case_1",
+      organisationId: "org_1",
+      companionId: "comp_1",
+      status: "arrived",
+      encounterClass: "IMP",
+      appointmentKind: "INPATIENT",
+      admission: {
+        encounterId: "enc_1",
+        organisationId: "org_1",
+        companionId: "comp_1",
+        unitId: "unit_1",
+        admittedAt: new Date("2026-06-11T10:00:00.000Z"),
+      },
+    } as never);
+
+    await EncounterController.assignUnit(req as any, res as any);
+
+    expect(mockedService.assignUnit).toHaveBeenCalledWith("enc_1", {
+      unitId: "unit_1",
+      assignedBy: "user_1",
+      reason: "Transfer to ICU unit",
+      assignedAt: new Date("2026-06-11T11:00:00.000Z"),
     });
     expect(res.status).toHaveBeenCalledWith(200);
   });

--- a/apps/backend/test/controllers/web/case-encounter.controller.test.ts
+++ b/apps/backend/test/controllers/web/case-encounter.controller.test.ts
@@ -27,6 +27,7 @@ jest.mock("../../../src/services/case-encounter.service", () => {
       dischargeEncounter: jest.fn(),
       assignUnit: jest.fn(),
       listUnitAssignments: jest.fn(),
+      listActiveInpatientEncounters: jest.fn(),
       getEncounterById: jest.fn(),
       listEncounters: jest.fn(),
     },
@@ -289,5 +290,52 @@ describe("CaseEncounterController", () => {
         ],
       }),
     );
+  });
+
+  it("lists active inpatient encounters as a Bundle", async () => {
+    req.query = { organization: "Organization/org_1" };
+    mockedService.listActiveInpatientEncounters.mockResolvedValue([
+      {
+        id: "enc_1",
+        caseId: "case_1",
+        appointmentId: "appt_1",
+        organisationId: "org_1",
+        companionId: "comp_1",
+        status: "arrived",
+        encounterClass: "IMP",
+        appointmentKind: "INPATIENT",
+        admission: {
+          encounterId: "enc_1",
+          organisationId: "org_1",
+          companionId: "comp_1",
+          unitId: "unit_1",
+          admittedAt: new Date("2026-06-11T10:30:00.000Z"),
+        },
+      },
+    ] as never);
+
+    await EncounterController.listActiveInpatients(req as any, res as any);
+
+    expect(mockedService.listActiveInpatientEncounters).toHaveBeenCalledWith({
+      organisationId: "org_1",
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceType: "Bundle",
+        total: 1,
+      }),
+    );
+  });
+
+  it("requires an organisation for active inpatient list", async () => {
+    req.query = {};
+
+    await EncounterController.listActiveInpatients(req as any, res as any);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: "organization is required.",
+    });
   });
 });

--- a/apps/backend/test/controllers/web/case-encounter.controller.test.ts
+++ b/apps/backend/test/controllers/web/case-encounter.controller.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { Request, Response } from "express";
+import {
+  CaseController,
+  EncounterController,
+} from "../../../src/controllers/web/case-encounter.controller";
+import {
+  CaseEncounterService,
+  CaseEncounterServiceError,
+} from "../../../src/services/case-encounter.service";
+import logger from "../../../src/utils/logger";
+
+jest.mock("../../../src/services/case-encounter.service", () => {
+  const actual = jest.requireActual(
+    "../../../src/services/case-encounter.service",
+  ) as Record<string, unknown>;
+
+  return {
+    ...actual,
+    CaseEncounterService: {
+      createCase: jest.fn(),
+      updateCase: jest.fn(),
+      getCaseById: jest.fn(),
+      listCases: jest.fn(),
+      createEncounter: jest.fn(),
+      updateEncounter: jest.fn(),
+      getEncounterById: jest.fn(),
+      listEncounters: jest.fn(),
+    },
+  };
+});
+jest.mock("../../../src/utils/logger", () => ({
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+}));
+
+const mockedService = jest.mocked(CaseEncounterService);
+const mockedLogger = jest.mocked(logger);
+
+const buildResponse = () => {
+  const json = jest.fn();
+  const status = jest.fn().mockReturnValue({ json });
+  return { json, status } as unknown as Response & {
+    json: jest.Mock;
+    status: jest.Mock;
+  };
+};
+
+describe("CaseEncounterController", () => {
+  let req: Partial<Request>;
+  let res: ReturnType<typeof buildResponse>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    req = { params: {}, query: {}, body: {} };
+    res = buildResponse();
+  });
+
+  it("creates a case from EpisodeOfCare payload", async () => {
+    req.body = {
+      resourceType: "EpisodeOfCare",
+      status: "active",
+      patient: { reference: "Patient/comp_1" },
+      managingOrganization: { reference: "Organization/org_1" },
+      extension: [
+        {
+          url: "https://yosemitecrew.com/fhir/StructureDefinition/case-appointment-kind",
+          valueString: "OUTPATIENT",
+        },
+      ],
+    };
+    mockedService.createCase.mockResolvedValue({
+      id: "case_1",
+      organisationId: "org_1",
+      companionId: "comp_1",
+      status: "active",
+      appointmentKind: "OUTPATIENT",
+    } as never);
+
+    await CaseController.create(req as any, res as any);
+
+    expect(mockedService.createCase).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organisationId: "org_1",
+        companionId: "comp_1",
+      }),
+    );
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceType: "EpisodeOfCare",
+        id: "case_1",
+      }),
+    );
+  });
+
+  it("lists cases as a FHIR Bundle", async () => {
+    req.query = {
+      organization: "Organization/org_1",
+      patient: "Patient/comp_1",
+      status: "active",
+      appointmentKind: "OUTPATIENT",
+    };
+    mockedService.listCases.mockResolvedValue([
+      {
+        id: "case_1",
+        organisationId: "org_1",
+        companionId: "comp_1",
+        status: "active",
+        appointmentKind: "OUTPATIENT",
+      },
+    ] as never);
+
+    await CaseController.list(req as any, res as any);
+
+    expect(mockedService.listCases).toHaveBeenCalledWith({
+      organisationId: "org_1",
+      companionId: "comp_1",
+      parentId: undefined,
+      status: "active",
+      appointmentKind: "OUTPATIENT",
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceType: "Bundle",
+        total: 1,
+      }),
+    );
+  });
+
+  it("creates an encounter from FHIR payload", async () => {
+    req.body = {
+      resourceType: "Encounter",
+      status: "planned",
+      class: {
+        system: "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+        code: "AMB",
+      },
+      subject: { reference: "Patient/comp_1" },
+      episodeOfCare: [{ reference: "EpisodeOfCare/case_1" }],
+      appointment: [{ reference: "Appointment/appt_1" }],
+      serviceProvider: { reference: "Organization/org_1" },
+      extension: [
+        {
+          url: "https://yosemitecrew.com/fhir/StructureDefinition/encounter-appointment-kind",
+          valueString: "OUTPATIENT",
+        },
+      ],
+    };
+    mockedService.createEncounter.mockResolvedValue({
+      id: "enc_1",
+      caseId: "case_1",
+      appointmentId: "appt_1",
+      organisationId: "org_1",
+      companionId: "comp_1",
+      status: "planned",
+      encounterClass: "AMB",
+      appointmentKind: "OUTPATIENT",
+    } as never);
+
+    await EncounterController.create(req as any, res as any);
+
+    expect(mockedService.createEncounter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        caseId: "case_1",
+        appointmentId: "appt_1",
+      }),
+    );
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+
+  it("returns service errors from encounter endpoints", async () => {
+    req.params = { id: "enc_missing" };
+    mockedService.getEncounterById.mockRejectedValue(
+      new CaseEncounterServiceError("Encounter not found.", 404),
+    );
+
+    await EncounterController.getById(req as any, res as any);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({
+      message: "Encounter not found.",
+    });
+    expect(mockedLogger.error).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/test/controllers/web/case-encounter.controller.test.ts
+++ b/apps/backend/test/controllers/web/case-encounter.controller.test.ts
@@ -27,7 +27,10 @@ jest.mock("../../../src/services/case-encounter.service", () => {
       dischargeEncounter: jest.fn(),
       assignUnit: jest.fn(),
       listUnitAssignments: jest.fn(),
+      listAdmissionUnitAssignments: jest.fn(),
       listActiveInpatientEncounters: jest.fn(),
+      startEncounter: jest.fn(),
+      markEncounterReadyForDischarge: jest.fn(),
       getEncounterById: jest.fn(),
       listEncounters: jest.fn(),
     },
@@ -290,6 +293,89 @@ describe("CaseEncounterController", () => {
         ],
       }),
     );
+  });
+
+  it("lists admission unit assignments as Parameters payload", async () => {
+    req.params = { id: "enc_1" };
+    mockedService.listAdmissionUnitAssignments.mockResolvedValue([
+      {
+        id: "assign_1",
+        encounterId: "enc_1",
+        admissionId: "enc_1",
+        unitId: "unit_1",
+        assignedAt: new Date("2026-06-11T11:00:00.000Z"),
+        releasedAt: null,
+        assignedBy: "user_1",
+        reason: "Monitoring",
+      },
+    ] as never);
+
+    await EncounterController.listAdmissionUnitAssignments(
+      req as any,
+      res as any,
+    );
+
+    expect(mockedService.listAdmissionUnitAssignments).toHaveBeenCalledWith(
+      "enc_1",
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceType: "Parameters",
+        parameter: [
+          expect.objectContaining({
+            name: "assignment",
+          }),
+        ],
+      }),
+    );
+  });
+
+  it("starts an encounter from Parameters payload", async () => {
+    req.params = { id: "enc_1" };
+    req.body = {
+      resourceType: "Parameters",
+      parameter: [
+        { name: "startedAt", valueDateTime: "2026-06-11T12:00:00.000Z" },
+      ],
+    };
+    mockedService.startEncounter.mockResolvedValue({
+      id: "enc_1",
+      caseId: "case_1",
+      organisationId: "org_1",
+      companionId: "comp_1",
+      status: "in-progress",
+      encounterClass: "IMP",
+      appointmentKind: "INPATIENT",
+    } as never);
+
+    await EncounterController.start(req as any, res as any);
+
+    expect(mockedService.startEncounter).toHaveBeenCalledWith("enc_1", {
+      startedAt: new Date("2026-06-11T12:00:00.000Z"),
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it("marks an encounter ready for discharge", async () => {
+    req.params = { id: "enc_1" };
+    req.body = { resourceType: "Parameters" };
+    mockedService.markEncounterReadyForDischarge.mockResolvedValue({
+      id: "enc_1",
+      caseId: "case_1",
+      organisationId: "org_1",
+      companionId: "comp_1",
+      status: "onleave",
+      encounterClass: "IMP",
+      appointmentKind: "INPATIENT",
+    } as never);
+
+    await EncounterController.readyForDischarge(req as any, res as any);
+
+    expect(mockedService.markEncounterReadyForDischarge).toHaveBeenCalledWith(
+      "enc_1",
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
   });
 
   it("lists active inpatient encounters as a Bundle", async () => {

--- a/apps/backend/test/controllers/web/case-encounter.controller.test.ts
+++ b/apps/backend/test/controllers/web/case-encounter.controller.test.ts
@@ -26,6 +26,7 @@ jest.mock("../../../src/services/case-encounter.service", () => {
       updateEncounter: jest.fn(),
       dischargeEncounter: jest.fn(),
       assignUnit: jest.fn(),
+      listUnitAssignments: jest.fn(),
       getEncounterById: jest.fn(),
       listEncounters: jest.fn(),
     },
@@ -255,5 +256,38 @@ describe("CaseEncounterController", () => {
       assignedAt: new Date("2026-06-11T11:00:00.000Z"),
     });
     expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it("lists unit assignments as Parameters payload", async () => {
+    req.params = { id: "enc_1" };
+    mockedService.listUnitAssignments.mockResolvedValue([
+      {
+        id: "assign_1",
+        encounterId: "enc_1",
+        admissionId: "enc_1",
+        unitId: "unit_1",
+        assignedAt: new Date("2026-06-11T11:00:00.000Z"),
+        releasedAt: new Date("2026-06-11T12:00:00.000Z"),
+        assignedBy: "user_1",
+        reason: "Transfer",
+      },
+    ] as never);
+
+    await EncounterController.listUnitAssignments(req as any, res as any);
+
+    expect(mockedService.listUnitAssignments).toHaveBeenCalledWith({
+      encounterId: "enc_1",
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceType: "Parameters",
+        parameter: [
+          expect.objectContaining({
+            name: "assignment",
+          }),
+        ],
+      }),
+    );
   });
 });

--- a/apps/backend/test/controllers/web/case-encounter.controller.test.ts
+++ b/apps/backend/test/controllers/web/case-encounter.controller.test.ts
@@ -24,6 +24,7 @@ jest.mock("../../../src/services/case-encounter.service", () => {
       listCases: jest.fn(),
       createEncounter: jest.fn(),
       updateEncounter: jest.fn(),
+      dischargeEncounter: jest.fn(),
       getEncounterById: jest.fn(),
       listEncounters: jest.fn(),
     },
@@ -184,5 +185,35 @@ describe("CaseEncounterController", () => {
       message: "Encounter not found.",
     });
     expect(mockedLogger.error).not.toHaveBeenCalled();
+  });
+
+  it("discharges an encounter from Parameters payload", async () => {
+    req.params = { id: "enc_1" };
+    req.body = {
+      resourceType: "Parameters",
+      parameter: [
+        {
+          name: "dischargedAt",
+          valueDateTime: "2026-06-11T12:00:00.000Z",
+        },
+      ],
+    };
+    mockedService.dischargeEncounter.mockResolvedValue({
+      id: "enc_1",
+      caseId: "case_1",
+      organisationId: "org_1",
+      companionId: "comp_1",
+      status: "finished",
+      encounterClass: "IMP",
+      appointmentKind: "INPATIENT",
+    } as never);
+
+    await EncounterController.discharge(req as any, res as any);
+
+    expect(mockedService.dischargeEncounter).toHaveBeenCalledWith("enc_1", {
+      dischargedAt: new Date("2026-06-11T12:00:00.000Z"),
+      periodEnd: undefined,
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
   });
 });

--- a/apps/backend/test/controllers/web/organisation-room.controller.test.ts
+++ b/apps/backend/test/controllers/web/organisation-room.controller.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { Request, Response } from "express";
+import { OrganisationRoomController } from "../../../src/controllers/web/organisation-room.controller";
+import { OrganisationRoomService } from "../../../src/services/organisation-room.service";
+
+jest.mock("../../../src/services/organisation-room.service", () => ({
+  OrganisationRoomService: {
+    create: jest.fn(),
+    update: jest.fn(),
+    getAllByOrganizationId: jest.fn(),
+    getSummaryByOrganizationId: jest.fn(),
+    getById: jest.fn(),
+    toggleAvailability: jest.fn(),
+    delete: jest.fn(),
+  },
+  OrganisationRoomServiceError: class OrganisationRoomServiceError extends Error {
+    constructor(
+      message: string,
+      public readonly statusCode: number,
+    ) {
+      super(message);
+      this.name = "OrganisationRoomServiceError";
+    }
+  },
+}));
+
+const mockedService = jest.mocked(OrganisationRoomService);
+
+const buildResponse = () => {
+  const json = jest.fn();
+  const status = jest.fn().mockReturnValue({ json });
+  return { json, status } as unknown as Response & {
+    json: jest.Mock;
+    status: jest.Mock;
+  };
+};
+
+describe("OrganisationRoomController", () => {
+  let req: Partial<Request>;
+  let res: ReturnType<typeof buildResponse>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    req = { params: {}, query: {}, body: {} };
+    res = buildResponse();
+  });
+
+  it("creates a room", async () => {
+    req.body = {
+      resourceType: "Location",
+      name: "Inpatient Ward A",
+      managingOrganization: { reference: "Organization/org_1" },
+      type: {
+        coding: [
+          {
+            system: "http://example.org/fhir/CodeSystem/organisation-room-type",
+            code: "inpatient",
+          },
+        ],
+      },
+      extension: [
+        {
+          url: "https://yosemitecrew.com/fhir/StructureDefinition/organisation-room-code",
+          valueString: "IP-01",
+        },
+      ],
+    };
+    mockedService.create.mockResolvedValue({
+      id: "room_1",
+      organisationId: "org_1",
+      name: "Inpatient Ward A",
+      code: "IP-01",
+      type: "INPATIENT",
+      assignedSpecialiteis: [],
+      assignedStaffs: [],
+      availableNow: true,
+      availabilityMode: "ALL_DAY",
+      availabilityDays: [],
+      capabilities: [],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as never);
+
+    await OrganisationRoomController.create(req as any, res as any);
+
+    expect(mockedService.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organisationId: "org_1",
+        name: "Inpatient Ward A",
+        code: "IP-01",
+      }),
+    );
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+
+  it("returns a room detail", async () => {
+    req.params = { organizationId: "org_1", id: "room_1" };
+    mockedService.getById.mockResolvedValue({ id: "room_1" } as never);
+
+    await OrganisationRoomController.getById(req as any, res as any);
+
+    expect(mockedService.getById).toHaveBeenCalledWith("room_1", "org_1");
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it("toggles room availability", async () => {
+    req.params = { organizationId: "org_1", id: "room_1" };
+    mockedService.toggleAvailability.mockResolvedValue({
+      id: "room_1",
+      availableNow: false,
+    } as never);
+
+    await OrganisationRoomController.toggleAvailability(req as any, res as any);
+
+    expect(mockedService.toggleAvailability).toHaveBeenCalledWith(
+      "room_1",
+      "org_1",
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it("returns summary rows for an organisation", async () => {
+    req.params = { organizationId: "org_1" };
+    mockedService.getSummaryByOrganizationId.mockResolvedValue([
+      { id: "room_1" },
+    ] as never);
+
+    await OrganisationRoomController.getAllByOrganizationId(
+      req as any,
+      res as any,
+    );
+
+    expect(mockedService.getSummaryByOrganizationId).toHaveBeenCalledWith(
+      "org_1",
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it("rejects a missing organisation identifier", async () => {
+    req.params = {};
+
+    await OrganisationRoomController.getById(req as any, res as any);
+
+    expect(mockedService.getById).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+});

--- a/apps/backend/test/controllers/web/room-unit-group.controller.test.ts
+++ b/apps/backend/test/controllers/web/room-unit-group.controller.test.ts
@@ -91,4 +91,55 @@ describe("RoomUnitGroupController", () => {
     });
     expect(res.status).toHaveBeenCalledWith(200);
   });
+
+  it("rejects invalid payloads and missing organisation ids", async () => {
+    req.body = { resourceType: "Observation" };
+    await RoomUnitGroupController.create(req as any, res as any);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: "Invalid payload. Expected FHIR Location resource.",
+    });
+
+    res = buildResponse();
+    req.body = {
+      resourceType: "Location",
+      name: "Dog ward",
+      partOf: { reference: "Location/room_1" },
+    };
+    await RoomUnitGroupController.create(
+      { ...req, organisationId: undefined } as any,
+      res as any,
+    );
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: "Organization identifier is required.",
+    });
+  });
+
+  it("handles missing update ids and delete organisation ids", async () => {
+    req.body = {
+      resourceType: "Location",
+      name: "Dog ward",
+      managingOrganization: { reference: "Organization/org_1" },
+      partOf: { reference: "Location/room_1" },
+    };
+
+    await RoomUnitGroupController.update(
+      { ...req, params: {} } as any,
+      res as any,
+    );
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: "Group identifier is required.",
+    });
+
+    await RoomUnitGroupController.delete(
+      { params: { id: "group_1" } } as any,
+      res as any,
+    );
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: "Organization identifier is required.",
+    });
+  });
 });

--- a/apps/backend/test/controllers/web/room-unit-group.controller.test.ts
+++ b/apps/backend/test/controllers/web/room-unit-group.controller.test.ts
@@ -1,27 +1,27 @@
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import { Request, Response } from "express";
-import { RoomUnitController } from "../../../src/controllers/web/room-unit.controller";
-import { RoomUnitService } from "../../../src/services/room-unit.service";
+import { RoomUnitGroupController } from "../../../src/controllers/web/room-unit-group.controller";
+import { RoomUnitGroupService } from "../../../src/services/room-unit-group.service";
 
-jest.mock("../../../src/services/room-unit.service", () => ({
-  RoomUnitService: {
+jest.mock("../../../src/services/room-unit-group.service", () => ({
+  RoomUnitGroupService: {
     create: jest.fn(),
     update: jest.fn(),
     list: jest.fn(),
     delete: jest.fn(),
   },
-  RoomUnitServiceError: class RoomUnitServiceError extends Error {
+  RoomUnitGroupServiceError: class RoomUnitGroupServiceError extends Error {
     constructor(
       message: string,
       public readonly statusCode: number,
     ) {
       super(message);
-      this.name = "RoomUnitServiceError";
+      this.name = "RoomUnitGroupServiceError";
     }
   },
 }));
 
-const mockedService = jest.mocked(RoomUnitService);
+const mockedService = jest.mocked(RoomUnitGroupService);
 
 const buildResponse = () => {
   const json = jest.fn();
@@ -32,7 +32,7 @@ const buildResponse = () => {
   };
 };
 
-describe("RoomUnitController", () => {
+describe("RoomUnitGroupController", () => {
   let req: Partial<Request>;
   let res: ReturnType<typeof buildResponse>;
 
@@ -42,51 +42,51 @@ describe("RoomUnitController", () => {
     res = buildResponse();
   });
 
-  it("creates a room unit", async () => {
+  it("creates a room unit group", async () => {
     req.body = {
       resourceType: "Location",
-      name: "Kennel 1",
+      name: "Dog ward",
       managingOrganization: { reference: "Organization/org_1" },
       partOf: { reference: "Location/room_1" },
       extension: [
         {
-          url: "https://yosemitecrew.com/fhir/StructureDefinition/room-unit-code",
-          valueString: "KEN-01",
+          url: "https://yosemitecrew.com/fhir/StructureDefinition/room-unit-group-count",
+          valueInteger: 2,
         },
       ],
     };
-    mockedService.create.mockResolvedValue({ id: "unit_1" } as never);
+    mockedService.create.mockResolvedValue({ id: "group_1" } as never);
 
-    await RoomUnitController.create(req as any, res as any);
+    await RoomUnitGroupController.create(req as any, res as any);
 
     expect(mockedService.create).toHaveBeenCalledWith(
       expect.objectContaining({
         organisationId: "org_1",
         roomId: "room_1",
-        code: "KEN-01",
+        name: "Dog ward",
+        unitCount: 2,
       }),
     );
     expect(res.status).toHaveBeenCalledWith(201);
   });
 
-  it("lists room units", async () => {
+  it("lists room unit groups", async () => {
     req.query = { organizationId: "org_1" };
     mockedService.list.mockResolvedValue([
       {
-        id: "unit_1",
+        id: "group_1",
         organisationId: "org_1",
         roomId: "room_1",
-        code: "KEN-01",
-        displayName: "Kennel 1",
+        name: "Dog ward",
+        unitCount: 2,
       },
     ] as never);
 
-    await RoomUnitController.list(req as any, res as any);
+    await RoomUnitGroupController.list(req as any, res as any);
 
     expect(mockedService.list).toHaveBeenCalledWith({
       organisationId: "org_1",
       roomId: undefined,
-      unitGroupId: undefined,
       isActive: undefined,
     });
     expect(res.status).toHaveBeenCalledWith(200);

--- a/apps/backend/test/controllers/web/room-unit.controller.test.ts
+++ b/apps/backend/test/controllers/web/room-unit.controller.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { Request, Response } from "express";
+import { RoomUnitController } from "../../../src/controllers/web/room-unit.controller";
+import { RoomUnitService } from "../../../src/services/room-unit.service";
+
+jest.mock("../../../src/services/room-unit.service", () => ({
+  RoomUnitService: {
+    create: jest.fn(),
+    update: jest.fn(),
+    list: jest.fn(),
+    delete: jest.fn(),
+  },
+  RoomUnitServiceError: class RoomUnitServiceError extends Error {
+    constructor(
+      message: string,
+      public readonly statusCode: number,
+    ) {
+      super(message);
+      this.name = "RoomUnitServiceError";
+    }
+  },
+}));
+
+const mockedService = jest.mocked(RoomUnitService);
+
+const buildResponse = () => {
+  const json = jest.fn();
+  const status = jest.fn().mockReturnValue({ json });
+  return { json, status } as unknown as Response & {
+    json: jest.Mock;
+    status: jest.Mock;
+  };
+};
+
+describe("RoomUnitController", () => {
+  let req: Partial<Request>;
+  let res: ReturnType<typeof buildResponse>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    req = { params: {}, query: {}, body: {} };
+    res = buildResponse();
+  });
+
+  it("creates a room unit from Location payload", async () => {
+    req.body = {
+      resourceType: "Location",
+      id: "unit_1",
+      name: "Kennel 1",
+      managingOrganization: { reference: "Organization/org_1" },
+      partOf: { reference: "Location/room_1" },
+      extension: [
+        {
+          url: "https://yosemitecrew.com/fhir/StructureDefinition/room-unit-code",
+          valueString: "KEN-01",
+        },
+      ],
+    };
+    mockedService.create.mockResolvedValue({
+      id: "unit_1",
+      organisationId: "org_1",
+      roomId: "room_1",
+      code: "KEN-01",
+      displayName: "Kennel 1",
+      isActive: true,
+    } as never);
+
+    await RoomUnitController.create(req as any, res as any);
+
+    expect(mockedService.create).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+
+  it("lists room units", async () => {
+    req.query = { organizationId: "org_1" };
+    mockedService.list.mockResolvedValue([
+      {
+        id: "unit_1",
+        organisationId: "org_1",
+        roomId: "room_1",
+        code: "KEN-01",
+        displayName: "Kennel 1",
+        isActive: true,
+      },
+    ] as never);
+
+    await RoomUnitController.list(req as any, res as any);
+
+    expect(mockedService.list).toHaveBeenCalledWith({
+      organisationId: "org_1",
+      roomId: undefined,
+      isActive: undefined,
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+});

--- a/apps/backend/test/controllers/web/room-unit.controller.test.ts
+++ b/apps/backend/test/controllers/web/room-unit.controller.test.ts
@@ -91,4 +91,54 @@ describe("RoomUnitController", () => {
     });
     expect(res.status).toHaveBeenCalledWith(200);
   });
+
+  it("rejects invalid payloads and missing organisation ids", async () => {
+    req.body = { resourceType: "Observation" };
+    await RoomUnitController.create(req as any, res as any);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: "Invalid payload. Expected FHIR Location resource.",
+    });
+
+    res = buildResponse();
+    req.body = {
+      resourceType: "Location",
+      name: "Kennel 1",
+      partOf: { reference: "Location/room_1" },
+      extension: [],
+    };
+    await RoomUnitController.create(
+      { ...req, organisationId: undefined } as any,
+      res as any,
+    );
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: "Organization identifier is required.",
+    });
+  });
+
+  it("handles missing update ids and delete organisation ids", async () => {
+    req.body = {
+      resourceType: "Location",
+      name: "Kennel 1",
+      managingOrganization: { reference: "Organization/org_1" },
+      partOf: { reference: "Location/room_1" },
+      extension: [],
+    };
+
+    await RoomUnitController.update({ ...req, params: {} } as any, res as any);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: "Unit identifier is required.",
+    });
+
+    await RoomUnitController.delete(
+      { params: { id: "unit_1" } } as any,
+      res as any,
+    );
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: "Organization identifier is required.",
+    });
+  });
 });

--- a/apps/backend/test/routers/healthcare-service.router.test.ts
+++ b/apps/backend/test/routers/healthcare-service.router.test.ts
@@ -1,0 +1,103 @@
+import express from "express";
+import type { Router } from "express";
+
+const authorizeCognito = jest.fn((_req, _res, next) => next());
+const withOrgPermissionsMiddleware = jest.fn((_req, _res, next) => next());
+const requirePermissionMiddleware = jest.fn((_req, _res, next) => next());
+
+const CatalogController = {
+  createProduct: jest.fn(),
+  updateProduct: jest.fn(),
+  getProductById: jest.fn(),
+  listProducts: jest.fn(),
+  resolveProductOperation: jest.fn(),
+  searchCatalogOperation: jest.fn(),
+};
+
+jest.mock("../../src/middlewares/auth", () => ({
+  authorizeCognito,
+}));
+
+jest.mock("../../src/middlewares/rbac", () => ({
+  withOrgPermissions: () => withOrgPermissionsMiddleware,
+  requirePermission: () => requirePermissionMiddleware,
+}));
+
+jest.mock("../../src/controllers/web/catalog.controller", () => ({
+  CatalogController,
+}));
+
+const healthcareServiceRouter = jest.requireActual(
+  "../../src/routers/healthcare-service.router",
+).default as Router;
+
+type Layer = {
+  route?: {
+    path: string;
+    methods: Record<string, boolean>;
+    stack: Array<{ handle: unknown }>;
+  };
+  handle?: {
+    stack?: Layer[];
+  };
+  regexp?: RegExp;
+};
+
+const findRoute = (path: string, method: "post" | "get" | "patch") => {
+  const layer = (
+    (healthcareServiceRouter as unknown as { stack: Layer[] }).stack ?? []
+  ).find(
+    (entry) =>
+      entry.route?.path === path && Boolean(entry.route?.methods?.[method]),
+  );
+
+  return layer?.route;
+};
+
+const matchMountedRouteRegexp = (path: string) => {
+  const app = express();
+  app.use("/fhir/v1/healthcare-service", healthcareServiceRouter);
+
+  const mountedRouterLayer = (
+    app as unknown as { _router: { stack: Layer[] } }
+  )._router.stack.find((layer) => layer.handle?.stack?.length);
+
+  const routeLayer = mountedRouterLayer?.handle?.stack?.find(
+    (layer) => layer.route?.path === path,
+  );
+
+  return routeLayer?.regexp;
+};
+
+describe("healthcare-service.router", () => {
+  it("requires Cognito auth for component search", () => {
+    const route = findRoute("/\\$search-components", "post");
+
+    expect(route?.stack.map((layer) => layer.handle)).toEqual([
+      authorizeCognito,
+      expect.any(Function),
+      withOrgPermissionsMiddleware,
+      requirePermissionMiddleware,
+      CatalogController.searchCatalogOperation,
+    ]);
+  });
+
+  it("requires Cognito auth for resolve selection", () => {
+    const route = findRoute("/\\$resolve-selection", "post");
+
+    expect(route?.stack.map((layer) => layer.handle)).toEqual([
+      authorizeCognito,
+      expect.any(Function),
+      withOrgPermissionsMiddleware,
+      requirePermissionMiddleware,
+      CatalogController.resolveProductOperation,
+    ]);
+  });
+
+  it("matches the mounted search-components URL", () => {
+    const regexp = matchMountedRouteRegexp("/\\$search-components");
+
+    expect(regexp?.test("/$search-components")).toBe(true);
+    expect(regexp?.test("/search-components")).toBe(false);
+  });
+});

--- a/apps/backend/test/scripts/migrate-all.helpers.test.ts
+++ b/apps/backend/test/scripts/migrate-all.helpers.test.ts
@@ -1,0 +1,48 @@
+import { getMissingCompanionForeignKeyReason } from "../../src/scripts/migrate-all.helpers";
+
+describe("getMissingCompanionForeignKeyReason", () => {
+  const knownIds = new Set(["companion-1", "companion-2"]);
+
+  it("returns null for unrelated models", () => {
+    expect(
+      getMissingCompanionForeignKeyReason(
+        "Organization",
+        { companionId: "companion-1" },
+        knownIds,
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null when the companion exists", () => {
+    expect(
+      getMissingCompanionForeignKeyReason(
+        "Document",
+        { companionId: "companion-1" },
+        knownIds,
+      ),
+    ).toBeNull();
+  });
+
+  it("flags missing companionId values", () => {
+    expect(getMissingCompanionForeignKeyReason("Document", {}, knownIds)).toBe(
+      "missing companionId",
+    );
+    expect(
+      getMissingCompanionForeignKeyReason(
+        "Document",
+        { companionId: "" },
+        knownIds,
+      ),
+    ).toBe("missing companionId");
+  });
+
+  it("flags unknown companion references", () => {
+    expect(
+      getMissingCompanionForeignKeyReason(
+        "CompanionOrganisation",
+        { companionId: "missing-id" },
+        knownIds,
+      ),
+    ).toBe("unknown companionId missing-id");
+  });
+});

--- a/apps/backend/test/services/appointment.prisma.service.test.ts
+++ b/apps/backend/test/services/appointment.prisma.service.test.ts
@@ -1,0 +1,236 @@
+import { beforeEach, describe, expect, jest, it } from "@jest/globals";
+import { AppointmentPrismaService } from "../../src/services/appointment.prisma.service";
+import { prisma } from "../../src/config/prisma";
+
+jest.mock("@yosemite-crew/types", () => ({
+  ...(jest.requireActual("@yosemite-crew/types") as unknown as Record<
+    string,
+    unknown
+  >),
+  fromAppointmentRequestDTO: jest.fn(),
+  toAppointmentResponseDTO: jest.fn((appointment) => appointment),
+}));
+
+jest.mock("../../src/config/prisma", () => ({
+  prisma: {
+    appointment: {
+      create: jest.fn(),
+      findUnique: jest.fn(),
+      findMany: jest.fn(),
+      update: jest.fn(),
+    },
+    invoice: {
+      findMany: jest.fn(),
+    },
+  },
+}));
+
+const mockedPrisma = jest.mocked(prisma);
+const mockedTypes = jest.requireMock("@yosemite-crew/types") as {
+  fromAppointmentRequestDTO: jest.Mock;
+  toAppointmentResponseDTO: jest.Mock;
+};
+
+const baseDomain = {
+  companion: {
+    id: "comp_1",
+    name: "Buddy",
+    species: "Dog",
+    breed: "Labrador",
+    parent: {
+      id: "parent_1",
+      name: "Parent One",
+    },
+  },
+  lead: {
+    id: "lead_1",
+    name: "Dr Vet",
+  },
+  supportStaff: [{ id: "staff_1", name: "Assistant" }],
+  room: { id: "room_1", name: "Room A" },
+  appointmentType: {
+    id: "service_1",
+    name: "Consultation",
+    speciality: { id: "spec_1", name: "Cardiology" },
+  },
+  appointmentKind: "INPATIENT",
+  organisationId: "org_1",
+  appointmentDate: new Date("2026-06-10T10:00:00.000Z"),
+  startTime: new Date("2026-06-10T10:00:00.000Z"),
+  endTime: new Date("2026-06-10T10:30:00.000Z"),
+  timeSlot: "10:00",
+  durationMinutes: 30,
+  status: "REQUESTED",
+  isEmergency: false,
+  concern: "Checkup",
+  attachments: [{ key: "file-1", name: "xray.png", contentType: "image/png" }],
+  formIds: ["form_1"],
+  idempotencyKey: null,
+};
+
+const makeRow = (overrides: Record<string, unknown> = {}): any => ({
+  id: "appt_1",
+  companion: baseDomain.companion,
+  lead: baseDomain.lead,
+  supportStaff: baseDomain.supportStaff,
+  room: baseDomain.room,
+  appointmentType: baseDomain.appointmentType,
+  appointmentKind: "INPATIENT",
+  caseId: null,
+  encounterId: null,
+  productItemId: null,
+  organisationId: "org_1",
+  appointmentDate: baseDomain.appointmentDate,
+  startTime: baseDomain.startTime,
+  endTime: baseDomain.endTime,
+  timeSlot: baseDomain.timeSlot,
+  durationMinutes: baseDomain.durationMinutes,
+  status: baseDomain.status,
+  isEmergency: baseDomain.isEmergency,
+  concern: baseDomain.concern,
+  attachments: baseDomain.attachments,
+  formIds: baseDomain.formIds,
+  expiresAt: null,
+  createdAt: new Date("2026-06-10T09:55:00.000Z"),
+  updatedAt: new Date("2026-06-10T09:55:00.000Z"),
+  idempotencyKey: null,
+  ...overrides,
+});
+
+describe("AppointmentPrismaService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedTypes.fromAppointmentRequestDTO.mockReturnValue(baseDomain as any);
+  });
+
+  it("creates a requested appointment with outpatient fallback", async () => {
+    mockedPrisma.appointment.create.mockResolvedValue(
+      makeRow({ status: "REQUESTED" }),
+    );
+    mockedPrisma.invoice.findMany.mockResolvedValue([]);
+
+    const result = await AppointmentPrismaService.createRequestedFromMobile({
+      resourceType: "Appointment",
+    } as any);
+
+    expect(mockedPrisma.appointment.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          status: "REQUESTED",
+          appointmentKind: "INPATIENT",
+          organisationId: "org_1",
+        }),
+      }),
+    );
+    expect((result as any).paymentStatus).toBe("UNPAID");
+    expect(result.id).toBe("appt_1");
+  });
+
+  it("creates a PMS appointment as upcoming", async () => {
+    mockedPrisma.appointment.create.mockResolvedValue(
+      makeRow({ status: "UPCOMING" }),
+    );
+    mockedPrisma.invoice.findMany.mockResolvedValue([]);
+
+    const result = await AppointmentPrismaService.createAppointmentFromPms(
+      { resourceType: "Appointment" } as any,
+      true,
+      "PAYMENT_LINK",
+    );
+
+    expect(mockedPrisma.appointment.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          status: "UPCOMING",
+        }),
+      }),
+    );
+    expect(result.status).toBe("UPCOMING");
+  });
+
+  it("returns 404 when appointment is missing", async () => {
+    mockedPrisma.appointment.findUnique.mockResolvedValue(null);
+
+    await expect(
+      AppointmentPrismaService.getById("missing"),
+    ).rejects.toMatchObject({
+      message: "Appointment not found",
+      statusCode: 404,
+    });
+  });
+
+  it("reschedules and resets UPCOMING appointments back to requested", async () => {
+    mockedPrisma.appointment.findUnique.mockResolvedValue(
+      makeRow({ status: "UPCOMING" }),
+    );
+    mockedPrisma.appointment.update.mockResolvedValue(
+      makeRow({
+        status: "REQUESTED",
+        timeSlot: "11:00",
+      }),
+    );
+    mockedPrisma.invoice.findMany.mockResolvedValue([]);
+
+    const result = await AppointmentPrismaService.rescheduleFromParent(
+      "appt_1",
+      "parent_1",
+      {
+        startTime: "2026-06-10T11:00:00.000Z",
+        endTime: "2026-06-10T11:30:00.000Z",
+      },
+    );
+
+    expect(mockedPrisma.appointment.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "appt_1" },
+        data: expect.objectContaining({
+          status: "REQUESTED",
+          timeSlot: expect.stringMatching(/^\d{2}:\d{2}$/),
+        }),
+      }),
+    );
+    expect(result.status).toBe("REQUESTED");
+  });
+
+  it("blocks reschedule when parent does not own appointment", async () => {
+    mockedPrisma.appointment.findUnique.mockResolvedValue(
+      makeRow({
+        companion: {
+          ...baseDomain.companion,
+          parent: { id: "other_parent", name: "Other" },
+        },
+      }),
+    );
+
+    await expect(
+      AppointmentPrismaService.rescheduleFromParent("appt_1", "parent_1", {
+        startTime: "2026-06-10T11:00:00.000Z",
+        endTime: "2026-06-10T11:30:00.000Z",
+      }),
+    ).rejects.toMatchObject({
+      message: "You are not allowed to modify this appointment.",
+      statusCode: 403,
+    });
+  });
+
+  it("lists appointments for organisation with filters", async () => {
+    mockedPrisma.appointment.findMany.mockResolvedValue([makeRow()]);
+    mockedPrisma.invoice.findMany.mockResolvedValue([]);
+
+    const result =
+      await AppointmentPrismaService.getAppointmentsForOrganisation("org_1", {
+        status: ["REQUESTED"],
+        startDate: new Date("2026-06-10T00:00:00.000Z"),
+      });
+
+    expect(mockedPrisma.appointment.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          organisationId: "org_1",
+          status: { in: ["REQUESTED"] },
+        }),
+      }),
+    );
+    expect(result).toHaveLength(1);
+  });
+});

--- a/apps/backend/test/services/appointment.prisma.service.test.ts
+++ b/apps/backend/test/services/appointment.prisma.service.test.ts
@@ -11,13 +11,34 @@ jest.mock("@yosemite-crew/types", () => ({
   toAppointmentResponseDTO: jest.fn((appointment) => appointment),
 }));
 
+jest.mock("../../src/services/catalog.service", () => ({
+  CatalogServiceError: class CatalogServiceError extends Error {
+    constructor(
+      message: string,
+      public readonly statusCode: number,
+    ) {
+      super(message);
+      this.name = "CatalogServiceError";
+    }
+  },
+  CatalogService: {
+    resolveSelection: jest.fn(),
+  },
+}));
+
 jest.mock("../../src/config/prisma", () => ({
   prisma: {
+    $transaction: jest.fn(),
     appointment: {
       create: jest.fn(),
       findUnique: jest.fn(),
       findMany: jest.fn(),
       update: jest.fn(),
+    },
+    occupancy: {
+      findFirst: jest.fn(),
+      create: jest.fn(),
+      deleteMany: jest.fn(),
     },
     invoice: {
       findMany: jest.fn(),
@@ -30,8 +51,19 @@ const mockedTypes = jest.requireMock("@yosemite-crew/types") as {
   fromAppointmentRequestDTO: jest.Mock;
   toAppointmentResponseDTO: jest.Mock;
 };
+const mockedCatalog = jest.requireMock(
+  "../../src/services/catalog.service",
+) as {
+  CatalogService: {
+    resolveSelection: jest.Mock;
+  };
+};
+const mockedResolveSelection = mockedCatalog.CatalogService
+  .resolveSelection as unknown as jest.Mock;
 
 const baseDomain = {
+  caseId: "case_1",
+  encounterId: undefined,
   companion: {
     id: "comp_1",
     name: "Buddy",
@@ -101,11 +133,22 @@ describe("AppointmentPrismaService", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockedTypes.fromAppointmentRequestDTO.mockReturnValue(baseDomain as any);
+    mockedResolveSelection.mockImplementation(async () => ({
+      productItemId: "product_1",
+      isBookable: true,
+      appointmentKinds: ["OUTPATIENT", "INPATIENT"],
+    }));
+    mockedPrisma.$transaction.mockImplementation(async (callback: any) =>
+      callback(mockedPrisma),
+    );
+    mockedPrisma.occupancy.findFirst.mockResolvedValue(null);
+    mockedPrisma.occupancy.create.mockResolvedValue({} as any);
+    mockedPrisma.occupancy.deleteMany.mockResolvedValue({ count: 1 } as any);
   });
 
-  it("creates a requested appointment with outpatient fallback", async () => {
+  it("creates a requested appointment with product validation", async () => {
     mockedPrisma.appointment.create.mockResolvedValue(
-      makeRow({ status: "REQUESTED" }),
+      makeRow({ status: "REQUESTED", caseId: "case_1" }),
     );
     mockedPrisma.invoice.findMany.mockResolvedValue([]);
 
@@ -119,6 +162,8 @@ describe("AppointmentPrismaService", () => {
           status: "REQUESTED",
           appointmentKind: "INPATIENT",
           organisationId: "org_1",
+          caseId: "case_1",
+          productItemId: "product_1",
         }),
       }),
     );
@@ -128,7 +173,7 @@ describe("AppointmentPrismaService", () => {
 
   it("creates a PMS appointment as upcoming", async () => {
     mockedPrisma.appointment.create.mockResolvedValue(
-      makeRow({ status: "UPCOMING" }),
+      makeRow({ status: "UPCOMING", caseId: "case_1" }),
     );
     mockedPrisma.invoice.findMany.mockResolvedValue([]);
 
@@ -142,6 +187,14 @@ describe("AppointmentPrismaService", () => {
       expect.objectContaining({
         data: expect.objectContaining({
           status: "UPCOMING",
+        }),
+      }),
+    );
+    expect(mockedPrisma.occupancy.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          userId: "lead_1",
+          referenceId: "appt_1",
         }),
       }),
     );
@@ -189,6 +242,7 @@ describe("AppointmentPrismaService", () => {
         }),
       }),
     );
+    expect(mockedPrisma.occupancy.deleteMany).toHaveBeenCalled();
     expect(result.status).toBe("REQUESTED");
   });
 
@@ -232,5 +286,56 @@ describe("AppointmentPrismaService", () => {
       }),
     );
     expect(result).toHaveLength(1);
+  });
+
+  it("rejects products that are not bookable for the selected appointment kind", async () => {
+    mockedResolveSelection.mockImplementation(async () => ({
+      productItemId: "product_1",
+      isBookable: true,
+      appointmentKinds: ["OUTPATIENT"],
+    }));
+
+    await expect(
+      AppointmentPrismaService.createRequestedFromMobile({
+        resourceType: "Appointment",
+      } as any),
+    ).rejects.toMatchObject({
+      message: "Selected product is not bookable for inpatient appointments.",
+      statusCode: 400,
+    });
+  });
+
+  it("blocks PMS approval when the lead already has overlapping occupancy", async () => {
+    mockedPrisma.appointment.findUnique.mockResolvedValue(
+      makeRow({ status: "REQUESTED" }),
+    );
+    mockedPrisma.occupancy.findFirst.mockResolvedValue({ id: "occ_1" } as any);
+
+    await expect(
+      AppointmentPrismaService.approveRequestedFromPms("appt_1", {
+        resourceType: "Appointment",
+      } as any),
+    ).rejects.toMatchObject({
+      message: "Selected vet is not available for this slot.",
+      statusCode: 409,
+    });
+  });
+
+  it("requires caseId when encounterId is provided", async () => {
+    mockedTypes.fromAppointmentRequestDTO.mockReturnValue({
+      ...baseDomain,
+      caseId: undefined,
+      encounterId: "enc_1",
+      appointmentKind: "OUTPATIENT",
+    } as any);
+
+    await expect(
+      AppointmentPrismaService.createRequestedFromMobile({
+        resourceType: "Appointment",
+      } as any),
+    ).rejects.toMatchObject({
+      message: "caseId is required when encounterId is provided.",
+      statusCode: 400,
+    });
   });
 });

--- a/apps/backend/test/services/appointment.prisma.service.test.ts
+++ b/apps/backend/test/services/appointment.prisma.service.test.ts
@@ -35,6 +35,14 @@ jest.mock("../../src/config/prisma", () => ({
       findMany: jest.fn(),
       update: jest.fn(),
     },
+    case: {
+      create: jest.fn(),
+      findUnique: jest.fn(),
+    },
+    encounter: {
+      create: jest.fn(),
+      findUnique: jest.fn(),
+    },
     occupancy: {
       findFirst: jest.fn(),
       create: jest.fn(),
@@ -147,6 +155,11 @@ describe("AppointmentPrismaService", () => {
   });
 
   it("creates a requested appointment with product validation", async () => {
+    mockedPrisma.case.findUnique.mockResolvedValue({
+      id: "case_1",
+      organisationId: "org_1",
+      companionId: "comp_1",
+    } as any);
     mockedPrisma.appointment.create.mockResolvedValue(
       makeRow({ status: "REQUESTED", caseId: "case_1" }),
     );
@@ -171,7 +184,47 @@ describe("AppointmentPrismaService", () => {
     expect(result.id).toBe("appt_1");
   });
 
+  it("auto-creates a case for inpatient appointments when frontend does not send one", async () => {
+    mockedTypes.fromAppointmentRequestDTO.mockReturnValue({
+      ...baseDomain,
+      caseId: undefined,
+    } as any);
+    mockedPrisma.case.create.mockResolvedValue({ id: "case_new" } as any);
+    mockedPrisma.appointment.create.mockResolvedValue(
+      makeRow({ status: "REQUESTED", caseId: "case_new" }),
+    );
+    mockedPrisma.invoice.findMany.mockResolvedValue([]);
+
+    const result = await AppointmentPrismaService.createRequestedFromMobile({
+      resourceType: "Appointment",
+    } as any);
+
+    expect(mockedPrisma.case.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          organisationId: "org_1",
+          companionId: "comp_1",
+          appointmentKind: "INPATIENT",
+          status: "active",
+        }),
+      }),
+    );
+    expect(mockedPrisma.appointment.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          caseId: "case_new",
+        }),
+      }),
+    );
+    expect((result as any).caseId).toBe("case_new");
+  });
+
   it("creates a PMS appointment as upcoming", async () => {
+    mockedPrisma.case.findUnique.mockResolvedValue({
+      id: "case_1",
+      organisationId: "org_1",
+      companionId: "comp_1",
+    } as any);
     mockedPrisma.appointment.create.mockResolvedValue(
       makeRow({ status: "UPCOMING", caseId: "case_1" }),
     );
@@ -265,6 +318,55 @@ describe("AppointmentPrismaService", () => {
       message: "You are not allowed to modify this appointment.",
       statusCode: 403,
     });
+  });
+
+  it("creates an encounter on check-in when one does not exist", async () => {
+    mockedPrisma.appointment.findUnique.mockResolvedValue(
+      makeRow({ status: "UPCOMING", caseId: "case_1", encounterId: null }),
+    );
+    mockedPrisma.encounter.create.mockResolvedValue({ id: "enc_1" } as any);
+    mockedPrisma.appointment.update
+      .mockResolvedValueOnce({ id: "appt_1" } as any)
+      .mockResolvedValueOnce(
+        makeRow({
+          status: "CHECKED_IN",
+          caseId: "case_1",
+          encounterId: "enc_1",
+        }),
+      );
+    mockedPrisma.invoice.findMany.mockResolvedValue([]);
+
+    const result = await AppointmentPrismaService.checkInAppointment("appt_1");
+
+    expect(mockedPrisma.encounter.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          caseId: "case_1",
+          organisationId: "org_1",
+          companionId: "comp_1",
+          status: "arrived",
+          encounterClass: "IMP",
+        }),
+      }),
+    );
+    expect(mockedPrisma.appointment.update).toHaveBeenNthCalledWith(1, {
+      where: { id: "appt_1" },
+      data: {
+        caseId: "case_1",
+        encounterId: "enc_1",
+      },
+    });
+    expect(mockedPrisma.appointment.update).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        where: { id: "appt_1" },
+        data: expect.objectContaining({
+          status: "CHECKED_IN",
+          encounterId: "enc_1",
+        }),
+      }),
+    );
+    expect((result as any).encounterId).toBe("enc_1");
   });
 
   it("lists appointments for organisation with filters", async () => {

--- a/apps/backend/test/services/appointment.prisma.service.test.ts
+++ b/apps/backend/test/services/appointment.prisma.service.test.ts
@@ -43,6 +43,9 @@ jest.mock("../../src/config/prisma", () => ({
       create: jest.fn(),
       findUnique: jest.fn(),
     },
+    admission: {
+      upsert: jest.fn(),
+    },
     occupancy: {
       findFirst: jest.fn(),
       create: jest.fn(),
@@ -54,7 +57,7 @@ jest.mock("../../src/config/prisma", () => ({
   },
 }));
 
-const mockedPrisma = jest.mocked(prisma);
+const mockedPrisma = prisma as any;
 const mockedTypes = jest.requireMock("@yosemite-crew/types") as {
   fromAppointmentRequestDTO: jest.Mock;
   toAppointmentResponseDTO: jest.Mock;
@@ -152,6 +155,7 @@ describe("AppointmentPrismaService", () => {
     mockedPrisma.occupancy.findFirst.mockResolvedValue(null);
     mockedPrisma.occupancy.create.mockResolvedValue({} as any);
     mockedPrisma.occupancy.deleteMany.mockResolvedValue({ count: 1 } as any);
+    mockedPrisma.admission.upsert.mockResolvedValue({} as any);
   });
 
   it("creates a requested appointment with product validation", async () => {
@@ -366,6 +370,16 @@ describe("AppointmentPrismaService", () => {
         }),
       }),
     );
+    expect(mockedPrisma.admission.upsert).toHaveBeenCalledWith({
+      where: { encounterId: "enc_1" },
+      update: {},
+      create: {
+        encounterId: "enc_1",
+        organisationId: "org_1",
+        companionId: "comp_1",
+        admittedAt: baseDomain.startTime,
+      },
+    });
     expect((result as any).encounterId).toBe("enc_1");
   });
 

--- a/apps/backend/test/services/case-encounter.service.test.ts
+++ b/apps/backend/test/services/case-encounter.service.test.ts
@@ -503,4 +503,100 @@ describe("CaseEncounterService", () => {
     expect(result[0]?.unitId).toBe("unit_1");
     expect(result[1]?.releasedAt).toBeUndefined();
   });
+
+  it("lists active inpatient encounters for an organisation", async () => {
+    mockedPrisma.admission.findMany.mockResolvedValueOnce([
+      {
+        encounterId: "enc_1",
+        organisationId: "org_1",
+        companionId: "comp_1",
+        unitId: "unit_1",
+        expectedStayDays: null,
+        admittedAt: new Date("2026-06-11T10:30:00.000Z"),
+        dischargedAt: null,
+        createdAt: new Date("2026-06-11T10:30:00.000Z"),
+        updatedAt: new Date("2026-06-11T10:30:00.000Z"),
+      },
+      {
+        encounterId: "enc_2",
+        organisationId: "org_1",
+        companionId: "comp_2",
+        unitId: "unit_2",
+        expectedStayDays: 3,
+        admittedAt: new Date("2026-06-11T11:00:00.000Z"),
+        dischargedAt: null,
+        createdAt: new Date("2026-06-11T11:00:00.000Z"),
+        updatedAt: new Date("2026-06-11T11:00:00.000Z"),
+      },
+    ] as never);
+    mockedPrisma.encounter.findMany.mockResolvedValue([
+      {
+        ...baseEncounterRow,
+        id: "enc_1",
+        status: "arrived",
+        periodStart: new Date("2026-06-11T10:30:00.000Z"),
+      },
+      {
+        ...baseEncounterRow,
+        id: "enc_2",
+        status: "in-progress",
+        periodStart: new Date("2026-06-11T11:00:00.000Z"),
+      },
+    ] as never);
+    mockedPrisma.appointment.findMany.mockResolvedValue([
+      { id: "appt_1", encounterId: "enc_1" },
+      { id: "appt_2", encounterId: "enc_2" },
+    ] as never);
+    mockedPrisma.admission.findMany.mockResolvedValueOnce([
+      {
+        encounterId: "enc_1",
+        organisationId: "org_1",
+        companionId: "comp_1",
+        unitId: "unit_1",
+        expectedStayDays: null,
+        admittedAt: new Date("2026-06-11T10:30:00.000Z"),
+        dischargedAt: null,
+        createdAt: new Date("2026-06-11T10:30:00.000Z"),
+        updatedAt: new Date("2026-06-11T10:30:00.000Z"),
+      },
+      {
+        encounterId: "enc_2",
+        organisationId: "org_1",
+        companionId: "comp_2",
+        unitId: "unit_2",
+        expectedStayDays: 3,
+        admittedAt: new Date("2026-06-11T11:00:00.000Z"),
+        dischargedAt: null,
+        createdAt: new Date("2026-06-11T11:00:00.000Z"),
+        updatedAt: new Date("2026-06-11T11:00:00.000Z"),
+      },
+    ] as never);
+
+    const result = await CaseEncounterService.listActiveInpatientEncounters({
+      organisationId: "org_1",
+    });
+
+    expect(mockedPrisma.admission.findMany).toHaveBeenNthCalledWith(1, {
+      where: {
+        organisationId: "org_1",
+        dischargedAt: null,
+      },
+    });
+    expect(mockedPrisma.encounter.findMany).toHaveBeenCalledWith({
+      where: {
+        id: {
+          in: ["enc_1", "enc_2"],
+        },
+        organisationId: "org_1",
+        appointmentKind: "INPATIENT",
+        status: {
+          in: ["arrived", "triaged", "in-progress", "onleave"],
+        },
+      },
+      orderBy: { periodStart: "asc" },
+    });
+    expect(result).toHaveLength(2);
+    expect(result[0]?.appointmentId).toBe("appt_1");
+    expect(result[0]?.admission?.unitId).toBe("unit_1");
+  });
 });

--- a/apps/backend/test/services/case-encounter.service.test.ts
+++ b/apps/backend/test/services/case-encounter.service.test.ts
@@ -31,6 +31,7 @@ jest.mock("../../src/config/prisma", () => ({
     },
     roomUnitAssignment: {
       findFirst: jest.fn(),
+      findMany: jest.fn(),
       update: jest.fn(),
       create: jest.fn(),
     },
@@ -404,5 +405,102 @@ describe("CaseEncounterService", () => {
       },
     });
     expect(result.admission?.unitId).toBe("unit_1");
+  });
+
+  it("rejects assignment when the unit is already occupied by another admission", async () => {
+    mockedPrisma.encounter.findUnique.mockResolvedValue(
+      baseEncounterRow as never,
+    );
+    mockedPrisma.admission.findUnique.mockResolvedValue({
+      encounterId: "enc_1",
+      organisationId: "org_1",
+      companionId: "comp_1",
+      unitId: null,
+      expectedStayDays: null,
+      admittedAt: new Date("2026-06-11T10:30:00.000Z"),
+      dischargedAt: null,
+      createdAt: new Date("2026-06-11T10:30:00.000Z"),
+      updatedAt: new Date("2026-06-11T10:30:00.000Z"),
+    } as never);
+    mockedPrisma.roomUnit.findUnique.mockResolvedValue({
+      id: "unit_1",
+      organisationId: "org_1",
+      roomId: "room_1",
+      code: "KEN-01",
+      displayName: "Kennel 1",
+      size: "M",
+      speciesConstraints: ["dog"],
+      isActive: true,
+      createdAt: new Date("2026-06-11T10:00:00.000Z"),
+      updatedAt: new Date("2026-06-11T10:00:00.000Z"),
+    } as never);
+    mockedPrisma.roomUnitAssignment.findFirst.mockResolvedValue({
+      id: "assign_other",
+      encounterId: "enc_other",
+      admissionId: "enc_other",
+      unitId: "unit_1",
+      assignedAt: new Date("2026-06-11T10:45:00.000Z"),
+      releasedAt: null,
+      assignedBy: "user_2",
+      reason: "Occupied",
+      createdAt: new Date("2026-06-11T10:45:00.000Z"),
+      updatedAt: new Date("2026-06-11T10:45:00.000Z"),
+    } as never);
+
+    await expect(
+      CaseEncounterService.assignUnit("enc_1", {
+        unitId: "unit_1",
+        assignedAt: new Date("2026-06-11T11:00:00.000Z"),
+      }),
+    ).rejects.toMatchObject({
+      message: "Room unit is already occupied.",
+      statusCode: 409,
+    } satisfies Partial<CaseEncounterServiceError>);
+  });
+
+  it("lists unit assignment history for an encounter", async () => {
+    mockedPrisma.roomUnitAssignment.findMany.mockResolvedValue([
+      {
+        id: "assign_1",
+        encounterId: "enc_1",
+        admissionId: "enc_1",
+        unitId: "unit_1",
+        assignedAt: new Date("2026-06-11T11:00:00.000Z"),
+        releasedAt: new Date("2026-06-11T12:00:00.000Z"),
+        assignedBy: "user_1",
+        reason: "Transfer",
+        createdAt: new Date("2026-06-11T11:00:00.000Z"),
+        updatedAt: new Date("2026-06-11T12:00:00.000Z"),
+      },
+      {
+        id: "assign_2",
+        encounterId: "enc_1",
+        admissionId: "enc_1",
+        unitId: "unit_2",
+        assignedAt: new Date("2026-06-11T12:15:00.000Z"),
+        releasedAt: null,
+        assignedBy: "user_1",
+        reason: null,
+        createdAt: new Date("2026-06-11T12:15:00.000Z"),
+        updatedAt: new Date("2026-06-11T12:15:00.000Z"),
+      },
+    ] as never);
+
+    const result = await CaseEncounterService.listUnitAssignments({
+      encounterId: "enc_1",
+    });
+
+    expect(mockedPrisma.roomUnitAssignment.findMany).toHaveBeenCalledWith({
+      where: {
+        encounterId: "enc_1",
+        admissionId: undefined,
+        unitId: undefined,
+        releasedAt: undefined,
+      },
+      orderBy: { assignedAt: "asc" },
+    });
+    expect(result).toHaveLength(2);
+    expect(result[0]?.unitId).toBe("unit_1");
+    expect(result[1]?.releasedAt).toBeUndefined();
   });
 });

--- a/apps/backend/test/services/case-encounter.service.test.ts
+++ b/apps/backend/test/services/case-encounter.service.test.ts
@@ -27,7 +27,9 @@ jest.mock("../../src/config/prisma", () => ({
       update: jest.fn(),
     },
     admission: {
+      findUnique: jest.fn(),
       findMany: jest.fn(),
+      update: jest.fn(),
     },
   },
 }));
@@ -254,5 +256,68 @@ describe("CaseEncounterService", () => {
     expect(results).toHaveLength(2);
     expect(results[0]?.appointmentId).toBe("appt_1");
     expect(results[1]?.appointmentId).toBe("appt_2");
+  });
+
+  it("discharges an inpatient encounter and closes admission", async () => {
+    mockedPrisma.encounter.findUnique.mockResolvedValue(
+      baseEncounterRow as never,
+    );
+    mockedPrisma.admission.findUnique.mockResolvedValue({
+      encounterId: "enc_1",
+      organisationId: "org_1",
+      companionId: "comp_1",
+      bedUnitId: null,
+      expectedStayDays: null,
+      admittedAt: new Date("2026-06-11T10:30:00.000Z"),
+      dischargedAt: null,
+      createdAt: new Date("2026-06-11T10:30:00.000Z"),
+      updatedAt: new Date("2026-06-11T10:30:00.000Z"),
+    } as never);
+    mockedPrisma.admission.update.mockResolvedValue({
+      encounterId: "enc_1",
+    } as never);
+    mockedPrisma.encounter.update.mockResolvedValue({
+      ...baseEncounterRow,
+      status: "finished",
+      periodEnd: new Date("2026-06-11T12:00:00.000Z"),
+    } as never);
+    mockedPrisma.appointment.findMany.mockResolvedValue([
+      { id: "appt_1", encounterId: "enc_1" },
+    ] as never);
+    mockedPrisma.admission.findMany.mockResolvedValue([
+      {
+        encounterId: "enc_1",
+        organisationId: "org_1",
+        companionId: "comp_1",
+        bedUnitId: null,
+        expectedStayDays: null,
+        admittedAt: new Date("2026-06-11T10:30:00.000Z"),
+        dischargedAt: new Date("2026-06-11T12:00:00.000Z"),
+        createdAt: new Date("2026-06-11T10:30:00.000Z"),
+        updatedAt: new Date("2026-06-11T12:00:00.000Z"),
+      },
+    ] as never);
+
+    const result = await CaseEncounterService.dischargeEncounter("enc_1", {
+      dischargedAt: new Date("2026-06-11T12:00:00.000Z"),
+    });
+
+    expect(mockedPrisma.admission.update).toHaveBeenCalledWith({
+      where: { encounterId: "enc_1" },
+      data: {
+        dischargedAt: new Date("2026-06-11T12:00:00.000Z"),
+      },
+    });
+    expect(mockedPrisma.encounter.update).toHaveBeenCalledWith({
+      where: { id: "enc_1" },
+      data: {
+        status: "finished",
+        periodEnd: new Date("2026-06-11T12:00:00.000Z"),
+      },
+    });
+    expect(result.status).toBe("finished");
+    expect(result.admission?.dischargedAt?.toISOString()).toBe(
+      "2026-06-11T12:00:00.000Z",
+    );
   });
 });

--- a/apps/backend/test/services/case-encounter.service.test.ts
+++ b/apps/backend/test/services/case-encounter.service.test.ts
@@ -26,6 +26,9 @@ jest.mock("../../src/config/prisma", () => ({
       findMany: jest.fn(),
       update: jest.fn(),
     },
+    admission: {
+      findMany: jest.fn(),
+    },
   },
 }));
 
@@ -67,6 +70,7 @@ describe("CaseEncounterService", () => {
     mockedPrisma.$transaction.mockImplementation(async (callback: any) =>
       callback(mockedPrisma),
     );
+    mockedPrisma.admission.findMany.mockResolvedValue([] as never);
   });
 
   it("creates a case", async () => {
@@ -212,11 +216,25 @@ describe("CaseEncounterService", () => {
     mockedPrisma.appointment.findMany.mockResolvedValue([
       { id: "appt_1", encounterId: "enc_1" },
     ] as never);
+    mockedPrisma.admission.findMany.mockResolvedValue([
+      {
+        encounterId: "enc_1",
+        organisationId: "org_1",
+        companionId: "comp_1",
+        bedUnitId: null,
+        expectedStayDays: null,
+        admittedAt: new Date("2026-06-11T10:30:00.000Z"),
+        dischargedAt: null,
+        createdAt: new Date("2026-06-11T10:30:00.000Z"),
+        updatedAt: new Date("2026-06-11T10:30:00.000Z"),
+      },
+    ] as never);
 
     const result = await CaseEncounterService.getEncounterById("enc_1");
 
     expect(result.id).toBe("enc_1");
     expect(result.appointmentId).toBe("appt_1");
+    expect(result.admission?.encounterId).toBe("enc_1");
   });
 
   it("lists encounters with linked appointment ids", async () => {

--- a/apps/backend/test/services/case-encounter.service.test.ts
+++ b/apps/backend/test/services/case-encounter.service.test.ts
@@ -29,6 +29,12 @@ jest.mock("../../src/config/prisma", () => ({
     roomUnit: {
       findUnique: jest.fn(),
     },
+    roomUnitGroup: {
+      findUnique: jest.fn(),
+    },
+    companion: {
+      findUnique: jest.fn(),
+    },
     roomUnitAssignment: {
       findFirst: jest.fn(),
       findMany: jest.fn(),
@@ -81,6 +87,12 @@ describe("CaseEncounterService", () => {
     mockedPrisma.$transaction.mockImplementation(async (callback: any) =>
       callback(mockedPrisma),
     );
+    mockedPrisma.companion.findUnique.mockResolvedValue({
+      id: "comp_1",
+      type: "dog",
+      speciesCode: "canislf",
+    } as never);
+    mockedPrisma.roomUnitGroup.findUnique.mockResolvedValue(null);
     mockedPrisma.admission.findMany.mockResolvedValue([] as never);
   });
 
@@ -379,6 +391,11 @@ describe("CaseEncounterService", () => {
       createdAt: new Date("2026-06-11T10:00:00.000Z"),
       updatedAt: new Date("2026-06-11T10:00:00.000Z"),
     } as never);
+    mockedPrisma.companion.findUnique.mockResolvedValue({
+      id: "comp_1",
+      type: "dog",
+      speciesCode: "canislf",
+    } as never);
     mockedPrisma.roomUnitAssignment.findFirst.mockResolvedValue(null as never);
     mockedPrisma.roomUnitAssignment.create.mockResolvedValue({
       id: "assign_1",
@@ -427,6 +444,107 @@ describe("CaseEncounterService", () => {
       },
     });
     expect(result.admission?.unitId).toBe("unit_1");
+  });
+
+  it("rejects assignment when the unit species constraints do not match", async () => {
+    mockedPrisma.encounter.findUnique.mockResolvedValue(
+      baseEncounterRow as never,
+    );
+    mockedPrisma.admission.findUnique.mockResolvedValue({
+      encounterId: "enc_1",
+      organisationId: "org_1",
+      companionId: "comp_1",
+      unitId: null,
+      expectedStayDays: null,
+      admittedAt: new Date("2026-06-11T10:30:00.000Z"),
+      dischargedAt: null,
+      createdAt: new Date("2026-06-11T10:30:00.000Z"),
+      updatedAt: new Date("2026-06-11T10:30:00.000Z"),
+    } as never);
+    mockedPrisma.roomUnit.findUnique.mockResolvedValue({
+      id: "unit_1",
+      organisationId: "org_1",
+      roomId: "room_1",
+      code: "KEN-01",
+      displayName: "Kennel 1",
+      size: "M",
+      speciesConstraints: ["cat"],
+      isActive: true,
+      createdAt: new Date("2026-06-11T10:00:00.000Z"),
+      updatedAt: new Date("2026-06-11T10:00:00.000Z"),
+    } as never);
+    mockedPrisma.companion.findUnique.mockResolvedValue({
+      id: "comp_1",
+      type: "dog",
+      speciesCode: "canislf",
+    } as never);
+
+    await expect(
+      CaseEncounterService.assignUnit("enc_1", {
+        unitId: "unit_1",
+        assignedAt: new Date("2026-06-11T11:00:00.000Z"),
+      }),
+    ).rejects.toMatchObject({
+      message: "Room unit is not compatible with this companion's species.",
+      statusCode: 409,
+    });
+  });
+
+  it("rejects assignment when the unit group species constraints do not match", async () => {
+    mockedPrisma.encounter.findUnique.mockResolvedValue(
+      baseEncounterRow as never,
+    );
+    mockedPrisma.admission.findUnique.mockResolvedValue({
+      encounterId: "enc_1",
+      organisationId: "org_1",
+      companionId: "comp_1",
+      unitId: null,
+      expectedStayDays: null,
+      admittedAt: new Date("2026-06-11T10:30:00.000Z"),
+      dischargedAt: null,
+      createdAt: new Date("2026-06-11T10:30:00.000Z"),
+      updatedAt: new Date("2026-06-11T10:30:00.000Z"),
+    } as never);
+    mockedPrisma.roomUnit.findUnique.mockResolvedValue({
+      id: "unit_1",
+      organisationId: "org_1",
+      roomId: "room_1",
+      unitGroupId: "group_1",
+      code: "KEN-01",
+      displayName: "Kennel 1",
+      size: "M",
+      speciesConstraints: ["dog"],
+      isActive: true,
+      createdAt: new Date("2026-06-11T10:00:00.000Z"),
+      updatedAt: new Date("2026-06-11T10:00:00.000Z"),
+    } as never);
+    mockedPrisma.roomUnitGroup.findUnique.mockResolvedValue({
+      id: "group_1",
+      organisationId: "org_1",
+      roomId: "room_1",
+      name: "Cat ward",
+      size: "M",
+      unitCount: 2,
+      speciesConstraints: ["cat"],
+      capabilities: [],
+      isActive: true,
+    } as never);
+    mockedPrisma.companion.findUnique.mockResolvedValue({
+      id: "comp_1",
+      type: "dog",
+      speciesCode: "canislf",
+    } as never);
+
+    await expect(
+      CaseEncounterService.assignUnit("enc_1", {
+        unitId: "unit_1",
+        assignedAt: new Date("2026-06-11T11:00:00.000Z"),
+      }),
+    ).rejects.toMatchObject({
+      message:
+        "Room unit group is not compatible with this companion's species.",
+      statusCode: 409,
+    });
   });
 
   it("rejects assignment when the unit is already occupied by another admission", async () => {

--- a/apps/backend/test/services/case-encounter.service.test.ts
+++ b/apps/backend/test/services/case-encounter.service.test.ts
@@ -282,6 +282,21 @@ describe("CaseEncounterService", () => {
       createdAt: new Date("2026-06-11T10:30:00.000Z"),
       updatedAt: new Date("2026-06-11T10:30:00.000Z"),
     } as never);
+    mockedPrisma.roomUnitAssignment.findFirst.mockResolvedValue({
+      id: "assign_1",
+      encounterId: "enc_1",
+      admissionId: "enc_1",
+      unitId: "unit_1",
+      assignedAt: new Date("2026-06-11T11:00:00.000Z"),
+      releasedAt: null,
+      assignedBy: "user_1",
+      reason: "Monitoring",
+      createdAt: new Date("2026-06-11T11:00:00.000Z"),
+      updatedAt: new Date("2026-06-11T11:00:00.000Z"),
+    } as never);
+    mockedPrisma.roomUnitAssignment.update.mockResolvedValue({
+      id: "assign_1",
+    } as never);
     mockedPrisma.admission.update.mockResolvedValue({
       encounterId: "enc_1",
     } as never);
@@ -315,6 +330,13 @@ describe("CaseEncounterService", () => {
       where: { encounterId: "enc_1" },
       data: {
         dischargedAt: new Date("2026-06-11T12:00:00.000Z"),
+        unitId: null,
+      },
+    });
+    expect(mockedPrisma.roomUnitAssignment.update).toHaveBeenCalledWith({
+      where: { id: "assign_1" },
+      data: {
+        releasedAt: new Date("2026-06-11T12:00:00.000Z"),
       },
     });
     expect(mockedPrisma.encounter.update).toHaveBeenCalledWith({
@@ -502,6 +524,127 @@ describe("CaseEncounterService", () => {
     expect(result).toHaveLength(2);
     expect(result[0]?.unitId).toBe("unit_1");
     expect(result[1]?.releasedAt).toBeUndefined();
+  });
+
+  it("lists unit assignment history for an admission", async () => {
+    mockedPrisma.admission.findUnique.mockResolvedValue({
+      encounterId: "enc_1",
+      organisationId: "org_1",
+      companionId: "comp_1",
+      unitId: "unit_1",
+      expectedStayDays: null,
+      admittedAt: new Date("2026-06-11T10:30:00.000Z"),
+      dischargedAt: null,
+      createdAt: new Date("2026-06-11T10:30:00.000Z"),
+      updatedAt: new Date("2026-06-11T10:30:00.000Z"),
+    } as never);
+    mockedPrisma.roomUnitAssignment.findMany.mockResolvedValue([
+      {
+        id: "assign_1",
+        encounterId: "enc_1",
+        admissionId: "enc_1",
+        unitId: "unit_1",
+        assignedAt: new Date("2026-06-11T11:00:00.000Z"),
+        releasedAt: null,
+        assignedBy: "user_1",
+        reason: "Transfer",
+        createdAt: new Date("2026-06-11T11:00:00.000Z"),
+        updatedAt: new Date("2026-06-11T11:00:00.000Z"),
+      },
+    ] as never);
+
+    const result =
+      await CaseEncounterService.listAdmissionUnitAssignments("enc_1");
+
+    expect(mockedPrisma.admission.findUnique).toHaveBeenCalledWith({
+      where: { encounterId: "enc_1" },
+    });
+    expect(mockedPrisma.roomUnitAssignment.findMany).toHaveBeenCalledWith({
+      where: {
+        admissionId: "enc_1",
+      },
+      orderBy: { assignedAt: "asc" },
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]?.admissionId).toBe("enc_1");
+  });
+
+  it("starts an encounter and keeps the original periodStart when present", async () => {
+    mockedPrisma.encounter.findUnique.mockResolvedValue({
+      ...baseEncounterRow,
+      status: "arrived",
+    } as never);
+    mockedPrisma.encounter.update.mockResolvedValue({
+      ...baseEncounterRow,
+      status: "in-progress",
+    } as never);
+    mockedPrisma.appointment.findMany.mockResolvedValue([
+      { id: "appt_1", encounterId: "enc_1" },
+    ] as never);
+    mockedPrisma.admission.findMany.mockResolvedValue([
+      {
+        encounterId: "enc_1",
+        organisationId: "org_1",
+        companionId: "comp_1",
+        unitId: "unit_1",
+        expectedStayDays: null,
+        admittedAt: new Date("2026-06-11T10:30:00.000Z"),
+        dischargedAt: null,
+        createdAt: new Date("2026-06-11T10:30:00.000Z"),
+        updatedAt: new Date("2026-06-11T10:30:00.000Z"),
+      },
+    ] as never);
+
+    const result = await CaseEncounterService.startEncounter("enc_1", {
+      startedAt: new Date("2026-06-11T12:00:00.000Z"),
+    });
+
+    expect(mockedPrisma.encounter.update).toHaveBeenCalledWith({
+      where: { id: "enc_1" },
+      data: {
+        status: "in-progress",
+        periodStart: new Date("2026-06-11T10:30:00.000Z"),
+      },
+    });
+    expect(result.status).toBe("in-progress");
+  });
+
+  it("marks an encounter ready for discharge", async () => {
+    mockedPrisma.encounter.findUnique.mockResolvedValue({
+      ...baseEncounterRow,
+      status: "in-progress",
+    } as never);
+    mockedPrisma.encounter.update.mockResolvedValue({
+      ...baseEncounterRow,
+      status: "onleave",
+    } as never);
+    mockedPrisma.appointment.findMany.mockResolvedValue([
+      { id: "appt_1", encounterId: "enc_1" },
+    ] as never);
+    mockedPrisma.admission.findMany.mockResolvedValue([
+      {
+        encounterId: "enc_1",
+        organisationId: "org_1",
+        companionId: "comp_1",
+        unitId: "unit_1",
+        expectedStayDays: null,
+        admittedAt: new Date("2026-06-11T10:30:00.000Z"),
+        dischargedAt: null,
+        createdAt: new Date("2026-06-11T10:30:00.000Z"),
+        updatedAt: new Date("2026-06-11T10:30:00.000Z"),
+      },
+    ] as never);
+
+    const result =
+      await CaseEncounterService.markEncounterReadyForDischarge("enc_1");
+
+    expect(mockedPrisma.encounter.update).toHaveBeenCalledWith({
+      where: { id: "enc_1" },
+      data: {
+        status: "onleave",
+      },
+    });
+    expect(result.status).toBe("onleave");
   });
 
   it("lists active inpatient encounters for an organisation", async () => {

--- a/apps/backend/test/services/case-encounter.service.test.ts
+++ b/apps/backend/test/services/case-encounter.service.test.ts
@@ -26,6 +26,14 @@ jest.mock("../../src/config/prisma", () => ({
       findMany: jest.fn(),
       update: jest.fn(),
     },
+    roomUnit: {
+      findUnique: jest.fn(),
+    },
+    roomUnitAssignment: {
+      findFirst: jest.fn(),
+      update: jest.fn(),
+      create: jest.fn(),
+    },
     admission: {
       findUnique: jest.fn(),
       findMany: jest.fn(),
@@ -319,5 +327,82 @@ describe("CaseEncounterService", () => {
     expect(result.admission?.dischargedAt?.toISOString()).toBe(
       "2026-06-11T12:00:00.000Z",
     );
+  });
+
+  it("assigns a unit to an active admission", async () => {
+    mockedPrisma.encounter.findUnique.mockResolvedValue(
+      baseEncounterRow as never,
+    );
+    mockedPrisma.admission.findUnique.mockResolvedValue({
+      encounterId: "enc_1",
+      organisationId: "org_1",
+      companionId: "comp_1",
+      unitId: null,
+      expectedStayDays: null,
+      admittedAt: new Date("2026-06-11T10:30:00.000Z"),
+      dischargedAt: null,
+      createdAt: new Date("2026-06-11T10:30:00.000Z"),
+      updatedAt: new Date("2026-06-11T10:30:00.000Z"),
+    } as never);
+    mockedPrisma.roomUnit.findUnique.mockResolvedValue({
+      id: "unit_1",
+      organisationId: "org_1",
+      roomId: "room_1",
+      code: "KEN-01",
+      displayName: "Kennel 1",
+      size: "M",
+      speciesConstraints: ["dog"],
+      isActive: true,
+      createdAt: new Date("2026-06-11T10:00:00.000Z"),
+      updatedAt: new Date("2026-06-11T10:00:00.000Z"),
+    } as never);
+    mockedPrisma.roomUnitAssignment.findFirst.mockResolvedValue(null as never);
+    mockedPrisma.roomUnitAssignment.create.mockResolvedValue({
+      id: "assign_1",
+    } as never);
+    mockedPrisma.admission.update.mockResolvedValue({
+      encounterId: "enc_1",
+    } as never);
+    mockedPrisma.appointment.findMany.mockResolvedValue([
+      { id: "appt_1", encounterId: "enc_1" },
+    ] as never);
+    mockedPrisma.admission.findMany.mockResolvedValue([
+      {
+        encounterId: "enc_1",
+        organisationId: "org_1",
+        companionId: "comp_1",
+        unitId: "unit_1",
+        expectedStayDays: null,
+        admittedAt: new Date("2026-06-11T10:30:00.000Z"),
+        dischargedAt: null,
+        createdAt: new Date("2026-06-11T10:30:00.000Z"),
+        updatedAt: new Date("2026-06-11T11:00:00.000Z"),
+      },
+    ] as never);
+
+    const result = await CaseEncounterService.assignUnit("enc_1", {
+      unitId: "unit_1",
+      assignedBy: "user_1",
+      reason: "Post-op monitoring",
+      assignedAt: new Date("2026-06-11T11:00:00.000Z"),
+    });
+
+    expect(mockedPrisma.roomUnitAssignment.create).toHaveBeenCalledWith({
+      data: {
+        encounterId: "enc_1",
+        admissionId: "enc_1",
+        unitId: "unit_1",
+        assignedAt: new Date("2026-06-11T11:00:00.000Z"),
+        assignedBy: "user_1",
+        reason: "Post-op monitoring",
+      },
+    });
+    expect(mockedPrisma.admission.update).toHaveBeenCalledWith({
+      where: { encounterId: "enc_1" },
+      data: {
+        unitId: "unit_1",
+      },
+    });
+    expect(result.admission?.unitId).toBe("unit_1");
   });
 });

--- a/apps/backend/test/services/case-encounter.service.test.ts
+++ b/apps/backend/test/services/case-encounter.service.test.ts
@@ -1,0 +1,240 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import {
+  CaseEncounterService,
+  CaseEncounterServiceError,
+} from "../../src/services/case-encounter.service";
+import { prisma } from "../../src/config/prisma";
+
+jest.mock("../../src/config/prisma", () => ({
+  prisma: {
+    $transaction: jest.fn(),
+    case: {
+      create: jest.fn(),
+      findUnique: jest.fn(),
+      findMany: jest.fn(),
+      update: jest.fn(),
+    },
+    encounter: {
+      create: jest.fn(),
+      findUnique: jest.fn(),
+      findMany: jest.fn(),
+      update: jest.fn(),
+    },
+    appointment: {
+      findUnique: jest.fn(),
+      findFirst: jest.fn(),
+      findMany: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}));
+
+const mockedPrisma = prisma as any;
+
+const baseCaseRow = {
+  id: "case_1",
+  organisationId: "org_1",
+  companionId: "comp_1",
+  parentId: "parent_1",
+  status: "active",
+  appointmentKind: "INPATIENT" as const,
+  title: "Case title",
+  description: "Case description",
+  createdAt: new Date("2026-06-11T10:00:00.000Z"),
+  updatedAt: new Date("2026-06-11T10:00:00.000Z"),
+};
+
+const baseEncounterRow = {
+  id: "enc_1",
+  caseId: "case_1",
+  organisationId: "org_1",
+  companionId: "comp_1",
+  parentId: "parent_1",
+  status: "planned",
+  encounterClass: "IMP",
+  appointmentKind: "INPATIENT" as const,
+  title: "Admission encounter",
+  reason: "Observation",
+  periodStart: new Date("2026-06-11T10:30:00.000Z"),
+  periodEnd: new Date("2026-06-11T11:00:00.000Z"),
+  createdAt: new Date("2026-06-11T10:00:00.000Z"),
+  updatedAt: new Date("2026-06-11T10:00:00.000Z"),
+};
+
+describe("CaseEncounterService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedPrisma.$transaction.mockImplementation(async (callback: any) =>
+      callback(mockedPrisma),
+    );
+  });
+
+  it("creates a case", async () => {
+    mockedPrisma.case.create.mockResolvedValue(baseCaseRow as never);
+
+    const result = await CaseEncounterService.createCase({
+      organisationId: "org_1",
+      companionId: "comp_1",
+      parentId: "parent_1",
+      status: "active",
+      appointmentKind: "INPATIENT",
+      title: "Case title",
+      description: "Case description",
+    });
+
+    expect(mockedPrisma.case.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        organisationId: "org_1",
+        companionId: "comp_1",
+        status: "active",
+        appointmentKind: "INPATIENT",
+      }),
+    });
+    expect(result.id).toBe("case_1");
+  });
+
+  it("creates an encounter and links the appointment", async () => {
+    mockedPrisma.case.findUnique.mockResolvedValue(baseCaseRow as never);
+    mockedPrisma.appointment.findUnique.mockResolvedValue({
+      id: "appt_1",
+      caseId: null,
+      encounterId: null,
+      organisationId: "org_1",
+      companion: { id: "comp_1" },
+    } as never);
+    mockedPrisma.encounter.create.mockResolvedValue(baseEncounterRow as never);
+    mockedPrisma.appointment.update.mockResolvedValue({
+      id: "appt_1",
+    } as never);
+
+    const result = await CaseEncounterService.createEncounter({
+      caseId: "case_1",
+      appointmentId: "appt_1",
+      organisationId: "org_1",
+      companionId: "comp_1",
+      parentId: "parent_1",
+      status: "planned",
+      encounterClass: "IMP",
+      appointmentKind: "INPATIENT",
+      title: "Admission encounter",
+      reason: "Observation",
+      periodStart: new Date("2026-06-11T10:30:00.000Z"),
+      periodEnd: new Date("2026-06-11T11:00:00.000Z"),
+    });
+
+    expect(mockedPrisma.encounter.create).toHaveBeenCalled();
+    expect(mockedPrisma.appointment.update).toHaveBeenCalledWith({
+      where: { id: "appt_1" },
+      data: {
+        caseId: "case_1",
+        encounterId: "enc_1",
+      },
+    });
+    expect(result.appointmentId).toBe("appt_1");
+  });
+
+  it("rejects encounter creation when appointment belongs to another companion", async () => {
+    mockedPrisma.case.findUnique.mockResolvedValue(baseCaseRow as never);
+    mockedPrisma.appointment.findUnique.mockResolvedValue({
+      id: "appt_1",
+      caseId: null,
+      encounterId: null,
+      organisationId: "org_1",
+      companion: { id: "comp_2" },
+    } as never);
+
+    await expect(
+      CaseEncounterService.createEncounter({
+        caseId: "case_1",
+        appointmentId: "appt_1",
+        organisationId: "org_1",
+        companionId: "comp_1",
+        status: "planned",
+        encounterClass: "IMP",
+        appointmentKind: "INPATIENT",
+      }),
+    ).rejects.toMatchObject({
+      message: "Encounter appointment companion mismatch.",
+      statusCode: 409,
+    } satisfies Partial<CaseEncounterServiceError>);
+  });
+
+  it("updates an encounter and re-links the appointment", async () => {
+    mockedPrisma.encounter.findUnique.mockResolvedValue(
+      baseEncounterRow as never,
+    );
+    mockedPrisma.appointment.findFirst.mockResolvedValue({
+      id: "appt_old",
+      caseId: "case_1",
+      encounterId: "enc_1",
+      organisationId: "org_1",
+      companion: { id: "comp_1" },
+    } as never);
+    mockedPrisma.appointment.findUnique.mockResolvedValue({
+      id: "appt_new",
+      caseId: "case_1",
+      encounterId: null,
+      organisationId: "org_1",
+      companion: { id: "comp_1" },
+    } as never);
+    mockedPrisma.encounter.update.mockResolvedValue({
+      ...baseEncounterRow,
+      status: "arrived",
+    } as never);
+    mockedPrisma.appointment.findMany.mockResolvedValue([
+      { id: "appt_new", encounterId: "enc_1" },
+    ] as never);
+
+    const result = await CaseEncounterService.updateEncounter("enc_1", {
+      appointmentId: "appt_new",
+      status: "arrived",
+    });
+
+    expect(mockedPrisma.appointment.update).toHaveBeenNthCalledWith(1, {
+      where: { id: "appt_old" },
+      data: { encounterId: null },
+    });
+    expect(mockedPrisma.appointment.update).toHaveBeenNthCalledWith(2, {
+      where: { id: "appt_new" },
+      data: {
+        caseId: "case_1",
+        encounterId: "enc_1",
+      },
+    });
+    expect(result.status).toBe("arrived");
+    expect(result.appointmentId).toBe("appt_new");
+  });
+
+  it("gets an encounter with its linked appointment id", async () => {
+    mockedPrisma.encounter.findUnique.mockResolvedValue(
+      baseEncounterRow as never,
+    );
+    mockedPrisma.appointment.findMany.mockResolvedValue([
+      { id: "appt_1", encounterId: "enc_1" },
+    ] as never);
+
+    const result = await CaseEncounterService.getEncounterById("enc_1");
+
+    expect(result.id).toBe("enc_1");
+    expect(result.appointmentId).toBe("appt_1");
+  });
+
+  it("lists encounters with linked appointment ids", async () => {
+    mockedPrisma.encounter.findMany.mockResolvedValue([
+      baseEncounterRow,
+      { ...baseEncounterRow, id: "enc_2", caseId: "case_2" },
+    ] as never);
+    mockedPrisma.appointment.findMany.mockResolvedValue([
+      { id: "appt_1", encounterId: "enc_1" },
+      { id: "appt_2", encounterId: "enc_2" },
+    ] as never);
+
+    const results = await CaseEncounterService.listEncounters({
+      organisationId: "org_1",
+    });
+
+    expect(results).toHaveLength(2);
+    expect(results[0]?.appointmentId).toBe("appt_1");
+    expect(results[1]?.appointmentId).toBe("appt_2");
+  });
+});

--- a/apps/backend/test/services/catalog.service.test.ts
+++ b/apps/backend/test/services/catalog.service.test.ts
@@ -46,9 +46,11 @@ jest.mock("../../src/config/prisma", () => ({
     },
     appointment: {
       count: jest.fn(),
+      findMany: jest.fn(),
     },
     invoice: {
       findMany: jest.fn(),
+      count: jest.fn(),
     },
     inventoryItem: {
       findMany: jest.fn(),
@@ -66,7 +68,9 @@ describe("CatalogService", () => {
       id: "spec_1",
     });
     (prisma.appointment.count as jest.Mock).mockResolvedValue(0);
+    (prisma.appointment.findMany as jest.Mock).mockResolvedValue([]);
     (prisma.invoice.findMany as jest.Mock).mockResolvedValue([]);
+    (prisma.invoice.count as jest.Mock).mockResolvedValue(0);
     (prisma.productPackageItem.findFirst as jest.Mock).mockResolvedValue(null);
     (prisma.productItem.findFirst as jest.Mock).mockImplementation(
       (args?: { where?: { code?: string; id?: string } }) => {
@@ -1441,7 +1445,9 @@ describe("CatalogService", () => {
     });
     (prisma.productItem.findMany as jest.Mock).mockResolvedValue([]);
     (prisma.appointment.count as jest.Mock).mockResolvedValue(0);
+    (prisma.appointment.findMany as jest.Mock).mockResolvedValue([]);
     (prisma.invoice.findMany as jest.Mock).mockResolvedValue([]);
+    (prisma.invoice.count as jest.Mock).mockResolvedValue(0);
     (prisma.speciality.update as jest.Mock)
       .mockResolvedValueOnce({ id: "spec_1", isActive: false })
       .mockResolvedValueOnce({ id: "spec_1", isActive: true });
@@ -1455,6 +1461,21 @@ describe("CatalogService", () => {
       where: { organisationId: "org_1", specialityId: "spec_1" },
       data: { isActive: false },
     });
+    expect(prisma.speciality.delete).toHaveBeenCalledWith({
+      where: { id: "spec_1" },
+    });
+  });
+
+  it("allows speciality deletion when invoices are unrelated to the speciality", async () => {
+    (prisma.productItem.findMany as jest.Mock).mockResolvedValue([]);
+    (prisma.appointment.count as jest.Mock).mockResolvedValue(0);
+    (prisma.appointment.findMany as jest.Mock).mockResolvedValue([]);
+    (prisma.invoice.count as jest.Mock).mockResolvedValue(229);
+    (prisma.speciality.delete as jest.Mock).mockResolvedValue({ id: "spec_1" });
+
+    await CatalogService.deleteSpeciality("spec_1", "org_1");
+
+    expect(prisma.invoice.count).not.toHaveBeenCalled();
     expect(prisma.speciality.delete).toHaveBeenCalledWith({
       where: { id: "spec_1" },
     });

--- a/apps/backend/test/services/integration.service.test.ts
+++ b/apps/backend/test/services/integration.service.test.ts
@@ -2,6 +2,7 @@ import {
   IntegrationService,
   IntegrationServiceError,
 } from "../../src/services/integration.service";
+import IntegrationAccountModel from "../../src/models/integration-account";
 import { prisma } from "../../src/config/prisma";
 import { isReadFromPostgres } from "../../src/config/read-switch";
 import { getIntegrationAdapter } from "../../src/integrations";
@@ -23,6 +24,23 @@ jest.mock("../../src/config/prisma", () => ({
   },
 }));
 
+jest.mock("../../src/models/integration-account", () => {
+  const ctor: any = jest.fn().mockImplementation((doc) => ({
+    ...doc,
+    save: jest.fn().mockResolvedValue(undefined),
+    toJSON: jest.fn().mockImplementation(() => ({ ...doc, id: "mongo-id" })),
+  }));
+  ctor.findOne = jest.fn();
+  ctor.findMany = jest.fn();
+  ctor.find = jest.fn();
+  ctor.findOneAndUpdate = jest.fn();
+  ctor.updateOne = jest.fn();
+  return {
+    __esModule: true,
+    default: ctor,
+  };
+});
+
 jest.mock("../../src/integrations", () => {
   const actual = jest.requireActual("../../src/integrations");
   return {
@@ -34,6 +52,18 @@ jest.mock("../../src/integrations", () => {
 describe("IntegrationService", () => {
   const readSwitch = isReadFromPostgres as jest.Mock;
   const adapter = { validateCredentials: jest.fn() };
+  const mockedModel = IntegrationAccountModel as any;
+
+  const makeLeanQuery = (result: unknown): any => ({
+    setOptions: jest.fn().mockReturnThis(),
+    select: jest.fn().mockReturnThis(),
+    sort: jest.fn().mockReturnThis(),
+    lean: jest.fn().mockResolvedValue(result),
+  });
+
+  const makeDocQuery = (result: unknown): any => ({
+    setOptions: jest.fn().mockResolvedValue(result),
+  });
 
   beforeEach(() => {
     jest.restoreAllMocks();
@@ -41,6 +71,10 @@ describe("IntegrationService", () => {
     readSwitch.mockReturnValue(true);
     (getIntegrationAdapter as jest.Mock).mockReturnValue(adapter);
     adapter.validateCredentials.mockResolvedValue({ ok: true });
+    mockedModel.findOne.mockReturnValue(makeLeanQuery(null));
+    mockedModel.findMany.mockReturnValue(makeLeanQuery([]));
+    mockedModel.findOneAndUpdate.mockResolvedValue(null);
+    mockedModel.updateOne.mockResolvedValue({ acknowledged: true });
   });
 
   it("rejects unsupported providers", () => {
@@ -136,5 +170,88 @@ describe("IntegrationService", () => {
     await expect(
       IntegrationService.requireAccount("org-1", "IDEXX"),
     ).rejects.toThrow("Integration not found.");
+  });
+
+  it("rejects invalid organisation ids and blank providers", async () => {
+    expect(() => IntegrationService.ensureProvider("   ")).toThrow(
+      IntegrationServiceError,
+    );
+    await expect(
+      IntegrationService.listForOrganisation("bad.id"),
+    ).rejects.toThrow("Invalid organisationId.");
+  });
+
+  it("creates and lists merck accounts on the mongo path", async () => {
+    readSwitch.mockReturnValue(false);
+    mockedModel.find.mockReturnValue(
+      makeLeanQuery([{ provider: "IDEXX" } as any]),
+    );
+    mockedModel.findOne.mockReturnValueOnce(makeLeanQuery(null));
+    mockedModel.findOne.mockReturnValueOnce(
+      makeLeanQuery({
+        provider: "MERCK_MANUALS",
+      }),
+    );
+
+    const list = (await IntegrationService.listForOrganisation(
+      "org_1",
+    )) as any[];
+
+    expect(list.map((item) => item.provider)).toEqual([
+      "IDEXX",
+      "MERCK_MANUALS",
+    ]);
+    expect(mockedModel.find).toHaveBeenCalled();
+  });
+
+  it("upserts mongo credentials and marks account disabled before validation", async () => {
+    readSwitch.mockReturnValue(false);
+    mockedModel.findOneAndUpdate.mockResolvedValue({
+      organisationId: "org_1",
+      provider: "IDEXX",
+      status: "disabled",
+      toJSON: () => ({ id: "mongo-upsert" }),
+    });
+
+    const result = await IntegrationService.upsertCredentials(
+      "org_1",
+      "IDEXX",
+      { username: "u", password: "p" } as any,
+    );
+
+    expect(result).toEqual({ id: "mongo-upsert" });
+    expect(getIntegrationAdapter).toHaveBeenCalledWith("IDEXX");
+    expect(adapter.validateCredentials).toHaveBeenCalled();
+  });
+
+  it("creates merck accounts on the mongo path when enabling and disabling", async () => {
+    readSwitch.mockReturnValue(false);
+    mockedModel.findOne
+      .mockReturnValueOnce(makeDocQuery(null))
+      .mockReturnValueOnce(makeDocQuery(null));
+
+    const enabledMerck = await IntegrationService.setEnabled(
+      "org_1",
+      "MERCK_MANUALS",
+    );
+    const disabledMerck = await IntegrationService.setDisabled(
+      "org_1",
+      "MERCK_MANUALS",
+    );
+
+    expect(enabledMerck).toMatchObject({
+      provider: "MERCK_MANUALS",
+      status: "enabled",
+    });
+    expect(disabledMerck).toMatchObject({
+      provider: "MERCK_MANUALS",
+      status: "disabled",
+    });
+  });
+
+  it("short-circuits merck credential validation", async () => {
+    expect(
+      await IntegrationService.validateCredentials("org_1", "MERCK_MANUALS"),
+    ).toEqual({ ok: true });
   });
 });

--- a/apps/backend/test/services/merck.service.test.ts
+++ b/apps/backend/test/services/merck.service.test.ts
@@ -8,6 +8,12 @@ jest.mock("src/integrations/merck/merck.client", () => {
   };
 });
 
+jest.mock("src/services/integration.service", () => ({
+  IntegrationService: {
+    ensureMerckAccount: jest.fn(),
+  },
+}));
+
 jest.mock("src/utils/logger", () => ({
   __esModule: true,
   default: {
@@ -18,12 +24,16 @@ jest.mock("src/utils/logger", () => ({
 }));
 
 import { MerckService } from "src/services/merck.service";
+import { IntegrationService } from "src/services/integration.service";
 import logger from "src/utils/logger";
 
 const mockedLogger = jest.mocked(logger);
 
 describe("MerckService", () => {
   const originalEnv = process.env;
+  const mockedIntegrationService = IntegrationService as unknown as {
+    ensureMerckAccount: jest.Mock;
+  };
   const getSearchMock = () =>
     // jest.mock factory adds this field at runtime
     (jest.requireMock("src/integrations/merck/merck.client") as any)
@@ -36,6 +46,9 @@ describe("MerckService", () => {
       "https://merckvetmanual.com/infobutton/searchjson";
     process.env.MERCK_HEALTHLINK_USERNAME = "test-user";
     process.env.MERCK_HEALTHLINK_PASSWORD = "test-pass";
+    mockedIntegrationService.ensureMerckAccount.mockResolvedValue({
+      status: "enabled",
+    });
   });
 
   afterAll(() => {
@@ -86,5 +99,156 @@ describe("MerckService", () => {
     expect(serialized).not.toContain(LEAK_USER);
     expect(serialized).not.toContain(LEAK_PASS);
     expect(serialized).not.toContain("holder.assignedEntity");
+  });
+
+  it("validates required fields before searching", async () => {
+    await expect(
+      MerckService.searchConsumer({
+        query: "   ",
+        requestId: "req-2",
+      }),
+    ).rejects.toThrow("q is required.");
+  });
+
+  it("normalizes JSON feed payloads", async () => {
+    getSearchMock().mockResolvedValueOnce({
+      data: JSON.stringify({
+        feed: {
+          id: "feed-1",
+          updated: "2026-01-01T00:00:00Z",
+          category: [{ "@scheme": "informationrecipient", "@term": "PAT" }],
+          entry: [
+            {
+              id: "topic-1",
+              title: { "#text": "  Feline  Diabetes " },
+              summary: {
+                "#text":
+                  '<p>One <a href="https://merckvetmanual.com/topic-a">A</a> and <a href="https://merckvetmanual.com/topic-a/">dup</a></p>',
+              },
+              updated: "2026-01-02T00:00:00Z",
+              link: { "@href": "https://merckvetmanual.com/topic-a/" },
+            },
+          ],
+        },
+      }),
+      contentType: "application/json",
+      status: 200,
+      finalUrl: null,
+    });
+
+    const response = await MerckService.searchConsumer({
+      query: "feline diabetes",
+      requestId: "req-json",
+      timezone: "America/New_York",
+      media: "full",
+      code: "1234",
+      codeSystem: "ICD10CM",
+      displayName: "  custom name  ",
+      originalText: "  original text  ",
+      subTopicCode: "M01",
+      subTopicDisplay: "sub topic",
+    });
+
+    expect(response.meta).toMatchObject({
+      requestId: "feed-1",
+      source: "merck-live-feed",
+      audience: "PAT",
+      language: "en",
+      totalResults: 1,
+    });
+    expect(response.entries[0]).toMatchObject({
+      id: "topic-1",
+      title: "Feline  Diabetes",
+      summaryText: "One A and dup",
+      audience: "PAT",
+      primaryUrl:
+        "https://merckvetmanual.com/topic-a/?utm_source=yosemitecrew&utm_medium=Partner",
+    });
+    expect(response.entries[0].subLinks).toEqual([
+      {
+        label: "Full Summary",
+        url: "https://merckvetmanual.com/topic-a/?utm_source=yosemitecrew&utm_medium=Partner",
+      },
+    ]);
+    expect(getSearchMock()).toHaveBeenCalledWith(
+      expect.objectContaining({
+        "mainSearchCriteria.v.c": "1234",
+        "mainSearchCriteria.v.csn": "ICD10CM",
+        "mainSearchCriteria.v.dn": "custom name",
+        "mainSearchCriteria.v.ot": "original text",
+        "subTopic.v.cs": "2.16.840.1.113883.6.177",
+        "subTopic.v.c": "M01",
+        "subTopic.v.dn": "sub topic",
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("normalizes XML payloads and retries on HTML", async () => {
+    getSearchMock()
+      .mockResolvedValueOnce({
+        data: "<html>blocked</html>",
+        contentType: "text/html",
+        status: 200,
+        finalUrl: null,
+      })
+      .mockResolvedValueOnce({
+        data: `<?xml version="1.0"?><feed><id>xml-feed</id><updated>2026-01-01</updated><category scheme="informationrecipient" term="PROV"/><entry><id>xml-1</id><title>Canine topic</title><summary><![CDATA[<p><a href="https://msdvetmanual.com/topic-b">Topic B</a></p>]]></summary><link href="https://msdvetmanual.com/topic-b"/></entry></feed>`,
+        contentType: "application/atom+xml",
+        status: 200,
+        finalUrl: null,
+      });
+
+    const response = await MerckService.searchConsumer({
+      query: "canine topic",
+      requestId: "req-xml",
+      timezone: "UTC+01:00",
+    });
+
+    expect(response.meta).toMatchObject({
+      requestId: "xml-feed",
+      source: "merck-live-atom",
+      audience: "PROV",
+      totalResults: 1,
+    });
+    expect(response.entries[0]).toMatchObject({
+      id: "xml-1",
+      title: "Canine topic",
+      summaryText: "Topic B",
+      primaryUrl:
+        "https://msdvetmanual.com/topic-b?media=hybrid&utm_source=yosemitecrew&utm_medium=Partner",
+    });
+    expect(getSearchMock()).toHaveBeenCalledTimes(2);
+    expect(mockedLogger.info).toHaveBeenCalledWith(
+      "Merck search completed",
+      expect.objectContaining({
+        requestId: "req-xml",
+      }),
+    );
+  });
+
+  it("throws when Merck integration is disabled for the organisation", async () => {
+    mockedIntegrationService.ensureMerckAccount.mockResolvedValueOnce({
+      status: "disabled",
+    });
+
+    await expect(
+      MerckService.search({
+        query: "canine topic",
+        organisationId: "org-1",
+        requestId: "req-disabled",
+        timezone: "America/New_York",
+      }),
+    ).rejects.toThrow("Merck Manuals is disabled for this organization.");
+  });
+
+  it("rejects invalid Merck timeout configuration", async () => {
+    process.env.MERCK_HEALTHLINK_TIMEOUT_MS = "0";
+    await expect(
+      MerckService.searchConsumer({
+        query: "canine topic",
+        requestId: "req-timeout",
+      }),
+    ).rejects.toThrow("Invalid Merck timeout configuration.");
   });
 });

--- a/apps/backend/test/services/organisation-room.service.test.ts
+++ b/apps/backend/test/services/organisation-room.service.test.ts
@@ -1,474 +1,286 @@
-import { Types } from "mongoose";
-import { OrganisationRoomService } from "../../src/services/organisation-room.service";
-import OrganisationRoomModel from "../../src/models/organisation-room";
-import { prisma } from "src/config/prisma";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { prisma } from "../../src/config/prisma";
+import {
+  OrganisationRoomService,
+  OrganisationRoomServiceError,
+} from "../../src/services/organisation-room.service";
 
-// --- Mocks ---
-jest.mock("../../src/models/organisation-room");
-
-jest.mock("src/config/prisma", () => ({
+jest.mock("../../src/config/prisma", () => ({
   prisma: {
     organisationRoom: {
+      create: jest.fn(),
+      findUnique: jest.fn(),
+      findFirst: jest.fn(),
       findMany: jest.fn(),
-      upsert: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
       deleteMany: jest.fn(),
+    },
+    roomUnit: {
+      findMany: jest.fn(),
+    },
+    roomUnitGroup: {
+      findMany: jest.fn(),
+    },
+    admission: {
+      findMany: jest.fn(),
+    },
+    organisationRoomSpeciality: {
+      createMany: jest.fn(),
+      deleteMany: jest.fn(),
+      findMany: jest.fn(),
+    },
+    organisationRoomStaff: {
+      createMany: jest.fn(),
+      deleteMany: jest.fn(),
+      findMany: jest.fn(),
+    },
+    speciality: {
+      findMany: jest.fn(),
+    },
+    user: {
+      findMany: jest.fn(),
+    },
+    userOrganization: {
+      findMany: jest.fn(),
     },
   },
 }));
 
-// Mock Types helpers
-jest.mock("@yosemite-crew/types", () => ({
-  fromOrganisationRoomRequestDTO: jest.fn((dto) => dto),
-  toOrganisationRoomResponseDTO: jest.fn((domain) => domain),
-}));
+const mockedPrisma = prisma as any;
 
-// --- Helper: Mongoose Chain Mock ---
-const mockChain = (result: any = null) => {
-  return {
-    lean: jest.fn().mockResolvedValue(result),
-    select: jest.fn().mockReturnThis(),
-    exec: jest.fn().mockResolvedValue(result),
-    then: (resolve: any) => Promise.resolve(result).then(resolve),
-  } as any;
+const baseRoom = {
+  id: "room_1",
+  organisationId: "org_1",
+  name: "Inpatient Ward A",
+  code: "IP-01",
+  description: "Main ward",
+  type: "INPATIENT",
+  occupancyStatus: "VACANT",
+  assignedSpecialiteis: [{ id: "spec_1", name: "Cardiology" }],
+  assignedStaffs: [
+    { id: "staff_1", name: "Dr. One" },
+    { id: "staff_2", name: "Dr. Two" },
+  ],
+  availableNow: true,
+  availabilityMode: "ALL_DAY",
+  availabilityDays: ["MONDAY", "TUESDAY"],
+  availabilityStartTime: "08:00",
+  availabilityEndTime: "18:00",
+  capabilities: ["oxygen"],
+  createdAt: new Date("2026-06-11T10:00:00.000Z"),
+  updatedAt: new Date("2026-06-11T10:00:00.000Z"),
 };
 
-// --- Helper: Mock Document ---
-const mockDoc = (data: any) => ({
-  ...data,
-  toObject: jest.fn(() => data),
-});
-
 describe("OrganisationRoomService", () => {
-  let mockOrgId: Types.ObjectId;
-  let mockRoomId: Types.ObjectId;
-  let validPayload: any;
-
   beforeEach(() => {
     jest.clearAllMocks();
-
-    mockOrgId = new Types.ObjectId();
-    mockRoomId = new Types.ObjectId();
-
-    validPayload = {
-      resourceType: "Location",
-      id: mockRoomId.toHexString(),
-      organisationId: mockOrgId.toHexString(),
-      name: "Consultation Room 1",
-      type: "CONSULTATION",
-      assignedStaffs: ["staff-1", "staff-2"],
-      assignedSpecialiteis: ["spec-1"],
-    };
-
-    // Default Mongoose Mocks with proper _id structure
-    (OrganisationRoomModel.findOne as jest.Mock).mockReturnValue(
-      mockChain(null),
-    );
-    (OrganisationRoomModel.find as jest.Mock).mockReturnValue(mockChain([]));
-    (OrganisationRoomModel.create as jest.Mock).mockResolvedValue(
-      mockDoc({ ...validPayload, _id: mockRoomId }),
-    );
-    (OrganisationRoomModel.findOneAndUpdate as jest.Mock).mockReturnValue(
-      mockChain(mockDoc({ ...validPayload, _id: mockRoomId })),
-    );
-    (OrganisationRoomModel.findOneAndDelete as jest.Mock).mockReturnValue(
-      mockChain(mockDoc({ ...validPayload, _id: mockRoomId })),
-    );
+    mockedPrisma.organisationRoom.findUnique.mockResolvedValue(null);
+    mockedPrisma.organisationRoom.findFirst.mockResolvedValue(null);
+    mockedPrisma.organisationRoom.findMany.mockResolvedValue([]);
+    mockedPrisma.organisationRoom.create.mockResolvedValue(baseRoom);
+    mockedPrisma.organisationRoom.update.mockResolvedValue({
+      ...baseRoom,
+      availableNow: false,
+    });
+    mockedPrisma.organisationRoom.delete.mockResolvedValue(baseRoom);
+    mockedPrisma.roomUnit.findMany.mockResolvedValue([]);
+    mockedPrisma.roomUnitGroup.findMany.mockResolvedValue([]);
+    mockedPrisma.admission.findMany.mockResolvedValue([]);
+    mockedPrisma.organisationRoomSpeciality.findMany.mockResolvedValue([]);
+    mockedPrisma.organisationRoomStaff.findMany.mockResolvedValue([]);
+    mockedPrisma.organisationRoomSpeciality.createMany.mockResolvedValue({});
+    mockedPrisma.organisationRoomStaff.createMany.mockResolvedValue({});
+    mockedPrisma.organisationRoomSpeciality.deleteMany.mockResolvedValue({
+      count: 0,
+    });
+    mockedPrisma.organisationRoomStaff.deleteMany.mockResolvedValue({
+      count: 0,
+    });
+    mockedPrisma.speciality.findMany.mockResolvedValue([
+      {
+        id: "spec_1",
+        name: "Cardiology",
+        organisationId: "org_1",
+      },
+    ]);
+    mockedPrisma.user.findMany.mockResolvedValue([
+      {
+        userId: "staff_1",
+        firstName: "Dr.",
+        lastName: "One",
+      },
+      {
+        userId: "staff_2",
+        firstName: "Dr.",
+        lastName: "Two",
+      },
+    ]);
+    mockedPrisma.userOrganization.findMany.mockResolvedValue([
+      { practitionerReference: "staff_1" },
+      { practitionerReference: "staff_2" },
+    ]);
   });
 
-  describe("Validation & Internals", () => {
-    it("should throw error if payload resourceType is invalid", async () => {
-      const invalid = { ...validPayload, resourceType: "Patient" };
-      await expect(OrganisationRoomService.create(invalid)).rejects.toThrow(
-        "Invalid payload. Expected FHIR Location resource.",
-      );
+  it("creates a room with defaults and validates unique code", async () => {
+    const result = await OrganisationRoomService.create({
+      organisationId: "org_1",
+      name: "Inpatient Ward A",
+      code: "IP-01",
+      type: "INPATIENT",
+      assignedSpecialiteis: [{ id: "spec_1", name: "Cardiology" }],
+      assignedStaffs: [
+        { id: "staff_1", name: "Dr. One" },
+        { id: "staff_2", name: "Dr. Two" },
+      ],
+      capabilities: ["oxygen"],
     });
 
-    it("should throw error if Organisation ID is invalid", async () => {
-      const invalid = { ...validPayload, organisationId: "invalid$id" };
-      await expect(OrganisationRoomService.create(invalid)).rejects.toThrow(
-        "Invalid character in Organisation identifier",
-      );
-    });
-
-    it("should throw error if Room Name is missing or empty", async () => {
-      await expect(
-        OrganisationRoomService.create({ ...validPayload, name: null }),
-      ).rejects.toThrow("Room name is required");
-
-      await expect(
-        OrganisationRoomService.create({ ...validPayload, name: "   " }),
-      ).rejects.toThrow("Room name cannot be empty");
-    });
-
-    it("should throw error if Room Type is invalid", async () => {
-      const invalid = { ...validPayload, type: "CAFETERIA" }; // Not in allowed Set
-      await expect(OrganisationRoomService.create(invalid)).rejects.toThrow(
-        "Room type must be one of: CONSULTATION, WAITING_AREA, SURGERY, ICU",
-      );
-    });
-
-    it("should validate and prune arrays (assignedStaffs)", async () => {
-      // Target: sanitizeIdList logic
-      const payloadWithBadStaff = {
-        ...validPayload,
-        // Provide ID to force update path if logic prefers update, or remove ID to force create
-        // The service checks `identifier` (from payload.id)
-        id: undefined,
-        assignedStaffs: ["staff-1", null, undefined, "", "staff-2"],
-      };
-
-      const createSpy = OrganisationRoomModel.create as jest.Mock;
-
-      await OrganisationRoomService.create(payloadWithBadStaff);
-
-      const persistedData = createSpy.mock.calls[0][0];
-      expect(persistedData.assignedStaffs).toHaveLength(2);
-      expect(persistedData.assignedStaffs).toEqual(["staff-1", "staff-2"]);
-    });
-
-    it("should handle pruning of nested objects", async () => {
-      // Mock DTO helper to return structure with undefineds
-      jest
-        .requireMock("@yosemite-crew/types")
-        .fromOrganisationRoomRequestDTO.mockReturnValueOnce({
-          ...validPayload,
-          id: undefined, // Force create path
-          meta: {
-            version: undefined,
-            tag: "test",
-          },
-        });
-
-      const createSpy = OrganisationRoomModel.create as jest.Mock;
-
-      await OrganisationRoomService.create({ ...validPayload, id: undefined });
-
-      // Verify create was called (pruning didn't crash)
-      expect(createSpy).toHaveBeenCalled();
-
-      // Restore mock behavior
-      jest
-        .requireMock("@yosemite-crew/types")
-        .fromOrganisationRoomRequestDTO.mockImplementation((dto: any) => dto);
-    });
-  });
-
-  describe("create", () => {
-    it("should create new room if ID not provided (or not found)", async () => {
-      const payloadNoId = { ...validPayload, id: undefined };
-
-      const res = await OrganisationRoomService.create(payloadNoId);
-
-      expect(OrganisationRoomModel.create).toHaveBeenCalled();
-      expect(res.created).toBe(true);
-      expect(res.response).toBeDefined();
-    });
-
-    it("should upsert (update) room if ID is provided", async () => {
-      // Mock findOneAndUpdate returning a valid doc with _id
-      (OrganisationRoomModel.findOneAndUpdate as jest.Mock).mockReturnValue(
-        mockChain(
-          mockDoc({ ...validPayload, _id: mockRoomId, name: "Updated Name" }),
-        ),
-      );
-
-      const res = await OrganisationRoomService.create(validPayload);
-
-      expect(OrganisationRoomModel.findOneAndUpdate).toHaveBeenCalledWith(
-        { fhirId: mockRoomId.toHexString() },
-        expect.anything(),
-        expect.anything(),
-      );
-      expect(res.created).toBe(false);
-      expect(res.response.name).toBe("Updated Name");
-    });
-
-    it("should fallback to create if upsert returns null", async () => {
-      // First try update -> null
-      (OrganisationRoomModel.findOneAndUpdate as jest.Mock).mockReturnValue(
-        mockChain(null),
-      );
-      // Then create -> doc
-      (OrganisationRoomModel.create as jest.Mock).mockResolvedValue(
-        mockDoc({ ...validPayload, _id: mockRoomId }),
-      );
-
-      const res = await OrganisationRoomService.create(validPayload);
-
-      expect(OrganisationRoomModel.create).toHaveBeenCalled();
-      expect(res.created).toBe(true);
-    });
-  });
-
-  describe("update", () => {
-    it("should update existing room", async () => {
-      const res = await OrganisationRoomService.update(
-        mockRoomId.toHexString(),
-        validPayload,
-      );
-      expect(res).toBeDefined();
-      expect(OrganisationRoomModel.findOneAndUpdate).toHaveBeenCalled();
-    });
-
-    it("should return null if room to update not found", async () => {
-      (OrganisationRoomModel.findOneAndUpdate as jest.Mock).mockReturnValue(
-        mockChain(null),
-      );
-      const res = await OrganisationRoomService.update(
-        mockRoomId.toHexString(),
-        validPayload,
-      );
-      expect(res).toBeNull();
-    });
-
-    it("should throw if update ID format is invalid", async () => {
-      await expect(
-        OrganisationRoomService.update("bad$id", validPayload),
-      ).rejects.toThrow("Invalid character in Room identifier");
-    });
-  });
-
-  describe("getAllByOrganizationId", () => {
-    it("should return list of rooms", async () => {
-      (OrganisationRoomModel.find as jest.Mock).mockReturnValue(
-        mockChain([
-          mockDoc({ ...validPayload, _id: new Types.ObjectId() }),
-          mockDoc({ ...validPayload, _id: new Types.ObjectId() }),
-        ]),
-      );
-
-      const res = await OrganisationRoomService.getAllByOrganizationId(
-        mockOrgId.toHexString(),
-      );
-      expect(res).toHaveLength(2);
-    });
-  });
-
-  describe("getAllByOrganizationId (postgres)", () => {
-    const originalReadFromPostgres = process.env.READ_FROM_POSTGRES;
-
-    beforeEach(() => {
-      process.env.READ_FROM_POSTGRES = "true";
-      (prisma.organisationRoom.findMany as jest.Mock).mockReset();
-    });
-
-    afterEach(() => {
-      process.env.READ_FROM_POSTGRES = originalReadFromPostgres;
-    });
-
-    it("should return list of rooms from prisma", async () => {
-      (prisma.organisationRoom.findMany as jest.Mock).mockResolvedValueOnce([
-        {
-          id: new Types.ObjectId().toHexString(),
-          fhirId: null,
-          organisationId: mockOrgId.toHexString(),
-          name: "Room 1",
-          type: "CONSULTATION",
-          assignedStaffs: [],
-          assignedSpecialiteis: [],
-          createdAt: new Date(),
-          updatedAt: new Date(),
+    expect(mockedPrisma.organisationRoom.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          organisationId: "org_1",
+          code: "IP-01",
         },
-      ]);
-
-      const res = await OrganisationRoomService.getAllByOrganizationId(
-        mockOrgId.toHexString(),
-      );
-      expect(res).toHaveLength(1);
-      expect(prisma.organisationRoom.findMany).toHaveBeenCalledWith({
-        where: { organisationId: mockOrgId.toHexString() },
-      });
-    });
-  });
-
-  describe("deleteAllByOrganizationId", () => {
-    it("should delete all rooms", async () => {
-      (OrganisationRoomModel.deleteMany as jest.Mock).mockReturnValue(
-        mockChain({ acknowledged: true, deletedCount: 5 }),
-      );
-
-      await OrganisationRoomService.deleteAllByOrganizationId(
-        mockOrgId.toHexString(),
-      );
-      expect(OrganisationRoomModel.deleteMany).toHaveBeenCalled();
-    });
-
-    it("should throw 500 if delete result is not acknowledged", async () => {
-      (OrganisationRoomModel.deleteMany as jest.Mock).mockReturnValue(
-        mockChain({ acknowledged: false }),
-      );
-
-      await expect(
-        OrganisationRoomService.deleteAllByOrganizationId(
-          mockOrgId.toHexString(),
-        ),
-      ).rejects.toThrow("Failed to delete organisation rooms");
-    });
-  });
-
-  describe("delete", () => {
-    it("should delete room by ID", async () => {
-      const res = await OrganisationRoomService.delete(
-        mockRoomId.toHexString(),
-        mockOrgId.toHexString(),
-      );
-      expect(res).toBeDefined();
-      expect(OrganisationRoomModel.findOneAndDelete).toHaveBeenCalledWith(
-        expect.objectContaining({
-          organisationId: mockOrgId.toHexString(),
+      }),
+    );
+    expect(mockedPrisma.organisationRoom.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          organisationId: "org_1",
+          name: "Inpatient Ward A",
+          code: "IP-01",
+          type: "INPATIENT",
+          occupancyStatus: "VACANT",
         }),
-        { sanitizeFilter: true },
-      );
-    });
-
-    it("should return null if room not found", async () => {
-      (OrganisationRoomModel.findOneAndDelete as jest.Mock).mockReturnValue(
-        mockChain(null),
-      );
-      const res = await OrganisationRoomService.delete(
-        mockRoomId.toHexString(),
-        mockOrgId.toHexString(),
-      );
-      expect(res).toBeNull();
-    });
-
-    it("should validate ID format before delete", async () => {
-      await expect(
-        OrganisationRoomService.delete(
-          "invalid id with spaces",
-          mockOrgId.toHexString(),
-        ),
-      ).rejects.toThrow("Invalid room identifier format");
-    });
+      }),
+    );
+    expect(
+      mockedPrisma.organisationRoomSpeciality.createMany,
+    ).toHaveBeenCalled();
+    expect(mockedPrisma.organisationRoomStaff.createMany).toHaveBeenCalled();
+    expect(result.code).toBe("IP-01");
+    expect(result.availableNow).toBe(true);
+    expect(result.assignedSpecialiteis[0]?.name).toBe("Cardiology");
   });
 
-  describe("dual write", () => {
-    const originalDualWrite = process.env.DUAL_WRITE_ENABLED;
-
-    afterEach(() => {
-      process.env.DUAL_WRITE_ENABLED = originalDualWrite;
+  it("rejects duplicate room codes within the same organisation", async () => {
+    mockedPrisma.organisationRoom.findFirst.mockResolvedValueOnce({
+      id: "room_existing",
     });
 
-    it("syncs to postgres on create when enabled", async () => {
-      process.env.DUAL_WRITE_ENABLED = "true";
-      jest.resetModules();
-      jest.doMock("src/utils/dual-write", () => ({
-        ...jest.requireActual("src/utils/dual-write"),
-        shouldDualWrite: true,
-      }));
+    await expect(
+      OrganisationRoomService.create({
+        organisationId: "org_1",
+        name: "Second room",
+        code: "IP-01",
+        type: "ICU",
+      }),
+    ).rejects.toMatchObject({
+      message: "Room code must be unique within the organisation.",
+      statusCode: 409,
+    } satisfies Partial<OrganisationRoomServiceError>);
+  });
 
-      let OrganisationRoomServiceIsolated!: typeof OrganisationRoomService;
-      let OrganisationRoomModelIsolated!: typeof OrganisationRoomModel;
-      let prismaIsolated!: typeof prisma;
+  it("lists rooms with computed occupancy summary", async () => {
+    mockedPrisma.organisationRoom.findMany.mockResolvedValue([baseRoom]);
+    mockedPrisma.roomUnit.findMany.mockResolvedValue([
+      {
+        id: "unit_1",
+        roomId: "room_1",
+        unitGroupId: "group_1",
+        code: "BED-01",
+        displayName: "Bed 1",
+        size: "M",
+        speciesConstraints: ["dog"],
+        isActive: true,
+      },
+      {
+        id: "unit_2",
+        roomId: "room_1",
+        unitGroupId: "group_1",
+        code: "BED-02",
+        displayName: "Bed 2",
+        size: "M",
+        speciesConstraints: ["dog"],
+        isActive: true,
+      },
+    ]);
+    mockedPrisma.roomUnitGroup.findMany.mockResolvedValue([
+      {
+        id: "group_1",
+        roomId: "room_1",
+        name: "Dog ward",
+        size: "Medium",
+        unitCount: 2,
+        speciesConstraints: ["dog"],
+        capabilities: ["oxygen"],
+        isActive: true,
+      },
+    ]);
+    mockedPrisma.admission.findMany.mockResolvedValue([{ unitId: "unit_1" }]);
 
-      jest.isolateModules(() => {
-        OrganisationRoomServiceIsolated =
-          // eslint-disable-next-line @typescript-eslint/no-var-requires
-          require("../../src/services/organisation-room.service").OrganisationRoomService;
-        OrganisationRoomModelIsolated =
-          // eslint-disable-next-line @typescript-eslint/no-var-requires
-          require("../../src/models/organisation-room").default;
-        // eslint-disable-next-line @typescript-eslint/no-var-requires
-        prismaIsolated = require("src/config/prisma").prisma;
-      });
+    const result =
+      await OrganisationRoomService.getSummaryByOrganizationId("org_1");
 
-      const doc = mockDoc({
-        _id: mockRoomId,
-        organisationId: mockOrgId.toHexString(),
-        name: "Room",
-        type: "CONSULTATION",
-      });
-      (
-        OrganisationRoomModelIsolated.findOneAndUpdate as jest.Mock
-      ).mockReturnValue(mockChain(null));
-      (OrganisationRoomModelIsolated.create as jest.Mock).mockResolvedValue(
-        doc,
-      );
+    expect(result).toHaveLength(1);
+    expect(result[0]?.totalUnits).toBe(2);
+    expect(result[0]?.occupiedUnits).toBe(1);
+    expect(result[0]?.vacantUnits).toBe(1);
+    expect(result[0]?.occupancyDisplay).toBe("Vacant (1)");
+    expect(result[0]?.unitGroups[0]?.occupiedCount).toBe(1);
+  });
 
-      await OrganisationRoomServiceIsolated.create({
-        ...validPayload,
-        id: undefined,
-      });
+  it("returns room-level occupancy when no units exist", async () => {
+    mockedPrisma.organisationRoom.findUnique.mockResolvedValue(baseRoom);
+    mockedPrisma.organisationRoom.findMany.mockResolvedValue([baseRoom]);
 
-      expect(prismaIsolated.organisationRoom.upsert).toHaveBeenCalledWith(
-        expect.objectContaining({ where: { id: mockRoomId.toHexString() } }),
-      );
+    const result = await OrganisationRoomService.getById("room_1", "org_1");
+
+    expect(result.occupancySource).toBe("ROOM");
+    expect(result.occupancyDisplay).toBe("VACANT");
+  });
+
+  it("toggles room availability without changing occupancy", async () => {
+    mockedPrisma.organisationRoom.findUnique.mockResolvedValue(baseRoom);
+
+    const result = await OrganisationRoomService.toggleAvailability(
+      "room_1",
+      "org_1",
+    );
+
+    expect(mockedPrisma.organisationRoom.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "room_1" },
+        data: { availableNow: false },
+      }),
+    );
+    expect(result.availableNow).toBe(false);
+  });
+
+  it("deletes a room only for the owning organisation", async () => {
+    mockedPrisma.organisationRoom.findUnique.mockResolvedValue(baseRoom);
+
+    const result = await OrganisationRoomService.delete("room_1", "org_1");
+
+    expect(mockedPrisma.organisationRoom.delete).toHaveBeenCalledWith({
+      where: { id: "room_1" },
+    });
+    expect(result.id).toBe("room_1");
+  });
+
+  it("rejects deleting a room from another organisation", async () => {
+    mockedPrisma.organisationRoom.findUnique.mockResolvedValue({
+      ...baseRoom,
+      organisationId: "org_other",
     });
 
-    it("deletes from postgres on delete when enabled", async () => {
-      process.env.DUAL_WRITE_ENABLED = "true";
-      jest.resetModules();
-      jest.doMock("src/utils/dual-write", () => ({
-        ...jest.requireActual("src/utils/dual-write"),
-        shouldDualWrite: true,
-      }));
-
-      let OrganisationRoomServiceIsolated!: typeof OrganisationRoomService;
-      let OrganisationRoomModelIsolated!: typeof OrganisationRoomModel;
-      let prismaIsolated!: typeof prisma;
-
-      jest.isolateModules(() => {
-        OrganisationRoomServiceIsolated =
-          // eslint-disable-next-line @typescript-eslint/no-var-requires
-          require("../../src/services/organisation-room.service").OrganisationRoomService;
-        OrganisationRoomModelIsolated =
-          // eslint-disable-next-line @typescript-eslint/no-var-requires
-          require("../../src/models/organisation-room").default;
-        // eslint-disable-next-line @typescript-eslint/no-var-requires
-        prismaIsolated = require("src/config/prisma").prisma;
-      });
-
-      const doc = mockDoc({ ...validPayload, _id: mockRoomId });
-      (
-        OrganisationRoomModelIsolated.findOneAndDelete as jest.Mock
-      ).mockReturnValue(mockChain(doc));
-
-      await OrganisationRoomServiceIsolated.delete(
-        mockRoomId.toHexString(),
-        mockOrgId.toHexString(),
-      );
-
-      expect(prismaIsolated.organisationRoom.deleteMany).toHaveBeenCalledWith(
-        expect.objectContaining({ where: { id: mockRoomId.toHexString() } }),
-      );
-    });
-
-    it("deletes all by org in postgres when enabled", async () => {
-      process.env.DUAL_WRITE_ENABLED = "true";
-      jest.resetModules();
-      jest.doMock("src/utils/dual-write", () => ({
-        ...jest.requireActual("src/utils/dual-write"),
-        shouldDualWrite: true,
-      }));
-
-      let OrganisationRoomServiceIsolated!: typeof OrganisationRoomService;
-      let OrganisationRoomModelIsolated!: typeof OrganisationRoomModel;
-      let prismaIsolated!: typeof prisma;
-
-      jest.isolateModules(() => {
-        OrganisationRoomServiceIsolated =
-          // eslint-disable-next-line @typescript-eslint/no-var-requires
-          require("../../src/services/organisation-room.service").OrganisationRoomService;
-        OrganisationRoomModelIsolated =
-          // eslint-disable-next-line @typescript-eslint/no-var-requires
-          require("../../src/models/organisation-room").default;
-        // eslint-disable-next-line @typescript-eslint/no-var-requires
-        prismaIsolated = require("src/config/prisma").prisma;
-      });
-
-      (OrganisationRoomModelIsolated.deleteMany as jest.Mock).mockReturnValue(
-        mockChain({ acknowledged: true }),
-      );
-
-      await OrganisationRoomServiceIsolated.deleteAllByOrganizationId(
-        mockOrgId.toHexString(),
-      );
-
-      expect(prismaIsolated.organisationRoom.deleteMany).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: { organisationId: mockOrgId.toHexString() },
-        }),
-      );
+    await expect(
+      OrganisationRoomService.delete("room_1", "org_1"),
+    ).rejects.toMatchObject({
+      message:
+        "Organisation room does not belong to the requested organisation.",
+      statusCode: 403,
     });
   });
 });

--- a/apps/backend/test/services/room-management.helpers.test.ts
+++ b/apps/backend/test/services/room-management.helpers.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  normalizeReferenceMappings,
+  normalizeRoomOccupancyStatus,
+  normalizeRoomType,
+  normalizeStringList,
+  normalizeStrictStringList,
+  optionalNonEmptyString,
+  requireNonEmptyString,
+  roomTypeSupportsUnits,
+  RoomValidationError,
+} from "../../src/services/room-management.helpers";
+
+describe("room-management.helpers", () => {
+  it("validates required strings", () => {
+    expect(requireNonEmptyString("  room  ", "roomId")).toBe("room");
+    expect(() => requireNonEmptyString(123, "roomId")).toThrow(
+      RoomValidationError,
+    );
+    expect(() => requireNonEmptyString("   ", "roomId")).toThrow(
+      "roomId is required.",
+    );
+    expect(() => requireNonEmptyString("bad$", "roomId")).toThrow(
+      "Invalid character in roomId.",
+    );
+  });
+
+  it("handles optional strings", () => {
+    expect(optionalNonEmptyString(undefined)).toBeUndefined();
+    expect(optionalNonEmptyString("  ")).toBeUndefined();
+    expect(optionalNonEmptyString("  ward ")).toBe("ward");
+    expect(() => optionalNonEmptyString(123)).toThrow("Invalid string value.");
+  });
+
+  it("normalizes string lists", () => {
+    expect(normalizeStringList([" a ", "", "b", "a", 1 as never])).toEqual([
+      "a",
+      "b",
+    ]);
+  });
+
+  it("normalizes strict string lists", () => {
+    expect(normalizeStrictStringList(null, "capabilities")).toEqual([]);
+    expect(
+      normalizeStrictStringList([" a ", "b", "a"], "capabilities"),
+    ).toEqual(["a", "b"]);
+    expect(() => normalizeStrictStringList("bad", "capabilities")).toThrow(
+      "capabilities must be an array.",
+    );
+    expect(() =>
+      normalizeStrictStringList([1 as never], "capabilities"),
+    ).toThrow("capabilities at index 0 must be a string.");
+    expect(() => normalizeStrictStringList(["   "], "capabilities")).toThrow(
+      "capabilities at index 0 cannot be empty.",
+    );
+  });
+
+  it("normalizes reference mappings", () => {
+    expect(normalizeReferenceMappings(null, "speciesConstraints")).toEqual([]);
+    expect(
+      normalizeReferenceMappings(
+        [
+          { id: " a ", name: " Alpha " },
+          { id: "a", name: "Alpha updated" },
+        ],
+        "speciesConstraints",
+      ),
+    ).toEqual([{ id: "a", name: "Alpha updated" }]);
+    expect(() =>
+      normalizeReferenceMappings("bad", "speciesConstraints"),
+    ).toThrow("speciesConstraints must be an array.");
+    expect(() =>
+      normalizeReferenceMappings([null], "speciesConstraints"),
+    ).toThrow("speciesConstraints at index 0 must be an object.");
+    expect(() =>
+      normalizeReferenceMappings([{ name: "Alpha" }], "speciesConstraints"),
+    ).toThrow("speciesConstraints at index 0 must have an id.");
+    expect(() =>
+      normalizeReferenceMappings([{ id: "a" }], "speciesConstraints"),
+    ).toThrow("speciesConstraints at index 0 must have a name.");
+  });
+
+  it("normalizes room types and occupancy statuses", () => {
+    expect(normalizeRoomType("exam")).toBe("EXAM_ROOM");
+    expect(normalizeRoomType("waiting area")).toBe("WAITING");
+    expect(roomTypeSupportsUnits("ICU")).toBe(true);
+    expect(roomTypeSupportsUnits("EXAM_ROOM")).toBe(false);
+    expect(normalizeRoomOccupancyStatus("occupied")).toBe("OCCUPIED");
+    expect(() => normalizeRoomType(123)).toThrow("Room type is required.");
+    expect(() => normalizeRoomType("unknown")).toThrow(
+      "Room type must be one of:",
+    );
+    expect(() => normalizeRoomOccupancyStatus(123)).toThrow(
+      "Occupancy status is required.",
+    );
+    expect(() => normalizeRoomOccupancyStatus("unknown")).toThrow(
+      "Occupancy status must be one of:",
+    );
+  });
+});

--- a/apps/backend/test/services/room-unit-group.service.test.ts
+++ b/apps/backend/test/services/room-unit-group.service.test.ts
@@ -115,6 +115,25 @@ describe("RoomUnitGroupService", () => {
     expect(results[0]?.unitCount).toBe(2);
   });
 
+  it("lists room unit groups with room and status filters", async () => {
+    mockedPrisma.roomUnitGroup.findMany.mockResolvedValue([]);
+
+    await RoomUnitGroupService.list({
+      organisationId: "org_1",
+      roomId: "room_1",
+      isActive: false,
+    });
+
+    expect(mockedPrisma.roomUnitGroup.findMany).toHaveBeenCalledWith({
+      where: {
+        organisationId: "org_1",
+        roomId: "room_1",
+        isActive: false,
+      },
+      orderBy: [{ roomId: "asc" }, { name: "asc" }],
+    });
+  });
+
   it("deletes a room unit group within the same organisation", async () => {
     mockedPrisma.roomUnitGroup.findUnique.mockResolvedValue({
       id: "group_1",
@@ -149,5 +168,84 @@ describe("RoomUnitGroupService", () => {
       where: { id: "group_1" },
     });
     expect(result.id).toBe("group_1");
+  });
+
+  it("rejects invalid room unit group inputs and missing rooms", async () => {
+    mockedPrisma.organisationRoom.findUnique.mockResolvedValueOnce(null);
+
+    await expect(
+      RoomUnitGroupService.create({
+        id: "group_2",
+        organisationId: "org_1",
+        roomId: "room_missing",
+        name: "Dog ward",
+        unitCount: 2,
+      }),
+    ).rejects.toMatchObject({
+      message: "Organisation room not found.",
+      statusCode: 404,
+    });
+
+    await expect(
+      RoomUnitGroupService.create({
+        id: "group_3",
+        organisationId: "org_1",
+        roomId: "room_1",
+        name: "Dog ward",
+        unitCount: 0,
+      }),
+    ).rejects.toMatchObject({
+      message: "unitCount must be greater than 0.",
+      statusCode: 400,
+    });
+  });
+
+  it("rejects room org mismatches on update and delete", async () => {
+    mockedPrisma.roomUnitGroup.findUnique.mockResolvedValueOnce({
+      id: "group_1",
+      organisationId: "org_1",
+      roomId: "room_1",
+      name: "Dog ward",
+      size: "Medium",
+      unitCount: 2,
+      speciesConstraints: ["dog"],
+      capabilities: ["oxygen"],
+      isActive: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    mockedPrisma.organisationRoom.findUnique.mockResolvedValueOnce({
+      id: "room_1",
+      organisationId: "org_2",
+      type: "INPATIENT",
+    });
+
+    await expect(
+      RoomUnitGroupService.update("group_1", { roomId: "room_1" }),
+    ).rejects.toMatchObject({
+      message: "Room organisation mismatch.",
+      statusCode: 409,
+    });
+
+    mockedPrisma.roomUnitGroup.findUnique.mockResolvedValueOnce({
+      id: "group_1",
+      organisationId: "org_1",
+      roomId: "room_1",
+      name: "Dog ward",
+      size: "Medium",
+      unitCount: 2,
+      speciesConstraints: ["dog"],
+      capabilities: ["oxygen"],
+      isActive: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await expect(
+      RoomUnitGroupService.delete("group_1", "org_2"),
+    ).rejects.toMatchObject({
+      message: "Room organisation mismatch.",
+      statusCode: 409,
+    });
   });
 });

--- a/apps/backend/test/services/room-unit-group.service.test.ts
+++ b/apps/backend/test/services/room-unit-group.service.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import { prisma } from "../../src/config/prisma";
-import { RoomUnitService } from "../../src/services/room-unit.service";
+import { RoomUnitGroupService } from "../../src/services/room-unit-group.service";
 
 jest.mock("../../src/config/prisma", () => ({
   prisma: {
@@ -8,9 +8,6 @@ jest.mock("../../src/config/prisma", () => ({
       findUnique: jest.fn(),
     },
     roomUnitGroup: {
-      findUnique: jest.fn(),
-    },
-    roomUnit: {
       create: jest.fn(),
       findUnique: jest.fn(),
       findMany: jest.fn(),
@@ -22,7 +19,7 @@ jest.mock("../../src/config/prisma", () => ({
 
 const mockedPrisma = prisma as any;
 
-describe("RoomUnitService", () => {
+describe("RoomUnitGroupService", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockedPrisma.organisationRoom.findUnique.mockResolvedValue({
@@ -32,51 +29,46 @@ describe("RoomUnitService", () => {
     });
   });
 
-  it("creates a room unit in a supported room", async () => {
-    mockedPrisma.roomUnit.create.mockResolvedValue({
-      id: "unit_1",
+  it("creates a room unit group for supported room types", async () => {
+    mockedPrisma.roomUnitGroup.create.mockResolvedValue({
+      id: "group_1",
       organisationId: "org_1",
       roomId: "room_1",
-      unitGroupId: "group_1",
-      code: "KEN-01",
-      displayName: "Kennel 1",
-      size: "M",
+      name: "Dog ward",
+      size: "Medium",
+      unitCount: 2,
       speciesConstraints: ["dog"],
+      capabilities: ["oxygen"],
       isActive: true,
       createdAt: new Date(),
       updatedAt: new Date(),
     });
-    mockedPrisma.roomUnitGroup.findUnique.mockResolvedValue({
-      id: "group_1",
-      roomId: "room_1",
-      organisationId: "org_1",
-    });
 
-    const result = await RoomUnitService.create({
-      id: "unit_1",
+    const result = await RoomUnitGroupService.create({
+      id: "group_1",
       organisationId: "org_1",
       roomId: "room_1",
-      unitGroupId: "group_1",
-      code: "KEN-01",
-      displayName: "Kennel 1",
-      size: "M",
+      name: "Dog ward",
+      size: "Medium",
+      unitCount: 2,
       speciesConstraints: ["dog"],
+      capabilities: ["oxygen"],
       isActive: true,
     });
 
-    expect(mockedPrisma.roomUnit.create).toHaveBeenCalledWith(
+    expect(mockedPrisma.roomUnitGroup.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
+          organisationId: "org_1",
           roomId: "room_1",
-          unitGroupId: "group_1",
-          code: "KEN-01",
+          unitCount: 2,
         }),
       }),
     );
-    expect(result.code).toBe("KEN-01");
+    expect(result.unitCount).toBe(2);
   });
 
-  it("rejects units for unsupported room types", async () => {
+  it("rejects unit groups with unsupported room types", async () => {
     mockedPrisma.organisationRoom.findUnique.mockResolvedValueOnce({
       id: "room_1",
       organisationId: "org_1",
@@ -84,12 +76,12 @@ describe("RoomUnitService", () => {
     });
 
     await expect(
-      RoomUnitService.create({
-        id: "unit_1",
+      RoomUnitGroupService.create({
+        id: "group_1",
         organisationId: "org_1",
         roomId: "room_1",
-        code: "KEN-01",
-        displayName: "Kennel 1",
+        name: "Dog ward",
+        unitCount: 2,
       }),
     ).rejects.toMatchObject({
       message:
@@ -98,62 +90,64 @@ describe("RoomUnitService", () => {
     });
   });
 
-  it("lists room units", async () => {
-    mockedPrisma.roomUnit.findMany.mockResolvedValue([
+  it("lists room unit groups", async () => {
+    mockedPrisma.roomUnitGroup.findMany.mockResolvedValue([
       {
-        id: "unit_1",
+        id: "group_1",
         organisationId: "org_1",
         roomId: "room_1",
-        unitGroupId: null,
-        code: "KEN-01",
-        displayName: "Kennel 1",
-        size: "M",
+        name: "Dog ward",
+        size: "Medium",
+        unitCount: 2,
         speciesConstraints: ["dog"],
+        capabilities: ["oxygen"],
         isActive: true,
         createdAt: new Date(),
         updatedAt: new Date(),
       },
     ]);
 
-    const results = await RoomUnitService.list({ organisationId: "org_1" });
+    const results = await RoomUnitGroupService.list({
+      organisationId: "org_1",
+    });
 
     expect(results).toHaveLength(1);
-    expect(results[0]?.displayName).toBe("Kennel 1");
+    expect(results[0]?.unitCount).toBe(2);
   });
 
-  it("deletes a room unit in the same organisation", async () => {
-    mockedPrisma.roomUnit.findUnique.mockResolvedValue({
-      id: "unit_1",
+  it("deletes a room unit group within the same organisation", async () => {
+    mockedPrisma.roomUnitGroup.findUnique.mockResolvedValue({
+      id: "group_1",
       organisationId: "org_1",
       roomId: "room_1",
-      unitGroupId: null,
-      code: "KEN-01",
-      displayName: "Kennel 1",
-      size: "M",
+      name: "Dog ward",
+      size: "Medium",
+      unitCount: 2,
       speciesConstraints: ["dog"],
+      capabilities: ["oxygen"],
       isActive: true,
       createdAt: new Date(),
       updatedAt: new Date(),
     });
-    mockedPrisma.roomUnit.delete.mockResolvedValue({
-      id: "unit_1",
+    mockedPrisma.roomUnitGroup.delete.mockResolvedValue({
+      id: "group_1",
       organisationId: "org_1",
       roomId: "room_1",
-      unitGroupId: null,
-      code: "KEN-01",
-      displayName: "Kennel 1",
-      size: "M",
+      name: "Dog ward",
+      size: "Medium",
+      unitCount: 2,
       speciesConstraints: ["dog"],
+      capabilities: ["oxygen"],
       isActive: true,
       createdAt: new Date(),
       updatedAt: new Date(),
     });
 
-    const result = await RoomUnitService.delete("unit_1", "org_1");
+    const result = await RoomUnitGroupService.delete("group_1", "org_1");
 
-    expect(mockedPrisma.roomUnit.delete).toHaveBeenCalledWith({
-      where: { id: "unit_1" },
+    expect(mockedPrisma.roomUnitGroup.delete).toHaveBeenCalledWith({
+      where: { id: "group_1" },
     });
-    expect(result.id).toBe("unit_1");
+    expect(result.id).toBe("group_1");
   });
 });

--- a/apps/backend/test/services/room-unit.service.test.ts
+++ b/apps/backend/test/services/room-unit.service.test.ts
@@ -121,6 +121,27 @@ describe("RoomUnitService", () => {
     expect(results[0]?.displayName).toBe("Kennel 1");
   });
 
+  it("lists room units with all filters", async () => {
+    mockedPrisma.roomUnit.findMany.mockResolvedValue([]);
+
+    await RoomUnitService.list({
+      organisationId: "org_1",
+      roomId: "room_1",
+      unitGroupId: "group_1",
+      isActive: false,
+    });
+
+    expect(mockedPrisma.roomUnit.findMany).toHaveBeenCalledWith({
+      where: {
+        organisationId: "org_1",
+        roomId: "room_1",
+        unitGroupId: "group_1",
+        isActive: false,
+      },
+      orderBy: { displayName: "asc" },
+    });
+  });
+
   it("deletes a room unit in the same organisation", async () => {
     mockedPrisma.roomUnit.findUnique.mockResolvedValue({
       id: "unit_1",
@@ -155,5 +176,65 @@ describe("RoomUnitService", () => {
       where: { id: "unit_1" },
     });
     expect(result.id).toBe("unit_1");
+  });
+
+  it("rejects missing units and unit group mismatches", async () => {
+    mockedPrisma.roomUnit.findUnique.mockResolvedValueOnce(null);
+
+    await expect(
+      RoomUnitService.update("unit_missing", { displayName: "Updated" }),
+    ).rejects.toMatchObject({
+      message: "Room unit not found.",
+      statusCode: 404,
+    });
+
+    mockedPrisma.roomUnit.findUnique.mockResolvedValueOnce({
+      id: "unit_1",
+      organisationId: "org_1",
+      roomId: "room_1",
+      unitGroupId: "group_1",
+      code: "KEN-01",
+      displayName: "Kennel 1",
+      size: "M",
+      speciesConstraints: ["dog"],
+      isActive: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    mockedPrisma.roomUnitGroup.findUnique.mockResolvedValueOnce({
+      id: "group_1",
+      roomId: "room_2",
+      organisationId: "org_1",
+    });
+
+    await expect(
+      RoomUnitService.update("unit_1", { unitGroupId: "group_1" }),
+    ).rejects.toMatchObject({
+      message: "Room unit group room mismatch.",
+      statusCode: 409,
+    });
+  });
+
+  it("rejects delete org mismatches", async () => {
+    mockedPrisma.roomUnit.findUnique.mockResolvedValueOnce({
+      id: "unit_1",
+      organisationId: "org_1",
+      roomId: "room_1",
+      unitGroupId: null,
+      code: "KEN-01",
+      displayName: "Kennel 1",
+      size: "M",
+      speciesConstraints: ["dog"],
+      isActive: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await expect(
+      RoomUnitService.delete("unit_1", "org_2"),
+    ).rejects.toMatchObject({
+      message: "Unit organisation mismatch.",
+      statusCode: 409,
+    });
   });
 });

--- a/apps/backend/test/services/room-unit.service.test.ts
+++ b/apps/backend/test/services/room-unit.service.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { prisma } from "../../src/config/prisma";
+import { RoomUnitService } from "../../src/services/room-unit.service";
+
+jest.mock("../../src/config/prisma", () => ({
+  prisma: {
+    organisationRoom: {
+      findUnique: jest.fn(),
+    },
+    roomUnit: {
+      create: jest.fn(),
+      findUnique: jest.fn(),
+      findMany: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+  },
+}));
+
+const mockedPrisma = prisma as any;
+
+describe("RoomUnitService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("creates a room unit", async () => {
+    mockedPrisma.organisationRoom.findUnique.mockResolvedValue({
+      id: "room_1",
+      organisationId: "org_1",
+    });
+    mockedPrisma.roomUnit.create.mockResolvedValue({
+      id: "unit_1",
+      organisationId: "org_1",
+      roomId: "room_1",
+      code: "KEN-01",
+      displayName: "Kennel 1",
+      size: "M",
+      speciesConstraints: ["dog"],
+      isActive: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const result = await RoomUnitService.create({
+      id: "unit_1",
+      organisationId: "org_1",
+      roomId: "room_1",
+      code: "KEN-01",
+      displayName: "Kennel 1",
+      size: "M",
+      speciesConstraints: ["dog"],
+      isActive: true,
+    });
+
+    expect(mockedPrisma.roomUnit.create).toHaveBeenCalled();
+    expect(result.code).toBe("KEN-01");
+  });
+
+  it("lists room units", async () => {
+    mockedPrisma.roomUnit.findMany.mockResolvedValue([
+      {
+        id: "unit_1",
+        organisationId: "org_1",
+        roomId: "room_1",
+        code: "KEN-01",
+        displayName: "Kennel 1",
+        size: "M",
+        speciesConstraints: ["dog"],
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+
+    const results = await RoomUnitService.list({ organisationId: "org_1" });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.displayName).toBe("Kennel 1");
+  });
+});

--- a/apps/backend/test/services/speciality.service.test.ts
+++ b/apps/backend/test/services/speciality.service.test.ts
@@ -1,7 +1,6 @@
 import { Types } from "mongoose";
 import { SpecialityService } from "../../src/services/speciality.service";
 import SpecialityModel from "../../src/models/speciality";
-import OrganisationRoomModel from "../../src/models/organisation-room";
 import UserModel from "../../src/models/user";
 import OrganizationModel from "../../src/models/organization";
 import { ServiceService } from "../../src/services/service.service";
@@ -11,7 +10,6 @@ import { prisma } from "src/config/prisma";
 
 // --- Mocks ---
 jest.mock("../../src/models/speciality");
-jest.mock("../../src/models/organisation-room");
 jest.mock("../../src/models/user");
 jest.mock("../../src/models/organization");
 jest.mock("../../src/services/service.service");
@@ -23,6 +21,14 @@ jest.mock("src/config/prisma", () => ({
     speciality: {
       findFirst: jest.fn(),
       findMany: jest.fn(),
+      deleteMany: jest.fn(),
+    },
+    organisationRoom: {
+      findMany: jest.fn(),
+      update: jest.fn(),
+    },
+    organisationRoomSpeciality: {
+      deleteMany: jest.fn(),
     },
     organization: {
       findFirst: jest.fn(),
@@ -118,6 +124,10 @@ describe("SpecialityService", () => {
       process.env.READ_FROM_POSTGRES = "true";
       (prisma.speciality.findFirst as jest.Mock).mockReset();
       (prisma.speciality.findMany as jest.Mock).mockReset();
+      (prisma.speciality.deleteMany as jest.Mock).mockReset();
+      (prisma.organisationRoom.findMany as jest.Mock).mockReset();
+      (prisma.organisationRoom.update as jest.Mock).mockReset();
+      (prisma.organisationRoomSpeciality.deleteMany as jest.Mock).mockReset();
       (prisma.organization.findFirst as jest.Mock).mockReset();
       (prisma.user.findFirst as jest.Mock).mockReset();
     });
@@ -458,6 +468,20 @@ describe("SpecialityService", () => {
       (SpecialityModel.findOneAndDelete as jest.Mock).mockResolvedValue(
         mockDoc({ _id: mockSpecId }),
       );
+      (prisma.organisationRoom.findMany as jest.Mock).mockResolvedValue([
+        {
+          id: "room_1",
+          assignedSpecialiteis: [mockSpecId.toHexString()],
+        },
+      ]);
+      (prisma.organisationRoom.update as jest.Mock).mockResolvedValue({
+        id: "room_1",
+      });
+      (
+        prisma.organisationRoomSpeciality.deleteMany as jest.Mock
+      ).mockResolvedValue({
+        count: 1,
+      });
 
       await SpecialityService.deleteSpeciality(
         mockSpecId.toHexString(),
@@ -467,7 +491,14 @@ describe("SpecialityService", () => {
       expect(ServiceService.deleteAllBySpecialityId).toHaveBeenCalledWith(
         mockSpecId.toString(),
       );
-      expect(OrganisationRoomModel.updateMany).toHaveBeenCalled();
+      expect(prisma.organisationRoomSpeciality.deleteMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            organisationId: mockOrgId.toHexString(),
+            specialityId: mockSpecId.toHexString(),
+          }),
+        }),
+      );
     });
 
     it("deleteSpeciality should throw if not found", async () => {

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -15,6 +15,7 @@
     "noUnusedParameters": false,
     "baseUrl": ".",
     "paths": {
+      "@yosemite-crew/lib": ["../../packages/lib/src/index.ts"],
       "@yosemite-crew/types": ["../../packages/types/src"],
       "@yosemite-crew/fhir": ["../../packages/fhir/src"],
       "@yosemite-crew/fhir-types": ["../../packages/fhir/src"]

--- a/apps/frontend/src/app/__tests__/components/Cards/RoomCard/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Cards/RoomCard/index.test.tsx
@@ -9,8 +9,11 @@ import { OrganisationRoom } from '@yosemite-crew/types';
 jest.mock('@/app/ui/tables/tableUtils', () => ({
   joinNames: jest.fn((map, ids) => {
     if (!ids || ids.length === 0) return '-';
-    // Simple join logic for testing verification
-    return ids.map((id: string) => map[id] || id).join(', ');
+    return ids
+      .map((item: any) =>
+        typeof item === 'string' ? map[item] || item : item.name || map[item.id]
+      )
+      .join(', ');
   }),
 }));
 
@@ -22,9 +25,13 @@ const mockRoom: OrganisationRoom = {
   _id: 'room-101',
   name: 'Surgery Room A',
   type: 'Surgery',
+  code: 'SRG-101',
   // Note: Using spelling from source code interface
-  assignedSpecialiteis: ['spec-1', 'spec-2'],
-  assignedStaffs: ['staff-1'],
+  assignedSpecialiteis: [
+    { id: 'spec-1', name: 'Orthopedics' },
+    { id: 'spec-2', name: 'General' },
+  ],
+  assignedStaffs: [{ id: 'staff-1', name: 'Dr. Strange' }],
 } as any;
 
 const mockSpecialityMap = {
@@ -61,8 +68,8 @@ describe('RoomCard Component', () => {
     expect(screen.getByText('Surgery')).toBeInTheDocument();
 
     // Verify helper function calls
-    expect(joinNames).toHaveBeenCalledWith(mockSpecialityMap, ['spec-1', 'spec-2']);
-    expect(joinNames).toHaveBeenCalledWith(mockStaffMap, ['staff-1']);
+    expect(joinNames).toHaveBeenCalledWith(mockSpecialityMap, mockRoom.assignedSpecialiteis);
+    expect(joinNames).toHaveBeenCalledWith(mockStaffMap, mockRoom.assignedStaffs);
 
     // Verify Rendered output from helper
     expect(screen.getByText('Orthopedics, General')).toBeInTheDocument();

--- a/apps/frontend/src/app/__tests__/components/DataTable/RoomTable.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/DataTable/RoomTable.test.tsx
@@ -40,14 +40,25 @@ const mockRooms: OrganisationRoom[] = [
   {
     name: 'Exam Room 1',
     type: 'Consultation',
-    assignedSpecialiteis: ['spec-1', 'spec-2'],
-    assignedStaffs: ['staff-1', 'staff-2'],
+    code: 'EX-001',
+    assignedSpecialiteis: [
+      { id: 'spec-1', name: 'General' },
+      { id: 'spec-2', name: 'Dermatology' },
+    ],
+    assignedStaffs: [
+      { id: 'staff-1', name: 'Dr. Smith' },
+      { id: 'staff-2', name: 'Nurse Joy' },
+    ],
   },
   {
     name: 'Surgery A',
     type: 'Operating',
+    code: 'SU-001',
     assignedSpecialiteis: [], // Test empty list
-    assignedStaffs: ['staff-1', 'staff-99'], // staff-99 does not exist in mock
+    assignedStaffs: [
+      { id: 'staff-1', name: 'Dr. Smith' },
+      { id: 'staff-99', name: '' },
+    ],
   },
 ] as any;
 
@@ -83,6 +94,12 @@ describe('RoomTable Component', () => {
     it('joinNames maps IDs to names and joins them', () => {
       const map = { '1': 'One', '2': 'Two' };
       expect(joinNames(map, ['1', '2'])).toBe('One, Two');
+      expect(
+        joinNames(map, [
+          { id: '1', name: 'One' },
+          { id: '2', name: 'Two' },
+        ])
+      ).toBe('One, Two');
     });
 
     it('joinNames handles missing IDs or empty arrays', () => {
@@ -123,7 +140,7 @@ describe('RoomTable Component', () => {
     expect(within(row2).getByText('Surgery A')).toBeInTheDocument();
     // Empty specialities -> "-"
     expect(within(row2).getByText('-')).toBeInTheDocument();
-    // Staff "staff-99" missing -> "Dr. Smith"
+    // Staff list falls back to the embedded room reference names
     expect(within(row2).getByText('Dr. Smith')).toBeInTheDocument();
   });
 
@@ -182,7 +199,6 @@ describe('RoomTable Component', () => {
   });
 
   it('handles empty hooks gracefully (empty mappings)', () => {
-    // FIX: Return empty arrays instead of undefined to prevent crash in 'joinNames'
     mockUseTeam.mockReturnValue([]);
     mockUseSpecialities.mockReturnValue([]);
 
@@ -194,9 +210,7 @@ describe('RoomTable Component', () => {
     const rows = within(desktopView as HTMLElement).getAllByRole('row');
     const dataRow = rows[1];
 
-    // Since maps are empty, joinNames returns "-"
-    const dashes = within(dataRow).getAllByText('-');
-    // Expect 2 dashes (one for Specialities, one for Staff)
-    expect(dashes.length).toBe(2);
+    expect(within(dataRow).getByText('General, Dermatology')).toBeInTheDocument();
+    expect(within(dataRow).getByText('Dr. Smith, Nurse Joy')).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/app/__tests__/pages/Organization/Sections/Rooms/RoomInfo.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Organization/Sections/Rooms/RoomInfo.test.tsx
@@ -1,47 +1,48 @@
-import React from "react";
-import { render } from "@testing-library/react";
-import "@testing-library/jest-dom";
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
 
-import RoomInfo from "@/app/features/organization/pages/Organization/Sections/Rooms/RoomInfo";
+import RoomInfo from '@/app/features/organization/pages/Organization/Sections/Rooms/RoomInfo';
 
 const updateRoomMock = jest.fn();
 const deleteRoomMock = jest.fn();
 const accordionCalls: any[] = [];
 
-jest.mock("@/app/features/organization/services/roomService", () => ({
+jest.mock('@/app/features/organization/services/roomService', () => ({
   updateRoom: (...args: any[]) => updateRoomMock(...args),
   deleteRoom: (...args: any[]) => deleteRoomMock(...args),
 }));
 
-jest.mock("@/app/hooks/useTeam", () => ({
-  useTeamForPrimaryOrg: () => [{ _id: "team-1", name: "Alex" }],
+jest.mock('@/app/hooks/useTeam', () => ({
+  useTeamForPrimaryOrg: () => [{ _id: 'team-1', name: 'Alex' }],
 }));
 
-jest.mock("@/app/hooks/useSpecialities", () => ({
-  useSpecialitiesForPrimaryOrg: () => [{ _id: "spec-1", name: "Surgery" }],
+jest.mock('@/app/hooks/useSpecialities', () => ({
+  useSpecialitiesForPrimaryOrg: () => [{ _id: 'spec-1', name: 'Surgery' }],
 }));
 
-jest.mock("@/app/ui/overlays/Modal", () => ({
+jest.mock('@/app/ui/overlays/Modal', () => ({
   __esModule: true,
   default: ({ showModal, children }: any) => (showModal ? <div>{children}</div> : null),
 }));
 
-jest.mock("@/app/ui/primitives/Icons/Close", () => ({
+jest.mock('@/app/ui/primitives/Icons/Close', () => ({
   __esModule: true,
   default: () => <div />,
 }));
 
-jest.mock("@/app/ui/primitives/Accordion/EditableAccordion", () => (props: any) => {
+jest.mock('@/app/ui/primitives/Accordion/EditableAccordion', () => (props: any) => {
   accordionCalls.push(props);
   return <div data-testid="room-accordion" />;
 });
 
-describe("RoomInfo modal", () => {
+describe('RoomInfo modal', () => {
   const activeRoom: any = {
-    id: "room-1",
-    organisationId: "org-1",
-    name: "Room A",
-    type: "EXAM",
+    id: 'room-1',
+    organisationId: 'org-1',
+    code: 'ROOM-1',
+    name: 'Room A',
+    type: 'EXAM',
     assignedSpecialiteis: [],
     assignedStaffs: [],
   };
@@ -51,28 +52,21 @@ describe("RoomInfo modal", () => {
     accordionCalls.length = 0;
   });
 
-  it("updates room on save", async () => {
-    render(
-      <RoomInfo
-        showModal
-        setShowModal={jest.fn()}
-        activeRoom={activeRoom}
-        canEditRoom
-      />
-    );
+  it('updates room on save', async () => {
+    render(<RoomInfo showModal setShowModal={jest.fn()} activeRoom={activeRoom} canEditRoom />);
 
     await accordionCalls[0].onSave({
-      name: "Updated",
-      type: "EXAM",
+      name: 'Updated',
+      type: 'EXAM',
       assignedSpecialiteis: [],
       assignedStaffs: [],
     });
 
     expect(updateRoomMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        id: "room-1",
-        organisationId: "org-1",
-        name: "Updated",
+        id: 'room-1',
+        organisationId: 'org-1',
+        name: 'Updated',
       })
     );
   });

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/AddRoom.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/AddRoom.tsx
@@ -1,28 +1,36 @@
-import Accordion from "@/app/ui/primitives/Accordion/Accordion";
-import FormInput from "@/app/ui/inputs/FormInput/FormInput";
-import Modal from "@/app/ui/overlays/Modal";
-import React, { useMemo, useState } from "react";
-import { RoomsTypes } from "@/app/features/organization/pages/Organization/types";
-import { Primary } from "@/app/ui/primitives/Buttons";
-import MultiSelectDropdown from "@/app/ui/inputs/MultiSelectDropdown";
-import { OrganisationRoom } from "@yosemite-crew/types";
-import { useTeamForPrimaryOrg } from "@/app/hooks/useTeam";
-import { useSpecialitiesForPrimaryOrg } from "@/app/hooks/useSpecialities";
-import { createRoom } from "@/app/features/organization/services/roomService";
-import LabelDropdown from "@/app/ui/inputs/Dropdown/LabelDropdown";
-import Close from "@/app/ui/primitives/Icons/Close";
-import { useNotify } from "@/app/hooks/useNotify";
+import Accordion from '@/app/ui/primitives/Accordion/Accordion';
+import FormInput from '@/app/ui/inputs/FormInput/FormInput';
+import Modal from '@/app/ui/overlays/Modal';
+import React, { useMemo, useState } from 'react';
+import { RoomsTypes } from '@/app/features/organization/pages/Organization/types';
+import { Primary } from '@/app/ui/primitives/Buttons';
+import MultiSelectDropdown from '@/app/ui/inputs/MultiSelectDropdown';
+import { OrganisationRoom } from '@yosemite-crew/types';
+import { useTeamForPrimaryOrg } from '@/app/hooks/useTeam';
+import { useSpecialitiesForPrimaryOrg } from '@/app/hooks/useSpecialities';
+import { createRoom } from '@/app/features/organization/services/roomService';
+import LabelDropdown from '@/app/ui/inputs/Dropdown/LabelDropdown';
+import Close from '@/app/ui/primitives/Icons/Close';
+import { useNotify } from '@/app/hooks/useNotify';
+import type { RoomReferenceMapping } from '@yosemite-crew/types';
+
+type RoomDraft = {
+  name: string;
+  code: string;
+  type: OrganisationRoom['type'];
+  assignedSpecialiteis: string[];
+  assignedStaffs: string[];
+};
 
 type AddRoomProps = {
   showModal: boolean;
   setShowModal: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
-const INITIAL_FORM_DATA: OrganisationRoom = {
-  id: "",
-  organisationId: "",
-  name: "",
-  type: "CONSULTATION",
+const INITIAL_FORM_DATA: RoomDraft = {
+  name: '',
+  code: '',
+  type: 'CONSULTATION',
   assignedSpecialiteis: [],
   assignedStaffs: [],
 };
@@ -31,7 +39,7 @@ const AddRoom = ({ showModal, setShowModal }: AddRoomProps) => {
   const teams = useTeamForPrimaryOrg();
   const { notify } = useNotify();
   const specialities = useSpecialitiesForPrimaryOrg();
-  const [formData, setFormData] = useState<OrganisationRoom>(INITIAL_FORM_DATA);
+  const [formData, setFormData] = useState<RoomDraft>(INITIAL_FORM_DATA);
   const [formDataErrors, setFormDataErrors] = useState<{
     name?: string;
   }>({});
@@ -42,7 +50,7 @@ const AddRoom = ({ showModal, setShowModal }: AddRoomProps) => {
         label: team.name || team.practionerId,
         value: team.practionerId,
       })),
-    [teams],
+    [teams]
   );
 
   const SpecialitiesOptions = useMemo(
@@ -51,30 +59,62 @@ const AddRoom = ({ showModal, setShowModal }: AddRoomProps) => {
         label: speciality.name,
         value: speciality._id || speciality.name,
       })),
-    [specialities],
+    [specialities]
   );
+
+  const specialitiesById = useMemo(
+    () =>
+      Object.fromEntries((SpecialitiesOptions ?? []).map((option) => [option.value, option.label])),
+    [SpecialitiesOptions]
+  );
+
+  const teamsById = useMemo(
+    () => Object.fromEntries((TeamOptions ?? []).map((option) => [option.value, option.label])),
+    [TeamOptions]
+  );
+
+  const toReferenceMappings = (
+    ids: string[],
+    byId: Record<string, string>
+  ): RoomReferenceMapping[] =>
+    ids
+      .map((id) => {
+        const name = byId[id];
+        return name ? { id, name } : undefined;
+      })
+      .filter((entry): entry is RoomReferenceMapping => Boolean(entry));
+
+  const buildCode = (name: string) => name.trim().replace(/\s+/g, '-').toUpperCase();
 
   const handleSave = async () => {
     const errors: { name?: string } = {};
-    if (!formData.name) errors.name = "Name is required";
+    if (!formData.name) errors.name = 'Name is required';
     setFormDataErrors(errors);
     if (Object.keys(errors).length > 0) {
       return;
     }
     try {
-      await createRoom(formData);
-      notify("success", {
-        title: "Room created",
-        text: "Room has been created successfully.",
+      await createRoom({
+        id: '',
+        organisationId: '',
+        name: formData.name,
+        code: formData.code || buildCode(formData.name),
+        type: formData.type,
+        assignedSpecialiteis: toReferenceMappings(formData.assignedSpecialiteis, specialitiesById),
+        assignedStaffs: toReferenceMappings(formData.assignedStaffs, teamsById),
+      });
+      notify('success', {
+        title: 'Room created',
+        text: 'Room has been created successfully.',
       });
       setShowModal(false);
       setFormData(INITIAL_FORM_DATA);
       setFormDataErrors({});
     } catch (error) {
       console.log(error);
-      notify("error", {
-        title: "Unable to create room",
-        text: "Failed to create room. Please try again.",
+      notify('error', {
+        title: 'Unable to create room',
+        text: 'Failed to create room. Please try again.',
       });
     }
   };
@@ -93,21 +133,14 @@ const AddRoom = ({ showModal, setShowModal }: AddRoomProps) => {
         </div>
 
         <div className="flex overflow-y-auto flex-1 w-full flex-col gap-6 justify-between scrollbar-hidden">
-          <Accordion
-            title="Add room"
-            defaultOpen
-            showEditIcon={false}
-            isEditing={true}
-          >
+          <Accordion title="Add room" defaultOpen showEditIcon={false} isEditing={true}>
             <div className="flex flex-col gap-3">
               <FormInput
                 intype="text"
                 inname="name"
                 value={formData.name}
                 inlabel="Name"
-                onChange={(e) =>
-                  setFormData({ ...formData, name: e.target.value })
-                }
+                onChange={(e) => setFormData({ ...formData, name: e.target.value })}
                 error={formDataErrors.name}
               />
               <LabelDropdown
@@ -124,17 +157,13 @@ const AddRoom = ({ showModal, setShowModal }: AddRoomProps) => {
               <MultiSelectDropdown
                 placeholder="Assigned specialities"
                 value={formData.assignedSpecialiteis || []}
-                onChange={(e) =>
-                  setFormData({ ...formData, assignedSpecialiteis: e })
-                }
+                onChange={(e) => setFormData({ ...formData, assignedSpecialiteis: e })}
                 options={SpecialitiesOptions}
               />
               <MultiSelectDropdown
                 placeholder="Assigned staff"
                 value={formData.assignedStaffs || []}
-                onChange={(e) =>
-                  setFormData({ ...formData, assignedStaffs: e })
-                }
+                onChange={(e) => setFormData({ ...formData, assignedStaffs: e })}
                 options={TeamOptions}
               />
             </div>

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/RoomInfo.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/RoomInfo.tsx
@@ -1,21 +1,17 @@
-import EditableAccordion, {
-  FieldConfig,
-} from "@/app/ui/primitives/Accordion/EditableAccordion";
-import Modal from "@/app/ui/overlays/Modal";
-import { OrganisationRoom } from "@yosemite-crew/types";
-import React, { useMemo } from "react";
-import { RoomsTypes } from "@/app/features/organization/pages/Organization/types";
-import { useTeamForPrimaryOrg } from "@/app/hooks/useTeam";
-import { useSpecialitiesForPrimaryOrg } from "@/app/hooks/useSpecialities";
-import {
-  deleteRoom,
-  updateRoom,
-} from "@/app/features/organization/services/roomService";
-import Close from "@/app/ui/primitives/Icons/Close";
-import { useNotify } from "@/app/hooks/useNotify";
+import EditableAccordion, { FieldConfig } from '@/app/ui/primitives/Accordion/EditableAccordion';
+import Modal from '@/app/ui/overlays/Modal';
+import { OrganisationRoom } from '@yosemite-crew/types';
+import React, { useMemo } from 'react';
+import { RoomsTypes } from '@/app/features/organization/pages/Organization/types';
+import { useTeamForPrimaryOrg } from '@/app/hooks/useTeam';
+import { useSpecialitiesForPrimaryOrg } from '@/app/hooks/useSpecialities';
+import { deleteRoom, updateRoom } from '@/app/features/organization/services/roomService';
+import Close from '@/app/ui/primitives/Icons/Close';
+import { useNotify } from '@/app/hooks/useNotify';
+import type { RoomReferenceMapping } from '@yosemite-crew/types';
 
 const getErrorMessage = (error: unknown, fallback: string) => {
-  if (typeof error === "object" && error !== null) {
+  if (typeof error === 'object' && error !== null) {
     const maybeError = error as {
       message?: string;
       response?: {
@@ -46,28 +42,23 @@ const getFields = ({
   SpecialitiesOptions: { label: string; value: string }[];
 }) =>
   [
-    { label: "Name", key: "name", type: "text", required: true },
-    { label: "Type", key: "type", type: "dropdown", options: RoomsTypes },
+    { label: 'Name', key: 'name', type: 'text', required: true },
+    { label: 'Type', key: 'type', type: 'dropdown', options: RoomsTypes },
     {
-      label: "Assigned speciality",
-      key: "assignedSpecialiteis",
-      type: "multiSelect",
+      label: 'Assigned speciality',
+      key: 'assignedSpecialiteis',
+      type: 'multiSelect',
       options: SpecialitiesOptions,
     },
     {
-      label: "Assigned staff",
-      key: "assignedStaffs",
-      type: "multiSelect",
+      label: 'Assigned staff',
+      key: 'assignedStaffs',
+      type: 'multiSelect',
       options: TeamOptions,
     },
   ] satisfies FieldConfig[];
 
-const RoomInfo = ({
-  showModal,
-  setShowModal,
-  activeRoom,
-  canEditRoom,
-}: RoomInfoProps) => {
+const RoomInfo = ({ showModal, setShowModal, activeRoom, canEditRoom }: RoomInfoProps) => {
   const { notify } = useNotify();
   const teams = useTeamForPrimaryOrg();
   const specialities = useSpecialitiesForPrimaryOrg();
@@ -78,7 +69,7 @@ const RoomInfo = ({
         label: team.name || team.practionerId,
         value: team.practionerId,
       })),
-    [teams],
+    [teams]
   );
 
   const SpecialitiesOptions = useMemo(
@@ -87,22 +78,44 @@ const RoomInfo = ({
         label: speciality.name,
         value: speciality._id || speciality.name,
       })),
-    [specialities],
+    [specialities]
   );
+
+  const specialitiesById = useMemo(
+    () =>
+      Object.fromEntries((SpecialitiesOptions ?? []).map((option) => [option.value, option.label])),
+    [SpecialitiesOptions]
+  );
+
+  const teamsById = useMemo(
+    () => Object.fromEntries((TeamOptions ?? []).map((option) => [option.value, option.label])),
+    [TeamOptions]
+  );
+
+  const toReferenceMappings = (
+    ids: string[] | undefined,
+    byId: Record<string, string>
+  ): RoomReferenceMapping[] =>
+    (ids ?? [])
+      .map((id) => {
+        const name = byId[id];
+        return name ? { id, name } : undefined;
+      })
+      .filter((entry): entry is RoomReferenceMapping => Boolean(entry));
 
   const fields = useMemo(
     () => getFields({ TeamOptions, SpecialitiesOptions }),
-    [TeamOptions, SpecialitiesOptions],
+    [TeamOptions, SpecialitiesOptions]
   );
 
   const roomInfoData = useMemo(
     () => ({
-      name: activeRoom?.name ?? "",
-      type: activeRoom?.type ?? "",
-      assignedSpecialiteis: activeRoom?.assignedSpecialiteis ?? "",
-      assignedStaffs: activeRoom?.assignedStaffs ?? "",
+      name: activeRoom?.name ?? '',
+      type: activeRoom?.type ?? '',
+      assignedSpecialiteis: activeRoom?.assignedSpecialiteis?.map((item) => item.id) ?? [],
+      assignedStaffs: activeRoom?.assignedStaffs?.map((item) => item.id) ?? [],
     }),
-    [activeRoom],
+    [activeRoom]
   );
 
   const handleUpdate = async (values: any) => {
@@ -110,24 +123,22 @@ const RoomInfo = ({
       const formData: OrganisationRoom = {
         id: activeRoom.id,
         organisationId: activeRoom.organisationId,
+        code: activeRoom.code,
         name: values.name,
         type: values.type,
-        assignedSpecialiteis: values.assignedSpecialiteis,
-        assignedStaffs: values.assignedStaffs,
+        assignedSpecialiteis: toReferenceMappings(values.assignedSpecialiteis, specialitiesById),
+        assignedStaffs: toReferenceMappings(values.assignedStaffs, teamsById),
       };
       await updateRoom(formData);
-      notify("success", {
-        title: "Room updated",
-        text: "Room details have been updated successfully.",
+      notify('success', {
+        title: 'Room updated',
+        text: 'Room details have been updated successfully.',
       });
       setShowModal(false);
     } catch (error) {
-      notify("error", {
-        title: "Unable to update room",
-        text: getErrorMessage(
-          error,
-          "Failed to update room. Please try again.",
-        ),
+      notify('error', {
+        title: 'Unable to update room',
+        text: getErrorMessage(error, 'Failed to update room. Please try again.'),
       });
       throw error;
     }
@@ -136,18 +147,15 @@ const RoomInfo = ({
   const handleDelete = async () => {
     try {
       await deleteRoom(activeRoom);
-      notify("success", {
-        title: "Room deleted",
-        text: "Room has been deleted successfully.",
+      notify('success', {
+        title: 'Room deleted',
+        text: 'Room has been deleted successfully.',
       });
       setShowModal(false);
     } catch (error) {
-      notify("error", {
-        title: "Unable to delete room",
-        text: getErrorMessage(
-          error,
-          "Failed to delete room. Please try again.",
-        ),
+      notify('error', {
+        title: 'Unable to delete room',
+        text: getErrorMessage(error, 'Failed to delete room. Please try again.'),
       });
     }
   };

--- a/apps/frontend/src/app/ui/tables/tableUtils.ts
+++ b/apps/frontend/src/app/ui/tables/tableUtils.ts
@@ -1,4 +1,4 @@
-import { InvoiceItem } from '@yosemite-crew/types';
+import { InvoiceItem, RoomReferenceMapping } from '@yosemite-crew/types';
 import { Team } from '@/app/features/organization/types/team';
 import { getStatusBadgeStyle } from '@/app/features/inventory/pages/Inventory/utils';
 
@@ -240,7 +240,12 @@ export const getStringified = (services: string[] = []): string => {
   return services.join(', ');
 };
 
-export const joinNames = (byId: Record<string, string>, ids: string[] = []) => {
-  const names = ids.map((id) => byId[id]).filter(Boolean);
+export const joinNames = (
+  byId: Record<string, string>,
+  ids: Array<string | RoomReferenceMapping> = []
+) => {
+  const names = ids
+    .map((item) => (typeof item === 'string' ? byId[item] : item.name || byId[item.id]))
+    .filter((name): name is string => Boolean(name));
   return names.length ? names.join(', ') : '-';
 };

--- a/packages/auth/src/config/supertokens.config.ts
+++ b/packages/auth/src/config/supertokens.config.ts
@@ -21,11 +21,11 @@ function requireEnv(name: string): string {
   return value;
 }
 
-const smtpSettings = getSmtpSettings();
 const SUPERTOKENS_API_KEY_FIELD = 'apiKey' as const;
 
 export function getSuperTokensConfig(): TypeInput {
   const supertokensApiKey = process.env.SUPERTOKENS_API_KEY;
+  const smtpSettings = getSmtpSettings();
 
   return {
     framework: 'express',

--- a/packages/database/prisma/migrations/20260609102059_catalog_module/migration.sql
+++ b/packages/database/prisma/migrations/20260609102059_catalog_module/migration.sql
@@ -23,13 +23,13 @@ CREATE TYPE "ProductKind" AS ENUM ('CONSULTATION', 'PROCEDURE', 'DIAGNOSTIC', 'M
 CREATE TYPE "PackageItemPricingMode" AS ENUM ('INCLUDED', 'INHERITED_PRICE', 'OVERRIDE_PRICE');
 
 -- DropForeignKey
-ALTER TABLE "EnterpriseMembership" DROP CONSTRAINT "EnterpriseMembership_enterpriseId_fkey";
+ALTER TABLE public."EnterpriseMembership" DROP CONSTRAINT "EnterpriseMembership_enterpriseId_fkey";
 
 -- DropForeignKey
-ALTER TABLE "Tenant" DROP CONSTRAINT "Tenant_enterpriseId_fkey";
+ALTER TABLE public."Tenant" DROP CONSTRAINT "Tenant_enterpriseId_fkey";
 
 -- DropForeignKey
-ALTER TABLE "TenantMembership" DROP CONSTRAINT "TenantMembership_tenantId_fkey";
+ALTER TABLE public."TenantMembership" DROP CONSTRAINT "TenantMembership_tenantId_fkey";
 
 -- DropForeignKey
 ALTER TABLE "auth_challenges" DROP CONSTRAINT "auth_challenges_authAccountId_fkey";
@@ -54,16 +54,16 @@ ADD COLUMN     "productItemId" TEXT;
 ALTER TABLE "Speciality" ADD COLUMN     "isActive" BOOLEAN NOT NULL DEFAULT true;
 
 -- DropTable
-DROP TABLE "Enterprise";
+DROP TABLE public."Enterprise";
 
 -- DropTable
-DROP TABLE "EnterpriseMembership";
+DROP TABLE public."EnterpriseMembership";
 
 -- DropTable
-DROP TABLE "Tenant";
+DROP TABLE public."Tenant";
 
 -- DropTable
-DROP TABLE "TenantMembership";
+DROP TABLE public."TenantMembership";
 
 -- DropTable
 DROP TABLE "auth_accounts";

--- a/packages/database/prisma/migrations/20260611113000_case_encounter_backbone/migration.sql
+++ b/packages/database/prisma/migrations/20260611113000_case_encounter_backbone/migration.sql
@@ -1,0 +1,71 @@
+-- CreateTable
+CREATE TABLE "Case" (
+    "id" TEXT NOT NULL,
+    "organisationId" TEXT NOT NULL,
+    "companionId" TEXT NOT NULL,
+    "parentId" TEXT,
+    "status" TEXT NOT NULL,
+    "appointmentKind" "AppointmentKind" NOT NULL DEFAULT 'OUTPATIENT',
+    "title" TEXT,
+    "description" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Case_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Encounter" (
+    "id" TEXT NOT NULL,
+    "caseId" TEXT NOT NULL,
+    "organisationId" TEXT NOT NULL,
+    "companionId" TEXT NOT NULL,
+    "parentId" TEXT,
+    "status" TEXT NOT NULL,
+    "encounterClass" TEXT NOT NULL,
+    "appointmentKind" "AppointmentKind" NOT NULL DEFAULT 'OUTPATIENT',
+    "title" TEXT,
+    "reason" TEXT,
+    "periodStart" TIMESTAMP(3),
+    "periodEnd" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Encounter_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Case_organisationId_status_idx" ON "Case"("organisationId", "status");
+
+-- CreateIndex
+CREATE INDEX "Case_organisationId_appointmentKind_idx" ON "Case"("organisationId", "appointmentKind");
+
+-- CreateIndex
+CREATE INDEX "Case_companionId_idx" ON "Case"("companionId");
+
+-- CreateIndex
+CREATE INDEX "Case_parentId_idx" ON "Case"("parentId");
+
+-- CreateIndex
+CREATE INDEX "Encounter_caseId_idx" ON "Encounter"("caseId");
+
+-- CreateIndex
+CREATE INDEX "Encounter_organisationId_status_idx" ON "Encounter"("organisationId", "status");
+
+-- CreateIndex
+CREATE INDEX "Encounter_organisationId_appointmentKind_idx" ON "Encounter"("organisationId", "appointmentKind");
+
+-- CreateIndex
+CREATE INDEX "Encounter_companionId_idx" ON "Encounter"("companionId");
+
+-- CreateIndex
+CREATE INDEX "Encounter_parentId_idx" ON "Encounter"("parentId");
+
+-- AddForeignKey
+ALTER TABLE "Appointment" ADD CONSTRAINT "Appointment_caseId_fkey" FOREIGN KEY ("caseId") REFERENCES "Case"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Appointment" ADD CONSTRAINT "Appointment_encounterId_fkey" FOREIGN KEY ("encounterId") REFERENCES "Encounter"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Encounter" ADD CONSTRAINT "Encounter_caseId_fkey" FOREIGN KEY ("caseId") REFERENCES "Case"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/database/prisma/migrations/20260611131500_admission_overlay/migration.sql
+++ b/packages/database/prisma/migrations/20260611131500_admission_overlay/migration.sql
@@ -1,0 +1,26 @@
+-- CreateTable
+CREATE TABLE "Admission" (
+    "encounterId" TEXT NOT NULL,
+    "organisationId" TEXT NOT NULL,
+    "companionId" TEXT NOT NULL,
+    "bedUnitId" TEXT,
+    "expectedStayDays" INTEGER,
+    "admittedAt" TIMESTAMP(3) NOT NULL,
+    "dischargedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Admission_pkey" PRIMARY KEY ("encounterId")
+);
+
+-- CreateIndex
+CREATE INDEX "Admission_organisationId_admittedAt_idx" ON "Admission"("organisationId", "admittedAt");
+
+-- CreateIndex
+CREATE INDEX "Admission_organisationId_dischargedAt_idx" ON "Admission"("organisationId", "dischargedAt");
+
+-- CreateIndex
+CREATE INDEX "Admission_companionId_idx" ON "Admission"("companionId");
+
+-- AddForeignKey
+ALTER TABLE "Admission" ADD CONSTRAINT "Admission_encounterId_fkey" FOREIGN KEY ("encounterId") REFERENCES "Encounter"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/database/prisma/migrations/20260611150000_room_unit_assignment/migration.sql
+++ b/packages/database/prisma/migrations/20260611150000_room_unit_assignment/migration.sql
@@ -1,0 +1,73 @@
+-- AlterTable
+ALTER TABLE "Admission" RENAME COLUMN "bedUnitId" TO "unitId";
+
+-- CreateTable
+CREATE TABLE "RoomUnit" (
+    "id" TEXT NOT NULL,
+    "organisationId" TEXT NOT NULL,
+    "roomId" TEXT NOT NULL,
+    "code" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "size" TEXT,
+    "speciesConstraints" JSONB,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RoomUnit_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RoomUnitAssignment" (
+    "id" TEXT NOT NULL,
+    "encounterId" TEXT NOT NULL,
+    "admissionId" TEXT NOT NULL,
+    "unitId" TEXT NOT NULL,
+    "assignedAt" TIMESTAMP(3) NOT NULL,
+    "releasedAt" TIMESTAMP(3),
+    "assignedBy" TEXT,
+    "reason" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RoomUnitAssignment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RoomUnit_roomId_code_key" ON "RoomUnit"("roomId", "code");
+
+-- CreateIndex
+CREATE INDEX "RoomUnit_organisationId_idx" ON "RoomUnit"("organisationId");
+
+-- CreateIndex
+CREATE INDEX "RoomUnit_roomId_idx" ON "RoomUnit"("roomId");
+
+-- CreateIndex
+CREATE INDEX "RoomUnit_organisationId_isActive_idx" ON "RoomUnit"("organisationId", "isActive");
+
+-- CreateIndex
+CREATE INDEX "RoomUnitAssignment_encounterId_assignedAt_idx" ON "RoomUnitAssignment"("encounterId", "assignedAt");
+
+-- CreateIndex
+CREATE INDEX "RoomUnitAssignment_admissionId_assignedAt_idx" ON "RoomUnitAssignment"("admissionId", "assignedAt");
+
+-- CreateIndex
+CREATE INDEX "RoomUnitAssignment_unitId_assignedAt_idx" ON "RoomUnitAssignment"("unitId", "assignedAt");
+
+-- CreateIndex
+CREATE INDEX "RoomUnitAssignment_releasedAt_idx" ON "RoomUnitAssignment"("releasedAt");
+
+-- AddForeignKey
+ALTER TABLE "Admission" ADD CONSTRAINT "Admission_unitId_fkey" FOREIGN KEY ("unitId") REFERENCES "RoomUnit"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RoomUnit" ADD CONSTRAINT "RoomUnit_roomId_fkey" FOREIGN KEY ("roomId") REFERENCES "OrganisationRoom"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RoomUnitAssignment" ADD CONSTRAINT "RoomUnitAssignment_encounterId_fkey" FOREIGN KEY ("encounterId") REFERENCES "Encounter"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RoomUnitAssignment" ADD CONSTRAINT "RoomUnitAssignment_admissionId_fkey" FOREIGN KEY ("admissionId") REFERENCES "Admission"("encounterId") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RoomUnitAssignment" ADD CONSTRAINT "RoomUnitAssignment_unitId_fkey" FOREIGN KEY ("unitId") REFERENCES "RoomUnit"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/database/prisma/migrations/20260611170000_room_availability_capabilities/migration.sql
+++ b/packages/database/prisma/migrations/20260611170000_room_availability_capabilities/migration.sql
@@ -1,0 +1,16 @@
+-- CreateEnum
+CREATE TYPE "RoomAvailabilityMode" AS ENUM ('DEFAULT', 'ALWAYS_ON', 'CUSTOM');
+
+-- AlterTable
+ALTER TABLE "OrganisationRoom"
+ADD COLUMN "code" TEXT,
+ADD COLUMN "availableNow" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN "availabilityMode" "RoomAvailabilityMode" NOT NULL DEFAULT 'DEFAULT',
+ADD COLUMN "availabilityDays" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+ADD COLUMN "availabilityStartTime" TEXT,
+ADD COLUMN "availabilityEndTime" TEXT,
+ADD COLUMN "speciesConstraints" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+ADD COLUMN "capabilities" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];
+
+-- CreateIndex
+CREATE INDEX "OrganisationRoom_organisationId_availableNow_idx" ON "OrganisationRoom"("organisationId", "availableNow");

--- a/packages/database/prisma/migrations/20260612000000_room_unit_management_cleanup/migration.sql
+++ b/packages/database/prisma/migrations/20260612000000_room_unit_management_cleanup/migration.sql
@@ -1,0 +1,84 @@
+-- AlterEnum
+ALTER TYPE "RoomType" RENAME VALUE 'WAITING_AREA' TO 'WAITING';
+ALTER TYPE "RoomType" ADD VALUE IF NOT EXISTS 'EXAM_ROOM';
+ALTER TYPE "RoomType" ADD VALUE IF NOT EXISTS 'TREATMENT';
+ALTER TYPE "RoomType" ADD VALUE IF NOT EXISTS 'DENTAL';
+ALTER TYPE "RoomType" ADD VALUE IF NOT EXISTS 'IMAGING';
+ALTER TYPE "RoomType" ADD VALUE IF NOT EXISTS 'GROOMING';
+ALTER TYPE "RoomType" ADD VALUE IF NOT EXISTS 'INPATIENT';
+ALTER TYPE "RoomType" ADD VALUE IF NOT EXISTS 'ISOLATION';
+ALTER TYPE "RoomType" ADD VALUE IF NOT EXISTS 'BOARDING';
+ALTER TYPE "RoomType" ADD VALUE IF NOT EXISTS 'RECEPTION';
+
+-- CreateEnum
+CREATE TYPE "RoomOccupancyStatus" AS ENUM ('VACANT', 'OCCUPIED');
+
+-- AlterEnum
+ALTER TYPE "RoomAvailabilityMode" RENAME VALUE 'DEFAULT' TO 'WORKING_HOURS';
+ALTER TYPE "RoomAvailabilityMode" RENAME VALUE 'ALWAYS_ON' TO 'ALL_DAY';
+
+-- AlterTable
+ALTER TABLE "OrganisationRoom" DROP COLUMN IF EXISTS "fhirId";
+ALTER TABLE "OrganisationRoom" DROP COLUMN "speciesConstraints";
+ALTER TABLE "OrganisationRoom" ADD COLUMN "description" TEXT;
+ALTER TABLE "OrganisationRoom" ADD COLUMN "occupancyStatus" "RoomOccupancyStatus" NOT NULL DEFAULT 'VACANT';
+
+UPDATE "OrganisationRoom"
+SET "code" = COALESCE(
+  NULLIF("code", ''),
+  'ROOM-' || SUBSTRING(REPLACE("id", '-', '') FROM 1 FOR 8)
+)
+WHERE "code" IS NULL OR TRIM("code") = '';
+
+ALTER TABLE "OrganisationRoom" ALTER COLUMN "code" SET NOT NULL;
+ALTER TABLE "OrganisationRoom" ALTER COLUMN "availabilityMode" SET DEFAULT 'ALL_DAY';
+
+-- AlterTable
+ALTER TABLE "RoomUnit" ADD COLUMN "unitGroupId" TEXT;
+
+-- CreateTable
+CREATE TABLE "RoomUnitGroup" (
+    "id" TEXT NOT NULL,
+    "organisationId" TEXT NOT NULL,
+    "roomId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "size" TEXT,
+    "unitCount" INTEGER NOT NULL DEFAULT 0,
+    "speciesConstraints" JSONB,
+    "capabilities" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RoomUnitGroup_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+DROP INDEX "OrganisationRoom_organisationId_availableNow_idx";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "OrganisationRoom_organisationId_code_key" ON "OrganisationRoom"("organisationId", "code");
+
+-- CreateIndex
+CREATE INDEX "OrganisationRoom_organisationId_type_idx" ON "OrganisationRoom"("organisationId", "type");
+
+-- CreateIndex
+CREATE INDEX "RoomUnit_unitGroupId_idx" ON "RoomUnit"("unitGroupId");
+
+-- CreateIndex
+CREATE INDEX "RoomUnitGroup_organisationId_idx" ON "RoomUnitGroup"("organisationId");
+
+-- CreateIndex
+CREATE INDEX "RoomUnitGroup_roomId_idx" ON "RoomUnitGroup"("roomId");
+
+-- CreateIndex
+CREATE INDEX "RoomUnitGroup_isActive_idx" ON "RoomUnitGroup"("isActive");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RoomUnitGroup_roomId_name_key" ON "RoomUnitGroup"("roomId", "name");
+
+-- AddForeignKey
+ALTER TABLE "RoomUnit" ADD CONSTRAINT "RoomUnit_unitGroupId_fkey" FOREIGN KEY ("unitGroupId") REFERENCES "RoomUnitGroup"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RoomUnitGroup" ADD CONSTRAINT "RoomUnitGroup_roomId_fkey" FOREIGN KEY ("roomId") REFERENCES "OrganisationRoom"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/database/prisma/migrations/20260612013000_room_reference_mappings/migration.sql
+++ b/packages/database/prisma/migrations/20260612013000_room_reference_mappings/migration.sql
@@ -1,0 +1,65 @@
+-- Remove denormalized string arrays.
+ALTER TABLE "OrganisationRoom"
+DROP COLUMN IF EXISTS "assignedSpecialiteis",
+DROP COLUMN IF EXISTS "assignedStaffs";
+
+-- Store room assignments as proper mapping rows.
+CREATE TABLE "OrganisationRoomSpeciality" (
+  "id" TEXT NOT NULL,
+  "organisationId" TEXT NOT NULL,
+  "roomId" TEXT NOT NULL,
+  "specialityId" TEXT NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "OrganisationRoomSpeciality_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "OrganisationRoomStaff" (
+  "id" TEXT NOT NULL,
+  "organisationId" TEXT NOT NULL,
+  "roomId" TEXT NOT NULL,
+  "staffUserId" TEXT NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "OrganisationRoomStaff_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "OrganisationRoomSpeciality_roomId_specialityId_key"
+  ON "OrganisationRoomSpeciality"("roomId", "specialityId");
+CREATE INDEX "OrganisationRoomSpeciality_organisationId_idx"
+  ON "OrganisationRoomSpeciality"("organisationId");
+CREATE INDEX "OrganisationRoomSpeciality_roomId_idx"
+  ON "OrganisationRoomSpeciality"("roomId");
+CREATE INDEX "OrganisationRoomSpeciality_specialityId_idx"
+  ON "OrganisationRoomSpeciality"("specialityId");
+
+CREATE UNIQUE INDEX "OrganisationRoomStaff_roomId_staffUserId_key"
+  ON "OrganisationRoomStaff"("roomId", "staffUserId");
+CREATE INDEX "OrganisationRoomStaff_organisationId_idx"
+  ON "OrganisationRoomStaff"("organisationId");
+CREATE INDEX "OrganisationRoomStaff_roomId_idx"
+  ON "OrganisationRoomStaff"("roomId");
+CREATE INDEX "OrganisationRoomStaff_staffUserId_idx"
+  ON "OrganisationRoomStaff"("staffUserId");
+
+ALTER TABLE "OrganisationRoomSpeciality"
+ADD CONSTRAINT "OrganisationRoomSpeciality_roomId_fkey"
+FOREIGN KEY ("roomId") REFERENCES "OrganisationRoom"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "OrganisationRoomSpeciality"
+ADD CONSTRAINT "OrganisationRoomSpeciality_specialityId_fkey"
+FOREIGN KEY ("specialityId") REFERENCES "Speciality"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "OrganisationRoomStaff"
+ADD CONSTRAINT "OrganisationRoomStaff_roomId_fkey"
+FOREIGN KEY ("roomId") REFERENCES "OrganisationRoom"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "OrganisationRoomStaff"
+ADD CONSTRAINT "OrganisationRoomStaff_staffUserId_fkey"
+FOREIGN KEY ("staffUserId") REFERENCES "User"("userId")
+ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -732,6 +732,8 @@ model User {
   lastName  String?
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  roomStaffLinks OrganisationRoomStaff[]
 }
 
 model UserProfile {
@@ -831,10 +833,30 @@ enum OrgDocumentVisibility {
 }
 
 enum RoomType {
-  CONSULTATION
-  WAITING_AREA
+  EXAM_ROOM
+  TREATMENT
   SURGERY
+  DENTAL
+  IMAGING
+  WAITING
+  GROOMING
   ICU
+  INPATIENT
+  ISOLATION
+  BOARDING
+  RECEPTION
+  CONSULTATION
+}
+
+enum RoomOccupancyStatus {
+  VACANT
+  OCCUPIED
+}
+
+enum RoomAvailabilityMode {
+  WORKING_HOURS
+  ALL_DAY
+  CUSTOM
 }
 
 enum OrganisationInviteEmploymentType {
@@ -933,26 +955,71 @@ model OrganizationDocument {
 }
 
 model OrganisationRoom {
-  id                   String   @id @default(uuid())
-  fhirId               String?
-  organisationId       String
-  name                 String
-  type                 RoomType
-  assignedSpecialiteis String[]
-  assignedStaffs       String[]
-  createdAt            DateTime @default(now())
-  updatedAt            DateTime @updatedAt
+  id                    String                @id @default(uuid())
+  organisationId        String
+  name                  String
+  code                  String
+  description           String?
+  type                  RoomType
+  occupancyStatus       RoomOccupancyStatus   @default(VACANT)
+  availableNow          Boolean               @default(true)
+  availabilityMode      RoomAvailabilityMode  @default(ALL_DAY)
+  availabilityDays      String[]              @default([])
+  availabilityStartTime  String?
+  availabilityEndTime    String?
+  capabilities          String[]              @default([])
+  createdAt             DateTime              @default(now())
+  updatedAt             DateTime              @updatedAt
 
-  units                RoomUnit[]
+  units                 RoomUnit[]
+  unitGroups            RoomUnitGroup[]
+  specialityLinks       OrganisationRoomSpeciality[]
+  staffLinks            OrganisationRoomStaff[]
 
-  @@index([fhirId])
+  @@unique([organisationId, code])
   @@index([organisationId])
+  @@index([organisationId, type])
+}
+
+model OrganisationRoomSpeciality {
+  id             String   @id @default(uuid())
+  organisationId String
+  roomId         String
+  specialityId   String
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  room           OrganisationRoom @relation(fields: [roomId], references: [id], onDelete: Cascade)
+  speciality     Speciality       @relation(fields: [specialityId], references: [id], onDelete: Cascade)
+
+  @@unique([roomId, specialityId])
+  @@index([organisationId])
+  @@index([roomId])
+  @@index([specialityId])
+}
+
+model OrganisationRoomStaff {
+  id             String   @id @default(uuid())
+  organisationId String
+  roomId         String
+  staffUserId    String
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  room           OrganisationRoom @relation(fields: [roomId], references: [id], onDelete: Cascade)
+  staff          User             @relation(fields: [staffUserId], references: [userId], onDelete: Cascade)
+
+  @@unique([roomId, staffUserId])
+  @@index([organisationId])
+  @@index([roomId])
+  @@index([staffUserId])
 }
 
 model RoomUnit {
   id                 String   @id @default(uuid())
   organisationId     String
   roomId             String
+  unitGroupId        String?
   code               String
   displayName        String
   size               String?
@@ -962,13 +1029,37 @@ model RoomUnit {
   updatedAt          DateTime @updatedAt
 
   room               OrganisationRoom     @relation(fields: [roomId], references: [id], onDelete: Cascade)
+  unitGroup          RoomUnitGroup?       @relation(fields: [unitGroupId], references: [id], onDelete: SetNull)
   currentAdmissions  Admission[]          @relation("AdmissionCurrentUnit")
   assignments        RoomUnitAssignment[]
 
   @@unique([roomId, code])
   @@index([organisationId])
   @@index([roomId])
+  @@index([unitGroupId])
   @@index([organisationId, isActive])
+}
+
+model RoomUnitGroup {
+  id                  String   @id @default(uuid())
+  organisationId      String
+  roomId              String
+  name                String
+  size                String?
+  unitCount           Int      @default(0)
+  speciesConstraints   Json?
+  capabilities        String[] @default([])
+  isActive            Boolean  @default(true)
+  createdAt           DateTime @default(now())
+  updatedAt           DateTime @updatedAt
+
+  room                OrganisationRoom @relation(fields: [roomId], references: [id], onDelete: Cascade)
+  units               RoomUnit[]
+
+  @@index([organisationId])
+  @@index([roomId])
+  @@index([isActive])
+  @@unique([roomId, name])
 }
 
 model RoomUnitAssignment {
@@ -1839,6 +1930,8 @@ model Speciality {
   isActive           Boolean  @default(true)
   createdAt          DateTime @default(now())
   updatedAt          DateTime @updatedAt
+
+  roomLinks          OrganisationRoomSpeciality[]
 
   @@index([organisationId])
   @@index([organisationId, isActive])

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -578,6 +578,7 @@ model Encounter {
   caseRecord      Case            @relation(fields: [caseId], references: [id], onDelete: Cascade)
   appointments    Appointment[]   @relation("EncounterAppointments")
   admission       Admission?
+  unitAssignments RoomUnitAssignment[]
 
   @@index([caseId])
   @@index([organisationId, status])
@@ -590,7 +591,7 @@ model Admission {
   encounterId       String   @id
   organisationId    String
   companionId       String
-  bedUnitId         String?
+  unitId            String?
   expectedStayDays  Int?
   admittedAt        DateTime
   dischargedAt      DateTime?
@@ -598,6 +599,8 @@ model Admission {
   updatedAt         DateTime @updatedAt
 
   encounter         Encounter @relation(fields: [encounterId], references: [id], onDelete: Cascade)
+  currentUnit       RoomUnit? @relation("AdmissionCurrentUnit", fields: [unitId], references: [id], onDelete: SetNull)
+  assignments       RoomUnitAssignment[]
 
   @@index([organisationId, admittedAt])
   @@index([organisationId, dischargedAt])
@@ -940,8 +943,54 @@ model OrganisationRoom {
   createdAt            DateTime @default(now())
   updatedAt            DateTime @updatedAt
 
+  units                RoomUnit[]
+
   @@index([fhirId])
   @@index([organisationId])
+}
+
+model RoomUnit {
+  id                 String   @id @default(uuid())
+  organisationId     String
+  roomId             String
+  code               String
+  displayName        String
+  size               String?
+  speciesConstraints Json?
+  isActive           Boolean  @default(true)
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+
+  room               OrganisationRoom     @relation(fields: [roomId], references: [id], onDelete: Cascade)
+  currentAdmissions  Admission[]          @relation("AdmissionCurrentUnit")
+  assignments        RoomUnitAssignment[]
+
+  @@unique([roomId, code])
+  @@index([organisationId])
+  @@index([roomId])
+  @@index([organisationId, isActive])
+}
+
+model RoomUnitAssignment {
+  id           String   @id @default(uuid())
+  encounterId  String
+  admissionId  String
+  unitId       String
+  assignedAt   DateTime
+  releasedAt   DateTime?
+  assignedBy   String?
+  reason       String?
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  encounter    Encounter  @relation(fields: [encounterId], references: [id], onDelete: Cascade)
+  admission    Admission  @relation(fields: [admissionId], references: [encounterId], onDelete: Cascade)
+  unit         RoomUnit   @relation(fields: [unitId], references: [id], onDelete: Cascade)
+
+  @@index([encounterId, assignedAt])
+  @@index([admissionId, assignedAt])
+  @@index([unitId, assignedAt])
+  @@index([releasedAt])
 }
 
 model OrganisationInvite {

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -577,12 +577,31 @@ model Encounter {
 
   caseRecord      Case            @relation(fields: [caseId], references: [id], onDelete: Cascade)
   appointments    Appointment[]   @relation("EncounterAppointments")
+  admission       Admission?
 
   @@index([caseId])
   @@index([organisationId, status])
   @@index([organisationId, appointmentKind])
   @@index([companionId])
   @@index([parentId])
+}
+
+model Admission {
+  encounterId       String   @id
+  organisationId    String
+  companionId       String
+  bedUnitId         String?
+  expectedStayDays  Int?
+  admittedAt        DateTime
+  dischargedAt      DateTime?
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
+
+  encounter         Encounter @relation(fields: [encounterId], references: [id], onDelete: Cascade)
+
+  @@index([organisationId, admittedAt])
+  @@index([organisationId, dischargedAt])
+  @@index([companionId])
 }
 
 model ChatSession {

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -525,6 +525,9 @@ model Appointment {
   createdAt         DateTime          @default(now())
   updatedAt         DateTime          @updatedAt
 
+  caseRecord        Case?             @relation("CaseAppointments", fields: [caseId], references: [id], onDelete: SetNull)
+  encounter         Encounter?        @relation("EncounterAppointments", fields: [encounterId], references: [id], onDelete: SetNull)
+
   @@index([organisationId, appointmentDate])
   @@index([organisationId])
   @@index([organisationId, productItemId])
@@ -533,6 +536,53 @@ model Appointment {
   @@index([status])
   @@index([expiresAt])
   @@unique([organisationId, idempotencyKey])
+}
+
+model Case {
+  id              String          @id @default(uuid())
+  organisationId  String
+  companionId     String
+  parentId        String?
+  status          String
+  appointmentKind AppointmentKind @default(OUTPATIENT)
+  title           String?
+  description     String?
+  createdAt       DateTime        @default(now())
+  updatedAt       DateTime        @updatedAt
+
+  appointments    Appointment[]   @relation("CaseAppointments")
+  encounters      Encounter[]
+
+  @@index([organisationId, status])
+  @@index([organisationId, appointmentKind])
+  @@index([companionId])
+  @@index([parentId])
+}
+
+model Encounter {
+  id              String          @id @default(uuid())
+  caseId          String
+  organisationId  String
+  companionId     String
+  parentId        String?
+  status          String
+  encounterClass  String
+  appointmentKind AppointmentKind @default(OUTPATIENT)
+  title           String?
+  reason          String?
+  periodStart     DateTime?
+  periodEnd       DateTime?
+  createdAt       DateTime        @default(now())
+  updatedAt       DateTime        @updatedAt
+
+  caseRecord      Case            @relation(fields: [caseId], references: [id], onDelete: Cascade)
+  appointments    Appointment[]   @relation("EncounterAppointments")
+
+  @@index([caseId])
+  @@index([organisationId, status])
+  @@index([organisationId, appointmentKind])
+  @@index([companionId])
+  @@index([parentId])
 }
 
 model ChatSession {

--- a/packages/types/src/admission.ts
+++ b/packages/types/src/admission.ts
@@ -2,7 +2,7 @@ export type Admission = {
   encounterId: string;
   organisationId: string;
   companionId: string;
-  bedUnitId?: string;
+  unitId?: string;
   expectedStayDays?: number;
   admittedAt: Date;
   dischargedAt?: Date;

--- a/packages/types/src/admission.ts
+++ b/packages/types/src/admission.ts
@@ -1,0 +1,11 @@
+export type Admission = {
+  encounterId: string;
+  organisationId: string;
+  companionId: string;
+  bedUnitId?: string;
+  expectedStayDays?: number;
+  admittedAt: Date;
+  dischargedAt?: Date;
+  createdAt?: Date;
+  updatedAt?: Date;
+};

--- a/packages/types/src/appointment.ts
+++ b/packages/types/src/appointment.ts
@@ -21,6 +21,8 @@ export type AppointmentPaymentStatus = 'PAID' | 'UNPAID';
 
 export type Appointment = {
   id?: string;
+  caseId?: string;
+  encounterId?: string;
   companion: {
     id: string;
     name: string;
@@ -84,6 +86,10 @@ const EXT_APPOINTMENT_FORM_IDS =
 const EXT_APPOINTMENT_PAYMENT_STATUS =
   'https://yosemitecrew.com/fhir/StructureDefinition/appointment-payment-status';
 const EXT_APPOINTMENT_KIND = 'https://yosemitecrew.com/fhir/StructureDefinition/appointment-kind';
+const EXT_APPOINTMENT_CASE_ID =
+  'https://yosemitecrew.com/fhir/StructureDefinition/appointment-case-id';
+const EXT_APPOINTMENT_ENCOUNTER_ID =
+  'https://yosemitecrew.com/fhir/StructureDefinition/appointment-encounter-id';
 
 export function toFHIRAppointment(appointment: Appointment): FHIRAppointment {
   const participants: AppointmentParticipant[] = [];
@@ -277,6 +283,20 @@ export function toFHIRAppointment(appointment: Appointment): FHIRAppointment {
     });
   }
 
+  if (appointment.caseId) {
+    extension.push({
+      url: EXT_APPOINTMENT_CASE_ID,
+      valueString: appointment.caseId,
+    });
+  }
+
+  if (appointment.encounterId) {
+    extension.push({
+      url: EXT_APPOINTMENT_ENCOUNTER_ID,
+      valueString: appointment.encounterId,
+    });
+  }
+
   const fhirAppointment: FHIRAppointment = {
     resourceType: 'Appointment',
     id: appointment.id,
@@ -359,6 +379,12 @@ export function fromFHIRAppointment(FHIRappointment: FHIRAppointment): Appointme
   )?.valueString as AppointmentPaymentStatus | undefined;
   const appointmentKind = FHIRappointment.extension?.find((ext) => ext.url === EXT_APPOINTMENT_KIND)
     ?.valueString as AppointmentKind | undefined;
+  const caseId = FHIRappointment.extension?.find(
+    (ext) => ext.url === EXT_APPOINTMENT_CASE_ID
+  )?.valueString;
+  const encounterId = FHIRappointment.extension?.find(
+    (ext) => ext.url === EXT_APPOINTMENT_ENCOUNTER_ID
+  )?.valueString;
 
   // Construct internal Appointment object
   const leadId = leadParticipant?.actor?.reference?.split('/')[1] ?? '';
@@ -369,6 +395,8 @@ export function fromFHIRAppointment(FHIRappointment: FHIRAppointment): Appointme
 
   const appointment: Appointment = {
     id: FHIRappointment.id ?? '',
+    caseId: caseId || undefined,
+    encounterId: encounterId || undefined,
     organisationId: orgParticipant?.actor?.reference?.split('/')[1] ?? 'unknown-org',
     companion: {
       id: companionParticipant?.actor?.reference?.split('/')[1] ?? 'unknown-pet',

--- a/packages/types/src/appointment.ts
+++ b/packages/types/src/appointment.ts
@@ -6,6 +6,7 @@ import type {
 } from '@yosemite-crew/fhir';
 import dayjs from 'dayjs';
 import { SPECIES_SYSTEM_URL } from './companion';
+import type { AppointmentKind } from './catalog';
 
 export type AppointmentStatus =
   | 'REQUESTED'
@@ -52,6 +53,7 @@ export type Appointment = {
       name: string;
     };
   };
+  appointmentKind?: AppointmentKind;
   organisationId: string; // Org / clinic
   appointmentDate: Date; // Date of the appointment
   startTime: Date; // Booking start timestamp
@@ -81,6 +83,7 @@ const EXT_APPOINTMENT_FORM_IDS =
   'https://yosemitecrew.com/fhir/StructureDefinition/appointment-form-id';
 const EXT_APPOINTMENT_PAYMENT_STATUS =
   'https://yosemitecrew.com/fhir/StructureDefinition/appointment-payment-status';
+const EXT_APPOINTMENT_KIND = 'https://yosemitecrew.com/fhir/StructureDefinition/appointment-kind';
 
 export function toFHIRAppointment(appointment: Appointment): FHIRAppointment {
   const participants: AppointmentParticipant[] = [];
@@ -267,6 +270,13 @@ export function toFHIRAppointment(appointment: Appointment): FHIRAppointment {
     });
   }
 
+  if (appointment.appointmentKind) {
+    extension.push({
+      url: EXT_APPOINTMENT_KIND,
+      valueString: appointment.appointmentKind,
+    });
+  }
+
   const fhirAppointment: FHIRAppointment = {
     resourceType: 'Appointment',
     id: appointment.id,
@@ -347,6 +357,8 @@ export function fromFHIRAppointment(FHIRappointment: FHIRAppointment): Appointme
   const paymentStatus = FHIRappointment.extension?.find(
     (ext) => ext.url === EXT_APPOINTMENT_PAYMENT_STATUS
   )?.valueString as AppointmentPaymentStatus | undefined;
+  const appointmentKind = FHIRappointment.extension?.find((ext) => ext.url === EXT_APPOINTMENT_KIND)
+    ?.valueString as AppointmentKind | undefined;
 
   // Construct internal Appointment object
   const leadId = leadParticipant?.actor?.reference?.split('/')[1] ?? '';
@@ -403,6 +415,7 @@ export function fromFHIRAppointment(FHIRappointment: FHIRAppointment): Appointme
         name: specialityCoding?.display || '',
       },
     },
+    appointmentKind: appointmentKind ?? 'OUTPATIENT',
     isEmergency: emergencyExtension?.valueBoolean,
     attachments,
     formIds,

--- a/packages/types/src/case.ts
+++ b/packages/types/src/case.ts
@@ -1,0 +1,98 @@
+import type { EpisodeOfCare, Extension } from '@yosemite-crew/fhir';
+import type { AppointmentKind } from './catalog';
+
+export const CASE_STATUSES = [
+  'planned',
+  'waitlist',
+  'active',
+  'onhold',
+  'finished',
+  'cancelled',
+  'entered-in-error',
+] as const;
+
+export type CaseStatus = (typeof CASE_STATUSES)[number];
+
+export type Case = {
+  id?: string;
+  organisationId: string;
+  companionId: string;
+  parentId?: string;
+  status: CaseStatus;
+  appointmentKind: AppointmentKind;
+  title?: string;
+  description?: string;
+  createdAt?: Date;
+  updatedAt?: Date;
+};
+
+const EXT_CASE_PARENT_ID = 'https://yosemitecrew.com/fhir/StructureDefinition/case-parent-id';
+const EXT_CASE_APPOINTMENT_KIND =
+  'https://yosemitecrew.com/fhir/StructureDefinition/case-appointment-kind';
+const EXT_CASE_TITLE = 'https://yosemitecrew.com/fhir/StructureDefinition/case-title';
+const EXT_CASE_DESCRIPTION = 'https://yosemitecrew.com/fhir/StructureDefinition/case-description';
+
+const getStringExtension = (extensions: Extension[] | undefined, url: string): string | undefined =>
+  extensions?.find((extension) => extension.url === url)?.valueString ?? undefined;
+
+export const toFHIRCase = (value: Case): EpisodeOfCare => {
+  const extension: Extension[] = [
+    {
+      url: EXT_CASE_APPOINTMENT_KIND,
+      valueString: value.appointmentKind,
+    },
+  ];
+
+  if (value.parentId) {
+    extension.push({
+      url: EXT_CASE_PARENT_ID,
+      valueString: value.parentId,
+    });
+  }
+
+  if (value.title) {
+    extension.push({
+      url: EXT_CASE_TITLE,
+      valueString: value.title,
+    });
+  }
+
+  if (value.description) {
+    extension.push({
+      url: EXT_CASE_DESCRIPTION,
+      valueString: value.description,
+    });
+  }
+
+  return {
+    resourceType: 'EpisodeOfCare',
+    id: value.id,
+    status: value.status,
+    patient: {
+      reference: `Patient/${value.companionId}`,
+    },
+    managingOrganization: {
+      reference: `Organization/${value.organisationId}`,
+    },
+    extension,
+  };
+};
+
+export const fromFHIRCase = (resource: EpisodeOfCare): Case => {
+  const patientReference = resource.patient?.reference ?? '';
+  const organisationReference = resource.managingOrganization?.reference ?? '';
+
+  return {
+    id: resource.id,
+    organisationId: organisationReference.replace(/^Organization\//, ''),
+    companionId: patientReference.replace(/^Patient\//, ''),
+    parentId: getStringExtension(resource.extension, EXT_CASE_PARENT_ID),
+    status: (resource.status ?? 'planned') as CaseStatus,
+    appointmentKind:
+      (getStringExtension(resource.extension, EXT_CASE_APPOINTMENT_KIND) as
+        | AppointmentKind
+        | undefined) ?? 'OUTPATIENT',
+    title: getStringExtension(resource.extension, EXT_CASE_TITLE),
+    description: getStringExtension(resource.extension, EXT_CASE_DESCRIPTION),
+  };
+};

--- a/packages/types/src/dto/case.dto.ts
+++ b/packages/types/src/dto/case.dto.ts
@@ -1,0 +1,15 @@
+import type { EpisodeOfCare } from '@yosemite-crew/fhir';
+import { type Case, fromFHIRCase, toFHIRCase } from '../case';
+
+export type CaseRequestDTO = EpisodeOfCare;
+export type CaseResponseDTO = EpisodeOfCare;
+
+export const fromCaseRequestDTO = (dto: CaseRequestDTO): Case => {
+  if (!dto || dto.resourceType !== 'EpisodeOfCare') {
+    throw new Error('Invalid payload. Expected FHIR EpisodeOfCare resource.');
+  }
+
+  return fromFHIRCase(dto);
+};
+
+export const toCaseResponseDTO = (value: Case): CaseResponseDTO => toFHIRCase(value);

--- a/packages/types/src/dto/encounter.dto.ts
+++ b/packages/types/src/dto/encounter.dto.ts
@@ -1,0 +1,16 @@
+import type { Encounter as FHIREncounter } from '@yosemite-crew/fhir';
+import { type Encounter, fromFHIREncounter, toFHIREncounter } from '../encounter';
+
+export type EncounterRequestDTO = FHIREncounter;
+export type EncounterResponseDTO = FHIREncounter;
+
+export const fromEncounterRequestDTO = (dto: EncounterRequestDTO): Encounter => {
+  if (!dto || dto.resourceType !== 'Encounter') {
+    throw new Error('Invalid payload. Expected FHIR Encounter resource.');
+  }
+
+  return fromFHIREncounter(dto);
+};
+
+export const toEncounterResponseDTO = (value: Encounter): EncounterResponseDTO =>
+  toFHIREncounter(value);

--- a/packages/types/src/dto/room-unit.dto.ts
+++ b/packages/types/src/dto/room-unit.dto.ts
@@ -1,0 +1,16 @@
+import type { Location as FHIRLocation } from '@yosemite-crew/fhir';
+import { fromFHIRRoomUnit, toFHIRRoomUnit, type RoomUnit } from '../roomUnit';
+
+export type RoomUnitRequestDTO = FHIRLocation;
+export type RoomUnitResponseDTO = FHIRLocation;
+
+export const fromRoomUnitRequestDTO = (dto: RoomUnitRequestDTO): RoomUnit => {
+  if (!dto || dto.resourceType !== 'Location') {
+    throw new Error('Invalid payload. Expected FHIR Location resource.');
+  }
+
+  return fromFHIRRoomUnit(dto);
+};
+
+export const toRoomUnitResponseDTO = (value: RoomUnit): RoomUnitResponseDTO =>
+  toFHIRRoomUnit(value);

--- a/packages/types/src/encounter.ts
+++ b/packages/types/src/encounter.ts
@@ -40,8 +40,7 @@ const EXT_ENCOUNTER_PARENT_ID =
 const EXT_ENCOUNTER_APPOINTMENT_KIND =
   'https://yosemitecrew.com/fhir/StructureDefinition/encounter-appointment-kind';
 const EXT_ENCOUNTER_TITLE = 'https://yosemitecrew.com/fhir/StructureDefinition/encounter-title';
-const EXT_ADMISSION_BED_UNIT_ID =
-  'https://yosemitecrew.com/fhir/StructureDefinition/admission-bed-unit-id';
+const EXT_ADMISSION_UNIT_ID = 'https://yosemitecrew.com/fhir/StructureDefinition/admission-unit-id';
 const EXT_ADMISSION_EXPECTED_STAY_DAYS =
   'https://yosemitecrew.com/fhir/StructureDefinition/admission-expected-stay-days';
 
@@ -79,11 +78,11 @@ export const toFHIREncounter = (value: Encounter): FHIREncounter => {
     value.admission || value.appointmentKind === 'INPATIENT'
       ? {
           extension: [
-            ...(value.admission?.bedUnitId
+            ...(value.admission?.unitId
               ? [
                   {
-                    url: EXT_ADMISSION_BED_UNIT_ID,
-                    valueString: value.admission.bedUnitId,
+                    url: EXT_ADMISSION_UNIT_ID,
+                    valueString: value.admission.unitId,
                   },
                 ]
               : []),

--- a/packages/types/src/encounter.ts
+++ b/packages/types/src/encounter.ts
@@ -1,4 +1,5 @@
 import type { Coding, Encounter as FHIREncounter, Extension } from '@yosemite-crew/fhir';
+import type { Admission } from './admission';
 import type { AppointmentKind } from './catalog';
 
 export const ENCOUNTER_STATUSES = [
@@ -29,6 +30,7 @@ export type Encounter = {
   reason?: string;
   periodStart?: Date;
   periodEnd?: Date;
+  admission?: Admission;
   createdAt?: Date;
   updatedAt?: Date;
 };
@@ -38,6 +40,10 @@ const EXT_ENCOUNTER_PARENT_ID =
 const EXT_ENCOUNTER_APPOINTMENT_KIND =
   'https://yosemitecrew.com/fhir/StructureDefinition/encounter-appointment-kind';
 const EXT_ENCOUNTER_TITLE = 'https://yosemitecrew.com/fhir/StructureDefinition/encounter-title';
+const EXT_ADMISSION_BED_UNIT_ID =
+  'https://yosemitecrew.com/fhir/StructureDefinition/admission-bed-unit-id';
+const EXT_ADMISSION_EXPECTED_STAY_DAYS =
+  'https://yosemitecrew.com/fhir/StructureDefinition/admission-expected-stay-days';
 
 const getStringExtension = (extensions: Extension[] | undefined, url: string): string | undefined =>
   extensions?.find((extension) => extension.url === url)?.valueString ?? undefined;
@@ -68,6 +74,30 @@ export const toFHIREncounter = (value: Encounter): FHIREncounter => {
       valueString: value.title,
     });
   }
+
+  const hospitalization =
+    value.admission || value.appointmentKind === 'INPATIENT'
+      ? {
+          extension: [
+            ...(value.admission?.bedUnitId
+              ? [
+                  {
+                    url: EXT_ADMISSION_BED_UNIT_ID,
+                    valueString: value.admission.bedUnitId,
+                  },
+                ]
+              : []),
+            ...(typeof value.admission?.expectedStayDays === 'number'
+              ? [
+                  {
+                    url: EXT_ADMISSION_EXPECTED_STAY_DAYS,
+                    valueInteger: value.admission.expectedStayDays,
+                  },
+                ]
+              : []),
+          ],
+        }
+      : undefined;
 
   return {
     resourceType: 'Encounter',
@@ -106,6 +136,7 @@ export const toFHIREncounter = (value: Encounter): FHIREncounter => {
           },
         ]
       : undefined,
+    hospitalization,
     extension,
   };
 };

--- a/packages/types/src/encounter.ts
+++ b/packages/types/src/encounter.ts
@@ -1,0 +1,139 @@
+import type { Coding, Encounter as FHIREncounter, Extension } from '@yosemite-crew/fhir';
+import type { AppointmentKind } from './catalog';
+
+export const ENCOUNTER_STATUSES = [
+  'planned',
+  'arrived',
+  'triaged',
+  'in-progress',
+  'onleave',
+  'finished',
+  'cancelled',
+] as const;
+
+export type EncounterStatus = (typeof ENCOUNTER_STATUSES)[number];
+
+export type EncounterClass = 'AMB' | 'IMP' | 'EMER' | 'OBSENC' | 'VR';
+
+export type Encounter = {
+  id?: string;
+  caseId: string;
+  appointmentId?: string;
+  organisationId: string;
+  companionId: string;
+  parentId?: string;
+  status: EncounterStatus;
+  encounterClass: EncounterClass;
+  appointmentKind: AppointmentKind;
+  title?: string;
+  reason?: string;
+  periodStart?: Date;
+  periodEnd?: Date;
+  createdAt?: Date;
+  updatedAt?: Date;
+};
+
+const EXT_ENCOUNTER_PARENT_ID =
+  'https://yosemitecrew.com/fhir/StructureDefinition/encounter-parent-id';
+const EXT_ENCOUNTER_APPOINTMENT_KIND =
+  'https://yosemitecrew.com/fhir/StructureDefinition/encounter-appointment-kind';
+const EXT_ENCOUNTER_TITLE = 'https://yosemitecrew.com/fhir/StructureDefinition/encounter-title';
+
+const getStringExtension = (extensions: Extension[] | undefined, url: string): string | undefined =>
+  extensions?.find((extension) => extension.url === url)?.valueString ?? undefined;
+
+const toEncounterClassCoding = (value: EncounterClass): Coding => ({
+  system: 'http://terminology.hl7.org/CodeSystem/v3-ActCode',
+  code: value,
+});
+
+export const toFHIREncounter = (value: Encounter): FHIREncounter => {
+  const extension: Extension[] = [
+    {
+      url: EXT_ENCOUNTER_APPOINTMENT_KIND,
+      valueString: value.appointmentKind,
+    },
+  ];
+
+  if (value.parentId) {
+    extension.push({
+      url: EXT_ENCOUNTER_PARENT_ID,
+      valueString: value.parentId,
+    });
+  }
+
+  if (value.title) {
+    extension.push({
+      url: EXT_ENCOUNTER_TITLE,
+      valueString: value.title,
+    });
+  }
+
+  return {
+    resourceType: 'Encounter',
+    id: value.id,
+    status: value.status,
+    class: toEncounterClassCoding(value.encounterClass),
+    subject: {
+      reference: `Patient/${value.companionId}`,
+    },
+    episodeOfCare: [
+      {
+        reference: `EpisodeOfCare/${value.caseId}`,
+      },
+    ],
+    appointment: value.appointmentId
+      ? [
+          {
+            reference: `Appointment/${value.appointmentId}`,
+          },
+        ]
+      : undefined,
+    serviceProvider: {
+      reference: `Organization/${value.organisationId}`,
+    },
+    period:
+      value.periodStart || value.periodEnd
+        ? {
+            start: value.periodStart?.toISOString(),
+            end: value.periodEnd?.toISOString(),
+          }
+        : undefined,
+    reasonCode: value.reason
+      ? [
+          {
+            text: value.reason,
+          },
+        ]
+      : undefined,
+    extension,
+  };
+};
+
+export const fromFHIREncounter = (resource: FHIREncounter): Encounter => {
+  const episodeReference = resource.episodeOfCare?.[0]?.reference ?? '';
+  const patientReference = resource.subject?.reference ?? '';
+  const organisationReference = resource.serviceProvider?.reference ?? '';
+  const appointmentReference = resource.appointment?.[0]?.reference ?? '';
+
+  return {
+    id: resource.id,
+    caseId: episodeReference.replace(/^EpisodeOfCare\//, ''),
+    appointmentId: appointmentReference
+      ? appointmentReference.replace(/^Appointment\//, '')
+      : undefined,
+    organisationId: organisationReference.replace(/^Organization\//, ''),
+    companionId: patientReference.replace(/^Patient\//, ''),
+    parentId: getStringExtension(resource.extension, EXT_ENCOUNTER_PARENT_ID),
+    status: (resource.status ?? 'planned') as EncounterStatus,
+    encounterClass: (resource.class?.code ?? 'AMB') as EncounterClass,
+    appointmentKind:
+      (getStringExtension(resource.extension, EXT_ENCOUNTER_APPOINTMENT_KIND) as
+        | AppointmentKind
+        | undefined) ?? 'OUTPATIENT',
+    title: getStringExtension(resource.extension, EXT_ENCOUNTER_TITLE),
+    reason: resource.reasonCode?.[0]?.text ?? undefined,
+    periodStart: resource.period?.start ? new Date(resource.period.start) : undefined,
+    periodEnd: resource.period?.end ? new Date(resource.period.end) : undefined,
+  };
+};

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -132,6 +132,7 @@ export type { OrganisationInvite, InviteStatus } from './organisationInvite';
 export type { Service } from './service';
 export type { Case, CaseStatus } from './case';
 export { fromFHIRCase, toFHIRCase } from './case';
+export type { Admission } from './admission';
 export type { Encounter, EncounterClass, EncounterStatus } from './encounter';
 export { fromFHIREncounter, toFHIREncounter } from './encounter';
 export type {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -135,6 +135,8 @@ export { fromFHIRCase, toFHIRCase } from './case';
 export type { Admission } from './admission';
 export type { Encounter, EncounterClass, EncounterStatus } from './encounter';
 export { fromFHIREncounter, toFHIREncounter } from './encounter';
+export type { RoomUnit } from './roomUnit';
+export { fromFHIRRoomUnit, toFHIRRoomUnit } from './roomUnit';
 export type {
   CatalogListRow,
   CatalogPackageBreakdownRow,
@@ -247,6 +249,12 @@ export {
   fromEncounterRequestDTO,
   toEncounterResponseDTO,
 } from './dto/encounter.dto';
+export {
+  type RoomUnitRequestDTO,
+  type RoomUnitResponseDTO,
+  fromRoomUnitRequestDTO,
+  toRoomUnitResponseDTO,
+} from './dto/room-unit.dto';
 export type { Invoice, InvoiceItem, InvoiceStatus, PaymentCollectionMethod } from './invoice';
 export type { Appointment, AppointmentPaymentStatus } from './appointment';
 export { toFHIRInvoice, fromFHIRInvoice } from './invoice';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -130,6 +130,10 @@ export type {
 
 export type { OrganisationInvite, InviteStatus } from './organisationInvite';
 export type { Service } from './service';
+export type { Case, CaseStatus } from './case';
+export { fromFHIRCase, toFHIRCase } from './case';
+export type { Encounter, EncounterClass, EncounterStatus } from './encounter';
+export { fromFHIREncounter, toFHIREncounter } from './encounter';
 export type {
   CatalogListRow,
   CatalogPackageBreakdownRow,
@@ -230,6 +234,18 @@ export {
   toAppointmentResponseDTO,
   fromAppointmentRequestDTO,
 } from './dto/appointment.dto';
+export {
+  type CaseRequestDTO,
+  type CaseResponseDTO,
+  fromCaseRequestDTO,
+  toCaseResponseDTO,
+} from './dto/case.dto';
+export {
+  type EncounterRequestDTO,
+  type EncounterResponseDTO,
+  fromEncounterRequestDTO,
+  toEncounterResponseDTO,
+} from './dto/encounter.dto';
 export type { Invoice, InvoiceItem, InvoiceStatus, PaymentCollectionMethod } from './invoice';
 export type { Appointment, AppointmentPaymentStatus } from './appointment';
 export { toFHIRInvoice, fromFHIRInvoice } from './invoice';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -76,7 +76,7 @@ export type {
 } from './parentCompanion';
 
 export type { Organization, Organisation, ToFHIROrganizationOptions } from './organization';
-export type { OrganisationRoom } from './organisationRoom';
+export type { OrganisationRoom, RoomReferenceMapping } from './organisationRoom';
 export {
   toFHIROrganisationRoom,
   fromFHIROrganisationRoom,
@@ -137,6 +137,8 @@ export type { Encounter, EncounterClass, EncounterStatus } from './encounter';
 export { fromFHIREncounter, toFHIREncounter } from './encounter';
 export type { RoomUnit } from './roomUnit';
 export { fromFHIRRoomUnit, toFHIRRoomUnit } from './roomUnit';
+export type { RoomUnitGroup } from './roomUnit';
+export { fromFHIRRoomUnitGroup, toFHIRRoomUnitGroup } from './roomUnit';
 export type {
   CatalogListRow,
   CatalogPackageBreakdownRow,

--- a/packages/types/src/organisationRoom.ts
+++ b/packages/types/src/organisationRoom.ts
@@ -1,17 +1,47 @@
 import type { Extension, Location as FHIRLocation } from '@yosemite-crew/fhir';
 
+export type RoomReferenceMapping = {
+  id: string;
+  name: string;
+};
+
 export type OrganisationRoom = {
   id: string;
   name: string;
   organisationId: string;
-  type: 'CONSULTATION' | 'WAITING_AREA' | 'SURGERY' | 'ICU';
-  assignedSpecialiteis?: string[];
-  assignedStaffs?: string[];
+  code: string;
+  description?: string;
+  type:
+    | 'EXAM_ROOM'
+    | 'TREATMENT'
+    | 'SURGERY'
+    | 'DENTAL'
+    | 'IMAGING'
+    | 'WAITING'
+    | 'GROOMING'
+    | 'ICU'
+    | 'INPATIENT'
+    | 'ISOLATION'
+    | 'BOARDING'
+    | 'RECEPTION'
+    | 'CONSULTATION';
+  assignedSpecialiteis?: RoomReferenceMapping[];
+  assignedStaffs?: RoomReferenceMapping[];
+  availableNow?: boolean;
+  availabilityMode?: 'WORKING_HOURS' | 'ALL_DAY' | 'CUSTOM';
+  availabilityDays?: string[];
+  availabilityStartTime?: string;
+  availabilityEndTime?: string;
+  capabilities?: string[];
 };
 
 const ROOM_IDENTIFIER_SYSTEM = 'http://example.org/fhir/NamingSystem/organisation-room-id';
 const ORGANISATION_IDENTIFIER_SYSTEM =
   'http://example.org/fhir/NamingSystem/organisation-room-organisation-id';
+const ROOM_CODE_EXTENSION_URL =
+  'https://yosemitecrew.com/fhir/StructureDefinition/organisation-room-code';
+const ROOM_DESCRIPTION_EXTENSION_URL =
+  'https://yosemitecrew.com/fhir/StructureDefinition/organisation-room-description';
 const ROOM_TYPE_SYSTEM = 'http://example.org/fhir/CodeSystem/organisation-room-type';
 const PHYSICAL_TYPE_SYSTEM = 'http://terminology.hl7.org/CodeSystem/location-physical-type';
 const PHYSICAL_TYPE_ROOM_CODE = 'ro';
@@ -19,14 +49,39 @@ const SPECIALITIES_EXTENSION_URL =
   'https://yosemitecrew.com/fhir/StructureDefinition/organisation-room-specialities';
 const STAFFS_EXTENSION_URL =
   'https://yosemitecrew.com/fhir/StructureDefinition/organisation-room-staffs';
-const SPECIALITY_CHILD_URL = 'specialityId';
-const STAFF_CHILD_URL = 'staffId';
+const AVAILABLE_NOW_EXTENSION_URL =
+  'https://yosemitecrew.com/fhir/StructureDefinition/organisation-room-available-now';
+const AVAILABILITY_MODE_EXTENSION_URL =
+  'https://yosemitecrew.com/fhir/StructureDefinition/organisation-room-availability-mode';
+const AVAILABILITY_DAYS_EXTENSION_URL =
+  'https://yosemitecrew.com/fhir/StructureDefinition/organisation-room-availability-days';
+const AVAILABILITY_START_TIME_EXTENSION_URL =
+  'https://yosemitecrew.com/fhir/StructureDefinition/organisation-room-availability-start-time';
+const AVAILABILITY_END_TIME_EXTENSION_URL =
+  'https://yosemitecrew.com/fhir/StructureDefinition/organisation-room-availability-end-time';
+const CAPABILITIES_EXTENSION_URL =
+  'https://yosemitecrew.com/fhir/StructureDefinition/organisation-room-capabilities';
+const SPECIALITY_CHILD_URL = 'speciality';
+const SPECIALITY_ID_CHILD_URL = 'id';
+const SPECIALITY_NAME_CHILD_URL = 'name';
+const STAFF_CHILD_URL = 'staff';
+const STAFF_ID_CHILD_URL = 'id';
+const STAFF_NAME_CHILD_URL = 'name';
 
 const ROOM_TYPE_CODING_MAP: Record<OrganisationRoom['type'], { code: string; display: string }> = {
-  CONSULTATION: { code: 'consultation', display: 'Consultation Room' },
-  WAITING_AREA: { code: 'waiting-area', display: 'Waiting Area' },
+  EXAM_ROOM: { code: 'exam-room', display: 'Exam Room' },
+  TREATMENT: { code: 'treatment', display: 'Treatment' },
   SURGERY: { code: 'surgery', display: 'Surgery Room' },
+  DENTAL: { code: 'dental', display: 'Dental' },
+  IMAGING: { code: 'imaging', display: 'Imaging' },
+  WAITING: { code: 'waiting', display: 'Waiting Area' },
+  GROOMING: { code: 'grooming', display: 'Grooming' },
   ICU: { code: 'icu', display: 'ICU' },
+  INPATIENT: { code: 'inpatient', display: 'Inpatient' },
+  ISOLATION: { code: 'isolation', display: 'Isolation' },
+  BOARDING: { code: 'boarding', display: 'Boarding' },
+  RECEPTION: { code: 'reception', display: 'Reception' },
+  CONSULTATION: { code: 'consultation', display: 'Consultation Room' },
 };
 
 const REVERSE_ROOM_TYPE_CODING_MAP = Object.entries(ROOM_TYPE_CODING_MAP).reduce<
@@ -112,20 +167,106 @@ const buildExtensions = (room: OrganisationRoom): Extension[] | undefined => {
   if (room.assignedSpecialiteis?.length) {
     extensions.push({
       url: SPECIALITIES_EXTENSION_URL,
-      extension: room.assignedSpecialiteis.filter(Boolean).map<Extension>((specialityId) => ({
-        url: SPECIALITY_CHILD_URL,
-        valueString: specialityId,
-      })),
+      extension: room.assignedSpecialiteis
+        .filter((speciality): speciality is RoomReferenceMapping =>
+          Boolean(speciality?.id && speciality?.name)
+        )
+        .map<Extension>((speciality) => ({
+          url: SPECIALITY_CHILD_URL,
+          extension: [
+            {
+              url: SPECIALITY_ID_CHILD_URL,
+              valueString: speciality.id,
+            },
+            {
+              url: SPECIALITY_NAME_CHILD_URL,
+              valueString: speciality.name,
+            },
+          ],
+        })),
     });
   }
 
   if (room.assignedStaffs?.length) {
     extensions.push({
       url: STAFFS_EXTENSION_URL,
-      extension: room.assignedStaffs.filter(Boolean).map<Extension>((staffId) => ({
-        url: STAFF_CHILD_URL,
-        valueString: staffId,
+      extension: room.assignedStaffs
+        .filter((staff): staff is RoomReferenceMapping => Boolean(staff?.id && staff?.name))
+        .map<Extension>((staff) => ({
+          url: STAFF_CHILD_URL,
+          extension: [
+            {
+              url: STAFF_ID_CHILD_URL,
+              valueString: staff.id,
+            },
+            {
+              url: STAFF_NAME_CHILD_URL,
+              valueString: staff.name,
+            },
+          ],
+        })),
+    });
+  }
+
+  if (typeof room.availableNow === 'boolean') {
+    extensions.push({
+      url: AVAILABLE_NOW_EXTENSION_URL,
+      valueBoolean: room.availableNow,
+    });
+  }
+
+  if (room.availabilityMode) {
+    extensions.push({
+      url: AVAILABILITY_MODE_EXTENSION_URL,
+      valueString: room.availabilityMode,
+    });
+  }
+
+  if (room.availabilityDays?.length) {
+    extensions.push({
+      url: AVAILABILITY_DAYS_EXTENSION_URL,
+      extension: room.availabilityDays.filter(Boolean).map<Extension>((day) => ({
+        url: 'day',
+        valueString: day,
       })),
+    });
+  }
+
+  if (room.availabilityStartTime) {
+    extensions.push({
+      url: AVAILABILITY_START_TIME_EXTENSION_URL,
+      valueString: room.availabilityStartTime,
+    });
+  }
+
+  if (room.availabilityEndTime) {
+    extensions.push({
+      url: AVAILABILITY_END_TIME_EXTENSION_URL,
+      valueString: room.availabilityEndTime,
+    });
+  }
+
+  if (room.capabilities?.length) {
+    extensions.push({
+      url: CAPABILITIES_EXTENSION_URL,
+      extension: room.capabilities.filter(Boolean).map<Extension>((capability) => ({
+        url: 'capability',
+        valueString: capability,
+      })),
+    });
+  }
+
+  if (room.code) {
+    extensions.push({
+      url: ROOM_CODE_EXTENSION_URL,
+      valueString: room.code,
+    });
+  }
+
+  if (room.description) {
+    extensions.push({
+      url: ROOM_DESCRIPTION_EXTENSION_URL,
+      valueString: room.description,
     });
   }
 
@@ -155,6 +296,48 @@ const parseArrayExtension = (
 
   return values.length ? values : undefined;
 };
+
+const parseMappingExtension = (
+  extensions: Extension[] | undefined,
+  url: string
+): RoomReferenceMapping[] | undefined => {
+  const parent = extensions?.find((extension) => extension.url === url);
+
+  if (!parent?.extension?.length) {
+    return undefined;
+  }
+
+  const values = parent.extension
+    .map((child) => {
+      if (!child.extension?.length) {
+        return undefined;
+      }
+
+      const id = child.extension.find((entry) => entry.url === 'id')?.valueString?.trim();
+      const name = child.extension.find((entry) => entry.url === 'name')?.valueString?.trim();
+
+      if (!id || !name) {
+        return undefined;
+      }
+
+      return { id, name };
+    })
+    .filter((value): value is RoomReferenceMapping => value !== undefined);
+
+  return values.length ? values : undefined;
+};
+
+const parseBooleanExtension = (
+  extensions: Extension[] | undefined,
+  url: string
+): boolean | undefined =>
+  extensions?.find((extension) => extension.url === url)?.valueBoolean ?? undefined;
+
+const parseStringExtension = (
+  extensions: Extension[] | undefined,
+  url: string
+): string | undefined =>
+  extensions?.find((extension) => extension.url === url)?.valueString ?? undefined;
 
 const resolveOrganisationId = (resource: FHIRLocation): string | undefined => {
   const referenceId = parseReferenceId(resource.managingOrganization?.reference);
@@ -209,13 +392,19 @@ export const fromFHIROrganisationRoom = (resource: FHIRLocation): OrganisationRo
     id: resource.id ?? findIdentifierValue(resource.identifier, ROOM_IDENTIFIER_SYSTEM) ?? '',
     name: resource.name ?? '',
     organisationId: resolveOrganisationId(resource) ?? '',
+    code: parseStringExtension(resource.extension, ROOM_CODE_EXTENSION_URL) ?? '',
+    description: parseStringExtension(resource.extension, ROOM_DESCRIPTION_EXTENSION_URL),
     type: parseRoomType(resource),
-    assignedSpecialiteis: parseArrayExtension(
-      extensions,
-      SPECIALITIES_EXTENSION_URL,
-      SPECIALITY_CHILD_URL
-    ),
-    assignedStaffs: parseArrayExtension(extensions, STAFFS_EXTENSION_URL, STAFF_CHILD_URL),
+    assignedSpecialiteis: parseMappingExtension(extensions, SPECIALITIES_EXTENSION_URL),
+    assignedStaffs: parseMappingExtension(extensions, STAFFS_EXTENSION_URL),
+    availableNow: parseBooleanExtension(extensions, AVAILABLE_NOW_EXTENSION_URL),
+    availabilityMode: parseStringExtension(extensions, AVAILABILITY_MODE_EXTENSION_URL) as
+      | OrganisationRoom['availabilityMode']
+      | undefined,
+    availabilityDays: parseArrayExtension(extensions, AVAILABILITY_DAYS_EXTENSION_URL, 'day'),
+    availabilityStartTime: parseStringExtension(extensions, AVAILABILITY_START_TIME_EXTENSION_URL),
+    availabilityEndTime: parseStringExtension(extensions, AVAILABILITY_END_TIME_EXTENSION_URL),
+    capabilities: parseArrayExtension(extensions, CAPABILITIES_EXTENSION_URL, 'capability'),
   };
 };
 

--- a/packages/types/src/roomUnit.ts
+++ b/packages/types/src/roomUnit.ts
@@ -1,0 +1,108 @@
+import type { Extension, Location as FHIRLocation } from '@yosemite-crew/fhir';
+
+export type RoomUnit = {
+  id: string;
+  organisationId: string;
+  roomId: string;
+  code: string;
+  displayName: string;
+  size?: string;
+  speciesConstraints?: string[];
+  isActive?: boolean;
+};
+
+const UNIT_IDENTIFIER_SYSTEM = 'http://example.org/fhir/NamingSystem/room-unit-id';
+const ROOM_UNIT_CODE_SYSTEM = 'http://example.org/fhir/CodeSystem/room-unit';
+const EXT_ROOM_UNIT_CODE = 'https://yosemitecrew.com/fhir/StructureDefinition/room-unit-code';
+const EXT_ROOM_UNIT_SIZE = 'https://yosemitecrew.com/fhir/StructureDefinition/room-unit-size';
+const EXT_ROOM_UNIT_SPECIES = 'https://yosemitecrew.com/fhir/StructureDefinition/room-unit-species';
+const EXT_ROOM_UNIT_ACTIVE = 'https://yosemitecrew.com/fhir/StructureDefinition/room-unit-active';
+
+const parseReferenceId = (reference?: string): string | undefined => {
+  const trimmed = reference?.trim();
+  if (!trimmed) return undefined;
+  const segments = trimmed.split('/');
+  return segments.at(-1) ?? undefined;
+};
+
+const getStringExtension = (extensions: Extension[] | undefined, url: string): string | undefined =>
+  extensions?.find((extension) => extension.url === url)?.valueString ?? undefined;
+
+const getBooleanExtension = (
+  extensions: Extension[] | undefined,
+  url: string
+): boolean | undefined =>
+  extensions?.find((extension) => extension.url === url)?.valueBoolean ?? undefined;
+
+const getStringArrayExtension = (
+  extensions: Extension[] | undefined,
+  url: string
+): string[] | undefined => {
+  const values = extensions
+    ?.filter((extension) => extension.url === url)
+    .map((extension) => extension.valueString?.trim())
+    .filter((value): value is string => Boolean(value));
+
+  return values?.length ? values : undefined;
+};
+
+export const toFHIRRoomUnit = (unit: RoomUnit): FHIRLocation => ({
+  resourceType: 'Location',
+  id: unit.id,
+  identifier: [
+    {
+      system: UNIT_IDENTIFIER_SYSTEM,
+      value: unit.id,
+    },
+  ],
+  name: unit.displayName,
+  managingOrganization: {
+    reference: `Organization/${unit.organisationId}`,
+  },
+  partOf: {
+    reference: `Location/${unit.roomId}`,
+  },
+  physicalType: {
+    coding: [
+      {
+        system: ROOM_UNIT_CODE_SYSTEM,
+        code: 'unit',
+        display: 'Unit',
+      },
+    ],
+    text: 'Unit',
+  },
+  extension: [
+    {
+      url: EXT_ROOM_UNIT_CODE,
+      valueString: unit.code,
+    },
+    ...(unit.size
+      ? [
+          {
+            url: EXT_ROOM_UNIT_SIZE,
+            valueString: unit.size,
+          },
+        ]
+      : []),
+    ...(unit.speciesConstraints?.map<Extension>((species) => ({
+      url: EXT_ROOM_UNIT_SPECIES,
+      valueString: species,
+    })) ?? []),
+    {
+      url: EXT_ROOM_UNIT_ACTIVE,
+      valueBoolean: unit.isActive ?? true,
+    },
+  ],
+});
+
+export const fromFHIRRoomUnit = (resource: FHIRLocation): RoomUnit => ({
+  id: resource.id ?? '',
+  organisationId: parseReferenceId(resource.managingOrganization?.reference) ?? '',
+  roomId: parseReferenceId(resource.partOf?.reference) ?? '',
+  code: getStringExtension(resource.extension, EXT_ROOM_UNIT_CODE) ?? '',
+  displayName: resource.name ?? '',
+  size: getStringExtension(resource.extension, EXT_ROOM_UNIT_SIZE),
+  speciesConstraints: getStringArrayExtension(resource.extension, EXT_ROOM_UNIT_SPECIES),
+  isActive: getBooleanExtension(resource.extension, EXT_ROOM_UNIT_ACTIVE) ?? true,
+});

--- a/packages/types/src/roomUnit.ts
+++ b/packages/types/src/roomUnit.ts
@@ -4,10 +4,23 @@ export type RoomUnit = {
   id: string;
   organisationId: string;
   roomId: string;
+  unitGroupId?: string;
   code: string;
   displayName: string;
   size?: string;
   speciesConstraints?: string[];
+  isActive?: boolean;
+};
+
+export type RoomUnitGroup = {
+  id: string;
+  organisationId: string;
+  roomId: string;
+  name: string;
+  size?: string;
+  unitCount: number;
+  speciesConstraints?: string[];
+  capabilities?: string[];
   isActive?: boolean;
 };
 
@@ -17,6 +30,17 @@ const EXT_ROOM_UNIT_CODE = 'https://yosemitecrew.com/fhir/StructureDefinition/ro
 const EXT_ROOM_UNIT_SIZE = 'https://yosemitecrew.com/fhir/StructureDefinition/room-unit-size';
 const EXT_ROOM_UNIT_SPECIES = 'https://yosemitecrew.com/fhir/StructureDefinition/room-unit-species';
 const EXT_ROOM_UNIT_ACTIVE = 'https://yosemitecrew.com/fhir/StructureDefinition/room-unit-active';
+const EXT_ROOM_UNIT_GROUP = 'https://yosemitecrew.com/fhir/StructureDefinition/room-unit-group';
+const EXT_ROOM_UNIT_GROUP_SIZE =
+  'https://yosemitecrew.com/fhir/StructureDefinition/room-unit-group-size';
+const EXT_ROOM_UNIT_GROUP_COUNT =
+  'https://yosemitecrew.com/fhir/StructureDefinition/room-unit-group-count';
+const EXT_ROOM_UNIT_GROUP_SPECIES =
+  'https://yosemitecrew.com/fhir/StructureDefinition/room-unit-group-species';
+const EXT_ROOM_UNIT_GROUP_CAPABILITY =
+  'https://yosemitecrew.com/fhir/StructureDefinition/room-unit-group-capability';
+const EXT_ROOM_UNIT_GROUP_ACTIVE =
+  'https://yosemitecrew.com/fhir/StructureDefinition/room-unit-group-active';
 
 const parseReferenceId = (reference?: string): string | undefined => {
   const trimmed = reference?.trim();
@@ -77,6 +101,14 @@ export const toFHIRRoomUnit = (unit: RoomUnit): FHIRLocation => ({
       url: EXT_ROOM_UNIT_CODE,
       valueString: unit.code,
     },
+    ...(unit.unitGroupId
+      ? [
+          {
+            url: EXT_ROOM_UNIT_GROUP,
+            valueString: unit.unitGroupId,
+          },
+        ]
+      : []),
     ...(unit.size
       ? [
           {
@@ -100,9 +132,78 @@ export const fromFHIRRoomUnit = (resource: FHIRLocation): RoomUnit => ({
   id: resource.id ?? '',
   organisationId: parseReferenceId(resource.managingOrganization?.reference) ?? '',
   roomId: parseReferenceId(resource.partOf?.reference) ?? '',
+  unitGroupId: getStringExtension(resource.extension, EXT_ROOM_UNIT_GROUP),
   code: getStringExtension(resource.extension, EXT_ROOM_UNIT_CODE) ?? '',
   displayName: resource.name ?? '',
   size: getStringExtension(resource.extension, EXT_ROOM_UNIT_SIZE),
   speciesConstraints: getStringArrayExtension(resource.extension, EXT_ROOM_UNIT_SPECIES),
   isActive: getBooleanExtension(resource.extension, EXT_ROOM_UNIT_ACTIVE) ?? true,
+});
+
+export const toFHIRRoomUnitGroup = (group: RoomUnitGroup): FHIRLocation => ({
+  resourceType: 'Location',
+  id: group.id,
+  identifier: [
+    {
+      system: 'http://example.org/fhir/NamingSystem/room-unit-group-id',
+      value: group.id,
+    },
+  ],
+  name: group.name,
+  managingOrganization: {
+    reference: `Organization/${group.organisationId}`,
+  },
+  partOf: {
+    reference: `Location/${group.roomId}`,
+  },
+  physicalType: {
+    coding: [
+      {
+        system: ROOM_UNIT_CODE_SYSTEM,
+        code: 'unit-group',
+        display: 'Unit Group',
+      },
+    ],
+    text: 'Unit Group',
+  },
+  extension: [
+    ...(group.size
+      ? [
+          {
+            url: EXT_ROOM_UNIT_GROUP_SIZE,
+            valueString: group.size,
+          },
+        ]
+      : []),
+    {
+      url: EXT_ROOM_UNIT_GROUP_COUNT,
+      valueInteger: group.unitCount,
+    },
+    ...(group.speciesConstraints?.map<Extension>((species) => ({
+      url: EXT_ROOM_UNIT_GROUP_SPECIES,
+      valueString: species,
+    })) ?? []),
+    ...(group.capabilities?.map<Extension>((capability) => ({
+      url: EXT_ROOM_UNIT_GROUP_CAPABILITY,
+      valueString: capability,
+    })) ?? []),
+    {
+      url: EXT_ROOM_UNIT_GROUP_ACTIVE,
+      valueBoolean: group.isActive ?? true,
+    },
+  ],
+});
+
+export const fromFHIRRoomUnitGroup = (resource: FHIRLocation): RoomUnitGroup => ({
+  id: resource.id ?? '',
+  organisationId: parseReferenceId(resource.managingOrganization?.reference) ?? '',
+  roomId: parseReferenceId(resource.partOf?.reference) ?? '',
+  name: resource.name ?? '',
+  size: getStringExtension(resource.extension, EXT_ROOM_UNIT_GROUP_SIZE),
+  unitCount:
+    resource.extension?.find((extension) => extension.url === EXT_ROOM_UNIT_GROUP_COUNT)
+      ?.valueInteger ?? 0,
+  speciesConstraints: getStringArrayExtension(resource.extension, EXT_ROOM_UNIT_GROUP_SPECIES),
+  capabilities: getStringArrayExtension(resource.extension, EXT_ROOM_UNIT_GROUP_CAPABILITY),
+  isActive: getBooleanExtension(resource.extension, EXT_ROOM_UNIT_GROUP_ACTIVE) ?? true,
 });


### PR DESCRIPTION
<!--
We, the rest of the Yosemite community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests and lints pass.

## Summary
This PR expands the inpatient and room-management stack end to end. It adds Prisma-backed appointment, case, and encounter flows; room, unit, and room-group administration APIs; shared admission and encounter types; and frontend updates for the organization room management UI.

## What changed
- Added a Prisma-backed appointment module and backend routes/controllers for appointment operations.
- Added case and encounter services plus controllers for inpatient and outpatient flows.
- Added automatic linking between appointments, cases, and encounters for OP/IP workflows.
- Added inpatient admission overlay and discharge operations.
- Added an active inpatient whiteboard endpoint and room/unit assignment logic for admitted encounters.
- Enforced inpatient unit occupancy and room availability constraints.
- Added room, room-unit, and room-unit-group management APIs and supporting cleanup logic.
- Updated shared Prisma schema, migrations, and `packages/types` contracts for admission, appointment, case, encounter, organisation room, and room-unit data.
- Updated the frontend room management screens, cards, and table utilities to align with the new backend model.
- Added and updated backend and frontend tests for the new controllers, services, helpers, and UI behavior.

## Current behavior
Before this change, the repo did not have the full set of backend primitives for room/unit management, inpatient encounter lifecycle handling, or the shared types needed to support those workflows consistently across packages and frontend consumers.

## New behavior
The application can now:
- manage rooms, room units, and room-unit groups through dedicated backend endpoints,
- create and link cases and encounters as part of appointment-driven workflows,
- admit and discharge inpatient encounters with room/unit assignment,
- expose active inpatient state for whiteboard-style views,
- enforce occupancy and availability rules in the backend,
- and render the updated room management experience in the frontend.


