### PR TITLE
ci(database): gate prisma migrations on a real postgres in CI

### DIFF
--- a/.github/workflows/_migration.yaml
+++ b/.github/workflows/_migration.yaml
@@ -1,0 +1,131 @@
+name: Migration
+
+# Reusable migration stage: prove that every Prisma migration applies cleanly to
+# a real Postgres, that the schema is valid, and that schema.prisma and the
+# migration history have not drifted apart.
+#
+# Why this stage exists: before it, migration SQL in this repository was never
+# executed by CI even once. There was no Postgres service, no `prisma validate`,
+# no `prisma migrate deploy` and no drift check in any workflow, in any husky
+# hook, or in any Dockerfile - `.husky/pre-push` runs lint and type-check only,
+# and there is no backend CD workflow. A schema change therefore merged green
+# and first ran when an operator applied it by hand against a live database.
+#
+# The drift check is the part that earns its keep: a `migrate diff` taken today
+# emits `DROP TABLE` for four live control-plane tables (see CONTROL_PLANE_TABLES
+# below), and nothing in the repository would have caught that before an
+# operator ran it.
+
+on:
+  workflow_call: {}
+
+permissions:
+  contents: read
+
+env:
+  # The four shared control-plane tables live in `public` and are deliberately
+  # NOT part of this datamodel. `packages/database/prisma/schema.prisma` models
+  # tenant-scoped operational data (one schema per tenant, see
+  # `packages/database/src/tenant.ts`), while Enterprise / Tenant /
+  # EnterpriseMembership / TenantMembership are shared across tenants, created by
+  # `20260607120000_tenant_control_plane`, and read through raw SQL rather than
+  # the generated client - `prisma.enterprise` and `prisma.tenant` have no
+  # callers anywhere in the repository.
+  #
+  # `migrate diff` cannot know that, so it reports them as droppable on every
+  # run. They are allow-listed here so the drift check still fails on every
+  # *other* difference. Do not "fix" this by declaring them in schema.prisma:
+  # that would replicate the control plane into every tenant schema.
+  #
+  # Written as one alternation rather than a word-split list on purpose: a
+  # `for t in $VAR` loop silently iterates once over the whole string in shells
+  # that do not word-split unquoted expansions, which would disable the
+  # allow-list without failing.
+  CONTROL_PLANE_TABLE_PATTERN: '"(Enterprise|Tenant|EnterpriseMembership|TenantMembership)"'
+
+jobs:
+  migrate:
+    name: Prisma migrations
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          # Not a secret: this database is a service container created for this
+          # job and destroyed with it, reachable only on the runner's localhost.
+          # Derived from the run id so no credential literal sits in the repo.
+          POSTGRES_PASSWORD: ${{ github.run_id }}
+          POSTGRES_DB: yosemite_ci
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://postgres:${{ github.run_id }}@localhost:5432/yosemite_ci?schema=public
+      DIRECT_URL: postgresql://postgres:${{ github.run_id }}@localhost:5432/yosemite_ci?schema=public
+      SHADOW_DATABASE_URL: postgresql://postgres:${{ github.run_id }}@localhost:5432/yosemite_shadow?schema=public
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      # `migrate diff --from-migrations` replays the whole history into a
+      # throwaway database, so it needs one that is not the target.
+      - name: Create shadow database
+        env:
+          PGPASSWORD: ${{ github.run_id }}
+        run: psql -h localhost -U postgres -d postgres -c 'CREATE DATABASE yosemite_shadow;'
+
+      - name: Validate schema
+        run: pnpm --filter @yosemite-crew/database exec prisma validate
+
+      # The gate that did not exist: prove the migration history applies, in
+      # order, to an empty database.
+      - name: Apply migrations
+        run: pnpm --filter @yosemite-crew/database run prisma:deploy
+
+      - name: Check schema and migrations have not drifted
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          pnpm --filter @yosemite-crew/database exec prisma migrate diff \
+            --from-migrations ./prisma/migrations \
+            --to-schema-datamodel ./prisma/schema.prisma \
+            --shadow-database-url "$SHADOW_DATABASE_URL" \
+            --script > drift.sql
+
+          # Drop the allow-listed control-plane statements, then SQL comments and
+          # blank lines. Anything still standing is real drift: either
+          # schema.prisma changed without a migration, or a migration changed
+          # without the schema.
+          #
+          # Both greps are guarded with `|| true`: grep exits 1 when it prints
+          # nothing, and "prints nothing" is the healthy outcome here, so without
+          # the guard `set -e` would fail the step precisely when there is no
+          # drift.
+          grep -Ev "$CONTROL_PLANE_TABLE_PATTERN" drift.sql > drift.filtered || true
+          remaining=$(grep -Ev '^[[:space:]]*(--|$)' drift.filtered || true)
+
+          if [ -n "$remaining" ]; then
+            echo "::error::schema.prisma and prisma/migrations have drifted apart."
+            echo "Generate a migration for the schema change, or reconcile the schema with the migration."
+            echo "--- unaccounted-for drift ---"
+            echo "$remaining"
+            exit 1
+          fi
+
+          echo "No drift: schema.prisma matches the migration history."

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,6 +43,17 @@ jobs:
     with:
       matrix: ${{ needs.core.outputs.matrix }}
 
+  migration:
+    needs: core
+    # Only when the database workspace is affected - that is what carries
+    # schema.prisma, prisma/migrations and the tenant helpers. No other
+    # workspace can change what `prisma migrate deploy` does, so this stays off
+    # the critical path for the majority of pull requests.
+    if: >
+      needs.core.outputs.has-any == 'true' &&
+      contains(needs.core.outputs.matrix, '@yosemite-crew/database')
+    uses: ./.github/workflows/_migration.yaml
+
   sonar:
     needs: [core, test]
     # Gated on the test stage's own output rather than on the affected booleans,
@@ -92,7 +103,7 @@ jobs:
     # its behaviour can be observed before it is made required; the runbook in
     # docs/ci/required-checks-migration.md covers that switchover.
     if: always()
-    needs: [core, test, sonar, frontend-quality]
+    needs: [core, test, migration, sonar, frontend-quality]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/packages/database/prisma/migrations/20260726100000_reconcile_schema_drift/migration.sql
+++ b/packages/database/prisma/migrations/20260726100000_reconcile_schema_drift/migration.sql
@@ -1,0 +1,50 @@
+-- Reconcile schema.prisma with the migration history.
+--
+-- These changes were made to schema.prisma without a matching migration, so a
+-- database built by replaying prisma/migrations did not match the schema the
+-- client is generated from. Deployed databases were updated out of band, which
+-- is why nothing failed in practice. Every statement here is written to be a
+-- no-op against a database that already has the change, so this applies cleanly
+-- to both a fresh replay and an already-drifted deployment.
+
+-- AlterEnum
+-- RenderedDocumentSourceKind gained TASK_SCHEDULE. This is the one statement
+-- with runtime consequences: without it, writing that variant against a
+-- migration-built database fails.
+ALTER TYPE "RenderedDocumentSourceKind" ADD VALUE IF NOT EXISTS 'TASK_SCHEDULE';
+
+-- AlterTable
+-- updatedAt is maintained by Prisma's @updatedAt, so the schema declares no
+-- database-level default. Earlier migrations left one behind.
+ALTER TABLE "Payment" ALTER COLUMN "updatedAt" DROP DEFAULT;
+ALTER TABLE "PaymentAttempt" ALTER COLUMN "updatedAt" DROP DEFAULT;
+ALTER TABLE "Refund" ALTER COLUMN "updatedAt" DROP DEFAULT;
+ALTER TABLE "WorkspaceDocumentPacket" ALTER COLUMN "updatedAt" DROP DEFAULT;
+
+-- DropIndex
+-- The tax-provider index moved from InvoiceTaxSnapshot to Invoice.
+DROP INDEX IF EXISTS "InvoiceTaxSnapshot_provider_idx";
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "Invoice_taxProvider_idx" ON "Invoice"("taxProvider");
+
+-- RenameIndex
+-- Postgres truncates identifiers at 63 characters, so the generated name was
+-- cut mid-word; the schema names it explicitly. Guarded because a deployment
+-- that already carries the shorter name has nothing to rename.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_class
+    WHERE relkind = 'i'
+      AND relname = 'PrescriptionDispenseRequest_prescriptionId_status_requestedAt_i'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM pg_class
+    WHERE relkind = 'i'
+      AND relname = 'PrescriptionDispenseRequest_prescriptionId_status_requested_idx'
+  ) THEN
+    ALTER INDEX "PrescriptionDispenseRequest_prescriptionId_status_requestedAt_i"
+      RENAME TO "PrescriptionDispenseRequest_prescriptionId_status_requested_idx";
+  END IF;
+END
+$$;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [ ] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

Migration SQL in this repository is never executed by CI, not even once, before an operator applies it.

Verified on `dev`: `grep -rniE "postgres|migrate deploy|prisma validate|shadow" .github/workflows/` returns zero hits. There is no Postgres service container in any workflow, `prisma validate` / `prisma migrate deploy` / `prisma migrate diff` appear in no workflow, `.husky/pre-push` runs lint and type-check only, no Dockerfile runs them, and there is no backend CD workflow. `packages/database`'s entire test script is `node --test dist/tenant.test.js`.

The practical effect is that a schema change merges green and first runs by hand against a live database.

This is not hypothetical. A `prisma migrate diff` taken on `dev` today emits `DROP TABLE` for four live tables - `Enterprise`, `Tenant`, `EnterpriseMembership`, `TenantMembership` - and nothing in the repository would catch it.

## What is the new behavior?

Adds a reusable `_migration.yaml` stage, called from the CI orchestrator when the `@yosemite-crew/database` workspace is affected. It stands up Postgres 16 as a service and:

1. runs `prisma validate`
2. runs `prisma migrate deploy` against an empty database, proving the whole migration history applies in order
3. diffs the migration history against `schema.prisma` and fails on any drift

### On the four control-plane tables

They are allow-listed, deliberately, rather than "fixed" by declaring them in `schema.prisma`.

`packages/database/prisma/schema.prisma` models tenant-scoped operational data, one schema per tenant (`packages/database/src/tenant.ts`). The four tables are shared control plane, live in `public`, are created by `20260607120000_tenant_control_plane`, and are read through raw SQL - `prisma.enterprise` and `prisma.tenant` have no callers anywhere in the repository. Declaring them in the datamodel would replicate the control plane into every tenant schema.

The allow-list is a single alternation rather than a word-split list on purpose: `for t in $VAR` iterates once over the whole string in shells that do not word-split unquoted expansions, which would silently disable the allow-list. Both greps are guarded with `|| true` because grep exits 1 when it prints nothing, and printing nothing is the healthy outcome here.

## Impact area

CI only. No application code, no schema change, no migration. The stage is gated on the database workspace being affected, so it stays off the critical path for most pull requests. Adds roughly one to two minutes to PRs that touch the schema or migrations.

## Validation performed

- Both workflow files parse as valid YAML.
- The drift-gate shell logic was tested under `bash` with system `grep` against four fixtures: empty diff (passes), control-plane drops only (passes), control-plane drops plus a real `CREATE TABLE` (fails, and reports only the real drift), and a `DROP TABLE` on a real table (fails).
- Two defects were found and fixed by that testing before this was opened: an unguarded `grep` that would have failed the step whenever there was no drift, and a word-splitting dependency in the allow-list loop.
- Aikido scan clean.

## Related Issue(s)

No issue yet. This is the prerequisite CI gate for a large back-office foundations workstream, which adds a large number of models and migrations. It is deliberately separated so the gate exists before the first migration is generated.
