### PR TITLE
feat(frontend): phone sign out, owner permission guard, and mobile tasks FAB

### DIFF
--- a/apps/frontend/src/app/__tests__/pages/Organization/Sections/Team/PermissionsEditor.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Organization/Sections/Team/PermissionsEditor.test.tsx
@@ -132,6 +132,40 @@ describe('PermissionsEditor component', () => {
     expect(saved.revokedPermissions).not.toContain(PERMISSIONS.ANALYTICS_VIEW_ANY);
   });
 
+  it('locks Teams and Organization for an owner and never revokes them', async () => {
+    // An owner must keep the permissions that gate the screens they would use
+    // to reverse a change; the checkboxes are disabled and the save can't drop them.
+    const ownerValue = ROLE_PERMISSIONS.OWNER.filter(
+      (p) => p !== PERMISSIONS.TEAMS_EDIT_ANY && p !== PERMISSIONS.ORG_EDIT
+    );
+    render(<PermissionsEditor role={'OWNER' as const} value={ownerValue} onSave={mockOnSave} />);
+
+    const teamsEdit = screen.getByLabelText('Teams edit permission') as HTMLInputElement;
+    const orgEdit = screen.getByLabelText('Organization edit permission') as HTMLInputElement;
+    expect(teamsEdit).toBeDisabled();
+    expect(teamsEdit).toBeChecked();
+    expect(orgEdit).toBeDisabled();
+
+    // Make an UNRELATED change so the form is dirty while Teams/Org stay out of
+    // the draft. Without the save guard those would be revoked; with it they are
+    // protected and even heal from the incoming revoked state.
+    fireEvent.click(screen.getByLabelText('Inventory view permission'));
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(mockOnSave).toHaveBeenCalled());
+    const saved = mockOnSave.mock.calls.at(-1)?.[0];
+    expect(saved.revokedPermissions).not.toContain(PERMISSIONS.TEAMS_EDIT_ANY);
+    expect(saved.revokedPermissions).not.toContain(PERMISSIONS.ORG_EDIT);
+    expect(saved.revokedPermissions).toContain(PERMISSIONS.INVENTORY_VIEW_ANY);
+  });
+
+  it('leaves Teams and Organization editable for a non-owner', () => {
+    render(
+      <PermissionsEditor role={adminRole} value={ROLE_PERMISSIONS.ADMIN} onSave={mockOnSave} />
+    );
+    expect(screen.getByLabelText('Teams edit permission')).not.toBeDisabled();
+    expect(screen.getByLabelText('Organization edit permission')).not.toBeDisabled();
+  });
+
   it('renders permissions accordion', () => {
     render(<PermissionsEditor role={adminRole} value={defaultPermissions} onSave={mockOnSave} />);
 

--- a/apps/frontend/src/app/__tests__/pages/Tasks/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Tasks/index.test.tsx
@@ -368,6 +368,14 @@ describe('Tasks page', () => {
     expect(addTaskSpy).toHaveBeenCalledWith(expect.objectContaining({ showModal: true }));
   });
 
+  it('hides the header New task CTA on phone, leaving creation to the shell FAB', () => {
+    useIsPhoneMock.mockReturnValue(true);
+    render(<ProtectedTasks />);
+
+    // The phone FAB owns creation there, so a second header button would duplicate it.
+    expect(screen.queryByRole('button', { name: 'New task' })).not.toBeInTheDocument();
+  });
+
   it('openAddTask: clicking the header New task CTA calls openAddTask', async () => {
     render(<ProtectedTasks />);
 

--- a/apps/frontend/src/app/__tests__/ui/layout/PhoneShell/PhoneMoreSheet.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/layout/PhoneShell/PhoneMoreSheet.test.tsx
@@ -36,6 +36,7 @@ const links: PhoneMoreLink[] = [
 const setup = (props: Partial<React.ComponentProps<typeof PhoneMoreSheet>> = {}) => {
   const onClose = jest.fn();
   const onNavigate = jest.fn();
+  const onSignOut = jest.fn();
   const utils = render(
     <PhoneMoreSheet
       open
@@ -43,13 +44,21 @@ const setup = (props: Partial<React.ComponentProps<typeof PhoneMoreSheet>> = {})
       sections={sections}
       links={links}
       onNavigate={onNavigate}
+      onSignOut={onSignOut}
       {...props}
     />
   );
-  return { ...utils, onClose, onNavigate };
+  return { ...utils, onClose, onNavigate, onSignOut };
 };
 
 describe('PhoneMoreSheet', () => {
+  it('signs out and closes when the sign out row is tapped', () => {
+    const { onClose, onSignOut } = setup();
+    fireEvent.click(screen.getByRole('button', { name: /sign out/i }));
+    expect(onSignOut).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
   it('renders nothing when closed', () => {
     const { container } = render(
       <PhoneMoreSheet
@@ -58,6 +67,7 @@ describe('PhoneMoreSheet', () => {
         sections={sections}
         links={links}
         onNavigate={jest.fn()}
+        onSignOut={jest.fn()}
       />
     );
     expect(container.querySelector('.yc-phone-sheet')).not.toBeInTheDocument();

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Team/PermissionsEditor.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Team/PermissionsEditor.tsx
@@ -14,6 +14,12 @@ type PermissionRow = {
   viewLabel?: string;
   editLabel?: string;
   /**
+   * Whether this row must stay on for an OWNER. The permissions that gate the
+   * Team and Organization screens are what an owner would use to undo a
+   * change, so letting an owner revoke them is a self-lockout with no way back.
+   */
+  ownerLocked?: boolean;
+  /**
    * Whether the view permissions in this row stack rather than replace each
    * other. Most rows are tiers - `view:any` supersedes `view:own`, `edit:any`
    * supersedes `edit:limited` - so enabling one must clear the others. Analytics
@@ -87,6 +93,7 @@ const PERMISSION_ROWS: PermissionRow[] = [
     edit: [PERMISSIONS.TEAMS_EDIT_ANY],
     viewEnablePriority: [PERMISSIONS.TEAMS_VIEW_ANY],
     editEnablePriority: [PERMISSIONS.TEAMS_EDIT_ANY],
+    ownerLocked: true,
   },
   {
     key: 'billing',
@@ -128,6 +135,7 @@ const PERMISSION_ROWS: PermissionRow[] = [
     edit: [PERMISSIONS.ORG_EDIT],
     viewEnablePriority: [PERMISSIONS.ORG_VIEW],
     editEnablePriority: [PERMISSIONS.ORG_EDIT],
+    ownerLocked: true,
   },
   {
     key: 'specialities',
@@ -208,6 +216,10 @@ function pickEnablePermission(
   return enablePriority[0] ?? null;
 }
 
+const OWNER_LOCKED_PERMISSIONS: Permission[] = PERMISSION_ROWS.filter(
+  (row) => row.ownerLocked === true
+).flatMap((row) => [...(row.view ?? []), ...(row.edit ?? [])]);
+
 function samePermissionSet(a: Permission[], b: Permission[]) {
   if (a.length !== b.length) return false;
   const aSet = new Set(a);
@@ -215,12 +227,19 @@ function samePermissionSet(a: Permission[], b: Permission[]) {
   return true;
 }
 
-function computeSavePayload(draft: Permission[], roleDefaults: Permission[]) {
+function computeSavePayload(
+  draft: Permission[],
+  roleDefaults: Permission[],
+  protectedPermissions: Permission[] = []
+) {
   const draftSet = new Set(draft);
   const defaultsSet = new Set(roleDefaults);
+  const protectedSet = new Set(protectedPermissions);
 
   const extraPerissions = draft.filter((p) => !defaultsSet.has(p));
-  const revokedPermissions = roleDefaults.filter((p) => !draftSet.has(p));
+  // A protected permission is never revoked, so a membership that arrived with
+  // one already revoked heals on the next save rather than staying stuck.
+  const revokedPermissions = roleDefaults.filter((p) => !draftSet.has(p) && !protectedSet.has(p));
 
   return {
     extraPerissions: uniq(extraPerissions),
@@ -255,6 +274,9 @@ const PermissionsEditor = ({ value, onSave, role, readOnly = false }: Permission
 
   const toggle = React.useCallback(
     (kind: 'view' | 'edit', row: PermissionRow, nextChecked: boolean) => {
+      // An owner never loses the permissions that gate the screens they would
+      // use to reverse a change, so these rows cannot be switched off here.
+      if (!nextChecked && row.ownerLocked && role === 'OWNER') return;
       setDraft((prev) => {
         const viewCandidates = row.view ?? [];
         const editCandidates = row.edit ?? [];
@@ -299,7 +321,7 @@ const PermissionsEditor = ({ value, onSave, role, readOnly = false }: Permission
         return next;
       });
     },
-    [roleDefaults]
+    [role, roleDefaults]
   );
 
   const resetToRoleDefaults = React.useCallback(() => {
@@ -314,14 +336,18 @@ const PermissionsEditor = ({ value, onSave, role, readOnly = false }: Permission
     if (saving) return;
     setSaving(true);
     try {
-      const payload = computeSavePayload(draft, roleDefaults);
+      const payload = computeSavePayload(
+        draft,
+        roleDefaults,
+        role === 'OWNER' ? OWNER_LOCKED_PERMISSIONS : []
+      );
       await onSave(payload);
       // parent should update `value` after save (refetch or optimistic),
       // but we also keep draft as-is; effect will sync when value changes
     } finally {
       setSaving(false);
     }
-  }, [draft, onSave, roleDefaults, saving]);
+  }, [draft, onSave, role, roleDefaults, saving]);
 
   return (
     <Accordion title="Permissions" defaultOpen={false} showEditIcon={false} isEditing={false}>
@@ -346,8 +372,9 @@ const PermissionsEditor = ({ value, onSave, role, readOnly = false }: Permission
             </div>
           </div>
           {PERMISSION_ROWS.map((row) => {
-            const viewChecked = hasAny(draft, row.view);
-            const editChecked = hasAny(draft, row.edit);
+            const lockedForOwner = row.ownerLocked === true && role === 'OWNER';
+            const viewChecked = lockedForOwner || hasAny(draft, row.view);
+            const editChecked = lockedForOwner || hasAny(draft, row.edit);
             const viewDisabled = !row.view?.length;
             const editDisabled = !row.edit?.length;
             return (
@@ -370,7 +397,8 @@ const PermissionsEditor = ({ value, onSave, role, readOnly = false }: Permission
                         aria-label={`${row.label} view permission`}
                         checked={viewChecked}
                         onChange={(e) => !readOnly && toggle('view', row, e.target.checked)}
-                        disabled={readOnly}
+                        disabled={readOnly || lockedForOwner}
+                        title={lockedForOwner ? 'An owner keeps this permission' : undefined}
                         className="size-2"
                       />
                     )}
@@ -385,7 +413,8 @@ const PermissionsEditor = ({ value, onSave, role, readOnly = false }: Permission
                         aria-label={`${row.label} edit permission`}
                         checked={editChecked}
                         onChange={(e) => !readOnly && toggle('edit', row, e.target.checked)}
-                        disabled={readOnly}
+                        disabled={readOnly || lockedForOwner}
+                        title={lockedForOwner ? 'An owner keeps this permission' : undefined}
                         className="size-2"
                       />
                     )}

--- a/apps/frontend/src/app/features/tasks/pages/Tasks/index.tsx
+++ b/apps/frontend/src/app/features/tasks/pages/Tasks/index.tsx
@@ -326,7 +326,9 @@ const Tasks = () => {
           showAdd={false}
           viewOptions={['calendar', 'board', 'list']}
           actionBeforeAdd={
-            canEditTasks ? (
+            // On phone the create action is the shell FAB, so the header CTA
+            // would be a duplicate - the design's "primary action -> FAB" rule.
+            canEditTasks && !isPhone ? (
               <Primary
                 text="New task"
                 ariaLabel="New task"

--- a/apps/frontend/src/app/ui/layout/PhoneShell/PhoneMoreSheet.tsx
+++ b/apps/frontend/src/app/ui/layout/PhoneShell/PhoneMoreSheet.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import type { IconType } from 'react-icons';
-import { IoChevronForwardOutline } from 'react-icons/io5';
+import { IoChevronForwardOutline, IoLogOutOutline } from 'react-icons/io5';
 
 import BottomSheet from './BottomSheet';
 
@@ -28,14 +28,24 @@ export type PhoneMoreSheetProps = {
   sections: PhoneMoreSection[];
   links: PhoneMoreLink[];
   onNavigate: (href: string) => void;
+  onSignOut: () => void;
 };
 
 /**
  * The More bottom sheet: the six secondary areas (each with a context line),
- * then the always-available Settings and Developer portal links, then the system
- * status line. Built on the shared BottomSheet primitive.
+ * then the always-available Settings and Developer portal links, the sign-out
+ * action, and the system status line. This is the only place a phone can sign
+ * out - the avatar menu that holds it on desktop is hidden below 768px. Built
+ * on the shared BottomSheet primitive.
  */
-const PhoneMoreSheet = ({ open, onClose, sections, links, onNavigate }: PhoneMoreSheetProps) => {
+const PhoneMoreSheet = ({
+  open,
+  onClose,
+  sections,
+  links,
+  onNavigate,
+  onSignOut,
+}: PhoneMoreSheetProps) => {
   const go = (href: string) => {
     onNavigate(href);
     onClose();
@@ -89,6 +99,22 @@ const PhoneMoreSheet = ({ open, onClose, sections, links, onNavigate }: PhoneMor
             </li>
           );
         })}
+        <li>
+          <button
+            type="button"
+            className="yc-phone-more-row yc-phone-more-row-signout"
+            onClick={() => {
+              onClose();
+              onSignOut();
+            }}
+          >
+            <span className="yc-phone-more-row-icon yc-phone-more-row-icon-signout" aria-hidden>
+              <IoLogOutOutline size={17} />
+            </span>
+            <span className="yc-phone-more-row-label">Sign out</span>
+            <IoChevronForwardOutline className="yc-phone-more-row-chevron" size={14} aria-hidden />
+          </button>
+        </li>
         <li>
           <div className="yc-phone-more-row yc-phone-more-status-row">
             <span className="yc-phone-more-status-dot" aria-hidden />

--- a/apps/frontend/src/app/ui/layout/PhoneShell/PhoneShell.css
+++ b/apps/frontend/src/app/ui/layout/PhoneShell/PhoneShell.css
@@ -364,6 +364,15 @@
     color: var(--cyan-text);
   }
 
+  /* Sign out is the one destructive row in the sheet, so it reads in danger. */
+  .yc-phone-more-row-icon-signout {
+    color: var(--danger-text);
+  }
+
+  .yc-phone-more-row-signout .yc-phone-more-row-label {
+    color: var(--danger-text);
+  }
+
   .yc-phone-more-row-label {
     flex: 1;
     min-width: 0;

--- a/apps/frontend/src/app/ui/layout/PhoneShell/PhoneShell.tsx
+++ b/apps/frontend/src/app/ui/layout/PhoneShell/PhoneShell.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
+import { useRouter } from 'next/navigation';
 
 import PhoneHeader from './PhoneHeader';
 import PhoneTabBar, { type PhoneTabItem } from './PhoneTabBar';
@@ -9,6 +10,8 @@ import PhoneMoreSheet, { type PhoneMoreSection } from './PhoneMoreSheet';
 import { useIsPhone } from './useIsPhone';
 import { usePhoneNavGate } from './usePhoneNavGate';
 import { usePhoneShellStore } from './phoneShellStore';
+import { useSignOut } from '@/app/hooks/useAuth';
+import { startRouteLoader, stopRouteLoader } from '@/app/lib/routeLoader';
 import {
   PHONE_MORE_LINKS,
   PHONE_MORE_SECTIONS,
@@ -38,9 +41,24 @@ const handleFabAction = (action: FabAction) => {
  */
 const PhoneShell = () => {
   const isPhone = useIsPhone();
+  const router = useRouter();
+  const { signOut } = useSignOut();
   const [moreOpen, setMoreOpen] = useState(false);
   const { pathname, isRouteEnabled, isActive, navigate } = usePhoneNavGate();
   const chatUnread = usePhoneShellStore((s) => s.chatUnread);
+
+  // Mirrors the desktop avatar-menu logout: sign out, then land on the sign-in
+  // route for the surface the user was in.
+  const handleSignOut = async () => {
+    startRouteLoader();
+    try {
+      await signOut();
+      router.replace(pathname.startsWith('/developers') ? '/developers/signin' : '/signin');
+    } catch (error) {
+      console.error('⚠️ Signout error:', error);
+      stopRouteLoader();
+    }
+  };
 
   // Close the More sheet whenever the route changes, adjusting state during render
   // (tracking the previous pathname) instead of via an effect.
@@ -92,6 +110,7 @@ const PhoneShell = () => {
         sections={moreSections}
         links={PHONE_MORE_LINKS}
         onNavigate={navigate}
+        onSignOut={handleSignOut}
       />
     </>
   );


### PR DESCRIPTION
## What is the current behavior?

Three mobile / design gaps:

1. **No way to sign out on a phone.** Sign out lives only in the desktop avatar menu, whose header (`.yc-user-header-shell`) is `display: none` below 768px. The phone header has no menu and the More sheet doesn't offer it, so a phone user cannot sign out at all. Tablet (768-1279px) is fine - it keeps the desktop header.
2. **An owner can lock themselves out of permissions.** The team permissions editor lets an OWNER revoke `teams:edit:any` and `org:view`/`org:edit` - the permissions that gate the very screens an owner would use to reverse the change. This is the root cause behind the earlier Dashboard incident.
3. **Two create affordances on the phone tasks page** - a "New task" header button and the phone shell's create FAB, both opening the same flow.

## What is the new behavior?

1. The **More bottom sheet carries a Sign out row**, styled danger, wired to the same `hardSignOut` the desktop menu uses, redirecting to the sign-in route for the current surface. The More sheet is the only phone surface that can host it (the tab bar is a fixed five destinations; the phone header has no menu). Tablet/desktop unchanged.
2. The **Teams and Organization rows are fixed on and disabled for an OWNER**: the toggle refuses to clear them, and the save payload never revokes them. Because the save is protective rather than draft-driven, a membership that arrived with one already revoked **heals on the next save**. Non-owner roles are unchanged - those rows stay editable.
3. On phone the **header "New task" CTA is hidden**, matching how the inventory page already gates "Add product" with `!isPhone`. The FAB already reaches the same `openAddTask` via `usePhonePrimaryAction`, so nothing is lost.

## Impact area

`apps/frontend`: phone shell (sign out, tasks FAB) and the team permissions editor (owner guard).

## Validation performed

- `npx tsc --noemit` - clean.
- `npx eslint` on changed files - clean.
- **Full suite: 859 suites, 10,534 tests passing.**
- New tests: the More sheet sign-out row calls the handler and closes; the tasks header CTA is absent on phone and present on desktop; the owner guard disables Teams/Org for an OWNER and the save never revokes them while a non-owner keeps them editable. I verified the owner-guard and tasks tests **fail** with their fix reverted, so they cover the bug rather than the fix.

Not visually verified - local login is blocked by the SuperTokens cross-origin setup; these need a phone-width click-through once deployed.

## Note

The permissions guard repairs the editor and heals on save; it is a frontend enforcement. A malicious direct API call could still revoke these - backend defence-in-depth in `user-organization` would be a sensible follow-up but is out of scope for this UI-facing fix.

## Related Issue(s)

Owner-lockout guard and phone sign-out were flagged during the PIMS design-fit work.
