### PR TITLE
feat(mobile): switch app environment dynamically on review login

### DIFF
--- a/apps/mobileAppYC/App.tsx
+++ b/apps/mobileAppYC/App.tsx
@@ -12,7 +12,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import {StatusBar, LogBox, Linking} from 'react-native';
+import {StatusBar, LogBox, Linking, DeviceEventEmitter} from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {SafeAreaProvider} from 'react-native-safe-area-context';
 import {Provider} from 'react-redux';
@@ -55,12 +55,15 @@ import type {RootStackParamList} from '@/navigation/types';
 import {
   API_CONFIG,
   AUTH_FEATURE_FLAGS,
+  DEV_API_MODE_CHANGED_EVENT,
   MOBILE_CONFIG_BEHAVIOR,
   POSTHOG_CONFIG,
   STRIPE_CONFIG,
   UI_FEATURE_FLAGS,
+  DEVELOPMENT_API_BASE_URL,
 } from '@/config/variables';
 import {updateApiClientBaseConfig} from '@/shared/services/apiClient';
+import {DEMO_API_MODE_KEY} from '@/features/auth/sessionManager';
 import {observationToolApi} from '@/features/observationalTools/services/observationToolService';
 import AppUpdateBottomSheet, {
   AppUpdateBottomSheetRef,
@@ -209,9 +212,20 @@ function App(): React.JSX.Element {
     {mobileConfig, appUpdatePrompt, isConfigLoading},
     dispatchMobileConfig,
   ] = useReducer(mobileConfigReducer, initialMobileConfigState);
+  const [devApiActive, setDevApiActive] = useState(
+    MOBILE_CONFIG_BEHAVIOR.useDevApi,
+  );
   const navigationRef = useNavigationContainerRef<RootStackParamList>();
   const pendingIntentRef = useRef<NotificationNavigationIntent | null>(null);
   const currentRouteNameRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const sub = DeviceEventEmitter.addListener(
+      DEV_API_MODE_CHANGED_EVENT,
+      ({isDevApi}: {isDevApi: boolean}) => setDevApiActive(isDevApi),
+    );
+    return () => sub.remove();
+  }, []);
 
   useEffect(() => {
     configureSocialProviders();
@@ -289,14 +303,19 @@ function App(): React.JSX.Element {
         });
 
         if (mounted) {
-          // Priority: local override apiBaseUrl > useDevApi flag > env from remote config
+          // Priority: local override > useDevApi flag > stored demo mode > prod default
           let resolvedBaseUrl: string;
           if (MOBILE_CONFIG_BEHAVIOR.overrides?.apiBaseUrl) {
             resolvedBaseUrl = MOBILE_CONFIG_BEHAVIOR.overrides.apiBaseUrl;
           } else if (MOBILE_CONFIG_BEHAVIOR.useDevApi) {
-            resolvedBaseUrl = 'https://devapi.yosemitecrew.com';
+            resolvedBaseUrl = DEVELOPMENT_API_BASE_URL;
           } else {
-            resolvedBaseUrl = PRODUCTION_API_BASE_URL;
+            const storedDemoMode =
+              await AsyncStorage.getItem(DEMO_API_MODE_KEY);
+            resolvedBaseUrl =
+              storedDemoMode === 'true'
+                ? DEVELOPMENT_API_BASE_URL
+                : PRODUCTION_API_BASE_URL;
           }
 
           const resolvedPmsUrl =
@@ -398,8 +417,11 @@ function App(): React.JSX.Element {
     };
   }, []);
 
-  const resolvedPublishableKey =
-    mobileConfig?.stripePublishableKey ?? STRIPE_CONFIG.publishableKey;
+  const resolvedPublishableKey = devApiActive
+    ? (mobileConfig?.stripePublishableKeyDev ??
+      mobileConfig?.stripePublishableKey ??
+      STRIPE_CONFIG.publishableKey)
+    : (mobileConfig?.stripePublishableKey ?? STRIPE_CONFIG.publishableKey);
 
   useEffect(() => {
     if (!resolvedPublishableKey && !isConfigLoading) {

--- a/apps/mobileAppYC/App.tsx
+++ b/apps/mobileAppYC/App.tsx
@@ -57,6 +57,7 @@ import {
   AUTH_FEATURE_FLAGS,
   DEV_API_MODE_CHANGED_EVENT,
   MOBILE_CONFIG_BEHAVIOR,
+  MOBILE_CONFIG_PATH,
   POSTHOG_CONFIG,
   STRIPE_CONFIG,
   UI_FEATURE_FLAGS,
@@ -312,10 +313,19 @@ function App(): React.JSX.Element {
           } else {
             const storedDemoMode =
               await AsyncStorage.getItem(DEMO_API_MODE_KEY);
-            resolvedBaseUrl =
-              storedDemoMode === 'true'
-                ? DEVELOPMENT_API_BASE_URL
-                : PRODUCTION_API_BASE_URL;
+            if (storedDemoMode === 'true') {
+              resolvedBaseUrl = DEVELOPMENT_API_BASE_URL;
+              try {
+                const devConfig = await fetchMobileConfig(
+                  `${DEVELOPMENT_API_BASE_URL}${MOBILE_CONFIG_PATH}`,
+                );
+                config = {...config, ...devConfig};
+              } catch (_) {}
+              Amplify.configure(devOutputs);
+              setDevApiActive(true);
+            } else {
+              resolvedBaseUrl = PRODUCTION_API_BASE_URL;
+            }
           }
 
           const resolvedPmsUrl =

--- a/apps/mobileAppYC/App.tsx
+++ b/apps/mobileAppYC/App.tsx
@@ -223,7 +223,23 @@ function App(): React.JSX.Element {
   useEffect(() => {
     const sub = DeviceEventEmitter.addListener(
       DEV_API_MODE_CHANGED_EVENT,
-      ({isDevApi}: {isDevApi: boolean}) => setDevApiActive(isDevApi),
+      ({isDevApi}: {isDevApi: boolean}) => {
+        setDevApiActive(isDevApi);
+        if (!isDevApi && !MOBILE_CONFIG_BEHAVIOR.skipRemoteFetch) {
+          fetchMobileConfig()
+            .then(prodConfig => {
+              dispatchMobileConfig({
+                type: 'CONFIG_LOADED',
+                config: applyMockAppUpdateFlow(
+                  prodConfig,
+                  MOBILE_CONFIG_BEHAVIOR.mockAppUpdateFlow,
+                ),
+                prompt: null,
+              });
+            })
+            .catch(() => {});
+        }
+      },
     );
     return () => sub.remove();
   }, []);
@@ -250,8 +266,22 @@ function App(): React.JSX.Element {
           enablePayments: false,
         };
 
+        // Check stored demo mode BEFORE fetching so we use the correct endpoint
+        // from the start — avoiding a prod-fetch failure blocking dev rehydration.
+        const storedDemoMode =
+          !MOBILE_CONFIG_BEHAVIOR.overrides?.apiBaseUrl &&
+          !MOBILE_CONFIG_BEHAVIOR.useDevApi
+            ? await AsyncStorage.getItem(DEMO_API_MODE_KEY)
+            : null;
+        const shouldUseDev =
+          MOBILE_CONFIG_BEHAVIOR.useDevApi || storedDemoMode === 'true';
+
         if (!MOBILE_CONFIG_BEHAVIOR.skipRemoteFetch) {
-          config = await fetchMobileConfig();
+          config = await fetchMobileConfig(
+            shouldUseDev
+              ? `${DEVELOPMENT_API_BASE_URL}${MOBILE_CONFIG_PATH}`
+              : undefined,
+          );
         }
 
         // Apply local overrides on top of remote config (field is `overrides`, not `override`)
@@ -310,22 +340,12 @@ function App(): React.JSX.Element {
             resolvedBaseUrl = MOBILE_CONFIG_BEHAVIOR.overrides.apiBaseUrl;
           } else if (MOBILE_CONFIG_BEHAVIOR.useDevApi) {
             resolvedBaseUrl = DEVELOPMENT_API_BASE_URL;
+          } else if (storedDemoMode === 'true') {
+            resolvedBaseUrl = DEVELOPMENT_API_BASE_URL;
+            Amplify.configure(devOutputs);
+            setDevApiActive(true);
           } else {
-            const storedDemoMode =
-              await AsyncStorage.getItem(DEMO_API_MODE_KEY);
-            if (storedDemoMode === 'true') {
-              resolvedBaseUrl = DEVELOPMENT_API_BASE_URL;
-              try {
-                const devConfig = await fetchMobileConfig(
-                  `${DEVELOPMENT_API_BASE_URL}${MOBILE_CONFIG_PATH}`,
-                );
-                config = {...config, ...devConfig};
-              } catch (_) {}
-              Amplify.configure(devOutputs);
-              setDevApiActive(true);
-            } else {
-              resolvedBaseUrl = PRODUCTION_API_BASE_URL;
-            }
+            resolvedBaseUrl = PRODUCTION_API_BASE_URL;
           }
 
           const resolvedPmsUrl =

--- a/apps/mobileAppYC/__tests__/config/variables.test.ts
+++ b/apps/mobileAppYC/__tests__/config/variables.test.ts
@@ -53,7 +53,7 @@ describe('Configuration Variables', () => {
       expect(config.PASSWORDLESS_AUTH_CONFIG.profileServiceUrl).toBe('');
       expect(config.STREAM_CHAT_CONFIG.apiKey).toBe('');
       expect(config.STRIPE_CONFIG.urlScheme).toBe('yosemitecrew');
-      expect(config.AUTH_FEATURE_FLAGS.enableReviewLogin).toBe(true);
+      expect(config.AUTH_FEATURE_FLAGS.enableReviewLogin).toBe(false);
       expect(config.DEMO_LOGIN_CONFIG.email).toBe('');
       expect(config.POSTHOG_CONFIG).toEqual({
         apiKey: '',

--- a/apps/mobileAppYC/__tests__/features/auth/sessionManager.test.ts
+++ b/apps/mobileAppYC/__tests__/features/auth/sessionManager.test.ts
@@ -94,7 +94,7 @@ jest.mock('@/features/auth/utils/parentProfileMapper', () => ({
 
 jest.mock('node:buffer', () => ({
   Buffer: {
-    from: jest.fn((str) => ({
+    from: jest.fn(str => ({
       toString: () => {
         // Simple mock decoding for "jwt-like" strings
         if (str.includes('eyJleHAiOjEwMH0')) return '{"exp":100}'; // 100 seconds
@@ -153,8 +153,8 @@ describe('sessionManager', () => {
     });
 
     it('decodes JWT expiration from idToken if expiresAt missing', () => {
-      const token = 'header.eyJleHAiOjEwMH0.sig';
-      const result = resolveExpiration({idToken: token});
+      const mockJwt = 'header.eyJleHAiOjEwMH0.sig';
+      const result = resolveExpiration({idToken: mockJwt});
       // 100 seconds * 1000 = 100000 ms
       expect(result).toBe(100000);
     });
@@ -209,7 +209,9 @@ describe('sessionManager', () => {
     });
 
     it('falls back to legacy storage if secure storage fails', async () => {
-      (storeTokens as jest.Mock).mockRejectedValue(new Error('Secure store failed'));
+      (storeTokens as jest.Mock).mockRejectedValue(
+        new Error('Secure store failed'),
+      );
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
 
       await persistSessionData(mockUser, mockTokens);
@@ -227,25 +229,31 @@ describe('sessionManager', () => {
     });
 
     it('handles error in fallback storage', async () => {
-       (storeTokens as jest.Mock).mockRejectedValue(new Error('Secure fail'));
-       (AsyncStorage.setItem as jest.Mock).mockImplementation((key) => {
-           if(key === '@auth_tokens') throw new Error('Legacy fail');
-           return Promise.resolve();
-       });
-       const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      (storeTokens as jest.Mock).mockRejectedValue(new Error('Secure fail'));
+      (AsyncStorage.setItem as jest.Mock).mockImplementation(key => {
+        if (key === '@auth_tokens') throw new Error('Legacy fail');
+        return Promise.resolve();
+      });
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
 
-       await persistSessionData(mockUser, mockTokens);
+      await persistSessionData(mockUser, mockTokens);
 
-       expect(consoleSpy).toHaveBeenCalledWith('Failed to persist auth tokens to legacy storage', expect.any(Error));
-       consoleSpy.mockRestore();
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Failed to persist auth tokens to legacy storage',
+        expect.any(Error),
+      );
+      consoleSpy.mockRestore();
     });
   });
 
   describe('persistUserData', () => {
-      it('persists user data to async storage', async () => {
-          await persistUserData(mockUser);
-          expect(AsyncStorage.setItem).toHaveBeenCalledWith('@user_data', JSON.stringify(mockUser));
-      });
+    it('persists user data to async storage', async () => {
+      await persistUserData(mockUser);
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+        '@user_data',
+        JSON.stringify(mockUser),
+      );
+    });
   });
 
   describe('clearSessionData', () => {
@@ -255,13 +263,16 @@ describe('sessionManager', () => {
       expect(AsyncStorage.multiRemove).toHaveBeenCalledWith([
         '@user_data',
         '@auth_tokens',
+        '@demo_api_mode',
         '@pending_profile',
       ]);
       expect(clearStoredTokens).toHaveBeenCalled();
     });
 
     it('handles secure store clear errors gracefully', async () => {
-      (clearStoredTokens as jest.Mock).mockRejectedValue(new Error('Clear fail'));
+      (clearStoredTokens as jest.Mock).mockRejectedValue(
+        new Error('Clear fail'),
+      );
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
 
       await clearSessionData();
@@ -275,9 +286,9 @@ describe('sessionManager', () => {
   });
 
   describe('getUserStorageKey', () => {
-      it('returns the user key constant', () => {
-          expect(getUserStorageKey()).toBe('@user_data');
-      });
+    it('returns the user key constant', () => {
+      expect(getUserStorageKey()).toBe('@user_data');
+    });
   });
 
   // ===========================================================================
@@ -288,7 +299,8 @@ describe('sessionManager', () => {
     // --- Amplify Recovery ---
     it('recovers session via Amplify if session exists', async () => {
       (AsyncStorage.getItem as jest.Mock).mockImplementation(key => {
-        if (key === '@user_data') return Promise.resolve(JSON.stringify(mockUser));
+        if (key === '@user_data')
+          return Promise.resolve(JSON.stringify(mockUser));
         return Promise.resolve(null);
       });
 
@@ -307,9 +319,9 @@ describe('sessionManager', () => {
         given_name: 'Amplify',
       });
       (fetchProfileStatus as jest.Mock).mockResolvedValue({
-          profileToken: 'new-profile-token',
-          isComplete: true,
-          parent: {id: 'pid-1'}
+        profileToken: 'new-profile-token',
+        isComplete: true,
+        parent: {id: 'pid-1'},
       });
 
       const result = await recoverAuthSession();
@@ -318,8 +330,8 @@ describe('sessionManager', () => {
       expect(result).toEqual({
         kind: 'authenticated',
         user: expect.objectContaining({
-            email: 'amplify@test.com',
-            profileToken: 'new-profile-token'
+          email: 'amplify@test.com',
+          profileToken: 'new-profile-token',
         }),
         tokens: expect.objectContaining({provider: 'amplify'}),
         provider: 'amplify',
@@ -328,35 +340,46 @@ describe('sessionManager', () => {
 
     it('returns pendingProfile if Amplify user matches pending profile key', async () => {
       (AsyncStorage.getItem as jest.Mock).mockImplementation(key => {
-        if (key === '@pending_profile') return Promise.resolve(JSON.stringify({userId: 'amplify-user-123'}));
+        if (key === '@pending_profile')
+          return Promise.resolve(JSON.stringify({userId: 'amplify-user-123'}));
         return Promise.resolve(null);
       });
 
-      (fetchAuthSession as jest.Mock).mockResolvedValue({tokens: {idToken: 't', accessToken: 't'}});
-      (getCurrentUser as jest.Mock).mockResolvedValue({userId: 'amplify-user-123'});
+      (fetchAuthSession as jest.Mock).mockResolvedValue({
+        tokens: {idToken: 't', accessToken: 't'},
+      });
+      (getCurrentUser as jest.Mock).mockResolvedValue({
+        userId: 'amplify-user-123',
+      });
 
       const result = await recoverAuthSession();
       expect(result).toEqual({kind: 'pendingProfile'});
     });
 
     it('handles resolveProfileTokenForUser failure gracefully in Amplify flow', async () => {
-        (AsyncStorage.getItem as jest.Mock).mockResolvedValue(JSON.stringify(mockUser));
-        (fetchAuthSession as jest.Mock).mockResolvedValue({
-            tokens: { idToken: 'id', accessToken: 'acc' }
-        });
-        (getCurrentUser as jest.Mock).mockResolvedValue({userId: 'u1'});
-        (fetchUserAttributes as jest.Mock).mockResolvedValue({});
-        (fetchProfileStatus as jest.Mock).mockRejectedValue(new Error('Profile API fail'));
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(
+        JSON.stringify(mockUser),
+      );
+      (fetchAuthSession as jest.Mock).mockResolvedValue({
+        tokens: {idToken: 'id', accessToken: 'acc'},
+      });
+      (getCurrentUser as jest.Mock).mockResolvedValue({userId: 'u1'});
+      (fetchUserAttributes as jest.Mock).mockResolvedValue({});
+      (fetchProfileStatus as jest.Mock).mockRejectedValue(
+        new Error('Profile API fail'),
+      );
 
-        const result = await recoverAuthSession();
+      const result = await recoverAuthSession();
 
-        expect(result?.kind).toBe('authenticated');
-        expect((result as any).user.profileToken).toBeUndefined();
+      expect(result?.kind).toBe('authenticated');
+      expect((result as any).user.profileToken).toBeUndefined();
     });
 
     // --- Firebase Recovery ---
     it('falls back to Firebase if Amplify fails', async () => {
-      (fetchAuthSession as jest.Mock).mockRejectedValue(new Error('No Amplify session'));
+      (fetchAuthSession as jest.Mock).mockRejectedValue(
+        new Error('No Amplify session'),
+      );
 
       const mockFirebaseUser = {
         uid: 'firebase-uid',
@@ -364,88 +387,99 @@ describe('sessionManager', () => {
       };
       (getAuth as jest.Mock).mockReturnValue({currentUser: mockFirebaseUser});
       (getIdToken as jest.Mock).mockResolvedValue('fb-id-token');
-      (getIdTokenResult as jest.Mock).mockResolvedValue({expirationTime: new Date().toISOString()});
-      (syncAuthUser as jest.Mock).mockResolvedValue({parentSummary: {id: 'p1', isComplete: true}});
+      (getIdTokenResult as jest.Mock).mockResolvedValue({
+        expirationTime: new Date().toISOString(),
+      });
+      (syncAuthUser as jest.Mock).mockResolvedValue({
+        parentSummary: {id: 'p1', isComplete: true},
+      });
 
       const result = await recoverAuthSession();
 
       expect(getAuth).toHaveBeenCalled();
       expect(reload).toHaveBeenCalledWith(mockFirebaseUser);
-      expect(result).toEqual(expect.objectContaining({
+      expect(result).toEqual(
+        expect.objectContaining({
           kind: 'authenticated',
-          provider: 'firebase'
-      }));
+          provider: 'firebase',
+        }),
+      );
     });
 
     it('signs out orphaned Firebase user (no parent, no pending profile)', async () => {
-        (fetchAuthSession as jest.Mock).mockRejectedValue(new Error());
-        (getAuth as jest.Mock).mockReturnValue({currentUser: {uid: 'orphan'}});
-        (reload as jest.Mock).mockResolvedValue(undefined);
-        (getIdToken as jest.Mock).mockResolvedValue('token');
-        (syncAuthUser as jest.Mock).mockResolvedValue({});
-        (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+      (fetchAuthSession as jest.Mock).mockRejectedValue(new Error());
+      (getAuth as jest.Mock).mockReturnValue({currentUser: {uid: 'orphan'}});
+      (reload as jest.Mock).mockResolvedValue(undefined);
+      (getIdToken as jest.Mock).mockResolvedValue('token');
+      (syncAuthUser as jest.Mock).mockResolvedValue({});
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
 
-        const result = await recoverAuthSession();
+      const result = await recoverAuthSession();
 
-        expect(firebaseSignOut).toHaveBeenCalled();
-        // Since Firebase recovery returns null, it falls through to stored (which is empty),
-        // then clears session and returns unauthenticated.
-        expect(result).toEqual({kind: 'unauthenticated'});
+      expect(firebaseSignOut).toHaveBeenCalled();
+      // Since Firebase recovery returns null, it falls through to stored (which is empty),
+      // then clears session and returns unauthenticated.
+      expect(result).toEqual({kind: 'unauthenticated'});
     });
 
     // --- Stored Tokens Recovery ---
     it('falls back to stored tokens if both providers fail', async () => {
-        (fetchAuthSession as jest.Mock).mockRejectedValue(new Error());
-        (getAuth as jest.Mock).mockReturnValue({currentUser: null});
+      (fetchAuthSession as jest.Mock).mockRejectedValue(new Error());
+      (getAuth as jest.Mock).mockReturnValue({currentUser: null});
 
-        (AsyncStorage.getItem as jest.Mock).mockImplementation(key => {
-            if (key === '@user_data') return Promise.resolve(JSON.stringify(mockUser));
-            return Promise.resolve(null);
-        });
+      (AsyncStorage.getItem as jest.Mock).mockImplementation(key => {
+        if (key === '@user_data')
+          return Promise.resolve(JSON.stringify(mockUser));
+        return Promise.resolve(null);
+      });
 
-        // Ensure tokens are NOT expired. Set expiresAt to future.
-        const futureTime = Date.now() + 500000;
-        (loadStoredTokens as jest.Mock).mockResolvedValue({
-            ...mockTokens,
-            expiresAt: futureTime
-        });
+      // Ensure tokens are NOT expired. Set expiresAt to future.
+      const futureTime = Date.now() + 500000;
+      (loadStoredTokens as jest.Mock).mockResolvedValue({
+        ...mockTokens,
+        expiresAt: futureTime,
+      });
 
-        const result = await recoverAuthSession();
+      const result = await recoverAuthSession();
 
-        expect(result).toEqual({
-            kind: 'authenticated',
-            user: expect.objectContaining({id: mockUser.id}),
-            tokens: expect.anything(),
-            provider: 'amplify'
-        });
+      expect(result).toEqual({
+        kind: 'authenticated',
+        user: expect.objectContaining({id: mockUser.id}),
+        tokens: expect.anything(),
+        provider: 'amplify',
+      });
     });
 
     it('migrates legacy tokens if secure tokens missing', async () => {
-        (fetchAuthSession as jest.Mock).mockRejectedValue(new Error());
-        (getAuth as jest.Mock).mockReturnValue({currentUser: null});
-        (AsyncStorage.getItem as jest.Mock).mockImplementation(key => {
-            if (key === '@user_data') return Promise.resolve(JSON.stringify(mockUser));
-            if (key === '@auth_tokens') return Promise.resolve(JSON.stringify(mockTokens));
-            return Promise.resolve(null);
-        });
-        (loadStoredTokens as jest.Mock).mockResolvedValue(null); // No secure tokens
+      (fetchAuthSession as jest.Mock).mockRejectedValue(new Error());
+      (getAuth as jest.Mock).mockReturnValue({currentUser: null});
+      (AsyncStorage.getItem as jest.Mock).mockImplementation(key => {
+        if (key === '@user_data')
+          return Promise.resolve(JSON.stringify(mockUser));
+        if (key === '@auth_tokens')
+          return Promise.resolve(JSON.stringify(mockTokens));
+        return Promise.resolve(null);
+      });
+      (loadStoredTokens as jest.Mock).mockResolvedValue(null); // No secure tokens
 
-        await recoverAuthSession();
+      await recoverAuthSession();
 
-        expect(storeTokens).toHaveBeenCalledWith(expect.objectContaining({accessToken: 'access-token'}));
-        expect(AsyncStorage.removeItem).toHaveBeenCalledWith('@auth_tokens');
+      expect(storeTokens).toHaveBeenCalledWith(
+        expect.objectContaining({accessToken: 'access-token'}),
+      );
+      expect(AsyncStorage.removeItem).toHaveBeenCalledWith('@auth_tokens');
     });
 
     it('returns unauthenticated if everything fails', async () => {
-        (fetchAuthSession as jest.Mock).mockRejectedValue(new Error());
-        (getAuth as jest.Mock).mockReturnValue({currentUser: null});
-        (loadStoredTokens as jest.Mock).mockResolvedValue(null);
-        (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+      (fetchAuthSession as jest.Mock).mockRejectedValue(new Error());
+      (getAuth as jest.Mock).mockReturnValue({currentUser: null});
+      (loadStoredTokens as jest.Mock).mockResolvedValue(null);
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
 
-        const result = await recoverAuthSession();
+      const result = await recoverAuthSession();
 
-        expect(result).toEqual({kind: 'unauthenticated'});
-        expect(AsyncStorage.multiRemove).toHaveBeenCalled();
+      expect(result).toEqual({kind: 'unauthenticated'});
+      expect(AsyncStorage.multiRemove).toHaveBeenCalled();
     });
   });
 
@@ -455,61 +489,74 @@ describe('sessionManager', () => {
 
   describe('getFreshStoredTokens', () => {
     it('returns stored tokens immediately if not expired', async () => {
-       const futureTime = Date.now() + 500000; // Well into future
-       (loadStoredTokens as jest.Mock).mockResolvedValue({
-           ...mockTokens,
-           expiresAt: futureTime
-       });
+      const futureTime = Date.now() + 500000; // Well into future
+      (loadStoredTokens as jest.Mock).mockResolvedValue({
+        ...mockTokens,
+        expiresAt: futureTime,
+      });
 
-       const result = await getFreshStoredTokens();
-       expect(result?.accessToken).toBe('access-token');
-       expect(fetchAuthSession).not.toHaveBeenCalled();
+      const result = await getFreshStoredTokens();
+      expect(result?.accessToken).toBe('access-token');
+      expect(fetchAuthSession).not.toHaveBeenCalled();
     });
 
     it('refreshes Firebase tokens if expired', async () => {
-        // Mock expired stored tokens
-        (loadStoredTokens as jest.Mock).mockResolvedValue({
-            ...mockTokens,
-            provider: 'firebase',
-            expiresAt: Date.now() - 1000 // Expired
-        });
+      // Mock expired stored tokens
+      (loadStoredTokens as jest.Mock).mockResolvedValue({
+        ...mockTokens,
+        provider: 'firebase',
+        expiresAt: Date.now() - 1000, // Expired
+      });
 
-        const mockFbUser = {uid: 'fb-1'};
-        (getAuth as jest.Mock).mockReturnValue({currentUser: mockFbUser});
-        (getIdToken as jest.Mock).mockResolvedValue('new-fb-token');
-        (getIdTokenResult as jest.Mock).mockResolvedValue({expirationTime: new Date(Date.now() + 100000).toISOString()});
+      const mockFbUser = {uid: 'fb-1'};
+      (getAuth as jest.Mock).mockReturnValue({currentUser: mockFbUser});
+      (getIdToken as jest.Mock).mockResolvedValue('new-fb-token');
+      (getIdTokenResult as jest.Mock).mockResolvedValue({
+        expirationTime: new Date(Date.now() + 100000).toISOString(),
+      });
     });
 
     it('refreshes Amplify tokens if expired', async () => {
-        // Mock expired stored tokens
-        (loadStoredTokens as jest.Mock).mockResolvedValue({
-            ...mockTokens,
-            provider: 'amplify',
-            expiresAt: Date.now() - 1000 // Expired
-        });
-        (fetchAuthSession as jest.Mock).mockResolvedValue({
-            tokens: {
-                idToken: {toString: () => 'new-amp-id', payload: {exp: Math.floor(Date.now()/1000) + 1000}},
-                accessToken: {toString: () => 'new-amp-access', payload: {exp: Math.floor(Date.now()/1000) + 1000}}
-            }
-        });
-        (getCurrentUser as jest.Mock).mockResolvedValue({userId: 'amp-1'});
+      // Mock expired stored tokens
+      (loadStoredTokens as jest.Mock).mockResolvedValue({
+        ...mockTokens,
+        provider: 'amplify',
+        expiresAt: Date.now() - 1000, // Expired
+      });
+      (fetchAuthSession as jest.Mock).mockResolvedValue({
+        tokens: {
+          idToken: {
+            toString: () => 'new-amp-id',
+            payload: {exp: Math.floor(Date.now() / 1000) + 1000},
+          },
+          accessToken: {
+            toString: () => 'new-amp-access',
+            payload: {exp: Math.floor(Date.now() / 1000) + 1000},
+          },
+        },
+      });
+      (getCurrentUser as jest.Mock).mockResolvedValue({userId: 'amp-1'});
     });
 
     it('returns null if refresh fails', async () => {
-        (loadStoredTokens as jest.Mock).mockResolvedValue({
-            ...mockTokens,
-            expiresAt: Date.now() - 1000
-        });
-        (fetchAuthSession as jest.Mock).mockRejectedValue(new Error('Network fail'));
+      (loadStoredTokens as jest.Mock).mockResolvedValue({
+        ...mockTokens,
+        expiresAt: Date.now() - 1000,
+      });
+      (fetchAuthSession as jest.Mock).mockRejectedValue(
+        new Error('Network fail'),
+      );
 
-        const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
-        const result = await getFreshStoredTokens();
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const result = await getFreshStoredTokens();
 
-        // Returns the old tokens (normalized) if refresh fails
-        expect(result?.accessToken).toBe('access-token');
-        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Unable to refresh'), expect.any(Error));
-        consoleSpy.mockRestore();
+      // Returns the old tokens (normalized) if refresh fails
+      expect(result?.accessToken).toBe('access-token');
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Unable to refresh'),
+        expect.any(Error),
+      );
+      consoleSpy.mockRestore();
     });
   });
 
@@ -519,52 +566,54 @@ describe('sessionManager', () => {
 
   describe('Lifecycle Functions', () => {
     it('scheduleSessionRefresh sets a timeout', () => {
-        const spy = jest.spyOn(globalThis, 'setTimeout');
-        const callback = jest.fn();
-        const expiresAt = Date.now() + 500000;
+      const spy = jest.spyOn(globalThis, 'setTimeout');
+      const callback = jest.fn();
+      const expiresAt = Date.now() + 500000;
 
-        scheduleSessionRefresh(expiresAt, callback);
+      scheduleSessionRefresh(expiresAt, callback);
 
-        expect(spy).toHaveBeenCalled();
-        jest.runAllTimers();
-        expect(callback).toHaveBeenCalled();
-        spy.mockRestore();
+      expect(spy).toHaveBeenCalled();
+      jest.runAllTimers();
+      expect(callback).toHaveBeenCalled();
+      spy.mockRestore();
     });
 
     it('registerAppStateListener triggers refresh on active if time elapsed', () => {
-        const callback = jest.fn();
-        let listener: (state: string) => void = () => {};
+      const callback = jest.fn();
+      let listener: (state: string) => void = () => {};
 
-        (AppState.addEventListener as jest.Mock).mockImplementation((evt, cb) => {
-            listener = cb;
-            return {remove: jest.fn()};
-        });
+      (AppState.addEventListener as jest.Mock).mockImplementation((evt, cb) => {
+        listener = cb;
+        return {remove: jest.fn()};
+      });
 
-        // Setup last timestamp way in the past
-        markAuthRefreshed(Date.now() - 1000000);
+      // Setup last timestamp way in the past
+      markAuthRefreshed(Date.now() - 1000000);
 
-        registerAppStateListener(callback);
+      registerAppStateListener(callback);
 
-        // Trigger active
-        listener('active');
+      // Trigger active
+      listener('active');
 
-        expect(callback).toHaveBeenCalled();
+      expect(callback).toHaveBeenCalled();
     });
 
     it('resetAuthLifecycle clears timeouts and listeners', async () => {
-        const spy = jest.spyOn(globalThis, 'clearTimeout');
-        const removeSpy = jest.fn();
-        (AppState.addEventListener as jest.Mock).mockReturnValue({remove: removeSpy});
+      const spy = jest.spyOn(globalThis, 'clearTimeout');
+      const removeSpy = jest.fn();
+      (AppState.addEventListener as jest.Mock).mockReturnValue({
+        remove: removeSpy,
+      });
 
-        registerAppStateListener(() => {});
-        scheduleSessionRefresh(Date.now() + 1000, () => {});
+      registerAppStateListener(() => {});
+      scheduleSessionRefresh(Date.now() + 1000, () => {});
 
-        resetAuthLifecycle({clearPendingProfile: true});
+      resetAuthLifecycle({clearPendingProfile: true});
 
-        expect(spy).toHaveBeenCalled();
-        expect(removeSpy).toHaveBeenCalled();
-        expect(AsyncStorage.removeItem).toHaveBeenCalledWith('@pending_profile');
-        spy.mockRestore();
+      expect(spy).toHaveBeenCalled();
+      expect(removeSpy).toHaveBeenCalled();
+      expect(AsyncStorage.removeItem).toHaveBeenCalledWith('@pending_profile');
+      spy.mockRestore();
     });
   });
 });

--- a/apps/mobileAppYC/__tests__/features/forms/formsSlice.test.ts
+++ b/apps/mobileAppYC/__tests__/features/forms/formsSlice.test.ts
@@ -612,7 +612,6 @@ describe('formsSlice', () => {
       expect(formApi.startSigning).toHaveBeenCalledWith({
         submissionId: 'sub-1',
         accessToken: mockAccessToken,
-        userId: mockUserId,
       });
       expect(store.getState().forms.signingBySubmission['sub-1']).toBe(false);
 

--- a/apps/mobileAppYC/__tests__/features/forms/services/formService.test.ts
+++ b/apps/mobileAppYC/__tests__/features/forms/services/formService.test.ts
@@ -187,23 +187,19 @@ describe('formService', () => {
       expect(result).toEqual(mockData);
     });
 
-    it('includes user-id header if provided', async () => {
+    it('sends request with auth headers only (no x-user-id)', async () => {
       mockApiClient.post.mockResolvedValue({data: {}});
 
       await formApi.startSigning({
         submissionId: 'sub-1',
         accessToken: mockToken,
-        userId: 'user-123',
       });
 
       expect(mockApiClient.post).toHaveBeenCalledWith(
         expect.any(String),
         expect.anything(),
         {
-          headers: {
-            ...mockAuthHeaders,
-            'x-user-id': 'user-123',
-          },
+          headers: mockAuthHeaders,
         },
       );
     });

--- a/apps/mobileAppYC/__tests__/features/legal/services/withdrawalService.test.ts
+++ b/apps/mobileAppYC/__tests__/features/legal/services/withdrawalService.test.ts
@@ -1,6 +1,11 @@
 import withdrawalService from '../../../../src/features/legal/services/withdrawalService';
-import apiClient, {withAuthHeaders} from '../../../../src/shared/services/apiClient';
-import {ensureAccessContext, toErrorMessage} from '../../../../src/shared/utils/serviceHelpers';
+import apiClient, {
+  withAuthHeaders,
+} from '../../../../src/shared/services/apiClient';
+import {
+  ensureAccessContext,
+  toErrorMessage,
+} from '../../../../src/shared/utils/serviceHelpers';
 
 // --- Mocks ---
 
@@ -43,7 +48,10 @@ describe('withdrawalService', () => {
       userId: mockUserId,
     });
 
-    const mockHeaders = {Authorization: 'Bearer mock-token', 'x-user-id': mockUserId};
+    const mockHeaders = {
+      Authorization: 'Bearer mock-token',
+      'x-user-id': mockUserId,
+    };
     (withAuthHeaders as jest.Mock).mockReturnValue(mockHeaders);
 
     const mockResponse = {success: true};
@@ -54,14 +62,11 @@ describe('withdrawalService', () => {
 
     // Verify
     expect(ensureAccessContext).toHaveBeenCalled();
-    expect(withAuthHeaders).toHaveBeenCalledWith(
-      mockAccessToken,
-      {'x-user-id': mockUserId}
-    );
+    expect(withAuthHeaders).toHaveBeenCalledWith(mockAccessToken);
     expect(apiClient.post).toHaveBeenCalledWith(
       '/v1/account-withdrawal/withdraw',
       mockPayload,
-      {headers: mockHeaders}
+      {headers: mockHeaders},
     );
     expect(result).toEqual(mockResponse);
   });
@@ -81,10 +86,7 @@ describe('withdrawalService', () => {
     await withdrawalService.submitWithdrawal(mockPayload);
 
     // Verify
-    expect(withAuthHeaders).toHaveBeenCalledWith(
-      mockAccessToken,
-      undefined // userId header object is undefined
-    );
+    expect(withAuthHeaders).toHaveBeenCalledWith(mockAccessToken);
   });
 
   // --- 2. Error Handling ---
@@ -94,19 +96,21 @@ describe('withdrawalService', () => {
     const formattedErrorMsg = 'Custom error message from helper';
 
     // Setup Mocks
-    (ensureAccessContext as jest.Mock).mockResolvedValue({accessToken: mockAccessToken});
+    (ensureAccessContext as jest.Mock).mockResolvedValue({
+      accessToken: mockAccessToken,
+    });
     (apiClient.post as jest.Mock).mockRejectedValue(apiError);
     (toErrorMessage as jest.Mock).mockReturnValue(formattedErrorMsg);
 
     // Execute & Verify
-    await expect(withdrawalService.submitWithdrawal(mockPayload))
-      .rejects
-      .toThrow(formattedErrorMsg);
+    await expect(
+      withdrawalService.submitWithdrawal(mockPayload),
+    ).rejects.toThrow(formattedErrorMsg);
 
     // Verify helpers called correctly
     expect(toErrorMessage).toHaveBeenCalledWith(
       apiError,
-      'Unable to submit withdrawal request. Please try again.'
+      'Unable to submit withdrawal request. Please try again.',
     );
   });
 });

--- a/apps/mobileAppYC/__tests__/features/observationalTools/services/observationToolService.test.ts
+++ b/apps/mobileAppYC/__tests__/features/observationalTools/services/observationToolService.test.ts
@@ -1,5 +1,8 @@
 import apiClient from '../../../../src/shared/services/apiClient';
-import { getFreshStoredTokens, isTokenExpired } from '../../../../src/features/auth/sessionManager';
+import {
+  getFreshStoredTokens,
+  isTokenExpired,
+} from '../../../../src/features/auth/sessionManager';
 import {
   observationToolApi,
   resolveObservationToolIdSync,
@@ -20,7 +23,7 @@ jest.mock('../../../../src/features/observationalTools/data', () => ({
     },
     'another-static': {
       name: 'Another Static',
-    }
+    },
   },
 }));
 
@@ -58,7 +61,7 @@ describe('observationToolService', () => {
       it('returns toolId directly if found in cache by ID', async () => {
         // First populate cache with a UNIQUE ID for this test
         (apiClient.get as jest.Mock).mockResolvedValue({
-          data: [{ id: 'cached-id-1', name: 'Cached Tool 1' }]
+          data: [{id: 'cached-id-1', name: 'Cached Tool 1'}],
         });
         await observationToolApi.list();
 
@@ -68,27 +71,33 @@ describe('observationToolService', () => {
       it('resolves ID from cache by Name', async () => {
         // Populate cache with UNIQUE ID/Name
         (apiClient.get as jest.Mock).mockResolvedValue({
-          data: [{ id: 'cached-id-2', name: 'My Special Tool' }]
+          data: [{id: 'cached-id-2', name: 'My Special Tool'}],
         });
         await observationToolApi.list();
 
         // Exact name
-        expect(resolveObservationToolIdSync('My Special Tool')).toBe('cached-id-2');
+        expect(resolveObservationToolIdSync('My Special Tool')).toBe(
+          'cached-id-2',
+        );
         // Case insensitive / normalized
-        expect(resolveObservationToolIdSync('my special tool')).toBe('cached-id-2');
+        expect(resolveObservationToolIdSync('my special tool')).toBe(
+          'cached-id-2',
+        );
       });
 
       it('resolves ID from Static Definitions', () => {
         // 1. Static def 'static-tool-key' has name 'Static Tool Name'
         // 2. We pretend the API returned a tool with that name and a real ID
         (apiClient.get as jest.Mock).mockResolvedValue({
-          data: [{ id: 'real-db-id-123', name: 'Static Tool Name' }]
+          data: [{id: 'real-db-id-123', name: 'Static Tool Name'}],
         });
 
         // Populate cache
         return observationToolApi.list().then(() => {
-           // Now passing the key 'static-tool-key' should look up the static def -> get name -> find in cache
-           expect(resolveObservationToolIdSync('static-tool-key')).toBe('real-db-id-123');
+          // Now passing the key 'static-tool-key' should look up the static def -> get name -> find in cache
+          expect(resolveObservationToolIdSync('static-tool-key')).toBe(
+            'real-db-id-123',
+          );
         });
       });
 
@@ -104,7 +113,7 @@ describe('observationToolService', () => {
 
       it('returns name from cache by ID', async () => {
         (apiClient.get as jest.Mock).mockResolvedValue({
-          data: [{ id: 'id-xyz', name: 'Tool XYZ' }]
+          data: [{id: 'id-xyz', name: 'Tool XYZ'}],
         });
         await observationToolApi.list();
         expect(getCachedObservationToolName('id-xyz')).toBe('Tool XYZ');
@@ -112,7 +121,7 @@ describe('observationToolService', () => {
 
       it('returns name from cache by Name (normalization)', async () => {
         (apiClient.get as jest.Mock).mockResolvedValue({
-          data: [{ id: 'id-abc', name: 'Tool ABC' }]
+          data: [{id: 'id-abc', name: 'Tool ABC'}],
         });
         await observationToolApi.list();
         expect(getCachedObservationToolName('tool abc')).toBe('Tool ABC');
@@ -129,8 +138,8 @@ describe('observationToolService', () => {
       });
 
       it('returns full object from cache by ID', async () => {
-        const toolData = { id: 'id-full', name: 'Full Tool', category: 'Health' };
-        (apiClient.get as jest.Mock).mockResolvedValue({ data: [toolData] });
+        const toolData = {id: 'id-full', name: 'Full Tool', category: 'Health'};
+        (apiClient.get as jest.Mock).mockResolvedValue({data: [toolData]});
         await observationToolApi.list();
 
         const result = getCachedObservationTool('id-full');
@@ -138,8 +147,8 @@ describe('observationToolService', () => {
       });
 
       it('returns full object from cache by Name', async () => {
-        const toolData = { id: 'id-full-2', name: 'Named Tool' };
-        (apiClient.get as jest.Mock).mockResolvedValue({ data: [toolData] });
+        const toolData = {id: 'id-full-2', name: 'Named Tool'};
+        (apiClient.get as jest.Mock).mockResolvedValue({data: [toolData]});
         await observationToolApi.list();
 
         const result = getCachedObservationTool('Named Tool');
@@ -153,7 +162,7 @@ describe('observationToolService', () => {
         // what is effectively already in the cache, OR use the other static key.
         // We will assert against the existing cache to acknowledge the singleton state.
 
-        const toolData = { id: 'real-db-id-123', name: 'Static Tool Name' };
+        const toolData = {id: 'real-db-id-123', name: 'Static Tool Name'};
         // We don't even need to mock API here because it's already in cache from previous test.
 
         const result = getCachedObservationTool('static-tool-key');
@@ -171,13 +180,19 @@ describe('observationToolService', () => {
   // =========================================================================
   describe('Auth Logic (ensureAccessToken)', () => {
     it('throws if no access token', async () => {
-      (getFreshStoredTokens as jest.Mock).mockResolvedValue({ accessToken: null });
-      await expect(observationToolApi.list()).rejects.toThrow('Missing access token');
+      (getFreshStoredTokens as jest.Mock).mockResolvedValue({
+        accessToken: null,
+      });
+      await expect(observationToolApi.list()).rejects.toThrow(
+        'Missing access token',
+      );
     });
 
     it('throws if token expired', async () => {
       (isTokenExpired as jest.Mock).mockReturnValue(true);
-      await expect(observationToolApi.list()).rejects.toThrow('Your session expired');
+      await expect(observationToolApi.list()).rejects.toThrow(
+        'Your session expired',
+      );
     });
   });
 
@@ -185,22 +200,26 @@ describe('observationToolService', () => {
   // Section 3: API Methods
   // =========================================================================
   describe('observationToolApi', () => {
-
     describe('list', () => {
       it('fetches and maps tools list', async () => {
         // Use unique IDs to avoid polluting cache for the specific GET test later
         const mockData = [
-          { _id: 'list-id-1', name: 'List Tool 1', isActive: true },
-          { id: 'list-id-2', name: 'List Tool 2', description: 'Desc' }
+          {_id: 'list-id-1', name: 'List Tool 1', isActive: true},
+          {id: 'list-id-2', name: 'List Tool 2', description: 'Desc'},
         ];
-        (apiClient.get as jest.Mock).mockResolvedValue({ data: mockData });
+        (apiClient.get as jest.Mock).mockResolvedValue({data: mockData});
 
-        const result = await observationToolApi.list({ onlyActive: true });
+        const result = await observationToolApi.list({onlyActive: true});
 
-        expect(apiClient.get).toHaveBeenCalledWith('/v1/observation-tools/mobile/tools', expect.objectContaining({
-          params: { onlyActive: 'true' },
-          headers: expect.objectContaining({ 'x-user-id': mockUserId })
-        }));
+        expect(apiClient.get).toHaveBeenCalledWith(
+          '/v1/observation-tools/mobile/tools',
+          expect.objectContaining({
+            params: {onlyActive: 'true'},
+            headers: expect.not.objectContaining({
+              'x-user-id': expect.anything(),
+            }),
+          }),
+        );
 
         expect(result).toHaveLength(2);
         expect(result[0].id).toBe('list-id-1');
@@ -208,7 +227,7 @@ describe('observationToolService', () => {
       });
 
       it('handles empty response gracefully', async () => {
-        (apiClient.get as jest.Mock).mockResolvedValue({ data: null });
+        (apiClient.get as jest.Mock).mockResolvedValue({data: null});
         const result = await observationToolApi.list();
         expect(result).toEqual([]);
       });
@@ -218,14 +237,14 @@ describe('observationToolService', () => {
       it('fetches a single tool by ID', async () => {
         // Use a UNIQUE ID ('tool-unique-get') to ensure it is NOT found in the cache
         // from previous tests (like 'tool-1' might have been if names collided)
-        const mockTool = { _id: 'tool-unique-get', name: 'Single Tool' };
-        (apiClient.get as jest.Mock).mockResolvedValue({ data: mockTool });
+        const mockTool = {_id: 'tool-unique-get', name: 'Single Tool'};
+        (apiClient.get as jest.Mock).mockResolvedValue({data: mockTool});
 
         const result = await observationToolApi.get('tool-unique-get');
 
         expect(apiClient.get).toHaveBeenCalledWith(
           '/v1/observation-tools/mobile/tools/tool-unique-get',
-          expect.anything()
+          expect.anything(),
         );
         expect(result.id).toBe('tool-unique-get');
         expect(result.name).toBe('Single Tool');
@@ -235,16 +254,20 @@ describe('observationToolService', () => {
         // We use 'another-static' because 'static-tool-key' was already cached in a previous test.
         // 'another-static' -> 'Another Static'
 
-        (apiClient.get as jest.Mock).mockImplementation((url) => {
+        (apiClient.get as jest.Mock).mockImplementation(url => {
           // If the code calls list to resolve the name
           if (url.includes('/tools?')) {
-             return Promise.resolve({ data: [{ id: 'real-id-999', name: 'Another Static' }] });
+            return Promise.resolve({
+              data: [{id: 'real-id-999', name: 'Another Static'}],
+            });
           }
           // If the code calls get with the resolved ID
           if (url.includes('/tools/real-id-999')) {
-             return Promise.resolve({ data: { id: 'real-id-999', name: 'Another Static' } });
+            return Promise.resolve({
+              data: {id: 'real-id-999', name: 'Another Static'},
+            });
           }
-          return Promise.resolve({ data: {} });
+          return Promise.resolve({data: {}});
         });
       });
     });
@@ -254,16 +277,18 @@ describe('observationToolService', () => {
         const submissionResponse = {
           _id: 'sub-1',
           toolId: 'tool-1',
-          score: 10
+          score: 10,
         };
-        (apiClient.post as jest.Mock).mockResolvedValue({ data: submissionResponse });
+        (apiClient.post as jest.Mock).mockResolvedValue({
+          data: submissionResponse,
+        });
 
         const result = await observationToolApi.submit({
           toolId: 'tool-1',
           companionId: 'comp-1',
           taskId: 'task-1',
-          answers: { q1: 'yes' },
-          summary: 'Good'
+          answers: {q1: 'yes'},
+          summary: 'Good',
         });
 
         expect(apiClient.post).toHaveBeenCalledWith(
@@ -271,10 +296,10 @@ describe('observationToolService', () => {
           expect.objectContaining({
             companionId: 'comp-1',
             taskId: 'task-1',
-            answers: { q1: 'yes' },
-            summary: 'Good'
+            answers: {q1: 'yes'},
+            summary: 'Good',
           }),
-          expect.anything()
+          expect.anything(),
         );
 
         expect(result.id).toBe('sub-1');
@@ -285,18 +310,18 @@ describe('observationToolService', () => {
     describe('linkSubmissionToAppointment', () => {
       it('links submission and returns updated object', async () => {
         (apiClient.post as jest.Mock).mockResolvedValue({
-          data: { id: 'sub-1', evaluationAppointmentId: 'appt-1' }
+          data: {id: 'sub-1', evaluationAppointmentId: 'appt-1'},
         });
 
         const result = await observationToolApi.linkSubmissionToAppointment({
           submissionId: 'sub-1',
-          appointmentId: 'appt-1'
+          appointmentId: 'appt-1',
         });
 
         expect(apiClient.post).toHaveBeenCalledWith(
           '/v1/observation-tools/mobile/submissions/sub-1/link-appointment',
-          { appointmentId: 'appt-1' },
-          expect.anything()
+          {appointmentId: 'appt-1'},
+          expect.anything(),
         );
         expect(result.evaluationAppointmentId).toBe('appt-1');
       });
@@ -305,13 +330,13 @@ describe('observationToolService', () => {
     describe('getSubmission', () => {
       it('fetches submission details', async () => {
         (apiClient.get as jest.Mock).mockResolvedValue({
-          data: { _id: 'sub-details-1', score: 5 }
+          data: {_id: 'sub-details-1', score: 5},
         });
 
         const result = await observationToolApi.getSubmission('sub-details-1');
         expect(apiClient.get).toHaveBeenCalledWith(
           '/v1/observation-tools/mobile/submissions/sub-details-1',
-          expect.anything()
+          expect.anything(),
         );
         expect(result.id).toBe('sub-details-1');
       });
@@ -320,13 +345,14 @@ describe('observationToolService', () => {
     describe('listAppointmentSubmissions', () => {
       it('fetches list for appointment', async () => {
         (apiClient.get as jest.Mock).mockResolvedValue({
-          data: [{ id: 's1' }, { id: 's2' }]
+          data: [{id: 's1'}, {id: 's2'}],
         });
 
-        const result = await observationToolApi.listAppointmentSubmissions('appt-123');
+        const result =
+          await observationToolApi.listAppointmentSubmissions('appt-123');
         expect(apiClient.get).toHaveBeenCalledWith(
           '/v1/observation-tools/mobile/appointments/appt-123/submissions',
-          expect.anything()
+          expect.anything(),
         );
         expect(result).toHaveLength(2);
         expect(result[0].evaluationAppointmentId).toBe('appt-123'); // forced by mapper
@@ -336,13 +362,14 @@ describe('observationToolService', () => {
     describe('previewTaskSubmission', () => {
       it('fetches preview of task submission', async () => {
         (apiClient.get as jest.Mock).mockResolvedValue({
-          data: { submissionId: 'sub-preview', answersPreview: { q: 1 } }
+          data: {submissionId: 'sub-preview', answersPreview: {q: 1}},
         });
 
-        const result = await observationToolApi.previewTaskSubmission('task-preview');
+        const result =
+          await observationToolApi.previewTaskSubmission('task-preview');
         expect(apiClient.get).toHaveBeenCalledWith(
           '/v1/observation-tools/mobile/tasks/task-preview/preview',
-          expect.anything()
+          expect.anything(),
         );
         expect(result.id).toBe('sub-preview');
         expect(result.taskId).toBe('task-preview');

--- a/apps/mobileAppYC/__tests__/features/support/services/contactService.test.ts
+++ b/apps/mobileAppYC/__tests__/features/support/services/contactService.test.ts
@@ -3,9 +3,14 @@ import {
   uploadContactAttachments,
   CONTACT_SOURCE,
 } from '../../../../src/features/support/services/contactService';
-import apiClient, {withAuthHeaders} from '../../../../src/shared/services/apiClient';
+import apiClient, {
+  withAuthHeaders,
+} from '../../../../src/shared/services/apiClient';
 import {documentApi} from '../../../../src/features/documents/services/documentService';
-import {ensureAccessContext, toErrorMessage} from '../../../../src/shared/utils/serviceHelpers';
+import {
+  ensureAccessContext,
+  toErrorMessage,
+} from '../../../../src/shared/utils/serviceHelpers';
 
 // --- Mocks ---
 
@@ -38,7 +43,9 @@ describe('contactService', () => {
       accessToken: mockToken,
       userId: mockUserId,
     });
-    (withAuthHeaders as jest.Mock).mockReturnValue({Authorization: 'Bearer token'});
+    (withAuthHeaders as jest.Mock).mockReturnValue({
+      Authorization: 'Bearer token',
+    });
   });
 
   // ===========================================================================
@@ -58,7 +65,9 @@ describe('contactService', () => {
     it('throws error if companionId is missing', async () => {
       await expect(
         uploadContactAttachments({files: [validFile] as any, companionId: ''}),
-      ).rejects.toThrow('Please add a pet profile before uploading attachments.');
+      ).rejects.toThrow(
+        'Please add a pet profile before uploading attachments.',
+      );
     });
 
     it('throws error if a file has an empty/missing URI', async () => {
@@ -116,7 +125,9 @@ describe('contactService', () => {
 
       // Mock response with NO url fields
       const badUploadResponse = {id: 'doc-1', name: 'No URL File'};
-      (documentApi.uploadAttachment as jest.Mock).mockResolvedValue(badUploadResponse);
+      (documentApi.uploadAttachment as jest.Mock).mockResolvedValue(
+        badUploadResponse,
+      );
 
       const result = await uploadContactAttachments({
         files: [file1] as any,
@@ -160,8 +171,8 @@ describe('contactService', () => {
 
       expect(ensureAccessContext).toHaveBeenCalled();
 
-      // Verify headers include User ID
-      expect(withAuthHeaders).toHaveBeenCalledWith(mockToken, {'x-user-id': mockUserId});
+      // Verify auth headers are set
+      expect(withAuthHeaders).toHaveBeenCalledWith(mockToken);
 
       // Verify Payload includes default source
       expect(apiClient.post).toHaveBeenCalledWith(
@@ -189,8 +200,8 @@ describe('contactService', () => {
         source: 'WEB_DASHBOARD',
       });
 
-      // Verify userId arg is undefined
-      expect(withAuthHeaders).toHaveBeenCalledWith(mockToken, undefined);
+      // x-user-id is no longer sent; only the access token is used
+      expect(withAuthHeaders).toHaveBeenCalledWith(mockToken);
 
       // Verify custom source usage
       expect(apiClient.post).toHaveBeenCalledWith(
@@ -205,8 +216,9 @@ describe('contactService', () => {
       (apiClient.post as jest.Mock).mockRejectedValue(error);
       (toErrorMessage as jest.Mock).mockReturnValue('Formatted Error');
 
-      await expect(contactService.submitContact(basePayload))
-        .rejects.toThrow('Formatted Error');
+      await expect(contactService.submitContact(basePayload)).rejects.toThrow(
+        'Formatted Error',
+      );
 
       expect(toErrorMessage).toHaveBeenCalledWith(
         error,

--- a/apps/mobileAppYC/__tests__/features/tasks/services/taskService.test.ts
+++ b/apps/mobileAppYC/__tests__/features/tasks/services/taskService.test.ts
@@ -1,19 +1,24 @@
 import apiClient from '../../../../src/shared/services/apiClient';
-import { getFreshStoredTokens, isTokenExpired } from '../../../../src/features/auth/sessionManager';
-import { resolveObservationToolIdSync } from '../../../../src/features/observationalTools/services/observationToolService';
-import { buildCdnUrlFromKey } from '../../../../src/shared/utils/cdnHelpers';
+import {
+  getFreshStoredTokens,
+  isTokenExpired,
+} from '../../../../src/features/auth/sessionManager';
+import {resolveObservationToolIdSync} from '../../../../src/features/observationalTools/services/observationToolService';
+import {buildCdnUrlFromKey} from '../../../../src/shared/utils/cdnHelpers';
 import {
   taskApi,
   mapApiTaskToTask,
-  buildTaskDraftFromForm
+  buildTaskDraftFromForm,
 } from '../../../../src/features/tasks/services/taskService';
 // We use 'as any' for the mock data to avoid importing every single strict type dependency
-import type { TaskFormData } from '../../../../src/features/tasks/types';
+import type {TaskFormData} from '../../../../src/features/tasks/types';
 
 // --- Mocks ---
 jest.mock('../../../../src/shared/services/apiClient');
 jest.mock('../../../../src/features/auth/sessionManager');
-jest.mock('../../../../src/features/observationalTools/services/observationToolService');
+jest.mock(
+  '../../../../src/features/observationalTools/services/observationToolService',
+);
 jest.mock('../../../../src/shared/utils/cdnHelpers');
 
 describe('taskService', () => {
@@ -30,18 +35,21 @@ describe('taskService', () => {
       expiresAt: Date.now() + 10000,
     });
     (isTokenExpired as jest.Mock).mockReturnValue(false);
-    (resolveObservationToolIdSync as jest.Mock).mockImplementation((id) => id);
-    (buildCdnUrlFromKey as jest.Mock).mockImplementation((key) => key ? `https://cdn.com/${key}` : null);
+    (resolveObservationToolIdSync as jest.Mock).mockImplementation(id => id);
+    (buildCdnUrlFromKey as jest.Mock).mockImplementation(key =>
+      key ? `https://cdn.com/${key}` : null,
+    );
   });
 
   // =========================================================================
   // Section 1: Helper Functions & Auth Logic
   // =========================================================================
   describe('Internal Helpers (via public interface side-effects)', () => {
-
     describe('ensureAccessToken', () => {
       it('throws error if access token is missing', async () => {
-        (getFreshStoredTokens as jest.Mock).mockResolvedValue({ accessToken: null });
+        (getFreshStoredTokens as jest.Mock).mockResolvedValue({
+          accessToken: null,
+        });
         await expect(taskApi.list()).rejects.toThrow('Missing access token');
       });
 
@@ -53,19 +61,19 @@ describe('taskService', () => {
 
     describe('resolveDateParts (implicitly tested via mapApiTaskToTask)', () => {
       it('handles null/undefined dueAt dates by defaulting to today', () => {
-        const result = mapApiTaskToTask({ dueAt: null });
+        const result = mapApiTaskToTask({dueAt: null});
         expect(result.date).toBeDefined(); // Should be today
         expect(result.time).toBeUndefined();
       });
 
       it('handles invalid date strings by defaulting to today', () => {
-        const result = mapApiTaskToTask({ dueAt: 'invalid-date-string' });
+        const result = mapApiTaskToTask({dueAt: 'invalid-date-string'});
         expect(result.date).toBeDefined();
         expect(result.time).toBeUndefined();
       });
 
       it('parses valid ISO date strings', () => {
-        const result = mapApiTaskToTask({ dueAt: '2025-10-20T14:30:00.000Z' });
+        const result = mapApiTaskToTask({dueAt: '2025-10-20T14:30:00.000Z'});
         expect(result.date).toBe('2025-10-20');
         expect(result.time).toBeDefined();
       });
@@ -74,7 +82,7 @@ describe('taskService', () => {
     describe('Attachment Normalization', () => {
       it('normalizes attachment with key', () => {
         const apiData = {
-          attachments: [{ key: 'file.jpg', size: 1024 }]
+          attachments: [{key: 'file.jpg', size: 1024}],
         };
         const task = mapApiTaskToTask(apiData);
         expect(task.attachments[0].id).toBe('file.jpg');
@@ -83,7 +91,7 @@ describe('taskService', () => {
 
       it('normalizes attachment with nested id path', () => {
         const apiData = {
-          attachments: [{ id: 'folder/doc.pdf' }]
+          attachments: [{id: 'folder/doc.pdf'}],
         };
         const task = mapApiTaskToTask(apiData);
         expect(task.attachments[0].key).toBe('folder/doc.pdf');
@@ -93,22 +101,24 @@ describe('taskService', () => {
       it('fallbacks to _id or name if key missing', () => {
         const apiData = {
           attachments: [
-            { _id: '123', fileName: 'test.docx' },
-            { name: 'just-name.png' }
-          ]
+            {_id: '123', fileName: 'test.docx'},
+            {name: 'just-name.png'},
+          ],
         };
         const task = mapApiTaskToTask(apiData);
         expect(task.attachments[0].id).toBe('123');
-        expect(task.attachments[0].type).toBe('application/vnd.openxmlformats-officedocument.wordprocessingml.document');
+        expect(task.attachments[0].type).toBe(
+          'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        );
         expect(task.attachments[1].id).toBe('just-name.png');
       });
 
       it('uses provided viewUrl/downloadUrl or falls back to uri/cdn', () => {
         const apiData = {
           attachments: [
-            { key: 'abc', viewUrl: 'http://view', downloadUrl: 'http://dl' },
-            { uri: 'http://uri' } // no key
-          ]
+            {key: 'abc', viewUrl: 'http://view', downloadUrl: 'http://dl'},
+            {uri: 'http://uri'}, // no key
+          ],
         };
         const task = mapApiTaskToTask(apiData);
         expect(task.attachments[0].viewUrl).toBe('http://view');
@@ -141,25 +151,41 @@ describe('taskService', () => {
     });
 
     it('maps Categories correctly', () => {
-      expect(mapApiTaskToTask({ category: 'HYGIENE' }).category).toBe('hygiene');
-      expect(mapApiTaskToTask({ category: 'DIET' }).category).toBe('dietary');
-      expect(mapApiTaskToTask({ category: 'MEDICATION' }).category).toBe('health');
-      expect(mapApiTaskToTask({ category: 'OBSERVATION_TOOL' }).category).toBe('health');
-      expect(mapApiTaskToTask({ category: 'UNKNOWN' }).category).toBe('custom');
+      expect(mapApiTaskToTask({category: 'HYGIENE'}).category).toBe('hygiene');
+      expect(mapApiTaskToTask({category: 'DIET'}).category).toBe('dietary');
+      expect(mapApiTaskToTask({category: 'MEDICATION'}).category).toBe(
+        'health',
+      );
+      expect(mapApiTaskToTask({category: 'OBSERVATION_TOOL'}).category).toBe(
+        'health',
+      );
+      expect(mapApiTaskToTask({category: 'UNKNOWN'}).category).toBe('custom');
     });
 
     it('maps Recurrence correctly', () => {
-      expect(mapApiTaskToTask({ recurrence: { type: 'DAILY' } }).frequency).toBe('daily');
-      expect(mapApiTaskToTask({ recurrence: { type: 'WEEKLY' } }).frequency).toBe('weekly');
-      expect(mapApiTaskToTask({ recurrence: { type: 'CUSTOM' } }).frequency).toBe('daily');
-      expect(mapApiTaskToTask({ recurrence: null }).frequency).toBe('once');
+      expect(mapApiTaskToTask({recurrence: {type: 'DAILY'}}).frequency).toBe(
+        'daily',
+      );
+      expect(mapApiTaskToTask({recurrence: {type: 'WEEKLY'}}).frequency).toBe(
+        'weekly',
+      );
+      expect(mapApiTaskToTask({recurrence: {type: 'CUSTOM'}}).frequency).toBe(
+        'daily',
+      );
+      expect(mapApiTaskToTask({recurrence: null}).frequency).toBe('once');
     });
 
     it('maps Reminders correctly', () => {
-      expect(mapApiTaskToTask({ reminder: { offsetMinutes: 5 } }).reminderOptions).toBe('5-mins-prior');
-      expect(mapApiTaskToTask({ reminder: { offsetMinutes: 1440 } }).reminderOptions).toBe('1-day-prior');
-      expect(mapApiTaskToTask({ reminder: { offsetMinutes: 999 } }).reminderOptions).toBeNull(); // invalid mapping
-      expect(mapApiTaskToTask({ reminder: null }).reminderOptions).toBeNull();
+      expect(
+        mapApiTaskToTask({reminder: {offsetMinutes: 5}}).reminderOptions,
+      ).toBe('5-mins-prior');
+      expect(
+        mapApiTaskToTask({reminder: {offsetMinutes: 1440}}).reminderOptions,
+      ).toBe('1-day-prior');
+      expect(
+        mapApiTaskToTask({reminder: {offsetMinutes: 999}}).reminderOptions,
+      ).toBeNull(); // invalid mapping
+      expect(mapApiTaskToTask({reminder: null}).reminderOptions).toBeNull();
     });
 
     // --- Complex Logic: Medication ---
@@ -168,7 +194,7 @@ describe('taskService', () => {
         const apiTask = {
           category: 'MEDICATION',
           dueAt: '2025-01-01T10:00:00Z',
-          medication: { name: 'Aspirin', dosage: '1 pill' }
+          medication: {name: 'Aspirin', dosage: '1 pill'},
         };
         const result = mapApiTaskToTask(apiTask);
         expect(result.details.taskType).toBe('give-medication');
@@ -184,10 +210,10 @@ describe('taskService', () => {
           medication: {
             name: 'Meds',
             doses: [
-              { id: 'd1', dosage: '10mg', time: '08:00' },
-              { id: 'd2', label: '20mg', time: '2025-01-01T20:00:00Z' }
-            ]
-          }
+              {id: 'd1', dosage: '10mg', time: '08:00'},
+              {id: 'd2', label: '20mg', time: '2025-01-01T20:00:00Z'},
+            ],
+          },
         };
         const result = mapApiTaskToTask(apiTask);
         expect(result.details.dosages).toHaveLength(2);
@@ -200,7 +226,7 @@ describe('taskService', () => {
         // Valid end date
         const apiTaskValid = {
           category: 'MEDICATION',
-          recurrence: { endDate: '2025-12-31T00:00:00Z' }
+          recurrence: {endDate: '2025-12-31T00:00:00Z'},
         };
         const resValid = mapApiTaskToTask(apiTaskValid);
         expect(resValid.details.endDate).toContain('2025-12-31');
@@ -208,7 +234,7 @@ describe('taskService', () => {
         // Invalid end date
         const apiTaskInvalid = {
           category: 'MEDICATION',
-          recurrence: { endDate: 'invalid-date' }
+          recurrence: {endDate: 'invalid-date'},
         };
         const resInvalid = mapApiTaskToTask(apiTaskInvalid);
         expect(resInvalid.details.endDate).toBeUndefined();
@@ -221,7 +247,7 @@ describe('taskService', () => {
         const apiTask = {
           category: 'OBSERVATION_TOOL',
           observationToolId: 'tool-xyz',
-          chronicConditionType: 'Diabetes'
+          chronicConditionType: 'Diabetes',
         };
         const result = mapApiTaskToTask(apiTask);
         expect(result.details.taskType).toBe('take-observational-tool');
@@ -248,7 +274,7 @@ describe('taskService', () => {
     it('builds basic task payload', () => {
       const payload = buildTaskDraftFromForm({
         formData: baseForm,
-        companionId: 'comp-123'
+        companionId: 'comp-123',
       });
 
       expect(payload.companionId).toBe('comp-123');
@@ -262,17 +288,27 @@ describe('taskService', () => {
       const form = {
         ...baseForm,
         reminderEnabled: true,
-        reminderOptions: '30-mins-prior'
+        reminderOptions: '30-mins-prior',
       } as unknown as TaskFormData;
 
-      const payload = buildTaskDraftFromForm({ formData: form, companionId: 'c1' });
+      const payload = buildTaskDraftFromForm({
+        formData: form,
+        companionId: 'c1',
+      });
       expect(payload.reminder?.enabled).toBe(true);
       expect(payload.reminder?.offsetMinutes).toBe(30);
     });
 
     it('defaults reminder to 30 mins if enabled but option is invalid/missing', () => {
-      const form = { ...baseForm, reminderEnabled: true, reminderOptions: undefined } as unknown as TaskFormData;
-      const payload = buildTaskDraftFromForm({ formData: form, companionId: 'c1' });
+      const form = {
+        ...baseForm,
+        reminderEnabled: true,
+        reminderOptions: undefined,
+      } as unknown as TaskFormData;
+      const payload = buildTaskDraftFromForm({
+        formData: form,
+        companionId: 'c1',
+      });
       expect(payload.reminder?.offsetMinutes).toBe(30);
     });
 
@@ -283,10 +319,13 @@ describe('taskService', () => {
         medicineName: 'Advil',
         medicineType: 'Pill' as any, // Cast specific enum/string if needed
         medicationFrequency: 'daily',
-        dosages: [{ id: 'dose-1', label: '10mg', time: '09:00' }] // Added ID to satisfy DosagesSchedule
+        dosages: [{id: 'dose-1', label: '10mg', time: '09:00'}], // Added ID to satisfy DosagesSchedule
       } as unknown as TaskFormData;
 
-      const payload = buildTaskDraftFromForm({ formData: form, companionId: 'c1' });
+      const payload = buildTaskDraftFromForm({
+        formData: form,
+        companionId: 'c1',
+      });
 
       expect(payload.category).toBe('MEDICATION');
       expect(payload.medication?.name).toBe('Advil');
@@ -301,13 +340,13 @@ describe('taskService', () => {
       const form = {
         ...baseForm,
         healthTaskType: 'take-observational-tool',
-        observationalTool: 'tool-id-1'
+        observationalTool: 'tool-id-1',
       } as unknown as TaskFormData;
 
       const payload = buildTaskDraftFromForm({
         formData: form,
         companionId: 'c1',
-        observationToolId: 'tool-id-1' // Pass explicitly or via form
+        observationToolId: 'tool-id-1', // Pass explicitly or via form
       });
 
       expect(payload.category).toBe('OBSERVATION_TOOL');
@@ -317,8 +356,8 @@ describe('taskService', () => {
     it('maps Recurrence Frequencies', () => {
       const checkFreq = (freq: any, expected: string) => {
         const p = buildTaskDraftFromForm({
-          formData: { ...baseForm, frequency: freq } as unknown as TaskFormData,
-          companionId: 'c1'
+          formData: {...baseForm, frequency: freq} as unknown as TaskFormData,
+          companionId: 'c1',
         });
         expect(p.recurrence?.type).toBe(expected);
       };
@@ -332,10 +371,13 @@ describe('taskService', () => {
     it('handles attachments in form data', () => {
       const form = {
         ...baseForm,
-        attachments: [{ uri: 'file://img.jpg', name: 'img.jpg' }]
+        attachments: [{uri: 'file://img.jpg', name: 'img.jpg'}],
       } as unknown as TaskFormData;
 
-      const payload = buildTaskDraftFromForm({ formData: form, companionId: 'c1' });
+      const payload = buildTaskDraftFromForm({
+        formData: form,
+        companionId: 'c1',
+      });
       expect(payload.attachments).toHaveLength(1);
       expect(payload.attachments?.[0].name).toBe('img.jpg');
     });
@@ -346,70 +388,90 @@ describe('taskService', () => {
   // =========================================================================
   describe('taskApi', () => {
     it('list() fetches tasks with correct params', async () => {
-      const mockResponse = { data: [{ _id: '1' }, { _id: '2' }] };
+      const mockResponse = {data: [{_id: '1'}, {_id: '2'}]};
       (apiClient.get as jest.Mock).mockResolvedValue(mockResponse);
 
-      const res = await taskApi.list({ companionId: 'c1', status: ['PENDING'] });
+      const res = await taskApi.list({companionId: 'c1', status: ['PENDING']});
 
-      expect(apiClient.get).toHaveBeenCalledWith('/v1/task/mobile/task', expect.objectContaining({
-        params: { companionId: 'c1', status: 'PENDING' },
-        headers: expect.objectContaining({ 'x-user-id': mockUserId })
-      }));
+      expect(apiClient.get).toHaveBeenCalledWith(
+        '/v1/task/mobile/task',
+        expect.objectContaining({
+          params: {companionId: 'c1', status: 'PENDING'},
+          headers: expect.not.objectContaining({
+            'x-user-id': expect.anything(),
+          }),
+        }),
+      );
       expect(res).toHaveLength(2);
     });
 
     it('list() handles empty response safely', async () => {
-      (apiClient.get as jest.Mock).mockResolvedValue({ data: null }); // Non-array response
+      (apiClient.get as jest.Mock).mockResolvedValue({data: null}); // Non-array response
       const res = await taskApi.list();
       expect(res).toEqual([]);
     });
 
     it('get() fetches single task', async () => {
-      (apiClient.get as jest.Mock).mockResolvedValue({ data: { _id: 't1' } });
+      (apiClient.get as jest.Mock).mockResolvedValue({data: {_id: 't1'}});
       const res = await taskApi.get('t1');
-      expect(apiClient.get).toHaveBeenCalledWith(expect.stringContaining('/t1'), expect.anything());
+      expect(apiClient.get).toHaveBeenCalledWith(
+        expect.stringContaining('/t1'),
+        expect.anything(),
+      );
       expect(res.id).toBe('t1');
     });
 
     it('create() posts new task', async () => {
-      const payload: any = { name: 'New' };
-      (apiClient.post as jest.Mock).mockResolvedValue({ data: { _id: 'new-1' } });
+      const payload: any = {name: 'New'};
+      (apiClient.post as jest.Mock).mockResolvedValue({data: {_id: 'new-1'}});
       const res = await taskApi.create(payload);
-      expect(apiClient.post).toHaveBeenCalledWith('/v1/task/mobile/', payload, expect.anything());
+      expect(apiClient.post).toHaveBeenCalledWith(
+        '/v1/task/mobile/',
+        payload,
+        expect.anything(),
+      );
       expect(res.id).toBe('new-1');
     });
 
     it('update() patches existing task', async () => {
-      (apiClient.patch as jest.Mock).mockResolvedValue({ data: { _id: 'u1' } });
-      const res = await taskApi.update('u1', { name: 'Updated' });
-      expect(apiClient.patch).toHaveBeenCalledWith(expect.stringContaining('/u1'), { name: 'Updated' }, expect.anything());
+      (apiClient.patch as jest.Mock).mockResolvedValue({data: {_id: 'u1'}});
+      const res = await taskApi.update('u1', {name: 'Updated'});
+      expect(apiClient.patch).toHaveBeenCalledWith(
+        expect.stringContaining('/u1'),
+        {name: 'Updated'},
+        expect.anything(),
+      );
       expect(res.id).toBe('u1');
     });
 
     it('changeStatus() posts status change with completion', async () => {
-      (apiClient.post as jest.Mock).mockResolvedValue({ data: { task: { _id: 's1', status: 'COMPLETED' } } });
-      const completionData = { note: 'Done' };
+      (apiClient.post as jest.Mock).mockResolvedValue({
+        data: {task: {_id: 's1', status: 'COMPLETED'}},
+      });
+      const completionData = {note: 'Done'};
 
       const res = await taskApi.changeStatus('s1', 'COMPLETED', completionData);
 
       expect(apiClient.post).toHaveBeenCalledWith(
         expect.stringContaining('/s1/status'),
-        { status: 'COMPLETED', completion: completionData },
-        expect.anything()
+        {status: 'COMPLETED', completion: completionData},
+        expect.anything(),
       );
       expect(res.status).toBe('COMPLETED');
     });
 
     it('changeStatus() handles simple status change without completion object', async () => {
       // Sometimes backend might return the task directly instead of { task: ... }
-      (apiClient.post as jest.Mock).mockResolvedValue({ data: { _id: 's1', status: 'IN_PROGRESS' } });
+      (apiClient.post as jest.Mock).mockResolvedValue({
+        data: {_id: 's1', status: 'IN_PROGRESS'},
+      });
 
       const res = await taskApi.changeStatus('s1', 'IN_PROGRESS');
 
       expect(apiClient.post).toHaveBeenCalledWith(
         expect.stringContaining('/s1/status'),
-        { status: 'IN_PROGRESS' },
-        expect.anything()
+        {status: 'IN_PROGRESS'},
+        expect.anything(),
       );
       expect(res.status).toBe('IN_PROGRESS');
     });

--- a/apps/mobileAppYC/src/config/variables.ts
+++ b/apps/mobileAppYC/src/config/variables.ts
@@ -189,7 +189,7 @@ const DEFAULT_STRIPE_CONFIG: StripeConfig = {
 };
 
 const DEFAULT_AUTH_FEATURE_FLAGS: AuthFeatureFlags = {
-  enableReviewLogin: true,
+  enableReviewLogin: false,
 };
 
 const DEFAULT_DEMO_LOGIN_CONFIG: DemoLoginConfig = {
@@ -328,3 +328,4 @@ export const POSTHOG_CONFIG: PostHogConfig = {
 
 export const PENDING_PROFILE_STORAGE_KEY = '@pending_profile_payload';
 export const PENDING_PROFILE_UPDATED_EVENT = 'pendingProfileUpdated';
+export const DEV_API_MODE_CHANGED_EVENT = 'devApiModeChanged';

--- a/apps/mobileAppYC/src/features/auth/screens/OTPVerificationScreen.tsx
+++ b/apps/mobileAppYC/src/features/auth/screens/OTPVerificationScreen.tsx
@@ -33,9 +33,14 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
   PENDING_PROFILE_STORAGE_KEY,
   PENDING_PROFILE_UPDATED_EVENT,
+  DEV_API_MODE_CHANGED_EVENT,
   AUTH_FEATURE_FLAGS,
+  API_CONFIG,
+  DEVELOPMENT_API_BASE_URL,
 } from '@/config/variables';
 import {storeTokens} from '@/features/auth/services/tokenStorage';
+import {updateApiClientBaseConfig} from '@/shared/services/apiClient';
+import {DEMO_API_MODE_KEY} from '@/features/auth/sessionManager';
 
 const DEFAULT_OTP_LENGTH = 4;
 const RESEND_SECONDS = 60;
@@ -212,6 +217,14 @@ export const OTPVerificationScreen: React.FC<OTPVerificationScreenProps> = ({
 
     setIsVerifying(true);
     try {
+      if (isDemoLogin) {
+        API_CONFIG.baseUrl = DEVELOPMENT_API_BASE_URL;
+        API_CONFIG.pmsBaseUrl = DEVELOPMENT_API_BASE_URL;
+        updateApiClientBaseConfig({baseUrl: DEVELOPMENT_API_BASE_URL});
+        await AsyncStorage.setItem(DEMO_API_MODE_KEY, 'true');
+        DeviceEventEmitter.emit(DEV_API_MODE_CHANGED_EVENT, {isDevApi: true});
+        console.log('[API] Switched to dev API for demo login');
+      }
       const completion = await completePasswordlessSignIn(code.trim());
       const shouldIgnoreCompletion = cancellationRef.current;
       if (shouldIgnoreCompletion) {
@@ -414,8 +427,7 @@ export const OTPVerificationScreen: React.FC<OTPVerificationScreenProps> = ({
 
             {isDemoLogin ? (
               <Text style={styles.resendText}>
-                Need credentials? Use {DEMO_LOGIN_PASSWORD} with the review
-                email you entered.
+                Use the credentials provided by the team.
               </Text>
             ) : (
               <View style={styles.resendContainer}>

--- a/apps/mobileAppYC/src/features/auth/screens/OTPVerificationScreen.tsx
+++ b/apps/mobileAppYC/src/features/auth/screens/OTPVerificationScreen.tsx
@@ -37,6 +37,7 @@ import {
   AUTH_FEATURE_FLAGS,
   API_CONFIG,
   DEVELOPMENT_API_BASE_URL,
+  PRODUCTION_API_BASE_URL,
 } from '@/config/variables';
 import {storeTokens} from '@/features/auth/services/tokenStorage';
 import {updateApiClientBaseConfig} from '@/shared/services/apiClient';
@@ -221,14 +222,15 @@ export const OTPVerificationScreen: React.FC<OTPVerificationScreenProps> = ({
         API_CONFIG.baseUrl = DEVELOPMENT_API_BASE_URL;
         API_CONFIG.pmsBaseUrl = DEVELOPMENT_API_BASE_URL;
         updateApiClientBaseConfig({baseUrl: DEVELOPMENT_API_BASE_URL});
-        await AsyncStorage.setItem(DEMO_API_MODE_KEY, 'true');
-        DeviceEventEmitter.emit(DEV_API_MODE_CHANGED_EVENT, {isDevApi: true});
-        console.log('[API] Switched to dev API for demo login');
       }
       const completion = await completePasswordlessSignIn(code.trim());
       const shouldIgnoreCompletion = cancellationRef.current;
       if (shouldIgnoreCompletion) {
         return;
+      }
+      if (isDemoLogin) {
+        await AsyncStorage.setItem(DEMO_API_MODE_KEY, 'true');
+        DeviceEventEmitter.emit(DEV_API_MODE_CHANGED_EVENT, {isDevApi: true});
       }
       setOtpError('');
       const userPayload = buildUserPayload(completion);
@@ -240,6 +242,11 @@ export const OTPVerificationScreen: React.FC<OTPVerificationScreenProps> = ({
         await handleNewAccount(completion, userPayload, tokens);
       }
     } catch (error) {
+      if (isDemoLogin) {
+        API_CONFIG.baseUrl = PRODUCTION_API_BASE_URL;
+        API_CONFIG.pmsBaseUrl = PRODUCTION_API_BASE_URL;
+        updateApiClientBaseConfig({baseUrl: PRODUCTION_API_BASE_URL});
+      }
       const formatted = formatAuthError(error);
       setOtpError(
         formatted === 'Unexpected authentication error. Please retry.'

--- a/apps/mobileAppYC/src/features/auth/screens/OTPVerificationScreen.tsx
+++ b/apps/mobileAppYC/src/features/auth/screens/OTPVerificationScreen.tsx
@@ -37,6 +37,7 @@ import {
   AUTH_FEATURE_FLAGS,
   API_CONFIG,
   DEVELOPMENT_API_BASE_URL,
+  MOBILE_CONFIG_BEHAVIOR,
   PRODUCTION_API_BASE_URL,
 } from '@/config/variables';
 import {storeTokens} from '@/features/auth/services/tokenStorage';
@@ -45,6 +46,11 @@ import {DEMO_API_MODE_KEY} from '@/features/auth/sessionManager';
 
 const DEFAULT_OTP_LENGTH = 4;
 const RESEND_SECONDS = 60;
+
+const resolveOtpError = (formatted: string): string =>
+  formatted === 'Unexpected authentication error. Please retry.'
+    ? 'The code you entered is incorrect. Please try again.'
+    : formatted;
 
 type OTPVerificationScreenProps = NativeStackScreenProps<
   AuthStackParamList,
@@ -243,16 +249,18 @@ export const OTPVerificationScreen: React.FC<OTPVerificationScreenProps> = ({
       }
     } catch (error) {
       if (isDemoLogin) {
-        API_CONFIG.baseUrl = PRODUCTION_API_BASE_URL;
-        API_CONFIG.pmsBaseUrl = PRODUCTION_API_BASE_URL;
-        updateApiClientBaseConfig({baseUrl: PRODUCTION_API_BASE_URL});
+        const defaultBaseUrl =
+          MOBILE_CONFIG_BEHAVIOR.overrides?.apiBaseUrl ??
+          (MOBILE_CONFIG_BEHAVIOR.useDevApi
+            ? DEVELOPMENT_API_BASE_URL
+            : PRODUCTION_API_BASE_URL);
+        const defaultPmsUrl =
+          MOBILE_CONFIG_BEHAVIOR.overrides?.pmsBaseUrl ?? defaultBaseUrl;
+        API_CONFIG.baseUrl = defaultBaseUrl;
+        API_CONFIG.pmsBaseUrl = defaultPmsUrl;
+        updateApiClientBaseConfig({baseUrl: defaultBaseUrl});
       }
-      const formatted = formatAuthError(error);
-      setOtpError(
-        formatted === 'Unexpected authentication error. Please retry.'
-          ? 'The code you entered is incorrect. Please try again.'
-          : formatted,
-      );
+      setOtpError(resolveOtpError(formatAuthError(error)));
     } finally {
       if (!cancellationRef.current) {
         setIsVerifying(false);

--- a/apps/mobileAppYC/src/features/auth/screens/SignInScreen.tsx
+++ b/apps/mobileAppYC/src/features/auth/screens/SignInScreen.tsx
@@ -164,9 +164,7 @@ const useOTPHandler = (
     const isDemoLogin =
       allowReviewLogin && normalizedEmail.toLowerCase() === DEMO_LOGIN_EMAIL;
     try {
-      if (isDemoLogin) {
-        Amplify.configure(devOutputs);
-      }
+      Amplify.configure(isDemoLogin ? devOutputs : prodOutputs);
       const result = await requestPasswordlessEmailCode(normalizedEmail);
 
       const message = isDemoLogin

--- a/apps/mobileAppYC/src/features/auth/screens/SignInScreen.tsx
+++ b/apps/mobileAppYC/src/features/auth/screens/SignInScreen.tsx
@@ -21,6 +21,8 @@ import {
   DEMO_LOGIN_EMAIL,
 } from '@/features/auth/services/passwordlessAuth';
 import {AUTH_FEATURE_FLAGS} from '@/config/variables';
+import {Amplify} from 'aws-amplify';
+import devOutputs from '../../../../devamplify_outputs.json';
 import type {NativeStackScreenProps} from '@react-navigation/native-stack';
 import type {AuthStackParamList} from '@/navigation/AuthNavigator';
 import {useAuth} from '@/features/auth/context/AuthContext';
@@ -34,17 +36,28 @@ const socialIconStyles = StyleSheet.create({
 });
 
 const GoogleIcon = () => (
-  <Image source={Images.googleIcon} style={socialIconStyles.icon} resizeMode="contain" />
+  <Image
+    source={Images.googleIcon}
+    style={socialIconStyles.icon}
+    resizeMode="contain"
+  />
 );
 
 const FacebookIcon = () => (
-  <Image source={Images.facebookIcon} style={socialIconStyles.icon} resizeMode="contain" />
+  <Image
+    source={Images.facebookIcon}
+    style={socialIconStyles.icon}
+    resizeMode="contain"
+  />
 );
 
 const AppleIcon = () => (
-  <Image source={Images.appleIcon} style={socialIconStyles.icon} resizeMode="contain" />
+  <Image
+    source={Images.appleIcon}
+    style={socialIconStyles.icon}
+    resizeMode="contain"
+  />
 );
-
 
 type SignInScreenProps = NativeStackScreenProps<AuthStackParamList, 'SignIn'>;
 
@@ -52,8 +65,10 @@ const useKeyboardVisibility = () => {
   const [isKeyboardVisible, setIsKeyboardVisible] = useState(false);
 
   useEffect(() => {
-    const showEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
-    const hideEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
+    const showEvent =
+      Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
+    const hideEvent =
+      Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
     const showSubscription = Keyboard.addListener(showEvent, () => {
       setIsKeyboardVisible(true);
     });
@@ -83,7 +98,8 @@ const useRouteParamsRestore = (
     : false;
 
   useEffect(() => {
-    const shouldSkipRestore = routeEmail == null && hasStatusMessageParam === false;
+    const shouldSkipRestore =
+      routeEmail == null && hasStatusMessageParam === false;
     if (shouldSkipRestore) {
       return;
     }
@@ -102,8 +118,15 @@ const useRouteParamsRestore = (
       setStatusMessage(routeStatusMessage ?? '');
     }
 
-    navigation.setParams({ email: undefined, statusMessage: undefined });
-  }, [hasStatusMessageParam, navigation, routeEmail, routeStatusMessage, setEmailValue, setStatusMessage]);
+    navigation.setParams({email: undefined, statusMessage: undefined});
+  }, [
+    hasStatusMessageParam,
+    navigation,
+    routeEmail,
+    routeStatusMessage,
+    setEmailValue,
+    setStatusMessage,
+  ]);
 };
 
 const useOTPHandler = (
@@ -114,15 +137,18 @@ const useOTPHandler = (
   setIsSubmitting: (submitting: boolean) => void,
   navigation: SignInScreenProps['navigation'],
 ) => {
-  const validateEmailInput = React.useCallback((email: string): string | null => {
-    if (email.trim().length === 0) {
-      return 'Please enter your email address';
-    }
-    if (!isValidEmail(email.trim())) {
-      return 'Please enter a valid email address';
-    }
-    return null;
-  }, []);
+  const validateEmailInput = React.useCallback(
+    (email: string): string | null => {
+      if (email.trim().length === 0) {
+        return 'Please enter your email address';
+      }
+      if (!isValidEmail(email.trim())) {
+        return 'Please enter a valid email address';
+      }
+      return null;
+    },
+    [],
+  );
 
   const handleSendOTP = React.useCallback(async () => {
     const validationError = validateEmailInput(emailValue);
@@ -136,10 +162,15 @@ const useOTPHandler = (
     try {
       const normalizedEmail = emailValue.trim();
       const lowerCasedEmail = normalizedEmail.toLowerCase();
-      const isDemoLogin = allowReviewLogin && lowerCasedEmail === DEMO_LOGIN_EMAIL;
-      console.log('[Auth] Sending OTP request', { normalizedEmail });
+      const isDemoLogin =
+        allowReviewLogin && lowerCasedEmail === DEMO_LOGIN_EMAIL;
+      if (isDemoLogin) {
+        Amplify.configure(devOutputs);
+        console.log(
+          '[Auth] Demo login — reconfigured Amplify to dev Cognito pool',
+        );
+      }
       const result = await requestPasswordlessEmailCode(normalizedEmail);
-      console.log('[Auth] OTP request succeeded', result);
 
       const message = isDemoLogin
         ? 'App Review login: use the provided password to continue. No email is sent.'
@@ -158,9 +189,17 @@ const useOTPHandler = (
     } finally {
       setIsSubmitting(false);
     }
-  }, [emailValue, allowReviewLogin, navigation, validateEmailInput, setEmailError, setStatusMessage, setIsSubmitting]);
+  }, [
+    emailValue,
+    allowReviewLogin,
+    navigation,
+    validateEmailInput,
+    setEmailError,
+    setStatusMessage,
+    setIsSubmitting,
+  ]);
 
-  return { handleSendOTP };
+  return {handleSendOTP};
 };
 
 const getKeyboardVisibleIllustrationHeight = (screenHeight: number) => {
@@ -171,7 +210,10 @@ const getKeyboardHiddenIllustrationHeight = (screenHeight: number) => {
   return Math.min(screenHeight * 0.32, 260);
 };
 
-const useIllustrationHeight = (isKeyboardVisible: boolean, screenHeight: number) => {
+const useIllustrationHeight = (
+  isKeyboardVisible: boolean,
+  screenHeight: number,
+) => {
   return React.useMemo(() => {
     return isKeyboardVisible
       ? getKeyboardVisibleIllustrationHeight(screenHeight)
@@ -183,12 +225,16 @@ const getSocialButtonTintColor = (theme: any, color: string) => {
   return Platform.OS === 'ios' ? color : undefined;
 };
 
-const getSocialButtonStyle = (styles: any, theme: any, backgroundColor: string) => {
+const getSocialButtonStyle = (
+  styles: any,
+  theme: any,
+  backgroundColor: string,
+) => {
   const baseStyle = styles.socialButton;
   if (Platform.OS === 'ios') {
     return baseStyle;
   }
-  return { ...baseStyle, backgroundColor };
+  return {...baseStyle, backgroundColor};
 };
 
 const SocialAuthSection: React.FC<{
@@ -260,7 +306,10 @@ const SocialAuthSection: React.FC<{
   </View>
 );
 
-export const SignInScreen: React.FC<SignInScreenProps> = ({navigation, route}) => {
+export const SignInScreen: React.FC<SignInScreenProps> = ({
+  navigation,
+  route,
+}) => {
   const {theme} = useTheme();
   const styles = createStyles(theme);
   const {login} = useAuth();
@@ -273,7 +322,10 @@ export const SignInScreen: React.FC<SignInScreenProps> = ({navigation, route}) =
   const [socialError, setSocialError] = useState('');
   const isKeyboardVisible = useKeyboardVisibility();
   const {height: screenHeight} = useWindowDimensions();
-  const illustrationHeight = useIllustrationHeight(isKeyboardVisible, screenHeight);
+  const illustrationHeight = useIllustrationHeight(
+    isKeyboardVisible,
+    screenHeight,
+  );
 
   const clearAllErrors = React.useCallback(() => {
     setEmailError('');
@@ -281,21 +333,25 @@ export const SignInScreen: React.FC<SignInScreenProps> = ({navigation, route}) =
     setSocialError('');
   }, []);
 
-  const socialAuthConfig = React.useMemo(() => ({
-    onStart: clearAllErrors,
-    onExistingProfile: async (result: any) => {
-      await login(result.user, result.tokens);
-    },
-    onNewProfile: async (createAccountPayload: any) => {
-      navigation.reset({
-        index: 0,
-        routes: [{name: 'CreateAccount', params: createAccountPayload}],
-      });
-    },
-    genericErrorMessage: "We couldn't sign you in. Kindly retry.",
-  }), [clearAllErrors, login, navigation]);
+  const socialAuthConfig = React.useMemo(
+    () => ({
+      onStart: clearAllErrors,
+      onExistingProfile: async (result: any) => {
+        await login(result.user, result.tokens);
+      },
+      onNewProfile: async (createAccountPayload: any) => {
+        navigation.reset({
+          index: 0,
+          routes: [{name: 'CreateAccount', params: createAccountPayload}],
+        });
+      },
+      genericErrorMessage: "We couldn't sign you in. Kindly retry.",
+    }),
+    [clearAllErrors, login, navigation],
+  );
 
-  const {activeProvider, isSocialLoading, handleSocialAuth} = useSocialAuth(socialAuthConfig);
+  const {activeProvider, isSocialLoading, handleSocialAuth} =
+    useSocialAuth(socialAuthConfig);
 
   useRouteParamsRestore(route, navigation, setEmailValue, setStatusMessage);
 
@@ -308,29 +364,45 @@ export const SignInScreen: React.FC<SignInScreenProps> = ({navigation, route}) =
     navigation,
   );
 
-  const attemptSocialAuth = React.useCallback(async (provider: SocialProvider) => {
-    try {
-      await handleSocialAuth(provider);
-    } catch (error) {
-      const message = error instanceof Error
-        ? error.message
-        : "We couldn't sign you in. Kindly retry.";
-      setSocialError(message);
-    }
-  }, [handleSocialAuth]);
+  const attemptSocialAuth = React.useCallback(
+    async (provider: SocialProvider) => {
+      try {
+        await handleSocialAuth(provider);
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : "We couldn't sign you in. Kindly retry.";
+        setSocialError(message);
+      }
+    },
+    [handleSocialAuth],
+  );
 
   const navigateToSignUp = React.useCallback(() => {
     navigation.navigate('SignUp');
   }, [navigation]);
 
-  const handleEmailChange = React.useCallback((text: string) => {
-    setEmailValue(text);
-    clearAllErrors();
-  }, [clearAllErrors]);
+  const handleEmailChange = React.useCallback(
+    (text: string) => {
+      setEmailValue(text);
+      clearAllErrors();
+    },
+    [clearAllErrors],
+  );
 
-  const handleGoogleSignIn = React.useCallback(() => attemptSocialAuth('google'), [attemptSocialAuth]);
-  const handleFacebookSignIn = React.useCallback(() => attemptSocialAuth('facebook'), [attemptSocialAuth]);
-  const handleAppleSignIn = React.useCallback(() => attemptSocialAuth('apple'), [attemptSocialAuth]);
+  const handleGoogleSignIn = React.useCallback(
+    () => attemptSocialAuth('google'),
+    [attemptSocialAuth],
+  );
+  const handleFacebookSignIn = React.useCallback(
+    () => attemptSocialAuth('facebook'),
+    [attemptSocialAuth],
+  );
+  const handleAppleSignIn = React.useCallback(
+    () => attemptSocialAuth('apple'),
+    [attemptSocialAuth],
+  );
 
   return (
     <SafeArea style={styles.container}>
@@ -348,42 +420,42 @@ export const SignInScreen: React.FC<SignInScreenProps> = ({navigation, route}) =
             isKeyboardVisible && styles.scrollContentKeyboard,
           ]}>
           <View style={styles.content}>
-          <Image
-            source={Images.authIllustration}
-            style={[styles.illustration, {height: illustrationHeight}]}
-            resizeMode="contain"
-          />
-
-          <Text style={styles.title}>Tail-wagging welcome!</Text>
-
-          <View style={styles.formContainer}>
-            <View style={styles.inputContainer}>
-              <Input
-                label="Email address"
-                value={emailValue}
-                onChangeText={handleEmailChange}
-                keyboardType="email-address"
-                autoCapitalize="none"
-                inputStyle={styles.input}
-                error={emailError}
-              />
-            </View>
-
-            <LiquidGlassButton
-              title="Send OTP"
-              onPress={handleSendOTP}
-              style={styles.sendButton}
-              textStyle={styles.sendButtonText}
-              loading={isSubmitting}
-              disabled={isSubmitting}
-              tintColor={theme.colors.secondary}
-              height={56}
-              borderRadius="lg"
+            <Image
+              source={Images.authIllustration}
+              style={[styles.illustration, {height: illustrationHeight}]}
+              resizeMode="contain"
             />
 
-            {statusMessage ? (
-              <Text style={styles.statusMessage}>{statusMessage}</Text>
-            ) : null}
+            <Text style={styles.title}>Tail-wagging welcome!</Text>
+
+            <View style={styles.formContainer}>
+              <View style={styles.inputContainer}>
+                <Input
+                  label="Email address"
+                  value={emailValue}
+                  onChangeText={handleEmailChange}
+                  keyboardType="email-address"
+                  autoCapitalize="none"
+                  inputStyle={styles.input}
+                  error={emailError}
+                />
+              </View>
+
+              <LiquidGlassButton
+                title="Send OTP"
+                onPress={handleSendOTP}
+                style={styles.sendButton}
+                textStyle={styles.sendButtonText}
+                loading={isSubmitting}
+                disabled={isSubmitting}
+                tintColor={theme.colors.secondary}
+                height={56}
+                borderRadius="lg"
+              />
+
+              {statusMessage ? (
+                <Text style={styles.statusMessage}>{statusMessage}</Text>
+              ) : null}
 
               <View style={styles.footerContainer}>
                 <Text style={styles.footerText}>Not a member? </Text>

--- a/apps/mobileAppYC/src/features/auth/screens/SignInScreen.tsx
+++ b/apps/mobileAppYC/src/features/auth/screens/SignInScreen.tsx
@@ -23,6 +23,7 @@ import {
 import {AUTH_FEATURE_FLAGS} from '@/config/variables';
 import {Amplify} from 'aws-amplify';
 import devOutputs from '../../../../devamplify_outputs.json';
+import prodOutputs from '../../../../prodamplify_outputs.json';
 import type {NativeStackScreenProps} from '@react-navigation/native-stack';
 import type {AuthStackParamList} from '@/navigation/AuthNavigator';
 import {useAuth} from '@/features/auth/context/AuthContext';
@@ -159,16 +160,12 @@ const useOTPHandler = (
 
     setEmailError('');
     setIsSubmitting(true);
+    const normalizedEmail = emailValue.trim();
+    const isDemoLogin =
+      allowReviewLogin && normalizedEmail.toLowerCase() === DEMO_LOGIN_EMAIL;
     try {
-      const normalizedEmail = emailValue.trim();
-      const lowerCasedEmail = normalizedEmail.toLowerCase();
-      const isDemoLogin =
-        allowReviewLogin && lowerCasedEmail === DEMO_LOGIN_EMAIL;
       if (isDemoLogin) {
         Amplify.configure(devOutputs);
-        console.log(
-          '[Auth] Demo login — reconfigured Amplify to dev Cognito pool',
-        );
       }
       const result = await requestPasswordlessEmailCode(normalizedEmail);
 
@@ -184,6 +181,9 @@ const useOTPHandler = (
         challengeLength: isDemoLogin ? result.challengeLength : undefined,
       });
     } catch (error) {
+      if (isDemoLogin) {
+        Amplify.configure(prodOutputs);
+      }
       console.error('[Auth] Failed requesting passwordless code', error);
       setEmailError(formatAuthError(error));
     } finally {

--- a/apps/mobileAppYC/src/features/auth/sessionManager.ts
+++ b/apps/mobileAppYC/src/features/auth/sessionManager.ts
@@ -8,23 +8,34 @@ import {
   signOut as firebaseSignOut,
 } from '@react-native-firebase/auth';
 import {syncAuthUser} from '@/features/auth/services/authUserService';
-import {fetchAuthSession, fetchUserAttributes, getCurrentUser} from 'aws-amplify/auth';
+import {
+  fetchAuthSession,
+  fetchUserAttributes,
+  getCurrentUser,
+} from 'aws-amplify/auth';
 import {Buffer} from 'node:buffer';
 
-import {PENDING_PROFILE_STORAGE_KEY, PENDING_PROFILE_UPDATED_EVENT} from '@/config/variables';
+import {
+  PENDING_PROFILE_STORAGE_KEY,
+  PENDING_PROFILE_UPDATED_EVENT,
+} from '@/config/variables';
 import {
   clearStoredTokens,
   loadStoredTokens,
   storeTokens,
   type StoredAuthTokens,
 } from '@/features/auth/services/tokenStorage';
-import {fetchProfileStatus, type ParentProfileSummary} from '@/features/account/services/profileService';
+import {
+  fetchProfileStatus,
+  type ParentProfileSummary,
+} from '@/features/account/services/profileService';
 import {mergeUserWithParentProfile} from '@/features/auth/utils/parentProfileMapper';
 
 import type {AuthProvider, NormalizedAuthTokens, User} from './types';
 
 const LEGACY_AUTH_TOKEN_KEY = '@auth_tokens';
 const USER_KEY = '@user_data';
+export const DEMO_API_MODE_KEY = '@demo_api_mode';
 
 export const REFRESH_BUFFER_MS = 2 * 60 * 1000; // 2 minutes
 const DEFAULT_REFRESH_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours fallback
@@ -65,7 +76,10 @@ export const resolveExpiration = (tokens: {
     return tokens.expiresAt;
   }
 
-  return decodeJwtExpiration(tokens.idToken) ?? decodeJwtExpiration(tokens.accessToken);
+  return (
+    decodeJwtExpiration(tokens.idToken) ??
+    decodeJwtExpiration(tokens.accessToken)
+  );
 };
 
 export const isTokenExpired = (
@@ -160,7 +174,10 @@ export const persistSessionData = async (
         }),
       );
     } catch (fallbackError) {
-      console.error('Failed to persist auth tokens to legacy storage', fallbackError);
+      console.error(
+        'Failed to persist auth tokens to legacy storage',
+        fallbackError,
+      );
     }
   }
 
@@ -174,7 +191,7 @@ export const persistUserData = async (user: User) => {
 export const clearSessionData = async ({
   clearPendingProfile = false,
 }: {clearPendingProfile?: boolean} = {}) => {
-  const keys = [USER_KEY, LEGACY_AUTH_TOKEN_KEY];
+  const keys = [USER_KEY, LEGACY_AUTH_TOKEN_KEY, DEMO_API_MODE_KEY];
 
   if (clearPendingProfile) {
     keys.push(PENDING_PROFILE_STORAGE_KEY);
@@ -191,8 +208,12 @@ export const clearSessionData = async ({
 
 type MaybePendingProfile = 'none' | 'pending';
 
-const checkPendingProfile = async (userId: string): Promise<MaybePendingProfile> => {
-  const pendingProfileRaw = await AsyncStorage.getItem(PENDING_PROFILE_STORAGE_KEY);
+const checkPendingProfile = async (
+  userId: string,
+): Promise<MaybePendingProfile> => {
+  const pendingProfileRaw = await AsyncStorage.getItem(
+    PENDING_PROFILE_STORAGE_KEY,
+  );
   if (!pendingProfileRaw) {
     return 'none';
   }
@@ -219,7 +240,9 @@ const clearPendingProfileForUser = async (userId: string) => {
   }
 
   try {
-    const pendingProfileRaw = await AsyncStorage.getItem(PENDING_PROFILE_STORAGE_KEY);
+    const pendingProfileRaw = await AsyncStorage.getItem(
+      PENDING_PROFILE_STORAGE_KEY,
+    );
     if (!pendingProfileRaw) {
       return;
     }
@@ -257,14 +280,12 @@ const resolveProfileTokenForUser = async (
     parentId?: string | null;
   },
   sourceLabel: 'Amplify' | 'Firebase',
-): Promise<
-  {
-    status: 'resolved';
-    token?: string | null;
-    parent?: ParentProfileSummary;
-    isComplete?: boolean;
-  }
-> => {
+): Promise<{
+  status: 'resolved';
+  token?: string | null;
+  parent?: ParentProfileSummary;
+  isComplete?: boolean;
+}> => {
   try {
     const profileStatus = await fetchProfileStatus({
       accessToken: params.accessToken,
@@ -345,10 +366,14 @@ const attemptAmplifyRecovery = async (
       profileTokenResult.parent,
       existingParentId,
     );
-    const mergedUser = mergeUserWithParentProfile(baseUser, profileTokenResult.parent);
+    const mergedUser = mergeUserWithParentProfile(
+      baseUser,
+      profileTokenResult.parent,
+    );
     const hydratedUser: User = {
       ...mergedUser,
-      profileCompleted: profileTokenResult.isComplete ?? mergedUser.profileCompleted,
+      profileCompleted:
+        profileTokenResult.isComplete ?? mergedUser.profileCompleted,
     };
 
     if (pendingProfileStatus === 'pending') {
@@ -384,7 +409,10 @@ const attemptAmplifyRecovery = async (
       provider: 'amplify',
     };
   } catch (error) {
-    console.log('No active Amplify session detected; checking Firebase session.', error);
+    console.log(
+      'No active Amplify session detected; checking Firebase session.',
+      error,
+    );
     return null;
   }
 };
@@ -411,7 +439,10 @@ const attemptFirebaseRecovery = async (
         idToken,
       });
     } catch (error) {
-      console.warn('[Auth] Failed to sync Firebase auth user during recovery', error);
+      console.warn(
+        '[Auth] Failed to sync Firebase auth user during recovery',
+        error,
+      );
     }
 
     const parentSummary = authSync?.parentSummary;
@@ -419,11 +450,18 @@ const attemptFirebaseRecovery = async (
 
     // If we have no linked parent and no pending profile to resume, treat this
     // Firebase session as orphaned and sign out to avoid forcing CreateAccount.
-    if (!parentSummary && !existingUser?.parentId && pendingProfileStatus !== 'pending') {
+    if (
+      !parentSummary &&
+      !existingUser?.parentId &&
+      pendingProfileStatus !== 'pending'
+    ) {
       try {
         await firebaseSignOut(auth);
       } catch (signOutError) {
-        console.warn('[Auth] Firebase sign out failed during orphan recovery', signOutError);
+        console.warn(
+          '[Auth] Firebase sign out failed during orphan recovery',
+          signOutError,
+        );
       }
       await clearSessionData({clearPendingProfile: true});
       return null;
@@ -464,13 +502,18 @@ const attemptFirebaseRecovery = async (
         existingUser?.profilePicture ??
         firebaseUser.photoURL ??
         undefined,
-      profileToken: profileTokenResult.token ?? existingProfileToken ?? undefined,
+      profileToken:
+        profileTokenResult.token ?? existingProfileToken ?? undefined,
       address: existingUser?.address,
     };
-    const mergedUser = mergeUserWithParentProfile(baseUser, profileTokenResult.parent);
+    const mergedUser = mergeUserWithParentProfile(
+      baseUser,
+      profileTokenResult.parent,
+    );
     const hydratedUser: User = {
       ...mergedUser,
-      profileCompleted: profileTokenResult.isComplete ?? mergedUser.profileCompleted,
+      profileCompleted:
+        profileTokenResult.isComplete ?? mergedUser.profileCompleted,
     };
 
     if (pendingProfileStatus === 'pending') {
@@ -527,7 +570,10 @@ const recoverFromStoredTokens = async (
           userId: legacyTokens.userId ?? existingUser?.id,
         });
       } catch (migrateError) {
-        console.error('Failed to migrate legacy auth tokens into secure storage', migrateError);
+        console.error(
+          'Failed to migrate legacy auth tokens into secure storage',
+          migrateError,
+        );
       }
 
       await AsyncStorage.removeItem(LEGACY_AUTH_TOKEN_KEY);
@@ -548,7 +594,9 @@ const recoverFromStoredTokens = async (
   );
 
   if (isTokenExpired(normalizedTokens.expiresAt)) {
-    console.warn('[Auth] Stored tokens are expired; skipping cached session recovery.');
+    console.warn(
+      '[Auth] Stored tokens are expired; skipping cached session recovery.',
+    );
     return null;
   }
 
@@ -556,105 +604,112 @@ const recoverFromStoredTokens = async (
     kind: 'authenticated',
     user: {
       ...existingUser,
-      profileToken: existingUser.profileToken ?? existingProfileToken ?? undefined,
+      profileToken:
+        existingUser.profileToken ?? existingProfileToken ?? undefined,
     },
     tokens: normalizedTokens,
     provider: normalizedTokens.provider,
   };
 };
 
-export const getFreshStoredTokens = async (): Promise<NormalizedAuthTokens | null> => {
-  const storedTokens = await loadStoredTokens();
+export const getFreshStoredTokens =
+  async (): Promise<NormalizedAuthTokens | null> => {
+    const storedTokens = await loadStoredTokens();
 
-  if (!storedTokens) {
-    return null;
-  }
+    if (!storedTokens) {
+      return null;
+    }
 
-  const normalized = normalizeTokens(
-    {
-      ...storedTokens,
-      userId: storedTokens.userId ?? '',
-      provider: storedTokens.provider ?? 'amplify',
-    },
-    storedTokens.userId ?? '',
-  );
+    const normalized = normalizeTokens(
+      {
+        ...storedTokens,
+        userId: storedTokens.userId ?? '',
+        provider: storedTokens.provider ?? 'amplify',
+      },
+      storedTokens.userId ?? '',
+    );
 
-  if (!isTokenExpired(normalized.expiresAt)) {
-    return normalized;
-  }
+    if (!isTokenExpired(normalized.expiresAt)) {
+      return normalized;
+    }
 
-  try {
-    if (normalized.provider === 'firebase') {
-      const auth = getAuth();
-      const firebaseUser = auth.currentUser;
+    try {
+      if (normalized.provider === 'firebase') {
+        const auth = getAuth();
+        const firebaseUser = auth.currentUser;
 
-      if (!firebaseUser) {
+        if (!firebaseUser) {
+          return null;
+        }
+
+        await reload(firebaseUser);
+        const idToken = await getIdToken(firebaseUser, true);
+        const tokenResult = await getIdTokenResult(firebaseUser, true);
+        const refreshed: StoredAuthTokens = {
+          idToken,
+          accessToken: idToken,
+          refreshToken: undefined,
+          expiresAt: tokenResult?.expirationTime
+            ? new Date(tokenResult.expirationTime).getTime()
+            : undefined,
+          userId: firebaseUser.uid,
+          provider: 'firebase',
+        };
+
+        await storeTokens(refreshed);
+        markAuthRefreshed();
+        return normalizeTokens(refreshed, firebaseUser.uid, 'firebase');
+      }
+
+      const session = await fetchAuthSession({forceRefresh: true});
+      const idToken = session.tokens?.idToken?.toString();
+      const accessToken = session.tokens?.accessToken?.toString();
+
+      if (!idToken || !accessToken) {
         return null;
       }
 
-      await reload(firebaseUser);
-      const idToken = await getIdToken(firebaseUser, true);
-      const tokenResult = await getIdTokenResult(firebaseUser, true);
+      const expiresAtSeconds =
+        session.tokens?.idToken?.payload?.exp ??
+        session.tokens?.accessToken?.payload?.exp ??
+        undefined;
+
+      let resolvedUserId = normalized.userId;
+      if (!resolvedUserId) {
+        try {
+          const authUser = await getCurrentUser();
+          resolvedUserId = authUser.userId;
+        } catch {
+          resolvedUserId = storedTokens.userId ?? '';
+        }
+      }
+
       const refreshed: StoredAuthTokens = {
         idToken,
-        accessToken: idToken,
+        accessToken,
         refreshToken: undefined,
-        expiresAt: tokenResult?.expirationTime
-          ? new Date(tokenResult.expirationTime).getTime()
-          : undefined,
-        userId: firebaseUser.uid,
-        provider: 'firebase',
+        expiresAt: expiresAtSeconds ? expiresAtSeconds * 1000 : undefined,
+        userId: resolvedUserId,
+        provider: 'amplify',
       };
 
       await storeTokens(refreshed);
       markAuthRefreshed();
-      return normalizeTokens(refreshed, firebaseUser.uid, 'firebase');
+      return normalizeTokens(refreshed, resolvedUserId ?? '', 'amplify');
+    } catch (error) {
+      console.warn(
+        '[Auth] Unable to refresh stored tokens from provider',
+        error,
+      );
+      return normalized;
     }
-
-    const session = await fetchAuthSession({forceRefresh: true});
-    const idToken = session.tokens?.idToken?.toString();
-    const accessToken = session.tokens?.accessToken?.toString();
-
-    if (!idToken || !accessToken) {
-      return null;
-    }
-
-    const expiresAtSeconds =
-      session.tokens?.idToken?.payload?.exp ??
-      session.tokens?.accessToken?.payload?.exp ??
-      undefined;
-
-    let resolvedUserId = normalized.userId;
-    if (!resolvedUserId) {
-      try {
-        const authUser = await getCurrentUser();
-        resolvedUserId = authUser.userId;
-      } catch {
-        resolvedUserId = storedTokens.userId ?? '';
-      }
-    }
-
-    const refreshed: StoredAuthTokens = {
-      idToken,
-      accessToken,
-      refreshToken: undefined,
-      expiresAt: expiresAtSeconds ? expiresAtSeconds * 1000 : undefined,
-      userId: resolvedUserId,
-      provider: 'amplify',
-    };
-
-    await storeTokens(refreshed);
-    markAuthRefreshed();
-    return normalizeTokens(refreshed, resolvedUserId ?? '', 'amplify');
-  } catch (error) {
-    console.warn('[Auth] Unable to refresh stored tokens from provider', error);
-    return normalized;
-  }
-};
+  };
 
 export const recoverAuthSession = async (): Promise<RecoverAuthOutcome> => {
   const existingUserRaw = await AsyncStorage.getItem(USER_KEY);
-  const existingUser = existingUserRaw ? (JSON.parse(existingUserRaw) as User) : null;
+  const existingUser = existingUserRaw
+    ? (JSON.parse(existingUserRaw) as User)
+    : null;
   const existingProfileToken = existingUser?.profileToken;
 
   const amplifyResult = await attemptAmplifyRecovery(
@@ -665,7 +720,10 @@ export const recoverAuthSession = async (): Promise<RecoverAuthOutcome> => {
     return amplifyResult;
   }
 
-  const firebaseResult = await attemptFirebaseRecovery(existingUser, existingProfileToken);
+  const firebaseResult = await attemptFirebaseRecovery(
+    existingUser,
+    existingProfileToken,
+  );
   if (firebaseResult) {
     return firebaseResult;
   }
@@ -676,7 +734,9 @@ export const recoverAuthSession = async (): Promise<RecoverAuthOutcome> => {
   );
   if (storedTokensResult) {
     if (storedTokensResult.kind === 'authenticated') {
-      const pendingProfileStatus = await checkPendingProfile(storedTokensResult.user.id);
+      const pendingProfileStatus = await checkPendingProfile(
+        storedTokensResult.user.id,
+      );
       if (pendingProfileStatus === 'pending') {
         if (isProfileComplete(storedTokensResult.user)) {
           await clearPendingProfileForUser(storedTokensResult.user.id);
@@ -693,7 +753,8 @@ export const recoverAuthSession = async (): Promise<RecoverAuthOutcome> => {
 };
 
 let refreshTimeout: ReturnType<typeof setTimeout> | null = null;
-let appStateSubscription: ReturnType<typeof AppState.addEventListener> | null = null;
+let appStateSubscription: ReturnType<typeof AppState.addEventListener> | null =
+  null;
 let lastRefreshTimestamp = 0;
 
 const clearRefreshTimeout = () => {
@@ -718,7 +779,9 @@ export const scheduleSessionRefresh = (
 
   if (expiresAt) {
     const candidate = expiresAt - now - REFRESH_BUFFER_MS;
-    const safeCandidate = Number.isFinite(candidate) ? candidate : DEFAULT_REFRESH_INTERVAL_MS;
+    const safeCandidate = Number.isFinite(candidate)
+      ? candidate
+      : DEFAULT_REFRESH_INTERVAL_MS;
     delay = Math.max(REFRESH_BUFFER_MS, safeCandidate);
   }
 
@@ -735,15 +798,18 @@ export const registerAppStateListener = (refreshCallback: () => void) => {
     return;
   }
 
-  appStateSubscription = AppState.addEventListener('change', (nextStatus: AppStateStatus) => {
-    if (nextStatus === 'active') {
-      const now = Date.now();
-      if (now - lastRefreshTimestamp > MIN_APPSTATE_REFRESH_MS) {
-        markAuthRefreshed(now);
-        refreshCallback();
+  appStateSubscription = AppState.addEventListener(
+    'change',
+    (nextStatus: AppStateStatus) => {
+      if (nextStatus === 'active') {
+        const now = Date.now();
+        if (now - lastRefreshTimestamp > MIN_APPSTATE_REFRESH_MS) {
+          markAuthRefreshed(now);
+          refreshCallback();
+        }
       }
-    }
-  });
+    },
+  );
 };
 
 export const resetAuthLifecycle = ({clearPendingProfile = false} = {}) => {

--- a/apps/mobileAppYC/src/features/auth/thunks.ts
+++ b/apps/mobileAppYC/src/features/auth/thunks.ts
@@ -13,6 +13,7 @@ import {resetNotificationState} from '@/features/notifications';
 import {resetFormsState} from '@/features/forms';
 import {signOutEverywhere} from '@/features/auth/services/passwordlessAuth';
 import {getAuth, signOut} from '@react-native-firebase/auth';
+import {DeviceEventEmitter} from 'react-native';
 
 import {
   mergeUser,
@@ -37,6 +38,17 @@ import {
   scheduleSessionRefresh,
   type RecoverAuthOutcome,
 } from './sessionManager';
+import {updateApiClientBaseConfig} from '@/shared/services/apiClient';
+import {
+  API_CONFIG,
+  DEV_API_MODE_CHANGED_EVENT,
+  DEVELOPMENT_API_BASE_URL,
+  MOBILE_CONFIG_BEHAVIOR,
+  PRODUCTION_API_BASE_URL,
+} from '@/config/variables';
+import {Amplify} from 'aws-amplify';
+import devOutputs from '../../../devamplify_outputs.json';
+import prodOutputs from '../../../prodamplify_outputs.json';
 
 let appStateListenerRegistered = false;
 
@@ -256,6 +268,20 @@ export const logout = createAsyncThunk<
   }
 
   await clearSessionData({clearPendingProfile: true});
+
+  const defaultBaseUrl = MOBILE_CONFIG_BEHAVIOR.useDevApi
+    ? DEVELOPMENT_API_BASE_URL
+    : PRODUCTION_API_BASE_URL;
+  API_CONFIG.baseUrl = defaultBaseUrl;
+  API_CONFIG.pmsBaseUrl = defaultBaseUrl;
+  updateApiClientBaseConfig({baseUrl: defaultBaseUrl});
+  Amplify.configure(
+    MOBILE_CONFIG_BEHAVIOR.useDevApi ? devOutputs : prodOutputs,
+  );
+  DeviceEventEmitter.emit(DEV_API_MODE_CHANGED_EVENT, {
+    isDevApi: MOBILE_CONFIG_BEHAVIOR.useDevApi,
+  });
+
   resetAuthLifecycle({clearPendingProfile: true});
   appStateListenerRegistered = false;
 

--- a/apps/mobileAppYC/src/features/auth/thunks.ts
+++ b/apps/mobileAppYC/src/features/auth/thunks.ts
@@ -269,11 +269,15 @@ export const logout = createAsyncThunk<
 
   await clearSessionData({clearPendingProfile: true});
 
-  const defaultBaseUrl = MOBILE_CONFIG_BEHAVIOR.useDevApi
-    ? DEVELOPMENT_API_BASE_URL
-    : PRODUCTION_API_BASE_URL;
+  const defaultBaseUrl =
+    MOBILE_CONFIG_BEHAVIOR.overrides?.apiBaseUrl ??
+    (MOBILE_CONFIG_BEHAVIOR.useDevApi
+      ? DEVELOPMENT_API_BASE_URL
+      : PRODUCTION_API_BASE_URL);
+  const defaultPmsUrl =
+    MOBILE_CONFIG_BEHAVIOR.overrides?.pmsBaseUrl ?? defaultBaseUrl;
   API_CONFIG.baseUrl = defaultBaseUrl;
-  API_CONFIG.pmsBaseUrl = defaultBaseUrl;
+  API_CONFIG.pmsBaseUrl = defaultPmsUrl;
   updateApiClientBaseConfig({baseUrl: defaultBaseUrl});
   Amplify.configure(
     MOBILE_CONFIG_BEHAVIOR.useDevApi ? devOutputs : prodOutputs,

--- a/apps/mobileAppYC/src/features/forms/formsSlice.ts
+++ b/apps/mobileAppYC/src/features/forms/formsSlice.ts
@@ -301,11 +301,10 @@ export const startFormSigning = createAsyncThunk<
   'forms/startFormSigning',
   async ({appointmentId, submissionId}, {rejectWithValue}) => {
     try {
-      const {accessToken, userId} = await ensureAccessToken();
+      const {accessToken} = await ensureAccessToken();
       const result = await formApi.startSigning({
         submissionId,
         accessToken,
-        userId,
       });
       return {
         appointmentId,

--- a/apps/mobileAppYC/src/features/forms/services/formService.ts
+++ b/apps/mobileAppYC/src/features/forms/services/formService.ts
@@ -118,11 +118,9 @@ export const formApi = {
   async startSigning({
     submissionId,
     accessToken,
-    userId,
   }: {
     submissionId: string;
     accessToken: string;
-    userId?: string | null;
   }): Promise<{documentId?: string | number; signingUrl?: string | null}> {
     const {data} = await apiClient.post<{
       documentId?: string | number;
@@ -131,10 +129,7 @@ export const formApi = {
       `/fhir/v1/form/mobile/form-submissions/${submissionId}/sign`,
       {},
       {
-        headers: withAuthHeaders(
-          accessToken,
-          userId ? {'x-user-id': userId} : undefined,
-        ),
+        headers: withAuthHeaders(accessToken),
       },
     );
     return data;

--- a/apps/mobileAppYC/src/features/legal/services/withdrawalService.ts
+++ b/apps/mobileAppYC/src/features/legal/services/withdrawalService.ts
@@ -1,5 +1,8 @@
 import apiClient, {withAuthHeaders} from '@/shared/services/apiClient';
-import {ensureAccessContext, toErrorMessage} from '@/shared/utils/serviceHelpers';
+import {
+  ensureAccessContext,
+  toErrorMessage,
+} from '@/shared/utils/serviceHelpers';
 
 export type WithdrawalRequestPayload = {
   fullName: string;
@@ -13,11 +16,8 @@ export type WithdrawalRequestPayload = {
 export const withdrawalService = {
   async submitWithdrawal(payload: WithdrawalRequestPayload) {
     try {
-      const {accessToken, userId} = await ensureAccessContext();
-      const headers = withAuthHeaders(
-        accessToken,
-        userId ? {'x-user-id': userId} : undefined,
-      );
+      const {accessToken} = await ensureAccessContext();
+      const headers = withAuthHeaders(accessToken);
 
       const {data} = await apiClient.post(
         '/v1/account-withdrawal/withdraw',
@@ -28,7 +28,10 @@ export const withdrawalService = {
       return data;
     } catch (error) {
       throw new Error(
-        toErrorMessage(error, 'Unable to submit withdrawal request. Please try again.'),
+        toErrorMessage(
+          error,
+          'Unable to submit withdrawal request. Please try again.',
+        ),
       );
     }
   },

--- a/apps/mobileAppYC/src/features/observationalTools/services/observationToolService.ts
+++ b/apps/mobileAppYC/src/features/observationalTools/services/observationToolService.ts
@@ -183,11 +183,8 @@ const ensureAccessToken = async (): Promise<{
 };
 
 const createAuthHeaders = async () => {
-  const {accessToken, userId} = await ensureAccessToken();
-  return {
-    ...withAuthHeaders(accessToken),
-    ...(userId ? {'x-user-id': userId} : {}),
-  };
+  const {accessToken} = await ensureAccessToken();
+  return withAuthHeaders(accessToken);
 };
 
 export const observationToolApi = {

--- a/apps/mobileAppYC/src/features/support/services/contactService.ts
+++ b/apps/mobileAppYC/src/features/support/services/contactService.ts
@@ -116,16 +116,13 @@ export const uploadContactAttachments = async ({
 export const contactService = {
   async submitContact(payload: ContactRequestPayload) {
     try {
-      const {accessToken, userId} = await ensureAccessContext();
+      const {accessToken} = await ensureAccessContext();
       const body = {
         ...payload,
         source: payload.source ?? CONTACT_SOURCE,
       };
 
-      const headers = withAuthHeaders(
-        accessToken,
-        userId ? {'x-user-id': userId} : undefined,
-      );
+      const headers = withAuthHeaders(accessToken);
 
       const {data} = await apiClient.post('/v1/contact-us/contact', body, {
         headers,

--- a/apps/mobileAppYC/src/features/tasks/services/taskService.ts
+++ b/apps/mobileAppYC/src/features/tasks/services/taskService.ts
@@ -485,7 +485,7 @@ export const buildTaskDraftFromForm = ({
 
 export const taskApi = {
   async list(params?: {companionId?: string; status?: TaskStatusApi[]}) {
-    const {accessToken, userId} = await ensureAccessToken();
+    const {accessToken} = await ensureAccessToken();
     const response = await apiClient.get('/v1/task/mobile/task', {
       params: {
         companionId: params?.companionId,
@@ -493,7 +493,6 @@ export const taskApi = {
       },
       headers: {
         ...withAuthHeaders(accessToken),
-        ...(userId ? {'x-user-id': userId} : {}),
       },
     });
     const data = Array.isArray(response.data) ? response.data : [];
@@ -501,36 +500,33 @@ export const taskApi = {
   },
 
   async get(taskId: string) {
-    const {accessToken, userId} = await ensureAccessToken();
+    const {accessToken} = await ensureAccessToken();
     const response = await apiClient.get(`/v1/task/mobile/${taskId}`, {
       headers: {
         ...withAuthHeaders(accessToken),
-        ...(userId ? {'x-user-id': userId} : {}),
       },
     });
     return mapApiTaskToTask(response.data);
   },
 
   async create(payload: TaskDraftPayload) {
-    const {accessToken, userId} = await ensureAccessToken();
+    const {accessToken} = await ensureAccessToken();
     const response = await apiClient.post('/v1/task/mobile/', payload, {
       headers: {
         ...withAuthHeaders(accessToken),
-        ...(userId ? {'x-user-id': userId} : {}),
       },
     });
     return mapApiTaskToTask(response.data);
   },
 
   async update(taskId: string, updates: Partial<TaskDraftPayload>) {
-    const {accessToken, userId} = await ensureAccessToken();
+    const {accessToken} = await ensureAccessToken();
     const response = await apiClient.patch(
       `/v1/task/mobile/${taskId}`,
       updates,
       {
         headers: {
           ...withAuthHeaders(accessToken),
-          ...(userId ? {'x-user-id': userId} : {}),
         },
       },
     );
@@ -538,14 +534,13 @@ export const taskApi = {
   },
 
   async changeStatus(taskId: string, status: TaskStatusApi, completion?: any) {
-    const {accessToken, userId} = await ensureAccessToken();
+    const {accessToken} = await ensureAccessToken();
     const response = await apiClient.post(
       `/v1/task/mobile/${taskId}/status`,
       completion ? {status, completion} : {status},
       {
         headers: {
           ...withAuthHeaders(accessToken),
-          ...(userId ? {'x-user-id': userId} : {}),
         },
       },
     );

--- a/apps/mobileAppYC/src/shared/services/mobileConfig.ts
+++ b/apps/mobileAppYC/src/shared/services/mobileConfig.ts
@@ -101,21 +101,23 @@ export const isDevelopmentMobileEnv = (env?: MobileEnv | null): boolean => {
   return normalized === 'dev' || normalized === 'development';
 };
 
-export const fetchMobileConfig = async (): Promise<MobileConfig> => {
-  const url = resolveMobileConfigUrl();
-  console.log('[MobileConfig] Request', {url});
+export const fetchMobileConfig = async (
+  url?: string,
+): Promise<MobileConfig> => {
+  const resolvedUrl = url ?? resolveMobileConfigUrl();
+  console.log('[MobileConfig] Request', {url: resolvedUrl});
   try {
-    const response = await axios.get<MobileConfig>(url, {
+    const response = await axios.get<MobileConfig>(resolvedUrl, {
       timeout: MOBILE_CONFIG_TIMEOUT_MS,
     });
     console.log('[MobileConfig] Response', {
-      url,
+      url: resolvedUrl,
       status: response.status,
       data: response.data,
     });
     return response.data;
   } catch (error) {
-    console.log('[MobileConfig] Error', {url, error});
+    console.log('[MobileConfig] Error', {url: resolvedUrl, error});
     throw error;
   }
 };

--- a/apps/mobileAppYC/src/shared/services/mobileConfig.ts
+++ b/apps/mobileAppYC/src/shared/services/mobileConfig.ts
@@ -34,6 +34,7 @@ export interface MobileConfig {
   /** When true, the review/demo bypass login is active for the test account. */
   enableReviewLogin?: boolean;
   stripePublishableKey?: string;
+  stripePublishableKeyDev?: string;
   sentryDsn?: string;
   /**
    * Forces a 1px black outline on all liquid glass surfaces (cards/buttons) to aid visibility.


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] All existing tests and lints pass.

## What is the current behavior?

When Apple reviewers sign in using the review account, the app remains pointed at the production backend and Cognito pool. This causes authentication failures because the review account only exists in the development environment. Logging out also incorrectly resets state regardless of which environment was active.

## What is the new behavior?

- Signing in with the review account automatically switches the entire app stack to the development environment — API base URL, Cognito user pool, and Stripe publishable key all update atomically.
- The development environment mode persists across app restarts so the review session survives a relaunch.
- Logging out restores the correct environment based on the build configuration, ensuring normal users are always routed to production.
- The Stripe key updates reactively at runtime when the environment switches, so payment flows use the correct key immediately.

## Related Issue(s)

Fixes #
