### PR TITLE
feat(backend): developer data API and MCP server

### DIFF
--- a/apps/backend/src/controllers/web/developer-api-key.controller.ts
+++ b/apps/backend/src/controllers/web/developer-api-key.controller.ts
@@ -1,0 +1,96 @@
+import { Request, Response } from "express";
+import { z } from "zod";
+import { DeveloperApiKeyEnvironment } from "@prisma/client";
+import {
+  DeveloperApiKeyService,
+  DeveloperApiKeyServiceError,
+} from "../../services/developer-api-key.service";
+import logger from "../../utils/logger";
+import type { OrgRequest } from "src/middlewares/rbac";
+import { resolveUserIdFromRequest } from "src/utils/request";
+
+const CreateApiKeySchema = z.object({
+  name: z.string().trim().min(1).max(100),
+  scopes: z.array(z.string().trim().min(1)).max(50).optional(),
+  environment: z.nativeEnum(DeveloperApiKeyEnvironment).optional(),
+  expiresAt: z.string().datetime().optional(),
+});
+
+const getOrgId = (req: Request): string | undefined =>
+  (req as OrgRequest).organisationId;
+
+const handleError = (
+  res: Response,
+  error: unknown,
+  action: string,
+): Response => {
+  if (error instanceof DeveloperApiKeyServiceError) {
+    return res.status(error.statusCode).json({ message: error.message });
+  }
+  logger.error(`DeveloperApiKey ${action} failed`, { error });
+  return res.status(500).json({ message: "Internal server error" });
+};
+
+export const DeveloperApiKeyController = {
+  createApiKey: async (req: Request, res: Response): Promise<Response> => {
+    try {
+      const organisationId = getOrgId(req);
+      if (!organisationId) {
+        return res.status(400).json({ message: "Missing organisationId" });
+      }
+      const createdBy = resolveUserIdFromRequest(req);
+      if (!createdBy) {
+        return res.status(401).json({ message: "Unauthorized" });
+      }
+
+      const parsed = CreateApiKeySchema.safeParse(req.body);
+      if (!parsed.success) {
+        return res
+          .status(400)
+          .json({ message: "Invalid request", errors: parsed.error.flatten() });
+      }
+
+      const { name, scopes, environment, expiresAt } = parsed.data;
+      const issued = await DeveloperApiKeyService.issue({
+        organisationId,
+        name,
+        createdBy,
+        scopes,
+        environment,
+        expiresAt: expiresAt ? new Date(expiresAt) : null,
+      });
+      return res.status(201).json(issued);
+    } catch (error) {
+      return handleError(res, error, "create");
+    }
+  },
+
+  listApiKeys: async (req: Request, res: Response): Promise<Response> => {
+    try {
+      const organisationId = getOrgId(req);
+      if (!organisationId) {
+        return res.status(400).json({ message: "Missing organisationId" });
+      }
+      const keys = await DeveloperApiKeyService.list(organisationId);
+      return res.status(200).json({ data: keys });
+    } catch (error) {
+      return handleError(res, error, "list");
+    }
+  },
+
+  revokeApiKey: async (req: Request, res: Response): Promise<Response> => {
+    try {
+      const organisationId = getOrgId(req);
+      if (!organisationId) {
+        return res.status(400).json({ message: "Missing organisationId" });
+      }
+      await DeveloperApiKeyService.revoke({
+        organisationId,
+        keyId: req.params.keyId,
+      });
+      return res.status(204).send();
+    } catch (error) {
+      return handleError(res, error, "revoke");
+    }
+  },
+};

--- a/apps/backend/src/controllers/web/developer-billing.controller.ts
+++ b/apps/backend/src/controllers/web/developer-billing.controller.ts
@@ -15,6 +15,10 @@ const CheckoutSchema = z.object({
   cancelUrl: z.string().url(),
 });
 
+const PortalSchema = z.object({
+  returnUrl: z.string().url(),
+});
+
 const handleError = (err: unknown, res: Response): void => {
   if (err instanceof DeveloperBillingServiceError) {
     res.status(err.statusCode).json({ error: err.message });
@@ -70,16 +74,15 @@ export const DeveloperBillingController = {
       res.status(400).json({ error: "organisationId is required" });
       return;
     }
-    const returnUrl =
-      typeof req.body?.returnUrl === "string" ? req.body.returnUrl : null;
-    if (!returnUrl) {
+    const parsed = PortalSchema.safeParse(req.body);
+    if (!parsed.success) {
       res.status(400).json({ error: "returnUrl is required" });
       return;
     }
     try {
       const url = await DeveloperBillingService.createPortalSession({
         organisationId,
-        returnUrl,
+        returnUrl: parsed.data.returnUrl,
       });
       res.status(201).json({ data: { url } });
     } catch (err) {

--- a/apps/backend/src/controllers/web/developer-billing.controller.ts
+++ b/apps/backend/src/controllers/web/developer-billing.controller.ts
@@ -1,0 +1,115 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import logger from "../../utils/logger";
+import type { OrgRequest } from "src/middlewares/rbac";
+import {
+  DeveloperBillingService,
+  DeveloperBillingServiceError,
+} from "../../services/developer-billing.service";
+
+const getOrgId = (req: Request): string | undefined =>
+  (req as OrgRequest).organisationId;
+
+const CheckoutSchema = z.object({
+  successUrl: z.string().url(),
+  cancelUrl: z.string().url(),
+});
+
+const handleError = (err: unknown, res: Response): void => {
+  if (err instanceof DeveloperBillingServiceError) {
+    res.status(err.statusCode).json({ error: err.message });
+    return;
+  }
+  logger.error("DeveloperBillingController unexpected error", err);
+  res.status(500).json({ error: "Internal server error" });
+};
+
+export const DeveloperBillingController = {
+  getSubscription: async (req: Request, res: Response): Promise<void> => {
+    const organisationId = getOrgId(req);
+    if (!organisationId) {
+      res.status(400).json({ error: "organisationId is required" });
+      return;
+    }
+    try {
+      const data =
+        await DeveloperBillingService.getSubscription(organisationId);
+      res.json({ data });
+    } catch (err) {
+      handleError(err, res);
+    }
+  },
+
+  createCheckout: async (req: Request, res: Response): Promise<void> => {
+    const organisationId = getOrgId(req);
+    if (!organisationId) {
+      res.status(400).json({ error: "organisationId is required" });
+      return;
+    }
+    const parsed = CheckoutSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res
+        .status(400)
+        .json({ error: parsed.error.errors[0]?.message ?? "Invalid request" });
+      return;
+    }
+    try {
+      const url = await DeveloperBillingService.createCheckoutSession({
+        organisationId,
+        ...parsed.data,
+      });
+      res.status(201).json({ data: { url } });
+    } catch (err) {
+      handleError(err, res);
+    }
+  },
+
+  createPortal: async (req: Request, res: Response): Promise<void> => {
+    const organisationId = getOrgId(req);
+    if (!organisationId) {
+      res.status(400).json({ error: "organisationId is required" });
+      return;
+    }
+    const returnUrl =
+      typeof req.body?.returnUrl === "string" ? req.body.returnUrl : null;
+    if (!returnUrl) {
+      res.status(400).json({ error: "returnUrl is required" });
+      return;
+    }
+    try {
+      const url = await DeveloperBillingService.createPortalSession({
+        organisationId,
+        returnUrl,
+      });
+      res.status(201).json({ data: { url } });
+    } catch (err) {
+      handleError(err, res);
+    }
+  },
+
+  webhook: async (req: Request, res: Response): Promise<void> => {
+    const signature = req.headers["stripe-signature"];
+    if (typeof signature !== "string") {
+      res.status(400).json({ error: "Missing stripe-signature header" });
+      return;
+    }
+    let event;
+    try {
+      event = DeveloperBillingService.verifyWebhook(
+        req.body as Buffer,
+        signature,
+      );
+    } catch (err) {
+      logger.error("Developer billing webhook verification failed", err);
+      res.status(400).json({ error: "Invalid webhook signature" });
+      return;
+    }
+    try {
+      await DeveloperBillingService.handleWebhookEvent(event);
+      res.json({ received: true });
+    } catch (err) {
+      logger.error("Developer billing webhook handler failed", err);
+      res.status(500).json({ error: "Webhook processing failed" });
+    }
+  },
+};

--- a/apps/backend/src/controllers/web/developer-billing.controller.ts
+++ b/apps/backend/src/controllers/web/developer-billing.controller.ts
@@ -52,9 +52,12 @@ export const DeveloperBillingController = {
     }
     const parsed = CheckoutSchema.safeParse(req.body);
     if (!parsed.success) {
+      const errors = parsed.error.errors;
       res
         .status(400)
-        .json({ error: parsed.error.errors[0]?.message ?? "Invalid request" });
+        .json({
+          error: errors.length > 0 ? errors[0].message : "Invalid request",
+        });
       return;
     }
     try {

--- a/apps/backend/src/controllers/web/developer-data.controller.ts
+++ b/apps/backend/src/controllers/web/developer-data.controller.ts
@@ -1,0 +1,225 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { prisma } from "src/config/prisma";
+import type { OrgRequest } from "src/middlewares/rbac";
+import logger from "../../utils/logger";
+
+const getOrgId = (req: Request): string | undefined =>
+  (req as OrgRequest).organisationId;
+
+const ListQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+  status: z.string().optional(),
+  dateFrom: z.string().datetime({ offset: true }).optional(),
+  dateTo: z.string().datetime({ offset: true }).optional(),
+});
+
+export const DeveloperDataController = {
+  listAppointments: async (req: Request, res: Response): Promise<void> => {
+    const organisationId = getOrgId(req);
+    if (!organisationId) {
+      res.status(400).json({ error: "organisationId is required" });
+      return;
+    }
+
+    const parsed = ListQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      res.status(400).json({ error: "Invalid query parameters" });
+      return;
+    }
+
+    const { limit, status, dateFrom, dateTo } = parsed.data;
+
+    try {
+      const where: Record<string, unknown> = { organisationId };
+      if (status) where.status = status;
+      if (dateFrom ?? dateTo) {
+        where.appointmentDate = {
+          ...(dateFrom ? { gte: new Date(dateFrom) } : {}),
+          ...(dateTo ? { lte: new Date(dateTo) } : {}),
+        };
+      }
+
+      const rows = await prisma.appointment.findMany({
+        where,
+        select: {
+          id: true,
+          organisationId: true,
+          patient: true,
+          lead: true,
+          appointmentType: true,
+          room: true,
+          appointmentDate: true,
+          startTime: true,
+          endTime: true,
+          timeSlot: true,
+          durationMinutes: true,
+          status: true,
+          isEmergency: true,
+          concern: true,
+          createdAt: true,
+          updatedAt: true,
+        },
+        orderBy: { appointmentDate: "desc" },
+        take: limit,
+      });
+
+      res.json({ data: rows, total: rows.length });
+    } catch (err) {
+      logger.error("DeveloperDataController.listAppointments failed", err);
+      res.status(500).json({ error: "Internal server error" });
+    }
+  },
+
+  getAppointment: async (req: Request, res: Response): Promise<void> => {
+    const organisationId = getOrgId(req);
+    if (!organisationId) {
+      res.status(400).json({ error: "organisationId is required" });
+      return;
+    }
+
+    const { id } = req.params;
+
+    try {
+      const row = await prisma.appointment.findFirst({
+        where: { id, organisationId },
+        select: {
+          id: true,
+          organisationId: true,
+          patient: true,
+          lead: true,
+          supportStaff: true,
+          appointmentType: true,
+          room: true,
+          appointmentDate: true,
+          startTime: true,
+          endTime: true,
+          timeSlot: true,
+          durationMinutes: true,
+          status: true,
+          isEmergency: true,
+          concern: true,
+          attachments: true,
+          formIds: true,
+          createdAt: true,
+          updatedAt: true,
+        },
+      });
+
+      if (!row) {
+        res.status(404).json({ error: "Appointment not found" });
+        return;
+      }
+
+      res.json({ data: row });
+    } catch (err) {
+      logger.error("DeveloperDataController.getAppointment failed", err);
+      res.status(500).json({ error: "Internal server error" });
+    }
+  },
+
+  listPatients: async (req: Request, res: Response): Promise<void> => {
+    const organisationId = getOrgId(req);
+    if (!organisationId) {
+      res.status(400).json({ error: "organisationId is required" });
+      return;
+    }
+
+    const parsed = ListQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      res.status(400).json({ error: "Invalid query parameters" });
+      return;
+    }
+
+    const { limit, status } = parsed.data;
+
+    try {
+      const links = await prisma.patientOrganisation.findMany({
+        where: {
+          organisationId,
+          status: "ACTIVE",
+        },
+        include: {
+          patient: {
+            select: {
+              id: true,
+              name: true,
+              type: true,
+              breed: true,
+              dateOfBirth: true,
+              gender: true,
+              photoUrl: true,
+              status: true,
+              isInsured: true,
+              microchipNumber: true,
+              createdAt: true,
+              updatedAt: true,
+            },
+          },
+        },
+        orderBy: { createdAt: "desc" },
+        take: limit,
+      });
+
+      const patients = links
+        .map((l) => l.patient)
+        .filter((p) => !status || p.status === status);
+
+      res.json({ data: patients, total: patients.length });
+    } catch (err) {
+      logger.error("DeveloperDataController.listPatients failed", err);
+      res.status(500).json({ error: "Internal server error" });
+    }
+  },
+
+  getPatient: async (req: Request, res: Response): Promise<void> => {
+    const organisationId = getOrgId(req);
+    if (!organisationId) {
+      res.status(400).json({ error: "organisationId is required" });
+      return;
+    }
+
+    const { id } = req.params;
+
+    try {
+      const link = await prisma.patientOrganisation.findFirst({
+        where: { patientId: id, organisationId, status: "ACTIVE" },
+        include: {
+          patient: {
+            select: {
+              id: true,
+              name: true,
+              type: true,
+              breed: true,
+              speciesCode: true,
+              breedCode: true,
+              dateOfBirth: true,
+              gender: true,
+              photoUrl: true,
+              currentWeight: true,
+              colour: true,
+              allergy: true,
+              isNeutered: true,
+              microchipNumber: true,
+              passportNumber: true,
+              isInsured: true,
+              status: true,
+              createdAt: true,
+              updatedAt: true,
+            },
+          },
+        },
+      });
+
+      if (!link) {
+        res.status(404).json({ error: "Patient not found" });
+        return;
+      }
+
+      res.json({ data: link.patient });
+    } catch (err) {
+      logger.error("DeveloperDataController.getPatient failed", err);
+      res.status(500).json({ error: "Internal server error" });
+    }
+  },
+};

--- a/apps/backend/src/controllers/web/developer-usage.controller.ts
+++ b/apps/backend/src/controllers/web/developer-usage.controller.ts
@@ -1,0 +1,26 @@
+import type { Request, Response } from "express";
+import logger from "../../utils/logger";
+import type { OrgRequest } from "src/middlewares/rbac";
+import { DeveloperUsageService } from "../../services/developer-usage.service";
+
+const getOrgId = (req: Request): string | undefined =>
+  (req as OrgRequest).organisationId;
+
+export const DeveloperUsageController = {
+  getUsage: async (req: Request, res: Response): Promise<void> => {
+    const organisationId = getOrgId(req);
+    if (!organisationId) {
+      res.status(400).json({ error: "organisationId is required" });
+      return;
+    }
+    const period =
+      typeof req.query.period === "string" ? req.query.period : undefined;
+    try {
+      const data = await DeveloperUsageService.getUsage(organisationId, period);
+      res.json({ data });
+    } catch (err) {
+      logger.error("DeveloperUsageController.getUsage failed", err);
+      res.status(500).json({ error: "Internal server error" });
+    }
+  },
+};

--- a/apps/backend/src/middlewares/api-key-auth.ts
+++ b/apps/backend/src/middlewares/api-key-auth.ts
@@ -4,6 +4,7 @@ import {
   DeveloperApiKeyService,
   type VerifiedApiKey,
 } from "src/services/developer-api-key.service";
+import { DeveloperUsageService } from "src/services/developer-usage.service";
 
 export interface ApiKeyRequest extends Request {
   apiKey?: VerifiedApiKey;
@@ -34,6 +35,15 @@ export const authorizeApiKey = async (
   const verified = await DeveloperApiKeyService.verify(presented);
   if (!verified) {
     return res.status(401).json({ message: "Invalid or expired API key" });
+  }
+
+  const usage = await DeveloperUsageService.incrementAndCheck(
+    verified.organisationId,
+  );
+  if (!usage.allowed) {
+    return res.status(429).json({
+      message: "Monthly API quota exceeded. Upgrade to Pro to continue.",
+    });
   }
 
   (req as ApiKeyRequest).apiKey = verified;

--- a/apps/backend/src/middlewares/api-key-auth.ts
+++ b/apps/backend/src/middlewares/api-key-auth.ts
@@ -1,0 +1,55 @@
+import type { NextFunction, Request, Response } from "express";
+import type { OrgRequest } from "src/middlewares/rbac";
+import {
+  DeveloperApiKeyService,
+  type VerifiedApiKey,
+} from "src/services/developer-api-key.service";
+
+export interface ApiKeyRequest extends Request {
+  apiKey?: VerifiedApiKey;
+}
+
+const extractApiKey = (req: Request): string | undefined => {
+  const header = req.header("authorization");
+  if (header?.startsWith("Bearer ")) {
+    return header.slice("Bearer ".length).trim() || undefined;
+  }
+  return req.header("x-api-key")?.trim() || undefined;
+};
+
+// Authenticates a request with a developer API key (Authorization: Bearer yc_...
+// or X-API-Key). On success the request is bound to the key's organisation so the
+// existing org-scoped RBAC applies; agents and servers use this path, never a
+// browser session.
+export const authorizeApiKey = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void | Response> => {
+  const presented = extractApiKey(req);
+  if (!presented) {
+    return res.status(401).json({ message: "Missing API key" });
+  }
+
+  const verified = await DeveloperApiKeyService.verify(presented);
+  if (!verified) {
+    return res.status(401).json({ message: "Invalid or expired API key" });
+  }
+
+  (req as ApiKeyRequest).apiKey = verified;
+  (req as OrgRequest).organisationId = verified.organisationId;
+  return next();
+};
+
+// Enforces a key scope. A key carrying the wildcard "*" scope passes everything.
+export const requireScope =
+  (scope: string) =>
+  (req: Request, res: Response, next: NextFunction): void | Response => {
+    const scopes = (req as ApiKeyRequest).apiKey?.scopes ?? [];
+    if (!scopes.includes(scope) && !scopes.includes("*")) {
+      return res
+        .status(403)
+        .json({ message: "Insufficient scope for this API key" });
+    }
+    return next();
+  };

--- a/apps/backend/src/routers/developer-api-key.router.ts
+++ b/apps/backend/src/routers/developer-api-key.router.ts
@@ -1,0 +1,30 @@
+import { Router } from "express";
+import { DeveloperApiKeyController } from "../controllers/web/developer-api-key.controller";
+import { authorizeCognito } from "src/middlewares/auth";
+import { requirePermission, withOrgPermissions } from "src/middlewares/rbac";
+
+const router = Router();
+
+router.post(
+  "/",
+  authorizeCognito,
+  withOrgPermissions(),
+  requirePermission("integrations:edit:any"),
+  DeveloperApiKeyController.createApiKey,
+);
+router.get(
+  "/",
+  authorizeCognito,
+  withOrgPermissions(),
+  requirePermission("integrations:view:any"),
+  DeveloperApiKeyController.listApiKeys,
+);
+router.delete(
+  "/:keyId",
+  authorizeCognito,
+  withOrgPermissions(),
+  requirePermission("integrations:edit:any"),
+  DeveloperApiKeyController.revokeApiKey,
+);
+
+export default router;

--- a/apps/backend/src/routers/developer-billing.router.ts
+++ b/apps/backend/src/routers/developer-billing.router.ts
@@ -1,0 +1,39 @@
+import express, { Router } from "express";
+import { DeveloperBillingController } from "../controllers/web/developer-billing.controller";
+import { authorizeCognito } from "src/middlewares/auth";
+import { requirePermission, withOrgPermissions } from "src/middlewares/rbac";
+
+const router = Router();
+
+// Public — Stripe calls this directly; raw body required for signature verification
+router.post(
+  "/webhook",
+  express.raw({ type: "application/json" }),
+  DeveloperBillingController.webhook,
+);
+
+router.get(
+  "/",
+  authorizeCognito,
+  withOrgPermissions(),
+  requirePermission("billing:view:any"),
+  DeveloperBillingController.getSubscription,
+);
+
+router.post(
+  "/checkout",
+  authorizeCognito,
+  withOrgPermissions(),
+  requirePermission("billing:edit:any"),
+  DeveloperBillingController.createCheckout,
+);
+
+router.post(
+  "/portal",
+  authorizeCognito,
+  withOrgPermissions(),
+  requirePermission("billing:view:any"),
+  DeveloperBillingController.createPortal,
+);
+
+export default router;

--- a/apps/backend/src/routers/developer-data.router.ts
+++ b/apps/backend/src/routers/developer-data.router.ts
@@ -1,0 +1,33 @@
+import { Router } from "express";
+import { authorizeApiKey, requireScope } from "src/middlewares/api-key-auth";
+import { DeveloperDataController } from "../controllers/web/developer-data.controller";
+
+const developerDataRouter = Router();
+
+developerDataRouter.use(authorizeApiKey);
+
+developerDataRouter.get(
+  "/appointments",
+  requireScope("appointments:read"),
+  DeveloperDataController.listAppointments,
+);
+
+developerDataRouter.get(
+  "/appointments/:id",
+  requireScope("appointments:read"),
+  DeveloperDataController.getAppointment,
+);
+
+developerDataRouter.get(
+  "/patients",
+  requireScope("patients:read"),
+  DeveloperDataController.listPatients,
+);
+
+developerDataRouter.get(
+  "/patients/:id",
+  requireScope("patients:read"),
+  DeveloperDataController.getPatient,
+);
+
+export default developerDataRouter;

--- a/apps/backend/src/routers/developer-usage.router.ts
+++ b/apps/backend/src/routers/developer-usage.router.ts
@@ -1,0 +1,16 @@
+import { Router } from "express";
+import { authorizeCognito } from "src/middlewares/auth";
+import { requirePermission, withOrgPermissions } from "src/middlewares/rbac";
+import { DeveloperUsageController } from "../controllers/web/developer-usage.controller";
+
+const developerUsageRouter = Router();
+
+developerUsageRouter.get(
+  "/",
+  authorizeCognito,
+  withOrgPermissions(),
+  requirePermission("billing:view:any"),
+  DeveloperUsageController.getUsage,
+);
+
+export default developerUsageRouter;

--- a/apps/backend/src/routers/index.ts
+++ b/apps/backend/src/routers/index.ts
@@ -61,6 +61,7 @@ import roomUnitGroupRouter from "./room-unit-group.router";
 import developerApiKeyRouter from "./developer-api-key.router";
 import developerBillingRouter from "./developer-billing.router";
 import developerUsageRouter from "./developer-usage.router";
+import developerDataRouter from "./developer-data.router";
 
 export function registerRoutes(app: Express) {
   app.use(`/fhir/v1/organization`, organizationRounter);
@@ -120,6 +121,7 @@ export function registerRoutes(app: Express) {
   app.use(`/v1/developers/api-keys`, developerApiKeyRouter);
   app.use(`/v1/developers/billing`, developerBillingRouter);
   app.use(`/v1/developers/usage`, developerUsageRouter);
+  app.use(`/v1/api`, developerDataRouter);
   app.use(`/v1/knowledge`, knowledgeRouter);
   app.use(`/v1/codes`, codeRouter);
   app.use(`/v1/labs`, labOrderRouter);

--- a/apps/backend/src/routers/index.ts
+++ b/apps/backend/src/routers/index.ts
@@ -58,6 +58,8 @@ import episodeOfCareRouter from "./episode-of-care.router";
 import encounterRouter from "./encounter.router";
 import roomUnitRouter from "./room-unit.router";
 import roomUnitGroupRouter from "./room-unit-group.router";
+import developerApiKeyRouter from "./developer-api-key.router";
+import developerBillingRouter from "./developer-billing.router";
 
 export function registerRoutes(app: Express) {
   app.use(`/fhir/v1/organization`, organizationRounter);
@@ -114,6 +116,8 @@ export function registerRoutes(app: Express) {
   app.use(`/v1/audit-trail`, auditTrailRouter);
   app.use(`/v1/companion-history`, companionHistoryRouter);
   app.use(`/v1/integration`, integrationRouter);
+  app.use(`/v1/developers/api-keys`, developerApiKeyRouter);
+  app.use(`/v1/developers/billing`, developerBillingRouter);
   app.use(`/v1/knowledge`, knowledgeRouter);
   app.use(`/v1/codes`, codeRouter);
   app.use(`/v1/labs`, labOrderRouter);

--- a/apps/backend/src/routers/index.ts
+++ b/apps/backend/src/routers/index.ts
@@ -60,6 +60,7 @@ import roomUnitRouter from "./room-unit.router";
 import roomUnitGroupRouter from "./room-unit-group.router";
 import developerApiKeyRouter from "./developer-api-key.router";
 import developerBillingRouter from "./developer-billing.router";
+import developerUsageRouter from "./developer-usage.router";
 
 export function registerRoutes(app: Express) {
   app.use(`/fhir/v1/organization`, organizationRounter);
@@ -118,6 +119,7 @@ export function registerRoutes(app: Express) {
   app.use(`/v1/integration`, integrationRouter);
   app.use(`/v1/developers/api-keys`, developerApiKeyRouter);
   app.use(`/v1/developers/billing`, developerBillingRouter);
+  app.use(`/v1/developers/usage`, developerUsageRouter);
   app.use(`/v1/knowledge`, knowledgeRouter);
   app.use(`/v1/codes`, codeRouter);
   app.use(`/v1/labs`, labOrderRouter);

--- a/apps/backend/src/services/developer-api-key.service.ts
+++ b/apps/backend/src/services/developer-api-key.service.ts
@@ -1,0 +1,183 @@
+import { createHash, randomBytes } from "node:crypto";
+import {
+  DeveloperApiKeyEnvironment,
+  DeveloperApiKeyStatus,
+} from "@prisma/client";
+import { prisma } from "src/config/prisma";
+
+export class DeveloperApiKeyServiceError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode: number,
+  ) {
+    super(message);
+    this.name = "DeveloperApiKeyServiceError";
+  }
+}
+
+const KEY_SECRET_BYTES = 24;
+const LAST_USED_THROTTLE_MS = 60_000;
+
+export type IssuedApiKey = {
+  id: string;
+  name: string;
+  prefix: string;
+  last4: string;
+  scopes: string[];
+  environment: DeveloperApiKeyEnvironment;
+  // The plaintext secret, returned exactly once at creation. Never persisted.
+  apiKey: string;
+};
+
+export type VerifiedApiKey = {
+  id: string;
+  organisationId: string;
+  scopes: string[];
+  environment: DeveloperApiKeyEnvironment;
+};
+
+const hashApiKey = (plaintext: string) =>
+  createHash("sha256").update(plaintext).digest("hex");
+
+const generateApiKey = (environment: DeveloperApiKeyEnvironment) => {
+  const secret = randomBytes(KEY_SECRET_BYTES).toString("base64url");
+  const plaintext = `yc_${environment}_${secret}`;
+  return {
+    plaintext,
+    hashedKey: hashApiKey(plaintext),
+    prefix: `yc_${environment}_${secret.slice(0, 6)}`,
+    last4: secret.slice(-4),
+  };
+};
+
+const requireNonEmpty = (value: unknown, field: string): string => {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new DeveloperApiKeyServiceError(`Invalid ${field}`, 400);
+  }
+  return value.trim();
+};
+
+export const DeveloperApiKeyService = {
+  async issue(input: {
+    organisationId: string;
+    name: string;
+    createdBy: string;
+    scopes?: string[];
+    environment?: DeveloperApiKeyEnvironment;
+    expiresAt?: Date | null;
+  }): Promise<IssuedApiKey> {
+    const organisationId = requireNonEmpty(
+      input.organisationId,
+      "organisationId",
+    );
+    const name = requireNonEmpty(input.name, "name");
+    const createdBy = requireNonEmpty(input.createdBy, "createdBy");
+    const environment = input.environment ?? DeveloperApiKeyEnvironment.live;
+    const scopes = (input.scopes ?? []).map((scope) =>
+      requireNonEmpty(scope, "scope"),
+    );
+
+    const generated = generateApiKey(environment);
+    const record = await prisma.developerApiKey.create({
+      data: {
+        organisationId,
+        name,
+        createdBy,
+        scopes,
+        environment,
+        prefix: generated.prefix,
+        hashedKey: generated.hashedKey,
+        last4: generated.last4,
+        expiresAt: input.expiresAt ?? null,
+      },
+    });
+
+    return {
+      id: record.id,
+      name: record.name,
+      prefix: record.prefix,
+      last4: record.last4,
+      scopes: record.scopes,
+      environment: record.environment,
+      apiKey: generated.plaintext,
+    };
+  },
+
+  async list(organisationId: string) {
+    const orgId = requireNonEmpty(organisationId, "organisationId");
+    return prisma.developerApiKey.findMany({
+      where: { organisationId: orgId },
+      orderBy: { createdAt: "desc" },
+      select: {
+        id: true,
+        name: true,
+        prefix: true,
+        last4: true,
+        scopes: true,
+        environment: true,
+        status: true,
+        lastUsedAt: true,
+        expiresAt: true,
+        revokedAt: true,
+        createdAt: true,
+      },
+    });
+  },
+
+  async revoke(input: {
+    organisationId: string;
+    keyId: string;
+  }): Promise<void> {
+    const organisationId = requireNonEmpty(
+      input.organisationId,
+      "organisationId",
+    );
+    const keyId = requireNonEmpty(input.keyId, "keyId");
+
+    const result = await prisma.developerApiKey.updateMany({
+      where: {
+        id: keyId,
+        organisationId,
+        status: DeveloperApiKeyStatus.active,
+      },
+      data: { status: DeveloperApiKeyStatus.revoked, revokedAt: new Date() },
+    });
+    if (result.count === 0) {
+      throw new DeveloperApiKeyServiceError("API key not found", 404);
+    }
+  },
+
+  // Authenticates a presented secret. Returns the org + scopes context, or null
+  // for any unknown / revoked / expired key (callers translate null to 401).
+  async verify(plaintextKey: string): Promise<VerifiedApiKey | null> {
+    if (typeof plaintextKey !== "string" || !plaintextKey.startsWith("yc_")) {
+      return null;
+    }
+    const record = await prisma.developerApiKey.findUnique({
+      where: { hashedKey: hashApiKey(plaintextKey) },
+    });
+    if (!record || record.status !== DeveloperApiKeyStatus.active) {
+      return null;
+    }
+    if (record.expiresAt && record.expiresAt.getTime() <= Date.now()) {
+      return null;
+    }
+
+    const now = Date.now();
+    if (
+      !record.lastUsedAt ||
+      now - record.lastUsedAt.getTime() > LAST_USED_THROTTLE_MS
+    ) {
+      void prisma.developerApiKey
+        .update({ where: { id: record.id }, data: { lastUsedAt: new Date() } })
+        .catch(() => undefined);
+    }
+
+    return {
+      id: record.id,
+      organisationId: record.organisationId,
+      scopes: record.scopes,
+      environment: record.environment,
+    };
+  },
+};

--- a/apps/backend/src/services/developer-billing.service.ts
+++ b/apps/backend/src/services/developer-billing.service.ts
@@ -23,11 +23,7 @@ const getStripeClient = (): Stripe => {
   return stripeClient;
 };
 
-const toPlanTier = (value?: string | null): DeveloperPlanTier => {
-  if (value === "pro") return "pro";
-  if (value === "enterprise") return "enterprise";
-  return "free";
-};
+const toPlanTier = (): DeveloperPlanTier => "free";
 
 const toSubscriptionStatus = (
   value?: string | null,
@@ -49,6 +45,118 @@ const resolveMeteredPriceId = (): string => {
   }
   return id;
 };
+
+async function handleCheckoutCompleted(
+  event: Stripe.Event,
+  session: Stripe.Checkout.Session,
+): Promise<void> {
+  if (session.mode !== "subscription") return;
+  const orgId = session.metadata?.organisationId;
+  if (!orgId) return;
+
+  const subId =
+    typeof session.subscription === "string"
+      ? session.subscription
+      : (session.subscription?.id ?? null);
+  if (!subId) return;
+
+  const stripe = getStripeClient();
+  const sub = await stripe.subscriptions.retrieve(subId, {
+    expand: ["items.data.price"],
+  });
+
+  const item = sub.items.data[0];
+  const priceId = item?.price?.id ?? null;
+
+  await prisma.developerSubscription.upsert({
+    where: { organisationId: orgId },
+    create: {
+      organisationId: orgId,
+      stripeCustomerId:
+        typeof sub.customer === "string" ? sub.customer : sub.customer.id,
+      stripeSubscriptionId: sub.id,
+      stripeSubscriptionItemId: item?.id ?? null,
+      stripePriceId: priceId,
+      plan: "pro",
+      status: toSubscriptionStatus(sub.status),
+      currentPeriodStart: item?.current_period_start
+        ? new Date(item.current_period_start * 1000)
+        : null,
+      currentPeriodEnd: item?.current_period_end
+        ? new Date(item.current_period_end * 1000)
+        : null,
+      cancelAtPeriodEnd: sub.cancel_at_period_end,
+      lastStripeEventId: event.id,
+    },
+    update: {
+      stripeSubscriptionId: sub.id,
+      stripeSubscriptionItemId: item?.id ?? null,
+      stripePriceId: priceId,
+      plan: "pro",
+      status: toSubscriptionStatus(sub.status),
+      currentPeriodStart: item?.current_period_start
+        ? new Date(item.current_period_start * 1000)
+        : null,
+      currentPeriodEnd: item?.current_period_end
+        ? new Date(item.current_period_end * 1000)
+        : null,
+      cancelAtPeriodEnd: sub.cancel_at_period_end,
+      lastStripeEventId: event.id,
+    },
+  });
+}
+
+async function handleSubscriptionUpdated(
+  event: Stripe.Event,
+  sub: Stripe.Subscription,
+): Promise<void> {
+  const record = await prisma.developerSubscription.findFirst({
+    where: { stripeSubscriptionId: sub.id },
+  });
+  if (!record) return;
+
+  const item = sub.items.data[0];
+
+  await prisma.developerSubscription.update({
+    where: { id: record.id },
+    data: {
+      status: toSubscriptionStatus(sub.status),
+      stripePriceId: item?.price?.id ?? record.stripePriceId,
+      stripeSubscriptionItemId: item?.id ?? record.stripeSubscriptionItemId,
+      currentPeriodStart: item?.current_period_start
+        ? new Date(item.current_period_start * 1000)
+        : null,
+      currentPeriodEnd: item?.current_period_end
+        ? new Date(item.current_period_end * 1000)
+        : null,
+      cancelAtPeriodEnd: sub.cancel_at_period_end,
+      lastStripeEventId: event.id,
+    },
+  });
+}
+
+async function handleSubscriptionDeleted(
+  event: Stripe.Event,
+  sub: Stripe.Subscription,
+): Promise<void> {
+  const record = await prisma.developerSubscription.findFirst({
+    where: { stripeSubscriptionId: sub.id },
+  });
+  if (!record) return;
+
+  await prisma.developerSubscription.update({
+    where: { id: record.id },
+    data: {
+      plan: toPlanTier(),
+      status: "canceled",
+      stripeSubscriptionId: null,
+      stripeSubscriptionItemId: null,
+      stripePriceId: null,
+      cancelAtPeriodEnd: false,
+      lastStripeEventId: event.id,
+    },
+  });
+}
 
 export const DeveloperBillingService = {
   async getSubscription(organisationId: string) {
@@ -188,116 +296,15 @@ export const DeveloperBillingService = {
 
   async handleWebhookEvent(event: Stripe.Event): Promise<void> {
     switch (event.type) {
-      case "checkout.session.completed": {
-        const session = event.data.object;
-        if (session.mode !== "subscription") break;
-        const orgId = session.metadata?.organisationId;
-        if (!orgId) break;
-
-        const subId =
-          typeof session.subscription === "string"
-            ? session.subscription
-            : (session.subscription?.id ?? null);
-        if (!subId) break;
-
-        const stripe = getStripeClient();
-        const sub = await stripe.subscriptions.retrieve(subId, {
-          expand: ["items.data.price"],
-        });
-
-        const item = sub.items.data[0];
-        const priceId = item?.price?.id ?? null;
-
-        await prisma.developerSubscription.upsert({
-          where: { organisationId: orgId },
-          create: {
-            organisationId: orgId,
-            stripeCustomerId:
-              typeof sub.customer === "string" ? sub.customer : sub.customer.id,
-            stripeSubscriptionId: sub.id,
-            stripeSubscriptionItemId: item?.id ?? null,
-            stripePriceId: priceId,
-            plan: "pro",
-            status: toSubscriptionStatus(sub.status),
-            currentPeriodStart: item?.current_period_start
-              ? new Date(item.current_period_start * 1000)
-              : null,
-            currentPeriodEnd: item?.current_period_end
-              ? new Date(item.current_period_end * 1000)
-              : null,
-            cancelAtPeriodEnd: sub.cancel_at_period_end,
-            lastStripeEventId: event.id,
-          },
-          update: {
-            stripeSubscriptionId: sub.id,
-            stripeSubscriptionItemId: item?.id ?? null,
-            stripePriceId: priceId,
-            plan: "pro",
-            status: toSubscriptionStatus(sub.status),
-            currentPeriodStart: item?.current_period_start
-              ? new Date(item.current_period_start * 1000)
-              : null,
-            currentPeriodEnd: item?.current_period_end
-              ? new Date(item.current_period_end * 1000)
-              : null,
-            cancelAtPeriodEnd: sub.cancel_at_period_end,
-            lastStripeEventId: event.id,
-          },
-        });
+      case "checkout.session.completed":
+        await handleCheckoutCompleted(event, event.data.object);
         break;
-      }
-
-      case "customer.subscription.updated": {
-        const sub = event.data.object;
-        const record = await prisma.developerSubscription.findFirst({
-          where: { stripeSubscriptionId: sub.id },
-        });
-        if (!record) break;
-
-        const item = sub.items.data[0];
-
-        await prisma.developerSubscription.update({
-          where: { id: record.id },
-          data: {
-            status: toSubscriptionStatus(sub.status),
-            stripePriceId: item?.price?.id ?? record.stripePriceId,
-            stripeSubscriptionItemId:
-              item?.id ?? record.stripeSubscriptionItemId,
-            currentPeriodStart: item?.current_period_start
-              ? new Date(item.current_period_start * 1000)
-              : null,
-            currentPeriodEnd: item?.current_period_end
-              ? new Date(item.current_period_end * 1000)
-              : null,
-            cancelAtPeriodEnd: sub.cancel_at_period_end,
-            lastStripeEventId: event.id,
-          },
-        });
+      case "customer.subscription.updated":
+        await handleSubscriptionUpdated(event, event.data.object);
         break;
-      }
-
-      case "customer.subscription.deleted": {
-        const sub = event.data.object;
-        const record = await prisma.developerSubscription.findFirst({
-          where: { stripeSubscriptionId: sub.id },
-        });
-        if (!record) break;
-
-        await prisma.developerSubscription.update({
-          where: { id: record.id },
-          data: {
-            plan: toPlanTier(null),
-            status: "canceled",
-            stripeSubscriptionId: null,
-            stripeSubscriptionItemId: null,
-            stripePriceId: null,
-            cancelAtPeriodEnd: false,
-            lastStripeEventId: event.id,
-          },
-        });
+      case "customer.subscription.deleted":
+        await handleSubscriptionDeleted(event, event.data.object);
         break;
-      }
-
       default:
         logger.info("Unhandled developer billing webhook event", {
           type: event.type,

--- a/apps/backend/src/services/developer-billing.service.ts
+++ b/apps/backend/src/services/developer-billing.service.ts
@@ -189,7 +189,7 @@ export const DeveloperBillingService = {
   async handleWebhookEvent(event: Stripe.Event): Promise<void> {
     switch (event.type) {
       case "checkout.session.completed": {
-        const session = event.data.object as Stripe.Checkout.Session;
+        const session = event.data.object;
         if (session.mode !== "subscription") break;
         const orgId = session.metadata?.organisationId;
         if (!orgId) break;
@@ -248,7 +248,7 @@ export const DeveloperBillingService = {
       }
 
       case "customer.subscription.updated": {
-        const sub = event.data.object as Stripe.Subscription;
+        const sub = event.data.object;
         const record = await prisma.developerSubscription.findFirst({
           where: { stripeSubscriptionId: sub.id },
         });
@@ -277,7 +277,7 @@ export const DeveloperBillingService = {
       }
 
       case "customer.subscription.deleted": {
-        const sub = event.data.object as Stripe.Subscription;
+        const sub = event.data.object;
         const record = await prisma.developerSubscription.findFirst({
           where: { stripeSubscriptionId: sub.id },
         });

--- a/apps/backend/src/services/developer-billing.service.ts
+++ b/apps/backend/src/services/developer-billing.service.ts
@@ -1,0 +1,314 @@
+import Stripe from "stripe";
+import logger from "../utils/logger";
+import { prisma } from "src/config/prisma";
+import { DeveloperPlanTier, DeveloperSubscriptionStatus } from "@prisma/client";
+
+export class DeveloperBillingServiceError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode: number,
+  ) {
+    super(message);
+    this.name = "DeveloperBillingServiceError";
+  }
+}
+
+let stripeClient: Stripe | null = null;
+
+const getStripeClient = (): Stripe => {
+  if (stripeClient) return stripeClient;
+  const apiKey = process.env.STRIPE_SECRET_KEY;
+  if (!apiKey) throw new Error("STRIPE_SECRET_KEY is not configured");
+  stripeClient = new Stripe(apiKey, { apiVersion: "2026-01-28.clover" });
+  return stripeClient;
+};
+
+const toPlanTier = (value?: string | null): DeveloperPlanTier => {
+  if (value === "pro") return "pro";
+  if (value === "enterprise") return "enterprise";
+  return "free";
+};
+
+const toSubscriptionStatus = (
+  value?: string | null,
+): DeveloperSubscriptionStatus => {
+  if (value === "trialing") return "trialing";
+  if (value === "past_due") return "past_due";
+  if (value === "canceled") return "canceled";
+  if (value === "incomplete") return "incomplete";
+  return "active";
+};
+
+const resolveMeteredPriceId = (): string => {
+  const id = process.env.STRIPE_DEV_METERED_PRICE_ID;
+  if (!id) {
+    throw new DeveloperBillingServiceError(
+      "STRIPE_DEV_METERED_PRICE_ID is not configured",
+      500,
+    );
+  }
+  return id;
+};
+
+export const DeveloperBillingService = {
+  async getSubscription(organisationId: string) {
+    if (!organisationId.trim()) {
+      throw new DeveloperBillingServiceError("organisationId is required", 400);
+    }
+    const record = await prisma.developerSubscription.findUnique({
+      where: { organisationId },
+      select: {
+        id: true,
+        organisationId: true,
+        plan: true,
+        status: true,
+        stripeSubscriptionItemId: true,
+        currentPeriodStart: true,
+        currentPeriodEnd: true,
+        cancelAtPeriodEnd: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+    return (
+      record ?? {
+        id: null,
+        organisationId,
+        plan: "free" as DeveloperPlanTier,
+        status: "active" as DeveloperSubscriptionStatus,
+        stripeSubscriptionItemId: null,
+        currentPeriodStart: null,
+        currentPeriodEnd: null,
+        cancelAtPeriodEnd: false,
+        createdAt: null,
+        updatedAt: null,
+      }
+    );
+  },
+
+  async getOrCreateCustomer(organisationId: string): Promise<string> {
+    const existing = await prisma.developerSubscription.findUnique({
+      where: { organisationId },
+      select: { stripeCustomerId: true },
+    });
+    if (existing?.stripeCustomerId) return existing.stripeCustomerId;
+
+    const stripe = getStripeClient();
+    const customer = await stripe.customers.create({
+      metadata: { organisationId, source: "developer_portal" },
+    });
+
+    await prisma.developerSubscription.upsert({
+      where: { organisationId },
+      create: { organisationId, stripeCustomerId: customer.id },
+      update: { stripeCustomerId: customer.id },
+    });
+
+    return customer.id;
+  },
+
+  async createCheckoutSession(input: {
+    organisationId: string;
+    successUrl: string;
+    cancelUrl: string;
+  }): Promise<string> {
+    const { organisationId, successUrl, cancelUrl } = input;
+    if (!organisationId.trim()) {
+      throw new DeveloperBillingServiceError("organisationId is required", 400);
+    }
+
+    const customerId =
+      await DeveloperBillingService.getOrCreateCustomer(organisationId);
+    const priceId = resolveMeteredPriceId();
+    const stripe = getStripeClient();
+
+    const session = await stripe.checkout.sessions.create({
+      mode: "subscription",
+      customer: customerId,
+      line_items: [{ price: priceId }],
+      success_url: successUrl,
+      cancel_url: cancelUrl,
+      metadata: { organisationId, source: "developer_portal" },
+    });
+
+    if (!session.url) {
+      throw new DeveloperBillingServiceError(
+        "Failed to create checkout session",
+        500,
+      );
+    }
+    return session.url;
+  },
+
+  async createPortalSession(input: {
+    organisationId: string;
+    returnUrl: string;
+  }): Promise<string> {
+    const { organisationId, returnUrl } = input;
+    if (!organisationId.trim()) {
+      throw new DeveloperBillingServiceError("organisationId is required", 400);
+    }
+
+    const record = await prisma.developerSubscription.findUnique({
+      where: { organisationId },
+      select: { stripeCustomerId: true },
+    });
+
+    if (!record?.stripeCustomerId) {
+      throw new DeveloperBillingServiceError(
+        "No billing account found — upgrade to Pro first",
+        404,
+      );
+    }
+
+    const stripe = getStripeClient();
+    const session = await stripe.billingPortal.sessions.create({
+      customer: record.stripeCustomerId,
+      return_url: returnUrl,
+    });
+
+    return session.url;
+  },
+
+  // Reports metered API usage to Stripe so it is invoiced at end of period.
+  // Uses Stripe Billing Meters (v20+ API). Call after each authenticated API request or batch.
+  async reportUsage(customerId: string, quantity: number): Promise<void> {
+    if (!customerId || quantity <= 0) return;
+    const eventName = process.env.STRIPE_DEV_METER_EVENT_NAME;
+    if (!eventName) return;
+    const stripe = getStripeClient();
+    await stripe.billing.meterEvents.create({
+      event_name: eventName,
+      payload: {
+        stripe_customer_id: customerId,
+        value: String(quantity),
+      },
+    });
+  },
+
+  async handleWebhookEvent(event: Stripe.Event): Promise<void> {
+    switch (event.type) {
+      case "checkout.session.completed": {
+        const session = event.data.object as Stripe.Checkout.Session;
+        if (session.mode !== "subscription") break;
+        const orgId = session.metadata?.organisationId;
+        if (!orgId) break;
+
+        const subId =
+          typeof session.subscription === "string"
+            ? session.subscription
+            : (session.subscription?.id ?? null);
+        if (!subId) break;
+
+        const stripe = getStripeClient();
+        const sub = await stripe.subscriptions.retrieve(subId, {
+          expand: ["items.data.price"],
+        });
+
+        const item = sub.items.data[0];
+        const priceId = item?.price?.id ?? null;
+
+        await prisma.developerSubscription.upsert({
+          where: { organisationId: orgId },
+          create: {
+            organisationId: orgId,
+            stripeCustomerId:
+              typeof sub.customer === "string" ? sub.customer : sub.customer.id,
+            stripeSubscriptionId: sub.id,
+            stripeSubscriptionItemId: item?.id ?? null,
+            stripePriceId: priceId,
+            plan: "pro",
+            status: toSubscriptionStatus(sub.status),
+            currentPeriodStart: item?.current_period_start
+              ? new Date(item.current_period_start * 1000)
+              : null,
+            currentPeriodEnd: item?.current_period_end
+              ? new Date(item.current_period_end * 1000)
+              : null,
+            cancelAtPeriodEnd: sub.cancel_at_period_end,
+            lastStripeEventId: event.id,
+          },
+          update: {
+            stripeSubscriptionId: sub.id,
+            stripeSubscriptionItemId: item?.id ?? null,
+            stripePriceId: priceId,
+            plan: "pro",
+            status: toSubscriptionStatus(sub.status),
+            currentPeriodStart: item?.current_period_start
+              ? new Date(item.current_period_start * 1000)
+              : null,
+            currentPeriodEnd: item?.current_period_end
+              ? new Date(item.current_period_end * 1000)
+              : null,
+            cancelAtPeriodEnd: sub.cancel_at_period_end,
+            lastStripeEventId: event.id,
+          },
+        });
+        break;
+      }
+
+      case "customer.subscription.updated": {
+        const sub = event.data.object as Stripe.Subscription;
+        const record = await prisma.developerSubscription.findFirst({
+          where: { stripeSubscriptionId: sub.id },
+        });
+        if (!record) break;
+
+        const item = sub.items.data[0];
+
+        await prisma.developerSubscription.update({
+          where: { id: record.id },
+          data: {
+            status: toSubscriptionStatus(sub.status),
+            stripePriceId: item?.price?.id ?? record.stripePriceId,
+            stripeSubscriptionItemId:
+              item?.id ?? record.stripeSubscriptionItemId,
+            currentPeriodStart: item?.current_period_start
+              ? new Date(item.current_period_start * 1000)
+              : null,
+            currentPeriodEnd: item?.current_period_end
+              ? new Date(item.current_period_end * 1000)
+              : null,
+            cancelAtPeriodEnd: sub.cancel_at_period_end,
+            lastStripeEventId: event.id,
+          },
+        });
+        break;
+      }
+
+      case "customer.subscription.deleted": {
+        const sub = event.data.object as Stripe.Subscription;
+        const record = await prisma.developerSubscription.findFirst({
+          where: { stripeSubscriptionId: sub.id },
+        });
+        if (!record) break;
+
+        await prisma.developerSubscription.update({
+          where: { id: record.id },
+          data: {
+            plan: toPlanTier(null),
+            status: "canceled",
+            stripeSubscriptionId: null,
+            stripeSubscriptionItemId: null,
+            stripePriceId: null,
+            cancelAtPeriodEnd: false,
+            lastStripeEventId: event.id,
+          },
+        });
+        break;
+      }
+
+      default:
+        logger.info("Unhandled developer billing webhook event", {
+          type: event.type,
+        });
+    }
+  },
+
+  verifyWebhook(body: Buffer, signature: string): Stripe.Event {
+    const secret = process.env.STRIPE_DEV_WEBHOOK_SECRET;
+    if (!secret) throw new Error("STRIPE_DEV_WEBHOOK_SECRET is not configured");
+    const stripe = getStripeClient();
+    return stripe.webhooks.constructEvent(body, signature, secret);
+  },
+};

--- a/apps/backend/src/services/developer-usage.service.ts
+++ b/apps/backend/src/services/developer-usage.service.ts
@@ -1,0 +1,116 @@
+import { prisma } from "src/config/prisma";
+import { DeveloperBillingService } from "./developer-billing.service";
+import logger from "../utils/logger";
+
+const FREE_TIER_LIMIT = 1_000;
+
+const currentBillingPeriod = (): string => {
+  const now = new Date();
+  const mm = String(now.getUTCMonth() + 1).padStart(2, "0");
+  return `${now.getUTCFullYear()}-${mm}`;
+};
+
+export const DeveloperUsageService = {
+  // Increments call count atomically and checks quota.
+  // Returns { allowed: boolean, callCount: number } — caller should 429 when !allowed.
+  async incrementAndCheck(
+    organisationId: string,
+  ): Promise<{ allowed: boolean; callCount: number }> {
+    const period = currentBillingPeriod();
+
+    const record = await prisma.developerApiUsage.upsert({
+      where: {
+        organisationId_billingPeriod: { organisationId, billingPeriod: period },
+      },
+      create: { organisationId, billingPeriod: period, callCount: 1 },
+      update: { callCount: { increment: 1 } },
+    });
+
+    const sub = await prisma.developerSubscription.findUnique({
+      where: { organisationId },
+      select: { plan: true, stripeCustomerId: true },
+    });
+
+    const plan = sub?.plan ?? "free";
+
+    if (plan === "free" && record.callCount > FREE_TIER_LIMIT) {
+      return { allowed: false, callCount: record.callCount };
+    }
+
+    if (plan === "pro" && sub?.stripeCustomerId) {
+      DeveloperUsageService.reportToStripe(
+        sub.stripeCustomerId,
+        organisationId,
+        period,
+        record.callCount,
+      );
+    }
+
+    return { allowed: true, callCount: record.callCount };
+  },
+
+  // Fire-and-forget: report accumulated usage to Stripe and update lastReportedAt.
+  // Called inline from incrementAndCheck; errors are logged but never surfaced to the caller.
+  reportToStripe(
+    customerId: string,
+    organisationId: string,
+    billingPeriod: string,
+    callCount: number,
+  ): void {
+    void (async () => {
+      try {
+        await DeveloperBillingService.reportUsage(customerId, callCount);
+        await prisma.developerApiUsage.update({
+          where: {
+            organisationId_billingPeriod: {
+              organisationId,
+              billingPeriod,
+            },
+          },
+          data: { lastReportedAt: new Date() },
+        });
+      } catch (err) {
+        logger.error("Failed to report API usage to Stripe", {
+          organisationId,
+          billingPeriod,
+          err,
+        });
+      }
+    })();
+  },
+
+  // Returns usage for a given org and period (defaults to current month).
+  async getUsage(
+    organisationId: string,
+    billingPeriod?: string,
+  ): Promise<{
+    billingPeriod: string;
+    callCount: number;
+    limit: number | null;
+  }> {
+    const period = billingPeriod ?? currentBillingPeriod();
+
+    const [record, sub] = await Promise.all([
+      prisma.developerApiUsage.findUnique({
+        where: {
+          organisationId_billingPeriod: {
+            organisationId,
+            billingPeriod: period,
+          },
+        },
+        select: { callCount: true },
+      }),
+      prisma.developerSubscription.findUnique({
+        where: { organisationId },
+        select: { plan: true },
+      }),
+    ]);
+
+    const plan = sub?.plan ?? "free";
+    return {
+      billingPeriod: period,
+      callCount: record?.callCount ?? 0,
+      limit: plan === "free" ? FREE_TIER_LIMIT : null,
+    };
+  },
+};

--- a/apps/backend/test/controllers/web/developer-api-key.controller.test.ts
+++ b/apps/backend/test/controllers/web/developer-api-key.controller.test.ts
@@ -1,0 +1,215 @@
+import type { Request, Response } from "express";
+import { DeveloperApiKeyController } from "../../../src/controllers/web/developer-api-key.controller";
+import {
+  DeveloperApiKeyService,
+  DeveloperApiKeyServiceError,
+} from "../../../src/services/developer-api-key.service";
+
+jest.mock("../../../src/services/developer-api-key.service", () => {
+  class Err extends Error {
+    constructor(
+      message: string,
+      public statusCode: number,
+    ) {
+      super(message);
+    }
+  }
+  return {
+    DeveloperApiKeyService: {
+      issue: jest.fn(),
+      list: jest.fn(),
+      revoke: jest.fn(),
+    },
+    DeveloperApiKeyServiceError: Err,
+  };
+});
+
+jest.mock("../../../src/utils/logger", () => ({
+  __esModule: true,
+  default: { error: jest.fn(), info: jest.fn() },
+}));
+
+const svc = DeveloperApiKeyService as unknown as {
+  issue: jest.Mock;
+  list: jest.Mock;
+  revoke: jest.Mock;
+};
+
+const buildRes = (): Response => {
+  const res: Partial<Response> = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  res.send = jest.fn().mockReturnValue(res);
+  return res as Response;
+};
+
+const buildReq = (
+  over: {
+    organisationId?: string;
+    userId?: string;
+    body?: unknown;
+    params?: Record<string, string>;
+  } = {},
+): Request =>
+  ({
+    body: over.body ?? {},
+    params: over.params ?? {},
+    headers: {},
+    organisationId: over.organisationId,
+    userId: over.userId,
+  }) as unknown as Request;
+
+describe("DeveloperApiKeyController.createApiKey", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("400 without an organisationId", async () => {
+    const res = buildRes();
+    await DeveloperApiKeyController.createApiKey(
+      buildReq({ userId: "u" }),
+      res,
+    );
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it("401 without a user", async () => {
+    const res = buildRes();
+    await DeveloperApiKeyController.createApiKey(
+      buildReq({ organisationId: "o" }),
+      res,
+    );
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  it("400 on an invalid body", async () => {
+    const res = buildRes();
+    await DeveloperApiKeyController.createApiKey(
+      buildReq({ organisationId: "o", userId: "u", body: { name: "" } }),
+      res,
+    );
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(svc.issue).not.toHaveBeenCalled();
+  });
+
+  it("201 with the issued key and normalised args", async () => {
+    svc.issue.mockResolvedValue({ id: "k", apiKey: "yc_live_secret" });
+    const res = buildRes();
+    await DeveloperApiKeyController.createApiKey(
+      buildReq({
+        organisationId: "o",
+        userId: "u",
+        body: { name: "CI", scopes: ["x"] },
+      }),
+      res,
+    );
+    expect(svc.issue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organisationId: "o",
+        name: "CI",
+        createdBy: "u",
+        expiresAt: null,
+      }),
+    );
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+
+  it("coerces expiresAt to a Date", async () => {
+    svc.issue.mockResolvedValue({});
+    const res = buildRes();
+    await DeveloperApiKeyController.createApiKey(
+      buildReq({
+        organisationId: "o",
+        userId: "u",
+        body: { name: "CI", expiresAt: "2027-01-01T00:00:00.000Z" },
+      }),
+      res,
+    );
+    expect(svc.issue.mock.calls[0][0].expiresAt).toBeInstanceOf(Date);
+  });
+
+  it("maps a service error to its status", async () => {
+    svc.issue.mockRejectedValue(new DeveloperApiKeyServiceError("bad", 400));
+    const res = buildRes();
+    await DeveloperApiKeyController.createApiKey(
+      buildReq({ organisationId: "o", userId: "u", body: { name: "CI" } }),
+      res,
+    );
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it("500 on an unexpected error", async () => {
+    svc.issue.mockRejectedValue(new Error("boom"));
+    const res = buildRes();
+    await DeveloperApiKeyController.createApiKey(
+      buildReq({ organisationId: "o", userId: "u", body: { name: "CI" } }),
+      res,
+    );
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+});
+
+describe("DeveloperApiKeyController.listApiKeys", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("400 without an org", async () => {
+    const res = buildRes();
+    await DeveloperApiKeyController.listApiKeys(buildReq(), res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it("200 wrapping the keys in data", async () => {
+    svc.list.mockResolvedValue([{ id: "k" }]);
+    const res = buildRes();
+    await DeveloperApiKeyController.listApiKeys(
+      buildReq({ organisationId: "o" }),
+      res,
+    );
+    expect(res.json).toHaveBeenCalledWith({ data: [{ id: "k" }] });
+  });
+
+  it("500 on error", async () => {
+    svc.list.mockRejectedValue(new Error("x"));
+    const res = buildRes();
+    await DeveloperApiKeyController.listApiKeys(
+      buildReq({ organisationId: "o" }),
+      res,
+    );
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+});
+
+describe("DeveloperApiKeyController.revokeApiKey", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("400 without an org", async () => {
+    const res = buildRes();
+    await DeveloperApiKeyController.revokeApiKey(
+      buildReq({ params: { keyId: "k" } }),
+      res,
+    );
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it("204 on success", async () => {
+    svc.revoke.mockResolvedValue(undefined);
+    const res = buildRes();
+    await DeveloperApiKeyController.revokeApiKey(
+      buildReq({ organisationId: "o", params: { keyId: "k" } }),
+      res,
+    );
+    expect(svc.revoke).toHaveBeenCalledWith({
+      organisationId: "o",
+      keyId: "k",
+    });
+    expect(res.status).toHaveBeenCalledWith(204);
+  });
+
+  it("404 maps the not-found service error", async () => {
+    svc.revoke.mockRejectedValue(new DeveloperApiKeyServiceError("nf", 404));
+    const res = buildRes();
+    await DeveloperApiKeyController.revokeApiKey(
+      buildReq({ organisationId: "o", params: { keyId: "k" } }),
+      res,
+    );
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+});

--- a/apps/backend/test/controllers/web/developer-billing.controller.test.ts
+++ b/apps/backend/test/controllers/web/developer-billing.controller.test.ts
@@ -1,0 +1,279 @@
+import type { Request, Response } from "express";
+import { DeveloperBillingController } from "../../../src/controllers/web/developer-billing.controller";
+import {
+  DeveloperBillingService,
+  DeveloperBillingServiceError,
+} from "../../../src/services/developer-billing.service";
+
+jest.mock("../../../src/services/developer-billing.service", () => {
+  class Err extends Error {
+    constructor(
+      message: string,
+      public statusCode: number,
+    ) {
+      super(message);
+    }
+  }
+  return {
+    DeveloperBillingService: {
+      getSubscription: jest.fn(),
+      createCheckoutSession: jest.fn(),
+      createPortalSession: jest.fn(),
+      handleWebhookEvent: jest.fn(),
+      verifyWebhook: jest.fn(),
+    },
+    DeveloperBillingServiceError: Err,
+  };
+});
+
+jest.mock("../../../src/utils/logger", () => ({
+  __esModule: true,
+  default: { error: jest.fn(), info: jest.fn() },
+}));
+
+const svc = DeveloperBillingService as unknown as {
+  getSubscription: jest.Mock;
+  createCheckoutSession: jest.Mock;
+  createPortalSession: jest.Mock;
+  handleWebhookEvent: jest.Mock;
+  verifyWebhook: jest.Mock;
+};
+
+const buildRes = (): Response => {
+  const res: Partial<Response> = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  res.send = jest.fn().mockReturnValue(res);
+  return res as Response;
+};
+
+const buildReq = (
+  over: {
+    organisationId?: string;
+    body?: unknown;
+    headers?: Record<string, string>;
+  } = {},
+): Request =>
+  ({
+    body: over.body ?? {},
+    params: {},
+    headers: over.headers ?? {},
+    organisationId: over.organisationId,
+  }) as unknown as Request;
+
+describe("DeveloperBillingController.getSubscription", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("400 without organisationId", async () => {
+    const res = buildRes();
+    await DeveloperBillingController.getSubscription(buildReq(), res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it("200 with data envelope", async () => {
+    svc.getSubscription.mockResolvedValue({ id: "s", plan: "free" });
+    const res = buildRes();
+    await DeveloperBillingController.getSubscription(
+      buildReq({ organisationId: "o" }),
+      res,
+    );
+    expect(res.json).toHaveBeenCalledWith({ data: { id: "s", plan: "free" } });
+  });
+
+  it("500 on unexpected error", async () => {
+    svc.getSubscription.mockRejectedValue(new Error("boom"));
+    const res = buildRes();
+    await DeveloperBillingController.getSubscription(
+      buildReq({ organisationId: "o" }),
+      res,
+    );
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+});
+
+describe("DeveloperBillingController.createCheckout", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("400 without organisationId", async () => {
+    const res = buildRes();
+    await DeveloperBillingController.createCheckout(buildReq(), res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it("400 when successUrl is missing", async () => {
+    const res = buildRes();
+    await DeveloperBillingController.createCheckout(
+      buildReq({
+        organisationId: "o",
+        body: { cancelUrl: "https://b.com" },
+      }),
+      res,
+    );
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(svc.createCheckoutSession).not.toHaveBeenCalled();
+  });
+
+  it("400 when successUrl is not a valid URL", async () => {
+    const res = buildRes();
+    await DeveloperBillingController.createCheckout(
+      buildReq({
+        organisationId: "o",
+        body: { successUrl: "not-a-url", cancelUrl: "https://b.com" },
+      }),
+      res,
+    );
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it("201 with checkout URL", async () => {
+    svc.createCheckoutSession.mockResolvedValue(
+      "https://checkout.stripe.com/x",
+    );
+    const res = buildRes();
+    await DeveloperBillingController.createCheckout(
+      buildReq({
+        organisationId: "o",
+        body: {
+          successUrl: "https://app.com/success",
+          cancelUrl: "https://app.com/cancel",
+        },
+      }),
+      res,
+    );
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith({
+      data: { url: "https://checkout.stripe.com/x" },
+    });
+  });
+
+  it("maps service error to its status code", async () => {
+    svc.createCheckoutSession.mockRejectedValue(
+      new DeveloperBillingServiceError("not configured", 500),
+    );
+    const res = buildRes();
+    await DeveloperBillingController.createCheckout(
+      buildReq({
+        organisationId: "o",
+        body: {
+          successUrl: "https://app.com/success",
+          cancelUrl: "https://app.com/cancel",
+        },
+      }),
+      res,
+    );
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+});
+
+describe("DeveloperBillingController.createPortal", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("400 without organisationId", async () => {
+    const res = buildRes();
+    await DeveloperBillingController.createPortal(buildReq(), res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it("400 without returnUrl", async () => {
+    const res = buildRes();
+    await DeveloperBillingController.createPortal(
+      buildReq({ organisationId: "o", body: {} }),
+      res,
+    );
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it("201 with portal URL", async () => {
+    svc.createPortalSession.mockResolvedValue("https://billing.stripe.com/p");
+    const res = buildRes();
+    await DeveloperBillingController.createPortal(
+      buildReq({
+        organisationId: "o",
+        body: { returnUrl: "https://app.com/billing" },
+      }),
+      res,
+    );
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith({
+      data: { url: "https://billing.stripe.com/p" },
+    });
+  });
+
+  it("404 maps not-found service error", async () => {
+    svc.createPortalSession.mockRejectedValue(
+      new DeveloperBillingServiceError("No billing account", 404),
+    );
+    const res = buildRes();
+    await DeveloperBillingController.createPortal(
+      buildReq({
+        organisationId: "o",
+        body: { returnUrl: "https://app.com/billing" },
+      }),
+      res,
+    );
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+});
+
+describe("DeveloperBillingController.webhook", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("400 when stripe-signature header is missing", async () => {
+    const res = buildRes();
+    await DeveloperBillingController.webhook(
+      buildReq({ body: Buffer.from("x") }),
+      res,
+    );
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(svc.verifyWebhook).not.toHaveBeenCalled();
+  });
+
+  it("400 when signature verification fails", async () => {
+    svc.verifyWebhook.mockImplementation(() => {
+      throw new Error("invalid");
+    });
+    const res = buildRes();
+    await DeveloperBillingController.webhook(
+      buildReq({
+        body: Buffer.from("x"),
+        headers: { "stripe-signature": "sig" },
+      }),
+      res,
+    );
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(svc.handleWebhookEvent).not.toHaveBeenCalled();
+  });
+
+  it("200 on successful event processing", async () => {
+    const fakeEvent = { type: "checkout.session.completed" };
+    svc.verifyWebhook.mockReturnValue(fakeEvent);
+    svc.handleWebhookEvent.mockResolvedValue(undefined);
+
+    const res = buildRes();
+    await DeveloperBillingController.webhook(
+      buildReq({
+        body: Buffer.from("x"),
+        headers: { "stripe-signature": "sig" },
+      }),
+      res,
+    );
+    expect(svc.handleWebhookEvent).toHaveBeenCalledWith(fakeEvent);
+    expect(res.json).toHaveBeenCalledWith({ received: true });
+  });
+
+  it("500 when handler throws", async () => {
+    const fakeEvent = { type: "some.event" };
+    svc.verifyWebhook.mockReturnValue(fakeEvent);
+    svc.handleWebhookEvent.mockRejectedValue(new Error("handler failed"));
+
+    const res = buildRes();
+    await DeveloperBillingController.webhook(
+      buildReq({
+        body: Buffer.from("x"),
+        headers: { "stripe-signature": "sig" },
+      }),
+      res,
+    );
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+});

--- a/apps/backend/test/controllers/web/developer-data.controller.test.ts
+++ b/apps/backend/test/controllers/web/developer-data.controller.test.ts
@@ -1,0 +1,342 @@
+import type { Request, Response } from "express";
+import { DeveloperDataController } from "../../../src/controllers/web/developer-data.controller";
+import { prisma } from "../../../src/config/prisma";
+
+jest.mock("../../../src/config/prisma", () => ({
+  prisma: {
+    appointment: {
+      findMany: jest.fn(),
+      findFirst: jest.fn(),
+    },
+    patientOrganisation: {
+      findMany: jest.fn(),
+      findFirst: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("../../../src/utils/logger", () => ({
+  __esModule: true,
+  default: { error: jest.fn(), info: jest.fn() },
+}));
+
+const mockPrisma = prisma as unknown as {
+  appointment: { findMany: jest.Mock; findFirst: jest.Mock };
+  patientOrganisation: { findMany: jest.Mock; findFirst: jest.Mock };
+};
+
+const buildRes = (): Response => {
+  const res: Partial<Response> = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res as Response;
+};
+
+const buildReq = (
+  organisationId?: string,
+  query: Record<string, string> = {},
+  params: Record<string, string> = {},
+): Request =>
+  ({
+    organisationId,
+    query,
+    params,
+  }) as unknown as Request;
+
+const sampleAppointment = {
+  id: "appt-1",
+  organisationId: "org-1",
+  patient: { id: "pat-1", name: "Buddy" },
+  lead: null,
+  appointmentType: null,
+  room: null,
+  appointmentDate: new Date("2026-07-01T10:00:00Z"),
+  startTime: new Date("2026-07-01T10:00:00Z"),
+  endTime: new Date("2026-07-01T10:30:00Z"),
+  timeSlot: "10:00",
+  durationMinutes: 30,
+  status: "UPCOMING",
+  isEmergency: false,
+  concern: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const samplePatient = {
+  id: "pat-1",
+  name: "Buddy",
+  type: "dog",
+  breed: "Labrador",
+  dateOfBirth: new Date("2020-01-01"),
+  gender: "male",
+  photoUrl: null,
+  status: "active",
+  isInsured: false,
+  microchipNumber: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ---- listAppointments ----
+
+describe("DeveloperDataController.listAppointments", () => {
+  it("400 when organisationId missing", async () => {
+    const res = buildRes();
+    await DeveloperDataController.listAppointments(buildReq(undefined), res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(mockPrisma.appointment.findMany).not.toHaveBeenCalled();
+  });
+
+  it("400 when query params are invalid", async () => {
+    const res = buildRes();
+    await DeveloperDataController.listAppointments(
+      buildReq("org-1", { limit: "not-a-number" }),
+      res,
+    );
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it("returns appointment list scoped to org", async () => {
+    mockPrisma.appointment.findMany.mockResolvedValue([sampleAppointment]);
+    const res = buildRes();
+    await DeveloperDataController.listAppointments(buildReq("org-1"), res);
+    expect(mockPrisma.appointment.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { organisationId: "org-1" } }),
+    );
+    expect(res.json).toHaveBeenCalledWith({
+      data: [sampleAppointment],
+      total: 1,
+    });
+  });
+
+  it("applies status filter", async () => {
+    mockPrisma.appointment.findMany.mockResolvedValue([sampleAppointment]);
+    const res = buildRes();
+    await DeveloperDataController.listAppointments(
+      buildReq("org-1", { status: "UPCOMING" }),
+      res,
+    );
+    expect(mockPrisma.appointment.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { organisationId: "org-1", status: "UPCOMING" },
+      }),
+    );
+  });
+
+  it("applies dateFrom filter", async () => {
+    mockPrisma.appointment.findMany.mockResolvedValue([]);
+    const res = buildRes();
+    await DeveloperDataController.listAppointments(
+      buildReq("org-1", { dateFrom: "2026-07-01T00:00:00Z" }),
+      res,
+    );
+    const call = mockPrisma.appointment.findMany.mock.calls[0][0];
+    expect(call.where.appointmentDate).toMatchObject({ gte: expect.any(Date) });
+  });
+
+  it("applies dateTo filter", async () => {
+    mockPrisma.appointment.findMany.mockResolvedValue([]);
+    const res = buildRes();
+    await DeveloperDataController.listAppointments(
+      buildReq("org-1", { dateTo: "2026-07-31T23:59:59Z" }),
+      res,
+    );
+    const call = mockPrisma.appointment.findMany.mock.calls[0][0];
+    expect(call.where.appointmentDate).toMatchObject({ lte: expect.any(Date) });
+  });
+
+  it("applies both dateFrom and dateTo", async () => {
+    mockPrisma.appointment.findMany.mockResolvedValue([]);
+    const res = buildRes();
+    await DeveloperDataController.listAppointments(
+      buildReq("org-1", {
+        dateFrom: "2026-07-01T00:00:00Z",
+        dateTo: "2026-07-31T23:59:59Z",
+      }),
+      res,
+    );
+    const call = mockPrisma.appointment.findMany.mock.calls[0][0];
+    expect(call.where.appointmentDate).toMatchObject({
+      gte: expect.any(Date),
+      lte: expect.any(Date),
+    });
+  });
+
+  it("500 when prisma throws", async () => {
+    mockPrisma.appointment.findMany.mockRejectedValue(new Error("db error"));
+    const res = buildRes();
+    await DeveloperDataController.listAppointments(buildReq("org-1"), res);
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+});
+
+// ---- getAppointment ----
+
+describe("DeveloperDataController.getAppointment", () => {
+  it("400 when organisationId missing", async () => {
+    const res = buildRes();
+    await DeveloperDataController.getAppointment(
+      buildReq(undefined, {}, { id: "appt-1" }),
+      res,
+    );
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it("404 when appointment not found or not in org", async () => {
+    mockPrisma.appointment.findFirst.mockResolvedValue(null);
+    const res = buildRes();
+    await DeveloperDataController.getAppointment(
+      buildReq("org-1", {}, { id: "appt-999" }),
+      res,
+    );
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it("returns appointment scoped to org", async () => {
+    mockPrisma.appointment.findFirst.mockResolvedValue(sampleAppointment);
+    const res = buildRes();
+    await DeveloperDataController.getAppointment(
+      buildReq("org-1", {}, { id: "appt-1" }),
+      res,
+    );
+    expect(mockPrisma.appointment.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "appt-1", organisationId: "org-1" },
+      }),
+    );
+    expect(res.json).toHaveBeenCalledWith({ data: sampleAppointment });
+  });
+
+  it("500 when prisma throws", async () => {
+    mockPrisma.appointment.findFirst.mockRejectedValue(new Error("db error"));
+    const res = buildRes();
+    await DeveloperDataController.getAppointment(
+      buildReq("org-1", {}, { id: "appt-1" }),
+      res,
+    );
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+});
+
+// ---- listPatients ----
+
+describe("DeveloperDataController.listPatients", () => {
+  it("400 when organisationId missing", async () => {
+    const res = buildRes();
+    await DeveloperDataController.listPatients(buildReq(undefined), res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it("400 when query params are invalid", async () => {
+    const res = buildRes();
+    await DeveloperDataController.listPatients(
+      buildReq("org-1", { limit: "bad" }),
+      res,
+    );
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it("returns patients linked to org", async () => {
+    mockPrisma.patientOrganisation.findMany.mockResolvedValue([
+      { patient: samplePatient },
+    ]);
+    const res = buildRes();
+    await DeveloperDataController.listPatients(buildReq("org-1"), res);
+    expect(mockPrisma.patientOrganisation.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { organisationId: "org-1", status: "ACTIVE" },
+      }),
+    );
+    expect(res.json).toHaveBeenCalledWith({ data: [samplePatient], total: 1 });
+  });
+
+  it("filters by patient status after loading from DB", async () => {
+    const activePatient = { ...samplePatient, status: "active" };
+    const archivedPatient = {
+      ...samplePatient,
+      id: "pat-2",
+      status: "archived",
+    };
+    mockPrisma.patientOrganisation.findMany.mockResolvedValue([
+      { patient: activePatient },
+      { patient: archivedPatient },
+    ]);
+    const res = buildRes();
+    await DeveloperDataController.listPatients(
+      buildReq("org-1", { status: "active" }),
+      res,
+    );
+    const body = (res.json as jest.Mock).mock.calls[0][0];
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].status).toBe("active");
+  });
+
+  it("500 when prisma throws", async () => {
+    mockPrisma.patientOrganisation.findMany.mockRejectedValue(
+      new Error("db error"),
+    );
+    const res = buildRes();
+    await DeveloperDataController.listPatients(buildReq("org-1"), res);
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+});
+
+// ---- getPatient ----
+
+describe("DeveloperDataController.getPatient", () => {
+  it("400 when organisationId missing", async () => {
+    const res = buildRes();
+    await DeveloperDataController.getPatient(
+      buildReq(undefined, {}, { id: "pat-1" }),
+      res,
+    );
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it("404 when patient not linked to org", async () => {
+    mockPrisma.patientOrganisation.findFirst.mockResolvedValue(null);
+    const res = buildRes();
+    await DeveloperDataController.getPatient(
+      buildReq("org-1", {}, { id: "pat-999" }),
+      res,
+    );
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it("returns patient scoped to org", async () => {
+    mockPrisma.patientOrganisation.findFirst.mockResolvedValue({
+      patient: samplePatient,
+    });
+    const res = buildRes();
+    await DeveloperDataController.getPatient(
+      buildReq("org-1", {}, { id: "pat-1" }),
+      res,
+    );
+    expect(mockPrisma.patientOrganisation.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          patientId: "pat-1",
+          organisationId: "org-1",
+          status: "ACTIVE",
+        },
+      }),
+    );
+    expect(res.json).toHaveBeenCalledWith({ data: samplePatient });
+  });
+
+  it("500 when prisma throws", async () => {
+    mockPrisma.patientOrganisation.findFirst.mockRejectedValue(
+      new Error("db error"),
+    );
+    const res = buildRes();
+    await DeveloperDataController.getPatient(
+      buildReq("org-1", {}, { id: "pat-1" }),
+      res,
+    );
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+});

--- a/apps/backend/test/controllers/web/developer-usage.controller.test.ts
+++ b/apps/backend/test/controllers/web/developer-usage.controller.test.ts
@@ -1,0 +1,70 @@
+import type { Request, Response } from "express";
+import { DeveloperUsageController } from "../../../src/controllers/web/developer-usage.controller";
+import { DeveloperUsageService } from "../../../src/services/developer-usage.service";
+
+jest.mock("../../../src/services/developer-usage.service", () => ({
+  DeveloperUsageService: { getUsage: jest.fn() },
+}));
+
+jest.mock("../../../src/utils/logger", () => ({
+  __esModule: true,
+  default: { error: jest.fn(), info: jest.fn() },
+}));
+
+const usageMock = DeveloperUsageService.getUsage as jest.Mock;
+
+const buildRes = (): Response => {
+  const res: Partial<Response> = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res as Response;
+};
+
+const buildReq = (
+  organisationId?: string,
+  query: Record<string, string> = {},
+): Request =>
+  ({
+    organisationId,
+    query,
+  }) as unknown as Request;
+
+const sampleUsage = { billingPeriod: "2026-06", callCount: 42, limit: 1000 };
+
+describe("DeveloperUsageController.getUsage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("400 when organisationId is missing", async () => {
+    const res = buildRes();
+    await DeveloperUsageController.getUsage(buildReq(undefined), res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(usageMock).not.toHaveBeenCalled();
+  });
+
+  it("returns usage data for the current period", async () => {
+    usageMock.mockResolvedValue(sampleUsage);
+    const res = buildRes();
+    await DeveloperUsageController.getUsage(buildReq("org-1"), res);
+    expect(usageMock).toHaveBeenCalledWith("org-1", undefined);
+    expect(res.json).toHaveBeenCalledWith({ data: sampleUsage });
+  });
+
+  it("passes query.period to the service", async () => {
+    usageMock.mockResolvedValue(sampleUsage);
+    const res = buildRes();
+    await DeveloperUsageController.getUsage(
+      buildReq("org-1", { period: "2026-05" }),
+      res,
+    );
+    expect(usageMock).toHaveBeenCalledWith("org-1", "2026-05");
+  });
+
+  it("500 when service throws", async () => {
+    usageMock.mockRejectedValue(new Error("db offline"));
+    const res = buildRes();
+    await DeveloperUsageController.getUsage(buildReq("org-1"), res);
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+});

--- a/apps/backend/test/middlewares/api-key-auth.test.ts
+++ b/apps/backend/test/middlewares/api-key-auth.test.ts
@@ -4,12 +4,18 @@ import {
   requireScope,
 } from "../../src/middlewares/api-key-auth";
 import { DeveloperApiKeyService } from "../../src/services/developer-api-key.service";
+import { DeveloperUsageService } from "../../src/services/developer-usage.service";
 
 jest.mock("../../src/services/developer-api-key.service", () => ({
   DeveloperApiKeyService: { verify: jest.fn() },
 }));
 
+jest.mock("../../src/services/developer-usage.service", () => ({
+  DeveloperUsageService: { incrementAndCheck: jest.fn() },
+}));
+
 const verifyMock = DeveloperApiKeyService.verify as jest.Mock;
+const incrementMock = DeveloperUsageService.incrementAndCheck as jest.Mock;
 
 const buildRes = (): Response => {
   const res: Partial<Response> = {};
@@ -23,11 +29,19 @@ const buildReq = (headers: Record<string, string> = {}): Request =>
     header: (name: string) => headers[name.toLowerCase()],
   }) as unknown as Request;
 
+const verifiedKey = {
+  id: "k",
+  organisationId: "org-9",
+  scopes: ["x"],
+  environment: "live",
+};
+
 describe("authorizeApiKey", () => {
   let next: NextFunction;
   beforeEach(() => {
     jest.clearAllMocks();
     next = jest.fn();
+    incrementMock.mockResolvedValue({ allowed: true, callCount: 1 });
   });
 
   it("401 when no key is presented", async () => {
@@ -50,12 +64,7 @@ describe("authorizeApiKey", () => {
   });
 
   it("binds the org and calls next for a valid Bearer key", async () => {
-    verifyMock.mockResolvedValue({
-      id: "k",
-      organisationId: "org-9",
-      scopes: ["x"],
-      environment: "live",
-    });
+    verifyMock.mockResolvedValue(verifiedKey);
     const req = buildReq({ authorization: "Bearer yc_live_good" });
     const res = buildRes();
 
@@ -69,12 +78,7 @@ describe("authorizeApiKey", () => {
   });
 
   it("accepts the X-API-Key header", async () => {
-    verifyMock.mockResolvedValue({
-      id: "k",
-      organisationId: "org-9",
-      scopes: [],
-      environment: "live",
-    });
+    verifyMock.mockResolvedValue(verifiedKey);
     const res = buildRes();
     await authorizeApiKey(buildReq({ "x-api-key": "yc_live_good" }), res, next);
     expect(verifyMock).toHaveBeenCalledWith("yc_live_good");
@@ -85,6 +89,44 @@ describe("authorizeApiKey", () => {
     const res = buildRes();
     await authorizeApiKey(buildReq({ authorization: "Basic abc" }), res, next);
     expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  it("401 when Bearer token is blank (empty after prefix strip)", async () => {
+    const res = buildRes();
+    await authorizeApiKey(buildReq({ authorization: "Bearer " }), res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("401 when x-api-key header is present but blank", async () => {
+    const res = buildRes();
+    await authorizeApiKey(buildReq({ "x-api-key": "   " }), res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("429 when quota is exceeded", async () => {
+    verifyMock.mockResolvedValue(verifiedKey);
+    incrementMock.mockResolvedValue({ allowed: false, callCount: 1001 });
+    const res = buildRes();
+    await authorizeApiKey(
+      buildReq({ authorization: "Bearer yc_live_good" }),
+      res,
+      next,
+    );
+    expect(res.status).toHaveBeenCalledWith(429);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("calls incrementAndCheck with the organisationId", async () => {
+    verifyMock.mockResolvedValue(verifiedKey);
+    const res = buildRes();
+    await authorizeApiKey(
+      buildReq({ authorization: "Bearer yc_live_good" }),
+      res,
+      next,
+    );
+    expect(incrementMock).toHaveBeenCalledWith("org-9");
   });
 });
 

--- a/apps/backend/test/middlewares/api-key-auth.test.ts
+++ b/apps/backend/test/middlewares/api-key-auth.test.ts
@@ -1,0 +1,121 @@
+import type { NextFunction, Request, Response } from "express";
+import {
+  authorizeApiKey,
+  requireScope,
+} from "../../src/middlewares/api-key-auth";
+import { DeveloperApiKeyService } from "../../src/services/developer-api-key.service";
+
+jest.mock("../../src/services/developer-api-key.service", () => ({
+  DeveloperApiKeyService: { verify: jest.fn() },
+}));
+
+const verifyMock = DeveloperApiKeyService.verify as jest.Mock;
+
+const buildRes = (): Response => {
+  const res: Partial<Response> = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res as Response;
+};
+
+const buildReq = (headers: Record<string, string> = {}): Request =>
+  ({
+    header: (name: string) => headers[name.toLowerCase()],
+  }) as unknown as Request;
+
+describe("authorizeApiKey", () => {
+  let next: NextFunction;
+  beforeEach(() => {
+    jest.clearAllMocks();
+    next = jest.fn();
+  });
+
+  it("401 when no key is presented", async () => {
+    const res = buildRes();
+    await authorizeApiKey(buildReq(), res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("401 when the key is invalid", async () => {
+    verifyMock.mockResolvedValue(null);
+    const res = buildRes();
+    await authorizeApiKey(
+      buildReq({ authorization: "Bearer yc_live_bad" }),
+      res,
+      next,
+    );
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("binds the org and calls next for a valid Bearer key", async () => {
+    verifyMock.mockResolvedValue({
+      id: "k",
+      organisationId: "org-9",
+      scopes: ["x"],
+      environment: "live",
+    });
+    const req = buildReq({ authorization: "Bearer yc_live_good" });
+    const res = buildRes();
+
+    await authorizeApiKey(req, res, next);
+
+    expect(verifyMock).toHaveBeenCalledWith("yc_live_good");
+    expect((req as unknown as { organisationId: string }).organisationId).toBe(
+      "org-9",
+    );
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("accepts the X-API-Key header", async () => {
+    verifyMock.mockResolvedValue({
+      id: "k",
+      organisationId: "org-9",
+      scopes: [],
+      environment: "live",
+    });
+    const res = buildRes();
+    await authorizeApiKey(buildReq({ "x-api-key": "yc_live_good" }), res, next);
+    expect(verifyMock).toHaveBeenCalledWith("yc_live_good");
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("ignores a non-Bearer Authorization header", async () => {
+    const res = buildRes();
+    await authorizeApiKey(buildReq({ authorization: "Basic abc" }), res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+});
+
+describe("requireScope", () => {
+  let next: NextFunction;
+  beforeEach(() => {
+    next = jest.fn();
+  });
+
+  it("403 when the scope is absent", () => {
+    const req = { apiKey: { scopes: ["a"] } } as unknown as Request;
+    const res = buildRes();
+    requireScope("b")(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("passes when the scope is present", () => {
+    const req = { apiKey: { scopes: ["b"] } } as unknown as Request;
+    requireScope("b")(req, buildRes(), next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("wildcard scope passes everything", () => {
+    const req = { apiKey: { scopes: ["*"] } } as unknown as Request;
+    requireScope("anything")(req, buildRes(), next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("403 when there is no apiKey context", () => {
+    requireScope("b")({} as Request, buildRes(), next);
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/test/services/developer-api-key.service.test.ts
+++ b/apps/backend/test/services/developer-api-key.service.test.ts
@@ -1,0 +1,242 @@
+import {
+  DeveloperApiKeyService,
+  DeveloperApiKeyServiceError,
+} from "../../src/services/developer-api-key.service";
+import { prisma } from "../../src/config/prisma";
+
+jest.mock("../../src/config/prisma", () => ({
+  prisma: {
+    developerApiKey: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      updateMany: jest.fn(),
+    },
+  },
+}));
+
+const mockPrisma = prisma as unknown as {
+  developerApiKey: {
+    create: jest.Mock;
+    findMany: jest.Mock;
+    findUnique: jest.Mock;
+    update: jest.Mock;
+    updateMany: jest.Mock;
+  };
+};
+
+describe("DeveloperApiKeyService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("issue", () => {
+    it("stores the hash (never the plaintext) and returns the plaintext once", async () => {
+      mockPrisma.developerApiKey.create.mockImplementation(
+        async ({ data }: { data: Record<string, unknown> }) => ({
+          id: "key-1",
+          name: data.name,
+          prefix: data.prefix,
+          last4: data.last4,
+          scopes: data.scopes,
+          environment: data.environment,
+        }),
+      );
+
+      const issued = await DeveloperApiKeyService.issue({
+        organisationId: "org-1",
+        name: "CI key",
+        createdBy: "user-1",
+        scopes: ["appointments:read"],
+      });
+
+      expect(issued.apiKey).toMatch(/^yc_live_/);
+      expect(issued.prefix).toMatch(/^yc_live_/);
+      expect(issued.last4).toHaveLength(4);
+
+      const createData =
+        mockPrisma.developerApiKey.create.mock.calls[0][0].data;
+      expect(createData.hashedKey).toHaveLength(64); // sha-256 hex
+      expect(createData.hashedKey).not.toEqual(issued.apiKey);
+      expect(createData).not.toHaveProperty("apiKey");
+    });
+
+    it("defaults environment to live and scopes to empty", async () => {
+      mockPrisma.developerApiKey.create.mockResolvedValue({
+        id: "k",
+        name: "n",
+        prefix: "yc_live_x",
+        last4: "abcd",
+        scopes: [],
+        environment: "live",
+      });
+
+      await DeveloperApiKeyService.issue({
+        organisationId: "org-1",
+        name: "n",
+        createdBy: "u",
+      });
+
+      expect(mockPrisma.developerApiKey.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ environment: "live", scopes: [] }),
+        }),
+      );
+    });
+
+    it("supports the test environment prefix", async () => {
+      mockPrisma.developerApiKey.create.mockResolvedValue({
+        id: "k",
+        name: "n",
+        prefix: "yc_test_x",
+        last4: "abcd",
+        scopes: [],
+        environment: "test",
+      });
+
+      const issued = await DeveloperApiKeyService.issue({
+        organisationId: "org-1",
+        name: "n",
+        createdBy: "u",
+        environment: "test" as never,
+      });
+
+      expect(issued.apiKey).toMatch(/^yc_test_/);
+    });
+
+    it.each([
+      ["organisationId", { organisationId: "", name: "n", createdBy: "u" }],
+      ["name", { organisationId: "o", name: "  ", createdBy: "u" }],
+      ["createdBy", { organisationId: "o", name: "n", createdBy: "" }],
+    ])("rejects an empty %s", async (_field, input) => {
+      await expect(
+        DeveloperApiKeyService.issue(input as never),
+      ).rejects.toBeInstanceOf(DeveloperApiKeyServiceError);
+      expect(mockPrisma.developerApiKey.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("list", () => {
+    it("returns org keys without secret columns", async () => {
+      mockPrisma.developerApiKey.findMany.mockResolvedValue([{ id: "k1" }]);
+      const result = await DeveloperApiKeyService.list("org-1");
+
+      expect(result).toEqual([{ id: "k1" }]);
+      const arg = mockPrisma.developerApiKey.findMany.mock.calls[0][0];
+      expect(arg.where).toEqual({ organisationId: "org-1" });
+      expect(arg.orderBy).toEqual({ createdAt: "desc" });
+      expect(arg.select.hashedKey).toBeUndefined();
+    });
+
+    it("rejects an empty org", async () => {
+      await expect(DeveloperApiKeyService.list("")).rejects.toBeInstanceOf(
+        DeveloperApiKeyServiceError,
+      );
+    });
+  });
+
+  describe("revoke", () => {
+    it("revokes an active key scoped to the org", async () => {
+      mockPrisma.developerApiKey.updateMany.mockResolvedValue({ count: 1 });
+      await expect(
+        DeveloperApiKeyService.revoke({ organisationId: "o", keyId: "k" }),
+      ).resolves.toBeUndefined();
+      expect(mockPrisma.developerApiKey.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            id: "k",
+            organisationId: "o",
+            status: "active",
+          }),
+        }),
+      );
+    });
+
+    it("throws 404 when nothing matched", async () => {
+      mockPrisma.developerApiKey.updateMany.mockResolvedValue({ count: 0 });
+      await expect(
+        DeveloperApiKeyService.revoke({ organisationId: "o", keyId: "k" }),
+      ).rejects.toMatchObject({ statusCode: 404 });
+    });
+  });
+
+  describe("verify", () => {
+    const activeRecord = {
+      id: "key-1",
+      organisationId: "org-1",
+      scopes: ["a"],
+      environment: "live",
+      status: "active",
+      expiresAt: null,
+      lastUsedAt: null,
+    };
+
+    it("returns null for a non-yc key without touching the DB", async () => {
+      expect(await DeveloperApiKeyService.verify("nope")).toBeNull();
+      expect(mockPrisma.developerApiKey.findUnique).not.toHaveBeenCalled();
+    });
+
+    it("returns null for a non-string key", async () => {
+      expect(
+        await DeveloperApiKeyService.verify(undefined as never),
+      ).toBeNull();
+    });
+
+    it("returns null for an unknown key", async () => {
+      mockPrisma.developerApiKey.findUnique.mockResolvedValue(null);
+      expect(await DeveloperApiKeyService.verify("yc_live_x")).toBeNull();
+    });
+
+    it("returns null for a revoked key", async () => {
+      mockPrisma.developerApiKey.findUnique.mockResolvedValue({
+        ...activeRecord,
+        status: "revoked",
+      });
+      expect(await DeveloperApiKeyService.verify("yc_live_x")).toBeNull();
+    });
+
+    it("returns null for an expired key", async () => {
+      mockPrisma.developerApiKey.findUnique.mockResolvedValue({
+        ...activeRecord,
+        expiresAt: new Date(Date.now() - 1000),
+      });
+      expect(await DeveloperApiKeyService.verify("yc_live_x")).toBeNull();
+    });
+
+    it("returns the context and refreshes a stale lastUsedAt", async () => {
+      mockPrisma.developerApiKey.findUnique.mockResolvedValue({
+        ...activeRecord,
+        lastUsedAt: null,
+      });
+      mockPrisma.developerApiKey.update.mockResolvedValue({});
+
+      const result = await DeveloperApiKeyService.verify("yc_live_x");
+      expect(result).toEqual({
+        id: "key-1",
+        organisationId: "org-1",
+        scopes: ["a"],
+        environment: "live",
+      });
+      expect(mockPrisma.developerApiKey.update).toHaveBeenCalled();
+    });
+
+    it("does not refresh a fresh lastUsedAt", async () => {
+      mockPrisma.developerApiKey.findUnique.mockResolvedValue({
+        ...activeRecord,
+        lastUsedAt: new Date(),
+      });
+      await DeveloperApiKeyService.verify("yc_live_x");
+      expect(mockPrisma.developerApiKey.update).not.toHaveBeenCalled();
+    });
+
+    it("swallows a lastUsedAt update failure", async () => {
+      mockPrisma.developerApiKey.findUnique.mockResolvedValue({
+        ...activeRecord,
+        lastUsedAt: null,
+      });
+      mockPrisma.developerApiKey.update.mockRejectedValue(new Error("db down"));
+      expect(await DeveloperApiKeyService.verify("yc_live_x")).not.toBeNull();
+    });
+  });
+});

--- a/apps/backend/test/services/developer-billing.service.test.ts
+++ b/apps/backend/test/services/developer-billing.service.test.ts
@@ -370,6 +370,214 @@ describe("DeveloperBillingService", () => {
         }),
       );
     });
+
+    it("skips customer.subscription.deleted when record not found", async () => {
+      mockPrisma.developerSubscription.findFirst.mockResolvedValue(null);
+      await DeveloperBillingService.handleWebhookEvent({
+        id: "evt_6",
+        type: "customer.subscription.deleted",
+        data: { object: { ...baseSubscription, status: "canceled" } },
+      } as never);
+      expect(mockPrisma.developerSubscription.update).not.toHaveBeenCalled();
+    });
+
+    it("logs and continues on unknown event type (default branch)", async () => {
+      await DeveloperBillingService.handleWebhookEvent({
+        id: "evt_7",
+        type: "payment_intent.created",
+        data: { object: {} },
+      } as never);
+      expect(mockPrisma.developerSubscription.upsert).not.toHaveBeenCalled();
+      expect(mockPrisma.developerSubscription.update).not.toHaveBeenCalled();
+    });
+
+    it("handles checkout.session.completed when subscription is an object", async () => {
+      const stripe = getStripeInstance();
+      stripe.subscriptions.retrieve.mockResolvedValue(baseSubscription);
+      mockPrisma.developerSubscription.upsert.mockResolvedValue({});
+
+      await DeveloperBillingService.handleWebhookEvent({
+        id: "evt_8",
+        type: "checkout.session.completed",
+        data: {
+          object: {
+            mode: "subscription",
+            subscription: { id: "sub_123" },
+            metadata: { organisationId: "org-1" },
+          },
+        },
+      } as never);
+
+      expect(stripe.subscriptions.retrieve).toHaveBeenCalledWith(
+        "sub_123",
+        expect.any(Object),
+      );
+    });
+
+    it("handles checkout with customer as object (not string)", async () => {
+      const stripe = getStripeInstance();
+      const subWithObjCustomer = {
+        ...baseSubscription,
+        customer: { id: "cus_obj" },
+      };
+      stripe.subscriptions.retrieve.mockResolvedValue(subWithObjCustomer);
+      mockPrisma.developerSubscription.upsert.mockResolvedValue({});
+
+      await DeveloperBillingService.handleWebhookEvent({
+        id: "evt_9",
+        type: "checkout.session.completed",
+        data: {
+          object: {
+            mode: "subscription",
+            subscription: "sub_123",
+            metadata: { organisationId: "org-1" },
+          },
+        },
+      } as never);
+
+      expect(mockPrisma.developerSubscription.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: expect.objectContaining({ stripeCustomerId: "cus_obj" }),
+        }),
+      );
+    });
+
+    it("skips checkout.session.completed when subscription id is missing", async () => {
+      await DeveloperBillingService.handleWebhookEvent({
+        id: "evt_10",
+        type: "checkout.session.completed",
+        data: {
+          object: {
+            mode: "subscription",
+            subscription: null,
+            metadata: { organisationId: "org-1" },
+          },
+        },
+      } as never);
+      expect(mockPrisma.developerSubscription.upsert).not.toHaveBeenCalled();
+    });
+
+    it("skips checkout.session.completed when organisationId metadata is missing", async () => {
+      await DeveloperBillingService.handleWebhookEvent({
+        id: "evt_11",
+        type: "checkout.session.completed",
+        data: {
+          object: {
+            mode: "subscription",
+            subscription: "sub_123",
+            metadata: {},
+          },
+        },
+      } as never);
+      expect(mockPrisma.developerSubscription.upsert).not.toHaveBeenCalled();
+    });
+
+    it("upserts with null periods when subscription has no items", async () => {
+      const stripe = getStripeInstance();
+      stripe.subscriptions.retrieve.mockResolvedValue({
+        ...baseSubscription,
+        items: { data: [] },
+      });
+      mockPrisma.developerSubscription.upsert.mockResolvedValue({});
+
+      await DeveloperBillingService.handleWebhookEvent({
+        id: "evt_12",
+        type: "checkout.session.completed",
+        data: {
+          object: {
+            mode: "subscription",
+            subscription: "sub_123",
+            metadata: { organisationId: "org-1" },
+          },
+        },
+      } as never);
+
+      expect(mockPrisma.developerSubscription.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: expect.objectContaining({
+            stripeSubscriptionItemId: null,
+            stripePriceId: null,
+            currentPeriodStart: null,
+            currentPeriodEnd: null,
+          }),
+        }),
+      );
+    });
+
+    it("handles subscription.updated with no items — falls back to record values", async () => {
+      mockPrisma.developerSubscription.findFirst.mockResolvedValue({
+        id: "ds-1",
+        stripePriceId: "price_old",
+        stripeSubscriptionItemId: "si_old",
+      });
+      mockPrisma.developerSubscription.update.mockResolvedValue({});
+
+      await DeveloperBillingService.handleWebhookEvent({
+        id: "evt_13",
+        type: "customer.subscription.updated",
+        data: {
+          object: {
+            ...baseSubscription,
+            items: { data: [] },
+            status: "trialing",
+          },
+        },
+      } as never);
+
+      expect(mockPrisma.developerSubscription.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            status: "trialing",
+            stripePriceId: "price_old",
+            stripeSubscriptionItemId: "si_old",
+            currentPeriodStart: null,
+            currentPeriodEnd: null,
+          }),
+        }),
+      );
+    });
+
+    it("maps incomplete status via toSubscriptionStatus", async () => {
+      mockPrisma.developerSubscription.findFirst.mockResolvedValue({
+        id: "ds-1",
+        stripePriceId: "price_old",
+        stripeSubscriptionItemId: "si_old",
+      });
+      mockPrisma.developerSubscription.update.mockResolvedValue({});
+
+      await DeveloperBillingService.handleWebhookEvent({
+        id: "evt_14",
+        type: "customer.subscription.updated",
+        data: { object: { ...baseSubscription, status: "incomplete" } },
+      } as never);
+
+      expect(mockPrisma.developerSubscription.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ status: "incomplete" }),
+        }),
+      );
+    });
+
+    it("maps canceled status via toSubscriptionStatus in subscription.updated", async () => {
+      mockPrisma.developerSubscription.findFirst.mockResolvedValue({
+        id: "ds-1",
+        stripePriceId: "price_old",
+        stripeSubscriptionItemId: "si_old",
+      });
+      mockPrisma.developerSubscription.update.mockResolvedValue({});
+
+      await DeveloperBillingService.handleWebhookEvent({
+        id: "evt_15",
+        type: "customer.subscription.updated",
+        data: { object: { ...baseSubscription, status: "canceled" } },
+      } as never);
+
+      expect(mockPrisma.developerSubscription.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ status: "canceled" }),
+        }),
+      );
+    });
   });
 
   describe("verifyWebhook", () => {
@@ -384,5 +592,52 @@ describe("DeveloperBillingService", () => {
       );
       expect(result).toBe(fakeEvent);
     });
+
+    it("throws when STRIPE_DEV_WEBHOOK_SECRET is not configured", () => {
+      const saved = process.env.STRIPE_DEV_WEBHOOK_SECRET;
+      delete process.env.STRIPE_DEV_WEBHOOK_SECRET;
+      expect(() =>
+        DeveloperBillingService.verifyWebhook(Buffer.from("body"), "sig"),
+      ).toThrow("STRIPE_DEV_WEBHOOK_SECRET is not configured");
+      process.env.STRIPE_DEV_WEBHOOK_SECRET = saved;
+    });
+  });
+});
+
+describe("DeveloperBillingService — module-isolated Stripe init", () => {
+  it("throws when STRIPE_SECRET_KEY is not configured", async () => {
+    const savedKey = process.env.STRIPE_SECRET_KEY;
+    delete process.env.STRIPE_SECRET_KEY;
+
+    let IsolatedBillingService: typeof DeveloperBillingService | undefined;
+
+    jest.isolateModules(() => {
+      jest.doMock("stripe", () => {
+        const MockStripe = jest.fn().mockImplementation(() => ({
+          customers: { create: jest.fn() },
+          checkout: { sessions: { create: jest.fn() } },
+        }));
+        return { __esModule: true, default: MockStripe };
+      });
+      jest.doMock("../../src/config/prisma", () => ({
+        prisma: { developerSubscription: { findUnique: jest.fn() } },
+      }));
+      const mod = jest.requireActual<{
+        DeveloperBillingService: typeof DeveloperBillingService;
+      }>("../../src/services/developer-billing.service");
+      IsolatedBillingService = mod.DeveloperBillingService;
+    });
+
+    if (!IsolatedBillingService) throw new Error("module load failed");
+
+    await expect(
+      IsolatedBillingService.createCheckoutSession({
+        organisationId: "o",
+        successUrl: "https://a.com",
+        cancelUrl: "https://b.com",
+      }),
+    ).rejects.toThrow("STRIPE_SECRET_KEY is not configured");
+
+    process.env.STRIPE_SECRET_KEY = savedKey;
   });
 });

--- a/apps/backend/test/services/developer-billing.service.test.ts
+++ b/apps/backend/test/services/developer-billing.service.test.ts
@@ -1,0 +1,388 @@
+import {
+  DeveloperBillingService,
+  DeveloperBillingServiceError,
+} from "../../src/services/developer-billing.service";
+import { prisma } from "../../src/config/prisma";
+
+jest.mock("../../src/config/prisma", () => ({
+  prisma: {
+    developerSubscription: {
+      findUnique: jest.fn(),
+      findFirst: jest.fn(),
+      upsert: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("stripe", () => {
+  const mockCustomersCreate = jest.fn();
+  const mockCheckoutSessionsCreate = jest.fn();
+  const mockBillingPortalCreate = jest.fn();
+  const mockSubscriptionsRetrieve = jest.fn();
+  const mockWebhooksConstructEvent = jest.fn();
+  const mockMeterEventsCreate = jest.fn();
+
+  const MockStripe = jest.fn().mockImplementation(() => ({
+    customers: { create: mockCustomersCreate },
+    checkout: { sessions: { create: mockCheckoutSessionsCreate } },
+    billingPortal: { sessions: { create: mockBillingPortalCreate } },
+    subscriptions: { retrieve: mockSubscriptionsRetrieve },
+    billing: { meterEvents: { create: mockMeterEventsCreate } },
+    webhooks: { constructEvent: mockWebhooksConstructEvent },
+  }));
+
+  return { __esModule: true, default: MockStripe };
+});
+
+const mockPrisma = prisma as unknown as {
+  developerSubscription: {
+    findUnique: jest.Mock;
+    findFirst: jest.Mock;
+    upsert: jest.Mock;
+    update: jest.Mock;
+  };
+};
+
+const getStripeInstance = () => {
+  const Stripe = jest.requireMock("stripe").default;
+  return new Stripe();
+};
+
+describe("DeveloperBillingService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.STRIPE_SECRET_KEY = "sk_test_key";
+    process.env.STRIPE_DEV_METERED_PRICE_ID = "price_metered_abc";
+    process.env.STRIPE_DEV_WEBHOOK_SECRET = "whsec_test";
+  });
+
+  describe("getSubscription", () => {
+    it("returns the record when found", async () => {
+      const record = {
+        id: "sub-1",
+        organisationId: "org-1",
+        plan: "pro",
+        status: "active",
+        stripeSubscriptionItemId: "si_x",
+        currentPeriodStart: new Date("2026-06-01"),
+        currentPeriodEnd: new Date("2026-07-01"),
+        cancelAtPeriodEnd: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      mockPrisma.developerSubscription.findUnique.mockResolvedValue(record);
+      const result = await DeveloperBillingService.getSubscription("org-1");
+      expect(result).toEqual(record);
+    });
+
+    it("returns a free default when no record exists", async () => {
+      mockPrisma.developerSubscription.findUnique.mockResolvedValue(null);
+      const result = await DeveloperBillingService.getSubscription("org-1");
+      expect(result.plan).toBe("free");
+      expect(result.id).toBeNull();
+    });
+
+    it("throws 400 on empty organisationId", async () => {
+      await expect(
+        DeveloperBillingService.getSubscription(""),
+      ).rejects.toBeInstanceOf(DeveloperBillingServiceError);
+    });
+  });
+
+  describe("getOrCreateCustomer", () => {
+    it("returns existing stripeCustomerId without calling Stripe", async () => {
+      mockPrisma.developerSubscription.findUnique.mockResolvedValue({
+        stripeCustomerId: "cus_existing",
+      });
+      const id = await DeveloperBillingService.getOrCreateCustomer("org-1");
+      expect(id).toBe("cus_existing");
+      const stripe = getStripeInstance();
+      expect(stripe.customers.create).not.toHaveBeenCalled();
+    });
+
+    it("creates a Stripe customer and upserts the record", async () => {
+      mockPrisma.developerSubscription.findUnique.mockResolvedValue(null);
+      const stripe = getStripeInstance();
+      stripe.customers.create.mockResolvedValue({ id: "cus_new" });
+      mockPrisma.developerSubscription.upsert.mockResolvedValue({});
+
+      const id = await DeveloperBillingService.getOrCreateCustomer("org-1");
+      expect(id).toBe("cus_new");
+      expect(mockPrisma.developerSubscription.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { organisationId: "org-1" },
+          create: expect.objectContaining({ stripeCustomerId: "cus_new" }),
+        }),
+      );
+    });
+  });
+
+  describe("createCheckoutSession", () => {
+    it("returns the checkout URL using the metered price", async () => {
+      mockPrisma.developerSubscription.findUnique.mockResolvedValue({
+        stripeCustomerId: "cus_x",
+      });
+      const stripe = getStripeInstance();
+      stripe.checkout.sessions.create.mockResolvedValue({
+        url: "https://checkout.stripe.com/test",
+      });
+
+      const url = await DeveloperBillingService.createCheckoutSession({
+        organisationId: "org-1",
+        successUrl: "https://app.com/success",
+        cancelUrl: "https://app.com/cancel",
+      });
+
+      expect(url).toBe("https://checkout.stripe.com/test");
+      expect(stripe.checkout.sessions.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mode: "subscription",
+          customer: "cus_x",
+          line_items: [{ price: "price_metered_abc" }],
+        }),
+      );
+    });
+
+    it("throws 400 on empty organisationId", async () => {
+      await expect(
+        DeveloperBillingService.createCheckoutSession({
+          organisationId: "",
+          successUrl: "https://app.com/success",
+          cancelUrl: "https://app.com/cancel",
+        }),
+      ).rejects.toBeInstanceOf(DeveloperBillingServiceError);
+    });
+
+    it("throws 500 when session url is missing", async () => {
+      mockPrisma.developerSubscription.findUnique.mockResolvedValue({
+        stripeCustomerId: "cus_x",
+      });
+      const stripe = getStripeInstance();
+      stripe.checkout.sessions.create.mockResolvedValue({ url: null });
+
+      await expect(
+        DeveloperBillingService.createCheckoutSession({
+          organisationId: "org-1",
+          successUrl: "https://app.com/success",
+          cancelUrl: "https://app.com/cancel",
+        }),
+      ).rejects.toMatchObject({ statusCode: 500 });
+    });
+
+    it("throws 500 when STRIPE_DEV_METERED_PRICE_ID is not set", async () => {
+      delete process.env.STRIPE_DEV_METERED_PRICE_ID;
+      mockPrisma.developerSubscription.findUnique.mockResolvedValue({
+        stripeCustomerId: "cus_x",
+      });
+
+      await expect(
+        DeveloperBillingService.createCheckoutSession({
+          organisationId: "org-1",
+          successUrl: "https://app.com/success",
+          cancelUrl: "https://app.com/cancel",
+        }),
+      ).rejects.toMatchObject({ statusCode: 500 });
+    });
+  });
+
+  describe("createPortalSession", () => {
+    it("returns the portal URL", async () => {
+      mockPrisma.developerSubscription.findUnique.mockResolvedValue({
+        stripeCustomerId: "cus_x",
+      });
+      const stripe = getStripeInstance();
+      stripe.billingPortal.sessions.create.mockResolvedValue({
+        url: "https://billing.stripe.com/session",
+      });
+
+      const url = await DeveloperBillingService.createPortalSession({
+        organisationId: "org-1",
+        returnUrl: "https://app.com/billing",
+      });
+
+      expect(url).toBe("https://billing.stripe.com/session");
+    });
+
+    it("throws 404 when no Stripe customer exists", async () => {
+      mockPrisma.developerSubscription.findUnique.mockResolvedValue(null);
+
+      await expect(
+        DeveloperBillingService.createPortalSession({
+          organisationId: "org-1",
+          returnUrl: "https://app.com/billing",
+        }),
+      ).rejects.toMatchObject({ statusCode: 404 });
+    });
+
+    it("throws 400 on empty organisationId", async () => {
+      await expect(
+        DeveloperBillingService.createPortalSession({
+          organisationId: "",
+          returnUrl: "https://app.com/billing",
+        }),
+      ).rejects.toBeInstanceOf(DeveloperBillingServiceError);
+    });
+  });
+
+  describe("reportUsage", () => {
+    it("calls stripe.billing.meterEvents.create with customer and quantity", async () => {
+      process.env.STRIPE_DEV_METER_EVENT_NAME = "api_calls";
+      const stripe = getStripeInstance();
+      stripe.billing.meterEvents.create.mockResolvedValue({});
+
+      await DeveloperBillingService.reportUsage("cus_abc", 42);
+
+      expect(stripe.billing.meterEvents.create).toHaveBeenCalledWith({
+        event_name: "api_calls",
+        payload: { stripe_customer_id: "cus_abc", value: "42" },
+      });
+    });
+
+    it("does nothing when quantity is zero", async () => {
+      process.env.STRIPE_DEV_METER_EVENT_NAME = "api_calls";
+      const stripe = getStripeInstance();
+      await DeveloperBillingService.reportUsage("cus_abc", 0);
+      expect(stripe.billing.meterEvents.create).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when customerId is empty", async () => {
+      process.env.STRIPE_DEV_METER_EVENT_NAME = "api_calls";
+      const stripe = getStripeInstance();
+      await DeveloperBillingService.reportUsage("", 10);
+      expect(stripe.billing.meterEvents.create).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when STRIPE_DEV_METER_EVENT_NAME is not set", async () => {
+      delete process.env.STRIPE_DEV_METER_EVENT_NAME;
+      const stripe = getStripeInstance();
+      await DeveloperBillingService.reportUsage("cus_abc", 10);
+      expect(stripe.billing.meterEvents.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("handleWebhookEvent", () => {
+    const baseSubscription = {
+      id: "sub_123",
+      status: "active",
+      customer: "cus_x",
+      cancel_at_period_end: false,
+      items: {
+        data: [
+          {
+            id: "si_x",
+            price: { id: "price_metered_abc" },
+            current_period_start: 1750000000,
+            current_period_end: 1752678400,
+          },
+        ],
+      },
+    };
+
+    it("upserts a DeveloperSubscription on checkout.session.completed", async () => {
+      const stripe = getStripeInstance();
+      stripe.subscriptions.retrieve.mockResolvedValue(baseSubscription);
+      mockPrisma.developerSubscription.upsert.mockResolvedValue({});
+
+      await DeveloperBillingService.handleWebhookEvent({
+        id: "evt_1",
+        type: "checkout.session.completed",
+        data: {
+          object: {
+            mode: "subscription",
+            subscription: "sub_123",
+            metadata: { organisationId: "org-1" },
+          },
+        },
+      } as never);
+
+      expect(mockPrisma.developerSubscription.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { organisationId: "org-1" },
+          create: expect.objectContaining({
+            plan: "pro",
+            stripeSubscriptionId: "sub_123",
+            stripeSubscriptionItemId: "si_x",
+          }),
+        }),
+      );
+    });
+
+    it("skips checkout.session.completed when mode is not subscription", async () => {
+      await DeveloperBillingService.handleWebhookEvent({
+        id: "evt_2",
+        type: "checkout.session.completed",
+        data: { object: { mode: "payment", subscription: null, metadata: {} } },
+      } as never);
+
+      expect(mockPrisma.developerSubscription.upsert).not.toHaveBeenCalled();
+    });
+
+    it("updates the record on customer.subscription.updated", async () => {
+      mockPrisma.developerSubscription.findFirst.mockResolvedValue({
+        id: "ds-1",
+        stripePriceId: "price_metered_abc",
+        stripeSubscriptionItemId: "si_x",
+      });
+      mockPrisma.developerSubscription.update.mockResolvedValue({});
+
+      await DeveloperBillingService.handleWebhookEvent({
+        id: "evt_3",
+        type: "customer.subscription.updated",
+        data: { object: { ...baseSubscription, status: "past_due" } },
+      } as never);
+
+      expect(mockPrisma.developerSubscription.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: "ds-1" },
+          data: expect.objectContaining({ status: "past_due" }),
+        }),
+      );
+    });
+
+    it("skips customer.subscription.updated when record not found", async () => {
+      mockPrisma.developerSubscription.findFirst.mockResolvedValue(null);
+      await DeveloperBillingService.handleWebhookEvent({
+        id: "evt_4",
+        type: "customer.subscription.updated",
+        data: { object: baseSubscription },
+      } as never);
+      expect(mockPrisma.developerSubscription.update).not.toHaveBeenCalled();
+    });
+
+    it("downgrades to free on customer.subscription.deleted", async () => {
+      mockPrisma.developerSubscription.findFirst.mockResolvedValue({
+        id: "ds-1",
+        stripePriceId: "price_metered_abc",
+        stripeSubscriptionItemId: "si_x",
+      });
+      mockPrisma.developerSubscription.update.mockResolvedValue({});
+
+      await DeveloperBillingService.handleWebhookEvent({
+        id: "evt_5",
+        type: "customer.subscription.deleted",
+        data: { object: { ...baseSubscription, status: "canceled" } },
+      } as never);
+
+      expect(mockPrisma.developerSubscription.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ plan: "free", status: "canceled" }),
+        }),
+      );
+    });
+  });
+
+  describe("verifyWebhook", () => {
+    it("calls stripe.webhooks.constructEvent and returns the event", () => {
+      const stripe = getStripeInstance();
+      const fakeEvent = { type: "checkout.session.completed" };
+      stripe.webhooks.constructEvent.mockReturnValue(fakeEvent);
+
+      const result = DeveloperBillingService.verifyWebhook(
+        Buffer.from("body"),
+        "sig",
+      );
+      expect(result).toBe(fakeEvent);
+    });
+  });
+});

--- a/apps/backend/test/services/developer-usage.service.test.ts
+++ b/apps/backend/test/services/developer-usage.service.test.ts
@@ -1,0 +1,265 @@
+import { DeveloperUsageService } from "../../src/services/developer-usage.service";
+import { DeveloperBillingService } from "../../src/services/developer-billing.service";
+import { prisma } from "../../src/config/prisma";
+import logger from "../../src/utils/logger";
+
+jest.mock("../../src/config/prisma", () => ({
+  prisma: {
+    developerApiUsage: {
+      upsert: jest.fn(),
+      update: jest.fn(),
+      findUnique: jest.fn(),
+    },
+    developerSubscription: {
+      findUnique: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("../../src/services/developer-billing.service", () => ({
+  DeveloperBillingService: {
+    reportUsage: jest.fn(),
+  },
+}));
+
+jest.mock("../../src/utils/logger", () => ({
+  __esModule: true,
+  default: { error: jest.fn(), info: jest.fn() },
+}));
+
+const mockPrisma = prisma as unknown as {
+  developerApiUsage: {
+    upsert: jest.Mock;
+    update: jest.Mock;
+    findUnique: jest.Mock;
+  };
+  developerSubscription: {
+    findUnique: jest.Mock;
+  };
+};
+
+const mockReportUsage = DeveloperBillingService.reportUsage as jest.Mock;
+const mockLoggerError = logger.error as jest.Mock;
+
+describe("DeveloperUsageService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("incrementAndCheck", () => {
+    it("free plan, first call — returns allowed:true and callCount:1", async () => {
+      mockPrisma.developerApiUsage.upsert.mockResolvedValue({ callCount: 1 });
+      mockPrisma.developerSubscription.findUnique.mockResolvedValue({
+        plan: "free",
+        stripeCustomerId: null,
+      });
+
+      const result = await DeveloperUsageService.incrementAndCheck("org-1");
+
+      expect(result).toEqual({ allowed: true, callCount: 1 });
+      expect(mockReportUsage).not.toHaveBeenCalled();
+    });
+
+    it("free plan, 1001st call — returns allowed:false", async () => {
+      mockPrisma.developerApiUsage.upsert.mockResolvedValue({
+        callCount: 1001,
+      });
+      mockPrisma.developerSubscription.findUnique.mockResolvedValue({
+        plan: "free",
+        stripeCustomerId: null,
+      });
+
+      const result = await DeveloperUsageService.incrementAndCheck("org-1");
+
+      expect(result).toEqual({ allowed: false, callCount: 1001 });
+    });
+
+    it("free plan at exactly 1000 — returns allowed:true (boundary is non-inclusive)", async () => {
+      mockPrisma.developerApiUsage.upsert.mockResolvedValue({
+        callCount: 1000,
+      });
+      mockPrisma.developerSubscription.findUnique.mockResolvedValue({
+        plan: "free",
+        stripeCustomerId: null,
+      });
+
+      const result = await DeveloperUsageService.incrementAndCheck("org-1");
+
+      expect(result).toEqual({ allowed: true, callCount: 1000 });
+    });
+
+    it("pro plan — returns allowed:true and fires reportToStripe for Stripe", async () => {
+      mockPrisma.developerApiUsage.upsert.mockResolvedValue({ callCount: 42 });
+      mockPrisma.developerSubscription.findUnique.mockResolvedValue({
+        plan: "pro",
+        stripeCustomerId: "cus_x",
+      });
+      mockReportUsage.mockResolvedValue(undefined);
+      mockPrisma.developerApiUsage.update.mockResolvedValue({});
+
+      const result = await DeveloperUsageService.incrementAndCheck("org-1");
+
+      expect(result).toEqual({ allowed: true, callCount: 42 });
+
+      // Flush the void IIFE inside reportToStripe
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mockReportUsage).toHaveBeenCalledWith("cus_x", 42);
+    });
+
+    it("no subscription record (null) — defaults to free plan, allowed:true when count <= 1000", async () => {
+      mockPrisma.developerApiUsage.upsert.mockResolvedValue({ callCount: 5 });
+      mockPrisma.developerSubscription.findUnique.mockResolvedValue(null);
+
+      const result = await DeveloperUsageService.incrementAndCheck("org-1");
+
+      expect(result).toEqual({ allowed: true, callCount: 5 });
+      expect(mockReportUsage).not.toHaveBeenCalled();
+    });
+
+    it("pro plan with null stripeCustomerId — does NOT call reportUsage", async () => {
+      mockPrisma.developerApiUsage.upsert.mockResolvedValue({ callCount: 10 });
+      mockPrisma.developerSubscription.findUnique.mockResolvedValue({
+        plan: "pro",
+        stripeCustomerId: null,
+      });
+
+      const result = await DeveloperUsageService.incrementAndCheck("org-1");
+
+      expect(result).toEqual({ allowed: true, callCount: 10 });
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mockReportUsage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("reportToStripe", () => {
+    it("happy path — calls reportUsage then updates lastReportedAt", async () => {
+      mockReportUsage.mockResolvedValue(undefined);
+      mockPrisma.developerApiUsage.update.mockResolvedValue({});
+
+      DeveloperUsageService.reportToStripe("cus_abc", "org-1", "2026-06", 99);
+
+      // Wait for the void IIFE to settle
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mockReportUsage).toHaveBeenCalledWith("cus_abc", 99);
+      expect(mockPrisma.developerApiUsage.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            organisationId_billingPeriod: {
+              organisationId: "org-1",
+              billingPeriod: "2026-06",
+            },
+          },
+          data: expect.objectContaining({ lastReportedAt: expect.any(Date) }),
+        }),
+      );
+    });
+
+    it("reportUsage throws — logs the error, does not rethrow", async () => {
+      const boom = new Error("stripe down");
+      mockReportUsage.mockRejectedValue(boom);
+
+      // Should not throw from the caller's perspective
+      expect(() => {
+        DeveloperUsageService.reportToStripe("cus_abc", "org-1", "2026-06", 5);
+      }).not.toThrow();
+
+      // Flush the void IIFE
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mockLoggerError).toHaveBeenCalledWith(
+        "Failed to report API usage to Stripe",
+        expect.objectContaining({
+          organisationId: "org-1",
+          billingPeriod: "2026-06",
+          err: boom,
+        }),
+      );
+      // update should NOT have been called after the throw
+      expect(mockPrisma.developerApiUsage.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getUsage", () => {
+    it("free plan — returns billingPeriod, callCount, and limit:1000", async () => {
+      mockPrisma.developerApiUsage.findUnique.mockResolvedValue({
+        callCount: 77,
+      });
+      mockPrisma.developerSubscription.findUnique.mockResolvedValue({
+        plan: "free",
+      });
+
+      const result = await DeveloperUsageService.getUsage("org-1", "2026-06");
+
+      expect(result).toEqual({
+        billingPeriod: "2026-06",
+        callCount: 77,
+        limit: 1000,
+      });
+    });
+
+    it("pro plan — returns limit:null", async () => {
+      mockPrisma.developerApiUsage.findUnique.mockResolvedValue({
+        callCount: 500,
+      });
+      mockPrisma.developerSubscription.findUnique.mockResolvedValue({
+        plan: "pro",
+      });
+
+      const result = await DeveloperUsageService.getUsage("org-1", "2026-06");
+
+      expect(result).toEqual({
+        billingPeriod: "2026-06",
+        callCount: 500,
+        limit: null,
+      });
+    });
+
+    it("no usage record — returns callCount:0", async () => {
+      mockPrisma.developerApiUsage.findUnique.mockResolvedValue(null);
+      mockPrisma.developerSubscription.findUnique.mockResolvedValue({
+        plan: "free",
+      });
+
+      const result = await DeveloperUsageService.getUsage("org-1", "2026-06");
+
+      expect(result).toEqual({
+        billingPeriod: "2026-06",
+        callCount: 0,
+        limit: 1000,
+      });
+    });
+
+    it("uses current billing period when none is provided", async () => {
+      mockPrisma.developerApiUsage.findUnique.mockResolvedValue({
+        callCount: 3,
+      });
+      mockPrisma.developerSubscription.findUnique.mockResolvedValue({
+        plan: "free",
+      });
+
+      const result = await DeveloperUsageService.getUsage("org-1");
+
+      expect(result.callCount).toBe(3);
+      expect(result.billingPeriod).toMatch(/^\d{4}-\d{2}$/);
+    });
+
+    it("defaults to free when no subscription record exists", async () => {
+      mockPrisma.developerApiUsage.findUnique.mockResolvedValue({
+        callCount: 5,
+      });
+      mockPrisma.developerSubscription.findUnique.mockResolvedValue(null);
+
+      const result = await DeveloperUsageService.getUsage("org-1", "2026-06");
+
+      expect(result.limit).toBe(1000);
+    });
+  });
+});

--- a/apps/frontend/src/app/(routes)/(app)/developers/(portal)/api-keys/page.tsx
+++ b/apps/frontend/src/app/(routes)/(app)/developers/(portal)/api-keys/page.tsx
@@ -1,26 +1,12 @@
 import type { Metadata } from 'next';
-export const metadata: Metadata = { title: 'API Keys — Yosemite Crew' };
 import React from 'react';
 
-import '@/app/features/organizations/styles/Organizations.css';
-import DevRouteGuard from '@/app/ui/layout/guards/DevRouteGuard/DevRouteGuard';
+import DeveloperApiKeys from '@/app/features/developers/pages/DeveloperApiKeys/DeveloperApiKeys';
+
+export const metadata: Metadata = { title: 'API Keys — Yosemite Crew' };
 
 function Page() {
-  return (
-    <DevRouteGuard>
-      <div className="OperationsWrapper">
-        <div className="TitleContainer">
-          <h2 className="text-heading-1 text-text-primary">API Keys</h2>
-        </div>
-        <p className="text-heading-2 text-text-primary" style={{ marginBottom: 8 }}>
-          Coming soon
-        </p>
-        <p className="text-body-3 text-text-secondary">
-          Manage and generate API keys for your integrations.
-        </p>
-      </div>
-    </DevRouteGuard>
-  );
+  return <DeveloperApiKeys />;
 }
 
 export default Page;

--- a/apps/frontend/src/app/(routes)/(app)/developers/(portal)/billing/page.tsx
+++ b/apps/frontend/src/app/(routes)/(app)/developers/(portal)/billing/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from 'next';
+import React from 'react';
+
+import DeveloperBilling from '@/app/features/developers/pages/DeveloperBilling/DeveloperBilling';
+
+export const metadata: Metadata = { title: 'Billing — Yosemite Crew' };
+
+function Page() {
+  return <DeveloperBilling />;
+}
+
+export default Page;

--- a/apps/frontend/src/app/__tests__/pages/DeveloperApiKeys.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/DeveloperApiKeys.test.tsx
@@ -1,0 +1,211 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+jest.mock('@/app/services/developerApiKeys', () => ({
+  listApiKeys: jest.fn(),
+  createApiKey: jest.fn(),
+  revokeApiKey: jest.fn(),
+}));
+
+jest.mock('@/app/ui/layout/guards/DevRouteGuard/DevRouteGuard', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="dev-guard">{children}</div>
+  ),
+}));
+
+jest.mock('@/app/ui/primitives/Buttons', () => ({
+  __esModule: true,
+  Primary: ({ text, onClick, type, isDisabled }: any) => (
+    <button type={type ?? 'button'} onClick={onClick} disabled={isDisabled}>
+      {text}
+    </button>
+  ),
+  Secondary: ({ text, onClick, isDisabled }: any) => (
+    <button type="button" onClick={onClick} disabled={isDisabled}>
+      {text}
+    </button>
+  ),
+}));
+
+jest.mock('@/app/lib/logger', () => ({
+  logger: { error: jest.fn(), info: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+}));
+
+import DeveloperApiKeys from '@/app/features/developers/pages/DeveloperApiKeys/DeveloperApiKeys';
+import { listApiKeys, createApiKey, revokeApiKey } from '@/app/services/developerApiKeys';
+
+const listApiKeysMock = listApiKeys as jest.Mock;
+const createApiKeyMock = createApiKey as jest.Mock;
+const revokeApiKeyMock = revokeApiKey as jest.Mock;
+
+const sampleKey = {
+  id: 'k1',
+  name: 'Prod',
+  prefix: 'yc_live_abc',
+  last4: 'wxyz',
+  scopes: [],
+  environment: 'live',
+  status: 'active',
+  lastUsedAt: null,
+  expiresAt: null,
+  revokedAt: null,
+  createdAt: '2026-06-01T00:00:00.000Z',
+};
+
+// userEvent.setup() installs its own navigator.clipboard, so clipboard tests
+// define their mock AFTER setup() and assert against that local mock.
+const mockClipboard = (writeText: jest.Mock) =>
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText },
+    configurable: true,
+    writable: true,
+  });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  listApiKeysMock.mockResolvedValue([]);
+});
+
+const openCreateForm = async (user: ReturnType<typeof userEvent.setup>) => {
+  await screen.findByTestId('api-keys-empty');
+  await user.click(screen.getByRole('button', { name: 'Create API key' }));
+};
+
+describe('DeveloperApiKeys page', () => {
+  it('shows the empty state when there are no keys', async () => {
+    render(<DeveloperApiKeys />);
+    expect(await screen.findByTestId('api-keys-empty')).toBeInTheDocument();
+    expect(listApiKeysMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the keys table', async () => {
+    listApiKeysMock.mockResolvedValue([sampleKey]);
+    render(<DeveloperApiKeys />);
+    expect(await screen.findByText('Prod')).toBeInTheDocument();
+    expect(screen.getByText('active')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Revoke' })).toBeInTheDocument();
+  });
+
+  it('shows an error when loading fails', async () => {
+    listApiKeysMock.mockRejectedValue(new Error('boom'));
+    render(<DeveloperApiKeys />);
+    expect(await screen.findByText(/Could not load your API keys/)).toBeInTheDocument();
+  });
+
+  it('creates a key, parses scopes, and reveals the secret once', async () => {
+    const user = userEvent.setup();
+    createApiKeyMock.mockResolvedValue({
+      apiKey: 'yc_live_THE_SECRET',
+    });
+    render(<DeveloperApiKeys />);
+    await openCreateForm(user);
+
+    await user.type(screen.getByLabelText('Key name'), 'CI');
+    await user.type(screen.getByLabelText(/Scopes/), 'appointments:read, inventory:read');
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+
+    expect(await screen.findByTestId('issued-secret')).toHaveTextContent('yc_live_THE_SECRET');
+    expect(createApiKeyMock).toHaveBeenCalledWith({
+      name: 'CI',
+      environment: 'live',
+      scopes: ['appointments:read', 'inventory:read'],
+    });
+    await waitFor(() => expect(listApiKeysMock).toHaveBeenCalledTimes(2));
+  });
+
+  it('disables Create until a name is entered', async () => {
+    const user = userEvent.setup();
+    render(<DeveloperApiKeys />);
+    await openCreateForm(user);
+    expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled();
+  });
+
+  it('copies the issued secret and reflects the copied state', async () => {
+    const user = userEvent.setup();
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    mockClipboard(writeText);
+    createApiKeyMock.mockResolvedValue({ apiKey: 'yc_live_SECRET' });
+    render(<DeveloperApiKeys />);
+    await openCreateForm(user);
+    await user.type(screen.getByLabelText('Key name'), 'CI');
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+    await screen.findByTestId('issued-secret');
+
+    await user.click(screen.getByRole('button', { name: 'Copy' }));
+    expect(writeText).toHaveBeenCalledWith('yc_live_SECRET');
+    expect(await screen.findByRole('button', { name: 'Copied' })).toBeInTheDocument();
+  });
+
+  it('stays on Copy when the clipboard write fails', async () => {
+    const user = userEvent.setup();
+    const writeText = jest.fn().mockRejectedValue(new Error('denied'));
+    mockClipboard(writeText);
+    createApiKeyMock.mockResolvedValue({ apiKey: 'yc_live_SECRET' });
+    render(<DeveloperApiKeys />);
+    await openCreateForm(user);
+    await user.type(screen.getByLabelText('Key name'), 'CI');
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+    await screen.findByTestId('issued-secret');
+
+    await user.click(screen.getByRole('button', { name: 'Copy' }));
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Copy' })).toBeInTheDocument());
+  });
+
+  it('dismisses the reveal with Done', async () => {
+    const user = userEvent.setup();
+    createApiKeyMock.mockResolvedValue({ apiKey: 'yc_live_SECRET' });
+    render(<DeveloperApiKeys />);
+    await openCreateForm(user);
+    await user.type(screen.getByLabelText('Key name'), 'CI');
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+    await screen.findByTestId('issued-secret');
+
+    await user.click(screen.getByRole('button', { name: 'Done' }));
+    await waitFor(() => expect(screen.queryByTestId('issued-secret')).not.toBeInTheDocument());
+  });
+
+  it('shows an error when creation fails', async () => {
+    const user = userEvent.setup();
+    createApiKeyMock.mockRejectedValue(new Error('nope'));
+    render(<DeveloperApiKeys />);
+    await openCreateForm(user);
+    await user.type(screen.getByLabelText('Key name'), 'CI');
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+    expect(await screen.findByText(/Could not create the API key/)).toBeInTheDocument();
+  });
+
+  it('cancels the form', async () => {
+    const user = userEvent.setup();
+    render(<DeveloperApiKeys />);
+    await openCreateForm(user);
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(screen.queryByLabelText('Key name')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Create API key' })).toBeInTheDocument();
+  });
+
+  it('revokes an active key and reloads', async () => {
+    const user = userEvent.setup();
+    listApiKeysMock.mockResolvedValueOnce([sampleKey]).mockResolvedValueOnce([]);
+    revokeApiKeyMock.mockResolvedValue(undefined);
+    render(<DeveloperApiKeys />);
+    await screen.findByText('Prod');
+
+    await user.click(screen.getByRole('button', { name: 'Revoke' }));
+    expect(revokeApiKeyMock).toHaveBeenCalledWith('k1');
+    expect(await screen.findByTestId('api-keys-empty')).toBeInTheDocument();
+  });
+
+  it('shows an error when revoke fails', async () => {
+    const user = userEvent.setup();
+    listApiKeysMock.mockResolvedValue([sampleKey]);
+    revokeApiKeyMock.mockRejectedValue(new Error('x'));
+    render(<DeveloperApiKeys />);
+    await screen.findByText('Prod');
+
+    await user.click(screen.getByRole('button', { name: 'Revoke' }));
+    expect(await screen.findByText(/Could not revoke the API key/)).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/__tests__/pages/DeveloperBilling.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/DeveloperBilling.test.tsx
@@ -1,0 +1,191 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+jest.mock('@/app/services/developerBilling', () => ({
+  getSubscription: jest.fn(),
+  createCheckoutSession: jest.fn(),
+  createPortalSession: jest.fn(),
+}));
+
+jest.mock('@/app/ui/layout/guards/DevRouteGuard/DevRouteGuard', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="dev-guard">{children}</div>
+  ),
+}));
+
+jest.mock('@/app/ui/primitives/Buttons', () => ({
+  __esModule: true,
+  Primary: ({ text, onClick, isDisabled }: any) => (
+    <button type="button" onClick={onClick} disabled={isDisabled}>
+      {text}
+    </button>
+  ),
+  Secondary: ({ text, onClick, isDisabled }: any) => (
+    <button type="button" onClick={onClick} disabled={isDisabled}>
+      {text}
+    </button>
+  ),
+}));
+
+jest.mock('@/app/lib/logger', () => ({
+  logger: { error: jest.fn(), info: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+}));
+
+import DeveloperBilling from '@/app/features/developers/pages/DeveloperBilling/DeveloperBilling';
+import {
+  getSubscription,
+  createCheckoutSession,
+  createPortalSession,
+} from '@/app/services/developerBilling';
+
+const getSubscriptionMock = getSubscription as jest.Mock;
+const createCheckoutMock = createCheckoutSession as jest.Mock;
+const createPortalMock = createPortalSession as jest.Mock;
+
+const freeSub = {
+  id: null,
+  organisationId: 'o1',
+  plan: 'free',
+  status: 'active',
+  stripeSubscriptionItemId: null,
+  currentPeriodStart: null,
+  currentPeriodEnd: null,
+  cancelAtPeriodEnd: false,
+  createdAt: null,
+  updatedAt: null,
+};
+
+const proSub = {
+  ...freeSub,
+  id: 's1',
+  plan: 'pro',
+  status: 'active',
+  stripeSubscriptionItemId: 'si_abc',
+  currentPeriodStart: '2026-06-01T00:00:00.000Z',
+  currentPeriodEnd: '2026-07-01T00:00:00.000Z',
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  getSubscriptionMock.mockResolvedValue(freeSub);
+});
+
+describe('DeveloperBilling page', () => {
+  it('renders all three plan cards', async () => {
+    render(<DeveloperBilling />);
+    expect(await screen.findByTestId('plan-card-free')).toBeInTheDocument();
+    expect(screen.getByTestId('plan-card-pro')).toBeInTheDocument();
+    expect(screen.getByTestId('plan-card-enterprise')).toBeInTheDocument();
+  });
+
+  it('shows Free badge when on the free plan', async () => {
+    render(<DeveloperBilling />);
+    expect(await screen.findByText('You are on the Free plan.')).toBeInTheDocument();
+  });
+
+  it('shows an error when loading fails', async () => {
+    getSubscriptionMock.mockRejectedValue(new Error('network'));
+    render(<DeveloperBilling />);
+    expect(await screen.findByText(/Could not load your subscription/)).toBeInTheDocument();
+  });
+
+  it('shows Pro badge and metered billing info when on Pro', async () => {
+    getSubscriptionMock.mockResolvedValue(proSub);
+    render(<DeveloperBilling />);
+    const meta = await screen.findByTestId('billing-plan-meta');
+    expect(meta.textContent).toMatch(/Metered billing/);
+  });
+
+  it('shows billing period dates when on Pro', async () => {
+    getSubscriptionMock.mockResolvedValue(proSub);
+    render(<DeveloperBilling />);
+    const meta = await screen.findByTestId('billing-plan-meta');
+    expect(meta.textContent).toMatch(/2026/);
+  });
+
+  it('shows Manage billing button when on Pro', async () => {
+    getSubscriptionMock.mockResolvedValue(proSub);
+    render(<DeveloperBilling />);
+    expect(await screen.findByRole('button', { name: 'Manage billing' })).toBeInTheDocument();
+  });
+
+  it('shows per-call pricing in the Pro plan card', async () => {
+    render(<DeveloperBilling />);
+    await screen.findByTestId('plan-card-pro');
+    expect(screen.getByText(/\$0\.002 per API call/)).toBeInTheDocument();
+  });
+
+  it('calls createCheckoutSession with successUrl and cancelUrl on Upgrade click', async () => {
+    const user = userEvent.setup();
+    createCheckoutMock.mockResolvedValue('https://checkout.stripe.com/test');
+    render(<DeveloperBilling />);
+    await screen.findByTestId('plan-card-pro');
+
+    await user.click(screen.getByRole('button', { name: 'Upgrade to Pro' }));
+    await waitFor(() =>
+      expect(createCheckoutMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          successUrl: expect.stringContaining('/developers/billing'),
+          cancelUrl: expect.stringContaining('/developers/billing'),
+        })
+      )
+    );
+  });
+
+  it('shows an error when checkout creation fails', async () => {
+    const user = userEvent.setup();
+    createCheckoutMock.mockRejectedValue(new Error('fail'));
+    render(<DeveloperBilling />);
+    await screen.findByTestId('plan-card-pro');
+
+    await user.click(screen.getByRole('button', { name: 'Upgrade to Pro' }));
+    expect(await screen.findByText(/Could not start the upgrade flow/)).toBeInTheDocument();
+  });
+
+  it('calls createPortalSession on Manage billing click', async () => {
+    const user = userEvent.setup();
+    getSubscriptionMock.mockResolvedValue(proSub);
+    createPortalMock.mockResolvedValue('https://billing.stripe.com/p');
+    render(<DeveloperBilling />);
+    await screen.findByText('Manage billing');
+
+    await user.click(screen.getByRole('button', { name: 'Manage billing' }));
+    await waitFor(() =>
+      expect(createPortalMock).toHaveBeenCalledWith(expect.stringContaining('/developers/billing'))
+    );
+  });
+
+  it('shows an error when portal creation fails', async () => {
+    const user = userEvent.setup();
+    getSubscriptionMock.mockResolvedValue(proSub);
+    createPortalMock.mockRejectedValue(new Error('fail'));
+    render(<DeveloperBilling />);
+    await screen.findByText('Manage billing');
+
+    await user.click(screen.getByRole('button', { name: 'Manage billing' }));
+    expect(await screen.findByText(/Could not open the billing portal/)).toBeInTheDocument();
+  });
+
+  it('shows Past due badge when status is past_due', async () => {
+    getSubscriptionMock.mockResolvedValue({ ...proSub, status: 'past_due' });
+    render(<DeveloperBilling />);
+    expect(await screen.findByText('Past due')).toBeInTheDocument();
+  });
+
+  it('shows cancelAtPeriodEnd notice when true', async () => {
+    getSubscriptionMock.mockResolvedValue({ ...proSub, cancelAtPeriodEnd: true });
+    render(<DeveloperBilling />);
+    const meta = await screen.findByTestId('billing-plan-meta');
+    expect(meta.textContent).toContain('Cancels at period end');
+  });
+
+  it('disables Upgrade to Pro when already on Pro', async () => {
+    getSubscriptionMock.mockResolvedValue(proSub);
+    render(<DeveloperBilling />);
+    await screen.findByTestId('billing-plan-meta');
+    expect(screen.getByRole('button', { name: 'Current plan' })).toBeDisabled();
+  });
+});

--- a/apps/frontend/src/app/__tests__/services/developerApiKeys.test.ts
+++ b/apps/frontend/src/app/__tests__/services/developerApiKeys.test.ts
@@ -1,0 +1,49 @@
+import { listApiKeys, createApiKey, revokeApiKey } from '@/app/services/developerApiKeys';
+import { getData, postData, deleteData } from '@/app/services/axios';
+
+jest.mock('@/app/services/axios', () => ({
+  getData: jest.fn(),
+  postData: jest.fn(),
+  deleteData: jest.fn(),
+}));
+
+const getDataMock = getData as jest.Mock;
+const postDataMock = postData as jest.Mock;
+const deleteDataMock = deleteData as jest.Mock;
+
+describe('developerApiKeys service', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  describe('listApiKeys', () => {
+    it('returns the data array from the response envelope', async () => {
+      getDataMock.mockResolvedValue({ data: { data: [{ id: 'k1' }] } });
+      await expect(listApiKeys()).resolves.toEqual([{ id: 'k1' }]);
+      expect(getDataMock).toHaveBeenCalledWith('/v1/developers/api-keys');
+    });
+
+    it('falls back to an empty array when the body is missing', async () => {
+      getDataMock.mockResolvedValue({ data: undefined });
+      await expect(listApiKeys()).resolves.toEqual([]);
+    });
+  });
+
+  describe('createApiKey', () => {
+    it('posts the payload and returns the issued key', async () => {
+      postDataMock.mockResolvedValue({ data: { id: 'k', apiKey: 'yc_live_x' } });
+      const result = await createApiKey({ name: 'CI', environment: 'live' });
+      expect(postDataMock).toHaveBeenCalledWith('/v1/developers/api-keys', {
+        name: 'CI',
+        environment: 'live',
+      });
+      expect(result).toEqual({ id: 'k', apiKey: 'yc_live_x' });
+    });
+  });
+
+  describe('revokeApiKey', () => {
+    it('deletes by id', async () => {
+      deleteDataMock.mockResolvedValue({});
+      await revokeApiKey('k1');
+      expect(deleteDataMock).toHaveBeenCalledWith('/v1/developers/api-keys/k1');
+    });
+  });
+});

--- a/apps/frontend/src/app/__tests__/services/developerBilling.test.ts
+++ b/apps/frontend/src/app/__tests__/services/developerBilling.test.ts
@@ -1,0 +1,70 @@
+import {
+  getSubscription,
+  createCheckoutSession,
+  createPortalSession,
+} from '@/app/services/developerBilling';
+import { getData, postData } from '@/app/services/axios';
+
+jest.mock('@/app/services/axios', () => ({
+  getData: jest.fn(),
+  postData: jest.fn(),
+}));
+
+const getDataMock = getData as jest.Mock;
+const postDataMock = postData as jest.Mock;
+
+const sampleSubscription = {
+  id: 's1',
+  organisationId: 'o1',
+  plan: 'free',
+  status: 'active',
+  stripeSubscriptionItemId: null,
+  currentPeriodStart: null,
+  currentPeriodEnd: null,
+  cancelAtPeriodEnd: false,
+  createdAt: null,
+  updatedAt: null,
+};
+
+describe('developerBilling service', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  describe('getSubscription', () => {
+    it('returns the subscription from the data envelope', async () => {
+      getDataMock.mockResolvedValue({ data: { data: sampleSubscription } });
+      const result = await getSubscription();
+      expect(result).toEqual(sampleSubscription);
+      expect(getDataMock).toHaveBeenCalledWith('/v1/developers/billing');
+    });
+  });
+
+  describe('createCheckoutSession', () => {
+    it('posts successUrl + cancelUrl and returns the checkout URL', async () => {
+      postDataMock.mockResolvedValue({
+        data: { data: { url: 'https://checkout.stripe.com/x' } },
+      });
+      const url = await createCheckoutSession({
+        successUrl: 'https://app.com/success',
+        cancelUrl: 'https://app.com/cancel',
+      });
+      expect(url).toBe('https://checkout.stripe.com/x');
+      expect(postDataMock).toHaveBeenCalledWith('/v1/developers/billing/checkout', {
+        successUrl: 'https://app.com/success',
+        cancelUrl: 'https://app.com/cancel',
+      });
+    });
+  });
+
+  describe('createPortalSession', () => {
+    it('posts returnUrl and returns the portal URL', async () => {
+      postDataMock.mockResolvedValue({
+        data: { data: { url: 'https://billing.stripe.com/p' } },
+      });
+      const url = await createPortalSession('https://app.com/billing');
+      expect(url).toBe('https://billing.stripe.com/p');
+      expect(postDataMock).toHaveBeenCalledWith('/v1/developers/billing/portal', {
+        returnUrl: 'https://app.com/billing',
+      });
+    });
+  });
+});

--- a/apps/frontend/src/app/constants/routes.ts
+++ b/apps/frontend/src/app/constants/routes.ts
@@ -69,6 +69,7 @@ export const appRoutes: RouteItem[] = [
 export const devRoutes: RouteItem[] = [
   { name: 'Dashboard', href: '/developers/home' },
   { name: 'API Keys', href: '/developers/api-keys' },
+  { name: 'Billing', href: '/developers/billing' },
   { name: 'Website - Builder', href: '/developers/website-builder' },
   { name: 'Plugins', href: '/developers/plugins' },
   { name: 'Documentation', href: '/developers/documentation' },

--- a/apps/frontend/src/app/features/developers/pages/DeveloperApiKeys/DeveloperApiKeys.css
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperApiKeys/DeveloperApiKeys.css
@@ -1,0 +1,73 @@
+.DevApiKeys-intro {
+  margin: 8px 0 24px;
+  max-width: 640px;
+}
+
+.DevApiKeys-reveal {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  margin-bottom: 24px;
+  border: 1px solid var(--color-border-brand, var(--color-text-primary));
+  border-radius: 16px;
+  background: var(--color-surface-secondary, #f6f7f9);
+}
+
+.DevApiKeys-secret {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.DevApiKeys-secret code {
+  padding: 8px 12px;
+  border-radius: 8px;
+  background: var(--color-surface-tertiary, #eceef1);
+  font-family: var(--font-mono, monospace);
+  word-break: break-all;
+}
+
+.DevApiKeys-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-width: 480px;
+  margin-bottom: 24px;
+}
+
+.DevApiKeys-input {
+  padding: 10px 12px;
+  border: 1px solid var(--color-border-primary, #d4d7dd);
+  border-radius: 12px;
+  background: var(--color-surface-primary, #fff);
+}
+
+.DevApiKeys-formActions {
+  display: flex;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.DevApiKeys-error {
+  color: var(--color-text-error, #c0392b);
+  margin-bottom: 16px;
+}
+
+.DevApiKeys-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.DevApiKeys-table th,
+.DevApiKeys-table td {
+  text-align: left;
+  padding: 12px 8px;
+  border-bottom: 1px solid var(--color-border-primary, #eceef1);
+  font-size: 14px;
+}
+
+.DevApiKeys-table code {
+  font-family: var(--font-mono, monospace);
+}

--- a/apps/frontend/src/app/features/developers/pages/DeveloperApiKeys/DeveloperApiKeys.tsx
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperApiKeys/DeveloperApiKeys.tsx
@@ -1,0 +1,261 @@
+'use client';
+import React, { useCallback, useEffect, useState } from 'react';
+
+import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
+import DevRouteGuard from '@/app/ui/layout/guards/DevRouteGuard/DevRouteGuard';
+import { logger } from '@/app/lib/logger';
+import {
+  createApiKey,
+  listApiKeys,
+  revokeApiKey,
+  type ApiKeyEnvironment,
+  type DeveloperApiKey,
+  type IssuedApiKey,
+} from '@/app/services/developerApiKeys';
+
+import './DeveloperApiKeys.css';
+import '@/app/features/organizations/styles/Organizations.css';
+
+const formatDate = (value: string | null): string =>
+  value ? new Date(value).toLocaleDateString() : '—';
+
+const DeveloperApiKeys = () => {
+  const [keys, setKeys] = useState<DeveloperApiKey[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [showForm, setShowForm] = useState(false);
+  const [name, setName] = useState('');
+  const [environment, setEnvironment] = useState<ApiKeyEnvironment>('live');
+  const [scopesInput, setScopesInput] = useState('');
+  const [creating, setCreating] = useState(false);
+
+  const [issued, setIssued] = useState<IssuedApiKey | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const loadKeys = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setKeys(await listApiKeys());
+    } catch (err) {
+      logger.error('Failed to load API keys', err);
+      setError('Could not load your API keys. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadKeys();
+  }, [loadKeys]);
+
+  const resetForm = () => {
+    setName('');
+    setScopesInput('');
+    setEnvironment('live');
+  };
+
+  const handleCreate = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!name.trim() || creating) return;
+    setCreating(true);
+    setError(null);
+    try {
+      const scopes = scopesInput
+        .split(',')
+        .map((scope) => scope.trim())
+        .filter(Boolean);
+      const result = await createApiKey({
+        name: name.trim(),
+        environment,
+        scopes: scopes.length ? scopes : undefined,
+      });
+      setIssued(result);
+      setCopied(false);
+      setShowForm(false);
+      resetForm();
+      await loadKeys();
+    } catch (err) {
+      logger.error('Failed to create API key', err);
+      setError('Could not create the API key. Please try again.');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleRevoke = async (id: string) => {
+    setError(null);
+    try {
+      await revokeApiKey(id);
+      await loadKeys();
+    } catch (err) {
+      logger.error('Failed to revoke API key', err);
+      setError('Could not revoke the API key. Please try again.');
+    }
+  };
+
+  const handleCopy = async () => {
+    if (!issued) return;
+    try {
+      await navigator.clipboard.writeText(issued.apiKey);
+      setCopied(true);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  const renderKeyList = () => {
+    if (loading) {
+      return <p className="text-body-3 text-text-secondary">Loading API keys…</p>;
+    }
+    if (keys.length === 0) {
+      return (
+        <p className="text-body-3 text-text-secondary" data-testid="api-keys-empty">
+          You don&apos;t have any API keys yet.
+        </p>
+      );
+    }
+    return (
+      <table className="DevApiKeys-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Key</th>
+            <th>Env</th>
+            <th>Status</th>
+            <th>Last used</th>
+            <th>Created</th>
+            <th aria-label="Actions" />
+          </tr>
+        </thead>
+        <tbody>
+          {keys.map((apiKey) => (
+            <tr key={apiKey.id}>
+              <td>{apiKey.name}</td>
+              <td>
+                <code>
+                  {apiKey.prefix}…{apiKey.last4}
+                </code>
+              </td>
+              <td>{apiKey.environment}</td>
+              <td>{apiKey.status}</td>
+              <td>{formatDate(apiKey.lastUsedAt)}</td>
+              <td>{formatDate(apiKey.createdAt)}</td>
+              <td>
+                {apiKey.status === 'active' && (
+                  <Secondary
+                    danger
+                    text="Revoke"
+                    onClick={() => handleRevoke(apiKey.id)}
+                    style={{ maxWidth: 110 }}
+                  />
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    );
+  };
+
+  return (
+    <DevRouteGuard>
+      <div className="OperationsWrapper">
+        <div className="TitleContainer">
+          <h1 className="text-heading-1 text-text-primary">API Keys</h1>
+          {!showForm && (
+            <Primary
+              text="Create API key"
+              onClick={() => setShowForm(true)}
+              style={{ maxWidth: 200 }}
+            />
+          )}
+        </div>
+
+        <p className="text-body-3 text-text-secondary DevApiKeys-intro">
+          Use API keys to authenticate apps and agents against the Yosemite Crew API. Treat them
+          like passwords — never expose them in client-side code.
+        </p>
+
+        {issued && (
+          <div className="DevApiKeys-reveal" role="alert">
+            <p className="text-body-2 text-text-primary">
+              Copy your new key now. For your security it won&apos;t be shown again.
+            </p>
+            <div className="DevApiKeys-secret">
+              <code data-testid="issued-secret">{issued.apiKey}</code>
+              <Secondary
+                text={copied ? 'Copied' : 'Copy'}
+                onClick={handleCopy}
+                style={{ maxWidth: 120 }}
+              />
+            </div>
+            <Secondary text="Done" onClick={() => setIssued(null)} style={{ maxWidth: 120 }} />
+          </div>
+        )}
+
+        {showForm && (
+          <form className="DevApiKeys-form" onSubmit={handleCreate}>
+            <label className="text-body-3 text-text-primary" htmlFor="apiKeyName">
+              Key name
+            </label>
+            <input
+              id="apiKeyName"
+              className="DevApiKeys-input"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder="e.g. Production server"
+              maxLength={100}
+            />
+            <label className="text-body-3 text-text-primary" htmlFor="apiKeyEnv">
+              Environment
+            </label>
+            <select
+              id="apiKeyEnv"
+              className="DevApiKeys-input"
+              value={environment}
+              onChange={(event) => setEnvironment(event.target.value as ApiKeyEnvironment)}
+            >
+              <option value="live">Live</option>
+              <option value="test">Test</option>
+            </select>
+            <label className="text-body-3 text-text-primary" htmlFor="apiKeyScopes">
+              Scopes (optional, comma-separated)
+            </label>
+            <input
+              id="apiKeyScopes"
+              className="DevApiKeys-input"
+              value={scopesInput}
+              onChange={(event) => setScopesInput(event.target.value)}
+              placeholder="appointments:read, inventory:read"
+            />
+            <div className="DevApiKeys-formActions">
+              <Primary
+                text={creating ? 'Creating…' : 'Create'}
+                type="submit"
+                isDisabled={!name.trim() || creating}
+                style={{ maxWidth: 140 }}
+              />
+              <Secondary
+                text="Cancel"
+                onClick={() => setShowForm(false)}
+                style={{ maxWidth: 120 }}
+              />
+            </div>
+          </form>
+        )}
+
+        {error && (
+          <p className="text-body-3 DevApiKeys-error" role="alert">
+            {error}
+          </p>
+        )}
+
+        {renderKeyList()}
+      </div>
+    </DevRouteGuard>
+  );
+};
+
+export default DeveloperApiKeys;

--- a/apps/frontend/src/app/features/developers/pages/DeveloperBilling/DeveloperBilling.css
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperBilling/DeveloperBilling.css
@@ -1,0 +1,180 @@
+.DevBilling-intro {
+  max-width: 640px;
+  margin-bottom: var(--spacing-6);
+}
+
+.DevBilling-currentPlan {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+  padding: var(--spacing-4) var(--spacing-5);
+  background: var(--color-surface-secondary);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-md);
+  margin-bottom: var(--spacing-8);
+}
+
+.DevBilling-planBadge {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--spacing-1) var(--spacing-3);
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.DevBilling-planBadge--free {
+  background: var(--color-surface-tertiary);
+  color: var(--color-text-secondary);
+}
+
+.DevBilling-planBadge--pro {
+  background: var(--color-brand-primary);
+  color: #fff;
+}
+
+.DevBilling-planBadge--enterprise {
+  background: var(--color-text-primary);
+  color: var(--color-surface-primary);
+}
+
+.DevBilling-planBadge--past_due {
+  background: var(--color-feedback-error-surface);
+  color: var(--color-feedback-error-text);
+}
+
+.DevBilling-planMeta {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+.DevBilling-intervalToggle {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-6);
+}
+
+.DevBilling-intervalBtn {
+  padding: var(--spacing-1-5) var(--spacing-4);
+  border-radius: var(--radius-full);
+  border: 1px solid var(--color-border-default);
+  background: transparent;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  transition:
+    background 120ms,
+    color 120ms,
+    border-color 120ms;
+}
+
+.DevBilling-intervalBtn--active {
+  background: var(--color-brand-primary);
+  color: #fff;
+  border-color: var(--color-brand-primary);
+}
+
+.DevBilling-intervalSavings {
+  font-size: var(--font-size-xs);
+  color: var(--color-feedback-success-text);
+  font-weight: var(--font-weight-medium);
+}
+
+.DevBilling-plans {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: var(--spacing-5);
+  margin-bottom: var(--spacing-8);
+}
+
+.DevBilling-planCard {
+  display: flex;
+  flex-direction: column;
+  padding: var(--spacing-6);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface-primary);
+  position: relative;
+}
+
+.DevBilling-planCard--current {
+  border-color: var(--color-brand-primary);
+  box-shadow: 0 0 0 1px var(--color-brand-primary);
+}
+
+.DevBilling-planCard--recommended::before {
+  content: 'Most Popular';
+  position: absolute;
+  top: -12px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--color-brand-primary);
+  color: #fff;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  padding: 2px var(--spacing-3);
+  border-radius: var(--radius-full);
+  white-space: nowrap;
+}
+
+.DevBilling-planName {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  margin-bottom: var(--spacing-1);
+}
+
+.DevBilling-planPrice {
+  font-size: var(--font-size-3xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text-primary);
+  margin-bottom: var(--spacing-1);
+}
+
+.DevBilling-planPriceSub {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  margin-bottom: var(--spacing-4);
+}
+
+.DevBilling-planDesc {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  margin-bottom: var(--spacing-5);
+}
+
+.DevBilling-planFeatures {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 var(--spacing-6);
+  flex: 1;
+}
+
+.DevBilling-planFeatures li {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-2);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  padding: var(--spacing-1-5) 0;
+}
+
+.DevBilling-planFeatures li::before {
+  content: '✓';
+  color: var(--color-feedback-success-text);
+  font-weight: var(--font-weight-bold);
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.DevBilling-error {
+  padding: var(--spacing-3) var(--spacing-4);
+  background: var(--color-feedback-error-surface);
+  color: var(--color-feedback-error-text);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  margin-bottom: var(--spacing-4);
+}

--- a/apps/frontend/src/app/features/developers/pages/DeveloperBilling/DeveloperBilling.tsx
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperBilling/DeveloperBilling.tsx
@@ -1,0 +1,259 @@
+'use client';
+import React, { useCallback, useEffect, useState } from 'react';
+
+import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
+import DevRouteGuard from '@/app/ui/layout/guards/DevRouteGuard/DevRouteGuard';
+import { logger } from '@/app/lib/logger';
+import {
+  createCheckoutSession,
+  createPortalSession,
+  getSubscription,
+  type DeveloperPlanTier,
+  type DeveloperSubscription,
+} from '@/app/services/developerBilling';
+
+import './DeveloperBilling.css';
+import '@/app/features/organizations/styles/Organizations.css';
+
+const PLANS: {
+  key: DeveloperPlanTier;
+  name: string;
+  price: string;
+  priceSub: string;
+  description: string;
+  features: string[];
+  recommended: boolean;
+}[] = [
+  {
+    key: 'free',
+    name: 'Free',
+    price: '$0',
+    priceSub: 'forever',
+    description: 'Explore the API and build your first integration.',
+    features: [
+      '1,000 API calls / month',
+      '1 API key',
+      'Test environment access',
+      'Community support',
+    ],
+    recommended: false,
+  },
+  {
+    key: 'pro',
+    name: 'Pro',
+    price: 'Pay as you go',
+    priceSub: 'metered · billed monthly',
+    description: 'Scales with your usage — pay only for what you consume.',
+    features: [
+      '~$0.002 per API call',
+      'First 1,000 calls free each month',
+      'Unlimited API keys',
+      'Live + test environments',
+      'Webhook support',
+      'Priority support',
+    ],
+    recommended: true,
+  },
+  {
+    key: 'enterprise',
+    name: 'Enterprise',
+    price: 'Custom',
+    priceSub: 'volume discounts available',
+    description: 'For platforms and large teams with predictable high-volume needs.',
+    features: [
+      'Custom per-call rate',
+      'Unlimited API keys',
+      'Dedicated support',
+      'Custom SLA',
+      'Usage analytics dashboard',
+    ],
+    recommended: false,
+  },
+];
+
+const formatPeriod = (start: string | null, end: string | null): string => {
+  if (!start || !end) return '';
+  const s = new Date(start).toLocaleDateString();
+  const e = new Date(end).toLocaleDateString();
+  return `${s} – ${e}`;
+};
+
+const PlanBadge = ({ plan, status }: { plan: DeveloperPlanTier; status: string }) => {
+  const isPastDue = status === 'past_due';
+  const cls = isPastDue
+    ? 'DevBilling-planBadge DevBilling-planBadge--past_due'
+    : `DevBilling-planBadge DevBilling-planBadge--${plan}`;
+  const label = isPastDue ? 'Past due' : plan.charAt(0).toUpperCase() + plan.slice(1);
+  return <span className={cls}>{label}</span>;
+};
+
+const DeveloperBilling = () => {
+  const [subscription, setSubscription] = useState<DeveloperSubscription | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [checkingOut, setCheckingOut] = useState(false);
+  const [openingPortal, setOpeningPortal] = useState(false);
+
+  const loadSubscription = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setSubscription(await getSubscription());
+    } catch (err) {
+      logger.error('Failed to load developer subscription', err);
+      setError('Could not load your subscription. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadSubscription();
+  }, [loadSubscription]);
+
+  const handleUpgrade = async () => {
+    if (checkingOut) return;
+    setCheckingOut(true);
+    setError(null);
+    try {
+      const successUrl = `${window.location.origin}/developers/billing?upgraded=1`;
+      const cancelUrl = `${window.location.origin}/developers/billing`;
+      const url = await createCheckoutSession({ successUrl, cancelUrl });
+      window.location.href = url;
+    } catch (err) {
+      logger.error('Failed to create checkout session', err);
+      setError('Could not start the upgrade flow. Please try again.');
+      setCheckingOut(false);
+    }
+  };
+
+  const handleManageBilling = async () => {
+    if (openingPortal) return;
+    setOpeningPortal(true);
+    setError(null);
+    try {
+      const returnUrl = `${window.location.origin}/developers/billing`;
+      const url = await createPortalSession(returnUrl);
+      window.location.href = url;
+    } catch (err) {
+      logger.error('Failed to open billing portal', err);
+      setError('Could not open the billing portal. Please try again.');
+      setOpeningPortal(false);
+    }
+  };
+
+  const currentPlan = subscription?.plan ?? 'free';
+  const isPro = currentPlan === 'pro' || currentPlan === 'enterprise';
+
+  const renderCurrentPlan = () => {
+    if (loading) {
+      return <p className="text-body-3 text-text-secondary">Loading subscription…</p>;
+    }
+    if (!subscription) return null;
+    return (
+      <div className="DevBilling-currentPlan">
+        <PlanBadge plan={subscription.plan} status={subscription.status} />
+        <span
+          className="text-body-3 text-text-secondary DevBilling-planMeta"
+          data-testid="billing-plan-meta"
+        >
+          {subscription.plan === 'free'
+            ? 'You are on the Free plan.'
+            : `Metered billing — ${formatPeriod(subscription.currentPeriodStart, subscription.currentPeriodEnd)}`}
+          {subscription.cancelAtPeriodEnd && ' · Cancels at period end'}
+        </span>
+        {isPro && (
+          <Secondary
+            text={openingPortal ? 'Opening…' : 'Manage billing'}
+            onClick={handleManageBilling}
+            style={{ maxWidth: 160, marginLeft: 'auto' }}
+          />
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <DevRouteGuard>
+      <div className="OperationsWrapper">
+        <div className="TitleContainer">
+          <h1 className="text-heading-1 text-text-primary">Billing</h1>
+        </div>
+
+        <p className="text-body-3 text-text-secondary DevBilling-intro">
+          API usage is billed at the end of each calendar month based on the number of requests made
+          with your live API keys. Test-environment calls are always free.
+        </p>
+
+        {renderCurrentPlan()}
+
+        {error && <p className="DevBilling-error">{error}</p>}
+
+        <div className="DevBilling-plans">
+          {PLANS.map((plan) => {
+            const isCurrent = currentPlan === plan.key;
+
+            return (
+              <div
+                key={plan.key}
+                className={[
+                  'DevBilling-planCard',
+                  isCurrent ? 'DevBilling-planCard--current' : '',
+                  plan.recommended && !isCurrent ? 'DevBilling-planCard--recommended' : '',
+                ]
+                  .filter(Boolean)
+                  .join(' ')}
+                data-testid={`plan-card-${plan.key}`}
+              >
+                <p className="DevBilling-planName">{plan.name}</p>
+                <p className="DevBilling-planPrice">{plan.price}</p>
+                <p className="DevBilling-planPriceSub">{plan.priceSub}</p>
+                <p className="DevBilling-planDesc">{plan.description}</p>
+
+                <ul className="DevBilling-planFeatures">
+                  {plan.features.map((feature) => (
+                    <li key={feature}>{feature}</li>
+                  ))}
+                </ul>
+
+                {plan.key === 'free' && (
+                  <Secondary
+                    text={isCurrent ? 'Current plan' : 'Downgrade'}
+                    isDisabled
+                    style={{ maxWidth: '100%' }}
+                  />
+                )}
+                {plan.key === 'pro' && (
+                  <Primary
+                    text={
+                      isCurrent ? 'Current plan' : checkingOut ? 'Redirecting…' : 'Upgrade to Pro'
+                    }
+                    onClick={isCurrent ? undefined : handleUpgrade}
+                    isDisabled={isCurrent || checkingOut}
+                    style={{ maxWidth: '100%' }}
+                  />
+                )}
+                {plan.key === 'enterprise' && (
+                  <Secondary
+                    text={isCurrent ? 'Current plan' : 'Contact us'}
+                    onClick={
+                      isCurrent
+                        ? undefined
+                        : () => {
+                            window.location.href = 'mailto:enterprise@yosemitecrew.com';
+                          }
+                    }
+                    isDisabled={isCurrent}
+                    style={{ maxWidth: '100%' }}
+                  />
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </DevRouteGuard>
+  );
+};
+
+export default DeveloperBilling;

--- a/apps/frontend/src/app/services/developerApiKeys.ts
+++ b/apps/frontend/src/app/services/developerApiKeys.ts
@@ -1,0 +1,52 @@
+import { getData, postData, deleteData } from '@/app/services/axios';
+
+export type ApiKeyEnvironment = 'live' | 'test';
+export type ApiKeyStatus = 'active' | 'revoked';
+
+export interface DeveloperApiKey {
+  id: string;
+  name: string;
+  prefix: string;
+  last4: string;
+  scopes: string[];
+  environment: ApiKeyEnvironment;
+  status: ApiKeyStatus;
+  lastUsedAt: string | null;
+  expiresAt: string | null;
+  revokedAt: string | null;
+  createdAt: string;
+}
+
+export interface IssuedApiKey {
+  id: string;
+  name: string;
+  prefix: string;
+  last4: string;
+  scopes: string[];
+  environment: ApiKeyEnvironment;
+  /** The plaintext secret, returned exactly once at creation. */
+  apiKey: string;
+}
+
+export interface CreateApiKeyPayload {
+  name: string;
+  scopes?: string[];
+  environment?: ApiKeyEnvironment;
+  expiresAt?: string;
+}
+
+const BASE = '/v1/developers/api-keys';
+
+export const listApiKeys = async (): Promise<DeveloperApiKey[]> => {
+  const res = await getData<{ data: DeveloperApiKey[] }>(BASE);
+  return res.data?.data ?? [];
+};
+
+export const createApiKey = async (payload: CreateApiKeyPayload): Promise<IssuedApiKey> => {
+  const res = await postData<IssuedApiKey, CreateApiKeyPayload>(BASE, payload);
+  return res.data;
+};
+
+export const revokeApiKey = async (id: string): Promise<void> => {
+  await deleteData(`${BASE}/${id}`);
+};

--- a/apps/frontend/src/app/services/developerBilling.ts
+++ b/apps/frontend/src/app/services/developerBilling.ts
@@ -1,0 +1,49 @@
+import { getData, postData } from '@/app/services/axios';
+
+export type DeveloperPlanTier = 'free' | 'pro' | 'enterprise';
+export type DeveloperSubscriptionStatus =
+  | 'active'
+  | 'trialing'
+  | 'past_due'
+  | 'canceled'
+  | 'incomplete';
+
+export interface DeveloperSubscription {
+  id: string | null;
+  organisationId: string;
+  plan: DeveloperPlanTier;
+  status: DeveloperSubscriptionStatus;
+  stripeSubscriptionItemId: string | null;
+  currentPeriodStart: string | null;
+  currentPeriodEnd: string | null;
+  cancelAtPeriodEnd: boolean;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+export interface CheckoutPayload {
+  successUrl: string;
+  cancelUrl: string;
+}
+
+const BASE = '/v1/developers/billing';
+
+export const getSubscription = async (): Promise<DeveloperSubscription> => {
+  const res = await getData<{ data: DeveloperSubscription }>(BASE);
+  return res.data.data;
+};
+
+export const createCheckoutSession = async (payload: CheckoutPayload): Promise<string> => {
+  const res = await postData<{ data: { url: string } }, CheckoutPayload>(
+    `${BASE}/checkout`,
+    payload
+  );
+  return res.data.data.url;
+};
+
+export const createPortalSession = async (returnUrl: string): Promise<string> => {
+  const res = await postData<{ data: { url: string } }, { returnUrl: string }>(`${BASE}/portal`, {
+    returnUrl,
+  });
+  return res.data.data.url;
+};

--- a/apps/frontend/src/app/ui/layout/Sidebar/Sidebar.tsx
+++ b/apps/frontend/src/app/ui/layout/Sidebar/Sidebar.tsx
@@ -67,7 +67,7 @@ const APP_ROUTE_GROUPS = [
 ] as const;
 
 const DEV_ROUTE_GROUPS = [
-  { label: 'Developer', routeNames: ['Dashboard', 'API Keys', 'Website - Builder'] },
+  { label: 'Developer', routeNames: ['Dashboard', 'API Keys', 'Billing', 'Website - Builder'] },
   { label: 'Platform', routeNames: ['Plugins', 'Documentation'] },
 ] as const;
 

--- a/packages/database/prisma/migrations/20260625000000_add_developer_api_key/migration.sql
+++ b/packages/database/prisma/migrations/20260625000000_add_developer_api_key/migration.sql
@@ -1,0 +1,38 @@
+-- CreateEnum
+CREATE TYPE "DeveloperApiKeyEnvironment" AS ENUM ('live', 'test');
+
+-- CreateEnum
+CREATE TYPE "DeveloperApiKeyStatus" AS ENUM ('active', 'revoked');
+
+-- CreateTable
+CREATE TABLE "DeveloperApiKeys" (
+    "id" TEXT NOT NULL,
+    "organisationId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "prefix" TEXT NOT NULL,
+    "hashedKey" TEXT NOT NULL,
+    "last4" TEXT NOT NULL,
+    "scopes" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "environment" "DeveloperApiKeyEnvironment" NOT NULL DEFAULT 'live',
+    "status" "DeveloperApiKeyStatus" NOT NULL DEFAULT 'active',
+    "lastUsedAt" TIMESTAMP(3),
+    "expiresAt" TIMESTAMP(3),
+    "revokedAt" TIMESTAMP(3),
+    "createdBy" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "DeveloperApiKeys_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DeveloperApiKeys_prefix_key" ON "DeveloperApiKeys"("prefix");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DeveloperApiKeys_hashedKey_key" ON "DeveloperApiKeys"("hashedKey");
+
+-- CreateIndex
+CREATE INDEX "DeveloperApiKeys_organisationId_idx" ON "DeveloperApiKeys"("organisationId");
+
+-- CreateIndex
+CREATE INDEX "DeveloperApiKeys_status_idx" ON "DeveloperApiKeys"("status");

--- a/packages/database/prisma/migrations/20260628000000_add_developer_subscription/migration.sql
+++ b/packages/database/prisma/migrations/20260628000000_add_developer_subscription/migration.sql
@@ -1,0 +1,34 @@
+-- CreateEnum
+CREATE TYPE "DeveloperPlanTier" AS ENUM ('free', 'pro', 'enterprise');
+
+-- CreateEnum
+CREATE TYPE "DeveloperSubscriptionStatus" AS ENUM ('active', 'trialing', 'past_due', 'canceled', 'incomplete');
+
+-- CreateTable
+CREATE TABLE "DeveloperSubscriptions" (
+    "id" TEXT NOT NULL,
+    "organisationId" TEXT NOT NULL,
+    "plan" "DeveloperPlanTier" NOT NULL DEFAULT 'free',
+    "status" "DeveloperSubscriptionStatus" NOT NULL DEFAULT 'active',
+    "stripeCustomerId" TEXT,
+    "stripeSubscriptionId" TEXT,
+    "stripeSubscriptionItemId" TEXT,
+    "stripePriceId" TEXT,
+    "currentPeriodStart" TIMESTAMP(3),
+    "currentPeriodEnd" TIMESTAMP(3),
+    "cancelAtPeriodEnd" BOOLEAN NOT NULL DEFAULT false,
+    "lastStripeEventId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "DeveloperSubscriptions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DeveloperSubscriptions_organisationId_key" ON "DeveloperSubscriptions"("organisationId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DeveloperSubscriptions_stripeSubscriptionId_key" ON "DeveloperSubscriptions"("stripeSubscriptionId");
+
+-- CreateIndex
+CREATE INDEX "DeveloperSubscriptions_stripeCustomerId_idx" ON "DeveloperSubscriptions"("stripeCustomerId");

--- a/packages/database/prisma/migrations/20260628010000_add_developer_api_usage/migration.sql
+++ b/packages/database/prisma/migrations/20260628010000_add_developer_api_usage/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "DeveloperApiUsage" (
+    "id" TEXT NOT NULL,
+    "organisationId" TEXT NOT NULL,
+    "billingPeriod" TEXT NOT NULL,
+    "callCount" INTEGER NOT NULL DEFAULT 0,
+    "lastReportedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "DeveloperApiUsage_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DeveloperApiUsage_organisationId_billingPeriod_key" ON "DeveloperApiUsage"("organisationId", "billingPeriod");
+
+-- CreateIndex
+CREATE INDEX "DeveloperApiUsage_billingPeriod_idx" ON "DeveloperApiUsage"("billingPeriod");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1245,6 +1245,74 @@ model OrganizationUsageCounter {
   @@map("OrgUsageCounters")
 }
 
+/// Programmatic API credential for the developer platform (humans + agents).
+/// Only the SHA-256 hash is stored; the plaintext secret is shown once at creation.
+model DeveloperApiKey {
+  id             String                    @id @default(uuid())
+  organisationId String
+  name           String
+  prefix         String                    @unique
+  hashedKey      String                    @unique
+  last4          String
+  scopes         String[]                  @default([])
+  environment    DeveloperApiKeyEnvironment @default(live)
+  status         DeveloperApiKeyStatus      @default(active)
+  lastUsedAt     DateTime?
+  expiresAt      DateTime?
+  revokedAt      DateTime?
+  createdBy      String
+  createdAt      DateTime                  @default(now())
+  updatedAt      DateTime                  @updatedAt
+
+  @@index([organisationId])
+  @@index([status])
+  @@map("DeveloperApiKeys")
+}
+
+enum DeveloperApiKeyEnvironment {
+  live
+  test
+}
+
+enum DeveloperApiKeyStatus {
+  active
+  revoked
+}
+
+model DeveloperSubscription {
+  id                       String                      @id @default(uuid())
+  organisationId           String                      @unique
+  plan                     DeveloperPlanTier           @default(free)
+  status                   DeveloperSubscriptionStatus @default(active)
+  stripeCustomerId         String?
+  stripeSubscriptionId     String?                     @unique
+  stripeSubscriptionItemId String?
+  stripePriceId            String?
+  currentPeriodStart       DateTime?
+  currentPeriodEnd         DateTime?
+  cancelAtPeriodEnd        Boolean                     @default(false)
+  lastStripeEventId        String?
+  createdAt                DateTime                    @default(now())
+  updatedAt                DateTime                    @updatedAt
+
+  @@index([stripeCustomerId])
+  @@map("DeveloperSubscriptions")
+}
+
+enum DeveloperPlanTier {
+  free
+  pro
+  enterprise
+}
+
+enum DeveloperSubscriptionStatus {
+  active
+  trialing
+  past_due
+  canceled
+  incomplete
+}
+
 enum DevicePlatform {
   ios
   android

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1313,6 +1313,22 @@ enum DeveloperSubscriptionStatus {
   incomplete
 }
 
+// Tracks per-org API call counts per billing period.
+// Free tier quota enforcement uses this; Pro tier batches here before reporting to Stripe meters.
+model DeveloperApiUsage {
+  id             String    @id @default(uuid())
+  organisationId String
+  billingPeriod  String
+  callCount      Int       @default(0)
+  lastReportedAt DateTime?
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+
+  @@unique([organisationId, billingPeriod])
+  @@index([billingPeriod])
+  @@map("DeveloperApiUsage")
+}
+
 enum DevicePlatform {
   ios
   android

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@yosemite-crew/mcp-server",
+  "version": "0.1.0",
+  "description": "MCP server for Yosemite Crew veterinary platform — access appointments, patients, and clinic data via developer API key",
+  "type": "module",
+  "bin": {
+    "yc-mcp": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "clean": "rm -rf dist",
+    "type-check": "tsc --noEmit",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.15.0",
+    "axios": "^1.15.0",
+    "zod": "^3.25.67"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.21",
+    "tsx": "^4.19.4",
+    "typescript": "5.0.4"
+  }
+}

--- a/packages/mcp-server/src/client.ts
+++ b/packages/mcp-server/src/client.ts
@@ -1,0 +1,19 @@
+import axios from 'axios';
+
+export function createApiClient() {
+  const apiKey = process.env.YC_API_KEY;
+  const baseURL = process.env.YC_API_BASE_URL ?? 'https://api.yosemitecrew.com';
+
+  if (!apiKey) {
+    throw new Error('YC_API_KEY environment variable is required');
+  }
+
+  return axios.create({
+    baseURL,
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    timeout: 30_000,
+  });
+}

--- a/packages/mcp-server/src/client.ts
+++ b/packages/mcp-server/src/client.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 export function createApiClient() {
   const apiKey = process.env.YC_API_KEY;
-  const baseURL = process.env.YC_API_BASE_URL ?? 'https://api.yosemitecrew.com';
+  const baseURL = process.env.YC_API_BASE_URL ?? 'http://localhost:3000';
 
   if (!apiKey) {
     throw new Error('YC_API_KEY environment variable is required');

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,0 +1,18 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { createApiClient } from './client.js';
+import { registerAppointmentTools } from './tools/appointments.js';
+import { registerPatientTools } from './tools/patients.js';
+
+const server = new McpServer({
+  name: 'yosemite-crew',
+  version: '0.1.0',
+});
+
+const client = createApiClient();
+
+registerAppointmentTools(server, client);
+registerPatientTools(server, client);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/packages/mcp-server/src/tools/appointments.ts
+++ b/packages/mcp-server/src/tools/appointments.ts
@@ -1,0 +1,66 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type { AxiosInstance } from 'axios';
+
+export function registerAppointmentTools(server: McpServer, client: AxiosInstance): void {
+  server.tool(
+    'list_appointments',
+    'List upcoming and past appointments for your organisation. Filter by status or date range.',
+    {
+      status: z
+        .enum([
+          'REQUESTED',
+          'UPCOMING',
+          'CHECKED_IN',
+          'IN_PROGRESS',
+          'COMPLETED',
+          'CANCELLED',
+          'NO_SHOW',
+        ])
+        .optional()
+        .describe('Filter by appointment status'),
+      dateFrom: z
+        .string()
+        .datetime({ offset: true })
+        .optional()
+        .describe('ISO 8601 start of date range (inclusive)'),
+      dateTo: z
+        .string()
+        .datetime({ offset: true })
+        .optional()
+        .describe('ISO 8601 end of date range (inclusive)'),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .default(50)
+        .describe('Maximum number of results to return (1-100)'),
+    },
+    async ({ status, dateFrom, dateTo, limit }) => {
+      const params: Record<string, unknown> = { limit };
+      if (status) params.status = status;
+      if (dateFrom) params.dateFrom = dateFrom;
+      if (dateTo) params.dateTo = dateTo;
+
+      const response = await client.get('/v1/api/appointments', { params });
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(response.data, null, 2) }],
+      };
+    }
+  );
+
+  server.tool(
+    'get_appointment',
+    'Get full details for a specific appointment by ID.',
+    {
+      id: z.string().uuid().describe('The appointment ID'),
+    },
+    async ({ id }) => {
+      const response = await client.get(`/v1/api/appointments/${id}`);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(response.data, null, 2) }],
+      };
+    }
+  );
+}

--- a/packages/mcp-server/src/tools/patients.ts
+++ b/packages/mcp-server/src/tools/patients.ts
@@ -1,0 +1,46 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type { AxiosInstance } from 'axios';
+
+export function registerPatientTools(server: McpServer, client: AxiosInstance): void {
+  server.tool(
+    'list_patients',
+    'List patients (companion animals) linked to your organisation. Optionally filter by record status.',
+    {
+      status: z
+        .enum(['active', 'archived', 'inactive'])
+        .optional()
+        .describe('Filter by patient record status'),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .default(50)
+        .describe('Maximum number of results to return (1-100)'),
+    },
+    async ({ status, limit }) => {
+      const params: Record<string, unknown> = { limit };
+      if (status) params.status = status;
+
+      const response = await client.get('/v1/api/patients', { params });
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(response.data, null, 2) }],
+      };
+    }
+  );
+
+  server.tool(
+    'get_patient',
+    'Get full details for a specific patient (companion animal) by ID.',
+    {
+      id: z.string().uuid().describe('The patient ID'),
+    },
+    async ({ id }) => {
+      const response = await client.get(`/v1/api/patients/${id}`);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(response.data, null, 2) }],
+      };
+    }
+  );
+}

--- a/packages/mcp-server/tsconfig.build.json
+++ b/packages/mcp-server/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  }
+}

--- a/packages/mcp-server/tsconfig.json
+++ b/packages/mcp-server/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1059,6 +1059,28 @@ importers:
         specifier: 5.0.4
         version: 5.0.4
 
+  packages/mcp-server:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: 1.26.0
+        version: 1.26.0(zod@3.25.76)
+      axios:
+        specifier: 1.17.0
+        version: 1.17.0(debug@4.4.3)
+      zod:
+        specifier: ^3.25.67
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^22.15.21
+        version: 22.19.8
+      tsx:
+        specifier: ^4.19.4
+        version: 4.22.4
+      typescript:
+        specifier: 5.0.4
+        version: 5.0.4
+
   packages/types:
     dependencies:
       '@yosemite-crew/fhir':
@@ -12636,7 +12658,6 @@ packages:
       hono: 4.12.18
     dependencies:
       hono: 4.12.18
-    dev: true
 
   /@hookform/resolvers@5.2.2(react-hook-form@7.71.1):
     resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
@@ -13933,7 +13954,6 @@ packages:
       zod-to-json-schema: 3.25.1(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@mongodb-js/saslprep@1.4.11:
     resolution: {integrity: sha512-o9rAHc0IpIjuPSxRutWpE1F62x7n+4mVS4rCNHkzhIUMQcc18bb6xEq5wd2NdN0WjepIyXIppRshYI2kQDOZVA==}
@@ -20791,7 +20811,6 @@ packages:
     dependencies:
       mime-types: 3.0.2
       negotiator: 1.0.0
-    dev: true
 
   /acorn-import-phases@1.0.4(acorn@8.15.0):
     resolution: {integrity: sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==}
@@ -20898,7 +20917,6 @@ packages:
         optional: true
     dependencies:
       ajv: 8.18.0
-    dev: true
 
   /ajv-keywords@3.5.2(ajv@6.14.0):
     resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
@@ -21959,7 +21977,6 @@ packages:
       type-is: 2.0.1
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /bonjour-service@1.3.0:
     resolution: {integrity: sha512-3YuAUiSkWykd+2Azjgyxei8OWf8thdn8AITIog2M4UICzoqfjlqr64WIjEXZllf/W6vK1goqleSR6brGomxQqA==}
@@ -23102,7 +23119,6 @@ packages:
   /content-disposition@1.0.1:
     resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
     engines: {node: '>=18'}
-    dev: true
 
   /content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
@@ -23154,7 +23170,6 @@ packages:
   /cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
     engines: {node: '>=6.6.0'}
-    dev: true
 
   /cookie@0.7.1:
     resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
@@ -25656,14 +25671,12 @@ packages:
   /eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
     engines: {node: '>=18.0.0'}
-    dev: true
 
   /eventsource@3.0.7:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
     dependencies:
       eventsource-parser: 3.0.6
-    dev: true
 
   /execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
@@ -25781,7 +25794,6 @@ packages:
     dependencies:
       express: 5.2.1
       ip-address: 10.1.1
-    dev: true
 
   /express@4.21.2:
     resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
@@ -25894,7 +25906,6 @@ packages:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /ext@1.7.0:
     resolution: {integrity: sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==}
@@ -26213,7 +26224,6 @@ packages:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /find-babel-config@2.1.2:
     resolution: {integrity: sha512-ZfZp1rQyp4gyuxqt1ZqjFGVeVBvmpURMqdIWXbPRfB97Bf6BzdK/xSIbylEINzQ0kB5tlDQfn9HkNXXWsqTqLg==}
@@ -26488,7 +26498,6 @@ packages:
   /fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
-    dev: true
 
   /fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -27423,7 +27432,6 @@ packages:
   /hono@4.12.18:
     resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
     engines: {node: '>=16.9.0'}
-    dev: true
 
   /hosted-git-info@4.1.0:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
@@ -27748,7 +27756,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       safer-buffer: 2.1.2
-    dev: true
 
   /icss-utils@5.1.0(postcss@8.5.14):
     resolution: {integrity: sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==}
@@ -27951,7 +27958,6 @@ packages:
   /ip-address@10.1.1:
     resolution: {integrity: sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==}
     engines: {node: '>= 12'}
-    dev: true
 
   /ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -28273,7 +28279,6 @@ packages:
 
   /is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
-    dev: true
 
   /is-property@1.0.2:
     resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
@@ -29406,7 +29411,6 @@ packages:
 
   /jose@6.1.3:
     resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
-    dev: true
 
   /jpeg-exif@1.1.4:
     resolution: {integrity: sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ==}
@@ -29533,7 +29537,6 @@ packages:
 
   /json-schema-typed@8.0.2:
     resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
-    dev: true
 
   /json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -30621,7 +30624,6 @@ packages:
   /media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
-    dev: true
 
   /memfs@4.56.10(tslib@2.8.1):
     resolution: {integrity: sha512-eLvzyrwqLHnLYalJP7YZ3wBe79MXktMdfQbvMrVD80K+NhrIukCVBvgP30zTJYEEDh9hZ/ep9z0KOdD7FSHo7w==}
@@ -30661,7 +30663,6 @@ packages:
   /merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
-    dev: true
 
   /merge-options@3.0.4:
     resolution: {integrity: sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==}
@@ -31758,7 +31759,6 @@ packages:
   /negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
-    dev: true
 
   /neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
@@ -32706,7 +32706,6 @@ packages:
 
   /path-to-regexp@8.3.0:
     resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
-    dev: true
 
   /path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -32847,7 +32846,6 @@ packages:
   /pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
-    dev: true
 
   /pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
@@ -34271,7 +34269,6 @@ packages:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       unpipe: 1.0.0
-    dev: true
 
   /rc-config-loader@4.1.4:
     resolution: {integrity: sha512-3GiwEzklkbXTDp52UR5nT8iXgYAx1V9ZG/kDZT7p60u2GCv2XTwQq4NzinMoMpNtXhmt3WkhYXcj6HH8HdwCEQ==}
@@ -35930,7 +35927,6 @@ packages:
       path-to-regexp: 8.3.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
@@ -36200,7 +36196,6 @@ packages:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /sentence-case@3.0.4:
     resolution: {integrity: sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==}
@@ -36298,7 +36293,6 @@ packages:
       send: 1.2.1
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
@@ -38495,7 +38489,6 @@ packages:
       content-type: 1.0.5
       media-typer: 1.1.0
       mime-types: 3.0.2
-    dev: true
 
   /type@2.7.3:
     resolution: {integrity: sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==}
@@ -40129,7 +40122,6 @@ packages:
       zod: ^3.25 || ^4
     dependencies:
       zod: 3.25.76
-    dev: true
 
   /zod-validation-error@4.0.2(zod@3.25.76):
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

Clinics and developers who fork and self-host the Yosemite Crew PIMS have no programmatic data API and no MCP server to interact with their own instance.

## What is the new behavior?

**Intended workflow:** fork the repo -> run your own PIMS instance -> create an API key via the developer portal -> point the MCP server at your instance -> vibe code against your own veterinary data.

**Backend - new `/v1/api` route group protected by `authorizeApiKey`:**
- `GET /v1/api/appointments` - list org appointments with optional status/date filters
- `GET /v1/api/appointments/:id` - get a single appointment (404 if not in org)
- `GET /v1/api/patients` - list patients via PatientOrganisation join (ACTIVE links only)
- `GET /v1/api/patients/:id` - get a single patient

All endpoints validate query params with Zod and apply per-scope checks via `requireScope`.

**New package `@yosemite-crew/mcp-server`:**
- 4 MCP tools: `list_appointments`, `get_appointment`, `list_patients`, `get_patient`
- Uses `McpServer` high-level SDK (v1.26) over stdio transport
- `YC_API_KEY` - API key from your self-hosted portal
- `YC_API_BASE_URL` - URL of your PIMS instance (defaults to `http://localhost:3000`)
- Compatible with Claude Desktop, Cursor, Cline, and any stdio-MCP client

**Tests:**
- `DeveloperDataController` - 21 tests, 100% branch coverage

## Related Issue(s)

Fixes #1725