### PR TITLE
fix(frontend): drop the duplicate New task button on phone

### DIFF
--- a/apps/frontend/src/app/__tests__/pages/Tasks/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Tasks/index.test.tsx
@@ -368,6 +368,14 @@ describe('Tasks page', () => {
     expect(addTaskSpy).toHaveBeenCalledWith(expect.objectContaining({ showModal: true }));
   });
 
+  it('hides the header New task CTA on phone, leaving creation to the shell FAB', () => {
+    useIsPhoneMock.mockReturnValue(true);
+    render(<ProtectedTasks />);
+
+    // The phone FAB owns creation there, so a second header button would duplicate it.
+    expect(screen.queryByRole('button', { name: 'New task' })).not.toBeInTheDocument();
+  });
+
   it('openAddTask: clicking the header New task CTA calls openAddTask', async () => {
     render(<ProtectedTasks />);
 

--- a/apps/frontend/src/app/features/tasks/pages/Tasks/index.tsx
+++ b/apps/frontend/src/app/features/tasks/pages/Tasks/index.tsx
@@ -326,7 +326,9 @@ const Tasks = () => {
           showAdd={false}
           viewOptions={['calendar', 'board', 'list']}
           actionBeforeAdd={
-            canEditTasks ? (
+            // On phone the create action is the shell FAB, so the header CTA
+            // would be a duplicate - the design's "primary action -> FAB" rule.
+            canEditTasks && !isPhone ? (
               <Primary
                 text="New task"
                 ariaLabel="New task"


### PR DESCRIPTION
## What is the current behavior?

On phone the tasks page renders **two** create affordances at once: the "New task" button in the page header, and the phone shell's create FAB. Both open the same add-task flow, stacked on a single small screen.

## What is the new behavior?

The header "New task" CTA is hidden on phone, leaving the FAB as the single create affordance. This is the design's "primary action -> FAB" rule, and it matches how the inventory page already gates its "Add product" button with `!isPhone`.

The FAB already reaches the same `openAddTask` flow via `usePhonePrimaryAction('task', openAddTask)`, so nothing is lost - only the duplicate is removed. Tablet and desktop are unchanged.

## Impact area

`apps/frontend` tasks page, phone breakpoint only.

## Validation performed

- `npx tsc --noemit` - clean.
- `pnpm --filter frontend run test --testPathPattern="pages/Tasks/index"` - 37 passed, including a new case asserting the header CTA is absent on phone while the desktop cases keep it.

Not visually verified - local login is blocked by the SuperTokens cross-origin setup.