### PR TITLE
fix(frontend): inventory save and stock display bugs (batch quantity, subcategory)

### DIFF
--- a/apps/frontend/src/app/features/inventory/components/AddInventory/index.tsx
+++ b/apps/frontend/src/app/features/inventory/components/AddInventory/index.tsx
@@ -271,11 +271,6 @@ const AddInventory = ({
   const validateStock = (): Partial<Record<keyof typeof formData.stock, string>> => {
     const stock = formData.stock;
     const errors: Partial<Record<keyof typeof formData.stock, string>> = {};
-    if (!stock.current) {
-      errors.current = 'On hand quantity is required';
-    } else if (Number.isNaN(Number(stock.current))) {
-      errors.current = 'Enter a valid number';
-    }
     if (!stock.reorderLevel) {
       errors.reorderLevel = 'Reorder level is required';
     } else if (Number.isNaN(Number(stock.reorderLevel))) {

--- a/apps/frontend/src/app/features/inventory/components/InventoryInfo.tsx
+++ b/apps/frontend/src/app/features/inventory/components/InventoryInfo.tsx
@@ -59,8 +59,6 @@ const getBasicInfoErrors = (
   const errs: Record<string, string> = {};
   if (!values.name && !inventory.basicInfo.name) errs.name = 'Name is required';
   if (!values.category && !inventory.basicInfo.category) errs.category = 'Category is required';
-  if (!values.subCategory && !inventory.basicInfo.subCategory)
-    errs.subCategory = 'Sub category is required';
   return errs;
 };
 

--- a/apps/frontend/src/app/ui/primitives/Accordion/EditableAccordion.tsx
+++ b/apps/frontend/src/app/ui/primitives/Accordion/EditableAccordion.tsx
@@ -595,6 +595,7 @@ const EditableAccordion: React.FC<EditableAccordionProps> = ({
         onDeleteClick={onDelete}
       >
         <div className={`flex flex-col`}>
+          {dynamicFooter && <div className="mb-3">{dynamicFooter(formValues)}</div>}
           {fields
             .filter((field) => !fieldFilter || fieldFilter(field.key, formValues))
             .map((field) => {
@@ -622,7 +623,6 @@ const EditableAccordion: React.FC<EditableAccordionProps> = ({
               );
             })}
           {renderedFooter && <div className="mt-3">{renderedFooter}</div>}
-          {dynamicFooter && <div className="mt-3">{dynamicFooter(formValues)}</div>}
         </div>
       </Accordion>
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

Three bugs in the Inventory feature:
1. Creating a new inventory item is blocked from saving if no batch quantity is entered, because the read-only "On Hand Quantity" field is wrongly treated as required with no way for the user to fill it in.
2. Editing any field on an existing inventory item (e.g. SKU, name) silently fails — with no error shown — if that item doesn't have a subcategory set, because edit-time validation wrongly requires subcategory even though it's optional on create and in the backend.
3. The "On hand stock" / "Available stock (dispensable)" summary badges render at the bottom of the Stock Control section instead of the top, making them easy to miss.

## What is the new behavior?

1. Removed the required-field check on `stock.current` in `AddInventory/index.tsx`'s `validateStock` — it's a derived, read-only field, and an empty batch quantity already resolves to `0` in the saved payload.
2. Removed the `subCategory` required check from `getBasicInfoErrors` in `InventoryInfo.tsx`, aligning edit-time validation with create-time validation and the backend schema (neither requires it).
3. Moved the `dynamicFooter` render block above the fields list in `EditableAccordion.tsx`, so the stock summary badges now appear at the top of the Stock Control section.

## Related Issue(s)

Fixes #1757