### PR TITLE
fix(frontend): standardize full-screen table status pills

### DIFF
--- a/apps/frontend/src/app/__tests__/components/AppointmentCardContent.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/AppointmentCardContent.test.tsx
@@ -242,9 +242,11 @@ describe('AppointmentModePill', () => {
 
     expect(screen.getByText('Outpatient')).toBeInTheDocument();
     expect(screen.getByTestId('icon-footsteps')).toBeInTheDocument();
-    expect(screen.getByText('Outpatient').parentElement).toHaveStyle({
-      backgroundColor: 'var(--color-neutral-100)',
+    const pill = screen.getByText('Outpatient').closest('[title="Outpatient"]') as HTMLElement;
+    expect(pill).toHaveStyle({
+      backgroundColor: 'var(--color-pill-neutral-bg)',
     });
+    expect(pill).toHaveClass('rounded-full!', 'text-[10px]', 'uppercase');
   });
 
   it('renders the inpatient pill in the default tone', () => {
@@ -254,8 +256,8 @@ describe('AppointmentModePill', () => {
 
     expect(screen.getByText('Inpatient')).toBeInTheDocument();
     expect(screen.getByTestId('icon-bed')).toBeInTheDocument();
-    expect(screen.getByText('Inpatient').parentElement).toHaveStyle({
-      backgroundColor: 'var(--color-primary-500)',
+    expect(screen.getByText('Inpatient').closest('[title="Inpatient"]')).toHaveStyle({
+      backgroundColor: 'var(--color-pill-info-bg)',
     });
   });
 
@@ -269,17 +271,17 @@ describe('AppointmentModePill', () => {
       />
     );
 
-    const pill = screen.getByText('Inpatient').parentElement as HTMLElement;
+    const pill = screen.getByText('Inpatient').closest('[title="Inpatient"]') as HTMLElement;
     expect(pill).toHaveClass('custom-class');
-    expect(pill).toHaveStyle({ backgroundColor: 'var(--color-primary-600)' });
+    expect(pill).toHaveStyle({ backgroundColor: 'var(--color-pill-info-bg)' });
     expect(screen.getByTestId('icon-bed')).toHaveAttribute('size', '20');
   });
 
   it('renders the outpatient pill in the strong tone', () => {
     render(<AppointmentModePill appointment={baseAppointment} tone="strong" />);
 
-    expect(screen.getByText('Outpatient').parentElement).toHaveStyle({
-      backgroundColor: 'var(--color-neutral-100)',
+    expect(screen.getByText('Outpatient').closest('[title="Outpatient"]')).toHaveStyle({
+      backgroundColor: 'var(--color-pill-neutral-bg)',
     });
   });
 });

--- a/apps/frontend/src/app/__tests__/components/Cards/AppointmentCard/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Cards/AppointmentCard/index.test.tsx
@@ -102,6 +102,24 @@ describe('AppointmentCard', () => {
     expect(screen.getByText('COMPLETED')).toBeInTheDocument();
   });
 
+  it('renders the card mode pill with the shared status-pill appearance', () => {
+    render(
+      <AppointmentCard
+        appointment={{ ...appointment, appointmentKind: 'INPATIENT' }}
+        handleViewAppointment={handleViewAppointment}
+        handleWorkspaceAppointment={handleWorkspaceAppointment}
+        getSoapViewIntent={getSoapViewIntent}
+        handleRescheduleAppointment={handleRescheduleAppointment}
+        canEditAppointments
+      />
+    );
+
+    const modePill = screen.getByText('Inpatient').closest('[title="Inpatient"]') as HTMLElement;
+    expect(modePill).toHaveClass('rounded-full!', 'text-[10px]', 'uppercase');
+    expect(modePill).not.toHaveClass('h-7');
+    expect(modePill).toHaveStyle({ backgroundColor: 'var(--color-pill-info-bg)' });
+  });
+
   it('calls handlers on view/reschedule', () => {
     render(
       <AppointmentCard

--- a/apps/frontend/src/app/__tests__/components/DataTable/Appointments.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/DataTable/Appointments.test.tsx
@@ -330,7 +330,7 @@ describe('Appointments table', () => {
     expect(screen.getByText('Ward 1')).toBeInTheDocument();
     expect(screen.getByText('Kennel A')).toBeInTheDocument();
     const modePill = screen.getByText('Inpatient').closest('[title="Inpatient"]') as HTMLElement;
-    expect(modePill).toHaveClass('rounded-full!', 'text-[10px]', 'uppercase');
+    expect(modePill).toHaveClass('mt-1', 'rounded-full!', 'text-[10px]', 'uppercase');
     expect(modePill).not.toHaveClass('h-6');
     expect(modePill).toHaveStyle({ backgroundColor: 'var(--color-pill-info-bg)' });
   });

--- a/apps/frontend/src/app/__tests__/components/DataTable/Appointments.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/DataTable/Appointments.test.tsx
@@ -290,6 +290,24 @@ describe('Appointments table', () => {
     expect(screen.getByText('-')).toBeInTheDocument();
   });
 
+  it('renders the desktop status cell through the protected shared pill class', () => {
+    const appointment: any = {
+      id: 'a6',
+      status: 'IN_PROGRESS',
+      companion: {
+        id: 'c6',
+        name: 'Ruby',
+        species: 'dog',
+        parent: { name: 'Jamie' },
+      },
+    };
+
+    render(<Appointments filteredList={[appointment]} canEditAppointments />);
+
+    const statusPill = screen.getByText('IN_PROGRESS');
+    expect(statusPill).toHaveClass('yc-status-pill', 'text-[10px]', 'leading-[normal]');
+  });
+
   it('shows room unit and mode pill in the room column for inpatient appointments', () => {
     const appointment: any = {
       id: 'a5',

--- a/apps/frontend/src/app/__tests__/components/DataTable/Appointments.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/DataTable/Appointments.test.tsx
@@ -311,6 +311,9 @@ describe('Appointments table', () => {
 
     expect(screen.getByText('Ward 1')).toBeInTheDocument();
     expect(screen.getByText('Kennel A')).toBeInTheDocument();
-    expect(screen.getByText('Inpatient')).toBeInTheDocument();
+    const modePill = screen.getByText('Inpatient').closest('[title="Inpatient"]') as HTMLElement;
+    expect(modePill).toHaveClass('rounded-full!', 'text-[10px]', 'uppercase');
+    expect(modePill).not.toHaveClass('h-6');
+    expect(modePill).toHaveStyle({ backgroundColor: 'var(--color-pill-info-bg)' });
   });
 });

--- a/apps/frontend/src/app/__tests__/components/DataTable/FormsTable.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/DataTable/FormsTable.test.tsx
@@ -187,7 +187,14 @@ describe('FormsTable Component', () => {
     expect(screen.getAllByText('Custom').length).toBeGreaterThan(0);
     expect(screen.getAllByText('2023-10-01 · Alice').length).toBeGreaterThan(0);
     const publishedStatus = screen.getByText('Published');
-    expect(publishedStatus).toHaveClass('rounded-full!', 'text-[10px]', 'font-bold', 'uppercase');
+    expect(publishedStatus).toHaveClass(
+      'yc-status-pill',
+      'rounded-full!',
+      'text-[10px]',
+      'leading-[normal]',
+      'font-bold',
+      'uppercase'
+    );
     expect(publishedStatus).toHaveAttribute(
       'style',
       expect.stringContaining('background-color: var(--color-pill-success-bg)')

--- a/apps/frontend/src/app/__tests__/components/DataTable/InvoiceTable.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/DataTable/InvoiceTable.test.tsx
@@ -152,7 +152,14 @@ describe('InvoiceTable', () => {
     expect(screen.queryByText('Finance')).not.toBeInTheDocument();
     expect(desktop.getByText('Paid in cash')).toBeInTheDocument();
     const status = desktop.getByText('Pending');
-    expect(status).toHaveClass('rounded-full!', 'text-[10px]', 'font-bold', 'uppercase');
+    expect(status).toHaveClass(
+      'yc-status-pill',
+      'rounded-full!',
+      'text-[10px]',
+      'leading-[normal]',
+      'font-bold',
+      'uppercase'
+    );
     expect(status).toHaveAttribute(
       'style',
       expect.stringContaining('background-color: var(--color-pill-neutral-bg)')

--- a/apps/frontend/src/app/__tests__/components/DataTable/Tasks.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/DataTable/Tasks.test.tsx
@@ -116,7 +116,9 @@ describe('Tasks table', () => {
       />
     );
 
-    expect(screen.getByTitle('PENDING')).toHaveStyle({
+    const statusPill = screen.getByTitle('PENDING');
+    expect(statusPill).toHaveClass('yc-status-pill', 'text-[10px]', 'leading-[normal]');
+    expect(statusPill).toHaveStyle({
       backgroundColor: 'var(--color-pill-neutral-bg)',
     });
 

--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/WorkspaceShell.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/WorkspaceShell.test.tsx
@@ -261,7 +261,9 @@ describe('CompanionContextCard', () => {
 
   it('renders the inpatient mode pill', () => {
     render(<CompanionContextCard name="Gigi" details={details} mode="INPATIENT" />);
-    expect(screen.getByText('Inpatient')).toBeInTheDocument();
+    const modePill = screen.getByText('Inpatient').closest('[title="Inpatient"]') as HTMLElement;
+    expect(modePill).toHaveClass('yc-status-pill', 'text-[10px]', 'uppercase');
+    expect(modePill).toHaveStyle({ backgroundColor: 'var(--color-pill-info-bg)' });
   });
 
   it('has no axe violations', async () => {

--- a/apps/frontend/src/app/__tests__/pages/Integrations/IdexxWorkspace.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Integrations/IdexxWorkspace.test.tsx
@@ -386,6 +386,7 @@ describe('IDEXX Hub page', () => {
 
     const pill = await screen.findByText('Complete');
     expect(pill).toHaveClass(
+      'yc-status-pill',
       'rounded-full!',
       'border!',
       'px-2.5',

--- a/apps/frontend/src/app/__tests__/ui/primitives/StatusPill.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/primitives/StatusPill.test.tsx
@@ -71,6 +71,7 @@ describe('StatusPill', () => {
     // status render at three different sizes across the app.
     render(<StatusPill label="Awaiting payment" />);
     const pill = screen.getByText('Awaiting payment');
+    expect(pill).toHaveClass('yc-status-pill');
     expect(pill).toHaveClass('px-2.5', 'py-[3px]', 'text-[10px]', 'font-bold');
     expect(pill).toHaveClass('tracking-[0.08em]', 'leading-[normal]', 'uppercase');
   });

--- a/apps/frontend/src/app/features/appointments/components/AppointmentBoardCard.tsx
+++ b/apps/frontend/src/app/features/appointments/components/AppointmentBoardCard.tsx
@@ -210,11 +210,7 @@ const BoardCardMetaRow = ({
       )}
     </div>
     <div className="flex shrink-0 items-center gap-1.5">
-      <AppointmentModePill
-        appointment={appointment}
-        className="h-6 px-2.5 text-[10px]"
-        iconSize={12}
-      />
+      <AppointmentModePill appointment={appointment} className="w-fit" iconSize={12} />
       <AppointmentPaymentBadge
         appointment={appointment}
         invoicesByAppointmentId={invoicesByAppointmentId}

--- a/apps/frontend/src/app/features/appointments/components/AppointmentCardContent.tsx
+++ b/apps/frontend/src/app/features/appointments/components/AppointmentCardContent.tsx
@@ -29,6 +29,12 @@ type AppointmentModePillProps = {
   tone?: 'default' | 'strong';
 };
 
+type EncounterModePillProps = {
+  mode: EncounterMode;
+  className?: string;
+  iconSize?: number;
+};
+
 const normalizeLeadId = (value?: string | null): string => {
   const trimmed = String(value ?? '').trim();
   if (!trimmed) return '';
@@ -116,12 +122,11 @@ export const AppointmentStatusBadge = ({ appointment }: AppointmentCardContentPr
   );
 };
 
-export const AppointmentModePill = ({
-  appointment,
+export const EncounterModePill = ({
+  mode,
   className = '',
   iconSize = 14,
-}: AppointmentModePillProps) => {
-  const mode: EncounterMode = resolveEncounterMode(appointment);
+}: EncounterModePillProps) => {
   const isInpatient = mode === 'INPATIENT';
   const label = isInpatient ? 'Inpatient' : 'Outpatient';
 
@@ -144,6 +149,15 @@ export const AppointmentModePill = ({
       }
     />
   );
+};
+
+export const AppointmentModePill = ({
+  appointment,
+  className = '',
+  iconSize = 14,
+}: AppointmentModePillProps) => {
+  const mode: EncounterMode = resolveEncounterMode(appointment);
+  return <EncounterModePill mode={mode} className={className} iconSize={iconSize} />;
 };
 
 const AppointmentCardContent = ({ appointment }: AppointmentCardContentProps) => (

--- a/apps/frontend/src/app/features/appointments/components/AppointmentCardContent.tsx
+++ b/apps/frontend/src/app/features/appointments/components/AppointmentCardContent.tsx
@@ -36,11 +36,6 @@ const normalizeLeadId = (value?: string | null): string => {
   return lowered === 'undefined' || lowered === 'null' ? '' : trimmed;
 };
 
-const resolveModeBackgroundColor = (isInpatient: boolean, isStrong: boolean): string => {
-  if (!isInpatient) return 'var(--color-neutral-100)';
-  return isStrong ? 'var(--color-primary-600)' : 'var(--color-primary-500)';
-};
-
 export const AppointmentCompanionHeader = ({ appointment }: AppointmentCardContentProps) => (
   <div className="flex gap-2 items-center">
     {(() => {
@@ -125,34 +120,29 @@ export const AppointmentModePill = ({
   appointment,
   className = '',
   iconSize = 14,
-  tone = 'default',
 }: AppointmentModePillProps) => {
   const mode: EncounterMode = resolveEncounterMode(appointment);
   const isInpatient = mode === 'INPATIENT';
-  const isStrong = tone === 'strong';
-  const modeStyle: React.CSSProperties = {
-    backgroundColor: resolveModeBackgroundColor(isInpatient, isStrong),
-    borderColor: isInpatient ? 'var(--color-primary-700)' : 'var(--color-neutral-200)',
-    borderStyle: 'solid',
-    borderWidth: '1px',
-    boxShadow: isStrong && isInpatient ? '0 1px 6px rgba(0, 87, 194, 0.18)' : undefined,
-    color: isInpatient ? 'var(--color-white)' : 'var(--color-neutral-700)',
-  };
+  const label = isInpatient ? 'Inpatient' : 'Outpatient';
 
   return (
-    <div
-      className={`flex h-7 shrink-0 items-center gap-1.5 rounded-2xl px-3 text-yc-12-b-neutral ${className}`}
-      style={modeStyle}
-    >
-      {isInpatient ? (
-        <IoBedOutline size={iconSize} aria-hidden="true" />
-      ) : (
-        <IoFootstepsOutline size={iconSize} aria-hidden="true" />
-      )}
-      <span className="whitespace-nowrap" style={{ color: 'inherit', opacity: 1 }}>
-        {isInpatient ? 'Inpatient' : 'Outpatient'}
-      </span>
-    </div>
+    <StatusPill
+      tone={isInpatient ? 'info' : 'neutral'}
+      title={label}
+      className={className}
+      label={
+        <>
+          {isInpatient ? (
+            <IoBedOutline size={iconSize} aria-hidden="true" />
+          ) : (
+            <IoFootstepsOutline size={iconSize} aria-hidden="true" />
+          )}
+          <span className="whitespace-nowrap" style={{ color: 'inherit', opacity: 1 }}>
+            {label}
+          </span>
+        </>
+      }
+    />
   );
 };
 

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/CompanionContextCard.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/CompanionContextCard.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import Image from 'next/image';
-import { IoBedOutline, IoChevronForwardOutline, IoFootstepsOutline } from 'react-icons/io5';
+import { IoChevronForwardOutline } from 'react-icons/io5';
 import { getSafeImageUrl, type ImageType } from '@/app/lib/urls';
 import type { EncounterMode } from '@/app/features/appointments/types/workspace';
+import { EncounterModePill } from '@/app/features/appointments/components/AppointmentCardContent';
 
 export type CompanionDetail = {
   label: string;
@@ -52,20 +53,6 @@ const DetailRow = ({ label, value }: CompanionDetail) => (
   </div>
 );
 
-/** Blue "Inpatient" / neutral "Outpatient" mode pill shown bottom-right. */
-const ModePill = ({ mode }: { mode: EncounterMode }) =>
-  mode === 'INPATIENT' ? (
-    <span className="flex h-7 items-center gap-1.5 rounded-2xl bg-primary-500 px-3 text-yc-12-b-neutral text-neutral-0">
-      <IoBedOutline size={14} aria-hidden="true" />
-      Inpatient
-    </span>
-  ) : (
-    <span className="flex h-7 items-center gap-1.5 rounded-2xl bg-neutral-100 px-3 text-yc-12-b-neutral text-neutral-700">
-      <IoFootstepsOutline size={14} aria-hidden="true" />
-      Outpatient
-    </span>
-  );
-
 /**
  * White companion card on the in-progress band. Round 64px avatar + a 3-column
  * grid of label/value rows. The right rail carries the "View Details" pill (→
@@ -99,7 +86,7 @@ const CompanionContextCard = ({
       ) : (
         <span aria-hidden="true" className="h-8" />
       )}
-      <ModePill mode={mode} />
+      <EncounterModePill mode={mode} />
     </div>
   </div>
 );

--- a/apps/frontend/src/app/ui/primitives/StatusPill/StatusPill.tsx
+++ b/apps/frontend/src/app/ui/primitives/StatusPill/StatusPill.tsx
@@ -111,7 +111,7 @@ const StatusPill = ({
   return (
     <span
       title={title ?? (typeof label === 'string' ? label : undefined)}
-      className={`inline-flex w-fit max-w-full shrink-0 items-center gap-1.5 overflow-hidden whitespace-nowrap rounded-full! border! px-2.5 py-[3px] text-[10px] leading-[normal] font-bold uppercase tracking-[0.08em] ${
+      className={`yc-status-pill inline-flex w-fit max-w-full shrink-0 items-center gap-1.5 overflow-hidden whitespace-nowrap rounded-full! border! px-2.5 py-[3px] text-[10px] leading-[normal] font-bold uppercase tracking-[0.08em] ${
         className ?? ''
       }`}
       style={{

--- a/apps/frontend/src/app/ui/tables/GenericTable/Generictable.css
+++ b/apps/frontend/src/app/ui/tables/GenericTable/Generictable.css
@@ -100,3 +100,12 @@
   line-height: 120%;
   opacity: 60%;
 }
+.TableDiv tbody tr td span.yc-status-pill,
+.TableDiv tbody tr td .yc-status-pill span {
+  font-family: var(--font-satoshi) !important;
+  font-size: 10px !important;
+  font-weight: 700 !important;
+  line-height: normal !important;
+  letter-spacing: 0.08em !important;
+  opacity: 1 !important;
+}

--- a/apps/frontend/src/app/ui/tables/GenericTable/Generictable.css
+++ b/apps/frontend/src/app/ui/tables/GenericTable/Generictable.css
@@ -91,7 +91,9 @@
   tbody
   tr
   td
-  span:not(a span):not(button span):not(.glass-tooltip):not(.glass-tooltip span) {
+  span:not(a span):not(button span):not(.glass-tooltip):not(.glass-tooltip span):not(
+    .yc-status-pill
+  ):not(.yc-status-pill span) {
   margin: 0px;
   font-family: var(--satoshi-font);
   color: var(--black-text);

--- a/apps/frontend/src/app/ui/tables/appointmentsTableColumns.tsx
+++ b/apps/frontend/src/app/ui/tables/appointmentsTableColumns.tsx
@@ -154,12 +154,7 @@ export const buildAppointmentColumns = ({
           {roomDisplay.unitLabel && (
             <div className="appointment-profile-sub text-[12px]">{roomDisplay.unitLabel}</div>
           )}
-          <AppointmentModePill
-            appointment={item}
-            className="mt-1 h-6 w-fit px-2.5 text-[10px]"
-            iconSize={12}
-            tone="strong"
-          />
+          <AppointmentModePill appointment={item} className="mt-1" iconSize={12} tone="strong" />
         </div>
       );
     },


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

Status pills were visually inconsistent across full-screen table views. Inventory and dispensary used the correct compact pill styling, while screens like dashboard, appointments, IDEXX, tasks, patients, templates, and finance could render larger or differently styled pills because local table/span styles overrode the shared pill appearance.

## What is the new behavior?

Status pills now use the shared inventory/dispensary pill styling consistently across responsive cards and full-screen table views. The shared `StatusPill` keeps the compact uppercase pill geometry, typography, border, and theme-aware color tokens, with regression coverage for the affected table surfaces.

## Related Issue(s)

Fixes #