### PR TITLE
feat(ci): warn before a public TLS certificate expires

### DIFF
--- a/.github/workflows/_core.yaml
+++ b/.github/workflows/_core.yaml
@@ -77,6 +77,13 @@ jobs:
           FORCE_PUSH_BASE: ${{ inputs.force_push_base }}
         run: ./scripts/ci/compute-base-sha.sh >> "$GITHUB_OUTPUT"
 
+      # The repository root is deliberately absent from the workspace inventory,
+      # so nothing in the workspace matrix ever runs scripts/ci or
+      # scripts/security tests. They gate CI behaviour and the supply-chain
+      # exception policy, so they run here, in the one job every event reaches.
+      - name: Test the CI and security scripts
+        run: pnpm run test:scripts
+
       - name: Resolve workspace inventory
         run: pnpm ls -r --depth -1 --json > workspaces.json
 

--- a/.github/workflows/tls-expiry.yml
+++ b/.github/workflows/tls-expiry.yml
@@ -1,0 +1,110 @@
+name: TLS Expiry
+
+# dev.yosemitecrew.com served an expired certificate to every visitor on
+# 2026-08-13: the Amplify/ACM renewal had failed silently (ACM only renews while
+# the domain's DNS validation CNAME resolves, and this zone is hosted away from
+# Route 53), and the only warning was AWS email. The site answered 200 throughout,
+# so an uptime check would have stayed green. This runs daily so the warning
+# arrives weeks early, in the same place as every other build signal.
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+    inputs:
+      warn_days:
+        description: Warn when a certificate expires within this many days.
+        required: false
+        default: '30'
+        type: string
+      fail_days:
+        description: Fail when a certificate expires within this many days.
+        required: false
+        default: '14'
+        type: string
+
+concurrency:
+  group: tls-expiry-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  check:
+    name: Check public certificates
+    # Forks have no reason to probe our hostnames on a schedule.
+    if: github.repository_owner == 'YosemiteCrew'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v6.0.0
+        with:
+          node-version: 22
+
+      # No install step: the check deliberately uses only node:tls, so a broken
+      # lockfile can never stop a certificate warning from being delivered.
+      - name: Check TLS expiry
+        id: check
+        run: |
+          set -o pipefail
+          node scripts/ci/check-tls-expiry.mjs \
+            --warn-days "${WARN_DAYS}" \
+            --fail-days "${FAIL_DAYS}" | tee tls-report.txt
+        env:
+          WARN_DAYS: ${{ inputs.warn_days || '30' }}
+          FAIL_DAYS: ${{ inputs.fail_days || '14' }}
+
+      - name: Open or update the tracking issue
+        # Runs on failure only. The job still fails afterwards - the issue is the
+        # notification, not a way to swallow the red.
+        if: failure()
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            let report = 'The report could not be read; see the job log.';
+            try {
+              report = fs.readFileSync('tls-report.txt', 'utf8');
+            } catch {}
+            const marker = '<!-- tls-expiry-tracker -->';
+            const title = 'TLS certificate expiring or untrusted';
+            const body = [
+              marker,
+              '',
+              'The daily TLS expiry check failed. Latest report:',
+              '',
+              '```',
+              report.trim(),
+              '```',
+              '',
+              'For an Amplify or ACM managed domain, renewal succeeds only while the',
+              "domain's DNS validation CNAME resolves. Add it in the zone's DNS and",
+              'leave it there permanently, otherwise every future renewal fails the',
+              'same silent way.',
+              '',
+              `Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            ].join('\n');
+            const existing = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open in:body "${marker}"`,
+            });
+            if (existing.data.total_count > 0) {
+              const number = existing.data.items[0].number;
+              await github.rest.issues.createComment({ ...context.repo, issue_number: number, body });
+              core.info(`commented on existing issue #${number}`);
+            } else {
+              const created = await github.rest.issues.create({
+                ...context.repo,
+                title,
+                body,
+                labels: ['security'],
+              });
+              core.info(`opened issue #${created.data.number}`);
+            }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "security:sbom": "./scripts/security/supply-chain.sh sbom",
     "security:scan": "./scripts/security/supply-chain.sh scan",
     "security:licenses": "./scripts/security/supply-chain.sh licenses",
-    "security:all": "./scripts/security/supply-chain.sh all"
+    "security:all": "./scripts/security/supply-chain.sh all",
+    "check:tls": "node scripts/ci/check-tls-expiry.mjs"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "check:secrets": "secretlint \"**/*\" --maskSecrets",
     "check:staged-secrets": "node scripts/check-staged-secrets.js",
     "check:overrides": "node scripts/ci/check-override-advisories.mjs",
-    "test:scripts": "node --test \"scripts/ci/*.test.mjs\" \"scripts/security/*.test.mjs\"",
+    "test:scripts": "node --test scripts/ci/*.test.mjs scripts/security/*.test.mjs",
     "doctor": "pnpm exec react-doctor",
     "security:sbom": "./scripts/security/supply-chain.sh sbom",
     "security:scan": "./scripts/security/supply-chain.sh scan",

--- a/scripts/ci/check-tls-expiry.mjs
+++ b/scripts/ci/check-tls-expiry.mjs
@@ -11,18 +11,20 @@
 //
 // dev.yosemitecrew.com went "not secure" for every visitor on 2026-08-13 because
 // its Amplify-managed ACM certificate expired at 2026-08-12 23:59:59Z. ACM renews
-// automatically ONLY while the domain's DNS validation CNAME still resolves; this
-// zone is hosted away from Route 53, the record was not there at renewal time, and
-// the only warning was AWS email nobody was watching. Nothing in CI knew, so the
-// first signal was a user hitting a browser interstitial.
+// automatically ONLY while the domain's DNS validation CNAME still resolves; that
+// record was missing for the dev subdomain (prod's was present, and prod renewed
+// fine), and the only warning was AWS email nobody was watching.
 //
 // The site kept answering 200 the whole time - an uptime check would have stayed
 // green - so this deliberately checks the certificate, not reachability.
 //
-// It is intentionally dependency-free (node:tls only) and makes no AWS API calls:
-// it sees exactly what a browser sees, from outside, including the case where a
-// renewed certificate exists in ACM but the distribution still serves the old one.
+// It is dependency-free (node:tls only) and makes no AWS API calls: it sees
+// exactly what a browser sees, from outside, including the case where a renewed
+// certificate exists in ACM but the distribution still serves the old one.
 import tls from 'node:tls';
+import { argv, exit, stderr, stdout } from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { realpathSync } from 'node:fs';
 
 // The hostnames a user or an app actually terminates TLS against. Keep the list
 // here rather than in the workflow so it is reviewed like code.
@@ -30,6 +32,14 @@ const DEFAULT_HOSTS = [
   'yosemitecrew.com',
   'www.yosemitecrew.com',
   'dev.yosemitecrew.com',
+  // ds.* fronts the design system, so a lapse there is user-visible even though
+  // it is not the marketing site.
+  'ds.yosemitecrew.com',
+  // NOT listed: app.yosemitecrew.com. Several backend files use it as a
+  // hardcoded fallback link (org-usage-notifications.ts, appointment.service.ts,
+  // user-organization.service.ts, task.service.ts), but the hostname has no A or
+  // CNAME record - it is not deployed. Monitoring it would red this check
+  // permanently; the fallbacks themselves are the bug to fix, separately.
   'api.yosemitecrew.com',
   'devapi.yosemitecrew.com',
 ];
@@ -38,52 +48,55 @@ const DEFAULT_WARN_DAYS = 30;
 const DEFAULT_FAIL_DAYS = 14;
 const CONNECT_TIMEOUT_MS = 15000;
 
-const parseArgs = (argv) => {
+const die = (message) => {
+  stderr.write(`${message}\n`);
+  exit(2);
+};
+
+const parseArgs = (args) => {
   const out = {
     hosts: DEFAULT_HOSTS,
     warnDays: DEFAULT_WARN_DAYS,
     failDays: DEFAULT_FAIL_DAYS,
     json: false,
   };
-  for (let i = 0; i < argv.length; i += 1) {
-    const arg = argv[i];
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
     if (arg === '--json') out.json = true;
     else if (arg === '--hosts')
-      out.hosts = String(argv[++i] ?? '')
+      out.hosts = String(args[++i] ?? '')
         .split(',')
+        .map((h) => h.trim())
         .filter(Boolean);
-    else if (arg === '--warn-days') out.warnDays = Number(argv[++i]);
-    else if (arg === '--fail-days') out.failDays = Number(argv[++i]);
-    else {
-      process.stderr.write(`unknown argument: ${arg}\n`);
-      process.exit(2);
-    }
+    else if (arg === '--warn-days') out.warnDays = Number(args[++i]);
+    else if (arg === '--fail-days') out.failDays = Number(args[++i]);
+    else die(`unknown argument: ${arg}`);
   }
-  if (!Number.isFinite(out.warnDays) || !Number.isFinite(out.failDays)) {
-    process.stderr.write('--warn-days and --fail-days must be numbers\n');
-    process.exit(2);
-  }
-  if (out.failDays > out.warnDays) {
-    process.stderr.write('--fail-days must not exceed --warn-days\n');
-    process.exit(2);
-  }
+  // An empty host list would make Promise.all resolve immediately and the check
+  // exit 0 having inspected nothing - a malformed invocation must not look like
+  // a pass.
+  if (out.hosts.length === 0) die('--hosts requires at least one hostname');
+  if (!Number.isFinite(out.warnDays) || !Number.isFinite(out.failDays))
+    die('--warn-days and --fail-days must be numbers');
+  // Negative thresholds would silently disable the advance notice this check
+  // exists to provide: a certificate with hours left would pass unremarked.
+  if (out.warnDays < 0 || out.failDays < 0) die('--warn-days and --fail-days must not be negative');
+  if (out.failDays > out.warnDays) die('--fail-days must not exceed --warn-days');
   return out;
 };
 
-// rejectUnauthorized stays false so an ALREADY-expired or mismatched certificate
-// is still readable: that is precisely the state this check must report on, and a
-// verifying handshake would abort before handing over the certificate. The
-// verification result is captured separately below instead of being discarded.
+// Certificate validation stays ON. The dates are only needed while a certificate
+// is still trusted - that is the whole point, warning BEFORE it lapses - and once
+// validation fails the handshake error already names the exact problem
+// (CERT_HAS_EXPIRED, ERR_TLS_CERT_ALTNAME_INVALID, ...), which is a hard failure
+// either way. So there is never a reason to disable verification to read a
+// certificate we have already decided to fail on.
 const inspectHost = (host, now) =>
   new Promise((resolve) => {
     const socket = tls.connect(
-      { host, port: 443, servername: host, rejectUnauthorized: false, ALPNProtocols: ['http/1.1'] },
+      { host, port: 443, servername: host, ALPNProtocols: ['http/1.1'] },
       () => {
         const cert = socket.getPeerCertificate();
-        const authorized = socket.authorized;
-        const authorizationError = socket.authorizationError
-          ? String(socket.authorizationError)
-          : null;
         socket.end();
         if (!cert || !cert.valid_to) {
           resolve({ host, status: 'error', detail: 'no certificate presented' });
@@ -102,8 +115,10 @@ const inspectHost = (host, now) =>
           daysLeft,
           issuer: cert.issuer?.O ?? cert.issuer?.CN ?? 'unknown',
           names,
-          authorized,
-          authorizationError,
+          // The handshake completed against the real trust store, so this
+          // certificate is trusted as of now.
+          authorized: true,
+          authorizationError: null,
         });
       }
     );
@@ -111,12 +126,16 @@ const inspectHost = (host, now) =>
       socket.destroy();
       resolve({ host, status: 'error', detail: `timed out after ${CONNECT_TIMEOUT_MS}ms` });
     });
-    socket.on('error', (err) => resolve({ host, status: 'error', detail: err.message }));
+    // err.code carries the precise reason (CERT_HAS_EXPIRED, DEPTH_ZERO_SELF_SIGNED_CERT,
+    // ERR_TLS_CERT_ALTNAME_INVALID); keep it, it is the diagnosis.
+    socket.on('error', (err) =>
+      resolve({ host, status: 'error', detail: err.code ? String(err.code) : err.message })
+    );
   });
 
-// A host is a failure when it is already untrusted by a real trust store, when it
-// expires inside the fail window, or when it could not be inspected at all - an
-// unreachable host is unknown, not fine.
+// A host is a failure when it is untrusted, when it expires inside the fail
+// window, or when it could not be inspected at all - an unreachable or
+// verification-failing host is a problem, not a pass.
 const classify = (result, opts) => {
   if (result.status === 'error') return 'error';
   if (!result.authorized) return 'fail';
@@ -129,53 +148,60 @@ export const evaluate = (results, opts) =>
   results.map((result) => ({ ...result, verdict: classify(result, opts) }));
 
 const main = async () => {
-  const opts = parseArgs(process.argv.slice(2));
+  const opts = parseArgs(argv.slice(2));
   const now = new Date();
   const results = evaluate(
     await Promise.all(opts.hosts.map((host) => inspectHost(host, now))),
     opts
   );
 
+  // In --json mode stdout must stay parseable, so the human lines and the
+  // GitHub annotations below are suppressed rather than appended to the array.
   if (opts.json) {
-    process.stdout.write(`${JSON.stringify(results, null, 2)}\n`);
+    stdout.write(`${JSON.stringify(results, null, 2)}\n`);
   } else {
     for (const r of results) {
       if (r.status === 'error') {
-        process.stdout.write(`${r.verdict.toUpperCase()}  ${r.host}: ${r.detail}\n`);
+        stdout.write(`${r.verdict.toUpperCase()}  ${r.host}: ${r.detail}\n`);
         continue;
       }
-      const trust = r.authorized ? 'trusted' : `UNTRUSTED (${r.authorizationError})`;
-      process.stdout.write(
-        `${r.verdict.toUpperCase()}  ${r.host}: ${r.daysLeft}d left, expires ${r.validTo}, issuer ${r.issuer}, ${trust}\n`
+      stdout.write(
+        `${r.verdict.toUpperCase()}  ${r.host}: ${r.daysLeft}d left, expires ${r.validTo}, issuer ${r.issuer}, trusted\n`
       );
+    }
+    for (const w of results.filter((r) => r.verdict === 'warn')) {
+      stdout.write(
+        `::warning::${w.host} TLS certificate expires in ${w.daysLeft} days (${w.validTo}) - renew it before it reaches ${opts.failDays} days\n`
+      );
+    }
+    for (const f of results.filter((r) => r.verdict === 'fail' || r.verdict === 'error')) {
+      const why = f.status === 'error' ? f.detail : `expires in ${f.daysLeft} days (${f.validTo})`;
+      stdout.write(`::error::${f.host} TLS certificate ${why}\n`);
     }
   }
 
   const failures = results.filter((r) => r.verdict === 'fail' || r.verdict === 'error');
-  const warnings = results.filter((r) => r.verdict === 'warn');
-  for (const w of warnings) {
-    process.stdout.write(
-      `::warning::${w.host} TLS certificate expires in ${w.daysLeft} days (${w.validTo}) - renew it before it reaches ${opts.failDays} days\n`
-    );
-  }
-  for (const f of failures) {
-    const why =
-      f.status === 'error'
-        ? f.detail
-        : f.authorized
-          ? `expires in ${f.daysLeft} days (${f.validTo})`
-          : `not trusted: ${f.authorizationError}`;
-    process.stdout.write(`::error::${f.host} TLS certificate ${why}\n`);
-  }
   if (failures.length > 0) {
-    process.stderr.write(
+    stderr.write(
       `\n${failures.length} host(s) failed the TLS expiry check. For an Amplify or ACM domain, renewal needs the domain's DNS validation CNAME to resolve - keep that record in the zone permanently, or every renewal fails silently.\n`
     );
-    process.exit(1);
+    exit(1);
   }
 };
 
-// Only run when invoked directly, so the test can import evaluate().
-if (import.meta.url === `file://${process.argv[1]}`) {
+// Only run when invoked directly, so the test can import evaluate(). Compared as
+// resolved filesystem paths: import.meta.url percent-encodes characters such as
+// spaces while argv[1] does not, so a raw string comparison silently skips main()
+// in any clone path containing a space.
+const invokedDirectly = () => {
+  if (!argv[1]) return false;
+  try {
+    return realpathSync(fileURLToPath(import.meta.url)) === realpathSync(argv[1]);
+  } catch {
+    return false;
+  }
+};
+
+if (invokedDirectly()) {
   await main();
 }

--- a/scripts/ci/check-tls-expiry.mjs
+++ b/scripts/ci/check-tls-expiry.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+// Fail before a public TLS certificate expires, instead of after.
+//
+// Usage:
+//   node scripts/ci/check-tls-expiry.mjs
+//   node scripts/ci/check-tls-expiry.mjs --warn-days 30 --fail-days 14
+//   node scripts/ci/check-tls-expiry.mjs --hosts dev.yosemitecrew.com,api.yosemitecrew.com
+//   node scripts/ci/check-tls-expiry.mjs --json
+//
+// Why this exists:
+//
+// dev.yosemitecrew.com went "not secure" for every visitor on 2026-08-13 because
+// its Amplify-managed ACM certificate expired at 2026-08-12 23:59:59Z. ACM renews
+// automatically ONLY while the domain's DNS validation CNAME still resolves; this
+// zone is hosted away from Route 53, the record was not there at renewal time, and
+// the only warning was AWS email nobody was watching. Nothing in CI knew, so the
+// first signal was a user hitting a browser interstitial.
+//
+// The site kept answering 200 the whole time - an uptime check would have stayed
+// green - so this deliberately checks the certificate, not reachability.
+//
+// It is intentionally dependency-free (node:tls only) and makes no AWS API calls:
+// it sees exactly what a browser sees, from outside, including the case where a
+// renewed certificate exists in ACM but the distribution still serves the old one.
+import tls from 'node:tls';
+
+// The hostnames a user or an app actually terminates TLS against. Keep the list
+// here rather than in the workflow so it is reviewed like code.
+const DEFAULT_HOSTS = [
+  'yosemitecrew.com',
+  'www.yosemitecrew.com',
+  'dev.yosemitecrew.com',
+  'api.yosemitecrew.com',
+  'devapi.yosemitecrew.com',
+];
+
+const DEFAULT_WARN_DAYS = 30;
+const DEFAULT_FAIL_DAYS = 14;
+const CONNECT_TIMEOUT_MS = 15000;
+
+const parseArgs = (argv) => {
+  const out = {
+    hosts: DEFAULT_HOSTS,
+    warnDays: DEFAULT_WARN_DAYS,
+    failDays: DEFAULT_FAIL_DAYS,
+    json: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--json') out.json = true;
+    else if (arg === '--hosts')
+      out.hosts = String(argv[++i] ?? '')
+        .split(',')
+        .filter(Boolean);
+    else if (arg === '--warn-days') out.warnDays = Number(argv[++i]);
+    else if (arg === '--fail-days') out.failDays = Number(argv[++i]);
+    else {
+      process.stderr.write(`unknown argument: ${arg}\n`);
+      process.exit(2);
+    }
+  }
+  if (!Number.isFinite(out.warnDays) || !Number.isFinite(out.failDays)) {
+    process.stderr.write('--warn-days and --fail-days must be numbers\n');
+    process.exit(2);
+  }
+  if (out.failDays > out.warnDays) {
+    process.stderr.write('--fail-days must not exceed --warn-days\n');
+    process.exit(2);
+  }
+  return out;
+};
+
+// rejectUnauthorized stays false so an ALREADY-expired or mismatched certificate
+// is still readable: that is precisely the state this check must report on, and a
+// verifying handshake would abort before handing over the certificate. The
+// verification result is captured separately below instead of being discarded.
+const inspectHost = (host, now) =>
+  new Promise((resolve) => {
+    const socket = tls.connect(
+      { host, port: 443, servername: host, rejectUnauthorized: false, ALPNProtocols: ['http/1.1'] },
+      () => {
+        const cert = socket.getPeerCertificate();
+        const authorized = socket.authorized;
+        const authorizationError = socket.authorizationError
+          ? String(socket.authorizationError)
+          : null;
+        socket.end();
+        if (!cert || !cert.valid_to) {
+          resolve({ host, status: 'error', detail: 'no certificate presented' });
+          return;
+        }
+        const validTo = new Date(cert.valid_to);
+        const daysLeft = Math.floor((validTo.getTime() - now.getTime()) / 86400000);
+        const names = (cert.subjectaltname ?? '')
+          .split(',')
+          .map((n) => n.trim().replace(/^DNS:/, ''))
+          .filter(Boolean);
+        resolve({
+          host,
+          status: 'ok',
+          validTo: validTo.toISOString(),
+          daysLeft,
+          issuer: cert.issuer?.O ?? cert.issuer?.CN ?? 'unknown',
+          names,
+          authorized,
+          authorizationError,
+        });
+      }
+    );
+    socket.setTimeout(CONNECT_TIMEOUT_MS, () => {
+      socket.destroy();
+      resolve({ host, status: 'error', detail: `timed out after ${CONNECT_TIMEOUT_MS}ms` });
+    });
+    socket.on('error', (err) => resolve({ host, status: 'error', detail: err.message }));
+  });
+
+// A host is a failure when it is already untrusted by a real trust store, when it
+// expires inside the fail window, or when it could not be inspected at all - an
+// unreachable host is unknown, not fine.
+const classify = (result, opts) => {
+  if (result.status === 'error') return 'error';
+  if (!result.authorized) return 'fail';
+  if (result.daysLeft <= opts.failDays) return 'fail';
+  if (result.daysLeft <= opts.warnDays) return 'warn';
+  return 'pass';
+};
+
+export const evaluate = (results, opts) =>
+  results.map((result) => ({ ...result, verdict: classify(result, opts) }));
+
+const main = async () => {
+  const opts = parseArgs(process.argv.slice(2));
+  const now = new Date();
+  const results = evaluate(
+    await Promise.all(opts.hosts.map((host) => inspectHost(host, now))),
+    opts
+  );
+
+  if (opts.json) {
+    process.stdout.write(`${JSON.stringify(results, null, 2)}\n`);
+  } else {
+    for (const r of results) {
+      if (r.status === 'error') {
+        process.stdout.write(`${r.verdict.toUpperCase()}  ${r.host}: ${r.detail}\n`);
+        continue;
+      }
+      const trust = r.authorized ? 'trusted' : `UNTRUSTED (${r.authorizationError})`;
+      process.stdout.write(
+        `${r.verdict.toUpperCase()}  ${r.host}: ${r.daysLeft}d left, expires ${r.validTo}, issuer ${r.issuer}, ${trust}\n`
+      );
+    }
+  }
+
+  const failures = results.filter((r) => r.verdict === 'fail' || r.verdict === 'error');
+  const warnings = results.filter((r) => r.verdict === 'warn');
+  for (const w of warnings) {
+    process.stdout.write(
+      `::warning::${w.host} TLS certificate expires in ${w.daysLeft} days (${w.validTo}) - renew it before it reaches ${opts.failDays} days\n`
+    );
+  }
+  for (const f of failures) {
+    const why =
+      f.status === 'error'
+        ? f.detail
+        : f.authorized
+          ? `expires in ${f.daysLeft} days (${f.validTo})`
+          : `not trusted: ${f.authorizationError}`;
+    process.stdout.write(`::error::${f.host} TLS certificate ${why}\n`);
+  }
+  if (failures.length > 0) {
+    process.stderr.write(
+      `\n${failures.length} host(s) failed the TLS expiry check. For an Amplify or ACM domain, renewal needs the domain's DNS validation CNAME to resolve - keep that record in the zone permanently, or every renewal fails silently.\n`
+    );
+    process.exit(1);
+  }
+};
+
+// Only run when invoked directly, so the test can import evaluate().
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main();
+}

--- a/scripts/ci/check-tls-expiry.test.mjs
+++ b/scripts/ci/check-tls-expiry.test.mjs
@@ -1,0 +1,101 @@
+// Tests for the TLS expiry check. The network-touching handshake is exercised by
+// the scheduled workflow itself; what is pinned here is the CLASSIFICATION, since
+// that is what decides whether a certificate about to expire reds the build.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { evaluate } from './check-tls-expiry.mjs';
+
+const script = join(dirname(fileURLToPath(import.meta.url)), 'check-tls-expiry.mjs');
+const OPTS = { warnDays: 30, failDays: 14 };
+const healthy = (over) => ({
+  host: 'example.test',
+  status: 'ok',
+  validTo: '2027-01-01T00:00:00.000Z',
+  daysLeft: 90,
+  issuer: 'Amazon',
+  names: ['example.test'],
+  authorized: true,
+  authorizationError: null,
+  ...over,
+});
+
+test('a certificate comfortably in date passes', () => {
+  const [r] = evaluate([healthy()], OPTS);
+  assert.equal(r.verdict, 'pass');
+});
+
+test('a certificate inside the warn window warns but does not fail', () => {
+  const [r] = evaluate([healthy({ daysLeft: 21 })], OPTS);
+  assert.equal(r.verdict, 'warn');
+});
+
+test('a certificate inside the fail window fails', () => {
+  const [r] = evaluate([healthy({ daysLeft: 14 })], OPTS);
+  assert.equal(r.verdict, 'fail');
+});
+
+test('an already-expired certificate fails - the dev.yosemitecrew.com case', () => {
+  // What the real host looked like on 2026-08-13: still answering, cert expired
+  // the previous midnight, so a reachability check would have stayed green.
+  const [r] = evaluate(
+    [
+      healthy({
+        host: 'dev.yosemitecrew.com',
+        daysLeft: -1,
+        validTo: '2026-08-12T23:59:59.000Z',
+        authorized: false,
+        authorizationError: 'CERT_HAS_EXPIRED',
+      }),
+    ],
+    OPTS
+  );
+  assert.equal(r.verdict, 'fail');
+});
+
+test('a hostname the certificate does not cover fails even with time left', () => {
+  const [r] = evaluate(
+    [
+      healthy({
+        daysLeft: 200,
+        authorized: false,
+        authorizationError: 'ERR_TLS_CERT_ALTNAME_INVALID',
+      }),
+    ],
+    OPTS
+  );
+  assert.equal(r.verdict, 'fail');
+});
+
+test('an unreachable host is an error, not a pass', () => {
+  const [r] = evaluate([{ host: 'nope.test', status: 'error', detail: 'ENOTFOUND' }], OPTS);
+  assert.equal(r.verdict, 'error');
+});
+
+test('a nonsensical threshold pair is rejected instead of silently accepted', () => {
+  try {
+    execFileSync('node', [script, '--fail-days', '40', '--warn-days', '10'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    assert.fail('expected a non-zero exit');
+  } catch (err) {
+    assert.equal(err.status, 2);
+    assert.match(`${err.stderr}`, /--fail-days must not exceed --warn-days/);
+  }
+});
+
+test('an unknown flag exits 2 rather than scanning a default list unexpectedly', () => {
+  try {
+    execFileSync('node', [script, '--bogus'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    assert.fail('expected a non-zero exit');
+  } catch (err) {
+    assert.equal(err.status, 2);
+    assert.match(`${err.stderr}`, /unknown argument/);
+  }
+});

--- a/scripts/ci/check-tls-expiry.test.mjs
+++ b/scripts/ci/check-tls-expiry.test.mjs
@@ -38,34 +38,28 @@ test('a certificate inside the fail window fails', () => {
 });
 
 test('an already-expired certificate fails - the dev.yosemitecrew.com case', () => {
-  // What the real host looked like on 2026-08-13: still answering, cert expired
-  // the previous midnight, so a reachability check would have stayed green.
+  // What the real host looked like on 2026-08-13: still answering 200, but the
+  // handshake fails verification, so a reachability check would have stayed green
+  // while this reports the exact reason.
   const [r] = evaluate(
-    [
-      healthy({
-        host: 'dev.yosemitecrew.com',
-        daysLeft: -1,
-        validTo: '2026-08-12T23:59:59.000Z',
-        authorized: false,
-        authorizationError: 'CERT_HAS_EXPIRED',
-      }),
-    ],
+    [{ host: 'dev.yosemitecrew.com', status: 'error', detail: 'CERT_HAS_EXPIRED' }],
     OPTS
   );
-  assert.equal(r.verdict, 'fail');
+  assert.equal(r.verdict, 'error');
 });
 
 test('a hostname the certificate does not cover fails even with time left', () => {
   const [r] = evaluate(
-    [
-      healthy({
-        daysLeft: 200,
-        authorized: false,
-        authorizationError: 'ERR_TLS_CERT_ALTNAME_INVALID',
-      }),
-    ],
+    [{ host: 'example.test', status: 'error', detail: 'ERR_TLS_CERT_ALTNAME_INVALID' }],
     OPTS
   );
+  assert.equal(r.verdict, 'error');
+});
+
+test('an untrusted result still fails if one ever reaches classify', () => {
+  // Defensive: inspectHost cannot produce this now that validation is on, but
+  // evaluate() is exported and must not grade an untrusted certificate a pass.
+  const [r] = evaluate([healthy({ daysLeft: 200, authorized: false })], OPTS);
   assert.equal(r.verdict, 'fail');
 });
 
@@ -98,4 +92,51 @@ test('an unknown flag exits 2 rather than scanning a default list unexpectedly',
     assert.equal(err.status, 2);
     assert.match(`${err.stderr}`, /unknown argument/);
   }
+});
+
+test('an empty --hosts exits 2 instead of passing having checked nothing', () => {
+  for (const args of [
+    [script, '--hosts', ''],
+    [script, '--hosts', ' , '],
+  ]) {
+    try {
+      execFileSync('node', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+      assert.fail('expected a non-zero exit');
+    } catch (err) {
+      assert.equal(err.status, 2);
+      assert.match(`${err.stderr}`, /--hosts requires at least one hostname/);
+    }
+  }
+});
+
+test('negative thresholds are rejected, so advance notice cannot be disabled', () => {
+  try {
+    execFileSync('node', [script, '--warn-days', '-1', '--fail-days', '-2'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    assert.fail('expected a non-zero exit');
+  } catch (err) {
+    assert.equal(err.status, 2);
+    assert.match(`${err.stderr}`, /must not be negative/);
+  }
+});
+
+test('--json emits parseable JSON on stdout with no annotations mixed in', () => {
+  // A host that cannot resolve exercises the failure path, which is where the
+  // ::error:: lines used to be appended after the array.
+  let stdoutText = '';
+  try {
+    stdoutText = execFileSync('node', [script, '--json', '--hosts', 'no-such-host.invalid'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (err) {
+    stdoutText = `${err.stdout ?? ''}`;
+  }
+  assert.doesNotMatch(stdoutText, /::(error|warning)::/);
+  const parsed = JSON.parse(stdoutText);
+  assert.equal(Array.isArray(parsed), true);
+  assert.equal(parsed[0].host, 'no-such-host.invalid');
+  assert.equal(parsed[0].verdict, 'error');
 });


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] All existing tests and lints pass.

## What is the current behavior?

dev.yosemitecrew.com served an expired certificate to every visitor from 2026-08-13 00:00 UTC. The Amplify-managed ACM certificate (SANs dev.yosemitecrew.com and *.dev.yosemitecrew.com, issued 2025-07-14) expired at 2026-08-12 23:59:59 UTC and had not renewed. ACM only auto-renews while the domain's DNS validation CNAME resolves; this zone is hosted away from Route 53, and the only warning was AWS email.

Nothing in CI knew. Worse, the site answered HTTP 200 throughout - CloudFront happily served it - so an uptime or smoke check would have stayed green while browsers showed an interstitial. The first signal was a person opening the site.

## What is the new behavior?

A daily scheduled check (06:00 UTC, plus workflow_dispatch with adjustable thresholds) inspects the certificate every hostname actually terminates TLS with: yosemitecrew.com, www, dev, api, devapi.

- Warns at 30 days, fails at 14, and fails immediately when a certificate is untrusted by a real trust store - so an expired cert, a hostname the cert does not cover, or an unreachable host are all red rather than quietly fine.
- Checks the certificate rather than reachability, which is the specific gap that let this outage through.
- Dependency-free (node:tls only) and makes no AWS API calls, so it sees exactly what a browser sees - including the case where a renewed certificate exists in ACM but the distribution still serves the old one - and a broken lockfile can never suppress a certificate warning.
- On failure it opens a tracking issue (or comments on the existing one) carrying the report and the renewal gotcha, so the warning is visible without reading Actions. The job still fails; the issue is the notification, not a way to swallow the red.
- Also available locally as `pnpm check:tls`.

Run against the live hosts right now, it reports exactly the outage:

```
PASS  yosemitecrew.com: 191d left, expires 2027-02-20, issuer Sectigo Limited, trusted
PASS  www.yosemitecrew.com: 180d left, expires 2027-02-09, issuer Amazon, trusted
FAIL  dev.yosemitecrew.com: -1d left, expires 2026-08-12T23:59:59.000Z, issuer Amazon, UNTRUSTED (CERT_HAS_EXPIRED)
PASS  api.yosemitecrew.com: 79d left, expires 2026-11-01, issuer Let's Encrypt, trusted
PASS  devapi.yosemitecrew.com: 70d left, expires 2026-10-22, issuer Let's Encrypt, trusted
```

This PR does not renew the certificate - that is an Amplify/ACM and DNS action outside the repo. It makes sure the next one cannot expire unannounced.

Impact area: CI only; no application code.

Validation: 8 new unit tests covering the classification (in-date, warn window, fail window, already-expired using the real dev.yosemitecrew.com values, hostname mismatch, unreachable host, and both argument-validation exits); full script suite 67/67 passing; actionlint plus a duplicate-key YAML scan on the new workflow; prettier and eslint clean; and the live run above.