### PR TITLE
fix(repo): defuse the grype sample-date time bomb and close exception loopholes

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -10,7 +10,8 @@
 # ignore:
 #   # GHSA-xxxx-xxxx-xxxx in foo@1.2.3: not reachable - the vulnerable code
 #   # path needs server-side rendering we never enable. Owner: ankit-yc.
-#   # Re-review by: 2026-12-01.
+#   # Re-review by: YYYY-MM-DD. (a real date here - the placeholder is
+#   # deliberate so this example never trips the expiry guard)
 #   - vulnerability: GHSA-xxxx-xxxx-xxxx
 #     package:
 #       name: foo

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -59,7 +59,9 @@ Gates fail closed; exceptions are explicit, reviewed, and expiring.
    an owner, and a `Re-review by: YYYY-MM-DD` date. Same discipline as
    `scripts/ci/override-advisory-baseline.json`. **Expiry is machine-enforced:
    the scan and license gates fail when any re-review date is in the past**,
-   so an exception cannot quietly outlive its justification.
+   so an exception cannot quietly outlive its justification - and they fail
+   just the same on any `ignore:` entry whose comment lacks a dated line, so
+   an undated vulnerability exception cannot escape enforcement either.
 2. **Licenses**: extend `allow:` in `.grant.yaml` only with the SPDX
    compatibility rationale in the PR, or add a package under
    `ignore-packages:` with a comment: the VERIFIED license (read the LICENSE
@@ -79,9 +81,11 @@ Gates fail closed; exceptions are explicit, reviewed, and expiring.
   automatically whenever `pnpm-lock.yaml`, the root `package.json`, or a
   mobile native lockfile (`android/app/gradle.lockfile`, `ios/Podfile.lock`)
   is newer than the cached copy, so a stale SBOM is never scanned silently.
-- The SBOM also catalogs the mobile native lockfiles (`android/
-app/gradle.lockfile` Maven deps, `ios/Podfile.lock` pods) - only build
-  output and vendored pods are excluded.
+- The SBOM also catalogs the Android native lockfile (`android/
+app/gradle.lockfile` Maven deps) - only build output and vendored pods are
+  excluded. The iOS `Podfile.lock` is NOT yet committed, so CocoaPods
+  dependencies are absent from the SBOM until #2129 lands (the staleness
+  check already watches its path).
 - Releases published by workflows authenticating with `GITHUB_TOKEN`
   (desktop-release, release-notes) do not emit a `release` event this
   workflow can observe. The user's tag push covers gating and SBOM artifacts

--- a/scripts/security/supply-chain.sh
+++ b/scripts/security/supply-chain.sh
@@ -147,9 +147,11 @@ sbom_is_stale() {
 check_exception_expiry() {
   local today expired
   today="$(date +%Y-%m-%d)"
+  # `|| true`: zero dated lines anywhere makes grep exit 1, which pipefail +
+  # set -e would otherwise turn into a silent scan death.
   expired="$(grep -hoE 'Re-review by: [0-9]{4}-[0-9]{2}-[0-9]{2}' \
     "${REPO_ROOT}/.grype.yaml" "${REPO_ROOT}/.grant.yaml" 2>/dev/null |
-    awk -v today="${today}" '{ if ($3 < today) print $3 }')"
+    awk -v today="${today}" '{ if ($3 < today) print $3 }')" || true
   if [ -n "${expired}" ]; then
     echo "EXPIRED security exceptions (re-review dates in the past): ${expired}" >&2
     echo "Re-review each entry in .grype.yaml / .grant.yaml and either fix the finding or renew the date with a fresh justification." >&2
@@ -162,10 +164,14 @@ check_exception_expiry() {
 # ignore-packages entry whose comment lacks a dated 'Re-review by:' line would
 # suppress findings forever, so it fails the gate here. Each comment block
 # dates the run of entries directly below it (families share one block).
-check_exception_dates() {
-  local undated
-  undated="$(awk '
-    /^ignore-packages:/ { insec = 1; next }
+# One parser for both exception files. Items in .grant.yaml's ignore-packages
+# are a flat list (any '- ' line is an entry); .grype.yaml's ignore entries are
+# nested maps, so only top-level '  - ' lines open an entry there - deeper
+# hyphens belong to the entry's own fields.
+_undated_exception_entries() {
+  local file="$1" section="$2" itemre="$3"
+  awk -v sec="^${section}:" -v itemre="${itemre}" '
+    $0 ~ sec { insec = 1; next }
     insec && /^[^[:space:]]/ { insec = 0 }
     !insec { next }
     /^[[:space:]]*#/ {
@@ -173,13 +179,26 @@ check_exception_dates() {
       if ($0 ~ /Re-review by: [0-9]{4}-[0-9]{2}-[0-9]{2}/) have = 1
       prev = "comment"; next
     }
-    /^[[:space:]]*-[[:space:]]/ {
-      if (!have) { pkg = $0; sub(/^[[:space:]]*-[[:space:]]*/, "", pkg); print pkg }
+    $0 ~ itemre {
+      if (!have) { entry = $0; sub(/^[[:space:]]*-[[:space:]]*/, "", entry); print entry }
       prev = "item"; next
     }
-  ' "${REPO_ROOT}/.grant.yaml" 2>/dev/null)"
-  if [ -n "${undated}" ]; then
-    echo "UNDATED security exceptions in .grant.yaml ignore-packages (no dated 'Re-review by: YYYY-MM-DD' comment): ${undated}" >&2
+  ' "${file}" 2>/dev/null
+}
+
+check_exception_dates() {
+  local undated_grant undated_grype failed=0
+  undated_grant="$(_undated_exception_entries "${REPO_ROOT}/.grant.yaml" 'ignore-packages' '^[[:space:]]*-[[:space:]]')" || true
+  undated_grype="$(_undated_exception_entries "${REPO_ROOT}/.grype.yaml" 'ignore' '^  -[[:space:]]')" || true
+  if [ -n "${undated_grant}" ]; then
+    echo "UNDATED security exceptions in .grant.yaml ignore-packages (no dated 'Re-review by: YYYY-MM-DD' comment): ${undated_grant}" >&2
+    failed=1
+  fi
+  if [ -n "${undated_grype}" ]; then
+    echo "UNDATED security exceptions in .grype.yaml ignore (no dated 'Re-review by: YYYY-MM-DD' comment): ${undated_grype}" >&2
+    failed=1
+  fi
+  if [ "${failed}" -ne 0 ]; then
     echo "Every exception must carry a machine-readable re-review date so expiry stays enforced - date the entry's comment block." >&2
     return 1
   fi
@@ -197,7 +216,9 @@ cmd_sbom() {
   # means the store is where the real package.json files live. The native
   # lockfiles (android gradle.lockfile, ios Podfile.lock) stay IN scope - they
   # carry the mobile app's Maven and CocoaPods dependencies - while build
-  # output and vendored pods are excluded.
+  # output and vendored pods are excluded. NOTE: the iOS Podfile.lock is not
+  # yet committed (#2129), so pods are absent from the SBOM until it lands;
+  # the staleness check already watches its path for that day.
   local excludes=(
     --exclude './**/.next/**'
     --exclude './**/dist/**'

--- a/scripts/security/supply-chain.sh
+++ b/scripts/security/supply-chain.sh
@@ -164,40 +164,56 @@ check_exception_expiry() {
 # ignore-packages entry whose comment lacks a dated 'Re-review by:' line would
 # suppress findings forever, so it fails the gate here. Each comment block
 # dates the run of entries directly below it (families share one block).
-# One parser for both exception files. Items in .grant.yaml's ignore-packages
-# are a flat list (any '- ' line is an entry); .grype.yaml's ignore entries are
-# nested maps, so only top-level '  - ' lines open an entry there - deeper
-# hyphens belong to the entry's own fields.
+# One parser for both exception files. Entries are the '- ' lines sharing the
+# section's item indent, learned from the FIRST hyphen line in the section, so
+# both the two-space and the equally-valid column-0 sequence layouts are
+# parsed; deeper hyphens are an entry's own nested fields. A non-empty
+# flow-style sequence ('ignore: [...]') cannot carry per-entry comments at
+# all, so it is rejected outright rather than silently under-parsed - the
+# guard must fail closed on layouts it cannot read.
 _undated_exception_entries() {
-  local file="$1" section="$2" itemre="$3"
-  awk -v sec="^${section}:" -v itemre="${itemre}" '
-    $0 ~ sec { insec = 1; next }
-    insec && /^[^[:space:]]/ { insec = 0 }
+  local file="$1" section="$2"
+  awk -v sec="^${section}:" '
+    !insec && $0 ~ sec {
+      insec = 1
+      rest = $0; sub(sec, "", rest); gsub(/[[:space:]]/, "", rest)
+      if (rest != "" && rest != "[]") { print "UNSUPPORTED_LAYOUT"; exit }
+      next
+    }
+    insec && /^[^[:space:]#-]/ { insec = 0 }
     !insec { next }
     /^[[:space:]]*#/ {
       if (prev == "item") have = 0
       if ($0 ~ /Re-review by: [0-9]{4}-[0-9]{2}-[0-9]{2}/) have = 1
       prev = "comment"; next
     }
-    $0 ~ itemre {
-      if (!have) { entry = $0; sub(/^[[:space:]]*-[[:space:]]*/, "", entry); print entry }
-      prev = "item"; next
+    /^[[:space:]]*$/ { next }
+    /^[[:space:]]*-([[:space:]]|$)/ {
+      ind = index($0, "-")
+      if (!itemind) itemind = ind
+      if (ind == itemind) {
+        if (!have) { entry = $0; sub(/^[[:space:]]*-[[:space:]]*/, "", entry); print entry }
+        prev = "item"
+      }
+      next
     }
   ' "${file}" 2>/dev/null
 }
 
 check_exception_dates() {
-  local undated_grant undated_grype failed=0
-  undated_grant="$(_undated_exception_entries "${REPO_ROOT}/.grant.yaml" 'ignore-packages' '^[[:space:]]*-[[:space:]]')" || true
-  undated_grype="$(_undated_exception_entries "${REPO_ROOT}/.grype.yaml" 'ignore' '^  -[[:space:]]')" || true
-  if [ -n "${undated_grant}" ]; then
-    echo "UNDATED security exceptions in .grant.yaml ignore-packages (no dated 'Re-review by: YYYY-MM-DD' comment): ${undated_grant}" >&2
-    failed=1
-  fi
-  if [ -n "${undated_grype}" ]; then
-    echo "UNDATED security exceptions in .grype.yaml ignore (no dated 'Re-review by: YYYY-MM-DD' comment): ${undated_grype}" >&2
-    failed=1
-  fi
+  local failed=0 file section label out
+  for label in "grant:.grant.yaml:ignore-packages" "grype:.grype.yaml:ignore"; do
+    file="${REPO_ROOT}/$(echo "${label}" | cut -d: -f2)"
+    section="$(echo "${label}" | cut -d: -f3)"
+    out="$(_undated_exception_entries "${file}" "${section}")" || true
+    if echo "${out}" | grep -q 'UNSUPPORTED_LAYOUT'; then
+      echo "UNSUPPORTED layout for '${section}:' in $(basename "${file}"): a non-empty flow-style sequence cannot carry the required per-entry comments - use the documented block layout." >&2
+      failed=1
+    elif [ -n "${out}" ]; then
+      echo "UNDATED security exceptions in $(basename "${file}") ${section} (no dated 'Re-review by: YYYY-MM-DD' comment): ${out}" >&2
+      failed=1
+    fi
+  done
   if [ "${failed}" -ne 0 ]; then
     echo "Every exception must carry a machine-readable re-review date so expiry stays enforced - date the entry's comment block." >&2
     return 1

--- a/scripts/security/supply-chain.test.mjs
+++ b/scripts/security/supply-chain.test.mjs
@@ -150,6 +150,60 @@ test('scan regenerates when the lockfile is newer than the SBOM', () => {
   assert.match(output, /node_modules missing/);
 });
 
+test('a grype ignore entry without a dated re-review line fails the scan', () => {
+  const root = fakeRoot();
+  writeFileSync(join(root, 'pnpm-lock.yaml'), "lockfileVersion: '6.0'\n");
+  writeFileSync(join(root, 'package.json'), '{}\n');
+  const sbomDir = join(root, 'security', 'sbom');
+  mkdirSync(sbomDir, { recursive: true });
+  writeFileSync(join(sbomDir, 'yosemite-crew.cdx.json'), '{}');
+  const past = new Date(Date.now() - 60_000);
+  utimesSync(join(root, 'pnpm-lock.yaml'), past, past);
+  utimesSync(join(root, 'package.json'), past, past);
+  writeFileSync(
+    join(root, '.grype.yaml'),
+    'ignore:\n' +
+      '  # Not reachable in our usage. Owner: ankit-yc.\n' +
+      '  - vulnerability: GHSA-xxxx-xxxx-xxxx\n' +
+      '    package:\n' +
+      '      name: foo\n'
+  );
+  writeFileSync(join(root, '.grant.yaml'), 'allow: []\n');
+
+  const { status, output } = run(['scan'], { SUPPLY_CHAIN_REPO_ROOT: root });
+  assert.notEqual(status, 0);
+  assert.match(output, /UNDATED security exceptions in \.grype\.yaml/);
+  assert.match(output, /GHSA-xxxx-xxxx-xxxx/);
+});
+
+test('the header example placeholder never trips the expiry or date guards', () => {
+  const root = fakeRoot();
+  writeFileSync(join(root, 'pnpm-lock.yaml'), "lockfileVersion: '6.0'\n");
+  writeFileSync(join(root, 'package.json'), '{}\n');
+  const sbomDir = join(root, 'security', 'sbom');
+  mkdirSync(sbomDir, { recursive: true });
+  writeFileSync(join(sbomDir, 'yosemite-crew.cdx.json'), '{}');
+  const past = new Date(Date.now() - 60_000);
+  utimesSync(join(root, 'pnpm-lock.yaml'), past, past);
+  utimesSync(join(root, 'package.json'), past, past);
+  // Mirrors the real .grype.yaml header: a commented example whose date is the
+  // YYYY-MM-DD placeholder. A literal date here once made every scan fail the
+  // day the sample "expired".
+  writeFileSync(
+    join(root, '.grype.yaml'),
+    '# Example:\n' +
+      '# ignore:\n' +
+      '#   # reason here. Owner: someone.\n' +
+      '#   # Re-review by: YYYY-MM-DD.\n' +
+      '#   - vulnerability: GHSA-xxxx-xxxx-xxxx\n' +
+      'ignore: []\n'
+  );
+  writeFileSync(join(root, '.grant.yaml'), 'allow: []\n');
+
+  const { status, output } = run(['scan'], { SUPPLY_CHAIN_REPO_ROOT: root });
+  assert.equal(status, 0, `scan should pass, got: ${output}`);
+});
+
 test('a tampered download is rejected by the pinned digest', () => {
   const root = fakeRoot({ syft: '1.50.0', grant: '0.6.8' }); // no grype -> install path
   // Stub curl that "downloads" attacker-controlled bytes.

--- a/scripts/security/supply-chain.test.mjs
+++ b/scripts/security/supply-chain.test.mjs
@@ -176,6 +176,47 @@ test('a grype ignore entry without a dated re-review line fails the scan', () =>
   assert.match(output, /GHSA-xxxx-xxxx-xxxx/);
 });
 
+test('an undated grype ignore in column-0 sequence layout still fails', () => {
+  const root = fakeRoot();
+  writeFileSync(join(root, 'pnpm-lock.yaml'), "lockfileVersion: '6.0'\n");
+  writeFileSync(join(root, 'package.json'), '{}\n');
+  const sbomDir = join(root, 'security', 'sbom');
+  mkdirSync(sbomDir, { recursive: true });
+  writeFileSync(join(sbomDir, 'yosemite-crew.cdx.json'), '{}');
+  const past = new Date(Date.now() - 60_000);
+  utimesSync(join(root, 'pnpm-lock.yaml'), past, past);
+  utimesSync(join(root, 'package.json'), past, past);
+  // Valid YAML: sequence items at the same indent as the key.
+  writeFileSync(
+    join(root, '.grype.yaml'),
+    'ignore:\n' + '- vulnerability: GHSA-col0-col0-col0\n' + '  package:\n' + '    name: foo\n'
+  );
+  writeFileSync(join(root, '.grant.yaml'), 'allow: []\n');
+
+  const { status, output } = run(['scan'], { SUPPLY_CHAIN_REPO_ROOT: root });
+  assert.notEqual(status, 0);
+  assert.match(output, /UNDATED security exceptions in \.grype\.yaml/);
+  assert.match(output, /GHSA-col0-col0-col0/);
+});
+
+test('a non-empty flow-style ignore sequence is rejected as unsupported', () => {
+  const root = fakeRoot();
+  writeFileSync(join(root, 'pnpm-lock.yaml'), "lockfileVersion: '6.0'\n");
+  writeFileSync(join(root, 'package.json'), '{}\n');
+  const sbomDir = join(root, 'security', 'sbom');
+  mkdirSync(sbomDir, { recursive: true });
+  writeFileSync(join(sbomDir, 'yosemite-crew.cdx.json'), '{}');
+  const past = new Date(Date.now() - 60_000);
+  utimesSync(join(root, 'pnpm-lock.yaml'), past, past);
+  utimesSync(join(root, 'package.json'), past, past);
+  writeFileSync(join(root, '.grype.yaml'), 'ignore: [{vulnerability: GHSA-flow-flow-flow}]\n');
+  writeFileSync(join(root, '.grant.yaml'), 'allow: []\n');
+
+  const { status, output } = run(['scan'], { SUPPLY_CHAIN_REPO_ROOT: root });
+  assert.notEqual(status, 0);
+  assert.match(output, /UNSUPPORTED layout for 'ignore:' in \.grype\.yaml/);
+});
+
 test('the header example placeholder never trips the expiry or date guards', () => {
   const root = fakeRoot();
   writeFileSync(join(root, 'pnpm-lock.yaml'), "lockfileVersion: '6.0'\n");


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] All existing tests and lints pass.

## What is the current behavior?

Three Codex findings on the promotion PR #2120, one a P1 time bomb: the expiry guard greps every dated line in the exception files, including the commented EXAMPLE in .grype.yaml's header - on 2026-12-02 every scan and license job would start failing with zero actual exceptions, and desktop publication now waits on that verdict. Also: grype ignore entries had no undated-entry guard (only grant's did), and the docs claimed the SBOM catalogs the iOS Podfile.lock when that file has never been committed.

## What is the new behavior?

- The .grype.yaml header example now uses a YYYY-MM-DD placeholder that can never match the expiry pattern, with a comment saying the placeholder is deliberate.
- The undated-exception guard is generalized to BOTH files: any .grype.yaml ignore entry (or .grant.yaml ignore-packages entry) whose comment block lacks a dated Re-review line fails the scan and license gates. Nested grype entry fields cannot be mistaken for entries (top-level items only).
- Latent bug found by the new regression test and fixed: with zero dated lines anywhere in either file, the expiry guard's grep exits 1 and pipefail plus set -e killed the scan silently - both guards now tolerate empty results explicitly.
- Docs and the script no longer overclaim iOS coverage: pods are absent from the SBOM until Podfile.lock is committed (#2129 - generating it needs full Xcode; a local attempt failed on the Command Line Tools-only toolchain). The staleness check keeps watching the path so committing it later needs no script change.
- Two new stub-based regression tests: an undated grype entry fails with the offending id named, and the header placeholder plus empty ignore list passes cleanly (9/9 script tests green).

Impact area: supply-chain tooling, its config and docs; no application code.

Validation: bash -n clean; node --test 9/9; the real .grant.yaml/.grype.yaml pass both guards.