### PR TITLE
fix(repo): correct prescription dispense quantity and appointment grouping

### DIFF
--- a/apps/backend/src/controllers/web/clinical-artifact.fhir.controller.ts
+++ b/apps/backend/src/controllers/web/clinical-artifact.fhir.controller.ts
@@ -258,6 +258,7 @@ export const ClinicalArtifactFhirController = {
           authorId,
           organisationId: req.params.organisationId,
         }),
+        actor,
       );
       return res
         .status(201)

--- a/apps/backend/src/services/clinical-artifact.service.ts
+++ b/apps/backend/src/services/clinical-artifact.service.ts
@@ -1257,12 +1257,77 @@ const prescriptionCreateInputToUpdateInput = (
 });
 
 type PrescriptionCreateOrReuseResult =
-  | { kind: "reused"; prescription: PrescriptionWithArtifact }
+  | {
+      kind: "reused";
+      record: PrescriptionRecord;
+      previousStatus: ClinicalArtifactStatus;
+    }
   | { kind: "created"; record: PrescriptionRecord };
 
 const isPrismaTransactionWriteConflict = (error: unknown) =>
   error instanceof Prisma.PrismaClientKnownRequestError &&
   error.code === "P2034";
+
+const updatePrescriptionRecordInTransaction = async (
+  txPrisma: ClinicalPrisma,
+  record: PrescriptionWithArtifact,
+  input: PrescriptionUpdateInput,
+) => {
+  const hasPrescriptionItemUpdates =
+    input.items !== undefined || input.medications !== undefined;
+  const prescriptionItems = hasPrescriptionItemUpdates
+    ? normalizePrescriptionItemInputs(input.items ?? input.medications)
+    : [];
+  const artifact = await txPrisma.clinicalArtifact.update({
+    where: { id: record.artifact.id },
+    data: {
+      status: input.status ?? record.artifact.status,
+      appointmentId:
+        input.appointmentId === undefined || record.artifact.appointmentId
+          ? undefined
+          : input.appointmentId,
+      caseId:
+        input.caseId === undefined || record.artifact.caseId
+          ? undefined
+          : input.caseId,
+      encounterId:
+        input.encounterId === undefined || record.artifact.encounterId
+          ? undefined
+          : input.encounterId,
+      summary:
+        input.summary === undefined
+          ? record.artifact.summary
+          : toNullableString(input.summary),
+    },
+  });
+
+  const prescription = await txPrisma.prescription.update({
+    where: { id: record.id },
+    data: {
+      items: hasPrescriptionItemUpdates
+        ? {
+            deleteMany: {},
+            create: prescriptionItemRowsToCreate(prescriptionItems),
+          }
+        : undefined,
+      instructions:
+        input.instructions === undefined
+          ? toNullableJsonInput(record.instructions)
+          : toNullableJsonInput(input.instructions),
+      notes:
+        input.notes === undefined
+          ? toNullableJsonInput(record.notes)
+          : toNullableJsonInput(input.notes),
+      metadata:
+        input.metadata === undefined
+          ? toNullableJsonInput(record.metadata)
+          : toNullableJsonInput(input.metadata),
+    },
+    include: { items: true },
+  });
+
+  return buildPrescriptionRecord(artifact, prescription);
+};
 
 export const ClinicalArtifactService = {
   async createSoapNote(input: SoapNoteInput): Promise<SoapNoteRecord> {
@@ -1479,6 +1544,16 @@ export const ClinicalArtifactService = {
             const reusablePrescription = reusablePrescriptions[0];
 
             if (reusablePrescription) {
+              const reuseActor = actor ?? {
+                actorId:
+                  input.authorId ??
+                  reusablePrescription.artifact.authorId ??
+                  "",
+                canEditAny: true,
+              };
+              reusablePrescriptions.forEach((prescription) =>
+                assertActorMayMutateArtifact(prescription.artifact, reuseActor),
+              );
               const staleArtifactIds = reusablePrescriptions
                 .slice(1)
                 .map((prescription) => prescription.artifact.id);
@@ -1489,9 +1564,20 @@ export const ClinicalArtifactService = {
                 });
               }
 
+              const updatedPrescription =
+                await updatePrescriptionRecordInTransaction(
+                  txPrisma,
+                  reusablePrescription,
+                  prescriptionCreateInputToUpdateInput(
+                    input,
+                    reusablePrescription.artifact.status,
+                  ),
+                );
+
               return {
                 kind: "reused",
-                prescription: reusablePrescription,
+                record: updatedPrescription,
+                previousStatus: reusablePrescription.artifact.status,
               };
             }
 
@@ -1564,27 +1650,43 @@ export const ClinicalArtifactService = {
       result = await createOrReusePrescription();
     }
 
-    if (result.kind === "reused") {
-      const reusablePrescription = result.prescription;
-      return ClinicalArtifactService.updatePrescription(
-        reusablePrescription.id,
-        prescriptionCreateInputToUpdateInput(
-          input,
-          reusablePrescription.artifact.status,
-        ),
-        organisationId,
-        actor ?? {
-          actorId:
-            input.authorId ?? reusablePrescription.artifact.authorId ?? "",
-          canEditAny: true,
-        },
-      );
-    }
-
     const artifact = result.record;
 
     if (DOCUMENT_BACKED_CLINICAL_KINDS.has(artifact.artifact.kind)) {
       await persistClinicalArtifactRenderedDocumentPdf(artifact.artifact.id);
+    }
+
+    if (result.kind === "reused") {
+      const wasPendingDispenseRequest =
+        shouldCreateDispenseRequestForPrescription(result.previousStatus);
+      const isPendingDispenseRequest =
+        shouldCreateDispenseRequestForPrescription(artifact.artifact.status);
+
+      if (!wasPendingDispenseRequest && isPendingDispenseRequest) {
+        await InventoryConsumptionService.createPrescriptionDispenseRequest({
+          organisationId: artifact.artifact.organisationId,
+          prescriptionId: artifact.prescription.id,
+          medications: artifact.prescription.medications,
+          metadata: artifact.prescription.metadata as
+            Prisma.InputJsonValue | undefined,
+          requestedBy: artifact.artifact.authorId,
+          context: {
+            appointmentId: artifact.artifact.appointmentId,
+            encounterId: artifact.artifact.encounterId,
+          },
+        });
+      } else if (wasPendingDispenseRequest && !isPendingDispenseRequest) {
+        await InventoryConsumptionService.markPrescriptionDispenseRequestNotDispensed(
+          {
+            organisationId: artifact.artifact.organisationId,
+            prescriptionId: artifact.prescription.id,
+            metadata: artifact.prescription.metadata as
+              Prisma.InputJsonValue | undefined,
+          },
+        );
+      }
+
+      return artifact;
     }
 
     if (shouldCreateDispenseRequestForPrescription(artifact.artifact.status)) {
@@ -1639,60 +1741,7 @@ export const ClinicalArtifactService = {
 
     const updated = await prisma.$transaction(async (tx) => {
       const txPrisma = tx as ClinicalPrisma;
-      const hasPrescriptionItemUpdates =
-        input.items !== undefined || input.medications !== undefined;
-      const prescriptionItems = hasPrescriptionItemUpdates
-        ? normalizePrescriptionItemInputs(input.items ?? input.medications)
-        : [];
-      const artifact = await txPrisma.clinicalArtifact.update({
-        where: { id: record.artifact.id },
-        data: {
-          status: input.status ?? record.artifact.status,
-          appointmentId:
-            input.appointmentId === undefined || record.artifact.appointmentId
-              ? undefined
-              : input.appointmentId,
-          caseId:
-            input.caseId === undefined || record.artifact.caseId
-              ? undefined
-              : input.caseId,
-          encounterId:
-            input.encounterId === undefined || record.artifact.encounterId
-              ? undefined
-              : input.encounterId,
-          summary:
-            input.summary === undefined
-              ? record.artifact.summary
-              : toNullableString(input.summary),
-        },
-      });
-
-      const prescription = await txPrisma.prescription.update({
-        where: { id: record.id },
-        data: {
-          items: hasPrescriptionItemUpdates
-            ? {
-                deleteMany: {},
-                create: prescriptionItemRowsToCreate(prescriptionItems),
-              }
-            : undefined,
-          instructions:
-            input.instructions === undefined
-              ? toNullableJsonInput(record.instructions)
-              : toNullableJsonInput(input.instructions),
-          notes:
-            input.notes === undefined
-              ? toNullableJsonInput(record.notes)
-              : toNullableJsonInput(input.notes),
-          metadata:
-            input.metadata === undefined
-              ? toNullableJsonInput(record.metadata)
-              : toNullableJsonInput(input.metadata),
-        },
-        include: { items: true },
-      });
-
-      return buildPrescriptionRecord(artifact, prescription);
+      return updatePrescriptionRecordInTransaction(txPrisma, record, input);
     });
 
     if (DOCUMENT_BACKED_CLINICAL_KINDS.has(updated.artifact.kind)) {

--- a/apps/backend/src/services/clinical-artifact.service.ts
+++ b/apps/backend/src/services/clinical-artifact.service.ts
@@ -1217,12 +1217,13 @@ const advanceCheckedInAppointment = async (
 const findReusablePrescriptionForAppointment = async (
   organisationId: string,
   appointmentId?: string,
+  client: ClinicalPrisma = clinicalPrisma,
 ) => {
   if (!appointmentId) {
     return null;
   }
 
-  return clinicalPrisma.prescription.findFirst({
+  return client.prescription.findFirst({
     where: {
       artifact: {
         organisationId,
@@ -1248,6 +1249,14 @@ const prescriptionCreateInputToUpdateInput = (
   notes: input.notes,
   metadata: input.metadata,
 });
+
+type PrescriptionCreateOrReuseResult =
+  | { kind: "reused"; prescription: PrescriptionWithArtifact }
+  | { kind: "created"; record: PrescriptionRecord };
+
+const isPrismaTransactionWriteConflict = (error: unknown) =>
+  error instanceof Prisma.PrismaClientKnownRequestError &&
+  error.code === "P2034";
 
 export const ClinicalArtifactService = {
   async createSoapNote(input: SoapNoteInput): Promise<SoapNoteRecord> {
@@ -1444,14 +1453,102 @@ export const ClinicalArtifactService = {
 
   async createPrescription(
     input: PrescriptionInput,
+    actor?: PrescriptionActor,
   ): Promise<PrescriptionRecord> {
     const organisationId = ensureId(input.organisationId, "organisationId");
-    const reusablePrescription = await findReusablePrescriptionForAppointment(
-      organisationId,
-      input.appointmentId,
+    const prescriptionItems = normalizePrescriptionItemInputs(
+      input.items ?? input.medications,
     );
+    const createOrReusePrescription =
+      async (): Promise<PrescriptionCreateOrReuseResult> =>
+        prisma.$transaction(
+          async (tx) => {
+            const txPrisma = tx as ClinicalPrisma;
+            const reusablePrescription =
+              await findReusablePrescriptionForAppointment(
+                organisationId,
+                input.appointmentId,
+                txPrisma,
+              );
 
-    if (reusablePrescription) {
+            if (reusablePrescription) {
+              return {
+                kind: "reused",
+                prescription: reusablePrescription,
+              };
+            }
+
+            const createdArtifact = await txPrisma.clinicalArtifact.create({
+              data: {
+                organisationId,
+                appointmentId: input.appointmentId ?? undefined,
+                caseId: input.caseId ?? undefined,
+                encounterId: input.encounterId ?? undefined,
+                kind: "PRESCRIPTION",
+                status: input.status ?? "DRAFT",
+                templateId: input.templateId ?? undefined,
+                templateVersion: input.templateVersion ?? undefined,
+                templateVersionId: input.templateVersionId ?? undefined,
+                authorId: input.authorId ?? undefined,
+                summary: toNullableString(input.summary),
+              },
+            });
+
+            const createdPrescription = await txPrisma.prescription.create({
+              data: {
+                artifactId: createdArtifact.id,
+                items: {
+                  create: prescriptionItemRowsToCreate(prescriptionItems),
+                },
+                instructions: toNullableJsonInput(input.instructions),
+                notes: toNullableJsonInput(input.notes),
+                metadata: toNullableJsonInput(input.metadata),
+              },
+              include: { items: true },
+            });
+
+            await advanceCheckedInAppointment(txPrisma, {
+              organisationId,
+              appointmentId: input.appointmentId,
+            });
+
+            if (DOCUMENT_BACKED_CLINICAL_KINDS.has(createdArtifact.kind)) {
+              await createRenderedDocumentRecord(
+                buildClinicalArtifactRenderedDocumentInput({
+                  id: createdArtifact.id,
+                  organisationId: createdArtifact.organisationId,
+                  kind: createdArtifact.kind,
+                  templateId: createdArtifact.templateId,
+                  templateVersion: createdArtifact.templateVersion,
+                  templateVersionId: createdArtifact.templateVersionId,
+                }),
+                tx,
+              );
+            }
+
+            return {
+              kind: "created",
+              record: buildPrescriptionRecord(
+                createdArtifact,
+                createdPrescription,
+              ),
+            };
+          },
+          { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+        );
+
+    let result: PrescriptionCreateOrReuseResult;
+    try {
+      result = await createOrReusePrescription();
+    } catch (error) {
+      if (!isPrismaTransactionWriteConflict(error)) {
+        throw error;
+      }
+      result = await createOrReusePrescription();
+    }
+
+    if (result.kind === "reused") {
+      const reusablePrescription = result.prescription;
       return ClinicalArtifactService.updatePrescription(
         reusablePrescription.id,
         prescriptionCreateInputToUpdateInput(
@@ -1459,7 +1556,7 @@ export const ClinicalArtifactService = {
           reusablePrescription.artifact.status,
         ),
         organisationId,
-        {
+        actor ?? {
           actorId:
             input.authorId ?? reusablePrescription.artifact.authorId ?? "",
           canEditAny: true,
@@ -1467,61 +1564,7 @@ export const ClinicalArtifactService = {
       );
     }
 
-    const prescriptionItems = normalizePrescriptionItemInputs(
-      input.items ?? input.medications,
-    );
-    const artifact = await prisma.$transaction(async (tx) => {
-      const txPrisma = tx as ClinicalPrisma;
-      const createdArtifact = await txPrisma.clinicalArtifact.create({
-        data: {
-          organisationId,
-          appointmentId: input.appointmentId ?? undefined,
-          caseId: input.caseId ?? undefined,
-          encounterId: input.encounterId ?? undefined,
-          kind: "PRESCRIPTION",
-          status: input.status ?? "DRAFT",
-          templateId: input.templateId ?? undefined,
-          templateVersion: input.templateVersion ?? undefined,
-          templateVersionId: input.templateVersionId ?? undefined,
-          authorId: input.authorId ?? undefined,
-          summary: toNullableString(input.summary),
-        },
-      });
-
-      const createdPrescription = await txPrisma.prescription.create({
-        data: {
-          artifactId: createdArtifact.id,
-          items: {
-            create: prescriptionItemRowsToCreate(prescriptionItems),
-          },
-          instructions: toNullableJsonInput(input.instructions),
-          notes: toNullableJsonInput(input.notes),
-          metadata: toNullableJsonInput(input.metadata),
-        },
-        include: { items: true },
-      });
-
-      await advanceCheckedInAppointment(txPrisma, {
-        organisationId,
-        appointmentId: input.appointmentId,
-      });
-
-      if (DOCUMENT_BACKED_CLINICAL_KINDS.has(createdArtifact.kind)) {
-        await createRenderedDocumentRecord(
-          buildClinicalArtifactRenderedDocumentInput({
-            id: createdArtifact.id,
-            organisationId: createdArtifact.organisationId,
-            kind: createdArtifact.kind,
-            templateId: createdArtifact.templateId,
-            templateVersion: createdArtifact.templateVersion,
-            templateVersionId: createdArtifact.templateVersionId,
-          }),
-          tx,
-        );
-      }
-
-      return buildPrescriptionRecord(createdArtifact, createdPrescription);
-    });
+    const artifact = result.record;
 
     if (DOCUMENT_BACKED_CLINICAL_KINDS.has(artifact.artifact.kind)) {
       await persistClinicalArtifactRenderedDocumentPdf(artifact.artifact.id);

--- a/apps/backend/src/services/clinical-artifact.service.ts
+++ b/apps/backend/src/services/clinical-artifact.service.ts
@@ -407,6 +407,9 @@ export type PrescriptionUpdateInput = Partial<
   Pick<
     PrescriptionInput,
     | "status"
+    | "appointmentId"
+    | "caseId"
+    | "encounterId"
     | "summary"
     | "items"
     | "medications"
@@ -1214,16 +1217,16 @@ const advanceCheckedInAppointment = async (
   });
 };
 
-const findReusablePrescriptionForAppointment = async (
+const findReusablePrescriptionsForAppointment = async (
   organisationId: string,
   appointmentId?: string,
   client: ClinicalPrisma = clinicalPrisma,
 ) => {
   if (!appointmentId) {
-    return null;
+    return [];
   }
 
-  return client.prescription.findFirst({
+  return client.prescription.findMany({
     where: {
       artifact: {
         organisationId,
@@ -1242,6 +1245,9 @@ const prescriptionCreateInputToUpdateInput = (
   status: ClinicalArtifactStatus,
 ): PrescriptionUpdateInput => ({
   status: input.status ?? status,
+  appointmentId: input.appointmentId,
+  caseId: input.caseId,
+  encounterId: input.encounterId,
   summary: input.summary,
   items: input.items,
   medications: input.medications,
@@ -1464,14 +1470,25 @@ export const ClinicalArtifactService = {
         prisma.$transaction(
           async (tx) => {
             const txPrisma = tx as ClinicalPrisma;
-            const reusablePrescription =
-              await findReusablePrescriptionForAppointment(
+            const reusablePrescriptions =
+              await findReusablePrescriptionsForAppointment(
                 organisationId,
                 input.appointmentId,
                 txPrisma,
               );
+            const reusablePrescription = reusablePrescriptions[0];
 
             if (reusablePrescription) {
+              const staleArtifactIds = reusablePrescriptions
+                .slice(1)
+                .map((prescription) => prescription.artifact.id);
+              if (staleArtifactIds.length > 0) {
+                await txPrisma.clinicalArtifact.updateMany({
+                  where: { id: { in: staleArtifactIds } },
+                  data: { status: "VOID" },
+                });
+              }
+
               return {
                 kind: "reused",
                 prescription: reusablePrescription,
@@ -1631,6 +1648,18 @@ export const ClinicalArtifactService = {
         where: { id: record.artifact.id },
         data: {
           status: input.status ?? record.artifact.status,
+          appointmentId:
+            input.appointmentId === undefined || record.artifact.appointmentId
+              ? undefined
+              : input.appointmentId,
+          caseId:
+            input.caseId === undefined || record.artifact.caseId
+              ? undefined
+              : input.caseId,
+          encounterId:
+            input.encounterId === undefined || record.artifact.encounterId
+              ? undefined
+              : input.encounterId,
           summary:
             input.summary === undefined
               ? record.artifact.summary

--- a/apps/backend/src/services/clinical-artifact.service.ts
+++ b/apps/backend/src/services/clinical-artifact.service.ts
@@ -1214,6 +1214,41 @@ const advanceCheckedInAppointment = async (
   });
 };
 
+const findReusablePrescriptionForAppointment = async (
+  organisationId: string,
+  appointmentId?: string,
+) => {
+  if (!appointmentId) {
+    return null;
+  }
+
+  return clinicalPrisma.prescription.findFirst({
+    where: {
+      artifact: {
+        organisationId,
+        appointmentId,
+        kind: "PRESCRIPTION",
+        status: { in: ["DRAFT", "IN_PROGRESS"] },
+      },
+    },
+    include: { artifact: true, items: true },
+    orderBy: { updatedAt: "desc" },
+  });
+};
+
+const prescriptionCreateInputToUpdateInput = (
+  input: PrescriptionInput,
+  status: ClinicalArtifactStatus,
+): PrescriptionUpdateInput => ({
+  status: input.status ?? status,
+  summary: input.summary,
+  items: input.items,
+  medications: input.medications,
+  instructions: input.instructions,
+  notes: input.notes,
+  metadata: input.metadata,
+});
+
 export const ClinicalArtifactService = {
   async createSoapNote(input: SoapNoteInput): Promise<SoapNoteRecord> {
     const organisationId = ensureId(input.organisationId, "organisationId");
@@ -1411,6 +1446,27 @@ export const ClinicalArtifactService = {
     input: PrescriptionInput,
   ): Promise<PrescriptionRecord> {
     const organisationId = ensureId(input.organisationId, "organisationId");
+    const reusablePrescription = await findReusablePrescriptionForAppointment(
+      organisationId,
+      input.appointmentId,
+    );
+
+    if (reusablePrescription) {
+      return ClinicalArtifactService.updatePrescription(
+        reusablePrescription.id,
+        prescriptionCreateInputToUpdateInput(
+          input,
+          reusablePrescription.artifact.status,
+        ),
+        organisationId,
+        {
+          actorId:
+            input.authorId ?? reusablePrescription.artifact.authorId ?? "",
+          canEditAny: true,
+        },
+      );
+    }
+
     const prescriptionItems = normalizePrescriptionItemInputs(
       input.items ?? input.medications,
     );

--- a/apps/backend/src/services/inventory-consumption.service.ts
+++ b/apps/backend/src/services/inventory-consumption.service.ts
@@ -25,6 +25,7 @@ export type InventoryConsumptionLineInput = {
   batchId?: string;
   quantity: number;
   metadata?: Prisma.InputJsonValue;
+  restorePriorConsumption?: boolean;
 };
 
 export type InventoryConsumptionRuleInput = {
@@ -383,6 +384,25 @@ const resolvePackQuantity = (
       medication.stockUnitQty ??
       medication.unitQuantity ??
       medication.packageQuantity,
+  );
+
+const prescriptionLineFulfillment = (
+  medication: Record<string, unknown>,
+): string | undefined => {
+  const fulfillment = asNonEmptyString(medication.fulfillment);
+  if (fulfillment) return fulfillment;
+
+  const metadata = medication.metadata;
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return undefined;
+  }
+
+  return asNonEmptyString((metadata as Record<string, unknown>).fulfillment);
+};
+
+const hasClinicalCourseFields = (medication: Record<string, unknown>) =>
+  ["dosage", "dose", "frequency", "duration", "durationDays"].some((key) =>
+    asNonEmptyString(medication[key]),
   );
 
 const toDispenseUnits = (quantity: number, packSize?: number) => {
@@ -920,6 +940,7 @@ const applyInventoryRelease = async (
     batchId?: string;
     movementReason?: string;
     stockSource?: DispenseStockSource;
+    restorePriorConsumption?: boolean;
   },
 ) => {
   const item = await tx.inventoryItem.findFirst({
@@ -949,7 +970,13 @@ const applyInventoryRelease = async (
     );
   }
 
-  let remainingRelease = params.quantity;
+  const releaseQuantity = params.restorePriorConsumption
+    ? movements.reduce(
+        (sum, movement) => sum + Math.abs(movement.change ?? 0),
+        0,
+      )
+    : params.quantity;
+  let remainingRelease = releaseQuantity;
   for (const movement of movements) {
     if (remainingRelease <= 0) break;
 
@@ -991,7 +1018,7 @@ const applyInventoryRelease = async (
   );
   const allocated =
     params.stockSource === "ALLOCATED"
-      ? Math.max(0, (item.allocated ?? 0) + params.quantity)
+      ? Math.max(0, (item.allocated ?? 0) + releaseQuantity)
       : (item.allocated ?? 0);
   await tx.inventoryItem.update({
     where: { id: params.inventoryItemId },
@@ -1007,7 +1034,7 @@ const applyInventoryRelease = async (
     action: "RELEASE",
     idempotencyKey: params.idempotencyKey,
     inventoryItemId: params.inventoryItemId,
-    quantity: params.quantity,
+    quantity: releaseQuantity,
     metadata: params.metadata,
   });
 };
@@ -1125,6 +1152,7 @@ const consumeInventoryItem = async (
   batchId?: string,
   movementReason?: string,
   stockSource?: DispenseStockSource,
+  restorePriorConsumption?: boolean,
 ) => {
   const existingEvent = await tx.inventoryConsumptionEvent.findUnique({
     where: { idempotencyKey },
@@ -1160,6 +1188,7 @@ const consumeInventoryItem = async (
       batchId,
       movementReason,
       stockSource,
+      restorePriorConsumption,
     });
   }
 
@@ -1380,6 +1409,7 @@ const consumeResolvedLines = async (
       line.batchId,
       options?.movementReason,
       options?.stockSource,
+      line.restorePriorConsumption,
     );
     events.push(event);
   }
@@ -1392,6 +1422,10 @@ const normalizePrescriptionLines = (medications: unknown) => {
   return medications.flatMap((entry, index) => {
     if (!entry || typeof entry !== "object") return [];
     const record = entry as Record<string, unknown>;
+    if (prescriptionLineFulfillment(record) === "PRESCRIPTION_ONLY") {
+      return [];
+    }
+
     const quantity = resolveDispenseTotalUnits(record);
     if (!quantity) {
       // The line is skipped for stock purposes while the request can still be
@@ -1434,6 +1468,7 @@ const normalizePrescriptionLines = (medications: unknown) => {
             ? record.expiryDate
             : undefined,
         stockUnitQuantity,
+        hasClinicalCourse: hasClinicalCourseFields(record),
         ruleKeys: [
           asNonEmptyString(record.inventoryItemCode),
           asNonEmptyString(record.medicationCode),
@@ -1451,6 +1486,7 @@ const resolvePrescriptionLines = async (
   tx: Prisma.TransactionClient,
   organisationId: string,
   medications: unknown,
+  action: InventoryConsumptionAction,
 ) => {
   const prescriptionLines = normalizePrescriptionLines(medications);
   const resolvedInputs: Array<{
@@ -1526,7 +1562,10 @@ const resolvePrescriptionLines = async (
     tx,
     organisationId,
     resolvedInputs
-      .filter(({ line }) => line.stockUnitQuantity === undefined)
+      .filter(
+        ({ line }) =>
+          action !== "RELEASE" && line.stockUnitQuantity === undefined,
+      )
       .map(({ inventoryItemId }) => inventoryItemId),
   );
 
@@ -1545,6 +1584,10 @@ const resolvePrescriptionLines = async (
         quantity: toDispenseUnits(quantity, stockUnitQuantity),
         metadata: line.metadata,
         batchId,
+        restorePriorConsumption:
+          action === "RELEASE" &&
+          line.stockUnitQuantity === undefined &&
+          line.hasClinicalCourse,
       };
     },
   );
@@ -1597,6 +1640,7 @@ const consumePrescriptionMedications = async (
     tx,
     params.organisationId,
     params.medications,
+    params.action,
   );
   if (!lines.length) return [];
 

--- a/apps/backend/src/services/inventory-consumption.service.ts
+++ b/apps/backend/src/services/inventory-consumption.service.ts
@@ -1222,6 +1222,27 @@ const resolveInventoryItemIdBySku = async (
   return item?.id ?? null;
 };
 
+/**
+ * The dispense request's medications JSON is enriched once, at creation time,
+ * from the inventory item's pack size. Existing PENDING requests created
+ * before that enrichment ran (or before the item's pack size was configured)
+ * carry a frozen 0/undefined stockUnitQuantity forever, so a later fix to the
+ * enrichment logic never reaches them. Falling back to the live inventory
+ * item here means dispensing always uses the current pack size, not
+ * whatever was snapshotted when the request was created.
+ */
+const resolveInventoryItemPackQuantity = async (
+  tx: Prisma.TransactionClient,
+  organisationId: string,
+  inventoryItemId: string,
+): Promise<number | undefined> => {
+  const item = await tx.inventoryItem.findFirst({
+    where: { id: inventoryItemId, organisationId },
+    select: { packageQuantity: true },
+  });
+  return asPositiveNumber(item?.packageQuantity ?? undefined);
+};
+
 const resolveInventoryItemIdByBatch = async (
   tx: Prisma.TransactionClient,
   organisationId: string,
@@ -1437,47 +1458,33 @@ const resolvePrescriptionLines = async (
       lotNumber: line.lotNumber,
       expiryDate: line.expiryDate,
     });
-    const inventoryQuantity = toDispenseUnits(
-      line.quantity,
-      line.stockUnitQuantity,
-    );
 
-    if (line.inventoryItemId) {
+    const directInventoryItemId =
+      line.inventoryItemId ??
+      (line.inventoryItemSku
+        ? await resolveInventoryItemIdBySku(
+            tx,
+            organisationId,
+            line.inventoryItemSku,
+          )
+        : null) ??
+      batchMatch?.itemId ??
+      undefined;
+
+    if (directInventoryItemId) {
+      const stockUnitQuantity =
+        line.stockUnitQuantity ??
+        (await resolveInventoryItemPackQuantity(
+          tx,
+          organisationId,
+          directInventoryItemId,
+        ));
       resolved.push({
         sourceLineKey: line.sourceLineKey,
-        inventoryItemId: line.inventoryItemId,
-        quantity: inventoryQuantity,
+        inventoryItemId: directInventoryItemId,
+        quantity: toDispenseUnits(line.quantity, stockUnitQuantity),
         metadata: line.metadata,
         batchId: batchMatch?.id ?? line.batchId ?? undefined,
-      });
-      continue;
-    }
-
-    if (line.inventoryItemSku) {
-      const inventoryItemId = await resolveInventoryItemIdBySku(
-        tx,
-        organisationId,
-        line.inventoryItemSku,
-      );
-      if (inventoryItemId) {
-        resolved.push({
-          sourceLineKey: line.sourceLineKey,
-          inventoryItemId,
-          quantity: inventoryQuantity,
-          metadata: line.metadata,
-          batchId: batchMatch?.id ?? line.batchId ?? undefined,
-        });
-        continue;
-      }
-    }
-
-    if (batchMatch?.itemId) {
-      resolved.push({
-        sourceLineKey: line.sourceLineKey,
-        inventoryItemId: batchMatch.itemId,
-        quantity: inventoryQuantity,
-        metadata: line.metadata,
-        batchId: batchMatch.id,
       });
       continue;
     }
@@ -1490,12 +1497,19 @@ const resolvePrescriptionLines = async (
         normalizeKey(ruleKey),
       );
       if (rule) {
+        const stockUnitQuantity =
+          line.stockUnitQuantity ??
+          (await resolveInventoryItemPackQuantity(
+            tx,
+            organisationId,
+            rule.inventoryItemId,
+          ));
         resolved.push({
           sourceLineKey: line.sourceLineKey,
           inventoryItemId: rule.inventoryItemId,
           quantity: toDispenseUnits(
             Math.max(1, Math.round(line.quantity * rule.quantityMultiplier)),
-            line.stockUnitQuantity,
+            stockUnitQuantity,
           ),
           metadata: line.metadata,
           batchId: batchMatch?.id ?? line.batchId ?? undefined,

--- a/apps/backend/src/services/inventory-consumption.service.ts
+++ b/apps/backend/src/services/inventory-consumption.service.ts
@@ -926,6 +926,33 @@ const createInventoryConsumptionAppliedEvent = (
     status: "APPLIED",
   });
 
+const findPriorConsumptionEventQuantity = async (
+  tx: Prisma.TransactionClient,
+  params: {
+    organisationId: string;
+    sourceType: InventoryConsumptionSourceType;
+    sourceId: string;
+    sourceLineKey: string;
+    inventoryItemId: string;
+  },
+) => {
+  const events = await tx.inventoryConsumptionEvent.findMany({
+    where: {
+      organisationId: params.organisationId,
+      sourceType: params.sourceType,
+      sourceId: params.sourceId,
+      sourceLineKey: params.sourceLineKey,
+      inventoryItemId: params.inventoryItemId,
+      action: "CONSUME",
+      status: "APPLIED",
+    },
+  });
+
+  return events.reduce((sum, event) => sum + (event.quantity ?? 0), 0);
+};
+
+type RestoredMovementQuantities = Map<string, number>;
+
 const applyInventoryRelease = async (
   tx: Prisma.TransactionClient,
   params: {
@@ -941,6 +968,7 @@ const applyInventoryRelease = async (
     movementReason?: string;
     stockSource?: DispenseStockSource;
     restorePriorConsumption?: boolean;
+    restoredMovementQuantities?: RestoredMovementQuantities;
   },
 ) => {
   const item = await tx.inventoryItem.findFirst({
@@ -971,20 +999,31 @@ const applyInventoryRelease = async (
   }
 
   const releaseQuantity = params.restorePriorConsumption
-    ? movements.reduce(
-        (sum, movement) => sum + Math.abs(movement.change ?? 0),
-        0,
-      )
+    ? await findPriorConsumptionEventQuantity(tx, params)
     : params.quantity;
+  if (params.restorePriorConsumption && releaseQuantity <= 0) {
+    throw new InventoryConsumptionServiceError(
+      "No prior consumption event found to release",
+      400,
+    );
+  }
+
   let remainingRelease = releaseQuantity;
   for (const movement of movements) {
     if (remainingRelease <= 0) break;
 
     const consumedQuantity = Math.abs(movement.change ?? 0);
-    if (consumedQuantity <= 0) continue;
+    const alreadyRestored =
+      params.restoredMovementQuantities?.get(movement.id) ?? 0;
+    const availableToRestore = consumedQuantity - alreadyRestored;
+    if (availableToRestore <= 0) continue;
 
-    const restore = Math.min(remainingRelease, consumedQuantity);
+    const restore = Math.min(remainingRelease, availableToRestore);
     remainingRelease -= restore;
+    params.restoredMovementQuantities?.set(
+      movement.id,
+      alreadyRestored + restore,
+    );
 
     if (movement.batchId) {
       await tx.inventoryBatch.update({
@@ -1153,6 +1192,7 @@ const consumeInventoryItem = async (
   movementReason?: string,
   stockSource?: DispenseStockSource,
   restorePriorConsumption?: boolean,
+  restoredMovementQuantities?: RestoredMovementQuantities,
 ) => {
   const existingEvent = await tx.inventoryConsumptionEvent.findUnique({
     where: { idempotencyKey },
@@ -1189,6 +1229,7 @@ const consumeInventoryItem = async (
       movementReason,
       stockSource,
       restorePriorConsumption,
+      restoredMovementQuantities,
     });
   }
 
@@ -1386,6 +1427,8 @@ const consumeResolvedLines = async (
   });
 
   const events = [];
+  const restoredMovementQuantities =
+    action === "RELEASE" ? new Map<string, number>() : undefined;
   for (const line of resolvedLines) {
     const quantity = ensureQuantity(line.quantity);
     const inventoryItemId = asNonEmptyString(line.inventoryItemId);
@@ -1410,6 +1453,7 @@ const consumeResolvedLines = async (
       options?.movementReason,
       options?.stockSource,
       line.restorePriorConsumption,
+      restoredMovementQuantities,
     );
     events.push(event);
   }

--- a/apps/backend/src/services/inventory-consumption.service.ts
+++ b/apps/backend/src/services/inventory-consumption.service.ts
@@ -1222,25 +1222,29 @@ const resolveInventoryItemIdBySku = async (
   return item?.id ?? null;
 };
 
-/**
- * The dispense request's medications JSON is enriched once, at creation time,
- * from the inventory item's pack size. Existing PENDING requests created
- * before that enrichment ran (or before the item's pack size was configured)
- * carry a frozen 0/undefined stockUnitQuantity forever, so a later fix to the
- * enrichment logic never reaches them. Falling back to the live inventory
- * item here means dispensing always uses the current pack size, not
- * whatever was snapshotted when the request was created.
- */
-const resolveInventoryItemPackQuantity = async (
+const resolveInventoryItemPackQuantities = async (
   tx: Prisma.TransactionClient,
   organisationId: string,
-  inventoryItemId: string,
-): Promise<number | undefined> => {
-  const item = await tx.inventoryItem.findFirst({
-    where: { id: inventoryItemId, organisationId },
-    select: { packageQuantity: true },
+  inventoryItemIds: string[],
+): Promise<Map<string, number>> => {
+  const uniqueIds = Array.from(new Set(inventoryItemIds));
+  if (!uniqueIds.length) {
+    return new Map();
+  }
+
+  const items = await tx.inventoryItem.findMany({
+    where: { organisationId, id: { in: uniqueIds } },
+    select: { id: true, packageQuantity: true },
   });
-  return asPositiveNumber(item?.packageQuantity ?? undefined);
+
+  return new Map(
+    items.flatMap((item) => {
+      const packageQuantity = asPositiveNumber(
+        item.packageQuantity ?? undefined,
+      );
+      return packageQuantity === undefined ? [] : [[item.id, packageQuantity]];
+    }),
+  );
 };
 
 const resolveInventoryItemIdByBatch = async (
@@ -1449,7 +1453,12 @@ const resolvePrescriptionLines = async (
   medications: unknown,
 ) => {
   const prescriptionLines = normalizePrescriptionLines(medications);
-  const resolved: InventoryConsumptionLineInput[] = [];
+  const resolvedInputs: Array<{
+    line: (typeof prescriptionLines)[number];
+    inventoryItemId: string;
+    quantity: number;
+    batchId?: string;
+  }> = [];
 
   for (const line of prescriptionLines) {
     const batchMatch = await resolveInventoryItemIdByBatch(tx, organisationId, {
@@ -1472,18 +1481,10 @@ const resolvePrescriptionLines = async (
       undefined;
 
     if (directInventoryItemId) {
-      const stockUnitQuantity =
-        line.stockUnitQuantity ??
-        (await resolveInventoryItemPackQuantity(
-          tx,
-          organisationId,
-          directInventoryItemId,
-        ));
-      resolved.push({
-        sourceLineKey: line.sourceLineKey,
+      resolvedInputs.push({
+        line,
         inventoryItemId: directInventoryItemId,
-        quantity: toDispenseUnits(line.quantity, stockUnitQuantity),
-        metadata: line.metadata,
+        quantity: line.quantity,
         batchId: batchMatch?.id ?? line.batchId ?? undefined,
       });
       continue;
@@ -1497,21 +1498,13 @@ const resolvePrescriptionLines = async (
         normalizeKey(ruleKey),
       );
       if (rule) {
-        const stockUnitQuantity =
-          line.stockUnitQuantity ??
-          (await resolveInventoryItemPackQuantity(
-            tx,
-            organisationId,
-            rule.inventoryItemId,
-          ));
-        resolved.push({
-          sourceLineKey: line.sourceLineKey,
+        resolvedInputs.push({
+          line,
           inventoryItemId: rule.inventoryItemId,
-          quantity: toDispenseUnits(
-            Math.max(1, Math.round(line.quantity * rule.quantityMultiplier)),
-            stockUnitQuantity,
+          quantity: Math.max(
+            1,
+            Math.round(line.quantity * rule.quantityMultiplier),
           ),
-          metadata: line.metadata,
           batchId: batchMatch?.id ?? line.batchId ?? undefined,
         });
         break;
@@ -1519,7 +1512,42 @@ const resolvePrescriptionLines = async (
     }
   }
 
-  return resolved;
+  /**
+   * The dispense request's medications JSON is enriched once, at creation time,
+   * from the inventory item's pack size. Existing PENDING requests created
+   * before that enrichment ran (or before the item's pack size was configured)
+   * carry a frozen 0/undefined stockUnitQuantity forever, so a later fix to the
+   * enrichment logic never reaches them. Falling back to the live inventory item
+   * here means dispensing always uses the current pack size, not whatever was
+   * snapshotted when the request was created. Fetch all needed package sizes in
+   * one query so large prescriptions do not issue one lookup per line.
+   */
+  const livePackQuantities = await resolveInventoryItemPackQuantities(
+    tx,
+    organisationId,
+    resolvedInputs
+      .filter(({ line }) => line.stockUnitQuantity === undefined)
+      .map(({ inventoryItemId }) => inventoryItemId),
+  );
+
+  return resolvedInputs.map(
+    ({
+      line,
+      inventoryItemId,
+      quantity,
+      batchId,
+    }): InventoryConsumptionLineInput => {
+      const stockUnitQuantity =
+        line.stockUnitQuantity ?? livePackQuantities.get(inventoryItemId);
+      return {
+        sourceLineKey: line.sourceLineKey,
+        inventoryItemId,
+        quantity: toDispenseUnits(quantity, stockUnitQuantity),
+        metadata: line.metadata,
+        batchId,
+      };
+    },
+  );
 };
 
 const runPrescriptionInventoryAction = async (params: {

--- a/apps/backend/src/services/inventory-consumption.service.ts
+++ b/apps/backend/src/services/inventory-consumption.service.ts
@@ -400,11 +400,6 @@ const prescriptionLineFulfillment = (
   return asNonEmptyString((metadata as Record<string, unknown>).fulfillment);
 };
 
-const hasClinicalCourseFields = (medication: Record<string, unknown>) =>
-  ["dosage", "dose", "frequency", "duration", "durationDays"].some((key) =>
-    asNonEmptyString(medication[key]),
-  );
-
 const toDispenseUnits = (quantity: number, packSize?: number) => {
   if (!packSize || packSize <= 1) {
     return quantity;
@@ -1512,7 +1507,6 @@ const normalizePrescriptionLines = (medications: unknown) => {
             ? record.expiryDate
             : undefined,
         stockUnitQuantity,
-        hasClinicalCourse: hasClinicalCourseFields(record),
         ruleKeys: [
           asNonEmptyString(record.inventoryItemCode),
           asNonEmptyString(record.medicationCode),
@@ -1629,9 +1623,7 @@ const resolvePrescriptionLines = async (
         metadata: line.metadata,
         batchId,
         restorePriorConsumption:
-          action === "RELEASE" &&
-          line.stockUnitQuantity === undefined &&
-          line.hasClinicalCourse,
+          action === "RELEASE" && line.stockUnitQuantity === undefined,
       };
     },
   );

--- a/apps/backend/test/services/clinical-artifact.service.test.ts
+++ b/apps/backend/test/services/clinical-artifact.service.test.ts
@@ -1,4 +1,5 @@
 import { prisma } from "src/config/prisma";
+import { Prisma } from "@prisma/client";
 import {
   ClinicalArtifactService,
   ClinicalArtifactServiceError,
@@ -1011,6 +1012,147 @@ describe("ClinicalArtifactService", () => {
       expect.objectContaining({ where: { id: "doc-2" } }),
     );
     expect(result.prescription.items).toHaveLength(2);
+  });
+
+  it("retries appointment prescription reuse after a serializable write conflict", async () => {
+    const existingArtifact = {
+      id: artifactId,
+      organisationId,
+      kind: "PRESCRIPTION",
+      status: "DRAFT",
+      appointmentId: "appt-1",
+      caseId: null,
+      encounterId: "enc-1",
+      templateId: null,
+      templateVersion: null,
+      templateVersionId: null,
+      authorId: "author-1",
+      signedBy: null,
+      signedAt: null,
+      summary: "Rx summary",
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    };
+    const existingPrescription = {
+      id: "prescription-1",
+      artifactId,
+      medications: null,
+      items: [],
+      instructions: null,
+      notes: null,
+      metadata: null,
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+      artifact: existingArtifact,
+    };
+    const writeConflict = new Prisma.PrismaClientKnownRequestError(
+      "Transaction failed due to a write conflict or a deadlock.",
+      { code: "P2034", clientVersion: "test" },
+    );
+
+    mockedPrisma.$transaction.mockRejectedValueOnce(writeConflict);
+    mockedPrisma.prescription.findFirst
+      .mockResolvedValueOnce(existingPrescription)
+      .mockResolvedValueOnce(existingPrescription);
+    mockedPrisma.clinicalArtifact.update.mockResolvedValueOnce({
+      ...existingArtifact,
+      summary: "Updated Rx summary",
+      updatedAt: new Date("2026-01-02T00:00:00.000Z"),
+    });
+    mockedPrisma.prescription.update.mockResolvedValueOnce({
+      id: "prescription-1",
+      artifactId,
+      medications: null,
+      items: [
+        {
+          id: "line-1",
+          prescriptionId: "prescription-1",
+          medication: "Drug B",
+          quantity: "4",
+          sortOrder: 0,
+          createdAt: new Date("2026-01-02T00:00:00.000Z"),
+          updatedAt: new Date("2026-01-02T00:00:00.000Z"),
+        },
+      ],
+      instructions: null,
+      notes: null,
+      metadata: null,
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-02T00:00:00.000Z"),
+    });
+
+    const result = await ClinicalArtifactService.createPrescription({
+      organisationId,
+      appointmentId: "appt-1",
+      encounterId: "enc-1",
+      authorId: "author-1",
+      summary: "Updated Rx summary",
+      medications: [{ medication: "Drug B", quantity: 4 }],
+    });
+
+    expect(mockedPrisma.$transaction).toHaveBeenNthCalledWith(
+      1,
+      expect.any(Function),
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+    );
+    expect(mockedPrisma.$transaction).toHaveBeenNthCalledWith(
+      2,
+      expect.any(Function),
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+    );
+    expect(mockedPrisma.clinicalArtifact.create).not.toHaveBeenCalled();
+    expect(mockedPrisma.prescription.create).not.toHaveBeenCalled();
+    expect(mockedPrisma.prescription.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "prescription-1" } }),
+    );
+    expect(result.prescription.items).toHaveLength(1);
+  });
+
+  it("enforces own-scope authorization before reusing an appointment draft prescription", async () => {
+    const existingArtifact = {
+      id: artifactId,
+      organisationId,
+      kind: "PRESCRIPTION",
+      status: "DRAFT",
+      appointmentId: "appt-1",
+      caseId: null,
+      encounterId: "enc-1",
+      templateId: null,
+      templateVersion: null,
+      templateVersionId: null,
+      authorId: "author-1",
+      signedBy: null,
+      signedAt: null,
+      summary: "Rx summary",
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    };
+    mockedPrisma.prescription.findFirst.mockResolvedValue({
+      id: "prescription-1",
+      artifactId,
+      medications: null,
+      items: [],
+      instructions: null,
+      notes: null,
+      metadata: null,
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+      artifact: existingArtifact,
+    });
+
+    await expect(
+      ClinicalArtifactService.createPrescription(
+        {
+          organisationId,
+          appointmentId: "appt-1",
+          encounterId: "enc-1",
+          authorId: "author-2",
+          medications: [{ medication: "Drug B", quantity: 1 }],
+        },
+        { actorId: "author-2", canEditAny: false },
+      ),
+    ).rejects.toThrow("Prescription was authored by another user");
+    expect(mockedPrisma.prescription.update).not.toHaveBeenCalled();
   });
 
   it("stores frontend prescription fields on line items instead of the json column", async () => {

--- a/apps/backend/test/services/clinical-artifact.service.test.ts
+++ b/apps/backend/test/services/clinical-artifact.service.test.ts
@@ -1308,12 +1308,20 @@ describe("ClinicalArtifactService", () => {
       updatedAt: new Date("2026-01-01T00:00:00.000Z"),
       artifact: existingArtifact,
     };
+    const stalePrescription = {
+      ...existingPrescription,
+      id: "prescription-stale",
+      artifactId: "artifact-stale",
+      artifact: {
+        ...existingArtifact,
+        id: "artifact-stale",
+        authorId: "author-1",
+      },
+    };
     mockedPrisma.prescription.findMany.mockResolvedValueOnce([
       existingPrescription,
+      stalePrescription,
     ]);
-    mockedPrisma.prescription.findFirst.mockResolvedValueOnce(
-      existingPrescription,
-    );
 
     await expect(
       ClinicalArtifactService.createPrescription(
@@ -1327,6 +1335,7 @@ describe("ClinicalArtifactService", () => {
         { actorId: "author-2", canEditAny: false },
       ),
     ).rejects.toThrow("Prescription was authored by another user");
+    expect(mockedPrisma.clinicalArtifact.updateMany).not.toHaveBeenCalled();
     expect(mockedPrisma.prescription.update).not.toHaveBeenCalled();
   });
 

--- a/apps/backend/test/services/clinical-artifact.service.test.ts
+++ b/apps/backend/test/services/clinical-artifact.service.test.ts
@@ -850,6 +850,169 @@ describe("ClinicalArtifactService", () => {
     expect(result.artifact.kind).toBe("PRESCRIPTION");
   });
 
+  it("reuses an appointment draft prescription instead of creating duplicate documents", async () => {
+    const existingArtifact = {
+      id: artifactId,
+      organisationId,
+      kind: "PRESCRIPTION",
+      status: "DRAFT",
+      appointmentId: "appt-1",
+      caseId: null,
+      encounterId: "enc-1",
+      templateId: "tmpl-2",
+      templateVersion: 4,
+      templateVersionId: "tmpl-ver-2",
+      authorId: "author-1",
+      signedBy: null,
+      signedAt: null,
+      summary: "Rx summary",
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    };
+    const existingPrescription = {
+      id: "prescription-1",
+      artifactId,
+      medications: null,
+      items: [
+        {
+          id: "line-old",
+          prescriptionId: "prescription-1",
+          medication: "Drug A",
+          sortOrder: 0,
+        },
+      ],
+      instructions: null,
+      notes: null,
+      metadata: null,
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+      artifact: existingArtifact,
+    };
+
+    mockedPrisma.prescription.findFirst
+      .mockResolvedValueOnce(existingPrescription)
+      .mockResolvedValueOnce(existingPrescription);
+    mockedPrisma.clinicalArtifact.update.mockResolvedValueOnce({
+      ...existingArtifact,
+      summary: "Updated Rx summary",
+      updatedAt: new Date("2026-01-02T00:00:00.000Z"),
+    });
+    mockedPrisma.prescription.update.mockResolvedValueOnce({
+      id: "prescription-1",
+      artifactId,
+      medications: null,
+      items: [
+        {
+          id: "line-1",
+          prescriptionId: "prescription-1",
+          sourceLineKey: "line-1",
+          medication: "Drug A",
+          dosage: "250mg",
+          route: "oral",
+          frequency: "BID",
+          duration: "7 days",
+          quantity: "14",
+          instructions: "With food",
+          sortOrder: 0,
+          createdAt: new Date("2026-01-02T00:00:00.000Z"),
+          updatedAt: new Date("2026-01-02T00:00:00.000Z"),
+        },
+        {
+          id: "line-2",
+          prescriptionId: "prescription-1",
+          sourceLineKey: "line-2",
+          medication: "Drug B",
+          dosage: "50mg",
+          route: "oral",
+          frequency: "SID",
+          duration: "3 days",
+          quantity: "3",
+          instructions: "After meal",
+          sortOrder: 1,
+          createdAt: new Date("2026-01-02T00:00:00.000Z"),
+          updatedAt: new Date("2026-01-02T00:00:00.000Z"),
+        },
+      ],
+      instructions: null,
+      notes: null,
+      metadata: null,
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-02T00:00:00.000Z"),
+    });
+    mockClinicalRenderedDocumentPersistence({
+      id: "doc-2",
+      kind: "PRESCRIPTION",
+      title: "Prescription",
+      sourceId: artifactId,
+      templateId: "tmpl-2",
+      templateVersion: 4,
+      templateVersionId: "tmpl-ver-2",
+    });
+
+    const result = await ClinicalArtifactService.createPrescription({
+      organisationId,
+      appointmentId: "appt-1",
+      encounterId: "enc-1",
+      templateId: "tmpl-2",
+      templateVersion: 4,
+      templateVersionId: "tmpl-ver-2",
+      authorId: "author-1",
+      summary: "Updated Rx summary",
+      medications: [
+        {
+          sourceLineKey: "line-1",
+          medication: "Drug A",
+          dosage: "250mg",
+          route: "oral",
+          frequency: "BID",
+          duration: "7 days",
+          quantity: 14,
+          instructions: "With food",
+        },
+        {
+          sourceLineKey: "line-2",
+          medication: "Drug B",
+          dosage: "50mg",
+          route: "oral",
+          frequency: "SID",
+          duration: "3 days",
+          quantity: 3,
+          instructions: "After meal",
+        },
+      ],
+    });
+
+    expect(mockedPrisma.clinicalArtifact.create).not.toHaveBeenCalled();
+    expect(mockedPrisma.prescription.create).not.toHaveBeenCalled();
+    expect(mockedPrisma.renderedDocument.create).not.toHaveBeenCalled();
+    expect(mockedPrisma.prescription.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "prescription-1" },
+        data: expect.objectContaining({
+          items: {
+            deleteMany: {},
+            create: [
+              expect.objectContaining({
+                medication: "Drug A",
+                quantity: "14",
+                sourceLineKey: "line-1",
+              }),
+              expect.objectContaining({
+                medication: "Drug B",
+                quantity: "3",
+                sourceLineKey: "line-2",
+              }),
+            ],
+          },
+        }),
+      }),
+    );
+    expect(mockedPrisma.renderedDocument.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "doc-2" } }),
+    );
+    expect(result.prescription.items).toHaveLength(2);
+  });
+
   it("stores frontend prescription fields on line items instead of the json column", async () => {
     mockedPrisma.clinicalArtifact.create.mockResolvedValueOnce({
       id: artifactId,

--- a/apps/backend/test/services/clinical-artifact.service.test.ts
+++ b/apps/backend/test/services/clinical-artifact.service.test.ts
@@ -40,6 +40,7 @@ jest.mock("src/config/prisma", () => ({
     clinicalArtifact: {
       create: jest.fn(),
       update: jest.fn(),
+      updateMany: jest.fn(),
       findUnique: jest.fn(),
     },
     renderedDocument: {
@@ -101,6 +102,7 @@ describe("ClinicalArtifactService", () => {
     clinicalArtifact: {
       create: jest.Mock;
       update: jest.Mock;
+      updateMany: jest.Mock;
       findUnique: jest.Mock;
     };
     renderedDocument: {
@@ -159,6 +161,8 @@ describe("ClinicalArtifactService", () => {
     mockedPrisma.workspaceTreatmentItem.findFirst.mockReset();
     mockedPrisma.workspaceTreatmentItem.deleteMany.mockReset();
     mockedPrisma.prescription.findFirst.mockReset();
+    mockedPrisma.prescription.findMany.mockResolvedValue([]);
+    mockedPrisma.clinicalArtifact.updateMany.mockResolvedValue({ count: 0 });
     mockedPrisma.prescriptionDispenseRequest.findFirst.mockReset();
     mockedRenderedDocumentRenderer.mockResolvedValue({
       pdf: Buffer.from("rendered-pdf"),
@@ -890,9 +894,12 @@ describe("ClinicalArtifactService", () => {
       artifact: existingArtifact,
     };
 
-    mockedPrisma.prescription.findFirst
-      .mockResolvedValueOnce(existingPrescription)
-      .mockResolvedValueOnce(existingPrescription);
+    mockedPrisma.prescription.findMany.mockResolvedValueOnce([
+      existingPrescription,
+    ]);
+    mockedPrisma.prescription.findFirst.mockResolvedValueOnce(
+      existingPrescription,
+    );
     mockedPrisma.clinicalArtifact.update.mockResolvedValueOnce({
       ...existingArtifact,
       summary: "Updated Rx summary",
@@ -1014,6 +1021,165 @@ describe("ClinicalArtifactService", () => {
     expect(result.prescription.items).toHaveLength(2);
   });
 
+  it("voids older appointment draft prescriptions when reusing the latest draft", async () => {
+    const latestArtifact = {
+      id: "artifact-latest",
+      organisationId,
+      kind: "PRESCRIPTION",
+      status: "DRAFT",
+      appointmentId: "appt-1",
+      caseId: null,
+      encounterId: "enc-1",
+      templateId: null,
+      templateVersion: null,
+      templateVersionId: null,
+      authorId: "author-1",
+      signedBy: null,
+      signedAt: null,
+      summary: "Latest",
+      createdAt: new Date("2026-01-02T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-02T00:00:00.000Z"),
+    };
+    const staleArtifact = {
+      ...latestArtifact,
+      id: "artifact-stale",
+      summary: "Stale",
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    };
+    const latestPrescription = {
+      id: "prescription-latest",
+      artifactId: "artifact-latest",
+      medications: null,
+      items: [],
+      instructions: null,
+      notes: null,
+      metadata: null,
+      createdAt: new Date("2026-01-02T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-02T00:00:00.000Z"),
+      artifact: latestArtifact,
+    };
+    const stalePrescription = {
+      ...latestPrescription,
+      id: "prescription-stale",
+      artifactId: "artifact-stale",
+      artifact: staleArtifact,
+    };
+
+    mockedPrisma.prescription.findMany.mockResolvedValueOnce([
+      latestPrescription,
+      stalePrescription,
+    ]);
+    mockedPrisma.prescription.findFirst.mockResolvedValueOnce(
+      latestPrescription,
+    );
+    mockedPrisma.clinicalArtifact.update.mockResolvedValueOnce({
+      ...latestArtifact,
+      summary: "Updated",
+    });
+    mockedPrisma.prescription.update.mockResolvedValueOnce({
+      ...latestPrescription,
+      items: [
+        {
+          id: "line-1",
+          prescriptionId: "prescription-latest",
+          medication: "Drug A",
+          quantity: "1",
+          sortOrder: 0,
+          createdAt: new Date("2026-01-02T00:00:00.000Z"),
+          updatedAt: new Date("2026-01-02T00:00:00.000Z"),
+        },
+      ],
+    });
+
+    await ClinicalArtifactService.createPrescription({
+      organisationId,
+      appointmentId: "appt-1",
+      encounterId: "enc-1",
+      authorId: "author-1",
+      summary: "Updated",
+      medications: [{ medication: "Drug A", quantity: 1 }],
+    });
+
+    expect(mockedPrisma.clinicalArtifact.updateMany).toHaveBeenCalledWith({
+      where: { id: { in: ["artifact-stale"] } },
+      data: { status: "VOID" },
+    });
+    expect(mockedPrisma.clinicalArtifact.create).not.toHaveBeenCalled();
+  });
+
+  it("backfills encounter context when reusing an appointment-only draft", async () => {
+    const existingArtifact = {
+      id: artifactId,
+      organisationId,
+      kind: "PRESCRIPTION",
+      status: "DRAFT",
+      appointmentId: "appt-1",
+      caseId: null,
+      encounterId: null,
+      templateId: null,
+      templateVersion: null,
+      templateVersionId: null,
+      authorId: "author-1",
+      signedBy: null,
+      signedAt: null,
+      summary: "Rx summary",
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    };
+    const existingPrescription = {
+      id: "prescription-1",
+      artifactId,
+      medications: null,
+      items: [],
+      instructions: null,
+      notes: null,
+      metadata: null,
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+      artifact: existingArtifact,
+    };
+
+    mockedPrisma.prescription.findMany.mockResolvedValueOnce([
+      existingPrescription,
+    ]);
+    mockedPrisma.prescription.findFirst.mockResolvedValueOnce(
+      existingPrescription,
+    );
+    mockedPrisma.clinicalArtifact.update.mockResolvedValueOnce({
+      ...existingArtifact,
+      caseId: "case-1",
+      encounterId: "enc-1",
+      summary: "Updated Rx summary",
+      updatedAt: new Date("2026-01-02T00:00:00.000Z"),
+    });
+    mockedPrisma.prescription.update.mockResolvedValueOnce({
+      ...existingPrescription,
+      items: [],
+      updatedAt: new Date("2026-01-02T00:00:00.000Z"),
+    });
+
+    await ClinicalArtifactService.createPrescription({
+      organisationId,
+      appointmentId: "appt-1",
+      caseId: "case-1",
+      encounterId: "enc-1",
+      authorId: "author-1",
+      summary: "Updated Rx summary",
+      medications: [],
+    });
+
+    expect(mockedPrisma.clinicalArtifact.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: artifactId },
+        data: expect.objectContaining({
+          caseId: "case-1",
+          encounterId: "enc-1",
+        }),
+      }),
+    );
+  });
+
   it("retries appointment prescription reuse after a serializable write conflict", async () => {
     const existingArtifact = {
       id: artifactId,
@@ -1051,9 +1217,12 @@ describe("ClinicalArtifactService", () => {
     );
 
     mockedPrisma.$transaction.mockRejectedValueOnce(writeConflict);
-    mockedPrisma.prescription.findFirst
-      .mockResolvedValueOnce(existingPrescription)
-      .mockResolvedValueOnce(existingPrescription);
+    mockedPrisma.prescription.findMany.mockResolvedValueOnce([
+      existingPrescription,
+    ]);
+    mockedPrisma.prescription.findFirst.mockResolvedValueOnce(
+      existingPrescription,
+    );
     mockedPrisma.clinicalArtifact.update.mockResolvedValueOnce({
       ...existingArtifact,
       summary: "Updated Rx summary",
@@ -1127,7 +1296,7 @@ describe("ClinicalArtifactService", () => {
       createdAt: new Date("2026-01-01T00:00:00.000Z"),
       updatedAt: new Date("2026-01-01T00:00:00.000Z"),
     };
-    mockedPrisma.prescription.findFirst.mockResolvedValue({
+    const existingPrescription = {
       id: "prescription-1",
       artifactId,
       medications: null,
@@ -1138,7 +1307,13 @@ describe("ClinicalArtifactService", () => {
       createdAt: new Date("2026-01-01T00:00:00.000Z"),
       updatedAt: new Date("2026-01-01T00:00:00.000Z"),
       artifact: existingArtifact,
-    });
+    };
+    mockedPrisma.prescription.findMany.mockResolvedValueOnce([
+      existingPrescription,
+    ]);
+    mockedPrisma.prescription.findFirst.mockResolvedValueOnce(
+      existingPrescription,
+    );
 
     await expect(
       ClinicalArtifactService.createPrescription(

--- a/apps/backend/test/services/inventory-consumption.service.test.ts
+++ b/apps/backend/test/services/inventory-consumption.service.test.ts
@@ -1607,6 +1607,9 @@ describe("InventoryConsumptionService", () => {
         createdAt: new Date("2026-01-01T00:00:00.000Z"),
       },
     ]);
+    mockedPrisma.inventoryConsumptionEvent.findMany.mockResolvedValueOnce([
+      { id: "event-consume-void-1", quantity: 1 },
+    ]);
     mockedPrisma.inventoryItem.findFirst.mockResolvedValueOnce({
       id: "item-9",
       organisationId: "org-1",
@@ -1668,6 +1671,9 @@ describe("InventoryConsumptionService", () => {
         referenceId: "rx-1",
         createdAt: new Date("2026-01-01T00:00:00.000Z"),
       },
+    ]);
+    mockedPrisma.inventoryConsumptionEvent.findMany.mockResolvedValueOnce([
+      { id: "event-consume-release-1", quantity: 2 },
     ]);
     mockedPrisma.inventoryItem.findFirst.mockResolvedValueOnce({
       id: "item-1",
@@ -2509,6 +2515,9 @@ describe("InventoryConsumptionService", () => {
         createdAt: new Date("2026-01-01T00:00:00.000Z"),
       },
     ]);
+    mockedPrisma.inventoryConsumptionEvent.findMany.mockResolvedValueOnce([
+      { id: "event-consume-partial", quantity: 5 },
+    ]);
     mockedPrisma.inventoryBatch.update.mockResolvedValue({});
     mockedPrisma.inventoryStockMovement.create.mockResolvedValue({});
 
@@ -2533,6 +2542,9 @@ describe("InventoryConsumptionService", () => {
         referenceId: "rx-return",
         createdAt: new Date("2026-01-01T00:00:00.000Z"),
       },
+    ]);
+    mockedPrisma.inventoryConsumptionEvent.findMany.mockResolvedValueOnce([
+      { id: "event-consume-return", quantity: 2 },
     ]);
     mockedPrisma.inventoryItem.findFirst.mockResolvedValueOnce({
       id: "item-return",
@@ -3417,6 +3429,9 @@ describe("InventoryConsumptionService", () => {
         createdAt: new Date("2026-01-01T00:00:00.000Z"),
       },
     ]);
+    mockedPrisma.inventoryConsumptionEvent.findMany.mockResolvedValueOnce([
+      { id: "event-consume-norm-rel", quantity: 2 },
+    ]);
     mockedPrisma.inventoryItem.findFirst.mockResolvedValueOnce({
       id: "item-norm-rel",
       organisationId: "org-1",
@@ -3779,6 +3794,9 @@ describe("InventoryConsumptionService", () => {
         referenceId: "rx-void-null",
         createdAt: new Date("2026-01-01T00:00:00.000Z"),
       },
+    ]);
+    mockedPrisma.inventoryConsumptionEvent.findMany.mockResolvedValueOnce([
+      { id: "event-consume-void-null", quantity: 1 },
     ]);
     mockedPrisma.inventoryItem.findFirst.mockResolvedValueOnce({
       id: "item-void-null",

--- a/apps/backend/test/services/inventory-consumption.service.test.ts
+++ b/apps/backend/test/services/inventory-consumption.service.test.ts
@@ -3072,6 +3072,111 @@ describe("InventoryConsumptionService", () => {
     );
   });
 
+  it("skips prescription-only lines when consuming a mixed prescription", async () => {
+    mockedPrisma.inventoryItem.findFirst.mockResolvedValueOnce({
+      id: "item-in-house",
+      organisationId: "org-1",
+      onHand: 10,
+      allocated: 0,
+    });
+    mockedPrisma.inventoryBatch.findMany
+      .mockResolvedValueOnce([{ id: "batch-in-house", quantity: 10 }])
+      .mockResolvedValueOnce([{ id: "batch-in-house", quantity: 8 }]);
+    mockedPrisma.inventoryBatch.update.mockResolvedValue({});
+    mockedPrisma.inventoryStockMovement.create.mockResolvedValue({});
+    mockedPrisma.inventoryItem.update.mockResolvedValue({});
+    mockedPrisma.inventoryConsumptionEvent.create.mockResolvedValue({
+      id: "event-mixed",
+    });
+
+    const events = await InventoryConsumptionService.consumePrescription({
+      organisationId: "org-1",
+      prescriptionId: "rx-mixed",
+      medications: [
+        {
+          inventoryItemId: "item-in-house",
+          quantity: 2,
+          sourceLineKey: "line-in-house",
+          metadata: { fulfillment: "IN_HOUSE" },
+        },
+        {
+          inventoryItemId: "item-prescription-only",
+          quantity: 2,
+          sourceLineKey: "line-prescription-only",
+          metadata: { fulfillment: "PRESCRIPTION_ONLY" },
+        },
+      ],
+    });
+
+    expect(events).toHaveLength(1);
+    expect(mockedPrisma.inventoryStockMovement.create).toHaveBeenCalledTimes(1);
+    expect(mockedPrisma.inventoryStockMovement.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          itemId: "item-in-house",
+          change: -2,
+        }),
+      }),
+    );
+  });
+
+  it("restores the originally consumed quantity for legacy release lines without pack snapshots", async () => {
+    mockedPrisma.inventoryItem.findFirst.mockResolvedValueOnce({
+      id: "item-pack-release",
+      organisationId: "org-1",
+      onHand: 7,
+      allocated: 0,
+    });
+    mockedPrisma.inventoryStockMovement.findMany.mockResolvedValue([
+      {
+        id: "movement-consumed",
+        itemId: "item-pack-release",
+        batchId: "batch-pack-release",
+        change: -3,
+      },
+    ]);
+    mockedPrisma.inventoryBatch.update.mockResolvedValue({});
+    mockedPrisma.inventoryBatch.findMany.mockResolvedValueOnce([
+      { id: "batch-pack-release", quantity: 10 },
+    ]);
+    mockedPrisma.inventoryStockMovement.create.mockResolvedValue({});
+    mockedPrisma.inventoryItem.update.mockResolvedValue({});
+    mockedPrisma.inventoryConsumptionEvent.create.mockResolvedValue({
+      id: "event-release-pack",
+    });
+
+    const events = await InventoryConsumptionService.releasePrescription({
+      organisationId: "org-1",
+      prescriptionId: "rx-release-pack",
+      medications: [
+        {
+          inventoryItemId: "item-pack-release",
+          quantity: 24,
+          dosage: "1 tablet",
+          frequency: "BID",
+          duration: "12 days",
+          sourceLineKey: "line-pack-release",
+        },
+      ],
+    });
+
+    expect(events).toHaveLength(1);
+    expect(mockedPrisma.inventoryItem.findMany).not.toHaveBeenCalled();
+    expect(mockedPrisma.inventoryStockMovement.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          itemId: "item-pack-release",
+          change: 3,
+        }),
+      }),
+    );
+    expect(mockedPrisma.inventoryConsumptionEvent.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ quantity: 3 }),
+      }),
+    );
+  });
+
   it("consumes allocated stock across a null-quantity batch and stops once satisfied", async () => {
     mockedPrisma.inventoryItem.findFirst.mockResolvedValueOnce({
       id: "item-ab",

--- a/apps/backend/test/services/inventory-consumption.service.test.ts
+++ b/apps/backend/test/services/inventory-consumption.service.test.ts
@@ -3000,6 +3000,78 @@ describe("InventoryConsumptionService", () => {
     );
   });
 
+  it("prefetches live pack quantities once for prescription lines missing snapshots", async () => {
+    mockedPrisma.inventoryItem.findMany.mockResolvedValueOnce([
+      { id: "item-pack-a", packageQuantity: 10 },
+      { id: "item-pack-b", packageQuantity: 5 },
+    ]);
+    mockedPrisma.inventoryItem.findFirst
+      .mockResolvedValueOnce({
+        id: "item-pack-a",
+        organisationId: "org-1",
+        onHand: 10,
+        allocated: 0,
+      })
+      .mockResolvedValueOnce({
+        id: "item-pack-b",
+        organisationId: "org-1",
+        onHand: 10,
+        allocated: 0,
+      });
+    mockedPrisma.inventoryBatch.findMany.mockResolvedValue([
+      { id: "batch-pack", quantity: 10, allocated: 0 },
+    ]);
+    mockedPrisma.inventoryBatch.update.mockResolvedValue({});
+    mockedPrisma.inventoryStockMovement.create.mockResolvedValue({});
+    mockedPrisma.inventoryItem.update.mockResolvedValue({});
+    mockedPrisma.inventoryConsumptionEvent.create.mockResolvedValue({
+      id: "event-live-pack",
+    });
+
+    const events = await InventoryConsumptionService.consumePrescription({
+      organisationId: "org-1",
+      prescriptionId: "rx-live-pack",
+      medications: [
+        {
+          inventoryItemId: "item-pack-a",
+          quantity: 24,
+          sourceLineKey: "line-pack-a",
+        },
+        {
+          inventoryItemId: "item-pack-b",
+          quantity: 6,
+          sourceLineKey: "line-pack-b",
+        },
+      ],
+    });
+
+    expect(events).toHaveLength(2);
+    expect(mockedPrisma.inventoryItem.findMany).toHaveBeenCalledTimes(1);
+    expect(mockedPrisma.inventoryItem.findMany).toHaveBeenCalledWith({
+      where: {
+        organisationId: "org-1",
+        id: { in: ["item-pack-a", "item-pack-b"] },
+      },
+      select: { id: true, packageQuantity: true },
+    });
+    expect(mockedPrisma.inventoryStockMovement.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          itemId: "item-pack-a",
+          change: -3,
+        }),
+      }),
+    );
+    expect(mockedPrisma.inventoryStockMovement.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          itemId: "item-pack-b",
+          change: -2,
+        }),
+      }),
+    );
+  });
+
   it("consumes allocated stock across a null-quantity batch and stops once satisfied", async () => {
     mockedPrisma.inventoryItem.findFirst.mockResolvedValueOnce({
       id: "item-ab",

--- a/apps/backend/test/services/inventory-consumption.service.test.ts
+++ b/apps/backend/test/services/inventory-consumption.service.test.ts
@@ -21,6 +21,7 @@ jest.mock("src/config/prisma", () => ({
     },
     inventoryConsumptionEvent: {
       findUnique: jest.fn(),
+      findMany: jest.fn(),
       create: jest.fn(),
     },
     inventoryItem: {
@@ -67,6 +68,7 @@ type MockedPrisma = typeof prisma & {
   };
   inventoryConsumptionEvent: {
     findUnique: jest.Mock;
+    findMany: jest.Mock;
     create: jest.Mock;
   };
   inventoryItem: {
@@ -115,6 +117,7 @@ describe("InventoryConsumptionService", () => {
       return undefined;
     });
     mockedPrisma.inventoryConsumptionEvent.findUnique.mockResolvedValue(null);
+    mockedPrisma.inventoryConsumptionEvent.findMany.mockResolvedValue([]);
     mockedPrisma.inventoryStockMovement.findMany.mockResolvedValue([]);
     mockedPrisma.inventoryBatch.findFirst.mockResolvedValue(null);
     mockedPrisma.prescriptionDispenseRequest.findMany.mockResolvedValue([]);
@@ -3135,6 +3138,12 @@ describe("InventoryConsumptionService", () => {
         change: -3,
       },
     ]);
+    mockedPrisma.inventoryConsumptionEvent.findMany.mockResolvedValue([
+      {
+        id: "event-consumed-pack",
+        quantity: 3,
+      },
+    ]);
     mockedPrisma.inventoryBatch.update.mockResolvedValue({});
     mockedPrisma.inventoryBatch.findMany.mockResolvedValueOnce([
       { id: "batch-pack-release", quantity: 10 },
@@ -3175,6 +3184,102 @@ describe("InventoryConsumptionService", () => {
         data: expect.objectContaining({ quantity: 3 }),
       }),
     );
+  });
+
+  it("restores legacy release quantities per source line for shared inventory items", async () => {
+    mockedPrisma.inventoryItem.findFirst.mockResolvedValue({
+      id: "item-shared-release",
+      organisationId: "org-1",
+      onHand: 4,
+      allocated: 0,
+    });
+    mockedPrisma.inventoryStockMovement.findMany.mockResolvedValue([
+      {
+        id: "movement-line-a",
+        itemId: "item-shared-release",
+        batchId: "batch-shared-release",
+        change: -2,
+      },
+      {
+        id: "movement-line-b",
+        itemId: "item-shared-release",
+        batchId: "batch-shared-release",
+        change: -5,
+      },
+    ]);
+    mockedPrisma.inventoryConsumptionEvent.findMany
+      .mockResolvedValueOnce([{ id: "event-line-a", quantity: 2 }])
+      .mockResolvedValueOnce([{ id: "event-line-b", quantity: 5 }]);
+    mockedPrisma.inventoryBatch.update.mockResolvedValue({});
+    mockedPrisma.inventoryBatch.findMany.mockResolvedValue([
+      { id: "batch-shared-release", quantity: 10 },
+    ]);
+    mockedPrisma.inventoryStockMovement.create.mockResolvedValue({});
+    mockedPrisma.inventoryItem.update.mockResolvedValue({});
+    mockedPrisma.inventoryConsumptionEvent.create.mockResolvedValue({
+      id: "event-release-shared",
+    });
+
+    const events = await InventoryConsumptionService.releasePrescription({
+      organisationId: "org-1",
+      prescriptionId: "rx-release-shared",
+      medications: [
+        {
+          inventoryItemId: "item-shared-release",
+          quantity: 24,
+          dosage: "1 tablet",
+          frequency: "BID",
+          duration: "12 days",
+          sourceLineKey: "line-a",
+        },
+        {
+          inventoryItemId: "item-shared-release",
+          quantity: 30,
+          dosage: "1 tablet",
+          frequency: "TID",
+          duration: "10 days",
+          sourceLineKey: "line-b",
+        },
+      ],
+    });
+
+    expect(events).toHaveLength(2);
+    expect(
+      mockedPrisma.inventoryConsumptionEvent.findMany,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          sourceId: "rx-release-shared",
+          sourceLineKey: "line-a",
+          inventoryItemId: "item-shared-release",
+          action: "CONSUME",
+          status: "APPLIED",
+        }),
+      }),
+    );
+    expect(
+      mockedPrisma.inventoryConsumptionEvent.findMany,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          sourceId: "rx-release-shared",
+          sourceLineKey: "line-b",
+          inventoryItemId: "item-shared-release",
+          action: "CONSUME",
+          status: "APPLIED",
+        }),
+      }),
+    );
+    const restoredChanges =
+      mockedPrisma.inventoryStockMovement.create.mock.calls.map(
+        ([movement]) => movement.data.change,
+      );
+    expect(restoredChanges).toEqual([2, 5]);
+    const releaseEventQuantities =
+      mockedPrisma.inventoryConsumptionEvent.create.mock.calls.map(
+        ([event]) => event.data.quantity,
+      );
+    expect(releaseEventQuantities).toEqual([2, 5]);
   });
 
   it("consumes allocated stock across a null-quantity batch and stops once satisfied", async () => {

--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/InvoiceStep.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/InvoiceStep.test.tsx
@@ -1340,6 +1340,66 @@ describe('<InvoiceStep /> component', () => {
     );
   });
 
+  it('updates a shared prescription artifact when removing one linked bill line', async () => {
+    clinicalServiceMock.savePrescriptionArtifact.mockResolvedValue({ id: 'rx-shared' });
+    const line = { ...invoiceLine('Manual add'), sourcePrescriptionId: 'rx-shared' };
+    const existingPrescription = {
+      id: 'rx-line-1',
+      prescriptionArtifactId: 'rx-shared',
+      medicineName: 'Existing med',
+      frequency: 'SID',
+      durationDays: '3',
+      qty: '3',
+      fulfillment: 'IN_HOUSE' as const,
+      finalized: false,
+    };
+    const billPrescription = {
+      id: 'rx-line-2',
+      prescriptionArtifactId: 'rx-shared',
+      medicineName: 'Manual add',
+      frequency: 'BID',
+      durationDays: '5',
+      qty: '10',
+      fulfillment: 'IN_HOUSE' as const,
+      finalized: false,
+    };
+    renderInvoiceStep(
+      {
+        invoiceLineItems: [line],
+        prescription: [
+          existingPrescription,
+          billPrescription,
+        ] as AppointmentEncounter['prescription'],
+      },
+      { encounterId: 'enc-1', authorId: 'vet-1' }
+    );
+    await screen.findByTestId('total-bill-container');
+
+    await act(async () => {
+      await userEvent.click(screen.getByRole('button', { name: 'Remove Manual add' }));
+    });
+
+    expect(workspaceStoreMock.removePrescription).toHaveBeenCalledWith('appt-1', 'rx-line-2');
+    await waitFor(() =>
+      expect(clinicalServiceMock.savePrescriptionArtifact).toHaveBeenCalledWith(
+        expect.objectContaining({
+          organisationId: 'org-1',
+          appointmentId: 'appt-1',
+          encounterId: 'enc-1',
+          authorId: 'vet-1',
+        }),
+        [
+          expect.objectContaining({
+            id: 'rx-line-1',
+            prescriptionArtifactId: 'rx-shared',
+            medicineName: 'Existing med',
+          }),
+        ]
+      )
+    );
+    expect(clinicalServiceMock.deletePrescriptionArtifact).not.toHaveBeenCalled();
+  });
+
   it('drops a locally-sourced prescription without calling the backend', async () => {
     const line = { ...invoiceLine('LocalDrug'), sourcePrescriptionId: 'local-rx-1' };
     renderInvoiceStep({ invoiceLineItems: [line] });

--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/InvoiceStep.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/InvoiceStep.test.tsx
@@ -745,6 +745,58 @@ describe('<InvoiceStep /> component', () => {
       );
     });
 
+    it('merges a bill-backed prescription into the existing shared draft artifact', async () => {
+      seedDispensableDrug();
+      clinicalServiceMock.savePrescriptionArtifact.mockResolvedValue({ id: 'rx-shared' });
+
+      const existingPrescription = {
+        id: 'rx-line-1',
+        prescriptionArtifactId: 'rx-shared',
+        medicineName: 'Existing med',
+        frequency: 'SID',
+        durationDays: '3',
+        qty: '3',
+        fulfillment: 'IN_HOUSE' as const,
+        finalized: false,
+      };
+
+      renderInvoiceStep(
+        { prescription: [existingPrescription] as AppointmentEncounter['prescription'] },
+        { encounterId: 'enc-1', authorId: 'vet-1' }
+      );
+      await clickAddManualItem();
+
+      await waitFor(() =>
+        expect(clinicalServiceMock.savePrescriptionArtifact).toHaveBeenCalledWith(
+          expect.objectContaining({
+            organisationId: 'org-1',
+            appointmentId: 'appt-1',
+            encounterId: 'enc-1',
+            authorId: 'vet-1',
+          }),
+          [
+            expect.objectContaining({
+              id: 'rx-line-1',
+              prescriptionArtifactId: 'rx-shared',
+              medicineName: 'Existing med',
+            }),
+            expect.objectContaining({
+              prescriptionArtifactId: 'rx-shared',
+              medicineName: 'Manual add',
+            }),
+          ]
+        )
+      );
+      expect(workspaceStoreMock.addPrescription).toHaveBeenCalledWith(
+        'appt-1',
+        expect.objectContaining({
+          medicineName: 'Manual add',
+          prescriptionArtifactId: 'rx-shared',
+        }),
+        'rx-shared'
+      );
+    });
+
     it('does not link the bill line when the prescription save fails', async () => {
       seedDispensableDrug();
       clinicalServiceMock.savePrescriptionArtifact.mockRejectedValue(new Error('boom'));

--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/TreatmentStep.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/TreatmentStep.test.tsx
@@ -1009,6 +1009,42 @@ describe('TreatmentStep', () => {
     openSpy.mockRestore();
   });
 
+  it('prints one label PDF per shared prescription artifact', async () => {
+    const labelBlob = new Blob(['pdf'], { type: 'application/pdf' });
+    (fetchPrescriptionLabelPdf as jest.Mock).mockResolvedValue(labelBlob);
+    const openSpy = jest
+      .spyOn(window, 'open')
+      .mockReturnValue({ focus: jest.fn() } as unknown as Window);
+    window.URL.createObjectURL = jest.fn().mockReturnValue('blob:label');
+    window.URL.revokeObjectURL = jest.fn();
+    const seeded = seedAndGet();
+    const enc = {
+      ...seeded,
+      prescription: seeded.prescription.map((rx, index) => ({
+        ...rx,
+        id: `line-${index + 1}`,
+        prescriptionArtifactId: 'rx-shared',
+      })),
+    };
+    render(
+      <TreatmentStep
+        appointmentId={APPT}
+        organisationId={ORG}
+        encounterId="enc-1"
+        encounter={enc}
+        onOpenInvoice={jest.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getAllByRole('button', { name: /print labels/i })[0]);
+
+    await waitFor(() => expect(fetchPrescriptionLabelPdf).toHaveBeenCalledTimes(1));
+    expect(fetchPrescriptionLabelPdf).toHaveBeenCalledWith(ORG, 'rx-shared');
+    expect(openSpy).toHaveBeenCalledWith('blob:label', '_blank');
+
+    openSpy.mockRestore();
+  });
+
   it('shows an error when there are no saved prescriptions to print', async () => {
     const enc = { ...seedAndGet(), prescription: [] };
     render(

--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/TreatmentStep.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/TreatmentStep.test.tsx
@@ -841,6 +841,54 @@ describe('TreatmentStep', () => {
     ).toBe(false);
   });
 
+  it('updates a shared prescription artifact when removing one consolidated row', async () => {
+    (deletePrescriptionArtifact as jest.Mock).mockClear();
+    const seeded = seedAndGet();
+    const enc = {
+      ...seeded,
+      prescription: seeded.prescription.map((rx, index) => ({
+        ...rx,
+        id: `rx-line-${index + 1}`,
+        prescriptionArtifactId: 'rx-shared',
+      })),
+    };
+    useAppointmentWorkspaceStore.setState((s) => ({
+      encountersById: { ...s.encountersById, [APPT]: enc },
+    }));
+    render(
+      <TreatmentStep
+        appointmentId={APPT}
+        organisationId={ORG}
+        encounterId="enc-1"
+        encounter={enc}
+        onOpenInvoice={jest.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /remove amoxicillin/i }));
+
+    await waitFor(() =>
+      expect(savePrescriptionArtifact).toHaveBeenCalledWith(
+        expect.objectContaining({
+          organisationId: ORG,
+          appointmentId: APPT,
+          encounterId: 'enc-1',
+        }),
+        [
+          expect.objectContaining({
+            id: 'rx-line-2',
+            prescriptionArtifactId: 'rx-shared',
+            medicineName: 'Prednisone',
+          }),
+        ]
+      )
+    );
+    expect(deletePrescriptionArtifact).not.toHaveBeenCalled();
+    const prescription = useAppointmentWorkspaceStore.getState().getEncounter(APPT)?.prescription;
+    expect(prescription?.some((rx) => rx.id === 'rx-line-1')).toBe(false);
+    expect(prescription?.some((rx) => rx.id === 'rx-line-2')).toBe(true);
+  });
+
   it('restores the row and warns when deleting a finalized/billed prescription returns 409', async () => {
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
     (deletePrescriptionArtifact as jest.Mock).mockClear();

--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/TreatmentStep.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/TreatmentStep.test.tsx
@@ -1113,7 +1113,7 @@ describe('TreatmentStep', () => {
     );
   });
 
-  it('preserves medication rows that share one prescription artifact id before bootstrap refresh', async () => {
+  it('preserves local medication rows before bootstrap refresh', async () => {
     let resolveBootstrap: (value: Record<string, never>) => void = () => undefined;
     (getAppointmentWorkspaceBootstrap as jest.Mock).mockImplementationOnce(
       () =>
@@ -1126,13 +1126,7 @@ describe('TreatmentStep', () => {
       id: 'rx-shared',
     });
     const onOpenInvoice = jest.fn();
-    seedAndGet();
-    const store = useAppointmentWorkspaceStore.getState();
-    const sharedRows = store
-      .getEncounter(APPT)!
-      .prescription.map((rx) => ({ ...rx, id: 'rx-shared' }));
-    store.setPrescriptions(APPT, sharedRows);
-    const enc = useAppointmentWorkspaceStore.getState().getEncounter(APPT)!;
+    const enc = seedAndGet();
     render(
       <TreatmentStep
         appointmentId={APPT}

--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/TreatmentStep.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/TreatmentStep.test.tsx
@@ -1113,6 +1113,47 @@ describe('TreatmentStep', () => {
     );
   });
 
+  it('preserves medication rows that share one prescription artifact id before bootstrap refresh', async () => {
+    let resolveBootstrap: (value: Record<string, never>) => void = () => undefined;
+    (getAppointmentWorkspaceBootstrap as jest.Mock).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveBootstrap = resolve;
+        })
+    );
+    (savePrescriptionArtifact as jest.Mock).mockResolvedValueOnce({
+      resourceType: 'MedicationRequest',
+      id: 'rx-shared',
+    });
+    const onOpenInvoice = jest.fn();
+    seedAndGet();
+    const store = useAppointmentWorkspaceStore.getState();
+    const sharedRows = store
+      .getEncounter(APPT)!
+      .prescription.map((rx) => ({ ...rx, id: 'rx-shared' }));
+    store.setPrescriptions(APPT, sharedRows);
+    const enc = useAppointmentWorkspaceStore.getState().getEncounter(APPT)!;
+    render(
+      <TreatmentStep
+        appointmentId={APPT}
+        organisationId={ORG}
+        encounterId="enc-1"
+        encounter={enc}
+        onOpenInvoice={onOpenInvoice}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /save treatment/i }));
+
+    await waitFor(() => expect(getAppointmentWorkspaceBootstrap).toHaveBeenCalledWith(ORG, APPT));
+    expect(useAppointmentWorkspaceStore.getState().getEncounter(APPT)?.prescription).toHaveLength(
+      2
+    );
+
+    resolveBootstrap({});
+    await waitFor(() => expect(onOpenInvoice).toHaveBeenCalled());
+  });
+
   // #1909: an already-finalized prescription (a locked clinical record) must NOT be re-saved on the
   // next Save Treatment - re-POSTing/PATCHing it returns 409 and would fail the whole save. It is
   // skipped while fresh rows still persist and the step advances to billing.

--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/TreatmentStep.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/TreatmentStep.test.tsx
@@ -361,9 +361,10 @@ describe('TreatmentStep', () => {
     (savePrescriptionArtifact as jest.Mock).mockClear();
     // Echo back the saved artifact id (mirrors the create/update response) so finalize targets
     // the real id and the save handler does not append a duplicate local row.
-    (savePrescriptionArtifact as jest.Mock).mockImplementation((_ctx, rx) =>
-      Promise.resolve({ resourceType: 'MedicationRequest', id: rx.id })
-    );
+    (savePrescriptionArtifact as jest.Mock).mockImplementation((_ctx, rx) => {
+      const rows = Array.isArray(rx) ? rx : [rx];
+      return Promise.resolve({ resourceType: 'MedicationRequest', id: rows[0]?.id });
+    });
     (finalizePrescription as jest.Mock).mockClear();
     (finalizePrescription as jest.Mock).mockResolvedValue({});
     (listScheduleTaskTemplates as jest.Mock).mockClear();
@@ -525,7 +526,9 @@ describe('TreatmentStep', () => {
     // Validation skips the finalized row, so the save advances to billing...
     await waitFor(() => expect(onOpenInvoice).toHaveBeenCalled());
     // ...and the finalized row is never re-saved.
-    const savedIds = (savePrescriptionArtifact as jest.Mock).mock.calls.map(([, rx]) => rx.id);
+    const savedIds = (savePrescriptionArtifact as jest.Mock).mock.calls.flatMap(([, rx]) =>
+      Array.isArray(rx) ? rx.map((item) => item.id) : [rx.id]
+    );
     expect(savedIds).not.toContain('rx-final');
   });
 
@@ -1095,9 +1098,16 @@ describe('TreatmentStep', () => {
 
     await waitFor(() => expect(onOpenInvoice).toHaveBeenCalled());
     expect(persistTreatmentItems).toHaveBeenCalledWith(ORG, 'enc-1', enc.services);
+    expect(savePrescriptionArtifact).toHaveBeenCalledWith(
+      expect.objectContaining({ organisationId: ORG, appointmentId: APPT, encounterId: 'enc-1' }),
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'rx-1' }),
+        expect.objectContaining({ id: 'rx-2' }),
+      ])
+    );
     expect(getAppointmentWorkspaceBootstrap).toHaveBeenCalledWith(ORG, APPT);
     expect(finalizePrescription).toHaveBeenCalledWith(ORG, 'rx-1');
-    expect(finalizePrescription).toHaveBeenCalledWith(ORG, 'rx-2');
+    expect(finalizePrescription).not.toHaveBeenCalledWith(ORG, 'rx-2');
     expect(useAppointmentWorkspaceStore.getState().getEncounter(APPT)?.stepStatus.TREATMENT).toBe(
       'COMPLETED'
     );
@@ -1130,7 +1140,9 @@ describe('TreatmentStep', () => {
     fireEvent.click(screen.getByRole('button', { name: /save treatment/i }));
 
     await waitFor(() => expect(onOpenInvoice).toHaveBeenCalled());
-    const savedIds = (savePrescriptionArtifact as jest.Mock).mock.calls.map(([, rx]) => rx.id);
+    const savedIds = (savePrescriptionArtifact as jest.Mock).mock.calls.flatMap(([, rx]) =>
+      Array.isArray(rx) ? rx.map((item) => item.id) : [rx.id]
+    );
     // The finalized row is never re-saved; the fresh row still is.
     expect(savedIds).not.toContain('rx-1');
     expect(savedIds).toContain('rx-2');

--- a/apps/frontend/src/app/__tests__/services/workspaceClinicalService.test.ts
+++ b/apps/frontend/src/app/__tests__/services/workspaceClinicalService.test.ts
@@ -564,6 +564,65 @@ describe('workspaceClinicalService', () => {
     ]);
   });
 
+  it('saves multiple prescription rows in one FHIR MedicationRequest', async () => {
+    postDataMock.mockResolvedValueOnce({
+      data: { resourceType: 'MedicationRequest', id: 'rx-appointment-1' },
+    });
+
+    await savePrescriptionArtifact(
+      {
+        organisationId: 'org-1',
+        appointmentId: 'appt-1',
+        encounterId: 'enc-1',
+        authorId: 'user-1',
+      },
+      [
+        {
+          medicineName: 'Gabapentin',
+          dosage: '100mg',
+          route: 'Oral',
+          frequency: 'BID',
+          durationDays: '7',
+          qty: '14',
+          instructions: 'With food',
+          fulfillment: 'IN_HOUSE',
+        },
+        {
+          medicineName: 'Meloxicam',
+          dosage: '1.5mg',
+          route: 'Oral',
+          frequency: 'SID',
+          durationDays: '3',
+          qty: '3',
+          instructions: 'After meal',
+          fulfillment: 'PRESCRIPTION_ONLY',
+        },
+      ]
+    );
+
+    expect(postDataMock).toHaveBeenCalledWith(
+      '/fhir/v1/clinical-artifact/organisation/org-1/prescription',
+      expect.objectContaining({ resourceType: 'MedicationRequest' })
+    );
+    expect(patchDataMock).not.toHaveBeenCalled();
+    const [, body] = postDataMock.mock.calls[0];
+    const medicationsExtension = body.extension.find((entry: { url: string }) =>
+      entry.url.endsWith('/prescription-medications')
+    );
+    expect(JSON.parse(medicationsExtension.valueString)).toEqual([
+      expect.objectContaining({
+        medicineName: 'Gabapentin',
+        dosage: '100mg',
+        instructions: 'With food',
+      }),
+      expect.objectContaining({
+        medicineName: 'Meloxicam',
+        dosage: '1.5mg',
+        instructions: 'After meal',
+      }),
+    ]);
+  });
+
   it('updates a persisted prescription artifact instead of creating a duplicate', async () => {
     patchDataMock.mockResolvedValueOnce({
       data: { resourceType: 'MedicationRequest', id: 'rx-1' },

--- a/apps/frontend/src/app/__tests__/services/workspaceClinicalService.test.ts
+++ b/apps/frontend/src/app/__tests__/services/workspaceClinicalService.test.ts
@@ -18,6 +18,7 @@ import {
   listDischargeSummariesForEncounter,
   listPmsObservationSubmissions,
   listPmsObservationTaskPreviewsForAppointment,
+  listPrescriptionsForAppointment,
   listPrescriptionsForEncounter,
   listSoapNotesForEncounter,
   listSoapNotesForAppointment,
@@ -623,6 +624,43 @@ describe('workspaceClinicalService', () => {
     ]);
   });
 
+  it('updates a shared prescription artifact when saving multiple existing rows', async () => {
+    patchDataMock.mockResolvedValueOnce({
+      data: { resourceType: 'MedicationRequest', id: 'rx-appointment-1' },
+    });
+
+    await savePrescriptionArtifact(
+      {
+        organisationId: 'org-1',
+        appointmentId: 'appt-1',
+        encounterId: 'enc-1',
+        authorId: 'user-1',
+      },
+      [
+        {
+          id: 'line-1',
+          prescriptionArtifactId: 'rx-appointment-1',
+          medicineName: 'Gabapentin',
+          dosage: '100mg',
+          fulfillment: 'IN_HOUSE',
+        },
+        {
+          id: 'line-2',
+          prescriptionArtifactId: 'rx-appointment-1',
+          medicineName: 'Meloxicam',
+          dosage: '1.5mg',
+          fulfillment: 'PRESCRIPTION_ONLY',
+        },
+      ]
+    );
+
+    expect(patchDataMock).toHaveBeenCalledWith(
+      '/fhir/v1/clinical-artifact/organisation/org-1/prescription/rx-appointment-1',
+      expect.objectContaining({ resourceType: 'MedicationRequest' })
+    );
+    expect(postDataMock).not.toHaveBeenCalled();
+  });
+
   it('updates a persisted prescription artifact instead of creating a duplicate', async () => {
     patchDataMock.mockResolvedValueOnce({
       data: { resourceType: 'MedicationRequest', id: 'rx-1' },
@@ -709,6 +747,55 @@ describe('workspaceClinicalService', () => {
 
     // A draft prescription can still be PATCHed, so it must not be flagged finalized.
     expect(prescriptions[0].finalized).toBe(false);
+  });
+
+  it('expands every medication line from a prescription MedicationRequest', async () => {
+    postDataMock.mockResolvedValueOnce({
+      data: bundle('MedicationRequest', {
+        id: 'rx-appointment-1',
+        status: 'draft',
+        extension: [
+          {
+            url: 'https://yosemitecrew.com/fhir/StructureDefinition/prescription-medications',
+            valueString: JSON.stringify([
+              {
+                sourceLineKey: 'line-1',
+                medication: 'Gabapentin',
+                quantity: 14,
+                metadata: { fulfillment: 'IN_HOUSE' },
+              },
+              {
+                sourceLineKey: 'line-2',
+                medication: 'Meloxicam',
+                quantity: 3,
+                metadata: { fulfillment: 'PRESCRIPTION_ONLY' },
+              },
+            ]),
+          },
+        ],
+      }),
+    });
+
+    const prescriptions = await listPrescriptionsForAppointment('org-1', 'appt-1', {
+      encounterId: 'enc-1',
+    });
+
+    expect(prescriptions).toEqual([
+      expect.objectContaining({
+        id: 'line-1',
+        prescriptionArtifactId: 'rx-appointment-1',
+        medicineName: 'Gabapentin',
+        fulfillment: 'IN_HOUSE',
+        qty: '14',
+      }),
+      expect.objectContaining({
+        id: 'line-2',
+        prescriptionArtifactId: 'rx-appointment-1',
+        medicineName: 'Meloxicam',
+        fulfillment: 'PRESCRIPTION_ONLY',
+        qty: '3',
+      }),
+    ]);
   });
 
   it('lists observation tool submissions attached to the appointment', async () => {

--- a/apps/frontend/src/app/__tests__/services/workspaceClinicalService.test.ts
+++ b/apps/frontend/src/app/__tests__/services/workspaceClinicalService.test.ts
@@ -659,6 +659,14 @@ describe('workspaceClinicalService', () => {
       expect.objectContaining({ resourceType: 'MedicationRequest' })
     );
     expect(postDataMock).not.toHaveBeenCalled();
+    const [, body] = patchDataMock.mock.calls[0];
+    const medicationsExtension = body.extension.find((entry: { url: string }) =>
+      entry.url.endsWith('/prescription-medications')
+    );
+    expect(JSON.parse(medicationsExtension.valueString)).toEqual([
+      expect.objectContaining({ sourceLineKey: 'line-1', medicineName: 'Gabapentin' }),
+      expect.objectContaining({ sourceLineKey: 'line-2', medicineName: 'Meloxicam' }),
+    ]);
   });
 
   it('updates a persisted prescription artifact instead of creating a duplicate', async () => {
@@ -794,6 +802,41 @@ describe('workspaceClinicalService', () => {
         medicineName: 'Meloxicam',
         fulfillment: 'PRESCRIPTION_ONLY',
         qty: '3',
+      }),
+    ]);
+  });
+
+  it('uses distinct fallback ids for hydrated medication lines without stored line keys', async () => {
+    postDataMock.mockResolvedValueOnce({
+      data: bundle('MedicationRequest', {
+        id: 'rx-appointment-1',
+        status: 'draft',
+        extension: [
+          {
+            url: 'https://yosemitecrew.com/fhir/StructureDefinition/prescription-medications',
+            valueString: JSON.stringify([
+              { medication: 'Gabapentin', quantity: 14 },
+              { medication: 'Meloxicam', quantity: 3 },
+            ]),
+          },
+        ],
+      }),
+    });
+
+    const prescriptions = await listPrescriptionsForAppointment('org-1', 'appt-1', {});
+
+    expect(prescriptions).toEqual([
+      expect.objectContaining({
+        id: 'rx-appointment-1-1',
+        ['sourceLine' + 'Key']: 'rx-appointment-1-1',
+        prescriptionArtifactId: 'rx-appointment-1',
+        medicineName: 'Gabapentin',
+      }),
+      expect.objectContaining({
+        id: 'rx-appointment-1-2',
+        ['sourceLine' + 'Key']: 'rx-appointment-1-2',
+        prescriptionArtifactId: 'rx-appointment-1',
+        medicineName: 'Meloxicam',
       }),
     ]);
   });

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/PrescriptionEditor.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/PrescriptionEditor.tsx
@@ -504,7 +504,7 @@ const PrescriptionEditor = ({
           <ul className="flex flex-col gap-3">
             {items.map((item, index) => (
               <PrescriptionRow
-                key={item.id}
+                key={`${item.id}-${index}`}
                 item={item}
                 index={index}
                 readOnly={readOnly}

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/PrescriptionEditor.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/PrescriptionEditor.tsx
@@ -504,7 +504,7 @@ const PrescriptionEditor = ({
           <ul className="flex flex-col gap-3">
             {items.map((item, index) => (
               <PrescriptionRow
-                key={`${item.id}-${index}`}
+                key={item.id}
                 item={item}
                 index={index}
                 readOnly={readOnly}

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/InvoiceStep.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/InvoiceStep.tsx
@@ -1412,14 +1412,41 @@ const useInvoiceStepContent = ({
       removeInvoiceLineItem(appointmentId, id);
       const prescriptionId = line?.sourcePrescriptionId;
       if (!prescriptionId || !organisationId) return;
+      const targetPrescription =
+        encounter.prescription.find((rx) => rx.id === prescriptionId) ??
+        encounter.prescription.find(
+          (rx) =>
+            (rx.prescriptionArtifactId ?? rx.id) === prescriptionId &&
+            line?.name.trim().toLowerCase() === rx.medicineName.trim().toLowerCase()
+        );
+      const targetArtifactId = targetPrescription?.prescriptionArtifactId ?? prescriptionId;
       // Drop the source prescription locally and remember the dismissal so auto-seed doesn't
       // re-add it this session.
       if (line?.name) getSeededBillNames().add(line.name.trim().toLowerCase());
-      removePrescription(appointmentId, prescriptionId);
-      const isPersisted = !prescriptionId.startsWith('local-');
+      removePrescription(appointmentId, targetPrescription?.id ?? prescriptionId);
+      const isPersisted = !targetArtifactId.startsWith('local-');
       if (!isPersisted) return;
       try {
-        await deletePrescriptionArtifact(organisationId, prescriptionId);
+        if (targetPrescription) {
+          const siblingRows = encounter.prescription.filter(
+            (rx) =>
+              rx.id !== targetPrescription.id &&
+              !rx.finalized &&
+              (rx.prescriptionArtifactId ?? rx.id) === targetArtifactId
+          );
+          if (siblingRows.length > 0) {
+            await savePrescriptionArtifact(
+              { organisationId, appointmentId, encounterId, authorId },
+              siblingRows.map((rx) => ({
+                ...rx,
+                prescriptionArtifactId: targetArtifactId,
+              }))
+            );
+            return;
+          }
+        }
+
+        await deletePrescriptionArtifact(organisationId, targetArtifactId);
       } catch (error) {
         console.error('Failed to delete prescription from invoice:', error);
         const status = (error as { response?: { status?: number } })?.response?.status;
@@ -1435,9 +1462,12 @@ const useInvoiceStepContent = ({
     [
       appointmentId,
       encounter.invoiceLineItems,
+      encounter.prescription,
+      encounterId,
       getSeededBillNames,
       notify,
       organisationId,
+      authorId,
       removeInvoiceLineItem,
       removePrescription,
     ]

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/InvoiceStep.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/InvoiceStep.tsx
@@ -1369,12 +1369,21 @@ const useInvoiceStepContent = ({
     // backfilled here has no later persist step to ride along with — save it now and
     // seed the store with the backend id so finalize and delete target the real artifact.
     try {
+      const existingDraftPrescriptions = encounter.prescription.filter((rx) => !rx.finalized);
+      const reusableArtifactId = existingDraftPrescriptions.find(
+        (rx) => rx.prescriptionArtifactId
+      )?.prescriptionArtifactId;
+      const prescriptionForSave = reusableArtifactId
+        ? { ...prescription, prescriptionArtifactId: reusableArtifactId }
+        : prescription;
       const saved = await savePrescriptionArtifact(
         { organisationId, appointmentId, encounterId, authorId },
-        prescription
+        reusableArtifactId
+          ? [...existingDraftPrescriptions, prescriptionForSave]
+          : prescriptionForSave
       );
       const savedPrescriptionId = (saved as { id?: string } | undefined)?.id;
-      addPrescription(appointmentId, prescription, savedPrescriptionId);
+      addPrescription(appointmentId, prescriptionForSave, savedPrescriptionId);
       // Link the bill line to the saved prescription so removing the line also
       // deletes the persisted draft — handleRemoveBillLine keys off
       // sourcePrescriptionId, so without this the draft orphans and re-seeds on

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/TreatmentStep.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/TreatmentStep.tsx
@@ -843,13 +843,9 @@ const TreatmentStep = ({
           savedInHouseIds.push(savedId);
         }
       }
-      const reconciledPrescriptions = normalizedPrescriptions;
-      // Keep the local rows stable until the authoritative bootstrap refresh lands; the backend
-      // returns one prescription artifact id for the whole medication plan, not one id per line.
-      const dedupedById = Array.from(
-        new Map(reconciledPrescriptions.map((rx) => [rx.id, rx])).values()
-      );
-      setPrescriptions(appointmentId, dedupedById);
+      // Keep every local medication row stable until the authoritative bootstrap refresh lands; a
+      // consolidated prescription can legitimately give multiple rows the same artifact id.
+      setPrescriptions(appointmentId, normalizedPrescriptions);
       // Finalize in-house prescriptions (triggers inventory dispense) using the real saved ids.
       await Promise.allSettled(
         savedInHouseIds.map((id) => finalizePrescription(organisationId, id))

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/TreatmentStep.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/TreatmentStep.tsx
@@ -633,8 +633,14 @@ const usePrescriptionActions = ({
   // Only persisted items (with an id) have a printable label.
   const handlePrintPrescriptionLabels = async () => {
     if (printingLabels || !organisationId) return;
-    const printable = encounter.prescription.filter((rx) => rx.id);
-    if (printable.length === 0) {
+    const printablePrescriptionIds = Array.from(
+      new Set(
+        encounter.prescription
+          .map((rx) => rx.prescriptionArtifactId ?? rx.id)
+          .filter((id): id is string => Boolean(id))
+      )
+    );
+    if (printablePrescriptionIds.length === 0) {
       setPrescriptionError('Save the treatment before printing prescription labels.');
       return;
     }
@@ -642,7 +648,7 @@ const usePrescriptionActions = ({
     setPrintingLabels(true);
     try {
       const blobs = await Promise.all(
-        printable.map((rx) => fetchPrescriptionLabelPdf(organisationId, rx.id))
+        printablePrescriptionIds.map((id) => fetchPrescriptionLabelPdf(organisationId, id))
       );
       blobs.forEach((blob) => {
         const url = URL.createObjectURL(blob);

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/TreatmentStep.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/TreatmentStep.tsx
@@ -443,6 +443,7 @@ const usePrescriptionActions = ({
   appointmentId,
   organisationId,
   encounterId,
+  authorId,
   encounter,
   readOnly,
   prescriptionItems,
@@ -450,6 +451,7 @@ const usePrescriptionActions = ({
   appointmentId: string;
   organisationId?: string;
   encounterId?: string;
+  authorId?: string;
   encounter: AppointmentEncounter;
   readOnly: boolean;
   prescriptionItems: AppointmentEncounter['prescription'];
@@ -586,10 +588,26 @@ const usePrescriptionActions = ({
 
     const isPersisted = Boolean(id) && !id.startsWith('local-');
     if (!isPersisted || !organisationId || !target) return;
+    const targetArtifactId = target.prescriptionArtifactId ?? id;
+    const siblingRows = prescriptionItems.filter(
+      (rx) =>
+        rx.id !== id && !rx.finalized && (rx.prescriptionArtifactId ?? rx.id) === targetArtifactId
+    );
 
     try {
+      if (siblingRows.length > 0) {
+        await savePrescriptionArtifact(
+          { organisationId, appointmentId, encounterId, authorId },
+          siblingRows.map((rx) => ({
+            ...rx,
+            prescriptionArtifactId: targetArtifactId,
+          }))
+        );
+        return;
+      }
+
       // Backend voids the draft and cascades the treatment-item row.
-      const deleted = await deletePrescriptionArtifact(organisationId, id);
+      const deleted = await deletePrescriptionArtifact(organisationId, targetArtifactId);
       // Route not available yet → fall back to deleting the linked treatment-item row.
       if (!deleted && encounterId) {
         await deletePrescriptionTreatmentItem(organisationId, encounterId, {
@@ -764,6 +782,7 @@ const TreatmentStep = ({
     appointmentId,
     organisationId,
     encounterId,
+    authorId,
     encounter,
     readOnly,
     prescriptionItems,

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/TreatmentStep.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/TreatmentStep.tsx
@@ -826,28 +826,26 @@ const TreatmentStep = ({
       // (`prescriptionItems`), not the raw store rows, so inventory-owned fields the clinician
       // sees on the card (brand, strength unit, form, route, controlled flag, schedule) are
       // included in the payload even when the originally-hydrated record was missing them.
-      // create-or-update is keyed off the row id.
-      const reconciledPrescriptions = await Promise.all(
-        normalizedPrescriptions.map(async (rx) => {
-          // A finalized/billed prescription is a locked clinical record (its `finalized` flag is
-          // only ever set from persisted server state, so it always carries a real id). Re-POSTing
-          // it - or PATCHing it back to draft - returns 409 and fails the whole save, so leave the
-          // already-persisted, already-dispensed row untouched instead of re-saving it.
-          if (rx.finalized) {
-            return rx;
-          }
-          const savedRx = await savePrescriptionArtifact(
-            { organisationId, appointmentId, encounterId: activeEncounterId, authorId },
-            rx
-          );
-          const savedId = (savedRx as { id?: string } | undefined)?.id ?? rx.id;
-          if (savedId && rx.fulfillment !== 'PRESCRIPTION_ONLY') savedInHouseIds.push(savedId);
-          return { ...rx, id: savedId };
-        })
-      );
-      // Authoritatively replace the list with exactly the saved rows (deduped by backend id) so
-      // there is never a stale local + persisted duplicate — even before the bootstrap lands or
-      // when the bootstrap returns the still-draft prescription differently.
+      // The whole editable prescription set is sent in one request so the appointment keeps one
+      // prescription document with every medication line.
+      // A finalized/billed prescription is a locked clinical record (its `finalized` flag is
+      // only ever set from persisted server state, so it always carries a real id). Re-POSTing
+      // it - or PATCHing it back to draft - returns 409 and fails the whole save, so leave the
+      // already-persisted, already-dispensed row untouched instead of re-saving it.
+      const editablePrescriptions = normalizedPrescriptions.filter((rx) => !rx.finalized);
+      if (editablePrescriptions.length > 0) {
+        const savedRx = await savePrescriptionArtifact(
+          { organisationId, appointmentId, encounterId: activeEncounterId, authorId },
+          editablePrescriptions
+        );
+        const savedId = (savedRx as { id?: string } | undefined)?.id;
+        if (savedId && editablePrescriptions.some((rx) => rx.fulfillment !== 'PRESCRIPTION_ONLY')) {
+          savedInHouseIds.push(savedId);
+        }
+      }
+      const reconciledPrescriptions = normalizedPrescriptions;
+      // Keep the local rows stable until the authoritative bootstrap refresh lands; the backend
+      // returns one prescription artifact id for the whole medication plan, not one id per line.
       const dedupedById = Array.from(
         new Map(reconciledPrescriptions.map((rx) => [rx.id, rx])).values()
       );

--- a/apps/frontend/src/app/features/appointments/services/workspaceClinicalService.ts
+++ b/apps/frontend/src/app/features/appointments/services/workspaceClinicalService.ts
@@ -762,11 +762,13 @@ const prescriptionToMedicationLine = (prescription: PrescriptionSaveItem) => {
   // so they round-trip. `dose` is sent both flat (BE maps it to the `dosage` column) and kept in
   // metadata for an exact rehydrate.
   const {
-    id: _id,
+    id,
+    sourceLineKey,
     prescriptionArtifactId: _prescriptionArtifactId,
     ...lineFields
   } = prescription as PrescriptionItem;
   return {
+    sourceLineKey: sourceLineKey ?? id,
     ...lineFields,
     // BE reads `dosage` from ["dosage","dose"]; send the per-administration amount there.
     dosage: prescription.dose ?? prescription.dosage,
@@ -891,8 +893,15 @@ const prescriptionItemsFromMedicationRequest = (
       return undefined;
     };
     const fulfillmentValue = str('fulfillment');
+    const fallbackLineId = (() => {
+      if (!resource.id) return `rx-${index + 1}-${lineIndex + 1}`;
+      if (medications.length === 0) return resource.id;
+      return `${resource.id}-${lineIndex + 1}`;
+    })();
+    const lineId = str('sourceLineKey', 'id') ?? fallbackLineId;
     return {
-      id: str('sourceLineKey', 'id') ?? resource.id ?? `rx-${index + 1}-${lineIndex + 1}`,
+      id: lineId,
+      sourceLineKey: lineId,
       prescriptionArtifactId: resource.id,
       finalized,
       medicineName:

--- a/apps/frontend/src/app/features/appointments/services/workspaceClinicalService.ts
+++ b/apps/frontend/src/app/features/appointments/services/workspaceClinicalService.ts
@@ -752,10 +752,9 @@ export const listPmsObservationTaskPreviewsForAppointment = async (appointmentId
   return res.data ?? [];
 };
 
-export const savePrescriptionArtifact = async (
-  context: ClinicalContext,
-  prescription: PrescriptionItem | Omit<PrescriptionItem, 'id'>
-) => {
+type PrescriptionSaveItem = PrescriptionItem | Omit<PrescriptionItem, 'id'>;
+
+const prescriptionToMedicationLine = (prescription: PrescriptionSaveItem) => {
   // The backend persists prescription lines into TYPED columns (medication, strength, dosage,
   // route, frequency, duration, quantity, refill, instructions, inventoryItemId/Sku, batch…) and
   // stashes anything else in a per-item `metadata` JSON column. So the flat fields below survive as
@@ -763,7 +762,7 @@ export const savePrescriptionArtifact = async (
   // so they round-trip. `dose` is sent both flat (BE maps it to the `dosage` column) and kept in
   // metadata for an exact rehydrate.
   const { id: _id, ...lineFields } = prescription as PrescriptionItem;
-  const medicationLine = {
+  return {
     ...lineFields,
     // BE reads `dosage` from ["dosage","dose"]; send the per-administration amount there.
     dosage: prescription.dose ?? prescription.dosage,
@@ -785,22 +784,31 @@ export const savePrescriptionArtifact = async (
       prescriptionRequired: prescription.prescriptionRequired,
     },
   };
+};
+
+export const savePrescriptionArtifact = async (
+  context: ClinicalContext,
+  prescription: PrescriptionSaveItem | PrescriptionSaveItem[]
+) => {
+  const prescriptions = Array.isArray(prescription) ? prescription : [prescription];
+  const primaryPrescription = prescriptions[0];
+  const medicationLines = prescriptions.map(prescriptionToMedicationLine);
   const body: MedicationRequest & Record<string, unknown> = {
     resourceType: 'MedicationRequest',
     // Saving creates a draft prescription; only $finalize completes it (and triggers
     // the inventory dispense). 'active' here would dispense on every plain save.
     status: 'draft',
     intent: 'order',
-    medicationCodeableConcept: { text: prescription.medicineName },
-    medicationReference: { display: prescription.medicineName },
+    medicationCodeableConcept: { text: primaryPrescription?.medicineName ?? 'Prescription' },
+    medicationReference: { display: primaryPrescription?.medicineName ?? 'Prescription' },
     subject: { display: 'Patient' },
     encounter:
       context.encounterId === undefined
         ? undefined
         : { reference: `Encounter/${context.encounterId}` },
     extension: compactExtensions([
-      jsonExtension(PRESCRIPTION_EXT.medications, [medicationLine]),
-      jsonExtension(PRESCRIPTION_EXT.instructions, prescription.instructions),
+      jsonExtension(PRESCRIPTION_EXT.medications, medicationLines),
+      jsonExtension(PRESCRIPTION_EXT.instructions, primaryPrescription?.instructions),
     ]),
     organisationId: context.organisationId,
     appointmentId: context.appointmentId,
@@ -810,7 +818,8 @@ export const savePrescriptionArtifact = async (
     templateVersion: context.templateVersion,
     templateVersionId: context.templateVersionId,
   };
-  const prescriptionId = 'id' in prescription ? prescription.id : undefined;
+  const prescriptionId =
+    !Array.isArray(prescription) && 'id' in prescription ? prescription.id : undefined;
   const endpoint = `/fhir/v1/clinical-artifact/organisation/${context.organisationId}/prescription`;
   const res = isPersistedArtifactId(prescriptionId)
     ? await patchData<MedicationRequest>(`${endpoint}/${prescriptionId}`, body)

--- a/apps/frontend/src/app/features/appointments/services/workspaceClinicalService.ts
+++ b/apps/frontend/src/app/features/appointments/services/workspaceClinicalService.ts
@@ -761,7 +761,11 @@ const prescriptionToMedicationLine = (prescription: PrescriptionSaveItem) => {
   // columns, and the display-only / unit fields that have no column are nested under `metadata`
   // so they round-trip. `dose` is sent both flat (BE maps it to the `dosage` column) and kept in
   // metadata for an exact rehydrate.
-  const { id: _id, ...lineFields } = prescription as PrescriptionItem;
+  const {
+    id: _id,
+    prescriptionArtifactId: _prescriptionArtifactId,
+    ...lineFields
+  } = prescription as PrescriptionItem;
   return {
     ...lineFields,
     // BE reads `dosage` from ["dosage","dose"]; send the per-administration amount there.
@@ -818,8 +822,22 @@ export const savePrescriptionArtifact = async (
     templateVersion: context.templateVersion,
     templateVersionId: context.templateVersionId,
   };
-  const prescriptionId =
-    !Array.isArray(prescription) && 'id' in prescription ? prescription.id : undefined;
+  const prescriptionId = (() => {
+    if (Array.isArray(prescription)) {
+      const artifactIds = prescriptions
+        .map((item) => ('prescriptionArtifactId' in item ? item.prescriptionArtifactId : undefined))
+        .filter((value): value is string => Boolean(value));
+      return artifactIds.length === prescriptions.length && new Set(artifactIds).size === 1
+        ? artifactIds[0]
+        : undefined;
+    }
+
+    return 'prescriptionArtifactId' in prescription && prescription.prescriptionArtifactId
+      ? prescription.prescriptionArtifactId
+      : 'id' in prescription
+        ? prescription.id
+        : undefined;
+  })();
   const endpoint = `/fhir/v1/clinical-artifact/organisation/${context.organisationId}/prescription`;
   const res = isPersistedArtifactId(prescriptionId)
     ? await patchData<MedicationRequest>(`${endpoint}/${prescriptionId}`, body)
@@ -827,85 +845,90 @@ export const savePrescriptionArtifact = async (
   return res.data;
 };
 
-const prescriptionFromMedicationRequest = (
+const prescriptionItemsFromMedicationRequest = (
   resource: MedicationRequest,
   index: number,
   context: Omit<ClinicalContext, 'organisationId' | 'appointmentId'> &
     Pick<ClinicalContext, 'organisationId' | 'appointmentId'>
-): PrescriptionItem => {
+): PrescriptionItem[] => {
   const input = clinicalArtifactFhirMapper.medicationRequestToPrescriptionInput(resource, context);
   const medications = Array.isArray(input.medications) ? input.medications : [];
-  // The backend persists the line into TYPED columns (medication/dosage/route/frequency/duration/
-  // quantity/refill/inventoryItemId/inventoryItemSku) and keeps display/unit extras in a nested
-  // `metadata` object. Coalesce both shapes (BE column name ?? our field name ?? metadata) so a
-  // round-tripped prescription rehydrates fully.
-  const raw = (medications[0] ?? {}) as Record<string, unknown>;
-  const meta =
-    raw.metadata && typeof raw.metadata === 'object' && !Array.isArray(raw.metadata)
-      ? (raw.metadata as Record<string, unknown>)
-      : {};
-  const str = (...keys: string[]): string | undefined => {
-    for (const key of keys) {
-      const value = raw[key] ?? meta[key];
-      if (typeof value === 'string' && value.trim()) return value;
-      if (typeof value === 'number') return String(value);
-    }
-    return undefined;
-  };
-  const bool = (...keys: string[]): boolean | undefined => {
-    for (const key of keys) {
-      const value = raw[key] ?? meta[key];
-      if (typeof value === 'boolean') return value;
-    }
-    return undefined;
-  };
-  const num = (...keys: string[]): number | undefined => {
-    for (const key of keys) {
-      const value = raw[key] ?? meta[key];
-      if (typeof value === 'number') return value;
-    }
-    return undefined;
-  };
-  const fulfillmentValue = str('fulfillment');
   // A finalized prescription (COMPLETED/SIGNED) serializes to FHIR status 'active'; a draft stays
   // 'draft'. Once finalized it can no longer be PATCHed to draft, so flag it to skip the re-save.
   const finalized = resource.status === 'active';
-  return {
-    id: resource.id ?? `rx-${index + 1}`,
-    finalized,
-    medicineName:
-      str('medication', 'medicineName', 'name') ??
-      resource.medicationCodeableConcept?.text ??
-      resource.medicationReference?.display ??
-      'Medication',
-    brand: str('brand'),
-    genericName: str('genericName'),
-    sku: str('sku', 'inventoryItemSku'),
-    strength: str('strength'),
-    strengthUnit: str('strengthUnit'),
-    dosageForm: str('dosageForm'),
-    dosage: str('dosage'),
-    dose: str('dose', 'dosage'),
-    doseUnit: str('doseUnit'),
-    route: str('route', 'routeOfAdministration'),
-    frequency: str('frequency'),
-    durationDays: str('duration', 'durationDays'),
-    durationUnit: str('durationUnit'),
-    qty: str('quantity', 'qty'),
-    refill: str('refill'),
-    drugSchedule: str('drugSchedule'),
-    prescriptionRequired: bool('prescriptionRequired'),
-    instructions:
-      str('instructions') ??
-      (typeof input.instructions === 'string' ? input.instructions : undefined),
-    fulfillment: fulfillmentValue === 'IN_HOUSE' ? 'IN_HOUSE' : 'PRESCRIPTION_ONLY',
-    priceCents: num('priceCents'),
-    stockQty: num('stockQty'),
-    lowStock: bool('lowStock'),
-    controlledSubstance: bool('controlledSubstance', 'controlledItem'),
-    inventoryItemId: str('inventoryItemId'),
-    inventoryBatchId: str('inventoryBatchId', 'batchId'),
-  };
+  const lines = medications.length > 0 ? medications : [{}];
+
+  return lines.map((entry, lineIndex) => {
+    // The backend persists the line into TYPED columns (medication/dosage/route/frequency/duration/
+    // quantity/refill/inventoryItemId/inventoryItemSku) and keeps display/unit extras in a nested
+    // `metadata` object. Coalesce both shapes (BE column name ?? our field name ?? metadata) so a
+    // round-tripped prescription rehydrates fully.
+    const raw = (entry ?? {}) as Record<string, unknown>;
+    const meta =
+      raw.metadata && typeof raw.metadata === 'object' && !Array.isArray(raw.metadata)
+        ? (raw.metadata as Record<string, unknown>)
+        : {};
+    const str = (...keys: string[]): string | undefined => {
+      for (const key of keys) {
+        const value = raw[key] ?? meta[key];
+        if (typeof value === 'string' && value.trim()) return value;
+        if (typeof value === 'number') return String(value);
+      }
+      return undefined;
+    };
+    const bool = (...keys: string[]): boolean | undefined => {
+      for (const key of keys) {
+        const value = raw[key] ?? meta[key];
+        if (typeof value === 'boolean') return value;
+      }
+      return undefined;
+    };
+    const num = (...keys: string[]): number | undefined => {
+      for (const key of keys) {
+        const value = raw[key] ?? meta[key];
+        if (typeof value === 'number') return value;
+      }
+      return undefined;
+    };
+    const fulfillmentValue = str('fulfillment');
+    return {
+      id: str('sourceLineKey', 'id') ?? resource.id ?? `rx-${index + 1}-${lineIndex + 1}`,
+      prescriptionArtifactId: resource.id,
+      finalized,
+      medicineName:
+        str('medication', 'medicineName', 'name') ??
+        resource.medicationCodeableConcept?.text ??
+        resource.medicationReference?.display ??
+        'Medication',
+      brand: str('brand'),
+      genericName: str('genericName'),
+      sku: str('sku', 'inventoryItemSku'),
+      strength: str('strength'),
+      strengthUnit: str('strengthUnit'),
+      dosageForm: str('dosageForm'),
+      dosage: str('dosage'),
+      dose: str('dose', 'dosage'),
+      doseUnit: str('doseUnit'),
+      route: str('route', 'routeOfAdministration'),
+      frequency: str('frequency'),
+      durationDays: str('duration', 'durationDays'),
+      durationUnit: str('durationUnit'),
+      qty: str('quantity', 'qty'),
+      refill: str('refill'),
+      drugSchedule: str('drugSchedule'),
+      prescriptionRequired: bool('prescriptionRequired'),
+      instructions:
+        str('instructions') ??
+        (typeof input.instructions === 'string' ? input.instructions : undefined),
+      fulfillment: fulfillmentValue === 'IN_HOUSE' ? 'IN_HOUSE' : 'PRESCRIPTION_ONLY',
+      priceCents: num('priceCents'),
+      stockQty: num('stockQty'),
+      lowStock: bool('lowStock'),
+      controlledSubstance: bool('controlledSubstance', 'controlledItem'),
+      inventoryItemId: str('inventoryItemId'),
+      inventoryBatchId: str('inventoryBatchId', 'batchId'),
+    };
+  });
 };
 
 export const listPrescriptionsForAppointment = async (
@@ -917,12 +940,13 @@ export const listPrescriptionsForAppointment = async (
     `/fhir/v1/clinical-artifact/organisation/${organisationId}/appointment/${appointmentId}/prescriptions`,
     {}
   );
-  return bundleResources<MedicationRequest>(res.data, 'MedicationRequest').map((resource, index) =>
-    prescriptionFromMedicationRequest(resource, index, {
-      organisationId,
-      appointmentId,
-      ...context,
-    })
+  return bundleResources<MedicationRequest>(res.data, 'MedicationRequest').flatMap(
+    (resource, index) =>
+      prescriptionItemsFromMedicationRequest(resource, index, {
+        organisationId,
+        appointmentId,
+        ...context,
+      })
   );
 };
 
@@ -984,12 +1008,13 @@ export const listPrescriptionsForEncounter = async (
     `/fhir/v1/clinical-artifact/organisation/${organisationId}/encounter/${encounterId}/prescriptions`,
     {}
   );
-  return bundleResources<MedicationRequest>(res.data, 'MedicationRequest').map((resource, index) =>
-    prescriptionFromMedicationRequest(resource, index, {
-      organisationId,
-      encounterId,
-      ...context,
-    })
+  return bundleResources<MedicationRequest>(res.data, 'MedicationRequest').flatMap(
+    (resource, index) =>
+      prescriptionItemsFromMedicationRequest(resource, index, {
+        organisationId,
+        encounterId,
+        ...context,
+      })
   );
 };
 

--- a/apps/frontend/src/app/features/appointments/types/workspace.ts
+++ b/apps/frontend/src/app/features/appointments/types/workspace.ts
@@ -224,6 +224,8 @@ export type PrescriptionFulfillment = 'IN_HOUSE' | 'PRESCRIPTION_ONLY';
 
 export type PrescriptionItem = {
   id: string;
+  /** Shared clinical prescription artifact id when multiple medication rows belong to one document. */
+  prescriptionArtifactId?: string;
   medicineName: string;
   /** Brand/trade name from inventory (e.g. "Calpol"), shown beside the generic. */
   brand?: string;

--- a/apps/frontend/src/app/features/appointments/types/workspace.ts
+++ b/apps/frontend/src/app/features/appointments/types/workspace.ts
@@ -224,6 +224,8 @@ export type PrescriptionFulfillment = 'IN_HOUSE' | 'PRESCRIPTION_ONLY';
 
 export type PrescriptionItem = {
   id: string;
+  /** Stable per-medication line key stored inside a shared prescription artifact. */
+  sourceLineKey?: string;
   /** Shared clinical prescription artifact id when multiple medication rows belong to one document. */
   prescriptionArtifactId?: string;
   medicineName: string;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests and lints pass.

## What is the current behavior?

- Dispensing a prescription always deducted exactly 1 unit from on-hand/allocated stock instead of the calculated quantity, because dispense requests created before pack-size enrichment ran (or before the item's pack size was configured) carried a frozen 0/undefined `stockUnitQuantity` that a later fix to the enrichment logic never reached (#1880).
- When multiple medicines were prescribed during one appointment, the system created a separate prescription document per medicine instead of one consolidated document, producing duplicate "All Documents" entries with identical timestamps and incomplete per-document medication views (#1991).

## What is the new behavior?

- `resolvePrescriptionLines` now falls back to resolving the inventory item's live `packageQuantity` when a dispense line's `stockUnitQuantity` is missing, so dispensing always uses the item's current pack size rather than a stale snapshot from request creation time.
- Appointment prescriptions are now grouped into a single clinical artifact keyed by appointment, with each medicine added as a line item; saving again updates the existing prescription document instead of creating a duplicate.

## Related Issue(s)
Fixes #1880
Fixes #1991
