### PR TITLE
fix(backend): stop a failed schedule render from taking down the chart

### DIFF
--- a/apps/backend/src/services/workspace.prisma.service.ts
+++ b/apps/backend/src/services/workspace.prisma.service.ts
@@ -8,6 +8,7 @@ import {
 } from "./finance/events";
 import { InvoiceService, InvoiceServiceError } from "./invoice.service";
 import { documentWhereForOrg } from "./document-scope";
+import logger from "src/utils/logger";
 import { createRenderedDocumentRecord } from "./rendered-document.service";
 import { roundMoney } from "./finance/pricing";
 import type {
@@ -1654,30 +1655,42 @@ const ensureRenderedTaskSchedules = async (
   }>,
 ) => {
   for (const schedule of schedules) {
-    const existing = await prisma.renderedDocument.findFirst({
-      where: {
-        organisationId,
-        sourceKind: "TASK_SCHEDULE" as never,
-        sourceId: schedule.id,
-      },
-      select: { id: true },
-    });
+    // Rendering the schedule PDF is a convenience, but this runs inside the
+    // workspace aggregate that every chart read goes through - viewing, signing
+    // and discharging all depend on it. A render that throws must therefore not
+    // take the chart down with it, so each schedule is isolated and only logged.
+    // Nothing is persisted on failure, so the next load simply retries.
+    try {
+      const existing = await prisma.renderedDocument.findFirst({
+        where: {
+          organisationId,
+          sourceKind: "TASK_SCHEDULE" as never,
+          sourceId: schedule.id,
+        },
+        select: { id: true },
+      });
 
-    if (existing) {
-      continue;
+      if (existing) {
+        continue;
+      }
+
+      await createRenderedDocumentRecord({
+        title: "Inpatient Schedule",
+        source: {
+          sourceKind: "TASK_SCHEDULE",
+          sourceId: schedule.id,
+          organisationId,
+          templateKind: "INPATIENT_SCHEDULE",
+          templateId: schedule.templateId,
+          templateVersion: schedule.templateVersion,
+        },
+      });
+    } catch (error) {
+      logger.error(
+        `[Workspace] Could not render the inpatient schedule document for schedule ${schedule.id} (organisation ${organisationId}). The workspace still loads without it.`,
+        error,
+      );
     }
-
-    await createRenderedDocumentRecord({
-      title: "Inpatient Schedule",
-      source: {
-        sourceKind: "TASK_SCHEDULE",
-        sourceId: schedule.id,
-        organisationId,
-        templateKind: "INPATIENT_SCHEDULE",
-        templateId: schedule.templateId,
-        templateVersion: schedule.templateVersion,
-      },
-    });
   }
 };
 

--- a/apps/backend/test/services/workspace.prisma.service.test.ts
+++ b/apps/backend/test/services/workspace.prisma.service.test.ts
@@ -7,6 +7,7 @@ import {
   dedupeTreatmentItemsByPrescription,
 } from "../../src/services/workspace.prisma.service";
 import { InvoiceService } from "src/services/invoice.service";
+import { createRenderedDocumentRecord } from "src/services/rendered-document.service";
 
 jest.mock("src/config/prisma", () => ({
   prisma: {
@@ -67,6 +68,11 @@ jest.mock("src/services/invoice.service", () => ({
       this.name = "InvoiceServiceError";
     }
   },
+}));
+
+jest.mock("src/services/rendered-document.service", () => ({
+  __esModule: true,
+  createRenderedDocumentRecord: jest.fn(),
 }));
 
 jest.mock("src/services/clinical-artifact.service", () => ({
@@ -1893,6 +1899,45 @@ describe("WorkspaceService", () => {
         kind: "SOAP_NOTE",
       }),
     ]);
+  });
+
+  it("still loads the chart when an inpatient schedule fails to render", async () => {
+    // Regression: the schedule PDF render runs inside the aggregate that every
+    // chart read goes through, so a throw there used to surface as a 500 and made
+    // the appointment impossible to open, sign or discharge - permanently, because
+    // a failed render persists nothing and so is retried on every load.
+    mockedPrisma.appointment.findFirst.mockResolvedValue({
+      id: "appt-1",
+      organisationId: "org-1",
+      status: "IN_PROGRESS",
+      appointmentKind: "INPATIENT",
+      concern: "Ward stay",
+      encounterId: "enc-1",
+      caseId: "case-1",
+      patient: { id: "patient-1", parent: { id: "parent-1" } },
+    });
+    mockedPrisma.taskSchedule.findMany.mockResolvedValue([
+      {
+        id: "sched-1",
+        templateId: "tmpl-1",
+        templateVersion: 1,
+        templateKind: "INPATIENT_SCHEDULE",
+        appointmentId: "appt-1",
+        encounterId: "enc-1",
+      },
+    ]);
+    mockedPrisma.renderedDocument.findFirst.mockResolvedValue(null);
+    (createRenderedDocumentRecord as jest.Mock).mockRejectedValue(
+      new Error("pdf renderer exploded"),
+    );
+
+    const result = await WorkspaceService.getAppointmentBootstrap(
+      { organisationId: "org-1", appointmentId: "appt-1" },
+      ["appointments:view:any", "tasks:view:any"],
+    );
+
+    expect(result).toBeDefined();
+    expect(createRenderedDocumentRecord).toHaveBeenCalled();
   });
 });
 

--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/DiagnosticsStep.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/DiagnosticsStep.test.tsx
@@ -16,6 +16,13 @@ expect.extend(toHaveNoViolations);
 // ---- module-under-mock: the real IDEXX backend hook + exported helpers ----
 const mockUseLabTests = jest.fn();
 
+const mockRouterPush = jest.fn();
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockRouterPush, replace: jest.fn(), prefetch: jest.fn() }),
+  useSearchParams: () => ({ get: jest.fn(() => null), entries: jest.fn(() => [].entries()) }),
+  usePathname: () => '/',
+}));
+
 jest.mock(
   '@/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/LabTests',
   () => ({
@@ -226,7 +233,10 @@ describe('DiagnosticsStep (workspace, real IDEXX backend)', () => {
   it('renders provider pills with IDEXX selected and the order builder/queue/results sections', () => {
     renderStep();
 
-    expect(screen.getByRole('button', { name: 'IDEXX' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Open the IDEXX workspace' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
     expect(screen.getByRole('img', { name: 'IDEXX' })).toBeInTheDocument();
     expect(screen.getByText('Order Builder')).toBeInTheDocument();
     expect(screen.getByText('Test Queue')).toBeInTheDocument();
@@ -265,7 +275,10 @@ describe('DiagnosticsStep (workspace, real IDEXX backend)', () => {
     // Clicking the disabled provider does not switch away from the IDEXX builder.
     fireEvent.click(radButton);
     expect(screen.getByText('Order Builder')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'IDEXX' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Open the IDEXX workspace' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
   });
 
   it('keeps diagnostic history visible but hides new-order controls when read-only', () => {
@@ -553,14 +566,18 @@ describe('DiagnosticsStep (workspace, real IDEXX backend)', () => {
     printSpy.mockRestore();
   });
 
-  it('keeps IDEXX selected when its already-active pill is clicked', () => {
+  it('opens the IDEXX workspace when the logo pill is clicked', () => {
     renderStep();
 
-    // Clicking the enabled IDEXX pill runs the onSelect path (setSelectedProvider).
-    fireEvent.click(screen.getByRole('button', { name: 'IDEXX' }));
+    // IDEXX is always the selected provider, so selection alone left the logo
+    // looking clickable while doing nothing visible. It now opens the hub.
+    fireEvent.click(screen.getByRole('button', { name: 'Open the IDEXX workspace' }));
 
-    expect(screen.getByRole('button', { name: 'IDEXX' })).toHaveAttribute('aria-pressed', 'true');
-    expect(screen.getByText('Order Builder')).toBeInTheDocument();
+    expect(mockRouterPush).toHaveBeenCalledWith('/appointments/idexx-workspace');
+    expect(screen.getByRole('button', { name: 'Open the IDEXX workspace' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
   });
 
   it('labels a non-submitted, non-created order "Open IDEXX" and opens it as an order source', () => {

--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/SoapStep.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/SoapStep.test.tsx
@@ -97,10 +97,10 @@ describe('SoapStep', () => {
     expect(screen.getByText('Speciality')).toBeInTheDocument();
     expect(screen.getByText(APPOINTMENT_SPECIALITY)).toBeInTheDocument();
     expect(screen.queryByRole('textbox', { name: 'Chief complaint' })).not.toBeInTheDocument();
-    expect(screen.getByText('S · Subjective')).toBeInTheDocument();
-    expect(screen.getByText('O · Objective')).toBeInTheDocument();
-    expect(screen.getByText('A · Assessment')).toBeInTheDocument();
-    expect(screen.getAllByText('P · Plan').length).toBeGreaterThan(0);
+    expect(screen.getByText('Subjective (History)')).toBeInTheDocument();
+    expect(screen.getByText('Objective (Examination)')).toBeInTheDocument();
+    expect(screen.getByText('Assessment (Differential)')).toBeInTheDocument();
+    expect(screen.getAllByText('Plan').length).toBeGreaterThan(0);
   });
 
   it('shows an empty state when no SOAP notes have been recorded', () => {
@@ -115,7 +115,7 @@ describe('SoapStep', () => {
     renderSoapStep(encounter);
     const chiefComplaint = screen.getByText('Chief complaint');
     const search = screen.getByLabelText(/search for soap template/i);
-    const subjective = screen.getByText('S · Subjective');
+    const subjective = screen.getByText('Subjective (History)');
     expect(chiefComplaint.compareDocumentPosition(search)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
     expect(search.compareDocumentPosition(subjective)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
   });
@@ -379,7 +379,7 @@ describe('SoapStep', () => {
     const enc = { ...useAppointmentWorkspaceStore.getState().getEncounter(APPT)!, viewOnly: true };
     renderSoapStep(enc);
     expect(screen.queryByLabelText(/search for soap template/i)).not.toBeInTheDocument();
-    expect(screen.queryByText('S · Subjective')).not.toBeInTheDocument();
+    expect(screen.queryByText('Subjective (History)')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Save & Next' })).not.toBeInTheDocument();
     expect(screen.getByText('All SOAP notes')).toBeInTheDocument();
     expect(screen.getByText(/By Dr Tim/)).toBeInTheDocument();
@@ -486,7 +486,7 @@ describe('SoapStep', () => {
     );
 
     // The custom structure REPLACES the four native editors.
-    expect(screen.queryByText('S · Subjective')).not.toBeInTheDocument();
+    expect(screen.queryByText('Subjective (History)')).not.toBeInTheDocument();
     expect(screen.getByText('Gait quality')).toBeInTheDocument();
 
     // A required custom field left empty blocks the save with a validation alert.

--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/SummaryStep.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/SummaryStep.test.tsx
@@ -608,6 +608,20 @@ describe('SummaryStep', () => {
     printSpy.mockRestore();
   });
 
+  it('dims the follow-up date once the summary is saved so it does not read as editable', () => {
+    // The saved state locks the field (the Edit pencil reopens it). Without the
+    // dimming it still renders as a live input, so the date looks broken rather
+    // than locked - which is how it was reported.
+    const enc = { ...seedAndGet(), dischargeSavedAt: '2026-04-20T10:00:00Z' };
+    renderSummary(enc);
+
+    const field = screen
+      .getAllByRole('button', { name: /^Follow up date:/ })[0]
+      .closest('[aria-disabled="true"]');
+    expect(field).toHaveClass('pointer-events-none');
+    expect(field).toHaveClass('opacity-60');
+  });
+
   it('opens the merged packet PDF when printing with encounter context', async () => {
     const enc = { ...seedAndGet(), dischargeSavedAt: '2026-04-20T10:00:00Z' };
     render(<SummaryStep appointmentId={APPT} appointment={appointment} encounter={enc} />);

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/DiagnosticsStep.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/DiagnosticsStep.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/navigation';
 import React, { useCallback, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
 import Image from 'next/image';
@@ -66,10 +67,18 @@ type ProviderOption = {
   label: string;
   available: boolean;
   unavailableReason?: string;
+  /** Provider hub to open on click. IDEXX is always the selected provider, so
+   *  without this the logo looks clickable but nothing happens. */
+  workspaceHref?: string;
 };
 
 const PROVIDERS: ProviderOption[] = [
-  { key: 'IDEXX', label: 'IDEXX', available: true },
+  {
+    key: 'IDEXX',
+    label: 'IDEXX',
+    available: true,
+    workspaceHref: '/appointments/idexx-workspace',
+  },
   {
     key: 'RAD_ANALYZER',
     label: 'RadAnalyzer',
@@ -106,37 +115,44 @@ const IntegrationPills = ({
 }: {
   selected: DiagnosticProvider;
   onSelect: (provider: DiagnosticProvider) => void;
-}) => (
-  <div className="flex flex-wrap items-center gap-3">
-    {PROVIDERS.map((provider) => {
-      const active = selected === provider.key;
-      const disabled = !provider.available;
-      return (
-        <button
-          key={provider.key}
-          type="button"
-          aria-pressed={active}
-          disabled={disabled}
-          title={disabled ? provider.unavailableReason : undefined}
-          onClick={() => {
-            if (!disabled) onSelect(provider.key);
-          }}
-          className={`inline-flex h-12 items-center gap-2 rounded-2xl border px-5 text-body-4 font-medium transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-brand ${getIntegrationPillClass(
-            disabled,
-            active
-          )}`}
-        >
-          <ProviderContent provider={provider} />
-          {disabled ? (
-            <span className="text-caption-2 text-text-secondary">Coming soon</span>
-          ) : (
-            active && <IoOpenOutline size={14} aria-hidden="true" />
-          )}
-        </button>
-      );
-    })}
-  </div>
-);
+}) => {
+  const router = useRouter();
+
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      {PROVIDERS.map((provider) => {
+        const active = selected === provider.key;
+        const disabled = !provider.available;
+        return (
+          <button
+            key={provider.key}
+            type="button"
+            aria-pressed={active}
+            disabled={disabled}
+            title={disabled ? provider.unavailableReason : undefined}
+            aria-label={provider.workspaceHref ? `Open the ${provider.label} workspace` : undefined}
+            onClick={() => {
+              if (disabled) return;
+              onSelect(provider.key);
+              if (provider.workspaceHref) router.push(provider.workspaceHref);
+            }}
+            className={`inline-flex h-12 items-center gap-2 rounded-2xl border px-5 text-body-4 font-medium transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-brand ${getIntegrationPillClass(
+              disabled,
+              active
+            )}`}
+          >
+            <ProviderContent provider={provider} />
+            {disabled ? (
+              <span className="text-caption-2 text-text-secondary">Coming soon</span>
+            ) : (
+              active && <IoOpenOutline size={14} aria-hidden="true" />
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+};
 
 /**
  * Maps a lab order / result status string to the shared design-system pill

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/NativeSoapFields.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/NativeSoapFields.tsx
@@ -31,7 +31,7 @@ const NativeSoapFields = ({
   <>
     <SectionContainer
       titleClassName="text-[10.5px] font-bold uppercase tracking-[0.1em] text-blue-text"
-      title="S · Subjective"
+      title="Subjective (History)"
       compactTop
       disableFocusBorder
     >
@@ -46,7 +46,7 @@ const NativeSoapFields = ({
 
     <SectionContainer
       titleClassName="text-[10.5px] font-bold uppercase tracking-[0.1em] text-blue-text"
-      title="O · Objective"
+      title="Objective (Examination)"
       compactTop
       disableFocusBorder
     >
@@ -68,7 +68,7 @@ const NativeSoapFields = ({
 
     <SectionContainer
       titleClassName="text-[10.5px] font-bold uppercase tracking-[0.1em] text-blue-text"
-      title="A · Assessment"
+      title="Assessment (Differential)"
       compactTop
       disableFocusBorder
     >
@@ -83,7 +83,7 @@ const NativeSoapFields = ({
 
     <SectionContainer
       titleClassName="text-[10.5px] font-bold uppercase tracking-[0.1em] text-blue-text"
-      title="P · Plan"
+      title="Plan"
       compactTop
       disableFocusBorder
     >

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/SummaryStep.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/SummaryStep.tsx
@@ -838,9 +838,12 @@ const useSummaryStepContent = ({
                   }}
                 />
                 <div className="mt-6 flex flex-wrap items-end justify-between gap-3">
-                  {/* Same Datepicker container as edit mode, rendered non-interactive. */}
+                  {/* Same Datepicker container as edit mode, rendered non-interactive.
+                  Dimmed to match the other read-only state below: without it the
+                  field still reads as an editable input, so the date looks broken
+                  rather than locked (the Edit pencil above reopens it). */}
                   <div
-                    className="pointer-events-none w-full select-none sm:max-w-72"
+                    className="pointer-events-none w-full select-none opacity-60 sm:max-w-72"
                     aria-disabled="true"
                   >
                     <Datepicker


### PR DESCRIPTION
## What is the current behavior?

On deployed dev, signing or discharging an appointment fails with `Request failed with status code 500`.

Tracing it: **every** workspace endpoint for the affected encounter returns 500 - appointment bootstrap, encounter, documents, finalization-gate - **except `treatment-items`, the one endpoint that does not go through `buildBootstrapAggregate`**. Signing fails for the same reason: `createEncounterDocumentPacket` calls `getEncounterBootstrap`, which is that same aggregate. The packet and Documenso code are fine - I ran the full sign flow end to end on a healthy encounter and it succeeds (packet 201, sign 200, real PDF URL).

Inside the aggregate, `ensureRenderedTaskSchedules` renders an "Inpatient Schedule" PDF for every task schedule that does not already have one, and it was awaited unguarded:

```ts
await ensureRenderedTaskSchedules(input.organisationId, schedules);
```

So a render that throws escapes as an unmapped 500 and the entire chart becomes unopenable - it cannot be viewed, signed, or discharged.

It is also **permanent**. A failed render persists no `renderedDocument`, so the `if (existing) continue` guard never engages and the same render is retried on every single load. The appointment never recovers on its own.

This is why only *some* appointments break: only actively admitted ones have task schedules and so reach the render at all. On dev, 2 of 22 in-progress appointments fail, 100% reproducibly. No working appointment has an Inpatient Schedule document - they have no task schedules, so the loop body never runs.

## What is the new behavior?

Each schedule's render is isolated. A failure is logged and the workspace loads without that PDF.

The rendered schedule is a convenience document, not part of the clinical record the aggregate returns, so it should never be able to make a patient's chart inaccessible. Nothing else changes: the render still runs, still persists on success, and because failures still persist nothing, a later load will retry it once the underlying issue is fixed.

**This does not fix the render error itself** - that needs the server-side stack, which is not visible from the client (the controller logs it but returns a bare `{"message":"Internal Server Error"}`). It stops that error from being fatal to the chart.

## Deliberately not included

I considered converting the aggregate's `Promise.all` to `allSettled` so any failing loader degrades per-section, and decided against it here. Those loaders return clinical data - medications, orders, tasks, vitals. Silently substituting an empty list when a loader fails would show a clinician an incomplete chart with no indication data is missing, which is worse than a visible error. Failing loudly is the right behaviour for clinical data; a decorative PDF render is not.

## Impact area

`apps/backend` - `workspace.prisma.service.ts` only. No API shape, schema, or frontend change.

## Validation performed

- Backend `type-check`: **0 errors**.
- Backend `lint`: clean.
- Backend tests: **241 suites / 4,632 passing**.
- New regression test asserts the bootstrap still resolves when the schedule render rejects. I verified it **fails with the fix reverted**, so it covers the bug rather than the code.

Note for anyone reproducing locally: a fresh worktree reports ~368 type errors until `@yosemite-crew/auth` and `@yosemite-crew/database` are built - stale package output, not real errors.

## Related Issue(s)

Reported from deployed dev: 500 when signing/discharging. Affected sample: encounter `0f7d8773-e1e5-4812-952d-364327712966`.
