### PR TITLE
feat(repo): add currency-exponent-aware minor-unit money helper

### DIFF
--- a/apps/backend/test/utils/money-minor-units.test.ts
+++ b/apps/backend/test/utils/money-minor-units.test.ts
@@ -1,0 +1,150 @@
+import {
+  fromMinorUnits,
+  getCurrencyExponent,
+  toMinorUnits,
+} from "@yosemite-crew/lib";
+
+describe("getCurrencyExponent", () => {
+  it("returns 2 for standard two-decimal currencies", () => {
+    expect(getCurrencyExponent("USD")).toBe(2);
+    expect(getCurrencyExponent("EUR")).toBe(2);
+    expect(getCurrencyExponent("GBP")).toBe(2);
+    expect(getCurrencyExponent("INR")).toBe(2);
+  });
+
+  it("returns 0 for zero-decimal currencies", () => {
+    expect(getCurrencyExponent("JPY")).toBe(0);
+    expect(getCurrencyExponent("KRW")).toBe(0);
+    expect(getCurrencyExponent("VND")).toBe(0);
+    expect(getCurrencyExponent("ISK")).toBe(0);
+    expect(getCurrencyExponent("XOF")).toBe(0);
+  });
+
+  it("returns 3 for three-decimal currencies", () => {
+    expect(getCurrencyExponent("BHD")).toBe(3);
+    expect(getCurrencyExponent("KWD")).toBe(3);
+    expect(getCurrencyExponent("OMR")).toBe(3);
+    expect(getCurrencyExponent("TND")).toBe(3);
+  });
+
+  it("returns 4 for four-decimal currencies", () => {
+    expect(getCurrencyExponent("CLF")).toBe(4);
+    expect(getCurrencyExponent("UYW")).toBe(4);
+  });
+
+  it("is case-insensitive and trims surrounding whitespace", () => {
+    expect(getCurrencyExponent("jpy")).toBe(0);
+    expect(getCurrencyExponent("bhd")).toBe(3);
+    expect(getCurrencyExponent("  usd  ")).toBe(2);
+  });
+
+  it("defaults unknown but well-formed codes to 2", () => {
+    expect(getCurrencyExponent("ZZZ")).toBe(2);
+  });
+
+  it("throws on malformed currency codes", () => {
+    expect(() => getCurrencyExponent("")).toThrow(RangeError);
+    expect(() => getCurrencyExponent("US")).toThrow(RangeError);
+    expect(() => getCurrencyExponent("USDD")).toThrow(RangeError);
+    expect(() => getCurrencyExponent("U1D")).toThrow(RangeError);
+    expect(() => getCurrencyExponent(123 as unknown as string)).toThrow(
+      RangeError,
+    );
+    expect(() => getCurrencyExponent(null as unknown as string)).toThrow(
+      RangeError,
+    );
+  });
+});
+
+describe("toMinorUnits", () => {
+  it("converts two-decimal amounts to cents", () => {
+    expect(toMinorUnits(19.99, "USD")).toBe(1999);
+    expect(toMinorUnits(10, "USD")).toBe(1000);
+    expect(toMinorUnits(0, "USD")).toBe(0);
+    expect(toMinorUnits(1234567.89, "USD")).toBe(123456789);
+  });
+
+  it("keeps zero-decimal currencies whole", () => {
+    expect(toMinorUnits(1500, "JPY")).toBe(1500);
+    expect(toMinorUnits(1500.4, "JPY")).toBe(1500);
+    expect(toMinorUnits(1500.6, "JPY")).toBe(1501);
+  });
+
+  it("scales three-decimal currencies by 1000", () => {
+    expect(toMinorUnits(1.234, "BHD")).toBe(1234);
+    expect(toMinorUnits(1.2345, "BHD")).toBe(1235);
+  });
+
+  it("scales four-decimal currencies by 10000", () => {
+    expect(toMinorUnits(1.2345, "CLF")).toBe(12345);
+  });
+
+  it("rounds half away from zero", () => {
+    expect(toMinorUnits(19.995, "USD")).toBe(2000);
+    expect(toMinorUnits(0.005, "USD")).toBe(1);
+    expect(toMinorUnits(0.004, "USD")).toBe(0);
+    expect(toMinorUnits(0.015, "USD")).toBe(2);
+  });
+
+  it("handles negative amounts symmetrically", () => {
+    expect(toMinorUnits(-5.5, "USD")).toBe(-550);
+    expect(toMinorUnits(-0.005, "USD")).toBe(-1);
+  });
+
+  it("does not accumulate binary floating-point error", () => {
+    expect(toMinorUnits(1.1, "USD")).toBe(110);
+    expect(toMinorUnits(0.1 + 0.2, "USD")).toBe(30);
+    expect(toMinorUnits(2.675, "USD")).toBe(268);
+  });
+
+  it("throws on non-finite amounts and invalid currencies", () => {
+    expect(() => toMinorUnits(Number.NaN, "USD")).toThrow(RangeError);
+    expect(() => toMinorUnits(Number.POSITIVE_INFINITY, "USD")).toThrow(
+      RangeError,
+    );
+    expect(() => toMinorUnits("5" as unknown as number, "USD")).toThrow(
+      RangeError,
+    );
+    expect(() => toMinorUnits(5, "US")).toThrow(RangeError);
+  });
+});
+
+describe("fromMinorUnits", () => {
+  it("converts minor units back to major amounts", () => {
+    expect(fromMinorUnits(1999, "USD")).toBe(19.99);
+    expect(fromMinorUnits(1000, "USD")).toBe(10);
+    expect(fromMinorUnits(0, "USD")).toBe(0);
+  });
+
+  it("respects the currency exponent", () => {
+    expect(fromMinorUnits(1500, "JPY")).toBe(1500);
+    expect(fromMinorUnits(1234, "BHD")).toBe(1.234);
+    expect(fromMinorUnits(12345, "CLF")).toBe(1.2345);
+  });
+
+  it("handles negative minor units", () => {
+    expect(fromMinorUnits(-550, "USD")).toBe(-5.5);
+  });
+
+  it("throws on non-integer minor amounts and invalid currencies", () => {
+    expect(() => fromMinorUnits(19.99, "USD")).toThrow(RangeError);
+    expect(() => fromMinorUnits(1.5, "USD")).toThrow(RangeError);
+    expect(() => fromMinorUnits(100, "US")).toThrow(RangeError);
+  });
+});
+
+describe("round trip", () => {
+  it.each([
+    [19.99, "USD"],
+    [0, "USD"],
+    [-5.5, "USD"],
+    [1500, "JPY"],
+    [1.234, "BHD"],
+    [1.2345, "CLF"],
+    [99.95, "EUR"],
+  ])("preserves %p %s through to-and-from minor units", (amount, currency) => {
+    expect(fromMinorUnits(toMinorUnits(amount, currency), currency)).toBe(
+      amount,
+    );
+  });
+});

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -13,6 +13,7 @@ export type { JsonObject, JsonPrimitive, JsonValue, Nullable, Optional } from '.
 export { addCachedPromise, type CachedPromise } from './utils/cached-promise-cache.js';
 export { mapAxiosError, type ExternalHttpError } from './utils/external-error.js';
 export { buildGeoPoint, type GeoPoint } from './utils/geojson.js';
+export { fromMinorUnits, getCurrencyExponent, toMinorUnits } from './money/minor-units.js';
 export {
   resolvePaymentCollectionMethod,
   type PaymentCollectionMethodValue,

--- a/packages/lib/src/money/minor-units.ts
+++ b/packages/lib/src/money/minor-units.ts
@@ -1,0 +1,109 @@
+/**
+ * Currency-exponent-aware minor-unit conversion.
+ *
+ * Payment providers transact in the smallest unit of a currency (its minor
+ * unit): cents for USD, but whole yen for JPY (0 decimals) and thousandths of a
+ * dinar for BHD (3 decimals). A fixed multiply-by-100 over-charges or
+ * under-charges every currency whose minor-unit exponent is not 2. These helpers
+ * convert between major units (the amount a person reads, e.g. 19.99) and minor
+ * units (what a provider expects, e.g. 1999) using the ISO 4217 exponent.
+ */
+
+const ZERO_DECIMAL_CURRENCIES = new Set<string>([
+  'BIF',
+  'CLP',
+  'DJF',
+  'GNF',
+  'ISK',
+  'JPY',
+  'KMF',
+  'KRW',
+  'PYG',
+  'RWF',
+  'UGX',
+  'UYI',
+  'VND',
+  'VUV',
+  'XAF',
+  'XOF',
+  'XPF',
+]);
+
+const THREE_DECIMAL_CURRENCIES = new Set<string>(['BHD', 'IQD', 'JOD', 'KWD', 'LYD', 'OMR', 'TND']);
+
+const FOUR_DECIMAL_CURRENCIES = new Set<string>(['CLF', 'UYW']);
+
+const DEFAULT_EXPONENT = 2;
+
+/** Precision (decimal places) used to absorb binary floating-point drift before the final integer round. */
+const DE_DRIFT_PRECISION = 4;
+
+function normalizeCurrency(currency: string): string {
+  if (typeof currency !== 'string') {
+    throw new RangeError('Currency code must be a string');
+  }
+  const code = currency.trim().toUpperCase();
+  if (!/^[A-Z]{3}$/.test(code)) {
+    throw new RangeError(`Invalid ISO 4217 currency code: ${JSON.stringify(currency)}`);
+  }
+  return code;
+}
+
+/**
+ * Returns the number of decimal places (the minor-unit exponent) for an ISO 4217
+ * currency code. Case-insensitive. Currencies not in the zero-, three-, or
+ * four-decimal sets default to two decimals, which is the ISO 4217 default.
+ *
+ * @throws RangeError if the code is not a three-letter alphabetic string.
+ */
+export function getCurrencyExponent(currency: string): number {
+  const code = normalizeCurrency(currency);
+  if (ZERO_DECIMAL_CURRENCIES.has(code)) {
+    return 0;
+  }
+  if (THREE_DECIMAL_CURRENCIES.has(code)) {
+    return 3;
+  }
+  if (FOUR_DECIMAL_CURRENCIES.has(code)) {
+    return 4;
+  }
+  return DEFAULT_EXPONENT;
+}
+
+/**
+ * Converts a major-unit amount (e.g. 19.99) to an integer count of minor units
+ * (e.g. 1999) for the given currency. Rounds half away from zero to the nearest
+ * minor unit.
+ *
+ * @throws RangeError if the amount is not finite or the currency code is invalid.
+ */
+export function toMinorUnits(majorAmount: number, currency: string): number {
+  if (typeof majorAmount !== 'number' || !Number.isFinite(majorAmount)) {
+    throw new RangeError(`Amount must be a finite number, received ${JSON.stringify(majorAmount)}`);
+  }
+  const exponent = getCurrencyExponent(currency);
+  const factor = 10 ** exponent;
+  // Scaling a float by a power of ten reintroduces representation error
+  // (1.1 * 100 === 110.00000000000001). Fix the value at a precision a few places
+  // beyond the target, then round to the nearest integer half away from zero.
+  const scaled = Number((majorAmount * factor).toFixed(DE_DRIFT_PRECISION));
+  const minor = Math.sign(scaled) * Math.round(Math.abs(scaled));
+  return minor === 0 ? 0 : minor;
+}
+
+/**
+ * Converts an integer count of minor units (e.g. 1999) back to a major-unit
+ * amount (e.g. 19.99) for the given currency.
+ *
+ * @throws RangeError if the minor amount is not an integer or the currency code is invalid.
+ */
+export function fromMinorUnits(minorAmount: number, currency: string): number {
+  if (!Number.isInteger(minorAmount)) {
+    throw new RangeError(
+      `Minor amount must be an integer, received ${JSON.stringify(minorAmount)}`
+    );
+  }
+  const exponent = getCurrencyExponent(currency);
+  const major = minorAmount / 10 ** exponent;
+  return major === 0 ? 0 : major;
+}


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows the commit guidelines.
- [x] There is an issue for this feature (#1659).
- [x] All existing tests and lints pass.

## What is the current behavior?

The backend converts money to provider minor units with a hardcoded multiply-by-100. That is correct only for two-decimal currencies. There is no shared, currency-aware conversion, so zero-decimal currencies (JPY, KRW) and three-decimal currencies (BHD, KWD) would be mis-charged by a factor of 100 or 10. A shared minor-unit helper is a prerequisite for the payment-gateway abstraction in #1659, where a second provider transacts in ISO 4217 minor units.

## What is the new behavior?

Adds a shared, dependency-free money helper in `packages/lib` (`packages/lib/src/money/minor-units.ts`), exported from the package barrel:

- `getCurrencyExponent(currency)` returns the ISO 4217 minor-unit exponent (0, 2, 3, and the 4-decimal special cases), defaulting to 2 for unknown but well-formed codes, and validating the code shape.
- `toMinorUnits(major, currency)` converts a major amount (e.g. 19.99) to an integer minor amount (e.g. 1999), rounding half away from zero and compensating for binary floating-point drift.
- `fromMinorUnits(minor, currency)` converts back.

Additive only. No existing code is changed or rewired in this PR. Wiring the helper into the finance flows is a separate, behaviour-affecting step that the platform fee and split policy decision still gates.

## Validation

- 26 unit tests in `apps/backend/test/utils/money-minor-units.test.ts` covering exponent lookup, each currency class, rounding, negative amounts, floating-point drift, error paths, and round-trips. All pass.
- `@yosemite-crew/lib` type-check clean. Files prettier-formatted.

## Related Issue(s)

Part of #1659. This is the first decision-independent Phase 0 prerequisite from the design plan; it does not close the issue.
