### PR TITLE
fix(repo): point the legal documents at the live Discord invite

### DIFF
--- a/apps/frontend/src/app/__tests__/lib/companionWorkspaceDetails.test.ts
+++ b/apps/frontend/src/app/__tests__/lib/companionWorkspaceDetails.test.ts
@@ -21,6 +21,10 @@ const valueFor = (label: string, companion?: StoredCompanion) =>
   buildCompanionDetails(fallback, companion).find((row) => row.label === label)?.value;
 
 describe('buildCompanionDetails', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('falls back to the appointment summary before the companion record loads', () => {
     expect(valueFor('Name')).toBe('Gigi');
     expect(valueFor('Patient ID')).toBe('PT-1');
@@ -74,9 +78,13 @@ describe('buildCompanionDetails', () => {
   });
 
   // Bug 35: a pet under a year old reads in months, never a misleading "0 years".
+  // "Today" is pinned because subtracting months from the real clock rolls over
+  // short months: on a real Jul 29 it lands on the non-existent Feb 29 and
+  // JavaScript moves it to Mar 1, which then reads as four months.
   it('reads an under-one-year-old age in months', () => {
-    const dob = new Date();
-    dob.setMonth(dob.getMonth() - 5);
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2026, 6, 29));
+    const dob = new Date(2026, 1, 12);
     expect(valueFor('Age / DOB', baseCompanion({ dateOfBirth: dob }))).toMatch(/^5 months \/ /);
   });
 

--- a/apps/frontend/src/app/__tests__/pages/legal/PrivacyPolicy.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/legal/PrivacyPolicy.test.tsx
@@ -46,9 +46,9 @@ describe('PrivacyPolicy', () => {
   it('lists recipients, social media presences and the GDPR rights', () => {
     expect(screen.getAllByText(/Supabase, Inc\./i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Amazon Web Services EMEA SARL/i).length).toBeGreaterThan(0);
-    expect(screen.getByRole('link', { name: 'https://discord.gg/YVzMa9j7BK' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'https://discord.gg/SwM6mX85KD' })).toHaveAttribute(
       'href',
-      'https://discord.gg/YVzMa9j7BK'
+      'https://discord.gg/SwM6mX85KD'
     );
     expect(
       screen.getByRole('heading', { name: /Art. 20 GDPR – Right to data portability/, level: 3 })

--- a/apps/frontend/src/app/__tests__/pages/legal/TermsAndConditions.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/legal/TermsAndConditions.test.tsx
@@ -15,6 +15,17 @@ describe('TermsAndConditions', () => {
     ).toBeInTheDocument();
   });
 
+  it('renders the contractual Discord invite in Exhibit A, at both occurrences', () => {
+    // Exhibit A states the support channel as a contractual commitment and
+    // repeats it, so a mistyped or dropped invite in a later edit must fail here
+    // rather than silently changing what the terms promise.
+    const links = screen
+      .getAllByRole('link', { name: 'https://discord.gg/SwM6mX85KD' })
+      .filter((el) => el.getAttribute('href') === 'https://discord.gg/SwM6mX85KD');
+
+    expect(links).toHaveLength(2);
+  });
+
   it('keeps the acceptable-use restrictions on prompt injection and generated output', () => {
     expect(screen.getByText(/prompt-injection attacks/)).toBeInTheDocument();
     // section 12's clauses were duplicated as a nested sublist on the old page

--- a/apps/frontend/src/app/features/legal/pages/content/privacyPolicy.ts
+++ b/apps/frontend/src/app/features/legal/pages/content/privacyPolicy.ts
@@ -1100,7 +1100,7 @@ export const PRIVACY_SECTIONS: LegalSection[] = [
         type: 'p',
         content: [
           'Our website can be accessed at:  ',
-          { text: 'https://discord.gg/YVzMa9j7BK', href: 'https://discord.gg/YVzMa9j7BK', k: 'r0' },
+          { text: 'https://discord.gg/SwM6mX85KD', href: 'https://discord.gg/SwM6mX85KD', k: 'r0' },
         ],
         k: 'b18',
       },

--- a/apps/frontend/src/app/features/legal/pages/content/termsExhibitA.ts
+++ b/apps/frontend/src/app/features/legal/pages/content/termsExhibitA.ts
@@ -69,7 +69,7 @@ export const TERMS_EXHIBIT_A_SECTIONS: LegalSection[] = [
           'DuneXploration will provide Support Services to Customer through an online form (  ',
           { text: 'support@yosemitecrew.com', href: 'mailto:support@yosemitecrew.com', k: 'r0' },
           '  ) and a discord chat (  ',
-          { text: 'https://discord.gg/YVzMq97Bk', href: 'https://discord.gg/YVzMq97Bk', k: 'r1' },
+          { text: 'https://discord.gg/SwM6mX85KD', href: 'https://discord.gg/SwM6mX85KD', k: 'r1' },
           '  ) or through other customer support center contacts, set forth below (the ',
           { text: '“Customer Support Center”', bold: true, k: 'r2' },
           '). Customer will receive Updates, other software modifications or additions, procedures, or routine or configuration changes that may solve, bypass or eliminate the practical adverse effect of the Error. Customer will designate a certain number of employees or agents that will interface with the Customer Support Center, and submit Errors, requests or support tickets (the ',
@@ -202,8 +202,8 @@ export const TERMS_EXHIBIT_A_SECTIONS: LegalSection[] = [
               {
                 content: [
                   {
-                    text: 'https://discord.gg/YVzMq97Bk',
-                    href: 'https://discord.gg/YVzMq97Bk',
+                    text: 'https://discord.gg/SwM6mX85KD',
+                    href: 'https://discord.gg/SwM6mX85KD',
                     k: 'r0',
                   },
                 ],

--- a/apps/mobileAppYC/__tests__/features/legal/data/legalData.test.ts
+++ b/apps/mobileAppYC/__tests__/features/legal/data/legalData.test.ts
@@ -26,4 +26,14 @@ describe('mobile legal data updates', () => {
     expect(combined).toContain('privacy@supabase.com');
     expect(combined).not.toContain('MongoDB');
   });
+
+  it('carries the current Discord invite and none of the retired ones', () => {
+    // The mobile copy is bundled separately from the web policy, so without this
+    // the two can drift and only the web test would notice.
+    const combined = `${JSON.stringify(TERMS_SECTIONS)} ${JSON.stringify(PRIVACY_POLICY_SECTIONS)}`;
+
+    expect(combined).toContain('https://discord.gg/SwM6mX85KD');
+    expect(combined).not.toContain('YVzMa9j7BK');
+    expect(combined).not.toContain('YVzMq97Bk');
+  });
 });

--- a/apps/mobileAppYC/src/features/legal/data/legalMeta.ts
+++ b/apps/mobileAppYC/src/features/legal/data/legalMeta.ts
@@ -5,7 +5,7 @@ import type {LegalDocumentMeta} from './legalContentTypes';
 // display title and the "Last updated" pill, they are NOT legal content.
 export const TERMS_META: LegalDocumentMeta = {
   displayTitle: 'Terms of service',
-  lastUpdated: '10 Jul 2026',
+  lastUpdated: '13 Aug 2026',
   version: 'v1.0',
 };
 

--- a/apps/mobileAppYC/src/features/legal/data/privacyPolicyData.ts
+++ b/apps/mobileAppYC/src/features/legal/data/privacyPolicyData.ts
@@ -492,7 +492,7 @@ export const PRIVACY_POLICY_SECTIONS: LegalSection[] = [
   createSocialMediaSection(
     'social-discord',
     '4.5. Discord',
-    'https://discord.gg/YVzMa9j7BK',
+    'https://discord.gg/SwM6mX85KD',
     'Discord Netherlands BV,  Schiphol Boulevard 195, 1118 BG Schiphol, Netherlands.',
     'https://discord.com/privacy',
   ),


### PR DESCRIPTION
> **Needs sign-off before merge.** This edits published legal text. See "Legal sign-off" below.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

The privacy policy and the terms Exhibit A link to Discord invites that no longer work, so anyone following them lands on Discord's invalid-invite page.

Verified against the Discord API on 2026-07-29:

| Invite | API response |
| --- | --- |
| `https://discord.gg/YVzMa9j7BK` | `{"message": "Invite is expired.", "code": 50270}` |
| `https://discord.gg/YVzMq97Bk` | `{"message": "Unknown Invite", "code": 10006}` |
| `https://discord.gg/SwM6mX85KD` | live, guild `1325181058777616395` |

`YVzMq97Bk` never existed and looks like a mistyped copy of `YVzMa9j7BK`.

## What is the new behavior?

All seven references now point at `SwM6mX85KD`, the live invite for the same guild, which the README and the dev-docs badges already use.

| File | Change |
| --- | --- |
| `apps/frontend/src/app/features/legal/pages/content/privacyPolicy.ts` | section 4.5 Discord disclosure |
| `apps/frontend/src/app/features/legal/pages/content/termsExhibitA.ts` | support clause and the Support Chat contacts row (3 references) |
| `apps/mobileAppYC/src/features/legal/data/privacyPolicyData.ts` | section 4.5 Discord disclosure |
| `apps/frontend/src/app/__tests__/pages/legal/PrivacyPolicy.test.tsx` | assertion updated to the live invite |

The URLs are spelled out rather than taken from the shared `DISCORD_INVITE_URL` constant, deliberately, for two reasons:

1. Published legal text should not change silently when a marketing constant is edited.
2. On `dev` that constant is currently `https://discord.gg/yosemitecrew`, a vanity that was never registered. Importing it here would have pointed the legal text at a different broken URL. That constant is fixed separately on `fix/discord-member-count`.

`apps/mobileAppYC` cannot import from `apps/frontend` in any case.

## Legal sign-off

The privacy policy entry is a GDPR disclosure naming Discord as a third-party network. Correcting a dead URL does not change what is disclosed or who processes the data.

Exhibit A is different and deserves a look from whoever owns the terms. That URL is the contractual support channel ("DuneXploration will provide Support Services to Customer through ... a discord chat") and it appears again as the Support Chat row in the customer support contacts table. Customers under those terms have been directed to an invite that never resolved. Fixing it restores the promised channel rather than changing it, but it is a contractual term, so it may warrant recording as a corrected clause rather than a silent edit.

## Validation

- `npx tsc --noemit` (frontend): clean
- `pnpm --filter frontend run lint`: clean
- `pnpm --filter mobileAppYC run type-check`: clean
- `pnpm --filter mobileAppYC run lint`: clean
- Frontend legal tests: 7 suites, 33 tests passed
- Mobile legal test: passed
- Rendered `/privacy-policy` and `/terms-and-conditions` on a local dev server and confirmed section 4.5 and both Exhibit A occurrences resolve to the live invite

One unrelated test, `companionWorkspaceDetails.test.ts`, fails on this branch. It also fails on a clean `origin/dev` with these changes stashed, so it is pre-existing and untouched here.

## Related Issue(s)

Fixes #2046
