### PR TITLE
fix(repo): fix stale-data and alignment bugs across profile, rooms, and dispensary

### DIFF
--- a/apps/backend/src/services/room-unit-group.service.ts
+++ b/apps/backend/src/services/room-unit-group.service.ts
@@ -123,7 +123,10 @@ const toDomain = (row: RoomUnitGroupRow): RoomUnitGroup => ({
 const getRoomUnitGroupDelegate = (): RoomUnitGroupDelegate =>
   (prisma as unknown as { roomUnitGroup: RoomUnitGroupDelegate }).roomUnitGroup;
 
-const assertRoomExists = async (roomId: string, organisationId: string) => {
+const assertRoomBelongsToOrganisation = async (
+  roomId: string,
+  organisationId: string,
+): Promise<RoomRow> => {
   const room = (await prisma.organisationRoom.findUnique({
     where: { id: roomId },
     select: { id: true, organisationId: true, type: true },
@@ -137,12 +140,24 @@ const assertRoomExists = async (roomId: string, organisationId: string) => {
     throw new RoomUnitGroupServiceError("Room organisation mismatch.", 409);
   }
 
+  return room;
+};
+
+const assertRoomSupportsUnits = (room: RoomRow) => {
   if (!roomTypeSupportsUnits(room.type)) {
     throw new RoomUnitGroupServiceError(
       "Units are only supported for ICU, Inpatient, Isolation and Boarding rooms.",
       409,
     );
   }
+};
+
+// Used by create (and by update when actually moving a group to a different
+// room) - a brand-new group-room association must target a room that
+// currently supports units.
+const assertRoomExists = async (roomId: string, organisationId: string) => {
+  const room = await assertRoomBelongsToOrganisation(roomId, organisationId);
+  assertRoomSupportsUnits(room);
 };
 
 export const RoomUnitGroupService = {
@@ -214,7 +229,17 @@ export const RoomUnitGroupService = {
       }
 
       const roomId = optionalNonEmptyString(input.roomId) ?? current.roomId;
-      await assertRoomExists(roomId, organisationId);
+      const room = await assertRoomBelongsToOrganisation(
+        roomId,
+        organisationId,
+      );
+      // Only require the target room to currently support units when the group
+      // is actually being moved there. A same-room update (e.g. deactivating a
+      // group after its room's type changed away from a unit-capable one) must
+      // still be possible - otherwise that type change can never be cleaned up.
+      if (roomId !== current.roomId) {
+        assertRoomSupportsUnits(room);
+      }
 
       const unitCount =
         input.unitCount == null

--- a/apps/backend/src/services/room-unit-group.service.ts
+++ b/apps/backend/src/services/room-unit-group.service.ts
@@ -233,11 +233,15 @@ export const RoomUnitGroupService = {
         roomId,
         organisationId,
       );
-      // Only require the target room to currently support units when the group
-      // is actually being moved there. A same-room update (e.g. deactivating a
-      // group after its room's type changed away from a unit-capable one) must
-      // still be possible - otherwise that type change can never be cleaned up.
-      if (roomId !== current.roomId) {
+      // Only exempt a same-room *deactivation* from the room-type check -
+      // otherwise a type change away from a unit-capable room could never be
+      // cleaned up (every cleanup request would 409). Any other same-room
+      // update (reactivating, renaming, resizing) must still be rejected
+      // while the room doesn't support units, or it recreates the exact
+      // invalid state - an active group on a non-unit-capable room - that
+      // create and move operations are meant to prevent.
+      const isDeactivating = input.isActive === false;
+      if (roomId !== current.roomId || !isDeactivating) {
         assertRoomSupportsUnits(room);
       }
 

--- a/apps/backend/src/services/room-unit.service.ts
+++ b/apps/backend/src/services/room-unit.service.ts
@@ -163,7 +163,10 @@ const getOccupiedUnitIds = async (
   );
 };
 
-const assertRoomExists = async (roomId: string, organisationId: string) => {
+const assertRoomBelongsToOrganisation = async (
+  roomId: string,
+  organisationId: string,
+): Promise<RoomRow> => {
   const room = (await prisma.organisationRoom.findUnique({
     where: { id: roomId },
     select: { id: true, organisationId: true, type: true },
@@ -177,12 +180,24 @@ const assertRoomExists = async (roomId: string, organisationId: string) => {
     throw new RoomUnitServiceError("Room organisation mismatch.", 409);
   }
 
+  return room;
+};
+
+const assertRoomSupportsUnits = (room: RoomRow) => {
   if (!roomTypeSupportsUnits(room.type)) {
     throw new RoomUnitServiceError(
       "Units are only supported for ICU, Inpatient, Isolation and Boarding rooms.",
       409,
     );
   }
+};
+
+// Used by create (and by update when actually moving a unit to a different
+// room) - a brand-new unit-room association must target a room that currently
+// supports units.
+const assertRoomExists = async (roomId: string, organisationId: string) => {
+  const room = await assertRoomBelongsToOrganisation(roomId, organisationId);
+  assertRoomSupportsUnits(room);
 };
 
 const assertRoomUnitGroupExists = async (
@@ -265,7 +280,15 @@ export const RoomUnitService = {
       input.unitGroupId === undefined
         ? (current.unitGroupId ?? undefined)
         : (normalizeOptionalString(input.unitGroupId) ?? undefined);
-    await assertRoomExists(roomId, organisationId);
+    const room = await assertRoomBelongsToOrganisation(roomId, organisationId);
+    // Only require the target room to currently support units when the unit is
+    // actually being moved there. A same-room update (e.g. deactivating a unit
+    // after its room's type changed away from a unit-capable one) must still be
+    // possible - otherwise that type change can never be cleaned up, leaving the
+    // stale unit active forever while every request to fix it 409s.
+    if (roomId !== current.roomId) {
+      assertRoomSupportsUnits(room);
+    }
     if (unitGroupId) {
       await assertRoomUnitGroupExists(unitGroupId, roomId, organisationId);
     }

--- a/apps/backend/src/services/room-unit.service.ts
+++ b/apps/backend/src/services/room-unit.service.ts
@@ -281,12 +281,15 @@ export const RoomUnitService = {
         ? (current.unitGroupId ?? undefined)
         : (normalizeOptionalString(input.unitGroupId) ?? undefined);
     const room = await assertRoomBelongsToOrganisation(roomId, organisationId);
-    // Only require the target room to currently support units when the unit is
-    // actually being moved there. A same-room update (e.g. deactivating a unit
-    // after its room's type changed away from a unit-capable one) must still be
-    // possible - otherwise that type change can never be cleaned up, leaving the
-    // stale unit active forever while every request to fix it 409s.
-    if (roomId !== current.roomId) {
+    // Only exempt a same-room *deactivation* from the room-type check -
+    // otherwise a type change away from a unit-capable room could never be
+    // cleaned up (every cleanup request would 409). Any other same-room
+    // update (reactivating, renaming, resizing) must still be rejected while
+    // the room doesn't support units, or it recreates the exact invalid
+    // state - an active unit on a non-unit-capable room - that create and
+    // move operations are meant to prevent.
+    const isDeactivating = input.isActive === false;
+    if (roomId !== current.roomId || !isDeactivating) {
       assertRoomSupportsUnits(room);
     }
     if (unitGroupId) {

--- a/apps/backend/src/services/user-profile.service.ts
+++ b/apps/backend/src/services/user-profile.service.ts
@@ -272,6 +272,32 @@ const optionalBoolean = (
   throw new UserProfileServiceError(`${field} must be a boolean.`, 400);
 };
 
+// A key that's absent from the raw patch must preserve whatever the address
+// already has for it; a key that's present but sanitizes to nothing (empty
+// string, null) is the caller explicitly clearing it. optionalString/Number
+// collapse both cases to `undefined`, so presence has to be checked against
+// the raw record first - `null` (kept, unlike `undefined`, by pruneUndefined)
+// is how "clear this field" survives sanitization to the merge step in update().
+const clearableAddressString = (
+  record: UnknownRecord,
+  key: string,
+  field: string,
+): string | null | undefined => {
+  const sanitized = optionalString(record[key], field);
+  if (sanitized !== undefined) return sanitized;
+  return key in record ? null : undefined;
+};
+
+const clearableAddressNumber = (
+  record: UnknownRecord,
+  key: string,
+  field: string,
+): number | null | undefined => {
+  const sanitized = optionalNumber(record[key], field);
+  if (sanitized !== undefined) return sanitized;
+  return key in record ? null : undefined;
+};
+
 // NOSONAR: Values are validated and sanitized before persistence, no query concatenation.
 const sanitizeAddress = (
   value: unknown,
@@ -282,15 +308,24 @@ const sanitizeAddress = (
 
   const record = assertPlainObject(value, "Personal details address");
 
+  // Fields may be `null` here (an explicit clear) even though the declared
+  // return type says `string | undefined` - that's intentional. Only the
+  // internal merge in update() and syncUserProfileAddress read this value,
+  // and both already treat "nullish" as one case; nothing serializes it
+  // straight into an API response, where the narrower type must hold.
   return pruneUndefined({
-    addressLine: optionalString(record.addressLine, "Address line"),
-    country: optionalString(record.country, "Address country"),
-    city: optionalString(record.city, "Address city"),
-    state: optionalString(record.state, "Address state"),
-    postalCode: optionalString(record.postalCode, "Address postal code"),
-    latitude: optionalNumber(record.latitude, "Address latitude"),
-    longitude: optionalNumber(record.longitude, "Address longitude"),
-  });
+    addressLine: clearableAddressString(record, "addressLine", "Address line"),
+    country: clearableAddressString(record, "country", "Address country"),
+    city: clearableAddressString(record, "city", "Address city"),
+    state: clearableAddressString(record, "state", "Address state"),
+    postalCode: clearableAddressString(
+      record,
+      "postalCode",
+      "Address postal code",
+    ),
+    latitude: clearableAddressNumber(record, "latitude", "Address latitude"),
+    longitude: clearableAddressNumber(record, "longitude", "Address longitude"),
+  } as UserProfileAddressMongo);
 };
 
 const sanitizePmsPreferences = (
@@ -931,12 +966,22 @@ export const UserProfileService = {
     // only for the address itself when the caller's payload actually included one; a
     // gender-only or timezone-only update has no `address` key at all and must keep
     // the existing address rather than reading its absence as "clear it".
+    //
+    // Within a submitted address, merge field-by-field rather than replacing the
+    // whole object: a one-field patch like `{ address: { country: "CA" } }` must
+    // preserve the untouched addressLine/city/state/postalCode/coordinates, not
+    // null them out. sanitizeAddress already turned an explicitly-cleared field
+    // into `null` (kept) versus an omitted one (absent), so a plain spread with
+    // the new address last resolves all three cases correctly.
     const existingPersonalDetails = buildPersonalDetailsFromPrisma(existing);
     const personalDetails = attributes.personalDetails
       ? {
           ...attributes.personalDetails,
           address: personalDetailsAddressProvided
-            ? attributes.personalDetails.address
+            ? {
+                ...existingPersonalDetails?.address,
+                ...attributes.personalDetails.address,
+              }
             : existingPersonalDetails?.address,
         }
       : existingPersonalDetails;

--- a/apps/backend/src/services/user-profile.service.ts
+++ b/apps/backend/src/services/user-profile.service.ts
@@ -789,10 +789,12 @@ const sanitizeUpdatePayload = (
 ): {
   attributes: Partial<UserProfileMongo>;
   personalDetailsAddressProvided: boolean;
+  personalDetailsAddressCleared: boolean;
 } => {
   const sanitized: Partial<UserProfileMongo> = {};
   let hasProfileUpdate = false;
   let personalDetailsAddressProvided = false;
+  let personalDetailsAddressCleared = false;
 
   if ("personalDetails" in payload) {
     sanitized.personalDetails = sanitizePersonalDetails(
@@ -803,11 +805,18 @@ const sanitizeUpdatePayload = (
     // object with no `address` key at all - that must preserve the existing
     // address rather than read as "clear it" (sanitizeAddress(undefined) and an
     // explicit address:null are otherwise indistinguishable downstream).
+    const rawPersonalDetails = payload.personalDetails;
     personalDetailsAddressProvided =
-      typeof payload.personalDetails === "object" &&
-      payload.personalDetails !== null &&
-      !Array.isArray(payload.personalDetails) &&
-      "address" in payload.personalDetails;
+      typeof rawPersonalDetails === "object" &&
+      rawPersonalDetails !== null &&
+      !Array.isArray(rawPersonalDetails) &&
+      "address" in rawPersonalDetails;
+    // sanitizeAddress(null) also returns undefined (same as an omitted key),
+    // so "delete the whole address" and "didn't touch it" must be told apart
+    // here, from the raw value, before that distinction is lost.
+    personalDetailsAddressCleared =
+      personalDetailsAddressProvided &&
+      (rawPersonalDetails as Record<string, unknown>).address == null;
   }
 
   if ("professionalDetails" in payload) {
@@ -824,6 +833,7 @@ const sanitizeUpdatePayload = (
   return {
     attributes: pruneUndefined(sanitized),
     personalDetailsAddressProvided,
+    personalDetailsAddressCleared,
   };
 };
 
@@ -929,8 +939,11 @@ export const UserProfileService = {
   ): Promise<UserProfileType | null> {
     const identifier = requireUserId(userId);
     const organizationIdentifier = requireOrganizationId(organizationId);
-    const { attributes, personalDetailsAddressProvided } =
-      sanitizeUpdatePayload(payload);
+    const {
+      attributes,
+      personalDetailsAddressProvided,
+      personalDetailsAddressCleared,
+    } = sanitizeUpdatePayload(payload);
 
     const existing = await prisma.userProfile.findFirst({
       where: { userId: identifier, organizationId: organizationIdentifier },
@@ -973,16 +986,23 @@ export const UserProfileService = {
     // null them out. sanitizeAddress already turned an explicitly-cleared field
     // into `null` (kept) versus an omitted one (absent), so a plain spread with
     // the new address last resolves all three cases correctly.
+    //
+    // An explicit `address: null` is different again - sanitizeAddress(null)
+    // collapses to `undefined`, same as an omitted address, so a plain merge
+    // would silently keep the old address instead of deleting it. Resolve that
+    // as `undefined` here so syncUserProfileAddress takes its delete branch.
     const existingPersonalDetails = buildPersonalDetailsFromPrisma(existing);
     const personalDetails = attributes.personalDetails
       ? {
           ...attributes.personalDetails,
-          address: personalDetailsAddressProvided
-            ? {
-                ...existingPersonalDetails?.address,
-                ...attributes.personalDetails.address,
-              }
-            : existingPersonalDetails?.address,
+          address: personalDetailsAddressCleared
+            ? undefined
+            : personalDetailsAddressProvided
+              ? {
+                  ...existingPersonalDetails?.address,
+                  ...attributes.personalDetails.address,
+                }
+              : existingPersonalDetails?.address,
         }
       : existingPersonalDetails;
     await syncUserProfileAddress(updated.id, personalDetails?.address);

--- a/apps/backend/src/services/user-profile.service.ts
+++ b/apps/backend/src/services/user-profile.service.ts
@@ -746,15 +746,28 @@ const sanitizeCreatePayload = (
 
 const sanitizeUpdatePayload = (
   payload: UpdateUserProfilePayload,
-): { attributes: Partial<UserProfileMongo> } => {
+): {
+  attributes: Partial<UserProfileMongo>;
+  personalDetailsAddressProvided: boolean;
+} => {
   const sanitized: Partial<UserProfileMongo> = {};
   let hasProfileUpdate = false;
+  let personalDetailsAddressProvided = false;
 
   if ("personalDetails" in payload) {
     sanitized.personalDetails = sanitizePersonalDetails(
       payload.personalDetails,
     );
     hasProfileUpdate = true;
+    // A caller updating only e.g. gender or timezone sends a personalDetails
+    // object with no `address` key at all - that must preserve the existing
+    // address rather than read as "clear it" (sanitizeAddress(undefined) and an
+    // explicit address:null are otherwise indistinguishable downstream).
+    personalDetailsAddressProvided =
+      typeof payload.personalDetails === "object" &&
+      payload.personalDetails !== null &&
+      !Array.isArray(payload.personalDetails) &&
+      "address" in payload.personalDetails;
   }
 
   if ("professionalDetails" in payload) {
@@ -770,6 +783,7 @@ const sanitizeUpdatePayload = (
 
   return {
     attributes: pruneUndefined(sanitized),
+    personalDetailsAddressProvided,
   };
 };
 
@@ -875,7 +889,8 @@ export const UserProfileService = {
   ): Promise<UserProfileType | null> {
     const identifier = requireUserId(userId);
     const organizationIdentifier = requireOrganizationId(organizationId);
-    const { attributes } = sanitizeUpdatePayload(payload);
+    const { attributes, personalDetailsAddressProvided } =
+      sanitizeUpdatePayload(payload);
 
     const existing = await prisma.userProfile.findFirst({
       where: { userId: identifier, organizationId: organizationIdentifier },
@@ -907,10 +922,19 @@ export const UserProfileService = {
     // it yet. Reading through buildPersonalDetailsFromPrisma would prefer that stale
     // relational row over the new address, so the sync below would just write the old
     // value back and the edit would never appear (including after a refresh). Use the
-    // freshly-submitted personalDetails directly instead, same as create() does.
-    const personalDetails =
-      attributes.personalDetails ??
-      (existing.personalDetails as UserProfilePersonalDetailsMongo | undefined);
+    // freshly-submitted personalDetails directly instead, same as create() does - but
+    // only for the address itself when the caller's payload actually included one; a
+    // gender-only or timezone-only update has no `address` key at all and must keep
+    // the existing address rather than reading its absence as "clear it".
+    const existingPersonalDetails = buildPersonalDetailsFromPrisma(existing);
+    const personalDetails = attributes.personalDetails
+      ? {
+          ...attributes.personalDetails,
+          address: personalDetailsAddressProvided
+            ? attributes.personalDetails.address
+            : existingPersonalDetails?.address,
+        }
+      : existingPersonalDetails;
     await syncUserProfileAddress(updated.id, personalDetails?.address);
 
     let availability: UserAvailability[] = [];

--- a/apps/backend/src/services/user-profile.service.ts
+++ b/apps/backend/src/services/user-profile.service.ts
@@ -573,14 +573,19 @@ const syncUserProfileAddress = async (
       latitude: address.latitude ?? undefined,
       longitude: address.longitude ?? undefined,
     },
+    // Unlike `create`, this row already exists - an omitted field here means
+    // the caller cleared it (e.g. emptied the Country input), not "leave it
+    // alone". Prisma treats an explicit `undefined` in an update as "don't
+    // touch this column", which would leave the stale value in place and have
+    // it resurface on the next read; `null` actually clears it.
     update: {
-      addressLine: address.addressLine ?? undefined,
-      country: address.country ?? undefined,
-      city: address.city ?? undefined,
-      state: address.state ?? undefined,
-      postalCode: address.postalCode ?? undefined,
-      latitude: address.latitude ?? undefined,
-      longitude: address.longitude ?? undefined,
+      addressLine: address.addressLine ?? null,
+      country: address.country ?? null,
+      city: address.city ?? null,
+      state: address.state ?? null,
+      postalCode: address.postalCode ?? null,
+      latitude: address.latitude ?? null,
+      longitude: address.longitude ?? null,
     },
   });
 };

--- a/apps/backend/src/services/user-profile.service.ts
+++ b/apps/backend/src/services/user-profile.service.ts
@@ -589,8 +589,7 @@ const buildPersonalDetailsFromPrisma = (
   profile: PrismaUserProfileWithAddress,
 ): UserProfilePersonalDetailsMongo | undefined => {
   const rawPersonalDetails = profile.personalDetails as
-    | UserProfilePersonalDetailsMongo
-    | undefined;
+    UserProfilePersonalDetailsMongo | undefined;
 
   if (!rawPersonalDetails && !profile.address) {
     return undefined;
@@ -633,8 +632,7 @@ const buildDomainProfileFromPrisma = (
   options?: { statusOverride?: UserProfileMongo["status"] },
 ): UserProfileType => {
   const rawProfessionalDetails = profile.professionalDetails as
-    | UserProfileProfessionalDetailsMongo
-    | undefined;
+    UserProfileProfessionalDetailsMongo | undefined;
 
   const personalDetails = buildPersonalDetailsFromPrisma(profile);
 
@@ -904,7 +902,15 @@ export const UserProfileService = {
           })
         : existing;
 
-    const personalDetails = buildPersonalDetailsFromPrisma(updated);
+    // `updated.address` (from the `include` above) is still the pre-update relational
+    // row here - the address just written into personalDetails hasn't been synced to
+    // it yet. Reading through buildPersonalDetailsFromPrisma would prefer that stale
+    // relational row over the new address, so the sync below would just write the old
+    // value back and the edit would never appear (including after a refresh). Use the
+    // freshly-submitted personalDetails directly instead, same as create() does.
+    const personalDetails =
+      attributes.personalDetails ??
+      (existing.personalDetails as UserProfilePersonalDetailsMongo | undefined);
     await syncUserProfileAddress(updated.id, personalDetails?.address);
 
     let availability: UserAvailability[] = [];
@@ -925,8 +931,7 @@ export const UserProfileService = {
         organizationId: updated.organizationId,
         personalDetails,
         professionalDetails: updated.professionalDetails as
-          | UserProfileProfessionalDetailsMongo
-          | undefined,
+          UserProfileProfessionalDetailsMongo | undefined,
         status: updated.status ?? "DRAFT",
       },
       availability,
@@ -1011,8 +1016,7 @@ export const UserProfileService = {
       organizationId: profile.organizationId,
       personalDetails: personalDetailsForStatus,
       professionalDetails: (profile.professionalDetails ?? undefined) as
-        | UserProfileProfessionalDetailsMongo
-        | undefined,
+        UserProfileProfessionalDetailsMongo | undefined,
       status: profile.status ?? "DRAFT",
     };
     const status = determineProfileStatus(profileForStatus, availability);

--- a/apps/backend/test/services/room-unit-group.service.test.ts
+++ b/apps/backend/test/services/room-unit-group.service.test.ts
@@ -216,6 +216,78 @@ describe("RoomUnitGroupService", () => {
     expect(result.unitCount).toBe(2);
   });
 
+  it("allows deactivating a group after its room's type no longer supports units", async () => {
+    // The room's type has since changed away from a unit-capable type (e.g.
+    // INPATIENT -> SURGERY) - the group isn't moving rooms, so cleanup must
+    // still be able to deactivate it instead of 409ing forever.
+    mockedPrisma.organisationRoom.findUnique.mockResolvedValue({
+      id: "room_1",
+      organisationId: "org_1",
+      type: "SURGERY",
+    });
+    mockedPrisma.roomUnitGroup.findFirst.mockResolvedValue({
+      id: "group_1",
+      organisationId: "org_1",
+      roomId: "room_1",
+      name: "Dog ward",
+      size: "Medium",
+      unitCount: 2,
+      speciesConstraints: ["dog"],
+      capabilities: ["oxygen"],
+      isActive: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    mockedPrisma.roomUnitGroup.update.mockResolvedValue({
+      id: "group_1",
+      organisationId: "org_1",
+      roomId: "room_1",
+      name: "Dog ward",
+      size: "Medium",
+      unitCount: 2,
+      speciesConstraints: ["dog"],
+      capabilities: ["oxygen"],
+      isActive: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const result = await RoomUnitGroupService.update("group_1", "org_1", {
+      isActive: false,
+    });
+
+    expect(result.isActive).toBe(false);
+  });
+
+  it("still rejects moving a group into a room that does not support units", async () => {
+    mockedPrisma.roomUnitGroup.findFirst.mockResolvedValue({
+      id: "group_1",
+      organisationId: "org_1",
+      roomId: "room_1",
+      name: "Dog ward",
+      size: "Medium",
+      unitCount: 2,
+      speciesConstraints: ["dog"],
+      capabilities: ["oxygen"],
+      isActive: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    mockedPrisma.organisationRoom.findUnique.mockResolvedValueOnce({
+      id: "room_2",
+      organisationId: "org_1",
+      type: "EXAM_ROOM",
+    });
+
+    await expect(
+      RoomUnitGroupService.update("group_1", "org_1", { roomId: "room_2" }),
+    ).rejects.toMatchObject({
+      message:
+        "Units are only supported for ICU, Inpatient, Isolation and Boarding rooms.",
+      statusCode: 409,
+    });
+  });
+
   it("deletes a room unit group within the same organisation", async () => {
     mockedPrisma.roomUnitGroup.findUnique.mockResolvedValue({
       id: "group_1",

--- a/apps/backend/test/services/room-unit-group.service.test.ts
+++ b/apps/backend/test/services/room-unit-group.service.test.ts
@@ -259,6 +259,67 @@ describe("RoomUnitGroupService", () => {
     expect(result.isActive).toBe(false);
   });
 
+  it("still rejects reactivating a group in a room that no longer supports units", async () => {
+    // The deactivation exemption must not extend to any other same-room
+    // update - reactivating (or editing while active) would recreate the
+    // exact invalid state create/move already reject.
+    mockedPrisma.organisationRoom.findUnique.mockResolvedValue({
+      id: "room_1",
+      organisationId: "org_1",
+      type: "SURGERY",
+    });
+    mockedPrisma.roomUnitGroup.findFirst.mockResolvedValue({
+      id: "group_1",
+      organisationId: "org_1",
+      roomId: "room_1",
+      name: "Dog ward",
+      size: "Medium",
+      unitCount: 2,
+      speciesConstraints: ["dog"],
+      capabilities: ["oxygen"],
+      isActive: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await expect(
+      RoomUnitGroupService.update("group_1", "org_1", { isActive: true }),
+    ).rejects.toMatchObject({
+      message:
+        "Units are only supported for ICU, Inpatient, Isolation and Boarding rooms.",
+      statusCode: 409,
+    });
+  });
+
+  it("still rejects a same-room, non-deactivating edit when the room no longer supports units", async () => {
+    mockedPrisma.organisationRoom.findUnique.mockResolvedValue({
+      id: "room_1",
+      organisationId: "org_1",
+      type: "SURGERY",
+    });
+    mockedPrisma.roomUnitGroup.findFirst.mockResolvedValue({
+      id: "group_1",
+      organisationId: "org_1",
+      roomId: "room_1",
+      name: "Dog ward",
+      size: "Medium",
+      unitCount: 2,
+      speciesConstraints: ["dog"],
+      capabilities: ["oxygen"],
+      isActive: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await expect(
+      RoomUnitGroupService.update("group_1", "org_1", { name: "Renamed" }),
+    ).rejects.toMatchObject({
+      message:
+        "Units are only supported for ICU, Inpatient, Isolation and Boarding rooms.",
+      statusCode: 409,
+    });
+  });
+
   it("still rejects moving a group into a room that does not support units", async () => {
     mockedPrisma.roomUnitGroup.findFirst.mockResolvedValue({
       id: "group_1",

--- a/apps/backend/test/services/room-unit.service.test.ts
+++ b/apps/backend/test/services/room-unit.service.test.ts
@@ -280,6 +280,67 @@ describe("RoomUnitService", () => {
     expect(result.isActive).toBe(false);
   });
 
+  it("still rejects reactivating a unit in a room that no longer supports units", async () => {
+    // The deactivation exemption must not extend to any other same-room
+    // update - reactivating (or editing while active) would recreate the
+    // exact invalid state create/move already reject.
+    mockedPrisma.organisationRoom.findUnique.mockResolvedValue({
+      id: "room_1",
+      organisationId: "org_1",
+      type: "SURGERY",
+    });
+    mockedPrisma.roomUnit.findFirst.mockResolvedValue({
+      id: "unit_1",
+      organisationId: "org_1",
+      roomId: "room_1",
+      unitGroupId: null,
+      code: "KEN-01",
+      displayName: "Kennel 1",
+      size: "M",
+      speciesConstraints: ["dog"],
+      isActive: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await expect(
+      RoomUnitService.update("unit_1", "org_1", { isActive: true }),
+    ).rejects.toMatchObject({
+      message:
+        "Units are only supported for ICU, Inpatient, Isolation and Boarding rooms.",
+      statusCode: 409,
+    });
+  });
+
+  it("still rejects a same-room, non-deactivating edit when the room no longer supports units", async () => {
+    mockedPrisma.organisationRoom.findUnique.mockResolvedValue({
+      id: "room_1",
+      organisationId: "org_1",
+      type: "SURGERY",
+    });
+    mockedPrisma.roomUnit.findFirst.mockResolvedValue({
+      id: "unit_1",
+      organisationId: "org_1",
+      roomId: "room_1",
+      unitGroupId: null,
+      code: "KEN-01",
+      displayName: "Kennel 1",
+      size: "M",
+      speciesConstraints: ["dog"],
+      isActive: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await expect(
+      RoomUnitService.update("unit_1", "org_1", { displayName: "Renamed" }),
+    ).rejects.toMatchObject({
+      message:
+        "Units are only supported for ICU, Inpatient, Isolation and Boarding rooms.",
+      statusCode: 409,
+    });
+  });
+
   it("still rejects moving a unit into a room that does not support units", async () => {
     mockedPrisma.roomUnit.findFirst.mockResolvedValue({
       id: "unit_1",

--- a/apps/backend/test/services/room-unit.service.test.ts
+++ b/apps/backend/test/services/room-unit.service.test.ts
@@ -237,6 +237,78 @@ describe("RoomUnitService", () => {
     expect(result.displayName).toBe("Kennel 1 Updated");
   });
 
+  it("allows deactivating a unit after its room's type no longer supports units", async () => {
+    // The room's type has since changed away from a unit-capable type (e.g.
+    // INPATIENT -> SURGERY) - the unit itself isn't moving rooms, so cleanup
+    // must still be able to deactivate it instead of 409ing forever.
+    mockedPrisma.organisationRoom.findUnique.mockResolvedValue({
+      id: "room_1",
+      organisationId: "org_1",
+      type: "SURGERY",
+    });
+    mockedPrisma.roomUnit.findFirst.mockResolvedValue({
+      id: "unit_1",
+      organisationId: "org_1",
+      roomId: "room_1",
+      unitGroupId: null,
+      code: "KEN-01",
+      displayName: "Kennel 1",
+      size: "M",
+      speciesConstraints: ["dog"],
+      isActive: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    mockedPrisma.roomUnit.update.mockResolvedValue({
+      id: "unit_1",
+      organisationId: "org_1",
+      roomId: "room_1",
+      unitGroupId: null,
+      code: "KEN-01",
+      displayName: "Kennel 1",
+      size: "M",
+      speciesConstraints: ["dog"],
+      isActive: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const result = await RoomUnitService.update("unit_1", "org_1", {
+      isActive: false,
+    });
+
+    expect(result.isActive).toBe(false);
+  });
+
+  it("still rejects moving a unit into a room that does not support units", async () => {
+    mockedPrisma.roomUnit.findFirst.mockResolvedValue({
+      id: "unit_1",
+      organisationId: "org_1",
+      roomId: "room_1",
+      unitGroupId: null,
+      code: "KEN-01",
+      displayName: "Kennel 1",
+      size: "M",
+      speciesConstraints: ["dog"],
+      isActive: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    mockedPrisma.organisationRoom.findUnique.mockResolvedValueOnce({
+      id: "room_2",
+      organisationId: "org_1",
+      type: "EXAM_ROOM",
+    });
+
+    await expect(
+      RoomUnitService.update("unit_1", "org_1", { roomId: "room_2" }),
+    ).rejects.toMatchObject({
+      message:
+        "Units are only supported for ICU, Inpatient, Isolation and Boarding rooms.",
+      statusCode: 409,
+    });
+  });
+
   it("deletes a room unit in the same organisation", async () => {
     mockedPrisma.roomUnit.findUnique.mockResolvedValue({
       id: "unit_1",

--- a/apps/backend/test/services/user-profile.service.test.ts
+++ b/apps/backend/test/services/user-profile.service.test.ts
@@ -461,6 +461,80 @@ describe("UserProfileService", () => {
         }),
       );
     });
+
+    it("preserves untouched address fields on a one-field address patch", async () => {
+      const existingAddress = {
+        addressLine: "Line 1",
+        city: "City",
+        state: "State",
+        postalCode: "12345",
+        country: "US",
+      };
+
+      (prisma.userProfile.findFirst as jest.Mock).mockResolvedValueOnce({
+        id: createdId,
+        userId,
+        organizationId,
+        personalDetails: completeProfile.personalDetails,
+        professionalDetails: completeProfile.professionalDetails,
+        status: "COMPLETED",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        address: existingAddress,
+      });
+      (prisma.userProfile.update as jest.Mock).mockResolvedValueOnce({
+        id: createdId,
+        userId,
+        organizationId,
+        personalDetails: completeProfile.personalDetails,
+        professionalDetails: completeProfile.professionalDetails,
+        status: "COMPLETED",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        address: existingAddress,
+      });
+      (prisma.userProfile.findUnique as jest.Mock).mockResolvedValueOnce({
+        id: createdId,
+        userId,
+        organizationId,
+        personalDetails: completeProfile.personalDetails,
+        professionalDetails: completeProfile.professionalDetails,
+        status: "COMPLETED",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        address: { ...existingAddress, country: "CA" },
+      });
+      (prisma.userOrganization.findFirst as jest.Mock).mockResolvedValueOnce({
+        roleCode: "OWNER",
+      });
+      (BaseAvailabilityService.getByUserId as jest.Mock).mockResolvedValueOnce([
+        {
+          slots: [{ startTime: "09:00", endTime: "10:00", isAvailable: true }],
+        },
+      ]);
+
+      // A genuinely sparse address patch - only `country`, unlike the full
+      // snapshot the web frontend always sends. addressLine/city/state/
+      // postalCode must survive untouched, not be nulled out.
+      await UserProfileService.update(userId, organizationId, {
+        personalDetails: {
+          ...completeProfile.personalDetails,
+          address: { country: "CA" },
+        },
+      });
+
+      expect(prisma.userProfileAddress.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          update: expect.objectContaining({
+            addressLine: "Line 1",
+            city: "City",
+            state: "State",
+            postalCode: "12345",
+            country: "CA",
+          }),
+        }),
+      );
+    });
   });
 
   describe("getByUserId", () => {

--- a/apps/backend/test/services/user-profile.service.test.ts
+++ b/apps/backend/test/services/user-profile.service.test.ts
@@ -535,6 +535,74 @@ describe("UserProfileService", () => {
         }),
       );
     });
+
+    it("deletes the address when the caller explicitly submits address: null", async () => {
+      (prisma.userProfile.findFirst as jest.Mock).mockResolvedValueOnce({
+        id: createdId,
+        userId,
+        organizationId,
+        personalDetails: completeProfile.personalDetails,
+        professionalDetails: completeProfile.professionalDetails,
+        status: "COMPLETED",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        address: {
+          addressLine: "Line 1",
+          city: "City",
+          state: "State",
+          postalCode: "12345",
+          country: "US",
+        },
+      });
+      (prisma.userProfile.update as jest.Mock).mockResolvedValueOnce({
+        id: createdId,
+        userId,
+        organizationId,
+        personalDetails: completeProfile.personalDetails,
+        professionalDetails: completeProfile.professionalDetails,
+        status: "COMPLETED",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        address: {
+          addressLine: "Line 1",
+          city: "City",
+          state: "State",
+          postalCode: "12345",
+          country: "US",
+        },
+      });
+      (prisma.userProfile.findUnique as jest.Mock).mockResolvedValueOnce({
+        id: createdId,
+        userId,
+        organizationId,
+        personalDetails: completeProfile.personalDetails,
+        professionalDetails: completeProfile.professionalDetails,
+        status: "COMPLETED",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        address: null,
+      });
+      (prisma.userOrganization.findFirst as jest.Mock).mockResolvedValueOnce({
+        roleCode: "OWNER",
+      });
+      (BaseAvailabilityService.getByUserId as jest.Mock).mockResolvedValueOnce([
+        {
+          slots: [{ startTime: "09:00", endTime: "10:00", isAvailable: true }],
+        },
+      ]);
+
+      // Explicit null - distinct from omitting `address` entirely (preserve)
+      // and from a sparse patch (merge field-by-field) - must delete the row.
+      await UserProfileService.update(userId, organizationId, {
+        personalDetails: {
+          ...completeProfile.personalDetails,
+          address: null,
+        },
+      });
+
+      expect(prisma.userProfileAddress.deleteMany).toHaveBeenCalled();
+      expect(prisma.userProfileAddress.upsert).not.toHaveBeenCalled();
+    });
   });
 
   describe("getByUserId", () => {

--- a/apps/backend/test/services/user-profile.service.test.ts
+++ b/apps/backend/test/services/user-profile.service.test.ts
@@ -304,6 +304,80 @@ describe("UserProfileService", () => {
         }),
       );
     });
+
+    it("preserves the existing address when the update payload omits it", async () => {
+      const existingAddress = {
+        addressLine: "Line 1",
+        city: "City",
+        state: "State",
+        postalCode: "12345",
+        country: "US",
+      };
+
+      (prisma.userProfile.findFirst as jest.Mock).mockResolvedValueOnce({
+        id: createdId,
+        userId,
+        organizationId,
+        personalDetails: completeProfile.personalDetails,
+        professionalDetails: completeProfile.professionalDetails,
+        status: "COMPLETED",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        address: existingAddress,
+      });
+      (prisma.userProfile.update as jest.Mock).mockResolvedValueOnce({
+        id: createdId,
+        userId,
+        organizationId,
+        personalDetails: {
+          ...completeProfile.personalDetails,
+          gender: "FEMALE",
+        },
+        professionalDetails: completeProfile.professionalDetails,
+        status: "COMPLETED",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        // The relational row hasn't been touched by this call yet - it still
+        // reflects the pre-update address, same as production.
+        address: existingAddress,
+      });
+      (prisma.userProfile.findUnique as jest.Mock).mockResolvedValueOnce({
+        id: createdId,
+        userId,
+        organizationId,
+        personalDetails: {
+          ...completeProfile.personalDetails,
+          gender: "FEMALE",
+        },
+        professionalDetails: completeProfile.professionalDetails,
+        status: "COMPLETED",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        address: existingAddress,
+      });
+      (prisma.userOrganization.findFirst as jest.Mock).mockResolvedValueOnce({
+        roleCode: "OWNER",
+      });
+      (BaseAvailabilityService.getByUserId as jest.Mock).mockResolvedValueOnce([
+        {
+          slots: [{ startTime: "09:00", endTime: "10:00", isAvailable: true }],
+        },
+      ]);
+
+      await UserProfileService.update(userId, organizationId, {
+        // Only gender changes - no `address` key at all, unlike the
+        // full-object saves the frontend normally sends.
+        personalDetails: { gender: "FEMALE" },
+      });
+
+      expect(prisma.userProfileAddress.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: expect.objectContaining(existingAddress),
+          update: expect.objectContaining(existingAddress),
+        }),
+      );
+      expect(prisma.userProfileAddress.deleteMany).not.toHaveBeenCalled();
+    });
   });
 
   describe("getByUserId", () => {

--- a/apps/backend/test/services/user-profile.service.test.ts
+++ b/apps/backend/test/services/user-profile.service.test.ts
@@ -378,6 +378,89 @@ describe("UserProfileService", () => {
       );
       expect(prisma.userProfileAddress.deleteMany).not.toHaveBeenCalled();
     });
+
+    it("clears an explicitly emptied address field instead of leaving the stale value", async () => {
+      (prisma.userProfile.findFirst as jest.Mock).mockResolvedValueOnce({
+        id: createdId,
+        userId,
+        organizationId,
+        personalDetails: completeProfile.personalDetails,
+        professionalDetails: completeProfile.professionalDetails,
+        status: "COMPLETED",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        address: {
+          addressLine: "Line 1",
+          city: "City",
+          state: "State",
+          postalCode: "12345",
+          country: "US",
+        },
+      });
+      (prisma.userProfile.update as jest.Mock).mockResolvedValueOnce({
+        id: createdId,
+        userId,
+        organizationId,
+        personalDetails: completeProfile.personalDetails,
+        professionalDetails: completeProfile.professionalDetails,
+        status: "COMPLETED",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        address: {
+          addressLine: "Line 1",
+          city: "City",
+          state: "State",
+          postalCode: "12345",
+          country: "US",
+        },
+      });
+      (prisma.userProfile.findUnique as jest.Mock).mockResolvedValueOnce({
+        id: createdId,
+        userId,
+        organizationId,
+        personalDetails: completeProfile.personalDetails,
+        professionalDetails: completeProfile.professionalDetails,
+        status: "COMPLETED",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        address: {
+          addressLine: "Line 1",
+          city: "City",
+          state: "State",
+          postalCode: "12345",
+          country: null,
+        },
+      });
+      (prisma.userOrganization.findFirst as jest.Mock).mockResolvedValueOnce({
+        roleCode: "OWNER",
+      });
+      (BaseAvailabilityService.getByUserId as jest.Mock).mockResolvedValueOnce([
+        {
+          slots: [{ startTime: "09:00", endTime: "10:00", isAvailable: true }],
+        },
+      ]);
+
+      // Country emptied out, every other address field resubmitted unchanged -
+      // the same shape the frontend's address form always sends.
+      await UserProfileService.update(userId, organizationId, {
+        personalDetails: {
+          ...completeProfile.personalDetails,
+          address: {
+            addressLine: "Line 1",
+            city: "City",
+            state: "State",
+            postalCode: "12345",
+            country: "",
+          },
+        },
+      });
+
+      expect(prisma.userProfileAddress.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          update: expect.objectContaining({ country: null }),
+        }),
+      );
+    });
   });
 
   describe("getByUserId", () => {

--- a/apps/frontend/src/app/__tests__/pages/Appointments/Sections/ViewAppointmentOverviewModal/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Appointments/Sections/ViewAppointmentOverviewModal/index.test.tsx
@@ -583,6 +583,46 @@ describe('ViewAppointmentOverviewModal', () => {
     await settle();
   });
 
+  it('only dims the field being saved, keeping both labels visible', async () => {
+    mockRoomState = inpatientRoomState();
+    let resolveUpdate: () => void = () => undefined;
+    (updateAppointment as jest.Mock).mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveUpdate = resolve;
+        })
+    );
+
+    render(
+      <ViewAppointmentOverviewModal {...defaultProps} activeAppointment={inpatientAppointment()} />
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('room-dropdown'));
+    });
+
+    // Room's label is unchanged (never swaps to "Saving…") and only its own
+    // wrapper is dimmed/non-interactive - Unit stays fully usable.
+    expect(screen.getByTestId('room-dropdown')).toHaveTextContent('Select Room');
+    expect(screen.getByTestId('unit-dropdown')).toHaveTextContent('Select Unit');
+    expect(screen.getByTestId('room-dropdown').parentElement).toHaveClass(
+      'pointer-events-none',
+      'opacity-60'
+    );
+    expect(screen.getByTestId('unit-dropdown').parentElement).not.toHaveClass(
+      'pointer-events-none'
+    );
+
+    await act(async () => {
+      resolveUpdate();
+    });
+    await settle();
+
+    expect(screen.getByTestId('room-dropdown').parentElement).not.toHaveClass(
+      'pointer-events-none'
+    );
+  });
+
   it('assigns the room and unit for an inpatient appointment with an encounter', async () => {
     mockRoomState = inpatientRoomState();
     render(

--- a/apps/frontend/src/app/__tests__/services/roomService.test.ts
+++ b/apps/frontend/src/app/__tests__/services/roomService.test.ts
@@ -508,6 +508,64 @@ describe('Room Service', () => {
       expect(mockSetRoomUnitsForRoom).not.toHaveBeenCalled();
     });
 
+    it('still prunes active groups when a partial update changes the room to a non-unit type', async () => {
+      const mockDTO = { resourceType: 'Location', id: 'room-1' };
+      const mockResponseData = { resourceType: 'Location', id: 'room-1' };
+      const mockFinalRoom = { id: 'room-1', name: 'Ward A', type: 'SURGERY' };
+      const staleGroup = {
+        id: 'group-1',
+        organisationId: 'org-123',
+        roomId: 'room-1',
+        name: 'Pod',
+        size: 'Extra large',
+        unitCount: 5,
+        isActive: true,
+      };
+      const staleUnit = {
+        id: 'unit-1',
+        organisationId: 'org-123',
+        roomId: 'room-1',
+        unitGroupId: 'group-1',
+        code: 'POD-1',
+        displayName: 'Pod 1',
+        isActive: true,
+      };
+
+      mockedToDTO.mockReturnValue(mockDTO);
+      mockedPutData.mockResolvedValue({ data: mockResponseData });
+      mockedFromDTO.mockReturnValue(mockFinalRoom);
+      mockedGetData.mockImplementation((url: string) => {
+        if (url.startsWith('/fhir/v1/room-unit-group')) {
+          return Promise.resolve({ data: [staleGroup] });
+        }
+        if (url.startsWith('/fhir/v1/room-unit')) {
+          return Promise.resolve({ data: [staleUnit] });
+        }
+        return Promise.resolve({ data: [] });
+      });
+
+      // Only the type changes - no `units`/`availability` in the payload at
+      // all, unlike the full snapshot the room-edit UI always sends. The
+      // omission must not be read as "leave the unit config alone", since the
+      // room can no longer support one.
+      await updateRoom({
+        id: 'room-1',
+        name: 'Ward A',
+        type: 'SURGERY',
+      } as OrganisationRoom);
+
+      expect(mockedPutData).toHaveBeenCalledWith(
+        '/fhir/v1/room-unit-group/group-1',
+        expect.objectContaining({ isActive: false })
+      );
+      expect(mockedPutData).toHaveBeenCalledWith(
+        '/fhir/v1/room-unit/unit-1',
+        expect.objectContaining({ isActive: false })
+      );
+      expect(mockSetRoomUnitGroupsForRoom).toHaveBeenCalledWith('room-1', []);
+      expect(mockSetRoomUnitsForRoom).toHaveBeenCalledWith('room-1', []);
+    });
+
     it('reactivates an archived group and unit instead of creating duplicates with the same name/code', async () => {
       const mockDTO = { resourceType: 'Location', id: 'room-1' };
       const mockResponseData = { resourceType: 'Location', id: 'room-1' };

--- a/apps/frontend/src/app/__tests__/services/roomService.test.ts
+++ b/apps/frontend/src/app/__tests__/services/roomService.test.ts
@@ -587,5 +587,66 @@ describe('Room Service', () => {
         expect.objectContaining({ code: 'POD-2' })
       );
     });
+
+    it('reuses a group deactivated during the same save instead of creating a duplicate', async () => {
+      const mockDTO = { resourceType: 'Location', id: 'room-1' };
+      const mockFinalRoom = { id: 'room-1', name: 'Ward A', type: 'INPATIENT' };
+      // The pre-deactivation snapshot: still active when fetched, since
+      // pruning hasn't run yet at that point in the reconciliation.
+      const activeGroupSnapshot = {
+        id: 'group-1',
+        organisationId: 'org-123',
+        roomId: 'room-1',
+        name: 'Pod',
+        size: 'Large',
+        unitCount: 1,
+        isActive: true,
+      };
+
+      mockedToDTO.mockReturnValue(mockDTO);
+      mockedFromDTO.mockReturnValue(mockFinalRoom);
+      mockedPutData.mockImplementation((_url: string, body: unknown) =>
+        Promise.resolve({ data: body })
+      );
+      mockedPostData.mockImplementation((_url: string, body: unknown) =>
+        Promise.resolve({ data: body })
+      );
+      mockedGetData.mockImplementation((url: string) => {
+        if (url.startsWith('/fhir/v1/room-unit-group')) {
+          return Promise.resolve({ data: [activeGroupSnapshot] });
+        }
+        return Promise.resolve({ data: [] });
+      });
+
+      // The draft list no longer references group-1's real id (it was
+      // "removed") and instead has a brand-new draft also named "Pod" - all
+      // within the same save.
+      await updateRoom({
+        id: 'room-1',
+        name: 'Ward A',
+        type: 'INPATIENT',
+        availability: { species: ['CANINE'], totalUnits: 1 },
+        units: [{ id: 'unit-new', name: 'Pod', size: 'Large', count: 1 }],
+      } as OrganisationRoom & {
+        availability: { species: string[]; totalUnits: number };
+        units: Array<{ id: string; name: string; size: string; count: number }>;
+      });
+
+      // Deactivated by pruning, then reactivated in the same pass by reusing
+      // its own id - never recreated fresh, which would collide on
+      // roomId+name.
+      expect(mockedPutData).toHaveBeenCalledWith(
+        '/fhir/v1/room-unit-group/group-1',
+        expect.objectContaining({ isActive: false })
+      );
+      expect(mockedPutData).toHaveBeenCalledWith(
+        '/fhir/v1/room-unit-group/group-1',
+        expect.objectContaining({ isActive: true })
+      );
+      expect(mockedPostData).not.toHaveBeenCalledWith(
+        '/fhir/v1/room-unit-group',
+        expect.anything()
+      );
+    });
   });
 });

--- a/apps/frontend/src/app/__tests__/services/roomService.test.ts
+++ b/apps/frontend/src/app/__tests__/services/roomService.test.ts
@@ -417,7 +417,7 @@ describe('Room Service', () => {
       consoleSpy.mockRestore();
     });
 
-    it('deletes stale unit groups and their units when the room type no longer supports units', async () => {
+    it('deactivates stale unit groups and their units when the room type no longer supports units', async () => {
       const mockDTO = { resourceType: 'Location', id: 'room-1' };
       const mockResponseData = { resourceType: 'Location', id: 'room-1' };
       const mockFinalRoom = { id: 'room-1', name: 'Puppy Ward', type: 'SURGERY' };
@@ -450,7 +450,6 @@ describe('Room Service', () => {
         }
         return Promise.resolve({ data: [] });
       });
-      mockedDeleteData.mockResolvedValue({ data: {} });
 
       await updateRoom({
         id: 'room-1',
@@ -463,10 +462,48 @@ describe('Room Service', () => {
         units: [];
       });
 
-      expect(mockedDeleteData).toHaveBeenCalledWith('/fhir/v1/room-unit/unit-1');
-      expect(mockedDeleteData).toHaveBeenCalledWith('/fhir/v1/room-unit-group/group-1');
+      // Deactivated in place (not deleted) - a hard delete would cascade onto
+      // RoomUnitAssignment history and null out any admission's current unit.
+      expect(mockedPutData).toHaveBeenCalledWith(
+        '/fhir/v1/room-unit/unit-1',
+        expect.objectContaining({ isActive: false })
+      );
+      expect(mockedPutData).toHaveBeenCalledWith(
+        '/fhir/v1/room-unit-group/group-1',
+        expect.objectContaining({ isActive: false })
+      );
+      expect(mockedDeleteData).not.toHaveBeenCalled();
       expect(mockSetRoomUnitGroupsForRoom).toHaveBeenCalledWith('room-1', []);
       expect(mockSetRoomUnitsForRoom).toHaveBeenCalledWith('room-1', []);
+    });
+
+    it('does not prune unit groups when a partial update omits units and availability', async () => {
+      const mockDTO = { resourceType: 'Location', id: 'room-1' };
+      const mockResponseData = { resourceType: 'Location', id: 'room-1' };
+      const mockFinalRoom = { id: 'room-1', name: 'Renamed Ward', type: 'INPATIENT' };
+
+      mockedToDTO.mockReturnValue(mockDTO);
+      mockedPutData.mockResolvedValue({ data: mockResponseData });
+      mockedFromDTO.mockReturnValue(mockFinalRoom);
+
+      // A rename-only payload: no `units` key, no `availability` key at all -
+      // as distinct from an explicit empty list/zero total.
+      await updateRoom({
+        id: 'room-1',
+        name: 'Renamed Ward',
+        type: 'INPATIENT',
+      } as OrganisationRoom);
+
+      expect(mockedGetData).not.toHaveBeenCalledWith(
+        expect.stringContaining('/fhir/v1/room-unit-group')
+      );
+      expect(mockedPutData).not.toHaveBeenCalledWith(
+        expect.stringContaining('/fhir/v1/room-unit-group/'),
+        expect.anything()
+      );
+      // Leaves the client-side cache alone too - there's nothing to reconcile.
+      expect(mockSetRoomUnitGroupsForRoom).not.toHaveBeenCalled();
+      expect(mockSetRoomUnitsForRoom).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/frontend/src/app/__tests__/services/roomService.test.ts
+++ b/apps/frontend/src/app/__tests__/services/roomService.test.ts
@@ -3,7 +3,7 @@ import {
   createRoom,
   updateRoom,
 } from '@/app/features/organization/services/roomService';
-import { getData, postData, putData } from '@/app/services/axios';
+import { deleteData, getData, postData, putData } from '@/app/services/axios';
 import { useOrgStore } from '@/app/stores/orgStore';
 import { useOrganisationRoomStore } from '@/app/stores/roomStore';
 import {
@@ -21,6 +21,7 @@ jest.mock('@/app/services/axios');
 const mockedGetData = getData as jest.Mock;
 const mockedPostData = postData as jest.Mock;
 const mockedPutData = putData as jest.Mock;
+const mockedDeleteData = deleteData as jest.Mock;
 
 jest.mock('@/app/stores/orgStore', () => ({
   useOrgStore: { getState: jest.fn() },
@@ -360,6 +361,7 @@ describe('Room Service', () => {
       mockedToDTO.mockReturnValue(mockDTO);
       mockedPutData.mockResolvedValue({ data: mockResponseData });
       mockedFromDTO.mockReturnValue(mockFinalRoom);
+      mockedGetData.mockResolvedValue({ data: [] });
 
       await updateRoom(mockUpdateInput);
 
@@ -388,6 +390,7 @@ describe('Room Service', () => {
       mockedToDTO.mockReturnValue(mockDTO);
       mockedPutData.mockResolvedValue({ data: mockResponseData });
       mockedFromDTO.mockReturnValue(mockFinalRoom);
+      mockedGetData.mockResolvedValue({ data: [] });
 
       await updateRoom({
         id: 'room-1',
@@ -412,6 +415,58 @@ describe('Room Service', () => {
       await expect(updateRoom(mockUpdateInput)).rejects.toThrow('Update Error');
       expect(consoleSpy).toHaveBeenCalledWith('Failed to update room:', error);
       consoleSpy.mockRestore();
+    });
+
+    it('deletes stale unit groups and their units when the room type no longer supports units', async () => {
+      const mockDTO = { resourceType: 'Location', id: 'room-1' };
+      const mockResponseData = { resourceType: 'Location', id: 'room-1' };
+      const mockFinalRoom = { id: 'room-1', name: 'Puppy Ward', type: 'SURGERY' };
+      const staleGroup = {
+        id: 'group-1',
+        organisationId: 'org-123',
+        roomId: 'room-1',
+        name: 'Pod',
+        size: 'Extra large',
+        unitCount: 5,
+      };
+      const staleUnit = {
+        id: 'unit-1',
+        organisationId: 'org-123',
+        roomId: 'room-1',
+        unitGroupId: 'group-1',
+        code: 'POD-1',
+        displayName: 'Pod 1',
+      };
+
+      mockedToDTO.mockReturnValue(mockDTO);
+      mockedPutData.mockResolvedValue({ data: mockResponseData });
+      mockedFromDTO.mockReturnValue(mockFinalRoom);
+      mockedGetData.mockImplementation((url: string) => {
+        if (url.startsWith('/fhir/v1/room-unit-group')) {
+          return Promise.resolve({ data: [staleGroup] });
+        }
+        if (url.startsWith('/fhir/v1/room-unit')) {
+          return Promise.resolve({ data: [staleUnit] });
+        }
+        return Promise.resolve({ data: [] });
+      });
+      mockedDeleteData.mockResolvedValue({ data: {} });
+
+      await updateRoom({
+        id: 'room-1',
+        name: 'Puppy Ward',
+        type: 'SURGERY',
+        availability: { species: ['CANINE'], totalUnits: 0 },
+        units: [],
+      } as OrganisationRoom & {
+        availability: { species: string[]; totalUnits: number };
+        units: [];
+      });
+
+      expect(mockedDeleteData).toHaveBeenCalledWith('/fhir/v1/room-unit/unit-1');
+      expect(mockedDeleteData).toHaveBeenCalledWith('/fhir/v1/room-unit-group/group-1');
+      expect(mockSetRoomUnitGroupsForRoom).toHaveBeenCalledWith('room-1', []);
+      expect(mockSetRoomUnitsForRoom).toHaveBeenCalledWith('room-1', []);
     });
   });
 });

--- a/apps/frontend/src/app/__tests__/services/roomService.test.ts
+++ b/apps/frontend/src/app/__tests__/services/roomService.test.ts
@@ -428,6 +428,7 @@ describe('Room Service', () => {
         name: 'Pod',
         size: 'Extra large',
         unitCount: 5,
+        isActive: true,
       };
       const staleUnit = {
         id: 'unit-1',
@@ -436,6 +437,7 @@ describe('Room Service', () => {
         unitGroupId: 'group-1',
         code: 'POD-1',
         displayName: 'Pod 1',
+        isActive: true,
       };
 
       mockedToDTO.mockReturnValue(mockDTO);
@@ -504,6 +506,86 @@ describe('Room Service', () => {
       // Leaves the client-side cache alone too - there's nothing to reconcile.
       expect(mockSetRoomUnitGroupsForRoom).not.toHaveBeenCalled();
       expect(mockSetRoomUnitsForRoom).not.toHaveBeenCalled();
+    });
+
+    it('reactivates an archived group and unit instead of creating duplicates with the same name/code', async () => {
+      const mockDTO = { resourceType: 'Location', id: 'room-1' };
+      const mockResponseData = { resourceType: 'Location', id: 'room-1' };
+      const mockFinalRoom = { id: 'room-1', name: 'Ward A', type: 'INPATIENT' };
+      const archivedGroup = {
+        id: 'group-1',
+        organisationId: 'org-123',
+        roomId: 'room-1',
+        name: 'Pod',
+        size: 'Large',
+        unitCount: 1,
+        isActive: false,
+      };
+      const archivedUnit = {
+        id: 'unit-1',
+        organisationId: 'org-123',
+        roomId: 'room-1',
+        unitGroupId: 'group-1',
+        code: 'POD-1',
+        displayName: 'Pod 1',
+        isActive: false,
+      };
+
+      mockedToDTO.mockReturnValue(mockDTO);
+      mockedFromDTO.mockReturnValue(mockFinalRoom);
+      mockedPutData.mockImplementation((_url: string, body: unknown) =>
+        Promise.resolve({ data: body })
+      );
+      mockedPostData.mockImplementation((_url: string, body: unknown) =>
+        Promise.resolve({ data: body })
+      );
+      mockedGetData.mockImplementation((url: string) => {
+        if (url === '/fhir/v1/organisation-room/room-1') {
+          return Promise.resolve({ data: mockResponseData });
+        }
+        if (url.startsWith('/fhir/v1/room-unit-group')) {
+          return Promise.resolve({ data: [archivedGroup] });
+        }
+        if (url.startsWith('/fhir/v1/room-unit')) {
+          // The active-only lookup (isActive=true) sees nothing; the
+          // unscoped lookup used for reactivation sees the archived row.
+          return Promise.resolve({
+            data: url.includes('isActive=true') ? [] : [archivedUnit],
+          });
+        }
+        return Promise.resolve({ data: [] });
+      });
+
+      await updateRoom({
+        id: 'room-1',
+        name: 'Ward A',
+        type: 'INPATIENT',
+        availability: { species: ['CANINE'], totalUnits: 2 },
+        units: [{ id: 'unit-new', name: 'Pod', size: 'Large', count: 2 }],
+      } as OrganisationRoom & {
+        availability: { species: string[]; totalUnits: number };
+        units: Array<{ id: string; name: string; size: string; count: number }>;
+      });
+
+      // Reactivated via PUT, reusing the archived rows' own ids - a fresh POST
+      // would collide on the roomId+name / roomId+code unique indexes.
+      expect(mockedPutData).toHaveBeenCalledWith(
+        '/fhir/v1/room-unit-group/group-1',
+        expect.objectContaining({ isActive: true })
+      );
+      expect(mockedPutData).toHaveBeenCalledWith(
+        '/fhir/v1/room-unit/unit-1',
+        expect.objectContaining({ isActive: true })
+      );
+      expect(mockedPostData).not.toHaveBeenCalledWith(
+        '/fhir/v1/room-unit-group',
+        expect.anything()
+      );
+      // The second desired unit has no archived match, so it's still created fresh.
+      expect(mockedPostData).toHaveBeenCalledWith(
+        '/fhir/v1/room-unit',
+        expect.objectContaining({ code: 'POD-2' })
+      );
     });
   });
 });

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/ViewAppointmentOverviewModal/index.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/ViewAppointmentOverviewModal/index.tsx
@@ -120,7 +120,7 @@ const resolveEstimateDisplay = (
 
 type RoomSelectorSectionProps = {
   label: string;
-  savingRoom: boolean;
+  saving: boolean;
   canEditRoom: boolean;
   options: Array<{ label: string; value: string }>;
   defaultOption: string;
@@ -130,7 +130,7 @@ type RoomSelectorSectionProps = {
 
 const RoomSelectorSection = ({
   label,
-  savingRoom,
+  saving,
   canEditRoom,
   options,
   defaultOption,
@@ -138,13 +138,18 @@ const RoomSelectorSection = ({
   fallback,
 }: RoomSelectorSectionProps) =>
   canEditRoom ? (
-    <LabelDropdown
-      placeholder={savingRoom ? 'Saving…' : label}
-      options={options}
-      defaultOption={defaultOption}
-      onSelect={onSelect}
-      searchable={false}
-    />
+    // The label always stays "Room"/"Unit" - Room and Unit save independently
+    // (see savingField in the parent), so only the field actually in flight
+    // dims, instead of both losing their identity to a shared "Saving…" state.
+    <div className={saving ? 'pointer-events-none opacity-60' : ''}>
+      <LabelDropdown
+        placeholder={label}
+        options={options}
+        defaultOption={defaultOption}
+        onSelect={onSelect}
+        searchable={false}
+      />
+    </div>
   ) : (
     <div>
       <span className="mb-1.5 block font-satoshi text-sm font-semibold text-text-secondary">
@@ -240,7 +245,7 @@ const OverviewLeftColumn = ({
 type OverviewRightColumnProps = {
   activeAppointment: Appointment;
   canEditAppointments: boolean;
-  savingRoom: boolean;
+  savingField: 'room' | 'unit' | null;
   canEditRoom: boolean;
   roomOptions: Array<{ label: string; value: string }>;
   effectiveRoomId: string | undefined;
@@ -261,7 +266,7 @@ type OverviewRightColumnProps = {
 const OverviewRightColumn = ({
   activeAppointment,
   canEditAppointments,
-  savingRoom,
+  savingField,
   canEditRoom,
   roomOptions,
   effectiveRoomId,
@@ -290,7 +295,7 @@ const OverviewRightColumn = ({
     {/* Room */}
     <RoomSelectorSection
       label="Room"
-      savingRoom={savingRoom}
+      saving={savingField === 'room'}
       canEditRoom={canEditRoom}
       options={roomOptions}
       defaultOption={effectiveRoomId ?? ''}
@@ -305,7 +310,7 @@ const OverviewRightColumn = ({
     {isInpatient ? (
       <RoomSelectorSection
         label="Unit"
-        savingRoom={savingRoom}
+        saving={savingField === 'unit'}
         canEditRoom={canEditRoom}
         options={unitOptions}
         defaultOption={effectiveUnitId ?? ''}
@@ -389,7 +394,7 @@ const ViewAppointmentOverviewModal = ({
     activeAppointment.id ? s.encountersById[activeAppointment.id] : undefined
   );
 
-  const [savingRoom, setSavingRoom] = useState(false);
+  const [savingField, setSavingField] = useState<'room' | 'unit' | null>(null);
 
   React.useEffect(() => {
     if (!showModal) return;
@@ -487,7 +492,7 @@ const ViewAppointmentOverviewModal = ({
   const handleRoomChange = useCallback(
     async (option: { label: string; value: string }) => {
       if (!canEditRoom) return;
-      setSavingRoom(true);
+      setSavingField('room');
       try {
         const foundRoom = rooms.find((r) => r.id === option.value);
         const nextUnitId = isInpatient
@@ -517,7 +522,7 @@ const ViewAppointmentOverviewModal = ({
       } catch {
         notify('error', { title: 'Room update failed', text: 'Please try again.' });
       } finally {
-        setSavingRoom(false);
+        setSavingField(null);
       }
     },
     [
@@ -537,7 +542,7 @@ const ViewAppointmentOverviewModal = ({
   const handleUnitChange = useCallback(
     async (option: { label: string; value: string }) => {
       if (!canEditRoom || !isInpatient || !activeAppointment.id) return;
-      setSavingRoom(true);
+      setSavingField('unit');
       try {
         initEncounter(activeAppointment.id, 'INPATIENT', {
           leadId: activeAppointment.lead?.id,
@@ -557,7 +562,7 @@ const ViewAppointmentOverviewModal = ({
       } catch {
         notify('error', { title: 'Unit update failed', text: 'Please try again.' });
       } finally {
-        setSavingRoom(false);
+        setSavingField(null);
       }
     },
     [
@@ -603,7 +608,7 @@ const ViewAppointmentOverviewModal = ({
         <OverviewRightColumn
           activeAppointment={activeAppointment}
           canEditAppointments={canEditAppointments}
-          savingRoom={savingRoom}
+          savingField={savingField}
           canEditRoom={canEditRoom}
           roomOptions={roomOptions}
           effectiveRoomId={effectiveRoomId}

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/ViewAppointmentOverviewModal/index.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/ViewAppointmentOverviewModal/index.tsx
@@ -136,29 +136,25 @@ const RoomSelectorSection = ({
   defaultOption,
   onSelect,
   fallback,
-}: RoomSelectorSectionProps) => (
-  <div className="relative">
-    <span
-      className="pointer-events-none absolute left-4 top-0 z-10 flex -translate-y-1/2 items-center gap-1 bg-neutral-0 px-1 font-satoshi text-sm leading-none"
-      style={{ color: 'var(--color-input-text-placeholder)' }}
-    >
-      {label}
-    </span>
-    {canEditRoom ? (
-      <LabelDropdown
-        placeholder={savingRoom ? 'Saving…' : `Select ${label.toLowerCase()}`}
-        options={options}
-        defaultOption={defaultOption}
-        onSelect={onSelect}
-        searchable={false}
-      />
-    ) : (
+}: RoomSelectorSectionProps) =>
+  canEditRoom ? (
+    <LabelDropdown
+      placeholder={savingRoom ? 'Saving…' : label}
+      options={options}
+      defaultOption={defaultOption}
+      onSelect={onSelect}
+      searchable={false}
+    />
+  ) : (
+    <div>
+      <span className="mb-1.5 block font-satoshi text-sm font-semibold text-text-secondary">
+        {label}
+      </span>
       <div className="border border-input-border-default rounded-2xl px-4 py-3 min-h-12 font-satoshi text-base text-text-primary">
         {fallback}
       </div>
-    )}
-  </div>
-);
+    </div>
+  );
 
 type OverviewLeftColumnProps = {
   companion: ReturnType<typeof getAppointmentCompanion>;

--- a/apps/frontend/src/app/features/integrations/pages/MerckManuals/index.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/MerckManuals/index.tsx
@@ -583,6 +583,7 @@ const MerckReaderPortal = ({
   readerLoading,
   readerBlocked,
   audience,
+  copied,
   onCopyUrl,
   setReaderOpen,
   setReaderLoading,
@@ -594,6 +595,7 @@ const MerckReaderPortal = ({
   readerLoading: boolean;
   readerBlocked: boolean;
   audience: MerckAudience;
+  copied: string | null;
   onCopyUrl: (url: string) => void;
   setReaderOpen: React.Dispatch<React.SetStateAction<boolean>>;
   setReaderLoading: React.Dispatch<React.SetStateAction<boolean>>;
@@ -644,7 +646,7 @@ const MerckReaderPortal = ({
               className="flex items-center gap-1.5 rounded-full! border border-hairline px-3 py-[7px] text-[12px] font-semibold text-[var(--ink-body)] transition-colors hover:bg-[var(--card-hover)]"
             >
               <IoLinkOutline size={13} aria-hidden="true" />
-              Copy manual URL
+              {copied === readerUrl ? 'Copied!' : 'Copy manual URL'}
             </button>
             <Link
               href={readerUrl}
@@ -912,6 +914,7 @@ const MerckManualsPage = ({ embedded = false }: MerckManualsPageProps) => {
         readerLoading={readerLoading}
         readerBlocked={readerBlocked}
         audience={audience}
+        copied={copied}
         onCopyUrl={onCopyUrl}
         setReaderOpen={setReaderOpen}
         setReaderLoading={setReaderLoading}

--- a/apps/frontend/src/app/features/organization/services/roomService.ts
+++ b/apps/frontend/src/app/features/organization/services/roomService.ts
@@ -370,8 +370,11 @@ const syncRoomUnitGroups = async (
   // A partial update that never mentions units/availability at all (e.g. a
   // plain rename) must leave the room's unit configuration - and the client's
   // cache of it - completely untouched, not read the omission as "zero units
-  // desired" and wipe out everything that was there.
-  if (options?.pruneStaleGroups && !providesUnitConfig(source)) return;
+  // desired" and wipe out everything that was there. But that only holds if
+  // the room is still unit-capable - a type-only change to e.g. SURGERY still
+  // has to prune whatever was active, or those groups/units stay attached to
+  // a room that can no longer support them.
+  if (options?.pruneStaleGroups && !providesUnitConfig(source) && canSyncUnits(room)) return;
 
   const { setRoomUnitGroupsForRoom, setRoomUnitsForRoom } = useOrganisationRoomStore.getState();
   const desiredUnitGroups = canSyncUnits(room) ? getDesiredUnitGroups(source) : [];

--- a/apps/frontend/src/app/features/organization/services/roomService.ts
+++ b/apps/frontend/src/app/features/organization/services/roomService.ts
@@ -231,13 +231,6 @@ const updateUnitGroup = async (group: RoomUnitGroup) => {
   return fromFHIRRoomUnitGroup(res.data);
 };
 
-const deleteUnitGroup = async (groupId: string) => {
-  const res = await deleteData<ReturnType<typeof toFHIRRoomUnitGroup>>(
-    `/fhir/v1/room-unit-group/${groupId}`
-  );
-  return fromFHIRRoomUnitGroup(res.data);
-};
-
 const listUnitGroupsForRoom = async (organisationId: string, roomId: string) => {
   const res = await getData<ReturnType<typeof toFHIRRoomUnitGroup>[]>(
     `/fhir/v1/room-unit-group${buildQuery({
@@ -252,6 +245,14 @@ const listUnitGroupsForRoom = async (organisationId: string, roomId: string) => 
 const createUnit = async (unit: RoomUnit) => {
   const res = await postData<ReturnType<typeof toFHIRRoomUnit>>(
     '/fhir/v1/room-unit',
+    toFHIRRoomUnit(unit)
+  );
+  return fromFHIRRoomUnit(res.data);
+};
+
+const updateUnit = async (unit: RoomUnit) => {
+  const res = await putData<ReturnType<typeof toFHIRRoomUnit>>(
+    `/fhir/v1/room-unit/${unit.id}`,
     toFHIRRoomUnit(unit)
   );
   return fromFHIRRoomUnit(res.data);
@@ -295,24 +296,42 @@ const syncUnitsForGroup = async (
   return [...currentUnits.slice(0, desiredCount), ...createdUnits];
 };
 
-const deleteUnitGroupAndItsUnits = async (group: RoomUnitGroup) => {
+// Units/groups can carry admission history (RoomUnitAssignment.unit cascades on
+// delete, and Admission.currentUnit is set-null) - a physical delete here would
+// silently corrupt that history or clear a patient's current location. Marking
+// them inactive instead keeps every row (and the history it's linked to) intact
+// while dropping them out of the room's active configuration.
+const deactivateUnitGroupAndItsUnits = async (group: RoomUnitGroup) => {
   const staleUnits = await listRoomUnitsForGroup(group.organisationId, group.roomId, group.id);
   for (const unit of staleUnits) {
-    await deleteUnit(unit.id);
+    await updateUnit({ ...unit, isActive: false });
   }
-  await deleteUnitGroup(group.id);
+  await updateUnitGroup({ ...group, isActive: false });
 };
+
+// The caller must have actually said something about units for pruning to run -
+// a partial update that never mentions `units`/`availability` (e.g. renaming a
+// room) leaves both undefined, and treating that as "zero desired groups" would
+// wipe out a room's entire unit configuration on an unrelated edit.
+const providesUnitConfig = (source: RoomMutationPayload) =>
+  source.units !== undefined || source.availability?.totalUnits !== undefined;
 
 const syncRoomUnitGroups = async (
   room: OrganisationRoom,
   source: RoomMutationPayload,
   options?: { pruneStaleGroups?: boolean }
 ) => {
+  // A partial update that never mentions units/availability at all (e.g. a
+  // plain rename) must leave the room's unit configuration - and the client's
+  // cache of it - completely untouched, not read the omission as "zero units
+  // desired" and wipe out everything that was there.
+  if (options?.pruneStaleGroups && !providesUnitConfig(source)) return;
+
   const { setRoomUnitGroupsForRoom, setRoomUnitsForRoom } = useOrganisationRoomStore.getState();
   const desiredUnitGroups = canSyncUnits(room) ? getDesiredUnitGroups(source) : [];
 
   // A type change away from a unit-capable room (or clearing every unit row)
-  // must delete the previously-synced groups, not just stop touching them -
+  // must deactivate the previously-synced groups, not just stop touching them -
   // otherwise the stale group (and its units) stay active and resurface the
   // old config next time the room is opened. A brand-new room can't have any
   // groups yet, so this only runs for updates.
@@ -327,7 +346,7 @@ const syncRoomUnitGroups = async (
     );
     const staleGroups = existingGroups.filter((group) => !desiredIds.has(group.id));
     for (const group of staleGroups) {
-      await deleteUnitGroupAndItsUnits(group);
+      await deactivateUnitGroupAndItsUnits(group);
     }
   }
 

--- a/apps/frontend/src/app/features/organization/services/roomService.ts
+++ b/apps/frontend/src/app/features/organization/services/roomService.ts
@@ -389,6 +389,7 @@ const syncRoomUnitGroups = async (
   // must deactivate the previously-synced groups, not just stop touching them -
   // otherwise the stale group (and its units) stay active and resurface the
   // old config next time the room is opened.
+  let staleGroups: RoomUnitGroup[] = [];
   if (options?.pruneStaleGroups) {
     const desiredIds = new Set(
       desiredUnitGroups
@@ -397,9 +398,7 @@ const syncRoomUnitGroups = async (
           (id): id is string => typeof id === 'string' && id.length > 0 && !id.startsWith('unit-')
         )
     );
-    const staleGroups = existingGroups.filter(
-      (group) => group.isActive && !desiredIds.has(group.id)
-    );
+    staleGroups = existingGroups.filter((group) => group.isActive && !desiredIds.has(group.id));
     for (const group of staleGroups) {
       await deactivateUnitGroupAndItsUnits(group);
     }
@@ -411,8 +410,16 @@ const syncRoomUnitGroups = async (
     return;
   }
 
+  // Include groups deactivated moments ago by the pruning step above, not
+  // just ones that were already inactive before this save - `existingGroups`
+  // was fetched before pruning ran, so a group removed and re-added under the
+  // same name within this single save would otherwise still show as active
+  // in this snapshot and get created fresh, colliding with the row it was
+  // just deactivated into.
   const archivedGroupsByName = new Map(
-    existingGroups.filter((group) => !group.isActive).map((group) => [group.name, group] as const)
+    [...existingGroups.filter((group) => !group.isActive), ...staleGroups].map(
+      (group) => [group.name, group] as const
+    )
   );
 
   const speciesConstraints = toSpeciesConstraints(source.availability?.species);

--- a/apps/frontend/src/app/features/organization/services/roomService.ts
+++ b/apps/frontend/src/app/features/organization/services/roomService.ts
@@ -231,6 +231,24 @@ const updateUnitGroup = async (group: RoomUnitGroup) => {
   return fromFHIRRoomUnitGroup(res.data);
 };
 
+const deleteUnitGroup = async (groupId: string) => {
+  const res = await deleteData<ReturnType<typeof toFHIRRoomUnitGroup>>(
+    `/fhir/v1/room-unit-group/${groupId}`
+  );
+  return fromFHIRRoomUnitGroup(res.data);
+};
+
+const listUnitGroupsForRoom = async (organisationId: string, roomId: string) => {
+  const res = await getData<ReturnType<typeof toFHIRRoomUnitGroup>[]>(
+    `/fhir/v1/room-unit-group${buildQuery({
+      organizationId: organisationId,
+      roomId,
+      isActive: true,
+    })}`
+  );
+  return res.data.map(fromFHIRRoomUnitGroup);
+};
+
 const createUnit = async (unit: RoomUnit) => {
   const res = await postData<ReturnType<typeof toFHIRRoomUnit>>(
     '/fhir/v1/room-unit',
@@ -277,13 +295,49 @@ const syncUnitsForGroup = async (
   return [...currentUnits.slice(0, desiredCount), ...createdUnits];
 };
 
-const syncRoomUnitGroups = async (room: OrganisationRoom, source: RoomMutationPayload) => {
-  if (!canSyncUnits(room)) return;
+const deleteUnitGroupAndItsUnits = async (group: RoomUnitGroup) => {
+  const staleUnits = await listRoomUnitsForGroup(group.organisationId, group.roomId, group.id);
+  for (const unit of staleUnits) {
+    await deleteUnit(unit.id);
+  }
+  await deleteUnitGroup(group.id);
+};
+
+const syncRoomUnitGroups = async (
+  room: OrganisationRoom,
+  source: RoomMutationPayload,
+  options?: { pruneStaleGroups?: boolean }
+) => {
+  const { setRoomUnitGroupsForRoom, setRoomUnitsForRoom } = useOrganisationRoomStore.getState();
+  const desiredUnitGroups = canSyncUnits(room) ? getDesiredUnitGroups(source) : [];
+
+  // A type change away from a unit-capable room (or clearing every unit row)
+  // must delete the previously-synced groups, not just stop touching them -
+  // otherwise the stale group (and its units) stay active and resurface the
+  // old config next time the room is opened. A brand-new room can't have any
+  // groups yet, so this only runs for updates.
+  if (options?.pruneStaleGroups) {
+    const existingGroups = await listUnitGroupsForRoom(room.organisationId, room.id);
+    const desiredIds = new Set(
+      desiredUnitGroups
+        .map((draft) => draft.id)
+        .filter(
+          (id): id is string => typeof id === 'string' && id.length > 0 && !id.startsWith('unit-')
+        )
+    );
+    const staleGroups = existingGroups.filter((group) => !desiredIds.has(group.id));
+    for (const group of staleGroups) {
+      await deleteUnitGroupAndItsUnits(group);
+    }
+  }
+
+  if (!desiredUnitGroups.length) {
+    setRoomUnitGroupsForRoom(room.id, []);
+    setRoomUnitsForRoom(room.id, []);
+    return;
+  }
 
   const speciesConstraints = toSpeciesConstraints(source.availability?.species);
-  const desiredUnitGroups = getDesiredUnitGroups(source);
-  if (!desiredUnitGroups.length) return;
-
   const syncedGroups: RoomUnitGroup[] = [];
   const syncedUnits: RoomUnit[] = [];
 
@@ -307,7 +361,6 @@ const syncRoomUnitGroups = async (room: OrganisationRoom, source: RoomMutationPa
     syncedUnits.push(...(await syncUnitsForGroup(group, unitCount, group.speciesConstraints)));
   }
 
-  const { setRoomUnitGroupsForRoom, setRoomUnitsForRoom } = useOrganisationRoomStore.getState();
   setRoomUnitGroupsForRoom(room.id, syncedGroups);
   setRoomUnitsForRoom(room.id, syncedUnits);
 };
@@ -366,7 +419,7 @@ export const updateRoom = async (payload: RoomMutationPayload) => {
     );
     const normalRoom = buildNormalizedRoom(normalizedPayload, res.data, payload.availability);
     upsertRoom(normalRoom);
-    await syncRoomUnitGroups(normalRoom, payload);
+    await syncRoomUnitGroups(normalRoom, payload, { pruneStaleGroups: true });
   } catch (err) {
     console.error('Failed to update room:', err);
     throw err;

--- a/apps/frontend/src/app/features/organization/services/roomService.ts
+++ b/apps/frontend/src/app/features/organization/services/roomService.ts
@@ -215,6 +215,24 @@ const listRoomUnitsForGroup = async (
   return res.data.map(fromFHIRRoomUnit);
 };
 
+// Includes inactive units - used to find a previously-deactivated unit whose
+// deterministic code (`${groupName}-${n}`) would otherwise collide with the
+// `@@unique([roomId, code])` constraint when creating a "new" one.
+const listAllUnitsForGroup = async (
+  organisationId: string,
+  roomId: string,
+  unitGroupId: string
+) => {
+  const res = await getData<ReturnType<typeof toFHIRRoomUnit>[]>(
+    `/fhir/v1/room-unit${buildQuery({
+      organizationId: organisationId,
+      roomId,
+      unitGroupId,
+    })}`
+  );
+  return res.data.map(fromFHIRRoomUnit);
+};
+
 const createUnitGroup = async (group: RoomUnitGroup) => {
   const res = await postData<ReturnType<typeof toFHIRRoomUnitGroup>>(
     '/fhir/v1/room-unit-group',
@@ -231,12 +249,15 @@ const updateUnitGroup = async (group: RoomUnitGroup) => {
   return fromFHIRRoomUnitGroup(res.data);
 };
 
+// Includes inactive groups - callers derive the active subset themselves. A
+// previously-deactivated group can occupy the exact name a "new" one would get
+// (`@@unique([roomId, name])`), so the reconciling create/update loop needs to
+// see it too, not just the pruning step that only cares about active ones.
 const listUnitGroupsForRoom = async (organisationId: string, roomId: string) => {
   const res = await getData<ReturnType<typeof toFHIRRoomUnitGroup>[]>(
     `/fhir/v1/room-unit-group${buildQuery({
       organizationId: organisationId,
       roomId,
-      isActive: true,
     })}`
   );
   return res.data.map(fromFHIRRoomUnitGroup);
@@ -276,20 +297,45 @@ const syncUnitsForGroup = async (
     await deleteUnit(unit.id);
   }
 
+  const missingCount = desiredCount - currentUnits.length;
+  // A previously-deactivated unit under this same group can occupy the exact
+  // code a fresh one would get (`@@unique([roomId, code])`), so look for one
+  // to reactivate before creating - only when we actually need more units.
+  const archivedByCode =
+    missingCount > 0
+      ? new Map(
+          (await listAllUnitsForGroup(group.organisationId, group.roomId, group.id))
+            .filter((unit) => !unit.isActive)
+            .map((unit) => [unit.code, unit] as const)
+        )
+      : new Map<string, RoomUnit>();
+
   for (let index = currentUnits.length; index < desiredCount; index += 1) {
     const unitNumber = index + 1;
+    const code = `${group.name}-${unitNumber}`.replace(/\s+/g, '-').toUpperCase();
+    const archived = archivedByCode.get(code);
+    const displayName = `${group.name} ${unitNumber}`;
     createdUnits.push(
-      await createUnit({
-        id: '',
-        organisationId: group.organisationId,
-        roomId: group.roomId,
-        unitGroupId: group.id,
-        code: `${group.name}-${unitNumber}`.replace(/\s+/g, '-').toUpperCase(),
-        displayName: `${group.name} ${unitNumber}`,
-        size: group.size,
-        speciesConstraints,
-        isActive: true,
-      })
+      archived
+        ? await updateUnit({
+            ...archived,
+            unitGroupId: group.id,
+            displayName,
+            size: group.size,
+            speciesConstraints,
+            isActive: true,
+          })
+        : await createUnit({
+            id: '',
+            organisationId: group.organisationId,
+            roomId: group.roomId,
+            unitGroupId: group.id,
+            code,
+            displayName,
+            size: group.size,
+            speciesConstraints,
+            isActive: true,
+          })
     );
   }
 
@@ -330,13 +376,20 @@ const syncRoomUnitGroups = async (
   const { setRoomUnitGroupsForRoom, setRoomUnitsForRoom } = useOrganisationRoomStore.getState();
   const desiredUnitGroups = canSyncUnits(room) ? getDesiredUnitGroups(source) : [];
 
+  // Fetched once (active + inactive) when reconciling on update: the active
+  // subset drives pruning below, and the inactive subset lets the create loop
+  // reactivate an archived group instead of colliding with its old name
+  // (`@@unique([roomId, name])`). A brand-new room can't have either, so this
+  // only runs for updates.
+  const existingGroups = options?.pruneStaleGroups
+    ? await listUnitGroupsForRoom(room.organisationId, room.id)
+    : [];
+
   // A type change away from a unit-capable room (or clearing every unit row)
   // must deactivate the previously-synced groups, not just stop touching them -
   // otherwise the stale group (and its units) stay active and resurface the
-  // old config next time the room is opened. A brand-new room can't have any
-  // groups yet, so this only runs for updates.
+  // old config next time the room is opened.
   if (options?.pruneStaleGroups) {
-    const existingGroups = await listUnitGroupsForRoom(room.organisationId, room.id);
     const desiredIds = new Set(
       desiredUnitGroups
         .map((draft) => draft.id)
@@ -344,7 +397,9 @@ const syncRoomUnitGroups = async (
           (id): id is string => typeof id === 'string' && id.length > 0 && !id.startsWith('unit-')
         )
     );
-    const staleGroups = existingGroups.filter((group) => !desiredIds.has(group.id));
+    const staleGroups = existingGroups.filter(
+      (group) => group.isActive && !desiredIds.has(group.id)
+    );
     for (const group of staleGroups) {
       await deactivateUnitGroupAndItsUnits(group);
     }
@@ -356,17 +411,26 @@ const syncRoomUnitGroups = async (
     return;
   }
 
+  const archivedGroupsByName = new Map(
+    existingGroups.filter((group) => !group.isActive).map((group) => [group.name, group] as const)
+  );
+
   const speciesConstraints = toSpeciesConstraints(source.availability?.species);
   const syncedGroups: RoomUnitGroup[] = [];
   const syncedUnits: RoomUnit[] = [];
 
   for (const [index, draft] of desiredUnitGroups.entries()) {
     const unitCount = Math.max(1, Number(draft.count ?? 1));
+    const name = draft.name?.trim() || `Unit type ${index + 1}`;
+    const draftId = draft.id?.startsWith('unit-') ? '' : (draft.id ?? '');
+    // Reuse a previously-deactivated group with the same name rather than
+    // creating a fresh row, which would collide on that same unique index.
+    const groupId = draftId || archivedGroupsByName.get(name)?.id || '';
     const groupPayload: RoomUnitGroup = {
-      id: draft.id?.startsWith('unit-') ? '' : (draft.id ?? ''),
+      id: groupId,
       organisationId: room.organisationId,
       roomId: room.id,
-      name: draft.name?.trim() || `Unit type ${index + 1}`,
+      name,
       size: draft.size,
       unitCount,
       speciesConstraints: draft.speciesConstraints ?? speciesConstraints,

--- a/apps/frontend/src/app/ui/tables/DispensaryTable.tsx
+++ b/apps/frontend/src/app/ui/tables/DispensaryTable.tsx
@@ -115,7 +115,7 @@ const DispensaryRow = ({
 
   return (
     <div
-      className="grid items-center gap-3 border-t border-card-border px-5 py-3 text-[13.5px] text-text-primary transition-colors hover:bg-[var(--surface-soft)]"
+      className="grid items-center gap-2.5 border-t border-card-border px-5 py-3 text-[13.5px] text-text-primary transition-colors hover:bg-[var(--surface-soft)]"
       style={{ gridTemplateColumns: GRID_COLUMNS }}
     >
       <div


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

Several PIMS bug reports were surfacing stale or misaligned data:

- Editing a team member's **address** (or the **country** field, which is stored on the same address record) saved correctly, but reopening the profile after a refresh showed the old value. The backend's `update()` synced the relational address row from a stale, pre-update read instead of the freshly-submitted data, so the sync effectively wrote the old value back over itself.
- The **appointment overview modal**'s Room/Unit fields rendered two stacked labels ("Room" above "Select room", "Unit" above "Select unit") because both the wrapper and the shared `LabelDropdown` component were rendering their own label.
- The **Merck manual reader** overlay's "Copy manual URL" button copied the URL correctly, but the "Copied URL to clipboard." confirmation rendered on the underlying search page, hidden behind the fullscreen reader overlay — so clicking it looked like nothing happened.
- Changing a room's **type** away from a unit-capable type (e.g. to Surgery) cleared the unit config locally and on save, but the previously-created `RoomUnitGroup`/`RoomUnit` records were never deleted server-side, so the stale unit type config (e.g. "Pod / Extra large / 5") resurfaced in view and edit mode after saving.
- The **Dispensary** table's status pills weren't aligned with their column header — the row grid used a different `gap` than the shared table header, causing a cumulative left-offset across columns.

## What is the new behavior?

- `UserProfileService.update()` now syncs the relational address (and therefore country) from the freshly-submitted `personalDetails`, matching the pattern already used in `create()`. Edits now persist correctly across a refresh.
- `RoomSelectorSection` no longer renders a redundant outer label for the editable case; it relies on `LabelDropdown`'s built-in label (using the plain field name, consistent with the other detail rows), and the read-only fallback uses a single matching label instead of the old floating-over-border style.
- The Merck reader header button now shows "Copied!" in place of "Copy manual URL" for ~1.5s after a successful copy, giving in-context feedback without needing to close the reader.
- `syncRoomUnitGroups` now fetches a room's existing unit groups on update and deletes any group (and its units) no longer represented in the desired list — covering both a type change away from unit-capable and a cleared/reduced unit list. New rooms skip this extra round trip since they can't have stale groups yet.
- `DispensaryRow`'s grid gap now matches the shared table header (and `InventoryTable`'s convention), so all status pills — regardless of label width — start at the same left edge under the "Status" column.

## Related Issue(s)

Fixes #
