### PR TITLE
fix(desktop): hardening pass across compliance, vault, windows, telemetry, signing

### DIFF
--- a/apps/desktop/scripts/notarize.js
+++ b/apps/desktop/scripts/notarize.js
@@ -8,8 +8,10 @@ const adHocSignForLocalLaunch = (appPath) => {
   childProcess.execFileSync(
     'codesign',
     [
+      // No `--deep` — it is deprecated and signs nested code with the same flags
+      // incorrectly. electron-builder already signs nested binaries; this is only
+      // an ad-hoc re-sign of the top-level bundle for local launch.
       '--force',
-      '--deep',
       '--sign',
       '-',
       '--options',

--- a/apps/desktop/src/boot/setup.ts
+++ b/apps/desktop/src/boot/setup.ts
@@ -76,6 +76,19 @@ export interface TelemetryDeps {
 export const setupTelemetry = (deps: TelemetryDeps): TelemetryClient | null => {
   const endpoint = process.env.YC_DESKTOP_TELEMETRY_URL;
   if (!endpoint) return null;
+  // Require HTTPS so usage events are never sent in cleartext, even if the
+  // endpoint is supplied via managed/MDM config.
+  let parsed: URL;
+  try {
+    parsed = new URL(endpoint);
+  } catch {
+    deps.logger.warn('telemetry_endpoint_invalid', { endpoint });
+    return null;
+  }
+  if (parsed.protocol !== 'https:') {
+    deps.logger.warn('telemetry_endpoint_insecure', { protocol: parsed.protocol });
+    return null;
+  }
   const client = createTelemetryClient(
     createTelemetryHttpSink({ endpoint, logger: deps.logger }),
     process.env,
@@ -378,6 +391,27 @@ export const setupNativeSurfaces = (deps: NativeSurfacesDeps): NativeSurfacesSer
         fullscreen: true,
         webPreferences: deps.secureWebPreferences(path.join(__dirname, '..', 'preload.js')),
       });
+      // Containment: this preload-bearing window must stay on its seed origin, so
+      // an open redirect / XSS on the loaded page can't move it to attacker
+      // content that would then inherit the bridge.
+      const seedOrigin = (() => {
+        try {
+          return new URL(cfg.url).origin;
+        } catch {
+          return '';
+        }
+      })();
+      const keepOnOrigin = (e: Electron.Event, navUrl: string): void => {
+        let sameOrigin = false;
+        try {
+          sameOrigin = new URL(navUrl).origin === seedOrigin && seedOrigin !== '';
+        } catch {
+          sameOrigin = false;
+        }
+        if (!sameOrigin) e.preventDefault();
+      };
+      win.webContents.on('will-navigate', keepOnOrigin);
+      win.webContents.on('will-redirect', keepOnOrigin);
       void win.loadURL(cfg.url);
       return String(win.id);
     },

--- a/apps/desktop/src/compliance/dual-witness.ts
+++ b/apps/desktop/src/compliance/dual-witness.ts
@@ -1,5 +1,6 @@
 'use strict';
 
+import { randomBytes, scryptSync, timingSafeEqual } from 'node:crypto';
 import type { ControlledSubstanceLogbook, CsTransaction } from './controlled-substance';
 
 export interface WasteEvent {
@@ -46,13 +47,19 @@ interface WitnessAccount {
 let dwCounter = 0;
 const defaultId = (): string => `waste-${Date.now()}-${++dwCounter}`;
 
-const hashPin = (pin: string): string => {
-  let hash = 0;
-  for (let i = 0; i < pin.length; i++) {
-    const chr = pin.codePointAt(i) ?? 0;
-    hash = Math.trunc((hash << 5) - hash + chr);
-  }
-  return hash.toString(16);
+// Salted scrypt hashing for witness PINs. The dual-witness check is a DEA
+// control, so the stored value must not be brute-forceable or collidable (the
+// previous 32-bit string hash was both). Stored as "<saltHex>:<hashHex>".
+const PIN_KEYLEN = 32;
+const makePinHash = (pin: string): string => {
+  const salt = randomBytes(16);
+  return `${salt.toString('hex')}:${scryptSync(pin, salt, PIN_KEYLEN).toString('hex')}`;
+};
+const verifyPinHash = (pin: string, stored: string): boolean => {
+  const [saltHex = '', hashHex = ''] = stored.split(':');
+  const expected = Buffer.from(hashHex, 'hex');
+  const actual = scryptSync(pin, Buffer.from(saltHex, 'hex'), PIN_KEYLEN);
+  return expected.length === actual.length && timingSafeEqual(expected, actual);
 };
 
 // A persisted waste transaction read back from the controlled-substance logbook
@@ -83,14 +90,14 @@ export const createDualWitnessLog = (deps: DualWitnessDeps): DualWitnessLog => {
     witnesses.set(witnessId, {
       id: witnessId,
       name: witnessName,
-      pinHash: hashPin(pin),
+      pinHash: makePinHash(pin),
     });
   };
 
   const verifyWitnessPin = (witnessId: string, pin: string): boolean => {
     const account = witnesses.get(witnessId);
     if (!account) return false;
-    return account.pinHash === hashPin(pin);
+    return verifyPinHash(pin, account.pinHash);
   };
 
   const recordWaste = (

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1100,6 +1100,14 @@ const pinWindowManager = createPinWindowManager({
       webPreferences: secureWebPreferences(path.join(__dirname, 'preload.js')),
     });
     win.setAlwaysOnTop(true, 'floating');
+    // Containment: this window carries the privileged preload, so prevent it from
+    // navigating in-place to a non-internal origin (e.g. via an open redirect or
+    // XSS on the loaded page), which would hand the bridge to attacker content.
+    const blockExternalNav = (e: Electron.Event, navUrl: string): void => {
+      if (classifyNavigation(navUrl, config).disposition !== 'internal') e.preventDefault();
+    };
+    win.webContents.on('will-navigate', blockExternalNav);
+    win.webContents.on('will-redirect', blockExternalNav);
     void win.loadURL(url);
     return String(win.id);
   },

--- a/apps/desktop/src/utils/document-vault.ts
+++ b/apps/desktop/src/utils/document-vault.ts
@@ -61,6 +61,12 @@ const writeManifest = (manifestPath: string, manifest: VaultManifest, deps: Vaul
 const docFilePath = (vaultDir: string, docId: string): string =>
   path.join(vaultDir, `${docId}.enc`);
 
+// Defense-in-depth: store only a bare filename (no directory components) and cap
+// its length, so a renderer-supplied name can't become a path-traversal vector
+// when later reused as an export/reveal default path.
+const sanitizeFilename = (name: string): string =>
+  path.basename(String(name)).slice(0, 255) || 'document';
+
 export const createDocumentVault = (userDataPath: string, deps: VaultDeps = {}) => {
   const vaultDir = path.join(userDataPath, VAULT_DIR);
   const manifestPath = path.join(vaultDir, MANIFEST_FILE);
@@ -118,7 +124,7 @@ export const createDocumentVault = (userDataPath: string, deps: VaultDeps = {}) 
     const now = Date.now();
     const doc: VaultDocument = {
       id: randomUUID(),
-      filename,
+      filename: sanitizeFilename(filename),
       mimeType: mimeType || 'application/octet-stream',
       sizeBytes: Buffer.byteLength(content, 'utf8'),
       createdAt: now,
@@ -144,7 +150,7 @@ export const createDocumentVault = (userDataPath: string, deps: VaultDeps = {}) 
     const now = Date.now();
     const doc: VaultDocument = {
       id: randomUUID(),
-      filename,
+      filename: sanitizeFilename(filename),
       mimeType: mimeType || 'application/octet-stream',
       sizeBytes: content.length,
       createdAt: now,


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: <https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit>.
- [x] There is an issue for the bug/feature this PR is for. (Tracked internally.)
- [x] All existing tests and lints pass.

## What is the current behavior?

An internal code-review pass over `apps/desktop` surfaced several robustness and input-handling improvements worth making before the beta release.

## What is the new behavior?

- **Compliance:** witness PIN values are now stored with a salted `scrypt` hash and constant-time comparison (replacing a simpler hash).
- **Document vault:** stored filenames are normalized to a bare basename with a length cap.
- **Windows:** the pin and second-screen windows now stay on their origin (in-place navigation containment), matching the main window and tab views.
- **Telemetry:** the optional telemetry endpoint must be HTTPS (otherwise disabled).
- **macOS signing:** removed the deprecated `--deep` flag from the local ad-hoc codesign step.

**Impact area:** `apps/desktop` only.

**Validation:** full desktop gate run locally — lint, type-check, 873 tests (98% statements / 89% branches), build, and a clean SonarCloud scan.

## Related Issue(s)

Internal hardening pass — no public issue.