### PR TITLE
fix(repo): restored-tab loading, tab-hover flicker, and artifacts-only release path

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1,9 +1,13 @@
 name: Desktop Release
 
-# Builds, code-signs, and publishes the desktop app to a GitHub Release.
-# Trigger by pushing a tag like `desktop-v0.1.0-beta.1`:
-#   1) bump "version" in apps/desktop/package.json
-#   2) git tag desktop-v<version> && git push origin desktop-v<version>
+# Builds and code-signs the desktop app. Two ways to run:
+#   • Push a tag `desktop-v*`  → builds, signs, and PUBLISHES a GitHub Release.
+#       1) bump "version" in apps/desktop/package.json
+#       2) git tag desktop-v<version> && git push origin desktop-v<version>
+#   • Run manually (Actions → "Desktop Release" → Run workflow / workflow_dispatch)
+#       → builds + signs, then uploads the signed installers as workflow ARTIFACTS
+#         (NO Release). Use this to collect signed mac/Windows builds for a
+#         coordinated joint release (alongside mobile + PIMS) later.
 #
 # Windows is signed via Azure Artifact Signing (formerly Trusted Signing).
 #   AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET
@@ -42,14 +46,25 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build, sign (Azure Artifact Signing), and publish
+      - name: Build & sign (Azure Artifact Signing); publish only on a tag
         working-directory: apps/desktop
-        run: pnpm run desktop:dist:win -- --publish always
+        run: pnpm run desktop:dist:win -- --publish ${{ github.event_name == 'push' && 'always' || 'never' }}
         env:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload signed Windows artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-windows-signed
+          path: |
+            apps/desktop/dist/*.exe
+            apps/desktop/dist/*.blockmap
+            apps/desktop/dist/latest.yml
+          if-no-files-found: warn
 
   macos:
     runs-on: macos-14
@@ -66,9 +81,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build, sign (Developer ID), notarize, and publish
+      - name: Build, sign (Developer ID) & notarize; publish only on a tag
         working-directory: apps/desktop
-        run: pnpm run desktop:dist:mac -- --publish always
+        run: pnpm run desktop:dist:mac -- --publish ${{ github.event_name == 'push' && 'always' || 'never' }}
         env:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
@@ -76,3 +91,15 @@ jobs:
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload signed macOS artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-macos-signed
+          path: |
+            apps/desktop/dist/*.dmg
+            apps/desktop/dist/*.zip
+            apps/desktop/dist/*.blockmap
+            apps/desktop/dist/latest-mac.yml
+          if-no-files-found: warn

--- a/apps/desktop/src/core/ipc-handlers.ts
+++ b/apps/desktop/src/core/ipc-handlers.ts
@@ -814,15 +814,26 @@ export const registerIpc = (services: IpcServices, ipc: IpcMainType = ipcMain): 
     return { ok };
   });
 
+  // Thumbnails for the tab-hover preview. capturePage() forces a WebContentsView
+  // to render, so capturing a background tab (parked offscreen at 0x0) flickers
+  // the UI. Only the visible (active) tab is captured live; its thumbnail is
+  // cached so that when it later becomes a background tab, hovering still shows
+  // the last-known preview without a flicker-inducing live capture.
+  const tabPreviewCache = new Map<string, string>();
   registry.handle('yc:tab-get-preview', async (_event, args) => {
     const [id] = args as [string];
     if (!services.tabViewHost || typeof id !== 'string')
       return { ok: false, error: 'invalid-args' };
     const wc = services.tabViewHost.getWebContents(id);
     if (!wc || wc.isDestroyed()) return { ok: false, error: 'no-contents' };
+    if (wc !== services.activeContents()) {
+      const cached = tabPreviewCache.get(id);
+      return cached ? { ok: true, dataUrl: cached } : { ok: false, error: 'no-preview' };
+    }
     try {
       const image = await wc.capturePage();
       const dataUrl = image.toDataURL();
+      tabPreviewCache.set(id, dataUrl);
       return { ok: true, dataUrl };
     } catch {
       return { ok: false, error: 'capture-failed' };

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1610,7 +1610,27 @@ if (gotSingleInstanceLock) {
       }));
       // enterTabMode reads the module window/tab globals assigned just above, so
       // it must run here (not inside createMainWindow) to actually take effect.
-      if (pendingTabModeUrl) enterTabMode(pendingTabModeUrl);
+      if (pendingTabModeUrl) {
+        enterTabMode(pendingTabModeUrl);
+        // Restored tab views are created/attached here while the window is still
+        // hidden (createMainWindow shows it asynchronously via ensureVisible). A
+        // WebContentsView added to a not-yet-shown window does not paint until it
+        // is re-laid-out, so restored tabs would otherwise sit transparent over
+        // the loading page forever. Re-attach + re-layout the active tab once the
+        // window is actually visible so it renders.
+        if (mainWindow && !mainWindow.isVisible()) {
+          mainWindow.once('show', () => {
+            if (attachedTabId && tabViewHost && mainWindow && !mainWindow.isDestroyed()) {
+              const activeView = tabViewHost.get(attachedTabId);
+              if (activeView) {
+                mainWindow.contentView.removeChildView(activeView);
+                mainWindow.contentView.addChildView(activeView);
+              }
+            }
+            layoutTabChrome();
+          });
+        }
+      }
       tray = setupTray({
         productName: PRODUCT_NAME,
         mainWindow,

--- a/apps/desktop/tests/ipc-handlers.test.ts
+++ b/apps/desktop/tests/ipc-handlers.test.ts
@@ -222,6 +222,32 @@ const register = (services: IpcServices) => {
   });
 };
 
+describe('ipc-handlers — tab preview caching', () => {
+  test('captures only the active tab live and serves cache for background tabs', async () => {
+    let active: unknown = null;
+    const services = makeServices({ activeContents: () => active as never });
+    const call = register(services);
+    const wc = (
+      services.tabViewHost as unknown as { getWebContents: (id: string) => unknown }
+    ).getWebContents('t1');
+
+    // Background tab with nothing cached yet → no preview (and crucially, no
+    // flicker-inducing capturePage of an offscreen view).
+    expect(await call('yc:tab-get-preview', 't1')).toMatchObject({
+      ok: false,
+      error: 'no-preview',
+    });
+
+    // Active (visible) tab → live capture, result cached.
+    active = wc;
+    expect(await call('yc:tab-get-preview', 't1')).toMatchObject({ ok: true });
+
+    // Same tab, now in the background → served from cache, no live capture.
+    active = null;
+    expect(await call('yc:tab-get-preview', 't1')).toMatchObject({ ok: true });
+  });
+});
+
 describe('ipc-handlers — happy paths', () => {
   test('core + settings + palette + cache handlers', async () => {
     const services = makeServices();


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

- Desktop signed builds can only be produced by publishing a public GitHub Release (the workflow is tag-only, `--publish always`).
- On reopening the app, session-restored tabs hang on the "Connecting to your practice…" loading splash forever (a freshly opened tab loads fine).
- Hovering across the tab bar flickers the content area.

## What is the new behavior?

**1. Artifacts-only signed build path** (`.github/workflows/desktop-release.yml`)
- Tag `desktop-v*` → builds, signs, publishes a GitHub Release (unchanged).
- Manual run (`workflow_dispatch`) → builds + signs but `--publish never`, uploading signed `.exe`/`.dmg`/`.zip` as workflow **artifacts** — for bundling desktop into a coordinated joint release (mobile + PIMS) without a standalone desktop Release.

**2. Fix — restored tabs stuck on loading** (`apps/desktop/src/main.ts`)
Restored tab views were created while the window was still hidden, so they never painted and the loading page showed through. They're now re-attached + re-laid-out once the window is visible.

**3. Fix — tab-hover flicker** (`apps/desktop/src/core/ipc-handlers.ts`)
The hover preview called `capturePage()` on background tabs, forcing offscreen views to render. Now only the visible tab is captured live; background tabs serve a thumbnail cached from when they were last active. Covered by a new unit test.

**Impact area:** CI workflow + `apps/desktop` shell (main process / IPC). No web-app or backend changes.

## Related Issue(s)

Fixes #1586