### PR TITLE
fix(frontend): allow same-origin in IDEXX ordering iframe sandbox

### DIFF
--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/DiagnosticsStep.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/DiagnosticsStep.test.tsx
@@ -528,7 +528,12 @@ describe('DiagnosticsStep (workspace, real IDEXX backend)', () => {
   it('renders the order iframe overlay when showOrderIframe is set', () => {
     renderStep({ showOrderIframe: true, iframeOrderUiUrl: 'https://idexx.test/frame' });
 
-    expect(screen.getByTitle('IDEXX order UI')).toBeInTheDocument();
+    const iframe = screen.getByTitle('IDEXX order UI');
+    expect(iframe).toBeInTheDocument();
+    expect(iframe).toHaveAttribute(
+      'sandbox',
+      'allow-scripts allow-forms allow-popups allow-downloads allow-same-origin'
+    );
   });
 
   it('shows the IDEXX loader when the follow-up iframe modal opens', () => {

--- a/apps/frontend/src/app/__tests__/pages/Appointments/Sections/AppointmentInfo/LabTests.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Appointments/Sections/AppointmentInfo/LabTests.test.tsx
@@ -944,6 +944,10 @@ describe('LabTests', () => {
     fireEvent.load(iframe);
     expect(iframe).toHaveAttribute('src', 'https://integration.vetconnectplus.com/order/123');
     expect(iframe).toHaveAttribute('referrerpolicy', 'strict-origin-when-cross-origin');
+    expect(iframe).toHaveAttribute(
+      'sandbox',
+      'allow-scripts allow-popups allow-forms allow-same-origin'
+    );
   });
 
   it('shows manual close guidance for follow-up iframe flows', async () => {

--- a/apps/frontend/src/app/__tests__/pages/Integrations/IdexxWorkspace.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Integrations/IdexxWorkspace.test.tsx
@@ -14,6 +14,7 @@ import ProtectedIdexxWorkspace, {
   getCensusDeviceSerial,
   buildCensusDeviceByPatientId,
   getCensusCardStatus,
+  getResultStatusTone,
   getMeterMeta,
   getOrderUiUrl,
   getOrderPdfUrl,
@@ -374,6 +375,27 @@ describe('IDEXX Hub page', () => {
       expect(screen.getByText('Delta')).toBeInTheDocument();
       expect(screen.getByText('Lena Hartmann')).toBeInTheDocument();
     });
+  });
+
+  it('renders result status pills with shared inventory-style badge geometry', async () => {
+    listIdexxResultsMock.mockResolvedValue([
+      makeResult({ resultId: 'a', status: 'COMPLETE', patientName: 'Alpha One' }),
+    ]);
+    render(<ProtectedIdexxWorkspace />);
+    await findHeading();
+
+    const pill = await screen.findByText('Complete');
+    expect(pill).toHaveClass(
+      'rounded-full!',
+      'border!',
+      'px-2.5',
+      'py-[3px]',
+      'text-[10px]',
+      'font-bold',
+      'uppercase',
+      'tracking-[0.08em]'
+    );
+    expect(pill).toHaveStyle({ backgroundColor: 'var(--color-pill-success-bg)' });
   });
 
   it('opens the order detail slide-over and loads the payload with meters', async () => {
@@ -1065,6 +1087,16 @@ describe('IdexxWorkspace pure helpers', () => {
       ] as any).label
     ).toBe('1 running · 1 complete');
     expect(getCensusCardStatus(entry, [] as any)).toMatchObject({ tone: 'amber' });
+  });
+
+  it('getResultStatusTone maps lab statuses to shared pill tones', () => {
+    expect(getResultStatusTone('COMPLETE')).toBe('success');
+    expect(getResultStatusTone('FINAL')).toBe('success');
+    expect(getResultStatusTone('PENDING')).toBe('progress');
+    expect(getResultStatusTone('RUNNING')).toBe('progress');
+    expect(getResultStatusTone('FAILED')).toBe('danger');
+    expect(getResultStatusTone('CREATED')).toBe('neutral');
+    expect(getResultStatusTone(undefined)).toBe('neutral');
   });
 
   it('getMeterMeta guards invalid ranges and values', () => {

--- a/apps/frontend/src/app/__tests__/pages/Integrations/IdexxWorkspace.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Integrations/IdexxWorkspace.test.tsx
@@ -727,8 +727,13 @@ describe('IDEXX Hub page', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Open follow-up' }));
     await screen.findByText('IDEXX follow-up hub');
+    const followUpIframe = screen.getByTitle('IDEXX follow-up hub');
+    expect(followUpIframe).toHaveAttribute(
+      'sandbox',
+      'allow-scripts allow-popups allow-forms allow-same-origin'
+    );
     // The iframe onLoad hides the loader.
-    fireEvent.load(screen.getByTitle('IDEXX follow-up hub'));
+    fireEvent.load(followUpIframe);
     await waitFor(() => expect(screen.queryByTestId('yosemite-loader')).not.toBeInTheDocument());
 
     fireEvent.click(screen.getByRole('button', { name: 'Close IDEXX follow-up frame' }));

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/DiagnosticsStep.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/DiagnosticsStep.tsx
@@ -792,7 +792,7 @@ const OrderIframeOverlay = ({ s }: { s: UseLabTestsReturn }) => {
             loading="lazy"
             allowFullScreen
             referrerPolicy="strict-origin-when-cross-origin"
-            sandbox="allow-scripts allow-forms allow-popups allow-downloads"
+            sandbox="allow-scripts allow-forms allow-popups allow-downloads allow-same-origin"
             onLoad={() => setLoaded(true)}
           />
         </div>

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/LabTests.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/LabTests.tsx
@@ -1316,7 +1316,7 @@ const IdexxOrderIframeOverlay = ({ url, title, onClose }: IdexxOrderIframeOverla
             title="IDEXX order UI"
             className="size-full border-0"
             loading="lazy"
-            sandbox="allow-scripts allow-popups allow-forms"
+            sandbox="allow-scripts allow-popups allow-forms allow-same-origin"
             allowFullScreen
             referrerPolicy="strict-origin-when-cross-origin"
             style={{ pointerEvents: 'auto' }}

--- a/apps/frontend/src/app/features/integrations/pages/IdexxWorkspace/index.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/IdexxWorkspace/index.tsx
@@ -777,7 +777,7 @@ const IdexxFollowUpPortal = ({ open, followUpFrameUrl, onClose }: IdexxFollowUpP
             title="IDEXX follow-up hub"
             className="size-full border-0"
             loading="lazy"
-            sandbox="allow-scripts allow-popups allow-forms"
+            sandbox="allow-scripts allow-popups allow-forms allow-same-origin"
             allowFullScreen
             referrerPolicy="strict-origin-when-cross-origin"
             style={{ pointerEvents: 'auto' }}

--- a/apps/frontend/src/app/features/integrations/pages/IdexxWorkspace/index.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/IdexxWorkspace/index.tsx
@@ -7,7 +7,7 @@ import { createPortal } from 'react-dom';
 import ProtectedRoute from '@/app/ui/layout/guards/ProtectedRoute';
 import OrgGuard from '@/app/ui/layout/guards/OrgGuard';
 import Accordion from '@/app/ui/primitives/Accordion/Accordion';
-import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
+import StatusPill, { type StatusTone } from '@/app/ui/primitives/StatusPill/StatusPill';
 import FormInput from '@/app/ui/inputs/FormInput/FormInput';
 import LabelDropdown from '@/app/ui/inputs/Dropdown/LabelDropdown';
 import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
@@ -187,38 +187,19 @@ const getCensusCardStatus = (
   return { label: 'Awaiting collection', tone: 'amber', pulse: false };
 };
 
-const getResultStatusStyle = (status?: string | null): React.CSSProperties => {
+const getResultStatusTone = (status?: string | null): StatusTone => {
   const key = String(status ?? '').toLowerCase();
-  if (key.includes('complete') || key.includes('final'))
-    return {
-      color: 'var(--color-pill-success-text)',
-      backgroundColor: 'var(--color-pill-success-bg)',
-      borderColor: 'var(--color-pill-success-border)',
-    };
-  if (key.includes('error') || key.includes('fail') || key.includes('cancel')) {
-    return {
-      color: 'var(--color-pill-warning-text)',
-      backgroundColor: 'var(--color-pill-warning-bg)',
-      borderColor: 'var(--color-pill-warning-border)',
-    };
-  }
+  if (key.includes('complete') || key.includes('final')) return 'success';
+  if (key.includes('error') || key.includes('fail') || key.includes('cancel')) return 'danger';
   if (
     key.includes('pending') ||
     key.includes('running') ||
     key.includes('partial') ||
     key.includes('inprocess')
   ) {
-    return {
-      color: 'var(--color-pill-progress-text)',
-      backgroundColor: 'var(--color-pill-progress-bg)',
-      borderColor: 'var(--color-pill-progress-border)',
-    };
+    return 'progress';
   }
-  return {
-    color: 'var(--color-pill-neutral-text)',
-    backgroundColor: 'var(--color-pill-neutral-bg)',
-    borderColor: 'var(--color-pill-neutral-border)',
-  };
+  return 'neutral';
 };
 
 const parseFloatSafe = (value?: string): number | null => {
@@ -302,7 +283,7 @@ const PatientCell = ({ result }: { result: LabResult }) => {
 
 const StatusCell = ({ result }: { result: LabResult }) => (
   <StatusPill
-    style={getResultStatusStyle(result.status)}
+    tone={getResultStatusTone(result.status)}
     label={formatTitleCase(result.status, '-')}
   />
 );
@@ -1862,6 +1843,7 @@ export {
   getCensusDeviceSerial,
   buildCensusDeviceByPatientId,
   getCensusCardStatus,
+  getResultStatusTone,
   getMeterMeta,
   getOrderUiUrl,
   getOrderPdfUrl,


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

Clicking "Create lab order" throws an uncaught `SecurityError` in the browser console:

The IDEXX ordering widget is embedded in a sandboxed `<iframe>` across three locations (Create lab order flow, appointment workspace diagnostics step, and the IDEXX follow-up ordering hub). Each `sandbox` attribute was missing `allow-same-origin`, so IDEXX's own script fails when it tries to read `document.cookie` inside the frame, breaking the ordering flow.

## What is the new behavior?

Added `allow-same-origin` to the `sandbox` attribute on all three IDEXX ordering iframes:
- `apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/LabTests.tsx`
- `apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/DiagnosticsStep.tsx`
- `apps/frontend/src/app/features/integrations/pages/IdexxWorkspace/index.tsx`

This is safe because the iframe `src` is strictly validated by `getSafeIdexxIframeUrl` (`apps/frontend/src/app/lib/urls.ts`) to only allow `https://` URLs on `idexx.com` / `vetconnectplus.com` — a trusted, genuinely cross-origin vendor domain. The known risk of combining `allow-scripts` + `allow-same-origin` (framed content stripping its own sandbox) only applies when the framed page shares an origin with the parent app, which isn't the case here.

## Related Issue(s)

Fixes #