### PR TITLE
fix(frontend): migrate to eslint-plugin-react-hooks 7 and pin it out of the hoist lottery

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,16 @@ updates:
     # scope, so those PRs would fail pr-governance. 'repo' is the catch-all scope.
     commit-message:
       prefix: 'chore(repo)'
+    ignore:
+      # react-doctor gates CI (the React Doctor score check) and is still 0.x,
+      # where semver calls every new feature release a "minor" - so it slips
+      # into the minor-and-patch group and upgrades ITSELF inside a 90-package
+      # batch, bringing new rules that fail the very PR carrying it (0.2.14 ->
+      # 0.9.5 added low-supply-chain-score, which fired on this repo's own
+      # override pins). Patches still flow; feature releases of a CI-gating
+      # tool are deliberate, reviewed upgrades.
+      - dependency-name: 'react-doctor'
+        update-types: ['version-update:semver-minor', 'version-update:semver-major']
     groups:
       # Every group is minor-and-patch only, including the named ones below. A
       # named group without `update-types` silently swallows MAJORS too, which is

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -96,6 +96,7 @@
     "tailwindcss": "^4.1.17",
     "ts-jest": "^29.4.4",
     "ts-node": "^10.9.2",
-    "typescript": "^5"
+    "typescript": "^5",
+    "eslint-plugin-react-hooks": "^7.1.1"
   }
 }

--- a/apps/frontend/src/app/(routes)/(public)/payment-status/PaymentStatusContent.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/payment-status/PaymentStatusContent.tsx
@@ -41,23 +41,26 @@ export function PaymentStatusContent() {
   const [state, setState] = useState<PaymentStatusState>({
     data: null,
     requestState: session_id ? 'loading' : 'missing_session',
-    stopped: false,
+    stopped: !session_id,
   });
   const stopPollingRef = useRef(false);
 
-  useEffect(() => {
+  // Render-phase adjustment: restart from a clean slate when the session id changes.
+  const [prevSessionId, setPrevSessionId] = useState(session_id);
+  if (prevSessionId !== session_id) {
+    setPrevSessionId(session_id);
     setState({
       data: null,
       requestState: session_id ? 'loading' : 'missing_session',
       stopped: !session_id,
     });
-    stopPollingRef.current = false;
-  }, [session_id]);
+  }
 
   useEffect(() => {
     if (!session_id) {
       return;
     }
+    stopPollingRef.current = false;
 
     const safeSessionId = session_id;
     let alive = true;

--- a/apps/frontend/src/app/__tests__/features/marketing/site/motion.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/marketing/site/motion.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { renderToString } from 'react-dom/server';
 import { render, screen, act, renderHook, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import {
@@ -157,6 +158,11 @@ describe('motion primitives', () => {
       fireEvent.scroll(globalThis.window);
     });
     expect(result.current).toBe(true);
+  });
+
+  it('useScrolled server-renders false so hydration matches the server HTML', () => {
+    const Probe = () => <span>{String(useScrolled(8))}</span>;
+    expect(renderToString(<Probe />)).toContain('false');
   });
 
   it('useMagnet, Tilt and Spotlight wire cursor handlers under rich motion', () => {

--- a/apps/frontend/src/app/__tests__/features/marketing/site/useGithubStats.test.ts
+++ b/apps/frontend/src/app/__tests__/features/marketing/site/useGithubStats.test.ts
@@ -1,9 +1,13 @@
+import { createElement } from 'react';
+import { renderToString } from 'react-dom/server';
 import { renderHook, waitFor } from '@testing-library/react';
 import {
   useGithubStats,
   useLatestRelease,
   useMobileRelease,
   usePlatformRelease,
+  type GithubStats,
+  type ReleaseInfo,
 } from '@/app/features/marketing/site/useGithubStats';
 
 type FetchLike = typeof fetch;
@@ -85,6 +89,36 @@ describe('useGithubStats hooks', () => {
     expect(fetchMock).not.toHaveBeenCalled();
     expect(result.current.stars).toBe('9k');
     expect(result.current.contributors).toBe('60');
+  });
+
+  it('server-renders the loading placeholders even when the session cache is seeded', () => {
+    sessionStorage.setItem('yc_marketing_stats_v1', JSON.stringify({ stars: '9k' }));
+    sessionStorage.setItem(
+      'yc_rel_platform_v1',
+      JSON.stringify({ tag: 'v9.9.9', date: 'Jan 1, 2026', url: 'https://x/cached' })
+    );
+    let stats: GithubStats | null = null;
+    let release: ReleaseInfo | null = null;
+    let mobile: ReleaseInfo | null = null;
+    const Probe = () => {
+      stats = useGithubStats();
+      release = useLatestRelease();
+      mobile = useMobileRelease();
+      return null;
+    };
+    renderToString(createElement(Probe));
+    expect(stats!.stars).toBeNull();
+    expect(release!.tag).toBeNull();
+    expect(mobile!.tag).toBeNull();
+  });
+
+  it('treats a corrupt session cache entry as the empty placeholders', async () => {
+    sessionStorage.setItem('yc_marketing_stats_v1', '{not json');
+    globalThis.fetch = jest.fn(() => Promise.resolve(notOk())) as unknown as FetchLike;
+    const { result } = renderHook(() => useGithubStats());
+    expect(result.current.stars).toBeNull();
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+    expect(result.current.stars).toBeNull();
   });
 
   it('refetches when the session cache is fresh but discord is still missing', async () => {

--- a/apps/frontend/src/app/__tests__/features/marketing/site/useTheme.test.ts
+++ b/apps/frontend/src/app/__tests__/features/marketing/site/useTheme.test.ts
@@ -1,3 +1,5 @@
+import { createElement } from 'react';
+import { renderToString } from 'react-dom/server';
 import { renderHook, act } from '@testing-library/react';
 import { useTheme } from '@/app/features/marketing/site/useTheme';
 
@@ -35,6 +37,17 @@ describe('useTheme', () => {
     expect(result.current.theme).toBe('light');
   });
 
+  it('server-renders the light default so hydration matches the server HTML', () => {
+    document.documentElement.setAttribute('data-theme', 'dark');
+    let ssrTheme: string | null = null;
+    const Probe = () => {
+      ssrTheme = useTheme().theme;
+      return null;
+    };
+    renderToString(createElement(Probe));
+    expect(ssrTheme).toBe('light');
+  });
+
   it('toggle flips the theme, persists it, and dispatches yc-theme-change', () => {
     document.documentElement.setAttribute('data-theme', 'light');
     const seen: string[] = [];
@@ -58,6 +71,8 @@ describe('useTheme', () => {
     document.documentElement.setAttribute('data-theme', 'light');
     const { result } = renderHook(() => useTheme());
     act(() => {
+      // Another instance's applyTheme sets the html attribute, then broadcasts.
+      document.documentElement.setAttribute('data-theme', 'dark');
       globalThis.dispatchEvent(new CustomEvent('yc-theme-change', { detail: { theme: 'dark' } }));
     });
     expect(result.current.theme).toBe('dark');

--- a/apps/frontend/src/app/__tests__/ui/theme/useTheme.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/theme/useTheme.test.ts
@@ -58,6 +58,8 @@ describe('useTheme', () => {
     document.documentElement.setAttribute('data-theme', 'light');
     const { result } = renderHook(() => useTheme());
     act(() => {
+      // Another instance's applyTheme sets the html attribute, then broadcasts.
+      document.documentElement.setAttribute('data-theme', 'dark');
       globalThis.dispatchEvent(new CustomEvent('yc-theme-change', { detail: { theme: 'dark' } }));
     });
     expect(result.current.theme).toBe('dark');
@@ -202,7 +204,11 @@ describe('useTheme', () => {
     document.documentElement.setAttribute('data-theme', 'dark');
     mockMatchMedia(false);
     const { result } = renderHook(() => useTheme());
-    const spy = jest.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+    // Private mode blocks the whole Storage API — writes and reads alike.
+    const removeSpy = jest.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+      throw new Error('blocked');
+    });
+    const getSpy = jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
       throw new Error('blocked');
     });
 
@@ -210,7 +216,8 @@ describe('useTheme', () => {
 
     expect(document.documentElement.getAttribute('data-theme')).toBe('light');
     expect(result.current.appearance).toBe('auto');
-    spy.mockRestore();
+    removeSpy.mockRestore();
+    getSpy.mockRestore();
   });
 
   it('reports auto appearance when reading the stored choice throws', () => {

--- a/apps/frontend/src/app/features/appointments/components/AppointmentBoard.tsx
+++ b/apps/frontend/src/app/features/appointments/components/AppointmentBoard.tsx
@@ -393,7 +393,9 @@ const AppointmentBoardComponent = ({
   );
 
   const handleDroppedAppointmentStatusRef = useRef(handleDroppedAppointmentStatus);
-  handleDroppedAppointmentStatusRef.current = handleDroppedAppointmentStatus;
+  useEffect(() => {
+    handleDroppedAppointmentStatusRef.current = handleDroppedAppointmentStatus;
+  });
 
   useBoardDropTargets({
     boardRootRef,

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/DayCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/DayCalendar.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useScrollBoundaryWheel } from '@/app/hooks/useScrollBoundaryWheel';
 import { HOURS_IN_DAY } from '@/app/features/appointments/components/Calendar/weekHelpers';
 import { Task } from '@/app/features/tasks/types/task';
@@ -71,7 +71,7 @@ const DayCalendar = ({
   slotStepMinutes = 15,
   resolveDisplayName,
 }: DayCalendarProps) => {
-  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [scrollContainer, setScrollContainer] = useState<HTMLDivElement | null>(null);
   const onWheelBoundary = useScrollBoundaryWheel();
   const { handleNextDay, handlePrevDay } = useCalendarNavigation(setCurrentDate);
   const { weekday, dateNumber } = getDateDisplay(date);
@@ -105,7 +105,7 @@ const DayCalendar = ({
     events: getTimedTaskProxyEvents(events),
     height,
     nowPosition,
-    scrollContainer: scrollRef.current,
+    scrollContainer,
     hourRowGapPx: HOUR_ROW_GAP_PX,
     hourRowTopOffsetPx: HOUR_ROW_TOP_OFFSET_PX,
   });
@@ -124,7 +124,7 @@ const DayCalendar = ({
       </div>
 
       <div
-        ref={scrollRef}
+        ref={setScrollContainer}
         className="overflow-x-hidden flex-1 px-2"
         style={{
           height: '100%',

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/UserCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/UserCalendar.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useScrollBoundaryWheel } from '@/app/hooks/useScrollBoundaryWheel';
 import { useWheelToHorizontalScroll } from '@/app/hooks/useWheelToHorizontalScroll';
 import { HOURS_IN_DAY } from '@/app/features/appointments/components/Calendar/weekHelpers';
@@ -84,7 +84,7 @@ const UserCalendar: React.FC<UserCalendarProps> = ({
   const { handleNextDay, handlePrevDay } = useCalendarNavigation(setCurrentDate);
   const height = getHourRowHeightPx(zoomMode);
   const HOUR_ROW_TOP_OFFSET_PX = 8;
-  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [scrollContainer, setScrollContainer] = useState<HTMLDivElement | null>(null);
   const onWheelBoundary = useScrollBoundaryWheel();
   const onWheelHorizontal = useWheelToHorizontalScroll();
   const teamColumnsStyle = useMemo(
@@ -164,7 +164,7 @@ const UserCalendar: React.FC<UserCalendarProps> = ({
     events: getTimedTaskProxyEvents(events),
     height,
     nowPosition,
-    scrollContainer: scrollRef.current,
+    scrollContainer,
     hourRowGapPx: HOUR_ROW_GAP_PX,
     hourRowTopOffsetPx: HOUR_ROW_TOP_OFFSET_PX,
   });
@@ -187,7 +187,7 @@ const UserCalendar: React.FC<UserCalendarProps> = ({
           />
 
           <div
-            ref={scrollRef}
+            ref={setScrollContainer}
             className="relative flex-1 min-h-0"
             style={{
               height: '100%',

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/WeekCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/WeekCalendar.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useScrollBoundaryWheel } from '@/app/hooks/useScrollBoundaryWheel';
 import { useWheelToHorizontalScroll } from '@/app/hooks/useWheelToHorizontalScroll';
 import {
@@ -87,7 +87,7 @@ const WeekCalendar: React.FC<WeekCalendarProps> = ({
   resolveDisplayName,
 }) => {
   const days = useMemo<Date[]>(() => getWeekDays(weekStart), [weekStart]);
-  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [scrollContainer, setScrollContainer] = useState<HTMLDivElement | null>(null);
   const onWheelBoundary = useScrollBoundaryWheel();
   const onWheelHorizontal = useWheelToHorizontalScroll();
   const now = useCalendarNow();
@@ -142,7 +142,7 @@ const WeekCalendar: React.FC<WeekCalendarProps> = ({
     events: getTimedTaskProxyEvents(events),
     height,
     nowPosition,
-    scrollContainer: scrollRef.current,
+    scrollContainer,
     skip: !!draggedTaskId || !days.length,
     rangeStart: days[0],
     rangeEnd: days.at(-1)
@@ -184,7 +184,7 @@ const WeekCalendar: React.FC<WeekCalendarProps> = ({
           </div>
 
           <div
-            ref={scrollRef}
+            ref={setScrollContainer}
             className="min-w-max flex-1 min-h-0"
             style={{
               height: '100%',

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/DayCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/DayCalendar.tsx
@@ -1,12 +1,4 @@
-import React, {
-  useCallback,
-  useEffect,
-  useId,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { useScrollBoundaryWheel } from '@/app/hooks/useScrollBoundaryWheel';
 import { usePopoverManager } from '@/app/hooks/usePopoverManager';
 import { calcNearestAvailableMinute } from '@/app/features/appointments/components/Calendar/calendarDrop';
@@ -554,7 +546,9 @@ const DayCalendarComponent: React.FC<DayCalendarProps> = ({
   // Keep a ref to the latest focus position so the scroll effect can read it
   // without depending on it — prevents re-scroll on every availability update.
   const getFocusTopPxRef = useRef(getFocusTopPx);
-  getFocusTopPxRef.current = getFocusTopPx;
+  useEffect(() => {
+    getFocusTopPxRef.current = getFocusTopPx;
+  });
 
   useEffect(() => {
     if (!scrollRef.current || skipAutoScroll) return;
@@ -599,12 +593,15 @@ const DayCalendarComponent: React.FC<DayCalendarProps> = ({
 
   const popoverStyle = getPopoverStyle(440, 490);
 
-  useLayoutEffect(() => {
-    if (!draggedAppointmentId) return;
-    setActivePopoverKey(null);
-    setDropPreviewMinute(null);
-    setContextMenu(null);
-  }, [draggedAppointmentId, setActivePopoverKey, setContextMenu]);
+  const [prevDraggedAppointmentId, setPrevDraggedAppointmentId] = useState(draggedAppointmentId);
+  if (prevDraggedAppointmentId !== draggedAppointmentId) {
+    setPrevDraggedAppointmentId(draggedAppointmentId);
+    if (draggedAppointmentId) {
+      setActivePopoverKey(null);
+      setDropPreviewMinute(null);
+      setContextMenu(null);
+    }
+  }
 
   const availabilityIntervals = getDropAvailabilityIntervals?.(date) ?? [];
 

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/Header.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/Header.tsx
@@ -135,16 +135,16 @@ const StatusFilterDropdown = ({
   setActiveStatus?: (v: string) => void;
   isMounted: boolean;
 }) => {
-  const dropdown = useAnchoredDropdown(180);
+  const { open, setOpen, style, triggerRef, panelRef } = useAnchoredDropdown(180);
   const selectedStatus = statusOptions.find((s) => s.key === activeStatus) ?? statusOptions[0];
   const isDefault = !selectedStatus || selectedStatus.key === 'all';
 
   return (
     <>
       <button
-        ref={dropdown.triggerRef}
+        ref={triggerRef}
         type="button"
-        onClick={() => dropdown.setOpen((v) => !v)}
+        onClick={() => setOpen((v) => !v)}
         className="flex shrink-0 items-center gap-1.5 rounded-full! transition-colors whitespace-nowrap focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-brand"
         style={
           isDefault
@@ -169,7 +169,7 @@ const StatusFilterDropdown = ({
                 {selectedStatus.name}
                 <IoChevronDown
                   size={12}
-                  className={clsx('shrink-0 transition-transform', dropdown.open && 'rotate-180')}
+                  className={clsx('shrink-0 transition-transform', open && 'rotate-180')}
                 />
               </>
             }
@@ -178,18 +178,18 @@ const StatusFilterDropdown = ({
         {isDefault && (
           <IoChevronDown
             size={12}
-            className={clsx('shrink-0 transition-transform', dropdown.open && 'rotate-180')}
+            className={clsx('shrink-0 transition-transform', open && 'rotate-180')}
           />
         )}
       </button>
 
       {isMounted &&
-        dropdown.open &&
+        open &&
         createPortal(
           <div
-            ref={dropdown.panelRef}
+            ref={panelRef}
             className="rounded-2xl border border-card-border bg-neutral-0 shadow-[0_8px_24px_var(--color-shadow-soft)] overflow-hidden"
-            style={dropdown.style}
+            style={style}
           >
             {statusOptions.map((status) => {
               const isActive = status.key === activeStatus;
@@ -199,7 +199,7 @@ const StatusFilterDropdown = ({
                   type="button"
                   onClick={() => {
                     setActiveStatus?.(status.key);
-                    dropdown.setOpen(false);
+                    setOpen(false);
                   }}
                   className={clsx(
                     'w-full flex items-center gap-2.5 px-3 py-2 text-[13px] text-left transition-colors',

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/Slot.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/Slot.tsx
@@ -1,4 +1,4 @@
-import React, { useId, useLayoutEffect, useMemo, useState } from 'react';
+import React, { useId, useMemo, useState } from 'react';
 import { usePopoverManager } from '@/app/hooks/usePopoverManager';
 import { Appointment, Invoice } from '@yosemite-crew/types';
 import { AppointmentViewIntent } from '@/app/features/appointments/types/calendar';
@@ -273,12 +273,17 @@ const SlotComponent: React.FC<SlotProps> = ({
 
   const popoverStyle = getPopoverStyle(440, 490);
 
-  useLayoutEffect(() => {
-    if (!draggedAppointmentId) return;
-    setActivePopoverKey(null);
-    setDropPreviewMinute(null);
-    setContextMenu(null);
-  }, [draggedAppointmentId, setActivePopoverKey, setContextMenu]);
+  // Dismiss the popover, drop preview, and context menu the moment a drag starts —
+  // adjusted during render via a prev-compare rather than an effect.
+  const [prevDraggedAppointmentId, setPrevDraggedAppointmentId] = useState(draggedAppointmentId);
+  if (draggedAppointmentId !== prevDraggedAppointmentId) {
+    setPrevDraggedAppointmentId(draggedAppointmentId);
+    if (draggedAppointmentId) {
+      setActivePopoverKey(null);
+      setDropPreviewMinute(null);
+      setContextMenu(null);
+    }
+  }
 
   const getMinuteFromSlotPointer = (clientY: number, container: HTMLDivElement) =>
     minuteFromSlotPointer(clientY, container, dropHour);

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/UserCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/UserCalendar.tsx
@@ -186,11 +186,13 @@ const UserCalendar: React.FC<UserCalendarProps> = ({
   const dateKey = date.toISOString();
 
   const nowPositionRef = useRef(nowPosition);
-  nowPositionRef.current = nowPosition;
   const eventsRef = useRef(events);
-  eventsRef.current = events;
   const visibleHourRangeRef = useRef(visibleHourRange);
-  visibleHourRangeRef.current = visibleHourRange;
+  useEffect(() => {
+    nowPositionRef.current = nowPosition;
+    eventsRef.current = events;
+    visibleHourRangeRef.current = visibleHourRange;
+  });
 
   useEffect(() => {
     const container = scrollRef.current;

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/WeekCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/WeekCalendar.tsx
@@ -94,11 +94,13 @@ const useWeekAutoScroll = ({
 }) => {
   const scrolledWeekRef = useRef<string | null>(null);
   const nowPositionRef = useRef(nowPosition);
-  nowPositionRef.current = nowPosition;
   const timedEventsRef = useRef(timedEvents);
-  timedEventsRef.current = timedEvents;
   const visibleHourRangeRef = useRef(visibleHourRange);
-  visibleHourRangeRef.current = visibleHourRange;
+  useEffect(() => {
+    nowPositionRef.current = nowPosition;
+    timedEventsRef.current = timedEvents;
+    visibleHourRangeRef.current = visibleHourRange;
+  });
 
   useEffect(() => {
     const container = scrollRef.current;

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/ZoomOutEventList.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/ZoomOutEventList.tsx
@@ -26,6 +26,35 @@ type ZoomOutEventListProps = {
   onDropPreviewClear: () => void;
 };
 
+/** Stack events top-to-bottom, spacing each by its gap from the running cursor. */
+const layoutZoomOutEvents = (
+  sortedSlotEvents: Appointment[],
+  height: number
+): Array<{ ev: Appointment; itemKey: string; marginTopPx: number; blockHeightPx: number }> => {
+  const laidOut: Array<{
+    ev: Appointment;
+    itemKey: string;
+    marginTopPx: number;
+    blockHeightPx: number;
+  }> = [];
+  let cursorMinute = 0;
+  for (const ev of sortedSlotEvents) {
+    const itemKey = getSlotEventKey(ev);
+    const startMinute = getDatePartsInPreferredTimeZone(ev.startTime).minute;
+    const rawDurationMinutes = Math.max(
+      5,
+      Math.round((ev.endTime.getTime() - ev.startTime.getTime()) / 60000)
+    );
+    const visibleDurationMinutes = Math.max(10, Math.min(rawDurationMinutes, 60 - startMinute));
+    const gapMinutes = Math.max(0, startMinute - cursorMinute);
+    const marginTopPx = (gapMinutes / 60) * height;
+    const blockHeightPx = Math.max((visibleDurationMinutes / 60) * height, 3);
+    cursorMinute = Math.max(cursorMinute, startMinute + visibleDurationMinutes);
+    laidOut.push({ ev, itemKey, marginTopPx, blockHeightPx });
+  }
+  return laidOut;
+};
+
 const ZoomOutEventList = ({
   sortedSlotEvents,
   height,
@@ -40,22 +69,10 @@ const ZoomOutEventList = ({
   onAppointmentDragEnd,
   onDropPreviewClear,
 }: ZoomOutEventListProps) => {
-  let cursorMinute = 0;
   return (
     <div className="flex flex-col px-1 py-0 h-full bg-transparent overflow-visible">
-      {sortedSlotEvents.map((ev) => {
-        const itemKey = getSlotEventKey(ev);
-        const startMinute = getDatePartsInPreferredTimeZone(ev.startTime).minute;
-        const rawDurationMinutes = Math.max(
-          5,
-          Math.round((ev.endTime.getTime() - ev.startTime.getTime()) / 60000)
-        );
-        const visibleDurationMinutes = Math.max(10, Math.min(rawDurationMinutes, 60 - startMinute));
-        const gapMinutes = Math.max(0, startMinute - cursorMinute);
-        const marginTopPx = (gapMinutes / 60) * height;
-        const blockHeightPx = Math.max((visibleDurationMinutes / 60) * height, 3);
-        cursorMinute = Math.max(cursorMinute, startMinute + visibleDurationMinutes);
-        return (
+      {layoutZoomOutEvents(sortedSlotEvents, height).map(
+        ({ ev, itemKey, marginTopPx, blockHeightPx }) => (
           <ZoomOutMarker
             key={itemKey}
             ev={ev}
@@ -73,8 +90,8 @@ const ZoomOutEventList = ({
             onAppointmentDragEnd={onAppointmentDragEnd}
             onDropPreviewClear={onDropPreviewClear}
           />
-        );
-      })}
+        )
+      )}
     </div>
   );
 };

--- a/apps/frontend/src/app/features/appointments/components/Calendar/useAppointmentDragAvailability.ts
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/useAppointmentDragAvailability.ts
@@ -80,8 +80,6 @@ const useDragAvailabilityInputs = ({
     return slots;
   }, []);
 
-  const buildStartFromCalendarMinutes = useCallback(buildAppointmentStartFromCalendarMinutes, []);
-
   const getAvailabilityKey = useCallback(
     (date: Date, targetLeadId?: string) =>
       buildAvailabilityKey({
@@ -99,7 +97,7 @@ const useDragAvailabilityInputs = ({
     (date: Date, targetLeadId?: string) =>
       computeAvailableStartMinutes({
         allAppointments,
-        buildStart: buildStartFromCalendarMinutes,
+        buildStart: buildAppointmentStartFromCalendarMinutes,
         date,
         dragContext: dragContextRef.current,
         getSlots: getSlotsForMoveValidation,
@@ -111,7 +109,6 @@ const useDragAvailabilityInputs = ({
       }),
     [
       allAppointments,
-      buildStartFromCalendarMinutes,
       dragContextRef,
       getSlotsForMoveValidation,
       normalizeId,
@@ -121,7 +118,7 @@ const useDragAvailabilityInputs = ({
   );
 
   return {
-    buildAppointmentStartFromCalendarMinutes: buildStartFromCalendarMinutes,
+    buildAppointmentStartFromCalendarMinutes,
     buildAvailableStartMinutes,
     getAvailabilityKey,
     getCurrentUserPractitionerId,

--- a/apps/frontend/src/app/features/appointments/components/Calendar/useCalendarSlots.ts
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/useCalendarSlots.ts
@@ -209,7 +209,9 @@ export function useCalendarAutoScroll({
   // Capture nowPosition in a ref so changes to it (every minute) don't re-fire
   // the scroll effect — we only want to scroll once on mount / date change.
   const nowPositionRef = useRef(nowPosition);
-  nowPositionRef.current = nowPosition;
+  useEffect(() => {
+    nowPositionRef.current = nowPosition;
+  });
 
   useEffect(() => {
     if (!scrollContainer || skip) return;

--- a/apps/frontend/src/app/features/appointments/components/Calendar/useTaskCalendarIdentity.ts
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/useTaskCalendarIdentity.ts
@@ -21,8 +21,6 @@ export const useTaskCalendarIdentity = (
   const { resolveMemberName } = useMemberMap();
   const normalizeId = useCallback((value?: string) => normalizeCalendarId(value), []);
 
-  const shiftDayKey = useCallback(shiftWeekdayKey, []);
-
   const resolveAssigneeId = useCallback(
     (candidateId?: string) => resolveTeamMemberPrimaryId(teams, candidateId, normalizeId),
     [normalizeId, teams]
@@ -54,7 +52,7 @@ export const useTaskCalendarIdentity = (
     canEditTask,
     resolveAssigneeId,
     resolveDisplayName,
-    shiftDayKey,
+    shiftDayKey: shiftWeekdayKey,
     shouldEnforceAvailability,
   };
 };

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/SearchResultsDropdown.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/SearchResultsDropdown.tsx
@@ -38,7 +38,9 @@ const SearchResultsDropdown = ({
 }: SearchResultsDropdownProps) => {
   const panelRef = useRef<HTMLDivElement>(null);
   const onCloseRef = useRef(onClose);
-  onCloseRef.current = onClose;
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  });
   const positionSnapshot = useSyncExternalStore(
     subscribeToWindowMetrics,
     () => {

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/VisitTimer.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/VisitTimer.tsx
@@ -33,29 +33,15 @@ const toMs = (value?: string | Date): number | undefined => {
   return Number.isNaN(ms) ? undefined : ms;
 };
 
-/**
- * "In room HH:MM:SS" visit timer pill for the workspace header. Counts up once per
- * second from the best-available start. Three states, per the design's micro-states:
- * resting ("Not started"), running (green pulse dot), and over-booked (amber, past
- * the booked slot). Purely informational — it never gates any action.
- */
-const VisitTimer = ({
-  startAt,
-  bookedEndAt,
-  className = '',
-  variant = 'default',
-}: VisitTimerProps) => {
-  const isPhone = variant === 'phone';
-  const startMs = toMs(startAt);
-  const [nowMs, setNowMs] = useState(() => Date.now());
+type VisitTimerInnerProps = {
+  startMs?: number;
+  bookedEndAt?: string | Date;
+  className: string;
+  isPhone: boolean;
+};
 
-  // Re-sync immediately when the start changes, at render time rather than in an
-  // effect, so the displayed elapsed value never lags a frame behind the prop.
-  const [prevStartMs, setPrevStartMs] = useState(startMs);
-  if (startMs !== prevStartMs) {
-    setPrevStartMs(startMs);
-    setNowMs(Date.now());
-  }
+const VisitTimerInner = ({ startMs, bookedEndAt, className, isPhone }: VisitTimerInnerProps) => {
+  const [nowMs, setNowMs] = useState(() => Date.now());
 
   useEffect(() => {
     if (startMs === undefined) return;
@@ -143,6 +129,33 @@ const VisitTimer = ({
       />
       In room {elapsed}
     </span>
+  );
+};
+
+/**
+ * "In room HH:MM:SS" visit timer pill for the workspace header. Counts up once per
+ * second from the best-available start. Three states, per the design's micro-states:
+ * resting ("Not started"), running (green pulse dot), and over-booked (amber, past
+ * the booked slot). Purely informational — it never gates any action.
+ */
+const VisitTimer = ({
+  startAt,
+  bookedEndAt,
+  className = '',
+  variant = 'default',
+}: VisitTimerProps) => {
+  const startMs = toMs(startAt);
+  // Re-seed immediately when the start changes: the key remounts the inner timer,
+  // whose `nowMs` initializer reads the clock on its first render, so the displayed
+  // elapsed value never lags a frame behind the prop.
+  return (
+    <VisitTimerInner
+      key={startMs ?? 'unset'}
+      startMs={startMs}
+      bookedEndAt={bookedEndAt}
+      className={className}
+      isPhone={variant === 'phone'}
+    />
   );
 };
 

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/index.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/index.tsx
@@ -397,7 +397,12 @@ const useAppointmentWorkspaceContent = ({ appointment }: AppointmentWorkspacePro
   );
   const [dischargeOverrideReason, setDischargeOverrideReason] = useState('');
   const lifecycleEncounterIdRef = useRef<string | undefined>(appointment.encounterId);
-  const initializedEncounterKeyRef = useRef<string | null>(null);
+  // Render-readable mirror of lifecycleEncounterIdRef (refs must not be read during
+  // render); every write site updates both so they never diverge.
+  const [resolvedEncounterId, setResolvedEncounterId] = useState<string | undefined>(
+    appointment.encounterId
+  );
+  const [initializedEncounterKey, setInitializedEncounterKey] = useState<string | null>(null);
   const supportStaffMember = useMemo(() => {
     const leadName = (appointment.lead?.name ?? '').trim();
     return (appointment.supportStaff ?? []).find(
@@ -416,9 +421,9 @@ const useAppointmentWorkspaceContent = ({ appointment }: AppointmentWorkspacePro
         supportStaffMember?.name ?? '',
       ].join('|')
     : '';
-  if (appointmentId && initializedEncounterKeyRef.current !== encounterInitKey) {
-    initializedEncounterKeyRef.current = encounterInitKey;
-    lifecycleEncounterIdRef.current = appointment.encounterId;
+  if (appointmentId && initializedEncounterKey !== encounterInitKey) {
+    setInitializedEncounterKey(encounterInitKey);
+    setResolvedEncounterId(appointment.encounterId);
     const leadName = (appointment.lead?.name ?? '').trim();
     initEncounter(appointmentId, initialMode, {
       leadId: appointment.lead?.id,
@@ -427,6 +432,12 @@ const useAppointmentWorkspaceContent = ({ appointment }: AppointmentWorkspacePro
       nurseName: supportStaffMember?.name?.trim(),
     });
   }
+
+  // Ref half of the reset above — refs cannot be written during render, so the
+  // lifecycle id ref re-seeds in an effect keyed on the same init key.
+  useEffect(() => {
+    lifecycleEncounterIdRef.current = appointment.encounterId;
+  }, [appointment.encounterId, encounterInitKey]);
 
   useEffect(() => {
     const organisationId = appointment.organisationId;
@@ -488,6 +499,7 @@ const useAppointmentWorkspaceContent = ({ appointment }: AppointmentWorkspacePro
           lifecycleEncounterIdRef.current =
             getWorkspaceBootstrapEncounterId(aggregateResult.value) ??
             lifecycleEncounterIdRef.current;
+          setResolvedEncounterId(lifecycleEncounterIdRef.current);
         }
         mergeEncounterData(appointmentId, {
           ...(aggregateResult.status === 'fulfilled'
@@ -530,15 +542,18 @@ const useAppointmentWorkspaceContent = ({ appointment }: AppointmentWorkspacePro
   const encounterMode = encounter?.mode ?? initialMode;
   const lockWindow = useAppointmentLockWindow();
 
+  // Sampled once on mount (render must stay pure, so no Date.now() in the memo);
+  // the lock windows are hours-scale, so a session-age drift is immaterial.
+  const [lockCheckedAt] = useState(() => Date.now());
   const lockedByWindow = useMemo(
     () =>
       isPastLockWindow(
         appointment.startTime,
         encounterMode,
-        Date.now(),
+        lockCheckedAt,
         resolveLockHours(encounterMode, lockWindow)
       ),
-    [appointment.startTime, encounterMode, lockWindow]
+    [appointment.startTime, encounterMode, lockCheckedAt, lockWindow]
   );
 
   // Ready-for-billing is a monotonic milestone: once any invoice for this visit is
@@ -611,6 +626,15 @@ const useAppointmentWorkspaceContent = ({ appointment }: AppointmentWorkspacePro
         : undefined,
     [encounter, lockedByWindow]
   );
+  // Narrow fields pulled off effectiveEncounter so the memos/callbacks below
+  // depend on exactly the values they read (mixing `?.` and plain accesses makes
+  // the compiler infer the whole object as the dependency).
+  const encounterRoomId = effectiveEncounter?.roomId;
+  const encounterUnitId = effectiveEncounter?.unitId;
+  const encounterLeadId = effectiveEncounter?.leadId;
+  const encounterLeadName = effectiveEncounter?.leadName;
+  const encounterNurseId = effectiveEncounter?.nurseId;
+  const encounterNurseName = effectiveEncounter?.nurseName;
   const persistedPatientAlerts = useMemo(
     () => storedAlertsToCompanionAlerts(companionRecord?.alerts, 'patient-alert'),
     [companionRecord?.alerts]
@@ -668,15 +692,13 @@ const useAppointmentWorkspaceContent = ({ appointment }: AppointmentWorkspacePro
       return toAssignableRoomOptions(
         rooms,
         roomIndexes,
-        effectiveEncounter?.roomId,
-        effectiveEncounter?.unitId,
+        encounterRoomId,
+        encounterUnitId,
         encounterMode === 'INPATIENT'
       );
     }
-    return effectiveEncounter?.roomId
-      ? [{ label: 'Room 1', value: effectiveEncounter.roomId }]
-      : [];
-  }, [effectiveEncounter?.roomId, effectiveEncounter?.unitId, encounterMode, roomIndexes, rooms]);
+    return encounterRoomId ? [{ label: 'Room 1', value: encounterRoomId }] : [];
+  }, [encounterRoomId, encounterUnitId, encounterMode, roomIndexes, rooms]);
   const unitOptions = useMemo(() => {
     if (selectedRoomUnits.length) {
       return selectedRoomUnits.map((unit) => ({
@@ -684,10 +706,8 @@ const useAppointmentWorkspaceContent = ({ appointment }: AppointmentWorkspacePro
         value: unit.id,
       }));
     }
-    return effectiveEncounter?.unitId
-      ? [{ label: effectiveEncounter.unitId, value: effectiveEncounter.unitId }]
-      : [];
-  }, [effectiveEncounter?.unitId, selectedRoomUnits]);
+    return encounterUnitId ? [{ label: encounterUnitId, value: encounterUnitId }] : [];
+  }, [encounterUnitId, selectedRoomUnits]);
   const unitOptionsByRoomId = useMemo(() => {
     const optionsByRoom: Record<string, { label: string; value: string }[]> = {};
     for (const room of rooms) {
@@ -719,11 +739,11 @@ const useAppointmentWorkspaceContent = ({ appointment }: AppointmentWorkspacePro
       options.push({ label: trimmed, value: trimmedId });
     };
     (appointment.supportStaff ?? []).forEach((staff) => add(staff.id, staff.name));
-    if (effectiveEncounter?.nurseId && effectiveEncounter.nurseName) {
-      add(effectiveEncounter.nurseId, effectiveEncounter.nurseName);
+    if (encounterNurseId && encounterNurseName) {
+      add(encounterNurseId, encounterNurseName);
     }
     return options;
-  }, [appointment.supportStaff, effectiveEncounter?.nurseId, effectiveEncounter?.nurseName]);
+  }, [appointment.supportStaff, encounterNurseId, encounterNurseName]);
   const hospitalizationServicePackages = useMemo(() => {
     // Only INPATIENT-bookable items may be added on hospitalization. The backend derives
     // `supportsInpatient` from `isInpatientPreferred` and rejects anything else with a 400
@@ -797,7 +817,10 @@ const useAppointmentWorkspaceContent = ({ appointment }: AppointmentWorkspacePro
     if (!organisationId || !appointmentId) return undefined;
     const bootstrap = await getAppointmentWorkspaceBootstrap(organisationId, appointmentId);
     const encounterId = getWorkspaceBootstrapEncounterId(bootstrap);
-    if (encounterId) lifecycleEncounterIdRef.current = encounterId;
+    if (encounterId) {
+      lifecycleEncounterIdRef.current = encounterId;
+      setResolvedEncounterId(encounterId);
+    }
     mergeEncounterData(appointmentId, normalizeWorkspaceBootstrapForEncounter(bootstrap));
     return encounterId;
   }, [appointment.organisationId, appointmentId, mergeEncounterData]);
@@ -855,10 +878,10 @@ const useAppointmentWorkspaceContent = ({ appointment }: AppointmentWorkspacePro
       /* v8 ignore stop */
 
       const admittedAt = options?.admittedAt ?? new Date().toISOString();
-      const resolvedRoomId = roomId ?? effectiveEncounter?.roomId ?? appointment.room?.id;
-      const resolvedUnitId = unitId ?? effectiveEncounter?.unitId;
-      const leadName = (effectiveEncounter?.leadName ?? appointment.lead?.name ?? '').trim();
-      const leadId = (effectiveEncounter?.leadId ?? appointment.lead?.id ?? '').trim();
+      const resolvedRoomId = roomId ?? encounterRoomId ?? appointment.room?.id;
+      const resolvedUnitId = unitId ?? encounterUnitId;
+      const leadName = (encounterLeadName ?? appointment.lead?.name ?? '').trim();
+      const leadId = (encounterLeadId ?? appointment.lead?.id ?? '').trim();
       const supportStaff: RequiredStaffMember[] = (appointment.supportStaff ?? [])
         .map((staff) => ({
           id: (staff.id ?? '').trim(),
@@ -871,10 +894,10 @@ const useAppointmentWorkspaceContent = ({ appointment }: AppointmentWorkspacePro
       ) {
         supportStaff.push(options.supportStaffMember);
       }
-      if (!supportStaff.length && effectiveEncounter?.nurseId && effectiveEncounter.nurseName) {
+      if (!supportStaff.length && encounterNurseId && encounterNurseName) {
         supportStaff.push({
-          id: effectiveEncounter.nurseId,
-          name: effectiveEncounter.nurseName,
+          id: encounterNurseId,
+          name: encounterNurseName,
         });
       }
 
@@ -940,12 +963,12 @@ const useAppointmentWorkspaceContent = ({ appointment }: AppointmentWorkspacePro
       appointment.supportStaff,
       appointmentId,
       canAdmitAppointmentStatus,
-      effectiveEncounter?.leadId,
-      effectiveEncounter?.leadName,
-      effectiveEncounter?.nurseId,
-      effectiveEncounter?.nurseName,
-      effectiveEncounter?.roomId,
-      effectiveEncounter?.unitId,
+      encounterLeadId,
+      encounterLeadName,
+      encounterNurseId,
+      encounterNurseName,
+      encounterRoomId,
+      encounterUnitId,
       encounterMode,
       isAdmitting,
       mergeEncounterData,
@@ -1356,7 +1379,7 @@ const useAppointmentWorkspaceContent = ({ appointment }: AppointmentWorkspacePro
           { overrideReason }
         );
         await completeAppointmentStatus();
-        setRoomUnitOccupied(effectiveEncounter?.unitId, false);
+        setRoomUnitOccupied(encounterUnitId, false);
         await loadRoomsForOrgPrimaryOrg({ force: true, silent: true });
         markDischarged(appointmentId, dischargedAt);
         notify('success', {
@@ -1379,7 +1402,7 @@ const useAppointmentWorkspaceContent = ({ appointment }: AppointmentWorkspacePro
       isFinalizing,
       markDischarged,
       notify,
-      effectiveEncounter?.unitId,
+      encounterUnitId,
       terminologyText,
       setRoomUnitOccupied,
     ]
@@ -1527,7 +1550,7 @@ const useAppointmentWorkspaceContent = ({ appointment }: AppointmentWorkspacePro
           appointmentId={appointmentId}
           appointment={appointment}
           encounter={effectiveEncounter}
-          resolvedEncounterId={lifecycleEncounterIdRef.current ?? appointment.encounterId}
+          resolvedEncounterId={resolvedEncounterId ?? appointment.encounterId}
         />
       )}
     </>

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/panels/DocumentsPanel.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/panels/DocumentsPanel.tsx
@@ -223,17 +223,18 @@ const ClinicalPacketSection = ({
   // Resolve the encounter's packet on mount so the state matrix reflects server
   // truth. `createEncounterDocumentPacket` is idempotent — it returns the
   // existing packet (with its status + signing state) when one is present.
-  const refreshPacket = useCallback(async () => {
-    if (!organisationId || !encounterId) return;
+  // Resolution is a pure fetch (null = leave current state alone) so the mount
+  // effect can apply the result in a subscription-style callback.
+  const resolvePacket = useCallback(async (): Promise<PacketState | null> => {
+    if (!organisationId || !encounterId) return null;
     try {
       try {
         const documents = await listEncounterWorkspaceDocuments(organisationId, encounterId);
         if (documents.some(isSignedDocumentRow)) {
-          setPacket({
+          return {
             status: 'FINAL',
             signingStatus: 'SIGNED',
-          });
-          return;
+          };
         }
       } catch (error) {
         if (isAuthRedirectError(error)) throw error;
@@ -241,21 +242,29 @@ const ClinicalPacketSection = ({
       }
 
       const result = await createEncounterDocumentPacket(organisationId, encounterId);
-      setPacket({
+      return {
         packetId: result?.packetId,
         status: result?.status,
         signingStatus: result?.signing?.status,
-      });
+      };
     } catch (error) {
       if (!isAuthRedirectError(error)) {
         console.error('Unable to load clinical packet:', error);
       }
+      return null;
     }
   }, [organisationId, encounterId]);
 
+  const refreshPacket = useCallback(async () => {
+    const next = await resolvePacket();
+    if (next) setPacket(next);
+  }, [resolvePacket]);
+
   useEffect(() => {
-    void refreshPacket();
-  }, [refreshPacket]);
+    void resolvePacket().then((next) => {
+      if (next) setPacket(next);
+    });
+  }, [resolvePacket]);
 
   const reconcilePacketAfterSigningClose = useCallback(
     async (packetId: string) => {

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/panels/TasksPanel.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/panels/TasksPanel.tsx
@@ -473,17 +473,23 @@ const TasksPanel = ({
     });
   }, []);
 
-  // Opened from a schedule row's "View": auto-open that task's edit form, then
-  // clear the focus flag so it doesn't re-trigger.
-  useEffect(() => {
-    if (!focusTaskId) return;
-    const task = tasksById[focusTaskId];
-    if (task) {
-      setEditingTask(task);
-      setFormOpen(true);
+  // Opened from a schedule row's "View": auto-open that task's edit form during
+  // render (prev-compare), then clear the focus flag in an effect so it doesn't
+  // re-trigger.
+  const [prevFocusTaskId, setPrevFocusTaskId] = useState<typeof focusTaskId>(null);
+  if (focusTaskId !== prevFocusTaskId) {
+    setPrevFocusTaskId(focusTaskId);
+    if (focusTaskId) {
+      const task = tasksById[focusTaskId];
+      if (task) {
+        setEditingTask(task);
+        setFormOpen(true);
+      }
     }
-    setFocusTaskId(null);
-  }, [focusTaskId, tasksById, setFocusTaskId]);
+  }
+  useEffect(() => {
+    if (focusTaskId) setFocusTaskId(null);
+  }, [focusTaskId, setFocusTaskId]);
 
   const isParent = tab === 'PARENT';
   const appointmentTasks = useMemo(

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/SummaryStep.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/SummaryStep.tsx
@@ -459,25 +459,36 @@ const useSummaryStepContent = ({
   // signing state stay in sync without a full page reload.
   const refreshDocuments = useCallback(async () => {
     if (!organisationId) return;
-    try {
-      // The encounter id is the preferred scope, but an appointment whose visit
-      // has not been checked in yet has no encounter at all. Its documents are
-      // still readable by appointment, so fall back to the appointment-scoped
-      // read-model instead of silently rendering an empty "no documents" state.
-      const rows = await (encounterId
+    // The encounter id is the preferred scope, but an appointment whose visit
+    // has not been checked in yet has no encounter at all. Its documents are
+    // still readable by appointment, so fall back to the appointment-scoped
+    // read-model instead of silently rendering an empty "no documents" state.
+    await (
+      encounterId
         ? listEncounterWorkspaceDocuments(organisationId, encounterId)
-        : listAppointmentWorkspaceDocuments(organisationId, appointmentId));
-      setDocuments(rows);
-      setDocumentsError(null);
-    } catch (error) {
-      console.error('Unable to load documents:', error);
-      setDocumentsError('Unable to load documents.');
-    }
+        : listAppointmentWorkspaceDocuments(organisationId, appointmentId)
+    )
+      .then((rows) => {
+        setDocuments(rows);
+        setDocumentsError(null);
+      })
+      .catch((error) => {
+        console.error('Unable to load documents:', error);
+        setDocumentsError('Unable to load documents.');
+      });
   }, [organisationId, encounterId, appointmentId]);
 
   useEffect(() => {
     void refreshDocuments();
   }, [refreshDocuments]);
+
+  // The signing overlay has no completion callback, so treat closing it after a
+  // sign was started as the signal to refetch (the Documenso webhook has run
+  // server-side by then).
+  const signingInitiatedRef = useRef(false);
+  // The packet being signed, captured when signing starts so the post-close
+  // reconcile can pull server-side signing truth from Documenso directly.
+  const signingPacketIdRef = useRef<string | null>(null);
 
   // After a signing session closes, pull server truth so the documents list,
   // discharge artifact status, and finalization gate (ready-for-discharge /
@@ -510,13 +521,6 @@ const useSummaryStepContent = ({
     await refreshDocuments();
   }, [organisationId, appointmentId, mergeEncounterData, refreshDocuments]);
 
-  // The signing overlay has no completion callback, so treat closing it after a
-  // sign was started as the signal to refetch (the Documenso webhook has run
-  // server-side by then).
-  const signingInitiatedRef = useRef(false);
-  // The packet being signed, captured when signing starts so the post-close
-  // reconcile can pull server-side signing truth from Documenso directly.
-  const signingPacketIdRef = useRef<string | null>(null);
   const resolvedDischargeEncounterRef = useRef<string | null>(null);
   const dischargeResolveKey = encounterId ?? appointmentId;
   const companionId = appointment?.patient?.id;

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AddAppointmentCentralModal/index.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AddAppointmentCentralModal/index.tsx
@@ -228,6 +228,16 @@ const getPortalStyle = (el: HTMLElement | null): CSSProperties | null => {
   };
 };
 
+/** Equality guard so the measure-on-every-render layout effect settles instead of looping. */
+const isSamePortalStyle = (a: CSSProperties | null, b: CSSProperties | null): boolean =>
+  a === b ||
+  (a !== null &&
+    b !== null &&
+    a.left === b.left &&
+    a.width === b.width &&
+    a.top === b.top &&
+    a.bottom === b.bottom);
+
 // ─── PersonRow ─────────────────────────────────────────────────────────────────
 type PersonRowProps = {
   fieldId: string;
@@ -287,8 +297,13 @@ export const PersonRow = ({
   const isFloated = hasValue || visibleOpen;
   const inputValue = hasValue ? selectedName! : query;
 
-  // Read position synchronously from the DOM at render time — no state delay
-  const portalStyle = visibleOpen ? getPortalStyle(triggerRef.current) : null;
+  // Measure position in a layout effect when the menu opens (applied before
+  // paint, so no visible delay) — refs must not be read during render
+  const [portalStyle, setPortalStyle] = useState<CSSProperties | null>(null);
+  useLayoutEffect(() => {
+    const next = visibleOpen ? getPortalStyle(triggerRef.current) : null;
+    setPortalStyle((cur) => (isSamePortalStyle(cur, next) ? cur : next));
+  }, [visibleOpen]);
 
   const dropdownMenu =
     visibleOpen && portalStyle && typeof document !== 'undefined'
@@ -581,8 +596,13 @@ export const TimeSlotDropdown = ({
   const selectedLabel = selectedSlot
     ? formatUtcTimeToLocalLabel(selectedSlot.startTime)
     : (prefillLabel ?? null);
-  // Read position synchronously from the DOM at render time — no state delay
-  const portalStyle = open ? getPortalStyle(triggerRef.current) : null;
+  // Measure position in a layout effect when the menu opens (applied before
+  // paint, so no visible delay) — refs must not be read during render
+  const [portalStyle, setPortalStyle] = useState<CSSProperties | null>(null);
+  useLayoutEffect(() => {
+    const next = open ? getPortalStyle(triggerRef.current) : null;
+    setPortalStyle((cur) => (isSamePortalStyle(cur, next) ? cur : next));
+  }, [open]);
 
   const dropdownMenu =
     open && portalStyle && typeof document !== 'undefined'
@@ -1121,7 +1141,7 @@ const useAddAppointmentCentralModalView = ({
     setVisitType(syncedVisitType);
   }
   const prevShowModalRef = useRef(showModal);
-  const prevPrefillKeyRef = useRef<string | null>(null);
+  const [prevPrefillKey, setPrevPrefillKey] = useState<string | null>(null);
   const autoSelectKeyRef = useRef<string | null>(null);
 
   const hasUnsavedChanges = useMemo(
@@ -1161,8 +1181,8 @@ const useAddAppointmentCentralModalView = ({
   }, [formData, selectedSlot, setFormDataErrors, uiState.submitAttempted, validateForm]);
 
   const prefillKey = computePrefillKey(prefill);
-  if (prefillKey !== prevPrefillKeyRef.current) {
-    prevPrefillKeyRef.current = prefillKey;
+  if (prefillKey !== prevPrefillKey) {
+    setPrevPrefillKey(prefillKey);
     dispatchUi({ type: 'reset' });
   }
 

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/Info/AppointmentInfo.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/Info/AppointmentInfo.tsx
@@ -363,6 +363,8 @@ const useAppointmentInfoView = ({
       ?.toLowerCase();
   }, []);
 
+  const activeLeadId = activeAppointment.lead?.id;
+  const activeLeadName = activeAppointment.lead?.name;
   const getLeadOptionsForSlot = useCallback(
     (slot: Slot | null) => {
       if (!teams?.length || !slot) return [];
@@ -399,19 +401,13 @@ const useAppointmentInfoView = ({
       const currentSlotEnd = toIsoTimePart(activeAppointment.endTime);
       const isCurrentAppointmentSlot =
         slot.startTime === currentSlotStart && slot.endTime === currentSlotEnd;
-      const activeLeadId = activeAppointment.lead?.id;
       const hasAssignedLeadInOptions = options.some(
         (option) => normalizeId(option.value) === normalizeId(activeLeadId)
       );
 
-      if (
-        isCurrentAppointmentSlot &&
-        activeLeadId &&
-        !hasAssignedLeadInOptions &&
-        activeAppointment.lead?.name
-      ) {
+      if (isCurrentAppointmentSlot && activeLeadId && !hasAssignedLeadInOptions && activeLeadName) {
         options.push({
-          label: activeAppointment.lead.name,
+          label: activeLeadName,
           value: activeLeadId,
         });
       }
@@ -424,8 +420,8 @@ const useAppointmentInfoView = ({
       normalizeId,
       activeAppointment.startTime,
       activeAppointment.endTime,
-      activeAppointment.lead?.id,
-      activeAppointment.lead?.name,
+      activeLeadId,
+      activeLeadName,
     ]
   );
 

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/LabTests.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/LabTests.tsx
@@ -232,6 +232,7 @@ export const useLabTests = (activeAppointment: Appointment | null) => {
   const [pdfPreviewTitle, setPdfPreviewTitle] = useState('IDEXX PDF');
   const [pdfPreviewLoadingId, setPdfPreviewLoadingId] = useState<string | null>(null);
 
+  const appointmentId = activeAppointment?.id;
   const companionId = activeAppointment?.companion?.id;
   const parentId = activeAppointment?.companion?.parent?.id;
   const [prevAppointmentStaffKey, setPrevAppointmentStaffKey] = useState<string | null>(null);
@@ -239,7 +240,9 @@ export const useLabTests = (activeAppointment: Appointment | null) => {
   // Stable ref so callbacks can read the latest appointmentOrders without
   // listing the array as a dep (new array ref every render → infinite loop).
   const appointmentOrdersRef = React.useRef(appointmentOrders);
-  appointmentOrdersRef.current = appointmentOrders;
+  useEffect(() => {
+    appointmentOrdersRef.current = appointmentOrders;
+  });
   const normalizedOrderStatus = getNormalizedLifecycleStatus(latestOrder);
   const needsInitialOrderPlacement = normalizedOrderStatus === 'CREATED';
 
@@ -350,7 +353,7 @@ export const useLabTests = (activeAppointment: Appointment | null) => {
   const refreshResultsRef = React.useRef<() => Promise<void>>(async () => undefined);
 
   const refreshAppointmentOrders = useCallback(async () => {
-    if (!primaryOrgId || !integrationEnabled || !activeAppointment?.id) {
+    if (!primaryOrgId || !integrationEnabled || !appointmentId) {
       setAppointmentOrders([]);
       setLatestOrder(null);
       return;
@@ -358,11 +361,7 @@ export const useLabTests = (activeAppointment: Appointment | null) => {
     setOrdersLoading(true);
     setError(null);
     try {
-      const orders = await listIdexxOrdersWithFallback(
-        primaryOrgId,
-        activeAppointment.id,
-        companionId
-      );
+      const orders = await listIdexxOrdersWithFallback(primaryOrgId, appointmentId, companionId);
       const normalized = normalizeOrders(orders);
       setAppointmentOrders(normalized);
       appointmentOrdersRef.current = normalized;
@@ -379,7 +378,7 @@ export const useLabTests = (activeAppointment: Appointment | null) => {
     } finally {
       setOrdersLoading(false);
     }
-  }, [activeAppointment?.id, companionId, integrationEnabled, primaryOrgId]);
+  }, [appointmentId, companionId, integrationEnabled, primaryOrgId]);
 
   const refreshCensus = useCallback(async () => {
     if (!primaryOrgId || !integrationEnabled) return;
@@ -422,16 +421,27 @@ export const useLabTests = (activeAppointment: Appointment | null) => {
   }, [companionId, integrationEnabled, primaryOrgId]);
 
   // Keep the ref current so refreshAppointmentOrders can call the latest version.
-  refreshResultsRef.current = refreshResults;
+  useEffect(() => {
+    refreshResultsRef.current = refreshResults;
+  });
 
   useEffect(() => {
-    void refreshResults();
+    const run = async () => {
+      await refreshResults();
+    };
+    void run();
   }, [refreshResults]);
   useEffect(() => {
-    void refreshCensus();
+    const run = async () => {
+      await refreshCensus();
+    };
+    void run();
   }, [refreshCensus]);
   useEffect(() => {
-    void refreshAppointmentOrders();
+    const run = async () => {
+      await refreshAppointmentOrders();
+    };
+    void run();
   }, [refreshAppointmentOrders]);
 
   useEffect(() => {
@@ -684,7 +694,7 @@ export const useLabTests = (activeAppointment: Appointment | null) => {
     try {
       const payload = {
         patientId: companionId,
-        appointmentId: activeAppointment?.id,
+        appointmentId,
         tests: selectedTests.map((test) => test.code),
         modality,
         veterinarian: veterinarian || undefined,
@@ -712,7 +722,7 @@ export const useLabTests = (activeAppointment: Appointment | null) => {
     primaryOrgId,
     companionId,
     selectedTests,
-    activeAppointment?.id,
+    appointmentId,
     modality,
     veterinarian,
     technician,

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/index.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/index.tsx
@@ -1278,13 +1278,14 @@ const AppoitmentInfo = ({
   const statusSummary = getAppointmentStateSummary(activeAppointment?.status);
   const statusLabel = toStatusLabel(activeAppointment?.status);
   const clinicalWorkspaceIntent = getClinicalNotesIntent(orgType);
+  const activeAppointmentId = activeAppointment?.id;
   const openWorkspaceIntent = useCallback(
     (intent: AppointmentViewIntent) => {
-      if (!activeAppointment?.id) return;
-      router.push(buildWorkspaceHrefForIntent(activeAppointment.id, intent));
+      if (!activeAppointmentId) return;
+      router.push(buildWorkspaceHrefForIntent(activeAppointmentId, intent));
       setShowModal(false);
     },
-    [activeAppointment?.id, router, setShowModal]
+    [activeAppointmentId, router, setShowModal]
   );
   const formsById = useFormsStore((s) => s.formsById);
   const signingOverlayOpen = useSigningOverlayStore((s) => s.open);

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/useAppointmentFormData.ts
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/useAppointmentFormData.ts
@@ -102,8 +102,19 @@ export const useAppointmentFormData = ({
     };
   }, [activeAppointment?.id, resolvedActiveLabel, resolvedActiveSubLabel, withSignatureMetaRef]);
 
-  // Re-apply signature metadata to the SOAP fields when the underlying forms change.
-  useEffect(() => {
+  // Re-apply signature metadata to the SOAP fields when the underlying forms
+  // change — adjusted during render via a prev-compare rather than an effect.
+  const [prevMetaInputs, setPrevMetaInputs] = useState({
+    formsById,
+    customForms,
+    withSignatureMeta,
+  });
+  if (
+    prevMetaInputs.formsById !== formsById ||
+    prevMetaInputs.customForms !== customForms ||
+    prevMetaInputs.withSignatureMeta !== withSignatureMeta
+  ) {
+    setPrevMetaInputs({ formsById, customForms, withSignatureMeta });
     setFormData((prev) => ({
       ...prev,
       subjective: withSignatureMeta(prev.subjective),
@@ -112,7 +123,7 @@ export const useAppointmentFormData = ({
       plan: withSignatureMeta(prev.plan),
       discharge: withSignatureMeta(prev.discharge),
     }));
-  }, [formsById, customForms, withSignatureMeta]);
+  }
 
   // Invoice totals are derived from the line items and the appointment's service
   // cost during render, then overlaid onto the value handed to children so

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/ChangeRoom.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/ChangeRoom.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState, useRef } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Appointment } from '@yosemite-crew/types';
 import CenterModal from '@/app/ui/overlays/Modal/CenterModal';
 import ModalHeader from '@/app/ui/overlays/Modal/ModalHeader';
@@ -77,13 +77,9 @@ const ChangeRoom = ({ showModal, setShowModal, activeAppointment }: ChangeRoomPr
     loadRoomsForOrgPrimaryOrg({ force: true, silent: true }).catch(() => undefined);
   }, [showModal]);
 
-  const prevResetKeyRef = useRef({ appointment: activeAppointment, showModal });
-  const resetKey = { appointment: activeAppointment, showModal };
-  if (
-    prevResetKeyRef.current.appointment !== activeAppointment ||
-    prevResetKeyRef.current.showModal !== showModal
-  ) {
-    prevResetKeyRef.current = resetKey;
+  const [prevResetKey, setPrevResetKey] = useState({ appointment: activeAppointment, showModal });
+  if (prevResetKey.appointment !== activeAppointment || prevResetKey.showModal !== showModal) {
+    setPrevResetKey({ appointment: activeAppointment, showModal });
     const newRoomId = activeAppointment.room?.id || '';
     if (selectedRoomId !== newRoomId) setSelectedRoomId(newRoomId);
     const newUnitId =

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/ChangeStatus.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/ChangeStatus.tsx
@@ -166,9 +166,9 @@ const ChangeStatus = ({
   const [availableVetIds, setAvailableVetIds] = React.useState<string[] | null>(null);
   const [isLoadingAvailability, setIsLoadingAvailability] = React.useState(shouldLoadAvailability);
   const availabilityKey = `${showModal ? 'open' : 'closed'}:${currentStatus}:${serviceId}:${activeAppointment.startTime}`;
-  const previousAvailabilityKeyRef = React.useRef(availabilityKey);
-  if (previousAvailabilityKeyRef.current !== availabilityKey) {
-    previousAvailabilityKeyRef.current = availabilityKey;
+  const [previousAvailabilityKey, setPreviousAvailabilityKey] = React.useState(availabilityKey);
+  if (previousAvailabilityKey !== availabilityKey) {
+    setPreviousAvailabilityKey(availabilityKey);
     setAvailableVetIds(null);
     setIsLoadingAvailability(shouldLoadAvailability);
   }

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/Reschedule.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/Reschedule.tsx
@@ -8,7 +8,14 @@ import {
 import { Slot } from '@/app/features/appointments/types/appointments';
 import { buildUtcDateFromDateAndTime, getDurationMinutes, toUtcCalendarDate } from '@/app/lib/date';
 import { Appointment } from '@yosemite-crew/types';
-import React, { useCallback, useEffect, useLayoutEffect, useMemo, useReducer, useRef } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useReducer,
+  useState,
+} from 'react';
 import ModalHeader from '@/app/ui/overlays/Modal/ModalHeader';
 import DateTimePickerSection from '@/app/features/appointments/components/DateTimePickerSection';
 import { allowReschedule } from '@/app/lib/appointments';
@@ -105,9 +112,9 @@ const Reschedule = ({ showModal, setShowModal, activeAppointment }: ReschedulePr
     [state.selectedSlot]
   );
 
-  const prevActiveAppointmentRef = useRef(activeAppointment);
-  if (prevActiveAppointmentRef.current !== activeAppointment) {
-    prevActiveAppointmentRef.current = activeAppointment;
+  const [prevActiveAppointment, setPrevActiveAppointment] = useState(activeAppointment);
+  if (prevActiveAppointment !== activeAppointment) {
+    setPrevActiveAppointment(activeAppointment);
     dispatch({
       type: 'PATCH',
       patch: {

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/ViewAppointmentOverviewModal/index.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/ViewAppointmentOverviewModal/index.tsx
@@ -536,6 +536,7 @@ const ViewAppointmentOverviewModal = ({
       rooms,
       setRoomUnit,
       setRoomUnitOccupied,
+      setSavingField,
     ]
   );
 
@@ -568,8 +569,7 @@ const ViewAppointmentOverviewModal = ({
     [
       activeAppointment.encounterId,
       activeAppointment.id,
-      activeAppointment.lead?.id,
-      activeAppointment.lead?.name,
+      activeAppointment.lead,
       canEditRoom,
       effectiveRoomId,
       initEncounter,
@@ -578,6 +578,7 @@ const ViewAppointmentOverviewModal = ({
       setRoomUnit,
       currentUnitId,
       setRoomUnitOccupied,
+      setSavingField,
     ]
   );
 

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/index.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/index.tsx
@@ -172,9 +172,9 @@ const resolveInitialIntent = (
 // its previous value — the null-sentinel derived-state pattern, factored out so
 // each call site stays a single statement rather than an inline prev-compare.
 const useOnValueChange = <T,>(value: T, onChange: () => void): void => {
-  const prevRef = useRef<{ value: T }>(undefined);
-  if (prevRef.current?.value !== value) {
-    prevRef.current = { value };
+  const [prev, setPrev] = useState<{ value: T } | undefined>(undefined);
+  if (prev?.value !== value) {
+    setPrev({ value });
     onChange();
   }
 };

--- a/apps/frontend/src/app/features/chat/components/ChatCommandPalette.tsx
+++ b/apps/frontend/src/app/features/chat/components/ChatCommandPalette.tsx
@@ -7,7 +7,7 @@
  * the parent's activateChannelById). Mounted once inside the chat shell.
  */
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { StreamChat, Channel, ChannelFilters, ChannelSort } from 'stream-chat';
 import { LuCommand } from 'react-icons/lu';
 import { IoReturnDownBackOutline, IoSearchOutline } from 'react-icons/io5';
@@ -46,9 +46,9 @@ export function ChatCommandPalette({
 
   // Reset the query as soon as the palette closes, computed during render
   // (rather than in an effect) so there's no stale-query flash on reopen.
-  const prevOpenRef = useRef(open);
-  if (prevOpenRef.current !== open) {
-    prevOpenRef.current = open;
+  const [prevOpen, setPrevOpen] = useState(open);
+  if (prevOpen !== open) {
+    setPrevOpen(open);
     if (!open && query) setQuery('');
   }
 

--- a/apps/frontend/src/app/features/chat/components/ChatContainer.tsx
+++ b/apps/frontend/src/app/features/chat/components/ChatContainer.tsx
@@ -241,39 +241,41 @@ interface ChannelState {
 
 export type { ChatScope };
 
+// Read the frozen/closed flags off the channel's current data payload.
+const readChannelState = (channel: StreamChannel | null | undefined): ChannelState => {
+  const channelData = channel?.data as any;
+  return {
+    frozen: channelData?.frozen === true,
+    updatedAt: channelData?.updated_at,
+    closedAt: channelData?.closedAt || channelData?.closed_at,
+  };
+};
+
 // Custom hook for channel state management
 const useChannelState = () => {
   const { channel } = useChannelStateContext();
-  const [state, setState] = useState<ChannelState>({
-    frozen: false,
-    updatedAt: undefined,
-    closedAt: undefined,
-  });
+  const [state, setState] = useState<ChannelState>(() => readChannelState(channel));
+
+  // Re-read during render (compare-guard) when the channel itself changes; the
+  // effect below only subscribes for external updates on that channel.
+  const [prevChannel, setPrevChannel] = useState(channel);
+  if (prevChannel !== channel) {
+    setPrevChannel(channel);
+    if (channel) setState(readChannelState(channel));
+  }
 
   useEffect(() => {
-    if (channel) {
-      const channelData = channel.data as any;
-      const isFrozen = channelData?.frozen === true;
-      const updatedAt = channelData?.updated_at;
-      const closedAt = channelData?.closedAt || channelData?.closed_at;
+    if (!channel) return;
+    // Listen for channel updates
+    const handleChannelUpdate = () => {
+      setState(readChannelState(channel));
+    };
 
-      setState({ frozen: isFrozen, updatedAt, closedAt });
+    channel.on('channel.updated', handleChannelUpdate);
 
-      // Listen for channel updates
-      const handleChannelUpdate = () => {
-        const updatedData = channel.data as any;
-        const newFrozen = updatedData?.frozen === true;
-        const newUpdatedAt = updatedData?.updated_at;
-        const newClosedAt = updatedData?.closedAt || updatedData?.closed_at;
-        setState({ frozen: newFrozen, updatedAt: newUpdatedAt, closedAt: newClosedAt });
-      };
-
-      channel.on('channel.updated', handleChannelUpdate);
-
-      return () => {
-        channel.off('channel.updated', handleChannelUpdate);
-      };
-    }
+    return () => {
+      channel.off('channel.updated', handleChannelUpdate);
+    };
   }, [channel]);
 
   return state;
@@ -1083,7 +1085,9 @@ const useChatContainerView = ({
     []
   );
   const groupModalBackendIdRef = useRef<string | undefined>(undefined);
-  const groupModalOwnerRef = useRef<string | undefined>(undefined);
+  // Rendered into the modal, so state (not a ref); only written in the open
+  // handlers below.
+  const [groupModalOwner, setGroupModalOwner] = useState<string | undefined>(undefined);
   const orgUsersRequestKeyRef = useRef<string | null>(null);
 
   const { notify } = useNotify();
@@ -1133,17 +1137,29 @@ const useChatContainerView = ({
     refreshStatuses();
   }, [refreshStatuses]);
 
-  useEffect(() => {
+  // Drop the previous organisation's colleague list during render (compare-guard)
+  // when the org switches; the effect below only clears the request-dedupe ref.
+  const [prevOrgUsersOrgId, setPrevOrgUsersOrgId] = useState(primaryOrgId);
+  if (prevOrgUsersOrgId !== primaryOrgId) {
+    setPrevOrgUsersOrgId(primaryOrgId);
     setOrgUsersStatus('idle');
     setOrgUsers([]);
+  }
+
+  useEffect(() => {
     orgUsersRequestKeyRef.current = null;
   }, [primaryOrgId]);
 
-  useLayoutEffect(() => {
-    if (!appointmentId) return;
-    setIsChannelSelected(false);
-    setShowEmptyPlaceholder(true);
-  }, [appointmentId]);
+  // Deselect the channel when an appointment scope arrives or changes, computed
+  // during render (compare-guard, seeded so it also fires on the first render).
+  const [prevAppointmentKey, setPrevAppointmentKey] = useState<{ id?: string } | null>(null);
+  if (prevAppointmentKey === null || prevAppointmentKey.id !== appointmentId) {
+    setPrevAppointmentKey({ id: appointmentId });
+    if (appointmentId) {
+      setIsChannelSelected(false);
+      setShowEmptyPlaceholder(true);
+    }
+  }
 
   const resolveGroupIdForChannel = useCallback(
     async (chan: StreamChannel | null) => {
@@ -1270,9 +1286,12 @@ const useChatContainerView = ({
   );
 
   // Read through a ref so an inline callback prop cannot re-trigger the scope
-  // reset below on every parent render.
+  // reset below on every parent render. Synced in a layout effect so the reset
+  // below (also a layout effect, declared after) reads the latest value.
   const onChannelSelectRef = useRef(onChannelSelect);
-  onChannelSelectRef.current = onChannelSelect;
+  useLayoutEffect(() => {
+    onChannelSelectRef.current = onChannelSelect;
+  });
 
   useLayoutEffect(() => {
     // Reset selection when switching audience scopes so stale channels do not persist
@@ -1328,7 +1347,7 @@ const useChatContainerView = ({
 
   const openCreateGroupModal = useCallback(() => {
     groupModalBackendIdRef.current = undefined;
-    groupModalOwnerRef.current = client?.userID;
+    setGroupModalOwner(client?.userID);
     setGroupModal({ ...INITIAL_GROUP_MODAL, mode: 'create', open: true });
   }, [client]);
 
@@ -1349,11 +1368,12 @@ const useChatContainerView = ({
       // Find owner from members array (role: "owner") or fallback to created_by
       const membersArray = chan.state?.members ? Object.values(chan.state.members) : [];
       const ownerMember = membersArray.find((m: any) => m.role === 'owner');
-      groupModalOwnerRef.current =
+      setGroupModalOwner(
         ownerMember?.user_id ||
-        ownerMember?.user?.id ||
-        (chan.data as any)?.createdBy ||
-        (chan as any)?.created_by?.id;
+          ownerMember?.user?.id ||
+          (chan.data as any)?.createdBy ||
+          (chan as any)?.created_by?.id
+      );
       const backendId = await resolveGroupIdForChannel(chan);
       groupModalBackendIdRef.current = backendId;
       patchGroupModal({ search: '', open: true });
@@ -2037,7 +2057,7 @@ const useChatContainerView = ({
               title={groupModalTitle}
               placeholder={groupModalPlaceholder}
               members={groupModalMembers}
-              ownerId={groupModalOwnerRef.current}
+              ownerId={groupModalOwner}
               currentUserId={client.userID}
               search={groupModalSearch}
               busy={groupModalBusy}

--- a/apps/frontend/src/app/features/chat/components/ChatMessage.tsx
+++ b/apps/frontend/src/app/features/chat/components/ChatMessage.tsx
@@ -151,11 +151,15 @@ function useAnchoredPopoverStyle(
   align: 'left' | 'right'
 ): CSSProperties | null {
   const [style, setStyle] = useState<CSSProperties | null>(null);
+  // Drop the measured style during render (compare-guard) when the popover
+  // closes, so the next open starts hidden and re-measures.
+  const [prevOpen, setPrevOpen] = useState(open);
+  if (prevOpen !== open) {
+    setPrevOpen(open);
+    if (!open) setStyle(null);
+  }
   useLayoutEffect(() => {
-    if (!open) {
-      setStyle(null);
-      return;
-    }
+    if (!open) return;
     const anchor = anchorRef.current?.getBoundingClientRect();
     const panel = panelRef.current;
     if (!anchor || !panel) return;
@@ -180,7 +184,9 @@ function usePopoverDismiss(
   panelRef: RefObject<HTMLDivElement | null>
 ): void {
   const onCloseRef = useRef(onClose);
-  onCloseRef.current = onClose;
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  });
   useEffect(() => {
     if (!open) return;
     const handlePointer = (event: Event) => {

--- a/apps/frontend/src/app/features/chat/components/MessageSearch.tsx
+++ b/apps/frontend/src/app/features/chat/components/MessageSearch.tsx
@@ -25,15 +25,25 @@ export function MessageSearch() {
   const [results, setResults] = useState<MessageResponse[]>([]);
   const [searching, setSearching] = useState(false);
 
-  useEffect(() => {
-    const trimmed = query.trim();
-    if (!open || !trimmed || !channel) {
+  const trimmed = query.trim();
+  const searchKey = open && trimmed && channel ? trimmed : null;
+
+  // Clear stale results / flip the searching flag during render (compare-guard)
+  // so the effect below only schedules the debounced search itself.
+  const [prevSearchKey, setPrevSearchKey] = useState(searchKey);
+  if (prevSearchKey !== searchKey) {
+    setPrevSearchKey(searchKey);
+    if (searchKey === null) {
       setResults([]);
       setSearching(false);
-      return;
+    } else {
+      setSearching(true);
     }
+  }
+
+  useEffect(() => {
+    if (!open || !trimmed || !channel) return;
     let active = true;
-    setSearching(true);
     const timer = setTimeout(() => {
       channel
         .search(trimmed)
@@ -51,9 +61,9 @@ export function MessageSearch() {
       active = false;
       clearTimeout(timer);
     };
-  }, [query, open, channel]);
+  }, [trimmed, open, channel]);
 
-  const hasQuery = query.trim().length > 0;
+  const hasQuery = trimmed.length > 0;
 
   return (
     <div className="relative">

--- a/apps/frontend/src/app/features/companions/components/AddCompanion/Sections/Companion.tsx
+++ b/apps/frontend/src/app/features/companions/components/AddCompanion/Sections/Companion.tsx
@@ -151,11 +151,18 @@ const useCompanionContent = ({
     [results]
   );
 
+  const [prevParentId, setPrevParentId] = useState(parentFormData.id);
+  if (prevParentId !== parentFormData.id) {
+    setPrevParentId(parentFormData.id);
+    if (!parentFormData.id) {
+      setResults([]);
+      setQuery('');
+    }
+  }
+
   useLayoutEffect(() => {
     const parentId = parentFormData.id;
     if (!parentId) {
-      setResults([]);
-      setQuery('');
       return;
     }
     let mounted = true;
@@ -195,10 +202,17 @@ const useCompanionContent = ({
     };
   }, []);
 
+  const [prevBreedSync, setPrevBreedSync] = useState({ type: formData.type, speciesOptions });
+  if (prevBreedSync.type !== formData.type || prevBreedSync.speciesOptions !== speciesOptions) {
+    setPrevBreedSync({ type: formData.type, speciesOptions });
+    if (!speciesOptions.some((option) => option.type === formData.type)) {
+      setBreedOptions([]);
+    }
+  }
+
   useLayoutEffect(() => {
     const selected = speciesOptions.find((option) => option.type === formData.type);
     if (!selected) {
-      setBreedOptions([]);
       return;
     }
     let mounted = true;

--- a/apps/frontend/src/app/features/companions/components/AddCompanion/Sections/Parent.tsx
+++ b/apps/frontend/src/app/features/companions/components/AddCompanion/Sections/Parent.tsx
@@ -265,10 +265,15 @@ function Parent({ setActiveLabel, formData, setFormData, ref }: ParentProps) {
     [results]
   );
 
+  const [prevQuery, setPrevQuery] = useState(query);
+  if (prevQuery !== query) {
+    setPrevQuery(query);
+    if (!query.trim()) setResults([]);
+  }
+
   useEffect(() => {
     const q = query.trim();
     if (!q) {
-      setResults([]);
       return;
     }
     const t = globalThis.setTimeout(async () => {

--- a/apps/frontend/src/app/features/companions/components/AddCompanionCentralModal/InputWithDropdown.tsx
+++ b/apps/frontend/src/app/features/companions/components/AddCompanionCentralModal/InputWithDropdown.tsx
@@ -38,7 +38,7 @@ const InputWithDropdown = ({
   const uid = useId();
   // Only auto-open after the user has typed — prevents dropdown firing when
   // edit mode mounts with a pre-filled value that matches existing companions.
-  const userHasTypedRef = useRef(false);
+  const [userHasTyped, setUserHasTyped] = useState(false);
 
   const filtered = useFilteredOptions(options, value);
 
@@ -57,7 +57,7 @@ const InputWithDropdown = ({
   const [prevFilteredLength, setPrevFilteredLength] = useState(filtered.length);
   if (filtered.length !== prevFilteredLength) {
     setPrevFilteredLength(filtered.length);
-    if (userHasTypedRef.current) {
+    if (userHasTyped) {
       setOpen(filtered.length > 0);
     }
   }
@@ -78,13 +78,18 @@ const InputWithDropdown = ({
   }, []);
 
   const computeStyleRef = useRef(computeStyle);
-  computeStyleRef.current = computeStyle;
+  useEffect(() => {
+    computeStyleRef.current = computeStyle;
+  });
+
+  const [prevOpen, setPrevOpen] = useState(open);
+  if (prevOpen !== open) {
+    setPrevOpen(open);
+    if (!open) setPortalStyle(null);
+  }
 
   useLayoutEffect(() => {
-    if (!open) {
-      setPortalStyle(null);
-      return;
-    }
+    if (!open) return;
     computeStyleRef.current();
   }, [open]);
 
@@ -138,11 +143,11 @@ const InputWithDropdown = ({
           value={value}
           autoComplete="off"
           onChange={(e) => {
-            userHasTypedRef.current = true;
+            setUserHasTyped(true);
             onChange(e.target.value);
           }}
           onFocus={() => {
-            if (userHasTypedRef.current && filtered.length > 0) setOpen(true);
+            if (userHasTyped && filtered.length > 0) setOpen(true);
           }}
           aria-invalid={Boolean(error)}
           className={`

--- a/apps/frontend/src/app/features/companions/components/AddCompanionCentralModal/index.tsx
+++ b/apps/frontend/src/app/features/companions/components/AddCompanionCentralModal/index.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useCallback, useEffect, useMemo, useReducer, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import AppointmentCentralModalShell from '@/app/features/appointments/components/AppointmentCentralModal/AppointmentCentralModalShell';
 import BottomSheet from '@/app/ui/layout/PhoneShell/BottomSheet';
@@ -329,7 +329,7 @@ const useAddCompanionCentralModalContent = ({
   const allCompanionParents = useCompanionsParentsForPrimaryOrg();
 
   // ── Edit-mode dirty tracking — snapshot of field values at the moment edit starts ──
-  const editSnapshotRef = useRef<EditSnapshot | null>(null);
+  const [editSnapshot, setEditSnapshot] = useState<EditSnapshot | null>(null);
 
   const companionResultsRef = useRef<StoredCompanion[]>([]);
 
@@ -360,17 +360,14 @@ const useAddCompanionCentralModalContent = ({
     [clearParentSearchTimeout, setParentResults]
   );
 
-  // ── Reset on close ──
-  const resetAll = useCallback(() => {
+  // ── Reset on close — modal state resets in the render-phase sync below; the
+  // search refs are cleared here after commit (refs must not change during render). ──
+  useEffect(() => {
+    if (showModal) return;
     parentSearchQueryRef.current = '';
     clearParentSearchTimeout();
     companionResultsRef.current = [];
-    dispatchModalState({
-      type: 'reset',
-      initialMode,
-      selectedCountryCode: defaultPhoneData.selectedCode,
-    });
-  }, [clearParentSearchTimeout, defaultPhoneData.selectedCode, initialMode]);
+  }, [showModal, clearParentSearchTimeout]);
 
   const populateEditForm = useCallback(
     (source: CompanionParent) => {
@@ -384,7 +381,7 @@ const useAddCompanionCentralModalContent = ({
       const pd = findPhoneData(p.phoneNumber || '', p.address.country);
       setSelectedCountryCode(pd.selectedCode);
       setLocalPhoneNumber(pd.localNumber);
-      editSnapshotRef.current = {
+      setEditSnapshot({
         companionName: c.name ?? '',
         companionType: c.type ?? '',
         companionBreed: c.breed ?? '',
@@ -392,7 +389,7 @@ const useAddCompanionCentralModalContent = ({
         lastName: p.lastName ?? '',
         email: p.email ?? '',
         phone: pd.localNumber,
-      };
+      });
     },
     [
       setCompanionFormData,
@@ -406,7 +403,13 @@ const useAddCompanionCentralModalContent = ({
   );
 
   const syncModalOpenState = () => {
-    if (!showModal) resetAll();
+    if (!showModal) {
+      dispatchModalState({
+        type: 'reset',
+        initialMode,
+        selectedCountryCode: defaultPhoneData.selectedCode,
+      });
+    }
     if (mode !== initialMode) setMode(initialMode);
     if (pendingStatus !== null) setPendingStatus(null);
   };
@@ -414,25 +417,19 @@ const useAddCompanionCentralModalContent = ({
     if (mode === 'edit' && viewCompanion) {
       populateEditForm(viewCompanion);
     } else if (mode !== 'edit') {
-      editSnapshotRef.current = null;
+      setEditSnapshot(null);
     }
   };
-  const modalSyncRef = useRef<ModalSyncState>({ initialMode, showModal });
-  if (
-    modalSyncRef.current.initialMode !== initialMode ||
-    modalSyncRef.current.showModal !== showModal
-  ) {
-    modalSyncRef.current = { initialMode, showModal };
+  const [prevModalSync, setPrevModalSync] = useState<ModalSyncState>({ initialMode, showModal });
+  if (prevModalSync.initialMode !== initialMode || prevModalSync.showModal !== showModal) {
+    setPrevModalSync({ initialMode, showModal });
     syncModalOpenState();
   }
 
   // ── Populate edit form from viewCompanion ──
-  const prevEditSyncRef = useRef({ mode, viewCompanion });
-  if (
-    prevEditSyncRef.current.mode !== mode ||
-    prevEditSyncRef.current.viewCompanion !== viewCompanion
-  ) {
-    prevEditSyncRef.current = { mode, viewCompanion };
+  const [prevEditSync, setPrevEditSync] = useState({ mode, viewCompanion });
+  if (prevEditSync.mode !== mode || prevEditSync.viewCompanion !== viewCompanion) {
+    setPrevEditSync({ mode, viewCompanion });
     syncEditForm();
   }
 
@@ -790,12 +787,12 @@ const useAddCompanionCentralModalContent = ({
     () =>
       mode !== 'view' &&
       computeHasUnsavedChanges(
-        editSnapshotRef.current ?? EMPTY_SNAPSHOT,
+        editSnapshot ?? EMPTY_SNAPSHOT,
         companionFormData,
         parentFormData,
         localPhoneNumber
       ),
-    [mode, companionFormData, parentFormData, localPhoneNumber]
+    [mode, editSnapshot, companionFormData, parentFormData, localPhoneNumber]
   );
 
   const canCloseModal = useCallback(() => {

--- a/apps/frontend/src/app/features/companions/components/CompanionInfo.tsx
+++ b/apps/frontend/src/app/features/companions/components/CompanionInfo.tsx
@@ -87,10 +87,22 @@ const CompanionInfo = ({
     scrollRef.current?.scrollTo({ top: 0, behavior: 'auto' });
   }, [activeLabel, activeSubLabel]);
 
-  useEffect(() => {
-    if (!showModal) return;
-    selectActiveLabel(initialLabel);
-  }, [showModal, initialLabel, activeCompanion?.companion.id, selectActiveLabel]);
+  const companionId = activeCompanion?.companion.id;
+  const [prevLabelSync, setPrevLabelSync] = useState<{
+    showModal: boolean;
+    initialLabel: LabelKey;
+    companionId: string | undefined;
+    selectActiveLabel: (labelKey: LabelKey) => void;
+  } | null>(null);
+  if (
+    prevLabelSync?.showModal !== showModal ||
+    prevLabelSync?.initialLabel !== initialLabel ||
+    prevLabelSync?.companionId !== companionId ||
+    prevLabelSync?.selectActiveLabel !== selectActiveLabel
+  ) {
+    setPrevLabelSync({ showModal, initialLabel, companionId, selectActiveLabel });
+    if (showModal) selectActiveLabel(initialLabel);
+  }
 
   return (
     <Modal showModal={showModal} setShowModal={setShowModal}>

--- a/apps/frontend/src/app/features/companions/components/Sections/Companion.tsx
+++ b/apps/frontend/src/app/features/companions/components/Sections/Companion.tsx
@@ -736,11 +736,18 @@ const Companion = ({ companion, canEditCompanionStatus = false }: CompanionTypeP
     };
   }, [isEditing]);
 
+  const [prevBreedSync, setPrevBreedSync] = useState({ isEditing, type: formData.type });
+  if (prevBreedSync.isEditing !== isEditing || prevBreedSync.type !== formData.type) {
+    setPrevBreedSync({ isEditing, type: formData.type });
+    if (isEditing && !SPECIES_QUERY_BY_TYPE[formData.type]) {
+      setBreedOptions([]);
+    }
+  }
+
   useLayoutEffect(() => {
     if (!isEditing) return;
     const speciesQuery = SPECIES_QUERY_BY_TYPE[formData.type];
     if (!speciesQuery) {
-      setBreedOptions([]);
       return;
     }
     let mounted = true;

--- a/apps/frontend/src/app/features/companions/pages/Companions/Companions.tsx
+++ b/apps/frontend/src/app/features/companions/pages/Companions/Companions.tsx
@@ -99,7 +99,11 @@ const Companions = () => {
   const activeCount = useMemo(() => getActiveCount(companions), [companions]);
   const speciesCounts = useMemo(() => getSpeciesCounts(companions), [companions]);
 
-  useEffect(() => {
+  // Render-phase adjustment: keep the active companion pointing at the latest
+  // store entry whenever the companions list changes.
+  const [prevCompanions, setPrevCompanions] = useState(companions);
+  if (prevCompanions !== companions) {
+    setPrevCompanions(companions);
     setActiveCompanion((prev) => {
       if (companions.length === 0) return null;
       if (prev?.companion.id) {
@@ -108,7 +112,7 @@ const Companions = () => {
       }
       return companions[0];
     });
-  }, [companions]);
+  }
 
   // Render-phase adjustment: open the companion view when a deep link points
   // at a companion we have loaded, once per companion id.

--- a/apps/frontend/src/app/features/dashboard/hooks/useDashboardAnalytics.ts
+++ b/apps/frontend/src/app/features/dashboard/hooks/useDashboardAnalytics.ts
@@ -343,27 +343,39 @@ export const useDashboardAnalytics = (duration: DashboardDuration) => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (!primaryOrgId) {
+  // Render-phase adjustment (React's documented setState-during-render reset
+  // pattern): seed loading/cached state as soon as the org or duration changes.
+  // The sentinel forces one evaluation on the first render, matching the
+  // previous effect's mount run.
+  const cacheKey = primaryOrgId ? `${primaryOrgId}:${duration}` : null;
+  const [prevCacheKey, setPrevCacheKey] = useState<string | null>('__unsynced__');
+  if (prevCacheKey !== cacheKey) {
+    setPrevCacheKey(cacheKey);
+    if (cacheKey) {
+      const cached = analyticsCache.get(cacheKey);
+      if (cached) {
+        setData(cached.data);
+      }
+      setIsLoading(true);
+      setError(null);
+    } else {
       setData(DEFAULT_DATA);
       setIsLoading(false);
       setError(null);
+    }
+  }
+
+  useEffect(() => {
+    if (!primaryOrgId) {
       return;
     }
 
-    const cacheKey = `${primaryOrgId}:${duration}`;
-    const cached = analyticsCache.get(cacheKey);
-    if (cached) {
-      setData(cached.data);
-    }
-
+    const key = `${primaryOrgId}:${duration}`;
     let cancelled = false;
 
     (async () => {
       try {
-        setIsLoading(true);
-        setError(null);
-        const next = await loadAnalyticsData(primaryOrgId, duration, cacheKey);
+        const next = await loadAnalyticsData(primaryOrgId, duration, key);
         if (!cancelled) {
           setData(next);
         }

--- a/apps/frontend/src/app/features/documents/components/CompanionRecordRow.tsx
+++ b/apps/frontend/src/app/features/documents/components/CompanionRecordRow.tsx
@@ -41,7 +41,6 @@ const STATUS_PILL_TOKENS: Record<RecordStatusTone, StatusPillTokens> = {
  */
 const CompanionRecordRow = ({ doc, onOpen }: CompanionRecordRowProps) => {
   const title = doc.title || 'Untitled document';
-  const Icon = getRecordIcon(doc);
   const source = getDocumentSource(doc);
   const subcategoryLabel = getCompanionDocumentSubcategoryLabel(doc.subcategory);
   const attachmentSummary = getAttachmentSummary(doc);
@@ -59,7 +58,7 @@ const CompanionRecordRow = ({ doc, onOpen }: CompanionRecordRowProps) => {
         aria-hidden="true"
         className="grid size-[38px] flex-none place-items-center rounded-xl bg-[var(--blue-soft)] text-[var(--blue-text)]"
       >
-        <Icon size={17} />
+        {React.createElement(getRecordIcon(doc), { size: 17 })}
       </span>
       <span className="flex min-w-0 flex-1 flex-col gap-0.5">
         <span className="truncate text-[13.5px] font-bold text-[var(--ink)]">{title}</span>

--- a/apps/frontend/src/app/features/finance/hooks/useOrganisationDiscountCap.ts
+++ b/apps/frontend/src/app/features/finance/hooks/useOrganisationDiscountCap.ts
@@ -29,18 +29,25 @@ export const useOrganisationDiscountCap = (organisationId?: string): Organisatio
   const [error, setError] = useState<string | null>(null);
   const [reloadToken, setReloadToken] = useState(0);
 
-  useEffect(() => {
-    if (!organisationId) {
+  // Render-phase adjustment: reset for each (re)load so a previous organisation's
+  // cap is not retained across an org switch, and a failed lookup leaves no stale
+  // cap - matching this hook's documented "null while loading and on failure".
+  const loadKey = `${organisationId ?? ''}|${reloadToken}`;
+  const [prevLoadKey, setPrevLoadKey] = useState(loadKey);
+  if (prevLoadKey !== loadKey) {
+    setPrevLoadKey(loadKey);
+    if (organisationId) {
+      setLoading(true);
+      setError(null);
+      setMaxOverallDiscountPercent(null);
+    } else {
       setLoading(false);
-      return undefined;
     }
+  }
+
+  useEffect(() => {
+    if (!organisationId) return undefined;
     let active = true;
-    setLoading(true);
-    setError(null);
-    // Start every (re)load unconstrained so a previous organisation's cap is not
-    // retained across an org switch, and a failed lookup leaves no stale cap -
-    // matching this hook's documented "null while loading and on failure".
-    setMaxOverallDiscountPercent(null);
     getOrganisationDiscountSettings(organisationId)
       .then((settings) => {
         if (!active) return;

--- a/apps/frontend/src/app/features/finance/pages/Discounts/index.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Discounts/index.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { Suspense, useEffect, useState } from 'react';
+import React, { Suspense, useState } from 'react';
 import { IoInformationCircleOutline } from 'react-icons/io5';
 import ProtectedRoute from '@/app/ui/layout/guards/ProtectedRoute';
 import OrgGuard from '@/app/ui/layout/guards/OrgGuard';
@@ -56,9 +56,12 @@ const DiscountsContent = () => {
 
   // Re-sync the field whenever the loaded/saved cap changes so the input always
   // reflects server truth. Keyed on the cap value, so a local edit is not clobbered.
-  useEffect(() => {
-    if (!loading) setCapInput(capToInput(maxOverallDiscountPercent));
-  }, [loading, maxOverallDiscountPercent]);
+  const syncedCap = loading ? null : capToInput(maxOverallDiscountPercent);
+  const [prevSyncedCap, setPrevSyncedCap] = useState(syncedCap);
+  if (prevSyncedCap !== syncedCap) {
+    setPrevSyncedCap(syncedCap);
+    if (syncedCap !== null) setCapInput(syncedCap);
+  }
 
   const handleSave = async () => {
     if (!primaryOrgId) return;

--- a/apps/frontend/src/app/features/finance/pages/Finance/index.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/index.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { Suspense, useEffect, useMemo, useRef, useState } from 'react';
+import React, { Suspense, useMemo, useState } from 'react';
 import dynamic from 'next/dynamic';
 import { useSearchParams } from 'next/navigation';
 import ProtectedRoute from '@/app/ui/layout/guards/ProtectedRoute';
@@ -47,7 +47,7 @@ const Finance = () => {
   const currency = useCurrencyForPrimaryOrg();
   const query = useSearchStore((s) => s.query);
   const searchParams = useSearchParams();
-  const handledDeepLinkRef = useRef<string | null>(null);
+  const [handledDeepLink, setHandledDeepLink] = useState<string | null>(null);
   const [activeStatus, setActiveStatus] = useState('all');
   const [viewInvoice, setViewInvoice] = useState(false);
   const [activeInvoice, setActiveInvoice] = useState<Invoice | null>(invoices[0] || null);
@@ -59,7 +59,9 @@ const Finance = () => {
     setViewInvoice(true);
   };
 
-  useEffect(() => {
+  const [prevInvoices, setPrevInvoices] = useState(invoices);
+  if (prevInvoices !== invoices) {
+    setPrevInvoices(invoices);
     setActiveInvoice((prev) => {
       if (invoices.length === 0) return null;
       if (prev?.id) {
@@ -68,20 +70,18 @@ const Finance = () => {
       }
       return invoices[0];
     });
-  }, [invoices]);
+  }
 
-  useEffect(() => {
-    const invoiceId = String(searchParams.get('invoiceId') ?? '').trim();
-    if (!invoiceId) return;
-    if (handledDeepLinkRef.current === invoiceId) return;
-
-    const target = invoices.find((invoice) => invoice.id === invoiceId);
-    if (!target) return;
-
-    setActiveInvoice(target);
+  const deepLinkInvoiceId = String(searchParams.get('invoiceId') ?? '').trim();
+  const deepLinkTarget =
+    deepLinkInvoiceId && handledDeepLink !== deepLinkInvoiceId
+      ? invoices.find((invoice) => invoice.id === deepLinkInvoiceId)
+      : undefined;
+  if (deepLinkTarget) {
+    setHandledDeepLink(deepLinkInvoiceId);
+    setActiveInvoice(deepLinkTarget);
     setViewInvoice(true);
-    handledDeepLinkRef.current = invoiceId;
-  }, [invoices, searchParams]);
+  }
 
   const filteredList = useMemo(() => {
     const q = query.trim().toLowerCase();

--- a/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/Build.tsx
+++ b/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/Build.tsx
@@ -390,7 +390,9 @@ const addMedicationToTreatmentPlan = (schema: FormField[], medicationField: Form
 
 const useOutsideClick = (ref: React.RefObject<HTMLElement | null>, onClose: () => void) => {
   const onCloseRef = useRef(onClose);
-  onCloseRef.current = onClose;
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  });
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -782,9 +784,16 @@ const MedicationGroupBuilder: React.FC<MedicationGroupBuilderProps> = ({ field, 
   );
   const selectedMedicineSet = React.useMemo(() => new Set(selectedMedicines), [selectedMedicines]);
 
+  // Flip the loading flag as soon as the org context (re)arrives — render-time
+  // adjust so the fetch effect only talks to the external inventory service.
+  const [prevMedicinesOrgId, setPrevMedicinesOrgId] = useState<string | null>(null);
+  if (prevMedicinesOrgId !== primaryOrgId) {
+    setPrevMedicinesOrgId(primaryOrgId);
+    if (primaryOrgId) setLoadingMedicines(true);
+  }
+
   useEffect(() => {
     if (!primaryOrgId) return;
-    setLoadingMedicines(true);
     fetchInventoryItems(primaryOrgId)
       .then((items) => setMedicines(items.filter(isMedicineInventoryItem)))
       .catch((err) => console.error('Failed to load medicines:', err))

--- a/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/Review.tsx
+++ b/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/Review.tsx
@@ -7,7 +7,7 @@ import {
   FormsUsageOptions,
   getFormCategoryDisplayLabel,
 } from '@/app/features/forms/types/forms';
-import React, { useRef } from 'react';
+import React from 'react';
 import FormRenderer from '@/app/features/forms/pages/Forms/Sections/AddForm/components/FormRenderer';
 import { useOrgStore } from '@/app/stores/orgStore';
 import { Organisation } from '@yosemite-crew/types';
@@ -85,9 +85,9 @@ const Review = ({
     buildInitialValues(formData.schema ?? [])
   );
   const schemaKey = JSON.stringify(formData.schema ?? []);
-  const prevSchemaKeyRef = useRef(schemaKey);
-  if (prevSchemaKeyRef.current !== schemaKey) {
-    prevSchemaKeyRef.current = schemaKey;
+  const [prevSchemaKey, setPrevSchemaKey] = React.useState(schemaKey);
+  if (prevSchemaKey !== schemaKey) {
+    setPrevSchemaKey(schemaKey);
     setValues(buildInitialValues(formData.schema ?? []));
   }
 

--- a/apps/frontend/src/app/features/forms/pages/Forms/index.tsx
+++ b/apps/frontend/src/app/features/forms/pages/Forms/index.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { Suspense, useEffect, useMemo, useRef, useState } from 'react';
+import React, { Suspense, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import dynamic from 'next/dynamic';
 import { useSearchParams } from 'next/navigation';
 import ProtectedRoute from '@/app/ui/layout/guards/ProtectedRoute';
@@ -86,7 +86,7 @@ const Forms = () => {
   const { formsById, formIds, activeFormId, loading } = formsStore;
   const headerSearchQuery = useSearchStore((s) => s.query);
   const searchParams = useSearchParams();
-  const handledDeepLinkRef = useRef<string | null>(null);
+  const [handledDeepLink, setHandledDeepLink] = useState<string | null>(null);
   const [filters, setFilters] = useState<FormsFilterState>({ status: 'All', category: 'All' });
   const [addPopup, setAddPopup] = useState(false);
   const [viewPopup, setViewPopup] = useState(false);
@@ -212,18 +212,22 @@ const Forms = () => {
     }
   }, [activeFormId, filteredList]);
 
-  useEffect(() => {
-    const formId = String(searchParams.get('formId') ?? '').trim();
-    if (!formId) return;
-    if (handledDeepLinkRef.current === formId) return;
-
-    const target = list.find((form) => form?._id === formId);
-    if (!target?._id) return;
-
-    useFormsStore.getState().setActiveForm(target._id);
+  // Deep link: open the info modal once per formId in the URL. The render-time
+  // adjust owns the local popup state; the layout effect mirrors the handled id
+  // into the forms store before paint so both land in the same frame.
+  const deepLinkFormId = String(searchParams.get('formId') ?? '').trim();
+  if (
+    deepLinkFormId &&
+    handledDeepLink !== deepLinkFormId &&
+    list.some((form) => form?._id === deepLinkFormId)
+  ) {
+    setHandledDeepLink(deepLinkFormId);
     setViewPopup(true);
-    handledDeepLinkRef.current = formId;
-  }, [list, searchParams]);
+  }
+
+  useLayoutEffect(() => {
+    if (handledDeepLink) useFormsStore.getState().setActiveForm(handledDeepLink);
+  }, [handledDeepLink]);
 
   const openAddForm = () => {
     setEditingForm(null);

--- a/apps/frontend/src/app/features/integrations/pages/IdexxWorkspace/index.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/IdexxWorkspace/index.tsx
@@ -1179,7 +1179,9 @@ const useIdexxWorkspaceActions = (s: IdexxWorkspaceActionsState) => {
   // Keep a stable ref to the latest state object so callbacks never need `s`
   // in their dep arrays (which would cause a new ref every render → infinite loop).
   const sRef = React.useRef(s);
-  sRef.current = s;
+  useEffect(() => {
+    sRef.current = s;
+  });
 
   const refresh = useCallback(async () => {
     const { primaryOrgId: orgId, integrationEnabled: enabled } = sRef.current;
@@ -1210,38 +1212,44 @@ const useIdexxWorkspaceActions = (s: IdexxWorkspaceActionsState) => {
     }
   }, []);
 
-  const getAppointmentLabsHref = useCallback((result: LabResult) => {
-    const { appointmentIdByOrderId: lookup } = sRef.current;
-    const raw = result.rawPayload as
-      | {
-          orderId?: string | number;
-          requisitionId?: string | number;
-          accessionId?: string | number;
-          alternateOrderId?: string | number;
-          alternateRequisitionId?: string | number;
-        }
-      | undefined;
-    const lookupIds = [
-      result.orderId,
-      result.requisitionId,
-      result.accessionId,
-      raw?.orderId,
-      raw?.requisitionId,
-      raw?.accessionId,
-      raw?.alternateOrderId,
-      raw?.alternateRequisitionId,
-    ]
-      .map((value) => String(value ?? '').trim())
-      .filter(Boolean);
-    const matchedOrderIdentifier = lookupIds.find((id) => lookup[id]) ?? '';
-    if (!matchedOrderIdentifier) return '';
-    const params = new URLSearchParams({
-      appointmentId: lookup[matchedOrderIdentifier],
-      open: 'labs',
-      subLabel: 'idexx-labs',
-    });
-    return `/appointments?${params.toString()}`;
-  }, []);
+  // Unlike the async actions below, this is called during render (to build row
+  // hrefs), so it must read the lookup from the current render, not the ref.
+  const { appointmentIdByOrderId } = s;
+  const getAppointmentLabsHref = useCallback(
+    (result: LabResult) => {
+      const lookup = appointmentIdByOrderId;
+      const raw = result.rawPayload as
+        | {
+            orderId?: string | number;
+            requisitionId?: string | number;
+            accessionId?: string | number;
+            alternateOrderId?: string | number;
+            alternateRequisitionId?: string | number;
+          }
+        | undefined;
+      const lookupIds = [
+        result.orderId,
+        result.requisitionId,
+        result.accessionId,
+        raw?.orderId,
+        raw?.requisitionId,
+        raw?.accessionId,
+        raw?.alternateOrderId,
+        raw?.alternateRequisitionId,
+      ]
+        .map((value) => String(value ?? '').trim())
+        .filter(Boolean);
+      const matchedOrderIdentifier = lookupIds.find((id) => lookup[id]) ?? '';
+      if (!matchedOrderIdentifier) return '';
+      const params = new URLSearchParams({
+        appointmentId: lookup[matchedOrderIdentifier],
+        open: 'labs',
+        subLabel: 'idexx-labs',
+      });
+      return `/appointments?${params.toString()}`;
+    },
+    [appointmentIdByOrderId]
+  );
 
   const handleLookupOrder = useCallback(async () => {
     const { primaryOrgId: orgId, orderLookupId: lookupId } = sRef.current;

--- a/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
@@ -506,7 +506,9 @@ const useIntegrationsPage = () => {
   const [merckSaving, setMerckSaving] = useState(false);
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
-  const [validateState, setValidateState] = useState<ValidateState>('idle');
+  const [validateState, setValidateState] = useState<ValidateState>(() =>
+    resolveValidateState(idexxIntegration?.credentialsStatus)
+  );
   const [activeFilter, setActiveFilter] = useState<IntegrationFilterKey>('all');
   const [error, setError] = useState<string | null>(null);
 
@@ -553,9 +555,15 @@ const useIntegrationsPage = () => {
     run().catch(() => undefined);
   }, [primaryOrgId, idexxIntegration?.status, canViewLabs]);
 
-  useEffect(() => {
+  // Render-phase adjustment: follow the stored credentials status whenever it
+  // changes without clobbering later local validate-state updates.
+  const [syncedCredentialsStatus, setSyncedCredentialsStatus] = useState(
+    idexxIntegration?.credentialsStatus
+  );
+  if (idexxIntegration?.credentialsStatus !== syncedCredentialsStatus) {
+    setSyncedCredentialsStatus(idexxIntegration?.credentialsStatus);
     setValidateState(resolveValidateState(idexxIntegration?.credentialsStatus));
-  }, [idexxIntegration?.credentialsStatus]);
+  }
 
   const { handleManualRefresh, handleStoreCredentials, handleValidate, handleEnableDisable } =
     useIdexxActions({

--- a/apps/frontend/src/app/features/inventory/components/InventoryInfo.tsx
+++ b/apps/frontend/src/app/features/inventory/components/InventoryInfo.tsx
@@ -693,8 +693,16 @@ const InventoryInfo = ({
   // one of those keys, so the lookup always hits.
   const currentLabelConfig = modalSections.find((l) => l.key === activeLabel)!;
 
-  useLayoutEffect(() => {
+  // Leave edit mode whenever the section or item changes — adjusted during render
+  // via a prev-compare (same pattern as the tab reset above); the imperative
+  // section/batch handles are cleared after commit since refs stay off-render.
+  const sectionResetKey = `${activeLabel}:${activeInventory?.id ?? ''}`;
+  const [prevSectionResetKey, setPrevSectionResetKey] = useState(sectionResetKey);
+  if (sectionResetKey !== prevSectionResetKey) {
+    setPrevSectionResetKey(sectionResetKey);
     setIsSectionEditing(false);
+  }
+  useLayoutEffect(() => {
     sectionActions.current = null;
     batchActions.current = null;
   }, [activeLabel, activeInventory?.id]);

--- a/apps/frontend/src/app/features/inventory/pages/Inventory/index.tsx
+++ b/apps/frontend/src/app/features/inventory/pages/Inventory/index.tsx
@@ -722,9 +722,9 @@ const resolveActiveInventory = (
 // its previous value — the null-sentinel derived-state pattern factored out so
 // each call site stays a single statement rather than an inline prev-compare.
 const useOnValueChange = <T,>(value: T, onChange: () => void): void => {
-  const prevRef = useRef<{ value: T }>(undefined);
-  if (prevRef.current?.value !== value) {
-    prevRef.current = { value };
+  const [prev, setPrev] = useState<{ value: T } | undefined>(undefined);
+  if (prev?.value !== value) {
+    setPrev({ value });
     onChange();
   }
 };
@@ -743,7 +743,7 @@ const useInventoryContent = () => {
   const rooms = useRoomsForPrimaryOrg();
   const headerSearchQuery = useSearchStore((s) => s.query);
   const searchParams = useSearchParams();
-  const handledDeepLinkRef = useRef<string | null>(null);
+  const [handledDeepLinkId, setHandledDeepLinkId] = useState<string | null>(null);
 
   const resolvedOrgType = primaryOrgId ? orgsById[primaryOrgId]?.type : undefined;
   const resolvedBusinessType: BusinessType =
@@ -759,27 +759,34 @@ const useInventoryContent = () => {
   const [filters, setFilters] = useState<InventoryFiltersState>(defaultFilters);
   const [dispensaryRecords, setDispensaryRecords] = useState<DispensaryRecord[]>([]);
 
-  const fetchDispensaryRecords = useCallback(async () => {
-    if (!primaryOrgId || !canViewPrescription) return;
-    const orgAtCallTime = primaryOrgId;
+  // Pure fetch (null = leave current state alone) so the refresh effect can apply
+  // the result in a subscription-style callback.
+  const resolveDispensaryRecords = useCallback(async (): Promise<DispensaryRecord[] | null> => {
+    if (!primaryOrgId || !canViewPrescription) return null;
     try {
-      const data = await listDispenseRequests(orgAtCallTime);
-      setDispensaryRecords((prev) => {
-        if (primaryOrgId === orgAtCallTime) {
-          return data.map(mapDispenseRequestToRecord);
-        }
-        /* v8 ignore next -- primaryOrgId and orgAtCallTime capture the same closure value, so this fallback is unreachable */
-        return prev;
-      });
+      const data = await listDispenseRequests(primaryOrgId);
+      return data.map(mapDispenseRequestToRecord);
     } catch {
       // silently fail — table shows empty state
+      return null;
     }
   }, [primaryOrgId, canViewPrescription]);
 
-  useEffect(() => {
+  const fetchDispensaryRecords = useCallback(async () => {
+    const records = await resolveDispensaryRecords();
+    if (records) setDispensaryRecords(records);
+  }, [resolveDispensaryRecords]);
+
+  // Org/permission changed: drop the previous org's rows during render, then
+  // refetch after commit.
+  useOnValueChange(resolveDispensaryRecords, () => {
     setDispensaryRecords([]);
-    fetchDispensaryRecords();
-  }, [fetchDispensaryRecords]);
+  });
+  useEffect(() => {
+    void resolveDispensaryRecords().then((records) => {
+      if (records) setDispensaryRecords(records);
+    });
+  }, [resolveDispensaryRecords]);
   const [activeDispensaryRecord, setActiveDispensaryRecord] = useState<DispensaryRecord | null>(
     null
   );
@@ -923,11 +930,11 @@ const useInventoryContent = () => {
 
   const deepLinkedInventoryId = String(searchParams.get('inventoryId') ?? '').trim();
   const deepLinkTarget =
-    deepLinkedInventoryId && handledDeepLinkRef.current !== deepLinkedInventoryId
+    deepLinkedInventoryId && handledDeepLinkId !== deepLinkedInventoryId
       ? inventory.find((item) => item.id === deepLinkedInventoryId)
       : undefined;
   if (deepLinkTarget !== undefined) {
-    handledDeepLinkRef.current = deepLinkedInventoryId;
+    setHandledDeepLinkId(deepLinkedInventoryId);
     setActiveInventory(deepLinkTarget);
     setViewInventory(true);
     setInfoInitialSection(undefined);

--- a/apps/frontend/src/app/features/marketing/site/motion.tsx
+++ b/apps/frontend/src/app/features/marketing/site/motion.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import React, {
-  useCallback,
   useEffect,
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
   type CSSProperties,
   type ReactNode,
 } from 'react';
@@ -356,15 +356,7 @@ export function CountUp({ value, className, style }: Readonly<CountUpProps>) {
   }, []);
 
   useEffect(() => {
-    if (target === null) {
-      setDisplay(value);
-      return undefined;
-    }
-    if (!inView) return undefined;
-    if (reduced) {
-      setDisplay(target.toLocaleString('en-US') + suffix);
-      return undefined;
-    }
+    if (target === null || !inView || reduced) return undefined;
     const duration = 1500;
     const start = performance.now();
     let frame = 0;
@@ -377,6 +369,13 @@ export function CountUp({ value, className, style }: Readonly<CountUpProps>) {
     frame = requestAnimationFrame(step);
     return () => cancelAnimationFrame(frame);
   }, [inView, reduced, target, suffix, value]);
+
+  // Non-numeric text renders verbatim; under reduced motion the final value shows
+  // as soon as the element is in view (no count-up); otherwise the rAF loop above
+  // drives the animating `display` state.
+  let shown = display;
+  if (target === null) shown = value;
+  else if (reduced && inView) shown = target.toLocaleString('en-US') + suffix;
 
   // Reserve the final value's width (invisible sizer) and overlay the animating
   // value, with tabular-nums for equal-width digits. Otherwise the number's
@@ -397,26 +396,24 @@ export function CountUp({ value, className, style }: Readonly<CountUpProps>) {
       <span aria-hidden="true" style={{ visibility: 'hidden' }}>
         {value}
       </span>
-      <span style={{ position: 'absolute', left: 0, top: 0 }}>{display}</span>
+      <span style={{ position: 'absolute', left: 0, top: 0 }}>{shown}</span>
     </span>
   );
 }
 
+/** Subscribe a scroll-position read to window scroll events (for useSyncExternalStore). */
+const subscribeToWindowScroll = (onStoreChange: () => void): (() => void) => {
+  globalThis.window.addEventListener('scroll', onStoreChange, { passive: true });
+  return () => globalThis.window.removeEventListener('scroll', onStoreChange);
+};
+
 /** Tracks whether the page has scrolled past the top, for nav glass elevation. */
 export function useScrolled(threshold = 8): boolean {
-  const [scrolled, setScrolled] = useState(false);
-  const onScroll = useCallback(
-    () => setScrolled(globalThis.window.scrollY > threshold),
-    [threshold]
+  return useSyncExternalStore(
+    subscribeToWindowScroll,
+    () => globalThis.window.scrollY > threshold,
+    () => false
   );
-
-  useEffect(() => {
-    globalThis.window.addEventListener('scroll', onScroll, { passive: true });
-    onScroll();
-    return () => globalThis.window.removeEventListener('scroll', onScroll);
-  }, [onScroll]);
-
-  return scrolled;
 }
 
 /**

--- a/apps/frontend/src/app/features/marketing/site/useGithubStats.ts
+++ b/apps/frontend/src/app/features/marketing/site/useGithubStats.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useSyncExternalStore } from 'react';
 import {
   getJsonStorageItem,
   getStorageItem,
@@ -31,6 +31,51 @@ const EMPTY_STATS: GithubStats = {
   contributors: null,
   discord: null,
 };
+
+/**
+ * Session-cache subscription for useSyncExternalStore. The session cache is the
+ * external store the cached (non-live) hooks render from: the effects below refresh
+ * it over the network, every write emits, and each subscribed instance re-reads.
+ * Snapshots are memoized on the raw JSON so getSnapshot returns a stable reference
+ * until the underlying entry actually changes.
+ */
+const cacheListeners = new Set<() => void>();
+
+const subscribeToSessionCache = (onStoreChange: () => void): (() => void) => {
+  cacheListeners.add(onStoreChange);
+  return () => {
+    cacheListeners.delete(onStoreChange);
+  };
+};
+
+const emitSessionCacheChange = (): void => {
+  for (const listener of cacheListeners) listener();
+};
+
+const parseJson = <T>(raw: string | null): T | null => {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+};
+
+let statsSnapshotRaw: string | null = null;
+let statsSnapshot: GithubStats = EMPTY_STATS;
+
+const getStatsSnapshot = (): GithubStats => {
+  const raw = getStorageItem('session', STATS_CACHE_KEY);
+  if (raw !== statsSnapshotRaw) {
+    statsSnapshotRaw = raw;
+    const cached = parseJson<Partial<GithubStats>>(raw);
+    statsSnapshot = cached ? { ...EMPTY_STATS, ...cached } : EMPTY_STATS;
+  }
+  return statsSnapshot;
+};
+
+/** SSR (and the hydrating first client render) always shows the loading placeholders. */
+const getServerStats = (): GithubStats => EMPTY_STATS;
 const REPO_STATS_SUMMARY =
   'https://raw.githubusercontent.com/YosemiteCrew/Yosemite-Crew/github-repo-stats/YosemiteCrew/Yosemite-Crew/latest-report/summary.json';
 // Same-origin route handler, not the product API: see the comment on that route
@@ -134,6 +179,7 @@ const runGithubStatsFetch = async (): Promise<Partial<GithubStats>> => {
   const cached = getJsonStorageItem<Partial<GithubStats>>('session', STATS_CACHE_KEY) ?? {};
   setJsonStorageItem('session', STATS_CACHE_KEY, { ...EMPTY_STATS, ...cached, ...fresh });
   setStorageItem('session', STATS_TS_KEY, String(Date.now()));
+  emitSessionCacheChange();
   return fresh;
 };
 
@@ -172,18 +218,21 @@ export interface LiveFetchOptions {
  */
 export function useGithubStats(options?: LiveFetchOptions): GithubStats {
   const live = options?.live ?? false;
-  const [stats, setStats] = useState<GithubStats>(EMPTY_STATS);
+  // Cached consumers render straight from the session cache (the external store):
+  // the server snapshot and the hydrating first paint are both the empty
+  // placeholders, so there is no hydration mismatch, and the cached value appears
+  // once hydration completes. Refreshes rewrite the cache, which emits.
+  const cachedStats = useSyncExternalStore(
+    subscribeToSessionCache,
+    getStatsSnapshot,
+    getServerStats
+  );
+  // Live mode never paints the cache under the "no cache" copy, so it keeps its
+  // own state fed exclusively from this-pass fetch results.
+  const [liveStats, setLiveStats] = useState<GithubStats>(EMPTY_STATS);
 
   useEffect(() => {
     let active = true;
-    // Seed from the session cache after mount, not in the useState initializer:
-    // reading storage during render makes the client's first paint diverge from the
-    // server HTML (which has no storage) and triggers a hydration mismatch. Live
-    // mode skips the seed so a stale value is never painted under the "no cache" copy.
-    if (!live) {
-      const cached = getJsonStorageItem<Partial<GithubStats>>('session', STATS_CACHE_KEY);
-      if (cached) setStats({ ...EMPTY_STATS, ...cached });
-    }
     const cached = getJsonStorageItem<Partial<GithubStats>>('session', STATS_CACHE_KEY);
     const needsDiscordRefresh = typeof cached?.discord !== 'string';
     if (live || !isStatsCacheFresh() || needsDiscordRefresh) {
@@ -192,8 +241,8 @@ export function useGithubStats(options?: LiveFetchOptions): GithubStats {
         if (!active) return;
         // Live: publish ONLY this-pass fields, so a failed fetcher stays as the
         // loading placeholder rather than a stale cached value under the "no cache"
-        // copy. Cached: keep last-known values for any field this pass did not return.
-        setStats((prev) => (live ? { ...EMPTY_STATS, ...fresh } : { ...prev, ...fresh }));
+        // copy. Cached consumers pick up the merged refresh via the cache emit.
+        if (live) setLiveStats({ ...EMPTY_STATS, ...fresh });
       })();
     }
     return () => {
@@ -201,7 +250,7 @@ export function useGithubStats(options?: LiveFetchOptions): GithubStats {
     };
   }, [live]);
 
-  return stats;
+  return live ? liveStats : cachedStats;
 }
 
 export interface ReleaseInfo {
@@ -213,6 +262,21 @@ export interface ReleaseInfo {
 }
 
 const EMPTY_RELEASE: ReleaseInfo = { tag: null, date: null, url: null };
+
+// Raw-string-memoized release snapshots per cache key (same contract as getStatsSnapshot).
+const releaseSnapshots = new Map<string, { raw: string | null; value: ReleaseInfo }>();
+
+const getReleaseSnapshot = (cacheKey: string): ReleaseInfo => {
+  const raw = getStorageItem('session', cacheKey);
+  const memo = releaseSnapshots.get(cacheKey);
+  if (memo && memo.raw === raw) return memo.value;
+  const value = parseJson<ReleaseInfo>(raw) ?? EMPTY_RELEASE;
+  releaseSnapshots.set(cacheKey, { raw, value });
+  return value;
+};
+
+/** SSR (and the hydrating first client render) always shows the loading placeholder. */
+const getServerRelease = (): ReleaseInfo => EMPTY_RELEASE;
 
 const formatReleaseDate = (iso?: string): string | null => {
   if (!iso) return null;
@@ -255,12 +319,17 @@ const useTaggedReleaseFromList = (
   cacheKey: string,
   matchesTag: (tag: string) => boolean
 ): ReleaseInfo => {
-  const [release, setRelease] = useState<ReleaseInfo>(EMPTY_RELEASE);
+  // Rendered straight from the session cache (the external store): the cached seed
+  // appears once hydration completes, and the refresh below rewrites the cache,
+  // which emits to every subscribed instance.
+  const release = useSyncExternalStore(
+    subscribeToSessionCache,
+    () => getReleaseSnapshot(cacheKey),
+    getServerRelease
+  );
 
   useEffect(() => {
     let active = true;
-    const cached = getJsonStorageItem<ReleaseInfo>('session', cacheKey);
-    if (cached) setRelease(cached);
     void (async () => {
       const list = (await fetchJson(
         `${GITHUB_API_REPO}/releases?per_page=30`,
@@ -269,9 +338,8 @@ const useTaggedReleaseFromList = (
       if (!active || !Array.isArray(list)) return;
       const match = list.find((entry) => matchesTag((entry.tag_name ?? '').toLowerCase()));
       if (!match?.html_url) return;
-      const next = toReleaseInfo(match);
-      setRelease(next);
-      setJsonStorageItem('session', cacheKey, next);
+      setJsonStorageItem('session', cacheKey, toReleaseInfo(match));
+      emitSessionCacheChange();
     })();
     return () => {
       active = false;
@@ -291,14 +359,17 @@ const useTaggedReleaseFromList = (
 export function useLatestRelease(options?: LiveFetchOptions): ReleaseInfo {
   const live = options?.live ?? false;
   const cacheKey = 'yc_rel_platform_v1';
-  const [release, setRelease] = useState<ReleaseInfo>(EMPTY_RELEASE);
+  // Cached consumers render straight from the session cache (see useTaggedReleaseFromList);
+  // live mode never paints the cache, so it keeps its own fetch-fed state.
+  const cachedRelease = useSyncExternalStore(
+    subscribeToSessionCache,
+    () => getReleaseSnapshot(cacheKey),
+    getServerRelease
+  );
+  const [liveRelease, setLiveRelease] = useState<ReleaseInfo>(EMPTY_RELEASE);
 
   useEffect(() => {
     let active = true;
-    if (!live) {
-      const cached = getJsonStorageItem<ReleaseInfo>('session', cacheKey);
-      if (cached) setRelease(cached);
-    }
     void (async () => {
       const json = (await fetchJson(
         `${GITHUB_API_REPO}/releases/latest`,
@@ -306,15 +377,16 @@ export function useLatestRelease(options?: LiveFetchOptions): ReleaseInfo {
       )) as RawRelease | null;
       if (!active || !json?.tag_name) return;
       const next = toReleaseInfo(json);
-      setRelease(next);
+      setLiveRelease(next);
       setJsonStorageItem('session', cacheKey, next);
+      emitSessionCacheChange();
     })();
     return () => {
       active = false;
     };
   }, [live]);
 
-  return release;
+  return live ? liveRelease : cachedRelease;
 }
 
 /**

--- a/apps/frontend/src/app/features/marketing/site/useTheme.ts
+++ b/apps/frontend/src/app/features/marketing/site/useTheme.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useSyncExternalStore } from 'react';
 
 export type Theme = 'light' | 'dark';
 
@@ -42,17 +42,26 @@ const applyTheme = (theme: Theme, persist: boolean) => {
   globalThis.dispatchEvent(new CustomEvent(THEME_CHANGE_EVENT, { detail: { theme } }));
 };
 
+/** Re-read the theme whenever any toggle instance broadcasts a flip (for useSyncExternalStore). */
+const subscribeToThemeChange = (onStoreChange: () => void): (() => void) => {
+  globalThis.addEventListener(THEME_CHANGE_EVENT, onStoreChange);
+  return () => globalThis.removeEventListener(THEME_CHANGE_EVENT, onStoreChange);
+};
+
+/** SSR always renders light; the client re-reads <html data-theme> on hydration. */
+const getServerTheme = (): Theme => 'light';
+
 /**
  * Light/dark theme controller for the marketing surface. The source of truth is the
- * `data-theme` attribute on <html> (set pre-paint in the root layout). This hook mirrors
- * it into React state for the toggle icon, follows OS changes while no explicit choice is
- * stored, and enables the flip transition shortly after first paint.
+ * `data-theme` attribute on <html> (set pre-paint in the root layout). This hook reads
+ * it for the toggle icon (every applyTheme dispatches the shared change event, keeping
+ * all instances in sync), follows OS changes while no explicit choice is stored, and
+ * enables the flip transition shortly after first paint.
  */
 export function useTheme() {
-  const [theme, setTheme] = useState<Theme>('light');
+  const theme = useSyncExternalStore(subscribeToThemeChange, readTheme, getServerTheme);
 
   useEffect(() => {
-    setTheme(readTheme());
     syncMetaThemeColor();
 
     // Enable the flip transition after first paint so the initial paint never animates.
@@ -60,14 +69,8 @@ export function useTheme() {
       globalThis.document.documentElement.dataset.themeReady = '1';
     }, 60);
 
-    // Keep every toggle instance's icon in sync when any of them flips the theme.
-    const onThemeChange = (event: Event) => {
-      const next = (event as CustomEvent<{ theme: Theme }>).detail?.theme ?? readTheme();
-      setTheme(next);
-    };
-    globalThis.addEventListener(THEME_CHANGE_EVENT, onThemeChange);
-
     // Follow OS changes only while the visitor hasn't explicitly chosen a theme.
+    // applyTheme broadcasts the change event, so every subscribed instance re-reads.
     const mq = globalThis.matchMedia?.('(prefers-color-scheme: dark)');
     const onOSChange = (event: MediaQueryListEvent) => {
       let saved: string | null = null;
@@ -78,14 +81,12 @@ export function useTheme() {
       }
       if (!saved) {
         applyTheme(event.matches ? 'dark' : 'light', false);
-        setTheme(event.matches ? 'dark' : 'light');
       }
     };
     mq?.addEventListener('change', onOSChange);
 
     return () => {
       globalThis.clearTimeout(readyTimer);
-      globalThis.removeEventListener(THEME_CHANGE_EVENT, onThemeChange);
       mq?.removeEventListener('change', onOSChange);
     };
   }, []);
@@ -93,7 +94,6 @@ export function useTheme() {
   const toggle = useCallback(() => {
     const next: Theme = readTheme() === 'dark' ? 'light' : 'dark';
     applyTheme(next, true);
-    setTheme(next);
   }, []);
 
   return { theme, toggle };

--- a/apps/frontend/src/app/features/onboarding/components/Steps/CreateOrg/AddressStep.tsx
+++ b/apps/frontend/src/app/features/onboarding/components/Steps/CreateOrg/AddressStep.tsx
@@ -45,12 +45,15 @@ const AddressStep = ({
     postalCode?: string;
   }>({});
 
-  React.useEffect(() => {
-    if (!errors) {
-      return;
+  // Sync parent-provided errors into local state during render, guarded by the
+  // previous prop so local edits from handleNext are not clobbered.
+  const [prevErrors, setPrevErrors] = useState<typeof errors | null>(null);
+  if (prevErrors !== errors) {
+    setPrevErrors(errors);
+    if (errors) {
+      setFormDataErrors(errors);
     }
-    setFormDataErrors(errors);
-  }, [errors]);
+  }
 
   const handleNext = () => {
     const { errors, normalizedData } = validateOrgAddress(formData);

--- a/apps/frontend/src/app/features/onboarding/components/Steps/CreateOrg/OrgStep.tsx
+++ b/apps/frontend/src/app/features/onboarding/components/Steps/CreateOrg/OrgStep.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import classNames from 'classnames';
 import {
   IoArrowForward,
@@ -84,12 +84,15 @@ const OrgStep = ({ errors, nextStep, formData, setFormData }: OrgStepProps) => {
   const selectedCountryCode = phoneData.selectedCode;
   const localPhoneNumber = phoneData.localNumber;
 
-  useEffect(() => {
-    if (!errors) {
-      return;
+  // Sync parent-provided errors into local state during render, guarded by the
+  // previous prop so local edits from handleNext are not clobbered.
+  const [prevErrors, setPrevErrors] = useState<typeof errors | null>(null);
+  if (prevErrors !== errors) {
+    setPrevErrors(errors);
+    if (errors) {
+      setFormDataErrors(errors);
     }
-    setFormDataErrors(errors);
-  }, [errors]);
+  }
 
   const handleNext = () => {
     const { errors, normalizedData } = validateOrgBasics({

--- a/apps/frontend/src/app/features/onboarding/pages/CreateOrg/CreateOrg.tsx
+++ b/apps/frontend/src/app/features/onboarding/pages/CreateOrg/CreateOrg.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { Suspense, useEffect, useState } from 'react';
+import React, { Suspense, useState } from 'react';
 import dynamic from 'next/dynamic';
 import { IoBusiness, IoLocationSharp } from 'react-icons/io5';
 
@@ -101,17 +101,28 @@ const CreateOrg = () => {
   const shouldBlockForTransition = isTransitioning || isCompletedRedirect;
   useFullscreenLoader('create-org-transition', shouldBlockForTransition);
 
-  useEffect(() => {
-    if (!isReady) {
-      return;
+  // Adopt the onboarding snapshot during render (guarded by the previous
+  // values) instead of mirroring it through an effect.
+  const [prevOnboarding, setPrevOnboarding] = useState<{
+    org: typeof org;
+    computedStep: number;
+    isReady: boolean;
+  } | null>(null);
+  if (
+    prevOnboarding?.org !== org ||
+    prevOnboarding?.computedStep !== computedStep ||
+    prevOnboarding?.isReady !== isReady
+  ) {
+    setPrevOnboarding({ org, computedStep, isReady });
+    if (isReady) {
+      if (computedStep >= 0 && computedStep <= 1) {
+        setActiveStep(computedStep);
+      }
+      if (org) {
+        setFormData(org);
+      }
     }
-    if (computedStep >= 0 && computedStep <= 1) {
-      setActiveStep(computedStep);
-    }
-    if (org) {
-      setFormData(org);
-    }
-  }, [org, computedStep, isReady]);
+  }
 
   if (isCompletedRedirect) {
     redirect('/dashboard');

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Documents/Documents.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Documents/Documents.tsx
@@ -1,5 +1,5 @@
 import SectionCard from '@/app/ui/primitives/SectionCard/SectionCard';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { IoCreateOutline, IoDocumentTextOutline, IoEllipsisHorizontal } from 'react-icons/io5';
 import AddDocument from '@/app/features/organization/pages/Organization/Sections/Documents/AddDocument';
 import DocumentInfo from '@/app/features/organization/pages/Organization/Sections/Documents/DocumentInfo';
@@ -41,7 +41,11 @@ const Documents = () => {
     documents[0] ?? null
   );
 
-  useEffect(() => {
+  // Re-point the selection when the documents list changes (adjusted during
+  // render, per React's "adjusting state when a prop changes" pattern).
+  const [prevDocuments, setPrevDocuments] = useState(documents);
+  if (prevDocuments !== documents) {
+    setPrevDocuments(documents);
     setActiveDocument((prev) => {
       if (documents.length === 0) return null;
       if (prev?._id) {
@@ -50,7 +54,7 @@ const Documents = () => {
       }
       return documents[0];
     });
-  }, [documents]);
+  }
 
   const handleView = (document: OrganizationDocument) => {
     setActiveDocument(document);

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/PhoneOrganization.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/PhoneOrganization.tsx
@@ -272,7 +272,11 @@ const PhoneOrganization = ({ primaryOrg }: PhoneOrganizationProps) => {
     });
   }, [primaryOrgId]);
 
-  useEffect(() => {
+  // Re-point the selection when the team list changes (adjusted during
+  // render, per React's "adjusting state when a prop changes" pattern).
+  const [prevTeams, setPrevTeams] = useState(teams);
+  if (prevTeams !== teams) {
+    setPrevTeams(teams);
     setActiveTeam((prev) => {
       if (teams.length === 0) return null;
       if (prev?._id) {
@@ -281,7 +285,7 @@ const PhoneOrganization = ({ primaryOrg }: PhoneOrganizationProps) => {
       }
       return teams[0];
     });
-  }, [teams]);
+  }
 
   const handleOpenTeam = (team: TeamProp) => {
     setActiveTeam(team);

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/ProfileCard.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/ProfileCard.tsx
@@ -15,7 +15,7 @@ import { useAuthStore } from '@/app/stores/authStore';
 import { UserProfile } from '@/app/features/users/types/profile';
 import { getSafeImageUrl } from '@/app/lib/urls';
 import { Organisation } from '@yosemite-crew/types';
-import React, { useMemo, useState, useRef } from 'react';
+import React, { useMemo, useState } from 'react';
 import { MEDIA_SOURCES } from '@/app/constants/mediaSources';
 import dynamic from 'next/dynamic';
 import { IoCreate, IoCheckmark } from 'react-icons/io5';
@@ -309,11 +309,11 @@ const ProfileCard = ({
   const orgId = primaryOrg?._id;
   const isDisabled = !orgId;
 
-  const prevOrgRef = useRef(org);
-  const prevFieldsRef = useRef(fields);
-  if (prevOrgRef.current !== org || prevFieldsRef.current !== fields) {
-    prevOrgRef.current = org;
-    prevFieldsRef.current = fields;
+  const [prevOrg, setPrevOrg] = useState(org);
+  const [prevFields, setPrevFields] = useState(fields);
+  if (prevOrg !== org || prevFields !== fields) {
+    setPrevOrg(org);
+    setPrevFields(fields);
     setFormValues(buildInitialValues(fields, org));
     setFormValuesErrors({});
   }

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/Rooms.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/Rooms.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import {
   IoBedOutline,
   IoBusinessOutline,
@@ -103,7 +103,11 @@ const Rooms = () => {
   const [viewPopup, setViewPopup] = useState(false);
   const [activeRoom, setActiveRoom] = useState<OrganisationRoom | null>(rooms[0] ?? null);
 
-  useEffect(() => {
+  // Re-point the selection when the rooms list changes (adjusted during
+  // render, per React's "adjusting state when a prop changes" pattern).
+  const [prevRooms, setPrevRooms] = useState(rooms);
+  if (prevRooms !== rooms) {
+    setPrevRooms(rooms);
     setActiveRoom((prev) => {
       if (rooms.length === 0) return null;
       if (prev?.id) {
@@ -112,7 +116,7 @@ const Rooms = () => {
       }
       return rooms[0];
     });
-  }, [rooms]);
+  }
 
   const handleView = (room: OrganisationRoom) => {
     setActiveRoom(room);

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/useRoomInfoController.ts
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/useRoomInfoController.ts
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useNotify } from '@/app/hooks/useNotify';
 import { useSpecialitiesForPrimaryOrg } from '@/app/hooks/useSpecialities';
 import { useTeamForPrimaryOrg } from '@/app/hooks/useTeam';
@@ -202,7 +202,7 @@ export const useRoomInfoController = ({
     [roomUnitGroupIds, roomUnitGroupsById]
   );
   const roomStateKey = getRoomStateKey(activeRoom, showModal, roomUnitGroups);
-  const syncedRoomStateKeyRef = useRef(roomStateKey);
+  const [syncedRoomStateKey, setSyncedRoomStateKey] = useState(roomStateKey);
   const [mode, setMode] = useState<'view' | 'edit'>('view');
   const [formData, setFormData] = useState<ManagedRoom>(() =>
     getRoomForm(activeRoom, roomUnitGroups)
@@ -218,8 +218,8 @@ export const useRoomInfoController = ({
     equipment: true,
   });
 
-  if (syncedRoomStateKeyRef.current !== roomStateKey) {
-    syncedRoomStateKeyRef.current = roomStateKey;
+  if (syncedRoomStateKey !== roomStateKey) {
+    setSyncedRoomStateKey(roomStateKey);
     setMode('view');
     setFormData(getRoomForm(activeRoom, roomUnitGroups));
     setCustomEquipmentName('');

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Specialities/AddSpeciality.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Specialities/AddSpeciality.tsx
@@ -3,7 +3,7 @@ import { Primary } from '@/app/ui/primitives/Buttons';
 import Modal from '@/app/ui/overlays/Modal';
 import ModalFooter from '@/app/ui/overlays/Modal/ModalFooter';
 import ModalHeader from '@/app/ui/overlays/Modal/ModalHeader';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import SpecialityCard from '@/app/features/organization/pages/Organization/Sections/Specialities/SpecialityCard';
 import { SpecialityWeb } from '@/app/features/organization/types/speciality';
 import SpecialitySearchWeb from '@/app/ui/inputs/SpecialitySearch/SpecialitySearchWeb';
@@ -60,7 +60,14 @@ const AddSpeciality = ({ showModal, setShowModal, specialities }: AddSpecialityP
   );
   const businessType = getResolvedBusinessType(primaryOrg?.type);
 
-  useEffect(() => {
+  // Re-apply the starter services when the business type or org resolves late
+  // (adjusted during render, per React's "adjusting state when a prop changes" pattern).
+  const [prevStarterKey, setPrevStarterKey] = useState({ businessType, primaryOrgId });
+  if (
+    prevStarterKey.businessType !== businessType ||
+    prevStarterKey.primaryOrgId !== primaryOrgId
+  ) {
+    setPrevStarterKey({ businessType, primaryOrgId });
     setFormData((previous) => {
       let hasChanges = false;
       const nextState = previous.map((speciality) => {
@@ -70,7 +77,7 @@ const AddSpeciality = ({ showModal, setShowModal, specialities }: AddSpecialityP
       });
       return hasChanges ? nextState : previous;
     });
-  }, [businessType, primaryOrgId]);
+  }
 
   const removeSpeciality = (index: number) => {
     setFormData((prev) => prev.filter((_, i) => i !== index));

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Specialities/Specialities.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Specialities/Specialities.tsx
@@ -31,7 +31,11 @@ const Specialities = () => {
     specialities[0] ?? null
   );
 
-  useEffect(() => {
+  // Re-point the selection when the specialities list changes (adjusted during
+  // render, per React's "adjusting state when a prop changes" pattern).
+  const [prevSpecialities, setPrevSpecialities] = useState(specialities);
+  if (prevSpecialities !== specialities) {
+    setPrevSpecialities(specialities);
     setActiveSpeciality((prev) => {
       if (specialities.length === 0) return null;
       if (prev?._id) {
@@ -40,7 +44,7 @@ const Specialities = () => {
       }
       return specialities[0];
     });
-  }, [specialities]);
+  }
 
   useEffect(() => {
     if (!primaryOrgId) return;

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Team/PermissionsEditor.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Team/PermissionsEditor.tsx
@@ -1,7 +1,7 @@
 import Accordion from '@/app/ui/primitives/Accordion/Accordion';
 import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
 import { Permission, PERMISSIONS, ROLE_PERMISSIONS, RoleCode } from '@/app/lib/permissions';
-import React, { useRef } from 'react';
+import React from 'react';
 import { uniq } from '@/app/features/organization/pages/Organization/Sections/Team/permissionsEditorUtils';
 
 type PermissionRow = {
@@ -327,10 +327,10 @@ const PermissionsEditor = ({ value, onSave, role, readOnly = false }: Permission
   const roleDefaults = React.useMemo(() => ROLE_PERMISSIONS[role] ?? [], [role]);
   const [draft, setDraft] = React.useState<Permission[]>(value);
   const [saving, setSaving] = React.useState(false);
-  const resetKeyRef = useRef<string>('');
   const resetKey = `${role}:${value.join('|')}`;
-  if (resetKeyRef.current !== resetKey) {
-    resetKeyRef.current = resetKey;
+  const [prevResetKey, setPrevResetKey] = React.useState(resetKey);
+  if (prevResetKey !== resetKey) {
+    setPrevResetKey(resetKey);
     if (!samePermissionSet(draft, value)) {
       setDraft(value);
     }

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Team/Team.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Team/Team.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import Image from 'next/image';
 import { IoEllipsisHorizontal, IoPersonAddOutline } from 'react-icons/io5';
 import AddTeam from '@/app/features/organization/pages/Organization/Sections/Team/AddTeam';
@@ -101,7 +101,11 @@ const Team = ({ isVerified = false }: { isVerified?: boolean }) => {
   const [activeTeam, setActiveTeam] = useState<TeamProp | null>(teams[0] ?? null);
   const showInvite = canEditTeam && isVerified;
 
-  useEffect(() => {
+  // Re-point the selection when the team list changes (adjusted during
+  // render, per React's "adjusting state when a prop changes" pattern).
+  const [prevTeams, setPrevTeams] = useState(teams);
+  if (prevTeams !== teams) {
+    setPrevTeams(teams);
     setActiveTeam((prev) => {
       if (teams.length === 0) return null;
       if (prev?._id) {
@@ -110,7 +114,7 @@ const Team = ({ isVerified = false }: { isVerified?: boolean }) => {
       }
       return teams[0];
     });
-  }, [teams]);
+  }
 
   const handleOpen = (team: TeamProp) => {
     setActiveTeam(team);

--- a/apps/frontend/src/app/features/organizations/pages/Organizations.tsx
+++ b/apps/frontend/src/app/features/organizations/pages/Organizations.tsx
@@ -19,6 +19,7 @@ const Organizations = () => {
   const orgStatus = useOrgStore((s) => s.status);
 
   const [invites, setInvites] = useState<Invite[]>([]);
+  // Starts true — the mount-only effect below always begins loading immediately.
   const [invitesLoading, setInvitesLoading] = useState(true);
   // Separate flag for the accept flow — covers the async work + navigation delay
   const [accepting, setAccepting] = useState(false);
@@ -27,7 +28,6 @@ const Organizations = () => {
 
   useEffect(() => {
     let cancelled = false;
-    setInvitesLoading(true);
     loadInvites()
       .then((data) => {
         if (!cancelled) setInvites(data);

--- a/apps/frontend/src/app/features/settings/pages/Settings/Sections/DefaultOpenScreenPreference.tsx
+++ b/apps/frontend/src/app/features/settings/pages/Settings/Sections/DefaultOpenScreenPreference.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useRef } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useNotify } from '@/app/hooks/useNotify';
 import { setSavedDefaultOpenScreenRoute } from '@/app/lib/defaultOpenScreen';
 import {
@@ -52,11 +52,11 @@ const DefaultOpenScreenPreference = () => {
   const [defaultView, setDefaultView] = useState<DefaultAppointmentsView>(savedView);
   const shouldShowDefaultView = selection === '/appointments';
 
-  const prevSavedRouteRef = useRef(savedRoute);
-  const prevSavedViewRef = useRef(savedView);
-  if (prevSavedRouteRef.current !== savedRoute || prevSavedViewRef.current !== savedView) {
-    prevSavedRouteRef.current = savedRoute;
-    prevSavedViewRef.current = savedView;
+  const [prevSavedRoute, setPrevSavedRoute] = useState(savedRoute);
+  const [prevSavedView, setPrevSavedView] = useState(savedView);
+  if (prevSavedRoute !== savedRoute || prevSavedView !== savedView) {
+    setPrevSavedRoute(savedRoute);
+    setPrevSavedView(savedView);
     setSelection(savedRoute);
     setDefaultView(savedView);
   }

--- a/apps/frontend/src/app/features/settings/pages/Settings/Sections/TimezonePreference.tsx
+++ b/apps/frontend/src/app/features/settings/pages/Settings/Sections/TimezonePreference.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
   DEFAULT_TIMEZONE,
   getSystemTimeZone,
@@ -30,15 +30,18 @@ const TimezonePreference = () => {
   );
   const [selectedTimezone, setSelectedTimezone] = useState<string>(profileTimezone);
 
-  useEffect(() => {
+  // Render-phase adjustment (React's documented setState-during-render reset
+  // pattern): re-seed the pill whenever the org or the profile's saved timezone
+  // changes.
+  const [prevOrgId, setPrevOrgId] = useState(primaryOrgId);
+  const [prevProfileTimezone, setPrevProfileTimezone] = useState(profileTimezone);
+  if (prevOrgId !== primaryOrgId || prevProfileTimezone !== profileTimezone) {
+    setPrevOrgId(primaryOrgId);
+    setPrevProfileTimezone(profileTimezone);
     const nextSyncMode = getTimezoneSyncModeForOrg(primaryOrgId);
     setSyncMode(nextSyncMode);
-    if (nextSyncMode === 'device') {
-      setSelectedTimezone(getSystemTimeZone());
-      return;
-    }
-    setSelectedTimezone(profileTimezone);
-  }, [primaryOrgId, profileTimezone]);
+    setSelectedTimezone(nextSyncMode === 'device' ? getSystemTimeZone() : profileTimezone);
+  }
 
   // The design collapses the mode + zone pair into a single compact pill whose
   // first entry is the device zone ("Device · Europe/Berlin") and whose remaining

--- a/apps/frontend/src/app/features/tasks/components/TaskBoard.tsx
+++ b/apps/frontend/src/app/features/tasks/components/TaskBoard.tsx
@@ -648,7 +648,9 @@ const TaskBoard = ({
   );
 
   const moveToStatusRef = useRef(moveToStatus);
-  moveToStatusRef.current = moveToStatus;
+  useEffect(() => {
+    moveToStatusRef.current = moveToStatus;
+  });
 
   const handleTaskCardDragStart = useCallback((event: React.DragEvent<HTMLElement>, task: Task) => {
     setDraggedTaskId(task._id ?? null);

--- a/apps/frontend/src/app/features/tasks/pages/Tasks/Sections/Reschedule.tsx
+++ b/apps/frontend/src/app/features/tasks/pages/Tasks/Sections/Reschedule.tsx
@@ -30,9 +30,9 @@ const RescheduleTask = ({ showModal, setShowModal, activeTask }: RescheduleTaskP
   // Holds the new due date while the series scope is chosen.
   const pendingDueAtRef = useRef<Date | null>(null);
 
-  const prevActiveTaskRef = useRef(activeTask);
-  if (prevActiveTaskRef.current !== activeTask) {
-    prevActiveTaskRef.current = activeTask;
+  const [prevActiveTask, setPrevActiveTask] = useState(activeTask);
+  if (prevActiveTask !== activeTask) {
+    setPrevActiveTask(activeTask);
     setSelectedDate(new Date(activeTask.dueAt));
     setDueTimeValue(getPreferredTimeValue(activeTask.dueAt, '00:00'));
   }

--- a/apps/frontend/src/app/features/tasks/pages/Tasks/index.tsx
+++ b/apps/frontend/src/app/features/tasks/pages/Tasks/index.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { Suspense, useCallback, useMemo, useState } from 'react';
 import type { SetStateAction } from 'react';
 import dynamic from 'next/dynamic';
 import { useSearchParams } from 'next/navigation';
@@ -87,7 +87,7 @@ const Tasks = () => {
   const canEditTasks = permissions.can(PERMISSIONS.TASKS_EDIT_ANY);
   const query = useSearchStore((s) => s.query);
   const searchParams = useSearchParams();
-  const handledDeepLinkRef = useRef<string | null>(null);
+  const [handledDeepLink, setHandledDeepLink] = useState<string | null>(null);
   const [activeFilter, setActiveFilter] = useState('all');
   const [activeStatus, setActiveStatus] = useState('all');
   const [activeScope, setActiveScope] = useState('team');
@@ -168,7 +168,11 @@ const Tasks = () => {
     [activeCalendar]
   );
 
-  useEffect(() => {
+  // Reconcile the active task against the latest task list during render
+  // (guarded by the previous list) instead of through an effect.
+  const [prevTasks, setPrevTasks] = useState<Task[] | null>(null);
+  if (prevTasks !== tasks) {
+    setPrevTasks(tasks);
     setActiveTask((prev) => {
       if (tasks.length === 0) return null;
       if (prev?._id) {
@@ -177,20 +181,19 @@ const Tasks = () => {
       }
       return tasks[0];
     });
-  }, [tasks]);
+  }
 
-  useEffect(() => {
-    const taskId = String(searchParams.get('taskId') ?? '').trim();
-    if (!taskId) return;
-    if (handledDeepLinkRef.current === taskId) return;
-
-    const target = tasks.find((task) => task._id === taskId);
-    if (!target) return;
-
-    setActiveTask(target);
-    setViewPopup(true);
-    handledDeepLinkRef.current = taskId;
-  }, [tasks, searchParams]);
+  // Deep-link handling: open the task named in the query string once its data
+  // arrives, at most once per taskId.
+  const deepLinkTaskId = String(searchParams.get('taskId') ?? '').trim();
+  if (deepLinkTaskId && handledDeepLink !== deepLinkTaskId) {
+    const target = tasks.find((task) => task._id === deepLinkTaskId);
+    if (target) {
+      setActiveTask(target);
+      setViewPopup(true);
+      setHandledDeepLink(deepLinkTaskId);
+    }
+  }
 
   const filteredList = useMemo(() => {
     const q = query.trim().toLowerCase();

--- a/apps/frontend/src/app/hooks/useAppointmentForm.ts
+++ b/apps/frontend/src/app/hooks/useAppointmentForm.ts
@@ -479,9 +479,9 @@ export const useAppointmentForm = (options: UseAppointmentFormOptions = {}) => {
     [normalizeId, teams]
   );
   const getLeadOptionsRef = useRef(getLeadOptionsForSlot);
-  getLeadOptionsRef.current = getLeadOptionsForSlot;
-  const teamsRef = useRef(teams);
-  teamsRef.current = teams;
+  useEffect(() => {
+    getLeadOptionsRef.current = getLeadOptionsForSlot;
+  });
   const getLeadProfileUrl = useCallback(
     (leadId: string) => {
       const matchedTeam = teams.find((team) => (team.practionerId || team._id) === leadId);
@@ -490,7 +490,9 @@ export const useAppointmentForm = (options: UseAppointmentFormOptions = {}) => {
     [teams]
   );
   const getLeadProfileUrlRef = useRef(getLeadProfileUrl);
-  getLeadProfileUrlRef.current = getLeadProfileUrl;
+  useEffect(() => {
+    getLeadProfileUrlRef.current = getLeadProfileUrl;
+  });
 
   useEffect(() => {
     selectedSlotRef.current = selectedSlot;
@@ -566,45 +568,56 @@ export const useAppointmentForm = (options: UseAppointmentFormOptions = {}) => {
     };
   }, [calendarSlotFlow, formData.appointmentType?.id, selectedDate]);
 
+  // Apply an incoming prefill during render, guarded by the previous prefill
+  // identity so teams updates (or unrelated renders) don't wipe user edits.
+  const [prevInitialPrefill, setPrevInitialPrefill] = useState<
+    AppointmentDraftPrefill | null | undefined
+  >(undefined);
+  if (prevInitialPrefill !== initialPrefill) {
+    setPrevInitialPrefill(initialPrefill);
+    if (initialPrefill) {
+      setPendingPrefill(initialPrefill);
+      setSelectedDate(initialPrefill.date);
+      setSelectedSlot(null);
+      const prefillStart = buildDateInPreferredTimeZone(
+        initialPrefill.date,
+        initialPrefill.minuteOfDay
+      );
+
+      // Prefill lead immediately from teams — before service/slot are chosen.
+      // The pendingPrefill effect re-validates once a slot is matched.
+      const prefillLead = initialPrefill.leadId
+        ? teams.find(
+            (t) => normalizeId(t.practionerId || t._id) === normalizeId(initialPrefill.leadId)
+          )
+        : undefined;
+      const prefillLeadId = prefillLead ? prefillLead.practionerId || prefillLead._id : undefined;
+      const prefillLeadName = prefillLead?.name || prefillLead?.practionerId || prefillLead?._id;
+
+      setFormData((prev) => ({
+        ...prev,
+        appointmentDate: prefillStart,
+        startTime: prefillStart,
+        endTime: prefillStart,
+        ...(prefillLeadId
+          ? {
+              lead: {
+                id: prefillLeadId,
+                name: prefillLeadName ?? '',
+                profileUrl: getLeadProfileUrl(prefillLeadId),
+              },
+            }
+          : {}),
+      }));
+    }
+  }
+
+  // Stamp the prefill lead id where later effects (slot/lead reconciliation)
+  // can read it without re-triggering on teams changes.
   useEffect(() => {
     if (!initialPrefill) return;
     prefillLeadIdRef.current = initialPrefill.leadId || '';
-    setPendingPrefill(initialPrefill);
-    setSelectedDate(initialPrefill.date);
-    setSelectedSlot(null);
-    const prefillStart = buildDateInPreferredTimeZone(
-      initialPrefill.date,
-      initialPrefill.minuteOfDay
-    );
-
-    // Prefill lead immediately from teams — before service/slot are chosen.
-    // Use teamsRef so teams updates don't re-trigger this effect and wipe user edits.
-    // The pendingPrefill effect re-validates once a slot is matched.
-    const prefillLead = initialPrefill.leadId
-      ? teamsRef.current.find(
-          (t) => normalizeId(t.practionerId || t._id) === normalizeId(initialPrefill.leadId)
-        )
-      : undefined;
-    const prefillLeadId = prefillLead ? prefillLead.practionerId || prefillLead._id : undefined;
-    const prefillLeadName = prefillLead?.name || prefillLead?.practionerId || prefillLead?._id;
-    if (prefillLeadId) currentLeadIdRef.current = prefillLeadId;
-
-    setFormData((prev) => ({
-      ...prev,
-      appointmentDate: prefillStart,
-      startTime: prefillStart,
-      endTime: prefillStart,
-      ...(prefillLeadId
-        ? {
-            lead: {
-              id: prefillLeadId,
-              name: prefillLeadName ?? '',
-              profileUrl: getLeadProfileUrlRef.current(prefillLeadId),
-            },
-          }
-        : {}),
-    }));
-  }, [initialPrefill, normalizeId]);
+  }, [initialPrefill]);
 
   useEffect(() => {
     const specialityId = formData.appointmentType?.speciality.id;
@@ -646,8 +659,8 @@ export const useAppointmentForm = (options: UseAppointmentFormOptions = {}) => {
     if (!serviceCandidates.length) return;
 
     let cancelled = false;
-    setIsLoadingSlotScopedOptions(true);
     const resolveSlotScopedOptions = async () => {
+      setIsLoadingSlotScopedOptions(true);
       const uniqueServiceIds = [
         ...new Set(serviceCandidates.map((c) => c.serviceId).filter(Boolean)),
       ];
@@ -795,13 +808,15 @@ export const useAppointmentForm = (options: UseAppointmentFormOptions = {}) => {
     () => getLeadOptionsForSlot(selectedSlot),
     [getLeadOptionsForSlot, selectedSlot]
   );
+  const formLeadId = formData.lead?.id;
+  const formLeadName = formData.lead?.name;
   const LeadOptions = useMemo((): LeadOption[] => {
     if (slotLeadOptions.length > 0) return slotLeadOptions;
-    if (formData.lead?.id && formData.lead?.name) {
-      return [{ value: formData.lead.id, label: formData.lead.name }];
+    if (formLeadId && formLeadName) {
+      return [{ value: formLeadId, label: formLeadName }];
     }
     return slotLeadOptions;
-  }, [slotLeadOptions, formData.lead?.id, formData.lead?.name]);
+  }, [slotLeadOptions, formLeadId, formLeadName]);
 
   // Context-aware message for the lead field empty state.
   const leadEmptyStateMessage = useMemo((): string => {
@@ -1019,69 +1034,86 @@ export const useAppointmentForm = (options: UseAppointmentFormOptions = {}) => {
     slotScopedServicesBySpecialityId,
   ]);
 
-  useEffect(() => {
-    const selectedServiceId = formData.appointmentType?.id;
-    if (!selectedServiceId) return;
-    const selectedService = services.find((service) => service.id === selectedServiceId);
-    const serviceAppointmentKind = resolveServiceAppointmentKind(selectedService, appointmentKind);
-    if (selectedService && serviceAppointmentKind !== appointmentKind) {
-      setFormData((prev) => ({
-        ...prev,
-        appointmentKind: serviceAppointmentKind,
-      }));
-      return;
-    }
-    if (!selectedService || isSelectableAppointmentService(selectedService)) return;
-    setSelectedSlot(null);
-    setTimeSlots([]);
-    slotMetaByRef.current = new WeakMap();
-    setFormData((prev) => ({
-      ...prev,
+  // Reconcile the selected service with the appointment kind during render,
+  // guarded by the previous inputs so the adjustment runs once per change.
+  // slotMetaByRef is not cleared here: its keys are held weakly and every slot
+  // load replaces the map wholesale, so stale entries are unreachable.
+  const [prevServiceKindSync, setPrevServiceKindSync] = useState<{
+    appointmentKind: AppointmentKind;
+    serviceId: string | undefined;
+    services: AppointmentCatalogService[];
+  } | null>(null);
+  if (
+    prevServiceKindSync?.appointmentKind !== appointmentKind ||
+    prevServiceKindSync?.serviceId !== formData.appointmentType?.id ||
+    prevServiceKindSync?.services !== services
+  ) {
+    setPrevServiceKindSync({
       appointmentKind,
-      appointmentType: {
-        id: '',
-        name: '',
-        speciality: prev.appointmentType?.speciality ?? { id: '', name: '' },
-      },
-      lead: undefined,
-    }));
-    setFormDataErrors((prev) => ({
-      ...prev,
-      serviceId: 'Select a bookable service.',
-      slot: undefined,
-      leadId: undefined,
-    }));
-  }, [appointmentKind, formData.appointmentType?.id, services]);
-
-  useEffect(() => {
-    if (!calendarSlotFlow || !slotScopedSpecialityIds.length) return;
-    const selectedSpecialityId = formData.appointmentType?.speciality.id;
-    if (!selectedSpecialityId) return;
-    if (!slotScopedSpecialityIds.includes(selectedSpecialityId)) {
-      setFormData((prev) => ({ ...prev, appointmentType: undefined }));
-      return;
-    }
+      serviceId: formData.appointmentType?.id,
+      services,
+    });
     const selectedServiceId = formData.appointmentType?.id;
-    if (!selectedServiceId) return;
-    const allowedServices = slotScopedServicesBySpecialityId[selectedSpecialityId] ?? [];
-    const hasService = allowedServices.some((option) => option.value === selectedServiceId);
-    if (!hasService) {
-      setFormData((prev) => ({
-        ...prev,
-        appointmentType: {
-          ...prev.appointmentType,
-          id: '',
-          name: '',
-          speciality: prev.appointmentType?.speciality ?? { id: '', name: '' },
-        },
-      }));
+    if (selectedServiceId) {
+      const selectedService = services.find((service) => service.id === selectedServiceId);
+      const serviceAppointmentKind = resolveServiceAppointmentKind(
+        selectedService,
+        appointmentKind
+      );
+      if (selectedService && serviceAppointmentKind !== appointmentKind) {
+        setFormData((prev) => ({
+          ...prev,
+          appointmentKind: serviceAppointmentKind,
+        }));
+      } else if (selectedService && selectedService.isBookable === false) {
+        // Inlined isSelectableAppointmentService: calling the helper here makes
+        // React Compiler treat selectedService as mutated during render.
+        setSelectedSlot(null);
+        setTimeSlots([]);
+        setFormData((prev) => ({
+          ...prev,
+          appointmentKind,
+          appointmentType: {
+            id: '',
+            name: '',
+            speciality: prev.appointmentType?.speciality ?? { id: '', name: '' },
+          },
+          lead: undefined,
+        }));
+        setFormDataErrors((prev) => ({
+          ...prev,
+          serviceId: 'Select a bookable service.',
+          slot: undefined,
+          leadId: undefined,
+        }));
+      }
     }
-  }, [
-    calendarSlotFlow,
-    formData.appointmentType,
-    slotScopedServicesBySpecialityId,
-    slotScopedSpecialityIds,
-  ]);
+  }
+
+  // Prune selections that fall outside the slot-scoped options during render.
+  // Each correction empties the offending selection, so the condition
+  // self-invalidates on the follow-up render.
+  if (calendarSlotFlow && slotScopedSpecialityIds.length) {
+    const selectedSpecialityId = formData.appointmentType?.speciality.id;
+    if (selectedSpecialityId && !slotScopedSpecialityIds.includes(selectedSpecialityId)) {
+      setFormData((prev) => ({ ...prev, appointmentType: undefined }));
+    } else if (selectedSpecialityId && formData.appointmentType?.id) {
+      const selectedServiceId = formData.appointmentType.id;
+      const allowedServices = slotScopedServicesBySpecialityId[selectedSpecialityId] ?? [];
+      const hasService = allowedServices.some((option) => option.value === selectedServiceId);
+      if (!hasService) {
+        setFormData((prev) => ({
+          ...prev,
+          appointmentType: {
+            ...prev.appointmentType,
+            id: '',
+            name: '',
+            speciality: prev.appointmentType?.speciality ?? { id: '', name: '' },
+          },
+        }));
+      }
+    }
+  }
 
   const ServiceInfoData = useMemo(() => {
     const serviceId = formData.appointmentType?.id;

--- a/apps/frontend/src/app/hooks/useMetrics.ts
+++ b/apps/frontend/src/app/hooks/useMetrics.ts
@@ -1,15 +1,23 @@
-import { useEffect, useState } from "react";
-import { useOrgStore } from "@/app/stores/orgStore";
-import { DashboardSummary, EMPTY_EXPLORE } from "@/app/features/metrics/types/metrics";
-import { getExploreMetrics } from "@/app/features/metrics/services/metricsService";
+import { useEffect, useState } from 'react';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { DashboardSummary, EMPTY_EXPLORE } from '@/app/features/metrics/types/metrics';
+import { getExploreMetrics } from '@/app/features/metrics/services/metricsService';
 
 export const useExploreMetrics = () => {
   const primaryOrgId = useOrgStore((s) => s.primaryOrgId);
   const [data, setData] = useState<DashboardSummary>(EMPTY_EXPLORE);
 
-  useEffect(() => {
+  // Reset during render when the org clears, instead of via an effect.
+  const [prevOrgId, setPrevOrgId] = useState(primaryOrgId);
+  if (prevOrgId !== primaryOrgId) {
+    setPrevOrgId(primaryOrgId);
     if (!primaryOrgId) {
       setData(EMPTY_EXPLORE);
+    }
+  }
+
+  useEffect(() => {
+    if (!primaryOrgId) {
       return;
     }
     let cancelled = false;

--- a/apps/frontend/src/app/hooks/useResendCountdown.ts
+++ b/apps/frontend/src/app/hooks/useResendCountdown.ts
@@ -1,35 +1,91 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, useSyncExternalStore } from 'react';
 
 /**
  * Countdown for OTP resend prompts. Deadline-based so a slow render can't
  * drift the clock: the remaining time is always derived from Date.now().
  * Restarts automatically whenever `active` flips to true.
+ *
+ * The ticking clock is an external mutable source, so it lives in a small
+ * per-instance store that React subscribes to via useSyncExternalStore —
+ * effects only push the `active`/duration props into the store.
  */
+type CountdownStore = {
+  subscribe: (onStoreChange: () => void) => () => void;
+  getSecondsLeft: () => number | null;
+  start: (durationMs: number) => void;
+  stop: () => void;
+  pause: () => void;
+};
+
+const createCountdownStore = (): CountdownStore => {
+  const listeners = new Set<() => void>();
+  let deadlineMs: number | null = null;
+  let secondsLeft: number | null = null;
+  let intervalId: ReturnType<typeof setInterval> | null = null;
+
+  const notify = () => listeners.forEach((listener) => listener());
+  const clearTick = () => {
+    if (intervalId !== null) {
+      clearInterval(intervalId);
+      intervalId = null;
+    }
+  };
+  const tick = () => {
+    if (deadlineMs === null) return;
+    secondsLeft = Math.max(0, Math.ceil((deadlineMs - Date.now()) / 1000));
+    if (secondsLeft === 0) clearTick();
+    notify();
+  };
+
+  return {
+    subscribe: (onStoreChange) => {
+      listeners.add(onStoreChange);
+      return () => {
+        listeners.delete(onStoreChange);
+      };
+    },
+    getSecondsLeft: () => secondsLeft,
+    start: (durationMs) => {
+      deadlineMs = Date.now() + durationMs;
+      secondsLeft = Math.max(0, Math.ceil(durationMs / 1000));
+      clearTick();
+      intervalId = setInterval(tick, 1000);
+      notify();
+    },
+    stop: () => {
+      if (deadlineMs === null) return;
+      deadlineMs = null;
+      secondsLeft = null;
+      clearTick();
+      notify();
+    },
+    pause: clearTick,
+  };
+};
+
+// Server render never has a running countdown.
+const getServerSecondsLeft = () => null;
+
 export const useResendCountdown = (active: boolean, durationSeconds: number) => {
-  const [deadline, setDeadline] = useState<number | null>(null);
-  const [nowMs, setNowMs] = useState(() => Date.now());
+  const [store] = useState(createCountdownStore);
+  const runningSecondsLeft = useSyncExternalStore(
+    store.subscribe,
+    store.getSecondsLeft,
+    getServerSecondsLeft
+  );
 
-  const restart = useCallback(() => {
-    const startedAtMs = Date.now();
-    setNowMs(startedAtMs);
-    setDeadline(startedAtMs + durationSeconds * 1000);
-  }, [durationSeconds]);
-
-  useEffect(() => {
-    if (active) restart();
-    else setDeadline(null);
-  }, [active, restart]);
-
-  const expired = deadline !== null && nowMs >= deadline;
+  const restart = useCallback(() => store.start(durationSeconds * 1000), [durationSeconds, store]);
 
   useEffect(() => {
-    if (!active || deadline === null || expired) return;
-    const interval = setInterval(() => setNowMs(Date.now()), 1000);
-    return () => clearInterval(interval);
-  }, [active, deadline, expired]);
+    if (!active) {
+      store.stop();
+      return;
+    }
+    store.start(durationSeconds * 1000);
+    return () => store.pause();
+  }, [active, durationSeconds, store]);
 
-  const secondsLeft =
-    deadline === null ? durationSeconds : Math.max(0, Math.ceil((deadline - nowMs) / 1000));
+  const secondsLeft = runningSecondsLeft ?? durationSeconds;
 
   return { restart, secondsLeft };
 };

--- a/apps/frontend/src/app/hooks/useTaskForm.ts
+++ b/apps/frontend/src/app/hooks/useTaskForm.ts
@@ -60,19 +60,27 @@ export const useTaskForm = (options: UseTaskFormOptions = {}) => {
     setError(null);
   }, [emptyTask, initialTask]);
 
-  useEffect(() => {
-    if (!due) return;
-    const [hourValue, minuteValue] = String(dueTimeValue || '00:00')
-      .split(':')
-      .map((value) => Number.parseInt(value, 10));
-    const hour = Number.isFinite(hourValue) ? hourValue : 0;
-    const minute = Number.isFinite(minuteValue) ? minuteValue : 0;
-    setFormData((prev) => ({
-      ...prev,
-      dueAt: buildDateInPreferredTimeZone(due, hour * 60 + minute),
-      timezone: prev.timezone || getPreferredTimeZone(),
-    }));
-  }, [due, dueTimeValue]);
+  // Fold the date + time pickers into formData.dueAt during render (guarded by
+  // the previous inputs) rather than mirroring them through an effect.
+  const [prevDueInputs, setPrevDueInputs] = useState<{
+    due: Date | null;
+    dueTimeValue: string;
+  } | null>(null);
+  if (prevDueInputs?.due !== due || prevDueInputs?.dueTimeValue !== dueTimeValue) {
+    setPrevDueInputs({ due, dueTimeValue });
+    if (due) {
+      const [hourValue, minuteValue] = String(dueTimeValue || '00:00')
+        .split(':')
+        .map((value) => Number.parseInt(value, 10));
+      const hour = Number.isFinite(hourValue) ? hourValue : 0;
+      const minute = Number.isFinite(minuteValue) ? minuteValue : 0;
+      setFormData((prev) => ({
+        ...prev,
+        dueAt: buildDateInPreferredTimeZone(due, hour * 60 + minute),
+        timezone: prev.timezone || getPreferredTimeZone(),
+      }));
+    }
+  }
 
   // Load the org task templates (and YC library) up front so the single
   // "Load from template" picker is always populated — the form no longer

--- a/apps/frontend/src/app/hooks/useWheelToHorizontalScroll.ts
+++ b/apps/frontend/src/app/hooks/useWheelToHorizontalScroll.ts
@@ -1,5 +1,5 @@
 'use client';
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 /**
  * Walk from `target` up to (but not including) `boundary`, returning true if
@@ -75,7 +75,9 @@ const scrollHorizontallyFromWheel = (
  */
 export const useWheelToHorizontalScroll = ({ ignoreAncestors = false } = {}) => {
   const ignoreAncestorsRef = useRef(ignoreAncestors);
-  ignoreAncestorsRef.current = ignoreAncestors;
+  useEffect(() => {
+    ignoreAncestorsRef.current = ignoreAncestors;
+  });
 
   return useCallback((e: React.WheelEvent<HTMLElement>) => {
     const boundary = e.currentTarget;

--- a/apps/frontend/src/app/ui/filters/FormsFilters/index.tsx
+++ b/apps/frontend/src/app/ui/filters/FormsFilters/index.tsx
@@ -99,19 +99,24 @@ const FormsFilters = ({ filters, onFiltersChange, categoryAction }: FormsFilters
     };
   }, [open]);
 
-  const panelStyle: React.CSSProperties | undefined =
-    open && triggerRef.current
-      ? (() => {
-          const rect = triggerRef.current.getBoundingClientRect();
-          return {
-            position: 'fixed',
-            top: rect.bottom + 6,
-            right: globalThis.window.innerWidth - rect.right,
-            minWidth: Math.max(rect.width, 200),
-            zIndex: 9999,
-          } satisfies React.CSSProperties;
-        })()
-      : undefined;
+  const [panelStyle, setPanelStyle] = useState<React.CSSProperties | undefined>(undefined);
+
+  // Measure the trigger in the click handler (not during render): the panel is
+  // portaled to <body>, so it is positioned from the trigger's viewport rect.
+  const toggleOpen = () => {
+    const next = !open;
+    if (next && triggerRef.current) {
+      const rect = triggerRef.current.getBoundingClientRect();
+      setPanelStyle({
+        position: 'fixed',
+        top: rect.bottom + 6,
+        right: globalThis.window.innerWidth - rect.right,
+        minWidth: Math.max(rect.width, 200),
+        zIndex: 9999,
+      });
+    }
+    setOpen(next);
+  };
 
   const selectCategory = (value: string) => {
     onFiltersChange({ ...filters, category: value as FormsCategory | 'All' });
@@ -151,7 +156,7 @@ const FormsFilters = ({ filters, onFiltersChange, categoryAction }: FormsFilters
         <button
           ref={triggerRef}
           type="button"
-          onClick={() => setOpen((prev) => !prev)}
+          onClick={toggleOpen}
           // No aria-haspopup: the popup is a plain stack of buttons, not a
           // listbox or a menu, and it implements no keyboard model. aria-expanded
           // plus the label below already say what this control does.

--- a/apps/frontend/src/app/ui/filters/InventoryFilters/index.tsx
+++ b/apps/frontend/src/app/ui/filters/InventoryFilters/index.tsx
@@ -143,19 +143,24 @@ const InventoryFilters = ({
   const visibility = filters.visibility ?? 'ALL';
 
   const sliderTranslate = getSliderTranslate(visibility);
-  const dropdownStyle =
-    dropdownOpen && triggerRef.current
-      ? (() => {
-          const rect = triggerRef.current.getBoundingClientRect();
-          return {
-            position: 'fixed',
-            top: rect.bottom + 6,
-            right: globalThis.window.innerWidth - rect.right,
-            minWidth: Math.max(rect.width, 180),
-            zIndex: 9999,
-          } satisfies React.CSSProperties;
-        })()
-      : undefined;
+  const [dropdownStyle, setDropdownStyle] = useState<React.CSSProperties | undefined>(undefined);
+
+  // Measure the trigger in the click handler (not during render): the panel is
+  // portaled to <body>, so it is positioned from the trigger's viewport rect.
+  const toggleDropdown = () => {
+    const next = !dropdownOpen;
+    if (next && triggerRef.current) {
+      const rect = triggerRef.current.getBoundingClientRect();
+      setDropdownStyle({
+        position: 'fixed',
+        top: rect.bottom + 6,
+        right: globalThis.window.innerWidth - rect.right,
+        minWidth: Math.max(rect.width, 180),
+        zIndex: 9999,
+      });
+    }
+    setDropdownOpen(next);
+  };
 
   return (
     <div className="w-full flex items-start justify-between flex-wrap gap-x-6 gap-y-3">
@@ -203,7 +208,7 @@ const InventoryFilters = ({
           ref={triggerRef}
           type="button"
           disabled={loading}
-          onClick={() => setDropdownOpen((v) => !v)}
+          onClick={toggleDropdown}
           className="flex h-10 items-center gap-2 px-3 rounded-2xl! transition-all duration-300 text-[13px] justify-between min-w-30"
           style={getStockHealthButtonStyle(selectedStockHealth)}
         >

--- a/apps/frontend/src/app/ui/inputs/Datepicker/index.tsx
+++ b/apps/frontend/src/app/ui/inputs/Datepicker/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useId, useMemo, useRef } from 'react';
+import React, { useCallback, useId, useMemo, useState } from 'react';
 import ReactDatePicker from 'react-datepicker';
 import { IoIosWarning } from 'react-icons/io';
 import { IoCalendarOutline } from 'react-icons/io5';
@@ -93,15 +93,16 @@ const getComparableDateTime = (date: Date | null | undefined) => {
 };
 
 const useStableDate = (date: Date | null | undefined) => {
-  const dateRef = useRef<Date | null>(date ?? null);
+  const [stableDate, setStableDate] = useState<Date | null>(date ?? null);
   const time = getComparableDateTime(date);
-  const previousTime = getComparableDateTime(dateRef.current);
+  const previousTime = getComparableDateTime(stableDate);
 
   if (time !== previousTime) {
-    dateRef.current = date ?? null;
+    setStableDate(date ?? null);
+    return date ?? null;
   }
 
-  return dateRef.current;
+  return stableDate;
 };
 
 const Datepicker = ({

--- a/apps/frontend/src/app/ui/inputs/Dropdown/LabelDropdown.tsx
+++ b/apps/frontend/src/app/ui/inputs/Dropdown/LabelDropdown.tsx
@@ -244,7 +244,16 @@ const LabelDropdown = ({
 
   const filteredOptions = useFilteredOptions(options, searchQuery);
   const shouldPortal = portal && typeof document !== 'undefined';
-  const isTerminologyLocked = Boolean(dropdownRef.current?.closest(TERMINOLOGY_LOCK_SELECTOR));
+  // Terminology locks are static wrapper attributes, so measuring once when the
+  // trigger mounts is enough; the portal panel re-applies the marker itself.
+  const [isTerminologyLocked, setIsTerminologyLocked] = useState(false);
+  const attachDropdownRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      dropdownRef.current = node;
+      setIsTerminologyLocked(Boolean(node?.closest(TERMINOLOGY_LOCK_SELECTOR)));
+    },
+    [dropdownRef]
+  );
   const activeOptionId =
     activeIndex >= 0 && activeIndex < filteredOptions.length
       ? `${listboxId}-option-${filteredOptions[activeIndex].value}`
@@ -271,13 +280,20 @@ const LabelDropdown = ({
   }, [dropdownRef]);
 
   const computeStyleRef = useRef(computeStyle);
-  computeStyleRef.current = computeStyle;
+  useLayoutEffect(() => {
+    computeStyleRef.current = computeStyle;
+  });
+
+  // Clear the floating style the moment the panel closes (render-time adjust,
+  // guarded so it only fires when open/portal actually change).
+  const [prevOpenPortal, setPrevOpenPortal] = useState({ open, portal });
+  if (prevOpenPortal.open !== open || prevOpenPortal.portal !== portal) {
+    setPrevOpenPortal({ open, portal });
+    if (!open || !portal) setPortalStyle(null);
+  }
 
   useLayoutEffect(() => {
-    if (!open || !portal) {
-      setPortalStyle(null);
-      return;
-    }
+    if (!open || !portal) return;
     computeStyleRef.current();
   }, [open, portal]);
 
@@ -409,7 +425,7 @@ const LabelDropdown = ({
         {icon}
         {placeholder}
       </span>
-      <div className="w-full relative" ref={dropdownRef}>
+      <div className="w-full relative" ref={attachDropdownRef}>
         <button
           type="button"
           className={triggerClassName(open, Boolean(error || hasError))}

--- a/apps/frontend/src/app/ui/inputs/Dropdown/useDropdownPositioning.ts
+++ b/apps/frontend/src/app/ui/inputs/Dropdown/useDropdownPositioning.ts
@@ -41,13 +41,20 @@ export function useDropdownPositioning({
   }, [dropdownRef]);
 
   const computePortalStyleRef = useRef(computePortalStyle);
-  computePortalStyleRef.current = computePortalStyle;
+  useLayoutEffect(() => {
+    computePortalStyleRef.current = computePortalStyle;
+  });
+
+  // Clear the floating style the moment the panel closes (render-time adjust,
+  // guarded so it only fires when open/portal actually change).
+  const [prevOpenPortal, setPrevOpenPortal] = useState({ open, portal });
+  if (prevOpenPortal.open !== open || prevOpenPortal.portal !== portal) {
+    setPrevOpenPortal({ open, portal });
+    if (!open || !portal) setPortalStyle(null);
+  }
 
   useLayoutEffect(() => {
-    if (!open || !portal) {
-      setPortalStyle(null);
-      return;
-    }
+    if (!open || !portal) return;
     computePortalStyleRef.current();
   }, [open, portal]);
 

--- a/apps/frontend/src/app/ui/inputs/MultiSelectDropdown/index.tsx
+++ b/apps/frontend/src/app/ui/inputs/MultiSelectDropdown/index.tsx
@@ -53,13 +53,20 @@ const usePortalPositioning = (
   }, [dropdownRef]);
 
   const computeStyleRef = useRef(computeStyle);
-  computeStyleRef.current = computeStyle;
+  useLayoutEffect(() => {
+    computeStyleRef.current = computeStyle;
+  });
+
+  // Clear the floating style the moment the panel closes (render-time adjust,
+  // guarded so it only fires when open/portal actually change).
+  const [prevOpenPortal, setPrevOpenPortal] = React.useState({ open, portal });
+  if (prevOpenPortal.open !== open || prevOpenPortal.portal !== portal) {
+    setPrevOpenPortal({ open, portal });
+    if (!open || !portal) setPortalStyle(null);
+  }
 
   useLayoutEffect(() => {
-    if (!open || !portal) {
-      setPortalStyle(null);
-      return;
-    }
+    if (!open || !portal) return;
     computeStyleRef.current();
   }, [open, portal]);
 

--- a/apps/frontend/src/app/ui/inputs/Slotpicker/index.tsx
+++ b/apps/frontend/src/app/ui/inputs/Slotpicker/index.tsx
@@ -61,9 +61,9 @@ const Slotpicker = ({
 
   const [viewYear, setViewYear] = useState(() => selectedDate.getFullYear());
   const [viewMonth, setViewMonth] = useState(() => selectedDate.getMonth());
-  const prevSelectedDateRef = useRef(selectedDate);
-  if (prevSelectedDateRef.current !== selectedDate) {
-    prevSelectedDateRef.current = selectedDate;
+  const [prevSelectedDate, setPrevSelectedDate] = useState(selectedDate);
+  if (prevSelectedDate !== selectedDate) {
+    setPrevSelectedDate(selectedDate);
     const newYear = selectedDate.getFullYear();
     const newMonth = selectedDate.getMonth();
     if (viewYear !== newYear) setViewYear(newYear);

--- a/apps/frontend/src/app/ui/layout/Header/GuestHeader/GuestHeader.tsx
+++ b/apps/frontend/src/app/ui/layout/Header/GuestHeader/GuestHeader.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { usePathname, useRouter } from 'next/navigation';
@@ -33,9 +33,9 @@ const GuestHeader = () => {
   const status = useAuthStore((s) => s.status);
   const { user, role } = useAuthStore();
   const [menuOpen, setMenuOpen] = useState(false);
-  const prevPathnameRef = useRef(pathname);
-  if (prevPathnameRef.current !== pathname) {
-    prevPathnameRef.current = pathname;
+  const [prevPathname, setPrevPathname] = useState(pathname);
+  if (prevPathname !== pathname) {
+    setPrevPathname(pathname);
     if (menuOpen) setMenuOpen(false);
   }
   const logoUrl = MEDIA_SOURCES.logo;

--- a/apps/frontend/src/app/ui/layout/PhoneShell/usePhonePrimaryAction.ts
+++ b/apps/frontend/src/app/ui/layout/PhoneShell/usePhonePrimaryAction.ts
@@ -25,7 +25,9 @@ import {
  */
 export function usePhonePrimaryAction(key: FabActionKey, handler: () => void): void {
   const handlerRef = useRef(handler);
-  handlerRef.current = handler;
+  useEffect(() => {
+    handlerRef.current = handler;
+  });
 
   useEffect(() => {
     const onPrimaryAction = (event: Event) => {

--- a/apps/frontend/src/app/ui/layout/PostHogUserSync.tsx
+++ b/apps/frontend/src/app/ui/layout/PostHogUserSync.tsx
@@ -26,43 +26,47 @@ const PostHogUserSync = () => {
   const readyRef = useRef(false);
 
   // syncIdentityRef always points at a closure over the latest attributes/status
-  // (refreshed every render below) so the mount-only event listeners and the
+  // (refreshed after every render below) so the mount-only event listeners and the
   // reactive effect can share one implementation without re-subscribing listeners.
   const syncIdentityRef = useRef<() => void>(() => {});
-  syncIdentityRef.current = () => {
-    const consented = consentedRef.current;
-    const ready = readyRef.current;
+  // No dep array: refresh the closure after every render, before the effects
+  // below (declaration order) ever invoke it.
+  useEffect(() => {
+    syncIdentityRef.current = () => {
+      const consented = consentedRef.current;
+      const ready = readyRef.current;
 
-    if (!consented || !ready) {
-      if (identifiedIdRef.current && ready) {
-        posthog.reset();
-      }
-      identifiedIdRef.current = null;
-      return;
-    }
-
-    if (status !== 'authenticated' && status !== 'signin-authenticated') {
-      if (identifiedIdRef.current) {
-        posthog.reset();
+      if (!consented || !ready) {
+        if (identifiedIdRef.current && ready) {
+          posthog.reset();
+        }
         identifiedIdRef.current = null;
+        return;
       }
-      return;
-    }
 
-    const distinctId = attributes?.sub ?? attributes?.email;
-    if (!distinctId || identifiedIdRef.current === distinctId) {
-      return;
-    }
+      if (status !== 'authenticated' && status !== 'signin-authenticated') {
+        if (identifiedIdRef.current) {
+          posthog.reset();
+          identifiedIdRef.current = null;
+        }
+        return;
+      }
 
-    const personProperties: Record<string, string> = {};
-    addDefinedValue(personProperties, 'email', attributes?.email);
-    addDefinedValue(personProperties, 'first_name', attributes?.given_name);
-    addDefinedValue(personProperties, 'last_name', attributes?.family_name);
-    addDefinedValue(personProperties, 'role', attributes?.['custom:role']);
+      const distinctId = attributes?.sub ?? attributes?.email;
+      if (!distinctId || identifiedIdRef.current === distinctId) {
+        return;
+      }
 
-    posthog.identify(distinctId, personProperties);
-    identifiedIdRef.current = distinctId;
-  };
+      const personProperties: Record<string, string> = {};
+      addDefinedValue(personProperties, 'email', attributes?.email);
+      addDefinedValue(personProperties, 'first_name', attributes?.given_name);
+      addDefinedValue(personProperties, 'last_name', attributes?.family_name);
+      addDefinedValue(personProperties, 'role', attributes?.['custom:role']);
+
+      posthog.identify(distinctId, personProperties);
+      identifiedIdRef.current = distinctId;
+    };
+  });
 
   useEffect(() => {
     consentedRef.current = hasConsent();

--- a/apps/frontend/src/app/ui/layout/UniversalSearch/UniversalSearchPalette.tsx
+++ b/apps/frontend/src/app/ui/layout/UniversalSearch/UniversalSearchPalette.tsx
@@ -596,17 +596,21 @@ const UniversalSearchPalette = () => {
   );
 
   const isOpenRef = useRef(isOpen);
-  isOpenRef.current = isOpen;
   const activeIndexRef = useRef(activeIndex);
-  activeIndexRef.current = activeIndex;
   const resultItemsRef = useRef(resultItems);
-  resultItemsRef.current = resultItems;
   const openRef = useRef(open);
-  openRef.current = open;
   const closeRef = useRef(close);
-  closeRef.current = close;
   const selectItemRef = useRef(selectItem);
-  selectItemRef.current = selectItem;
+  // No dep array: keep the latest values readable from the mount-only keydown
+  // listener below without resubscribing it on every render.
+  useEffect(() => {
+    isOpenRef.current = isOpen;
+    activeIndexRef.current = activeIndex;
+    resultItemsRef.current = resultItems;
+    openRef.current = open;
+    closeRef.current = close;
+    selectItemRef.current = selectItem;
+  });
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
@@ -649,15 +653,31 @@ const UniversalSearchPalette = () => {
     return () => document.removeEventListener('keydown', onKeyDown);
   }, []);
 
+  // Render-phase adjustments (React's documented setState-during-render reset
+  // pattern): clear the query when the route changes, and reset the highlight +
+  // re-read persisted recents whenever the palette opens.
+  const [prevPathname, setPrevPathname] = useState(pathname);
+  if (prevPathname !== pathname) {
+    setPrevPathname(pathname);
+    setQuery('');
+  }
+  // Seeded false (not isOpen) so mounting with the palette already open still
+  // runs the open reset, matching the old effect's mount run.
+  const [prevIsOpen, setPrevIsOpen] = useState(false);
+  if (prevIsOpen !== isOpen) {
+    setPrevIsOpen(isOpen);
+    if (isOpen) {
+      setActiveIndex(0);
+      setRecents(readRecents());
+    }
+  }
+
   useEffect(() => {
     close();
-    setQuery('');
   }, [pathname, close]);
 
   useEffect(() => {
     if (!isOpen) return;
-    setActiveIndex(0);
-    setRecents(readRecents());
     const timeout = globalThis.window?.setTimeout(() => {
       inputRef.current?.focus();
       inputRef.current?.select();

--- a/apps/frontend/src/app/ui/layout/guards/DevRouteGuard/DevRouteGuard.tsx
+++ b/apps/frontend/src/app/ui/layout/guards/DevRouteGuard/DevRouteGuard.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { redirect, usePathname } from 'next/navigation';
 import { getStorageItem } from '@/app/lib/browserStorage';
 import { useAuthStore } from '@/app/stores/authStore';
@@ -19,30 +19,22 @@ const DevRouteGuard = ({ children }: { children: React.ReactNode }) => {
   const pathname = usePathname();
   const authStore = useAuthStore();
   const { status, role } = authStore;
-  const [allowed, setAllowed] = useState(false);
   const isPending = status === 'idle' || status === 'checking';
   const isDevPath = pathname?.startsWith('/developers');
   const devFlag =
     isLocalDeveloperFallbackEnabled() && getStorageItem('session', 'devAuth') === 'true';
   const isDevRole = role === 'developer' || devFlag;
   const isAuthenticated = status === 'authenticated' || status === 'signin-authenticated';
+  // Derived during render: non-dev paths always pass; dev paths need an
+  // authenticated developer. While auth status is pending nothing renders.
+  const allowed = !isPending && (!isDevPath || (isAuthenticated && isDevRole));
 
   useEffect(() => {
     // Wait for auth status to be determined
     if (isPending) return;
 
-    if (!isDevPath) {
-      setAllowed(true);
-      return;
-    }
-
-    if (isAuthenticated && isDevRole) {
-      setAllowed(true);
-      return;
-    }
-
     // Authenticated but not a developer - sign out and redirect
-    if (isAuthenticated && !isDevRole) {
+    if (isDevPath && isAuthenticated && !isDevRole) {
       authStore.signout();
     }
   }, [isPending, isDevPath, isAuthenticated, isDevRole, authStore]);

--- a/apps/frontend/src/app/ui/layout/guards/OrgGuard.tsx
+++ b/apps/frontend/src/app/ui/layout/guards/OrgGuard.tsx
@@ -342,66 +342,31 @@ const OrgGuard = ({ children, skeleton = null }: OrgGuardProps) => {
     setChecked(Boolean(primaryOrgId && readOrgGuardPassed(primaryOrgId)));
   }
 
-  useEffect(() => {
-    if (isAuthGuardDisabled) {
-      setChecked(true);
-      return;
-    }
-    if (isStatusPending(orgStatus)) {
-      return;
-    }
-    if (!primaryOrgId) {
-      setChecked(true);
-      return;
-    }
-    if (shouldWaitForData) {
-      return;
-    }
-
-    if (!primaryOrg || !membership || membership.active === false) {
-      return;
-    }
-
-    const role = membership.roleDisplay ?? membership.roleCode;
-    const availabilities = getAvailabilitiesByOrgId(primaryOrgId);
-    const redirectTo = resolveOrgRedirect({
-      pathname,
-      primaryOrgId,
-      primaryOrg,
-      membership,
-      profile,
-      availabilities,
-    });
-
-    if (redirectTo && redirectTo !== pathname) return;
-
-    const permissionsFallbackRedirect = getPermissionsFallbackRedirect(pathname, membership);
-    if (permissionsFallbackRedirect) return;
-
-    const preferredLanding = resolveDefaultOpenScreenRouteForProfile({
-      profile,
-      orgType: primaryOrg.type,
-      role,
-    });
-    const landingRedirect = applyDefaultLandingRedirect(pathname, primaryOrgId, preferredLanding);
-    if (landingRedirect) return;
-
-    writeOrgGuardPassed(primaryOrgId);
+  // The guard passes when the bypass is on, when there is no org to check, or
+  // when all data is loaded and no redirect applies. `checked` stays sticky:
+  // once a pass is observed it survives later data refetches until the primary
+  // org changes (reset above). Skipped while a redirect is about to throw, so a
+  // pass is only recorded for renders that actually commit — mirroring the
+  // previous effect-based timing.
+  const guardPassed =
+    isAuthGuardDisabled ||
+    (!isStatusPending(orgStatus) &&
+      (!primaryOrgId ||
+        Boolean(
+          !shouldWaitForData &&
+          primaryOrg &&
+          membership &&
+          membership.active !== false &&
+          guardRedirect === null
+        )));
+  if (!guardRedirect && guardPassed && !checked) {
     setChecked(true);
-  }, [
-    isAuthGuardDisabled,
-    primaryOrgId,
-    primaryOrg,
-    pathname,
-    profile,
-    orgStatus,
-    getAvailabilitiesByOrgId,
-    availabilityStatus,
-    profileStatus,
-    membership,
-    teamStatus,
-    shouldWaitForData,
-  ]);
+  }
+
+  useEffect(() => {
+    if (isAuthGuardDisabled || !primaryOrgId || !guardPassed) return;
+    writeOrgGuardPassed(primaryOrgId);
+  }, [isAuthGuardDisabled, primaryOrgId, guardPassed]);
 
   if (guardRedirect) {
     redirect(guardRedirect);

--- a/apps/frontend/src/app/ui/overlays/CalBookingOverlay.tsx
+++ b/apps/frontend/src/app/ui/overlays/CalBookingOverlay.tsx
@@ -11,7 +11,9 @@ type CalBookingOverlayProps = {
 
 const CalBookingOverlay = ({ open, onClose }: CalBookingOverlayProps) => {
   const onCloseRef = useRef(onClose);
-  onCloseRef.current = onClose;
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  });
 
   useEffect(() => {
     if (!open) return;

--- a/apps/frontend/src/app/ui/overlays/Modal/ChangeStatusModal.tsx
+++ b/apps/frontend/src/app/ui/overlays/Modal/ChangeStatusModal.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useState } from 'react';
 import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
 import CenterModal from '@/app/ui/overlays/Modal/CenterModal';
 import ModalHeader from '@/app/ui/overlays/Modal/ModalHeader';
@@ -71,11 +71,11 @@ const ChangeStatusModal = <S extends string>({
   const [selectedStatus, setSelectedStatus] = useState<S>(preferredSelection);
   const [saving, setSaving] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const previousSelectionKeyRef = useRef<string | null>(null);
   const selectionKey = buildSelectionKey(showModal, currentStatus, preferredStatus, statusOptions);
+  const [previousSelectionKey, setPreviousSelectionKey] = useState(selectionKey);
 
-  if (previousSelectionKeyRef.current !== selectionKey) {
-    previousSelectionKeyRef.current = selectionKey;
+  if (previousSelectionKey !== selectionKey) {
+    setPreviousSelectionKey(selectionKey);
     const nextSelection = resolveSelectedStatus(
       currentStatus,
       preferredStatus,

--- a/apps/frontend/src/app/ui/overlays/Modal/ModalBase.tsx
+++ b/apps/frontend/src/app/ui/overlays/Modal/ModalBase.tsx
@@ -54,10 +54,14 @@ const ModalBase = ({
   }, [canClose, setShowModal, onClose]);
 
   const closeModalRef = useRef(closeModal);
-  closeModalRef.current = closeModal;
+  useEffect(() => {
+    closeModalRef.current = closeModal;
+  });
 
   const ignoreOutsideClickRef = useRef(ignoreOutsideClick);
-  ignoreOutsideClickRef.current = ignoreOutsideClick;
+  useEffect(() => {
+    ignoreOutsideClickRef.current = ignoreOutsideClick;
+  });
 
   // Sync inert state and body scroll lock with showModal.
   // Focus is moved in a separate effect that fires after isInert settles (below).

--- a/apps/frontend/src/app/ui/primitives/Accordion/EditableAccordion.tsx
+++ b/apps/frontend/src/app/ui/primitives/Accordion/EditableAccordion.tsx
@@ -1,4 +1,4 @@
-import React, { useImperativeHandle, useMemo, useState, useCallback, useRef } from 'react';
+import React, { useImperativeHandle, useMemo, useState, useCallback } from 'react';
 import Accordion from '@/app/ui/primitives/Accordion/Accordion';
 import FormInput from '@/app/ui/inputs/FormInput/FormInput';
 import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
@@ -452,11 +452,11 @@ const EditableAccordion: React.FC<EditableAccordionProps> = ({
   const [formValues, setFormValues] = useState<FormValues>(() => buildInitialValues(fields, data));
   const [formValuesErrors, setFormValuesErrors] = useState<Record<string, string | undefined>>({});
 
-  const prevDataRef = useRef(data);
-  const prevFieldsRef = useRef(fields);
-  if (prevDataRef.current !== data || prevFieldsRef.current !== fields) {
-    prevDataRef.current = data;
-    prevFieldsRef.current = fields;
+  const [prevData, setPrevData] = useState(data);
+  const [prevFields, setPrevFields] = useState(fields);
+  if (prevData !== data || prevFields !== fields) {
+    setPrevData(data);
+    setPrevFields(fields);
     setFormValues(buildInitialValues(fields, data));
     setFormValuesErrors({});
   }

--- a/apps/frontend/src/app/ui/primitives/RichTextEditor/RichTextEditor.tsx
+++ b/apps/frontend/src/app/ui/primitives/RichTextEditor/RichTextEditor.tsx
@@ -38,7 +38,9 @@ const RichTextEditor = ({
   // `value`) must not destroy and rebuild the editor, which reset DOM focus and
   // the cursor after a single keystroke (the reported bug).
   const onChangeRef = useRef(onChange);
-  onChangeRef.current = onChange;
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  });
 
   // Create the editor ONCE (no dependency array) so it stays mounted across
   // keystrokes, preserving focus, cursor, and Enter behaviour.

--- a/apps/frontend/src/app/ui/tables/FormsTable.tsx
+++ b/apps/frontend/src/app/ui/tables/FormsTable.tsx
@@ -32,24 +32,23 @@ type LinkedServiceOption = { label: string; value: string };
    document for everything else. */
 const getTemplateIcon = (category: string) => {
   const key = String(category ?? '').toLowerCase();
-  if (key.includes('intake')) return IoClipboardOutline;
+  if (key.includes('intake')) return <IoClipboardOutline size={16} aria-hidden="true" />;
   if (key.includes('soap') || key.includes('note') || key.includes('discharge')) {
-    return IoMedkitOutline;
+    return <IoMedkitOutline size={16} aria-hidden="true" />;
   }
-  return IoDocumentTextOutline;
+  return <IoDocumentTextOutline size={16} aria-hidden="true" />;
 };
 
 /* Divs, not spans: `.TableDiv tbody tr td span:not(...)` in Generictable.css
    force-styles every bare span inside a cell (700 weight, 60% opacity). */
 const TemplateNameCell = ({ item }: { item: FormsProps }) => {
-  const Icon = getTemplateIcon(item.category);
   return (
     <div className="flex min-w-0 items-center gap-2.5">
       <div
         className="flex size-9 shrink-0 items-center justify-center rounded-[11px]"
         style={{ background: 'var(--blue-soft)', color: 'var(--blue-text)' }}
       >
-        <Icon size={16} aria-hidden="true" />
+        {getTemplateIcon(item.category)}
       </div>
       <div className="flex min-w-0 flex-col">
         <div className="appointment-profile-title cell-name truncate" title={item.name}>

--- a/apps/frontend/src/app/ui/tables/RowActionMenu.tsx
+++ b/apps/frontend/src/app/ui/tables/RowActionMenu.tsx
@@ -38,6 +38,12 @@ const RowActionMenu = ({
   const changeOpen = useCallback(
     (next: boolean) => {
       setOpen(next);
+      if (!next) {
+        // Reset for the next open cycle: drop the stale position and re-arm
+        // the once-per-open re-measure pass below.
+        setStyle(null);
+        measuredRef.current = false;
+      }
       onOpenChange?.(next);
     },
     [onOpenChange]
@@ -81,11 +87,7 @@ const RowActionMenu = ({
   }, []);
 
   useLayoutEffect(() => {
-    if (!open) {
-      setStyle(null);
-      measuredRef.current = false;
-      return;
-    }
+    if (!open) return;
     position();
   }, [open, position]);
 
@@ -105,7 +107,9 @@ const RowActionMenu = ({
   // once per open (deps: [open]) instead of re-subscribing whenever the parent
   // re-creates onOpenChange.
   const closeMenuRef = useRef(() => changeOpen(false));
-  closeMenuRef.current = () => changeOpen(false);
+  useEffect(() => {
+    closeMenuRef.current = () => changeOpen(false);
+  });
 
   useEffect(() => {
     if (!open) return;

--- a/apps/frontend/src/app/ui/theme/useTheme.ts
+++ b/apps/frontend/src/app/ui/theme/useTheme.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useSyncExternalStore } from 'react';
 
 export type Theme = 'light' | 'dark';
 
@@ -62,22 +62,36 @@ const applyTheme = (theme: Theme, persist: boolean) => {
   globalThis.dispatchEvent(new CustomEvent(THEME_CHANGE_EVENT, { detail: { theme } }));
 };
 
+/** Re-read theme + appearance whenever any toggle instance broadcasts a change (for useSyncExternalStore). */
+const subscribeToThemeChange = (onStoreChange: () => void): (() => void) => {
+  globalThis.addEventListener(THEME_CHANGE_EVENT, onStoreChange);
+  return () => globalThis.removeEventListener(THEME_CHANGE_EVENT, onStoreChange);
+};
+
+/** SSR always renders the defaults; the client re-reads the real values on hydration. */
+const getServerTheme = (): Theme => 'light';
+const getServerAppearance = (): Appearance => 'auto';
+
 /**
  * Light/dark theme controller for the PIMS app surface. The source of truth is the
- * `data-theme` attribute on <html> (set pre-paint in the app route-group layout). This
- * hook mirrors it into React state for the toggle icon, follows OS changes while no
- * explicit choice is stored, and enables the flip transition shortly after first paint.
+ * `data-theme` attribute on <html> (set pre-paint in the app route-group layout) plus
+ * the stored `yc-theme` choice. Both are read through useSyncExternalStore — every
+ * applyTheme dispatches the shared change event, keeping all toggle instances in sync.
+ * The hook follows OS changes while no explicit choice is stored, and enables the flip
+ * transition shortly after first paint.
  *
  * It shares the `yc-theme` storage key and `yc-theme-change` event with the marketing
  * surface so a single theme choice is honored across the whole product.
  */
 export function useTheme() {
-  const [theme, setTheme] = useState<Theme>('light');
-  const [appearanceState, setAppearanceState] = useState<Appearance>('auto');
+  const theme = useSyncExternalStore(subscribeToThemeChange, readTheme, getServerTheme);
+  const appearance = useSyncExternalStore(
+    subscribeToThemeChange,
+    readAppearance,
+    getServerAppearance
+  );
 
   useEffect(() => {
-    setTheme(readTheme());
-    setAppearanceState(readAppearance());
     syncMetaThemeColor();
 
     // Enable the flip transition after first paint so the initial paint never animates.
@@ -85,15 +99,8 @@ export function useTheme() {
       globalThis.document.documentElement.dataset.themeReady = '1';
     }, 60);
 
-    // Keep every toggle instance's icon in sync when any of them flips the theme.
-    const onThemeChange = (event: Event) => {
-      const next = (event as CustomEvent<{ theme: Theme }>).detail?.theme ?? readTheme();
-      setTheme(next);
-      setAppearanceState(readAppearance());
-    };
-    globalThis.addEventListener(THEME_CHANGE_EVENT, onThemeChange);
-
     // Follow OS changes only while the visitor hasn't explicitly chosen a theme.
+    // applyTheme broadcasts the change event, so every subscribed instance re-reads.
     const mq = globalThis.matchMedia?.('(prefers-color-scheme: dark)');
     const onOSChange = (event: MediaQueryListEvent) => {
       let saved: string | null = null;
@@ -104,15 +111,12 @@ export function useTheme() {
       }
       if (!saved) {
         applyTheme(event.matches ? 'dark' : 'light', false);
-        setTheme(event.matches ? 'dark' : 'light');
-        setAppearanceState('auto');
       }
     };
     mq?.addEventListener('change', onOSChange);
 
     return () => {
       globalThis.clearTimeout(readyTimer);
-      globalThis.removeEventListener(THEME_CHANGE_EVENT, onThemeChange);
       mq?.removeEventListener('change', onOSChange);
     };
   }, []);
@@ -120,7 +124,6 @@ export function useTheme() {
   const toggle = useCallback(() => {
     const next: Theme = readTheme() === 'dark' ? 'light' : 'dark';
     applyTheme(next, true);
-    setTheme(next);
   }, []);
 
   /**
@@ -135,15 +138,11 @@ export function useTheme() {
       } catch {
         /* private mode: nothing persisted to clear */
       }
-      const resolved = osTheme();
-      applyTheme(resolved, false);
-      setTheme(resolved);
+      applyTheme(osTheme(), false);
     } else {
       applyTheme(next, true);
-      setTheme(next);
     }
-    setAppearanceState(next);
   }, []);
 
-  return { theme, toggle, appearance: appearanceState, setAppearance };
+  return { theme, toggle, appearance, setAppearance };
 }

--- a/apps/frontend/src/app/ui/widgets/Summary/AppointmentTask.tsx
+++ b/apps/frontend/src/app/ui/widgets/Summary/AppointmentTask.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useMemo, useRef, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import Appointments from '@/app/ui/tables/Appointments';
@@ -104,15 +104,15 @@ const AppointmentTask = () => {
   const [activeSubLabel, setActiveSubLabel] = useState('all');
 
   const popupsOpen = viewPopup || detailPopup;
-  const prevPopupsOpenRef = useRef(popupsOpen);
-  if (prevPopupsOpenRef.current !== popupsOpen) {
-    prevPopupsOpenRef.current = popupsOpen;
+  const [prevPopupsOpen, setPrevPopupsOpen] = useState(popupsOpen);
+  if (prevPopupsOpen !== popupsOpen) {
+    setPrevPopupsOpen(popupsOpen);
     if (!popupsOpen) setViewIntent(null);
   }
 
-  const prevActiveTableRef = useRef(activeTable);
-  if (prevActiveTableRef.current !== activeTable) {
-    prevActiveTableRef.current = activeTable;
+  const [prevActiveTable, setPrevActiveTable] = useState(activeTable);
+  if (prevActiveTable !== activeTable) {
+    setPrevActiveTable(activeTable);
     resetActiveTableState(activeTable, activeSubLabel, viewTaskPopup, {
       setActiveSubLabel,
       setViewTaskPopup,
@@ -125,15 +125,15 @@ const AppointmentTask = () => {
     });
   }
 
-  const prevAppointmentsRef = useRef(appointments);
-  if (prevAppointmentsRef.current !== appointments) {
-    prevAppointmentsRef.current = appointments;
+  const [prevAppointments, setPrevAppointments] = useState(appointments);
+  if (prevAppointments !== appointments) {
+    setPrevAppointments(appointments);
     setActiveAppointment((prev) => getNextSelectedAppointment(prev, appointments));
   }
 
-  const prevTasksRef = useRef(tasks);
-  if (prevTasksRef.current !== tasks) {
-    prevTasksRef.current = tasks;
+  const [prevTasks, setPrevTasks] = useState(tasks);
+  if (prevTasks !== tasks) {
+    setPrevTasks(tasks);
     setActiveTask((prev) => getNextSelectedTask(prev, tasks));
   }
 

--- a/apps/frontend/src/app/ui/widgets/Summary/Availability.tsx
+++ b/apps/frontend/src/app/ui/widgets/Summary/Availability.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import clsx from 'clsx';
 import AvailabilityTable from '@/app/ui/tables/AvailabilityTable';
 import { useTeamForPrimaryOrg } from '@/app/hooks/useTeam';
@@ -35,7 +35,9 @@ const Availability = () => {
     });
   }, [teams, selectedLabel]);
 
-  useEffect(() => {
+  const [prevTeams, setPrevTeams] = useState(teams);
+  if (prevTeams !== teams) {
+    setPrevTeams(teams);
     setActiveTeam((prev) => {
       if (teams.length === 0) return null;
       if (prev?._id) {
@@ -44,7 +46,7 @@ const Availability = () => {
       }
       return teams[0];
     });
-  }, [teams]);
+  }
 
   return (
     <PermissionGate allOf={[PERMISSIONS.TEAMS_VIEW_ANY]}>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -621,6 +621,9 @@ importers:
       eslint-config-next:
         specifier: 15.5.18
         version: 15.5.18(eslint@9.39.2)(typescript@5.9.3)
+      eslint-plugin-react-hooks:
+        specifier: ^7.1.1
+        version: 7.1.1(eslint@9.39.2)
       eslint-plugin-sonarjs:
         specifier: ^3.0.7
         version: 3.0.7(eslint@9.39.2)
@@ -3446,7 +3449,7 @@ packages:
     dependencies:
       '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/traverse': 7.29.8
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -3676,7 +3679,7 @@ packages:
       '@babel/core': 7.29.6
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/traverse': 7.29.8
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -3886,7 +3889,7 @@ packages:
       '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.8
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -4061,7 +4064,7 @@ packages:
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.6)
       '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.6)
-      '@babel/traverse': 7.29.8
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -19648,7 +19651,7 @@ packages:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
     dependencies:
       '@babel/core': 7.29.6
-      '@babel/parser': 7.29.7
+      '@babel/parser': 7.29.8
       eslint: 9.39.2
       hermes-parser: 0.25.1
       zod: 3.25.76


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

Every recreation of the Dependabot minor-and-patch group (#2069 -> #2072 -> #2074 -> #2075) fails `next build` with ~225 `react-hooks/*` errors, so ~90 routine dependency updates cannot land.

**The mechanism is a hoist lottery, not a declared upgrade.** The frontend's ESLint config loads `next/core-web-vitals` through `FlatCompat`, which resolves `eslint-plugin-react-hooks` by walking up from the project directory - landing on whatever single copy `.npmrc`'s `shamefully-hoist` put in the root `node_modules`. Today's lockfile hoists `5.2.0`, so dev builds. The group's regenerated lockfile flips the hoist winner to `7.1.1` - pulled in by `react-doctor@0.9.5`, not by any ESLint package - and v7 turns the React Compiler rules on as errors. `eslint-config-next` itself declares `^5.0.0` and never asked for any of this. Which lint rules gate the build was effectively decided by pnpm's hoist order.

Separately, the group keeps upgrading **react-doctor itself** (a CI gate) because it is 0.x, where semver labels every feature release a "minor". The 0.2.14 -> 0.9.5 ride-along both flips the hoist above and adds a `low-supply-chain-score` rule that fails on this repo's own security override pins.

## What is the new behavior?

**The migration is taken deliberately, and the lottery is closed.**

1. **`eslint-plugin-react-hooks@^7.1.1` is a direct frontend devDependency.** FlatCompat now finds it deterministically in `apps/frontend/node_modules` regardless of hoist order, and the codebase is clean under it.

2. **All 225 errors across 102 files fixed - zero suppressions** (no `eslint-disable`, no config downgrades). By rule:

| Rule | Count | Fix pattern |
| --- | --- | --- |
| `refs` | 136 | Latest-value ref writes moved into dep-less `useEffect`s; render reads of `ref.current` replaced with state (callback-ref-to-state for DOM containers; portal positioning measured in `useLayoutEffect` pre-paint, so no visible change) |
| `set-state-in-effect` | 68 | State derived during render where possible; prop-driven resets converted to the React-documented adjust-during-render guard; external sources moved to async-safe/subscription forms; mirror states deleted in favour of reading the source |
| `preserve-manual-memoization` | 13 | Dep lists completed, or narrow locals hoisted so the compiler's inferred deps match the declared ones (recompute frequency unchanged) |
| `purity` / `immutability` / `use-memo` / `static-components` | 8 | Impure reads (`Date.now`) sampled once; ref declaration order fixed; inline components hoisted to module scope |

3. **`dependabot.yml` ignores react-doctor semver-minor/major.** Patches still flow; feature releases of a tool that gates CI become deliberate, reviewed upgrades. (Same disease as the earlier `update-types` fix in #2070 - CI-gating tools must not upgrade themselves inside routine batches.)

After this lands, `@dependabot recreate` on #2075 produces a batch with both failure sources structurally removed.

## Validation

- `npx eslint . --ext .ts,.tsx`: clean - **0 react-hooks errors and no new errors of any kind**
- `npx tsc --noEmit`: clean
- Full suite: **877 suites / 10,816 tests pass** (4 tests added alongside the refactors)
- `npx next build`: succeeds **including the "Linting and checking validity of types" stage that failed on every group PR**
- `react-doctor@0.7.4` (the version the CI action pins): error count identical to dev (the one pre-existing `search-index.json` finding); one "Derived state stored in an effect" warning is actually fixed by the migration; two new warning-level notes appeared where refactors shifted patterns - fixing those would reintroduce the exact ref patterns the hooks rules ban, so they stay as warnings

The work was done in 12 parallel batches, each self-verified with per-file eslint and targeted jest before the tree-wide eslint + tsc + full suite + production build above.

## Related Issue(s)

Fixes #
