### PR TITLE
feat(frontend): show avatar, specialty and today count in planner headers

### DIFF
--- a/apps/frontend/src/app/__tests__/components/Calendar/common/CalendarTeamNamesRow.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/common/CalendarTeamNamesRow.test.tsx
@@ -4,14 +4,21 @@ import '@testing-library/jest-dom';
 import { CalendarTeamNamesRow } from '@/app/features/appointments/components/Calendar/common/CalendarTeamNamesRow';
 import type { Team } from '@/app/features/organization/types/team';
 
+const mockUserLabelsSpy = jest.fn();
+
 jest.mock('@/app/features/appointments/components/Calendar/common/UserLabels', () => ({
   __esModule: true,
-  default: ({ team }: { team: Team[] }) => (
-    <div data-testid="user-labels">{team.map((member) => member.name).join(',')}</div>
-  ),
+  default: (props: { team: Team[]; appointmentCounts?: Record<string, number> }) => {
+    mockUserLabelsSpy(props);
+    return <div data-testid="user-labels">{props.team.map((member) => member.name).join(',')}</div>;
+  },
 }));
 
 describe('CalendarTeamNamesRow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   const team = [
     { _id: '1', name: 'Dr. Sarah Weber' },
     { _id: '2', name: 'Dr. Matteo Brunner' },
@@ -33,5 +40,19 @@ describe('CalendarTeamNamesRow', () => {
     const band = container.firstChild as HTMLElement;
     expect(band.style.background).toContain('var(--screen)');
     expect(band.style.background).not.toContain('white');
+  });
+
+  it('forwards per-practitioner appointment counts to the user labels', () => {
+    render(
+      <CalendarTeamNamesRow
+        team={team}
+        teamColumnsStyle={{}}
+        appointmentCounts={{ '1': 4, '2': 0 }}
+      />
+    );
+
+    expect(mockUserLabelsSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ appointmentCounts: { '1': 4, '2': 0 } })
+    );
   });
 });

--- a/apps/frontend/src/app/__tests__/components/Calendar/common/UserCalendar.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/common/UserCalendar.test.tsx
@@ -9,10 +9,12 @@ jest.mock('@/app/hooks/useTeam', () => ({
 }));
 
 const mockAppointmentsForUser = jest.fn();
+const mockCountForUser = jest.fn();
 jest.mock('@/app/features/appointments/components/Calendar/helpers', () => ({
   DEFAULT_CALENDAR_FOCUS_MINUTES: 540,
   EVENT_VERTICAL_GAP_PX: 2,
   appointentsForUser: (...args: any[]) => mockAppointmentsForUser(...args),
+  countAppointmentsForUserOnDay: (...args: any[]) => mockCountForUser(...args),
   computeUnavailableSegments: jest.fn(() => []),
   getFirstRelevantTimedEventStart: jest.fn(() => null),
   getNowTopPxForHourRange: jest.fn((_: Date, __: number, ___: number, height: number) => height),
@@ -82,7 +84,7 @@ describe('UserCalendar (Appointments)', () => {
   const setCurrentDate = jest.fn();
 
   const team = [
-    { _id: 'u1', name: 'Alex' },
+    { _id: 'u1', practionerId: 'p1', name: 'Alex' },
     { _id: 'u2', name: 'Sam' },
   ];
 
@@ -92,6 +94,7 @@ describe('UserCalendar (Appointments)', () => {
     jest.clearAllMocks();
     (useTeamForPrimaryOrg as jest.Mock).mockReturnValue(team);
     mockAppointmentsForUser.mockReturnValue(events);
+    mockCountForUser.mockImplementation((_events: any, user: any) => (user._id === 'u1' ? 2 : 5));
   });
 
   it('renders user labels and slots per team member', () => {
@@ -108,6 +111,9 @@ describe('UserCalendar (Appointments)', () => {
 
     expect(screen.getByTestId('user-labels')).toBeInTheDocument();
     expect(userLabelsSpy).toHaveBeenCalledWith(expect.objectContaining({ team }));
+    expect(userLabelsSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ appointmentCounts: { p1: 2, u2: 5 } })
+    );
 
     const slots = screen.getAllByTestId('slot');
     expect(slots.length).toBeGreaterThanOrEqual(team.length);

--- a/apps/frontend/src/app/__tests__/components/Calendar/common/UserLabels.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/common/UserLabels.test.tsx
@@ -92,3 +92,89 @@ describe('UserLabels', () => {
     expect(screen.getByText('Alex')).toHaveClass('text-text-secondary');
   });
 });
+
+describe('UserLabels (team-day planner header)', () => {
+  const team: Team[] = [
+    {
+      _id: 't1',
+      name: 'Alex Kim',
+      practionerId: 'user-1',
+      organisationId: 'org-1',
+      role: 'VETERINARIAN',
+      speciality: [{ organisationId: 'org-1', name: 'Cardiology' }],
+      status: 'Available',
+      revokedPermissions: [],
+      effectivePermissions: [],
+      extraPerissions: [],
+    },
+    {
+      _id: 't2',
+      name: 'Sam Lee',
+      practionerId: 'user-2',
+      organisationId: 'org-1',
+      role: 'TECHNICIAN',
+      speciality: [],
+      status: 'Available',
+      revokedPermissions: [],
+      effectivePermissions: [],
+      extraPerissions: [],
+    },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useAuthStoreMock.mockReturnValue({ attributes: { sub: 'user-1' } });
+  });
+
+  it('renders avatar initials, name, specialty and today count when counts are provided', () => {
+    render(<UserLabels team={team} appointmentCounts={{ 'user-1': 3, 'user-2': 0 }} />);
+
+    expect(screen.getByText('Alex Kim')).toBeInTheDocument();
+    expect(screen.getByText('AK')).toBeInTheDocument();
+    expect(screen.getByText('Cardiology')).toBeInTheDocument();
+    expect(screen.getByText('3 today')).toBeInTheDocument();
+    expect(screen.getByText('0 today')).toBeInTheDocument();
+  });
+
+  it('falls back to the humanized role when a practitioner has no specialty', () => {
+    render(<UserLabels team={team} appointmentCounts={{}} />);
+
+    expect(screen.getByText('Technician')).toBeInTheDocument();
+  });
+
+  it('defaults the count to zero when a practitioner is absent from the counts map', () => {
+    render(<UserLabels team={team} appointmentCounts={{}} />);
+
+    expect(screen.getAllByText('0 today')).toHaveLength(2);
+  });
+
+  it('highlights the current user name and leaves others as primary text', () => {
+    useAuthStoreMock.mockReturnValue({ attributes: { email: 'user-2' } });
+
+    render(<UserLabels team={team} appointmentCounts={{ 'user-1': 1, 'user-2': 2 }} />);
+
+    expect(screen.getByText('Sam Lee')).toHaveClass('text-(--color-primary-700)');
+    expect(screen.getByText('Alex Kim')).toHaveClass('text-text-primary');
+  });
+
+  it('handles a member without a name and falls back to _id for the count key', () => {
+    const teamWithGaps: Team[] = [
+      {
+        _id: 't3',
+        practionerId: '',
+        organisationId: 'org-1',
+        role: 'RECEPTIONIST',
+        speciality: [],
+        status: 'Available',
+        revokedPermissions: [],
+        effectivePermissions: [],
+        extraPerissions: [],
+      },
+    ];
+
+    render(<UserLabels team={teamWithGaps} appointmentCounts={{ t3: 7 }} />);
+
+    expect(screen.getByText('Receptionist')).toBeInTheDocument();
+    expect(screen.getByText('7 today')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/__tests__/components/Calendar/helpers.test.ts
+++ b/apps/frontend/src/app/__tests__/components/Calendar/helpers.test.ts
@@ -15,12 +15,14 @@ import {
   getNowTopPxForHourRange,
   isAllDayForDate,
   eventsForDay,
+  countAppointmentsForUserOnDay,
   scrollContainerToTarget,
   PIXELS_PER_STEP,
   MINUTES_PER_STEP,
 } from '@/app/features/appointments/components/Calendar/helpers';
 import { Appointment } from '@yosemite-crew/types';
 import { Task } from '@/app/features/tasks/types/task';
+import { Team } from '@/app/features/organization/types/team';
 
 jest.mock('@/app/lib/timezone', () => ({
   getMinutesSinceStartOfDayInPreferredTimeZone: (date: Date) =>
@@ -399,6 +401,53 @@ describe('Calendar Helpers', () => {
       const res = eventsForDay(tasks, day);
       expect(res).toHaveLength(1);
       expect(res[0].dueAt.getDate()).toBe(1);
+    });
+  });
+
+  describe('countAppointmentsForUserOnDay', () => {
+    const day = new Date(2023, 0, 1);
+    const user = { practionerId: 'p1' } as Team;
+
+    const leadAppt = (startTime: Date): Appointment =>
+      ({ startTime, lead: { id: 'p1' } }) as unknown as Appointment;
+
+    it('counts the practitioner lead appointments on the day', () => {
+      const events = [leadAppt(new Date(2023, 0, 1, 9, 0)), leadAppt(new Date(2023, 0, 1, 14, 0))];
+      expect(countAppointmentsForUserOnDay(events, user, day)).toBe(2);
+    });
+
+    it('counts appointments where the practitioner is support staff', () => {
+      const events = [
+        {
+          startTime: new Date(2023, 0, 1, 9, 0),
+          lead: { id: 'someone-else' },
+          supportStaff: [{ id: 'p1' }],
+        },
+      ] as unknown as Appointment[];
+      expect(countAppointmentsForUserOnDay(events, user, day)).toBe(1);
+    });
+
+    it('excludes appointments on other days', () => {
+      const events = [leadAppt(new Date(2023, 0, 1, 9, 0)), leadAppt(new Date(2023, 0, 2, 9, 0))];
+      expect(countAppointmentsForUserOnDay(events, user, day)).toBe(1);
+    });
+
+    it('excludes appointments for other practitioners', () => {
+      const events = [
+        { startTime: new Date(2023, 0, 1, 9, 0), lead: { id: 'someone-else' }, supportStaff: [] },
+      ] as unknown as Appointment[];
+      expect(countAppointmentsForUserOnDay(events, user, day)).toBe(0);
+    });
+
+    it('counts a multi-hour appointment once', () => {
+      const events = [
+        {
+          startTime: new Date(2023, 0, 1, 9, 0),
+          endTime: new Date(2023, 0, 1, 12, 0),
+          lead: { id: 'p1' },
+        },
+      ] as unknown as Appointment[];
+      expect(countAppointmentsForUserOnDay(events, user, day)).toBe(1);
     });
   });
 });

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/CalendarDayHeader.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/CalendarDayHeader.tsx
@@ -41,6 +41,7 @@ type CalendarDayHeaderProps = {
   teamColumnsStyle: React.CSSProperties;
   onPrevDay: () => void;
   onNextDay: () => void;
+  appointmentCounts?: Record<string, number>;
 };
 
 const CalendarDayHeader = ({
@@ -50,6 +51,7 @@ const CalendarDayHeader = ({
   teamColumnsStyle,
   onPrevDay,
   onNextDay,
+  appointmentCounts,
 }: CalendarDayHeaderProps) => (
   <div className="min-w-max bg-neutral-0 shrink-0">
     <CalendarDayNav
@@ -58,7 +60,11 @@ const CalendarDayHeader = ({
       onPrevDay={onPrevDay}
       onNextDay={onNextDay}
     />
-    <CalendarTeamNamesRow team={team} teamColumnsStyle={teamColumnsStyle} />
+    <CalendarTeamNamesRow
+      team={team}
+      teamColumnsStyle={teamColumnsStyle}
+      appointmentCounts={appointmentCounts}
+    />
   </div>
 );
 

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/CalendarTeamNamesRow.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/CalendarTeamNamesRow.tsx
@@ -5,15 +5,20 @@ import { Team } from '@/app/features/organization/types/team';
 type CalendarTeamNamesRowProps = {
   team: Team[];
   teamColumnsStyle: React.CSSProperties;
+  appointmentCounts?: Record<string, number>;
 };
 
-export const CalendarTeamNamesRow = ({ team, teamColumnsStyle }: CalendarTeamNamesRowProps) => (
+export const CalendarTeamNamesRow = ({
+  team,
+  teamColumnsStyle,
+  appointmentCounts,
+}: CalendarTeamNamesRowProps) => (
   <div
     className="grid grid-cols-[64px_minmax(0,1fr)_64px] border-b border-grey-light min-w-max"
     style={{ background: 'color-mix(in srgb, var(--color-brand-100) 55%, var(--screen))' }}
   >
     <div className="sticky left-0 z-30" style={{ background: 'inherit' }} />
-    <UserLabels team={team} columnsStyle={teamColumnsStyle} />
+    <UserLabels team={team} columnsStyle={teamColumnsStyle} appointmentCounts={appointmentCounts} />
     <div className="sticky right-0 z-30" style={{ background: 'inherit' }} />
   </div>
 );

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/UserCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/UserCalendar.tsx
@@ -3,6 +3,7 @@ import { useWheelToHorizontalScroll } from '@/app/hooks/useWheelToHorizontalScro
 import {
   computeUnavailableSegments,
   appointentsForUser,
+  countAppointmentsForUserOnDay,
   DEFAULT_CALENDAR_FOCUS_MINUTES,
   getFirstRelevantTimedEventStart,
   getNowTopPxForHourRange,
@@ -118,6 +119,13 @@ const UserCalendar: React.FC<UserCalendarProps> = ({
     () => getCalendarColumnGridStyle(team.length, zoomMode === 'out' ? 108 : 170),
     [team.length, zoomMode]
   );
+  const appointmentCountByPractitioner = useMemo(() => {
+    const counts: Record<string, number> = {};
+    team.forEach((user) => {
+      counts[user.practionerId || user._id] = countAppointmentsForUserOnDay(events, user, date);
+    });
+    return counts;
+  }, [team, events, date]);
   const weekday = formatDateInPreferredTimeZone(date, { weekday: 'short' });
   const dateNumber = formatDateInPreferredTimeZone(date, { day: 'numeric' });
 
@@ -236,6 +244,7 @@ const UserCalendar: React.FC<UserCalendarProps> = ({
             teamColumnsStyle={teamColumnsStyle}
             onPrevDay={handlePrevDay}
             onNextDay={handleNextDay}
+            appointmentCounts={appointmentCountByPractitioner}
           />
 
           <div

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/UserLabels.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/UserLabels.tsx
@@ -1,30 +1,70 @@
 import { Team } from '@/app/features/organization/types/team';
 import { useAuthStore } from '@/app/stores/authStore';
+import AppointmentAvatar from '@/app/features/appointments/components/AppointmentCentralModal/AppointmentAvatar';
+import clsx from 'clsx';
 import React from 'react';
 
-type UserLabels = {
+type UserLabelsProps = {
   team: Team[];
   columnsStyle?: React.CSSProperties;
+  appointmentCounts?: Record<string, number>;
 };
 
-const UserLabels = ({ team, columnsStyle }: UserLabels) => {
+const humanizeRole = (role: string): string =>
+  role
+    .toLowerCase()
+    .split(/[_\s]+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+
+const UserLabels = ({ team, columnsStyle, appointmentCounts }: UserLabelsProps) => {
   const { attributes } = useAuthStore();
   const currentUserId = attributes?.sub || attributes?.email;
+  const showDetails = appointmentCounts !== undefined;
 
   return (
-    <div className="grid min-w-max py-1.5" style={columnsStyle}>
+    <div className="grid min-w-max py-2" style={columnsStyle}>
       {team.map((user, idx) => {
         const isCurrentUser = !!currentUserId && user.practionerId === currentUserId;
-        return (
-          <div
-            key={`${idx}-${user._id || user.practionerId || user.name}`}
-            className="flex items-center justify-center flex-col"
-          >
-            <div
-              className={`text-body-4 font-medium ${isCurrentUser ? 'text-(--color-primary-700)' : 'text-text-secondary'}`}
-            >
-              {user.name || ''}
+        const name = user.name || '';
+        const key = `${idx}-${user._id || user.practionerId || name}`;
+
+        if (!showDetails) {
+          return (
+            <div key={key} className="flex items-center justify-center flex-col">
+              <div
+                className={clsx(
+                  'text-body-4 font-medium',
+                  isCurrentUser ? 'text-(--color-primary-700)' : 'text-text-secondary'
+                )}
+              >
+                {name}
+              </div>
             </div>
+          );
+        }
+
+        const specialityLabel = user.speciality[0]?.name.trim() || humanizeRole(user.role);
+        const count = appointmentCounts[user.practionerId || user._id] ?? 0;
+
+        return (
+          <div key={key} className="flex flex-col items-center gap-1 px-2 min-w-0 text-center">
+            <AppointmentAvatar name={name} photoUrl={user.image} size={28} />
+            <div className="w-full min-w-0">
+              <div
+                className={clsx(
+                  'text-caption-1 truncate',
+                  isCurrentUser ? 'text-(--color-primary-700)' : 'text-text-primary'
+                )}
+              >
+                {name}
+              </div>
+              <div className="text-caption-2 text-text-secondary truncate">{specialityLabel}</div>
+            </div>
+            <span className="inline-flex items-center rounded-full bg-card-bg px-2 py-0.5 text-caption-2 text-text-secondary whitespace-nowrap">
+              {count} today
+            </span>
           </div>
         );
       })}

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/UserLabels.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/UserLabels.tsx
@@ -25,10 +25,10 @@ const UserLabels = ({ team, columnsStyle, appointmentCounts }: UserLabelsProps) 
 
   return (
     <div className="grid min-w-max py-2" style={columnsStyle}>
-      {team.map((user, idx) => {
+      {team.map((user) => {
         const isCurrentUser = !!currentUserId && user.practionerId === currentUserId;
         const name = user.name || '';
-        const key = `${idx}-${user._id || user.practionerId || name}`;
+        const key = user._id || user.practionerId || name;
 
         if (!showDetails) {
           return (

--- a/apps/frontend/src/app/features/appointments/components/Calendar/helpers.ts
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/helpers.ts
@@ -353,6 +353,16 @@ export function appointentsForUser(events: Appointment[], user: Team): Appointme
   });
 }
 
+export function countAppointmentsForUserOnDay(
+  events: Appointment[],
+  user: Team,
+  day: Date
+): number {
+  return appointentsForUser(events, user).filter((event) =>
+    isOnPreferredTimeZoneCalendarDay(event.startTime, day)
+  ).length;
+}
+
 export type AvailabilityInterval = { startMinute: number; endMinute: number };
 
 export function computeUnavailableSegments(


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

In the appointments team-day planner, each practitioner column header renders only the practitioner name. The Appointments design handoff ("Calendar - team day view") calls for avatar, name, a specialty subtitle, and a per-practitioner "N today" appointment count.

## What is the new behavior?

Each planner column header now renders:

- Avatar (initials, or photo when available), via the existing `AppointmentAvatar` primitive
- Name
- Specialty subtitle from `speciality[0].name`, falling back to a humanized role when no specialty is set
- A "N today" pill with that practitioner's appointment count for the visible day

Plumbing:

- New pure helper `countAppointmentsForUserOnDay(events, user, day)` in `Calendar/helpers.ts`. It counts each of a practitioner's appointments once by start day, using the same tz-aware day check the grid uses, so multi-hour appointments are not double counted.
- `UserCalendar` memoizes a per-practitioner count map from the appointments it already holds and threads it through `CalendarDayHeader` and `CalendarTeamNamesRow` into `UserLabels`.

Scope guard:

- `CalendarDayHeader` is shared with the tasks calendar. The enriched layout is gated on the `appointmentCounts` prop, so the tasks header (which passes no counts) keeps its original name-only label. Its tests remain green unchanged.

## Impact area

- apps/frontend, appointments team-day planner header only. No change to appointment rendering, slots, availability, or the now-line logic.

## Validation performed

- Tests: 82 passing across the touched Calendar suites (including the tasks calendar suites). Touched-file coverage held or improved: `UserLabels`, `CalendarDayHeader`, `CalendarTeamNamesRow` at 100 percent; the new helper fully covered; `UserCalendar` branch coverage improved.
- `tsc --noEmit` clean, eslint clean, Aikido SAST and secrets scan 0 findings.
- Browser QA in Storybook with the real components: header renders per the handoff in light and dark (tokens flip correctly, specialty subtitle and count pill legible, role fallback works). Confirmed the taller header does not disturb now-line and hour-grid alignment (now-line and its hour gridline coincide at the same offset), because the header is a flex sibling above the independently scrolling grid body.

## Related Issue(s)

Fixes #1839

## Notes for reviewers

This PR is stacked on `feat/frontend-pims-warm-bone` (#1799) because the header depends on that branch's dark-mode header surfaces. The base will be retargeted to `dev` once #1799 merges. The diff against the warm-bone base is limited to the nine files of this change.
