### PR TITLE
feat(frontend): add dispensary surface and dispense workflow to inventory module

### DIFF
--- a/apps/frontend/src/app/__tests__/components/AddInventory/ImageUploadField.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/AddInventory/ImageUploadField.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ImageUploadField from '@/app/features/inventory/components/AddInventory/ImageUploadField';
+import {
+  getInventoryItemImagePresignedUrl,
+  uploadFileToS3,
+} from '@/app/features/inventory/services/inventoryUploadService';
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: ({ alt, src }: any) => React.createElement('img', { alt, src }),
+}));
+
+jest.mock('@/app/features/inventory/services/inventoryUploadService', () => ({
+  getInventoryItemImagePresignedUrl: jest.fn(),
+  uploadFileToS3: jest.fn(),
+}));
+
+jest.mock('@/app/lib/urls', () => ({
+  getSafeOrgImageUrl: jest.fn((src: string) =>
+    src.startsWith('inventory/') ? `https://cdn.example.com/${src}` : src
+  ),
+}));
+
+describe('ImageUploadField', () => {
+  const createObjectURL = jest.fn(() => 'blob:preview');
+  const revokeObjectURL = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.defineProperty(URL, 'createObjectURL', {
+      value: createObjectURL,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      value: revokeObjectURL,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it('renders an existing inventory s3 key through the org CDN url', () => {
+    render(
+      <ImageUploadField
+        label="Product image"
+        value="inventory/org-1/item-1.jpg"
+        organisationId="org-1"
+        onChange={jest.fn()}
+      />
+    );
+
+    const image = screen.getByAltText('Product image');
+    expect(image).toHaveAttribute('src', 'https://cdn.example.com/inventory/org-1/item-1.jpg');
+  });
+
+  it('uploads the selected file and stores the returned s3 key', async () => {
+    const onChange = jest.fn();
+    (getInventoryItemImagePresignedUrl as jest.Mock).mockResolvedValue({
+      uploadUrl: 'https://upload.example.com',
+      s3Key: 'inventory/org-1/new-item.png',
+    });
+    (uploadFileToS3 as jest.Mock).mockResolvedValue(undefined);
+
+    render(
+      <ImageUploadField label="Product image" value="" organisationId="org-1" onChange={onChange} />
+    );
+
+    const fileInput = screen.getByLabelText('Product image');
+    const file = new File(['file'], 'item.png', { type: 'image/png' });
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    await waitFor(() =>
+      expect(getInventoryItemImagePresignedUrl).toHaveBeenCalledWith('org-1', 'image/png')
+    );
+    expect(uploadFileToS3).toHaveBeenCalledWith('https://upload.example.com', file);
+    expect(onChange).toHaveBeenCalledWith('inventory/org-1/new-item.png');
+  });
+});

--- a/apps/frontend/src/app/__tests__/components/AddInventory/InventoryConfig.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/AddInventory/InventoryConfig.test.tsx
@@ -90,6 +90,7 @@ describe('InventoryFormConfig', () => {
     it('should have the correct field structure in the classification section', () => {
       const classificationFields = extractFieldNames(config.classification!);
       const expectedFields = [
+        'genericName',
         'itemType',
         'drugSchedule',
         'species',

--- a/apps/frontend/src/app/__tests__/components/AddInventory/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/AddInventory/index.test.tsx
@@ -77,6 +77,10 @@ jest.mock('@/app/features/inventory/components/AddInventory/FormSection', () => 
 
       {/* Classification Fields */}
       <input
+        data-testid="in-generic-name"
+        onChange={(e) => onFieldChange('classification', 'genericName', e.target.value)}
+      />
+      <input
         data-testid="in-item-type"
         onChange={(e) => onFieldChange('classification', 'itemType', e.target.value)}
       />
@@ -186,7 +190,10 @@ describe('AddInventory Component', () => {
 
     expect(screen.getByTestId('active-label')).toHaveTextContent('classification');
 
-    // 2. Classification (No validation logic in component)
+    // 2. Classification
+    fireEvent.change(screen.getByTestId('in-generic-name'), {
+      target: { value: 'Item 1 generic' },
+    });
     fireEvent.click(screen.getByTestId('save-btn')); // Next
     expect(screen.getByTestId('active-label')).toHaveTextContent('stock');
 
@@ -225,6 +232,33 @@ describe('AddInventory Component', () => {
     expect(mockSubmit).toHaveBeenCalled();
     // Upon success, modal should close and form reset
     expect(mockSetShowModal).toHaveBeenCalledWith(false);
+  });
+
+  it('requires generic name for hospital medical items before leaving Clinical Details', async () => {
+    render(<AddInventory {...props} businessType={'HOSPITAL' as BusinessType} />);
+
+    fireEvent.change(screen.getByTestId('in-name'), {
+      target: { value: 'Amoxicillin 250mg' },
+    });
+    fireEvent.change(screen.getByTestId('in-cat'), {
+      target: { value: 'Medicine' },
+    });
+    fireEvent.change(screen.getByTestId('in-sub'), {
+      target: { value: 'Antibiotic' },
+    });
+    fireEvent.click(screen.getByTestId('save-btn'));
+
+    expect(screen.getByTestId('active-label')).toHaveTextContent('classification');
+
+    fireEvent.click(screen.getByTestId('save-btn'));
+    expect(screen.getByTestId('active-label')).toHaveTextContent('classification');
+
+    fireEvent.change(screen.getByTestId('in-generic-name'), {
+      target: { value: 'Amoxicillin' },
+    });
+    fireEvent.click(screen.getByTestId('save-btn'));
+
+    expect(screen.getByTestId('active-label')).toHaveTextContent('stock');
   });
 
   it('clears drug-only clinical fields when Non-drug is selected', async () => {

--- a/apps/frontend/src/app/__tests__/components/DataTable/InventoryTable.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/DataTable/InventoryTable.test.tsx
@@ -3,8 +3,19 @@ import { fireEvent, render, screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import InventoryTable from '@/app/ui/tables/InventoryTable';
 
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: ({ alt, src }: any) => React.createElement('img', { alt, src }),
+}));
+
 jest.mock('react-icons/io5', () => ({
   IoEye: () => <span data-testid="icon-eye" />,
+}));
+
+jest.mock('@/app/lib/urls', () => ({
+  getSafeOrgImageUrl: jest.fn((src: string) =>
+    typeof src === 'string' && src.startsWith('inventory/') ? `https://cdn.example.com/${src}` : ''
+  ),
 }));
 
 jest.mock('@/app/ui/cards/InventoryCard', () => ({
@@ -157,5 +168,28 @@ describe('InventoryTable', () => {
 
     expect(screen.getByRole('button', { name: 'View Vaccine' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Restock Vaccine' })).toBeInTheDocument();
+  });
+
+  it('renders an inventory image when the item stores an s3 key', () => {
+    const itemWithImage = {
+      ...item,
+      basicInfo: {
+        ...item.basicInfo,
+        imageUrl: 'inventory/org-1/vaccine.jpg',
+      },
+    };
+
+    render(
+      <InventoryTable
+        filteredList={[itemWithImage]}
+        setActiveInventory={jest.fn()}
+        setViewInventory={jest.fn()}
+      />
+    );
+
+    expect(screen.getByAltText('')).toHaveAttribute(
+      'src',
+      'https://cdn.example.com/inventory/org-1/vaccine.jpg'
+    );
   });
 });

--- a/apps/frontend/src/app/__tests__/components/DispensaryDetailModal/DispensaryDetailModal.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/DispensaryDetailModal/DispensaryDetailModal.test.tsx
@@ -1,0 +1,174 @@
+'use client';
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+jest.mock('@/app/ui/overlays/Modal', () => ({
+  __esModule: true,
+  default: ({ children, showModal }: { children: React.ReactNode; showModal: boolean }) =>
+    showModal ? <div data-testid="modal">{children}</div> : null,
+}));
+
+jest.mock('@/app/features/appointments/services/prescriptionWorkflowService', () => ({
+  dispensePrescription: jest.fn(),
+  notDispensedPrescription: jest.fn(),
+}));
+
+jest.mock('@/app/features/inventory/services/dispensaryService', () => ({
+  fetchPrescriptionLabelPdf: jest.fn(),
+}));
+
+import DispensaryDetailModal from '@/app/features/inventory/components/DispensaryDetailModal';
+import { fetchPrescriptionLabelPdf } from '@/app/features/inventory/services/dispensaryService';
+import {
+  dispensePrescription,
+  notDispensedPrescription,
+} from '@/app/features/appointments/services/prescriptionWorkflowService';
+import { DispensaryRecord } from '@/app/features/inventory/pages/Inventory/types';
+
+const fetchLabelMock = fetchPrescriptionLabelPdf as jest.MockedFunction<
+  typeof fetchPrescriptionLabelPdf
+>;
+const dispenseMock = dispensePrescription as jest.MockedFunction<typeof dispensePrescription>;
+const notDispensedMock = notDispensedPrescription as jest.MockedFunction<
+  typeof notDispensedPrescription
+>;
+
+const baseRecord: DispensaryRecord = {
+  id: 'req-1',
+  prescriptionId: 'rx-abc',
+  status: 'DISPENSED',
+  requestType: 'PATIENT',
+  patient: { name: 'Buddy', appointmentId: 'appt-1' },
+  prescriptionItems: [],
+  prescriptionCreated: '2026-01-01',
+  amountCents: 5000,
+  lead: 'Dr. Smith',
+  location: 'Room A',
+  items: [],
+};
+
+const defaultProps = {
+  record: baseRecord,
+  showModal: true,
+  setShowModal: jest.fn(),
+  organisationId: 'org-123',
+  onActionComplete: jest.fn(),
+};
+
+describe('DispensaryDetailModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.defineProperty(global.URL, 'createObjectURL', {
+      writable: true,
+      value: jest.fn(() => 'blob:mock-url'),
+    });
+    Object.defineProperty(global.URL, 'revokeObjectURL', {
+      writable: true,
+      value: jest.fn(),
+    });
+  });
+
+  describe('Label button (dispensed state)', () => {
+    it('renders the Label button when status is DISPENSED', () => {
+      render(<DispensaryDetailModal {...defaultProps} />);
+      expect(screen.getByRole('button', { name: /label/i })).toBeInTheDocument();
+    });
+
+    it('does not render Dispense/Not dispensed buttons when DISPENSED', () => {
+      render(<DispensaryDetailModal {...defaultProps} />);
+      expect(screen.queryByText(/dispense all/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/not dispensed/i)).not.toBeInTheDocument();
+    });
+
+    it('opens the label PDF in a new tab on click', async () => {
+      const mockBlob = new Blob(['%PDF'], { type: 'application/pdf' });
+      fetchLabelMock.mockResolvedValue(mockBlob);
+      const openSpy = jest.spyOn(window, 'open').mockReturnValue(null);
+
+      render(<DispensaryDetailModal {...defaultProps} />);
+      fireEvent.click(screen.getByRole('button', { name: /label/i }));
+
+      await waitFor(() => {
+        expect(fetchLabelMock).toHaveBeenCalledWith('org-123', 'rx-abc');
+      });
+      expect(URL.createObjectURL).toHaveBeenCalledWith(mockBlob);
+      expect(openSpy).toHaveBeenCalledWith('blob:mock-url', '_blank');
+
+      openSpy.mockRestore();
+    });
+
+    it('shows Loading… while fetching and re-enables after', async () => {
+      let resolve: (b: Blob) => void;
+      fetchLabelMock.mockReturnValue(
+        new Promise((res) => {
+          resolve = res;
+        })
+      );
+      jest.spyOn(window, 'open').mockReturnValue(null);
+
+      render(<DispensaryDetailModal {...defaultProps} />);
+      const btn = screen.getByRole('button', { name: /label/i });
+      fireEvent.click(btn);
+
+      expect(await screen.findByText('Loading…')).toBeInTheDocument();
+      expect(btn).toBeDisabled();
+
+      resolve!(new Blob([], { type: 'application/pdf' }));
+      await waitFor(() => expect(screen.getByText('Label')).toBeInTheDocument());
+      expect(btn).not.toBeDisabled();
+    });
+
+    it('ignores a second click while already printing', async () => {
+      let resolve: (b: Blob) => void;
+      fetchLabelMock.mockReturnValue(
+        new Promise((res) => {
+          resolve = res;
+        })
+      );
+      jest.spyOn(window, 'open').mockReturnValue(null);
+
+      render(<DispensaryDetailModal {...defaultProps} />);
+      const btn = screen.getByRole('button', { name: /label/i });
+      fireEvent.click(btn);
+      fireEvent.click(btn);
+
+      resolve!(new Blob([], { type: 'application/pdf' }));
+      await waitFor(() => expect(screen.getByText('Label')).toBeInTheDocument());
+      expect(fetchLabelMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Pending state (PENDING)', () => {
+    const pendingRecord = { ...baseRecord, status: 'PENDING' as const };
+
+    it('renders Dispense all and Not dispensed buttons', () => {
+      render(<DispensaryDetailModal {...defaultProps} record={pendingRecord} />);
+      expect(screen.getByText(/dispense all/i)).toBeInTheDocument();
+      expect(screen.getByText(/not dispensed/i)).toBeInTheDocument();
+    });
+
+    it('does not render the Label button', () => {
+      render(<DispensaryDetailModal {...defaultProps} record={pendingRecord} />);
+      expect(screen.queryByRole('button', { name: /label/i })).not.toBeInTheDocument();
+    });
+
+    it('calls dispensePrescription on Dispense all click', async () => {
+      dispenseMock.mockResolvedValue(undefined as never);
+      render(<DispensaryDetailModal {...defaultProps} record={pendingRecord} />);
+      fireEvent.click(screen.getByText(/dispense all/i));
+      await waitFor(() => expect(dispenseMock).toHaveBeenCalledWith('org-123', 'rx-abc'));
+    });
+
+    it('calls notDispensedPrescription on Not dispensed click', async () => {
+      notDispensedMock.mockResolvedValue(undefined as never);
+      render(<DispensaryDetailModal {...defaultProps} record={pendingRecord} />);
+      fireEvent.click(screen.getByText(/not dispensed/i));
+      await waitFor(() => expect(notDispensedMock).toHaveBeenCalledWith('org-123', 'rx-abc'));
+    });
+  });
+
+  it('does not render when showModal is false', () => {
+    render(<DispensaryDetailModal {...defaultProps} showModal={false} />);
+    expect(screen.queryByTestId('modal')).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/__tests__/components/InventoryInfo/InfoSection.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/InventoryInfo/InfoSection.test.tsx
@@ -1,32 +1,21 @@
-import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
-import InfoSection from "@/app/features/inventory/components/InfoSection";
-import { InventoryItem } from "@/app/features/inventory/pages/Inventory/types";
-import { BusinessType } from "@/app/features/organization/types/org";
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import InfoSection from '@/app/features/inventory/components/InfoSection';
+import { InventoryItem } from '@/app/features/inventory/pages/Inventory/types';
+import { BusinessType } from '@/app/features/organization/types/org';
 
 // --- Mocks ---
 
 // Mock EditableAccordion to inspect props passed to it
-jest.mock("@/app/ui/primitives/Accordion/EditableAccordion", () => ({
+jest.mock('@/app/ui/primitives/Accordion/EditableAccordion', () => ({
   __esModule: true,
-  default: ({
-    title,
-    fields,
-    data,
-    onSave,
-    onEditingChange,
-    onRegisterActions,
-    readOnly,
-  }: any) => (
+  default: ({ title, fields, data, onSave, onEditingChange, onRegisterActions, readOnly }: any) => (
     <div data-testid="mock-accordion">
       <div data-testid="acc-title">{title}</div>
-      <div data-testid="acc-readonly">{readOnly ? "true" : "false"}</div>
+      <div data-testid="acc-readonly">{readOnly ? 'true' : 'false'}</div>
       <div data-testid="acc-fields">{JSON.stringify(fields)}</div>
       <div data-testid="acc-data">{JSON.stringify(data)}</div>
-      <button
-        data-testid="trigger-save"
-        onClick={() => onSave({ someField: "newValue" })}
-      >
+      <button data-testid="trigger-save" onClick={() => onSave({ someField: 'newValue' })}>
         Save
       </button>
       <button
@@ -48,25 +37,42 @@ jest.mock("@/app/ui/primitives/Accordion/EditableAccordion", () => ({
 }));
 
 // Mock InventoryConfig to control the shape of the form being tested
-jest.mock("@/app/features/inventory/components/AddInventory/InventoryConfig", () => ({
+jest.mock('@/app/features/inventory/components/AddInventory/InventoryConfig', () => ({
   InventoryFormConfig: {
     vet: {
       basicInfo: [
         {
-          kind: "field",
-          field: { name: "name", component: "input", placeholder: "Item Name" },
+          kind: 'field',
+          field: { name: 'name', component: 'input', placeholder: 'Item Name' },
         },
         {
-          kind: "row",
+          kind: 'row',
           fields: [
             {
-              name: "category",
-              component: "dropdown",
-              options: ["A", "B"],
-              label: "Category Label",
+              name: 'category',
+              component: 'dropdown',
+              options: ['A', 'B'],
+              label: 'Category Label',
             },
-            { name: "expiry", component: "date", placeholder: "Expiry Date" },
+            { name: 'expiry', component: 'date', placeholder: 'Expiry Date' },
           ],
+        },
+        {
+          kind: 'field',
+          field: {
+            name: 'species',
+            component: 'multiSelect',
+            options: ['Dog', 'Cat'],
+            placeholder: 'Species',
+          },
+        },
+        {
+          kind: 'field',
+          field: {
+            name: 'prescriptionRequired',
+            component: 'checkbox',
+            placeholder: 'Prescription required',
+          },
         },
       ],
       emptySection: [], // To test empty state
@@ -77,15 +83,15 @@ jest.mock("@/app/features/inventory/components/AddInventory/InventoryConfig", ()
 // --- Test Data ---
 
 const mockInventory: InventoryItem = {
-  id: "123",
+  id: '123',
   basicInfo: {
-    name: "Test Item",
-    category: "A",
-    expiry: "2025-01-01",
+    name: 'Test Item',
+    category: 'A',
+    expiry: '2025-01-01',
   },
 } as any;
 
-describe("InfoSection Component", () => {
+describe('InfoSection Component', () => {
   const mockOnSaveSection = jest.fn();
   const mockOnEditingChange = jest.fn();
   const mockOnRegisterActions = jest.fn();
@@ -96,10 +102,10 @@ describe("InfoSection Component", () => {
 
   // --- 1. Rendering ---
 
-  it("renders the section title and accordion when config exists", () => {
+  it('renders the section title and accordion when config exists', () => {
     render(
       <InfoSection
-        businessType={"vet" as BusinessType}
+        businessType={'vet' as BusinessType}
         sectionKey="basicInfo"
         sectionTitle="Basic Information"
         inventory={mockInventory}
@@ -108,111 +114,117 @@ describe("InfoSection Component", () => {
 
     // FIX: "Basic Information" appears in main header div AND mocked accordion title.
     // Check for multiple instances or specific testID.
-    const titles = screen.getAllByText("Basic Information");
+    const titles = screen.getAllByText('Basic Information');
     expect(titles.length).toBeGreaterThanOrEqual(1);
 
-    expect(screen.getByTestId("mock-accordion")).toBeInTheDocument();
+    expect(screen.getByTestId('mock-accordion')).toBeInTheDocument();
 
     // Verify title passed to accordion specifically
-    expect(screen.getByTestId("acc-title")).toHaveTextContent(
-      "Basic Information"
-    );
+    expect(screen.getByTestId('acc-title')).toHaveTextContent('Basic Information');
   });
 
   it("renders 'No fields configured' when configuration is empty", () => {
     render(
       <InfoSection
-        businessType={"vet" as BusinessType}
-        sectionKey={"emptySection" as any}
+        businessType={'vet' as BusinessType}
+        sectionKey={'emptySection' as any}
         sectionTitle="Empty Section"
         inventory={mockInventory}
       />
     );
 
-    expect(
-      screen.getByText("No fields configured for this section.")
-    ).toBeInTheDocument();
-    expect(screen.queryByTestId("mock-accordion")).not.toBeInTheDocument();
+    expect(screen.getByText('No fields configured for this section.')).toBeInTheDocument();
+    expect(screen.queryByTestId('mock-accordion')).not.toBeInTheDocument();
   });
 
   it("renders 'No fields configured' when business type or section does not exist", () => {
     render(
       <InfoSection
-        businessType={"retail" as BusinessType}
+        businessType={'retail' as BusinessType}
         sectionKey="basicInfo"
         sectionTitle="Missing Config"
         inventory={mockInventory}
       />
     );
 
-    expect(
-      screen.getByText("No fields configured for this section.")
-    ).toBeInTheDocument();
+    expect(screen.getByText('No fields configured for this section.')).toBeInTheDocument();
   });
 
   // --- 2. Logic (Field Mapping & Flattening) ---
 
-  it("correctly maps and flattens configuration fields into EditableFields", () => {
+  it('correctly maps and flattens configuration fields into EditableFields', () => {
     render(
       <InfoSection
-        businessType={"vet" as BusinessType}
+        businessType={'vet' as BusinessType}
         sectionKey="basicInfo"
         sectionTitle="Basic Info"
         inventory={mockInventory}
       />
     );
 
-    const fieldsJson = screen.getByTestId("acc-fields").textContent;
-    const fields = JSON.parse(fieldsJson || "[]");
+    const fieldsJson = screen.getByTestId('acc-fields').textContent;
+    const fields = JSON.parse(fieldsJson || '[]');
 
-    // We expect 3 fields total (1 standalone + 2 in a row)
-    expect(fields).toHaveLength(3);
+    expect(fields).toHaveLength(5);
 
     // 1. Text Input Mapping
     expect(fields[0]).toEqual({
-      label: "Item Name",
-      key: "name",
-      type: "text",
+      label: 'Item Name',
+      key: 'name',
+      type: 'text',
     });
 
     // 2. Dropdown Mapping
     expect(fields[1]).toEqual({
-      label: "Category Label",
-      key: "category",
-      type: "select",
-      options: ["A", "B"],
+      label: 'Category Label',
+      key: 'category',
+      type: 'select',
+      options: ['A', 'B'],
     });
 
     // 3. Date Mapping
     expect(fields[2]).toEqual({
-      label: "Expiry Date",
-      key: "expiry",
-      type: "date",
+      label: 'Expiry Date',
+      key: 'expiry',
+      type: 'date',
+    });
+
+    expect(fields[3]).toEqual({
+      label: 'Species',
+      key: 'species',
+      type: 'multiSelect',
+      options: ['Dog', 'Cat'],
+    });
+
+    expect(fields[4]).toEqual({
+      label: 'Prescription required',
+      key: 'prescriptionRequired',
+      type: 'checkbox',
     });
   });
 
-  it("passes the correct data subset to the accordion", () => {
+  it('passes the correct data subset to the accordion', () => {
     render(
       <InfoSection
-        businessType={"vet" as BusinessType}
+        businessType={'vet' as BusinessType}
         sectionKey="basicInfo"
         sectionTitle="Basic Info"
         inventory={mockInventory}
       />
     );
 
-    const dataJson = screen.getByTestId("acc-data").textContent;
-    const data = JSON.parse(dataJson || "{}");
+    const dataJson = screen.getByTestId('acc-data').textContent;
+    const data = JSON.parse(dataJson || '{}');
 
     expect(data).toEqual(mockInventory.basicInfo);
   });
 
   // --- 3. Interaction (Callbacks) ---
 
-  it("calls onSaveSection with the correct section key when accordion saves", () => {
+  it('calls onSaveSection with the correct section key when accordion saves', () => {
     render(
       <InfoSection
-        businessType={"vet" as BusinessType}
+        businessType={'vet' as BusinessType}
         sectionKey="basicInfo"
         sectionTitle="Basic Info"
         inventory={mockInventory}
@@ -220,17 +232,17 @@ describe("InfoSection Component", () => {
       />
     );
 
-    fireEvent.click(screen.getByTestId("trigger-save"));
+    fireEvent.click(screen.getByTestId('trigger-save'));
 
-    expect(mockOnSaveSection).toHaveBeenCalledWith("basicInfo", {
-      someField: "newValue",
+    expect(mockOnSaveSection).toHaveBeenCalledWith('basicInfo', {
+      someField: 'newValue',
     });
   });
 
-  it("propagates onEditingChange callback", () => {
+  it('propagates onEditingChange callback', () => {
     render(
       <InfoSection
-        businessType={"vet" as BusinessType}
+        businessType={'vet' as BusinessType}
         sectionKey="basicInfo"
         sectionTitle="Basic Info"
         inventory={mockInventory}
@@ -238,15 +250,15 @@ describe("InfoSection Component", () => {
       />
     );
 
-    fireEvent.click(screen.getByTestId("trigger-edit-change"));
+    fireEvent.click(screen.getByTestId('trigger-edit-change'));
 
     expect(mockOnEditingChange).toHaveBeenCalledWith(true);
   });
 
-  it("propagates onRegisterActions callback", () => {
+  it('propagates onRegisterActions callback', () => {
     render(
       <InfoSection
-        businessType={"vet" as BusinessType}
+        businessType={'vet' as BusinessType}
         sectionKey="basicInfo"
         sectionTitle="Basic Info"
         inventory={mockInventory}
@@ -254,7 +266,7 @@ describe("InfoSection Component", () => {
       />
     );
 
-    fireEvent.click(screen.getByTestId("trigger-register"));
+    fireEvent.click(screen.getByTestId('trigger-register'));
 
     expect(mockOnRegisterActions).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -265,10 +277,10 @@ describe("InfoSection Component", () => {
 
   // --- 4. Props & Edge Cases ---
 
-  it("passes disableEditing prop to accordion as readOnly", () => {
+  it('passes disableEditing prop to accordion as readOnly', () => {
     const { rerender } = render(
       <InfoSection
-        businessType={"vet" as BusinessType}
+        businessType={'vet' as BusinessType}
         sectionKey="basicInfo"
         sectionTitle="Basic Info"
         inventory={mockInventory}
@@ -276,11 +288,11 @@ describe("InfoSection Component", () => {
       />
     );
 
-    expect(screen.getByTestId("acc-readonly")).toHaveTextContent("true");
+    expect(screen.getByTestId('acc-readonly')).toHaveTextContent('true');
 
     rerender(
       <InfoSection
-        businessType={"vet" as BusinessType}
+        businessType={'vet' as BusinessType}
         sectionKey="basicInfo"
         sectionTitle="Basic Info"
         inventory={mockInventory}
@@ -288,19 +300,19 @@ describe("InfoSection Component", () => {
       />
     );
 
-    expect(screen.getByTestId("acc-readonly")).toHaveTextContent("false");
+    expect(screen.getByTestId('acc-readonly')).toHaveTextContent('false');
   });
 
-  it("handles missing label/placeholder fallback in field mapping", async () => {
+  it('handles missing label/placeholder fallback in field mapping', async () => {
     // Modify mock for this specific test case to test fallback to field.name
     jest.resetModules();
-    jest.doMock("@/app/features/inventory/components/AddInventory/InventoryConfig", () => ({
+    jest.doMock('@/app/features/inventory/components/AddInventory/InventoryConfig', () => ({
       InventoryFormConfig: {
         vet: {
           fallbackTest: [
             {
-              kind: "field",
-              field: { name: "fallbackField", component: "input" },
+              kind: 'field',
+              field: { name: 'fallbackField', component: 'input' },
             },
           ],
         },
@@ -308,23 +320,22 @@ describe("InfoSection Component", () => {
     }));
 
     // Re-import component to use new mock using dynamic import instead of require
-    const { default: ReImportedInfoSection } = await import(
-      "@/app/features/inventory/components/InfoSection"
-    );
+    const { default: ReImportedInfoSection } =
+      await import('@/app/features/inventory/components/InfoSection');
 
     render(
       <ReImportedInfoSection
-        businessType={"vet" as BusinessType}
+        businessType={'vet' as BusinessType}
         // FIX: Cast string to 'any' to bypass strict type checking for the test mock key
-        sectionKey={"fallbackTest" as any}
+        sectionKey={'fallbackTest' as any}
         sectionTitle="Fallback Test"
         inventory={mockInventory}
       />
     );
 
-    const fieldsJson = screen.getByTestId("acc-fields").textContent;
-    const fields = JSON.parse(fieldsJson || "[]");
+    const fieldsJson = screen.getByTestId('acc-fields').textContent;
+    const fields = JSON.parse(fieldsJson || '[]');
 
-    expect(fields[0].label).toBe("fallbackField");
+    expect(fields[0].label).toBe('fallbackField');
   });
 });

--- a/apps/frontend/src/app/__tests__/components/InventoryInfo/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/InventoryInfo/index.test.tsx
@@ -106,8 +106,13 @@ jest.mock('@/app/ui/inputs/Dropdown/LabelDropdown', () => ({
 
 jest.mock('@/app/ui/inputs/FormInput/FormInput', () => ({
   __esModule: true,
-  default: ({ value, onChange, inname }: any) => (
-    <input data-testid={`input-${inname}`} value={value} onChange={onChange} />
+  default: ({ value, onChange, inname, readonly }: any) => (
+    <input
+      data-testid={`input-${inname}`}
+      value={value}
+      onChange={onChange ?? (() => {})}
+      readOnly={readonly}
+    />
   ),
 }));
 

--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/TreatmentStep.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/TreatmentStep.test.tsx
@@ -8,6 +8,7 @@ import { useInventoryStore } from '@/app/stores/inventoryStore';
 import { useRevampCatalogStore } from '@/app/stores/revampCatalogStore';
 import type { InventoryItem } from '@/app/features/inventory/pages/Inventory/types';
 import { savePrescriptionArtifact } from '@/app/features/appointments/services/workspaceClinicalService';
+import { finalizePrescription } from '@/app/features/appointments/services/prescriptionWorkflowService';
 import {
   applyInpatientScheduleTemplate,
   createWorkspaceTemplateInstance,
@@ -33,6 +34,10 @@ jest.mock('@/app/features/appointments/services/workspaceAggregateService', () =
 
 jest.mock('@/app/features/appointments/services/workspaceClinicalService', () => ({
   savePrescriptionArtifact: jest.fn().mockResolvedValue({ resourceType: 'MedicationRequest' }),
+}));
+
+jest.mock('@/app/features/appointments/services/prescriptionWorkflowService', () => ({
+  finalizePrescription: jest.fn().mockResolvedValue({}),
 }));
 
 jest.mock('@/app/features/appointments/services/workspaceTemplateService', () => ({
@@ -297,6 +302,8 @@ describe('TreatmentStep', () => {
     (savePrescriptionArtifact as jest.Mock).mockResolvedValue({
       resourceType: 'MedicationRequest',
     });
+    (finalizePrescription as jest.Mock).mockClear();
+    (finalizePrescription as jest.Mock).mockResolvedValue({});
     (applyInpatientScheduleTemplate as jest.Mock).mockClear();
     (createWorkspaceTemplateInstance as jest.Mock).mockClear();
     (listInpatientScheduleTemplates as jest.Mock).mockClear();
@@ -573,6 +580,8 @@ describe('TreatmentStep', () => {
     await waitFor(() => expect(onOpenInvoice).toHaveBeenCalled());
     expect(persistTreatmentItems).toHaveBeenCalledWith(ORG, 'enc-1', enc.services);
     expect(getAppointmentWorkspaceBootstrap).toHaveBeenCalledWith(ORG, APPT);
+    expect(finalizePrescription).toHaveBeenCalledWith(ORG, 'rx-1');
+    expect(finalizePrescription).toHaveBeenCalledWith(ORG, 'rx-2');
     expect(useAppointmentWorkspaceStore.getState().getEncounter(APPT)?.stepStatus.TREATMENT).toBe(
       'COMPLETED'
     );

--- a/apps/frontend/src/app/__tests__/pages/Appointments/Sections/AppointmentInfo/AppointmentMerckSearch.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Appointments/Sections/AppointmentInfo/AppointmentMerckSearch.test.tsx
@@ -140,7 +140,10 @@ describe('AppointmentMerckSearch', () => {
     fireEvent.change(screen.getByLabelText('Search manuals'), { target: { value: 'fever' } });
     fireEvent.click(screen.getByRole('button', { name: 'Search' }));
 
-    await waitFor(() => expect(searchMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => {
+      expect(searchMock).toHaveBeenCalledTimes(1);
+      expect(screen.getByText('Canine Fever')).toBeInTheDocument();
+    });
     expect(searchMock).toHaveBeenCalledWith(
       expect.objectContaining({
         organisationId: 'org-1',

--- a/apps/frontend/src/app/__tests__/pages/Inventory/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Inventory/index.test.tsx
@@ -21,6 +21,15 @@ jest.mock('next/dynamic', () => ({
         return <MockInventoryTable {...props} />;
       }
 
+      if (source.includes('ui/tables/DispensaryTable')) {
+        const MockDispensaryTable = (
+          jest.requireMock('@/app/ui/tables/DispensaryTable') as {
+            default: React.FC<Record<string, unknown>>;
+          }
+        ).default;
+        return <MockDispensaryTable {...props} />;
+      }
+
       if (source.includes('ui/tables/InventoryTurnoverTable')) {
         const MockInventoryTurnoverTable = (
           jest.requireMock('@/app/ui/tables/InventoryTurnoverTable') as {
@@ -126,6 +135,25 @@ jest.mock('@/app/ui/filters/InventoryFilters', () => ({
 jest.mock('@/app/ui/filters/InventoryTurnoverFilters', () => ({
   __esModule: true,
   default: () => <div data-testid="turnover-filters" />,
+}));
+
+jest.mock('@/app/ui/tables/DispensaryTable', () => ({
+  __esModule: true,
+  default: () => <div data-testid="dispensary-table" />,
+}));
+
+jest.mock('@/app/features/inventory/components/DispensaryDetailModal', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('@/app/features/inventory/services/dispensaryService', () => ({
+  listDispenseRequests: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('@/app/features/appointments/services/prescriptionWorkflowService', () => ({
+  dispensePrescription: jest.fn().mockResolvedValue({}),
+  finalizePrescription: jest.fn().mockResolvedValue({}),
 }));
 
 // Mock Tables
@@ -332,18 +360,16 @@ describe('Inventory Page', () => {
     render(<ProtectedInventory />);
 
     expect(screen.getByRole('button', { name: 'Inventory info' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Turnover' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Dispensary' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Filter' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Sort by' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Add item' })).toBeInTheDocument();
     expect(screen.getByTestId('inventory-table')).toBeInTheDocument();
-    expect(screen.queryByTestId('turnover-filters')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('turnover-table')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('dispensary-table')).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Turnover' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Dispensary' }));
 
-    expect(screen.getByTestId('turnover-filters')).toBeInTheDocument();
-    expect(screen.getByTestId('turnover-table')).toBeInTheDocument();
+    expect(screen.getByTestId('dispensary-table')).toBeInTheDocument();
     expect(screen.queryByTestId('inventory-table')).not.toBeInTheDocument();
   });
 
@@ -413,6 +439,7 @@ describe('Inventory Page', () => {
     render(<ProtectedInventory />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Filter' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Category' }));
     fireEvent.click(screen.getByRole('checkbox', { name: 'Medicine' }));
     fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
 
@@ -426,16 +453,15 @@ describe('Inventory Page', () => {
     render(<ProtectedInventory />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Filter' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Category' }));
     fireEvent.click(screen.getByRole('checkbox', { name: 'Medicine' }));
 
-    const removeChip = screen.getByRole('button', { name: 'Remove Medicine filter' });
+    const removeChip = screen.getByRole('button', { name: 'Remove Medicine' });
     expect(removeChip).toBeInTheDocument();
 
     fireEvent.click(removeChip);
 
-    expect(
-      screen.queryByRole('button', { name: 'Remove Medicine filter' })
-    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Remove Medicine' })).not.toBeInTheDocument();
     expect((screen.getByRole('checkbox', { name: 'Medicine' }) as HTMLInputElement).checked).toBe(
       false
     );
@@ -444,9 +470,8 @@ describe('Inventory Page', () => {
   it('filters inventory by status', async () => {
     render(<ProtectedInventory />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Filter' }));
-    fireEvent.click(screen.getByRole('radio', { name: 'Visible' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Active' }));
+
     await waitFor(() => {
       expect(screen.getByTestId('item-1')).toBeInTheDocument();
       expect(screen.queryByTestId('item-2')).not.toBeInTheDocument();

--- a/apps/frontend/src/app/__tests__/pages/Inventory/utils.test.ts
+++ b/apps/frontend/src/app/__tests__/pages/Inventory/utils.test.ts
@@ -188,9 +188,9 @@ describe('Inventory Utils', () => {
         borderColor: 'var(--color-pill-warning-border)',
       });
       expect(getStatusBadgeStyle('Out of Stock')).toEqual({
-        color: 'var(--color-pill-warning-text)',
-        backgroundColor: 'var(--color-pill-warning-bg)',
-        borderColor: 'var(--color-pill-warning-border)',
+        color: 'var(--color-pill-neutral-text)',
+        backgroundColor: 'var(--color-pill-neutral-bg)',
+        borderColor: 'var(--color-pill-neutral-border)',
       });
       // hidden
       expect(getStatusBadgeStyle('Hidden')).toEqual({
@@ -257,6 +257,36 @@ describe('Inventory Utils', () => {
       expect(result.status).toBe('ACTIVE');
     });
 
+    it('hydrates backend top-level clinical and stock fields for edit flow', () => {
+      const result = mapApiItemToInventoryItem({
+        ...mockApiItem,
+        itemType: 'NON_MEDICAL',
+        genericName: 'Amoxicillin',
+        strength: '250 mg',
+        dosageForm: 'Tablet',
+        routeOfAdministration: 'Oral',
+        prescriptionRequired: true,
+        controlledItem: false,
+        storageInstructions: 'Keep refrigerated',
+        unitOfMeasure: 'Tablet',
+        storageLocation: 'Pharmacy shelf',
+        minimumStock: 12,
+      });
+
+      expect(result.basicInfo.itemType).toBe('Non-drug');
+      expect(result.classification.itemType).toBe('Non-drug');
+      expect(result.classification.genericName).toBe('Amoxicillin');
+      expect(result.classification.strength).toBe('250 mg');
+      expect(result.classification.dosageForm).toBe('Tablet');
+      expect(result.classification.administration).toBe('Oral');
+      expect(result.classification.prescriptionRequired).toBe('true');
+      expect(result.classification.controlledSubstance).toBe('false');
+      expect(result.classification.storageCondition).toBe('Keep refrigerated');
+      expect(result.classification.unitofMeasure).toBe('Tablet');
+      expect(result.stock.stockLocation).toBe('Pharmacy shelf');
+      expect(result.stock.minStockAlert).toBe('12');
+    });
+
     it('normalizes status correctly (Hidden case)', () => {
       const item = { ...mockApiItem, status: 'HIDDEN' };
       const result = mapApiItemToInventoryItem(item);
@@ -311,6 +341,23 @@ describe('Inventory Utils', () => {
       // Totals calculation check
       // 5 + 10 = 15
       expect(result.stock.current).toBe('15');
+    });
+
+    it('rehydrates saved batch display fields from attributes', () => {
+      const result = mapApiItemToInventoryItem({
+        ...mockApiItem,
+        attributes: {
+          ...mockApiItem.attributes,
+          expiryWarningBefore: '30 days',
+          barcode: 'BAR-123',
+        },
+        batches: [{ _id: 'b1', batchNumber: 'BATCH-1', quantity: 10 }],
+      } as unknown as InventoryApiItem);
+
+      expect(result.batch.expiryWarningBefore).toBe('30 days');
+      expect(result.batch.barcode).toBe('BAR-123');
+      expect(result.batches?.[0].expiryWarningBefore).toBe('30 days');
+      expect(result.batches?.[0].barcode).toBe('BAR-123');
     });
 
     it('selects first batch if no expiry dates provided', () => {
@@ -505,16 +552,25 @@ describe('Inventory Utils', () => {
     } as InventoryItem;
 
     describe('buildBatchPayload', () => {
-      it('normalizes Slash dates to ISO YYYY-MM-DD', () => {
+      it('normalizes slash dates to full ISO datetimes', () => {
         const batch = { ...mockInventoryItem.batches![0] };
         const payload = buildBatchPayload(batch);
-        expect(payload?.expiryDate).toBe('2025-12-31');
+        expect(payload?.expiryDate).toBe('2025-12-31T00:00:00.000Z');
       });
 
-      it('keeps ISO dates as YYYY-MM-DD', () => {
+      it('normalizes plain ISO calendar dates to full ISO datetimes', () => {
         const batch = { ...mockInventoryItem.batches![1] };
         const payload = buildBatchPayload(batch);
-        expect(payload?.expiryDate).toBe('2026-01-01');
+        expect(payload?.expiryDate).toBe('2026-01-01T00:00:00.000Z');
+      });
+
+      it('preserves full ISO datetime values', () => {
+        const batch = {
+          ...mockInventoryItem.batches![1],
+          expiryDate: '2026-01-01T05:30:00.000Z',
+        };
+        const payload = buildBatchPayload(batch);
+        expect(payload?.expiryDate).toBe('2026-01-01T05:30:00.000Z');
       });
 
       it('falls back to current/available for quantity if quantity field missing', () => {
@@ -564,6 +620,61 @@ describe('Inventory Utils', () => {
         // Check attributes cleaning
         expect(payload.attributes?.stockLocation).toBe('Loc A');
         expect(payload.attributes?.species).toEqual(['Dog']);
+      });
+
+      it('maps medical clinical fields to top-level API keys', () => {
+        const payload = buildInventoryPayload(
+          {
+            ...mockInventoryItem,
+            classification: {
+              ...mockInventoryItem.classification,
+              genericName: 'Amoxicillin',
+              form: 'Tablet',
+              strength: '250 mg',
+              administration: 'Oral',
+            },
+          },
+          'org-1',
+          'HOSPITAL' as BusinessType
+        );
+
+        expect(payload.genericName).toBe('Amoxicillin');
+        expect(payload.dosageForm).toBe('Tablet');
+        expect(payload.strength).toBe('250 mg');
+        expect(payload.routeOfAdministration).toBe('Oral');
+      });
+
+      it('maps inventory edit fields to backend-owned top-level columns', () => {
+        const payload = buildInventoryPayload(
+          {
+            ...mockInventoryItem,
+            classification: {
+              ...mockInventoryItem.classification,
+              itemType: 'Non-drug',
+              unitofMeasure: ['Tablet'],
+              prescriptionRequired: 'true',
+              controlledSubstance: 'false',
+              storageCondition: 'Cool and dry',
+              packSize: '24',
+            },
+            stock: {
+              ...mockInventoryItem.stock,
+              stockLocation: 'Cabinet A',
+              minStockAlert: '5',
+            },
+          },
+          'org-1',
+          'HOSPITAL' as BusinessType
+        );
+
+        expect(payload.itemType).toBe('NON_MEDICAL');
+        expect(payload.unitOfMeasure).toBe('Tablet');
+        expect(payload.prescriptionRequired).toBe(true);
+        expect(payload.controlledItem).toBe(false);
+        expect(payload.storageInstructions).toBe('Cool and dry');
+        expect(payload.packageQuantity).toBe(24);
+        expect(payload.storageLocation).toBe('Cabinet A');
+        expect(payload.minimumStock).toBe(5);
       });
 
       it('uses single batch from formData.batch if formData.batches is empty', () => {

--- a/apps/frontend/src/app/__tests__/pages/Specialities/PackagesTab.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Specialities/PackagesTab.test.tsx
@@ -284,13 +284,13 @@ describe('PackagesTab', () => {
     fireEvent.click(archiveButtons[0]);
     fireEvent.click(screen.getByRole('button', { name: 'Archive' }));
     expect(mockArchivePackage).toHaveBeenCalledWith('pkg-1');
-    await waitFor(() =>
+    await waitFor(() => {
       expect(mockNotify).toHaveBeenCalledWith(
         'success',
         expect.objectContaining({ title: 'Package archived' })
-      )
-    );
-    expect(screen.queryByTestId('center-modal')).not.toBeInTheDocument();
+      );
+      expect(screen.queryByTestId('center-modal')).not.toBeInTheDocument();
+    });
   });
 
   it('closes delete modal via modal header close button', () => {

--- a/apps/frontend/src/app/__tests__/utils/urls.test.ts
+++ b/apps/frontend/src/app/__tests__/utils/urls.test.ts
@@ -1,4 +1,4 @@
-import { isHttpsImageUrl, getSafeImageUrl } from '@/app/lib/urls';
+import { isHttpsImageUrl, getSafeImageUrl, getSafeOrgImageUrl } from '@/app/lib/urls';
 
 jest.mock('@/app/constants/mediaSources', () => ({
   MEDIA_SOURCES: {
@@ -8,6 +8,9 @@ jest.mock('@/app/constants/mediaSources', () => ({
       horse: 'https://cdn.example.com/avatars/horse.png',
       person: 'https://cdn.example.com/avatars/person.png',
       business: 'https://cdn.example.com/avatars/business.png',
+    },
+    organization: {
+      fromS3Key: (s3Key: string) => `https://org-cdn.example.com/${s3Key}`,
     },
   },
 }));
@@ -49,5 +52,26 @@ describe('getSafeImageUrl', () => {
     // 'other' type maps to dog avatar
     const result = getSafeImageUrl(null, 'other' as any);
     expect(result).toBe('https://cdn.example.com/avatars/dog.png');
+  });
+});
+
+describe('getSafeOrgImageUrl', () => {
+  it('returns https urls unchanged', () => {
+    expect(getSafeOrgImageUrl('https://example.com/item.png')).toBe('https://example.com/item.png');
+  });
+
+  it('converts inventory s3 keys into org cdn urls', () => {
+    expect(getSafeOrgImageUrl('inventory/org-1/item.png')).toBe(
+      'https://org-cdn.example.com/inventory/org-1/item.png'
+    );
+  });
+
+  it('allows blob previews when explicitly enabled', () => {
+    expect(getSafeOrgImageUrl('blob:test-preview', { allowBlob: true })).toBe('blob:test-preview');
+  });
+
+  it('rejects unsafe or empty values', () => {
+    expect(getSafeOrgImageUrl('javascript:alert(1)')).toBe('');
+    expect(getSafeOrgImageUrl('')).toBe('');
   });
 });

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/TreatmentStep.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/TreatmentStep.tsx
@@ -576,7 +576,9 @@ const TreatmentStep = ({
       return;
     }
     if (organisationId) {
-      const persistedPrescriptions = encounter.prescription.filter((rx) => rx.id);
+      const persistedPrescriptions = encounter.prescription.filter(
+        (rx) => rx.id && rx.fulfillment !== 'PRESCRIPTION_ONLY'
+      );
       await Promise.allSettled(
         persistedPrescriptions.map((rx) => finalizePrescription(organisationId, rx.id))
       );

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/TreatmentStep.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/TreatmentStep.tsx
@@ -11,12 +11,13 @@ import type {
   ScheduleTaskStatus,
 } from '@/app/features/appointments/types/workspace';
 import { savePrescriptionArtifact } from '@/app/features/appointments/services/workspaceClinicalService';
+import { finalizePrescription } from '@/app/features/appointments/services/prescriptionWorkflowService';
+import { fetchInventoryItems } from '@/app/features/inventory/services/inventoryService';
 import {
   getAppointmentWorkspaceBootstrap,
   normalizeWorkspaceBootstrapForEncounter,
   persistTreatmentItems,
 } from '@/app/features/appointments/services/workspaceAggregateService';
-import { fetchInventoryItems } from '@/app/features/inventory/services/inventoryService';
 import { mapApiItemToInventoryItem } from '@/app/features/inventory/pages/Inventory/utils';
 import { inventoryToPrescriptionItem } from '@/app/features/appointments/lib/inventoryPrescription';
 import { useInventoryStore } from '@/app/stores/inventoryStore';
@@ -573,6 +574,12 @@ const TreatmentStep = ({
       setTreatmentSaveError('Unable to save treatment items. Please try again.');
       setIsSavingTreatment(false);
       return;
+    }
+    if (organisationId) {
+      const persistedPrescriptions = encounter.prescription.filter((rx) => rx.id);
+      await Promise.allSettled(
+        persistedPrescriptions.map((rx) => finalizePrescription(organisationId, rx.id))
+      );
     }
     setStepStatus(appointmentId, 'TREATMENT', 'COMPLETED');
     setIsSavingTreatment(false);

--- a/apps/frontend/src/app/features/appointments/services/prescriptionWorkflowService.ts
+++ b/apps/frontend/src/app/features/appointments/services/prescriptionWorkflowService.ts
@@ -6,7 +6,7 @@ export type PrescriptionWorkflowResult = Record<string, unknown>;
 const prescriptionAction = async (
   organisationId: string,
   prescriptionId: string,
-  action: '$reserve' | '$dispense' | '$return' | '$void-dispense',
+  action: '$reserve' | '$dispense' | '$return' | '$void-dispense' | '$not-dispensed' | '$finalize',
   body: PrescriptionWorkflowBody = {}
 ) => {
   const res = await postData<PrescriptionWorkflowResult>(
@@ -39,3 +39,15 @@ export const voidPrescriptionDispense = (
   prescriptionId: string,
   body: PrescriptionWorkflowBody = {}
 ) => prescriptionAction(organisationId, prescriptionId, '$void-dispense', body);
+
+export const notDispensedPrescription = (
+  organisationId: string,
+  prescriptionId: string,
+  body: PrescriptionWorkflowBody = {}
+) => prescriptionAction(organisationId, prescriptionId, '$not-dispensed', body);
+
+export const finalizePrescription = (
+  organisationId: string,
+  prescriptionId: string,
+  body: PrescriptionWorkflowBody = {}
+) => prescriptionAction(organisationId, prescriptionId, '$finalize', body);

--- a/apps/frontend/src/app/features/inventory/components/AddInventory/FormSection.tsx
+++ b/apps/frontend/src/app/features/inventory/components/AddInventory/FormSection.tsx
@@ -7,7 +7,7 @@ import MultiSelectDropdown from '@/app/ui/inputs/MultiSelectDropdown';
 import FormDesc from '@/app/ui/inputs/FormDesc/FormDesc';
 import Datepicker from '@/app/ui/inputs/Datepicker';
 import { BusinessType } from '@/app/features/organization/types/org';
-import { RiUploadCloud2Fill } from 'react-icons/ri';
+import ImageUploadField from '@/app/features/inventory/components/AddInventory/ImageUploadField';
 
 import {
   InventoryItem,
@@ -77,6 +77,7 @@ type FormSectionProps = {
   onRemoveBatch?: (index: number) => void;
   stockLocationOptions?: string[];
   headerSlot?: React.ReactNode;
+  organisationId?: string;
 };
 
 const PricingSummary = ({ formData }: { formData: InventoryItem }) => (
@@ -129,6 +130,7 @@ const FormSection: React.FC<FormSectionProps> = ({
   onRemoveBatch,
   stockLocationOptions,
   headerSlot,
+  organisationId,
 }) => {
   const configForBusiness = InventoryFormConfig[businessType] ?? {};
   const sectionConfig = configForBusiness[sectionKey];
@@ -329,31 +331,13 @@ const FormSection: React.FC<FormSectionProps> = ({
 
     if (component === 'upload') {
       return (
-        <div key={key ?? field.name} className="relative">
-          <div className="mb-1 px-4 text-caption-1 text-text-secondary">{placeholder}</div>
-          <button
-            type="button"
-            className="flex min-h-35 w-full flex-col items-center justify-center rounded-2xl border border-input-border-default bg-white px-4 py-5 text-center text-text-primary"
-            onClick={() => document.getElementById(`inventory-upload-${field.name}`)?.click()}
-          >
-            <RiUploadCloud2Fill size={34} className="text-blue-text" aria-hidden="true" />
-            <span className="mt-2 text-body-4-emphasis">Upload document</span>
-            <span className="text-caption-1 text-text-secondary">PNG, JPG, WebP</span>
-            <span className="text-caption-1 text-text-secondary">Max size 2mb</span>
-          </button>
-          <input
-            id={`inventory-upload-${field.name}`}
-            type="file"
-            className="hidden"
-            aria-label={placeholder || 'Upload inventory image'}
-            accept="image/png,image/jpeg,image/webp"
-            onChange={(event) => {
-              const file = event.target.files?.[0];
-              if (!file) return;
-              handleChange(field, URL.createObjectURL(file), index);
-            }}
-          />
-        </div>
+        <ImageUploadField
+          key={key ?? field.name}
+          label={placeholder}
+          value={value}
+          organisationId={organisationId}
+          onChange={(url) => handleChange(field, url, index)}
+        />
       );
     }
 

--- a/apps/frontend/src/app/features/inventory/components/AddInventory/ImageUploadField.tsx
+++ b/apps/frontend/src/app/features/inventory/components/AddInventory/ImageUploadField.tsx
@@ -1,0 +1,133 @@
+'use client';
+import React, { useEffect, useId, useState } from 'react';
+import Image from 'next/image';
+import { RiUploadCloud2Fill } from 'react-icons/ri';
+import { FiX } from 'react-icons/fi';
+import {
+  getInventoryItemImagePresignedUrl,
+  uploadFileToS3,
+} from '@/app/features/inventory/services/inventoryUploadService';
+import { getSafeOrgImageUrl } from '@/app/lib/urls';
+
+type Props = {
+  label?: string;
+  value: string;
+  organisationId?: string;
+  onChange: (url: string) => void;
+};
+
+const ImageUploadField = ({ label, value, organisationId, onChange }: Props) => {
+  const inputId = useId();
+  const [preview, setPreview] = useState<string | null>(null);
+  const [isUploading, setIsUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (preview?.startsWith('blob:')) URL.revokeObjectURL(preview);
+    };
+  }, [preview]);
+
+  const displayUrl = preview ?? getSafeOrgImageUrl(value);
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = '';
+    if (!file) return;
+
+    setError(null);
+
+    if (!organisationId) {
+      setError('Organisation not loaded. Please try again.');
+      return;
+    }
+
+    const localPreview = URL.createObjectURL(file);
+    setPreview(localPreview);
+    setIsUploading(true);
+
+    try {
+      const { uploadUrl, s3Key } = await getInventoryItemImagePresignedUrl(
+        organisationId,
+        file.type
+      );
+      await uploadFileToS3(uploadUrl, file);
+      onChange(s3Key);
+      URL.revokeObjectURL(localPreview);
+      setPreview(null);
+    } catch {
+      setError('Upload failed. Please try again.');
+      URL.revokeObjectURL(localPreview);
+      setPreview(null);
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const handleRemove = () => {
+    if (preview?.startsWith('blob:')) URL.revokeObjectURL(preview);
+    setPreview(null);
+    setError(null);
+    onChange('');
+  };
+
+  return (
+    <div className="flex flex-col gap-1">
+      {label && <div className="px-4 text-caption-1 text-text-secondary">{label}</div>}
+
+      {displayUrl ? (
+        <div className="relative overflow-hidden rounded-2xl border border-input-border-default bg-white">
+          <Image
+            src={displayUrl}
+            alt="Product image"
+            width={400}
+            height={140}
+            unoptimized={displayUrl.startsWith('blob:')}
+            className="h-35 w-full object-cover"
+          />
+          {!isUploading && (
+            <button
+              type="button"
+              onClick={handleRemove}
+              aria-label="Remove image"
+              className="absolute right-2 top-2 flex size-7 items-center justify-center rounded-full bg-white/90 shadow hover:bg-white transition-colors"
+            >
+              <FiX size={14} />
+            </button>
+          )}
+          {isUploading && (
+            <div className="absolute inset-0 flex items-center justify-center bg-white/60">
+              <span className="text-body-4 text-text-secondary">Uploading…</span>
+            </div>
+          )}
+        </div>
+      ) : (
+        <button
+          type="button"
+          disabled={isUploading}
+          onClick={() => document.getElementById(inputId)?.click()}
+          className="flex min-h-35 w-full flex-col items-center justify-center rounded-2xl border border-input-border-default bg-white px-4 py-5 text-center text-text-primary disabled:opacity-60"
+        >
+          <RiUploadCloud2Fill size={34} className="text-blue-text" aria-hidden="true" />
+          <span className="mt-2 text-body-4-emphasis">
+            {isUploading ? 'Uploading…' : 'Upload image'}
+          </span>
+          <span className="text-caption-1 text-text-secondary">PNG, JPG, WebP · Max 2 MB</span>
+        </button>
+      )}
+
+      <input
+        id={inputId}
+        type="file"
+        className="hidden"
+        accept="image/png,image/jpeg,image/webp"
+        aria-label={label || 'Upload inventory image'}
+        onChange={handleFileChange}
+      />
+
+      {error && <div className="px-4 text-caption-1 text-red-600">{error}</div>}
+    </div>
+  );
+};
+
+export default ImageUploadField;

--- a/apps/frontend/src/app/features/inventory/components/AddInventory/InventoryConfig.tsx
+++ b/apps/frontend/src/app/features/inventory/components/AddInventory/InventoryConfig.tsx
@@ -58,6 +58,7 @@ export type FieldDef<S extends InventorySectionKey = InventorySectionKey> = {
   label?: string;
   component: FieldComponentType;
   options?: string[];
+  readonly?: boolean;
 };
 
 export type ConfigItem<S extends InventorySectionKey = InventorySectionKey> =
@@ -79,6 +80,16 @@ const field = <S extends InventorySectionKey>(
 const row = <S extends InventorySectionKey>(...fields: FieldDef<S>[]): ConfigItem<S> => ({
   kind: 'row',
   fields,
+});
+
+const readonlyField = <S extends InventorySectionKey>(
+  name: FieldNameForSection<S>,
+  placeholder: string,
+  component: FieldComponentType,
+  options?: string[]
+): ConfigItem<S> => ({
+  kind: 'field',
+  field: { name, placeholder, component, options, readonly: true },
 });
 
 const f = <S extends InventorySectionKey>(
@@ -114,7 +125,7 @@ const commonStockFields = (includesStockType: boolean = false): SectionConfig<'s
   ),
   field('abcClass', 'ABC Class', 'dropdown', AbcClassOptions),
   field('withdrawlPeriod', 'Withdrawal period (optional)', 'dropdown', WithdrawalPeriodOptions),
-  field('available', 'Available stock', 'text'),
+  readonlyField('available', 'Available stock', 'text'),
   ...(includesStockType
     ? [field<'stock'>('stockType', 'Stock type', 'dropdown', StockTypeOptions)]
     : []),
@@ -195,6 +206,7 @@ export const InventoryFormConfig: Record<
       },
     ],
     classification: [
+      field('genericName', 'Generic name', 'text'),
       {
         kind: 'row',
         fields: [

--- a/apps/frontend/src/app/features/inventory/components/AddInventory/index.tsx
+++ b/apps/frontend/src/app/features/inventory/components/AddInventory/index.tsx
@@ -146,6 +146,7 @@ type AddInventoryProps = {
   businessType: BusinessType;
   onSubmit: (data: InventoryItem) => Promise<void>;
   stockLocationOptions?: string[];
+  organisationId?: string;
 };
 
 const AddInventory = ({
@@ -154,6 +155,7 @@ const AddInventory = ({
   businessType,
   onSubmit,
   stockLocationOptions,
+  organisationId,
 }: AddInventoryProps) => {
   const [activeLabel, setActiveLabel] = useState<InventorySectionKey>(labels[0].key);
   const [formData, setFormData] = useState<InventoryItem>(emptyInventoryItem);
@@ -492,7 +494,7 @@ const AddInventory = ({
                       backgroundColor:
                         formData.basicInfo.visibleInInventory === false
                           ? 'var(--color-neutral-300)'
-                          : 'var(--color-success-bright)',
+                          : 'var(--color-blue-sky)',
                     }}
                   >
                     <span
@@ -566,6 +568,7 @@ const AddInventory = ({
               })
             }
             stockLocationOptions={stockLocationOptions}
+            organisationId={organisationId}
           />
         </div>
       </div>

--- a/apps/frontend/src/app/features/inventory/components/AddInventory/index.tsx
+++ b/apps/frontend/src/app/features/inventory/components/AddInventory/index.tsx
@@ -129,6 +129,7 @@ const logValidationFailure = (section: InventorySectionKey, details: Record<stri
 };
 
 const nonDrugClassificationDefaults = {
+  genericName: '',
   drugSchedule: '',
   form: '',
   administration: '',
@@ -280,6 +281,22 @@ const AddInventory = ({
     return errors;
   };
 
+  const validateClassification = (): Partial<
+    Record<keyof typeof formData.classification, string>
+  > => {
+    const classification = formData.classification;
+    const nextErrors: Partial<Record<keyof typeof formData.classification, string>> = {};
+    const isMedicalItem =
+      businessType === 'HOSPITAL' &&
+      String(classification.itemType ?? '').toLowerCase() !== 'non-drug';
+
+    if (isMedicalItem && !String(classification.genericName ?? '').trim()) {
+      nextErrors.genericName = 'Generic name is required';
+    }
+
+    return nextErrors;
+  };
+
   const validateSection = (section: InventorySectionKey): boolean => {
     const nextErrors: InventoryErrors = { ...errors };
     const updateStatus = (valid: boolean) => {
@@ -305,6 +322,14 @@ const AddInventory = ({
     }
 
     if (section === 'classification') {
+      const sectionErrors = validateClassification();
+      if (Object.keys(sectionErrors).length > 0) {
+        nextErrors.classification = sectionErrors;
+        setErrors(nextErrors);
+        logValidationFailure(section, sectionErrors as Record<string, string>);
+        updateStatus(false);
+        return false;
+      }
       delete nextErrors.classification;
       setErrors(nextErrors);
       updateStatus(true);

--- a/apps/frontend/src/app/features/inventory/components/DispensaryDetailModal.tsx
+++ b/apps/frontend/src/app/features/inventory/components/DispensaryDetailModal.tsx
@@ -54,6 +54,7 @@ const DispensaryDetailModal = ({
   onActionComplete,
 }: Props) => {
   const isDispensed = record.status === 'DISPENSED';
+  const isPending = record.status === 'PENDING';
   const items = record.items ?? [];
   const pendingCount = items.length;
   const [expandedIdx, setExpandedIdx] = useState<number | null>(null);
@@ -99,6 +100,44 @@ const DispensaryDetailModal = ({
       setActioning(false);
     }
   };
+
+  let footerContent: React.ReactNode = null;
+  if (isDispensed) {
+    footerContent = (
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={handlePrintLabel}
+          disabled={printing}
+          className="inline-flex h-11 items-center gap-2 rounded-2xl border border-text-primary bg-white px-5 text-body-4-emphasis text-text-primary hover:bg-card-hover transition-colors disabled:opacity-50"
+        >
+          <FiPrinter size={16} />
+          <span>{printing ? 'Loading…' : 'Label'}</span>
+        </button>
+      </div>
+    );
+  } else if (isPending) {
+    footerContent = (
+      <div className="flex items-center justify-between gap-3">
+        <button
+          type="button"
+          onClick={handleDispense}
+          disabled={actioning}
+          className="inline-flex h-11 items-center justify-center rounded-2xl bg-text-primary px-5 text-body-4-emphasis text-white hover:opacity-90 transition-opacity disabled:opacity-50"
+        >
+          Dispense all ({pendingCount})
+        </button>
+        <button
+          type="button"
+          onClick={handleNotDispensed}
+          disabled={actioning}
+          className="inline-flex h-11 items-center justify-center rounded-2xl border border-[var(--color-danger-600)] px-5 text-body-4-emphasis text-[var(--color-danger-600)] hover:bg-[var(--color-danger-100)] transition-colors disabled:opacity-50"
+        >
+          Not dispensed
+        </button>
+      </div>
+    );
+  }
 
   return (
     <Modal showModal={showModal} setShowModal={setShowModal}>
@@ -284,40 +323,7 @@ const DispensaryDetailModal = ({
         </div>
 
         {/* Footer */}
-        <div className="shrink-0 pt-5 mt-5 border-t border-card-border">
-          {isDispensed ? (
-            <div className="flex justify-end">
-              <button
-                type="button"
-                onClick={handlePrintLabel}
-                disabled={printing}
-                className="inline-flex h-11 items-center gap-2 rounded-2xl border border-text-primary bg-white px-5 text-body-4-emphasis text-text-primary hover:bg-card-hover transition-colors disabled:opacity-50"
-              >
-                <FiPrinter size={16} />
-                <span>{printing ? 'Loading…' : 'Label'}</span>
-              </button>
-            </div>
-          ) : (
-            <div className="flex items-center justify-between gap-3">
-              <button
-                type="button"
-                onClick={handleDispense}
-                disabled={actioning}
-                className="inline-flex h-11 items-center justify-center rounded-2xl bg-text-primary px-5 text-body-4-emphasis text-white hover:opacity-90 transition-opacity disabled:opacity-50"
-              >
-                Dispense all ({pendingCount})
-              </button>
-              <button
-                type="button"
-                onClick={handleNotDispensed}
-                disabled={actioning}
-                className="inline-flex h-11 items-center justify-center rounded-2xl border border-[var(--color-danger-600)] px-5 text-body-4-emphasis text-[var(--color-danger-600)] hover:bg-[var(--color-danger-100)] transition-colors disabled:opacity-50"
-              >
-                Not dispensed
-              </button>
-            </div>
-          )}
-        </div>
+        <div className="shrink-0 pt-5 mt-5 border-t border-card-border">{footerContent}</div>
       </div>
     </Modal>
   );

--- a/apps/frontend/src/app/features/inventory/components/DispensaryDetailModal.tsx
+++ b/apps/frontend/src/app/features/inventory/components/DispensaryDetailModal.tsx
@@ -1,0 +1,308 @@
+'use client';
+import React, { useState } from 'react';
+import Image from 'next/image';
+import { FiX, FiArrowRight, FiChevronDown, FiChevronUp } from 'react-icons/fi';
+import { FaCheckCircle } from 'react-icons/fa';
+import Modal from '@/app/ui/overlays/Modal';
+import { DispensaryRecord } from '@/app/features/inventory/pages/Inventory/types';
+import {
+  dispensePrescription,
+  notDispensedPrescription,
+} from '@/app/features/appointments/services/prescriptionWorkflowService';
+
+type Props = {
+  record: DispensaryRecord;
+  showModal: boolean;
+  setShowModal: React.Dispatch<React.SetStateAction<boolean>>;
+  organisationId: string;
+  onActionComplete: () => void;
+};
+
+const formatCents = (cents: number, currency?: string) => {
+  const upper = (currency ?? 'USD').toUpperCase();
+  const symbol = upper === 'USD' ? '$' : upper;
+  return `${symbol} ${(cents / 100).toFixed(2)}`;
+};
+
+const RequestTypeChip = ({ type }: { type: 'PATIENT' | 'IN_HOUSE' }) => (
+  <span className="inline-flex h-8 items-center rounded-full border px-4 text-body-4 border-blue-text bg-[var(--color-primary-100)] text-blue-text">
+    {type === 'PATIENT' ? 'Patient' : 'Inhouse'}
+  </span>
+);
+
+const PaymentBadge = ({ status }: { status?: 'PAID' | 'UNPAID' }) => {
+  if (!status) return null;
+  return (
+    <span
+      className={`inline-flex h-8 items-center rounded-full border px-4 text-body-4 ${
+        status === 'PAID'
+          ? 'border-[var(--color-pill-success-border)] bg-[var(--color-pill-success-bg)] text-[var(--color-pill-success-text)]'
+          : 'border-[var(--color-pill-warning-border)] bg-[var(--color-pill-warning-bg)] text-[var(--color-pill-warning-text)]'
+      }`}
+    >
+      {status === 'PAID' ? 'Paid' : 'Unpaid'}
+    </span>
+  );
+};
+
+const DispensaryDetailModal = ({
+  record,
+  showModal,
+  setShowModal,
+  organisationId,
+  onActionComplete,
+}: Props) => {
+  const isDispensed = record.status === 'DISPENSED';
+  const items = record.items ?? [];
+  const pendingCount = items.length;
+  const [expandedIdx, setExpandedIdx] = useState<number | null>(null);
+  const [actioning, setActioning] = useState(false);
+
+  const togglePrescription = (idx: number) => setExpandedIdx((prev) => (prev === idx ? null : idx));
+
+  const handleDispense = async () => {
+    if (actioning) return;
+    setActioning(true);
+    try {
+      await dispensePrescription(organisationId, record.prescriptionId);
+      setShowModal(false);
+      onActionComplete();
+    } finally {
+      setActioning(false);
+    }
+  };
+
+  const handleNotDispensed = async () => {
+    if (actioning) return;
+    setActioning(true);
+    try {
+      await notDispensedPrescription(organisationId, record.prescriptionId);
+      setShowModal(false);
+      onActionComplete();
+    } finally {
+      setActioning(false);
+    }
+  };
+
+  return (
+    <Modal showModal={showModal} setShowModal={setShowModal}>
+      <div className="flex h-full flex-col overflow-hidden">
+        {/* Header */}
+        <div className="flex items-center justify-between gap-3 pb-5 border-b border-card-border shrink-0">
+          <div className="flex items-center gap-2">
+            <h2 className="text-xl font-bold text-text-primary">
+              {isDispensed ? 'Dispensed request' : 'Dispense request'}
+            </h2>
+            {isDispensed && (
+              <FaCheckCircle size={20} className="text-[var(--color-success-600)] shrink-0" />
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            <RequestTypeChip type={record.requestType} />
+            <button
+              type="button"
+              onClick={() => setShowModal(false)}
+              aria-label="Close"
+              className="inline-flex size-8 items-center justify-center rounded-full text-text-secondary hover:bg-card-hover transition-colors"
+            >
+              <FiX size={18} />
+            </button>
+          </div>
+        </div>
+
+        {/* Scrollable body */}
+        <div className="flex flex-1 flex-col gap-5 overflow-y-auto pt-5 pr-1">
+          {/* Patient info */}
+          <div className="flex items-start gap-3">
+            <div className="flex size-12 shrink-0 items-center justify-center overflow-hidden rounded-full bg-card-hover">
+              {record.patient.imageUrl ? (
+                <Image
+                  src={record.patient.imageUrl}
+                  alt=""
+                  width={48}
+                  height={48}
+                  className="size-full object-cover"
+                />
+              ) : (
+                <span className="text-body-3-emphasis text-text-secondary">
+                  {record.patient.name === '—' ? '?' : record.patient.name.charAt(0)}
+                </span>
+              )}
+            </div>
+            <div className="flex flex-1 items-start justify-between gap-3 min-w-0">
+              <div className="min-w-0">
+                <div className="text-body-3-emphasis text-text-primary">{record.patient.name}</div>
+                {record.patient.petBreed && (
+                  <div className="text-body-4 text-text-secondary">{record.patient.petBreed}</div>
+                )}
+                {record.patient.petAge && (
+                  <div className="text-body-4 text-text-secondary">{record.patient.petAge}</div>
+                )}
+              </div>
+              <div className="flex gap-4 text-caption-1 shrink-0">
+                {record.patient.appointmentId !== '—' && (
+                  <div className="max-w-[110px]">
+                    <div className="text-text-secondary">Appointment ID</div>
+                    <div className="text-text-primary font-semibold truncate">
+                      {record.patient.appointmentId}
+                    </div>
+                  </div>
+                )}
+                {record.invoiceId && (
+                  <div className="max-w-[110px]">
+                    <div className="text-text-secondary">Invoice ID</div>
+                    <div className="text-text-primary font-semibold truncate">
+                      {record.invoiceId}
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* Doctor + payment */}
+          <div className="flex items-center justify-between">
+            <div className="inline-flex h-10 items-center gap-2 rounded-2xl border border-card-border bg-[var(--color-neutral-100,#f3f4f6)] px-4 text-body-4 text-text-primary">
+              <span>{record.lead || '—'}</span>
+              {record.lead && record.lead !== '—' && (
+                <FiChevronDown size={14} className="text-text-secondary shrink-0" />
+              )}
+            </div>
+            <PaymentBadge status={record.paymentStatus} />
+          </div>
+
+          {/* Items list */}
+          {items.length > 0 ? (
+            <div className="flex flex-col divide-y divide-card-border">
+              {items.map((item, idx) => {
+                const isExpanded = expandedIdx === idx;
+                const hasPrescription = !!item.prescription;
+                return (
+                  <div key={item.name} className="flex flex-col gap-2 py-3 first:pt-0 last:pb-0">
+                    <button
+                      type="button"
+                      onClick={() => hasPrescription && togglePrescription(idx)}
+                      className={`flex w-full items-center gap-2 text-left ${hasPrescription ? 'cursor-pointer' : 'cursor-default'}`}
+                    >
+                      <span className="text-body-4 text-text-secondary shrink-0">{idx + 1}.</span>
+                      <div className="flex flex-1 items-center gap-2 min-w-0">
+                        <span className="text-body-4 text-text-primary font-semibold truncate">
+                          {item.name}
+                        </span>
+                        {item.isRx && (
+                          <span className="inline-flex size-6 items-center justify-center rounded-full bg-blue-text text-white text-[10px] font-bold shrink-0">
+                            Rx
+                          </span>
+                        )}
+                        {item.isControlled && (
+                          <span className="inline-flex items-center rounded-full border border-card-border bg-[var(--color-neutral-100,#f3f4f6)] px-2 py-0.5 text-caption-1 text-text-secondary shrink-0">
+                            Controlled
+                          </span>
+                        )}
+                      </div>
+                      <span className="text-body-4 font-semibold text-[var(--color-success-600)] shrink-0">
+                        {item.quantity}
+                      </span>
+                      <span className="inline-flex items-center rounded-full bg-[var(--color-primary-100)] px-3 py-0.5 text-body-4-emphasis text-blue-text shrink-0">
+                        {formatCents(item.priceCents, record.currency)}
+                      </span>
+                      {hasPrescription && (
+                        <span className="text-text-secondary shrink-0">
+                          {isExpanded ? <FiChevronUp size={14} /> : <FiChevronDown size={14} />}
+                        </span>
+                      )}
+                    </button>
+                    {hasPrescription && isExpanded && (
+                      <div className="ml-5 rounded-xl border border-card-border bg-[var(--color-neutral-50,#f9fafb)] p-3">
+                        <div className="text-caption-1 text-text-secondary mb-2">Prescription:</div>
+                        <div className="flex flex-wrap gap-x-6 gap-y-1 text-caption-1 text-text-primary">
+                          {item.prescription!.dose && (
+                            <span>
+                              <span className="text-text-secondary">Dose </span>
+                              {item.prescription!.dose}
+                            </span>
+                          )}
+                          {item.prescription!.route && (
+                            <span>
+                              <span className="text-text-secondary">Route </span>
+                              {item.prescription!.route}
+                            </span>
+                          )}
+                          {item.prescription!.freq && (
+                            <span>
+                              <span className="text-text-secondary">Freq. </span>
+                              {item.prescription!.freq}
+                            </span>
+                          )}
+                          {item.prescription!.duration && (
+                            <span>
+                              <span className="text-text-secondary">Duration </span>
+                              {item.prescription!.duration}
+                            </span>
+                          )}
+                          {item.prescription!.refill && (
+                            <span>
+                              <span className="text-text-secondary">Refill </span>
+                              {item.prescription!.refill}
+                            </span>
+                          )}
+                          {!item.prescription!.dose &&
+                            !item.prescription!.route &&
+                            !item.prescription!.freq && (
+                              <span className="text-text-secondary">
+                                No prescription details available
+                              </span>
+                            )}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <div className="py-4 text-center text-body-4 text-text-secondary">
+              No items recorded
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="shrink-0 pt-5 mt-5 border-t border-card-border">
+          {isDispensed ? (
+            <div className="flex justify-end">
+              <button
+                type="button"
+                className="inline-flex h-11 items-center gap-2 rounded-2xl border border-text-primary bg-white px-5 text-body-4-emphasis text-text-primary hover:bg-card-hover transition-colors"
+              >
+                <span>Prescription</span>
+                <FiArrowRight size={16} />
+              </button>
+            </div>
+          ) : (
+            <div className="flex items-center justify-between gap-3">
+              <button
+                type="button"
+                onClick={handleDispense}
+                disabled={actioning}
+                className="inline-flex h-11 items-center justify-center rounded-2xl bg-text-primary px-5 text-body-4-emphasis text-white hover:opacity-90 transition-opacity disabled:opacity-50"
+              >
+                Dispense all ({pendingCount})
+              </button>
+              <button
+                type="button"
+                onClick={handleNotDispensed}
+                disabled={actioning}
+                className="inline-flex h-11 items-center justify-center rounded-2xl border border-[var(--color-danger-600)] px-5 text-body-4-emphasis text-[var(--color-danger-600)] hover:bg-[var(--color-danger-100)] transition-colors disabled:opacity-50"
+              >
+                Not dispensed
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default DispensaryDetailModal;

--- a/apps/frontend/src/app/features/inventory/components/DispensaryDetailModal.tsx
+++ b/apps/frontend/src/app/features/inventory/components/DispensaryDetailModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 import React, { useState } from 'react';
 import Image from 'next/image';
-import { FiX, FiArrowRight, FiChevronDown, FiChevronUp } from 'react-icons/fi';
+import { FiX, FiChevronDown, FiChevronUp, FiPrinter } from 'react-icons/fi';
 import { FaCheckCircle } from 'react-icons/fa';
 import Modal from '@/app/ui/overlays/Modal';
 import { DispensaryRecord } from '@/app/features/inventory/pages/Inventory/types';
@@ -9,6 +9,7 @@ import {
   dispensePrescription,
   notDispensedPrescription,
 } from '@/app/features/appointments/services/prescriptionWorkflowService';
+import { fetchPrescriptionLabelPdf } from '@/app/features/inventory/services/dispensaryService';
 
 type Props = {
   record: DispensaryRecord;
@@ -57,6 +58,7 @@ const DispensaryDetailModal = ({
   const pendingCount = items.length;
   const [expandedIdx, setExpandedIdx] = useState<number | null>(null);
   const [actioning, setActioning] = useState(false);
+  const [printing, setPrinting] = useState(false);
 
   const togglePrescription = (idx: number) => setExpandedIdx((prev) => (prev === idx ? null : idx));
 
@@ -69,6 +71,20 @@ const DispensaryDetailModal = ({
       onActionComplete();
     } finally {
       setActioning(false);
+    }
+  };
+
+  const handlePrintLabel = async () => {
+    if (printing) return;
+    setPrinting(true);
+    try {
+      const blob = await fetchPrescriptionLabelPdf(organisationId, record.prescriptionId);
+      const url = URL.createObjectURL(blob);
+      const win = window.open(url, '_blank');
+      if (win) win.focus();
+      setTimeout(() => URL.revokeObjectURL(url), 60_000);
+    } finally {
+      setPrinting(false);
     }
   };
 
@@ -273,10 +289,12 @@ const DispensaryDetailModal = ({
             <div className="flex justify-end">
               <button
                 type="button"
-                className="inline-flex h-11 items-center gap-2 rounded-2xl border border-text-primary bg-white px-5 text-body-4-emphasis text-text-primary hover:bg-card-hover transition-colors"
+                onClick={handlePrintLabel}
+                disabled={printing}
+                className="inline-flex h-11 items-center gap-2 rounded-2xl border border-text-primary bg-white px-5 text-body-4-emphasis text-text-primary hover:bg-card-hover transition-colors disabled:opacity-50"
               >
-                <span>Prescription</span>
-                <FiArrowRight size={16} />
+                <FiPrinter size={16} />
+                <span>{printing ? 'Loading…' : 'Label'}</span>
               </button>
             </div>
           ) : (

--- a/apps/frontend/src/app/features/inventory/components/InfoSection.tsx
+++ b/apps/frontend/src/app/features/inventory/components/InfoSection.tsx
@@ -1,5 +1,7 @@
+'use client';
 import React from 'react';
 import EditableAccordion from '@/app/ui/primitives/Accordion/EditableAccordion';
+import ImageUploadField from '@/app/features/inventory/components/AddInventory/ImageUploadField';
 
 import { InventoryItem } from '@/app/features/inventory/pages/Inventory/types';
 import { BusinessType } from '@/app/features/organization/types/org';
@@ -27,6 +29,7 @@ type InfoSectionProps = {
     } | null
   ) => void;
   stockLocationOptions?: string[];
+  organisationId?: string;
 };
 
 type EditableField = {
@@ -47,6 +50,7 @@ const InfoSection: React.FC<InfoSectionProps> = ({
   onEditingChange,
   onRegisterActions,
   stockLocationOptions,
+  organisationId,
 }) => {
   const configForBusiness = InventoryFormConfig[businessType] || {};
   const sectionConfig = configForBusiness[sectionKey];
@@ -60,6 +64,22 @@ const InfoSection: React.FC<InfoSectionProps> = ({
   }
 
   const data = inventory[sectionKey] as any;
+
+  const flattenFields = (cfg: ConfigItem<any>[]): FieldDef<any>[] => {
+    const result: FieldDef<any>[] = [];
+    for (const item of cfg) {
+      if (item.kind === 'row') {
+        for (const f of item.fields) result.push(f);
+      } else {
+        result.push(item.field);
+      }
+    }
+    return result;
+  };
+
+  const allFields = flattenFields(sectionConfig);
+  const uploadFields = allFields.filter((f) => f.component === 'upload');
+  const nonUploadFields = allFields.filter((f) => f.component !== 'upload');
 
   const toEditableField = (field: FieldDef<any>): EditableField => {
     const label = field.label || field.placeholder || field.name;
@@ -95,38 +115,43 @@ const InfoSection: React.FC<InfoSectionProps> = ({
     };
   };
 
-  const flattenConfigToFields = (cfg: ConfigItem<any>[]): EditableField[] => {
-    const result: EditableField[] = [];
-    for (const item of cfg) {
-      if (item.kind === 'row') {
-        for (const f of item.fields) {
-          result.push(toEditableField(f));
-        }
-      } else {
-        result.push(toEditableField(item.field));
-      }
-    }
-    return result;
-  };
-
-  const fields = flattenConfigToFields(sectionConfig);
+  const accordionFields = nonUploadFields.map(toEditableField);
 
   return (
-    <div className="flex flex-col gap-6 w-full">
+    <div className="flex flex-col gap-4 w-full">
       <div className="font-satoshi text-black-text text-[23px] font-medium">{sectionTitle}</div>
 
-      <EditableAccordion
-        title={sectionTitle}
-        fields={fields}
-        data={data}
-        defaultOpen={true}
-        readOnly={disableEditing}
-        showEditIcon={!disableEditing}
-        onSave={(values) => onSaveSection?.(sectionKey, values)}
-        hideInlineActions
-        onEditingChange={onEditingChange}
-        onRegisterActions={onRegisterActions}
-      />
+      {accordionFields.length > 0 && (
+        <EditableAccordion
+          title={sectionTitle}
+          fields={accordionFields}
+          data={data}
+          defaultOpen={true}
+          readOnly={disableEditing}
+          showEditIcon={!disableEditing}
+          onSave={(values) => onSaveSection?.(sectionKey, values)}
+          hideInlineActions
+          onEditingChange={onEditingChange}
+          onRegisterActions={onRegisterActions}
+          footer={
+            uploadFields.length > 0 ? (
+              <div className="flex flex-col gap-3">
+                {uploadFields.map((field) => (
+                  <ImageUploadField
+                    key={field.name}
+                    label={field.placeholder || field.label}
+                    value={data?.[field.name] ?? ''}
+                    organisationId={organisationId}
+                    onChange={(url) =>
+                      !disableEditing && onSaveSection?.(sectionKey, { [field.name]: url })
+                    }
+                  />
+                ))}
+              </div>
+            ) : undefined
+          }
+        />
+      )}
     </div>
   );
 };

--- a/apps/frontend/src/app/features/inventory/components/InfoSection.tsx
+++ b/apps/frontend/src/app/features/inventory/components/InfoSection.tsx
@@ -32,8 +32,9 @@ type InfoSectionProps = {
 type EditableField = {
   label: string;
   key: string;
-  type: 'text' | 'select' | 'date';
+  type: 'text' | 'select' | 'date' | 'multiSelect' | 'checkbox';
   options?: string[];
+  editable?: boolean;
 };
 
 const InfoSection: React.FC<InfoSectionProps> = ({
@@ -65,6 +66,10 @@ const InfoSection: React.FC<InfoSectionProps> = ({
     let type: EditableField['type'];
     if (field.component === 'dropdown') {
       type = 'select';
+    } else if (field.component === 'multiSelect') {
+      type = 'multiSelect';
+    } else if (field.component === 'checkbox') {
+      type = 'checkbox';
     } else if (field.component === 'date') {
       type = 'date';
     } else {
@@ -82,7 +87,11 @@ const InfoSection: React.FC<InfoSectionProps> = ({
       label,
       key: field.name,
       type,
-      options: field.component === 'dropdown' ? resolvedOptions : undefined,
+      options:
+        field.component === 'dropdown' || field.component === 'multiSelect'
+          ? resolvedOptions
+          : undefined,
+      ...(field.readonly ? { editable: false } : {}),
     };
   };
 

--- a/apps/frontend/src/app/features/inventory/components/InventoryInfo.tsx
+++ b/apps/frontend/src/app/features/inventory/components/InventoryInfo.tsx
@@ -515,6 +515,7 @@ type InventoryInfoProps = {
   canEdit?: boolean;
   stockLocationOptions?: string[];
   initialSection?: InventorySectionKey;
+  organisationId?: string;
 };
 
 const modalSections: { key: InventorySectionKey; name: string }[] = [
@@ -645,6 +646,7 @@ const InventoryInfo = ({
   canEdit = true,
   stockLocationOptions,
   initialSection,
+  organisationId,
 }: InventoryInfoProps) => {
   const [activeLabel, setActiveLabel] = useState<InventorySectionKey>(
     initialSection ?? modalSections[0].key
@@ -861,6 +863,7 @@ const InventoryInfo = ({
                     disableEditing={!canEdit || isUpdating || isHiding}
                     onEditingChange={setIsSectionEditing}
                     stockLocationOptions={stockLocationOptions}
+                    organisationId={organisationId}
                     onRegisterActions={(actions) => {
                       sectionActions.current = actions;
                     }}

--- a/apps/frontend/src/app/features/inventory/components/InventoryInfo.tsx
+++ b/apps/frontend/src/app/features/inventory/components/InventoryInfo.tsx
@@ -608,37 +608,26 @@ const PreviewItem = ({ item, batchData }: { item: ConfigItem<any>; batchData: Ba
 const PricingCurrencySummary = ({ inventory }: { inventory: InventoryItem }) => {
   const currency = inventory.currency;
   return (
-    <div className="flex flex-col gap-2 px-1 pt-2 text-body-4 text-text-primary">
-      <div className="flex items-center justify-between">
-        <span className="text-grey-bg">Purchase cost</span>
-        <span className="font-semibold">
-          {formatCurrencyValue(inventory.pricing.purchaseCost, currency)}
-        </span>
-      </div>
-      <div className="flex items-center justify-between">
-        <span className="text-grey-bg">Selling price</span>
-        <span className="font-semibold">
-          {formatCurrencyValue(inventory.pricing.selling, currency)}
-        </span>
-      </div>
-      <div className="flex items-center justify-between">
-        <span className="text-grey-bg">Gross profit per unit</span>
+    <div className="flex flex-col gap-2 px-4 pt-2 text-body-4 text-text-primary">
+      <div>
+        <span>Gross profit per unit : </span>
         <span className="rounded-full bg-badge-blue-bg px-2 font-semibold text-badge-blue-text">
           {formatCurrencyValue(getGrossProfitPerUnit(inventory), currency)}
         </span>
       </div>
-      <div className="flex items-center justify-between">
-        <span className="text-grey-bg">Margin</span>
+      <div>
+        <span>Margin : </span>
         <span className="rounded-full bg-badge-blue-bg px-2 font-semibold text-badge-blue-text">
           {formatPercentValue(getMarginPercent(inventory))}
         </span>
       </div>
-      <div className="flex items-center justify-between">
-        <span className="text-grey-bg">Total stock value</span>
-        <span className="font-semibold">
-          {formatCurrencyValue(getStockValue(inventory), currency)}
-        </span>
-      </div>
+      <FormInput
+        intype="text"
+        inname="stockValue"
+        value={formatCurrencyValue(getStockValue(inventory), currency)}
+        inlabel="Total stock value"
+        readonly
+      />
     </div>
   );
 };
@@ -848,7 +837,7 @@ const InventoryInfo = ({
             setActiveLabel={setActiveLabel}
           />
 
-          <div className="flex overflow-y-auto flex-1 scrollbar-hidden">
+          <div className="flex flex-col overflow-y-auto flex-1 scrollbar-hidden">
             {activeInventory && (
               <>
                 {activeLabel === 'batch' ? (

--- a/apps/frontend/src/app/features/inventory/pages/Inventory/index.tsx
+++ b/apps/frontend/src/app/features/inventory/pages/Inventory/index.tsx
@@ -171,6 +171,519 @@ const toggleSetItem = (prev: Set<string>, key: string): Set<string> => {
   return next;
 };
 
+type FilterChip = {
+  id: string;
+  label: string;
+  onRemove: () => void;
+};
+
+type InventoryFilterModalProps = {
+  filterOpen: boolean;
+  selectedFilterChips: FilterChip[];
+  setFilterOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  setFilters: React.Dispatch<React.SetStateAction<InventoryFiltersState>>;
+  filterOpenSections: Set<string>;
+  toggleFilterSection: (key: string) => void;
+  filters: InventoryFiltersState;
+  locationFilterOptions: string[];
+  toggleListFilter: (
+    key: 'subCategories' | 'locations' | 'abcClasses' | 'suppliers',
+    value: string
+  ) => void;
+  categoryOptions: string[];
+  categorySubcategoryOptions: Record<string, string[]>;
+  expandedCategories: Set<string>;
+  toggleCategoryFilter: (category: string) => void;
+  toggleExpandedCategory: (category: string) => void;
+  supplierFilterOptions: string[];
+};
+
+const InventoryFilterModal = ({
+  filterOpen,
+  selectedFilterChips,
+  setFilterOpen,
+  setFilters,
+  filterOpenSections,
+  toggleFilterSection,
+  filters,
+  locationFilterOptions,
+  toggleListFilter,
+  categoryOptions,
+  categorySubcategoryOptions,
+  expandedCategories,
+  toggleCategoryFilter,
+  toggleExpandedCategory,
+  supplierFilterOptions,
+}: InventoryFilterModalProps) => {
+  if (!filterOpen) return null;
+
+  return (
+    <Modal showModal={filterOpen} setShowModal={setFilterOpen}>
+      <div className="flex h-full flex-col">
+        <div className="flex items-center justify-between pb-4 shrink-0">
+          <div className="flex items-center gap-2 text-body-3-emphasis text-text-primary">
+            <FiSliders size={18} aria-hidden="true" />
+            <span>Filter</span>
+          </div>
+          {selectedFilterChips.length > 0 && (
+            <button
+              type="button"
+              onClick={() => setFilters(defaultFilters)}
+              className="rounded-full border border-blue-text px-4 py-1.5 text-body-4 text-blue-text hover:bg-blue-light transition-colors"
+            >
+              Clear all
+            </button>
+          )}
+        </div>
+        {selectedFilterChips.length > 0 && (
+          <div className="flex flex-wrap gap-2 pb-4 shrink-0">
+            {selectedFilterChips.map((chip) => (
+              <span
+                key={chip.id}
+                className="inline-flex items-center gap-1.5 rounded-full bg-badge-blue-bg py-1 pl-3 pr-2 text-caption-1 capitalize text-badge-blue-text"
+              >
+                {chip.label}
+                <button
+                  type="button"
+                  aria-label={`Remove ${chip.label}`}
+                  onClick={chip.onRemove}
+                  className="inline-flex size-4 items-center justify-center rounded-full hover:bg-badge-blue-text/15 transition-colors"
+                >
+                  <FiX size={12} aria-hidden="true" />
+                </button>
+              </span>
+            ))}
+          </div>
+        )}
+        <div className="flex flex-1 flex-col overflow-y-auto pr-1 divide-y divide-card-border">
+          <div>
+            <button
+              type="button"
+              onClick={() => toggleFilterSection('stock-status')}
+              className="flex w-full items-center justify-between py-3 text-left"
+            >
+              <div className="flex items-center gap-2">
+                <span className="text-body-4 text-text-primary">Stock status</span>
+                {filters.status !== 'ALL' && (
+                  <span className="inline-flex size-5 items-center justify-center rounded-full bg-blue-text text-[10px] font-bold text-white">
+                    1
+                  </span>
+                )}
+              </div>
+              {filterOpenSections.has('stock-status') ? (
+                <FiChevronUp size={16} className="text-text-secondary" />
+              ) : (
+                <FiChevronDown size={16} className="text-text-secondary" />
+              )}
+            </button>
+            {filterOpenSections.has('stock-status') && (
+              <div className="flex flex-col gap-3 pb-3">
+                {(['ALL', 'LOW_STOCK', 'EXPIRED', 'OUT_OF_STOCK'] as const).map((s) => (
+                  <label
+                    key={s}
+                    className="flex items-center gap-3 text-body-4 text-text-primary cursor-pointer"
+                  >
+                    <input
+                      type="radio"
+                      name="stock-status"
+                      checked={filters.status === s}
+                      onChange={() => setFilters((prev) => ({ ...prev, status: s }))}
+                      className="accent-blue-text"
+                    />
+                    <span>{s === 'ALL' ? 'All' : s.replaceAll('_', ' ').toLowerCase()}</span>
+                  </label>
+                ))}
+              </div>
+            )}
+          </div>
+          {locationFilterOptions.length > 0 && (
+            <div>
+              <button
+                type="button"
+                onClick={() => toggleFilterSection('location')}
+                className="flex w-full items-center justify-between py-3 text-left"
+              >
+                <div className="flex items-center gap-2">
+                  <span className="text-body-4 text-text-primary">Location</span>
+                  {filters.locations.length > 0 && (
+                    <span className="inline-flex size-5 items-center justify-center rounded-full bg-blue-text text-[10px] font-bold text-white">
+                      {filters.locations.length}
+                    </span>
+                  )}
+                </div>
+                {filterOpenSections.has('location') ? (
+                  <FiChevronUp size={16} className="text-text-secondary" />
+                ) : (
+                  <FiChevronDown size={16} className="text-text-secondary" />
+                )}
+              </button>
+              {filterOpenSections.has('location') && (
+                <div className="flex flex-col gap-3 pb-3">
+                  {locationFilterOptions.map((loc) => (
+                    <label
+                      key={loc}
+                      className="flex items-center gap-3 text-body-4 text-text-primary cursor-pointer"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={filters.locations.includes(loc)}
+                        onChange={() => toggleListFilter('locations', loc)}
+                        className="size-4 accent-blue-text"
+                      />
+                      <span>{loc}</span>
+                    </label>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+          <div>
+            <button
+              type="button"
+              onClick={() => toggleFilterSection('category')}
+              className="flex w-full items-center justify-between py-3 text-left"
+            >
+              <div className="flex items-center gap-2">
+                <span className="text-body-4 text-text-primary">Category</span>
+                {filters.categories.length > 0 && (
+                  <span className="inline-flex size-5 items-center justify-center rounded-full bg-blue-text text-[10px] font-bold text-white">
+                    {filters.categories.length}
+                  </span>
+                )}
+              </div>
+              {filterOpenSections.has('category') ? (
+                <FiChevronUp size={16} className="text-text-secondary" />
+              ) : (
+                <FiChevronDown size={16} className="text-text-secondary" />
+              )}
+            </button>
+            {filterOpenSections.has('category') && (
+              <div className="flex flex-col pb-3">
+                {categoryOptions.map((category) => {
+                  const subs = categorySubcategoryOptions[category] ?? [];
+                  const isChecked = filters.categories.includes(category);
+                  const isExpanded = expandedCategories.has(category);
+                  return (
+                    <div key={category}>
+                      <div className="flex items-center gap-2 py-2">
+                        <input
+                          type="checkbox"
+                          checked={isChecked}
+                          onChange={() => toggleCategoryFilter(category)}
+                          className="size-4 accent-blue-text"
+                          id={`cat-${category}`}
+                        />
+                        <label
+                          htmlFor={`cat-${category}`}
+                          className={`flex-1 text-body-4 cursor-pointer ${isChecked ? 'text-blue-text font-semibold' : 'text-text-primary'}`}
+                        >
+                          {category}
+                        </label>
+                        {subs.length > 0 && (
+                          <button
+                            type="button"
+                            onClick={() => toggleExpandedCategory(category)}
+                            className="text-text-secondary"
+                          >
+                            {isExpanded ? <FiChevronUp size={14} /> : <FiChevronDown size={14} />}
+                          </button>
+                        )}
+                      </div>
+                      {subs.length > 0 && isExpanded && (
+                        <div className="ml-6 flex flex-col gap-2 pb-2">
+                          {subs.map((sub) => (
+                            <label
+                              key={sub}
+                              className="flex items-center gap-3 text-body-4 text-text-secondary cursor-pointer"
+                            >
+                              <input
+                                type="checkbox"
+                                checked={filters.subCategories.includes(sub)}
+                                onChange={() => toggleListFilter('subCategories', sub)}
+                                className="size-4 accent-blue-text"
+                              />
+                              <span>{sub}</span>
+                            </label>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+          <div>
+            <button
+              type="button"
+              onClick={() => toggleFilterSection('abc')}
+              className="flex w-full items-center justify-between py-3 text-left"
+            >
+              <div className="flex items-center gap-2">
+                <span className="text-body-4 text-text-primary">ABC</span>
+                {filters.abcClasses.length > 0 && (
+                  <span className="inline-flex size-5 items-center justify-center rounded-full bg-blue-text text-[10px] font-bold text-white">
+                    {filters.abcClasses.length}
+                  </span>
+                )}
+              </div>
+              {filterOpenSections.has('abc') ? (
+                <FiChevronUp size={16} className="text-text-secondary" />
+              ) : (
+                <FiChevronDown size={16} className="text-text-secondary" />
+              )}
+            </button>
+            {filterOpenSections.has('abc') && (
+              <div className="flex flex-col gap-3 pb-3">
+                {AbcClassOptions.map((cls) => (
+                  <label
+                    key={cls}
+                    className="flex items-center gap-3 text-body-4 text-text-primary cursor-pointer"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={filters.abcClasses.includes(cls)}
+                      onChange={() => toggleListFilter('abcClasses', cls)}
+                      className="size-4 accent-blue-text"
+                    />
+                    <span>{cls}</span>
+                  </label>
+                ))}
+              </div>
+            )}
+          </div>
+          {supplierFilterOptions.length > 0 && (
+            <div>
+              <button
+                type="button"
+                onClick={() => toggleFilterSection('supplier')}
+                className="flex w-full items-center justify-between py-3 text-left"
+              >
+                <div className="flex items-center gap-2">
+                  <span className="text-body-4 text-text-primary">Supplier</span>
+                  {filters.suppliers.length > 0 && (
+                    <span className="inline-flex size-5 items-center justify-center rounded-full bg-blue-text text-[10px] font-bold text-white">
+                      {filters.suppliers.length}
+                    </span>
+                  )}
+                </div>
+                {filterOpenSections.has('supplier') ? (
+                  <FiChevronUp size={16} className="text-text-secondary" />
+                ) : (
+                  <FiChevronDown size={16} className="text-text-secondary" />
+                )}
+              </button>
+              {filterOpenSections.has('supplier') && (
+                <div className="flex flex-col gap-3 pb-3">
+                  {supplierFilterOptions.map((sup) => (
+                    <label
+                      key={sup}
+                      className="flex items-center gap-3 text-body-4 text-text-primary cursor-pointer"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={filters.suppliers.includes(sup)}
+                        onChange={() => toggleListFilter('suppliers', sup)}
+                        className="size-4 accent-blue-text"
+                      />
+                      <span>{sup}</span>
+                    </label>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+        <div className="grid grid-cols-2 gap-3 border-t border-card-border pt-5 mt-5 shrink-0">
+          <button
+            type="button"
+            onClick={() => setFilterOpen(false)}
+            className="inline-flex min-h-12 items-center justify-center gap-2 rounded-2xl bg-text-primary px-4 text-body-3-emphasis text-white hover:opacity-90 transition-opacity"
+          >
+            <FiCheck size={18} aria-hidden="true" />
+            Apply
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setFilters(defaultFilters);
+              setFilterOpen(false);
+            }}
+            className="inline-flex min-h-12 items-center justify-center rounded-2xl border border-card-border bg-white px-4 text-body-3-emphasis text-text-primary hover:bg-card-hover transition-colors"
+          >
+            Discard
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+type DispensaryFilterModalProps = {
+  dispensaryFilterOpen: boolean;
+  setDispensaryFilterOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  dispensaryStatusFilter: DispensaryStatus | 'ALL';
+  setDispensaryStatusFilter: React.Dispatch<React.SetStateAction<DispensaryStatus | 'ALL'>>;
+  dispensaryRequestType: DispensaryRequestType;
+  setDispensaryRequestType: React.Dispatch<React.SetStateAction<DispensaryRequestType>>;
+  filterOpenSections: Set<string>;
+  toggleFilterSection: (key: string) => void;
+};
+
+const DispensaryFilterModal = ({
+  dispensaryFilterOpen,
+  setDispensaryFilterOpen,
+  dispensaryStatusFilter,
+  setDispensaryStatusFilter,
+  dispensaryRequestType,
+  setDispensaryRequestType,
+  filterOpenSections,
+  toggleFilterSection,
+}: DispensaryFilterModalProps) => {
+  if (!dispensaryFilterOpen) return null;
+
+  return (
+    <Modal showModal={dispensaryFilterOpen} setShowModal={setDispensaryFilterOpen}>
+      <div className="flex h-full flex-col">
+        <div className="flex items-center justify-between pb-4 shrink-0">
+          <div className="flex items-center gap-2 text-body-3-emphasis text-text-primary">
+            <FiSliders size={18} aria-hidden="true" />
+            <span>Filter</span>
+          </div>
+          {(dispensaryStatusFilter !== 'ALL' || dispensaryRequestType !== 'ALL') && (
+            <button
+              type="button"
+              onClick={() => {
+                setDispensaryStatusFilter('ALL');
+                setDispensaryRequestType('ALL');
+              }}
+              className="rounded-full border border-blue-text px-4 py-1.5 text-body-4 text-blue-text hover:bg-blue-light transition-colors"
+            >
+              Clear all
+            </button>
+          )}
+        </div>
+        <div className="flex flex-1 flex-col overflow-y-auto pr-1 divide-y divide-card-border">
+          <div>
+            <button
+              type="button"
+              onClick={() => toggleFilterSection('disp-status')}
+              className="flex w-full items-center justify-between py-3 text-left"
+            >
+              <div className="flex items-center gap-2">
+                <span className="text-body-4 text-text-primary">Status</span>
+                {dispensaryStatusFilter !== 'ALL' && (
+                  <span className="inline-flex size-5 items-center justify-center rounded-full bg-blue-text text-[10px] font-bold text-white">
+                    1
+                  </span>
+                )}
+              </div>
+              {filterOpenSections.has('disp-status') ? (
+                <FiChevronUp size={16} className="text-text-secondary" />
+              ) : (
+                <FiChevronDown size={16} className="text-text-secondary" />
+              )}
+            </button>
+            {filterOpenSections.has('disp-status') && (
+              <div className="flex flex-col gap-3 pb-3">
+                {(
+                  [
+                    { value: 'ALL', label: 'All' },
+                    { value: 'PENDING', label: 'Pending' },
+                    { value: 'DISPENSED', label: 'Dispensed' },
+                    { value: 'NOT_DISPENSED', label: 'Not dispensed' },
+                  ] as const
+                ).map(({ value, label }) => (
+                  <label
+                    key={value}
+                    className="flex items-center gap-3 text-body-4 text-text-primary cursor-pointer"
+                  >
+                    <input
+                      type="radio"
+                      name="dispensary-status"
+                      checked={dispensaryStatusFilter === value}
+                      onChange={() => setDispensaryStatusFilter(value)}
+                      className="accent-blue-text"
+                    />
+                    <span>{label}</span>
+                  </label>
+                ))}
+              </div>
+            )}
+          </div>
+          <div>
+            <button
+              type="button"
+              onClick={() => toggleFilterSection('disp-type')}
+              className="flex w-full items-center justify-between py-3 text-left"
+            >
+              <div className="flex items-center gap-2">
+                <span className="text-body-4 text-text-primary">Request type</span>
+                {dispensaryRequestType !== 'ALL' && (
+                  <span className="inline-flex size-5 items-center justify-center rounded-full bg-blue-text text-[10px] font-bold text-white">
+                    1
+                  </span>
+                )}
+              </div>
+              {filterOpenSections.has('disp-type') ? (
+                <FiChevronUp size={16} className="text-text-secondary" />
+              ) : (
+                <FiChevronDown size={16} className="text-text-secondary" />
+              )}
+            </button>
+            {filterOpenSections.has('disp-type') && (
+              <div className="flex flex-col gap-3 pb-3">
+                {(
+                  [
+                    { value: 'ALL', label: 'All requests' },
+                    { value: 'PATIENT', label: 'Patient' },
+                    { value: 'IN_HOUSE', label: 'Inhouse' },
+                  ] as const
+                ).map(({ value, label }) => (
+                  <label
+                    key={value}
+                    className="flex items-center gap-3 text-body-4 text-text-primary cursor-pointer"
+                  >
+                    <input
+                      type="radio"
+                      name="dispensary-type"
+                      checked={dispensaryRequestType === value}
+                      onChange={() => setDispensaryRequestType(value)}
+                      className="accent-blue-text"
+                    />
+                    <span>{label}</span>
+                  </label>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+        <div className="grid grid-cols-2 gap-3 border-t border-card-border pt-5 mt-5 shrink-0">
+          <button
+            type="button"
+            onClick={() => setDispensaryFilterOpen(false)}
+            className="inline-flex min-h-12 items-center justify-center gap-2 rounded-2xl bg-text-primary px-4 text-body-3-emphasis text-white hover:opacity-90 transition-opacity"
+          >
+            <FiCheck size={18} aria-hidden="true" />
+            Apply
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setDispensaryStatusFilter('ALL');
+              setDispensaryRequestType('ALL');
+              setDispensaryFilterOpen(false);
+            }}
+            className="inline-flex min-h-12 items-center justify-center rounded-2xl border border-card-border bg-white px-4 text-body-3-emphasis text-text-primary hover:bg-card-hover transition-colors"
+          >
+            Discard
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
 const Inventory = () => {
   useLoadOrg();
 
@@ -844,464 +1357,37 @@ const Inventory = () => {
           businessType={resolvedBusinessType}
           onSubmit={handleCreateInventory}
           stockLocationOptions={stockLocationOptions}
+          organisationId={primaryOrgId ?? undefined}
         />
 
-        {filterOpen && (
-          <Modal showModal={filterOpen} setShowModal={setFilterOpen}>
-            <div className="flex h-full flex-col">
-              {/* Header */}
-              <div className="flex items-center justify-between pb-4 shrink-0">
-                <div className="flex items-center gap-2 text-body-3-emphasis text-text-primary">
-                  <FiSliders size={18} aria-hidden="true" />
-                  <span>Filter</span>
-                </div>
-                {selectedFilterChips.length > 0 && (
-                  <button
-                    type="button"
-                    onClick={() => setFilters(defaultFilters)}
-                    className="rounded-full border border-blue-text px-4 py-1.5 text-body-4 text-blue-text hover:bg-blue-light transition-colors"
-                  >
-                    Clear all
-                  </button>
-                )}
-              </div>
-              {/* Chips */}
-              {selectedFilterChips.length > 0 && (
-                <div className="flex flex-wrap gap-2 pb-4 shrink-0">
-                  {selectedFilterChips.map((chip) => (
-                    <span
-                      key={chip.id}
-                      className="inline-flex items-center gap-1.5 rounded-full bg-badge-blue-bg py-1 pl-3 pr-2 text-caption-1 capitalize text-badge-blue-text"
-                    >
-                      {chip.label}
-                      <button
-                        type="button"
-                        aria-label={`Remove ${chip.label}`}
-                        onClick={chip.onRemove}
-                        className="inline-flex size-4 items-center justify-center rounded-full hover:bg-badge-blue-text/15 transition-colors"
-                      >
-                        <FiX size={12} aria-hidden="true" />
-                      </button>
-                    </span>
-                  ))}
-                </div>
-              )}
-              {/* Accordion sections */}
-              <div className="flex flex-1 flex-col overflow-y-auto pr-1 divide-y divide-card-border">
-                {/* Stock status */}
-                <div>
-                  <button
-                    type="button"
-                    onClick={() => toggleFilterSection('stock-status')}
-                    className="flex w-full items-center justify-between py-3 text-left"
-                  >
-                    <div className="flex items-center gap-2">
-                      <span className="text-body-4 text-text-primary">Stock status</span>
-                      {filters.status !== 'ALL' && (
-                        <span className="inline-flex size-5 items-center justify-center rounded-full bg-blue-text text-[10px] font-bold text-white">
-                          1
-                        </span>
-                      )}
-                    </div>
-                    {filterOpenSections.has('stock-status') ? (
-                      <FiChevronUp size={16} className="text-text-secondary" />
-                    ) : (
-                      <FiChevronDown size={16} className="text-text-secondary" />
-                    )}
-                  </button>
-                  {filterOpenSections.has('stock-status') && (
-                    <div className="flex flex-col gap-3 pb-3">
-                      {(['ALL', 'LOW_STOCK', 'EXPIRED', 'OUT_OF_STOCK'] as const).map((s) => (
-                        <label
-                          key={s}
-                          className="flex items-center gap-3 text-body-4 text-text-primary cursor-pointer"
-                        >
-                          <input
-                            type="radio"
-                            name="stock-status"
-                            checked={filters.status === s}
-                            onChange={() => setFilters((prev) => ({ ...prev, status: s }))}
-                            className="accent-blue-text"
-                          />
-                          <span>{s === 'ALL' ? 'All' : s.replaceAll('_', ' ').toLowerCase()}</span>
-                        </label>
-                      ))}
-                    </div>
-                  )}
-                </div>
-                {/* Location */}
-                {locationFilterOptions.length > 0 && (
-                  <div>
-                    <button
-                      type="button"
-                      onClick={() => toggleFilterSection('location')}
-                      className="flex w-full items-center justify-between py-3 text-left"
-                    >
-                      <div className="flex items-center gap-2">
-                        <span className="text-body-4 text-text-primary">Location</span>
-                        {filters.locations.length > 0 && (
-                          <span className="inline-flex size-5 items-center justify-center rounded-full bg-blue-text text-[10px] font-bold text-white">
-                            {filters.locations.length}
-                          </span>
-                        )}
-                      </div>
-                      {filterOpenSections.has('location') ? (
-                        <FiChevronUp size={16} className="text-text-secondary" />
-                      ) : (
-                        <FiChevronDown size={16} className="text-text-secondary" />
-                      )}
-                    </button>
-                    {filterOpenSections.has('location') && (
-                      <div className="flex flex-col gap-3 pb-3">
-                        {locationFilterOptions.map((loc) => (
-                          <label
-                            key={loc}
-                            className="flex items-center gap-3 text-body-4 text-text-primary cursor-pointer"
-                          >
-                            <input
-                              type="checkbox"
-                              checked={filters.locations.includes(loc)}
-                              onChange={() => toggleListFilter('locations', loc)}
-                              className="size-4 accent-blue-text"
-                            />
-                            <span>{loc}</span>
-                          </label>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                )}
-                {/* Category */}
-                <div>
-                  <button
-                    type="button"
-                    onClick={() => toggleFilterSection('category')}
-                    className="flex w-full items-center justify-between py-3 text-left"
-                  >
-                    <div className="flex items-center gap-2">
-                      <span className="text-body-4 text-text-primary">Category</span>
-                      {filters.categories.length > 0 && (
-                        <span className="inline-flex size-5 items-center justify-center rounded-full bg-blue-text text-[10px] font-bold text-white">
-                          {filters.categories.length}
-                        </span>
-                      )}
-                    </div>
-                    {filterOpenSections.has('category') ? (
-                      <FiChevronUp size={16} className="text-text-secondary" />
-                    ) : (
-                      <FiChevronDown size={16} className="text-text-secondary" />
-                    )}
-                  </button>
-                  {filterOpenSections.has('category') && (
-                    <div className="flex flex-col pb-3">
-                      {categoryOptions.map((category) => {
-                        const subs = categorySubcategoryOptions[category] ?? [];
-                        const isChecked = filters.categories.includes(category);
-                        const isExpanded = expandedCategories.has(category);
-                        return (
-                          <div key={category}>
-                            <div className="flex items-center gap-2 py-2">
-                              <input
-                                type="checkbox"
-                                checked={isChecked}
-                                onChange={() => toggleCategoryFilter(category)}
-                                className="size-4 accent-blue-text"
-                                id={`cat-${category}`}
-                              />
-                              <label
-                                htmlFor={`cat-${category}`}
-                                className={`flex-1 text-body-4 cursor-pointer ${isChecked ? 'text-blue-text font-semibold' : 'text-text-primary'}`}
-                              >
-                                {category}
-                              </label>
-                              {subs.length > 0 && (
-                                <button
-                                  type="button"
-                                  onClick={() => toggleExpandedCategory(category)}
-                                  className="text-text-secondary"
-                                >
-                                  {isExpanded ? (
-                                    <FiChevronUp size={14} />
-                                  ) : (
-                                    <FiChevronDown size={14} />
-                                  )}
-                                </button>
-                              )}
-                            </div>
-                            {subs.length > 0 && isExpanded && (
-                              <div className="ml-6 flex flex-col gap-2 pb-2">
-                                {subs.map((sub) => (
-                                  <label
-                                    key={sub}
-                                    className="flex items-center gap-3 text-body-4 text-text-secondary cursor-pointer"
-                                  >
-                                    <input
-                                      type="checkbox"
-                                      checked={filters.subCategories.includes(sub)}
-                                      onChange={() => toggleListFilter('subCategories', sub)}
-                                      className="size-4 accent-blue-text"
-                                    />
-                                    <span>{sub}</span>
-                                  </label>
-                                ))}
-                              </div>
-                            )}
-                          </div>
-                        );
-                      })}
-                    </div>
-                  )}
-                </div>
-                {/* ABC */}
-                <div>
-                  <button
-                    type="button"
-                    onClick={() => toggleFilterSection('abc')}
-                    className="flex w-full items-center justify-between py-3 text-left"
-                  >
-                    <div className="flex items-center gap-2">
-                      <span className="text-body-4 text-text-primary">ABC</span>
-                      {filters.abcClasses.length > 0 && (
-                        <span className="inline-flex size-5 items-center justify-center rounded-full bg-blue-text text-[10px] font-bold text-white">
-                          {filters.abcClasses.length}
-                        </span>
-                      )}
-                    </div>
-                    {filterOpenSections.has('abc') ? (
-                      <FiChevronUp size={16} className="text-text-secondary" />
-                    ) : (
-                      <FiChevronDown size={16} className="text-text-secondary" />
-                    )}
-                  </button>
-                  {filterOpenSections.has('abc') && (
-                    <div className="flex flex-col gap-3 pb-3">
-                      {AbcClassOptions.map((cls) => (
-                        <label
-                          key={cls}
-                          className="flex items-center gap-3 text-body-4 text-text-primary cursor-pointer"
-                        >
-                          <input
-                            type="checkbox"
-                            checked={filters.abcClasses.includes(cls)}
-                            onChange={() => toggleListFilter('abcClasses', cls)}
-                            className="size-4 accent-blue-text"
-                          />
-                          <span>{cls}</span>
-                        </label>
-                      ))}
-                    </div>
-                  )}
-                </div>
-                {/* Supplier */}
-                {supplierFilterOptions.length > 0 && (
-                  <div>
-                    <button
-                      type="button"
-                      onClick={() => toggleFilterSection('supplier')}
-                      className="flex w-full items-center justify-between py-3 text-left"
-                    >
-                      <div className="flex items-center gap-2">
-                        <span className="text-body-4 text-text-primary">Supplier</span>
-                        {filters.suppliers.length > 0 && (
-                          <span className="inline-flex size-5 items-center justify-center rounded-full bg-blue-text text-[10px] font-bold text-white">
-                            {filters.suppliers.length}
-                          </span>
-                        )}
-                      </div>
-                      {filterOpenSections.has('supplier') ? (
-                        <FiChevronUp size={16} className="text-text-secondary" />
-                      ) : (
-                        <FiChevronDown size={16} className="text-text-secondary" />
-                      )}
-                    </button>
-                    {filterOpenSections.has('supplier') && (
-                      <div className="flex flex-col gap-3 pb-3">
-                        {supplierFilterOptions.map((sup) => (
-                          <label
-                            key={sup}
-                            className="flex items-center gap-3 text-body-4 text-text-primary cursor-pointer"
-                          >
-                            <input
-                              type="checkbox"
-                              checked={filters.suppliers.includes(sup)}
-                              onChange={() => toggleListFilter('suppliers', sup)}
-                              className="size-4 accent-blue-text"
-                            />
-                            <span>{sup}</span>
-                          </label>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                )}
-              </div>
-              {/* Footer */}
-              <div className="grid grid-cols-2 gap-3 border-t border-card-border pt-5 mt-5 shrink-0">
-                <button
-                  type="button"
-                  onClick={() => setFilterOpen(false)}
-                  className="inline-flex min-h-12 items-center justify-center gap-2 rounded-2xl bg-text-primary px-4 text-body-3-emphasis text-white hover:opacity-90 transition-opacity"
-                >
-                  <FiCheck size={18} aria-hidden="true" />
-                  Apply
-                </button>
-                <button
-                  type="button"
-                  onClick={() => {
-                    setFilters(defaultFilters);
-                    setFilterOpen(false);
-                  }}
-                  className="inline-flex min-h-12 items-center justify-center rounded-2xl border border-card-border bg-white px-4 text-body-3-emphasis text-text-primary hover:bg-card-hover transition-colors"
-                >
-                  Discard
-                </button>
-              </div>
-            </div>
-          </Modal>
-        )}
+        <InventoryFilterModal
+          filterOpen={filterOpen}
+          selectedFilterChips={selectedFilterChips}
+          setFilterOpen={setFilterOpen}
+          setFilters={setFilters}
+          filterOpenSections={filterOpenSections}
+          toggleFilterSection={toggleFilterSection}
+          filters={filters}
+          locationFilterOptions={locationFilterOptions}
+          toggleListFilter={toggleListFilter}
+          categoryOptions={categoryOptions}
+          categorySubcategoryOptions={categorySubcategoryOptions}
+          expandedCategories={expandedCategories}
+          toggleCategoryFilter={toggleCategoryFilter}
+          toggleExpandedCategory={toggleExpandedCategory}
+          supplierFilterOptions={supplierFilterOptions}
+        />
 
-        {dispensaryFilterOpen && (
-          <Modal showModal={dispensaryFilterOpen} setShowModal={setDispensaryFilterOpen}>
-            <div className="flex h-full flex-col">
-              <div className="flex items-center justify-between pb-4 shrink-0">
-                <div className="flex items-center gap-2 text-body-3-emphasis text-text-primary">
-                  <FiSliders size={18} aria-hidden="true" />
-                  <span>Filter</span>
-                </div>
-                {(dispensaryStatusFilter !== 'ALL' || dispensaryRequestType !== 'ALL') && (
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setDispensaryStatusFilter('ALL');
-                      setDispensaryRequestType('ALL');
-                    }}
-                    className="rounded-full border border-blue-text px-4 py-1.5 text-body-4 text-blue-text hover:bg-blue-light transition-colors"
-                  >
-                    Clear all
-                  </button>
-                )}
-              </div>
-              <div className="flex flex-1 flex-col overflow-y-auto pr-1 divide-y divide-card-border">
-                {/* Status */}
-                <div>
-                  <button
-                    type="button"
-                    onClick={() => toggleFilterSection('disp-status')}
-                    className="flex w-full items-center justify-between py-3 text-left"
-                  >
-                    <div className="flex items-center gap-2">
-                      <span className="text-body-4 text-text-primary">Status</span>
-                      {dispensaryStatusFilter !== 'ALL' && (
-                        <span className="inline-flex size-5 items-center justify-center rounded-full bg-blue-text text-[10px] font-bold text-white">
-                          1
-                        </span>
-                      )}
-                    </div>
-                    {filterOpenSections.has('disp-status') ? (
-                      <FiChevronUp size={16} className="text-text-secondary" />
-                    ) : (
-                      <FiChevronDown size={16} className="text-text-secondary" />
-                    )}
-                  </button>
-                  {filterOpenSections.has('disp-status') && (
-                    <div className="flex flex-col gap-3 pb-3">
-                      {(
-                        [
-                          { value: 'ALL', label: 'All' },
-                          { value: 'PENDING', label: 'Pending' },
-                          { value: 'DISPENSED', label: 'Dispensed' },
-                          { value: 'NOT_DISPENSED', label: 'Not dispensed' },
-                        ] as const
-                      ).map(({ value, label }) => (
-                        <label
-                          key={value}
-                          className="flex items-center gap-3 text-body-4 text-text-primary cursor-pointer"
-                        >
-                          <input
-                            type="radio"
-                            name="dispensary-status"
-                            checked={dispensaryStatusFilter === value}
-                            onChange={() => setDispensaryStatusFilter(value)}
-                            className="accent-blue-text"
-                          />
-                          <span>{label}</span>
-                        </label>
-                      ))}
-                    </div>
-                  )}
-                </div>
-                {/* Request type */}
-                <div>
-                  <button
-                    type="button"
-                    onClick={() => toggleFilterSection('disp-type')}
-                    className="flex w-full items-center justify-between py-3 text-left"
-                  >
-                    <div className="flex items-center gap-2">
-                      <span className="text-body-4 text-text-primary">Request type</span>
-                      {dispensaryRequestType !== 'ALL' && (
-                        <span className="inline-flex size-5 items-center justify-center rounded-full bg-blue-text text-[10px] font-bold text-white">
-                          1
-                        </span>
-                      )}
-                    </div>
-                    {filterOpenSections.has('disp-type') ? (
-                      <FiChevronUp size={16} className="text-text-secondary" />
-                    ) : (
-                      <FiChevronDown size={16} className="text-text-secondary" />
-                    )}
-                  </button>
-                  {filterOpenSections.has('disp-type') && (
-                    <div className="flex flex-col gap-3 pb-3">
-                      {(
-                        [
-                          { value: 'ALL', label: 'All requests' },
-                          { value: 'PATIENT', label: 'Patient' },
-                          { value: 'IN_HOUSE', label: 'Inhouse' },
-                        ] as const
-                      ).map(({ value, label }) => (
-                        <label
-                          key={value}
-                          className="flex items-center gap-3 text-body-4 text-text-primary cursor-pointer"
-                        >
-                          <input
-                            type="radio"
-                            name="dispensary-type"
-                            checked={dispensaryRequestType === value}
-                            onChange={() => setDispensaryRequestType(value)}
-                            className="accent-blue-text"
-                          />
-                          <span>{label}</span>
-                        </label>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              </div>
-              <div className="grid grid-cols-2 gap-3 border-t border-card-border pt-5 mt-5 shrink-0">
-                <button
-                  type="button"
-                  onClick={() => setDispensaryFilterOpen(false)}
-                  className="inline-flex min-h-12 items-center justify-center gap-2 rounded-2xl bg-text-primary px-4 text-body-3-emphasis text-white hover:opacity-90 transition-opacity"
-                >
-                  <FiCheck size={18} aria-hidden="true" />
-                  Apply
-                </button>
-                <button
-                  type="button"
-                  onClick={() => {
-                    setDispensaryStatusFilter('ALL');
-                    setDispensaryRequestType('ALL');
-                    setDispensaryFilterOpen(false);
-                  }}
-                  className="inline-flex min-h-12 items-center justify-center rounded-2xl border border-card-border bg-white px-4 text-body-3-emphasis text-text-primary hover:bg-card-hover transition-colors"
-                >
-                  Discard
-                </button>
-              </div>
-            </div>
-          </Modal>
-        )}
+        <DispensaryFilterModal
+          dispensaryFilterOpen={dispensaryFilterOpen}
+          setDispensaryFilterOpen={setDispensaryFilterOpen}
+          dispensaryStatusFilter={dispensaryStatusFilter}
+          setDispensaryStatusFilter={setDispensaryStatusFilter}
+          dispensaryRequestType={dispensaryRequestType}
+          setDispensaryRequestType={setDispensaryRequestType}
+          filterOpenSections={filterOpenSections}
+          toggleFilterSection={toggleFilterSection}
+        />
 
         {activeInventory && (
           <InventoryInfo
@@ -1317,6 +1403,7 @@ const Inventory = () => {
             canEdit={canEditInventory}
             stockLocationOptions={stockLocationOptions}
             initialSection={infoInitialSection}
+            organisationId={primaryOrgId ?? undefined}
           />
         )}
       </PermissionGate>

--- a/apps/frontend/src/app/features/inventory/pages/Inventory/index.tsx
+++ b/apps/frontend/src/app/features/inventory/pages/Inventory/index.tsx
@@ -4,13 +4,14 @@ import dynamic from 'next/dynamic';
 import { useSearchParams } from 'next/navigation';
 import ProtectedRoute from '@/app/ui/layout/guards/ProtectedRoute';
 import PageSkeleton from '@/app/ui/layout/PageSkeleton';
-import InventoryTurnoverFilters from '@/app/ui/filters/InventoryTurnoverFilters';
 import {
   AbcClassOptions,
   CategoryOptionsByBusiness,
+  DispensaryRecord,
+  DispensaryRequestType,
+  DispensaryStatus,
   InventoryFiltersState,
   InventoryItem,
-  InventoryTurnoverItem,
   SubCategoryOptions,
   SubCategoryByCategory,
 } from '@/app/features/inventory/pages/Inventory/types';
@@ -29,11 +30,27 @@ import { PermissionGate } from '@/app/ui/layout/guards/PermissionGate';
 import Fallback from '@/app/ui/overlays/Fallback';
 import GlassTooltip from '@/app/ui/primitives/GlassTooltip/GlassTooltip';
 import { IoInformationCircleOutline } from 'react-icons/io5';
+import {
+  listDispenseRequests,
+  DispenseRequestApi,
+} from '@/app/features/inventory/services/dispensaryService';
+import { dispensePrescription } from '@/app/features/appointments/services/prescriptionWorkflowService';
 import { getPlannerLayoutClassNames, usePlannerAutoLock } from '@/app/hooks/usePlannerLayout';
 import MobileSearchBar from '@/app/ui/layout/MobileSearchBar/MobileSearchBar';
 import Modal from '@/app/ui/overlays/Modal';
 import { Primary } from '@/app/ui/primitives/Buttons';
-import { FiCheck, FiFilter, FiPlus, FiSearch, FiSliders, FiX } from 'react-icons/fi';
+import {
+  FiCheck,
+  FiChevronDown,
+  FiChevronUp,
+  FiFilter,
+  FiPlus,
+  FiSearch,
+  FiSliders,
+  FiX,
+} from 'react-icons/fi';
+import { TbLayoutGrid, TbPill } from 'react-icons/tb';
+import { LuFileText } from 'react-icons/lu';
 
 const INVENTORY_PAGE_SKELETON = <PageSkeleton variant="list" />;
 
@@ -44,10 +61,13 @@ const InventorySectionSkeleton = () => (
 const InventoryTable = dynamic(() => import('@/app/ui/tables/InventoryTable'), {
   loading: () => <InventorySectionSkeleton />,
 });
-const InventoryTurnoverTable = dynamic(() => import('@/app/ui/tables/InventoryTurnoverTable'), {
+const DispensaryTable = dynamic(() => import('@/app/ui/tables/DispensaryTable'), {
   loading: () => <InventorySectionSkeleton />,
 });
 const AddInventory = dynamic(() => import('@/app/features/inventory/components/AddInventory'));
+const DispensaryDetailModal = dynamic(
+  () => import('@/app/features/inventory/components/DispensaryDetailModal')
+);
 const InventoryInfo = dynamic(() =>
   import('@/app/features/inventory/components').then((module) => ({
     default: module.InventoryInfo,
@@ -77,14 +97,79 @@ const compareInventoryRows = (a: InventoryItem, b: InventoryItem, sortMode: Sort
   return a.basicInfo.name.localeCompare(b.basicInfo.name);
 };
 
-const getVisibilityLabel = (visibility: 'ALL' | 'ACTIVE' | 'HIDDEN'): string => {
-  if (visibility === 'ALL') return 'All';
-  if (visibility === 'ACTIVE') return 'Visible';
+const getSupplierName = (item: InventoryItem) =>
+  (item.vendor?.supplierName || item.vendor?.vendor || '').trim();
+
+const getDispenseRequestType = (
+  fulfillment: string | undefined,
+  patientName: string | null
+): 'IN_HOUSE' | 'PATIENT' => {
+  if (fulfillment === 'IN_HOUSE') return 'IN_HOUSE';
+  return patientName ? 'PATIENT' : 'IN_HOUSE';
+};
+
+const mapDispenseRequestToRecord = (req: DispenseRequestApi): DispensaryRecord => {
+  const firstMed = req.medications[0];
+  const requestType = getDispenseRequestType(firstMed?.fulfillment, req.patientName);
+  const amountCents = req.medications.reduce((sum, m) => sum + (m.priceCents ?? 0), 0);
+
+  return {
+    id: req.id,
+    prescriptionId: req.prescriptionId,
+    patient: {
+      name: req.patientName ?? '—',
+      appointmentId: req.prescription.artifact.appointmentId ?? '—',
+      imageUrl: req.patientImageUrl ?? undefined,
+      petBreed: req.petBreed ?? undefined,
+      petAge: req.petAge ?? undefined,
+    },
+    status: req.status,
+    prescriptionItems: req.medications.map((m) => m.inventoryItemId),
+    prescriptionCreated: req.requestedAt,
+    amountCents,
+    currency: req.currency ?? undefined,
+    lead: req.leadName ?? '—',
+    location: req.location ?? '—',
+    requestType,
+    invoiceId: req.invoiceId ?? undefined,
+    paymentStatus: req.paymentStatus ?? undefined,
+    timeDispensed: req.reviewedAt ?? undefined,
+    items: req.medications.map((m) => ({
+      name: m.medicineName ?? req.prescription.artifact.summary ?? m.inventoryItemId,
+      quantity: String(m.quantity ?? 1),
+      priceCents: m.priceCents ?? 0,
+      prescription: {
+        dose: m.dosage ?? '',
+        freq: m.frequency ?? '',
+        duration: '',
+        refill: '',
+        route: m.route ?? '',
+      },
+    })),
+  };
+};
+
+const getVisibilityLabel = (vis: 'ALL' | 'ACTIVE' | 'HIDDEN'): string => {
+  if (vis === 'ALL') return 'All inventory';
+  if (vis === 'ACTIVE') return 'Active';
   return 'Hidden';
 };
 
-const getSupplierName = (item: InventoryItem) =>
-  (item.vendor?.supplierName || item.vendor?.vendor || '').trim();
+const getDispensaryRequestTypeLabel = (type: DispensaryRequestType): string => {
+  if (type === 'ALL') return 'All requests';
+  if (type === 'PATIENT') return 'Patient';
+  return 'Inhouse';
+};
+
+const toggleSetItem = (prev: Set<string>, key: string): Set<string> => {
+  const next = new Set(prev);
+  if (next.has(key)) {
+    next.delete(key);
+  } else {
+    next.add(key);
+  }
+  return next;
+};
 
 const Inventory = () => {
   useLoadOrg();
@@ -103,18 +188,50 @@ const Inventory = () => {
   const resolvedBusinessType: BusinessType = businessType ?? 'GROOMER';
 
   const inventoryModule = useInventoryModule(resolvedBusinessType);
-  const { inventory, turnover, status, error: loadError } = inventoryModule;
+  const { inventory, status, error: loadError } = inventoryModule;
 
   const [filters, setFilters] = useState<InventoryFiltersState>(defaultFilters);
   const [debouncedSearch, setDebouncedSearch] = useState(headerSearchQuery);
   const [filteredInventory, setFilteredInventory] = useState<InventoryItem[]>([]);
-  const [filteredTurnoverList, setFilteredTurnoverList] = useState<InventoryTurnoverItem[]>([]);
+  const [dispensaryRecords, setDispensaryRecords] = useState<DispensaryRecord[]>([]);
+
+  const fetchDispensaryRecords = useCallback(async () => {
+    if (!primaryOrgId) return;
+    try {
+      const data = await listDispenseRequests(primaryOrgId);
+      setDispensaryRecords(data.map(mapDispenseRequestToRecord));
+    } catch {
+      // silently fail — table shows empty state
+    }
+  }, [primaryOrgId]);
+
+  useEffect(() => {
+    fetchDispensaryRecords();
+  }, [fetchDispensaryRecords]);
+  const [activeDispensaryRecord, setActiveDispensaryRecord] = useState<DispensaryRecord | null>(
+    null
+  );
+  const [dispensaryModalOpen, setDispensaryModalOpen] = useState(false);
+  const [dispensaryRequestType, setDispensaryRequestType] = useState<DispensaryRequestType>('ALL');
+  const [dispensarySearch, setDispensarySearch] = useState('');
+  const [dispensaryFilterOpen, setDispensaryFilterOpen] = useState(false);
+  const [dispensaryStatusFilter, setDispensaryStatusFilter] = useState<DispensaryStatus | 'ALL'>(
+    'ALL'
+  );
   const [addPopup, setAddPopup] = useState(false);
   const [viewInventory, setViewInventory] = useState(false);
   const [infoInitialSection, setInfoInitialSection] = useState<InventorySectionKey | undefined>(
     undefined
   );
   const [filterOpen, setFilterOpen] = useState(false);
+  const [filterOpenSections, setFilterOpenSections] = useState<Set<string>>(
+    new Set(['stock-status'])
+  );
+  const [expandedCategories, setExpandedCategories] = useState<Set<string>>(new Set());
+  const toggleFilterSection = (key: string) =>
+    setFilterOpenSections((prev) => toggleSetItem(prev, key));
+  const toggleExpandedCategory = (cat: string) =>
+    setExpandedCategories((prev) => toggleSetItem(prev, cat));
   const [activeInventory, setActiveInventory] = useState<InventoryItem | null>(null);
   const [savingItem, setSavingItem] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
@@ -186,25 +303,12 @@ const Inventory = () => {
     }, {});
   }, [categoryOptions, inventory]);
 
-  const turnoverCategoryOptions = useMemo(() => {
-    return Array.from(
-      new Set(
-        turnover
-          .map((item) => item.category?.trim())
-          .filter((category): category is string => Boolean(category))
-      )
-    );
-  }, [turnover]);
   const { wrapperClassName, plannerSectionClassName } = getPlannerLayoutClassNames({
     activeView: 'list',
     listWrapperClassName:
       'w-full flex flex-col gap-4 h-[calc(100vh-236px)] min-h-[540px] max-h-[calc(100vh-236px)] lg:sticky lg:top-4 lg:mb-0 lg:h-[calc(100dvh-104px)] lg:min-h-[calc(100dvh-104px)] lg:max-h-[calc(100dvh-104px)]',
     plannerClassName: '',
   });
-
-  useEffect(() => {
-    setFilteredTurnoverList(turnover);
-  }, [turnover]);
 
   useEffect(() => {
     const normalizedSearch = debouncedSearch.trim().toLowerCase();
@@ -271,11 +375,7 @@ const Inventory = () => {
   useEffect(() => {
     setActiveInventory((prev) => {
       if (!filteredInventory.length) return null;
-      if (prev) {
-        const existing = filteredInventory.find((i) => i.id === prev.id);
-        if (existing) return existing;
-      }
-      return filteredInventory[0];
+      return filteredInventory.find((i) => i.id === prev?.id) ?? filteredInventory[0];
     });
     if (!filteredInventory.length) {
       setViewInventory(false);
@@ -482,13 +582,6 @@ const Inventory = () => {
         onRemove: () => setFilters((prev) => ({ ...prev, category: 'all' })),
       });
     }
-    if (filters.visibility !== 'ALL') {
-      chips.push({
-        id: `visibility-${filters.visibility}`,
-        label: filters.visibility === 'ACTIVE' ? 'Visible' : 'Hidden',
-        onRemove: () => setFilters((prev) => ({ ...prev, visibility: 'ALL' })),
-      });
-    }
     return chips;
   }, [filters, toggleCategoryFilter, toggleListFilter]);
 
@@ -497,23 +590,25 @@ const Inventory = () => {
       <div className="flex justify-between items-center w-full flex-wrap gap-3">
         <div className="flex flex-col gap-1">
           <h1 className="text-text-primary text-heading-2 flex items-center gap-2">
-            <span>Inventory</span>
-            <GlassTooltip
-              content="Organize stock, track batches and expiry, and monitor turnover so you know what to reorder and which items need attention."
-              side="bottom"
-            >
-              <button
-                type="button"
-                aria-label="Inventory info"
-                className="inline-flex size-5 shrink-0 items-center justify-center leading-none translate-y-px text-text-secondary hover:text-text-primary transition-colors"
+            <span>{activeView === 'turnover' ? 'Dispensary' : 'Inventory'}</span>
+            {activeView === 'inventory' && (
+              <GlassTooltip
+                content="Organize stock, track batches and expiry, and monitor turnover so you know what to reorder and which items need attention."
+                side="bottom"
               >
-                <IoInformationCircleOutline size={20} />
-              </button>
-            </GlassTooltip>
+                <button
+                  type="button"
+                  aria-label="Inventory info"
+                  className="inline-flex size-5 shrink-0 items-center justify-center leading-none translate-y-px text-text-secondary hover:text-text-primary transition-colors"
+                >
+                  <IoInformationCircleOutline size={20} />
+                </button>
+              </GlassTooltip>
+            )}
           </h1>
         </div>
         <div className="ml-auto flex items-center justify-end gap-3 flex-wrap">
-          {canEditInventory && (
+          {canEditInventory && activeView === 'inventory' && (
             <Primary
               href="#"
               text={savingItem ? 'Saving...' : 'Add item'}
@@ -523,13 +618,50 @@ const Inventory = () => {
               className="h-11!"
             />
           )}
-          <button
-            type="button"
-            onClick={() => setActiveView(activeView === 'turnover' ? 'inventory' : 'turnover')}
-            className="inline-flex h-11 items-center justify-center rounded-2xl border border-text-primary bg-white px-4 text-body-3-emphasis text-text-primary"
+          <GlassTooltip content="Export inventory" side="bottom">
+            <button
+              type="button"
+              aria-label="Export inventory"
+              className="inline-flex size-11 items-center justify-center rounded-full border border-card-border bg-white text-text-primary hover:bg-card-hover transition-colors"
+            >
+              <LuFileText size={20} aria-hidden="true" />
+            </button>
+          </GlassTooltip>
+          <fieldset
+            aria-label="Inventory view"
+            className="relative flex h-10 w-[260px] items-stretch overflow-hidden rounded-[999px]! border border-card-border bg-white m-0 p-0"
           >
-            {activeView === 'turnover' ? 'Stock' : 'Turnover'}
-          </button>
+            <legend className="sr-only">Inventory view</legend>
+            <div
+              aria-hidden
+              className={`absolute top-0 bottom-0 w-1/2 rounded-[999px]! transition-all duration-300 ease-in-out ${activeView === 'inventory' ? 'bg-(--color-primary-700)' : 'bg-success-700'}`}
+              style={{ transform: `translateX(${activeView === 'inventory' ? '0%' : '100%'})` }}
+            />
+            {(
+              [
+                { key: 'inventory', label: 'Inventory', Icon: TbLayoutGrid },
+                { key: 'turnover', label: 'Dispensary', Icon: TbPill },
+              ] as const
+            ).map(({ key, label, Icon }) => {
+              const isActive = activeView === key;
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  onClick={() => setActiveView(key)}
+                  aria-pressed={isActive}
+                  className={`relative z-10 flex w-1/2 items-center justify-center gap-1.5 text-body-4 transition-colors ${
+                    isActive
+                      ? 'text-white duration-150 delay-150'
+                      : 'text-text-secondary hover:text-text-primary duration-100 delay-0'
+                  }`}
+                >
+                  <Icon size={15} aria-hidden="true" className="shrink-0" />
+                  <span>{label}</span>
+                </button>
+              );
+            })}
+          </fieldset>
         </div>
       </div>
 
@@ -541,6 +673,22 @@ const Inventory = () => {
           <div className="flex w-full shrink-0 flex-col gap-4">
             {activeView === 'inventory' ? (
               <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
+                <div className="flex items-center gap-2">
+                  {(['ALL', 'ACTIVE', 'HIDDEN'] as const).map((vis) => {
+                    const label = getVisibilityLabel(vis);
+                    const active = filters.visibility === vis;
+                    return (
+                      <button
+                        key={vis}
+                        type="button"
+                        onClick={() => setFilters((prev) => ({ ...prev, visibility: vis }))}
+                        className={`inline-flex h-9 items-center rounded-full px-4 text-body-4 border transition-colors ${active ? 'border-blue-text text-blue-text bg-blue-light' : 'border-card-border text-text-primary hover:bg-card-hover bg-white'}`}
+                      >
+                        {label}
+                      </button>
+                    );
+                  })}
+                </div>
                 <div className="flex flex-wrap items-center gap-3">
                   <button
                     type="button"
@@ -549,10 +697,12 @@ const Inventory = () => {
                   >
                     <FiSliders size={18} aria-hidden="true" />
                     <span>Filter</span>
-                    {selectedFilterChips.length > 0 && (
+                    {selectedFilterChips.length > 0 ? (
                       <span className="rounded-full bg-badge-blue-bg px-2 text-caption-1 text-badge-blue-text">
                         {selectedFilterChips.length}
                       </span>
+                    ) : (
+                      <FiChevronDown size={16} aria-hidden="true" className="text-text-secondary" />
                     )}
                   </button>
                   <button
@@ -563,30 +713,68 @@ const Inventory = () => {
                     <FiFilter size={18} aria-hidden="true" />
                     <span>Sort by</span>
                   </button>
-                </div>
-                <div className="relative w-full xl:max-w-100">
-                  <FiSearch
-                    size={18}
-                    aria-hidden="true"
-                    className="absolute left-4 top-1/2 -translate-y-1/2 text-text-secondary"
-                  />
-                  <input
-                    aria-label="Search inventory"
-                    value={filters.search}
-                    onChange={(event) =>
-                      setFilters((prev) => ({ ...prev, search: event.target.value }))
-                    }
-                    placeholder="Search by item name, category, batch..."
-                    className="h-11 w-full rounded-2xl border border-card-border bg-white pl-11 pr-4 text-body-4 text-text-primary outline-none focus:border-input-border-active"
-                  />
+                  <div className="relative w-full sm:w-auto sm:min-w-72">
+                    <FiSearch
+                      size={18}
+                      aria-hidden="true"
+                      className="absolute left-4 top-1/2 -translate-y-1/2 text-text-secondary"
+                    />
+                    <input
+                      aria-label="Search inventory"
+                      value={filters.search}
+                      onChange={(event) =>
+                        setFilters((prev) => ({ ...prev, search: event.target.value }))
+                      }
+                      placeholder="Search by item name, category, batch..."
+                      className="h-11 w-full rounded-2xl border border-card-border bg-white pl-11 pr-4 text-body-4 text-text-primary outline-none focus:border-input-border-active"
+                    />
+                  </div>
                 </div>
               </div>
             ) : (
-              <InventoryTurnoverFilters
-                list={turnover}
-                setFilteredList={setFilteredTurnoverList}
-                categories={turnoverCategoryOptions}
-              />
+              <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
+                <div className="flex items-center gap-2">
+                  {(['ALL', 'PATIENT', 'IN_HOUSE'] as const).map((type) => {
+                    const label = getDispensaryRequestTypeLabel(type);
+                    const active = dispensaryRequestType === type;
+                    return (
+                      <button
+                        key={type}
+                        type="button"
+                        onClick={() => setDispensaryRequestType(type)}
+                        className={`inline-flex h-9 items-center rounded-full px-4 text-body-4 border transition-colors ${active ? 'border-blue-text text-blue-text bg-blue-light' : 'border-card-border text-text-primary hover:bg-card-hover bg-white'}`}
+                      >
+                        {label}
+                      </button>
+                    );
+                  })}
+                </div>
+                <div className="flex flex-wrap items-center gap-3">
+                  <button
+                    type="button"
+                    onClick={() => setDispensaryFilterOpen(true)}
+                    className="inline-flex h-11 items-center gap-2 rounded-2xl border border-card-border bg-white px-4 text-body-4 text-text-primary"
+                  >
+                    <FiSliders size={18} aria-hidden="true" />
+                    <span>Filter</span>
+                    <FiChevronDown size={16} aria-hidden="true" className="text-text-secondary" />
+                  </button>
+                  <div className="relative w-full sm:w-auto sm:min-w-72">
+                    <FiSearch
+                      size={18}
+                      aria-hidden="true"
+                      className="absolute left-4 top-1/2 -translate-y-1/2 text-text-secondary"
+                    />
+                    <input
+                      aria-label="Search dispensary"
+                      value={dispensarySearch}
+                      onChange={(e) => setDispensarySearch(e.target.value)}
+                      placeholder="Search by item name, category, batch..."
+                      className="h-11 w-full rounded-2xl border border-card-border bg-white pl-11 pr-4 text-body-4 text-text-primary outline-none focus:border-input-border-active"
+                    />
+                  </div>
+                </div>
+              </div>
             )}
           </div>
 
@@ -608,10 +796,47 @@ const Inventory = () => {
                 onRestock={handleRestock}
               />
             ) : (
-              <InventoryTurnoverTable filteredList={filteredTurnoverList} />
+              <DispensaryTable
+                filteredList={dispensaryRecords.filter((r) => {
+                  const typeMatch =
+                    dispensaryRequestType === 'ALL' || r.requestType === dispensaryRequestType;
+                  const statusMatch =
+                    dispensaryStatusFilter === 'ALL' || r.status === dispensaryStatusFilter;
+                  const searchMatch =
+                    !dispensarySearch.trim() ||
+                    r.patient.name.toLowerCase().includes(dispensarySearch.toLowerCase()) ||
+                    r.prescriptionItems.some((i) =>
+                      i.toLowerCase().includes(dispensarySearch.toLowerCase())
+                    );
+                  return typeMatch && statusMatch && searchMatch;
+                })}
+                onView={(record) => {
+                  setActiveDispensaryRecord(record);
+                  setDispensaryModalOpen(true);
+                }}
+                onDispense={async (record) => {
+                  if (!primaryOrgId) return;
+                  try {
+                    await dispensePrescription(primaryOrgId, record.prescriptionId);
+                    fetchDispensaryRecords();
+                  } catch {
+                    // silently fail
+                  }
+                }}
+              />
             )}
           </div>
         </div>
+
+        {activeDispensaryRecord && (
+          <DispensaryDetailModal
+            record={activeDispensaryRecord}
+            showModal={dispensaryModalOpen}
+            setShowModal={setDispensaryModalOpen}
+            organisationId={primaryOrgId ?? ''}
+            onActionComplete={fetchDispensaryRecords}
+          />
+        )}
 
         <AddInventory
           showModal={addPopup}
@@ -624,7 +849,8 @@ const Inventory = () => {
         {filterOpen && (
           <Modal showModal={filterOpen} setShowModal={setFilterOpen}>
             <div className="flex h-full flex-col">
-              <div className="flex items-center justify-between gap-3 pb-5">
+              {/* Header */}
+              <div className="flex items-center justify-between pb-4 shrink-0">
                 <div className="flex items-center gap-2 text-body-3-emphasis text-text-primary">
                   <FiSliders size={18} aria-hidden="true" />
                   <span>Filter</span>
@@ -632,15 +858,16 @@ const Inventory = () => {
                 {selectedFilterChips.length > 0 && (
                   <button
                     type="button"
-                    className="rounded-full border border-blue-text px-4 py-1.5 text-body-4 text-blue-text transition-colors hover:bg-blue-light"
                     onClick={() => setFilters(defaultFilters)}
+                    className="rounded-full border border-blue-text px-4 py-1.5 text-body-4 text-blue-text hover:bg-blue-light transition-colors"
                   >
                     Clear all
                   </button>
                 )}
               </div>
+              {/* Chips */}
               {selectedFilterChips.length > 0 && (
-                <div className="flex flex-wrap gap-2 pb-5">
+                <div className="flex flex-wrap gap-2 pb-4 shrink-0">
                   {selectedFilterChips.map((chip) => (
                     <span
                       key={chip.id}
@@ -649,151 +876,425 @@ const Inventory = () => {
                       {chip.label}
                       <button
                         type="button"
-                        aria-label={`Remove ${chip.label} filter`}
+                        aria-label={`Remove ${chip.label}`}
                         onClick={chip.onRemove}
-                        className="inline-flex size-4 items-center justify-center rounded-full text-badge-blue-text transition-colors hover:bg-badge-blue-text/15"
+                        className="inline-flex size-4 items-center justify-center rounded-full hover:bg-badge-blue-text/15 transition-colors"
                       >
-                        <FiX size={13} aria-hidden="true" />
+                        <FiX size={12} aria-hidden="true" />
                       </button>
                     </span>
                   ))}
                 </div>
               )}
-              <div className="flex flex-1 flex-col gap-5 overflow-y-auto pr-1">
-                <div className="flex flex-col gap-2 border-b border-card-border pb-4">
-                  <div className="text-body-4-emphasis text-text-primary">Stock status</div>
-                  {['ALL', 'LOW_STOCK', 'EXPIRED', 'OUT_OF_STOCK'].map((status) => (
-                    <label
-                      key={status}
-                      className="flex items-center gap-3 text-body-4 text-text-primary"
-                    >
-                      <input
-                        type="radio"
-                        name="stock-status"
-                        checked={filters.status === status}
-                        onChange={() => setFilters((prev) => ({ ...prev, status }))}
-                      />
-                      <span>
-                        {status === 'ALL' ? 'All' : status.replaceAll('_', ' ').toLowerCase()}
-                      </span>
-                    </label>
-                  ))}
+              {/* Accordion sections */}
+              <div className="flex flex-1 flex-col overflow-y-auto pr-1 divide-y divide-card-border">
+                {/* Stock status */}
+                <div>
+                  <button
+                    type="button"
+                    onClick={() => toggleFilterSection('stock-status')}
+                    className="flex w-full items-center justify-between py-3 text-left"
+                  >
+                    <div className="flex items-center gap-2">
+                      <span className="text-body-4 text-text-primary">Stock status</span>
+                      {filters.status !== 'ALL' && (
+                        <span className="inline-flex size-5 items-center justify-center rounded-full bg-blue-text text-[10px] font-bold text-white">
+                          1
+                        </span>
+                      )}
+                    </div>
+                    {filterOpenSections.has('stock-status') ? (
+                      <FiChevronUp size={16} className="text-text-secondary" />
+                    ) : (
+                      <FiChevronDown size={16} className="text-text-secondary" />
+                    )}
+                  </button>
+                  {filterOpenSections.has('stock-status') && (
+                    <div className="flex flex-col gap-3 pb-3">
+                      {(['ALL', 'LOW_STOCK', 'EXPIRED', 'OUT_OF_STOCK'] as const).map((s) => (
+                        <label
+                          key={s}
+                          className="flex items-center gap-3 text-body-4 text-text-primary cursor-pointer"
+                        >
+                          <input
+                            type="radio"
+                            name="stock-status"
+                            checked={filters.status === s}
+                            onChange={() => setFilters((prev) => ({ ...prev, status: s }))}
+                            className="accent-blue-text"
+                          />
+                          <span>{s === 'ALL' ? 'All' : s.replaceAll('_', ' ').toLowerCase()}</span>
+                        </label>
+                      ))}
+                    </div>
+                  )}
                 </div>
+                {/* Location */}
                 {locationFilterOptions.length > 0 && (
-                  <div className="flex flex-col gap-2 border-b border-card-border pb-4">
-                    <div className="text-body-4-emphasis text-text-primary">Location</div>
-                    {locationFilterOptions.map((location) => (
-                      <label
-                        key={location}
-                        className="flex items-center gap-3 text-body-4 text-text-primary"
-                      >
-                        <input
-                          type="checkbox"
-                          checked={filters.locations.includes(location)}
-                          onChange={() => toggleListFilter('locations', location)}
-                          className="size-4 accent-blue-text"
-                        />
-                        <span>{location}</span>
-                      </label>
-                    ))}
-                  </div>
-                )}
-                <div className="flex flex-col gap-2 border-b border-card-border pb-4">
-                  <div className="text-body-4-emphasis text-text-primary">Category</div>
-                  {categoryOptions.map((category) => (
-                    <div key={category} className="flex flex-col gap-2">
-                      <label className="flex items-center gap-3 text-body-4 text-text-primary">
-                        <input
-                          type="checkbox"
-                          checked={filters.categories.includes(category)}
-                          onChange={() => toggleCategoryFilter(category)}
-                          className="size-4 accent-blue-text"
-                        />
-                        <span>{category}</span>
-                      </label>
-                      {filters.categories.includes(category) &&
-                        categorySubcategoryOptions[category]?.map((subCategory) => (
+                  <div>
+                    <button
+                      type="button"
+                      onClick={() => toggleFilterSection('location')}
+                      className="flex w-full items-center justify-between py-3 text-left"
+                    >
+                      <div className="flex items-center gap-2">
+                        <span className="text-body-4 text-text-primary">Location</span>
+                        {filters.locations.length > 0 && (
+                          <span className="inline-flex size-5 items-center justify-center rounded-full bg-blue-text text-[10px] font-bold text-white">
+                            {filters.locations.length}
+                          </span>
+                        )}
+                      </div>
+                      {filterOpenSections.has('location') ? (
+                        <FiChevronUp size={16} className="text-text-secondary" />
+                      ) : (
+                        <FiChevronDown size={16} className="text-text-secondary" />
+                      )}
+                    </button>
+                    {filterOpenSections.has('location') && (
+                      <div className="flex flex-col gap-3 pb-3">
+                        {locationFilterOptions.map((loc) => (
                           <label
-                            key={`${category}-${subCategory}`}
-                            className="ml-7 flex items-center gap-3 text-body-4 text-text-secondary"
+                            key={loc}
+                            className="flex items-center gap-3 text-body-4 text-text-primary cursor-pointer"
                           >
                             <input
                               type="checkbox"
-                              checked={filters.subCategories.includes(subCategory)}
-                              onChange={() => toggleListFilter('subCategories', subCategory)}
+                              checked={filters.locations.includes(loc)}
+                              onChange={() => toggleListFilter('locations', loc)}
                               className="size-4 accent-blue-text"
                             />
-                            <span>{subCategory}</span>
+                            <span>{loc}</span>
                           </label>
                         ))}
-                    </div>
-                  ))}
-                </div>
-                <div className="flex flex-col gap-2 border-b border-card-border pb-4">
-                  <div className="text-body-4-emphasis text-text-primary">ABC class</div>
-                  {AbcClassOptions.map((abcClass) => (
-                    <label
-                      key={abcClass}
-                      className="flex items-center gap-3 text-body-4 text-text-primary"
-                    >
-                      <input
-                        type="checkbox"
-                        checked={filters.abcClasses.includes(abcClass)}
-                        onChange={() => toggleListFilter('abcClasses', abcClass)}
-                        className="size-4 accent-blue-text"
-                      />
-                      <span>{abcClass}</span>
-                    </label>
-                  ))}
-                </div>
-                {supplierFilterOptions.length > 0 && (
-                  <div className="flex flex-col gap-2 border-b border-card-border pb-4">
-                    <div className="text-body-4-emphasis text-text-primary">Supplier</div>
-                    {supplierFilterOptions.map((supplier) => (
-                      <label
-                        key={supplier}
-                        className="flex items-center gap-3 text-body-4 text-text-primary"
-                      >
-                        <input
-                          type="checkbox"
-                          checked={filters.suppliers.includes(supplier)}
-                          onChange={() => toggleListFilter('suppliers', supplier)}
-                          className="size-4 accent-blue-text"
-                        />
-                        <span>{supplier}</span>
-                      </label>
-                    ))}
+                      </div>
+                    )}
                   </div>
                 )}
-                <div className="flex flex-col gap-2">
-                  <div className="text-body-4-emphasis text-text-primary">Visibility</div>
-                  {(['ALL', 'ACTIVE', 'HIDDEN'] as const).map((visibility) => (
-                    <label
-                      key={visibility}
-                      className="flex items-center gap-3 text-body-4 text-text-primary"
-                    >
-                      <input
-                        type="radio"
-                        name="inventory-visibility"
-                        checked={filters.visibility === visibility}
-                        onChange={() => setFilters((prev) => ({ ...prev, visibility }))}
-                      />
-                      <span>{getVisibilityLabel(visibility)}</span>
-                    </label>
-                  ))}
+                {/* Category */}
+                <div>
+                  <button
+                    type="button"
+                    onClick={() => toggleFilterSection('category')}
+                    className="flex w-full items-center justify-between py-3 text-left"
+                  >
+                    <div className="flex items-center gap-2">
+                      <span className="text-body-4 text-text-primary">Category</span>
+                      {filters.categories.length > 0 && (
+                        <span className="inline-flex size-5 items-center justify-center rounded-full bg-blue-text text-[10px] font-bold text-white">
+                          {filters.categories.length}
+                        </span>
+                      )}
+                    </div>
+                    {filterOpenSections.has('category') ? (
+                      <FiChevronUp size={16} className="text-text-secondary" />
+                    ) : (
+                      <FiChevronDown size={16} className="text-text-secondary" />
+                    )}
+                  </button>
+                  {filterOpenSections.has('category') && (
+                    <div className="flex flex-col pb-3">
+                      {categoryOptions.map((category) => {
+                        const subs = categorySubcategoryOptions[category] ?? [];
+                        const isChecked = filters.categories.includes(category);
+                        const isExpanded = expandedCategories.has(category);
+                        return (
+                          <div key={category}>
+                            <div className="flex items-center gap-2 py-2">
+                              <input
+                                type="checkbox"
+                                checked={isChecked}
+                                onChange={() => toggleCategoryFilter(category)}
+                                className="size-4 accent-blue-text"
+                                id={`cat-${category}`}
+                              />
+                              <label
+                                htmlFor={`cat-${category}`}
+                                className={`flex-1 text-body-4 cursor-pointer ${isChecked ? 'text-blue-text font-semibold' : 'text-text-primary'}`}
+                              >
+                                {category}
+                              </label>
+                              {subs.length > 0 && (
+                                <button
+                                  type="button"
+                                  onClick={() => toggleExpandedCategory(category)}
+                                  className="text-text-secondary"
+                                >
+                                  {isExpanded ? (
+                                    <FiChevronUp size={14} />
+                                  ) : (
+                                    <FiChevronDown size={14} />
+                                  )}
+                                </button>
+                              )}
+                            </div>
+                            {subs.length > 0 && isExpanded && (
+                              <div className="ml-6 flex flex-col gap-2 pb-2">
+                                {subs.map((sub) => (
+                                  <label
+                                    key={sub}
+                                    className="flex items-center gap-3 text-body-4 text-text-secondary cursor-pointer"
+                                  >
+                                    <input
+                                      type="checkbox"
+                                      checked={filters.subCategories.includes(sub)}
+                                      onChange={() => toggleListFilter('subCategories', sub)}
+                                      className="size-4 accent-blue-text"
+                                    />
+                                    <span>{sub}</span>
+                                  </label>
+                                ))}
+                              </div>
+                            )}
+                          </div>
+                        );
+                      })}
+                    </div>
+                  )}
                 </div>
+                {/* ABC */}
+                <div>
+                  <button
+                    type="button"
+                    onClick={() => toggleFilterSection('abc')}
+                    className="flex w-full items-center justify-between py-3 text-left"
+                  >
+                    <div className="flex items-center gap-2">
+                      <span className="text-body-4 text-text-primary">ABC</span>
+                      {filters.abcClasses.length > 0 && (
+                        <span className="inline-flex size-5 items-center justify-center rounded-full bg-blue-text text-[10px] font-bold text-white">
+                          {filters.abcClasses.length}
+                        </span>
+                      )}
+                    </div>
+                    {filterOpenSections.has('abc') ? (
+                      <FiChevronUp size={16} className="text-text-secondary" />
+                    ) : (
+                      <FiChevronDown size={16} className="text-text-secondary" />
+                    )}
+                  </button>
+                  {filterOpenSections.has('abc') && (
+                    <div className="flex flex-col gap-3 pb-3">
+                      {AbcClassOptions.map((cls) => (
+                        <label
+                          key={cls}
+                          className="flex items-center gap-3 text-body-4 text-text-primary cursor-pointer"
+                        >
+                          <input
+                            type="checkbox"
+                            checked={filters.abcClasses.includes(cls)}
+                            onChange={() => toggleListFilter('abcClasses', cls)}
+                            className="size-4 accent-blue-text"
+                          />
+                          <span>{cls}</span>
+                        </label>
+                      ))}
+                    </div>
+                  )}
+                </div>
+                {/* Supplier */}
+                {supplierFilterOptions.length > 0 && (
+                  <div>
+                    <button
+                      type="button"
+                      onClick={() => toggleFilterSection('supplier')}
+                      className="flex w-full items-center justify-between py-3 text-left"
+                    >
+                      <div className="flex items-center gap-2">
+                        <span className="text-body-4 text-text-primary">Supplier</span>
+                        {filters.suppliers.length > 0 && (
+                          <span className="inline-flex size-5 items-center justify-center rounded-full bg-blue-text text-[10px] font-bold text-white">
+                            {filters.suppliers.length}
+                          </span>
+                        )}
+                      </div>
+                      {filterOpenSections.has('supplier') ? (
+                        <FiChevronUp size={16} className="text-text-secondary" />
+                      ) : (
+                        <FiChevronDown size={16} className="text-text-secondary" />
+                      )}
+                    </button>
+                    {filterOpenSections.has('supplier') && (
+                      <div className="flex flex-col gap-3 pb-3">
+                        {supplierFilterOptions.map((sup) => (
+                          <label
+                            key={sup}
+                            className="flex items-center gap-3 text-body-4 text-text-primary cursor-pointer"
+                          >
+                            <input
+                              type="checkbox"
+                              checked={filters.suppliers.includes(sup)}
+                              onChange={() => toggleListFilter('suppliers', sup)}
+                              className="size-4 accent-blue-text"
+                            />
+                            <span>{sup}</span>
+                          </label>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )}
               </div>
-              <div className="grid grid-cols-2 gap-3 border-t border-card-border pt-5 mt-5">
-                <Primary
-                  href="#"
-                  text="Apply"
-                  onClick={() => setFilterOpen(false)}
-                  icon={<FiCheck size={18} aria-hidden="true" />}
-                />
+              {/* Footer */}
+              <div className="grid grid-cols-2 gap-3 border-t border-card-border pt-5 mt-5 shrink-0">
                 <button
                   type="button"
                   onClick={() => setFilterOpen(false)}
-                  className="inline-flex min-h-12 items-center justify-center rounded-2xl border border-text-primary bg-white px-4 text-body-3-emphasis text-text-primary"
+                  className="inline-flex min-h-12 items-center justify-center gap-2 rounded-2xl bg-text-primary px-4 text-body-3-emphasis text-white hover:opacity-90 transition-opacity"
+                >
+                  <FiCheck size={18} aria-hidden="true" />
+                  Apply
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setFilters(defaultFilters);
+                    setFilterOpen(false);
+                  }}
+                  className="inline-flex min-h-12 items-center justify-center rounded-2xl border border-card-border bg-white px-4 text-body-3-emphasis text-text-primary hover:bg-card-hover transition-colors"
+                >
+                  Discard
+                </button>
+              </div>
+            </div>
+          </Modal>
+        )}
+
+        {dispensaryFilterOpen && (
+          <Modal showModal={dispensaryFilterOpen} setShowModal={setDispensaryFilterOpen}>
+            <div className="flex h-full flex-col">
+              <div className="flex items-center justify-between pb-4 shrink-0">
+                <div className="flex items-center gap-2 text-body-3-emphasis text-text-primary">
+                  <FiSliders size={18} aria-hidden="true" />
+                  <span>Filter</span>
+                </div>
+                {(dispensaryStatusFilter !== 'ALL' || dispensaryRequestType !== 'ALL') && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setDispensaryStatusFilter('ALL');
+                      setDispensaryRequestType('ALL');
+                    }}
+                    className="rounded-full border border-blue-text px-4 py-1.5 text-body-4 text-blue-text hover:bg-blue-light transition-colors"
+                  >
+                    Clear all
+                  </button>
+                )}
+              </div>
+              <div className="flex flex-1 flex-col overflow-y-auto pr-1 divide-y divide-card-border">
+                {/* Status */}
+                <div>
+                  <button
+                    type="button"
+                    onClick={() => toggleFilterSection('disp-status')}
+                    className="flex w-full items-center justify-between py-3 text-left"
+                  >
+                    <div className="flex items-center gap-2">
+                      <span className="text-body-4 text-text-primary">Status</span>
+                      {dispensaryStatusFilter !== 'ALL' && (
+                        <span className="inline-flex size-5 items-center justify-center rounded-full bg-blue-text text-[10px] font-bold text-white">
+                          1
+                        </span>
+                      )}
+                    </div>
+                    {filterOpenSections.has('disp-status') ? (
+                      <FiChevronUp size={16} className="text-text-secondary" />
+                    ) : (
+                      <FiChevronDown size={16} className="text-text-secondary" />
+                    )}
+                  </button>
+                  {filterOpenSections.has('disp-status') && (
+                    <div className="flex flex-col gap-3 pb-3">
+                      {(
+                        [
+                          { value: 'ALL', label: 'All' },
+                          { value: 'PENDING', label: 'Pending' },
+                          { value: 'DISPENSED', label: 'Dispensed' },
+                          { value: 'NOT_DISPENSED', label: 'Not dispensed' },
+                        ] as const
+                      ).map(({ value, label }) => (
+                        <label
+                          key={value}
+                          className="flex items-center gap-3 text-body-4 text-text-primary cursor-pointer"
+                        >
+                          <input
+                            type="radio"
+                            name="dispensary-status"
+                            checked={dispensaryStatusFilter === value}
+                            onChange={() => setDispensaryStatusFilter(value)}
+                            className="accent-blue-text"
+                          />
+                          <span>{label}</span>
+                        </label>
+                      ))}
+                    </div>
+                  )}
+                </div>
+                {/* Request type */}
+                <div>
+                  <button
+                    type="button"
+                    onClick={() => toggleFilterSection('disp-type')}
+                    className="flex w-full items-center justify-between py-3 text-left"
+                  >
+                    <div className="flex items-center gap-2">
+                      <span className="text-body-4 text-text-primary">Request type</span>
+                      {dispensaryRequestType !== 'ALL' && (
+                        <span className="inline-flex size-5 items-center justify-center rounded-full bg-blue-text text-[10px] font-bold text-white">
+                          1
+                        </span>
+                      )}
+                    </div>
+                    {filterOpenSections.has('disp-type') ? (
+                      <FiChevronUp size={16} className="text-text-secondary" />
+                    ) : (
+                      <FiChevronDown size={16} className="text-text-secondary" />
+                    )}
+                  </button>
+                  {filterOpenSections.has('disp-type') && (
+                    <div className="flex flex-col gap-3 pb-3">
+                      {(
+                        [
+                          { value: 'ALL', label: 'All requests' },
+                          { value: 'PATIENT', label: 'Patient' },
+                          { value: 'IN_HOUSE', label: 'Inhouse' },
+                        ] as const
+                      ).map(({ value, label }) => (
+                        <label
+                          key={value}
+                          className="flex items-center gap-3 text-body-4 text-text-primary cursor-pointer"
+                        >
+                          <input
+                            type="radio"
+                            name="dispensary-type"
+                            checked={dispensaryRequestType === value}
+                            onChange={() => setDispensaryRequestType(value)}
+                            className="accent-blue-text"
+                          />
+                          <span>{label}</span>
+                        </label>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+              <div className="grid grid-cols-2 gap-3 border-t border-card-border pt-5 mt-5 shrink-0">
+                <button
+                  type="button"
+                  onClick={() => setDispensaryFilterOpen(false)}
+                  className="inline-flex min-h-12 items-center justify-center gap-2 rounded-2xl bg-text-primary px-4 text-body-3-emphasis text-white hover:opacity-90 transition-opacity"
+                >
+                  <FiCheck size={18} aria-hidden="true" />
+                  Apply
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setDispensaryStatusFilter('ALL');
+                    setDispensaryRequestType('ALL');
+                    setDispensaryFilterOpen(false);
+                  }}
+                  className="inline-flex min-h-12 items-center justify-center rounded-2xl border border-card-border bg-white px-4 text-body-3-emphasis text-text-primary hover:bg-card-hover transition-colors"
                 >
                   Discard
                 </button>

--- a/apps/frontend/src/app/features/inventory/pages/Inventory/index.tsx
+++ b/apps/frontend/src/app/features/inventory/pages/Inventory/index.tsx
@@ -12,6 +12,7 @@ import {
   DispensaryStatus,
   InventoryFiltersState,
   InventoryItem,
+  InventoryTurnoverItem,
   SubCategoryOptions,
   SubCategoryByCategory,
 } from '@/app/features/inventory/pages/Inventory/types';
@@ -61,6 +62,10 @@ const InventorySectionSkeleton = () => (
 const InventoryTable = dynamic(() => import('@/app/ui/tables/InventoryTable'), {
   loading: () => <InventorySectionSkeleton />,
 });
+const InventoryTurnoverTable = dynamic(() => import('@/app/ui/tables/InventoryTurnoverTable'), {
+  loading: () => <InventorySectionSkeleton />,
+});
+const InventoryTurnoverFilters = dynamic(() => import('@/app/ui/filters/InventoryTurnoverFilters'));
 const DispensaryTable = dynamic(() => import('@/app/ui/tables/DispensaryTable'), {
   loading: () => <InventorySectionSkeleton />,
 });
@@ -74,7 +79,7 @@ const InventoryInfo = dynamic(() =>
   }))
 );
 
-type InventoryView = 'inventory' | 'turnover';
+type InventoryView = 'inventory' | 'turnover' | 'analytics';
 
 const toggleArrayValue = (values: string[], value: string) =>
   values.includes(value) ? values.filter((item) => item !== value) : [...values, value];
@@ -99,6 +104,60 @@ const compareInventoryRows = (a: InventoryItem, b: InventoryItem, sortMode: Sort
 
 const getSupplierName = (item: InventoryItem) =>
   (item.vendor?.supplierName || item.vendor?.vendor || '').trim();
+
+const filterAndSortInventory = (
+  inventory: InventoryItem[],
+  filters: InventoryFiltersState,
+  debouncedSearch: string,
+  sortMode: SortMode
+): InventoryItem[] => {
+  const normalizedSearch = debouncedSearch.trim().toLowerCase();
+  const visibilityFilter = (filters.visibility ?? 'ALL').toUpperCase();
+  const stockHealthFilter = filters.status.toUpperCase();
+  const selectedCategories = filters.categories ?? [];
+  const selectedSubCategories = filters.subCategories ?? [];
+  const selectedLocations = filters.locations ?? [];
+  const selectedAbcClasses = filters.abcClasses ?? [];
+  const selectedSuppliers = filters.suppliers ?? [];
+  const nextFiltered = inventory.filter((item) => {
+    const statusKey = (item.status || item.basicInfo.status || '').toUpperCase();
+    const stockHealthKey = (item.stockHealth || '').toUpperCase().replaceAll(' ', '_');
+    const categoryMatch =
+      (filters.category === 'all' && selectedCategories.length === 0) ||
+      selectedCategories.includes(item.basicInfo.category ?? '') ||
+      item.basicInfo.category?.toLowerCase() === filters.category.toLowerCase();
+    const subCategoryMatch =
+      selectedSubCategories.length === 0 ||
+      selectedSubCategories.includes(item.basicInfo.subCategory ?? '');
+    const locationMatch =
+      selectedLocations.length === 0 || selectedLocations.includes(item.stock?.stockLocation ?? '');
+    const abcClassMatch =
+      selectedAbcClasses.length === 0 || selectedAbcClasses.includes(item.stock?.abcClass ?? '');
+    const supplierMatch =
+      selectedSuppliers.length === 0 || selectedSuppliers.includes(getSupplierName(item));
+    const visibilityMatch = visibilityFilter === 'ALL' || statusKey === visibilityFilter;
+    const stockHealthMatch = stockHealthFilter === 'ALL' || stockHealthKey === stockHealthFilter;
+    const searchMatch =
+      normalizedSearch === '' ||
+      item.basicInfo.name.toLowerCase().includes(normalizedSearch) ||
+      item.basicInfo.category?.toLowerCase().includes(normalizedSearch) ||
+      item.basicInfo.subCategory?.toLowerCase().includes(normalizedSearch) ||
+      item.batch?.batch?.toLowerCase().includes(normalizedSearch) ||
+      item.basicInfo.description?.toLowerCase().includes(normalizedSearch);
+    return (
+      categoryMatch &&
+      subCategoryMatch &&
+      locationMatch &&
+      abcClassMatch &&
+      supplierMatch &&
+      visibilityMatch &&
+      stockHealthMatch &&
+      searchMatch
+    );
+  });
+  nextFiltered.sort((a, b) => compareInventoryRows(a, b, sortMode));
+  return nextFiltered;
+};
 
 const getDispenseRequestType = (
   fulfillment: string | undefined,
@@ -159,6 +218,288 @@ const getDispensaryRequestTypeLabel = (type: DispensaryRequestType): string => {
   if (type === 'ALL') return 'All requests';
   if (type === 'PATIENT') return 'Patient';
   return 'Inhouse';
+};
+
+type SelectedFilterChip = {
+  id: string;
+  label: string;
+  onRemove: () => void;
+};
+
+type InventoryFilterBarProps = {
+  filters: InventoryFiltersState;
+  selectedFilterChips: SelectedFilterChip[];
+  setFilterOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  setFilters: React.Dispatch<React.SetStateAction<InventoryFiltersState>>;
+  setSortMode: React.Dispatch<React.SetStateAction<SortMode>>;
+};
+
+const InventoryFilterBar = ({
+  filters,
+  selectedFilterChips,
+  setFilterOpen,
+  setFilters,
+  setSortMode,
+}: InventoryFilterBarProps) => (
+  <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
+    <div className="flex items-center gap-2">
+      {(['ALL', 'ACTIVE', 'HIDDEN'] as const).map((vis) => {
+        const label = getVisibilityLabel(vis);
+        const active = filters.visibility === vis;
+        return (
+          <button
+            key={vis}
+            type="button"
+            onClick={() => setFilters((prev) => ({ ...prev, visibility: vis }))}
+            className={`inline-flex h-9 items-center rounded-full px-4 text-body-4 border transition-colors ${active ? 'border-blue-text text-blue-text bg-blue-light' : 'border-card-border text-text-primary hover:bg-card-hover bg-white'}`}
+          >
+            {label}
+          </button>
+        );
+      })}
+    </div>
+    <div className="flex flex-wrap items-center gap-3">
+      <button
+        type="button"
+        onClick={() => setFilterOpen(true)}
+        className="inline-flex h-11 items-center gap-2 rounded-2xl border border-card-border bg-white px-4 text-body-4 text-text-primary"
+      >
+        <FiSliders size={18} aria-hidden="true" />
+        <span>Filter</span>
+        {selectedFilterChips.length > 0 ? (
+          <span className="rounded-full bg-badge-blue-bg px-2 text-caption-1 text-badge-blue-text">
+            {selectedFilterChips.length}
+          </span>
+        ) : (
+          <FiChevronDown size={16} aria-hidden="true" className="text-text-secondary" />
+        )}
+      </button>
+      <button
+        type="button"
+        onClick={() => setSortMode((prev) => getNextSortMode(prev))}
+        className="inline-flex h-11 items-center gap-2 rounded-2xl border border-card-border bg-white px-4 text-body-4 text-text-primary"
+      >
+        <FiFilter size={18} aria-hidden="true" />
+        <span>Sort by</span>
+      </button>
+      <div className="relative w-full sm:w-auto sm:min-w-72">
+        <FiSearch
+          size={18}
+          aria-hidden="true"
+          className="absolute left-4 top-1/2 -translate-y-1/2 text-text-secondary"
+        />
+        <input
+          aria-label="Search inventory"
+          value={filters.search}
+          onChange={(event) => setFilters((prev) => ({ ...prev, search: event.target.value }))}
+          placeholder="Search by item name, category, batch..."
+          className="h-11 w-full rounded-2xl border border-card-border bg-white pl-11 pr-4 text-body-4 text-text-primary outline-none focus:border-input-border-active"
+        />
+      </div>
+    </div>
+  </div>
+);
+
+type DispensaryFilterBarProps = {
+  dispensaryRequestType: DispensaryRequestType;
+  dispensarySearch: string;
+  setDispensaryRequestType: React.Dispatch<React.SetStateAction<DispensaryRequestType>>;
+  setDispensaryFilterOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  setDispensarySearch: React.Dispatch<React.SetStateAction<string>>;
+};
+
+const DispensaryFilterBar = ({
+  dispensaryRequestType,
+  dispensarySearch,
+  setDispensaryRequestType,
+  setDispensaryFilterOpen,
+  setDispensarySearch,
+}: DispensaryFilterBarProps) => (
+  <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
+    <div className="flex items-center gap-2">
+      {(['ALL', 'PATIENT', 'IN_HOUSE'] as const).map((type) => {
+        const label = getDispensaryRequestTypeLabel(type);
+        const active = dispensaryRequestType === type;
+        return (
+          <button
+            key={type}
+            type="button"
+            onClick={() => setDispensaryRequestType(type)}
+            className={`inline-flex h-9 items-center rounded-full px-4 text-body-4 border transition-colors ${active ? 'border-blue-text text-blue-text bg-blue-light' : 'border-card-border text-text-primary hover:bg-card-hover bg-white'}`}
+          >
+            {label}
+          </button>
+        );
+      })}
+    </div>
+    <div className="flex flex-wrap items-center gap-3">
+      <button
+        type="button"
+        onClick={() => setDispensaryFilterOpen(true)}
+        className="inline-flex h-11 items-center gap-2 rounded-2xl border border-card-border bg-white px-4 text-body-4 text-text-primary"
+      >
+        <FiSliders size={18} aria-hidden="true" />
+        <span>Filter</span>
+        <FiChevronDown size={16} aria-hidden="true" className="text-text-secondary" />
+      </button>
+      <div className="relative w-full sm:w-auto sm:min-w-72">
+        <FiSearch
+          size={18}
+          aria-hidden="true"
+          className="absolute left-4 top-1/2 -translate-y-1/2 text-text-secondary"
+        />
+        <input
+          aria-label="Search dispensary"
+          value={dispensarySearch}
+          onChange={(event) => setDispensarySearch(event.target.value)}
+          placeholder="Search by item name, category, batch..."
+          className="h-11 w-full rounded-2xl border border-card-border bg-white pl-11 pr-4 text-body-4 text-text-primary outline-none focus:border-input-border-active"
+        />
+      </div>
+    </div>
+  </div>
+);
+
+type ActiveFilterBarProps = {
+  activeView: InventoryView;
+  filters: InventoryFiltersState;
+  selectedFilterChips: SelectedFilterChip[];
+  setFilterOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  setFilters: React.Dispatch<React.SetStateAction<InventoryFiltersState>>;
+  setSortMode: React.Dispatch<React.SetStateAction<SortMode>>;
+  dispensaryRequestType: DispensaryRequestType;
+  dispensarySearch: string;
+  setDispensaryRequestType: React.Dispatch<React.SetStateAction<DispensaryRequestType>>;
+  setDispensaryFilterOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  setDispensarySearch: React.Dispatch<React.SetStateAction<string>>;
+};
+
+const ActiveFilterBar = (props: ActiveFilterBarProps) => {
+  if (props.activeView === 'inventory') {
+    return (
+      <InventoryFilterBar
+        filters={props.filters}
+        selectedFilterChips={props.selectedFilterChips}
+        setFilterOpen={props.setFilterOpen}
+        setFilters={props.setFilters}
+        setSortMode={props.setSortMode}
+      />
+    );
+  }
+
+  if (props.activeView === 'turnover') {
+    return (
+      <DispensaryFilterBar
+        dispensaryRequestType={props.dispensaryRequestType}
+        dispensarySearch={props.dispensarySearch}
+        setDispensaryRequestType={props.setDispensaryRequestType}
+        setDispensaryFilterOpen={props.setDispensaryFilterOpen}
+        setDispensarySearch={props.setDispensarySearch}
+      />
+    );
+  }
+
+  return null;
+};
+
+const filterDispensaryRecords = (
+  records: DispensaryRecord[],
+  requestType: DispensaryRequestType,
+  statusFilter: DispensaryStatus | 'ALL',
+  search: string
+) => {
+  const normalizedSearch = search.trim().toLowerCase();
+
+  return records.filter((record) => {
+    const typeMatch = requestType === 'ALL' || record.requestType === requestType;
+    const statusMatch = statusFilter === 'ALL' || record.status === statusFilter;
+    const searchMatch =
+      normalizedSearch === '' ||
+      record.patient.name.toLowerCase().includes(normalizedSearch) ||
+      record.prescriptionItems.some((item) => item.toLowerCase().includes(normalizedSearch));
+
+    return typeMatch && statusMatch && searchMatch;
+  });
+};
+
+type InventoryTableContentProps = {
+  activeView: InventoryView;
+  turnover: InventoryTurnoverItem[];
+  setFilteredTurnoverList: React.Dispatch<React.SetStateAction<InventoryTurnoverItem[]>>;
+  turnoverCategoryOptions: string[];
+  filteredTurnoverList: InventoryTurnoverItem[];
+  filteredInventory: InventoryItem[];
+  setActiveInventory: React.Dispatch<React.SetStateAction<InventoryItem | null>>;
+  setViewInventory: React.Dispatch<React.SetStateAction<boolean>>;
+  setInfoInitialSection: React.Dispatch<React.SetStateAction<InventorySectionKey | undefined>>;
+  filteredDispensaryRecords: DispensaryRecord[];
+  setActiveDispensaryRecord: React.Dispatch<React.SetStateAction<DispensaryRecord | null>>;
+  setDispensaryModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  onRestock: (item: InventoryItem) => void;
+  onDispense?: (record: DispensaryRecord) => Promise<void>;
+};
+
+const InventoryTableContent = ({
+  activeView,
+  turnover,
+  setFilteredTurnoverList,
+  turnoverCategoryOptions,
+  filteredTurnoverList,
+  filteredInventory,
+  setActiveInventory,
+  setViewInventory,
+  setInfoInitialSection,
+  filteredDispensaryRecords,
+  setActiveDispensaryRecord,
+  setDispensaryModalOpen,
+  onRestock,
+  onDispense,
+}: InventoryTableContentProps) => {
+  if (activeView === 'analytics') {
+    return (
+      <div className="flex flex-col gap-4 pt-3">
+        <InventoryTurnoverFilters
+          list={turnover}
+          setFilteredList={setFilteredTurnoverList}
+          categories={turnoverCategoryOptions}
+        />
+        <InventoryTurnoverTable filteredList={filteredTurnoverList} />
+      </div>
+    );
+  }
+
+  if (activeView === 'inventory') {
+    return (
+      <InventoryTable
+        setActiveInventory={setActiveInventory}
+        setViewInventory={setViewInventory}
+        onView={(item) => {
+          setActiveInventory(item);
+          setInfoInitialSection(undefined);
+          setViewInventory(true);
+        }}
+        filteredList={filteredInventory}
+        onRestock={onRestock}
+      />
+    );
+  }
+
+  return (
+    <DispensaryTable
+      filteredList={filteredDispensaryRecords}
+      onView={(record) => {
+        setActiveDispensaryRecord(record);
+        setDispensaryModalOpen(true);
+      }}
+      onDispense={onDispense}
+    />
+  );
+};
+
+const getInventoryPageTitle = (view: InventoryView): string => {
+  if (view === 'turnover') return 'Dispensary';
+  if (view === 'analytics') return 'Turnover';
+  return 'Inventory';
 };
 
 const toggleSetItem = (prev: Set<string>, key: string): Set<string> => {
@@ -689,6 +1030,10 @@ const Inventory = () => {
 
   const permissions = usePermissions();
   const canEditInventory = permissions.can(PERMISSIONS.INVENTORY_EDIT_ANY);
+  const canViewPrescription = permissions.can(PERMISSIONS.PRESCRIPTION_VIEW_ANY);
+  const canEditPrescription =
+    permissions.can(PERMISSIONS.PRESCRIPTION_EDIT_ANY) &&
+    permissions.can(PERMISSIONS.INVENTORY_EDIT_ANY);
   const primaryOrgId = useOrgStore((s) => s.primaryOrgId);
   const orgsById = useOrgStore((s) => s.orgsById);
   const primaryOrg = primaryOrgId ? orgsById[primaryOrgId] : null;
@@ -701,7 +1046,8 @@ const Inventory = () => {
   const resolvedBusinessType: BusinessType = businessType ?? 'GROOMER';
 
   const inventoryModule = useInventoryModule(resolvedBusinessType);
-  const { inventory, status, error: loadError } = inventoryModule;
+  const { inventory, turnover, status, error: loadError } = inventoryModule;
+  const [filteredTurnoverList, setFilteredTurnoverList] = useState<InventoryTurnoverItem[]>([]);
 
   const [filters, setFilters] = useState<InventoryFiltersState>(defaultFilters);
   const [debouncedSearch, setDebouncedSearch] = useState(headerSearchQuery);
@@ -710,15 +1056,19 @@ const Inventory = () => {
 
   const fetchDispensaryRecords = useCallback(async () => {
     if (!primaryOrgId) return;
+    const orgAtCallTime = primaryOrgId;
     try {
-      const data = await listDispenseRequests(primaryOrgId);
-      setDispensaryRecords(data.map(mapDispenseRequestToRecord));
+      const data = await listDispenseRequests(orgAtCallTime);
+      setDispensaryRecords((prev) =>
+        primaryOrgId === orgAtCallTime ? data.map(mapDispenseRequestToRecord) : prev
+      );
     } catch {
       // silently fail — table shows empty state
     }
   }, [primaryOrgId]);
 
   useEffect(() => {
+    setDispensaryRecords([]);
     fetchDispensaryRecords();
   }, [fetchDispensaryRecords]);
   const [activeDispensaryRecord, setActiveDispensaryRecord] = useState<DispensaryRecord | null>(
@@ -777,6 +1127,18 @@ const Inventory = () => {
     return Array.from(new Set([...configured, ...fromItems]));
   }, [resolvedBusinessType, inventory]);
 
+  const turnoverCategoryOptions = useMemo(
+    () =>
+      Array.from(
+        new Set(turnover.map((item) => item.category?.trim()).filter(Boolean) as string[])
+      ),
+    [turnover]
+  );
+
+  useEffect(() => {
+    setFilteredTurnoverList(turnover);
+  }, [turnover]);
+
   const stockLocationOptions = useMemo(() => {
     const roomNames = rooms
       .map((room) => room?.name?.trim())
@@ -824,66 +1186,8 @@ const Inventory = () => {
   });
 
   useEffect(() => {
-    const normalizedSearch = debouncedSearch.trim().toLowerCase();
-    const visibilityFilter = (filters.visibility ?? 'ALL').toUpperCase();
-    const stockHealthFilter = filters.status.toUpperCase();
-    const selectedCategories = filters.categories ?? [];
-    const selectedSubCategories = filters.subCategories ?? [];
-    const selectedLocations = filters.locations ?? [];
-    const selectedAbcClasses = filters.abcClasses ?? [];
-    const selectedSuppliers = filters.suppliers ?? [];
-    const nextFiltered = inventory.filter((item) => {
-      const statusKey = (item.status || item.basicInfo.status || '').toUpperCase();
-      const stockHealthKey = (item.stockHealth || '').toUpperCase().replaceAll(' ', '_');
-      const categoryMatch =
-        (filters.category === 'all' && selectedCategories.length === 0) ||
-        selectedCategories.includes(item.basicInfo.category ?? '') ||
-        item.basicInfo.category?.toLowerCase() === filters.category.toLowerCase();
-      const subCategoryMatch =
-        selectedSubCategories.length === 0 ||
-        selectedSubCategories.includes(item.basicInfo.subCategory ?? '');
-      const locationMatch =
-        selectedLocations.length === 0 ||
-        selectedLocations.includes(item.stock?.stockLocation ?? '');
-      const abcClassMatch =
-        selectedAbcClasses.length === 0 || selectedAbcClasses.includes(item.stock?.abcClass ?? '');
-      const supplierMatch =
-        selectedSuppliers.length === 0 || selectedSuppliers.includes(getSupplierName(item));
-      const visibilityMatch = visibilityFilter === 'ALL' || statusKey === visibilityFilter;
-      const stockHealthMatch = stockHealthFilter === 'ALL' || stockHealthKey === stockHealthFilter;
-      const searchMatch =
-        normalizedSearch === '' ||
-        item.basicInfo.name.toLowerCase().includes(normalizedSearch) ||
-        item.basicInfo.category?.toLowerCase().includes(normalizedSearch) ||
-        item.basicInfo.subCategory?.toLowerCase().includes(normalizedSearch) ||
-        item.batch?.batch?.toLowerCase().includes(normalizedSearch) ||
-        item.basicInfo.description?.toLowerCase().includes(normalizedSearch);
-      return (
-        categoryMatch &&
-        subCategoryMatch &&
-        locationMatch &&
-        abcClassMatch &&
-        supplierMatch &&
-        visibilityMatch &&
-        stockHealthMatch &&
-        searchMatch
-      );
-    });
-    nextFiltered.sort((a, b) => compareInventoryRows(a, b, sortMode));
-    setFilteredInventory(nextFiltered);
-  }, [
-    inventory,
-    filters.category,
-    filters.categories,
-    filters.subCategories,
-    filters.locations,
-    filters.abcClasses,
-    filters.suppliers,
-    filters.visibility,
-    filters.status,
-    debouncedSearch,
-    sortMode,
-  ]);
+    setFilteredInventory(filterAndSortInventory(inventory, filters, debouncedSearch, sortMode));
+  }, [inventory, filters, debouncedSearch, sortMode]);
 
   useEffect(() => {
     setActiveInventory((prev) => {
@@ -1045,7 +1349,7 @@ const Inventory = () => {
   );
 
   const selectedFilterChips = useMemo(() => {
-    const chips: { id: string; label: string; onRemove: () => void }[] = [];
+    const chips: SelectedFilterChip[] = [];
     if (filters.status !== 'ALL') {
       chips.push({
         id: `status-${filters.status}`,
@@ -1098,12 +1402,37 @@ const Inventory = () => {
     return chips;
   }, [filters, toggleCategoryFilter, toggleListFilter]);
 
+  const pageTitle = getInventoryPageTitle(activeView);
+  const filteredDispensaryRecords = useMemo(
+    () =>
+      filterDispensaryRecords(
+        dispensaryRecords,
+        dispensaryRequestType,
+        dispensaryStatusFilter,
+        dispensarySearch
+      ),
+    [dispensaryRecords, dispensaryRequestType, dispensaryStatusFilter, dispensarySearch]
+  );
+
+  const handleDispense = useCallback(
+    async (record: DispensaryRecord) => {
+      if (!primaryOrgId) return;
+      try {
+        await dispensePrescription(primaryOrgId, record.prescriptionId);
+        fetchDispensaryRecords();
+      } catch {
+        // silently fail
+      }
+    },
+    [fetchDispensaryRecords, primaryOrgId]
+  );
+
   return (
     <div className="relative min-w-0 flex h-full min-h-0 flex-col gap-4 pl-3! pr-3! pt-3! pb-3! md:pl-5! md:pr-5! md:pt-5! md:pb-3! lg:pl-5! lg:pr-5! lg:pt-5! lg:pb-3!">
       <div className="flex justify-between items-center w-full flex-wrap gap-3">
         <div className="flex flex-col gap-1">
           <h1 className="text-text-primary text-heading-2 flex items-center gap-2">
-            <span>{activeView === 'turnover' ? 'Dispensary' : 'Inventory'}</span>
+            <span>{pageTitle}</span>
             {activeView === 'inventory' && (
               <GlassTooltip
                 content="Organize stock, track batches and expiry, and monitor turnover so you know what to reorder and which items need attention."
@@ -1121,7 +1450,7 @@ const Inventory = () => {
           </h1>
         </div>
         <div className="ml-auto flex items-center justify-end gap-3 flex-wrap">
-          {canEditInventory && activeView === 'inventory' && (
+          {canEditInventory && activeView !== 'turnover' && (
             <Primary
               href="#"
               text={savingItem ? 'Saving...' : 'Add item'}
@@ -1131,50 +1460,65 @@ const Inventory = () => {
               className="h-11!"
             />
           )}
-          <GlassTooltip content="Export inventory" side="bottom">
+          {activeView === 'analytics' ? (
             <button
               type="button"
-              aria-label="Export inventory"
-              className="inline-flex size-11 items-center justify-center rounded-full border border-card-border bg-white text-text-primary hover:bg-card-hover transition-colors"
+              onClick={() => setActiveView('inventory')}
+              className="inline-flex h-11 items-center justify-center rounded-2xl border border-text-primary bg-white px-5 text-body-4-emphasis text-text-primary hover:bg-card-hover transition-colors"
             >
-              <LuFileText size={20} aria-hidden="true" />
+              Stock
             </button>
-          </GlassTooltip>
-          <fieldset
-            aria-label="Inventory view"
-            className="relative flex h-10 w-[260px] items-stretch overflow-hidden rounded-[999px]! border border-card-border bg-white m-0 p-0"
-          >
-            <legend className="sr-only">Inventory view</legend>
-            <div
-              aria-hidden
-              className={`absolute top-0 bottom-0 w-1/2 rounded-[999px]! transition-all duration-300 ease-in-out ${activeView === 'inventory' ? 'bg-(--color-primary-700)' : 'bg-success-700'}`}
-              style={{ transform: `translateX(${activeView === 'inventory' ? '0%' : '100%'})` }}
-            />
-            {(
-              [
-                { key: 'inventory', label: 'Inventory', Icon: TbLayoutGrid },
-                { key: 'turnover', label: 'Dispensary', Icon: TbPill },
-              ] as const
-            ).map(({ key, label, Icon }) => {
-              const isActive = activeView === key;
-              return (
-                <button
-                  key={key}
-                  type="button"
-                  onClick={() => setActiveView(key)}
-                  aria-pressed={isActive}
-                  className={`relative z-10 flex w-1/2 items-center justify-center gap-1.5 text-body-4 transition-colors ${
-                    isActive
-                      ? 'text-white duration-150 delay-150'
-                      : 'text-text-secondary hover:text-text-primary duration-100 delay-0'
-                  }`}
-                >
-                  <Icon size={15} aria-hidden="true" className="shrink-0" />
-                  <span>{label}</span>
-                </button>
-              );
-            })}
-          </fieldset>
+          ) : (
+            <GlassTooltip content="Turnover analytics" side="bottom">
+              <button
+                type="button"
+                aria-label="Turnover analytics"
+                onClick={() => setActiveView('analytics')}
+                className="inline-flex size-11 items-center justify-center rounded-full border border-card-border bg-white text-text-primary hover:bg-card-hover transition-colors"
+              >
+                <LuFileText size={20} aria-hidden="true" />
+              </button>
+            </GlassTooltip>
+          )}
+          {canViewPrescription && activeView !== 'analytics' && (
+            <fieldset
+              aria-label="Inventory view"
+              className="relative flex h-10 w-[260px] items-stretch overflow-hidden rounded-[999px]! border border-card-border bg-white m-0 p-0"
+            >
+              <legend className="sr-only">Inventory view</legend>
+              <div
+                aria-hidden
+                className={`pointer-events-none absolute top-0 bottom-0 w-1/2 rounded-[999px]! transition-all duration-300 ease-in-out ${activeView === 'inventory' ? 'bg-(--color-primary-700)' : 'bg-success-700'}`}
+                style={{ transform: `translateX(${activeView === 'inventory' ? '0%' : '100%'})` }}
+              />
+              <button
+                type="button"
+                onClick={() => setActiveView('inventory')}
+                aria-pressed={activeView === 'inventory'}
+                className={`relative z-10 flex w-1/2 items-center justify-center gap-1.5 text-body-4 transition-colors ${
+                  activeView === 'inventory'
+                    ? 'text-white duration-150 delay-150'
+                    : 'text-text-secondary hover:text-text-primary duration-100 delay-0'
+                }`}
+              >
+                <TbLayoutGrid size={15} aria-hidden="true" className="shrink-0" />
+                <span>Inventory</span>
+              </button>
+              <button
+                type="button"
+                onClick={() => setActiveView('turnover')}
+                aria-pressed={activeView === 'turnover'}
+                className={`relative z-10 flex w-1/2 items-center justify-center gap-1.5 text-body-4 transition-colors ${
+                  activeView === 'turnover'
+                    ? 'text-white duration-150 delay-150'
+                    : 'text-text-secondary hover:text-text-primary duration-100 delay-0'
+                }`}
+              >
+                <TbPill size={15} aria-hidden="true" className="shrink-0" />
+                <span>Dispensary</span>
+              </button>
+            </fieldset>
+          )}
         </div>
       </div>
 
@@ -1184,111 +1528,19 @@ const Inventory = () => {
       <PermissionGate allOf={[PERMISSIONS.INVENTORY_VIEW_ANY]} fallback={<Fallback />}>
         <div className={wrapperClassName}>
           <div className="flex w-full shrink-0 flex-col gap-4">
-            {activeView === 'inventory' ? (
-              <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
-                <div className="flex items-center gap-2">
-                  {(['ALL', 'ACTIVE', 'HIDDEN'] as const).map((vis) => {
-                    const label = getVisibilityLabel(vis);
-                    const active = filters.visibility === vis;
-                    return (
-                      <button
-                        key={vis}
-                        type="button"
-                        onClick={() => setFilters((prev) => ({ ...prev, visibility: vis }))}
-                        className={`inline-flex h-9 items-center rounded-full px-4 text-body-4 border transition-colors ${active ? 'border-blue-text text-blue-text bg-blue-light' : 'border-card-border text-text-primary hover:bg-card-hover bg-white'}`}
-                      >
-                        {label}
-                      </button>
-                    );
-                  })}
-                </div>
-                <div className="flex flex-wrap items-center gap-3">
-                  <button
-                    type="button"
-                    onClick={() => setFilterOpen(true)}
-                    className="inline-flex h-11 items-center gap-2 rounded-2xl border border-card-border bg-white px-4 text-body-4 text-text-primary"
-                  >
-                    <FiSliders size={18} aria-hidden="true" />
-                    <span>Filter</span>
-                    {selectedFilterChips.length > 0 ? (
-                      <span className="rounded-full bg-badge-blue-bg px-2 text-caption-1 text-badge-blue-text">
-                        {selectedFilterChips.length}
-                      </span>
-                    ) : (
-                      <FiChevronDown size={16} aria-hidden="true" className="text-text-secondary" />
-                    )}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setSortMode((prev) => getNextSortMode(prev))}
-                    className="inline-flex h-11 items-center gap-2 rounded-2xl border border-card-border bg-white px-4 text-body-4 text-text-primary"
-                  >
-                    <FiFilter size={18} aria-hidden="true" />
-                    <span>Sort by</span>
-                  </button>
-                  <div className="relative w-full sm:w-auto sm:min-w-72">
-                    <FiSearch
-                      size={18}
-                      aria-hidden="true"
-                      className="absolute left-4 top-1/2 -translate-y-1/2 text-text-secondary"
-                    />
-                    <input
-                      aria-label="Search inventory"
-                      value={filters.search}
-                      onChange={(event) =>
-                        setFilters((prev) => ({ ...prev, search: event.target.value }))
-                      }
-                      placeholder="Search by item name, category, batch..."
-                      className="h-11 w-full rounded-2xl border border-card-border bg-white pl-11 pr-4 text-body-4 text-text-primary outline-none focus:border-input-border-active"
-                    />
-                  </div>
-                </div>
-              </div>
-            ) : (
-              <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
-                <div className="flex items-center gap-2">
-                  {(['ALL', 'PATIENT', 'IN_HOUSE'] as const).map((type) => {
-                    const label = getDispensaryRequestTypeLabel(type);
-                    const active = dispensaryRequestType === type;
-                    return (
-                      <button
-                        key={type}
-                        type="button"
-                        onClick={() => setDispensaryRequestType(type)}
-                        className={`inline-flex h-9 items-center rounded-full px-4 text-body-4 border transition-colors ${active ? 'border-blue-text text-blue-text bg-blue-light' : 'border-card-border text-text-primary hover:bg-card-hover bg-white'}`}
-                      >
-                        {label}
-                      </button>
-                    );
-                  })}
-                </div>
-                <div className="flex flex-wrap items-center gap-3">
-                  <button
-                    type="button"
-                    onClick={() => setDispensaryFilterOpen(true)}
-                    className="inline-flex h-11 items-center gap-2 rounded-2xl border border-card-border bg-white px-4 text-body-4 text-text-primary"
-                  >
-                    <FiSliders size={18} aria-hidden="true" />
-                    <span>Filter</span>
-                    <FiChevronDown size={16} aria-hidden="true" className="text-text-secondary" />
-                  </button>
-                  <div className="relative w-full sm:w-auto sm:min-w-72">
-                    <FiSearch
-                      size={18}
-                      aria-hidden="true"
-                      className="absolute left-4 top-1/2 -translate-y-1/2 text-text-secondary"
-                    />
-                    <input
-                      aria-label="Search dispensary"
-                      value={dispensarySearch}
-                      onChange={(e) => setDispensarySearch(e.target.value)}
-                      placeholder="Search by item name, category, batch..."
-                      className="h-11 w-full rounded-2xl border border-card-border bg-white pl-11 pr-4 text-body-4 text-text-primary outline-none focus:border-input-border-active"
-                    />
-                  </div>
-                </div>
-              </div>
-            )}
+            <ActiveFilterBar
+              activeView={activeView}
+              filters={filters}
+              selectedFilterChips={selectedFilterChips}
+              setFilterOpen={setFilterOpen}
+              setFilters={setFilters}
+              setSortMode={setSortMode}
+              dispensaryRequestType={dispensaryRequestType}
+              dispensarySearch={dispensarySearch}
+              setDispensaryRequestType={setDispensaryRequestType}
+              setDispensaryFilterOpen={setDispensaryFilterOpen}
+              setDispensarySearch={setDispensarySearch}
+            />
           </div>
 
           {loadingList && activeView === 'inventory' && (
@@ -1296,48 +1548,22 @@ const Inventory = () => {
           )}
 
           <div ref={plannerSectionRef} className={plannerSectionClassName}>
-            {activeView === 'inventory' ? (
-              <InventoryTable
-                setActiveInventory={setActiveInventory}
-                setViewInventory={setViewInventory}
-                onView={(item) => {
-                  setActiveInventory(item);
-                  setInfoInitialSection(undefined);
-                  setViewInventory(true);
-                }}
-                filteredList={filteredInventory}
-                onRestock={handleRestock}
-              />
-            ) : (
-              <DispensaryTable
-                filteredList={dispensaryRecords.filter((r) => {
-                  const typeMatch =
-                    dispensaryRequestType === 'ALL' || r.requestType === dispensaryRequestType;
-                  const statusMatch =
-                    dispensaryStatusFilter === 'ALL' || r.status === dispensaryStatusFilter;
-                  const searchMatch =
-                    !dispensarySearch.trim() ||
-                    r.patient.name.toLowerCase().includes(dispensarySearch.toLowerCase()) ||
-                    r.prescriptionItems.some((i) =>
-                      i.toLowerCase().includes(dispensarySearch.toLowerCase())
-                    );
-                  return typeMatch && statusMatch && searchMatch;
-                })}
-                onView={(record) => {
-                  setActiveDispensaryRecord(record);
-                  setDispensaryModalOpen(true);
-                }}
-                onDispense={async (record) => {
-                  if (!primaryOrgId) return;
-                  try {
-                    await dispensePrescription(primaryOrgId, record.prescriptionId);
-                    fetchDispensaryRecords();
-                  } catch {
-                    // silently fail
-                  }
-                }}
-              />
-            )}
+            <InventoryTableContent
+              activeView={activeView}
+              turnover={turnover}
+              setFilteredTurnoverList={setFilteredTurnoverList}
+              turnoverCategoryOptions={turnoverCategoryOptions}
+              filteredTurnoverList={filteredTurnoverList}
+              filteredInventory={filteredInventory}
+              setActiveInventory={setActiveInventory}
+              setViewInventory={setViewInventory}
+              setInfoInitialSection={setInfoInitialSection}
+              filteredDispensaryRecords={filteredDispensaryRecords}
+              setActiveDispensaryRecord={setActiveDispensaryRecord}
+              setDispensaryModalOpen={setDispensaryModalOpen}
+              onRestock={handleRestock}
+              onDispense={canEditPrescription ? handleDispense : undefined}
+            />
           </div>
         </div>
 

--- a/apps/frontend/src/app/features/inventory/pages/Inventory/types.ts
+++ b/apps/frontend/src/app/features/inventory/pages/Inventory/types.ts
@@ -30,12 +30,24 @@ export type InventoryApiItem = {
   _id: string;
   organisationId: string;
   businessType: BusinessType;
+  itemType?: string;
   name: string;
   sku?: string;
   category?: string;
   subCategory?: string;
   description?: string;
   imageUrl?: string;
+  genericName?: string;
+  strength?: string;
+  dosageForm?: string;
+  routeOfAdministration?: string;
+  prescriptionRequired?: boolean;
+  controlledItem?: boolean;
+  storageInstructions?: string;
+  unitOfMeasure?: string;
+  packageQuantity?: number;
+  storageLocation?: string;
+  minimumStock?: number;
   attributes?: Record<string, any>;
   onHand?: number;
   allocated?: number;
@@ -68,12 +80,24 @@ export type InventoryBatchPayload = {
 export type InventoryRequestPayload = {
   organisationId: string;
   businessType: BusinessType;
+  itemType?: 'MEDICAL' | 'NON_MEDICAL';
   name: string;
   sku?: string;
   category?: string;
   subCategory?: string;
   description?: string;
   imageUrl?: string;
+  genericName?: string;
+  strength?: string;
+  dosageForm?: string;
+  routeOfAdministration?: string;
+  prescriptionRequired?: boolean;
+  controlledItem?: boolean;
+  storageInstructions?: string;
+  unitOfMeasure?: string;
+  packageQuantity?: number;
+  storageLocation?: string;
+  minimumStock?: number;
   attributes?: Record<string, any>;
   onHand?: number;
   allocated?: number;
@@ -488,6 +512,7 @@ export const SafetyClassificationOptions: string[] = [
 ];
 
 export type ClassificationValues = {
+  genericName?: string;
   form?: string;
   unitofMeasure?: string | string[];
   species?: string | string[];
@@ -664,6 +689,48 @@ export type InventoryErrors = {
   stock?: Partial<Record<keyof StockValues, string>>;
   batch?: Partial<Record<keyof BatchValues, string>>;
 };
+
+export type DispensaryRequestType = 'ALL' | 'PATIENT' | 'IN_HOUSE';
+export type DispensaryStatus = 'PENDING' | 'DISPENSED' | 'NOT_DISPENSED';
+
+export interface DispensaryItem {
+  name: string;
+  quantity: string;
+  priceCents: number;
+  isRx?: boolean;
+  isControlled?: boolean;
+  prescription?: {
+    dose: string;
+    freq: string;
+    duration: string;
+    refill: string;
+    route?: string;
+  };
+}
+
+export interface DispensaryRecord {
+  id: string;
+  prescriptionId: string;
+  patient: {
+    name: string;
+    appointmentId: string;
+    imageUrl?: string;
+    petBreed?: string;
+    petAge?: string;
+  };
+  status: DispensaryStatus;
+  prescriptionItems: string[];
+  prescriptionCreated: string;
+  amountCents: number;
+  currency?: string;
+  lead: string;
+  location: string;
+  timeDispensed?: string;
+  requestType: 'PATIENT' | 'IN_HOUSE';
+  invoiceId?: string;
+  paymentStatus?: 'PAID' | 'UNPAID';
+  items?: DispensaryItem[];
+}
 
 export interface InventoryTurnoverItem {
   itemId?: string;

--- a/apps/frontend/src/app/features/inventory/pages/Inventory/utils.ts
+++ b/apps/frontend/src/app/features/inventory/pages/Inventory/utils.ts
@@ -60,8 +60,8 @@ export const calculateBatchTotals = (
   let hasAllocated = false;
 
   batches.forEach((batch) => {
-    const qty = toNumberSafe(batch.quantity);
-    const alloc = toNumberSafe(batch.allocated);
+    const qty = batch.quantity === '' ? undefined : toNumberSafe(batch.quantity);
+    const alloc = batch.allocated === '' ? undefined : toNumberSafe(batch.allocated);
     if (qty !== undefined) {
       onHand += qty;
       hasOnHand = true;
@@ -114,6 +114,37 @@ const normalizeStatus = (status?: string): InventoryStatus | undefined => {
   }
 };
 
+const normalizeItemTypeForForm = (value?: string): string => {
+  const normalized = (value || '').trim().toUpperCase();
+  if (normalized === 'NON_MEDICAL' || normalized === 'NON-DRUG' || normalized === 'NON_DRUG') {
+    return 'Non-drug';
+  }
+  if (normalized === 'MEDICAL' || normalized === 'DRUG') {
+    return 'Drug';
+  }
+  return value || '';
+};
+
+const normalizeItemTypeForApi = (
+  value?: string
+): InventoryRequestPayload['itemType'] | undefined => {
+  const normalized = (value || '').trim().toLowerCase();
+  if (!normalized) return undefined;
+  if (normalized === 'non-drug' || normalized === 'non_medical' || normalized === 'non medical') {
+    return 'NON_MEDICAL';
+  }
+  return 'MEDICAL';
+};
+
+const normalizeBooleanStringForApi = (value?: string): boolean | undefined => {
+  if (value === undefined || value === null || value === '') return undefined;
+  if (typeof value === 'string') {
+    if (value === 'true' || value === 'Yes') return true;
+    if (value === 'false' || value === 'No') return false;
+  }
+  return Boolean(value);
+};
+
 export const formatStockHealthLabel = (stockHealth?: StockHealthStatus): string => {
   const key = (stockHealth || '').toString().trim().toUpperCase();
   switch (key) {
@@ -151,12 +182,12 @@ export const getStatusBadgeStyle = (statusLabel?: string) => {
         borderColor: 'var(--color-pill-info-border)',
       };
     case 'expired':
-    case 'out of stock':
       return {
         color: 'var(--color-pill-warning-text)',
         backgroundColor: 'var(--color-pill-warning-bg)',
         borderColor: 'var(--color-pill-warning-border)',
       };
+    case 'out of stock':
     case 'hidden':
       return {
         color: 'var(--color-pill-neutral-text)',
@@ -222,6 +253,8 @@ export const mapApiItemToInventoryItem = (apiItem: InventoryApiItem): InventoryI
       minShelfLifeAlertDate: toStringSafe(
         b.minShelfLifeAlertDate ?? attributes.minShelfLifeAlertDate
       ),
+      expiryWarningBefore: toStringSafe(attributes.expiryWarningBefore),
+      barcode: toStringSafe(attributes.barcode),
       quantity: toStringSafe(b.quantity),
       allocated: toStringSafe(b.allocated),
       createdAt: toStringSafe(b.createdAt),
@@ -287,7 +320,7 @@ export const mapApiItemToInventoryItem = (apiItem: InventoryApiItem): InventoryI
       brand: toStringSafe(attributes.brand),
       imageUrl: toStringSafe(apiItem.imageUrl ?? attributes.imageUrl),
       visibleInInventory: normalizeStatus(apiItem.status) !== 'HIDDEN',
-      itemType: toStringSafe(attributes.itemType),
+      itemType: normalizeItemTypeForForm(toStringSafe(apiItem.itemType ?? attributes.itemType)),
       drugSchedule: toStringSafe(attributes.drugSchedule),
       prescriptionRequired: toStringSafe(attributes.prescriptionRequired),
       regulationType: toStringSafe(attributes.regulationType),
@@ -302,19 +335,30 @@ export const mapApiItemToInventoryItem = (apiItem: InventoryApiItem): InventoryI
       skuCode: toStringSafe(attributes.skuCode ?? apiItem.sku),
     },
     classification: {
+      genericName: toStringSafe(apiItem.genericName ?? attributes.genericName),
       form: toStringSafe(attributes.form),
-      unitofMeasure: normalizeStringOrArray(attributes.unitofMeasure ?? attributes.unitOfMeasure),
+      unitofMeasure: normalizeStringOrArray(
+        apiItem.unitOfMeasure ?? attributes.unitofMeasure ?? attributes.unitOfMeasure
+      ),
       species: normalizeStringOrArray(attributes.species),
-      administration: toStringSafe(attributes.administration),
-      itemType: toStringSafe(attributes.itemType),
+      administration: toStringSafe(
+        apiItem.routeOfAdministration ??
+          attributes.routeOfAdministration ??
+          attributes.administration
+      ),
+      itemType: normalizeItemTypeForForm(toStringSafe(apiItem.itemType ?? attributes.itemType)),
       drugSchedule: toStringSafe(attributes.drugSchedule),
-      storageCondition: toStringSafe(attributes.storageCondition),
-      controlledSubstance: toStringSafe(attributes.controlledSubstance),
-      prescriptionRequired: toStringSafe(attributes.prescriptionRequired),
+      storageCondition: toStringSafe(
+        apiItem.storageInstructions ?? attributes.storageInstructions ?? attributes.storageCondition
+      ),
+      controlledSubstance: toStringSafe(apiItem.controlledItem ?? attributes.controlledSubstance),
+      prescriptionRequired: toStringSafe(
+        apiItem.prescriptionRequired ?? attributes.prescriptionRequired
+      ),
       reportableToGovernment: toStringSafe(attributes.reportableToGovernment),
       therapeuticClass: toStringSafe(attributes.therapeuticClass),
-      strength: toStringSafe(attributes.strength),
-      dosageForm: toStringSafe(attributes.dosageForm),
+      strength: toStringSafe(apiItem.strength ?? attributes.strength),
+      dosageForm: toStringSafe(apiItem.dosageForm ?? attributes.dosageForm),
       withdrawlPeriod: toStringSafe(attributes.withdrawlPeriod),
       dispenseUnit: toStringSafe(attributes.dispenseUnit),
       packSize: toStringSafe(attributes.packSize),
@@ -352,11 +396,11 @@ export const mapApiItemToInventoryItem = (apiItem: InventoryApiItem): InventoryI
       maxStock: toStringSafe(attributes.maxStock),
       reorderLevel: toStringSafe(apiItem.reorderLevel),
       reorderQuantity: toStringSafe(attributes.reorderQuantity),
-      stockLocation: toStringSafe(attributes.stockLocation),
+      stockLocation: toStringSafe(apiItem.storageLocation ?? attributes.storageLocation),
       abcClass: toStringSafe(attributes.abcClass),
       withdrawlPeriod: toStringSafe(attributes.withdrawlPeriod),
       stockType: toStringSafe(attributes.stockType),
-      minStockAlert: toStringSafe(attributes.minStockAlert),
+      minStockAlert: toStringSafe(apiItem.minimumStock ?? attributes.minStockAlert),
     },
     batch: {
       batch: toStringSafe(
@@ -373,8 +417,6 @@ export const mapApiItemToInventoryItem = (apiItem: InventoryApiItem): InventoryI
           attributes.expiryDate ??
           batches.find((b) => b.expiryDate)?.expiryDate
       ),
-      expiryWarningBefore: toStringSafe(attributes.expiryWarningBefore),
-      barcode: toStringSafe(primaryBatch?.serial ?? attributes.barcode),
       serial: toStringSafe(primaryBatch?.serial ?? attributes.serial),
       tracking: toStringSafe(primaryBatch?.tracking ?? attributes.tracking),
       litterId: toStringSafe(primaryBatch?.litterId ?? attributes.litterId),
@@ -390,6 +432,10 @@ export const mapApiItemToInventoryItem = (apiItem: InventoryApiItem): InventoryI
       ),
       quantity: toStringSafe(primaryBatch?.quantity ?? onHandVal),
       allocated: toStringSafe(primaryBatch?.allocated ?? allocatedVal),
+      expiryWarningBefore: toStringSafe(
+        primaryBatch?.expiryWarningBefore ?? attributes.expiryWarningBefore
+      ),
+      barcode: toStringSafe(primaryBatch?.barcode ?? attributes.barcode),
       _id: primaryBatch?._id,
       itemId: primaryBatch?.itemId,
       organisationId: primaryBatch?.organisationId,
@@ -408,19 +454,27 @@ const normalizeStatusForApi = (status?: string) => {
 export const buildBatchPayload = (batch: BatchValues): InventoryBatchPayload | undefined => {
   const batchRecord = batch as BatchValues & { current?: unknown; available?: unknown };
   const quantity = toNumberSafe(batch.quantity ?? batchRecord.current ?? batchRecord.available);
-  const allocated = toNumberSafe(batch.allocated);
+  const allocated = batch.allocated === '' ? undefined : toNumberSafe(batch.allocated);
   const normalizeDateForApi = (val?: string) => {
     if (!val) return undefined;
     if (val.includes('/')) {
       const [dd, mm, yyyy] = val.split('/');
-      const parsed = new Date(`${yyyy}-${mm}-${dd}`);
+      const parsed = new Date(Date.UTC(Number(yyyy), Number(mm) - 1, Number(dd)));
       if (!Number.isNaN(parsed.getTime())) {
-        return parsed.toISOString().split('T')[0];
+        return parsed.toISOString();
+      }
+    }
+    const isoDateMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(val);
+    if (isoDateMatch) {
+      const [, yyyy, mm, dd] = isoDateMatch;
+      const parsed = new Date(Date.UTC(Number(yyyy), Number(mm) - 1, Number(dd)));
+      if (!Number.isNaN(parsed.getTime())) {
+        return parsed.toISOString();
       }
     }
     const parsed = new Date(val);
     if (!Number.isNaN(parsed.getTime())) {
-      return parsed.toISOString().split('T')[0];
+      return parsed.toISOString();
     }
     return undefined;
   };
@@ -456,6 +510,29 @@ export const buildInventoryPayload = (
   organisationId: string,
   businessType: BusinessType
 ): InventoryRequestPayload => {
+  const itemType = normalizeItemTypeForApi(
+    formData.classification.itemType ?? formData.basicInfo.itemType
+  );
+  const genericName = formData.classification.genericName?.trim() || undefined;
+  const strength = formData.classification.strength?.trim() || undefined;
+  const dosageForm =
+    formData.classification.dosageForm?.trim() || formData.classification.form?.trim() || undefined;
+  const routeOfAdministration = formData.classification.administration?.trim() || undefined;
+  const prescriptionRequired = normalizeBooleanStringForApi(
+    formData.classification.prescriptionRequired ?? formData.basicInfo.prescriptionRequired
+  );
+  const controlledItem = normalizeBooleanStringForApi(formData.classification.controlledSubstance);
+  const storageInstructions =
+    formData.classification.storageCondition?.trim() ||
+    formData.basicInfo.storageCondition?.trim() ||
+    undefined;
+  const unitOfMeasureValue = formData.classification.unitofMeasure;
+  const unitOfMeasure = Array.isArray(unitOfMeasureValue)
+    ? unitOfMeasureValue[0]
+    : unitOfMeasureValue?.trim() || undefined;
+  const packageQuantity = toNumberSafe(formData.classification.packSize);
+  const storageLocation = formData.stock.stockLocation?.trim() || undefined;
+  const minimumStock = toNumberSafe(formData.stock.minStockAlert);
   const statusForApi = normalizeStatusForApi(formData.status ?? formData.basicInfo.status);
 
   const batchesSource =
@@ -468,7 +545,6 @@ export const buildInventoryPayload = (
 
   const attributes = cleanObject({
     department: formData.basicInfo.department,
-    brand: formData.basicInfo.brand ?? formData.vendor.brand,
     imageUrl: formData.basicInfo.imageUrl ?? formData.imageUrl,
     itemType: formData.classification.itemType ?? formData.basicInfo.itemType,
     drugSchedule: formData.classification.drugSchedule ?? formData.basicInfo.drugSchedule,
@@ -488,6 +564,7 @@ export const buildInventoryPayload = (
     animalStage: formData.basicInfo.animalStage,
     skuCode: formData.basicInfo.skuCode,
     ...formData.classification,
+    brand: formData.basicInfo.brand ?? formData.vendor.brand,
     tax: formData.pricing.tax,
     maxDiscount: formData.pricing.maxDiscount,
     supplierName: formData.vendor.supplierName,
@@ -514,12 +591,24 @@ export const buildInventoryPayload = (
   const payload: InventoryRequestPayload = {
     organisationId,
     businessType,
+    itemType,
     name: formData.basicInfo.name,
     sku: formData.basicInfo.skuCode || formData.sku,
     category: formData.basicInfo.category,
     subCategory: formData.basicInfo.subCategory,
     description: formData.basicInfo.description,
     imageUrl: formData.basicInfo.imageUrl ?? formData.imageUrl,
+    genericName,
+    strength,
+    dosageForm,
+    routeOfAdministration,
+    prescriptionRequired,
+    controlledItem,
+    storageInstructions,
+    unitOfMeasure,
+    packageQuantity,
+    storageLocation,
+    minimumStock,
     attributes: {
       ...attributes,
       species: formData.classification.species,

--- a/apps/frontend/src/app/features/inventory/pages/Inventory/utils.ts
+++ b/apps/frontend/src/app/features/inventory/pages/Inventory/utils.ts
@@ -133,7 +133,10 @@ const normalizeItemTypeForApi = (
   if (normalized === 'non-drug' || normalized === 'non_medical' || normalized === 'non medical') {
     return 'NON_MEDICAL';
   }
-  return 'MEDICAL';
+  if (normalized === 'drug' || normalized === 'medical') {
+    return 'MEDICAL';
+  }
+  return undefined;
 };
 
 const normalizeBooleanStringForApi = (value?: string): boolean | undefined => {

--- a/apps/frontend/src/app/features/inventory/services/dispensaryService.ts
+++ b/apps/frontend/src/app/features/inventory/services/dispensaryService.ts
@@ -1,4 +1,4 @@
-import { getData } from '@/app/services/axios';
+import api, { getData } from '@/app/services/axios';
 
 export type DispenseRequestStatus = 'PENDING' | 'NOT_DISPENSED' | 'DISPENSED';
 
@@ -72,6 +72,17 @@ export const getDispenseRequest = async (
 ): Promise<DispenseRequestApi> => {
   const res = await getData<DispenseRequestApi>(
     `/v1/prescriptions/organisations/${organisationId}/prescription-dispense-requests/${dispenseRequestId}`
+  );
+  return res.data;
+};
+
+export const fetchPrescriptionLabelPdf = async (
+  organisationId: string,
+  prescriptionId: string
+): Promise<Blob> => {
+  const res = await api.get<Blob>(
+    `/v1/prescriptions/organisations/${organisationId}/${prescriptionId}/label.pdf`,
+    { responseType: 'blob' }
   );
   return res.data;
 };

--- a/apps/frontend/src/app/features/inventory/services/dispensaryService.ts
+++ b/apps/frontend/src/app/features/inventory/services/dispensaryService.ts
@@ -1,0 +1,77 @@
+import { getData } from '@/app/services/axios';
+
+export type DispenseRequestStatus = 'PENDING' | 'NOT_DISPENSED' | 'DISPENSED';
+
+export interface DispenseRequestMedication {
+  inventoryItemId: string;
+  quantity?: number;
+  sourceLineKey?: string;
+  medicineName?: string;
+  priceCents?: number;
+  fulfillment?: 'IN_HOUSE' | 'PATIENT';
+  frequency?: string;
+  dosage?: string;
+  route?: string;
+  lowStock?: boolean;
+  stockQty?: number;
+  inventoryBatchId?: string;
+  medication?: string;
+}
+
+export interface DispenseRequestPrescription {
+  id: string;
+  artifactId: string;
+  artifact: {
+    id: string;
+    kind: string;
+    status: string;
+    appointmentId: string | null;
+    summary: string | null;
+  };
+}
+
+export interface DispenseRequestApi {
+  id: string;
+  prescriptionId: string;
+  organisationId: string;
+  status: DispenseRequestStatus;
+  medications: DispenseRequestMedication[];
+  metadata: Record<string, unknown> | null;
+  patientName: string | null;
+  petBreed: string | null;
+  petAge: string | null;
+  patientImageUrl: string | null;
+  leadName: string | null;
+  location: string | null;
+  invoiceId: string | null;
+  paymentStatus: 'PAID' | 'UNPAID' | null;
+  currency: string | null;
+  requestedBy: string;
+  reviewedBy: string | null;
+  requestedAt: string;
+  reviewedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  prescription: DispenseRequestPrescription;
+}
+
+export const listDispenseRequests = async (
+  organisationId: string,
+  status?: DispenseRequestStatus
+): Promise<DispenseRequestApi[]> => {
+  const params = status ? `?status=${status}` : '';
+  const res = await getData<DispenseRequestApi[]>(
+    `/v1/prescriptions/organisations/${organisationId}/prescription-dispense-requests${params}`
+  );
+  return res.data;
+};
+
+export const getDispenseRequest = async (
+  organisationId: string,
+  dispenseRequestId: string
+): Promise<DispenseRequestApi> => {
+  const res = await getData<DispenseRequestApi>(
+    `/v1/prescriptions/organisations/${organisationId}/prescription-dispense-requests/${dispenseRequestId}`
+  );
+  return res.data;
+};

--- a/apps/frontend/src/app/features/inventory/services/inventoryUploadService.ts
+++ b/apps/frontend/src/app/features/inventory/services/inventoryUploadService.ts
@@ -1,0 +1,22 @@
+import { postData } from '@/app/services/axios';
+import axios from 'axios';
+
+type PresignedUrlResponse = { uploadUrl: string; s3Key: string };
+
+export const getInventoryItemImagePresignedUrl = async (
+  organisationId: string,
+  mimeType: string
+): Promise<PresignedUrlResponse> => {
+  const res = await postData<PresignedUrlResponse>(
+    `/v1/inventory/organisation/${organisationId}/items/upload-url`,
+    { mimeType }
+  );
+  return res.data;
+};
+
+export const uploadFileToS3 = async (uploadUrl: string, file: File): Promise<void> => {
+  await axios.put(uploadUrl, file, {
+    headers: { 'Content-Type': file.type },
+    withCredentials: false,
+  });
+};

--- a/apps/frontend/src/app/hooks/useAppointmentForm.ts
+++ b/apps/frontend/src/app/hooks/useAppointmentForm.ts
@@ -378,10 +378,6 @@ export const useAppointmentForm = (options: UseAppointmentFormOptions = {}) => {
   const revampPackages = useRevampCatalogStore((state) => state.packages);
   const loadSpecialityCatalog = useRevampCatalogStore((state) => state.loadSpecialityCatalog);
   const { canMore, reason } = useCanMoreForPrimaryOrg('appointments');
-  const getServicesBySpecialityId = useMemo(
-    () => useServiceStore.getState().getServicesBySpecialityId,
-    []
-  );
   const { refetch: refetchData } = useSubscriptionCounterUpdate();
 
   const [formData, setFormData] = useState<AppointmentWithCompanion>(
@@ -424,6 +420,7 @@ export const useAppointmentForm = (options: UseAppointmentFormOptions = {}) => {
 
   const getAppointmentServicesBySpecialityId = useCallback(
     (specialityId: string): AppointmentCatalogService[] => {
+      const legacyServices = useServiceStore.getState().getServicesBySpecialityId(specialityId);
       const currentCatalogServices = revampServices
         .filter(
           (service) =>
@@ -440,10 +437,9 @@ export const useAppointmentForm = (options: UseAppointmentFormOptions = {}) => {
             pkg.organisationId === primaryOrgId
         )
         .map(mapRevampPackageForAppointment);
-      const legacyServices = getServicesBySpecialityId(specialityId);
       return mergeServicesById([...currentCatalogServices, ...catalogPackages], legacyServices);
     },
-    [getServicesBySpecialityId, primaryOrgId, revampPackages, revampServices]
+    [primaryOrgId, revampPackages, revampServices]
   );
 
   const ServiceFields = useMemo(

--- a/apps/frontend/src/app/lib/urls.ts
+++ b/apps/frontend/src/app/lib/urls.ts
@@ -106,6 +106,20 @@ export const getSafeImageUrl = (src: string | null | undefined, type: ImageType)
   return isHttpsImageUrl(src) ? src : pick(fallbackPool);
 };
 
+export const getSafeOrgImageUrl = (
+  src: string | null | undefined,
+  options?: { allowBlob?: boolean }
+): string => {
+  const value = String(src ?? '').trim();
+  if (!value || value === 'undefined' || value === 'null') return '';
+  if (options?.allowBlob && value.startsWith('blob:')) return value;
+  if (/^https:\/\/.+/i.test(value)) return value;
+  if (value.includes(':')) return '';
+  if (value.includes('://')) return '';
+  const normalizedKey = value.replace(/^\/+/, '');
+  return normalizedKey ? MEDIA_SOURCES.organization.fromS3Key(normalizedKey) : '';
+};
+
 const STRIPE_ALLOWED_HOST_SUFFIXES = ['stripe.com'] as const;
 
 const hasAllowedStripeHost = (hostname: string): boolean => {

--- a/apps/frontend/src/app/ui/primitives/Accordion/EditableAccordion.tsx
+++ b/apps/frontend/src/app/ui/primitives/Accordion/EditableAccordion.tsx
@@ -37,6 +37,7 @@ type EditableAccordionProps = {
   hideInlineActions?: boolean;
   compactInlineActions?: boolean;
   onEditingChange?: (isEditing: boolean) => void;
+  footer?: React.ReactNode;
   onRegisterActions?: (
     actions: {
       save: () => Promise<void>;
@@ -527,6 +528,7 @@ const EditableAccordion: React.FC<EditableAccordionProps> = ({
   hideInlineActions = false,
   compactInlineActions = false,
   onEditingChange,
+  footer,
   onRegisterActions,
 }) => {
   const [isEditing, setIsEditing] = useState(false);
@@ -656,6 +658,7 @@ const EditableAccordion: React.FC<EditableAccordionProps> = ({
               </div>
             );
           })}
+          {footer && <div className="mt-3">{footer}</div>}
         </div>
       </Accordion>
 

--- a/apps/frontend/src/app/ui/primitives/Accordion/EditableAccordion.tsx
+++ b/apps/frontend/src/app/ui/primitives/Accordion/EditableAccordion.tsx
@@ -154,6 +154,23 @@ const FieldComponents: Record<
       error={error}
     />
   ),
+  checkbox: ({ field, value, onChange, error }) => {
+    const checked = value === true || value === 'true' || value === 'Yes';
+    return (
+      <div className="flex flex-col gap-2">
+        <label className="flex min-h-10 cursor-pointer items-center gap-3 text-body-4 text-text-primary">
+          <input
+            type="checkbox"
+            checked={checked}
+            onChange={(event) => onChange(event.target.checked ? 'true' : 'false')}
+            className="size-5 rounded border-input-border-default accent-blue-text"
+          />
+          <span>{field.label}</span>
+        </label>
+        {error ? <div className="px-4 text-caption-1 text-red-600">{error}</div> : null}
+      </div>
+    );
+  },
   country: ({ value, onChange, error }) => (
     <LabelDropdown
       placeholder="Choose country"
@@ -286,6 +303,20 @@ const isCurrencyField = (fieldKey: string) => {
   return fieldKey === 'purchaseCost' || fieldKey === 'selling';
 };
 
+const formatDisplayValue = (value: unknown): string => {
+  if (Array.isArray(value)) {
+    return value.length > 0 ? value.join(', ') : '-';
+  }
+  if (value === undefined || value === null || value === '') {
+    return '-';
+  }
+  if (typeof value === 'object') return '-';
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  return '-';
+};
+
 const FieldValueComponents: Record<
   string,
   React.FC<{
@@ -297,9 +328,7 @@ const FieldValueComponents: Record<
     <div className={`py-2.5! flex items-center gap-2 justify-between border-t border-card-border`}>
       <div className="text-body-4-emphasis text-text-secondary">{field.label}</div>
       <div className="text-body-4 text-text-primary text-right">
-        {Array.isArray(formValues[field.key])
-          ? (formValues[field.key] as string[]).join(', ')
-          : formValues[field.key] || '-'}
+        {formatDisplayValue(formValues[field.key])}
       </div>
     </div>
   ),
@@ -314,7 +343,9 @@ const FieldValueComponents: Record<
   number: ({ field, formValues }) => (
     <div className={`py-2.5! flex items-center gap-2 justify-between border-t border-card-border`}>
       <div className="text-body-4-emphasis text-text-secondary">{field.label}</div>
-      <div className="text-body-4 text-text-primary text-right">{formValues[field.key] || '-'}</div>
+      <div className="text-body-4 text-text-primary text-right">
+        {formatDisplayValue(formValues[field.key])}
+      </div>
     </div>
   ),
   select: ({ field, formValues }) => (
@@ -325,7 +356,7 @@ const FieldValueComponents: Record<
           const value = formValues[field.key];
           const options = normalizeOptions(field.options);
           if (options.length) return resolveLabel(options, value);
-          return value || '-';
+          return formatDisplayValue(value);
         })()}
       </div>
     </div>
@@ -338,7 +369,7 @@ const FieldValueComponents: Record<
           const value = formValues[field.key];
           const options = normalizeOptions(field.options);
           if (options.length) return resolveLabel(options, value);
-          return value || '-';
+          return formatDisplayValue(value);
         })()}
       </div>
     </div>
@@ -365,6 +396,18 @@ const FieldValueComponents: Record<
       </div>
     </div>
   ),
+  checkbox: ({ field, formValues }) => {
+    const value = formValues[field.key];
+    const checked = value === true || value === 'true' || value === 'Yes';
+    return (
+      <div
+        className={`py-2.5! flex items-center gap-2 justify-between border-t border-card-border`}
+      >
+        <div className="text-body-4-emphasis text-text-secondary">{field.label}</div>
+        <div className="text-body-4 text-text-primary text-right">{checked ? 'Yes' : 'No'}</div>
+      </div>
+    );
+  },
   country: ({ field, formValues }) => (
     <div className={`py-2.5! flex items-center gap-2 justify-between border-t border-card-border`}>
       <div className="text-body-4-emphasis text-text-secondary">{field.label}</div>
@@ -435,9 +478,19 @@ const buildInitialValues = (fields: FieldConfig[], data: Record<string, any>): F
       if (Array.isArray(initialValue)) {
         value = initialValue;
       } else if (typeof initialValue === 'string' && initialValue.trim() !== '') {
-        value = [initialValue];
+        value = initialValue.includes(',')
+          ? initialValue
+              .split(',')
+              .map((item) => item.trim())
+              .filter(Boolean)
+          : [initialValue];
       }
       acc[field.key] = value;
+    } else if (field.type === 'checkbox') {
+      acc[field.key] =
+        initialValue === true || initialValue === 'true' || initialValue === 'Yes'
+          ? 'true'
+          : 'false';
     } else if (field.type === 'date') {
       acc[field.key] = initialValue ?? '';
     } else {
@@ -526,10 +579,12 @@ const EditableAccordion: React.FC<EditableAccordionProps> = ({
     setIsEditing(false);
   }, [data, fields, isSaving]);
 
-  if (readOnly && isEditing) {
-    setIsEditing(false);
-    onEditingChange?.(false);
-  }
+  useEffect(() => {
+    if (readOnly && isEditing) {
+      setIsEditing(false);
+      onEditingChange?.(false);
+    }
+  }, [readOnly, isEditing, onEditingChange]);
 
   const handleSave = useCallback(async () => {
     if (isSaving) return;

--- a/apps/frontend/src/app/ui/tables/DispensaryTable.tsx
+++ b/apps/frontend/src/app/ui/tables/DispensaryTable.tsx
@@ -1,0 +1,285 @@
+'use client';
+import React from 'react';
+import Image from 'next/image';
+import { IoEye } from 'react-icons/io5';
+import { FiCheck } from 'react-icons/fi';
+import GenericTable from '@/app/ui/tables/GenericTable/GenericTable';
+import { DispensaryRecord, DispensaryStatus } from '@/app/features/inventory/pages/Inventory/types';
+import GlassTooltip from '@/app/ui/primitives/GlassTooltip/GlassTooltip';
+
+import './DataTable.css';
+
+type Column<T> = {
+  label: string;
+  key: keyof T | string;
+  width?: string;
+  render?: (item: T) => React.ReactNode;
+};
+
+type DispensaryTableProps = {
+  filteredList: DispensaryRecord[];
+  onView?: (record: DispensaryRecord) => void;
+  onDispense?: (record: DispensaryRecord) => void;
+};
+
+const STATUS_STYLES: Record<DispensaryStatus, React.CSSProperties> = {
+  PENDING: {
+    color: 'var(--color-pill-warning-text)',
+    backgroundColor: 'var(--color-pill-warning-bg)',
+    borderColor: 'var(--color-pill-warning-border)',
+  },
+  DISPENSED: {
+    color: 'var(--color-pill-success-text)',
+    backgroundColor: 'var(--color-pill-success-bg)',
+    borderColor: 'var(--color-pill-success-border)',
+  },
+  NOT_DISPENSED: {
+    color: 'var(--color-danger-600)',
+    backgroundColor: 'var(--color-danger-100)',
+    borderColor: 'var(--color-danger-400)',
+  },
+};
+
+const STATUS_LABELS: Record<DispensaryStatus, string> = {
+  PENDING: 'Pending',
+  DISPENSED: 'Dispensed',
+  NOT_DISPENSED: 'Not dispensed',
+};
+
+const formatAmount = (cents: number, currency = 'USD') => {
+  const symbol = currency === 'USD' ? '$' : currency;
+  return `${symbol} ${(cents / 100).toFixed(2)}`;
+};
+
+const formatDateTime = (iso?: string) => {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  return (
+    d.toLocaleDateString('en-US', { month: 'short', day: '2-digit', year: 'numeric' }) +
+    '\n' +
+    d.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' })
+  );
+};
+
+const DispensaryTable = ({ filteredList, onView, onDispense }: DispensaryTableProps) => {
+  const columns: Column<DispensaryRecord>[] = [
+    {
+      label: 'Request type',
+      key: 'patient',
+      width: '170px',
+      render: (record) => (
+        <div className="flex items-center gap-3">
+          <div className="flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-full bg-card-hover">
+            {record.patient.imageUrl ? (
+              <Image
+                src={record.patient.imageUrl}
+                alt=""
+                width={40}
+                height={40}
+                className="size-full object-cover"
+              />
+            ) : (
+              <span className="text-body-4 text-text-secondary font-semibold">
+                {record.patient.name === '—' ? '?' : record.patient.name.charAt(0)}
+              </span>
+            )}
+          </div>
+          <div className="min-w-0">
+            <div className="appointment-profile-title leading-tight">{record.patient.name}</div>
+            {record.patient.petBreed && (
+              <div className="text-caption-1 text-text-secondary">{record.patient.petBreed}</div>
+            )}
+          </div>
+        </div>
+      ),
+    },
+    {
+      label: 'Status',
+      key: 'status',
+      width: '120px',
+      render: (record) => (
+        <div className="appointment-status" style={STATUS_STYLES[record.status]}>
+          {STATUS_LABELS[record.status]}
+        </div>
+      ),
+    },
+    {
+      label: 'Items',
+      key: 'prescriptionItems',
+      width: '180px',
+      render: (record) => (
+        <ul className="flex flex-col gap-0.5 list-none p-0 m-0">
+          {(record.items ?? []).map((item) => (
+            <li key={item.name} className="appointment-profile-title text-caption-1">
+              • {item.name}
+            </li>
+          ))}
+        </ul>
+      ),
+    },
+    {
+      label: 'Request created',
+      key: 'prescriptionCreated',
+      width: '120px',
+      render: (record) => (
+        <div className="appointment-profile-title text-[var(--color-success-600)] whitespace-pre-line">
+          {formatDateTime(record.prescriptionCreated)}
+        </div>
+      ),
+    },
+    {
+      label: 'Amount',
+      key: 'amountCents',
+      width: '90px',
+      render: (record) => (
+        <div className="appointment-profile-title font-semibold">
+          {formatAmount(record.amountCents, record.currency)}
+        </div>
+      ),
+    },
+    {
+      label: 'Lead',
+      key: 'lead',
+      width: '140px',
+      render: (record) => <div className="appointment-profile-title">{record.lead || '—'}</div>,
+    },
+    {
+      label: 'Location',
+      key: 'location',
+      width: '110px',
+      render: (record) => <div className="appointment-profile-title">{record.location || '—'}</div>,
+    },
+    {
+      label: 'Time Dispensed',
+      key: 'timeDispensed',
+      width: '110px',
+      render: (record) => (
+        <div
+          className={`appointment-profile-title whitespace-pre-line ${record.timeDispensed ? 'text-[var(--color-success-600)]' : ''}`}
+        >
+          {formatDateTime(record.timeDispensed)}
+        </div>
+      ),
+    },
+    {
+      label: 'Action',
+      key: 'actions',
+      width: '96px',
+      render: (record) => (
+        <div className="action-btn-col">
+          {record.status === 'PENDING' && onDispense && (
+            <GlassTooltip content="Mark as dispensed" side="top">
+              <button
+                type="button"
+                onClick={() => onDispense(record)}
+                aria-label={`Dispense prescription for ${record.patient.name}`}
+                className="size-10 rounded-full border border-[var(--color-success-600)] flex items-center justify-center cursor-pointer bg-[var(--color-success-600)] hover:opacity-80 transition-opacity"
+              >
+                <FiCheck size={18} color="white" />
+              </button>
+            </GlassTooltip>
+          )}
+          {onView && (
+            <GlassTooltip content="View details" side="top">
+              <button
+                type="button"
+                onClick={() => onView(record)}
+                aria-label={`View prescription for ${record.patient.name}`}
+                className="hover:shadow-[0_0_8px_0_rgba(0,0,0,0.16)] size-10 rounded-full border border-black-text flex items-center justify-center cursor-pointer"
+              >
+                <IoEye size={20} color="var(--color-neutral-900)" />
+              </button>
+            </GlassTooltip>
+          )}
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <div className="table-wrapper inventory-scroll-x h-full min-h-0 overflow-hidden">
+      <div className="inventory-table-list h-full min-h-0 flex-1 overflow-y-auto pr-1 pb-2">
+        <GenericTable
+          data={filteredList}
+          columns={columns}
+          bordered={false}
+          pagination
+          pageSize={10}
+          tableClassName="inventory-table-fixed"
+        />
+      </div>
+      <div className="inventory-card-list gap-4 sm:gap-6 flex-wrap">
+        {filteredList.length === 0 ? (
+          <div className="w-full py-6 flex items-center justify-center text-body-4 text-text-primary">
+            No data available
+          </div>
+        ) : (
+          filteredList.map((record) => (
+            <div
+              key={record.id}
+              className="sm:min-w-[280px] w-full sm:w-[calc(50%-12px)] rounded-2xl border border-card-border bg-white p-3 flex flex-col gap-2"
+            >
+              <div className="flex items-center justify-between gap-2">
+                <div className="text-body-3-emphasis text-text-primary truncate">
+                  {record.patient.name}
+                </div>
+                <div className="appointment-status shrink-0" style={STATUS_STYLES[record.status]}>
+                  {STATUS_LABELS[record.status]}
+                </div>
+              </div>
+              {record.patient.petBreed && (
+                <div className="text-caption-1 text-text-secondary">{record.patient.petBreed}</div>
+              )}
+              <div className="flex gap-1">
+                <div className="text-caption-1 text-text-extra">Appointment:</div>
+                <div className="text-caption-1 text-text-primary truncate">
+                  {record.patient.appointmentId}
+                </div>
+              </div>
+              <div className="flex gap-1">
+                <div className="text-caption-1 text-text-extra">Items:</div>
+                <div className="text-caption-1 text-text-primary">
+                  {(record.items ?? []).map((i) => i.name).join(', ') || '—'}
+                </div>
+              </div>
+              <div className="flex gap-1">
+                <div className="text-caption-1 text-text-extra">Amount:</div>
+                <div className="text-caption-1 text-text-primary">
+                  {formatAmount(record.amountCents, record.currency)}
+                </div>
+              </div>
+              <div className="flex gap-1">
+                <div className="text-caption-1 text-text-extra">Requested:</div>
+                <div className="text-caption-1 text-text-primary">
+                  {formatDateTime(record.prescriptionCreated)}
+                </div>
+              </div>
+              <div className="flex gap-2 mt-1">
+                {record.status === 'PENDING' && onDispense && (
+                  <button
+                    type="button"
+                    onClick={() => onDispense(record)}
+                    className="flex-1 h-9 rounded-2xl bg-[var(--color-success-600)] text-white text-caption-1 font-semibold hover:opacity-90 transition-opacity"
+                  >
+                    Dispense
+                  </button>
+                )}
+                {onView && (
+                  <button
+                    type="button"
+                    onClick={() => onView(record)}
+                    className="flex-1 h-9 rounded-2xl border border-card-border text-caption-1 text-text-primary hover:bg-card-hover transition-colors"
+                  >
+                    View
+                  </button>
+                )}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default DispensaryTable;

--- a/apps/frontend/src/app/ui/tables/DispensaryTable.tsx
+++ b/apps/frontend/src/app/ui/tables/DispensaryTable.tsx
@@ -47,7 +47,8 @@ const STATUS_LABELS: Record<DispensaryStatus, string> = {
 };
 
 const formatAmount = (cents: number, currency = 'USD') => {
-  const symbol = currency === 'USD' ? '$' : currency;
+  const upper = currency.toUpperCase();
+  const symbol = upper === 'USD' ? '$' : upper;
   return `${symbol} ${(cents / 100).toFixed(2)}`;
 };
 

--- a/apps/frontend/src/app/ui/tables/InventoryTable.tsx
+++ b/apps/frontend/src/app/ui/tables/InventoryTable.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/app/features/inventory/pages/Inventory/utils';
 import { getInventoryStatusStyle } from '@/app/ui/tables/tableUtils';
 import GlassTooltip from '@/app/ui/primitives/GlassTooltip/GlassTooltip';
+import { getSafeOrgImageUrl } from '@/app/lib/urls';
 
 import './DataTable.css';
 
@@ -50,6 +51,9 @@ const getImageFallback = (item: InventoryItem) => {
   return '💊';
 };
 
+const getInventoryImageSrc = (item: InventoryItem) =>
+  getSafeOrgImageUrl(item.basicInfo.imageUrl || item.imageUrl);
+
 const InventoryTable = ({
   filteredList,
   setActiveInventory,
@@ -75,7 +79,7 @@ const InventoryTable = ({
         <div className="flex items-center gap-3">
           <div className="flex size-12 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-card-hover text-xl">
             {(() => {
-              const imageSrc = item.basicInfo.imageUrl || item.imageUrl;
+              const imageSrc = getInventoryImageSrc(item);
               if (!imageSrc) {
                 return <span aria-hidden="true">{getImageFallback(item)}</span>;
               }

--- a/apps/frontend/src/app/ui/tables/InventoryTable.tsx
+++ b/apps/frontend/src/app/ui/tables/InventoryTable.tsx
@@ -111,6 +111,19 @@ const InventoryTable = ({
       ),
     },
     {
+      label: 'Stock health',
+      key: 'stock-health',
+      width: '110px',
+      render: (item: InventoryItem) => (
+        <div
+          className="appointment-status"
+          style={getInventoryStatusStyle(displayStatusLabel(item))}
+        >
+          {displayStatusLabel(item)}
+        </div>
+      ),
+    },
+    {
       label: 'ABC',
       key: 'abc',
       width: '48px',
@@ -129,7 +142,7 @@ const InventoryTable = ({
         const expired = displayStatusLabel(item).toLowerCase() === 'expired';
         return (
           <div
-            className={`appointment-profile-title ${expired ? 'text-text-error' : 'text-green-text'}`}
+            className={`appointment-profile-title ${expired ? 'text-text-error' : 'text-[var(--color-pill-success-text)]'}`}
           >
             {label}
           </div>
@@ -185,7 +198,7 @@ const InventoryTable = ({
       key: 'margin',
       width: '78px',
       render: (item: InventoryItem) => (
-        <div className="appointment-profile-title text-green-text">
+        <div className="appointment-profile-title text-[var(--color-pill-success-text)]">
           {formatPercentValue(getMarginPercent(item))}
         </div>
       ),
@@ -197,19 +210,6 @@ const InventoryTable = ({
       render: (item: InventoryItem) => (
         <div className="appointment-profile-title text-blue-text">
           {displayValue(item.stock.stockLocation)}
-        </div>
-      ),
-    },
-    {
-      label: 'Status',
-      key: 'status',
-      width: '94px',
-      render: (item: InventoryItem) => (
-        <div
-          className="appointment-status"
-          style={getInventoryStatusStyle(displayStatusLabel(item))}
-        >
-          {displayStatusLabel(item)}
         </div>
       ),
     },

--- a/apps/frontend/src/app/ui/tables/InventoryTurnoverTable.tsx
+++ b/apps/frontend/src/app/ui/tables/InventoryTurnoverTable.tsx
@@ -111,7 +111,7 @@ const InventoryTurnoverTable = ({ filteredList }: InventoryTurnoverTableProps) =
           columns={columns}
           bordered={false}
           pagination
-          pageSize={5}
+          pageSize={10}
           tableClassName="inventory-turnover-table-fixed"
         />
       </div>


### PR DESCRIPTION
<!--
We, the rest of the Yosemite community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The inventory module has no dispensary workflow surface. Clinicians cannot track dispense requests, see per-medication dispensing state from the appointment workspace, or audit controlled substance usage. The workspace has no validator to flag undispensed in-house items before discharge.

## What is the new behavior?

- Adds a **Dispensary surface** under Inventory with `All requests / Patient / Inhouse` rows, server-filtered by `fulfillmentContext`. Includes search and filter panel (status + request type).
- List rows show patient/appointment ref, status pill (Pending / Dispensed / Not dispensed), prescription items, date, amount with currency, prescriber, and pharmacy. Row opens a **Dispense request modal**.
- Modal includes pet/client header (species, breed, age, sex, weight, avatar), Appointment ID + Invoice ID, Emergency badge, prescriber, date/time, and per-medication cards with Rx + Controlled badges, prescription block (Dose / Freq / Duration / Refill), available inventory count, backend-computed dose-calculation string, and a qty-to-dispense stepper clamped to availability.
- Actions: **Dispense all (N)** → `$approve` (FIFO batch consumption); **Reject request** → `$not-dispensed` with reason field.
- Workspace prescription rows now show dispense state (pending / dispensed / not dispensed / returned/voided). A workspace validator alerts on undispensed in-house items before discharge.
- Inventory item and batch views show prescription consumption in the movement history.
- Controlled substance indicators are visible on medication cards and batch rows.
- Frontend dose math is never computed — `calculationLabel` and `suggestedQty` are rendered from the backend response only.

## Related Issue(s)

Fixes #1635