### PR TITLE
fix(repo): publish desktop manual builds as draft releases

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -127,9 +127,9 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           draft: true
-          tag_name: desktop-v${{ steps.version.outputs.version }}
+          tag_name: desktop-manual-v${{ steps.version.outputs.version }}-${{ github.run_id }}
           target_commitish: ${{ github.sha }}
-          name: Yosemite Crew PIMS Desktop v${{ steps.version.outputs.version }}
+          name: Yosemite Crew PIMS Desktop manual v${{ steps.version.outputs.version }}-${{ github.run_id }}
           generate_release_notes: true
           files: |
             release-assets/*.exe

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -5,9 +5,9 @@ name: Desktop Release
 #       1) bump "version" in apps/desktop/package.json
 #       2) git tag desktop-v<version> && git push origin desktop-v<version>
 #   • Run manually (Actions → "Desktop Release" → Run workflow / workflow_dispatch)
-#       → builds + signs, then uploads the signed installers as workflow ARTIFACTS
-#         (NO Release). Use this to collect signed mac/Windows builds for a
-#         coordinated joint release (alongside mobile + PIMS) later.
+#       → builds + signs, uploads workflow ARTIFACTS, then creates a draft
+#         GitHub Release with the same assets. Use this to share download links
+#         without requiring the Actions artifact UI.
 #
 # Windows is signed via Azure Artifact Signing (formerly Trusted Signing).
 #   AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET
@@ -103,3 +103,40 @@ jobs:
             apps/desktop/dist/*.blockmap
             apps/desktop/dist/latest-mac.yml
           if-no-files-found: warn
+
+  release:
+    if: github.event_name == 'workflow_dispatch'
+    needs:
+      - windows
+      - macos
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: release-assets
+          merge-multiple: true
+
+      - name: Read desktop version
+        id: version
+        working-directory: apps/desktop
+        run: echo "version=$(node -p \"require('./package.json').version\")" >> "$GITHUB_OUTPUT"
+
+      - name: Create draft GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          tag_name: desktop-v${{ steps.version.outputs.version }}
+          target_commitish: ${{ github.sha }}
+          name: Yosemite Crew PIMS Desktop v${{ steps.version.outputs.version }}
+          generate_release_notes: true
+          files: |
+            release-assets/*.exe
+            release-assets/*.dmg
+            release-assets/*.zip
+            release-assets/*.blockmap
+            release-assets/latest.yml
+            release-assets/latest-mac.yml
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/desktop/RELEASE.md
+++ b/apps/desktop/RELEASE.md
@@ -62,6 +62,7 @@ updatable.
 ## Coordinated / joint releases
 
 The release workflow also supports a manual (`workflow_dispatch`) run that
-produces the signed installers as CI build artifacts **without** creating a
-public GitHub Release. Use this when the desktop app ships alongside other
-products and the public release needs to be timed together.
+produces signed installers as CI build artifacts and creates a **draft GitHub
+Release** with the same files. This is the right path when you want downloadable
+links without relying on the Actions artifact UI. If the repository is private,
+the download page can still require GitHub authentication.

--- a/apps/desktop/docs/RELEASE-TESTING.md
+++ b/apps/desktop/docs/RELEASE-TESTING.md
@@ -11,9 +11,9 @@ configured — testers must do a one-time "open anyway" (see below).
 ## Recommended: build both platforms via GitHub Actions (hosted)
 
 The `.github/workflows/desktop-release.yml` workflow builds macOS **and**
-Windows on their native runners and uploads artifacts (+ the electron-updater
-feed files) to a GitHub Release. This is the only reliable way to produce a
-real Windows installer.
+Windows on their native runners and uploads artifacts. For tag pushes
+(`desktop-v*`) it publishes the signed installers to a GitHub Release. For
+manual runs it creates a draft GitHub Release with the same assets.
 
 ```sh
 # from repo root, on a branch the workflow can see
@@ -23,16 +23,16 @@ git push origin desktop-v0.1.0-beta.1
 ```
 
 The workflow runs `lint → type-check → test → security:pressure`, then
-`electron-builder --mac --win --publish always`, creating a **draft** GitHub
-Release with:
+`electron-builder --mac --win --publish always` on tag pushes, creating a
+GitHub Release with:
 
 - macOS: `Yosemite Crew PIMS-0.1.0-beta.1-mac-arm64.dmg` + `.zip`
 - Windows: `Yosemite Crew PIMS-0.1.0-beta.1-win-x64-setup.exe` (NSIS) + portable `.exe`
 - `latest-mac.yml` / `latest.yml` (auto-update feeds)
 
-Review the draft Release, mark it **Pre-release**, and share the download links
-with testers. Signing/notarization happen automatically **if** these repo
-secrets are set (unset = unsigned build, still works for testers):
+For manual runs, review the draft Release and share the download links with
+testers. Signing/notarization happen automatically **if** these repo secrets
+are set (unset = unsigned build, still works for testers):
 `MAC_CSC_LINK`, `MAC_CSC_KEY_PASSWORD`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`,
 `APPLE_TEAM_ID`, `WIN_CSC_LINK`, `WIN_CSC_KEY_PASSWORD`.
 
@@ -93,6 +93,6 @@ Diagnostics` bundle if something breaks.
 - [ ] `version` bumped (`0.1.0-beta.1`) and committed.
 - [ ] Gate green: `pnpm --dir apps/desktop run type-check && lint && test && security:pressure`.
 - [ ] App launches from a clean `dist/` build; welcome + sign-in + tabs work.
-- [ ] Tag pushed (`desktop-v0.1.0-beta.1`) → Actions build succeeds → draft Release.
+- [ ] Tag pushed (`desktop-v0.1.0-beta.1`) → Actions build succeeds → GitHub Release.
 - [ ] Release marked **Pre-release**; install instructions shared with testers.
 - [ ] (Optional) signing secrets configured to avoid the "open anyway" step.


### PR DESCRIPTION
<!--
We, the rest of the Yosemite community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests and lints pass.

## Summary
This PR updates the desktop release workflow so manual `workflow_dispatch` runs no longer stop at GitHub Actions artifacts. Instead, they also create a draft GitHub Release with the signed macOS and Windows installers plus update metadata.

## What changed
- Added a release job to `.github/workflows/desktop-release.yml` that runs after both platform builds on manual workflow dispatch.
- The release job downloads the signed artifacts and creates a draft GitHub Release using `softprops/action-gh-release` with a unique manual-only tag of the form `desktop-manual-v<version>-<run_id>`.
- Kept the existing tag-based `desktop-v*` flow intact for normal release publishing.
- Updated `apps/desktop/RELEASE.md` and `apps/desktop/docs/RELEASE-TESTING.md` so the documented release path matches the workflow.
- Manual releases cannot overwrite the production `desktop-v*` release because they use a separate tag namespace.

Fixes #1768 