### PR TITLE
ci(repo): bump github/codeql-action from v3.37.1 to v4.37.1

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -88,7 +88,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@b7351df727350dca84cb9d725d57dcf5bc82ba26 # v3.37.1
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           config-file: ./.github/codeql/codeql-config.yml
           languages: ${{ matrix.language }}
@@ -119,6 +119,6 @@ jobs:
       #     xcodebuild -workspace mobileAppYC.xcworkspace -scheme mobileAppYC -configuration Debug -sdk iphonesimulator clean build
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@b7351df727350dca84cb9d725d57dcf5bc82ba26 # v3.37.1
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           category: '/language:${{matrix.language}}'


### PR DESCRIPTION
## What changed

Bumps `github/codeql-action/init` **and** `github/codeql-action/analyze` from v3.37.1 to v4.37.1 together (SHA `7188fc3`).

## Why

Dependabot split this into two PRs — [#1928](https://github.com/YosemiteCrew/Yosemite-Crew/pull/1928) (init) and [#1931](https://github.com/YosemiteCrew/Yosemite-Crew/pull/1931) (analyze). Merging either alone leaves `init` and `analyze` on different majors, and CodeQL then fails both analyze jobs with:

> Loaded a configuration file for version '4.37.1', but running version '3.37.1'

Both bot PRs' CodeQL checks are currently red for exactly this reason. Bumping both in one commit is the only way this goes green.

## Supersedes

Closes #1928 and #1931.

## Validation

- YAML parses.
- Both refs now point to the same v4.37.1 SHA, so init/analyze majors match.