### PR TITLE
fix(mobile): exchange Apple iOS identity token as oAuthTokens

### DIFF
--- a/apps/mobileAppYC/__tests__/features/auth/services/socialAuth.test.ts
+++ b/apps/mobileAppYC/__tests__/features/auth/services/socialAuth.test.ts
@@ -248,7 +248,7 @@ describe('socialAuth', () => {
     });
   });
 
-  it('signs in with Apple on iOS using the authorization code flow', async () => {
+  it('signs in with Apple on iOS by exchanging the identity token as oAuthTokens', async () => {
     RN.Platform.OS = 'ios';
     mockAppleAuth.performRequest.mockResolvedValueOnce({
       identityToken: 'apple-id-token',
@@ -263,6 +263,19 @@ describe('socialAuth', () => {
     const result = await signInWithSocialProvider('apple');
 
     expect(mockAppleAuth.performRequest).toHaveBeenCalled();
+    // The signinup body must use the oAuthTokens path. The authorization-code
+    // flow (redirectURIInfo) breaks native sign-in: SuperTokens forwards the
+    // empty redirect_uri to Apple's token endpoint and Apple rejects the code.
+    const signInUpCall = (global.fetch as jest.Mock).mock.calls.find(([url]) =>
+      String(url).includes('/signinup'),
+    );
+    expect(signInUpCall).toBeDefined();
+    const body = JSON.parse(signInUpCall![1].body);
+    expect(body).toEqual({
+      thirdPartyId: 'apple',
+      oAuthTokens: {id_token: 'apple-id-token'},
+    });
+    expect(body.redirectURIInfo).toBeUndefined();
     expect(result.tokens.idToken).toBe('st-access-token');
     expect(result.user.firstName).toBe('Ada');
     expect(result.user.lastName).toBe('Lovelace');

--- a/apps/mobileAppYC/src/features/auth/services/socialAuth.ts
+++ b/apps/mobileAppYC/src/features/auth/services/socialAuth.ts
@@ -139,7 +139,6 @@ const cacheAppleProfile = async (
 type NativeCredential = {
   accessToken?: string;
   idToken?: string;
-  authorizationCode?: string;
   email?: string | null;
   firstName?: string | null;
   lastName?: string | null;
@@ -286,7 +285,6 @@ const signInWithAppleIOS = async (): Promise<NativeCredential> => {
 
   return {
     idToken: appleAuthRequestResponse.identityToken,
-    authorizationCode: appleAuthRequestResponse.authorizationCode ?? undefined,
     firstName: appleAuthRequestResponse.fullName?.givenName ?? null,
     lastName: appleAuthRequestResponse.fullName?.familyName ?? null,
     email: appleAuthRequestResponse.email ?? null,
@@ -442,24 +440,13 @@ const buildSignInUpBody = (
   provider: SocialProvider,
   credential: NativeCredential,
 ): Record<string, unknown> => {
-  if (
-    provider === 'apple' &&
-    Platform.OS === 'ios' &&
-    credential.authorizationCode
-  ) {
-    // Apple requires the authorization-code flow on the backend.
-    return {
-      thirdPartyId: 'apple',
-      redirectURIInfo: {
-        redirectURIOnProviderDashboard: '',
-        redirectURIQueryParams: {
-          code: credential.authorizationCode,
-          id_token: credential.idToken,
-        },
-      },
-    };
-  }
-
+  // Apple iOS deliberately uses the same oAuthTokens path as every other
+  // provider. The authorization-code flow (redirectURIInfo) is wrong for a
+  // native app: SuperTokens forwards redirectURIOnProviderDashboard verbatim
+  // as redirect_uri to Apple's token endpoint, and a code minted by native
+  // Sign in with Apple has no redirect URI, so Apple rejects the exchange.
+  // The id_token alone is enough — the backend verifies it against Apple's
+  // JWKS with the app bundle id as the audience.
   const oAuthTokens: Record<string, string> = {};
   if (credential.accessToken) {
     oAuthTokens.access_token = credential.accessToken;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

Apple sign-in on iOS fails, while Google sign-in works. The two providers take different paths in `buildSignInUpBody` (`apps/mobileAppYC/src/features/auth/services/socialAuth.ts`): Apple iOS always has an `authorizationCode`, so it alone was routed through SuperTokens' authorization-code flow with `redirectURIInfo.redirectURIOnProviderDashboard: ''`.

Verified by executing `supertokens-node@24.0.2` (the exact version the backend resolves) with the network intercepted: the provider forwards that empty string verbatim as `redirect_uri` to Apple's token endpoint:

```json
{
  "client_id": "com.yosemitecrew.mobile",
  "redirect_uri": "",
  "code": "…",
  "grant_type": "authorization_code",
  "client_secret": "<es256-jwt>"
}
```

Apple's guidance for native codes is to omit `redirect_uri` entirely (the code was never bound to one), and RFC 6749 §4.1.3 requires an included value to match the authorization request. Beyond the `redirect_uri` problem, this path also bound every login to the 5-minute single-use authorization code and to the server-side client-secret JWT being valid with Apple. Any failure in that exchange kills the login with no retry.

## What is the new behavior?

Apple iOS sends the identity token through `oAuthTokens: { id_token }`, the same shape Google already uses and SuperTokens' documented flow for native mobile sign-in. Verified against the real provider: the backend resolves the user from the id_token alone via Apple's JWKS, enforcing the app bundle id as the token audience (a token minted for any other app is rejected), with zero calls to Apple's token endpoint.

First-login name/email still come from the native response fields and the existing Keychain cache. The now-unused `authorizationCode` plumbing is removed, and the test suite pins the exact `/signinup` wire format so the old shape cannot silently return.

Deployment note: requires `AUTH_APPLE_CLIENT_ID` in the backend environment to equal the app bundle id (`com.yosemitecrew.mobile`), with the other `AUTH_APPLE_*` vars present. The `apple` provider is confirmed present on the production `loginmethods` endpoint. This is a client-side fix, so it reaches devices with the next app build.

Validation: targeted Jest run 73/73 passing, `tsc --noEmit` clean, ESLint clean, `socialAuth.ts` at 100% statements/functions/lines and 98.9% branches.

## Related Issue(s)

Fixes #
