### PR TITLE
fix(frontend): persist developer sign-up role and fix account-type routing

### DIFF
--- a/apps/frontend/src/app/(routes)/(public)/developers/signin/page.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/developers/signin/page.tsx
@@ -11,12 +11,7 @@ export const metadata: Metadata = {
 function Page() {
   return (
     <Suspense fallback={<div></div>}>
-      <SignIn
-        redirectPath="/developers/home"
-        signupHref="/developers/signup"
-        allowNext={false}
-        isDeveloper
-      />
+      <SignIn signupHref="/developers/signup" allowNext={false} isDeveloper />
     </Suspense>
   );
 }

--- a/apps/frontend/src/app/__tests__/(routes)/developers/signin/page.test.tsx
+++ b/apps/frontend/src/app/__tests__/(routes)/developers/signin/page.test.tsx
@@ -1,20 +1,29 @@
-import React from "react";
-import { render, screen } from "@testing-library/react";
-import Page from "@/app/(routes)/(public)/developers/signin/page";
-import SignIn from "@/app/features/auth/pages/SignIn/SignIn";
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Page from '@/app/(routes)/(public)/developers/signin/page';
+import SignIn from '@/app/features/auth/pages/SignIn/SignIn';
 
-jest.mock("@/app/features/auth/pages/SignIn/SignIn", () => {
+jest.mock('@/app/features/auth/pages/SignIn/SignIn', () => {
   return jest.fn(() => <div data-testid="mock-signin">SignIn Component</div>);
 });
 
-describe("Developer SignIn Page", () => {
+describe('Developer SignIn Page', () => {
   beforeEach(() => {
     (SignIn as jest.Mock).mockClear();
   });
 
-  it("renders the SignIn component with the correct developer configuration props", () => {
+  it('renders the SignIn component with the correct developer configuration props', () => {
     render(<Page />);
 
-    expect(screen.getByTestId("mock-signin")).toBeInTheDocument();
+    expect(screen.getByTestId('mock-signin')).toBeInTheDocument();
+
+    const props = (SignIn as jest.Mock).mock.calls[0][0];
+    expect(props.isDeveloper).toBe(true);
+    expect(props.signupHref).toBe('/developers/signup');
+    expect(props.allowNext).toBe(false);
+    // No hardcoded developer redirect: the account-type selector drives the
+    // destination, so a business-mode sign-in on this route is not misrouted
+    // into the developer area (and ejected by DevRouteGuard).
+    expect(props.redirectPath).toBeUndefined();
   });
 });

--- a/apps/frontend/src/app/__tests__/components/OtpModal/OtpModal.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/OtpModal/OtpModal.test.tsx
@@ -22,7 +22,7 @@ jest.mock('@/app/services/axios', () => ({
 
 // Mock Auth Store
 jest.mock('@/app/stores/authStore', () => ({
-  useAuthStore: jest.fn(),
+  useAuthStore: Object.assign(jest.fn(), { getState: jest.fn() }),
 }));
 
 // Mock Iconify
@@ -68,6 +68,7 @@ describe('OtpModal Component', () => {
       resendCode: mockResendCode,
       signIn: mockSignIn,
     });
+    (useAuthStore.getState as jest.Mock).mockReturnValue({ pendingSignUp: null });
   });
 
   afterEach(() => {
@@ -237,7 +238,7 @@ describe('OtpModal Component', () => {
     expect(mockConfirmSignUp).toHaveBeenCalledWith(defaultProps.email, '012345');
     expect(mockSetShowVerifyModal).toHaveBeenCalledWith(false);
     expect(mockSignIn).toHaveBeenCalledWith(defaultProps.email, defaultProps.password);
-    expect(postData).toHaveBeenCalledWith('/fhir/v1/user');
+    expect(postData).toHaveBeenCalledWith('/fhir/v1/user', undefined);
     expect(mockPush).toHaveBeenCalledWith('/appointments');
   });
 

--- a/apps/frontend/src/app/__tests__/pages/SignUp.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/SignUp.test.tsx
@@ -95,6 +95,19 @@ describe('SignUp page', () => {
     expect(screen.getByText('Please check the Terms and Conditions box')).toBeInTheDocument();
   });
 
+  test('shows a visible focus ring on the terms box while the checkbox is focused', () => {
+    render(<SignUp />);
+    const checkbox = screen.getByRole('checkbox', { name: /terms and conditions/i });
+    // The visible custom box is the aria-hidden span immediately before the input.
+    const box = checkbox.previousElementSibling as HTMLElement;
+
+    expect(box.style.outlineOffset).toBe('');
+    fireEvent.focus(checkbox);
+    expect(box.style.outlineOffset).toBe('2px');
+    fireEvent.blur(checkbox);
+    expect(box.style.outlineOffset).toBe('');
+  });
+
   test('clears first and last name errors as the user updates those fields', () => {
     render(<SignUp />);
 

--- a/apps/frontend/src/app/__tests__/services/userProvisioningService.test.ts
+++ b/apps/frontend/src/app/__tests__/services/userProvisioningService.test.ts
@@ -1,27 +1,49 @@
 import { provisionBackendUser } from '@/app/features/auth/services/userProvisioningService';
 import { isAuthRedirectError, postData } from '@/app/services/axios';
+import { useAuthStore } from '@/app/stores/authStore';
 
 jest.mock('@/app/services/axios', () => ({
   postData: jest.fn(),
   isAuthRedirectError: jest.fn(() => false),
 }));
 
+jest.mock('@/app/stores/authStore', () => ({
+  useAuthStore: { getState: jest.fn(() => ({ pendingSignUp: null })) },
+}));
+
+const mockGetState = useAuthStore.getState as unknown as jest.Mock;
+
 describe('provisionBackendUser', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
+    mockGetState.mockReturnValue({ pendingSignUp: null });
   });
 
   afterEach(() => {
     jest.useRealTimers();
   });
 
-  it('returns true on first success without retrying', async () => {
+  it('returns true on first success and sends no body without a pending sign-up', async () => {
     (postData as jest.Mock).mockResolvedValue({});
 
     await expect(provisionBackendUser()).resolves.toBe(true);
     expect(postData).toHaveBeenCalledTimes(1);
-    expect(postData).toHaveBeenCalledWith('/fhir/v1/user');
+    expect(postData).toHaveBeenCalledWith('/fhir/v1/user', undefined);
+  });
+
+  it('sends the pending sign-up name and role so the backend can persist it', async () => {
+    mockGetState.mockReturnValue({
+      pendingSignUp: { firstName: 'Ada', lastName: 'Lovelace', role: 'developer' },
+    });
+    (postData as jest.Mock).mockResolvedValue({});
+
+    await expect(provisionBackendUser()).resolves.toBe(true);
+    expect(postData).toHaveBeenCalledWith('/fhir/v1/user', {
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      role: 'developer',
+    });
   });
 
   it('retries with backoff after a transient failure and succeeds', async () => {

--- a/apps/frontend/src/app/features/auth/pages/SignUp/SignUp.tsx
+++ b/apps/frontend/src/app/features/auth/pages/SignUp/SignUp.tsx
@@ -339,62 +339,71 @@ type SignUpTermsFieldProps = {
   onAgreeChange: (checked: boolean) => void;
 };
 
-const SignUpTermsField = ({ agree, error, onAgreeChange }: SignUpTermsFieldProps) => (
-  <>
-    <label
-      style={{
-        display: 'flex',
-        gap: 11,
-        alignItems: 'flex-start',
-        cursor: 'pointer',
-        marginTop: 3,
-      }}
-    >
-      <span
-        aria-hidden="true"
+const SignUpTermsField = ({ agree, error, onAgreeChange }: SignUpTermsFieldProps) => {
+  const [focused, setFocused] = useState(false);
+  return (
+    <>
+      <label
         style={{
-          ...TERMS_CHECKBOX_STYLE,
-          border: `1.5px solid ${agree ? 'var(--blue)' : 'var(--divider)'}`,
-          background: agree ? 'var(--blue)' : 'var(--field-bg)',
+          display: 'flex',
+          gap: 11,
+          alignItems: 'flex-start',
+          cursor: 'pointer',
+          marginTop: 3,
         }}
       >
-        {agree ? <IoCheckmark style={{ fontSize: 14, color: '#fff' }} /> : null}
-      </span>
-      <input
-        type="checkbox"
-        checked={agree}
-        aria-label="I agree to the terms and conditions and privacy policy"
-        onChange={(e) => onAgreeChange(e.target.checked)}
-        style={VISUALLY_HIDDEN_CHECKBOX_STYLE}
-      />
-      <span
-        style={{
-          fontSize: 13.5,
-          lineHeight: 1.5,
-          color: 'var(--ink-muted)',
-          letterSpacing: '-0.01em',
-        }}
-      >
-        I agree to the{' '}
-        <Link
-          href="/terms-and-conditions?ref=signup"
-          style={{ color: 'var(--nav-active)', textDecoration: 'none' }}
+        <span
+          aria-hidden="true"
+          style={{
+            ...TERMS_CHECKBOX_STYLE,
+            border: `1.5px solid ${agree ? 'var(--blue)' : 'var(--divider)'}`,
+            background: agree ? 'var(--blue)' : 'var(--field-bg)',
+            // Mirror the hidden input's focus onto the visible box so keyboard
+            // users see a focus indicator on the required Terms control.
+            outline: focused ? '2px solid var(--blue)' : undefined,
+            outlineOffset: focused ? 2 : undefined,
+          }}
         >
-          Terms
-        </Link>{' '}
-        and{' '}
-        <Link
-          href="/privacy-policy?ref=signup"
-          style={{ color: 'var(--nav-active)', textDecoration: 'none' }}
+          {agree ? <IoCheckmark style={{ fontSize: 14, color: '#fff' }} /> : null}
+        </span>
+        <input
+          type="checkbox"
+          checked={agree}
+          aria-label="I agree to the terms and conditions and privacy policy"
+          onChange={(e) => onAgreeChange(e.target.checked)}
+          onFocus={() => setFocused(true)}
+          onBlur={() => setFocused(false)}
+          style={VISUALLY_HIDDEN_CHECKBOX_STYLE}
+        />
+        <span
+          style={{
+            fontSize: 13.5,
+            lineHeight: 1.5,
+            color: 'var(--ink-muted)',
+            letterSpacing: '-0.01em',
+          }}
         >
-          Privacy policy
-        </Link>
-        .
-      </span>
-    </label>
-    <FieldError message={error} />
-  </>
-);
+          I agree to the{' '}
+          <Link
+            href="/terms-and-conditions?ref=signup"
+            style={{ color: 'var(--nav-active)', textDecoration: 'none' }}
+          >
+            Terms
+          </Link>{' '}
+          and{' '}
+          <Link
+            href="/privacy-policy?ref=signup"
+            style={{ color: 'var(--nav-active)', textDecoration: 'none' }}
+          >
+            Privacy policy
+          </Link>
+          .
+        </span>
+      </label>
+      <FieldError message={error} />
+    </>
+  );
+};
 
 const SignUpPetParentNote = () => (
   <AuthAltNote>

--- a/apps/frontend/src/app/features/auth/services/userProvisioningService.ts
+++ b/apps/frontend/src/app/features/auth/services/userProvisioningService.ts
@@ -1,5 +1,6 @@
 import { isAuthRedirectError, postData } from '@/app/services/axios';
 import { logger } from '@/app/lib/logger';
+import { useAuthStore } from '@/app/stores/authStore';
 
 const PROVISION_MAX_ATTEMPTS = 3;
 const PROVISION_RETRY_BASE_MS = 800;
@@ -7,15 +8,27 @@ const PROVISION_RETRY_BASE_MS = 800;
 const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
 /**
- * Creates the backend user record for a freshly confirmed account. The write
- * is idempotent on the backend, so transient failures (cold start, 429, 5xx)
- * are retried with backoff instead of aborting the whole signup flow.
- * Returns false on persistent transient failure; rethrows auth-loss errors.
+ * Creates the backend user record for a freshly confirmed account. The name and
+ * role captured on the sign-up form (held in the auth store as pendingSignUp)
+ * are sent so the backend persists the selected role to SuperTokens metadata;
+ * without it a developer sign-up loses its role on the next /v1/auth/me and is
+ * ejected from the developer area. The write is idempotent on the backend, so
+ * transient failures (cold start, 429, 5xx) are retried with backoff instead of
+ * aborting the whole signup flow. Returns false on persistent transient
+ * failure; rethrows auth-loss errors.
  */
 export const provisionBackendUser = async (): Promise<boolean> => {
+  const { pendingSignUp } = useAuthStore.getState();
+  const body = pendingSignUp
+    ? {
+        firstName: pendingSignUp.firstName,
+        lastName: pendingSignUp.lastName,
+        role: pendingSignUp.role,
+      }
+    : undefined;
   for (let attempt = 0; attempt < PROVISION_MAX_ATTEMPTS; attempt++) {
     try {
-      await postData('/fhir/v1/user');
+      await postData('/fhir/v1/user', body);
       return true;
     } catch (error) {
       if (isAuthRedirectError(error)) throw error;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our commit-message guidelines.
- [x] All existing tests and lints pass.

## What is the current behavior?

Three review findings on the sign-up / sign-in flow that shipped with the marketing-site re-integration (merged via #1773):

1. **Developer role lost after reload.** Selecting "Developer" on the /signup account-type selector only placed the role in the frontend auth store's pending sign-up state. The post-verification path calls `provisionBackendUser()`, which posted `/fhir/v1/user` with no body, so `resolveProvisioningProfile` never received `body.role` and the role was not persisted to SuperTokens metadata. After a reload, `/v1/auth/me` returned no role and `DevRouteGuard` signed the account out of `/developers`.
2. **Business-mode sign-ins misrouted on the developer route.** `/developers/signin` hardcoded `redirectPath="/developers/home"`. Since `resolvePostAuthRedirect` returns `redirectPath` first, choosing "Pet business" in the selector (`isDeveloper=false`) still forced the developer redirect, sending a valid clinic account into `DevRouteGuard` where it was signed out as a non-developer.
3. **No visible focus on the required Terms checkbox.** The Terms/Privacy control is a visually-hidden `<input>` paired with an `aria-hidden` custom box. The box had no focus styling, so keyboard users got no visible focus indicator on the required step.

## What is the new behavior?

1. `provisionBackendUser` now sends the pending sign-up `firstName`, `lastName`, and `role`, so the backend persists the selected role. A developer sign-up keeps its role across reloads and is no longer ejected from the developer area. (The retry/backoff and non-throwing behavior are unchanged.)
2. The developer sign-in route no longer hardcodes `redirectPath`. The account-type selector (`isDeveloper`) drives the destination: business-mode sign-ins reach the clinic workspace, and developer-mode sign-ins still land on `/developers/home` via the existing `resolvePostAuthRedirect` developer branch.
3. The Terms box draws a 2px focus ring in `var(--blue)` (matching the app's `:focus-visible` convention) while the hidden input is focused.

## Validation

- `apps/frontend`: `tsc --noEmit` clean, `eslint --max-warnings=0` clean.
- 108 auth tests pass across 13 suites (userProvisioningService, OtpModal, SignUp, SignIn, developer sign-in route, VerifyEmail, provisioning, and the auth feature suites).
- react-doctor: 0 errors on the changed files.
- Tests updated: provisioning now asserts the name/role body, the developer route asserts no forced `redirectPath`, and a new test covers the Terms checkbox focus ring.

## Related Issue(s)

Follow-up to the code-review findings on #1773 (merged). No separate tracking issue.
