### PR TITLE
fix(repo): scope the chat conversation list to the active organisation

### DIFF
--- a/apps/backend/src/controllers/app/chat.controller.ts
+++ b/apps/backend/src/controllers/app/chat.controller.ts
@@ -379,7 +379,13 @@ export const ChatController = {
 
       const sessions = await prisma.chatSession.findMany({
         where: {
-          organisationId,
+          // A cross-clinic chat is stored against the requesting clinic with the
+          // other one as counterpart, so matching organisationId alone hides the
+          // conversation from the clinic that was invited into it.
+          OR: [
+            { organisationId },
+            { counterpartOrganisationId: organisationId },
+          ],
           members: { has: userId },
           ...(includeClosed ? {} : { status: { not: "CLOSED" } }),
         },

--- a/apps/backend/src/services/chat.service.ts
+++ b/apps/backend/src/services/chat.service.ts
@@ -33,6 +33,10 @@ type YosemiteChannelData = ChannelData & {
   name?: string;
   appointmentId?: string;
   organisationId?: string;
+  // Every organisation the channel belongs to. Clients scope their channel list
+  // by this field, so a channel without it shows up in every organisation the
+  // member belongs to. Cross-clinic chats carry both sides.
+  organisationIds?: string[];
   patientId?: string;
   parentId?: string;
   vetId?: string | null;
@@ -297,6 +301,7 @@ export const ChatService = {
       name: `Appointment Chat`,
       appointmentId,
       organisationId: orgId,
+      organisationIds: [orgId],
       patientId,
       parentId,
       vetId,
@@ -372,12 +377,14 @@ export const ChatService = {
 
     const channelId = `od_${hash}`;
 
-    await streamServer
-      .channel("team", channelId, {
-        members,
-        created_by_id: userA,
-      })
-      .create();
+    const directChannelData: YosemiteChannelData = {
+      members,
+      created_by_id: userA,
+      organisationId,
+      organisationIds: [organisationId],
+    };
+
+    await streamServer.channel("team", channelId, directChannelData).create();
 
     const session = await prisma.chatSession.create({
       data: {
@@ -440,6 +447,8 @@ export const ChatService = {
       isPrivate,
       members,
       created_by_id: createdBy,
+      organisationId,
+      organisationIds: [organisationId],
     };
 
     await streamServer.channel("team", channelId, channelData).create();

--- a/apps/backend/src/services/networkChat.service.ts
+++ b/apps/backend/src/services/networkChat.service.ts
@@ -1,5 +1,5 @@
 // src/services/networkChat.service.ts
-import { StreamChat } from "stream-chat";
+import { ChannelData, StreamChat } from "stream-chat";
 import crypto from "node:crypto";
 
 import { ChatServiceError } from "./chat.service";
@@ -277,12 +277,15 @@ export const NetworkChatService = {
     );
     const channelId = `nd_${hash}`;
 
-    await streamServer
-      .channel("team", channelId, {
-        members,
-        created_by_id: requesterUserId,
-      })
-      .create();
+    // Both clinics list this conversation, so it is scoped to the pair rather
+    // than to the requester alone.
+    const channelData: ChannelData & { organisationIds: string[] } = {
+      members,
+      created_by_id: requesterUserId,
+      organisationIds: [requesterOrgId, otherOrgId],
+    };
+
+    await streamServer.channel("team", channelId, channelData).create();
 
     const session = await prisma.chatSession.create({
       data: {

--- a/apps/backend/test/controllers/chat.controller.test.ts
+++ b/apps/backend/test/controllers/chat.controller.test.ts
@@ -476,6 +476,19 @@ describe("ChatController.listMySessions", () => {
     ]);
   });
 
+  it("matches the organisation on either side of a cross-clinic session", async () => {
+    findMany.mockResolvedValue([{ id: "s1" }]);
+    const res = makeRes();
+    await ChatController.listMySessions(
+      makeReq({ params: { organisationId: "o1" } }),
+      res,
+    );
+    expect(findMany.mock.calls[0][0].where.OR).toEqual([
+      { organisationId: "o1" },
+      { counterpartOrganisationId: "o1" },
+    ]);
+  });
+
   it("excludes closed sessions by default", async () => {
     findMany.mockResolvedValue([{ id: "s1" }]);
     const res = makeRes();

--- a/apps/backend/test/services/chat.service.coverage.test.ts
+++ b/apps/backend/test/services/chat.service.coverage.test.ts
@@ -151,7 +151,11 @@ describe("ChatService.ensureAppointmentChat", () => {
     expect(mockChannel).toHaveBeenCalledWith(
       "messaging",
       "appointment-a1",
-      expect.objectContaining({ appointmentId: "a1", organisationId: "org1" }),
+      expect.objectContaining({
+        appointmentId: "a1",
+        organisationId: "org1",
+        organisationIds: ["org1"],
+      }),
     );
     expect(mockCreate).toHaveBeenCalled();
     // parent + vet + system upserts
@@ -248,7 +252,10 @@ describe("ChatService.createOrgDirectChat", () => {
     expect(mockChannel).toHaveBeenCalledWith(
       "team",
       expect.stringMatching(/^od_/),
-      expect.objectContaining({ members: ["userA", "userB"] }),
+      expect.objectContaining({
+        members: ["userA", "userB"],
+        organisationIds: ["org1"],
+      }),
     );
     expect(mockUpsertUser).toHaveBeenCalledTimes(2);
     expect(mockedPrisma.chatSession.create).toHaveBeenCalledWith(
@@ -291,7 +298,11 @@ describe("ChatService.createOrgGroupChat", () => {
     expect(mockChannel).toHaveBeenCalledWith(
       "team",
       expect.stringMatching(/^org-group-/),
-      expect.objectContaining({ name: "Team", created_by_id: "owner" }),
+      expect.objectContaining({
+        name: "Team",
+        created_by_id: "owner",
+        organisationIds: ["org1"],
+      }),
     );
     expect(mockedPrisma.chatSession.create).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/backend/test/services/networkChat.service.test.ts
+++ b/apps/backend/test/services/networkChat.service.test.ts
@@ -357,6 +357,12 @@ describe("NetworkChatService.createNetworkDirectChat", () => {
 
     expect(mockUpsertUser).toHaveBeenCalledTimes(2);
     expect(mockChannel).toHaveBeenCalledTimes(1);
+    // Both clinics list the conversation, so the channel is stamped with both.
+    expect(mockChannel).toHaveBeenCalledWith(
+      "team",
+      expect.stringMatching(/^nd_/),
+      expect.objectContaining({ organisationIds: ["org1", "org2"] }),
+    );
     expect(mockCreate).toHaveBeenCalledTimes(1);
     const createArgs = mockedPrisma.chatSession.create.mock.calls[0][0].data;
     expect(createArgs).toMatchObject({

--- a/apps/frontend/src/app/__tests__/components/chat/ChatCommandPalette.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/chat/ChatCommandPalette.test.tsx
@@ -71,6 +71,23 @@ describe('ChatCommandPalette', () => {
     expect(screen.getByText('Tim')).toBeInTheDocument();
   });
 
+  it('drops conversations that do not belong to the active organisation', async () => {
+    const client = makeClient();
+    render(
+      <ChatCommandPalette
+        client={client}
+        filters={filters}
+        onJump={jest.fn()}
+        channelBelongsToOrg={(channel) => channel.id === 'c1'}
+      />
+    );
+
+    await openPalette();
+
+    await waitFor(() => expect(screen.getByText('Bella')).toBeInTheDocument());
+    expect(screen.queryByText('Tim')).not.toBeInTheDocument();
+  });
+
   it('opens on Ctrl+K as well', async () => {
     const client = makeClient();
     render(<ChatCommandPalette client={client} filters={filters} onJump={jest.fn()} />);

--- a/apps/frontend/src/app/__tests__/components/chat/ChatContainer.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/chat/ChatContainer.test.tsx
@@ -304,8 +304,11 @@ describe('ChatContainer', () => {
       { id: 'u2', userId: 'user-2', name: 'User Two', email: 'u2@test.com' },
       { id: 'u3', userId: 'user-3', name: 'User Three', email: 'u3@test.com' },
     ]);
+    // The org-scoped session list doubles as the organisation allow-list for
+    // channels created before channels carried an organisation stamp, so the
+    // default mock claims the shared fixture channel for the active org.
     (chatService.getChatSessions as jest.Mock).mockResolvedValue({
-      channels: [],
+      channels: [{ channelId: 'channel-1' }],
     });
     (chatService.listOrgChatSessions as jest.Mock).mockResolvedValue([]);
 
@@ -1224,6 +1227,74 @@ describe('ChatContainer', () => {
       expect(result).toContain(byMember);
       expect(result).not.toContain(stateless);
       expect(result).not.toContain(unrelated);
+    });
+  });
+
+  describe('channel filtering by organisation', () => {
+    type FilterFn = (channels: unknown[]) => unknown[];
+    const getFilter = () =>
+      (globalThis as unknown as { __testChannelFilter?: FilterFn }).__testChannelFilter;
+
+    const renderForFilter = async () => {
+      await act(async () => {
+        render(<ChatContainer scope="clients" />);
+      });
+      await waitFor(() => expect(getFilter()).toBeDefined());
+      return getFilter() as FilterFn;
+    };
+
+    const clientChannel = (id: string, data: Record<string, unknown>) => ({
+      ...defaultMockChannel,
+      id,
+      type: 'messaging',
+      data: { appointmentId: `appt-${id}`, ...data },
+      state: { members: {} },
+    });
+
+    it('drops a channel stamped with another organisation', async () => {
+      const mine = clientChannel('mine', { organisationId: 'org-1' });
+      const theirs = clientChannel('theirs', { organisationId: 'org-2' });
+      const filter = await renderForFilter();
+
+      const result = filter([mine, theirs]);
+      expect(result).toContain(mine);
+      expect(result).not.toContain(theirs);
+    });
+
+    it('keeps a cross-clinic channel that lists the active organisation', async () => {
+      const shared = clientChannel('shared', { organisationIds: ['org-2', 'org-1'] });
+      const foreign = clientChannel('foreign', { organisationIds: ['org-2', 'org-3'] });
+      const filter = await renderForFilter();
+
+      const result = filter([shared, foreign]);
+      expect(result).toContain(shared);
+      expect(result).not.toContain(foreign);
+    });
+
+    it('drops an unstamped channel the organisation has no session for', async () => {
+      const known = clientChannel('channel-1', {});
+      const unknown = clientChannel('other-org-channel', {});
+      const filter = await renderForFilter();
+
+      const result = filter([known, unknown]);
+      expect(result).toContain(known);
+      expect(result).not.toContain(unknown);
+    });
+
+    it('keeps unstamped channels when the session list could not be loaded', async () => {
+      (chatService.getChatSessions as jest.Mock).mockRejectedValue(new Error('offline'));
+      const unknown = clientChannel('other-org-channel', {});
+      const filter = await renderForFilter();
+
+      expect(filter([unknown])).toContain(unknown);
+    });
+
+    it('scopes to the organisation switched into rather than the one loaded before', async () => {
+      const theirs = clientChannel('theirs', { organisationId: 'org-2' });
+      const filter = await renderForFilter();
+
+      expect(filter([theirs])).not.toContain(theirs);
+      expect(chatService.getChatSessions).toHaveBeenCalledWith('org-1', { includeClosed: true });
     });
   });
 

--- a/apps/frontend/src/app/features/chat/components/ChatCommandPalette.tsx
+++ b/apps/frontend/src/app/features/chat/components/ChatCommandPalette.tsx
@@ -28,7 +28,17 @@ export function ChatCommandPalette({
   client,
   filters,
   onJump,
-}: Readonly<{ client: StreamChat; filters: ChannelFilters; onJump: (id: string) => void }>) {
+  channelBelongsToOrg,
+}: Readonly<{
+  client: StreamChat;
+  filters: ChannelFilters;
+  onJump: (id: string) => void;
+  // Stream has no server-side organisation scope, so the palette drops the
+  // conversations that belong to another organisation the same way the sidebar
+  // list does. Jumping to one of those would open a channel the active
+  // organisation cannot otherwise see.
+  channelBelongsToOrg?: (channel: Channel) => boolean;
+}>) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
   const [channels, setChannels] = useState<Channel[]>([]);
@@ -66,7 +76,7 @@ export function ChatCommandPalette({
     client
       .queryChannels(filters, PALETTE_SORT, { limit: 30 })
       .then((res) => {
-        if (active) setChannels(res);
+        if (active) setChannels(channelBelongsToOrg ? res.filter(channelBelongsToOrg) : res);
       })
       .catch(() => {
         if (active) setChannels([]);
@@ -74,7 +84,7 @@ export function ChatCommandPalette({
     return () => {
       active = false;
     };
-  }, [open, client, filters]);
+  }, [open, client, filters, channelBelongsToOrg]);
 
   const results = useMemo(() => {
     const q = query.trim().toLowerCase();

--- a/apps/frontend/src/app/features/chat/components/ChatContainer.tsx
+++ b/apps/frontend/src/app/features/chat/components/ChatContainer.tsx
@@ -1028,6 +1028,14 @@ const useChatContainerView = ({
   const [orgUsersStatus, setOrgUsersStatus] = useState<'idle' | 'loading' | 'loaded'>('idle');
   const orgUsersLoading = orgUsersStatus === 'loading';
   const [chatSessionChannels, setChatSessionChannels] = useState<any[]>([]);
+  // Stream returns every channel the signed-in user belongs to, across all of
+  // their organisations, so the list is scoped against the channels the backend
+  // reports for the active organisation. Tagged with the org it was loaded for
+  // so a stale response is never applied to the org switched into.
+  const [orgChannelIds, setOrgChannelIds] = useState<{
+    orgId: string;
+    ids: Set<string>;
+  } | null>(null);
   const [directSearch, setDirectSearch] = useState('');
   const [searchTerm, setSearchTerm] = useState('');
   const [shareChannelId, setShareChannelId] = useState<string | null>(null);
@@ -1095,14 +1103,27 @@ const useChatContainerView = ({
 
   const refreshStatuses = useCallback(() => {
     if (!primaryOrgId) return;
-    getChatSessions(primaryOrgId, { includeClosed: true })
+    const requestedOrgId = primaryOrgId;
+    getChatSessions(requestedOrgId, { includeClosed: true })
       .then((response) => {
         const payload: any = response ?? {};
         const channels = getSessionChannels(payload);
         setChatSessionChannels(channels);
+        setOrgChannelIds({
+          orgId: requestedOrgId,
+          ids: new Set<string>(
+            channels
+              .map((session: any) => String(session?.channelId ?? ''))
+              .filter((channelId: string) => channelId.length > 0)
+          ),
+        });
       })
       .catch((err) => {
         console.error('Failed to load chat session statuses:', err);
+        // Without the organisation's session list there is nothing to scope the
+        // channel list by, so drop the allow-list rather than emptying the
+        // sidebar on a transient API failure.
+        setOrgChannelIds(null);
       });
   }, [getSessionChannels, primaryOrgId]);
 
@@ -1343,6 +1364,27 @@ const useChatContainerView = ({
     [handlePreviewSelect, client?.userID, showArchived]
   );
 
+  const belongsToPrimaryOrg = useCallback(
+    (chan: StreamChannel) => {
+      /* v8 ignore next -- unreachable: the Stream client is only created once an org is selected, and nothing that uses this predicate renders until the client exists */
+      if (!primaryOrgId) return true;
+      const data = chan.data as { organisationId?: string; organisationIds?: string[] } | undefined;
+      // Cross-clinic conversations belong to both sides, so the stamp is a
+      // list; single-org channels written before it existed carry the scalar.
+      const declaredOrgIds = data?.organisationIds ?? [];
+      const stamped = declaredOrgIds.length
+        ? declaredOrgIds
+        : [data?.organisationId].filter(Boolean);
+      if (stamped.length) return stamped.includes(primaryOrgId);
+      // Channels created before the stamp fall back to the backend's org-scoped
+      // session list, which is only trusted once it has loaded for the
+      // organisation currently selected.
+      if (orgChannelIds?.orgId !== primaryOrgId) return true;
+      return orgChannelIds.ids.has(chan.id ?? '');
+    },
+    [primaryOrgId, orgChannelIds]
+  );
+
   const channelFilter = useCallback<NonNullable<ChannelListProps['channelRenderFilterFn']>>(
     (channels) => {
       const scopeMatches = (chan: StreamChannel) => {
@@ -1382,9 +1424,11 @@ const useChatContainerView = ({
           .join(' ');
         return name.includes(q) || members.includes(q);
       };
-      return channels.filter((chan) => scopeMatches(chan) && searchMatches(chan));
+      return channels.filter(
+        (chan) => belongsToPrimaryOrg(chan) && scopeMatches(chan) && searchMatches(chan)
+      );
     },
-    [scope, searchTerm]
+    [scope, searchTerm, belongsToPrimaryOrg]
   );
 
   const shareContextValue = useMemo(
@@ -1948,7 +1992,12 @@ const useChatContainerView = ({
           />
         }
       />
-      <ChatCommandPalette client={client} filters={filters} onJump={activateChannelById} />
+      <ChatCommandPalette
+        client={client}
+        filters={filters}
+        onJump={activateChannelById}
+        channelBelongsToOrg={belongsToPrimaryOrg}
+      />
     </>
   );
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The Chat page lists the same conversations in every organisation the signed-in user belongs to. Switching clinics in the header changes the org context everywhere else, but the chat sidebar keeps showing an identical list, including client chats belonging to the other clinic.

Stream Chat has no server-side notion of our organisations, and `ChatContainer` queried it with membership only:

```js
{ type: { $in: ['messaging', 'team'] }, members: { $in: [client.userID] } }
```

Every channel the user is a member of therefore rendered in every organisation. Colleague and group chats made this unfixable client-side too: their Stream channel data carried no organisation field at all.

## What is the new behavior?

Backend

- Direct, group and appointment channels are stamped with `organisationIds` in their Stream channel data; cross-clinic channels carry both clinics.
- `listMySessions` matches `counterpartOrganisationId` as well as `organisationId`, so a cross-clinic conversation is returned to the clinic that was invited into it rather than only to the one that started it.

Frontend

- `ChatContainer` drops channels stamped for another organisation, in both the sidebar list and the Cmd+K jump palette.
- Channels created before the stamp fall back to the backend's org-scoped session list (already fetched for chat statuses). That allow-list is only consulted once it has loaded for the organisation currently selected, so a failed or in-flight request leaves the list unfiltered instead of emptying it.

## Impact area

`apps/frontend` chat feature, `apps/backend` chat + network-chat services and the session list endpoint. No schema change, no migration - `counterpartOrganisationId` already exists on `ChatSession`.

## Validation performed

- `npx tsc --noemit` (apps/frontend) - clean.
- `eslint` on the four changed frontend files - clean.
- `pnpm --filter frontend run test --testPathPattern="chat/(ChatContainer|ChatCommandPalette)"` - 177 passed, including 5 new organisation-scoping cases and a new palette case.
- Coverage over the two changed components: 99.73% statements, 97.59% branches, 99.73% lines.
- `pnpm --filter backend run test --testPathPattern="(chat.controller|chat.service|networkChat.service)"` - 123 passed, including new assertions for the org stamp and the counterpart match.
- Backend `tsc` reports no errors in the touched files (this worktree has a pre-existing repo-wide type-check baseline unrelated to this change).

Not verified in a browser: the chat surface needs a signed-in session and local login is blocked by the SuperTokens cross-origin setup, so the behaviour should be confirmed on the deployed branch by switching organisations with a two-clinic account.

## Related Issue(s)

Fixes #1974
