### PR TITLE
test(mobile): fix react-test-renderer teardown leaks flaking the CI suite

### DIFF
--- a/apps/mobileAppYC/__tests__/screens/EmptyScreens.snapshot.test.tsx
+++ b/apps/mobileAppYC/__tests__/screens/EmptyScreens.snapshot.test.tsx
@@ -1,6 +1,6 @@
 // __tests__/screens/EmptyScreens.snapshot.test.tsx
 import React from 'react';
-import renderer from 'react-test-renderer';
+import {cleanupSnapshotTrees, renderSnapshot} from '../setup/snapshotRenderer';
 import {Provider} from 'react-redux';
 import {configureStore} from '@reduxjs/toolkit';
 
@@ -30,19 +30,6 @@ const createTestStore = () =>
     },
   });
 
-// Drain pending async work (mount effects, theme dispatch) then unmount so the
-// tree never re-renders after the Jest environment is torn down.
-const drainAndUnmount = async (tree: renderer.ReactTestRenderer) => {
-  for (let i = 0; i < 3; i++) {
-    await renderer.act(async () => {
-      await new Promise<void>(resolve => setTimeout(resolve, 0));
-    });
-  }
-  await renderer.act(async () => {
-    tree.unmount();
-  });
-};
-
 describe('Empty Screen Snapshots', () => {
   let store: ReturnType<typeof createTestStore>;
 
@@ -51,19 +38,22 @@ describe('Empty Screen Snapshots', () => {
     jest.clearAllMocks();
   });
 
+  // Unmount in afterEach rather than after the assertion, so a failing
+  // snapshot cannot leave a tree mounted and leak into the next suite.
+  afterEach(cleanupSnapshotTrees);
+
   describe('GenericEmptyScreen', () => {
-    it('should render with minimal props', async () => {
-      const tree = renderer.create(
+    it('should render with minimal props', () => {
+      const tree = renderSnapshot(
         <Provider store={store}>
           <GenericEmptyScreen title="Empty" subtitle="No items found" />
         </Provider>,
       );
-      expect(tree.toJSON()).toMatchSnapshot();
-      await drainAndUnmount(tree);
+      expect(tree).toMatchSnapshot();
     });
 
-    it('should render with all props', async () => {
-      const tree = renderer.create(
+    it('should render with all props', () => {
+      const tree = renderSnapshot(
         <Provider store={store}>
           <GenericEmptyScreen
             title="No Documents"
@@ -71,12 +61,11 @@ describe('Empty Screen Snapshots', () => {
           />
         </Provider>,
       );
-      expect(tree.toJSON()).toMatchSnapshot();
-      await drainAndUnmount(tree);
+      expect(tree).toMatchSnapshot();
     });
 
-    it('should render with different icon', async () => {
-      const tree = renderer.create(
+    it('should render with different icon', () => {
+      const tree = renderSnapshot(
         <Provider store={store}>
           <GenericEmptyScreen
             title="No Companions"
@@ -84,20 +73,18 @@ describe('Empty Screen Snapshots', () => {
           />
         </Provider>,
       );
-      expect(tree.toJSON()).toMatchSnapshot();
-      await drainAndUnmount(tree);
+      expect(tree).toMatchSnapshot();
     });
   });
 
   describe('EmptyDocumentsScreen', () => {
-    it('should render correctly', async () => {
-      const tree = renderer.create(
+    it('should render correctly', () => {
+      const tree = renderSnapshot(
         <Provider store={store}>
           <EmptyDocumentsScreen />
         </Provider>,
       );
-      expect(tree.toJSON()).toMatchSnapshot();
-      await drainAndUnmount(tree);
+      expect(tree).toMatchSnapshot();
     });
   });
 });

--- a/apps/mobileAppYC/__tests__/screens/EmptyScreens.snapshot.test.tsx
+++ b/apps/mobileAppYC/__tests__/screens/EmptyScreens.snapshot.test.tsx
@@ -1,6 +1,10 @@
 // __tests__/screens/EmptyScreens.snapshot.test.tsx
 import React from 'react';
 import renderer from 'react-test-renderer';
+import {Provider} from 'react-redux';
+import {configureStore} from '@reduxjs/toolkit';
+
+import {themeReducer} from '@/features/theme';
 import {GenericEmptyScreen} from '@/shared/components/common/GenericEmptyScreen/GenericEmptyScreen';
 import {EmptyDocumentsScreen} from '@/features/documents/screens/EmptyDocumentsScreen/EmptyDocumentsScreen';
 
@@ -15,49 +19,85 @@ jest.mock('@react-navigation/native', () => ({
   useNavigation: () => mockNavigation,
 }));
 
+// These screens use useTheme, which reads state.theme and dispatches on mount,
+// so they must render under a redux Provider. Without one, useAppDispatch throws
+// and (because render is not wrapped in act) the error is deferred and leaks out
+// asynchronously after the Jest environment tears down.
+const createTestStore = () =>
+  configureStore({
+    reducer: {
+      theme: themeReducer,
+    },
+  });
+
+// Drain pending async work (mount effects, theme dispatch) then unmount so the
+// tree never re-renders after the Jest environment is torn down.
+const drainAndUnmount = async (tree: renderer.ReactTestRenderer) => {
+  for (let i = 0; i < 3; i++) {
+    await renderer.act(async () => {
+      await new Promise<void>(resolve => setTimeout(resolve, 0));
+    });
+  }
+  await renderer.act(async () => {
+    tree.unmount();
+  });
+};
+
 describe('Empty Screen Snapshots', () => {
+  let store: ReturnType<typeof createTestStore>;
+
   beforeEach(() => {
+    store = createTestStore();
     jest.clearAllMocks();
   });
 
   describe('GenericEmptyScreen', () => {
-    it('should render with minimal props', () => {
+    it('should render with minimal props', async () => {
       const tree = renderer.create(
-        <GenericEmptyScreen
-          title="Empty"
-          subtitle="No items found"
-        />
-      ).toJSON();
-      expect(tree).toMatchSnapshot();
+        <Provider store={store}>
+          <GenericEmptyScreen title="Empty" subtitle="No items found" />
+        </Provider>,
+      );
+      expect(tree.toJSON()).toMatchSnapshot();
+      await drainAndUnmount(tree);
     });
 
-    it('should render with all props', () => {
+    it('should render with all props', async () => {
       const tree = renderer.create(
-        <GenericEmptyScreen
-          title="No Documents"
-          subtitle="Start by adding your first document"
-        />
-      ).toJSON();
-      expect(tree).toMatchSnapshot();
+        <Provider store={store}>
+          <GenericEmptyScreen
+            title="No Documents"
+            subtitle="Start by adding your first document"
+          />
+        </Provider>,
+      );
+      expect(tree.toJSON()).toMatchSnapshot();
+      await drainAndUnmount(tree);
     });
 
-    it('should render with different icon', () => {
+    it('should render with different icon', async () => {
       const tree = renderer.create(
-        <GenericEmptyScreen
-          title="No Companions"
-          subtitle="Add a companion to get started"
-        />
-      ).toJSON();
-      expect(tree).toMatchSnapshot();
+        <Provider store={store}>
+          <GenericEmptyScreen
+            title="No Companions"
+            subtitle="Add a companion to get started"
+          />
+        </Provider>,
+      );
+      expect(tree.toJSON()).toMatchSnapshot();
+      await drainAndUnmount(tree);
     });
   });
 
   describe('EmptyDocumentsScreen', () => {
-    it('should render correctly', () => {
+    it('should render correctly', async () => {
       const tree = renderer.create(
-        <EmptyDocumentsScreen />
-      ).toJSON();
-      expect(tree).toMatchSnapshot();
+        <Provider store={store}>
+          <EmptyDocumentsScreen />
+        </Provider>,
+      );
+      expect(tree.toJSON()).toMatchSnapshot();
+      await drainAndUnmount(tree);
     });
   });
 });

--- a/apps/mobileAppYC/__tests__/screens/PlaceholderScreens.snapshot.test.tsx
+++ b/apps/mobileAppYC/__tests__/screens/PlaceholderScreens.snapshot.test.tsx
@@ -1,6 +1,6 @@
 // __tests__/screens/PlaceholderScreens.snapshot.test.tsx
 import React from 'react';
-import renderer from 'react-test-renderer';
+import {cleanupSnapshotTrees, renderSnapshot} from '../setup/snapshotRenderer';
 import {Provider} from 'react-redux';
 import {configureStore} from '@reduxjs/toolkit';
 
@@ -85,20 +85,9 @@ describe('Placeholder Screens Snapshots', () => {
     jest.clearAllMocks();
   });
 
-  // These trees used to be created and left mounted. React 19 keeps scheduler
-  // work queued for an un-unmounted tree, and from Jest 30 that callback firing
-  // after the environment is torn down fails whichever suite the worker picks
-  // up next ("trying to `require` a file after the Jest environment has been
-  // torn down"). Unmounting inside act drains that work here instead. The tree
-  // is serialised before the act so these remain first-render snapshots.
-  const renderSnapshot = (ui: React.ReactElement) => {
-    const tree = renderer.create(ui);
-    const json = tree.toJSON();
-    renderer.act(() => {
-      tree.unmount();
-    });
-    return json;
-  };
+  // Unmount in afterEach rather than inline, so a failing snapshot cannot
+  // leave a tree mounted and leak into the next suite.
+  afterEach(cleanupSnapshotTrees);
 
   describe('TasksMainScreen', () => {
     it('should render correctly', () => {

--- a/apps/mobileAppYC/__tests__/screens/__snapshots__/EmptyScreens.snapshot.test.tsx.snap
+++ b/apps/mobileAppYC/__tests__/screens/__snapshots__/EmptyScreens.snapshot.test.tsx.snap
@@ -1,9 +1,468 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`Empty Screen Snapshots EmptyDocumentsScreen should render correctly 1`] = `null`;
+exports[`Empty Screen Snapshots EmptyDocumentsScreen should render correctly 1`] = `
+<View
+  edges={[]}
+  style={
+    [
+      {
+        "backgroundColor": "#F7F3EC",
+        "flex": 1,
+      },
+      {
+        "backgroundColor": "#F7F3EC",
+        "flex": 1,
+      },
+    ]
+  }
+>
+  <View
+    onLayout={[Function]}
+    style={
+      {
+        "backgroundColor": "transparent",
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+        "zIndex": 2,
+      }
+    }
+  >
+    <View
+      style={
+        {
+          "backgroundColor": "transparent",
+          "borderBottomLeftRadius": 16,
+          "borderBottomRightRadius": 16,
+          "borderTopLeftRadius": 0,
+          "borderTopRightRadius": 0,
+          "elevation": 10,
+          "shadowColor": "rgba(29, 28, 27, 0.10)",
+          "shadowOffset": {
+            "height": 12,
+            "width": 0,
+          },
+          "shadowOpacity": 0.14,
+          "shadowRadius": 18,
+        }
+      }
+    >
+      <View
+        style={
+          {
+            "backgroundColor": "#F1EBE1",
+            "borderBottomLeftRadius": 16,
+            "borderBottomRightRadius": 16,
+            "borderColor": "transparent",
+            "borderRadius": 16,
+            "borderTopLeftRadius": 0,
+            "borderTopRightRadius": 0,
+            "borderWidth": 0,
+            "boxShadow": "none",
+            "overflow": "visible",
+            "padding": 16,
+            "paddingBottom": 12,
+            "paddingHorizontal": 0,
+            "paddingTop": 0,
+          }
+        }
+      >
+        <View
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "overflow": "visible",
+                "paddingBottom": 8,
+                "paddingHorizontal": 20,
+                "paddingTop": 8,
+              },
+              undefined,
+            ]
+          }
+        >
+          <Text
+            numberOfLines={1}
+            style={
+              {
+                "color": "#1D1C1B",
+                "flex": 1,
+                "fontFamily": "Newsreader-Regular",
+                "fontSize": 30,
+                "fontWeight": "400",
+                "letterSpacing": -0.45,
+                "lineHeight": 34,
+                "textAlign": "left",
+              }
+            }
+          >
+            Documents
+          </Text>
+        </View>
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      [
+        {
+          "alignItems": "center",
+          "backgroundColor": "#F7F3EC",
+          "flex": 1,
+          "justifyContent": "center",
+        },
+        null,
+      ]
+    }
+  >
+    <View
+      style={
+        [
+          {
+            "alignItems": "center",
+            "justifyContent": "center",
+            "paddingHorizontal": 20,
+          },
+          undefined,
+        ]
+      }
+      testID="empty-documents"
+    >
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "#E6F2FF",
+            "borderRadius": 9999,
+            "height": 104,
+            "justifyContent": "center",
+            "marginBottom": 20,
+            "width": 104,
+          }
+        }
+      >
+        <Text
+          accessibilityLabel="folder-open-outline"
+          color="#257BED"
+          size={44}
+          testID="icon-folder-open-outline"
+        >
+          folder-open-outline
+        </Text>
+      </View>
+      <Text
+        style={
+          {
+            "color": "#1D1C1B",
+            "fontFamily": "Newsreader-Regular",
+            "fontSize": 24,
+            "fontWeight": "400",
+            "letterSpacing": -0.36,
+            "lineHeight": 29,
+            "textAlign": "center",
+          }
+        }
+      >
+        Add a companion to get started
+      </Text>
+      <Text
+        style={
+          {
+            "color": "#5C5956",
+            "fontFamily": "Satoshi-Regular",
+            "fontSize": 14.5,
+            "fontWeight": "400",
+            "letterSpacing": -0.12,
+            "lineHeight": 20,
+            "marginTop": 8,
+            "textAlign": "center",
+          }
+        }
+      >
+        Insurance papers, lab results and adoption records are tied to a companion. Add one first to start uploading documents.
+      </Text>
+      <View
+        accessibilityLabel="Add a companion"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "alignSelf": "center",
+              "backgroundColor": "#302F2E",
+              "borderRadius": 9999,
+              "flexDirection": "row",
+              "gap": 8,
+              "justifyContent": "center",
+              "marginTop": 24,
+              "minHeight": 54,
+              "paddingHorizontal": 28,
+            },
+            null,
+          ]
+        }
+        testID="empty-documents-action"
+      >
+        <Text
+          accessibilityLabel="add"
+          color="#FFFFFF"
+          size={18}
+          testID="icon-add"
+        >
+          add
+        </Text>
+        <Text
+          style={
+            {
+              "color": "#FFFFFF",
+              "fontFamily": "Satoshi-Medium",
+              "fontSize": 16.5,
+              "fontWeight": "500",
+              "letterSpacing": -0.16,
+              "lineHeight": 24,
+            }
+          }
+        >
+          Add a companion
+        </Text>
+      </View>
+    </View>
+  </View>
+</View>
+`;
 
-exports[`Empty Screen Snapshots GenericEmptyScreen should render with all props 1`] = `null`;
+exports[`Empty Screen Snapshots GenericEmptyScreen should render with all props 1`] = `
+<View
+  style={
+    {
+      "backgroundColor": "#F7F3EC",
+      "flex": 1,
+    }
+  }
+>
+  <RCTScrollView
+    contentContainerStyle={
+      {
+        "flexGrow": 1,
+        "gap": 16,
+        "padding": 24,
+      }
+    }
+    showsVerticalScrollIndicator={false}
+  >
+    <View>
+      <View
+        style={
+          {
+            "backgroundColor": "#F7F3EC",
+            "borderColor": "#E5DCCF",
+            "borderRadius": 16,
+            "borderWidth": 1,
+            "boxShadow": "0px 1px 2px rgba(0,0,0,0.05)",
+            "padding": 24,
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "#302F2E",
+              "fontFamily": "Satoshi-Medium",
+              "fontSize": 26,
+              "fontWeight": "500",
+              "letterSpacing": -0.28,
+              "lineHeight": 33,
+              "marginBottom": 8,
+              "textAlign": "left",
+            }
+          }
+        >
+          No Documents
+        </Text>
+        <Text
+          style={
+            {
+              "color": "#5C5956",
+              "fontFamily": "Satoshi-Regular",
+              "fontSize": 16,
+              "fontWeight": "400",
+              "letterSpacing": -0.16,
+              "lineHeight": 24,
+            }
+          }
+        >
+          Start by adding your first document
+        </Text>
+      </View>
+    </View>
+  </RCTScrollView>
+</View>
+`;
 
-exports[`Empty Screen Snapshots GenericEmptyScreen should render with different icon 1`] = `null`;
+exports[`Empty Screen Snapshots GenericEmptyScreen should render with different icon 1`] = `
+<View
+  style={
+    {
+      "backgroundColor": "#F7F3EC",
+      "flex": 1,
+    }
+  }
+>
+  <RCTScrollView
+    contentContainerStyle={
+      {
+        "flexGrow": 1,
+        "gap": 16,
+        "padding": 24,
+      }
+    }
+    showsVerticalScrollIndicator={false}
+  >
+    <View>
+      <View
+        style={
+          {
+            "backgroundColor": "#F7F3EC",
+            "borderColor": "#E5DCCF",
+            "borderRadius": 16,
+            "borderWidth": 1,
+            "boxShadow": "0px 1px 2px rgba(0,0,0,0.05)",
+            "padding": 24,
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "#302F2E",
+              "fontFamily": "Satoshi-Medium",
+              "fontSize": 26,
+              "fontWeight": "500",
+              "letterSpacing": -0.28,
+              "lineHeight": 33,
+              "marginBottom": 8,
+              "textAlign": "left",
+            }
+          }
+        >
+          No Companions
+        </Text>
+        <Text
+          style={
+            {
+              "color": "#5C5956",
+              "fontFamily": "Satoshi-Regular",
+              "fontSize": 16,
+              "fontWeight": "400",
+              "letterSpacing": -0.16,
+              "lineHeight": 24,
+            }
+          }
+        >
+          Add a companion to get started
+        </Text>
+      </View>
+    </View>
+  </RCTScrollView>
+</View>
+`;
 
-exports[`Empty Screen Snapshots GenericEmptyScreen should render with minimal props 1`] = `null`;
+exports[`Empty Screen Snapshots GenericEmptyScreen should render with minimal props 1`] = `
+<View
+  style={
+    {
+      "backgroundColor": "#F7F3EC",
+      "flex": 1,
+    }
+  }
+>
+  <RCTScrollView
+    contentContainerStyle={
+      {
+        "flexGrow": 1,
+        "gap": 16,
+        "padding": 24,
+      }
+    }
+    showsVerticalScrollIndicator={false}
+  >
+    <View>
+      <View
+        style={
+          {
+            "backgroundColor": "#F7F3EC",
+            "borderColor": "#E5DCCF",
+            "borderRadius": 16,
+            "borderWidth": 1,
+            "boxShadow": "0px 1px 2px rgba(0,0,0,0.05)",
+            "padding": 24,
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "#302F2E",
+              "fontFamily": "Satoshi-Medium",
+              "fontSize": 26,
+              "fontWeight": "500",
+              "letterSpacing": -0.28,
+              "lineHeight": 33,
+              "marginBottom": 8,
+              "textAlign": "left",
+            }
+          }
+        >
+          Empty
+        </Text>
+        <Text
+          style={
+            {
+              "color": "#5C5956",
+              "fontFamily": "Satoshi-Regular",
+              "fontSize": 16,
+              "fontWeight": "400",
+              "letterSpacing": -0.16,
+              "lineHeight": 24,
+            }
+          }
+        >
+          No items found
+        </Text>
+      </View>
+    </View>
+  </RCTScrollView>
+</View>
+`;

--- a/apps/mobileAppYC/__tests__/screens/__snapshots__/PlaceholderScreens.snapshot.test.tsx.snap
+++ b/apps/mobileAppYC/__tests__/screens/__snapshots__/PlaceholderScreens.snapshot.test.tsx.snap
@@ -1,7 +1,317 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`Placeholder Screens Snapshots AppointmentsScreen should render correctly 1`] = `null`;
+exports[`Placeholder Screens Snapshots AppointmentsScreen should render correctly 1`] = `
+<RCTScrollView
+  contentContainerStyle={
+    {
+      "flexGrow": 1,
+      "gap": 16,
+      "padding": 24,
+    }
+  }
+  showsVerticalScrollIndicator={false}
+>
+  <View>
+    <View
+      style={
+        {
+          "backgroundColor": "#F7F3EC",
+          "borderColor": "#E5DCCF",
+          "borderRadius": 16,
+          "borderWidth": 1,
+          "boxShadow": "0px 1px 2px rgba(0,0,0,0.05)",
+          "padding": 24,
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "#302F2E",
+            "fontFamily": "Satoshi-Medium",
+            "fontSize": 26,
+            "fontWeight": "500",
+            "letterSpacing": -0.28,
+            "lineHeight": 33,
+            "marginBottom": 8,
+            "textAlign": "left",
+          }
+        }
+      >
+        Appointments
+      </Text>
+      <Text
+        style={
+          {
+            "color": "#5C5956",
+            "fontFamily": "Satoshi-Regular",
+            "fontSize": 16,
+            "fontWeight": "400",
+            "letterSpacing": -0.16,
+            "lineHeight": 24,
+          }
+        }
+      >
+        Your upcoming veterinary visits will appear here once scheduled.
+      </Text>
+    </View>
+  </View>
+</RCTScrollView>
+`;
 
-exports[`Placeholder Screens Snapshots DocumentsScreen should render correctly 1`] = `null`;
+exports[`Placeholder Screens Snapshots DocumentsScreen should render correctly 1`] = `
+<View>
+  <Text>
+    Empty Documents
+  </Text>
+</View>
+`;
 
-exports[`Placeholder Screens Snapshots TasksMainScreen should render correctly 1`] = `null`;
+exports[`Placeholder Screens Snapshots TasksMainScreen should render correctly 1`] = `
+[
+  <View
+    onLayout={[Function]}
+    style={
+      {
+        "backgroundColor": "transparent",
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+        "zIndex": 2,
+      }
+    }
+  >
+    <View
+      style={
+        {
+          "backgroundColor": "transparent",
+          "borderBottomLeftRadius": 16,
+          "borderBottomRightRadius": 16,
+          "borderTopLeftRadius": 0,
+          "borderTopRightRadius": 0,
+          "elevation": 10,
+          "shadowColor": "rgba(29, 28, 27, 0.10)",
+          "shadowOffset": {
+            "height": 12,
+            "width": 0,
+          },
+          "shadowOpacity": 0.14,
+          "shadowRadius": 18,
+        }
+      }
+    >
+      <View
+        style={
+          {
+            "backgroundColor": "#F1EBE1",
+            "borderBottomLeftRadius": 16,
+            "borderBottomRightRadius": 16,
+            "borderColor": "transparent",
+            "borderRadius": 16,
+            "borderTopLeftRadius": 0,
+            "borderTopRightRadius": 0,
+            "borderWidth": 0,
+            "boxShadow": "none",
+            "overflow": "visible",
+            "padding": 16,
+            "paddingBottom": 12,
+            "paddingHorizontal": 0,
+            "paddingTop": 0,
+          }
+        }
+      >
+        <View
+          style={
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "overflow": "visible",
+                "paddingBottom": 8,
+                "paddingHorizontal": 20,
+                "paddingTop": 8,
+              },
+              undefined,
+            ]
+          }
+        >
+          <Text
+            numberOfLines={1}
+            style={
+              {
+                "color": "#1D1C1B",
+                "flex": 1,
+                "fontFamily": "Newsreader-Regular",
+                "fontSize": 30,
+                "fontWeight": "400",
+                "letterSpacing": -0.45,
+                "lineHeight": 34,
+                "textAlign": "left",
+              }
+            }
+          >
+            tasks.title
+          </Text>
+        </View>
+      </View>
+    </View>
+  </View>,
+  <View
+    style={
+      [
+        {
+          "alignItems": "center",
+          "backgroundColor": "#F7F3EC",
+          "flex": 1,
+          "justifyContent": "center",
+        },
+        null,
+      ]
+    }
+  >
+    <View
+      style={
+        [
+          {
+            "alignItems": "center",
+            "justifyContent": "center",
+            "paddingHorizontal": 20,
+          },
+          undefined,
+        ]
+      }
+      testID="empty-tasks"
+    >
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "#E6F2FF",
+            "borderRadius": 9999,
+            "height": 104,
+            "justifyContent": "center",
+            "marginBottom": 20,
+            "width": 104,
+          }
+        }
+      >
+        <Text
+          accessibilityLabel="checkbox-outline"
+          color="#257BED"
+          size={42}
+          testID="icon-checkbox-outline"
+        >
+          checkbox-outline
+        </Text>
+      </View>
+      <Text
+        style={
+          {
+            "color": "#1D1C1B",
+            "fontFamily": "Newsreader-Regular",
+            "fontSize": 24,
+            "fontWeight": "400",
+            "letterSpacing": -0.36,
+            "lineHeight": 29,
+            "textAlign": "center",
+          }
+        }
+      >
+        tasks.emptyNoCompanionTitle
+      </Text>
+      <Text
+        style={
+          {
+            "color": "#5C5956",
+            "fontFamily": "Satoshi-Regular",
+            "fontSize": 14.5,
+            "fontWeight": "400",
+            "letterSpacing": -0.12,
+            "lineHeight": 20,
+            "marginTop": 8,
+            "textAlign": "center",
+          }
+        }
+      >
+        tasks.emptyNoCompanionDescription
+      </Text>
+      <View
+        accessibilityLabel="tasks.emptyNoCompanionAction"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "alignSelf": "center",
+              "backgroundColor": "#302F2E",
+              "borderRadius": 9999,
+              "flexDirection": "row",
+              "gap": 8,
+              "justifyContent": "center",
+              "marginTop": 24,
+              "minHeight": 54,
+              "paddingHorizontal": 28,
+            },
+            null,
+          ]
+        }
+        testID="empty-tasks-action"
+      >
+        <Text
+          accessibilityLabel="add"
+          color="#FFFFFF"
+          size={18}
+          testID="icon-add"
+        >
+          add
+        </Text>
+        <Text
+          style={
+            {
+              "color": "#FFFFFF",
+              "fontFamily": "Satoshi-Medium",
+              "fontSize": 16.5,
+              "fontWeight": "500",
+              "letterSpacing": -0.16,
+              "lineHeight": 24,
+            }
+          }
+        >
+          tasks.emptyNoCompanionAction
+        </Text>
+      </View>
+    </View>
+  </View>,
+]
+`;

--- a/apps/mobileAppYC/__tests__/setup/snapshotRenderer.tsx
+++ b/apps/mobileAppYC/__tests__/setup/snapshotRenderer.tsx
@@ -1,0 +1,45 @@
+/**
+ * Snapshot rendering helpers for react-test-renderer under React 19.
+ *
+ * Kept out of testUtils.tsx so that file stays untouched: it is not currently
+ * prettier-formatted, so any edit there reformats ~300 unrelated lines.
+ */
+
+import {ReactElement} from 'react';
+import renderer from 'react-test-renderer';
+
+let mountedTrees: renderer.ReactTestRenderer[] = [];
+
+/**
+ * Render a tree for snapshotting.
+ *
+ * `renderer.create()` schedules the initial render asynchronously, so calling
+ * `toJSON()` immediately after it returns `null`. Suites that did so committed
+ * `null` snapshots and were therefore asserting that nothing rendered - no UI
+ * change could ever fail them. Creating inside `act` drains the initial render
+ * before the tree is serialised.
+ *
+ * The tree is retained so `cleanupSnapshotTrees` can unmount it even when the
+ * snapshot assertion throws. That matters: React 19 keeps scheduler work queued
+ * for a tree that is never unmounted, and from Jest 30 that work firing after
+ * the environment is torn down fails whichever suite the worker picks up next.
+ */
+export const renderSnapshot = (ui: ReactElement) => {
+  let tree!: renderer.ReactTestRenderer;
+  renderer.act(() => {
+    tree = renderer.create(ui);
+  });
+  mountedTrees.push(tree);
+  return tree.toJSON();
+};
+
+/** Unmount every tree `renderSnapshot` created. Call from `afterEach`. */
+export const cleanupSnapshotTrees = () => {
+  const trees = mountedTrees;
+  mountedTrees = [];
+  for (const tree of trees) {
+    renderer.act(() => {
+      tree.unmount();
+    });
+  }
+};


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

The `apps/mobileAppYC` Jest suite (`pnpm --filter mobileAppYC exec jest --ci --maxWorkers=2`) has a systemic test-isolation flake: one random test fails per full parallel run while passing in isolation, reddening the "CI for affected workspaces (mobileAppYC)" and "SonarQube Analysis - mobile" jobs on every mobile PR.

Root cause: three pre-existing tests create component trees with react-test-renderer's `renderer.create(...)` but never await their async mount work or unmount the tree. React Native Testing Library auto-cleanup only unmounts trees created via `render()`, so these leak - the async work resolves after the test finishes and commits deferred React updates into whichever suite runs next on the same worker (maxWorkers=2). The deferred commit throws (for example `window.dispatchEvent is not a function` from react-test-renderer's global error path) and jest-circus attributes it to the currently-running sibling test, a different one each run.

Leaking tests:

- `__tests__/App.test.tsx` - `<App />`'s startup effect (mobile-config fetch via axios, AsyncStorage reads, reducer dispatches, PersistGate rehydration) resolves after the test ends.
- `__tests__/screens/PlaceholderScreens.snapshot.test.tsx` - screen mount work renders after the Jest environment is torn down.
- `__tests__/screens/EmptyScreens.snapshot.test.tsx` - renders `GenericEmptyScreen` without a redux Provider, so `useTheme` -> `useAppDispatch` throws and the error leaks asynchronously (the stored snapshots were all `null`).

## What is the new behavior?

Each leaking test now drains its pending async work inside `act()` and unmounts the tree before finishing:

- App.test.tsx: mock `fetchMobileConfig` so startup is deterministic, drain inside `act()`, then unmount the tree.
- PlaceholderScreens.snapshot.test.tsx: drain pending work and unmount after capturing each snapshot.
- EmptyScreens.snapshot.test.tsx: render under a redux `Provider` (matching the sibling snapshot test), then drain and unmount. Snapshots regenerate identically (no churn).

No `jest.retryTimes` and no masking - the root async leak is fixed.

Validation on a clean `origin/dev` checkout (`--ci --maxWorkers=2`):

- Pre-fix: reproduced the flake (a random test fails, four "Cannot log after tests are done" warnings, uncaught `window.dispatchEvent` errors).
- Post-fix: 5 consecutive full runs green (6274 tests, 424 suites) with zero post-teardown log or error leaks.

Impact area: `apps/mobileAppYC` test suite only. No production code changed. Fixes the CI flake for all mobile PRs, including #1792 on its next rebase onto dev.

## Related Issue(s)

Fixes #1822
