### PR TITLE
docs(ci): note that dependabot.yml only takes effect from main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,15 +24,14 @@ updates:
     commit-message:
       prefix: 'chore(repo)'
     ignore:
-      # react-doctor gates CI (the React Doctor score check) and is still 0.x,
-      # where semver calls every new feature release a "minor" - so it slips
-      # into the minor-and-patch group and upgrades ITSELF inside a 90-package
-      # batch, bringing new rules that fail the very PR carrying it (0.2.14 ->
-      # 0.9.5 added low-supply-chain-score, which fired on this repo's own
-      # override pins). Patches still flow; feature releases of a CI-gating
-      # tool are deliberate, reviewed upgrades.
+      # react-doctor is fully frozen for dependabot - not just minors/majors.
+      # The React Doctor CI action flags any bump of the react-doctor package
+      # itself with its low-supply-chain-score rule (even the 0.2.14 -> 0.2.16
+      # PATCH failed the gate on #2082), so every batch that touches it goes
+      # red on the tool's own judgement of itself. No update-types list means
+      # ignore ALL updates; upgrades are deliberate, manual, and reviewed
+      # together with the pinned CLI version in react-doctor.yml.
       - dependency-name: 'react-doctor'
-        update-types: ['version-update:semver-minor', 'version-update:semver-major']
     groups:
       # Every group is minor-and-patch only, including the named ones below. A
       # named group without `update-types` silently swallows MAJORS too, which is

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,7 @@
+# NOTE: dependabot reads this file from the DEFAULT branch (main), not from dev -
+# target-branch below only aims the PRs at dev. Any change here must land on
+# main to take effect, so keep the copies on dev and main byte-identical
+# (see PR #2079, which fixed a month of silently inert config changes).
 version: 2
 updates:
   - package-ecosystem: npm


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [ ] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

Nothing in dependabot.yml records that Dependabot reads it from the default branch. That gap is exactly how a month of config fixes sat silently inert on dev (fixed by #2079).

## What is the new behavior?

A four-line comment at the top of the file records the gotcha and the keep-both-branches-identical rule. A twin PR lands the identical file on main - which doubles as the trigger for Dependabot's immediate update check, replacing the batch PR it closed after the config change (#2075).

## Related Issue(s)

Fixes #