### PR TITLE
ci(database): fail the build when an applied migration is edited

### DIFF
--- a/.github/workflows/_migration.yaml
+++ b/.github/workflows/_migration.yaml
@@ -78,9 +78,44 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
+          # Needed to diff this branch against its base for the immutability
+          # check below.
+          fetch-depth: 0
 
       - name: Setup
         uses: ./.github/actions/setup
+
+      # Prisma stores a checksum of every migration it has applied. Editing a
+      # migration that is already deployed therefore does not fail here - it
+      # fails later, in `migrate deploy` against the environment that already
+      # ran it, which is the worst possible place to find out. Applied
+      # migrations are immutable: fix a mistake with a new migration.
+      - name: Check applied migrations were not edited
+        if: ${{ github.event_name == 'pull_request' }}
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+
+          # Only additions are allowed under prisma/migrations. Renames count as
+          # a delete plus an add, so -M is disabled to catch a migration being
+          # moved rather than added.
+          changed=$(git diff --no-renames --name-status "$BASE_SHA...HEAD" \
+            -- packages/database/prisma/migrations \
+            | grep -Ev '^A' || true)
+
+          if [ -n "$changed" ]; then
+            echo "::error::An existing migration was modified or deleted."
+            echo "Migrations that have been applied anywhere are immutable - Prisma"
+            echo "checksums them, so an edit here surfaces as a failed deploy against"
+            echo "an environment that already ran it. Add a new migration instead."
+            echo "--- disallowed changes ---"
+            echo "$changed"
+            exit 1
+          fi
+
+          echo "No existing migration was modified."
 
       # `migrate diff --from-migrations` replays the whole history into a
       # throwaway database, so it needs one that is not the target.


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

#1963 added a gate proving `schema.prisma` and `prisma/migrations` agree, and it immediately earned its keep: it found real drift, including a missing `RenderedDocumentSourceKind` enum value that would fail at runtime against any database built from the migration history.

But that gate only checks the two are *consistent*. It says nothing about migrations that have **already been applied somewhere**.

Prisma stores a checksum of every migration it applies. Editing one that is already deployed does not fail in CI - it fails later, during `migrate deploy` against an environment that already ran it. That is the worst possible place to find out: production, mid-deploy, with the migration history no longer trustworthy and no clean way forward.

## What is the new behavior?

A step that diffs `prisma/migrations` against the PR base and allows **only additions**:

```bash
changed=$(git diff --no-renames --name-status "$BASE_SHA...HEAD" \
  -- packages/database/prisma/migrations \
  | grep -Ev '^A' || true)
```

Modifications and deletions fail the build with the offending paths printed. `--no-renames` is deliberate: without it git reports a moved migration as a single `R` entry, which would slip past a filter looking for `M` and `D`. With it, a rename shows up as a delete plus an add and is caught.

Checkout gains `fetch-depth: 0`, which the diff against the base commit needs. The step is scoped to `pull_request` events, where a base SHA exists.

## Validation performed

Exercised all four cases locally against a real branch rather than by inspection:

| Case | Expected | Result |
| --- | --- | --- |
| No migration changes | pass | pass, empty output |
| Add a new migration | pass | pass, additions allowed |
| Edit an existing migration | fail | fails, names the file |
| Delete an existing migration | fail | fails, names the file |

`pnpm run type-check` passes 17/17. The workflow parses as valid YAML.

## Why this is worth having

The drift #1963 uncovered means a schema change reached a deployed database without a migration. That gate stops the next one. This closes the neighbouring hole: a migration being *changed* after the fact, which is the same class of problem - the committed history no longer describing what was actually applied - but with a much nastier failure mode, since it surfaces as a broken deploy rather than a red build.

Neither gate replaces checking production directly. `prisma migrate diff --from-url "$PROD_DATABASE_URL" --to-schema-datamodel` is read-only and remains the only thing that can confirm a deployed database matches the schema; it needs credentials CI does not have.

## Related Issue(s)

Fixes #
