### PR TITLE
ci(repo): group remaining Dependabot updates into single PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,16 @@ updates:
           - 'prettier'
           - 'husky'
           - 'lint-staged'
+      # Catch-all. Must stay LAST: a dependency joins the first group it
+      # matches, so an earlier '*' would swallow the named groups above.
+      # Minor and patch only, so major bumps still get an individual PR
+      # and an individual review.
+      minor-and-patch:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -49,3 +59,12 @@ updates:
     labels:
       - dependencies
       - github-actions
+    groups:
+      # Action majors are routinely breaking, so keep them out of the group
+      # and let each land on its own.
+      actions:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

`.github/dependabot.yml` groups three dependency families for the `npm` ecosystem (`typescript-eslint`, `testing`, `build-tooling`) and groups nothing at all for `github-actions`. Dependabot's documented default is that "any outdated dependencies that do not match a rule are updated in individual pull requests", so every other dependency gets its own PR.

The most recent weekly run produced 7 single-dependency PRs (#1809 through #1815) next to the 3 grouped ones. Each triggers the same full PR matrix of roughly 22 jobs, and all 7 were closed without merging.

## What is the new behavior?

Adds a catch-all group to both ecosystems in `.github/dependabot.yml`:

- `npm`: `minor-and-patch`, matching `*`, limited to `minor` and `patch`, defined last.
- `github-actions`: `actions`, matching `*`, limited to `minor` and `patch`.

Ungrouped minor and patch updates now arrive as one PR per ecosystem instead of one per dependency.

Two deliberate constraints, both recorded as comments in the file so they survive future edits:

- The catch-all is defined **last**. Dependabot places a dependency in the first group it matches, so an earlier `*` would swallow the three named groups.
- Majors are excluded from both groups, so a breaking bump still gets its own PR and its own review.

Nothing else changes: the named groups, schedule, `target-branch`, `open-pull-requests-limit`, labels, and commit prefixes are all untouched.

**Impact area:** CI and repository configuration. No product or runtime code.

**Validation performed:**

- `.github/dependabot.yml` parsed and asserted: valid YAML, `version: 2`, every `*` group is last within its ecosystem, and all group identifiers satisfy Dependabot's documented naming rule (start and end with a letter).
- Aikido SAST and secrets scan: 0 findings.
- Config-only change, so there is no test or type surface to exercise.

## Related Issue(s)

Fixes #1855
