### PR TITLE
docs(ci): state the real merge-queue sonar contract

### DIFF
--- a/.github/workflows/_sonar.yaml
+++ b/.github/workflows/_sonar.yaml
@@ -120,9 +120,10 @@ jobs:
         with:
           projectBaseDir: ${{ matrix.dir }}
           # Wait for the gate so a red quality gate reds this job, and therefore
-          # the aggregate required check, on merge_group as well as on a PR.
-          # SonarCloud decorates pull requests but posts no status on a merge
-          # group ref, so without this the queue would have no Sonar signal.
+          # the PR run's aggregate required check. That PR-run verdict is the
+          # only Sonar signal a merge queue gets: the caller skips this stage on
+          # merge_group refs (the SonarCloud plan analyzes each project's main
+          # branch only, so a queue's ephemeral ref can never publish).
           args: -Dsonar.qualitygate.wait=true
         env:
           SONAR_TOKEN: ${{ (matrix.app_key == 'frontend' && secrets.SONAR_TOKEN_FRONTEND) || (matrix.app_key == 'backend' && secrets.SONAR_TOKEN_API) || (matrix.app_key == 'mobile' && secrets.SONAR_TOKEN_MOBILE) || (matrix.app_key == 'desktop' && secrets.SONAR_TOKEN_DESKTOP) || '' }}

--- a/docs/ci/required-checks-migration.md
+++ b/docs/ci/required-checks-migration.md
@@ -57,7 +57,13 @@ Two steps remain, both needing a green `merge_group` run first:
    itself SKIPS sonar deliberately, because the SonarCloud plan only analyzes
    each project's main branch and a queue's ephemeral ref can never publish -
    the same reason dev pushes skip it. A queue run therefore re-verifies build
-   and tests, not Sonar; the gate was already enforced at the PR head.
+   and tests, not Sonar; for most PRs the gate was already enforced at the PR
+   head. Three PR classes skip the PR-run scan and enter the queue with NO
+   Sonar verdict - Dependabot PRs (their secret store has no Sonar tokens),
+   fork PRs (same reason), and everything while the `DISABLE_SONAR` kill
+   switch is set - so their Sonar signal arrives only after merge, from the
+   push-to-main scan and the nightly. Weigh that residual gap before removing
+   `code_quality` from the required set.
 
 `strict_required_status_checks_policy` stays `false` deliberately: setting it
 forces every PR to rebase serially, which is the problem the queue solves.

--- a/docs/ci/required-checks-migration.md
+++ b/docs/ci/required-checks-migration.md
@@ -51,8 +51,13 @@ Two steps remain, both needing a green `merge_group` run first:
    a `code_quality` status posts on a `merge_group` ref. It is not expected to -
    SonarCloud decorates pull requests, not merge groups. If it does not, remove
    `code_quality` from dev's required set before enabling the queue, keeping it
-   as PR decoration; `CI Required` carries the Sonar signal because `_sonar` runs
-   `-Dsonar.qualitygate.wait=true`.
+   as PR decoration. The Sonar signal for queued changes is the PR run's sonar
+   stage (which runs `-Dsonar.qualitygate.wait=true`, so a red gate reds the
+   PR's `CI Required` before the PR can enter the queue): the `merge_group` run
+   itself SKIPS sonar deliberately, because the SonarCloud plan only analyzes
+   each project's main branch and a queue's ephemeral ref can never publish -
+   the same reason dev pushes skip it. A queue run therefore re-verifies build
+   and tests, not Sonar; the gate was already enforced at the PR head.
 
 `strict_required_status_checks_policy` stays `false` deliberately: setting it
 forces every PR to rebase serially, which is the problem the queue solves.


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] All existing tests and lints pass.

## What is the current behavior?

Codex P2 on the promotion #2136: after #2134, merge_group runs skip the sonar stage, but docs/ci/required-checks-migration.md still tells administrators that CI Required carries the Sonar signal inside the queue, and a _sonar.yaml comment promises the aggregate checks the merge-group ref. The old promise could never have held anyway - the SonarCloud plan analyzes each project's main branch only, so a queue's ephemeral ref is as unpublishable as the dev pushes that failed for months.

## What is the new behavior?

Both places now state the real contract: the Sonar signal for queued changes is the PR run's sonar stage (qualitygate.wait reds the PR's CI Required before it can enter the queue); the merge_group run deliberately re-verifies build and tests, not Sonar, because the gate was already enforced at the PR head.

Impact area: documentation and a workflow comment only; zero behavior change.

Validation: actionlint clean on _sonar.yaml.