### PR TITLE
ci(repo): sync dependabot config from dev - fully freeze playwright

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -70,10 +70,11 @@ updates:
       - dependency-name: 'google-auth-library'
         update-types: ['version-update:semver-major']
       # playwright raised its node floor to >=20 in 1.62; the backend image runs
-      # node 18 and the security override pins playwright-core at 1.61.1 - keep
-      # playwright in lockstep on ~1.61.1 until the runtime upgrade (#2125).
+      # node 18 and the security override pins playwright-core at EXACTLY 1.61.1,
+      # which every playwright release must match exactly. Fully frozen (even
+      # patches) so the pair only moves atomically with the runtime upgrade
+      # (#2125) - a patch bump here without the override recreates the mismatch.
       - dependency-name: 'playwright'
-        update-types: ['version-update:semver-major', 'version-update:semver-minor']
     groups:
       # Every group is minor-and-patch only, including the named ones below. A
       # named group without `update-types` silently swallows MAJORS too, which is


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] All existing tests and lints pass.

## What is the current behavior?

The playwright dependabot entry tightens on dev (#2126, Codex follow-up): even patch updates are frozen, because the security override pins playwright-core at exactly 1.61.1 and any lone playwright bump recreates a version mismatch in the production PDF renderer. Main still has the earlier major+minor-only entry.

## What is the new behavior?

main's dependabot.yml is byte-identical to dev's again. Same pattern as #2122 and #2127; keeps the promotion PR #2120 conflict-free and activates the freeze where dependabot reads it.

Impact area: dependabot configuration only.

Validation: exact byte copy of dev's file; yaml parses clean.