### PR TITLE
fix(mobile): date the privacy policy correctly and hold nitro-sound on the node 20 line

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -69,6 +69,10 @@ updates:
       # runs node 18 - unfreeze together with the runtime upgrade (#2125).
       - dependency-name: 'google-auth-library'
         update-types: ['version-update:semver-major']
+      # react-native-nitro-sound added engines node >=22.21.0 in 0.2.18; the repo
+      # and CI run node 20, so an engine-strict install fails outright. Frozen at
+      # 0.2.17 until the runtime upgrade (#2125).
+      - dependency-name: 'react-native-nitro-sound'
       # playwright raised its node floor to >=20 in 1.62; the backend image runs
       # node 18 and the security override pins playwright-core at EXACTLY 1.61.1,
       # which every playwright release must match exactly. Fully frozen (even

--- a/apps/mobileAppYC/__tests__/features/legal/data/legalData.test.ts
+++ b/apps/mobileAppYC/__tests__/features/legal/data/legalData.test.ts
@@ -1,5 +1,6 @@
 import {TERMS_SECTIONS} from '@/features/legal/data/termsData';
 import {PRIVACY_POLICY_SECTIONS} from '@/features/legal/data/privacyPolicyData';
+import {PRIVACY_META, TERMS_META} from '@/features/legal/data/legalMeta';
 
 describe('mobile legal data updates', () => {
   it('includes trademark notice in terms and privacy sections', () => {
@@ -35,5 +36,13 @@ describe('mobile legal data updates', () => {
     expect(combined).toContain('https://discord.gg/SwM6mX85KD');
     expect(combined).not.toContain('YVzMa9j7BK');
     expect(combined).not.toContain('YVzMq97Bk');
+  });
+
+  it('dates each document from the copy that actually changed', () => {
+    // The Discord invite change touched the privacy copy only, so advancing the
+    // terms date instead would tell users the terms were revised when they were
+    // not - and leave the revised privacy policy showing a stale date.
+    expect(PRIVACY_META.lastUpdated).toBe('13 Aug 2026');
+    expect(TERMS_META.lastUpdated).toBe('10 Jul 2026');
   });
 });

--- a/apps/mobileAppYC/package.json
+++ b/apps/mobileAppYC/package.json
@@ -70,7 +70,7 @@
     "react-native-localize": "^3.7.0",
     "react-native-maps": "^1.29.0",
     "react-native-nitro-modules": "^0.31.5",
-    "react-native-nitro-sound": "^0.2.18",
+    "react-native-nitro-sound": "0.2.17",
     "react-native-pdf": "^7.0.4",
     "react-native-permissions": "^5.6.1",
     "react-native-reanimated": "4.2.3",

--- a/apps/mobileAppYC/src/features/legal/data/legalMeta.ts
+++ b/apps/mobileAppYC/src/features/legal/data/legalMeta.ts
@@ -5,12 +5,12 @@ import type {LegalDocumentMeta} from './legalContentTypes';
 // display title and the "Last updated" pill, they are NOT legal content.
 export const TERMS_META: LegalDocumentMeta = {
   displayTitle: 'Terms of service',
-  lastUpdated: '13 Aug 2026',
+  lastUpdated: '10 Jul 2026',
   version: 'v1.0',
 };
 
 export const PRIVACY_META: LegalDocumentMeta = {
   displayTitle: 'How we handle your data',
-  lastUpdated: '10 Jul 2026',
+  lastUpdated: '13 Aug 2026',
   version: 'GDPR',
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -817,8 +817,8 @@ importers:
         specifier: ^0.31.5
         version: 0.31.10(react-native@0.81.6)(react@19.1.0)
       react-native-nitro-sound:
-        specifier: ^0.2.18
-        version: 0.2.18(react-native-nitro-modules@0.31.10)(react-native@0.81.6)(react@19.1.0)
+        specifier: 0.2.17
+        version: 0.2.17(react-native-nitro-modules@0.31.10)(react-native@0.81.6)(react@19.1.0)
       react-native-pdf:
         specifier: ^7.0.4
         version: 7.0.4(react-native-blob-util@0.24.10)(react-native@0.81.6)(react@19.1.0)
@@ -866,7 +866,7 @@ importers:
         version: 7.8.5
       stream-chat-react-native:
         specifier: ^8.13.17
-        version: 8.13.17(@react-native-clipboard/clipboard@1.16.3)(@react-native-community/netinfo@11.5.2)(@react-native-documents/picker@11.0.4)(@types/react@19.2.11)(react-native-blob-util@0.24.10)(react-native-gesture-handler@2.32.0)(react-native-haptic-feedback@2.3.3)(react-native-image-picker@8.2.1)(react-native-nitro-sound@0.2.18)(react-native-reanimated@4.2.3)(react-native-safe-area-context@5.8.1)(react-native-share@12.3.1)(react-native-svg@15.15.5)(react-native-video@6.19.2)(react-native@0.81.6)(react@19.1.0)(typescript@5.9.3)
+        version: 8.13.17(@react-native-clipboard/clipboard@1.16.3)(@react-native-community/netinfo@11.5.2)(@react-native-documents/picker@11.0.4)(@types/react@19.2.11)(react-native-blob-util@0.24.10)(react-native-gesture-handler@2.32.0)(react-native-haptic-feedback@2.3.3)(react-native-image-picker@8.2.1)(react-native-nitro-sound@0.2.17)(react-native-reanimated@4.2.3)(react-native-safe-area-context@5.8.1)(react-native-share@12.3.1)(react-native-svg@15.15.5)(react-native-video@6.19.2)(react-native@0.81.6)(react@19.1.0)(typescript@5.9.3)
       supertokens-react-native:
         specifier: ^5.1.5
         version: 5.1.5(@react-native-async-storage/async-storage@2.2.0)(axios@1.18.0)(react-native@0.81.6)
@@ -27505,9 +27505,8 @@ packages:
       react-native: 0.81.6(@babel/core@7.29.7)(@react-native-community/cli@20.0.2)(@react-native/metro-config@0.81.6)(@types/react@19.2.11)(react@19.1.0)
     dev: false
 
-  /react-native-nitro-sound@0.2.18(react-native-nitro-modules@0.31.10)(react-native@0.81.6)(react@19.1.0):
-    resolution: {integrity: sha512-++wXJDjJz90GIbjeA37K7DWfDVvbdd8PkJPKdJbT/2xbGBGmInv7W+R8bZyJL72SntobI0ncr8IDHdfsxxLTuw==}
-    engines: {node: '>=22.21.0'}
+  /react-native-nitro-sound@0.2.17(react-native-nitro-modules@0.31.10)(react-native@0.81.6)(react@19.1.0):
+    resolution: {integrity: sha512-I8XyqI9yiLba52WMok0/veIJm7uAJdvoQzqH1u5M4eTRUmBCDMOZ32FN6jLCADQGoH3/IXJ++WkWGZw0ZyR8DA==}
     peerDependencies:
       react: '*'
       react-native: '*'
@@ -29549,7 +29548,7 @@ packages:
       - utf-8-validate
     dev: false
 
-  /stream-chat-react-native@8.13.17(@react-native-clipboard/clipboard@1.16.3)(@react-native-community/netinfo@11.5.2)(@react-native-documents/picker@11.0.4)(@types/react@19.2.11)(react-native-blob-util@0.24.10)(react-native-gesture-handler@2.32.0)(react-native-haptic-feedback@2.3.3)(react-native-image-picker@8.2.1)(react-native-nitro-sound@0.2.18)(react-native-reanimated@4.2.3)(react-native-safe-area-context@5.8.1)(react-native-share@12.3.1)(react-native-svg@15.15.5)(react-native-video@6.19.2)(react-native@0.81.6)(react@19.1.0)(typescript@5.9.3):
+  /stream-chat-react-native@8.13.17(@react-native-clipboard/clipboard@1.16.3)(@react-native-community/netinfo@11.5.2)(@react-native-documents/picker@11.0.4)(@types/react@19.2.11)(react-native-blob-util@0.24.10)(react-native-gesture-handler@2.32.0)(react-native-haptic-feedback@2.3.3)(react-native-image-picker@8.2.1)(react-native-nitro-sound@0.2.17)(react-native-reanimated@4.2.3)(react-native-safe-area-context@5.8.1)(react-native-share@12.3.1)(react-native-svg@15.15.5)(react-native-video@6.19.2)(react-native@0.81.6)(react@19.1.0)(typescript@5.9.3):
     resolution: {integrity: sha512-f7Uh5ZgImALnD3LqImSxJgNk0IPgc36yZ3t+ymoSpDki+4GdQZRvD9yXt5B1iEviMOPFzLFNCf7zxDotIBZ8IA==}
     peerDependencies:
       '@react-native-camera-roll/camera-roll': '>=7.8.0'
@@ -29596,7 +29595,7 @@ packages:
       react-native-blob-util: 0.24.10(react-native@0.81.6)(react@19.1.0)
       react-native-haptic-feedback: 2.3.3(react-native@0.81.6)
       react-native-image-picker: 8.2.1(react-native@0.81.6)(react@19.1.0)
-      react-native-nitro-sound: 0.2.18(react-native-nitro-modules@0.31.10)(react-native@0.81.6)(react@19.1.0)
+      react-native-nitro-sound: 0.2.17(react-native-nitro-modules@0.31.10)(react-native@0.81.6)(react@19.1.0)
       react-native-share: 12.3.1
       react-native-video: 6.19.2(react-native@0.81.6)(react@19.1.0)
       stream-chat-react-native-core: 8.13.17(@react-native-community/netinfo@11.5.2)(@types/react@19.2.11)(react-native-gesture-handler@2.32.0)(react-native-reanimated@4.2.3)(react-native-safe-area-context@5.8.1)(react-native-svg@15.15.5)(react-native@0.81.6)(react@19.1.0)(typescript@5.9.3)


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] All existing tests and lints pass.

## What is the current behavior?

Two P2 findings raised on the promotion PR #2144, both now on main.

The first is my own mistake in #2047. Asked to bump the mobile privacy document's revision date, I replaced the first occurrence of the old date string in legalMeta.ts - which was TERMS_META, not PRIVACY_META. Both constants held '10 Jul 2026', so the edit landed on the wrong document: mobile users currently see the UNCHANGED terms marked as revised on 13 Aug, while the privacy policy, whose copy actually changed, still shows 10 Jul. LegalScreen renders meta.lastUpdated directly, so this is user-visible on a legal document.

The second: react-native-nitro-sound 0.2.18 added `engines.node >= 22.21.0`. The repo and CI run Node 20, so an engine-strict install fails before the mobile build or tests, and a non-strict install runs the dependency outside its supported runtime.

## What is the new behavior?

- The dates are swapped onto the documents they belong to: PRIVACY_META is 13 Aug 2026 (its copy changed), TERMS_META is back to 10 Jul 2026 (the mobile terms data was untouched by #2047 - only privacyPolicyData.ts changed). A regression test now pins each date to its own document, so a future edit cannot advance the wrong one silently.
- react-native-nitro-sound is pinned to 0.2.17, the last release before the Node 22 floor, and frozen in dependabot with a comment tying the unfreeze to the runtime upgrade (#2125). This is the same pattern already used for google-auth-library and playwright, which hit the identical wall.

Impact area: mobile legal metadata and one mobile dependency pin; no application logic.

Validation: legal data suite 4/4 passing including the new assertion; the lockfile has zero remaining references to nitro-sound 0.2.18 or 0.2.19; dependabot.yml still parses to three ecosystems, all targeting dev.