### PR TITLE
fix(repo): place Documenso signature fields using percentage coordinates

### DIFF
--- a/apps/backend/src/controllers/web/appointment.prisma.controller.ts
+++ b/apps/backend/src/controllers/web/appointment.prisma.controller.ts
@@ -278,6 +278,9 @@ export const AppointmentController = {
         req.params.appointmentId,
         {
           admittedAt: body.admittedAt ? new Date(body.admittedAt) : undefined,
+          // The admitting user is whoever is signed in and clicked
+          // "Convert to Inpatient" (the verified Cognito token), never the body.
+          admittedBy: (req as { userId?: string }).userId,
           expectedStayDays: body.expectedStayDays,
           lead: body.lead,
           supportStaff: body.supportStaff,

--- a/apps/backend/src/services/appointment.prisma.service.ts
+++ b/apps/backend/src/services/appointment.prisma.service.ts
@@ -90,6 +90,7 @@ type AdmissionUpsertDelegate = {
       organisationId: string;
       patientId: string;
       admittedAt: Date;
+      admittedBy?: string | null;
       expectedStayDays?: number | null;
     };
   }): Promise<unknown>;
@@ -209,6 +210,7 @@ type AdmitSupportStaffInput = {
 };
 type AdmitRequestInput = {
   admittedAt?: Date;
+  admittedBy?: string;
   expectedStayDays?: number;
   lead?: AdmitLeadInput;
   supportStaff?: AdmitSupportStaffInput[];
@@ -802,6 +804,7 @@ const admitInpatientRoomUnit = async (params: {
       organisationId: row.organisationId,
       patientId: getPatientId(row.patient),
       admittedAt,
+      admittedBy: normalizeOptionalString(input?.admittedBy) ?? null,
       expectedStayDays: input?.expectedStayDays ?? null,
     },
   });

--- a/apps/backend/src/services/documenso.service.ts
+++ b/apps/backend/src/services/documenso.service.ts
@@ -17,12 +17,15 @@ const EXTERNAL_AUTH_SECRET =
 
 const documensoClients = new Map<string, Documenso>();
 
+// Documenso positions fields as percentages (0–100) of the page from the
+// top-left, not PDF points. Last-resort fallback when a caller provides no
+// placement; real placements come from the PDF renderers as percentages.
 const DEFAULT_SIGNATURE_PLACEMENT: ClinicalPdfSignaturePlacement = {
   pageNumber: 1,
-  pageX: 330,
-  pageY: 700,
-  width: 220,
-  height: 96,
+  pageX: 55.44,
+  pageY: 83.15,
+  width: 36.96,
+  height: 11.4,
 };
 
 const getBaseUrl = () => {

--- a/apps/backend/src/services/rendered-document-renderer.service.ts
+++ b/apps/backend/src/services/rendered-document-renderer.service.ts
@@ -834,6 +834,29 @@ type EncounterLocationHeader = {
  * resolved through the unit → room chain. Returns an empty object when nothing
  * can be resolved so callers keep their existing fallbacks.
  */
+const resolveUnitRoomNames = async (
+  unitId: string | undefined,
+  fallbackRoomName: string | undefined,
+): Promise<{ unitName?: string; roomName?: string }> => {
+  if (!unitId) {
+    return { roomName: fallbackRoomName };
+  }
+
+  const unit = await prisma.roomUnit.findUnique({ where: { id: unitId } });
+  if (!unit) {
+    return { roomName: fallbackRoomName };
+  }
+
+  const room = await prisma.organisationRoom.findUnique({
+    where: { id: unit.roomId },
+  });
+  return {
+    unitName:
+      readString(unit.displayName) ?? readString(unit.code) ?? undefined,
+    roomName: (room ? readString(room.name) : undefined) ?? fallbackRoomName,
+  };
+};
+
 const loadEncounterLocationHeader = async (
   appointmentId: string | null | undefined,
   encounterId: string | null | undefined,
@@ -891,22 +914,9 @@ const loadEncounterLocationHeader = async (
     : null;
 
   const unitId = admission?.unitId ?? assignment?.unitId ?? undefined;
-
-  if (unitId) {
-    const unit = await prisma.roomUnit.findUnique({ where: { id: unitId } });
-    if (unit) {
-      result.unitName =
-        readString(unit.displayName) ?? readString(unit.code) ?? undefined;
-
-      const room = await prisma.organisationRoom.findUnique({
-        where: { id: unit.roomId },
-      });
-      result.roomName =
-        (room ? readString(room.name) : undefined) ?? appointmentRoomName;
-    }
-  }
-
-  result.roomName ??= appointmentRoomName;
+  const location = await resolveUnitRoomNames(unitId, appointmentRoomName);
+  result.unitName = location.unitName;
+  result.roomName = location.roomName;
 
   // The admitting user (whoever clicked "Convert to Inpatient") is recorded on
   // the admission; fall back to whoever assigned the unit if it's absent.

--- a/apps/backend/src/services/rendered-document-renderer.service.ts
+++ b/apps/backend/src/services/rendered-document-renderer.service.ts
@@ -586,6 +586,27 @@ const readFirstString = (
   return undefined;
 };
 
+/**
+ * Format a date/time as "YYYY-MM-DD HH:mm" (UTC). Used for the human-readable
+ * admission/recorded timestamps surfaced in the combined header and vital record.
+ * Returns undefined for nullish or invalid inputs so callers keep their fallbacks.
+ */
+const formatDateTime = (value: Date | null | undefined): string | undefined => {
+  if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
+    return undefined;
+  }
+
+  const pad = (part: number) => String(part).padStart(2, "0");
+
+  const year = value.getUTCFullYear();
+  const month = pad(value.getUTCMonth() + 1);
+  const day = pad(value.getUTCDate());
+  const hours = pad(value.getUTCHours());
+  const minutes = pad(value.getUTCMinutes());
+
+  return `${year}-${month}-${day} ${hours}:${minutes}`;
+};
+
 const normalizePrescriptionItems = (
   value: unknown,
 ): PrescriptionDocumentData["items"] => {
@@ -792,6 +813,104 @@ const loadAppointmentClinicalHeader = async (
     lead: appointment.lead as unknown as Record<string, unknown>,
     room: appointment.room as unknown as Record<string, unknown>,
   });
+};
+
+type EncounterLocationHeader = {
+  roomName?: string;
+  unitName?: string;
+  admittedAt?: string;
+  admittedBy?: string;
+};
+
+/**
+ * Resolve the encounter's physical location for the combined clinical header.
+ *
+ * Outpatient encounters (`appointmentKind === 'OUTPATIENT'` and no admission)
+ * surface only the appointment's room JSON name. Inpatient encounters (an
+ * `Admission` row exists, or `appointmentKind === 'INPATIENT'`) surface the
+ * admission timestamp, the admitting staff member, and the assigned room/unit
+ * resolved through the unit → room chain. Returns an empty object when nothing
+ * can be resolved so callers keep their existing fallbacks.
+ */
+const loadEncounterLocationHeader = async (
+  appointmentId: string | null | undefined,
+  encounterId: string | null | undefined,
+): Promise<EncounterLocationHeader> => {
+  let appointmentRoom: Record<string, unknown> = {};
+  let appointmentKind: string | undefined;
+  let resolvedEncounterId = encounterId ?? undefined;
+
+  if (appointmentId) {
+    const appointment = await prisma.appointment.findUnique({
+      where: { id: appointmentId },
+      select: { appointmentKind: true, room: true, encounterId: true },
+    });
+    if (appointment) {
+      appointmentRoom = isRecord(appointment.room)
+        ? (appointment.room as Record<string, unknown>)
+        : {};
+      appointmentKind = appointment.appointmentKind ?? undefined;
+      resolvedEncounterId ??= appointment.encounterId ?? undefined;
+    }
+  }
+
+  const appointmentRoomName = readFirstString(appointmentRoom, [
+    "name",
+    "code",
+    "number",
+    "label",
+  ]);
+
+  const admission = resolvedEncounterId
+    ? await prisma.admission.findUnique({
+        where: { encounterId: resolvedEncounterId },
+      })
+    : null;
+
+  const isInpatient = appointmentKind === "INPATIENT" || admission !== null;
+
+  if (!isInpatient) {
+    return {
+      roomName: appointmentRoomName,
+    };
+  }
+
+  const result: EncounterLocationHeader = {};
+
+  if (admission) {
+    result.admittedAt = formatDateTime(admission.admittedAt) ?? undefined;
+  }
+
+  const assignment = resolvedEncounterId
+    ? await prisma.roomUnitAssignment.findFirst({
+        where: { encounterId: resolvedEncounterId, releasedAt: null },
+        orderBy: { assignedAt: "desc" },
+      })
+    : null;
+
+  const unitId = admission?.unitId ?? assignment?.unitId ?? undefined;
+
+  if (unitId) {
+    const unit = await prisma.roomUnit.findUnique({ where: { id: unitId } });
+    if (unit) {
+      result.unitName =
+        readString(unit.displayName) ?? readString(unit.code) ?? undefined;
+
+      const room = await prisma.organisationRoom.findUnique({
+        where: { id: unit.roomId },
+      });
+      result.roomName =
+        (room ? readString(room.name) : undefined) ?? appointmentRoomName;
+    }
+  }
+
+  result.roomName ??= appointmentRoomName;
+
+  if (assignment?.assignedBy) {
+    result.admittedBy = (await resolveSigner(assignment.assignedBy)).name;
+  }
+
+  return result;
 };
 
 const readAppointmentIdField = (
@@ -1094,6 +1213,13 @@ const buildTemplateFreeVitalRecordPdfInput = async (
   const notes = readRecordNotes(record, metadata);
   const signature = await buildArtifactSignature(record);
 
+  // `record.data.recordedBy` is a User id; resolve it to a display name the same
+  // way signers are resolved. Fall back to the existing chain when it can't be
+  // resolved (no id, unknown user, or no name on the user).
+  const recordedByName = (
+    await resolveSigner(readString(record.data.recordedBy) ?? null)
+  ).name;
+
   return {
     documentType: "VITAL_RECORD",
     organization,
@@ -1102,6 +1228,7 @@ const buildTemplateFreeVitalRecordPdfInput = async (
       date: record.artifact.updatedAt,
       appointmentId: readAppointmentIdField(record, metadata),
       recordedBy:
+        recordedByName ??
         header.leadName ??
         readFirstString(metadata, [
           "recordedBy",
@@ -1113,6 +1240,12 @@ const buildTemplateFreeVitalRecordPdfInput = async (
         ]) ??
         readString(record.artifact.authorId) ??
         "—",
+      recordedAt:
+        formatDateTime(
+          record.data.measuredAt instanceof Date
+            ? record.data.measuredAt
+            : undefined,
+        ) ?? undefined,
       ...readPatientClientFields(header, metadata),
       contact:
         header.clientContact ??
@@ -1581,6 +1714,8 @@ type BuiltCombinedClinicalSection = {
   section: CombinedClinicalSection;
   /** Appointment id of the underlying artifact, used to load the shared header. */
   appointmentId: string | null;
+  /** Encounter id of the underlying artifact, used to resolve admission/location. */
+  encounterId: string | null;
 };
 
 const buildCombinedClinicalSection = async (
@@ -1601,6 +1736,7 @@ const buildCombinedClinicalSection = async (
   const input: RenderedDocumentPdfSource = { title: doc.title, source };
   const record = await loadClinicalArtifactDocument(source);
   const appointmentId = record.artifact.appointmentId;
+  const encounterId = record.artifact.encounterId;
 
   switch (doc.kind) {
     case "SOAP_NOTE": {
@@ -1612,6 +1748,7 @@ const buildCombinedClinicalSection = async (
       return {
         section: { documentType: "SOAP_NOTE", data: built.data },
         appointmentId,
+        encounterId,
       };
     }
     case "VITAL_RECORD": {
@@ -1623,6 +1760,7 @@ const buildCombinedClinicalSection = async (
       return {
         section: { documentType: "VITAL_RECORD", data: built.data },
         appointmentId,
+        encounterId,
       };
     }
     case "PRESCRIPTION": {
@@ -1634,6 +1772,7 @@ const buildCombinedClinicalSection = async (
       return {
         section: { documentType: "PRESCRIPTION", data: built.data },
         appointmentId,
+        encounterId,
       };
     }
     case "DISCHARGE_SUMMARY": {
@@ -1645,6 +1784,7 @@ const buildCombinedClinicalSection = async (
       return {
         section: { documentType: "DISCHARGE_SUMMARY", data: built.data },
         appointmentId,
+        encounterId,
       };
     }
     default:
@@ -1678,6 +1818,7 @@ export const renderCombinedClinicalPacketPdf = async (
 
   const sections: CombinedClinicalSection[] = [];
   let headerAppointmentId: string | null = null;
+  let headerEncounterId: string | null = null;
   for (const doc of input.documents) {
     const built = await buildCombinedClinicalSection(
       doc,
@@ -1687,6 +1828,7 @@ export const renderCombinedClinicalPacketPdf = async (
     if (built) {
       sections.push(built.section);
       headerAppointmentId ??= built.appointmentId;
+      headerEncounterId ??= built.encounterId;
     }
   }
 
@@ -1702,9 +1844,25 @@ export const renderCombinedClinicalPacketPdf = async (
   const appointmentHeader =
     await loadAppointmentClinicalHeader(headerAppointmentId);
 
+  // Resolve the encounter's physical location (inpatient room/unit + admission
+  // details, or the outpatient room). These authoritative values override the
+  // appointment-JSON-derived room/unit; existing fallbacks are kept otherwise.
+  const locationHeader = await loadEncounterLocationHeader(
+    headerAppointmentId,
+    headerEncounterId,
+  );
+
+  const header = buildCombinedClinicalHeader(sections[0], appointmentHeader);
+
   return generateCombinedClinicalPdfWithMetadata({
     organization,
-    header: buildCombinedClinicalHeader(sections[0], appointmentHeader),
+    header: {
+      ...header,
+      roomName: locationHeader.roomName ?? header.roomName,
+      unitName: locationHeader.unitName ?? header.unitName,
+      admittedAt: locationHeader.admittedAt,
+      admittedBy: locationHeader.admittedBy,
+    },
     sections,
     printedBy: undefined,
     signature: { status: "PENDING", label: "Signature" },

--- a/apps/backend/src/services/rendered-document-renderer.service.ts
+++ b/apps/backend/src/services/rendered-document-renderer.service.ts
@@ -121,12 +121,15 @@ type OrganizationBrand = {
   } | null;
 };
 
+// Documenso field coordinates are percentages (0–100) of the page from the
+// top-left, not PDF points. Used as the FORM_SUBMISSION placement (the HTML/A4
+// form render has no anchored signature line) and as a last-resort fallback.
 const DEFAULT_SIGNATURE_PLACEMENT = {
   pageNumber: 1,
-  pageX: 330,
-  pageY: 700,
-  width: 220,
-  height: 96,
+  pageX: 55.44,
+  pageY: 83.15,
+  width: 36.96,
+  height: 11.4,
 };
 
 const humanizeLabel = (value: string) =>

--- a/apps/backend/src/services/rendered-document-renderer.service.ts
+++ b/apps/backend/src/services/rendered-document-renderer.service.ts
@@ -906,8 +906,11 @@ const loadEncounterLocationHeader = async (
 
   result.roomName ??= appointmentRoomName;
 
-  if (assignment?.assignedBy) {
-    result.admittedBy = (await resolveSigner(assignment.assignedBy)).name;
+  // The admitting user (whoever clicked "Convert to Inpatient") is recorded on
+  // the admission; fall back to whoever assigned the unit if it's absent.
+  const admitterId = admission?.admittedBy ?? assignment?.assignedBy;
+  if (admitterId) {
+    result.admittedBy = (await resolveSigner(admitterId)).name;
   }
 
   return result;

--- a/apps/backend/src/services/rendered-document-renderer.service.ts
+++ b/apps/backend/src/services/rendered-document-renderer.service.ts
@@ -226,10 +226,10 @@ const buildDocumentDetailsSection = (
   ],
 });
 
-const buildOrganizationBranding = (
+const buildOrganizationAddressLines = (
   organization: OrganizationBrand,
-): PdfBranding => {
-  const addressLines = [
+): string[] =>
+  [
     organization.address?.addressLine,
     [
       organization.address?.city,
@@ -240,6 +240,11 @@ const buildOrganizationBranding = (
       .join(", "),
     organization.address?.country,
   ].filter((line): line is string => Boolean(line && line.trim()));
+
+const buildOrganizationBranding = (
+  organization: OrganizationBrand,
+): PdfBranding => {
+  const addressLines = buildOrganizationAddressLines(organization);
 
   return {
     organizationName: organization.name,
@@ -253,17 +258,7 @@ const buildOrganizationBranding = (
 const buildSharedOrganizationBranding = (
   organization: OrganizationBrand,
 ): OrganizationBranding => {
-  const addressLines = [
-    organization.address?.addressLine,
-    [
-      organization.address?.city,
-      organization.address?.state,
-      organization.address?.postalCode,
-    ]
-      .filter((line): line is string => Boolean(line && line.trim()))
-      .join(", "),
-    organization.address?.country,
-  ].filter((line): line is string => Boolean(line && line.trim()));
+  const addressLines = buildOrganizationAddressLines(organization);
 
   return {
     name: organization.name,
@@ -1052,6 +1047,17 @@ const readRecordNotes = (
   readString(metadata.notes) ??
   "";
 
+const resolveLeadName = (
+  header: AppointmentClinicalHeader,
+  metadata: Record<string, unknown>,
+  record: ClinicalArtifactDocumentSource,
+  keys: string[] = ["doctorName", "providerName", "doctor"],
+): string =>
+  header.leadName ??
+  readFirstString(metadata, keys) ??
+  readString(record.artifact.authorId) ??
+  "—";
+
 const buildTemplateFreeSoapNotePdfInput = async (
   input: RenderedDocumentPdfSource,
   record: ClinicalArtifactDocumentSource,
@@ -1074,11 +1080,7 @@ const buildTemplateFreeSoapNotePdfInput = async (
       title: input.title,
       date: record.artifact.updatedAt,
       appointmentId: readAppointmentIdField(record, metadata),
-      doctorName:
-        header.leadName ??
-        readFirstString(metadata, ["doctorName", "providerName", "doctor"]) ??
-        readString(record.artifact.authorId) ??
-        "—",
+      doctorName: resolveLeadName(header, metadata, record),
       ...readPatientClientFields(header, metadata),
       subjective: (record.data.subjective ??
         metadata.subjective ??
@@ -1120,16 +1122,12 @@ const buildTemplateFreePrescriptionPdfInput = async (
       date: record.artifact.updatedAt,
       appointmentId: readAppointmentIdField(record, metadata),
       prescriptionId: record.artifact.id,
-      leadName:
-        header.leadName ??
-        readFirstString(metadata, [
-          "leadName",
-          "doctorName",
-          "providerName",
-          "doctor",
-        ]) ??
-        readString(record.artifact.authorId) ??
-        "—",
+      leadName: resolveLeadName(header, metadata, record, [
+        "leadName",
+        "doctorName",
+        "providerName",
+        "doctor",
+      ]),
       ...readPatientClientFields(header, metadata),
       clientContact:
         header.clientContact ??
@@ -1181,11 +1179,7 @@ const buildTemplateFreeDischargeSummaryPdfInput = async (
       title: input.title,
       date: record.artifact.updatedAt,
       appointmentId: readAppointmentIdField(record, metadata),
-      doctorName:
-        header.leadName ??
-        readFirstString(metadata, ["doctorName", "providerName", "doctor"]) ??
-        readString(record.artifact.authorId) ??
-        "—",
+      doctorName: resolveLeadName(header, metadata, record),
       ...readPatientClientFields(header, metadata),
       contact:
         header.clientContact ??

--- a/apps/backend/src/services/rendered-document-renderer.service.ts
+++ b/apps/backend/src/services/rendered-document-renderer.service.ts
@@ -136,6 +136,8 @@ const DEFAULT_SIGNATURE_PLACEMENT = {
   height: 11.4,
 };
 
+const SIGNATURE_LABEL = "Signature";
+
 const humanizeLabel = (value: string) =>
   value
     .split(/[\s._/-]+/u)
@@ -495,7 +497,7 @@ const buildResolvedTemplatePdfInput = (
   title: input.title,
   signature: {
     status: "PENDING",
-    label: "Signature",
+    label: SIGNATURE_LABEL,
   },
 });
 
@@ -963,7 +965,7 @@ const readPrintedByField = (
 
 const buildPendingSignature = (): { status: "PENDING"; label: string } => ({
   status: "PENDING",
-  label: "Signature",
+  label: SIGNATURE_LABEL,
 });
 
 /**
@@ -1013,7 +1015,7 @@ const buildArtifactSignature = async (
 
   return {
     status: "SIGNED",
-    label: "Signature",
+    label: SIGNATURE_LABEL,
     signerName: signer.name,
     signerEmail: signer.email,
     authMethod: "Email",
@@ -1868,7 +1870,7 @@ export const renderCombinedClinicalPacketPdf = async (
     },
     sections,
     printedBy: undefined,
-    signature: { status: "PENDING", label: "Signature" },
+    signature: { status: "PENDING", label: SIGNATURE_LABEL },
   });
 };
 

--- a/apps/backend/src/services/rendered-document-renderer.service.ts
+++ b/apps/backend/src/services/rendered-document-renderer.service.ts
@@ -9,6 +9,7 @@ import {
   type CombinedClinicalDocumentInput,
   type CombinedClinicalSection,
   type DischargeSummaryDocumentData,
+  type DocumentSignature,
   type OrganizationBranding,
   type PrescriptionDocumentData,
   type PrescriptionItem,
@@ -710,6 +711,8 @@ type AppointmentClinicalHeader = {
   clientContact?: string;
   speciesBreed?: string;
   ageSex?: string;
+  roomName?: string;
+  unitName?: string;
 };
 
 const readAppointmentContact = (
@@ -730,6 +733,8 @@ const readAppointmentHeader = (
   const patient = isRecord(appointment.patient) ? appointment.patient : {};
   const lead = isRecord(appointment.lead) ? appointment.lead : {};
   const parent = isRecord(patient.parent) ? patient.parent : {};
+  const room = isRecord(appointment.room) ? appointment.room : {};
+  const unit = isRecord(room.unit) ? room.unit : {};
   const species = readFirstString(patient, ["species", "speciesName"]);
   const breed = readFirstString(patient, ["breed", "breedName"]);
 
@@ -752,6 +757,17 @@ const readAppointmentHeader = (
         : (species ?? breed ?? undefined),
     ageSex:
       readFirstString(patient, ["ageSex", "age", "sex", "gender"]) ?? undefined,
+    roomName:
+      readFirstString(room, ["name", "code", "number", "roomName", "label"]) ??
+      undefined,
+    unitName:
+      readFirstString(unit, [
+        "name",
+        "displayName",
+        "code",
+        "unitName",
+        "label",
+      ]) ?? undefined,
   };
 };
 
@@ -764,7 +780,7 @@ const loadAppointmentClinicalHeader = async (
 
   const appointment = await prisma.appointment.findUnique({
     where: { id: appointmentId },
-    select: { patient: true, lead: true },
+    select: { patient: true, lead: true, room: true },
   });
 
   if (!appointment) {
@@ -774,6 +790,7 @@ const loadAppointmentClinicalHeader = async (
   return readAppointmentHeader({
     patient: appointment.patient as unknown as Record<string, unknown>,
     lead: appointment.lead as unknown as Record<string, unknown>,
+    room: appointment.room as unknown as Record<string, unknown>,
   });
 };
 
@@ -827,6 +844,61 @@ const buildPendingSignature = (): { status: "PENDING"; label: string } => ({
   label: "Signature",
 });
 
+/**
+ * Resolve a signer's display name and email from the user id stored on the
+ * artifact (`signedBy`). Artifact signer ids are `User.userId` (the external id
+ * used for signing), matching how the packet-signing path resolves the signer
+ * email. Returns `undefined` fields when the user cannot be found so the caller
+ * can still render a SIGNED signature with whatever is available.
+ */
+const resolveSigner = async (
+  signedBy: string | null,
+): Promise<{ name?: string; email?: string }> => {
+  if (!signedBy) {
+    return {};
+  }
+
+  const user = await prisma.user.findFirst({
+    where: { userId: signedBy },
+    select: { firstName: true, lastName: true, email: true },
+  });
+  if (!user) {
+    return {};
+  }
+
+  const name =
+    [user.firstName, user.lastName]
+      .map((part) => part?.trim())
+      .filter((part): part is string => Boolean(part))
+      .join(" ") || undefined;
+
+  return { name, email: user.email?.trim() || undefined };
+};
+
+/**
+ * Build the per-document signature block. A signed artifact (`signedAt` present)
+ * yields a SIGNED signature enriched with the resolved signer name/email and the
+ * authentication method; an unsigned artifact stays PENDING.
+ */
+const buildArtifactSignature = async (
+  record: ClinicalArtifactDocumentSource,
+): Promise<DocumentSignature> => {
+  if (!record.artifact.signedAt) {
+    return buildPendingSignature();
+  }
+
+  const signer = await resolveSigner(record.artifact.signedBy);
+
+  return {
+    status: "SIGNED",
+    label: "Signature",
+    signerName: signer.name,
+    signerEmail: signer.email,
+    authMethod: "Email",
+    signedAt: record.artifact.signedAt,
+  };
+};
+
 const readRecordNotes = (
   record: ClinicalArtifactDocumentSource,
   metadata: Record<string, unknown>,
@@ -849,6 +921,7 @@ const buildTemplateFreeSoapNotePdfInput = async (
   const header = await loadAppointmentClinicalHeader(
     record.artifact.appointmentId,
   );
+  const signature = await buildArtifactSignature(record);
 
   return {
     documentType: "SOAP_NOTE",
@@ -874,7 +947,7 @@ const buildTemplateFreeSoapNotePdfInput = async (
         "") as unknown as string,
       plan: (record.data.plan ?? metadata.plan ?? "") as unknown as string,
       printedBy: readPrintedByField(record, metadata),
-      signature: buildPendingSignature(),
+      signature,
     },
   };
 };
@@ -893,6 +966,7 @@ const buildTemplateFreePrescriptionPdfInput = async (
     record.artifact.appointmentId,
   );
   const notes = readRecordNotes(record, metadata);
+  const signature = await buildArtifactSignature(record);
 
   return {
     documentType: "PRESCRIPTION",
@@ -927,7 +1001,7 @@ const buildTemplateFreePrescriptionPdfInput = async (
       ),
       notes,
       printedBy: readPrintedByField(record, metadata),
-      signature: buildPendingSignature(),
+      signature,
     },
   };
 };
@@ -954,6 +1028,7 @@ const buildTemplateFreeDischargeSummaryPdfInput = async (
   const followUpText = (record.data.followUp ??
     metadata.followUp ??
     "") as unknown as string;
+  const signature = await buildArtifactSignature(record);
 
   return {
     documentType: "DISCHARGE_SUMMARY",
@@ -998,7 +1073,7 @@ const buildTemplateFreeDischargeSummaryPdfInput = async (
         readFirstString(metadata, ["contact", "phone"]) ??
         "—") as unknown as string,
       printedBy: readPrintedByField(record, metadata),
-      signature: buildPendingSignature(),
+      signature,
     },
   };
 };
@@ -1017,6 +1092,7 @@ const buildTemplateFreeVitalRecordPdfInput = async (
     record.artifact.appointmentId,
   );
   const notes = readRecordNotes(record, metadata);
+  const signature = await buildArtifactSignature(record);
 
   return {
     documentType: "VITAL_RECORD",
@@ -1049,7 +1125,7 @@ const buildTemplateFreeVitalRecordPdfInput = async (
       metadata:
         record.data.metadata !== undefined ? record.data.metadata : metadata,
       printedBy: readPrintedByField(record, metadata),
-      signature: buildPendingSignature(),
+      signature,
     },
   };
 };
@@ -1454,6 +1530,7 @@ type CombinedClinicalPacketInput = {
  */
 const buildCombinedClinicalHeader = (
   section: CombinedClinicalSection,
+  appointmentHeader: AppointmentClinicalHeader,
 ): CombinedClinicalDocumentInput["header"] => {
   let doctorName: string | undefined;
   let clientContact: string | undefined;
@@ -1477,25 +1554,40 @@ const buildCombinedClinicalHeader = (
       doctorName = undefined;
   }
 
+  // The appointment-derived values are authoritative for the whole packet, so
+  // they override the per-section-derived ones (which depend on the first
+  // section's document type — e.g. SOAP carries no contact). Section values
+  // remain the fallback when the appointment record omits a field.
+  const normalizedSectionContact =
+    clientContact && clientContact !== "—" ? clientContact : undefined;
+
   const { data } = section;
   return {
     date: data.date,
     appointmentId: data.appointmentId,
-    patientName: data.patientName,
-    clientName: data.clientName,
-    clientId: data.clientId,
-    speciesBreed: data.speciesBreed,
-    ageSex: data.ageSex,
-    doctorName,
-    clientContact,
+    patientName: appointmentHeader.patientName ?? data.patientName,
+    clientName: appointmentHeader.clientName ?? data.clientName,
+    clientId: appointmentHeader.clientId ?? data.clientId,
+    speciesBreed: appointmentHeader.speciesBreed ?? data.speciesBreed,
+    ageSex: appointmentHeader.ageSex ?? data.ageSex,
+    doctorName: appointmentHeader.leadName ?? doctorName,
+    clientContact: appointmentHeader.clientContact ?? normalizedSectionContact,
+    roomName: appointmentHeader.roomName,
+    unitName: appointmentHeader.unitName,
   };
+};
+
+type BuiltCombinedClinicalSection = {
+  section: CombinedClinicalSection;
+  /** Appointment id of the underlying artifact, used to load the shared header. */
+  appointmentId: string | null;
 };
 
 const buildCombinedClinicalSection = async (
   doc: CombinedClinicalPacketDocument,
   organisationId: string,
   organization: OrganizationBranding,
-): Promise<CombinedClinicalSection | undefined> => {
+): Promise<BuiltCombinedClinicalSection | undefined> => {
   if (!COMBINED_CLINICAL_KINDS.has(doc.kind)) {
     return undefined;
   }
@@ -1508,6 +1600,7 @@ const buildCombinedClinicalSection = async (
   };
   const input: RenderedDocumentPdfSource = { title: doc.title, source };
   const record = await loadClinicalArtifactDocument(source);
+  const appointmentId = record.artifact.appointmentId;
 
   switch (doc.kind) {
     case "SOAP_NOTE": {
@@ -1516,7 +1609,10 @@ const buildCombinedClinicalSection = async (
         record,
         organization,
       );
-      return { documentType: "SOAP_NOTE", data: built.data };
+      return {
+        section: { documentType: "SOAP_NOTE", data: built.data },
+        appointmentId,
+      };
     }
     case "VITAL_RECORD": {
       const built = await buildTemplateFreeVitalRecordPdfInput(
@@ -1524,7 +1620,10 @@ const buildCombinedClinicalSection = async (
         record,
         organization,
       );
-      return { documentType: "VITAL_RECORD", data: built.data };
+      return {
+        section: { documentType: "VITAL_RECORD", data: built.data },
+        appointmentId,
+      };
     }
     case "PRESCRIPTION": {
       const built = await buildTemplateFreePrescriptionPdfInput(
@@ -1532,7 +1631,10 @@ const buildCombinedClinicalSection = async (
         record,
         organization,
       );
-      return { documentType: "PRESCRIPTION", data: built.data };
+      return {
+        section: { documentType: "PRESCRIPTION", data: built.data },
+        appointmentId,
+      };
     }
     case "DISCHARGE_SUMMARY": {
       const built = await buildTemplateFreeDischargeSummaryPdfInput(
@@ -1540,7 +1642,10 @@ const buildCombinedClinicalSection = async (
         record,
         organization,
       );
-      return { documentType: "DISCHARGE_SUMMARY", data: built.data };
+      return {
+        section: { documentType: "DISCHARGE_SUMMARY", data: built.data },
+        appointmentId,
+      };
     }
     default:
       return undefined;
@@ -1572,14 +1677,16 @@ export const renderCombinedClinicalPacketPdf = async (
   const organization = buildSharedOrganizationBranding(brand);
 
   const sections: CombinedClinicalSection[] = [];
+  let headerAppointmentId: string | null = null;
   for (const doc of input.documents) {
-    const section = await buildCombinedClinicalSection(
+    const built = await buildCombinedClinicalSection(
       doc,
       input.organisationId,
       organization,
     );
-    if (section) {
-      sections.push(section);
+    if (built) {
+      sections.push(built.section);
+      headerAppointmentId ??= built.appointmentId;
     }
   }
 
@@ -1589,9 +1696,15 @@ export const renderCombinedClinicalPacketPdf = async (
     );
   }
 
+  // Resolve the shared patient/encounter values (incl. room/unit and a reliable
+  // client contact) from the appointment once, so they don't depend on the first
+  // section's document type (e.g. a leading SOAP note carries no client contact).
+  const appointmentHeader =
+    await loadAppointmentClinicalHeader(headerAppointmentId);
+
   return generateCombinedClinicalPdfWithMetadata({
     organization,
-    header: buildCombinedClinicalHeader(sections[0]),
+    header: buildCombinedClinicalHeader(sections[0], appointmentHeader),
     sections,
     printedBy: undefined,
     signature: { status: "PENDING", label: "Signature" },

--- a/apps/backend/src/services/rendered-document-renderer.service.ts
+++ b/apps/backend/src/services/rendered-document-renderer.service.ts
@@ -857,34 +857,44 @@ const resolveUnitRoomNames = async (
   };
 };
 
+const loadAppointmentLocationContext = async (
+  appointmentId: string | null | undefined,
+): Promise<{
+  roomName?: string;
+  appointmentKind?: string;
+  encounterId?: string;
+}> => {
+  if (!appointmentId) {
+    return {};
+  }
+
+  const appointment = await prisma.appointment.findUnique({
+    where: { id: appointmentId },
+    select: { appointmentKind: true, room: true, encounterId: true },
+  });
+  if (!appointment) {
+    return {};
+  }
+
+  const room = isRecord(appointment.room)
+    ? (appointment.room as Record<string, unknown>)
+    : {};
+  return {
+    roomName: readFirstString(room, ["name", "code", "number", "label"]),
+    appointmentKind: appointment.appointmentKind ?? undefined,
+    encounterId: appointment.encounterId ?? undefined,
+  };
+};
+
 const loadEncounterLocationHeader = async (
   appointmentId: string | null | undefined,
   encounterId: string | null | undefined,
 ): Promise<EncounterLocationHeader> => {
-  let appointmentRoom: Record<string, unknown> = {};
-  let appointmentKind: string | undefined;
-  let resolvedEncounterId = encounterId ?? undefined;
-
-  if (appointmentId) {
-    const appointment = await prisma.appointment.findUnique({
-      where: { id: appointmentId },
-      select: { appointmentKind: true, room: true, encounterId: true },
-    });
-    if (appointment) {
-      appointmentRoom = isRecord(appointment.room)
-        ? (appointment.room as Record<string, unknown>)
-        : {};
-      appointmentKind = appointment.appointmentKind ?? undefined;
-      resolvedEncounterId ??= appointment.encounterId ?? undefined;
-    }
-  }
-
-  const appointmentRoomName = readFirstString(appointmentRoom, [
-    "name",
-    "code",
-    "number",
-    "label",
-  ]);
+  const appointmentContext =
+    await loadAppointmentLocationContext(appointmentId);
+  const appointmentRoomName = appointmentContext.roomName;
+  const appointmentKind = appointmentContext.appointmentKind;
+  const resolvedEncounterId = encounterId ?? appointmentContext.encounterId;
 
   const admission = resolvedEncounterId
     ? await prisma.admission.findUnique({

--- a/apps/backend/src/services/rendered-document-renderer.service.ts
+++ b/apps/backend/src/services/rendered-document-renderer.service.ts
@@ -3,8 +3,11 @@ import { Prisma } from "@prisma/client";
 import {
   generateClinicalPdf,
   generateClinicalPdfWithMetadata,
+  generateCombinedClinicalPdfWithMetadata,
   generateResolvedTemplatePdfWithMetadata,
   type ClinicalDocumentType,
+  type CombinedClinicalDocumentInput,
+  type CombinedClinicalSection,
   type DischargeSummaryDocumentData,
   type OrganizationBranding,
   type PrescriptionDocumentData,
@@ -1420,6 +1423,180 @@ export const renderRenderedDocumentPdfWithMetadata = async (
 export const renderRenderedDocumentPdf = async (
   input: RenderedDocumentPdfSource,
 ) => (await renderRenderedDocumentPdfWithMetadata(input)).pdf;
+
+const COMBINED_CLINICAL_KINDS = new Set([
+  "SOAP_NOTE",
+  "VITAL_RECORD",
+  "PRESCRIPTION",
+  "DISCHARGE_SUMMARY",
+]);
+
+type CombinedClinicalPacketDocument = {
+  documentId: string;
+  sourceId: string;
+  kind: string;
+  title: string;
+};
+
+type CombinedClinicalPacketInput = {
+  organisationId: string;
+  signerName?: string | null;
+  documents: CombinedClinicalPacketDocument[];
+};
+
+/**
+ * Build the shared encounter header from the first combinable section's data.
+ * All four template-free builders pull the same appointment header, so the lead
+ * section already carries the shared patient/encounter values. The lead provider
+ * field differs by document type (SOAP/Discharge: doctorName; Vital: recordedBy;
+ * Prescription: leadName), as does the client contact field (Prescription:
+ * clientContact; Vital/Discharge: contact).
+ */
+const buildCombinedClinicalHeader = (
+  section: CombinedClinicalSection,
+): CombinedClinicalDocumentInput["header"] => {
+  let doctorName: string | undefined;
+  let clientContact: string | undefined;
+  switch (section.documentType) {
+    case "SOAP_NOTE":
+      doctorName = section.data.doctorName;
+      break;
+    case "DISCHARGE_SUMMARY":
+      doctorName = section.data.doctorName;
+      clientContact = section.data.contact;
+      break;
+    case "VITAL_RECORD":
+      doctorName = section.data.recordedBy;
+      clientContact = section.data.contact;
+      break;
+    case "PRESCRIPTION":
+      doctorName = section.data.leadName;
+      clientContact = section.data.clientContact;
+      break;
+    default:
+      doctorName = undefined;
+  }
+
+  const { data } = section;
+  return {
+    date: data.date,
+    appointmentId: data.appointmentId,
+    patientName: data.patientName,
+    clientName: data.clientName,
+    clientId: data.clientId,
+    speciesBreed: data.speciesBreed,
+    ageSex: data.ageSex,
+    doctorName,
+    clientContact,
+  };
+};
+
+const buildCombinedClinicalSection = async (
+  doc: CombinedClinicalPacketDocument,
+  organisationId: string,
+  organization: OrganizationBranding,
+): Promise<CombinedClinicalSection | undefined> => {
+  if (!COMBINED_CLINICAL_KINDS.has(doc.kind)) {
+    return undefined;
+  }
+
+  const source: RenderedDocumentSource = {
+    sourceKind: "CLINICAL_ARTIFACT",
+    sourceId: doc.sourceId,
+    organisationId,
+    templateKind: doc.kind as RenderedDocumentSource["templateKind"],
+  };
+  const input: RenderedDocumentPdfSource = { title: doc.title, source };
+  const record = await loadClinicalArtifactDocument(source);
+
+  switch (doc.kind) {
+    case "SOAP_NOTE": {
+      const built = await buildTemplateFreeSoapNotePdfInput(
+        input,
+        record,
+        organization,
+      );
+      return { documentType: "SOAP_NOTE", data: built.data };
+    }
+    case "VITAL_RECORD": {
+      const built = await buildTemplateFreeVitalRecordPdfInput(
+        input,
+        record,
+        organization,
+      );
+      return { documentType: "VITAL_RECORD", data: built.data };
+    }
+    case "PRESCRIPTION": {
+      const built = await buildTemplateFreePrescriptionPdfInput(
+        input,
+        record,
+        organization,
+      );
+      return { documentType: "PRESCRIPTION", data: built.data };
+    }
+    case "DISCHARGE_SUMMARY": {
+      const built = await buildTemplateFreeDischargeSummaryPdfInput(
+        input,
+        record,
+        organization,
+      );
+      return { documentType: "DISCHARGE_SUMMARY", data: built.data };
+    }
+    default:
+      return undefined;
+  }
+};
+
+/**
+ * Render an ordered set of clinical artifacts as ONE continuous PDF — SOAP,
+ * Vital, Prescription and Discharge become content-only sections under a single
+ * shared header, signed once at the end. Mirrors the CLINICAL_ARTIFACT
+ * template-free path: each document is loaded via `loadClinicalArtifactDocument`
+ * and shaped by the same `buildTemplateFree*PdfInput` builders, sharing one
+ * `buildSharedOrganizationBranding` organization. Non-clinical kinds are skipped.
+ */
+export const renderCombinedClinicalPacketPdf = async (
+  input: CombinedClinicalPacketInput,
+): Promise<{
+  pdf: Buffer;
+  pageCount: number;
+  signaturePlacement: {
+    pageNumber: number;
+    pageX: number;
+    pageY: number;
+    width: number;
+    height: number;
+  };
+}> => {
+  const brand = await loadOrganizationBrand(input.organisationId);
+  const organization = buildSharedOrganizationBranding(brand);
+
+  const sections: CombinedClinicalSection[] = [];
+  for (const doc of input.documents) {
+    const section = await buildCombinedClinicalSection(
+      doc,
+      input.organisationId,
+      organization,
+    );
+    if (section) {
+      sections.push(section);
+    }
+  }
+
+  if (!sections.length) {
+    throw new Error(
+      "Combined clinical packet has no combinable clinical sections",
+    );
+  }
+
+  return generateCombinedClinicalPdfWithMetadata({
+    organization,
+    header: buildCombinedClinicalHeader(sections[0]),
+    sections,
+    printedBy: undefined,
+    signature: { status: "PENDING", label: "Signature" },
+  });
+};
 
 type PrescriptionItemRow = {
   medication: string;

--- a/apps/backend/src/services/workspace-document-packet.service.ts
+++ b/apps/backend/src/services/workspace-document-packet.service.ts
@@ -6,6 +6,7 @@ import {
 } from "src/services/workspace.prisma.service";
 import { DocumensoService } from "src/services/documenso.service";
 import { buildMergedClinicalPacketPdf } from "src/services/clinical-packet-pdf.service";
+import { renderCombinedClinicalPacketPdf } from "src/services/rendered-document-renderer.service";
 import { rerenderPersistedClinicalRenderedDocumentPdf } from "src/services/rendered-document.service";
 import logger from "src/utils/logger";
 import type {
@@ -146,6 +147,21 @@ const CANONICAL_MERGE_ORDER = [
 const MERGE_ORDER_RANK = new Map(
   CANONICAL_MERGE_ORDER.map((kind, index) => [kind, index]),
 );
+
+/**
+ * The four clinical-artifact kinds that the combined renderer can emit as
+ * content-only sections under one shared header (invoices are not packet
+ * members). A packet whose docs are all of these AND all CLINICAL_ARTIFACT
+ * sourced renders as ONE continuous PDF; anything else falls back to the merge.
+ */
+const CLINICAL_KINDS = new Set(CANONICAL_MERGE_ORDER);
+
+const isAllClinicalArtifacts = (docs: WorkspaceDocumentRow[]): boolean =>
+  docs.length > 0 &&
+  docs.every(
+    (doc) =>
+      doc.sourceKind === "CLINICAL_ARTIFACT" && CLINICAL_KINDS.has(doc.kind),
+  );
 
 const mergeOrderRank = (kind: string): number =>
   MERGE_ORDER_RANK.get(kind) ?? CANONICAL_MERGE_ORDER.length;
@@ -335,16 +351,36 @@ export const WorkspaceDocumentPacketService = {
       mergeableDocuments,
     );
 
-    const merged = await buildMergedClinicalPacketPdf({
-      organisationId: packet.organisationId,
-      title,
-      signerName: input.signerName ?? null,
-      documents: mergeableDocuments.map((doc) => ({
-        documentId: doc.documentId,
-        title: doc.title,
-        kind: doc.kind,
-      })),
-    });
+    let merged;
+    if (isAllClinicalArtifacts(mergeableDocuments)) {
+      logger.info(
+        `[WorkspaceDocumentPacket] Signing packet ${packet.id} as a combined clinical PDF (${mergeableDocuments.length} clinical artifact(s)).`,
+      );
+      merged = await renderCombinedClinicalPacketPdf({
+        organisationId: packet.organisationId,
+        signerName: input.signerName ?? null,
+        documents: mergeableDocuments.map((doc) => ({
+          documentId: doc.documentId,
+          sourceId: doc.sourceId,
+          kind: doc.kind,
+          title: doc.title,
+        })),
+      });
+    } else {
+      logger.info(
+        `[WorkspaceDocumentPacket] Signing packet ${packet.id} via PDF merge (mixed/non-clinical packet, ${mergeableDocuments.length} document(s)).`,
+      );
+      merged = await buildMergedClinicalPacketPdf({
+        organisationId: packet.organisationId,
+        title,
+        signerName: input.signerName ?? null,
+        documents: mergeableDocuments.map((doc) => ({
+          documentId: doc.documentId,
+          title: doc.title,
+          kind: doc.kind,
+        })),
+      });
+    }
 
     const doc = await DocumensoService.createDocument({
       pdf: merged.pdf,
@@ -556,15 +592,34 @@ export const WorkspaceDocumentPacketService = {
 
     await ensureClinicalArtifactsRendered(organisationId, documents);
 
-    const merged = await buildMergedClinicalPacketPdf({
-      organisationId,
-      title: `Clinical Packet ${encounterId}`,
-      documents: documents.map((doc) => ({
-        documentId: doc.documentId,
-        title: doc.title,
-        kind: doc.kind,
-      })),
-    });
+    let merged;
+    if (isAllClinicalArtifacts(documents)) {
+      logger.info(
+        `[WorkspaceDocumentPacket] Building encounter ${encounterId} packet PDF as a combined clinical PDF (${documents.length} clinical artifact(s)).`,
+      );
+      merged = await renderCombinedClinicalPacketPdf({
+        organisationId,
+        documents: documents.map((doc) => ({
+          documentId: doc.documentId,
+          sourceId: doc.sourceId,
+          kind: doc.kind,
+          title: doc.title,
+        })),
+      });
+    } else {
+      logger.info(
+        `[WorkspaceDocumentPacket] Building encounter ${encounterId} packet PDF via PDF merge (mixed/non-clinical packet, ${documents.length} document(s)).`,
+      );
+      merged = await buildMergedClinicalPacketPdf({
+        organisationId,
+        title: `Clinical Packet ${encounterId}`,
+        documents: documents.map((doc) => ({
+          documentId: doc.documentId,
+          title: doc.title,
+          kind: doc.kind,
+        })),
+      });
+    }
 
     return merged.pdf;
   },

--- a/apps/backend/test/controllers/web/appointment.prisma.controller.test.ts
+++ b/apps/backend/test/controllers/web/appointment.prisma.controller.test.ts
@@ -220,6 +220,7 @@ describe("AppointmentPrismaController", () => {
       req as any,
       res as any,
     );
+    (req as { userId?: string }).userId = "actor-1";
     await AppointmentController.admitFromPMS(req as any, res as any);
     await AppointmentController.updateFromPms(req as any, res as any);
 
@@ -228,6 +229,7 @@ describe("AppointmentPrismaController", () => {
       "appt_1",
       expect.objectContaining({
         admittedAt: new Date("2026-06-11T12:00:00.000Z"),
+        admittedBy: "actor-1",
         expectedStayDays: 3,
         lead: {
           id: "lead_1",

--- a/apps/backend/test/pdf/document-end-block.test.ts
+++ b/apps/backend/test/pdf/document-end-block.test.ts
@@ -38,7 +38,7 @@ describe("renderDocumentEndBlock", () => {
       pageX: 59.6639,
       pageY: 64.0143,
       width: 36.9748,
-      height: 4.7506,
+      height: 2.8504,
     });
   });
 });

--- a/apps/backend/test/services/appointment.prisma.service.test.ts
+++ b/apps/backend/test/services/appointment.prisma.service.test.ts
@@ -743,6 +743,7 @@ describe("AppointmentPrismaService", () => {
         organisationId: "org_1",
         patientId: "comp_1",
         admittedAt: new Date("2026-06-11T12:00:00.000Z"),
+        admittedBy: null,
         expectedStayDays: 5,
       },
     });

--- a/apps/backend/test/services/clinical-packet-pdf.service.test.ts
+++ b/apps/backend/test/services/clinical-packet-pdf.service.test.ts
@@ -40,8 +40,17 @@ describe("buildMergedClinicalPacketPdf", () => {
     // 2 + 1 source pages + 1 appended attestation/signature page
     expect(result.pageCount).toBe(4);
     expect(result.signaturePlacement.pageNumber).toBe(4);
-    expect(result.signaturePlacement.width).toBeGreaterThan(0);
-    expect(result.signaturePlacement.height).toBeGreaterThan(0);
+    // Documenso uses percentage coordinates (0–100), not PDF points — guard
+    // against a regression to point values (which land the field off-page).
+    const placement = result.signaturePlacement;
+    expect(placement.pageX).toBeGreaterThan(0);
+    expect(placement.pageX).toBeLessThanOrEqual(100);
+    expect(placement.pageY).toBeGreaterThan(0);
+    expect(placement.pageY).toBeLessThanOrEqual(100);
+    expect(placement.width).toBeGreaterThan(0);
+    expect(placement.height).toBeGreaterThan(0);
+    expect(placement.pageX + placement.width).toBeLessThanOrEqual(100);
+    expect(placement.pageY + placement.height).toBeLessThanOrEqual(100);
     expect(result.pdf.subarray(0, 5).toString("utf8")).toBe("%PDF-");
 
     // Loader called once per document with the org id

--- a/apps/backend/test/services/documenso.service.test.ts
+++ b/apps/backend/test/services/documenso.service.test.ts
@@ -237,6 +237,75 @@ describe("DocumensoService", () => {
         );
       });
 
+      it("sends the signature field on-page so the signer can reach it", async () => {
+        mockCreateV0.mockResolvedValueOnce({
+          document: { id: "doc_sig" },
+          uploadUrl: "http://upload",
+        });
+
+        await DocumensoService.createDocument({
+          pdf: Buffer.from("test"),
+          signerEmail: "test@test.com",
+          signaturePlacement: {
+            pageNumber: 1,
+            pageX: 59.66,
+            pageY: 60.21,
+            width: 36.97,
+            height: 2.85,
+          },
+        });
+
+        const arg = mockCreateV0.mock.calls.at(-1)?.[0] as {
+          recipients: Array<{
+            fields: Array<{
+              type: string;
+              pageX: number;
+              pageY: number;
+              width: number;
+              height: number;
+            }>;
+          }>;
+        };
+        const field = arg.recipients[0].fields[0];
+        expect(field.type).toBe("SIGNATURE");
+        // Documenso uses 0–100 page percentages. PDF points (>100) placed the
+        // field off-page where the signer could not reach it — the historical
+        // "sign button doesn't work" bug. Guard the field stays on the page.
+        for (const value of [
+          field.pageX,
+          field.pageY,
+          field.width,
+          field.height,
+        ]) {
+          expect(value).toBeGreaterThan(0);
+          expect(value).toBeLessThanOrEqual(100);
+        }
+        expect(field.pageX + field.width).toBeLessThanOrEqual(100);
+        expect(field.pageY + field.height).toBeLessThanOrEqual(100);
+      });
+
+      it("falls back to an on-page default placement when none is provided", async () => {
+        mockCreateV0.mockResolvedValueOnce({
+          document: { id: "doc_def" },
+          uploadUrl: "http://upload",
+        });
+
+        await DocumensoService.createDocument({
+          pdf: Buffer.from("test"),
+          signerEmail: "test@test.com",
+        });
+
+        const arg = mockCreateV0.mock.calls.at(-1)?.[0] as {
+          recipients: Array<{
+            fields: Array<{ pageX: number; pageY: number; height: number }>;
+          }>;
+        };
+        const field = arg.recipients[0].fields[0];
+        expect(field.pageX).toBeLessThanOrEqual(100);
+        expect(field.pageY).toBeLessThanOrEqual(100);
+        expect(field.pageY + field.height).toBeLessThanOrEqual(100);
+      });
+
       it("throws when uploadPdfBuffer fetch fails (!response.ok)", async () => {
         (globalThis.fetch as jest.Mock).mockResolvedValueOnce({
           ok: false,

--- a/apps/backend/test/services/rendered-document-renderer.service.test.ts
+++ b/apps/backend/test/services/rendered-document-renderer.service.test.ts
@@ -1583,5 +1583,818 @@ describe("rendered-document-renderer service", () => {
         }),
       );
     });
+
+    it("falls back to the appointment header recorder and omits recordedAt when both are absent", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        baseOrganization,
+      );
+      mockedPrisma.appointment.findUnique.mockResolvedValueOnce({
+        patient: { name: "Milo", parent: { id: "CL-2", name: "Owner" } },
+        lead: { name: "Dr. Vet" },
+        room: { name: "Exam 1" },
+      });
+      mockedPrisma.vitalRecord.findUnique.mockResolvedValueOnce({
+        id: "vital-no-recorder",
+        measuredAt: null,
+        recordedBy: null,
+        vitals: { heartRate: 92 },
+        notes: null,
+        metadata: {},
+        artifact: {
+          id: "artifact-vital-no-recorder",
+          organisationId: "org-1",
+          appointmentId: "appt-1",
+          caseId: null,
+          encounterId: null,
+          kind: "VITAL_RECORD",
+          status: "DRAFT",
+          templateId: null,
+          templateVersion: null,
+          templateVersionId: null,
+          authorId: "author-1",
+          signedBy: null,
+          signedAt: null,
+          summary: "Vital summary",
+          createdAt: new Date("2026-06-14T00:00:00.000Z"),
+          updatedAt: new Date("2026-06-14T00:00:00.000Z"),
+        },
+      });
+
+      await renderRenderedDocumentPdf({
+        title: "Vital Record",
+        source: {
+          sourceKind: "CLINICAL_ARTIFACT",
+          sourceId: "vital-no-recorder",
+          organisationId: "org-1",
+          templateKind: "VITAL_RECORD",
+        },
+      });
+
+      expect(mockedPrisma.user.findFirst).not.toHaveBeenCalled();
+      expect(mockedGenerateClinicalPdfWithMetadata).toHaveBeenCalledWith(
+        expect.objectContaining({
+          documentType: "VITAL_RECORD",
+          data: expect.objectContaining({
+            recordedBy: "Dr. Vet",
+            recordedAt: undefined,
+          }),
+        }),
+      );
+    });
+  });
+
+  describe("clinical artifact loader edge cases", () => {
+    const baseOrganization = {
+      name: "MediCare Hospital",
+      imageUrl: null,
+      phoneNo: "+91 99999 00000",
+      website: "https://medicare.example",
+      address: null,
+    };
+
+    const dischargeArtifact = (overrides: Record<string, unknown> = {}) => ({
+      id: "artifact-discharge",
+      organisationId: "org-1",
+      appointmentId: "appt-1",
+      caseId: null,
+      encounterId: null,
+      kind: "DISCHARGE_SUMMARY",
+      status: "DRAFT",
+      templateId: null,
+      templateVersion: null,
+      templateVersionId: null,
+      authorId: "author-1",
+      signedBy: null,
+      signedAt: null,
+      summary: "Discharge summary",
+      createdAt: new Date("2026-06-14T00:00:00.000Z"),
+      updatedAt: new Date("2026-06-14T00:00:00.000Z"),
+      ...overrides,
+    });
+
+    it("loads a discharge summary via findUnique and renders the template-free PDF", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        baseOrganization,
+      );
+      mockedPrisma.dischargeSummary.findUnique.mockResolvedValueOnce({
+        id: "discharge-1",
+        summary: "Discharged in stable condition",
+        diagnoses: ["Gastritis"],
+        medications: ["Carprofen"],
+        followUp: "Recheck in 7 days",
+        instructions: "Rest and fluids",
+        metadata: { chiefComplaint: "Vomiting" },
+        artifact: dischargeArtifact(),
+      });
+
+      await renderRenderedDocumentPdf({
+        title: "Discharge Summary",
+        source: {
+          sourceKind: "CLINICAL_ARTIFACT",
+          sourceId: "discharge-1",
+          organisationId: "org-1",
+          templateKind: "DISCHARGE_SUMMARY",
+        },
+      });
+
+      expect(mockedPrisma.dischargeSummary.findUnique).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: "discharge-1" } }),
+      );
+      expect(mockedGenerateClinicalPdfWithMetadata).toHaveBeenCalledWith(
+        expect.objectContaining({
+          documentType: "DISCHARGE_SUMMARY",
+          data: expect.objectContaining({
+            title: "Discharge Summary",
+            chiefComplaint: "Vomiting",
+          }),
+        }),
+      );
+    });
+
+    it("falls back to artifactId when loading a discharge summary", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        baseOrganization,
+      );
+      mockedPrisma.dischargeSummary.findUnique.mockResolvedValueOnce(null);
+      mockedPrisma.dischargeSummary.findFirst.mockResolvedValueOnce({
+        id: "discharge-2",
+        summary: "Discharged",
+        diagnoses: [],
+        medications: [],
+        followUp: "",
+        instructions: "",
+        metadata: {},
+        artifact: dischargeArtifact({ id: "artifact-discharge-2" }),
+      });
+
+      await renderRenderedDocumentPdf({
+        title: "Discharge Summary",
+        source: {
+          sourceKind: "CLINICAL_ARTIFACT",
+          sourceId: "artifact-discharge-2",
+          organisationId: "org-1",
+          templateKind: "DISCHARGE_SUMMARY",
+        },
+      });
+
+      expect(mockedPrisma.dischargeSummary.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { artifactId: "artifact-discharge-2" },
+        }),
+      );
+      expect(mockedGenerateClinicalPdfWithMetadata).toHaveBeenCalledWith(
+        expect.objectContaining({ documentType: "DISCHARGE_SUMMARY" }),
+      );
+    });
+
+    it("rejects a discharge summary outside the organisation", async () => {
+      mockedPrisma.dischargeSummary.findUnique.mockResolvedValueOnce({
+        id: "discharge-3",
+        summary: "Discharged",
+        diagnoses: [],
+        medications: [],
+        followUp: "",
+        instructions: "",
+        metadata: {},
+        artifact: dischargeArtifact({
+          id: "artifact-discharge-3",
+          organisationId: "org-2",
+        }),
+      });
+
+      await expect(
+        renderRenderedDocumentPdf({
+          title: "Discharge Summary",
+          source: {
+            sourceKind: "CLINICAL_ARTIFACT",
+            sourceId: "discharge-3",
+            organisationId: "org-1",
+            templateKind: "DISCHARGE_SUMMARY",
+          },
+        }),
+      ).rejects.toThrow("Discharge summary does not belong to organisation");
+    });
+
+    it("loads a vital record via the artifactId findFirst fallback", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        baseOrganization,
+      );
+      mockedPrisma.vitalRecord.findUnique.mockResolvedValueOnce(null);
+      mockedPrisma.vitalRecord.findFirst.mockResolvedValueOnce({
+        id: "vital-fallback-1",
+        measuredAt: new Date("2026-06-14T00:00:00.000Z"),
+        recordedBy: null,
+        vitals: { heartRate: 80 },
+        notes: null,
+        metadata: {},
+        artifact: {
+          id: "artifact-vital-fallback",
+          organisationId: "org-1",
+          appointmentId: "appt-1",
+          caseId: null,
+          encounterId: null,
+          kind: "VITAL_RECORD",
+          status: "DRAFT",
+          templateId: null,
+          templateVersion: null,
+          templateVersionId: null,
+          authorId: "author-1",
+          signedBy: null,
+          signedAt: null,
+          summary: "Vital summary",
+          createdAt: new Date("2026-06-14T00:00:00.000Z"),
+          updatedAt: new Date("2026-06-14T00:00:00.000Z"),
+        },
+      });
+
+      await renderRenderedDocumentPdf({
+        title: "Vital Record",
+        source: {
+          sourceKind: "CLINICAL_ARTIFACT",
+          sourceId: "artifact-vital-fallback",
+          organisationId: "org-1",
+          templateKind: "VITAL_RECORD",
+        },
+      });
+
+      expect(mockedPrisma.vitalRecord.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { artifactId: "artifact-vital-fallback" },
+        }),
+      );
+      expect(mockedGenerateClinicalPdfWithMetadata).toHaveBeenCalledWith(
+        expect.objectContaining({ documentType: "VITAL_RECORD" }),
+      );
+    });
+
+    it("rejects an unsupported clinical document kind", async () => {
+      await expect(
+        renderRenderedDocumentPdf({
+          title: "Unsupported",
+          source: {
+            sourceKind: "CLINICAL_ARTIFACT",
+            sourceId: "whatever-1",
+            organisationId: "org-1",
+            templateKind: "INPATIENT_SCHEDULE",
+          },
+        }),
+      ).rejects.toThrow("Unsupported clinical document kind");
+    });
+  });
+
+  describe("combined clinical packet sections and location edge cases", () => {
+    const baseOrganization = {
+      name: "MediCare Hospital",
+      imageUrl: null,
+      phoneNo: "+91 99999 00000",
+      website: "https://medicare.example",
+      address: null,
+    };
+
+    const unsignedArtifact = (overrides: Record<string, unknown>) => ({
+      id: "artifact-x",
+      organisationId: "org-1",
+      appointmentId: "appt-1",
+      caseId: null,
+      encounterId: null,
+      kind: "SOAP_NOTE",
+      status: "DRAFT",
+      templateId: null,
+      templateVersion: null,
+      templateVersionId: null,
+      authorId: "author-1",
+      signedBy: null,
+      signedAt: null,
+      summary: "summary",
+      createdAt: new Date("2026-06-14T00:00:00.000Z"),
+      updatedAt: new Date("2026-06-14T00:00:00.000Z"),
+      ...overrides,
+    });
+
+    it("builds a section for every clinical kind and leads the header with a discharge summary", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        baseOrganization,
+      );
+      // No appointment lookup match — exercises loadAppointmentLocationContext
+      // and loadAppointmentClinicalHeader null-appointment branches.
+      mockedPrisma.appointment.findUnique.mockResolvedValue(null);
+      mockedPrisma.dischargeSummary.findUnique.mockResolvedValueOnce({
+        id: "discharge-combined",
+        summary: "Discharged stable",
+        diagnoses: [],
+        medications: [],
+        followUp: "",
+        instructions: "",
+        metadata: { contact: "(555) 222 0000", doctorName: "Dr. House" },
+        artifact: unsignedArtifact({
+          id: "art-discharge",
+          kind: "DISCHARGE_SUMMARY",
+        }),
+      });
+      mockedPrisma.vitalRecord.findUnique.mockResolvedValueOnce({
+        id: "vital-combined",
+        measuredAt: new Date("2026-06-14T00:00:00.000Z"),
+        recordedBy: null,
+        vitals: { heartRate: 80 },
+        notes: null,
+        metadata: { contact: "(555) 222 0001" },
+        artifact: unsignedArtifact({ id: "art-vital", kind: "VITAL_RECORD" }),
+      });
+      mockedPrisma.prescription.findUnique.mockResolvedValueOnce({
+        id: "rx-combined",
+        items: [],
+        medications: [{ name: "Carprofen" }],
+        instructions: [],
+        notes: {},
+        metadata: {},
+        artifact: unsignedArtifact({ id: "art-rx", kind: "PRESCRIPTION" }),
+      });
+      mockedPrisma.soapNote.findUnique.mockResolvedValueOnce({
+        id: "soap-combined",
+        subjective: {},
+        objective: {},
+        assessment: {},
+        plan: {},
+        diagnoses: [],
+        metadata: {},
+        artifact: unsignedArtifact({ id: "art-soap", kind: "SOAP_NOTE" }),
+      });
+
+      await renderCombinedClinicalPacketPdf({
+        organisationId: "org-1",
+        documents: [
+          {
+            documentId: "doc-discharge",
+            sourceId: "discharge-combined",
+            kind: "DISCHARGE_SUMMARY",
+            title: "Discharge Summary",
+          },
+          {
+            documentId: "doc-vital",
+            sourceId: "vital-combined",
+            kind: "VITAL_RECORD",
+            title: "Vital Record",
+          },
+          {
+            documentId: "doc-rx",
+            sourceId: "rx-combined",
+            kind: "PRESCRIPTION",
+            title: "Prescription",
+          },
+          {
+            documentId: "doc-soap",
+            sourceId: "soap-combined",
+            kind: "SOAP_NOTE",
+            title: "SOAP Note",
+          },
+        ],
+      });
+
+      const call =
+        mockedGenerateCombinedClinicalPdfWithMetadata.mock.calls[0][0];
+      expect(call.sections).toHaveLength(4);
+      expect(
+        call.sections.map((s: { documentType: string }) => s.documentType),
+      ).toEqual([
+        "DISCHARGE_SUMMARY",
+        "VITAL_RECORD",
+        "PRESCRIPTION",
+        "SOAP_NOTE",
+      ]);
+      // Discharge summary leads, so its doctorName/contact seed the header.
+      expect(call.header.doctorName).toBe("Dr. House");
+      expect(call.header.clientContact).toBe("(555) 222 0000");
+    });
+
+    it("leads the header with a prescription section (leadName + clientContact)", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        baseOrganization,
+      );
+      mockedPrisma.appointment.findUnique.mockResolvedValue(null);
+      mockedPrisma.prescription.findUnique.mockResolvedValueOnce({
+        id: "rx-lead",
+        items: [],
+        medications: [{ name: "Carprofen" }],
+        instructions: [],
+        notes: {},
+        metadata: {
+          leadName: "Dr. Strange",
+          clientContact: "(555) 111 2222",
+        },
+        artifact: unsignedArtifact({ id: "art-rx-lead", kind: "PRESCRIPTION" }),
+      });
+
+      await renderCombinedClinicalPacketPdf({
+        organisationId: "org-1",
+        documents: [
+          {
+            documentId: "doc-rx-lead",
+            sourceId: "rx-lead",
+            kind: "PRESCRIPTION",
+            title: "Prescription",
+          },
+        ],
+      });
+
+      const call =
+        mockedGenerateCombinedClinicalPdfWithMetadata.mock.calls[0][0];
+      expect(call.header.doctorName).toBe("Dr. Strange");
+      expect(call.header.clientContact).toBe("(555) 111 2222");
+    });
+
+    it("leads the header with a vital record section (recordedBy + contact)", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        baseOrganization,
+      );
+      mockedPrisma.appointment.findUnique.mockResolvedValue(null);
+      mockedPrisma.vitalRecord.findUnique.mockResolvedValueOnce({
+        id: "vital-lead",
+        measuredAt: new Date("2026-06-14T00:00:00.000Z"),
+        recordedBy: null,
+        vitals: { heartRate: 80 },
+        notes: null,
+        metadata: {
+          recordedBy: "Nurse Joy",
+          contact: "(555) 333 4444",
+        },
+        artifact: unsignedArtifact({
+          id: "art-vital-lead",
+          kind: "VITAL_RECORD",
+        }),
+      });
+
+      await renderCombinedClinicalPacketPdf({
+        organisationId: "org-1",
+        documents: [
+          {
+            documentId: "doc-vital-lead",
+            sourceId: "vital-lead",
+            kind: "VITAL_RECORD",
+            title: "Vital Record",
+          },
+        ],
+      });
+
+      const call =
+        mockedGenerateCombinedClinicalPdfWithMetadata.mock.calls[0][0];
+      expect(call.header.doctorName).toBe("Nurse Joy");
+      expect(call.header.clientContact).toBe("(555) 333 4444");
+    });
+
+    it("skips non-combinable kinds and throws when no combinable sections remain", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        baseOrganization,
+      );
+
+      await expect(
+        renderCombinedClinicalPacketPdf({
+          organisationId: "org-1",
+          documents: [
+            {
+              documentId: "doc-form",
+              sourceId: "form-1",
+              kind: "FORM",
+              title: "Intake Form",
+            },
+          ],
+        }),
+      ).rejects.toThrow(
+        "Combined clinical packet has no combinable clinical sections",
+      );
+      expect(
+        mockedGenerateCombinedClinicalPdfWithMetadata,
+      ).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the appointment room when the unit row cannot be found", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        baseOrganization,
+      );
+      mockedPrisma.appointment.findUnique.mockResolvedValue({
+        appointmentKind: "INPATIENT",
+        encounterId: "enc-no-unit-row",
+        patient: { name: "Bella", parent: { id: "CL-1", name: "Owner" } },
+        lead: { name: "Dr. Tim" },
+        room: { name: "Appointment Room" },
+      });
+      mockedPrisma.admission.findUnique.mockResolvedValueOnce({
+        encounterId: "enc-no-unit-row",
+        unitId: "unit-missing",
+        admittedAt: new Date("2026-06-20T08:00:00.000Z"),
+        admittedBy: null,
+        dischargedAt: null,
+      });
+      // roomUnit.findUnique returns null (default) → roomName falls back to
+      // the appointment room and unitName stays undefined.
+      mockedPrisma.soapNote.findUnique.mockResolvedValueOnce({
+        id: "soap-no-unit-row",
+        subjective: {},
+        objective: {},
+        assessment: {},
+        plan: {},
+        diagnoses: [],
+        metadata: {},
+        artifact: unsignedArtifact({
+          id: "art-soap-no-unit-row",
+          kind: "SOAP_NOTE",
+          encounterId: "enc-no-unit-row",
+        }),
+      });
+
+      await renderCombinedClinicalPacketPdf({
+        organisationId: "org-1",
+        documents: [
+          {
+            documentId: "doc-soap-no-unit-row",
+            sourceId: "soap-no-unit-row",
+            kind: "SOAP_NOTE",
+            title: "SOAP Note",
+          },
+        ],
+      });
+
+      expect(mockedPrisma.roomUnit.findUnique).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: "unit-missing" } }),
+      );
+      expect(mockedPrisma.organisationRoom.findUnique).not.toHaveBeenCalled();
+      const call =
+        mockedGenerateCombinedClinicalPdfWithMetadata.mock.calls[0][0];
+      expect(call.header.roomName).toBe("Appointment Room");
+      expect(call.header.unitName).toBeUndefined();
+      expect(call.header.admittedAt).toBe("2026-06-20 08:00");
+      expect(call.header.admittedBy).toBeUndefined();
+    });
+
+    it("falls back to the appointment room when the unit's room row is missing", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        baseOrganization,
+      );
+      mockedPrisma.appointment.findUnique.mockResolvedValue({
+        appointmentKind: "INPATIENT",
+        encounterId: "enc-no-room",
+        patient: { name: "Bella", parent: { id: "CL-1", name: "Owner" } },
+        lead: { name: "Dr. Tim" },
+        room: { name: "Appointment Room" },
+      });
+      mockedPrisma.admission.findUnique.mockResolvedValueOnce({
+        encounterId: "enc-no-room",
+        unitId: "unit-1",
+        admittedAt: new Date("2026-06-20T08:00:00.000Z"),
+        admittedBy: null,
+        dischargedAt: null,
+      });
+      mockedPrisma.roomUnit.findUnique.mockResolvedValueOnce({
+        id: "unit-1",
+        roomId: "room-missing",
+        code: "U-9",
+        displayName: "Ward Bed 9",
+      });
+      // organisationRoom.findUnique returns null (default) → roomName falls
+      // back to the appointment room; unitName still resolves.
+      mockedPrisma.soapNote.findUnique.mockResolvedValueOnce({
+        id: "soap-no-room",
+        subjective: {},
+        objective: {},
+        assessment: {},
+        plan: {},
+        diagnoses: [],
+        metadata: {},
+        artifact: unsignedArtifact({
+          id: "art-soap-no-room",
+          kind: "SOAP_NOTE",
+          encounterId: "enc-no-room",
+        }),
+      });
+
+      await renderCombinedClinicalPacketPdf({
+        organisationId: "org-1",
+        documents: [
+          {
+            documentId: "doc-soap-no-room",
+            sourceId: "soap-no-room",
+            kind: "SOAP_NOTE",
+            title: "SOAP Note",
+          },
+        ],
+      });
+
+      expect(mockedPrisma.organisationRoom.findUnique).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: "room-missing" } }),
+      );
+      const call =
+        mockedGenerateCombinedClinicalPdfWithMetadata.mock.calls[0][0];
+      expect(call.header.roomName).toBe("Appointment Room");
+      expect(call.header.unitName).toBe("Ward Bed 9");
+    });
+
+    it("resolves the unit from the assignment and the admitter from assignment.assignedBy", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        baseOrganization,
+      );
+      mockedPrisma.appointment.findUnique.mockResolvedValue({
+        appointmentKind: "INPATIENT",
+        encounterId: "enc-assignment",
+        patient: { name: "Bella", parent: { id: "CL-1", name: "Owner" } },
+        lead: { name: "Dr. Tim" },
+        room: { name: "Appointment Room" },
+      });
+      // Admission exists but carries no unitId and no admittedBy — both must be
+      // sourced from the assignment instead.
+      mockedPrisma.admission.findUnique.mockResolvedValueOnce({
+        encounterId: "enc-assignment",
+        unitId: null,
+        admittedAt: new Date("2026-06-20T08:00:00.000Z"),
+        admittedBy: null,
+        dischargedAt: null,
+      });
+      mockedPrisma.roomUnitAssignment.findFirst.mockResolvedValueOnce({
+        id: "assign-2",
+        encounterId: "enc-assignment",
+        unitId: "unit-2",
+        assignedAt: new Date("2026-06-20T08:00:00.000Z"),
+        releasedAt: null,
+        assignedBy: "assigner-user-id",
+      });
+      mockedPrisma.roomUnit.findUnique.mockResolvedValueOnce({
+        id: "unit-2",
+        roomId: "room-2",
+        code: "U-2",
+        displayName: "ICU Bed 2",
+      });
+      mockedPrisma.organisationRoom.findUnique.mockResolvedValueOnce({
+        id: "room-2",
+        name: "Critical Care",
+        code: "CC",
+      });
+      mockedPrisma.user.findFirst.mockResolvedValueOnce({
+        firstName: "Sam",
+        lastName: "Wells",
+        email: "sam.wells@example.com",
+      });
+      mockedPrisma.soapNote.findUnique.mockResolvedValueOnce({
+        id: "soap-assignment",
+        subjective: {},
+        objective: {},
+        assessment: {},
+        plan: {},
+        diagnoses: [],
+        metadata: {},
+        artifact: unsignedArtifact({
+          id: "art-soap-assignment",
+          kind: "SOAP_NOTE",
+          encounterId: "enc-assignment",
+        }),
+      });
+
+      await renderCombinedClinicalPacketPdf({
+        organisationId: "org-1",
+        documents: [
+          {
+            documentId: "doc-soap-assignment",
+            sourceId: "soap-assignment",
+            kind: "SOAP_NOTE",
+            title: "SOAP Note",
+          },
+        ],
+      });
+
+      expect(mockedPrisma.roomUnit.findUnique).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: "unit-2" } }),
+      );
+      expect(mockedPrisma.user.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { userId: "assigner-user-id" } }),
+      );
+      const call =
+        mockedGenerateCombinedClinicalPdfWithMetadata.mock.calls[0][0];
+      expect(call.header.roomName).toBe("Critical Care");
+      expect(call.header.unitName).toBe("ICU Bed 2");
+      expect(call.header.admittedBy).toBe("Sam Wells");
+    });
+
+    it("treats an encounter with an admission as inpatient even when no unit can be resolved", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        baseOrganization,
+      );
+      mockedPrisma.appointment.findUnique.mockResolvedValue({
+        appointmentKind: "OUTPATIENT",
+        encounterId: "enc-admission-only",
+        patient: { name: "Bella", parent: { id: "CL-1", name: "Owner" } },
+        lead: { name: "Dr. Tim" },
+        room: { name: "Appointment Room" },
+      });
+      // Admission present (so inpatient) but no unitId; assignment absent too.
+      mockedPrisma.admission.findUnique.mockResolvedValueOnce({
+        encounterId: "enc-admission-only",
+        unitId: null,
+        admittedAt: new Date("2026-06-20T08:00:00.000Z"),
+        admittedBy: "admitter-user-id",
+        dischargedAt: null,
+      });
+      mockedPrisma.user.findFirst.mockResolvedValueOnce({
+        firstName: "Ada",
+        lastName: "Byron",
+        email: "ada@example.com",
+      });
+      mockedPrisma.soapNote.findUnique.mockResolvedValueOnce({
+        id: "soap-admission-only",
+        subjective: {},
+        objective: {},
+        assessment: {},
+        plan: {},
+        diagnoses: [],
+        metadata: {},
+        artifact: unsignedArtifact({
+          id: "art-soap-admission-only",
+          kind: "SOAP_NOTE",
+          encounterId: "enc-admission-only",
+        }),
+      });
+
+      await renderCombinedClinicalPacketPdf({
+        organisationId: "org-1",
+        documents: [
+          {
+            documentId: "doc-soap-admission-only",
+            sourceId: "soap-admission-only",
+            kind: "SOAP_NOTE",
+            title: "SOAP Note",
+          },
+        ],
+      });
+
+      expect(mockedPrisma.roomUnit.findUnique).not.toHaveBeenCalled();
+      expect(mockedPrisma.user.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { userId: "admitter-user-id" } }),
+      );
+      const call =
+        mockedGenerateCombinedClinicalPdfWithMetadata.mock.calls[0][0];
+      // No unit → resolveUnitRoomNames returns just the fallback room name.
+      expect(call.header.roomName).toBe("Appointment Room");
+      expect(call.header.unitName).toBeUndefined();
+      expect(call.header.admittedBy).toBe("Ada Byron");
+    });
+
+    it("resolves location from the encounterId on the artifact when the appointment is absent", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        baseOrganization,
+      );
+      // No appointmentId on the artifact, but the encounterId drives the
+      // admission/assignment lookups directly (loadAppointmentLocationContext
+      // short-circuits on the missing appointment).
+      mockedPrisma.appointment.findUnique.mockResolvedValue(null);
+      mockedPrisma.admission.findUnique.mockResolvedValueOnce({
+        encounterId: "enc-direct",
+        unitId: "unit-3",
+        admittedAt: new Date("2026-06-20T08:00:00.000Z"),
+        admittedBy: null,
+        dischargedAt: null,
+      });
+      mockedPrisma.roomUnit.findUnique.mockResolvedValueOnce({
+        id: "unit-3",
+        roomId: "room-3",
+        code: "U-3",
+        displayName: "Recovery Bed 3",
+      });
+      mockedPrisma.organisationRoom.findUnique.mockResolvedValueOnce({
+        id: "room-3",
+        name: "Recovery Ward",
+        code: "RW",
+      });
+      mockedPrisma.soapNote.findUnique.mockResolvedValueOnce({
+        id: "soap-direct",
+        subjective: {},
+        objective: {},
+        assessment: {},
+        plan: {},
+        diagnoses: [],
+        metadata: {},
+        artifact: unsignedArtifact({
+          id: "art-soap-direct",
+          kind: "SOAP_NOTE",
+          appointmentId: null,
+          encounterId: "enc-direct",
+        }),
+      });
+
+      await renderCombinedClinicalPacketPdf({
+        organisationId: "org-1",
+        documents: [
+          {
+            documentId: "doc-soap-direct",
+            sourceId: "soap-direct",
+            kind: "SOAP_NOTE",
+            title: "SOAP Note",
+          },
+        ],
+      });
+
+      expect(mockedPrisma.admission.findUnique).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { encounterId: "enc-direct" } }),
+      );
+      const call =
+        mockedGenerateCombinedClinicalPdfWithMetadata.mock.calls[0][0];
+      expect(call.header.roomName).toBe("Recovery Ward");
+      expect(call.header.unitName).toBe("Recovery Bed 3");
+    });
   });
 });

--- a/apps/backend/test/services/rendered-document-renderer.service.test.ts
+++ b/apps/backend/test/services/rendered-document-renderer.service.test.ts
@@ -2,6 +2,7 @@ import { TemplateKind } from "@prisma/client";
 import { prisma } from "src/config/prisma";
 import {
   buildPrescriptionLabelPdfInput,
+  renderCombinedClinicalPacketPdf,
   renderPrescriptionLabelPdf,
   renderRenderedDocumentPdf,
 } from "../../src/services/rendered-document-renderer.service";
@@ -9,6 +10,7 @@ import { renderPdf } from "../../src/services/formPDF.service";
 import {
   generateClinicalPdf,
   generateClinicalPdfWithMetadata,
+  generateCombinedClinicalPdfWithMetadata,
   generateResolvedTemplatePdfWithMetadata,
 } from "@yosemite-crew/lib";
 
@@ -55,6 +57,9 @@ jest.mock("src/config/prisma", () => ({
     inventoryItem: {
       findMany: jest.fn(),
     },
+    user: {
+      findFirst: jest.fn(),
+    },
   },
 }));
 
@@ -65,6 +70,7 @@ jest.mock("../../src/services/formPDF.service", () => ({
 jest.mock("@yosemite-crew/lib", () => ({
   generateClinicalPdf: jest.fn(),
   generateClinicalPdfWithMetadata: jest.fn(),
+  generateCombinedClinicalPdfWithMetadata: jest.fn(),
   generateResolvedTemplatePdfWithMetadata: jest.fn(),
 }));
 
@@ -82,11 +88,14 @@ describe("rendered-document-renderer service", () => {
     dischargeSummary: { findUnique: jest.Mock; findFirst: jest.Mock };
     vitalRecord: { findUnique: jest.Mock; findFirst: jest.Mock };
     inventoryItem: { findMany: jest.Mock };
+    user: { findFirst: jest.Mock };
   };
   const mockedRenderPdf = renderPdf as jest.Mock;
   const mockedGenerateClinicalPdf = generateClinicalPdf as jest.Mock;
   const mockedGenerateClinicalPdfWithMetadata =
     generateClinicalPdfWithMetadata as jest.Mock;
+  const mockedGenerateCombinedClinicalPdfWithMetadata =
+    generateCombinedClinicalPdfWithMetadata as jest.Mock;
   const mockedGenerateResolvedTemplatePdfWithMetadata =
     generateResolvedTemplatePdfWithMetadata as jest.Mock;
 
@@ -96,11 +105,23 @@ describe("rendered-document-renderer service", () => {
     mockedGenerateClinicalPdf.mockResolvedValue(Buffer.from("label-pdf"));
     mockedPrisma.appointment.findUnique.mockResolvedValue(null);
     mockedPrisma.inventoryItem.findMany.mockResolvedValue([]);
+    mockedPrisma.user.findFirst.mockResolvedValue(null);
     mockedGenerateClinicalPdfWithMetadata.mockResolvedValue({
       pdf: Buffer.from("pdf"),
       pageCount: 1,
       signaturePlacement: {
         pageNumber: 1,
+        pageX: 340,
+        pageY: 710,
+        width: 220,
+        height: 96,
+      },
+    });
+    mockedGenerateCombinedClinicalPdfWithMetadata.mockResolvedValue({
+      pdf: Buffer.from("combined-pdf"),
+      pageCount: 2,
+      signaturePlacement: {
+        pageNumber: 2,
         pageX: 340,
         pageY: 710,
         width: 220,
@@ -1044,6 +1065,274 @@ describe("rendered-document-renderer service", () => {
           prescriptionId: "rx-missing",
         }),
       ).rejects.toThrow("Prescription not found");
+    });
+  });
+
+  describe("template-free clinical artifact signature", () => {
+    const baseOrganization = {
+      name: "MediCare Hospital",
+      imageUrl: null,
+      phoneNo: "+91 99999 00000",
+      website: "https://medicare.example",
+      address: null,
+    };
+
+    const signedSoapNote = () => ({
+      id: "soap-signed-1",
+      subjective: { history: "cough" },
+      objective: { temp: 38.5 },
+      assessment: { impression: "kennel cough" },
+      plan: { treatment: "rest" },
+      diagnoses: [],
+      metadata: { author: "vet-1" },
+      artifact: {
+        id: "artifact-signed-1",
+        organisationId: "org-1",
+        appointmentId: "appt-1",
+        caseId: null,
+        encounterId: null,
+        kind: "SOAP_NOTE",
+        status: "SIGNED",
+        templateId: null,
+        templateVersion: null,
+        templateVersionId: null,
+        authorId: "author-1",
+        signedBy: "signer-user-id",
+        signedAt: new Date("2026-06-20T00:00:00.000Z"),
+        summary: "SOAP summary",
+        createdAt: new Date("2026-06-14T00:00:00.000Z"),
+        updatedAt: new Date("2026-06-14T00:00:00.000Z"),
+      },
+    });
+
+    it("renders a SIGNED signature with resolved signer name/email and authMethod", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        baseOrganization,
+      );
+      mockedPrisma.soapNote.findUnique.mockResolvedValueOnce(signedSoapNote());
+      mockedPrisma.user.findFirst.mockResolvedValueOnce({
+        firstName: "Tim",
+        lastName: "Apple",
+        email: "tim.apple@example.com",
+      });
+
+      await renderRenderedDocumentPdf({
+        title: "SOAP Note",
+        source: {
+          sourceKind: "CLINICAL_ARTIFACT",
+          sourceId: "soap-signed-1",
+          organisationId: "org-1",
+          templateKind: "SOAP_NOTE",
+        },
+      });
+
+      expect(mockedPrisma.user.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { userId: "signer-user-id" },
+        }),
+      );
+      expect(mockedGenerateClinicalPdfWithMetadata).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            signature: {
+              status: "SIGNED",
+              label: "Signature",
+              signerName: "Tim Apple",
+              signerEmail: "tim.apple@example.com",
+              authMethod: "Email",
+              signedAt: new Date("2026-06-20T00:00:00.000Z"),
+            },
+          }),
+        }),
+      );
+    });
+
+    it("still renders SIGNED with authMethod when the signer user cannot be resolved", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        baseOrganization,
+      );
+      mockedPrisma.soapNote.findUnique.mockResolvedValueOnce(signedSoapNote());
+      mockedPrisma.user.findFirst.mockResolvedValueOnce(null);
+
+      await renderRenderedDocumentPdf({
+        title: "SOAP Note",
+        source: {
+          sourceKind: "CLINICAL_ARTIFACT",
+          sourceId: "soap-signed-1",
+          organisationId: "org-1",
+          templateKind: "SOAP_NOTE",
+        },
+      });
+
+      expect(mockedGenerateClinicalPdfWithMetadata).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            signature: expect.objectContaining({
+              status: "SIGNED",
+              authMethod: "Email",
+              signerName: undefined,
+              signerEmail: undefined,
+              signedAt: new Date("2026-06-20T00:00:00.000Z"),
+            }),
+          }),
+        }),
+      );
+    });
+  });
+
+  describe("combined clinical packet header", () => {
+    const baseOrganization = {
+      name: "MediCare Hospital",
+      imageUrl: null,
+      phoneNo: "+91 99999 00000",
+      website: "https://medicare.example",
+      address: null,
+    };
+
+    const unsignedArtifact = (overrides: Record<string, unknown>) => ({
+      id: "artifact-x",
+      organisationId: "org-1",
+      appointmentId: "appt-1",
+      caseId: null,
+      encounterId: null,
+      kind: "SOAP_NOTE",
+      status: "DRAFT",
+      templateId: null,
+      templateVersion: null,
+      templateVersionId: null,
+      authorId: "author-1",
+      signedBy: null,
+      signedAt: null,
+      summary: "summary",
+      createdAt: new Date("2026-06-14T00:00:00.000Z"),
+      updatedAt: new Date("2026-06-14T00:00:00.000Z"),
+      ...overrides,
+    });
+
+    it("merges appointment room/unit and client contact into the shared header even when SOAP is first", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        baseOrganization,
+      );
+      // Appointment is read by each section builder AND once for the shared
+      // header — keep the same record for every call.
+      mockedPrisma.appointment.findUnique.mockResolvedValue({
+        patient: {
+          name: "Bella Hadid",
+          species: "Canine",
+          breed: "Bulldog",
+          parent: {
+            id: "CL-1001",
+            name: "Yasmin Hadid",
+            phoneNumber: "(512) 555 0111",
+          },
+        },
+        lead: { name: "Dr. Tim Apple" },
+        room: {
+          id: "room-1",
+          name: "Exam Room 3",
+          unit: { displayName: "Unit B" },
+        },
+      });
+      mockedPrisma.soapNote.findUnique.mockResolvedValueOnce({
+        id: "soap-combined-1",
+        subjective: { history: "cough" },
+        objective: {},
+        assessment: {},
+        plan: {},
+        diagnoses: [],
+        metadata: {},
+        artifact: unsignedArtifact({ id: "art-soap", kind: "SOAP_NOTE" }),
+      });
+      mockedPrisma.prescription.findUnique.mockResolvedValueOnce({
+        id: "rx-combined-1",
+        items: [],
+        medications: [{ name: "Carprofen" }],
+        instructions: [],
+        notes: {},
+        metadata: {},
+        artifact: unsignedArtifact({ id: "art-rx", kind: "PRESCRIPTION" }),
+      });
+
+      const result = await renderCombinedClinicalPacketPdf({
+        organisationId: "org-1",
+        documents: [
+          {
+            documentId: "doc-soap",
+            sourceId: "soap-combined-1",
+            kind: "SOAP_NOTE",
+            title: "SOAP Note",
+          },
+          {
+            documentId: "doc-rx",
+            sourceId: "rx-combined-1",
+            kind: "PRESCRIPTION",
+            title: "Prescription",
+          },
+        ],
+      });
+
+      expect(
+        mockedGenerateCombinedClinicalPdfWithMetadata,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          header: expect.objectContaining({
+            patientName: "Bella Hadid",
+            clientName: "Yasmin Hadid",
+            clientId: "CL-1001",
+            speciesBreed: "Canine / Bulldog",
+            doctorName: "Dr. Tim Apple",
+            clientContact: "(512) 555 0111",
+            roomName: "Exam Room 3",
+            unitName: "Unit B",
+          }),
+          signature: expect.objectContaining({ status: "PENDING" }),
+        }),
+      );
+      expect(result.pdf).toEqual(Buffer.from("combined-pdf"));
+    });
+
+    it("leaves unitName undefined when the appointment room has no unit", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        baseOrganization,
+      );
+      mockedPrisma.appointment.findUnique.mockResolvedValue({
+        patient: { name: "Milo", parent: { id: "CL-2", name: "Owner" } },
+        lead: { name: "Dr. Vet" },
+        room: { id: "room-2", name: "Ward A" },
+      });
+      mockedPrisma.soapNote.findUnique.mockResolvedValueOnce({
+        id: "soap-combined-2",
+        subjective: {},
+        objective: {},
+        assessment: {},
+        plan: {},
+        diagnoses: [],
+        metadata: {},
+        artifact: unsignedArtifact({ id: "art-soap-2", kind: "SOAP_NOTE" }),
+      });
+
+      await renderCombinedClinicalPacketPdf({
+        organisationId: "org-1",
+        documents: [
+          {
+            documentId: "doc-soap-2",
+            sourceId: "soap-combined-2",
+            kind: "SOAP_NOTE",
+            title: "SOAP Note",
+          },
+        ],
+      });
+
+      expect(
+        mockedGenerateCombinedClinicalPdfWithMetadata,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          header: expect.objectContaining({
+            roomName: "Ward A",
+            unitName: undefined,
+          }),
+        }),
+      );
     });
   });
 });

--- a/apps/backend/test/services/rendered-document-renderer.service.test.ts
+++ b/apps/backend/test/services/rendered-document-renderer.service.test.ts
@@ -1,4 +1,5 @@
 import { TemplateKind } from "@prisma/client";
+import type { RenderedDocumentSource } from "@yosemite-crew/types";
 import { prisma } from "src/config/prisma";
 import {
   buildPrescriptionLabelPdfInput,
@@ -3348,6 +3349,125 @@ describe("rendered-document-renderer service", () => {
       expect(mockedGenerateClinicalPdfWithMetadata).toHaveBeenCalledWith(
         expect.objectContaining({ documentType: "SOAP_NOTE" }),
       );
+    });
+
+    it("re-throws non-'Template version not found' errors from the template version lookup", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        baseOrganization,
+      );
+      mockedPrisma.soapNote.findUnique.mockResolvedValueOnce({
+        id: "soap-db-down",
+        subjective: { history: "cough" },
+        objective: {},
+        assessment: {},
+        plan: {},
+        diagnoses: [],
+        metadata: {},
+        artifact: {
+          id: "art-soap-db-down",
+          organisationId: "org-1",
+          appointmentId: null,
+          caseId: null,
+          encounterId: null,
+          kind: "SOAP_NOTE",
+          status: "DRAFT",
+          templateId: "template-db-down",
+          templateVersion: 4,
+          templateVersionId: null,
+          authorId: "author-1",
+          signedBy: null,
+          signedAt: null,
+          summary: "summary",
+          createdAt: new Date("2026-06-14T00:00:00.000Z"),
+          updatedAt: new Date("2026-06-14T00:00:00.000Z"),
+        },
+      });
+      // The version lookup rejects with an unrelated error → not swallowed by
+      // the "Template version not found" guard, so it propagates out.
+      mockedPrisma.templateVersion.findUnique.mockRejectedValueOnce(
+        new Error("db down"),
+      );
+
+      await expect(
+        renderRenderedDocumentPdf({
+          title: "SOAP Note",
+          source: {
+            sourceKind: "CLINICAL_ARTIFACT",
+            sourceId: "soap-db-down",
+            organisationId: "org-1",
+            templateKind: "SOAP_NOTE",
+            templateVersion: 4,
+          },
+        }),
+      ).rejects.toThrow("db down");
+
+      expect(
+        mockedGenerateResolvedTemplatePdfWithMetadata,
+      ).not.toHaveBeenCalled();
+      expect(mockedGenerateClinicalPdfWithMetadata).not.toHaveBeenCalled();
+    });
+
+    it("re-throws non-'Template version not found' errors from the latest-version lookup", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        baseOrganization,
+      );
+      mockedPrisma.soapNote.findUnique.mockResolvedValueOnce({
+        id: "soap-latest-down",
+        subjective: { history: "cough" },
+        objective: {},
+        assessment: {},
+        plan: {},
+        diagnoses: [],
+        metadata: {},
+        artifact: {
+          id: "art-soap-latest-down",
+          organisationId: "org-1",
+          appointmentId: null,
+          caseId: null,
+          encounterId: null,
+          kind: "SOAP_NOTE",
+          status: "DRAFT",
+          templateId: "template-latest-down",
+          // templateVersion null → loadLatestTemplateVersionOrThrow path.
+          templateVersion: null,
+          templateVersionId: null,
+          authorId: "author-1",
+          signedBy: null,
+          signedAt: null,
+          summary: "summary",
+          createdAt: new Date("2026-06-14T00:00:00.000Z"),
+          updatedAt: new Date("2026-06-14T00:00:00.000Z"),
+        },
+      });
+      mockedPrisma.templateVersion.findFirst.mockRejectedValueOnce(
+        new Error("db down"),
+      );
+
+      await expect(
+        renderRenderedDocumentPdf({
+          title: "SOAP Note",
+          source: {
+            sourceKind: "CLINICAL_ARTIFACT",
+            sourceId: "soap-latest-down",
+            organisationId: "org-1",
+            templateKind: "SOAP_NOTE",
+          },
+        }),
+      ).rejects.toThrow("db down");
+    });
+
+    it("rejects unsupported rendered document source kinds", async () => {
+      await expect(
+        renderRenderedDocumentPdf({
+          title: "Unsupported",
+          source: {
+            sourceKind: "UNKNOWN_KIND",
+            sourceId: "whatever",
+            organisationId: "org-1",
+            templateKind: "SOAP_NOTE",
+          } as unknown as RenderedDocumentSource,
+        }),
+      ).rejects.toThrow("Unsupported rendered document source kind");
     });
 
     it("defaults missing snapshot sections/config to empty/null in the resolved template", async () => {

--- a/apps/backend/test/services/rendered-document-renderer.service.test.ts
+++ b/apps/backend/test/services/rendered-document-renderer.service.test.ts
@@ -22,6 +22,18 @@ jest.mock("src/config/prisma", () => ({
     appointment: {
       findUnique: jest.fn(),
     },
+    admission: {
+      findUnique: jest.fn(),
+    },
+    roomUnit: {
+      findUnique: jest.fn(),
+    },
+    organisationRoom: {
+      findUnique: jest.fn(),
+    },
+    roomUnitAssignment: {
+      findFirst: jest.fn(),
+    },
     formSubmission: {
       findUnique: jest.fn(),
     },
@@ -78,6 +90,10 @@ describe("rendered-document-renderer service", () => {
   const mockedPrisma = prisma as unknown as {
     organization: { findUnique: jest.Mock };
     appointment: { findUnique: jest.Mock };
+    admission: { findUnique: jest.Mock };
+    roomUnit: { findUnique: jest.Mock };
+    organisationRoom: { findUnique: jest.Mock };
+    roomUnitAssignment: { findFirst: jest.Mock };
     formSubmission: { findUnique: jest.Mock };
     form: { findUnique: jest.Mock };
     formVersion: { findUnique: jest.Mock };
@@ -104,6 +120,10 @@ describe("rendered-document-renderer service", () => {
     mockedRenderPdf.mockResolvedValue(Buffer.from("pdf"));
     mockedGenerateClinicalPdf.mockResolvedValue(Buffer.from("label-pdf"));
     mockedPrisma.appointment.findUnique.mockResolvedValue(null);
+    mockedPrisma.admission.findUnique.mockResolvedValue(null);
+    mockedPrisma.roomUnit.findUnique.mockResolvedValue(null);
+    mockedPrisma.organisationRoom.findUnique.mockResolvedValue(null);
+    mockedPrisma.roomUnitAssignment.findFirst.mockResolvedValue(null);
     mockedPrisma.inventoryItem.findMany.mockResolvedValue([]);
     mockedPrisma.user.findFirst.mockResolvedValue(null);
     mockedGenerateClinicalPdfWithMetadata.mockResolvedValue({
@@ -1330,6 +1350,235 @@ describe("rendered-document-renderer service", () => {
           header: expect.objectContaining({
             roomName: "Ward A",
             unitName: undefined,
+          }),
+        }),
+      );
+    });
+
+    it("populates inpatient room/unit/admission details from admission, unit, room and assignment", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        baseOrganization,
+      );
+      // First call (per-section header) returns the patient/lead; the shared
+      // location lookup re-reads with the inpatient kind + encounter id.
+      mockedPrisma.appointment.findUnique.mockResolvedValue({
+        appointmentKind: "INPATIENT",
+        encounterId: "enc-inpatient",
+        patient: {
+          name: "Bella Hadid",
+          parent: { id: "CL-1001", name: "Yasmin Hadid" },
+        },
+        lead: { name: "Dr. Tim Apple" },
+        room: { id: "room-appt", name: "Reception" },
+      });
+      mockedPrisma.admission.findUnique.mockResolvedValueOnce({
+        encounterId: "enc-inpatient",
+        unitId: "unit-1",
+        admittedAt: new Date("2026-06-20T09:30:00.000Z"),
+        dischargedAt: null,
+      });
+      mockedPrisma.roomUnitAssignment.findFirst.mockResolvedValueOnce({
+        id: "assign-1",
+        encounterId: "enc-inpatient",
+        unitId: "unit-1",
+        assignedAt: new Date("2026-06-20T09:30:00.000Z"),
+        releasedAt: null,
+        assignedBy: "admitting-user-id",
+      });
+      mockedPrisma.roomUnit.findUnique.mockResolvedValueOnce({
+        id: "unit-1",
+        roomId: "room-ward",
+        code: "U-1",
+        displayName: "ICU Bed 4",
+      });
+      mockedPrisma.organisationRoom.findUnique.mockResolvedValueOnce({
+        id: "room-ward",
+        name: "Intensive Care Ward",
+        code: "ICU",
+      });
+      mockedPrisma.user.findFirst.mockResolvedValueOnce({
+        firstName: "Nina",
+        lastName: "Patel",
+        email: "nina.patel@example.com",
+      });
+      mockedPrisma.soapNote.findUnique.mockResolvedValueOnce({
+        id: "soap-inpatient",
+        subjective: {},
+        objective: {},
+        assessment: {},
+        plan: {},
+        diagnoses: [],
+        metadata: {},
+        artifact: unsignedArtifact({
+          id: "art-soap-inpatient",
+          kind: "SOAP_NOTE",
+          encounterId: "enc-inpatient",
+        }),
+      });
+
+      await renderCombinedClinicalPacketPdf({
+        organisationId: "org-1",
+        documents: [
+          {
+            documentId: "doc-soap-inpatient",
+            sourceId: "soap-inpatient",
+            kind: "SOAP_NOTE",
+            title: "SOAP Note",
+          },
+        ],
+      });
+
+      expect(mockedPrisma.admission.findUnique).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { encounterId: "enc-inpatient" },
+        }),
+      );
+      expect(mockedPrisma.roomUnitAssignment.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { encounterId: "enc-inpatient", releasedAt: null },
+          orderBy: { assignedAt: "desc" },
+        }),
+      );
+      expect(mockedPrisma.user.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { userId: "admitting-user-id" },
+        }),
+      );
+      expect(
+        mockedGenerateCombinedClinicalPdfWithMetadata,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          header: expect.objectContaining({
+            roomName: "Intensive Care Ward",
+            unitName: "ICU Bed 4",
+            admittedAt: "2026-06-20 09:30",
+            admittedBy: "Nina Patel",
+          }),
+        }),
+      );
+    });
+
+    it("uses the appointment room and leaves admission details undefined for outpatient encounters", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        baseOrganization,
+      );
+      mockedPrisma.appointment.findUnique.mockResolvedValue({
+        appointmentKind: "OUTPATIENT",
+        encounterId: null,
+        patient: { name: "Milo", parent: { id: "CL-2", name: "Owner" } },
+        lead: { name: "Dr. Vet" },
+        room: { id: "room-2", name: "Exam Room 7" },
+      });
+      mockedPrisma.soapNote.findUnique.mockResolvedValueOnce({
+        id: "soap-outpatient",
+        subjective: {},
+        objective: {},
+        assessment: {},
+        plan: {},
+        diagnoses: [],
+        metadata: {},
+        artifact: unsignedArtifact({
+          id: "art-soap-outpatient",
+          kind: "SOAP_NOTE",
+          encounterId: null,
+        }),
+      });
+
+      await renderCombinedClinicalPacketPdf({
+        organisationId: "org-1",
+        documents: [
+          {
+            documentId: "doc-soap-outpatient",
+            sourceId: "soap-outpatient",
+            kind: "SOAP_NOTE",
+            title: "SOAP Note",
+          },
+        ],
+      });
+
+      expect(mockedPrisma.admission.findUnique).not.toHaveBeenCalled();
+      expect(mockedPrisma.roomUnit.findUnique).not.toHaveBeenCalled();
+      expect(
+        mockedGenerateCombinedClinicalPdfWithMetadata,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          header: expect.objectContaining({
+            roomName: "Exam Room 7",
+            unitName: undefined,
+            admittedAt: undefined,
+            admittedBy: undefined,
+          }),
+        }),
+      );
+    });
+  });
+
+  describe("vital record recorder and timestamp", () => {
+    const baseOrganization = {
+      name: "MediCare Hospital",
+      imageUrl: null,
+      phoneNo: "+91 99999 00000",
+      website: "https://medicare.example",
+      address: null,
+    };
+
+    it("resolves the VitalRecord.recordedBy user and formats measuredAt", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        baseOrganization,
+      );
+      mockedPrisma.vitalRecord.findUnique.mockResolvedValueOnce({
+        id: "vital-recorder-1",
+        measuredAt: new Date("2026-06-21T14:05:00.000Z"),
+        recordedBy: "tech-user-id",
+        vitals: { heartRate: 92 },
+        notes: null,
+        metadata: { author: "vet-1" },
+        artifact: {
+          id: "artifact-vital-recorder",
+          organisationId: "org-1",
+          appointmentId: "appt-1",
+          caseId: null,
+          encounterId: null,
+          kind: "VITAL_RECORD",
+          status: "DRAFT",
+          templateId: null,
+          templateVersion: null,
+          templateVersionId: null,
+          authorId: "author-1",
+          signedBy: null,
+          signedAt: null,
+          summary: "Vital summary",
+          createdAt: new Date("2026-06-14T00:00:00.000Z"),
+          updatedAt: new Date("2026-06-14T00:00:00.000Z"),
+        },
+      });
+      mockedPrisma.user.findFirst.mockResolvedValueOnce({
+        firstName: "Ravi",
+        lastName: "Kumar",
+        email: "ravi.kumar@example.com",
+      });
+
+      await renderRenderedDocumentPdf({
+        title: "Vital Record",
+        source: {
+          sourceKind: "CLINICAL_ARTIFACT",
+          sourceId: "vital-recorder-1",
+          organisationId: "org-1",
+          templateKind: "VITAL_RECORD",
+        },
+      });
+
+      expect(mockedPrisma.user.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { userId: "tech-user-id" },
+        }),
+      );
+      expect(mockedGenerateClinicalPdfWithMetadata).toHaveBeenCalledWith(
+        expect.objectContaining({
+          documentType: "VITAL_RECORD",
+          data: expect.objectContaining({
+            recordedBy: "Ravi Kumar",
+            recordedAt: "2026-06-21 14:05",
           }),
         }),
       );

--- a/apps/backend/test/services/rendered-document-renderer.service.test.ts
+++ b/apps/backend/test/services/rendered-document-renderer.service.test.ts
@@ -2397,4 +2397,1021 @@ describe("rendered-document-renderer service", () => {
       expect(call.header.unitName).toBe("Recovery Bed 3");
     });
   });
+
+  describe("template-free builder fallback branches", () => {
+    const baseOrganization = {
+      name: "MediCare Hospital",
+      imageUrl: null,
+      phoneNo: "+91 99999 00000",
+      website: "https://medicare.example",
+      address: null,
+    };
+
+    // An artifact with no appointmentId (so loadAppointmentClinicalHeader
+    // returns {} and every header.* field is undefined), no template, and
+    // no signedAt (PENDING). Each field's `data.X ?? metadata.X ?? default`
+    // chain therefore depends purely on `data`/`metadata`.
+    const templateFreeArtifact = (overrides: Record<string, unknown> = {}) => ({
+      id: "artifact-fallback",
+      organisationId: "org-1",
+      appointmentId: null,
+      caseId: null,
+      encounterId: null,
+      kind: "SOAP_NOTE",
+      status: "DRAFT",
+      templateId: null,
+      templateVersion: null,
+      templateVersionId: null,
+      authorId: "author-1",
+      signedBy: null,
+      signedAt: null,
+      summary: "summary",
+      createdAt: new Date("2026-06-14T00:00:00.000Z"),
+      updatedAt: new Date("2026-06-14T00:00:00.000Z"),
+      ...overrides,
+    });
+
+    it("SOAP note falls back to metadata for narrative + author for doctorName", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        baseOrganization,
+      );
+      mockedPrisma.soapNote.findUnique.mockResolvedValueOnce({
+        id: "soap-meta",
+        subjective: null,
+        objective: null,
+        assessment: null,
+        plan: null,
+        diagnoses: [],
+        metadata: {
+          subjective: "meta subjective",
+          objective: "meta objective",
+          assessment: "meta assessment",
+          plan: "meta plan",
+        },
+        artifact: templateFreeArtifact({ id: "art-soap-meta" }),
+      });
+
+      await renderRenderedDocumentPdf({
+        title: "SOAP Note",
+        source: {
+          sourceKind: "CLINICAL_ARTIFACT",
+          sourceId: "soap-meta",
+          organisationId: "org-1",
+          templateKind: "SOAP_NOTE",
+        },
+      });
+
+      expect(mockedGenerateClinicalPdfWithMetadata).toHaveBeenCalledWith(
+        expect.objectContaining({
+          documentType: "SOAP_NOTE",
+          data: expect.objectContaining({
+            subjective: "meta subjective",
+            objective: "meta objective",
+            assessment: "meta assessment",
+            plan: "meta plan",
+            // header.leadName + metadata[doctorName] absent → authorId.
+            doctorName: "author-1",
+            // header + metadata patient fields absent → "—" defaults.
+            patientName: "—",
+            speciesBreed: "—",
+            ageSex: "—",
+            clientName: "—",
+            clientId: "—",
+            // metadata has no appointmentId and artifact.appointmentId is null.
+            appointmentId: "—",
+            printedBy: "author-1",
+          }),
+        }),
+      );
+    });
+
+    it("SOAP note falls back to empty strings and '—' when data, metadata and author are all absent", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        baseOrganization,
+      );
+      mockedPrisma.soapNote.findUnique.mockResolvedValueOnce({
+        id: "soap-empty",
+        subjective: null,
+        objective: null,
+        assessment: null,
+        plan: null,
+        diagnoses: [],
+        metadata: {},
+        artifact: templateFreeArtifact({
+          id: "art-soap-empty",
+          authorId: null,
+        }),
+      });
+
+      await renderRenderedDocumentPdf({
+        title: "SOAP Note",
+        source: {
+          sourceKind: "CLINICAL_ARTIFACT",
+          sourceId: "soap-empty",
+          organisationId: "org-1",
+          templateKind: "SOAP_NOTE",
+        },
+      });
+
+      expect(mockedGenerateClinicalPdfWithMetadata).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            subjective: "",
+            objective: "",
+            assessment: "",
+            plan: "",
+            doctorName: "—",
+            printedBy: undefined,
+          }),
+        }),
+      );
+    });
+
+    it("prescription falls back to data.medications, metadata contact and author lead", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        baseOrganization,
+      );
+      mockedPrisma.prescription.findUnique.mockResolvedValueOnce({
+        id: "rx-meta",
+        // items is null/empty → normalizePrescriptionItems falls through to
+        // data.medications.
+        items: null,
+        medications: [{ name: "Amoxicillin" }],
+        instructions: [],
+        notes: null,
+        metadata: { contact: "(555) 000 1111" },
+        artifact: templateFreeArtifact({
+          id: "art-rx-meta",
+          kind: "PRESCRIPTION",
+        }),
+      });
+
+      await renderRenderedDocumentPdf({
+        title: "Prescription",
+        source: {
+          sourceKind: "CLINICAL_ARTIFACT",
+          sourceId: "rx-meta",
+          organisationId: "org-1",
+          templateKind: "PRESCRIPTION",
+        },
+      });
+
+      const call = mockedGenerateClinicalPdfWithMetadata.mock.calls[0][0];
+      expect(call.documentType).toBe("PRESCRIPTION");
+      expect(call.data.items).toEqual([
+        expect.objectContaining({ medication: "Amoxicillin" }),
+      ]);
+      // header.clientContact absent + metadata.contact present.
+      expect(call.data.clientContact).toBe("(555) 000 1111");
+      // metadata.notes / data.notes absent → readRecordNotes returns "".
+      expect(call.data.notes).toBe("");
+      // leadName: header + metadata[lead keys] absent → authorId.
+      expect(call.data.leadName).toBe("author-1");
+    });
+
+    it("prescription falls back to '—' contact when neither header nor metadata supply it", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        baseOrganization,
+      );
+      mockedPrisma.prescription.findUnique.mockResolvedValueOnce({
+        id: "rx-empty",
+        items: [],
+        medications: null,
+        instructions: [],
+        notes: null,
+        metadata: {},
+        artifact: templateFreeArtifact({
+          id: "art-rx-empty",
+          kind: "PRESCRIPTION",
+        }),
+      });
+
+      await renderRenderedDocumentPdf({
+        title: "Prescription",
+        source: {
+          sourceKind: "CLINICAL_ARTIFACT",
+          sourceId: "rx-empty",
+          organisationId: "org-1",
+          templateKind: "PRESCRIPTION",
+        },
+      });
+
+      const call = mockedGenerateClinicalPdfWithMetadata.mock.calls[0][0];
+      expect(call.data.clientContact).toBe("—");
+      // Neither items nor medications → empty list.
+      expect(call.data.items).toEqual([]);
+    });
+
+    it("discharge summary falls back to metadata for every narrative field", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        baseOrganization,
+      );
+      mockedPrisma.dischargeSummary.findUnique.mockResolvedValueOnce({
+        id: "discharge-meta",
+        summary: null,
+        diagnoses: null,
+        medications: null,
+        followUp: null,
+        instructions: null,
+        metadata: {
+          summary: "meta summary",
+          instructions: "meta instructions",
+          followUp: "meta follow up",
+          chiefComplaint: "meta chief complaint",
+          treatmentSummary: "meta treatment",
+          procedures: ["Surgery"],
+          diagnostics: ["X-ray"],
+          dischargeSummary: "meta discharge",
+          homeCare: ["Rest"],
+          emergencyCare: ["Call vet"],
+          emergencyContact: "(555) 999 0000",
+          contact: "(555) 999 1111",
+        },
+        artifact: templateFreeArtifact({
+          id: "art-discharge-meta",
+          kind: "DISCHARGE_SUMMARY",
+        }),
+      });
+
+      await renderRenderedDocumentPdf({
+        title: "Discharge Summary",
+        source: {
+          sourceKind: "CLINICAL_ARTIFACT",
+          sourceId: "discharge-meta",
+          organisationId: "org-1",
+          templateKind: "DISCHARGE_SUMMARY",
+        },
+      });
+
+      const call = mockedGenerateClinicalPdfWithMetadata.mock.calls[0][0];
+      expect(call.documentType).toBe("DISCHARGE_SUMMARY");
+      expect(call.data).toEqual(
+        expect.objectContaining({
+          chiefComplaint: "meta chief complaint",
+          treatmentSummary: "meta treatment",
+          procedures: ["Surgery"],
+          diagnostics: ["X-ray"],
+          dischargeSummary: "meta discharge",
+          homeCare: ["Rest"],
+          emergencyCare: ["Call vet"],
+          emergencyContact: "(555) 999 0000",
+          // header.clientContact absent → metadata contact.
+          contact: "(555) 999 1111",
+          doctorName: "author-1",
+        }),
+      );
+    });
+
+    it("discharge summary falls back through summaryText and '—' contact when metadata is empty", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        baseOrganization,
+      );
+      mockedPrisma.dischargeSummary.findUnique.mockResolvedValueOnce({
+        id: "discharge-data",
+        // data.summary feeds chiefComplaint/treatmentSummary/dischargeSummary
+        // via the summaryText fallback; instructions feed homeCare.
+        summary: "data summary",
+        diagnoses: ["Gastritis"],
+        medications: ["Carprofen"],
+        followUp: "data follow up",
+        instructions: "data instructions",
+        metadata: {},
+        artifact: templateFreeArtifact({
+          id: "art-discharge-data",
+          kind: "DISCHARGE_SUMMARY",
+          authorId: null,
+        }),
+      });
+
+      await renderRenderedDocumentPdf({
+        title: "Discharge Summary",
+        source: {
+          sourceKind: "CLINICAL_ARTIFACT",
+          sourceId: "discharge-data",
+          organisationId: "org-1",
+          templateKind: "DISCHARGE_SUMMARY",
+        },
+      });
+
+      const call = mockedGenerateClinicalPdfWithMetadata.mock.calls[0][0];
+      expect(call.data).toEqual(
+        expect.objectContaining({
+          // metadata.chiefComplaint absent → data.summary.
+          chiefComplaint: "data summary",
+          // metadata.treatmentSummary absent → summaryText (data.summary).
+          treatmentSummary: "data summary",
+          // metadata.dischargeSummary absent → summaryText.
+          dischargeSummary: "data summary",
+          // metadata.procedures absent → data.medications.
+          procedures: ["Carprofen"],
+          // data.diagnoses present → diagnostics.
+          diagnostics: ["Gastritis"],
+          // metadata.homeCare absent → instructionsText.
+          homeCare: ["data instructions"],
+          // metadata emergency fields absent → [].
+          emergencyCare: [],
+          // emergencyContact + contact metadata absent → "—".
+          emergencyContact: "—",
+          contact: "—",
+          // author null → "—".
+          doctorName: "—",
+        }),
+      );
+    });
+
+    it("discharge summary derives homeCare from the instructions text", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        baseOrganization,
+      );
+      mockedPrisma.dischargeSummary.findUnique.mockResolvedValueOnce({
+        id: "discharge-homecare",
+        summary: null,
+        diagnoses: [],
+        medications: [],
+        followUp: "Recheck in 7 days",
+        instructions: "Keep the wound dry\nLimit activity",
+        metadata: {},
+        artifact: templateFreeArtifact({
+          id: "art-discharge-homecare",
+          kind: "DISCHARGE_SUMMARY",
+        }),
+      });
+
+      await renderRenderedDocumentPdf({
+        title: "Discharge Summary",
+        source: {
+          sourceKind: "CLINICAL_ARTIFACT",
+          sourceId: "discharge-homecare",
+          organisationId: "org-1",
+          templateKind: "DISCHARGE_SUMMARY",
+        },
+      });
+
+      const call = mockedGenerateClinicalPdfWithMetadata.mock.calls[0][0];
+      // metadata.homeCare absent → instructionsText (multi-line → list).
+      // followUpText is an unreachable fallback because instructionsText is
+      // always a string (`?? ""`), so `?? followUpText` never triggers.
+      expect(call.data.homeCare).toEqual([
+        "Keep the wound dry",
+        "Limit activity",
+      ]);
+    });
+
+    it("vital record falls back to metadata vitals, metadata recorder and contact", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        baseOrganization,
+      );
+      mockedPrisma.vitalRecord.findUnique.mockResolvedValueOnce({
+        id: "vital-meta",
+        measuredAt: null,
+        // recordedBy not a resolvable user id → readString returns it, but
+        // resolveSigner(user.findFirst=null) yields no name → falls through.
+        recordedBy: null,
+        // data.vitals absent → metadata.vitals.
+        vitals: null,
+        notes: null,
+        metadata: {
+          vitals: [{ label: "Heart rate", value: 88, unit: "bpm" }],
+          recordedBy: "Nurse Meta",
+          contact: "(555) 222 3333",
+        },
+        artifact: templateFreeArtifact({
+          id: "art-vital-meta",
+          kind: "VITAL_RECORD",
+        }),
+      });
+
+      await renderRenderedDocumentPdf({
+        title: "Vital Record",
+        source: {
+          sourceKind: "CLINICAL_ARTIFACT",
+          sourceId: "vital-meta",
+          organisationId: "org-1",
+          templateKind: "VITAL_RECORD",
+        },
+      });
+
+      const call = mockedGenerateClinicalPdfWithMetadata.mock.calls[0][0];
+      expect(call.documentType).toBe("VITAL_RECORD");
+      expect(call.data.measurements).toEqual([
+        expect.objectContaining({ label: "Heart rate", value: "88" }),
+      ]);
+      // recordedByName + header.leadName absent → metadata.recordedBy.
+      expect(call.data.recordedBy).toBe("Nurse Meta");
+      // measuredAt null → recordedAt undefined.
+      expect(call.data.recordedAt).toBeUndefined();
+      // header.clientContact absent → metadata.contact.
+      expect(call.data.contact).toBe("(555) 222 3333");
+      // data.metadata is defined → metadata object passed through.
+      expect(call.data.metadata).toEqual(
+        expect.objectContaining({ recordedBy: "Nurse Meta" }),
+      );
+    });
+
+    it("vital record falls back to metadata.vitalRows and '—' contact, defaulting recordedBy to author", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        baseOrganization,
+      );
+      mockedPrisma.vitalRecord.findUnique.mockResolvedValueOnce({
+        id: "vital-rows",
+        measuredAt: null,
+        recordedBy: null,
+        vitals: null,
+        notes: null,
+        // metadata.vitals absent → falls through to metadata.vitalRows.
+        metadata: { vitalRows: [{ label: "Temp", value: 38.6, unit: "C" }] },
+        artifact: templateFreeArtifact({
+          id: "art-vital-rows",
+          kind: "VITAL_RECORD",
+        }),
+      });
+
+      await renderRenderedDocumentPdf({
+        title: "Vital Record",
+        source: {
+          sourceKind: "CLINICAL_ARTIFACT",
+          sourceId: "vital-rows",
+          organisationId: "org-1",
+          templateKind: "VITAL_RECORD",
+        },
+      });
+
+      const call = mockedGenerateClinicalPdfWithMetadata.mock.calls[0][0];
+      expect(call.data.measurements).toEqual([
+        expect.objectContaining({ label: "Temp", value: "38.6" }),
+      ]);
+      // recordedByName + header.leadName + metadata recorder keys absent →
+      // artifact.authorId.
+      expect(call.data.recordedBy).toBe("author-1");
+      expect(call.data.contact).toBe("—");
+    });
+
+    it("vital record defaults recordedBy to '—' when even the author id is absent", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        baseOrganization,
+      );
+      mockedPrisma.vitalRecord.findUnique.mockResolvedValueOnce({
+        id: "vital-noauthor",
+        measuredAt: null,
+        recordedBy: null,
+        vitals: { heartRate: 70 },
+        notes: null,
+        metadata: {},
+        artifact: templateFreeArtifact({
+          id: "art-vital-noauthor",
+          kind: "VITAL_RECORD",
+          authorId: null,
+        }),
+      });
+
+      await renderRenderedDocumentPdf({
+        title: "Vital Record",
+        source: {
+          sourceKind: "CLINICAL_ARTIFACT",
+          sourceId: "vital-noauthor",
+          organisationId: "org-1",
+          templateKind: "VITAL_RECORD",
+        },
+      });
+
+      const call = mockedGenerateClinicalPdfWithMetadata.mock.calls[0][0];
+      expect(call.data.recordedBy).toBe("—");
+    });
+  });
+
+  describe("signer resolution fallback branches", () => {
+    const baseOrganization = {
+      name: "MediCare Hospital",
+      imageUrl: null,
+      phoneNo: "+91 99999 00000",
+      website: "https://medicare.example",
+      address: null,
+    };
+
+    const signedArtifact = (overrides: Record<string, unknown> = {}) => ({
+      id: "soap-signed-fallback",
+      subjective: { history: "cough" },
+      objective: {},
+      assessment: {},
+      plan: {},
+      diagnoses: [],
+      metadata: {},
+      artifact: {
+        id: "art-signed-fallback",
+        organisationId: "org-1",
+        appointmentId: null,
+        caseId: null,
+        encounterId: null,
+        kind: "SOAP_NOTE",
+        status: "SIGNED",
+        templateId: null,
+        templateVersion: null,
+        templateVersionId: null,
+        authorId: "author-1",
+        signedBy: "signer-id",
+        signedAt: new Date("2026-06-20T00:00:00.000Z"),
+        summary: "summary",
+        createdAt: new Date("2026-06-14T00:00:00.000Z"),
+        updatedAt: new Date("2026-06-14T00:00:00.000Z"),
+        ...overrides,
+      },
+    });
+
+    it("resolves a signer with only an email (no name) so the name '|| undefined' branch runs", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        baseOrganization,
+      );
+      mockedPrisma.soapNote.findUnique.mockResolvedValueOnce(signedArtifact());
+      // Blank/whitespace names collapse to undefined; email trims to a value.
+      mockedPrisma.user.findFirst.mockResolvedValueOnce({
+        firstName: "   ",
+        lastName: null,
+        email: "  signer@example.com  ",
+      });
+
+      await renderRenderedDocumentPdf({
+        title: "SOAP Note",
+        source: {
+          sourceKind: "CLINICAL_ARTIFACT",
+          sourceId: "soap-signed-fallback",
+          organisationId: "org-1",
+          templateKind: "SOAP_NOTE",
+        },
+      });
+
+      const call = mockedGenerateClinicalPdfWithMetadata.mock.calls[0][0];
+      expect(call.data.signature).toEqual(
+        expect.objectContaining({
+          status: "SIGNED",
+          signerName: undefined,
+          signerEmail: "signer@example.com",
+          authMethod: "Email",
+        }),
+      );
+    });
+
+    it("resolves a signer name but no email so the email '|| undefined' branch runs", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        baseOrganization,
+      );
+      mockedPrisma.soapNote.findUnique.mockResolvedValueOnce(signedArtifact());
+      mockedPrisma.user.findFirst.mockResolvedValueOnce({
+        firstName: "Tim",
+        lastName: "Apple",
+        email: "   ",
+      });
+
+      await renderRenderedDocumentPdf({
+        title: "SOAP Note",
+        source: {
+          sourceKind: "CLINICAL_ARTIFACT",
+          sourceId: "soap-signed-fallback",
+          organisationId: "org-1",
+          templateKind: "SOAP_NOTE",
+        },
+      });
+
+      const call = mockedGenerateClinicalPdfWithMetadata.mock.calls[0][0];
+      expect(call.data.signature).toEqual(
+        expect.objectContaining({
+          status: "SIGNED",
+          signerName: "Tim Apple",
+          signerEmail: undefined,
+        }),
+      );
+    });
+
+    it("returns an empty signer when the artifact is signed without a signedBy id", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        baseOrganization,
+      );
+      mockedPrisma.soapNote.findUnique.mockResolvedValueOnce(
+        signedArtifact({ signedBy: null }),
+      );
+
+      await renderRenderedDocumentPdf({
+        title: "SOAP Note",
+        source: {
+          sourceKind: "CLINICAL_ARTIFACT",
+          sourceId: "soap-signed-fallback",
+          organisationId: "org-1",
+          templateKind: "SOAP_NOTE",
+        },
+      });
+
+      // resolveSigner short-circuits on the null id → user.findFirst skipped.
+      expect(mockedPrisma.user.findFirst).not.toHaveBeenCalled();
+      const call = mockedGenerateClinicalPdfWithMetadata.mock.calls[0][0];
+      expect(call.data.signature).toEqual(
+        expect.objectContaining({
+          status: "SIGNED",
+          signerName: undefined,
+          signerEmail: undefined,
+          authMethod: "Email",
+        }),
+      );
+    });
+  });
+
+  describe("prescription label fallback branches", () => {
+    const labelOrganization = {
+      name: "MediCare Hospital",
+      imageUrl: null,
+      phoneNo: "+91 99999 00000",
+      website: "https://medicare.example",
+      address: null,
+    };
+
+    const labelPrescription = (overrides: Record<string, unknown> = {}) => ({
+      id: "rx-label-fallback",
+      items: [
+        {
+          medication: "Carprofen",
+          strength: null,
+          dosage: null,
+          route: null,
+          frequency: null,
+          duration: null,
+          quantity: null,
+          instructions: null,
+          sortOrder: 0,
+        },
+      ],
+      medications: [{ name: "Carprofen" }, { inventoryItemId: "inv-1" }],
+      instructions: null,
+      notes: null,
+      metadata: {},
+      artifact: {
+        id: "art-label-fallback",
+        organisationId: "org-1",
+        appointmentId: null,
+        caseId: null,
+        encounterId: null,
+        kind: "PRESCRIPTION",
+        status: "SIGNED",
+        templateId: null,
+        templateVersion: null,
+        templateVersionId: null,
+        authorId: "author-label",
+        signedBy: null,
+        signedAt: null,
+        summary: "summary",
+        createdAt: new Date("2026-06-14T00:00:00.000Z"),
+        updatedAt: new Date("2026-06-14T00:00:00.000Z"),
+      },
+      ...overrides,
+    });
+
+    it("maps item fields to undefined and marks them not controlled when no inventory link resolves", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        labelOrganization,
+      );
+      mockedPrisma.prescription.findFirst.mockResolvedValueOnce(
+        labelPrescription(),
+      );
+      // inv-1 is queried but returns no controlled flag → defaults to false.
+      mockedPrisma.inventoryItem.findMany.mockResolvedValueOnce([]);
+
+      const input = await buildPrescriptionLabelPdfInput({
+        organisationId: "org-1",
+        prescriptionId: "rx-label-fallback",
+      });
+
+      // collectMedicationInventoryIds: first line has no inventoryItemId ("")
+      // and second resolves to "inv-1".
+      expect(mockedPrisma.inventoryItem.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { organisationId: "org-1", id: { in: ["inv-1"] } },
+        }),
+      );
+      expect(input.data.items[0]).toEqual(
+        expect.objectContaining({
+          medication: "Carprofen",
+          strength: undefined,
+          dosage: undefined,
+          route: undefined,
+          frequency: undefined,
+          duration: undefined,
+          quantity: undefined,
+          instructions: undefined,
+          controlled: false,
+        }),
+      );
+      // header (no appointment) + metadata empty → "—" / author fallbacks.
+      expect(input.data.patientName).toBe("—");
+      expect(input.data.clientName).toBe("—");
+      expect(input.data.prescriberName).toBe("author-label");
+    });
+
+    it("falls back to metadata for patient/client and defaults prescriber to '—' when author is absent", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        labelOrganization,
+      );
+      mockedPrisma.prescription.findFirst.mockResolvedValueOnce(
+        labelPrescription({
+          medications: "not-an-array",
+          metadata: { patientName: "Milo", clientName: "Owner Meta" },
+          artifact: {
+            id: "art-label-no-author",
+            organisationId: "org-1",
+            appointmentId: null,
+            caseId: null,
+            encounterId: null,
+            kind: "PRESCRIPTION",
+            status: "SIGNED",
+            templateId: null,
+            templateVersion: null,
+            templateVersionId: null,
+            authorId: null,
+            signedBy: null,
+            signedAt: null,
+            summary: "summary",
+            createdAt: new Date("2026-06-14T00:00:00.000Z"),
+            updatedAt: new Date("2026-06-14T00:00:00.000Z"),
+          },
+        }),
+      );
+
+      const input = await buildPrescriptionLabelPdfInput({
+        organisationId: "org-1",
+        prescriptionId: "rx-label-fallback",
+      });
+
+      // medications is not an array → collectMedicationInventoryIds returns []
+      // → inventory lookup skipped.
+      expect(mockedPrisma.inventoryItem.findMany).not.toHaveBeenCalled();
+      expect(input.data.patientName).toBe("Milo");
+      expect(input.data.clientName).toBe("Owner Meta");
+      expect(input.data.prescriberName).toBe("—");
+    });
+  });
+
+  describe("combined header and location fallback branches", () => {
+    const baseOrganization = {
+      name: "MediCare Hospital",
+      imageUrl: null,
+      phoneNo: "+91 99999 00000",
+      website: "https://medicare.example",
+      address: null,
+    };
+
+    const unsignedArtifact = (overrides: Record<string, unknown>) => ({
+      id: "artifact-x",
+      organisationId: "org-1",
+      appointmentId: "appt-1",
+      caseId: null,
+      encounterId: null,
+      kind: "SOAP_NOTE",
+      status: "DRAFT",
+      templateId: null,
+      templateVersion: null,
+      templateVersionId: null,
+      authorId: "author-1",
+      signedBy: null,
+      signedAt: null,
+      summary: "summary",
+      createdAt: new Date("2026-06-14T00:00:00.000Z"),
+      updatedAt: new Date("2026-06-14T00:00:00.000Z"),
+      ...overrides,
+    });
+
+    it("resolves the unit name from the unit code when the unit has no displayName", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        baseOrganization,
+      );
+      mockedPrisma.appointment.findUnique.mockResolvedValue({
+        appointmentKind: "INPATIENT",
+        encounterId: "enc-code-unit",
+        patient: { name: "Bella", parent: { id: "CL-1", name: "Owner" } },
+        lead: { name: "Dr. Tim" },
+        room: { name: "Appointment Room" },
+      });
+      mockedPrisma.admission.findUnique.mockResolvedValueOnce({
+        encounterId: "enc-code-unit",
+        unitId: "unit-code",
+        admittedAt: new Date("2026-06-20T08:00:00.000Z"),
+        admittedBy: null,
+        dischargedAt: null,
+      });
+      mockedPrisma.roomUnit.findUnique.mockResolvedValueOnce({
+        id: "unit-code",
+        roomId: "room-code",
+        code: "U-CODE",
+        displayName: null,
+      });
+      mockedPrisma.organisationRoom.findUnique.mockResolvedValueOnce({
+        id: "room-code",
+        name: "Coded Ward",
+        code: "CW",
+      });
+      mockedPrisma.soapNote.findUnique.mockResolvedValueOnce({
+        id: "soap-code-unit",
+        subjective: {},
+        objective: {},
+        assessment: {},
+        plan: {},
+        diagnoses: [],
+        metadata: {},
+        artifact: unsignedArtifact({
+          id: "art-soap-code-unit",
+          kind: "SOAP_NOTE",
+          encounterId: "enc-code-unit",
+        }),
+      });
+
+      await renderCombinedClinicalPacketPdf({
+        organisationId: "org-1",
+        documents: [
+          {
+            documentId: "doc-soap-code-unit",
+            sourceId: "soap-code-unit",
+            kind: "SOAP_NOTE",
+            title: "SOAP Note",
+          },
+        ],
+      });
+
+      const call =
+        mockedGenerateCombinedClinicalPdfWithMetadata.mock.calls[0][0];
+      // displayName null → unitName falls back to unit.code.
+      expect(call.header.unitName).toBe("U-CODE");
+      expect(call.header.roomName).toBe("Coded Ward");
+    });
+
+    it("ignores a non-record appointment room when resolving the location context", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        baseOrganization,
+      );
+      // room is a string (non-record) → loadAppointmentLocationContext uses {}.
+      mockedPrisma.appointment.findUnique.mockResolvedValue({
+        appointmentKind: "OUTPATIENT",
+        encounterId: null,
+        patient: { name: "Bella", parent: { id: "CL-1", name: "Owner" } },
+        lead: { name: "Dr. Tim" },
+        room: "not-a-record",
+      });
+      mockedPrisma.soapNote.findUnique.mockResolvedValueOnce({
+        id: "soap-bad-room",
+        subjective: {},
+        objective: {},
+        assessment: {},
+        plan: {},
+        diagnoses: [],
+        metadata: {},
+        artifact: unsignedArtifact({
+          id: "art-soap-bad-room",
+          kind: "SOAP_NOTE",
+          encounterId: null,
+        }),
+      });
+
+      await renderCombinedClinicalPacketPdf({
+        organisationId: "org-1",
+        documents: [
+          {
+            documentId: "doc-soap-bad-room",
+            sourceId: "soap-bad-room",
+            kind: "SOAP_NOTE",
+            title: "SOAP Note",
+          },
+        ],
+      });
+
+      const call =
+        mockedGenerateCombinedClinicalPdfWithMetadata.mock.calls[0][0];
+      // Outpatient with non-record room → no roomName from location context;
+      // the per-section/appointment header still supplies the room (string
+      // room JSON yields no name), so it stays undefined.
+      expect(call.header.roomName).toBeUndefined();
+      expect(call.header.unitName).toBeUndefined();
+    });
+  });
+
+  describe("clinical artifact resolved-template fallback branches", () => {
+    const baseOrganization = {
+      name: "MediCare Hospital",
+      imageUrl: null,
+      phoneNo: "+91 99999 00000",
+      website: "https://medicare.example",
+      address: null,
+    };
+
+    it("falls back to the template-free path when the template version cannot be found", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        baseOrganization,
+      );
+      mockedPrisma.soapNote.findUnique.mockResolvedValueOnce({
+        id: "soap-missing-version",
+        subjective: { history: "cough" },
+        objective: {},
+        assessment: {},
+        plan: {},
+        diagnoses: [],
+        metadata: {},
+        artifact: {
+          id: "art-soap-missing-version",
+          organisationId: "org-1",
+          appointmentId: null,
+          caseId: null,
+          encounterId: null,
+          kind: "SOAP_NOTE",
+          status: "DRAFT",
+          templateId: "template-x",
+          templateVersion: 4,
+          templateVersionId: null,
+          authorId: "author-1",
+          signedBy: null,
+          signedAt: null,
+          summary: "summary",
+          createdAt: new Date("2026-06-14T00:00:00.000Z"),
+          updatedAt: new Date("2026-06-14T00:00:00.000Z"),
+        },
+      });
+      // Specific version lookup misses → "Template version not found" is
+      // swallowed and the builder returns undefined (template-free path).
+      mockedPrisma.templateVersion.findUnique.mockResolvedValueOnce(null);
+
+      await renderRenderedDocumentPdf({
+        title: "SOAP Note",
+        source: {
+          sourceKind: "CLINICAL_ARTIFACT",
+          sourceId: "soap-missing-version",
+          organisationId: "org-1",
+          templateKind: "SOAP_NOTE",
+          templateVersion: 4,
+        },
+      });
+
+      expect(
+        mockedGenerateResolvedTemplatePdfWithMetadata,
+      ).not.toHaveBeenCalled();
+      expect(mockedGenerateClinicalPdfWithMetadata).toHaveBeenCalledWith(
+        expect.objectContaining({ documentType: "SOAP_NOTE" }),
+      );
+    });
+
+    it("defaults missing snapshot sections/config to empty/null in the resolved template", async () => {
+      mockedPrisma.organization.findUnique.mockResolvedValueOnce(
+        baseOrganization,
+      );
+      mockedPrisma.soapNote.findUnique.mockResolvedValueOnce({
+        id: "soap-empty-snapshot",
+        subjective: { history: "cough" },
+        objective: {},
+        assessment: {},
+        plan: {},
+        diagnoses: [],
+        metadata: {},
+        artifact: {
+          id: "art-soap-empty-snapshot",
+          organisationId: "org-1",
+          appointmentId: null,
+          caseId: null,
+          encounterId: null,
+          kind: "SOAP_NOTE",
+          status: "DRAFT",
+          templateId: "template-y",
+          templateVersion: 2,
+          templateVersionId: "template-version-y",
+          authorId: "author-1",
+          signedBy: null,
+          signedAt: null,
+          summary: "summary",
+          createdAt: new Date("2026-06-14T00:00:00.000Z"),
+          updatedAt: new Date("2026-06-14T00:00:00.000Z"),
+        },
+      });
+      // schemaSnapshot has no sections; render/validation snapshots are null.
+      mockedPrisma.templateVersion.findUnique.mockResolvedValueOnce({
+        id: "template-version-y",
+        version: 2,
+        schemaSnapshot: {},
+        renderConfigSnapshot: null,
+        validationSnapshot: null,
+      });
+
+      await renderRenderedDocumentPdf({
+        title: "SOAP Note",
+        source: {
+          sourceKind: "CLINICAL_ARTIFACT",
+          sourceId: "soap-empty-snapshot",
+          organisationId: "org-1",
+          templateKind: "SOAP_NOTE",
+          templateVersion: 2,
+        },
+      });
+
+      expect(
+        mockedGenerateResolvedTemplatePdfWithMetadata,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          template: expect.objectContaining({
+            schemaSnapshot: { sections: [] },
+            renderConfigSnapshot: null,
+            validationSnapshot: null,
+          }),
+        }),
+      );
+    });
+  });
 });

--- a/apps/backend/test/services/workspace-document-packet.service.test.ts
+++ b/apps/backend/test/services/workspace-document-packet.service.test.ts
@@ -186,6 +186,24 @@ describe("WorkspaceDocumentPacketService.createForEncounter / getById", () => {
     expect(packet.packetId).toBe("packet-1");
     expect(packet.signing).toBeNull();
   });
+
+  it("treats a signing blob without a string status as no signing", async () => {
+    mockedPrisma.workspaceDocumentPacket.findFirst.mockResolvedValue(
+      basePacket({
+        id: "packet-1",
+        documents: [],
+        // Object but `status` is not a string → parseSigning returns null.
+        signing: { documentId: "123", status: 42 },
+      }),
+    );
+
+    const packet = await WorkspaceDocumentPacketService.getById(
+      "org-1",
+      "packet-1",
+    );
+
+    expect(packet.signing).toBeNull();
+  });
 });
 
 describe("WorkspaceDocumentPacketService.sign", () => {
@@ -519,6 +537,45 @@ describe("WorkspaceDocumentPacketService.sign", () => {
     ).rejects.toMatchObject({ statusCode: 409 });
   });
 
+  it("rejects with 409 when every document is a non-rendered upload", async () => {
+    arrange();
+    // All docs are direct uploads (sourceKind: "DOCUMENT") → selectMergeable
+    // filters them all out (logging the skip) → no rendered docs remain.
+    mockedPrisma.workspaceDocumentPacket.findFirst.mockResolvedValue(
+      basePacket({
+        documents: [
+          { ...docRow("d1", "FORM"), sourceKind: "DOCUMENT" },
+          { ...docRow("d2", "FORM"), sourceKind: "DOCUMENT" },
+        ],
+      }),
+    );
+
+    await expect(
+      WorkspaceDocumentPacketService.sign({
+        organisationId: "org-1",
+        packetId: "pkt-1",
+        signerId: "user-1",
+      }),
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      message: "Document packet has no rendered documents to sign",
+    });
+    expect(mockedRenderCombinedPacketPdf).not.toHaveBeenCalled();
+    expect(mockedBuildPacketPdf).not.toHaveBeenCalled();
+  });
+
+  it("rejects with 404 when the packet cannot be found", async () => {
+    mockedPrisma.workspaceDocumentPacket.findFirst.mockResolvedValue(null);
+
+    await expect(
+      WorkspaceDocumentPacketService.sign({
+        organisationId: "org-1",
+        packetId: "pkt-missing",
+        signerId: "user-1",
+      }),
+    ).rejects.toMatchObject({ statusCode: 404 });
+  });
+
   it("rejects when the signer email cannot be resolved", async () => {
     mockedPrisma.workspaceDocumentPacket.findFirst.mockResolvedValue(
       basePacket(),
@@ -632,6 +689,91 @@ describe("WorkspaceDocumentPacketService.completeSigning", () => {
     expect(mockedDocumenso.downloadSignedDocument).not.toHaveBeenCalled();
     expect(mockedPrisma.workspaceDocumentPacket.update).not.toHaveBeenCalled();
   });
+
+  it("returns the packet untouched when no signing has been initiated", async () => {
+    mockedPrisma.workspaceDocumentPacket.findUnique.mockResolvedValue(
+      basePacket({ signing: null }),
+    );
+
+    const result =
+      await WorkspaceDocumentPacketService.completeSigning("pkt-1");
+
+    expect(result?.packetId).toBe("pkt-1");
+    expect(mockedDocumenso.downloadSignedDocument).not.toHaveBeenCalled();
+    expect(mockedPrisma.workspaceDocumentPacket.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects with 400 when the Documenso document id is missing", async () => {
+    mockedPrisma.workspaceDocumentPacket.findUnique.mockResolvedValue(
+      basePacket({
+        signing: { status: "IN_PROGRESS", documentIds: [] },
+      }),
+    );
+
+    await expect(
+      WorkspaceDocumentPacketService.completeSigning("pkt-1"),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it("rejects with 400 when the organisation has no Documenso API key", async () => {
+    mockedPrisma.workspaceDocumentPacket.findUnique.mockResolvedValue(
+      basePacket({
+        signing: { status: "IN_PROGRESS", documentId: "123", documentIds: [] },
+      }),
+    );
+    mockedDocumenso.resolveOrganisationApiKey.mockResolvedValue(null);
+
+    await expect(
+      WorkspaceDocumentPacketService.completeSigning("pkt-1"),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it("rejects with 502 when the signed packet cannot be downloaded", async () => {
+    mockedPrisma.workspaceDocumentPacket.findUnique.mockResolvedValue(
+      basePacket({
+        signing: { status: "IN_PROGRESS", documentId: "123", documentIds: [] },
+      }),
+    );
+    mockedDocumenso.resolveOrganisationApiKey.mockResolvedValue("api-key");
+    mockedDocumenso.downloadSignedDocument.mockResolvedValue(null);
+
+    await expect(
+      WorkspaceDocumentPacketService.completeSigning("pkt-1"),
+    ).rejects.toMatchObject({ statusCode: 502 });
+  });
+
+  it("swallows per-document errors while finalising the packet", async () => {
+    mockedPrisma.workspaceDocumentPacket.findUnique.mockResolvedValue(
+      basePacket({
+        signing: {
+          status: "IN_PROGRESS",
+          documentId: "123",
+          signerId: "user-1",
+          signerName: "Dr Jane",
+          documentIds: ["d1"],
+        },
+      }),
+    );
+    mockedDocumenso.resolveOrganisationApiKey.mockResolvedValue("api-key");
+    mockedDocumenso.downloadSignedDocument.mockResolvedValue({
+      downloadUrl: "https://signed.example/packet.pdf",
+    });
+    mockedPrisma.workspaceDocumentPacket.update.mockImplementation(
+      async ({ data }: { data: Record<string, unknown> }) =>
+        basePacket({ status: data.status, signing: data.signing }),
+    );
+    // The child rendered-document update throws → the catch logs and the
+    // packet still finalises successfully.
+    mockedPrisma.renderedDocument.update.mockRejectedValue(
+      new Error("child update failed"),
+    );
+
+    const result =
+      await WorkspaceDocumentPacketService.completeSigning("pkt-1");
+
+    expect(result?.status).toBe("FINAL");
+    expect(mockedPrisma.documentSignature.upsert).not.toHaveBeenCalled();
+  });
 });
 
 describe("WorkspaceDocumentPacketService.resetSigning", () => {
@@ -656,6 +798,14 @@ describe("WorkspaceDocumentPacketService.resetSigning", () => {
     );
 
     await WorkspaceDocumentPacketService.resetSigning("pkt-1");
+
+    expect(mockedPrisma.workspaceDocumentPacket.update).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when the packet cannot be found", async () => {
+    mockedPrisma.workspaceDocumentPacket.findUnique.mockResolvedValue(null);
+
+    await WorkspaceDocumentPacketService.resetSigning("pkt-missing");
 
     expect(mockedPrisma.workspaceDocumentPacket.update).not.toHaveBeenCalled();
   });

--- a/apps/backend/test/services/workspace-document-packet.service.test.ts
+++ b/apps/backend/test/services/workspace-document-packet.service.test.ts
@@ -2,6 +2,7 @@ import { prisma } from "src/config/prisma";
 import { WorkspaceService } from "src/services/workspace.prisma.service";
 import { DocumensoService } from "../../src/services/documenso.service";
 import { buildMergedClinicalPacketPdf } from "../../src/services/clinical-packet-pdf.service";
+import { renderCombinedClinicalPacketPdf } from "../../src/services/rendered-document-renderer.service";
 import { rerenderPersistedClinicalRenderedDocumentPdf } from "../../src/services/rendered-document.service";
 import { WorkspaceDocumentPacketService } from "../../src/services/workspace-document-packet.service";
 
@@ -46,6 +47,10 @@ jest.mock("../../src/services/clinical-packet-pdf.service", () => ({
   buildMergedClinicalPacketPdf: jest.fn(),
 }));
 
+jest.mock("../../src/services/rendered-document-renderer.service", () => ({
+  renderCombinedClinicalPacketPdf: jest.fn(),
+}));
+
 jest.mock("../../src/services/rendered-document.service", () => ({
   rerenderPersistedClinicalRenderedDocumentPdf: jest.fn(),
 }));
@@ -77,8 +82,22 @@ const mockedDocumenso = DocumensoService as unknown as {
 };
 const mockedBuildPacketPdf =
   buildMergedClinicalPacketPdf as unknown as jest.Mock;
+const mockedRenderCombinedPacketPdf =
+  renderCombinedClinicalPacketPdf as unknown as jest.Mock;
 const mockedRerenderClinicalArtifact =
   rerenderPersistedClinicalRenderedDocumentPdf as unknown as jest.Mock;
+
+const combinedPdfResult = () => ({
+  pdf: Buffer.from("combined-pdf"),
+  pageCount: 2,
+  signaturePlacement: {
+    pageNumber: 2,
+    pageX: 80,
+    pageY: 690,
+    width: 240,
+    height: 96,
+  },
+});
 
 const docRow = (id: string, kind = "SOAP_NOTE") => ({
   documentId: id,
@@ -192,6 +211,7 @@ describe("WorkspaceDocumentPacketService.sign", () => {
         height: 96,
       },
     });
+    mockedRenderCombinedPacketPdf.mockResolvedValue(combinedPdfResult());
     mockedDocumenso.createDocument.mockResolvedValue({
       id: 123,
       recipients: [{ token: "tok-1" }],
@@ -205,6 +225,15 @@ describe("WorkspaceDocumentPacketService.sign", () => {
 
   it("builds a merged packet, sends it to Documenso, and stores IN_PROGRESS signing", async () => {
     arrange();
+    // Mixed packet (a non-clinical FORM is present) → the merge fallback runs.
+    mockedPrisma.workspaceDocumentPacket.findFirst.mockResolvedValue(
+      basePacket({
+        documents: [
+          docRow("d1", "SOAP_NOTE"),
+          { ...docRow("d2", "FORM"), sourceKind: "FORM_SUBMISSION" },
+        ],
+      }),
+    );
 
     const result = await WorkspaceDocumentPacketService.sign({
       organisationId: "org-1",
@@ -213,6 +242,7 @@ describe("WorkspaceDocumentPacketService.sign", () => {
       signerName: "Dr Jane",
     });
 
+    expect(mockedRenderCombinedPacketPdf).not.toHaveBeenCalled();
     expect(mockedBuildPacketPdf).toHaveBeenCalledWith(
       expect.objectContaining({
         organisationId: "org-1",
@@ -327,7 +357,10 @@ describe("WorkspaceDocumentPacketService.sign", () => {
       signerId: "user-1",
     });
 
-    const buildArg = mockedBuildPacketPdf.mock.calls[0][0];
+    // All four docs are clinical artifacts → the combined renderer is used and
+    // receives them in the canonical clinical order.
+    expect(mockedBuildPacketPdf).not.toHaveBeenCalled();
+    const buildArg = mockedRenderCombinedPacketPdf.mock.calls[0][0];
     expect(buildArg.documents.map((d: { kind: string }) => d.kind)).toEqual([
       "SOAP_NOTE",
       "VITAL_RECORD",
@@ -358,6 +391,90 @@ describe("WorkspaceDocumentPacketService.sign", () => {
     expect(
       buildArg.documents.map((d: { documentId: string }) => d.documentId),
     ).toEqual(["soap", "misc-a", "misc-b"]);
+  });
+
+  it("renders a combined clinical PDF (not a merge) when every doc is a clinical artifact", async () => {
+    arrange();
+    mockedPrisma.workspaceDocumentPacket.findFirst.mockResolvedValue(
+      basePacket({
+        documents: [docRow("d1", "SOAP_NOTE"), docRow("d2", "PRESCRIPTION")],
+      }),
+    );
+
+    await WorkspaceDocumentPacketService.sign({
+      organisationId: "org-1",
+      packetId: "pkt-1",
+      signerId: "user-1",
+      signerName: "Dr Jane",
+    });
+
+    expect(mockedBuildPacketPdf).not.toHaveBeenCalled();
+    expect(mockedRenderCombinedPacketPdf).toHaveBeenCalledWith({
+      organisationId: "org-1",
+      signerName: "Dr Jane",
+      documents: [
+        expect.objectContaining({
+          documentId: "d1",
+          sourceId: "src-d1",
+          kind: "SOAP_NOTE",
+          title: "Doc d1",
+        }),
+        expect.objectContaining({
+          documentId: "d2",
+          sourceId: "src-d2",
+          kind: "PRESCRIPTION",
+        }),
+      ],
+    });
+    expect(mockedDocumenso.createDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        signaturePlacement: expect.objectContaining({ pageNumber: 2 }),
+      }),
+    );
+  });
+
+  it("falls back to the PDF merge when the packet mixes in a non-clinical doc", async () => {
+    arrange();
+    mockedPrisma.workspaceDocumentPacket.findFirst.mockResolvedValue(
+      basePacket({
+        documents: [
+          docRow("d1", "SOAP_NOTE"),
+          { ...docRow("d2", "FORM"), sourceKind: "TEMPLATE_INSTANCE" },
+        ],
+      }),
+    );
+
+    await WorkspaceDocumentPacketService.sign({
+      organisationId: "org-1",
+      packetId: "pkt-1",
+      signerId: "user-1",
+    });
+
+    expect(mockedRenderCombinedPacketPdf).not.toHaveBeenCalled();
+    expect(mockedBuildPacketPdf).toHaveBeenCalledWith(
+      expect.objectContaining({ organisationId: "org-1" }),
+    );
+  });
+
+  it("falls back to the merge when a clinical kind is not a CLINICAL_ARTIFACT source", async () => {
+    arrange();
+    mockedPrisma.workspaceDocumentPacket.findFirst.mockResolvedValue(
+      basePacket({
+        documents: [
+          docRow("d1", "SOAP_NOTE"),
+          { ...docRow("d2", "PRESCRIPTION"), sourceKind: "TEMPLATE_INSTANCE" },
+        ],
+      }),
+    );
+
+    await WorkspaceDocumentPacketService.sign({
+      organisationId: "org-1",
+      packetId: "pkt-1",
+      signerId: "user-1",
+    });
+
+    expect(mockedRenderCombinedPacketPdf).not.toHaveBeenCalled();
+    expect(mockedBuildPacketPdf).toHaveBeenCalled();
   });
 
   it("rejects when the packet is already FINAL", async () => {
@@ -562,9 +679,10 @@ describe("WorkspaceDocumentPacketService.buildEncounterPacketPdf", () => {
         height: 96,
       },
     });
+    mockedRenderCombinedPacketPdf.mockResolvedValue(combinedPdfResult());
   };
 
-  it("merges the encounter documents into a single PDF for print", async () => {
+  it("renders the encounter clinical artifacts into a single combined PDF for print", async () => {
     mockedWorkspaceService.getEncounterBootstrap.mockResolvedValue({
       appointment: null,
       encounter: { id: "enc-1" },
@@ -583,6 +701,39 @@ describe("WorkspaceDocumentPacketService.buildEncounterPacketPdf", () => {
 
     expect(pdf).toBeInstanceOf(Buffer);
     expect(mockedRerenderClinicalArtifact).not.toHaveBeenCalled();
+    expect(mockedBuildPacketPdf).not.toHaveBeenCalled();
+    expect(mockedRenderCombinedPacketPdf).toHaveBeenCalledWith({
+      organisationId: "org-1",
+      documents: [
+        expect.objectContaining({ documentId: "d1", sourceId: "src-d1" }),
+        expect.objectContaining({ documentId: "d2", sourceId: "src-d2" }),
+      ],
+    });
+  });
+
+  it("merges the encounter documents into a single PDF for print when a non-clinical doc is present", async () => {
+    mockedWorkspaceService.getEncounterBootstrap.mockResolvedValue({
+      appointment: null,
+      encounter: { id: "enc-1" },
+      companion: null,
+      documents: [
+        { ...docRow("d1"), pdfUrl: "https://cdn/d1.pdf" },
+        {
+          ...docRow("d2", "FORM"),
+          sourceKind: "FORM_SUBMISSION",
+          pdfUrl: "https://cdn/d2.pdf",
+        },
+      ],
+    });
+    arrangePrintBuild();
+
+    const pdf = await WorkspaceDocumentPacketService.buildEncounterPacketPdf(
+      "org-1",
+      "enc-1",
+    );
+
+    expect(pdf).toBeInstanceOf(Buffer);
+    expect(mockedRenderCombinedPacketPdf).not.toHaveBeenCalled();
     expect(mockedBuildPacketPdf).toHaveBeenCalledWith(
       expect.objectContaining({
         organisationId: "org-1",
@@ -614,7 +765,7 @@ describe("WorkspaceDocumentPacketService.buildEncounterPacketPdf", () => {
     expect(mockedRerenderClinicalArtifact).toHaveBeenCalledWith("d2", "org-1");
   });
 
-  it("merges print documents in the canonical clinical order", async () => {
+  it("orders print documents in the canonical clinical order for the combined PDF", async () => {
     mockedWorkspaceService.getEncounterBootstrap.mockResolvedValue({
       appointment: null,
       encounter: { id: "enc-1" },
@@ -633,7 +784,8 @@ describe("WorkspaceDocumentPacketService.buildEncounterPacketPdf", () => {
       "enc-1",
     );
 
-    const buildArg = mockedBuildPacketPdf.mock.calls[0][0];
+    expect(mockedBuildPacketPdf).not.toHaveBeenCalled();
+    const buildArg = mockedRenderCombinedPacketPdf.mock.calls[0][0];
     expect(buildArg.documents.map((d: { kind: string }) => d.kind)).toEqual([
       "SOAP_NOTE",
       "VITAL_RECORD",

--- a/packages/database/prisma/migrations/20260624000000_add_admission_admitted_by/migration.sql
+++ b/packages/database/prisma/migrations/20260624000000_add_admission_admitted_by/migration.sql
@@ -1,0 +1,2 @@
+-- Records the authenticated user who admitted the patient (clicked "Convert to Inpatient").
+ALTER TABLE "Admission" ADD COLUMN "admittedBy" TEXT;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -604,6 +604,7 @@ model Admission {
   unitId            String?
   expectedStayDays  Int?
   admittedAt        DateTime
+  admittedBy        String?
   dischargedAt      DateTime?
   createdAt         DateTime @default(now())
   updatedAt         DateTime @updatedAt

--- a/packages/lib/src/pdf/PdfEngine.ts
+++ b/packages/lib/src/pdf/PdfEngine.ts
@@ -235,6 +235,8 @@ export type CombinedClinicalDocumentInput = {
     clientContact?: string;
     speciesBreed?: string;
     ageSex?: string;
+    roomName?: string;
+    unitName?: string;
   };
   sections: CombinedClinicalSection[];
   printedBy?: string;
@@ -342,6 +344,8 @@ export const generateCombinedClinicalPdfWithMetadata = async (
         clientContact: input.header.clientContact,
         speciesBreed: input.header.speciesBreed,
         ageSex: input.header.ageSex,
+        roomName: input.header.roomName,
+        unitName: input.header.unitName,
       }),
       { columns: 3 }
     );

--- a/packages/lib/src/pdf/PdfEngine.ts
+++ b/packages/lib/src/pdf/PdfEngine.ts
@@ -11,15 +11,40 @@ import type {
   BaseClinicalDocumentData,
   ClinicalDocumentType,
   ClinicalPdfRenderResult,
+  DischargeSummaryDocumentData,
+  DocumentSignature,
+  OrganizationBranding,
   PdfGenerationInput,
+  PrescriptionDocumentData,
   PdfTheme,
+  SoapNoteDocumentData,
+  VitalRecordDocumentData,
 } from './types.js';
-import { renderDischargeSummaryTemplate } from './templates/DischargeSummaryTemplate.js';
+import {
+  renderDischargeSummaryContent,
+  renderDischargeSummaryTemplate,
+} from './templates/DischargeSummaryTemplate.js';
 import { renderInvoiceTemplate } from './templates/InvoiceTemplate.js';
 import { renderPrescriptionLabelTemplate } from './templates/PrescriptionLabelTemplate.js';
-import { renderPrescriptionTemplate } from './templates/PrescriptionTemplate.js';
-import { renderSoapNoteTemplate } from './templates/SoapNoteTemplate.js';
-import { renderVitalRecordTemplate } from './templates/VitalRecordTemplate.js';
+import {
+  renderPrescriptionContent,
+  renderPrescriptionTemplate,
+} from './templates/PrescriptionTemplate.js';
+import { renderSoapNoteContent, renderSoapNoteTemplate } from './templates/SoapNoteTemplate.js';
+import {
+  renderVitalRecordContent,
+  renderVitalRecordTemplate,
+} from './templates/VitalRecordTemplate.js';
+import { buildClinicalHeaderKeyValue } from './templates/shared.js';
+import { renderDocumentEndBlock } from './sections/DocumentEndBlock.js';
+import { renderKeyValueGrid } from './sections/KeyValueGrid.js';
+import {
+  renderDivider,
+  renderDocumentTitle,
+  renderParagraph,
+  renderSpacer,
+} from './sections/Text.js';
+import { addPageBreak } from './Pagination.js';
 
 const buildTheme = (fonts: PdfFontFamilies): PdfTheme => ({
   colors: {
@@ -187,6 +212,181 @@ export const generateClinicalPdfWithMetadata = async <TData extends BaseClinical
 export const generateClinicalPdf = async <TData extends BaseClinicalDocumentData>(
   input: PdfGenerationInput<TData>
 ): Promise<Buffer> => (await generateClinicalPdfWithMetadata(input)).pdf;
+
+// One section of a combined clinical document. Each carries the typed data its
+// matching template body renders. INVOICE is intentionally excluded — invoices
+// are issued as their own standalone PDF.
+export type CombinedClinicalSection =
+  | { documentType: 'SOAP_NOTE'; data: SoapNoteDocumentData }
+  | { documentType: 'VITAL_RECORD'; data: VitalRecordDocumentData }
+  | { documentType: 'PRESCRIPTION'; data: PrescriptionDocumentData }
+  | { documentType: 'DISCHARGE_SUMMARY'; data: DischargeSummaryDocumentData };
+
+export type CombinedClinicalDocumentInput = {
+  organization: OrganizationBranding;
+  // Shared patient/encounter metadata, rendered once at the top of the record.
+  header: {
+    date: Date;
+    appointmentId?: string;
+    doctorName?: string;
+    patientName?: string;
+    clientName?: string;
+    clientId?: string;
+    clientContact?: string;
+    speciesBreed?: string;
+    ageSex?: string;
+  };
+  sections: CombinedClinicalSection[];
+  printedBy?: string;
+  signature?: DocumentSignature;
+};
+
+const COMBINED_SECTION_LABELS: Record<CombinedClinicalSection['documentType'], string> = {
+  SOAP_NOTE: 'SOAP Note',
+  VITAL_RECORD: 'Vital Record',
+  PRESCRIPTION: 'Prescription',
+  DISCHARGE_SUMMARY: 'Discharge Summary',
+};
+
+// Each section: a heading (the document title) then its content only — the
+// shared patient header is rendered once for the whole record.
+const renderCombinedSection = (ctx: PdfContext, section: CombinedClinicalSection): void => {
+  renderDocumentTitle(ctx, section.data.title);
+  renderSpacer(ctx, ctx.theme.spacing.itemGap);
+  switch (section.documentType) {
+    case 'SOAP_NOTE':
+      renderSoapNoteContent(ctx, section.data);
+      return;
+    case 'VITAL_RECORD':
+      renderVitalRecordContent(ctx, section.data);
+      return;
+    case 'PRESCRIPTION':
+      renderPrescriptionContent(ctx, section.data);
+      return;
+    case 'DISCHARGE_SUMMARY':
+      renderDischargeSummaryContent(ctx, section.data);
+      return;
+    default: {
+      const exhaustiveCheck: never = section;
+      throw new Error(`Unsupported combined clinical section: ${JSON.stringify(exhaustiveCheck)}`);
+    }
+  }
+};
+
+const renderAttestationPage = (ctx: PdfContext, sections: CombinedClinicalSection[]): void => {
+  renderDocumentTitle(ctx, 'Clinical Document Packet');
+  renderParagraph(
+    ctx,
+    'This record combines the documents listed below, signed together as a single, complete clinical record:'
+  );
+  renderSpacer(ctx, ctx.theme.spacing.itemGap);
+  sections.forEach((section, index) => {
+    const label = COMBINED_SECTION_LABELS[section.documentType];
+    const title = section.data.title?.trim() || label;
+    const line =
+      title.toLowerCase() === label.toLowerCase()
+        ? `${index + 1}. ${title}`
+        : `${index + 1}. ${title}  (${label})`;
+    renderParagraph(ctx, line);
+  });
+  renderSpacer(ctx, ctx.theme.spacing.sectionGap);
+  renderParagraph(
+    ctx,
+    'By signing below I confirm that I have reviewed the documents listed above and that they form a single, complete clinical record.'
+  );
+  renderSpacer(ctx, ctx.theme.spacing.sectionGap);
+};
+
+// Renders SOAP, Vital, Prescription and Discharge sections into ONE continuous
+// PDF with a single signature on a final attestation page. Used for combined
+// clinical packets so the signer signs the whole record once (invoices stay
+// separate). Standalone single-document rendering is unchanged.
+export const generateCombinedClinicalPdfWithMetadata = async (
+  input: CombinedClinicalDocumentInput
+): Promise<ClinicalPdfRenderResult> => {
+  if (input.sections.length === 0) {
+    throw new Error('Cannot render a combined clinical document with no sections');
+  }
+
+  const document = createDocument();
+  const { fonts, theme } = resolveThemeAndFonts(document);
+  const logoSource = await resolveLogoSource(input.organization.logoUrl ?? null);
+  const ctx = new PdfContext({
+    document,
+    organization: input.organization,
+    theme,
+    fonts,
+    logoSource,
+  });
+
+  const output = collectPdfBuffer(document);
+
+  try {
+    renderHeader(ctx);
+
+    // Single documents place a title above the header rule and metadata just
+    // below it; the combined record has no per-document title, so start the
+    // shared header in the body zone to clear the header separator cleanly.
+    ctx.cursorY = ctx.bodyStartY;
+    // One shared patient/encounter header for the whole combined record.
+    renderKeyValueGrid(
+      ctx,
+      buildClinicalHeaderKeyValue({
+        date: input.header.date,
+        appointmentId: input.header.appointmentId,
+        leadLabel: 'Doctor',
+        leadName: input.header.doctorName,
+        patientName: input.header.patientName,
+        clientName: input.header.clientName,
+        clientId: input.header.clientId,
+        clientContact: input.header.clientContact,
+        speciesBreed: input.header.speciesBreed,
+        ageSex: input.header.ageSex,
+      }),
+      { columns: 3 }
+    );
+    renderSpacer(ctx, ctx.theme.spacing.sectionGap);
+
+    input.sections.forEach((section, index) => {
+      if (index > 0) {
+        renderDivider(ctx);
+        renderSpacer(ctx, ctx.theme.spacing.itemGap);
+      }
+      renderCombinedSection(ctx, section);
+    });
+
+    // The single signature lives on its own attestation page at the very end.
+    addPageBreak(ctx);
+    renderAttestationPage(ctx, input.sections);
+    const signaturePlacement = renderDocumentEndBlock(ctx, {
+      printedBy: input.printedBy,
+      signature: input.signature,
+    });
+
+    const pageRange = document.bufferedPageRange();
+    for (let index = pageRange.start; index < pageRange.start + pageRange.count; index += 1) {
+      document.switchToPage(index);
+      renderFooter(ctx, index + 1, pageRange.count, ctx.generatedAt);
+    }
+    document.end();
+
+    const pdf = await output.promise;
+
+    return {
+      pdf,
+      pageCount: pageRange.count,
+      signaturePlacement,
+    };
+  } catch (error) {
+    const normalizedError = error instanceof Error ? error : new Error(String(error));
+    output.reject(normalizedError);
+    throw normalizedError;
+  }
+};
+
+export const generateCombinedClinicalPdf = async (
+  input: CombinedClinicalDocumentInput
+): Promise<Buffer> => (await generateCombinedClinicalPdfWithMetadata(input)).pdf;
 
 export const createClinicalPdfContext = (
   document: PdfDocumentInstance,

--- a/packages/lib/src/pdf/PdfEngine.ts
+++ b/packages/lib/src/pdf/PdfEngine.ts
@@ -237,6 +237,8 @@ export type CombinedClinicalDocumentInput = {
     ageSex?: string;
     roomName?: string;
     unitName?: string;
+    admittedAt?: string;
+    admittedBy?: string;
   };
   sections: CombinedClinicalSection[];
   printedBy?: string;
@@ -346,6 +348,8 @@ export const generateCombinedClinicalPdfWithMetadata = async (
         ageSex: input.header.ageSex,
         roomName: input.header.roomName,
         unitName: input.header.unitName,
+        admittedAt: input.header.admittedAt,
+        admittedBy: input.header.admittedBy,
       }),
       { columns: 3 }
     );

--- a/packages/lib/src/pdf/clinicalPacket.ts
+++ b/packages/lib/src/pdf/clinicalPacket.ts
@@ -66,6 +66,12 @@ const SIGNATURE_FIELD = {
   height: 96,
 };
 
+// Documenso expects field coordinates as percentages (0–100) of the page, not
+// PDF points. SIGNATURE_FIELD is kept in top-left points (matching Documenso's
+// origin) for drawing the visible box; convert to percentages for the field.
+const toFieldPercent = (value: number, total: number): number =>
+  Number(((value / total) * 100).toFixed(4));
+
 const humanizeKind = (kind: string): string =>
   kind
     .toLowerCase()
@@ -225,10 +231,10 @@ export const buildMergedClinicalPacketPdf = async (
     pageCount,
     signaturePlacement: {
       pageNumber: pageCount,
-      pageX: SIGNATURE_FIELD.pageX,
-      pageY: SIGNATURE_FIELD.pageY,
-      width: SIGNATURE_FIELD.width,
-      height: SIGNATURE_FIELD.height,
+      pageX: toFieldPercent(SIGNATURE_FIELD.pageX, A4_WIDTH),
+      pageY: toFieldPercent(SIGNATURE_FIELD.pageY, A4_HEIGHT),
+      width: toFieldPercent(SIGNATURE_FIELD.width, A4_WIDTH),
+      height: toFieldPercent(SIGNATURE_FIELD.height, A4_HEIGHT),
     },
   };
 };

--- a/packages/lib/src/pdf/index.ts
+++ b/packages/lib/src/pdf/index.ts
@@ -34,8 +34,12 @@ export { BasePdfTemplate } from './BasePdfTemplate.js';
 export {
   generateClinicalPdf,
   generateClinicalPdfWithMetadata,
+  generateCombinedClinicalPdf,
+  generateCombinedClinicalPdfWithMetadata,
   createClinicalPdfContext,
   clinicalPdfTheme,
+  type CombinedClinicalSection,
+  type CombinedClinicalDocumentInput,
 } from './PdfEngine.js';
 export { generatePdf, generatePdfWithMetadata } from './GenericPdfEngine.js';
 export {

--- a/packages/lib/src/pdf/layout.ts
+++ b/packages/lib/src/pdf/layout.ts
@@ -15,10 +15,13 @@ export const PDF_LAYOUT = {
   headerOrgY: 16,
   headerContactX: 481,
   headerContactY: 16,
-  headerSeparatorY: 160,
-  titleY: 89,
-  metadataY: 111,
-  bodyStartY: 184,
+  // The header rule sits just below the org letterhead (logo ends at y60), so it
+  // never cuts through the document title/metadata. Body content begins right
+  // below it on every page — including continuation pages (no large top gap).
+  headerSeparatorY: 70,
+  titleY: 88,
+  metadataY: 110,
+  bodyStartY: 88,
   footerSeparatorY: 781,
   footerTextY: 793,
   footerTimestampY: 819,

--- a/packages/lib/src/pdf/layout.ts
+++ b/packages/lib/src/pdf/layout.ts
@@ -5,13 +5,15 @@ export const PDF_PAGE_SIZE = {
 
 export const PDF_LAYOUT = {
   marginX: 20,
+  // Logo left edge aligns with marginX so the letterhead lines up with the
+  // header rule, metadata, tables and footer (all at marginX).
   headerLogo: {
-    x: 12,
+    x: 20,
     y: 12,
-    width: 64,
-    height: 48,
+    width: 44,
+    height: 44,
   },
-  headerOrgX: 84,
+  headerOrgX: 78,
   headerOrgY: 16,
   headerContactX: 481,
   headerContactY: 16,

--- a/packages/lib/src/pdf/sections/DocumentEndBlock.ts
+++ b/packages/lib/src/pdf/sections/DocumentEndBlock.ts
@@ -112,7 +112,9 @@ export const renderDocumentEndBlock = (
    * details text below the line.
    */
   const signatureFieldY = lineY;
-  const signatureFieldHeight = 40;
+  // 24 == the underline offset (drawn at lineY + 24 below) so the field bottom
+  // rests exactly on the signature line, above the signer-detail text.
+  const signatureFieldHeight = 24;
 
   ctx.document
     .moveTo(signatureX, lineY + 24)

--- a/packages/lib/src/pdf/sections/DocumentEndBlock.ts
+++ b/packages/lib/src/pdf/sections/DocumentEndBlock.ts
@@ -11,7 +11,9 @@ const estimateSignatureHeight = (signature?: DocumentEndBlockInput['signature'])
   const detailsLines = [
     signature.signerName,
     [signature.signerRole, signature.signerDegree].filter(Boolean).join(' '),
+    signature.signerEmail,
     signature.signedAt ? signature.signedAt.toISOString() : undefined,
+    signature.authMethod,
   ].filter(Boolean).length;
 
   return 104 + detailsLines * 10;
@@ -136,10 +138,18 @@ export const renderDocumentEndBlock = (
       details.push(role);
     }
 
+    if (signature.signerEmail) {
+      details.push(signature.signerEmail);
+    }
+
     const signedAt = formatSignedAt(signature.signedAt);
 
     if (signedAt) {
       details.push(`Signed ${signedAt}`);
+    }
+
+    if (signature.authMethod) {
+      details.push(`Authenticated via ${signature.authMethod}`);
     }
   } else {
     details.push('Pending signature');

--- a/packages/lib/src/pdf/sections/Table.ts
+++ b/packages/lib/src/pdf/sections/Table.ts
@@ -100,4 +100,9 @@ export const renderTable = (ctx: PdfContext, input: TableRenderInput): void => {
     ctx.document.restore();
     ctx.moveDown(rowHeight);
   }
+
+  // Trailing gap so following content (a section heading's own leading gap adds
+  // to this, or totals/text that have none) clears the table's bottom border
+  // instead of sitting flush against it.
+  ctx.moveDown(PDF_SPACING.sectionGap - PDF_SPACING.paragraphGap);
 };

--- a/packages/lib/src/pdf/sections/Table.ts
+++ b/packages/lib/src/pdf/sections/Table.ts
@@ -9,7 +9,10 @@ const resolveColumnWidths = (ctx: PdfContext, columns: TableRenderInput['columns
   const explicitTotal = explicitWidths.reduce((sum, width) => sum + width, 0);
 
   if (explicitTotal > 0 && explicitTotal <= 1.01) {
-    return explicitWidths.map((width) => ctx.contentWidth * width);
+    // Normalize the fractional widths so the table always spans the full
+    // content width — columns summing to e.g. 0.86 are scaled up to fill the
+    // row and stay flush with the section rules, instead of stopping short.
+    return explicitWidths.map((width) => (ctx.contentWidth * width) / explicitTotal);
   }
 
   const unspecifiedCount = columns.filter((column) => column.width === undefined).length;

--- a/packages/lib/src/pdf/sections/Text.ts
+++ b/packages/lib/src/pdf/sections/Text.ts
@@ -147,6 +147,9 @@ export const renderDocumentTitle = (ctx: PdfContext, title: string): void => {
 export const renderSectionTitle = (ctx: PdfContext, title: string): void => {
   const fontSize = PDF_FONT_SIZES.sectionTitle;
   const height = Math.ceil(fontSize * 1.35 + 2);
+  // Leading gap so each section heading has consistent breathing room above it,
+  // regardless of whether the previous block was text, bullets or a table.
+  ctx.moveDown(PDF_SPACING.paragraphGap);
   ensureSpace(ctx, height + 12);
 
   ctx.document

--- a/packages/lib/src/pdf/templates/DischargeSummaryTemplate.ts
+++ b/packages/lib/src/pdf/templates/DischargeSummaryTemplate.ts
@@ -7,29 +7,11 @@ import { renderRichText } from '../sections/RichText.js';
 import type { ClinicalPdfSignaturePlacement, DischargeSummaryDocumentData } from '../types.js';
 import { buildClinicalHeaderKeyValue } from './shared.js';
 
-export const renderDischargeSummaryTemplate = (
+// Content sections only (no title, metadata or signature) for combined packets.
+export const renderDischargeSummaryContent = (
   ctx: PdfContext,
   data: DischargeSummaryDocumentData
-): ClinicalPdfSignaturePlacement => {
-  renderDocumentTitle(ctx, data.title);
-  renderKeyValueGrid(
-    ctx,
-    buildClinicalHeaderKeyValue({
-      date: data.date,
-      appointmentId: data.appointmentId,
-      leadLabel: 'Doctor',
-      leadName: data.doctorName,
-      patientName: data.patientName,
-      clientName: data.clientName,
-      clientId: data.clientId,
-      clientContact: data.contact,
-      speciesBreed: data.speciesBreed,
-      ageSex: data.ageSex,
-    }),
-    { columns: 3 }
-  );
-  renderSpacer(ctx, ctx.theme.spacing.sectionGap);
-
+): void => {
   renderSectionTitle(ctx, 'Chief Complaint');
   renderRichText(ctx, data.chiefComplaint);
 
@@ -53,8 +35,40 @@ export const renderDischargeSummaryTemplate = (
 
   renderSectionTitle(ctx, 'Emergency Contact');
   renderRichText(ctx, data.emergencyContact);
+};
 
+// Title + metadata + content, without the signature end block.
+export const renderDischargeSummaryBody = (
+  ctx: PdfContext,
+  data: DischargeSummaryDocumentData
+): void => {
+  renderDocumentTitle(ctx, data.title);
+  renderKeyValueGrid(
+    ctx,
+    buildClinicalHeaderKeyValue({
+      date: data.date,
+      appointmentId: data.appointmentId,
+      leadLabel: 'Doctor',
+      leadName: data.doctorName,
+      patientName: data.patientName,
+      clientName: data.clientName,
+      clientId: data.clientId,
+      clientContact: data.contact,
+      speciesBreed: data.speciesBreed,
+      ageSex: data.ageSex,
+    }),
+    { columns: 3 }
+  );
   renderSpacer(ctx, ctx.theme.spacing.sectionGap);
+  renderDischargeSummaryContent(ctx, data);
+  renderSpacer(ctx, ctx.theme.spacing.sectionGap);
+};
+
+export const renderDischargeSummaryTemplate = (
+  ctx: PdfContext,
+  data: DischargeSummaryDocumentData
+): ClinicalPdfSignaturePlacement => {
+  renderDischargeSummaryBody(ctx, data);
   return renderDocumentEndBlock(ctx, {
     printedBy: data.printedBy,
     signature: data.signature,

--- a/packages/lib/src/pdf/templates/PrescriptionTemplate.ts
+++ b/packages/lib/src/pdf/templates/PrescriptionTemplate.ts
@@ -7,29 +7,11 @@ import { renderRichText } from '../sections/RichText.js';
 import type { ClinicalPdfSignaturePlacement, PrescriptionDocumentData } from '../types.js';
 import { buildClinicalHeaderKeyValue } from './shared.js';
 
-export const renderPrescriptionTemplate = (
+// Content sections only (no title, metadata or signature) for combined packets.
+export const renderPrescriptionContent = (
   ctx: PdfContext,
   data: PrescriptionDocumentData
-): ClinicalPdfSignaturePlacement => {
-  renderDocumentTitle(ctx, data.title);
-  renderKeyValueGrid(
-    ctx,
-    buildClinicalHeaderKeyValue({
-      date: data.date,
-      appointmentId: data.appointmentId,
-      leadLabel: 'Lead',
-      leadName: data.leadName,
-      patientName: data.patientName,
-      clientName: data.clientName,
-      clientId: data.clientId,
-      clientContact: data.clientContact,
-      speciesBreed: data.speciesBreed,
-      ageSex: data.ageSex,
-    }),
-    { columns: 3 }
-  );
-  renderSpacer(ctx, ctx.theme.spacing.sectionGap);
-
+): void => {
   renderSectionTitle(ctx, 'Medication Details');
   renderTable(ctx, {
     columns: [
@@ -56,8 +38,37 @@ export const renderPrescriptionTemplate = (
     renderSectionTitle(ctx, 'Notes');
     renderRichText(ctx, data.notes);
   }
+};
 
+// Title + metadata + content, without the signature end block.
+export const renderPrescriptionBody = (ctx: PdfContext, data: PrescriptionDocumentData): void => {
+  renderDocumentTitle(ctx, data.title);
+  renderKeyValueGrid(
+    ctx,
+    buildClinicalHeaderKeyValue({
+      date: data.date,
+      appointmentId: data.appointmentId,
+      leadLabel: 'Lead',
+      leadName: data.leadName,
+      patientName: data.patientName,
+      clientName: data.clientName,
+      clientId: data.clientId,
+      clientContact: data.clientContact,
+      speciesBreed: data.speciesBreed,
+      ageSex: data.ageSex,
+    }),
+    { columns: 3 }
+  );
   renderSpacer(ctx, ctx.theme.spacing.sectionGap);
+  renderPrescriptionContent(ctx, data);
+  renderSpacer(ctx, ctx.theme.spacing.sectionGap);
+};
+
+export const renderPrescriptionTemplate = (
+  ctx: PdfContext,
+  data: PrescriptionDocumentData
+): ClinicalPdfSignaturePlacement => {
+  renderPrescriptionBody(ctx, data);
   return renderDocumentEndBlock(ctx, {
     printedBy: data.printedBy,
     signature: data.signature,

--- a/packages/lib/src/pdf/templates/SoapNoteTemplate.ts
+++ b/packages/lib/src/pdf/templates/SoapNoteTemplate.ts
@@ -6,10 +6,25 @@ import { renderRichText } from '../sections/RichText.js';
 import type { ClinicalPdfSignaturePlacement, SoapNoteDocumentData } from '../types.js';
 import { buildClinicalHeaderKeyValue } from './shared.js';
 
-export const renderSoapNoteTemplate = (
-  ctx: PdfContext,
-  data: SoapNoteDocumentData
-): ClinicalPdfSignaturePlacement => {
+// Content sections only (no title, metadata or signature) so a combined
+// clinical packet can render them under one shared header and sign once.
+export const renderSoapNoteContent = (ctx: PdfContext, data: SoapNoteDocumentData): void => {
+  renderSectionTitle(ctx, 'Subjective');
+  renderRichText(ctx, data.subjective);
+
+  renderSectionTitle(ctx, 'Objective');
+  renderRichText(ctx, data.objective);
+
+  renderSectionTitle(ctx, 'Assessment');
+  renderRichText(ctx, data.assessment);
+
+  renderSectionTitle(ctx, 'Plan');
+  renderRichText(ctx, data.plan);
+};
+
+// Title + metadata + content, without the signature end block (standalone
+// rendering appends the end block below).
+export const renderSoapNoteBody = (ctx: PdfContext, data: SoapNoteDocumentData): void => {
   renderDocumentTitle(ctx, data.title);
   renderKeyValueGrid(
     ctx,
@@ -27,20 +42,15 @@ export const renderSoapNoteTemplate = (
     { columns: 3 }
   );
   renderSpacer(ctx, ctx.theme.spacing.sectionGap);
-
-  renderSectionTitle(ctx, 'Subjective');
-  renderRichText(ctx, data.subjective);
-
-  renderSectionTitle(ctx, 'Objective');
-  renderRichText(ctx, data.objective);
-
-  renderSectionTitle(ctx, 'Assessment');
-  renderRichText(ctx, data.assessment);
-
-  renderSectionTitle(ctx, 'Plan');
-  renderRichText(ctx, data.plan);
-
+  renderSoapNoteContent(ctx, data);
   renderSpacer(ctx, ctx.theme.spacing.sectionGap);
+};
+
+export const renderSoapNoteTemplate = (
+  ctx: PdfContext,
+  data: SoapNoteDocumentData
+): ClinicalPdfSignaturePlacement => {
+  renderSoapNoteBody(ctx, data);
   return renderDocumentEndBlock(ctx, {
     printedBy: data.printedBy,
     signature: data.signature,

--- a/packages/lib/src/pdf/templates/VitalRecordTemplate.ts
+++ b/packages/lib/src/pdf/templates/VitalRecordTemplate.ts
@@ -7,29 +7,8 @@ import { renderTable } from '../sections/Table.js';
 import type { ClinicalPdfSignaturePlacement, VitalRecordDocumentData } from '../types.js';
 import { buildClinicalHeaderKeyValue, buildKeyValue } from './shared.js';
 
-export const renderVitalRecordTemplate = (
-  ctx: PdfContext,
-  data: VitalRecordDocumentData
-): ClinicalPdfSignaturePlacement => {
-  renderDocumentTitle(ctx, data.title);
-  renderKeyValueGrid(
-    ctx,
-    buildClinicalHeaderKeyValue({
-      date: data.date,
-      appointmentId: data.appointmentId,
-      leadLabel: 'Recorded By',
-      leadName: data.recordedBy,
-      patientName: data.patientName,
-      clientName: data.clientName,
-      clientId: data.clientId,
-      clientContact: data.contact,
-      speciesBreed: data.speciesBreed,
-      ageSex: data.ageSex,
-    }),
-    { columns: 3 }
-  );
-  renderSpacer(ctx, ctx.theme.spacing.sectionGap);
-
+// Content sections only (no title, metadata or signature) for combined packets.
+export const renderVitalRecordContent = (ctx: PdfContext, data: VitalRecordDocumentData): void => {
   renderSectionTitle(ctx, 'Vital Measurements');
   renderTable(ctx, {
     columns: [
@@ -59,8 +38,37 @@ export const renderVitalRecordTemplate = (
     );
     renderKeyValueGrid(ctx, buildKeyValue(metadataEntries), { columns: 2 });
   }
+};
 
+// Title + metadata + content, without the signature end block.
+export const renderVitalRecordBody = (ctx: PdfContext, data: VitalRecordDocumentData): void => {
+  renderDocumentTitle(ctx, data.title);
+  renderKeyValueGrid(
+    ctx,
+    buildClinicalHeaderKeyValue({
+      date: data.date,
+      appointmentId: data.appointmentId,
+      leadLabel: 'Recorded By',
+      leadName: data.recordedBy,
+      patientName: data.patientName,
+      clientName: data.clientName,
+      clientId: data.clientId,
+      clientContact: data.contact,
+      speciesBreed: data.speciesBreed,
+      ageSex: data.ageSex,
+    }),
+    { columns: 3 }
+  );
   renderSpacer(ctx, ctx.theme.spacing.sectionGap);
+  renderVitalRecordContent(ctx, data);
+  renderSpacer(ctx, ctx.theme.spacing.sectionGap);
+};
+
+export const renderVitalRecordTemplate = (
+  ctx: PdfContext,
+  data: VitalRecordDocumentData
+): ClinicalPdfSignaturePlacement => {
+  renderVitalRecordBody(ctx, data);
   return renderDocumentEndBlock(ctx, {
     printedBy: data.printedBy,
     signature: data.signature,

--- a/packages/lib/src/pdf/templates/VitalRecordTemplate.ts
+++ b/packages/lib/src/pdf/templates/VitalRecordTemplate.ts
@@ -1,6 +1,11 @@
 import type { PdfContext } from '../PdfContext.js';
 import { renderKeyValueGrid } from '../sections/KeyValueGrid.js';
-import { renderDocumentTitle, renderSectionTitle, renderSpacer } from '../sections/Text.js';
+import {
+  renderDocumentTitle,
+  renderSectionTitle,
+  renderSpacer,
+  renderSubTitle,
+} from '../sections/Text.js';
 import { renderDocumentEndBlock } from '../sections/DocumentEndBlock.js';
 import { renderRichText } from '../sections/RichText.js';
 import { renderTable } from '../sections/Table.js';
@@ -9,6 +14,16 @@ import { buildClinicalHeaderKeyValue, buildKeyValue } from './shared.js';
 
 // Content sections only (no title, metadata or signature) for combined packets.
 export const renderVitalRecordContent = (ctx: PdfContext, data: VitalRecordDocumentData): void => {
+  const recordedLine = [
+    data.recordedBy ? `Recorded by ${data.recordedBy}` : undefined,
+    data.recordedAt ? `on ${data.recordedAt}` : undefined,
+  ]
+    .filter(Boolean)
+    .join(' ');
+  if (recordedLine) {
+    renderSubTitle(ctx, recordedLine);
+  }
+
   renderSectionTitle(ctx, 'Vital Measurements');
   renderTable(ctx, {
     columns: [

--- a/packages/lib/src/pdf/templates/shared.ts
+++ b/packages/lib/src/pdf/templates/shared.ts
@@ -21,6 +21,8 @@ export const buildClinicalHeaderKeyValue = (input: {
   clientContact?: string;
   speciesBreed?: string;
   ageSex?: string;
+  roomName?: string;
+  unitName?: string;
 }): KeyValueItem[] =>
   buildKeyValue([
     ['Date', input.date.toISOString().slice(0, 10)],
@@ -32,6 +34,8 @@ export const buildClinicalHeaderKeyValue = (input: {
     ['Client Contact', input.clientContact],
     ['Species / Breed', input.speciesBreed],
     ['Age / Sex', input.ageSex],
+    ['Room', input.roomName],
+    ['Unit', input.unitName],
   ]);
 
 export const buildKeyValueGroups = (

--- a/packages/lib/src/pdf/templates/shared.ts
+++ b/packages/lib/src/pdf/templates/shared.ts
@@ -23,6 +23,8 @@ export const buildClinicalHeaderKeyValue = (input: {
   ageSex?: string;
   roomName?: string;
   unitName?: string;
+  admittedAt?: string;
+  admittedBy?: string;
 }): KeyValueItem[] =>
   buildKeyValue([
     ['Date', input.date.toISOString().slice(0, 10)],
@@ -36,6 +38,8 @@ export const buildClinicalHeaderKeyValue = (input: {
     ['Age / Sex', input.ageSex],
     ['Room', input.roomName],
     ['Unit', input.unitName],
+    ['Admitted', input.admittedAt],
+    ['Admitted By', input.admittedBy],
   ]);
 
 export const buildKeyValueGroups = (

--- a/packages/lib/src/pdf/types.ts
+++ b/packages/lib/src/pdf/types.ts
@@ -25,6 +25,8 @@ export type DocumentSignature = {
   signerName?: string;
   signerRole?: string;
   signerDegree?: string;
+  signerEmail?: string;
+  authMethod?: string;
   signedAt?: Date;
   label?: string;
 };

--- a/packages/lib/src/pdf/types.ts
+++ b/packages/lib/src/pdf/types.ts
@@ -173,6 +173,7 @@ export type VitalRecordDocumentData = BaseClinicalDocumentData & {
   date: Date;
   appointmentId?: string;
   recordedBy?: string;
+  recordedAt?: string;
   patientName: string;
   speciesBreed?: string;
   ageSex?: string;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug this PR is for (#1641).
- [x] All existing tests and lints pass.

## What is the current behavior?

Documenso signature fields are positioned using PDF **point** coordinates (e.g. `pageX: 330, pageY: 700`). The [Documenso fields API](https://docs.documenso.com/docs/developers/api/fields) expects **percentages of the page (0–100), top-left origin**, so a point value like `700` is read as `700%` and the field renders far off-page, detached from the rendered signature line. This affects every signable document (clinical artifacts, resolved templates, clinical packets, form submissions).

## What is the new behavior?

Every signature-field placement is sent to Documenso as percentages (0–100, top-left):

- **`packages/lib/src/pdf/clinicalPacket.ts`** — the merged-packet placement is converted from top-left points to percentages via a `toFieldPercent` helper. `SIGNATURE_FIELD` stays in points only to draw the visible box, so the Documenso field and the drawn box align exactly.
- **`apps/backend/src/services/rendered-document-renderer.service.ts`** — `DEFAULT_SIGNATURE_PLACEMENT` (form-submission render path + fallback) expressed as percentages.
- **`apps/backend/src/services/documenso.service.ts`** — last-resort fallback default expressed as percentages.
- The clinical/template renderer (`DocumentEndBlock`) already returns percentages and is the reference behaviour (unchanged).

## Validation

- Backend `tsc --noEmit`: clean · `packages/lib` `tsc --noEmit`: clean · backend ESLint (changed files): clean
- Backend jest — 10 affected suites, 118 tests: pass. Added a percentage-range guard in `clinical-packet-pdf.service.test.ts` that fails if a placement regresses to point values (>100).
- **Visual:** rendered the real SOAP and merged-packet PDFs (pending + signed) and overlaid the computed Documenso field rectangle — it lands exactly on the rendered "Signature" line/box. The packet overlay is byte-identical to the drawn signature box.

## Related Issue(s)

Fixes #1641
