### PR TITLE
fix(frontend): resolve QA-logged and marketing/auth/chat UI bugs

### DIFF
--- a/apps/frontend/src/app/__tests__/(routes)/signin/page.test.tsx
+++ b/apps/frontend/src/app/__tests__/(routes)/signin/page.test.tsx
@@ -15,9 +15,13 @@ jest.mock('next/navigation', () => ({
   redirect: jest.fn(),
 }));
 
-jest.mock('@/app/stores/authStore', () => ({
-  useAuthStore: jest.fn(),
-}));
+jest.mock('@/app/stores/authStore', () => {
+  const useAuthStore = jest.fn();
+  (useAuthStore as unknown as { getState: unknown }).getState = jest.fn(() => ({
+    checkSession: jest.fn(),
+  }));
+  return { useAuthStore };
+});
 
 jest.mock('@/app/lib/postAuthRedirect', () => ({
   resolvePostAuthRedirect: jest.fn(),

--- a/apps/frontend/src/app/__tests__/(routes)/signup/page.test.tsx
+++ b/apps/frontend/src/app/__tests__/(routes)/signup/page.test.tsx
@@ -16,9 +16,13 @@ jest.mock('next/navigation', () => ({
   redirect: jest.fn(),
 }));
 
-jest.mock('@/app/stores/authStore', () => ({
-  useAuthStore: jest.fn(),
-}));
+jest.mock('@/app/stores/authStore', () => {
+  const useAuthStore = jest.fn();
+  (useAuthStore as unknown as { getState: unknown }).getState = jest.fn(() => ({
+    checkSession: jest.fn(),
+  }));
+  return { useAuthStore };
+});
 
 jest.mock('@/app/lib/postAuthRedirect', () => ({
   resolvePostAuthRedirect: jest.fn(),

--- a/apps/frontend/src/app/__tests__/components/DashboardSteps/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/DashboardSteps/index.test.tsx
@@ -6,7 +6,7 @@ import DashboardSteps from '@/app/ui/widgets/DashboardSteps';
 
 const usePrimaryOrgMock = jest.fn();
 const useSubscriptionMock = jest.fn();
-const useServicesMock = jest.fn();
+const useSpecialitiesMock = jest.fn();
 const useTeamMock = jest.fn();
 const mockCan = jest.fn();
 
@@ -19,7 +19,7 @@ jest.mock('@/app/hooks/useBilling', () => ({
 }));
 
 jest.mock('@/app/hooks/useSpecialities', () => ({
-  useServicesForPrimaryOrgSpecialities: () => useServicesMock(),
+  useSpecialitiesForPrimaryOrg: () => useSpecialitiesMock(),
 }));
 
 jest.mock('@/app/hooks/useTeam', () => ({
@@ -54,7 +54,7 @@ describe('DashboardSteps', () => {
       connectAccountId: 'acct_1',
       connectChargesEnabled: false,
     });
-    useServicesMock.mockReturnValue([]);
+    useSpecialitiesMock.mockReturnValue([{ _id: 'sp1', activeServiceCount: 0 }]);
     useTeamMock.mockReturnValue([{ _id: 'u1' }]);
 
     render(<DashboardSteps />);
@@ -73,7 +73,7 @@ describe('DashboardSteps', () => {
       connectAccountId: null,
       connectChargesEnabled: false,
     });
-    useServicesMock.mockReturnValue([]);
+    useSpecialitiesMock.mockReturnValue([{ _id: 'sp1', activeServiceCount: 0 }]);
     useTeamMock.mockReturnValue([{ _id: 'u1' }]);
     mockCan.mockImplementation((input: any) => input === 'specialities:edit:any');
 
@@ -90,7 +90,7 @@ describe('DashboardSteps', () => {
       connectAccountId: 'acct_1',
       connectChargesEnabled: false,
     });
-    useServicesMock.mockReturnValue([{ id: 'svc' }]);
+    useSpecialitiesMock.mockReturnValue([{ _id: 'sp1', activeServiceCount: 3 }]);
     useTeamMock.mockReturnValue([{ _id: 'u1' }]);
 
     render(<DashboardSteps />);
@@ -106,10 +106,71 @@ describe('DashboardSteps', () => {
       connectAccountId: 'acct_1',
       connectChargesEnabled: true,
     });
-    useServicesMock.mockReturnValue([{ id: 'svc' }]);
+    useSpecialitiesMock.mockReturnValue([{ _id: 'sp1', activeServiceCount: 3 }]);
     useTeamMock.mockReturnValue([{ _id: 'u1' }, { _id: 'u2' }]);
 
     const { container } = render(<DashboardSteps />);
     expect(container.firstChild).toBeNull();
+  });
+
+  it('completes Step 1 when any speciality has activeServiceCount > 0 (survives refresh)', () => {
+    usePrimaryOrgMock.mockReturnValue({ _id: 'org1', isVerified: true });
+    useSubscriptionMock.mockReturnValue({
+      connectAccountId: 'acct_1',
+      connectChargesEnabled: false,
+    });
+    useSpecialitiesMock.mockReturnValue([
+      { _id: 'sp1', activeServiceCount: 0 },
+      { _id: 'sp2', activeServiceCount: 4 },
+    ]);
+    useTeamMock.mockReturnValue([{ _id: 'u1' }]);
+
+    render(<DashboardSteps />);
+
+    expect(screen.getByText('View services')).toBeInTheDocument();
+    expect(screen.getByText('1 of 3 done')).toBeInTheDocument();
+  });
+
+  it('leaves Step 1 incomplete when no speciality has active services', () => {
+    usePrimaryOrgMock.mockReturnValue({ _id: 'org1', isVerified: true });
+    useSubscriptionMock.mockReturnValue({
+      connectAccountId: 'acct_1',
+      connectChargesEnabled: false,
+    });
+    useSpecialitiesMock.mockReturnValue([{ _id: 'sp1', activeServiceCount: 0 }, { _id: 'sp2' }]);
+    useTeamMock.mockReturnValue([{ _id: 'u1' }]);
+
+    render(<DashboardSteps />);
+
+    expect(screen.getByText('Add services')).toBeInTheDocument();
+    expect(screen.getByText('0 of 3 done')).toBeInTheDocument();
+  });
+
+  it('renders nothing when there is no primary org', () => {
+    usePrimaryOrgMock.mockReturnValue(null);
+    useSubscriptionMock.mockReturnValue({
+      connectAccountId: 'acct_1',
+      connectChargesEnabled: false,
+    });
+    useSpecialitiesMock.mockReturnValue([{ _id: 'sp1', activeServiceCount: 0 }]);
+    useTeamMock.mockReturnValue([{ _id: 'u1' }]);
+
+    const { container } = render(<DashboardSteps />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('treats a missing team list as an incomplete team step', () => {
+    usePrimaryOrgMock.mockReturnValue({ _id: 'org1', isVerified: true });
+    useSubscriptionMock.mockReturnValue({
+      connectAccountId: 'acct_1',
+      connectChargesEnabled: false,
+    });
+    useSpecialitiesMock.mockReturnValue([{ _id: 'sp1', activeServiceCount: 0 }]);
+    useTeamMock.mockReturnValue(undefined);
+
+    render(<DashboardSteps />);
+
+    expect(screen.getByText('Invite team')).toBeInTheDocument();
+    expect(screen.getByText('0 of 3 done')).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/app/__tests__/components/DataTable/InvoiceTable.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/DataTable/InvoiceTable.test.tsx
@@ -225,7 +225,7 @@ describe('InvoiceTable', () => {
     expect(screen.getByTestId('cell-appointment-id')).toHaveTextContent('Sam');
   });
 
-  it('renders the appointment type in the subtitle and falls back to appointmentDate for the time', () => {
+  it('pairs the appointment type with the time only in the desktop sub-line and falls back to appointmentDate for the time', () => {
     useAppointmentsForPrimaryOrgMock.mockReturnValue([
       {
         id: 'appt-1',
@@ -238,9 +238,13 @@ describe('InvoiceTable', () => {
 
     render(<InvoiceTable filteredList={[invoice]} />);
 
-    expect(
-      within(screen.getByTestId('generic-table')).getByTitle('Wellness exam · Jan 1 10:00 AM')
-    ).toBeInTheDocument();
+    // The Date column already carries 'Jan 1', so the desktop sub-line must not
+    // repeat it — only the appointment type and time.
+    const desktopSub = within(screen.getByTestId('generic-table')).getByTitle(
+      'Wellness exam · 10:00 AM'
+    );
+    expect(desktopSub).toBeInTheDocument();
+    expect(desktopSub).not.toHaveTextContent('Jan 1');
   });
 
   it('renders an empty subtitle and no date cell when the appointment is not found', () => {

--- a/apps/frontend/src/app/__tests__/components/chat/ChatMessage.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/chat/ChatMessage.test.tsx
@@ -152,6 +152,61 @@ describe('ChatMessage', () => {
     expect(handleReaction).toHaveBeenCalledWith('❤️', expect.anything());
   });
 
+  it('renders the reaction picker in a body portal with every emoji visible', () => {
+    // Regression: the picker previously opened downward inside Stream's
+    // overflow:auto message list and was clipped on the last message. It now
+    // renders through a portal to document.body with position:fixed so no scroll
+    // ancestor can clip it, and every REACTION_EMOJI stays visible.
+    const REACTION_EMOJIS = ['👍', '❤️', '😂', '🎉', '🙏', '✅'];
+    setup();
+    fireEvent.click(screen.getByLabelText('React'));
+    REACTION_EMOJIS.forEach((emoji) => {
+      expect(screen.getByText(emoji)).toBeInTheDocument();
+    });
+    const popover = screen.getByText('❤️').closest('div');
+    expect(popover?.parentElement).toBe(document.body);
+    expect(popover).toHaveStyle({ position: 'fixed' });
+  });
+
+  it('closes the reaction picker on Escape', () => {
+    setup();
+    fireEvent.click(screen.getByLabelText('React'));
+    expect(screen.getByText('❤️')).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByText('❤️')).not.toBeInTheDocument();
+  });
+
+  it('dismisses the reaction picker when the page scrolls', () => {
+    setup();
+    fireEvent.click(screen.getByLabelText('React'));
+    expect(screen.getByText('❤️')).toBeInTheDocument();
+    fireEvent.scroll(window);
+    expect(screen.queryByText('❤️')).not.toBeInTheDocument();
+  });
+
+  it('flips the reaction picker above the trigger when there is no room below', () => {
+    setup();
+    const reactBtn = screen.getByLabelText('React');
+    // Anchor sits at the very bottom of the viewport, so the picker must open
+    // upward rather than clip past the fold.
+    jest.spyOn(reactBtn, 'getBoundingClientRect').mockReturnValue({
+      bottom: 900,
+      top: 890,
+      left: 50,
+      right: 90,
+      width: 40,
+      height: 20,
+      x: 50,
+      y: 890,
+      toJSON: () => ({}),
+    } as DOMRect);
+    fireEvent.click(reactBtn);
+    const popover = screen.getByText('❤️').closest('div');
+    expect(popover).toHaveStyle({ position: 'fixed' });
+    // top = max(8, anchor.top - panelHeight - 6) with a zero-height jsdom panel.
+    expect(popover?.style.top).toBe('884px');
+  });
+
   it('replies via the thread handler', () => {
     const { handleOpenThread } = setup();
     fireEvent.click(screen.getByLabelText('Reply'));
@@ -251,19 +306,19 @@ describe('ChatMessage', () => {
     expect(editMessage).not.toHaveBeenCalled();
   });
 
-  it('closes the reaction picker via the backdrop', () => {
+  it('closes the reaction picker on an outside pointer-down', () => {
     setup();
     fireEvent.click(screen.getByLabelText('React'));
     expect(screen.getByText('❤️')).toBeInTheDocument();
-    fireEvent.click(screen.getByLabelText('Close'));
+    fireEvent.mouseDown(document.body);
     expect(screen.queryByText('❤️')).not.toBeInTheDocument();
   });
 
-  it('closes the more-menu via the backdrop', () => {
+  it('closes the more-menu on an outside pointer-down', () => {
     setup({ isMyMessage: true });
     fireEvent.click(screen.getByLabelText('More'));
     expect(screen.getByText('Edit')).toBeInTheDocument();
-    fireEvent.click(screen.getByLabelText('Close'));
+    fireEvent.mouseDown(document.body);
     expect(screen.queryByText('Edit')).not.toBeInTheDocument();
   });
 

--- a/apps/frontend/src/app/__tests__/features/auth/AuthedRedirectShell.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/auth/AuthedRedirectShell.test.tsx
@@ -5,10 +5,13 @@ const redirect = jest.fn();
 jest.mock('next/navigation', () => ({ redirect: (url: string) => redirect(url) }));
 
 let mockState: { status: string; role: string };
-jest.mock('@/app/stores/authStore', () => ({
-  useAuthStore: (selector: (state: { status: string; role: string }) => unknown) =>
-    selector(mockState),
-}));
+const mockCheckSession = jest.fn();
+jest.mock('@/app/stores/authStore', () => {
+  const useAuthStore = (selector: (state: { status: string; role: string }) => unknown) =>
+    selector(mockState);
+  useAuthStore.getState = () => ({ checkSession: mockCheckSession });
+  return { useAuthStore };
+});
 
 const resolvePostAuthRedirect = jest.fn();
 jest.mock('@/app/lib/postAuthRedirect', () => ({
@@ -21,6 +24,7 @@ describe('AuthedRedirectShell', () => {
   beforeEach(() => {
     redirect.mockReset();
     resolvePostAuthRedirect.mockReset();
+    mockCheckSession.mockReset();
     mockState = { status: 'unauthenticated', role: 'member' };
   });
 
@@ -52,5 +56,22 @@ describe('AuthedRedirectShell', () => {
       expect(resolvePostAuthRedirect).toHaveBeenCalledWith({ fallbackRole: 'admin' })
     );
     await waitFor(() => expect(redirect).toHaveBeenCalledWith('/dashboard'));
+  });
+
+  it('bootstraps the session check when the auth status is idle', async () => {
+    mockState = { status: 'idle', role: 'member' };
+
+    render(
+      <AuthedRedirectShell>
+        <div>auth screen</div>
+      </AuthedRedirectShell>
+    );
+
+    // idle is not authenticated, so the auth screen still renders and nothing redirects,
+    // but the session check is kicked off so `status` can resolve.
+    await waitFor(() => expect(mockCheckSession).toHaveBeenCalledTimes(1));
+    expect(screen.getByText('auth screen')).toBeInTheDocument();
+    expect(resolvePostAuthRedirect).not.toHaveBeenCalled();
+    expect(redirect).not.toHaveBeenCalled();
   });
 });

--- a/apps/frontend/src/app/__tests__/features/companions/InClinicTodayBand.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/companions/InClinicTodayBand.test.tsx
@@ -93,6 +93,56 @@ describe('InClinicTodayBand', () => {
     expect(screen.getByText('B')).toBeInTheDocument();
   });
 
+  it('opens the specific appointment on card click and keyboard activation', () => {
+    useAppointmentsMock.mockReturnValue([
+      {
+        id: 'a1 b',
+        status: 'IN_PROGRESS',
+        startTime: today,
+        appointmentDate: today,
+        concern: 'dental cleaning',
+        companion: { id: 'c1', name: 'Poppy', species: 'dog', breed: 'Beagle' },
+      },
+    ]);
+
+    render(<InClinicTodayBand companions={companions} />);
+
+    const card = screen.getByRole('button', {
+      name: 'Open appointment for Poppy, 08:30, In progress',
+    });
+
+    fireEvent.click(card);
+    expect(pushMock).toHaveBeenCalledWith('/appointments?appointmentId=a1%20b&open=details');
+
+    pushMock.mockClear();
+    fireEvent.keyDown(card, { key: 'Enter' });
+    expect(pushMock).toHaveBeenCalledWith('/appointments?appointmentId=a1%20b&open=details');
+
+    pushMock.mockClear();
+    fireEvent.keyDown(card, { key: ' ' });
+    expect(pushMock).toHaveBeenCalledWith('/appointments?appointmentId=a1%20b&open=details');
+
+    // A non-activation key is ignored.
+    pushMock.mockClear();
+    fireEvent.keyDown(card, { key: 'Escape' });
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it('renders a non-interactive card when the appointment has no id', () => {
+    useAppointmentsMock.mockReturnValue([
+      {
+        status: 'CHECKED_IN',
+        appointmentDate: today,
+        companion: { id: 'c1', name: 'Poppy', species: 'dog' },
+      },
+    ]);
+
+    render(<InClinicTodayBand companions={companions} />);
+
+    // No appointment id → the card is not exposed as a button and cannot navigate.
+    expect(screen.queryByRole('button', { name: /Open appointment for/ })).not.toBeInTheDocument();
+  });
+
   it('routes to the schedule from the header link', () => {
     useAppointmentsMock.mockReturnValue([
       {

--- a/apps/frontend/src/app/__tests__/features/integrations/pages/MerckManuals.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/integrations/pages/MerckManuals.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { axe, toHaveNoViolations } from 'jest-axe';
 
@@ -400,6 +400,90 @@ describe('MerckManuals page', () => {
 
     fireEvent.load(iframe);
     await waitFor(() => expect(screen.queryByText(/Fetching/)).not.toBeInTheDocument());
+  });
+
+  it('falls back to open-in-new-tab when the reader load times out (framing refused)', async () => {
+    jest.useFakeTimers();
+    try {
+      render(<ProtectedMerckManuals />);
+      fireEvent.change(screen.getByLabelText('Search manuals'), { target: { value: 'fever' } });
+      fireEvent.click(screen.getByText('Search'));
+      await waitFor(() => expect(screen.getByText('Canine Fever')).toBeInTheDocument());
+
+      fireEvent.click(screen.getByText('Open'));
+      await screen.findByTitle('Canine Fever');
+      expect(screen.getByText(/Fetching/)).toBeInTheDocument();
+
+      act(() => {
+        jest.advanceTimersByTime(12000);
+      });
+
+      const fallback = screen
+        .getByText('This manual can’t be shown here')
+        .closest('div') as HTMLElement;
+      expect(fallback).toBeInTheDocument();
+      // The infinite spinner and the un-renderable iframe are both gone.
+      expect(screen.queryByText(/Fetching/)).not.toBeInTheDocument();
+      expect(screen.queryByTitle('Canine Fever')).not.toBeInTheDocument();
+      // The fallback reuses the "Open in new tab" action pointing at the original URL.
+      const fallbackLink = within(fallback).getByRole('link', { name: /Open in new tab/ });
+      expect(fallbackLink).toHaveAttribute('href', baseEntry.primaryUrl);
+      expect(fallbackLink).toHaveAttribute('target', '_blank');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('does not fall back when the iframe loads before the timeout elapses', async () => {
+    jest.useFakeTimers();
+    try {
+      render(<ProtectedMerckManuals />);
+      fireEvent.change(screen.getByLabelText('Search manuals'), { target: { value: 'fever' } });
+      fireEvent.click(screen.getByText('Search'));
+      await waitFor(() => expect(screen.getByText('Canine Fever')).toBeInTheDocument());
+
+      fireEvent.click(screen.getByText('Open'));
+      const iframe = await screen.findByTitle('Canine Fever');
+
+      act(() => {
+        fireEvent.load(iframe);
+      });
+      act(() => {
+        jest.advanceTimersByTime(12000);
+      });
+
+      expect(screen.queryByText('This manual can’t be shown here')).not.toBeInTheDocument();
+      expect(screen.queryByText(/Fetching/)).not.toBeInTheDocument();
+      expect(screen.getByTitle('Canine Fever')).toBeInTheDocument();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('resets the blocked fallback when a new reader is opened', async () => {
+    jest.useFakeTimers();
+    try {
+      render(<ProtectedMerckManuals />);
+      fireEvent.change(screen.getByLabelText('Search manuals'), { target: { value: 'fever' } });
+      fireEvent.click(screen.getByText('Search'));
+      await waitFor(() => expect(screen.getByText('Canine Fever')).toBeInTheDocument());
+
+      fireEvent.click(screen.getByText('Open'));
+      await screen.findByTitle('Canine Fever');
+      act(() => {
+        jest.advanceTimersByTime(12000);
+      });
+      expect(screen.getByText('This manual can’t be shown here')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByLabelText('Close Merck reader'));
+      fireEvent.click(screen.getByRole('button', { name: 'Overview' }));
+
+      expect(await screen.findByTitle('Canine Fever')).toBeInTheDocument();
+      expect(screen.queryByText('This manual can’t be shown here')).not.toBeInTheDocument();
+      expect(screen.getByText(/Fetching/)).toBeInTheDocument();
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it('opens the reader from the title button, sub-topic pill and supports open-in-new-tab', async () => {

--- a/apps/frontend/src/app/__tests__/features/marketing/site/SiteNav.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/marketing/site/SiteNav.test.tsx
@@ -4,6 +4,8 @@ import '@testing-library/jest-dom';
 
 let starsValue: string | null = '2.4k';
 let scrolledValue = false;
+let mockAuthState: { status: string; user: unknown; role: string | null };
+const mockCheckSession = jest.fn();
 
 jest.mock('@/app/features/marketing/site/useGithubStats', () => ({
   useGithubStats: () => ({ stars: starsValue }),
@@ -11,6 +13,11 @@ jest.mock('@/app/features/marketing/site/useGithubStats', () => ({
 jest.mock('@/app/features/marketing/site/motion', () => ({
   useScrolled: () => scrolledValue,
 }));
+jest.mock('@/app/stores/authStore', () => {
+  const useAuthStore = (selector: (s: typeof mockAuthState) => unknown) => selector(mockAuthState);
+  useAuthStore.getState = () => ({ checkSession: mockCheckSession });
+  return { useAuthStore };
+});
 jest.mock('next/image', () => ({
   __esModule: true,
   default: jest.requireActual('@/app/__tests__/support/marketingTestMocks').NextImageMock,
@@ -26,6 +33,8 @@ describe('SiteNav', () => {
   beforeEach(() => {
     starsValue = '2.4k';
     scrolledValue = false;
+    mockAuthState = { status: 'unauthenticated', user: null, role: null };
+    mockCheckSession.mockReset();
   });
 
   it('renders the primary nav links, star count and the get-started CTA', () => {
@@ -70,5 +79,28 @@ describe('SiteNav', () => {
     scrolledValue = true;
     render(<SiteNav active="about" />);
     expect(screen.getAllByRole('link', { name: 'About' }).length).toBeGreaterThan(0);
+  });
+
+  it('shows a "Go to app" link to the default route for an authenticated visitor', () => {
+    mockAuthState = { status: 'authenticated', user: { userId: 'u1' }, role: 'developer' };
+    render(<SiteNav />);
+    const goToApp = screen.getAllByRole('link', { name: 'Go to app' });
+    expect(goToApp.length).toBeGreaterThan(0);
+    expect(goToApp.every((el) => el.getAttribute('href') === '/developers/home')).toBe(true);
+    expect(screen.queryByRole('link', { name: 'Get started' })).not.toBeInTheDocument();
+  });
+
+  it('shows the "Get started" sign-up link for a guest', () => {
+    render(<SiteNav />);
+    const getStarted = screen.getAllByRole('link', { name: 'Get started' });
+    expect(getStarted.length).toBeGreaterThan(0);
+    expect(getStarted.every((el) => el.getAttribute('href') === '/signup')).toBe(true);
+    expect(screen.queryByRole('link', { name: 'Go to app' })).not.toBeInTheDocument();
+  });
+
+  it('bootstraps the session check when the auth status is idle', () => {
+    mockAuthState = { status: 'idle', user: null, role: null };
+    render(<SiteNav />);
+    expect(mockCheckSession).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/AppointmentWorkspace.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/AppointmentWorkspace.test.tsx
@@ -2069,6 +2069,46 @@ describe('AppointmentWorkspace container', () => {
     ).toBe(false);
   });
 
+  it('lands on SOAP (never Summary) when the appointment has not started, even past the lock window', async () => {
+    // An IN_PROGRESS appointment past its lock window lands on read-only Summary
+    // (see the lock-window test). A not-yet-started (Upcoming) one must instead
+    // open on SOAP so staff never skip clinical documentation.
+    render(
+      <AppointmentWorkspace
+        appointment={
+          {
+            ...makeAppointment(new Date('2026-04-20T09:00:00Z')),
+            status: 'UPCOMING',
+          } as Appointment
+        }
+      />
+    );
+
+    await waitFor(() => expect(useAppointmentWorkspaceStore.getState().activeStep).toBe('SOAP'));
+  });
+
+  it('does not auto-prefill SOAP from a resolved template before the visit has started', async () => {
+    (resolveSoapTemplate as jest.Mock).mockResolvedValue({
+      id: 'tmpl-upcoming',
+      content: { subjective: '<p>Prefilled subjective</p>' },
+    });
+    render(
+      <AppointmentWorkspace
+        appointment={{ ...makeAppointment(new Date()), status: 'UPCOMING' } as Appointment}
+      />
+    );
+
+    expect(await screen.findByText('SOAP read only: false')).toBeInTheDocument();
+    // The resolver still runs during hydration, but the template is NOT applied
+    // to the draft while the appointment is Upcoming.
+    await waitFor(() => expect(resolveSoapTemplate).toHaveBeenCalled());
+    expect(
+      (useAppointmentWorkspaceStore.getState().getEncounter('appt-workspace')?.soap ?? []).some(
+        (note) => note.templateId === 'tmpl-upcoming'
+      )
+    ).toBe(false);
+  });
+
   it('checks the appointment in to create an encounter when none exists', async () => {
     mockStepParam = 'TREATMENT';
     render(<AppointmentWorkspace appointment={makeAppointment(new Date())} />);

--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/SoapStep.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/SoapStep.test.tsx
@@ -5,7 +5,10 @@ import { axe, toHaveNoViolations } from 'jest-axe';
 import SoapStep from '@/app/features/appointments/pages/AppointmentWorkspace/steps/SoapStep';
 import { useAppointmentWorkspaceStore } from '@/app/stores/appointmentWorkspaceStore';
 import { saveSoapNote } from '@/app/features/appointments/services/workspaceClinicalService';
-import { getWorkspaceTemplateById } from '@/app/features/appointments/services/workspaceTemplateService';
+import {
+  getWorkspaceTemplateById,
+  resolveSoapTemplate,
+} from '@/app/features/appointments/services/workspaceTemplateService';
 
 expect.extend(toHaveNoViolations);
 
@@ -65,9 +68,11 @@ describe('SoapStep', () => {
     (saveSoapNote as jest.Mock).mockResolvedValue({ id: 'soap-saved' });
     (getWorkspaceTemplateById as jest.Mock).mockReset();
     (getWorkspaceTemplateById as jest.Mock).mockResolvedValue(undefined);
+    (resolveSoapTemplate as jest.Mock).mockReset();
+    (resolveSoapTemplate as jest.Mock).mockResolvedValue(null);
   });
 
-  const renderSoapStep = (encounter = seedAndGet()) =>
+  const renderSoapStep = (encounter = seedAndGet(), visitStarted = true) =>
     render(
       <SoapStep
         appointmentId={APPT}
@@ -76,6 +81,7 @@ describe('SoapStep', () => {
         appointmentService={APPOINTMENT_SERVICE}
         appointmentSpeciality={APPOINTMENT_SPECIALITY}
         encounter={encounter}
+        visitStarted={visitStarted}
         onRecordVitals={onRecordVitals}
         onSaveAndNext={onSaveAndNext}
       />
@@ -204,6 +210,47 @@ describe('SoapStep', () => {
     expect(soap?.templateId).toBeUndefined();
   });
 
+  it('auto-prefills the service/package SOAP template once the visit has started', async () => {
+    (resolveSoapTemplate as jest.Mock).mockResolvedValueOnce({
+      id: 'tpl-auto',
+      name: 'Auto SOAP',
+      content: { subjective: '<p>auto subjective</p>' },
+    });
+    const encounter = seedAndGet();
+    renderSoapStep(encounter, true);
+    await waitFor(() => {
+      expect(resolveSoapTemplate).toHaveBeenCalled();
+      const draft = useAppointmentWorkspaceStore
+        .getState()
+        .getEncounter(APPT)
+        ?.soap.find((entry) => entry.status !== 'COMPLETED');
+      expect(draft?.subjective).toBe('<p>auto subjective</p>');
+    });
+  });
+
+  it('does NOT auto-prefill the SOAP template before the visit has started', async () => {
+    (resolveSoapTemplate as jest.Mock).mockResolvedValue({
+      id: 'tpl-auto',
+      name: 'Auto SOAP',
+      content: { subjective: '<p>auto subjective</p>' },
+    });
+    const encounter = seedAndGet();
+    renderSoapStep(encounter, false);
+    // The auto-resolve is gated off, so the resolver never runs and the draft
+    // stays empty.
+    await waitFor(() => {
+      expect(
+        useAppointmentWorkspaceStore.getState().getEncounter(APPT)?.soapTemplates.length
+      ).toBeGreaterThan(0);
+    });
+    expect(resolveSoapTemplate).not.toHaveBeenCalled();
+    const draft = useAppointmentWorkspaceStore
+      .getState()
+      .getEncounter(APPT)
+      ?.soap.find((entry) => entry.status !== 'COMPLETED');
+    expect(draft?.subjective ?? '').not.toContain('auto subjective');
+  });
+
   it('shows the autosave indicator after a save', () => {
     seedAndGet();
     useAppointmentWorkspaceStore.getState().upsertSoap(APPT, { subjective: '<p>history</p>' });
@@ -213,6 +260,7 @@ describe('SoapStep', () => {
         appointmentId={APPT}
         appointmentReason={APPOINTMENT_REASON}
         encounter={enc}
+        visitStarted
         onRecordVitals={onRecordVitals}
         onSaveAndNext={onSaveAndNext}
       />
@@ -233,6 +281,7 @@ describe('SoapStep', () => {
         appointmentId={APPT}
         appointmentReason={APPOINTMENT_REASON}
         encounter={enc}
+        visitStarted
         onRecordVitals={onRecordVitals}
         onSaveAndNext={onSaveAndNext}
       />
@@ -247,6 +296,7 @@ describe('SoapStep', () => {
         appointmentId={APPT}
         appointmentReason={APPOINTMENT_REASON}
         encounter={updated}
+        visitStarted
         onRecordVitals={onRecordVitals}
         onSaveAndNext={onSaveAndNext}
       />
@@ -271,6 +321,7 @@ describe('SoapStep', () => {
         encounter={enc}
         authorId="current-user"
         authorName="Dr Current User"
+        visitStarted
         onRecordVitals={onRecordVitals}
         onSaveAndNext={onSaveAndNext}
       />
@@ -288,6 +339,7 @@ describe('SoapStep', () => {
         encounter={updated}
         authorId="current-user"
         authorName="Dr Current User"
+        visitStarted
         onRecordVitals={onRecordVitals}
         onSaveAndNext={onSaveAndNext}
       />
@@ -388,6 +440,7 @@ describe('SoapStep', () => {
         organisationId="org-1"
         appointmentReason={APPOINTMENT_REASON}
         encounter={enc}
+        visitStarted
         onRecordVitals={onRecordVitals}
         onSaveAndNext={onSaveAndNext}
       />
@@ -426,6 +479,7 @@ describe('SoapStep', () => {
         organisationId="org-1"
         appointmentReason={APPOINTMENT_REASON}
         encounter={enc}
+        visitStarted
         onRecordVitals={onRecordVitals}
         onSaveAndNext={onSaveAndNext}
       />

--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/StaffField.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/StaffField.test.tsx
@@ -17,4 +17,12 @@ describe('StaffField', () => {
     // No avatar image/initials are rendered when there is no name.
     expect(screen.queryByRole('img')).not.toBeInTheDocument();
   });
+
+  it('fills the field surface with the theme field background so it does not wash out', () => {
+    render(<StaffField label="Assigned Lead" name="Dr. Tim Apple" />);
+    // The shell is the label span's parent box; it carries the filled surface.
+    const shell = screen.getByText('Assigned Lead').parentElement as HTMLElement;
+    expect(shell).toHaveStyle({ background: 'var(--field-bg)' });
+    expect(shell).toHaveStyle({ borderColor: 'var(--hairline)' });
+  });
 });

--- a/apps/frontend/src/app/__tests__/pages/Appointments/Sections/AppointmentInfo/AppointmentMerckSearch.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Appointments/Sections/AppointmentInfo/AppointmentMerckSearch.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import AppointmentMerckSearch from '@/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/AppointmentMerckSearch';
@@ -336,6 +336,35 @@ describe('AppointmentMerckSearch', () => {
     await waitFor(() =>
       expect(screen.queryByTestId('appointment-merck-reader-loader')).not.toBeInTheDocument()
     );
+  });
+
+  it('falls back to the new-tab prompt when the reader never fires load', async () => {
+    render(<AppointmentMerckSearch activeAppointment={null} />);
+    fireEvent.change(screen.getByLabelText('Search manuals'), { target: { value: 'fever' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+    await screen.findByText('Canine Fever');
+
+    jest.useFakeTimers();
+    try {
+      fireEvent.click(screen.getByRole('button', { name: 'Open' }));
+      expect(screen.getByTestId('appointment-merck-reader-loader')).toBeInTheDocument();
+
+      act(() => {
+        jest.advanceTimersByTime(12000);
+      });
+
+      expect(screen.getByText(/can.t open inside the app/)).toBeInTheDocument();
+      expect(screen.queryByTestId('appointment-merck-reader-loader')).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getAllByRole('button', { name: 'Open in new tab' }).at(-1)!);
+      expect(globalThis.open).toHaveBeenCalledWith(
+        'https://www.merckvetmanual.com/topic',
+        '_blank',
+        'noopener,noreferrer'
+      );
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it('opens the reader from the result title and sub-topic pills', async () => {

--- a/apps/frontend/src/app/__tests__/pages/Forms/Sections/AddForm/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Forms/Sections/AddForm/index.test.tsx
@@ -163,7 +163,14 @@ describe('AddForm single-screen builder', () => {
   it('renders the builder view with palette/canvas Build and the details fold by default', () => {
     render(<AddForm showModal setShowModal={jest.fn()} serviceOptions={serviceOptions} />);
 
-    expect(screen.getByText('Add template')).toBeInTheDocument();
+    const title = screen.getByText('Add template');
+    expect(title).toBeInTheDocument();
+    // Single-line ellipsis keeps the header title/subtitle from fragmenting
+    // word-by-word in the narrow drawer (#1952).
+    expect(title).toHaveClass('truncate');
+    const subtitle = screen.getByText(/Uncategorised/);
+    expect(subtitle).toHaveClass('truncate');
+    expect(title.parentElement).toHaveClass('flex-1', 'min-w-0');
     expect(screen.getByText('Build Step')).toBeInTheDocument();
     // Details is always mounted (hidden) so its validator is registered; it is passed hideNext.
     expect(screen.getByText('Details Step')).toBeInTheDocument();

--- a/apps/frontend/src/app/__tests__/services/roomService.test.ts
+++ b/apps/frontend/src/app/__tests__/services/roomService.test.ts
@@ -215,6 +215,28 @@ describe('Room Service', () => {
       );
     });
 
+    it('carries the draft availability species onto the upserted room for non-unit rooms', async () => {
+      const mockDTO = { resourceType: 'Location' };
+      const mockResponseData = { resourceType: 'Location', id: 'new-2' };
+      const mockFinalRoom = { id: 'room-2', name: 'Puppy Ward', organisationId: 'org-123' };
+
+      mockedToDTO.mockReturnValue(mockDTO);
+      mockedPostData.mockResolvedValue({ data: mockResponseData });
+      mockedFromDTO.mockReturnValue(mockFinalRoom);
+
+      await createRoom({
+        name: 'Puppy Ward',
+        type: 'EXAM_ROOM',
+        availability: { species: ['CANINE', 'FELINE'], totalUnits: 0 },
+      } as OrganisationRoom & { availability: { species: string[]; totalUnits: number } });
+
+      expect(mockRoomStoreUpsertRoom).toHaveBeenCalledWith(
+        expect.objectContaining({
+          availability: expect.objectContaining({ species: ['CANINE', 'FELINE'] }),
+        })
+      );
+    });
+
     it('uses a provided custom room code as-is', async () => {
       const mockDTO = { resourceType: 'Location' };
       const mockResponseData = { resourceType: 'Location', id: 'new-1' };
@@ -354,6 +376,29 @@ describe('Room Service', () => {
         expect.objectContaining({
           ...mockFinalRoom,
           organisationId: 'org-123',
+        })
+      );
+    });
+
+    it('carries the draft availability species onto the upserted room', async () => {
+      const mockDTO = { resourceType: 'Location', id: 'raw-2' };
+      const mockResponseData = { resourceType: 'Location', id: 'raw-2' };
+      const mockFinalRoom = { id: 'room-1', name: 'Updated Room' };
+
+      mockedToDTO.mockReturnValue(mockDTO);
+      mockedPutData.mockResolvedValue({ data: mockResponseData });
+      mockedFromDTO.mockReturnValue(mockFinalRoom);
+
+      await updateRoom({
+        id: 'room-1',
+        name: 'Updated Room',
+        type: 'EXAM_ROOM',
+        availability: { species: ['EQUINE'], totalUnits: 0 },
+      } as OrganisationRoom & { availability: { species: string[]; totalUnits: number } });
+
+      expect(mockRoomStoreUpsertRoom).toHaveBeenCalledWith(
+        expect.objectContaining({
+          availability: expect.objectContaining({ species: ['EQUINE'] }),
         })
       );
     });

--- a/apps/frontend/src/app/__tests__/ui/tables/DispensaryTable.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/tables/DispensaryTable.test.tsx
@@ -187,13 +187,16 @@ describe('DispensaryTable', () => {
     // Both the date and time formatters must run for the rendered timestamps...
     expect(dateSpy).toHaveBeenCalled();
     expect(timeSpy).toHaveBeenCalled();
-    // ...and none of them may pin the output to UTC, or the viewer sees a time
-    // offset from their own clock (the reported bug).
-    for (const [, options] of dateSpy.mock.calls) {
-      expect(options).not.toHaveProperty('timeZone');
-    }
-    for (const [, options] of timeSpy.mock.calls) {
-      expect(options).not.toHaveProperty('timeZone');
+    // ...and must format in the viewer's OWN resolved timezone, never pinned to
+    // UTC, or the viewer sees a time offset from their own clock (the reported
+    // bug). An explicit local zone is fine; a forced 'UTC' is not.
+    const viewerZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    for (const [, options] of [...dateSpy.mock.calls, ...timeSpy.mock.calls]) {
+      const zone = (options as Intl.DateTimeFormatOptions | undefined)?.timeZone;
+      expect(zone).not.toBe('UTC');
+      if (zone !== undefined) {
+        expect(zone).toBe(viewerZone);
+      }
     }
 
     dateSpy.mockRestore();

--- a/apps/frontend/src/app/__tests__/ui/tables/DispensaryTable.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/tables/DispensaryTable.test.tsx
@@ -187,16 +187,15 @@ describe('DispensaryTable', () => {
     // Both the date and time formatters must run for the rendered timestamps...
     expect(dateSpy).toHaveBeenCalled();
     expect(timeSpy).toHaveBeenCalled();
-    // ...and must format in the viewer's OWN resolved timezone, never pinned to
-    // UTC, or the viewer sees a time offset from their own clock (the reported
-    // bug). An explicit local zone is fine; a forced 'UTC' is not.
+    // ...and must format in the viewer's OWN resolved timezone rather than a
+    // hardcoded literal (the #1879 bug pinned every viewer to 'UTC'). When the
+    // runner itself is in UTC (e.g. CI) the resolved zone is legitimately 'UTC';
+    // what matters is that the passed zone equals the viewer's resolved zone,
+    // never a constant. A wrong hardcoded zone would differ on a non-UTC runner.
     const viewerZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
     for (const [, options] of [...dateSpy.mock.calls, ...timeSpy.mock.calls]) {
       const zone = (options as Intl.DateTimeFormatOptions | undefined)?.timeZone;
-      expect(zone).not.toBe('UTC');
-      if (zone !== undefined) {
-        expect(zone).toBe(viewerZone);
-      }
+      expect(zone).toBe(viewerZone);
     }
 
     dateSpy.mockRestore();

--- a/apps/frontend/src/app/__tests__/ui/tables/DispensaryTable.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/tables/DispensaryTable.test.tsx
@@ -177,6 +177,29 @@ describe('DispensaryTable', () => {
     expect(screen.getAllByText('—').length).toBeGreaterThan(0);
   });
 
+  it('formats Requested/Dispensed timestamps in the viewer local timezone (never forced UTC)', () => {
+    const dateSpy = jest.spyOn(Date.prototype, 'toLocaleDateString');
+    const timeSpy = jest.spyOn(Date.prototype, 'toLocaleTimeString');
+    const record = { ...baseRecord, timeDispensed: '2026-06-30T15:29:25.223Z' };
+
+    render(<DispensaryTable filteredList={[record]} />);
+
+    // Both the date and time formatters must run for the rendered timestamps...
+    expect(dateSpy).toHaveBeenCalled();
+    expect(timeSpy).toHaveBeenCalled();
+    // ...and none of them may pin the output to UTC, or the viewer sees a time
+    // offset from their own clock (the reported bug).
+    for (const [, options] of dateSpy.mock.calls) {
+      expect(options).not.toHaveProperty('timeZone');
+    }
+    for (const [, options] of timeSpy.mock.calls) {
+      expect(options).not.toHaveProperty('timeZone');
+    }
+
+    dateSpy.mockRestore();
+    timeSpy.mockRestore();
+  });
+
   it('applies the success color class when timeDispensed is present', () => {
     const record = { ...baseRecord, timeDispensed: '2026-06-30T15:29:25.223Z' };
     const { container } = render(<DispensaryTable filteredList={[record]} />);

--- a/apps/frontend/src/app/__tests__/utils/forms.test.ts
+++ b/apps/frontend/src/app/__tests__/utils/forms.test.ts
@@ -499,6 +499,91 @@ describe('Forms Utils', () => {
       expect(result.species).toEqual(['Canine', 'Feline']);
     });
 
+    it('round-trips the saved visibility from rules into the UI usage', () => {
+      const makeTemplate = (visibility: unknown) => ({
+        id: 'tpl-visibility',
+        organisationId: 'org-1',
+        ownerUserId: null,
+        ownership: 'ORG_TEMPLATE' as const,
+        kind: 'SOAP_NOTE' as const,
+        name: 'Visibility template',
+        description: null,
+        status: 'DRAFT' as const,
+        scope: 'ORGANISATION' as const,
+        rules: { visibility },
+        latestVersion: 1,
+        publishedVersion: null,
+        createdBy: 'user-1',
+        updatedBy: 'user-1',
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-01-02T00:00:00.000Z'),
+        versions: [],
+      });
+
+      // External and Internal & External must survive reload instead of
+      // collapsing back to 'Internal' (#1896).
+      expect(mapTemplateToUI(makeTemplate('External') as any).usage).toBe('External');
+      expect(mapTemplateToUI(makeTemplate('Internal & External') as any).usage).toBe(
+        'Internal & External'
+      );
+      expect(mapTemplateToUI(makeTemplate('Internal_External') as any).usage).toBe(
+        'Internal & External'
+      );
+      expect(mapTemplateToUI(makeTemplate('Internal') as any).usage).toBe('Internal');
+
+      // Missing / blank visibility falls back to Internal.
+      expect(mapTemplateToUI(makeTemplate(undefined) as any).usage).toBe('Internal');
+      expect(mapTemplateToUI(makeTemplate('   ') as any).usage).toBe('Internal');
+    });
+
+    it('round-trips visibility for plan-definition (care pathway) templates', () => {
+      const result = mapTemplateToUI({
+        id: 'tpl-care-visibility',
+        organisationId: 'org-1',
+        ownerUserId: 'user-1',
+        ownership: 'USER_TEMPLATE',
+        kind: 'INPATIENT_SCHEDULE',
+        name: 'Post-op pathway',
+        description: null,
+        status: 'DRAFT',
+        scope: 'INPATIENT',
+        rules: { visibility: 'External' },
+        latestVersion: 1,
+        publishedVersion: null,
+        createdBy: 'user-1',
+        updatedBy: 'user-1',
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-01-02T00:00:00.000Z'),
+        versions: [],
+      } as any);
+
+      expect(result.usage).toBe('External');
+    });
+
+    it('defaults visibility to Internal when rules is null', () => {
+      const result = mapTemplateToUI({
+        id: 'tpl-null-rules',
+        organisationId: 'org-1',
+        ownerUserId: null,
+        ownership: 'ORG_TEMPLATE',
+        kind: 'SOAP_NOTE',
+        name: 'Null rules template',
+        description: null,
+        status: 'DRAFT',
+        scope: 'ORGANISATION',
+        rules: null,
+        latestVersion: 1,
+        publishedVersion: null,
+        createdBy: 'user-1',
+        updatedBy: 'user-1',
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-01-02T00:00:00.000Z'),
+        versions: [],
+      } as any);
+
+      expect(result.usage).toBe('Internal');
+    });
+
     it('normalizes lowercase template species into UI labels', () => {
       const result = mapTemplateToUI({
         id: 'tpl-species-lower',

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/Header.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/Header.tsx
@@ -182,13 +182,13 @@ const StatusFilterDropdown = ({
                     dropdown.setOpen(false);
                   }}
                   className={clsx(
-                    'w-full flex items-center gap-2.5 px-3 py-2.5 text-body-4 text-left transition-colors',
+                    'w-full flex items-center gap-2.5 px-3 py-2 text-[13px] text-left transition-colors',
                     isActive && status.key !== 'all' ? 'font-medium' : 'hover:bg-card-hover'
                   )}
                 >
                   {status.border && (
                     <span
-                      className="inline-block size-3 rounded-full shrink-0"
+                      className="inline-block size-2 rounded-full shrink-0"
                       style={{
                         backgroundColor: status.border,
                         borderWidth: '1px',
@@ -200,7 +200,7 @@ const StatusFilterDropdown = ({
                   <span style={{ color: getDropdownStatusTextColor(status) }}>{status.name}</span>
                   {isActive && (
                     <span
-                      className="ml-auto text-sm font-semibold"
+                      className="ml-auto text-[12px] font-semibold"
                       style={{ color: getDropdownStatusTextColor(status) }}
                     >
                       ✓

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/appointmentContextMenuHelpers.ts
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/appointmentContextMenuHelpers.ts
@@ -29,7 +29,7 @@ export const SUBMENU_ROW_OFFSET = 4;
 
 export const getMenuItemClassName = (destructive = false, active = false) =>
   [
-    'flex w-full items-center justify-between gap-2 rounded-[12px] px-2.5 py-1.5 text-left font-satoshi text-[16px] font-normal leading-5 tracking-[-0.32px] transition-colors',
+    'flex w-full items-center justify-between gap-2 rounded-[12px] px-2.5 py-1.5 text-left font-satoshi text-[13px] font-normal leading-5 tracking-[-0.32px] transition-colors',
     destructive ? 'text-text-error hover:bg-danger-100/72' : 'text-text-primary hover:bg-white/50',
     active ? 'bg-white/58' : 'bg-transparent',
   ].join(' ');

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/WorkspaceMetaBar.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/WorkspaceMetaBar.tsx
@@ -32,9 +32,11 @@ const ReadOnlyMetaField = ({ label, value }: { label: string; value: string }) =
 
 /**
  * Editable Room/Unit dropdown. LabelDropdown's trigger already carries the
- * design's 46px / 1.5px-hairline / 13px-radius box, so the only change needed
- * here is the label: its stacked label is hidden and re-rendered notched into
- * the trigger's top border, matching the sibling read-only meta fields.
+ * design's 46px / 1.5px-hairline / 13px-radius box, so the changes needed here
+ * are the label and the fill: its stacked label is hidden and re-rendered
+ * notched into the trigger's top border, and the trigger is filled with
+ * `--field-bg` (theme-live via var()) so it matches the sibling read-only meta
+ * fields instead of washing out transparently.
  */
 const EditableMetaDropdown = ({
   label,
@@ -47,7 +49,7 @@ const EditableMetaDropdown = ({
   value?: string;
   onSelect: (option: DropdownOption) => void;
 }) => (
-  <div className="relative w-full [&>div>span]:pointer-events-none [&>div>span]:absolute [&>div>span]:-top-[7px] [&>div>span]:left-3 [&>div>span]:z-30 [&>div>span]:mb-0 [&>div>span]:bg-[var(--screen)] [&>div>span]:px-[5px] [&>div>span]:text-[10.5px] [&>div>span]:text-[var(--ink-faint)] [&>div>div>button]:rounded-[14px]! [&>div>div>button]:bg-transparent! [&>div>div>button]:text-[13.5px]! [&>div>div>button]:font-semibold!">
+  <div className="relative w-full [&>div>span]:pointer-events-none [&>div>span]:absolute [&>div>span]:-top-[7px] [&>div>span]:left-3 [&>div>span]:z-30 [&>div>span]:mb-0 [&>div>span]:bg-[var(--screen)] [&>div>span]:px-[5px] [&>div>span]:text-[10.5px] [&>div>span]:text-[var(--ink-faint)] [&>div>div>button]:rounded-[14px]! [&>div>div>button]:bg-[var(--field-bg)]! [&>div>div>button]:text-[13.5px]! [&>div>div>button]:font-semibold!">
     <LabelDropdown
       placeholder={label}
       options={options}

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/StaffField.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/StaffField.tsx
@@ -16,14 +16,16 @@ type MetaFieldShellProps = {
 };
 
 /**
- * Shared meta-bar field chrome: a 46px box with a 1.5px hairline border and the
- * label notched into the top border (the label paints the screen background
- * behind itself so the border reads as interrupted rather than overlapped).
+ * Shared meta-bar field chrome: a 46px box with a filled surface, a 1.5px
+ * hairline border, and the label notched into the top border (the label paints
+ * the screen background behind itself so the border reads as interrupted rather
+ * than overlapped). The surface uses `--field-bg` so the field reads as filled —
+ * matching the design — instead of washing out transparently over the page.
  */
 export const MetaFieldShell = ({ label, children, className = '' }: MetaFieldShellProps) => (
   <div
     className={`relative flex h-[46px] w-full items-center gap-2 rounded-[14px] border-[1.5px] pr-2 pl-3.5 ${className}`}
-    style={{ borderColor: 'var(--hairline)' }}
+    style={{ background: 'var(--field-bg)', borderColor: 'var(--hairline)' }}
   >
     <span
       className="absolute -top-[7px] left-3 truncate px-[5px] text-[10.5px] font-semibold leading-[120%]"

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/index.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/index.tsx
@@ -106,6 +106,18 @@ type RequiredStaffMember = {
 
 const ADMISSIBLE_APPOINTMENT_STATUSES = new Set(['CHECKED_IN', 'IN_PROGRESS']);
 
+/**
+ * Whether the visit has actually begun. Only a checked-in, in-progress, or
+ * completed appointment has started; an Upcoming/Requested one has not. This
+ * gates two workflow decisions: a not-started appointment must land on SOAP
+ * (never Summary/discharge), and its SOAP draft must not be auto-prefilled from
+ * a service/package template before clinical documentation has begun.
+ */
+const hasVisitStarted = (status: Appointment['status']): boolean => {
+  const normalized = normalizeAppointmentStatus(status);
+  return normalized === 'CHECKED_IN' || normalized === 'IN_PROGRESS' || normalized === 'COMPLETED';
+};
+
 /** Companion detail rows condensed into the header's one-line identity summary. */
 const SUMMARY_META_LABELS = new Set(['Breed/Species', 'Sex', 'Age / DOB', 'Weight']);
 
@@ -484,13 +496,15 @@ const useAppointmentWorkspaceContent = ({ appointment }: AppointmentWorkspacePro
           ...(clinicalResult.status === 'fulfilled' ? clinicalResult.value : {}),
           soapTemplates: templatesResult.status === 'fulfilled' ? templatesResult.value : [],
         });
-        // Prefill the active SOAP draft from the resolved template only when there
-        // is no saved/typed SOAP content yet, so we never overwrite a real record.
+        // Prefill the active SOAP draft from the resolved template only once the
+        // visit has started AND there is no saved/typed SOAP content yet — so a
+        // not-yet-started appointment opens with empty SOAP, and we never
+        // overwrite a real record.
         const resolvedSoap =
           resolvedSoapResult.status === 'fulfilled' ? resolvedSoapResult.value : null;
         const liveEncounter = getEncounter(appointmentId);
         const hasSoapContent = hasMeaningfulSoapContent(liveEncounter?.soap ?? []);
-        if (resolvedSoap && !hasSoapContent) {
+        if (resolvedSoap && !hasSoapContent && hasVisitStarted(appointment.status)) {
           applySoapTemplate(appointmentId, resolvedSoap);
         }
       })
@@ -501,6 +515,7 @@ const useAppointmentWorkspaceContent = ({ appointment }: AppointmentWorkspacePro
     appointment.encounterId,
     appointment.organisationId,
     appointment.appointmentType?.id,
+    appointment.status,
     appointmentId,
     actor.id,
     actor.name,
@@ -544,12 +559,20 @@ const useAppointmentWorkspaceContent = ({ appointment }: AppointmentWorkspacePro
   useEffect(() => {
     if (!encounter || landedForRef.current === encounter.appointmentId) return;
     landedForRef.current = encounter.appointmentId;
+    // A not-yet-started (Upcoming/Requested) appointment always opens on SOAP —
+    // never on Summary/discharge — regardless of any derived encounter progress,
+    // a past lock window, or stale route/tab state. Progress-driven landing (and
+    // an explicit ?step=) only applies once the visit has actually begun.
+    if (!hasVisitStarted(appointment.status)) {
+      setActiveStep('SOAP');
+      return;
+    }
     const landingEncounter = {
       ...encounter,
       viewOnly: encounter.viewOnly || encounter.readyForDischarge.value || lockedByWindow,
     };
     setActiveStep(isValidStep(stepParam) ? stepParam : resolveLandingStep(landingEncounter));
-  }, [encounter, lockedByWindow, stepParam, setActiveStep]);
+  }, [encounter, lockedByWindow, stepParam, setActiveStep, appointment.status]);
 
   const companionDetails = useMemo(
     () =>
@@ -1462,6 +1485,7 @@ const useAppointmentWorkspaceContent = ({ appointment }: AppointmentWorkspacePro
           appointmentService={appointment.appointmentType?.name}
           appointmentSpeciality={appointment.appointmentType?.speciality?.name}
           encounter={effectiveEncounter}
+          visitStarted={hasVisitStarted(appointment.status)}
           onRecordVitals={() => setActiveSideAction('RECORD')}
           onSaveAndNext={handleSaveAndNext}
         />

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/SoapStep.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/SoapStep.tsx
@@ -41,10 +41,13 @@ import NativeSoapFields from './NativeSoapFields';
  * Auto-load the SOAP template linked to the encounter's service/package when the active draft
  * is still empty, so the clinician lands on the preloaded content. Runs once per encounter and
  * never overwrites typed content; the search box below still lets them override the default.
+ * Gated on `visitStarted` so a not-yet-started (Upcoming) appointment opens with empty SOAP —
+ * the template only prefills once clinical documentation has begun.
  */
 const useAutoResolvedSoapTemplate = ({
   organisationId,
   readOnly,
+  visitStarted,
   note,
   appointmentId,
   encounterId,
@@ -54,6 +57,7 @@ const useAutoResolvedSoapTemplate = ({
 }: {
   organisationId?: string;
   readOnly: boolean;
+  visitStarted: boolean;
   note: SoapNoteEntry;
   appointmentId: string;
   encounterId?: string;
@@ -63,7 +67,7 @@ const useAutoResolvedSoapTemplate = ({
 }) => {
   const autoResolvedSoapRef = useRef(false);
   useEffect(() => {
-    if (!organisationId || readOnly || autoResolvedSoapRef.current) return;
+    if (!organisationId || readOnly || !visitStarted || autoResolvedSoapRef.current) return;
     if (note.templateId || hasNativeSoapContent(note) || isCustomSoap(note)) return;
     autoResolvedSoapRef.current = true;
     let cancelled = false;
@@ -94,6 +98,7 @@ const useAutoResolvedSoapTemplate = ({
     note,
     organisationId,
     readOnly,
+    visitStarted,
   ]);
 };
 
@@ -169,6 +174,11 @@ type SoapStepProps = {
   appointmentService?: string;
   appointmentSpeciality?: string;
   encounter: AppointmentEncounter;
+  /**
+   * Whether the visit has started (checked in / in progress / completed). Gates the
+   * service/package SOAP auto-prefill so a not-yet-started appointment stays empty.
+   */
+  visitStarted: boolean;
   onRecordVitals: () => void;
   onSaveAndNext: () => void;
 };
@@ -189,6 +199,7 @@ const SoapStep = ({
   appointmentService,
   appointmentSpeciality,
   encounter,
+  visitStarted,
   onRecordVitals,
   onSaveAndNext,
 }: SoapStepProps) => {
@@ -221,6 +232,7 @@ const SoapStep = ({
   useAutoResolvedSoapTemplate({
     organisationId,
     readOnly,
+    visitStarted,
     note,
     appointmentId,
     encounterId,

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/AppointmentMerckSearch.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/AppointmentMerckSearch.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import FormInput from '@/app/ui/inputs/FormInput/FormInput';
 import { Primary } from '@/app/ui/primitives/Buttons';
@@ -33,6 +33,9 @@ import {
 type AppointmentMerckSearchProps = {
   activeAppointment: Appointment | null;
 };
+
+// A framing-refused MSD page never fires onLoad; cap the spinner and fall back.
+const MERCK_READER_TIMEOUT_MS = 12000;
 
 const getSafeMerckEntries = (entries: MerckEntry[]) =>
   entries.filter(
@@ -254,14 +257,18 @@ const MerckReaderOverlay = ({
   url,
   title,
   loading,
+  blocked,
   onClose,
   onLoad,
+  onError,
 }: {
   url: string;
   title: string;
   loading: boolean;
+  blocked: boolean;
   onClose: () => void;
   onLoad: () => void;
+  onError: () => void;
 }) => (
   <div
     data-signing-overlay="true"
@@ -289,7 +296,31 @@ const MerckReaderOverlay = ({
         </button>
       </div>
       <div className="relative flex-1">
-        {loading ? (
+        {blocked ? (
+          // MSD forbids third-party framing (X-Frame-Options / frame-ancestors),
+          // so the embed can never load. Rather than spin forever, offer the
+          // working new-tab path.
+          <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 bg-[var(--screen)] px-6 text-center">
+            <span className="flex size-11 items-center justify-center rounded-full bg-blue-soft text-blue-text">
+              <IoOpenOutline size={20} aria-hidden="true" />
+            </span>
+            <span className="text-[13.5px] font-bold text-[var(--ink)]">
+              This manual can’t open inside the app
+            </span>
+            <span className="max-w-[340px] text-[12px] text-[var(--ink-faint)]">
+              MSD does not allow its manuals to be embedded. Open it in a new tab instead.
+            </span>
+            <button
+              type="button"
+              onClick={() => globalThis.window.open(url, '_blank', 'noopener,noreferrer')}
+              className="mt-1 inline-flex items-center gap-2 rounded-full! border border-hairline px-4 py-2 text-[12.5px] font-semibold text-[var(--ink-body)] transition-colors hover:bg-[var(--card-hover)]"
+            >
+              <IoOpenOutline size={15} aria-hidden="true" />
+              Open in new tab
+            </button>
+          </div>
+        ) : null}
+        {loading && !blocked ? (
           <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 bg-[var(--screen)]">
             <YosemiteLoader
               label="Loading Manual"
@@ -309,6 +340,7 @@ const MerckReaderOverlay = ({
           referrerPolicy="strict-origin"
           sandbox="allow-scripts allow-popups allow-forms"
           onLoad={onLoad}
+          onError={onError}
         />
       </div>
     </div>
@@ -334,6 +366,7 @@ const AppointmentMerckSearch = ({ activeAppointment }: AppointmentMerckSearchPro
   const [readerUrl, setReaderUrl] = useState<string | null>(null);
   const [readerTitle, setReaderTitle] = useState('Merck Manual');
   const [readerLoading, setReaderLoading] = useState(false);
+  const [readerBlocked, setReaderBlocked] = useState(false);
   const requestRef = useRef(0);
   const resultCacheRef = useRef<Map<string, MerckEntry[]>>(null!);
   resultCacheRef.current ??= new Map();
@@ -399,8 +432,23 @@ const AppointmentMerckSearch = ({ activeAppointment }: AppointmentMerckSearchPro
     setReaderTitle(entry.title);
     setReaderUrl(url);
     setReaderLoading(true);
+    setReaderBlocked(false);
     setReaderOpen(true);
   };
+
+  // MSD refuses third-party framing, so the iframe's onLoad often never fires
+  // (nor does onError, reliably). Cap the spinner and switch to the new-tab
+  // fallback so it can't hang on "Loading Manual" forever.
+  const failReaderLoad = useCallback(() => {
+    setReaderLoading(false);
+    setReaderBlocked(true);
+  }, []);
+
+  useEffect(() => {
+    if (!readerOpen || !readerUrl || !readerLoading) return;
+    const timer = setTimeout(failReaderLoad, MERCK_READER_TIMEOUT_MS);
+    return () => clearTimeout(timer);
+  }, [readerOpen, readerUrl, readerLoading, failReaderLoad]);
 
   const copyUrl = async (url: string) => {
     try {
@@ -543,8 +591,10 @@ const AppointmentMerckSearch = ({ activeAppointment }: AppointmentMerckSearchPro
               url={readerUrl}
               title={readerTitle}
               loading={readerLoading}
+              blocked={readerBlocked}
               onClose={() => setReaderOpen(false)}
               onLoad={() => setReaderLoading(false)}
+              onError={failReaderLoad}
             />,
             document.body
           )

--- a/apps/frontend/src/app/features/auth/pages/AuthedRedirectShell.tsx
+++ b/apps/frontend/src/app/features/auth/pages/AuthedRedirectShell.tsx
@@ -16,6 +16,15 @@ export default function AuthedRedirectShell({ children }: Readonly<{ children: R
   const isAuthenticated = status === 'authenticated';
   const [route, setRoute] = useState<string | null>(null);
 
+  // Public route pages don't otherwise bootstrap the SuperTokens session check, so an
+  // already-authenticated visitor would sit at `idle` forever and never get forwarded.
+  // Kick off the check once so `status` resolves and the redirect logic below can run.
+  useEffect(() => {
+    if (status === 'idle') {
+      void useAuthStore.getState().checkSession();
+    }
+  }, [status]);
+
   // The destination depends on client-only session state, so it cannot be resolved on
   // the server. Resolve it in an effect and navigate with `redirect()` during render so
   // the auth screen is never painted for a visitor who is on their way somewhere else.

--- a/apps/frontend/src/app/features/chat/components/ChatCommandPalette.tsx
+++ b/apps/frontend/src/app/features/chat/components/ChatCommandPalette.tsx
@@ -141,7 +141,7 @@ export function ChatCommandPalette({
                     <ChatAvatar name={title} size="sm" />
                     <Text
                       as="span"
-                      variant="body-4-emphasis"
+                      variant="caption-1"
                       className="flex-1 truncate text-neutral-900"
                     >
                       {title}

--- a/apps/frontend/src/app/features/chat/components/ChatMessage.tsx
+++ b/apps/frontend/src/app/features/chat/components/ChatMessage.tsx
@@ -12,7 +12,19 @@
  * the top-level component stays simple to read and test.
  */
 
-import { useState, type MouseEvent, type ReactNode, type SyntheticEvent } from 'react';
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type MouseEvent,
+  type ReactNode,
+  type Ref,
+  type RefObject,
+  type SyntheticEvent,
+} from 'react';
+import { createPortal } from 'react-dom';
 import { useMessageContext, useChannelActionContext, Attachment } from 'stream-chat-react';
 import {
   IoCheckmarkDone,
@@ -93,13 +105,21 @@ function MentionAwareText({ body, mine }: Readonly<{ body: string; mine: boolean
   );
 }
 
+// React 19 passes `ref` as a normal prop, so no forwardRef wrapper is needed.
 function MsgIconButton({
   label,
   onClick,
   children,
-}: Readonly<{ label: string; onClick?: (e: MouseEvent) => void; children: ReactNode }>) {
+  ref,
+}: Readonly<{
+  label: string;
+  onClick?: (e: MouseEvent) => void;
+  children: ReactNode;
+  ref?: Ref<HTMLButtonElement>;
+}>) {
   return (
     <button
+      ref={ref}
       type="button"
       aria-label={label}
       onClick={onClick}
@@ -107,6 +127,96 @@ function MsgIconButton({
     >
       {children}
     </button>
+  );
+}
+
+const POPOVER_MEASURE_STYLE: CSSProperties = {
+  position: 'fixed',
+  top: 0,
+  left: 0,
+  visibility: 'hidden',
+  zIndex: 5000,
+};
+
+/**
+ * Popover anchored to a trigger button and rendered through a portal to
+ * document.body, so Stream's overflow:auto message list never clips it. It opens
+ * below the trigger (matching the design) and flips above only when there is no
+ * room before the viewport bottom — the last-message case that used to crop the
+ * reaction picker. Dismisses on outside click, scroll, resize, or Escape.
+ */
+function AnchoredPopover({
+  anchorRef,
+  open,
+  onClose,
+  align,
+  className,
+  children,
+}: Readonly<{
+  anchorRef: RefObject<HTMLButtonElement | null>;
+  open: boolean;
+  onClose: () => void;
+  align: 'left' | 'right';
+  className: string;
+  children: ReactNode;
+}>) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const [style, setStyle] = useState<CSSProperties | null>(null);
+
+  useLayoutEffect(() => {
+    if (!open) {
+      setStyle(null);
+      return;
+    }
+    const anchor = anchorRef.current?.getBoundingClientRect();
+    const panel = panelRef.current;
+    if (!anchor || !panel) return;
+    const panelH = panel.offsetHeight;
+    const panelW = panel.offsetWidth;
+    const vw = globalThis.window.innerWidth;
+    const vh = globalThis.window.innerHeight;
+    const below = anchor.bottom + 6;
+    const flipUp = below + panelH + 8 > vh;
+    const top = flipUp ? Math.max(8, anchor.top - panelH - 6) : below;
+    const rawLeft = align === 'right' ? anchor.right - panelW : anchor.left;
+    const left = Math.min(Math.max(8, rawLeft), Math.max(8, vw - panelW - 8));
+    setStyle({ position: 'fixed', top, left, zIndex: 5000 });
+  }, [open, anchorRef, align]);
+
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  useEffect(() => {
+    if (!open) return;
+    const handlePointer = (event: Event) => {
+      const target = event.target as Node;
+      if (panelRef.current?.contains(target) || anchorRef.current?.contains(target)) return;
+      onCloseRef.current();
+    };
+    const dismiss = () => onCloseRef.current();
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onCloseRef.current();
+    };
+    document.addEventListener('mousedown', handlePointer);
+    globalThis.window.addEventListener('scroll', dismiss, { passive: true, capture: true });
+    globalThis.window.addEventListener('resize', dismiss);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handlePointer);
+      globalThis.window.removeEventListener('scroll', dismiss, {
+        capture: true,
+      } as EventListenerOptions);
+      globalThis.window.removeEventListener('resize', dismiss);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [open, anchorRef]);
+
+  if (!open || typeof document === 'undefined') return null;
+  return createPortal(
+    <div ref={panelRef} style={style ?? POPOVER_MEASURE_STYLE} className={className}>
+      {children}
+    </div>,
+    document.body
   );
 }
 
@@ -137,14 +247,17 @@ function MessageActions({
 }>) {
   const [pickerOpen, setPickerOpen] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
+  const reactBtnRef = useRef<HTMLButtonElement>(null);
+  const moreBtnRef = useRef<HTMLButtonElement>(null);
   const closeAll = () => {
     setPickerOpen(false);
     setMenuOpen(false);
   };
-  const side = mine ? 'right-0' : 'left-0';
+  const align = mine ? 'right' : 'left';
   return (
-    <span className="relative flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+    <span className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
       <MsgIconButton
+        ref={reactBtnRef}
         label="React"
         onClick={() => {
           closeAll();
@@ -158,6 +271,7 @@ function MessageActions({
       </MsgIconButton>
       {mine && (
         <MsgIconButton
+          ref={moreBtnRef}
           label="More"
           onClick={() => {
             closeAll();
@@ -167,79 +281,61 @@ function MessageActions({
           <IoEllipsisVertical className="h-4 w-4" />
         </MsgIconButton>
       )}
-      {pickerOpen && (
-        <>
+      <AnchoredPopover
+        anchorRef={reactBtnRef}
+        open={pickerOpen}
+        onClose={() => setPickerOpen(false)}
+        align={align}
+        className="flex items-center gap-0.5 rounded-full border border-[var(--hairline)] bg-[var(--screen)] p-1 shadow-[0_6px_16px_var(--sh10),0_20px_48px_var(--sh12)]"
+      >
+        {REACTION_EMOJIS.map((emoji) => (
           <button
+            key={emoji}
             type="button"
-            aria-label="Close"
-            className="fixed inset-0 z-10 cursor-default"
-            onClick={() => setPickerOpen(false)}
-          />
-          <div
-            className={clsx(
-              'absolute top-9 z-20 flex items-center gap-0.5 rounded-full border border-[var(--hairline)] bg-[var(--screen)] p-1 shadow-[0_6px_16px_var(--sh10),0_20px_48px_var(--sh12)]',
-              side
-            )}
+            onClick={(ev) => {
+              onReact(emoji, ev);
+              setPickerOpen(false);
+            }}
+            className="flex size-8 items-center justify-center rounded-full text-lg leading-none hover:bg-[var(--inset)]"
           >
-            {REACTION_EMOJIS.map((emoji) => (
-              <button
-                key={emoji}
-                type="button"
-                onClick={(ev) => {
-                  onReact(emoji, ev);
-                  setPickerOpen(false);
-                }}
-                className="flex size-8 items-center justify-center rounded-full text-lg hover:bg-[var(--inset)]"
-              >
-                {emoji}
-              </button>
-            ))}
-          </div>
-        </>
-      )}
-      {menuOpen && (
-        <>
-          <button
-            type="button"
-            aria-label="Close"
-            className="fixed inset-0 z-10 cursor-default"
-            onClick={() => setMenuOpen(false)}
-          />
-          <div
-            className={clsx(
-              'absolute top-9 z-20 w-36 rounded-2xl border border-[var(--hairline)] bg-[var(--screen)] p-1.5 shadow-[0_6px_16px_var(--sh10),0_24px_56px_var(--sh12)]',
-              side
-            )}
-          >
-            <button
-              type="button"
-              onClick={() => {
-                onEdit();
-                setMenuOpen(false);
-              }}
-              className="flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left hover:bg-[var(--screen-2)]"
-            >
-              <IoCreateOutline className="h-4 w-4 text-[var(--ink-faint)]" />
-              <Text as="span" variant="body-4" className="text-[var(--ink-body)]">
-                Edit
-              </Text>
-            </button>
-            <button
-              type="button"
-              onClick={() => {
-                onDelete();
-                setMenuOpen(false);
-              }}
-              className="flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left hover:bg-[var(--screen-2)]"
-            >
-              <IoTrashOutline className="h-4 w-4 text-[var(--danger-text)]" />
-              <Text as="span" variant="body-4" className="text-[var(--danger-text)]">
-                Delete
-              </Text>
-            </button>
-          </div>
-        </>
-      )}
+            {emoji}
+          </button>
+        ))}
+      </AnchoredPopover>
+      <AnchoredPopover
+        anchorRef={moreBtnRef}
+        open={menuOpen}
+        onClose={() => setMenuOpen(false)}
+        align={align}
+        className="w-36 rounded-2xl border border-[var(--hairline)] bg-[var(--screen)] p-1.5 shadow-[0_6px_16px_var(--sh10),0_24px_56px_var(--sh12)]"
+      >
+        <button
+          type="button"
+          onClick={() => {
+            onEdit();
+            setMenuOpen(false);
+          }}
+          className="flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left hover:bg-[var(--screen-2)]"
+        >
+          <IoCreateOutline className="h-4 w-4 text-[var(--ink-faint)]" />
+          <Text as="span" variant="body-4" className="text-[var(--ink-body)]">
+            Edit
+          </Text>
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            onDelete();
+            setMenuOpen(false);
+          }}
+          className="flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left hover:bg-[var(--screen-2)]"
+        >
+          <IoTrashOutline className="h-4 w-4 text-[var(--danger-text)]" />
+          <Text as="span" variant="body-4" className="text-[var(--danger-text)]">
+            Delete
+          </Text>
+        </button>
+      </AnchoredPopover>
     </span>
   );
 }

--- a/apps/frontend/src/app/features/chat/components/ChatMessage.tsx
+++ b/apps/frontend/src/app/features/chat/components/ChatMessage.tsx
@@ -139,30 +139,18 @@ const POPOVER_MEASURE_STYLE: CSSProperties = {
 };
 
 /**
- * Popover anchored to a trigger button and rendered through a portal to
- * document.body, so Stream's overflow:auto message list never clips it. It opens
- * below the trigger (matching the design) and flips above only when there is no
- * room before the viewport bottom — the last-message case that used to crop the
- * reaction picker. Dismisses on outside click, scroll, resize, or Escape.
+ * Fixed-position style anchored to a trigger: opens below it, flipping above only
+ * when there is no room before the viewport bottom (the last-message case that
+ * used to crop the reaction picker). Null until measured, so the panel first
+ * renders hidden (POPOVER_MEASURE_STYLE) to be measurable.
  */
-function AnchoredPopover({
-  anchorRef,
-  open,
-  onClose,
-  align,
-  className,
-  children,
-}: Readonly<{
-  anchorRef: RefObject<HTMLButtonElement | null>;
-  open: boolean;
-  onClose: () => void;
-  align: 'left' | 'right';
-  className: string;
-  children: ReactNode;
-}>) {
-  const panelRef = useRef<HTMLDivElement>(null);
+function useAnchoredPopoverStyle(
+  anchorRef: RefObject<HTMLButtonElement | null>,
+  panelRef: RefObject<HTMLDivElement | null>,
+  open: boolean,
+  align: 'left' | 'right'
+): CSSProperties | null {
   const [style, setStyle] = useState<CSSProperties | null>(null);
-
   useLayoutEffect(() => {
     if (!open) {
       setStyle(null);
@@ -171,8 +159,7 @@ function AnchoredPopover({
     const anchor = anchorRef.current?.getBoundingClientRect();
     const panel = panelRef.current;
     if (!anchor || !panel) return;
-    const panelH = panel.offsetHeight;
-    const panelW = panel.offsetWidth;
+    const { offsetHeight: panelH, offsetWidth: panelW } = panel;
     const vw = globalThis.window.innerWidth;
     const vh = globalThis.window.innerHeight;
     const below = anchor.bottom + 6;
@@ -181,11 +168,19 @@ function AnchoredPopover({
     const rawLeft = align === 'right' ? anchor.right - panelW : anchor.left;
     const left = Math.min(Math.max(8, rawLeft), Math.max(8, vw - panelW - 8));
     setStyle({ position: 'fixed', top, left, zIndex: 5000 });
-  }, [open, anchorRef, align]);
+  }, [open, anchorRef, panelRef, align]);
+  return style;
+}
 
+/** Closes the popover on an outside pointer-down, scroll, resize, or Escape. */
+function usePopoverDismiss(
+  open: boolean,
+  onClose: () => void,
+  anchorRef: RefObject<HTMLButtonElement | null>,
+  panelRef: RefObject<HTMLDivElement | null>
+): void {
   const onCloseRef = useRef(onClose);
   onCloseRef.current = onClose;
-
   useEffect(() => {
     if (!open) return;
     const handlePointer = (event: Event) => {
@@ -209,7 +204,32 @@ function AnchoredPopover({
       globalThis.window.removeEventListener('resize', dismiss);
       document.removeEventListener('keydown', handleKey);
     };
-  }, [open, anchorRef]);
+  }, [open, anchorRef, panelRef]);
+}
+
+/**
+ * Popover anchored to a trigger button and rendered through a portal to
+ * document.body, so Stream's overflow:auto message list never clips it.
+ * Positioning and dismissal live in dedicated hooks.
+ */
+function AnchoredPopover({
+  anchorRef,
+  open,
+  onClose,
+  align,
+  className,
+  children,
+}: Readonly<{
+  anchorRef: RefObject<HTMLButtonElement | null>;
+  open: boolean;
+  onClose: () => void;
+  align: 'left' | 'right';
+  className: string;
+  children: ReactNode;
+}>) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const style = useAnchoredPopoverStyle(anchorRef, panelRef, open, align);
+  usePopoverDismiss(open, onClose, anchorRef, panelRef);
 
   if (!open || typeof document === 'undefined') return null;
   return createPortal(
@@ -318,7 +338,7 @@ function MessageActions({
           className="flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left hover:bg-[var(--screen-2)]"
         >
           <IoCreateOutline className="h-4 w-4 text-[var(--ink-faint)]" />
-          <Text as="span" variant="body-4" className="text-[var(--ink-body)]">
+          <Text as="span" variant="caption-1" className="text-[13px] text-[var(--ink-body)]">
             Edit
           </Text>
         </button>
@@ -331,7 +351,7 @@ function MessageActions({
           className="flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left hover:bg-[var(--screen-2)]"
         >
           <IoTrashOutline className="h-4 w-4 text-[var(--danger-text)]" />
-          <Text as="span" variant="body-4" className="text-[var(--danger-text)]">
+          <Text as="span" variant="caption-1" className="text-[13px] text-[var(--danger-text)]">
             Delete
           </Text>
         </button>

--- a/apps/frontend/src/app/features/chat/components/ConversationRow.tsx
+++ b/apps/frontend/src/app/features/chat/components/ConversationRow.tsx
@@ -71,7 +71,7 @@ function MenuItem({
       )}
     >
       {icon}
-      <Text as="span" variant="body-4" className="text-[var(--ink)]">
+      <Text as="span" variant="caption-1" className="text-[13px] text-[var(--ink)]">
         {label}
       </Text>
     </button>

--- a/apps/frontend/src/app/features/chat/components/MessageSearch.tsx
+++ b/apps/frontend/src/app/features/chat/components/MessageSearch.tsx
@@ -121,10 +121,18 @@ export function MessageSearch() {
                     }}
                     className="flex w-full flex-col gap-0.5 rounded-xl px-3 py-2 text-left hover:bg-chat-surface-soft"
                   >
-                    <Text as="span" variant="body-4-emphasis" className="truncate text-neutral-900">
+                    <Text
+                      as="span"
+                      variant="caption-1"
+                      className="truncate text-[13px] text-neutral-900"
+                    >
                       {message.user?.name || message.user?.id || 'User'}
                     </Text>
-                    <Text as="span" variant="caption-1" className="truncate text-neutral-500">
+                    <Text
+                      as="span"
+                      variant="caption-1"
+                      className="truncate text-[12px] text-neutral-500"
+                    >
                       {message.text || 'Attachment'}
                     </Text>
                   </button>

--- a/apps/frontend/src/app/features/companions/components/AddCompanionCentralModal/InputWithDropdown.tsx
+++ b/apps/frontend/src/app/features/companions/components/AddCompanionCentralModal/InputWithDropdown.tsx
@@ -111,7 +111,7 @@ const InputWithDropdown = ({
         <button
           key={opt.value}
           type="button"
-          className="px-5 py-3 text-left text-body-4 hover:bg-card-hover rounded-2xl! text-text-secondary! hover:text-text-primary! w-full"
+          className="px-5 py-2 text-left text-[13px] hover:bg-card-hover rounded-2xl! text-text-secondary! hover:text-text-primary! w-full"
           onMouseDown={(e) => e.stopPropagation()}
           onClick={() => handleSelect(opt)}
         >

--- a/apps/frontend/src/app/features/companions/pages/Companions/InClinicTodayBand.tsx
+++ b/apps/frontend/src/app/features/companions/pages/Companions/InClinicTodayBand.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { IoArrowForward, IoPawOutline } from 'react-icons/io5';
@@ -20,6 +20,7 @@ import {
 
 type BandCard = {
   key: string;
+  appointmentId?: string;
   name: string;
   subtitle: string;
   time: string;
@@ -43,6 +44,7 @@ const buildBandCards = (
     const status = getInClinicStatusMeta(appointment.status);
     return {
       key: appointment.id ?? `${name}-${index}`,
+      appointmentId: appointment.id,
       name,
       subtitle,
       time: formatTimeLabel(appointment.startTime ?? appointment.appointmentDate),
@@ -84,35 +86,69 @@ const BandMedia = ({ card }: { card: BandCard }) => {
   );
 };
 
-const BandCardView = ({ card }: { card: BandCard }) => (
-  <article className="w-[146px] shrink-0 snap-start overflow-hidden rounded-2xl border border-[var(--hairline)] bg-[var(--screen)] shadow-[0_1px_2px_var(--sh03),0_6px_16px_var(--sh05)] md:w-auto md:rounded-[18px] md:shadow-[0_1px_2px_var(--sh03),0_10px_26px_var(--sh05)]">
-    <div className="relative h-[84px] md:h-[138px]">
-      <BandMedia card={card} />
-      <span className="absolute left-2 top-2 z-[2] rounded-full bg-[rgba(29,28,27,0.55)] px-2 py-[3px] text-[10px] font-bold text-[#f7f3ec] tabular-nums backdrop-blur-[10px] md:left-2.5 md:top-2.5 md:px-2.5 md:py-1 md:text-[11px] md:tracking-[0.04em]">
-        {card.time}
-      </span>
-    </div>
-    <div className="flex items-center justify-between gap-2 px-[11px] pb-2.5 pt-2 md:px-3.5 md:pb-3 md:pt-2.5">
-      <span className="min-w-0">
-        <span className="block truncate font-newsreader text-[15px] tracking-[-0.01em] text-[var(--ink)] md:text-[17px]">
-          {card.name}
+type BandCardViewProps = {
+  card: BandCard;
+  onOpen: (appointmentId: string) => void;
+};
+
+const INTERACTIVE_CARD_CLASSES =
+  ' cursor-pointer transition-[transform,box-shadow] duration-150 hover:-translate-y-0.5 hover:shadow-[0_2px_4px_var(--sh03),0_16px_34px_var(--sh05)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-brand active:translate-y-0 active:shadow-[0_1px_2px_var(--sh03)]';
+
+const BandCardView = ({ card, onOpen }: BandCardViewProps) => {
+  const { appointmentId } = card;
+
+  // Only appointments with an id can be opened; unlinked fallback cards stay
+  // presentational so we never expose a button that navigates nowhere.
+  const interactiveProps = appointmentId
+    ? {
+        role: 'button',
+        tabIndex: 0,
+        onClick: () => onOpen(appointmentId),
+        onKeyDown: (event: React.KeyboardEvent<HTMLElement>) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            onOpen(appointmentId);
+          }
+        },
+        'aria-label': `Open appointment for ${card.name}, ${card.time}, ${card.statusLabel}`,
+      }
+    : null;
+
+  return (
+    <article
+      {...interactiveProps}
+      className={`w-[146px] shrink-0 snap-start overflow-hidden rounded-2xl border border-[var(--hairline)] bg-[var(--screen)] shadow-[0_1px_2px_var(--sh03),0_6px_16px_var(--sh05)] md:w-auto md:rounded-[18px] md:shadow-[0_1px_2px_var(--sh03),0_10px_26px_var(--sh05)]${
+        interactiveProps ? INTERACTIVE_CARD_CLASSES : ''
+      }`}
+    >
+      <div className="relative h-[84px] md:h-[138px]">
+        <BandMedia card={card} />
+        <span className="absolute left-2 top-2 z-[2] rounded-full bg-[rgba(29,28,27,0.55)] px-2 py-[3px] text-[10px] font-bold text-[#f7f3ec] tabular-nums backdrop-blur-[10px] md:left-2.5 md:top-2.5 md:px-2.5 md:py-1 md:text-[11px] md:tracking-[0.04em]">
+          {card.time}
         </span>
-        {card.subtitle ? (
-          <span className="block truncate text-[11.5px] text-[var(--ink-faint)]">
-            {card.subtitle}
+      </div>
+      <div className="flex items-center justify-between gap-2 px-[11px] pb-2.5 pt-2 md:px-3.5 md:pb-3 md:pt-2.5">
+        <span className="min-w-0">
+          <span className="block truncate font-newsreader text-[15px] tracking-[-0.01em] text-[var(--ink)] md:text-[17px]">
+            {card.name}
           </span>
-        ) : null}
-      </span>
-      <span
-        className="inline-flex shrink-0 items-center gap-[5px] text-[8.5px] font-bold uppercase tracking-[0.08em] md:gap-1.5 md:text-[9.5px] md:tracking-[0.09em]"
-        style={{ color: card.statusColor }}
-      >
-        <span className="size-[5px] rounded-full bg-current md:size-1.5" aria-hidden="true" />
-        {card.statusLabel}
-      </span>
-    </div>
-  </article>
-);
+          {card.subtitle ? (
+            <span className="block truncate text-[11.5px] text-[var(--ink-faint)]">
+              {card.subtitle}
+            </span>
+          ) : null}
+        </span>
+        <span
+          className="inline-flex shrink-0 items-center gap-[5px] text-[8.5px] font-bold uppercase tracking-[0.08em] md:gap-1.5 md:text-[9.5px] md:tracking-[0.09em]"
+          style={{ color: card.statusColor }}
+        >
+          <span className="size-[5px] rounded-full bg-current md:size-1.5" aria-hidden="true" />
+          {card.statusLabel}
+        </span>
+      </div>
+    </article>
+  );
+};
 
 type InClinicTodayBandProps = {
   companions: CompanionParent[];
@@ -125,6 +161,13 @@ const InClinicTodayBand = ({ companions }: InClinicTodayBandProps) => {
   const terminologyText = useCompanionTerminologyText();
   const appointments = useAppointmentsForPrimaryOrg();
   const cards = useMemo(() => buildBandCards(appointments, companions), [appointments, companions]);
+
+  const openAppointment = useCallback(
+    (appointmentId: string) => {
+      router.push(`/appointments?appointmentId=${encodeURIComponent(appointmentId)}&open=details`);
+    },
+    [router]
+  );
 
   if (cards.length === 0) return null;
 
@@ -149,7 +192,7 @@ const InClinicTodayBand = ({ companions }: InClinicTodayBandProps) => {
       </div>
       <div className="flex snap-x gap-2.5 overflow-x-auto scrollbar-hidden md:grid md:grid-cols-4 md:gap-3.5 md:overflow-visible">
         {cards.map((card) => (
-          <BandCardView key={card.key} card={card} />
+          <BandCardView key={card.key} card={card} onOpen={openAppointment} />
         ))}
       </div>
     </section>

--- a/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/Build.tsx
+++ b/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/Build.tsx
@@ -355,7 +355,7 @@ const AddFieldDropdown: React.FC<{
                 onSelect(option.key);
                 setOpen(false);
               }}
-              className={`${i === 0 ? 'border-t-0!' : 'border-t! border-t-grey-light!'} font-satoshi font-medium text-[16px] text-black-text text-left px-3 py-2 w-full`}
+              className={`${i === 0 ? 'border-t-0!' : 'border-t! border-t-grey-light!'} font-satoshi font-medium text-[13px] text-black-text text-left px-3 py-2 w-full`}
             >
               {option.name}
             </button>

--- a/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/index.tsx
+++ b/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/index.tsx
@@ -219,12 +219,12 @@ const AddForm = ({
       <div className="flex h-full flex-col gap-4">
         {/* Header: title + details summary + preview / MSD / save / close actions */}
         <div className="flex items-start justify-between gap-3 border-b border-[var(--hairline)] pb-3">
-          <div className="flex min-w-0 flex-col gap-0.5">
-            <div className="text-[17px] font-bold tracking-[-0.02em] text-[var(--ink)]">
+          <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+            <div className="truncate text-[17px] font-bold tracking-[-0.02em] text-[var(--ink)]">
               {isEditing ? 'Edit template' : 'Add template'}
               {formData.name ? ` · ${formData.name}` : ''}
             </div>
-            <div className="text-caption-2 text-text-secondary">{detailsSummary}</div>
+            <div className="truncate text-[12.5px] text-[var(--ink-muted)]">{detailsSummary}</div>
           </div>
           <div className="flex items-center gap-2">
             <button

--- a/apps/frontend/src/app/features/integrations/pages/MerckManuals/index.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/MerckManuals/index.tsx
@@ -535,25 +535,72 @@ const READER_AUDIENCE_META: Record<MerckAudience, { label: string; className: st
 const READER_FOOTER_NOTICE =
   "Content © MSD Veterinary Manual · displayed under your clinic's integration";
 
+// MSD forbids third-party framing (X-Frame-Options / frame-ancestors); the load
+// then never fires onLoad, so cap the spinner and fall back to opening in a new tab.
+const READER_LOAD_TIMEOUT_MS = 12000;
+
+const MerckReaderFallback = ({
+  readerUrl,
+  readerTitle,
+}: {
+  readerUrl: string;
+  readerTitle: string;
+}) => (
+  <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 bg-[var(--screen)] px-8 text-center">
+    <span className="flex size-14 items-center justify-center rounded-full bg-[var(--inset)] text-[var(--ink-faint)]">
+      <IoBookOutline size={24} aria-hidden="true" />
+    </span>
+    <span className="text-[15px] font-bold text-[var(--ink)]">This manual can’t be shown here</span>
+    <span className="max-w-[380px] text-[12.5px] leading-relaxed text-[var(--ink-muted)]">
+      MSD Veterinary Manual doesn’t allow its pages to be embedded. Open “{readerTitle}” in a new
+      tab to read the full content.
+    </span>
+    <Link
+      href={readerUrl}
+      target="_blank"
+      rel="noreferrer"
+      className="mt-1 flex items-center gap-1.5 rounded-full! border border-hairline bg-[var(--screen)] px-4 py-2 text-[12.5px] font-bold text-[var(--ink-body)] transition-colors hover:bg-[var(--card-hover)]"
+    >
+      <IoOpenOutline size={14} aria-hidden="true" />
+      Open in new tab
+    </Link>
+  </div>
+);
+
 const MerckReaderPortal = ({
   readerOpen,
   readerUrl,
   readerTitle,
   readerLoading,
+  readerBlocked,
   audience,
   onCopyUrl,
   setReaderOpen,
   setReaderLoading,
+  setReaderBlocked,
 }: {
   readerOpen: boolean;
   readerUrl: string | null;
   readerTitle: string;
   readerLoading: boolean;
+  readerBlocked: boolean;
   audience: MerckAudience;
   onCopyUrl: (url: string) => void;
   setReaderOpen: React.Dispatch<React.SetStateAction<boolean>>;
   setReaderLoading: React.Dispatch<React.SetStateAction<boolean>>;
+  setReaderBlocked: React.Dispatch<React.SetStateAction<boolean>>;
 }) => {
+  const onReaderLoadFailed = useCallback(() => {
+    setReaderLoading(false);
+    setReaderBlocked(true);
+  }, [setReaderLoading, setReaderBlocked]);
+
+  useEffect(() => {
+    if (!readerOpen || !readerUrl || !readerLoading) return;
+    const timer = setTimeout(onReaderLoadFailed, READER_LOAD_TIMEOUT_MS);
+    return () => clearTimeout(timer);
+  }, [readerOpen, readerUrl, readerLoading, onReaderLoadFailed]);
+
   if (!readerOpen || !readerUrl || typeof document === 'undefined') return null;
 
   const audienceMeta = READER_AUDIENCE_META[audience];
@@ -610,23 +657,30 @@ const MerckReaderPortal = ({
           </div>
         </div>
         <div className="relative flex-1">
-          {readerLoading ? (
-            <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 bg-[var(--screen)]">
-              <YosemiteLoader label="Loading Manual" size={120} testId="merck-reader-loader" />
-              <span className="max-w-[320px] text-center text-[12px] text-[var(--ink-faint)]">
-                Fetching “{readerTitle}” from MSD…
-              </span>
-            </div>
-          ) : null}
-          <iframe
-            src={readerUrl}
-            title={readerTitle}
-            className="flex-1 size-full border-0"
-            loading="lazy"
-            referrerPolicy="strict-origin"
-            sandbox="allow-scripts allow-popups allow-forms"
-            onLoad={() => setReaderLoading(false)}
-          />
+          {readerBlocked ? (
+            <MerckReaderFallback readerUrl={readerUrl} readerTitle={readerTitle} />
+          ) : (
+            <>
+              {readerLoading ? (
+                <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 bg-[var(--screen)]">
+                  <YosemiteLoader label="Loading Manual" size={120} testId="merck-reader-loader" />
+                  <span className="max-w-[320px] text-center text-[12px] text-[var(--ink-faint)]">
+                    Fetching “{readerTitle}” from MSD…
+                  </span>
+                </div>
+              ) : null}
+              <iframe
+                src={readerUrl}
+                title={readerTitle}
+                className="flex-1 size-full border-0"
+                loading="lazy"
+                referrerPolicy="strict-origin"
+                sandbox="allow-scripts allow-popups allow-forms"
+                onLoad={() => setReaderLoading(false)}
+                onError={onReaderLoadFailed}
+              />
+            </>
+          )}
         </div>
         <div className="border-t border-hairline px-6 py-3">
           <span className="text-[11.5px] text-[var(--ink-faint)]">{READER_FOOTER_NOTICE}</span>
@@ -657,6 +711,7 @@ const MerckManualsPage = ({ embedded = false }: MerckManualsPageProps) => {
   const [readerTitle, setReaderTitle] = useState('Merck Manual');
   const [readerUrl, setReaderUrl] = useState<string | null>(null);
   const [readerLoading, setReaderLoading] = useState(false);
+  const [readerBlocked, setReaderBlocked] = useState(false);
 
   const requestIdRef = useRef(0);
   const resultCacheRef = useRef<Map<string, MerckEntry[]>>(null!);
@@ -723,6 +778,7 @@ const MerckManualsPage = ({ embedded = false }: MerckManualsPageProps) => {
     setReaderTitle(entry.title);
     setReaderUrl(url);
     setReaderLoading(true);
+    setReaderBlocked(false);
     setReaderOpen(true);
   };
 
@@ -845,10 +901,12 @@ const MerckManualsPage = ({ embedded = false }: MerckManualsPageProps) => {
         readerUrl={readerUrl}
         readerTitle={readerTitle}
         readerLoading={readerLoading}
+        readerBlocked={readerBlocked}
         audience={audience}
         onCopyUrl={onCopyUrl}
         setReaderOpen={setReaderOpen}
         setReaderLoading={setReaderLoading}
+        setReaderBlocked={setReaderBlocked}
       />
 
       {entries.length === 0 ? (

--- a/apps/frontend/src/app/features/inventory/pages/Inventory/index.tsx
+++ b/apps/frontend/src/app/features/inventory/pages/Inventory/index.tsx
@@ -453,7 +453,7 @@ export const InventoryFilterBar = ({
                         setSortMode(option.key);
                         setSortOpen(false);
                       }}
-                      className={`w-full flex items-center px-3 py-2.5 text-body-4 text-left transition-colors ${isActive ? 'font-medium text-text-primary' : 'text-text-secondary hover:bg-card-hover'}`}
+                      className={`w-full flex items-center px-3 py-2 text-[13px] text-left transition-colors ${isActive ? 'font-medium text-text-primary' : 'text-text-secondary hover:bg-card-hover'}`}
                     >
                       {option.label}
                       {isActive && <span className="ml-auto font-semibold">✓</span>}

--- a/apps/frontend/src/app/features/marketing/site/SiteNav.tsx
+++ b/apps/frontend/src/app/features/marketing/site/SiteNav.tsx
@@ -11,6 +11,8 @@ import {
 import Image from 'next/image';
 import Link from 'next/link';
 import { IoLogoGithub, IoMenuOutline, IoCloseOutline } from 'react-icons/io5';
+import { useAuthStore, type AuthUser } from '@/app/stores/authStore';
+import { resolveDefaultOpenScreenRoute } from '@/app/lib/defaultOpenScreen';
 import { GITHUB_REPO_URL, MARKETING_LOGO } from './assets';
 import { useGithubStats } from './useGithubStats';
 import { useScrolled } from './motion';
@@ -167,7 +169,11 @@ function NavLinks({ active }: Readonly<Pick<SiteNavProps, 'active'>>) {
   );
 }
 
-function DesktopActions({ starsLabel }: Readonly<{ starsLabel: string }>) {
+function DesktopActions({
+  starsLabel,
+  user,
+  defaultAppRoute,
+}: Readonly<{ starsLabel: string; user: AuthUser | null; defaultAppRoute: string }>) {
   return (
     <div className="yc-nav-cta" style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
       <ThemeToggle style={{ width: 40, height: 40 }} />
@@ -189,9 +195,15 @@ function DesktopActions({ starsLabel }: Readonly<{ starsLabel: string }>) {
           {starsLabel}
         </span>
       </a>
-      <Link href="/signup" style={GET_STARTED_LINK_STYLE}>
-        Get started
-      </Link>
+      {user ? (
+        <Link href={defaultAppRoute} style={GET_STARTED_LINK_STYLE}>
+          Go to app
+        </Link>
+      ) : (
+        <Link href="/signup" style={GET_STARTED_LINK_STYLE}>
+          Get started
+        </Link>
+      )}
     </div>
   );
 }
@@ -223,9 +235,18 @@ interface MobilePanelProps {
   menuOpen: boolean;
   panelRef: RefObject<HTMLDivElement | null>;
   onClose: () => void;
+  user: AuthUser | null;
+  defaultAppRoute: string;
 }
 
-function MobilePanel({ active, menuOpen, panelRef, onClose }: Readonly<MobilePanelProps>) {
+function MobilePanel({
+  active,
+  menuOpen,
+  panelRef,
+  onClose,
+  user,
+  defaultAppRoute,
+}: Readonly<MobilePanelProps>) {
   return (
     <div
       ref={panelRef}
@@ -271,9 +292,15 @@ function MobilePanel({ active, menuOpen, panelRef, onClose }: Readonly<MobilePan
         <IoLogoGithub style={{ fontSize: 16 }} aria-hidden="true" /> Star on GitHub
       </a>
       <div style={{ display: 'flex', gap: 8, margin: '4px 0' }}>
-        <Link href="/signup" onClick={onClose} style={PANEL_GET_STARTED_STYLE}>
-          Get started
-        </Link>
+        {user ? (
+          <Link href={defaultAppRoute} onClick={onClose} style={PANEL_GET_STARTED_STYLE}>
+            Go to app
+          </Link>
+        ) : (
+          <Link href="/signup" onClick={onClose} style={PANEL_GET_STARTED_STYLE}>
+            Get started
+          </Link>
+        )}
         <ThemeToggle />
       </div>
     </div>
@@ -351,18 +378,39 @@ export function SiteNav({ active }: Readonly<SiteNavProps>) {
   const starsLabel = stars ? `★ ${stars}` : '★';
   const closeMenu = useCallback(() => setMenuOpen(false), []);
   const toggleMenu = useCallback(() => setMenuOpen((v) => !v), []);
+  const status = useAuthStore((s) => s.status);
+  const user = useAuthStore((s) => s.user);
+  const role = useAuthStore((s) => s.role);
+  const defaultAppRoute =
+    role === 'developer' ? '/developers/home' : resolveDefaultOpenScreenRoute(role);
 
   useEscapeToClose(menuOpen, closeMenu);
+
+  // Public marketing pages don't otherwise bootstrap the SuperTokens session check, so
+  // an authenticated visitor would keep seeing "Get started". Kick it off once on idle
+  // so `user` resolves and the "Go to app" affordance is shown instead.
+  useEffect(() => {
+    if (status === 'idle') {
+      void useAuthStore.getState().checkSession();
+    }
+  }, [status]);
 
   return (
     <header data-nav="true" style={navHeaderStyle(scrolled)}>
       <div style={NAV_INNER_STYLE}>
         <NavLogo />
         <NavLinks active={active} />
-        <DesktopActions starsLabel={starsLabel} />
+        <DesktopActions starsLabel={starsLabel} user={user} defaultAppRoute={defaultAppRoute} />
         <BurgerButton menuOpen={menuOpen} onToggle={toggleMenu} />
       </div>
-      <MobilePanel active={active} menuOpen={menuOpen} panelRef={panelRef} onClose={closeMenu} />
+      <MobilePanel
+        active={active}
+        menuOpen={menuOpen}
+        panelRef={panelRef}
+        onClose={closeMenu}
+        user={user}
+        defaultAppRoute={defaultAppRoute}
+      />
     </header>
   );
 }

--- a/apps/frontend/src/app/features/marketing/site/SiteNav.tsx
+++ b/apps/frontend/src/app/features/marketing/site/SiteNav.tsx
@@ -11,6 +11,7 @@ import {
 import Image from 'next/image';
 import Link from 'next/link';
 import { IoLogoGithub, IoMenuOutline, IoCloseOutline } from 'react-icons/io5';
+import { useShallow } from 'zustand/react/shallow';
 import { useAuthStore, type AuthUser } from '@/app/stores/authStore';
 import { resolveDefaultOpenScreenRoute } from '@/app/lib/defaultOpenScreen';
 import { GITHUB_REPO_URL, MARKETING_LOGO } from './assets';
@@ -378,9 +379,9 @@ export function SiteNav({ active }: Readonly<SiteNavProps>) {
   const starsLabel = stars ? `★ ${stars}` : '★';
   const closeMenu = useCallback(() => setMenuOpen(false), []);
   const toggleMenu = useCallback(() => setMenuOpen((v) => !v), []);
-  const status = useAuthStore((s) => s.status);
-  const user = useAuthStore((s) => s.user);
-  const role = useAuthStore((s) => s.role);
+  const { status, user, role } = useAuthStore(
+    useShallow((s) => ({ status: s.status, user: s.user, role: s.role }))
+  );
   const defaultAppRoute =
     role === 'developer' ? '/developers/home' : resolveDefaultOpenScreenRoute(role);
 

--- a/apps/frontend/src/app/features/marketing/site/marketing.css
+++ b/apps/frontend/src/app/features/marketing/site/marketing.css
@@ -478,6 +478,31 @@
   background: var(--field-bg);
   box-shadow: 0 0 0 3px var(--glow-b10);
 }
+/* Chrome/WebKit paints autofilled inputs with its own pale-blue background and
+   near-white text, ignoring the warm-bone tokens above. Repaint the field with
+   design tokens: the huge inset box-shadow masks the UA background (the
+   background-color animation trick keeps it from flashing back), and
+   -webkit-text-fill-color / caret-color restore legible --ink-body text. */
+.yc-field:-webkit-autofill,
+.yc-field:-webkit-autofill:hover,
+.yc-field:-webkit-autofill:focus,
+.yc-field:-webkit-autofill:active {
+  -webkit-text-fill-color: var(--ink-body);
+  caret-color: var(--ink-body);
+  -webkit-box-shadow: 0 0 0 100px var(--field-bg) inset;
+  box-shadow: 0 0 0 100px var(--field-bg) inset;
+  border-color: var(--hairline);
+  transition: background-color 100000s ease-in-out 0s;
+}
+.yc-field:-webkit-autofill:focus {
+  border-color: var(--blue);
+  -webkit-box-shadow:
+    0 0 0 100px var(--field-bg) inset,
+    0 0 0 3px var(--glow-b10);
+  box-shadow:
+    0 0 0 100px var(--field-bg) inset,
+    0 0 0 3px var(--glow-b10);
+}
 select.yc-field {
   appearance: none;
   -webkit-appearance: none;

--- a/apps/frontend/src/app/features/marketing/site/motion.tsx
+++ b/apps/frontend/src/app/features/marketing/site/motion.tsx
@@ -19,7 +19,7 @@ const HERO_VIDEO_STYLE: CSSProperties = {
   top: 0,
   left: 0,
   width: '100%',
-  height: '100vh',
+  height: '100%',
   objectFit: 'cover',
   opacity: 0.3,
   filter: 'blur(1px) saturate(200%) brightness(0.8)',
@@ -33,11 +33,11 @@ const HERO_SCRIM_STYLE: CSSProperties = {
   top: 0,
   left: 0,
   right: 0,
-  height: '100vh',
+  height: '100%',
   zIndex: 1,
   pointerEvents: 'none',
   background:
-    'linear-gradient(180deg, rgba(239,232,220,0.66) 0%, rgba(239,232,220,0.54) 40%, rgba(239,232,220,0.22) 64%, rgba(239,232,220,0) 86%)',
+    'linear-gradient(180deg, rgba(239,232,220,0.66) 0%, rgba(239,232,220,0.54) 40%, rgba(239,232,220,0.22) 64%, rgba(239,232,220,0.04) 92%, rgba(239,232,220,0) 100%)',
 };
 
 /** Static base for the scroll-progress bar; width is applied inline from scroll state. */

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/DeleteOrg.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/DeleteOrg.tsx
@@ -19,7 +19,7 @@ const DeleteOrg = () => {
 
   return (
     <PermissionGate allOf={[PERMISSIONS.ORG_DELETE]}>
-      <div className="flex items-center gap-3 rounded-[18px] border border-[var(--danger-border)] px-5! py-[14px]!">
+      <div className="mt-auto flex items-center gap-3 rounded-[18px] border border-[var(--danger-border)] px-5! py-[14px]!">
         <div className="flex-1">
           <div className="text-[13px] font-bold text-[var(--danger-text)]">Delete organization</div>
           <div className="text-[11.5px] text-[var(--ink-faint)]">

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/AddRoomSections.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/AddRoomSections.tsx
@@ -276,7 +276,7 @@ export const EquipmentSection = ({
             onChange={(value) => onChange({ equipment: value })}
             options={equipmentOptions}
           />
-          <div className="flex items-start gap-2">
+          <div className="flex items-end gap-2">
             <FormInput
               intype="text"
               value={customEquipmentName}
@@ -287,7 +287,7 @@ export const EquipmentSection = ({
               type="button"
               aria-label="Add custom equipment"
               onClick={onAddCustomEquipment}
-              className="mt-0 flex size-12 shrink-0 items-center justify-center rounded-2xl bg-text-primary text-white"
+              className="flex size-12 shrink-0 cursor-pointer items-center justify-center rounded-2xl bg-text-primary text-white"
             >
               <FiPlus size={18} aria-hidden="true" />
             </button>

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/RoomInfoSections.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/RoomInfoSections.tsx
@@ -332,7 +332,7 @@ const RoomInfoSections = ({
             onChange={(value) => onFormChange({ equipment: value })}
             options={Array.from(new Set([...RoomEquipmentOptions, ...options.equipment]))}
           />
-          <div className="flex items-start gap-2">
+          <div className="flex items-end gap-2">
             <FormInput
               intype="text"
               value={customEquipmentName}
@@ -343,7 +343,7 @@ const RoomInfoSections = ({
               type="button"
               aria-label="Add custom equipment"
               onClick={onAddCustomEquipment}
-              className="flex size-12 shrink-0 items-center justify-center rounded-2xl bg-text-primary text-white"
+              className="flex size-12 shrink-0 cursor-pointer items-center justify-center rounded-2xl bg-text-primary text-white"
             >
               <FiPlus size={18} aria-hidden="true" />
             </button>

--- a/apps/frontend/src/app/features/organization/pages/Organization/index.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/index.tsx
@@ -90,9 +90,9 @@ export const Organization = () => {
     <div className="yc-page-content flex flex-col gap-[14px]">
       <Profile primaryOrg={primaryorg} />
       {primaryorg.isVerified ? (
-        <div className="grid gap-[14px] xl:grid-cols-[1.5fr_1fr] xl:items-start">
+        <div className="grid gap-[14px] xl:grid-cols-[1.5fr_1fr] xl:items-stretch">
           <Team isVerified={primaryorg.isVerified} />
-          <div className="flex flex-col gap-[14px]">
+          <div className="flex min-h-0 flex-col gap-[14px]">
             <Rooms />
             <Payment />
             <DeleteOrg />

--- a/apps/frontend/src/app/features/organization/pages/Specialities/PackageBreakdownSearch.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Specialities/PackageBreakdownSearch.tsx
@@ -43,10 +43,10 @@ const PackageBreakdownSearch = ({
             key={item.id}
             type="button"
             onClick={() => onSelectItem(item)}
-            className="w-full flex items-center justify-between px-4 py-2.5 text-left hover:bg-card-hover text-body-4 text-text-primary"
+            className="w-full flex items-center justify-between px-4 py-2 text-left hover:bg-card-hover text-[13px] text-text-primary"
           >
             <span>{item.name}</span>
-            <span className="text-caption-1 text-text-secondary">
+            <span className="text-[12px] text-text-secondary">
               {TYPE_LABELS[item.type] ?? item.type} ·{' '}
               {formatMoney(item.unitPrice, item.currency ?? orgCurrency)}
             </span>
@@ -55,7 +55,7 @@ const PackageBreakdownSearch = ({
       </div>
     )}
     {searchQuery.trim() && filteredSearch.length === 0 && !searchLoading && (
-      <div className="absolute top-full left-0 right-0 z-50 mt-1 bg-[var(--screen)] border border-card-border rounded-2xl shadow-lg px-4 py-3 text-body-4 text-text-secondary">
+      <div className="absolute top-full left-0 right-0 z-50 mt-1 bg-[var(--screen)] border border-card-border rounded-2xl shadow-lg px-4 py-3 text-[13px] text-text-secondary">
         No items found.
       </div>
     )}

--- a/apps/frontend/src/app/features/organization/pages/Specialities/SpecialitySearchBar.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Specialities/SpecialitySearchBar.tsx
@@ -69,14 +69,14 @@ const SpecialitySearchBar = ({
               key={result.id}
               type="button"
               onMouseDown={() => onSelectResult(result)}
-              className="w-full flex items-center justify-between gap-3 px-4 py-2.5 text-left hover:bg-card-hover transition-colors"
+              className="w-full flex items-center justify-between gap-3 px-4 py-2 text-left hover:bg-card-hover transition-colors"
             >
-              <span className="text-body-4 text-text-primary truncate">{result.name}</span>
-              <span className="text-caption-1 text-text-secondary shrink-0">{result.meta}</span>
+              <span className="text-[13px] text-text-primary truncate">{result.name}</span>
+              <span className="text-[12px] text-text-secondary shrink-0">{result.meta}</span>
             </button>
           ))
         ) : (
-          <div className="px-4 py-3 text-body-4 text-text-secondary">No results found.</div>
+          <div className="px-4 py-2 text-[13px] text-text-secondary">No results found.</div>
         )}
       </div>
     )}

--- a/apps/frontend/src/app/features/organization/services/roomService.ts
+++ b/apps/frontend/src/app/features/organization/services/roomService.ts
@@ -312,6 +312,18 @@ const syncRoomUnitGroups = async (room: OrganisationRoom, source: RoomMutationPa
   setRoomUnitsForRoom(room.id, syncedUnits);
 };
 
+// Merge the server's canonical room DTO back over the locally-built base and
+// re-attach the client-only availability draft (which the API does not echo).
+const buildNormalizedRoom = (
+  base: OrganisationRoom,
+  dto: OrganisationRoomResponseDTO,
+  availability?: RoomAvailabilityDraft
+): OrganisationRoom & { availability?: RoomAvailabilityDraft } => ({
+  ...base,
+  ...fromOrganisationRoomRequestDTO(dto),
+  availability,
+});
+
 export const createRoom = async (room: RoomMutationPayload) => {
   const { upsertRoom } = useOrganisationRoomStore.getState();
   const { primaryOrgId } = useOrgStore.getState();
@@ -326,11 +338,7 @@ export const createRoom = async (room: RoomMutationPayload) => {
     };
     const fhirRoom = toOrganisationRoomResponseDTO(payload);
     const res = await postData<OrganisationRoomResponseDTO>('/fhir/v1/organisation-room', fhirRoom);
-    const normalRoom: OrganisationRoom & { availability?: RoomAvailabilityDraft } = {
-      ...payload,
-      ...fromOrganisationRoomRequestDTO(res.data),
-      availability: room.availability,
-    };
+    const normalRoom = buildNormalizedRoom(payload, res.data, room.availability);
     upsertRoom(normalRoom);
     await syncRoomUnitGroups(normalRoom, room);
   } catch (err) {
@@ -356,11 +364,7 @@ export const updateRoom = async (payload: RoomMutationPayload) => {
       '/fhir/v1/organisation-room/' + payload.id,
       fhirRoom
     );
-    const normalRoom: OrganisationRoom & { availability?: RoomAvailabilityDraft } = {
-      ...normalizedPayload,
-      ...fromOrganisationRoomRequestDTO(res.data),
-      availability: payload.availability,
-    };
+    const normalRoom = buildNormalizedRoom(normalizedPayload, res.data, payload.availability);
     upsertRoom(normalRoom);
     await syncRoomUnitGroups(normalRoom, payload);
   } catch (err) {

--- a/apps/frontend/src/app/features/organization/services/roomService.ts
+++ b/apps/frontend/src/app/features/organization/services/roomService.ts
@@ -326,9 +326,10 @@ export const createRoom = async (room: RoomMutationPayload) => {
     };
     const fhirRoom = toOrganisationRoomResponseDTO(payload);
     const res = await postData<OrganisationRoomResponseDTO>('/fhir/v1/organisation-room', fhirRoom);
-    const normalRoom = {
+    const normalRoom: OrganisationRoom & { availability?: RoomAvailabilityDraft } = {
       ...payload,
       ...fromOrganisationRoomRequestDTO(res.data),
+      availability: room.availability,
     };
     upsertRoom(normalRoom);
     await syncRoomUnitGroups(normalRoom, room);
@@ -355,9 +356,10 @@ export const updateRoom = async (payload: RoomMutationPayload) => {
       '/fhir/v1/organisation-room/' + payload.id,
       fhirRoom
     );
-    const normalRoom = {
+    const normalRoom: OrganisationRoom & { availability?: RoomAvailabilityDraft } = {
       ...normalizedPayload,
       ...fromOrganisationRoomRequestDTO(res.data),
+      availability: payload.availability,
     };
     upsertRoom(normalRoom);
     await syncRoomUnitGroups(normalRoom, payload);

--- a/apps/frontend/src/app/lib/forms.ts
+++ b/apps/frontend/src/app/lib/forms.ts
@@ -414,6 +414,19 @@ const restoreFieldPlaceholders = (fields: FormField[]): void => {
   });
 };
 
+// buildTemplatePayload persists the chosen visibility as `rules.visibility`
+// (e.g. 'Internal', 'External', 'Internal & External'). Round-trip it back into
+// the form's `visibilityType` on reload instead of hardcoding 'Internal', so the
+// selector rehydrates the saved value. normalizeUsageLabel folds the various
+// stored encodings ('Internal_External' etc.) back to the canonical label.
+const resolveTemplateVisibility = (template: TemplateLike): Form['visibilityType'] => {
+  const persisted = (template.rules as { visibility?: unknown } | null)?.visibility;
+  if (typeof persisted === 'string' && persisted.trim()) {
+    return normalizeUsageLabel(persisted) as Form['visibilityType'];
+  }
+  return 'Internal';
+};
+
 const templateToForm = (template: TemplateLike): Form => {
   const sanitizePrescriptionSchema = (snapshot: TemplateSchemaSnapshot): TemplateSchemaSnapshot => {
     // The backend persists the canonical medications section plus generic
@@ -464,7 +477,7 @@ const templateToForm = (template: TemplateLike): Form => {
       name: input.name,
       category: templateKindToCategory(input.kind),
       description: input.description,
-      visibilityType: 'Internal',
+      visibilityType: resolveTemplateVisibility(template),
       status: template.status === 'ARCHIVED' ? 'archived' : 'draft',
       schema: uiSchema,
       serviceId: templateServicesFromLinks(template),
@@ -492,7 +505,7 @@ const templateToForm = (template: TemplateLike): Form => {
     name: input.name,
     category: templateKindToCategory(input.kind),
     description: input.description,
-    visibilityType: 'Internal',
+    visibilityType: resolveTemplateVisibility(template),
     status: resolveTemplateStatus(template.status, input.schemaSnapshot.sections.length),
     schema: uiSchema,
     serviceId: templateServicesFromLinks(template),

--- a/apps/frontend/src/app/ui/filters/Filters/index.tsx
+++ b/apps/frontend/src/app/ui/filters/Filters/index.tsx
@@ -239,13 +239,13 @@ const Filters = ({
                           setOpen(false);
                         }}
                         className={clsx(
-                          'w-full flex items-center gap-2.5 px-3 py-2.5 text-body-4 text-left transition-colors',
+                          'w-full flex items-center gap-2.5 px-3 py-2 text-[13px] text-left transition-colors',
                           isActive && status.key !== 'all' ? 'font-medium' : 'hover:bg-card-hover'
                         )}
                       >
                         {status.border && (
                           <span
-                            className="inline-block size-3 rounded-full shrink-0"
+                            className="inline-block size-2 rounded-full shrink-0"
                             style={{
                               backgroundColor: status.border,
                               borderWidth: '1px',
@@ -259,7 +259,7 @@ const Filters = ({
                         </span>
                         {isActive && (
                           <span
-                            className="ml-auto text-sm font-semibold"
+                            className="ml-auto text-[12px] font-semibold"
                             style={{ color: getDropdownStatusTextColor(status) }}
                           >
                             ✓

--- a/apps/frontend/src/app/ui/filters/InventoryFilters/index.tsx
+++ b/apps/frontend/src/app/ui/filters/InventoryFilters/index.tsx
@@ -204,7 +204,7 @@ const InventoryFilters = ({
           type="button"
           disabled={loading}
           onClick={() => setDropdownOpen((v) => !v)}
-          className="flex h-12 items-center gap-2 px-3 rounded-2xl! transition-all duration-300 text-body-4 justify-between min-w-30"
+          className="flex h-10 items-center gap-2 px-3 rounded-2xl! transition-all duration-300 text-[13px] justify-between min-w-30"
           style={getStockHealthButtonStyle(selectedStockHealth)}
         >
           <span>
@@ -237,12 +237,12 @@ const InventoryFilters = ({
                       setDropdownOpen(false);
                     }}
                     className={clsx(
-                      'w-full flex items-center gap-2.5 px-3 py-2.5 text-body-4 text-left transition-colors',
+                      'w-full flex items-center gap-2.5 px-3 py-2 text-[13px] text-left transition-colors',
                       isSelected && option.key !== 'ALL' ? 'font-medium' : 'hover:bg-card-hover'
                     )}
                   >
                     <span
-                      className="inline-block size-3 rounded-full shrink-0"
+                      className="inline-block size-2 rounded-full shrink-0"
                       style={{
                         backgroundColor: option.border,
                         borderWidth: '1px',
@@ -253,7 +253,7 @@ const InventoryFilters = ({
                     <span style={{ color: dropdownTextColor }}>{option.name}</span>
                     {isSelected && (
                       <span
-                        className="ml-auto text-sm font-semibold"
+                        className="ml-auto text-[12px] font-semibold"
                         style={{ color: dropdownTextColor }}
                       >
                         ✓

--- a/apps/frontend/src/app/ui/filters/InventoryTurnoverFilters/index.tsx
+++ b/apps/frontend/src/app/ui/filters/InventoryTurnoverFilters/index.tsx
@@ -158,7 +158,7 @@ const InventoryTurnoverFilters = ({
           ref={triggerRef}
           type="button"
           onClick={() => setDropdownOpen((v) => !v)}
-          className="flex h-12 items-center gap-2 px-3 rounded-2xl! transition-all duration-300 text-body-4 justify-between min-w-30"
+          className="flex h-10 items-center gap-2 px-3 rounded-2xl! transition-all duration-300 text-[13px] justify-between min-w-30"
           style={getTurnoverStatusButtonStyle(selectedStatus)}
         >
           <span>{selectedStatus.key === 'ALL' ? 'Status' : selectedStatus.name}</span>
@@ -189,12 +189,12 @@ const InventoryTurnoverFilters = ({
                       setDropdownOpen(false);
                     }}
                     className={clsx(
-                      'w-full flex items-center gap-2.5 px-3 py-2.5 text-body-4 text-left transition-colors',
+                      'w-full flex items-center gap-2.5 px-3 py-2 text-[13px] text-left transition-colors',
                       isSelected && option.key !== 'ALL' ? 'font-medium' : 'hover:bg-card-hover'
                     )}
                   >
                     <span
-                      className="inline-block size-3 rounded-full shrink-0"
+                      className="inline-block size-2 rounded-full shrink-0"
                       style={{
                         backgroundColor: option.border,
                         borderWidth: '1px',
@@ -205,7 +205,7 @@ const InventoryTurnoverFilters = ({
                     <span style={{ color: dropdownTextColor }}>{option.name}</span>
                     {isSelected && (
                       <span
-                        className="ml-auto text-sm font-semibold"
+                        className="ml-auto text-[12px] font-semibold"
                         style={{ color: dropdownTextColor }}
                       >
                         ✓

--- a/apps/frontend/src/app/ui/inputs/GoogleSearchDropDown/GoogleSearchDropDown.tsx
+++ b/apps/frontend/src/app/ui/inputs/GoogleSearchDropDown/GoogleSearchDropDown.tsx
@@ -410,7 +410,7 @@ const GoogleSearchDropDown = ({
         >
           {predictions?.map((pred, index: number) => (
             <button
-              className="flex w-full flex-col items-start gap-1 rounded-2xl! px-[1.25rem] py-[0.75rem] text-left hover:bg-card-hover"
+              className="flex w-full flex-col items-start gap-1 rounded-2xl! px-[1.25rem] py-2 text-left hover:bg-card-hover"
               key={pred.placeId ?? `${pred.kind}-${pred.description}-${index}`}
               type="button"
               onMouseDown={(e) => {
@@ -426,11 +426,11 @@ const GoogleSearchDropDown = ({
                 inputRef.current?.focus();
               }}
             >
-              <span className="w-full text-left text-body-4-emphasis text-text-primary">
+              <span className="w-full text-left text-[13px] font-medium text-text-primary">
                 {getPredictionPrimaryText(pred)}
               </span>
               {getPredictionSecondaryText(pred) ? (
-                <span className="w-full text-left text-caption-1 text-text-secondary">
+                <span className="w-full text-left text-[12px] font-medium text-text-secondary">
                   {getPredictionSecondaryText(pred)}
                 </span>
               ) : null}

--- a/apps/frontend/src/app/ui/inputs/MultiSelectDropdown/index.tsx
+++ b/apps/frontend/src/app/ui/inputs/MultiSelectDropdown/index.tsx
@@ -228,7 +228,7 @@ const MultiSelectPanel = ({
             type="button"
             id={`${listboxId}-option-${option.value}`}
             aria-pressed={isSelected}
-            className={`flex items-center justify-between gap-2 px-5 py-3 text-left text-body-4 hover:bg-card-hover rounded-2xl! text-text-secondary! hover:text-text-primary! w-full ${
+            className={`flex items-center justify-between gap-2 px-5 py-2 text-left text-[13px] hover:bg-card-hover rounded-2xl! text-text-secondary! hover:text-text-primary! w-full ${
               activeOptionId === `${listboxId}-option-${option.value}`
                 ? 'bg-card-hover text-text-primary!'
                 : ''

--- a/apps/frontend/src/app/ui/inputs/SearchDropdown/index.tsx
+++ b/apps/frontend/src/app/ui/inputs/SearchDropdown/index.tsx
@@ -197,7 +197,7 @@ const SearchDropdown = ({
               onClick={() => onSelectOption(option.value)}
               className={
                 optionClassName ??
-                `px-5 py-3 text-body-4 hover:bg-card-hover rounded-2xl! text-text-secondary! hover:text-text-primary! w-full text-start ${
+                `px-5 py-2 text-[13px] hover:bg-card-hover rounded-2xl! text-text-secondary! hover:text-text-primary! w-full text-start ${
                   activeOptionId === `${listboxId}-option-${option.value}`
                     ? 'bg-card-hover text-text-primary!'
                     : ''

--- a/apps/frontend/src/app/ui/layout/Sidebar/Sidebar.css
+++ b/apps/frontend/src/app/ui/layout/Sidebar/Sidebar.css
@@ -37,7 +37,7 @@
   padding: 18px 0 14px;
 }
 
-/* Design rail: 18px gap between the 32px logo and the first icon. */
+/* 18px gap between the brand logo and the first icon on the collapsed rail. */
 .sidebar-collapsed .sidebar-routes {
   margin-top: 18px;
 }
@@ -75,14 +75,14 @@
 }
 
 .logo img {
-  width: 30px;
-  height: 30px;
+  width: 40px;
+  height: 40px;
   object-fit: contain;
 }
 
 .logo-collapsed img {
-  width: 30px;
-  height: 30px;
+  width: 40px;
+  height: 40px;
 }
 
 .sidebar-wordmark-group {

--- a/apps/frontend/src/app/ui/layout/Sidebar/Sidebar.tsx
+++ b/apps/frontend/src/app/ui/layout/Sidebar/Sidebar.tsx
@@ -156,7 +156,7 @@ const Sidebar = () => {
           className={`logo ${isCollapsed ? 'logo-collapsed' : ''}`}
           aria-label="Yosemite Crew dashboard"
         >
-          <Image src="/icon.svg" alt="Yosemite Crew" width={30} height={30} priority />
+          <Image src="/icon.svg" alt="Yosemite Crew" width={40} height={40} priority />
           {/* The mark alone carries the brand here; the link keeps its aria-label
               so the accessible name survives dropping the wordmark. */}
           {!isCollapsed && isDevPortal && (

--- a/apps/frontend/src/app/ui/tables/DispensaryTable.tsx
+++ b/apps/frontend/src/app/ui/tables/DispensaryTable.tsx
@@ -61,6 +61,12 @@ const formatAmount = (cents: number, currency = 'USD') => {
   return `${symbol} ${(cents / 100).toFixed(2)}`;
 };
 
+// Format dispensary timestamps in the viewer's own timezone (they used to be
+// forced to UTC, #1879). Resolving it explicitly documents the intent and keeps
+// the value deterministic; the table's rows are client-fetched, so there is no
+// server-rendered value that could hydrate-mismatch.
+const VIEWER_TIME_ZONE = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
 const formatDateTime = (iso?: string) => {
   if (!iso) return '—';
   const d = new Date(iso);
@@ -69,9 +75,14 @@ const formatDateTime = (iso?: string) => {
       month: 'short',
       day: '2-digit',
       year: 'numeric',
+      timeZone: VIEWER_TIME_ZONE,
     }) +
     '\n' +
-    d.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' })
+    d.toLocaleTimeString('en-US', {
+      hour: '2-digit',
+      minute: '2-digit',
+      timeZone: VIEWER_TIME_ZONE,
+    })
   );
 };
 

--- a/apps/frontend/src/app/ui/tables/DispensaryTable.tsx
+++ b/apps/frontend/src/app/ui/tables/DispensaryTable.tsx
@@ -69,10 +69,9 @@ const formatDateTime = (iso?: string) => {
       month: 'short',
       day: '2-digit',
       year: 'numeric',
-      timeZone: 'UTC',
     }) +
     '\n' +
-    d.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', timeZone: 'UTC' })
+    d.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' })
   );
 };
 

--- a/apps/frontend/src/app/ui/tables/InvoiceTable.tsx
+++ b/apps/frontend/src/app/ui/tables/InvoiceTable.tsx
@@ -153,11 +153,13 @@ const InvoiceTable = ({ filteredList, setActiveInvoice, setViewInvoice }: Invoic
     // The Date column already carries the appointment date, so the desktop
     // sub-line pairs the appointment type with the time only — no duplicated
     // date. On tablet the Date column is dropped, so the date folds back in.
+    const foldedDate =
+      foldMeta && appointment ? formatDateLabel(appointment.appointmentDate) : undefined;
     const appointmentSubtitle = appointment
       ? buildAppointmentSubtitle(
           appointment.appointmentType?.name,
           formatTimeLabel(appointment.startTime ?? appointment.appointmentDate),
-          foldMeta ? formatDateLabel(appointment.appointmentDate) : undefined
+          foldedDate
         )
       : '';
     // Tablet drops the Services and Date columns, so their content folds here.

--- a/apps/frontend/src/app/ui/tables/InvoiceTable.tsx
+++ b/apps/frontend/src/app/ui/tables/InvoiceTable.tsx
@@ -26,8 +26,8 @@ import { getAvatarPalette } from '@/app/features/companions/pages/Companions/com
 
 const buildAppointmentSubtitle = (
   typeName: string | undefined,
-  dateText: string,
-  timeText: string
+  timeText: string,
+  dateText?: string
 ): string => {
   const stamp = [dateText, timeText]
     .map((part) => part?.trim())
@@ -150,11 +150,14 @@ const InvoiceTable = ({ filteredList, setActiveInvoice, setViewInvoice }: Invoic
       getAppointmentCompanionPhotoUrl(companion),
       (companion?.species as ImageType) ?? 'other'
     );
+    // The Date column already carries the appointment date, so the desktop
+    // sub-line pairs the appointment type with the time only — no duplicated
+    // date. On tablet the Date column is dropped, so the date folds back in.
     const appointmentSubtitle = appointment
       ? buildAppointmentSubtitle(
           appointment.appointmentType?.name,
-          formatDateLabel(appointment.appointmentDate),
-          formatTimeLabel(appointment.startTime ?? appointment.appointmentDate)
+          formatTimeLabel(appointment.startTime ?? appointment.appointmentDate),
+          foldMeta ? formatDateLabel(appointment.appointmentDate) : undefined
         )
       : '';
     // Tablet drops the Services and Date columns, so their content folds here.

--- a/apps/frontend/src/app/ui/widgets/DashboardSteps/index.tsx
+++ b/apps/frontend/src/app/ui/widgets/DashboardSteps/index.tsx
@@ -4,7 +4,7 @@ import clsx from 'clsx';
 import { IoCheckmarkCircle } from 'react-icons/io5';
 import { Secondary } from '@/app/ui/primitives/Buttons';
 import { usePrimaryOrg } from '@/app/hooks/useOrgSelectors';
-import { useServicesForPrimaryOrgSpecialities } from '@/app/hooks/useSpecialities';
+import { useSpecialitiesForPrimaryOrg } from '@/app/hooks/useSpecialities';
 import { useTeamForPrimaryOrg } from '@/app/hooks/useTeam';
 import { useSubscriptionForPrimaryOrg } from '@/app/hooks/useBilling';
 import { PermissionGate } from '@/app/ui/layout/guards/PermissionGate';
@@ -24,13 +24,13 @@ type Step = {
 const DashboardSteps = () => {
   const primaryOrg = usePrimaryOrg();
   const subscription = useSubscriptionForPrimaryOrg();
-  const services = useServicesForPrimaryOrgSpecialities();
+  const specialities = useSpecialitiesForPrimaryOrg();
   const teams = useTeamForPrimaryOrg();
   const { can } = usePermissions();
 
   const steps: Step[] = useMemo(() => {
     if (!primaryOrg || !subscription) return [];
-    const hasServices = (services?.length ?? 0) > 0;
+    const hasServices = specialities.some((s) => (s.activeServiceCount ?? 0) > 0);
     const hasTeam = (teams?.length ?? 0) > 1;
     const hasStripeAccount = Boolean(subscription.connectAccountId);
     const stripeCompleted = Boolean(subscription.connectChargesEnabled);
@@ -77,7 +77,7 @@ const DashboardSteps = () => {
       },
     ];
     return nextSteps.filter((step) => step.isVisible);
-  }, [can, primaryOrg, services, teams, subscription]);
+  }, [can, primaryOrg, specialities, teams, subscription]);
 
   const completedCount = useMemo(() => steps.filter((s) => s.isCompleted).length, [steps]);
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

A batch of UI bugs reported by QA against the merged PIMS redesign, plus marketing-site, auth, and chat issues found in review:

- Dispensary times rendered in UTC; the invoice subline duplicated the Date column; room species were not read back after editing; the add-equipment button had a misaligned cursor; the organization panel and delete-org spacing were off.
- Not-started appointments opened on the SOAP Summary and pre-filled SOAP before the visit began.
- Companions in-clinic band cards could not be opened to their appointment.
- The MSD manual reader spun on "Loading Manual" forever when the embed was blocked.
- Form template visibility was hardcoded to Internal on load.
- The dashboard "add services" step never activated.
- Appointment-workspace staff fields ("Assigned lead", "Support staff") washed out on the warm panel.
- Marketing sign-in/sign-up fields showed Chrome's pale-blue autofill background with washed-out text.
- After logging in, revisiting the marketing site or /signin showed the login form again instead of a "Go to app" affordance.
- The in-app sidebar logo was too small (30px).
- The chat reaction emoji picker was cropped by the scrolling message list on the last message.
- On phones the marketing hero background photo hard-cut with a visible seam partway down.

## What is the new behavior?

QA-logged PIMS bugs (commit 1):

- Dispensary times show local time (dropped the hardcoded `timeZone: 'UTC'`).
- Invoice parent/patient subline no longer duplicates the Date column.
- Rooms: species read back after edit; add-equipment button cursor/alignment fixed. (Cross-reload species persistence still needs a backend field.)
- Organization panel alignment and delete-org spacing corrected.
- SOAP: not-started appointments open on SOAP rather than Summary, and prefill is gated until the visit starts.
- Companions in-clinic band cards are keyboard- and click-navigable to the appointment.
- MSD reader gains an `onError` handler and a 12s load timeout, falling back to "Open in new tab" instead of an infinite spinner.
- Form template visibility is read back from `rules.visibility`.
- Dashboard "add services" step derives from active service counts.
- Appointment-workspace staff fields are filled with `--field-bg` so labels no longer wash out.

Marketing / auth / sidebar / chat (commit 2):

- Sign-in/sign-up `:-webkit-autofill` is repainted with the warm `--field-bg` surface and `--ink-body` text (both themes), removing the pale-blue autofill wash.
- `AuthedRedirectShell` and `SiteNav` bootstrap the SuperTokens session check on public pages, so an authenticated visitor is forwarded off /signin and the marketing nav shows "Go to app" instead of "Get started".
- Sidebar brand logo enlarged 30px -> 40px.
- Chat reaction picker and message menu render through a `document.body` portal with collision-aware placement (open below, flip above only against the viewport bottom), so they are never clipped by Stream's scrolling list.
- Mobile hero: the ambient video and scrim cover the full hero section (`height: 100%`) instead of a fixed `100vh`, and the scrim fades fully to transparent, removing the hard photo seam when the hero grows taller than the viewport.

## Validation

- `tsc --noEmit`: 0 errors. ESLint: clean. Full Jest suite: 855 suites / 10,459 tests green.
- Mobile hero verified in-browser: at a viewport shorter than the hero, the video and scrim measure the full hero height (866px) and cover the previously-bare 119px seam.
- /signin verified: field text resolves to `--ink-body` (dark, ruling out a token flip) and the `:-webkit-autofill` rule is live in the CSSOM.
- Chat picker: 46 ChatMessage tests (100% statements/functions/lines).
- react-doctor: these fixes add no new findings (`forwardRef` was modernized to a `ref` prop); the repo-wide 91/100 is the pre-existing dev baseline.

## Related Issue(s)

Fixes #1879
Fixes #1886
Fixes #1896
Fixes #1943
Fixes #1946
Fixes #1948
Fixes #1949
Fixes #1950
Fixes #1951

Partially addresses #1945 (species read back within the session; cross-reload persistence needs a backend field). The autofill wash, forced re-login / "Go to app", sidebar logo size, chat emoji crop, and mobile hero seam were reported directly and have no tracking issue.
