### PR TITLE
fix(frontend): deployed-audit visual fixes (workspace tint, integrations modal, table header)

### DIFF
--- a/apps/frontend/src/app/(routes)/(app)/chat/page.css
+++ b/apps/frontend/src/app/(routes)/(app)/chat/page.css
@@ -9,12 +9,9 @@
   height: calc(100vh - 80px);
   height: calc(100dvh - 80px);
   min-height: 0;
-  background: linear-gradient(
-    180deg,
-    var(--color-chat-surface) 0%,
-    var(--color-chat-empty-bg) 60%,
-    var(--color-neutral-0) 100%
-  );
+  /* Flat warm-bone page per the design - the previous three-stop vertical
+     gradient produced the washed/banded backdrop behind the chat workspace. */
+  background: var(--screen);
   padding: 12px;
   box-sizing: border-box;
   display: flex;

--- a/apps/frontend/src/app/__tests__/components/Calendar/common/DayCalendar.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/common/DayCalendar.test.tsx
@@ -399,7 +399,9 @@ describe('DayCalendar (Appointments)', () => {
     expect(screen.getByRole('menuitem', { name: 'Open companion overview' })).toBeInTheDocument();
   });
 
-  it('updates current date with navigation', () => {
+  it('renders a bare day header with no in-grid day arrows', () => {
+    // Day navigation is owned by the header toolbar's date-nav pill (covered in
+    // Header.test.tsx); the grid's day header is just the frame's label + date.
     render(
       <DayCalendar
         events={[]}
@@ -412,13 +414,8 @@ describe('DayCalendar (Appointments)', () => {
       />
     );
 
-    fireEvent.click(screen.getByText('Next'));
-    fireEvent.click(screen.getByText('Prev'));
-
-    const nextFn = setCurrentDate.mock.calls[0][0];
-    const prevFn = setCurrentDate.mock.calls[1][0];
-
-    expect(nextFn(new Date(2025, 0, 6)).getDate()).toBe(7);
-    expect(prevFn(new Date(2025, 0, 6)).getDate()).toBe(5);
+    expect(screen.queryByText('Next')).not.toBeInTheDocument();
+    expect(screen.queryByText('Prev')).not.toBeInTheDocument();
+    expect(setCurrentDate).not.toHaveBeenCalled();
   });
 });

--- a/apps/frontend/src/app/__tests__/components/Calendar/common/Header.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/common/Header.test.tsx
@@ -71,7 +71,7 @@ describe('Header Component', () => {
     const statusButton = screen.getByRole('button', { name: /Scheduled/i });
     const addAppointmentButton = screen.getByRole('button', { name: 'New appointment' });
     const datepicker = screen.getByTestId('datepicker');
-    const viewSelector = screen.getByRole('button', { name: /week/i });
+    const viewSelector = screen.getByRole('button', { name: 'Week' });
     const zoomInButton = screen.getByTitle('Zoom in timeline');
 
     // Design order: date -> view segmented pill -> status -> emergencies -> new appointment -> zoom.
@@ -89,6 +89,81 @@ describe('Header Component', () => {
     expect(addAppointmentButton.compareDocumentPosition(zoomInButton)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING
     );
+  });
+
+  // --- 1b. Date nav pill + Today (moved here from the grid headers) ---
+
+  it('steps the current date by a day from the nav pill outside the week view', () => {
+    render(<Header {...defaultProps} activeCalendar="team" setActiveCalendar={jest.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Previous day' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Next day' }));
+
+    const prevFn = mockSetCurrentDate.mock.calls[0][0];
+    const nextFn = mockSetCurrentDate.mock.calls[1][0];
+
+    expect(prevFn(new Date(2025, 0, 6)).getDate()).toBe(5);
+    expect(nextFn(new Date(2025, 0, 6)).getDate()).toBe(7);
+  });
+
+  it('steps whole weeks from the nav pill when the week view owns the week start', () => {
+    const setWeekStart = jest.fn();
+    render(
+      <Header
+        {...defaultProps}
+        activeCalendar="week"
+        setActiveCalendar={jest.fn()}
+        weekStart={new Date('2025-01-06T00:00:00.000Z')}
+        setWeekStart={setWeekStart}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Previous week' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Next week' }));
+
+    // The week setter runs an updater that also syncs the current date.
+    const prevFn = setWeekStart.mock.calls[0][0];
+    const nextFn = setWeekStart.mock.calls[1][0];
+    const base = new Date('2025-01-06T00:00:00.000Z');
+
+    expect(prevFn(base).getDate()).toBe(30); // 30 Dec
+    expect(nextFn(base).getDate()).toBe(13); // 13 Jan
+    expect(mockSetCurrentDate).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls back to day stepping in the week view when no week setter is supplied', () => {
+    render(<Header {...defaultProps} activeCalendar="week" setActiveCalendar={jest.fn()} />);
+
+    expect(screen.getByRole('button', { name: 'Previous day' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Next day' }));
+    expect(mockSetCurrentDate.mock.calls[0][0](new Date(2025, 0, 6)).getDate()).toBe(7);
+  });
+
+  it('jumps to today and realigns the week start', () => {
+    const setWeekStart = jest.fn();
+    render(
+      <Header
+        {...defaultProps}
+        activeCalendar="week"
+        setActiveCalendar={jest.fn()}
+        weekStart={new Date('2025-01-06T00:00:00.000Z')}
+        setWeekStart={setWeekStart}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Today' }));
+
+    expect(mockSetCurrentDate).toHaveBeenCalledWith(expect.any(Date));
+    // Week views re-anchor to the Monday of the current week.
+    expect(setWeekStart).toHaveBeenCalledWith(expect.any(Date));
+    expect(setWeekStart.mock.calls[0][0].getDay()).toBe(1);
+  });
+
+  it('leaves the week start alone when jumping to today without a week setter', () => {
+    render(<Header {...defaultProps} />);
+
+    expect(() => fireEvent.click(screen.getByRole('button', { name: 'Today' }))).not.toThrow();
+    expect(mockSetCurrentDate).toHaveBeenCalledTimes(1);
   });
 
   it('renders the emergency pill as a slim danger-outlined pill with a leading dot', () => {
@@ -186,10 +261,11 @@ describe('Header Component', () => {
       />
     );
 
-    // Active non-emergency pill uses the brand/blue treatment and the brand border.
+    // Active non-emergency pill fills with --inset behind a --divider outline and
+    // steps its label to --ink 700, per the planner's filter row.
     const allPillActive = screen.getByRole('button', { name: 'All' });
-    expect(allPillActive).toHaveClass('bg-blue-light');
-    expect(allPillActive).toHaveStyle({ borderColor: 'var(--color-text-brand)' });
+    expect(allPillActive).toHaveClass('bg-[var(--inset)]', 'font-bold', 'text-[var(--ink)]');
+    expect(allPillActive).toHaveStyle({ borderColor: 'var(--divider)' });
 
     // Clicking an inactive pill selects it; clicking the active pill resets to 'all'.
     fireEvent.click(screen.getByRole('button', { name: 'Emergencies' }));
@@ -207,10 +283,11 @@ describe('Header Component', () => {
       />
     );
 
-    // Inactive non-emergency pill falls back to the muted tertiary treatment and card border.
+    // Inactive non-emergency pill falls back to a bare --hairline outline with
+    // --ink-muted 600 type.
     const allPillInactive = screen.getByRole('button', { name: 'All' });
-    expect(allPillInactive).toHaveClass('text-text-tertiary');
-    expect(allPillInactive).toHaveStyle({ borderColor: 'var(--color-card-border)' });
+    expect(allPillInactive).toHaveClass('text-[var(--ink-muted)]', 'font-semibold');
+    expect(allPillInactive).toHaveStyle({ borderColor: 'var(--hairline)' });
 
     // Active emergency pill draws its label colour from the inline style (white on
     // danger-800), so it no longer carries the AA-failing `text-danger-500!` class.
@@ -322,13 +399,13 @@ describe('Header Component', () => {
       <Header {...defaultProps} activeCalendar="week" setActiveCalendar={setActiveCalendar} />
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /week/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Week' }));
     // Selecting a different view transitions to it.
     fireEvent.click(screen.getByText('Day').closest('button') as HTMLElement);
     expect(setActiveCalendar).toHaveBeenCalledWith('day');
 
     setActiveCalendar.mockClear();
-    fireEvent.click(screen.getByRole('button', { name: /week/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Week' }));
     // Re-selecting the already active view is a no-op.
     fireEvent.click(screen.getAllByText('Week').at(-1)!.closest('button') as HTMLElement);
     expect(setActiveCalendar).not.toHaveBeenCalled();

--- a/apps/frontend/src/app/__tests__/components/Calendar/common/HorizontalLines.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/common/HorizontalLines.test.tsx
@@ -61,17 +61,22 @@ describe('HorizontalLines Component', () => {
 
     const { container } = render(<HorizontalLines {...defaultProps} />);
 
-    // Check for the red circle and line
-    // Circle class: "bg-red-500"
-    // Line class: "border-t-red-500"
-    const redCircle = container.querySelector('.bg-red-500');
-    const redLine = container.querySelector('.border-t-red-500');
+    // The now-line is the frame's --blue 2px rule with a 7px --blue dot; the old
+    // red-500 treatment was pre-design-system.
+    const nowDot = Array.from(container.querySelectorAll('div')).find((el) =>
+      el.getAttribute('style')?.includes('background-color: var(--blue)')
+    );
+    const nowLine = Array.from(container.querySelectorAll('div')).find((el) =>
+      el.getAttribute('style')?.includes('border-top-color: var(--blue)')
+    );
 
-    expect(redCircle).toBeInTheDocument();
-    expect(redLine).toBeInTheDocument();
+    expect(nowDot).toBeInTheDocument();
+    expect(nowDot).toHaveClass('size-[7px]');
+    expect(nowLine).toBeInTheDocument();
+    expect(nowLine?.getAttribute('style')).toContain('border-top-width: 2px');
 
     // Check position
-    const wrapper = redCircle?.parentElement;
+    const wrapper = nowDot?.parentElement;
     expect(wrapper).toHaveStyle({ top: '500px' });
   });
 
@@ -79,7 +84,9 @@ describe('HorizontalLines Component', () => {
     (getNowTopPxForWindow as jest.Mock).mockReturnValue(null);
 
     const { container } = render(<HorizontalLines {...defaultProps} />);
-    const redCircle = container.querySelector('.bg-red-500');
-    expect(redCircle).not.toBeInTheDocument();
+    const nowDot = Array.from(container.querySelectorAll('div')).find((el) =>
+      el.getAttribute('style')?.includes('background-color: var(--blue)')
+    );
+    expect(nowDot).toBeUndefined();
   });
 });

--- a/apps/frontend/src/app/__tests__/components/Calendar/common/UserCalendar.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/common/UserCalendar.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import UserCalendar from '@/app/features/appointments/components/Calendar/common/UserCalendar';
@@ -137,7 +137,10 @@ describe('UserCalendar (Appointments)', () => {
     );
   });
 
-  it('updates current date on navigation', () => {
+  it('renders the team day header with no in-grid day arrows', () => {
+    // The planner frame's team header is a plain date band over the practitioner
+    // columns; day navigation is owned by the header toolbar's date-nav pill
+    // (covered in Header.test.tsx). The task calendar still passes its own arrows.
     render(
       <UserCalendar
         events={events}
@@ -149,14 +152,9 @@ describe('UserCalendar (Appointments)', () => {
       />
     );
 
-    fireEvent.click(screen.getByText('PrevDay'));
-    fireEvent.click(screen.getByText('NextDay'));
-
-    const prevFn = setCurrentDate.mock.calls[0][0];
-    const nextFn = setCurrentDate.mock.calls[1][0];
-
-    expect(prevFn(new Date(2025, 0, 6)).getDate()).toBe(5);
-    expect(nextFn(new Date(2025, 0, 6)).getDate()).toBe(7);
+    expect(screen.queryByText('PrevDay')).not.toBeInTheDocument();
+    expect(screen.queryByText('NextDay')).not.toBeInTheDocument();
+    expect(setCurrentDate).not.toHaveBeenCalled();
   });
 
   it('renders zoom-out layout with availability, unavailable segments and the now indicator', () => {

--- a/apps/frontend/src/app/__tests__/components/Calendar/common/UserLabels.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/common/UserLabels.test.tsx
@@ -89,6 +89,8 @@ describe('UserLabels', () => {
     render(<UserLabels team={team} />);
 
     expect(screen.getByText('Sam')).toHaveClass('text-(--color-primary-700)');
-    expect(screen.getByText('Alex')).toHaveClass('text-text-secondary');
+    // Other members take the frame's 13px/700 --ink column-header type (was 16px
+    // /500 --ink-muted body type).
+    expect(screen.getByText('Alex')).toHaveClass('text-[var(--ink)]', 'text-[13px]', 'font-bold');
   });
 });

--- a/apps/frontend/src/app/__tests__/components/Calendar/common/WeekCalendar.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/common/WeekCalendar.test.tsx
@@ -131,7 +131,10 @@ describe('WeekCalendar (Appointments)', () => {
     expect(slotSpy).toHaveBeenCalled();
   });
 
-  it('updates week start and current date on navigation', () => {
+  it('renders bare day headers with no in-grid week arrows', () => {
+    // The frame's week grid is `gutter + 7 day columns` with no arrow columns —
+    // week navigation is owned by the header toolbar's date-nav pill (covered in
+    // Header.test.tsx). The grid header carries only the day label and date.
     render(
       <WeekCalendar
         events={events}
@@ -144,17 +147,44 @@ describe('WeekCalendar (Appointments)', () => {
       />
     );
 
-    fireEvent.click(screen.getByText('PrevWeek'));
-    fireEvent.click(screen.getByText('NextWeek'));
+    expect(screen.queryByText('PrevWeek')).not.toBeInTheDocument();
+    expect(screen.queryByText('NextWeek')).not.toBeInTheDocument();
+    expect(setWeekStart).not.toHaveBeenCalled();
+  });
 
-    const prevFn = setWeekStart.mock.calls[0][0];
-    const nextFn = setWeekStart.mock.calls[1][0];
+  it('styles the day header strip with the frame typography and tints today', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2025-01-07T10:00:00Z'));
 
-    prevFn(weekStart);
-    nextFn(weekStart);
+    const { container } = render(
+      <WeekCalendar
+        events={events}
+        handleViewAppointment={handleViewAppointment}
+        weekStart={weekStart}
+        setWeekStart={setWeekStart}
+        setCurrentDate={setCurrentDate}
+        handleRescheduleAppointment={handleRescheduleAppointment}
+        canEditAppointments
+      />
+    );
 
-    expect(setCurrentDate).toHaveBeenCalledWith(new Date('2024-12-30T00:00:00Z'));
-    expect(setCurrentDate).toHaveBeenCalledWith(new Date('2025-01-13T00:00:00Z'));
+    // Day label: all-caps 9.5px/700/0.08em (was 16px body type).
+    const dayLabel = container.querySelector('.text-\\[9\\.5px\\]');
+    expect(dayLabel).toHaveClass('font-bold', 'uppercase', 'tracking-[0.08em]');
+
+    // Today's date drops into a 24px --blue disc, and its header cell takes
+    // --nav-active-bg. Days mock to 6/7/8 Jan, so the 7th is today.
+    const todayDisc = Array.from(container.querySelectorAll('div')).find(
+      (el) =>
+        el.className.includes('size-6') &&
+        el.getAttribute('style')?.includes('background-color: var(--blue)')
+    );
+    expect(todayDisc).toHaveTextContent('7');
+    expect(todayDisc?.parentElement?.getAttribute('style')).toContain(
+      'background-color: var(--nav-active-bg)'
+    );
+
+    jest.useRealTimers();
   });
 
   it('shows now indicator when current time is within week', () => {
@@ -173,7 +203,11 @@ describe('WeekCalendar (Appointments)', () => {
       />
     );
 
-    expect(container.querySelector('.border-t-red-500')).toBeInTheDocument();
+    // The now-line follows the frame's --blue 2px rule, not the old red-500.
+    const nowLine = Array.from(container.querySelectorAll('div')).find((el) =>
+      el.getAttribute('style')?.includes('border-top-color: var(--blue)')
+    );
+    expect(nowLine).toBeInTheDocument();
 
     jest.useRealTimers();
   });

--- a/apps/frontend/src/app/__tests__/components/Calendar/responsive/PhoneDayStrip.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/responsive/PhoneDayStrip.test.tsx
@@ -2,9 +2,8 @@ import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import type { Appointment } from '@yosemite-crew/types';
 
-import PhoneDayStrip, {
-  buildPhoneDayStrip,
-} from '@/app/features/appointments/components/Calendar/responsive/PhoneDayStrip';
+import PhoneDayStrip from '@/app/features/appointments/components/Calendar/responsive/PhoneDayStrip';
+import { buildPhoneDayStrip } from '@/app/features/appointments/components/Calendar/responsive/phoneDayStripModel';
 
 const WEEK_START = new Date(2026, 6, 6);
 const TODAY = new Date(2026, 6, 7, 10, 20);

--- a/apps/frontend/src/app/__tests__/components/Calendar/responsive/PhoneDayStrip.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/responsive/PhoneDayStrip.test.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { Appointment } from '@yosemite-crew/types';
+
+import PhoneDayStrip, {
+  buildPhoneDayStrip,
+} from '@/app/features/appointments/components/Calendar/responsive/PhoneDayStrip';
+
+const WEEK_START = new Date(2026, 6, 6);
+const TODAY = new Date(2026, 6, 7, 10, 20);
+
+const at = (day: number, hours = 9): Date => new Date(2026, 6, day, hours);
+
+const makeAppointment = (day: number, overrides: Partial<Appointment> = {}): Appointment => ({
+  id: `appt-${day}-${overrides.id ?? '1'}`,
+  patient: {
+    id: 'pet-1',
+    name: 'Poppy',
+    species: 'dog',
+    parent: { id: 'parent-1', name: 'Lena Hartmann' },
+  },
+  organisationId: 'org-1',
+  appointmentDate: at(day),
+  startTime: at(day),
+  timeSlot: '09:00',
+  durationMinutes: 30,
+  endTime: at(day, 10),
+  status: 'UPCOMING',
+  ...overrides,
+});
+
+describe('buildPhoneDayStrip', () => {
+  it('returns seven Monday-first cells starting at the week start', () => {
+    const cells = buildPhoneDayStrip({
+      weekStart: WEEK_START,
+      appointments: [],
+      selectedDate: TODAY,
+      today: TODAY,
+    });
+
+    expect(cells).toHaveLength(7);
+    expect(cells.map((cell) => cell.weekdayLabel)).toEqual([
+      'MON',
+      'TUE',
+      'WED',
+      'THU',
+      'FRI',
+      'SAT',
+      'SUN',
+    ]);
+    expect(cells.map((cell) => cell.dayOfMonth)).toEqual([6, 7, 8, 9, 10, 11, 12]);
+  });
+
+  it('buckets appointments onto their own day and bands them into dots', () => {
+    const cells = buildPhoneDayStrip({
+      weekStart: WEEK_START,
+      appointments: [
+        makeAppointment(6, { id: 'a' }),
+        makeAppointment(8, { id: 'b' }),
+        ...Array.from({ length: 11 }, (_, index) => makeAppointment(9, { id: `c${index}` })),
+      ],
+      selectedDate: TODAY,
+      today: TODAY,
+    });
+
+    expect(cells[0].appointmentCount).toBe(1);
+    expect(cells[0].dotCount).toBe(1);
+    expect(cells[1].appointmentCount).toBe(0);
+    expect(cells[1].dotCount).toBe(0);
+    // 11 appointments saturates the three-dot band.
+    expect(cells[3].appointmentCount).toBe(11);
+    expect(cells[3].dotCount).toBe(3);
+  });
+
+  it('marks today, past days and the selected day independently', () => {
+    const cells = buildPhoneDayStrip({
+      weekStart: WEEK_START,
+      appointments: [],
+      selectedDate: new Date(2026, 6, 9),
+      today: TODAY,
+    });
+
+    expect(cells[0].isPast).toBe(true);
+    expect(cells[0].isToday).toBe(false);
+    expect(cells[1].isToday).toBe(true);
+    expect(cells[1].isPast).toBe(false);
+    expect(cells[1].isSelected).toBe(false);
+    expect(cells[3].isSelected).toBe(true);
+  });
+});
+
+describe('PhoneDayStrip', () => {
+  const renderStrip = (onSelectDay?: (date: Date) => void) =>
+    render(
+      <PhoneDayStrip
+        weekStart={WEEK_START}
+        appointments={[makeAppointment(7, { id: 'a' })]}
+        selectedDate={TODAY}
+        today={TODAY}
+        onSelectDay={onSelectDay}
+      />
+    );
+
+  it('renders one labelled button per day with its load in the accessible name', () => {
+    renderStrip();
+
+    expect(screen.getByRole('group', { name: 'Select a day' })).toBeInTheDocument();
+    expect(screen.getAllByRole('button')).toHaveLength(7);
+    expect(screen.getByRole('button', { name: 'TUE 7 · 1 appointments' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'MON 6 · 0 appointments' })).toBeInTheDocument();
+  });
+
+  it('marks the selected day pressed and today as the current date', () => {
+    renderStrip();
+    const tuesday = screen.getByRole('button', { name: 'TUE 7 · 1 appointments' });
+
+    expect(tuesday).toHaveAttribute('aria-pressed', 'true');
+    expect(tuesday).toHaveAttribute('aria-current', 'date');
+    expect(screen.getByRole('button', { name: 'MON 6 · 0 appointments' })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+  });
+
+  it('renders one dot per load band and none for an empty day', () => {
+    renderStrip();
+
+    expect(screen.getByTestId('day-strip-dots-2026-07-07').children).toHaveLength(1);
+    expect(screen.getByTestId('day-strip-dots-2026-07-06').children).toHaveLength(0);
+  });
+
+  it('reports the tapped day to the caller', () => {
+    const onSelectDay = jest.fn();
+    renderStrip(onSelectDay);
+
+    fireEvent.click(screen.getByRole('button', { name: 'THU 9 · 0 appointments' }));
+
+    expect(onSelectDay).toHaveBeenCalledTimes(1);
+    expect(onSelectDay.mock.calls[0][0].getDate()).toBe(9);
+  });
+
+  it('does not throw when no handler is supplied', () => {
+    renderStrip();
+
+    expect(() =>
+      fireEvent.click(screen.getByRole('button', { name: 'THU 9 · 0 appointments' }))
+    ).not.toThrow();
+  });
+});

--- a/apps/frontend/src/app/__tests__/components/Calendar/responsive/TabletCalendarTitleBand.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/responsive/TabletCalendarTitleBand.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import TabletCalendarTitleBand from '@/app/features/appointments/components/Calendar/responsive/TabletCalendarTitleBand';
+
+const WEEK_START = new Date(2026, 6, 6);
+const CURRENT_DATE = new Date(2026, 6, 7);
+
+const renderBand = (props: Partial<React.ComponentProps<typeof TabletCalendarTitleBand>> = {}) =>
+  render(
+    <TabletCalendarTitleBand
+      activeCalendar="week"
+      currentDate={CURRENT_DATE}
+      weekStart={WEEK_START}
+      appointmentCount={41}
+      {...props}
+    />
+  );
+
+describe('TabletCalendarTitleBand', () => {
+  it('names the ISO week and its count in the week view', () => {
+    renderBand();
+
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(
+      'Week 28 (41 appointments)'
+    );
+  });
+
+  it('names the day in the day and team views', () => {
+    renderBand({ activeCalendar: 'team', appointmentCount: 14 });
+
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(
+      'Tue 7 Jul (14 appointments)'
+    );
+  });
+
+  it('drops the count when the period is empty', () => {
+    renderBand({ appointmentCount: 0 });
+
+    const heading = screen.getByRole('heading', { level: 2 });
+    expect(heading).toHaveTextContent('Week 28');
+    expect(heading).not.toHaveTextContent('appointments');
+  });
+
+  it('renders the four-status legend', () => {
+    renderBand();
+
+    ['Upcoming', 'In progress', 'Done', 'Emergency'].forEach((label) => {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    });
+  });
+
+  it('renders no interactive control, so it cannot fight the shared header', () => {
+    renderBand();
+
+    expect(screen.queryAllByRole('button')).toHaveLength(0);
+  });
+});

--- a/apps/frontend/src/app/__tests__/components/Calendar/responsive/tabletToolbarModel.test.ts
+++ b/apps/frontend/src/app/__tests__/components/Calendar/responsive/tabletToolbarModel.test.ts
@@ -1,0 +1,98 @@
+import {
+  addCalendarDays,
+  buildTabletToolbarTitle,
+  getDayRangeLabel,
+  getPagerStepDays,
+  getWeekRangeLabel,
+} from '@/app/features/appointments/components/Calendar/responsive/tabletToolbarModel';
+
+describe('tabletToolbarModel', () => {
+  describe('addCalendarDays', () => {
+    it('shifts forward without mutating the input', () => {
+      const start = new Date(2026, 6, 6);
+      const shifted = addCalendarDays(start, 6);
+
+      expect(shifted.getDate()).toBe(12);
+      expect(start.getDate()).toBe(6);
+    });
+
+    it('rolls across a month boundary', () => {
+      expect(addCalendarDays(new Date(2026, 5, 29), 6).getMonth()).toBe(6);
+    });
+  });
+
+  describe('getWeekRangeLabel', () => {
+    it('names the month once when the week sits inside one month', () => {
+      expect(getWeekRangeLabel(new Date(2026, 6, 6))).toBe('6 – 12 Jul');
+    });
+
+    it('names both months when the week straddles two', () => {
+      expect(getWeekRangeLabel(new Date(2026, 5, 29))).toBe('29 Jun – 5 Jul');
+    });
+  });
+
+  describe('getDayRangeLabel', () => {
+    it('renders weekday, day and short month', () => {
+      expect(getDayRangeLabel(new Date(2026, 6, 7))).toBe('Tue 7 Jul');
+    });
+  });
+
+  describe('getPagerStepDays', () => {
+    it('steps a whole week in the week view', () => {
+      expect(getPagerStepDays('week')).toBe(7);
+    });
+
+    it.each(['day', 'team'])('steps a single day in the %s view', (view) => {
+      expect(getPagerStepDays(view)).toBe(1);
+    });
+  });
+
+  describe('buildTabletToolbarTitle', () => {
+    const weekStart = new Date(2026, 6, 6);
+    const currentDate = new Date(2026, 6, 7);
+
+    it('names the ISO week and the count in the week view', () => {
+      expect(
+        buildTabletToolbarTitle({
+          activeCalendar: 'week',
+          currentDate,
+          weekStart,
+          appointmentCount: 41,
+        })
+      ).toEqual({ title: 'Week 28', countLabel: '(41 appointments)' });
+    });
+
+    it('names the day in the day and team views', () => {
+      expect(
+        buildTabletToolbarTitle({
+          activeCalendar: 'team',
+          currentDate,
+          weekStart,
+          appointmentCount: 14,
+        })
+      ).toEqual({ title: 'Tue 7 Jul', countLabel: '(14 appointments)' });
+    });
+
+    it('singularises a lone appointment', () => {
+      expect(
+        buildTabletToolbarTitle({
+          activeCalendar: 'week',
+          currentDate,
+          weekStart,
+          appointmentCount: 1,
+        }).countLabel
+      ).toBe('(1 appointment)');
+    });
+
+    it('drops the count entirely when the period is empty', () => {
+      expect(
+        buildTabletToolbarTitle({
+          activeCalendar: 'week',
+          currentDate,
+          weekStart,
+          appointmentCount: 0,
+        }).countLabel
+      ).toBe('');
+    });
+  });
+});

--- a/apps/frontend/src/app/__tests__/components/Calendar/responsive/useIsTabletCalendar.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/responsive/useIsTabletCalendar.test.tsx
@@ -1,0 +1,80 @@
+import { renderHook, act } from '@testing-library/react';
+
+import useIsTabletCalendar, {
+  TABLET_CALENDAR_MEDIA_QUERY,
+} from '@/app/features/appointments/components/Calendar/responsive/useIsTabletCalendar';
+
+type Listener = () => void;
+
+const installMatchMedia = (matches: boolean) => {
+  const listeners = new Set<Listener>();
+  const mediaQueryList = {
+    matches,
+    addEventListener: (_: string, listener: Listener) => listeners.add(listener),
+    removeEventListener: (_: string, listener: Listener) => listeners.delete(listener),
+  };
+  const matchMedia = jest.fn(() => mediaQueryList);
+  (globalThis as { matchMedia: unknown }).matchMedia = matchMedia;
+
+  return {
+    matchMedia,
+    setMatches: (next: boolean) => {
+      mediaQueryList.matches = next;
+      listeners.forEach((listener) => listener());
+    },
+    listenerCount: () => listeners.size,
+  };
+};
+
+describe('useIsTabletCalendar', () => {
+  afterEach(() => {
+    (globalThis as { matchMedia?: unknown }).matchMedia = undefined;
+    jest.clearAllMocks();
+  });
+
+  it('gates on 768–1023px, leaving phone and desktop untouched', () => {
+    expect(TABLET_CALENDAR_MEDIA_QUERY).toBe('(min-width: 768px) and (max-width: 1023px)');
+  });
+
+  it('reports true inside the band after mount', () => {
+    const media = installMatchMedia(true);
+    const { result } = renderHook(() => useIsTabletCalendar());
+
+    expect(media.matchMedia).toHaveBeenCalledWith(TABLET_CALENDAR_MEDIA_QUERY);
+    expect(result.current).toBe(true);
+  });
+
+  it('reports false outside the band', () => {
+    installMatchMedia(false);
+    const { result } = renderHook(() => useIsTabletCalendar());
+
+    expect(result.current).toBe(false);
+  });
+
+  it('follows viewport changes', () => {
+    const media = installMatchMedia(false);
+    const { result } = renderHook(() => useIsTabletCalendar());
+
+    act(() => media.setMatches(true));
+    expect(result.current).toBe(true);
+
+    act(() => media.setMatches(false));
+    expect(result.current).toBe(false);
+  });
+
+  it('detaches its listener on unmount', () => {
+    const media = installMatchMedia(true);
+    const { unmount } = renderHook(() => useIsTabletCalendar());
+
+    expect(media.listenerCount()).toBe(1);
+    unmount();
+    expect(media.listenerCount()).toBe(0);
+  });
+
+  it('stays false when the environment has no matchMedia', () => {
+    (globalThis as { matchMedia?: unknown }).matchMedia = undefined;
+    const { result } = renderHook(() => useIsTabletCalendar());
+
+    expect(result.current).toBe(false);
+  });
+});

--- a/apps/frontend/src/app/__tests__/components/Inputs/Dropdown/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Inputs/Dropdown/index.test.tsx
@@ -13,8 +13,12 @@ jest.mock('react-icons/io', () => ({
 }));
 
 /** The active option is the only one carrying the exact `bg-card-hover` class token. */
+// The active row carries the design's warm --nav-active-bg wash; every other row
+// is transparent, so this identifies exactly one option.
+const ACTIVE_OPTION_CLASS = 'bg-[var(--nav-active-bg)]';
+
 const activeOptionLabel = () =>
-  screen.getAllByRole('button').find((button) => button.classList.contains('bg-card-hover'))
+  screen.getAllByRole('button').find((button) => button.classList.contains(ACTIVE_OPTION_CLASS))
     ?.textContent;
 
 describe('Dropdown (index)', () => {

--- a/apps/frontend/src/app/__tests__/components/tasks/TaskWeekAgenda.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/tasks/TaskWeekAgenda.test.tsx
@@ -173,6 +173,16 @@ describe('TaskWeekAgenda', () => {
     expect(screen.getByText(/· today/)).toBeInTheDocument();
   });
 
+  it("tints only today's day column, matching the blue header cell above it", () => {
+    const { container } = renderAgenda();
+    // Week is Mon Jul 6 .. Sun Jul 12 and "today" is Wed Jul 8 → column index 2.
+    const columns = [...container.querySelectorAll('[class*="group/col"]')];
+    expect(columns).toHaveLength(7);
+    columns.forEach((column, index) => {
+      expect(column.className.includes('bg-[var(--surface-soft)]')).toBe(index === 2);
+    });
+  });
+
   it('formats a week range that spans two months', () => {
     const monthEnd = new Date(2026, 6, 29); // Wed Jul 29 → Jul 29 .. Aug 4
     renderAgenda({ currentDate: monthEnd, weekStart: monthEnd });

--- a/apps/frontend/src/app/__tests__/components/tasks/TaskWeekAgenda.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/tasks/TaskWeekAgenda.test.tsx
@@ -173,16 +173,6 @@ describe('TaskWeekAgenda', () => {
     expect(screen.getByText(/· today/)).toBeInTheDocument();
   });
 
-  it("tints only today's day column, matching the blue header cell above it", () => {
-    const { container } = renderAgenda();
-    // Week is Mon Jul 6 .. Sun Jul 12 and "today" is Wed Jul 8 → column index 2.
-    const columns = [...container.querySelectorAll('[class*="group/col"]')];
-    expect(columns).toHaveLength(7);
-    columns.forEach((column, index) => {
-      expect(column.className.includes('bg-[var(--surface-soft)]')).toBe(index === 2);
-    });
-  });
-
   it('formats a week range that spans two months', () => {
     const monthEnd = new Date(2026, 6, 29); // Wed Jul 29 → Jul 29 .. Aug 4
     renderAgenda({ currentDate: monthEnd, weekStart: monthEnd });

--- a/apps/frontend/src/app/__tests__/components/tasks/TaskWeekAgenda.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/tasks/TaskWeekAgenda.test.tsx
@@ -56,8 +56,6 @@ jest.mock('@/app/stores/authStore', () => ({
 describe('TaskWeekAgenda', () => {
   const setActiveTask = jest.fn();
   const setViewPopup = jest.fn();
-  const setCurrentDate = jest.fn();
-  const setWeekStart = jest.fn();
   const onCreateFromCalendarSlot = jest.fn();
 
   // Week: Mon Jul 6 2026 .. Sun Jul 12 2026; "today" is Wed Jul 8.
@@ -144,9 +142,7 @@ describe('TaskWeekAgenda', () => {
       <TaskWeekAgenda
         filteredList={tasks}
         currentDate={monday}
-        setCurrentDate={setCurrentDate}
         weekStart={monday}
-        setWeekStart={setWeekStart}
         canEditTasks
         setActiveTask={setActiveTask}
         setViewPopup={setViewPopup}
@@ -167,16 +163,22 @@ describe('TaskWeekAgenda', () => {
 
   it('lays out a 7-day agenda board and marks today', () => {
     renderAgenda();
-    // The week-range navigator pill.
-    expect(screen.getByText('6 – 12 Jul')).toBeInTheDocument();
-    // Today's header carries the "· today" marker.
-    expect(screen.getByText(/· today/)).toBeInTheDocument();
+    // One column header per day of the visible week; today (Wed 8) is marked.
+    const headers = ['MON 6', 'TUE 7', 'WED 8 · today', 'THU 9', 'FRI 10', 'SAT 11', 'SUN 12'];
+    headers.forEach((label) => {
+      expect(
+        screen.getByText(
+          (_content, element) => element?.tagName === 'SPAN' && element.textContent === label
+        )
+      ).toBeInTheDocument();
+    });
   });
 
-  it('formats a week range that spans two months', () => {
-    const monthEnd = new Date(2026, 6, 29); // Wed Jul 29 → Jul 29 .. Aug 4
-    renderAgenda({ currentDate: monthEnd, weekStart: monthEnd });
-    expect(screen.getByText('29 Jul – 4 Aug')).toBeInTheDocument();
+  it('leaves the week-range navigator to the page title row', () => {
+    renderAgenda();
+    expect(screen.queryByRole('button', { name: 'Previous week' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Next week' })).not.toBeInTheDocument();
+    expect(screen.queryByText('6 – 12 Jul')).not.toBeInTheDocument();
   });
 
   it('places tasks in their due-day columns and drops off-week tasks', () => {
@@ -222,18 +224,6 @@ describe('TaskWeekAgenda', () => {
     // Unknown / empty assignees drop the trailing name segment.
     expect(screen.getByText('Care · 12:00')).toBeInTheDocument();
     expect(screen.getByText('Care · 13:00')).toBeInTheDocument();
-  });
-
-  it('navigates weeks via the range pill', () => {
-    renderAgenda();
-    fireEvent.click(screen.getByRole('button', { name: 'Previous week' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Next week' }));
-    expect(setCurrentDate).toHaveBeenCalledTimes(2);
-    expect(setWeekStart).toHaveBeenCalledTimes(2);
-    const prevUpdater = setCurrentDate.mock.calls[0][0] as (d: Date) => Date;
-    const nextUpdater = setCurrentDate.mock.calls[1][0] as (d: Date) => Date;
-    expect(prevUpdater(new Date(2026, 6, 8)).getDate()).toBe(1);
-    expect(nextUpdater(new Date(2026, 6, 8)).getDate()).toBe(15);
   });
 
   it('creates a task from a day column at the default hour', () => {

--- a/apps/frontend/src/app/__tests__/components/tasks/TaskWeekNav.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/tasks/TaskWeekNav.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import TaskWeekNav from '@/app/features/tasks/components/TaskWeekNav';
+
+// Deterministic Monday-aligned week starting at whatever currentDate we pass.
+jest.mock('@/app/features/appointments/components/Calendar/weekHelpers', () => ({
+  getStartOfWeek: (d: Date) => d,
+  getWeekDays: (start: Date) =>
+    Array.from({ length: 7 }, (_, i) => {
+      const day = new Date(start);
+      day.setDate(day.getDate() + i);
+      return day;
+    }),
+}));
+
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+jest.mock('@/app/lib/timezone', () => ({
+  formatDateInPreferredTimeZone: (date: Date, opts: any = {}) => {
+    const d = new Date(date);
+    if (opts.month === 'short' && opts.day == null) return MONTHS[d.getMonth()];
+    return String(d.getDate());
+  },
+}));
+
+describe('TaskWeekNav', () => {
+  const setCurrentDate = jest.fn();
+  const setWeekStart = jest.fn();
+
+  // Week: Mon Jul 6 2026 .. Sun Jul 12 2026.
+  const monday = new Date(2026, 6, 6);
+
+  const renderNav = (overrides: Partial<React.ComponentProps<typeof TaskWeekNav>> = {}) =>
+    render(
+      <TaskWeekNav
+        currentDate={monday}
+        setCurrentDate={setCurrentDate}
+        setWeekStart={setWeekStart}
+        {...overrides}
+      />
+    );
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('labels the visible week range within a single month', () => {
+    renderNav();
+    expect(screen.getByText('6 – 12 Jul')).toBeInTheDocument();
+  });
+
+  it('formats a week range that spans two months', () => {
+    renderNav({ currentDate: new Date(2026, 6, 29) }); // Wed Jul 29 → Jul 29 .. Aug 4
+    expect(screen.getByText('29 Jul – 4 Aug')).toBeInTheDocument();
+  });
+
+  it('steps the week back and forward through both date setters', () => {
+    renderNav();
+    fireEvent.click(screen.getByRole('button', { name: 'Previous week' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Next week' }));
+
+    expect(setCurrentDate).toHaveBeenCalledTimes(2);
+    expect(setWeekStart).toHaveBeenCalledTimes(2);
+
+    const prevCurrent = setCurrentDate.mock.calls[0][0] as (d: Date) => Date;
+    const nextCurrent = setCurrentDate.mock.calls[1][0] as (d: Date) => Date;
+    expect(prevCurrent(new Date(2026, 6, 8)).getDate()).toBe(1);
+    expect(nextCurrent(new Date(2026, 6, 8)).getDate()).toBe(15);
+
+    const prevWeekStart = setWeekStart.mock.calls[0][0] as (d: Date) => Date;
+    const nextWeekStart = setWeekStart.mock.calls[1][0] as (d: Date) => Date;
+    expect(prevWeekStart(new Date(2026, 6, 8)).getDate()).toBe(1);
+    expect(nextWeekStart(new Date(2026, 6, 8)).getDate()).toBe(15);
+  });
+});

--- a/apps/frontend/src/app/__tests__/pages/Integrations/Integrations.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Integrations/Integrations.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { axe, toHaveNoViolations } from 'jest-axe';
 
@@ -73,6 +73,22 @@ jest.mock('@/app/stores/integrationStore', () => ({
     }),
 }));
 
+jest.mock('@/app/ui/overlays/Modal', () => ({
+  __esModule: true,
+  default: ({ showModal, children }: any) =>
+    showModal ? <div data-testid="settings-modal">{children}</div> : null,
+}));
+
+jest.mock('@/app/ui/primitives/Accordion/Accordion', () => ({
+  __esModule: true,
+  default: ({ title, children }: any) => (
+    <div>
+      <div>{title}</div>
+      {children}
+    </div>
+  ),
+}));
+
 jest.mock('@/app/ui/inputs/FormInput/FormInput', () => ({
   __esModule: true,
   default: ({ inname, inlabel, value, onChange }: any) => (
@@ -100,6 +116,15 @@ jest.mock('@/app/ui/primitives/Buttons', () => ({
   ),
 }));
 
+jest.mock('@/app/ui/primitives/Icons/Close', () => ({
+  __esModule: true,
+  default: ({ onClick }: any) => (
+    <button type="button" onClick={onClick}>
+      close
+    </button>
+  ),
+}));
+
 jest.mock('@/app/features/integrations/services/idexxService', () => ({
   getApiErrorMessage: (_error: unknown, fallback: string) => fallback,
   getOrgIntegrations: (...args: any[]) => getOrgIntegrationsMock(...args),
@@ -119,6 +144,9 @@ jest.mock('@/app/features/integrations/services/merckService', () => ({
     search: jest.fn(),
   })),
 }));
+
+const openSettings = () =>
+  fireEvent.click(screen.getByRole('button', { name: 'Manage credentials' }));
 
 describe('Integrations settings', () => {
   beforeEach(() => {
@@ -172,15 +200,15 @@ describe('Integrations settings', () => {
     });
   });
 
-  it('stores credentials from the inline panel', async () => {
+  it('stores credentials from the settings modal', async () => {
     render(<ProtectedIntegrations />);
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Manage credentials' })).toBeInTheDocument();
     });
 
-    // Inputs live in the always-visible panel; "Manage credentials" just scrolls to it.
-    fireEvent.click(screen.getByRole('button', { name: 'Manage credentials' }));
+    // The credentials form lives inside the side settings modal, opened from the IDEXX card.
+    openSettings();
     fireEvent.change(screen.getByTestId('idexx-username'), { target: { value: 'user-a' } });
     fireEvent.change(screen.getByTestId('idexx-password'), { target: { value: 'pass-a' } });
     fireEvent.click(screen.getByRole('button', { name: /Store credentials|Update credentials/ }));
@@ -217,7 +245,7 @@ describe('Integrations settings', () => {
       expect(screen.getByRole('button', { name: 'Manage credentials' })).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Manage credentials' }));
+    openSettings();
     fireEvent.click(screen.getByRole('button', { name: 'Disable IDEXX' }));
 
     await waitFor(() => {
@@ -248,7 +276,7 @@ describe('Integrations settings', () => {
       expect(screen.getByRole('button', { name: 'Enable' })).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Manage credentials' }));
+    openSettings();
 
     const enableInSettingsButton = await screen.findByRole('button', { name: 'Enable IDEXX' });
     expect(enableInSettingsButton).not.toBeDisabled();
@@ -264,7 +292,8 @@ describe('Integrations settings', () => {
         'IDEXX credentials are missing or invalid. Open settings, fill credentials, validate, and then enable.'
       )
     ).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'IDEXX credentials' })).toBeInTheDocument();
+    // The side settings modal is (still) open with its heading.
+    expect(screen.getByText('Integration settings')).toBeInTheDocument();
   });
 
   it('reloads integrations and refreshes Merck status after toggling Merck', async () => {
@@ -344,8 +373,6 @@ describe('Integrations settings', () => {
     const availableBtn = screen.getByRole('button', { name: 'Available' });
     fireEvent.click(availableBtn);
     await waitFor(() => {
-      // The IDEXX catalog card (its title is card-only; the always-on panel is "IDEXX
-      // credentials") is hidden when Available is active and IDEXX is already enabled.
       expect(screen.queryByText('IDEXX VetConnect PLUS')).not.toBeInTheDocument();
     });
   });
@@ -353,7 +380,7 @@ describe('Integrations settings', () => {
   it('shows validated successfully message after validate click', async () => {
     render(<ProtectedIntegrations />);
     await screen.findByRole('button', { name: 'Manage credentials' });
-    fireEvent.click(screen.getByRole('button', { name: 'Manage credentials' }));
+    openSettings();
     fireEvent.click(screen.getByRole('button', { name: 'Validate' }));
     await screen.findByText('Credentials validated successfully.');
   });
@@ -436,40 +463,19 @@ describe('Integrations settings', () => {
     expect(screen.getAllByText('Disabled').length).toBeGreaterThanOrEqual(1);
   });
 
-  it('renders the inline IDEXX credentials panel without any interaction', async () => {
+  it('opens the side settings modal from the IDEXX card', async () => {
     render(<ProtectedIntegrations />);
-    // The panel is always visible in the 2-column layout, not gated behind a modal.
-    expect(await screen.findByRole('heading', { name: 'IDEXX credentials' })).toBeInTheDocument();
-    expect(screen.getByTestId('idexx-username')).toBeInTheDocument();
-    expect(screen.getByTestId('idexx-password')).toBeInTheDocument();
+    await screen.findByRole('button', { name: 'Manage credentials' });
+    // The credentials surface is gated behind the modal, not an always-visible panel.
+    expect(screen.queryByTestId('settings-modal')).not.toBeInTheDocument();
+    openSettings();
+    const modal = await screen.findByTestId('settings-modal');
+    expect(within(modal).getByText('Integration settings')).toBeInTheDocument();
+    expect(within(modal).getByTestId('idexx-username')).toBeInTheDocument();
+    expect(within(modal).getByTestId('idexx-password')).toBeInTheDocument();
   });
 
-  it('shows the validated chip when credentials are valid', async () => {
-    render(<ProtectedIntegrations />);
-    await screen.findByRole('heading', { name: 'IDEXX credentials' });
-    // Chip copy (no trailing period) is distinct from the inline validate message.
-    expect(screen.getByText('Credentials validated successfully')).toBeInTheDocument();
-  });
-
-  it('shows the "no credentials stored" chip when credentials are missing', async () => {
-    const missingIntegration = {
-      _id: 'int-1',
-      organisationId: 'org-1',
-      provider: 'IDEXX',
-      status: 'disabled',
-      credentialsStatus: 'missing',
-      enabledAt: null,
-      lastValidatedAt: null,
-    };
-    useIntegrationsForPrimaryOrgMock.mockReturnValue([missingIntegration]);
-    useIntegrationByProviderForPrimaryOrgMock.mockReturnValue(missingIntegration);
-
-    render(<ProtectedIntegrations />);
-    await screen.findByRole('heading', { name: 'IDEXX credentials' });
-    expect(screen.getByText('No credentials stored')).toBeInTheDocument();
-  });
-
-  it('renders recent orders in the panel footer when IDEXX is enabled', async () => {
+  it('renders recent orders in the settings modal when IDEXX is enabled', async () => {
     // Give sync health a real lastSyncAt so its "Pending" fallback does not collide with
     // the empty-status order pill, which is the "Pending" this test asserts on.
     const enabledWithSync = {
@@ -511,17 +517,48 @@ describe('Integrations settings', () => {
     ]);
 
     render(<ProtectedIntegrations />);
+    await screen.findByRole('button', { name: 'Manage credentials' });
+    // Orders load on mount; open the modal to read them.
+    await waitFor(() =>
+      expect(listIdexxOrdersMock).toHaveBeenCalledWith({ organisationId: 'org-1' })
+    );
+    openSettings();
 
-    expect(await screen.findByText('Recent orders')).toBeInTheDocument();
-    expect(screen.getByText('Poppy · ear cytology')).toBeInTheDocument();
-    expect(screen.getByText('pre-surgical CBC')).toBeInTheDocument();
-    expect(screen.getByText('Order IDX-3')).toBeInTheDocument();
-    expect(screen.getByText('Running')).toBeInTheDocument();
-    expect(screen.getByText('Resulted')).toBeInTheDocument();
-    expect(screen.getByText('Pending')).toBeInTheDocument();
+    const modal = await screen.findByTestId('settings-modal');
+    expect(within(modal).getByText('Recent orders')).toBeInTheDocument();
+    expect(within(modal).getByText('Poppy · ear cytology')).toBeInTheDocument();
+    expect(within(modal).getByText('pre-surgical CBC')).toBeInTheDocument();
+    expect(within(modal).getByText('Order IDX-3')).toBeInTheDocument();
+    expect(within(modal).getByText('Running')).toBeInTheDocument();
+    expect(within(modal).getByText('Resulted')).toBeInTheDocument();
+    expect(within(modal).getByText('Pending')).toBeInTheDocument();
   });
 
-  it('lists linked IVLS devices in the panel with their activation status', async () => {
+  it('shows the empty recent-orders message in the modal when IDEXX is disabled', async () => {
+    const disabledIntegration = {
+      _id: 'int-1',
+      organisationId: 'org-1',
+      provider: 'IDEXX',
+      status: 'disabled',
+      credentialsStatus: 'missing',
+      enabledAt: null,
+      lastValidatedAt: null,
+    };
+    useIntegrationsForPrimaryOrgMock.mockReturnValue([disabledIntegration]);
+    useIntegrationByProviderForPrimaryOrgMock.mockReturnValue(disabledIntegration);
+
+    render(<ProtectedIntegrations />);
+    await screen.findByRole('button', { name: 'Manage credentials' });
+    // Disabled → orders are never fetched.
+    await waitFor(() => expect(listIdexxOrdersMock).not.toHaveBeenCalled());
+    openSettings();
+
+    const modal = await screen.findByTestId('settings-modal');
+    expect(within(modal).getByText('Recent orders')).toBeInTheDocument();
+    expect(within(modal).getByText('No recent orders.')).toBeInTheDocument();
+  });
+
+  it('lists linked IVLS devices in the settings modal with their activation status', async () => {
     listIdexxIvlsDevicesMock.mockResolvedValue({
       ivlsDeviceList: [
         {
@@ -540,19 +577,24 @@ describe('Integrations settings', () => {
     });
 
     render(<ProtectedIntegrations />);
+    await screen.findByRole('button', { name: 'Manage credentials' });
+    await waitFor(() => expect(listIdexxIvlsDevicesMock).toHaveBeenCalledWith('org-1'));
+    openSettings();
 
-    expect(await screen.findByText('Catalyst One')).toBeInTheDocument();
-    expect(screen.getByText('SN-1')).toBeInTheDocument();
+    const modal = await screen.findByTestId('settings-modal');
+    expect(within(modal).getByText('Catalyst One')).toBeInTheDocument();
+    expect(within(modal).getByText('SN-1')).toBeInTheDocument();
     // Empty display name falls back, and both activation-status pill branches render.
-    expect(screen.getByText('IVLS device')).toBeInTheDocument();
-    expect(screen.getByText('Active')).toBeInTheDocument();
-    expect(screen.getByText('Inactive')).toBeInTheDocument();
-    expect(screen.getByText('Not available')).toBeInTheDocument();
+    expect(within(modal).getByText('IVLS device')).toBeInTheDocument();
+    expect(within(modal).getByText('Active')).toBeInTheDocument();
+    expect(within(modal).getByText('Inactive')).toBeInTheDocument();
+    expect(within(modal).getByText('Not available')).toBeInTheDocument();
   });
 
-  it('refreshes integrations from the panel refresh control', async () => {
+  it('refreshes integrations from the modal refresh control', async () => {
     render(<ProtectedIntegrations />);
-    await screen.findByRole('heading', { name: 'IDEXX credentials' });
+    await screen.findByRole('button', { name: 'Manage credentials' });
+    openSettings();
 
     fireEvent.click(screen.getByRole('button', { name: 'Refresh integrations' }));
 
@@ -561,24 +603,13 @@ describe('Integrations settings', () => {
     });
   });
 
-  it('does not fetch recent orders when IDEXX is disabled', async () => {
-    const disabledIntegration = {
-      _id: 'int-1',
-      organisationId: 'org-1',
-      provider: 'IDEXX',
-      status: 'disabled',
-      credentialsStatus: 'missing',
-      enabledAt: null,
-      lastValidatedAt: null,
-    };
-    useIntegrationsForPrimaryOrgMock.mockReturnValue([disabledIntegration]);
-    useIntegrationByProviderForPrimaryOrgMock.mockReturnValue(disabledIntegration);
-
+  it('closes the settings modal via the Close control', async () => {
     render(<ProtectedIntegrations />);
-    await screen.findByRole('heading', { name: 'IDEXX credentials' });
-    await waitFor(() => {
-      expect(listIdexxOrdersMock).not.toHaveBeenCalled();
-    });
-    expect(screen.queryByText('Recent orders')).not.toBeInTheDocument();
+    await screen.findByRole('button', { name: 'Manage credentials' });
+    openSettings();
+
+    const modal = await screen.findByTestId('settings-modal');
+    fireEvent.click(within(modal).getByRole('button', { name: 'close' }));
+    await waitFor(() => expect(screen.queryByTestId('settings-modal')).not.toBeInTheDocument());
   });
 });

--- a/apps/frontend/src/app/__tests__/pages/Integrations/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Integrations/index.test.tsx
@@ -34,7 +34,9 @@ const disableMerckMock = jest.fn();
 // ---------------------------------------------------------------------------
 jest.mock('next/image', () => ({
   __esModule: true,
-  // Keep the mock accessible without triggering Next's <img> lint rule.
+  // Render as a <span> whose text is empty (alt is not rendered as content) so
+  // card titles that match their logo alt (e.g. "MSD Veterinary Manual") stay
+  // uniquely queryable by text.
   default: ({ alt }: any) => <span aria-label={alt || ''} data-testid="mock-next-image" />,
 }));
 
@@ -89,6 +91,22 @@ jest.mock('@/app/stores/integrationStore', () => {
   return { useIntegrationStore };
 });
 
+jest.mock('@/app/ui/overlays/Modal', () => ({
+  __esModule: true,
+  default: ({ showModal, children }: any) =>
+    showModal ? <div data-testid="settings-modal">{children}</div> : null,
+}));
+
+jest.mock('@/app/ui/primitives/Accordion/Accordion', () => ({
+  __esModule: true,
+  default: ({ title, children }: any) => (
+    <div>
+      <div>{title}</div>
+      {children}
+    </div>
+  ),
+}));
+
 jest.mock('@/app/ui/inputs/FormInput/FormInput', () => ({
   __esModule: true,
   default: ({ inname, value, onChange }: any) => (
@@ -112,6 +130,15 @@ jest.mock('@/app/ui/primitives/Buttons', () => ({
   Secondary: ({ text, onClick, isDisabled, href }: any) => (
     <button type="button" data-href={href} onClick={onClick} disabled={isDisabled}>
       {text}
+    </button>
+  ),
+}));
+
+jest.mock('@/app/ui/primitives/Icons/Close', () => ({
+  __esModule: true,
+  default: ({ onClick }: any) => (
+    <button type="button" onClick={onClick}>
+      close
     </button>
   ),
 }));
@@ -197,7 +224,7 @@ const waitForPage = () =>
 
 const openSettings = async () => {
   fireEvent.click(screen.getByRole('button', { name: 'Manage credentials' }));
-  return screen.findByTestId('idexx-credentials-panel');
+  return screen.findByTestId('settings-modal');
 };
 
 // Resolve an integration card root from its (unique) title text.
@@ -290,6 +317,9 @@ describe('IntegrationsPage — default disabled render', () => {
     expect(screen.getAllByText('Disabled').length).toBeGreaterThanOrEqual(1);
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
 
+    // The credentials surface is behind the modal, closed on first render.
+    expect(screen.queryByTestId('settings-modal')).not.toBeInTheDocument();
+
     // "All" tab is active; the others are not.
     expect(screen.getByRole('button', { name: 'All' })).toHaveAttribute('aria-pressed', 'true');
     expect(screen.getByRole('button', { name: 'Connected' })).toHaveAttribute(
@@ -298,26 +328,41 @@ describe('IntegrationsPage — default disabled render', () => {
     );
   });
 
-  it('shows the store-credentials hint in the panel for a fresh integration', async () => {
+  it('opens the settings modal showing store-credentials hint for a fresh integration', async () => {
     renderPage();
     await waitForPage();
     await openSettings();
 
-    const modal = screen.getByTestId('idexx-credentials-panel');
-    expect(within(modal).getByRole('heading', { name: 'IDEXX credentials' })).toBeInTheDocument();
+    const modal = screen.getByTestId('settings-modal');
+    expect(within(modal).getByText('Integration settings')).toBeInTheDocument();
     // hasStoredCredentials === false → "Store credentials" + connect hint + Enable IDEXX.
     expect(within(modal).getByRole('button', { name: 'Store credentials' })).toBeInTheDocument();
     expect(within(modal).getByRole('button', { name: 'Enable IDEXX' })).toBeDisabled();
     expect(within(modal).getByText('Store credentials first to enable IDEXX.')).toBeInTheDocument();
-    // credentialsStatus "missing" → neutral fallback token label + the "no credentials" chip.
+    // credentialsStatus "missing" → neutral fallback token label + no validate meta yet.
     expect(within(modal).getByText('Missing')).toBeInTheDocument();
-    expect(within(modal).getByText('No credentials stored')).toBeInTheDocument();
     expect(
       within(modal).queryByText('Credentials validated successfully.')
     ).not.toBeInTheDocument();
+    // formatOptionalDate fallback branches.
+    expect(within(modal).getByText('Not refreshed yet')).toBeInTheDocument();
     expect(
       within(modal).getByText('No linked IVLS devices found for this organization.')
     ).toBeInTheDocument();
+    // Recent orders section renders its empty message while IDEXX is disabled.
+    expect(within(modal).getByText('Recent orders')).toBeInTheDocument();
+    expect(within(modal).getByText('No recent orders.')).toBeInTheDocument();
+  });
+
+  it('closes the settings modal via the Close control', async () => {
+    renderPage();
+    await waitForPage();
+    await openSettings();
+
+    fireEvent.click(
+      within(screen.getByTestId('settings-modal')).getByRole('button', { name: 'close' })
+    );
+    await waitFor(() => expect(screen.queryByTestId('settings-modal')).not.toBeInTheDocument());
   });
 });
 
@@ -395,7 +440,7 @@ describe('IntegrationsPage — enabled render', () => {
     await waitFor(() => expect(listIdexxIvlsDevicesMock).toHaveBeenCalled());
     await openSettings();
 
-    const modal = screen.getByTestId('idexx-credentials-panel');
+    const modal = screen.getByTestId('settings-modal');
     // hasStoredCredentials === true → "Update credentials" + enabled connection.
     expect(within(modal).getByRole('button', { name: 'Update credentials' })).toBeInTheDocument();
     expect(within(modal).getByRole('button', { name: 'Disable IDEXX' })).toBeInTheDocument();
@@ -416,6 +461,59 @@ describe('IntegrationsPage — enabled render', () => {
     await flush();
   });
 
+  it('renders recent orders in the modal with label and pill branches', async () => {
+    listIdexxOrdersMock.mockResolvedValue([
+      {
+        _id: 'o1',
+        idexxOrderId: 'IDX-1',
+        patientName: 'Poppy',
+        tests: ['ear cytology'],
+        status: 'RUNNING',
+      },
+      {
+        _id: 'o2',
+        idexxOrderId: 'IDX-2',
+        patientName: '',
+        tests: ['pre-surgical CBC'],
+        status: 'RESULTED',
+      },
+      { idexxOrderId: 'IDX-3', patientName: '', tests: [], status: '' },
+    ]);
+
+    renderPage();
+    await waitForPage();
+    await waitFor(() =>
+      expect(listIdexxOrdersMock).toHaveBeenCalledWith({ organisationId: 'org-1' })
+    );
+    await openSettings();
+
+    const modal = screen.getByTestId('settings-modal');
+    // name + tests, tests-only, and id-fallback label branches.
+    expect(within(modal).getByText('Poppy · ear cytology')).toBeInTheDocument();
+    expect(within(modal).getByText('pre-surgical CBC')).toBeInTheDocument();
+    expect(within(modal).getByText('Order IDX-3')).toBeInTheDocument();
+    // running / resulted / neutral(empty→Pending) pill branches.
+    expect(within(modal).getByText('Running')).toBeInTheDocument();
+    expect(within(modal).getByText('Resulted')).toBeInTheDocument();
+    expect(within(modal).getByText('Pending')).toBeInTheDocument();
+    await flush();
+  });
+
+  it('swallows recent-orders load failures without surfacing an error', async () => {
+    listIdexxOrdersMock.mockRejectedValue(new Error('orders down'));
+
+    renderPage();
+    await waitForPage();
+    await waitFor(() => expect(listIdexxOrdersMock).toHaveBeenCalled());
+    await openSettings();
+
+    const modal = screen.getByTestId('settings-modal');
+    expect(within(modal).getByText('No recent orders.')).toBeInTheDocument();
+    // The orders failure is intentionally swallowed — no page alert.
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    await flush();
+  });
+
   it('shows the empty-device message when no IVLS devices are linked', async () => {
     listIdexxIvlsDevicesMock.mockResolvedValue({ ivlsDeviceList: [] });
     renderPage();
@@ -424,7 +522,7 @@ describe('IntegrationsPage — enabled render', () => {
     await openSettings();
 
     expect(
-      within(screen.getByTestId('idexx-credentials-panel')).getByText(
+      within(screen.getByTestId('settings-modal')).getByText(
         'No linked IVLS devices found for this organization.'
       )
     ).toBeInTheDocument();
@@ -638,7 +736,7 @@ describe('IntegrationsPage — enable/disable IDEXX', () => {
       'IDEXX credentials are missing or invalid. Open settings, fill credentials, validate, and then enable.'
     );
     // setShowSettings(true) opened the modal.
-    expect(await screen.findByTestId('idexx-credentials-panel')).toBeInTheDocument();
+    expect(await screen.findByTestId('settings-modal')).toBeInTheDocument();
     await flush();
   });
 
@@ -676,7 +774,7 @@ describe('IntegrationsPage — enable/disable IDEXX', () => {
 
     const alert = await screen.findByRole('alert');
     expect(alert).toHaveTextContent('Store IDEXX credentials in settings before enabling.');
-    expect(await screen.findByTestId('idexx-credentials-panel')).toBeInTheDocument();
+    expect(await screen.findByTestId('settings-modal')).toBeInTheDocument();
     expect(enableIntegrationMock).not.toHaveBeenCalled();
     await flush();
   });
@@ -710,9 +808,7 @@ describe('IntegrationsPage — enable/disable IDEXX', () => {
     await openSettings();
 
     fireEvent.click(
-      within(screen.getByTestId('idexx-credentials-panel')).getByRole('button', {
-        name: 'Disable IDEXX',
-      })
+      within(screen.getByTestId('settings-modal')).getByRole('button', { name: 'Disable IDEXX' })
     );
 
     await waitFor(() => expect(confirmSpy).toHaveBeenCalled());
@@ -750,9 +846,7 @@ describe('IntegrationsPage — enable/disable IDEXX', () => {
     await openSettings();
 
     fireEvent.click(
-      within(screen.getByTestId('idexx-credentials-panel')).getByRole('button', {
-        name: 'Disable IDEXX',
-      })
+      within(screen.getByTestId('settings-modal')).getByRole('button', { name: 'Disable IDEXX' })
     );
 
     // getEnableDisableLabel(saving=true) → "Updating..." (both the enable/disable and the
@@ -993,7 +1087,7 @@ describe('IntegrationsPage — misc branches', () => {
     expect(screen.getAllByText('Connecting').length).toBeGreaterThanOrEqual(1);
 
     await openSettings();
-    const modal = screen.getByTestId('idexx-credentials-panel');
+    const modal = screen.getByTestId('settings-modal');
     // credentialsStatusTokens fallback branch (unknown key) → "Expired" label rendered.
     expect(within(modal).getByText('Expired')).toBeInTheDocument();
     // resolveValidateState('expired') → 'idle' → no validate meta.
@@ -1011,7 +1105,7 @@ describe('IntegrationsPage — misc branches', () => {
     await waitForPage();
     await openSettings();
 
-    const modal = screen.getByTestId('idexx-credentials-panel');
+    const modal = screen.getByTestId('settings-modal');
     expect(
       within(modal).getByText('Stored credentials detected. Validate and enable when ready.')
     ).toBeInTheDocument();

--- a/apps/frontend/src/app/__tests__/pages/Tasks/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Tasks/index.test.tsx
@@ -80,6 +80,7 @@ const useSearchParamsMock = jest.fn();
 const useIsPhoneMock = jest.fn();
 const taskCalendarSpy = jest.fn();
 const taskAgendaSpy = jest.fn();
+const taskWeekNavSpy = jest.fn();
 const taskTableSpy = jest.fn();
 const taskBoardSpy = jest.fn();
 const taskInfoSpy = jest.fn();
@@ -142,6 +143,7 @@ jest.mock('@/app/ui/layout/guards/PermissionGate', () => ({
 
 jest.mock('@/app/ui/widgets/TitleCalendar', () => (props: any) => (
   <div>
+    {props.actionBeforeAdd}
     <button type="button" onClick={() => props.setActiveView('calendar')}>
       Calendar
     </button>
@@ -178,6 +180,11 @@ jest.mock('@/app/features/appointments/components/Calendar/TaskCalendar', () => 
 jest.mock('@/app/features/tasks/components/TaskWeekAgenda', () => (props: any) => {
   taskAgendaSpy(props);
   return <div data-testid="task-week-agenda" />;
+});
+
+jest.mock('@/app/features/tasks/components/TaskWeekNav', () => (props: any) => {
+  taskWeekNavSpy(props);
+  return <div data-testid="task-week-nav" />;
 });
 
 jest.mock('@/app/ui/tables/Tasks', () => (props: any) => {
@@ -412,36 +419,54 @@ describe('Tasks page', () => {
     );
   });
 
-  it('setCurrentDate prop passed to the agenda updates the date', async () => {
+  it('setCurrentDate prop passed to the title-row week nav updates the date', async () => {
     render(<ProtectedTasks />);
 
-    const agendaProps = taskAgendaSpy.mock.calls[0][0];
-    expect(agendaProps.setCurrentDate).toBeInstanceOf(Function);
+    const navProps = taskWeekNavSpy.mock.calls[0][0];
+    expect(navProps.setCurrentDate).toBeInstanceOf(Function);
     const newDate = new Date('2025-06-01');
 
     await act(async () => {
-      agendaProps.setCurrentDate(newDate);
+      navProps.setCurrentDate(newDate);
       await Promise.resolve();
     });
 
     expect(taskAgendaSpy).toHaveBeenCalledWith(expect.objectContaining({ currentDate: newDate }));
+    expect(taskWeekNavSpy).toHaveBeenCalledWith(expect.objectContaining({ currentDate: newDate }));
   });
 
-  it('setWeekStart prop passed to the agenda updates weekStart', async () => {
+  it('setWeekStart prop passed to the title-row week nav updates weekStart', async () => {
     render(<ProtectedTasks />);
 
-    const agendaProps = taskAgendaSpy.mock.calls[0][0];
-    expect(agendaProps.setWeekStart).toBeInstanceOf(Function);
+    const navProps = taskWeekNavSpy.mock.calls[0][0];
+    expect(navProps.setWeekStart).toBeInstanceOf(Function);
     const newWeekStart = new Date('2025-05-26');
 
     await act(async () => {
-      agendaProps.setWeekStart(newWeekStart);
+      navProps.setWeekStart(newWeekStart);
       await Promise.resolve();
     });
 
     expect(taskAgendaSpy).toHaveBeenCalledWith(
       expect.objectContaining({ weekStart: newWeekStart })
     );
+  });
+
+  it('renders the week nav in the title row only for the desktop calendar view', () => {
+    const { unmount } = render(<ProtectedTasks />);
+    expect(screen.getByTestId('task-week-nav')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('List'));
+    expect(screen.queryByTestId('task-week-nav')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Board'));
+    expect(screen.queryByTestId('task-week-nav')).not.toBeInTheDocument();
+    unmount();
+
+    // The phone day list brings its own header, so the pill stays off there.
+    useIsPhoneMock.mockReturnValue(true);
+    render(<ProtectedTasks />);
+    expect(screen.queryByTestId('task-week-nav')).not.toBeInTheDocument();
   });
 
   it('setActiveCalendar prop updates activeCalendar passed to the phone TaskCalendar', async () => {
@@ -531,7 +556,7 @@ describe('Tasks page', () => {
 
     const nextDate = new Date('2025-07-04');
     await act(async () => {
-      lastPropsOf(taskAgendaSpy).setCurrentDate(() => nextDate);
+      lastPropsOf(taskWeekNavSpy).setCurrentDate(() => nextDate);
       await Promise.resolve();
     });
 

--- a/apps/frontend/src/app/features/appointments/components/Calendar/AppointmentCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/AppointmentCalendar.tsx
@@ -19,6 +19,8 @@ import { filterAppointmentsForWeek } from '@/app/features/appointments/component
 import { useAppointmentCalendarDrag } from '@/app/features/appointments/components/Calendar/useAppointmentCalendarDrag';
 import useIsPhone from '@/app/ui/layout/PhoneShell/useIsPhone';
 import PhoneCalendar from '@/app/features/appointments/components/Calendar/responsive/PhoneCalendar';
+import useIsTabletCalendar from '@/app/features/appointments/components/Calendar/responsive/useIsTabletCalendar';
+import TabletCalendarTitleBand from '@/app/features/appointments/components/Calendar/responsive/TabletCalendarTitleBand';
 type AppointmentCalendarProps = {
   filteredList: Appointment[];
   allAppointments: Appointment[];
@@ -80,6 +82,7 @@ const AppointmentCalendar = ({
 }: AppointmentCalendarProps) => {
   const { notify } = useNotify();
   const isPhone = useIsPhone();
+  const isTablet = useIsTabletCalendar();
   const [zoomMode, setZoomMode] = useState<CalendarZoomMode>('in');
   const teams = useTeamForPrimaryOrg();
   const authUserId = useAuthStore(
@@ -239,10 +242,19 @@ const AppointmentCalendar = ({
   }
 
   return (
-    <div className="h-full min-h-0 border border-card-border rounded-2xl overflow-hidden w-full flex flex-col">
+    <div
+      className="h-full min-h-0 w-full flex flex-col overflow-hidden rounded-[18px] border"
+      style={{
+        borderColor: 'var(--hairline)',
+        backgroundColor: 'var(--screen)',
+        boxShadow: '0 1px 2px var(--sh03), 0 8px 22px var(--sh05)',
+      }}
+    >
       <Header
         currentDate={currentDate}
         setCurrentDate={setCurrentDate}
+        weekStart={weekStart}
+        setWeekStart={setWeekStart}
         zoomMode={zoomMode}
         setZoomMode={setZoomMode}
         activeCalendar={activeCalendar}
@@ -261,6 +273,16 @@ const AppointmentCalendar = ({
         <div className="px-3 py-2 text-caption-1 text-text-error border-b border-card-border">
           {dragError}
         </div>
+      ) : null}
+      {/* The tablet frame names the visible period above the grid and carries
+          the status legend there; desktop keeps the header alone. */}
+      {isTablet ? (
+        <TabletCalendarTitleBand
+          activeCalendar={activeCalendar}
+          currentDate={currentDate}
+          weekStart={weekStart}
+          appointmentCount={activeCalendar === 'week' ? weekEvents.length : dayEvents.length}
+        />
       ) : null}
       {activeCalendar === 'day' && (
         <DayCalendar

--- a/apps/frontend/src/app/features/appointments/components/Calendar/PhoneTaskDayList.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/PhoneTaskDayList.tsx
@@ -271,9 +271,10 @@ const PhoneTaskDayList = ({
       aria-label="Tasks"
       className="flex h-full min-h-0 flex-col bg-[var(--screen)] text-[var(--ink-body)]"
     >
-      <header className="flex h-[54px] flex-none items-center justify-between gap-2 border-b border-[var(--hairline)] px-4">
-        <h2 className="m-0 font-newsreader text-xl font-normal tracking-[-0.015em] text-[var(--ink)]">
-          {`Tasks (${list.totalCount})`}
+      <header className="flex h-[54px] flex-none items-center justify-between gap-2.5 border-b border-[var(--hairline)] px-3.5">
+        <h2 className="m-0 font-satoshi text-[15px] font-bold tracking-[-0.02em] text-[var(--ink)]">
+          Tasks{' '}
+          <span className="font-medium text-[var(--ink-faint)]">{`(${list.totalCount})`}</span>
         </h2>
         <span className="flex flex-none items-center gap-1">
           <button

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/AllDayEventsRow.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/AllDayEventsRow.tsx
@@ -30,9 +30,18 @@ const AllDayEventsRow = ({
   onMarkerDoubleClick,
   onMarkerContextMenu,
 }: AllDayEventsRowProps) => (
-  <div className="p-2 border-b border-grey-light bg-neutral-100 shrink-0">
-    <div className="text-xs font-satoshi text-grey-text mb-1">All-day</div>
-    <div className="flex flex-wrap gap-2">
+  // All-week tray from the frame: --inset surface, 10px/700/0.08em all-caps label.
+  <div
+    className="shrink-0 border-b px-[10px] py-2"
+    style={{ borderColor: 'var(--hairline)', backgroundColor: 'var(--inset)' }}
+  >
+    <div
+      className="mb-1 text-[10px] font-bold uppercase tracking-[0.08em] font-satoshi"
+      style={{ color: 'var(--ink-faint)' }}
+    >
+      All-day
+    </div>
+    <div className="flex flex-wrap gap-[7px]">
       {allDayEvents.map((ev, idx) => {
         const itemKey = getEventKey(ev, idx, 'all-day');
         return (
@@ -46,7 +55,7 @@ const AllDayEventsRow = ({
             onClick={(event) => onMarkerClick(event, itemKey)}
             onDoubleClick={() => onMarkerDoubleClick(ev)}
             onContextMenu={(event) => onMarkerContextMenu(event, ev)}
-            className="flex items-center gap-2 rounded-full! px-3 py-1 text-xs font-satoshi"
+            className="flex items-center gap-1.5 rounded-full! px-[10px] py-[5px] text-[11px] font-semibold font-satoshi"
             style={getStatusStyle(ev.status)}
           >
             <Image
@@ -54,14 +63,14 @@ const AllDayEventsRow = ({
                 getAppointmentCompanionPhotoUrl(ev.companion),
                 (ev.companion ?? ev.patient).species.toLowerCase() as ImageType
               )}
-              height={20}
-              width={20}
+              height={18}
+              width={18}
               priority
-              className="size-5 rounded-full object-cover"
+              className="size-[18px] rounded-full object-cover"
               alt={''}
             />
-            <span className="font-medium truncate max-w-40">{getCompanionDisplayName(ev)}</span>
-            <span className="opacity-70 truncate max-w-30">{ev.concern || ''}</span>
+            <span className="truncate max-w-40">{getCompanionDisplayName(ev)}</span>
+            <span className="opacity-75 truncate max-w-30 font-normal">{ev.concern || ''}</span>
           </button>
         );
       })}

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/CalendarDayHeader.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/CalendarDayHeader.tsx
@@ -8,42 +8,63 @@ export { CalendarTeamNamesRow } from './CalendarTeamNamesRow';
 type CalendarDayNavProps = {
   weekday: string;
   dateNumber: string;
-  onPrevDay: () => void;
-  onNextDay: () => void;
+  /**
+   * Inline day-stepper arrows. Omitted by the appointments planner, whose header
+   * toolbar owns navigation via its date-nav pill; the task calendar still passes
+   * them and keeps its arrows here.
+   */
+  onPrevDay?: () => void;
+  onNextDay?: () => void;
 };
 
 /**
- * Date-navigation bar — arrows flank the date.
- * UserCalendar renders this inside its overflow-x-auto scroll container, on a min-w-max
- * track sized to the full team grid. `sticky left-0` pins the bar to the viewport's left
- * edge so it stays reachable at any scroll offset, and `w-fit` keeps it sized to its own
- * content instead of stretching the arrows across the whole scrollable width.
+ * Date band above the team columns, styled like the week grid's day headers: an
+ * all-caps 9.5px/700/0.08em --ink-faint label over the 14px/700 date on the
+ * --screen-2 band.
+ *
+ * UserCalendar renders this inside its overflow-x-auto scroll container, on a
+ * min-w-max track sized to the full team grid, so `sticky left-0` keeps the date
+ * legible at any horizontal scroll offset and `w-fit` stops it stretching across
+ * the whole scrollable width.
  */
 export const CalendarDayNav = ({
   weekday,
   dateNumber,
   onPrevDay,
   onNextDay,
-}: CalendarDayNavProps) => (
-  <div className="sticky left-0 z-30 flex w-fit items-center gap-2 p-2 bg-neutral-0 shrink-0">
-    <Back onClick={onPrevDay} />
-    <div className="flex items-center gap-2">
-      <div className="text-body-4 text-(--color-primary-700)">{weekday}</div>
-      <div className="text-body-4-emphasis text-white size-8 flex items-center justify-center rounded-full bg-text-brand">
-        {dateNumber}
+}: CalendarDayNavProps) => {
+  const hasInlineNav = !!onPrevDay && !!onNextDay;
+  return (
+    <div
+      className={`sticky left-0 z-30 flex w-fit shrink-0 items-center gap-1.5 py-2 ${
+        hasInlineNav ? 'px-2' : 'px-4'
+      }`}
+      style={{ backgroundColor: 'var(--screen-2)' }}
+    >
+      {hasInlineNav && <Back onClick={onPrevDay} />}
+      <div className="flex items-baseline gap-1.5">
+        <div
+          className="text-[9.5px] font-bold uppercase tracking-[0.08em]"
+          style={{ color: 'var(--ink-faint)' }}
+        >
+          {weekday}
+        </div>
+        <div className="text-[14px] font-bold" style={{ color: 'var(--ink)' }}>
+          {dateNumber}
+        </div>
       </div>
+      {hasInlineNav && <Next onClick={onNextDay} />}
     </div>
-    <Next onClick={onNextDay} />
-  </div>
-);
+  );
+};
 
 type CalendarDayHeaderProps = {
   weekday: string;
   dateNumber: string;
   team: Team[];
   teamColumnsStyle: React.CSSProperties;
-  onPrevDay: () => void;
-  onNextDay: () => void;
+  onPrevDay?: () => void;
+  onNextDay?: () => void;
 };
 
 const CalendarDayHeader = ({
@@ -54,7 +75,7 @@ const CalendarDayHeader = ({
   onPrevDay,
   onNextDay,
 }: CalendarDayHeaderProps) => (
-  <div className="min-w-max bg-neutral-0 shrink-0">
+  <div className="min-w-max shrink-0" style={{ backgroundColor: 'var(--screen-2)' }}>
     <CalendarDayNav
       weekday={weekday}
       dateNumber={dateNumber}

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/CalendarHourLabel.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/CalendarHourLabel.tsx
@@ -17,6 +17,8 @@ type CalendarHourLabelProps = {
   className?: string;
 };
 
+// Time gutter type per the planner frame: 10.5px tabular numerals in --ink-faint,
+// right-aligned 10px inside the 64px gutter rather than left-hugging 12px ink.
 const CalendarHourLabel: React.FC<CalendarHourLabelProps> = ({
   hour,
   height,
@@ -27,11 +29,11 @@ const CalendarHourLabel: React.FC<CalendarHourLabelProps> = ({
   className = '',
 }) => (
   <div
-    className={`text-caption-2 text-text-primary pl-2! relative ${className}`}
+    className={`relative text-[10.5px] leading-none tabular-nums text-[var(--ink-faint)] ${className}`}
     style={{ height: `${height}px` }}
   >
     <span
-      className={`absolute top-0 ${pinFirstHour && hour === firstHour ? 'translate-y-0' : '-translate-y-1/2'}`}
+      className={`absolute top-0 right-[10px] ${pinFirstHour && hour === firstHour ? 'translate-y-0' : '-translate-y-1/2'}`}
     >
       {formatHourLabel(hour)}
     </span>
@@ -39,7 +41,7 @@ const CalendarHourLabel: React.FC<CalendarHourLabelProps> = ({
       slotOffsetMinutes.map((minute) => (
         <span
           key={`slot-time-${hour}-${minute}`}
-          className="absolute right-1 -translate-y-1/2 text-[10px] leading-none text-text-secondary text-right whitespace-nowrap"
+          className="absolute right-[10px] -translate-y-1/2 text-[9.5px] leading-none tabular-nums text-[var(--ink-faint)] text-right whitespace-nowrap opacity-70"
           style={{ top: `${(minute / 60) * 100}%` }}
         >
           {formatMinuteLabel(hour * 60 + minute)}

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/DayCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/DayCalendar.tsx
@@ -27,7 +27,7 @@ import { AppointmentViewIntent, LaidOutEvent } from '@/app/features/appointments
 import TimeLabels from '@/app/features/appointments/components/Calendar/common/TimeLabels';
 import HorizontalLines from '@/app/features/appointments/components/Calendar/common/HorizontalLines';
 import { Appointment } from '@yosemite-crew/types';
-import { useCalendarNavigation, getDateDisplay } from '@/app/hooks/useCalendarNavigation';
+import { getDateDisplay } from '@/app/hooks/useCalendarNavigation';
 import { createPortal } from 'react-dom';
 import {
   CalendarZoomMode,
@@ -484,7 +484,8 @@ const DayCalendarComponent: React.FC<DayCalendarProps> = ({
   handleChangeRoomAppointment,
   handleAcceptAppointment,
   canEditAppointments,
-  setCurrentDate,
+  // setCurrentDate stays on the props contract for callers, but day navigation
+  // now lives in the header toolbar's date-nav pill, which owns the setter.
   draggedAppointmentId,
   draggedAppointmentLabel,
   canDragAppointment,
@@ -515,7 +516,6 @@ const DayCalendarComponent: React.FC<DayCalendarProps> = ({
   } = usePopoverManager({ closeOnHoverLeave: false });
   const appointmentPopoverId = useId();
   const timelineInstructionsId = useId();
-  const { handleNextDay, handlePrevDay } = useCalendarNavigation(setCurrentDate);
   const { weekday, dateNumber } = getDateDisplay(date);
   const now = useCalendarNow();
   const invoices = useInvoicesForPrimaryOrg();
@@ -638,12 +638,7 @@ const DayCalendarComponent: React.FC<DayCalendarProps> = ({
 
   return (
     <div className="h-full flex flex-col">
-      <DayCalendarHeader
-        weekday={weekday}
-        dateNumber={dateNumber}
-        onPrevDay={handlePrevDay}
-        onNextDay={handleNextDay}
-      />
+      <DayCalendarHeader weekday={weekday} dateNumber={dateNumber} />
       {allDayEvents.length > 0 && (
         <AllDayEventsRow
           allDayEvents={allDayEvents}

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/DayCalendarHeader.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/DayCalendarHeader.tsx
@@ -1,28 +1,28 @@
-import Next from '@/app/ui/primitives/Icons/Next';
-import Back from '@/app/ui/primitives/Icons/Back';
-
 type DayCalendarHeaderProps = {
   weekday: string;
   dateNumber: string | number;
-  onPrevDay: () => void;
-  onNextDay: () => void;
 };
 
-const DayCalendarHeader = ({
-  weekday,
-  dateNumber,
-  onPrevDay,
-  onNextDay,
-}: DayCalendarHeaderProps) => (
-  <div className="flex items-center justify-between p-2 border-b border-grey-light shrink-0">
-    <Back onClick={onPrevDay} />
-    <div className="flex items-center gap-2 text-center">
-      <div className="text-body-4 text-(--color-primary-700)">{weekday}</div>
-      <div className="text-body-4-emphasis text-white size-10 flex items-center justify-center rounded-full bg-text-brand">
-        {dateNumber}
-      </div>
+/**
+ * Day-column header for the single-day grid. Same recipe as the week grid's day
+ * headers: a --screen-2 band closed by a --hairline rule, carrying an all-caps
+ * 9.5px/700/0.08em --ink-faint label over the 14px/700 date. Day navigation lives
+ * in the header toolbar's date-nav pill, so this strip carries no arrows.
+ */
+const DayCalendarHeader = ({ weekday, dateNumber }: DayCalendarHeaderProps) => (
+  <div
+    className="flex shrink-0 flex-col items-center gap-px border-b px-1 py-2"
+    style={{ borderColor: 'var(--hairline)', backgroundColor: 'var(--screen-2)' }}
+  >
+    <div
+      className="text-[9.5px] font-bold uppercase tracking-[0.08em]"
+      style={{ color: 'var(--ink-faint)' }}
+    >
+      {weekday}
     </div>
-    <Next onClick={onNextDay} />
+    <div className="text-[14px] font-bold" style={{ color: 'var(--ink)' }}>
+      {dateNumber}
+    </div>
   </div>
 );
 

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/Header.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/Header.tsx
@@ -11,13 +11,23 @@ import { getMonthYear } from '@/app/features/appointments/components/Calendar/he
 import { getEmergencyPillStyle } from '@/app/features/appointments/components/appointmentBoardHelpers';
 import { CalendarZoomMode } from '@/app/features/appointments/components/Calendar/calendarLayout';
 import Datepicker from '@/app/ui/inputs/Datepicker';
-import { IoAdd, IoAddOutline, IoChevronDown, IoRemoveOutline } from 'react-icons/io5';
+import {
+  IoAdd,
+  IoAddOutline,
+  IoChevronBack,
+  IoChevronDown,
+  IoChevronForward,
+  IoRemoveOutline,
+} from 'react-icons/io5';
 import GlassTooltip from '@/app/ui/primitives/GlassTooltip/GlassTooltip';
 import clsx from 'clsx';
 import { createPortal } from 'react-dom';
 import { Primary } from '@/app/ui/primitives/Buttons';
 import SegmentedPill from '@/app/ui/primitives/SegmentedPill/SegmentedPill';
 import { useHasMounted } from '@/app/hooks/useHasMounted';
+import { useCalendarNavigation } from '@/app/hooks/useCalendarNavigation';
+import { useCalendarWeekNavigation } from '@/app/features/appointments/components/Calendar/useCalendarSlots';
+import { getStartOfWeek } from '@/app/features/appointments/components/Calendar/weekHelpers';
 
 type FilterOption = { key: string; name: string };
 type StatusOption = {
@@ -31,21 +41,25 @@ type StatusOption = {
 const getDropdownStatusTextColor = (status: StatusOption): string =>
   status.dropdownText ?? status.text ?? 'var(--color-text-primary)';
 
+// Scope pills follow the planner's filter-row recipe: inactive is a bare
+// --hairline outline with --ink-muted 600 type; the selected pill fills with
+// --inset behind a --divider outline and steps the label to --ink 700.
 const getFilterClassName = (filterKey: string, activeFilter: string): string => {
-  if (filterKey !== activeFilter) return 'text-text-tertiary hover:bg-card-hover!';
+  if (filterKey !== activeFilter)
+    return 'font-semibold text-[var(--ink-muted)] hover:bg-card-hover!';
   // The active emergency pill draws its fill/label from getEmergencyPillStyle's
   // inline style (AA-safe white on --color-danger-800); return no colour class so
   // an `!important` text colour can't override it (the old `text-danger-500!`
   // failed WCAG AA in dark mode).
-  if (filterKey === 'emergencies') return '';
-  return 'bg-blue-light text-blue-text!';
+  if (filterKey === 'emergencies') return 'font-bold';
+  return 'bg-[var(--inset)] font-bold text-[var(--ink)]';
 };
 
 const getFilterBorderColor = (filterKey: string, activeFilter: string): string => {
-  if (filterKey !== activeFilter) return 'var(--color-card-border)';
+  if (filterKey !== activeFilter) return 'var(--hairline)';
   /* v8 ignore next -- unreachable: only called for non-emergency pills (emergency pills use getEmergencyPillStyle) */
   if (filterKey === 'emergencies') return 'var(--color-danger-500)';
-  return 'var(--color-text-brand)';
+  return 'var(--divider)';
 };
 
 const CALENDAR_VIEW_OPTIONS: ReadonlyArray<{ value: string; label: string }> = [
@@ -124,7 +138,7 @@ const StatusFilterDropdown = ({
         ref={dropdown.triggerRef}
         type="button"
         onClick={() => dropdown.setOpen((v) => !v)}
-        className="flex shrink-0 items-center gap-1.5 px-3 py-2 rounded-full! transition-colors text-[12px] font-semibold whitespace-nowrap"
+        className="flex shrink-0 items-center gap-1.5 px-3 py-1.5 rounded-full! transition-colors text-[12px] font-semibold whitespace-nowrap"
         style={
           !isDefault && selectedStatus?.bg
             ? {
@@ -232,7 +246,7 @@ const FilterPills = ({
             type="button"
             onClick={() => onToggle(filter.key)}
             className={clsx(
-              'relative flex shrink-0 items-center justify-center gap-2 whitespace-nowrap px-3 py-2 rounded-full! text-[12px] font-semibold transition-colors',
+              'relative flex shrink-0 items-center justify-center gap-1.5 whitespace-nowrap px-[13px] py-1.5 rounded-full! text-[12px] transition-colors',
               getFilterClassName(filter.key, activeFilter ?? '')
             )}
             style={pillStyle}
@@ -262,6 +276,19 @@ const FilterPills = ({
   );
 };
 
+// Round control inside a segmented/nav pill: the planner sizes these at 30px with
+// a 14px glyph in --ink-faint, raising the selected one onto --screen.
+const PILL_CONTROL_CLASS =
+  'inline-flex size-[30px] shrink-0 cursor-pointer items-center justify-center rounded-full! transition-colors';
+
+/** Track shared by the date-nav pill and the zoom toggle: 4px pad, --hairline, --field-bg. */
+const PILL_TRACK_STYLE: React.CSSProperties = {
+  borderWidth: '1px',
+  borderStyle: 'solid',
+  borderColor: 'var(--hairline)',
+  backgroundColor: 'var(--field-bg)',
+};
+
 const ZoomToggle = ({
   zoomMode,
   setZoomMode,
@@ -270,41 +297,88 @@ const ZoomToggle = ({
   setZoomMode: React.Dispatch<React.SetStateAction<CalendarZoomMode>>;
 }) => {
   const isZoomIn = zoomMode !== 'out';
+  const segmentClass = (active: boolean) =>
+    `${PILL_CONTROL_CLASS} ${
+      active
+        ? 'bg-neutral-0 text-[var(--ink)] shadow-[0_1px_3px_var(--sh08)]'
+        : 'text-[var(--ink-faint)] hover:text-[var(--ink)]'
+    }`;
   return (
-    <div className="inline-flex shrink-0 items-center rounded-full border border-card-border bg-card-bg p-1">
+    <div
+      className="inline-flex shrink-0 items-center gap-1 rounded-full p-1"
+      style={PILL_TRACK_STYLE}
+    >
       <button
         type="button"
         onClick={() => setZoomMode('in')}
         title="Zoom in timeline"
         aria-label="Zoom in timeline"
-        className={`size-9 rounded-full! cursor-pointer inline-flex items-center justify-center transition-colors ${
-          isZoomIn
-            ? 'bg-neutral-0 text-text-primary border border-card-border'
-            : 'text-text-secondary hover:bg-card-hover border border-transparent'
-        }`}
+        className={segmentClass(isZoomIn)}
       >
-        <IoAddOutline size={18} />
+        <IoAddOutline size={16} />
       </button>
       <button
         type="button"
         onClick={() => setZoomMode('out')}
         title="Zoom out timeline"
         aria-label="Zoom out timeline"
-        className={`size-9 rounded-full! cursor-pointer inline-flex items-center justify-center transition-colors ${
-          isZoomIn
-            ? 'text-text-secondary hover:bg-card-hover border border-transparent'
-            : 'bg-neutral-0 text-text-primary border border-card-border'
-        }`}
+        className={segmentClass(!isZoomIn)}
       >
-        <IoRemoveOutline size={18} />
+        <IoRemoveOutline size={16} />
       </button>
     </div>
   );
 };
 
+/**
+ * Date nav pill — prev arrow, current range label, next arrow on one --field-bg
+ * track, per the planner header. The arrows step by week in the week view and by
+ * day everywhere else, reusing the same navigation hooks the grids used before.
+ */
+const CalendarDateNav = ({
+  label,
+  prevLabel,
+  nextLabel,
+  onPrev,
+  onNext,
+}: {
+  label: string;
+  prevLabel: string;
+  nextLabel: string;
+  onPrev: () => void;
+  onNext: () => void;
+}) => (
+  <div className="flex shrink-0 items-center gap-1 rounded-full p-1" style={PILL_TRACK_STYLE}>
+    <button
+      type="button"
+      onClick={onPrev}
+      aria-label={prevLabel}
+      title={prevLabel}
+      className={`${PILL_CONTROL_CLASS} text-[var(--ink-faint)] hover:text-[var(--ink)]`}
+    >
+      <IoChevronBack size={14} aria-hidden="true" />
+    </button>
+    <span className="whitespace-nowrap px-1.5 text-[13px] font-bold text-[var(--ink)]">
+      {label}
+    </span>
+    <button
+      type="button"
+      onClick={onNext}
+      aria-label={nextLabel}
+      title={nextLabel}
+      className={`${PILL_CONTROL_CLASS} text-[var(--ink-faint)] hover:text-[var(--ink)]`}
+    >
+      <IoChevronForward size={14} aria-hidden="true" />
+    </button>
+  </div>
+);
+
 type Headerprops = {
   currentDate: Date;
   setCurrentDate: React.Dispatch<React.SetStateAction<Date>>;
+  /** Supplied by the week view so the header arrows step whole weeks. */
+  weekStart?: Date;
+  setWeekStart?: React.Dispatch<React.SetStateAction<Date>>;
   zoomMode?: CalendarZoomMode;
   setZoomMode?: React.Dispatch<React.SetStateAction<CalendarZoomMode>>;
   activeCalendar?: string;
@@ -323,6 +397,7 @@ type Headerprops = {
 const Header = ({
   setCurrentDate,
   currentDate,
+  setWeekStart,
   zoomMode,
   setZoomMode,
   activeCalendar,
@@ -345,9 +420,28 @@ const Header = ({
     setActiveFilter(activeFilter === filterKey ? 'all' : filterKey);
   };
 
+  const { handlePrevDay, handleNextDay } = useCalendarNavigation(setCurrentDate);
+  // Hooks must run unconditionally, so the week navigation is always built; the
+  // no-op dispatch only ever runs when the week view did not hand down its state.
+  const noopSetWeekStart = useCallback<React.Dispatch<React.SetStateAction<Date>>>(() => {}, []);
+  const { handlePrevWeek, handleNextWeek } = useCalendarWeekNavigation(
+    setWeekStart ?? noopSetWeekStart,
+    setCurrentDate
+  );
+  const navigatesByWeek = activeCalendar === 'week' && !!setWeekStart;
+
+  const handleToday = useCallback(() => {
+    const today = new Date();
+    setCurrentDate(today);
+    setWeekStart?.(getStartOfWeek(today));
+  }, [setCurrentDate, setWeekStart]);
+
   return (
-    <div className="sticky top-0 z-140 shrink-0 flex w-full items-center gap-4 border-b border-card-border bg-neutral-0 px-3 py-2">
-      <div className="flex shrink-0 items-center gap-3">
+    <div
+      className="sticky top-0 z-140 shrink-0 flex w-full items-center gap-4 border-b bg-neutral-0 px-4 py-2.5"
+      style={{ borderColor: 'var(--hairline)' }}
+    >
+      <div className="flex shrink-0 items-center gap-2.5">
         <GlassTooltip content="Select date" side="bottom">
           <div className="relative z-150">
             <Datepicker
@@ -357,9 +451,21 @@ const Header = ({
             />
           </div>
         </GlassTooltip>
-        <div className="whitespace-nowrap text-body-3 font-medium text-text-primary">
-          {getMonthYear(currentDate)}
-        </div>
+        <CalendarDateNav
+          label={getMonthYear(currentDate)}
+          prevLabel={navigatesByWeek ? 'Previous week' : 'Previous day'}
+          nextLabel={navigatesByWeek ? 'Next week' : 'Next day'}
+          onPrev={navigatesByWeek ? handlePrevWeek : handlePrevDay}
+          onNext={navigatesByWeek ? handleNextWeek : handleNextDay}
+        />
+        <button
+          type="button"
+          onClick={handleToday}
+          className="shrink-0 rounded-full! px-[13px] py-2 text-[12px] font-bold whitespace-nowrap transition-colors text-[var(--ink-body)] hover:bg-card-hover!"
+          style={{ borderWidth: '1px', borderStyle: 'solid', borderColor: 'var(--hairline)' }}
+        >
+          Today
+        </button>
       </div>
 
       <div
@@ -400,12 +506,16 @@ const Header = ({
 
           {showAddButton && (
             <>
-              <div className="h-8 w-px shrink-0 bg-card-border" aria-hidden="true" />
+              <div
+                className="h-6 w-px shrink-0"
+                style={{ backgroundColor: 'var(--hairline)' }}
+                aria-hidden="true"
+              />
               <Primary
                 text="New appointment"
                 onClick={onAddButtonClick}
-                icon={<IoAdd size={18} aria-hidden="true" />}
-                className="h-12 w-fit shrink-0 justify-center gap-2 px-4 py-0 whitespace-nowrap hover:scale-100"
+                icon={<IoAdd size={16} aria-hidden="true" />}
+                className="h-10 w-fit shrink-0 justify-center gap-[7px] px-[18px] py-0 text-[13.5px] font-semibold whitespace-nowrap hover:scale-100"
               />
             </>
           )}

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/Header.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/Header.tsx
@@ -281,6 +281,14 @@ const FilterPills = ({
 const PILL_CONTROL_CLASS =
   'inline-flex size-[30px] shrink-0 cursor-pointer items-center justify-center rounded-full! transition-colors';
 
+/** Zoom-toggle segment: the selected half lifts onto --screen, the other stays faint. */
+const getZoomSegmentClass = (active: boolean): string =>
+  `${PILL_CONTROL_CLASS} ${
+    active
+      ? 'bg-neutral-0 text-[var(--ink)] shadow-[0_1px_3px_var(--sh08)]'
+      : 'text-[var(--ink-faint)] hover:text-[var(--ink)]'
+  }`;
+
 /** Track shared by the date-nav pill and the zoom toggle: 4px pad, --hairline, --field-bg. */
 const PILL_TRACK_STYLE: React.CSSProperties = {
   borderWidth: '1px',
@@ -297,12 +305,6 @@ const ZoomToggle = ({
   setZoomMode: React.Dispatch<React.SetStateAction<CalendarZoomMode>>;
 }) => {
   const isZoomIn = zoomMode !== 'out';
-  const segmentClass = (active: boolean) =>
-    `${PILL_CONTROL_CLASS} ${
-      active
-        ? 'bg-neutral-0 text-[var(--ink)] shadow-[0_1px_3px_var(--sh08)]'
-        : 'text-[var(--ink-faint)] hover:text-[var(--ink)]'
-    }`;
   return (
     <div
       className="inline-flex shrink-0 items-center gap-1 rounded-full p-1"
@@ -313,7 +315,7 @@ const ZoomToggle = ({
         onClick={() => setZoomMode('in')}
         title="Zoom in timeline"
         aria-label="Zoom in timeline"
-        className={segmentClass(isZoomIn)}
+        className={getZoomSegmentClass(isZoomIn)}
       >
         <IoAddOutline size={16} />
       </button>
@@ -322,7 +324,7 @@ const ZoomToggle = ({
         onClick={() => setZoomMode('out')}
         title="Zoom out timeline"
         aria-label="Zoom out timeline"
-        className={segmentClass(!isZoomIn)}
+        className={getZoomSegmentClass(!isZoomIn)}
       >
         <IoRemoveOutline size={16} />
       </button>

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/HorizontalLines.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/HorizontalLines.tsx
@@ -6,6 +6,10 @@ import {
 } from '@/app/features/appointments/components/Calendar/helpers';
 import { formatDateInPreferredTimeZone } from '@/app/lib/timezone';
 
+// Warm grid rules, matching SlotGridLines and the frame's `1px solid var(--hairline)`.
+const HOUR_LINE_COLOR = 'var(--hairline)';
+const SLOT_LINE_COLOR = 'color-mix(in srgb, var(--hairline) 55%, transparent)';
+
 type HorizontalLinesProps = {
   date: Date;
   now?: Date;
@@ -55,8 +59,8 @@ const HorizontalLines = ({
       return (
         <div
           key={hour}
-          className="absolute left-0 right-0 border-t border-[var(--color-calendar-line-strong)]"
-          style={{ top }}
+          className="absolute left-0 right-0 border-t"
+          style={{ top, borderColor: HOUR_LINE_COLOR }}
         />
       );
     }).filter(Boolean);
@@ -74,8 +78,8 @@ const HorizontalLines = ({
       lines.push(
         <div
           key={`slot-${minute}`}
-          className="absolute left-0 right-0 border-t border-[var(--color-calendar-line-soft)]"
-          style={{ top }}
+          className="absolute left-0 right-0 border-t"
+          style={{ top, borderColor: SLOT_LINE_COLOR }}
         />
       );
     }
@@ -85,22 +89,39 @@ const HorizontalLines = ({
 
   return (
     <>
-      <div className="absolute left-0 right-0 top-0 border-t border-[var(--color-calendar-line-strong)]" />
+      <div
+        className="absolute left-0 right-0 top-0 border-t"
+        style={{ borderColor: HOUR_LINE_COLOR }}
+      />
       {slotLines}
       {hourLines}
       <div
-        className="absolute left-0 right-0 border-t border-[var(--color-calendar-line-strong)]"
-        style={{ top: totalHeightPx }}
+        className="absolute left-0 right-0 border-t"
+        style={{ top: totalHeightPx, borderColor: HOUR_LINE_COLOR }}
       />
       {nowTopPx != null && (
         <div className="absolute left-0 right-0 z-10" style={{ top: nowTopPx }}>
           {nowTimeLabel && (
-            <div className="absolute left-3 -translate-y-[115%] text-[10px] leading-none font-semibold text-danger-700 whitespace-nowrap">
+            <div
+              className="absolute left-3 -translate-y-[115%] text-[10px] leading-none font-semibold whitespace-nowrap"
+              style={{ color: 'var(--blue-text)' }}
+            >
               {nowTimeLabel}
             </div>
           )}
-          <div className="absolute left-[-5px] size-3 rounded-full bg-red-500 translate-y-[-50%]" />
-          <div className="border-t-2 border-t-red-500 translate-y-[-50%]" />
+          <div
+            className="absolute left-[-5px] size-[7px] rounded-full translate-y-[-50%]"
+            style={{ backgroundColor: 'var(--blue)' }}
+          />
+          <div
+            className="translate-y-[-50%]"
+            style={{
+              borderTopWidth: '2px',
+              borderTopStyle: 'solid',
+              borderTopColor: 'var(--blue)',
+              opacity: 0.75,
+            }}
+          />
         </div>
       )}
     </>

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/Slot.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/Slot.tsx
@@ -421,7 +421,9 @@ const SlotComponent: React.FC<SlotProps> = ({
             onDropPreviewClear={() => setDropPreviewMinute(null)}
           />
         ) : (
-          <div className="relative h-full bg-neutral-0 overflow-visible px-1">
+          // Transparent so the week grid's today-column tint reads through; the
+          // calendar container already supplies the --screen surface underneath.
+          <div className="relative h-full overflow-visible px-1">
             {laidOutZoomInEvents.map(
               ({ ev, startMinute, visibleDurationMinutes, laneIndex, laneCount }) => {
                 const itemKey = getSlotEventKey(ev);

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/SlotGridLines.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/SlotGridLines.tsx
@@ -7,6 +7,13 @@ type SlotGridLinesProps = {
   slotOffsetMinutes: number[];
 };
 
+// Hour rules are the frame's plain `1px solid var(--hairline)`. The sub-hour slot
+// rules have no counterpart in the frame, so they take a diluted --hairline, which
+// stays a step softer than the hour rule in both themes (a flat --divider does not:
+// it is darker than --hairline in light and lighter in dark).
+const HOUR_LINE_COLOR = 'var(--hairline)';
+const SLOT_LINE_COLOR = 'color-mix(in srgb, var(--hairline) 55%, transparent)';
+
 const SlotGridLines = ({
   userId,
   hour,
@@ -14,16 +21,19 @@ const SlotGridLines = ({
   slotOffsetMinutes,
 }: SlotGridLinesProps) => (
   <div className="pointer-events-none absolute inset-0 z-10">
-    <div className="absolute inset-x-0 top-0 border-t border-[var(--color-calendar-line-strong)]" />
+    <div className="absolute inset-x-0 top-0 border-t" style={{ borderColor: HOUR_LINE_COLOR }} />
     {slotOffsetMinutes.map((minute) => (
       <div
         key={`${userId}-${hour}-slot-${minute}`}
-        className="absolute inset-x-0 border-t border-[var(--color-calendar-line-soft)]"
-        style={{ top: `${(minute / 60) * 100}%` }}
+        className="absolute inset-x-0 border-t"
+        style={{ top: `${(minute / 60) * 100}%`, borderColor: SLOT_LINE_COLOR }}
       />
     ))}
     {hour === lastVisibleHour && (
-      <div className="absolute inset-x-0 top-full border-t border-[var(--color-calendar-line-strong)]" />
+      <div
+        className="absolute inset-x-0 top-full border-t"
+        style={{ borderColor: HOUR_LINE_COLOR }}
+      />
     )}
   </div>
 );

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/UserCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/UserCalendar.tsx
@@ -18,7 +18,6 @@ import { useTeamForPrimaryOrg } from '@/app/hooks/useTeam';
 import CalendarDayHeader from '@/app/features/appointments/components/Calendar/common/CalendarDayHeader';
 import Slot from '@/app/features/appointments/components/Calendar/common/Slot';
 import { Appointment } from '@yosemite-crew/types';
-import { useCalendarNavigation } from '@/app/hooks/useCalendarNavigation';
 import {
   CalendarZoomMode,
   getCalendarColumnGridStyle,
@@ -87,7 +86,8 @@ const UserCalendar: React.FC<UserCalendarProps> = ({
   handleRescheduleAppointment,
   handleChangeRoomAppointment,
   handleAcceptAppointment,
-  setCurrentDate,
+  // setCurrentDate stays on the props contract for callers, but day navigation
+  // now lives in the header toolbar's date-nav pill, which owns the setter.
   canEditAppointments,
   draggedAppointmentId,
   draggedAppointmentLabel,
@@ -110,7 +110,6 @@ const UserCalendar: React.FC<UserCalendarProps> = ({
   const now = useCalendarNow();
   const invoices = useInvoicesForPrimaryOrg();
   const invoicesByAppointmentId = useMemo(() => createInvoiceByAppointmentId(invoices), [invoices]);
-  const { handleNextDay, handlePrevDay } = useCalendarNavigation(setCurrentDate);
   const height = getHourRowHeightPx(zoomMode);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const onWheelHorizontal = useWheelToHorizontalScroll();
@@ -235,8 +234,6 @@ const UserCalendar: React.FC<UserCalendarProps> = ({
             dateNumber={dateNumber}
             team={team}
             teamColumnsStyle={teamColumnsStyle}
-            onPrevDay={handlePrevDay}
-            onNextDay={handleNextDay}
           />
 
           <div

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/UserLabels.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/UserLabels.tsx
@@ -12,7 +12,9 @@ const UserLabels = ({ team, columnsStyle }: UserLabels) => {
   const currentUserId = attributes?.sub || attributes?.email;
 
   return (
-    <div className="grid min-w-max py-1.5" style={columnsStyle}>
+    // Team column headers take the planner frame's 13px/700 --ink name type
+    // (was 16px/500 muted body), on the frame's 12px vertical padding.
+    <div className="grid min-w-max py-3" style={columnsStyle}>
       {team.map((user, idx) => {
         const isCurrentUser = !!currentUserId && user.practionerId === currentUserId;
         return (
@@ -21,7 +23,7 @@ const UserLabels = ({ team, columnsStyle }: UserLabels) => {
             className="flex items-center justify-center flex-col"
           >
             <div
-              className={`text-body-4 font-medium ${isCurrentUser ? 'text-(--color-primary-700)' : 'text-text-secondary'}`}
+              className={`text-[13px] font-bold leading-[1.2] ${isCurrentUser ? 'text-(--color-primary-700)' : 'text-[var(--ink)]'}`}
             >
               {user.name || ''}
             </div>

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/WeekCalendar.css
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/WeekCalendar.css
@@ -9,7 +9,7 @@
    768–1279 band overrides them. */
 
 .yc-week-grid {
-  /* Time gutter and the mirrored nav-arrow column. */
+  /* Time gutter. 64px on desktop, per the planner frame's `64px repeat(n, 1fr)`. */
   --yc-week-gutter: 64px;
   /* Minimum width of a single day column before the track starts scrolling. */
   --yc-week-day-min: 140px;
@@ -25,10 +25,11 @@
   min-width: max-content;
 }
 
-/* Three-column shell: time gutter | day columns | next-week arrow. */
+/* Two-column shell: time gutter | day columns. The week grid in the design has no
+   arrow columns at all — prev/next live in the header toolbar's date-nav pill. */
 .yc-week-grid__shell {
   display: grid;
-  grid-template-columns: var(--yc-week-gutter) minmax(0, 1fr) var(--yc-week-gutter);
+  grid-template-columns: var(--yc-week-gutter) minmax(0, 1fr);
 }
 
 /* ------------------------------------------------------- tablet: 768–1279 */
@@ -48,15 +49,15 @@
   }
 
   /* The hour gutter drops from 64px to 44px, so the labels take the frame's
-     9.5px tabular type. Both selectors need to out-specify the unlayered
-     `.text-caption-2` override in globals.css. */
+     9.5px tabular type and tuck to a 6px right inset (the tablet frame's
+     `right: 6px`) instead of the desktop frame's 10px. */
   .yc-week-grid .yc-week-grid__hour-label {
-    padding-left: 2px !important;
-    font-size: 9.5px !important;
+    font-size: 9.5px;
     line-height: 1;
   }
 
   .yc-week-grid .yc-week-grid__hour-label span {
+    right: 6px;
     font-size: 9.5px;
   }
 }

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/WeekCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/WeekCalendar.tsx
@@ -18,8 +18,6 @@ import {
 import Slot from '@/app/features/appointments/components/Calendar/common/Slot';
 import { getStatusStyle } from '@/app/config/statusConfig';
 import { Appointment } from '@yosemite-crew/types';
-import Back from '@/app/ui/primitives/Icons/Back';
-import Next from '@/app/ui/primitives/Icons/Next';
 import {
   CalendarZoomMode,
   getHourRowHeightPx,
@@ -38,7 +36,6 @@ import { formatCompanionNameWithOwnerLastName } from '@/app/lib/companionName';
 import {
   getVisibleHourRange,
   getVisibleHours,
-  useCalendarWeekNavigation,
   useSlotOffsetMinutes,
 } from '@/app/features/appointments/components/Calendar/useCalendarSlots';
 import type { AppointmentViewIntent } from '@/app/features/appointments/types/calendar';
@@ -171,59 +168,73 @@ const UnavailableHourOverlays = ({
   );
 };
 
-/** Week nav arrows either side of the seven day-of-week headers; today's date is pilled. */
+/**
+ * Day-of-week header strip. Per the week-grid frame: a --screen-2 band closed by a
+ * --hairline rule, each day a centred stack of an all-caps 9.5px/700/0.08em label
+ * over a 14px/700 date, hairline-separated. Today swaps the label to --nav-active
+ * and drops the date into a 24px --blue disc, over a --nav-active-bg cell.
+ * Week navigation lives in the header toolbar's date-nav pill, not here.
+ */
 const WeekDayHeaderRow = ({
   days,
   now,
   dayColumnsStyle,
-  onPrevWeek,
-  onNextWeek,
 }: {
   days: Date[];
   now: Date;
   dayColumnsStyle: React.CSSProperties;
-  onPrevWeek: () => void;
-  onNextWeek: () => void;
 }) => (
-  <div className="yc-week-grid__shell yc-week-grid__track border-b border-card-border py-2 bg-neutral-0">
-    <div className="sticky left-0 z-40 bg-neutral-0 flex items-center justify-center">
-      <Back onClick={onPrevWeek} />
-    </div>
-    <div className="grid bg-neutral-0" style={dayColumnsStyle}>
+  <div
+    className="yc-week-grid__shell yc-week-grid__track border-b"
+    style={{ borderColor: 'var(--hairline)', backgroundColor: 'var(--screen-2)' }}
+  >
+    <div className="sticky left-0 z-40" style={{ backgroundColor: 'var(--screen-2)' }} />
+    <div className="grid" style={dayColumnsStyle}>
       {days.map((day) => {
         const weekday = formatDateInPreferredTimeZone(day, {
           weekday: 'short',
         });
         const dateNumber = day.getDate();
         const isToday = isOnPreferredTimeZoneCalendarDay(now, day);
-        const dateNumberClass = isToday
-          ? 'bg-text-brand text-white border-transparent'
-          : 'bg-card-bg text-text-secondary border-transparent';
         return (
-          <div key={day.toISOString()} className="flex items-center justify-center gap-2">
+          <div
+            key={day.toISOString()}
+            className="flex flex-col items-center gap-px border-l px-1 py-2"
+            style={{
+              borderColor: 'var(--hairline)',
+              backgroundColor: isToday ? 'var(--nav-active-bg)' : undefined,
+            }}
+          >
             <div
-              className={`text-body-4 ${
-                isToday ? 'text-(--color-primary-700)' : 'text-text-primary'
-              }`}
+              className="text-[9.5px] font-bold uppercase tracking-[0.08em]"
+              style={{ color: isToday ? 'var(--nav-active)' : 'var(--ink-faint)' }}
             >
               {weekday}
             </div>
-            <div
-              className={`text-body-4-emphasis size-10 flex items-center justify-center rounded-full border ${dateNumberClass}`}
-            >
-              {dateNumber}
-            </div>
+            {isToday ? (
+              <div
+                className="flex size-6 items-center justify-center rounded-full text-[13px] font-bold text-white"
+                style={{ backgroundColor: 'var(--blue)' }}
+              >
+                {dateNumber}
+              </div>
+            ) : (
+              <div className="text-[14px] font-bold" style={{ color: 'var(--ink)' }}>
+                {dateNumber}
+              </div>
+            )}
           </div>
         );
       })}
     </div>
-    <div className="sticky right-0 z-40 bg-neutral-0 flex items-center justify-center">
-      <Next onClick={onNextWeek} />
-    </div>
   </div>
 );
 
-/** The pinned all-day strip above the hour grid — only rendered when some day has one. */
+/**
+ * The pinned all-day strip above the hour grid — only rendered when some day has
+ * one. Matches the frame's all-week band: an --inset tray, a 10px/700/0.08em
+ * all-caps --ink-faint label, and status-tinted 11px/600 rounded-full chips.
+ */
 const AllDayBand = ({
   days,
   allDayByDay,
@@ -235,23 +246,29 @@ const AllDayBand = ({
   dayColumnsStyle: React.CSSProperties;
   handleViewAppointment: (appointment: Appointment) => void;
 }) => (
-  <div className="border-b border-card-border bg-neutral-100">
-    <div className="yc-week-grid__shell yc-week-grid__track py-2">
-      <div className="sticky left-0 z-40 bg-neutral-100 text-xs font-satoshi text-grey-text flex items-start pr-2">
+  <div className="border-b" style={{ borderColor: 'var(--hairline)' }}>
+    <div
+      className="yc-week-grid__shell yc-week-grid__track py-2"
+      style={{ backgroundColor: 'var(--inset)' }}
+    >
+      <div
+        className="sticky left-0 z-40 flex items-start pr-2 pl-2 text-[10px] font-bold uppercase tracking-[0.08em]"
+        style={{ backgroundColor: 'var(--inset)', color: 'var(--ink-faint)' }}
+      >
         All-day
       </div>
       <div className="grid yc-week-grid__track" style={dayColumnsStyle}>
         {days.map((day, idx) => {
           const dayAllEvents = allDayByDay[idx];
           return (
-            <div key={day.toISOString()} className="flex flex-col gap-1 pr-2">
+            <div key={day.toISOString()} className="flex flex-col gap-1 px-1">
               {dayAllEvents.map((ev) => (
                 <button
                   key={`${(ev.companion ?? ev.patient).name}-${ev.startTime.toISOString()}`}
                   type="button"
                   onClick={() => handleViewAppointment(ev)}
                   aria-label={getAllDayAppointmentAriaLabel(ev)}
-                  className="w-full rounded-md! px-2 py-1 text-[11px] font-satoshi text-left truncate"
+                  className="w-full rounded-full! px-[10px] py-[5px] text-[11px] font-semibold font-satoshi text-left truncate"
                   style={{
                     ...({
                       ...getStatusStyle(ev.status),
@@ -259,7 +276,7 @@ const AllDayBand = ({
                     } as React.CSSProperties),
                   }}
                 >
-                  <div className="font-medium truncate">
+                  <div className="truncate">
                     {formatCompanionNameWithOwnerLastName(
                       (ev.companion ?? ev.patient).name,
                       (ev.companion ?? ev.patient).parent
@@ -272,7 +289,6 @@ const AllDayBand = ({
           );
         })}
       </div>
-      <div className="sticky right-0 z-40 bg-neutral-100" />
     </div>
   </div>
 );
@@ -302,18 +318,31 @@ const NowIndicatorOverlay = ({
                 }}
               >
                 {nowTimeLabel && (
-                  <div className="absolute left-3 -translate-y-[115%] text-[10px] leading-none font-semibold text-danger-700 whitespace-nowrap">
+                  <div
+                    className="absolute left-3 -translate-y-[115%] text-[10px] leading-none font-semibold whitespace-nowrap"
+                    style={{ color: 'var(--blue-text)' }}
+                  >
                     {nowTimeLabel}
                   </div>
                 )}
-                <div className="absolute -left-1.25 size-3 rounded-full bg-red-500 -translate-y-1/2" />
-                <div className="border-t-2 border-t-red-500 translate-y-[-50%]" />
+                <div
+                  className="absolute -left-1.25 size-[7px] rounded-full -translate-y-1/2"
+                  style={{ backgroundColor: 'var(--blue)' }}
+                />
+                <div
+                  className="translate-y-[-50%]"
+                  style={{
+                    borderTopWidth: '2px',
+                    borderTopStyle: 'solid',
+                    borderTopColor: 'var(--blue)',
+                    opacity: 0.75,
+                  }}
+                />
               </div>
             )}
           </div>
         ))}
       </div>
-      <div />
     </div>
   </div>
 );
@@ -360,8 +389,9 @@ const WeekCalendar: React.FC<WeekCalendarProps> = ({
   handleDetailAppointment,
   handleOpenWorkspace,
   weekStart,
-  setWeekStart,
-  setCurrentDate,
+  // setWeekStart / setCurrentDate stay on the props contract but are no longer read
+  // here: week navigation moved to the header toolbar's date-nav pill, which owns
+  // both setters. The grid itself only reads weekStart.
   handleRescheduleAppointment,
   handleChangeRoomAppointment,
   handleAcceptAppointment,
@@ -449,9 +479,10 @@ const WeekCalendar: React.FC<WeekCalendarProps> = ({
     return entries;
   }, [days, timedEvents, visibleHours]);
   const lastVisibleHour = visibleHours.at(-1) ?? visibleHourRange.endHour;
-  const { handlePrevWeek, handleNextWeek } = useCalendarWeekNavigation(
-    setWeekStart,
-    setCurrentDate
+
+  const todayColumnIndex = useMemo(
+    () => days.findIndex((day) => isOnPreferredTimeZoneCalendarDay(now, day)),
+    [days, now]
   );
 
   const nowPosition = useMemo(() => {
@@ -517,13 +548,7 @@ const WeekCalendar: React.FC<WeekCalendarProps> = ({
       >
         <div className="yc-week-grid__track h-full flex flex-col">
           <div className="z-30 bg-neutral-0 shrink-0">
-            <WeekDayHeaderRow
-              days={days}
-              now={now}
-              dayColumnsStyle={dayColumnsStyle}
-              onPrevWeek={handlePrevWeek}
-              onNextWeek={handleNextWeek}
-            />
+            <WeekDayHeaderRow days={days} now={now} dayColumnsStyle={dayColumnsStyle} />
 
             {hasAnyAllDay && (
               <AllDayBand
@@ -564,11 +589,19 @@ const WeekCalendar: React.FC<WeekCalendarProps> = ({
                     {days.map((day, dayIndex) => {
                       const slotEvents =
                         timedEventsByDayHour.get(`${day.toISOString()}-${hour}`) ?? [];
+                      // Today's column carries a soft wash for the whole height of
+                      // the grid, matching the tinted day column in the frame. It is
+                      // keyed off the day itself, not the now-line, so the tint holds
+                      // when the current time falls outside the visible hour range.
+                      const isTodayColumn = dayIndex === todayColumnIndex;
                       return (
                         <div
                           key={`${day.toISOString()}-${hour}`}
                           className="relative"
-                          style={{ height: `${height}px` }}
+                          style={{
+                            height: `${height}px`,
+                            backgroundColor: isTodayColumn ? 'var(--surface-soft)' : undefined,
+                          }}
                         >
                           <UnavailableHourOverlays
                             segments={unavailableByDay[dayIndex]}
@@ -613,7 +646,6 @@ const WeekCalendar: React.FC<WeekCalendarProps> = ({
                       );
                     })}
                   </div>
-                  <div className="sticky right-0 z-20 bg-neutral-0" style={{ height }} />
                 </div>
               ))}
               <div style={{ height: zoomMode === 'out' ? 30 : 40 }} />

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/ZoomInMarker.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/ZoomInMarker.tsx
@@ -35,7 +35,9 @@ const ZoomInMarker = ({
   const companionDisplayName = getCompanionDisplayName(ev);
   const markerTitle = [companionDisplayName, serviceName, concern].filter(Boolean).join(' • ');
   const buttonProps = getMarkerButtonProps(ev, interaction, markerTitle);
-  const laneGapPx = 3;
+  // 2px lane gap on top of the slot's own 4px inset lands the block on the frame's
+  // `left: 6px; right: 6px` inset.
+  const laneGapPx = 2;
   const widthPercent = 100 / laneCount;
   const leftPercent = widthPercent * laneIndex;
 
@@ -53,8 +55,9 @@ const ZoomInMarker = ({
     ? 'cursor-grab active:cursor-grabbing'
     : 'cursor-pointer';
 
+  // Frame subtitle: 11px in the status text colour at 0.75 opacity.
   const subtitleClass =
-    'truncate font-satoshi text-[11px] font-normal leading-[1.2] tracking-[-0.22px]';
+    'truncate font-satoshi text-[11px] font-normal leading-[1.2] tracking-[-0.22px] opacity-75';
   let subtitleNode: React.ReactNode = null;
   if (tall) {
     subtitleNode = (
@@ -83,9 +86,12 @@ const ZoomInMarker = ({
     subtitleNode = <div className={`${subtitleClass} mt-1`}>{serviceName}</div>;
   }
 
+  // Frame appointment card: 12px radius over a 1px status outline, thickened to a
+  // 3px status spine on the leading edge.
   const appointmentBlockStyle: React.CSSProperties = {
     ...statusStyle,
     borderWidth: '1px',
+    borderLeftWidth: '3px',
     borderStyle: 'solid',
     borderColor: statusStyle.borderColor,
     top: topPx,
@@ -96,7 +102,7 @@ const ZoomInMarker = ({
   };
 
   return (
-    <div className="absolute z-20 overflow-hidden rounded-2xl!" style={appointmentBlockStyle}>
+    <div className="absolute z-20 overflow-hidden rounded-[12px]!" style={appointmentBlockStyle}>
       <button
         type="button"
         {...buttonProps}
@@ -118,7 +124,7 @@ const ZoomInMarker = ({
           </div>
         )}
         <div className="min-w-0 flex-1 overflow-hidden">
-          <div className="truncate text-caption-1 font-bold leading-[1.2]">
+          <div className="truncate text-[12.5px] font-bold leading-[1.2] tracking-[-0.25px]">
             {companionDisplayName}
           </div>
           {subtitleNode}

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/slotHelpers.ts
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/slotHelpers.ts
@@ -64,10 +64,10 @@ export const getMarkerSizing = (laneCount: number, blockHeightPx: number): Marke
   } else {
     imgSize = 24;
   }
+  // The frame pads every full-size appointment card at 8px 12px; only the short
+  // single-lane tier tightens vertically so a 5-minute block still fits its name.
   let verticalPadding: string;
-  if (tall) {
-    verticalPadding = 'py-2.5';
-  } else if (medium) {
+  if (tall || medium) {
     verticalPadding = 'py-2';
   } else {
     verticalPadding = 'py-0.5';

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneCalendar.tsx
@@ -17,6 +17,7 @@ import type { Task } from '@/app/features/tasks/types/task';
 import type { AppointmentDraftPrefill } from '@/app/features/appointments/types/calendar';
 
 import PhoneDayRail from './PhoneDayRail';
+import PhoneDayStrip from './PhoneDayStrip';
 import PhoneWeekOverview from './PhoneWeekOverview';
 import PhoneMonthOverview from './PhoneMonthOverview';
 import PhoneMyDayRail from './PhoneMyDayRail';
@@ -307,6 +308,15 @@ const PhoneCalendar = ({
           ariaLabel="Calendar view"
         />
       </div>
+      {/* The frame gives the phone day view its own date strip rather than a
+          shrunken week header, so the week stays one tap away from the rail. */}
+      <PhoneDayStrip
+        weekStart={weekStart}
+        appointments={appointments}
+        selectedDate={currentDate}
+        today={referenceNow}
+        onSelectDay={setCurrentDate}
+      />
       <div className="min-h-0 flex-1 overflow-y-auto">
         <PhoneDayRail
           appointments={dayEvents}

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneDayStrip.css
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneDayStrip.css
@@ -1,0 +1,86 @@
+/* PIMS phone day strip — the week as seven tappable load cells.
+   Every value is measured from the "Phone day calendar" frame in
+   `PIMS Responsive - Calendar`; the comment above each block names the source
+   declaration. Colours are token-only so light and dark come for free. */
+
+/* Frame: display flex; gap 5px. */
+.yc-day-strip {
+  display: flex;
+  flex: none;
+  gap: 5px;
+}
+
+/* Frame: flex 1; column; centred; gap 3px; padding 7px 0 6px; radius 12px. */
+.yc-day-strip__cell {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+  padding: 7px 0 6px;
+  border: 0;
+  border-radius: 12px;
+  background: none;
+  cursor: pointer;
+}
+
+/* Frame: selected cell fills --blue and lifts on 0 6px 16px var(--glow-b26). */
+.yc-day-strip__cell--selected {
+  background: var(--blue);
+  box-shadow: 0 6px 16px var(--glow-b26);
+}
+
+/* Frame: a day with no load recedes to 45%. */
+.yc-day-strip__cell--quiet {
+  opacity: 0.45;
+}
+
+/* Frame: font-size 9px; font-weight 700; letter-spacing 0.06em; --ink-faint. */
+.yc-day-strip__weekday {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: var(--ink-faint);
+}
+
+/* Frame: the selected cell's weekday is white at 75%. */
+.yc-day-strip__cell--selected .yc-day-strip__weekday {
+  color: rgba(255, 255, 255, 0.75);
+}
+
+/* Frame: font-size 14px; font-weight 700; color var(--ink). */
+.yc-day-strip__date {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--ink);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Frame: days already past drop to var(--ink-muted). */
+.yc-day-strip__date--past {
+  color: var(--ink-muted);
+}
+
+.yc-day-strip__cell--selected .yc-day-strip__date {
+  color: #ffffff;
+}
+
+/* Frame: dot row gap 2px; each dot 3.5px, fully round. */
+.yc-day-strip__dots {
+  display: flex;
+  gap: 2px;
+  height: 3.5px;
+}
+
+.yc-day-strip__dot {
+  width: 3.5px;
+  height: 3.5px;
+  border-radius: 9999px;
+  background: var(--blue);
+}
+
+/* Frame: on the filled cell the dots invert to white. */
+.yc-day-strip__cell--selected .yc-day-strip__dot {
+  background: #ffffff;
+}

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneDayStrip.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneDayStrip.tsx
@@ -4,79 +4,8 @@ import React, { useMemo } from 'react';
 import clsx from 'clsx';
 import type { Appointment } from '@yosemite-crew/types';
 
-import { getDateKeyInPreferredTimeZone } from '@/app/lib/timezone';
-import { getLoadDotCount } from './phoneMonthModel';
+import { buildPhoneDayStrip, type PhoneDayStripCell } from './phoneDayStripModel';
 import './PhoneDayStrip.css';
-
-const DAYS_IN_WEEK = 7;
-
-/** Frame labels: three-letter, uppercase, Monday first. */
-const WEEKDAY_LABELS = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'] as const;
-
-export type PhoneDayStripCell = {
-  date: Date;
-  dateKey: string;
-  dayOfMonth: number;
-  weekdayLabel: string;
-  isToday: boolean;
-  isPast: boolean;
-  isSelected: boolean;
-  appointmentCount: number;
-  dotCount: number;
-};
-
-export type PhoneDayStripInput = {
-  weekStart: Date;
-  appointments: readonly Appointment[];
-  selectedDate: Date;
-  today: Date;
-};
-
-const addDays = (date: Date, days: number): Date => {
-  const next = new Date(date);
-  next.setDate(next.getDate() + days);
-  return next;
-};
-
-/**
- * Seven cells from `weekStart`, each carrying its own load. Appointments are
- * bucketed by their calendar-day key in the preferred timezone (the only correct
- * instant -> day conversion), so a late-evening appointment cannot land on the
- * neighbouring cell when the browser sits in a different zone.
- */
-export const buildPhoneDayStrip = ({
-  weekStart,
-  appointments,
-  selectedDate,
-  today,
-}: PhoneDayStripInput): PhoneDayStripCell[] => {
-  const counts = new Map<string, number>();
-  appointments.forEach((appointment) => {
-    const key = getDateKeyInPreferredTimeZone(appointment.startTime);
-    counts.set(key, (counts.get(key) ?? 0) + 1);
-  });
-
-  const todayKey = getDateKeyInPreferredTimeZone(today);
-  const selectedKey = getDateKeyInPreferredTimeZone(selectedDate);
-
-  return Array.from({ length: DAYS_IN_WEEK }, (_, index) => {
-    const date = addDays(weekStart, index);
-    const dateKey = getDateKeyInPreferredTimeZone(date);
-    const appointmentCount = counts.get(dateKey) ?? 0;
-
-    return {
-      date,
-      dateKey,
-      dayOfMonth: date.getDate(),
-      weekdayLabel: WEEKDAY_LABELS[index],
-      isToday: dateKey === todayKey,
-      isPast: dateKey < todayKey,
-      isSelected: dateKey === selectedKey,
-      appointmentCount,
-      dotCount: getLoadDotCount(appointmentCount),
-    };
-  });
-};
 
 /** Past load reads as done (green); anything from today onwards reads live (blue). */
 const dotColour = (cell: PhoneDayStripCell): string =>

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneDayStrip.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneDayStrip.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import clsx from 'clsx';
+import type { Appointment } from '@yosemite-crew/types';
+
+import { getDateKeyInPreferredTimeZone } from '@/app/lib/timezone';
+import { getLoadDotCount } from './phoneMonthModel';
+import './PhoneDayStrip.css';
+
+const DAYS_IN_WEEK = 7;
+
+/** Frame labels: three-letter, uppercase, Monday first. */
+const WEEKDAY_LABELS = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'] as const;
+
+export type PhoneDayStripCell = {
+  date: Date;
+  dateKey: string;
+  dayOfMonth: number;
+  weekdayLabel: string;
+  isToday: boolean;
+  isPast: boolean;
+  isSelected: boolean;
+  appointmentCount: number;
+  dotCount: number;
+};
+
+export type PhoneDayStripInput = {
+  weekStart: Date;
+  appointments: readonly Appointment[];
+  selectedDate: Date;
+  today: Date;
+};
+
+const addDays = (date: Date, days: number): Date => {
+  const next = new Date(date);
+  next.setDate(next.getDate() + days);
+  return next;
+};
+
+/**
+ * Seven cells from `weekStart`, each carrying its own load. Appointments are
+ * bucketed by their calendar-day key in the preferred timezone (the only correct
+ * instant -> day conversion), so a late-evening appointment cannot land on the
+ * neighbouring cell when the browser sits in a different zone.
+ */
+export const buildPhoneDayStrip = ({
+  weekStart,
+  appointments,
+  selectedDate,
+  today,
+}: PhoneDayStripInput): PhoneDayStripCell[] => {
+  const counts = new Map<string, number>();
+  appointments.forEach((appointment) => {
+    const key = getDateKeyInPreferredTimeZone(appointment.startTime);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  });
+
+  const todayKey = getDateKeyInPreferredTimeZone(today);
+  const selectedKey = getDateKeyInPreferredTimeZone(selectedDate);
+
+  return Array.from({ length: DAYS_IN_WEEK }, (_, index) => {
+    const date = addDays(weekStart, index);
+    const dateKey = getDateKeyInPreferredTimeZone(date);
+    const appointmentCount = counts.get(dateKey) ?? 0;
+
+    return {
+      date,
+      dateKey,
+      dayOfMonth: date.getDate(),
+      weekdayLabel: WEEKDAY_LABELS[index],
+      isToday: dateKey === todayKey,
+      isPast: dateKey < todayKey,
+      isSelected: dateKey === selectedKey,
+      appointmentCount,
+      dotCount: getLoadDotCount(appointmentCount),
+    };
+  });
+};
+
+/** Past load reads as done (green); anything from today onwards reads live (blue). */
+const dotColour = (cell: PhoneDayStripCell): string =>
+  cell.isPast ? 'var(--status-completed-border)' : 'var(--blue)';
+
+export type PhoneDayStripProps = {
+  weekStart: Date;
+  appointments: readonly Appointment[];
+  selectedDate: Date;
+  /** Injectable for deterministic rendering/tests. Defaults to now. */
+  today?: Date;
+  onSelectDay?: (date: Date) => void;
+  className?: string;
+};
+
+/**
+ * Phone day selector — the week as seven tappable load cells.
+ *
+ * The frame gives the phone day view its own date strip rather than a shrunken
+ * week header: each cell stacks the weekday over the date over up to three load
+ * dots, and the selected day fills with `--blue` and lifts on a blue glow. Empty
+ * days recede to 45% so the busy end of the week reads at a glance.
+ */
+const PhoneDayStrip = ({
+  weekStart,
+  appointments,
+  selectedDate,
+  today,
+  onSelectDay,
+  className,
+}: Readonly<PhoneDayStripProps>) => {
+  const cells = useMemo(
+    () => buildPhoneDayStrip({ weekStart, appointments, selectedDate, today: today ?? new Date() }),
+    [weekStart, appointments, selectedDate, today]
+  );
+
+  return (
+    <div className={clsx('yc-day-strip', className)} role="group" aria-label="Select a day">
+      {cells.map((cell) => (
+        <button
+          key={cell.dateKey}
+          type="button"
+          aria-pressed={cell.isSelected}
+          aria-current={cell.isToday ? 'date' : undefined}
+          aria-label={`${cell.weekdayLabel} ${cell.dayOfMonth} · ${cell.appointmentCount} appointments`}
+          onClick={() => onSelectDay?.(cell.date)}
+          className={clsx(
+            'yc-day-strip__cell',
+            cell.isSelected && 'yc-day-strip__cell--selected',
+            !cell.isSelected && cell.appointmentCount === 0 && 'yc-day-strip__cell--quiet'
+          )}
+        >
+          <span className="yc-day-strip__weekday">{cell.weekdayLabel}</span>
+          <span
+            className={clsx(
+              'yc-day-strip__date',
+              !cell.isSelected && cell.isPast && 'yc-day-strip__date--past'
+            )}
+          >
+            {cell.dayOfMonth}
+          </span>
+          <span className="yc-day-strip__dots" data-testid={`day-strip-dots-${cell.dateKey}`}>
+            {Array.from({ length: cell.dotCount }, (_, index) => (
+              <span
+                key={`${cell.dateKey}-dot-${index}`}
+                className="yc-day-strip__dot"
+                style={cell.isSelected ? undefined : { background: dotColour(cell) }}
+              />
+            ))}
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default PhoneDayStrip;

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/TabletCalendar.css
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/TabletCalendar.css
@@ -1,0 +1,79 @@
+/* PIMS tablet calendar (768–1023px).
+   Every value below is measured from the "Tablet week grid" frame in
+   `PIMS Responsive - Calendar`; the comment on each block names the source
+   declaration so a later change can be checked against the frame rather than
+   guessed. Colours are token-only, so light and dark come for free.
+
+   Ownership: the calendar's control strip (pager, Today, view switch, filters,
+   New, zoom) lives in `common/Header.tsx`, which the desktop pass owns. Nothing
+   here restyles it. This file only adds the period line the tablet frame puts
+   between the header and the grid, plus the grid's card surround. */
+
+@media (min-width: 768px) and (max-width: 1023.98px) {
+  /* --------------------------------------------------------- period line */
+
+  /* Frame: padding 18px 20px on the content column, 12px gap to the grid. */
+  .yc-tablet-toolbar__body {
+    display: flex;
+    flex: none;
+    flex-direction: column;
+    gap: 12px;
+    padding: 14px 20px 12px;
+    background: var(--screen);
+  }
+
+  .yc-tablet-toolbar__title-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    min-width: 0;
+  }
+
+  /* Frame: Newsreader 400 24px, letter-spacing -0.015em, var(--ink). */
+  .yc-tablet-toolbar__title {
+    margin: 0;
+    font-family: var(--font-newsreader), Georgia, serif;
+    font-weight: 400;
+    font-size: 24px;
+    letter-spacing: -0.015em;
+    color: var(--ink);
+    white-space: nowrap;
+  }
+
+  /* Frame: font-size 16px; color var(--ink-faint). */
+  .yc-tablet-toolbar__title-count {
+    font-size: 16px;
+    color: var(--ink-faint);
+  }
+
+  /* Frame: gap 12px; font-size 10.5px; color var(--ink-faint). */
+  .yc-tablet-toolbar__legend {
+    display: flex;
+    flex: none;
+    align-items: center;
+    gap: 12px;
+    font-size: 10.5px;
+    color: var(--ink-faint);
+    white-space: nowrap;
+  }
+
+  .yc-tablet-toolbar__legend-item {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  /* Frame: 7px square, radius 2px. */
+  .yc-tablet-toolbar__legend-swatch {
+    width: 7px;
+    height: 7px;
+    border-radius: 2px;
+  }
+}
+
+/* The grid's own card surround (1px hairline, radius 18px, two-stop shadow) and
+   its internal geometry at this band (44px time gutter, seven equal 1fr columns,
+   9.5px hour labels) are already set by `AppointmentCalendar`'s container and by
+   the 768–1279 band of `common/WeekCalendar.css`. Both are owned by the desktop
+   pass, so nothing is duplicated here. */

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/TabletCalendarTitleBand.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/TabletCalendarTitleBand.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import React from 'react';
+
+import { buildTabletToolbarTitle } from './tabletToolbarModel';
+import './TabletCalendar.css';
+
+/** Frame legend: four 7px swatches, in this order, at 10.5px `--ink-faint`. */
+const LEGEND_ITEMS: ReadonlyArray<{ label: string; colour: string }> = [
+  { label: 'Upcoming', colour: 'var(--status-upcoming-border)' },
+  { label: 'In progress', colour: 'var(--status-in-progress-border)' },
+  { label: 'Done', colour: 'var(--status-completed-border)' },
+  { label: 'Emergency', colour: 'var(--danger)' },
+];
+
+export type TabletCalendarTitleBandProps = {
+  /** The shared page-level view key: `day` | `week` | `team`. */
+  activeCalendar: string;
+  currentDate: Date;
+  weekStart: Date;
+  /** Appointments already scoped to the visible period by the caller. */
+  appointmentCount: number;
+};
+
+/**
+ * The tablet frame's period line: a serif title naming the visible period, its
+ * appointment count, and the status legend.
+ *
+ * This band exists only between 768 and 1023px. The controls above it (pager,
+ * Today, view switch, filters, New, zoom) all live in the shared calendar
+ * `Header`, which is owned by the desktop pass — this component deliberately
+ * adds no control of its own so the two layers cannot fight over the same
+ * handler. Below 768px `PhoneCalendar` renders its own title instead.
+ */
+const TabletCalendarTitleBand = ({
+  activeCalendar,
+  currentDate,
+  weekStart,
+  appointmentCount,
+}: Readonly<TabletCalendarTitleBandProps>) => {
+  const { title, countLabel } = buildTabletToolbarTitle({
+    activeCalendar,
+    currentDate,
+    weekStart,
+    appointmentCount,
+  });
+
+  return (
+    <div className="yc-tablet-toolbar__body">
+      <div className="yc-tablet-toolbar__title-row">
+        <h2 className="yc-tablet-toolbar__title">
+          {title}
+          {countLabel ? (
+            <span className="yc-tablet-toolbar__title-count">{` ${countLabel}`}</span>
+          ) : null}
+        </h2>
+        <span className="yc-tablet-toolbar__legend">
+          {LEGEND_ITEMS.map((item) => (
+            <span key={item.label} className="yc-tablet-toolbar__legend-item">
+              <span
+                aria-hidden
+                className="yc-tablet-toolbar__legend-swatch"
+                style={{ background: item.colour }}
+              />
+              {item.label}
+            </span>
+          ))}
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export default TabletCalendarTitleBand;

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/phoneDayStripModel.ts
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/phoneDayStripModel.ts
@@ -1,0 +1,74 @@
+import type { Appointment } from '@yosemite-crew/types';
+
+import { getDateKeyInPreferredTimeZone } from '@/app/lib/timezone';
+import { getLoadDotCount } from './phoneMonthModel';
+
+const DAYS_IN_WEEK = 7;
+
+/** Frame labels: three-letter, uppercase, Monday first. */
+const WEEKDAY_LABELS = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'] as const;
+
+export type PhoneDayStripCell = {
+  date: Date;
+  dateKey: string;
+  dayOfMonth: number;
+  weekdayLabel: string;
+  isToday: boolean;
+  isPast: boolean;
+  isSelected: boolean;
+  appointmentCount: number;
+  dotCount: number;
+};
+
+export type PhoneDayStripInput = {
+  weekStart: Date;
+  appointments: readonly Appointment[];
+  selectedDate: Date;
+  today: Date;
+};
+
+const addDays = (date: Date, days: number): Date => {
+  const next = new Date(date);
+  next.setDate(next.getDate() + days);
+  return next;
+};
+
+/**
+ * Seven cells from `weekStart`, each carrying its own load. Appointments are
+ * bucketed by their calendar-day key in the preferred timezone (the only correct
+ * instant -> day conversion), so a late-evening appointment cannot land on the
+ * neighbouring cell when the browser sits in a different zone.
+ */
+export const buildPhoneDayStrip = ({
+  weekStart,
+  appointments,
+  selectedDate,
+  today,
+}: PhoneDayStripInput): PhoneDayStripCell[] => {
+  const counts = new Map<string, number>();
+  appointments.forEach((appointment) => {
+    const key = getDateKeyInPreferredTimeZone(appointment.startTime);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  });
+
+  const todayKey = getDateKeyInPreferredTimeZone(today);
+  const selectedKey = getDateKeyInPreferredTimeZone(selectedDate);
+
+  return Array.from({ length: DAYS_IN_WEEK }, (_, index) => {
+    const date = addDays(weekStart, index);
+    const dateKey = getDateKeyInPreferredTimeZone(date);
+    const appointmentCount = counts.get(dateKey) ?? 0;
+
+    return {
+      date,
+      dateKey,
+      dayOfMonth: date.getDate(),
+      weekdayLabel: WEEKDAY_LABELS[index],
+      isToday: dateKey === todayKey,
+      isPast: dateKey < todayKey,
+      isSelected: dateKey === selectedKey,
+      appointmentCount,
+      dotCount: getLoadDotCount(appointmentCount),
+    };
+  });
+};

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/tabletToolbarModel.ts
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/tabletToolbarModel.ts
@@ -1,0 +1,97 @@
+import { formatDateInPreferredTimeZone, getDatePartsInPreferredTimeZone } from '@/app/lib/timezone';
+import { getIsoWeekNumber } from './phoneMonthModel';
+
+/**
+ * Pure derivation for the tablet calendar toolbar.
+ *
+ * The tablet frame condenses the desktop header into a single pager + title
+ * line, so the toolbar needs a compact range label ("6 – 12 Jul") and a title
+ * that names the period rather than repeating the month picker. Everything here
+ * is formatting only — no state, no side effects — so it can be unit tested
+ * without rendering the grid.
+ */
+
+const DAYS_IN_WEEK = 7;
+
+export const addCalendarDays = (date: Date, days: number): Date => {
+  const next = new Date(date);
+  next.setDate(next.getDate() + days);
+  return next;
+};
+
+/**
+ * The frame writes dates day-first ("6 – 12 Jul", "Tue 7 Jul"), which `en-US`
+ * will not produce, so the day and month are composed by hand from the
+ * preferred-timezone parts rather than handed wholesale to `Intl`.
+ */
+const getShortMonth = (date: Date): string =>
+  formatDateInPreferredTimeZone(date, { month: 'short' });
+
+const getShortWeekday = (date: Date): string =>
+  formatDateInPreferredTimeZone(date, { weekday: 'short' });
+
+/**
+ * "6 – 12 Jul" when the week sits inside one month, "29 Jun – 5 Jul" when it
+ * straddles two. Uses an en dash exactly as the frame does.
+ */
+export const getWeekRangeLabel = (weekStart: Date): string => {
+  const weekEnd = addCalendarDays(weekStart, DAYS_IN_WEEK - 1);
+  const startParts = getDatePartsInPreferredTimeZone(weekStart);
+  const endParts = getDatePartsInPreferredTimeZone(weekEnd);
+  const endLabel = `${endParts.day} ${getShortMonth(weekEnd)}`;
+
+  if (startParts.month === endParts.month && startParts.year === endParts.year) {
+    return `${startParts.day} – ${endLabel}`;
+  }
+
+  return `${startParts.day} ${getShortMonth(weekStart)} – ${endLabel}`;
+};
+
+/** "Tue 7 Jul" — the period label for the single-day and team views. */
+export const getDayRangeLabel = (date: Date): string =>
+  `${getShortWeekday(date)} ${getDatePartsInPreferredTimeZone(date).day} ${getShortMonth(date)}`;
+
+export type TabletToolbarTitle = {
+  /** e.g. `Week 28` or `Tue 7 Jul`. */
+  title: string;
+  /** e.g. `(41 appointments)`, or an empty string when the period is empty. */
+  countLabel: string;
+};
+
+export type TabletToolbarTitleInput = {
+  /** The shared page-level view key: `day` | `week` | `team`. */
+  activeCalendar: string;
+  currentDate: Date;
+  weekStart: Date;
+  /** Appointments already scoped to the visible period by the caller. */
+  appointmentCount: number;
+};
+
+const pluralise = (count: number): string =>
+  `${count} ${count === 1 ? 'appointment' : 'appointments'}`;
+
+export const buildTabletToolbarTitle = ({
+  activeCalendar,
+  currentDate,
+  weekStart,
+  appointmentCount,
+}: TabletToolbarTitleInput): TabletToolbarTitle => {
+  const countLabel = appointmentCount > 0 ? `(${pluralise(appointmentCount)})` : '';
+
+  if (activeCalendar === 'week') {
+    const parts = getDatePartsInPreferredTimeZone(weekStart);
+    return {
+      title: `Week ${getIsoWeekNumber(parts.year, parts.month, parts.day)}`,
+      countLabel,
+    };
+  }
+
+  return { title: getDayRangeLabel(currentDate), countLabel };
+};
+
+/**
+ * The pager steps a whole week in the week view and a single day everywhere
+ * else, so one control drives both without changing which view is active.
+ */
+export const getPagerStepDays = (activeCalendar: string): number =>
+  activeCalendar === 'week' ? DAYS_IN_WEEK : 1;

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/useIsTabletCalendar.ts
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/useIsTabletCalendar.ts
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/**
+ * Tablet band for the appointments calendar. The responsive contract is:
+ * phone (< 768px) gets the purpose-built rails, tablet (768–1023px) keeps a real
+ * seven-day grid under a condensed toolbar, and desktop (>= 1024px) is untouched.
+ *
+ * This is deliberately narrower than the shell's `TABLET_RAIL_MEDIA_QUERY`
+ * (768–1279): the icon rail and the calendar chrome are different questions, and
+ * the calendar frame that was signed off stops at 1023.
+ */
+export const TABLET_CALENDAR_MEDIA_QUERY = '(min-width: 768px) and (max-width: 1023px)';
+
+/**
+ * Returns true only inside the tablet band. Starts `false` during SSR and the
+ * first client render (there is no `matchMedia` on the server) so desktop never
+ * flashes the tablet toolbar and there is no hydration mismatch; it flips to the
+ * real value after mount.
+ */
+export function useIsTabletCalendar(query: string = TABLET_CALENDAR_MEDIA_QUERY): boolean {
+  const [isTabletCalendar, setIsTabletCalendar] = useState(false);
+
+  useEffect(() => {
+    if (typeof globalThis.matchMedia !== 'function') return undefined;
+
+    const mediaQueryList = globalThis.matchMedia(query);
+    const update = () => setIsTabletCalendar(mediaQueryList.matches);
+
+    update();
+    mediaQueryList.addEventListener('change', update);
+    return () => mediaQueryList.removeEventListener('change', update);
+  }, [query]);
+
+  return isTabletCalendar;
+}
+
+export default useIsTabletCalendar;

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/index.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/index.tsx
@@ -1650,7 +1650,7 @@ const useAppointmentWorkspaceContent = ({ appointment }: AppointmentWorkspacePro
 
   return (
     <div className="flex flex-col gap-5 pb-12">
-      <div className="-mx-4 -mt-5 flex flex-col gap-5 bg-(--status-in-progress-bg) px-4 pt-5 pb-5 sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8">
+      <div className="-mx-4 -mt-5 flex flex-col gap-5 bg-(--screen) px-4 pt-5 pb-5 sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8">
         <WorkspaceHeader
           appointment={appointment}
           companionName={companion.name}

--- a/apps/frontend/src/app/features/chat/components/ChatContainer.css
+++ b/apps/frontend/src/app/features/chat/components/ChatContainer.css
@@ -23,6 +23,47 @@
   }
 }
 
+/* ---------------------------------------------------------------------------
+   Stream theme -> warm-bone token bridge.
+   stream-chat-react is mounted with theme="str-chat__theme-light", whose palette
+   is cool: #ffffff backgrounds, #dbdde1 / #b4b7bb grey surfaces and lines, and a
+   system font stack. Every Stream-owned surface we do NOT replace with a custom
+   component inherited that palette, which is what made the thread read as a
+   cool, "weird" canvas under the warm-bone chrome (and stayed light in dark
+   mode). Remapping the theme variables onto our own tokens fixes the whole
+   subtree at once and is automatically theme-correct, because the warm-bone
+   tokens already flip with [data-theme].
+   --------------------------------------------------------------------------- */
+.str-chat,
+.str-chat__theme-light {
+  --str-chat__font-family: var(--font-satoshi);
+  --str-chat__background-color: var(--screen);
+  --str-chat__secondary-background-color: var(--screen-2);
+  --str-chat__primary-color: var(--blue);
+  --str-chat__active-primary-color: var(--blue);
+  --str-chat__primary-color-low-emphasis: var(--blue-soft);
+  --str-chat__on-primary-color: #ffffff;
+  --str-chat__primary-surface-color: var(--blue-soft);
+  --str-chat__primary-surface-color-low-emphasis: var(--blue-soft);
+  --str-chat__surface-color: var(--hairline);
+  --str-chat__secondary-surface-color: var(--inset);
+  --str-chat__tertiary-surface-color: var(--screen-2);
+  --str-chat__text-color: var(--ink-body);
+  --str-chat__text-low-emphasis-color: var(--ink-faint);
+  --str-chat__disabled-color: var(--hairline);
+  --str-chat__on-disabled-color: var(--screen);
+  --str-chat__danger-color: var(--danger-text);
+  --str-chat__info-color: var(--success);
+  --str-chat__message-highlight-color: var(--blue-soft);
+  --str-chat__unread-badge-color: var(--blue);
+  --str-chat__on-unread-badge-color: #ffffff;
+  --str-chat__box-shadow-color: var(--sh12);
+  /* Date separators are a centered label in the design — no rule through the
+     thread — so the line colour is neutralised here as well as hidden below. */
+  --str-chat__date-separator-line-color: transparent;
+  --str-chat__date-separator-color: var(--ink-faint);
+}
+
 .str-chat {
   display: flex;
   height: 100%;
@@ -73,32 +114,23 @@
   min-height: 0;
 }
 
+/* Design (conversation list): rows are inset 10px from the panel edges and
+   separated by a 2px gap — no dividers. */
 .str-chat__channel-list-messenger__main {
   flex: 1;
   min-height: 0;
   overflow-y: auto;
-  padding: 8px;
+  padding: 8px 10px 12px;
   display: flex;
   flex-direction: column;
   gap: 2px;
 }
 
-.str-chat__channel-preview {
-  padding: 12px 16px;
-  border-bottom: 1px solid var(--color-chat-divider-soft);
-  cursor: pointer;
-  transition: background-color 0.2s;
-}
-
-.str-chat__channel-preview:hover {
-  background: var(--color-chat-surface-soft);
-}
-
-.str-chat__channel-preview--active {
-  background: var(--color-chat-panel);
-  border-left: 3px solid var(--color-chat-panel-border);
-  padding-left: 13px;
-}
+/* NOTE: Stream's own `.str-chat__channel-preview` styling is intentionally
+   absent. That class only ships on ChannelPreviewMessenger, which we replace
+   with <ConversationRow>; the design's conversation list is a stack of rounded
+   rows separated by a 2px gap, NOT a ruled list, so no divider/left-stripe rules
+   belong here. Row styling lives in ConversationRow.tsx. */
 
 .chat-preview-trigger {
   display: block;
@@ -213,8 +245,32 @@
   background: var(--color-chat-surface);
 }
 
+/* Thread gutters. Design ("Chat extended") message canvas is `padding: 16px
+   22px`. Stream additionally applies `padding: 0 min(2.5rem, 4%)` to the scroll
+   container (with matching negative margins on each <li>), which stacked on top
+   of ours for a ~54px gutter on a desktop-width thread. Neutralise Stream's pair
+   so the measured 22px is the whole gutter. */
+.str-chat__main-panel .str-chat__list .str-chat__message-list-scroll,
+.str-chat__main-panel .str-chat__virtual-list .str-chat__message-list-scroll > div {
+  padding-inline: 0;
+}
+
+.str-chat__main-panel .str-chat__list .str-chat__li,
+.str-chat__main-panel .str-chat__virtual-list .str-chat__li,
+.str-chat__main-panel .str-chat__list .str-chat__parent-message-li,
+.str-chat__main-panel .str-chat__virtual-list .str-chat__parent-message-li {
+  margin-inline: 0;
+  padding-inline: 0;
+}
+
 .str-chat__main-panel .str-chat__list {
   padding: 16px 18px 8px;
+}
+
+@media (min-width: 1280px) {
+  .str-chat__main-panel .str-chat__list {
+    padding: 16px 22px 8px;
+  }
 }
 
 /* Guard against horizontal overflow anywhere in the conversation pane: long
@@ -262,25 +318,39 @@
    (ChatChannelListPaginator) using the reusable Primary button, so Stream's
    default full-width load-more button needs no override here. */
 
-/* Date separators between message groups */
+/* Date separators between message groups.
+   Design ("Chat extended" / "Tasks & Chat", thread): a small centered eyebrow
+   label — 10.5px / 700 / 0.08em / uppercase / --ink-faint — with NO rule running
+   across the thread. Stream's default draws a 1px --disabled-color line either
+   side of the date, which is the faint full-width banding the design does not
+   have. */
 .str-chat__date-separator {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 12px 8px;
+  justify-content: center;
+  gap: 0;
+  padding: 10px 8px 6px;
+  background: transparent;
+}
+
+/* Stream spaces the separator's children with a trailing margin; with the lines
+   hidden that margin would push the label off-centre. */
+.str-chat__date-separator > *:not(:last-child) {
+  margin-right: 0;
 }
 
 .str-chat__date-separator-line {
-  flex: 1;
-  height: 1px;
-  background: var(--color-chat-divider);
+  display: none;
 }
 
 .str-chat__date-separator-date {
   font-family: var(--font-satoshi);
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--color-text-secondary);
+  font-size: 10.5px;
+  font-weight: 700;
+  line-height: 1.2;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
   white-space: nowrap;
 }
 

--- a/apps/frontend/src/app/features/chat/components/ChatContainer.tsx
+++ b/apps/frontend/src/app/features/chat/components/ChatContainer.tsx
@@ -509,7 +509,7 @@ const ChannelHeaderWithCounterpart: FC<{
             <Text
               as="span"
               variant="body-3-emphasis"
-              className="min-w-0 flex-1 truncate text-[13.5px] font-bold text-[var(--ink)]"
+              className="min-w-0 flex-1 truncate text-[13.5px] font-bold text-[var(--ink)] xl:text-[14.5px]"
             >
               {title}
             </Text>
@@ -521,12 +521,18 @@ const ChannelHeaderWithCounterpart: FC<{
             )}
           </span>
           {online && !isGroupChat && !hasSessionClosed ? (
-            <span className="flex min-w-0 items-center gap-1.5 text-[10.5px] text-[var(--success)]">
-              <span className="chat-presence-dot h-[5px] w-[5px] shrink-0 rounded-full bg-[var(--success)]" />
+            /* Design (thread header, online): 11.5px --success with a 6px pulsing dot. */
+            <span className="flex min-w-0 items-center gap-1.5 text-[11.5px] text-[var(--success)]">
+              <span className="chat-presence-dot h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--success)]" />
               <span className="truncate">{statusText}</span>
             </span>
           ) : (
-            <Text as="span" variant="caption-2" className="truncate text-[var(--ink-faint)]">
+            /* Design (thread header, offline): 11px --ink-faint. */
+            <Text
+              as="span"
+              variant="caption-2"
+              className="truncate text-[11px] text-[var(--ink-faint)]"
+            >
               {statusText}
             </Text>
           )}
@@ -947,14 +953,16 @@ const ChatSidebarHeader: FC<ChatSidebarHeaderProps> = ({
         <ChatScopeSwitcher scope={scope} onScopeChange={onScopeChange} />
       </div>
       <div className="border-b border-chat-divider p-3">
-        <div className="flex min-h-[38px] items-center gap-2 rounded-full border border-[var(--hairline)] bg-[var(--field-bg)] px-4 py-2 transition-colors focus-within:border-input-border-active">
-          <IoSearchOutline className="size-4 shrink-0 text-input-text-placeholder" />
+        {/* Design (channel-list search): 38px pill, --field-bg + --hairline,
+            0 13px padding, 14px icon, 12.5px --ink-faint placeholder. */}
+        <div className="flex min-h-[38px] items-center gap-2 rounded-full border border-[var(--hairline)] bg-[var(--field-bg)] px-[13px] py-2 transition-colors focus-within:border-input-border-active">
+          <IoSearchOutline className="size-3.5 shrink-0 text-[var(--ink-faint)]" />
           <input
             value={searchTerm}
             onChange={(e) => onSearchTermChange(e.target.value)}
             placeholder="Search conversations…"
             aria-label="Search conversations"
-            className="w-full bg-transparent font-satoshi text-body-4 text-text-primary outline-none placeholder:text-input-text-placeholder"
+            className="w-full bg-transparent font-satoshi text-[12.5px] text-[var(--ink-body)] outline-none placeholder:text-[var(--ink-faint)]"
           />
           <span className="hidden shrink-0 items-center gap-0.5 rounded-md border border-[var(--hairline)] px-1.5 py-0.5 text-xs font-semibold text-[var(--ink-faint)] sm:flex">
             <LuCommand className="size-3" />K

--- a/apps/frontend/src/app/features/chat/components/ChatHeaderContext.tsx
+++ b/apps/frontend/src/app/features/chat/components/ChatHeaderContext.tsx
@@ -90,19 +90,29 @@ export function ChatHeaderContext({
         </div>
       )}
       {appointment && (
-        <div className="flex flex-col gap-2.5 border-b border-[var(--hairline)] bg-[var(--screen-2)] px-3 py-2.5 sm:flex-row sm:items-center sm:justify-between sm:gap-3 sm:px-4 sm:py-3">
-          {/* Compact appointment context chip that sits above the message thread. */}
-          <span className="inline-flex min-w-0 items-center gap-2.5 self-start rounded-full border border-[var(--hairline)] bg-[var(--pill-raised)] py-1.5 pl-1.5 pr-3.5 sm:self-auto">
-            <ChatAvatar name={apptName || 'Appointment'} size="sm" />
+        <div className="flex flex-col gap-2 border-b border-[var(--hairline)] bg-[var(--screen-2)] px-3.5 py-2 sm:flex-row sm:items-center sm:justify-between sm:gap-3 sm:px-4 sm:py-2.5">
+          {/* Compact appointment context chip that sits above the message thread.
+              Measured from the design's in-thread context pill ("Tasks & Chat"
+              header chip / design-07 thread chip): 20-22px avatar, 6px gap,
+              6-7px block padding, 11-12px / 600 --ink-body label on a
+              --pill-raised + --hairline pill. Sized so the chip lands at ~36px
+              — the same visual weight as the 40px Secondary actions beside it,
+              not the 48px block it was before. */}
+          <span className="inline-flex min-w-0 items-center gap-1.5 self-start rounded-full border border-[var(--hairline)] bg-[var(--pill-raised)] py-1 pl-1 pr-3 sm:self-auto">
+            <ChatAvatar name={apptName || 'Appointment'} size="xs" />
             <span className="flex min-w-0 flex-col">
               <Text
                 as="span"
                 variant="caption-2"
-                className="font-bold uppercase tracking-[0.08em] text-[var(--ink-muted)]"
+                className="text-[10px] font-bold uppercase leading-[1.2] tracking-[0.1em] text-[var(--ink-muted)]"
               >
                 Appointment
               </Text>
-              <Text as="span" variant="caption-1" className="truncate text-[var(--ink-body)]">
+              <Text
+                as="span"
+                variant="caption-1"
+                className="truncate text-[11.5px] font-semibold leading-[1.35] text-[var(--ink-body)] xl:text-[12px]"
+              >
                 {[apptLabel, apptName].filter(Boolean).join(' · ') || 'Linked appointment'}
               </Text>
             </span>

--- a/apps/frontend/src/app/features/chat/components/ChatMessage.tsx
+++ b/apps/frontend/src/app/features/chat/components/ChatMessage.tsx
@@ -455,7 +455,8 @@ export function ChatMessage({ firstOfGroup }: Readonly<{ firstOfGroup?: boolean 
       <MessageGutter mine={mine} firstOfGroup={firstOfGroup} name={counterpartName} />
       <div
         className={clsx(
-          'flex max-w-[80%] flex-col gap-1 sm:max-w-md',
+          // Design: bubble column caps at 460px on the wide desktop frame.
+          'flex max-w-[80%] flex-col gap-1 sm:max-w-md xl:max-w-[460px]',
           mine ? 'items-end' : 'items-start'
         )}
       >
@@ -468,7 +469,8 @@ export function ChatMessage({ firstOfGroup }: Readonly<{ firstOfGroup?: boolean 
           {!mine && actions}
         </div>
         <span className={clsx('flex items-center gap-2 px-1', reactions.length > 0 && 'mt-2.5')}>
-          <Text as="span" variant="caption-2" className="text-[var(--ink-faint)] text-[10px]">
+          {/* Design (message meta): 10.5px --ink-faint, e.g. "09:29 · Dr. Weber". */}
+          <Text as="span" variant="caption-2" className="text-[10.5px] text-[var(--ink-faint)]">
             {formatMessageTimeLabel(mine, time, senderName)}
           </Text>
           {mine && <MessageStatusIcon sending={sending} seen={seen} />}

--- a/apps/frontend/src/app/features/companions/pages/Companions/Companions.tsx
+++ b/apps/frontend/src/app/features/companions/pages/Companions/Companions.tsx
@@ -176,7 +176,7 @@ const Companions = () => {
     <div className="relative min-w-0 h-full min-h-0 yc-page-content">
       <div className="flex justify-between items-end w-full flex-wrap gap-3">
         <div className="flex flex-col gap-1">
-          <h1 className="text-text-primary text-page-title flex items-baseline gap-2 flex-wrap">
+          <h1 className="text-page-title flex items-baseline gap-2 flex-wrap">
             <span className="flex items-baseline gap-3">
               {terminologyText('Companions')}
               <span className="font-newsreader text-[16px] italic text-[var(--ink-faint)]">

--- a/apps/frontend/src/app/features/developers/pages/DeveloperApiKeys/DeveloperApiKeys.tsx
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperApiKeys/DeveloperApiKeys.tsx
@@ -84,7 +84,7 @@ const DeveloperApiKeys = () => {
       <div className="OperationsWrapper">
         <div className="TitleContainer">
           <div className="dev-keys-heading">
-            <h1 className="text-page-title text-text-primary">API keys</h1>
+            <h1 className="text-page-title">API keys</h1>
             <p className="text-body-3 text-text-secondary">
               Keys are scoped per environment and shown only once
             </p>

--- a/apps/frontend/src/app/features/developers/pages/DeveloperPlugins/DeveloperPlugins.tsx
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperPlugins/DeveloperPlugins.tsx
@@ -68,7 +68,7 @@ const DeveloperPlugins = () => {
       <div className="OperationsWrapper">
         <div className="TitleContainer">
           <div className="dev-plugins-heading">
-            <h1 className="text-page-title text-text-primary">Plugins</h1>
+            <h1 className="text-page-title">Plugins</h1>
             <p className="text-body-3 text-text-secondary">
               Extend every clinic on the platform. The WordPress model, for animal health
             </p>

--- a/apps/frontend/src/app/features/developers/pages/DeveloperWebsiteBuilder/DeveloperWebsiteBuilder.tsx
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperWebsiteBuilder/DeveloperWebsiteBuilder.tsx
@@ -42,7 +42,7 @@ const DeveloperWebsiteBuilder = () => {
       <div className="OperationsWrapper">
         <div className="TitleContainer">
           <div className="dev-wb-heading">
-            <h1 className="text-page-title text-text-primary">Website builder</h1>
+            <h1 className="text-page-title">Website builder</h1>
             <p className="text-body-3 text-text-secondary">
               A clinic website with booking built in, live in an afternoon.
             </p>

--- a/apps/frontend/src/app/features/finance/pages/Finance/index.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/index.tsx
@@ -146,9 +146,9 @@ const Finance = () => {
             <div className="flex items-center justify-between w-full flex-wrap gap-2">
               <div className="flex flex-col gap-0.5">
                 <div className="flex items-center gap-2">
-                  <h1 className="text-text-primary text-page-title">
-                    {'Finance'}
-                    <span className="text-body-2 text-text-tertiary">{` (${invoices.length})`}</span>
+                  <h1 className="text-page-title">
+                    {'Finance'}{' '}
+                    <span className="text-page-title-count">{`(${invoices.length})`}</span>
                   </h1>
                   <GlassTooltip
                     content="Review invoices, monitor payment status, and open each record to see billed services, balances, and payment history."

--- a/apps/frontend/src/app/features/forms/pages/Forms/index.tsx
+++ b/apps/frontend/src/app/features/forms/pages/Forms/index.tsx
@@ -255,10 +255,9 @@ const Forms = () => {
     <div className="relative min-w-0 h-full min-h-0 yc-page-content">
       <div className="flex justify-between items-center w-full flex-wrap gap-2">
         <div className="flex flex-col gap-1">
-          <h1 className="text-text-primary text-page-title flex items-center gap-2">
+          <h1 className="text-page-title flex items-center gap-2">
             <span>
-              {'Templates'}
-              <span className="text-body-2 text-text-tertiary">{` (${list.length})`}</span>
+              {'Templates'} <span className="text-page-title-count">{`(${list.length})`}</span>
             </span>
             <GlassTooltip
               content="Build and reuse templates, link them to services, and use custom available templates."

--- a/apps/frontend/src/app/features/integrations/pages/IdexxWorkspace/index.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/IdexxWorkspace/index.tsx
@@ -1537,7 +1537,7 @@ const IdexxHubHeader = ({
 }) => (
   <div className="flex flex-wrap items-start justify-between gap-3">
     <div className="flex flex-col gap-2">
-      <h1 className="flex flex-wrap items-center gap-2 text-page-title text-text-primary">
+      <h1 className="flex flex-wrap items-center gap-2 text-page-title">
         IDEXX diagnostics
         <HubInfoPill />
       </h1>

--- a/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
@@ -7,6 +7,8 @@ import OrgGuard from '@/app/ui/layout/guards/OrgGuard';
 import PageSkeleton from '@/app/ui/layout/PageSkeleton';
 
 const INTEGRATIONS_PAGE_SKELETON = <PageSkeleton variant="list" />;
+import Modal from '@/app/ui/overlays/Modal';
+import Accordion from '@/app/ui/primitives/Accordion/Accordion';
 import FormInput from '@/app/ui/inputs/FormInput/FormInput';
 import FormInputPass from '@/app/ui/inputs/FormInputPass/FormInputPass';
 import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
@@ -32,9 +34,8 @@ import {
 import { IvlsDevice, LabOrder } from '@/app/features/integrations/services/types';
 import { getMerckGateway } from '@/app/features/integrations/services/merckService';
 import { useResolvedMerckIntegrationForPrimaryOrg } from '@/app/hooks/useMerckIntegration';
+import Close from '@/app/ui/primitives/Icons/Close';
 import {
-  IoCheckmarkCircleOutline,
-  IoChevronForwardOutline,
   IoExtensionPuzzleOutline,
   IoInformationCircleOutline,
   IoRefreshOutline,
@@ -65,11 +66,6 @@ const statusTokens: Record<string, StatusTokens> = {
     bg: 'var(--color-pill-info-bg)',
     text: 'var(--color-pill-info-text)',
     border: 'var(--color-pill-info-border)',
-  },
-  neutral: {
-    bg: 'var(--color-pill-neutral-bg)',
-    text: 'var(--color-pill-neutral-text)',
-    border: 'var(--color-pill-neutral-border)',
   },
 };
 
@@ -218,7 +214,7 @@ const StatusPill = ({ status, label }: { status?: string; label?: string }) => {
   const isLive = key === 'enabled';
   return (
     <span
-      className="shrink-0 max-w-full inline-flex items-center justify-center gap-1.5 whitespace-nowrap text-caption-3 px-2.5 py-1 rounded-full! border!"
+      className="shrink-0 max-w-full inline-flex items-center gap-1.5 whitespace-nowrap uppercase tracking-[0.06em] text-label-xsmall px-2.5 py-1 rounded-full! border!"
       style={
         tokens
           ? {
@@ -265,6 +261,80 @@ const LinkedDevicesList = ({ devices }: { devices: IvlsDevice[] }) => {
   );
 };
 
+const ORDER_PILL_RESULTED = new Set(['result', 'complete', 'final', 'confirm']);
+const ORDER_PILL_RUNNING = new Set(['run', 'pending', 'progress', 'process', 'partial']);
+
+const getOrderPillTokens = (status?: string | null): StatusTokens => {
+  const key = String(status ?? '').toLowerCase();
+  if ([...ORDER_PILL_RESULTED].some((token) => key.includes(token))) {
+    return {
+      bg: 'var(--color-pill-success-bg)',
+      text: 'var(--color-pill-success-text)',
+      border: 'var(--color-pill-success-border)',
+    };
+  }
+  if ([...ORDER_PILL_RUNNING].some((token) => key.includes(token))) {
+    return {
+      bg: 'var(--color-pill-progress-bg)',
+      text: 'var(--color-pill-progress-text)',
+      border: 'var(--color-pill-progress-border)',
+    };
+  }
+  return {
+    bg: 'var(--color-pill-neutral-bg)',
+    text: 'var(--color-pill-neutral-text)',
+    border: 'var(--color-pill-neutral-border)',
+  };
+};
+
+const formatOrderStatusLabel = (status?: string | null): string => {
+  const raw = String(status ?? '').trim();
+  if (!raw) return 'Pending';
+  return `${raw.charAt(0).toUpperCase()}${raw.slice(1).toLowerCase()}`;
+};
+
+const formatOrderLabel = (order: LabOrder): string => {
+  const name = String(order.patientName ?? '').trim();
+  const tests = (order.tests ?? []).filter(Boolean).join(', ');
+  if (name && tests) return `${name} · ${tests}`;
+  return name || tests || `Order ${order.idexxOrderId}`;
+};
+
+const RecentOrdersList = ({ orders }: { orders: LabOrder[] }) => {
+  if (orders.length === 0) {
+    return <div className="text-body-4 text-text-secondary">No recent orders.</div>;
+  }
+
+  return (
+    <>
+      {orders.slice(0, 3).map((order) => {
+        const tokens = getOrderPillTokens(order.status);
+        return (
+          <div
+            key={order._id || order.idexxOrderId}
+            className="flex items-center justify-between gap-2 text-caption-1"
+          >
+            <span className="min-w-0 truncate font-semibold text-text-primary">
+              {formatOrderLabel(order)}
+            </span>
+            <span
+              className="shrink-0 text-label-xsmall px-2 py-0.5 rounded-full! border!"
+              style={{
+                backgroundColor: tokens.bg,
+                color: tokens.text,
+                borderColor: tokens.border,
+                borderStyle: 'solid',
+              }}
+            >
+              {formatOrderStatusLabel(order.status)}
+            </span>
+          </div>
+        );
+      })}
+    </>
+  );
+};
+
 type IdexxActionsState = {
   primaryOrgId: string | null | undefined;
   refreshing: boolean;
@@ -277,6 +347,7 @@ type IdexxActionsState = {
   setRefreshing: (v: boolean) => void;
   setSaving: (v: boolean) => void;
   setValidateState: (v: ValidateState) => void;
+  setShowSettings: (v: boolean) => void;
 };
 
 const useIdexxActions = (s: IdexxActionsState) => {
@@ -348,6 +419,7 @@ const useIdexxActions = (s: IdexxActionsState) => {
       return true;
     } catch (validationError) {
       s.setValidateState('invalid');
+      s.setShowSettings(true);
       s.setError(
         getApiErrorMessage(
           validationError,
@@ -361,6 +433,7 @@ const useIdexxActions = (s: IdexxActionsState) => {
   const handleEnableDisable = useCallback(async () => {
     if (!s.primaryOrgId) return;
     if (!s.idexxIntegration) {
+      s.setShowSettings(true);
       s.setError('Store IDEXX credentials in settings before enabling.');
       return;
     }
@@ -415,6 +488,7 @@ const useIntegrationsPage = () => {
   const [recentOrders, setRecentOrders] = useState<LabOrder[]>([]);
   const [saving, setSaving] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
+  const [showSettings, setShowSettings] = useState(false);
   const [merckSaving, setMerckSaving] = useState(false);
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
@@ -441,7 +515,7 @@ const useIntegrationsPage = () => {
           setDevices([]);
           setError(getApiErrorMessage(e, 'Unable to load linked IDEXX devices.'));
         }
-        // Recent orders feed the credentials panel footer. They are secondary to the
+        // Recent orders feed the settings modal's activity section. They are secondary to the
         // devices load, so a failure here is swallowed rather than surfaced as an error.
         try {
           const orders = await listIdexxOrders({ organisationId: primaryOrgId });
@@ -474,6 +548,7 @@ const useIntegrationsPage = () => {
       setRefreshing,
       setSaving,
       setValidateState,
+      setShowSettings,
     });
 
   const linkedCount = useMemo(() => {
@@ -536,6 +611,8 @@ const useIntegrationsPage = () => {
     recentOrders,
     saving,
     refreshing,
+    showSettings,
+    setShowSettings,
     username,
     setUsername,
     password,
@@ -562,109 +639,9 @@ const useIntegrationsPage = () => {
   };
 };
 
-const ORDER_PILL_RESULTED = new Set(['result', 'complete', 'final', 'confirm']);
-const ORDER_PILL_RUNNING = new Set(['run', 'pending', 'progress', 'process', 'partial']);
-
-const getOrderPillTokens = (status?: string | null): StatusTokens => {
-  const key = String(status ?? '').toLowerCase();
-  if ([...ORDER_PILL_RESULTED].some((token) => key.includes(token))) {
-    return {
-      bg: 'var(--color-pill-success-bg)',
-      text: 'var(--color-pill-success-text)',
-      border: 'var(--color-pill-success-border)',
-    };
-  }
-  if ([...ORDER_PILL_RUNNING].some((token) => key.includes(token))) {
-    return {
-      bg: 'var(--color-pill-progress-bg)',
-      text: 'var(--color-pill-progress-text)',
-      border: 'var(--color-pill-progress-border)',
-    };
-  }
-  return {
-    bg: 'var(--color-pill-neutral-bg)',
-    text: 'var(--color-pill-neutral-text)',
-    border: 'var(--color-pill-neutral-border)',
-  };
-};
-
-const formatOrderStatusLabel = (status?: string | null): string => {
-  const raw = String(status ?? '').trim();
-  if (!raw) return 'Pending';
-  return `${raw.charAt(0).toUpperCase()}${raw.slice(1).toLowerCase()}`;
-};
-
-const formatOrderLabel = (order: LabOrder): string => {
-  const name = String(order.patientName ?? '').trim();
-  const tests = (order.tests ?? []).filter(Boolean).join(', ');
-  if (name && tests) return `${name} · ${tests}`;
-  return name || tests || `Order ${order.idexxOrderId}`;
-};
-
-const RecentOrdersSection = ({ orders }: { orders: LabOrder[] }) => {
-  if (orders.length === 0) return null;
-  return (
-    <div className="flex flex-col gap-2 border-t border-[var(--hairline)] px-5 py-4">
-      <span className="text-caption-3 uppercase tracking-[0.1em] text-text-extra">
-        Recent orders
-      </span>
-      {orders.slice(0, 3).map((order) => {
-        const tokens = getOrderPillTokens(order.status);
-        return (
-          <div
-            key={order._id || order.idexxOrderId}
-            className="flex items-center justify-between gap-2 text-caption-1"
-          >
-            <span className="min-w-0 truncate font-semibold text-text-primary">
-              {formatOrderLabel(order)}
-            </span>
-            <span
-              className="shrink-0 text-label-xsmall px-2 py-0.5 rounded-full! border!"
-              style={{
-                backgroundColor: tokens.bg,
-                color: tokens.text,
-                borderColor: tokens.border,
-                borderStyle: 'solid',
-              }}
-            >
-              {formatOrderStatusLabel(order.status)}
-            </span>
-          </div>
-        );
-      })}
-    </div>
-  );
-};
-
-const CredentialsValidatedChip = ({
-  validateState,
-  hasStoredCredentials,
-}: {
-  validateState: ValidateState;
-  hasStoredCredentials: boolean;
-}) => {
-  if (validateState === 'valid') {
-    return (
-      <span className="inline-flex items-center gap-1.5 text-caption-1 font-bold text-green-700">
-        <IoCheckmarkCircleOutline size={14} aria-hidden="true" />
-        Credentials validated successfully
-      </span>
-    );
-  }
-  if (validateState === 'invalid') {
-    return (
-      <span className="text-caption-1 font-bold text-text-error">Credentials need attention</span>
-    );
-  }
-  return (
-    <span className="text-caption-1 font-semibold text-text-secondary">
-      {hasStoredCredentials ? 'Not validated yet' : 'No credentials stored'}
-    </span>
-  );
-};
-
-const IdexxCredentialsPanel = ({
-  panelRef,
+const IdexxSettingsModal = ({
+  showSettings,
+  setShowSettings,
   idexxIntegration,
   idexxEnabled,
   hasStoredCredentials,
@@ -674,6 +651,7 @@ const IdexxCredentialsPanel = ({
   validateState,
   saving,
   refreshing,
+  integrationsLastFetchedAt,
   devices,
   recentOrders,
   username,
@@ -685,7 +663,8 @@ const IdexxCredentialsPanel = ({
   handleValidate,
   handleEnableDisable,
 }: {
-  panelRef: React.RefObject<HTMLDivElement | null>;
+  showSettings: boolean;
+  setShowSettings: React.Dispatch<React.SetStateAction<boolean>>;
   idexxIntegration: ReturnType<typeof useIntegrationByProviderForPrimaryOrg>;
   idexxEnabled: boolean;
   hasStoredCredentials: boolean;
@@ -695,6 +674,7 @@ const IdexxCredentialsPanel = ({
   validateState: ValidateState;
   saving: boolean;
   refreshing: boolean;
+  integrationsLastFetchedAt: string | null | undefined;
   devices: IvlsDevice[];
   recentOrders: LabOrder[];
   username: string;
@@ -707,6 +687,7 @@ const IdexxCredentialsPanel = ({
   handleEnableDisable: () => Promise<void>;
 }) => {
   const enableDisableLabel = getEnableDisableLabel(saving, idexxEnabled);
+  const lastRefreshedText = formatOptionalDate(integrationsLastFetchedAt, 'Not refreshed yet');
   const refreshIconClass = refreshing ? 'animate-spin' : '';
   const validateMeta = getValidateStateMeta(validateState);
   const lastValidatedText = formatOptionalDate(
@@ -717,151 +698,172 @@ const IdexxCredentialsPanel = ({
   const enabledAtText = formatOptionalDate(idexxIntegration?.enabledAt, 'Not enabled');
 
   return (
-    <div
-      ref={panelRef}
-      data-testid="idexx-credentials-panel"
-      className="flex w-full flex-col overflow-hidden rounded-[18px] border border-[var(--hairline)] bg-[var(--screen)] shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)] xl:sticky xl:top-4"
-    >
-      <div className="flex flex-wrap items-center justify-between gap-2 border-b border-[var(--hairline)] px-5 py-4">
-        <h2 className="text-heading-3 text-text-primary">IDEXX credentials</h2>
-        <div className="flex items-center gap-2">
-          <CredentialsValidatedChip
-            validateState={validateState}
-            hasStoredCredentials={hasStoredCredentials}
-          />
+    <Modal showModal={showSettings} setShowModal={setShowSettings}>
+      <div className="flex flex-col h-full gap-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h3 className="text-heading-3 text-text-primary">Integration settings</h3>
+            <div className="text-body-4 text-text-secondary">
+              Configure IDEXX for this organization
+            </div>
+          </div>
+          <Close onClick={() => setShowSettings(false)} />
+        </div>
+        <div className="flex items-center justify-between rounded-xl border border-[var(--hairline)] px-3 py-2 bg-[var(--field-bg)]">
+          <div className="text-caption-1 text-text-secondary">
+            Last refreshed: <span className="text-text-primary">{lastRefreshedText}</span>
+          </div>
           <button
             type="button"
             onClick={() => {
               handleManualRefresh().catch(() => undefined);
             }}
-            className="flex size-8 items-center justify-center rounded-full! border border-[var(--hairline)] text-text-primary hover:bg-card-hover"
+            className="size-8 rounded-full! border border-[var(--hairline)] flex items-center justify-center text-text-primary hover:bg-card-hover"
             aria-label="Refresh integrations"
             title="Refresh integrations"
             disabled={refreshing}
           >
-            <IoRefreshOutline className={refreshIconClass} size={15} />
+            <IoRefreshOutline className={refreshIconClass} size={16} />
           </button>
         </div>
-      </div>
 
-      <div className="flex flex-col gap-3.5 px-5 py-4">
-        <FormInput
-          intype="text"
-          inname="idexx-username"
-          inlabel="VetConnect username"
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
-        />
-        <FormInputPass
-          intype="password"
-          inname="idexx-password"
-          inlabel="Password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-        />
-        <div className="flex flex-wrap gap-2">
-          <Primary
-            href="#"
-            text={credentialsActionLabel}
-            onClick={handleStoreCredentials}
-            isDisabled={saving || !username.trim() || !password.trim()}
-          />
-          <Secondary
-            href="#"
-            text={saving ? 'Validating...' : 'Validate'}
-            onClick={handleValidate}
-            isDisabled={saving}
-          />
-        </div>
-        {validateMeta ? (
-          <div className={`text-body-4 ${validateMeta.className}`}>{validateMeta.text}</div>
-        ) : null}
-        <div className="grid grid-cols-2 gap-2 text-caption-1">
-          <div className="text-text-secondary">Credentials status</div>
-          <div className="text-right">
-            <span
-              className="text-label-xsmall px-2 py-1 rounded-2xl! border!"
-              style={(() => {
-                const t = credentialsStatusTokens[credentialsStatusKey];
-                return t
-                  ? {
-                      backgroundColor: t.bg,
-                      color: t.text,
-                      borderColor: t.border,
-                      borderStyle: 'solid',
-                    }
-                  : {
-                      backgroundColor: 'var(--color-card-hover)',
-                      color: 'var(--color-text-secondary)',
-                      borderColor: 'var(--color-card-border)',
-                      borderStyle: 'solid',
-                    };
-              })()}
-            >
-              {credentialsStatusLabel}
-            </span>
+        <div className="flex-1 overflow-y-auto flex flex-col gap-4 pr-1">
+          <Accordion title="Credentials" defaultOpen showEditIcon={false} isEditing>
+            <div className="flex flex-col gap-3 py-2">
+              <FormInput
+                intype="text"
+                inname="idexx-username"
+                inlabel="IDEXX username"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+              />
+              <FormInputPass
+                intype="password"
+                inname="idexx-password"
+                inlabel="IDEXX password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+              />
+              <div className="flex flex-wrap gap-2">
+                <Primary
+                  href="#"
+                  text={credentialsActionLabel}
+                  onClick={handleStoreCredentials}
+                  isDisabled={saving || !username.trim() || !password.trim()}
+                />
+                <Secondary
+                  href="#"
+                  text={saving ? 'Validating...' : 'Validate'}
+                  onClick={handleValidate}
+                  isDisabled={saving}
+                />
+              </div>
+              {validateMeta ? (
+                <div className={`text-body-4 ${validateMeta.className}`}>{validateMeta.text}</div>
+              ) : null}
+              <div className="grid grid-cols-2 gap-2 text-caption-1">
+                <div className="text-text-secondary">Credentials status</div>
+                <div className="text-right">
+                  <span
+                    className="text-label-xsmall px-2 py-1 rounded-2xl! border!"
+                    style={(() => {
+                      const t = credentialsStatusTokens[credentialsStatusKey];
+                      return t
+                        ? {
+                            backgroundColor: t.bg,
+                            color: t.text,
+                            borderColor: t.border,
+                            borderStyle: 'solid',
+                          }
+                        : {
+                            backgroundColor: 'var(--color-card-hover)',
+                            color: 'var(--color-text-secondary)',
+                            borderColor: 'var(--color-card-border)',
+                            borderStyle: 'solid',
+                          };
+                    })()}
+                  >
+                    {credentialsStatusLabel}
+                  </span>
+                </div>
+                <div className="text-text-secondary">Last validated</div>
+                <div className="text-text-primary text-right">{lastValidatedText}</div>
+              </div>
+            </div>
+          </Accordion>
+
+          <Accordion title="Connection" defaultOpen showEditIcon={false} isEditing>
+            <div className="flex flex-col gap-3 py-2">
+              <div className="flex items-center justify-between gap-2">
+                <div className="text-body-4 text-text-primary">Current status</div>
+                <StatusPill status={idexxIntegration?.status} />
+              </div>
+              <div className="flex items-center justify-between gap-2">
+                <div className="text-caption-1 text-text-secondary">Connected since</div>
+                <div className="text-caption-1 text-text-primary">
+                  {formatDateTimeLocal(idexxIntegration?.enabledAt)}
+                </div>
+              </div>
+              <div className="text-caption-1 text-text-secondary">
+                Enabling IDEXX allows appointment lab ordering and results visibility.
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Primary
+                  href="#"
+                  text={enableDisableLabel}
+                  onClick={handleEnableDisable}
+                  isDisabled={
+                    saving || !idexxIntegration || (!idexxEnabled && !hasStoredCredentials)
+                  }
+                />
+                <Secondary href="/appointments" text="Open appointments" />
+              </div>
+              <div className="text-caption-1 text-text-secondary">
+                {getConnectionHint(idexxEnabled, hasStoredCredentials)}
+              </div>
+            </div>
+          </Accordion>
+
+          <Accordion title="Sync health" defaultOpen showEditIcon={false} isEditing>
+            <div className="flex flex-col gap-3 py-2">
+              <div className="flex items-center justify-between gap-2">
+                <div className="text-caption-1 text-text-secondary">Last sync</div>
+                <div className="text-caption-1 text-text-primary">{lastSyncText}</div>
+              </div>
+              <div className="flex items-center justify-between gap-2">
+                <div className="text-caption-1 text-text-secondary">Enabled at</div>
+                <div className="text-caption-1 text-text-primary">{enabledAtText}</div>
+              </div>
+              <div className="flex items-center justify-between gap-2">
+                <div className="text-caption-1 text-text-secondary">Last validated</div>
+                <div className="text-caption-1 text-text-primary">{lastValidatedText}</div>
+              </div>
+              <div className="flex items-center justify-between gap-2">
+                <div className="text-caption-1 text-text-secondary">Linked IVLS devices</div>
+                <div className="text-caption-1 text-text-primary">{devices.length}</div>
+              </div>
+              <Secondary href="/appointments/idexx-workspace" text="IDEXX Hub" />
+            </div>
+          </Accordion>
+
+          <Accordion title="Recent orders" defaultOpen showEditIcon={false} isEditing>
+            <div className="flex flex-col gap-2 py-2">
+              <RecentOrdersList orders={recentOrders} />
+            </div>
+          </Accordion>
+
+          <Accordion title="Linked medical devices" defaultOpen showEditIcon={false} isEditing>
+            <div className="flex flex-col gap-2 py-2">
+              <LinkedDevicesList devices={devices} />
+            </div>
+          </Accordion>
+
+          <div className="text-caption-2 text-text-extra pt-1 pb-1">
+            {IDEXX_REGIONAL_AVAILABILITY_DISCLAIMER}
           </div>
-          <div className="text-text-secondary">Last validated</div>
-          <div className="text-text-primary text-right">{lastValidatedText}</div>
         </div>
       </div>
-
-      <div className="flex flex-col gap-3 border-t border-[var(--hairline)] px-5 py-4">
-        <span className="text-caption-3 uppercase tracking-[0.1em] text-text-extra">
-          Connection
-        </span>
-        <div className="flex items-center justify-between gap-2">
-          <div className="text-body-4 text-text-primary">Current status</div>
-          <StatusPill status={idexxIntegration?.status} />
-        </div>
-        <div className="flex items-center justify-between gap-2">
-          <div className="text-caption-1 text-text-secondary">Connected since</div>
-          <div className="text-caption-1 text-text-primary">
-            {formatDateTimeLocal(idexxIntegration?.enabledAt)}
-          </div>
-        </div>
-        <div className="flex flex-wrap gap-2">
-          <Primary
-            href="#"
-            text={enableDisableLabel}
-            onClick={handleEnableDisable}
-            isDisabled={saving || !idexxIntegration || (!idexxEnabled && !hasStoredCredentials)}
-          />
-          <Secondary href="/appointments" text="Open appointments" />
-        </div>
-        <div className="text-caption-1 text-text-secondary">
-          {getConnectionHint(idexxEnabled, hasStoredCredentials)}
-        </div>
-      </div>
-
-      <div className="flex flex-col gap-3 border-t border-[var(--hairline)] px-5 py-4">
-        <span className="text-caption-3 uppercase tracking-[0.1em] text-text-extra">
-          Sync health
-        </span>
-        <div className="flex items-center justify-between gap-2">
-          <div className="text-caption-1 text-text-secondary">Last sync</div>
-          <div className="text-caption-1 text-text-primary">{lastSyncText}</div>
-        </div>
-        <div className="flex items-center justify-between gap-2">
-          <div className="text-caption-1 text-text-secondary">Enabled at</div>
-          <div className="text-caption-1 text-text-primary">{enabledAtText}</div>
-        </div>
-        <div className="flex items-center justify-between gap-2">
-          <div className="text-caption-1 text-text-secondary">Linked IVLS devices</div>
-          <div className="text-caption-1 text-text-primary">{devices.length}</div>
-        </div>
-        <Secondary href="/appointments/idexx-workspace" text="IDEXX Hub" />
-        <div className="flex flex-col gap-2 pt-1">
-          <LinkedDevicesList devices={devices} />
-        </div>
-      </div>
-
-      <RecentOrdersSection orders={recentOrders} />
-
-      <div className="border-t border-[var(--hairline)] px-5 py-3 text-caption-2 text-text-extra">
-        {IDEXX_REGIONAL_AVAILABILITY_DISCLAIMER}
-      </div>
-    </div>
+    </Modal>
   );
 };
 
@@ -902,15 +904,15 @@ const INTEGRATION_CARD_CLASS =
   'rounded-[18px] border border-[var(--hairline)] bg-[var(--screen)] p-5 w-full flex items-stretch gap-4 min-h-[245px] shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]';
 const INTEGRATION_CARD_HEADER_CLASS = 'grid grid-cols-[minmax(0,1fr)_auto] items-start gap-2';
 const INTEGRATION_CARD_TITLE_CLASS = 'min-w-0 truncate text-heading-3 text-text-primary pt-1';
+const COMING_SOON_PILL_CLASS =
+  'shrink-0 max-w-full whitespace-nowrap text-label-xsmall px-2 py-1 rounded-2xl! border!';
 
 const IdexxIntegrationCard = ({
   s,
   buttonLabel,
-  onManageCredentials,
 }: {
   s: IntegrationsPageState;
   buttonLabel: string;
-  onManageCredentials: () => void;
 }) => {
   if (!s.showIdexxCard) return null;
 
@@ -958,7 +960,7 @@ const IdexxIntegrationCard = ({
           <Secondary
             href="#"
             text="Manage credentials"
-            onClick={onManageCredentials}
+            onClick={() => s.setShowSettings(true)}
             className="px-4 whitespace-nowrap"
           />
           {s.idexxEnabled ? (
@@ -1077,7 +1079,17 @@ const RadIntegrationCard = ({
         <div className="flex flex-col gap-3 pb-3">
           <div className={INTEGRATION_CARD_HEADER_CLASS}>
             <div className={INTEGRATION_CARD_TITLE_CLASS}>RadAnalyzer</div>
-            <StatusPill status="neutral" label="Coming soon" />
+            <span
+              className={COMING_SOON_PILL_CLASS}
+              style={{
+                backgroundColor: 'var(--color-pill-neutral-bg)',
+                color: 'var(--color-pill-neutral-text)',
+                borderColor: 'var(--color-pill-neutral-border)',
+                borderStyle: 'solid',
+              }}
+            >
+              Coming soon
+            </span>
           </div>
           <div className="text-body-4 text-text-secondary line-clamp-4">
             Imaging and analyzer connectivity for diagnostic workflows in Yosemite Crew.
@@ -1118,7 +1130,17 @@ const VetnioIntegrationCard = ({
         <div className="flex flex-col gap-3 pb-3">
           <div className={INTEGRATION_CARD_HEADER_CLASS}>
             <div className={INTEGRATION_CARD_TITLE_CLASS}>Vetnio</div>
-            <StatusPill status="neutral" label="Coming soon" />
+            <span
+              className={COMING_SOON_PILL_CLASS}
+              style={{
+                backgroundColor: 'var(--color-pill-neutral-bg)',
+                color: 'var(--color-pill-neutral-text)',
+                borderColor: 'var(--color-pill-neutral-border)',
+                borderStyle: 'solid',
+              }}
+            >
+              Coming soon
+            </span>
           </div>
           <div className="text-body-4 text-text-secondary line-clamp-4">
             AI-powered documentation for veterinary practices &mdash; instantly generate clinical
@@ -1156,7 +1178,17 @@ const QuickBooksIntegrationCard = ({
         <div className="flex flex-col gap-3 pb-3">
           <div className={INTEGRATION_CARD_HEADER_CLASS}>
             <div className={INTEGRATION_CARD_TITLE_CLASS}>QuickBooks</div>
-            <StatusPill status="neutral" label="Coming soon" />
+            <span
+              className={COMING_SOON_PILL_CLASS}
+              style={{
+                backgroundColor: 'var(--color-pill-neutral-bg)',
+                color: 'var(--color-pill-neutral-text)',
+                borderColor: 'var(--color-pill-neutral-border)',
+                borderStyle: 'solid',
+              }}
+            >
+              Coming soon
+            </span>
           </div>
           <div className="text-body-4 text-text-secondary line-clamp-4">
             Accounting sync for invoices, payments, customers, and financial workflows through
@@ -1199,7 +1231,17 @@ const LaikaIntegrationCard = ({
         <div className="flex flex-col gap-3 pb-3">
           <div className={INTEGRATION_CARD_HEADER_CLASS}>
             <div className={INTEGRATION_CARD_TITLE_CLASS}>Laika</div>
-            <StatusPill status="neutral" label="Coming soon" />
+            <span
+              className={COMING_SOON_PILL_CLASS}
+              style={{
+                backgroundColor: 'var(--color-pill-neutral-bg)',
+                color: 'var(--color-pill-neutral-text)',
+                borderColor: 'var(--color-pill-neutral-border)',
+                borderStyle: 'solid',
+              }}
+            >
+              Coming soon
+            </span>
           </div>
           <div className="text-body-4 text-text-secondary line-clamp-4">
             AI-powered diagnostic support for veterinary clinicians &mdash; interpret lab results,
@@ -1221,22 +1263,16 @@ const IntegrationCards = ({
   s,
   idexxCardButtonLabel,
   merckCardButtonLabel,
-  onManageCredentials,
 }: {
   s: IntegrationsPageState;
   idexxCardButtonLabel: string;
   merckCardButtonLabel: string;
-  onManageCredentials: () => void;
 }) => {
   if (!s.showIdexxCard && !s.showMerckCard && s.activeFilter === 'connected') return null;
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 gap-4 items-stretch">
-      <IdexxIntegrationCard
-        s={s}
-        buttonLabel={idexxCardButtonLabel}
-        onManageCredentials={onManageCredentials}
-      />
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 items-stretch">
+      <IdexxIntegrationCard s={s} buttonLabel={idexxCardButtonLabel} />
       <MerckIntegrationCard s={s} buttonLabel={merckCardButtonLabel} />
       <RadIntegrationCard activeFilter={s.activeFilter} />
       <VetnioIntegrationCard activeFilter={s.activeFilter} />
@@ -1248,7 +1284,6 @@ const IntegrationCards = ({
 
 const IntegrationsPage = () => {
   const s = useIntegrationsPage();
-  const panelRef = React.useRef<HTMLDivElement>(null);
   const { showNoConnected, showNoAvailable } = getIntegrationEmptyState(
     s.integrationStatus,
     s.activeFilter,
@@ -1257,11 +1292,6 @@ const IntegrationsPage = () => {
   );
   const idexxCardButtonLabel = getIdexxCardButtonLabel(s.saving, s.idexxEnabled);
   const merckCardButtonLabel = getIdexxCardButtonLabel(s.merckSaving, s.merckEnabled);
-  const handleManageCredentials = useCallback(() => {
-    // On stacked layouts the panel sits below the catalog; scroll it into view when the
-    // IDEXX card's "Manage credentials" is pressed. On xl the panel is already visible.
-    panelRef.current?.scrollIntoView?.({ behavior: 'smooth', block: 'start' });
-  }, []);
 
   return (
     <div className="yc-page-content">
@@ -1305,65 +1335,59 @@ const IntegrationsPage = () => {
         </div>
       ) : null}
 
-      <div className="grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)] xl:items-start">
-        <div className="flex flex-col gap-4">
-          <IntegrationCards
-            s={s}
-            idexxCardButtonLabel={idexxCardButtonLabel}
-            merckCardButtonLabel={merckCardButtonLabel}
-            onManageCredentials={handleManageCredentials}
-          />
+      <div className="flex flex-col gap-4">
+        <IntegrationCards
+          s={s}
+          idexxCardButtonLabel={idexxCardButtonLabel}
+          merckCardButtonLabel={merckCardButtonLabel}
+        />
 
-          <div className="flex items-center gap-2.5 rounded-[16px] border border-[var(--hairline)] px-3.5 py-3 text-[var(--ink-muted)]">
-            <span className="flex size-[34px] shrink-0 items-center justify-center rounded-[10px] bg-[var(--inset)] text-[var(--cyan-text)]">
-              <IoExtensionPuzzleOutline size={15} aria-hidden="true" />
-            </span>
-            <span className="flex-1 text-[11.5px] leading-[1.45]">
-              More integrations ship as plugins. Browse the developer portal&apos;s plugin catalog.
-            </span>
-            <IoChevronForwardOutline
-              size={14}
-              aria-hidden="true"
-              className="shrink-0 text-[var(--ink-faint)]"
-            />
-          </div>
-
-          {showNoConnected ? (
-            <output className="text-body-4 text-text-secondary">
-              No connected integrations yet.
-            </output>
-          ) : null}
-
-          {showNoAvailable ? (
-            <output className="text-body-4 text-text-secondary">
-              No available integrations right now.
-            </output>
-          ) : null}
+        <div className="flex items-center gap-2.5 rounded-[16px] border border-[var(--hairline)] px-3.5 py-3 text-[var(--ink-muted)]">
+          <span className="flex size-[34px] shrink-0 items-center justify-center rounded-[10px] bg-[var(--inset)] text-[var(--cyan-text)]">
+            <IoExtensionPuzzleOutline size={15} aria-hidden="true" />
+          </span>
+          <span className="flex-1 text-[11.5px] leading-[1.45]">
+            More integrations ship as plugins. Browse the developer portal&apos;s plugin catalog.
+          </span>
         </div>
 
-        <IdexxCredentialsPanel
-          panelRef={panelRef}
-          idexxIntegration={s.idexxIntegration}
-          idexxEnabled={s.idexxEnabled}
-          hasStoredCredentials={s.hasStoredCredentials}
-          credentialsStatusKey={s.credentialsStatusKey}
-          credentialsStatusLabel={s.credentialsStatusLabel}
-          credentialsActionLabel={s.credentialsActionLabel}
-          validateState={s.validateState}
-          saving={s.saving}
-          refreshing={s.refreshing}
-          devices={s.devices}
-          recentOrders={s.recentOrders}
-          username={s.username}
-          setUsername={s.setUsername}
-          password={s.password}
-          setPassword={s.setPassword}
-          handleManualRefresh={s.handleManualRefresh}
-          handleStoreCredentials={s.handleStoreCredentials}
-          handleValidate={s.handleValidate}
-          handleEnableDisable={s.handleEnableDisable}
-        />
+        {showNoConnected ? (
+          <output className="text-body-4 text-text-secondary">
+            No connected integrations yet.
+          </output>
+        ) : null}
+
+        {showNoAvailable ? (
+          <output className="text-body-4 text-text-secondary">
+            No available integrations right now.
+          </output>
+        ) : null}
       </div>
+
+      <IdexxSettingsModal
+        showSettings={s.showSettings}
+        setShowSettings={s.setShowSettings}
+        idexxIntegration={s.idexxIntegration}
+        idexxEnabled={s.idexxEnabled}
+        hasStoredCredentials={s.hasStoredCredentials}
+        credentialsStatusKey={s.credentialsStatusKey}
+        credentialsStatusLabel={s.credentialsStatusLabel}
+        credentialsActionLabel={s.credentialsActionLabel}
+        validateState={s.validateState}
+        saving={s.saving}
+        refreshing={s.refreshing}
+        integrationsLastFetchedAt={s.integrationsLastFetchedAt}
+        devices={s.devices}
+        recentOrders={s.recentOrders}
+        username={s.username}
+        setUsername={s.setUsername}
+        password={s.password}
+        setPassword={s.setPassword}
+        handleManualRefresh={s.handleManualRefresh}
+        handleStoreCredentials={s.handleStoreCredentials}
+        handleValidate={s.handleValidate}
+        handleEnableDisable={s.handleEnableDisable}
+      />
     </div>
   );
 };

--- a/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
@@ -1297,7 +1297,7 @@ const IntegrationsPage = () => {
     <div className="yc-page-content">
       <div className="flex justify-between items-start gap-3 flex-wrap">
         <div className="flex flex-col gap-1">
-          <h1 className="text-text-primary text-page-title flex items-center gap-2">
+          <h1 className="text-page-title flex items-center gap-2">
             <span>Integrations</span>
             <GlassTooltip
               content={`Connect and manage external tools for ${

--- a/apps/frontend/src/app/features/inventory/pages/Inventory/index.tsx
+++ b/apps/frontend/src/app/features/inventory/pages/Inventory/index.tsx
@@ -1237,9 +1237,9 @@ const useInventoryContent = () => {
     <div className="relative min-w-0 h-full min-h-0 yc-page-content">
       <div className="flex justify-between items-center w-full flex-wrap gap-3">
         <div className="flex flex-col gap-1">
-          <h1 className="text-text-primary text-page-title flex items-center gap-2">
+          <h1 className="text-page-title flex items-center gap-2">
             <span>{pageTitle}</span>
-            <span className="text-[17px] text-[var(--ink-faint)]">({titleCount})</span>
+            <span className="text-page-title-count">({titleCount})</span>
             {activeView === 'inventory' && (
               <GlassTooltip
                 content="Organize stock, track batches and expiry, and monitor turnover so you know what to reorder and which items need attention."

--- a/apps/frontend/src/app/features/onboarding/pages/StripeOnboarding/index.tsx
+++ b/apps/frontend/src/app/features/onboarding/pages/StripeOnboarding/index.tsx
@@ -169,7 +169,7 @@ const StripeOnboarding = () => {
       </div>
 
       <div className="flex flex-col items-center gap-2 text-center">
-        <h1 className="text-page-title text-text-primary">Stripe onboarding</h1>
+        <h1 className="text-page-title">Stripe onboarding</h1>
         <p className="max-w-[460px] text-body-3 text-text-secondary">
           Complete your Stripe setup to accept card payments, verify tax details, and review payout
           information for your organization.

--- a/apps/frontend/src/app/features/organization/pages/Specialities/SpecialitiesRevamp.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Specialities/SpecialitiesRevamp.tsx
@@ -50,7 +50,7 @@ const SpecialitiesRevamp = () => {
   if (!primaryOrgId) {
     return (
       <div className="flex flex-col w-full gap-3 px-4 md:px-8 py-6 max-w-350 mx-auto">
-        <h1 className="text-page-title text-text-primary">Specialities</h1>
+        <h1 className="text-page-title">Specialities</h1>
         <p className="text-body-4 text-text-secondary">
           Select an organisation before managing specialities.
         </p>
@@ -70,7 +70,7 @@ const SpecialitiesRevamp = () => {
           >
             <IoChevronBack size={18} color="var(--color-neutral-900)" aria-hidden="true" />
           </Link>
-          <h1 className="text-page-title text-text-primary">Specialities</h1>
+          <h1 className="text-page-title">Specialities</h1>
         </div>
 
         <Primary

--- a/apps/frontend/src/app/features/tasks/components/TaskWeekAgenda.tsx
+++ b/apps/frontend/src/app/features/tasks/components/TaskWeekAgenda.tsx
@@ -93,7 +93,7 @@ const AgendaCard = ({ task, isFutureDay, assigneeName, onOpen }: AgendaCardProps
     >
       <span
         className={clsx(
-          'flex items-center gap-[5px] text-[11.5px] font-bold leading-[1.2]',
+          'flex items-center gap-1.5 text-[11.5px] font-bold leading-4',
           isCompleted && 'line-through'
         )}
         style={{ color: style.textColor }}
@@ -108,7 +108,7 @@ const AgendaCard = ({ task, isFutureDay, assigneeName, onOpen }: AgendaCardProps
         <span className="min-w-0 break-words">{task.name || '-'}</span>
       </span>
       <span
-        className="mt-0.5 block text-[10px] leading-[1.2]"
+        className="mt-0.5 block text-[10px] leading-4"
         style={{ color: style.metaColor, opacity: isParent ? 1 : 0.8 }}
       >
         {metaParts.join(' · ')}
@@ -207,7 +207,7 @@ const TaskWeekAgenda = ({
           >
             <IoChevronBack size={14} aria-hidden="true" />
           </button>
-          <span className="px-1.5 text-[13px] font-bold tabular-nums text-[var(--ink)]">
+          <span className="px-1.5 text-[13px] font-bold tabular-nums text-text-primary">
             {weekRangeLabel}
           </span>
           <button
@@ -231,7 +231,7 @@ const TaskWeekAgenda = ({
               <span
                 key={day.getTime()}
                 className={clsx(
-                  'px-3.5 py-[11px] text-[11px] font-bold tracking-[0.08em]',
+                  'px-3.5 py-2.5 text-[11px] font-bold tracking-[0.08em]',
                   index > 0 && 'border-l border-card-border',
                   isToday
                     ? 'text-[var(--blue-text)] bg-[var(--nav-active-bg)]'
@@ -239,7 +239,7 @@ const TaskWeekAgenda = ({
                 )}
               >
                 {weekday}{' '}
-                <span className={clsx('text-[12px]', !isToday && 'text-[var(--ink)]')}>
+                <span className={clsx('text-[12px]', !isToday && 'text-text-primary')}>
                   {dayNumber}
                   {isToday && ' · today'}
                 </span>
@@ -248,20 +248,16 @@ const TaskWeekAgenda = ({
           })}
         </div>
 
-        {/* The body scrolls as one block; the scrollbar is width-less in every
-            engine so the day columns stay aligned with the header's dividers. */}
-        <div className="grid min-h-0 flex-1 grid-cols-7 overflow-y-auto scrollbar-hidden [scrollbar-width:none]">
+        <div className="grid min-h-0 flex-1 grid-cols-7 overflow-y-auto scrollbar-hidden">
           {days.map((day, index) => {
             const isFutureDay = day.getTime() > todayStartMs;
-            const isToday = isOnPreferredTimeZoneCalendarDay(today, day);
             const dayTasks = tasksByDay[index] ?? [];
             return (
               <div
                 key={`${weekStartKey}-${day.getTime()}`}
                 className={clsx(
                   'group/col flex flex-col gap-2 px-2 py-2.5',
-                  index > 0 && 'border-l border-card-border',
-                  isToday && 'bg-[var(--surface-soft)]'
+                  index > 0 && 'border-l border-card-border'
                 )}
               >
                 {dayTasks.map((task) => (

--- a/apps/frontend/src/app/features/tasks/components/TaskWeekAgenda.tsx
+++ b/apps/frontend/src/app/features/tasks/components/TaskWeekAgenda.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo } from 'react';
 import clsx from 'clsx';
-import { IoAdd, IoChevronBack, IoChevronForward } from 'react-icons/io5';
+import { IoAdd } from 'react-icons/io5';
 import {
   getStartOfWeek,
   getWeekDays,
@@ -18,41 +18,22 @@ import {
   getTaskCardVariant,
 } from '@/app/features/tasks/components/taskCardVisuals';
 
+/**
+ * The week-range navigator that drives `currentDate`/`weekStart` renders in the
+ * page title row (TaskWeekNav), per the design; this board only reads the week.
+ */
 type TaskWeekAgendaProps = {
   filteredList: Task[];
   currentDate: Date;
-  setCurrentDate: React.Dispatch<React.SetStateAction<Date>>;
   weekStart: Date;
-  setWeekStart: React.Dispatch<React.SetStateAction<Date>>;
   canEditTasks?: boolean;
   setActiveTask?: (task: Task) => void;
   setViewPopup?: (open: boolean) => void;
   onCreateFromCalendarSlot?: (prefill: { dueAt: Date; assignedTo?: string }) => void;
 };
 
-const addDays = (date: Date, amount: number): Date => {
-  const next = new Date(date);
-  next.setDate(next.getDate() + amount);
-  return next;
-};
-
 /** Default drop time for a task created from an empty day column. */
 const DEFAULT_NEW_TASK_HOUR = 9;
-
-const buildWeekRangeLabel = (days: Date[]): string => {
-  const first = days[0];
-  const last = days.at(-1);
-  /* v8 ignore next 2 -- getWeekDays always returns 7 days; defensive only. */
-  if (!first || !last) return '';
-  const firstDay = formatDateInPreferredTimeZone(first, { day: 'numeric' });
-  const lastDay = formatDateInPreferredTimeZone(last, { day: 'numeric' });
-  const firstMonth = formatDateInPreferredTimeZone(first, { month: 'short' });
-  const lastMonth = formatDateInPreferredTimeZone(last, { month: 'short' });
-  if (firstMonth === lastMonth) {
-    return `${firstDay} – ${lastDay} ${lastMonth}`;
-  }
-  return `${firstDay} ${firstMonth} – ${lastDay} ${lastMonth}`;
-};
 
 type AgendaCardProps = {
   task: Task;
@@ -120,9 +101,7 @@ const AgendaCard = ({ task, isFutureDay, assigneeName, onOpen }: AgendaCardProps
 const TaskWeekAgenda = ({
   filteredList,
   currentDate,
-  setCurrentDate,
   weekStart,
-  setWeekStart,
   canEditTasks = false,
   setActiveTask,
   setViewPopup,
@@ -182,112 +161,73 @@ const TaskWeekAgenda = ({
     [onCreateFromCalendarSlot]
   );
 
-  const goToPrevWeek = useCallback(() => {
-    setCurrentDate((prev) => addDays(prev, -7));
-    setWeekStart((prev) => addDays(prev, -7));
-  }, [setCurrentDate, setWeekStart]);
-
-  const goToNextWeek = useCallback(() => {
-    setCurrentDate((prev) => addDays(prev, 7));
-    setWeekStart((prev) => addDays(prev, 7));
-  }, [setCurrentDate, setWeekStart]);
-
-  const weekRangeLabel = useMemo(() => buildWeekRangeLabel(days), [days]);
   const weekStartKey = weekStart.getTime();
 
   return (
-    <div className="flex h-full min-h-0 flex-col gap-3">
-      <div className="flex items-center justify-end">
-        <span className="flex items-center gap-1 rounded-full border border-[var(--hairline)] bg-[var(--field-bg)] p-1">
-          <button
-            type="button"
-            aria-label="Previous week"
-            onClick={goToPrevWeek}
-            className="flex size-[30px] items-center justify-center rounded-full text-text-tertiary transition-colors hover:bg-card-hover hover:text-text-primary"
-          >
-            <IoChevronBack size={14} aria-hidden="true" />
-          </button>
-          <span className="px-1.5 text-[13px] font-bold tabular-nums text-text-primary">
-            {weekRangeLabel}
-          </span>
-          <button
-            type="button"
-            aria-label="Next week"
-            onClick={goToNextWeek}
-            className="flex size-[30px] items-center justify-center rounded-full text-text-tertiary transition-colors hover:bg-card-hover hover:text-text-primary"
-          >
-            <IoChevronForward size={14} aria-hidden="true" />
-          </button>
-        </span>
+    <div className="flex h-full min-h-0 flex-col overflow-hidden rounded-[18px] border border-card-border bg-neutral-0 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]">
+      <div className="grid grid-cols-7 border-b border-card-border bg-[var(--screen-2)]">
+        {days.map((day, index) => {
+          const isToday = isOnPreferredTimeZoneCalendarDay(today, day);
+          const weekday = formatDateInPreferredTimeZone(day, { weekday: 'short' }).toUpperCase();
+          const dayNumber = formatDateInPreferredTimeZone(day, { day: 'numeric' });
+          return (
+            <span
+              key={day.getTime()}
+              className={clsx(
+                'px-3.5 py-2.5 text-[11px] font-bold tracking-[0.08em]',
+                index > 0 && 'border-l border-card-border',
+                isToday ? 'text-[var(--blue-text)] bg-[var(--nav-active-bg)]' : 'text-text-tertiary'
+              )}
+            >
+              {weekday}{' '}
+              <span className={clsx('text-[12px]', !isToday && 'text-text-primary')}>
+                {dayNumber}
+                {isToday && ' · today'}
+              </span>
+            </span>
+          );
+        })}
       </div>
 
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-[18px] border border-card-border bg-neutral-0 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]">
-        <div className="grid grid-cols-7 border-b border-card-border bg-[var(--screen-2)]">
-          {days.map((day, index) => {
-            const isToday = isOnPreferredTimeZoneCalendarDay(today, day);
-            const weekday = formatDateInPreferredTimeZone(day, { weekday: 'short' }).toUpperCase();
-            const dayNumber = formatDateInPreferredTimeZone(day, { day: 'numeric' });
-            return (
-              <span
-                key={day.getTime()}
-                className={clsx(
-                  'px-3.5 py-2.5 text-[11px] font-bold tracking-[0.08em]',
-                  index > 0 && 'border-l border-card-border',
-                  isToday
-                    ? 'text-[var(--blue-text)] bg-[var(--nav-active-bg)]'
-                    : 'text-text-tertiary'
-                )}
-              >
-                {weekday}{' '}
-                <span className={clsx('text-[12px]', !isToday && 'text-text-primary')}>
-                  {dayNumber}
-                  {isToday && ' · today'}
-                </span>
-              </span>
-            );
-          })}
-        </div>
-
-        <div className="grid min-h-0 flex-1 grid-cols-7 overflow-y-auto scrollbar-hidden">
-          {days.map((day, index) => {
-            const isFutureDay = day.getTime() > todayStartMs;
-            const dayTasks = tasksByDay[index] ?? [];
-            return (
-              <div
-                key={`${weekStartKey}-${day.getTime()}`}
-                className={clsx(
-                  'group/col flex flex-col gap-2 px-2 py-2.5',
-                  index > 0 && 'border-l border-card-border'
-                )}
-              >
-                {dayTasks.map((task) => (
-                  <AgendaCard
-                    key={task._id}
-                    task={task}
-                    isFutureDay={isFutureDay}
-                    assigneeName={resolveAssignee(task)}
-                    onOpen={openTask}
-                  />
-                ))}
-                {canEditTasks && (
-                  <button
-                    type="button"
-                    aria-label={`Add task on ${formatDateInPreferredTimeZone(day, {
-                      weekday: 'long',
-                      day: 'numeric',
-                      month: 'short',
-                    })}`}
-                    onClick={() => handleColumnAdd(day)}
-                    className="mt-auto flex items-center justify-center gap-1 rounded-[10px] border border-dashed border-[var(--divider)] py-1.5 text-[11px] font-semibold text-text-tertiary opacity-0 transition-opacity hover:text-text-primary focus-visible:opacity-100 group-hover/col:opacity-100"
-                  >
-                    <IoAdd size={13} aria-hidden="true" />
-                    Add
-                  </button>
-                )}
-              </div>
-            );
-          })}
-        </div>
+      <div className="grid min-h-0 flex-1 grid-cols-7 overflow-y-auto scrollbar-hidden">
+        {days.map((day, index) => {
+          const isFutureDay = day.getTime() > todayStartMs;
+          const dayTasks = tasksByDay[index] ?? [];
+          return (
+            <div
+              key={`${weekStartKey}-${day.getTime()}`}
+              className={clsx(
+                'group/col flex flex-col gap-2 px-2 py-2.5',
+                index > 0 && 'border-l border-card-border'
+              )}
+            >
+              {dayTasks.map((task) => (
+                <AgendaCard
+                  key={task._id}
+                  task={task}
+                  isFutureDay={isFutureDay}
+                  assigneeName={resolveAssignee(task)}
+                  onOpen={openTask}
+                />
+              ))}
+              {canEditTasks && (
+                <button
+                  type="button"
+                  aria-label={`Add task on ${formatDateInPreferredTimeZone(day, {
+                    weekday: 'long',
+                    day: 'numeric',
+                    month: 'short',
+                  })}`}
+                  onClick={() => handleColumnAdd(day)}
+                  className="mt-auto flex items-center justify-center gap-1 rounded-[10px] border border-dashed border-[var(--divider)] py-1.5 text-[11px] font-semibold text-text-tertiary opacity-0 transition-opacity hover:text-text-primary focus-visible:opacity-100 group-hover/col:opacity-100"
+                >
+                  <IoAdd size={13} aria-hidden="true" />
+                  Add
+                </button>
+              )}
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/apps/frontend/src/app/features/tasks/components/TaskWeekAgenda.tsx
+++ b/apps/frontend/src/app/features/tasks/components/TaskWeekAgenda.tsx
@@ -93,7 +93,7 @@ const AgendaCard = ({ task, isFutureDay, assigneeName, onOpen }: AgendaCardProps
     >
       <span
         className={clsx(
-          'flex items-center gap-1.5 text-[11.5px] font-bold leading-4',
+          'flex items-center gap-[5px] text-[11.5px] font-bold leading-[1.2]',
           isCompleted && 'line-through'
         )}
         style={{ color: style.textColor }}
@@ -108,7 +108,7 @@ const AgendaCard = ({ task, isFutureDay, assigneeName, onOpen }: AgendaCardProps
         <span className="min-w-0 break-words">{task.name || '-'}</span>
       </span>
       <span
-        className="mt-0.5 block text-[10px] leading-4"
+        className="mt-0.5 block text-[10px] leading-[1.2]"
         style={{ color: style.metaColor, opacity: isParent ? 1 : 0.8 }}
       >
         {metaParts.join(' · ')}
@@ -207,7 +207,7 @@ const TaskWeekAgenda = ({
           >
             <IoChevronBack size={14} aria-hidden="true" />
           </button>
-          <span className="px-1.5 text-[13px] font-bold tabular-nums text-text-primary">
+          <span className="px-1.5 text-[13px] font-bold tabular-nums text-[var(--ink)]">
             {weekRangeLabel}
           </span>
           <button
@@ -231,7 +231,7 @@ const TaskWeekAgenda = ({
               <span
                 key={day.getTime()}
                 className={clsx(
-                  'px-3.5 py-2.5 text-[11px] font-bold tracking-[0.08em]',
+                  'px-3.5 py-[11px] text-[11px] font-bold tracking-[0.08em]',
                   index > 0 && 'border-l border-card-border',
                   isToday
                     ? 'text-[var(--blue-text)] bg-[var(--nav-active-bg)]'
@@ -239,7 +239,7 @@ const TaskWeekAgenda = ({
                 )}
               >
                 {weekday}{' '}
-                <span className={clsx('text-[12px]', !isToday && 'text-text-primary')}>
+                <span className={clsx('text-[12px]', !isToday && 'text-[var(--ink)]')}>
                   {dayNumber}
                   {isToday && ' · today'}
                 </span>
@@ -248,16 +248,20 @@ const TaskWeekAgenda = ({
           })}
         </div>
 
-        <div className="grid min-h-0 flex-1 grid-cols-7 overflow-y-auto scrollbar-hidden">
+        {/* The body scrolls as one block; the scrollbar is width-less in every
+            engine so the day columns stay aligned with the header's dividers. */}
+        <div className="grid min-h-0 flex-1 grid-cols-7 overflow-y-auto scrollbar-hidden [scrollbar-width:none]">
           {days.map((day, index) => {
             const isFutureDay = day.getTime() > todayStartMs;
+            const isToday = isOnPreferredTimeZoneCalendarDay(today, day);
             const dayTasks = tasksByDay[index] ?? [];
             return (
               <div
                 key={`${weekStartKey}-${day.getTime()}`}
                 className={clsx(
                   'group/col flex flex-col gap-2 px-2 py-2.5',
-                  index > 0 && 'border-l border-card-border'
+                  index > 0 && 'border-l border-card-border',
+                  isToday && 'bg-[var(--surface-soft)]'
                 )}
               >
                 {dayTasks.map((task) => (

--- a/apps/frontend/src/app/features/tasks/components/TaskWeekNav.tsx
+++ b/apps/frontend/src/app/features/tasks/components/TaskWeekNav.tsx
@@ -1,0 +1,82 @@
+'use client';
+import React, { useCallback, useMemo } from 'react';
+import { IoChevronBack, IoChevronForward } from 'react-icons/io5';
+import {
+  getStartOfWeek,
+  getWeekDays,
+} from '@/app/features/appointments/components/Calendar/weekHelpers';
+import { formatDateInPreferredTimeZone } from '@/app/lib/timezone';
+
+/**
+ * Week-range navigator for the tasks planner. The design puts this control in
+ * the page title row next to the view toggle, so it lives outside the agenda
+ * board and is threaded in through TitleCalendar's `actionBeforeAdd` slot.
+ */
+type TaskWeekNavProps = {
+  currentDate: Date;
+  setCurrentDate: React.Dispatch<React.SetStateAction<Date>>;
+  setWeekStart: React.Dispatch<React.SetStateAction<Date>>;
+};
+
+const addDays = (date: Date, amount: number): Date => {
+  const next = new Date(date);
+  next.setDate(next.getDate() + amount);
+  return next;
+};
+
+const buildWeekRangeLabel = (days: Date[]): string => {
+  const first = days[0];
+  const last = days.at(-1);
+  /* v8 ignore next 2 -- getWeekDays always returns 7 days; defensive only. */
+  if (!first || !last) return '';
+  const firstDay = formatDateInPreferredTimeZone(first, { day: 'numeric' });
+  const lastDay = formatDateInPreferredTimeZone(last, { day: 'numeric' });
+  const firstMonth = formatDateInPreferredTimeZone(first, { month: 'short' });
+  const lastMonth = formatDateInPreferredTimeZone(last, { month: 'short' });
+  if (firstMonth === lastMonth) {
+    return `${firstDay} – ${lastDay} ${lastMonth}`;
+  }
+  return `${firstDay} ${firstMonth} – ${lastDay} ${lastMonth}`;
+};
+
+const TaskWeekNav = ({ currentDate, setCurrentDate, setWeekStart }: TaskWeekNavProps) => {
+  // Monday-aligned, matching the agenda board the label describes.
+  const days = useMemo(() => getWeekDays(getStartOfWeek(currentDate, 1)), [currentDate]);
+  const weekRangeLabel = useMemo(() => buildWeekRangeLabel(days), [days]);
+
+  const goToPrevWeek = useCallback(() => {
+    setCurrentDate((prev) => addDays(prev, -7));
+    setWeekStart((prev) => addDays(prev, -7));
+  }, [setCurrentDate, setWeekStart]);
+
+  const goToNextWeek = useCallback(() => {
+    setCurrentDate((prev) => addDays(prev, 7));
+    setWeekStart((prev) => addDays(prev, 7));
+  }, [setCurrentDate, setWeekStart]);
+
+  return (
+    <span className="flex items-center gap-1 rounded-full border border-[var(--hairline)] bg-[var(--field-bg)] p-1">
+      <button
+        type="button"
+        aria-label="Previous week"
+        onClick={goToPrevWeek}
+        className="flex size-[30px] items-center justify-center rounded-full text-text-tertiary transition-colors hover:bg-card-hover hover:text-text-primary"
+      >
+        <IoChevronBack size={14} aria-hidden="true" />
+      </button>
+      <span className="px-1.5 text-[13px] font-bold tabular-nums text-text-primary">
+        {weekRangeLabel}
+      </span>
+      <button
+        type="button"
+        aria-label="Next week"
+        onClick={goToNextWeek}
+        className="flex size-[30px] items-center justify-center rounded-full text-text-tertiary transition-colors hover:bg-card-hover hover:text-text-primary"
+      >
+        <IoChevronForward size={14} aria-hidden="true" />
+      </button>
+    </span>
+  );
+};
+
+export default TaskWeekNav;

--- a/apps/frontend/src/app/features/tasks/pages/Tasks/index.tsx
+++ b/apps/frontend/src/app/features/tasks/pages/Tasks/index.tsx
@@ -12,6 +12,7 @@ import { useTasksForPrimaryOrg } from '@/app/hooks/useTask';
 import { Task, TaskFilters, TaskStatus, TaskStatusFilters } from '@/app/features/tasks/types/task';
 import { useSearchStore } from '@/app/stores/searchStore';
 import TaskFilterBar from '@/app/features/tasks/components/TaskFilterBar';
+import TaskWeekNav from '@/app/features/tasks/components/TaskWeekNav';
 import { useIsPhone } from '@/app/ui/layout/PhoneShell/useIsPhone';
 import { usePermissions } from '@/app/hooks/usePermissions';
 import { PERMISSIONS } from '@/app/lib/permissions';
@@ -172,6 +173,11 @@ const Tasks = () => {
       'w-full h-[calc(100vh-200px)] sm:h-[calc(100vh-220px)] min-h-[620px] max-h-[calc(100vh-200px)] sm:max-h-[calc(100vh-220px)] lg:sticky lg:top-4 lg:mb-0 lg:h-[calc(100dvh-105px)] lg:min-h-[calc(100dvh-105px)] lg:max-h-[calc(100dvh-105px)]',
   });
 
+  // The design carries the week-range navigator in the title row, beside the
+  // view toggle — so it only exists for the desktop/tablet week agenda, not for
+  // the board, the list, or the phone day list (which brings its own header).
+  const showWeekNav = activeView === 'calendar' && !isPhone;
+
   let plannerContent: React.ReactNode;
   if (activeView === 'calendar') {
     // The design's tasks "Calendar" is a 7-day agenda board on tablet/desktop; a
@@ -199,9 +205,7 @@ const Tasks = () => {
       <TaskWeekAgenda
         filteredList={filteredList}
         currentDate={currentDate}
-        setCurrentDate={handleCurrentDateChange}
         weekStart={weekStart}
-        setWeekStart={setWeekStart}
         canEditTasks={canEditTasks}
         setActiveTask={setActiveTask}
         setViewPopup={setViewPopup}
@@ -249,6 +253,15 @@ const Tasks = () => {
           setActiveView={setActiveView}
           showAdd={false}
           viewOptions={['calendar', 'board', 'list']}
+          actionBeforeAdd={
+            showWeekNav ? (
+              <TaskWeekNav
+                currentDate={currentDate}
+                setCurrentDate={handleCurrentDateChange}
+                setWeekStart={setWeekStart}
+              />
+            ) : undefined
+          }
         />
         <MobileSearchBar placeholder="Search tasks" />
 

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -959,12 +959,24 @@ input[type='number'] {
     @apply font-satoshi text-[2.5rem] font-medium leading-[3rem] tracking-[-0.8px];
   }
 
-  /* Page title - Serif module page titles (Newsreader).
-     Fluid 30px -> 40px. It sits beside a body-size count and description, so a
-     fixed 46px overpowered that pairing at every width; unlike the display and
-     heading classes it had no step-down of its own. */
+  /* Page title - Serif screen titles (Newsreader 400).
+     Design: 26px / -0.015em / var(--ink) on desktop, 24px on tablet + phone.
+     The earlier 30->40px scale came from the design DOCUMENT's own 46px frame
+     heading, not from the app screens it documents - every PIMS screen title
+     in the frames is the 26px h2, which is what pairs with the count and the
+     13.5px description beside it. */
   .text-page-title {
-    @apply font-newsreader text-[clamp(1.875rem,1.35rem+1.6vw,2.5rem)] font-medium leading-[1.1] tracking-[-0.02em];
+    @apply font-newsreader text-[clamp(1.5rem,1.4rem+0.35vw,1.625rem)] font-normal leading-[1.2] tracking-[-0.015em];
+    color: var(--ink);
+  }
+
+  /* Count that trails a page title - "Appointments (14)".
+     Design: 17px / var(--ink-faint) desktop, 16px tablet + phone. Inherits the
+     serif family and 400 weight from .text-page-title so it reads as a quieter
+     companion to the title rather than a second heading. */
+  .text-page-title-count {
+    @apply text-[clamp(1rem,0.95rem+0.15vw,1.0625rem)] font-normal;
+    color: var(--ink-faint);
   }
 
   /* Heading - 28px/1.75rem - Main section titles | 24px Mobile */

--- a/apps/frontend/src/app/ui/inputs/Dropdown/Dropdown.css
+++ b/apps/frontend/src/app/ui/inputs/Dropdown/Dropdown.css
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
 }
+/* Design: label above field is 12px / 600 / --ink-soft with a 6px gap. */
 .select-top-label {
   display: block;
   margin-bottom: 6px;
@@ -15,6 +16,8 @@
   width: 100%;
   position: relative;
 }
+/* Design select trigger: 46px tall, 0 13px padding, 13px radius,
+   1.5px --hairline, warm --field-bg. Identical to the text-field spec. */
 .select-input-container {
   width: 100%;
   height: 46px;
@@ -32,6 +35,7 @@
     border-color 0.15s,
     box-shadow 0.15s;
 }
+/* Design value text: 13px / 400 / --ink-body. */
 .select-input-selected {
   min-width: 0;
   flex: 1;
@@ -39,11 +43,14 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--ink-body);
-  font-size: 13.5px;
+  font-size: 13px;
   font-weight: 400;
   line-height: 120%;
   font-family: var(--satoshi-font);
   text-align: left;
+}
+.select-input-selected.select-input-placeholder {
+  color: var(--ink-faint);
 }
 .select-container.select-open .select-input-container {
   border-color: var(--blue) !important;
@@ -62,18 +69,26 @@
   color: var(--ink-faint);
   pointer-events: none;
 }
+/* Design chevron: 13px, --ink-faint. react-icons writes the colour as an inline
+   style and the size as width/height attributes, so the colour needs a bump to
+   land while the box size does not. */
+.select-input-drop-icon svg {
+  width: 13px;
+  height: 13px;
+  color: var(--ink-faint) !important;
+}
+/* Design floating menu: detached from the trigger by 4px, 13px radius,
+   1px --hairline-soft, 6px padding, 1px row gap, 0 24px 60px --sh28. */
 .select-input-dropdown {
-  height: 200px;
+  max-height: 200px;
   width: 100%;
   position: absolute;
-  top: 110%;
-  border-radius: 12px;
+  top: calc(100% + 4px);
+  border-radius: 13px;
   border: 1px solid var(--hairline-soft) !important;
   /* Warm liquid-glass floating menu: cream frost in light, espresso in dark. */
   background: var(--glass-93);
-  box-shadow:
-    0 12px 34px var(--sh12),
-    inset 0 1px 0 var(--glass-inset-hi);
+  box-shadow: 0 24px 60px var(--sh28);
   -webkit-backdrop-filter: blur(24px) saturate(1.4);
   backdrop-filter: blur(24px) saturate(1.4);
   outline: none;
@@ -81,7 +96,8 @@
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  padding: 8px;
+  gap: 1px;
+  padding: 6px;
 }
 
 @supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
@@ -89,21 +105,60 @@
     background: var(--screen);
   }
 }
+/* The portal path positions the panel flush under the trigger (rect.bottom - 1),
+   so recover the design's 4px detachment here. */
 .select-input-dropdown-portal {
   position: absolute;
   top: auto;
+  margin-top: 5px;
 }
+/* Design menu row: 7px 11px padding, 8px radius, 12.5px / 600 / --ink-body. */
 .select-input-dropdown-item {
   cursor: pointer;
-  padding: 12px 8px;
+  padding: 7px 11px;
   border-radius: 8px;
   background: transparent;
   text-align: start;
   color: var(--ink-body);
-  font-size: 13px;
-  font-weight: 400;
-  line-height: 120%;
+  font-size: 12.5px;
+  font-weight: 600;
+  line-height: 130%;
   font-family: var(--satoshi-font);
+  transition:
+    background-color 0.12s,
+    color 0.12s;
+}
+.select-input-dropdown-item:hover,
+.select-input-dropdown-item.select-input-dropdown-item-active {
+  background: var(--nav-active-bg);
+  color: var(--nav-active);
+}
+/* Compact in-menu search field: design's 36px / 11px-radius field. */
+.select-input-dropdown-search {
+  height: 36px;
+  padding: 0 11px;
+  margin-bottom: 4px;
+  border-radius: 11px;
+  border: 1.5px solid var(--hairline);
+  background: var(--field-bg);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+.select-input-dropdown-search input {
+  width: 100%;
+  border: 0;
+  background: transparent;
+  color: var(--ink-body);
+  font-size: 12.5px;
+  font-family: var(--satoshi-font);
+}
+.select-input-dropdown-search input:focus-visible {
+  outline: none;
+}
+.select-input-dropdown-search input::placeholder {
+  color: var(--ink-faint);
 }
 
 .Errors {

--- a/apps/frontend/src/app/ui/inputs/Dropdown/DropdownPanel.tsx
+++ b/apps/frontend/src/app/ui/inputs/Dropdown/DropdownPanel.tsx
@@ -15,6 +15,8 @@ type DropdownPanelProps = {
   handleKeyDown: (event: React.KeyboardEvent) => void;
   activeOptionId: string | undefined;
   filteredList: DropdownOption[];
+  /** Unfiltered option list. Part of the caller contract; the design's menu has
+   *  no per-row dividers, so the panel itself only renders `filteredList`. */
   list: DropdownOption[];
   setActiveIndex: (index: number) => void;
   selectOption: (option: DropdownOption) => void;
@@ -33,7 +35,6 @@ const DropdownPanel = ({
   handleKeyDown,
   activeOptionId,
   filteredList,
-  list,
   setActiveIndex,
   selectOption,
 }: DropdownPanelProps) => (
@@ -45,16 +46,11 @@ const DropdownPanel = ({
     style={shouldPortal ? (portalStyle ?? undefined) : undefined}
   >
     {search && (
-      <div className="h-[40px]! rounded-[13px] border-[1.5px]! border-input-border-default! bg-[var(--field-bg)] px-[13px]! flex items-center gap-[9px]">
+      <div className="select-input-dropdown-search">
         <label htmlFor={searchInputId} className="sr-only">
           Search {placeholder}
         </label>
-        <IoSearch
-          size={15}
-          color="var(--color-neutral-600)"
-          className="shrink-0"
-          aria-hidden="true"
-        />
+        <IoSearch size={13} color="var(--ink-faint)" className="shrink-0" aria-hidden="true" />
         <input
           id={searchInputId}
           type="search"
@@ -67,7 +63,6 @@ const DropdownPanel = ({
           }}
           aria-controls={listboxId}
           aria-activedescendant={activeOptionId}
-          className="border-0 text-[12.5px]! w-full focus-visible:outline-none placeholder:text-neutral-600"
           placeholder={`Search ${placeholder}`}
           autoComplete="off"
         />
@@ -76,14 +71,13 @@ const DropdownPanel = ({
     {filteredList.map((option, index: number) => {
       const label: string = option.label ?? option.value ?? '';
       const valueToSend: string = option.value ?? option.label ?? '';
+      const isActive = activeOptionId === `${listboxId}-option-${valueToSend}`;
       return (
         <button
           key={valueToSend || label}
           id={`${listboxId}-option-${valueToSend}`}
           type="button"
-          className={`select-input-dropdown-item ${index === list.length - 1 ? '' : 'border-b border-grey-light'} ${
-            activeOptionId === `${listboxId}-option-${valueToSend}` ? 'bg-card-hover' : ''
-          }`}
+          className={`select-input-dropdown-item ${isActive ? 'select-input-dropdown-item-active' : ''}`}
           onMouseEnter={() => setActiveIndex(index)}
           onClick={() => selectOption(option)}
         >

--- a/apps/frontend/src/app/ui/inputs/Dropdown/LabelDropdown.tsx
+++ b/apps/frontend/src/app/ui/inputs/Dropdown/LabelDropdown.tsx
@@ -48,17 +48,21 @@ const findDropdownOption = (options: DropdownOption[], defaultOption?: string) =
   );
 };
 
+// Design select trigger: 46px tall, 0 13px padding (right side widened for the
+// chevron), 13px radius, 1.5px --hairline, warm --field-bg, 13px value text.
 const triggerClassName = (open: boolean, hasErrorState: boolean): string => {
   const base =
-    'relative w-full flex h-[46px] items-center px-[14px] pr-11 min-w-30 border-[1.5px] cursor-pointer bg-[var(--field-bg)] text-[13.5px] outline-none transition-colors focus:shadow-[0_0_0_3px_var(--glow-b10)]';
-  if (open) return `${base} border-[var(--blue)]! border-b-0! rounded-t-[13px]! z-20`;
+    'relative w-full flex h-[46px] items-center px-[13px] pr-9 min-w-30 rounded-[13px]! border-[1.5px] cursor-pointer bg-[var(--field-bg)] text-[13px] outline-none transition-colors focus:shadow-[0_0_0_3px_var(--glow-b10)]';
+  if (open) return `${base} border-[var(--blue)]! shadow-[0_0_0_3px_var(--glow-b10)] z-20`;
   const border = hasErrorState ? 'border-[var(--danger)]!' : 'border-[var(--hairline)]!';
-  return `${base} rounded-[13px]! ${border}`;
+  return `${base} ${border}`;
 };
 
+// Design menu row: 7px 11px padding, 8px radius, 12.5px / 600, --ink-body,
+// active/hover on the warm --nav-active-bg wash.
 const optionClassName = (isActive: boolean): string =>
-  `flex items-center justify-between gap-2 px-5 py-3 text-left text-body-4 hover:bg-card-hover rounded-2xl! text-text-secondary! hover:text-text-primary! w-full ${
-    isActive ? 'bg-card-hover text-text-primary!' : ''
+  `flex items-center justify-between gap-2 px-[11px] py-[7px] text-left text-[12.5px] font-semibold rounded-[8px]! w-full transition-colors hover:bg-[var(--nav-active-bg)] hover:text-[var(--nav-active)]! ${
+    isActive ? 'bg-[var(--nav-active-bg)] text-[var(--nav-active)]!' : 'text-[var(--ink-body)]!'
   }`;
 
 type DropdownPanelProps = {
@@ -95,7 +99,7 @@ const DropdownPanel = ({
       aria-label={placeholder}
       data-portal-dropdown
       data-terminology-lock={isTerminologyLocked ? 'true' : undefined}
-      className="border-[var(--blue)] max-h-50 overflow-y-auto scrollbar-hidden z-200 rounded-b-[13px] border border-t bg-[var(--glass-93)] shadow-[0_16px_34px_var(--sh12)] backdrop-blur-[24px] backdrop-saturate-150 flex flex-col items-stretch w-full px-3 py-2.5"
+      className="max-h-[200px] overflow-y-auto scrollbar-hidden z-200 rounded-[13px] border border-[var(--hairline-soft)] bg-[var(--glass-93)] shadow-[0_24px_60px_var(--sh28)] backdrop-blur-[24px] backdrop-saturate-150 flex flex-col items-stretch gap-px w-full p-1.5"
       style={shouldPortal ? (portalStyle ?? undefined) : undefined}
     >
       {filteredOptions.length > 0 &&
@@ -110,14 +114,16 @@ const DropdownPanel = ({
           >
             <span className="min-w-0 truncate">{option.label}</span>
             {option.badge && (
-              <span className="shrink-0 rounded-2xl bg-primary-100 px-2 py-0.5 text-caption-2 font-medium text-text-brand">
+              <span className="shrink-0 rounded-full bg-primary-100 px-2 py-0.5 text-[11px] font-semibold text-text-brand">
                 {option.badge}
               </span>
             )}
           </button>
         ))}
       {filteredOptions.length === 0 && (
-        <div className="text-caption-1 py-3 text-text-primary text-center">{emptyMessage}</div>
+        <div className="py-[7px] text-center text-[12.5px] font-medium text-[var(--ink-faint)]">
+          {emptyMessage}
+        </div>
       )}
     </div>
   );
@@ -167,17 +173,17 @@ const DropdownTriggerContent = ({
           event.stopPropagation();
           onSearchKeyDown(event);
         }}
-        className="w-full min-w-0 bg-transparent text-left text-[13.5px] text-[var(--ink-body)] focus-visible:outline-none placeholder:text-[var(--ink-faint)]"
+        className="w-full min-w-0 bg-transparent text-left text-[13px] text-[var(--ink-body)] focus-visible:outline-none placeholder:text-[var(--ink-faint)]"
       />
     )}
     {(!open || !searchable) && selected && (
-      <span className="min-w-0 flex-1 text-left text-[var(--ink-body)] text-[13.5px] truncate">
+      <span className="min-w-0 flex-1 text-left text-[var(--ink-body)] text-[13px] truncate">
         {selected.label}
       </span>
     )}
-    <span className="absolute right-3.5 top-1/2 -translate-y-1/2 flex items-center justify-center">
+    <span className="absolute right-[13px] top-1/2 -translate-y-1/2 flex items-center justify-center">
       <IoChevronDown
-        size={14}
+        size={13}
         aria-hidden="true"
         style={{
           flexShrink: 0,
@@ -257,7 +263,8 @@ const LabelDropdown = ({
       position: 'absolute',
       left: rect.left + globalThis.window.scrollX,
       width: rect.width,
-      top: rect.bottom + globalThis.window.scrollY - 1,
+      // Design detaches the menu from the trigger by 4px.
+      top: rect.bottom + globalThis.window.scrollY + 4,
       maxHeight: panelMaxHeight,
       zIndex: 5000,
     });
@@ -398,7 +405,7 @@ const LabelDropdown = ({
 
   return (
     <div className="flex flex-col w-full">
-      <span className="mb-1.5 flex items-center gap-1 truncate text-[12.5px] font-semibold text-[var(--ink-soft)]">
+      <span className="mb-1.5 flex items-center gap-1 truncate text-[12px] font-semibold text-[var(--ink-soft)]">
         {icon}
         {placeholder}
       </span>
@@ -433,7 +440,7 @@ const LabelDropdown = ({
         </button>
         {open && shouldPortal && portalStyle && createPortal(panelNode, document.body)}
         {open && !shouldPortal && (
-          <div className="absolute top-full left-0 w-full">{panelNode}</div>
+          <div className="absolute top-full left-0 mt-1 w-full">{panelNode}</div>
         )}
       </div>
       {error && (

--- a/apps/frontend/src/app/ui/inputs/Dropdown/index.tsx
+++ b/apps/frontend/src/app/ui/inputs/Dropdown/index.tsx
@@ -156,7 +156,9 @@ const Dropdown = ({ placeholder, options, defaultOption, onSelect, error }: Drop
     <div className="relative" ref={dropdownRef}>
       <button
         type="button"
-        className={`w-full flex items-center justify-between gap-2 h-[46px] px-[14px] min-w-[120px] bg-[var(--field-bg)] border-[1.5px] text-[13.5px] outline-none transition-colors focus:shadow-[0_0_0_3px_var(--glow-b10)] ${error ? 'border-[var(--danger)]!' : ''} ${open ? 'border-b-0! border-[var(--blue)]! rounded-t-[13px]!' : 'border-[var(--hairline)]! rounded-[13px]!'}`}
+        className={`w-full flex items-center justify-between gap-2 h-[46px] px-[13px] min-w-[120px] rounded-[13px]! bg-[var(--field-bg)] border-[1.5px] text-[13px] outline-none transition-colors focus:shadow-[0_0_0_3px_var(--glow-b10)] ${
+          error ? 'border-[var(--danger)]!' : 'border-[var(--hairline)]!'
+        } ${open ? 'border-[var(--blue)]! shadow-[0_0_0_3px_var(--glow-b10)]' : ''}`}
         onClick={() => setOpen((e) => !e)}
         onKeyDown={handleKeyDown}
         aria-haspopup="listbox"
@@ -164,34 +166,34 @@ const Dropdown = ({ placeholder, options, defaultOption, onSelect, error }: Drop
         aria-controls={open ? listboxId : undefined}
       >
         {selected ? (
-          <div className="text-[var(--ink-body)] text-[13.5px] truncate max-w-[200px]">
+          <div className="text-[var(--ink-body)] text-[13px] truncate max-w-[200px]">
             {selected.label}
           </div>
         ) : (
-          <div className="text-[var(--ink-faint)] text-[13.5px] truncate max-w-[200px]">
+          <div className="text-[var(--ink-faint)] text-[13px] truncate max-w-[200px]">
             {placeholder}
           </div>
         )}
         <IoChevronDown
-          size={14}
+          size={13}
           color="var(--ink-faint)"
-          className="shrink-0 transition-transform"
+          className={`shrink-0 transition-transform ${open ? 'rotate-180' : ''}`}
         />
       </button>
       {open && (
         <div
           id={listboxId}
-          className="border-[var(--blue)] max-h-50 overflow-y-auto scrollbar-hidden z-99 absolute top-full left-0 rounded-b-[13px] border border-t bg-[var(--glass-93)] shadow-[0_16px_34px_var(--sh12)] backdrop-blur-[24px] backdrop-saturate-150 flex flex-col items-stretch w-full px-3 py-2.5"
+          className="max-h-[200px] overflow-y-auto scrollbar-hidden z-200 absolute top-[calc(100%_+_4px)] left-0 rounded-[13px] border border-[var(--hairline-soft)] bg-[var(--glass-93)] shadow-[0_24px_60px_var(--sh28)] backdrop-blur-[24px] backdrop-saturate-150 flex flex-col items-stretch gap-px w-full p-1.5"
         >
           {options.map((option, i) => (
             <button
               type="button"
               key={option.key + i}
               id={`${listboxId}-option-${option.key}`}
-              className={`px-5 py-3 text-[13px] hover:bg-card-hover rounded-[10px]! text-text-secondary! hover:text-text-primary! w-full text-left ${
+              className={`px-[11px] py-[7px] text-[12.5px] font-semibold rounded-[8px]! w-full text-left transition-colors hover:bg-[var(--nav-active-bg)] hover:text-[var(--nav-active)]! ${
                 activeOptionId === `${listboxId}-option-${option.key}`
-                  ? 'bg-card-hover text-text-primary!'
-                  : ''
+                  ? 'bg-[var(--nav-active-bg)] text-[var(--nav-active)]!'
+                  : 'text-[var(--ink-body)]!'
               }`}
               onMouseEnter={() => setActiveIndex(i)}
               onClick={() => selectOption(option)}

--- a/apps/frontend/src/app/ui/tables/PaginatedGridTable.tsx
+++ b/apps/frontend/src/app/ui/tables/PaginatedGridTable.tsx
@@ -74,7 +74,13 @@ const PaginatedGridTable = <T,>({
   return (
     <div className="table-wrapper inventory-scroll-x h-full min-h-0 overflow-hidden">
       <div className="inventory-table-list h-full min-h-0 flex-1">
-        <div className="flex h-full min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden rounded-[18px] border border-card-border bg-neutral-0 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]">
+        {/* `isolate` (isolation:isolate) makes this rounded container own a
+            compositing context so overflow-hidden actually clips the
+            position:sticky, z-10 header to the 18px corners — otherwise Chrome
+            renders the sticky header on its own layer and its square top edge
+            pokes out past the rounded corners on scroll repaint (same fix as
+            .TableShell in Generictable.css). */}
+        <div className="isolate flex h-full min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden rounded-[18px] border border-card-border bg-neutral-0 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]">
           <div className="min-h-0 flex-1 overflow-auto">
             <div className="min-w-[1080px]">
               <div

--- a/apps/frontend/src/app/ui/widgets/Summary/Availability.tsx
+++ b/apps/frontend/src/app/ui/widgets/Summary/Availability.tsx
@@ -49,7 +49,7 @@ const Availability = () => {
   return (
     <PermissionGate allOf={[PERMISSIONS.TEAMS_VIEW_ANY]}>
       <div className="summary-container">
-        <h2 className="text-[15px] font-bold tracking-[-0.02em] text-[var(--ink)]">
+        <h2 className="text-[16px] font-bold tracking-[-0.02em] text-[var(--ink)]">
           Availability <span className="font-medium text-[var(--ink-faint)]">({teams.length})</span>
         </h2>
         <div className="flex items-center gap-2 flex-wrap">

--- a/apps/frontend/src/app/ui/widgets/TitleCalendar/index.tsx
+++ b/apps/frontend/src/app/ui/widgets/TitleCalendar/index.tsx
@@ -40,17 +40,16 @@ const TitleCalendar = ({
   const segW = n === 2 ? 'w-1/2' : 'w-1/3';
 
   return (
-    <div className="flex w-full flex-wrap items-center justify-between gap-x-6 gap-y-2">
+    <div className="flex w-full flex-wrap items-end justify-between gap-x-4 gap-y-2">
       <div className="flex min-w-0 flex-col gap-[3px]">
-        <h1 className="text-page-title text-text-primary">
-          {title}
-          <span className="text-[17px] text-[var(--ink-faint)]">{` (${count})`}</span>
+        <h1 className="text-page-title">
+          {title} <span className="text-page-title-count">{`(${count})`}</span>
         </h1>
         {description ? (
           <p className="text-[13.5px] text-[var(--ink-muted)]">{description}</p>
         ) : null}
       </div>
-      <div className="flex w-full shrink-0 flex-wrap items-center justify-end gap-2 sm:w-auto">
+      <div className="flex w-full shrink-0 flex-wrap items-center justify-end gap-2.5 sm:w-auto">
         {actionBeforeAdd}
         {showAdd && (
           <Primary href="#" text="Add" onClick={() => setAddPopup(true)} className="px-7" />


### PR DESCRIPTION
## What changed
Visual issues found by walking the deployed dev site after PR #1912 merged:

- Appointment workspace: the full-bleed header banner used `--status-in-progress-bg` (#f5f3ff lavender) as its background, tinting the whole workspace blue/violet. Switched to `--screen` (warm-bone) to match the design. The status token itself is unchanged - still used for status pills and calendar chips.
- Integrations: restored the IDEXX credentials side drawer (the "Manage credentials" button opens the settings modal) instead of the inline right-hand panel; full-width catalog card grid. All credential store/validate, enable/disable, status, sync-health, and recent-orders functionality preserved.
- Tables: added `isolate` to PaginatedGridTable's rounded shell so the sticky header clips to the rounded corners (removes the header seam).

## Why
The inline integrations panel and the blue workspace tint were regressions vs the design; the table header had a visible corner seam. These only showed on the deployed, populated screens.

## Impact area
apps/frontend - appointments workspace, integrations, shared tables.

## Validation
- Full frontend suite green: 10,190 tests, tsc clean, lint clean.
- Integrations rewritten tests cover the drawer + recent-orders (100% stmts/lines on index.tsx).

Follow-up to #1912.