### PR TITLE
ci(repo): sync dependabot config from dev - freeze playwright minors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -66,9 +66,14 @@ updates:
       # #2096). Re-bump deliberately once the Socket score recovers.
       - dependency-name: 'posthog-js'
       # google-auth-library 11 requires node >=22 at runtime; the backend image
-      # runs node 18 - unfreeze together with the runtime upgrade.
+      # runs node 18 - unfreeze together with the runtime upgrade (#2125).
       - dependency-name: 'google-auth-library'
         update-types: ['version-update:semver-major']
+      # playwright raised its node floor to >=20 in 1.62; the backend image runs
+      # node 18 and the security override pins playwright-core at 1.61.1 - keep
+      # playwright in lockstep on ~1.61.1 until the runtime upgrade (#2125).
+      - dependency-name: 'playwright'
+        update-types: ['version-update:semver-major', 'version-update:semver-minor']
     groups:
       # Every group is minor-and-patch only, including the named ones below. A
       # named group without `update-types` silently swallows MAJORS too, which is


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] All existing tests and lints pass.

## What is the current behavior?

Dev's dependabot.yml gains a playwright major+minor freeze in #2126 (playwright 1.62 requires node >=20; the backend image runs node 18 - see #2125). Dependabot reads config from main, and the divergence would also re-conflict the promotion PR #2120.

## What is the new behavior?

main's copy is byte-identical to dev's again: the playwright ignore entry is active where dependabot reads it, and #2120 stays conflict-free. Same pattern as #2122.

Impact area: dependabot configuration only.

Validation: exact byte copy of the file merged to dev in #2126; yaml parses clean.