### PR TITLE
fix(repo): validate re-review dates as bounded calendar days and parse quoted keys

### DIFF
--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -61,7 +61,10 @@ Gates fail closed; exceptions are explicit, reviewed, and expiring.
    the scan and license gates fail when any re-review date is in the past**,
    so an exception cannot quietly outlive its justification - and they fail
    just the same on any `ignore:` entry whose comment lacks a dated line, so
-   an undated vulnerability exception cannot escape enforcement either.
+   an undated vulnerability exception cannot escape enforcement either. Dates
+   must be real calendar days no more than two years out: an impossible value
+   like 9999-99-99 or a decade-away date is rejected, and quoted spellings of
+   the section keys are parsed like unquoted ones.
 2. **Licenses**: extend `allow:` in `.grant.yaml` only with the SPDX
    compatibility rationale in the PR, or add a package under
    `ignore-packages:` with a comment: the VERIFIED license (read the LICENSE

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -65,8 +65,10 @@ Gates fail closed; exceptions are explicit, reviewed, and expiring.
    must be real calendar days no more than two years out: an impossible value
    like 9999-99-99 or a decade-away date is rejected. The guard enforces the
    exact canonical layout - `ignore:` / `ignore-packages:` at column 0,
-   unquoted - and fails on any other spelling of the section keys rather than
-   silently skipping a section it cannot parse.
+   unquoted, and PRESENT (write `ignore: []` when there are no exceptions) -
+   and fails on any other spelling of the section keys or on a document form
+   it cannot inspect (a root flow mapping, a deleted section) rather than
+   silently passing what it could not examine.
 2. **Licenses**: extend `allow:` in `.grant.yaml` only with the SPDX
    compatibility rationale in the PR, or add a package under
    `ignore-packages:` with a comment: the VERIFIED license (read the LICENSE

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -63,8 +63,10 @@ Gates fail closed; exceptions are explicit, reviewed, and expiring.
    just the same on any `ignore:` entry whose comment lacks a dated line, so
    an undated vulnerability exception cannot escape enforcement either. Dates
    must be real calendar days no more than two years out: an impossible value
-   like 9999-99-99 or a decade-away date is rejected, and quoted spellings of
-   the section keys are parsed like unquoted ones.
+   like 9999-99-99 or a decade-away date is rejected. The guard enforces the
+   exact canonical layout - `ignore:` / `ignore-packages:` at column 0,
+   unquoted - and fails on any other spelling of the section keys rather than
+   silently skipping a section it cannot parse.
 2. **Licenses**: extend `allow:` in `.grant.yaml` only with the SPDX
    compatibility rationale in the PR, or add a package under
    `ignore-packages:` with a comment: the VERIFIED license (read the LICENSE

--- a/scripts/security/supply-chain.sh
+++ b/scripts/security/supply-chain.sh
@@ -145,15 +145,41 @@ sbom_is_stale() {
 # dates. An expired exception fails the gate instead of quietly outliving its
 # justification.
 check_exception_expiry() {
-  local today expired
+  local today horizon dates invalid over_horizon expired
   today="$(date +%Y-%m-%d)"
+  # Two years is the outer bound for any re-review date: "expiring exceptions"
+  # means a bounded window, and the cap also rejects never-reachable far-future
+  # dates. GNU date first (CI), BSD date fallback (macOS).
+  horizon="$(date -d '+2 years' +%Y-%m-%d 2>/dev/null || date -v+2y +%Y-%m-%d)"
   # `|| true`: zero dated lines anywhere makes grep exit 1, which pipefail +
   # set -e would otherwise turn into a silent scan death.
-  expired="$(grep -hoE 'Re-review by: [0-9]{4}-[0-9]{2}-[0-9]{2}' \
+  dates="$(grep -hoE 'Re-review by: [0-9]{4}-[0-9]{2}-[0-9]{2}' \
     "${REPO_ROOT}/.grype.yaml" "${REPO_ROOT}/.grant.yaml" 2>/dev/null |
-    awk -v today="${today}" '{ if ($3 < today) print $3 }')" || true
+    awk '{ print $3 }')" || true
+  # Digit shape alone is not a date: 9999-99-99 matches the pattern, compares
+  # lexically as forever-in-the-future, and would never expire. Reject anything
+  # that is not a real calendar day (leap years included).
+  invalid="$(awk '
+    NF == 0 { next }
+    {
+      split($0, p, "-"); y = p[1] + 0; m = p[2] + 0; d = p[3] + 0
+      split("31 28 31 30 31 30 31 31 30 31 30 31", dim, " ")
+      leap = (y % 4 == 0 && (y % 100 != 0 || y % 400 == 0))
+      maxd = (m >= 1 && m <= 12) ? dim[m] + ((m == 2 && leap) ? 1 : 0) : 0
+      if (m < 1 || m > 12 || d < 1 || d > maxd) print $0
+    }' <<<"${dates}")"
+  over_horizon="$(awk -v h="${horizon}" 'NF > 0 && $0 > h { print }' <<<"${dates}")"
+  expired="$(awk -v t="${today}" 'NF > 0 && $0 < t { print }' <<<"${dates}")"
+  if [ -n "${invalid}" ]; then
+    echo "INVALID re-review dates (not real calendar days): ${invalid}" >&2
+  fi
+  if [ -n "${over_horizon}" ]; then
+    echo "OVER-HORIZON re-review dates (more than 2 years out, max ${horizon}): ${over_horizon}" >&2
+  fi
   if [ -n "${expired}" ]; then
     echo "EXPIRED security exceptions (re-review dates in the past): ${expired}" >&2
+  fi
+  if [ -n "${invalid}${over_horizon}${expired}" ]; then
     echo "Re-review each entry in .grype.yaml / .grant.yaml and either fix the finding or renew the date with a fresh justification." >&2
     return 1
   fi
@@ -173,7 +199,11 @@ check_exception_expiry() {
 # guard must fail closed on layouts it cannot read.
 _undated_exception_entries() {
   local file="$1" section="$2"
-  awk -v sec="^${section}:" '
+  # The key regex accepts optional single or double quotes: "ignore": is the
+  # same setting to a YAML parser, so it must be the same section to us -
+  # otherwise a quoted spelling would skip the guard entirely.
+  awk -v section="${section}" '
+    BEGIN { sec = "^[\"'\'']?" section "[\"'\'']?:" }
     !insec && $0 ~ sec {
       insec = 1
       rest = $0; sub(sec, "", rest); gsub(/[[:space:]]/, "", rest)

--- a/scripts/security/supply-chain.sh
+++ b/scripts/security/supply-chain.sh
@@ -210,6 +210,14 @@ _assert_canonical_section() {
     echo "NON-CANONICAL spelling of '${section}:' in $(basename "${file}") (${variants}) - the exception guard only inspects the documented layout; spell the key exactly '${section}:' at column 0." >&2
     return 1
   fi
+  # Presence is REQUIRED: a document that hides the section from line-level
+  # inspection (a root flow mapping, an exotic key form, or simply deleting
+  # the section) must fail rather than sail through unexaminable. Keep an
+  # empty '${section}: []' line when there are no exceptions.
+  if ! grep -qE "^${section}:" "${file}" 2>/dev/null; then
+    echo "MISSING canonical '${section}:' section in $(basename "${file}") - the guard requires it present at column 0 (use '${section}: []' when empty); a layout it cannot inspect fails closed." >&2
+    return 1
+  fi
   return 0
 }
 

--- a/scripts/security/supply-chain.sh
+++ b/scripts/security/supply-chain.sh
@@ -197,13 +197,26 @@ check_exception_expiry() {
 # flow-style sequence ('ignore: [...]') cannot carry per-entry comments at
 # all, so it is rejected outright rather than silently under-parsed - the
 # guard must fail closed on layouts it cannot read.
+# The guard is a layout gate, not a YAML parser, so it cannot chase every
+# valid-YAML spelling of the same key (quotes, whitespace before the colon,
+# explicit-key form, ...). Instead it enforces the one canonical spelling and
+# REJECTS any other recognizable spelling of the section key outright - a
+# respelled section fails the gate instead of becoming invisible to it.
+_assert_canonical_section() {
+  local file="$1" section="$2" variants
+  variants="$(grep -nE "^[[:space:]]*\\??[[:space:]]*[\"']?${section}[\"']?[[:space:]]*(:|\$)" "${file}" 2>/dev/null |
+    grep -vE "^[0-9]+:${section}:")" || true
+  if [ -n "${variants}" ]; then
+    echo "NON-CANONICAL spelling of '${section}:' in $(basename "${file}") (${variants}) - the exception guard only inspects the documented layout; spell the key exactly '${section}:' at column 0." >&2
+    return 1
+  fi
+  return 0
+}
+
 _undated_exception_entries() {
   local file="$1" section="$2"
-  # The key regex accepts optional single or double quotes: "ignore": is the
-  # same setting to a YAML parser, so it must be the same section to us -
-  # otherwise a quoted spelling would skip the guard entirely.
   awk -v section="${section}" '
-    BEGIN { sec = "^[\"'\'']?" section "[\"'\'']?:" }
+    BEGIN { sec = "^" section ":" }
     !insec && $0 ~ sec {
       insec = 1
       rest = $0; sub(sec, "", rest); gsub(/[[:space:]]/, "", rest)
@@ -235,6 +248,10 @@ check_exception_dates() {
   for label in "grant:.grant.yaml:ignore-packages" "grype:.grype.yaml:ignore"; do
     file="${REPO_ROOT}/$(echo "${label}" | cut -d: -f2)"
     section="$(echo "${label}" | cut -d: -f3)"
+    if ! _assert_canonical_section "${file}" "${section}"; then
+      failed=1
+      continue
+    fi
     out="$(_undated_exception_entries "${file}" "${section}")" || true
     if echo "${out}" | grep -q 'UNSUPPORTED_LAYOUT'; then
       echo "UNSUPPORTED layout for '${section}:' in $(basename "${file}"): a non-empty flow-style sequence cannot carry the required per-entry comments - use the documented block layout." >&2

--- a/scripts/security/supply-chain.test.mjs
+++ b/scripts/security/supply-chain.test.mjs
@@ -98,7 +98,7 @@ test('scan fails when an ignore-packages entry lacks a dated re-review line', ()
     [
       'allow: []',
       'ignore-packages:',
-      '  # Dated entry, fine. Re-review by: 2999-01-01.',
+      '  # Dated entry, fine. Re-review by: 2027-01-01.',
       '  - compliant-pkg',
       '  # Re-review: on version bump.',
       '  - missing-date-pkg',
@@ -243,6 +243,64 @@ test('the header example placeholder never trips the expiry or date guards', () 
 
   const { status, output } = run(['scan'], { SUPPLY_CHAIN_REPO_ROOT: root });
   assert.equal(status, 0, `scan should pass, got: ${output}`);
+});
+
+const scanRootWithConfigs = (grypeYaml, grantYaml) => {
+  const root = fakeRoot();
+  writeFileSync(join(root, 'pnpm-lock.yaml'), "lockfileVersion: '6.0'\n");
+  writeFileSync(join(root, 'package.json'), '{}\n');
+  const sbomDir = join(root, 'security', 'sbom');
+  mkdirSync(sbomDir, { recursive: true });
+  writeFileSync(join(sbomDir, 'yosemite-crew.cdx.json'), '{}');
+  const past = new Date(Date.now() - 60_000);
+  utimesSync(join(root, 'pnpm-lock.yaml'), past, past);
+  utimesSync(join(root, 'package.json'), past, past);
+  writeFileSync(join(root, '.grype.yaml'), grypeYaml);
+  writeFileSync(join(root, '.grant.yaml'), grantYaml);
+  return root;
+};
+
+test('a quoted "ignore": key cannot bypass the undated-entry guard', () => {
+  const root = scanRootWithConfigs(
+    '"ignore":\n' +
+      '  # No date here. Owner: someone.\n' +
+      '  - vulnerability: GHSA-quot-quot-quot\n' +
+      '    package:\n' +
+      '      name: foo\n',
+    'allow: []\n'
+  );
+  const { status, output } = run(['scan'], { SUPPLY_CHAIN_REPO_ROOT: root });
+  assert.notEqual(status, 0);
+  assert.match(output, /UNDATED security exceptions in \.grype\.yaml/);
+  assert.match(output, /GHSA-quot-quot-quot/);
+});
+
+test('an impossible calendar date is rejected, not treated as forever-future', () => {
+  const root = scanRootWithConfigs(
+    'ignore:\n' +
+      '  # Looks dated but 9999-99-99 is not a day that exists. Owner: x.\n' +
+      '  # Re-review by: 9999-99-99.\n' +
+      '  - vulnerability: GHSA-nope-nope-nope\n',
+    'allow: []\n'
+  );
+  const { status, output } = run(['scan'], { SUPPLY_CHAIN_REPO_ROOT: root });
+  assert.notEqual(status, 0);
+  assert.match(output, /INVALID re-review dates/);
+  assert.match(output, /9999-99-99/);
+});
+
+test('a valid date more than two years out fails the horizon bound', () => {
+  const farOut = new Date(Date.now() + 3 * 365 * 24 * 3600 * 1000).toISOString().slice(0, 10);
+  const root = scanRootWithConfigs(
+    'ignore:\n' +
+      `  # Bounded window dodge. Owner: x. Re-review by: ${farOut}.\n` +
+      '  - vulnerability: GHSA-farr-farr-farr\n',
+    'allow: []\n'
+  );
+  const { status, output } = run(['scan'], { SUPPLY_CHAIN_REPO_ROOT: root });
+  assert.notEqual(status, 0);
+  assert.match(output, /OVER-HORIZON re-review dates/);
+  assert.match(output, new RegExp(farOut));
 });
 
 test('a tampered download is rejected by the pinned digest', () => {

--- a/scripts/security/supply-chain.test.mjs
+++ b/scripts/security/supply-chain.test.mjs
@@ -260,7 +260,7 @@ const scanRootWithConfigs = (grypeYaml, grantYaml) => {
   return root;
 };
 
-test('a quoted "ignore": key cannot bypass the undated-entry guard', () => {
+test('a quoted "ignore": key is rejected as non-canonical, not silently skipped', () => {
   const root = scanRootWithConfigs(
     '"ignore":\n' +
       '  # No date here. Owner: someone.\n' +
@@ -271,8 +271,27 @@ test('a quoted "ignore": key cannot bypass the undated-entry guard', () => {
   );
   const { status, output } = run(['scan'], { SUPPLY_CHAIN_REPO_ROOT: root });
   assert.notEqual(status, 0);
-  assert.match(output, /UNDATED security exceptions in \.grype\.yaml/);
-  assert.match(output, /GHSA-quot-quot-quot/);
+  assert.match(output, /NON-CANONICAL spelling of 'ignore:' in \.grype\.yaml/);
+});
+
+test('whitespace before the colon is rejected as non-canonical', () => {
+  const root = scanRootWithConfigs(
+    '"ignore" :\n' + '  # No date. Owner: someone.\n' + '  - vulnerability: GHSA-sp-sp-sp\n',
+    'allow: []\n'
+  );
+  const { status, output } = run(['scan'], { SUPPLY_CHAIN_REPO_ROOT: root });
+  assert.notEqual(status, 0);
+  assert.match(output, /NON-CANONICAL spelling of 'ignore:' in \.grype\.yaml/);
+});
+
+test('the explicit-key YAML form is rejected as non-canonical', () => {
+  const root = scanRootWithConfigs(
+    '? ignore\n' + ':\n' + '  - vulnerability: GHSA-exp-exp-exp\n',
+    'allow: []\n'
+  );
+  const { status, output } = run(['scan'], { SUPPLY_CHAIN_REPO_ROOT: root });
+  assert.notEqual(status, 0);
+  assert.match(output, /NON-CANONICAL spelling of 'ignore:' in \.grype\.yaml/);
 });
 
 test('an impossible calendar date is rejected, not treated as forever-future', () => {

--- a/scripts/security/supply-chain.test.mjs
+++ b/scripts/security/supply-chain.test.mjs
@@ -72,7 +72,7 @@ test("scan fails when an exception's re-review date has expired", () => {
   utimesSync(join(root, 'pnpm-lock.yaml'), past, past);
   utimesSync(join(root, 'package.json'), past, past);
   writeFileSync(join(root, '.grype.yaml'), '# Re-review by: 2020-01-01\nignore: []\n');
-  writeFileSync(join(root, '.grant.yaml'), 'allow: []\n');
+  writeFileSync(join(root, '.grant.yaml'), 'allow: []\nignore-packages: []\n');
 
   const { status, output } = run(['scan'], { SUPPLY_CHAIN_REPO_ROOT: root });
   assert.notEqual(status, 0);
@@ -168,7 +168,7 @@ test('a grype ignore entry without a dated re-review line fails the scan', () =>
       '    package:\n' +
       '      name: foo\n'
   );
-  writeFileSync(join(root, '.grant.yaml'), 'allow: []\n');
+  writeFileSync(join(root, '.grant.yaml'), 'allow: []\nignore-packages: []\n');
 
   const { status, output } = run(['scan'], { SUPPLY_CHAIN_REPO_ROOT: root });
   assert.notEqual(status, 0);
@@ -191,7 +191,7 @@ test('an undated grype ignore in column-0 sequence layout still fails', () => {
     join(root, '.grype.yaml'),
     'ignore:\n' + '- vulnerability: GHSA-col0-col0-col0\n' + '  package:\n' + '    name: foo\n'
   );
-  writeFileSync(join(root, '.grant.yaml'), 'allow: []\n');
+  writeFileSync(join(root, '.grant.yaml'), 'allow: []\nignore-packages: []\n');
 
   const { status, output } = run(['scan'], { SUPPLY_CHAIN_REPO_ROOT: root });
   assert.notEqual(status, 0);
@@ -210,7 +210,7 @@ test('a non-empty flow-style ignore sequence is rejected as unsupported', () => 
   utimesSync(join(root, 'pnpm-lock.yaml'), past, past);
   utimesSync(join(root, 'package.json'), past, past);
   writeFileSync(join(root, '.grype.yaml'), 'ignore: [{vulnerability: GHSA-flow-flow-flow}]\n');
-  writeFileSync(join(root, '.grant.yaml'), 'allow: []\n');
+  writeFileSync(join(root, '.grant.yaml'), 'allow: []\nignore-packages: []\n');
 
   const { status, output } = run(['scan'], { SUPPLY_CHAIN_REPO_ROOT: root });
   assert.notEqual(status, 0);
@@ -239,7 +239,7 @@ test('the header example placeholder never trips the expiry or date guards', () 
       '#   - vulnerability: GHSA-xxxx-xxxx-xxxx\n' +
       'ignore: []\n'
   );
-  writeFileSync(join(root, '.grant.yaml'), 'allow: []\n');
+  writeFileSync(join(root, '.grant.yaml'), 'allow: []\nignore-packages: []\n');
 
   const { status, output } = run(['scan'], { SUPPLY_CHAIN_REPO_ROOT: root });
   assert.equal(status, 0, `scan should pass, got: ${output}`);
@@ -267,7 +267,7 @@ test('a quoted "ignore": key is rejected as non-canonical, not silently skipped'
       '  - vulnerability: GHSA-quot-quot-quot\n' +
       '    package:\n' +
       '      name: foo\n',
-    'allow: []\n'
+    'allow: []\nignore-packages: []\n'
   );
   const { status, output } = run(['scan'], { SUPPLY_CHAIN_REPO_ROOT: root });
   assert.notEqual(status, 0);
@@ -277,7 +277,7 @@ test('a quoted "ignore": key is rejected as non-canonical, not silently skipped'
 test('whitespace before the colon is rejected as non-canonical', () => {
   const root = scanRootWithConfigs(
     '"ignore" :\n' + '  # No date. Owner: someone.\n' + '  - vulnerability: GHSA-sp-sp-sp\n',
-    'allow: []\n'
+    'allow: []\nignore-packages: []\n'
   );
   const { status, output } = run(['scan'], { SUPPLY_CHAIN_REPO_ROOT: root });
   assert.notEqual(status, 0);
@@ -287,7 +287,7 @@ test('whitespace before the colon is rejected as non-canonical', () => {
 test('the explicit-key YAML form is rejected as non-canonical', () => {
   const root = scanRootWithConfigs(
     '? ignore\n' + ':\n' + '  - vulnerability: GHSA-exp-exp-exp\n',
-    'allow: []\n'
+    'allow: []\nignore-packages: []\n'
   );
   const { status, output } = run(['scan'], { SUPPLY_CHAIN_REPO_ROOT: root });
   assert.notEqual(status, 0);
@@ -300,7 +300,7 @@ test('an impossible calendar date is rejected, not treated as forever-future', (
       '  # Looks dated but 9999-99-99 is not a day that exists. Owner: x.\n' +
       '  # Re-review by: 9999-99-99.\n' +
       '  - vulnerability: GHSA-nope-nope-nope\n',
-    'allow: []\n'
+    'allow: []\nignore-packages: []\n'
   );
   const { status, output } = run(['scan'], { SUPPLY_CHAIN_REPO_ROOT: root });
   assert.notEqual(status, 0);
@@ -314,12 +314,29 @@ test('a valid date more than two years out fails the horizon bound', () => {
     'ignore:\n' +
       `  # Bounded window dodge. Owner: x. Re-review by: ${farOut}.\n` +
       '  - vulnerability: GHSA-farr-farr-farr\n',
-    'allow: []\n'
+    'allow: []\nignore-packages: []\n'
   );
   const { status, output } = run(['scan'], { SUPPLY_CHAIN_REPO_ROOT: root });
   assert.notEqual(status, 0);
   assert.match(output, /OVER-HORIZON re-review dates/);
   assert.match(output, new RegExp(farOut));
+});
+
+test('a root flow-mapping document cannot hide the ignore section', () => {
+  const root = scanRootWithConfigs(
+    '{ignore: [{vulnerability: GHSA-hide-hide-hide}]}\n',
+    'allow: []\nignore-packages: []\n'
+  );
+  const { status, output } = run(['scan'], { SUPPLY_CHAIN_REPO_ROOT: root });
+  assert.notEqual(status, 0);
+  assert.match(output, /MISSING canonical 'ignore:' section in \.grype\.yaml/);
+});
+
+test('deleting the section entirely fails rather than passing unexamined', () => {
+  const root = scanRootWithConfigs('# nothing to see\n', 'allow: []\nignore-packages: []\n');
+  const { status, output } = run(['scan'], { SUPPLY_CHAIN_REPO_ROOT: root });
+  assert.notEqual(status, 0);
+  assert.match(output, /MISSING canonical 'ignore:' section in \.grype\.yaml/);
 });
 
 test('a tampered download is rejected by the pinned digest', () => {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] All existing tests and lints pass.

## What is the current behavior?

Codex P1s on the exception guard (filed on #2130 post-merge and on this PR), all real bypasses: a quoted "ignore": key or one with whitespace before the colon is the same setting to a YAML parser but invisible to the guard's anchored regex, and a digit-shaped but impossible date (9999-99-99) compares lexically as forever-in-the-future so it never expires.

## What is the new behavior?

- The guard is now explicitly a LAYOUT GATE: it enforces the one canonical spelling (`ignore:` / `ignore-packages:` at column 0) and REJECTS any other recognizable spelling of the section key - quoted forms, whitespace before the colon, the explicit-key form - with a NON-CANONICAL error naming the offending line. A respelled section fails the gate instead of becoming invisible to it, which closes the whole class instead of the latest spelling.
- Extracted re-review dates are validated as REAL calendar days (month/day bounds, leap years) - impossible values fail with an INVALID message.
- New policy bound closing the remaining hole (a valid-but-absurd 9999-01-01 would also never expire): re-review dates more than two years out fail with an OVER-HORIZON message. All current entries sit well inside the window.
- docs/security/supply-chain.md documents the rules.

Impact area: supply-chain gate script, its tests and docs; no application code.

Validation: bash -n clean; node --test 16/16 (six new regression tests across the two rounds); the real .grype.yaml/.grant.yaml pass every guard.