### PR TITLE
fix(frontend): remove departed team members from about page

### DIFF
--- a/apps/frontend/src/app/__tests__/components/TeamSlide.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/TeamSlide.test.tsx
@@ -19,7 +19,7 @@ describe('TeamSlide Component', () => {
   it('should render all team member images with correct alt text', () => {
     render(<TeamSlide />);
 
-    const teamMembers = ['Ankit', 'Anna', 'Harshit', 'Harshvardhan', 'Sneha'];
+    const teamMembers = ['Ankit', 'Anna', 'Harshit', 'Harshvardhan'];
 
     for (const name of teamMembers) {
       const image = screen.getByAltText(name);
@@ -30,10 +30,13 @@ describe('TeamSlide Component', () => {
   it('should have the correct image sources', () => {
     render(<TeamSlide />);
 
-    const snehaImage = screen.getByAltText('Sneha');
-    expect(snehaImage).toHaveAttribute('src', MEDIA_SOURCES.team.sneha);
+    const harshvardhanImage = screen.getByAltText('Harshvardhan');
+    expect(harshvardhanImage).toHaveAttribute('src', MEDIA_SOURCES.team.harshvardhan);
 
     const ankitImage = screen.getByAltText('Ankit');
     expect(ankitImage).toHaveAttribute('src', MEDIA_SOURCES.team.ankit);
+
+    // Departed members no longer appear on the slider.
+    expect(screen.queryByAltText('Sneha')).not.toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/app/__tests__/pages/About.marketing.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/About.marketing.test.tsx
@@ -145,15 +145,15 @@ describe('About (marketing)', () => {
         name: /Harshvardhan Parmar, Contributor, on LinkedIn/i,
       })
     ).toHaveAttribute('href', 'https://www.linkedin.com/in/harshvardhan-parmar/');
-    expect(screen.getByRole('link', { name: /Sneha, Contributor, on LinkedIn/i })).toHaveAttribute(
-      'href',
-      'https://www.linkedin.com/in/snehadevc/'
-    );
+    // Departed members are no longer listed in the core team.
     expect(
-      screen.getByRole('link', {
+      screen.queryByRole('link', { name: /Sneha, Contributor, on LinkedIn/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', {
         name: /Vallirani Ravulapati, Contributor, on LinkedIn/i,
       })
-    ).toHaveAttribute('href', 'https://www.linkedin.com/in/vallirani-ravulapati/');
+    ).not.toBeInTheDocument();
     expect(
       container.querySelector(
         'img[src="https://d2il6osz49gpup.cloudfront.net/aboutus-page/Ankit_profile.png"]'

--- a/apps/frontend/src/app/constants/mediaSources.ts
+++ b/apps/frontend/src/app/constants/mediaSources.ts
@@ -59,7 +59,6 @@ export const MEDIA_SOURCES = {
     harshit: ycCdn('aboutus-page/harshit.png'),
     anna: ycCdn('aboutus-page/anna.png'),
     harshvardhan: ycCdn('aboutus-page/harshvardhan.png'),
-    sneha: ycCdn('aboutus-page/sneha.png'),
   },
   aboutUs: {
     storyImage: ycCdn('aboutus-page/aboutnew.png'),

--- a/apps/frontend/src/app/features/marketing/pages/About/About.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/About/About.tsx
@@ -701,20 +701,6 @@ const CORE_TEAM: CrewMember[] = [
     slotId: 'crew-harshvardhan',
     delay: 80,
   },
-  {
-    name: 'Sneha',
-    role: 'Contributor',
-    href: 'https://www.linkedin.com/in/snehadevc/',
-    slotId: 'crew-sneha',
-    delay: 160,
-  },
-  {
-    name: 'Vallirani Ravulapati',
-    role: 'Contributor',
-    href: 'https://www.linkedin.com/in/vallirani-ravulapati/',
-    slotId: 'crew-vallirani',
-    delay: 240,
-  },
 ];
 
 function ProfileCard({

--- a/apps/frontend/src/app/ui/widgets/TeamSlide/TeamSlide.tsx
+++ b/apps/frontend/src/app/ui/widgets/TeamSlide/TeamSlide.tsx
@@ -26,11 +26,6 @@ const teamImages = [
     alt: 'Harshvardhan',
     linkedin: 'https://www.linkedin.com/in/harshvardhan-parmar/',
   },
-  {
-    src: MEDIA_SOURCES.team.sneha,
-    alt: 'Sneha',
-    linkedin: 'https://www.linkedin.com/in/snehadevc/',
-  },
 ];
 
 const TeamSlide = () => {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The About page core-team section lists Sneha and Vallirani Ravulapati, and the team slider (`TeamSlide`) shows Sneha — both have left the team.

## What is the new behavior?

- Sneha and Vallirani removed from the About page `CORE_TEAM` cards (`About.tsx`).
- Sneha removed from the team slider (`TeamSlide.tsx`).
- The now-unused `team.sneha` CDN entry removed from `mediaSources.ts`.
- Tests updated: the mirror suites now assert the departed members no longer render, so a stale entry cannot quietly return.

Impact area: marketing About page and the team slider only; no behavior change elsewhere.

Validation: targeted Jest run (`About.marketing`, `TeamSlide`) 9/9 passing with 100% statement/line coverage on all three touched source files; `npx tsc --noEmit` clean; `pnpm --filter frontend run lint` clean.

## Related Issue(s)

Fixes #