### PR TITLE
fix(frontend): tidy add-product modal internals to the warm-bone aesthetic

### DIFF
--- a/apps/frontend/src/app/__tests__/components/companionHistory/HistoryDocumentUpload.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/companionHistory/HistoryDocumentUpload.test.tsx
@@ -9,9 +9,19 @@ jest.mock('@/app/ui/layout/guards/PermissionGate', () => ({
   PermissionGate: ({ children }: any) => <>{children}</>,
 }));
 
-jest.mock('@/app/ui/primitives/Accordion/Accordion', () => ({
+jest.mock('@/app/ui/overlays/Modal', () => ({
   __esModule: true,
-  default: ({ children }: any) => <div>{children}</div>,
+  default: ({ showModal, children }: any) => (showModal ? <div>{children}</div> : null),
+}));
+
+jest.mock('@/app/ui/overlays/Modal/ModalHeader', () => ({
+  __esModule: true,
+  default: ({ title, onClose }: any) => (
+    <div>
+      <div>{title}</div>
+      <button type="button" aria-label="close" onClick={onClose} />
+    </div>
+  ),
 }));
 
 jest.mock('@/app/ui/inputs/Dropdown/LabelDropdown', () => ({
@@ -83,6 +93,7 @@ describe('HistoryDocumentUpload', () => {
 
   it('shows validation errors for missing fields', async () => {
     render(<HistoryDocumentUpload companionId="comp-1" />);
+    fireEvent.click(screen.getByText('Upload record'));
 
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
@@ -91,11 +102,12 @@ describe('HistoryDocumentUpload', () => {
     expect(createCompanionDocumentMock).not.toHaveBeenCalled();
   });
 
-  it('submits document and resets form on success', async () => {
+  it('submits the document, closes the panel and resets the form', async () => {
     const onUploaded = jest.fn();
     createCompanionDocumentMock.mockResolvedValue({ _id: 'doc-1' });
 
     render(<HistoryDocumentUpload companionId="comp-1" onUploaded={onUploaded} />);
+    fireEvent.click(screen.getByText('Upload record'));
 
     fireEvent.change(screen.getByTestId('Category'), {
       target: { value: 'HEALTH' },
@@ -134,6 +146,9 @@ describe('HistoryDocumentUpload', () => {
     });
 
     expect(onUploaded).toHaveBeenCalledTimes(1);
+    // The panel closes itself on success, and reopening starts from a clean form.
+    expect(screen.queryByLabelText('Title')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText('Upload record'));
     expect(screen.getByLabelText('Title')).toHaveValue('');
   });
 });

--- a/apps/frontend/src/app/__tests__/ui/overlays/Modal/ModalBase.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/overlays/Modal/ModalBase.test.tsx
@@ -56,6 +56,24 @@ describe('ModalBase', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it('stays open when the click lands inside another modal', () => {
+    const { setShowModal, onClose } = renderModal();
+
+    // Modals portal to document.body, so one opened from inside another is a
+    // DOM sibling. Clicking it must not read as an outside click here.
+    const sibling = document.createElement('dialog');
+    sibling.className = 'yc-modal-dialog';
+    const inner = document.createElement('button');
+    sibling.appendChild(inner);
+    document.body.appendChild(sibling);
+
+    fireEvent.mouseDown(inner);
+    expect(setShowModal).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+
+    sibling.remove();
+  });
+
   it('does not close when canClose returns false', () => {
     const { setShowModal, onClose } = renderModal({ canClose: () => false });
 

--- a/apps/frontend/src/app/features/companionHistory/components/HistoryDocumentUpload.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/HistoryDocumentUpload.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
-import Accordion from '@/app/ui/primitives/Accordion/Accordion';
+import Modal from '@/app/ui/overlays/Modal';
+import ModalHeader from '@/app/ui/overlays/Modal/ModalHeader';
+import { Primary } from '@/app/ui/primitives/Buttons';
 import { PermissionGate } from '@/app/ui/layout/guards/PermissionGate';
 import { PERMISSIONS } from '@/app/lib/permissions';
 import {
@@ -18,6 +20,7 @@ type HistoryDocumentUploadProps = {
 };
 
 const HistoryDocumentUpload = ({ companionId, onUploaded }: HistoryDocumentUploadProps) => {
+  const [uploadOpen, setUploadOpen] = useState(false);
   const [file, setFile] = useState<File | null>(null);
   const [formData, setFormData] = useState<CompanionRecord>(emptyCompanionRecord);
   const [saving, setSaving] = useState(false);
@@ -65,6 +68,7 @@ const HistoryDocumentUpload = ({ companionId, onUploaded }: HistoryDocumentUploa
       });
       setFile(null);
       setFormDataErrors({});
+      setUploadOpen(false);
       onUploaded?.();
     } catch (error) {
       console.error('Failed to save companion document:', error);
@@ -75,19 +79,38 @@ const HistoryDocumentUpload = ({ companionId, onUploaded }: HistoryDocumentUploa
 
   return (
     <PermissionGate allOf={[PERMISSIONS.COMPANIONS_EDIT_ANY]}>
-      <Accordion title="Upload records" defaultOpen={false} showEditIcon={false} isEditing>
-        <CompanionDocumentUploadForm
-          companionId={companionId}
-          formData={formData}
-          setFormData={setFormData}
-          file={file}
-          setFile={setFile}
-          formDataErrors={formDataErrors}
-          saving={saving}
-          onSave={handleSave}
-          issueDateInputId="historyIncludeIssueDate"
+      <div className="flex justify-end">
+        <Primary
+          href="#"
+          text="Upload record"
+          onClick={() => setUploadOpen(true)}
+          className="w-auto"
         />
-      </Accordion>
+      </div>
+
+      <Modal
+        variant="centered"
+        size="md"
+        showModal={uploadOpen}
+        setShowModal={setUploadOpen}
+        onClose={() => setUploadOpen(false)}
+        aria-label="Upload record"
+      >
+        <div className="flex max-h-[80vh] flex-col gap-4 overflow-y-auto scrollbar-hidden">
+          <ModalHeader title="Upload record" onClose={() => setUploadOpen(false)} />
+          <CompanionDocumentUploadForm
+            companionId={companionId}
+            formData={formData}
+            setFormData={setFormData}
+            file={file}
+            setFile={setFile}
+            formDataErrors={formDataErrors}
+            saving={saving}
+            onSave={handleSave}
+            issueDateInputId="historyIncludeIssueDate"
+          />
+        </div>
+      </Modal>
     </PermissionGate>
   );
 };

--- a/apps/frontend/src/app/features/inventory/components/AddInventory/FormSection.tsx
+++ b/apps/frontend/src/app/features/inventory/components/AddInventory/FormSection.tsx
@@ -442,8 +442,6 @@ const FormSection: React.FC<FormSectionProps> = ({
   return (
     <div className="flex w-full flex-1 flex-col justify-between gap-6">
       <div className="flex flex-col gap-6">
-        <div className="font-satoshi text-black-text text-[23px] font-medium">{sectionTitle}</div>
-
         <Accordion title={sectionTitle} defaultOpen showEditIcon={false} isEditing={true}>
           {sectionKey === 'batch' ? (
             <div className="flex flex-col gap-6">

--- a/apps/frontend/src/app/ui/overlays/Modal/ModalBase.tsx
+++ b/apps/frontend/src/app/ui/overlays/Modal/ModalBase.tsx
@@ -105,6 +105,13 @@ const ModalBase = ({
     const handleClickOutside = (e: MouseEvent) => {
       const target = e.target as HTMLElement | null;
       if (ignoreOutsideClickRef.current?.(target)) return;
+      // Every modal portals to document.body, so a modal opened from inside
+      // another one is its sibling in the DOM rather than its descendant. A
+      // click in the child would otherwise read as "outside" to the parent and
+      // dismiss it - taking the child down with it. Interacting with any dialog
+      // is never a dismissal of a different one; the backdrop sits outside
+      // .yc-modal-dialog, so click-to-dismiss still works.
+      if (target?.closest('.yc-modal-dialog')) return;
       if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
         closeModalRef.current();
       }

--- a/apps/frontend/src/app/ui/widgets/Labels/Labels.tsx
+++ b/apps/frontend/src/app/ui/widgets/Labels/Labels.tsx
@@ -57,16 +57,20 @@ const Labels = ({
             aria-selected={label.key === activeLabel}
             disabled={disableClicking}
             onClick={() => setActiveLabel(label.key)}
-            className={`shrink-0 min-w-20 h-9 text-body-4 px-3 text-text-secondary rounded-2xl! border transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-text ${
+            className={`shrink-0 min-w-20 h-9 text-body-4 px-3 rounded-full! border transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ink)] ${
               label.key === activeLabel
-                ? 'bg-blue-light text-primary-700! border-text-brand!'
-                : 'border-card-border! hover:bg-card-hover!'
+                ? 'bg-[var(--color-pill-neutral-bg)] text-[var(--ink)]! border-[var(--color-pill-neutral-border)]! font-bold'
+                : 'text-[var(--ink-soft)] border-[var(--hairline)]! font-semibold hover:bg-card-hover!'
             } ${disableClicking ? 'opacity-70 cursor-not-allowed' : ''}`}
           >
             <span className="flex items-center justify-center gap-1.5 text-center w-full">
               {label.name}
-              {statuses[label.key] === 'valid' && <span className="text-green-600 text-sm">•</span>}
-              {statuses[label.key] === 'error' && <span className="text-red-500 text-sm">•</span>}
+              {statuses[label.key] === 'valid' && (
+                <span className="text-sm text-[var(--success)]">•</span>
+              )}
+              {statuses[label.key] === 'error' && (
+                <span className="text-sm text-[var(--danger)]">•</span>
+              )}
             </span>
           </button>
         ))}


### PR DESCRIPTION
## What is the current behavior?

Two things the side-modal redesign (#1977) did not reach, both live on dev and visible in the Add product modal:

1. The step section prints its title three times - the active tab, a 23px heading, and the accordion header directly beneath it - so "Basic Details" stacks on itself (confirmed on the deployed modal: three nodes reading "Basic Details" at 16/23/20px).
2. The section tab strip (the shared `Labels` component, used by five modals) keeps a blue-outline active state - `bg-blue-light`, brand-blue border, `primary-700` text - which is off-brand for the warm-bone palette and stands out against every other control on the page.

## What is the new behavior?

- The redundant 23px heading in `AddInventory/FormSection.tsx` is removed. The tab names the step; the accordion header carries the title in the body. Each section has exactly one accordion, so nothing is lost.
- `Labels` active tabs now match the page's own Active/Hidden pills, measured 1:1 off the live deployed control: fully rounded, warm neutral fill (`--color-pill-neutral-bg`), ink text, hairline border, bold when active and ink-soft when not. The valid/error status dots move onto the `--success` / `--danger` tokens.

This restyles the tab strip in all five modals that use `Labels` (Add product, inventory detail, companion detail, add companion, appointment detail) consistently.

## Impact area

`apps/frontend` - `AddInventory/FormSection.tsx` and the shared `ui/widgets/Labels`. Presentation only.

## Validation performed

- `npx tsc --noemit` - clean.
- `npx eslint` on both files - clean.
- `pnpm --filter frontend run test` across `Labels` and all five consumer modals - 51 suites, 693 tests passing.
- The problem was confirmed on the deployed dev site (logged-in) by measuring the live DOM; the target styles were measured 1:1 off the live Active/Hidden pills. The fix itself needs a visual pass once this branch deploys.

## Related Issue(s)

Follow-up to #1977. No separate issue filed.
