### PR TITLE
fix(frontend): keep the hero encircle visible on resize in Safari

### DIFF
--- a/apps/frontend/src/app/__tests__/features/marketing/site/motionPrimitives.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/marketing/site/motionPrimitives.test.tsx
@@ -163,6 +163,18 @@ describe('InkAnnotate', () => {
     expect(path.style.strokeDashoffset).toBe('0');
   });
 
+  it('keeps the mark shown on resize even when the offset serializes as "0px" (Safari)', () => {
+    render(<InkAnnotate type="circle">whole</InkAnnotate>);
+    act(() => ioCallback?.([{ intersectionRatio: 0.6, isIntersecting: true }])); // reveal -> shown
+    const path = document.querySelector('[data-ink] path') as SVGPathElement;
+    // WebKit reports strokeDashoffset '0' as '0px'; a string check would misread this as
+    // hidden and retract the mark. Visibility is tracked in state, so it must stay shown.
+    path.style.strokeDashoffset = '0px';
+    widthSpy.mockReturnValue(200);
+    resizeViewport();
+    expect(path.style.strokeDashoffset).toBe('0');
+  });
+
   it('retracts to the refitted length when scrolled out after the mark grows', () => {
     render(<InkAnnotate type="underline">grow</InkAnnotate>);
     act(() => ioCallback?.([{ intersectionRatio: 0.6, isIntersecting: true }])); // play -> shown

--- a/apps/frontend/src/app/features/marketing/site/motion.tsx
+++ b/apps/frontend/src/app/features/marketing/site/motion.tsx
@@ -613,6 +613,14 @@ interface InkOptions {
   reduced: boolean;
 }
 
+interface InkState {
+  /** Whether the mark is currently fully drawn (shown) rather than retracted (hidden).
+   *  Tracked explicitly so a resize re-fit never has to read visibility back from the
+   *  serialized style — Safari/WebKit reports strokeDashoffset '0' as '0px', which would
+   *  make a string check misread a visible mark as hidden and retract it on every resize. */
+  revealed: boolean;
+}
+
 /** Fit the ink svg's viewBox/size and the path `d` to the host box. Shared by the first
  *  draw and every resize, so the mark always traces the word's current metrics. */
 function setInkGeometry(
@@ -666,7 +674,8 @@ function buildInkSvg(
 function observeInkReplay(
   host: HTMLElement,
   path: SVGPathElement,
-  opts: InkOptions
+  opts: InkOptions,
+  state: InkState
 ): IntersectionObserver | null {
   const len = path.getTotalLength();
   const dur = opts.type === 'circle' ? 1550 : 1150;
@@ -677,6 +686,7 @@ function observeInkReplay(
   const play = () => {
     path.style.transition = `stroke-dashoffset ${dur}ms cubic-bezier(0.6,0.04,0.28,1) ${first ? opts.delay : 220}ms`;
     first = false;
+    state.revealed = true;
     afterTwoFrames(reveal);
   };
   const rewind = () => {
@@ -684,6 +694,7 @@ function observeInkReplay(
     // Re-read the length: a mark refitted to a new size (refitInk) has a new dash array,
     // so hiding with the original `len` would leave part of a grown mark visible.
     path.style.strokeDashoffset = String(path.getTotalLength());
+    state.revealed = false;
     path.getBoundingClientRect();
   };
   path.style.strokeDasharray = String(len);
@@ -712,15 +723,15 @@ function refitInk(
   path: SVGPathElement,
   w: number,
   h: number,
-  opts: InkOptions
+  opts: InkOptions,
+  revealed: boolean
 ): void {
-  const shown = path.style.strokeDashoffset === '0';
   setInkGeometry(svg, path, w, h, opts.type);
   if (opts.reduced) return;
   const len = path.getTotalLength();
   path.style.transition = 'none';
   path.style.strokeDasharray = String(len);
-  path.style.strokeDashoffset = shown ? '0' : String(len);
+  path.style.strokeDashoffset = revealed ? '0' : String(len);
 }
 
 /** Draw the ink mark (once fonts settle), wire its replay, and keep it fitted to the word
@@ -734,16 +745,17 @@ function runInkAnnotation(host: HTMLElement, opts: InkOptions): () => void {
   let path: SVGPathElement | null = null;
   let lastW = 0;
   let lastH = 0;
+  const state: InkState = { revealed: false };
 
   const relayout = () => {
     resizeRaf = 0;
     const w = host.offsetWidth;
     const h = host.offsetHeight;
-    // Only re-trace when the traced word box actually changed size.
-    if (!svg || !path || (w === lastW && h === lastH)) return;
+    // Re-trace only when the box changed to a real (non-zero) new size.
+    if (!svg || !path || !w || !h || (w === lastW && h === lastH)) return;
     lastW = w;
     lastH = h;
-    refitInk(svg, path, w, h, opts);
+    refitInk(svg, path, w, h, opts, state.revealed);
   };
 
   // Coalesce a burst of resize notifications into a single re-fit on the next frame.
@@ -775,7 +787,12 @@ function runInkAnnotation(host: HTMLElement, opts: InkOptions): () => void {
     path = built.path;
     lastW = w;
     lastH = h;
-    if (!opts.reduced) io = observeInkReplay(host, path, opts);
+    if (opts.reduced) {
+      // The reduced-motion mark carries no dash, so it is drawn (shown) from the start.
+      state.revealed = true;
+    } else {
+      io = observeInkReplay(host, path, opts, state);
+    }
     observeResize();
   };
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

Follow-up to #1878 (which added resize re-fitting to the hero encircle/underline). In **Safari/WebKit** the encircle **completely disappears on window resize** and does not come back. Chrome is unaffected.

Root cause: the resize re-fit (`refitInk`) decided whether the mark was currently shown by reading `path.style.strokeDashoffset` back and comparing it to the string `'0'`. Chrome serializes that value as `'0'`, but Safari/WebKit reports it as `'0px'`. So in Safari the check was always false: every resize treated the fully-drawn mark as hidden and retracted its stroke to nothing. Because nothing then changes the element's intersection, the draw-on-view observer never replays it, so it stays gone.

## What is the new behavior?

Visibility is now tracked as an explicit boolean (`InkState.revealed`) that the reveal/rewind handlers set, and the re-fit reads that boolean instead of parsing the serialized style. This is engine-independent, so the mark stays drawn across resizes in Safari and Chrome alike. The re-fit also skips when the traced box is momentarily zero-sized (defensive).

- Chrome behavior is unchanged: verified the stroke stays fully drawn (dashoffset 0) across ~600-sample resize bursts on both a local build and the deployed dev site.
- Added a regression test that simulates Safari's `'0px'` serialization and asserts the mark stays shown on resize.

**Impact area:** apps/frontend marketing site only, the InkAnnotate encircle/underline (`site/motion.tsx`) on all marketing hero pages. No other behavior changes.

**Validation:** `tsc` clean, `eslint` clean (pre-commit), 33 motion tests pass, `motion.tsx` coverage 98.69% lines with the new code covered. Chrome verified in-browser (no regression). Safari fix is verified by construction + unit test; a real-Safari confirmation is welcome on the deployed branch.

## Related Issue(s)

Follow-up to #1878 / #1772 (warm-bone marketing site). Reported during dev testing in Safari; no dedicated issue was opened.
