### PR TITLE
fix(repo): guard clinical-terms and desktop notices file reads against path traversal

### DIFF
--- a/apps/backend/src/services/clinical-terms.service.ts
+++ b/apps/backend/src/services/clinical-terms.service.ts
@@ -239,6 +239,9 @@ export const ClinicalTermsService = {
   },
 
   async importFromFile(filePath: string) {
+    if (filePath.includes("..") || path.isAbsolute(filePath)) {
+      throw new Error("Invalid file path");
+    }
     const absolutePath = path.resolve(filePath);
     const rawText = fs.readFileSync(absolutePath, "utf-8");
     const parsed = this.parseConcepts(JSON.parse(rawText));

--- a/apps/backend/test/services/clinical-terms.service.test.ts
+++ b/apps/backend/test/services/clinical-terms.service.test.ts
@@ -1,6 +1,8 @@
 import { ClinicalTermsService } from "../../src/services/clinical-terms.service";
 import { CodeService } from "src/services/code.service";
 import { prisma } from "src/config/prisma";
+import fs from "node:fs";
+import path from "node:path";
 
 jest.mock("src/services/code.service", () => ({
   CodeService: {
@@ -246,6 +248,112 @@ describe("ClinicalTermsService", () => {
           source: "VeNom",
         },
       ]);
+    });
+  });
+
+  describe("importFromFile - path traversal protection", () => {
+    const testDataDir = path.join(process.cwd(), "test-data-clinical");
+    const validFile = path.join(testDataDir, "concepts.json");
+
+    beforeAll(() => {
+      // Create test directory and file
+      if (!fs.existsSync(testDataDir)) {
+        fs.mkdirSync(testDataDir, { recursive: true });
+      }
+      fs.writeFileSync(
+        validFile,
+        JSON.stringify([
+          {
+            ycCode: "YC-TEST",
+            label: "Test Concept",
+            domain: "Diagnosis",
+            active: true,
+            source: "test",
+            designations: [],
+            codes: [],
+            species: ["SA"],
+          },
+        ])
+      );
+    });
+
+    afterAll(() => {
+      // Clean up test files
+      if (fs.existsSync(validFile)) {
+        fs.unlinkSync(validFile);
+      }
+      if (fs.existsSync(testDataDir)) {
+        fs.rmdirSync(testDataDir);
+      }
+    });
+
+    it("should successfully import from a valid relative file path", async () => {
+      // Update test data to use valid source value
+      fs.writeFileSync(
+        validFile,
+        JSON.stringify([
+          {
+            ycCode: "YC-TEST",
+            label: "Test Concept",
+            domain: "Diagnosis",
+            active: true,
+            source: "VeNom",  // Changed from "test" to valid enum value
+            designations: [],
+            codes: [],
+            species: ["SA"],
+          },
+        ])
+      );
+      
+      const result = await ClinicalTermsService.importFromFile(
+        "test-data-clinical/concepts.json"
+      );
+      expect(CodeService.upsertEntry).toHaveBeenCalled();
+      expect(result).toHaveProperty("entriesUpserted");
+    });
+
+    it("should reject path traversal with double dots", async () => {
+      await expect(
+        ClinicalTermsService.importFromFile("../../../etc/passwd")
+      ).rejects.toThrow("Invalid file path");
+    });
+
+    it("should reject path traversal in middle of path", async () => {
+      await expect(
+        ClinicalTermsService.importFromFile("data/../../../etc/passwd")
+      ).rejects.toThrow("Invalid file path");
+    });
+
+    it("should reject absolute Unix paths", async () => {
+      await expect(
+        ClinicalTermsService.importFromFile("/etc/passwd")
+      ).rejects.toThrow("Invalid file path");
+    });
+
+    it("should reject absolute Windows paths", async () => {
+      const windowsPath = "C:\\Windows\\System32\\config\\sam";
+      if (path.isAbsolute(windowsPath)) {
+        await expect(
+          ClinicalTermsService.importFromFile(windowsPath)
+        ).rejects.toThrow("Invalid file path");
+      } else {
+        // On Unix, this would fail with ENOENT or parsing error, which is acceptable
+        await expect(
+          ClinicalTermsService.importFromFile(windowsPath)
+        ).rejects.toThrow();
+      }
+    });
+
+    it("should reject URL-encoded path traversal", async () => {
+      await expect(
+        ClinicalTermsService.importFromFile("..%2F..%2F..%2Fetc%2Fpasswd")
+      ).rejects.toThrow("Invalid file path");
+    });
+
+    it("should reject backslash path traversal", async () => {
+      await expect(
+        ClinicalTermsService.importFromFile("..\\..\\..\\windows\\system32\\config\\sam")
+      ).rejects.toThrow("Invalid file path");
     });
   });
 });

--- a/apps/desktop/scripts/generate-notices.js
+++ b/apps/desktop/scripts/generate-notices.js
@@ -17,7 +17,20 @@ const licenseFileNames = [
   'NOTICE.md',
 ];
 
-const readJson = (filePath) => JSON.parse(fs.readFileSync(filePath, 'utf8'));
+// Resolve a path and ensure it stays within node_modules (path-traversal guard).
+const resolveWithinNodeModules = (filePath) => {
+  const base = path.resolve(nodeModulesRoot);
+  const target = path.resolve(filePath);
+  const relative = path.relative(base, target);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error('Invalid file path');
+  }
+  return target;
+};
+
+const readJson = (filePath) => {
+  return JSON.parse(fs.readFileSync(resolveWithinNodeModules(filePath), 'utf8'));
+};
 
 const packageDirs = () => {
   if (!fs.existsSync(nodeModulesRoot)) {
@@ -46,7 +59,7 @@ const licenseTextFor = (dir) => {
   for (const name of licenseFileNames) {
     const candidate = path.join(dir, name);
     if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
-      return fs.readFileSync(candidate, 'utf8').trim();
+      return fs.readFileSync(resolveWithinNodeModules(candidate), 'utf8').trim();
     }
   }
   return '';

--- a/apps/desktop/tests/generate-notices.test.js
+++ b/apps/desktop/tests/generate-notices.test.js
@@ -1,0 +1,129 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+// Recreate the readJson and licenseTextFor functions with security checks for testing
+const nodeModulesRoot = path.join(__dirname, '..', 'node_modules');
+
+const readJson = (filePath) => {
+  const base = path.resolve(nodeModulesRoot);
+  const target = path.resolve(filePath);
+  const relative = path.relative(base, target);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error('Invalid file path');
+  }
+  return JSON.parse(fs.readFileSync(target, 'utf8'));
+};
+
+const licenseTextFor = (dir) => {
+  const licenseFileNames = [
+    'LICENSE',
+    'LICENSE.md',
+    'LICENSE.txt',
+    'LICENCE',
+    'LICENCE.md',
+    'NOTICE',
+    'NOTICE.md',
+  ];
+  
+  for (const name of licenseFileNames) {
+    const candidate = path.join(dir, name);
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+      const base = path.resolve(nodeModulesRoot);
+      const target = path.resolve(candidate);
+      const relative = path.relative(base, target);
+      if (relative.startsWith('..') || path.isAbsolute(relative)) {
+        throw new Error('Invalid file path');
+      }
+      return fs.readFileSync(target, 'utf8').trim();
+    }
+  }
+  return '';
+};
+
+describe('generate-notices path traversal protection', () => {
+  const testDataDir = path.join(__dirname, 'test-notices-data');
+  const testNodeModules = path.join(testDataDir, 'node_modules');
+  const testPackageDir = path.join(testNodeModules, 'test-package');
+
+  beforeAll(() => {
+    // Create test directory structure
+    if (!fs.existsSync(testPackageDir)) {
+      fs.mkdirSync(testPackageDir, { recursive: true });
+    }
+    fs.writeFileSync(
+      path.join(testPackageDir, 'package.json'),
+      JSON.stringify({ name: 'test-package', version: '1.0.0', license: 'MIT' })
+    );
+    fs.writeFileSync(
+      path.join(testPackageDir, 'LICENSE'),
+      'MIT License\n\nTest license text'
+    );
+  });
+
+  afterAll(() => {
+    // Clean up test files
+    if (fs.existsSync(testDataDir)) {
+      fs.rmSync(testDataDir, { recursive: true, force: true });
+    }
+  });
+
+  describe('readJson security validation', () => {
+    it('should reject path traversal with double dots', () => {
+      expect(() => {
+        readJson('../../../etc/passwd');
+      }).toThrow('Invalid file path');
+    });
+
+    it('should reject path traversal in middle of path', () => {
+      expect(() => {
+        readJson('node_modules/../../../etc/passwd');
+      }).toThrow('Invalid file path');
+    });
+
+    it('should reject absolute Unix paths', () => {
+      expect(() => {
+        readJson('/etc/passwd');
+      }).toThrow('Invalid file path');
+    });
+
+    it('should reject absolute Windows paths', () => {
+      const windowsPath = 'C:\\Windows\\System32\\config\\sam';
+      if (path.isAbsolute(windowsPath)) {
+        expect(() => {
+          readJson(windowsPath);
+        }).toThrow('Invalid file path');
+      } else {
+        // On Unix, this would fail with ENOENT, which is acceptable
+        expect(() => {
+          readJson(windowsPath);
+        }).toThrow();
+      }
+    });
+
+    it('should reject URL-encoded path traversal', () => {
+      expect(() => {
+        readJson('..%2F..%2F..%2Fetc%2Fpasswd');
+      }).toThrow('Invalid file path');
+    });
+  });
+
+  describe('licenseTextFor security validation', () => {
+    it('should reject path traversal attempts in license file reading', () => {
+      expect(() => {
+        licenseTextFor('../../../etc');
+      }).toThrow('Invalid file path');
+    });
+
+    it('should reject absolute paths in license file reading', () => {
+      expect(() => {
+        licenseTextFor('/etc');
+      }).toThrow('Invalid file path');
+    });
+
+    it('should reject backslash path traversal', () => {
+      expect(() => {
+        licenseTextFor('..\\..\\..\\windows\\system32');
+      }).toThrow('Invalid file path');
+    });
+  });
+});


### PR DESCRIPTION
## What changed

Re-applies the path-traversal hardening from #1829 (Aikido SAST 63592116) onto current `dev`. Adds `..`/absolute-path guards to file reads in:
- `apps/backend/src/services/clinical-terms.service.ts` (`importFromFile`)
- `apps/desktop/scripts/generate-notices.js` (`resolveWithinNodeModules`)

with unit tests for both.

## Why a new PR

#1829's branch was many weeks behind `dev` and conflicted across hundreds of unrelated files. This is a clean cherry-pick of just the security fix onto current `dev`.

## Note

The original also guarded `apps/backend/src/scripts/seed-codebook.ts`, but that script has since been **removed from the backend**, so that guard and its test are intentionally dropped (dead code).

## Supersedes

Closes #1829.