### PR TITLE
fix(frontend): let the analytics view toggle restore both of its permissions

### DIFF
--- a/apps/frontend/src/app/__tests__/pages/Organization/Sections/Team/PermissionsEditor.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Organization/Sections/Team/PermissionsEditor.test.tsx
@@ -6,7 +6,7 @@ import {
   computeEffectivePermissions,
   uniq,
 } from '@/app/features/organization/pages/Organization/Sections/Team/permissionsEditorUtils';
-import { Permission, PERMISSIONS } from '@/app/lib/permissions';
+import { Permission, PERMISSIONS, ROLE_PERMISSIONS } from '@/app/lib/permissions';
 
 jest.mock('@/app/ui/primitives/Accordion/Accordion', () => ({
   __esModule: true,
@@ -110,6 +110,26 @@ describe('PermissionsEditor component', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  it('restores both analytics view permissions when the row is re-enabled', async () => {
+    // ADMIN holds analytics:view:any and analytics:view:clinical together.
+    // Turning the row off drops both; turning it back on must return both,
+    // not just the first - otherwise view:clinical is unrecoverable from the UI.
+    render(
+      <PermissionsEditor role={adminRole} value={ROLE_PERMISSIONS.ADMIN} onSave={mockOnSave} />
+    );
+
+    const analyticsView = screen.getByLabelText('Analytics view permission');
+    fireEvent.click(analyticsView); // off
+    fireEvent.click(analyticsView); // back on
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(mockOnSave).toHaveBeenCalled());
+    const saved = mockOnSave.mock.calls.at(-1)?.[0];
+    expect(saved.revokedPermissions).not.toContain(PERMISSIONS.ANALYTICS_VIEW_CLINICAL);
+    expect(saved.revokedPermissions).not.toContain(PERMISSIONS.ANALYTICS_VIEW_ANY);
   });
 
   it('renders permissions accordion', () => {

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Team/PermissionsEditor.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Team/PermissionsEditor.tsx
@@ -13,6 +13,14 @@ type PermissionRow = {
   editEnablePriority?: Permission[];
   viewLabel?: string;
   editLabel?: string;
+  /**
+   * Whether the view permissions in this row stack rather than replace each
+   * other. Most rows are tiers - `view:any` supersedes `view:own`, `edit:any`
+   * supersedes `edit:limited` - so enabling one must clear the others. Analytics
+   * is not: a role holds `view:any` and `view:clinical` together, so picking one
+   * would silently drop the other with no way to get it back.
+   */
+  additiveView?: boolean;
 };
 
 const PERMISSION_ROWS: PermissionRow[] = [
@@ -105,6 +113,7 @@ const PERMISSION_ROWS: PermissionRow[] = [
     viewEnablePriority: [PERMISSIONS.ANALYTICS_VIEW_ANY, PERMISSIONS.ANALYTICS_VIEW_CLINICAL],
     editEnablePriority: [PERMISSIONS.ANALYTICS_EDIT_ANY],
     viewLabel: 'View (Any/Clinical)',
+    additiveView: true,
   },
   {
     key: 'audit',
@@ -172,6 +181,20 @@ function removeAll(perms: Permission[], candidates?: Permission[]) {
   if (!candidates?.length) return perms;
   const remove = new Set(candidates);
   return perms.filter((p) => !remove.has(p));
+}
+
+/**
+ * Which permissions an additive group restores: everything the role baseline
+ * grants, so re-enabling gives back exactly what turning it off removed.
+ */
+function pickAdditiveEnablePermissions(
+  roleDefaults: Permission[],
+  enablePriority?: Permission[]
+): Permission[] {
+  if (!enablePriority?.length) return [];
+  const defaultsSet = new Set(roleDefaults);
+  const fromDefaults = enablePriority.filter((p) => defaultsSet.has(p));
+  return fromDefaults.length ? fromDefaults : enablePriority.slice(0, 1);
 }
 
 function pickEnablePermission(
@@ -251,19 +274,26 @@ const PermissionsEditor = ({ value, onSave, role, readOnly = false }: Permission
           return removeAll(prev, candidates);
         }
 
-        // Check => remove conflicts in that group, add the chosen permission
-        const toAdd = pickEnablePermission(roleDefaults, priority);
-        if (!toAdd) return prev;
+        // Check => remove conflicts in that group, then add back what applies:
+        // every baseline permission for an additive group, one tier otherwise.
+        const isAdditive = kind === 'view' && row.additiveView === true;
+        const single = pickEnablePermission(roleDefaults, priority);
+        const toAdd = isAdditive
+          ? pickAdditiveEnablePermissions(roleDefaults, priority)
+          : ((single ? [single] : []) as Permission[]);
+        if (!toAdd.length) return prev;
 
-        let next = uniq([...removeAll(prev, candidates), toAdd]);
+        let next = uniq([...removeAll(prev, candidates), ...toAdd]);
 
         // ✅ Rule: turning EDIT on also turns VIEW on
         if (kind === 'edit' && viewCandidates.length && !hasAny(next, viewCandidates)) {
-          const viewToAdd = pickEnablePermission(
-            roleDefaults,
-            row.viewEnablePriority ?? viewCandidates
-          );
-          if (viewToAdd) next = uniq([...next, viewToAdd]);
+          const viewPriority = row.viewEnablePriority ?? viewCandidates;
+          const viewToAdd = row.additiveView
+            ? pickAdditiveEnablePermissions(roleDefaults, viewPriority)
+            : ((pickEnablePermission(roleDefaults, viewPriority)
+                ? [pickEnablePermission(roleDefaults, viewPriority)]
+                : []) as Permission[]);
+          if (viewToAdd.length) next = uniq([...next, ...viewToAdd]);
         }
 
         return next;


### PR DESCRIPTION
## What is the current behavior?

Enabling a permission row in the team editor clears the whole group and adds back exactly one permission:

```ts
const toAdd = pickEnablePermission(roleDefaults, priority);
let next = uniq([...removeAll(prev, candidates), toAdd]);
```

That is correct for tiers - `view:any` supersedes `view:own`, `edit:any` supersedes `edit:limited` - where holding two at once is meaningless. Analytics is not a tier: OWNER and ADMIN both hold `analytics:view:any` **and** `analytics:view:clinical`.

So on the Analytics row: turning "View (Any/Clinical)" off revokes both, and turning it back on returns only `view:any`. `analytics:view:clinical` stays in `revokedPermissions` permanently, with no path to restore it from the UI. Hit in practice on a real OWNER membership on dev, which is still in that state.

## What is the new behavior?

A row can declare its view permissions **additive**. An additive group restores every permission its role baseline grants instead of picking one, so re-enabling returns exactly what disabling removed. Analytics is the only additive row today; every other row keeps the pick-one tier behaviour unchanged.

The same applies through the edit-implies-view cascade, so enabling Analytics edit also restores both view permissions rather than one.

## Impact area

`apps/frontend` team permissions editor. Behavioural fix, scoped to rows marked additive.

## Validation performed

- `npx tsc --noemit` - clean.
- `npx eslint` on the changed file - clean.
- **Full suite: 859 suites, 10,534 tests passing.**
- New regression test toggles the Analytics view row off and back on and asserts neither analytics permission ends up revoked. I verified it **fails** with the additive branch disabled and passes with it, so it genuinely covers the bug rather than the fix.

## Note for whoever merges

This repairs the editor, not existing data. Memberships already carrying a revoked `analytics:view:clinical` - including the Avenger Park OWNER this was found on - stay revoked until the Analytics row is toggled once after this ships, which will now restore both.

## Related Issue(s)

Fixes #1978
