### PR TITLE
fix(repo): correct dispense stock deduction and finance avatar contrast

### DIFF
--- a/apps/backend/src/services/inventory-consumption.service.ts
+++ b/apps/backend/src/services/inventory-consumption.service.ts
@@ -246,12 +246,7 @@ const resolveDurationInDays = (item: {
   durationUnit?: unknown;
   metadata?: unknown;
 }) => {
-  const normalizedDurationDays = readPositiveInteger(item.durationDays);
-  if (normalizedDurationDays !== undefined) {
-    return normalizedDurationDays;
-  }
-
-  const durationText = item.duration ?? item.days;
+  const durationText = item.duration ?? item.days ?? item.durationDays;
   const rawDuration = readPositiveInteger(durationText);
   if (rawDuration === undefined) {
     return undefined;
@@ -290,6 +285,43 @@ const resolveFrequencyPerDay = (frequency?: string | null) => {
   };
   if (Object.prototype.hasOwnProperty.call(directMap, normalized)) {
     return directMap[normalized];
+  }
+
+  if (
+    normalized.includes("SID") ||
+    (normalized.includes("ONCE") && !normalized.includes("WEEKLY"))
+  ) {
+    return 1;
+  }
+  if (normalized.includes("BID") || normalized.includes("TWICE")) {
+    return 2;
+  }
+  if (
+    normalized.includes("TID") ||
+    normalized.includes("THREE TIMES") ||
+    normalized.includes("THRICE")
+  ) {
+    return 3;
+  }
+  if (normalized.includes("QID") || normalized.includes("FOUR TIMES")) {
+    return 4;
+  }
+  if (normalized.includes("ONCE WEEKLY") || normalized.includes("WEEKLY")) {
+    return 1 / 7;
+  }
+  if (
+    normalized.includes("BEFORE MEALS") ||
+    normalized.includes("AFTER MEALS")
+  ) {
+    return 3;
+  }
+
+  const everyHoursText = /EVERY\s+(\d+)\s+HOURS?/.exec(normalized);
+  if (everyHoursText) {
+    const hours = Number(everyHoursText[1]);
+    if (Number.isFinite(hours) && hours > 0) {
+      return Math.max(1, Math.ceil(24 / hours));
+    }
   }
 
   const everyNhours = /^Q(\d+)H$/.exec(normalized);
@@ -707,7 +739,12 @@ const enrichDispenseRequestMedications = async (
       asNonEmptyString(item.name);
     const frequency = asNonEmptyString(item.frequency ?? item.freq);
     const doseParts = readDoseParts(item.dosage ?? item.dose);
-    const durationDays = resolveDurationInDays(item);
+    const rawDurationDays = readPositiveInteger(
+      item.durationDays ?? item.duration ?? item.days,
+    );
+    const durationInDays = resolveDurationInDays(item);
+    const durationDays =
+      durationInDays === undefined ? undefined : rawDurationDays;
     const refillsRemaining =
       readPositiveInteger(item.refillsRemaining) ??
       readPositiveInteger(item.refill);
@@ -729,8 +766,8 @@ const enrichDispenseRequestMedications = async (
       ) ??
       (doseQty !== undefined &&
       frequencyPerDay !== undefined &&
-      durationDays !== undefined
-        ? Math.max(1, Math.ceil(doseQty * frequencyPerDay * durationDays))
+      durationInDays !== undefined
+        ? Math.max(1, Math.ceil(doseQty * frequencyPerDay * durationInDays))
         : undefined);
 
     return {

--- a/apps/backend/src/services/inventory-consumption.service.ts
+++ b/apps/backend/src/services/inventory-consumption.service.ts
@@ -204,16 +204,19 @@ const readDoseParts = (
  * days, weeks and months), so the raw value is not a day count. Multiplying a
  * weekly duration as if it were days under-dispenses the course.
  */
-const DURATION_UNIT_IN_DAYS: Record<string, number> = {
-  DAY: 1,
-  DAYS: 1,
-  D: 1,
-  WEEK: 7,
-  WEEKS: 7,
-  W: 7,
-  MONTH: 30,
-  MONTHS: 30,
-  M: 30,
+const DURATION_UNIT_DEFINITIONS: Record<
+  string,
+  { label: "days" | "weeks" | "months"; multiplier: number }
+> = {
+  DAY: { label: "days", multiplier: 1 },
+  DAYS: { label: "days", multiplier: 1 },
+  D: { label: "days", multiplier: 1 },
+  WEEK: { label: "weeks", multiplier: 7 },
+  WEEKS: { label: "weeks", multiplier: 7 },
+  W: { label: "weeks", multiplier: 7 },
+  MONTH: { label: "months", multiplier: 30 },
+  MONTHS: { label: "months", multiplier: 30 },
+  M: { label: "months", multiplier: 30 },
 };
 
 /**
@@ -239,18 +242,8 @@ const readDurationUnit = (
   return match?.[1]?.toUpperCase();
 };
 
-const toDurationUnitLabel = (unit: string): string | undefined => {
-  if (unit === "DAY" || unit === "DAYS" || unit === "D") {
-    return "days";
-  }
-  if (unit === "WEEK" || unit === "WEEKS" || unit === "W") {
-    return "weeks";
-  }
-  if (unit === "MONTH" || unit === "MONTHS" || unit === "M") {
-    return "months";
-  }
-  return undefined;
-};
+const getDurationUnitDefinition = (unit: string | undefined) =>
+  unit ? DURATION_UNIT_DEFINITIONS[unit] : undefined;
 
 const resolveDurationInDays = (item: {
   durationDays?: unknown;
@@ -274,8 +267,10 @@ const resolveDurationInDays = (item: {
     return rawDuration;
   }
 
-  const multiplier = DURATION_UNIT_IN_DAYS[unit];
-  return multiplier === undefined ? undefined : rawDuration * multiplier;
+  const unitDefinition = getDurationUnitDefinition(unit);
+  return unitDefinition === undefined
+    ? undefined
+    : rawDuration * unitDefinition.multiplier;
 };
 
 const resolveDurationUnitLabel = (item: {
@@ -290,7 +285,7 @@ const resolveDurationUnitLabel = (item: {
     item.durationUnit ?? metadata.durationUnit,
     item.duration ?? item.days ?? item.durationDays,
   );
-  return unit ? toDurationUnitLabel(unit) : undefined;
+  return getDurationUnitDefinition(unit)?.label;
 };
 
 const resolveFrequencyPerDay = (frequency?: string | null) => {

--- a/apps/backend/src/services/inventory-consumption.service.ts
+++ b/apps/backend/src/services/inventory-consumption.service.ts
@@ -239,6 +239,19 @@ const readDurationUnit = (
   return match?.[1]?.toUpperCase();
 };
 
+const toDurationUnitLabel = (unit: string): string | undefined => {
+  if (unit === "DAY" || unit === "DAYS" || unit === "D") {
+    return "days";
+  }
+  if (unit === "WEEK" || unit === "WEEKS" || unit === "W") {
+    return "weeks";
+  }
+  if (unit === "MONTH" || unit === "MONTHS" || unit === "M") {
+    return "months";
+  }
+  return undefined;
+};
+
 const resolveDurationInDays = (item: {
   durationDays?: unknown;
   duration?: unknown;
@@ -263,6 +276,21 @@ const resolveDurationInDays = (item: {
 
   const multiplier = DURATION_UNIT_IN_DAYS[unit];
   return multiplier === undefined ? undefined : rawDuration * multiplier;
+};
+
+const resolveDurationUnitLabel = (item: {
+  durationDays?: unknown;
+  duration?: unknown;
+  days?: unknown;
+  durationUnit?: unknown;
+  metadata?: unknown;
+}) => {
+  const metadata = toRecord(item.metadata);
+  const unit = readDurationUnit(
+    item.durationUnit ?? metadata.durationUnit,
+    item.duration ?? item.days ?? item.durationDays,
+  );
+  return unit ? toDurationUnitLabel(unit) : undefined;
 };
 
 const resolveFrequencyPerDay = (frequency?: string | null) => {
@@ -745,6 +773,14 @@ const enrichDispenseRequestMedications = async (
     const durationInDays = resolveDurationInDays(item);
     const durationDays =
       durationInDays === undefined ? undefined : rawDurationDays;
+    const metadataDurationUnit = resolveDurationUnitLabel(item);
+    const metadata =
+      metadataDurationUnit === undefined
+        ? item.metadata
+        : {
+            ...toRecord(item.metadata),
+            durationUnit: metadataDurationUnit,
+          };
     const refillsRemaining =
       readPositiveInteger(item.refillsRemaining) ??
       readPositiveInteger(item.refill);
@@ -772,6 +808,7 @@ const enrichDispenseRequestMedications = async (
 
     return {
       ...item,
+      metadata,
       inventoryItemName:
         inventoryItem?.name ??
         asNonEmptyString(item.inventoryItemName) ??

--- a/apps/backend/src/services/inventory-consumption.service.ts
+++ b/apps/backend/src/services/inventory-consumption.service.ts
@@ -244,6 +244,7 @@ const resolveDurationInDays = (item: {
   duration?: unknown;
   days?: unknown;
   durationUnit?: unknown;
+  metadata?: unknown;
 }) => {
   const durationText = item.durationDays ?? item.duration ?? item.days;
   const rawDuration =
@@ -253,7 +254,11 @@ const resolveDurationInDays = (item: {
     return undefined;
   }
 
-  const unit = readDurationUnit(item.durationUnit, durationText);
+  const metadata = toRecord(item.metadata);
+  const unit = readDurationUnit(
+    item.durationUnit ?? metadata.durationUnit,
+    durationText,
+  );
   if (!unit) {
     return rawDuration;
   }

--- a/apps/backend/src/services/inventory-consumption.service.ts
+++ b/apps/backend/src/services/inventory-consumption.service.ts
@@ -246,10 +246,13 @@ const resolveDurationInDays = (item: {
   durationUnit?: unknown;
   metadata?: unknown;
 }) => {
-  const durationText = item.durationDays ?? item.duration ?? item.days;
-  const rawDuration =
-    readPositiveInteger(item.durationDays) ??
-    readPositiveInteger(item.duration ?? item.days);
+  const normalizedDurationDays = readPositiveInteger(item.durationDays);
+  if (normalizedDurationDays !== undefined) {
+    return normalizedDurationDays;
+  }
+
+  const durationText = item.duration ?? item.days;
+  const rawDuration = readPositiveInteger(durationText);
   if (rawDuration === undefined) {
     return undefined;
   }

--- a/apps/backend/test/services/inventory-consumption.service.test.ts
+++ b/apps/backend/test/services/inventory-consumption.service.test.ts
@@ -1102,10 +1102,7 @@ describe("InventoryConsumptionService", () => {
           inventoryItemId: "item-created-duration",
           quantity: 2,
           frequency: "BID",
-          duration: "3",
-          metadata: {
-            durationUnit: "weeks",
-          },
+          duration: "3 weeks",
           sourceLineKey: "line-created-duration",
         },
       ],

--- a/apps/backend/test/services/inventory-consumption.service.test.ts
+++ b/apps/backend/test/services/inventory-consumption.service.test.ts
@@ -994,6 +994,73 @@ describe("InventoryConsumptionService", () => {
     );
   });
 
+  it("honors durationUnit stored in prescription metadata when approving a dispense request", async () => {
+    mockedPrisma.prescriptionDispenseRequest.findFirst.mockResolvedValueOnce({
+      id: "request-metadata-duration",
+      prescriptionId: "rx-metadata-duration",
+      organisationId: "org-1",
+      status: "PENDING",
+      medications: [
+        {
+          inventoryItemId: "item-metadata-duration",
+          quantity: 2,
+          frequency: "BID",
+          duration: "3",
+          metadata: {
+            durationUnit: "weeks",
+          },
+          stockUnitQuantity: 15,
+          stockUnitQty: 15,
+          sourceLineKey: "line-1",
+        },
+      ],
+      metadata: {
+        appointmentKind: "INPATIENT",
+        dispenseStockSource: "ALLOCATED",
+      },
+    });
+    mockedPrisma.inventoryItem.findFirst.mockResolvedValueOnce({
+      id: "item-metadata-duration",
+      organisationId: "org-1",
+      onHand: 20,
+      allocated: 20,
+    });
+    mockedPrisma.inventoryBatch.findMany
+      .mockResolvedValueOnce([
+        { id: "batch-metadata-duration", quantity: 20, allocated: 0 },
+      ])
+      .mockResolvedValueOnce([
+        { id: "batch-metadata-duration", quantity: 14, allocated: 0 },
+      ]);
+    mockedPrisma.inventoryBatch.update.mockResolvedValue({});
+    mockedPrisma.inventoryStockMovement.create.mockResolvedValue({});
+    mockedPrisma.inventoryItem.update.mockResolvedValue({});
+    mockedPrisma.inventoryConsumptionEvent.create.mockResolvedValue({
+      id: "event-metadata-duration",
+    });
+    mockedPrisma.prescriptionDispenseRequest.update.mockResolvedValueOnce({
+      id: "request-metadata-duration",
+      prescriptionId: "rx-metadata-duration",
+      organisationId: "org-1",
+      status: "DISPENSED",
+    });
+
+    const events =
+      await InventoryConsumptionService.approvePrescriptionDispenseRequest({
+        organisationId: "org-1",
+        prescriptionId: "rx-metadata-duration",
+        medications: [],
+        reviewedBy: "user-1",
+      });
+
+    expect(events).toHaveLength(1);
+    expect(mockedPrisma.inventoryItem.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { onHand: 14, allocated: 14 },
+      }),
+    );
+  });
+
   it("returns null when a dispense request is not found for not-dispensed", async () => {
     mockedPrisma.prescriptionDispenseRequest.findFirst.mockResolvedValueOnce(
       null,

--- a/apps/backend/test/services/inventory-consumption.service.test.ts
+++ b/apps/backend/test/services/inventory-consumption.service.test.ts
@@ -1061,6 +1061,128 @@ describe("InventoryConsumptionService", () => {
     );
   });
 
+  it("does not reapply metadata duration units when approving a created dispense request", async () => {
+    mockedPrisma.inventoryItem.findMany.mockResolvedValueOnce([
+      {
+        id: "item-created-duration",
+        sku: "created-duration",
+        name: "Created Duration Medicine",
+        stockUnitType: "strip",
+        unitOfMeasure: "tablet",
+        packageQuantity: 15,
+        sellingPrice: 12.34,
+        unitCost: 8.5,
+        prescriptionRequired: true,
+        controlledItem: false,
+      },
+    ]);
+    mockedPrisma.prescriptionDispenseRequest.findFirst.mockResolvedValueOnce(
+      null,
+    );
+    mockedPrisma.prescriptionDispenseRequest.create.mockResolvedValueOnce({
+      id: "request-created-duration",
+      prescriptionId: "rx-created-duration",
+      organisationId: "org-1",
+      status: "PENDING",
+      medications: [],
+      metadata: null,
+      requestedBy: "user-1",
+      reviewedBy: null,
+      reviewedAt: null,
+      requestedAt: new Date("2026-01-01T00:00:00.000Z"),
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    });
+
+    await InventoryConsumptionService.createPrescriptionDispenseRequest({
+      organisationId: "org-1",
+      prescriptionId: "rx-created-duration",
+      medications: [
+        {
+          inventoryItemId: "item-created-duration",
+          quantity: 2,
+          frequency: "BID",
+          duration: "3",
+          metadata: {
+            durationUnit: "weeks",
+          },
+          sourceLineKey: "line-created-duration",
+        },
+      ],
+      requestedBy: "user-1",
+    });
+
+    const createdRequest = mockedPrisma.prescriptionDispenseRequest.create.mock
+      .calls[0][0] as {
+      data: {
+        medications: Record<string, unknown>[];
+        metadata: Record<string, unknown>;
+      };
+    };
+
+    expect(createdRequest.data.medications[0]).toEqual(
+      expect.objectContaining({
+        quantity: 2,
+        durationDays: 21,
+        metadata: { durationUnit: "weeks" },
+      }),
+    );
+
+    mockedPrisma.prescriptionDispenseRequest.findFirst.mockResolvedValueOnce({
+      id: "request-created-duration",
+      prescriptionId: "rx-created-duration",
+      organisationId: "org-1",
+      status: "PENDING",
+      medications: createdRequest.data.medications,
+      metadata: createdRequest.data.metadata,
+    });
+    mockedPrisma.inventoryItem.findFirst.mockResolvedValueOnce({
+      id: "item-created-duration",
+      organisationId: "org-1",
+      onHand: 50,
+      allocated: 0,
+    });
+    mockedPrisma.inventoryBatch.findMany
+      .mockResolvedValueOnce([
+        { id: "batch-created-duration", quantity: 50, allocated: 0 },
+      ])
+      .mockResolvedValueOnce([
+        { id: "batch-created-duration", quantity: 44, allocated: 0 },
+      ]);
+    mockedPrisma.inventoryBatch.update.mockResolvedValue({});
+    mockedPrisma.inventoryStockMovement.create.mockResolvedValue({});
+    mockedPrisma.inventoryItem.update.mockResolvedValue({});
+    mockedPrisma.inventoryConsumptionEvent.create.mockResolvedValue({
+      id: "event-created-duration",
+    });
+    mockedPrisma.prescriptionDispenseRequest.update.mockResolvedValueOnce({
+      id: "request-created-duration",
+      prescriptionId: "rx-created-duration",
+      organisationId: "org-1",
+      status: "DISPENSED",
+    });
+
+    const events =
+      await InventoryConsumptionService.approvePrescriptionDispenseRequest({
+        organisationId: "org-1",
+        prescriptionId: "rx-created-duration",
+        medications: [],
+        reviewedBy: "user-1",
+      });
+
+    expect(events).toHaveLength(1);
+    expect(mockedPrisma.inventoryStockMovement.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ change: -6 }),
+      }),
+    );
+    expect(mockedPrisma.inventoryItem.update).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        data: { onHand: 44 },
+      }),
+    );
+  });
+
   it("returns null when a dispense request is not found for not-dispensed", async () => {
     mockedPrisma.prescriptionDispenseRequest.findFirst.mockResolvedValueOnce(
       null,

--- a/apps/backend/test/services/inventory-consumption.service.test.ts
+++ b/apps/backend/test/services/inventory-consumption.service.test.ts
@@ -1061,7 +1061,7 @@ describe("InventoryConsumptionService", () => {
     );
   });
 
-  it("does not reapply metadata duration units when approving a created dispense request", async () => {
+  it("matches the dispensary modal duration calculation when approving a created request", async () => {
     mockedPrisma.inventoryItem.findMany.mockResolvedValueOnce([
       {
         id: "item-created-duration",
@@ -1123,7 +1123,7 @@ describe("InventoryConsumptionService", () => {
     expect(createdRequest.data.medications[0]).toEqual(
       expect.objectContaining({
         quantity: 2,
-        durationDays: 21,
+        durationDays: 3,
         metadata: { durationUnit: "weeks" },
       }),
     );
@@ -1179,6 +1179,79 @@ describe("InventoryConsumptionService", () => {
     expect(mockedPrisma.inventoryItem.update).toHaveBeenLastCalledWith(
       expect.objectContaining({
         data: { onHand: 44 },
+      }),
+    );
+  });
+
+  it("matches the dispensary modal calculation for descriptive frequency labels", async () => {
+    mockedPrisma.prescriptionDispenseRequest.findFirst.mockResolvedValueOnce({
+      id: "request-modal-frequency",
+      prescriptionId: "rx-modal-frequency",
+      organisationId: "org-1",
+      status: "PENDING",
+      medications: [
+        {
+          inventoryItemId: "item-modal-frequency",
+          inventoryItemName: "Enterogermina",
+          quantity: 1,
+          frequency: "TID (three times daily)",
+          durationDays: 6,
+          metadata: {
+            durationUnit: "days",
+          },
+          stockUnitQuantity: 4,
+          stockUnitQty: 4,
+          sourceLineKey: "line-modal-frequency",
+        },
+      ],
+      metadata: {
+        appointmentKind: "INPATIENT",
+        dispenseStockSource: "ALLOCATED",
+      },
+    });
+    mockedPrisma.inventoryItem.findFirst.mockResolvedValueOnce({
+      id: "item-modal-frequency",
+      organisationId: "org-1",
+      onHand: 20,
+      allocated: 20,
+    });
+    mockedPrisma.inventoryBatch.findMany
+      .mockResolvedValueOnce([
+        { id: "batch-modal-frequency", quantity: 20, allocated: 0 },
+      ])
+      .mockResolvedValueOnce([
+        { id: "batch-modal-frequency", quantity: 15, allocated: 0 },
+      ]);
+    mockedPrisma.inventoryBatch.update.mockResolvedValue({});
+    mockedPrisma.inventoryStockMovement.create.mockResolvedValue({});
+    mockedPrisma.inventoryItem.update.mockResolvedValue({});
+    mockedPrisma.inventoryConsumptionEvent.create.mockResolvedValue({
+      id: "event-modal-frequency",
+    });
+    mockedPrisma.prescriptionDispenseRequest.update.mockResolvedValueOnce({
+      id: "request-modal-frequency",
+      prescriptionId: "rx-modal-frequency",
+      organisationId: "org-1",
+      status: "DISPENSED",
+    });
+
+    const events =
+      await InventoryConsumptionService.approvePrescriptionDispenseRequest({
+        organisationId: "org-1",
+        prescriptionId: "rx-modal-frequency",
+        medications: [],
+        reviewedBy: "user-1",
+      });
+
+    expect(events).toHaveLength(1);
+    expect(mockedPrisma.inventoryStockMovement.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ change: -5 }),
+      }),
+    );
+    expect(mockedPrisma.inventoryItem.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { onHand: 15, allocated: 15 },
       }),
     );
   });

--- a/apps/frontend/src/app/__tests__/components/DataTable/InvoiceTable.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/DataTable/InvoiceTable.test.tsx
@@ -26,7 +26,11 @@ jest.mock('next/navigation', () => ({
 
 jest.mock('next/image', () => ({
   __esModule: true,
-  default: ({ alt }: any) => <span data-testid="companion-avatar">{alt}</span>,
+  default: ({ alt, className }: any) => (
+    <span data-testid="companion-avatar" className={className}>
+      {alt}
+    </span>
+  ),
 }));
 
 const mockGenericTableCalls: { columns: any[]; tableClassName?: string }[] = [];
@@ -144,6 +148,7 @@ describe('InvoiceTable', () => {
 
     expect(desktop.getByText('Sam / Buddy')).toBeInTheDocument();
     expect(desktop.getByText('#inv-1')).toBeInTheDocument();
+    expect(desktop.getByTestId('companion-avatar').parentElement?.tagName).toBe('DIV');
     // Design's date cell is one muted line — the time rides the identity
     // sub-line, so it is not repeated here.
     const dateCell = desktop.getByRole('button', { name: 'Open finance details for Buddy' });

--- a/apps/frontend/src/app/ui/tables/InvoiceTable.tsx
+++ b/apps/frontend/src/app/ui/tables/InvoiceTable.tsx
@@ -175,7 +175,7 @@ const InvoiceTable = ({ filteredList, setActiveInvoice, setViewInvoice }: Invoic
     const avatarPalette = getAvatarPalette(companion?.id || companionName);
     return (
       <div className="appointment-profile flex items-center gap-2.5">
-        <span
+        <div
           className="flex size-[30px] shrink-0 overflow-hidden rounded-full"
           style={{ background: avatarPalette.bg }}
         >
@@ -186,7 +186,7 @@ const InvoiceTable = ({ filteredList, setActiveInvoice, setViewInvoice }: Invoic
             height={30}
             className="size-[30px] rounded-full object-cover"
           />
-        </span>
+        </div>
         <div className="appointment-profile-two min-w-0">
           <div className="appointment-profile-title cell-name truncate" title={ownerAndCompanion}>
             {ownerAndCompanion}


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

Dispensing a prescription from Inventory → Dispensary can deduct the wrong stock amount from Inventory Catalog. Prescriptions with a duration unit saved in metadata, such as `3 weeks`, are treated by backend stock consumption as only `3 days`, so on-hand and allocated stock can drop by only `1` pack/strip instead of the full calculated dispense amount.

On the Finance page, the patient avatar in the Parent / Patient column can appear faded because the invoice table renders the avatar wrapper as a plain `span`, which is affected by the table’s generic span opacity styling.

## What is the new behavior?

Backend stock consumption now reads the prescription duration unit from medication metadata when approving dispense requests. The stock deduction now matches the dispense quantity shown in the modal, including multi-week prescriptions and pack/strip conversion.

The Finance table now keeps the Parent / Patient avatar at full opacity by avoiding the generic table span opacity rule.

## Related Issue(s)

Fixes #1880  
Fixes #1941