### PR TITLE
fix(frontend): make the legal documents usable on mobile

### DIFF
--- a/apps/frontend/src/app/__tests__/features/marketing/site/LegalDoc.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/marketing/site/LegalDoc.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { DocSection, LegalDoc } from '@/app/features/marketing/site';
+
+const TOC = [
+  { id: 'first', label: '1. First section' },
+  { id: 'second', label: '2. Second section' },
+];
+
+const renderDoc = () =>
+  render(
+    <LegalDoc
+      eyebrow="Legal"
+      title="Terms and conditions"
+      subtitle="A subtitle."
+      meta="Updated March 2026"
+      toc={TOC}
+    >
+      <DocSection id="first" title="1. First section">
+        <p>First body.</p>
+      </DocSection>
+      <DocSection id="second" title="2. Second section">
+        <p>Second body.</p>
+      </DocSection>
+    </LegalDoc>
+  );
+
+describe('LegalDoc', () => {
+  it('renders the hero, the contents and the anchored sections', () => {
+    renderDoc();
+
+    expect(screen.getByRole('heading', { name: 'Terms and conditions', level: 1 })).toBeVisible();
+    expect(screen.getByText('A subtitle.')).toBeVisible();
+    expect(screen.getByText('Updated March 2026')).toBeVisible();
+
+    const nav = screen.getByRole('navigation');
+    expect(within(nav).getByRole('link', { name: '1. First section' })).toHaveAttribute(
+      'href',
+      '#first'
+    );
+    expect(within(nav).getByRole('link', { name: '2. Second section' })).toHaveAttribute(
+      'href',
+      '#second'
+    );
+    expect(screen.getByRole('heading', { name: '1. First section', level: 2 })).toBeInTheDocument();
+  });
+
+  it('omits the meta line when the document has no last-updated note', () => {
+    render(
+      <LegalDoc eyebrow="Legal" title="Impressum" subtitle="A subtitle." toc={TOC}>
+        <DocSection id="first" title="1. First section">
+          <p>First body.</p>
+        </DocSection>
+      </LegalDoc>
+    );
+
+    expect(screen.getByRole('heading', { name: 'Impressum', level: 1 })).toBeVisible();
+    expect(screen.queryByText('Updated March 2026')).not.toBeInTheDocument();
+  });
+
+  // The rail is hidden below the grid breakpoint, so the toggle is how a phone
+  // reaches the contents of documents that run to tens of thousands of words.
+  it('collapses the contents behind a toggle that reports its state', async () => {
+    const user = userEvent.setup();
+    renderDoc();
+
+    const toggle = screen.getByRole('button', { name: /on this page/i });
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(toggle).toHaveAttribute('aria-controls', 'yc-toc-list');
+    expect(screen.getByRole('navigation')).toHaveAttribute('data-open', 'false');
+
+    await user.click(toggle);
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('navigation')).toHaveAttribute('data-open', 'true');
+  });
+
+  it('closes the contents again once a section is chosen', async () => {
+    const user = userEvent.setup();
+    renderDoc();
+
+    const toggle = screen.getByRole('button', { name: /on this page/i });
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+    await user.click(screen.getByRole('link', { name: '2. Second section' }));
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.getByRole('navigation')).toHaveAttribute('data-open', 'false');
+  });
+});

--- a/apps/frontend/src/app/features/marketing/site/LegalDoc.tsx
+++ b/apps/frontend/src/app/features/marketing/site/LegalDoc.tsx
@@ -44,8 +44,9 @@ export function LegalDoc({
   children,
 }: Readonly<LegalDocProps>) {
   // These documents run to tens of thousands of words, so the contents has to stay
-  // reachable on a phone. Below the grid breakpoint it collapses behind a toggle;
-  // above it the sticky rail is always open and the toggle is not rendered.
+  // reachable on a phone. Both the toggle and the rail heading are always in the
+  // markup; marketing.css shows one and hides the other at the grid breakpoint, so
+  // above it the rail stays open and `tocOpen` has no effect on what is displayed.
   const [tocOpen, setTocOpen] = useState(false);
 
   return (

--- a/apps/frontend/src/app/features/marketing/site/LegalDoc.tsx
+++ b/apps/frontend/src/app/features/marketing/site/LegalDoc.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { ReactNode } from 'react';
+import { useState, type ReactNode } from 'react';
 import { Reveal } from './motion';
 
 export interface TocEntry {
@@ -43,6 +43,11 @@ export function LegalDoc({
   toc,
   children,
 }: Readonly<LegalDocProps>) {
+  // These documents run to tens of thousands of words, so the contents has to stay
+  // reachable on a phone. Below the grid breakpoint it collapses behind a toggle;
+  // above it the sticky rail is always open and the toggle is not rendered.
+  const [tocOpen, setTocOpen] = useState(false);
+
   return (
     <div data-yc-theme style={{ background: 'var(--page)', color: 'var(--ink-body)' }}>
       <section
@@ -127,6 +132,7 @@ export function LegalDoc({
             style={{ position: 'sticky', top: 100, display: 'flex', flexDirection: 'column' }}
           >
             <div
+              className="yc-toc-heading"
               style={{
                 fontSize: 12,
                 fontWeight: 700,
@@ -139,11 +145,23 @@ export function LegalDoc({
             >
               On this page
             </div>
-            {toc.map((entry) => (
-              <a key={entry.id} href={`#${entry.id}`}>
-                {entry.label}
-              </a>
-            ))}
+            <button
+              type="button"
+              className="yc-toc-toggle"
+              aria-expanded={tocOpen}
+              aria-controls="yc-toc-list"
+              onClick={() => setTocOpen((open) => !open)}
+            >
+              On this page
+              <span aria-hidden="true">{tocOpen ? '–' : '+'}</span>
+            </button>
+            <nav id="yc-toc-list" className="yc-toc-list" data-open={tocOpen}>
+              {toc.map((entry) => (
+                <a key={entry.id} href={`#${entry.id}`} onClick={() => setTocOpen(false)}>
+                  {entry.label}
+                </a>
+              ))}
+            </nav>
           </aside>
           <Reveal className="yc-doc">{children}</Reveal>
         </div>

--- a/apps/frontend/src/app/features/marketing/site/marketing.css
+++ b/apps/frontend/src/app/features/marketing/site/marketing.css
@@ -475,6 +475,9 @@
 .yc-doc section {
   padding: 40px 0;
   border-top: 1px solid var(--hairline);
+  /* The contents links target the section, not its heading, so the offset has to
+     live here too or the sticky header covers the title after a jump. */
+  scroll-margin-top: 96px;
 }
 .yc-doc section:first-child {
   border-top: none;
@@ -497,12 +500,74 @@
   border-left-color: var(--hairline-hover);
 }
 
+/* Grid items are min-width:auto by default, so the widest table's min-content
+   width would stretch the document column past the viewport. Because
+   .yc-public-page clips overflow-x, that showed up as the right edge of every
+   line being cut off on a phone rather than as a scrollbar. Let the column
+   shrink; the table scrolls on its own (see .yc-doc table). */
+[data-doc-grid] > * {
+  min-width: 0;
+}
+
+.yc-toc-toggle {
+  display: none;
+}
+.yc-toc-list {
+  display: flex;
+  flex-direction: column;
+}
+
 @media (max-width: 900px) {
   [data-doc-grid] {
     grid-template-columns: 1fr !important;
+    gap: 0 !important;
   }
+  /* The contents stays available on small screens: these documents are far too
+     long to thumb through. It collapses so it does not bury the text. */
   [data-toc] {
-    display: none !important;
+    position: static !important;
+    margin-bottom: 24px;
+    border: 1px solid var(--hairline);
+    border-radius: 14px;
+    background: var(--inset);
+  }
+  .yc-toc-heading {
+    display: none;
+  }
+  .yc-toc-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    width: 100%;
+    min-height: 48px;
+    padding: 12px 16px;
+    border: 0;
+    border-radius: 14px;
+    background: none;
+    font: inherit;
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--ink-faint2);
+    cursor: pointer;
+  }
+  .yc-toc-toggle span {
+    font-size: 18px;
+    line-height: 1;
+  }
+  .yc-toc-list {
+    display: none;
+    padding: 0 8px 8px;
+  }
+  .yc-toc-list[data-open='true'] {
+    display: flex;
+  }
+  .yc-toc a {
+    min-height: 44px;
+    display: flex;
+    align-items: center;
   }
 }
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The terms and privacy pages are not usable on a phone. Three separate problems, all of which only became reachable once the full legal text replaced the summarised copy in #2014.

**Text is cut off.** Grid items are `min-width: auto`, so the widest table's min-content width stretches the document column to 626px inside a 342px grid cell. `.yc-public-page` clips `overflow-x`, so this never becomes a scrollbar: roughly a third of every line is invisible and unreachable. 920 elements are affected on the terms page at 390px.

**There is no way to navigate.** The contents rail is `display: none` below 900px, which was fine for the old 1,400-word summaries. The terms page is now 74,735px tall on a 390px viewport, about 88 screens, with no way to reach a section.

**Section jumps hide their heading.** The contents links target `<section id>`, but `scroll-margin-top` sits only on the `h2` inside the section, so the sticky header covers the title on arrival. This one affects desktop too.

## What is the new behavior?

**The column can shrink, the tables scroll.**

```css
[data-doc-grid] > * { min-width: 0; }
```

The document column returns to 342px at 390px wide, and each table scrolls inside its own box, which is what the existing `.yc-doc table { overflow-x: auto }` always intended. Cause was isolated before fixing: hiding the tables collapsed the column straight back to 342px.

**The contents collapses instead of disappearing.** Below 900px the rail becomes a toggle: `aria-expanded` and `aria-controls` on the button, closes once a section is chosen, 48px toggle and 44px link targets. Above 900px nothing changes: both the toggle and the rail heading are always in the markup, and the stylesheet shows one and hides the other at the breakpoint.

**`scroll-margin-top` moves to the section**, so a jump lands with the title clear of the header.

## Impact area

`apps/frontend`, the shared `LegalDoc` layout and the `.yc-doc` prose styles. No content, route or data changed.

`LegalDoc` is shared, so Trust Center, Accessibility, DMCA and Impressum get the same mobile contents. Their existing tests pass unchanged.

## Validation performed

Tested by tapping as a user at each viewport, not by scripting clicks.

| Viewport | Result |
| --- | --- |
| 390 | Contents collapsed on load, expands on tap, jump lands clear of the header, tables scroll internally (342 visible / 580 to 626 content), no page-level horizontal scroll, no clipped text |
| 834 | Same collapsible treatment, below the 900px breakpoint |
| 1440 | Sticky rail unchanged, toggle hidden by the stylesheet |

- `pnpm --filter frontend run test -- --testPathPatterns="legal/|marketing"`: 25 suites, 157 tests passing.
- `pnpm --filter frontend run type-check`: clean.
- `pnpm --filter frontend run lint`: clean.
- react-doctor 100/100 on both `features/legal` and `features/marketing/site`.
- Pre-commit hooks green, including gitleaks and secretlint.

New `LegalDoc.test.tsx`: the component had no direct test and this change adds interactive behaviour. It covers the hero and anchors, the collapse and expand cycle with its ARIA state, closing on navigation, and the optional meta line. `LegalDoc.tsx` is at 100% statements, branches, functions and lines.

## Known issue left out of scope

`Reveal` sets `opacity`, `transform` and `filter` inline and the server and client disagree, so every marketing page logs a hydration mismatch. It predates this work, appears on all marketing routes rather than just these two, and does not break interactivity. Worth its own issue rather than widening this one.

Fixes #2021
