### PR TITLE
ci(repo): fully freeze react-test-renderer and posthog-js for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,8 +55,16 @@ updates:
         update-types: ['version-update:semver-minor', 'version-update:semver-major']
       - dependency-name: '@stripe/stripe-react-native'
         update-types: ['version-update:semver-minor', 'version-update:semver-major']
+      # react-test-renderer is fully frozen: @testing-library/react-native
+      # requires it to EXACTLY equal the react version RN pins, so even the
+      # 19.1.0 -> 19.1.9 PATCH failed every mobile suite (#2096). It moves
+      # only with a deliberate RN upgrade.
       - dependency-name: 'react-test-renderer'
-        update-types: ['version-update:semver-minor', 'version-update:semver-major']
+      # posthog-js is fully frozen at ^1.391.7: the React Doctor gate scores
+      # the lowest version a range allows via Socket, and every 1.4x range so
+      # far scores below the 50 minimum (1.413.x scored 31/100 on #2088 and
+      # #2096). Re-bump deliberately once the Socket score recovers.
+      - dependency-name: 'posthog-js'
     groups:
       # Every group is minor-and-patch only, including the named ones below. A
       # named group without `update-types` silently swallows MAJORS too, which is


### PR DESCRIPTION
react-test-renderer must exactly equal the react version RN pins - even the 19.1.0 -> 19.1.9 PATCH failed all 457 mobile suites on #2096 (@testing-library/react-native enforces the equality). posthog-js 1.4x ranges keep scoring 31/100 on Socket's supply-chain axis, below the React Doctor gate's minimum of 50, re-redding every batch that bumps it. Both join react-doctor as fully-frozen dependencies that move only as deliberate reviewed changes; a twin PR lands the byte-identical file on main, the copy dependabot actually reads. After both merge, recreating #2096 should finally produce a clean batch.