### PR TITLE
docs(repo): reflect SuperTokens auth in the architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ flowchart LR
     subgraph data ["Data & Services"]
         PG[("Supabase Postgres<br/><sub>Prisma · schema per tenant</sub>")]
         REDIS[("Redis<br/><sub>queue backing store</sub>")]
-        AWS["AWS<br/><sub>Cognito · S3 · SES · Pinpoint</sub>"]
+        AUTH["SuperTokens<br/><sub>session boundary</sub>"]
+        AWS["AWS<br/><sub>S3 · SES · Pinpoint</sub>"]
         LABS["Lab & Partner<br/><sub>IDEXX · Merck</sub>"]
     end
 
@@ -142,6 +143,7 @@ flowchart LR
     API <--> RT
     API --> JOBS
     API --> PG
+    API --> AUTH
     API --> AWS
     JOBS --> REDIS
     JOBS --> PG


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The root README architecture diagram lists Cognito inside the AWS services node (Cognito, S3, SES, Pinpoint), but the platform has moved authentication from Cognito to SuperTokens. SuperTokens is the active auth provider across the backend, `packages/auth`, and the mobile app. Cognito remains only as a legacy adapter that is never selectable (`packages/auth/src/types.ts` marks it "legacy-cognito, never selectable via AUTH_PROVIDER"), plus a few legacy enum values and stale comments; the mobile source has zero Cognito references.

The diagram is the last place in the README that still presents Cognito as live infrastructure, and it leaves SuperTokens unrepresented, even though the monorepo table already describes `@yosemite-crew/auth` as a "session boundary built on SuperTokens."

## What is the new behavior?

- Removed Cognito from the AWS services node. S3 and SES are still in active use and stay; Pinpoint is left unchanged.
- Added a SuperTokens "session boundary" node under Data and Services, with an `API --> AUTH` edge, so auth is represented where Cognito used to be.

This makes the diagram consistent with the `@yosemite-crew/auth` package description already in the README.

Impact area: documentation only (`README.md`, the architecture Mermaid diagram). No code or behavior changes.

Validation performed:

- `prettier --check README.md` passes; pre-commit and the full pre-push gate (repo-wide lint and type-check) passed.
- Verified against the codebase that SuperTokens is the active provider (backend, `packages/auth`, mobile) and that Cognito is legacy-only.
- Statically validated the Mermaid block: balanced brackets and quotes, every edge endpoint resolves to a defined node, and no reserved-word node ids.

Follow-up to #1857, which was merged before this diagram correction could be included.

## Related Issue(s)

No linked issue; this is a documentation-only accuracy fix to the root README.

Fixes #
