### PR TITLE
fix(backend): hide void prescription documents

### DIFF
--- a/apps/backend/src/services/workspace.prisma.service.ts
+++ b/apps/backend/src/services/workspace.prisma.service.ts
@@ -1805,10 +1805,7 @@ const loadDocuments = async (params: {
           },
           {
             clinicalArtifact: {
-              is: {
-                appointmentId: params.appointmentId,
-                status: { not: ClinicalArtifactStatus.VOID },
-              },
+              is: { appointmentId: params.appointmentId },
             },
           },
         ]
@@ -1830,10 +1827,7 @@ const loadDocuments = async (params: {
           },
           {
             clinicalArtifact: {
-              is: {
-                encounterId: params.encounterId,
-                status: { not: ClinicalArtifactStatus.VOID },
-              },
+              is: { encounterId: params.encounterId },
             },
           },
         ]
@@ -1862,6 +1856,11 @@ const loadDocuments = async (params: {
     prisma.renderedDocument.findMany({
       where: {
         organisationId: params.organisationId,
+        NOT: {
+          clinicalArtifact: {
+            is: { status: ClinicalArtifactStatus.VOID },
+          },
+        },
         ...(renderedDocumentConditions.length
           ? { OR: renderedDocumentConditions }
           : {}),

--- a/apps/backend/src/services/workspace.prisma.service.ts
+++ b/apps/backend/src/services/workspace.prisma.service.ts
@@ -1,4 +1,4 @@
-import { Prisma } from "@prisma/client";
+import { ClinicalArtifactStatus, Prisma } from "@prisma/client";
 import { prisma } from "src/config/prisma";
 import { ClinicalArtifactService } from "./clinical-artifact.service";
 import { FormAssignmentService } from "./form-assignment.service";
@@ -1805,7 +1805,10 @@ const loadDocuments = async (params: {
           },
           {
             clinicalArtifact: {
-              is: { appointmentId: params.appointmentId },
+              is: {
+                appointmentId: params.appointmentId,
+                status: { not: ClinicalArtifactStatus.VOID },
+              },
             },
           },
         ]
@@ -1827,7 +1830,10 @@ const loadDocuments = async (params: {
           },
           {
             clinicalArtifact: {
-              is: { encounterId: params.encounterId },
+              is: {
+                encounterId: params.encounterId,
+                status: { not: ClinicalArtifactStatus.VOID },
+              },
             },
           },
         ]

--- a/apps/backend/test/services/workspace.prisma.service.test.ts
+++ b/apps/backend/test/services/workspace.prisma.service.test.ts
@@ -550,14 +550,16 @@ describe("WorkspaceService", () => {
         { sourceKind: "INVOICE", sourceId: { in: ["invoice-1"] } },
         {
           clinicalArtifact: {
-            is: {
-              appointmentId: "appt-1",
-              status: { not: "VOID" },
-            },
+            is: { appointmentId: "appt-1" },
           },
         },
       ]),
     );
+    expect(renderedDocumentQuery?.where?.NOT).toEqual({
+      clinicalArtifact: {
+        is: { status: "VOID" },
+      },
+    });
   });
 
   it("returns a bootstrap payload without billing state when no invoice is open", async () => {
@@ -1751,6 +1753,18 @@ describe("WorkspaceService", () => {
                 organisationId: "org-scope",
                 status: { in: ["ACTIVE", "PENDING"] },
               },
+            },
+          },
+        }),
+      }),
+    );
+    expect(mockedPrisma.renderedDocument.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          organisationId: "org-scope",
+          NOT: {
+            clinicalArtifact: {
+              is: { status: "VOID" },
             },
           },
         }),

--- a/apps/backend/test/services/workspace.prisma.service.test.ts
+++ b/apps/backend/test/services/workspace.prisma.service.test.ts
@@ -548,6 +548,14 @@ describe("WorkspaceService", () => {
     expect(renderedDocumentQuery?.where?.OR).toEqual(
       expect.arrayContaining([
         { sourceKind: "INVOICE", sourceId: { in: ["invoice-1"] } },
+        {
+          clinicalArtifact: {
+            is: {
+              appointmentId: "appt-1",
+              status: { not: "VOID" },
+            },
+          },
+        },
       ]),
     );
   });


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

When multiple medicines are prescribed during one appointment, stale duplicate rendered prescription documents can remain visible in Summary → All Documents after the backend consolidates appointment prescriptions. This makes the appointment appear to have multiple Prescription documents, each showing only part of the medication plan.

## What is the new behavior?

All Documents now excludes rendered documents whose backing clinical artifact is `VOID`. The appointment keeps a single active prescription document for its current prescription artifact, containing all prescribed medication lines, while stale duplicate prescription documents are hidden from the workspace document list.

## Related Issue(s)

Fixes #1991