### PR TITLE
ci(ci): gate the credential-bearing e2e off PRs and stop it writing the password to disk

### DIFF
--- a/.github/workflows/frontend-e2e.yml
+++ b/.github/workflows/frontend-e2e.yml
@@ -23,7 +23,15 @@ concurrency:
 
 jobs:
   # `secrets` is not available in a job-level `if:` — gate on a preflight output instead.
+  #
+  # This job resolves YC_E2E_* into a runner, so it must never run on a
+  # pull_request: that event runs PR-controlled code (this very workflow file
+  # is editable on the PR branch), which is precisely the surface that could
+  # exfiltrate the credentials. The `environment: e2e` gate on playwright-auth
+  # does NOT cover preflight, so this event gate is the real protection. Trusted
+  # events only (workflow_dispatch, or a future push to a protected branch).
   preflight:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     outputs:
       has-auth-creds: ${{ steps.check.outputs.has-auth-creds }}
@@ -164,7 +172,11 @@ jobs:
   playwright-auth:
     name: Playwright authenticated flow
     needs: [preflight, build]
-    if: needs.preflight.outputs.has-auth-creds == 'true'
+    # preflight is skipped on pull_request (above), which alone skips this job -
+    # but state the PR exclusion explicitly so the intent survives edits to
+    # preflight. On a PR this job shows a neutral skip, not the red failure it
+    # produced when it reached the e2e environment's dev/main-only branch gate.
+    if: needs.preflight.outputs.has-auth-creds == 'true' && github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     # This job runs PR-controlled code (the local setup action, dependency
     # lifecycle scripts, and Playwright specs) with the YC_E2E_* credentials in
@@ -178,6 +190,12 @@ jobs:
       contents: read
     env:
       NEXT_TELEMETRY_DISABLED: '1'
+      # Playwright writes an AI error-context snapshot on failure that captures
+      # the DOM verbatim - including the filled password field. That write is
+      # gated ONLY by this var (playwright/lib/index.js _takePageSnapshot), not
+      # by trace/screenshot/video, so set it here to stop the password reaching
+      # error-context.md on the runner.
+      PLAYWRIGHT_NO_COPY_PROMPT: '1'
       YC_E2E_EMAIL: ${{ secrets.YC_E2E_EMAIL }}
       YC_E2E_PASSWORD: ${{ secrets.YC_E2E_PASSWORD }}
 

--- a/apps/frontend/e2e/auth-flow.spec.ts
+++ b/apps/frontend/e2e/auth-flow.spec.ts
@@ -1,5 +1,15 @@
 import { expect, test, type Page } from '@playwright/test';
 
+// This spec types a real credential into the sign-in form, and Playwright
+// records input values verbatim. Force trace, screenshot and video off for this
+// file (the config default is trace: 'on-first-retry', which would capture the
+// filled field). This does NOT cover the AI error-context snapshot, which is a
+// separate on-failure sink gated only by PLAYWRIGHT_NO_COPY_PROMPT - that is set
+// in the playwright-auth job env, not here. Together they keep the password off
+// the runner's disk. Defence in depth: the job also uploads no artifacts.
+// Scoped to this file so other specs keep their debugging artefacts.
+test.use({ trace: 'off', screenshot: 'off', video: 'off' });
+
 const LOGIN_PATH = '/signin';
 const APP_ROUTE_PATTERN =
   /^\/(dashboard|appointments|organization|organizations|create-org|team-onboarding)(\/|$|\?)/;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

The auth e2e ("Playwright authenticated flow") handles the real YC_E2E_* secret, and its handling on pull requests was wrong in two ways:

1. **The credential could be resolved into a PR runner.** The `preflight` job reads `secrets.YC_E2E_EMAIL/PASSWORD` into its step env with NO environment gate. On a `pull_request` the workflow file is editable on the PR branch, so preflight was an exfiltration surface that the `environment: e2e` gate on `playwright-auth` never covered.
2. **The check was red on every PR for no useful reason.** The `e2e` environment restricts deployment to `dev`/`main`, so on a PR the auth job reached that gate and failed with zero steps - a red X that was not a code failure and did not block merge (dev has no required-status-checks), just noise that trains people to ignore red.

Separately, a failing run wrote the password to the runner's disk in more places than the removed artifact uploads: Playwright's config default `trace: 'on-first-retry'` records the filled password field, and its AI error-context snapshot captures the DOM verbatim on failure.

## What is the new behavior?

- **`preflight` is gated `if: github.event_name != 'pull_request'`** - the load-bearing security edit. It and the auth job it feeds never run on a PR, so the secret is never resolved into a PR runner. Deny-list phrasing keeps a future `push` trigger working.
- **`playwright-auth` skips neutral on PRs** instead of failing red. It carries the event exclusion explicitly so the intent survives edits to preflight. `build` and the public smoke job do not depend on preflight, so they still run and give real PR signal.
- **The dev/main path is unchanged**: on `workflow_dispatch` both gates pass and the job runs behind the `e2e` environment as before.
- **The password no longer reaches the runner's disk.** `auth-flow.spec.ts` forces `trace`/`screenshot`/`video` off, and the job sets `PLAYWRIGHT_NO_COPY_PROMPT=1` to suppress the AI error-context snapshot - a separate on-failure sink gated only by that var, not by trace/screenshot/video (verified in `playwright/lib/index.js` `_takePageSnapshot`, which early-returns when the var is set). Defence in depth on top of the already-removed uploads.

### Validation

- YAML parses; both gates confirmed via the parsed job graph.
- The spec still loads (`playwright test --list` = 1 test) and lints clean.
- The gating was adversarially verified on four axes (secret exposure, signal, dev/main run path, on-disk sinks); the error-context sink was found and closed as part of that.
- No code-execution surface; gitleaks clean on both files.

### Follow-up (not in this PR)

- The durable fix for real pre-merge auth coverage is a credential-free network-mocked sign-in, so the check runs green/red on every PR with no secret. Tracked separately.
- Operator: the old leaked artifacts hold a now-rotated (dead) password; purge at leisure.

## Related Issue(s)

Follows the credential-leak remediation in the warm-bone PR (removed the auth artifact uploads).
