### PR TITLE
fix(repo): clear the dev-to-main promotion gate blockers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -65,6 +65,10 @@ updates:
       # far scores below the 50 minimum (1.413.x scored 31/100 on #2088 and
       # #2096). Re-bump deliberately once the Socket score recovers.
       - dependency-name: 'posthog-js'
+      # google-auth-library 11 requires node >=22 at runtime; the backend image
+      # runs node 18 - unfreeze together with the runtime upgrade.
+      - dependency-name: 'google-auth-library'
+        update-types: ['version-update:semver-major']
     groups:
       # Every group is minor-and-patch only, including the named ones below. A
       # named group without `update-types` silently swallows MAJORS too, which is

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -155,6 +155,21 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Ensure the dispatched ref is the release tag
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          REF: ${{ github.ref }}
+          TAG: ${{ inputs.release_tag }}
+        run: |
+          # The sbom job builds from the DISPATCHED ref while TAG names an
+          # existing release, and `gh release upload --clobber` replaces that
+          # release's assets - so a dispatch from any other ref would swap the
+          # release's SBOMs for ones built from different code. Fail closed.
+          if [ "${REF}" != "refs/tags/${TAG}" ]; then
+            echo "dispatch ref ${REF} does not match refs/tags/${TAG} - run this workflow FROM the release tag so the uploaded SBOMs describe the released code" >&2
+            exit 1
+          fi
+
       - name: Download the gated SBOM artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -24,6 +24,16 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: >-
+          Attach SBOMs to an existing release with this tag (for releases
+          published via GITHUB_TOKEN that emit no release event). Run the
+          dispatch from the tag ref so the SBOM is built from the released
+          code.
+        type: string
+        required: false
+        default: ''
 
 concurrency:
   group: supply-chain-${{ github.event.pull_request.number || github.ref }}
@@ -131,11 +141,14 @@ jobs:
 
   publish-release-sboms:
     name: Attach SBOMs to the release
-    # Only the release event carries a release to attach assets to. Tag pushes
-    # from workflows publishing via GITHUB_TOKEN still get gated + archived
-    # SBOMs through the jobs above; attaching those is a manual rerun of this
-    # workflow from the release once it exists.
-    if: github.event_name == 'release'
+    # The release event carries the target tag itself. Releases published by
+    # workflows using GITHUB_TOKEN (desktop-release, release-notes) emit no
+    # release event, so those are covered by a workflow_dispatch run with
+    # release_tag set - dispatched FROM THE TAG REF, so the sbom job above
+    # builds from the released code and the assets match the release.
+    if: >-
+      github.event_name == 'release' ||
+      (github.event_name == 'workflow_dispatch' && inputs.release_tag != '')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [sbom]
@@ -151,7 +164,7 @@ jobs:
       - name: Upload SBOMs as release assets
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ github.event.release.tag_name }}
+          TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
           REPO: ${{ github.repository }}
         run: |
           gh release upload "$TAG" \

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -47,7 +47,7 @@
     "express-rate-limit": "^8.6.2",
     "fhir": "4.12.0",
     "firebase-admin": "^13.6.0",
-    "google-auth-library": "^11.0.0",
+    "google-auth-library": "^10.9.1",
     "helmet": "^8.3.0",
     "jsonwebtoken": "9.0.3",
     "jwks-rsa": "^3.2.0",

--- a/apps/backend/src/services/finance/payment.ts
+++ b/apps/backend/src/services/finance/payment.ts
@@ -13,6 +13,7 @@ import { prisma } from "src/config/prisma";
 import logger from "src/utils/logger";
 import { FinanceEventService } from "./events";
 import { roundMoney } from "./pricing";
+import { markInvoiceTreatmentItemsSettled } from "./settlement";
 
 type PaymentLineSummary = {
   id: string;
@@ -277,6 +278,33 @@ const applyCheckoutSessionTaxToInvoice = async (
   const taxPercent =
     subtotal > 0 ? roundMoney((taxAmount / subtotal) * 100) : 0;
 
+  const sessionAmounts = {
+    sessionId: input.sessionId,
+    amountSubtotal: input.amountSubtotal ?? null,
+    amountTotal: input.amountTotal ?? null,
+    amountTax: input.amountTax ?? null,
+    automaticTaxStatus: input.automaticTaxStatus ?? null,
+  };
+
+  const buildTaxSnapshotData = () => ({
+    provider: "STRIPE" as const,
+    providerReferenceId: input.sessionId,
+    jurisdictionCountry: null,
+    jurisdictionState: null,
+    taxBehavior: invoice.taxSnapshot?.taxBehavior ?? null,
+    taxableSubtotal: subtotal,
+    taxAmount,
+    taxBreakdown: {
+      subtotal,
+      taxableSubtotal: subtotal,
+      taxTotal: taxAmount,
+      totalAmount,
+      ...sessionAmounts,
+    },
+    rawProviderPayload: input.rawProviderPayload ?? sessionAmounts,
+    calculatedAt: new Date(),
+  });
+
   return prisma.invoice.update({
     where: { id: invoice.id },
     data: {
@@ -287,62 +315,8 @@ const applyCheckoutSessionTaxToInvoice = async (
       totalAmount,
       taxSnapshot: {
         upsert: {
-          create: {
-            provider: "STRIPE",
-            providerReferenceId: input.sessionId,
-            jurisdictionCountry: null,
-            jurisdictionState: null,
-            taxBehavior: invoice.taxSnapshot?.taxBehavior ?? null,
-            taxableSubtotal: subtotal,
-            taxAmount,
-            taxBreakdown: {
-              subtotal,
-              taxableSubtotal: subtotal,
-              taxTotal: taxAmount,
-              totalAmount,
-              sessionId: input.sessionId,
-              amountSubtotal: input.amountSubtotal ?? null,
-              amountTotal: input.amountTotal ?? null,
-              amountTax: input.amountTax ?? null,
-              automaticTaxStatus: input.automaticTaxStatus ?? null,
-            },
-            rawProviderPayload: input.rawProviderPayload ?? {
-              sessionId: input.sessionId,
-              amountSubtotal: input.amountSubtotal ?? null,
-              amountTotal: input.amountTotal ?? null,
-              amountTax: input.amountTax ?? null,
-              automaticTaxStatus: input.automaticTaxStatus ?? null,
-            },
-            calculatedAt: new Date(),
-          },
-          update: {
-            provider: "STRIPE",
-            providerReferenceId: input.sessionId,
-            jurisdictionCountry: null,
-            jurisdictionState: null,
-            taxBehavior: invoice.taxSnapshot?.taxBehavior ?? null,
-            taxableSubtotal: subtotal,
-            taxAmount,
-            taxBreakdown: {
-              subtotal,
-              taxableSubtotal: subtotal,
-              taxTotal: taxAmount,
-              totalAmount,
-              sessionId: input.sessionId,
-              amountSubtotal: input.amountSubtotal ?? null,
-              amountTotal: input.amountTotal ?? null,
-              amountTax: input.amountTax ?? null,
-              automaticTaxStatus: input.automaticTaxStatus ?? null,
-            },
-            rawProviderPayload: input.rawProviderPayload ?? {
-              sessionId: input.sessionId,
-              amountSubtotal: input.amountSubtotal ?? null,
-              amountTotal: input.amountTotal ?? null,
-              amountTax: input.amountTax ?? null,
-              automaticTaxStatus: input.automaticTaxStatus ?? null,
-            },
-            calculatedAt: new Date(),
-          },
+          create: buildTaxSnapshotData(),
+          update: buildTaxSnapshotData(),
         },
       },
     },
@@ -416,28 +390,7 @@ const updateInvoiceAfterPayment = async (params: {
           : {}),
       },
     });
-    const invoiceRowIds = (Array.isArray(invoice.items) ? invoice.items : [])
-      .map((item) =>
-        typeof item === "object" &&
-        item !== null &&
-        "id" in item &&
-        typeof item.id === "string"
-          ? item.id
-          : null,
-      )
-      .filter((id): id is string => Boolean(id));
-    if (invoiceRowIds.length > 0) {
-      await prisma.workspaceTreatmentItem.updateMany({
-        where: {
-          appointmentId: invoice.appointmentId,
-          invoiceRowId: { in: invoiceRowIds },
-        },
-        data: {
-          settledInvoiceId: invoiceId,
-          settledAt: receivedAt,
-        },
-      });
-    }
+    await markInvoiceTreatmentItemsSettled(invoice, invoiceId, receivedAt);
     return settledInvoice;
   }
 

--- a/apps/backend/src/services/finance/settlement.ts
+++ b/apps/backend/src/services/finance/settlement.ts
@@ -1,0 +1,33 @@
+import type { Prisma } from "@prisma/client";
+import { prisma } from "src/config/prisma";
+
+// Stamp the workspace treatment items billed on an invoice as settled so the
+// visit workspace stops offering them for further billing.
+export const markInvoiceTreatmentItemsSettled = async (
+  invoice: { appointmentId: string | null; items: Prisma.JsonValue },
+  settledInvoiceId: string,
+  settledAt: Date,
+) => {
+  const invoiceRowIds = (Array.isArray(invoice.items) ? invoice.items : [])
+    .map((item) =>
+      typeof item === "object" &&
+      item !== null &&
+      "id" in item &&
+      typeof item.id === "string"
+        ? item.id
+        : null,
+    )
+    .filter((id): id is string => Boolean(id));
+  if (invoiceRowIds.length > 0) {
+    await prisma.workspaceTreatmentItem.updateMany({
+      where: {
+        appointmentId: invoice.appointmentId,
+        invoiceRowId: { in: invoiceRowIds },
+      },
+      data: {
+        settledInvoiceId,
+        settledAt,
+      },
+    });
+  }
+};

--- a/apps/backend/src/services/invoice.service.ts
+++ b/apps/backend/src/services/invoice.service.ts
@@ -28,6 +28,7 @@ import {
   getInvoiceFinancialSummary,
 } from "./finance/payment";
 import { FinanceEventService } from "./finance/events";
+import { markInvoiceTreatmentItemsSettled } from "./finance/settlement";
 import { createRenderedDocumentRecord } from "./rendered-document.service";
 import { prisma } from "src/config/prisma";
 import { CatalogService, CatalogServiceError } from "./catalog.service";
@@ -1093,28 +1094,7 @@ const recordInvoicePaidState = async (invoice: PrismaInvoice, paidAt: Date) => {
       visitBillingStage: "SETTLED",
     },
   });
-  const invoiceRowIds = (Array.isArray(invoice.items) ? invoice.items : [])
-    .map((item) =>
-      typeof item === "object" &&
-      item !== null &&
-      "id" in item &&
-      typeof item.id === "string"
-        ? item.id
-        : null,
-    )
-    .filter((id): id is string => Boolean(id));
-  if (invoiceRowIds.length > 0) {
-    await prisma.workspaceTreatmentItem.updateMany({
-      where: {
-        appointmentId: invoice.appointmentId,
-        invoiceRowId: { in: invoiceRowIds },
-      },
-      data: {
-        settledInvoiceId: invoice.id,
-        settledAt: paidAt,
-      },
-    });
-  }
+  await markInvoiceTreatmentItemsSettled(invoice, invoice.id, paidAt);
 
   await recordInvoiceAuditForRow(updated, "INVOICE_PAID", updated.id, {
     status: updated.status,

--- a/apps/backend/src/services/organization.service.ts
+++ b/apps/backend/src/services/organization.service.ts
@@ -12,6 +12,7 @@ import { SpecialityService } from "./speciality.service";
 import { OrganisationRoomService } from "./organisation-room.service";
 import { buildS3Key, moveFile } from "src/middlewares/upload";
 import logger from "src/utils/logger";
+import { pruneUndefined } from "src/utils/prune-undefined";
 import { Prisma } from "@prisma/client";
 import { prisma } from "src/config/prisma";
 import { buildGeoPoint } from "src/utils/geojson";
@@ -152,37 +153,6 @@ const sanitizeTypeCoding = (
       "Organization type display",
     ),
   };
-};
-
-const pruneUndefined = <T>(value: T): T => {
-  if (Array.isArray(value)) {
-    const arrayValue = value as unknown[];
-    const cleaned: unknown[] = arrayValue
-      .map((item) => pruneUndefined(item))
-      .filter((item) => item !== undefined);
-    return cleaned as unknown as T;
-  }
-
-  if (value && typeof value === "object") {
-    if (value instanceof Date) {
-      return value;
-    }
-
-    const record = value as Record<string, unknown>;
-    const cleanedRecord: Record<string, unknown> = {};
-
-    for (const [key, entryValue] of Object.entries(record)) {
-      const next = pruneUndefined(entryValue);
-
-      if (next !== undefined) {
-        cleanedRecord[key] = next;
-      }
-    }
-
-    return cleanedRecord as unknown as T;
-  }
-
-  return value;
 };
 
 const requireSafeString = (value: unknown, fieldName: string): string => {
@@ -679,6 +649,43 @@ const createPersistableFromFHIR = (payload: OrganizationFHIRPayload) => {
   return { persistable, attributes };
 };
 
+const buildOrganizationWriteData = (persistable: OrganizationMongo) => ({
+  fhirId: persistable.fhirId ?? undefined,
+  name: persistable.name,
+  taxId: persistable.taxId,
+  dunsNumber: persistable.DUNSNumber ?? undefined,
+  imageUrl: persistable.imageURL ?? undefined,
+  type: persistable.type,
+  petNamePreference: persistable.petNamePreference ?? undefined,
+  phoneNo: persistable.phoneNo,
+  website: persistable.website ?? undefined,
+  documensoTeamId: persistable.documensoTeamId ?? undefined,
+  documensoApiKey: persistable.documensoApiKey ?? undefined,
+  isVerified: persistable.isVerified ?? false,
+  isActive: persistable.isActive ?? true,
+  typeCoding: (persistable.typeCoding ??
+    undefined) as unknown as Prisma.InputJsonValue,
+  healthAndSafetyCertNo: persistable.healthAndSafetyCertNo ?? undefined,
+  animalWelfareComplianceCertNo:
+    persistable.animalWelfareComplianceCertNo ?? undefined,
+  fireAndEmergencyCertNo: persistable.fireAndEmergencyCertNo ?? undefined,
+  googlePlacesId: persistable.googlePlacesId ?? undefined,
+  stripeAccountId: persistable.stripeAccountId ?? undefined,
+  averageRating: persistable.averageRating ?? 0,
+  ratingCount: persistable.ratingCount ?? 0,
+  appointmentCheckInBufferMinutes:
+    persistable.appointmentCheckInBufferMinutes ??
+    DEFAULT_APPOINTMENT_CHECK_IN_BUFFER_MINUTES,
+  appointmentCheckInRadiusMeters:
+    persistable.appointmentCheckInRadiusMeters ??
+    DEFAULT_APPOINTMENT_CHECK_IN_RADIUS_METERS,
+  appointmentLockWindowOutpatientMinutes:
+    persistable.appointmentLockWindowOutpatientMinutes ?? undefined,
+  appointmentLockWindowInpatientMinutes:
+    persistable.appointmentLockWindowInpatientMinutes ?? undefined,
+  crossOrgMessagingEnabled: persistable.crossOrgMessagingEnabled ?? false,
+});
+
 export const OrganizationService = {
   async upsert(payload: OrganizationFHIRPayload, userId?: string) {
     const { persistable, attributes } = createPersistableFromFHIR(payload);
@@ -692,42 +699,7 @@ export const OrganizationService = {
         })
       : null;
 
-    const data = {
-      fhirId: persistable.fhirId ?? undefined,
-      name: persistable.name,
-      taxId: persistable.taxId,
-      dunsNumber: persistable.DUNSNumber ?? undefined,
-      imageUrl: persistable.imageURL ?? undefined,
-      type: persistable.type,
-      petNamePreference: persistable.petNamePreference ?? undefined,
-      phoneNo: persistable.phoneNo,
-      website: persistable.website ?? undefined,
-      documensoTeamId: persistable.documensoTeamId ?? undefined,
-      documensoApiKey: persistable.documensoApiKey ?? undefined,
-      isVerified: persistable.isVerified ?? false,
-      isActive: persistable.isActive ?? true,
-      typeCoding: (persistable.typeCoding ??
-        undefined) as unknown as Prisma.InputJsonValue,
-      healthAndSafetyCertNo: persistable.healthAndSafetyCertNo ?? undefined,
-      animalWelfareComplianceCertNo:
-        persistable.animalWelfareComplianceCertNo ?? undefined,
-      fireAndEmergencyCertNo: persistable.fireAndEmergencyCertNo ?? undefined,
-      googlePlacesId: persistable.googlePlacesId ?? undefined,
-      stripeAccountId: persistable.stripeAccountId ?? undefined,
-      averageRating: persistable.averageRating ?? 0,
-      ratingCount: persistable.ratingCount ?? 0,
-      appointmentCheckInBufferMinutes:
-        persistable.appointmentCheckInBufferMinutes ??
-        DEFAULT_APPOINTMENT_CHECK_IN_BUFFER_MINUTES,
-      appointmentCheckInRadiusMeters:
-        persistable.appointmentCheckInRadiusMeters ??
-        DEFAULT_APPOINTMENT_CHECK_IN_RADIUS_METERS,
-      appointmentLockWindowOutpatientMinutes:
-        persistable.appointmentLockWindowOutpatientMinutes ?? undefined,
-      appointmentLockWindowInpatientMinutes:
-        persistable.appointmentLockWindowInpatientMinutes ?? undefined,
-      crossOrgMessagingEnabled: persistable.crossOrgMessagingEnabled ?? false,
-    };
+    const data = buildOrganizationWriteData(persistable);
 
     const organisation = existing
       ? await prisma.organization.update({
@@ -884,42 +856,7 @@ export const OrganizationService = {
 
     await prisma.organization.update({
       where: { id: organisation.id },
-      data: {
-        fhirId: persistable.fhirId ?? undefined,
-        name: persistable.name,
-        taxId: persistable.taxId,
-        dunsNumber: persistable.DUNSNumber ?? undefined,
-        imageUrl: persistable.imageURL ?? undefined,
-        type: persistable.type,
-        petNamePreference: persistable.petNamePreference ?? undefined,
-        phoneNo: persistable.phoneNo,
-        website: persistable.website ?? undefined,
-        documensoTeamId: persistable.documensoTeamId ?? undefined,
-        documensoApiKey: persistable.documensoApiKey ?? undefined,
-        isVerified: persistable.isVerified ?? false,
-        isActive: persistable.isActive ?? true,
-        typeCoding: (persistable.typeCoding ??
-          undefined) as unknown as Prisma.InputJsonValue,
-        healthAndSafetyCertNo: persistable.healthAndSafetyCertNo ?? undefined,
-        animalWelfareComplianceCertNo:
-          persistable.animalWelfareComplianceCertNo ?? undefined,
-        fireAndEmergencyCertNo: persistable.fireAndEmergencyCertNo ?? undefined,
-        googlePlacesId: persistable.googlePlacesId ?? undefined,
-        stripeAccountId: persistable.stripeAccountId ?? undefined,
-        averageRating: persistable.averageRating ?? 0,
-        ratingCount: persistable.ratingCount ?? 0,
-        appointmentCheckInBufferMinutes:
-          persistable.appointmentCheckInBufferMinutes ??
-          DEFAULT_APPOINTMENT_CHECK_IN_BUFFER_MINUTES,
-        appointmentCheckInRadiusMeters:
-          persistable.appointmentCheckInRadiusMeters ??
-          DEFAULT_APPOINTMENT_CHECK_IN_RADIUS_METERS,
-        appointmentLockWindowOutpatientMinutes:
-          persistable.appointmentLockWindowOutpatientMinutes ?? undefined,
-        appointmentLockWindowInpatientMinutes:
-          persistable.appointmentLockWindowInpatientMinutes ?? undefined,
-        crossOrgMessagingEnabled: persistable.crossOrgMessagingEnabled ?? false,
-      },
+      data: buildOrganizationWriteData(persistable),
     });
 
     const updated = await prisma.organization.findUniqueOrThrow({

--- a/apps/backend/src/services/parent-companion.service.ts
+++ b/apps/backend/src/services/parent-companion.service.ts
@@ -188,6 +188,62 @@ const asRecord = (doc: {
   updatedAt: Date;
 }): ParentPatientRecord => doc;
 
+const promoteLinkToPrimary = (
+  target: Pick<ParentPatientRecord, "id" | "acceptedAt">,
+  normalizedPatientId: string,
+  normalizedTargetParentId: string,
+  permissionsOverride?: Partial<ParentCompanionPermissions>,
+) =>
+  prisma.$transaction(async (tx) => {
+    const existingPrimary = await tx.parentPatient.findFirst({
+      where: {
+        patientId: normalizedPatientId,
+        role: "PRIMARY",
+        status: "ACTIVE",
+        parentId: { not: normalizedTargetParentId },
+      },
+      select: { id: true },
+    });
+
+    if (existingPrimary) {
+      await tx.parentPatient.update({
+        where: { id: existingPrimary.id },
+        data: {
+          role: "CO_PARENT",
+          permissions: {
+            ...BASE_PERMISSIONS,
+            assignAsPrimaryParent: false,
+          },
+        },
+      });
+    }
+
+    return tx.parentPatient.update({
+      where: { id: target.id },
+      data: {
+        role: "PRIMARY",
+        status: "ACTIVE",
+        permissions: buildPermissions(
+          "PRIMARY",
+          permissionsOverride,
+        ) as unknown as Prisma.InputJsonValue,
+        acceptedAt: target.acceptedAt ?? new Date(),
+      },
+      select: {
+        id: true,
+        parentId: true,
+        patientId: true,
+        role: true,
+        status: true,
+        permissions: true,
+        invitedByParentId: true,
+        acceptedAt: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+  });
+
 export const ParentCompanionService = {
   async linkParent({
     parentId,
@@ -375,55 +431,12 @@ export const ParentCompanionService = {
     const wantsPrimary = updates.assignAsPrimaryParent === true;
 
     if (wantsPrimary && !isCurrentlyPrimary) {
-      const promoted = await prisma.$transaction(async (tx) => {
-        const existingPrimary = await tx.parentPatient.findFirst({
-          where: {
-            patientId: normalizedPatientId,
-            role: "PRIMARY",
-            status: "ACTIVE",
-            parentId: { not: normalizedTargetParentId },
-          },
-          select: { id: true },
-        });
-
-        if (existingPrimary) {
-          await tx.parentPatient.update({
-            where: { id: existingPrimary.id },
-            data: {
-              role: "CO_PARENT",
-              permissions: {
-                ...BASE_PERMISSIONS,
-                assignAsPrimaryParent: false,
-              },
-            },
-          });
-        }
-
-        return tx.parentPatient.update({
-          where: { id: target.id },
-          data: {
-            role: "PRIMARY",
-            status: "ACTIVE",
-            permissions: buildPermissions(
-              "PRIMARY",
-              updates,
-            ) as unknown as Prisma.InputJsonValue,
-            acceptedAt: target.acceptedAt ?? new Date(),
-          },
-          select: {
-            id: true,
-            parentId: true,
-            patientId: true,
-            role: true,
-            status: true,
-            permissions: true,
-            invitedByParentId: true,
-            acceptedAt: true,
-            createdAt: true,
-            updatedAt: true,
-          },
-        });
-      });
+      const promoted = await promoteLinkToPrimary(
+        target,
+        normalizedPatientId,
+        normalizedTargetParentId,
+        updates,
+      );
 
       return loadLinkWithParent(asRecord(promoted));
     }
@@ -505,55 +518,12 @@ export const ParentCompanionService = {
       throw new ParentCompanionServiceError("Co-parent link not found.", 404);
     }
 
-    const promoted = await prisma.$transaction(async (tx) => {
-      const existingPrimary = await tx.parentPatient.findFirst({
-        where: {
-          patientId: normalizedPatientId,
-          role: "PRIMARY",
-          status: "ACTIVE",
-          parentId: { not: normalizedTargetParentId },
-        },
-        select: { id: true },
-      });
-
-      if (existingPrimary) {
-        await tx.parentPatient.update({
-          where: { id: existingPrimary.id },
-          data: {
-            role: "CO_PARENT",
-            permissions: {
-              ...BASE_PERMISSIONS,
-              assignAsPrimaryParent: false,
-            },
-          },
-        });
-      }
-
-      return tx.parentPatient.update({
-        where: { id: target.id },
-        data: {
-          role: "PRIMARY",
-          status: "ACTIVE",
-          permissions: buildPermissions(
-            "PRIMARY",
-            permissionsOverride,
-          ) as unknown as Prisma.InputJsonValue,
-          acceptedAt: target.acceptedAt ?? new Date(),
-        },
-        select: {
-          id: true,
-          parentId: true,
-          patientId: true,
-          role: true,
-          status: true,
-          permissions: true,
-          invitedByParentId: true,
-          acceptedAt: true,
-          createdAt: true,
-          updatedAt: true,
-        },
-      });
-    });
+    const promoted = await promoteLinkToPrimary(
+      target,
+      normalizedPatientId,
+      normalizedTargetParentId,
+      permissionsOverride,
+    );
 
     return loadLinkWithParent(asRecord(promoted));
   },

--- a/apps/backend/src/services/speciality.service.ts
+++ b/apps/backend/src/services/speciality.service.ts
@@ -9,6 +9,7 @@ import {
 import { ServiceService } from "./service.service";
 import { sendEmailTemplate } from "src/utils/email";
 import logger from "src/utils/logger";
+import { pruneUndefined } from "src/utils/prune-undefined";
 import { prisma } from "src/config/prisma";
 
 export type SpecialityFHIRPayload = SpecialityRequestDTO;
@@ -85,36 +86,6 @@ const sendSpecialityHeadAssignmentEmail = async (params: {
   } catch (error) {
     logger.error("Failed to send speciality head assignment email.", error);
   }
-};
-
-const pruneUndefined = <T>(value: T): T => {
-  if (Array.isArray(value)) {
-    const cleaned = (value as unknown[])
-      .map((item) => pruneUndefined(item))
-      .filter((item) => item !== undefined);
-    return cleaned as unknown as T;
-  }
-
-  if (value && typeof value === "object") {
-    if (value instanceof Date) {
-      return value;
-    }
-
-    const record = value as Record<string, unknown>;
-    const cleanedRecord: Record<string, unknown> = {};
-
-    for (const [key, entryValue] of Object.entries(record)) {
-      const next = pruneUndefined(entryValue);
-
-      if (next !== undefined) {
-        cleanedRecord[key] = next;
-      }
-    }
-
-    return cleanedRecord as unknown as T;
-  }
-
-  return value;
 };
 
 const requireSafeString = (value: unknown, fieldName: string): string => {

--- a/apps/backend/src/services/stripe.service.ts
+++ b/apps/backend/src/services/stripe.service.ts
@@ -76,6 +76,41 @@ const resolveCapturedAmount = (
   return capturedMinorUnits / 100;
 };
 
+const settleAppointmentBookingInvoice = async (params: {
+  invoiceId: string;
+  appointmentId: string;
+  pi: Stripe.PaymentIntent;
+  charge: Stripe.Charge;
+  connectedAccountId?: string;
+}) => {
+  const { invoiceId, appointmentId, pi, charge, connectedAccountId } = params;
+
+  await FinancePaymentService.handleInvoicePaymentIntentSucceeded({
+    invoiceId,
+    paymentIntentId: pi.id,
+    chargeId: charge.id,
+    receiptUrl: charge.receipt_url ?? null,
+    currency: pi.currency ?? null,
+    amount: resolveCapturedAmount(pi, charge),
+    connectedAccountId: connectedAccountId ?? null,
+    allowUnboundAttempt: true,
+    rawProviderPayload: {
+      paymentIntentId: pi.id,
+      chargeId: charge.id,
+      source: "stripe._handleAppointmentBookingPayment",
+    },
+  });
+
+  await prisma.appointment.updateMany({
+    where: { id: appointmentId },
+    data: {
+      status: "REQUESTED",
+      updatedAt: new Date(),
+      expiresAt: null,
+    },
+  });
+};
+
 export const StripeService = {
   // ----------------------------
   // CONNECT (existing + improved)
@@ -657,29 +692,12 @@ export const StripeService = {
         ...(connectedAccountId ? { stripeAccount: connectedAccountId } : {}),
       });
 
-      await FinancePaymentService.handleInvoicePaymentIntentSucceeded({
+      await settleAppointmentBookingInvoice({
         invoiceId: openInvoice.id,
-        paymentIntentId: pi.id,
-        chargeId: charge.id,
-        receiptUrl: charge.receipt_url ?? null,
-        currency: pi.currency ?? null,
-        amount: resolveCapturedAmount(pi, charge),
-        connectedAccountId: connectedAccountId ?? null,
-        allowUnboundAttempt: true,
-        rawProviderPayload: {
-          paymentIntentId: pi.id,
-          chargeId: charge.id,
-          source: "stripe._handleAppointmentBookingPayment",
-        },
-      });
-
-      await prisma.appointment.updateMany({
-        where: { id: appointmentId },
-        data: {
-          status: "REQUESTED",
-          updatedAt: new Date(),
-          expiresAt: null,
-        },
+        appointmentId,
+        pi,
+        charge,
+        connectedAccountId,
       });
 
       logger.info(
@@ -732,29 +750,12 @@ export const StripeService = {
       },
     });
 
-    await FinancePaymentService.handleInvoicePaymentIntentSucceeded({
+    await settleAppointmentBookingInvoice({
       invoiceId: createdInvoice.id,
-      paymentIntentId: pi.id,
-      chargeId: charge.id,
-      receiptUrl: charge.receipt_url ?? null,
-      currency: pi.currency ?? null,
-      amount: resolveCapturedAmount(pi, charge),
-      connectedAccountId: connectedAccountId ?? null,
-      allowUnboundAttempt: true,
-      rawProviderPayload: {
-        paymentIntentId: pi.id,
-        chargeId: charge.id,
-        source: "stripe._handleAppointmentBookingPayment",
-      },
-    });
-
-    await prisma.appointment.updateMany({
-      where: { id: appointmentId },
-      data: {
-        status: "REQUESTED",
-        updatedAt: new Date(),
-        expiresAt: null,
-      },
+      appointmentId,
+      pi,
+      charge,
+      connectedAccountId,
     });
 
     logger.info(`Appointment ${appointmentId} booking PAID. Invoice created`);

--- a/apps/backend/src/services/user-organization.service.ts
+++ b/apps/backend/src/services/user-organization.service.ts
@@ -13,6 +13,7 @@ import { StripeService } from "./stripe.service";
 import { sendFreePlanLimitReachedEmail } from "src/utils/org-usage-notifications";
 import { sendEmailTemplate } from "src/utils/email";
 import logger from "src/utils/logger";
+import { pruneUndefined } from "src/utils/prune-undefined";
 import { prisma } from "src/config/prisma";
 import type { UserOrganization as PrismaUserOrganization } from "@prisma/client";
 
@@ -134,37 +135,6 @@ function computeEffectivePermissions(
 
   return [...combined];
 }
-
-const pruneUndefined = <T>(value: T): T => {
-  if (Array.isArray(value)) {
-    const arrayValue = value as unknown[];
-    const cleaned: unknown[] = arrayValue
-      .map((item) => pruneUndefined(item))
-      .filter((item) => item !== undefined);
-    return cleaned as unknown as T;
-  }
-
-  if (value && typeof value === "object") {
-    if (value instanceof Date) {
-      return value;
-    }
-
-    const record = value as Record<string, unknown>;
-    const cleanedRecord: Record<string, unknown> = {};
-
-    for (const [key, entryValue] of Object.entries(record)) {
-      const next = pruneUndefined(entryValue);
-
-      if (next !== undefined) {
-        cleanedRecord[key] = next;
-      }
-    }
-
-    return cleanedRecord as unknown as T;
-  }
-
-  return value;
-};
 
 const requireSafeString = (value: unknown, fieldName: string): string => {
   if (value == null) {

--- a/apps/backend/src/utils/prune-undefined.ts
+++ b/apps/backend/src/utils/prune-undefined.ts
@@ -1,0 +1,30 @@
+export const pruneUndefined = <T>(value: T): T => {
+  if (Array.isArray(value)) {
+    const arrayValue = value as unknown[];
+    const cleaned: unknown[] = arrayValue
+      .map((item) => pruneUndefined(item))
+      .filter((item) => item !== undefined);
+    return cleaned as unknown as T;
+  }
+
+  if (value && typeof value === "object") {
+    if (value instanceof Date) {
+      return value;
+    }
+
+    const record = value as Record<string, unknown>;
+    const cleanedRecord: Record<string, unknown> = {};
+
+    for (const [key, entryValue] of Object.entries(record)) {
+      const next = pruneUndefined(entryValue);
+
+      if (next !== undefined) {
+        cleanedRecord[key] = next;
+      }
+    }
+
+    return cleanedRecord as unknown as T;
+  }
+
+  return value;
+};

--- a/apps/backend/test/services/availability.service.test.ts
+++ b/apps/backend/test/services/availability.service.test.ts
@@ -125,6 +125,39 @@ describe("AvailabilityService", () => {
       ]);
     });
 
+    it("getOrganisationBaseAvailability: should read and map rows for every user", async () => {
+      (prisma.baseAvailability.findMany as jest.Mock).mockResolvedValueOnce([
+        {
+          id: "base-2",
+          userId: "u2",
+          organisationId: "org1",
+          dayOfWeek: "WEDNESDAY",
+          slots: [{ startTime: "09:00", endTime: "12:00", isAvailable: true }],
+          createdAt: new Date("2026-03-03T00:00:00Z"),
+          updatedAt: new Date("2026-03-04T00:00:00Z"),
+        },
+      ]);
+
+      const res =
+        await AvailabilityService.getOrganisationBaseAvailability("org1");
+
+      expect(prisma.baseAvailability.findMany).toHaveBeenCalledWith({
+        where: { organisationId: "org1" },
+        orderBy: [{ userId: "asc" }, { dayOfWeek: "asc" }],
+      });
+      expect(res).toEqual([
+        {
+          _id: "base-2",
+          userId: "u2",
+          organisationId: "org1",
+          dayOfWeek: "WEDNESDAY",
+          slots: [{ startTime: "09:00", endTime: "12:00", isAvailable: true }],
+          createdAt: new Date("2026-03-03T00:00:00Z"),
+          updatedAt: new Date("2026-03-04T00:00:00Z"),
+        },
+      ]);
+    });
+
     it("deleteBaseAvailability: should delete via prisma", async () => {
       await AvailabilityService.deleteBaseAvailability("org1", "u1");
       expect(prisma.baseAvailability.deleteMany).toHaveBeenCalledWith({

--- a/apps/backend/test/services/clinical-artifact.service.test.ts
+++ b/apps/backend/test/services/clinical-artifact.service.test.ts
@@ -1016,6 +1016,138 @@ describe("ClinicalArtifactService", () => {
     ).not.toHaveProperty("medications");
   });
 
+  it("normalizes primitive prescription entries into medication-only line items", async () => {
+    mockedPrisma.clinicalArtifact.create.mockResolvedValueOnce({
+      id: artifactId,
+      organisationId,
+      kind: "PRESCRIPTION",
+      status: "DRAFT",
+      appointmentId: "appt-1",
+      caseId: null,
+      encounterId: "enc-1",
+      templateId: "tmpl-2",
+      templateVersion: 4,
+      templateVersionId: "tmpl-ver-2",
+      authorId: "author-1",
+      signedBy: null,
+      signedAt: null,
+      summary: "Rx summary",
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    });
+    mockedPrisma.prescription.create.mockResolvedValueOnce({
+      id: "prescription-primitive-1",
+      artifactId,
+      medications: null,
+      items: [
+        {
+          id: "line-primitive-1",
+          prescriptionId: "prescription-primitive-1",
+          sourceLineKey: null,
+          medication: "Amoxicillin 250mg",
+          strength: null,
+          dosage: null,
+          route: null,
+          frequency: null,
+          duration: null,
+          quantity: null,
+          instructions: null,
+          refill: null,
+          inventoryItemId: null,
+          inventoryItemSku: null,
+          batchId: null,
+          batchNumber: null,
+          lotNumber: null,
+          expiryDate: null,
+          metadata: null,
+          sortOrder: 0,
+          createdAt: new Date("2026-01-01T00:00:00.000Z"),
+          updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+        },
+      ],
+      instructions: null,
+      notes: null,
+      metadata: null,
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    });
+    mockedPrisma.renderedDocument.create.mockResolvedValueOnce({
+      id: "doc-5",
+      organisationId,
+      sourceKind: "CLINICAL_ARTIFACT",
+      sourceId: artifactId,
+      templateInstanceId: null,
+      clinicalArtifactId: artifactId,
+      templateId: "tmpl-2",
+      templateVersion: 4,
+      templateVersionId: "tmpl-ver-2",
+      kind: "PRESCRIPTION",
+      version: 1,
+      title: "Prescription",
+      mimeType: "application/pdf",
+      status: "DRAFT",
+      signable: true,
+      pdfUrl: null,
+      pdf: null,
+      signedBy: null,
+      signedAt: null,
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+      signature: null,
+    });
+    mockClinicalRenderedDocumentPersistence({
+      id: "doc-5",
+      kind: "PRESCRIPTION",
+      title: "Prescription",
+      templateId: "tmpl-2",
+      templateVersion: 4,
+      templateVersionId: "tmpl-ver-2",
+    });
+
+    await ClinicalArtifactService.createPrescription({
+      organisationId,
+      appointmentId: "appt-1",
+      encounterId: "enc-1",
+      templateId: "tmpl-2",
+      templateVersion: 4,
+      templateVersionId: "tmpl-ver-2",
+      authorId: "author-1",
+      summary: "Rx summary",
+      medications: [
+        "Amoxicillin 250mg",
+        {
+          sourceLineKey: "line-record",
+          medication: "Drug C",
+          dosage: "1 tablet",
+        },
+      ] as never,
+      instructions: null,
+      notes: null,
+      metadata: null,
+    });
+
+    expect(mockedPrisma.prescription.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          items: {
+            create: [
+              expect.objectContaining({
+                medication: "Amoxicillin 250mg",
+                sortOrder: 0,
+              }),
+              expect.objectContaining({
+                medication: "Drug C",
+                sourceLineKey: "line-record",
+                dosage: "1 tablet",
+                sortOrder: 1,
+              }),
+            ],
+          },
+        }),
+      }),
+    );
+  });
+
   it("marks the dispense request not dispensed when a signed prescription is voided", async () => {
     const signedMedications = [
       { inventoryItemId: "item-1", quantity: 2, sourceLineKey: "line-1" },
@@ -1586,6 +1718,95 @@ describe("ClinicalArtifactService", () => {
           kind: "VITAL_RECORD",
           title: "Vital record",
           clinicalArtifactId: artifactId,
+        }),
+      }),
+    );
+    expect(result.artifact.kind).toBe("VITAL_RECORD");
+  });
+
+  it("defaults vital record vitals to an empty object when none are provided", async () => {
+    mockedPrisma.clinicalArtifact.create.mockResolvedValueOnce({
+      id: artifactId,
+      organisationId,
+      kind: "VITAL_RECORD",
+      status: "DRAFT",
+      appointmentId: "appt-1",
+      caseId: null,
+      encounterId: "enc-1",
+      templateId: "tmpl-4",
+      templateVersion: 6,
+      templateVersionId: "tmpl-ver-4",
+      authorId: "author-1",
+      signedBy: null,
+      signedAt: null,
+      summary: "Vitals summary",
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    });
+    mockedPrisma.vitalRecord.create.mockResolvedValueOnce({
+      id: "vital-2",
+      artifactId,
+      measuredAt: new Date("2026-01-01T00:00:00.000Z"),
+      recordedBy: "author-1",
+      vitals: {},
+      notes: null,
+      metadata: null,
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    });
+    mockedPrisma.renderedDocument.create.mockResolvedValueOnce({
+      id: "doc-6",
+      organisationId,
+      sourceKind: "CLINICAL_ARTIFACT",
+      sourceId: artifactId,
+      templateInstanceId: null,
+      clinicalArtifactId: artifactId,
+      templateId: "tmpl-4",
+      templateVersion: 6,
+      templateVersionId: "tmpl-ver-4",
+      kind: "VITAL_RECORD",
+      version: 1,
+      title: "Vital record",
+      mimeType: "application/pdf",
+      status: "DRAFT",
+      signable: true,
+      pdfUrl: null,
+      pdf: null,
+      signedBy: null,
+      signedAt: null,
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+      signature: null,
+    });
+    mockClinicalRenderedDocumentPersistence({
+      id: "doc-6",
+      kind: "VITAL_RECORD",
+      title: "Vital record",
+      templateId: "tmpl-4",
+      templateVersion: 6,
+      templateVersionId: "tmpl-ver-4",
+    });
+
+    const result = await ClinicalArtifactService.createVitalRecord({
+      organisationId,
+      appointmentId: "appt-1",
+      encounterId: "enc-1",
+      templateId: "tmpl-4",
+      templateVersion: 6,
+      templateVersionId: "tmpl-ver-4",
+      authorId: "author-1",
+      summary: "Vitals summary",
+      measuredAt: "2026-01-01T00:00:00.000Z",
+      recordedBy: "author-1",
+      vitals: null,
+      notes: null,
+      metadata: null,
+    });
+
+    expect(mockedPrisma.vitalRecord.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          vitals: {},
         }),
       }),
     );

--- a/apps/backend/test/services/companion.service.test.ts
+++ b/apps/backend/test/services/companion.service.test.ts
@@ -507,6 +507,26 @@ describe("CompanionService", () => {
     await expect(CompanionService.getById("")).resolves.toBeNull();
   });
 
+  it("returns null when no companion matches the id", async () => {
+    mockedPrisma.patient.findUnique.mockResolvedValueOnce(null);
+
+    await expect(CompanionService.getById("missing-1")).resolves.toBeNull();
+    expect(mockedPrisma.patient.findUnique).toHaveBeenCalledWith({
+      where: { id: "missing-1" },
+    });
+  });
+
+  it("returns a mapped companion by id", async () => {
+    mockedPrisma.patient.findUnique.mockResolvedValueOnce(createdPatient);
+
+    const result = await CompanionService.getById("patient-1");
+
+    expect(mockedPrisma.patient.findUnique).toHaveBeenCalledWith({
+      where: { id: "patient-1" },
+    });
+    expect(result?.response).toMatchObject({ id: "patient-1" });
+  });
+
   it("rejects blank search terms", async () => {
     await expect(CompanionService.getByName("   ")).rejects.toEqual(
       expect.objectContaining({

--- a/apps/backend/test/services/form-assignment.service.test.ts
+++ b/apps/backend/test/services/form-assignment.service.test.ts
@@ -304,6 +304,51 @@ describe("FormAssignmentService", () => {
     expect(rows[0].signerIdentity).toBeNull();
   });
 
+  it("normalizes viewed, submitted, signed, and expired assignment statuses", async () => {
+    const baseRow = {
+      organisationId: "org-1",
+      templateId: "template-1",
+      templateVersion: 2,
+      appointmentId: "appt-1",
+      encounterId: "enc-1",
+      companionId: "comp-1",
+      signerUserId: null,
+      signerName: null,
+      signerEmail: null,
+      signerRole: null,
+      mobileVisible: true,
+      signingRequired: true,
+      sentAt: new Date("2026-06-14T10:00:00.000Z"),
+      viewedAt: null,
+      submittedAt: null,
+      signedAt: null,
+      expiredAt: null,
+      cancelledAt: null,
+      createdBy: "user-1",
+      updatedBy: "user-1",
+      createdAt: new Date("2026-06-14T10:00:00.000Z"),
+      updatedAt: new Date("2026-06-14T10:00:00.000Z"),
+    };
+    mockedPrisma.formAssignment.findMany.mockResolvedValueOnce([
+      { ...baseRow, id: "assignment-viewed", status: "VIEWED" },
+      { ...baseRow, id: "assignment-submitted", status: "SUBMITTED" },
+      { ...baseRow, id: "assignment-signed", status: "SIGNED" },
+      { ...baseRow, id: "assignment-expired", status: "EXPIRED" },
+    ]);
+
+    const rows = await FormAssignmentService.listForAppointment(
+      "org-1",
+      "appt-1",
+    );
+
+    expect(rows.map((row) => row.status)).toEqual([
+      "viewed",
+      "submitted",
+      "signed",
+      "expired",
+    ]);
+  });
+
   it("lists organisation assignments with signed document metadata", async () => {
     mockedPrisma.formAssignment.findMany.mockResolvedValueOnce([
       {
@@ -777,6 +822,42 @@ describe("FormAssignmentService", () => {
       expect(result[0].parentName).toBeNull();
       // No signed rows => no template-instance lookup.
       expect(mockedPrisma.templateInstance.findMany).not.toHaveBeenCalled();
+    });
+
+    it("normalizes viewed, submitted, expired, and cancelled lifecycle statuses", async () => {
+      const baseRow = {
+        templateId: "tpl-1",
+        templateVersion: 1,
+        companionId: "comp-1",
+        appointmentId: null,
+        signingRequired: true,
+        mobileVisible: true,
+        sentAt: null,
+        viewedAt: null,
+        submittedAt: null,
+        signedAt: null,
+        expiredAt: null,
+        cancelledAt: null,
+        template: { name: "Intake Form" },
+        companion: { name: "Milo" },
+      };
+      mockedPrisma.formAssignment.findMany.mockResolvedValue([
+        { ...baseRow, id: "fa-viewed", status: "VIEWED" },
+        { ...baseRow, id: "fa-submitted", status: "SUBMITTED" },
+        { ...baseRow, id: "fa-expired", status: "EXPIRED" },
+        { ...baseRow, id: "fa-cancelled", status: "CANCELLED" },
+      ]);
+
+      const result = await FormAssignmentService.listForOrganisation({
+        organisationId: "org-1",
+      });
+
+      expect(result.map((item) => item.status)).toEqual([
+        "VIEWED",
+        "SUBMITTED",
+        "EXPIRED",
+        "CANCELLED",
+      ]);
     });
 
     it("resolves a parentId filter to the parent's companions", async () => {

--- a/apps/backend/test/services/form.service.test.ts
+++ b/apps/backend/test/services/form.service.test.ts
@@ -300,6 +300,84 @@ describe("FormService", () => {
       expect(prisma.formField.createMany).toHaveBeenCalled();
       expect(anyRes.createdBy).toBe("John Doe");
     });
+
+    it("maps known businessType and requiredSigner values to prisma enums", async () => {
+      const req: any = {
+        name: "Form B",
+        category: "Cat",
+        visibilityType: "Internal",
+        businessType: "HOSPITAL",
+        requiredSigner: "CLIENT",
+        schema: [],
+      };
+
+      (prisma.form.create as jest.Mock).mockResolvedValue({
+        id: "form-2",
+        orgId: validId,
+        businessType: "HOSPITAL",
+        name: "Form B",
+        category: "Cat",
+        description: null,
+        visibilityType: "Internal",
+        serviceId: [],
+        speciesFilter: [],
+        requiredSigner: "CLIENT",
+        status: "draft",
+        schema: [],
+        createdBy: "u1",
+        updatedBy: "u1",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      await FormService.create(validId, req, "u1");
+
+      expect(prisma.form.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            businessType: "HOSPITAL",
+            requiredSigner: "CLIENT",
+          }),
+        }),
+      );
+    });
+
+    it("drops businessType and requiredSigner values outside the prisma enums", async () => {
+      const req: any = {
+        name: "Form C",
+        category: "Cat",
+        visibilityType: "Internal",
+        businessType: "FOOD_TRUCK",
+        requiredSigner: "ACCOUNTANT",
+        schema: [],
+      };
+
+      (prisma.form.create as jest.Mock).mockResolvedValue({
+        id: "form-3",
+        orgId: validId,
+        businessType: null,
+        name: "Form C",
+        category: "Cat",
+        description: null,
+        visibilityType: "Internal",
+        serviceId: [],
+        speciesFilter: [],
+        requiredSigner: null,
+        status: "draft",
+        schema: [],
+        createdBy: "u1",
+        updatedBy: "u1",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      await FormService.create(validId, req, "u1");
+
+      const createArgs = (prisma.form.create as jest.Mock).mock
+        .calls[0][0] as any;
+      expect(createArgs.data.businessType).toBeUndefined();
+      expect(createArgs.data.requiredSigner).toBeUndefined();
+    });
   });
 
   describe("getFormForAdmin", () => {

--- a/apps/backend/test/services/inventory.service.test.ts
+++ b/apps/backend/test/services/inventory.service.test.ts
@@ -1082,4 +1082,74 @@ describe("Inventory service", () => {
       });
     });
   });
+
+  // These run last with reset mocks: earlier tests intentionally leave
+  // queued mockResolvedValueOnce values that later tests consume.
+  it("applies a status change during update", async () => {
+    (prisma.inventoryItem.findFirst as jest.Mock).mockReset();
+    (prisma.inventoryItem.update as jest.Mock).mockReset();
+    (prisma.inventoryBatch.findMany as jest.Mock).mockReset();
+    (prisma.inventoryBatch.findMany as jest.Mock).mockResolvedValue([]);
+    (prisma.inventoryItem.findFirst as jest.Mock).mockResolvedValueOnce({
+      id: "item-4",
+      organisationId: "org-1",
+      category: "Consumables",
+      businessType: "HOSPITAL",
+      itemType: "NON_MEDICAL",
+    });
+    (prisma.inventoryItem.update as jest.Mock).mockResolvedValueOnce({
+      id: "item-4",
+      organisationId: "org-1",
+      status: "HIDDEN",
+    });
+
+    const result = await InventoryService.updateItem(
+      "item-4",
+      {
+        status: "HIDDEN",
+      },
+      "org-1",
+    );
+
+    expect(prisma.inventoryItem.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          status: "HIDDEN",
+        }),
+      }),
+    );
+    expect(result.item.status).toBe("HIDDEN");
+  });
+
+  it("translates business, category, and search filters into the prisma where clause", async () => {
+    (prisma.inventoryItem.findMany as jest.Mock).mockReset();
+    (prisma.inventoryBatch.findMany as jest.Mock).mockReset();
+    (prisma.inventoryItem.findMany as jest.Mock).mockResolvedValue([]);
+    (prisma.inventoryBatch.findMany as jest.Mock).mockResolvedValue([]);
+
+    const result = await InventoryService.listItems({
+      organisationId: "org-1",
+      businessType: "HOSPITAL",
+      category: "Consumables",
+      subCategory: "Bandages",
+      search: "band",
+    } as never);
+
+    expect(prisma.inventoryItem.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          organisationId: "org-1",
+          businessType: "HOSPITAL",
+          category: "Consumables",
+          subCategory: "Bandages",
+          OR: [
+            { name: { contains: "band", mode: "insensitive" } },
+            { sku: { contains: "band", mode: "insensitive" } },
+            { description: { contains: "band", mode: "insensitive" } },
+          ],
+        }),
+      }),
+    );
+    expect(result).toEqual([]);
+  });
 });

--- a/apps/backend/test/services/organisation-document.service.test.ts
+++ b/apps/backend/test/services/organisation-document.service.test.ts
@@ -73,6 +73,195 @@ describe("OrganizationDocumentService", () => {
     );
   });
 
+  it("defaults visibility to INTERNAL when none is provided on create", async () => {
+    mockedPrisma.organizationDocument.create.mockResolvedValueOnce({
+      id: "doc-10",
+      organisationId: "org-1",
+      title: "Handbook",
+      description: "",
+      category: "GENERAL",
+      fileUrl: null,
+      fileName: null,
+      fileType: null,
+      fileSize: null,
+      visibility: "INTERNAL",
+      version: 1,
+      createdAt: new Date("2026-03-01T00:00:00Z"),
+      updatedAt: new Date("2026-03-01T00:00:00Z"),
+    });
+
+    await OrganizationDocumentService.createDocument({
+      organisationId: "org-1",
+      title: "Handbook",
+      category: "GENERAL",
+    });
+
+    expect(mockedPrisma.organizationDocument.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        visibility: "INTERNAL",
+      }),
+    });
+  });
+
+  it("applies category and visibility filters when listing for an organisation", async () => {
+    mockedPrisma.organizationDocument.findMany.mockResolvedValueOnce([]);
+
+    await OrganizationDocumentService.listDocumentsForOrganisation({
+      organisationId: "org-1",
+      category: "GENERAL",
+      visibility: "INTERNAL",
+    });
+
+    expect(mockedPrisma.organizationDocument.findMany).toHaveBeenCalledWith({
+      where: {
+        organisationId: "org-1",
+        category: "GENERAL",
+        visibility: "INTERNAL",
+      },
+      orderBy: { updatedAt: "desc" },
+    });
+  });
+
+  it("ignores the ALL visibility filter when listing for an organisation", async () => {
+    mockedPrisma.organizationDocument.findMany.mockResolvedValueOnce([]);
+
+    await OrganizationDocumentService.listDocumentsForOrganisation({
+      organisationId: "org-1",
+      visibility: "ALL",
+    });
+
+    expect(mockedPrisma.organizationDocument.findMany).toHaveBeenCalledWith({
+      where: { organisationId: "org-1" },
+      orderBy: { updatedAt: "desc" },
+    });
+  });
+
+  it("upserts a policy document as PUBLIC when none exists", async () => {
+    mockedPrisma.organizationDocument.findFirst.mockResolvedValueOnce(null);
+    mockedPrisma.organizationDocument.create.mockResolvedValueOnce({
+      id: "doc-11",
+      organisationId: "org-1",
+      title: "Terms",
+      description: "",
+      category: "TERMS_AND_CONDITIONS",
+      fileUrl: null,
+      fileName: null,
+      fileType: null,
+      fileSize: null,
+      visibility: "PUBLIC",
+      version: 1,
+      createdAt: new Date("2026-03-01T00:00:00Z"),
+      updatedAt: new Date("2026-03-01T00:00:00Z"),
+    });
+
+    await OrganizationDocumentService.upsertPolicyDocument({
+      organisationId: "org-1",
+      title: "Terms",
+      category: "TERMS_AND_CONDITIONS",
+    });
+
+    expect(mockedPrisma.organizationDocument.findFirst).toHaveBeenCalledWith({
+      where: {
+        organisationId: "org-1",
+        category: "TERMS_AND_CONDITIONS",
+      },
+    });
+    expect(mockedPrisma.organizationDocument.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        category: "TERMS_AND_CONDITIONS",
+        visibility: "PUBLIC",
+      }),
+    });
+  });
+
+  it("keeps the existing visibility when upserting a policy document without one", async () => {
+    const existing = {
+      id: "doc-12",
+      organisationId: "org-1",
+      title: "Privacy",
+      description: "old",
+      category: "PRIVACY_POLICY",
+      fileUrl: null,
+      fileName: null,
+      fileType: null,
+      fileSize: null,
+      visibility: "INTERNAL",
+      version: 1,
+      createdAt: new Date("2026-03-01T00:00:00Z"),
+      updatedAt: new Date("2026-03-01T00:00:00Z"),
+    };
+    mockedPrisma.organizationDocument.findFirst
+      .mockResolvedValueOnce(existing)
+      .mockResolvedValueOnce(existing);
+    mockedPrisma.organizationDocument.update.mockResolvedValueOnce({
+      ...existing,
+      title: "Privacy updated",
+    });
+
+    await OrganizationDocumentService.upsertPolicyDocument({
+      organisationId: "org-1",
+      title: "Privacy updated",
+      category: "PRIVACY_POLICY",
+    });
+
+    expect(mockedPrisma.organizationDocument.update).toHaveBeenCalledWith({
+      where: { id: "doc-12" },
+      data: expect.objectContaining({
+        title: "Privacy updated",
+        visibility: "INTERNAL",
+      }),
+    });
+  });
+
+  it("overrides the existing visibility when upserting a policy document with one", async () => {
+    const existing = {
+      id: "doc-13",
+      organisationId: "org-1",
+      title: "Cancellation",
+      description: "",
+      category: "CANCELLATION_POLICY",
+      fileUrl: null,
+      fileName: null,
+      fileType: null,
+      fileSize: null,
+      visibility: "INTERNAL",
+      version: 1,
+      createdAt: new Date("2026-03-01T00:00:00Z"),
+      updatedAt: new Date("2026-03-01T00:00:00Z"),
+    };
+    mockedPrisma.organizationDocument.findFirst
+      .mockResolvedValueOnce(existing)
+      .mockResolvedValueOnce(existing);
+    mockedPrisma.organizationDocument.update.mockResolvedValueOnce({
+      ...existing,
+      visibility: "PUBLIC",
+    });
+
+    await OrganizationDocumentService.upsertPolicyDocument({
+      organisationId: "org-1",
+      title: "Cancellation",
+      category: "CANCELLATION_POLICY",
+      visibility: "PUBLIC",
+    });
+
+    expect(mockedPrisma.organizationDocument.update).toHaveBeenCalledWith({
+      where: { id: "doc-13" },
+      data: expect.objectContaining({
+        visibility: "PUBLIC",
+      }),
+    });
+  });
+
+  it("rejects upserts for non-policy categories", async () => {
+    await expect(
+      OrganizationDocumentService.upsertPolicyDocument({
+        organisationId: "org-1",
+        title: "Handbook",
+        category: "GENERAL",
+      }),
+    ).rejects.toThrow("upsertPolicyDocument is only for policy categories");
+  });
+
   it("updates documents with _id mapped from prisma id", async () => {
     mockedPrisma.organizationDocument.findFirst.mockResolvedValueOnce({
       id: "doc-2",

--- a/apps/backend/test/services/organization.service.test.ts
+++ b/apps/backend/test/services/organization.service.test.ts
@@ -237,6 +237,40 @@ describe("OrganizationService", () => {
       });
     });
 
+    it("creates an organisation from a minimal payload without optional fields", async () => {
+      const minimalDto: any = {
+        resourceType: "Organization",
+        name: "Minimal Hospital",
+        phoneNo: "1234567890",
+        type: "HOSPITAL",
+        taxId: "TAX-456",
+      };
+      (TypesPkg.fromOrganizationRequestDTO as jest.Mock).mockReturnValueOnce({
+        ...minimalDto,
+      });
+      (prisma.organization.create as jest.Mock).mockResolvedValueOnce(baseOrg);
+      (
+        prisma.organization.findUniqueOrThrow as jest.Mock
+      ).mockResolvedValueOnce(baseOrg);
+
+      const result = await OrganizationService.upsert(minimalDto);
+
+      expect(prisma.organization.findFirst).not.toHaveBeenCalled();
+      expect(prisma.organization.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            fhirId: undefined,
+            imageUrl: undefined,
+            appointmentLockWindowOutpatientMinutes: undefined,
+            appointmentLockWindowInpatientMinutes: undefined,
+            appointmentCheckInBufferMinutes: 5,
+            appointmentCheckInRadiusMeters: 200,
+          }),
+        }),
+      );
+      expect(result.created).toBe(true);
+    });
+
     it("updates an existing organisation", async () => {
       (prisma.organization.findFirst as jest.Mock).mockResolvedValueOnce(
         baseOrg,

--- a/apps/backend/test/services/parent-companion.service.test.ts
+++ b/apps/backend/test/services/parent-companion.service.test.ts
@@ -192,6 +192,159 @@ describe("ParentCompanionService", () => {
     expect(result.role).toBe("PRIMARY");
   });
 
+  it("demotes the existing primary when promoting via permission updates", async () => {
+    const acceptedAt = new Date("2026-02-02");
+    mockedPrisma.parentPatient.findFirst
+      .mockResolvedValueOnce({
+        id: "requester-link",
+        parentId: "parent-1",
+        patientId: "patient-1",
+        role: "PRIMARY",
+        status: "ACTIVE",
+      })
+      .mockResolvedValueOnce({
+        id: "target-link",
+        parentId: "parent-2",
+        patientId: "patient-1",
+        role: "CO_PARENT",
+        status: "ACTIVE",
+        permissions: {},
+        invitedByParentId: null,
+        acceptedAt,
+        createdAt: new Date("2026-01-01"),
+        updatedAt: new Date("2026-01-01"),
+      })
+      .mockResolvedValueOnce({ id: "old-primary-link" });
+    mockedPrisma.parentPatient.update
+      .mockResolvedValueOnce({ id: "old-primary-link" })
+      .mockResolvedValueOnce({
+        id: "target-link",
+        parentId: "parent-2",
+        patientId: "patient-1",
+        role: "PRIMARY",
+        status: "ACTIVE",
+        permissions: { assignAsPrimaryParent: true },
+        invitedByParentId: null,
+        acceptedAt,
+        createdAt: new Date("2026-01-01"),
+        updatedAt: new Date("2026-01-01"),
+      });
+    mockedPrisma.parent.findUnique.mockResolvedValue({
+      id: "parent-2",
+      firstName: "Alex",
+      lastName: "Smith",
+      email: "alex@example.com",
+      phoneNumber: "456",
+      profileImageUrl: null,
+    });
+
+    const result = await ParentCompanionService.updatePermissions(
+      "parent-1",
+      "parent-2",
+      "patient-1",
+      { assignAsPrimaryParent: true },
+    );
+
+    expect(mockedPrisma.parentPatient.update).toHaveBeenNthCalledWith(1, {
+      where: { id: "old-primary-link" },
+      data: {
+        role: "CO_PARENT",
+        permissions: expect.objectContaining({
+          assignAsPrimaryParent: false,
+        }),
+      },
+    });
+    expect(mockedPrisma.parentPatient.update).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        where: { id: "target-link" },
+        data: expect.objectContaining({
+          role: "PRIMARY",
+          status: "ACTIVE",
+          acceptedAt,
+        }),
+      }),
+    );
+    expect(result.role).toBe("PRIMARY");
+  });
+
+  it("promotes an active co-parent via promoteToPrimary without an existing primary", async () => {
+    mockedPrisma.parentPatient.findFirst
+      .mockResolvedValueOnce({
+        id: "requester-link",
+        parentId: "parent-1",
+        patientId: "patient-1",
+        role: "PRIMARY",
+        status: "ACTIVE",
+      })
+      .mockResolvedValueOnce({
+        id: "target-link",
+        parentId: "parent-2",
+        patientId: "patient-1",
+        role: "CO_PARENT",
+        status: "ACTIVE",
+        permissions: {},
+        invitedByParentId: null,
+        acceptedAt: null,
+        createdAt: new Date("2026-01-01"),
+        updatedAt: new Date("2026-01-01"),
+      })
+      .mockResolvedValueOnce(null);
+    mockedPrisma.parentPatient.update.mockResolvedValueOnce({
+      id: "target-link",
+      parentId: "parent-2",
+      patientId: "patient-1",
+      role: "PRIMARY",
+      status: "ACTIVE",
+      permissions: { assignAsPrimaryParent: true },
+      invitedByParentId: null,
+      acceptedAt: new Date("2026-03-03"),
+      createdAt: new Date("2026-01-01"),
+      updatedAt: new Date("2026-01-01"),
+    });
+    mockedPrisma.parent.findUnique.mockResolvedValue({
+      id: "parent-2",
+      firstName: "Alex",
+      lastName: "Smith",
+      email: "alex@example.com",
+      phoneNumber: "456",
+      profileImageUrl: null,
+    });
+
+    const result = await ParentCompanionService.promoteToPrimary(
+      "parent-1",
+      "patient-1",
+      "parent-2",
+    );
+
+    expect(mockedPrisma.parentPatient.update).toHaveBeenCalledTimes(1);
+    const updateArgs = mockedPrisma.parentPatient.update.mock.calls[0][0];
+    expect(updateArgs.where).toEqual({ id: "target-link" });
+    expect(updateArgs.data.role).toBe("PRIMARY");
+    expect(updateArgs.data.acceptedAt).toBeInstanceOf(Date);
+    expect(result.role).toBe("PRIMARY");
+  });
+
+  it("throws when the promoteToPrimary target link is missing", async () => {
+    mockedPrisma.parentPatient.findFirst
+      .mockResolvedValueOnce({
+        id: "requester-link",
+        parentId: "parent-1",
+        patientId: "patient-1",
+        role: "PRIMARY",
+        status: "ACTIVE",
+      })
+      .mockResolvedValueOnce(null);
+
+    await expect(
+      ParentCompanionService.promoteToPrimary(
+        "parent-1",
+        "patient-1",
+        "parent-2",
+      ),
+    ).rejects.toMatchObject({ statusCode: 404 });
+  });
+
   it("returns active companion ids for a parent", async () => {
     mockedPrisma.parentPatient.findMany.mockResolvedValueOnce([
       { patientId: "patient-1" },

--- a/apps/backend/test/services/task-workflow-materializer.test.ts
+++ b/apps/backend/test/services/task-workflow-materializer.test.ts
@@ -178,6 +178,119 @@ describe("task workflow materializer", () => {
     expect(seeds[0].dueAt.toISOString()).toBe("2026-01-01T08:00:00.000Z");
   });
 
+  it("parses a care pathway snapshot with block details, shift windows, and exceptions", () => {
+    const seeds = materializeTaskWorkflowSeeds(
+      "CARE_PATHWAY",
+      {
+        admissionOffsetMinutes: 0,
+        taskBlocks: [
+          {
+            id: "meds",
+            dayOffset: 0,
+            timeOfDay: "07:00",
+            taskKind: "MEDICATION",
+            category: "Medication",
+            name: "Morning medicine",
+            audience: "EMPLOYEE_TASK",
+            assignedRole: "EMPLOYEE_TASK",
+            reminderOffsetMinutes: 10,
+            additionalNotes: "Give with food",
+            medication: { name: "Amoxicillin", dosage: "50mg" },
+            observationToolId: "obs-1",
+            recurrence: {
+              type: "DAILY",
+              customCron: "0 7 * * *",
+              endAfterDays: 3,
+            },
+          },
+          {
+            dayOffset: 1,
+            timeOfDay: "09:00",
+            taskKind: "DIET",
+            category: "Diet",
+            name: "Feeding check",
+            audience: "PARENT_TASK",
+            dependsOn: ["meds", ""],
+          },
+        ],
+        dischargeOffsetMinutes: 30,
+        followUpTaskName: "Discharge review",
+        signOffRequired: true,
+        shiftWindows: [
+          { start: "08:00", end: "18:00", days: [0, 1, 2, 3, 4, 5, 6, "x", 9] },
+          { start: "06:00", end: "20:00" },
+          { start: 42 },
+        ],
+        exceptions: [
+          { date: "2026-01-02", mode: "SHIFT", start: "10:00", end: "11:00" },
+          { date: "2026-01-03", mode: "SKIP" },
+          { date: "2026-01-04", mode: "OTHER" },
+        ],
+      },
+      {
+        admissionAt: new Date("2026-01-01T00:00:00.000Z"),
+        organisationId: "org-1",
+        createdBy: "creator-1",
+        templateId: "tmpl-5",
+        resolveAssignee: (audience) =>
+          audience === "PARENT_TASK" ? "parent-1" : "employee-1",
+      },
+    );
+
+    expect(seeds).toHaveLength(3);
+    expect(seeds[0].name).toBe("Morning medicine");
+    expect(seeds[0].medication).toEqual({
+      name: "Amoxicillin",
+      dosage: "50mg",
+    });
+    expect(seeds[0].observationToolId).toBe("obs-1");
+    expect(seeds[0].additionalNotes).toBe("Give with food");
+    expect(seeds[0].recurrence).toMatchObject({
+      type: "DAILY",
+      cronExpression: "0 7 * * *",
+    });
+    expect(seeds[0].reminder).toEqual({ enabled: true, offsetMinutes: 10 });
+    expect(seeds[0].dueAt.toISOString()).toBe("2026-01-01T07:00:00.000Z");
+    expect(seeds[1].name).toBe("Feeding check");
+    expect(seeds[1].assignedTo).toBe("parent-1");
+    expect(seeds[1].dueAt.toISOString()).toBe("2026-01-02T10:00:00.000Z");
+    expect(seeds[2].name).toBe("Discharge review");
+    expect(seeds[2].dueAt.toISOString()).toBe("2026-01-01T00:30:00.000Z");
+    expect(seeds[2].reminder).toEqual({ enabled: true, offsetMinutes: 0 });
+  });
+
+  it("defaults optional care pathway snapshot fields when absent", () => {
+    const seeds = materializeTaskWorkflowSeeds(
+      "CARE_PATHWAY",
+      {
+        taskBlocks: [
+          {
+            dayOffset: 0,
+            timeOfDay: "08:00",
+            taskKind: "CARE",
+            category: "Care",
+            name: "Solo task",
+            audience: "EMPLOYEE_TASK",
+          },
+        ],
+      },
+      {
+        admissionAt: new Date("2026-01-01T00:00:00.000Z"),
+        organisationId: "org-1",
+        createdBy: "creator-1",
+        templateId: "tmpl-6",
+        resolveAssignee: () => "employee-1",
+      },
+    );
+
+    expect(seeds).toHaveLength(1);
+    expect(seeds[0].name).toBe("Solo task");
+    expect(seeds[0].medication).toBeUndefined();
+    expect(seeds[0].recurrence).toBeUndefined();
+    expect(seeds[0].reminder).toBeUndefined();
+    expect(seeds[0].dueAt.toISOString()).toBe("2026-01-01T08:00:00.000Z");
+  });
+
   it("materializes a task workflow seed from a template instance snapshot", () => {
     const seeds = materializeTaskWorkflowSeeds(
       "TASK_TEMPLATE",

--- a/apps/backend/test/services/task.service.test.ts
+++ b/apps/backend/test/services/task.service.test.ts
@@ -1307,5 +1307,67 @@ describe("TaskService", () => {
 
       expect(txUpdate).toHaveBeenCalledTimes(2);
     });
+
+    it("splits the series on THIS_AND_FOLLOWING, capping the master and re-parenting future rows", async () => {
+      const occurrenceDueAt = new Date("2026-02-02T09:00:00.000Z");
+      const occurrence = seriesTask({
+        id: "task-2",
+        dueAt: occurrenceDueAt,
+        recurrence: { type: "DAILY", masterTaskId: "task-1" },
+      });
+      mockedPrisma.task.findFirst.mockResolvedValueOnce(occurrence as never);
+      mockedPrisma.task.findMany.mockResolvedValueOnce([
+        seriesTask({
+          recurrence: {
+            type: "DAILY",
+            isMaster: true,
+            cronExpression: "0 9 * * *",
+          },
+        }),
+        occurrence,
+        seriesTask({
+          id: "task-3",
+          dueAt: new Date("2026-02-03T09:00:00.000Z"),
+          recurrence: { type: "DAILY", masterTaskId: "task-1" },
+        }),
+      ] as never);
+      const txUpdate = jest
+        .fn()
+        .mockResolvedValue(seriesTask({ id: "task-2", name: "renamed" }));
+      mockedPrisma.$transaction.mockImplementationOnce(
+        async (cb: (tx: unknown) => Promise<unknown>) =>
+          cb({ task: { update: txUpdate } }),
+      );
+
+      const result = await TaskService.updateTask(
+        "task-2",
+        { name: "renamed" },
+        "actor-1",
+        "THIS_AND_FOLLOWING",
+        "org-1",
+      );
+
+      // current occurrence + old master + one future row
+      expect(txUpdate).toHaveBeenCalledTimes(3);
+      expect(txUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: "task-1" },
+          data: expect.objectContaining({
+            recurrence: expect.objectContaining({
+              endDate: new Date(occurrenceDueAt.getTime() - 1),
+            }),
+          }),
+        }),
+      );
+      expect(txUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: "task-3" },
+          data: expect.objectContaining({
+            recurrence: expect.objectContaining({ masterTaskId: "task-2" }),
+          }),
+        }),
+      );
+      expect(result.id).toBe("task-2");
+    });
   });
 });

--- a/apps/backend/test/utils/prune-undefined.test.ts
+++ b/apps/backend/test/utils/prune-undefined.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "@jest/globals";
+import { pruneUndefined } from "../../src/utils/prune-undefined";
+
+describe("pruneUndefined", () => {
+  it("removes undefined entries from arrays recursively", () => {
+    expect(pruneUndefined([1, undefined, "a", [undefined, 2]])).toEqual([
+      1,
+      "a",
+      [2],
+    ]);
+  });
+
+  it("removes undefined properties from nested objects", () => {
+    expect(
+      pruneUndefined({
+        keep: "value",
+        drop: undefined,
+        nested: { keep: 0, drop: undefined },
+      }),
+    ).toEqual({ keep: "value", nested: { keep: 0 } });
+  });
+
+  it("preserves Date instances", () => {
+    const date = new Date("2026-01-01");
+    expect(pruneUndefined({ date }).date).toBe(date);
+    expect(pruneUndefined(date)).toBe(date);
+  });
+
+  it("keeps null values and returns primitives unchanged", () => {
+    expect(pruneUndefined({ value: null })).toEqual({ value: null });
+    expect(pruneUndefined(null)).toBeNull();
+    expect(pruneUndefined("text")).toBe("text");
+    expect(pruneUndefined(0)).toBe(0);
+    expect(pruneUndefined(undefined)).toBeUndefined();
+  });
+});

--- a/apps/desktop/docs/update-feed-threat-model.md
+++ b/apps/desktop/docs/update-feed-threat-model.md
@@ -22,7 +22,8 @@ This is the threat model for the desktop app's auto-update path (the GitHub Rele
 - Release feeds come from the configured GitHub repository.
 - macOS production artifacts are expected to be Developer ID signed, hardened, notarized, stapled, and Gatekeeper accepted.
 - Windows production artifacts are expected to be Authenticode signed.
-- Update channel selection is explicit: default `latest`, beta only with `YC_DESKTOP_UPDATE_CHANNEL=beta`.
+- Update channel selection is layered: the default is derived from the running version (a `-beta.N` build defaults to `beta`; the app currently ships only beta builds, and electron-updater's prerelease path is a superset that also picks up stable releases), the stored settings preference can change it, and the `YC_DESKTOP_UPDATE_CHANNEL` env var - the managed/MDM control - is authoritative over both.
+- Consequence for the beta-channel threat above: current installs follow the beta feed by default, so a compromised beta feed reaches the whole fleet rather than only opt-in testers - the signing, notarization, and release checks below are the controls that hold there, and a managed deployment can pin `YC_DESKTOP_UPDATE_CHANNEL=latest` to keep its fleet off prerelease artifacts regardless of local settings.
 
 ## Required Release Checks
 

--- a/apps/desktop/src/lifecycle/updater.ts
+++ b/apps/desktop/src/lifecycle/updater.ts
@@ -96,8 +96,11 @@ export const configureUpdateChannel = (
   preferred?: UpdateChannel,
   version?: string
 ): UpdateChannel => {
+  // The env var is the managed (MDM) control, so it must beat the stored user
+  // preference - which is always populated via DEFAULT_SETTINGS and would
+  // otherwise make the override unreachable.
   const channel =
-    preferred ?? updateChannelOverrideFromEnv(env) ?? updateChannelForVersion(version);
+    updateChannelOverrideFromEnv(env) ?? preferred ?? updateChannelForVersion(version);
   autoUpdater.channel = channel;
   autoUpdater.allowPrerelease = channel === 'beta';
   return channel;

--- a/apps/desktop/tests/updater.test.ts
+++ b/apps/desktop/tests/updater.test.ts
@@ -117,17 +117,39 @@ describe('pure helpers', () => {
     expect(betaUpdater).toEqual({ channel: 'beta', allowPrerelease: true });
   });
 
-  test('honors an explicit preferred channel over env', () => {
+  test('the env override (managed control) beats a stored preference', () => {
     const updater: { channel?: string; allowPrerelease?: boolean } = {};
-    // env says beta, but the persisted preference (latest) wins.
+    // env says beta, so the persisted preference (latest) must lose.
     expect(configureUpdateChannel(updater, { [UPDATE_CHANNEL_ENV]: 'beta' }, 'latest')).toBe(
+      'beta'
+    );
+    expect(updater).toEqual({ channel: 'beta', allowPrerelease: true });
+
+    const pinnedUpdater: { channel?: string; allowPrerelease?: boolean } = {};
+    expect(configureUpdateChannel(pinnedUpdater, { [UPDATE_CHANNEL_ENV]: 'latest' }, 'beta')).toBe(
       'latest'
     );
-    expect(updater).toEqual({ channel: 'latest', allowPrerelease: false });
+    expect(pinnedUpdater).toEqual({ channel: 'latest', allowPrerelease: false });
+  });
 
-    const betaUpdater: { channel?: string; allowPrerelease?: boolean } = {};
-    expect(configureUpdateChannel(betaUpdater, {}, 'beta')).toBe('beta');
-    expect(betaUpdater).toEqual({ channel: 'beta', allowPrerelease: true });
+  test('the stored preference wins when the env var is unset', () => {
+    const updater: { channel?: string; allowPrerelease?: boolean } = {};
+    expect(configureUpdateChannel(updater, {}, 'beta')).toBe('beta');
+    expect(updater).toEqual({ channel: 'beta', allowPrerelease: true });
+
+    const latestUpdater: { channel?: string; allowPrerelease?: boolean } = {};
+    expect(configureUpdateChannel(latestUpdater, {}, 'latest', '0.1.0-beta.4')).toBe('latest');
+    expect(latestUpdater).toEqual({ channel: 'latest', allowPrerelease: false });
+  });
+
+  test('falls back to the version-derived channel when env and preference are unset', () => {
+    const betaBuild: { channel?: string; allowPrerelease?: boolean } = {};
+    expect(configureUpdateChannel(betaBuild, {}, undefined, '0.1.0-beta.4')).toBe('beta');
+    expect(betaBuild).toEqual({ channel: 'beta', allowPrerelease: true });
+
+    const stableBuild: { channel?: string; allowPrerelease?: boolean } = {};
+    expect(configureUpdateChannel(stableBuild, {}, undefined, '0.2.0')).toBe('latest');
+    expect(stableBuild).toEqual({ channel: 'latest', allowPrerelease: false });
   });
 
   test('accepts both named and default electron-updater exports', () => {
@@ -217,6 +239,21 @@ describe('initAutoUpdates', () => {
     });
     expect(updater.channel).toBe('beta');
     expect(updater.allowPrerelease).toBe(true);
+  });
+
+  test('the env override beats a stored preference during startup checks', async () => {
+    const updater = makeFakeUpdater();
+    await initAutoUpdates({
+      electron: {
+        app: { isPackaged: true, getVersion: () => '0.1.0-beta.4' },
+        dialog: { showMessageBox: () => Promise.resolve({ response: 1 }) },
+      },
+      autoUpdater: updater as never,
+      env: { [UPDATE_CHANNEL_ENV]: 'latest' },
+      preferredChannel: 'beta',
+    });
+    expect(updater.channel).toBe('latest');
+    expect(updater.allowPrerelease).toBe(false);
   });
 
   test('a stored Stable preference survives the version-derived default', async () => {
@@ -365,6 +402,21 @@ describe('checkForUpdatesManually', () => {
     });
     expect(updater.channel).toBe('beta');
     expect(updater.allowPrerelease).toBe(true);
+  });
+
+  test('the env override beats a stored preference during manual checks', async () => {
+    const updater = makeFakeUpdater();
+    await checkForUpdatesManually({
+      electron: {
+        app: { isPackaged: true, getVersion: () => '0.1.0-beta.4' },
+        dialog: { showMessageBox: () => undefined },
+      },
+      autoUpdater: updater as never,
+      env: { [UPDATE_CHANNEL_ENV]: 'latest' },
+      preferredChannel: 'beta',
+    });
+    expect(updater.channel).toBe('latest');
+    expect(updater.allowPrerelease).toBe(false);
   });
 
   test('each registered handler shows the matching dialog', async () => {

--- a/apps/frontend/src/app/__tests__/components/AddCompanionCentralModal/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/AddCompanionCentralModal/index.test.tsx
@@ -1441,6 +1441,79 @@ describe('AddCompanionCentralModal', () => {
       expect(screen.getByLabelText('First name')).toHaveValue('Alice');
     });
 
+    it('closes the dropdown on outside mousedown and reopens it on focus', async () => {
+      mockSearchParent.mockResolvedValue([
+        {
+          id: 'p-found',
+          firstName: 'Alice',
+          lastName: 'Wonder',
+          email: 'alice@w.com',
+          phoneNumber: '+12025559999',
+          birthDate: undefined,
+          address: {
+            addressLine: '5 Oak',
+            city: 'LA',
+            state: 'CA',
+            postalCode: '90001',
+            country: 'US',
+          },
+          createdFrom: 'pms' as const,
+        },
+      ]);
+
+      await act(async () => {
+        render(<AddCompanionCentralModal {...defaultProps} />);
+      });
+
+      await goToParentStep();
+
+      await act(async () => {
+        fireEvent.change(screen.getByLabelText('First name'), { target: { value: 'Alice' } });
+      });
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 350));
+      });
+
+      const option = await screen.findByRole('button', { name: 'Alice Wonder' });
+
+      // Typing again once results are visible keeps tracking the filtered length.
+      // The open panel shares the input's aria-label, so query the textbox role.
+      await act(async () => {
+        fireEvent.change(screen.getByRole('textbox', { name: 'First name' }), {
+          target: { value: 'Alice W' },
+        });
+      });
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 350));
+      });
+      expect(screen.getByRole('button', { name: 'Alice Wonder' })).toBeInTheDocument();
+
+      // A window resize while open recomputes the portal position and keeps it open
+      await act(async () => {
+        fireEvent(window, new Event('resize'));
+      });
+      expect(screen.getByRole('button', { name: 'Alice Wonder' })).toBeInTheDocument();
+
+      // Mousedown inside the dropdown panel never closes it
+      await act(async () => {
+        fireEvent.mouseDown(document.querySelector('[data-iwd-panel]') as HTMLElement);
+        fireEvent.mouseDown(option);
+      });
+      expect(screen.getByRole('button', { name: 'Alice Wonder' })).toBeInTheDocument();
+
+      // Outside mousedown closes the dropdown
+      await act(async () => {
+        fireEvent.mouseDown(document.body);
+      });
+      expect(screen.queryByRole('button', { name: 'Alice Wonder' })).not.toBeInTheDocument();
+
+      // Re-focusing the input after the user has typed reopens it
+      await act(async () => {
+        fireEvent.focus(screen.getByRole('textbox', { name: 'First name' }));
+      });
+      expect(screen.getByRole('button', { name: 'Alice Wonder' })).toBeInTheDocument();
+    });
+
     it('handlePhoneChange updates localPhoneNumber field', async () => {
       await act(async () => {
         render(<AddCompanionCentralModal {...defaultProps} />);

--- a/apps/frontend/src/app/__tests__/components/Calendar/common/Slot.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/common/Slot.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, createEvent, fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { axe, toHaveNoViolations } from 'jest-axe';
 
@@ -528,6 +528,14 @@ describe('Slot (Appointments)', () => {
 
     expect(screen.getByRole('menu', { name: 'Appointment context actions' })).toBeInTheDocument();
     expect(screen.getByRole('menuitem', { name: 'Open companion overview' })).toBeInTheDocument();
+
+    // Selecting an action fires it and closes the menu through onClose.
+    fireEvent.click(screen.getByRole('menuitem', { name: 'View appointment' }));
+
+    expect(handleViewAppointment).toHaveBeenCalledWith(event);
+    expect(
+      screen.queryByRole('menu', { name: 'Appointment context actions' })
+    ).not.toBeInTheDocument();
   });
 
   it('has no axe accessibility violations when the appointment popover is open', async () => {
@@ -815,9 +823,80 @@ describe('Slot (Appointments)', () => {
 
     const slot = screen.getByRole('region', { name: /Appointments slot for/i });
     fireEvent.dragOver(slot, { clientX: 10, clientY: 20 });
+    // relatedTarget still inside the region => the preview is kept. jsdom drops
+    // relatedTarget passed through fireEvent init, so define it on the event.
+    const leaveInside = createEvent.dragLeave(slot);
+    Object.defineProperty(leaveInside, 'relatedTarget', { value: slot });
+    fireEvent(slot, leaveInside);
+    // relatedTarget outside the region => the preview is cleared.
+    fireEvent.dragOver(slot, { clientX: 10, clientY: 20 });
+    const leaveOutside = createEvent.dragLeave(slot);
+    Object.defineProperty(leaveOutside, 'relatedTarget', { value: document.body });
+    fireEvent(slot, leaveOutside);
     // relatedTarget null => the drag left the region entirely.
+    fireEvent.dragOver(slot, { clientX: 10, clientY: 20 });
     fireEvent.dragLeave(slot, { relatedTarget: null });
 
     expect(slot).toBeInTheDocument();
+  });
+
+  it('dismisses the context menu the moment a drag starts', () => {
+    const slotProps = {
+      slotEvents: [event],
+      height: 120,
+      handleViewAppointment,
+      handleDetailAppointment,
+      handleRescheduleAppointment,
+      dayIndex: 0,
+      length: 1,
+      canEditAppointments: true,
+    };
+    const { rerender } = render(<Slot {...slotProps} />);
+
+    fireEvent.contextMenu(screen.getByRole('button', { name: /Rex/i }));
+    expect(screen.getByRole('menu', { name: 'Appointment context actions' })).toBeInTheDocument();
+
+    rerender(<Slot {...slotProps} draggedAppointmentId="appt-1" draggedAppointmentLabel="Rex" />);
+
+    expect(
+      screen.queryByRole('menu', { name: 'Appointment context actions' })
+    ).not.toBeInTheDocument();
+
+    // Drag ends - the prev-compare tracks the cleared id without dismissing anything.
+    rerender(<Slot {...slotProps} draggedAppointmentId={null} />);
+    expect(screen.getByRole('button', { name: /Rex/i })).toBeInTheDocument();
+  });
+
+  it('renders zoom-in markers via the patient fallback when companion is missing', () => {
+    const patientEvent: any = {
+      status: 'in_progress',
+      startTime: new Date('2025-01-06T09:00:00Z'),
+      endTime: new Date('2025-01-06T09:30:00Z'),
+      concern: 'Checkup',
+      lead: { name: 'Dr. Lee' },
+      appointmentType: { name: 'Exam' },
+      companion: undefined,
+      patient: { name: 'Bella', species: 'cat', parent: { name: 'Owner Smith' } },
+    };
+
+    render(
+      <Slot
+        slotEvents={[patientEvent]}
+        height={120}
+        handleViewAppointment={handleViewAppointment}
+        handleDetailAppointment={handleDetailAppointment}
+        handleRescheduleAppointment={handleRescheduleAppointment}
+        dayIndex={0}
+        length={1}
+        canEditAppointments
+      />
+    );
+
+    const marker = screen.getByRole('button', { name: /Bella/i });
+    expect(marker).toBeInTheDocument();
+
+    // Drag end on a zoom-in marker clears the drop preview via onDropPreviewClear.
+    fireEvent.dragEnd(marker);
+    expect(marker).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/AppointmentWorkspace.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/AppointmentWorkspace.test.tsx
@@ -1478,6 +1478,54 @@ describe('AppointmentWorkspace container', () => {
     expect(screen.getByText('Summary read only: true')).toBeInTheDocument();
   });
 
+  it('locks a workspace left open when the cutoff passes, without a remount', async () => {
+    jest.useFakeTimers();
+    try {
+      // Outpatient default window is 24h; open the workspace 5 minutes before
+      // the cutoff so the re-check timer is what flips the lock.
+      const start = new Date(Date.now() - (24 * 60 - 5) * 60 * 1000);
+      render(<AppointmentWorkspace appointment={makeAppointment(start)} />);
+
+      expect(await screen.findByText('SOAP read only: false')).toBeInTheDocument();
+
+      // Still inside the window: advancing 1 minute must not lock.
+      act(() => {
+        jest.advanceTimersByTime(60 * 1000);
+      });
+      expect(screen.getByText('SOAP read only: false')).toBeInTheDocument();
+
+      // Cross the cutoff (+ the re-check buffer): the lock engages in place.
+      act(() => {
+        jest.advanceTimersByTime(5 * 60 * 1000);
+      });
+      expect(screen.getByText('SOAP read only: true')).toBeInTheDocument();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('schedules no lock re-check when the start time is unparsable', async () => {
+    jest.useFakeTimers();
+    try {
+      const appointment = {
+        ...makeAppointment(new Date()),
+        startTime: 'not-a-date',
+      } as unknown as Appointment;
+      render(<AppointmentWorkspace appointment={appointment} />);
+
+      expect(await screen.findByText('SOAP read only: false')).toBeInTheDocument();
+
+      // An unparsable start can never pass the lock window, so time passing
+      // must not lock the workspace (and no re-check timer flips state).
+      act(() => {
+        jest.advanceTimersByTime(2 * 60 * 1000);
+      });
+      expect(screen.getByText('SOAP read only: false')).toBeInTheDocument();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('opens discharge date and time in a modal from the Summary control row', async () => {
     mockStepParam = 'SUMMARY';
     render(<AppointmentWorkspace appointment={makeAppointment(new Date(), true)} />);

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/Slot.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/Slot.tsx
@@ -7,16 +7,15 @@ import {
   autoScrollCalendarVertically,
 } from '@/app/features/appointments/components/Calendar/helpers';
 import { calcNearestAvailableMinute } from '@/app/features/appointments/components/Calendar/calendarDrop';
-import { createPortal } from 'react-dom';
-import AppointmentPopover from '@/app/features/appointments/components/Calendar/common/AppointmentPopover';
-import AppointmentContextMenu from '@/app/features/appointments/components/Calendar/common/AppointmentContextMenu';
-import { formatDateInPreferredTimeZone, getDatePartsInPreferredTimeZone } from '@/app/lib/timezone';
+import { formatDateInPreferredTimeZone } from '@/app/lib/timezone';
 import { CalendarZoomMode } from '@/app/features/appointments/components/Calendar/calendarLayout';
 import { useNotify } from '@/app/hooks/useNotify';
-import ZoomInMarker from '@/app/features/appointments/components/Calendar/common/ZoomInMarker';
 import { useSlotMarkerInteractions } from '@/app/features/appointments/components/Calendar/common/useSlotMarkerInteractions';
+import ZoomInEventList from '@/app/features/appointments/components/Calendar/common/ZoomInEventList';
 import ZoomOutEventList from '@/app/features/appointments/components/Calendar/common/ZoomOutEventList';
 import DropPreviewOverlay from '@/app/features/appointments/components/Calendar/common/DropPreviewOverlay';
+import SlotCreateButton from '@/app/features/appointments/components/Calendar/common/SlotCreateButton';
+import SlotPortals from '@/app/features/appointments/components/Calendar/common/SlotPortals';
 
 type SlotProps = {
   slotEvents: Appointment[];
@@ -59,83 +58,6 @@ const getSlotEventKey = (event: Appointment): string =>
     event.startTime.toISOString(),
     event.endTime.toISOString(),
   ].join('-');
-
-type LaidOutSlotEvent = {
-  ev: Appointment;
-  startMinute: number;
-  endMinute: number;
-  visibleDurationMinutes: number;
-  laneIndex: number;
-  laneCount: number;
-};
-
-/**
- * Lay overlapping events of one hour slot out into side-by-side lanes: events are
- * clustered by overlap, each cluster packed greedily into the fewest lanes, and
- * every event in a cluster shares the cluster's lane count for width division.
- */
-const layoutZoomInEvents = (sortedSlotEvents: Appointment[]): LaidOutSlotEvent[] => {
-  const base = sortedSlotEvents
-    .map((ev) => {
-      const startMinute = getDatePartsInPreferredTimeZone(ev.startTime).minute;
-      const rawDurationMinutes = Math.max(
-        5,
-        Math.round((ev.endTime.getTime() - ev.startTime.getTime()) / 60000)
-      );
-      const visibleDurationMinutes = Math.max(10, Math.min(rawDurationMinutes, 60 - startMinute));
-      return {
-        ev,
-        startMinute,
-        endMinute: startMinute + visibleDurationMinutes,
-        visibleDurationMinutes,
-      };
-    })
-    .sort((a, b) => {
-      if (a.startMinute !== b.startMinute) return a.startMinute - b.startMinute;
-      return a.endMinute - b.endMinute;
-    });
-
-  const output: LaidOutSlotEvent[] = [];
-
-  let cursor = 0;
-  while (cursor < base.length) {
-    const cluster: typeof base = [base[cursor]];
-    let clusterEnd = base[cursor].endMinute;
-    let next = cursor + 1;
-    while (next < base.length && base[next].startMinute < clusterEnd) {
-      cluster.push(base[next]);
-      clusterEnd = Math.max(clusterEnd, base[next].endMinute);
-      next += 1;
-    }
-
-    const laneEnds: number[] = [];
-    const clusterOut: LaidOutSlotEvent[] = [];
-    cluster.forEach((item) => {
-      let laneIndex = -1;
-      for (let i = 0; i < laneEnds.length; i += 1) {
-        if (laneEnds[i] <= item.startMinute) {
-          laneIndex = i;
-          break;
-        }
-      }
-      if (laneIndex === -1) {
-        laneIndex = laneEnds.length;
-        laneEnds.push(item.endMinute);
-      } else {
-        laneEnds[laneIndex] = item.endMinute;
-      }
-      clusterOut.push({ ...item, laneIndex, laneCount: 1 });
-    });
-
-    const laneCount = Math.max(1, laneEnds.length);
-    clusterOut.forEach((item) => {
-      output.push({ ...item, laneCount });
-    });
-    cursor = next;
-  }
-
-  return output;
-};
 
 /** Availability overlay rectangles for one hour slot while a drag is in flight. */
 const computeAvailabilitySegments = (
@@ -305,11 +227,6 @@ const SlotComponent: React.FC<SlotProps> = ({
     [draggedAppointmentDurationMinutes, dropAvailabilityIntervals, height, hourEnd, hourStart]
   );
 
-  const laidOutZoomInEvents = useMemo(
-    () => layoutZoomInEvents(sortedSlotEvents),
-    [sortedSlotEvents]
-  );
-
   const tryCreateAppointmentAt = (minute: number) => {
     /* v8 ignore next -- defensive guard: the create button only mounts when both dropDate and onCreateAppointmentAt are set, so this early return is unreachable from the UI */
     if (!dropDate || !onCreateAppointmentAt) return;
@@ -337,7 +254,6 @@ const SlotComponent: React.FC<SlotProps> = ({
   };
 
   const { createAppointmentLabel, slotRegionLabel } = buildSlotLabels(dropDate, dropHour);
-  const canPortal = typeof document !== 'undefined';
 
   return (
     <>
@@ -380,18 +296,11 @@ const SlotComponent: React.FC<SlotProps> = ({
         }}
       >
         {dropDate && onCreateAppointmentAt && !draggedAppointmentId ? (
-          <button
-            type="button"
-            aria-label={createAppointmentLabel}
-            className="absolute inset-0 z-1 rounded-none!"
-            onClick={(event) => {
-              const parent = event.currentTarget.parentElement as HTMLDivElement;
-              tryCreateAppointmentAt(getMinuteFromSlotPointer(event.clientY, parent));
-            }}
-            onDoubleClick={(event) => {
-              const parent = event.currentTarget.parentElement as HTMLDivElement;
-              tryCreateAppointmentAt(getMinuteFromSlotPointer(event.clientY, parent));
-            }}
+          <SlotCreateButton
+            label={createAppointmentLabel}
+            onPick={(clientY, container) =>
+              tryCreateAppointmentAt(getMinuteFromSlotPointer(clientY, container))
+            }
           />
         ) : null}
         {draggedAppointmentId &&
@@ -426,76 +335,42 @@ const SlotComponent: React.FC<SlotProps> = ({
             onDropPreviewClear={() => setDropPreviewMinute(null)}
           />
         ) : (
-          // Transparent so the week grid's today-column tint reads through; the
-          // calendar container already supplies the --screen surface underneath.
-          <div className="relative h-full overflow-visible px-1">
-            {laidOutZoomInEvents.map(
-              ({ ev, startMinute, visibleDurationMinutes, laneIndex, laneCount }) => {
-                const itemKey = getSlotEventKey(ev);
-                const topPx = (startMinute / 60) * height;
-                const blockHeightPx = Math.max((visibleDurationMinutes / 60) * height, 40);
-
-                return (
-                  <ZoomInMarker
-                    key={itemKey}
-                    ev={ev}
-                    itemKey={itemKey}
-                    laneIndex={laneIndex}
-                    laneCount={laneCount}
-                    topPx={topPx}
-                    blockHeightPx={blockHeightPx}
-                    activePopoverKey={activePopoverKey}
-                    appointmentPopoverId={appointmentPopoverId}
-                    draggedAppointmentId={draggedAppointmentId}
-                    canDragAppointment={canDragAppointment}
-                    onMarkerClick={handleMarkerClick}
-                    onMarkerDoubleClick={handleMarkerDoubleClick}
-                    onMarkerContextMenu={handleMarkerContextMenu}
-                    onAppointmentDragStart={onAppointmentDragStart}
-                    onAppointmentDragEnd={onAppointmentDragEnd}
-                    onDropPreviewClear={() => setDropPreviewMinute(null)}
-                  />
-                );
-              }
-            )}
-          </div>
+          <ZoomInEventList
+            sortedSlotEvents={sortedSlotEvents}
+            height={height}
+            activePopoverKey={activePopoverKey}
+            appointmentPopoverId={appointmentPopoverId}
+            draggedAppointmentId={draggedAppointmentId}
+            canDragAppointment={canDragAppointment}
+            onMarkerClick={handleMarkerClick}
+            onMarkerDoubleClick={handleMarkerDoubleClick}
+            onMarkerContextMenu={handleMarkerContextMenu}
+            onAppointmentDragStart={onAppointmentDragStart}
+            onAppointmentDragEnd={onAppointmentDragEnd}
+            onDropPreviewClear={() => setDropPreviewMinute(null)}
+          />
         )}
       </section>
-      {canPortal &&
-        !draggedAppointmentId &&
-        activeEvent &&
-        activeRect &&
-        createPortal(
-          <AppointmentPopover
-            appointment={activeEvent}
-            invoicesByAppointmentId={invoicesByAppointmentId}
-            canEditAppointments={canEditAppointments}
-            popoverId={appointmentPopoverId}
-            popoverDialogRef={popoverDialogRef}
-            popoverStyle={popoverStyle}
-            handleRescheduleAppointment={handleRescheduleAppointment}
-            handleChangeRoomAppointment={handleChangeRoomAppointment}
-            handleAcceptAppointment={handleAcceptAppointment}
-            onClose={() => setActivePopoverKey(null)}
-            registerAnchorEl={registerAnchorEl}
-          />,
-          document.body
-        )}
-      {canPortal &&
-        contextMenu &&
-        contextMenuStyle &&
-        createPortal(
-          <AppointmentContextMenu
-            appointment={contextMenu.appointment}
-            canEditAppointments={canEditAppointments}
-            menuRef={contextMenuRef}
-            menuStyle={contextMenuStyle}
-            handleViewAppointment={handleViewAppointment}
-            handleRescheduleAppointment={handleRescheduleAppointment}
-            onClose={() => setContextMenu(null)}
-          />,
-          document.body
-        )}
+      <SlotPortals
+        activeEvent={activeEvent}
+        activeRect={activeRect}
+        draggedAppointmentId={draggedAppointmentId}
+        invoicesByAppointmentId={invoicesByAppointmentId}
+        canEditAppointments={canEditAppointments}
+        appointmentPopoverId={appointmentPopoverId}
+        popoverDialogRef={popoverDialogRef}
+        popoverStyle={popoverStyle}
+        registerAnchorEl={registerAnchorEl}
+        contextMenu={contextMenu}
+        contextMenuRef={contextMenuRef}
+        contextMenuStyle={contextMenuStyle}
+        handleViewAppointment={handleViewAppointment}
+        handleRescheduleAppointment={handleRescheduleAppointment}
+        handleChangeRoomAppointment={handleChangeRoomAppointment}
+        handleAcceptAppointment={handleAcceptAppointment}
+        onPopoverClose={() => setActivePopoverKey(null)}
+        onContextMenuClose={() => setContextMenu(null)}
+      />
     </>
   );
 };

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/SlotCreateButton.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/SlotCreateButton.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+type SlotCreateButtonProps = {
+  label: string;
+  onPick: (clientY: number, container: HTMLDivElement) => void;
+};
+
+/** Invisible full-slot click layer that books the minute under the pointer. */
+const SlotCreateButton = ({ label, onPick }: SlotCreateButtonProps) => {
+  const pickFromEvent = (event: React.MouseEvent<HTMLButtonElement>) => {
+    const parent = event.currentTarget.parentElement as HTMLDivElement;
+    onPick(event.clientY, parent);
+  };
+
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      className="absolute inset-0 z-1 rounded-none!"
+      onClick={pickFromEvent}
+      onDoubleClick={pickFromEvent}
+    />
+  );
+};
+
+export default SlotCreateButton;

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/SlotPortals.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/SlotPortals.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { createPortal } from 'react-dom';
+import { Appointment, Invoice } from '@yosemite-crew/types';
+import { AppointmentViewIntent } from '@/app/features/appointments/types/calendar';
+import AppointmentPopover from '@/app/features/appointments/components/Calendar/common/AppointmentPopover';
+import AppointmentContextMenu from '@/app/features/appointments/components/Calendar/common/AppointmentContextMenu';
+import { MarkerContextMenuState } from '@/app/features/appointments/components/Calendar/common/useMarkerInteractions';
+
+type SlotPortalsProps = {
+  activeEvent: Appointment | null;
+  activeRect: DOMRect | null;
+  draggedAppointmentId?: string | null;
+  invoicesByAppointmentId: Record<string, Invoice>;
+  canEditAppointments: boolean;
+  appointmentPopoverId: string;
+  popoverDialogRef: React.RefObject<HTMLDialogElement | null>;
+  popoverStyle: React.CSSProperties;
+  registerAnchorEl: (el: HTMLElement | null) => () => void;
+  contextMenu: MarkerContextMenuState | null;
+  contextMenuRef: React.RefObject<HTMLDivElement | null>;
+  contextMenuStyle: React.CSSProperties | null;
+  handleViewAppointment: (appt: Appointment, intent?: AppointmentViewIntent) => void;
+  handleRescheduleAppointment: (appt: Appointment) => void;
+  handleChangeRoomAppointment?: (appt: Appointment) => void;
+  handleAcceptAppointment?: (appt: Appointment) => void;
+  onPopoverClose: () => void;
+  onContextMenuClose: () => void;
+};
+
+/**
+ * The slot's floating layers - the appointment popover and the right-click
+ * context menu - portaled to document.body so they escape the slot's overflow
+ * clipping. The popover hides while a drag is in flight.
+ */
+const SlotPortals = ({
+  activeEvent,
+  activeRect,
+  draggedAppointmentId,
+  invoicesByAppointmentId,
+  canEditAppointments,
+  appointmentPopoverId,
+  popoverDialogRef,
+  popoverStyle,
+  registerAnchorEl,
+  contextMenu,
+  contextMenuRef,
+  contextMenuStyle,
+  handleViewAppointment,
+  handleRescheduleAppointment,
+  handleChangeRoomAppointment,
+  handleAcceptAppointment,
+  onPopoverClose,
+  onContextMenuClose,
+}: SlotPortalsProps) => {
+  const canPortal = typeof document !== 'undefined';
+
+  return (
+    <>
+      {canPortal &&
+        !draggedAppointmentId &&
+        activeEvent &&
+        activeRect &&
+        createPortal(
+          <AppointmentPopover
+            appointment={activeEvent}
+            invoicesByAppointmentId={invoicesByAppointmentId}
+            canEditAppointments={canEditAppointments}
+            popoverId={appointmentPopoverId}
+            popoverDialogRef={popoverDialogRef}
+            popoverStyle={popoverStyle}
+            handleRescheduleAppointment={handleRescheduleAppointment}
+            handleChangeRoomAppointment={handleChangeRoomAppointment}
+            handleAcceptAppointment={handleAcceptAppointment}
+            onClose={onPopoverClose}
+            registerAnchorEl={registerAnchorEl}
+          />,
+          document.body
+        )}
+      {canPortal &&
+        contextMenu &&
+        contextMenuStyle &&
+        createPortal(
+          <AppointmentContextMenu
+            appointment={contextMenu.appointment}
+            canEditAppointments={canEditAppointments}
+            menuRef={contextMenuRef}
+            menuStyle={contextMenuStyle}
+            handleViewAppointment={handleViewAppointment}
+            handleRescheduleAppointment={handleRescheduleAppointment}
+            onClose={onContextMenuClose}
+          />,
+          document.body
+        )}
+    </>
+  );
+};
+
+export default SlotPortals;

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/ZoomInEventList.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/ZoomInEventList.tsx
@@ -1,0 +1,162 @@
+import React, { useMemo } from 'react';
+import { Appointment } from '@yosemite-crew/types';
+import { getDatePartsInPreferredTimeZone } from '@/app/lib/timezone';
+import ZoomInMarker from '@/app/features/appointments/components/Calendar/common/ZoomInMarker';
+
+const getSlotEventKey = (event: Appointment): string =>
+  [
+    event.id,
+    (event.companion ?? event.patient).name,
+    event.startTime.toISOString(),
+    event.endTime.toISOString(),
+  ].join('-');
+
+type ZoomInEventListProps = {
+  sortedSlotEvents: Appointment[];
+  height: number;
+  activePopoverKey: string | null;
+  appointmentPopoverId: string;
+  draggedAppointmentId?: string | null;
+  canDragAppointment?: (appointment: Appointment) => boolean;
+  onMarkerClick: React.ComponentProps<typeof ZoomInMarker>['onMarkerClick'];
+  onMarkerDoubleClick: React.ComponentProps<typeof ZoomInMarker>['onMarkerDoubleClick'];
+  onMarkerContextMenu: React.ComponentProps<typeof ZoomInMarker>['onMarkerContextMenu'];
+  onAppointmentDragStart?: (appointment: Appointment) => void;
+  onAppointmentDragEnd?: () => void;
+  onDropPreviewClear: () => void;
+};
+
+type LaidOutSlotEvent = {
+  ev: Appointment;
+  startMinute: number;
+  endMinute: number;
+  visibleDurationMinutes: number;
+  laneIndex: number;
+  laneCount: number;
+};
+
+/**
+ * Lay overlapping events of one hour slot out into side-by-side lanes: events are
+ * clustered by overlap, each cluster packed greedily into the fewest lanes, and
+ * every event in a cluster shares the cluster's lane count for width division.
+ */
+const layoutZoomInEvents = (sortedSlotEvents: Appointment[]): LaidOutSlotEvent[] => {
+  const base = sortedSlotEvents
+    .map((ev) => {
+      const startMinute = getDatePartsInPreferredTimeZone(ev.startTime).minute;
+      const rawDurationMinutes = Math.max(
+        5,
+        Math.round((ev.endTime.getTime() - ev.startTime.getTime()) / 60000)
+      );
+      const visibleDurationMinutes = Math.max(10, Math.min(rawDurationMinutes, 60 - startMinute));
+      return {
+        ev,
+        startMinute,
+        endMinute: startMinute + visibleDurationMinutes,
+        visibleDurationMinutes,
+      };
+    })
+    .sort((a, b) => {
+      if (a.startMinute !== b.startMinute) return a.startMinute - b.startMinute;
+      return a.endMinute - b.endMinute;
+    });
+
+  const output: LaidOutSlotEvent[] = [];
+
+  let cursor = 0;
+  while (cursor < base.length) {
+    const cluster: typeof base = [base[cursor]];
+    let clusterEnd = base[cursor].endMinute;
+    let next = cursor + 1;
+    while (next < base.length && base[next].startMinute < clusterEnd) {
+      cluster.push(base[next]);
+      clusterEnd = Math.max(clusterEnd, base[next].endMinute);
+      next += 1;
+    }
+
+    const laneEnds: number[] = [];
+    const clusterOut: LaidOutSlotEvent[] = [];
+    cluster.forEach((item) => {
+      let laneIndex = -1;
+      for (let i = 0; i < laneEnds.length; i += 1) {
+        if (laneEnds[i] <= item.startMinute) {
+          laneIndex = i;
+          break;
+        }
+      }
+      if (laneIndex === -1) {
+        laneIndex = laneEnds.length;
+        laneEnds.push(item.endMinute);
+      } else {
+        laneEnds[laneIndex] = item.endMinute;
+      }
+      clusterOut.push({ ...item, laneIndex, laneCount: 1 });
+    });
+
+    const laneCount = Math.max(1, laneEnds.length);
+    clusterOut.forEach((item) => {
+      output.push({ ...item, laneCount });
+    });
+    cursor = next;
+  }
+
+  return output;
+};
+
+const ZoomInEventList = ({
+  sortedSlotEvents,
+  height,
+  activePopoverKey,
+  appointmentPopoverId,
+  draggedAppointmentId,
+  canDragAppointment,
+  onMarkerClick,
+  onMarkerDoubleClick,
+  onMarkerContextMenu,
+  onAppointmentDragStart,
+  onAppointmentDragEnd,
+  onDropPreviewClear,
+}: ZoomInEventListProps) => {
+  const laidOutZoomInEvents = useMemo(
+    () => layoutZoomInEvents(sortedSlotEvents),
+    [sortedSlotEvents]
+  );
+
+  return (
+    // Transparent so the week grid's today-column tint reads through; the
+    // calendar container already supplies the --screen surface underneath.
+    <div className="relative h-full overflow-visible px-1">
+      {laidOutZoomInEvents.map(
+        ({ ev, startMinute, visibleDurationMinutes, laneIndex, laneCount }) => {
+          const itemKey = getSlotEventKey(ev);
+          const topPx = (startMinute / 60) * height;
+          const blockHeightPx = Math.max((visibleDurationMinutes / 60) * height, 40);
+
+          return (
+            <ZoomInMarker
+              key={itemKey}
+              ev={ev}
+              itemKey={itemKey}
+              laneIndex={laneIndex}
+              laneCount={laneCount}
+              topPx={topPx}
+              blockHeightPx={blockHeightPx}
+              activePopoverKey={activePopoverKey}
+              appointmentPopoverId={appointmentPopoverId}
+              draggedAppointmentId={draggedAppointmentId}
+              canDragAppointment={canDragAppointment}
+              onMarkerClick={onMarkerClick}
+              onMarkerDoubleClick={onMarkerDoubleClick}
+              onMarkerContextMenu={onMarkerContextMenu}
+              onAppointmentDragStart={onAppointmentDragStart}
+              onAppointmentDragEnd={onAppointmentDragEnd}
+              onDropPreviewClear={onDropPreviewClear}
+            />
+          );
+        }
+      )}
+    </div>
+  );
+};
+
+export default ZoomInEventList;

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/ZoomInEventList.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/ZoomInEventList.tsx
@@ -35,13 +35,10 @@ type LaidOutSlotEvent = {
   laneCount: number;
 };
 
-/**
- * Lay overlapping events of one hour slot out into side-by-side lanes: events are
- * clustered by overlap, each cluster packed greedily into the fewest lanes, and
- * every event in a cluster shares the cluster's lane count for width division.
- */
-const layoutZoomInEvents = (sortedSlotEvents: Appointment[]): LaidOutSlotEvent[] => {
-  const base = sortedSlotEvents
+type BaseSlotEvent = Omit<LaidOutSlotEvent, 'laneIndex' | 'laneCount'>;
+
+const toBaseSlotEvents = (sortedSlotEvents: Appointment[]): BaseSlotEvent[] =>
+  sortedSlotEvents
     .map((ev) => {
       const startMinute = getDatePartsInPreferredTimeZone(ev.startTime).minute;
       const rawDurationMinutes = Math.max(
@@ -61,45 +58,56 @@ const layoutZoomInEvents = (sortedSlotEvents: Appointment[]): LaidOutSlotEvent[]
       return a.endMinute - b.endMinute;
     });
 
-  const output: LaidOutSlotEvent[] = [];
+// A cluster is a maximal run of transitively-overlapping events; it ends at the
+// first event that starts after everything seen so far has ended.
+const collectCluster = (
+  base: BaseSlotEvent[],
+  cursor: number
+): { cluster: BaseSlotEvent[]; next: number } => {
+  const cluster: BaseSlotEvent[] = [base[cursor]];
+  let clusterEnd = base[cursor].endMinute;
+  let next = cursor + 1;
+  while (next < base.length && base[next].startMinute < clusterEnd) {
+    cluster.push(base[next]);
+    clusterEnd = Math.max(clusterEnd, base[next].endMinute);
+    next += 1;
+  }
+  return { cluster, next };
+};
 
+// Greedy interval partitioning: reuse the first lane that is free by the item's
+// start, else open a new lane. Every event in the cluster shares the final lane
+// count so widths divide evenly.
+const packClusterIntoLanes = (cluster: BaseSlotEvent[]): LaidOutSlotEvent[] => {
+  const laneEnds: number[] = [];
+  const laidOut = cluster.map((item) => {
+    let laneIndex = laneEnds.findIndex((end) => end <= item.startMinute);
+    if (laneIndex === -1) {
+      laneIndex = laneEnds.length;
+      laneEnds.push(item.endMinute);
+    } else {
+      laneEnds[laneIndex] = item.endMinute;
+    }
+    return { ...item, laneIndex, laneCount: 1 };
+  });
+  const laneCount = Math.max(1, laneEnds.length);
+  return laidOut.map((item) => ({ ...item, laneCount }));
+};
+
+/**
+ * Lay overlapping events of one hour slot out into side-by-side lanes: events are
+ * clustered by overlap, each cluster packed greedily into the fewest lanes, and
+ * every event in a cluster shares the cluster's lane count for width division.
+ */
+const layoutZoomInEvents = (sortedSlotEvents: Appointment[]): LaidOutSlotEvent[] => {
+  const base = toBaseSlotEvents(sortedSlotEvents);
+  const output: LaidOutSlotEvent[] = [];
   let cursor = 0;
   while (cursor < base.length) {
-    const cluster: typeof base = [base[cursor]];
-    let clusterEnd = base[cursor].endMinute;
-    let next = cursor + 1;
-    while (next < base.length && base[next].startMinute < clusterEnd) {
-      cluster.push(base[next]);
-      clusterEnd = Math.max(clusterEnd, base[next].endMinute);
-      next += 1;
-    }
-
-    const laneEnds: number[] = [];
-    const clusterOut: LaidOutSlotEvent[] = [];
-    cluster.forEach((item) => {
-      let laneIndex = -1;
-      for (let i = 0; i < laneEnds.length; i += 1) {
-        if (laneEnds[i] <= item.startMinute) {
-          laneIndex = i;
-          break;
-        }
-      }
-      if (laneIndex === -1) {
-        laneIndex = laneEnds.length;
-        laneEnds.push(item.endMinute);
-      } else {
-        laneEnds[laneIndex] = item.endMinute;
-      }
-      clusterOut.push({ ...item, laneIndex, laneCount: 1 });
-    });
-
-    const laneCount = Math.max(1, laneEnds.length);
-    clusterOut.forEach((item) => {
-      output.push({ ...item, laneCount });
-    });
+    const { cluster, next } = collectCluster(base, cursor);
+    output.push(...packClusterIntoLanes(cluster));
     cursor = next;
   }
-
   return output;
 };
 

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/index.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/index.tsx
@@ -106,6 +106,12 @@ type RequiredStaffMember = {
 
 const ADMISSIBLE_APPOINTMENT_STATUSES = new Set(['CHECKED_IN', 'IN_PROGRESS']);
 
+// Small grace past the lock cutoff before re-sampling the clock, and the max
+// single setTimeout delay - browsers overflow delays above 2^31-1 ms and fire
+// immediately, and the max lock window (720h) exceeds that limit.
+const LOCK_RECHECK_BUFFER_MS = 1000;
+const MAX_LOCK_RECHECK_DELAY_MS = 0x7fffffff;
+
 /**
  * Whether the visit has actually begun. Only a checked-in, in-progress, or
  * completed appointment has started; an Upcoming/Requested one has not. This
@@ -542,9 +548,10 @@ const useAppointmentWorkspaceContent = ({ appointment }: AppointmentWorkspacePro
   const encounterMode = encounter?.mode ?? initialMode;
   const lockWindow = useAppointmentLockWindow();
 
-  // Sampled once on mount (render must stay pure, so no Date.now() in the memo);
-  // the lock windows are hours-scale, so a session-age drift is immaterial.
-  const [lockCheckedAt] = useState(() => Date.now());
+  // Sampled in state (render must stay pure, so no Date.now() in the memo) and
+  // refreshed by the timer effect below, so a workspace opened before the cutoff
+  // and left open still locks the legal record when the cutoff passes.
+  const [lockCheckedAt, setLockCheckedAt] = useState(() => Date.now());
   const lockedByWindow = useMemo(
     () =>
       isPastLockWindow(
@@ -555,6 +562,22 @@ const useAppointmentWorkspaceContent = ({ appointment }: AppointmentWorkspacePro
       ),
     [appointment.startTime, encounterMode, lockCheckedAt, lockWindow]
   );
+  // While still inside the lock window, schedule a clock re-sample for just
+  // after the cutoff. Delays past the setTimeout limit run in clamped chunks;
+  // lockCheckedAt in the deps re-arms the timer after each fire, and once
+  // lockedByWindow flips true the effect stops scheduling.
+  useEffect(() => {
+    if (lockedByWindow || !appointment.startTime) return undefined;
+    const startMs = new Date(appointment.startTime).getTime();
+    if (Number.isNaN(startMs)) return undefined;
+    const cutoffMs = startMs + resolveLockHours(encounterMode, lockWindow) * 60 * 60 * 1000;
+    const delayMs = Math.min(
+      Math.max(cutoffMs - lockCheckedAt, 0) + LOCK_RECHECK_BUFFER_MS,
+      MAX_LOCK_RECHECK_DELAY_MS
+    );
+    const timer = setTimeout(() => setLockCheckedAt(Date.now()), delayMs);
+    return () => clearTimeout(timer);
+  }, [appointment.startTime, encounterMode, lockCheckedAt, lockWindow, lockedByWindow]);
 
   // Ready-for-billing is a monotonic milestone: once any invoice for this visit is
   // paid/settled it can't be un-marked (the backend 409s the revert), so lock the

--- a/apps/frontend/src/app/features/companions/components/AddCompanionCentralModal/InputWithDropdown.tsx
+++ b/apps/frontend/src/app/features/companions/components/AddCompanionCentralModal/InputWithDropdown.tsx
@@ -36,9 +36,6 @@ const InputWithDropdown = ({
   const [open, setOpen] = useState(false);
   const [portalStyle, setPortalStyle] = useState<React.CSSProperties | null>(null);
   const uid = useId();
-  // Only auto-open after the user has typed — prevents dropdown firing when
-  // edit mode mounts with a pre-filled value that matches existing companions.
-  const [userHasTyped, setUserHasTyped] = useState(false);
 
   const filtered = useFilteredOptions(options, value);
 
@@ -53,13 +50,14 @@ const InputWithDropdown = ({
     return () => document.removeEventListener('mousedown', handler);
   }, []);
 
-  // Auto-open when results arrive, auto-close when empty — but only after user interaction
-  const [prevFilteredLength, setPrevFilteredLength] = useState(filtered.length);
-  if (filtered.length !== prevFilteredLength) {
+  // Auto-open when results arrive, auto-close when empty - but only after the user
+  // has typed. null until the first keystroke seeds it (in onChange), which prevents
+  // the dropdown firing when edit mode mounts with a pre-filled value that matches
+  // existing companions.
+  const [prevFilteredLength, setPrevFilteredLength] = useState<number | null>(null);
+  if (prevFilteredLength !== null && filtered.length !== prevFilteredLength) {
     setPrevFilteredLength(filtered.length);
-    if (userHasTyped) {
-      setOpen(filtered.length > 0);
-    }
+    setOpen(filtered.length > 0);
   }
 
   const computeStyle = useCallback(() => {
@@ -143,11 +141,11 @@ const InputWithDropdown = ({
           value={value}
           autoComplete="off"
           onChange={(e) => {
-            setUserHasTyped(true);
+            setPrevFilteredLength((prev) => prev ?? filtered.length);
             onChange(e.target.value);
           }}
           onFocus={() => {
-            if (userHasTyped && filtered.length > 0) setOpen(true);
+            if (prevFilteredLength !== null && filtered.length > 0) setOpen(true);
           }}
           aria-invalid={Boolean(error)}
           className={`

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -82,8 +82,10 @@ app/gradle.lockfile` Maven deps, `ios/Podfile.lock` pods) - only build
 - Releases published by workflows authenticating with `GITHUB_TOKEN`
   (desktop-release, release-notes) do not emit a `release` event this
   workflow can observe. The user's tag push covers gating and SBOM artifacts
-  for those refs; attaching the assets to such a release is a manual rerun of
-  the workflow from that release.
+  for those refs; to attach the assets to such a release, run the workflow
+  via `workflow_dispatch` from the tag ref with the `release_tag` input set
+  to that tag - the SBOM is built from the dispatched ref, so dispatching
+  from the tag makes the uploaded assets match the released code.
 - The dependency install runs on Linux in CI, so packages restricted to other
   platforms via the `os` field contribute lockfile entries (completeness) but
   no installed license metadata - a known, documented margin.

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -84,8 +84,10 @@ app/gradle.lockfile` Maven deps, `ios/Podfile.lock` pods) - only build
   workflow can observe. The user's tag push covers gating and SBOM artifacts
   for those refs; to attach the assets to such a release, run the workflow
   via `workflow_dispatch` from the tag ref with the `release_tag` input set
-  to that tag - the SBOM is built from the dispatched ref, so dispatching
-  from the tag makes the uploaded assets match the released code.
+  to that tag. The SBOM is built from the dispatched ref, so the publish job
+  fails closed unless the dispatch ref IS `refs/tags/<release_tag>` - a
+  dispatch from any other ref would otherwise clobber the release's SBOMs
+  with artifacts built from different code.
 - The dependency install runs on Linux in CI, so packages restricted to other
   platforms via the `os` field contribute lockfile entries (completeness) but
   no installed license metadata - a known, documented margin.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,8 +237,8 @@ importers:
         specifier: ^13.6.0
         version: 13.6.0
       google-auth-library:
-        specifier: ^11.0.0
-        version: 11.0.0
+        specifier: ^10.9.1
+        version: 10.9.1
       helmet:
         specifier: ^8.3.0
         version: 8.3.0
@@ -20386,9 +20386,9 @@ packages:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
     dev: true
 
-  /google-auth-library@11.0.0:
-    resolution: {integrity: sha512-WC5gkb2pElGhZKgGx9r799trH3ZUx90ecgIOIMmgiiHS/gzO3r4vvFoQWuKI0QmR2xU5uee2M4hDUxRZDh/x7w==}
-    engines: {node: '>=22'}
+  /google-auth-library@10.9.1:
+    resolution: {integrity: sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==}
+    engines: {node: '>=18'}
     dependencies:
       base64-js: 1.5.1
       ecdsa-sig-formatter: 1.0.11


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] All existing tests and lints pass.

## What is the current behavior?

The dev-to-main promotion PR #2120 cannot merge: the backend SonarCloud gate fails (new-code coverage 86.1 percent against our 95 percent bar, new-code duplication 4.3 percent against the 3 percent gate), Codex raised three P1 and two P2 findings, and React Doctor reports two new warnings.

## What is the new behavior?

Everything needed to turn #2120 green, verified locally with full suites (backend 4820, frontend 10821, desktop 945 tests - all passing; type-check and lint clean in all three workspaces):

- fix(backend): tests covering 31 of the 33 uncovered new-code lines across 11 services (the remaining 2, appointment.prisma.service.ts 1201/1210, are unreachable dead branches of a private helper - documented below). All flagged duplication removed by real extraction: buildTaxSnapshotData and a shared finance/settlement.ts module (payment.ts and invoice.service.ts), settleAppointmentBookingInvoice (stripe.service.ts), a shared src/utils/prune-undefined.ts (organization, user-organization, speciality services), buildOrganizationWriteData and promoteLinkToPrimary helpers (organization, parent-companion services). New helpers are at 100 percent coverage.
- fix(desktop): the YC_DESKTOP_UPDATE_CHANNEL managed override is now authoritative over the stored preference (Codex P1) - precedence is env override, then stored preference, then version-derived default; tests pin all three tiers. The update-feed threat model now describes the real channel-selection layers instead of the stale "default latest" control (Codex P2).
- fix(frontend): the clinical lock re-evaluates after mount (Codex P1) - a timer effect re-samples the clock just past the lock cutoff (clamped chunks for long windows, cleared on unmount), so an open workspace locks SOAP/discharge the moment the window passes; fake-timer tests cover it and AppointmentWorkspace/index.tsx sits at 100 percent coverage. Both new React Doctor warnings cleared: InputWithDropdown folds the typed-latch into the existing adjust state (the ref swap the bot suggested would itself violate ref rules - the value IS read in render), and Slot.tsx is decomposed into ZoomInEventList, SlotCreateButton and SlotPortals sibling components, all at 100 percent coverage.
- chore(repo): google-auth-library reverted to ^10.9.1 (Codex P1 - v11 requires node 22, the backend image runs node 18) with the major frozen in dependabot until the runtime upgrade; supply-chain.yml gains a release_tag workflow_dispatch input so GITHUB_TOKEN-published releases can receive their SBOM assets (Codex P2), with docs updated.

Known accepted gap: appointment.prisma.service.ts lines 1201/1210 stay uncovered - they are filters.patientId/parentId branches of the private buildWhereFromFilters that no exported method can reach; removing or wiring them is a behavior decision left out of this gate-clearing PR.

Impact area: backend services and tests, desktop updater, appointments workspace and calendar, companions modal, dependabot and supply-chain CI config.

Validation: full backend, frontend and desktop suites plus type-check and lint (clean); actionlint on the changed workflow; duplicate-key YAML scan on dependabot.yml; scripts test suites 46/46.