### PR TITLE
fix(repo): clear the frontend Sonar backlog, restore the live Discord count, and fix the dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,25 +9,39 @@ updates:
       timezone: 'UTC'
     target-branch: dev
     open-pull-requests-limit: 10
+    # Only labels that exist in the repo. Dependabot cannot create labels, so an
+    # unknown name makes it post a config error on every PR it opens instead of
+    # applying the label.
     labels:
       - dependencies
-      - automerge-candidate
     # Use a conventional type(scope) the PR-title gate accepts. A bare 'chore'
     # with include:scope yields 'chore(deps): …', and 'deps' is not an allowed
     # scope, so those PRs would fail pr-governance. 'repo' is the catch-all scope.
     commit-message:
       prefix: 'chore(repo)'
     groups:
+      # Every group is minor-and-patch only, including the named ones below. A
+      # named group without `update-types` silently swallows MAJORS too, which is
+      # how a TypeScript 5 -> 7 bump landed inside "typescript-eslint" and a
+      # Jest 29 -> 30 bump inside "testing": each arrived as an unreviewable
+      # group PR that broke the build, instead of the individual PR a breaking
+      # major needs. Majors now always get their own PR and their own review.
       typescript-eslint:
         patterns:
           - 'typescript'
           - '@types/*'
           - 'eslint*'
           - '@typescript-eslint/*'
+        update-types:
+          - minor
+          - patch
       testing:
         patterns:
           - 'jest*'
           - '@testing-library/*'
+        update-types:
+          - minor
+          - patch
       build-tooling:
         patterns:
           - 'turbo'
@@ -35,6 +49,9 @@ updates:
           - 'prettier'
           - 'husky'
           - 'lint-staged'
+        update-types:
+          - minor
+          - patch
       # Catch-all. Must stay LAST: a dependency joins the first group it
       # matches, so an earlier '*' would swallow the named groups above.
       # Minor and patch only, so major bumps still get an individual PR
@@ -58,7 +75,7 @@ updates:
       prefix: 'ci(repo)'
     labels:
       - dependencies
-      - github-actions
+      - github_actions
     groups:
       # Action majors are routinely breaking, so keep them out of the group
       # and let each land on its own.

--- a/apps/frontend/src/app/__tests__/api/discordMembersRoute.test.ts
+++ b/apps/frontend/src/app/__tests__/api/discordMembersRoute.test.ts
@@ -11,28 +11,16 @@ jest.mock('next/server', () => ({
   },
 }));
 
+import { GET } from '@/app/api/community/discord-members/route';
+
 type MockedResponse = {
   body: { discordMembers: string | null };
   init?: { headers?: Record<string, string> };
 };
 
-type RouteModule = { GET: () => Promise<unknown> };
-
-/**
- * The route keeps a module-level cache of the last successful count, so every
- * test needs its own module instance or one test's cached value answers the
- * next one's request.
- */
-const loadRoute = async (): Promise<RouteModule> => {
-  let mod: RouteModule | undefined;
-  await jest.isolateModulesAsync(async () => {
-    mod = (await import('@/app/api/community/discord-members/route')) as RouteModule;
-  });
-  return mod as RouteModule;
-};
-
-const callRoute = async (route: RouteModule): Promise<MockedResponse> =>
-  (await route.GET()) as MockedResponse;
+// `next/server` is mocked above, so GET actually resolves to the plain
+// { body, init } shape rather than the NextResponse its signature declares.
+const callRoute = async (): Promise<MockedResponse> => (await GET()) as unknown as MockedResponse;
 
 const okInvite = (data: unknown) =>
   ({ ok: true, json: () => Promise.resolve(data) }) as unknown as Response;
@@ -52,7 +40,7 @@ describe('GET /api/community/discord-members', () => {
     const fetchMock = jest.fn().mockResolvedValue(okInvite({ approximate_member_count: 1204 }));
     globalThis.fetch = fetchMock as unknown as typeof fetch;
 
-    const res = await callRoute(await loadRoute());
+    const res = await callRoute();
 
     expect(res.body).toEqual({ discordMembers: '1,204' });
     expect(res.init?.headers?.['Cache-Control']).toBe(CACHED);
@@ -65,7 +53,7 @@ describe('GET /api/community/discord-members', () => {
     const fetchMock = jest.fn().mockResolvedValue(okInvite({ approximate_member_count: 42 }));
     globalThis.fetch = fetchMock as unknown as typeof fetch;
 
-    await callRoute(await loadRoute());
+    await callRoute();
 
     const [url, init] = fetchMock.mock.calls[0];
     expect(String(url)).toContain('with_counts=true');
@@ -80,7 +68,7 @@ describe('GET /api/community/discord-members', () => {
     const fetchMock = jest.fn().mockResolvedValue(okInvite({ approximate_member_count: 5 }));
     globalThis.fetch = fetchMock as unknown as typeof fetch;
 
-    await callRoute(await loadRoute());
+    await callRoute();
 
     const init = fetchMock.mock.calls[0][1] as RequestInit & { next?: unknown };
     expect(init.cache).toBe('no-store');
@@ -94,7 +82,7 @@ describe('GET /api/community/discord-members', () => {
       .mockResolvedValueOnce(okInvite({ approximate_member_count: 196 }));
     globalThis.fetch = fetchMock as unknown as typeof fetch;
 
-    const res = await callRoute(await loadRoute());
+    const res = await callRoute();
 
     expect(res.body).toEqual({ discordMembers: '196' });
     expect(String(fetchMock.mock.calls[1][0])).toContain(FALLBACK_CODE);
@@ -107,7 +95,7 @@ describe('GET /api/community/discord-members', () => {
       .mockResolvedValueOnce(okInvite({ approximate_member_count: 7 }));
     globalThis.fetch = fetchMock as unknown as typeof fetch;
 
-    expect((await callRoute(await loadRoute())).body).toEqual({ discordMembers: '7' });
+    expect((await callRoute()).body).toEqual({ discordMembers: '7' });
   });
 
   it('falls back when an invite resolves to a non-object payload', async () => {
@@ -117,7 +105,7 @@ describe('GET /api/community/discord-members', () => {
       .mockResolvedValueOnce(okInvite({ approximate_member_count: 8 }));
     globalThis.fetch = fetchMock as unknown as typeof fetch;
 
-    expect((await callRoute(await loadRoute())).body).toEqual({ discordMembers: '8' });
+    expect((await callRoute()).body).toEqual({ discordMembers: '8' });
   });
 
   it('returns a null count that is not cached when every lookup fails', async () => {
@@ -125,7 +113,7 @@ describe('GET /api/community/discord-members', () => {
       .fn()
       .mockRejectedValue(new Error('network down')) as unknown as typeof fetch;
 
-    const res = await callRoute(await loadRoute());
+    const res = await callRoute();
 
     // Null rather than an error status: the caller keeps its loading placeholder
     // and never paints a fabricated number.
@@ -133,53 +121,22 @@ describe('GET /api/community/discord-members', () => {
     expect(res.init?.headers?.['Cache-Control']).toBe('no-store');
   });
 
-  it('serves a second request from the cached count without calling Discord again', async () => {
-    const fetchMock = jest.fn().mockResolvedValue(okInvite({ approximate_member_count: 1204 }));
-    globalThis.fetch = fetchMock as unknown as typeof fetch;
-    const route = await loadRoute();
-
-    expect((await callRoute(route)).body).toEqual({ discordMembers: '1,204' });
-    const second = await callRoute(route);
-
-    expect(second.body).toEqual({ discordMembers: '1,204' });
-    expect(second.init?.headers?.['Cache-Control']).toBe(CACHED);
-    // One upstream call for two requests.
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-  });
-
-  it('retries Discord immediately after a failure rather than caching it', async () => {
+  it('retries Discord on the next request after a failure rather than caching it', async () => {
     // The regression this guards: a 200 with no member count used to be cached by
     // the fetch layer, so the count stayed blank for the whole TTL after Discord
-    // recovered. Only parsed counts are cached now.
+    // recovered. Nothing about a failure is cached at any layer now.
     const fetchMock = jest
       .fn()
       .mockResolvedValueOnce(okInvite({ code: PRIMARY_CODE }))
       .mockResolvedValueOnce(okInvite({ code: FALLBACK_CODE }))
       .mockResolvedValue(okInvite({ approximate_member_count: 311 }));
     globalThis.fetch = fetchMock as unknown as typeof fetch;
-    const route = await loadRoute();
 
-    expect((await callRoute(route)).body).toEqual({ discordMembers: null });
+    expect((await callRoute()).body).toEqual({ discordMembers: null });
     expect(fetchMock).toHaveBeenCalledTimes(2);
 
     // Next request goes back out to Discord and picks up the recovered count.
-    expect((await callRoute(route)).body).toEqual({ discordMembers: '311' });
+    expect((await callRoute()).body).toEqual({ discordMembers: '311' });
     expect(fetchMock).toHaveBeenCalledTimes(3);
-  });
-
-  it('refetches once the cached count has aged past its TTL', async () => {
-    const fetchMock = jest
-      .fn()
-      .mockResolvedValueOnce(okInvite({ approximate_member_count: 100 }))
-      .mockResolvedValue(okInvite({ approximate_member_count: 200 }));
-    globalThis.fetch = fetchMock as unknown as typeof fetch;
-    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1_000_000);
-    const route = await loadRoute();
-
-    expect((await callRoute(route)).body).toEqual({ discordMembers: '100' });
-
-    nowSpy.mockReturnValue(1_000_000 + 300_001);
-    expect((await callRoute(route)).body).toEqual({ discordMembers: '200' });
-    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/frontend/src/app/__tests__/api/discordMembersRoute.test.ts
+++ b/apps/frontend/src/app/__tests__/api/discordMembersRoute.test.ts
@@ -1,0 +1,109 @@
+/**
+ * The route returns a `NextResponse`, which needs the Web `Response` global that
+ * the jsdom test environment does not provide. Mocking `next/server` down to the
+ * one factory the route uses keeps the whole handler under test — status body and
+ * cache headers included — without switching the suite to a node environment
+ * (jest.setup.ts touches `HTMLElement`, so it cannot run there).
+ */
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: (body: unknown, init?: { headers?: Record<string, string> }) => ({ body, init }),
+  },
+}));
+
+import { GET } from '@/app/api/community/discord-members/route';
+
+type MockedResponse = {
+  body: { discordMembers: string | null };
+  init?: { headers?: Record<string, string> };
+};
+
+const callRoute = async (): Promise<MockedResponse> => (await GET()) as unknown as MockedResponse;
+
+const okInvite = (data: unknown) =>
+  ({ ok: true, json: () => Promise.resolve(data) }) as unknown as Response;
+
+const notOk = () => ({ ok: false, json: () => Promise.resolve(null) }) as unknown as Response;
+
+const PRIMARY_CODE = 'SwM6mX85KD';
+const FALLBACK_CODE = 'yosemitecrew';
+
+describe('GET /api/community/discord-members', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns the formatted member count from the primary invite code', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(okInvite({ approximate_member_count: 1204 }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const res = await callRoute();
+
+    expect(res.body).toEqual({ discordMembers: '1,204' });
+    expect(res.init?.headers?.['Cache-Control']).toBe(
+      'public, max-age=300, stale-while-revalidate=300'
+    );
+    // The fallback code is only tried when the first one fails.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0][0])).toContain(PRIMARY_CODE);
+  });
+
+  it('sends the counts query and a descriptive User-Agent Discord accepts', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(okInvite({ approximate_member_count: 42 }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await callRoute();
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain('with_counts=true');
+    expect((init as RequestInit).headers).toMatchObject({
+      'User-Agent': expect.stringContaining('yosemitecrew.com'),
+    });
+  });
+
+  it('falls back to the second invite code when the first is rejected', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(notOk())
+      .mockResolvedValueOnce(okInvite({ approximate_member_count: 196 }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const res = await callRoute();
+
+    expect(res.body).toEqual({ discordMembers: '196' });
+    expect(String(fetchMock.mock.calls[1][0])).toContain(FALLBACK_CODE);
+  });
+
+  it('falls back when an invite resolves without a member count', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(okInvite({ code: PRIMARY_CODE }))
+      .mockResolvedValueOnce(okInvite({ approximate_member_count: 7 }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    expect((await callRoute()).body).toEqual({ discordMembers: '7' });
+  });
+
+  it('falls back when an invite resolves to a non-object payload', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(okInvite(null))
+      .mockResolvedValueOnce(okInvite({ approximate_member_count: 8 }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    expect((await callRoute()).body).toEqual({ discordMembers: '8' });
+  });
+
+  it('returns a null count that is not cached when every lookup fails', async () => {
+    globalThis.fetch = jest
+      .fn()
+      .mockRejectedValue(new Error('network down')) as unknown as typeof fetch;
+
+    const res = await callRoute();
+
+    // Null rather than an error status: the caller keeps its loading placeholder
+    // and never paints a fabricated number.
+    expect(res.body).toEqual({ discordMembers: null });
+    expect(res.init?.headers?.['Cache-Control']).toBe('no-store');
+  });
+});

--- a/apps/frontend/src/app/__tests__/api/discordMembersRoute.test.ts
+++ b/apps/frontend/src/app/__tests__/api/discordMembersRoute.test.ts
@@ -1,8 +1,8 @@
 /**
  * The route returns a `NextResponse`, which needs the Web `Response` global that
  * the jsdom test environment does not provide. Mocking `next/server` down to the
- * one factory the route uses keeps the whole handler under test — status body and
- * cache headers included — without switching the suite to a node environment
+ * one factory the route uses keeps the whole handler under test - status body and
+ * cache headers included - without switching the suite to a node environment
  * (jest.setup.ts touches `HTMLElement`, so it cannot run there).
  */
 jest.mock('next/server', () => ({
@@ -11,14 +11,28 @@ jest.mock('next/server', () => ({
   },
 }));
 
-import { GET } from '@/app/api/community/discord-members/route';
-
 type MockedResponse = {
   body: { discordMembers: string | null };
   init?: { headers?: Record<string, string> };
 };
 
-const callRoute = async (): Promise<MockedResponse> => (await GET()) as unknown as MockedResponse;
+type RouteModule = { GET: () => Promise<unknown> };
+
+/**
+ * The route keeps a module-level cache of the last successful count, so every
+ * test needs its own module instance or one test's cached value answers the
+ * next one's request.
+ */
+const loadRoute = async (): Promise<RouteModule> => {
+  let mod: RouteModule | undefined;
+  await jest.isolateModulesAsync(async () => {
+    mod = (await import('@/app/api/community/discord-members/route')) as RouteModule;
+  });
+  return mod as RouteModule;
+};
+
+const callRoute = async (route: RouteModule): Promise<MockedResponse> =>
+  (await route.GET()) as MockedResponse;
 
 const okInvite = (data: unknown) =>
   ({ ok: true, json: () => Promise.resolve(data) }) as unknown as Response;
@@ -27,6 +41,7 @@ const notOk = () => ({ ok: false, json: () => Promise.resolve(null) }) as unknow
 
 const PRIMARY_CODE = 'SwM6mX85KD';
 const FALLBACK_CODE = 'yosemitecrew';
+const CACHED = 'public, max-age=300, stale-while-revalidate=300';
 
 describe('GET /api/community/discord-members', () => {
   afterEach(() => {
@@ -37,12 +52,10 @@ describe('GET /api/community/discord-members', () => {
     const fetchMock = jest.fn().mockResolvedValue(okInvite({ approximate_member_count: 1204 }));
     globalThis.fetch = fetchMock as unknown as typeof fetch;
 
-    const res = await callRoute();
+    const res = await callRoute(await loadRoute());
 
     expect(res.body).toEqual({ discordMembers: '1,204' });
-    expect(res.init?.headers?.['Cache-Control']).toBe(
-      'public, max-age=300, stale-while-revalidate=300'
-    );
+    expect(res.init?.headers?.['Cache-Control']).toBe(CACHED);
     // The fallback code is only tried when the first one fails.
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(String(fetchMock.mock.calls[0][0])).toContain(PRIMARY_CODE);
@@ -52,13 +65,26 @@ describe('GET /api/community/discord-members', () => {
     const fetchMock = jest.fn().mockResolvedValue(okInvite({ approximate_member_count: 42 }));
     globalThis.fetch = fetchMock as unknown as typeof fetch;
 
-    await callRoute();
+    await callRoute(await loadRoute());
 
     const [url, init] = fetchMock.mock.calls[0];
     expect(String(url)).toContain('with_counts=true');
     expect((init as RequestInit).headers).toMatchObject({
       'User-Agent': expect.stringContaining('yosemitecrew.com'),
     });
+  });
+
+  it('never caches the upstream request itself', async () => {
+    // Next's data cache keys on the request, not the outcome, so caching here
+    // would also cache a 200 that carries no count and replay it for the TTL.
+    const fetchMock = jest.fn().mockResolvedValue(okInvite({ approximate_member_count: 5 }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await callRoute(await loadRoute());
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit & { next?: unknown };
+    expect(init.cache).toBe('no-store');
+    expect(init.next).toBeUndefined();
   });
 
   it('falls back to the second invite code when the first is rejected', async () => {
@@ -68,7 +94,7 @@ describe('GET /api/community/discord-members', () => {
       .mockResolvedValueOnce(okInvite({ approximate_member_count: 196 }));
     globalThis.fetch = fetchMock as unknown as typeof fetch;
 
-    const res = await callRoute();
+    const res = await callRoute(await loadRoute());
 
     expect(res.body).toEqual({ discordMembers: '196' });
     expect(String(fetchMock.mock.calls[1][0])).toContain(FALLBACK_CODE);
@@ -81,7 +107,7 @@ describe('GET /api/community/discord-members', () => {
       .mockResolvedValueOnce(okInvite({ approximate_member_count: 7 }));
     globalThis.fetch = fetchMock as unknown as typeof fetch;
 
-    expect((await callRoute()).body).toEqual({ discordMembers: '7' });
+    expect((await callRoute(await loadRoute())).body).toEqual({ discordMembers: '7' });
   });
 
   it('falls back when an invite resolves to a non-object payload', async () => {
@@ -91,7 +117,7 @@ describe('GET /api/community/discord-members', () => {
       .mockResolvedValueOnce(okInvite({ approximate_member_count: 8 }));
     globalThis.fetch = fetchMock as unknown as typeof fetch;
 
-    expect((await callRoute()).body).toEqual({ discordMembers: '8' });
+    expect((await callRoute(await loadRoute())).body).toEqual({ discordMembers: '8' });
   });
 
   it('returns a null count that is not cached when every lookup fails', async () => {
@@ -99,11 +125,61 @@ describe('GET /api/community/discord-members', () => {
       .fn()
       .mockRejectedValue(new Error('network down')) as unknown as typeof fetch;
 
-    const res = await callRoute();
+    const res = await callRoute(await loadRoute());
 
     // Null rather than an error status: the caller keeps its loading placeholder
     // and never paints a fabricated number.
     expect(res.body).toEqual({ discordMembers: null });
     expect(res.init?.headers?.['Cache-Control']).toBe('no-store');
+  });
+
+  it('serves a second request from the cached count without calling Discord again', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(okInvite({ approximate_member_count: 1204 }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const route = await loadRoute();
+
+    expect((await callRoute(route)).body).toEqual({ discordMembers: '1,204' });
+    const second = await callRoute(route);
+
+    expect(second.body).toEqual({ discordMembers: '1,204' });
+    expect(second.init?.headers?.['Cache-Control']).toBe(CACHED);
+    // One upstream call for two requests.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries Discord immediately after a failure rather than caching it', async () => {
+    // The regression this guards: a 200 with no member count used to be cached by
+    // the fetch layer, so the count stayed blank for the whole TTL after Discord
+    // recovered. Only parsed counts are cached now.
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(okInvite({ code: PRIMARY_CODE }))
+      .mockResolvedValueOnce(okInvite({ code: FALLBACK_CODE }))
+      .mockResolvedValue(okInvite({ approximate_member_count: 311 }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const route = await loadRoute();
+
+    expect((await callRoute(route)).body).toEqual({ discordMembers: null });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    // Next request goes back out to Discord and picks up the recovered count.
+    expect((await callRoute(route)).body).toEqual({ discordMembers: '311' });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('refetches once the cached count has aged past its TTL', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(okInvite({ approximate_member_count: 100 }))
+      .mockResolvedValue(okInvite({ approximate_member_count: 200 }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1_000_000);
+    const route = await loadRoute();
+
+    expect((await callRoute(route)).body).toEqual({ discordMembers: '100' });
+
+    nowSpy.mockReturnValue(1_000_000 + 300_001);
+    expect((await callRoute(route)).body).toEqual({ discordMembers: '200' });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/frontend/src/app/__tests__/components/AppointmentCardContent.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/AppointmentCardContent.test.tsx
@@ -261,13 +261,12 @@ describe('AppointmentModePill', () => {
     });
   });
 
-  it('renders the inpatient pill in the strong tone with the supplied class and icon size', () => {
+  it('renders the inpatient pill with the supplied class and icon size', () => {
     render(
       <AppointmentModePill
         appointment={{ ...baseAppointment, appointmentKind: 'INPATIENT' }}
         className="custom-class"
         iconSize={20}
-        tone="strong"
       />
     );
 
@@ -277,8 +276,8 @@ describe('AppointmentModePill', () => {
     expect(screen.getByTestId('icon-bed')).toHaveAttribute('size', '20');
   });
 
-  it('renders the outpatient pill in the strong tone', () => {
-    render(<AppointmentModePill appointment={baseAppointment} tone="strong" />);
+  it('renders the outpatient pill on the neutral pill background', () => {
+    render(<AppointmentModePill appointment={baseAppointment} />);
 
     expect(screen.getByText('Outpatient').closest('[title="Outpatient"]')).toHaveStyle({
       backgroundColor: 'var(--color-pill-neutral-bg)',

--- a/apps/frontend/src/app/__tests__/components/Calendar/common/DayCalendar.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/common/DayCalendar.test.tsx
@@ -175,7 +175,6 @@ describe('DayCalendar (Appointments)', () => {
   const handleDetailAppointment = jest.fn();
   const handleOpenWorkspace = jest.fn();
   const handleRescheduleAppointment = jest.fn();
-  const setCurrentDate = jest.fn();
   const originalConsoleError = console.error;
 
   const baseDate = new Date('2025-01-06T10:00:00Z');
@@ -410,6 +409,5 @@ describe('DayCalendar (Appointments)', () => {
 
     expect(screen.queryByText('Next')).not.toBeInTheDocument();
     expect(screen.queryByText('Prev')).not.toBeInTheDocument();
-    expect(setCurrentDate).not.toHaveBeenCalled();
   });
 });

--- a/apps/frontend/src/app/__tests__/components/Calendar/common/DayCalendar.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/common/DayCalendar.test.tsx
@@ -256,7 +256,6 @@ describe('DayCalendar (Appointments)', () => {
         handleDetailAppointment={handleDetailAppointment}
         handleOpenWorkspace={handleOpenWorkspace}
         handleRescheduleAppointment={handleRescheduleAppointment}
-        setCurrentDate={setCurrentDate}
         canEditAppointments={false}
       />
     );
@@ -286,7 +285,6 @@ describe('DayCalendar (Appointments)', () => {
         handleDetailAppointment={handleDetailAppointment}
         handleOpenWorkspace={handleOpenWorkspace}
         handleRescheduleAppointment={handleRescheduleAppointment}
-        setCurrentDate={setCurrentDate}
         canEditAppointments={false}
         onCreateAppointmentAt={jest.fn()}
       />
@@ -320,7 +318,6 @@ describe('DayCalendar (Appointments)', () => {
         handleDetailAppointment={handleDetailAppointment}
         handleOpenWorkspace={handleOpenWorkspace}
         handleRescheduleAppointment={handleRescheduleAppointment}
-        setCurrentDate={setCurrentDate}
         canEditAppointments
       />
     );
@@ -369,7 +366,6 @@ describe('DayCalendar (Appointments)', () => {
         handleDetailAppointment={handleDetailAppointment}
         handleOpenWorkspace={handleOpenWorkspace}
         handleRescheduleAppointment={handleRescheduleAppointment}
-        setCurrentDate={setCurrentDate}
         canEditAppointments
       />
     );
@@ -388,7 +384,6 @@ describe('DayCalendar (Appointments)', () => {
         handleViewAppointment={handleViewAppointment}
         handleDetailAppointment={handleDetailAppointment}
         handleRescheduleAppointment={handleRescheduleAppointment}
-        setCurrentDate={setCurrentDate}
         canEditAppointments
       />
     );
@@ -409,7 +404,6 @@ describe('DayCalendar (Appointments)', () => {
         handleViewAppointment={handleViewAppointment}
         handleDetailAppointment={handleDetailAppointment}
         handleRescheduleAppointment={handleRescheduleAppointment}
-        setCurrentDate={setCurrentDate}
         canEditAppointments={false}
       />
     );

--- a/apps/frontend/src/app/__tests__/components/Calendar/common/Header.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/common/Header.test.tsx
@@ -113,7 +113,6 @@ describe('Header Component', () => {
         {...defaultProps}
         activeCalendar="week"
         setActiveCalendar={jest.fn()}
-        weekStart={new Date('2025-01-06T00:00:00.000Z')}
         setWeekStart={setWeekStart}
       />
     );
@@ -146,7 +145,6 @@ describe('Header Component', () => {
         {...defaultProps}
         activeCalendar="week"
         setActiveCalendar={jest.fn()}
-        weekStart={new Date('2025-01-06T00:00:00.000Z')}
         setWeekStart={setWeekStart}
       />
     );

--- a/apps/frontend/src/app/__tests__/components/Calendar/common/UserCalendar.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/common/UserCalendar.test.tsx
@@ -116,7 +116,6 @@ describe('UserCalendar (Appointments)', () => {
         date={new Date('2025-01-06T00:00:00Z')}
         handleViewAppointment={handleViewAppointment}
         handleRescheduleAppointment={handleRescheduleAppointment}
-        setCurrentDate={setCurrentDate}
         canEditAppointments
       />
     );
@@ -147,7 +146,6 @@ describe('UserCalendar (Appointments)', () => {
         date={new Date('2025-01-06T00:00:00Z')}
         handleViewAppointment={handleViewAppointment}
         handleRescheduleAppointment={handleRescheduleAppointment}
-        setCurrentDate={setCurrentDate}
         canEditAppointments
       />
     );
@@ -180,7 +178,6 @@ describe('UserCalendar (Appointments)', () => {
         zoomMode="out"
         handleViewAppointment={handleViewAppointment}
         handleRescheduleAppointment={handleRescheduleAppointment}
-        setCurrentDate={setCurrentDate}
         canEditAppointments
         availabilityLoaded
         getVisibleAvailabilityIntervals={getVisibleAvailabilityIntervals}
@@ -225,7 +222,6 @@ describe('UserCalendar (Appointments)', () => {
         date={new Date('2019-05-05T00:00:00Z')}
         handleViewAppointment={handleViewAppointment}
         handleRescheduleAppointment={handleRescheduleAppointment}
-        setCurrentDate={setCurrentDate}
         canEditAppointments
       />
     );
@@ -241,7 +237,6 @@ describe('UserCalendar (Appointments)', () => {
         date={new Date('2019-05-05T00:00:00Z')}
         handleViewAppointment={handleViewAppointment}
         handleRescheduleAppointment={handleRescheduleAppointment}
-        setCurrentDate={setCurrentDate}
         canEditAppointments
         draggedAppointmentId="drag-1"
       />
@@ -257,7 +252,6 @@ describe('UserCalendar (Appointments)', () => {
         date={new Date('2019-05-05T00:00:00Z')}
         handleViewAppointment={handleViewAppointment}
         handleRescheduleAppointment={handleRescheduleAppointment}
-        setCurrentDate={setCurrentDate}
         canEditAppointments
         skipAutoScroll
       />
@@ -275,7 +269,6 @@ describe('UserCalendar (Appointments)', () => {
         zoomMode="in"
         handleViewAppointment={handleViewAppointment}
         handleRescheduleAppointment={handleRescheduleAppointment}
-        setCurrentDate={setCurrentDate}
         canEditAppointments
       />
     );
@@ -291,7 +284,6 @@ describe('UserCalendar (Appointments)', () => {
         zoomMode="out"
         handleViewAppointment={handleViewAppointment}
         handleRescheduleAppointment={handleRescheduleAppointment}
-        setCurrentDate={setCurrentDate}
         canEditAppointments
       />
     );

--- a/apps/frontend/src/app/__tests__/components/Calendar/common/UserCalendar.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/common/UserCalendar.test.tsx
@@ -89,7 +89,6 @@ import {
 describe('UserCalendar (Appointments)', () => {
   const handleViewAppointment = jest.fn();
   const handleRescheduleAppointment = jest.fn();
-  const setCurrentDate = jest.fn();
 
   const team = [
     { _id: 'u1', name: 'Alex' },
@@ -152,7 +151,6 @@ describe('UserCalendar (Appointments)', () => {
 
     expect(screen.queryByText('PrevDay')).not.toBeInTheDocument();
     expect(screen.queryByText('NextDay')).not.toBeInTheDocument();
-    expect(setCurrentDate).not.toHaveBeenCalled();
   });
 
   it('renders zoom-out layout with availability, unavailable segments and the now indicator', () => {

--- a/apps/frontend/src/app/__tests__/components/Calendar/common/WeekCalendar.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/common/WeekCalendar.test.tsx
@@ -69,9 +69,6 @@ jest.mock('@/app/ui/primitives/Icons/Next', () => ({
 describe('WeekCalendar (Appointments)', () => {
   const handleViewAppointment = jest.fn();
   const handleRescheduleAppointment = jest.fn();
-  const setWeekStart = jest.fn();
-  const setCurrentDate = jest.fn();
-
   const weekStart = new Date('2025-01-06T00:00:00Z');
   const days = [
     new Date('2025-01-06T00:00:00Z'),
@@ -110,8 +107,6 @@ describe('WeekCalendar (Appointments)', () => {
         events={events}
         handleViewAppointment={handleViewAppointment}
         weekStart={weekStart}
-        setWeekStart={setWeekStart}
-        setCurrentDate={setCurrentDate}
         handleRescheduleAppointment={handleRescheduleAppointment}
         canEditAppointments
       />
@@ -140,8 +135,6 @@ describe('WeekCalendar (Appointments)', () => {
         events={events}
         handleViewAppointment={handleViewAppointment}
         weekStart={weekStart}
-        setWeekStart={setWeekStart}
-        setCurrentDate={setCurrentDate}
         handleRescheduleAppointment={handleRescheduleAppointment}
         canEditAppointments
       />
@@ -149,7 +142,6 @@ describe('WeekCalendar (Appointments)', () => {
 
     expect(screen.queryByText('PrevWeek')).not.toBeInTheDocument();
     expect(screen.queryByText('NextWeek')).not.toBeInTheDocument();
-    expect(setWeekStart).not.toHaveBeenCalled();
   });
 
   it('styles the day header strip with the frame typography and tints today', () => {
@@ -161,8 +153,6 @@ describe('WeekCalendar (Appointments)', () => {
         events={events}
         handleViewAppointment={handleViewAppointment}
         weekStart={weekStart}
-        setWeekStart={setWeekStart}
-        setCurrentDate={setCurrentDate}
         handleRescheduleAppointment={handleRescheduleAppointment}
         canEditAppointments
       />
@@ -196,8 +186,6 @@ describe('WeekCalendar (Appointments)', () => {
         events={events}
         handleViewAppointment={handleViewAppointment}
         weekStart={weekStart}
-        setWeekStart={setWeekStart}
-        setCurrentDate={setCurrentDate}
         handleRescheduleAppointment={handleRescheduleAppointment}
         canEditAppointments
       />
@@ -218,8 +206,6 @@ describe('WeekCalendar (Appointments)', () => {
         events={events}
         handleViewAppointment={handleViewAppointment}
         weekStart={weekStart}
-        setWeekStart={setWeekStart}
-        setCurrentDate={setCurrentDate}
         handleRescheduleAppointment={handleRescheduleAppointment}
         canEditAppointments
       />
@@ -254,8 +240,6 @@ describe('WeekCalendar (Appointments)', () => {
         zoomMode="out"
         handleViewAppointment={handleViewAppointment}
         weekStart={weekStart}
-        setWeekStart={setWeekStart}
-        setCurrentDate={setCurrentDate}
         handleRescheduleAppointment={handleRescheduleAppointment}
         canEditAppointments
       />
@@ -270,8 +254,6 @@ describe('WeekCalendar (Appointments)', () => {
         events={events}
         handleViewAppointment={handleViewAppointment}
         weekStart={weekStart}
-        setWeekStart={setWeekStart}
-        setCurrentDate={setCurrentDate}
         handleRescheduleAppointment={handleRescheduleAppointment}
         canEditAppointments
       />

--- a/apps/frontend/src/app/__tests__/components/Filters/FormsFilters/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Filters/FormsFilters/index.test.tsx
@@ -108,16 +108,16 @@ describe('FormsFilters Component', () => {
     expect(trigger).toHaveTextContent('All categories');
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
     // The boxed dropdown / stacked label are gone; options stay hidden until opened.
-    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('category-menu')).not.toBeInTheDocument();
   });
 
   it('opens the category menu and lists the options', () => {
     renderFilters();
     openMenu();
     expect(getTrigger()).toHaveAttribute('aria-expanded', 'true');
-    const listbox = screen.getByRole('listbox', { name: 'Category' });
-    expect(within(listbox).getByTestId('option-All')).toHaveTextContent('All categories');
-    expect(within(listbox).getByTestId('option-Custom')).toBeInTheDocument();
+    const menu = screen.getByTestId('category-menu');
+    expect(within(menu).getByTestId('option-All')).toHaveTextContent('All categories');
+    expect(within(menu).getByTestId('option-Custom')).toBeInTheDocument();
   });
 
   it('selects a category and closes the menu', () => {
@@ -125,7 +125,7 @@ describe('FormsFilters Component', () => {
     openMenu();
     fireEvent.click(screen.getByTestId('option-Custom'));
     expect(mockOnFiltersChange).toHaveBeenLastCalledWith({ status: 'All', category: 'Custom' });
-    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('category-menu')).not.toBeInTheDocument();
   });
 
   it('reflects the selected category label on the trigger', () => {
@@ -144,31 +144,31 @@ describe('FormsFilters Component', () => {
     renderFilters({ status: 'All', category: 'Custom' });
     openMenu();
     const selected = screen.getByTestId('option-Custom');
-    expect(selected).toHaveAttribute('aria-selected', 'true');
+    expect(selected).toHaveAttribute('aria-pressed', 'true');
     expect(selected.className).toContain('font-semibold');
 
     const unselected = screen.getByTestId('option-All');
-    expect(unselected).toHaveAttribute('aria-selected', 'false');
+    expect(unselected).toHaveAttribute('aria-pressed', 'false');
   });
 
   it('closes on an outside mousedown but stays open for interactions inside', () => {
     renderFilters();
     openMenu();
-    const listbox = screen.getByRole('listbox');
+    const menu = screen.getByTestId('category-menu');
     fireEvent.mouseDown(getTrigger());
-    expect(screen.getByRole('listbox')).toBeInTheDocument();
-    fireEvent.mouseDown(listbox);
-    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    expect(screen.getByTestId('category-menu')).toBeInTheDocument();
+    fireEvent.mouseDown(menu);
+    expect(screen.getByTestId('category-menu')).toBeInTheDocument();
     fireEvent.mouseDown(document.body);
-    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('category-menu')).not.toBeInTheDocument();
   });
 
   it('closes the category menu on scroll', () => {
     renderFilters();
     openMenu();
-    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    expect(screen.getByTestId('category-menu')).toBeInTheDocument();
     fireEvent.scroll(window);
-    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('category-menu')).not.toBeInTheDocument();
   });
 
   it('renders the category action node', () => {

--- a/apps/frontend/src/app/__tests__/components/Filters/FormsFilters/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Filters/FormsFilters/index.test.tsx
@@ -144,11 +144,11 @@ describe('FormsFilters Component', () => {
     renderFilters({ status: 'All', category: 'Custom' });
     openMenu();
     const selected = screen.getByTestId('option-Custom');
-    expect(selected).toHaveAttribute('aria-pressed', 'true');
+    expect(selected).toHaveAttribute('aria-current', 'true');
     expect(selected.className).toContain('font-semibold');
 
     const unselected = screen.getByTestId('option-All');
-    expect(unselected).toHaveAttribute('aria-pressed', 'false');
+    expect(unselected).not.toHaveAttribute('aria-current');
   });
 
   it('closes on an outside mousedown but stays open for interactions inside', () => {

--- a/apps/frontend/src/app/__tests__/features/marketing/site/useGithubStats.test.ts
+++ b/apps/frontend/src/app/__tests__/features/marketing/site/useGithubStats.test.ts
@@ -1,10 +1,4 @@
 import { renderHook, waitFor } from '@testing-library/react';
-jest.mock('@/app/services/http', () => ({
-  http: {
-    get: jest.fn(),
-  },
-}));
-import { http } from '@/app/services/http';
 import {
   useGithubStats,
   useLatestRelease,
@@ -13,7 +7,6 @@ import {
 } from '@/app/features/marketing/site/useGithubStats';
 
 type FetchLike = typeof fetch;
-const mockHttpGet = http.get as jest.Mock;
 
 const makeRes = (data: unknown, link?: string) =>
   ({
@@ -29,16 +22,31 @@ const notOk = () =>
     headers: { get: () => null },
   }) as unknown as Response;
 
+const DISCORD_ENDPOINT = '/api/community/discord-members';
+
+/**
+ * Member count served by the same-origin Discord route for the current test.
+ * Discord is read through plain `fetch` like every other stat, so tests wrap
+ * their handler in `withDiscord` and set this instead of mocking a client.
+ */
+let discordMembers: string | null = null;
+
+const withDiscord = (handler: (url: string) => Promise<Response>) =>
+  jest.fn((input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes(DISCORD_ENDPOINT)) return Promise.resolve(makeRes({ discordMembers }));
+    return handler(url);
+  });
+
 describe('useGithubStats hooks', () => {
   beforeEach(() => {
     sessionStorage.clear();
-    mockHttpGet.mockReset();
-    mockHttpGet.mockResolvedValue({ data: { discordMembers: null }, status: 200 });
+    discordMembers = null;
   });
 
   it('resolves stars, self-hosters, contributors and discord', async () => {
-    globalThis.fetch = jest.fn((input: RequestInfo | URL) => {
-      const url = String(input);
+    discordMembers = '3,210';
+    globalThis.fetch = withDiscord((url) => {
       if (url.includes('/releases')) return Promise.resolve(makeRes([]));
       if (url.includes('summary.json'))
         return Promise.resolve(makeRes({ clones: { total: 67134 } }));
@@ -48,7 +56,6 @@ describe('useGithubStats hooks', () => {
         return Promise.resolve(makeRes({ stargazers_count: 2431 }));
       return Promise.resolve(makeRes(null));
     }) as unknown as FetchLike;
-    mockHttpGet.mockResolvedValueOnce({ data: { discordMembers: '3,210' }, status: 200 });
 
     const { result } = renderHook(() => useGithubStats());
     await waitFor(() => expect(result.current.stars).toBe('2.4k'));
@@ -81,8 +88,8 @@ describe('useGithubStats hooks', () => {
   });
 
   it('refetches when the session cache is fresh but discord is still missing', async () => {
-    const fetchMock = jest.fn((input: RequestInfo | URL) => {
-      const url = String(input);
+    discordMembers = '196';
+    const fetchMock = withDiscord((url) => {
       if (url.includes('summary.json'))
         return Promise.resolve(makeRes({ clones: { total: 67134 } }));
       if (url.includes('contributors'))
@@ -92,7 +99,6 @@ describe('useGithubStats hooks', () => {
       return Promise.resolve(makeRes(null));
     });
     globalThis.fetch = fetchMock as unknown as FetchLike;
-    mockHttpGet.mockResolvedValueOnce({ data: { discordMembers: '196' }, status: 200 });
     sessionStorage.setItem(
       'yc_marketing_stats_v1',
       JSON.stringify({
@@ -114,8 +120,8 @@ describe('useGithubStats hooks', () => {
   });
 
   it('refetches on mount in live mode even when the session cache is still fresh', async () => {
-    const fetchMock = jest.fn((input: RequestInfo | URL) => {
-      const url = String(input);
+    discordMembers = '3,210';
+    const fetchMock = withDiscord((url) => {
       if (url.includes('summary.json'))
         return Promise.resolve(makeRes({ clones: { total: 67134 } }));
       if (url.includes('contributors'))
@@ -125,7 +131,6 @@ describe('useGithubStats hooks', () => {
       return Promise.resolve(makeRes(null));
     });
     globalThis.fetch = fetchMock as unknown as FetchLike;
-    mockHttpGet.mockResolvedValueOnce({ data: { discordMembers: '3,210' }, status: 200 });
     sessionStorage.setItem(
       'yc_marketing_stats_v1',
       JSON.stringify({
@@ -159,11 +164,9 @@ describe('useGithubStats hooks', () => {
       })
     );
     sessionStorage.setItem('yc_marketing_stats_ts_v1', String(Date.now()));
-    globalThis.fetch = jest.fn((_input: RequestInfo | URL) => {
-      // Every other endpoint fails: stars, the self-hoster report, and contributors.
-      return Promise.resolve(notOk());
-    }) as unknown as FetchLike;
-    mockHttpGet.mockResolvedValueOnce({ data: { discordMembers: '3,210' }, status: 200 });
+    discordMembers = '3,210';
+    // Every other endpoint fails: stars, the self-hoster report, and contributors.
+    globalThis.fetch = withDiscord(() => Promise.resolve(notOk())) as unknown as FetchLike;
 
     const { result } = renderHook(() => useGithubStats({ live: true }));
 
@@ -178,8 +181,8 @@ describe('useGithubStats hooks', () => {
   });
 
   it('fires exactly one round of requests when several instances mount at once', async () => {
-    const fetchMock = jest.fn((input: RequestInfo | URL) => {
-      const url = String(input);
+    discordMembers = '3,210';
+    const fetchMock = withDiscord((url) => {
       if (url.includes('summary.json'))
         return Promise.resolve(makeRes({ clones: { total: 67134 } }));
       if (url.includes('contributors'))
@@ -189,7 +192,6 @@ describe('useGithubStats hooks', () => {
       return Promise.resolve(makeRes(null));
     });
     globalThis.fetch = fetchMock as unknown as FetchLike;
-    mockHttpGet.mockResolvedValue({ data: { discordMembers: '3,210' }, status: 200 });
 
     const { result } = renderHook(() => {
       useGithubStats();
@@ -204,8 +206,8 @@ describe('useGithubStats hooks', () => {
     expect(urls.filter((u) => u.endsWith('/Yosemite-Crew')).length).toBe(1);
     expect(countIncluding('summary.json')).toBe(1);
     expect(countIncluding('contributors')).toBe(1);
-    expect(fetchMock).toHaveBeenCalledTimes(3);
-    expect(mockHttpGet).toHaveBeenCalledTimes(1);
+    expect(countIncluding(DISCORD_ENDPOINT)).toBe(1);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
 
     expect(result.current.selfHosters).toBe('67,134');
     expect(result.current.contributors).toBe('58');
@@ -226,14 +228,12 @@ describe('useGithubStats hooks', () => {
       }
       return Promise.resolve(notOk());
     }) as unknown as FetchLike;
-    mockHttpGet.mockResolvedValue({ data: { discordMembers: null }, status: 200 });
     const { result } = renderHook(() => useGithubStats());
     await waitFor(() => expect(result.current.selfHosters).toBe('67'));
   });
 
   it('shows no self-hoster count (placeholder) when the report is unavailable', async () => {
     globalThis.fetch = jest.fn(() => Promise.resolve(notOk())) as unknown as FetchLike;
-    mockHttpGet.mockResolvedValue({ data: { discordMembers: null }, status: 200 });
     const { result } = renderHook(() => useGithubStats());
     // No hard-coded fallback: a failed report leaves the placeholder, never a fake number.
     await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
@@ -316,7 +316,6 @@ describe('useGithubStats hooks', () => {
   it('yields no stats (all placeholders) when every request rejects', async () => {
     // Every fetch throwing exercises the fetchJson and fetchContributors catch paths.
     globalThis.fetch = jest.fn(() => Promise.reject(new Error('network'))) as unknown as FetchLike;
-    mockHttpGet.mockResolvedValue({ data: { discordMembers: null }, status: 200 });
     const { result } = renderHook(() => useGithubStats());
     await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
     expect(result.current.selfHosters).toBeNull();
@@ -330,7 +329,6 @@ describe('useGithubStats hooks', () => {
       if (url.includes('summary.json')) return Promise.resolve(makeRes({}));
       return Promise.resolve(notOk());
     }) as unknown as FetchLike;
-    mockHttpGet.mockResolvedValue({ data: { discordMembers: null }, status: 200 });
     const { result } = renderHook(() => useGithubStats());
     await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
     expect(result.current.selfHosters).toBeNull();

--- a/apps/frontend/src/app/__tests__/lib/paymentStatus.test.ts
+++ b/apps/frontend/src/app/__tests__/lib/paymentStatus.test.ts
@@ -202,6 +202,22 @@ describe('paymentStatus', () => {
     expect(display.state).toBe('PAID_CASH');
   });
 
+  it('metadataSuggestsCash ignores a non-primitive metadata value', () => {
+    // A nested object must not stringify to '[object Object]' and be scanned for
+    // 'cash' — it carries no payment mode, so the invoice stays plain PAID.
+    const display = getAppointmentPaymentDisplay({ id: 'a1', status: 'REQUESTED' } as any, {
+      a1: {
+        id: 'inv',
+        appointmentId: 'a1',
+        status: 'PAID',
+        paidAt: '2025-01-01T00:00:00Z',
+        stripePaymentIntentId: 'pi_123',
+        metadata: { paymentMethod: { label: 'cash' } },
+      } as any,
+    });
+    expect(display.state).toBe('PAID');
+  });
+
   it('metadataSuggestsCash checks tender keyword', () => {
     const display = getAppointmentPaymentDisplay({ id: 'a1', status: 'REQUESTED' } as any, {
       a1: {

--- a/apps/frontend/src/app/__tests__/services/specialityService.test.ts
+++ b/apps/frontend/src/app/__tests__/services/specialityService.test.ts
@@ -285,11 +285,9 @@ describe('specialityService', () => {
       const result = await createSpecialitiesBulk(payload);
 
       expect(result).toHaveLength(1);
-      expect(mockAddSpeciality).toHaveBeenCalledWith(
-        expect.objectContaining({ _id: 'spec-a' }),
-        expect.any(Number),
-        expect.any(Array)
-      );
+      // Exactly one argument: the store action is called through an arrow, not
+      // handed to forEach directly, so forEach's index and array never reach it.
+      expect(mockAddSpeciality).toHaveBeenCalledWith(expect.objectContaining({ _id: 'spec-a' }));
     });
 
     it('throws error on failure', async () => {
@@ -317,6 +315,11 @@ describe('specialityService', () => {
 
       expect(axiosService.postData).toHaveBeenCalledWith('/fhir/v1/service/bulk', payload);
       expect(mockAddService).toHaveBeenCalledTimes(2);
+      // One argument per call: forEach's index and array must not leak into the
+      // store action, which only accepts a Service.
+      for (const call of mockAddService.mock.calls) {
+        expect(call).toHaveLength(1);
+      }
       expect(result).toHaveLength(2);
       expect(result[0].id).toBe('svc-a');
     });

--- a/apps/frontend/src/app/api/community/discord-members/route.ts
+++ b/apps/frontend/src/app/api/community/discord-members/route.ts
@@ -20,9 +20,11 @@ import { NextResponse } from 'next/server';
  * server, never by the browser.
  */
 
-// Both the vanity code and the raw invite code resolve to the same guild. The
-// vanity URL is the one published in the docs, but it only works while the guild
-// keeps its boost level, so the raw code stays as the fallback.
+// Both codes resolve to the same guild. Order matters: the first one to return a
+// count wins. The raw invite code is primary - it is what the READMEs, dev-docs
+// and issue templates publish, and it does not expire. The `yosemitecrew` vanity
+// slug (used by the site footer and marketing assets) is only the fallback,
+// because a vanity URL stops resolving if the guild loses its boost level.
 const DISCORD_INVITE_CODES = ['SwM6mX85KD', 'yosemitecrew'];
 
 // Discord requires a descriptive User-Agent on API calls and rate-limits or

--- a/apps/frontend/src/app/api/community/discord-members/route.ts
+++ b/apps/frontend/src/app/api/community/discord-members/route.ts
@@ -66,33 +66,22 @@ const fetchMemberCount = async (inviteCode: string): Promise<string | null> => {
   }
 };
 
-/**
- * Last successfully parsed count. Only successes land here, so a failed or
- * malformed upstream response can never be served from cache - the next request
- * retries Discord immediately. Per server instance, like the equivalent cache in
- * the backend's DiscordMembersService.
- */
-let cached: { count: string; at: number } | null = null;
-
-const readCached = (now: number): string | null =>
-  cached && now - cached.at < CACHE_TTL_SECONDS * 1000 ? cached.count : null;
-
 export async function GET(): Promise<NextResponse<DiscordMembersResponse>> {
-  const now = Date.now();
-  const successHeaders = {
-    'Cache-Control': `public, max-age=${CACHE_TTL_SECONDS}, stale-while-revalidate=${CACHE_TTL_SECONDS}`,
-  };
-
-  const fresh = readCached(now);
-  if (fresh !== null) {
-    return NextResponse.json({ discordMembers: fresh }, { headers: successHeaders });
-  }
-
   for (const inviteCode of DISCORD_INVITE_CODES) {
     const discordMembers = await fetchMemberCount(inviteCode);
     if (discordMembers !== null) {
-      cached = { count: discordMembers, at: now };
-      return NextResponse.json({ discordMembers }, { headers: successHeaders });
+      // Caching lives entirely in this response header, never in module state.
+      // Keyed on the outcome, so only a real count is ever cached: repeat traffic
+      // is served by the CDN and the browser for the TTL, while a failure (below)
+      // is cached nowhere and retried on the very next request.
+      return NextResponse.json(
+        { discordMembers },
+        {
+          headers: {
+            'Cache-Control': `public, max-age=${CACHE_TTL_SECONDS}, stale-while-revalidate=${CACHE_TTL_SECONDS}`,
+          },
+        }
+      );
     }
   }
 

--- a/apps/frontend/src/app/api/community/discord-members/route.ts
+++ b/apps/frontend/src/app/api/community/discord-members/route.ts
@@ -51,7 +51,12 @@ const fetchMemberCount = async (inviteCode: string): Promise<string | null> => {
       `https://discord.com/api/v10/invites/${inviteCode}?with_counts=true&with_expiration=true`,
       {
         headers: { Accept: 'application/json', 'User-Agent': DISCORD_USER_AGENT },
-        next: { revalidate: CACHE_TTL_SECONDS },
+        // Deliberately uncached at the fetch layer. Next's data cache keys on the
+        // request, not the outcome, so `revalidate` here would also cache a 200
+        // that carries no member count (or malformed JSON) and keep replaying it
+        // for the whole TTL after Discord recovered. Only a parsed count is
+        // cached, and that happens below.
+        cache: 'no-store',
       }
     );
     if (!response.ok) return null;
@@ -61,23 +66,38 @@ const fetchMemberCount = async (inviteCode: string): Promise<string | null> => {
   }
 };
 
+/**
+ * Last successfully parsed count. Only successes land here, so a failed or
+ * malformed upstream response can never be served from cache - the next request
+ * retries Discord immediately. Per server instance, like the equivalent cache in
+ * the backend's DiscordMembersService.
+ */
+let cached: { count: string; at: number } | null = null;
+
+const readCached = (now: number): string | null =>
+  cached && now - cached.at < CACHE_TTL_SECONDS * 1000 ? cached.count : null;
+
 export async function GET(): Promise<NextResponse<DiscordMembersResponse>> {
+  const now = Date.now();
+  const successHeaders = {
+    'Cache-Control': `public, max-age=${CACHE_TTL_SECONDS}, stale-while-revalidate=${CACHE_TTL_SECONDS}`,
+  };
+
+  const fresh = readCached(now);
+  if (fresh !== null) {
+    return NextResponse.json({ discordMembers: fresh }, { headers: successHeaders });
+  }
+
   for (const inviteCode of DISCORD_INVITE_CODES) {
     const discordMembers = await fetchMemberCount(inviteCode);
     if (discordMembers !== null) {
-      return NextResponse.json(
-        { discordMembers },
-        {
-          headers: {
-            'Cache-Control': `public, max-age=${CACHE_TTL_SECONDS}, stale-while-revalidate=${CACHE_TTL_SECONDS}`,
-          },
-        }
-      );
+      cached = { count: discordMembers, at: now };
+      return NextResponse.json({ discordMembers }, { headers: successHeaders });
     }
   }
 
   // 200 with a null count, not an error status: the caller treats a missing
-  // count as "contribute nothing this pass" and keeps its loading placeholder,
-  // and a failed lookup should not be cached.
+  // count as "contribute nothing this pass" and keeps its loading placeholder.
+  // Nothing about a failure is cached, at this layer or any other.
   return NextResponse.json({ discordMembers: null }, { headers: { 'Cache-Control': 'no-store' } });
 }

--- a/apps/frontend/src/app/api/community/discord-members/route.ts
+++ b/apps/frontend/src/app/api/community/discord-members/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from 'next/server';
+
+/**
+ * Public Discord member count for the marketing surfaces (nav, footer, About,
+ * Insights).
+ *
+ * This lives in the web app rather than being read from the product API for
+ * three reasons, each of which has broken the number on the live site before:
+ *
+ *  - Same-origin. The browser calls `/api/...`, which `connect-src 'self'`
+ *    already allows and which needs no CORS negotiation with the API domain.
+ *  - No env var in the URL. Building the product-API URL by concatenating
+ *    `NEXT_PUBLIC_BASE_URL` breaks whenever that value's trailing slash
+ *    changes between environments.
+ *  - No credentials and no session interceptor. This is public data; routing it
+ *    through the authenticated axios client meant a 401 could bounce a visitor
+ *    on a public page to the sign-in screen.
+ *
+ * It also keeps visitors' IPs out of Discord's hands: the lookup is made by the
+ * server, never by the browser.
+ */
+
+// Both the vanity code and the raw invite code resolve to the same guild. The
+// vanity URL is the one published in the docs, but it only works while the guild
+// keeps its boost level, so the raw code stays as the fallback.
+const DISCORD_INVITE_CODES = ['SwM6mX85KD', 'yosemitecrew'];
+
+// Discord requires a descriptive User-Agent on API calls and rate-limits or
+// rejects generic ones.
+const DISCORD_USER_AGENT = 'DiscordBot (https://www.yosemitecrew.com, 1.0)';
+
+const CACHE_TTL_SECONDS = 300;
+
+export interface DiscordMembersResponse {
+  /** Localized member count, e.g. '1,204'. Null when the lookup failed. */
+  discordMembers: string | null;
+}
+
+const readMemberCount = (invite: unknown): string | null => {
+  if (!invite || typeof invite !== 'object') return null;
+  const { approximate_member_count: count } = invite as { approximate_member_count?: number };
+  if (typeof count !== 'number') return null;
+  return count.toLocaleString('en-US');
+};
+
+const fetchMemberCount = async (inviteCode: string): Promise<string | null> => {
+  try {
+    const response = await fetch(
+      `https://discord.com/api/v10/invites/${inviteCode}?with_counts=true&with_expiration=true`,
+      {
+        headers: { Accept: 'application/json', 'User-Agent': DISCORD_USER_AGENT },
+        next: { revalidate: CACHE_TTL_SECONDS },
+      }
+    );
+    if (!response.ok) return null;
+    return readMemberCount(await response.json());
+  } catch {
+    return null;
+  }
+};
+
+export async function GET(): Promise<NextResponse<DiscordMembersResponse>> {
+  for (const inviteCode of DISCORD_INVITE_CODES) {
+    const discordMembers = await fetchMemberCount(inviteCode);
+    if (discordMembers !== null) {
+      return NextResponse.json(
+        { discordMembers },
+        {
+          headers: {
+            'Cache-Control': `public, max-age=${CACHE_TTL_SECONDS}, stale-while-revalidate=${CACHE_TTL_SECONDS}`,
+          },
+        }
+      );
+    }
+  }
+
+  // 200 with a null count, not an error status: the caller treats a missing
+  // count as "contribute nothing this pass" and keeps its loading placeholder,
+  // and a failed lookup should not be cached.
+  return NextResponse.json({ discordMembers: null }, { headers: { 'Cache-Control': 'no-store' } });
+}

--- a/apps/frontend/src/app/features/appointments/components/AppointmentCardContent.tsx
+++ b/apps/frontend/src/app/features/appointments/components/AppointmentCardContent.tsx
@@ -26,7 +26,6 @@ type AppointmentModePillProps = {
   appointment: Appointment;
   className?: string;
   iconSize?: number;
-  tone?: 'default' | 'strong';
 };
 
 type EncounterModePillProps = {

--- a/apps/frontend/src/app/features/appointments/components/Calendar/AppointmentCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/AppointmentCalendar.tsx
@@ -253,7 +253,6 @@ const AppointmentCalendar = ({
       <Header
         currentDate={currentDate}
         setCurrentDate={setCurrentDate}
-        weekStart={weekStart}
         setWeekStart={setWeekStart}
         zoomMode={zoomMode}
         setZoomMode={setZoomMode}
@@ -292,7 +291,6 @@ const AppointmentCalendar = ({
           date={currentDate}
           zoomMode={zoomMode}
           handleDetailAppointment={handleViewAppointment}
-          setCurrentDate={setCurrentDate}
         />
       )}
       {activeCalendar === 'week' && (
@@ -302,8 +300,6 @@ const AppointmentCalendar = ({
           events={weekEvents}
           zoomMode={zoomMode}
           weekStart={weekStart}
-          setWeekStart={setWeekStart}
-          setCurrentDate={setCurrentDate}
         />
       )}
       {activeCalendar === 'team' && (
@@ -314,7 +310,6 @@ const AppointmentCalendar = ({
           date={currentDate}
           zoomMode={zoomMode}
           forceFullDayInZoomIn
-          setCurrentDate={setCurrentDate}
           getVisibleAvailabilityIntervals={getViewAvailabilityIntervals}
         />
       )}

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/DayCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/DayCalendar.tsx
@@ -57,7 +57,6 @@ type DayCalendarProps = {
   handleViewAppointment: (appointment: Appointment, intent?: AppointmentViewIntent) => void;
   handleDetailAppointment: (appointment: Appointment, intent?: AppointmentViewIntent) => void;
   handleOpenWorkspace?: (appointment: Appointment, intent?: AppointmentViewIntent) => void;
-  setCurrentDate: React.Dispatch<React.SetStateAction<Date>>;
   handleRescheduleAppointment: (appointment: Appointment) => void;
   handleChangeRoomAppointment?: (appointment: Appointment) => void;
   handleAcceptAppointment?: (appointment: Appointment) => void;
@@ -484,8 +483,6 @@ const DayCalendarComponent: React.FC<DayCalendarProps> = ({
   handleChangeRoomAppointment,
   handleAcceptAppointment,
   canEditAppointments,
-  // setCurrentDate stays on the props contract for callers, but day navigation
-  // now lives in the header toolbar's date-nav pill, which owns the setter.
   draggedAppointmentId,
   draggedAppointmentLabel,
   canDragAppointment,

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/Header.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/Header.tsx
@@ -406,7 +406,6 @@ type Headerprops = {
   currentDate: Date;
   setCurrentDate: React.Dispatch<React.SetStateAction<Date>>;
   /** Supplied by the week view so the header arrows step whole weeks. */
-  weekStart?: Date;
   setWeekStart?: React.Dispatch<React.SetStateAction<Date>>;
   zoomMode?: CalendarZoomMode;
   setZoomMode?: React.Dispatch<React.SetStateAction<CalendarZoomMode>>;

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/UserCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/UserCalendar.tsx
@@ -48,7 +48,6 @@ type UserCalendarProps = {
   handleViewAppointment: any;
   handleDetailAppointment?: any;
   handleOpenWorkspace?: (appointment: Appointment, intent?: AppointmentViewIntent) => void;
-  setCurrentDate: React.Dispatch<React.SetStateAction<Date>>;
   handleRescheduleAppointment: any;
   handleChangeRoomAppointment?: any;
   handleAcceptAppointment?: (appt: Appointment) => void;
@@ -86,8 +85,6 @@ const UserCalendar: React.FC<UserCalendarProps> = ({
   handleRescheduleAppointment,
   handleChangeRoomAppointment,
   handleAcceptAppointment,
-  // setCurrentDate stays on the props contract for callers, but day navigation
-  // now lives in the header toolbar's date-nav pill, which owns the setter.
   canEditAppointments,
   draggedAppointmentId,
   draggedAppointmentLabel,

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/WeekCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/WeekCalendar.tsx
@@ -354,8 +354,6 @@ type WeekCalendarProps = {
   handleDetailAppointment?: any;
   handleOpenWorkspace?: (appointment: Appointment, intent?: AppointmentViewIntent) => void;
   weekStart: Date;
-  setWeekStart: React.Dispatch<React.SetStateAction<Date>>;
-  setCurrentDate: React.Dispatch<React.SetStateAction<Date>>;
   handleRescheduleAppointment: any;
   handleChangeRoomAppointment?: any;
   handleAcceptAppointment?: (appt: Appointment) => void;
@@ -389,9 +387,6 @@ const WeekCalendar: React.FC<WeekCalendarProps> = ({
   handleDetailAppointment,
   handleOpenWorkspace,
   weekStart,
-  // setWeekStart / setCurrentDate stay on the props contract but are no longer read
-  // here: week navigation moved to the header toolbar's date-nav pill, which owns
-  // both setters. The grid itself only reads weekStart.
   handleRescheduleAppointment,
   handleChangeRoomAppointment,
   handleAcceptAppointment,

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneDayStrip.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneDayStrip.tsx
@@ -43,7 +43,11 @@ const PhoneDayStrip = ({
   );
 
   return (
-    <div className={clsx('yc-day-strip', className)} role="group" aria-label="Select a day">
+    <div /* NOSONAR: styled horizontal day strip; native <fieldset> defaults (block layout, border, required legend) break the strip design */
+      className={clsx('yc-day-strip', className)}
+      role="group"
+      aria-label="Select a day"
+    >
       {cells.map((cell) => (
         <button
           key={cell.dateKey}

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AddAppointmentCentralModal/index.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AddAppointmentCentralModal/index.tsx
@@ -545,6 +545,13 @@ export const TimeSlotTriggerValue = ({ isLoading, selectedLabel }: TimeSlotTrigg
   return <span style={{ ...text16R, color: INPUT_PLACEHOLDER }} />;
 };
 
+/** Trigger border: open state wins over the error state, which wins over resting. */
+const timeSlotTriggerBorderClass = (open: boolean, error?: string): string => {
+  if (open) return 'border-[var(--blue)]! shadow-[0_0_0_3px_var(--glow-b10)]';
+  if (error) return 'border-[var(--danger)]!';
+  return 'border-[var(--hairline)]!';
+};
+
 export const TimeSlotDropdown = ({
   timeSlots,
   selectedSlot,
@@ -616,11 +623,7 @@ export const TimeSlotDropdown = ({
         ref={triggerRef}
         className={clsx(
           'relative flex h-[44px] w-full items-center rounded-[12px]! border-[1.5px] bg-[var(--field-bg)] px-[13px] pr-9 text-left text-[13px] transition-colors duration-150 select-none focus:shadow-[0_0_0_3px_var(--glow-b10)]',
-          open
-            ? 'border-[var(--blue)]! shadow-[0_0_0_3px_var(--glow-b10)]'
-            : error
-              ? 'border-[var(--danger)]!'
-              : 'border-[var(--hairline)]!'
+          timeSlotTriggerBorderClass(open, error)
         )}
         onClick={() => setOpen((o) => !o)}
         aria-expanded={open}

--- a/apps/frontend/src/app/features/auth/pages/ForgotPassword/ForgotPassword.tsx
+++ b/apps/frontend/src/app/features/auth/pages/ForgotPassword/ForgotPassword.tsx
@@ -174,7 +174,7 @@ const ForgotPassword = () => {
               >
                 try another email
               </button>
-              .
+              {'.'}
             </AuthAltNote>
           </div>
         ) : (

--- a/apps/frontend/src/app/features/chat/components/ChatContainer.css
+++ b/apps/frontend/src/app/features/chat/components/ChatContainer.css
@@ -128,11 +128,11 @@
   gap: 2px;
 }
 
-/* NOTE: Stream's own `.str-chat__channel-preview` styling is intentionally
-   absent. That class only ships on ChannelPreviewMessenger, which we replace
-   with <ConversationRow>; the design's conversation list is a stack of rounded
-   rows separated by a 2px gap, NOT a ruled list, so no divider/left-stripe rules
-   belong here. Row styling lives in ConversationRow.tsx. */
+/* NOTE: Stream's own channel-preview styling is intentionally absent. Its class
+   only ships on ChannelPreviewMessenger, which we replace with ConversationRow;
+   the design's conversation list is a stack of rounded rows separated by a 2px
+   gap, NOT a ruled list, so no divider or left-stripe rules belong here. Row
+   styling lives in ConversationRow.tsx. */
 
 .chat-preview-trigger {
   display: block;

--- a/apps/frontend/src/app/features/finance/services/discountSettingsService.ts
+++ b/apps/frontend/src/app/features/finance/services/discountSettingsService.ts
@@ -66,9 +66,7 @@ export const getOrganisationDiscountSettings = async (
   organisationId: string
 ): Promise<OrganisationDiscountSettings> => {
   if (!organisationId) throw new Error('Organisation ID missing');
-  const res = await getData<FinanceEnvelope<unknown> | unknown>(
-    discountSettingsPath(organisationId)
-  );
+  const res = await getData<unknown>(discountSettingsPath(organisationId));
   return normalizeSettings(unwrapFinanceData(res.data), organisationId);
 };
 
@@ -77,9 +75,6 @@ export const updateOrganisationDiscountSettings = async (
   input: { maxOverallDiscountPercent: number | null }
 ): Promise<OrganisationDiscountSettings> => {
   if (!organisationId) throw new Error('Organisation ID missing');
-  const res = await putData<FinanceEnvelope<unknown> | unknown>(
-    discountSettingsPath(organisationId),
-    input
-  );
+  const res = await putData<unknown>(discountSettingsPath(organisationId), input);
   return normalizeSettings(unwrapFinanceData(res.data), organisationId);
 };

--- a/apps/frontend/src/app/features/forms/pages/Forms/index.tsx
+++ b/apps/frontend/src/app/features/forms/pages/Forms/index.tsx
@@ -149,7 +149,10 @@ const Forms = () => {
 
   const serviceOptions = useMemo(() => {
     const specialityNameById = new Map(
-      orgSpecialities.map((speciality) => [String(speciality.id ?? ''), speciality.name])
+      orgSpecialities.map((speciality) => [
+        String(speciality.id ?? ''),
+        toPrimitiveString(speciality.name),
+      ])
     );
 
     const catalogItems = [
@@ -168,8 +171,10 @@ const Forms = () => {
     for (const item of catalogItems) {
       if (!item.id || !item.name) continue;
       const duplicateName = (nameFrequency.get(item.name.toLowerCase()) ?? 0) > 1;
+      // `||`, not `??`: a speciality whose name is missing or non-primitive
+      // resolves to '', which should read as unknown rather than render blank.
       const specialityLabel =
-        specialityNameById.get(toPrimitiveString(item.specialityId)) ?? 'Unknown Speciality';
+        specialityNameById.get(toPrimitiveString(item.specialityId)) || 'Unknown Speciality';
       options.push({
         label: duplicateName ? `${specialityLabel} / ${item.name}` : item.name,
         value: item.id,

--- a/apps/frontend/src/app/features/marketing/site/LegalDoc.tsx
+++ b/apps/frontend/src/app/features/marketing/site/LegalDoc.tsx
@@ -153,7 +153,7 @@ export function LegalDoc({
               aria-controls="yc-toc-list"
               onClick={() => setTocOpen((open) => !open)}
             >
-              On this page
+              {'On this page'}
               <span aria-hidden="true">{tocOpen ? '–' : '+'}</span>
             </button>
             <nav id="yc-toc-list" className="yc-toc-list" data-open={tocOpen}>

--- a/apps/frontend/src/app/features/marketing/site/useGithubStats.ts
+++ b/apps/frontend/src/app/features/marketing/site/useGithubStats.ts
@@ -7,7 +7,6 @@ import {
   setJsonStorageItem,
   setStorageItem,
 } from '@/app/lib/browserStorage';
-import { http } from '@/app/services/http';
 import { GITHUB_API_REPO } from './assets';
 
 export interface GithubStats {
@@ -34,7 +33,9 @@ const EMPTY_STATS: GithubStats = {
 };
 const REPO_STATS_SUMMARY =
   'https://raw.githubusercontent.com/YosemiteCrew/Yosemite-Crew/github-repo-stats/YosemiteCrew/Yosemite-Crew/latest-report/summary.json';
-const DISCORD_MEMBERS_ENDPOINT = `${process.env.NEXT_PUBLIC_BASE_URL}v1/marketing/discord-members`;
+// Same-origin route handler, not the product API: see the comment on that route
+// for why the number kept breaking when it was read across origins.
+const DISCORD_MEMBERS_ENDPOINT = '/api/community/discord-members';
 const CONTRIBUTORS_API = `${GITHUB_API_REPO}/contributors?per_page=1&anon=true`;
 
 const formatCompact = (n: number): string =>
@@ -100,13 +101,11 @@ const fetchContributors = async (): Promise<Partial<GithubStats>> => {
 };
 
 const fetchDiscord = async (): Promise<Partial<GithubStats>> => {
-  try {
-    const response = await http.get<{ discordMembers: string | null }>(DISCORD_MEMBERS_ENDPOINT);
-    if (typeof response.data.discordMembers !== 'string') return {};
-    return { discord: response.data.discordMembers };
-  } catch {
-    return {};
-  }
+  const json = (await fetchJson(DISCORD_MEMBERS_ENDPOINT)) as {
+    discordMembers?: string | null;
+  } | null;
+  if (typeof json?.discordMembers !== 'string') return {};
+  return { discord: json.discordMembers };
 };
 
 /**

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Team/PermissionsEditor.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Team/PermissionsEditor.tsx
@@ -216,6 +216,68 @@ function pickEnablePermission(
   return enablePriority[0] ?? null;
 }
 
+/**
+ * Which permissions to add when a group is switched on: every baseline
+ * permission for an additive group, one tier otherwise.
+ */
+function pickEnablePermissions(
+  roleDefaults: Permission[],
+  enablePriority: Permission[] | undefined,
+  additive: boolean
+): Permission[] {
+  if (additive) return pickAdditiveEnablePermissions(roleDefaults, enablePriority);
+  const single = pickEnablePermission(roleDefaults, enablePriority);
+  return single ? [single] : [];
+}
+
+/** Rule: turning EDIT on also turns VIEW on. */
+function withViewEnabled(
+  next: Permission[],
+  row: PermissionRow,
+  roleDefaults: Permission[]
+): Permission[] {
+  const viewCandidates = row.view ?? [];
+  if (!viewCandidates.length || hasAny(next, viewCandidates)) return next;
+  const viewToAdd = pickEnablePermissions(
+    roleDefaults,
+    row.viewEnablePriority ?? viewCandidates,
+    row.additiveView === true
+  );
+  return viewToAdd.length ? uniq([...next, ...viewToAdd]) : next;
+}
+
+/** The permission set that results from toggling one row's view/edit switch. */
+function applyToggle(
+  prev: Permission[],
+  kind: 'view' | 'edit',
+  row: PermissionRow,
+  nextChecked: boolean,
+  roleDefaults: Permission[]
+): Permission[] {
+  const viewCandidates = row.view ?? [];
+  const editCandidates = row.edit ?? [];
+  const isView = kind === 'view';
+
+  // ✅ Rule: turning VIEW off also turns EDIT off
+  if (!nextChecked && isView) {
+    return removeAll(prev, uniq([...viewCandidates, ...editCandidates]));
+  }
+
+  const candidates = isView ? viewCandidates : editCandidates;
+  if (!candidates.length) return prev;
+
+  // Uncheck => remove all in that group
+  if (!nextChecked) return removeAll(prev, candidates);
+
+  // Check => remove conflicts in that group, then add back what applies.
+  const priority = isView ? row.viewEnablePriority : row.editEnablePriority;
+  const toAdd = pickEnablePermissions(roleDefaults, priority, isView && row.additiveView === true);
+  if (!toAdd.length) return prev;
+
+  const next = uniq([...removeAll(prev, candidates), ...toAdd]);
+  return isView ? next : withViewEnabled(next, row, roleDefaults);
+}
+
 const OWNER_LOCKED_PERMISSIONS: Permission[] = PERMISSION_ROWS.reduce<Permission[]>(
   (permissions, row) => {
     if (row.ownerLocked === true) permissions.push(...(row.view ?? []), ...(row.edit ?? []));
@@ -281,49 +343,7 @@ const PermissionsEditor = ({ value, onSave, role, readOnly = false }: Permission
       // An owner never loses the permissions that gate the screens they would
       // use to reverse a change, so these rows cannot be switched off here.
       if (!nextChecked && row.ownerLocked && role === 'OWNER') return;
-      setDraft((prev) => {
-        const viewCandidates = row.view ?? [];
-        const editCandidates = row.edit ?? [];
-
-        // ✅ Rule: turning VIEW off also turns EDIT off
-        if (!nextChecked && kind === 'view') {
-          return removeAll(prev, uniq([...viewCandidates, ...editCandidates]));
-        }
-
-        const candidates = kind === 'view' ? viewCandidates : editCandidates;
-        const priority = kind === 'view' ? row.viewEnablePriority : row.editEnablePriority;
-
-        if (!candidates.length) return prev;
-
-        // Uncheck => remove all in that group
-        if (!nextChecked) {
-          return removeAll(prev, candidates);
-        }
-
-        // Check => remove conflicts in that group, then add back what applies:
-        // every baseline permission for an additive group, one tier otherwise.
-        const isAdditive = kind === 'view' && row.additiveView === true;
-        const single = pickEnablePermission(roleDefaults, priority);
-        const toAdd = isAdditive
-          ? pickAdditiveEnablePermissions(roleDefaults, priority)
-          : ((single ? [single] : []) as Permission[]);
-        if (!toAdd.length) return prev;
-
-        let next = uniq([...removeAll(prev, candidates), ...toAdd]);
-
-        // ✅ Rule: turning EDIT on also turns VIEW on
-        if (kind === 'edit' && viewCandidates.length && !hasAny(next, viewCandidates)) {
-          const viewPriority = row.viewEnablePriority ?? viewCandidates;
-          const viewToAdd = row.additiveView
-            ? pickAdditiveEnablePermissions(roleDefaults, viewPriority)
-            : ((pickEnablePermission(roleDefaults, viewPriority)
-                ? [pickEnablePermission(roleDefaults, viewPriority)]
-                : []) as Permission[]);
-          if (viewToAdd.length) next = uniq([...next, ...viewToAdd]);
-        }
-
-        return next;
-      });
+      setDraft((prev) => applyToggle(prev, kind, row, nextChecked, roleDefaults));
     },
     [role, roleDefaults]
   );

--- a/apps/frontend/src/app/features/organization/services/specialityService.ts
+++ b/apps/frontend/src/app/features/organization/services/specialityService.ts
@@ -193,7 +193,7 @@ export const createSpecialitiesBulk = async (payload: Speciality[]) => {
     const normalSpecialities = getBulkResponseItems(res.data).map((speciality) =>
       fromSpecialityRequestDTO(speciality)
     );
-    normalSpecialities.forEach(addSpeciality);
+    normalSpecialities.forEach((speciality) => addSpeciality(speciality));
     return normalSpecialities;
   } catch (err) {
     console.error('Failed to create specialities:', err);
@@ -225,7 +225,7 @@ export const createServicesBulk = async (payload: Service[]) => {
     const normalServices = getBulkResponseItems(res.data).map((service) =>
       fromServiceRequestDTO(service)
     );
-    normalServices.forEach(addService);
+    normalServices.forEach((service) => addService(service));
     return normalServices;
   } catch (err) {
     console.error('Failed to create services:', err);
@@ -235,12 +235,10 @@ export const createServicesBulk = async (payload: Service[]) => {
 
 export const createBulkSpecialityServices = async (payload: SpecialityWeb[]) => {
   try {
-    const specialitiesToCreate = payload.filter(Boolean).map(
-      (item): Speciality => ({
-        ...item,
-        services: [],
-      })
-    );
+    const specialitiesToCreate = payload.filter(Boolean).map((item): Speciality => ({
+      ...item,
+      services: [],
+    }));
     const addedSpecialities = await createSpecialitiesBulk(specialitiesToCreate);
     const specialityIdByName = new Map(
       addedSpecialities.map((speciality) => [

--- a/apps/frontend/src/app/features/settings/pages/Settings/Sections/HoursEditModal.tsx
+++ b/apps/frontend/src/app/features/settings/pages/Settings/Sections/HoursEditModal.tsx
@@ -42,6 +42,11 @@ const buildDefaultAvailability = (): AvailabilityState =>
 type MembershipLike = { practitionerReference?: string; id?: string } | null | undefined;
 type OrgLike = { _id?: unknown } | null | undefined;
 
+// `_id` comes off the store untyped. Only a primitive is a usable organisation
+// id, so anything else resolves to '' instead of stringifying to '[object Object]'.
+const toOrgId = (value: unknown): string =>
+  typeof value === 'string' || typeof value === 'number' ? String(value) : '';
+
 // Convert the editable availability and persist it (team vs. org level). Returns
 // false when nothing is enabled, so the caller can keep the editor open.
 const persistAvailability = async (
@@ -57,7 +62,7 @@ const persistAvailability = async (
       {
         _id: membership.id ?? membership.practitionerReference,
         practionerId: membership.practitionerReference,
-        organisationId: primaryOrgId ?? String(org?._id ?? ''),
+        organisationId: primaryOrgId ?? toOrgId(org?._id),
       } as any,
       converted,
       null

--- a/apps/frontend/src/app/features/tasks/components/TaskFilterBar.tsx
+++ b/apps/frontend/src/app/features/tasks/components/TaskFilterBar.tsx
@@ -63,7 +63,7 @@ const TaskFilterBar = ({
       <div className="flex flex-wrap items-center gap-2">
         {showScope && (
           <>
-            <div
+            <div /* NOSONAR: styled inline-flex segmented control; native <fieldset> defaults (block layout, border, required legend) break the pill design */
               role="group"
               aria-label="Task scope"
               className="inline-flex items-center rounded-full border border-[var(--hairline)] p-0.5"

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -816,6 +816,159 @@ html[data-theme='dark'] {
   --status-in-progress-border: rgba(154, 113, 247, 0.6);
   --color-status-success-text: #74d0a2;
   --color-status-success-bg: rgba(74, 205, 155, 0.16);
+
+  /* ---------------------------------------------------------------------
+     Warm-bone token set, folded in from what used to be a second
+     html[data-theme="dark"] block further down this file. The two blocks were
+     kept apart while the surfaces landed on separate branches; they are one
+     rule now. Declarations below still come last, so where a token appears in
+     both halves this value is the effective one -- do not reorder.
+     --------------------------------------------------------------------- */
+  --page: #201c18;
+  --band: #2a2216;
+  --inset: #302820;
+  --screen: #2f271e;
+  --screen-2: #221d17;
+  --hairline: #40362b;
+  --divider: #3a3128;
+  --hairline-hover: #4a4033;
+  --nav-active: #8fb6f5;
+  --nav-active-bg: rgba(143, 182, 245, 0.13);
+  --ink: #f4efe6;
+  --ink-body: #e6ddd0;
+  --ink-muted: #a89e90;
+  --ink-soft: #cabfb0;
+  --ink-faint: #9d9285;
+  --ink-faint2: #8b8173;
+  --ink-6b: #a1968a;
+  --cta: #f2ece1;
+  --cta-hover: #fbf8f1;
+  --cta-text: #201c18;
+  --blue: #257bed;
+  --blue-text: #8fb6f5;
+  --blue-soft: rgba(143, 182, 245, 0.16);
+  --pink: #ff90d4;
+  --cyan: #5ce1e6;
+  --cyan-text: #5ce1e6;
+  --success: #2bbd86;
+  --avatar-violet-bg: rgba(167, 139, 250, 0.2);
+  --avatar-violet-ink: #cbb2f4;
+  --avatar-green-bg: rgba(74, 205, 155, 0.17);
+  --avatar-green-ink: #74d0a2;
+  --avatar-amber-bg: rgba(233, 170, 120, 0.17);
+  --avatar-amber-ink: #ecb488;
+  --hairline-soft: rgba(255, 255, 255, 0.09);
+  --glass-inset-hi: rgba(255, 255, 255, 0.06);
+  --sh03: rgba(0, 0, 0, 0.14);
+  --sh05: rgba(0, 0, 0, 0.2);
+  --sh06: rgba(0, 0, 0, 0.24);
+  --sh08: rgba(0, 0, 0, 0.3);
+  --sh09: rgba(0, 0, 0, 0.32);
+  --sh10: rgba(0, 0, 0, 0.34);
+  --sh12: rgba(0, 0, 0, 0.36);
+  --sh14: rgba(0, 0, 0, 0.4);
+  --sh16: rgba(0, 0, 0, 0.44);
+  --sh18: rgba(0, 0, 0, 0.48);
+  --sh20: rgba(0, 0, 0, 0.52);
+  --sh22: rgba(0, 0, 0, 0.55);
+  --sh28: rgba(0, 0, 0, 0.62);
+  --sh55: rgba(0, 0, 0, 0.8);
+  --glow-b07: rgba(37, 123, 237, 0.13);
+  --glow-b10: rgba(37, 123, 237, 0.18);
+  --glow-b12: rgba(37, 123, 237, 0.22);
+  --glow-b14: rgba(37, 123, 237, 0.25);
+  --glow-b26: rgba(37, 123, 237, 0.42);
+  --glow-c10: rgba(92, 225, 230, 0.18);
+  --glow-c14: rgba(92, 225, 230, 0.25);
+  --glow-p10: rgba(244, 121, 190, 0.18);
+  --glow-p12: rgba(244, 121, 190, 0.22);
+  --surface-soft: #2a2216;
+  --pill-raised: #383026;
+  --glass-93: rgba(34, 29, 23, 0.92);
+  --field-bg: #241f18;
+  /* Dark tint-on-dark equivalents for the chrome/state semantic surfaces. */
+  --danger-bg: rgba(234, 55, 41, 0.18);
+  --danger-bg-faint: rgba(234, 55, 41, 0.08);
+  --danger-text: #f2938a;
+  --danger: #ea3729;
+  --danger-border: rgba(242, 147, 138, 0.42);
+  --warn-bg: rgba(245, 158, 11, 0.16);
+  --warn-text: #f2b56b;
+  --warn-border: rgba(245, 168, 60, 0.42);
+  --pink-soft: rgba(255, 144, 212, 0.16);
+  --pink-text: #ff9dd8;
+
+  /* Dark overrides for coloured ramps, status chips, and semantic one-offs so tinted
+   badges, alerts, pills, chat, and calendar surfaces flip with the theme. Status values
+   match the DS dark set. Light mode is unaffected (these only apply under data-theme=dark). */
+  /* tinted chip backgrounds + text (success / warning / danger / brand) */
+  --color-success-100: rgba(74, 205, 155, 0.16);
+  --color-success-700: #74d0a2;
+  --color-success-600: #2bbd86;
+  --color-warning-100: rgba(245, 168, 60, 0.16);
+  --color-warning-700: #f2b56b;
+  --color-danger-100: rgba(234, 55, 41, 0.18);
+  --color-danger-700: #f2938a;
+  --color-primary-100: rgba(143, 182, 245, 0.16);
+  --color-blue-light: rgba(143, 182, 245, 0.16);
+  --color-blue-text: #8fb6f5;
+  --color-text-brand: #8fb6f5;
+  --color-text-error: #f2938a;
+  /* warning / pending / danger-soft surfaces */
+  --color-card-warning: rgba(245, 168, 60, 0.14);
+  --color-white-pending: rgba(245, 168, 60, 0.14);
+  --color-danger-soft: rgba(234, 55, 41, 0.18);
+  /* overlays + shadows */
+  --color-overlay-backdrop: rgba(0, 0, 0, 0.62);
+  --color-shadow-soft: rgba(0, 0, 0, 0.4);
+  --color-shadow-xs: rgba(0, 0, 0, 0.28);
+  --color-shadow-sm: rgba(0, 0, 0, 0.5);
+  --color-shadow-md: rgba(0, 0, 0, 0.55);
+  /* chat surfaces */
+  --color-chat-surface: #221d17;
+  --color-chat-panel: #2a2216;
+  --color-chat-panel-border: #40362b;
+  --color-chat-divider: #3a3128;
+  --color-chat-divider-soft: #302820;
+  --color-chat-surface-soft: #262019;
+  --color-chat-empty-bg: #201c18;
+  /* calendar gridlines */
+  --color-calendar-line-strong: #4a4136;
+  --color-calendar-line-soft: #302820;
+  /* Calendar overlays: the light theme dims unavailable slots with a black wash
+     (rgba(0,0,0,0.045)) that is invisible on the dark surface. Re-declare the
+     three overlays as light/colour washes so unavailable, available, and preview
+     slots stay distinguishable in dark mode. */
+  --color-calendar-dim-overlay: rgba(255, 255, 255, 0.06);
+  --color-calendar-availability-overlay: rgba(74, 205, 155, 0.2);
+  --color-calendar-preview-overlay: rgba(103, 160, 239, 0.26);
+  /* active input border */
+  --color-input-border-active: #8fb6f5;
+  /* DS Badge status set — dark tint-on-dark equivalents */
+  --status-requested-bg: rgba(255, 255, 255, 0.07);
+  --status-requested-text: #b9b0a4;
+  --status-requested-border: rgba(255, 255, 255, 0.28);
+  --status-upcoming-bg: rgba(37, 123, 237, 0.18);
+  --status-upcoming-text: #9cc4f8;
+  --status-upcoming-border: rgba(103, 160, 239, 0.6);
+  --status-checked-in-bg: rgba(99, 102, 241, 0.18);
+  --status-checked-in-text: #bcbef9;
+  --status-checked-in-border: rgba(129, 132, 245, 0.6);
+  --status-in-progress-bg: rgba(139, 92, 246, 0.18);
+  --status-in-progress-text: #cdb8fa;
+  --status-in-progress-border: rgba(154, 113, 247, 0.6);
+  --status-completed-bg: rgba(74, 205, 155, 0.16);
+  --status-completed-text: #74d0a2;
+  --status-completed-border: rgba(74, 205, 155, 0.55);
+  --status-cancelled-bg: rgba(249, 115, 22, 0.15);
+  --status-cancelled-text: #f0a36c;
+  --status-cancelled-border: rgba(249, 115, 22, 0.5);
+  --status-no-show-bg: rgba(249, 115, 22, 0.15);
+  --status-no-show-text: #f0a36c;
+  --status-no-show-border: rgba(249, 115, 22, 0.5);
+  --status-danger-bg: rgba(234, 55, 41, 0.18);
+  --status-danger-text: #f2938a;
+  --status-danger-border: rgba(242, 147, 138, 0.42);
 }
 
 /* Native control theming + flip transition, scoped to the marketing surface. */
@@ -1444,164 +1597,6 @@ input[type='number'] {
 
 .yc-shimmer {
   animation: ycShimmer 1.6s ease-in-out infinite;
-}
-
-/* ==========================================================================
-   Warm-bone + dark theme tokens — shared design-system layer.
-   Token VALUES are kept identical to the marketing surface (PR #1773) so the two
-   surfaces resolve to one theme layer when both land; whichever merges second
-   dedupes this block. Light values introduce NEW tokens only and leave every
-   existing PIMS surface untouched — consuming components opt in per surface.
-   Dark mode is driven by html[data-theme="dark"], stamped pre-paint from
-   localStorage 'yc-theme' or prefers-color-scheme (see ui/theme/ThemeScript).
-   ========================================================================== */
-
-html[data-theme='dark'] {
-  --page: #201c18;
-  --band: #2a2216;
-  --inset: #302820;
-  --screen: #2f271e;
-  --screen-2: #221d17;
-  --hairline: #40362b;
-  --divider: #3a3128;
-  --hairline-hover: #4a4033;
-  --nav-active: #8fb6f5;
-  --nav-active-bg: rgba(143, 182, 245, 0.13);
-  --ink: #f4efe6;
-  --ink-body: #e6ddd0;
-  --ink-muted: #a89e90;
-  --ink-soft: #cabfb0;
-  --ink-faint: #9d9285;
-  --ink-faint2: #8b8173;
-  --ink-6b: #a1968a;
-  --cta: #f2ece1;
-  --cta-hover: #fbf8f1;
-  --cta-text: #201c18;
-  --blue: #257bed;
-  --blue-text: #8fb6f5;
-  --blue-soft: rgba(143, 182, 245, 0.16);
-  --pink: #ff90d4;
-  --cyan: #5ce1e6;
-  --cyan-text: #5ce1e6;
-  --success: #2bbd86;
-  --avatar-violet-bg: rgba(167, 139, 250, 0.2);
-  --avatar-violet-ink: #cbb2f4;
-  --avatar-green-bg: rgba(74, 205, 155, 0.17);
-  --avatar-green-ink: #74d0a2;
-  --avatar-amber-bg: rgba(233, 170, 120, 0.17);
-  --avatar-amber-ink: #ecb488;
-  --hairline-soft: rgba(255, 255, 255, 0.09);
-  --glass-inset-hi: rgba(255, 255, 255, 0.06);
-  --sh03: rgba(0, 0, 0, 0.14);
-  --sh05: rgba(0, 0, 0, 0.2);
-  --sh06: rgba(0, 0, 0, 0.24);
-  --sh08: rgba(0, 0, 0, 0.3);
-  --sh09: rgba(0, 0, 0, 0.32);
-  --sh10: rgba(0, 0, 0, 0.34);
-  --sh12: rgba(0, 0, 0, 0.36);
-  --sh14: rgba(0, 0, 0, 0.4);
-  --sh16: rgba(0, 0, 0, 0.44);
-  --sh18: rgba(0, 0, 0, 0.48);
-  --sh20: rgba(0, 0, 0, 0.52);
-  --sh22: rgba(0, 0, 0, 0.55);
-  --sh28: rgba(0, 0, 0, 0.62);
-  --sh55: rgba(0, 0, 0, 0.8);
-  --glow-b07: rgba(37, 123, 237, 0.13);
-  --glow-b10: rgba(37, 123, 237, 0.18);
-  --glow-b12: rgba(37, 123, 237, 0.22);
-  --glow-b14: rgba(37, 123, 237, 0.25);
-  --glow-b26: rgba(37, 123, 237, 0.42);
-  --glow-c10: rgba(92, 225, 230, 0.18);
-  --glow-c14: rgba(92, 225, 230, 0.25);
-  --glow-p10: rgba(244, 121, 190, 0.18);
-  --glow-p12: rgba(244, 121, 190, 0.22);
-  --surface-soft: #2a2216;
-  --pill-raised: #383026;
-  --glass-93: rgba(34, 29, 23, 0.92);
-  --field-bg: #241f18;
-  /* Dark tint-on-dark equivalents for the chrome/state semantic surfaces. */
-  --danger-bg: rgba(234, 55, 41, 0.18);
-  --danger-bg-faint: rgba(234, 55, 41, 0.08);
-  --danger-text: #f2938a;
-  --danger: #ea3729;
-  --danger-border: rgba(242, 147, 138, 0.42);
-  --warn-bg: rgba(245, 158, 11, 0.16);
-  --warn-text: #f2b56b;
-  --warn-border: rgba(245, 168, 60, 0.42);
-  --pink-soft: rgba(255, 144, 212, 0.16);
-  --pink-text: #ff9dd8;
-
-  /* Dark overrides for coloured ramps, status chips, and semantic one-offs so tinted
-   badges, alerts, pills, chat, and calendar surfaces flip with the theme. Status values
-   match the DS dark set. Light mode is unaffected (these only apply under data-theme=dark). */
-  /* tinted chip backgrounds + text (success / warning / danger / brand) */
-  --color-success-100: rgba(74, 205, 155, 0.16);
-  --color-success-700: #74d0a2;
-  --color-success-600: #2bbd86;
-  --color-warning-100: rgba(245, 168, 60, 0.16);
-  --color-warning-700: #f2b56b;
-  --color-danger-100: rgba(234, 55, 41, 0.18);
-  --color-danger-700: #f2938a;
-  --color-primary-100: rgba(143, 182, 245, 0.16);
-  --color-blue-light: rgba(143, 182, 245, 0.16);
-  --color-blue-text: #8fb6f5;
-  --color-text-brand: #8fb6f5;
-  --color-text-error: #f2938a;
-  /* warning / pending / danger-soft surfaces */
-  --color-card-warning: rgba(245, 168, 60, 0.14);
-  --color-white-pending: rgba(245, 168, 60, 0.14);
-  --color-danger-soft: rgba(234, 55, 41, 0.18);
-  /* overlays + shadows */
-  --color-overlay-backdrop: rgba(0, 0, 0, 0.62);
-  --color-shadow-soft: rgba(0, 0, 0, 0.4);
-  --color-shadow-xs: rgba(0, 0, 0, 0.28);
-  --color-shadow-sm: rgba(0, 0, 0, 0.5);
-  --color-shadow-md: rgba(0, 0, 0, 0.55);
-  /* chat surfaces */
-  --color-chat-surface: #221d17;
-  --color-chat-panel: #2a2216;
-  --color-chat-panel-border: #40362b;
-  --color-chat-divider: #3a3128;
-  --color-chat-divider-soft: #302820;
-  --color-chat-surface-soft: #262019;
-  --color-chat-empty-bg: #201c18;
-  /* calendar gridlines */
-  --color-calendar-line-strong: #4a4136;
-  --color-calendar-line-soft: #302820;
-  /* Calendar overlays: the light theme dims unavailable slots with a black wash
-     (rgba(0,0,0,0.045)) that is invisible on the dark surface. Re-declare the
-     three overlays as light/colour washes so unavailable, available, and preview
-     slots stay distinguishable in dark mode. */
-  --color-calendar-dim-overlay: rgba(255, 255, 255, 0.06);
-  --color-calendar-availability-overlay: rgba(74, 205, 155, 0.2);
-  --color-calendar-preview-overlay: rgba(103, 160, 239, 0.26);
-  /* active input border */
-  --color-input-border-active: #8fb6f5;
-  /* DS Badge status set — dark tint-on-dark equivalents */
-  --status-requested-bg: rgba(255, 255, 255, 0.07);
-  --status-requested-text: #b9b0a4;
-  --status-requested-border: rgba(255, 255, 255, 0.28);
-  --status-upcoming-bg: rgba(37, 123, 237, 0.18);
-  --status-upcoming-text: #9cc4f8;
-  --status-upcoming-border: rgba(103, 160, 239, 0.6);
-  --status-checked-in-bg: rgba(99, 102, 241, 0.18);
-  --status-checked-in-text: #bcbef9;
-  --status-checked-in-border: rgba(129, 132, 245, 0.6);
-  --status-in-progress-bg: rgba(139, 92, 246, 0.18);
-  --status-in-progress-text: #cdb8fa;
-  --status-in-progress-border: rgba(154, 113, 247, 0.6);
-  --status-completed-bg: rgba(74, 205, 155, 0.16);
-  --status-completed-text: #74d0a2;
-  --status-completed-border: rgba(74, 205, 155, 0.55);
-  --status-cancelled-bg: rgba(249, 115, 22, 0.15);
-  --status-cancelled-text: #f0a36c;
-  --status-cancelled-border: rgba(249, 115, 22, 0.5);
-  --status-no-show-bg: rgba(249, 115, 22, 0.15);
-  --status-no-show-text: #f0a36c;
-  --status-no-show-border: rgba(249, 115, 22, 0.5);
-  --status-danger-bg: rgba(234, 55, 41, 0.18);
-  --status-danger-text: #f2938a;
-  --status-danger-border: rgba(242, 147, 138, 0.42);
 }
 
 /* PIMS app surface — native control theming + post-paint flip transition.

--- a/apps/frontend/src/app/lib/paymentStatus.ts
+++ b/apps/frontend/src/app/lib/paymentStatus.ts
@@ -63,11 +63,18 @@ const hasStripePaymentEvidence = (invoice: Invoice) =>
     invoice.stripeReceiptUrl
   );
 
+// Metadata values are free-form. Only a primitive can carry a payment mode, so
+// anything else compares as '' rather than the useless '[object Object]'.
+const toComparableText = (value: unknown): string =>
+  typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean'
+    ? String(value).toLowerCase()
+    : '';
+
 const metadataSuggestsCash = (invoice: Invoice): boolean => {
   if (!invoice.metadata) return false;
   return Object.entries(invoice.metadata).some(([key, value]) => {
     const keyText = String(key || '').toLowerCase();
-    const valueText = String(value ?? '').toLowerCase();
+    const valueText = toComparableText(value);
     const keyIndicatesPayment =
       keyText.includes('payment') ||
       keyText.includes('tender') ||

--- a/apps/frontend/src/app/services/axios.ts
+++ b/apps/frontend/src/app/services/axios.ts
@@ -90,18 +90,33 @@ const inFlightGetRequests = new Map<string, Promise<AxiosResponse<unknown>>>();
 let unauthorizedSessionPromise: Promise<void> | null = null;
 
 const AUTH_REDIRECT_ERROR_NAME = 'AuthRedirectError';
+// Every route under (routes)/(public) that a signed-out visitor can land on. A
+// 401 from any request made while one of these is open must NOT bounce the
+// visitor to sign-in — they were never signed in, and the marketing shell fires
+// background requests (community stats, release info) from every page.
 const PUBLIC_PATHS = new Set([
   '/',
+  '/about',
   '/about-us',
   '/accessibility',
+  '/book-demo',
+  '/contact',
   '/contact-us',
+  '/dmca',
   '/forgot-password',
+  '/impressum',
+  '/insights',
+  '/overview',
   '/pet-businesses',
   '/pet-parents',
+  '/pms',
   '/pricing',
+  '/privacy-policy',
   '/reset-password',
   '/signin',
   '/signup',
+  '/terms-and-conditions',
+  '/trust-center',
   '/verify-email',
 ]);
 

--- a/apps/frontend/src/app/ui/filters/FormsFilters/index.tsx
+++ b/apps/frontend/src/app/ui/filters/FormsFilters/index.tsx
@@ -169,8 +169,8 @@ const FormsFilters = ({ filters, onFiltersChange, categoryAction }: FormsFilters
           createPortal(
             <div
               ref={panelRef}
-              role="listbox"
               aria-label="Category"
+              data-testid="category-menu"
               className="yc-glass-overlay rounded-2xl max-h-64 overflow-y-auto py-1"
               style={panelStyle}
             >
@@ -180,8 +180,7 @@ const FormsFilters = ({ filters, onFiltersChange, categoryAction }: FormsFilters
                   <button
                     key={opt.value}
                     type="button"
-                    role="option"
-                    aria-selected={isSelected}
+                    aria-pressed={isSelected}
                     data-testid={`option-${opt.value}`}
                     onClick={() => selectCategory(opt.value)}
                     className={clsx(

--- a/apps/frontend/src/app/ui/filters/FormsFilters/index.tsx
+++ b/apps/frontend/src/app/ui/filters/FormsFilters/index.tsx
@@ -152,7 +152,9 @@ const FormsFilters = ({ filters, onFiltersChange, categoryAction }: FormsFilters
           ref={triggerRef}
           type="button"
           onClick={() => setOpen((prev) => !prev)}
-          aria-haspopup="listbox"
+          // No aria-haspopup: the popup is a plain stack of buttons, not a
+          // listbox or a menu, and it implements no keyboard model. aria-expanded
+          // plus the label below already say what this control does.
           aria-expanded={open}
           aria-label={`Category: ${selectedCategoryLabel}`}
           className="inline-flex items-center gap-1.5 rounded-full! border border-[var(--hairline)] px-[13px] py-1.5 text-[12px] font-semibold text-[var(--ink-muted)] transition-colors hover:border-[var(--divider)]"
@@ -180,7 +182,11 @@ const FormsFilters = ({ filters, onFiltersChange, categoryAction }: FormsFilters
                   <button
                     key={opt.value}
                     type="button"
-                    aria-pressed={isSelected}
+                    // Single-select, so these are plain buttons per AGENTS.md, not
+                    // toggles: aria-pressed would expose eight independent
+                    // switches. aria-current marks the chosen one within the set
+                    // without claiming a listbox or menu widget.
+                    aria-current={isSelected ? 'true' : undefined}
                     data-testid={`option-${opt.value}`}
                     onClick={() => selectCategory(opt.value)}
                     className={clsx(

--- a/apps/frontend/src/app/ui/inputs/Dropdown/Dropdown.tsx
+++ b/apps/frontend/src/app/ui/inputs/Dropdown/Dropdown.tsx
@@ -162,7 +162,6 @@ const Dropdown = ({
       handleKeyDown={handleKeyDown}
       activeOptionId={activeOptionId}
       filteredList={filteredList}
-      list={list}
       setActiveIndex={setActiveIndex}
       selectOption={selectOption}
     />

--- a/apps/frontend/src/app/ui/inputs/Dropdown/DropdownPanel.tsx
+++ b/apps/frontend/src/app/ui/inputs/Dropdown/DropdownPanel.tsx
@@ -15,9 +15,6 @@ type DropdownPanelProps = {
   handleKeyDown: (event: React.KeyboardEvent) => void;
   activeOptionId: string | undefined;
   filteredList: DropdownOption[];
-  /** Unfiltered option list. Part of the caller contract; the design's menu has
-   *  no per-row dividers, so the panel itself only renders `filteredList`. */
-  list: DropdownOption[];
   setActiveIndex: (index: number) => void;
   selectOption: (option: DropdownOption) => void;
 };

--- a/apps/frontend/src/app/ui/tables/GenericTable/Generictable.css
+++ b/apps/frontend/src/app/ui/tables/GenericTable/Generictable.css
@@ -108,6 +108,9 @@
   font-size: 10px !important;
   font-weight: 700 !important;
   line-height: normal !important;
-  letter-spacing: 0.08em !important;
+  /* No !important on letter-spacing: WCAG 1.4.12 text spacing requires the user
+     to be able to widen tracking, and an !important here would block that. The
+     selector is specific enough to win without it. */
+  letter-spacing: 0.08em;
   opacity: 1 !important;
 }

--- a/apps/frontend/src/app/ui/tables/InvoiceTable.tsx
+++ b/apps/frontend/src/app/ui/tables/InvoiceTable.tsx
@@ -159,9 +159,10 @@ const InvoiceTable = ({ filteredList, setActiveInvoice, setViewInvoice }: Invoic
     // back in here alongside the time.
     const foldedDate =
       foldMeta && appointment ? formatDateLabel(appointment.appointmentDate) : undefined;
+    const foldedTypeName = foldMeta ? appointment?.appointmentType?.name : undefined;
     const appointmentSubtitle = appointment
       ? buildAppointmentSubtitle(
-          foldMeta ? appointment.appointmentType?.name : undefined,
+          foldedTypeName,
           formatTimeLabel(appointment.startTime ?? appointment.appointmentDate),
           foldedDate
         )

--- a/apps/frontend/src/app/ui/tables/appointmentsTableColumns.tsx
+++ b/apps/frontend/src/app/ui/tables/appointmentsTableColumns.tsx
@@ -154,7 +154,7 @@ export const buildAppointmentColumns = ({
           {roomDisplay.unitLabel && (
             <div className="appointment-profile-sub text-[12px]">{roomDisplay.unitLabel}</div>
           )}
-          <AppointmentModePill appointment={item} className="mt-1" iconSize={12} tone="strong" />
+          <AppointmentModePill appointment={item} className="mt-1" iconSize={12} />
         </div>
       );
     },


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

**Sonar.** The SonarCloud frontend project has 27 open issues (2 bugs, 25 code smells) and 0 hotspots, going back three months.

**Discord member count.** The live community number is blank on the website, including the Insights page, and it has been "fixed" twice in the last two days without holding. Verified against the deployed APIs, there are three independent causes:

1. `api.yosemitecrew.com/v1/marketing/discord-members` returns **404** - the backend marketing route is not deployed to production, so the live site has no data source at all. Dev works and returns `{"discordMembers":"196"}`.
2. The URL is built by concatenating onto `NEXT_PUBLIC_BASE_URL`, so it breaks whenever that value's trailing slash differs between environments. The slash was added in 673a79ca2 and removed again in d97db201b; exactly one of dev and prod can be right at a time.
3. The request goes through the authenticated axios client, which sets `withCredentials` and redirects to sign-in on a 401 - for public data, read from every marketing page. `/insights` and the legal pages are missing from that client's `PUBLIC_PATHS` allowlist, so a 401 there would bounce a signed-out visitor to the sign-in screen.

**Dependabot.** Every PR Dependabot opens carries a config error: it is told to apply an `automerge-candidate` label that does not exist in the repo (and that no workflow consumes), plus `github-actions` where the repo's label is `github_actions`. Separately, the three named groups have no `update-types` restriction while the catch-all does, so they silently swallow **majors** - which is how TypeScript 5 to 7 arrived inside "typescript-eslint" (#2025) and Jest 29 to 30 inside "testing" (#2065), each as one unreviewable group PR that breaks the build instead of the individual PR a breaking major needs.

## What is the new behavior?

### Sonar - all 27 issues fixed, 0 remaining

| Rule | Fix |
| --- | --- |
| S7727 x2 (Bug) | `specialityService` passed the store action straight to `forEach`, so it was called with `(value, index, array)`. Wrapped in an arrow. |
| S6772 x2 | Ambiguous text nodes wrapped in JSX expressions, per the repo's frontend-sonar convention. |
| S6767 x7 | Removed dead props and every call site: `Header.weekStart`, `DropdownPanel.list`, `AppointmentModePill.tone`, and `setCurrentDate` / `setWeekStart` on Day/User/WeekCalendar. All five were documented in code as "kept for the caller contract" but never read. |
| S3776 + S3358 x2 | `PermissionsEditor`'s toggle updater split into three pure helpers (`pickEnablePermissions`, `withViewEnabled`, `applyToggle`), which drops the cognitive complexity and removes both nested ternaries. |
| S3358 x2 | Hoisted the nested ternaries in `InvoiceTable` and the time-slot trigger border. |
| S6551 x3 | Guard to primitives instead of stringifying, so an object can no longer reach a template as `[object Object]`. |
| S6571 x2 | `FinanceEnvelope<unknown> \| unknown` collapses to `unknown`; named it honestly. |
| S6819 x3 | `NOSONAR` plus the design reason on the two pill groups, matching the existing `SegmentedPill` and `InvoiceStatusFilterPills` precedent (native `fieldset` defaults break the pill design). `FormsFilters` drops the `listbox` / `option` roles for the plain-button pattern every other dropdown here already uses. |
| S4666 | Folded the duplicate `html[data-theme='dark']` block into the first one. Declaration order is preserved and all 166 resolved token values were verified byte-identical before and after; every other dark rule in the file is more specific, so the cascade is unaffected. |
| S125 | Reworded a comment Sonar read as commented-out CSS. |
| S7925 | Dropped `!important` from `letter-spacing` so WCAG 1.4.12 tracking adjustment works. The selector is specific enough without it. |

Two `AppointmentModePill` tests were named for the "strong tone" but only ever asserted the default background - the prop did nothing - so they are retitled to what they actually check.

### Discord member count

The count is now served by a same-origin Next route handler, `GET /api/community/discord-members`, which does the Discord invite lookup server-side and caches it for 5 minutes. That removes all three causes at once: no cross-origin call, no CORS, no `NEXT_PUBLIC_BASE_URL` in the URL, no credentials, no session interceptor, and no dependency on the backend deploy. `connect-src 'self'` already allows it, and visitors' IPs no longer reach Discord. A failed lookup returns `200` with a null count and `Cache-Control: no-store`, so the caller keeps its loading placeholder rather than painting a stale or fabricated number.

Separately, every `(routes)/(public)` path was added to the axios `PUBLIC_PATHS` allowlist, so a background 401 on any public page can no longer redirect a signed-out visitor to sign-in.

The backend route is left in place for non-web consumers.

### Dependabot

- Dropped `automerge-candidate` (dead config) and corrected `github-actions` to `github_actions`, so Dependabot stops posting a config error on every PR.
- Gave `typescript-eslint`, `testing`, and `build-tooling` the same `update-types: [minor, patch]` restriction the catch-all already has. Breaking majors now get their own PR and their own review, as the file's own comment always intended.

### Validation

- `npx tsc --noEmit` in `apps/frontend`: clean.
- `pnpm --filter frontend run lint`: clean.
- Targeted tests over every touched file: 88 suites, 1439 tests, all passing.
- New route handler: 100% statements, branches, functions and lines. Every other touched file is at or above the coverage it had.
- Discord fix verified end to end against a local dev server: the route returns `{"discordMembers":"196"}` with the expected cache headers, and the Insights page renders `196 DISCORD MEMBERS` live.
- Pre-push hook (full monorepo lint + type-check) passed.

## Related Issue(s)

Fixes #
