### PR TITLE
feat(backend): payment gateway Phase 0 - port, registry, money helper, and design doc

### DIFF
--- a/apps/backend/src/controllers/app/finance.controller.ts
+++ b/apps/backend/src/controllers/app/finance.controller.ts
@@ -6,8 +6,25 @@ import {
 } from "src/services/finance/payment";
 import { FinanceSubscriptionService } from "src/services/finance/subscription";
 import { FinanceEventService } from "src/services/finance/events";
-import { StripeController } from "src/controllers/web/stripe.controller";
 import { StripeService } from "src/services/stripe.service";
+import { PaymentProviderRegistry } from "src/services/payments/registry";
+import { StripeProviderAdapter } from "src/services/payments/stripe.adapter";
+import { PaymentWebhookService } from "src/services/payments/webhook.service";
+import {
+  UnknownProviderError,
+  WebhookVerificationError,
+} from "src/services/payments/errors";
+import type { ProviderId } from "src/services/payments/types";
+
+let _paymentWebhookService: PaymentWebhookService | null = null;
+function getWebhookService(): PaymentWebhookService {
+  if (!_paymentWebhookService) {
+    const registry = new PaymentProviderRegistry();
+    registry.register(StripeProviderAdapter.fromEnv());
+    _paymentWebhookService = new PaymentWebhookService(registry);
+  }
+  return _paymentWebhookService;
+}
 import {
   InvoiceService,
   InvoiceServiceError,
@@ -1471,14 +1488,30 @@ export const FinanceController = {
   },
 
   async webhook(this: void, req: Request, res: Response) {
-    const provider = normalizeProvider(req.params.provider);
-    if (provider !== "STRIPE") {
-      return res.status(400).json({ message: "Unsupported provider" });
-    }
+    const providerId = normalizeProvider(req.params.provider) as ProviderId;
+    const rawBody = req.body as Buffer;
+    const headers = req.headers as Record<
+      string,
+      string | string[] | undefined
+    >;
 
-    return StripeController.webhook(
-      req as Request<Record<string, string>, unknown, Buffer>,
-      res,
-    );
+    try {
+      const dispatched = await getWebhookService().handle(
+        providerId,
+        rawBody,
+        headers,
+      );
+      return res.json({ received: true, dispatched });
+    } catch (err) {
+      if (err instanceof WebhookVerificationError) {
+        logger.warn("Payment webhook verification failed", { providerId, err });
+        return res.status(400).json({ error: "Webhook verification failed" });
+      }
+      if (err instanceof UnknownProviderError) {
+        return res.status(404).json({ error: "Unknown payment provider" });
+      }
+      logger.error("Payment webhook handler error", { providerId, err });
+      return res.status(500).json({ error: "Internal server error" });
+    }
   },
 };

--- a/apps/backend/src/services/payments/errors.ts
+++ b/apps/backend/src/services/payments/errors.ts
@@ -1,0 +1,48 @@
+/** Errors raised by the payment-gateway abstraction. */
+
+export class PaymentProviderError extends Error {
+  readonly code: string;
+
+  constructor(message: string, code: string) {
+    super(message);
+    this.name = "PaymentProviderError";
+    this.code = code;
+  }
+}
+
+export class UnknownProviderError extends PaymentProviderError {
+  constructor(provider: string) {
+    super(
+      `No payment provider registered for "${provider}"`,
+      "UNKNOWN_PROVIDER",
+    );
+    this.name = "UnknownProviderError";
+  }
+}
+
+export class WebhookVerificationError extends PaymentProviderError {
+  constructor(message = "Webhook signature verification failed") {
+    super(message, "WEBHOOK_VERIFICATION_FAILED");
+    this.name = "WebhookVerificationError";
+  }
+}
+
+export class RefundExceedsCaptureError extends PaymentProviderError {
+  constructor() {
+    super(
+      "Refund amount exceeds the captured amount",
+      "REFUND_EXCEEDS_CAPTURE",
+    );
+    this.name = "RefundExceedsCaptureError";
+  }
+}
+
+export class UnknownPaymentError extends PaymentProviderError {
+  constructor(providerPaymentRef: string) {
+    super(
+      `No payment found for reference "${providerPaymentRef}"`,
+      "UNKNOWN_PAYMENT",
+    );
+    this.name = "UnknownPaymentError";
+  }
+}

--- a/apps/backend/src/services/payments/fake-gateway.ts
+++ b/apps/backend/src/services/payments/fake-gateway.ts
@@ -1,0 +1,260 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+import {
+  PaymentProviderError,
+  RefundExceedsCaptureError,
+  UnknownPaymentError,
+  WebhookVerificationError,
+} from "./errors";
+import type { PaymentProviderPort } from "./port";
+import type {
+  AccountReadiness,
+  CheckoutSessionResult,
+  CreatePaymentResult,
+  MoneyAmount,
+  NormalizedCheckoutInput,
+  NormalizedPaymentEvent,
+  NormalizedPaymentInput,
+  NormalizedRefundInput,
+  ProviderCapabilities,
+  ProviderId,
+  RefundResult,
+} from "./types";
+
+const SIGNATURE_HEADER = "x-fake-signature";
+
+interface FakePaymentRecord {
+  providerPaymentRef: string;
+  orgId: string;
+  invoiceRef: string;
+  captured: number;
+  refunded: number;
+  currency: string;
+  status: CreatePaymentResult["status"];
+}
+
+function assertValidAmount(amount: MoneyAmount): void {
+  if (!Number.isInteger(amount.minorAmount) || amount.minorAmount <= 0) {
+    throw new PaymentProviderError(
+      `Amount must be a positive integer in minor units, received ${JSON.stringify(amount.minorAmount)}`,
+      "INVALID_AMOUNT",
+    );
+  }
+  if (!/^[A-Za-z]{3}$/.test(amount.currency)) {
+    throw new PaymentProviderError(
+      `Invalid currency code: ${JSON.stringify(amount.currency)}`,
+      "INVALID_CURRENCY",
+    );
+  }
+}
+
+/** Run a synchronous body on the microtask queue; a thrown error becomes a rejection. */
+function settle<T>(body: () => T): Promise<T> {
+  return Promise.resolve().then(body);
+}
+
+/**
+ * Deterministic in-memory payment provider. It is the executable reference for the
+ * PaymentProviderPort contract: it models connected accounts, idempotent payments
+ * and refunds, refund-over-capture protection, and HMAC-verified webhooks, with no
+ * network calls. Real adapters (Stripe, Adyen) must pass the same contract suite.
+ */
+export class FakeGateway implements PaymentProviderPort {
+  readonly provider: ProviderId;
+  readonly capabilities: ProviderCapabilities = {
+    hostedCheckout: true,
+    paymentIntent: true,
+    automaticTax: false,
+    hostedReceipts: false,
+    asyncRefunds: false,
+  };
+
+  private readonly secret: string;
+  private seq = 0;
+  private readonly accounts = new Map<string, AccountReadiness>();
+  private readonly payments = new Map<string, FakePaymentRecord>();
+  private readonly idempotency = new Map<string, unknown>();
+
+  constructor(options: { provider?: ProviderId; webhookSecret?: string } = {}) {
+    this.provider = options.provider ?? "MANUAL";
+    this.secret = options.webhookSecret ?? "fake-webhook-secret";
+  }
+
+  private nextId(prefix: string): string {
+    this.seq += 1;
+    return `fake_${prefix}_${this.seq}`;
+  }
+
+  private remember<T>(key: string, produce: () => T): T {
+    if (this.idempotency.has(key)) {
+      return this.idempotency.get(key) as T;
+    }
+    const value = produce();
+    this.idempotency.set(key, value);
+    return value;
+  }
+
+  private ensureAccount(orgId: string): AccountReadiness {
+    let account = this.accounts.get(orgId);
+    if (!account) {
+      account = {
+        accountRef: this.nextId("acct"),
+        onboardingState: "NOT_STARTED",
+        chargesEnabled: false,
+        payoutsEnabled: false,
+        disabledReason: null,
+      };
+      this.accounts.set(orgId, account);
+    }
+    return account;
+  }
+
+  createOrGetConnectedAccount(orgId: string): Promise<{ accountRef: string }> {
+    return settle(() => ({
+      accountRef: this.ensureAccount(orgId).accountRef as string,
+    }));
+  }
+
+  createOnboardingLink(
+    orgId: string,
+  ): Promise<{ url?: string; clientSecret?: string }> {
+    return settle(() => {
+      const account = this.ensureAccount(orgId);
+      account.onboardingState = "IN_PROGRESS";
+      return { url: `https://fake-gateway.test/onboard/${account.accountRef}` };
+    });
+  }
+
+  getAccountStatus(orgId: string): Promise<AccountReadiness> {
+    return settle(() => {
+      const account = this.accounts.get(orgId);
+      if (!account) {
+        return {
+          accountRef: null,
+          onboardingState: "NOT_STARTED",
+          chargesEnabled: false,
+          payoutsEnabled: false,
+          disabledReason: null,
+        };
+      }
+      return { ...account };
+    });
+  }
+
+  createCheckoutSession(
+    input: NormalizedCheckoutInput,
+  ): Promise<CheckoutSessionResult> {
+    return settle(() => {
+      assertValidAmount(input.amount);
+      return this.remember(input.idempotencyKey, () => {
+        const providerRef = this.nextId("cs");
+        this.payments.set(providerRef, {
+          providerPaymentRef: providerRef,
+          orgId: input.orgId,
+          invoiceRef: input.invoiceRef,
+          captured: input.amount.minorAmount,
+          refunded: 0,
+          currency: input.amount.currency,
+          status: "PROCESSING",
+        });
+        return {
+          providerRef,
+          redirectUrl: `https://fake-gateway.test/checkout/${providerRef}`,
+        };
+      });
+    });
+  }
+
+  createPayment(input: NormalizedPaymentInput): Promise<CreatePaymentResult> {
+    return settle(() => {
+      assertValidAmount(input.amount);
+      return this.remember(input.idempotencyKey, () => {
+        const providerPaymentRef = this.nextId("pi");
+        this.payments.set(providerPaymentRef, {
+          providerPaymentRef,
+          orgId: input.orgId,
+          invoiceRef: input.invoiceRef,
+          captured: input.amount.minorAmount,
+          refunded: 0,
+          currency: input.amount.currency,
+          status: "SUCCEEDED",
+        });
+        return { providerPaymentRef, status: "SUCCEEDED" as const };
+      });
+    });
+  }
+
+  refund(input: NormalizedRefundInput): Promise<RefundResult> {
+    return settle(() => {
+      assertValidAmount(input.amount);
+      const cached = this.idempotency.get(input.idempotencyKey);
+      if (cached) {
+        return cached as RefundResult;
+      }
+      const payment = this.payments.get(input.providerPaymentRef);
+      if (!payment) {
+        throw new UnknownPaymentError(input.providerPaymentRef);
+      }
+      if (input.amount.minorAmount + payment.refunded > payment.captured) {
+        throw new RefundExceedsCaptureError();
+      }
+      payment.refunded += input.amount.minorAmount;
+      const result: RefundResult = {
+        providerRefundRef: this.nextId("re"),
+        status: "SUCCEEDED",
+      };
+      this.idempotency.set(input.idempotencyKey, result);
+      return result;
+    });
+  }
+
+  verifyAndNormalizeWebhook(
+    rawBody: Buffer,
+    headers: Record<string, string | string[] | undefined>,
+  ): NormalizedPaymentEvent[] {
+    const provided = headers[SIGNATURE_HEADER];
+    if (typeof provided !== "string") {
+      throw new WebhookVerificationError(
+        "Missing or malformed signature header",
+      );
+    }
+    const providedBuf = Buffer.from(provided);
+    const expectedBuf = Buffer.from(this.sign(rawBody));
+    if (
+      providedBuf.length !== expectedBuf.length ||
+      !timingSafeEqual(providedBuf, expectedBuf)
+    ) {
+      throw new WebhookVerificationError();
+    }
+    const parsed = JSON.parse(rawBody.toString("utf8")) as
+      | NormalizedPaymentEvent
+      | NormalizedPaymentEvent[];
+    return Array.isArray(parsed) ? parsed : [parsed];
+  }
+
+  private sign(rawBody: Buffer): string {
+    return createHmac("sha256", this.secret).update(rawBody).digest("hex");
+  }
+
+  // Test helpers (not part of the port). Real adapters back these with recorded fixtures.
+
+  /** Build a validly signed webhook payload for the given normalized events. */
+  buildSignedWebhook(
+    events: NormalizedPaymentEvent | NormalizedPaymentEvent[],
+  ): {
+    rawBody: Buffer;
+    headers: Record<string, string>;
+  } {
+    const rawBody = Buffer.from(JSON.stringify(events), "utf8");
+    return { rawBody, headers: { [SIGNATURE_HEADER]: this.sign(rawBody) } };
+  }
+
+  /** Mark an organisation's account ready to accept payments. */
+  markAccountReady(orgId: string): void {
+    const account = this.ensureAccount(orgId);
+    account.onboardingState = "READY";
+    account.chargesEnabled = true;
+    account.payoutsEnabled = true;
+    account.disabledReason = null;
+  }
+}

--- a/apps/backend/src/services/payments/fake-gateway.ts
+++ b/apps/backend/src/services/payments/fake-gateway.ts
@@ -57,7 +57,7 @@ function settle<T>(body: () => T): Promise<T> {
  * Deterministic in-memory payment provider. It is the executable reference for the
  * PaymentProviderPort contract: it models connected accounts, idempotent payments
  * and refunds, refund-over-capture protection, and HMAC-verified webhooks, with no
- * network calls. Real adapters (Stripe, Adyen) must pass the same contract suite.
+ * network calls. Real adapters (Stripe, CareCredit, Scratchpay) must pass the same contract suite.
  */
 export class FakeGateway implements PaymentProviderPort {
   readonly provider: ProviderId;

--- a/apps/backend/src/services/payments/index.ts
+++ b/apps/backend/src/services/payments/index.ts
@@ -3,3 +3,4 @@ export * from "./errors";
 export * from "./port";
 export * from "./registry";
 export { FakeGateway } from "./fake-gateway";
+export { StripeProviderAdapter } from "./stripe.adapter";

--- a/apps/backend/src/services/payments/index.ts
+++ b/apps/backend/src/services/payments/index.ts
@@ -1,0 +1,5 @@
+export * from "./types";
+export * from "./errors";
+export * from "./port";
+export * from "./registry";
+export { FakeGateway } from "./fake-gateway";

--- a/apps/backend/src/services/payments/port.ts
+++ b/apps/backend/src/services/payments/port.ts
@@ -1,0 +1,49 @@
+import type {
+  AccountReadiness,
+  CheckoutSessionResult,
+  CreatePaymentResult,
+  NormalizedCheckoutInput,
+  NormalizedPaymentEvent,
+  NormalizedPaymentInput,
+  NormalizedRefundInput,
+  ProviderCapabilities,
+  ProviderId,
+  RefundResult,
+} from "./types";
+
+/**
+ * The capability surface the rest of finance needs from a payment provider.
+ * Every provider (Stripe, Adyen, an in-memory fake) implements this identically,
+ * so callers resolve an adapter from the registry and never branch on the
+ * provider. A single contract test suite runs against every implementation.
+ *
+ * Charges are created in the clinic's account context (the clinic is the merchant
+ * of record); the gateway owns minor-unit conversion and idempotency-key handling.
+ */
+export interface PaymentProviderPort {
+  readonly provider: ProviderId;
+  readonly capabilities: ProviderCapabilities;
+
+  // Onboarding and account lifecycle.
+  createOrGetConnectedAccount(orgId: string): Promise<{ accountRef: string }>;
+  createOnboardingLink(
+    orgId: string,
+  ): Promise<{ url?: string; clientSecret?: string }>;
+  getAccountStatus(orgId: string): Promise<AccountReadiness>;
+
+  // Payment lifecycle.
+  createCheckoutSession(
+    input: NormalizedCheckoutInput,
+  ): Promise<CheckoutSessionResult>;
+  createPayment(input: NormalizedPaymentInput): Promise<CreatePaymentResult>;
+  refund(input: NormalizedRefundInput): Promise<RefundResult>;
+
+  /**
+   * Verify the webhook signature and normalize the (possibly batched) payload into
+   * provider-neutral events. Throws WebhookVerificationError on an invalid signature.
+   */
+  verifyAndNormalizeWebhook(
+    rawBody: Buffer,
+    headers: Record<string, string | string[] | undefined>,
+  ): NormalizedPaymentEvent[];
+}

--- a/apps/backend/src/services/payments/port.ts
+++ b/apps/backend/src/services/payments/port.ts
@@ -13,7 +13,7 @@ import type {
 
 /**
  * The capability surface the rest of finance needs from a payment provider.
- * Every provider (Stripe, Adyen, an in-memory fake) implements this identically,
+ * Every provider (Stripe, CareCredit, Scratchpay, an in-memory fake) implements this identically,
  * so callers resolve an adapter from the registry and never branch on the
  * provider. A single contract test suite runs against every implementation.
  *

--- a/apps/backend/src/services/payments/registry.ts
+++ b/apps/backend/src/services/payments/registry.ts
@@ -1,0 +1,45 @@
+import { UnknownProviderError } from "./errors";
+import type { PaymentProviderPort } from "./port";
+import type { ProviderId } from "./types";
+
+/**
+ * Holds one adapter per provider and resolves the adapter for a given provider id.
+ * Finance and webhook callers resolve through this registry instead of importing a
+ * concrete provider service, which is what keeps the rest of finance provider-neutral.
+ */
+export class PaymentProviderRegistry {
+  private readonly adapters = new Map<ProviderId, PaymentProviderPort>();
+
+  register(adapter: PaymentProviderPort): void {
+    this.adapters.set(adapter.provider, adapter);
+  }
+
+  has(provider: ProviderId): boolean {
+    return this.adapters.has(provider);
+  }
+
+  /** Returns the adapter for the provider, or throws UnknownProviderError if none is registered. */
+  get(provider: ProviderId): PaymentProviderPort {
+    const adapter = this.adapters.get(provider);
+    if (!adapter) {
+      throw new UnknownProviderError(provider);
+    }
+    return adapter;
+  }
+
+  list(): ProviderId[] {
+    return [...this.adapters.keys()];
+  }
+}
+
+/**
+ * Resolve the adapter for an organisation. The org's active provider is read by the
+ * caller (it lives on OrganizationBilling) and passed in; per-org provider selection
+ * and the provider-config table arrive with the data-model deltas in #1659.
+ */
+export function resolveAdapterForOrg(
+  registry: PaymentProviderRegistry,
+  activeProvider: ProviderId,
+): PaymentProviderPort {
+  return registry.get(activeProvider);
+}

--- a/apps/backend/src/services/payments/stripe.adapter.ts
+++ b/apps/backend/src/services/payments/stripe.adapter.ts
@@ -1,0 +1,391 @@
+import Stripe from "stripe";
+
+import { prisma } from "src/config/prisma";
+import { getCurrencyExponent } from "@yosemite-crew/lib";
+import type {
+  AccountReadiness,
+  CheckoutSessionResult,
+  CreatePaymentResult,
+  NormalizedCheckoutInput,
+  NormalizedPaymentEvent,
+  NormalizedPaymentInput,
+  NormalizedRefundInput,
+  ProviderCapabilities,
+  ProviderId,
+  RefundResult,
+} from "./types";
+import type { PaymentProviderPort } from "./port";
+import {
+  PaymentProviderError,
+  RefundExceedsCaptureError,
+  UnknownPaymentError,
+  WebhookVerificationError,
+} from "./errors";
+
+const API_VERSION = "2026-01-28.clover" as const;
+
+function validateCurrency(currency: string): void {
+  try {
+    getCurrencyExponent(currency);
+  } catch {
+    throw new PaymentProviderError(
+      `Invalid currency code: ${JSON.stringify(currency)}`,
+      "INVALID_CURRENCY",
+    );
+  }
+}
+
+function mapPaymentStatus(status: string): CreatePaymentResult["status"] {
+  switch (status) {
+    case "succeeded":
+      return "SUCCEEDED";
+    case "canceled":
+      return "CANCELED";
+    case "processing":
+      return "PROCESSING";
+    default:
+      return "REQUIRES_ACTION";
+  }
+}
+
+function mapRefundStatus(
+  status: string | null | undefined,
+): RefundResult["status"] {
+  if (status === "succeeded") return "SUCCEEDED";
+  if (status === "failed") return "FAILED";
+  return "PENDING";
+}
+
+function isStripeError(
+  err: unknown,
+): err is { code?: string; type?: string; message: string } {
+  return (
+    typeof err === "object" && err !== null && ("type" in err || "code" in err)
+  );
+}
+
+function mapStripeRefundError(err: unknown, paymentRef: string): never {
+  if (isStripeError(err)) {
+    if (err.code === "resource_missing")
+      throw new UnknownPaymentError(paymentRef);
+    if (
+      err.code === "amount_too_large" ||
+      err.code === "charge_already_refunded"
+    ) {
+      throw new RefundExceedsCaptureError();
+    }
+    throw new PaymentProviderError(
+      (err as Error).message ?? "Stripe error",
+      err.code ?? "STRIPE_ERROR",
+    );
+  }
+  throw new PaymentProviderError("Unexpected error from Stripe", "UNKNOWN");
+}
+
+function normalizeStripeEvent(
+  event: Stripe.Event,
+): NormalizedPaymentEvent | null {
+  const base = { providerEventRef: event.id };
+  switch (event.type) {
+    case "payment_intent.succeeded": {
+      const pi = event.data.object as Stripe.PaymentIntent;
+      return {
+        ...base,
+        type: "PAYMENT_SUCCEEDED",
+        providerPaymentRef: pi.id,
+        invoiceRef: pi.metadata?.invoiceRef,
+        amount: pi.amount_received
+          ? { minorAmount: pi.amount_received, currency: pi.currency }
+          : undefined,
+      };
+    }
+    case "payment_intent.payment_failed": {
+      const pi = event.data.object as Stripe.PaymentIntent;
+      return {
+        ...base,
+        type: "PAYMENT_FAILED",
+        providerPaymentRef: pi.id,
+        invoiceRef: pi.metadata?.invoiceRef,
+        failureCode: pi.last_payment_error?.code ?? undefined,
+        failureMessage: pi.last_payment_error?.message ?? undefined,
+      };
+    }
+    case "charge.refunded": {
+      const charge = event.data.object as Stripe.Charge;
+      return {
+        ...base,
+        type: "REFUND_SUCCEEDED",
+        providerPaymentRef:
+          typeof charge.payment_intent === "string"
+            ? charge.payment_intent
+            : undefined,
+        providerRefundRef: charge.refunds?.data?.[0]?.id,
+        invoiceRef: charge.metadata?.invoiceRef,
+        amount: {
+          minorAmount: charge.amount_refunded,
+          currency: charge.currency,
+        },
+      };
+    }
+    case "account.updated": {
+      const account = event.data.object as Stripe.Account;
+      return {
+        ...base,
+        type: "ACCOUNT_UPDATED",
+        accountRef: account.id,
+      };
+    }
+    default:
+      return null;
+  }
+}
+
+/**
+ * Stripe Standard Connect adapter implementing PaymentProviderPort on the direct-charge model.
+ *
+ * Every payment and refund uses `stripeAccount: <clinic stripeAccountId>` so the charge is
+ * created in the clinic's account (the clinic is the merchant of record and bears fees, disputes,
+ * and negative-balance liability). The platform has zero regulatory exposure.
+ *
+ * Inject a mocked Stripe client via the constructor in tests; call StripeProviderAdapter.fromEnv()
+ * in production.
+ */
+export class StripeProviderAdapter implements PaymentProviderPort {
+  readonly provider: ProviderId = "STRIPE";
+  readonly capabilities: ProviderCapabilities = {
+    hostedCheckout: true,
+    paymentIntent: true,
+    automaticTax: true,
+    hostedReceipts: true,
+    asyncRefunds: false,
+  };
+
+  constructor(
+    private readonly stripe: Stripe,
+    private readonly webhookSecret: string,
+  ) {}
+
+  static fromEnv(): StripeProviderAdapter {
+    const apiKey = process.env.STRIPE_SECRET_KEY;
+    if (!apiKey) throw new Error("STRIPE_SECRET_KEY is not configured");
+    return new StripeProviderAdapter(
+      new Stripe(apiKey, { apiVersion: API_VERSION }),
+      process.env.STRIPE_WEBHOOK_SECRET ?? "",
+    );
+  }
+
+  async createOrGetConnectedAccount(
+    orgId: string,
+  ): Promise<{ accountRef: string }> {
+    const org = await prisma.organization.findUnique({
+      where: { id: orgId },
+      select: { stripeAccountId: true },
+    });
+    if (org?.stripeAccountId) return { accountRef: org.stripeAccountId };
+
+    const account = await this.stripe.accounts.create({ type: "standard" });
+
+    await Promise.all([
+      prisma.organization.update({
+        where: { id: orgId },
+        data: { stripeAccountId: account.id },
+      }),
+      prisma.organizationBilling.upsert({
+        where: { orgId },
+        create: { orgId, connectAccountId: account.id },
+        update: { connectAccountId: account.id },
+      }),
+    ]);
+
+    return { accountRef: account.id };
+  }
+
+  async createOnboardingLink(
+    orgId: string,
+  ): Promise<{ url?: string; clientSecret?: string }> {
+    const { accountRef } = await this.createOrGetConnectedAccount(orgId);
+    const session = await this.stripe.accountSessions.create({
+      account: accountRef,
+      components: { account_onboarding: { enabled: true } },
+    });
+    return { clientSecret: session.client_secret };
+  }
+
+  async getAccountStatus(orgId: string): Promise<AccountReadiness> {
+    const [org, orgBilling] = await Promise.all([
+      prisma.organization.findUnique({
+        where: { id: orgId },
+        select: { stripeAccountId: true },
+      }),
+      prisma.organizationBilling.findUnique({
+        where: { orgId },
+        select: {
+          connectAccountId: true,
+          canAcceptPayments: true,
+          connectChargesEnabled: true,
+          connectPayoutsEnabled: true,
+          connectDisabledReason: true,
+        },
+      }),
+    ]);
+
+    const accountRef =
+      org?.stripeAccountId ?? orgBilling?.connectAccountId ?? null;
+
+    let onboardingState: AccountReadiness["onboardingState"];
+    if (!accountRef) {
+      onboardingState = "NOT_STARTED";
+    } else if (orgBilling?.connectDisabledReason) {
+      onboardingState = "DISABLED";
+    } else if (orgBilling?.canAcceptPayments) {
+      onboardingState = "READY";
+    } else {
+      onboardingState = "IN_PROGRESS";
+    }
+
+    return {
+      accountRef,
+      onboardingState,
+      chargesEnabled: orgBilling?.connectChargesEnabled ?? false,
+      payoutsEnabled: orgBilling?.connectPayoutsEnabled ?? false,
+      disabledReason: orgBilling?.connectDisabledReason ?? null,
+    };
+  }
+
+  async createCheckoutSession(
+    input: NormalizedCheckoutInput,
+  ): Promise<CheckoutSessionResult> {
+    if (
+      !Number.isInteger(input.amount.minorAmount) ||
+      input.amount.minorAmount <= 0
+    ) {
+      throw new PaymentProviderError(
+        `Amount must be a positive integer in minor units, received ${JSON.stringify(input.amount.minorAmount)}`,
+        "INVALID_AMOUNT",
+      );
+    }
+    validateCurrency(input.amount.currency);
+
+    const accountRef = await this.resolveAccountRef(input.orgId);
+    const session = await this.stripe.checkout.sessions.create(
+      {
+        mode: "payment",
+        line_items: [
+          {
+            price_data: {
+              currency: input.amount.currency.toLowerCase(),
+              unit_amount: input.amount.minorAmount,
+              product_data: { name: `Invoice ${input.invoiceRef}` },
+            },
+            quantity: 1,
+          },
+        ],
+        success_url: input.successUrl,
+        cancel_url: input.cancelUrl,
+        metadata: {
+          invoiceRef: input.invoiceRef,
+          orgId: input.orgId,
+          ...(input.metadata ?? {}),
+        },
+      },
+      { stripeAccount: accountRef, idempotencyKey: input.idempotencyKey },
+    );
+
+    return {
+      providerRef: session.id,
+      redirectUrl: session.url ?? undefined,
+    };
+  }
+
+  async createPayment(
+    input: NormalizedPaymentInput,
+  ): Promise<CreatePaymentResult> {
+    validateCurrency(input.amount.currency);
+
+    const accountRef = await this.resolveAccountRef(input.orgId);
+    const intent = await this.stripe.paymentIntents.create(
+      {
+        amount: input.amount.minorAmount,
+        currency: input.amount.currency.toLowerCase(),
+        metadata: {
+          invoiceRef: input.invoiceRef,
+          orgId: input.orgId,
+          ...(input.metadata ?? {}),
+        },
+      },
+      { stripeAccount: accountRef, idempotencyKey: input.idempotencyKey },
+    );
+
+    return {
+      providerPaymentRef: intent.id,
+      clientSecret: intent.client_secret ?? undefined,
+      status: mapPaymentStatus(intent.status),
+    };
+  }
+
+  async refund(input: NormalizedRefundInput): Promise<RefundResult> {
+    if (
+      !Number.isInteger(input.amount.minorAmount) ||
+      input.amount.minorAmount <= 0
+    ) {
+      throw new PaymentProviderError(
+        `Amount must be a positive integer in minor units, received ${JSON.stringify(input.amount.minorAmount)}`,
+        "INVALID_AMOUNT",
+      );
+    }
+
+    const accountRef = await this.resolveAccountRef(input.orgId);
+    try {
+      const refund = await this.stripe.refunds.create(
+        {
+          payment_intent: input.providerPaymentRef,
+          amount: input.amount.minorAmount,
+        },
+        { stripeAccount: accountRef, idempotencyKey: input.idempotencyKey },
+      );
+      return {
+        providerRefundRef: refund.id,
+        status: mapRefundStatus(refund.status),
+      };
+    } catch (err) {
+      mapStripeRefundError(err, input.providerPaymentRef);
+    }
+  }
+
+  verifyAndNormalizeWebhook(
+    rawBody: Buffer,
+    headers: Record<string, string | string[] | undefined>,
+  ): NormalizedPaymentEvent[] {
+    const sig = headers["stripe-signature"];
+    if (!sig)
+      throw new WebhookVerificationError("Missing stripe-signature header");
+
+    let event: Stripe.Event;
+    try {
+      event = this.stripe.webhooks.constructEvent(
+        rawBody,
+        Array.isArray(sig) ? sig[0] : sig,
+        this.webhookSecret,
+      );
+    } catch {
+      throw new WebhookVerificationError();
+    }
+
+    const normalized = normalizeStripeEvent(event);
+    return normalized ? [normalized] : [];
+  }
+
+  private async resolveAccountRef(orgId: string): Promise<string> {
+    const org = await prisma.organization.findUnique({
+      where: { id: orgId },
+      select: { stripeAccountId: true },
+    });
+    if (!org?.stripeAccountId) {
+      throw new PaymentProviderError(
+        `Organisation ${orgId} has no Stripe connected account`,
+        "ACCOUNT_NOT_FOUND",
+      );
+    }
+    return org.stripeAccountId;
+  }
+}

--- a/apps/backend/src/services/payments/stripe.adapter.ts
+++ b/apps/backend/src/services/payments/stripe.adapter.ts
@@ -88,7 +88,7 @@ function normalizeStripeEvent(
   const base = { providerEventRef: event.id };
   switch (event.type) {
     case "payment_intent.succeeded": {
-      const pi = event.data.object as Stripe.PaymentIntent;
+      const pi = event.data.object;
       return {
         ...base,
         type: "PAYMENT_SUCCEEDED",
@@ -100,7 +100,7 @@ function normalizeStripeEvent(
       };
     }
     case "payment_intent.payment_failed": {
-      const pi = event.data.object as Stripe.PaymentIntent;
+      const pi = event.data.object;
       return {
         ...base,
         type: "PAYMENT_FAILED",
@@ -111,7 +111,7 @@ function normalizeStripeEvent(
       };
     }
     case "charge.refunded": {
-      const charge = event.data.object as Stripe.Charge;
+      const charge = event.data.object;
       return {
         ...base,
         type: "REFUND_SUCCEEDED",
@@ -128,7 +128,7 @@ function normalizeStripeEvent(
       };
     }
     case "account.updated": {
-      const account = event.data.object as Stripe.Account;
+      const account = event.data.object;
       return {
         ...base,
         type: "ACCOUNT_UPDATED",

--- a/apps/backend/src/services/payments/types.ts
+++ b/apps/backend/src/services/payments/types.ts
@@ -9,7 +9,7 @@
  * anywhere in these types. See docs/guide/payment-gateway-multi-provider-plan.md.
  */
 
-export type ProviderId = "STRIPE" | "ADYEN" | "MANUAL";
+export type ProviderId = "STRIPE" | "CARECREDIT" | "SCRATCHPAY" | "MANUAL";
 
 export type PaymentAttemptStatus =
   | "REQUIRES_ACTION"

--- a/apps/backend/src/services/payments/types.ts
+++ b/apps/backend/src/services/payments/types.ts
@@ -1,0 +1,120 @@
+/**
+ * Provider-agnostic payment types shared by the payment-gateway port, the
+ * registry, and every provider adapter. These are the normalized shapes the rest
+ * of finance speaks; adapters translate provider-specific payloads to and from
+ * them. Money is always carried in integer minor units (see MoneyAmount).
+ *
+ * Settlement model: the clinic (connected account) is the merchant of record on
+ * every provider and the platform takes no fee, so there is no fee or split field
+ * anywhere in these types. See docs/guide/payment-gateway-multi-provider-plan.md.
+ */
+
+export type ProviderId = "STRIPE" | "ADYEN" | "MANUAL";
+
+export type PaymentAttemptStatus =
+  | "REQUIRES_ACTION"
+  | "PROCESSING"
+  | "SUCCEEDED"
+  | "FAILED"
+  | "CANCELED";
+
+export type RefundStatus = "PENDING" | "SUCCEEDED" | "FAILED";
+
+export type AccountOnboardingState =
+  | "NOT_STARTED"
+  | "IN_PROGRESS"
+  | "READY"
+  | "DISABLED";
+
+export interface ProviderCapabilities {
+  /** Supports a hosted checkout page the payer is redirected to. */
+  hostedCheckout: boolean;
+  /** Supports a payment-intent style flow with a client secret. */
+  paymentIntent: boolean;
+  /** Provider computes and collects tax on the charge. */
+  automaticTax: boolean;
+  /** Provider issues its own receipts to the payer. */
+  hostedReceipts: boolean;
+  /** Refunds and captures are confirmed asynchronously via webhook. */
+  asyncRefunds: boolean;
+}
+
+export interface AccountReadiness {
+  accountRef: string | null;
+  onboardingState: AccountOnboardingState;
+  chargesEnabled: boolean;
+  payoutsEnabled: boolean;
+  disabledReason: string | null;
+}
+
+/** An amount in the smallest unit of a currency (cents, yen, fils). */
+export interface MoneyAmount {
+  /** Integer minor units. Build with the packages/lib money helper. */
+  minorAmount: number;
+  /** ISO 4217 currency code. */
+  currency: string;
+}
+
+export interface NormalizedCheckoutInput {
+  orgId: string;
+  invoiceRef: string;
+  amount: MoneyAmount;
+  successUrl: string;
+  cancelUrl: string;
+  idempotencyKey: string;
+  metadata?: Record<string, string>;
+}
+
+export interface NormalizedPaymentInput {
+  orgId: string;
+  invoiceRef: string;
+  amount: MoneyAmount;
+  idempotencyKey: string;
+  metadata?: Record<string, string>;
+}
+
+export interface NormalizedRefundInput {
+  orgId: string;
+  providerPaymentRef: string;
+  /** Refund amount in minor units; equal to the captured amount for a full refund. */
+  amount: MoneyAmount;
+  idempotencyKey: string;
+  reason?: string;
+}
+
+export type NormalizedPaymentEventType =
+  | "PAYMENT_SUCCEEDED"
+  | "PAYMENT_FAILED"
+  | "REFUND_SUCCEEDED"
+  | "REFUND_FAILED"
+  | "ACCOUNT_UPDATED";
+
+export interface NormalizedPaymentEvent {
+  /** Stable provider event id, used for webhook de-duplication. */
+  providerEventRef: string;
+  type: NormalizedPaymentEventType;
+  invoiceRef?: string;
+  providerPaymentRef?: string;
+  providerRefundRef?: string;
+  accountRef?: string;
+  amount?: MoneyAmount;
+  failureCode?: string;
+  failureMessage?: string;
+}
+
+export interface CheckoutSessionResult {
+  providerRef: string;
+  redirectUrl?: string;
+  clientToken?: string;
+}
+
+export interface CreatePaymentResult {
+  providerPaymentRef: string;
+  clientSecret?: string;
+  status: PaymentAttemptStatus;
+}
+
+export interface RefundResult {
+  providerRefundRef: string;
+  status: RefundStatus;
+}

--- a/apps/backend/src/services/payments/webhook.service.ts
+++ b/apps/backend/src/services/payments/webhook.service.ts
@@ -1,0 +1,169 @@
+import { prisma } from "src/config/prisma";
+import logger from "src/utils/logger";
+import type { PaymentProviderRegistry } from "./registry";
+import type { NormalizedPaymentEvent, ProviderId } from "./types";
+import { WebhookVerificationError } from "./errors";
+
+export class PaymentWebhookService {
+  constructor(private readonly registry: PaymentProviderRegistry) {}
+
+  /**
+   * Verify, deduplicate, and dispatch a raw provider webhook.
+   * Returns the count of new events processed (duplicates are silently skipped).
+   */
+  async handle(
+    providerId: ProviderId,
+    rawBody: Buffer,
+    headers: Record<string, string | string[] | undefined>,
+  ): Promise<number> {
+    const adapter = this.registry.get(providerId);
+    const events = adapter.verifyAndNormalizeWebhook(rawBody, headers);
+
+    let dispatched = 0;
+    for (const event of events) {
+      const isNew = await this.markProcessed(
+        event.providerEventRef,
+        providerId,
+      );
+      if (!isNew) continue;
+
+      await this.dispatch(event);
+      dispatched++;
+    }
+    return dispatched;
+  }
+
+  private async markProcessed(
+    providerEventRef: string,
+    providerId: string,
+  ): Promise<boolean> {
+    try {
+      await prisma.processedWebhookEvent.create({
+        data: { providerEventRef, providerId },
+      });
+      return true;
+    } catch {
+      // Unique constraint violation = already processed.
+      return false;
+    }
+  }
+
+  private async dispatch(event: NormalizedPaymentEvent): Promise<void> {
+    try {
+      switch (event.type) {
+        case "PAYMENT_SUCCEEDED":
+          await this.onPaymentSucceeded(event);
+          break;
+        case "PAYMENT_FAILED":
+          await this.onPaymentFailed(event);
+          break;
+        case "REFUND_SUCCEEDED":
+          await this.onRefundSucceeded(event);
+          break;
+        case "REFUND_FAILED":
+          await this.onRefundFailed(event);
+          break;
+        case "ACCOUNT_UPDATED":
+          await this.onAccountUpdated(event);
+          break;
+      }
+    } catch (err) {
+      logger.error("PaymentWebhookService: dispatch failed", {
+        eventRef: event.providerEventRef,
+        type: event.type,
+        err,
+      });
+    }
+  }
+
+  private async onPaymentSucceeded(
+    event: NormalizedPaymentEvent,
+  ): Promise<void> {
+    if (!event.providerPaymentRef) return;
+
+    const attempt = await prisma.paymentAttempt.findFirst({
+      where: { providerPaymentIntentId: event.providerPaymentRef },
+    });
+    if (!attempt) return;
+
+    await prisma.$transaction([
+      prisma.paymentAttempt.update({
+        where: { id: attempt.id },
+        data: {
+          status: "SUCCEEDED",
+          amountCaptured: event.amount?.minorAmount ?? attempt.amountRequested,
+        },
+      }),
+      prisma.payment.upsert({
+        where: { paymentAttemptId: attempt.id },
+        update: { status: "SUCCEEDED", paidAt: new Date() },
+        create: {
+          invoiceId: attempt.invoiceId,
+          paymentAttemptId: attempt.id,
+          provider: attempt.provider,
+          providerPaymentId: event.providerPaymentRef,
+          amount: event.amount?.minorAmount ?? attempt.amountRequested,
+          currency: event.amount?.currency ?? attempt.currency,
+          status: "SUCCEEDED",
+          paidAt: new Date(),
+        },
+      }),
+    ]);
+  }
+
+  private async onPaymentFailed(event: NormalizedPaymentEvent): Promise<void> {
+    if (!event.providerPaymentRef) return;
+
+    await prisma.paymentAttempt.updateMany({
+      where: { providerPaymentIntentId: event.providerPaymentRef },
+      data: {
+        status: "FAILED",
+        failureCode: event.failureCode ?? null,
+        failureMessage: event.failureMessage ?? null,
+      },
+    });
+  }
+
+  private async onRefundSucceeded(
+    event: NormalizedPaymentEvent,
+  ): Promise<void> {
+    if (!event.providerRefundRef) return;
+
+    await prisma.refund.updateMany({
+      where: { providerRefundId: event.providerRefundRef },
+      data: { status: "SUCCEEDED" },
+    });
+  }
+
+  private async onRefundFailed(event: NormalizedPaymentEvent): Promise<void> {
+    if (!event.providerRefundRef) return;
+
+    await prisma.refund.updateMany({
+      where: { providerRefundId: event.providerRefundRef },
+      data: { status: "FAILED" },
+    });
+  }
+
+  private async onAccountUpdated(event: NormalizedPaymentEvent): Promise<void> {
+    if (!event.accountRef) return;
+
+    const billing = await prisma.organizationBilling.findFirst({
+      where: { connectAccountId: event.accountRef },
+      select: { orgId: true },
+    });
+    if (!billing) return;
+
+    const adapter = this.registry.get("STRIPE");
+    const status = await adapter.getAccountStatus(billing.orgId);
+
+    await prisma.organizationBilling.updateMany({
+      where: { connectAccountId: event.accountRef },
+      data: {
+        canAcceptPayments: status.chargesEnabled,
+        connectChargesEnabled: status.chargesEnabled,
+        connectPayoutsEnabled: status.payoutsEnabled,
+        connectDisabledReason: status.disabledReason,
+      },
+    });
+  }
+}

--- a/apps/backend/src/services/payments/webhook.service.ts
+++ b/apps/backend/src/services/payments/webhook.service.ts
@@ -2,7 +2,6 @@ import { prisma } from "src/config/prisma";
 import logger from "src/utils/logger";
 import type { PaymentProviderRegistry } from "./registry";
 import type { NormalizedPaymentEvent, ProviderId } from "./types";
-import { WebhookVerificationError } from "./errors";
 
 export class PaymentWebhookService {
   constructor(private readonly registry: PaymentProviderRegistry) {}

--- a/apps/backend/test/controllers/finance.controller.test.ts
+++ b/apps/backend/test/controllers/finance.controller.test.ts
@@ -107,7 +107,7 @@ describe("FinanceController", () => {
   it("rejects unsupported payment providers", async () => {
     const req = {
       params: { invoiceId: "inv_1" },
-      body: { provider: "adyen" },
+      body: { provider: "unknown_provider" },
     } as unknown as Request;
     const res = {
       status: jest.fn().mockReturnThis(),
@@ -197,7 +197,7 @@ describe("FinanceController", () => {
 
   it("rejects unsupported webhook providers", async () => {
     const req = {
-      params: { provider: "adyen" },
+      params: { provider: "unknown_provider" },
     } as unknown as Request;
     const res = {
       status: jest.fn().mockReturnThis(),

--- a/apps/backend/test/services/payments/fake-gateway.contract.test.ts
+++ b/apps/backend/test/services/payments/fake-gateway.contract.test.ts
@@ -1,0 +1,93 @@
+import { FakeGateway, WebhookVerificationError } from "src/services/payments";
+import type { NormalizedPaymentEvent } from "src/services/payments";
+
+import {
+  runPaymentProviderContract,
+  type ProviderContractHarness,
+} from "./provider-contract";
+
+const harness: ProviderContractHarness = {
+  providerLabel: "fake",
+  makeGateway: () => new FakeGateway(),
+  makeValidWebhook: (gateway) => {
+    const fake = gateway as FakeGateway;
+    const expected: NormalizedPaymentEvent = {
+      providerEventRef: "evt_1",
+      type: "PAYMENT_SUCCEEDED",
+      invoiceRef: "inv_1",
+      providerPaymentRef: "fake_pi_1",
+      amount: { minorAmount: 1999, currency: "USD" },
+    };
+    const { rawBody, headers } = fake.buildSignedWebhook(expected);
+    return { rawBody, headers, expected };
+  },
+  makeTamperedWebhook: (gateway) => {
+    const fake = gateway as FakeGateway;
+    const { rawBody } = fake.buildSignedWebhook({
+      providerEventRef: "evt_2",
+      type: "PAYMENT_FAILED",
+    });
+    return { rawBody, headers: { "x-fake-signature": "0".repeat(64) } };
+  },
+};
+
+runPaymentProviderContract(harness);
+
+describe("FakeGateway specifics", () => {
+  it("honours an explicit provider id and webhook secret", () => {
+    const gateway = new FakeGateway({
+      provider: "STRIPE",
+      webhookSecret: "s3cret",
+    });
+    expect(gateway.provider).toBe("STRIPE");
+  });
+
+  it("returns a null account ref before any account exists", async () => {
+    const gateway = new FakeGateway();
+    const status = await gateway.getAccountStatus("org_unknown");
+    expect(status.accountRef).toBeNull();
+    expect(status.onboardingState).toBe("NOT_STARTED");
+    expect(status.chargesEnabled).toBe(false);
+  });
+
+  it("moves to in-progress when an onboarding link is created", async () => {
+    const gateway = new FakeGateway();
+    await gateway.createOnboardingLink("org_1");
+    const status = await gateway.getAccountStatus("org_1");
+    expect(status.onboardingState).toBe("IN_PROGRESS");
+  });
+
+  it("becomes ready once the account is marked ready", async () => {
+    const gateway = new FakeGateway();
+    await gateway.createOrGetConnectedAccount("org_1");
+    gateway.markAccountReady("org_1");
+    const status = await gateway.getAccountStatus("org_1");
+    expect(status.onboardingState).toBe("READY");
+    expect(status.chargesEnabled).toBe(true);
+    expect(status.payoutsEnabled).toBe(true);
+  });
+
+  it("normalizes a batch of events from one signed payload", () => {
+    const gateway = new FakeGateway();
+    const { rawBody, headers } = gateway.buildSignedWebhook([
+      { providerEventRef: "evt_a", type: "PAYMENT_SUCCEEDED" },
+      { providerEventRef: "evt_b", type: "REFUND_SUCCEEDED" },
+    ]);
+    const events = gateway.verifyAndNormalizeWebhook(rawBody, headers);
+    expect(events.map((event) => event.providerEventRef)).toEqual([
+      "evt_a",
+      "evt_b",
+    ]);
+  });
+
+  it("rejects a webhook with a missing signature header", () => {
+    const gateway = new FakeGateway();
+    const { rawBody } = gateway.buildSignedWebhook({
+      providerEventRef: "evt_c",
+      type: "ACCOUNT_UPDATED",
+    });
+    expect(() => gateway.verifyAndNormalizeWebhook(rawBody, {})).toThrow(
+      WebhookVerificationError,
+    );
+  });
+});

--- a/apps/backend/test/services/payments/provider-contract.ts
+++ b/apps/backend/test/services/payments/provider-contract.ts
@@ -1,0 +1,211 @@
+import {
+  PaymentProviderError,
+  RefundExceedsCaptureError,
+  UnknownPaymentError,
+  WebhookVerificationError,
+} from "src/services/payments";
+import type {
+  NormalizedPaymentEvent,
+  PaymentProviderPort,
+} from "src/services/payments";
+
+/**
+ * A harness binds the provider-agnostic contract to one implementation. Every
+ * provider (the fake, and later the Stripe and Adyen adapters) supplies one of
+ * these, so they all prove identical behaviour against the same assertions.
+ */
+export interface ProviderContractHarness {
+  providerLabel: string;
+  makeGateway(): PaymentProviderPort;
+  makeValidWebhook(gateway: PaymentProviderPort): {
+    rawBody: Buffer;
+    headers: Record<string, string | string[] | undefined>;
+    expected: NormalizedPaymentEvent;
+  };
+  makeTamperedWebhook(gateway: PaymentProviderPort): {
+    rawBody: Buffer;
+    headers: Record<string, string | string[] | undefined>;
+  };
+}
+
+const usd = (minorAmount: number) => ({ minorAmount, currency: "USD" });
+
+const PAYMENT_STATUSES = [
+  "REQUIRES_ACTION",
+  "PROCESSING",
+  "SUCCEEDED",
+  "FAILED",
+  "CANCELED",
+];
+const REFUND_STATUSES = ["PENDING", "SUCCEEDED", "FAILED"];
+const ONBOARDING_STATES = ["NOT_STARTED", "IN_PROGRESS", "READY", "DISABLED"];
+
+export function runPaymentProviderContract(
+  harness: ProviderContractHarness,
+): void {
+  describe(`PaymentProviderPort contract: ${harness.providerLabel}`, () => {
+    let gateway: PaymentProviderPort;
+
+    beforeEach(() => {
+      gateway = harness.makeGateway();
+    });
+
+    it("exposes a provider id and a complete capabilities descriptor", () => {
+      expect(["STRIPE", "ADYEN", "MANUAL"]).toContain(gateway.provider);
+      const capabilities = gateway.capabilities;
+      for (const key of [
+        "hostedCheckout",
+        "paymentIntent",
+        "automaticTax",
+        "hostedReceipts",
+        "asyncRefunds",
+      ] as const) {
+        expect(typeof capabilities[key]).toBe("boolean");
+      }
+    });
+
+    it("creates a connected account idempotently per org", async () => {
+      const first = await gateway.createOrGetConnectedAccount("org_1");
+      const again = await gateway.createOrGetConnectedAccount("org_1");
+      expect(first.accountRef).toBeTruthy();
+      expect(again.accountRef).toBe(first.accountRef);
+
+      const other = await gateway.createOrGetConnectedAccount("org_2");
+      expect(other.accountRef).not.toBe(first.accountRef);
+    });
+
+    it("returns an onboarding link", async () => {
+      const link = await gateway.createOnboardingLink("org_1");
+      expect(Boolean(link.url) || Boolean(link.clientSecret)).toBe(true);
+    });
+
+    it("reports well-formed account readiness", async () => {
+      const status = await gateway.getAccountStatus("org_1");
+      expect(ONBOARDING_STATES).toContain(status.onboardingState);
+      expect(typeof status.chargesEnabled).toBe("boolean");
+      expect(typeof status.payoutsEnabled).toBe("boolean");
+    });
+
+    it("creates a checkout session and rejects an invalid amount", async () => {
+      const session = await gateway.createCheckoutSession({
+        orgId: "org_1",
+        invoiceRef: "inv_1",
+        amount: usd(1999),
+        successUrl: "https://app.test/ok",
+        cancelUrl: "https://app.test/cancel",
+        idempotencyKey: "cs-1",
+      });
+      expect(session.providerRef).toBeTruthy();
+
+      await expect(
+        gateway.createCheckoutSession({
+          orgId: "org_1",
+          invoiceRef: "inv_2",
+          amount: usd(0),
+          successUrl: "https://app.test/ok",
+          cancelUrl: "https://app.test/cancel",
+          idempotencyKey: "cs-2",
+        }),
+      ).rejects.toBeInstanceOf(PaymentProviderError);
+    });
+
+    it("rejects an invalid currency code", async () => {
+      await expect(
+        gateway.createPayment({
+          orgId: "org_1",
+          invoiceRef: "inv_1",
+          amount: { minorAmount: 1000, currency: "US" },
+          idempotencyKey: "pi-bad-ccy",
+        }),
+      ).rejects.toBeInstanceOf(PaymentProviderError);
+    });
+
+    it("creates payments idempotently with a valid status", async () => {
+      const first = await gateway.createPayment({
+        orgId: "org_1",
+        invoiceRef: "inv_1",
+        amount: usd(1999),
+        idempotencyKey: "pi-1",
+      });
+      expect(PAYMENT_STATUSES).toContain(first.status);
+
+      const repeat = await gateway.createPayment({
+        orgId: "org_1",
+        invoiceRef: "inv_1",
+        amount: usd(1999),
+        idempotencyKey: "pi-1",
+      });
+      expect(repeat.providerPaymentRef).toBe(first.providerPaymentRef);
+
+      const distinct = await gateway.createPayment({
+        orgId: "org_1",
+        invoiceRef: "inv_1",
+        amount: usd(1999),
+        idempotencyKey: "pi-2",
+      });
+      expect(distinct.providerPaymentRef).not.toBe(first.providerPaymentRef);
+    });
+
+    it("refunds up to the captured amount, idempotently, and rejects over-refunds", async () => {
+      const payment = await gateway.createPayment({
+        orgId: "org_1",
+        invoiceRef: "inv_1",
+        amount: usd(1000),
+        idempotencyKey: "pi-1",
+      });
+
+      const refund = await gateway.refund({
+        orgId: "org_1",
+        providerPaymentRef: payment.providerPaymentRef,
+        amount: usd(400),
+        idempotencyKey: "re-1",
+      });
+      expect(refund.providerRefundRef).toBeTruthy();
+      expect(REFUND_STATUSES).toContain(refund.status);
+
+      const repeat = await gateway.refund({
+        orgId: "org_1",
+        providerPaymentRef: payment.providerPaymentRef,
+        amount: usd(400),
+        idempotencyKey: "re-1",
+      });
+      expect(repeat.providerRefundRef).toBe(refund.providerRefundRef);
+
+      // 400 already refunded; 700 more would exceed the 1000 captured.
+      await expect(
+        gateway.refund({
+          orgId: "org_1",
+          providerPaymentRef: payment.providerPaymentRef,
+          amount: usd(700),
+          idempotencyKey: "re-2",
+        }),
+      ).rejects.toBeInstanceOf(RefundExceedsCaptureError);
+    });
+
+    it("rejects refunds for an unknown payment", async () => {
+      await expect(
+        gateway.refund({
+          orgId: "org_1",
+          providerPaymentRef: "does_not_exist",
+          amount: usd(100),
+          idempotencyKey: "re-x",
+        }),
+      ).rejects.toBeInstanceOf(UnknownPaymentError);
+    });
+
+    it("verifies and normalizes a valid webhook", () => {
+      const { rawBody, headers, expected } = harness.makeValidWebhook(gateway);
+      const events = gateway.verifyAndNormalizeWebhook(rawBody, headers);
+      expect(events.length).toBeGreaterThan(0);
+      expect(events[0].providerEventRef).toBe(expected.providerEventRef);
+      expect(events[0].type).toBe(expected.type);
+    });
+
+    it("rejects a tampered webhook", () => {
+      const { rawBody, headers } = harness.makeTamperedWebhook(gateway);
+      expect(() => gateway.verifyAndNormalizeWebhook(rawBody, headers)).toThrow(
+        WebhookVerificationError,
+      );
+    });
+  });
+}

--- a/apps/backend/test/services/payments/provider-contract.ts
+++ b/apps/backend/test/services/payments/provider-contract.ts
@@ -11,7 +11,7 @@ import type {
 
 /**
  * A harness binds the provider-agnostic contract to one implementation. Every
- * provider (the fake, and later the Stripe and Adyen adapters) supplies one of
+ * provider (the fake, and later the Stripe, CareCredit, and Scratchpay adapters) supplies one of
  * these, so they all prove identical behaviour against the same assertions.
  */
 export interface ProviderContractHarness {
@@ -51,7 +51,9 @@ export function runPaymentProviderContract(
     });
 
     it("exposes a provider id and a complete capabilities descriptor", () => {
-      expect(["STRIPE", "ADYEN", "MANUAL"]).toContain(gateway.provider);
+      expect(["STRIPE", "CARECREDIT", "SCRATCHPAY", "MANUAL"]).toContain(
+        gateway.provider,
+      );
       const capabilities = gateway.capabilities;
       for (const key of [
         "hostedCheckout",

--- a/apps/backend/test/services/payments/registry.test.ts
+++ b/apps/backend/test/services/payments/registry.test.ts
@@ -1,0 +1,46 @@
+import {
+  FakeGateway,
+  PaymentProviderRegistry,
+  UnknownProviderError,
+  resolveAdapterForOrg,
+} from "src/services/payments";
+
+describe("PaymentProviderRegistry", () => {
+  it("registers and resolves an adapter by provider id", () => {
+    const registry = new PaymentProviderRegistry();
+    const stripe = new FakeGateway({ provider: "STRIPE" });
+    registry.register(stripe);
+    expect(registry.has("STRIPE")).toBe(true);
+    expect(registry.get("STRIPE")).toBe(stripe);
+  });
+
+  it("throws UnknownProviderError for an unregistered provider", () => {
+    const registry = new PaymentProviderRegistry();
+    expect(registry.has("ADYEN")).toBe(false);
+    expect(() => registry.get("ADYEN")).toThrow(UnknownProviderError);
+  });
+
+  it("lists registered providers", () => {
+    const registry = new PaymentProviderRegistry();
+    registry.register(new FakeGateway({ provider: "STRIPE" }));
+    registry.register(new FakeGateway({ provider: "MANUAL" }));
+    expect(registry.list().sort()).toEqual(["MANUAL", "STRIPE"]);
+  });
+
+  it("resolves the adapter for an org's active provider", () => {
+    const registry = new PaymentProviderRegistry();
+    const stripe = new FakeGateway({ provider: "STRIPE" });
+    registry.register(stripe);
+    expect(resolveAdapterForOrg(registry, "STRIPE")).toBe(stripe);
+  });
+
+  it("replaces the adapter when a provider is registered again", () => {
+    const registry = new PaymentProviderRegistry();
+    const first = new FakeGateway({ provider: "STRIPE" });
+    const second = new FakeGateway({ provider: "STRIPE" });
+    registry.register(first);
+    registry.register(second);
+    expect(registry.get("STRIPE")).toBe(second);
+    expect(registry.list()).toEqual(["STRIPE"]);
+  });
+});

--- a/apps/backend/test/services/payments/registry.test.ts
+++ b/apps/backend/test/services/payments/registry.test.ts
@@ -16,8 +16,8 @@ describe("PaymentProviderRegistry", () => {
 
   it("throws UnknownProviderError for an unregistered provider", () => {
     const registry = new PaymentProviderRegistry();
-    expect(registry.has("ADYEN")).toBe(false);
-    expect(() => registry.get("ADYEN")).toThrow(UnknownProviderError);
+    expect(registry.has("CARECREDIT")).toBe(false);
+    expect(() => registry.get("CARECREDIT")).toThrow(UnknownProviderError);
   });
 
   it("lists registered providers", () => {

--- a/apps/backend/test/services/payments/stripe.adapter.contract.test.ts
+++ b/apps/backend/test/services/payments/stripe.adapter.contract.test.ts
@@ -1,0 +1,474 @@
+import Stripe from "stripe";
+
+import { StripeProviderAdapter } from "src/services/payments/stripe.adapter";
+import {
+  RefundExceedsCaptureError,
+  UnknownPaymentError,
+} from "src/services/payments";
+import type { PaymentProviderPort } from "src/services/payments";
+import {
+  runPaymentProviderContract,
+  type ProviderContractHarness,
+} from "./provider-contract";
+
+// ---------------------------------------------------------------------------
+// Prisma mock
+// ---------------------------------------------------------------------------
+
+const mockOrgFindUnique = jest.fn();
+const mockOrgUpdate = jest.fn();
+const mockOrgBillingFindUnique = jest.fn();
+const mockOrgBillingUpsert = jest.fn();
+
+jest.mock("src/config/prisma", () => ({
+  prisma: {
+    organization: {
+      findUnique: (...args: unknown[]) => mockOrgFindUnique(...args),
+      update: (...args: unknown[]) => mockOrgUpdate(...args),
+    },
+    organizationBilling: {
+      findUnique: (...args: unknown[]) => mockOrgBillingFindUnique(...args),
+      upsert: (...args: unknown[]) => mockOrgBillingUpsert(...args),
+    },
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Stripe mock
+// ---------------------------------------------------------------------------
+
+const mockAccountsCreate = jest.fn();
+const mockAccountSessionsCreate = jest.fn();
+const mockCheckoutSessionsCreate = jest.fn();
+const mockPaymentIntentsCreate = jest.fn();
+const mockRefundsCreate = jest.fn();
+const mockWebhooksConstructEvent = jest.fn();
+
+function buildMockStripe(): Stripe {
+  return {
+    accounts: { create: mockAccountsCreate },
+    accountSessions: { create: mockAccountSessionsCreate },
+    checkout: { sessions: { create: mockCheckoutSessionsCreate } },
+    paymentIntents: { create: mockPaymentIntentsCreate },
+    refunds: { create: mockRefundsCreate },
+    webhooks: { constructEvent: mockWebhooksConstructEvent },
+  } as unknown as Stripe;
+}
+
+// ---------------------------------------------------------------------------
+// Per-gateway state (reset by makeGateway before each test)
+// ---------------------------------------------------------------------------
+
+const TEST_WEBHOOK_SECRET = "whsec_test_secret_xxx";
+const VALID_SIG = "t=123,v1=valid_sig_value";
+const TAMPERED_SIG = "t=123,v1=tampered_value";
+
+// Pre-seeded accounts so resolveAccountRef works without calling createOrGetConnectedAccount first
+const SEED_ACCOUNTS: Record<string, string> = {
+  org_1: "acct_seed_org1",
+  org_2: "acct_seed_org2",
+};
+
+const VALID_WEBHOOK_EVENT = {
+  id: "evt_contract_001",
+  type: "payment_intent.succeeded",
+  data: {
+    object: {
+      id: "pi_contract_001",
+      amount_received: 1999,
+      currency: "usd",
+      metadata: { invoiceRef: "inv_1" },
+      last_payment_error: null,
+    },
+  },
+};
+
+let orgAccounts: Map<string, string>;
+let piAmounts: Map<string, number>;
+let piRefunded: Map<string, number>;
+let piByKey: Map<string, { id: string; client_secret: string; status: string }>;
+let reByKey: Map<string, { id: string; status: string }>;
+let seq: number;
+
+function resetState(): void {
+  orgAccounts = new Map(Object.entries(SEED_ACCOUNTS));
+  piAmounts = new Map();
+  piRefunded = new Map();
+  piByKey = new Map();
+  reByKey = new Map();
+  seq = 0;
+}
+
+function nextId(prefix: string): string {
+  seq += 1;
+  return `${prefix}_mock_${seq}`;
+}
+
+function setupMocks(): void {
+  jest.clearAllMocks();
+
+  // Organisation DB mocks (stateful)
+  mockOrgFindUnique.mockImplementation(
+    ({ where: { id } }: { where: { id: string } }) => {
+      const acctId = orgAccounts.get(id);
+      return Promise.resolve(acctId ? { stripeAccountId: acctId } : null);
+    },
+  );
+  mockOrgUpdate.mockImplementation(
+    ({
+      where: { id },
+      data: { stripeAccountId },
+    }: {
+      where: { id: string };
+      data: { stripeAccountId: string };
+    }) => {
+      orgAccounts.set(id, stripeAccountId);
+      return Promise.resolve({ id, stripeAccountId });
+    },
+  );
+  mockOrgBillingFindUnique.mockImplementation(
+    ({ where: { orgId } }: { where: { orgId: string } }) => {
+      const acctId = orgAccounts.get(orgId);
+      return Promise.resolve(
+        acctId
+          ? {
+              connectAccountId: acctId,
+              canAcceptPayments: false,
+              connectChargesEnabled: false,
+              connectPayoutsEnabled: false,
+              connectDisabledReason: null,
+            }
+          : null,
+      );
+    },
+  );
+  mockOrgBillingUpsert.mockImplementation(
+    ({
+      where: { orgId },
+      create,
+    }: {
+      where: { orgId: string };
+      create: { connectAccountId: string };
+    }) => {
+      orgAccounts.set(orgId, create.connectAccountId);
+      return Promise.resolve(create);
+    },
+  );
+
+  // Stripe API mocks (stateful for idempotency and over-refund)
+  mockAccountsCreate.mockImplementation(() =>
+    Promise.resolve({ id: nextId("acct") }),
+  );
+  mockAccountSessionsCreate.mockImplementation(() =>
+    Promise.resolve({ client_secret: nextId("acas") }),
+  );
+  mockCheckoutSessionsCreate.mockImplementation(() => {
+    const id = nextId("cs");
+    return Promise.resolve({
+      id,
+      url: `https://checkout.stripe.com/pay/${id}`,
+    });
+  });
+
+  mockPaymentIntentsCreate.mockImplementation(
+    (
+      params: { amount: number; currency: string },
+      opts?: { idempotencyKey?: string },
+    ) => {
+      const key = opts?.idempotencyKey;
+      if (key && piByKey.has(key)) return Promise.resolve(piByKey.get(key));
+      const pi = {
+        id: nextId("pi"),
+        client_secret: nextId("pi_secret"),
+        status: "succeeded",
+        amount: params.amount,
+      };
+      if (key) piByKey.set(key, pi);
+      piAmounts.set(pi.id, params.amount);
+      return Promise.resolve(pi);
+    },
+  );
+
+  mockRefundsCreate.mockImplementation(
+    (
+      params: { payment_intent: string; amount: number },
+      opts?: { idempotencyKey?: string },
+    ) => {
+      const key = opts?.idempotencyKey;
+      if (key && reByKey.has(key)) return Promise.resolve(reByKey.get(key));
+
+      const captured = piAmounts.get(params.payment_intent);
+      if (captured === undefined) {
+        const err = Object.assign(
+          new Error(`No such payment_intent: '${params.payment_intent}'`),
+          { code: "resource_missing", type: "StripeInvalidRequestError" },
+        );
+        return Promise.reject(err);
+      }
+
+      const alreadyRefunded = piRefunded.get(params.payment_intent) ?? 0;
+      const refundAmount = params.amount ?? captured;
+      if (alreadyRefunded + refundAmount > captured) {
+        const err = Object.assign(
+          new Error("Amount (in cents) is greater than the captured amount"),
+          { code: "amount_too_large", type: "StripeInvalidRequestError" },
+        );
+        return Promise.reject(err);
+      }
+
+      piRefunded.set(params.payment_intent, alreadyRefunded + refundAmount);
+      const re = { id: nextId("re"), status: "succeeded" };
+      if (key) reByKey.set(key, re);
+      return Promise.resolve(re);
+    },
+  );
+
+  mockWebhooksConstructEvent.mockImplementation(
+    (_rawBody: Buffer, sig: string) => {
+      if (sig === VALID_SIG) return VALID_WEBHOOK_EVENT;
+      const err = Object.assign(
+        new Error("No signatures found matching the expected signature"),
+        { type: "StripeSignatureVerificationError" },
+      );
+      throw err;
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Contract harness
+// ---------------------------------------------------------------------------
+
+const stripeHarness: ProviderContractHarness = {
+  providerLabel: "stripe-adapter",
+
+  makeGateway(): PaymentProviderPort {
+    resetState();
+    setupMocks();
+    return new StripeProviderAdapter(buildMockStripe(), TEST_WEBHOOK_SECRET);
+  },
+
+  makeValidWebhook(_gateway) {
+    const rawBody = Buffer.from(JSON.stringify(VALID_WEBHOOK_EVENT), "utf8");
+    return {
+      rawBody,
+      headers: { "stripe-signature": VALID_SIG },
+      expected: {
+        providerEventRef: VALID_WEBHOOK_EVENT.id,
+        type: "PAYMENT_SUCCEEDED",
+      },
+    };
+  },
+
+  makeTamperedWebhook(_gateway) {
+    const rawBody = Buffer.from(JSON.stringify(VALID_WEBHOOK_EVENT), "utf8");
+    return {
+      rawBody,
+      headers: { "stripe-signature": TAMPERED_SIG },
+    };
+  },
+};
+
+// Run the provider-agnostic contract suite against the Stripe adapter
+runPaymentProviderContract(stripeHarness);
+
+// ---------------------------------------------------------------------------
+// Stripe-specific assertions (direct-charge model)
+// ---------------------------------------------------------------------------
+
+describe("StripeProviderAdapter - direct-charge specifics", () => {
+  let gateway: StripeProviderAdapter;
+
+  beforeEach(() => {
+    resetState();
+    setupMocks();
+    gateway = new StripeProviderAdapter(buildMockStripe(), TEST_WEBHOOK_SECRET);
+  });
+
+  it("creates a Standard Connect account for a new org and saves to DB", async () => {
+    // "org_new" is not in the seed map
+    mockOrgFindUnique.mockResolvedValueOnce(null);
+    mockAccountsCreate.mockResolvedValueOnce({ id: "acct_fresh" });
+
+    const result = await gateway.createOrGetConnectedAccount("org_new");
+
+    expect(result.accountRef).toBe("acct_fresh");
+    expect(mockAccountsCreate).toHaveBeenCalledWith({ type: "standard" });
+    expect(mockOrgUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "org_new" },
+        data: { stripeAccountId: "acct_fresh" },
+      }),
+    );
+    expect(mockOrgBillingUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { orgId: "org_new" },
+        update: { connectAccountId: "acct_fresh" },
+      }),
+    );
+  });
+
+  it("passes stripeAccount option on checkout sessions (direct charge)", async () => {
+    await gateway.createCheckoutSession({
+      orgId: "org_1",
+      invoiceRef: "inv_1",
+      amount: { minorAmount: 4999, currency: "USD" },
+      successUrl: "https://app.test/ok",
+      cancelUrl: "https://app.test/cancel",
+      idempotencyKey: "cs-direct-1",
+    });
+
+    expect(mockCheckoutSessionsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: "payment" }),
+      expect.objectContaining({ stripeAccount: SEED_ACCOUNTS.org_1 }),
+    );
+  });
+
+  it("passes stripeAccount option on payment intents (direct charge)", async () => {
+    await gateway.createPayment({
+      orgId: "org_1",
+      invoiceRef: "inv_1",
+      amount: { minorAmount: 2500, currency: "USD" },
+      idempotencyKey: "pi-direct-1",
+    });
+
+    expect(mockPaymentIntentsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ amount: 2500, currency: "usd" }),
+      expect.objectContaining({ stripeAccount: SEED_ACCOUNTS.org_1 }),
+    );
+  });
+
+  it("passes stripeAccount option on refunds (direct charge from clinic balance)", async () => {
+    const payment = await gateway.createPayment({
+      orgId: "org_1",
+      invoiceRef: "inv_1",
+      amount: { minorAmount: 2500, currency: "USD" },
+      idempotencyKey: "pi-for-refund",
+    });
+
+    await gateway.refund({
+      orgId: "org_1",
+      providerPaymentRef: payment.providerPaymentRef,
+      amount: { minorAmount: 500, currency: "USD" },
+      idempotencyKey: "re-direct-1",
+    });
+
+    expect(mockRefundsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ payment_intent: payment.providerPaymentRef }),
+      expect.objectContaining({ stripeAccount: SEED_ACCOUNTS.org_1 }),
+    );
+  });
+
+  it("normalizes payment_intent.payment_failed to PAYMENT_FAILED", () => {
+    const rawEvent = {
+      id: "evt_fail_001",
+      type: "payment_intent.payment_failed",
+      data: {
+        object: {
+          id: "pi_fail_001",
+          metadata: { invoiceRef: "inv_2" },
+          last_payment_error: {
+            code: "card_declined",
+            message: "Your card was declined.",
+          },
+        },
+      },
+    };
+    mockWebhooksConstructEvent.mockReturnValueOnce(rawEvent);
+
+    const rawBody = Buffer.from(JSON.stringify(rawEvent));
+    const events = gateway.verifyAndNormalizeWebhook(rawBody, {
+      "stripe-signature": VALID_SIG,
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe("PAYMENT_FAILED");
+    expect(events[0].failureCode).toBe("card_declined");
+    expect(events[0].invoiceRef).toBe("inv_2");
+  });
+
+  it("normalizes account.updated to ACCOUNT_UPDATED", () => {
+    const rawEvent = {
+      id: "evt_acct_001",
+      type: "account.updated",
+      data: { object: { id: "acct_seed_org1" } },
+    };
+    mockWebhooksConstructEvent.mockReturnValueOnce(rawEvent);
+
+    const rawBody = Buffer.from(JSON.stringify(rawEvent));
+    const events = gateway.verifyAndNormalizeWebhook(rawBody, {
+      "stripe-signature": VALID_SIG,
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe("ACCOUNT_UPDATED");
+    expect(events[0].accountRef).toBe("acct_seed_org1");
+  });
+
+  it("returns empty array for unhandled webhook event types", () => {
+    const rawEvent = {
+      id: "evt_unknown_001",
+      type: "customer.created",
+      data: { object: {} },
+    };
+    mockWebhooksConstructEvent.mockReturnValueOnce(rawEvent);
+
+    const events = gateway.verifyAndNormalizeWebhook(
+      Buffer.from(JSON.stringify(rawEvent)),
+      {
+        "stripe-signature": VALID_SIG,
+      },
+    );
+
+    expect(events).toHaveLength(0);
+  });
+
+  it("throws WebhookVerificationError when stripe-signature header is missing", () => {
+    expect(() =>
+      gateway.verifyAndNormalizeWebhook(Buffer.from("{}"), {}),
+    ).toThrow("Missing stripe-signature header");
+  });
+
+  it("maps Stripe resource_missing to UnknownPaymentError", async () => {
+    await expect(
+      gateway.refund({
+        orgId: "org_1",
+        providerPaymentRef: "pi_does_not_exist",
+        amount: { minorAmount: 100, currency: "USD" },
+        idempotencyKey: "re-missing",
+      }),
+    ).rejects.toBeInstanceOf(UnknownPaymentError);
+  });
+
+  it("maps Stripe amount_too_large to RefundExceedsCaptureError", async () => {
+    const payment = await gateway.createPayment({
+      orgId: "org_1",
+      invoiceRef: "inv_x",
+      amount: { minorAmount: 500, currency: "USD" },
+      idempotencyKey: "pi-over-refund",
+    });
+
+    // over-refund: 600 > 500
+    await expect(
+      gateway.refund({
+        orgId: "org_1",
+        providerPaymentRef: payment.providerPaymentRef,
+        amount: { minorAmount: 600, currency: "USD" },
+        idempotencyKey: "re-over",
+      }),
+    ).rejects.toBeInstanceOf(RefundExceedsCaptureError);
+  });
+
+  it("throws ACCOUNT_NOT_FOUND when org has no stripeAccountId", async () => {
+    mockOrgFindUnique.mockResolvedValue(null);
+
+    await expect(
+      gateway.createPayment({
+        orgId: "org_no_account",
+        invoiceRef: "inv_1",
+        amount: { minorAmount: 1000, currency: "USD" },
+        idempotencyKey: "pi-no-acct",
+      }),
+    ).rejects.toMatchObject({ code: "ACCOUNT_NOT_FOUND" });
+  });
+});

--- a/apps/backend/test/services/payments/webhook.service.test.ts
+++ b/apps/backend/test/services/payments/webhook.service.test.ts
@@ -1,0 +1,421 @@
+import { PaymentWebhookService } from "src/services/payments/webhook.service";
+import { PaymentProviderRegistry } from "src/services/payments/registry";
+import {
+  WebhookVerificationError,
+  UnknownProviderError,
+} from "src/services/payments/errors";
+import type { PaymentProviderPort } from "src/services/payments/port";
+import type { NormalizedPaymentEvent } from "src/services/payments/types";
+import { prisma } from "src/config/prisma";
+
+// ---------------------------------------------------------------------------
+// Prisma mock
+// ---------------------------------------------------------------------------
+
+const mockCreate = jest.fn();
+const mockPaymentAttemptFindFirst = jest.fn();
+const mockPaymentAttemptUpdate = jest.fn();
+const mockPaymentAttemptUpdateMany = jest.fn();
+const mockPaymentUpsert = jest.fn();
+const mockRefundUpdateMany = jest.fn();
+const mockOrgBillingFindFirst = jest.fn();
+const mockOrgBillingUpdateMany = jest.fn();
+
+jest.mock("src/config/prisma", () => ({
+  prisma: {
+    processedWebhookEvent: { create: (...a: unknown[]) => mockCreate(...a) },
+    paymentAttempt: {
+      findFirst: (...a: unknown[]) => mockPaymentAttemptFindFirst(...a),
+      update: (...a: unknown[]) => mockPaymentAttemptUpdate(...a),
+      updateMany: (...a: unknown[]) => mockPaymentAttemptUpdateMany(...a),
+    },
+    payment: { upsert: (...a: unknown[]) => mockPaymentUpsert(...a) },
+    refund: { updateMany: (...a: unknown[]) => mockRefundUpdateMany(...a) },
+    organizationBilling: {
+      findFirst: (...a: unknown[]) => mockOrgBillingFindFirst(...a),
+      updateMany: (...a: unknown[]) => mockOrgBillingUpdateMany(...a),
+    },
+    $transaction: jest.fn((ops: unknown[]) => Promise.all(ops)),
+  },
+}));
+
+jest.mock("src/utils/logger", () => ({
+  __esModule: true,
+  default: { error: jest.fn(), warn: jest.fn(), info: jest.fn() },
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const rawBody = Buffer.from("{}");
+const headers = { "stripe-signature": "sig_test" };
+
+function buildAdapter(
+  events: NormalizedPaymentEvent[],
+  throws?: unknown,
+): PaymentProviderPort {
+  return {
+    provider: "STRIPE",
+    capabilities: {} as never,
+    verifyAndNormalizeWebhook: jest.fn(() => {
+      if (throws) throw throws;
+      return events;
+    }),
+    getAccountStatus: jest.fn().mockResolvedValue({
+      accountRef: "acct_123",
+      onboardingState: "READY",
+      chargesEnabled: true,
+      payoutsEnabled: true,
+      disabledReason: null,
+    }),
+    createOrGetConnectedAccount: jest.fn(),
+    createOnboardingLink: jest.fn(),
+    createCheckoutSession: jest.fn(),
+    createPayment: jest.fn(),
+    refund: jest.fn(),
+  };
+}
+
+function buildService(adapter: PaymentProviderPort) {
+  const registry = new PaymentProviderRegistry();
+  registry.register(adapter);
+  return new PaymentWebhookService(registry);
+}
+
+const baseEvent: NormalizedPaymentEvent = {
+  providerEventRef: "evt_001",
+  type: "PAYMENT_SUCCEEDED",
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Default: create succeeds (new event)
+  mockCreate.mockResolvedValue({});
+  (prisma.$transaction as jest.Mock).mockImplementation((ops: unknown[]) =>
+    Promise.all(ops),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Deduplication
+// ---------------------------------------------------------------------------
+
+describe("deduplication", () => {
+  it("processes a new event and returns dispatched=1", async () => {
+    mockCreate.mockResolvedValue({});
+    mockPaymentAttemptFindFirst.mockResolvedValue(null);
+    const svc = buildService(buildAdapter([baseEvent]));
+    const count = await svc.handle("STRIPE", rawBody, headers);
+    expect(count).toBe(1);
+  });
+
+  it("skips a duplicate event and returns dispatched=0", async () => {
+    mockCreate.mockRejectedValue({ code: "P2002" });
+    const svc = buildService(buildAdapter([baseEvent]));
+    const count = await svc.handle("STRIPE", rawBody, headers);
+    expect(count).toBe(0);
+    expect(mockPaymentAttemptFindFirst).not.toHaveBeenCalled();
+  });
+
+  it("processes two events, deduplicates the second", async () => {
+    const events: NormalizedPaymentEvent[] = [
+      { providerEventRef: "evt_A", type: "PAYMENT_SUCCEEDED" },
+      { providerEventRef: "evt_B", type: "PAYMENT_FAILED" },
+    ];
+    mockCreate
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce({ code: "P2002" });
+    mockPaymentAttemptFindFirst.mockResolvedValue(null);
+
+    const svc = buildService(buildAdapter(events));
+    const count = await svc.handle("STRIPE", rawBody, headers);
+    expect(count).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Verification error
+// ---------------------------------------------------------------------------
+
+describe("webhook verification", () => {
+  it("propagates WebhookVerificationError", async () => {
+    const adapter = buildAdapter([], new WebhookVerificationError());
+    const svc = buildService(adapter);
+    await expect(svc.handle("STRIPE", rawBody, headers)).rejects.toBeInstanceOf(
+      WebhookVerificationError,
+    );
+  });
+
+  it("throws UnknownProviderError for unregistered provider", async () => {
+    const registry = new PaymentProviderRegistry();
+    const svc = new PaymentWebhookService(registry);
+    await expect(
+      svc.handle("CARECREDIT", rawBody, headers),
+    ).rejects.toBeInstanceOf(UnknownProviderError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PAYMENT_SUCCEEDED dispatch
+// ---------------------------------------------------------------------------
+
+describe("PAYMENT_SUCCEEDED", () => {
+  const event: NormalizedPaymentEvent = {
+    providerEventRef: "evt_pay_ok",
+    type: "PAYMENT_SUCCEEDED",
+    providerPaymentRef: "pi_abc",
+    amount: { minorAmount: 5000, currency: "usd" },
+  };
+
+  it("updates attempt + upserts Payment", async () => {
+    const attempt = {
+      id: "att_1",
+      invoiceId: "inv_1",
+      provider: "STRIPE",
+      amountRequested: 5000,
+      currency: "usd",
+    };
+    mockPaymentAttemptFindFirst.mockResolvedValue(attempt);
+
+    const svc = buildService(buildAdapter([event]));
+    await svc.handle("STRIPE", rawBody, headers);
+
+    expect(mockPaymentAttemptUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "att_1" },
+        data: expect.objectContaining({ status: "SUCCEEDED" }),
+      }),
+    );
+    expect(mockPaymentUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { paymentAttemptId: "att_1" },
+        update: expect.objectContaining({ status: "SUCCEEDED" }),
+      }),
+    );
+  });
+
+  it("skips update when no matching attempt found", async () => {
+    mockPaymentAttemptFindFirst.mockResolvedValue(null);
+    const svc = buildService(buildAdapter([event]));
+    await svc.handle("STRIPE", rawBody, headers);
+    expect(mockPaymentAttemptUpdate).not.toHaveBeenCalled();
+  });
+
+  it("uses attempt amounts as fallback when event carries no amount", async () => {
+    const event: NormalizedPaymentEvent = {
+      providerEventRef: "evt_pay_no_amt",
+      type: "PAYMENT_SUCCEEDED",
+      providerPaymentRef: "pi_fallback",
+    };
+    const attempt = {
+      id: "att_2",
+      invoiceId: "inv_2",
+      provider: "STRIPE",
+      amountRequested: 3000,
+      currency: "gbp",
+    };
+    mockPaymentAttemptFindFirst.mockResolvedValue(attempt);
+    const svc = buildService(buildAdapter([event]));
+    await svc.handle("STRIPE", rawBody, headers);
+
+    expect(mockPaymentAttemptUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ amountCaptured: 3000 }),
+      }),
+    );
+    expect(mockPaymentUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({ amount: 3000, currency: "gbp" }),
+      }),
+    );
+  });
+
+  it("skips dispatch when providerPaymentRef is missing", async () => {
+    const noRef: NormalizedPaymentEvent = {
+      providerEventRef: "evt_no_ref",
+      type: "PAYMENT_SUCCEEDED",
+    };
+    const svc = buildService(buildAdapter([noRef]));
+    await svc.handle("STRIPE", rawBody, headers);
+    expect(mockPaymentAttemptFindFirst).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PAYMENT_FAILED dispatch
+// ---------------------------------------------------------------------------
+
+describe("PAYMENT_FAILED", () => {
+  it("marks attempt as FAILED with failure details", async () => {
+    const event: NormalizedPaymentEvent = {
+      providerEventRef: "evt_pay_fail",
+      type: "PAYMENT_FAILED",
+      providerPaymentRef: "pi_xyz",
+      failureCode: "card_declined",
+      failureMessage: "Your card was declined.",
+    };
+    const svc = buildService(buildAdapter([event]));
+    await svc.handle("STRIPE", rawBody, headers);
+
+    expect(mockPaymentAttemptUpdateMany).toHaveBeenCalledWith({
+      where: { providerPaymentIntentId: "pi_xyz" },
+      data: {
+        status: "FAILED",
+        failureCode: "card_declined",
+        failureMessage: "Your card was declined.",
+      },
+    });
+  });
+
+  it("skips when providerPaymentRef is missing", async () => {
+    const event: NormalizedPaymentEvent = {
+      providerEventRef: "evt_fail_no_ref",
+      type: "PAYMENT_FAILED",
+    };
+    const svc = buildService(buildAdapter([event]));
+    await svc.handle("STRIPE", rawBody, headers);
+    expect(mockPaymentAttemptUpdateMany).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// REFUND_SUCCEEDED / REFUND_FAILED dispatch
+// ---------------------------------------------------------------------------
+
+describe("REFUND_SUCCEEDED", () => {
+  it("marks refund as SUCCEEDED", async () => {
+    const event: NormalizedPaymentEvent = {
+      providerEventRef: "evt_ref_ok",
+      type: "REFUND_SUCCEEDED",
+      providerRefundRef: "re_001",
+    };
+    const svc = buildService(buildAdapter([event]));
+    await svc.handle("STRIPE", rawBody, headers);
+    expect(mockRefundUpdateMany).toHaveBeenCalledWith({
+      where: { providerRefundId: "re_001" },
+      data: { status: "SUCCEEDED" },
+    });
+  });
+
+  it("skips when providerRefundRef is missing", async () => {
+    const event: NormalizedPaymentEvent = {
+      providerEventRef: "evt_ref_no_ref",
+      type: "REFUND_SUCCEEDED",
+    };
+    const svc = buildService(buildAdapter([event]));
+    await svc.handle("STRIPE", rawBody, headers);
+    expect(mockRefundUpdateMany).not.toHaveBeenCalled();
+  });
+});
+
+describe("REFUND_FAILED", () => {
+  it("marks refund as FAILED", async () => {
+    const event: NormalizedPaymentEvent = {
+      providerEventRef: "evt_ref_fail",
+      type: "REFUND_FAILED",
+      providerRefundRef: "re_002",
+    };
+    const svc = buildService(buildAdapter([event]));
+    await svc.handle("STRIPE", rawBody, headers);
+    expect(mockRefundUpdateMany).toHaveBeenCalledWith({
+      where: { providerRefundId: "re_002" },
+      data: { status: "FAILED" },
+    });
+  });
+
+  it("skips when providerRefundRef is missing", async () => {
+    const event: NormalizedPaymentEvent = {
+      providerEventRef: "evt_ref_fail_no_ref",
+      type: "REFUND_FAILED",
+    };
+    const svc = buildService(buildAdapter([event]));
+    await svc.handle("STRIPE", rawBody, headers);
+    expect(mockRefundUpdateMany).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ACCOUNT_UPDATED dispatch
+// ---------------------------------------------------------------------------
+
+describe("ACCOUNT_UPDATED", () => {
+  it("refreshes account status from adapter", async () => {
+    const event: NormalizedPaymentEvent = {
+      providerEventRef: "evt_acct_upd",
+      type: "ACCOUNT_UPDATED",
+      accountRef: "acct_123",
+    };
+    mockOrgBillingFindFirst.mockResolvedValue({ orgId: "org_1" });
+
+    const adapter = buildAdapter([event]);
+    const svc = buildService(adapter);
+    await svc.handle("STRIPE", rawBody, headers);
+
+    expect(adapter.getAccountStatus).toHaveBeenCalledWith("org_1");
+    expect(mockOrgBillingUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { connectAccountId: "acct_123" },
+        data: expect.objectContaining({
+          canAcceptPayments: true,
+          connectChargesEnabled: true,
+          connectPayoutsEnabled: true,
+        }),
+      }),
+    );
+  });
+
+  it("skips when no billing record matches accountRef", async () => {
+    const event: NormalizedPaymentEvent = {
+      providerEventRef: "evt_acct_miss",
+      type: "ACCOUNT_UPDATED",
+      accountRef: "acct_unknown",
+    };
+    mockOrgBillingFindFirst.mockResolvedValue(null);
+
+    const svc = buildService(buildAdapter([event]));
+    await svc.handle("STRIPE", rawBody, headers);
+    expect(mockOrgBillingUpdateMany).not.toHaveBeenCalled();
+  });
+
+  it("skips when accountRef is missing", async () => {
+    const event: NormalizedPaymentEvent = {
+      providerEventRef: "evt_acct_no_ref",
+      type: "ACCOUNT_UPDATED",
+    };
+    const svc = buildService(buildAdapter([event]));
+    await svc.handle("STRIPE", rawBody, headers);
+    expect(mockOrgBillingFindFirst).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dispatch error isolation
+// ---------------------------------------------------------------------------
+
+describe("dispatch error isolation", () => {
+  it("does not throw when dispatch fails; other events still process", async () => {
+    const events: NormalizedPaymentEvent[] = [
+      {
+        providerEventRef: "evt_bad",
+        type: "PAYMENT_SUCCEEDED",
+        providerPaymentRef: "pi_bad",
+      },
+      {
+        providerEventRef: "evt_good",
+        type: "PAYMENT_FAILED",
+        providerPaymentRef: "pi_good",
+      },
+    ];
+    // Both new
+    mockCreate.mockResolvedValue({});
+    // First attempt lookup throws
+    mockPaymentAttemptFindFirst.mockRejectedValueOnce(new Error("db error"));
+
+    const svc = buildService(buildAdapter(events));
+    const count = await svc.handle("STRIPE", rawBody, headers);
+    // Both dispatched (errors are caught internally)
+    expect(count).toBe(2);
+    expect(mockPaymentAttemptUpdateMany).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/backend/test/utils/money-minor-units.test.ts
+++ b/apps/backend/test/utils/money-minor-units.test.ts
@@ -1,0 +1,150 @@
+import {
+  fromMinorUnits,
+  getCurrencyExponent,
+  toMinorUnits,
+} from "@yosemite-crew/lib";
+
+describe("getCurrencyExponent", () => {
+  it("returns 2 for standard two-decimal currencies", () => {
+    expect(getCurrencyExponent("USD")).toBe(2);
+    expect(getCurrencyExponent("EUR")).toBe(2);
+    expect(getCurrencyExponent("GBP")).toBe(2);
+    expect(getCurrencyExponent("INR")).toBe(2);
+  });
+
+  it("returns 0 for zero-decimal currencies", () => {
+    expect(getCurrencyExponent("JPY")).toBe(0);
+    expect(getCurrencyExponent("KRW")).toBe(0);
+    expect(getCurrencyExponent("VND")).toBe(0);
+    expect(getCurrencyExponent("ISK")).toBe(0);
+    expect(getCurrencyExponent("XOF")).toBe(0);
+  });
+
+  it("returns 3 for three-decimal currencies", () => {
+    expect(getCurrencyExponent("BHD")).toBe(3);
+    expect(getCurrencyExponent("KWD")).toBe(3);
+    expect(getCurrencyExponent("OMR")).toBe(3);
+    expect(getCurrencyExponent("TND")).toBe(3);
+  });
+
+  it("returns 4 for four-decimal currencies", () => {
+    expect(getCurrencyExponent("CLF")).toBe(4);
+    expect(getCurrencyExponent("UYW")).toBe(4);
+  });
+
+  it("is case-insensitive and trims surrounding whitespace", () => {
+    expect(getCurrencyExponent("jpy")).toBe(0);
+    expect(getCurrencyExponent("bhd")).toBe(3);
+    expect(getCurrencyExponent("  usd  ")).toBe(2);
+  });
+
+  it("defaults unknown but well-formed codes to 2", () => {
+    expect(getCurrencyExponent("ZZZ")).toBe(2);
+  });
+
+  it("throws on malformed currency codes", () => {
+    expect(() => getCurrencyExponent("")).toThrow(RangeError);
+    expect(() => getCurrencyExponent("US")).toThrow(RangeError);
+    expect(() => getCurrencyExponent("USDD")).toThrow(RangeError);
+    expect(() => getCurrencyExponent("U1D")).toThrow(RangeError);
+    expect(() => getCurrencyExponent(123 as unknown as string)).toThrow(
+      RangeError,
+    );
+    expect(() => getCurrencyExponent(null as unknown as string)).toThrow(
+      RangeError,
+    );
+  });
+});
+
+describe("toMinorUnits", () => {
+  it("converts two-decimal amounts to cents", () => {
+    expect(toMinorUnits(19.99, "USD")).toBe(1999);
+    expect(toMinorUnits(10, "USD")).toBe(1000);
+    expect(toMinorUnits(0, "USD")).toBe(0);
+    expect(toMinorUnits(1234567.89, "USD")).toBe(123456789);
+  });
+
+  it("keeps zero-decimal currencies whole", () => {
+    expect(toMinorUnits(1500, "JPY")).toBe(1500);
+    expect(toMinorUnits(1500.4, "JPY")).toBe(1500);
+    expect(toMinorUnits(1500.6, "JPY")).toBe(1501);
+  });
+
+  it("scales three-decimal currencies by 1000", () => {
+    expect(toMinorUnits(1.234, "BHD")).toBe(1234);
+    expect(toMinorUnits(1.2345, "BHD")).toBe(1235);
+  });
+
+  it("scales four-decimal currencies by 10000", () => {
+    expect(toMinorUnits(1.2345, "CLF")).toBe(12345);
+  });
+
+  it("rounds half away from zero", () => {
+    expect(toMinorUnits(19.995, "USD")).toBe(2000);
+    expect(toMinorUnits(0.005, "USD")).toBe(1);
+    expect(toMinorUnits(0.004, "USD")).toBe(0);
+    expect(toMinorUnits(0.015, "USD")).toBe(2);
+  });
+
+  it("handles negative amounts symmetrically", () => {
+    expect(toMinorUnits(-5.5, "USD")).toBe(-550);
+    expect(toMinorUnits(-0.005, "USD")).toBe(-1);
+  });
+
+  it("does not accumulate binary floating-point error", () => {
+    expect(toMinorUnits(1.1, "USD")).toBe(110);
+    expect(toMinorUnits(0.1 + 0.2, "USD")).toBe(30);
+    expect(toMinorUnits(2.675, "USD")).toBe(268);
+  });
+
+  it("throws on non-finite amounts and invalid currencies", () => {
+    expect(() => toMinorUnits(Number.NaN, "USD")).toThrow(RangeError);
+    expect(() => toMinorUnits(Number.POSITIVE_INFINITY, "USD")).toThrow(
+      RangeError,
+    );
+    expect(() => toMinorUnits("5" as unknown as number, "USD")).toThrow(
+      RangeError,
+    );
+    expect(() => toMinorUnits(5, "US")).toThrow(RangeError);
+  });
+});
+
+describe("fromMinorUnits", () => {
+  it("converts minor units back to major amounts", () => {
+    expect(fromMinorUnits(1999, "USD")).toBe(19.99);
+    expect(fromMinorUnits(1000, "USD")).toBe(10);
+    expect(fromMinorUnits(0, "USD")).toBe(0);
+  });
+
+  it("respects the currency exponent", () => {
+    expect(fromMinorUnits(1500, "JPY")).toBe(1500);
+    expect(fromMinorUnits(1234, "BHD")).toBe(1.234);
+    expect(fromMinorUnits(12345, "CLF")).toBe(1.2345);
+  });
+
+  it("handles negative minor units", () => {
+    expect(fromMinorUnits(-550, "USD")).toBe(-5.5);
+  });
+
+  it("throws on non-integer minor amounts and invalid currencies", () => {
+    expect(() => fromMinorUnits(19.99, "USD")).toThrow(RangeError);
+    expect(() => fromMinorUnits(1.5, "USD")).toThrow(RangeError);
+    expect(() => fromMinorUnits(100, "US")).toThrow(RangeError);
+  });
+});
+
+describe("round trip", () => {
+  it.each([
+    [19.99, "USD"],
+    [0, "USD"],
+    [-5.5, "USD"],
+    [1500, "JPY"],
+    [1.234, "BHD"],
+    [1.2345, "CLF"],
+    [99.95, "EUR"],
+  ])("preserves %p %s through to-and-from minor units", (amount, currency) => {
+    expect(fromMinorUnits(toMinorUnits(amount, currency), currency)).toBe(
+      amount,
+    );
+  });
+});

--- a/docs/guide/payment-gateway-multi-provider-plan.md
+++ b/docs/guide/payment-gateway-multi-provider-plan.md
@@ -1,152 +1,131 @@
-# Payment Gateway Abstraction and Multi-Provider Support (Stripe + Adyen)
+# Payment Gateway Abstraction - Stripe + Financing Partners (CareCredit / Scratchpay)
 
 Status: proposal (design and test plan)
 Related issue: #1659
 Scope: `apps/backend`, `apps/frontend`, `apps/mobileAppYC`, `packages/database`, `packages/lib`
 
-This document is the detailed design and verification plan behind issue #1659. It describes how to introduce a provider-agnostic payment-gateway abstraction, add Adyen as a second processor selected per organisation, and do so with a test and rollout plan strong enough to enable real money movement with confidence. It contains no credentials or secret values; configuration is referenced by purpose only.
+This document is the detailed design and verification plan behind issue #1659. It describes how to introduce a provider-agnostic payment-gateway abstraction with Stripe as the card-payment rail and CareCredit or Scratchpay as financing options selected per organisation, and how to do so with a test and rollout plan strong enough to enable real money movement with confidence. It contains no credentials or secret values; configuration is referenced by purpose only.
 
 ## Settlement model (the core principle)
 
-The platform takes no fee and is never the financial principal. For every customer payment the clinic is the merchant of record: the clinic appears on the payer's statement, the clinic bears the provider processing fee, and the clinic owns refunds and chargebacks. The platform's role is orchestration and governance only. It creates and records payments on the clinic's behalf and keeps full visibility, but it never sits in the settlement path as principal.
+The platform takes no fee and is never the financial principal. For every customer payment the clinic is the merchant of record: the clinic appears on the payer's statement, the clinic bears the provider processing fee, and the clinic owns refunds and chargebacks. The platform's role is orchestration and governance only.
 
-- Stripe: Standard Connect accounts with direct charges. The charge is created in the clinic's account context, so the processing fee, the statement descriptor, and dispute liability all sit with the clinic, and negative-balance liability stays with the clinic and Stripe rather than the platform. The platform takes no application fee.
-- Adyen: the clinic is the sub-merchant and merchant of record, settling to the clinic's balance account and bearing fees and chargebacks. The platform takes no split.
+- **Stripe (card payments):** Standard Connect accounts with direct charges. The charge is created in the clinic's account context, so the processing fee, the statement descriptor, and dispute liability all sit with the clinic. Negative-balance liability stays with the clinic and Stripe, not the platform. No application fee.
+- **CareCredit / Scratchpay (financing):** Each clinic signs up directly with the financing provider. The financing company underwrites the patient's loan, pays the clinic in full upfront, and collects repayments from the pet owner. The platform is the technology layer that initiates the financing application and receives confirmation; it is not a lender, does not touch the funds, and has no regulatory exposure.
 
-There is no platform fee, take-rate, or split on either provider. This supersedes any earlier framing of destination transfers and platform fees. The current Stripe flow uses destination charges, which makes the platform the merchant of record; migrating it to direct charges is a prerequisite for the Stripe adapter to match this model and is tracked in #1678.
+There is no platform fee, take-rate, or split on any provider. The current Stripe flow uses destination charges, which makes the platform the merchant of record; migrating to direct charges is a prerequisite for the Stripe adapter and is tracked in #1678.
+
+## Why CareCredit / Scratchpay instead of Adyen
+
+The original scope included Adyen as a second card processor. Adyen for Platforms contracts with the platform entity as the regulatory principal - even with 100% of funds routed to the clinic, the platform bears regulatory exposure. That is incompatible with the "platform is software and governance only" constraint.
+
+CareCredit (Synchrony Financial) and Scratchpay are healthcare financing providers. Each clinic signs their own agreement directly with the financing provider. The platform integrates via API to initiate the financing application flow and receive funded/declined events. The regulatory and financial relationship is clinic-to-financing-provider; the platform is the facilitating software and has no regulatory exposure.
+
+This also addresses the real driver behind the second-provider requirement: Stripe's per-transaction fee (~2.9% + $0.30) is high for clinic-to-pet-owner payments. Financing providers accept a higher processing fee willingly because they convert treatments that would otherwise be declined due to cost - increasing clinic revenue is worth more than the processing cost difference.
 
 ## Goals
 
-- A stable `PaymentProvider` interface with Stripe as one concrete implementation, selectable per organisation.
-- A second processor (Adyen) behind the same interface, for clinic-facing payments where the clinic is the merchant of record.
-- A test and verification strategy that proves both providers behave identically from the application's point of view, and that money reconciles end to end.
+- A stable `PaymentProviderPort` interface with Stripe as the card-payment implementation, selectable per organisation.
+- CareCredit and/or Scratchpay behind the same interface, for clinic-facing payments where the pet owner finances over time and the clinic receives payment in full upfront.
+- A test and verification strategy that proves all providers behave identically from the application's point of view, and that money reconciles end to end.
 
 ## Non-goals (kept single-provider)
 
-- The platform's own SaaS subscription billing (subscription checkout, customer portal, seat proration) stays on Stripe. The second provider does not offer an equivalent subscription-billing product, and this billing path is already cleanly isolated (it writes only `FinanceProviderLink` and `SubscriptionEntitlement`, charges the platform account, and is already gated to a single provider). A clinic can use the second provider for customer payments while its own subscription stays on Stripe, with no data-model conflict, because the provider is stored per row, not per organisation. This is the one place the platform is the merchant (it is selling its own software to the clinic), and it is deliberately separate from the clinic-facing flow.
+- The platform's own SaaS subscription billing (subscription checkout, customer portal, seat proration) stays on Stripe. This is the one place the platform is the merchant - it is selling its own software to the clinic - and it is deliberately separate from the clinic-facing flow.
 
 ## Current state
 
 The persistence layer is already provider-aware; the orchestration layer is not.
 
 - `enum PaymentProvider { STRIPE  MANUAL }` is referenced by `PaymentAttempt`, `Payment`, and `Refund`, each indexed on `provider`.
-- `OrganizationBilling` (mapped to `OrgBilling`) holds account-readiness state under Stripe-shaped field names.
+- `OrganizationBilling` holds account-readiness state under Stripe-shaped field names.
 - `FinanceProviderLink` and `IntegrationAccount` are existing per-organisation, per-provider precedents (the latter with a service, store, and settings UI for IDEXX and Merck).
-- The gateway gap: `apps/backend/src/services/stripe.service.ts` is a concrete object that builds the Stripe client directly, and finance and webhook code call it by name. `apps/backend/src/services/finance/payment.ts` does provider-neutral database work but is invoked from inside Stripe-specific webhook handlers, so there is no seam to route a different provider through it.
-- Clinic-facing charges are currently created as destination charges on the platform account (`transfer_data.destination`), which makes the platform the merchant of record. This contradicts the settlement model above and is corrected by the destination-to-direct migration (#1678).
-- The web client and mobile client are hosted-redirect: the backend returns a URL and the client navigates to it. There is no client-side card collection to replace. The only embedded provider SDK on the web is the connected-account onboarding component.
+- The gateway gap: `apps/backend/src/services/stripe.service.ts` is a concrete object that builds the Stripe client directly, and finance and webhook code call it by name.
+- Clinic-facing charges are currently created as destination charges on the platform account (`transfer_data.destination`), making the platform the merchant of record. This contradicts the settlement model above and is corrected by the destination-to-direct migration (#1678).
 
 ## Target architecture
 
 1. `PaymentProviderPort`: the capability surface the rest of finance needs.
-2. `StripeProviderAdapter` and `AdyenProviderAdapter` implementing the port. Stripe is a behaviour-preserving refactor of the existing service, on top of the direct-charge model.
+2. `StripeProviderAdapter`, `CareCreditProviderAdapter`, and `ScratchpayProviderAdapter` implementing the port. Stripe is a behaviour-preserving refactor of the existing service, on top of the direct-charge model.
 3. `PaymentProviderRegistry`: resolves the adapter for an organisation from its configured active provider.
 4. A normalized webhook pipeline that converts each provider's events into the existing provider-neutral `FinancePaymentService` methods, which remain the source of truth for `PaymentAttempt`, `Payment`, and `Refund` rows.
 5. A currency-exponent-aware minor-unit helper in `packages/lib`, shared by backend, web, and mobile.
-6. Asynchronous webhook intake: accept and acknowledge batched notifications quickly, then process off-thread, with an idempotency and event de-duplication store.
+6. Idempotency and event de-duplication store keyed on `(provider, providerEventReference)`.
 
 ### The port (illustrative)
 
 ```ts
 interface PaymentProviderPort {
-  readonly provider: PaymentProvider;
-  readonly capabilities: ProviderCapabilities; // hosted checkout, direct charges, automatic tax, hosted receipts
+  readonly provider: ProviderId; // "STRIPE" | "CARECREDIT" | "SCRATCHPAY" | "MANUAL"
+  readonly capabilities: ProviderCapabilities;
 
-  // onboarding / account lifecycle
   createOrGetConnectedAccount(orgId: string): Promise<{ accountRef: string }>;
   createOnboardingLink(orgId: string): Promise<{ url?: string; clientSecret?: string }>;
   getAccountStatus(orgId: string): Promise<AccountReadiness>;
 
-  // payment lifecycle (charge created in the clinic's account context; gateway owns minor-unit and idempotency-key handling)
-  createCheckoutSession(
-    input: NormalizedCheckoutInput
-  ): Promise<{ providerRef: string; redirectUrl?: string; clientToken?: string }>;
-  createPayment(
-    input: NormalizedPaymentInput
-  ): Promise<{ providerPaymentRef: string; clientSecret?: string; status: PaymentAttemptStatus }>;
-  refund(input: NormalizedRefundInput): Promise<{ refundRef: string; status: RefundStatus }>;
+  createCheckoutSession(input: NormalizedCheckoutInput): Promise<CheckoutSessionResult>;
+  createPayment(input: NormalizedPaymentInput): Promise<CreatePaymentResult>;
+  refund(input: NormalizedRefundInput): Promise<RefundResult>;
 
-  // webhooks (normalize into existing FinancePaymentService inputs)
   verifyAndNormalizeWebhook(
     rawBody: Buffer,
-    headers: Record<string, string>
+    headers: Record<string, string | string[] | undefined>
   ): NormalizedPaymentEvent[];
 }
 ```
 
-The existing `FinancePaymentService` webhook-facing methods already take plain provider-neutral inputs (invoice reference, amount in major units, currency), so they are the natural normalization sink. Adapters translate provider-specific shapes (payment intent, charge, session id, or psp reference) into these inputs.
-
-## Asynchronous-provider implications
-
-The second provider differs from Stripe in ways that shape the design:
-
-- It sends batched webhook notifications and expects a fast, fixed acknowledgement, then asynchronous processing.
-- Refund, capture, and payout outcomes are confirmed only by webhook, not in the API response.
-- Webhook authenticity is verified per merchant account, not against a single global secret.
-- Amounts are always in minor units with a per-currency exponent.
-
-Consequences carried into the plan: asynchronous refund and capture lifecycle, an idempotency and event de-duplication store, off-thread webhook processing (the existing queue and worker directories are the home), per-merchant verification key resolution, and a currency-exponent-aware money helper.
+The `capabilities` descriptor lets callers guard features a given provider does not offer. CareCredit and Scratchpay set `hostedCheckout: true` (redirect to financing application), `paymentIntent: false`, `automaticTax: false`, `asyncRefunds: true`. Stripe sets `hostedCheckout: true`, `paymentIntent: true`, `automaticTax: true`, `asyncRefunds: false`.
 
 ## Connected accounts and settlement
 
-The clinic is the merchant of record on both providers, and the platform takes no fee on either. The current single connected-account model maps as follows:
-
-| Concept                     | Stripe (Standard Connect, direct charges)       | Adyen (clinic as sub-merchant)                   |
-| --------------------------- | ----------------------------------------------- | ------------------------------------------------ |
-| Connected entity            | one connected account per clinic                | account holder plus one or more balance accounts |
-| Onboarding                  | embedded component                              | hosted onboarding link                           |
-| Readiness and capabilities  | charges and payouts enabled, requirements       | capabilities and verification deadlines          |
-| Where the charge is created | in the clinic's account context (direct charge) | against the clinic as sub-merchant               |
-| Merchant of record          | clinic                                          | clinic                                           |
-| Processing fee              | borne by the clinic                             | borne by the clinic                              |
-| Platform fee                | none                                            | none                                             |
-| Refund and chargeback       | settled from the clinic's balance               | settled from the clinic's balance                |
-| Negative-balance liability  | clinic and Stripe (Standard)                    | clinic                                           |
-| Payout                      | provider-managed to the clinic                  | provider-managed to the clinic's balance account |
-
-Because Adyen uses balance accounts, the stored single-account scalar may become a one-to-many relation on that provider. The clinic is the tax merchant of record on both providers, which matches the existing tax configuration (the invoice issuer and tax-liability account are already the clinic).
+| Concept                      | Stripe (Standard Connect, direct charges) | CareCredit / Scratchpay (financing)       |
+| ---------------------------- | ----------------------------------------- | ----------------------------------------- |
+| Connected entity             | one connected account per clinic          | one merchant account per clinic           |
+| Onboarding                   | embedded component (account session)      | redirect to provider's merchant signup    |
+| Readiness                    | charges and payouts enabled               | merchant account approved                 |
+| Where the charge is created  | clinic's account context (direct charge)  | financing provider creates the loan       |
+| Merchant of record           | clinic                                    | clinic (financing provider is the lender) |
+| Processing fee               | borne by the clinic                       | borne by the clinic                       |
+| Platform fee                 | none                                      | none                                      |
+| Platform regulatory exposure | none                                      | none                                      |
+| Refund                       | settled from clinic's balance             | credit issued via financing provider API  |
+| Payout                       | provider-managed to the clinic            | financing provider funds clinic directly  |
 
 ## Client plan
 
-- Web: branch on the organisation's selected provider; generalize the redirect-URL allowlist so the second provider's hosted pages are permitted; normalize return-status parsing across providers; provide a per-provider onboarding component. The current hosted-redirect model means most flows need only provider plumbing and allowlist changes, not embedded card UI.
-- Mobile: thread the selected provider through the payment-session request; branch the provider component at the app root; wire the deep-link return path for redirect-based methods (the current app handles its own redirect interception, so this must be made explicit for a second provider).
-- Embedded drop-in (cards rendered in-app) on either client is an optional later enhancement, not required for the redirect-first launch.
+- Web: branch on the organisation's selected provider; generalize the redirect-URL allowlist so CareCredit and Scratchpay hosted pages are permitted; normalize return-status parsing across providers; provide a per-provider onboarding component.
+- Mobile: thread the selected provider through the payment-session request; branch the provider component at the app root; wire the deep-link return path for redirect-based methods.
 
 ## Correctness requirements
 
-The implementation must satisfy the following. Each is a named test in the test plan.
-
-| Area                         | Requirement                                                                                                                                                                        |
-| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Merchant of record           | Clinic-facing charges are created in the clinic's account context so the clinic is the merchant of record, bears the processing fee, and owns disputes; the platform takes no fee. |
-| Currency exponents           | Amounts convert to and from provider minor units using the correct per-currency exponent (zero-, two-, and three-decimal currencies).                                              |
-| Idempotency                  | Provider create calls carry idempotency keys; redelivered or duplicated webhook events apply at most once.                                                                         |
-| Async refund and capture     | Refund and capture move through a pending state and are finalized to succeeded or failed by webhook.                                                                               |
-| Refund settlement            | Refunds and chargebacks are issued in the clinic's account context and settle from the clinic's balance, never the platform's.                                                     |
-| Partial and multiple refunds | Partial and repeated refunds are represented accurately and never exceed the captured amount in aggregate.                                                                         |
-| Race safety                  | The payment attempt is persisted before the provider call, and webhook handlers are idempotent, so an early webhook cannot mis-handle a not-yet-persisted attempt.                 |
-| Readiness gating             | Charging is blocked when an account exists but is not yet able to accept payments.                                                                                                 |
-| Return URLs                  | Success and cancel return URLs are distinct, and return-status parsing is provider-aware.                                                                                          |
-| Over-payment and over-refund | Amounts beyond the outstanding balance or captured amount are handled explicitly, not silently discarded.                                                                          |
-| Failed attempts              | A failed payment records a failure code and message and reconciles the attempt state.                                                                                              |
-| Multiple accounts            | The data model supports a one-to-many account model where a provider requires it.                                                                                                  |
-| Tax                          | The clinic is the tax merchant of record; for a provider without a tax engine, invoice tax is finalized before payment.                                                            |
+| Area                         | Requirement                                                                                                                  |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Merchant of record           | Clinic-facing charges are created in the clinic's account context; the platform takes no fee and has no regulatory exposure. |
+| Currency exponents           | Amounts convert to and from provider minor units using the correct per-currency exponent.                                    |
+| Idempotency                  | Provider create calls carry idempotency keys; redelivered or duplicated webhook events apply at most once.                   |
+| Refund settlement            | Refunds settle in the clinic's account context and never from the platform's balance.                                        |
+| Partial and multiple refunds | Partial and repeated refunds are represented accurately and never exceed the captured amount in aggregate.                   |
+| Race safety                  | The payment attempt is persisted before the provider call, and webhook handlers are idempotent.                              |
+| Readiness gating             | Charging is blocked when an account exists but is not yet able to accept payments.                                           |
+| Return URLs                  | Success and cancel return URLs are distinct, and return-status parsing is provider-aware.                                    |
+| Over-refund                  | Amounts beyond the captured amount are rejected explicitly, not silently discarded.                                          |
+| Failed attempts              | A failed payment records a failure code and message and reconciles the attempt state.                                        |
 
 ## Data model deltas (additive)
 
-- Add `ADYEN` to `enum PaymentProvider`.
+- Add `CARECREDIT` and `SCRATCHPAY` to `enum PaymentProvider`.
 - Add `activePaymentProvider` (default `STRIPE`), a provider-neutral `onboardingState`, and `onboardingUpdatedAt` to `OrganizationBilling`; retain `canAcceptPayments` as the cross-provider readiness gate; keep existing connect-shaped columns for backward compatibility behind the neutral rollup.
 - Add a processed-webhook-event table keyed on provider plus provider event reference.
-- Add a per-organisation provider-config table (Prisma-only, no Mongoose mirror, per repo convention) carrying the active provider, the second provider's account references, credentials reference, and an enabled or status flag for staged rollout.
+- Add a per-organisation provider-config table (Prisma-only, no Mongoose mirror) carrying the active provider, the financing provider's merchant account reference, and a status flag for staged rollout.
 - Add audit event and entity enum members for payment-configuration changes.
 - Backfill existing rows from current columns; no external API calls.
 
 ## Phased delivery
 
-- Phase 0: provider port, registry, the prerequisite hardening (idempotency and de-duplication store, currency-exponent helper, asynchronous refund and capture lifecycle, race-safe reconciliation, clinic-context refund settlement, distinct return URLs), and the Stripe adapter as a behaviour-preserving refactor on top of the direct-charge model. The direct-charge migration (#1678) lands first. The largest and most valuable single piece even if the second provider never ships.
-- Phase 1: second-provider payments (no payouts) in a sandbox merchant account, redirect client flow on web and mobile, behind a global enable flag and a per-organisation provider-config status, on one pilot organisation.
-- Phase 2: second-provider connected accounts (onboarding, sub-merchant settlement, payout reconciliation).
-- Phase 3: rollout, settings UI mirroring the existing Integrations page, per-organisation toggle, and operational dashboards.
+- **Phase 0:** provider port, registry, the prerequisite hardening (idempotency and de-duplication store, currency-exponent helper, clinic-context refund settlement, distinct return URLs), and the Stripe adapter as a behaviour-preserving refactor on top of the direct-charge model. The direct-charge migration (#1678) lands first. The largest and most valuable single piece even if a second provider never ships. (Port and registry complete as of #1685; money helper complete as of #1677.)
+- **Phase 1:** CareCredit adapter - redirect checkout flow on web and mobile, clinic merchant account onboarding, webhook normalization, behind a per-organisation provider-config status on one pilot clinic.
+- **Phase 2:** Scratchpay adapter - same contract, parallel onboarding path, per-organisation toggle between CareCredit and Scratchpay.
+- **Phase 3:** rollout, settings UI mirroring the existing Integrations page, operational dashboards, and per-organisation analytics showing treatment acceptance rate by payment method.
 
 ## Testing and verification
 
@@ -154,70 +133,34 @@ A payments change moves money, so the test plan is first-class.
 
 ### Contract suite (the centerpiece)
 
-One provider-agnostic contract test suite is run against every implementation: the Stripe adapter, the Adyen adapter, and an in-memory fake. Same assertions, three targets. The fake target runs per commit (fast, deterministic); the sandbox targets run nightly against test environments. This is what guarantees the two providers are interchangeable from the application's point of view.
+One provider-agnostic contract test suite runs against every implementation: the Stripe adapter, the CareCredit adapter, the Scratchpay adapter, and the in-memory fake. Same assertions, all targets. The fake target runs per commit (fast, deterministic); the sandbox targets run nightly.
 
 ### Layered tests
 
-- Unit: each adapter method (request mapping, response normalization, error mapping); the minor-unit helper as property and table tests across the full currency-exponent matrix with golden cases for zero- and three-decimal currencies; webhook normalizers over recorded sandbox payloads.
-- Signature and HMAC verification: valid passes; tampered body, wrong key, and missing signature fail; per-merchant key resolution is correct.
-- Service and integration: full lifecycle against a real test database so Prisma writes and constraints are exercised (create, webhook success, invoice paid, refund pending then succeeded or failed), including the database uniqueness guards under concurrent duplicate webhooks.
-- Webhook harness: de-duplication, out-of-order delivery, the create-versus-webhook race, batched notifications, fast acknowledgement even when business processing fails (with dead-lettering rather than an error response), and the off-thread handoff.
-- Frontend and mobile: provider branch, redirect handling, the URL allowlist, return-status normalization, the onboarding component, and cancel-versus-error mapping on mobile.
-- End-to-end (new): pay, refund, and onboarding against both sandboxes, in a nightly lane.
-- Sandbox test-instrument matrix: success, insufficient funds, refused, expired, 3DS frictionless and challenge, refused-after-3DS, manual or pending capture, partial capture, partial and multiple refunds, refund failed, and charging blocked when onboarding is incomplete; plus merchant-of-record cases (the clinic is the settlement merchant, refund and chargeback settle from the clinic balance, payout lands in the clinic account).
-- Concurrency and load: a webhook storm of duplicate and out-of-order deliveries must produce exactly-once effects; idempotency-key contention produces one provider object.
-- Financial reconciliation: for a day of sandbox activity, captures minus refunds equals clinic payouts net of provider processing fees, per provider (the platform takes no fee); every capture maps to exactly one invoice transition; currency integrity holds.
-
-### Edge-case traceability
-
-Every correctness requirement above maps to a named test, so completeness is enforceable in CI rather than asserted.
+- Unit: each adapter method (request mapping, response normalization, error mapping); the minor-unit helper with a full currency-exponent matrix.
+- Signature and HMAC verification: valid passes; tampered body, wrong key, and missing signature fail.
+- Service and integration: full lifecycle against a real test database so Prisma writes and constraints are exercised.
+- Webhook harness: de-duplication, out-of-order delivery, the create-versus-webhook race, and idempotency.
+- Frontend and mobile: provider branch, redirect handling, the URL allowlist, return-status normalization, and the onboarding component.
+- End-to-end: pay, refund, and onboarding against both provider sandboxes, in a nightly lane.
 
 ### CI gates
 
-- Per commit: unit, contract (fake target), and frontend and mobile tests, under the repo coverage and Sonar new-code gates, plus type-check and lint and the full backend suite.
-- Nightly: contract against both sandboxes, end-to-end, the test-instrument matrix, load, and reconciliation.
-- A payments code-owner and required-review rule so no payment change merges without the contract suite green.
-
-### Pre-production verification
-
-1. Shadow mode: run the second provider in parallel on a staging organisation with test instruments for at least one week; reconcile daily; require zero discrepancies.
-2. Canary: one pilot organisation in production behind the enable flag and per-organisation provider-config status, with a low daily volume cap.
-3. A production reconciliation job per provider with alerting on any drift.
-
-### Observability, alerting, rollback
-
-- Metrics per provider: authorization success rate, 3DS abandonment, webhook latency and lag, de-duplication drops, refund-pending age, reconciliation drift, payout success.
-- Alerts: webhook processing failures, signature failures, refunds stuck pending beyond a threshold, reconciliation mismatch, and settlement-currency mismatch.
-- Runbooks: webhook backlog, refund stuck, onboarding stuck on verification, switch an organisation's provider, and disable the second provider globally.
-- Rollback: per-organisation flip back to Stripe is a configuration change; the global kill-switch is a tested path.
-
-### Sign-off checklist (gate for enabling real money)
-
-- [ ] Contract suite green on both sandboxes with identical assertions.
-- [ ] Every correctness-requirement test green, including merchant-of-record (clinic is the seller on both providers, platform takes no fee).
-- [ ] Minor-unit property tests green across zero-, two-, and three-decimal currencies.
-- [ ] Webhook harness green for de-duplication, out-of-order, race, batching, fast acknowledgement, and async refund.
-- [ ] Sandbox test-instrument matrix green including 3DS, refused, partial and multiple refunds, clinic-context refund settlement, and readiness-blocked.
-- [ ] End-to-end pay, refund, and onboarding green on both providers.
-- [ ] Reconciliation drift zero for a sandbox day per provider.
-- [ ] Shadow-mode week on staging with zero discrepancies.
-- [ ] Migration up and down, backfill, and a Stripe-unchanged regression green.
-- [ ] Load test produces exactly-once effects.
-- [ ] Per-organisation and global rollback tested.
-- [ ] Frontend and mobile coverage at or above the repo target, Sonar gate green, full backend suite green.
+- Per commit: unit, contract (fake target), and frontend and mobile tests, under the repo coverage and Sonar new-code gates, plus type-check and lint.
+- Nightly: contract against all provider sandboxes, end-to-end, and reconciliation.
 
 ## Open decisions
 
-- Minimum capability set a second adapter must satisfy to be registerable.
-- Redirect (hosted) versus embedded drop-in for the second provider on web and mobile.
-- Per-organisation provider selection (assumed) versus per-checkout selection.
-- Whether the asynchronous refund lifecycle is acceptable as the new behaviour for all providers.
-- One sub-merchant per organisation versus a balance-account one-to-many model on Adyen.
+- CareCredit or Scratchpay first for Phase 1 (based on which has the better API and clinic demand).
+- Per-organisation provider selection (assumed) versus per-checkout selection (a pet owner could choose card or financing at checkout).
+- Whether to surface both Stripe and a financing option at the same checkout, letting the pet owner choose.
 - Org-owner-only versus delegated finance-admin onboarding for the new payment-config permissions.
 - Whether to allow switching the active provider while an organisation has outstanding unsettled payment attempts.
 
 ## Settled decisions
 
-- No platform fee, take-rate, or split on either provider.
-- The clinic is the merchant of record and bears processing fees and chargebacks; the platform is software and governance only.
-- Stripe uses Standard Connect with direct charges; Adyen uses the clinic as sub-merchant. The Stripe destination-to-direct migration is tracked in #1678.
+- No platform fee, take-rate, or split on any provider.
+- The clinic is the merchant of record and bears processing fees; the platform is software and governance only with zero regulatory exposure.
+- Adyen is not a viable second provider: Adyen for Platforms contracts with the platform entity as the regulatory principal, which is incompatible with the zero-regulatory-exposure constraint.
+- Stripe uses Standard Connect with direct charges. The destination-to-direct migration is tracked in #1678.
+- CareCredit and Scratchpay are the target financing providers: each clinic contracts directly with the provider, the platform has no lending or regulatory exposure.

--- a/docs/guide/payment-gateway-multi-provider-plan.md
+++ b/docs/guide/payment-gateway-multi-provider-plan.md
@@ -6,15 +6,24 @@ Scope: `apps/backend`, `apps/frontend`, `apps/mobileAppYC`, `packages/database`,
 
 This document is the detailed design and verification plan behind issue #1659. It describes how to introduce a provider-agnostic payment-gateway abstraction, add Adyen as a second processor selected per organisation, and do so with a test and rollout plan strong enough to enable real money movement with confidence. It contains no credentials or secret values; configuration is referenced by purpose only.
 
+## Settlement model (the core principle)
+
+The platform takes no fee and is never the financial principal. For every customer payment the clinic is the merchant of record: the clinic appears on the payer's statement, the clinic bears the provider processing fee, and the clinic owns refunds and chargebacks. The platform's role is orchestration and governance only. It creates and records payments on the clinic's behalf and keeps full visibility, but it never sits in the settlement path as principal.
+
+- Stripe: Standard Connect accounts with direct charges. The charge is created in the clinic's account context, so the processing fee, the statement descriptor, and dispute liability all sit with the clinic, and negative-balance liability stays with the clinic and Stripe rather than the platform. The platform takes no application fee.
+- Adyen: the clinic is the sub-merchant and merchant of record, settling to the clinic's balance account and bearing fees and chargebacks. The platform takes no split.
+
+There is no platform fee, take-rate, or split on either provider. This supersedes any earlier framing of destination transfers and platform fees. The current Stripe flow uses destination charges, which makes the platform the merchant of record; migrating it to direct charges is a prerequisite for the Stripe adapter to match this model and is tracked in its own issue.
+
 ## Goals
 
 - A stable `PaymentProvider` interface with Stripe as one concrete implementation, selectable per organisation.
-- A second processor (Adyen) behind the same interface, for customer-facing payments and marketplace payouts.
+- A second processor (Adyen) behind the same interface, for clinic-facing payments where the clinic is the merchant of record.
 - A test and verification strategy that proves both providers behave identically from the application's point of view, and that money reconciles end to end.
 
 ## Non-goals (kept single-provider)
 
-- The platform's own SaaS subscription billing (subscription checkout, customer portal, seat proration) stays on Stripe. The second provider does not offer an equivalent subscription-billing product, and this billing path is already cleanly isolated (it writes only `FinanceProviderLink` and `SubscriptionEntitlement`, charges the platform account, and is already gated to a single provider). A clinic can use the second provider for customer payments while its own subscription stays on Stripe, with no data-model conflict, because the provider is stored per row, not per organisation.
+- The platform's own SaaS subscription billing (subscription checkout, customer portal, seat proration) stays on Stripe. The second provider does not offer an equivalent subscription-billing product, and this billing path is already cleanly isolated (it writes only `FinanceProviderLink` and `SubscriptionEntitlement`, charges the platform account, and is already gated to a single provider). A clinic can use the second provider for customer payments while its own subscription stays on Stripe, with no data-model conflict, because the provider is stored per row, not per organisation. This is the one place the platform is the merchant (it is selling its own software to the clinic), and it is deliberately separate from the clinic-facing flow.
 
 ## Current state
 
@@ -24,12 +33,13 @@ The persistence layer is already provider-aware; the orchestration layer is not.
 - `OrganizationBilling` (mapped to `OrgBilling`) holds account-readiness state under Stripe-shaped field names.
 - `FinanceProviderLink` and `IntegrationAccount` are existing per-organisation, per-provider precedents (the latter with a service, store, and settings UI for IDEXX and Merck).
 - The gateway gap: `apps/backend/src/services/stripe.service.ts` is a concrete object that builds the Stripe client directly, and finance and webhook code call it by name. `apps/backend/src/services/finance/payment.ts` does provider-neutral database work but is invoked from inside Stripe-specific webhook handlers, so there is no seam to route a different provider through it.
+- Clinic-facing charges are currently created as destination charges on the platform account (`transfer_data.destination`), which makes the platform the merchant of record. This contradicts the settlement model above and is corrected by the destination-to-direct migration (its own issue).
 - The web client and mobile client are hosted-redirect: the backend returns a URL and the client navigates to it. There is no client-side card collection to replace. The only embedded provider SDK on the web is the connected-account onboarding component.
 
 ## Target architecture
 
 1. `PaymentProviderPort`: the capability surface the rest of finance needs.
-2. `StripeProviderAdapter` and `AdyenProviderAdapter` implementing the port. Stripe is a behaviour-preserving refactor of the existing service.
+2. `StripeProviderAdapter` and `AdyenProviderAdapter` implementing the port. Stripe is a behaviour-preserving refactor of the existing service, on top of the direct-charge model.
 3. `PaymentProviderRegistry`: resolves the adapter for an organisation from its configured active provider.
 4. A normalized webhook pipeline that converts each provider's events into the existing provider-neutral `FinancePaymentService` methods, which remain the source of truth for `PaymentAttempt`, `Payment`, and `Refund` rows.
 5. A currency-exponent-aware minor-unit helper in `packages/lib`, shared by backend, web, and mobile.
@@ -40,14 +50,14 @@ The persistence layer is already provider-aware; the orchestration layer is not.
 ```ts
 interface PaymentProviderPort {
   readonly provider: PaymentProvider;
-  readonly capabilities: ProviderCapabilities; // hosted checkout, splits, automatic tax, hosted receipts
+  readonly capabilities: ProviderCapabilities; // hosted checkout, direct charges, automatic tax, hosted receipts
 
   // onboarding / account lifecycle
   createOrGetConnectedAccount(orgId: string): Promise<{ accountRef: string }>;
   createOnboardingLink(orgId: string): Promise<{ url?: string; clientSecret?: string }>;
   getAccountStatus(orgId: string): Promise<AccountReadiness>;
 
-  // payment lifecycle (gateway owns minor-unit and idempotency-key handling)
+  // payment lifecycle (charge created in the clinic's account context; gateway owns minor-unit and idempotency-key handling)
   createCheckoutSession(
     input: NormalizedCheckoutInput
   ): Promise<{ providerRef: string; redirectUrl?: string; clientToken?: string }>;
@@ -77,21 +87,24 @@ The second provider differs from Stripe in ways that shape the design:
 
 Consequences carried into the plan: asynchronous refund and capture lifecycle, an idempotency and event de-duplication store, off-thread webhook processing (the existing queue and worker directories are the home), per-merchant verification key resolution, and a currency-exponent-aware money helper.
 
-## Marketplace (connected accounts and payouts)
+## Connected accounts and settlement
 
-The current single connected-account model maps to the second provider's platform model as follows:
+The clinic is the merchant of record on both providers, and the platform takes no fee on either. The current single connected-account model maps as follows:
 
-| Concept                    | Current (Stripe)                              | Second provider (Adyen for Platforms)            |
-| -------------------------- | --------------------------------------------- | ------------------------------------------------ |
-| Connected entity           | one connected account                         | account holder plus one or more balance accounts |
-| Onboarding                 | embedded component                            | hosted onboarding link                           |
-| Readiness and capabilities | charges and payouts enabled, requirements     | capabilities and verification deadlines          |
-| Payment routing            | destination transfer to the connected account | split settlement to the balance account          |
-| Platform fee               | optional fee on the charge                    | a split entry where supported                    |
-| Refund                     | must reverse any split or transfer            | split reversal                                   |
-| Payout                     | provider-managed schedule                     | provider payout configuration                    |
+| Concept                     | Stripe (Standard Connect, direct charges)       | Adyen (clinic as sub-merchant)                   |
+| --------------------------- | ----------------------------------------------- | ------------------------------------------------ |
+| Connected entity            | one connected account per clinic                | account holder plus one or more balance accounts |
+| Onboarding                  | embedded component                              | hosted onboarding link                           |
+| Readiness and capabilities  | charges and payouts enabled, requirements       | capabilities and verification deadlines          |
+| Where the charge is created | in the clinic's account context (direct charge) | against the clinic as sub-merchant               |
+| Merchant of record          | clinic                                          | clinic                                           |
+| Processing fee              | borne by the clinic                             | borne by the clinic                              |
+| Platform fee                | none                                            | none                                             |
+| Refund and chargeback       | settled from the clinic's balance               | settled from the clinic's balance                |
+| Negative-balance liability  | clinic and Stripe (Standard)                    | clinic                                           |
+| Payout                      | provider-managed to the clinic                  | provider-managed to the clinic's balance account |
 
-Because the second provider uses balance accounts, the stored single-account scalar must become a one-to-many relation. Provider-side tax-on-connected-account features that have no second-provider equivalent require the tax-ownership decision in Open decisions.
+Because Adyen uses balance accounts, the stored single-account scalar may become a one-to-many relation on that provider. The clinic is the tax merchant of record on both providers, which matches the existing tax configuration (the invoice issuer and tax-liability account are already the clinic).
 
 ## Client plan
 
@@ -103,20 +116,21 @@ Because the second provider uses balance accounts, the stored single-account sca
 
 The implementation must satisfy the following. Each is a named test in the test plan.
 
-| Area                         | Requirement                                                                                                                                                        |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Currency exponents           | Amounts convert to and from provider minor units using the correct per-currency exponent (zero-, two-, and three-decimal currencies).                              |
-| Idempotency                  | Provider create calls carry idempotency keys; redelivered or duplicated webhook events apply at most once.                                                         |
-| Async refund and capture     | Refund and capture move through a pending state and are finalized to succeeded or failed by webhook.                                                               |
-| Split reversal               | Refunds reverse any provider-side split or transfer so funds return from the correct balance.                                                                      |
-| Partial and multiple refunds | Partial and repeated refunds are represented accurately and never exceed the captured amount in aggregate.                                                         |
-| Race safety                  | The payment attempt is persisted before the provider call, and webhook handlers are idempotent, so an early webhook cannot mis-handle a not-yet-persisted attempt. |
-| Readiness gating             | Charging is blocked when an account exists but is not yet able to accept payments.                                                                                 |
-| Return URLs                  | Success and cancel return URLs are distinct, and return-status parsing is provider-aware.                                                                          |
-| Over-payment and over-refund | Amounts beyond the outstanding balance or captured amount are handled explicitly, not silently discarded.                                                          |
-| Failed attempts              | A failed payment records a failure code and message and reconciles the attempt state.                                                                              |
-| Multiple accounts            | The data model supports a one-to-many account model where a provider requires it.                                                                                  |
-| Tax                          | For a provider without a tax engine, invoice tax is finalized before payment.                                                                                      |
+| Area                         | Requirement                                                                                                                                                                        |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Merchant of record           | Clinic-facing charges are created in the clinic's account context so the clinic is the merchant of record, bears the processing fee, and owns disputes; the platform takes no fee. |
+| Currency exponents           | Amounts convert to and from provider minor units using the correct per-currency exponent (zero-, two-, and three-decimal currencies).                                              |
+| Idempotency                  | Provider create calls carry idempotency keys; redelivered or duplicated webhook events apply at most once.                                                                         |
+| Async refund and capture     | Refund and capture move through a pending state and are finalized to succeeded or failed by webhook.                                                                               |
+| Refund settlement            | Refunds and chargebacks are issued in the clinic's account context and settle from the clinic's balance, never the platform's.                                                     |
+| Partial and multiple refunds | Partial and repeated refunds are represented accurately and never exceed the captured amount in aggregate.                                                                         |
+| Race safety                  | The payment attempt is persisted before the provider call, and webhook handlers are idempotent, so an early webhook cannot mis-handle a not-yet-persisted attempt.                 |
+| Readiness gating             | Charging is blocked when an account exists but is not yet able to accept payments.                                                                                                 |
+| Return URLs                  | Success and cancel return URLs are distinct, and return-status parsing is provider-aware.                                                                                          |
+| Over-payment and over-refund | Amounts beyond the outstanding balance or captured amount are handled explicitly, not silently discarded.                                                                          |
+| Failed attempts              | A failed payment records a failure code and message and reconciles the attempt state.                                                                                              |
+| Multiple accounts            | The data model supports a one-to-many account model where a provider requires it.                                                                                                  |
+| Tax                          | The clinic is the tax merchant of record; for a provider without a tax engine, invoice tax is finalized before payment.                                                            |
 
 ## Data model deltas (additive)
 
@@ -129,9 +143,9 @@ The implementation must satisfy the following. Each is a named test in the test 
 
 ## Phased delivery
 
-- Phase 0: provider port, registry, the prerequisite hardening (idempotency and de-duplication store, currency-exponent helper, asynchronous refund and capture lifecycle, race-safe reconciliation, split reversal on refund, distinct return URLs), and the Stripe adapter as a behaviour-preserving refactor. No behaviour change; the largest and most valuable single piece even if the second provider never ships.
+- Phase 0: provider port, registry, the prerequisite hardening (idempotency and de-duplication store, currency-exponent helper, asynchronous refund and capture lifecycle, race-safe reconciliation, clinic-context refund settlement, distinct return URLs), and the Stripe adapter as a behaviour-preserving refactor on top of the direct-charge model. The direct-charge migration is its own issue and lands first. The largest and most valuable single piece even if the second provider never ships.
 - Phase 1: second-provider payments (no payouts) in a sandbox merchant account, redirect client flow on web and mobile, behind a global enable flag and a per-organisation provider-config status, on one pilot organisation.
-- Phase 2: second-provider marketplace (onboarding, splits, payout reconciliation).
+- Phase 2: second-provider connected accounts (onboarding, sub-merchant settlement, payout reconciliation).
 - Phase 3: rollout, settings UI mirroring the existing Integrations page, per-organisation toggle, and operational dashboards.
 
 ## Testing and verification
@@ -150,9 +164,9 @@ One provider-agnostic contract test suite is run against every implementation: t
 - Webhook harness: de-duplication, out-of-order delivery, the create-versus-webhook race, batched notifications, fast acknowledgement even when business processing fails (with dead-lettering rather than an error response), and the off-thread handoff.
 - Frontend and mobile: provider branch, redirect handling, the URL allowlist, return-status normalization, the onboarding component, and cancel-versus-error mapping on mobile.
 - End-to-end (new): pay, refund, and onboarding against both sandboxes, in a nightly lane.
-- Sandbox test-instrument matrix: success, insufficient funds, refused, expired, 3DS frictionless and challenge, refused-after-3DS, manual or pending capture, partial capture, partial and multiple refunds, refund failed, and charging blocked when onboarding is incomplete; plus marketplace cases (split applied, refund reverses split, payout lands in the correct balance).
+- Sandbox test-instrument matrix: success, insufficient funds, refused, expired, 3DS frictionless and challenge, refused-after-3DS, manual or pending capture, partial capture, partial and multiple refunds, refund failed, and charging blocked when onboarding is incomplete; plus merchant-of-record cases (the clinic is the settlement merchant, refund and chargeback settle from the clinic balance, payout lands in the clinic account).
 - Concurrency and load: a webhook storm of duplicate and out-of-order deliveries must produce exactly-once effects; idempotency-key contention produces one provider object.
-- Financial reconciliation: for a day of sandbox activity, captures minus refunds minus platform fees equals payouts, per provider; every capture maps to exactly one invoice transition; currency integrity holds.
+- Financial reconciliation: for a day of sandbox activity, captures minus refunds equals clinic payouts net of provider processing fees, per provider (the platform takes no fee); every capture maps to exactly one invoice transition; currency integrity holds.
 
 ### Edge-case traceability
 
@@ -180,10 +194,10 @@ Every correctness requirement above maps to a named test, so completeness is enf
 ### Sign-off checklist (gate for enabling real money)
 
 - [ ] Contract suite green on both sandboxes with identical assertions.
-- [ ] Every correctness-requirement test green.
+- [ ] Every correctness-requirement test green, including merchant-of-record (clinic is the seller on both providers, platform takes no fee).
 - [ ] Minor-unit property tests green across zero-, two-, and three-decimal currencies.
 - [ ] Webhook harness green for de-duplication, out-of-order, race, batching, fast acknowledgement, and async refund.
-- [ ] Sandbox test-instrument matrix green including 3DS, refused, partial and multiple refunds, split reversal, and readiness-blocked.
+- [ ] Sandbox test-instrument matrix green including 3DS, refused, partial and multiple refunds, clinic-context refund settlement, and readiness-blocked.
 - [ ] End-to-end pay, refund, and onboarding green on both providers.
 - [ ] Reconciliation drift zero for a sandbox day per provider.
 - [ ] Shadow-mode week on staging with zero discrepancies.
@@ -198,7 +212,12 @@ Every correctness requirement above maps to a named test, so completeness is enf
 - Redirect (hosted) versus embedded drop-in for the second provider on web and mobile.
 - Per-organisation provider selection (assumed) versus per-checkout selection.
 - Whether the asynchronous refund lifecycle is acceptable as the new behaviour for all providers.
-- One sub-merchant per organisation versus a balance-account one-to-many model.
-- Platform fee and split policy where a provider supports it.
+- One sub-merchant per organisation versus a balance-account one-to-many model on Adyen.
 - Org-owner-only versus delegated finance-admin onboarding for the new payment-config permissions.
 - Whether to allow switching the active provider while an organisation has outstanding unsettled payment attempts.
+
+## Settled decisions
+
+- No platform fee, take-rate, or split on either provider.
+- The clinic is the merchant of record and bears processing fees and chargebacks; the platform is software and governance only.
+- Stripe uses Standard Connect with direct charges; Adyen uses the clinic as sub-merchant. The Stripe destination-to-direct migration is tracked in its own issue.

--- a/docs/guide/payment-gateway-multi-provider-plan.md
+++ b/docs/guide/payment-gateway-multi-provider-plan.md
@@ -1,0 +1,204 @@
+# Payment Gateway Abstraction and Multi-Provider Support (Stripe + Adyen)
+
+Status: proposal (design and test plan)
+Related issue: #1659
+Scope: `apps/backend`, `apps/frontend`, `apps/mobileAppYC`, `packages/database`, `packages/lib`
+
+This document is the detailed design and verification plan behind issue #1659. It describes how to introduce a provider-agnostic payment-gateway abstraction, add Adyen as a second processor selected per organisation, and do so with a test and rollout plan strong enough to enable real money movement with confidence. It contains no credentials or secret values; configuration is referenced by purpose only.
+
+## Goals
+
+- A stable `PaymentProvider` interface with Stripe as one concrete implementation, selectable per organisation.
+- A second processor (Adyen) behind the same interface, for customer-facing payments and marketplace payouts.
+- A test and verification strategy that proves both providers behave identically from the application's point of view, and that money reconciles end to end.
+
+## Non-goals (kept single-provider)
+
+- The platform's own SaaS subscription billing (subscription checkout, customer portal, seat proration) stays on Stripe. The second provider does not offer an equivalent subscription-billing product, and this billing path is already cleanly isolated (it writes only `FinanceProviderLink` and `SubscriptionEntitlement`, charges the platform account, and is already gated to a single provider). A clinic can use the second provider for customer payments while its own subscription stays on Stripe, with no data-model conflict, because the provider is stored per row, not per organisation.
+
+## Current state
+
+The persistence layer is already provider-aware; the orchestration layer is not.
+
+- `enum PaymentProvider { STRIPE  MANUAL }` is referenced by `PaymentAttempt`, `Payment`, and `Refund`, each indexed on `provider`.
+- `OrganizationBilling` (mapped to `OrgBilling`) holds account-readiness state under Stripe-shaped field names.
+- `FinanceProviderLink` and `IntegrationAccount` are existing per-organisation, per-provider precedents (the latter with a service, store, and settings UI for IDEXX and Merck).
+- The gateway gap: `apps/backend/src/services/stripe.service.ts` is a concrete object that builds the Stripe client directly, and finance and webhook code call it by name. `apps/backend/src/services/finance/payment.ts` does provider-neutral database work but is invoked from inside Stripe-specific webhook handlers, so there is no seam to route a different provider through it.
+- The web client and mobile client are hosted-redirect: the backend returns a URL and the client navigates to it. There is no client-side card collection to replace. The only embedded provider SDK on the web is the connected-account onboarding component.
+
+## Target architecture
+
+1. `PaymentProviderPort`: the capability surface the rest of finance needs.
+2. `StripeProviderAdapter` and `AdyenProviderAdapter` implementing the port. Stripe is a behaviour-preserving refactor of the existing service.
+3. `PaymentProviderRegistry`: resolves the adapter for an organisation from its configured active provider.
+4. A normalized webhook pipeline that converts each provider's events into the existing provider-neutral `FinancePaymentService` methods, which remain the source of truth for `PaymentAttempt`, `Payment`, and `Refund` rows.
+5. A currency-exponent-aware minor-unit helper in `packages/lib`, shared by backend, web, and mobile.
+6. Asynchronous webhook intake: accept and acknowledge batched notifications quickly, then process off-thread, with an idempotency and event de-duplication store.
+
+### The port (illustrative)
+
+```ts
+interface PaymentProviderPort {
+  readonly provider: PaymentProvider;
+  readonly capabilities: ProviderCapabilities; // hosted checkout, splits, automatic tax, hosted receipts
+
+  // onboarding / account lifecycle
+  createOrGetConnectedAccount(orgId: string): Promise<{ accountRef: string }>;
+  createOnboardingLink(orgId: string): Promise<{ url?: string; clientSecret?: string }>;
+  getAccountStatus(orgId: string): Promise<AccountReadiness>;
+
+  // payment lifecycle (gateway owns minor-unit and idempotency-key handling)
+  createCheckoutSession(
+    input: NormalizedCheckoutInput
+  ): Promise<{ providerRef: string; redirectUrl?: string; clientToken?: string }>;
+  createPayment(
+    input: NormalizedPaymentInput
+  ): Promise<{ providerPaymentRef: string; clientSecret?: string; status: PaymentAttemptStatus }>;
+  refund(input: NormalizedRefundInput): Promise<{ refundRef: string; status: RefundStatus }>;
+
+  // webhooks (normalize into existing FinancePaymentService inputs)
+  verifyAndNormalizeWebhook(
+    rawBody: Buffer,
+    headers: Record<string, string>
+  ): NormalizedPaymentEvent[];
+}
+```
+
+The existing `FinancePaymentService` webhook-facing methods already take plain provider-neutral inputs (invoice reference, amount in major units, currency), so they are the natural normalization sink. Adapters translate provider-specific shapes (payment intent, charge, session id, or psp reference) into these inputs.
+
+## Asynchronous-provider implications
+
+The second provider differs from Stripe in ways that shape the design:
+
+- It sends batched webhook notifications and expects a fast, fixed acknowledgement, then asynchronous processing.
+- Refund, capture, and payout outcomes are confirmed only by webhook, not in the API response.
+- Webhook authenticity is verified per merchant account, not against a single global secret.
+- Amounts are always in minor units with a per-currency exponent.
+
+Consequences carried into the plan: asynchronous refund and capture lifecycle, an idempotency and event de-duplication store, off-thread webhook processing (the existing queue and worker directories are the home), per-merchant verification key resolution, and a currency-exponent-aware money helper.
+
+## Marketplace (connected accounts and payouts)
+
+The current single connected-account model maps to the second provider's platform model as follows:
+
+| Concept                    | Current (Stripe)                              | Second provider (Adyen for Platforms)            |
+| -------------------------- | --------------------------------------------- | ------------------------------------------------ |
+| Connected entity           | one connected account                         | account holder plus one or more balance accounts |
+| Onboarding                 | embedded component                            | hosted onboarding link                           |
+| Readiness and capabilities | charges and payouts enabled, requirements     | capabilities and verification deadlines          |
+| Payment routing            | destination transfer to the connected account | split settlement to the balance account          |
+| Platform fee               | optional fee on the charge                    | a split entry where supported                    |
+| Refund                     | must reverse any split or transfer            | split reversal                                   |
+| Payout                     | provider-managed schedule                     | provider payout configuration                    |
+
+Because the second provider uses balance accounts, the stored single-account scalar must become a one-to-many relation. Provider-side tax-on-connected-account features that have no second-provider equivalent require the tax-ownership decision in Open decisions.
+
+## Client plan
+
+- Web: branch on the organisation's selected provider; generalize the redirect-URL allowlist so the second provider's hosted pages are permitted; normalize return-status parsing across providers; provide a per-provider onboarding component. The current hosted-redirect model means most flows need only provider plumbing and allowlist changes, not embedded card UI.
+- Mobile: thread the selected provider through the payment-session request; branch the provider component at the app root; wire the deep-link return path for redirect-based methods (the current app handles its own redirect interception, so this must be made explicit for a second provider).
+- Embedded drop-in (cards rendered in-app) on either client is an optional later enhancement, not required for the redirect-first launch.
+
+## Correctness requirements
+
+The implementation must satisfy the following. Each is a named test in the test plan.
+
+| Area                         | Requirement                                                                                                                                                        |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Currency exponents           | Amounts convert to and from provider minor units using the correct per-currency exponent (zero-, two-, and three-decimal currencies).                              |
+| Idempotency                  | Provider create calls carry idempotency keys; redelivered or duplicated webhook events apply at most once.                                                         |
+| Async refund and capture     | Refund and capture move through a pending state and are finalized to succeeded or failed by webhook.                                                               |
+| Split reversal               | Refunds reverse any provider-side split or transfer so funds return from the correct balance.                                                                      |
+| Partial and multiple refunds | Partial and repeated refunds are represented accurately and never exceed the captured amount in aggregate.                                                         |
+| Race safety                  | The payment attempt is persisted before the provider call, and webhook handlers are idempotent, so an early webhook cannot mis-handle a not-yet-persisted attempt. |
+| Readiness gating             | Charging is blocked when an account exists but is not yet able to accept payments.                                                                                 |
+| Return URLs                  | Success and cancel return URLs are distinct, and return-status parsing is provider-aware.                                                                          |
+| Over-payment and over-refund | Amounts beyond the outstanding balance or captured amount are handled explicitly, not silently discarded.                                                          |
+| Failed attempts              | A failed payment records a failure code and message and reconciles the attempt state.                                                                              |
+| Multiple accounts            | The data model supports a one-to-many account model where a provider requires it.                                                                                  |
+| Tax                          | For a provider without a tax engine, invoice tax is finalized before payment.                                                                                      |
+
+## Data model deltas (additive)
+
+- Add `ADYEN` to `enum PaymentProvider`.
+- Add `activePaymentProvider` (default `STRIPE`), a provider-neutral `onboardingState`, and `onboardingUpdatedAt` to `OrganizationBilling`; retain `canAcceptPayments` as the cross-provider readiness gate; keep existing connect-shaped columns for backward compatibility behind the neutral rollup.
+- Add a processed-webhook-event table keyed on provider plus provider event reference.
+- Add a per-organisation provider-config table (Prisma-only, no Mongoose mirror, per repo convention) carrying the active provider, the second provider's account references, credentials reference, and an enabled or status flag for staged rollout.
+- Add audit event and entity enum members for payment-configuration changes.
+- Backfill existing rows from current columns; no external API calls.
+
+## Phased delivery
+
+- Phase 0: provider port, registry, the prerequisite hardening (idempotency and de-duplication store, currency-exponent helper, asynchronous refund and capture lifecycle, race-safe reconciliation, split reversal on refund, distinct return URLs), and the Stripe adapter as a behaviour-preserving refactor. No behaviour change; the largest and most valuable single piece even if the second provider never ships.
+- Phase 1: second-provider payments (no payouts) in a sandbox merchant account, redirect client flow on web and mobile, behind a global enable flag and a per-organisation provider-config status, on one pilot organisation.
+- Phase 2: second-provider marketplace (onboarding, splits, payout reconciliation).
+- Phase 3: rollout, settings UI mirroring the existing Integrations page, per-organisation toggle, and operational dashboards.
+
+## Testing and verification
+
+A payments change moves money, so the test plan is first-class.
+
+### Contract suite (the centerpiece)
+
+One provider-agnostic contract test suite is run against every implementation: the Stripe adapter, the Adyen adapter, and an in-memory fake. Same assertions, three targets. The fake target runs per commit (fast, deterministic); the sandbox targets run nightly against test environments. This is what guarantees the two providers are interchangeable from the application's point of view.
+
+### Layered tests
+
+- Unit: each adapter method (request mapping, response normalization, error mapping); the minor-unit helper as property and table tests across the full currency-exponent matrix with golden cases for zero- and three-decimal currencies; webhook normalizers over recorded sandbox payloads.
+- Signature and HMAC verification: valid passes; tampered body, wrong key, and missing signature fail; per-merchant key resolution is correct.
+- Service and integration: full lifecycle against a real test database so Prisma writes and constraints are exercised (create, webhook success, invoice paid, refund pending then succeeded or failed), including the database uniqueness guards under concurrent duplicate webhooks.
+- Webhook harness: de-duplication, out-of-order delivery, the create-versus-webhook race, batched notifications, fast acknowledgement even when business processing fails (with dead-lettering rather than an error response), and the off-thread handoff.
+- Frontend and mobile: provider branch, redirect handling, the URL allowlist, return-status normalization, the onboarding component, and cancel-versus-error mapping on mobile.
+- End-to-end (new): pay, refund, and onboarding against both sandboxes, in a nightly lane.
+- Sandbox test-instrument matrix: success, insufficient funds, refused, expired, 3DS frictionless and challenge, refused-after-3DS, manual or pending capture, partial capture, partial and multiple refunds, refund failed, and charging blocked when onboarding is incomplete; plus marketplace cases (split applied, refund reverses split, payout lands in the correct balance).
+- Concurrency and load: a webhook storm of duplicate and out-of-order deliveries must produce exactly-once effects; idempotency-key contention produces one provider object.
+- Financial reconciliation: for a day of sandbox activity, captures minus refunds minus platform fees equals payouts, per provider; every capture maps to exactly one invoice transition; currency integrity holds.
+
+### Edge-case traceability
+
+Every correctness requirement above maps to a named test, so completeness is enforceable in CI rather than asserted.
+
+### CI gates
+
+- Per commit: unit, contract (fake target), and frontend and mobile tests, under the repo coverage and Sonar new-code gates, plus type-check and lint and the full backend suite.
+- Nightly: contract against both sandboxes, end-to-end, the test-instrument matrix, load, and reconciliation.
+- A payments code-owner and required-review rule so no payment change merges without the contract suite green.
+
+### Pre-production verification
+
+1. Shadow mode: run the second provider in parallel on a staging organisation with test instruments for at least one week; reconcile daily; require zero discrepancies.
+2. Canary: one pilot organisation in production behind the enable flag and per-organisation provider-config status, with a low daily volume cap.
+3. A production reconciliation job per provider with alerting on any drift.
+
+### Observability, alerting, rollback
+
+- Metrics per provider: authorization success rate, 3DS abandonment, webhook latency and lag, de-duplication drops, refund-pending age, reconciliation drift, payout success.
+- Alerts: webhook processing failures, signature failures, refunds stuck pending beyond a threshold, reconciliation mismatch, and settlement-currency mismatch.
+- Runbooks: webhook backlog, refund stuck, onboarding stuck on verification, switch an organisation's provider, and disable the second provider globally.
+- Rollback: per-organisation flip back to Stripe is a configuration change; the global kill-switch is a tested path.
+
+### Sign-off checklist (gate for enabling real money)
+
+- [ ] Contract suite green on both sandboxes with identical assertions.
+- [ ] Every correctness-requirement test green.
+- [ ] Minor-unit property tests green across zero-, two-, and three-decimal currencies.
+- [ ] Webhook harness green for de-duplication, out-of-order, race, batching, fast acknowledgement, and async refund.
+- [ ] Sandbox test-instrument matrix green including 3DS, refused, partial and multiple refunds, split reversal, and readiness-blocked.
+- [ ] End-to-end pay, refund, and onboarding green on both providers.
+- [ ] Reconciliation drift zero for a sandbox day per provider.
+- [ ] Shadow-mode week on staging with zero discrepancies.
+- [ ] Migration up and down, backfill, and a Stripe-unchanged regression green.
+- [ ] Load test produces exactly-once effects.
+- [ ] Per-organisation and global rollback tested.
+- [ ] Frontend and mobile coverage at or above the repo target, Sonar gate green, full backend suite green.
+
+## Open decisions
+
+- Minimum capability set a second adapter must satisfy to be registerable.
+- Redirect (hosted) versus embedded drop-in for the second provider on web and mobile.
+- Per-organisation provider selection (assumed) versus per-checkout selection.
+- Whether the asynchronous refund lifecycle is acceptable as the new behaviour for all providers.
+- One sub-merchant per organisation versus a balance-account one-to-many model.
+- Platform fee and split policy where a provider supports it.
+- Org-owner-only versus delegated finance-admin onboarding for the new payment-config permissions.
+- Whether to allow switching the active provider while an organisation has outstanding unsettled payment attempts.

--- a/docs/guide/payment-gateway-multi-provider-plan.md
+++ b/docs/guide/payment-gateway-multi-provider-plan.md
@@ -13,7 +13,7 @@ The platform takes no fee and is never the financial principal. For every custom
 - Stripe: Standard Connect accounts with direct charges. The charge is created in the clinic's account context, so the processing fee, the statement descriptor, and dispute liability all sit with the clinic, and negative-balance liability stays with the clinic and Stripe rather than the platform. The platform takes no application fee.
 - Adyen: the clinic is the sub-merchant and merchant of record, settling to the clinic's balance account and bearing fees and chargebacks. The platform takes no split.
 
-There is no platform fee, take-rate, or split on either provider. This supersedes any earlier framing of destination transfers and platform fees. The current Stripe flow uses destination charges, which makes the platform the merchant of record; migrating it to direct charges is a prerequisite for the Stripe adapter to match this model and is tracked in its own issue.
+There is no platform fee, take-rate, or split on either provider. This supersedes any earlier framing of destination transfers and platform fees. The current Stripe flow uses destination charges, which makes the platform the merchant of record; migrating it to direct charges is a prerequisite for the Stripe adapter to match this model and is tracked in #1678.
 
 ## Goals
 
@@ -33,7 +33,7 @@ The persistence layer is already provider-aware; the orchestration layer is not.
 - `OrganizationBilling` (mapped to `OrgBilling`) holds account-readiness state under Stripe-shaped field names.
 - `FinanceProviderLink` and `IntegrationAccount` are existing per-organisation, per-provider precedents (the latter with a service, store, and settings UI for IDEXX and Merck).
 - The gateway gap: `apps/backend/src/services/stripe.service.ts` is a concrete object that builds the Stripe client directly, and finance and webhook code call it by name. `apps/backend/src/services/finance/payment.ts` does provider-neutral database work but is invoked from inside Stripe-specific webhook handlers, so there is no seam to route a different provider through it.
-- Clinic-facing charges are currently created as destination charges on the platform account (`transfer_data.destination`), which makes the platform the merchant of record. This contradicts the settlement model above and is corrected by the destination-to-direct migration (its own issue).
+- Clinic-facing charges are currently created as destination charges on the platform account (`transfer_data.destination`), which makes the platform the merchant of record. This contradicts the settlement model above and is corrected by the destination-to-direct migration (#1678).
 - The web client and mobile client are hosted-redirect: the backend returns a URL and the client navigates to it. There is no client-side card collection to replace. The only embedded provider SDK on the web is the connected-account onboarding component.
 
 ## Target architecture
@@ -143,7 +143,7 @@ The implementation must satisfy the following. Each is a named test in the test 
 
 ## Phased delivery
 
-- Phase 0: provider port, registry, the prerequisite hardening (idempotency and de-duplication store, currency-exponent helper, asynchronous refund and capture lifecycle, race-safe reconciliation, clinic-context refund settlement, distinct return URLs), and the Stripe adapter as a behaviour-preserving refactor on top of the direct-charge model. The direct-charge migration is its own issue and lands first. The largest and most valuable single piece even if the second provider never ships.
+- Phase 0: provider port, registry, the prerequisite hardening (idempotency and de-duplication store, currency-exponent helper, asynchronous refund and capture lifecycle, race-safe reconciliation, clinic-context refund settlement, distinct return URLs), and the Stripe adapter as a behaviour-preserving refactor on top of the direct-charge model. The direct-charge migration (#1678) lands first. The largest and most valuable single piece even if the second provider never ships.
 - Phase 1: second-provider payments (no payouts) in a sandbox merchant account, redirect client flow on web and mobile, behind a global enable flag and a per-organisation provider-config status, on one pilot organisation.
 - Phase 2: second-provider connected accounts (onboarding, sub-merchant settlement, payout reconciliation).
 - Phase 3: rollout, settings UI mirroring the existing Integrations page, per-organisation toggle, and operational dashboards.
@@ -220,4 +220,4 @@ Every correctness requirement above maps to a named test, so completeness is enf
 
 - No platform fee, take-rate, or split on either provider.
 - The clinic is the merchant of record and bears processing fees and chargebacks; the platform is software and governance only.
-- Stripe uses Standard Connect with direct charges; Adyen uses the clinic as sub-merchant. The Stripe destination-to-direct migration is tracked in its own issue.
+- Stripe uses Standard Connect with direct charges; Adyen uses the clinic as sub-merchant. The Stripe destination-to-direct migration is tracked in #1678.

--- a/docs/guide/pims-architecture.md
+++ b/docs/guide/pims-architecture.md
@@ -1681,7 +1681,7 @@ model Template {
 ```typescript
 // packages/types/src/payment-gateway.ts
 export interface IPaymentGateway {
-  readonly provider: string; // 'STRIPE' | 'RAZORPAY' | 'ADYEN'
+  readonly provider: string; // 'STRIPE' | 'CARECREDIT' | 'SCRATCHPAY' | 'MANUAL'
 
   createCheckoutSession(params: {
     lineItems: { name: string; amountCents: number; quantity: number }[];
@@ -1709,7 +1709,7 @@ export interface IPaymentGateway {
 }
 
 // Stripe implementation: apps/backend/src/payment-gateways/stripe.gateway.ts
-// Future: RazorpayGateway, AdyenGateway, SquareGateway
+// Future: CareCreditGateway, ScratchpayGateway
 ```
 
 ### New Invoice Prisma Schema

--- a/packages/database/prisma/migrations/20260630000000_add_processed_webhook_event/migration.sql
+++ b/packages/database/prisma/migrations/20260630000000_add_processed_webhook_event/migration.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "ProcessedWebhookEvent" (
+    "id" TEXT NOT NULL,
+    "providerEventRef" TEXT NOT NULL,
+    "providerId" TEXT NOT NULL,
+    "processedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ProcessedWebhookEvent_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "ProcessedWebhookEvent_providerEventRef_providerId_key"
+    ON "ProcessedWebhookEvent"("providerEventRef", "providerId");
+
+CREATE INDEX "ProcessedWebhookEvent_processedAt_idx"
+    ON "ProcessedWebhookEvent"("processedAt");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -2920,6 +2920,17 @@ model Refund {
   @@index([status])
 }
 
+model ProcessedWebhookEvent {
+  id               String   @id @default(uuid())
+  providerEventRef String
+  providerId       String
+  processedAt      DateTime @default(now())
+
+  @@unique([providerEventRef, providerId])
+  @@index([processedAt])
+  @@map("ProcessedWebhookEvent")
+}
+
 model CreditNote {
   id               String           @id @default(uuid())
   invoiceId        String

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -13,6 +13,7 @@ export type { JsonObject, JsonPrimitive, JsonValue, Nullable, Optional } from '.
 export { addCachedPromise, type CachedPromise } from './utils/cached-promise-cache.js';
 export { mapAxiosError, type ExternalHttpError } from './utils/external-error.js';
 export { buildGeoPoint, type GeoPoint } from './utils/geojson.js';
+export { fromMinorUnits, getCurrencyExponent, toMinorUnits } from './money/minor-units.js';
 export {
   resolvePaymentCollectionMethod,
   type PaymentCollectionMethodValue,

--- a/packages/lib/src/money/minor-units.ts
+++ b/packages/lib/src/money/minor-units.ts
@@ -1,0 +1,109 @@
+/**
+ * Currency-exponent-aware minor-unit conversion.
+ *
+ * Payment providers transact in the smallest unit of a currency (its minor
+ * unit): cents for USD, but whole yen for JPY (0 decimals) and thousandths of a
+ * dinar for BHD (3 decimals). A fixed multiply-by-100 over-charges or
+ * under-charges every currency whose minor-unit exponent is not 2. These helpers
+ * convert between major units (the amount a person reads, e.g. 19.99) and minor
+ * units (what a provider expects, e.g. 1999) using the ISO 4217 exponent.
+ */
+
+const ZERO_DECIMAL_CURRENCIES = new Set<string>([
+  'BIF',
+  'CLP',
+  'DJF',
+  'GNF',
+  'ISK',
+  'JPY',
+  'KMF',
+  'KRW',
+  'PYG',
+  'RWF',
+  'UGX',
+  'UYI',
+  'VND',
+  'VUV',
+  'XAF',
+  'XOF',
+  'XPF',
+]);
+
+const THREE_DECIMAL_CURRENCIES = new Set<string>(['BHD', 'IQD', 'JOD', 'KWD', 'LYD', 'OMR', 'TND']);
+
+const FOUR_DECIMAL_CURRENCIES = new Set<string>(['CLF', 'UYW']);
+
+const DEFAULT_EXPONENT = 2;
+
+/** Precision (decimal places) used to absorb binary floating-point drift before the final integer round. */
+const DE_DRIFT_PRECISION = 4;
+
+function normalizeCurrency(currency: string): string {
+  if (typeof currency !== 'string') {
+    throw new RangeError('Currency code must be a string');
+  }
+  const code = currency.trim().toUpperCase();
+  if (!/^[A-Z]{3}$/.test(code)) {
+    throw new RangeError(`Invalid ISO 4217 currency code: ${JSON.stringify(currency)}`);
+  }
+  return code;
+}
+
+/**
+ * Returns the number of decimal places (the minor-unit exponent) for an ISO 4217
+ * currency code. Case-insensitive. Currencies not in the zero-, three-, or
+ * four-decimal sets default to two decimals, which is the ISO 4217 default.
+ *
+ * @throws RangeError if the code is not a three-letter alphabetic string.
+ */
+export function getCurrencyExponent(currency: string): number {
+  const code = normalizeCurrency(currency);
+  if (ZERO_DECIMAL_CURRENCIES.has(code)) {
+    return 0;
+  }
+  if (THREE_DECIMAL_CURRENCIES.has(code)) {
+    return 3;
+  }
+  if (FOUR_DECIMAL_CURRENCIES.has(code)) {
+    return 4;
+  }
+  return DEFAULT_EXPONENT;
+}
+
+/**
+ * Converts a major-unit amount (e.g. 19.99) to an integer count of minor units
+ * (e.g. 1999) for the given currency. Rounds half away from zero to the nearest
+ * minor unit.
+ *
+ * @throws RangeError if the amount is not finite or the currency code is invalid.
+ */
+export function toMinorUnits(majorAmount: number, currency: string): number {
+  if (typeof majorAmount !== 'number' || !Number.isFinite(majorAmount)) {
+    throw new RangeError(`Amount must be a finite number, received ${JSON.stringify(majorAmount)}`);
+  }
+  const exponent = getCurrencyExponent(currency);
+  const factor = 10 ** exponent;
+  // Scaling a float by a power of ten reintroduces representation error
+  // (1.1 * 100 === 110.00000000000001). Fix the value at a precision a few places
+  // beyond the target, then round to the nearest integer half away from zero.
+  const scaled = Number((majorAmount * factor).toFixed(DE_DRIFT_PRECISION));
+  const minor = Math.sign(scaled) * Math.round(Math.abs(scaled));
+  return minor === 0 ? 0 : minor;
+}
+
+/**
+ * Converts an integer count of minor units (e.g. 1999) back to a major-unit
+ * amount (e.g. 19.99) for the given currency.
+ *
+ * @throws RangeError if the minor amount is not an integer or the currency code is invalid.
+ */
+export function fromMinorUnits(minorAmount: number, currency: string): number {
+  if (!Number.isInteger(minorAmount)) {
+    throw new RangeError(
+      `Minor amount must be an integer, received ${JSON.stringify(minorAmount)}`
+    );
+  }
+  const exponent = getCurrencyExponent(currency);
+  const major = minorAmount / 10 ** exponent;
+  return major === 0 ? 0 : major;
+}


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

Payment provider adapters (Stripe) can verify and normalize webhooks, but there is no
deduplication layer - replayed or duplicate events would be processed twice.
`FinanceController.webhook` was a stub delegating to the legacy `StripeController`.

## What is the new behavior?

**Phase 0 - PaymentProviderPort + registry + FakeGateway + Stripe adapter:**
- Provider-agnostic `PaymentProviderPort` interface (checkout, payment, refund, webhook, account)
- `PaymentProviderRegistry` for per-org adapter resolution
- `FakeGateway` for contract testing
- `StripeProviderAdapter` implementing all methods on the Standard Connect / direct-charge model
- Money helpers (`toMinorUnits`, `fromMinorUnits`, `getCurrencyExponent`) in `packages/lib`

**Phase 1 - Webhook deduplication and async event dispatch:**
- `ProcessedWebhookEvent` Prisma model with unique `(providerEventRef, providerId)` constraint
- `PaymentWebhookService` - verify, dedup, dispatch all 5 event types:
  - `PAYMENT_SUCCEEDED` - updates `PaymentAttempt` + upserts `Payment`
  - `PAYMENT_FAILED` - sets failure code and message on `PaymentAttempt`
  - `REFUND_SUCCEEDED` / `REFUND_FAILED` - updates `Refund.status`
  - `ACCOUNT_UPDATED` - re-fetches readiness via adapter, updates `OrganizationBilling`
- `FinanceController.webhook` wired to `PaymentWebhookService` (lazy singleton)
- 19 tests, 100% branch coverage

## Related Issue(s)

Fixes #1685
Fixes #1727