### PR TITLE
ci(repo): sync dependabot config from dev - freeze google-auth-library majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -65,6 +65,10 @@ updates:
       # far scores below the 50 minimum (1.413.x scored 31/100 on #2088 and
       # #2096). Re-bump deliberately once the Socket score recovers.
       - dependency-name: 'posthog-js'
+      # google-auth-library 11 requires node >=22 at runtime; the backend image
+      # runs node 18 - unfreeze together with the runtime upgrade.
+      - dependency-name: 'google-auth-library'
+        update-types: ['version-update:semver-major']
     groups:
       # Every group is minor-and-patch only, including the named ones below. A
       # named group without `update-types` silently swallows MAJORS too, which is


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] All existing tests and lints pass.

## What is the current behavior?

Dependabot reads its config from main, whose copy lacks the google-auth-library major freeze that landed on dev in #2121 - so dependabot would re-open the v11 major PR (v11 requires node 22; the backend image runs node 18). The 4-line divergence also puts the dev-to-main promotion PR #2120 into a merge conflict on this file, which silently skips its pull_request CI runs.

## What is the new behavior?

main's .github/dependabot.yml is byte-identical to dev's again (the file's own header requires the copies stay in sync): an ignore entry freezing google-auth-library semver-major with a comment tying the unfreeze to the runtime upgrade. This activates the freeze where dependabot actually reads it and clears #2120's conflict.

Impact area: dependabot configuration only; no code.

Validation: yaml parses clean; the file is an exact byte copy of origin/dev's.