### PR TITLE
fix(backend): scope mobile task detail reads to the authenticated parent

### DIFF
--- a/apps/backend/src/controllers/web/task.controller.ts
+++ b/apps/backend/src/controllers/web/task.controller.ts
@@ -172,7 +172,9 @@ const handleError = (error: unknown, res: Response) => {
   return res.status(500).json({ message: "Internal Server Error" });
 };
 
-const resolveUserId = (req: Request<unknown, unknown, unknown, unknown>): string => {
+const resolveUserId = (
+  req: Request<unknown, unknown, unknown, unknown>,
+): string => {
   const authReq = req as AuthenticatedRequest;
   return typeof authReq.userId === "string" ? authReq.userId : "";
 };
@@ -297,13 +299,30 @@ export const TaskController = {
       const task = await TaskService.getById(req.params.taskId, organisationId);
       if (!task) return res.status(404).json({ message: "Task not found" });
 
-      // PMS context (org membership resolved): callers without tasks:view:any
-      // may only read tasks they created or are assigned to.
-      if (organisationId && !hasPermission(req, "tasks:view:any")) {
+      if (organisationId) {
+        // PMS context (org membership resolved): callers without tasks:view:any
+        // may only read tasks they created or are assigned to.
+        if (!hasPermission(req, "tasks:view:any")) {
+          const actorId = resolveUserId(req);
+          const isOwner =
+            !!actorId &&
+            (task.createdBy === actorId || task.assignedTo === actorId);
+          if (!isOwner) {
+            return res.status(404).json({ message: "Task not found" });
+          }
+        }
+      } else {
+        // Mobile context (no PMS org): resolve the authenticated parent and only
+        // return a task they created or are assigned to, so a signed-in parent
+        // cannot read another parent's task by guessing its ID.
         const actorId = resolveUserId(req);
+        const authUser = actorId
+          ? await AuthUserMobileService.getByProviderUserId(actorId)
+          : null;
+        const parentId = authUser?.parentId?.toString();
         const isOwner =
-          !!actorId &&
-          (task.createdBy === actorId || task.assignedTo === actorId);
+          !!parentId &&
+          (task.createdBy === parentId || task.assignedTo === parentId);
         if (!isOwner) {
           return res.status(404).json({ message: "Task not found" });
         }

--- a/apps/backend/test/controllers/task.controller.test.ts
+++ b/apps/backend/test/controllers/task.controller.test.ts
@@ -229,7 +229,11 @@ describe("Task Controllers", () => {
       it("should success (200)", async () => {
         req.params = { taskId: "t1" };
         (req as any).userId = "u1";
-        (req as any).userPermissions = ["tasks:view:own"];
+        // Mobile (no org context): the authenticated parent owns the task
+        // because it is assigned to them.
+        (mockedAuthService.getByProviderUserId as any).mockResolvedValue({
+          parentId: "u1",
+        });
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (mockedTaskService.getById as any).mockResolvedValue({
           id: "t1",
@@ -242,6 +246,22 @@ describe("Task Controllers", () => {
           assignedTo: "u1",
           createdBy: "u2",
         });
+      });
+
+      it("should 404 for a mobile caller who does not own the task", async () => {
+        req.params = { taskId: "t1" };
+        (req as any).userId = "u1";
+        (mockedAuthService.getByProviderUserId as any).mockResolvedValue({
+          parentId: "other-parent",
+        });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (mockedTaskService.getById as any).mockResolvedValue({
+          id: "t1",
+          assignedTo: "u9",
+          createdBy: "u8",
+        });
+        await TaskController.getById(req as any, res as Response);
+        expect(statusMock).toHaveBeenCalledWith(404);
       });
 
       it("should handle error", async () => {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [x] There is an issue for the bug/feature this PR is for. Context: follow-up to the closed #1640 (superseded by the merged #1793); this closes the one gap #1793 left.
- [x] All existing tests and lints pass.

## What is the current behavior?

`GET /mobile/:taskId` is served by the shared `TaskController.getById` (apps/backend/src/controllers/web/task.controller.ts), mounted with `authorizeCognitoMobile` in task.router.ts. Mobile requests carry no PMS org context, so `resolveOrganisationId(req)` is `undefined`, the `if (organisationId && !hasPermission(...))` ownership check is skipped entirely, and `TaskService.getById(taskId, undefined)` returns any task by ID. An authenticated mobile user who knows or guesses a task ID can read another parent's task detail (IDOR / broken access control, P1).

PR #1793 fixed the analogous mobile appointment-detail IDOR (via a dedicated `getByIdMobile` handler) but did not cover the task path.

## What is the new behavior?

`TaskController.getById` now enforces ownership in the mobile (no-org) context too. When there is no `organisationId`, it resolves the authenticated parent from the verified token (`AuthUserMobileService.getByProviderUserId(resolveUserId(req))` -> `parentId`) and returns the task only if `task.createdBy === parentId || task.assignedTo === parentId` (mirroring `TaskService.listForParent`'s created-or-assigned filter); otherwise `404`, indistinguishable from not-found so IDs cannot be probed. The PMS (org-scoped) path is unchanged in behaviour.

Regression tests added in `test/controllers/task.controller.test.ts`: mobile owner returns the task (200); mobile non-owner returns 404.

Validation: `pnpm --filter backend run type-check` and `lint` clean; full backend jest suite green (3396 tests); opengrep AIK scan of the changed file clean.

## Related Issue(s)

Follow-up to #1640 (closed, superseded by the merged #1793). Closes the mobile task-detail IDOR that #1793 did not cover.
