### PR TITLE
fix(ci): only run sonar scans on pull requests and pushes to main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,11 +67,21 @@ jobs:
     # Skip Sonar for them (the roll-up below counts a skipped stage as a pass);
     # the nightly sonar-cloud-analysis run remains the type-aware backstop and
     # every dependency change is re-scanned there once it lands on dev.
+    #
+    # Push events only analyze on main: the SonarCloud plan accepts analysis of
+    # each project's MAIN BRANCH only, so a push-to-dev scan can never publish
+    # anywhere and every leg fails with "Not authorized or project not found"
+    # at the quality-gate check. PR analysis carries the gate; the push-to-main
+    # scan and the nightly keep the dashboard current. (All four projects'
+    # SonarCloud main branches are named `main` - the Backend project's was
+    # named `dev` until 2026-08-11, which made its legs fail on main pushes and
+    # pass on dev pushes, the mirror image of the other three.)
     if: >
       vars.DISABLE_SONAR != 'true' &&
       needs.test.outputs.apps-with-coverage != '' &&
       needs.test.outputs.apps-with-coverage != '[]' &&
-      github.event.pull_request.user.login != 'dependabot[bot]'
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      (github.event_name != 'push' || github.ref == 'refs/heads/main')
     # A reusable workflow cannot request more than its caller grants, and
     # startup validation checks this even when the job is skipped, so the Sonar
     # scan's checks:write / pull-requests:write are granted on the call here

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,10 +68,12 @@ jobs:
     # the nightly sonar-cloud-analysis run remains the type-aware backstop and
     # every dependency change is re-scanned there once it lands on dev.
     #
-    # Push events only analyze on main: the SonarCloud plan accepts analysis of
-    # each project's MAIN BRANCH only, so a push-to-dev scan can never publish
-    # anywhere and every leg fails with "Not authorized or project not found"
-    # at the quality-gate check. PR analysis carries the gate; the push-to-main
+    # Sonar can only publish from a pull_request event (PR analysis) or from
+    # main (the SonarCloud plan accepts analysis of each project's MAIN BRANCH
+    # only). Any other ref - a dev push, a workflow_dispatch from dev, a merge
+    # queue's ephemeral ref - can never publish anywhere and every leg fails
+    # with "Not authorized or project not found" at the quality-gate check, so
+    # those runs skip the stage. PR analysis carries the gate; the push-to-main
     # scan and the nightly keep the dashboard current. (All four projects'
     # SonarCloud main branches are named `main` - the Backend project's was
     # named `dev` until 2026-08-11, which made its legs fail on main pushes and
@@ -81,7 +83,7 @@ jobs:
       needs.test.outputs.apps-with-coverage != '' &&
       needs.test.outputs.apps-with-coverage != '[]' &&
       github.event.pull_request.user.login != 'dependabot[bot]' &&
-      (github.event_name != 'push' || github.ref == 'refs/heads/main')
+      (github.event_name == 'pull_request' || github.ref == 'refs/heads/main')
     # A reusable workflow cannot request more than its caller grants, and
     # startup validation checks this even when the job is skipped, so the Sonar
     # scan's checks:write / pull-requests:write are granted on the call here


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] All existing tests and lints pass.

## What is the current behavior?

Two long-standing Sonar reds, finally root-caused as one config asymmetry: the Backend SonarCloud project's main branch was literally NAMED `dev` while the other three projects' is `main`. The plan only accepts analysis of each project's main branch, so:

- every push to main that included backend coverage failed `sonar / Sonar scan (backend)` with "Not authorized or project not found" at the quality-gate check (the promotion run last night, and every one before it), and
- every push to dev failed the frontend/desktop/mobile legs for the mirror-image reason - three reds and a failed CI Required after every single merge to dev.

## What is the new behavior?

- The SonarCloud side is already fixed (admin API, done 2026-08-11): the Backend project's empty placeholder `main` branch was deleted and its main branch renamed `dev` -> `main`, keeping the full analysis history. The failed backend leg on main's promotion run was rerun as proof.
- This PR aligns the CI side: the sonar stage now runs on pull requests and pushes to main only. A push-to-dev scan can never publish anywhere by plan, so it produced nothing but the standing red. PR analysis carries the quality gate, the push-to-main scan and the nightly sonar-cloud-analysis keep the dashboard current, and the CI Required roll-up already counts a skipped stage as a pass - so post-merge dev pushes go green.

Impact area: CI workflow condition only; no scans are lost that ever succeeded.

Validation: actionlint and yaml.safe_load clean on ci.yaml.