### PR TITLE
fix(desktop): repaint restored tab on reopen, fix splash logo, and cut duplication

### DIFF
--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -34,6 +34,7 @@ jobs:
             backend
             frontend
             mobile
+            desktop
             dev-docs
             types
             fhir

--- a/apps/desktop/src/compliance/dual-witness.ts
+++ b/apps/desktop/src/compliance/dual-witness.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import type { ControlledSubstanceLogbook } from './controlled-substance';
+import type { ControlledSubstanceLogbook, CsTransaction } from './controlled-substance';
 
 export interface WasteEvent {
   id: string;
@@ -55,6 +55,25 @@ const hashPin = (pin: string): string => {
   return hash.toString(16);
 };
 
+// A persisted waste transaction read back from the controlled-substance logbook
+// is, by definition, one that passed dual-witness verification at record time.
+const txToWasteEvent = (tx: CsTransaction): WasteEvent => ({
+  id: tx.id,
+  timestamp: tx.timestamp,
+  drugName: tx.drugName,
+  drugClass: tx.drugClass,
+  lotNumber: tx.lotNumber,
+  quantity: tx.quantity,
+  unit: tx.unit,
+  veterinarianId: tx.veterinarianId,
+  veterinarianName: tx.veterinarianName,
+  witnessId: tx.witnessId || '',
+  witnessName: tx.witnessName || '',
+  witnessPinVerified: true,
+  reason: tx.notes || '',
+  csTransactionId: tx.id,
+});
+
 export const createDualWitnessLog = (deps: DualWitnessDeps): DualWitnessLog => {
   const now = deps.now || (() => Date.now());
   const generateId = deps.generateId || defaultId;
@@ -81,27 +100,30 @@ export const createDualWitnessLog = (deps: DualWitnessDeps): DualWitnessLog => {
     >
   ): WasteEvent => {
     const pinVerified = verifyWitnessPin(input.witnessId, input.witnessPin);
+    const buildEvent = (witnessPinVerified: boolean, csTransactionId: string): WasteEvent => ({
+      id: generateId(),
+      timestamp: now(),
+      drugName: input.drugName,
+      drugClass: input.drugClass,
+      lotNumber: input.lotNumber,
+      quantity: input.quantity,
+      unit: input.unit,
+      veterinarianId: input.veterinarianId,
+      veterinarianName: input.veterinarianName,
+      witnessId: input.witnessId,
+      witnessName: input.witnessName,
+      witnessPinVerified,
+      reason: input.reason,
+      csTransactionId,
+    });
+
     if (!pinVerified) {
       // Reject before touching inventory: an unverified or missing witness must not
       // produce a controlled-substance waste transaction (which would decrement stock
       // and later read back via getWasteEvents() as a compliant, verified record).
-      return {
-        id: generateId(),
-        timestamp: now(),
-        drugName: input.drugName,
-        drugClass: input.drugClass,
-        lotNumber: input.lotNumber,
-        quantity: input.quantity,
-        unit: input.unit,
-        veterinarianId: input.veterinarianId,
-        veterinarianName: input.veterinarianName,
-        witnessId: input.witnessId,
-        witnessName: input.witnessName,
-        witnessPinVerified: false,
-        reason: input.reason,
-        csTransactionId: '',
-      };
+      return buildEvent(false, '');
     }
+
     const csTx = deps.logbook.record({
       action: 'waste',
       drugName: input.drugName,
@@ -115,68 +137,19 @@ export const createDualWitnessLog = (deps: DualWitnessDeps): DualWitnessLog => {
       witnessName: input.witnessName,
     });
 
-    const event: WasteEvent = {
-      id: generateId(),
-      timestamp: now(),
-      drugName: input.drugName,
-      drugClass: input.drugClass,
-      lotNumber: input.lotNumber,
-      quantity: input.quantity,
-      unit: input.unit,
-      veterinarianId: input.veterinarianId,
-      veterinarianName: input.veterinarianName,
-      witnessId: input.witnessId,
-      witnessName: input.witnessName,
-      witnessPinVerified: pinVerified,
-      reason: input.reason,
-      csTransactionId: csTx.id,
-    };
-
-    return event;
+    return buildEvent(pinVerified, csTx.id);
   };
 
   const getWasteEvents = (drugName?: string): WasteEvent[] => {
     const txs = drugName ? deps.logbook.getByDrug(drugName) : deps.logbook.getTransactions();
-    return txs
-      .filter((tx) => tx.action === 'waste')
-      .map((tx) => ({
-        id: tx.id,
-        timestamp: tx.timestamp,
-        drugName: tx.drugName,
-        drugClass: tx.drugClass,
-        lotNumber: tx.lotNumber,
-        quantity: tx.quantity,
-        unit: tx.unit,
-        veterinarianId: tx.veterinarianId,
-        veterinarianName: tx.veterinarianName,
-        witnessId: tx.witnessId || '',
-        witnessName: tx.witnessName || '',
-        witnessPinVerified: true,
-        reason: tx.notes || '',
-        csTransactionId: tx.id,
-      }));
+    return txs.filter((tx) => tx.action === 'waste').map(txToWasteEvent);
   };
 
   const getWasteByWitness = (witnessId: string): WasteEvent[] => {
     const txs = deps.logbook.getTransactions();
     return txs
       .filter((tx) => tx.action === 'waste' && tx.witnessId === witnessId)
-      .map((tx) => ({
-        id: tx.id,
-        timestamp: tx.timestamp,
-        drugName: tx.drugName,
-        drugClass: tx.drugClass,
-        lotNumber: tx.lotNumber,
-        quantity: tx.quantity,
-        unit: tx.unit,
-        veterinarianId: tx.veterinarianId,
-        veterinarianName: tx.veterinarianName,
-        witnessId: tx.witnessId || '',
-        witnessName: tx.witnessName || '',
-        witnessPinVerified: true,
-        reason: tx.notes || '',
-        csTransactionId: tx.id,
-      }));
+      .map(txToWasteEvent);
   };
 
   return {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -423,6 +423,25 @@ const enterTabMode = (initialUrl: string): void => {
   saveSession();
 };
 
+// A WebContentsView added to a not-yet-shown window does not paint until it is
+// re-laid-out, so a restored/active tab would otherwise sit transparent over the
+// loading splash forever. Re-attach + re-layout the active tab once the window is
+// actually visible. Needed on cold start (restored session) AND on macOS dock
+// reopen — both create the window hidden, then show it asynchronously.
+const repaintActiveTabOnShow = (): void => {
+  if (!mainWindow || mainWindow.isVisible()) return;
+  mainWindow.once('show', () => {
+    if (attachedTabId && tabViewHost && mainWindow && !mainWindow.isDestroyed()) {
+      const activeView = tabViewHost.get(attachedTabId);
+      if (activeView) {
+        mainWindow.contentView.removeChildView(activeView);
+        mainWindow.contentView.addChildView(activeView);
+      }
+    }
+    layoutTabChrome();
+  });
+};
+
 // Make `id` the active tab: swap the content view and re-layout.
 const detachContentView = (id: string): void => {
   if (!tabViewHost || !mainWindow || mainWindow.isDestroyed()) return;
@@ -1612,24 +1631,7 @@ if (gotSingleInstanceLock) {
       // it must run here (not inside createMainWindow) to actually take effect.
       if (pendingTabModeUrl) {
         enterTabMode(pendingTabModeUrl);
-        // Restored tab views are created/attached here while the window is still
-        // hidden (createMainWindow shows it asynchronously via ensureVisible). A
-        // WebContentsView added to a not-yet-shown window does not paint until it
-        // is re-laid-out, so restored tabs would otherwise sit transparent over
-        // the loading page forever. Re-attach + re-layout the active tab once the
-        // window is actually visible so it renders.
-        if (mainWindow && !mainWindow.isVisible()) {
-          mainWindow.once('show', () => {
-            if (attachedTabId && tabViewHost && mainWindow && !mainWindow.isDestroyed()) {
-              const activeView = tabViewHost.get(attachedTabId);
-              if (activeView) {
-                mainWindow.contentView.removeChildView(activeView);
-                mainWindow.contentView.addChildView(activeView);
-              }
-            }
-            layoutTabChrome();
-          });
-        }
+        repaintActiveTabOnShow();
       }
       tray = setupTray({
         productName: PRODUCT_NAME,
@@ -1819,7 +1821,13 @@ if (gotSingleInstanceLock) {
         tabViewHost = output.tabViewHost;
         saveSession = output.saveSession;
         coldStartWatchdog = output.coldStartWatchdog;
-        if (output.enterTabModeUrl) enterTabMode(output.enterTabModeUrl);
+        if (output.enterTabModeUrl) {
+          enterTabMode(output.enterTabModeUrl);
+          // Same hidden-window repaint fix as cold start: the reopened window is
+          // created hidden and shown async, so the restored tab must be re-laid-out
+          // on show or it stays stuck behind the loading splash.
+          repaintActiveTabOnShow();
+        }
       });
     }
   });

--- a/apps/desktop/src/pages/loading.css
+++ b/apps/desktop/src/pages/loading.css
@@ -41,47 +41,29 @@ body {
 }
 .badge {
   position: relative;
-  width: 116px;
-  height: 116px;
   display: grid;
   place-items: center;
 }
+/* The logo art already includes its own badge ring and a BETA pill that breaks
+   the circle, so we deliberately avoid a hard frame here. A framed circle clipped
+   the protruding pill and left a dark backing square behind the mark. Instead a
+   soft circular brand glow sits behind the artwork. */
 .badge::before {
   content: '';
   position: absolute;
-  inset: -10px;
+  width: 132px;
+  height: 132px;
   border-radius: 50%;
-  background: conic-gradient(
-    from 0deg,
-    var(--brand-925),
-    var(--brand-900),
-    var(--color-brand-600),
-    var(--brand-925)
-  );
-  animation: spin 2.4s linear infinite;
-  filter: blur(2px);
-  opacity: 0.55;
-}
-.badge::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  border-radius: 50%;
-  background: var(--surface-card);
+  background: radial-gradient(circle, rgba(59, 135, 236, 0.34), transparent 70%);
+  filter: blur(14px);
 }
 .logo {
   position: relative;
   z-index: 1;
-  width: 96px;
-  height: 96px;
-  border-radius: 22px;
-  object-fit: contain;
-  box-shadow: 0 10px 30px rgba(59, 135, 236, 0.25);
-}
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
+  width: 136px;
+  height: auto;
+  /* drop-shadow follows the artwork's alpha, so there is no square halo */
+  filter: drop-shadow(0 10px 22px rgba(59, 135, 236, 0.28));
 }
 .title {
   font-size: 19px;
@@ -124,7 +106,6 @@ body {
   }
 }
 @media (prefers-reduced-motion: reduce) {
-  .badge::before,
   .bar,
   .wrap {
     animation: none;

--- a/apps/desktop/src/ui/app-menu.ts
+++ b/apps/desktop/src/ui/app-menu.ts
@@ -54,6 +54,13 @@ const tr = (key: MessageKey): string => translateMessage(key, app.getLocale());
 export const createAppMenu = (actions: MenuActions): void => {
   const isMac = process.platform === 'darwin';
 
+  // Forward a shortcut id to the focused tab's renderer. Find / Find Next /
+  // Find Previous each repeated this inline.
+  const sendShortcut = (shortcutId: string): void => {
+    const wc = actions.activeContents();
+    if (wc && !wc.isDestroyed()) wc.send('yc:shortcut', shortcutId);
+  };
+
   const template: MenuItemConstructorOptions[] = [
     ...(isMac
       ? [
@@ -174,32 +181,17 @@ export const createAppMenu = (actions: MenuActions): void => {
         {
           label: 'Find…',
           accelerator: 'CmdOrCtrl+F',
-          click: () => {
-            const wc = actions.activeContents();
-            if (wc && !wc.isDestroyed()) {
-              wc.send('yc:shortcut', 'find-in-page');
-            }
-          },
+          click: () => sendShortcut('find-in-page'),
         },
         {
           label: 'Find Next',
           accelerator: 'CmdOrCtrl+G',
-          click: () => {
-            const wc = actions.activeContents();
-            if (wc && !wc.isDestroyed()) {
-              wc.send('yc:shortcut', 'find-next');
-            }
-          },
+          click: () => sendShortcut('find-next'),
         },
         {
           label: 'Find Previous',
           accelerator: 'CmdOrCtrl+Shift+G',
-          click: () => {
-            const wc = actions.activeContents();
-            if (wc && !wc.isDestroyed()) {
-              wc.send('yc:shortcut', 'find-previous');
-            }
-          },
+          click: () => sendShortcut('find-previous'),
         },
       ],
     },

--- a/apps/desktop/src/ui/command-palette.ts
+++ b/apps/desktop/src/ui/command-palette.ts
@@ -26,168 +26,147 @@ export interface RecentEntry {
 // Action items navigate to the owning page with an `?action=` intent param the
 // web app can read to open the corresponding modal (forward-compatible: without
 // that handler they simply land on the correct page).
+const nav = (
+  id: string,
+  label: string,
+  description: string,
+  keywords: string[],
+  slug: string
+): PaletteItem => ({
+  id,
+  label,
+  description,
+  keywords,
+  url: `yosemitecrew://${slug}`,
+  type: 'navigate',
+});
+
+const action = (
+  id: string,
+  label: string,
+  description: string,
+  keywords: string[],
+  slug?: string
+): PaletteItem => ({
+  id,
+  label,
+  description,
+  keywords,
+  ...(slug ? { url: `yosemitecrew://${slug}` } : {}),
+  type: 'action',
+});
+
 export const BUILTIN_ACTIONS: PaletteItem[] = [
-  {
-    id: 'go-dashboard',
-    label: 'Dashboard',
-    description: 'Go to workspace home',
-    keywords: ['home', 'overview'],
-    url: 'yosemitecrew://dashboard',
-    type: 'navigate',
-  },
-  {
-    id: 'go-appointments',
-    label: 'Appointments',
-    description: 'View and manage appointments',
-    keywords: ['schedule', 'calendar', 'visits', 'booking'],
-    url: 'yosemitecrew://appointments',
-    type: 'navigate',
-  },
-  {
-    id: 'go-patients',
-    label: 'Patients',
-    description: 'Companion (patient) records',
-    keywords: ['records', 'clients', 'companions', 'medical', 'pets'],
-    url: 'yosemitecrew://companions',
-    type: 'navigate',
-  },
-  {
-    id: 'go-chat',
-    label: 'Chat',
-    description: 'Messages and notifications',
-    keywords: ['messages', 'inbox', 'communication', 'alerts'],
-    url: 'yosemitecrew://chat',
-    type: 'navigate',
-  },
-  {
-    id: 'go-finance',
-    label: 'Finance',
-    description: 'Invoices and payments',
-    keywords: ['invoices', 'payments', 'billing', 'charges'],
-    url: 'yosemitecrew://finance',
-    type: 'navigate',
-  },
-  {
-    id: 'go-tasks',
-    label: 'Tasks',
-    description: 'Your tasks and to-dos',
-    keywords: ['todo', 'work', 'checklist'],
-    url: 'yosemitecrew://tasks',
-    type: 'navigate',
-  },
-  {
-    id: 'go-inventory',
-    label: 'Inventory',
-    description: 'Stock and supplies',
-    keywords: ['stock', 'supplies', 'drugs', 'products'],
-    url: 'yosemitecrew://inventory',
-    type: 'navigate',
-  },
-  {
-    id: 'go-insights',
-    label: 'Insights',
-    description: 'Analytics and reporting',
-    keywords: ['analytics', 'reports', 'data', 'statistics'],
-    url: 'yosemitecrew://insights',
-    type: 'navigate',
-  },
-  {
-    id: 'go-forms',
-    label: 'Forms',
-    description: 'Templates and forms',
-    keywords: ['templates', 'documents', 'forms'],
-    url: 'yosemitecrew://forms',
-    type: 'navigate',
-  },
-  {
-    id: 'go-organization',
-    label: 'Organization',
-    description: 'Practice settings',
-    keywords: ['practice', 'clinic', 'team', 'org'],
-    url: 'yosemitecrew://organization',
-    type: 'navigate',
-  },
-  {
-    id: 'action-new-appointment',
-    label: 'New appointment',
-    description: 'Book a new appointment',
-    keywords: ['create', 'schedule', 'book', 'add'],
-    url: 'yosemitecrew://appointments?action=new',
-    type: 'action',
-  },
-  {
-    id: 'action-find-patient',
-    label: 'Find patient',
-    description: 'Search for a companion',
-    keywords: ['search', 'lookup', 'client', 'find'],
-    url: 'yosemitecrew://companions?action=search',
-    type: 'action',
-  },
-  {
-    id: 'action-new-invoice',
-    label: 'Create invoice',
-    description: 'Generate a new invoice',
-    keywords: ['bill', 'charge', 'payment', 'create'],
-    url: 'yosemitecrew://finance?action=new-invoice',
-    type: 'action',
-  },
-  {
-    id: 'action-check-in',
-    label: 'Check in patient',
-    description: 'Walk-in patient check-in',
-    keywords: ['arrival', 'walk-in', 'register'],
-    url: 'yosemitecrew://appointments?action=check-in',
-    type: 'action',
-  },
-  {
-    id: 'open-settings',
-    label: 'Open settings',
-    description: 'Application preferences',
-    keywords: ['preferences', 'config', 'options'],
-    type: 'action',
-  },
-  {
-    id: 'tab:new',
-    label: 'New tab',
-    description: 'Open a new browser tab',
-    keywords: ['tab', 'add', 'open'],
-    type: 'action',
-  },
-  {
-    id: 'tab:close',
-    label: 'Close tab',
-    description: 'Close the current tab',
-    keywords: ['close', 'remove', 'exit'],
-    type: 'action',
-  },
-  {
-    id: 'tab:reopen',
-    label: 'Reopen closed tab',
-    description: 'Restore the last closed tab',
-    keywords: ['undo', 'restore', 'reopen'],
-    type: 'action',
-  },
-  {
-    id: 'tab:search',
-    label: 'Search tabs',
-    description: 'Find and switch to a tab',
-    keywords: ['find', 'switch', 'search', 'filter'],
-    type: 'action',
-  },
-  {
-    id: 'tab:toggle-vertical',
-    label: 'Toggle vertical tabs',
-    description: 'Switch between horizontal and sidebar layout',
-    keywords: ['vertical', 'sidebar', 'layout', 'orientation'],
-    type: 'action',
-  },
-  {
-    id: 'tab:toggle-split',
-    label: 'Toggle split view',
-    description: 'View two tabs side by side',
-    keywords: ['split', 'side', 'dual', 'layout'],
-    type: 'action',
-  },
+  nav('go-dashboard', 'Dashboard', 'Go to workspace home', ['home', 'overview'], 'dashboard'),
+  nav(
+    'go-appointments',
+    'Appointments',
+    'View and manage appointments',
+    ['schedule', 'calendar', 'visits', 'booking'],
+    'appointments'
+  ),
+  nav(
+    'go-patients',
+    'Patients',
+    'Companion (patient) records',
+    ['records', 'clients', 'companions', 'medical', 'pets'],
+    'companions'
+  ),
+  nav(
+    'go-chat',
+    'Chat',
+    'Messages and notifications',
+    ['messages', 'inbox', 'communication', 'alerts'],
+    'chat'
+  ),
+  nav(
+    'go-finance',
+    'Finance',
+    'Invoices and payments',
+    ['invoices', 'payments', 'billing', 'charges'],
+    'finance'
+  ),
+  nav('go-tasks', 'Tasks', 'Your tasks and to-dos', ['todo', 'work', 'checklist'], 'tasks'),
+  nav(
+    'go-inventory',
+    'Inventory',
+    'Stock and supplies',
+    ['stock', 'supplies', 'drugs', 'products'],
+    'inventory'
+  ),
+  nav(
+    'go-insights',
+    'Insights',
+    'Analytics and reporting',
+    ['analytics', 'reports', 'data', 'statistics'],
+    'insights'
+  ),
+  nav('go-forms', 'Forms', 'Templates and forms', ['templates', 'documents', 'forms'], 'forms'),
+  nav(
+    'go-organization',
+    'Organization',
+    'Practice settings',
+    ['practice', 'clinic', 'team', 'org'],
+    'organization'
+  ),
+  action(
+    'action-new-appointment',
+    'New appointment',
+    'Book a new appointment',
+    ['create', 'schedule', 'book', 'add'],
+    'appointments?action=new'
+  ),
+  action(
+    'action-find-patient',
+    'Find patient',
+    'Search for a companion',
+    ['search', 'lookup', 'client', 'find'],
+    'companions?action=search'
+  ),
+  action(
+    'action-new-invoice',
+    'Create invoice',
+    'Generate a new invoice',
+    ['bill', 'charge', 'payment', 'create'],
+    'finance?action=new-invoice'
+  ),
+  action(
+    'action-check-in',
+    'Check in patient',
+    'Walk-in patient check-in',
+    ['arrival', 'walk-in', 'register'],
+    'appointments?action=check-in'
+  ),
+  action('open-settings', 'Open settings', 'Application preferences', [
+    'preferences',
+    'config',
+    'options',
+  ]),
+  action('tab:new', 'New tab', 'Open a new browser tab', ['tab', 'add', 'open']),
+  action('tab:close', 'Close tab', 'Close the current tab', ['close', 'remove', 'exit']),
+  action('tab:reopen', 'Reopen closed tab', 'Restore the last closed tab', [
+    'undo',
+    'restore',
+    'reopen',
+  ]),
+  action('tab:search', 'Search tabs', 'Find and switch to a tab', [
+    'find',
+    'switch',
+    'search',
+    'filter',
+  ]),
+  action(
+    'tab:toggle-vertical',
+    'Toggle vertical tabs',
+    'Switch between horizontal and sidebar layout',
+    ['vertical', 'sidebar', 'layout', 'orientation']
+  ),
+  action('tab:toggle-split', 'Toggle split view', 'View two tabs side by side', [
+    'split',
+    'side',
+    'dual',
+    'layout',
+  ]),
 ];
 
 export const scoreFuzzyMatch = (query: string, text: string): number => {

--- a/apps/desktop/src/ui/keyboard-shortcuts.ts
+++ b/apps/desktop/src/ui/keyboard-shortcuts.ts
@@ -9,61 +9,23 @@ export interface ShortcutDef {
   description: string;
 }
 
+const sc = (accelerator: string, id: string, label: string, description: string): ShortcutDef => ({
+  accelerator,
+  id,
+  label,
+  description,
+});
+
 export const SHORTCUTS: ShortcutDef[] = [
-  {
-    accelerator: 'CommandOrControl+K',
-    id: 'open-palette',
-    label: 'Command Palette',
-    description: 'Open command palette',
-  },
-  {
-    accelerator: 'CommandOrControl+P',
-    id: 'open-palette',
-    label: 'Quick Switch',
-    description: 'Quick switch between recent items',
-  },
-  {
-    accelerator: 'CommandOrControl+Shift+N',
-    id: 'new-patient',
-    label: 'New patient',
-    description: 'Create a new patient record',
-  },
-  {
-    accelerator: 'CommandOrControl+Shift+A',
-    id: 'appointments',
-    label: 'Appointments',
-    description: 'Go to appointments',
-  },
-  {
-    accelerator: 'CommandOrControl+Shift+S',
-    id: 'search',
-    label: 'Search patients',
-    description: 'Search for patients',
-  },
-  {
-    accelerator: 'CommandOrControl+Shift+E',
-    id: 'check-in',
-    label: 'Check in patient',
-    description: 'Walk-in check-in',
-  },
-  {
-    accelerator: 'CommandOrControl+Shift+I',
-    id: 'inbox',
-    label: 'Inbox',
-    description: 'Open inbox',
-  },
-  {
-    accelerator: 'CommandOrControl+Shift+B',
-    id: 'billing',
-    label: 'Billing',
-    description: 'Go to billing',
-  },
-  {
-    accelerator: 'CommandOrControl+Shift+T',
-    id: 'new-appointment',
-    label: 'New appointment',
-    description: 'Book a new appointment',
-  },
+  sc('CommandOrControl+K', 'open-palette', 'Command Palette', 'Open command palette'),
+  sc('CommandOrControl+P', 'open-palette', 'Quick Switch', 'Quick switch between recent items'),
+  sc('CommandOrControl+Shift+N', 'new-patient', 'New patient', 'Create a new patient record'),
+  sc('CommandOrControl+Shift+A', 'appointments', 'Appointments', 'Go to appointments'),
+  sc('CommandOrControl+Shift+S', 'search', 'Search patients', 'Search for patients'),
+  sc('CommandOrControl+Shift+E', 'check-in', 'Check in patient', 'Walk-in check-in'),
+  sc('CommandOrControl+Shift+I', 'inbox', 'Inbox', 'Open inbox'),
+  sc('CommandOrControl+Shift+B', 'billing', 'Billing', 'Go to billing'),
+  sc('CommandOrControl+Shift+T', 'new-appointment', 'New appointment', 'Book a new appointment'),
 ];
 
 export type ShortcutId = (typeof SHORTCUTS)[number]['id'];


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: <https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit>.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

1. **SonarCloud duplication** in `apps/desktop`: `command-palette.ts` 40.5%, `keyboard-shortcuts.ts` 33.5%, `dual-witness.ts` 17.9%, `app-menu.ts` 9.0%.
2. **Reopen loading bug:** on macOS, closing the window and reopening from the dock strands the app on the loading splash — the `activate` path entered tab mode but never re-attached the restored tab to the freshly-shown window, so it sat transparent over the splash.
3. **Odd splash logo:** the circular-badge-with-BETA-pill art was forced into a square frame with a dark `surface-card` backing circle, leaving a dark square behind the logo.

## What is the new behavior?

**Duplication — behavior-preserving helpers:**
- **`command-palette.ts`** — `nav()` / `action()` builders collapse the 21-entry `BUILTIN_ACTIONS`.
- **`keyboard-shortcuts.ts`** — `sc()` builder collapses `SHORTCUTS`.
- **`dual-witness.ts`** — a single `txToWasteEvent()` mapper (was duplicated across both getters) and a `buildEvent()` helper in `recordWaste`.
- **`app-menu.ts`** — a `sendShortcut()` helper for the three Find / Find Next / Find Previous handlers.

**Fixes:**
- **`main.ts`** — extracted the cold-start repaint logic into a shared `repaintActiveTabOnShow()` and applied it on the `activate` reopen path, so a restored tab repaints when the reopened window is shown instead of staying stuck behind the splash (also de-dupes the two paths).
- **`loading.css`** — removed the square frame + dark backing circle + square shadow; the logo now renders at its natural aspect ratio with a soft circular glow and an alpha-following drop-shadow (no dark square).

**Impact area:** `apps/desktop` only (no web/backend changes).

**Validation:** four dedup suites pass (`command-palette`, `keyboard-shortcuts`, `dual-witness`, `app-menu` — 44 tests); `tsc --noEmit` clean; prettier applied. `main.ts` / `create-main-window.ts` are excluded from coverage (composition roots), so the reopen fix is verified by manually closing + reopening the window. SonarCloud re-runs on the new commit.

## Related Issue(s)

Fixes #1595