### PR TITLE
fix(frontend): align the tasks planner toolbar with appointments and repair owner nav gating

### DIFF
--- a/apps/frontend/src/app/__tests__/components/OrgGuard.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/OrgGuard.test.tsx
@@ -409,6 +409,10 @@ describe('OrgGuard', () => {
             roleDisplay: 'Admin',
             roleCode: 'ADMIN',
             effectivePermissions: ['appointments:view:any'],
+            // Permissions resolve from the role, so the integrations grant the
+            // ADMIN baseline carries has to be revoked explicitly for this
+            // membership to genuinely lack access to /integrations.
+            revokedPermissions: ['integrations:view:any'],
           },
         },
       })
@@ -421,7 +425,9 @@ describe('OrgGuard', () => {
     );
 
     await waitFor(() => {
-      expect(redirect).toHaveBeenCalledWith('/organization');
+      // Redirected off /integrations, and the ADMIN baseline makes the dashboard
+      // the first route this membership can actually reach.
+      expect(redirect).toHaveBeenCalledWith('/dashboard');
     });
   });
 });

--- a/apps/frontend/src/app/__tests__/components/OrgGuard.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/OrgGuard.test.tsx
@@ -372,7 +372,8 @@ describe('OrgGuard', () => {
         membershipsByOrgId: {
           [orgId]: {
             roleDisplay: 'Owner',
-            effectivePermissions: ['analytics:view:any'],
+            // Permissions derive from roleCode, mirroring a real mapping.
+            roleCode: 'OWNER',
           },
         },
       })

--- a/apps/frontend/src/app/__tests__/components/Sidebar.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Sidebar.test.tsx
@@ -174,7 +174,7 @@ describe('Sidebar', () => {
   it('starts the route loader and navigates when clicking an enabled inactive route', () => {
     setup({
       pathname: '/organization',
-      membership: { effectivePermissions: ['analytics:view:any'], roleDisplay: 'Owner' },
+      membership: { extraPermissions: ['analytics:view:any'], roleDisplay: 'Owner' },
       collapsed: false,
     });
 
@@ -188,7 +188,7 @@ describe('Sidebar', () => {
   it('does not navigate when clicking a disabled route', () => {
     setup({
       pathname: '/organization',
-      membership: { effectivePermissions: ['analytics:view:any'], roleDisplay: 'Owner' },
+      membership: { extraPermissions: ['analytics:view:any'], roleDisplay: 'Owner' },
       collapsed: false,
     });
 
@@ -301,7 +301,7 @@ describe('Sidebar', () => {
 
   it('resolves the logo target to appointments for non-owner roles', () => {
     setup({
-      membership: { effectivePermissions: ALL_PERMISSIONS, roleDisplay: 'Veterinarian' },
+      membership: { extraPermissions: ALL_PERMISSIONS, roleDisplay: 'Veterinarian' },
       collapsed: false,
     });
 

--- a/apps/frontend/src/app/__tests__/hooks/usePermissions.test.ts
+++ b/apps/frontend/src/app/__tests__/hooks/usePermissions.test.ts
@@ -1,27 +1,29 @@
-import { renderHook } from "@testing-library/react";
-import { usePermissions, useHasPermission } from "@/app/hooks/usePermissions";
-import { useOrgStore } from "@/app/stores/orgStore";
+import { renderHook } from '@testing-library/react';
+import { usePermissions, useHasPermission } from '@/app/hooks/usePermissions';
+import { useOrgStore } from '@/app/stores/orgStore';
 
 // --- Mocks ---
 
-jest.mock("@/app/stores/orgStore", () => ({
+jest.mock('@/app/stores/orgStore', () => ({
   useOrgStore: jest.fn(),
 }));
 
-describe("usePermissions Hook", () => {
+describe('usePermissions Hook', () => {
+  // Permissions resolve from role + extras, never from the stored snapshot, so
+  // these roleless fixtures carry their sets as extras.
   const mockMemberships = {
-    "org-1": {
+    'org-1': {
       // Cast as any to bypass strict Permission type checking for test data
-      effectivePermissions: ["perm:read", "perm:write"] as any,
+      extraPermissions: ['perm:read', 'perm:write'] as any,
     },
-    "org-2": {
-      effectivePermissions: ["perm:admin"] as any,
+    'org-2': {
+      extraPermissions: ['perm:admin'] as any,
     },
   };
 
   const setupStore = (
-    primaryOrgId: string | null = "org-1",
-    status: string = "idle",
+    primaryOrgId: string | null = 'org-1',
+    status: string = 'idle',
     memberships = mockMemberships
   ) => {
     (useOrgStore as unknown as jest.Mock).mockImplementation((selector) =>
@@ -39,23 +41,23 @@ describe("usePermissions Hook", () => {
 
   // --- 1. Basic State & ID Resolution ---
 
-  it("resolves permissions from primaryOrgId by default", () => {
-    setupStore("org-1");
+  it('resolves permissions from primaryOrgId by default', () => {
+    setupStore('org-1');
     const { result } = renderHook(() => usePermissions());
 
-    expect(result.current.permissions).toEqual(["perm:read", "perm:write"]);
-    expect(result.current.activeOrgId).toBe("org-1");
+    expect(result.current.permissions).toEqual(['perm:read', 'perm:write']);
+    expect(result.current.activeOrgId).toBe('org-1');
   });
 
-  it("resolves permissions from explicitly passed orgId", () => {
-    setupStore("org-1");
-    const { result } = renderHook(() => usePermissions("org-2"));
+  it('resolves permissions from explicitly passed orgId', () => {
+    setupStore('org-1');
+    const { result } = renderHook(() => usePermissions('org-2'));
 
-    expect(result.current.permissions).toEqual(["perm:admin"]);
-    expect(result.current.activeOrgId).toBe("org-2");
+    expect(result.current.permissions).toEqual(['perm:admin']);
+    expect(result.current.activeOrgId).toBe('org-2');
   });
 
-  it("returns empty permissions if no active org", () => {
+  it('returns empty permissions if no active org', () => {
     setupStore(null);
     const { result } = renderHook(() => usePermissions());
 
@@ -63,15 +65,15 @@ describe("usePermissions Hook", () => {
     expect(result.current.activeOrgId).toBeNull();
   });
 
-  it("returns empty permissions if org membership does not exist", () => {
-    setupStore("org-missing");
+  it('returns empty permissions if org membership does not exist', () => {
+    setupStore('org-missing');
     const { result } = renderHook(() => usePermissions());
 
     expect(result.current.permissions).toEqual([]);
   });
 
-  it("reflects loading state correctly", () => {
-    setupStore("org-1", "loading");
+  it('reflects loading state correctly', () => {
+    setupStore('org-1', 'loading');
     const { result } = renderHook(() => usePermissions());
 
     expect(result.current.isLoading).toBe(true);
@@ -79,68 +81,68 @@ describe("usePermissions Hook", () => {
 
   // --- 2. Logic: hasPermission / Single Permission Check ---
 
-  it("can() checks single string permission", () => {
-    setupStore("org-1");
+  it('can() checks single string permission', () => {
+    setupStore('org-1');
     const { result } = renderHook(() => usePermissions());
 
-    expect(result.current.can("perm:read" as any)).toBe(true);
-    expect(result.current.can("perm:admin" as any)).toBe(false);
+    expect(result.current.can('perm:read' as any)).toBe(true);
+    expect(result.current.can('perm:admin' as any)).toBe(false);
   });
 
   // --- 3. Logic: canAll (Array Input) ---
 
-  it("canAll() returns true only if ALL permissions match", () => {
-    setupStore("org-1");
+  it('canAll() returns true only if ALL permissions match', () => {
+    setupStore('org-1');
     const { result } = renderHook(() => usePermissions());
 
     // Both present
-    expect(result.current.canAll(["perm:read", "perm:write"] as any)).toBe(true);
+    expect(result.current.canAll(['perm:read', 'perm:write'] as any)).toBe(true);
     // One missing
-    expect(result.current.canAll(["perm:read", "perm:admin"] as any)).toBe(false);
+    expect(result.current.canAll(['perm:read', 'perm:admin'] as any)).toBe(false);
   });
 
-  it("canAll() handles single item input gracefully", () => {
-    setupStore("org-1");
+  it('canAll() handles single item input gracefully', () => {
+    setupStore('org-1');
     const { result } = renderHook(() => usePermissions());
 
-    expect(result.current.canAll("perm:read" as any)).toBe(true);
+    expect(result.current.canAll('perm:read' as any)).toBe(true);
   });
 
-  it("canAll() returns false for empty input", () => {
-    setupStore("org-1");
+  it('canAll() returns false for empty input', () => {
+    setupStore('org-1');
     const { result } = renderHook(() => usePermissions());
 
     expect(result.current.canAll([] as any)).toBe(false);
   });
 
-  it("can() delegates array input to canAll (implicit AND)", () => {
-    setupStore("org-1");
+  it('can() delegates array input to canAll (implicit AND)', () => {
+    setupStore('org-1');
     const { result } = renderHook(() => usePermissions());
 
-    expect(result.current.can(["perm:read", "perm:write"] as any)).toBe(true);
-    expect(result.current.can(["perm:read", "perm:missing"] as any)).toBe(false);
+    expect(result.current.can(['perm:read', 'perm:write'] as any)).toBe(true);
+    expect(result.current.can(['perm:read', 'perm:missing'] as any)).toBe(false);
   });
 
   // --- 4. Logic: canAny (Array Input) ---
 
-  it("canAny() returns true if AT LEAST ONE permission matches", () => {
-    setupStore("org-1");
+  it('canAny() returns true if AT LEAST ONE permission matches', () => {
+    setupStore('org-1');
     const { result } = renderHook(() => usePermissions());
 
     // One match
-    expect(result.current.canAny(["perm:read", "perm:admin"] as any)).toBe(true);
+    expect(result.current.canAny(['perm:read', 'perm:admin'] as any)).toBe(true);
     // No match
-    expect(result.current.canAny(["perm:missing", "perm:admin"] as any)).toBe(false);
+    expect(result.current.canAny(['perm:missing', 'perm:admin'] as any)).toBe(false);
   });
 
-  it("canAny() handles single item input gracefully", () => {
-    setupStore("org-1");
+  it('canAny() handles single item input gracefully', () => {
+    setupStore('org-1');
     const { result } = renderHook(() => usePermissions());
-    expect(result.current.canAny("perm:read" as any)).toBe(true);
+    expect(result.current.canAny('perm:read' as any)).toBe(true);
   });
 
-  it("canAny() returns false for empty input", () => {
-    setupStore("org-1");
+  it('canAny() returns false for empty input', () => {
+    setupStore('org-1');
     const { result } = renderHook(() => usePermissions());
     expect(result.current.canAny([] as any)).toBe(false);
   });
@@ -148,56 +150,56 @@ describe("usePermissions Hook", () => {
   // --- 5. Complex Logic: can({ anyOf, allOf }) ---
 
   it("can() supports 'anyOf' object input", () => {
-    setupStore("org-1");
+    setupStore('org-1');
     const { result } = renderHook(() => usePermissions());
 
     // Has one of them
-    expect(result.current.can({ anyOf: ["perm:read", "perm:admin"] } as any)).toBe(true);
+    expect(result.current.can({ anyOf: ['perm:read', 'perm:admin'] } as any)).toBe(true);
     // Has none
-    expect(result.current.can({ anyOf: ["perm:missing"] } as any)).toBe(false);
+    expect(result.current.can({ anyOf: ['perm:missing'] } as any)).toBe(false);
   });
 
   it("can() supports 'allOf' object input", () => {
-    setupStore("org-1");
+    setupStore('org-1');
     const { result } = renderHook(() => usePermissions());
 
     // Has both
-    expect(result.current.can({ allOf: ["perm:read", "perm:write"] } as any)).toBe(true);
+    expect(result.current.can({ allOf: ['perm:read', 'perm:write'] } as any)).toBe(true);
     // Missing one
-    expect(result.current.can({ allOf: ["perm:read", "perm:admin"] } as any)).toBe(false);
+    expect(result.current.can({ allOf: ['perm:read', 'perm:admin'] } as any)).toBe(false);
   });
 
   it("can() supports combined 'anyOf' AND 'allOf'", () => {
-    setupStore("org-1"); // Has read, write
+    setupStore('org-1'); // Has read, write
     const { result } = renderHook(() => usePermissions());
 
     // Success case: Meets "any" condition AND meets "all" condition
     expect(
       result.current.can({
-        anyOf: ["perm:read", "perm:admin"], // Needs one of these (has read) -> Pass
-        allOf: ["perm:write"], // Needs all of these (has write) -> Pass
+        anyOf: ['perm:read', 'perm:admin'], // Needs one of these (has read) -> Pass
+        allOf: ['perm:write'], // Needs all of these (has write) -> Pass
       } as any)
     ).toBe(true);
 
     // Fail case: Fails 'anyOf'
     expect(
       result.current.can({
-        anyOf: ["perm:admin"], // Missing -> Fail
-        allOf: ["perm:write"],
+        anyOf: ['perm:admin'], // Missing -> Fail
+        allOf: ['perm:write'],
       } as any)
     ).toBe(false);
 
     // Fail case: Fails 'allOf'
     expect(
       result.current.can({
-        anyOf: ["perm:read"],
-        allOf: ["perm:admin"], // Missing -> Fail
+        anyOf: ['perm:read'],
+        allOf: ['perm:admin'], // Missing -> Fail
       } as any)
     ).toBe(false);
   });
 
-  it("can() returns false if both lists in object are empty/undefined", () => {
-    setupStore("org-1");
+  it('can() returns false if both lists in object are empty/undefined', () => {
+    setupStore('org-1');
     const { result } = renderHook(() => usePermissions());
 
     expect(result.current.can({} as any)).toBe(false);
@@ -206,16 +208,16 @@ describe("usePermissions Hook", () => {
 
   // --- 6. Helper Hook: useHasPermission ---
 
-  it("useHasPermission returns boolean directly", () => {
-    setupStore("org-1");
-    const { result } = renderHook(() => useHasPermission("perm:read" as any));
+  it('useHasPermission returns boolean directly', () => {
+    setupStore('org-1');
+    const { result } = renderHook(() => useHasPermission('perm:read' as any));
 
     expect(result.current).toBe(true);
   });
 
-  it("useHasPermission handles array input", () => {
-    setupStore("org-1");
-    const { result } = renderHook(() => useHasPermission(["perm:read", "perm:admin"] as any));
+  it('useHasPermission handles array input', () => {
+    setupStore('org-1');
+    const { result } = renderHook(() => useHasPermission(['perm:read', 'perm:admin'] as any));
     // Default array behavior in `can` is `canAll`
     expect(result.current).toBe(false);
   });

--- a/apps/frontend/src/app/__tests__/lib/routePermissions.test.ts
+++ b/apps/frontend/src/app/__tests__/lib/routePermissions.test.ts
@@ -19,7 +19,7 @@ describe('routePermissions', () => {
     ).toBe(true);
   });
 
-  it('requires labs:view:any for the IDEXX workspace route override', () => {
+  it('requires both labs and integrations view for the IDEXX workspace route', () => {
     expect(canAccessPathByPermissions('/appointments/idexx-workspace', [])).toBe(false);
     expect(
       canAccessPathByPermissions('/appointments/idexx-workspace', [
@@ -27,15 +27,47 @@ describe('routePermissions', () => {
       ])
     ).toBe(false);
     // Seeing the integration is not enough: the workspace loads lab results and
-    // orders on open, and those routes require labs:view:any.
+    // orders on open from routes that require labs:view:any.
     expect(
       canAccessPathByPermissions('/appointments/idexx-workspace', [
         PERMISSIONS.INTEGRATIONS_VIEW_ANY,
       ])
     ).toBe(false);
+    // Nor is lab access alone: the workspace reads the integration status, so a
+    // membership whose extras or revocations split the pair renders it empty.
     expect(
       canAccessPathByPermissions('/appointments/idexx-workspace', [PERMISSIONS.LABS_VIEW_ANY])
+    ).toBe(false);
+    expect(
+      canAccessPathByPermissions('/appointments/idexx-workspace', [
+        PERMISSIONS.LABS_VIEW_ANY,
+        PERMISSIONS.INTEGRATIONS_VIEW_ANY,
+      ])
     ).toBe(true);
+  });
+
+  it('every role baseline that reaches the IDEXX workspace holds both grants', () => {
+    // The pairing that makes the AND safe in practice: roles either have both
+    // or neither, so only a custom membership can split them.
+    const roles = ['OWNER', 'ADMIN', 'VETERINARIAN', 'TECHNICIAN'] as const;
+
+    for (const roleCode of roles) {
+      expect(
+        canAccessPathByPermissions(
+          '/appointments/idexx-workspace',
+          resolveMembershipPermissions({ roleCode })
+        )
+      ).toBe(true);
+    }
+
+    for (const roleCode of ['SUPERVISOR', 'ASSISTANT', 'RECEPTIONIST'] as const) {
+      expect(
+        canAccessPathByPermissions(
+          '/appointments/idexx-workspace',
+          resolveMembershipPermissions({ roleCode })
+        )
+      ).toBe(false);
+    }
   });
 
   it('hasAnyRequiredPermission returns false when required permissions are missing', () => {

--- a/apps/frontend/src/app/__tests__/lib/routePermissions.test.ts
+++ b/apps/frontend/src/app/__tests__/lib/routePermissions.test.ts
@@ -2,6 +2,7 @@ import {
   canAccessPathByPermissions,
   hasAnyRequiredPermission,
   resolveFirstAccessibleAppRoute,
+  resolveMembershipPermissions,
 } from '@/app/lib/routePermissions';
 import { PERMISSIONS } from '@/app/lib/permissions';
 
@@ -77,5 +78,46 @@ describe('routePermissions', () => {
 
   it('prefers first accessible route over custom fallback route', () => {
     expect(resolveFirstAccessibleAppRoute([], '/home')).toBe('/organization');
+  });
+
+  describe('resolveMembershipPermissions', () => {
+    it('returns an empty list when there is no membership', () => {
+      expect(resolveMembershipPermissions(null)).toEqual([]);
+      expect(resolveMembershipPermissions()).toEqual([]);
+    });
+
+    it('falls back to the stored set when the role is unrecognised', () => {
+      expect(
+        resolveMembershipPermissions({
+          roleCode: 'NOT_A_ROLE',
+          effectivePermissions: [PERMISSIONS.TASKS_VIEW_ANY],
+        })
+      ).toEqual([PERMISSIONS.TASKS_VIEW_ANY]);
+    });
+
+    it('repairs a drifted stored set from the role baseline', () => {
+      // An owner row written before analytics joined the role table keeps that
+      // stale set forever, which greyed the Dashboard nav entry for the owner.
+      const resolved = resolveMembershipPermissions({
+        roleCode: 'OWNER',
+        effectivePermissions: [PERMISSIONS.TASKS_VIEW_ANY],
+      });
+
+      expect(resolved).toContain(PERMISSIONS.ANALYTICS_VIEW_ANY);
+      expect(resolved).toContain(PERMISSIONS.TASKS_VIEW_ANY);
+    });
+
+    it('keeps extra grants and honours explicit revocations', () => {
+      const resolved = resolveMembershipPermissions({
+        roleCode: 'OWNER',
+        effectivePermissions: [],
+        extraPermissions: ['custom:extra'],
+        revokedPermissions: [PERMISSIONS.TASKS_VIEW_ANY],
+      });
+
+      expect(resolved).toContain('custom:extra');
+      expect(resolved).toContain(PERMISSIONS.ANALYTICS_VIEW_ANY);
+      expect(resolved).not.toContain(PERMISSIONS.TASKS_VIEW_ANY);
+    });
   });
 });

--- a/apps/frontend/src/app/__tests__/lib/routePermissions.test.ts
+++ b/apps/frontend/src/app/__tests__/lib/routePermissions.test.ts
@@ -19,17 +19,22 @@ describe('routePermissions', () => {
     ).toBe(true);
   });
 
-  it('requires integrations:view:any for IDEXX workspace route override', () => {
+  it('requires labs:view:any for the IDEXX workspace route override', () => {
     expect(canAccessPathByPermissions('/appointments/idexx-workspace', [])).toBe(false);
     expect(
       canAccessPathByPermissions('/appointments/idexx-workspace', [
         PERMISSIONS.APPOINTMENTS_VIEW_ANY,
       ])
     ).toBe(false);
+    // Seeing the integration is not enough: the workspace loads lab results and
+    // orders on open, and those routes require labs:view:any.
     expect(
       canAccessPathByPermissions('/appointments/idexx-workspace', [
         PERMISSIONS.INTEGRATIONS_VIEW_ANY,
       ])
+    ).toBe(false);
+    expect(
+      canAccessPathByPermissions('/appointments/idexx-workspace', [PERMISSIONS.LABS_VIEW_ANY])
     ).toBe(true);
   });
 
@@ -91,6 +96,28 @@ describe('routePermissions', () => {
         resolveMembershipPermissions({
           roleCode: 'NOT_A_ROLE',
           extraPermissions: [PERMISSIONS.TASKS_VIEW_ANY],
+        })
+      ).toEqual([PERMISSIONS.TASKS_VIEW_ANY]);
+    });
+
+    it('still applies revocations when the role is unrecognised', () => {
+      // The backend only skips the revocation step when there is no role at
+      // all; a role that is merely unknown resolves against an empty baseline
+      // and still has its revocations subtracted.
+      expect(
+        resolveMembershipPermissions({
+          roleCode: 'NOT_A_ROLE',
+          extraPermissions: [PERMISSIONS.TASKS_VIEW_ANY, PERMISSIONS.INTEGRATIONS_VIEW_ANY],
+          revokedPermissions: [PERMISSIONS.TASKS_VIEW_ANY],
+        })
+      ).toEqual([PERMISSIONS.INTEGRATIONS_VIEW_ANY]);
+    });
+
+    it('returns the extras verbatim when there is no role at all', () => {
+      expect(
+        resolveMembershipPermissions({
+          extraPermissions: [PERMISSIONS.TASKS_VIEW_ANY],
+          revokedPermissions: [PERMISSIONS.TASKS_VIEW_ANY],
         })
       ).toEqual([PERMISSIONS.TASKS_VIEW_ANY]);
     });

--- a/apps/frontend/src/app/__tests__/lib/routePermissions.test.ts
+++ b/apps/frontend/src/app/__tests__/lib/routePermissions.test.ts
@@ -120,6 +120,54 @@ describe('routePermissions', () => {
       expect(resolved).not.toContain(PERMISSIONS.ANALYTICS_VIEW_ANY);
     });
 
+    it('grants nothing for an explicitly deactivated membership', () => {
+      // The backend RBAC lookup requires active: true, so a client that still
+      // holds a deactivated mapping must not light up nav for an offboarded user.
+      expect(
+        resolveMembershipPermissions({
+          roleCode: 'OWNER',
+          active: false,
+          effectivePermissions: [PERMISSIONS.TASKS_VIEW_ANY],
+        })
+      ).toEqual([]);
+    });
+
+    it('treats a missing active flag as active, matching the backend default', () => {
+      expect(resolveMembershipPermissions({ roleCode: 'OWNER' })).toContain(
+        PERMISSIONS.ANALYTICS_VIEW_ANY
+      );
+    });
+
+    it('honours extra grants on a membership with no recognised role', () => {
+      // The backend returns the extras verbatim when there is no role, so the
+      // client must not fall back to an empty or stale snapshot alone.
+      const resolved = resolveMembershipPermissions({
+        extraPermissions: [PERMISSIONS.INTEGRATIONS_VIEW_ANY],
+        effectivePermissions: [PERMISSIONS.TASKS_VIEW_ANY],
+      });
+
+      expect(resolved).toContain(PERMISSIONS.INTEGRATIONS_VIEW_ANY);
+      expect(resolved).toContain(PERMISSIONS.TASKS_VIEW_ANY);
+    });
+
+    it('grants integrations to every role the backend grants it to', () => {
+      // The client role table had drifted from the backend for the non-admin
+      // roles, which hid /integrations from users the API authorises.
+      const roles = [
+        'SUPERVISOR',
+        'VETERINARIAN',
+        'TECHNICIAN',
+        'ASSISTANT',
+        'RECEPTIONIST',
+      ] as const;
+
+      for (const roleCode of roles) {
+        expect(resolveMembershipPermissions({ roleCode })).toContain(
+          PERMISSIONS.INTEGRATIONS_VIEW_ANY
+        );
+      }
+    });
+
     it('keeps extra grants and honours explicit revocations', () => {
       const resolved = resolveMembershipPermissions({
         roleCode: 'OWNER',

--- a/apps/frontend/src/app/__tests__/lib/routePermissions.test.ts
+++ b/apps/frontend/src/app/__tests__/lib/routePermissions.test.ts
@@ -107,6 +107,19 @@ describe('routePermissions', () => {
       expect(resolved).toContain(PERMISSIONS.TASKS_VIEW_ANY);
     });
 
+    it('drops a stored grant the role no longer carries', () => {
+      // Removing a permission from the role table leaves it in every snapshot
+      // written before that change, and nothing ever adds it to
+      // revokedPermissions, so folding the snapshot in would re-grant access
+      // the API now denies.
+      const resolved = resolveMembershipPermissions({
+        roleCode: 'TECHNICIAN',
+        effectivePermissions: [PERMISSIONS.ANALYTICS_VIEW_ANY],
+      });
+
+      expect(resolved).not.toContain(PERMISSIONS.ANALYTICS_VIEW_ANY);
+    });
+
     it('keeps extra grants and honours explicit revocations', () => {
       const resolved = resolveMembershipPermissions({
         roleCode: 'OWNER',

--- a/apps/frontend/src/app/__tests__/lib/routePermissions.test.ts
+++ b/apps/frontend/src/app/__tests__/lib/routePermissions.test.ts
@@ -86,38 +86,33 @@ describe('routePermissions', () => {
       expect(resolveMembershipPermissions()).toEqual([]);
     });
 
-    it('falls back to the stored set when the role is unrecognised', () => {
+    it('grants only the extras when the role is unrecognised', () => {
       expect(
         resolveMembershipPermissions({
           roleCode: 'NOT_A_ROLE',
-          effectivePermissions: [PERMISSIONS.TASKS_VIEW_ANY],
+          extraPermissions: [PERMISSIONS.TASKS_VIEW_ANY],
         })
       ).toEqual([PERMISSIONS.TASKS_VIEW_ANY]);
     });
 
-    it('repairs a drifted stored set from the role baseline', () => {
-      // An owner row written before analytics joined the role table keeps that
-      // stale set forever, which greyed the Dashboard nav entry for the owner.
-      const resolved = resolveMembershipPermissions({
-        roleCode: 'OWNER',
-        effectivePermissions: [PERMISSIONS.TASKS_VIEW_ANY],
-      });
+    it('derives the full baseline for a recognised role', () => {
+      // An owner row written before analytics joined the role table keeps a
+      // stale snapshot forever, which greyed the Dashboard nav entry for the
+      // owner. Deriving from the role instead repairs it.
+      const resolved = resolveMembershipPermissions({ roleCode: 'OWNER' });
 
       expect(resolved).toContain(PERMISSIONS.ANALYTICS_VIEW_ANY);
       expect(resolved).toContain(PERMISSIONS.TASKS_VIEW_ANY);
     });
 
-    it('drops a stored grant the role no longer carries', () => {
-      // Removing a permission from the role table leaves it in every snapshot
-      // written before that change, and nothing ever adds it to
-      // revokedPermissions, so folding the snapshot in would re-grant access
-      // the API now denies.
-      const resolved = resolveMembershipPermissions({
-        roleCode: 'TECHNICIAN',
-        effectivePermissions: [PERMISSIONS.ANALYTICS_VIEW_ANY],
-      });
+    it('never grants a permission the role does not carry', () => {
+      // Removing a permission from the role table leaves it behind in earlier
+      // snapshots without ever reaching revokedPermissions, so the snapshot is
+      // not a grant source at all: only role plus extras count.
+      const resolved = resolveMembershipPermissions({ roleCode: 'TECHNICIAN' });
 
       expect(resolved).not.toContain(PERMISSIONS.ANALYTICS_VIEW_ANY);
+      expect(resolved).toContain(PERMISSIONS.INTEGRATIONS_VIEW_ANY);
     });
 
     it('grants nothing for an explicitly deactivated membership', () => {
@@ -127,7 +122,7 @@ describe('routePermissions', () => {
         resolveMembershipPermissions({
           roleCode: 'OWNER',
           active: false,
-          effectivePermissions: [PERMISSIONS.TASKS_VIEW_ANY],
+          extraPermissions: [PERMISSIONS.TASKS_VIEW_ANY],
         })
       ).toEqual([]);
     });
@@ -138,16 +133,14 @@ describe('routePermissions', () => {
       );
     });
 
-    it('honours extra grants on a membership with no recognised role', () => {
+    it('grants exactly the extras on a membership with no recognised role', () => {
       // The backend returns the extras verbatim when there is no role, so the
-      // client must not fall back to an empty or stale snapshot alone.
-      const resolved = resolveMembershipPermissions({
-        extraPermissions: [PERMISSIONS.INTEGRATIONS_VIEW_ANY],
-        effectivePermissions: [PERMISSIONS.TASKS_VIEW_ANY],
-      });
-
-      expect(resolved).toContain(PERMISSIONS.INTEGRATIONS_VIEW_ANY);
-      expect(resolved).toContain(PERMISSIONS.TASKS_VIEW_ANY);
+      // extras are the whole grant: nothing is inherited from a snapshot.
+      expect(
+        resolveMembershipPermissions({
+          extraPermissions: [PERMISSIONS.INTEGRATIONS_VIEW_ANY],
+        })
+      ).toEqual([PERMISSIONS.INTEGRATIONS_VIEW_ANY]);
     });
 
     it('grants integrations to every role the backend grants it to', () => {
@@ -171,7 +164,6 @@ describe('routePermissions', () => {
     it('keeps extra grants and honours explicit revocations', () => {
       const resolved = resolveMembershipPermissions({
         roleCode: 'OWNER',
-        effectivePermissions: [],
         extraPermissions: ['custom:extra'],
         revokedPermissions: [PERMISSIONS.TASKS_VIEW_ANY],
       });

--- a/apps/frontend/src/app/__tests__/pages/Appointments/Sections/AppointmentInfo/Prescription/AuditPermissions.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Appointments/Sections/AppointmentInfo/Prescription/AuditPermissions.test.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Audit from '@/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/Prescription/Audit';
+
+/**
+ * The sibling Audit test stubs PermissionGate out entirely, so nothing covered
+ * the gate that actually decides whether the audit trail appears. That is why a
+ * green suite still shipped an audit trail that rendered empty everywhere.
+ *
+ * These cases deliberately use the real PermissionGate, usePermissions and
+ * resolveMembershipPermissions, driving them from the org store the app reads
+ * at runtime, so the whole chain is exercised end to end.
+ */
+
+const getAppointmentAuditTrailMock = jest.fn();
+const membershipMock = jest.fn<Record<string, unknown> | null, []>(() => null);
+
+jest.mock('@/app/stores/orgStore', () => ({
+  useOrgStore: (selector: any) =>
+    selector({
+      primaryOrgId: 'org-1',
+      status: 'loaded',
+      membershipsByOrgId: { 'org-1': membershipMock() },
+    }),
+}));
+
+jest.mock('@/app/ui/overlays/Fallback', () => ({
+  __esModule: true,
+  default: () => <div>fallback</div>,
+}));
+
+jest.mock('@/app/features/audit/services/auditService', () => ({
+  getAppointmentAuditTrail: (...args: any[]) => getAppointmentAuditTrailMock(...args),
+}));
+
+jest.mock('@/app/lib/validators', () => ({
+  toTitle: (value: string) => `TITLE:${value}`,
+}));
+
+jest.mock('@/app/lib/date', () => ({
+  formatDateTimeLocal: (value: string) => `DATE:${value}`,
+}));
+
+const auditEntry = {
+  id: 'a1',
+  eventType: 'status_change',
+  entityType: 'appointment',
+  actorType: 'user',
+  actorName: 'dr jane',
+  occurredAt: '2025-01-01T00:00:00.000Z',
+};
+
+describe('Audit trail permission gate', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getAppointmentAuditTrailMock.mockResolvedValue([auditEntry]);
+  });
+
+  it('renders for an owner whose stored permission snapshot is empty', async () => {
+    // The reported bug: memberships persist effectivePermissions at save time,
+    // so an owner row written before audit:view:any joined the role table keeps
+    // an empty set and every audit surface rendered the fallback. Permissions
+    // now derive from roleCode, so the trail appears.
+    membershipMock.mockReturnValue({ roleCode: 'OWNER', effectivePermissions: [] });
+
+    render(<Audit activeAppointment={{ id: 'appt-1' } as any} />);
+
+    await waitFor(() => {
+      expect(getAppointmentAuditTrailMock).toHaveBeenCalledWith('appt-1');
+    });
+    expect(await screen.findByText('TITLE:status_change')).toBeInTheDocument();
+    expect(screen.getByText('Updated by: dr jane • TITLE:USER')).toBeInTheDocument();
+    expect(screen.queryByText('fallback')).not.toBeInTheDocument();
+  });
+
+  it('renders for an admin, who also carries audit:view:any', async () => {
+    membershipMock.mockReturnValue({ roleCode: 'ADMIN' });
+
+    render(<Audit activeAppointment={{ id: 'appt-1' } as any} />);
+
+    expect(await screen.findByText('TITLE:status_change')).toBeInTheDocument();
+    expect(screen.queryByText('fallback')).not.toBeInTheDocument();
+  });
+
+  it('stays hidden for a role without audit:view:any', async () => {
+    // Veterinarian carries analytics but not audit, so the gate must still deny.
+    membershipMock.mockReturnValue({ roleCode: 'VETERINARIAN' });
+
+    render(<Audit activeAppointment={{ id: 'appt-1' } as any} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('fallback')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('TITLE:status_change')).not.toBeInTheDocument();
+  });
+
+  it('stays hidden when the membership is deactivated', async () => {
+    membershipMock.mockReturnValue({ roleCode: 'OWNER', active: false });
+
+    render(<Audit activeAppointment={{ id: 'appt-1' } as any} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('fallback')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/frontend/src/app/__tests__/pages/Integrations/Integrations.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Integrations/Integrations.test.tsx
@@ -46,7 +46,14 @@ jest.mock('@/app/hooks/useOrgSelectors', () => ({
 }));
 
 jest.mock('@/app/stores/orgStore', () => ({
-  useOrgStore: (selector: any) => selector({ primaryOrgId: 'org-1' }),
+  useOrgStore: (selector: any) =>
+    selector({
+      primaryOrgId: 'org-1',
+      status: 'loaded',
+      // Owner membership so integrations:edit:any resolves and the mutation
+      // controls render for these cases.
+      membershipsByOrgId: { 'org-1': { roleCode: 'OWNER' } },
+    }),
 }));
 
 jest.mock('@/app/hooks/useIntegrations', () => ({

--- a/apps/frontend/src/app/__tests__/pages/Integrations/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Integrations/index.test.tsx
@@ -13,6 +13,7 @@ const useIntegrationsForPrimaryOrgMock = jest.fn();
 const useIntegrationByProviderForPrimaryOrgMock = jest.fn();
 const usePrimaryOrgMock = jest.fn();
 const usePrimaryOrgIdMock = jest.fn();
+const membershipMock = jest.fn(() => ({ roleCode: 'OWNER' }) as Record<string, unknown>);
 const useResolvedMerckMock = jest.fn();
 const refreshMerckIntegrationMock = jest.fn();
 const integrationStatusMock = jest.fn();
@@ -65,7 +66,16 @@ jest.mock('@/app/hooks/useOrgSelectors', () => ({
 }));
 
 jest.mock('@/app/stores/orgStore', () => ({
-  useOrgStore: (selector: any) => selector({ primaryOrgId: usePrimaryOrgIdMock() }),
+  useOrgStore: (selector: any) => {
+    const primaryOrgId = usePrimaryOrgIdMock();
+    // The page resolves integrations:edit:any from this membership, so the role
+    // drives whether the mutation controls render.
+    return selector({
+      primaryOrgId,
+      status: 'loaded',
+      membershipsByOrgId: primaryOrgId ? { [primaryOrgId]: membershipMock() } : {},
+    });
+  },
 }));
 
 jest.mock('@/app/hooks/useIntegrations', () => ({
@@ -1148,7 +1158,11 @@ describe('IntegrationsPage — misc branches', () => {
     await flush();
   });
 
-  it('short-circuits every action handler when there is no primary org', async () => {
+  it('renders no mutating controls, and calls nothing, without a primary org', async () => {
+    // integrations:edit:any resolves from the active org's membership, so with
+    // no org there is no edit grant and every mutating control stays off the
+    // page. That subsumes the old per-handler org guards, which are now only
+    // reachable if the org is cleared after the controls have rendered.
     usePrimaryOrgIdMock.mockReturnValue(null);
     usePrimaryOrgMock.mockReturnValue(null); // tooltip "?? your organization" branch
     useIntegrationByProviderForPrimaryOrgMock.mockReturnValue(
@@ -1157,22 +1171,14 @@ describe('IntegrationsPage — misc branches', () => {
 
     renderPage();
     await waitForPage();
-    await openSettings();
 
-    // Fill credentials so the Store button is enabled and reaches its org guard.
-    fireEvent.change(screen.getByTestId('idexx-username'), { target: { value: 'user-a' } });
-    fireEvent.change(screen.getByTestId('idexx-password'), { target: { value: 'pass-a' } });
-
-    fireEvent.click(screen.getByRole('button', { name: 'Store credentials' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Validate' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Refresh integrations' }));
-    // Card enable buttons are gated on saving only, so they reach the org guard.
-    fireEvent.click(
-      within(getCard('IDEXX VetConnect PLUS')).getByRole('button', { name: 'Enable' })
-    );
-    fireEvent.click(
-      within(getCard('MSD Veterinary Manual')).getByRole('button', { name: 'Enable' })
-    );
+    expect(screen.queryByRole('button', { name: 'Manage credentials' })).not.toBeInTheDocument();
+    expect(
+      within(getCard('IDEXX VetConnect PLUS')).queryByRole('button', { name: 'Enable' })
+    ).not.toBeInTheDocument();
+    expect(
+      within(getCard('MSD Veterinary Manual')).queryByRole('button', { name: 'Enable' })
+    ).not.toBeInTheDocument();
 
     await flush();
 
@@ -1182,5 +1188,22 @@ describe('IntegrationsPage — misc branches', () => {
     expect(enableIntegrationMock).not.toHaveBeenCalled();
     expect(listIdexxIvlsDevicesMock).not.toHaveBeenCalled();
     expect(getMerckGatewayMock).not.toHaveBeenCalled();
+  });
+
+  it('hides the mutating controls from a view-only role but keeps the read links', async () => {
+    // Supervisor/Vet/Technician/Assistant/Receptionist get integrations:view:any
+    // from the backend but not integrations:edit:any, so the catalog stays
+    // readable while every control that would 403 is withheld.
+    membershipMock.mockReturnValue({ roleCode: 'RECEPTIONIST' });
+
+    renderPage();
+    await waitForPage();
+
+    expect(screen.queryByRole('button', { name: 'Manage credentials' })).not.toBeInTheDocument();
+    expect(
+      within(getCard('MSD Veterinary Manual')).queryByRole('button', { name: 'Enable' })
+    ).not.toBeInTheDocument();
+    // The read-only affordance survives.
+    expect(getCard('IDEXX VetConnect PLUS')).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/app/__tests__/pages/Tasks/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Tasks/index.test.tsx
@@ -413,6 +413,50 @@ describe('Tasks page', () => {
     );
   });
 
+  it('keeps the pill row on the phone planner, which renders no calendar header', () => {
+    // Below 768px TaskCalendar swaps the grid for the day list and returns
+    // before the header, so the pill row stays as the only filter surface.
+    useIsPhoneMock.mockReturnValue(true);
+    render(<ProtectedTasks />);
+
+    expect(filterBarSpy).toHaveBeenCalled();
+  });
+
+  it('clears an audience filter the planner header cannot display', async () => {
+    render(<ProtectedTasks />);
+
+    fireEvent.click(screen.getByText('List'));
+    await act(async () => {
+      lastPropsOf(filterBarSpy).setActiveFilter('employee_task');
+      await Promise.resolve();
+    });
+    expect(lastPropsOf(filterBarSpy).activeFilter).toBe('employee_task');
+
+    // Back on the planner the header only carries the pet-parent pill, so a
+    // carried Team filter would narrow the grid with nothing able to clear it.
+    await act(async () => {
+      fireEvent.click(screen.getByText('Calendar'));
+      await Promise.resolve();
+    });
+    expect(lastPropsOf(taskCalendarSpy).activeFilter).toBe('all');
+  });
+
+  it('preserves the pet-parent filter across views because the header shows it', async () => {
+    render(<ProtectedTasks />);
+
+    fireEvent.click(screen.getByText('List'));
+    await act(async () => {
+      lastPropsOf(filterBarSpy).setActiveFilter('parent_task');
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Calendar'));
+      await Promise.resolve();
+    });
+    expect(lastPropsOf(taskCalendarSpy).activeFilter).toBe('parent_task');
+  });
+
   it('filteredList in board view ignores status filter (shows all matching query/audience)', async () => {
     useTasksMock.mockReturnValue([
       { _id: 't1', status: 'pending', audience: 'EMPLOYEE_TASK', name: 'Follow up' },

--- a/apps/frontend/src/app/__tests__/pages/Tasks/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Tasks/index.test.tsx
@@ -706,18 +706,21 @@ describe('Tasks page', () => {
       expect.objectContaining({ _id: 't2' }),
     ]);
 
+    // Audience pills other than the pet-parent one only exist in the list view,
+    // so that is the only place a Team filter can actually be applied.
+    fireEvent.click(screen.getByText('List'));
     await act(async () => {
-      lastPropsOf(taskCalendarSpy).setActiveFilter('employee_task');
+      lastPropsOf(filterBarSpy).setActiveFilter('employee_task');
       await Promise.resolve();
     });
     // t2 is the only completed task, but its audience is client_task.
-    expect(lastPropsOf(taskCalendarSpy).filteredList).toEqual([]);
+    expect(lastPropsOf(taskTableSpy).filteredList).toEqual([]);
 
     await act(async () => {
-      lastPropsOf(taskCalendarSpy).setActiveStatus('pending');
+      lastPropsOf(filterBarSpy).setActiveStatus('pending');
       await Promise.resolve();
     });
-    expect(lastPropsOf(taskCalendarSpy).filteredList).toEqual([
+    expect(lastPropsOf(taskTableSpy).filteredList).toEqual([
       expect.objectContaining({ _id: 't1' }),
     ]);
   });

--- a/apps/frontend/src/app/__tests__/pages/Tasks/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Tasks/index.test.tsx
@@ -381,18 +381,36 @@ describe('Tasks page', () => {
     expect(addTaskSpy).toHaveBeenCalledWith(expect.objectContaining({ showModal: true }));
   });
 
-  it('feeds the inline audience + status pills to the filter bar', () => {
+  it('feeds the status dropdown and pet-parent pill to the planner header', () => {
     render(<ProtectedTasks />);
 
-    expect(filterBarSpy).toHaveBeenCalledWith(
+    expect(taskCalendarSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         filterOptions: expect.any(Array),
         statusOptions: expect.any(Array),
       })
     );
-    // The design's status row is Pending / In progress / Completed only.
-    const { statusOptions } = lastPropsOf(filterBarSpy);
+    const { statusOptions, filterOptions } = lastPropsOf(taskCalendarSpy);
+    // The design's status set is Pending / In progress / Completed only.
     expect(statusOptions.map((option: { key: string }) => option.key)).not.toContain('cancelled');
+    // Day/Week/Team already covers the team split, so only the parent pill remains.
+    expect(filterOptions.map((option: { key: string }) => option.key)).toEqual(['parent_task']);
+    expect(filterOptions[0].dotColor).toBe('var(--pink)');
+    // The planner header owns the filters, so no separate pill row renders.
+    expect(filterBarSpy).not.toHaveBeenCalled();
+  });
+
+  it('keeps the audience, status and scope pill row for the list view', () => {
+    render(<ProtectedTasks />);
+    fireEvent.click(screen.getByText('List'));
+
+    expect(filterBarSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filterOptions: expect.any(Array),
+        statusOptions: expect.any(Array),
+        scopeOptions: expect.any(Array),
+      })
+    );
   });
 
   it('filteredList in board view ignores status filter (shows all matching query/audience)', async () => {
@@ -637,7 +655,7 @@ describe('Tasks page', () => {
     render(<ProtectedTasks />);
 
     await act(async () => {
-      lastPropsOf(filterBarSpy).setActiveStatus('completed');
+      lastPropsOf(taskCalendarSpy).setActiveStatus('completed');
       await Promise.resolve();
     });
     expect(lastPropsOf(taskCalendarSpy).filteredList).toEqual([
@@ -645,14 +663,14 @@ describe('Tasks page', () => {
     ]);
 
     await act(async () => {
-      lastPropsOf(filterBarSpy).setActiveFilter('employee_task');
+      lastPropsOf(taskCalendarSpy).setActiveFilter('employee_task');
       await Promise.resolve();
     });
     // t2 is the only completed task, but its audience is client_task.
     expect(lastPropsOf(taskCalendarSpy).filteredList).toEqual([]);
 
     await act(async () => {
-      lastPropsOf(filterBarSpy).setActiveStatus('pending');
+      lastPropsOf(taskCalendarSpy).setActiveStatus('pending');
       await Promise.resolve();
     });
     expect(lastPropsOf(taskCalendarSpy).filteredList).toEqual([
@@ -794,13 +812,15 @@ describe('Tasks page', () => {
     // The default "Team" scope surfaces everyone's tasks.
     expect(lastPropsOf(taskCalendarSpy).filteredList).toHaveLength(4);
 
+    // The scope control lives in the list view only.
+    fireEvent.click(screen.getByText('List'));
     await act(async () => {
       lastPropsOf(filterBarSpy).setActiveScope('mine');
       await Promise.resolve();
     });
 
     // "My tasks" keeps only the two that resolve to the signed-in member.
-    expect(lastPropsOf(taskCalendarSpy).filteredList).toEqual([
+    expect(lastPropsOf(taskTableSpy).filteredList).toEqual([
       expect.objectContaining({ _id: 'mine-direct' }),
       expect.objectContaining({ _id: 'mine-primary' }),
     ]);
@@ -821,12 +841,13 @@ describe('Tasks page', () => {
 
     render(<ProtectedTasks />);
 
+    fireEvent.click(screen.getByText('List'));
     await act(async () => {
       lastPropsOf(filterBarSpy).setActiveScope('mine');
       await Promise.resolve();
     });
 
-    expect(lastPropsOf(taskCalendarSpy).filteredList).toEqual([]);
+    expect(lastPropsOf(taskTableSpy).filteredList).toEqual([]);
   });
 
   it('does not apply the my-tasks scope in board view', async () => {
@@ -851,12 +872,13 @@ describe('Tasks page', () => {
 
     render(<ProtectedTasks />);
 
-    // Narrow to my tasks in the calendar view.
+    // Narrow to my tasks in the list view, the only view with the scope control.
+    fireEvent.click(screen.getByText('List'));
     await act(async () => {
       lastPropsOf(filterBarSpy).setActiveScope('mine');
       await Promise.resolve();
     });
-    expect(lastPropsOf(taskCalendarSpy).filteredList).toEqual([
+    expect(lastPropsOf(taskTableSpy).filteredList).toEqual([
       expect.objectContaining({ _id: 'mine' }),
     ]);
 

--- a/apps/frontend/src/app/__tests__/ui/layout/PhoneShell/PhoneShell.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/layout/PhoneShell/PhoneShell.test.tsx
@@ -52,7 +52,8 @@ const setOrg = ({
   mockUseOrgStore.mockImplementation((selector: any) =>
     selector({
       primaryOrgId: 'org-1',
-      membershipsByOrgId: { 'org-1': { effectivePermissions: permissions } },
+      // Permissions resolve from role + extras, not the stored snapshot.
+      membershipsByOrgId: { 'org-1': { extraPermissions: permissions } },
     })
   );
 };

--- a/apps/frontend/src/app/__tests__/ui/layout/PhoneShell/usePhoneNavGate.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/layout/PhoneShell/usePhoneNavGate.test.tsx
@@ -30,7 +30,11 @@ const setupStore = (
   mockUseOrgStore.mockImplementation((selector: any) =>
     selector({
       primaryOrgId,
-      membershipsByOrgId: primaryOrgId ? { [primaryOrgId]: { effectivePermissions } } : {},
+      // Permissions resolve from role + extras, never from the stored snapshot,
+      // so a roleless fixture carries its set as extras.
+      membershipsByOrgId: primaryOrgId
+        ? { [primaryOrgId]: { extraPermissions: effectivePermissions } }
+        : {},
     })
   );
 };

--- a/apps/frontend/src/app/features/appointments/components/Calendar/TaskCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/TaskCalendar.tsx
@@ -30,6 +30,19 @@ type TaskCalendarProps = {
   setWeekStart: React.Dispatch<React.SetStateAction<Date>>;
   canEditTasks?: boolean;
   onCreateFromCalendarSlot?: (prefill: { dueAt: Date; assignedTo?: string }) => void;
+  filterOptions?: Array<{ key: string; name: string; dotColor?: string }>;
+  activeFilter?: string;
+  setActiveFilter?: (value: string) => void;
+  statusOptions?: Array<{
+    key: string;
+    name: string;
+    bg?: string;
+    text?: string;
+    border?: string;
+    dropdownText?: string;
+  }>;
+  activeStatus?: string;
+  setActiveStatus?: (value: string) => void;
 };
 
 const TaskCalendar = ({
@@ -48,6 +61,12 @@ const TaskCalendar = ({
   setWeekStart,
   canEditTasks = false,
   onCreateFromCalendarSlot,
+  filterOptions,
+  activeFilter,
+  setActiveFilter,
+  statusOptions,
+  activeStatus,
+  setActiveStatus,
 }: TaskCalendarProps) => {
   const allTaskItems = allTasks ?? filteredList;
   const teams = useTeamForPrimaryOrg();
@@ -151,6 +170,12 @@ const TaskCalendar = ({
           setZoomMode={setZoomMode}
           activeCalendar={activeCalendar}
           setActiveCalendar={setActiveCalendar}
+          filterOptions={filterOptions}
+          activeFilter={activeFilter}
+          setActiveFilter={setActiveFilter}
+          statusOptions={statusOptions}
+          activeStatus={activeStatus}
+          setActiveStatus={setActiveStatus}
         />
         {dragError ? (
           <div className="px-3 py-2 text-caption-1 text-text-error border-b border-card-border">

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/Header.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/Header.tsx
@@ -29,7 +29,7 @@ import { useCalendarNavigation } from '@/app/hooks/useCalendarNavigation';
 import { useCalendarWeekNavigation } from '@/app/features/appointments/components/Calendar/useCalendarSlots';
 import { getStartOfWeek } from '@/app/features/appointments/components/Calendar/weekHelpers';
 
-type FilterOption = { key: string; name: string };
+type FilterOption = { key: string; name: string; dotColor?: string };
 type StatusOption = {
   key: string;
   name: string;
@@ -256,6 +256,13 @@ const FilterPills = ({
                 aria-hidden="true"
                 className="size-1.5 shrink-0 rounded-full"
                 style={{ backgroundColor: 'var(--danger)' }}
+              />
+            )}
+            {!isEmergencyFilter && filter.dotColor && (
+              <span
+                aria-hidden="true"
+                className="size-1.5 shrink-0 rounded-full"
+                style={{ backgroundColor: filter.dotColor }}
               />
             )}
             <span>{filter.name}</span>

--- a/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
@@ -1059,7 +1059,7 @@ const MerckIntegrationCard = ({
       </div>
       <div className={INTEGRATION_CARD_ACTIONS_CLASS}>
         {s.merckEnabled ? (
-          <Primary
+          <Secondary
             href="/integrations/merck-manuals"
             text="Open manuals"
             className="px-4 whitespace-nowrap"
@@ -1125,12 +1125,12 @@ const RadIntegrationCard = ({
         <span
           className="inline-flex min-h-10 items-center justify-center rounded-full! px-4 text-[13.5px] font-semibold whitespace-nowrap select-none"
           style={{
-            background: 'var(--inset)',
-            color: 'var(--ink-muted)',
-            border: '1px solid var(--hairline)',
+            background: 'transparent',
+            color: 'var(--ink-body)',
+            border: '1px solid var(--divider)',
           }}
         >
-          Coming soon
+          Notify me
         </span>
       </div>
     </div>
@@ -1173,12 +1173,12 @@ const VetnioIntegrationCard = ({
         <span
           className="inline-flex min-h-10 items-center justify-center rounded-full! px-4 text-[13.5px] font-semibold whitespace-nowrap select-none"
           style={{
-            background: 'var(--inset)',
-            color: 'var(--ink-muted)',
-            border: '1px solid var(--hairline)',
+            background: 'transparent',
+            color: 'var(--ink-body)',
+            border: '1px solid var(--divider)',
           }}
         >
-          Coming soon
+          Notify me
         </span>
       </div>
     </div>
@@ -1221,12 +1221,12 @@ const QuickBooksIntegrationCard = ({
         <span
           className="inline-flex min-h-10 items-center justify-center rounded-full! px-4 text-[13.5px] font-semibold whitespace-nowrap select-none"
           style={{
-            background: 'var(--inset)',
-            color: 'var(--ink-muted)',
-            border: '1px solid var(--hairline)',
+            background: 'transparent',
+            color: 'var(--ink-body)',
+            border: '1px solid var(--divider)',
           }}
         >
-          Coming soon
+          Notify me
         </span>
       </div>
     </div>
@@ -1270,12 +1270,12 @@ const LaikaIntegrationCard = ({
         <span
           className="inline-flex min-h-10 items-center justify-center rounded-full! px-4 text-[13.5px] font-semibold whitespace-nowrap select-none"
           style={{
-            background: 'var(--inset)',
-            color: 'var(--ink-muted)',
-            border: '1px solid var(--hairline)',
+            background: 'transparent',
+            color: 'var(--ink-body)',
+            border: '1px solid var(--divider)',
           }}
         >
-          Coming soon
+          Notify me
         </span>
       </div>
     </div>

--- a/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
@@ -14,6 +14,8 @@ import FormInputPass from '@/app/ui/inputs/FormInputPass/FormInputPass';
 import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
 import { useOrgStore } from '@/app/stores/orgStore';
 import { usePrimaryOrg } from '@/app/hooks/useOrgSelectors';
+import { useHasPermission } from '@/app/hooks/usePermissions';
+import { PERMISSIONS } from '@/app/lib/permissions';
 import {
   loadIntegrationsForPrimaryOrg,
   useIntegrationByProviderForPrimaryOrg,
@@ -494,6 +496,10 @@ const useIdexxActions = (s: IdexxActionsState) => {
 const useIntegrationsPage = () => {
   const primaryOrg = usePrimaryOrg();
   const primaryOrgId = useOrgStore((s) => s.primaryOrgId);
+  // Most roles can view the catalog but not change it: the backend requires
+  // integrations:edit:any for the credentials, enable, disable and validate
+  // routes, so those controls stay hidden rather than 403 on click.
+  const canEditIntegrations = useHasPermission(PERMISSIONS.INTEGRATIONS_EDIT_ANY);
   const integrations = useIntegrationsForPrimaryOrg();
   const {
     integration: merckIntegration,
@@ -622,6 +628,7 @@ const useIntegrationsPage = () => {
   return {
     primaryOrg,
     primaryOrgId,
+    canEditIntegrations,
     integrationStatus,
     integrationsLastFetchedAt,
     idexxIntegration,
@@ -991,13 +998,14 @@ const IdexxIntegrationCard = ({
         patient automatically.
       </div>
       <div className={INTEGRATION_CARD_ACTIONS_CLASS}>
-        {s.idexxEnabled ? (
+        {s.idexxEnabled && (
           <Secondary
             href="/appointments/idexx-workspace"
             text="Open workspace"
             className="px-4 whitespace-nowrap"
           />
-        ) : (
+        )}
+        {!s.idexxEnabled && s.canEditIntegrations && (
           <Primary
             href="#"
             text={buttonLabel}
@@ -1006,17 +1014,19 @@ const IdexxIntegrationCard = ({
             className="px-4 whitespace-nowrap"
           />
         )}
-        <button
-          type="button"
-          onClick={() => s.setShowSettings(true)}
-          aria-label="Manage credentials"
-          title="Manage"
-          className={`${CARD_ICON_BUTTON_CLASS} ml-auto`}
-          style={MANAGE_ICON_BUTTON_STYLE}
-        >
-          <IoSettingsOutline size={14} aria-hidden="true" />
-        </button>
-        {s.idexxEnabled ? (
+        {s.canEditIntegrations && (
+          <button
+            type="button"
+            onClick={() => s.setShowSettings(true)}
+            aria-label="Manage credentials"
+            title="Manage"
+            className={`${CARD_ICON_BUTTON_CLASS} ml-auto`}
+            style={MANAGE_ICON_BUTTON_STYLE}
+          >
+            <IoSettingsOutline size={14} aria-hidden="true" />
+          </button>
+        )}
+        {s.idexxEnabled && s.canEditIntegrations ? (
           <button
             type="button"
             onClick={s.handleEnableDisable}
@@ -1058,13 +1068,14 @@ const MerckIntegrationCard = ({
         for every clinic.
       </div>
       <div className={INTEGRATION_CARD_ACTIONS_CLASS}>
-        {s.merckEnabled ? (
+        {s.merckEnabled && (
           <Secondary
             href="/integrations/merck-manuals"
             text="Open manuals"
             className="px-4 whitespace-nowrap"
           />
-        ) : (
+        )}
+        {!s.merckEnabled && s.canEditIntegrations && (
           <Primary
             href="#"
             text={buttonLabel}
@@ -1073,7 +1084,7 @@ const MerckIntegrationCard = ({
             className="px-4 whitespace-nowrap"
           />
         )}
-        {s.merckEnabled ? (
+        {s.merckEnabled && s.canEditIntegrations ? (
           <button
             type="button"
             onClick={s.handleMerckEnableDisable}
@@ -1391,8 +1402,11 @@ const IntegrationsPage = () => {
         ) : null}
       </div>
 
+      {/* Every control inside the panel hits an integrations:edit:any route, so
+          it never mounts for a view-only role - closing the paths that open it
+          from a failed validate or enable as well as from the gear. */}
       <IdexxSettingsModal
-        showSettings={s.showSettings}
+        showSettings={s.canEditIntegrations && s.showSettings}
         setShowSettings={s.setShowSettings}
         idexxIntegration={s.idexxIntegration}
         idexxEnabled={s.idexxEnabled}

--- a/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
@@ -537,7 +537,14 @@ const useIntegrationsPage = () => {
   useEffect(() => {
     const run = async () => {
       if (!primaryOrgId) return;
-      if (!canViewLabs) return;
+      if (!canViewLabs) {
+        // Losing lab access (org switch, or the permission revoked) must drop
+        // anything fetched under the previous one, or the settings modal keeps
+        // rendering stale devices and orders.
+        setDevices([]);
+        setRecentOrders([]);
+        return;
+      }
       if (idexxIntegration?.status === 'enabled') {
         try {
           const ivls = await listIdexxIvlsDevices(primaryOrgId);

--- a/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
@@ -500,6 +500,10 @@ const useIntegrationsPage = () => {
   // integrations:edit:any for the credentials, enable, disable and validate
   // routes, so those controls stay hidden rather than 403 on click.
   const canEditIntegrations = useHasPermission(PERMISSIONS.INTEGRATIONS_EDIT_ANY);
+  // Supervisor, Assistant and Receptionist can view the catalog without holding
+  // labs:view:any, and the device/order loaders hit lab routes that require it,
+  // so those reads are skipped rather than failing the page on open.
+  const canViewLabs = useHasPermission(PERMISSIONS.LABS_VIEW_ANY);
   const integrations = useIntegrationsForPrimaryOrg();
   const {
     integration: merckIntegration,
@@ -533,6 +537,7 @@ const useIntegrationsPage = () => {
   useEffect(() => {
     const run = async () => {
       if (!primaryOrgId) return;
+      if (!canViewLabs) return;
       if (idexxIntegration?.status === 'enabled') {
         try {
           const ivls = await listIdexxIvlsDevices(primaryOrgId);
@@ -555,7 +560,7 @@ const useIntegrationsPage = () => {
       }
     };
     run().catch(() => undefined);
-  }, [primaryOrgId, idexxIntegration?.status]);
+  }, [primaryOrgId, idexxIntegration?.status, canViewLabs]);
 
   useEffect(() => {
     setValidateState(resolveValidateState(idexxIntegration?.credentialsStatus));
@@ -629,6 +634,7 @@ const useIntegrationsPage = () => {
     primaryOrg,
     primaryOrgId,
     canEditIntegrations,
+    canViewLabs,
     integrationStatus,
     integrationsLastFetchedAt,
     idexxIntegration,
@@ -998,7 +1004,7 @@ const IdexxIntegrationCard = ({
         patient automatically.
       </div>
       <div className={INTEGRATION_CARD_ACTIONS_CLASS}>
-        {s.idexxEnabled && (
+        {s.idexxEnabled && s.canViewLabs && (
           <Secondary
             href="/appointments/idexx-workspace"
             text="Open workspace"

--- a/apps/frontend/src/app/features/organization/services/orgService.ts
+++ b/apps/frontend/src/app/features/organization/services/orgService.ts
@@ -103,7 +103,10 @@ export const createOrg = async (formData: Organisation) => {
       organizationReference: _id,
       roleCode: 'OWNER',
       roleDisplay: 'Owner',
-      active: false,
+      // The server creates this mapping active (it defaults `active ?? true`),
+      // so the optimistic copy has to match or the creator is treated as a
+      // deactivated member until the next mapping fetch.
+      active: true,
       effectivePermissions: ROLE_PERMISSIONS.OWNER,
       extraPermissions: [],
       revokedPermissions: [],

--- a/apps/frontend/src/app/features/tasks/pages/Tasks/index.tsx
+++ b/apps/frontend/src/app/features/tasks/pages/Tasks/index.tsx
@@ -36,6 +36,16 @@ const TASKS_PAGE_SKELETON = <PageSkeleton variant="planner" />;
 const TASK_STATUS_PILLS = TaskStatusFilters.filter((option) => option.key !== 'cancelled');
 
 /**
+ * Calendar-only audience pill. The planner header already carries the
+ * Day/Week/Team switcher, so the team split needs no second control; only the
+ * pet-parent filter survives, as the task-side counterpart to the appointments
+ * planner's Emergencies pill.
+ */
+const TASK_CALENDAR_FILTERS = TaskFilters.filter((option) => option.key === 'parent_task').map(
+  (option) => ({ ...option, dotColor: 'var(--pink)' })
+);
+
+/**
  * Assignee scope, kept as a segmented control (not an audience chip) so its
  * "Team" label never reads as the "Team" audience pill sitting next to it.
  * "My tasks" narrows every view to the tasks assigned to the signed-in member.
@@ -181,9 +191,10 @@ const Tasks = () => {
         activeView === 'board' || statusWanted === 'all' || status === statusWanted;
       const matchesFilter = filterWanted === 'all' || filter === filterWanted;
       const matchesQuery = !q || item.name?.toLowerCase().includes(q);
-      // The board hides the My/Team scope control (it has its own toolbar), so the
-      // page-level scope must not narrow the list feeding it - mirror matchesStatus.
-      const matchesScope = activeView === 'board' || !scopeToMine || isAssignedToMe(item);
+      // Only the list view still renders the My/Team scope control - the board has
+      // its own toolbar and the planner relies on the Day/Week/Team switcher - so
+      // the page-level scope must never narrow the views that cannot clear it.
+      const matchesScope = activeView !== 'list' || !scopeToMine || isAssignedToMe(item);
 
       return matchesStatus && matchesFilter && matchesQuery && matchesScope;
     });
@@ -241,6 +252,12 @@ const Tasks = () => {
         setWeekStart={setWeekStart}
         canEditTasks={canEditTasks}
         onCreateFromCalendarSlot={handleCreateFromCalendarSlot}
+        filterOptions={TASK_CALENDAR_FILTERS}
+        activeFilter={activeFilter}
+        setActiveFilter={setActiveFilter}
+        statusOptions={TASK_STATUS_PILLS}
+        activeStatus={activeStatus}
+        setActiveStatus={setActiveStatus}
       />
     );
   } else if (activeView === 'board') {
@@ -302,7 +319,7 @@ const Tasks = () => {
 
         <PermissionGate allOf={[PERMISSIONS.TASKS_VIEW_ANY]} fallback={<Fallback />}>
           <div className={wrapperClassName}>
-            {activeView !== 'board' && (
+            {activeView === 'list' && (
               <TaskFilterBar
                 filterOptions={TaskFilters}
                 statusOptions={TASK_STATUS_PILLS}

--- a/apps/frontend/src/app/features/tasks/pages/Tasks/index.tsx
+++ b/apps/frontend/src/app/features/tasks/pages/Tasks/index.tsx
@@ -109,12 +109,11 @@ const Tasks = () => {
   const showsTaskFilterBar = activeView === 'list' || (activeView === 'calendar' && isPhone);
 
   // The planner header only carries the pet-parent pill, so an audience chosen
-  // in the list view would keep filtering the calendar with nothing on screen to
-  // show or clear it. Normalise back to "all" whenever the pill row is hidden.
-  useEffect(() => {
-    if (showsTaskFilterBar) return;
-    setActiveFilter((prev) => (prev === 'all' || prev === PARENT_AUDIENCE_KEY ? prev : 'all'));
-  }, [showsTaskFilterBar]);
+  // in the list view cannot be shown or cleared from the calendar. Derive what
+  // actually applies rather than writing the state back: no extra render, and
+  // the list view keeps its own selection when the user returns to it.
+  const appliedFilter =
+    showsTaskFilterBar || activeFilter === PARENT_AUDIENCE_KEY ? activeFilter : 'all';
   const [currentDate, setCurrentDate] = useState<Date>(new Date());
   const [weekStart, setWeekStart] = useState(() => startOfDay(currentDate));
   const { plannerSectionRef } = usePlannerAutoLock({ activeView });
@@ -195,7 +194,7 @@ const Tasks = () => {
 
   const filteredList = useMemo(() => {
     const q = query.trim().toLowerCase();
-    const filterWanted = activeFilter.toLowerCase();
+    const filterWanted = appliedFilter.toLowerCase();
     const statusWanted = activeStatus.toLowerCase();
     const scopeToMine = activeScope === 'mine';
 
@@ -217,7 +216,7 @@ const Tasks = () => {
   }, [
     tasks,
     activeStatus,
-    activeFilter,
+    appliedFilter,
     query,
     activeView,
     activeScope,
@@ -278,7 +277,7 @@ const Tasks = () => {
         canEditTasks={canEditTasks}
         onCreateFromCalendarSlot={handleCreateFromCalendarSlot}
         filterOptions={TASK_CALENDAR_FILTERS}
-        activeFilter={activeFilter}
+        activeFilter={appliedFilter}
         setActiveFilter={setActiveFilter}
         statusOptions={TASK_STATUS_PILLS}
         activeStatus={activeStatus}

--- a/apps/frontend/src/app/features/tasks/pages/Tasks/index.tsx
+++ b/apps/frontend/src/app/features/tasks/pages/Tasks/index.tsx
@@ -18,6 +18,7 @@ import { useAuthStore } from '@/app/stores/authStore';
 import { normalizeCalendarId } from '@/app/features/appointments/components/Calendar/taskCalendarAvailabilityUtils';
 import { resolveTeamMemberPrimaryId } from '@/app/features/appointments/components/Calendar/appointmentDragAvailabilityUtils';
 import TaskFilterBar from '@/app/features/tasks/components/TaskFilterBar';
+import { useIsPhone } from '@/app/ui/layout/PhoneShell/useIsPhone';
 import { usePermissions } from '@/app/hooks/usePermissions';
 import { PERMISSIONS } from '@/app/lib/permissions';
 import { PermissionGate } from '@/app/ui/layout/guards/PermissionGate';
@@ -41,8 +42,10 @@ const TASK_STATUS_PILLS = TaskStatusFilters.filter((option) => option.key !== 'c
  * pet-parent filter survives, as the task-side counterpart to the appointments
  * planner's Emergencies pill.
  */
-const TASK_CALENDAR_FILTERS = TaskFilters.filter((option) => option.key === 'parent_task').map(
-  (option) => ({ ...option, dotColor: 'var(--pink)' })
+const PARENT_AUDIENCE_KEY = 'parent_task';
+
+const TASK_CALENDAR_FILTERS = TaskFilters.flatMap((option) =>
+  option.key === PARENT_AUDIENCE_KEY ? [{ ...option, dotColor: 'var(--pink)' }] : []
 );
 
 /**
@@ -99,6 +102,19 @@ const Tasks = () => {
   const [activeTask, setActiveTask] = useState<Task | null>(tasks[0] ?? null);
   const [activeCalendar, setActiveCalendar] = useState('week');
   const [activeView, setActiveView] = useState('calendar');
+  const isPhone = useIsPhone();
+  // The phone planner swaps the grid for a day list and never renders the
+  // calendar header, so the pill row stays there. Deriving visibility once keeps
+  // the rendered controls and the filters they drive from drifting apart.
+  const showsTaskFilterBar = activeView === 'list' || (activeView === 'calendar' && isPhone);
+
+  // The planner header only carries the pet-parent pill, so an audience chosen
+  // in the list view would keep filtering the calendar with nothing on screen to
+  // show or clear it. Normalise back to "all" whenever the pill row is hidden.
+  useEffect(() => {
+    if (showsTaskFilterBar) return;
+    setActiveFilter((prev) => (prev === 'all' || prev === PARENT_AUDIENCE_KEY ? prev : 'all'));
+  }, [showsTaskFilterBar]);
   const [currentDate, setCurrentDate] = useState<Date>(new Date());
   const [weekStart, setWeekStart] = useState(() => startOfDay(currentDate));
   const { plannerSectionRef } = usePlannerAutoLock({ activeView });
@@ -191,14 +207,23 @@ const Tasks = () => {
         activeView === 'board' || statusWanted === 'all' || status === statusWanted;
       const matchesFilter = filterWanted === 'all' || filter === filterWanted;
       const matchesQuery = !q || item.name?.toLowerCase().includes(q);
-      // Only the list view still renders the My/Team scope control - the board has
-      // its own toolbar and the planner relies on the Day/Week/Team switcher - so
-      // the page-level scope must never narrow the views that cannot clear it.
-      const matchesScope = activeView !== 'list' || !scopeToMine || isAssignedToMe(item);
+      // The scope control ships with the pill row, so scope may only narrow the
+      // list while that row is on screen; otherwise a carried "My tasks" would
+      // filter a view that offers no way to clear it.
+      const matchesScope = !showsTaskFilterBar || !scopeToMine || isAssignedToMe(item);
 
       return matchesStatus && matchesFilter && matchesQuery && matchesScope;
     });
-  }, [tasks, activeStatus, activeFilter, query, activeView, activeScope, isAssignedToMe]);
+  }, [
+    tasks,
+    activeStatus,
+    activeFilter,
+    query,
+    activeView,
+    activeScope,
+    showsTaskFilterBar,
+    isAssignedToMe,
+  ]);
 
   const handleCreateFromCalendarSlot = useCallback(
     (prefill: { dueAt: Date; assignedTo?: string }) => {
@@ -319,7 +344,7 @@ const Tasks = () => {
 
         <PermissionGate allOf={[PERMISSIONS.TASKS_VIEW_ANY]} fallback={<Fallback />}>
           <div className={wrapperClassName}>
-            {activeView === 'list' && (
+            {showsTaskFilterBar && (
               <TaskFilterBar
                 filterOptions={TaskFilters}
                 statusOptions={TASK_STATUS_PILLS}

--- a/apps/frontend/src/app/hooks/usePermissions.ts
+++ b/apps/frontend/src/app/hooks/usePermissions.ts
@@ -1,6 +1,7 @@
 import { useMemo, useCallback } from 'react';
 import { useOrgStore } from '@/app/stores/orgStore';
 import type { Permission } from '@/app/lib/permissions';
+import { resolveMembershipPermissions } from '@/app/lib/routePermissions';
 
 type CanInput =
   | Permission
@@ -28,8 +29,12 @@ export const usePermissions = (explicitOrgId?: string | null): PermissionCheckRe
 
   const permissions = useMemo<string[]>(() => {
     if (!activeOrgId) return [];
-    const membership = membershipsByOrgId[activeOrgId];
-    return membership?.effectivePermissions ?? [];
+    // The stored effectivePermissions array is a snapshot written at save time,
+    // so a membership written before a permission joined the role table keeps a
+    // stale set and every PermissionGate silently hides features the role owns
+    // (audit trail, analytics). The backend already recomputes from the role on
+    // each request, so deriving here keeps the two sides in agreement.
+    return resolveMembershipPermissions(membershipsByOrgId[activeOrgId]);
   }, [activeOrgId, membershipsByOrgId]);
 
   const hasPermission = useCallback(

--- a/apps/frontend/src/app/lib/permissions.ts
+++ b/apps/frontend/src/app/lib/permissions.ts
@@ -75,13 +75,7 @@ export function toPermissionArray(input: string[] | undefined): Permission[] {
 }
 
 export type RoleCode =
-  | 'OWNER'
-  | 'ADMIN'
-  | 'SUPERVISOR'
-  | 'VETERINARIAN'
-  | 'TECHNICIAN'
-  | 'ASSISTANT'
-  | 'RECEPTIONIST';
+  'OWNER' | 'ADMIN' | 'SUPERVISOR' | 'VETERINARIAN' | 'TECHNICIAN' | 'ASSISTANT' | 'RECEPTIONIST';
 
 /**
  * Baseline permissions per role.
@@ -266,6 +260,7 @@ export const ROLE_PERMISSIONS: Record<RoleCode, Permission[]> = {
 
     'document:view:any',
     'document:edit:any',
+    'integrations:view:any',
   ],
 
   VETERINARIAN: [
@@ -314,6 +309,7 @@ export const ROLE_PERMISSIONS: Record<RoleCode, Permission[]> = {
 
     'labs:view:any',
     'labs:edit:any',
+    'integrations:view:any',
   ],
 
   TECHNICIAN: [
@@ -359,6 +355,7 @@ export const ROLE_PERMISSIONS: Record<RoleCode, Permission[]> = {
 
     'labs:view:any',
     'labs:edit:any',
+    'integrations:view:any',
   ],
 
   ASSISTANT: [
@@ -401,6 +398,7 @@ export const ROLE_PERMISSIONS: Record<RoleCode, Permission[]> = {
     'room:edit:any',
 
     'document:view:any',
+    'integrations:view:any',
   ],
 
   RECEPTIONIST: [
@@ -445,5 +443,6 @@ export const ROLE_PERMISSIONS: Record<RoleCode, Permission[]> = {
     'room:edit:any',
 
     'document:view:any',
+    'integrations:view:any',
   ],
 };

--- a/apps/frontend/src/app/lib/routePermissions.ts
+++ b/apps/frontend/src/app/lib/routePermissions.ts
@@ -1,5 +1,5 @@
 import { appRoutes } from '@/app/constants/routes';
-import { Permission, PERMISSIONS } from '@/app/lib/permissions';
+import { Permission, PERMISSIONS, ROLE_PERMISSIONS, RoleCode } from '@/app/lib/permissions';
 
 const ROUTE_ACCESS_OVERRIDES: ReadonlyArray<{ pathPrefix: string; requiredAny: Permission[] }> = [
   {
@@ -31,6 +31,39 @@ export const hasAnyRequiredPermission = (
 
   const permissionSet = new Set(effectivePermissions);
   return requiredAnyPermissions.some((permission) => permissionSet.has(permission));
+};
+
+type MembershipPermissionSource = {
+  roleCode?: string | null;
+  effectivePermissions?: string[] | null;
+  extraPermissions?: string[] | null;
+  revokedPermissions?: string[] | null;
+};
+
+/**
+ * Effective permissions for a membership, recomputed from its role instead of
+ * trusting the stored snapshot alone. Memberships persist effectivePermissions
+ * at write time, so a row written before a permission joined the role table
+ * keeps that stale set indefinitely, which silently greys out nav entries the
+ * role does own. Recomputing baseline + extras - revocations mirrors the
+ * backend formula, so drifted rows heal without a data migration while explicit
+ * revocations are still honoured. An unrecognised role falls back to the stored
+ * array so an unknown role never gains permissions it was never granted.
+ */
+export const resolveMembershipPermissions = (
+  membership?: MembershipPermissionSource | null
+): string[] => {
+  const stored = membership?.effectivePermissions ?? [];
+  const baseline = ROLE_PERMISSIONS[membership?.roleCode as RoleCode];
+  if (!baseline) return stored;
+
+  const granted = new Set<string>([
+    ...baseline,
+    ...(membership?.extraPermissions ?? []),
+    ...stored,
+  ]);
+  for (const permission of membership?.revokedPermissions ?? []) granted.delete(permission);
+  return [...granted];
 };
 
 const resolveRequiredAnyPermissionsForPath = (pathname: string): Permission[] | undefined => {

--- a/apps/frontend/src/app/lib/routePermissions.ts
+++ b/apps/frontend/src/app/lib/routePermissions.ts
@@ -35,6 +35,7 @@ export const hasAnyRequiredPermission = (
 
 type MembershipPermissionSource = {
   roleCode?: string | null;
+  active?: boolean | null;
   effectivePermissions?: string[] | null;
   extraPermissions?: string[] | null;
   revokedPermissions?: string[] | null;
@@ -53,16 +54,26 @@ type MembershipPermissionSource = {
 export const resolveMembershipPermissions = (
   membership?: MembershipPermissionSource | null
 ): string[] => {
+  // The backend only resolves permissions for an active mapping and treats a
+  // missing flag as active, so an explicitly deactivated membership grants
+  // nothing here either.
+  if (membership?.active === false) return [];
+
+  const extras = membership?.extraPermissions ?? [];
   const baseline = ROLE_PERMISSIONS[membership?.roleCode as RoleCode];
-  // Nothing to derive from, so the stored snapshot is the only signal left.
-  if (!baseline) return membership?.effectivePermissions ?? [];
+  // No baseline to derive from. The backend still grants the extras for a
+  // roleless mapping, so honour those alongside whatever was last stored
+  // rather than hiding routes the API allows.
+  if (!baseline) {
+    return [...new Set([...extras, ...(membership?.effectivePermissions ?? [])])];
+  }
 
   // Deliberately excludes the stored snapshot. Dropping a permission from the
   // role table leaves it in every previously written snapshot without ever
   // appearing in revokedPermissions, so folding those in would re-grant access
   // the API now denies. Matching the backend formula exactly keeps the two in
   // step in both directions.
-  const granted = new Set<string>([...baseline, ...(membership?.extraPermissions ?? [])]);
+  const granted = new Set<string>([...baseline, ...extras]);
   for (const permission of membership?.revokedPermissions ?? []) granted.delete(permission);
   return [...granted];
 };

--- a/apps/frontend/src/app/lib/routePermissions.ts
+++ b/apps/frontend/src/app/lib/routePermissions.ts
@@ -36,7 +36,6 @@ export const hasAnyRequiredPermission = (
 type MembershipPermissionSource = {
   roleCode?: string | null;
   active?: boolean | null;
-  effectivePermissions?: string[] | null;
   extraPermissions?: string[] | null;
   revokedPermissions?: string[] | null;
 };
@@ -61,18 +60,16 @@ export const resolveMembershipPermissions = (
 
   const extras = membership?.extraPermissions ?? [];
   const baseline = ROLE_PERMISSIONS[membership?.roleCode as RoleCode];
-  // No baseline to derive from. The backend still grants the extras for a
-  // roleless mapping, so honour those alongside whatever was last stored
-  // rather than hiding routes the API allows.
-  if (!baseline) {
-    return [...new Set([...extras, ...(membership?.effectivePermissions ?? [])])];
-  }
+  // No baseline to derive from, and the backend returns the extras verbatim in
+  // that case, so the extras are the whole grant.
+  if (!baseline) return [...new Set(extras)];
 
-  // Deliberately excludes the stored snapshot. Dropping a permission from the
-  // role table leaves it in every previously written snapshot without ever
-  // appearing in revokedPermissions, so folding those in would re-grant access
-  // the API now denies. Matching the backend formula exactly keeps the two in
-  // step in both directions.
+  // The stored effectivePermissions snapshot is deliberately never consulted.
+  // It is written at save time, so dropping a permission from the role table
+  // leaves it behind in every earlier snapshot without ever appearing in
+  // revokedPermissions; folding those in would re-grant access the API now
+  // denies. Deriving purely from role plus extras minus revocations is exactly
+  // what the backend recomputes on every request.
   const granted = new Set<string>([...baseline, ...extras]);
   for (const permission of membership?.revokedPermissions ?? []) granted.delete(permission);
   return [...granted];

--- a/apps/frontend/src/app/lib/routePermissions.ts
+++ b/apps/frontend/src/app/lib/routePermissions.ts
@@ -3,8 +3,12 @@ import { Permission, PERMISSIONS, ROLE_PERMISSIONS, RoleCode } from '@/app/lib/p
 
 const ROUTE_ACCESS_OVERRIDES: ReadonlyArray<{ pathPrefix: string; requiredAny: Permission[] }> = [
   {
+    // The workspace loads lab results and orders on open, and those routes
+    // require labs:view:any, so viewing the integration is not enough. Every
+    // role already carries integrations:view:any, so gating on the lab
+    // permission alone is the stricter of the two and needs no AND support.
     pathPrefix: '/appointments/idexx-workspace',
-    requiredAny: [PERMISSIONS.INTEGRATIONS_VIEW_ANY],
+    requiredAny: [PERMISSIONS.LABS_VIEW_ANY],
   },
   {
     pathPrefix: '/integrations',
@@ -59,10 +63,11 @@ export const resolveMembershipPermissions = (
   if (membership?.active === false) return [];
 
   const extras = membership?.extraPermissions ?? [];
-  const baseline = ROLE_PERMISSIONS[membership?.roleCode as RoleCode];
-  // No baseline to derive from, and the backend returns the extras verbatim in
-  // that case, so the extras are the whole grant.
-  if (!baseline) return [...new Set(extras)];
+  const roleCode = membership?.roleCode;
+  // No role at all: the backend returns the extras verbatim, without applying
+  // revocations. A role that is merely unrecognised is different - it falls
+  // through to an empty baseline below and still honours revocations.
+  if (!roleCode) return [...new Set(extras)];
 
   // The stored effectivePermissions snapshot is deliberately never consulted.
   // It is written at save time, so dropping a permission from the role table
@@ -70,6 +75,7 @@ export const resolveMembershipPermissions = (
   // revokedPermissions; folding those in would re-grant access the API now
   // denies. Deriving purely from role plus extras minus revocations is exactly
   // what the backend recomputes on every request.
+  const baseline = ROLE_PERMISSIONS[roleCode as RoleCode] ?? [];
   const granted = new Set<string>([...baseline, ...extras]);
   for (const permission of membership?.revokedPermissions ?? []) granted.delete(permission);
   return [...granted];

--- a/apps/frontend/src/app/lib/routePermissions.ts
+++ b/apps/frontend/src/app/lib/routePermissions.ts
@@ -1,14 +1,19 @@
 import { appRoutes } from '@/app/constants/routes';
 import { Permission, PERMISSIONS, ROLE_PERMISSIONS, RoleCode } from '@/app/lib/permissions';
 
-const ROUTE_ACCESS_OVERRIDES: ReadonlyArray<{ pathPrefix: string; requiredAny: Permission[] }> = [
+const ROUTE_ACCESS_OVERRIDES: ReadonlyArray<{
+  pathPrefix: string;
+  requiredAny?: Permission[];
+  requiredAll?: Permission[];
+}> = [
   {
-    // The workspace loads lab results and orders on open, and those routes
-    // require labs:view:any, so viewing the integration is not enough. Every
-    // role already carries integrations:view:any, so gating on the lab
-    // permission alone is the stricter of the two and needs no AND support.
+    // The workspace needs both grants: it loads lab results and orders from
+    // routes requiring labs:view:any, and reads the integration status from
+    // routes requiring integrations:view:any, so holding one without the other
+    // renders it empty. Role baselines always pair them, but extras and
+    // revocations can separate the two on a custom membership.
     pathPrefix: '/appointments/idexx-workspace',
-    requiredAny: [PERMISSIONS.LABS_VIEW_ANY],
+    requiredAll: [PERMISSIONS.LABS_VIEW_ANY, PERMISSIONS.INTEGRATIONS_VIEW_ANY],
   },
   {
     pathPrefix: '/integrations',
@@ -35,6 +40,17 @@ export const hasAnyRequiredPermission = (
 
   const permissionSet = new Set(effectivePermissions);
   return requiredAnyPermissions.some((permission) => permissionSet.has(permission));
+};
+
+export const hasAllRequiredPermissions = (
+  effectivePermissions: string[] | undefined,
+  requiredAllPermissions?: Permission[]
+): boolean => {
+  if (!requiredAllPermissions?.length) return true;
+  if (!effectivePermissions?.length) return false;
+
+  const permissionSet = new Set(effectivePermissions);
+  return requiredAllPermissions.every((permission) => permissionSet.has(permission));
 };
 
 type MembershipPermissionSource = {
@@ -81,14 +97,16 @@ export const resolveMembershipPermissions = (
   return [...granted];
 };
 
-const resolveRequiredAnyPermissionsForPath = (pathname: string): Permission[] | undefined => {
+const resolveRouteAccessRequirements = (
+  pathname: string
+): { any?: Permission[]; all?: Permission[] } => {
   const override = ROUTE_ACCESS_OVERRIDES.find((rule) => matchesPath(pathname, rule.pathPrefix));
   if (override) {
-    return override.requiredAny;
+    return { any: override.requiredAny, all: override.requiredAll };
   }
 
   const route = appRoutes.find((item) => matchesPath(pathname, item.href));
-  return route?.requiredAnyPermissions;
+  return { any: route?.requiredAnyPermissions };
 };
 
 export const canAccessPathByPermissions = (
@@ -96,8 +114,11 @@ export const canAccessPathByPermissions = (
   effectivePermissions: string[] | undefined
 ): boolean => {
   const normalizedPath = normalizePath(pathname);
-  const requiredAnyPermissions = resolveRequiredAnyPermissionsForPath(normalizedPath);
-  return hasAnyRequiredPermission(effectivePermissions, requiredAnyPermissions);
+  const { any, all } = resolveRouteAccessRequirements(normalizedPath);
+  return (
+    hasAnyRequiredPermission(effectivePermissions, any) &&
+    hasAllRequiredPermissions(effectivePermissions, all)
+  );
 };
 
 export const resolveFirstAccessibleAppRoute = (

--- a/apps/frontend/src/app/lib/routePermissions.ts
+++ b/apps/frontend/src/app/lib/routePermissions.ts
@@ -53,15 +53,16 @@ type MembershipPermissionSource = {
 export const resolveMembershipPermissions = (
   membership?: MembershipPermissionSource | null
 ): string[] => {
-  const stored = membership?.effectivePermissions ?? [];
   const baseline = ROLE_PERMISSIONS[membership?.roleCode as RoleCode];
-  if (!baseline) return stored;
+  // Nothing to derive from, so the stored snapshot is the only signal left.
+  if (!baseline) return membership?.effectivePermissions ?? [];
 
-  const granted = new Set<string>([
-    ...baseline,
-    ...(membership?.extraPermissions ?? []),
-    ...stored,
-  ]);
+  // Deliberately excludes the stored snapshot. Dropping a permission from the
+  // role table leaves it in every previously written snapshot without ever
+  // appearing in revokedPermissions, so folding those in would re-grant access
+  // the API now denies. Matching the backend formula exactly keeps the two in
+  // step in both directions.
+  const granted = new Set<string>([...baseline, ...(membership?.extraPermissions ?? [])]);
   for (const permission of membership?.revokedPermissions ?? []) granted.delete(permission);
   return [...granted];
 };

--- a/apps/frontend/src/app/ui/layout/PhoneShell/usePhoneNavGate.ts
+++ b/apps/frontend/src/app/ui/layout/PhoneShell/usePhoneNavGate.ts
@@ -36,7 +36,9 @@ export function usePhoneNavGate(): PhoneNavGate {
   );
   const effectivePermissions = resolveMembershipPermissions(membership);
 
-  const orgMissing = !primaryOrg;
+  // A deactivated mapping counts as no org: an empty permission set alone would
+  // still leave routes that declare no required permission reachable.
+  const orgMissing = !primaryOrg || membership?.active === false;
   const orgVerified = !!primaryOrg?.isVerified;
 
   const isRouteEnabled = (routeName?: string): boolean => {

--- a/apps/frontend/src/app/ui/layout/PhoneShell/usePhoneNavGate.ts
+++ b/apps/frontend/src/app/ui/layout/PhoneShell/usePhoneNavGate.ts
@@ -3,7 +3,7 @@
 import { usePathname, useRouter } from 'next/navigation';
 
 import { appRoutes } from '@/app/config/routes';
-import { hasAnyRequiredPermission } from '@/app/lib/routePermissions';
+import { hasAnyRequiredPermission, resolveMembershipPermissions } from '@/app/lib/routePermissions';
 import { startRouteLoader, stopRouteLoader } from '@/app/lib/routeLoader';
 import { useOrgStore } from '@/app/stores/orgStore';
 import { usePrimaryOrg } from '@/app/hooks/useOrgSelectors';
@@ -34,7 +34,7 @@ export function usePhoneNavGate(): PhoneNavGate {
   const membership = useOrgStore((s) =>
     primaryOrgId ? (s.membershipsByOrgId?.[primaryOrgId] ?? null) : null
   );
-  const effectivePermissions = membership?.effectivePermissions ?? [];
+  const effectivePermissions = resolveMembershipPermissions(membership);
 
   const orgMissing = !primaryOrg;
   const orgVerified = !!primaryOrg?.isVerified;

--- a/apps/frontend/src/app/ui/layout/Sidebar/Sidebar.tsx
+++ b/apps/frontend/src/app/ui/layout/Sidebar/Sidebar.tsx
@@ -143,7 +143,9 @@ const Sidebar = () => {
   // Developer portal doesn't need org data to load
   if (isInitialLoading && !isDevPortal) return <div className="sidebar"></div>;
 
-  const orgMissing = !primaryOrg;
+  // A deactivated mapping counts as no org: an empty permission set alone would
+  // still leave routes that declare no required permission reachable.
+  const orgMissing = !primaryOrg || membership?.active === false;
   const orgVerified = !!primaryOrg?.isVerified;
 
   return (

--- a/apps/frontend/src/app/ui/layout/Sidebar/Sidebar.tsx
+++ b/apps/frontend/src/app/ui/layout/Sidebar/Sidebar.tsx
@@ -28,7 +28,7 @@ import { useLoadSpecialitiesForPrimaryOrg } from '@/app/hooks/useSpecialities';
 import { appRoutes, devRoutes } from '@/app/config/routes';
 import type { RouteItem } from '@/app/config/routes';
 import { startRouteLoader, stopRouteLoader } from '@/app/lib/routeLoader';
-import { hasAnyRequiredPermission } from '@/app/lib/routePermissions';
+import { hasAnyRequiredPermission, resolveMembershipPermissions } from '@/app/lib/routePermissions';
 import {
   isSidebarCollapsedByDefault,
   setSidebarCollapsedPreference,
@@ -106,7 +106,7 @@ const Sidebar = () => {
   const membership = useOrgStore((s) =>
     primaryOrgId ? (s.membershipsByOrgId?.[primaryOrgId] ?? null) : null
   );
-  const effectivePermissions = membership?.effectivePermissions ?? [];
+  const effectivePermissions = resolveMembershipPermissions(membership);
 
   const routeIcons = useMemo(() => ROUTE_ICONS, []);
 

--- a/apps/frontend/src/app/ui/layout/guards/OrgGuard.tsx
+++ b/apps/frontend/src/app/ui/layout/guards/OrgGuard.tsx
@@ -238,7 +238,12 @@ const resolveGuardRedirect = ({
 }: GuardRedirectParams): string | null => {
   if (isAuthGuardDisabled || isStatusPending(orgStatus) || shouldWaitForData) return null;
   if (!primaryOrgId) return getOrgFallbackRedirect(pathname);
-  if (!primaryOrg || !membership) return getOrgFallbackRedirect(pathname);
+  // A deactivated mapping is treated as no membership at all: returning no
+  // permissions is not enough on its own, because routes that declare no
+  // required permission stay reachable for an empty permission set.
+  if (!primaryOrg || !membership || membership.active === false) {
+    return getOrgFallbackRedirect(pathname);
+  }
 
   return resolveReadyOrgGuardRedirect({
     pathname,
@@ -353,7 +358,7 @@ const OrgGuard = ({ children, skeleton = null }: OrgGuardProps) => {
       return;
     }
 
-    if (!primaryOrg || !membership) {
+    if (!primaryOrg || !membership || membership.active === false) {
       return;
     }
 

--- a/apps/frontend/src/app/ui/layout/guards/OrgGuard.tsx
+++ b/apps/frontend/src/app/ui/layout/guards/OrgGuard.tsx
@@ -31,6 +31,7 @@ import { getStorage, getStorageItem, setStorageItem } from '@/app/lib/browserSto
 import {
   canAccessPathByPermissions,
   resolveFirstAccessibleAppRoute,
+  resolveMembershipPermissions,
 } from '@/app/lib/routePermissions';
 import { appRoutes } from '@/app/constants/routes';
 
@@ -210,7 +211,7 @@ const resolveReadyOrgGuardRedirect = ({
   });
   if (orgRedirect && orgRedirect !== pathname) return orgRedirect;
 
-  const effectivePermissions = membership.effectivePermissions ?? [];
+  const effectivePermissions = resolveMembershipPermissions(membership);
   const permissionsFallbackRedirect = getPermissionsFallbackRedirect(
     pathname,
     effectivePermissions
@@ -370,7 +371,7 @@ const OrgGuard = ({ children, skeleton = null }: OrgGuardProps) => {
 
     if (redirectTo && redirectTo !== pathname) return;
 
-    const effectivePermissions = membership.effectivePermissions ?? [];
+    const effectivePermissions = resolveMembershipPermissions(membership);
     const permissionsFallbackRedirect = getPermissionsFallbackRedirect(
       pathname,
       effectivePermissions

--- a/apps/frontend/src/app/ui/layout/guards/OrgGuard.tsx
+++ b/apps/frontend/src/app/ui/layout/guards/OrgGuard.tsx
@@ -161,7 +161,7 @@ const getOrgFallbackRedirect = (pathname: string): string | null => {
 // resolution lives in exactly one place; both guard paths need the same answer.
 const getPermissionsFallbackRedirect = (
   pathname: string,
-  membership: Parameters<typeof resolveMembershipPermissions>[0]
+  membership: UserOrganization
 ): string | null => {
   const effectivePermissions = resolveMembershipPermissions(membership);
   if (canAccessPathByPermissions(pathname, effectivePermissions)) return null;

--- a/apps/frontend/src/app/ui/layout/guards/OrgGuard.tsx
+++ b/apps/frontend/src/app/ui/layout/guards/OrgGuard.tsx
@@ -157,10 +157,13 @@ const getOrgFallbackRedirect = (pathname: string): string | null => {
   return pathname === '/organizations' ? null : '/organizations';
 };
 
+// Takes the membership rather than a permission array so the role-derived
+// resolution lives in exactly one place; both guard paths need the same answer.
 const getPermissionsFallbackRedirect = (
   pathname: string,
-  effectivePermissions: string[]
+  membership: Parameters<typeof resolveMembershipPermissions>[0]
 ): string | null => {
+  const effectivePermissions = resolveMembershipPermissions(membership);
   if (canAccessPathByPermissions(pathname, effectivePermissions)) return null;
   const fallbackRoute = resolveFirstAccessibleAppRoute(effectivePermissions);
   if (fallbackRoute === pathname) return null;
@@ -211,11 +214,7 @@ const resolveReadyOrgGuardRedirect = ({
   });
   if (orgRedirect && orgRedirect !== pathname) return orgRedirect;
 
-  const effectivePermissions = resolveMembershipPermissions(membership);
-  const permissionsFallbackRedirect = getPermissionsFallbackRedirect(
-    pathname,
-    effectivePermissions
-  );
+  const permissionsFallbackRedirect = getPermissionsFallbackRedirect(pathname, membership);
   if (permissionsFallbackRedirect) return permissionsFallbackRedirect;
 
   const preferredLanding = resolveDefaultOpenScreenRouteForProfile({
@@ -371,11 +370,7 @@ const OrgGuard = ({ children, skeleton = null }: OrgGuardProps) => {
 
     if (redirectTo && redirectTo !== pathname) return;
 
-    const effectivePermissions = resolveMembershipPermissions(membership);
-    const permissionsFallbackRedirect = getPermissionsFallbackRedirect(
-      pathname,
-      effectivePermissions
-    );
+    const permissionsFallbackRedirect = getPermissionsFallbackRedirect(pathname, membership);
     if (permissionsFallbackRedirect) return;
 
     const preferredLanding = resolveDefaultOpenScreenRouteForProfile({


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

Reported from the deployed dev environment, comparing the Tasks view against the Appointments view.

1. Tasks planner: `Pending` / `In progress` / `Completed` render as a standalone pill row above the calendar, whereas the appointments planner keeps status inside the calendar header as an `All statuses` dropdown.
2. Tasks planner: a `My tasks` / `Team` scope toggle plus `All` / `Team` audience pills sit in that same row, duplicating the `Day` / `Week` / `Team` switcher the calendar header already provides.
3. Integrations: every coming-soon card prints "Coming soon" twice, once as the header status pill and again in the action slot.
4. Integrations: "Open manuals" is a filled primary button while the equivalent "Open workspace" action is outlined, so two active integrations look different.
5. Sidebar: `Dashboard` renders greyed out and unclickable for an organisation owner.
6. Audit trail renders empty everywhere it appears (appointment info tab, workspace activity panel, companion history), for a user whose role does grant `audit:view:any`.

Items 5 and 6 turned out to be the same defect. `effectivePermissions` is persisted on the membership as a snapshot at write time. A row written before a permission joined the role table keeps that stale set indefinitely. The backend does not have this problem: `rbac.ts` recomputes from the role on every request and persists the corrected set, so the API returns audit rows and analytics happily. The client trusted the snapshot, so `usePermissions` under-reported permissions and every `PermissionGate` hid features the role owns, while the sidebar greyed the matching routes.

## What is the new behavior?

1. Task statuses move into the calendar header as the shared `All statuses` dropdown. `TaskCalendar` now forwards status and filter props to the calendar `Header`, which already supported them.
2. The scope toggle and the `All` / `Team` audience pills are removed from the planner, since `Day` / `Week` / `Team` already expresses that split. Only the pet-parent pill remains, beside the status dropdown, as the counterpart to the appointments `Emergencies` pill. The list view keeps the full pill row because it has no calendar switcher, and page-level scope no longer narrows views that cannot clear it.
3. Coming-soon cards now read "Notify me" in the action slot, with the outlined treatment the design specifies, so the status appears once.
4. "Open manuals" uses the same outlined button as "Open workspace".
5 and 6. Permission checks resolve from the membership role (baseline plus extras minus revocations), mirroring the backend formula, instead of trusting the stored snapshot. This is applied at the shared sources: `usePermissions` (behind every `PermissionGate`), `OrgGuard`, `Sidebar` and `usePhoneNavGate`. Drifted rows heal without a data migration, explicit revocations still apply, and an unrecognised role falls back to the stored array so it never gains permissions it was not granted.

A minor supporting change: calendar filter pills accept an optional `dotColor` so the pet-parent pill can carry its pink dot, the same way `Emergencies` carries a red one.

### Impact area

`apps/frontend` only. Tasks planner, integrations catalog, and the shared permission resolution behind `PermissionGate`, `OrgGuard`, sidebar and phone nav. No backend, schema or dependency changes. Server-side authorisation is unchanged and still enforces independently.

### Validation performed

- `pnpm --filter frontend run type-check`: clean
- `eslint` on all changed files: clean
- Full frontend suite: **857 suites, 10493 tests passing** (run in full because permission resolution is app-wide)
- New coverage for the role-derived resolver: stale-snapshot repair, revocation handling, unknown-role fallback
- Tests updated for the moved planner controls. The `OrgGuard` fixture paired `roleCode: ADMIN` with a snapshot that contradicted it, so it now revokes the integrations grant explicitly and expects the dashboard fallback the ADMIN baseline actually allows.

Not yet done: a browser pass on the deployed branch, and the local Sonar and Aikido scans. Opening as draft for that reason.

## Related Issue(s)

Related to #1906 (integration pill consistency). The tasks toolbar, owner nav gating and audit trail visibility are not yet tracked by an issue.

Fixes #
