### PR TITLE
chore(ci): remove ruby from the language matrix

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,8 +47,6 @@ jobs:
           #   build-mode: manual
           - language: javascript-typescript
             build-mode: none
-          - language: ruby
-            build-mode: none
           # - language: swift
           #   build-mode: manual
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'


### PR DESCRIPTION
<!--
We, the rest of the Yosemite community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests and lints pass.

## Description
- As we are not using `Ruby` in any of our apps or package, it's not required to have it in side `language matrix` for our `codeql` workflow. 
- This PR removes `Ruby` from the `language matrix` of `.github/worflows/codeql.yaml`.


