### PR TITLE
fix(mobile): key appointment mock slots off one local day in tests

### DIFF
--- a/apps/mobileAppYC/__tests__/features/appointments/mocks.test.ts
+++ b/apps/mobileAppYC/__tests__/features/appointments/mocks.test.ts
@@ -11,6 +11,7 @@ import {
   mockAvailability,
   mockAppointments,
   mockInvoices,
+  todayISO,
 } from '@/features/appointments/mocks';
 
 describe('features/appointments/mocks', () => {
@@ -24,14 +25,34 @@ describe('features/appointments/mocks', () => {
     });
   });
 
+  it('todayISO returns the device-local calendar day, not the UTC day', () => {
+    // Pins the local-date semantics the fixture and the consuming screens rely on.
+    // Deriving the key with `toISOString().slice(0, 10)` would give the UTC day,
+    // which differs from the local day between midnight and the UTC offset.
+    jest.useFakeTimers().setSystemTime(new Date('2026-07-24T22:30:00Z'));
+    try {
+      const d = new Date();
+      const expected = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(
+        2,
+        '0',
+      )}-${String(d.getDate()).padStart(2, '0')}`;
+
+      expect(todayISO()).toBe(expected);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('exports employee availability keyed by today for each entry', () => {
-    const todayISO = new Date().toISOString().slice(0, 10);
+    // Reuse the fixture's own helper - deriving this key independently is how this
+    // test used to drift from the fixture in any timezone ahead of UTC.
+    const today = todayISO();
 
     expect(mockAvailability.length).toBeGreaterThan(0);
     mockAvailability.forEach(entry => {
-      expect(entry.slotsByDate[todayISO]).toBeDefined();
-      expect(entry.slotsByDate[todayISO].length).toBeGreaterThan(0);
-      entry.slotsByDate[todayISO].forEach(slot => {
+      expect(entry.slotsByDate[today]).toBeDefined();
+      expect(entry.slotsByDate[today].length).toBeGreaterThan(0);
+      entry.slotsByDate[today].forEach(slot => {
         expect(slot.isAvailable).toBe(true);
         expect(slot.startTime).toBeTruthy();
       });

--- a/apps/mobileAppYC/src/features/appointments/mocks.ts
+++ b/apps/mobileAppYC/src/features/appointments/mocks.ts
@@ -6,15 +6,14 @@ import type {
   Invoice,
 } from './types';
 
-
-
 export const mockServices: VetService[] = [
   {
     id: 'svc_internal_consult',
     businessId: 'biz_sfamc',
     specialty: 'Internal Medicine',
     name: 'Internal Medicine Consultation',
-    description: 'Comprehensive diagnostic review and treatment planning for internal conditions.',
+    description:
+      'Comprehensive diagnostic review and treatment planning for internal conditions.',
     basePrice: 185,
     icon: Images.hospitalIcon,
     defaultEmployeeId: 'emp_brown',
@@ -24,7 +23,8 @@ export const mockServices: VetService[] = [
     businessId: 'biz_sfamc',
     specialty: 'Oncology',
     name: 'Oncology Follow-up',
-    description: 'Post-treatment monitoring including imaging and oncology review.',
+    description:
+      'Post-treatment monitoring including imaging and oncology review.',
     basePrice: 220,
     icon: Images.hospitalIcon,
     defaultEmployeeId: 'emp_emily',
@@ -34,7 +34,8 @@ export const mockServices: VetService[] = [
     businessId: 'biz_sfamc',
     specialty: 'Cardiology',
     name: 'Cardiology Evaluation',
-    description: 'Advanced cardiology work-up, ECG review, and treatment recommendations.',
+    description:
+      'Advanced cardiology work-up, ECG review, and treatment recommendations.',
     basePrice: 210,
     icon: Images.hospitalIcon,
     defaultEmployeeId: 'emp_emily',
@@ -44,7 +45,8 @@ export const mockServices: VetService[] = [
     businessId: 'biz_pawpet',
     specialty: 'Pain Management & Rehab',
     name: 'Rehab Program Intake',
-    description: 'Custom rehabilitation plan with mobility assessment and therapy plan.',
+    description:
+      'Custom rehabilitation plan with mobility assessment and therapy plan.',
     basePrice: 165,
     icon: Images.hospitalIcon,
     defaultEmployeeId: 'emp_olivia',
@@ -60,14 +62,21 @@ export const mockServices: VetService[] = [
   },
 ];
 
-// Helper to create a YYYY-MM-DD string for today
-const todayISO = () => {
+// Helper to create a YYYY-MM-DD string for today, in the device's local timezone.
+// The consuming screens key off the device's local day, so this must stay local.
+// Exported so tests reuse it rather than deriving the key themselves: computing it
+// with `new Date().toISOString().slice(0, 10)` yields the UTC day, which disagrees
+// with the local day between midnight and the UTC offset (e.g. 00:00-02:00 CEST).
+export const todayISO = () => {
   const d = new Date();
   const yyyy = d.getFullYear();
   const mm = String(d.getMonth() + 1).padStart(2, '0');
   const dd = String(d.getDate()).padStart(2, '0');
   return `${yyyy}-${mm}-${dd}`;
 };
+
+// Evaluated once so every entry below shares one key, even across a midnight tick.
+const TODAY_ISO = todayISO();
 
 export const mockAvailability: EmployeeAvailability[] = [
   {
@@ -76,7 +85,7 @@ export const mockAvailability: EmployeeAvailability[] = [
     serviceId: 'svc_internal_consult',
     label: 'Internal medicine consults',
     slotsByDate: {
-      [todayISO()]: ['10:00', '11:00', '13:00', '15:00', '18:00'].map(time => ({
+      [TODAY_ISO]: ['10:00', '11:00', '13:00', '15:00', '18:00'].map(time => ({
         startTime: time,
         endTime: time,
         isAvailable: true,
@@ -89,7 +98,7 @@ export const mockAvailability: EmployeeAvailability[] = [
     serviceId: 'svc_cardiology_eval',
     label: 'Cardiology evaluations',
     slotsByDate: {
-      [todayISO()]: ['09:30', '12:30', '16:00'].map(time => ({
+      [TODAY_ISO]: ['09:30', '12:30', '16:00'].map(time => ({
         startTime: time,
         endTime: time,
         isAvailable: true,
@@ -102,7 +111,7 @@ export const mockAvailability: EmployeeAvailability[] = [
     serviceId: 'svc_rehab_program',
     label: 'Rehab intake',
     slotsByDate: {
-      [todayISO()]: ['10:15', '13:45', '17:30'].map(time => ({
+      [TODAY_ISO]: ['10:15', '13:45', '17:30'].map(time => ({
         startTime: time,
         endTime: time,
         isAvailable: true,
@@ -114,7 +123,7 @@ export const mockAvailability: EmployeeAvailability[] = [
     serviceId: 'svc_groom_spa',
     label: 'Grooming sessions',
     slotsByDate: {
-      [todayISO()]: ['09:00', '11:30', '14:00'].map(time => ({
+      [TODAY_ISO]: ['09:00', '11:30', '14:00'].map(time => ({
         startTime: time,
         endTime: time,
         isAvailable: true,


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

`mocks.test.ts` -> "exports employee availability keyed by today for each entry" derives its expected key from the **UTC** day:

```js
const todayISO = new Date().toISOString().slice(0, 10);
```

while the fixture builds `slotsByDate` keys from **local** date parts. Between midnight and the UTC offset the two disagree, `entry.slotsByDate[todayISO]` is `undefined`, and the assertion fails.

CI runners are UTC, so this leg is always green in CI and only fails on developer machines ahead of UTC.

Reproduced locally at 00:56 CEST, running the pre-fix test unchanged:

```
TZ=Europe/Berlin  ✕ exports employee availability keyed by today for each entry
                    expect(received).toBeDefined()  Received: undefined
                    > 32 | expect(entry.slotsByDate[todayISO]).toBeDefined();
                    Tests: 1 failed, 3 passed, 4 total

TZ=UTC            ✓ exports employee availability keyed by today for each entry
                    Tests: 4 passed, 4 total
```

The fixture also called `todayISO()` once per entry across 4 call sites, so a midnight tick during module evaluation could key different entries to different days.

## What is the new behavior?

`todayISO` is exported from the fixture and used by the test, so both sides key off one local day and cannot drift apart again. The key is hoisted into a single `TODAY_ISO` constant shared by all four entries.

The fixture deliberately stays on **local** dates - the consuming screens key off the device's local day, so moving it to UTC would relocate the bug rather than fix it. `mocks.ts` is imported only by its own test today; `slotsByDate` is consumed by `businessesSlice.ts` and `utils/availability.ts` from real API data, which this does not touch.

Added a case pinning `todayISO` to the device-local day at a fixed instant (`2026-07-24T22:30:00Z`) that lands on either side of midnight depending on the zone, so a future switch to UTC fails loudly.

### Validation

```
TZ=UTC                 Tests: 5 passed, 5 total
TZ=Europe/Berlin       Tests: 5 passed, 5 total
TZ=Asia/Kolkata        Tests: 5 passed, 5 total
TZ=America/Los_Angeles Tests: 5 passed, 5 total

features/appointments suite   53 suites, 1221 tests passed
type-check                    clean
eslint (changed files)        exit 0
coverage src/features/appointments/mocks.ts
                              Statements 100% (16/16)  Branches 100% (0/0)
                              Functions  100% (6/6)    Lines    100% (15/15)
```

All four timezone runs were executed at 00:56 CEST, inside the window where the old test fails.

## Related Issue(s)

Fixes #1996
