### PR TITLE
fix(ci): remove the duplicate with key breaking desktop-release validation

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -274,8 +274,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-        with:
-          persist-credentials: false
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [ ] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

Since #2077 merged (07:23 today), every push on every branch produces a jobless failed "Desktop Release" run - 68 failures and counting - with GitHub's "this run likely failed because of a workflow file issue". The release job's checkout step carries a duplicated `with:` block. YAML parsers tolerate duplicate keys (last one wins), so the file parses locally, but GitHub's workflow validator rejects it outright. Consequence beyond the noise: a real `v*` tag push could not have produced a desktop release.

## What is the new behavior?

The duplicate block is removed (one line change). Verified with actionlint, which implements GitHub's validation and pinpointed the exact line; a sweep of every other workflow file with actionlint's syntax-check comes back clean, so this was the only one.

## Related Issue(s)

Fixes #