### PR TITLE
fix(backend): Support passwordless demo login

### DIFF
--- a/apps/backend/test/auth/supertokens.config.test.ts
+++ b/apps/backend/test/auth/supertokens.config.test.ts
@@ -1,7 +1,21 @@
+const mockPasswordlessInit = jest.fn((config: unknown) => ({
+  name: "passwordless",
+  config,
+}));
+
+jest.mock("supertokens-node/recipe/passwordless", () => ({
+  __esModule: true,
+  default: {
+    init: mockPasswordlessInit,
+  },
+}));
+
 const ORIGINAL_ENV = {
   AUTH_API_DOMAIN: process.env.AUTH_API_DOMAIN,
   AUTH_WEBSITE_DOMAIN: process.env.AUTH_WEBSITE_DOMAIN,
   SUPERTOKENS_CONNECTION_URI: process.env.SUPERTOKENS_CONNECTION_URI,
+  DEMO_LOGIN_EMAIL: process.env.DEMO_LOGIN_EMAIL,
+  DEMO_LOGIN_PASSWORD: process.env.DEMO_LOGIN_PASSWORD,
   SMTP_HOST: process.env.SMTP_HOST,
   SMTP_PORT: process.env.SMTP_PORT,
   SMTP_SECURE: process.env.SMTP_SECURE,
@@ -24,9 +38,12 @@ const restoreEnv = () => {
 describe("@yosemite-crew/auth supertokens config", () => {
   beforeEach(() => {
     jest.resetModules();
+    mockPasswordlessInit.mockClear();
     process.env.AUTH_API_DOMAIN = "https://api.example.com";
     process.env.AUTH_WEBSITE_DOMAIN = "https://app.example.com";
     process.env.SUPERTOKENS_CONNECTION_URI = "http://localhost:3567";
+    process.env.DEMO_LOGIN_EMAIL = "";
+    process.env.DEMO_LOGIN_PASSWORD = "";
     delete process.env.SMTP_HOST;
     delete process.env.SMTP_PORT;
     delete process.env.SMTP_SECURE;
@@ -52,5 +69,67 @@ describe("@yosemite-crew/auth supertokens config", () => {
     expect(() => getSuperTokensConfig()).toThrow(
       "[auth] Missing required environment variable: SMTP_HOST",
     );
+  });
+
+  it("configures the demo password and suppresses demo email delivery when the review account is enabled", async () => {
+    process.env.SMTP_HOST = "smtp.example.test";
+    process.env.SMTP_PORT = "465";
+    process.env.SMTP_SECURE = "true";
+    process.env.SMTP_USER = "smtp-user";
+    process.env.SMTP_PASSWORD = "smtp-password";
+    process.env.SMTP_FROM_NAME = "Yosemite Crew";
+    process.env.SMTP_FROM_EMAIL = "[email protected]";
+    process.env.DEMO_LOGIN_EMAIL = "test@yosemitecrew.com";
+    process.env.DEMO_LOGIN_PASSWORD = "review-password";
+
+    const { getSuperTokensConfig } = require("@yosemite-crew/auth");
+    const config = getSuperTokensConfig();
+    const passwordlessRecipe = config.recipeList.find(
+      (recipe: { name?: string }) => recipe.name === "passwordless",
+    ) as any;
+
+    expect(passwordlessRecipe).toBeDefined();
+
+    const originalCreateCode = jest.fn(async (input: unknown) => input);
+    const overriddenFunctions = passwordlessRecipe.config.override.functions({
+      createCode: originalCreateCode,
+    });
+
+    await overriddenFunctions.createCode({ email: "test@yosemitecrew.com" });
+    await overriddenFunctions.createCode({ email: "someone@example.com" });
+
+    expect(originalCreateCode).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: "test@yosemitecrew.com",
+        userInputCode: "review-password",
+      }),
+    );
+    expect(originalCreateCode).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: "someone@example.com",
+      }),
+    );
+    const secondCreateCodeCall = originalCreateCode.mock.calls[1]?.[0] as {
+      userInputCode?: string;
+    };
+    expect(secondCreateCodeCall.userInputCode).toBeUndefined();
+
+    const originalSendEmail = jest.fn(async (input: unknown) => input);
+    const overriddenEmailDelivery =
+      passwordlessRecipe.config.emailDelivery.override({
+        sendEmail: originalSendEmail,
+      });
+
+    await overriddenEmailDelivery.sendEmail({
+      email: "test@yosemitecrew.com",
+    });
+    await overriddenEmailDelivery.sendEmail({
+      email: "someone@example.com",
+    });
+
+    expect(originalSendEmail).toHaveBeenCalledTimes(1);
+    expect(originalSendEmail).toHaveBeenCalledWith({
+      email: "someone@example.com",
+    });
   });
 });

--- a/packages/auth/src/config/supertokens.config.ts
+++ b/packages/auth/src/config/supertokens.config.ts
@@ -35,6 +35,9 @@ const SUPERTOKENS_API_KEY_FIELD = 'apiKey' as const;
 const CTX_LOGIN_METHOD = 'ycLoginMethod';
 const CTX_EMAIL = 'ycEmail';
 const CTX_PROFILE = 'ycAuthProfile';
+const DEMO_LOGIN_EMAIL = (process.env.DEMO_LOGIN_EMAIL ?? '').trim().toLowerCase();
+const DEMO_LOGIN_PASSWORD = process.env.DEMO_LOGIN_PASSWORD ?? '';
+const DEMO_LOGIN_ENABLED = DEMO_LOGIN_EMAIL !== '' && DEMO_LOGIN_PASSWORD !== '';
 
 type MutableContext = Record<string, unknown>;
 
@@ -87,6 +90,21 @@ async function reportUserCreated(input: {
 function isMfaRequirementEnabled(): boolean {
   // Escape hatch for CI/e2e environments only; defaults to enforced.
   return process.env.AUTH_REQUIRE_MFA !== 'false';
+}
+
+function isDemoLoginEmail(email?: string): boolean {
+  if (!DEMO_LOGIN_ENABLED || !email) {
+    return false;
+  }
+
+  return email.trim().toLowerCase() === DEMO_LOGIN_EMAIL;
+}
+
+function resolvePasswordlessRecipientEmail(input: {
+  email?: string;
+  templateVars?: { email?: string };
+}): string | undefined {
+  return input.email ?? input.templateVars?.email;
 }
 
 function buildThirdPartyProviders(): ProviderInput[] {
@@ -257,10 +275,37 @@ export function getSuperTokensConfig(): TypeInput {
           service: new PasswordlessSMTPService({
             smtpSettings,
           }),
+          override: (original) => ({
+            ...original,
+            sendEmail: async (input) => {
+              const recipientEmail = resolvePasswordlessRecipientEmail(
+                input as {
+                  email?: string;
+                  templateVars?: { email?: string };
+                }
+              );
+
+              if (isDemoLoginEmail(recipientEmail)) {
+                return;
+              }
+
+              return original.sendEmail(input);
+            },
+          }),
         },
         override: {
           functions: (original) => ({
             ...original,
+            createCode: async (input) => {
+              if ('email' in input && isDemoLoginEmail(input.email)) {
+                return original.createCode({
+                  ...input,
+                  userInputCode: DEMO_LOGIN_PASSWORD,
+                });
+              }
+
+              return original.createCode(input);
+            },
             consumeCode: async (input) => {
               const ctx = input.userContext as MutableContext;
               ctx[CTX_LOGIN_METHOD] = 'otp-email';


### PR DESCRIPTION
  review account

<!--
We, the rest of the Yosemite community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests and lints pass.

## Description
- As we have migrate to `supertokens` from `cognito` as our primary auth system, we have to migrate our demo login flow for test account in mobile.
- This PR changes that flow and enable review login with new supertokens config.