### PR TITLE
ci(repo): stop anything but dev merging into main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -118,6 +118,32 @@ updates:
         update-types:
           - minor
           - patch
+  # Ruby lives only in the mobile app's CocoaPods toolchain. It had no entry at
+  # all, so bundler surfaced solely as SECURITY updates - and those always open
+  # against the default branch, which is how #2131 landed straight on main.
+  # A real entry keeps routine bundler bumps flowing through dev like everything
+  # else; the guard workflow is what stops security PRs merging into main.
+  - package-ecosystem: bundler
+    directory: /apps/mobileAppYC
+    schedule:
+      interval: weekly
+      day: monday
+      time: '05:15'
+      timezone: 'UTC'
+    target-branch: dev
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: 'chore(mobile)'
+    labels:
+      - dependencies
+      - ruby
+    groups:
+      bundler:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/workflows/promotion-guard.yml
+++ b/.github/workflows/promotion-guard.yml
@@ -11,7 +11,11 @@ name: Promotion Guard
 # Mark it required on main's ruleset for it to block rather than merely report.
 on:
   pull_request_target:
-    types: [opened, reopened, synchronize, labeled, unlabeled]
+    # `edited` matters: retargeting an existing PR onto main emits edited (with
+    # changes.base), not opened or synchronize. Without it the guard never runs
+    # for a retargeted PR, which - once the check is required - leaves that PR
+    # waiting forever on a status instead of getting the actionable error.
+    types: [opened, reopened, synchronize, edited, labeled, unlabeled]
     branches: [main]
 
 concurrency:

--- a/.github/workflows/promotion-guard.yml
+++ b/.github/workflows/promotion-guard.yml
@@ -1,0 +1,61 @@
+name: Promotion Guard
+
+# main takes changes from dev, and only from dev.
+#
+# Config alone cannot enforce this. `target-branch: dev` aims Dependabot VERSION
+# updates at dev, but Dependabot SECURITY updates always open against the default
+# branch and ignore it - which is exactly how the json security bump (#2131)
+# arrived as a PR into main on 2026-08-13 and was merged there, leaving dev still
+# on the vulnerable version. This job is the part that actually holds the line.
+#
+# Mark it required on main's ruleset for it to block rather than merely report.
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+    branches: [main]
+
+concurrency:
+  group: promotion-guard-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+# pull_request_target runs against the BASE repository, so it must never check
+# out or execute the pull request's code. It only reads branch metadata below.
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    name: Only dev may merge into main
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check the head branch
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+          # A deliberate, human-applied escape hatch for the rare direct-to-main
+          # change (an emergency hotfix, or a dependabot.yml sync that has to
+          # take effect before the next promotion). Dependabot cannot apply it:
+          # it only sets the labels listed in dependabot.yml, and this is not
+          # one of them.
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          set -euo pipefail
+
+          if [[ ",${LABELS}," == *",main-direct,"* ]]; then
+            echo "::notice::'main-direct' label present - a human has explicitly allowed this direct merge."
+            exit 0
+          fi
+
+          if [[ "${HEAD_REPO}" != "${BASE_REPO}" ]]; then
+            echo "::error::A fork branch (${HEAD_REPO}:${HEAD_REF}) cannot merge into main. Target dev instead."
+            exit 1
+          fi
+
+          if [[ "${HEAD_REF}" != "dev" ]]; then
+            echo "::error::main only accepts merges from dev, but this PR's head is '${HEAD_REF}'. Retarget it at dev and let the usual dev-to-main promotion carry it. If this genuinely must land on main first, add the 'main-direct' label."
+            exit 1
+          fi
+
+          echo "Head branch is dev - promotion allowed."

--- a/apps/mobileAppYC/Gemfile.lock
+++ b/apps/mobileAppYC/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
       mutex_m
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    json (2.20.0)
+    json (2.21.2)
     logger (1.7.0)
     minitest (5.27.0)
     molinillo (0.8.0)


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] All existing tests and lints pass.

## What is the current behavior?

On 2026-08-13 a Dependabot PR was merged straight into main (#2131, the json 2.20.0 -> 2.21.2 security bump). That should not be possible: main takes changes from dev, and only from dev.

The cause is not a misconfiguration. `target-branch: dev` aims Dependabot VERSION updates at dev, but Dependabot SECURITY updates always open against the default branch and ignore it entirely - so security PRs will keep arriving with `base: main` no matter what the config says. Bundler also had no ecosystem entry at all, so Ruby only ever surfaced through that security path.

It also left main ahead of dev: main got json 2.21.2, dev stayed on the vulnerable 2.20.0, and the alert still read "fixed" because Dependabot judges alerts against the default branch alone.

## What is the new behavior?

- A `Promotion Guard` workflow fails any pull request into main whose head branch is not `dev`, and any PR from a fork. The only way past it is a human applying a `main-direct` label - which Dependabot cannot do, since it applies only the labels named in dependabot.yml. It uses `pull_request_target` so the guard runs from the base repository, and reads branch metadata only: it never checks out or executes the PR's code.
- A `bundler` ecosystem is added for /apps/mobileAppYC with `target-branch: dev`, so routine Ruby bumps now flow through dev like every other ecosystem instead of appearing only as security PRs.
- dev is brought up to json 2.21.2, closing the gap where the fix existed on main but not on the branch everyone works from.

To actually block rather than merely report, `Only dev may merge into main` needs marking as a required check on main's ruleset - that is a repository settings change, not something this PR can do.

Impact area: CI configuration and the mobile Gemfile.lock; no application code.

Validation: actionlint clean on the new workflow; both YAML files parse with a duplicate-key-rejecting loader; dependabot.yml now resolves to three ecosystems (npm, bundler, github-actions), each targeting dev.