### PR TITLE
ci(repo): stop dependabot PRs failing Sonar and commit-lint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,10 +50,17 @@ jobs:
     # vars.DISABLE_SONAR is a kill switch that works on every trigger, unlike a
     # workflow_dispatch input, which is null on pull_request and would silently
     # skip the stage on exactly the events that matter most.
+    #
+    # Dependabot PRs run with the Dependabot secret store, which does not carry
+    # the SONAR_TOKEN* values, so the scan can only fail with "Not authorized".
+    # Skip Sonar for them (the roll-up below counts a skipped stage as a pass);
+    # the nightly sonar-cloud-analysis run remains the type-aware backstop and
+    # every dependency change is re-scanned there once it lands on dev.
     if: >
       vars.DISABLE_SONAR != 'true' &&
       needs.test.outputs.apps-with-coverage != '' &&
-      needs.test.outputs.apps-with-coverage != '[]'
+      needs.test.outputs.apps-with-coverage != '[]' &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
     # A reusable workflow cannot request more than its caller grants, and
     # startup validation checks this even when the job is skipped, so the Sonar
     # scan's checks:write / pull-requests:write are granted on the call here

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -53,7 +53,13 @@ jobs:
     timeout-minutes: 15
     # Release sync PRs replay already-merged dev history into main. Keep title
     # validation active, but do not re-lint historical commits in that path.
-    if: ${{ !(github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'dev') }}
+    #
+    # Dependabot writes long changelog and release-note lines into its commit
+    # bodies, which trip config-conventional's body/footer-max-line-length and
+    # fail this job on every bot PR. The PR-title gate above still runs, so the
+    # conventional type(scope) contract is enforced on the squash-merge subject;
+    # only the generated body lines are exempt.
+    if: ${{ !(github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'dev') && github.event.pull_request.user.login != 'dependabot[bot]' }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
## What changed

Two structural CI failures hit essentially **every** Dependabot PR and are unrelated to the dependency being bumped. This exempts `dependabot[bot]` from both:

1. **Sonar** (`ci.yaml`): the scan stage needs `SONAR_TOKEN*`, which live only in the **Actions** secret store. Dependabot PRs run against the separate **Dependabot** secret store (empty), so every scan fails `Not authorized or project not found`. The stage is now skipped for `dependabot[bot]`; the `CI Required` roll-up already counts a skipped stage as a pass, and the nightly `sonar-cloud-analysis` run re-scans the change once it lands on dev.
2. **commit-lint** (`pr-governance.yml`): config-conventional's `body-max-line-length`/`footer-max-line-length` are always exceeded by Dependabot's changelog commit bodies. The commit-message job is skipped for `dependabot[bot]`. The **Validate PR title** gate still runs, so the conventional `type(scope)` contract is enforced on the squash-merge subject.

## Why

Without this, every Dependabot PR shows red Sonar + red commit-lint, drowning out real signal and blocking clean one-by-one merges.

## Impact

- Human and Aikido PRs are unaffected (guards key off `pull_request.user.login`).
- `push`/`merge_group` events are unaffected (login is empty there, so Sonar runs).

## Validation

- YAML parses.
- Verified `CI Required` (`ci.yaml`) treats `skipped` as pass.
- Verified `sonar-cloud-analysis.yml` is now schedule-only (no PR trigger), so no duplicate Sonar check remains after rebase.