### PR TITLE
fix(frontend): mobile QA UI fixes across marketing, calendar, org and integrations

### DIFF
--- a/apps/backend/src/services/appointment.prisma.service.ts
+++ b/apps/backend/src/services/appointment.prisma.service.ts
@@ -2216,10 +2216,25 @@ export const AppointmentPrismaService = {
       let inProgressCaseId = resolvedCaseId;
       if (patch.status === "IN_PROGRESS" && row.status !== "IN_PROGRESS") {
         if (!inProgressEncounterId) {
+          // Create the encounter from the PATCHED appointment context (patient, kind, type, case,
+          // concern, times) - the same values the update below writes - so a request that both
+          // starts the appointment AND edits it never links an encounter built from stale
+          // pre-update context.
+          const patchedRow = {
+            ...row,
+            patient: input.patient,
+            appointmentKind,
+            appointmentType,
+            concern: input.concern ?? row.concern,
+            startTime: patch.startTime,
+            endTime: patch.endTime,
+            caseId: resolvedCaseId ?? row.caseId,
+            encounterId: null,
+          } as AppointmentRow;
           const ensured = await ensureEncounterOnCheckIn({
             tx,
             appointmentId,
-            current: row,
+            current: patchedRow,
             caseId: resolvedCaseId,
           });
           inProgressEncounterId = ensured.encounterId;

--- a/apps/backend/src/services/appointment.prisma.service.ts
+++ b/apps/backend/src/services/appointment.prisma.service.ts
@@ -1025,9 +1025,15 @@ const ensureEncounterOnCheckIn = async (args: {
   tx: TransactionClient;
   appointmentId: string;
   current: AppointmentRow;
-}) => {
+  // Pre-resolved case for the appointment. When provided it is used as-is, so this helper and its
+  // caller never both resolve/create a case (which would leave an inpatient with a duplicate case).
+  caseId?: string;
+}): Promise<{ encounterId: string; caseId: string | null }> => {
   if (args.current.encounterId) {
-    return args.current.encounterId;
+    return {
+      encounterId: args.current.encounterId,
+      caseId: normalizeOptionalString(args.current.caseId) ?? null,
+    };
   }
 
   const patientId = getPatientId(args.current.patient);
@@ -1035,6 +1041,7 @@ const ensureEncounterOnCheckIn = async (args: {
     args.current.appointmentKind,
   );
   const caseId =
+    normalizeOptionalString(args.caseId) ??
     normalizeOptionalString(args.current.caseId) ??
     (await resolveCaseContext({
       tx: args.tx,
@@ -1088,7 +1095,7 @@ const ensureEncounterOnCheckIn = async (args: {
     },
   });
 
-  return createdEncounter.id;
+  return { encounterId: createdEncounter.id, caseId };
 };
 
 const assertLeadAvailability = async (args: {
@@ -1807,7 +1814,7 @@ export const AppointmentPrismaService = {
     );
 
     const updated = await prisma.$transaction(async (tx) => {
-      const encounterId = await ensureEncounterOnCheckIn({
+      const { encounterId } = await ensureEncounterOnCheckIn({
         tx,
         appointmentId,
         current: row,
@@ -1847,7 +1854,7 @@ export const AppointmentPrismaService = {
     assertAppointmentTransition(row.status, "CHECKED_IN", "checkInAppointment");
 
     const updated = await prisma.$transaction(async (tx) => {
-      const encounterId = await ensureEncounterOnCheckIn({
+      const { encounterId } = await ensureEncounterOnCheckIn({
         tx,
         appointmentId,
         current: row,
@@ -2199,17 +2206,28 @@ export const AppointmentPrismaService = {
         });
       }
 
-      // On the transition into IN_PROGRESS, stamp the encounter's real
-      // actual-start so the workspace visit timer runs (bug #1903). Only fires on
-      // the first move into IN_PROGRESS and only when an encounter exists.
-      if (
-        patch.status === "IN_PROGRESS" &&
-        row.status !== "IN_PROGRESS" &&
-        encounterId
-      ) {
+      // On the transition into IN_PROGRESS, stamp the encounter's real actual-start so the
+      // workspace visit timer runs (bug #1903). Guarantee an encounter first: an appointment can
+      // reach IN_PROGRESS without one (e.g. a CHECKED_IN set from the edit form rather than the
+      // encounter-creating check-in action), and with no encounter there is nowhere to record the
+      // start, so the timer stays "Not started". Thread the ensured ids into the update below so it
+      // does not overwrite the freshly-linked case/encounter back to null.
+      let inProgressEncounterId = encounterId;
+      let inProgressCaseId = resolvedCaseId;
+      if (patch.status === "IN_PROGRESS" && row.status !== "IN_PROGRESS") {
+        if (!inProgressEncounterId) {
+          const ensured = await ensureEncounterOnCheckIn({
+            tx,
+            appointmentId,
+            current: row,
+            caseId: resolvedCaseId,
+          });
+          inProgressEncounterId = ensured.encounterId;
+          inProgressCaseId = ensured.caseId ?? resolvedCaseId;
+        }
         await stampEncounterActualStartOnProgress({
           tx,
-          encounterId,
+          encounterId: inProgressEncounterId,
           startedAt: new Date(),
         });
       }
@@ -2221,8 +2239,8 @@ export const AppointmentPrismaService = {
           appointmentType: appointmentType
             ? toJsonValue(appointmentType)
             : toNullableJsonValue(row.appointmentType),
-          caseId: resolvedCaseId ?? null,
-          encounterId: encounterId ?? null,
+          caseId: inProgressCaseId ?? null,
+          encounterId: inProgressEncounterId ?? null,
           productItemId: selection.productItemId,
           updatedAt: new Date(),
         },

--- a/apps/backend/src/services/workspace-document-packet.service.ts
+++ b/apps/backend/src/services/workspace-document-packet.service.ts
@@ -151,7 +151,7 @@ const selectMergeableDocuments = (
   const skipped = documents.length - mergeable.length;
   if (skipped > 0) {
     logger.warn(
-      `[WorkspaceDocumentPacket] Skipping ${skipped} non-rendered document(s) when ${context}; only rendered documents are included in the merged PDF.`,
+      `[WorkspaceDocumentPacket] Skipping ${skipped} non-packet document(s) (direct uploads and invoices) when ${context}; only clinical/form packet members are merged into the PDF.`,
     );
   }
   return mergeable;

--- a/apps/backend/src/services/workspace-document-packet.service.ts
+++ b/apps/backend/src/services/workspace-document-packet.service.ts
@@ -142,7 +142,12 @@ const selectMergeableDocuments = (
   documents: WorkspaceDocumentRow[],
   context: string,
 ): WorkspaceDocumentRow[] => {
-  const mergeable = documents.filter((doc) => doc.sourceKind !== "DOCUMENT");
+  // Exclude direct uploads (DOCUMENT - not renderable/mergeable) and INVOICE rendered documents:
+  // an invoice surfaces in the All Documents list but is NOT a clinical-packet member, so it must
+  // never be merged into a signed or printed discharge packet.
+  const mergeable = documents.filter(
+    (doc) => doc.sourceKind !== "DOCUMENT" && doc.sourceKind !== "INVOICE",
+  );
   const skipped = documents.length - mergeable.length;
   if (skipped > 0) {
     logger.warn(

--- a/apps/backend/src/services/workspace.prisma.service.ts
+++ b/apps/backend/src/services/workspace.prisma.service.ts
@@ -296,6 +296,7 @@ type WorkspaceAccess = {
   tasks: boolean;
   labs: boolean;
   documents: boolean;
+  billing: boolean;
   treatmentItems: boolean;
 };
 
@@ -312,6 +313,7 @@ const SYSTEM_WORKSPACE_ACCESS: WorkspaceAccess = {
   tasks: true,
   labs: true,
   documents: true,
+  billing: true,
   treatmentItems: true,
 };
 
@@ -324,6 +326,7 @@ const buildWorkspaceAccess = (
   tasks: snapshot.canViewTasks,
   labs: snapshot.canViewLabs,
   documents: snapshot.canViewDocuments,
+  billing: snapshot.permissions.includes("billing:view:any"),
   treatmentItems: snapshot.permissions.includes("billing:view:any"),
 });
 
@@ -1760,18 +1763,24 @@ const loadDocuments = async (params: {
     string,
     { appointmentId: string | null; encounterId: string | null }
   >;
+  canViewBilling?: boolean;
 }) => {
   // An INVOICE rendered document links to the appointment through its source row
   // (Invoice.appointmentId), not through a templateInstance or clinicalArtifact - so without this
   // the appointment's invoice PDF is silently omitted from the All Documents section. Resolve the
   // invoice ids up front and match the rendered documents by sourceId. (Legacy form-submission
   // reads stay retired; forms surface via the rendered-document/templateInstance pipeline.)
-  const appointmentInvoices = params.appointmentId
-    ? await prisma.invoice.findMany({
-        where: { appointmentId: params.appointmentId },
-        select: { id: true },
-      })
-    : [];
+  //
+  // Invoices are financial documents: the rendered-document controller only serves an INVOICE PDF to
+  // callers holding `billing:view:any`. Gate the lookup on the same permission so a document-view-only
+  // caller never receives invoice ids they could not open - matching the controller's access rule.
+  const appointmentInvoices =
+    params.appointmentId && params.canViewBilling
+      ? await prisma.invoice.findMany({
+          where: { appointmentId: params.appointmentId },
+          select: { id: true },
+        })
+      : [];
 
   const renderedDocumentConditions = [
     ...(params.appointmentId
@@ -2059,6 +2068,7 @@ const buildBootstrapAggregate = async (
       appointmentId,
       encounterId,
       companionId,
+      canViewBilling: access.billing,
       scheduleIds: schedules.map((schedule) => schedule.id),
       scheduleContext,
     }),

--- a/apps/backend/src/services/workspace.prisma.service.ts
+++ b/apps/backend/src/services/workspace.prisma.service.ts
@@ -1761,6 +1761,18 @@ const loadDocuments = async (params: {
     { appointmentId: string | null; encounterId: string | null }
   >;
 }) => {
+  // An INVOICE rendered document links to the appointment through its source row
+  // (Invoice.appointmentId), not through a templateInstance or clinicalArtifact - so without this
+  // the appointment's invoice PDF is silently omitted from the All Documents section. Resolve the
+  // invoice ids up front and match the rendered documents by sourceId. (Legacy form-submission
+  // reads stay retired; forms surface via the rendered-document/templateInstance pipeline.)
+  const appointmentInvoices = params.appointmentId
+    ? await prisma.invoice.findMany({
+        where: { appointmentId: params.appointmentId },
+        select: { id: true },
+      })
+    : [];
+
   const renderedDocumentConditions = [
     ...(params.appointmentId
       ? [
@@ -1773,6 +1785,14 @@ const loadDocuments = async (params: {
             clinicalArtifact: {
               is: { appointmentId: params.appointmentId },
             },
+          },
+        ]
+      : []),
+    ...(appointmentInvoices.length
+      ? [
+          {
+            sourceKind: "INVOICE" as never,
+            sourceId: { in: appointmentInvoices.map((invoice) => invoice.id) },
           },
         ]
       : []),

--- a/apps/backend/test/services/appointment.prisma.service.test.ts
+++ b/apps/backend/test/services/appointment.prisma.service.test.ts
@@ -3271,6 +3271,65 @@ describe("AppointmentPrismaService", () => {
       expect(result.status).toBe("IN_PROGRESS");
     });
 
+    it("builds the ensured encounter from the patched patient, not the pre-update row", async () => {
+      // A request that both starts the appointment AND changes the companion must create the new
+      // encounter for the PATCHED patient, matching the appointment the update writes (Codex).
+      mockedTypes.fromAppointmentRequestDTO.mockReturnValue({
+        ...baseDomain,
+        status: "IN_PROGRESS",
+        patient: {
+          id: "comp_new",
+          name: "New Pet",
+          parent: { id: "parent_new" },
+        },
+      } as any);
+      mockedPrisma.appointment.findUnique.mockResolvedValue(
+        makeRow({
+          status: "CHECKED_IN",
+          caseId: "case_1",
+          encounterId: null,
+          patient: {
+            id: "comp_old",
+            name: "Old Pet",
+            parent: { id: "parent_old" },
+          },
+        }),
+      );
+      mockedPrisma.case.findUnique.mockResolvedValue({
+        id: "case_1",
+        organisationId: "org_1",
+        patientId: "comp_new",
+      } as any);
+      mockedPrisma.encounter.create.mockResolvedValue({ id: "enc_new" } as any);
+      mockedPrisma.encounter.findUnique.mockResolvedValue({
+        id: "enc_new",
+        status: "arrived",
+        periodStart: new Date("2026-06-10T10:00:00.000Z"),
+      } as any);
+      mockedPrisma.encounter.update.mockResolvedValue({ id: "enc_new" } as any);
+      mockedPrisma.appointment.update.mockResolvedValue(
+        makeRow({
+          status: "IN_PROGRESS",
+          caseId: "case_1",
+          encounterId: "enc_new",
+        }),
+      );
+      mockedPrisma.invoice.findMany.mockResolvedValue([]);
+
+      await AppointmentPrismaService.updateAppointmentPMS("appt_1", {
+        resourceType: "Appointment",
+      } as any);
+
+      expect(mockedPrisma.encounter.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            patientId: "comp_new",
+            parentId: "parent_new",
+          }),
+        }),
+      );
+    });
+
     it("preserves a recorded start and status when the encounter is already under way", async () => {
       seedInProgressTransition({
         status: "onleave",

--- a/apps/backend/test/services/appointment.prisma.service.test.ts
+++ b/apps/backend/test/services/appointment.prisma.service.test.ts
@@ -3210,6 +3210,67 @@ describe("AppointmentPrismaService", () => {
       expect(result.status).toBe("IN_PROGRESS");
     });
 
+    it("creates and stamps an encounter when the appointment goes IN_PROGRESS without one (bug #1903)", async () => {
+      // A checked-in appointment can lack an encounter (e.g. CHECKED_IN set from the edit form
+      // rather than the encounter-creating check-in action). The transition must create one and
+      // stamp its actual-start, otherwise the visit timer would stay "Not started" forever.
+      mockedTypes.fromAppointmentRequestDTO.mockReturnValue({
+        ...baseDomain,
+        status: "IN_PROGRESS",
+      } as any);
+      mockedPrisma.appointment.findUnique.mockResolvedValue(
+        makeRow({ status: "CHECKED_IN", caseId: "case_1", encounterId: null }),
+      );
+      mockedPrisma.case.findUnique.mockResolvedValue({
+        id: "case_1",
+        organisationId: "org_1",
+        patientId: "comp_1",
+      } as any);
+      mockedPrisma.encounter.create.mockResolvedValue({ id: "enc_new" } as any);
+      mockedPrisma.encounter.findUnique.mockResolvedValue({
+        id: "enc_new",
+        status: "arrived",
+        periodStart: new Date("2026-06-10T10:00:00.000Z"),
+      } as any);
+      mockedPrisma.encounter.update.mockResolvedValue({ id: "enc_new" } as any);
+      mockedPrisma.appointment.update.mockResolvedValue(
+        makeRow({
+          status: "IN_PROGRESS",
+          caseId: "case_1",
+          encounterId: "enc_new",
+        }),
+      );
+      mockedPrisma.invoice.findMany.mockResolvedValue([]);
+
+      const before = Date.now();
+      const result = await AppointmentPrismaService.updateAppointmentPMS(
+        "appt_1",
+        { resourceType: "Appointment" } as any,
+      );
+
+      // A new encounter is created for the checked-in appointment that had none...
+      expect(mockedPrisma.encounter.create).toHaveBeenCalled();
+      // ...and its actual-start is stamped to the transition time so the timer runs.
+      const stampCall = mockedPrisma.encounter.update.mock.calls.find(
+        ([arg]: any[]) =>
+          arg?.where?.id === "enc_new" && arg?.data?.status === "in-progress",
+      );
+      const stampedPeriodStart = stampCall?.[0]?.data?.periodStart as Date;
+      expect(stampedPeriodStart).toBeInstanceOf(Date);
+      expect(stampedPeriodStart.getTime()).toBeGreaterThanOrEqual(before);
+      // The freshly-linked encounter/case are persisted on the appointment, not nulled out.
+      expect(mockedPrisma.appointment.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: "appt_1" },
+          data: expect.objectContaining({
+            encounterId: "enc_new",
+            caseId: "case_1",
+          }),
+        }),
+      );
+      expect(result.status).toBe("IN_PROGRESS");
+    });
+
     it("preserves a recorded start and status when the encounter is already under way", async () => {
       seedInProgressTransition({
         status: "onleave",

--- a/apps/backend/test/services/workspace-document-packet.service.test.ts
+++ b/apps/backend/test/services/workspace-document-packet.service.test.ts
@@ -439,6 +439,40 @@ describe("WorkspaceDocumentPacketService.sign", () => {
     expect(result.signing?.status).toBe("IN_PROGRESS");
   });
 
+  it("never merges an INVOICE rendered document into the signed clinical packet", async () => {
+    arrange();
+    // A visit with a finalized invoice: the invoice shows in All Documents but is not a packet
+    // member, so signing must exclude it while still merging the clinical docs.
+    mockedPrisma.workspaceDocumentPacket.findFirst.mockResolvedValue(
+      basePacket({
+        documents: [
+          docRow("d1", "SOAP_NOTE"),
+          { ...docRow("d2", "FORM"), sourceKind: "FORM_SUBMISSION" },
+          { ...docRow("inv", "INVOICE"), sourceKind: "INVOICE" },
+        ],
+      }),
+    );
+
+    await WorkspaceDocumentPacketService.sign({
+      organisationId: "org-1",
+      packetId: "pkt-1",
+      signerId: "user-1",
+      signerName: "Dr Jane",
+    });
+
+    expect(mockedBuildPacketPdf).toHaveBeenCalledWith(
+      expect.objectContaining({
+        documents: [
+          expect.objectContaining({ documentId: "d1" }),
+          expect.objectContaining({ documentId: "d2" }),
+        ],
+      }),
+    );
+    const updateArg =
+      mockedPrisma.workspaceDocumentPacket.update.mock.calls[0][0];
+    expect(updateArg.data.signing.documentIds).toEqual(["d1", "d2"]);
+  });
+
   it("refuses to sign when the authenticated signer has no resolvable email", async () => {
     arrange();
     mockedPrisma.user.findFirst.mockResolvedValue(null);

--- a/apps/backend/test/services/workspace.prisma.service.test.ts
+++ b/apps/backend/test/services/workspace.prisma.service.test.ts
@@ -13,7 +13,7 @@ jest.mock("src/config/prisma", () => ({
     appointment: { findFirst: jest.fn() },
     encounter: { findFirst: jest.fn(), findMany: jest.fn() },
     case: { findFirst: jest.fn() },
-    invoice: { findFirst: jest.fn() },
+    invoice: { findFirst: jest.fn(), findMany: jest.fn() },
     organization: { findUnique: jest.fn() },
     patient: { findFirst: jest.fn() },
     patientOrganisation: { findFirst: jest.fn() },
@@ -87,7 +87,7 @@ describe("WorkspaceService", () => {
     appointment: { findFirst: jest.Mock };
     encounter: { findFirst: jest.Mock; findMany: jest.Mock };
     case: { findFirst: jest.Mock };
-    invoice: { findFirst: jest.Mock };
+    invoice: { findFirst: jest.Mock; findMany: jest.Mock };
     organization: { findUnique: jest.Mock };
     patient: { findFirst: jest.Mock };
     patientOrganisation: { findFirst: jest.Mock };
@@ -143,6 +143,7 @@ describe("WorkspaceService", () => {
     mockedPrisma.encounter.findFirst.mockResolvedValue(null);
     mockedPrisma.case.findFirst.mockResolvedValue(null);
     mockedPrisma.invoice.findFirst.mockResolvedValue(null);
+    mockedPrisma.invoice.findMany.mockResolvedValue([]);
     mockedPrisma.organization.findUnique.mockResolvedValue(null);
     mockedPrisma.patient.findFirst.mockResolvedValue(null);
     mockedPrisma.patientOrganisation.findFirst.mockResolvedValue(null);
@@ -310,6 +311,9 @@ describe("WorkspaceService", () => {
       readyForBillingAt: new Date("2026-06-15T12:00:00.000Z"),
       readyForBillingActorId: "user-1",
     });
+    // #1910: the appointment's invoice PDF (an INVOICE rendered document) must be pulled into the
+    // All Documents set by matching its sourceId to the appointment's invoice ids.
+    mockedPrisma.invoice.findMany.mockResolvedValue([{ id: "invoice-1" }]);
     mockedPrisma.user.findUnique.mockResolvedValue({
       firstName: "Dr",
       lastName: "Ready",
@@ -527,6 +531,19 @@ describe("WorkspaceService", () => {
       organisationId: "org-1",
       appointmentId: "appt-1",
     });
+    // #1910: the rendered-document query must include an INVOICE sourceId condition built from the
+    // appointment's invoice ids, so the invoice PDF is surfaced in All Documents.
+    expect(mockedPrisma.invoice.findMany).toHaveBeenCalledWith({
+      where: { appointmentId: "appt-1" },
+      select: { id: true },
+    });
+    const renderedDocumentQuery =
+      mockedPrisma.renderedDocument.findMany.mock.calls.at(-1)?.[0];
+    expect(renderedDocumentQuery?.where?.OR).toEqual(
+      expect.arrayContaining([
+        { sourceKind: "INVOICE", sourceId: { in: ["invoice-1"] } },
+      ]),
+    );
   });
 
   it("returns a bootstrap payload without billing state when no invoice is open", async () => {

--- a/apps/backend/test/services/workspace.prisma.service.test.ts
+++ b/apps/backend/test/services/workspace.prisma.service.test.ts
@@ -637,6 +637,92 @@ describe("WorkspaceService", () => {
     expect(result.readyForBillingByName).toBeNull();
   });
 
+  it("omits the appointment invoice document when the caller lacks billing permission", async () => {
+    mockedPrisma.appointment.findFirst.mockResolvedValue({
+      id: "appt-3",
+      organisationId: "org-1",
+      status: "UPCOMING",
+      appointmentKind: "OUTPATIENT",
+      concern: "Annual review",
+      productItemId: null,
+      encounterId: "enc-3",
+      caseId: "case-3",
+      patient: { id: "patient-3", parent: { id: "parent-3" } },
+      startTime: new Date("2026-06-15T10:00:00.000Z"),
+      endTime: new Date("2026-06-15T10:30:00.000Z"),
+      createdAt: new Date("2026-06-14T10:00:00.000Z"),
+      updatedAt: new Date("2026-06-14T10:00:00.000Z"),
+    });
+    mockedPrisma.encounter.findFirst.mockResolvedValue({
+      id: "enc-3",
+      organisationId: "org-1",
+      caseId: "case-3",
+      patientId: "patient-3",
+      parentId: "parent-3",
+      status: "onleave",
+      encounterClass: "IMP",
+      appointmentKind: "OUTPATIENT",
+      title: "Annual review",
+      reason: null,
+      periodStart: null,
+      periodEnd: null,
+      createdAt: new Date("2026-06-14T10:00:00.000Z"),
+      updatedAt: new Date("2026-06-15T10:00:00.000Z"),
+    });
+    mockedPrisma.organization.findUnique.mockResolvedValue({
+      appointmentLockWindowOutpatientMinutes: 30,
+      appointmentLockWindowInpatientMinutes: null,
+    });
+    mockedPrisma.patient.findFirst.mockResolvedValue({
+      id: "patient-3",
+      name: "Buddy",
+      type: "PET",
+      status: "ACTIVE",
+      createdAt: new Date("2026-06-14T10:00:00.000Z"),
+      updatedAt: new Date("2026-06-14T10:00:00.000Z"),
+    });
+    mockedPrisma.parent.findFirst.mockResolvedValue({
+      id: "parent-3",
+      firstName: "Jane",
+      lastName: "Doe",
+      createdAt: new Date("2026-06-14T10:00:00.000Z"),
+      updatedAt: new Date("2026-06-14T10:00:00.000Z"),
+    });
+    // An open invoice exists for the appointment, but a document-view-only caller must never receive
+    // its PDF: INVOICE rendered documents are financial and require billing:view:any (mirrors the
+    // rendered-document controller's access rule).
+    mockedPrisma.invoice.findMany.mockResolvedValue([{ id: "invoice-1" }]);
+
+    await WorkspaceService.getAppointmentBootstrap(
+      {
+        organisationId: "org-1",
+        appointmentId: "appt-3",
+      },
+      [
+        "appointments:view:any",
+        "tasks:view:any",
+        "forms:view:any",
+        "prescription:view:any",
+        "labs:view:any",
+        "document:view:any",
+      ],
+    );
+
+    // The invoice-id lookup that feeds the INVOICE sourceId condition must be skipped entirely.
+    expect(mockedPrisma.invoice.findMany).not.toHaveBeenCalledWith({
+      where: { appointmentId: "appt-3" },
+      select: { id: true },
+    });
+    const renderedDocumentQuery =
+      mockedPrisma.renderedDocument.findMany.mock.calls.at(-1)?.[0];
+    const orConditions = (renderedDocumentQuery?.where?.OR ?? []) as Array<{
+      sourceKind?: string;
+    }>;
+    expect(
+      orConditions.some((condition) => condition.sourceKind === "INVOICE"),
+    ).toBe(false);
+  });
+
   it("manages persisted treatment items", async () => {
     mockedPrisma.workspaceTreatmentItem.findMany.mockResolvedValue([
       {

--- a/apps/frontend/src/app/__tests__/features/appointments/components/Calendar/responsive/PhoneCalendar.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/appointments/components/Calendar/responsive/PhoneCalendar.test.tsx
@@ -301,7 +301,8 @@ describe('PhoneCalendar', () => {
 
       await userEvent.click(screen.getByRole('button', { name: /^2026-07-07/ }));
 
-      expect(setCurrentDate).toHaveBeenCalledWith(new Date(2026, 6, 7));
+      // Cells anchor to noon UTC so the date key round-trips across timezones.
+      expect(setCurrentDate).toHaveBeenCalledWith(new Date(Date.UTC(2026, 6, 7, 12, 0, 0)));
       expect(screen.getByRole('region', { name: 'Month overview' })).toBeInTheDocument();
     });
 
@@ -321,8 +322,8 @@ describe('PhoneCalendar', () => {
 
       const openedDate = (setCurrentDate as jest.Mock).mock.calls.at(-1)?.[0] as Date;
       expect(openedDate).toBeInstanceOf(Date);
-      expect(openedDate.getHours()).toBe(0);
-      expect(openedDate.getMinutes()).toBe(0);
+      // parseDateKey anchors the opened day to noon UTC (timezone-stable).
+      expect(openedDate.getUTCHours()).toBe(12);
       expect(setActiveCalendar).toHaveBeenCalledWith('day');
     });
   });

--- a/apps/frontend/src/app/__tests__/features/appointments/components/Calendar/responsive/PhoneCalendar.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/appointments/components/Calendar/responsive/PhoneCalendar.test.tsx
@@ -12,6 +12,7 @@ import { useTeamForPrimaryOrg } from '@/app/hooks/useTeam';
 import { useCompanionsForPrimaryOrg } from '@/app/hooks/useCompanion';
 import { changeTaskStatus } from '@/app/features/tasks/services/taskService';
 import { useNotify } from '@/app/hooks/useNotify';
+import { getDateKeyInPreferredTimeZone, getDatePartsInPreferredTimeZone } from '@/app/lib/timezone';
 
 jest.mock('next/image', () => ({
   __esModule: true,
@@ -301,8 +302,10 @@ describe('PhoneCalendar', () => {
 
       await userEvent.click(screen.getByRole('button', { name: /^2026-07-07/ }));
 
-      // Cells anchor to noon UTC so the date key round-trips across timezones.
-      expect(setCurrentDate).toHaveBeenCalledWith(new Date(Date.UTC(2026, 6, 7, 12, 0, 0)));
+      // Cells anchor to local noon in the preferred timezone, so the selected date round-trips
+      // back to its own day key (not the next day, as a UTC-noon anchor would in +12/+13 zones).
+      const selectedDate = (setCurrentDate as jest.Mock).mock.calls.at(-1)?.[0] as Date;
+      expect(getDateKeyInPreferredTimeZone(selectedDate)).toBe('2026-07-07');
       expect(screen.getByRole('region', { name: 'Month overview' })).toBeInTheDocument();
     });
 
@@ -322,8 +325,9 @@ describe('PhoneCalendar', () => {
 
       const openedDate = (setCurrentDate as jest.Mock).mock.calls.at(-1)?.[0] as Date;
       expect(openedDate).toBeInstanceOf(Date);
-      // parseDateKey anchors the opened day to noon UTC (timezone-stable).
-      expect(openedDate.getUTCHours()).toBe(12);
+      // parseDateKey anchors the opened day to local noon in the preferred timezone (never near a
+      // day boundary), so the day key stays stable across every zone.
+      expect(getDatePartsInPreferredTimeZone(openedDate).hour).toBe(12);
       expect(setActiveCalendar).toHaveBeenCalledWith('day');
     });
   });

--- a/apps/frontend/src/app/__tests__/features/appointments/components/Calendar/responsive/PhoneCalendar.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/appointments/components/Calendar/responsive/PhoneCalendar.test.tsx
@@ -185,13 +185,18 @@ describe('PhoneCalendar', () => {
       expect(onOpenWorkspace).toHaveBeenCalledWith(checkedIn);
     });
 
-    it('books into a folded band at the fold start minute', async () => {
-      renderCalendar();
+    it('books into a folded band using the viewed day as-is, not a device-local projection', async () => {
+      // currentDate carries a time-of-day. The booking date must be that exact instant (its day is
+      // read in the preferred timezone downstream), NOT stripped to device-local midnight, which
+      // would shift the day when the preferred zone is ahead of the device (bug: opening 7 Jul in
+      // Pacific/Auckland from a US/Pacific browser prefilled 6 Jul).
+      const viewed = localDate(7, 12);
+      renderCalendar({ currentDate: viewed });
 
       await userEvent.click(screen.getAllByRole('button', { name: 'Book' })[0]);
 
       expect(onCreateFromCalendarSlot).toHaveBeenCalledWith({
-        date: new Date(2026, 6, 7),
+        date: viewed,
         minuteOfDay: expect.any(Number),
       });
     });

--- a/apps/frontend/src/app/__tests__/features/appointments/components/Calendar/responsive/PhoneWeekOverview.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/appointments/components/Calendar/responsive/PhoneWeekOverview.test.tsx
@@ -5,6 +5,7 @@ import type { Appointment } from '@yosemite-crew/types';
 
 import PhoneWeekOverview from '@/app/features/appointments/components/Calendar/responsive/PhoneWeekOverview';
 import { toDateKey } from '@/app/features/appointments/components/Calendar/responsive/phoneWeekLoad';
+import { buildPreferredTimeZoneDayInstant, setPreferredTimeZone } from '@/app/lib/timezone';
 
 jest.mock('react-icons/io5', () => ({
   IoChevronBackOutline: () => <span data-testid="icon-back" />,
@@ -61,6 +62,7 @@ const renderOverview = (props: Partial<React.ComponentProps<typeof PhoneWeekOver
 
 beforeEach(() => {
   idCounter = 0;
+  window.localStorage.clear();
 });
 
 describe('PhoneWeekOverview — header', () => {
@@ -206,6 +208,28 @@ describe('PhoneWeekOverview — day rows', () => {
   it('marks no day as current when nothing is selected', () => {
     renderOverview({ appointments: makeMany(TUESDAY, 2) });
     expect(screen.queryByRole('button', { current: 'date' })).not.toBeInTheDocument();
+  });
+
+  it('keys the current-day marker in the preferred time zone past +12', () => {
+    // Pacific/Auckland is UTC+13 in January (NZDT). Selecting 7 Jan builds its instant at noon
+    // Auckland - 2026-01-06T23:00Z - which reads as 6 Jan in the device zone. Keying the marker
+    // device-locally highlighted the wrong row; it must be keyed in the preferred zone so the
+    // pressed day stays highlighted (matches how the model buckets each row's appointments).
+    setPreferredTimeZone('Pacific/Auckland');
+    const januaryWeekStart = new Date(Date.UTC(2026, 0, 5, 12));
+    const selectedWednesday = buildPreferredTimeZoneDayInstant(2026, 1, 7);
+
+    render(
+      <PhoneWeekOverview
+        weekStart={januaryWeekStart}
+        appointments={[]}
+        selectedDate={selectedWednesday}
+      />
+    );
+
+    const selected = screen.getByRole('button', { current: 'date' });
+    expect(within(selected).getByText('WED')).toBeInTheDocument();
+    expect(selected).toHaveClass('yc-pwo-row--selected');
   });
 
   it('tones down a day whose work is all done', () => {

--- a/apps/frontend/src/app/__tests__/features/appointments/components/Calendar/responsive/phoneMonthModel.test.ts
+++ b/apps/frontend/src/app/__tests__/features/appointments/components/Calendar/responsive/phoneMonthModel.test.ts
@@ -11,6 +11,7 @@ import {
   getMondayFirstWeekday,
   shiftMonthAnchor,
 } from '@/app/features/appointments/components/Calendar/responsive/phoneMonthModel';
+import { getDateKeyInPreferredTimeZone, setPreferredTimeZone } from '@/app/lib/timezone';
 
 // The preferred timezone falls back to Europe/Berlin when localStorage is empty,
 // which makes every assertion below independent of the host machine's zone.
@@ -63,6 +64,19 @@ const TODAY = new Date(Date.UTC(2026, 6, 7, 8)); // Tue 7 Jul 2026, 10:00 Berlin
 
 const cellFor = (model: ReturnType<typeof buildPhoneMonthModel>, dateKey: string) =>
   model.weeks.flatMap((week) => week.cells).find((cell) => cell.dateKey === dateKey);
+
+describe('buildPhoneMonthModel — cell date round-trips in extreme forward zones', () => {
+  it('a UTC+12/+13 zone keeps the selected day (cell.date resolves to its own dateKey)', () => {
+    // Selecting a day sets currentDate = cell.date, which is then re-read via the preferred
+    // timezone. In Pacific/Auckland a UTC-noon anchor resolved to the NEXT calendar day, so
+    // clicking 7 Jul silently selected 8 Jul. The cell.date must round-trip to its own key.
+    setPreferredTimeZone('Pacific/Auckland');
+    const model = buildPhoneMonthModel({ monthDate: JULY_2026, appointments: [], today: TODAY });
+    const cell = cellFor(model, '2026-07-07');
+    expect(cell).toBeDefined();
+    expect(getDateKeyInPreferredTimeZone(cell!.date)).toBe('2026-07-07');
+  });
+});
 
 describe('getLoadDotCount', () => {
   it('renders no dots for an empty day', () => {

--- a/apps/frontend/src/app/__tests__/features/appointments/components/Calendar/responsive/phoneMonthModel.test.ts
+++ b/apps/frontend/src/app/__tests__/features/appointments/components/Calendar/responsive/phoneMonthModel.test.ts
@@ -11,7 +11,11 @@ import {
   getMondayFirstWeekday,
   shiftMonthAnchor,
 } from '@/app/features/appointments/components/Calendar/responsive/phoneMonthModel';
-import { getDateKeyInPreferredTimeZone, setPreferredTimeZone } from '@/app/lib/timezone';
+import {
+  buildPreferredTimeZoneDayInstant,
+  getDateKeyInPreferredTimeZone,
+  setPreferredTimeZone,
+} from '@/app/lib/timezone';
 
 // The preferred timezone falls back to Europe/Berlin when localStorage is empty,
 // which makes every assertion below independent of the host machine's zone.
@@ -65,16 +69,18 @@ const TODAY = new Date(Date.UTC(2026, 6, 7, 8)); // Tue 7 Jul 2026, 10:00 Berlin
 const cellFor = (model: ReturnType<typeof buildPhoneMonthModel>, dateKey: string) =>
   model.weeks.flatMap((week) => week.cells).find((cell) => cell.dateKey === dateKey);
 
-describe('buildPhoneMonthModel — cell date round-trips in extreme forward zones', () => {
-  it('a UTC+12/+13 zone keeps the selected day (cell.date resolves to its own dateKey)', () => {
-    // Selecting a day sets currentDate = cell.date, which is then re-read via the preferred
-    // timezone. In Pacific/Auckland a UTC-noon anchor resolved to the NEXT calendar day, so
-    // clicking 7 Jul silently selected 8 Jul. The cell.date must round-trip to its own key.
+describe('buildPhoneMonthModel — cell dateKey round-trips in extreme forward zones', () => {
+  it('a UTC+12/+13 zone keeps the selected day (dateKey resolves to its own instant)', () => {
+    // Selecting a day builds currentDate on demand from cell.dateKey (as PhoneCalendar does), which
+    // is then re-read via the preferred timezone. In Pacific/Auckland a UTC-noon anchor resolved to
+    // the NEXT calendar day, so clicking 7 Jul silently selected 8 Jul. The key must round-trip.
     setPreferredTimeZone('Pacific/Auckland');
     const model = buildPhoneMonthModel({ monthDate: JULY_2026, appointments: [], today: TODAY });
     const cell = cellFor(model, '2026-07-07');
     expect(cell).toBeDefined();
-    expect(getDateKeyInPreferredTimeZone(cell!.date)).toBe('2026-07-07');
+    const [year, month, day] = cell!.dateKey.split('-').map(Number);
+    const selected = buildPreferredTimeZoneDayInstant(year, month, day);
+    expect(getDateKeyInPreferredTimeZone(selected)).toBe('2026-07-07');
   });
 });
 

--- a/apps/frontend/src/app/__tests__/features/marketing/site/ReleasePill.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/marketing/site/ReleasePill.test.tsx
@@ -13,14 +13,21 @@ const mobile: ReleaseInfo = {
   date: 'Jun 30, 2026',
   url: 'https://github.com/YosemiteCrew/Yosemite-Crew/releases/tag/m1',
 };
+const platform: ReleaseInfo = {
+  tag: 'v2.1.0-beta',
+  date: 'Jul 13, 2026',
+  url: 'https://github.com/YosemiteCrew/Yosemite-Crew/releases/tag/pims-v2.1.0-beta',
+};
 const empty: ReleaseInfo = { tag: null, date: null, url: null };
 
 let latestValue: ReleaseInfo = latest;
 let mobileValue: ReleaseInfo = mobile;
+let platformValue: ReleaseInfo = platform;
 
 jest.mock('@/app/features/marketing/site/useGithubStats', () => ({
   useLatestRelease: () => latestValue,
   useMobileRelease: () => mobileValue,
+  usePlatformRelease: () => platformValue,
 }));
 
 import { ReleasePill } from '@/app/features/marketing/site/ReleasePill';
@@ -29,6 +36,7 @@ describe('ReleasePill', () => {
   beforeEach(() => {
     latestValue = latest;
     mobileValue = mobile;
+    platformValue = platform;
   });
 
   it('renders the Home "Latest release" variant with the live tag and link', () => {
@@ -47,15 +55,22 @@ describe('ReleasePill', () => {
     expect(link).toHaveAttribute('href', 'https://github.com/YosemiteCrew/Yosemite-Crew/releases');
   });
 
-  it('renders the platform variant with only its hard-coded copy, no desktop metadata', () => {
+  it('renders the platform variant with the live PIMS tag, publish date and release link', () => {
     render(<ReleasePill variant="platform" label="Platform PIMS" version="v2.0 beta" />);
     expect(screen.getByText('Platform PIMS')).toBeInTheDocument();
-    // The repo-wide "latest release" is a desktop build, so the platform pill must not
-    // borrow its tag, date, or URL: it shows only hard-coded copy + the releases index.
-    expect(screen.getByText('v2.0 beta')).toBeInTheDocument();
-    expect(screen.queryByText('v2.0.0-beta')).not.toBeInTheDocument();
     const link = screen.getByRole('link');
-    expect(link).not.toHaveTextContent('Jul 2, 2026');
+    // Shows the real PIMS release version + date, not the stale hard-coded copy.
+    expect(link).toHaveTextContent('v2.1.0-beta');
+    expect(link).toHaveTextContent('Jul 13, 2026');
+    expect(screen.queryByText('v2.0 beta')).not.toBeInTheDocument();
+    expect(link).toHaveAttribute('href', platform.url);
+  });
+
+  it('falls back to the hard-coded version (no date) when no platform release resolved', () => {
+    platformValue = empty;
+    render(<ReleasePill variant="platform" label="Platform PIMS" version="v2.1.0-beta" />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveTextContent('v2.1.0-beta');
     expect(link).toHaveAttribute('href', 'https://github.com/YosemiteCrew/Yosemite-Crew/releases');
   });
 

--- a/apps/frontend/src/app/__tests__/features/marketing/site/ReleasePill.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/marketing/site/ReleasePill.test.tsx
@@ -24,10 +24,14 @@ let latestValue: ReleaseInfo = latest;
 let mobileValue: ReleaseInfo = mobile;
 let platformValue: ReleaseInfo = platform;
 
+const mockUseLatestRelease = jest.fn((): ReleaseInfo => latestValue);
+const mockUseMobileRelease = jest.fn((): ReleaseInfo => mobileValue);
+const mockUsePlatformRelease = jest.fn((): ReleaseInfo => platformValue);
+
 jest.mock('@/app/features/marketing/site/useGithubStats', () => ({
-  useLatestRelease: () => latestValue,
-  useMobileRelease: () => mobileValue,
-  usePlatformRelease: () => platformValue,
+  useLatestRelease: () => mockUseLatestRelease(),
+  useMobileRelease: () => mockUseMobileRelease(),
+  usePlatformRelease: () => mockUsePlatformRelease(),
 }));
 
 import { ReleasePill } from '@/app/features/marketing/site/ReleasePill';
@@ -37,6 +41,23 @@ describe('ReleasePill', () => {
     latestValue = latest;
     mobileValue = mobile;
     platformValue = platform;
+    mockUseLatestRelease.mockClear();
+    mockUseMobileRelease.mockClear();
+    mockUsePlatformRelease.mockClear();
+  });
+
+  it('fetches only the release endpoint the variant needs, not all of them', () => {
+    const { unmount } = render(<ReleasePill variant="latest" version="v2.0 beta" />);
+    expect(mockUseLatestRelease).toHaveBeenCalled();
+    expect(mockUseMobileRelease).not.toHaveBeenCalled();
+    expect(mockUsePlatformRelease).not.toHaveBeenCalled();
+    unmount();
+
+    mockUseLatestRelease.mockClear();
+    render(<ReleasePill variant="platform" label="Platform PIMS" version="v2.1.0-beta" />);
+    expect(mockUsePlatformRelease).toHaveBeenCalled();
+    expect(mockUseLatestRelease).not.toHaveBeenCalled();
+    expect(mockUseMobileRelease).not.toHaveBeenCalled();
   });
 
   it('renders the Home "Latest release" variant with the live tag and link', () => {

--- a/apps/frontend/src/app/__tests__/features/marketing/site/useGithubStats.test.ts
+++ b/apps/frontend/src/app/__tests__/features/marketing/site/useGithubStats.test.ts
@@ -3,6 +3,7 @@ import {
   useGithubStats,
   useLatestRelease,
   useMobileRelease,
+  usePlatformRelease,
 } from '@/app/features/marketing/site/useGithubStats';
 
 type FetchLike = typeof fetch;
@@ -239,6 +240,38 @@ describe('useGithubStats hooks', () => {
     await waitFor(() => expect(result.current.url).toBe('https://x/m'));
     // The version comes from tag_name (-> 'v1.2'), never the free-form release name.
     expect(result.current.tag).toBe('v1.2');
+  });
+
+  it('resolves the newest platform (PIMS) release from the releases list, not the desktop build', async () => {
+    globalThis.fetch = jest.fn(() =>
+      Promise.resolve(
+        makeRes([
+          {
+            tag_name: 'desktop-v0.1.0-beta.2',
+            name: 'Desktop',
+            published_at: '2026-07-13T13:33:54Z',
+            html_url: 'https://x/desktop',
+          },
+          {
+            tag_name: 'pims-v2.1.0-beta',
+            name: 'PIMS v2.1.0-beta',
+            published_at: '2026-07-13T13:33:55Z',
+            html_url: 'https://x/pims',
+          },
+          {
+            tag_name: 'pims-v2.0.0-beta',
+            name: 'PIMS v2.0.0-beta',
+            published_at: '2026-07-02T00:00:00Z',
+            html_url: 'https://x/pims-old',
+          },
+        ])
+      )
+    ) as unknown as FetchLike;
+    const { result } = renderHook(() => usePlatformRelease());
+    // Picks the newest pims-tagged release (list is newest-first), never the desktop build.
+    await waitFor(() => expect(result.current.url).toBe('https://x/pims'));
+    expect(result.current.tag).toBe('v2.1.0-beta');
+    expect(result.current.date).toContain('2026');
   });
 
   it('yields no stats (all placeholders) when every request rejects', async () => {

--- a/apps/frontend/src/app/__tests__/hooks/useAppointmentForm.test.ts
+++ b/apps/frontend/src/app/__tests__/hooks/useAppointmentForm.test.ts
@@ -345,6 +345,79 @@ describe('useAppointmentForm', () => {
     });
   });
 
+  it('keeps a slot-derived duration when the same service is re-selected and clears it when the service changes', async () => {
+    const loadSpecialityCatalog = jest.fn(() => Promise.resolve());
+    setRevampCatalogState({
+      loadSpecialityCatalog,
+      services: [
+        {
+          id: 'svc-consult',
+          code: 'CS-001',
+          name: 'General consult',
+          description: 'Exam and consultation',
+          type: 'CONSULTATION',
+          specialityId: 'spec-general',
+          organisationId: 'org-1',
+          grossAmount: 75,
+          defaultDiscount: 0,
+          maxDiscount: 10,
+          durationMinutes: 30,
+          isBookable: true,
+          isInpatientPreferred: false,
+          status: 'ACTIVE',
+          createdAt: '2026-01-01T00:00:00.000Z',
+        },
+        {
+          id: 'svc-dental',
+          code: 'CS-002',
+          name: 'Dental clean',
+          description: 'Scale and polish',
+          type: 'CONSULTATION',
+          specialityId: 'spec-general',
+          organisationId: 'org-1',
+          grossAmount: 120,
+          defaultDiscount: 0,
+          maxDiscount: 10,
+          durationMinutes: 45,
+          isBookable: true,
+          isInpatientPreferred: false,
+          status: 'ACTIVE',
+          createdAt: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+    const { result } = renderHook(() => useAppointmentForm());
+
+    await act(async () => {
+      result.current.handleSpecialitySelect({ label: 'General', value: 'spec-general' });
+    });
+    await act(async () => {
+      result.current.handleServiceSelect({ label: 'General consult', value: 'svc-consult' });
+    });
+    expect(result.current.formData.appointmentType?.id).toBe('svc-consult');
+
+    // A calendar slot fills in the duration for this service.
+    await act(async () => {
+      result.current.setFormData((prev) => ({ ...prev, durationMinutes: 30 }));
+    });
+    expect(result.current.formData.durationMinutes).toBe(30);
+
+    // Re-selecting the same service must keep that duration: the slot-load effect does not re-run
+    // when the service id is unchanged, so zeroing it here would strand booking on
+    // "Please select a duration".
+    await act(async () => {
+      result.current.handleServiceSelect({ label: 'General consult', value: 'svc-consult' });
+    });
+    expect(result.current.formData.durationMinutes).toBe(30);
+
+    // Switching to a different service clears the stale duration so the badge follows the new one.
+    await act(async () => {
+      result.current.handleServiceSelect({ label: 'Dental clean', value: 'svc-dental' });
+    });
+    expect(result.current.formData.appointmentType?.id).toBe('svc-dental');
+    expect(result.current.formData.durationMinutes).toBe(0);
+  });
+
   it('includes bookable packages with a Package badge and excludes non-bookable packages', async () => {
     const loadSpecialityCatalog = jest.fn(() => Promise.resolve());
     setRevampCatalogState({

--- a/apps/frontend/src/app/__tests__/lib/timezone.test.ts
+++ b/apps/frontend/src/app/__tests__/lib/timezone.test.ts
@@ -2,6 +2,7 @@ import {
   DEFAULT_TIMEZONE,
   TIMEZONE_STORAGE_KEY,
   buildDateInPreferredTimeZone,
+  buildPreferredTimeZoneDayInstant,
   formatDateInPreferredTimeZone,
   formatUtcClockTimeLabel,
   getDateKeyInPreferredTimeZone,
@@ -123,6 +124,29 @@ describe('timezone utils', () => {
     const parts = getDatePartsInPreferredTimeZone(date);
     expect(parts.hour).toBe(1);
     expect(parts.minute).toBe(30);
+  });
+
+  it('buildPreferredTimeZoneDayInstant anchors at local noon and round-trips the calendar day', () => {
+    // Pacific/Auckland is UTC+12 (UTC+13 in DST): a UTC-noon anchor would resolve to the NEXT
+    // calendar day, shifting month selections. Local noon keeps the day key stable.
+    setPreferredTimeZone('Pacific/Auckland');
+    const instant = buildPreferredTimeZoneDayInstant(2026, 7, 7);
+    expect(getDateKeyInPreferredTimeZone(instant)).toBe('2026-07-07');
+    expect(getDatePartsInPreferredTimeZone(instant).hour).toBe(12);
+  });
+
+  it('buildPreferredTimeZoneDayInstant round-trips year-end in an extreme +12/+13 zone', () => {
+    setPreferredTimeZone('Pacific/Auckland');
+    expect(getDateKeyInPreferredTimeZone(buildPreferredTimeZoneDayInstant(2026, 12, 31))).toBe(
+      '2026-12-31'
+    );
+  });
+
+  it('buildPreferredTimeZoneDayInstant round-trips in a negative-offset zone', () => {
+    setPreferredTimeZone('America/Los_Angeles');
+    const instant = buildPreferredTimeZoneDayInstant(2026, 7, 7);
+    expect(getDateKeyInPreferredTimeZone(instant)).toBe('2026-07-07');
+    expect(getDatePartsInPreferredTimeZone(instant).hour).toBe(12);
   });
 
   it('getSystemTimeZone returns a valid timezone string', () => {

--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/TreatmentStep.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/TreatmentStep.test.tsx
@@ -492,6 +492,43 @@ describe('TreatmentStep', () => {
     expect(screen.getByRole('combobox', { name: /fulfillment/i })).toBeDisabled();
   });
 
+  it('does not block Save Treatment on a finalized row missing a now-required field', async () => {
+    // A finalized record hydrated from older/external data may lack a currently-required field. It
+    // is read-only and skipped by the save loop, so it must not wedge the save behind a validation
+    // error the clinician cannot fix (Codex P2 on #1909).
+    const onOpenInvoice = jest.fn();
+    const enc = {
+      ...seedAndGet(),
+      prescription: [
+        {
+          id: 'rx-final',
+          medicineName: 'Amoxicillin - 625',
+          // Deliberately missing frequency/duration/quantity (required on a fresh row).
+          fulfillment: 'PRESCRIPTION_ONLY' as const,
+          finalized: true,
+          billed: false,
+        },
+      ],
+    };
+    render(
+      <TreatmentStep
+        appointmentId={APPT}
+        organisationId={ORG}
+        encounterId="enc-1"
+        encounter={enc}
+        onOpenInvoice={onOpenInvoice}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /save treatment/i }));
+
+    // Validation skips the finalized row, so the save advances to billing...
+    await waitFor(() => expect(onOpenInvoice).toHaveBeenCalled());
+    // ...and the finalized row is never re-saved.
+    const savedIds = (savePrescriptionArtifact as jest.Mock).mock.calls.map(([, rx]) => rx.id);
+    expect(savedIds).not.toContain('rx-final');
+  });
+
   it('adds and removes services from the workspace store', () => {
     const enc = seedAndGet();
     render(

--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/TreatmentStep.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/TreatmentStep.test.tsx
@@ -465,6 +465,33 @@ describe('TreatmentStep', () => {
     expect(screen.queryByText('Medication')).not.toBeInTheDocument();
   });
 
+  it('locks a finalized (unbilled) prescription so its edits cannot be silently dropped', () => {
+    // The save loop skips re-saving finalized rows, so their fields must be read-only - otherwise a
+    // clinician's edits would never persist yet still show/invoice (Codex P1 on #1909).
+    const enc = {
+      ...seedAndGet(),
+      prescription: [
+        {
+          id: 'rx-final',
+          medicineName: 'Amoxicillin - 625',
+          frequency: 'BID (twice daily)',
+          durationDays: '5',
+          durationUnit: 'days',
+          qty: '10',
+          refill: '2',
+          fulfillment: 'IN_HOUSE' as const,
+          finalized: true,
+          billed: false,
+        },
+      ],
+    };
+    render(<TreatmentStep appointmentId={APPT} encounter={enc} onOpenInvoice={jest.fn()} />);
+
+    // The locked state is surfaced, and the row's controls are read-only.
+    expect(screen.getByText('Finalized')).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: /fulfillment/i })).toBeDisabled();
+  });
+
   it('adds and removes services from the workspace store', () => {
     const enc = seedAndGet();
     render(

--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/TreatmentStep.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/TreatmentStep.test.tsx
@@ -1039,6 +1039,42 @@ describe('TreatmentStep', () => {
     );
   });
 
+  // #1909: an already-finalized prescription (a locked clinical record) must NOT be re-saved on the
+  // next Save Treatment - re-POSTing/PATCHing it returns 409 and would fail the whole save. It is
+  // skipped while fresh rows still persist and the step advances to billing.
+  it('skips re-saving a finalized prescription while still saving fresh rows', async () => {
+    const onOpenInvoice = jest.fn();
+    seedAndGet();
+    // Mark rx-1 as an already-finalized record; rx-2 stays a fresh (savable) row.
+    const store = useAppointmentWorkspaceStore.getState();
+    const seeded = store.getEncounter(APPT)!.prescription;
+    store.setPrescriptions(
+      APPT,
+      seeded.map((rx) => (rx.id === 'rx-1' ? { ...rx, finalized: true } : rx))
+    );
+    const enc = useAppointmentWorkspaceStore.getState().getEncounter(APPT)!;
+    render(
+      <TreatmentStep
+        appointmentId={APPT}
+        organisationId={ORG}
+        encounterId="enc-1"
+        encounter={enc}
+        onOpenInvoice={onOpenInvoice}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /save treatment/i }));
+
+    await waitFor(() => expect(onOpenInvoice).toHaveBeenCalled());
+    const savedIds = (savePrescriptionArtifact as jest.Mock).mock.calls.map(([, rx]) => rx.id);
+    // The finalized row is never re-saved; the fresh row still is.
+    expect(savedIds).not.toContain('rx-1');
+    expect(savedIds).toContain('rx-2');
+    // The finalized row is not re-dispensed either.
+    expect(finalizePrescription).not.toHaveBeenCalledWith(ORG, 'rx-1');
+    expect(finalizePrescription).toHaveBeenCalledWith(ORG, 'rx-2');
+  });
+
   it('blocks the invoice and shows an error when treatment persistence fails', async () => {
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
     (persistTreatmentItems as jest.Mock).mockRejectedValueOnce(new Error('save failed'));

--- a/apps/frontend/src/app/__tests__/pages/ContactusPage.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/ContactusPage.test.tsx
@@ -244,8 +244,8 @@ describe('ContactusPage', () => {
         email: 'jane.doe@example.com',
         source: 'PMS_WEB',
       });
-      expect(screen.getByLabelText('Full Name')).toHaveValue('');
-      expect(screen.getByLabelText('Enter Email Address')).toHaveValue('');
+      // On success the form is replaced by the confirmation card.
+      expect(await screen.findByText('Message sent')).toBeInTheDocument();
     });
 
     it('should show the uploaded image name on the complaint form', async () => {
@@ -318,9 +318,7 @@ describe('ContactusPage', () => {
           declarationAccepted: true,
         },
       });
-      expect(screen.getByLabelText('Full Name')).toHaveValue('');
-      expect(screen.getByLabelText('Enter Email Address')).toHaveValue('');
-      expect(screen.getByRole('radio', { name: 'General Enquiry' })).toBeChecked();
+      expect(await screen.findByText('Message sent')).toBeInTheDocument();
     });
 
     it('should keep submit button disabled if DSAR form is almost valid', () => {
@@ -355,6 +353,31 @@ describe('ContactusPage', () => {
       fireEvent.click(checkboxes[1]);
 
       expect(submitButton).toBeDisabled();
+    });
+
+    it('shows a confirmation after a successful send and returns to a fresh form', async () => {
+      render(<ContactusPage />);
+      const submitButton = screen.getAllByRole('button', { name: 'Send message' })[0];
+
+      fireEvent.change(screen.getByLabelText('Full Name'), { target: { value: 'John Doe' } });
+      fireEvent.change(screen.getByLabelText('Enter Email Address'), {
+        target: { value: 'john.doe@example.com' },
+      });
+      fireEvent.change(screen.getByPlaceholderText('Your Message'), {
+        target: { value: 'A confirmed message.' },
+      });
+
+      await waitFor(() => expect(submitButton).toBeEnabled());
+      fireEvent.click(submitButton);
+
+      // The success card replaces the form, so the clinician gets an explicit acknowledgement.
+      expect(await screen.findByText('Message sent')).toBeInTheDocument();
+      expect(screen.queryByLabelText('Full Name')).not.toBeInTheDocument();
+
+      // "Send another message" brings back a fresh (empty) form.
+      fireEvent.click(screen.getByRole('button', { name: /Send another message/i }));
+      expect(screen.getByLabelText('Full Name')).toHaveValue('');
+      expect(screen.getByRole('radio', { name: 'General Enquiry' })).toBeChecked();
     });
 
     it('should handle API submission failure gracefully', async () => {

--- a/apps/frontend/src/app/__tests__/pages/Organization/Sections/PhoneOrganization.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Organization/Sections/PhoneOrganization.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import PhoneOrganization from '@/app/features/organization/pages/Organization/Sections/PhoneOrganization';
@@ -39,6 +39,11 @@ jest.mock('@/app/features/organization/services/orgService', () => ({
   updateOrg: jest.fn(),
 }));
 
+const mockLoadServicesForOrg = jest.fn();
+jest.mock('@/app/features/organization/services/serviceService', () => ({
+  loadServicesForOrg: (...args: unknown[]) => mockLoadServicesForOrg(...args),
+}));
+
 jest.mock('@/app/features/organization/pages/Organization/Sections/Team/AddTeam', () => ({
   __esModule: true,
   default: ({ showModal }: { showModal: boolean }) =>
@@ -57,6 +62,7 @@ jest.mock('@/app/features/organization/pages/Organization/Sections/OrgProfileEdi
 }));
 
 const org: Organisation = {
+  _id: 'org-1',
   name: 'Alpenblick Animal Clinic',
   type: 'HOSPITAL',
   phoneNo: '+49 8821',
@@ -71,6 +77,7 @@ const renderPhone = () => render(<PhoneOrganization primaryOrg={org} />);
 describe('PhoneOrganization', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockLoadServicesForOrg.mockResolvedValue([]);
     canMock.mockReturnValue(true);
     useTeamMock.mockReturnValue([
       {
@@ -110,6 +117,18 @@ describe('PhoneOrganization', () => {
       'href',
       '/stripe-onboarding?orgId=org-1'
     );
+  });
+
+  it('loads the org services on mount so the specialities accordion has bodies', () => {
+    renderPhone();
+    expect(mockLoadServicesForOrg).toHaveBeenCalledWith('org-1');
+  });
+
+  it('keeps rendering when the service load fails', async () => {
+    mockLoadServicesForOrg.mockRejectedValueOnce(new Error('boom'));
+    renderPhone();
+    await waitFor(() => expect(mockLoadServicesForOrg).toHaveBeenCalledWith('org-1'));
+    expect(screen.getByText('Specialities & services')).toBeInTheDocument();
   });
 
   it('navigates back when the back button is pressed', () => {

--- a/apps/frontend/src/app/__tests__/pages/Organization/Sections/PhoneOrganization.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Organization/Sections/PhoneOrganization.test.tsx
@@ -124,6 +124,13 @@ describe('PhoneOrganization', () => {
     expect(mockLoadServicesForOrg).toHaveBeenCalledWith('org-1');
   });
 
+  it('passes undefined (not the string "undefined") to the loader when the org has no id', () => {
+    render(<PhoneOrganization primaryOrg={{ ...org, _id: undefined }} />);
+    // A missing id must stay undefined so loadServicesForOrg falls back to the store id / skips,
+    // instead of fetching /organisation/undefined.
+    expect(mockLoadServicesForOrg).toHaveBeenCalledWith(undefined);
+  });
+
   it('keeps rendering when the service load fails', async () => {
     mockLoadServicesForOrg.mockRejectedValueOnce(new Error('boom'));
     renderPhone();

--- a/apps/frontend/src/app/__tests__/pages/PetBusinesses.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/PetBusinesses.test.tsx
@@ -36,7 +36,7 @@ describe('PetBusinesses page', () => {
   test('renders the hero with release pill, word-by-word headline and CTAs', () => {
     render(<PetBusinesses />);
 
-    expect(screen.getByTestId('release-pill')).toHaveTextContent('Platform PIMS v2.0 beta');
+    expect(screen.getByTestId('release-pill')).toHaveTextContent('Platform PIMS v2.1.0-beta');
 
     const heading = screen.getByRole('heading', { level: 1 });
     expect(heading).toHaveTextContent('The');

--- a/apps/frontend/src/app/__tests__/services/workspaceAggregateService.test.ts
+++ b/apps/frontend/src/app/__tests__/services/workspaceAggregateService.test.ts
@@ -654,6 +654,8 @@ describe('workspaceAggregateService', () => {
         medicineName: 'Metronidazole',
         priceCents: 1800,
         billed: true,
+        // #1909: a billed medication is a finalized record — never re-POSTed on save.
+        finalized: true,
       }),
     ]);
   });
@@ -751,6 +753,8 @@ describe('workspaceAggregateService', () => {
         route: 'PO',
         frequency: 'BID',
         qty: '2',
+        // #1909: artifact status COMPLETED means the line is finalized (skip re-save).
+        finalized: true,
       }),
     ]);
     expect(patch.services).toBeUndefined();
@@ -784,7 +788,10 @@ describe('workspaceAggregateService', () => {
       ],
     });
 
-    expect(patch.prescription).toEqual([expect.objectContaining({ id: 'line-1', billed: true })]);
+    expect(patch.prescription).toEqual([
+      // #1909: a billed line is finalized too, even when the artifact carries no final status.
+      expect.objectContaining({ id: 'line-1', billed: true, finalized: true }),
+    ]);
   });
 
   it('does not mark a same-drug artifact prescription as billed without a prescription link', () => {
@@ -830,7 +837,10 @@ describe('workspaceAggregateService', () => {
       treatmentItems: [],
     });
 
-    expect(patch.prescription).toEqual([expect.objectContaining({ id: 'line-1', billed: false })]);
+    expect(patch.prescription).toEqual([
+      // An unbilled line with no final artifact status is not finalized and stays re-savable.
+      expect.objectContaining({ id: 'line-1', billed: false, finalized: false }),
+    ]);
   });
 
   it('reconciles a document packet and builds a packet PDF blob URL', async () => {

--- a/apps/frontend/src/app/__tests__/services/workspaceClinicalService.test.ts
+++ b/apps/frontend/src/app/__tests__/services/workspaceClinicalService.test.ts
@@ -630,7 +630,26 @@ describe('workspaceClinicalService', () => {
       {}
     );
     expect(prescriptions[0].id).toBe('rx-enc');
+    // #1909: a FHIR status of 'active' means the prescription is finalized (COMPLETED/SIGNED).
+    expect(prescriptions[0].finalized).toBe(true);
     expect(prescription.id).toBe('rx-enc');
+  });
+
+  it('marks a draft-status prescription as not finalized', async () => {
+    postDataMock.mockResolvedValueOnce({
+      data: bundle('MedicationRequest', {
+        id: 'rx-draft',
+        status: 'draft',
+        medicationCodeableConcept: { text: 'Meloxicam' },
+      }),
+    });
+
+    const prescriptions = await listPrescriptionsForEncounter('org-1', 'enc-1', {
+      appointmentId: 'appt-1',
+    });
+
+    // A draft prescription can still be PATCHed, so it must not be flagged finalized.
+    expect(prescriptions[0].finalized).toBe(false);
   });
 
   it('lists observation tool submissions attached to the appointment', async () => {

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneCalendar.tsx
@@ -85,7 +85,9 @@ const startOfLocalDay = (date: Date): Date =>
 
 const parseDateKey = (dateKey: string): Date => {
   const [year, month, day] = dateKey.split('-').map(Number);
-  return new Date(year, month - 1, day);
+  // Anchor to noon UTC so the key round-trips through getDateKeyInPreferredTimeZone
+  // for every device timezone (a local midnight can land on the previous day).
+  return new Date(Date.UTC(year, month - 1, day, 12, 0, 0));
 };
 
 const minutesOfDay = (date: Date): number => date.getHours() * 60 + date.getMinutes();

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneCalendar.tsx
@@ -11,7 +11,7 @@ import { useLoadTasksForPrimaryOrg, useTasksAssignedToUser } from '@/app/hooks/u
 import { useTeamForPrimaryOrg } from '@/app/hooks/useTeam';
 import { useCompanionsForPrimaryOrg } from '@/app/hooks/useCompanion';
 import { changeTaskStatus } from '@/app/features/tasks/services/taskService';
-import { getPreferredTimeZone } from '@/app/lib/timezone';
+import { buildPreferredTimeZoneDayInstant, getPreferredTimeZone } from '@/app/lib/timezone';
 import { useNotify } from '@/app/hooks/useNotify';
 import type { Task } from '@/app/features/tasks/types/task';
 import type { AppointmentDraftPrefill } from '@/app/features/appointments/types/calendar';
@@ -85,9 +85,10 @@ const startOfLocalDay = (date: Date): Date =>
 
 const parseDateKey = (dateKey: string): Date => {
   const [year, month, day] = dateKey.split('-').map(Number);
-  // Anchor to noon UTC so the key round-trips through getDateKeyInPreferredTimeZone
-  // for every device timezone (a local midnight can land on the previous day).
-  return new Date(Date.UTC(year, month - 1, day, 12, 0, 0));
+  // Anchor at local noon in the preferred timezone so the key round-trips through
+  // getDateKeyInPreferredTimeZone for every zone - a UTC-noon anchor lands on the next day
+  // for zones 12+ hours ahead of UTC (e.g. Pacific/Auckland).
+  return buildPreferredTimeZoneDayInstant(year, month, day);
 };
 
 const minutesOfDay = (date: Date): number => date.getHours() * 60 + date.getMinutes();

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneCalendar.tsx
@@ -312,7 +312,7 @@ const PhoneCalendar = ({
           view="month"
           onViewChange={applyClinicView}
           onMonthChange={setMonthAnchor}
-          onSelectDay={(cell: PhoneMonthCell) => setCurrentDate(cell.date)}
+          onSelectDay={(cell: PhoneMonthCell) => setCurrentDate(parseDateKey(cell.dateKey))}
           onOpenDay={(dateKey: string) => openDay(parseDateKey(dateKey))}
         />
       </div>

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneCalendar.tsx
@@ -224,8 +224,12 @@ const PhoneCalendar = ({
 
   const handleBookFold = useCallback(
     (fold: DayRailFold) => {
+      // Pass currentDate straight through (the booking path reads its day in the PREFERRED
+      // timezone via buildDateInPreferredTimeZone). Do NOT re-project through startOfLocalDay,
+      // whose device-local getters shift the day when the preferred zone is ahead of the device
+      // (e.g. opening 7 Jul in Pacific/Auckland from a US/Pacific browser prefilled 6 Jul).
       onCreateFromCalendarSlot?.({
-        date: startOfLocalDay(currentDate),
+        date: currentDate,
         minuteOfDay: fold.startMinutes,
       });
     },

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneWeekOverview.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneWeekOverview.tsx
@@ -5,10 +5,11 @@ import clsx from 'clsx';
 import { IoChevronBackOutline, IoChevronForwardOutline, IoWarning } from 'react-icons/io5';
 import type { Appointment } from '@yosemite-crew/types';
 
+import { getDateKeyInPreferredTimeZone } from '@/app/lib/timezone';
+
 import {
   buildPhoneWeekOverview,
   SEGMENT_COLORS,
-  toDateKey,
   type PhoneWeekDayMeta,
   type PhoneWeekDayRow,
 } from './phoneWeekLoad';
@@ -140,7 +141,11 @@ const PhoneWeekOverview = ({
     [weekStart, appointments, dayMeta, defaultCapacity]
   );
 
-  const selectedKey = selectedDate ? toDateKey(selectedDate) : null;
+  // Each day row is keyed by its preferred-time-zone day (buildPhoneWeekOverview matches
+  // appointments the same way), so the selection must be keyed in that zone too. Using the
+  // device-local day here highlighted the wrong row when the preferred zone crossed a local
+  // midnight relative to the selected instant.
+  const selectedKey = selectedDate ? getDateKeyInPreferredTimeZone(selectedDate) : null;
 
   return (
     <section className="yc-pwo" aria-label={`${overview.weekLabel}, ${overview.rangeLabel}`}>

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/phoneMonthModel.ts
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/phoneMonthModel.ts
@@ -42,7 +42,9 @@ const STATUS_LABELS: Record<AppointmentStatus, string> = {
 };
 
 export type PhoneMonthCell = {
-  /** Local-midnight Date for the cell, for consumers that need a Date. */
+  /** Instant anchored at LOCAL NOON in the preferred timezone (not midnight), so it round-trips
+   *  back to this cell's `dateKey` in every zone. Use `dateKey` for day identity; never assume a
+   *  midnight boundary on this value. */
   date: Date;
   /** `YYYY-MM-DD` calendar key — the identity of the cell. */
   dateKey: string;

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/phoneMonthModel.ts
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/phoneMonthModel.ts
@@ -273,7 +273,9 @@ export const buildPhoneMonthModel = ({
     const appointmentCount = bucket?.appointments.length ?? 0;
 
     return {
-      date: new Date(ref.year, ref.month - 1, ref.day),
+      // Noon UTC so the cell date round-trips through the preferred-timezone date
+      // key on every device (a local-midnight Date can resolve to the prior day).
+      date: new Date(Date.UTC(ref.year, ref.month - 1, ref.day, 12, 0, 0)),
       dateKey,
       dayOfMonth: ref.day,
       isOutsideMonth,

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/phoneMonthModel.ts
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/phoneMonthModel.ts
@@ -1,10 +1,6 @@
 import type { Appointment } from '@yosemite-crew/types';
 import type { AppointmentStatus } from '@/app/features/appointments/types/appointments';
-import {
-  buildPreferredTimeZoneDayInstant,
-  getDateKeyInPreferredTimeZone,
-  getDatePartsInPreferredTimeZone,
-} from '@/app/lib/timezone';
+import { getDateKeyInPreferredTimeZone, getDatePartsInPreferredTimeZone } from '@/app/lib/timezone';
 
 /**
  * Pure derivation layer for the phone month overview ("dot map + day peek").
@@ -42,11 +38,8 @@ const STATUS_LABELS: Record<AppointmentStatus, string> = {
 };
 
 export type PhoneMonthCell = {
-  /** Instant anchored at LOCAL NOON in the preferred timezone (not midnight), so it round-trips
-   *  back to this cell's `dateKey` in every zone. Use `dateKey` for day identity; never assume a
-   *  midnight boundary on this value. */
-  date: Date;
-  /** `YYYY-MM-DD` calendar key — the identity of the cell. */
+  /** `YYYY-MM-DD` calendar key — the identity of the cell. Consumers derive a concrete instant on
+   *  demand (via parseDateKey) only when a day is actually selected, never for every grid cell. */
   dateKey: string;
   dayOfMonth: number;
   /** True for the leading/trailing days borrowed from the adjacent months. */
@@ -279,11 +272,6 @@ export const buildPhoneMonthModel = ({
     const appointmentCount = bucket?.appointments.length ?? 0;
 
     return {
-      // Anchor at local noon in the preferred timezone so the cell date round-trips through
-      // the preferred-timezone date key on every device. A UTC-noon anchor resolves to the
-      // prior day for negative offsets and, more importantly, to the NEXT day for zones 12+
-      // hours ahead of UTC (e.g. Pacific/Auckland), which shifted month selections by a day.
-      date: buildPreferredTimeZoneDayInstant(ref.year, ref.month, ref.day),
       dateKey,
       dayOfMonth: ref.day,
       isOutsideMonth,

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/phoneMonthModel.ts
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/phoneMonthModel.ts
@@ -1,6 +1,10 @@
 import type { Appointment } from '@yosemite-crew/types';
 import type { AppointmentStatus } from '@/app/features/appointments/types/appointments';
-import { getDateKeyInPreferredTimeZone, getDatePartsInPreferredTimeZone } from '@/app/lib/timezone';
+import {
+  buildPreferredTimeZoneDayInstant,
+  getDateKeyInPreferredTimeZone,
+  getDatePartsInPreferredTimeZone,
+} from '@/app/lib/timezone';
 
 /**
  * Pure derivation layer for the phone month overview ("dot map + day peek").
@@ -273,9 +277,11 @@ export const buildPhoneMonthModel = ({
     const appointmentCount = bucket?.appointments.length ?? 0;
 
     return {
-      // Noon UTC so the cell date round-trips through the preferred-timezone date
-      // key on every device (a local-midnight Date can resolve to the prior day).
-      date: new Date(Date.UTC(ref.year, ref.month - 1, ref.day, 12, 0, 0)),
+      // Anchor at local noon in the preferred timezone so the cell date round-trips through
+      // the preferred-timezone date key on every device. A UTC-noon anchor resolves to the
+      // prior day for negative offsets and, more importantly, to the NEXT day for zones 12+
+      // hours ahead of UTC (e.g. Pacific/Auckland), which shifted month selections by a day.
+      date: buildPreferredTimeZoneDayInstant(ref.year, ref.month, ref.day),
       dateKey,
       dayOfMonth: ref.day,
       isOutsideMonth,

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/PrescriptionEditor.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/PrescriptionEditor.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState } from 'react';
 import {
   IoChevronDownOutline,
   IoCopyOutline,
+  IoLockClosedOutline,
   IoPrintOutline,
   IoShieldOutline,
   IoTrashOutline,
@@ -231,7 +232,11 @@ const PrescriptionRow = ({
 }) => {
   // Billed/paid items are locked: fields render read-only and there is no delete.
   const isBilled = Boolean(item.billed);
-  const rowReadOnly = readOnly || isBilled;
+  // A finalized (COMPLETED/SIGNED) prescription is a locked clinical record too. The save loop
+  // skips re-saving finalized rows, so if the fields stayed editable a clinician's edits would be
+  // silently dropped (never persisted) yet still shown/invoiced. Lock the fields like billed rows.
+  const isFinalized = !isBilled && Boolean(item.finalized);
+  const rowReadOnly = readOnly || isBilled || isFinalized;
   const errors = validatePrescriptionItem(item);
 
   // Inventory-owned facts. Form/Route only become editable when inventory did not supply them.
@@ -261,6 +266,12 @@ const PrescriptionRow = ({
             <StockHealthPill qty={item.stockQty} low={item.lowStock ?? false} />
           )}
           {isBilled && <BilledBadge />}
+          {isFinalized && (
+            <span className="inline-flex items-center gap-1 rounded-2xl border border-card-border bg-neutral-100 px-2 py-0.5 text-caption-2 font-medium text-text-secondary">
+              <IoLockClosedOutline size={12} aria-hidden="true" />
+              Finalized
+            </span>
+          )}
           <FulfillmentDropdown
             value={item.fulfillment}
             disabled={rowReadOnly}

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/PrescriptionEditor.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/PrescriptionEditor.tsx
@@ -372,7 +372,7 @@ const PrescriptionRow = ({
             onChange={(value) => onUpdateItem(item.id, { instructions: value })}
           />
         </div>
-        <span className="shrink-0 self-center text-body-3-emphasis font-bold text-text-primary">
+        <span className="shrink-0 self-start text-body-3-emphasis font-bold text-text-primary">
           {item.priceCents == null ? '-' : formatCents(item.priceCents)}
         </span>
       </div>

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/SummaryStep.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/SummaryStep.tsx
@@ -237,12 +237,6 @@ const SigningStatusPill = ({ signingStatus }: { signingStatus?: string | null })
   );
 };
 
-/** Shared column template (mirrors the Invoice table) so the heading and row
- *  grids resolve to identical track widths. The Actions track is fixed. */
-const DOCUMENT_COLS =
-  '@2xl:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)_minmax(0,1.6fr)_minmax(0,1.2fr)_minmax(0,1.2fr)_92px]';
-const DOCUMENT_ROW_GRID = `grid gap-3 ${DOCUMENT_COLS} @2xl:items-center`;
-
 const downloadDocumentUrl = (url: string) => {
   const link = globalThis.document.createElement('a');
   link.href = url;
@@ -302,53 +296,47 @@ export const AllDocumentsTable = ({
         </p>
       )}
       {!error && documents.length > 0 && (
-        <div className="@container flex flex-col gap-3">
-          <div
-            className={`${DOCUMENT_ROW_GRID} hidden border border-transparent px-4 text-caption-2 font-medium tracking-wide text-text-secondary uppercase [&>span]:truncate @2xl:grid`}
-          >
-            <span>Created</span>
-            <span>Source</span>
-            <span>Title</span>
-            <span>Status</span>
-            <span>Signing</span>
-            <span className="text-right">Actions</span>
-          </div>
+        <div className="flex flex-col gap-3">
+          {/* Stacked cards, not a fixed multi-column grid: the section lives in a ~400px aside, so a
+              6-track row forces the status/signing pills to overflow their columns and overlap the
+              neighbouring cell. A card keeps the title on its own line (truncates with a tooltip),
+              lets the pills wrap, and pins the actions to the right at every width. */}
           <ul className="flex flex-col gap-3">
             {documents.map((document) => (
               <li
                 key={document.documentId}
-                className={`${DOCUMENT_ROW_GRID} rounded-2xl border border-card-border p-4`}
+                className="flex items-start gap-3 rounded-2xl border border-card-border p-4"
               >
-                <span className="truncate text-body-4 text-text-secondary">
-                  {formatDateTime(toIsoString(document.createdAt))}
-                </span>
-                <span>
-                  <DocumentSourcePill source={document.sourceKind} />
-                </span>
-                <span className="truncate font-medium text-text-primary">{document.title}</span>
-                <span className="truncate text-body-4 text-text-primary">
-                  {humanizeToken(document.status)}
-                </span>
-                <span className="truncate">
-                  <SigningStatusPill signingStatus={document.signingStatus} />
-                </span>
-                <div className="flex justify-end gap-2">
-                  {canView && (
-                    <>
-                      <CircleIconButton
-                        icon={<IoEyeOutline aria-hidden="true" />}
-                        label={`View ${document.title}`}
-                        variant="dark"
-                        onClick={() => void handleDocumentAction(document)}
-                      />
-                      <CircleIconButton
-                        icon={<IoDownloadOutline aria-hidden="true" />}
-                        label={`Download ${document.title}`}
-                        onClick={() => void handleDocumentAction(document)}
-                      />
-                    </>
-                  )}
+                <div className="flex min-w-0 flex-1 flex-col gap-2">
+                  <span className="truncate font-medium text-text-primary" title={document.title}>
+                    {document.title}
+                  </span>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <DocumentSourcePill source={document.sourceKind} />
+                    <span className="text-body-4 text-text-primary">
+                      {humanizeToken(document.status)}
+                    </span>
+                    <SigningStatusPill signingStatus={document.signingStatus} />
+                  </div>
+                  <span className="text-body-4 text-text-secondary">
+                    {formatDateTime(toIsoString(document.createdAt))}
+                  </span>
                 </div>
+                {canView && (
+                  <div className="flex shrink-0 justify-end gap-2">
+                    <CircleIconButton
+                      icon={<IoEyeOutline aria-hidden="true" />}
+                      label={`View ${document.title}`}
+                      variant="dark"
+                      onClick={() => void handleDocumentAction(document)}
+                    />
+                    <CircleIconButton
+                      icon={<IoDownloadOutline aria-hidden="true" />}
+                      label={`Download ${document.title}`}
+                      onClick={() => void handleDocumentAction(document)}
+                    />
+                  </div>
+                )}
               </li>
             ))}
           </ul>

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/TreatmentStep.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/TreatmentStep.tsx
@@ -785,10 +785,12 @@ const TreatmentStep = ({
     // BEFORE the persist/no-persist branch so it blocks even when org/encounter haven't hydrated
     // (otherwise the step would silently advance without validating). Each row must carry the
     // required clinical instructions (frequency, duration, quantity, route, form) and pass every
-    // number-format rule.
-    const prescriptionErrors = normalizedPrescriptions.flatMap((rx) =>
-      getPrescriptionSaveErrors(rx)
-    );
+    // number-format rule. Finalized rows are read-only and skipped by the save loop, so exclude
+    // them: an older/external finalized record missing a now-required field must not wedge the
+    // save behind a validation error the clinician cannot fix.
+    const prescriptionErrors = normalizedPrescriptions
+      .filter((rx) => !rx.finalized)
+      .flatMap((rx) => getPrescriptionSaveErrors(rx));
     if (prescriptionErrors.length > 0) {
       setPrescriptionError(prescriptionErrors[0]);
       setTreatmentSaveError('Complete all prescription details before saving.');

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/TreatmentStep.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/TreatmentStep.tsx
@@ -830,6 +830,13 @@ const TreatmentStep = ({
       // create-or-update is keyed off the row id.
       const reconciledPrescriptions = await Promise.all(
         normalizedPrescriptions.map(async (rx) => {
+          // A finalized/billed prescription is a locked clinical record (its `finalized` flag is
+          // only ever set from persisted server state, so it always carries a real id). Re-POSTing
+          // it - or PATCHing it back to draft - returns 409 and fails the whole save, so leave the
+          // already-persisted, already-dispensed row untouched instead of re-saving it.
+          if (rx.finalized) {
+            return rx;
+          }
           const savedRx = await savePrescriptionArtifact(
             { organisationId, appointmentId, encounterId: activeEncounterId, authorId },
             rx

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/TreatmentStep.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/TreatmentStep.tsx
@@ -788,9 +788,9 @@ const TreatmentStep = ({
     // number-format rule. Finalized rows are read-only and skipped by the save loop, so exclude
     // them: an older/external finalized record missing a now-required field must not wedge the
     // save behind a validation error the clinician cannot fix.
-    const prescriptionErrors = normalizedPrescriptions
-      .filter((rx) => !rx.finalized)
-      .flatMap((rx) => getPrescriptionSaveErrors(rx));
+    const prescriptionErrors = normalizedPrescriptions.flatMap((rx) =>
+      rx.finalized ? [] : getPrescriptionSaveErrors(rx)
+    );
     if (prescriptionErrors.length > 0) {
       setPrescriptionError(prescriptionErrors[0]);
       setTreatmentSaveError('Complete all prescription details before saving.');

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AddAppointmentCentralModal/index.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AddAppointmentCentralModal/index.tsx
@@ -187,7 +187,7 @@ export const Arrow = ({ open }: { open: boolean }) => (
 // ─── Floating label ─────────────────────────────────────────────────────────────
 export const FloatLabel = ({ floated, children }: { floated: boolean; children: ReactNode }) => (
   <span
-    className="pointer-events-none absolute left-5 z-10 flex items-center gap-1 bg-neutral-0 px-1 transition-all duration-150"
+    className="yc-float-label pointer-events-none absolute left-5 z-10 flex items-center gap-1 bg-neutral-0 px-1 transition-all duration-150"
     style={
       floated
         ? { ...floatLabelActive, top: 0, transform: 'translateY(-50%)' }

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AddAppointmentCentralModal/index.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AddAppointmentCentralModal/index.tsx
@@ -574,8 +574,6 @@ export const TimeSlotDropdown = ({
   const selectedLabel = selectedSlot
     ? formatUtcTimeToLocalLabel(selectedSlot.startTime)
     : (prefillLabel ?? null);
-  const isFloated = Boolean(selectedLabel) || open;
-
   // Read position synchronously from the DOM at render time — no state delay
   const portalStyle = open ? getPortalStyle(triggerRef.current) : null;
 
@@ -609,27 +607,30 @@ export const TimeSlotDropdown = ({
       : null;
 
   return (
-    <div ref={containerRef}>
+    <div ref={containerRef} className="flex w-full flex-col">
+      <span className="mb-1.5 block truncate text-[12px] font-semibold text-[var(--ink-soft)]">
+        {label}
+      </span>
       <button
         type="button"
         ref={triggerRef}
         className={clsx(
-          'relative flex w-full items-center min-h-[46px] border-[1.5px] bg-neutral-0 text-left transition-colors duration-150 select-none',
+          'relative flex h-[44px] w-full items-center rounded-[12px]! border-[1.5px] bg-[var(--field-bg)] px-[13px] pr-9 text-left text-[13px] transition-colors duration-150 select-none focus:shadow-[0_0_0_3px_var(--glow-b10)]',
           open
-            ? 'rounded-t-[12px] border-input-border-active border-b-0'
-            : 'rounded-[12px] border-[var(--hairline)]',
-          error ? 'border-input-border-error!' : ''
+            ? 'border-[var(--blue)]! shadow-[0_0_0_3px_var(--glow-b10)]'
+            : error
+              ? 'border-[var(--danger)]!'
+              : 'border-[var(--hairline)]!'
         )}
         onClick={() => setOpen((o) => !o)}
         aria-expanded={open}
+        aria-label={selectedLabel ? `${label}, ${selectedLabel}` : label}
       >
-        <FloatLabel floated={isFloated}>{label}</FloatLabel>
-
-        <span className="flex-1 min-w-0 pl-5 pr-11 py-3">
+        <span className="flex-1 min-w-0">
           <TimeSlotTriggerValue isLoading={isLoading} selectedLabel={selectedLabel} />
         </span>
 
-        <span className="absolute right-5 top-1/2 -translate-y-1/2 flex items-center justify-center">
+        <span className="absolute right-4 top-1/2 -translate-y-1/2 flex items-center justify-center">
           <Arrow open={open} />
         </span>
       </button>
@@ -640,10 +641,25 @@ export const TimeSlotDropdown = ({
 };
 
 // ─── SlotBadge — duration display ──────────────────────────────────────────────
+// Matches the shared Datepicker / LabelDropdown field: label above the control,
+// h-44, field-bg, rounded-12, hairline border - so it lines up with Date/Type.
 export const SlotBadge = ({ label }: { label: string | null }) => (
-  <div className="relative flex items-center min-h-[46px] border-[1.5px] border-[var(--hairline)] rounded-[12px] bg-neutral-0 px-5 py-3">
-    <FloatLabel floated={Boolean(label)}>Slot duration</FloatLabel>
-    <span style={label ? text16R : { ...text16R, color: INPUT_PLACEHOLDER }}>{label ?? ''}</span>
+  <div className="flex w-full flex-col">
+    <span className="mb-1.5 block truncate text-[12px] font-semibold text-[var(--ink-soft)]">
+      Slot duration
+    </span>
+    <div className="relative flex h-[44px] w-full items-center rounded-[12px]! border-[1.5px] border-[var(--hairline)]! bg-[var(--field-bg)] px-[13px]">
+      <span
+        className="text-[13px]"
+        style={
+          label
+            ? { ...text16R, fontSize: 13 }
+            : { ...text16R, fontSize: 13, color: INPUT_PLACEHOLDER }
+        }
+      >
+        {label ?? ''}
+      </span>
+    </div>
   </div>
 );
 
@@ -758,7 +774,9 @@ export const AppointmentFormContent = ({
   onCancel,
   variant = 'modal',
 }: AppointmentFormContentProps) => (
-  <div className="relative">
+  // Rebind --field-bg to the warm surface so every field (Date/Time/Slot/Type and
+  // the person pickers) shares one warm token instead of the cool #fafafa default.
+  <div className="relative [--field-bg:var(--color-neutral-0)]">
     <div
       className={
         variant === 'sheet'
@@ -1373,12 +1391,12 @@ const useAddAppointmentCentralModalView = ({
       );
       if (mins > 0) return `${mins} mins`;
     }
-    if (formData.durationMinutes) return `${formData.durationMinutes} mins`;
-    // Before a time slot is chosen, fall back to the selected service's configured
-    // duration so the badge reflects the picked service instead of staying empty.
+    // Prefer the selected service's configured duration over a possibly-stale slot
+    // duration so switching service/speciality updates the badge immediately.
     // Display-only: booking still requires a real slot (durationMinutes validation).
     const serviceMins = Number(ServiceInfoData?.duration);
     if (Number.isFinite(serviceMins) && serviceMins > 0) return `${serviceMins} mins`;
+    if (formData.durationMinutes) return `${formData.durationMinutes} mins`;
     return null;
   }, [selectedSlot, formData.durationMinutes, ServiceInfoData?.duration]);
 

--- a/apps/frontend/src/app/features/appointments/services/workspaceAggregateService.ts
+++ b/apps/frontend/src/app/features/appointments/services/workspaceAggregateService.ts
@@ -222,6 +222,7 @@ const medicationTreatmentItemToPrescription = (
   const priceCents = Math.round((asNumber(priceSnapshot.unitPrice) ?? 0) * 100);
   // Treatment items carry `quantity` as a number, while PrescriptionItem.qty is a string.
   const quantity = asNumber(item.quantity) ?? asString(item.quantity);
+  const billed = asString(item.billingStatus) === 'BILLED';
   return {
     id: asString(item.id) ?? `prescription-${index + 1}`,
     medicineName: asString(item.name) ?? asString(productSnapshot.name) ?? 'Medication',
@@ -231,7 +232,9 @@ const medicationTreatmentItemToPrescription = (
     fulfillment: 'IN_HOUSE',
     priceCents,
     inventoryItemId: asString(item.productId) ?? asString(productSnapshot.inventoryItemId),
-    billed: asString(item.billingStatus) === 'BILLED',
+    billed,
+    // A billed medication is a finalized clinical record - never re-POST it on save.
+    finalized: billed,
   };
 };
 
@@ -266,6 +269,10 @@ const prescriptionLinesFromEnvelope = (item: Record<string, unknown>): Prescript
   const fulfillment = fulfillmentFrom(item.fulfillment ?? prescription.fulfillment);
   const priceCents =
     asNumber(item.priceCents) ?? Math.round((asNumber(priceSnapshot.unitPrice) ?? 0) * 100);
+  // A prescription persisted in a final clinical status (COMPLETED/SIGNED) can no longer be
+  // PATCHed back to draft - the backend rejects that with 409. Flag it so the save loop skips it.
+  const artifactStatus = asString(artifact.status);
+  const finalized = artifactStatus === 'COMPLETED' || artifactStatus === 'SIGNED';
 
   const lines = asArray(prescription.items);
   if (lines.length === 0) {
@@ -273,6 +280,7 @@ const prescriptionLinesFromEnvelope = (item: Record<string, unknown>): Prescript
     return [
       {
         id: baseId,
+        finalized,
         medicineName: fallbackName,
         strength: asString(item.strength) ?? asString(item.dosage),
         dosageForm: asString(item.dosageForm) ?? asString(metadata.dosageForm),
@@ -302,6 +310,7 @@ const prescriptionLinesFromEnvelope = (item: Record<string, unknown>): Prescript
     };
     return {
       id: asString(line.id) ?? `${baseId}-${lineIndex + 1}`,
+      finalized,
       medicineName: asString(line.medication) ?? metaStr('medicineName') ?? fallbackName,
       brand: metaStr('brand'),
       genericName: metaStr('genericName'),
@@ -369,7 +378,9 @@ const normalizePrescriptions = (
     );
     linkedIds.forEach((value) => sourceIds.add(value));
     prescriptionLinesFromEnvelope(item).forEach((line) => {
-      byId.set(line.id, { ...line, billed: isLineBilled(line, linkedIds) });
+      const billed = isLineBilled(line, linkedIds);
+      // A billed line is finalized too - it must never be re-POSTed on the next save.
+      byId.set(line.id, { ...line, billed, finalized: line.finalized || billed });
     });
   });
   treatmentItems.filter(isMedicationTreatmentItem).forEach((item, index) => {

--- a/apps/frontend/src/app/features/appointments/services/workspaceClinicalService.ts
+++ b/apps/frontend/src/app/features/appointments/services/workspaceClinicalService.ts
@@ -858,8 +858,12 @@ const prescriptionFromMedicationRequest = (
     return undefined;
   };
   const fulfillmentValue = str('fulfillment');
+  // A finalized prescription (COMPLETED/SIGNED) serializes to FHIR status 'active'; a draft stays
+  // 'draft'. Once finalized it can no longer be PATCHed to draft, so flag it to skip the re-save.
+  const finalized = resource.status === 'active';
   return {
     id: resource.id ?? `rx-${index + 1}`,
+    finalized,
     medicineName:
       str('medication', 'medicineName', 'name') ??
       resource.medicationCodeableConcept?.text ??

--- a/apps/frontend/src/app/features/appointments/types/workspace.ts
+++ b/apps/frontend/src/app/features/appointments/types/workspace.ts
@@ -280,6 +280,9 @@ export type PrescriptionItem = {
   billedAt?: string;
   /** Who finalized/charged the item (display only). */
   billedByName?: string;
+  /** True once the item is persisted as a finalized clinical record (status COMPLETED/SIGNED).
+   * A finalized row must not be re-POSTed on the next save - the backend rejects it with 409. */
+  finalized?: boolean;
 };
 
 /** Full employee + schedule task category set. */

--- a/apps/frontend/src/app/features/documents/components/CompanionDocumentUploadForm.tsx
+++ b/apps/frontend/src/app/features/documents/components/CompanionDocumentUploadForm.tsx
@@ -48,7 +48,9 @@ const CompanionDocumentUploadForm = ({
   const subcategoryOptions = getSubcategoryOptionsForCategory(formData.category);
 
   return (
-    <div className="flex flex-col gap-3">
+    // Rebind --field-bg to the warm surface locally so this form's dropdowns and
+    // inputs match the theme instead of the cool #fafafa default.
+    <div className="flex flex-col gap-3 [--field-bg:var(--color-neutral-0)]">
       <LabelDropdown
         placeholder="Category"
         onSelect={(option) => {

--- a/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
@@ -1122,7 +1122,16 @@ const RadIntegrationCard = ({
         Imaging and analyzer connectivity for diagnostic workflows in Yosemite Crew.
       </div>
       <div className={INTEGRATION_CARD_ACTIONS_CLASS}>
-        <Primary href="#" text="Coming soon" isDisabled className="px-4 whitespace-nowrap" />
+        <span
+          className="inline-flex min-h-10 items-center justify-center rounded-full! px-4 text-[13.5px] font-semibold whitespace-nowrap select-none"
+          style={{
+            background: 'var(--inset)',
+            color: 'var(--ink-muted)',
+            border: '1px solid var(--hairline)',
+          }}
+        >
+          Coming soon
+        </span>
       </div>
     </div>
   );
@@ -1161,7 +1170,16 @@ const VetnioIntegrationCard = ({
         discharge summaries, and client communications from consultations.
       </div>
       <div className={INTEGRATION_CARD_ACTIONS_CLASS}>
-        <Primary href="#" text="Coming soon" isDisabled className="px-4 whitespace-nowrap" />
+        <span
+          className="inline-flex min-h-10 items-center justify-center rounded-full! px-4 text-[13.5px] font-semibold whitespace-nowrap select-none"
+          style={{
+            background: 'var(--inset)',
+            color: 'var(--ink-muted)',
+            border: '1px solid var(--hairline)',
+          }}
+        >
+          Coming soon
+        </span>
       </div>
     </div>
   );
@@ -1200,7 +1218,16 @@ const QuickBooksIntegrationCard = ({
         QuickBooks Online.
       </div>
       <div className={INTEGRATION_CARD_ACTIONS_CLASS}>
-        <Primary href="#" text="Coming soon" isDisabled className="px-4 whitespace-nowrap" />
+        <span
+          className="inline-flex min-h-10 items-center justify-center rounded-full! px-4 text-[13.5px] font-semibold whitespace-nowrap select-none"
+          style={{
+            background: 'var(--inset)',
+            color: 'var(--ink-muted)',
+            border: '1px solid var(--hairline)',
+          }}
+        >
+          Coming soon
+        </span>
       </div>
     </div>
   );
@@ -1240,7 +1267,16 @@ const LaikaIntegrationCard = ({
         veterinary medical data.
       </div>
       <div className={INTEGRATION_CARD_ACTIONS_CLASS}>
-        <Primary href="#" text="Coming soon" isDisabled className="px-4 whitespace-nowrap" />
+        <span
+          className="inline-flex min-h-10 items-center justify-center rounded-full! px-4 text-[13.5px] font-semibold whitespace-nowrap select-none"
+          style={{
+            background: 'var(--inset)',
+            color: 'var(--ink-muted)',
+            border: '1px solid var(--hairline)',
+          }}
+        >
+          Coming soon
+        </span>
       </div>
     </div>
   );

--- a/apps/frontend/src/app/features/marketing/pages/ContactusPage/ContactusPage.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/ContactusPage/ContactusPage.tsx
@@ -11,6 +11,7 @@ import {
   IoBusinessOutline,
   IoAlertCircleOutline,
   IoArrowForwardOutline,
+  IoCheckmarkCircle,
 } from 'react-icons/io5';
 
 import {
@@ -1215,6 +1216,70 @@ function ComplaintFields({
   );
 }
 
+/* ---------- success confirmation (replaces the form after a send) ---------- */
+
+function ContactSuccess({ onReset }: Readonly<{ onReset: () => void }>) {
+  return (
+    <div style={{ animation: `ycHeroUp 1s ${EASE} 0.4s both` }}>
+      <div
+        role="status"
+        aria-live="polite"
+        style={{ ...FORM_STYLE, alignItems: 'center', textAlign: 'center', gap: 16 }}
+      >
+        <span
+          aria-hidden="true"
+          style={{
+            width: 56,
+            height: 56,
+            borderRadius: 9999,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            background: 'rgba(0,143,93,0.12)',
+            color: 'var(--success)',
+          }}
+        >
+          <IoCheckmarkCircle style={{ fontSize: 32 }} />
+        </span>
+        <h2
+          style={{
+            margin: 0,
+            fontFamily: NEWSREADER,
+            fontSize: 26,
+            fontWeight: 500,
+            letterSpacing: '-0.03em',
+            color: 'var(--ink)',
+          }}
+        >
+          Message sent
+        </h2>
+        <p
+          style={{
+            margin: 0,
+            maxWidth: 360,
+            fontSize: 15,
+            lineHeight: 1.55,
+            letterSpacing: '-0.01em',
+            color: 'var(--ink-muted)',
+          }}
+        >
+          Thanks. A person reads every message, and we&apos;ll reply to your email shortly. Check
+          your spam folder if you don&apos;t hear back.
+        </p>
+        <button
+          type="button"
+          onClick={onReset}
+          className="yc-btn-primary"
+          style={{ ...SUBMIT_BUTTON_STYLE, cursor: 'pointer' }}
+        >
+          Send another message
+          <IoArrowForwardOutline aria-hidden="true" style={{ fontSize: 17 }} />
+        </button>
+      </div>
+    </div>
+  );
+}
+
 /* ---------- right column: the contact form ---------- */
 
 interface ContactFormProps {
@@ -1300,6 +1365,7 @@ const ContactusPage = () => {
   const [phone, setPhone] = useState<string>('');
   const [message, setMessage] = useState('');
   const [submitting, setSubmitting] = useState<boolean>(false);
+  const [submitted, setSubmitted] = useState<boolean>(false);
   // Query Type
   const [errors, setErrors] = useState<{ [key: string]: string }>({});
   const [selectedQueryType, setSelectedQueryType] = useState<TicketCategory>('General Enquiry');
@@ -1376,6 +1442,9 @@ const ContactusPage = () => {
       const payload = buildPayload(formValues);
       await postData('/v1/contact-us/contact-web', payload);
       resetForm();
+      // Surface an explicit confirmation: without it the form just clears on success, which reads
+      // as "nothing happened / the form is broken".
+      setSubmitted(true);
     } catch (error) {
       const errorMessage = axios.isAxiosError(error)
         ? error.response?.data?.message || error.message
@@ -1413,13 +1482,17 @@ const ContactusPage = () => {
       <div data-grid-1-m style={HERO_GRID_STYLE}>
         <ContactHero />
 
-        <ContactForm
-          values={formValues}
-          setters={setters}
-          errors={errors}
-          confirm={{ selections: confirmSelections, onToggle: toggleConfirmOption }}
-          submit={submit}
-        />
+        {submitted ? (
+          <ContactSuccess onReset={() => setSubmitted(false)} />
+        ) : (
+          <ContactForm
+            values={formValues}
+            setters={setters}
+            errors={errors}
+            confirm={{ selections: confirmSelections, onToggle: toggleConfirmOption }}
+            submit={submit}
+          />
+        )}
       </div>
     </section>
   );

--- a/apps/frontend/src/app/features/marketing/pages/ContactusPage/ContactusPage.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/ContactusPage/ContactusPage.tsx
@@ -1218,51 +1218,53 @@ function ComplaintFields({
 
 /* ---------- success confirmation (replaces the form after a send) ---------- */
 
+const SUCCESS_CARD_STYLE: CSSProperties = {
+  ...FORM_STYLE,
+  alignItems: 'center',
+  textAlign: 'center',
+  gap: 16,
+};
+
+const SUCCESS_ICON_STYLE: CSSProperties = {
+  width: 56,
+  height: 56,
+  borderRadius: 9999,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  background: 'rgba(0,143,93,0.12)',
+  color: 'var(--success)',
+};
+
+const SUCCESS_TITLE_STYLE: CSSProperties = {
+  margin: 0,
+  fontFamily: NEWSREADER,
+  fontSize: 26,
+  fontWeight: 500,
+  letterSpacing: '-0.03em',
+  color: 'var(--ink)',
+};
+
+const SUCCESS_TEXT_STYLE: CSSProperties = {
+  margin: 0,
+  maxWidth: 360,
+  fontSize: 15,
+  lineHeight: 1.55,
+  letterSpacing: '-0.01em',
+  color: 'var(--ink-muted)',
+};
+
+const SUCCESS_BUTTON_STYLE: CSSProperties = { ...SUBMIT_BUTTON_STYLE, cursor: 'pointer' };
+
 function ContactSuccess({ onReset }: Readonly<{ onReset: () => void }>) {
   return (
     <div style={{ animation: `ycHeroUp 1s ${EASE} 0.4s both` }}>
-      <div
-        role="status"
-        aria-live="polite"
-        style={{ ...FORM_STYLE, alignItems: 'center', textAlign: 'center', gap: 16 }}
-      >
-        <span
-          aria-hidden="true"
-          style={{
-            width: 56,
-            height: 56,
-            borderRadius: 9999,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            background: 'rgba(0,143,93,0.12)',
-            color: 'var(--success)',
-          }}
-        >
+      <div role="status" aria-live="polite" style={SUCCESS_CARD_STYLE}>
+        <span aria-hidden="true" style={SUCCESS_ICON_STYLE}>
           <IoCheckmarkCircle style={{ fontSize: 32 }} />
         </span>
-        <h2
-          style={{
-            margin: 0,
-            fontFamily: NEWSREADER,
-            fontSize: 26,
-            fontWeight: 500,
-            letterSpacing: '-0.03em',
-            color: 'var(--ink)',
-          }}
-        >
-          Message sent
-        </h2>
-        <p
-          style={{
-            margin: 0,
-            maxWidth: 360,
-            fontSize: 15,
-            lineHeight: 1.55,
-            letterSpacing: '-0.01em',
-            color: 'var(--ink-muted)',
-          }}
-        >
+        <h2 style={SUCCESS_TITLE_STYLE}>Message sent</h2>
+        <p style={SUCCESS_TEXT_STYLE}>
           Thanks. A person reads every message, and we&apos;ll reply to your email shortly. Check
           your spam folder if you don&apos;t hear back.
         </p>
@@ -1270,7 +1272,7 @@ function ContactSuccess({ onReset }: Readonly<{ onReset: () => void }>) {
           type="button"
           onClick={onReset}
           className="yc-btn-primary"
-          style={{ ...SUBMIT_BUTTON_STYLE, cursor: 'pointer' }}
+          style={SUCCESS_BUTTON_STYLE}
         >
           Send another message
           <IoArrowForwardOutline aria-hidden="true" style={{ fontSize: 17 }} />

--- a/apps/frontend/src/app/features/marketing/pages/Home/Home.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/Home/Home.tsx
@@ -1213,7 +1213,7 @@ function PetBusinessesPillar() {
           linkText="Explore the practice suite"
         />
 
-        <Reveal delay={150} style={{ display: 'flex', justifyContent: 'center' }}>
+        <Reveal delay={150} style={{ display: 'flex', justifyContent: 'center', minWidth: 0 }}>
           <div
             className="yc-card-lift"
             style={{

--- a/apps/frontend/src/app/features/marketing/pages/PetBusinesses/PetBusinesses.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/PetBusinesses/PetBusinesses.tsx
@@ -445,7 +445,7 @@ function Hero() {
 
       <div style={HERO_CONTENT_STYLE}>
         <div ref={releaseRef} style={{ opacity: 0, animation: `ycHeroUp 0.9s ${EASE} 0.05s both` }}>
-          <ReleasePill variant="platform" label="Platform PIMS" version="v2.0 beta" />
+          <ReleasePill variant="platform" label="Platform PIMS" version="v2.1.0-beta" />
         </div>
 
         <HeroHeading />

--- a/apps/frontend/src/app/features/marketing/site/MarketingShell.tsx
+++ b/apps/frontend/src/app/features/marketing/site/MarketingShell.tsx
@@ -28,7 +28,9 @@ export function MarketingShell({
         id="main-content"
         tabIndex={-1}
         className="yc-public-page"
-        style={{ background: 'var(--page)' }}
+        // overflow-x: clip guards the public pages against any horizontal scroll
+        // without creating a scroll container (which would break sticky descendants).
+        style={{ background: 'var(--page)', overflowX: 'clip' }}
       >
         {children}
       </main>

--- a/apps/frontend/src/app/features/marketing/site/ReleasePill.tsx
+++ b/apps/frontend/src/app/features/marketing/site/ReleasePill.tsx
@@ -59,57 +59,60 @@ const PILL_STYLE: CSSProperties = {
   whiteSpace: 'nowrap',
 };
 
-function useReleaseFor(variant: ReleaseVariant): ReleaseInfo {
-  const latest = useLatestRelease();
-  const mobile = useMobileRelease();
-  const platform = usePlatformRelease();
-  if (variant === 'mobile') return mobile;
-  if (variant === 'latest') return latest;
-  // The platform pill resolves the newest PIMS-tagged release (its own tag/date/url), NOT the
-  // repo-wide "latest release" which is a desktop build.
-  if (variant === 'platform') return platform;
-  // static: no live release metadata.
-  return { tag: null, date: null, url: null };
+const EMPTY_RELEASE: ReleaseInfo = { tag: null, date: null, url: null };
+
+const Dot = () => (
+  <span
+    style={{ width: 7, height: 7, borderRadius: 9999, background: GREEN_DOT, flex: 'none' }}
+    aria-hidden="true"
+  />
+);
+
+const Divider = () => (
+  <span
+    style={{ width: 1, height: 12, background: 'var(--divider)', flex: 'none' }}
+    aria-hidden="true"
+  />
+);
+
+/** Home "Latest release" pill body. Takes an already-resolved release (no fetching here). */
+function LatestPillBody({
+  version,
+  href,
+  release,
+}: Readonly<{ version: string; href?: string; release: ReleaseInfo }>) {
+  const resolvedHref = release.url ?? href ?? `${GITHUB_REPO_URL}/releases`;
+  return (
+    <a href={resolvedHref} target="_blank" rel="noopener noreferrer" style={LATEST_PILL_STYLE}>
+      <Dot />
+      <span style={{ color: 'var(--ink-body)', fontWeight: 600 }}>Latest release</span>
+      <Divider />
+      <span>{release.tag ?? version}</span>
+      <IoLogoGithub
+        style={{ fontSize: 15, flex: 'none', color: 'var(--ink-faint)' }}
+        aria-hidden="true"
+      />
+    </a>
+  );
 }
 
-/**
- * Hero eyebrow release pill. The version string is fixed copy; the publish date and
- * link resolve live from GitHub. Green status dot follows the live-status convention.
- */
-export function ReleasePill({ variant, label, version, href }: Readonly<ReleasePillProps>) {
-  const release = useReleaseFor(variant);
+/** Platform / mobile / static pill body. Takes an already-resolved release (no fetching here). */
+function StandardPillBody({
+  variant,
+  label,
+  version,
+  href,
+  release,
+}: Readonly<{
+  variant: ReleaseVariant;
+  label?: string;
+  version: string;
+  href?: string;
+  release: ReleaseInfo;
+}>) {
   // When no specific release URL resolved, link to the releases index rather than
   // /releases/latest, so a platform/static pill never deep-links the desktop build.
   const resolvedHref = release.url ?? href ?? `${GITHUB_REPO_URL}/releases`;
-
-  const dot = (
-    <span
-      style={{ width: 7, height: 7, borderRadius: 9999, background: GREEN_DOT, flex: 'none' }}
-      aria-hidden="true"
-    />
-  );
-  const divider = (
-    <span
-      style={{ width: 1, height: 12, background: 'var(--divider)', flex: 'none' }}
-      aria-hidden="true"
-    />
-  );
-
-  if (variant === 'latest') {
-    return (
-      <a href={resolvedHref} target="_blank" rel="noopener noreferrer" style={LATEST_PILL_STYLE}>
-        {dot}
-        <span style={{ color: 'var(--ink-body)', fontWeight: 600 }}>Latest release</span>
-        {divider}
-        <span>{release.tag ?? version}</span>
-        <IoLogoGithub
-          style={{ fontSize: 15, flex: 'none', color: 'var(--ink-faint)' }}
-          aria-hidden="true"
-        />
-      </a>
-    );
-  }
-
   const isStatic = variant === 'static';
   // The live release tag is trusted for the mobile and platform pills (each hook filters to its
   // own tag prefix), so they show the real version + publish date. The hard-coded `version` stays
@@ -118,7 +121,7 @@ export function ReleasePill({ variant, label, version, href }: Readonly<ReleaseP
     variant === 'mobile' || variant === 'platform' ? (release.tag ?? version) : version;
   return (
     <a href={resolvedHref} target="_blank" rel="noopener noreferrer" style={PILL_STYLE}>
-      {dot}
+      <Dot />
       {label}
       <span
         style={{ width: 1, height: 12, background: 'var(--divider)', margin: '0 3px' }}
@@ -134,4 +137,37 @@ export function ReleasePill({ variant, label, version, href }: Readonly<ReleaseP
       />
     </a>
   );
+}
+
+// Per-variant wrappers each mount EXACTLY ONE release hook, so a pill only ever fires the single
+// GitHub request it needs. A `latest`/`mobile`/`static` pill never fetches the platform releases
+// list (and vice-versa), which keeps public marketing loads off the unauthenticated rate limit.
+function LatestPill({ version, href }: Readonly<ReleasePillProps>) {
+  return <LatestPillBody version={version} href={href} release={useLatestRelease()} />;
+}
+function MobilePill(props: Readonly<ReleasePillProps>) {
+  return <StandardPillBody {...props} release={useMobileRelease()} />;
+}
+function PlatformPill(props: Readonly<ReleasePillProps>) {
+  return <StandardPillBody {...props} release={usePlatformRelease()} />;
+}
+function StaticPill(props: Readonly<ReleasePillProps>) {
+  return <StandardPillBody {...props} release={EMPTY_RELEASE} />;
+}
+
+/**
+ * Hero eyebrow release pill. The version string is fixed copy; the publish date and link resolve
+ * live from GitHub. Dispatches to a per-variant pill so only the needed release endpoint is fetched.
+ */
+export function ReleasePill(props: Readonly<ReleasePillProps>) {
+  switch (props.variant) {
+    case 'latest':
+      return <LatestPill {...props} />;
+    case 'mobile':
+      return <MobilePill {...props} />;
+    case 'platform':
+      return <PlatformPill {...props} />;
+    default:
+      return <StaticPill {...props} />;
+  }
 }

--- a/apps/frontend/src/app/features/marketing/site/ReleasePill.tsx
+++ b/apps/frontend/src/app/features/marketing/site/ReleasePill.tsx
@@ -3,7 +3,12 @@
 import type { CSSProperties } from 'react';
 import { IoLogoGithub } from 'react-icons/io5';
 import { GITHUB_REPO_URL } from './assets';
-import { useLatestRelease, useMobileRelease, type ReleaseInfo } from './useGithubStats';
+import {
+  useLatestRelease,
+  useMobileRelease,
+  usePlatformRelease,
+  type ReleaseInfo,
+} from './useGithubStats';
 
 type ReleaseVariant = 'latest' | 'platform' | 'mobile' | 'static';
 
@@ -57,11 +62,13 @@ const PILL_STYLE: CSSProperties = {
 function useReleaseFor(variant: ReleaseVariant): ReleaseInfo {
   const latest = useLatestRelease();
   const mobile = useMobileRelease();
+  const platform = usePlatformRelease();
   if (variant === 'mobile') return mobile;
   if (variant === 'latest') return latest;
-  // platform + static: no live release metadata. The repo-wide "latest release" is a
-  // desktop build, so a platform pill must not borrow its tag, date, or URL (it would
-  // link to and date-stamp the desktop release while showing the platform version).
+  // The platform pill resolves the newest PIMS-tagged release (its own tag/date/url), NOT the
+  // repo-wide "latest release" which is a desktop build.
+  if (variant === 'platform') return platform;
+  // static: no live release metadata.
   return { tag: null, date: null, url: null };
 }
 
@@ -104,10 +111,11 @@ export function ReleasePill({ variant, label, version, href }: Readonly<ReleaseP
   }
 
   const isStatic = variant === 'static';
-  // The live release tag is only trusted for the mobile pill (useMobileRelease filters
-  // to mobile tags). The platform pill keeps its hard-coded copy, since the repo-wide
-  // "latest release" is a desktop build, not the platform version.
-  const shownVersion = variant === 'mobile' ? (release.tag ?? version) : version;
+  // The live release tag is trusted for the mobile and platform pills (each hook filters to its
+  // own tag prefix), so they show the real version + publish date. The hard-coded `version` stays
+  // as the fallback shown until the live release resolves (or if the fetch fails).
+  const shownVersion =
+    variant === 'mobile' || variant === 'platform' ? (release.tag ?? version) : version;
   return (
     <a href={resolvedHref} target="_blank" rel="noopener noreferrer" style={PILL_STYLE}>
       {dot}

--- a/apps/frontend/src/app/features/marketing/site/useGithubStats.ts
+++ b/apps/frontend/src/app/features/marketing/site/useGithubStats.ts
@@ -265,6 +265,53 @@ export function useLatestRelease(options?: LiveFetchOptions): ReleaseInfo {
   return release;
 }
 
+/**
+ * Newest platform (PIMS) GitHub release. Used by the Pet Businesses hero pill. The repo's
+ * `/releases/latest` is a desktop build, so the platform pill must not borrow it; instead pick the
+ * newest release whose TAG is a platform tag (`pims-`/`pms-`), which carries the real PIMS version
+ * and publish date and links to that release.
+ */
+export function usePlatformRelease(): ReleaseInfo {
+  const cacheKey = 'yc_rel_pims_v1';
+  const [release, setRelease] = useState<ReleaseInfo>(EMPTY_RELEASE);
+
+  useEffect(() => {
+    let active = true;
+    const cached = getJsonStorageItem<ReleaseInfo>('session', cacheKey);
+    if (cached) setRelease(cached);
+    void (async () => {
+      const list = (await fetchJson(
+        `${GITHUB_API_REPO}/releases?per_page=30`,
+        'application/vnd.github+json'
+      )) as Array<{
+        tag_name?: string;
+        published_at?: string;
+        html_url?: string;
+      }> | null;
+      if (!active || !Array.isArray(list)) return;
+      // Match on the release TAG only (not the free-text title): the platform app ships under
+      // `pims-`/`pms-` tags, so a desktop or backend release whose notes mention "PIMS" is not
+      // mistaken for the platform release. The list is newest-first, so the first match is latest.
+      const isPlatformTag = (x: { tag_name?: string }) => /^(pims|pms)[-_]/i.test(x.tag_name ?? '');
+      const platform = list.find(isPlatformTag);
+      if (!platform?.html_url) return;
+      const next: ReleaseInfo = {
+        // tag_name only: the release `name` is a free-form title, not a version.
+        tag: (platform.tag_name ?? '').replace(/^[a-z]+-(?=v?\d)/i, '') || null,
+        date: formatReleaseDate(platform.published_at),
+        url: platform.html_url,
+      };
+      setRelease(next);
+      setJsonStorageItem('session', cacheKey, next);
+    })();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return release;
+}
+
 /** Newest mobile-tagged GitHub release. Used by the Pet Parents hero pill. */
 export function useMobileRelease(): ReleaseInfo {
   const cacheKey = 'yc_rel_mobile_v1';

--- a/apps/frontend/src/app/features/marketing/site/useGithubStats.ts
+++ b/apps/frontend/src/app/features/marketing/site/useGithubStats.ts
@@ -223,6 +223,60 @@ const formatReleaseDate = (iso?: string): string | null => {
   }
 };
 
+type RawRelease = { tag_name?: string; published_at?: string; html_url?: string };
+
+/**
+ * Shape a raw GitHub release into ReleaseInfo. The version comes from tag_name (the git tag),
+ * never the release `name` (a free-form title): strip a leading area prefix (backend-/mobile-/
+ * pims-/...) so only the version remains.
+ */
+const toReleaseInfo = (raw: RawRelease): ReleaseInfo => ({
+  tag: (raw.tag_name ?? '').replace(/^[a-z]+-(?=v?\d)/i, '') || null,
+  date: formatReleaseDate(raw.published_at),
+  url: raw.html_url ?? null,
+});
+
+// Tag predicates (module-level so the reference stays stable across renders, keeping the
+// useTaggedReleaseFromList effect from re-firing). Inputs are already lower-cased.
+const matchesMobileTag = (tag: string): boolean => /mobile|ios|android|app-v|expo/.test(tag);
+const matchesPlatformTag = (tag: string): boolean => /^(pims|pms)[-_]/.test(tag);
+
+/**
+ * Newest release from the repo's releases list whose TAG matches `matchesTag`. Matching on the tag
+ * (not the free-text title) keeps e.g. a backend release that merely mentions "mobile" from being
+ * picked; the list is newest-first, so the first match is the latest. Shared by useMobileRelease
+ * and usePlatformRelease, which differ only in their cache key and tag predicate.
+ */
+const useTaggedReleaseFromList = (
+  cacheKey: string,
+  matchesTag: (tag: string) => boolean
+): ReleaseInfo => {
+  const [release, setRelease] = useState<ReleaseInfo>(EMPTY_RELEASE);
+
+  useEffect(() => {
+    let active = true;
+    const cached = getJsonStorageItem<ReleaseInfo>('session', cacheKey);
+    if (cached) setRelease(cached);
+    void (async () => {
+      const list = (await fetchJson(
+        `${GITHUB_API_REPO}/releases?per_page=30`,
+        'application/vnd.github+json'
+      )) as RawRelease[] | null;
+      if (!active || !Array.isArray(list)) return;
+      const match = list.find((entry) => matchesTag((entry.tag_name ?? '').toLowerCase()));
+      if (!match?.html_url) return;
+      const next = toReleaseInfo(match);
+      setRelease(next);
+      setJsonStorageItem('session', cacheKey, next);
+    })();
+    return () => {
+      active = false;
+    };
+  }, [cacheKey, matchesTag]);
+
+  return release;
+};
+
 /**
  * Latest GitHub release (platform). Used by the Home chip and Pet Businesses hero
  * pill (cached) and the Insights latest-release card. Pass `{ live: true }` on the
@@ -245,15 +299,9 @@ export function useLatestRelease(options?: LiveFetchOptions): ReleaseInfo {
       const json = (await fetchJson(
         `${GITHUB_API_REPO}/releases/latest`,
         'application/vnd.github+json'
-      )) as { tag_name?: string; published_at?: string; html_url?: string } | null;
+      )) as RawRelease | null;
       if (!active || !json?.tag_name) return;
-      const next: ReleaseInfo = {
-        // Derive the version from tag_name (the git tag), never the release `name`:
-        // GitHub release names are free-form titles and would land in the version slot.
-        tag: json.tag_name.replace(/^[a-z]+-(?=v?\d)/i, ''),
-        date: formatReleaseDate(json.published_at),
-        url: json.html_url ?? null,
-      };
+      const next = toReleaseInfo(json);
       setRelease(next);
       setJsonStorageItem('session', cacheKey, next);
     })();
@@ -272,85 +320,10 @@ export function useLatestRelease(options?: LiveFetchOptions): ReleaseInfo {
  * and publish date and links to that release.
  */
 export function usePlatformRelease(): ReleaseInfo {
-  const cacheKey = 'yc_rel_pims_v1';
-  const [release, setRelease] = useState<ReleaseInfo>(EMPTY_RELEASE);
-
-  useEffect(() => {
-    let active = true;
-    const cached = getJsonStorageItem<ReleaseInfo>('session', cacheKey);
-    if (cached) setRelease(cached);
-    void (async () => {
-      const list = (await fetchJson(
-        `${GITHUB_API_REPO}/releases?per_page=30`,
-        'application/vnd.github+json'
-      )) as Array<{
-        tag_name?: string;
-        published_at?: string;
-        html_url?: string;
-      }> | null;
-      if (!active || !Array.isArray(list)) return;
-      // Match on the release TAG only (not the free-text title): the platform app ships under
-      // `pims-`/`pms-` tags, so a desktop or backend release whose notes mention "PIMS" is not
-      // mistaken for the platform release. The list is newest-first, so the first match is latest.
-      const isPlatformTag = (x: { tag_name?: string }) => /^(pims|pms)[-_]/i.test(x.tag_name ?? '');
-      const platform = list.find(isPlatformTag);
-      if (!platform?.html_url) return;
-      const next: ReleaseInfo = {
-        // tag_name only: the release `name` is a free-form title, not a version.
-        tag: (platform.tag_name ?? '').replace(/^[a-z]+-(?=v?\d)/i, '') || null,
-        date: formatReleaseDate(platform.published_at),
-        url: platform.html_url,
-      };
-      setRelease(next);
-      setJsonStorageItem('session', cacheKey, next);
-    })();
-    return () => {
-      active = false;
-    };
-  }, []);
-
-  return release;
+  return useTaggedReleaseFromList('yc_rel_pims_v1', matchesPlatformTag);
 }
 
 /** Newest mobile-tagged GitHub release. Used by the Pet Parents hero pill. */
 export function useMobileRelease(): ReleaseInfo {
-  const cacheKey = 'yc_rel_mobile_v1';
-  const [release, setRelease] = useState<ReleaseInfo>(EMPTY_RELEASE);
-
-  useEffect(() => {
-    let active = true;
-    const cached = getJsonStorageItem<ReleaseInfo>('session', cacheKey);
-    if (cached) setRelease(cached);
-    void (async () => {
-      const list = (await fetchJson(
-        `${GITHUB_API_REPO}/releases?per_page=30`,
-        'application/vnd.github+json'
-      )) as Array<{
-        tag_name?: string;
-        published_at?: string;
-        html_url?: string;
-      }> | null;
-      if (!active || !Array.isArray(list)) return;
-      // Match on the release TAG only (not the free-text title), so a platform or
-      // backend release whose notes merely mention "mobile" is not mistaken for the
-      // mobile app release.
-      const isMobileTag = (x: { tag_name?: string }) =>
-        /mobile|ios|android|app-v|expo/.test((x.tag_name ?? '').toLowerCase());
-      const mobile = list.find(isMobileTag);
-      if (!mobile?.html_url) return;
-      const next: ReleaseInfo = {
-        // tag_name only: the release `name` is a free-form title, not a version.
-        tag: (mobile.tag_name ?? '').replace(/^[a-z]+-(?=v?\d)/i, '') || null,
-        date: formatReleaseDate(mobile.published_at),
-        url: mobile.html_url,
-      };
-      setRelease(next);
-      setJsonStorageItem('session', cacheKey, next);
-    })();
-    return () => {
-      active = false;
-    };
-  }, []);
-
-  return release;
+  return useTaggedReleaseFromList('yc_rel_mobile_v1', matchesMobileTag);
 }

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/PhoneOrganization.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/PhoneOrganization.tsx
@@ -14,6 +14,7 @@ import { Organisation, Service } from '@yosemite-crew/types';
 import { useTeamForPrimaryOrg } from '@/app/hooks/useTeam';
 import { Team as TeamProp } from '@/app/features/organization/types/team';
 import { useSpecialitiesWithServiceNamesForPrimaryOrg } from '@/app/hooks/useSpecialities';
+import { loadServicesForOrg } from '@/app/features/organization/services/serviceService';
 import { SpecialityWeb } from '@/app/features/organization/types/speciality';
 import { useSubscriptionForPrimaryOrg } from '@/app/hooks/useBilling';
 import { usePermissions } from '@/app/hooks/usePermissions';
@@ -257,6 +258,15 @@ const PhoneOrganization = ({ primaryOrg }: PhoneOrganizationProps) => {
   const [addPopup, setAddPopup] = useState(false);
   const [viewPopup, setViewPopup] = useState(false);
   const [activeTeam, setActiveTeam] = useState<TeamProp | null>(teams[0] ?? null);
+
+  // The desktop Specialities panel loads the catalog on mount; the phone screen
+  // must too, or the specialities accordion has no services to reveal when tapped.
+  const primaryOrgId = String(primaryOrg._id);
+  useEffect(() => {
+    loadServicesForOrg(primaryOrgId).catch(() => {
+      // Leave the accordion bodies empty if the load fails; the list still renders.
+    });
+  }, [primaryOrgId]);
 
   useEffect(() => {
     setActiveTeam((prev) => {

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/PhoneOrganization.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/PhoneOrganization.tsx
@@ -261,7 +261,9 @@ const PhoneOrganization = ({ primaryOrg }: PhoneOrganizationProps) => {
 
   // The desktop Specialities panel loads the catalog on mount; the phone screen
   // must too, or the specialities accordion has no services to reveal when tapped.
-  const primaryOrgId = String(primaryOrg._id);
+  // Keep a missing id as undefined (never the string "undefined") so loadServicesForOrg can fall
+  // back to the store's primary org id / skip, instead of fetching /organisation/undefined.
+  const primaryOrgId = primaryOrg._id ? String(primaryOrg._id) : undefined;
   useEffect(() => {
     loadServicesForOrg(primaryOrgId).catch(() => {
       // Leave the accordion bodies empty if the load fails; the list still renders.

--- a/apps/frontend/src/app/hooks/useAppointmentForm.ts
+++ b/apps/frontend/src/app/hooks/useAppointmentForm.ts
@@ -1226,6 +1226,8 @@ export const useAppointmentForm = (options: UseAppointmentFormOptions = {}) => {
       setFormData((prev) => ({
         ...prev,
         appointmentKind,
+        // Clear any slot-derived duration so the badge follows the new speciality.
+        durationMinutes: 0,
         appointmentType: {
           id: '',
           name: '',
@@ -1257,6 +1259,8 @@ export const useAppointmentForm = (options: UseAppointmentFormOptions = {}) => {
       setFormData((prev) => ({
         ...prev,
         appointmentKind: serviceAppointmentKind,
+        // Clear any slot-derived duration so the badge follows the new service.
+        durationMinutes: 0,
         appointmentType: {
           id: option.value,
           name: option.label,

--- a/apps/frontend/src/app/hooks/useAppointmentForm.ts
+++ b/apps/frontend/src/app/hooks/useAppointmentForm.ts
@@ -1259,8 +1259,11 @@ export const useAppointmentForm = (options: UseAppointmentFormOptions = {}) => {
       setFormData((prev) => ({
         ...prev,
         appointmentKind: serviceAppointmentKind,
-        // Clear any slot-derived duration so the badge follows the new service.
-        durationMinutes: 0,
+        // Clear any slot-derived duration so the badge follows the new service - but only when the
+        // service actually changes. Re-selecting the same service does not re-run the slot-load
+        // effect, so zeroing here would strand durationMinutes at 0 and block booking with
+        // "Please select a duration".
+        durationMinutes: prev.appointmentType?.id === option.value ? prev.durationMinutes : 0,
         appointmentType: {
           id: option.value,
           name: option.label,

--- a/apps/frontend/src/app/lib/timezone.ts
+++ b/apps/frontend/src/app/lib/timezone.ts
@@ -440,14 +440,18 @@ const getOffsetMinutesForTimeZoneAtInstant = (timeZone: string, instant: Date): 
   return sign * (hours * 60 + minutes);
 };
 
-export const buildDateInPreferredTimeZone = (calendarDay: Date, minuteOfDay: number): Date => {
-  const { year, month, day } = getDatePartsInPreferredTimeZone(calendarDay);
-  const clampedMinute = Math.max(0, Math.min(24 * 60 - 1, Math.round(minuteOfDay)));
-  const hour = Math.floor(clampedMinute / 60);
-  const minute = clampedMinute % 60;
+// Resolve the UTC instant for a wall-clock time (year/month/day + hour/minute) in a given zone by
+// looking up the zone's offset for that local time. A short fixpoint settles DST transitions where
+// the offset used to place the instant differs from the offset at the resulting instant.
+const zonedWallClockToInstant = (
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+  timeZone: string
+): Date => {
   const naiveUtcMs = Date.UTC(year, month - 1, day, hour, minute, 0, 0);
-  const timeZone = getPreferredTimeZone();
-
   let instant = new Date(naiveUtcMs);
   for (let attempt = 0; attempt < 3; attempt++) {
     const offsetMinutes = getOffsetMinutesForTimeZoneAtInstant(timeZone, instant);
@@ -458,8 +462,23 @@ export const buildDateInPreferredTimeZone = (calendarDay: Date, minuteOfDay: num
     }
     instant = nextInstant;
   }
-
   return instant;
 };
+
+export const buildDateInPreferredTimeZone = (calendarDay: Date, minuteOfDay: number): Date => {
+  const { year, month, day } = getDatePartsInPreferredTimeZone(calendarDay);
+  const clampedMinute = Math.max(0, Math.min(24 * 60 - 1, Math.round(minuteOfDay)));
+  const hour = Math.floor(clampedMinute / 60);
+  const minute = clampedMinute % 60;
+  return zonedWallClockToInstant(year, month, day, hour, minute, getPreferredTimeZone());
+};
+
+// Build the instant that represents (year, month, day) at LOCAL NOON in the preferred time zone.
+// Anchoring at local noon - never at UTC noon - keeps the calendar-day round-trip stable through
+// getDateKeyInPreferredTimeZone in every zone, including those 12+ hours ahead of UTC (e.g.
+// Pacific/Auckland at UTC+12/+13), where a UTC-noon anchor resolves to the following calendar day.
+// Noon sits far from any day boundary, so a DST shift can never move it onto a neighbouring date.
+export const buildPreferredTimeZoneDayInstant = (year: number, month: number, day: number): Date =>
+  zonedWallClockToInstant(year, month, day, 12, 0, getPreferredTimeZone());
 
 export { TIMEZONE_STORAGE_KEY, DEFAULT_TIMEZONE };

--- a/apps/frontend/src/app/lib/timezone.ts
+++ b/apps/frontend/src/app/lib/timezone.ts
@@ -421,7 +421,14 @@ export const getHourInPreferredTimeZone = (value: Date): number => {
   return getDatePartsInPreferredTimeZone(value).hour;
 };
 
-const getOffsetMinutesForTimeZoneAtInstant = (timeZone: string, instant: Date): number => {
+// Intl.DateTimeFormat construction is the expensive part of an offset lookup, and the offset
+// helper is called in tight loops (e.g. once per cell when building the phone month grid). The
+// formatter is immutable and reusable for any instant, so cache one per timezone.
+const offsetFormatterByTimeZone = new Map<string, Intl.DateTimeFormat>();
+
+const getOffsetFormatter = (timeZone: string): Intl.DateTimeFormat => {
+  const cached = offsetFormatterByTimeZone.get(timeZone);
+  if (cached) return cached;
   const formatter = new Intl.DateTimeFormat('en-US', {
     timeZone,
     timeZoneName: 'shortOffset',
@@ -429,7 +436,12 @@ const getOffsetMinutesForTimeZoneAtInstant = (timeZone: string, instant: Date): 
     minute: '2-digit',
     hourCycle: 'h23',
   });
-  const offsetLabel = formatter
+  offsetFormatterByTimeZone.set(timeZone, formatter);
+  return formatter;
+};
+
+const getOffsetMinutesForTimeZoneAtInstant = (timeZone: string, instant: Date): number => {
+  const offsetLabel = getOffsetFormatter(timeZone)
     .formatToParts(instant)
     .find((part) => part.type === 'timeZoneName')?.value;
   const match = /GMT([+-])(\d{1,2})(?::?(\d{2}))?/.exec(offsetLabel ?? '');

--- a/apps/frontend/src/app/ui/layout/PhoneShell/PhoneShell.css
+++ b/apps/frontend/src/app/ui/layout/PhoneShell/PhoneShell.css
@@ -251,7 +251,7 @@
      --screen icon (--blue-text) + label + context line. */
   .yc-phone-more-grid {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
     gap: 8px;
     margin: 0;
     padding: 0;

--- a/apps/frontend/src/app/ui/overlays/Sheet/Sheet.css
+++ b/apps/frontend/src/app/ui/overlays/Sheet/Sheet.css
@@ -61,6 +61,13 @@
     }
   }
 
+  /* Floating field labels straddle the field's top border, so inside a sheet the
+     protruding half must match the sheet surface (not the desktop --neutral-0
+     panel) or it shows as a lighter cream patch. */
+  .yc-phone-sheet .yc-float-label {
+    background: var(--glass-93);
+  }
+
   /* The grabber, title row and footer are fixed furniture: `flex: none` keeps
      the flex column from shrinking them (a 44x5 grabber squashes to 2px
      otherwise) so the body is the only region that gives, and scrolls. */
@@ -140,6 +147,9 @@
 
   dialog.yc-modal-sheet-closed {
     transform: translateY(100%);
+    /* Parked off-screen: drop the upward float shadow so it stops bleeding a
+       dark band up into the page above (seen behind e.g. the Settings screen). */
+    box-shadow: none;
   }
 
   /* `variant="drawer"` on a phone: full-screen, per "drawers go full-screen".


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [ ] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

> These come from a mobile QA pass on the deployed dev build (no pre-filed issues); each item is described below. Follow-up to #1961.

## What is the current behavior?

A phone QA pass surfaced eight UI defects:

1. The public marketing home scrolls horizontally on a ~390px phone (the hero is shifted with an empty gutter on the right).
2. The New-appointment sheet's floating Patient/Client labels show a lighter cream patch behind the text.
3. The medical-records "Upload records" form renders its fields in the old cool-white style, out of place on the warm theme.
4. On the mobile Schedule, the month calendar day selection misbehaves compared to the week view.
5. The "More" menu's two-column grid overflows the sheet, clipping the right column's subtitles.
6. The Settings page shows a dark shade band above the bottom tab bar.
7. The Organization "Specialities & services" accordion reveals nothing when a row is tapped.
8. Coming-soon integration cards render their action as a heavy gray disabled pill (old design).

## What is the new behavior?

1. Add `minWidth: 0` to the practice-card grid item (its ~476px min-content was forcing the collapsed track past the viewport), plus an `overflow-x: clip` guard on the public shell. Verified: document overflow 110px to 0 with no clipping.
2. Tag the floating label `yc-float-label` and, inside `.yc-phone-sheet`, paint it with the sheet surface (`var(--glass-93)`) so it blends; desktop keeps `neutral-0`.
3. Rebind `--field-bg` to the warm surface locally on the upload form so all its inputs/dropdowns warm up, with zero blast radius on shared primitives.
4. Anchor the month cell dates and the "Open day" handoff to noon UTC so the preferred-timezone date key round-trips (a local-midnight date could resolve to the previous day).
5. Use `minmax(0, 1fr)` columns so the two tiles split 50/50 and long subtitles ellipsize instead of blowing out the track.
6. Drop the float shadow on the parked (closed) bottom sheet so it stops bleeding a dark band into the page above.
7. Load the service catalog on mount in `PhoneOrganization`, mirroring the desktop panel, so the accordion bodies have services.
8. Replace the disabled Primary with a lightweight muted ghost pill matching the card design.

All changes are scoped to `apps/frontend`. tsc, lint, and the touched-file test suites pass; new/changed logic keeps its coverage.

## Related Issue(s)

N/A - direct QA feedback on the deployed dev build (follow-up to #1961).
