### PR TITLE
refactor(frontend): shared StatusPill primitive and app-wide status badge convergence

### DIFF
--- a/apps/frontend/src/app/__tests__/components/chat/SharedEntityCard.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/chat/SharedEntityCard.test.tsx
@@ -85,7 +85,7 @@ describe('SharedEntityCard', () => {
       />
     );
     const pill = screen.getByText('PAID');
-    expect(pill).toHaveStyle({ background: 'var(--status-completed-bg)' });
+    expect(pill).toHaveStyle({ backgroundColor: 'var(--status-completed-bg)' });
   });
 
   it('falls back to the requested tone for an unmapped status', () => {
@@ -94,7 +94,9 @@ describe('SharedEntityCard', () => {
         entity={makeEntity({ entityType: 'INVOICE', snapshot: { status: 'MYSTERY' } })}
       />
     );
-    expect(screen.getByText('MYSTERY')).toHaveStyle({ background: 'var(--status-requested-bg)' });
+    expect(screen.getByText('MYSTERY')).toHaveStyle({
+      backgroundColor: 'var(--status-requested-bg)',
+    });
   });
 
   it('omits the status pill when snapshot.status is not a string', () => {

--- a/apps/frontend/src/app/__tests__/pages/Appointments/Sections/AppointmentInfo/labTestsUtils.test.ts
+++ b/apps/frontend/src/app/__tests__/pages/Appointments/Sections/AppointmentInfo/labTestsUtils.test.ts
@@ -120,7 +120,7 @@ describe('labTestsUtils', () => {
     expect(getOrderStatusTone(order({ status: 'pending review' }), new Map())).toBe('warning');
     expect(
       getOrderStatusTone(order({ idexxOrderId: 'error', status: 'created' }), resultProgress)
-    ).toBe('warning');
+    ).toBe('danger');
     expect(getOrderStatusTone(order({ status: 'unknown' }), new Map())).toBe('neutral');
   });
 });

--- a/apps/frontend/src/app/__tests__/pages/Appointments/Sections/AppointmentInfo/labTestsUtils.test.ts
+++ b/apps/frontend/src/app/__tests__/pages/Appointments/Sections/AppointmentInfo/labTestsUtils.test.ts
@@ -1,6 +1,7 @@
 import {
   formatTestPrice,
   getOrderStatusBadgeClass,
+  getOrderStatusTone,
   getTestSpecimen,
   getTestTurnaround,
   resolveOrderPdfUrl,
@@ -110,5 +111,16 @@ describe('labTestsUtils', () => {
     expect(getOrderStatusBadgeClass(order({ status: 'unknown' }), new Map())).toBe(
       'bg-card-hover text-text-secondary'
     );
+  });
+
+  it('maps badge classes to status pill tones', () => {
+    const resultProgress = new Map<string, string>([['error', 'Error']]);
+
+    expect(getOrderStatusTone(order({ status: 'submitted' }), new Map())).toBe('success');
+    expect(getOrderStatusTone(order({ status: 'pending review' }), new Map())).toBe('warning');
+    expect(
+      getOrderStatusTone(order({ idexxOrderId: 'error', status: 'created' }), resultProgress)
+    ).toBe('warning');
+    expect(getOrderStatusTone(order({ status: 'unknown' }), new Map())).toBe('neutral');
   });
 });

--- a/apps/frontend/src/app/__tests__/pages/Organization/Sections/Documents/Documents.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Organization/Sections/Documents/Documents.test.tsx
@@ -111,7 +111,7 @@ describe('Organization documents section', () => {
 
     const badge = screen.getByText('E-SIGN');
     expect(badge).toBeInTheDocument();
-    expect(badge).toHaveClass('bg-[var(--status-completed-bg)]');
+    expect(badge).toHaveStyle({ backgroundColor: 'var(--status-completed-bg)' });
     expect(screen.getByTestId('icon-template')).toBeInTheDocument();
     expect(screen.queryByTestId('icon-doc')).not.toBeInTheDocument();
   });

--- a/apps/frontend/src/app/__tests__/pages/Organization/Sections/Team/Team.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Organization/Sections/Team/Team.test.tsx
@@ -43,7 +43,7 @@ describe('Team section', () => {
     expect(screen.getByText('Employment')).toBeInTheDocument();
   });
 
-  it('renders role, employment and an uppercase status pill for a member', () => {
+  it('renders role, employment and a status pill for a member', () => {
     useTeamMock.mockReturnValue([
       {
         _id: 'team-1',
@@ -58,7 +58,7 @@ describe('Team section', () => {
 
     expect(screen.getByText('Veterinarian')).toBeInTheDocument();
     expect(screen.getByText('Full time')).toBeInTheDocument();
-    expect(screen.getByText('AVAILABLE')).toBeInTheDocument();
+    expect(screen.getByText('Available')).toBeInTheDocument();
     expect(screen.getByText('Small animals')).toBeInTheDocument();
   });
 

--- a/apps/frontend/src/app/__tests__/pages/Organization/Sections/orgDisplay.test.ts
+++ b/apps/frontend/src/app/__tests__/pages/Organization/Sections/orgDisplay.test.ts
@@ -46,12 +46,12 @@ describe('orgDisplay helpers', () => {
     it('maps off-duty to OFF DUTY muted', () => {
       const pill = teamStatusPill('Off-Duty');
       expect(pill.label).toBe('OFF DUTY');
-      expect(pill.className).toMatch(/band/);
+      expect(pill.tokens.bg).toMatch(/band/);
     });
 
-    it('uppercases other statuses as active', () => {
-      expect(teamStatusPill('Available').label).toBe('AVAILABLE');
-      expect(teamStatusPill('Available').className).toMatch(/status-completed/);
+    it('keeps other statuses as the completed pill', () => {
+      expect(teamStatusPill('Available').label).toBe('Available');
+      expect(teamStatusPill('Available').tokens.bg).toMatch(/status-completed/);
     });
 
     it('defaults to ACTIVE when status is missing', () => {
@@ -61,8 +61,8 @@ describe('orgDisplay helpers', () => {
   });
 
   describe('orgTypePillLabel', () => {
-    it('uppercases a provided type', () => {
-      expect(orgTypePillLabel('Hospital')).toBe('HOSPITAL');
+    it('trims a provided type', () => {
+      expect(orgTypePillLabel('Hospital')).toBe('Hospital');
     });
 
     it('falls back to CLINIC', () => {

--- a/apps/frontend/src/app/__tests__/ui/Badge.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/Badge.test.tsx
@@ -32,8 +32,8 @@ describe('Badge', () => {
 
     const badge = screen.getByText('Delete');
     expect(badge).toHaveStyle({
-      backgroundColor: 'var(--color-pill-warning-bg)',
-      color: 'var(--color-pill-warning-text)',
+      backgroundColor: 'var(--danger-bg)',
+      color: 'var(--danger-text)',
     });
     expect(badge.className).toContain('extra');
   });

--- a/apps/frontend/src/app/__tests__/ui/Badge.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/Badge.test.tsx
@@ -5,24 +5,36 @@ import Badge from '@/app/ui/Badge';
 
 describe('Badge', () => {
   it('renders with neutral tone by default', () => {
-    render(<Badge data-testid="badge">Default</Badge>);
-    const badge = screen.getByTestId('badge');
+    render(<Badge>Default</Badge>);
+    const badge = screen.getByText('Default');
 
     expect(badge).toHaveTextContent('Default');
-    expect(badge.className).toContain('bg-card-bg');
-    expect(badge.className).toContain('text-text-secondary');
+    expect(badge).toHaveStyle({
+      backgroundColor: 'var(--color-pill-neutral-bg)',
+      color: 'var(--color-pill-neutral-text)',
+    });
+  });
+
+  it('maps the brand tone onto the accent pill tone', () => {
+    render(<Badge tone="brand">Bookable</Badge>);
+
+    expect(screen.getByText('Bookable')).toHaveStyle({
+      backgroundColor: 'var(--color-pill-accent-bg)',
+    });
   });
 
   it('applies selected tone and custom className', () => {
     render(
-      <Badge tone="danger" className="extra" data-testid="badge">
+      <Badge tone="danger" className="extra">
         Delete
       </Badge>
     );
 
-    const badge = screen.getByTestId('badge');
-    expect(badge.className).toContain('bg-danger-100');
-    expect(badge.className).toContain('text-danger-700');
+    const badge = screen.getByText('Delete');
+    expect(badge).toHaveStyle({
+      backgroundColor: 'var(--color-pill-warning-bg)',
+      color: 'var(--color-pill-warning-text)',
+    });
     expect(badge.className).toContain('extra');
   });
 });

--- a/apps/frontend/src/app/__tests__/ui/primitives/StatusPill.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/primitives/StatusPill.test.tsx
@@ -57,4 +57,10 @@ describe('StatusPill', () => {
     render(<StatusPill label="Overdue" tone="danger" />);
     expect(screen.getByText('Overdue')).toHaveStyle({ backgroundColor: 'var(--danger-bg)' });
   });
+  it('hugs its content so a flex column cannot stretch it into a band', () => {
+    render(<StatusPill label="Low stock" />);
+    // The class this replaced set width:fit-content; without it the badge is
+    // stretched by a flex column's default align-items: stretch.
+    expect(screen.getByText('Low stock')).toHaveClass('w-fit');
+  });
 });

--- a/apps/frontend/src/app/__tests__/ui/primitives/StatusPill.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/primitives/StatusPill.test.tsx
@@ -43,4 +43,14 @@ describe('StatusPill', () => {
     render(<StatusPill label="Fit" className="w-fit" />);
     expect(screen.getByText('Fit').closest('span')).toHaveClass('w-fit');
   });
+  it('applies a CSS style passthrough over the tone colours', () => {
+    render(
+      <StatusPill
+        label="Overdue"
+        tone="neutral"
+        style={{ backgroundColor: 'rgb(10, 20, 30)', color: 'rgb(1, 1, 1)' }}
+      />
+    );
+    expect(screen.getByText('Overdue')).toHaveStyle({ backgroundColor: 'rgb(10, 20, 30)' });
+  });
 });

--- a/apps/frontend/src/app/__tests__/ui/primitives/StatusPill.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/primitives/StatusPill.test.tsx
@@ -53,4 +53,8 @@ describe('StatusPill', () => {
     );
     expect(screen.getByText('Overdue')).toHaveStyle({ backgroundColor: 'rgb(10, 20, 30)' });
   });
+  it('draws the danger tone from the --danger-* scale, not warning', () => {
+    render(<StatusPill label="Overdue" tone="danger" />);
+    expect(screen.getByText('Overdue')).toHaveStyle({ backgroundColor: 'var(--danger-bg)' });
+  });
 });

--- a/apps/frontend/src/app/__tests__/ui/primitives/StatusPill.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/primitives/StatusPill.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
+
+describe('StatusPill', () => {
+  it('renders the label', () => {
+    render(<StatusPill label="Enabled" />);
+    expect(screen.getByText('Enabled')).toBeInTheDocument();
+  });
+
+  it('colours from a tone token set by default', () => {
+    render(<StatusPill label="Paid" tone="success" />);
+    expect(screen.getByText('Paid')).toHaveStyle({
+      backgroundColor: 'var(--color-pill-success-bg)',
+    });
+  });
+
+  it('falls back to the neutral tone when none is given', () => {
+    render(<StatusPill label="Draft" />);
+    expect(screen.getByText('Draft')).toHaveStyle({
+      backgroundColor: 'var(--color-pill-neutral-bg)',
+    });
+  });
+
+  it('lets explicit tokens override the tone', () => {
+    render(
+      <StatusPill
+        label="Custom"
+        tone="success"
+        tokens={{ bg: 'rgb(1, 2, 3)', text: 'rgb(4, 5, 6)', border: 'rgb(7, 8, 9)' }}
+      />
+    );
+    expect(screen.getByText('Custom')).toHaveStyle({ backgroundColor: 'rgb(1, 2, 3)' });
+  });
+
+  it('renders a live dot only when showDot is set', () => {
+    const { container, rerender } = render(<StatusPill label="Online" showDot />);
+    expect(container.querySelector('span[aria-hidden="true"]')).toBeInTheDocument();
+    rerender(<StatusPill label="Offline" />);
+    expect(container.querySelector('span[aria-hidden="true"]')).not.toBeInTheDocument();
+  });
+
+  it('appends layout classes from className', () => {
+    render(<StatusPill label="Fit" className="w-fit" />);
+    expect(screen.getByText('Fit').closest('span')).toHaveClass('w-fit');
+  });
+});

--- a/apps/frontend/src/app/features/appointments/components/AppointmentCardContent.tsx
+++ b/apps/frontend/src/app/features/appointments/components/AppointmentCardContent.tsx
@@ -4,6 +4,7 @@ import { Appointment } from '@yosemite-crew/types';
 import { getSafeImageUrl, ImageType } from '@/app/lib/urls';
 import { formatDateLabel, formatTimeLabel } from '@/app/lib/forms';
 import { getStatusStyle } from '@/app/config/statusConfig';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import { toTitle } from '@/app/lib/validators';
 import AppointmentDetailField from '@/app/features/appointments/components/AppointmentDetailField';
 import {
@@ -112,12 +113,11 @@ export const AppointmentDetails = ({ appointment }: AppointmentCardContentProps)
 export const AppointmentStatusBadge = ({ appointment }: AppointmentCardContentProps) => {
   const displayStatus = normalizeAppointmentStatus(appointment.status) ?? 'REQUESTED';
   return (
-    <span
-      style={{ ...getStatusStyle(displayStatus), borderWidth: '1px', borderStyle: 'solid' }}
-      className="text-caption-3 inline-flex w-fit items-center justify-center gap-1.5 rounded-full! border px-2.5 py-1 whitespace-nowrap"
-    >
-      {toTitle(displayStatus)}
-    </span>
+    <StatusPill
+      style={getStatusStyle(displayStatus)}
+      label={toTitle(displayStatus)}
+      className="w-fit"
+    />
   );
 };
 

--- a/apps/frontend/src/app/features/appointments/components/AppointmentPaymentBadge.tsx
+++ b/apps/frontend/src/app/features/appointments/components/AppointmentPaymentBadge.tsx
@@ -1,4 +1,5 @@
 import { Appointment } from '@yosemite-crew/types';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import {
   createInvoiceByAppointmentId,
   getAppointmentPaymentDisplay,
@@ -13,15 +14,14 @@ const AppointmentPaymentBadge = ({
 }) => {
   const payment = getAppointmentPaymentDisplay(appointment, invoicesByAppointmentId);
   return (
-    <div
-      className="shrink-0 rounded-full px-2.5 py-1 text-[10px] font-medium font-satoshi"
+    <StatusPill
+      label={payment.label}
       style={{
         backgroundColor: payment.badgeBackgroundColor,
         color: payment.badgeTextColor,
+        borderColor: payment.badgeBackgroundColor,
       }}
-    >
-      {payment.label}
-    </div>
+    />
   );
 };
 

--- a/apps/frontend/src/app/features/appointments/components/AppointmentStatusPill.tsx
+++ b/apps/frontend/src/app/features/appointments/components/AppointmentStatusPill.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useId, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { IoCaretDown } from 'react-icons/io5';
 import type { Appointment } from '@yosemite-crew/types';
@@ -9,6 +9,7 @@ import {
   toStatusLabel,
 } from '@/app/lib/appointments';
 import { getStatusStyle } from '@/app/config/statusConfig';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import { changeAppointmentStatus } from '@/app/features/appointments/services/appointmentService';
 import type { AppointmentStatus } from '@/app/features/appointments/types/appointments';
 
@@ -21,20 +22,6 @@ type AppointmentStatusPillProps = {
   /** Keeps the open menu anchored to a scroll/hover container. */
   registerAnchorEl?: (el: HTMLElement | null) => () => void;
 };
-
-// Colours only — typography + shape come from the `.text-caption-3` DS
-// micro-badge class and the shared pill utility classes below.
-const basePillStyle = (style: ReturnType<typeof getStatusStyle>): React.CSSProperties => ({
-  backgroundColor: style.backgroundColor,
-  color: style.color,
-  borderWidth: '1px',
-  borderStyle: 'solid',
-  borderColor: style.borderColor,
-});
-
-// DS status micro-badge: ALL-CAPS 10px/700/0.08em, pad 4px 10px, fully round.
-const PILL_CLASS =
-  'text-caption-3 inline-flex w-fit items-center justify-center gap-1.5 rounded-full! border px-2.5 py-1 whitespace-nowrap';
 
 /**
  * Shared appointment status pill. Renders a static badge, or — when the status
@@ -63,11 +50,6 @@ const AppointmentStatusPill = ({
     !isRequestedLikeStatus(appointment.status) &&
     canShowStatusChangeAction(appointment.status) &&
     allowedTransitions.length > 0;
-
-  const triggerStyle = useMemo<React.CSSProperties>(
-    () => ({ ...basePillStyle(statusStyle), opacity: saving ? 0.6 : 1 }),
-    [statusStyle, saving]
-  );
 
   const positionMenu = () => {
     if (!triggerRef.current) return;
@@ -124,9 +106,7 @@ const AppointmentStatusPill = ({
 
   if (!canChange) {
     return (
-      <span className={PILL_CLASS} style={basePillStyle(statusStyle)}>
-        {toStatusLabel(appointment.status)}
-      </span>
+      <StatusPill style={statusStyle} label={toStatusLabel(appointment.status)} className="w-fit" />
     );
   }
 
@@ -142,13 +122,20 @@ const AppointmentStatusPill = ({
         aria-haspopup="menu"
         aria-expanded={open}
         aria-controls={menuId}
-        className={PILL_CLASS}
-        style={triggerStyle}
+        className="w-fit rounded-full!"
+        style={{ opacity: saving ? 0.6 : 1 }}
       >
-        <span>{saving ? 'Saving…' : toStatusLabel(appointment.status)}</span>
-        <IoCaretDown
-          size={8}
-          className={`shrink-0 transition-transform ${open ? 'rotate-180' : ''}`}
+        <StatusPill
+          style={statusStyle}
+          label={
+            <>
+              <span>{saving ? 'Saving…' : toStatusLabel(appointment.status)}</span>
+              <IoCaretDown
+                size={8}
+                className={`shrink-0 transition-transform ${open ? 'rotate-180' : ''}`}
+              />
+            </>
+          }
         />
       </button>
 

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/InpatientSchedule.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/InpatientSchedule.tsx
@@ -8,6 +8,7 @@ import {
   IoSearchOutline,
 } from 'react-icons/io5';
 import SectionContainer from '@/app/ui/primitives/SectionContainer/SectionContainer';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import LabelDropdown from '@/app/ui/inputs/Dropdown/LabelDropdown';
 import CircleIconButton from '@/app/features/appointments/pages/AppointmentWorkspace/components/CircleIconButton';
 import { getStatusStyle } from '@/app/config/statusConfig';
@@ -89,12 +90,11 @@ const StatusPillSelect = ({
 
   if (locked) {
     return (
-      <span
-        className="text-caption-3 inline-flex w-fit items-center justify-center gap-1.5 rounded-full! border px-2.5 py-1"
-        style={{ ...statusPillStyle(status), borderWidth: '1px', borderStyle: 'solid' }}
-      >
-        {formatStatusLabel(status)}
-      </span>
+      <StatusPill
+        style={statusPillStyle(status)}
+        label={formatStatusLabel(status)}
+        className="w-fit"
+      />
     );
   }
 
@@ -107,14 +107,20 @@ const StatusPillSelect = ({
         aria-expanded={open}
         onClick={() => setOpen((v) => !v)}
         onBlur={() => setOpen(false)}
-        className="text-caption-3 inline-flex w-fit items-center justify-center gap-1.5 rounded-full! border px-2.5 py-1 transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-brand"
-        style={{ ...statusPillStyle(status), borderWidth: '1px', borderStyle: 'solid' }}
+        className="w-fit rounded-full! transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-brand"
       >
-        {formatStatusLabel(status)}
-        <IoChevronDownOutline
-          size={10}
-          aria-hidden="true"
-          className={`shrink-0 transition-transform ${open ? 'rotate-180' : ''}`}
+        <StatusPill
+          style={statusPillStyle(status)}
+          label={
+            <>
+              {formatStatusLabel(status)}
+              <IoChevronDownOutline
+                size={10}
+                aria-hidden="true"
+                className={`shrink-0 transition-transform ${open ? 'rotate-180' : ''}`}
+              />
+            </>
+          }
         />
       </button>
       {open && (

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/OutpatientSchedule.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/OutpatientSchedule.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { IoAddOutline, IoEllipsisHorizontal, IoPaperPlaneOutline } from 'react-icons/io5';
 import './OutpatientSchedule.css';
 import SectionContainer from '@/app/ui/primitives/SectionContainer/SectionContainer';
+import SharedStatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import { getStatusStyle } from '@/app/config/statusConfig';
 import type {
   OutpatientScheduleModel,
@@ -47,23 +48,13 @@ const dayMarker = (iso: string): { weekday: string; day: string } => {
   return { weekday: WEEKDAYS[date.getDay()], day: String(date.getDate()) };
 };
 
-const StatusPill = ({ status }: { status: OutpatientVisitStatus }) => {
-  const style = getStatusStyle(STATUS_STYLE_KEY[status]);
-  return (
-    <span
-      className="text-caption-3 inline-flex w-fit items-center rounded-full! border px-2.5 py-1"
-      style={{
-        color: style.color,
-        backgroundColor: style.backgroundColor,
-        borderColor: style.borderColor,
-        borderWidth: '1px',
-        borderStyle: 'solid',
-      }}
-    >
-      {STATUS_LABEL[status]}
-    </span>
-  );
-};
+const StatusPill = ({ status }: { status: OutpatientVisitStatus }) => (
+  <SharedStatusPill
+    style={getStatusStyle(STATUS_STYLE_KEY[status])}
+    label={STATUS_LABEL[status]}
+    className="w-fit"
+  />
+);
 
 /**
  * "Laser therapy · session 2 of 6" — the design's session suffix. Only appended

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/SummaryStep.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/SummaryStep.tsx
@@ -17,6 +17,7 @@ import {
   IoSearchOutline,
 } from 'react-icons/io5';
 import SectionContainer from '@/app/ui/primitives/SectionContainer/SectionContainer';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import GlassTooltip from '@/app/ui/primitives/GlassTooltip/GlassTooltip';
 import Search from '@/app/ui/inputs/Search';
 import Datepicker from '@/app/ui/inputs/Datepicker';
@@ -221,20 +222,7 @@ const signingStatusStyleKey = (signingStatus?: string | null): string => {
 
 const SigningStatusPill = ({ signingStatus }: { signingStatus?: string | null }) => {
   const style = getStatusStyle(signingStatusStyleKey(signingStatus));
-  return (
-    <span
-      className="text-caption-3 inline-flex w-fit items-center rounded-full! border px-2.5 py-1"
-      style={{
-        color: style.color,
-        backgroundColor: style.backgroundColor,
-        borderColor: style.borderColor,
-        borderWidth: '1px',
-        borderStyle: 'solid',
-      }}
-    >
-      {humanizeToken(signingStatus)}
-    </span>
-  );
+  return <StatusPill style={style} label={humanizeToken(signingStatus)} className="w-fit" />;
 };
 
 const downloadDocumentUrl = (url: string) => {

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/Info/AppointmentInfo.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/Info/AppointmentInfo.tsx
@@ -38,6 +38,7 @@ import {
   toStatusLabel,
 } from '@/app/lib/appointments';
 import { getStatusStyle } from '@/app/config/statusConfig';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import { useNotify } from '@/app/hooks/useNotify';
 import { useOrganisationRoomStore } from '@/app/stores/roomStore';
 import { toAssignableRoomOptions } from '@/app/features/appointments/lib/roomUnitAvailability';
@@ -905,18 +906,10 @@ const useAppointmentInfoView = ({
                       className="py-2.5! flex items-center gap-2 justify-between border-t border-card-border"
                     >
                       <div className="text-body-4-emphasis text-text-secondary">{field.label}</div>
-                      <span
-                        className="text-caption-3 inline-flex items-center justify-center border px-2.5 py-1 rounded-full! whitespace-nowrap"
-                        style={{
-                          backgroundColor: statusStyle.backgroundColor,
-                          color: statusStyle.color,
-                          borderWidth: '1px',
-                          borderStyle: 'solid',
-                          borderColor: statusStyle.borderColor,
-                        }}
-                      >
-                        {toStatusLabel(activeAppointment.status)}
-                      </span>
+                      <StatusPill
+                        style={statusStyle}
+                        label={toStatusLabel(activeAppointment.status)}
+                      />
                     </div>
                   );
                 }

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/LabTests.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/LabTests.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { createPortal } from 'react-dom';
 import { IoOpenOutline } from 'react-icons/io5';
 import Accordion from '@/app/ui/primitives/Accordion/Accordion';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import LabelDropdown from '@/app/ui/inputs/Dropdown/LabelDropdown';
 import FormInput from '@/app/ui/inputs/FormInput/FormInput';
 import SearchDropdown from '@/app/ui/inputs/SearchDropdown';
@@ -36,7 +37,7 @@ import {
 import { formatDateTimeLocal } from '@/app/lib/date';
 import {
   formatTestPrice,
-  getOrderStatusBadgeClass,
+  getOrderStatusTone,
   getTestSpecimen,
   getTestTurnaround,
   resolveOrderPdfUrl,
@@ -154,11 +155,11 @@ const PastOrderCard = ({
           Updated: {formatDateTimeLocal(order.updatedAt, '-')}
         </div>
       </div>
-      <span
-        className={`text-label-xsmall px-2 py-1 rounded w-fit ${getOrderStatusBadgeClass(order, resultProgressByOrderId)}`}
-      >
-        {getOrderDisplayStatus(order)}
-      </span>
+      <StatusPill
+        className="w-fit"
+        tone={getOrderStatusTone(order, resultProgressByOrderId)}
+        label={getOrderDisplayStatus(order)}
+      />
     </div>
     <div className="flex flex-wrap items-center gap-2 justify-end">
       {getOrderDisplayStatus(order) === 'Complete' ? (
@@ -950,9 +951,7 @@ const ReferenceLabForm = ({ s }: { s: UseLabTestsReturn }) => (
           <div className="flex flex-col gap-1">
             <div className="flex items-start justify-between gap-2">
               <div className="text-body-4 text-text-primary pr-2">{test.display}</div>
-              <div className="text-label-xsmall px-2 py-1 rounded bg-blue-50 text-blue-700 whitespace-nowrap">
-                {formatTestPrice(test)}
-              </div>
+              <StatusPill tone="info" label={formatTestPrice(test)} />
             </div>
             <div className="flex flex-wrap gap-x-3 gap-y-1 text-caption-1 text-text-secondary">
               <span>Code: {test.code}</span>
@@ -980,9 +979,7 @@ const ReferenceLabForm = ({ s }: { s: UseLabTestsReturn }) => (
           >
             <div className="flex items-start justify-between gap-2">
               <div className="text-body-4 text-text-primary truncate">{test.display}</div>
-              <div className="text-label-xsmall px-2 py-1 rounded bg-blue-50 text-blue-700 whitespace-nowrap">
-                {formatTestPrice(test)}
-              </div>
+              <StatusPill tone="info" label={formatTestPrice(test)} />
             </div>
             <div className="mt-0.5 text-caption-1 text-text-secondary truncate">
               {test.code} • Turnaround time: {getTestTurnaround(test)}
@@ -1090,11 +1087,11 @@ const LabOrderStatus = ({ s }: { s: UseLabTestsReturn }) => (
                   Updated: {formatDateTimeLocal(s.latestOrder.updatedAt, '-')}
                 </div>
               </div>
-              <span
-                className={`text-label-xsmall px-2 py-1 rounded w-fit ${getOrderStatusBadgeClass(s.latestOrder, s.resultProgressByOrderId)}`}
-              >
-                {s.getOrderDisplayStatus(s.latestOrder)}
-              </span>
+              <StatusPill
+                className="w-fit"
+                tone={getOrderStatusTone(s.latestOrder, s.resultProgressByOrderId)}
+                label={s.getOrderDisplayStatus(s.latestOrder)}
+              />
             </div>
             <div className="flex items-center gap-2 flex-wrap justify-end">
               <Primary

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/index.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/index.tsx
@@ -37,6 +37,7 @@ import SearchDropdown from '@/app/ui/inputs/SearchDropdown';
 import { useFormsStore } from '@/app/stores/formsStore';
 import { useLoadFormsForPrimaryOrg } from '@/app/hooks/useForms';
 import Accordion from '@/app/ui/primitives/Accordion/Accordion';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import { Primary } from '@/app/ui/primitives/Buttons';
 import { SoapNoteSubmission } from '@/app/features/appointments/types/soap';
 import SignatureActions from '@/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/Prescription/Submissions/SignatureActions';
@@ -186,7 +187,7 @@ type CustomFormsSectionProps = {
 };
 
 const FormBadge: React.FC<{ label: string; badgeClass: string }> = ({ label, badgeClass }) => (
-  <span className={`text-label-xsmall px-2 py-1 rounded ${badgeClass}`}>{label}</span>
+  <StatusPill label={label} tone={badgeClass.startsWith('bg-green-50') ? 'success' : 'warning'} />
 );
 
 const CustomFormsSection: React.FC<CustomFormsSectionProps> = ({

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/labTestsUtils.ts
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/labTestsUtils.ts
@@ -1,4 +1,5 @@
 import type { IdexxTest, LabOrder } from '@/app/features/integrations/services/types';
+import type { StatusTone } from '@/app/ui/primitives/StatusPill/StatusPill';
 import { getSafeIdexxIframeUrl } from '@/app/lib/urls';
 
 export const formatTestPrice = (test: IdexxTest) => {
@@ -65,4 +66,14 @@ export const getOrderStatusBadgeClass = (
   if (key.includes('error') || key.includes('failed') || key.includes('cancel'))
     return 'bg-red-50 text-red-700';
   return 'bg-card-hover text-text-secondary';
+};
+
+export const getOrderStatusTone = (
+  order: LabOrder,
+  resultProgressByOrderId: Map<string, string>
+): StatusTone => {
+  const badgeClass = getOrderStatusBadgeClass(order, resultProgressByOrderId);
+  if (badgeClass.startsWith('bg-green-50')) return 'success';
+  if (badgeClass.startsWith('bg-amber-50') || badgeClass.startsWith('bg-red-50')) return 'warning';
+  return 'neutral';
 };

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/labTestsUtils.ts
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/labTestsUtils.ts
@@ -74,6 +74,7 @@ export const getOrderStatusTone = (
 ): StatusTone => {
   const badgeClass = getOrderStatusBadgeClass(order, resultProgressByOrderId);
   if (badgeClass.startsWith('bg-green-50')) return 'success';
-  if (badgeClass.startsWith('bg-amber-50') || badgeClass.startsWith('bg-red-50')) return 'warning';
+  if (badgeClass.startsWith('bg-red-50')) return 'danger';
+  if (badgeClass.startsWith('bg-amber-50')) return 'warning';
   return 'neutral';
 };

--- a/apps/frontend/src/app/features/chat/components/SharedEntityCard.tsx
+++ b/apps/frontend/src/app/features/chat/components/SharedEntityCard.tsx
@@ -23,6 +23,7 @@ import {
 } from 'react-icons/io5';
 import Text from '@/app/ui/Text';
 import { useCompanionTerminologyText } from '@/app/hooks/useCompanionTerminologyText';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 
 export type SharedEntityData = {
   entityType: string;
@@ -119,16 +120,14 @@ export function SharedEntityCard({
           )}
         </span>
         {status && (
-          <span
-            className="inline-flex shrink-0 items-center rounded-full border px-[9px] py-[3px] text-[9.5px] font-bold uppercase"
-            style={{
-              background: `var(--status-${statusTone ?? 'requested'}-bg)`,
-              color: `var(--status-${statusTone ?? 'requested'}-text)`,
-              borderColor: `var(--status-${statusTone ?? 'requested'}-border)`,
+          <StatusPill
+            label={status}
+            tokens={{
+              bg: `var(--status-${statusTone ?? 'requested'}-bg)`,
+              text: `var(--status-${statusTone ?? 'requested'}-text)`,
+              border: `var(--status-${statusTone ?? 'requested'}-border)`,
             }}
-          >
-            {status}
-          </span>
+          />
         )}
       </div>
       {showValueRow && (

--- a/apps/frontend/src/app/features/companionHistory/components/CompanionHistoryTimeline.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/CompanionHistoryTimeline.tsx
@@ -54,6 +54,7 @@ import { getCompanionAuditTrail } from '@/app/features/audit/services/auditServi
 import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
 import Search from '@/app/ui/inputs/Search';
 import PdfPreviewOverlay from '@/app/ui/overlays/PdfPreviewOverlay';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import { AppointmentLabels, TaskLabels, getStatusStyle } from '@/app/config/statusConfig';
 import {
   canTransitionAppointmentStatus,
@@ -329,13 +330,15 @@ export const StatusPillSelect = ({
 
   if (locked || disabled || menuOptions.length === 0) {
     return (
-      <span
-        className="text-caption-3 inline-flex w-fit items-center justify-center gap-1.5 rounded-full! border px-2.5 py-1"
-        style={{ ...statusPillStyle(normalizedStatus), borderWidth: '1px', borderStyle: 'solid' }}
-        title={formatStatusLabel(status)}
-      >
-        <span className="whitespace-nowrap">{label}</span>
-      </span>
+      <StatusPill
+        style={statusPillStyle(normalizedStatus)}
+        className="w-fit"
+        label={
+          <span className="whitespace-nowrap" title={formatStatusLabel(status)}>
+            {label}
+          </span>
+        }
+      />
     );
   }
 
@@ -348,15 +351,21 @@ export const StatusPillSelect = ({
         aria-expanded={open}
         onClick={() => setOpen((value) => !value)}
         onBlur={() => setOpen(false)}
-        className="text-caption-3 inline-flex w-fit items-center justify-center gap-1.5 rounded-full! border px-2.5 py-1 transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-brand"
-        style={{ ...statusPillStyle(normalizedStatus), borderWidth: '1px', borderStyle: 'solid' }}
+        className="w-fit rounded-full! transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-brand"
         title={formatStatusLabel(status)}
       >
-        <span className="whitespace-nowrap">{label}</span>
-        <IoChevronDownOutline
-          size={10}
-          aria-hidden="true"
-          className={`shrink-0 transition-transform ${open ? 'rotate-180' : ''}`}
+        <StatusPill
+          style={statusPillStyle(normalizedStatus)}
+          label={
+            <>
+              <span className="whitespace-nowrap">{label}</span>
+              <IoChevronDownOutline
+                size={10}
+                aria-hidden="true"
+                className={`shrink-0 transition-transform ${open ? 'rotate-180' : ''}`}
+              />
+            </>
+          }
         />
       </button>
       {open ? (

--- a/apps/frontend/src/app/features/companionHistory/pages/phone/PhoneCompanionRecord.tsx
+++ b/apps/frontend/src/app/features/companionHistory/pages/phone/PhoneCompanionRecord.tsx
@@ -22,6 +22,7 @@ import type {
 import { buildCompanionDetails } from '@/app/lib/companionWorkspaceDetails';
 import { formatCompanionAge } from '@/app/lib/date';
 import { getSafeImageUrl, type ImageType } from '@/app/lib/urls';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 
 type PhoneCompanionRecordProps = {
   companionId: string;
@@ -147,10 +148,19 @@ const PhoneRecordIdentity = ({
           onRemove={onRemoveAlert}
         />
       ))}
-      <span className="inline-flex items-center gap-1 rounded-full border border-(--status-completed-border) bg-(--status-completed-bg) px-2.5 py-1 text-[9.5px] font-bold text-(--status-completed-text)">
-        Dues cleared
-        <IoCheckmarkOutline size={10} aria-hidden="true" />
-      </span>
+      <StatusPill
+        label={
+          <>
+            Dues cleared
+            <IoCheckmarkOutline size={10} aria-hidden="true" />
+          </>
+        }
+        tokens={{
+          bg: 'var(--status-completed-bg)',
+          text: 'var(--status-completed-text)',
+          border: 'var(--status-completed-border)',
+        }}
+      />
       <button
         type="button"
         aria-label={addAlertLabel}

--- a/apps/frontend/src/app/features/documents/components/CompanionRecordRow.tsx
+++ b/apps/frontend/src/app/features/documents/components/CompanionRecordRow.tsx
@@ -5,6 +5,7 @@ import {
   getCompanionDocumentSubcategoryLabel,
 } from '@/app/features/documents/types/companionDocuments';
 import { formatDateLabel } from '@/app/lib/forms';
+import StatusPill, { type StatusPillTokens } from '@/app/ui/primitives/StatusPill/StatusPill';
 import {
   RecordStatusTone,
   getAttachmentSummary,
@@ -18,11 +19,18 @@ type CompanionRecordRowProps = {
   onOpen: () => void;
 };
 
-const STATUS_PILL_CLASSES: Record<RecordStatusTone, string> = {
-  success:
-    'bg-[var(--status-completed-bg)] text-[var(--status-completed-text)] border-[var(--status-completed-border)]',
-  warning: 'bg-[var(--warn-bg)] text-[var(--warn-text)] border-[var(--warn-border)]',
-  info: 'bg-[var(--status-upcoming-bg)] text-[var(--status-upcoming-text)] border-[var(--status-upcoming-border)]',
+const STATUS_PILL_TOKENS: Record<RecordStatusTone, StatusPillTokens> = {
+  success: {
+    bg: 'var(--status-completed-bg)',
+    text: 'var(--status-completed-text)',
+    border: 'var(--status-completed-border)',
+  },
+  warning: { bg: 'var(--warn-bg)', text: 'var(--warn-text)', border: 'var(--warn-border)' },
+  info: {
+    bg: 'var(--status-upcoming-bg)',
+    text: 'var(--status-upcoming-text)',
+    border: 'var(--status-upcoming-border)',
+  },
 };
 
 /**
@@ -64,12 +72,7 @@ const CompanionRecordRow = ({ doc, onOpen }: CompanionRecordRowProps) => {
       </span>
       <span className="flex flex-none flex-wrap items-center justify-end gap-1.5">
         {pills.map((pill) => (
-          <span
-            key={pill.label}
-            className={`inline-flex items-center whitespace-nowrap rounded-full border px-2.5 py-[3px] text-[9.5px] font-bold uppercase ${STATUS_PILL_CLASSES[pill.tone]}`}
-          >
-            {pill.label}
-          </span>
+          <StatusPill key={pill.label} label={pill.label} tokens={STATUS_PILL_TOKENS[pill.tone]} />
         ))}
       </span>
       <IoChevronForwardOutline

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceDetailHeader.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceDetailHeader.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import { Appointment, Invoice } from '@yosemite-crew/types';
 import { IoDownloadOutline, IoOpenOutline } from 'react-icons/io5';
 import ModalHeader from '@/app/ui/overlays/Modal/ModalHeader';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import { getInvoiceNumberLabel } from '@/app/lib/invoice';
 import { formatDateLabel } from '@/app/lib/forms';
 import { getSafeImageUrl, ImageType } from '@/app/lib/urls';
@@ -69,12 +70,7 @@ const InvoiceDetailHeader = ({
       actions={
         <>
           {statusLabel && (
-            <span
-              className="inline-flex items-center rounded-full px-2.5 py-[3px] text-[10px] font-bold uppercase tracking-[0.08em] border shrink-0"
-              style={statusStyle}
-            >
-              {statusLabel}
-            </span>
+            <StatusPill className="shrink-0" label={statusLabel} style={statusStyle} />
           )}
           {pdfUrl && (
             <a

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoicePhoneRecord.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoicePhoneRecord.tsx
@@ -10,6 +10,7 @@ import {
   IoOpenOutline,
   IoPhonePortraitOutline,
 } from 'react-icons/io5';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import { formatMoney } from '@/app/lib/money';
 import { formatDateLabel, formatTimeLabel } from '@/app/lib/forms';
 import { getInvoiceNumberLabel } from '@/app/lib/invoice';
@@ -143,12 +144,7 @@ const InvoicePhoneRecord = ({
                 {numberLabel}
               </h2>
               {statusLabel && (
-                <span
-                  className="shrink-0 inline-flex items-center rounded-full border px-2 py-0.5 text-[9px] font-bold uppercase tracking-[0.04em]"
-                  style={statusStyle}
-                >
-                  {statusLabel}
-                </span>
+                <StatusPill className="shrink-0" label={statusLabel} style={statusStyle} />
               )}
             </span>
             {subtitle && (

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/PhoneInvoiceList.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/PhoneInvoiceList.tsx
@@ -19,6 +19,7 @@ import { getInvoiceOutstanding, type FinanceMetrics } from '@/app/lib/financeMet
 import { getSafeImageUrl, ImageType } from '@/app/lib/urls';
 import { getAppointmentCompanion, getAppointmentCompanionPhotoUrl } from '@/app/lib/appointments';
 import InvoiceStatusFilterPills from '@/app/features/finance/pages/Finance/Sections/InvoiceStatusFilterPills';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 
 type PhoneInvoiceListProps = {
   filteredList: Invoice[];
@@ -99,12 +100,7 @@ const PhoneInvoiceCard = ({
           )}
         </span>
         {statusLabel && (
-          <span
-            className="shrink-0 inline-flex items-center rounded-full border px-2.5 py-[3px] text-[9.5px] font-bold uppercase tracking-[0.04em]"
-            style={getInvoiceStatusStyle(invoice.status)}
-          >
-            {statusLabel}
-          </span>
+          <StatusPill label={statusLabel} style={getInvoiceStatusStyle(invoice.status)} />
         )}
       </span>
       <span className="flex items-center gap-2.5">

--- a/apps/frontend/src/app/features/guides/pages/Guides.tsx
+++ b/apps/frontend/src/app/features/guides/pages/Guides.tsx
@@ -9,6 +9,7 @@ import PageSkeleton from '@/app/ui/layout/PageSkeleton';
 const GUIDES_PAGE_SKELETON = <PageSkeleton variant="list" />;
 import GuidePlayerModal from '@/app/ui/overlays/Modal/GuidePlayerModal';
 import Search from '@/app/ui/inputs/Search';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import FilteredEmptyState from '@/app/ui/layout/states/FilteredEmptyState';
 import { guidesData } from '@/app/features/guides/data/guidesData';
 import { GuideVideo } from '@/app/features/guides/types/guides';
@@ -180,12 +181,11 @@ const Guides = () => {
                 >
                   {video.duration}
                 </span>
-                <span
-                  className="absolute left-2.5 top-2.5 rounded-full px-[9px] py-[3px] text-[9.5px] font-bold uppercase tracking-[0.06em]"
-                  style={{ backgroundColor: 'rgba(247,243,236,0.92)', color: '#1d1c1b' }}
-                >
-                  {video.category}
-                </span>
+                <StatusPill
+                  className="absolute left-2.5 top-2.5"
+                  tone="neutral"
+                  label={video.category}
+                />
               </div>
               <div className="flex flex-col gap-1.5 px-4 pb-[15px] pt-3.5">
                 <span className="text-[14.5px] font-bold text-[var(--ink)]">{video.title}</span>

--- a/apps/frontend/src/app/features/integrations/pages/IdexxWorkspace/index.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/IdexxWorkspace/index.tsx
@@ -7,6 +7,7 @@ import { createPortal } from 'react-dom';
 import ProtectedRoute from '@/app/ui/layout/guards/ProtectedRoute';
 import OrgGuard from '@/app/ui/layout/guards/OrgGuard';
 import Accordion from '@/app/ui/primitives/Accordion/Accordion';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import FormInput from '@/app/ui/inputs/FormInput/FormInput';
 import LabelDropdown from '@/app/ui/inputs/Dropdown/LabelDropdown';
 import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
@@ -300,9 +301,10 @@ const PatientCell = ({ result }: { result: LabResult }) => {
 };
 
 const StatusCell = ({ result }: { result: LabResult }) => (
-  <span className="appointment-status" style={getResultStatusStyle(result.status)}>
-    {formatTitleCase(result.status, '-')}
-  </span>
+  <StatusPill
+    style={getResultStatusStyle(result.status)}
+    label={formatTitleCase(result.status, '-')}
+  />
 );
 
 type ResultActionCellProps = {

--- a/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
@@ -70,6 +70,11 @@ const statusTokens: Record<string, StatusTokens> = {
     text: 'var(--color-pill-info-text)',
     border: 'var(--color-pill-info-border)',
   },
+  'coming-soon': {
+    bg: 'var(--color-pill-neutral-bg)',
+    text: 'var(--color-pill-neutral-text)',
+    border: 'var(--color-pill-neutral-border)',
+  },
 };
 
 const credentialsStatusTokens: Record<string, StatusTokens> = {
@@ -956,9 +961,6 @@ const INTEGRATION_CARD_TITLE_STYLE: React.CSSProperties = { color: 'var(--ink)' 
 const INTEGRATION_CARD_DESC_CLASS = 'text-[12.5px] leading-[1.55] line-clamp-4';
 const INTEGRATION_CARD_DESC_STYLE: React.CSSProperties = { color: 'var(--ink-muted)' };
 const INTEGRATION_CARD_ACTIONS_CLASS = 'mt-auto flex flex-wrap items-center gap-2 pt-0.5';
-const COMING_SOON_PILL_CLASS =
-  'shrink-0 max-w-full whitespace-nowrap text-label-xsmall px-2 py-1 rounded-2xl! border!';
-
 // 42x42 / radius 13 icon chip that leads each card header.
 const INTEGRATION_ICON_CLASS =
   'flex size-[42px] shrink-0 items-center justify-center rounded-[13px] text-[12px] font-extrabold tracking-[0.02em]';
@@ -1131,17 +1133,7 @@ const RadIntegrationCard = ({
         <div className={INTEGRATION_CARD_TITLE_CLASS} style={INTEGRATION_CARD_TITLE_STYLE}>
           RadAnalyzer
         </div>
-        <span
-          className={COMING_SOON_PILL_CLASS}
-          style={{
-            backgroundColor: 'var(--color-pill-neutral-bg)',
-            color: 'var(--color-pill-neutral-text)',
-            borderColor: 'var(--color-pill-neutral-border)',
-            borderStyle: 'solid',
-          }}
-        >
-          Coming soon
-        </span>
+        <StatusPill status="coming-soon" label="Coming soon" />
       </div>
       <div className={INTEGRATION_CARD_DESC_CLASS} style={INTEGRATION_CARD_DESC_STYLE}>
         Imaging and analyzer connectivity for diagnostic workflows in Yosemite Crew.
@@ -1178,17 +1170,7 @@ const VetnioIntegrationCard = ({
         <div className={INTEGRATION_CARD_TITLE_CLASS} style={INTEGRATION_CARD_TITLE_STYLE}>
           Vetnio
         </div>
-        <span
-          className={COMING_SOON_PILL_CLASS}
-          style={{
-            backgroundColor: 'var(--color-pill-neutral-bg)',
-            color: 'var(--color-pill-neutral-text)',
-            borderColor: 'var(--color-pill-neutral-border)',
-            borderStyle: 'solid',
-          }}
-        >
-          Coming soon
-        </span>
+        <StatusPill status="coming-soon" label="Coming soon" />
       </div>
       <div className={INTEGRATION_CARD_DESC_CLASS} style={INTEGRATION_CARD_DESC_STYLE}>
         AI-powered documentation for veterinary practices &mdash; instantly generate clinical notes,
@@ -1226,17 +1208,7 @@ const QuickBooksIntegrationCard = ({
         <div className={INTEGRATION_CARD_TITLE_CLASS} style={INTEGRATION_CARD_TITLE_STYLE}>
           QuickBooks
         </div>
-        <span
-          className={COMING_SOON_PILL_CLASS}
-          style={{
-            backgroundColor: 'var(--color-pill-neutral-bg)',
-            color: 'var(--color-pill-neutral-text)',
-            borderColor: 'var(--color-pill-neutral-border)',
-            borderStyle: 'solid',
-          }}
-        >
-          Coming soon
-        </span>
+        <StatusPill status="coming-soon" label="Coming soon" />
       </div>
       <div className={INTEGRATION_CARD_DESC_CLASS} style={INTEGRATION_CARD_DESC_STYLE}>
         Accounting sync for invoices, payments, customers, and financial workflows through
@@ -1274,17 +1246,7 @@ const LaikaIntegrationCard = ({
         <div className={INTEGRATION_CARD_TITLE_CLASS} style={INTEGRATION_CARD_TITLE_STYLE}>
           Laika
         </div>
-        <span
-          className={COMING_SOON_PILL_CLASS}
-          style={{
-            backgroundColor: 'var(--color-pill-neutral-bg)',
-            color: 'var(--color-pill-neutral-text)',
-            borderColor: 'var(--color-pill-neutral-border)',
-            borderStyle: 'solid',
-          }}
-        >
-          Coming soon
-        </span>
+        <StatusPill status="coming-soon" label="Coming soon" />
       </div>
       <div className={INTEGRATION_CARD_DESC_CLASS} style={INTEGRATION_CARD_DESC_STYLE}>
         AI-powered diagnostic support for veterinary clinicians &mdash; interpret lab results,

--- a/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
@@ -210,17 +210,7 @@ const DeviceCard = ({ device }: { device: IvlsDevice }) => {
             {device.deviceSerialNumber}
           </div>
         </div>
-        <span
-          className="text-label-xsmall px-2 py-1 rounded-2xl! border!"
-          style={{
-            backgroundColor: dt.bg,
-            color: dt.text,
-            borderColor: dt.border,
-            borderStyle: 'solid',
-          }}
-        >
-          {statusLabel}
-        </span>
+        <StatusPill label={statusLabel} tokens={dt} showDot={statusKey === 'active'} />
       </div>
       <div className="mt-2 grid grid-cols-2 gap-2 text-caption-1">
         <div className="text-text-secondary">Last cloud poll</div>
@@ -234,11 +224,23 @@ const DeviceCard = ({ device }: { device: IvlsDevice }) => {
   );
 };
 
-const StatusPill = ({ status, label }: { status?: string; label?: string }) => {
+const StatusPill = ({
+  status,
+  label,
+  tokens: tokensOverride,
+  showDot,
+}: {
+  status?: string;
+  label?: string;
+  // Pills whose colours come from a different map (device, credentials) pass
+  // their tokens directly; everything else looks the key up in statusTokens.
+  tokens?: StatusTokens;
+  showDot?: boolean;
+}) => {
   const key = (status ?? 'disabled').toLowerCase();
   const normalizedLabel = label ?? `${key.charAt(0).toUpperCase()}${key.slice(1)}`;
-  const tokens = statusTokens[key];
-  const isLive = key === 'enabled';
+  const tokens = tokensOverride ?? statusTokens[key];
+  const isLive = showDot ?? key === 'enabled';
   return (
     <span
       className="shrink-0 max-w-full inline-flex items-center gap-1.5 whitespace-nowrap uppercase tracking-[0.06em] text-[10px] font-bold px-2.5 py-0.5 rounded-full! border!"
@@ -344,17 +346,7 @@ const RecentOrdersList = ({ orders }: { orders: LabOrder[] }) => {
             <span className="min-w-0 truncate font-semibold text-text-primary">
               {formatOrderLabel(order)}
             </span>
-            <span
-              className="shrink-0 text-label-xsmall px-2 py-0.5 rounded-full! border!"
-              style={{
-                backgroundColor: tokens.bg,
-                color: tokens.text,
-                borderColor: tokens.border,
-                borderStyle: 'solid',
-              }}
-            >
-              {formatOrderStatusLabel(order.status)}
-            </span>
+            <StatusPill label={formatOrderStatusLabel(order.status)} tokens={tokens} />
           </div>
         );
       })}
@@ -810,27 +802,10 @@ const IdexxSettingsModal = ({
               <div className="grid grid-cols-2 gap-2 text-caption-1">
                 <div className="text-text-secondary">Credentials status</div>
                 <div className="text-right">
-                  <span
-                    className="text-label-xsmall px-2 py-1 rounded-2xl! border!"
-                    style={(() => {
-                      const t = credentialsStatusTokens[credentialsStatusKey];
-                      return t
-                        ? {
-                            backgroundColor: t.bg,
-                            color: t.text,
-                            borderColor: t.border,
-                            borderStyle: 'solid',
-                          }
-                        : {
-                            backgroundColor: 'var(--color-card-hover)',
-                            color: 'var(--color-text-secondary)',
-                            borderColor: 'var(--color-card-border)',
-                            borderStyle: 'solid',
-                          };
-                    })()}
-                  >
-                    {credentialsStatusLabel}
-                  </span>
+                  <StatusPill
+                    label={credentialsStatusLabel}
+                    tokens={credentialsStatusTokens[credentialsStatusKey]}
+                  />
                 </div>
                 <div className="text-text-secondary">Last validated</div>
                 <div className="text-text-primary text-right">{lastValidatedText}</div>

--- a/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
@@ -46,6 +46,7 @@ import {
 } from 'react-icons/io5';
 import clsx from 'clsx';
 import GlassTooltip from '@/app/ui/primitives/GlassTooltip/GlassTooltip';
+import SharedStatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 
 type StatusTokens = { bg: string; text: string; border: string };
 
@@ -224,6 +225,15 @@ const DeviceCard = ({ device }: { device: IvlsDevice }) => {
   );
 };
 
+// Resolves this page's status keys (enabled/disabled/valid/active/…) to the
+// shared StatusPill, keeping the key semantics and the enabled-only live dot so
+// no call site changes. Colours still come from the local token maps.
+const NEUTRAL_FALLBACK_TOKENS: StatusTokens = {
+  bg: 'var(--color-card-hover)',
+  text: 'var(--color-text-secondary)',
+  border: 'var(--color-card-border)',
+};
+
 const StatusPill = ({
   status,
   label,
@@ -239,36 +249,13 @@ const StatusPill = ({
 }) => {
   const key = (status ?? 'disabled').toLowerCase();
   const normalizedLabel = label ?? `${key.charAt(0).toUpperCase()}${key.slice(1)}`;
-  const tokens = tokensOverride ?? statusTokens[key];
-  const isLive = showDot ?? key === 'enabled';
+  const tokens = tokensOverride ?? statusTokens[key] ?? NEUTRAL_FALLBACK_TOKENS;
   return (
-    <span
-      className="shrink-0 max-w-full inline-flex items-center gap-1.5 whitespace-nowrap uppercase tracking-[0.06em] text-[10px] font-bold px-2.5 py-0.5 rounded-full! border!"
-      style={
-        tokens
-          ? {
-              backgroundColor: tokens.bg,
-              color: tokens.text,
-              borderColor: tokens.border,
-              borderStyle: 'solid',
-            }
-          : {
-              backgroundColor: 'var(--color-card-hover)',
-              color: 'var(--color-text-secondary)',
-              borderColor: 'var(--color-card-border)',
-              borderStyle: 'solid',
-            }
-      }
-    >
-      {isLive ? (
-        <span
-          aria-hidden="true"
-          className="size-1.5 rounded-full"
-          style={{ backgroundColor: 'var(--success)' }}
-        />
-      ) : null}
-      {normalizedLabel}
-    </span>
+    <SharedStatusPill
+      label={normalizedLabel}
+      tokens={tokens}
+      showDot={showDot ?? key === 'enabled'}
+    />
   );
 };
 

--- a/apps/frontend/src/app/features/integrations/pages/MerckManuals/index.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/MerckManuals/index.tsx
@@ -42,6 +42,7 @@ import {
   IoOptionsOutline,
   IoSearchOutline,
 } from 'react-icons/io5';
+import StatusPill, { StatusPillTokens } from '@/app/ui/primitives/StatusPill/StatusPill';
 
 type MerckManualsPageProps = {
   embedded?: boolean;
@@ -520,15 +521,22 @@ const MerckSearchPanel = ({
   </div>
 );
 
-const READER_AUDIENCE_META: Record<MerckAudience, { label: string; className: string }> = {
+const READER_AUDIENCE_META: Record<MerckAudience, { label: string; tokens: StatusPillTokens }> = {
   PROV: {
     label: 'PROFESSIONAL',
-    className:
-      'bg-[var(--status-upcoming-bg)] text-[var(--status-upcoming-text)] border-[var(--status-upcoming-border)]',
+    tokens: {
+      bg: 'var(--status-upcoming-bg)',
+      text: 'var(--status-upcoming-text)',
+      border: 'var(--status-upcoming-border)',
+    },
   },
   PAT: {
     label: 'PET PARENT',
-    className: 'bg-blue-soft text-blue-text border-[var(--status-upcoming-border)]',
+    tokens: {
+      bg: 'var(--blue-soft)',
+      text: 'var(--blue-text)',
+      border: 'var(--status-upcoming-border)',
+    },
   },
 };
 
@@ -622,11 +630,11 @@ const MerckReaderPortal = ({
             >
               {readerTitle}
             </div>
-            <span
-              className={`inline-flex flex-none items-center rounded-full border px-2.5 py-[3px] text-[9.5px] font-bold tracking-[0.06em] ${audienceMeta.className}`}
-            >
-              {audienceMeta.label}
-            </span>
+            <StatusPill
+              label={audienceMeta.label}
+              tokens={audienceMeta.tokens}
+              className="flex-none"
+            />
           </div>
           <div className="flex flex-none items-center gap-2">
             <button

--- a/apps/frontend/src/app/features/inventory/components/TurnoverAnalytics/index.tsx
+++ b/apps/frontend/src/app/features/inventory/components/TurnoverAnalytics/index.tsx
@@ -12,7 +12,7 @@ import {
 } from 'react-icons/io5';
 import { useDashboardAnalytics } from '@/app/features/dashboard/hooks/useDashboardAnalytics';
 import useIsPhone from '@/app/ui/layout/PhoneShell/useIsPhone';
-import StatusPill, { type StatusPillTokens } from '@/app/ui/primitives/StatusPill/StatusPill';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import {
   InventoryItem,
   InventoryTurnoverItem,
@@ -62,12 +62,6 @@ const kpiLabelClass = 'text-[10px] font-bold uppercase tracking-[0.08em] text-[v
 const kpiValueClass = 'text-[22px] font-bold tracking-[-0.02em] tabular-nums text-[var(--ink)]';
 const kpiCaptionClass = 'text-[11px] text-[var(--ink-faint)]';
 const insetBoxClass = 'bg-[var(--inset)] border border-[var(--divider)]';
-
-const LOW_STOCK_PILL_TOKENS: StatusPillTokens = {
-  bg: 'var(--danger-bg)',
-  text: 'var(--danger-text)',
-  border: 'var(--danger-border)',
-};
 
 const abcTileClass: Record<AbcClass, string> = {
   'Class A': 'bg-[var(--blue)] text-white',
@@ -341,7 +335,7 @@ const ProductDetailPanel = ({
         <span className="text-[14px] font-bold text-[var(--ink)]">{panel.name}</span>
         <span className="text-[11px] text-[var(--ink-faint)]">{panel.subtitle}</span>
       </span>
-      {panel.isLowStock && <StatusPill label="LOW STOCK" tokens={LOW_STOCK_PILL_TOKENS} />}
+      {panel.isLowStock && <StatusPill label="LOW STOCK" tone="danger" />}
     </div>
     <div className="flex flex-col gap-3 px-[18px] py-3.5">
       <div className="grid grid-cols-2 gap-2.5">

--- a/apps/frontend/src/app/features/inventory/components/TurnoverAnalytics/index.tsx
+++ b/apps/frontend/src/app/features/inventory/components/TurnoverAnalytics/index.tsx
@@ -12,6 +12,7 @@ import {
 } from 'react-icons/io5';
 import { useDashboardAnalytics } from '@/app/features/dashboard/hooks/useDashboardAnalytics';
 import useIsPhone from '@/app/ui/layout/PhoneShell/useIsPhone';
+import StatusPill, { type StatusPillTokens } from '@/app/ui/primitives/StatusPill/StatusPill';
 import {
   InventoryItem,
   InventoryTurnoverItem,
@@ -61,6 +62,12 @@ const kpiLabelClass = 'text-[10px] font-bold uppercase tracking-[0.08em] text-[v
 const kpiValueClass = 'text-[22px] font-bold tracking-[-0.02em] tabular-nums text-[var(--ink)]';
 const kpiCaptionClass = 'text-[11px] text-[var(--ink-faint)]';
 const insetBoxClass = 'bg-[var(--inset)] border border-[var(--divider)]';
+
+const LOW_STOCK_PILL_TOKENS: StatusPillTokens = {
+  bg: 'var(--danger-bg)',
+  text: 'var(--danger-text)',
+  border: 'var(--danger-border)',
+};
 
 const abcTileClass: Record<AbcClass, string> = {
   'Class A': 'bg-[var(--blue)] text-white',
@@ -334,11 +341,7 @@ const ProductDetailPanel = ({
         <span className="text-[14px] font-bold text-[var(--ink)]">{panel.name}</span>
         <span className="text-[11px] text-[var(--ink-faint)]">{panel.subtitle}</span>
       </span>
-      {panel.isLowStock && (
-        <span className="inline-flex items-center rounded-full border border-[var(--danger-border)] bg-[var(--danger-bg)] px-2.5 py-[3px] text-[9.5px] font-bold text-[var(--danger-text)]">
-          LOW STOCK
-        </span>
-      )}
+      {panel.isLowStock && <StatusPill label="LOW STOCK" tokens={LOW_STOCK_PILL_TOKENS} />}
     </div>
     <div className="flex flex-col gap-3 px-[18px] py-3.5">
       <div className="grid grid-cols-2 gap-2.5">

--- a/apps/frontend/src/app/features/inventory/pages/Inventory/InventoryPhoneCatalog.tsx
+++ b/apps/frontend/src/app/features/inventory/pages/Inventory/InventoryPhoneCatalog.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { IoAlertCircleOutline, IoCubeOutline } from 'react-icons/io5';
 import clsx from 'clsx';
 
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import { InventoryFiltersState, InventoryItem } from './types';
 import { getStatusBadgeStyle } from './utils';
 import { buildInventoryPhoneMeta, type InventoryPhoneMeta } from './InventoryPhoneCatalog.utils';
@@ -72,12 +73,11 @@ export const InventoryPhoneCard = ({
               </span>
             )}
           </span>
-          <span
-            className="inline-flex flex-none items-center rounded-full border px-[9px] py-[3px] text-[9.5px] font-bold uppercase whitespace-nowrap"
+          <StatusPill
+            label={meta.statusLabel}
             style={getStatusBadgeStyle(meta.statusLabel)}
-          >
-            {meta.statusLabel}
-          </span>
+            className="flex-none"
+          />
         </span>
         <span className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11.5px] text-[var(--ink-muted)]">
           {meta.onHandText && (

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Documents/Documents.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Documents/Documents.tsx
@@ -9,27 +9,26 @@ import { usePermissions } from '@/app/hooks/usePermissions';
 import { PERMISSIONS } from '@/app/lib/permissions';
 import { PermissionGate } from '@/app/ui/layout/guards/PermissionGate';
 import { toTitle } from '@/app/lib/validators';
-
-const BADGE_BASE =
-  'inline-flex items-center rounded-full border px-[9px] py-[3px] text-[9.5px] font-bold';
-const BADGE_ESIGN =
-  'bg-[var(--status-completed-bg)] text-[var(--status-completed-text)] border-[var(--status-completed-border)]';
-const BADGE_FILE =
-  'bg-[var(--status-upcoming-bg)] text-[var(--status-upcoming-text)] border-[var(--status-upcoming-border)]';
+import StatusPill, { type StatusPillTokens } from '@/app/ui/primitives/StatusPill/StatusPill';
+import {
+  COMPLETED_PILL_TOKENS,
+  UPCOMING_PILL_TOKENS,
+} from '@/app/features/organization/pages/Organization/Sections/orgDisplay';
 
 /**
  * The design colour-codes the two kinds of org document: green E-SIGN for in-app
  * templates and blue for a static upload. A document with no uploaded file is the
  * template case — there is nothing to download, it gets signed in the app.
  */
-const getDocTypeBadge = (fileUrl?: string): { label: string; className: string } => {
+const getDocTypeBadge = (fileUrl?: string): { label: string; tokens: StatusPillTokens } => {
   const url = String(fileUrl ?? '')
     .trim()
     .toLowerCase();
-  if (!url) return { label: 'E-SIGN', className: BADGE_ESIGN };
-  if (url.endsWith('.pdf')) return { label: 'PDF', className: BADGE_FILE };
-  if (url.endsWith('.doc') || url.endsWith('.docx')) return { label: 'DOC', className: BADGE_FILE };
-  return { label: 'FILE', className: BADGE_FILE };
+  if (!url) return { label: 'E-SIGN', tokens: COMPLETED_PILL_TOKENS };
+  if (url.endsWith('.pdf')) return { label: 'PDF', tokens: UPCOMING_PILL_TOKENS };
+  if (url.endsWith('.doc') || url.endsWith('.docx'))
+    return { label: 'DOC', tokens: UPCOMING_PILL_TOKENS };
+  return { label: 'FILE', tokens: UPCOMING_PILL_TOKENS };
 };
 
 const Documents = () => {
@@ -105,7 +104,7 @@ const Documents = () => {
                       {document.description ? ` · ${document.description}` : ''}
                     </span>
                   </button>
-                  <span className={`${BADGE_BASE} ${badge.className}`}>{badge.label}</span>
+                  <StatusPill label={badge.label} tokens={badge.tokens} />
                   <button
                     type="button"
                     onClick={() => handleView(document)}

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/OrgProfileBand.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/OrgProfileBand.tsx
@@ -3,7 +3,11 @@ import Image from 'next/image';
 import { IoCreateOutline, IoShieldCheckmark } from 'react-icons/io5';
 import { Organisation } from '@yosemite-crew/types';
 import { getSafeImageUrl } from '@/app/lib/urls';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import {
+  COMPLETED_PILL_TOKENS,
+  REQUESTED_PILL_TOKENS,
+  UPCOMING_PILL_TOKENS,
   initialsOf,
   orgTypePillLabel,
 } from '@/app/features/organization/pages/Organization/Sections/orgDisplay';
@@ -72,18 +76,19 @@ const OrgProfileBand = ({ org, canEdit, onEdit }: OrgProfileBandProps) => {
             {org.name || 'Organization'}
           </span>
           {org.isVerified ? (
-            <span className="inline-flex items-center gap-[5px] rounded-full border border-[var(--status-completed-border)] bg-[var(--status-completed-bg)] px-[10px] py-[3px] text-[10px] font-bold text-[var(--status-completed-text)]">
-              <IoShieldCheckmark size={10} aria-hidden="true" />
-              VERIFIED
-            </span>
+            <StatusPill
+              tokens={COMPLETED_PILL_TOKENS}
+              label={
+                <>
+                  <IoShieldCheckmark size={10} aria-hidden="true" />
+                  VERIFIED
+                </>
+              }
+            />
           ) : (
-            <span className="inline-flex items-center rounded-full border border-[var(--status-requested-border)] bg-[var(--status-requested-bg)] px-[10px] py-[3px] text-[10px] font-bold text-[var(--status-requested-text)]">
-              PENDING
-            </span>
+            <StatusPill label="PENDING" tokens={REQUESTED_PILL_TOKENS} />
           )}
-          <span className="inline-flex items-center rounded-full border border-[var(--status-upcoming-border)] bg-[var(--status-upcoming-bg)] px-[10px] py-[3px] text-[10px] font-bold text-[var(--status-upcoming-text)]">
-            {orgTypePillLabel(org.type)}
-          </span>
+          <StatusPill label={orgTypePillLabel(org.type)} tokens={UPCOMING_PILL_TOKENS} />
         </span>
         {primaryMeta && <span className="text-[13px] text-[var(--ink-muted)]">{primaryMeta}</span>}
         {secondaryMeta && (

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/PhoneOrganization.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/PhoneOrganization.tsx
@@ -24,7 +24,10 @@ import AddTeam from '@/app/features/organization/pages/Organization/Sections/Tea
 import TeamInfo from '@/app/features/organization/pages/Organization/Sections/Team/TeamInfo';
 import OrgProfileEditCards from '@/app/features/organization/pages/Organization/Sections/OrgProfileEditCards';
 import { useOrgProfileForm } from '@/app/features/organization/pages/Organization/Sections/useOrgProfileForm';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import {
+  COMPLETED_PILL_TOKENS,
+  UPCOMING_PILL_TOKENS,
   avatarAccentFor,
   humanize,
   initialsOf,
@@ -101,14 +104,17 @@ const ProfileCardCompact = ({ org }: { org: Organisation }) => {
             {org.name || 'Organization'}
           </span>
           {org.isVerified && (
-            <span className="inline-flex items-center gap-[3px] rounded-full border border-[var(--status-completed-border)] bg-[var(--status-completed-bg)] px-2 py-[2px] text-[8.5px] font-bold text-[var(--status-completed-text)]">
-              <IoShieldCheckmark size={8} aria-hidden="true" />
-              VERIFIED
-            </span>
+            <StatusPill
+              tokens={COMPLETED_PILL_TOKENS}
+              label={
+                <>
+                  <IoShieldCheckmark size={8} aria-hidden="true" />
+                  VERIFIED
+                </>
+              }
+            />
           )}
-          <span className="inline-flex items-center rounded-full border border-[var(--status-upcoming-border)] bg-[var(--status-upcoming-bg)] px-2 py-[2px] text-[8.5px] font-bold text-[var(--status-upcoming-text)]">
-            {orgTypePillLabel(org.type)}
-          </span>
+          <StatusPill label={orgTypePillLabel(org.type)} tokens={UPCOMING_PILL_TOKENS} />
         </span>
         <span className="mt-[3px] block text-[11px] leading-[1.45] text-[var(--ink-faint)]">
           {line1}
@@ -155,11 +161,7 @@ const TeamListRow = ({ team, onOpen }: { team: TeamProp; onOpen: (team: TeamProp
           {teamSubline(team) || '—'}
         </span>
       </span>
-      <span
-        className={`inline-flex flex-none items-center rounded-full border px-2 py-[2px] text-[8.5px] font-bold ${pill.className}`}
-      >
-        {pill.label}
-      </span>
+      <StatusPill label={pill.label} tokens={pill.tokens} className="flex-none" />
     </button>
   );
 };

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/ProfileCard.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/ProfileCard.tsx
@@ -19,6 +19,11 @@ import React, { useMemo, useState, useRef } from 'react';
 import { MEDIA_SOURCES } from '@/app/constants/mediaSources';
 import dynamic from 'next/dynamic';
 import { IoCreate, IoCheckmark } from 'react-icons/io5';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
+import {
+  COMPLETED_PILL_TOKENS,
+  REQUESTED_PILL_TOKENS,
+} from '@/app/features/organization/pages/Organization/Sections/orgDisplay';
 const CalBookingOverlay = dynamic(() => import('@/app/ui/overlays/CalBookingOverlay'), {
   ssr: false,
 });
@@ -433,16 +438,15 @@ const ProfileCard = ({
                 <div className="text-[15px] font-bold text-[var(--ink)] lg:text-[24px] lg:font-normal lg:font-newsreader lg:tracking-[-0.015em]">
                   {org.name}
                 </div>
-                <span
-                  className={`inline-flex items-center gap-[3px] rounded-full border px-2 py-0.5 text-[8.5px] font-bold uppercase ${
-                    org.isVerified
-                      ? 'bg-[var(--status-completed-bg)] text-[var(--status-completed-text)] border-[var(--status-completed-border)]'
-                      : 'bg-[var(--status-requested-bg)] text-[var(--status-requested-text)] border-[var(--status-requested-border)]'
-                  }`}
-                >
-                  {org.isVerified && <IoCheckmark size={8} aria-hidden="true" />}
-                  {org.isVerified ? 'Verified' : 'Pending'}
-                </span>
+                <StatusPill
+                  tokens={org.isVerified ? COMPLETED_PILL_TOKENS : REQUESTED_PILL_TOKENS}
+                  label={
+                    <>
+                      {org.isVerified && <IoCheckmark size={8} aria-hidden="true" />}
+                      {org.isVerified ? 'Verified' : 'Pending'}
+                    </>
+                  }
+                />
               </div>
               {!org?.isVerified && (
                 <Primary

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Team/Team.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Team/Team.tsx
@@ -9,6 +9,7 @@ import { PermissionGate } from '@/app/ui/layout/guards/PermissionGate';
 import { PERMISSIONS } from '@/app/lib/permissions';
 import { usePermissions } from '@/app/hooks/usePermissions';
 import { getSafeImageUrl } from '@/app/lib/urls';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import {
   avatarAccentFor,
   humanize,
@@ -75,11 +76,7 @@ const TeamRow = ({ team, onOpen }: { team: TeamProp; onOpen: (team: TeamProp) =>
       <span className="truncate text-[var(--ink-muted)]">{humanize(team.role) || '—'}</span>
       <span className="truncate text-[var(--ink-muted)]">{employmentLabel(team)}</span>
       <span>
-        <span
-          className={`inline-flex items-center rounded-full border px-[9px] py-[2px] text-[9.5px] font-bold ${pill.className}`}
-        >
-          {pill.label}
-        </span>
+        <StatusPill label={pill.label} tokens={pill.tokens} />
       </span>
       <span className="flex justify-center">
         <button

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/orgDisplay.ts
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/orgDisplay.ts
@@ -1,4 +1,5 @@
 import { toTitle } from '@/app/lib/validators';
+import type { StatusPillTokens } from '@/app/ui/primitives/StatusPill/StatusPill';
 
 /**
  * Warm-bone avatar palette used across the organization surfaces. Mirrors the
@@ -34,32 +35,48 @@ export const initialsOf = (name = ''): string => {
   return initials || '?';
 };
 
-export type StatusPillStyle = { label: string; className: string };
+export type StatusPillStyle = { label: string; tokens: StatusPillTokens };
 
-const PILL_COMPLETED =
-  'bg-[var(--status-completed-bg)] text-[var(--status-completed-text)] border-[var(--status-completed-border)]';
-const PILL_REQUESTED =
-  'bg-[var(--status-requested-bg)] text-[var(--status-requested-text)] border-[var(--status-requested-border)]';
-const PILL_MUTED = 'bg-[var(--band)] text-[var(--ink-muted)] border-[var(--hairline)]';
+/** The organization surfaces' status pill colours, as `StatusPill` token sets. */
+export const COMPLETED_PILL_TOKENS: StatusPillTokens = {
+  bg: 'var(--status-completed-bg)',
+  text: 'var(--status-completed-text)',
+  border: 'var(--status-completed-border)',
+};
+export const REQUESTED_PILL_TOKENS: StatusPillTokens = {
+  bg: 'var(--status-requested-bg)',
+  text: 'var(--status-requested-text)',
+  border: 'var(--status-requested-border)',
+};
+export const UPCOMING_PILL_TOKENS: StatusPillTokens = {
+  bg: 'var(--status-upcoming-bg)',
+  text: 'var(--status-upcoming-text)',
+  border: 'var(--status-upcoming-border)',
+};
+const MUTED_PILL_TOKENS: StatusPillTokens = {
+  bg: 'var(--band)',
+  text: 'var(--ink-muted)',
+  border: 'var(--hairline)',
+};
 
 /**
  * Maps the team member's availability status onto the design's uppercase
  * micro-badge. "Requested" reads as an invited/pending member (amber), an
  * off-duty member is muted, and available/consulting members are the completed
- * green pill. The real status text is preserved (uppercased) rather than
- * flattened to the design's mock ACTIVE/INVITED wording.
+ * green pill. The real status text is preserved rather than flattened to the
+ * design's mock ACTIVE/INVITED wording; the pill renders it uppercase.
  */
 export const teamStatusPill = (status?: string): StatusPillStyle => {
   const value = (status ?? '').trim().toLowerCase();
-  if (value === 'requested') return { label: 'INVITED', className: PILL_REQUESTED };
-  if (value === 'off-duty') return { label: 'OFF DUTY', className: PILL_MUTED };
-  const label = value ? status!.toUpperCase() : 'ACTIVE';
-  return { label, className: PILL_COMPLETED };
+  if (value === 'requested') return { label: 'INVITED', tokens: REQUESTED_PILL_TOKENS };
+  if (value === 'off-duty') return { label: 'OFF DUTY', tokens: MUTED_PILL_TOKENS };
+  const label = value ? status! : 'ACTIVE';
+  return { label, tokens: COMPLETED_PILL_TOKENS };
 };
 
-/** Humanized organization type for the identity band's uppercase type pill. */
+/** Organization type for the identity band's uppercase type pill. */
 export const orgTypePillLabel = (type?: string): string =>
-  (type ?? '').trim() ? type!.trim().toUpperCase() : 'CLINIC';
+  (type ?? '').trim() ? type!.trim() : 'CLINIC';
 
 /** Humanized role label (VETERINARIAN -> Veterinarian, FRONT_DESK -> Front desk). */
 export const humanize = (value?: string): string => (value ? toTitle(value) : '');

--- a/apps/frontend/src/app/features/organization/pages/Specialities/ServicesTab.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Specialities/ServicesTab.tsx
@@ -19,7 +19,9 @@ import { useCurrencyForPrimaryOrg } from '@/app/hooks/useBilling';
 import { formatMoney } from '@/app/lib/money';
 import YosemiteLoader from '@/app/ui/overlays/Loader/YosemiteLoader';
 import { getCatalogErrorMessage } from '@/app/features/organization/services/catalogErrors';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import {
+  COMPLETED_PILL_TOKENS,
   avatarAccentFor,
   humanize,
   initialsOf,
@@ -59,9 +61,6 @@ const TYPE_LABELS: Record<string, string> = {
 /** Design column template for the speciality service table. */
 const GRID_COLS = 'grid-cols-[1.7fr_1fr_90px_90px_100px_120px_44px]';
 
-const STATUS_PILL_CLASS =
-  'inline-flex items-center rounded-full border px-[9px] py-[2px] text-[9.5px] font-bold uppercase bg-[var(--status-completed-bg)] text-[var(--status-completed-text)] border-[var(--status-completed-border)]';
-
 /**
  * The design's status micro-badge. The catalog status arrives as a backend enum
  * (`ACTIVE`, `ARCHIVED`, ...) which must never reach UI copy, so it is humanized
@@ -69,8 +68,8 @@ const STATUS_PILL_CLASS =
  * `text-transform`. Shared by the wide row and the compact row so the two can
  * never drift apart.
  */
-const StatusPill = ({ status }: { status: string }) => (
-  <span className={STATUS_PILL_CLASS}>{humanize(status)}</span>
+const ServiceStatusPill = ({ status }: { status: string }) => (
+  <StatusPill label={humanize(status)} tokens={COMPLETED_PILL_TOKENS} />
 );
 
 const BookableCell = ({ isBookable }: { isBookable: boolean }) =>
@@ -278,7 +277,7 @@ const ServiceRow = ({
           <BookableCell isBookable={service.isBookable} />
         </span>
         <span>
-          <StatusPill status={service.status} />
+          <ServiceStatusPill status={service.status} />
         </span>
         <RowActionsMenu serviceName={service.name} onEdit={onEdit} onArchive={onArchive} />
       </div>
@@ -289,7 +288,7 @@ const ServiceRow = ({
           <div className="min-w-0 flex-1">
             <ServiceNameCell service={service} expanded={expanded} onToggle={toggle} />
           </div>
-          <StatusPill status={service.status} />
+          <ServiceStatusPill status={service.status} />
           <RowActionsMenu serviceName={service.name} onEdit={onEdit} onArchive={onArchive} />
         </div>
         <div className="flex flex-wrap items-center gap-x-3 gap-y-2">

--- a/apps/frontend/src/app/features/organization/pages/Specialities/SpecialityAccordionRevamp.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Specialities/SpecialityAccordionRevamp.tsx
@@ -6,6 +6,8 @@ import type {
 import type { PackagesTabHandle } from '@/app/features/organization/pages/Specialities/PackagesTab';
 import { IoIosArrowDown } from 'react-icons/io';
 import SegmentedPill from '@/app/ui/primitives/SegmentedPill/SegmentedPill';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
+import { COMPLETED_PILL_TOKENS } from '@/app/features/organization/pages/Organization/Sections/orgDisplay';
 import ServicesTab from '@/app/features/organization/pages/Specialities/ServicesTab';
 import PackagesTab from '@/app/features/organization/pages/Specialities/PackagesTab';
 import ArchiveTab from '@/app/features/organization/pages/Specialities/ArchiveTab';
@@ -26,10 +28,6 @@ type SpecialityAccordionRevampProps = {
   speciality: SpecialityRevamp;
   defaultOpen?: boolean;
 };
-
-/** Design's uppercase micro-badge for a speciality that is in service. */
-const SPECIALITY_STATUS_PILL_CLASS =
-  'inline-flex shrink-0 items-center rounded-full border px-[9px] py-[2px] text-[9.5px] font-bold bg-[var(--status-completed-bg)] text-[var(--status-completed-text)] border-[var(--status-completed-border)]';
 
 type SpecialityAccordionHeaderProps = {
   speciality: SpecialityRevamp;
@@ -143,7 +141,7 @@ const SpecialityAccordionHeader = ({
             />
           </div>
         )}
-        {!open && <span className={SPECIALITY_STATUS_PILL_CLASS}>ACTIVE</span>}
+        {!open && <StatusPill label="ACTIVE" tokens={COMPLETED_PILL_TOKENS} />}
         {open && activeTab !== 'archive' && (
           <div className="shrink-0 w-full sm:w-auto">
             <Primary

--- a/apps/frontend/src/app/features/settings/pages/Settings/Sections/YourOrganizations.tsx
+++ b/apps/frontend/src/app/features/settings/pages/Settings/Sections/YourOrganizations.tsx
@@ -4,7 +4,14 @@ import Link from 'next/link';
 import { IoAdd } from 'react-icons/io5';
 import { useOrgWithMemberships } from '@/app/hooks/useOrgSelectors';
 import { useOrgStore } from '@/app/stores/orgStore';
+import StatusPill, { type StatusPillTokens } from '@/app/ui/primitives/StatusPill/StatusPill';
 import '@/app/features/settings/styles/Settings.css';
+
+const PRIMARY_PILL_TOKENS: StatusPillTokens = {
+  bg: 'var(--status-completed-bg)',
+  text: 'var(--status-completed-text)',
+  border: 'var(--status-completed-border)',
+};
 
 // Avatar palette for the non-primary organizations, mirroring the design's
 // rotating violet/green/amber tokens. The primary org always uses the blue tile.
@@ -65,9 +72,7 @@ const YourOrganizations = () => {
               </span>
             </span>
             {isPrimary ? (
-              <span className="inline-flex flex-none items-center rounded-full border border-[var(--status-completed-border)] bg-[var(--status-completed-bg)] px-[9px] py-0.5 text-[9.5px] font-bold text-[var(--status-completed-text)]">
-                PRIMARY
-              </span>
+              <StatusPill label="PRIMARY" tokens={PRIMARY_PILL_TOKENS} className="flex-none" />
             ) : (
               <button
                 type="button"

--- a/apps/frontend/src/app/ui/Badge.tsx
+++ b/apps/frontend/src/app/ui/Badge.tsx
@@ -1,31 +1,23 @@
-import type { HTMLAttributes } from 'react';
-import clsx from 'clsx';
+import type { ReactNode } from 'react';
+
+import StatusPill, { type StatusTone } from '@/app/ui/primitives/StatusPill/StatusPill';
 
 export type BadgeProps = {
   tone?: 'neutral' | 'brand' | 'success' | 'warning' | 'danger';
   className?: string;
-} & HTMLAttributes<HTMLSpanElement>;
-
-const toneClassMap: Record<NonNullable<BadgeProps['tone']>, string> = {
-  neutral: 'bg-card-bg text-text-secondary',
-  brand: 'bg-primary-600 text-white',
-  success: 'bg-success-100 text-success-700',
-  warning: 'bg-warning-100 text-warning-700',
-  danger: 'bg-danger-100 text-danger-700',
+  children?: ReactNode;
 };
 
-const Badge = ({ tone = 'neutral', className, ...props }: BadgeProps) => {
-  return (
-    <span
-      className={clsx(
-        // DS micro-badge: ALL-CAPS 10px / 700 / 0.08em, pad 4px 10px, fully round.
-        'inline-flex items-center justify-center gap-1 rounded-full px-2.5 py-1 text-[10px] font-bold uppercase leading-none tracking-[0.08em]',
-        toneClassMap[tone],
-        className
-      )}
-      {...props}
-    />
-  );
+const toneMap: Record<NonNullable<BadgeProps['tone']>, StatusTone> = {
+  neutral: 'neutral',
+  brand: 'accent',
+  success: 'success',
+  warning: 'warning',
+  danger: 'warning',
 };
+
+const Badge = ({ tone = 'neutral', className, children }: BadgeProps) => (
+  <StatusPill label={children} tone={toneMap[tone]} className={className} />
+);
 
 export default Badge;

--- a/apps/frontend/src/app/ui/Badge.tsx
+++ b/apps/frontend/src/app/ui/Badge.tsx
@@ -13,7 +13,7 @@ const toneMap: Record<NonNullable<BadgeProps['tone']>, StatusTone> = {
   brand: 'accent',
   success: 'success',
   warning: 'warning',
-  danger: 'warning',
+  danger: 'danger',
 };
 
 const Badge = ({ tone = 'neutral', className, children }: BadgeProps) => (

--- a/apps/frontend/src/app/ui/cards/AvailabilityCard/index.tsx
+++ b/apps/frontend/src/app/ui/cards/AvailabilityCard/index.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import React from 'react';
 import { Team } from '@/app/features/organization/types/team';
 import { getSafeImageUrl } from '@/app/lib/urls';
@@ -54,9 +55,7 @@ const AvailabilityCard = ({ team, handleViewTeam }: AvailabilityCardProps) => {
           {formatWeeklyWorkingHours(team.weeklyWorkingHours)}
         </div>
       </div>
-      <div style={getAvailabilityStatusStyle(team.status)} className="appointment-status">
-        {team.status}
-      </div>
+      <StatusPill style={getAvailabilityStatusStyle(team.status)} label={team.status} />
       <Secondary href="#" onClick={() => handleViewTeam(team)} text="View" className="w-full" />
     </div>
   );

--- a/apps/frontend/src/app/ui/cards/CompanionCard/CompanionCard.tsx
+++ b/apps/frontend/src/app/ui/cards/CompanionCard/CompanionCard.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import React from 'react';
 import { IoCalendarOutline, IoEye, IoListOutline, IoSyncOutline } from 'react-icons/io5';
 import { getCompanionStatusStyle } from '@/app/ui/tables/tableUtils';
@@ -92,12 +93,10 @@ const CompanionCard = ({
         <div className="text-caption-1 text-text-extra">Upcoming appointment:</div>
         <div className="text-caption-1 text-text-primary">{'-'}</div>
       </div>
-      <div
+      <StatusPill
         style={getCompanionStatusStyle(companion.companion.status || 'inactive')}
-        className="appointment-status"
-      >
-        {toTitleCase(companion.companion.status || 'inactive')}
-      </div>
+        label={toTitleCase(companion.companion.status || 'inactive')}
+      />
       <div className="flex gap-2 justify-center">
         <GlassTooltip content={terminologyText('View companion')} side="top">
           <button

--- a/apps/frontend/src/app/ui/cards/FormCard/index.tsx
+++ b/apps/frontend/src/app/ui/cards/FormCard/index.tsx
@@ -1,3 +1,4 @@
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import { FormsProps, getFormCategoryDisplayLabel } from '@/app/features/forms/types/forms';
 import React from 'react';
 import { getFormsStatusStyle } from '@/app/ui/tables/tableUtils';
@@ -41,9 +42,7 @@ const FormCard = ({ form, handleViewForm, getUserName, orgType }: FormCardProps)
         <div className="text-caption-1 text-text-extra">Last updated:</div>
         <div className="text-caption-1 text-text-primary">{form.lastUpdated}</div>
       </div>
-      <div style={getFormsStatusStyle(form.status || '')} className="appointment-status">
-        {form.status}
-      </div>
+      <StatusPill style={getFormsStatusStyle(form.status || '')} label={form.status} />
       <div className="flex gap-3 w-full">
         <Secondary href="#" onClick={() => handleViewForm(form)} text="View" className="w-full" />
       </div>

--- a/apps/frontend/src/app/ui/cards/InventoryCard/index.tsx
+++ b/apps/frontend/src/app/ui/cards/InventoryCard/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import { getInventoryStatusStyle } from '@/app/ui/tables/tableUtils';
 import {
   displayStatusLabel,
@@ -71,9 +72,10 @@ const InventoryCard = ({ item, handleViewInventory }: any) => {
           {displayValue(item.stock.stockLocation)}
         </div>
       </div>
-      <div style={getInventoryStatusStyle(displayStatusLabel(item))} className="appointment-status">
-        {displayStatusLabel(item)}
-      </div>
+      <StatusPill
+        style={getInventoryStatusStyle(displayStatusLabel(item))}
+        label={displayStatusLabel(item)}
+      />
       <div className="flex gap-3 w-full">
         <Secondary
           href="#"

--- a/apps/frontend/src/app/ui/cards/InventoryTurnoverCard/index.tsx
+++ b/apps/frontend/src/app/ui/cards/InventoryTurnoverCard/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import { formatTurnoverStatus, getInventoryTurnoverStatusStyle } from '@/app/ui/tables/tableUtils';
 
 const InventoryTurnoverCard = ({ item }: any) => {
@@ -38,9 +39,10 @@ const InventoryTurnoverCard = ({ item }: any) => {
         <div className="text-caption-1 text-text-extra">Days on shelf:</div>
         <div className="text-caption-1 text-text-primary">{item.daysOnShelf}</div>
       </div>
-      <div style={getInventoryTurnoverStatusStyle(item.status)} className="appointment-status">
-        {formatTurnoverStatus(item.status)}
-      </div>
+      <StatusPill
+        style={getInventoryTurnoverStatusStyle(item.status)}
+        label={formatTurnoverStatus(item.status)}
+      />
     </div>
   );
 };

--- a/apps/frontend/src/app/ui/cards/InviteCard/InviteCard.tsx
+++ b/apps/frontend/src/app/ui/cards/InviteCard/InviteCard.tsx
@@ -27,7 +27,7 @@ const InviteCard = ({ invite, handleAccept, handleReject, disabled = false }: In
       <span className="min-w-0 flex-1">
         <span className="flex items-center gap-2">
           <span className="invite-picker-name truncate">{invite.organisationName}</span>
-          <Badge tone="neutral" className="invite-picker-badge shrink-0 px-2! py-0.5! text-[9px]!">
+          <Badge tone="neutral" className="invite-picker-badge shrink-0">
             INVITED
           </Badge>
         </span>

--- a/apps/frontend/src/app/ui/cards/InvoiceCard/index.tsx
+++ b/apps/frontend/src/app/ui/cards/InvoiceCard/index.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import { getInvoiceItemNames, getInvoiceStatusStyle } from '@/app/ui/tables/tableUtils';
 import { Invoice } from '@yosemite-crew/types';
 import { formatDateLabel } from '@/app/lib/forms';
@@ -70,9 +71,7 @@ const InvoiceCard = ({ invoice, handleViewInvoice }: InvoiceCardProps) => {
           {formatMoney(invoice.totalAmount, currency)}
         </div>
       </div>
-      <div style={getInvoiceStatusStyle(invoice.status)} className="appointment-status">
-        {toTitle(invoice?.status)}
-      </div>
+      <StatusPill style={getInvoiceStatusStyle(invoice.status)} label={toTitle(invoice?.status)} />
       <div className="flex gap-1">
         <div className="text-caption-1 text-text-extra">Payment:</div>
         <div className="text-caption-1 text-text-primary">

--- a/apps/frontend/src/app/ui/cards/OrgCard/OrgCard.tsx
+++ b/apps/frontend/src/app/ui/cards/OrgCard/OrgCard.tsx
@@ -59,15 +59,12 @@ const OrgCard = ({ org, handleOrgClick }: OrgCardProps) => {
         <span className="flex items-center gap-2">
           <span className="org-picker-name truncate">{name}</span>
           {isVerified ? (
-            <Badge
-              tone="success"
-              className="org-picker-badge-verified shrink-0 px-2! py-0.5! text-[9px]!"
-            >
+            <Badge tone="success" className="org-picker-badge-verified shrink-0">
               <IoShieldCheckmark aria-hidden />
               VERIFIED
             </Badge>
           ) : (
-            <Badge tone="warning" className="shrink-0 px-2! py-0.5! text-[9px]!">
+            <Badge tone="warning" className="shrink-0">
               PENDING
             </Badge>
           )}

--- a/apps/frontend/src/app/ui/primitives/StatusPill/StatusPill.tsx
+++ b/apps/frontend/src/app/ui/primitives/StatusPill/StatusPill.tsx
@@ -59,6 +59,13 @@ type StatusPillProps = {
   tone?: StatusTone;
   /** Explicit colour set for callers that already resolve a status colour. */
   tokens?: StatusPillTokens;
+  /**
+   * Colour passthrough for the many features whose status helpers already return
+   * a CSS style object ({color, backgroundColor, borderColor}). Wins over
+   * `tone`/`tokens`, so `<StatusPill style={getInvoiceStatusStyle(s)} .../>` just
+   * works. Colour only - layout belongs in `className`.
+   */
+  style?: React.CSSProperties;
   /** Leading `--success` dot for a "live"/"online" state. */
   showDot?: boolean;
   /** Extra classes for layout only (e.g. `w-fit`). */
@@ -69,6 +76,7 @@ const StatusPill = ({
   label,
   tone = 'neutral',
   tokens,
+  style,
   showDot = false,
   className,
 }: StatusPillProps) => {
@@ -83,6 +91,7 @@ const StatusPill = ({
         color: resolved.text,
         borderColor: resolved.border,
         borderStyle: 'solid',
+        ...style,
       }}
     >
       {showDot && (

--- a/apps/frontend/src/app/ui/primitives/StatusPill/StatusPill.tsx
+++ b/apps/frontend/src/app/ui/primitives/StatusPill/StatusPill.tsx
@@ -11,11 +11,12 @@ import React from 'react';
  *   already compute a status colour via a helper can adopt the shared geometry
  *   without rewriting their colour logic. `tokens` wins when both are given.
  *
- * There is no `danger` tone: the pill token scale has no danger set, and the
- * app has always drawn error/overdue states with `warning`. Callers that mean
- * danger pass `tone="warning"` (or their own tokens).
+ * `danger` draws from the `--danger-*` scale rather than `--color-pill-*`,
+ * which has no danger set. It is a distinct tone on purpose: folding danger
+ * into `warning` would silently repaint every error state amber.
  */
-export type StatusTone = 'success' | 'warning' | 'info' | 'neutral' | 'accent' | 'progress';
+export type StatusTone =
+  'success' | 'warning' | 'danger' | 'info' | 'neutral' | 'accent' | 'progress';
 
 export type StatusPillTokens = { bg: string; text: string; border: string };
 
@@ -29,6 +30,11 @@ const TONE_TOKENS: Record<StatusTone, StatusPillTokens> = {
     bg: 'var(--color-pill-warning-bg)',
     text: 'var(--color-pill-warning-text)',
     border: 'var(--color-pill-warning-border)',
+  },
+  danger: {
+    bg: 'var(--danger-bg)',
+    text: 'var(--danger-text)',
+    border: 'var(--danger-border)',
   },
   info: {
     bg: 'var(--color-pill-info-bg)',

--- a/apps/frontend/src/app/ui/primitives/StatusPill/StatusPill.tsx
+++ b/apps/frontend/src/app/ui/primitives/StatusPill/StatusPill.tsx
@@ -87,9 +87,13 @@ const StatusPill = ({
   className,
 }: StatusPillProps) => {
   const resolved = tokens ?? TONE_TOKENS[tone];
+  // `w-fit` matters: a badge is often a direct child of a flex column, whose
+  // default `align-items: stretch` would otherwise pull it into a full-width
+  // band. An explicit cross size defeats the stretch, and unlike `self-start`
+  // it leaves the badge centred in the flex rows it also sits in.
   return (
     <span
-      className={`inline-flex max-w-full shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full! border! px-2.5 py-0.5 text-[10px] font-bold uppercase tracking-[0.06em] ${
+      className={`inline-flex w-fit max-w-full shrink-0 items-center justify-center gap-1.5 whitespace-nowrap rounded-full! border! px-2.5 py-0.5 text-[10px] font-bold uppercase tracking-[0.06em] ${
         className ?? ''
       }`}
       style={{

--- a/apps/frontend/src/app/ui/primitives/StatusPill/StatusPill.tsx
+++ b/apps/frontend/src/app/ui/primitives/StatusPill/StatusPill.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+
+/**
+ * The one status pill for the whole app. Geometry and type are the warm-bone
+ * badge: 10px/700 uppercase, +0.06em, a full-radius bordered pill, with an
+ * optional leading live-dot. Colour is the only thing that varies.
+ *
+ * Two ways to colour it:
+ * - `tone` picks a `--color-pill-*` token set (the normal case).
+ * - `tokens` passes an explicit {bg,text,border} set, so the many features that
+ *   already compute a status colour via a helper can adopt the shared geometry
+ *   without rewriting their colour logic. `tokens` wins when both are given.
+ *
+ * There is no `danger` tone: the pill token scale has no danger set, and the
+ * app has always drawn error/overdue states with `warning`. Callers that mean
+ * danger pass `tone="warning"` (or their own tokens).
+ */
+export type StatusTone = 'success' | 'warning' | 'info' | 'neutral' | 'accent' | 'progress';
+
+export type StatusPillTokens = { bg: string; text: string; border: string };
+
+const TONE_TOKENS: Record<StatusTone, StatusPillTokens> = {
+  success: {
+    bg: 'var(--color-pill-success-bg)',
+    text: 'var(--color-pill-success-text)',
+    border: 'var(--color-pill-success-border)',
+  },
+  warning: {
+    bg: 'var(--color-pill-warning-bg)',
+    text: 'var(--color-pill-warning-text)',
+    border: 'var(--color-pill-warning-border)',
+  },
+  info: {
+    bg: 'var(--color-pill-info-bg)',
+    text: 'var(--color-pill-info-text)',
+    border: 'var(--color-pill-info-border)',
+  },
+  neutral: {
+    bg: 'var(--color-pill-neutral-bg)',
+    text: 'var(--color-pill-neutral-text)',
+    border: 'var(--color-pill-neutral-border)',
+  },
+  accent: {
+    bg: 'var(--color-pill-accent-bg)',
+    text: 'var(--color-pill-accent-text)',
+    border: 'var(--color-pill-accent-border)',
+  },
+  progress: {
+    bg: 'var(--color-pill-progress-bg)',
+    text: 'var(--color-pill-progress-text)',
+    border: 'var(--color-pill-progress-border)',
+  },
+};
+
+type StatusPillProps = {
+  /** The state or category shown. Rendered uppercase by the type styles. */
+  label: React.ReactNode;
+  /** Semantic colour. Ignored when `tokens` is given. Defaults to neutral. */
+  tone?: StatusTone;
+  /** Explicit colour set for callers that already resolve a status colour. */
+  tokens?: StatusPillTokens;
+  /** Leading `--success` dot for a "live"/"online" state. */
+  showDot?: boolean;
+  /** Extra classes for layout only (e.g. `w-fit`). */
+  className?: string;
+};
+
+const StatusPill = ({
+  label,
+  tone = 'neutral',
+  tokens,
+  showDot = false,
+  className,
+}: StatusPillProps) => {
+  const resolved = tokens ?? TONE_TOKENS[tone];
+  return (
+    <span
+      className={`inline-flex max-w-full shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full! border! px-2.5 py-0.5 text-[10px] font-bold uppercase tracking-[0.06em] ${
+        className ?? ''
+      }`}
+      style={{
+        backgroundColor: resolved.bg,
+        color: resolved.text,
+        borderColor: resolved.border,
+        borderStyle: 'solid',
+      }}
+    >
+      {showDot && (
+        <span
+          aria-hidden="true"
+          className="size-1.5 rounded-full"
+          style={{ backgroundColor: 'var(--success)' }}
+        />
+      )}
+      {label}
+    </span>
+  );
+};
+
+export default StatusPill;

--- a/apps/frontend/src/app/ui/tables/AvailabilityTable.tsx
+++ b/apps/frontend/src/app/ui/tables/AvailabilityTable.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import GenericTable from '@/app/ui/tables/GenericTable/GenericTable';
 
 import Image from 'next/image';
@@ -112,9 +113,7 @@ const AvailabilityTable = ({
       key: 'status',
       width: '12%',
       render: (item: Team) => (
-        <div className="appointment-status" style={getAvailabilityStatusStyle(item.status)}>
-          {item.status}
-        </div>
+        <StatusPill style={getAvailabilityStatusStyle(item.status)} label={item.status} />
       ),
     },
   ];

--- a/apps/frontend/src/app/ui/tables/FormsTable.tsx
+++ b/apps/frontend/src/app/ui/tables/FormsTable.tsx
@@ -1,3 +1,4 @@
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import { FormsProps, getFormCategoryDisplayLabel } from '@/app/features/forms/types/forms';
 import React, { useMemo } from 'react';
 import {
@@ -170,9 +171,7 @@ const FormsTable = ({
       key: 'status',
       width: '110px',
       render: (item: FormsProps) => (
-        <div className="appointment-status" style={getFormsStatusStyle(item.status || '')}>
-          {item.status}
-        </div>
+        <StatusPill style={getFormsStatusStyle(item.status || '')} label={item.status} />
       ),
     },
     {

--- a/apps/frontend/src/app/ui/tables/InventoryTable.tsx
+++ b/apps/frontend/src/app/ui/tables/InventoryTable.tsx
@@ -18,6 +18,7 @@ import { getInventoryStatusStyle } from '@/app/ui/tables/tableUtils';
 import GlassTooltip from '@/app/ui/primitives/GlassTooltip/GlassTooltip';
 import { getSafeOrgImageUrl } from '@/app/lib/urls';
 import { MEDIA_SOURCES } from '@/app/constants/mediaSources';
+import SharedStatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 
 import './DataTable.css';
 
@@ -84,12 +85,7 @@ const getInventoryImageSrc = (item: InventoryItem) => {
 };
 
 const StatusPill = ({ label }: { label: string }) => (
-  <span
-    className="inline-flex items-center rounded-full border px-[9px] py-[3px] text-[9.5px] font-bold uppercase tracking-[0.06em] whitespace-nowrap"
-    style={getInventoryStatusStyle(label)}
-  >
-    {label}
-  </span>
+  <SharedStatusPill label={label} style={getInventoryStatusStyle(label)} />
 );
 
 const ProductCell = ({ item }: { item: InventoryItem }) => {

--- a/apps/frontend/src/app/ui/tables/InventoryTurnoverTable.tsx
+++ b/apps/frontend/src/app/ui/tables/InventoryTurnoverTable.tsx
@@ -1,6 +1,7 @@
 'use client';
 import React from 'react';
 import GenericTable from '@/app/ui/tables/GenericTable/GenericTable';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import { InventoryTurnoverItem } from '@/app/features/inventory/pages/Inventory/types';
 import InventoryTurnoverCard from '@/app/ui/cards/InventoryTurnoverCard';
 
@@ -96,9 +97,10 @@ const InventoryTurnoverTable = ({ filteredList }: InventoryTurnoverTableProps) =
       key: 'status',
       width: '100px',
       render: (item: InventoryTurnoverItem) => (
-        <div className="appointment-status" style={getInventoryTurnoverStatusStyle(item.status)}>
-          {formatTurnoverStatus(item.status)}
-        </div>
+        <StatusPill
+          style={getInventoryTurnoverStatusStyle(item.status)}
+          label={formatTurnoverStatus(item.status)}
+        />
       ),
     },
   ];

--- a/apps/frontend/src/app/ui/tables/InvoiceTable.tsx
+++ b/apps/frontend/src/app/ui/tables/InvoiceTable.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import Image from 'next/image';
 import GenericTable from '@/app/ui/tables/GenericTable/GenericTable';
 import { IoEye, IoOpenOutline } from 'react-icons/io5';
@@ -72,9 +73,7 @@ const renderServices = (item: Invoice) => (
 );
 
 const renderStatus = (item: Invoice) => (
-  <div className="appointment-status" style={getInvoiceStatusStyle(item?.status)}>
-    {toTitle(item?.status)}
-  </div>
+  <StatusPill style={getInvoiceStatusStyle(item?.status)} label={toTitle(item?.status)} />
 );
 
 const renderPayment = (item: Invoice) => (

--- a/apps/frontend/src/app/ui/tables/Tasks.tsx
+++ b/apps/frontend/src/app/ui/tables/Tasks.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import GenericTable from '@/app/ui/tables/GenericTable/GenericTable';
 import { IoEyeOutline, IoSyncOutline } from 'react-icons/io5';
 import { IoIosCalendar } from 'react-icons/io';
@@ -120,9 +121,7 @@ const Tasks = ({
       key: 'status',
       width: '130px',
       render: (item: Task) => (
-        <div className="appointment-status" style={getTaskStatusStyle(item.status)}>
-          {toTitleCase(item.status)}
-        </div>
+        <StatusPill style={getTaskStatusStyle(item.status)} label={toTitleCase(item.status)} />
       ),
     },
     {

--- a/apps/frontend/src/app/ui/tables/appointmentsTableColumns.tsx
+++ b/apps/frontend/src/app/ui/tables/appointmentsTableColumns.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import Image from 'next/image';
 import { FaCheckCircle } from 'react-icons/fa';
 import { IoIosCloseCircle, IoIosCalendar } from 'react-icons/io';
@@ -224,16 +225,14 @@ export const buildAppointmentColumns = ({
 
       return (
         <div className="appointment-profile-two">
-          <div
-            className="appointment-status"
+          <StatusPill
             style={{
               ...statusStyle,
               borderWidth: '1px',
               borderStyle: 'solid',
             }}
-          >
-            {toTitle(displayStatus)}
-          </div>
+            label={toTitle(displayStatus)}
+          />
           <div
             className="mt-1 text-[11px] leading-4 font-medium text-center font-satoshi"
             style={{ color: payment.textColor }}


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] All existing tests and lints pass.

## What is the current behavior?

On the Integrations page the two card status badges had drifted into two separate implementations. The "ENABLED" badge renders through `StatusPill` (10px bold uppercase, +0.06em tracking, 10px/2px padding, full radius); the "Coming soon" badge used a separate one-off class (`text-label-xsmall`, 8px/4px padding, 16px radius, sentence case), so it rendered noticeably larger and in a different case right next to it.

## What is the new behavior?

`coming-soon` becomes a status like any other: its neutral colours move into the `statusTokens` map, and all four coming-soon cards render through `StatusPill`. The two badges are now the same component and cannot drift apart again. Coming-soon correctly gets no live dot (that is gated on `enabled`) and keeps its neutral colour; only the geometry and typography are unified.

## Impact area

`apps/frontend` Integrations page, presentation only. The rendered label text is unchanged ("Coming soon"); the uppercase is CSS.

## Validation performed

- `npx tsc --noemit` (apps/frontend) - clean.
- `npx eslint` on the changed file - clean.
- `pnpm --filter frontend run test --testPathPattern="Integrations"` - 11 suites, 276 tests passing.

Not verified in a browser yet - needs a visual pass on the deployed branch.

## Related Issue(s)

Follow-up to #1977 (side-modal redesign), which touched this file; this pill drift was noticed during that review after the PR had merged.
