### PR TITLE
docs(repo): rewrite README as a comprehensive platform overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,23 @@
   </a>
 </p>
 
-<h1 align="center" >Open-Source Operating System for Animal Health</h1>
+<h1 align="center">Open-Source Operating System for Animal Health</h1>
+
+<p align="center">
+  <b>A free, fully customizable Practice Information Management System</b><br />
+  and the open platform that grows around it.
+</p>
+
+<p align="center">
+  Built for the clinics that carry animal health, the families who depend on them,<br />
+  and the developers extending both.
+</p>
 
 <div align="center">
 
 [![Website](https://img.shields.io/badge/Yosemite%20Crew-D04122)](https://yosemitecrew.com/) [![Contributing](https://img.shields.io/badge/Contribute-FF9800)](https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md) [![Github License](https://img.shields.io/badge/License-4CAF50)](https://github.com/YosemiteCrew/Yosemite-Crew/tree/main?tab=License-1-ov-file) [![Figma](https://img.shields.io/badge/Figma-383838?logo=figma)](https://www.figma.com/design/NAAV4XGcJ6FlGXGK68AUbp/Yosemite-Crew?node-id=0-1&t=qCMi0h3RReIRMkrK-1) [![Discord](https://img.shields.io/discord/1325181058777616395?color=7289da&label=Discord&logo=discord&logoColor=ffffff)](https://discord.gg/SwM6mX85KD) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/YosemiteCrew/Yosemite-Crew)
 
 </div>
-
 <br>
 
 https://github.com/user-attachments/assets/5c01ce0a-2c84-4200-85b5-96eff488e113
@@ -30,27 +39,151 @@ https://github.com/user-attachments/assets/5c01ce0a-2c84-4200-85b5-96eff488e113
 | Code Smells  | [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=yosemitecrew_Yosemite-Crew_Backend&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=yosemitecrew_Yosemite-Crew_Backend)               | [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=yosemitecrew_Yosemite-Crew_Frontend&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=yosemitecrew_Yosemite-Crew_Frontend)               | [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=yosemitecrew_Yosemite-Crew_MobileAppYC&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=yosemitecrew_Yosemite-Crew_MobileAppYC)               | [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=yosemitecrew_Yosemite-Crew_Desktop&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=yosemitecrew_Yosemite-Crew_Desktop)               |
 | Reliability  | [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=yosemitecrew_Yosemite-Crew_Backend&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=yosemitecrew_Yosemite-Crew_Backend) | [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=yosemitecrew_Yosemite-Crew_Frontend&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=yosemitecrew_Yosemite-Crew_Frontend) | [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=yosemitecrew_Yosemite-Crew_MobileAppYC&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=yosemitecrew_Yosemite-Crew_MobileAppYC) | [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=yosemitecrew_Yosemite-Crew_Desktop&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=yosemitecrew_Yosemite-Crew_Desktop) |
 
+# 📖 Contents
+
+- [Overview](#-overview)
+- [Who It Is For](#-who-it-is-for)
+- [Architecture](#-architecture)
+- [Inside the Monorepo](#-inside-the-monorepo)
+- [Installation](#-installation)
+- [Our Tech Stack](#-our-tech-stack)
+- [Engineering Quality](#-engineering-quality)
+- [Documentation](#-documentation)
+- [Dev Environment Access](#-dev-environment-access)
+- [Join Our Growing Community](#-join-our-growing-community)
+- [License](#-license)
+
+<br>
+
 # 📝 Overview
 
-Yosemite Crew is an open-source operating system designed for animal health industry. At its core is a free, fully customizable Practice Information Management System (PIMS) that unifies pet care operations, bringing together pet owners, pet businesses, and developers into one innovative ecosystem.
+Yosemite Crew is an open-source operating system for the animal health industry. At its core is a free, fully customizable Practice Information Management System (PIMS) that unifies pet care operations, bringing together pet owners, pet businesses, and developers into one ecosystem.
 
-For Pet Owners
+Most veterinary software asks a clinic to bend around the vendor: rigid subscriptions, closed data, and a roadmap someone else owns. Yosemite Crew inverts that. The clinical record is yours, the schema is open, the integration surface speaks [FHIR R4](https://hl7.org/fhir/R4/), and the entire platform is yours to fork, extend, or run yourself.
 
-- **Ultimate Convenience:** A user-friendly mobile app enables pet owners to effortlessly schedule appointments, conduct virtual consultations, manage pet health records, and access a wealth of resources.
-- **Enhanced Accessibility:** Whether in remote locations or facing mobility challenges, pet owners can tap into quality veterinary care anytime, anywhere.
+It is one monorepo spanning four products: a web PIMS for clinics, a mobile app for pet parents, a desktop shell, and a developer platform.
 
-For Veterinary Clinics and Pet Care Providers
+<br>
 
-- **Streamlined Efficiency:** Yosemite Crew simplifies appointment scheduling and enhances communication, reducing administrative burdens and boosting overall productivity.
-- **Customization & Integration:** As an open-source solution, the platform offers unmatched flexibility, allowing clinics to tailor the system to their unique needs without being locked into rigid subscription models. Seamless integration with existing systems further reduces barriers to adoption.
-- **Robust Security & Compliance:** With comprehensive data management, reporting capabilities, and adherence to regulatory standards, the system ensures that sensitive information remains secure and that clinics can make informed, data-driven decisions.
-- **Scalability & Support:** Designed to grow alongside veterinary practices, Yosemite Crew is scalable and supported by regular updates and a vibrant community of contributors, ensuring the platform remains state-of-the-art.
+# 👥 Who It Is For
 
-For Developers
+<table>
+<tr>
+<td width="33%" valign="top">
 
-- **Empowering Innovation:** The dedicated developer portal is at the heart of an ecosystem that mirrors the versatility of the WordPress plugin model.
-- **Flexible Development Environment:** Equipped with robust public APIs, comprehensive documentation, and ready-to-use MVP templates, developers can quickly create, install, and manage custom plugins that extend the platform's core functionalities.
-- **Community-Driven Growth:** This open-source approach fosters a collaborative environment where developers can continuously innovate and expand veterinary care options, driving the evolution of animal healthcare technology.
+### 🐾 Pet Owners
+
+**Ultimate convenience.** A mobile app to schedule appointments, hold virtual consultations, manage health records, and reach a library of care resources.
+
+**Enhanced accessibility.** Whether in remote locations or facing mobility challenges, quality veterinary care stays reachable anytime, anywhere.
+
+</td>
+<td width="33%" valign="top">
+
+### 🏥 Clinics & Providers
+
+**Streamlined efficiency.** Scheduling and communication that cut administrative load instead of adding to it.
+
+**Customization & integration.** Open source means no rigid subscription lock-in, and a system you can shape to how your practice actually works.
+
+**Security & compliance.** Comprehensive data management, reporting, and adherence to regulatory standards.
+
+**Scalability & support.** Built to grow with your practice, backed by regular updates and a community of contributors.
+
+</td>
+<td width="33%" valign="top">
+
+### 💻 Developers
+
+**Empowering innovation.** A developer portal at the heart of an ecosystem that mirrors the versatility of the WordPress plugin model.
+
+**Flexible environment.** Public APIs, documentation, and ready-to-use templates for building and managing plugins that extend the core.
+
+**Community-driven growth.** A collaborative environment where contributors keep expanding what veterinary care software can do.
+
+</td>
+</tr>
+</table>
+
+<br>
+
+# 🏛 Architecture
+
+Four clients, one API, one source of truth. Every product in the repo speaks to the same Express service and the same Postgres schema.
+
+```mermaid
+%%{init: {"theme":"base","themeVariables":{"fontFamily":"ui-sans-serif, -apple-system, Segoe UI, Helvetica, Arial, sans-serif","primaryColor":"#ffffff","primaryTextColor":"#1d1c1b","primaryBorderColor":"#bfbfbe","lineColor":"#a09f9f","clusterBkg":"#f7f7f7","clusterBorder":"#eaeaea","fontSize":"14px"}}}%%
+flowchart LR
+    subgraph clients ["Clients"]
+        WEB["Web PIMS<br/><sub>Next.js 15 · React 19</sub>"]
+        MOB["Mobile App<br/><sub>React Native 0.81</sub>"]
+        DESK["Desktop Shell<br/><sub>Electron</sub>"]
+        EXT["Your Integration<br/><sub>FHIR R4 · public APIs</sub>"]
+    end
+
+    subgraph platform ["Platform"]
+        API["Express API<br/><sub>REST + FHIR routers</sub>"]
+        RT["Socket.IO<br/><sub>realtime</sub>"]
+        JOBS["BullMQ Workers<br/><sub>reminders · labs · schedules</sub>"]
+    end
+
+    subgraph data ["Data & Services"]
+        PG[("Supabase Postgres<br/><sub>Prisma · schema per tenant</sub>")]
+        REDIS[("Redis<br/><sub>queue backing store</sub>")]
+        AWS["AWS<br/><sub>Cognito · S3 · SES · Pinpoint</sub>"]
+        LABS["Lab & Partner<br/><sub>IDEXX · Merck</sub>"]
+    end
+
+    WEB --> API
+    MOB --> API
+    DESK --> API
+    EXT --> API
+
+    API <--> RT
+    API --> JOBS
+    API --> PG
+    API --> AWS
+    JOBS --> REDIS
+    JOBS --> PG
+    JOBS --> LABS
+
+    classDef accent fill:#f2f8ff,stroke:#247aed,stroke-width:1.5px,color:#1d1c1b
+    classDef store fill:#f7f7f7,stroke:#a09f9f,color:#1d1c1b
+    class API,EXT accent
+    class PG,REDIS store
+```
+
+**Postgres is the source of truth.** Prisma Migrate owns the schema, and tenant data is isolated by Postgres schema rather than by a filter column, so one clinic's records cannot leak into another's through a forgotten `WHERE`. See [ADR 0001](./docs/adr/0001-postgres-prisma-source-of-truth.md).
+
+**FHIR R4 is a first-class surface,** not an export button. Clinical artifacts, tasks, templates, and rendered documents have FHIR-shaped routes, so an integrator can talk to Yosemite Crew in a vocabulary the wider health ecosystem already speaks.
+
+<br>
+
+# 🗂 Inside the Monorepo
+
+A pnpm + Turborepo workspace. Apps ship; packages are the shared spine underneath them.
+
+### Apps
+
+| App                | What it is                                                                                              |
+| ------------------ | ------------------------------------------------------------------------------------------------------- |
+| `apps/frontend`    | The web PIMS. Next.js 15, React 19, Zustand, Storybook, Playwright end-to-end and accessibility suites. |
+| `apps/backend`     | The API. Express 4 on TypeScript, Prisma, Socket.IO realtime, BullMQ workers, Stripe.                   |
+| `apps/mobileAppYC` | The pet parent app. React Native 0.81, Redux, i18next localization, Detox end-to-end.                   |
+| `apps/desktop`     | The desktop shell. Electron, packaged by electron-builder, notarized, with auto-update.                 |
+| `apps/dev-docs`    | The developer documentation site. Docusaurus.                                                           |
+
+### Packages
+
+| Package                        | What it holds                                                                 |
+| ------------------------------ | ----------------------------------------------------------------------------- |
+| `@yosemite-crew/database`      | The Prisma schema and migrations. The schema source of truth.                 |
+| `@yosemite-crew/auth`          | Provider-independent session boundary built on SuperTokens.                   |
+| `@yosemite-crew/types`         | Shared domain and form types across web, mobile, and API.                     |
+| `@yosemite-crew/fhir`          | FHIR R4 helpers.                                                              |
+| `@yosemite-crew/fhirtypes`     | FHIR R4 resource type definitions.                                            |
+| `@yosemite-crew/design-tokens` | Semantic design tokens shared by web and mobile. Intent, not platform detail. |
+| `@yosemite-crew/lib`           | Cross-workspace utilities.                                                    |
 
 <br>
 
@@ -59,8 +192,8 @@ For Developers
 ### Prerequisites
 
 - Git
-- Node.js
-- pnpm
+- Node.js 20 (see [`.nvmrc`](./.nvmrc))
+- pnpm 8
 
 ### Steps
 
@@ -82,6 +215,15 @@ For Developers
 
 - Git hooks are installed automatically during `pnpm install` (Husky + commitlint + lint-staged + secret scanning).
 
+- Configure environment variables. Each app ships an example file to copy and fill in:
+
+  ```shell
+  cp apps/backend/.env.example apps/backend/.env
+  cp apps/frontend/.env.example apps/frontend/.env
+  ```
+
+  The backend needs a reachable database on boot. [`apps/backend/README.md`](./apps/backend/README.md) documents the startup requirements, including the legacy MongoDB connection that `READ_FROM_POSTGRES=true` bypasses, and Redis for the background job queues.
+
 - Run the website and api.
 
   ```shell
@@ -100,14 +242,60 @@ For Developers
   pnpm run ios                                    -- Run the app on iOS
   ```
 
+- Before opening a pull request, run the same gates CI will run.
+
+  ```shell
+  pnpm run verify                                 -- lint + type-check + test + build
+  ```
+
+<br>
+
+# 🚀 Our Tech Stack
+
+- [TypeScript](https://www.typescriptlang.org/) for type safety
+- [Turborepo](https://turbo.build) and [PNPM Workspaces](https://pnpm.io/workspaces) for a powerful monorepo structure and efficient build system
+- [Express](https://expressjs.com/) as a backend framework, with [Supabase](https://supabase.com/) Postgres and [Prisma](https://www.prisma.io/) for data storage and migrations
+- [BullMQ](https://docs.bullmq.io/) on [Redis](https://redis.io/) for background jobs, and [Socket.IO](https://socket.io/) for realtime updates
+- [Next.js](https://nextjs.org/) and [React](https://reactjs.org/) for the frontend, with [Zustand](https://zustand.docs.pmnd.rs/) for state management
+- [React Native](https://reactnative.dev/) for mobile app development, and [Electron](https://www.electronjs.org/) for the desktop shell
+- [FHIR R4](https://hl7.org/fhir/R4/) for clinical interoperability
+- [Stripe](https://stripe.com/) for payments
+- [AWS](https://aws.amazon.com) to ensure reliable and scalable cloud infrastructure
+
 <br>
 
 # ✅ Engineering Quality
 
+Open source is a promise about how the code is kept, not only about who can read it. Every change entering `dev` passes the same gates.
+
+| Gate                | What it enforces                                                              |
+| ------------------- | ----------------------------------------------------------------------------- |
+| **Static analysis** | SonarCloud quality gate per app (see the table above), plus CodeQL scanning.  |
+| **Types & lint**    | Repo-wide `type-check` and `lint`, enforced again on pre-push.                |
+| **Tests**           | Unit and component suites per workspace, with coverage held on touched files. |
+| **Accessibility**   | A dedicated accessibility suite and Playwright a11y run on the web app.       |
+| **End-to-end**      | Playwright for web, Detox for mobile.                                         |
+| **Visual review**   | Storybook and Chromatic for the component library.                            |
+| **Supply chain**    | Dependency review, secret scanning, and staged-secret checks on every commit. |
+| **Governance**      | Conventional commits and PR title validation.                                 |
+
 - Contributor workflow: [CONTRIBUTING.md](./CONTRIBUTING.md)
 - Security reporting: [SECURITY.md](./SECURITY.md)
 - Engineering standards: [docs/engineering-standards.md](./docs/engineering-standards.md)
+- Architecture decisions: [docs/adr](./docs/adr)
 - AI/automation contribution policy: [AGENTS.md](./AGENTS.md)
+
+<br>
+
+# 📚 Documentation
+
+| Where                                                                  | What you will find                                      |
+| ---------------------------------------------------------------------- | ------------------------------------------------------- |
+| [Developer docs](./apps/dev-docs)                                      | The Docusaurus site for platform and API documentation. |
+| [Engineering wiki](https://github.com/YosemiteCrew/Yosemite-Crew/wiki) | The structured engineering knowledge base.              |
+| [Architecture guides](./docs/guide)                                    | PIMS architecture, realtime, notifications, analytics.  |
+| [Architecture decisions](./docs/adr)                                   | The record of why the platform is shaped as it is.      |
+| [DeepWiki](https://deepwiki.com/YosemiteCrew/Yosemite-Crew)            | An AI-generated tour of the codebase.                   |
 
 <br>
 
@@ -117,24 +305,21 @@ Request current dev or staging access from the maintainers through a secure chan
 
 <br>
 
-# 🚀 Our Tech Stack
-
-- [TypeScript](https://www.typescriptlang.org/) for type safety
-- [Turborepo](https://turbo.build) and [PNPM Workspaces](https://pnpm.io/workspaces) for a powerful monorepo structure and efficient build system
-- [Express](https://expressjs.com/) as a backend framework, with [Supabase](https://supabase.com/) for data storage, [Redis](https://redis.io/) for lightning-fast caching
-- [React](https://reactjs.org/) for the frontend, with [Zustand](https://zustand.docs.pmnd.rs/) for state management
-- [React Native](https://reactnative.dev/) for mobile app development
-- [AWS](https://aws.amazon.com) to ensure reliable and scalable cloud infrastructure
-
-<br>
-
 # 💬 Join Our Growing Community
 
 - Star our repo and show your support!
 - [Tik-tok](https://www.tiktok.com/@yosemitecrew) and [Instagram](https://www.instagram.com/yosemite_crew) for memes
 - Follow us on [LinkedIn](https://www.linkedin.com/company/yosemitecrew/) to get all the latest news
 - Join our [Discord](https://discord.com/invite/SwM6mX85KD) to chat with fellow contributors and users
-- [Contribute](https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md) — we love contributions! Whether it’s code, docs, or ideas, your help is always welcome!
+- [Contribute](https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md) - we love contributions! Whether it's code, docs, or ideas, your help is always welcome!
+
+<br>
+
+# 📜 License
+
+Yosemite Crew is released under the **GNU Affero General Public License v3.0**, with a Yosemite Crew licensing exception that permits combining the program with works under CC-BY-3.0 and CC-BY-4.0.
+
+The YOSEMITE CREW name, logo, and branding are **not** covered by the open source license. Commercial use of the branding requires a separate commercial license. See [License.txt](./License.txt) for the full terms.
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ A pnpm + Turborepo workspace. Apps ship; packages are the shared spine underneat
 
 - Git hooks are installed automatically during `pnpm install` (Husky + commitlint + lint-staged + secret scanning).
 
-- Configure environment variables. Each app ships an example file to copy and fill in:
+- Configure environment variables for the API and web app. Each ships an example file to copy and fill in:
 
   ```shell
   cp apps/backend/.env.example apps/backend/.env
@@ -232,7 +232,7 @@ A pnpm + Turborepo workspace. Apps ship; packages are the shared spine underneat
   pnpm run dev                                     -- To run website & api
   ```
 
-- Run the Yosemite Crew mobile app.
+- Run the Yosemite Crew mobile app. The mobile app does not load `.env` files. It needs its own configuration (a `variables.local.ts`, Amplify outputs, and native Firebase and credential files copied from [`apps/mobileAppYC/config-templates/`](./apps/mobileAppYC/config-templates)). Follow the setup in [`apps/mobileAppYC/README.md`](./apps/mobileAppYC/README.md) before running.
 
   ```shell
   // In apps/mobileAppYC directory
@@ -268,16 +268,16 @@ A pnpm + Turborepo workspace. Apps ship; packages are the shared spine underneat
 
 Open source is a promise about how the code is kept, not only about who can read it. Every change entering `dev` passes the same gates.
 
-| Gate                | What it enforces                                                              |
-| ------------------- | ----------------------------------------------------------------------------- |
-| **Static analysis** | SonarCloud quality gate per app (see the table above), plus CodeQL scanning.  |
-| **Types & lint**    | Repo-wide `type-check` and `lint`, enforced again on pre-push.                |
-| **Tests**           | Unit and component suites per workspace, with coverage held on touched files. |
-| **Accessibility**   | A dedicated accessibility suite and Playwright a11y run on the web app.       |
-| **End-to-end**      | Playwright for web, Detox for mobile.                                         |
-| **Visual review**   | Storybook and Chromatic for the component library.                            |
-| **Supply chain**    | Dependency review, secret scanning, and staged-secret checks on every commit. |
-| **Governance**      | Conventional commits and PR title validation.                                 |
+| Gate                | What it enforces                                                                                             |
+| ------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Static analysis** | SonarCloud quality gate per app (see the table above), plus CodeQL scanning.                                 |
+| **Types & lint**    | Repo-wide `type-check` and `lint`, enforced again on pre-push.                                               |
+| **Tests**           | Unit and component suites per workspace, with coverage held on touched files.                                |
+| **Accessibility**   | A dedicated accessibility suite and Playwright a11y run on the web app.                                      |
+| **End-to-end**      | Playwright on the web app, enforced in CI. A Detox harness is available for the mobile app and runs locally. |
+| **Visual review**   | Storybook and Chromatic for the component library.                                                           |
+| **Supply chain**    | Dependency review, secret scanning, and staged-secret checks on every commit.                                |
+| **Governance**      | Conventional commits and PR title validation.                                                                |
 
 - Contributor workflow: [CONTRIBUTING.md](./CONTRIBUTING.md)
 - Security reporting: [SECURITY.md](./SECURITY.md)


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The root `README.md` gives a solid overview but has drifted from the codebase and reads as a flat wall of sections:

- It describes the stack as "React for the frontend" and "Redis for lightning-fast caching". The web app is Next.js 15 / React 19, and Redis is not used as a cache anywhere in the repo. Its only role is as the backing store for the BullMQ job queues (`apps/backend/src/queues/bull.config.ts`).
- Electron (desktop), FHIR R4 (clinical interoperability), and Stripe (payments) are all shipped in the repo but absent from the README.
- Prerequisites list Node.js and pnpm without pinning versions, while the repo pins Node 20 (`.nvmrc`) and pnpm 8 (`packageManager`).
- There is no table of contents, no architecture overview, no monorepo map, and no License section, despite the AGPL-3.0 plus trademark terms being non-standard enough to state up front.

## What is the new behavior?

A comprehensive rewrite of the root README, aligned to what is actually on `dev` and presented with a cleaner structure.

Structure and content:

- Table of contents, a sharper overview, and the three audiences (pet owners, clinics, developers) laid out as a three-column table.
- A themed Mermaid architecture diagram (four clients, one Express API, one Postgres source of truth) styled with the repo's own `design-tokens` palette.
- An "Inside the Monorepo" section mapping every app and package to what it is.
- Installation gains an environment-variable step (pointing at the shipped `.env.example` files and `apps/backend/README.md` for the boot-time database requirement) and a `pnpm run verify` step.
- An "Engineering Quality" gate table, a "Documentation" map, and a "License" section covering the AGPL-3.0 licensing exception and the separate trademark terms.

Accuracy fixes:

- Corrected the Redis claim (queue backing store, not a cache).
- Corrected the stack list to Next.js 15 / React 19, and added Electron, FHIR R4, Prisma, BullMQ, Socket.IO, and Stripe.
- Pinned prerequisites to Node 20 and pnpm 8.

Preserved verbatim, byte-for-byte:

- The product video embed.
- The full SonarCloud "Code Quality" badge table.

Validation performed:

- `prettier --check README.md` passes; pre-commit (lint-staged prettier + secretlint + staged-secret scan) and the full pre-push gate (repo-wide lint + type-check) passed.
- Confirmed the preserved video and SonarCloud table are byte-identical to `dev`.
- Verified every relative link resolves to a real file and every table-of-contents anchor resolves to a heading.
- Rendered the Mermaid diagram to confirm it lays out correctly.

Impact area: documentation only (`README.md`). No code or behavior changes.

Out of scope, filed as a follow-up: `docker-compose.yml` references `apps/website` and `apps/api`, which no longer exist (the apps are `frontend` and `backend`), so it is stale. Not touched here to keep this PR docs-only.

## Related Issue(s)

No linked issue; this is a documentation-only improvement to the root README.

Fixes #
