### PR TITLE
docs(repo): update README video link and default inventory screen to Active filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 <br>
 
-https://github.com/user-attachments/assets/46f13270-295e-4d7d-ba34-d11cba392cdc
+https://github.com/user-attachments/assets/142485b9-92b3-443c-9a37-1627272b6b22
 
 <br>
 

--- a/apps/frontend/src/app/__tests__/pages/Inventory/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Inventory/index.test.tsx
@@ -312,7 +312,7 @@ const mockInventory = [
   },
   {
     id: '2',
-    status: 'HIDDEN',
+    status: 'ACTIVE',
     stockHealth: 'Low Stock',
     basicInfo: { name: 'Item B', category: 'Food', description: 'Desc B' },
   },
@@ -491,6 +491,17 @@ describe('Inventory Page', () => {
   });
 
   it('filters inventory by status', async () => {
+    (useInventoryModule as jest.Mock).mockReturnValue({
+      inventory: [mockInventory[0], { ...mockInventory[1], status: 'HIDDEN' }],
+      turnover: mockTurnover,
+      status: 'success',
+      error: null,
+      createItem: mockCreateItem,
+      updateItem: mockUpdateItem,
+      hideItem: mockHideItem,
+      unhideItem: mockUnhideItem,
+      addBatch: mockAddBatch,
+    });
     render(<ProtectedInventory />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Active' }));

--- a/apps/frontend/src/app/__tests__/pages/Inventory/utils.test.ts
+++ b/apps/frontend/src/app/__tests__/pages/Inventory/utils.test.ts
@@ -924,7 +924,7 @@ describe('Inventory Utils', () => {
       abcClasses: [],
       suppliers: [],
       status: 'ALL',
-      visibility: 'ALL',
+      visibility: 'ACTIVE',
       search: '',
     });
   });

--- a/apps/frontend/src/app/features/inventory/pages/Inventory/utils.ts
+++ b/apps/frontend/src/app/features/inventory/pages/Inventory/utils.ts
@@ -657,7 +657,7 @@ export const defaultFilters: InventoryFiltersState = {
   locations: [],
   abcClasses: [],
   suppliers: [],
-  visibility: 'ALL',
+  visibility: 'ACTIVE',
   status: 'ALL',
   search: '',
 };


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The Inventory screen's Active/Hidden toggle defaulted to neither option selected (`visibility: 'ALL'`), so on load it was unclear which view was active and hidden items were mixed in with active ones by default. Separately, the README's demo video link was outdated.

## What is the new behavior?

- Inventory screen now defaults to the "Active" filter on load and after clearing filters, so the toggle is visibly selected and hidden items are excluded by default.
- Updated the README's embedded demo video link.

## Related Issue(s)

Fixes #
