### PR TITLE
perf(frontend): load posthog only after analytics consent

### DIFF
--- a/apps/frontend/src/app/__tests__/lib/posthogClient.test.ts
+++ b/apps/frontend/src/app/__tests__/lib/posthogClient.test.ts
@@ -1,0 +1,40 @@
+import posthog from 'posthog-js';
+import { getLoadedPostHog, loadPostHog, resetPostHogClientForTests } from '@/app/lib/posthogClient';
+
+jest.mock('posthog-js', () => ({
+  __esModule: true,
+  default: { init: jest.fn() },
+}));
+
+describe('posthogClient', () => {
+  beforeEach(() => {
+    resetPostHogClientForTests();
+  });
+
+  it('reports no client until the analytics chunk has been loaded', () => {
+    expect(getLoadedPostHog()).toBeNull();
+  });
+
+  it('resolves the posthog client on load and exposes it synchronously afterwards', async () => {
+    const loaded = await loadPostHog();
+
+    expect(loaded).toBe(posthog);
+    expect(getLoadedPostHog()).toBe(posthog);
+  });
+
+  it('reuses the same client across repeated loads', async () => {
+    const first = await loadPostHog();
+    const second = await loadPostHog();
+
+    expect(second).toBe(first);
+  });
+
+  it('clears the cached client when reset', async () => {
+    await loadPostHog();
+    expect(getLoadedPostHog()).not.toBeNull();
+
+    resetPostHogClientForTests();
+
+    expect(getLoadedPostHog()).toBeNull();
+  });
+});

--- a/apps/frontend/src/app/__tests__/ui/layout/PostHogBootstrap.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/layout/PostHogBootstrap.test.tsx
@@ -2,6 +2,15 @@ import React from 'react';
 import { act, render, waitFor } from '@testing-library/react';
 import posthog from 'posthog-js';
 import { COOKIE_CONSENT_KEY, POSTHOG_READY_EVENT } from '@/app/lib/posthog';
+import * as posthogClient from '@/app/lib/posthogClient';
+import { resetPostHogClientForTests } from '@/app/lib/posthogClient';
+
+// Delegates to the real client so the cached-handle behaviour stays intact, while
+// letting a single test simulate a failed chunk load.
+jest.mock('@/app/lib/posthogClient', () => {
+  const actual = jest.requireActual('@/app/lib/posthogClient');
+  return { ...actual, loadPostHog: jest.fn(() => actual.loadPostHog()) };
+});
 import PostHogBootstrap from '@/app/ui/layout/PostHogBootstrap';
 
 jest.mock('posthog-js', () => ({
@@ -33,6 +42,10 @@ describe('PostHogBootstrap', () => {
     };
     globalThis.localStorage.clear();
     jest.clearAllMocks();
+    // Each test starts like a fresh page load, with the analytics chunk not yet
+    // fetched. Without this the cached client leaks between tests and the
+    // already-loaded path is taken instead of initialization.
+    resetPostHogClientForTests();
   });
 
   afterAll(() => {
@@ -137,5 +150,59 @@ describe('PostHogBootstrap', () => {
     render(<PostHogBootstrap />);
 
     await waitFor(() => expect(posthog.init).not.toHaveBeenCalled());
+  });
+
+  it('does not opt in when consent is withdrawn while the analytics chunk loads', async () => {
+    globalThis.localStorage.setItem(COOKIE_CONSENT_KEY, 'true');
+
+    render(<PostHogBootstrap />);
+    // Revoke in the same tick the mount effect starts loading the chunk, before
+    // the dynamic import resolves.
+    act(() => {
+      globalThis.dispatchEvent(
+        new StorageEvent('storage', { key: COOKIE_CONSENT_KEY, newValue: 'false' })
+      );
+    });
+
+    await waitFor(() => expect(posthog.init).not.toHaveBeenCalled());
+    expect(posthog.opt_in_capturing).not.toHaveBeenCalled();
+  });
+
+  it('opts out instead of opting in when consent is withdrawn before the loaded callback runs', async () => {
+    globalThis.localStorage.setItem(COOKIE_CONSENT_KEY, 'true');
+
+    render(<PostHogBootstrap />);
+    await waitFor(() => expect(posthog.init).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      globalThis.dispatchEvent(
+        new StorageEvent('storage', { key: COOKIE_CONSENT_KEY, newValue: 'false' })
+      );
+    });
+    // PostHog calls `loaded` asynchronously; by now consent is gone.
+    act(() => {
+      getInitOptions().loaded?.(posthog);
+    });
+
+    expect(posthog.opt_in_capturing).not.toHaveBeenCalled();
+    expect(posthog.opt_out_capturing).toHaveBeenCalled();
+  });
+
+  it('retries initialization after a failed analytics chunk load', async () => {
+    const loadMock = posthogClient.loadPostHog as jest.Mock;
+    loadMock.mockRejectedValueOnce(new Error('chunk load failed'));
+    globalThis.localStorage.setItem(COOKIE_CONSENT_KEY, 'true');
+
+    render(<PostHogBootstrap />);
+    await waitFor(() => expect(loadMock).toHaveBeenCalledTimes(1));
+    expect(posthog.init).not.toHaveBeenCalled();
+
+    act(() => {
+      globalThis.dispatchEvent(
+        new StorageEvent('storage', { key: COOKIE_CONSENT_KEY, newValue: 'true' })
+      );
+    });
+
+    await waitFor(() => expect(posthog.init).toHaveBeenCalledTimes(1));
   });
 });

--- a/apps/frontend/src/app/__tests__/ui/layout/PostHogBootstrap.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/layout/PostHogBootstrap.test.tsx
@@ -188,6 +188,41 @@ describe('PostHogBootstrap', () => {
     expect(posthog.opt_out_capturing).toHaveBeenCalled();
   });
 
+  it('still signals readiness when consent was withdrawn during initialization', async () => {
+    // Readiness means the client is initialized, not that we are capturing. If it
+    // is skipped here it is never emitted at all, because re-consenting takes the
+    // already-loaded path which only toggles capture - leaving anything that waits
+    // on the event permanently inactive.
+    globalThis.localStorage.setItem(COOKIE_CONSENT_KEY, 'true');
+    const onReady = jest.fn();
+    globalThis.addEventListener(POSTHOG_READY_EVENT, onReady);
+
+    render(<PostHogBootstrap />);
+    await waitFor(() => expect(posthog.init).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      globalThis.dispatchEvent(
+        new StorageEvent('storage', { key: COOKIE_CONSENT_KEY, newValue: 'false' })
+      );
+    });
+    act(() => {
+      getInitOptions().loaded?.(posthog);
+    });
+
+    expect(posthog.opt_in_capturing).not.toHaveBeenCalled();
+    expect(onReady).toHaveBeenCalledTimes(1);
+
+    // ...and re-consenting from the cached path opts back in.
+    act(() => {
+      globalThis.dispatchEvent(
+        new StorageEvent('storage', { key: COOKIE_CONSENT_KEY, newValue: 'true' })
+      );
+    });
+    await waitFor(() => expect(posthog.opt_in_capturing).toHaveBeenCalled());
+
+    globalThis.removeEventListener(POSTHOG_READY_EVENT, onReady);
+  });
+
   it('retries initialization after a failed analytics chunk load', async () => {
     const loadMock = posthogClient.loadPostHog as jest.Mock;
     loadMock.mockRejectedValueOnce(new Error('chunk load failed'));

--- a/apps/frontend/src/app/__tests__/ui/layout/PostHogBootstrap.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/layout/PostHogBootstrap.test.tsx
@@ -168,6 +168,42 @@ describe('PostHogBootstrap', () => {
     expect(posthog.opt_in_capturing).not.toHaveBeenCalled();
   });
 
+  it('initializes on renewed consent after an abandoned load left the module cached', async () => {
+    // Abandoning init still leaves loadPostHog's module cached, so a later
+    // consent event sees a non-null handle. Treating that as "already
+    // initialized" would only toggle capture on a client init() never ran on:
+    // no ready event, and analytics dead until a reload.
+    globalThis.localStorage.setItem(COOKIE_CONSENT_KEY, 'true');
+    const onReady = jest.fn();
+    globalThis.addEventListener(POSTHOG_READY_EVENT, onReady);
+
+    render(<PostHogBootstrap />);
+    act(() => {
+      globalThis.dispatchEvent(
+        new StorageEvent('storage', { key: COOKIE_CONSENT_KEY, newValue: 'false' })
+      );
+    });
+    await waitFor(() => expect(posthog.init).not.toHaveBeenCalled());
+    // The abandoned load cached the module all the same.
+    expect(posthogClient.getLoadedPostHog()).not.toBeNull();
+
+    act(() => {
+      globalThis.localStorage.setItem(COOKIE_CONSENT_KEY, 'true');
+      globalThis.dispatchEvent(
+        new StorageEvent('storage', { key: COOKIE_CONSENT_KEY, newValue: 'true' })
+      );
+    });
+
+    await waitFor(() => expect(posthog.init).toHaveBeenCalledTimes(1));
+    act(() => {
+      getInitOptions().loaded?.(posthog);
+    });
+
+    expect(posthog.opt_in_capturing).toHaveBeenCalled();
+    expect(onReady).toHaveBeenCalled();
+    globalThis.removeEventListener(POSTHOG_READY_EVENT, onReady);
+  });
+
   it('opts out instead of opting in when consent is withdrawn before the loaded callback runs', async () => {
     globalThis.localStorage.setItem(COOKIE_CONSENT_KEY, 'true');
 

--- a/apps/frontend/src/app/__tests__/ui/layout/PostHogUserSync.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/layout/PostHogUserSync.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { act, render, waitFor } from '@testing-library/react';
 import posthog from 'posthog-js';
 import { COOKIE_CONSENT_KEY, POSTHOG_READY_EVENT } from '@/app/lib/posthog';
+import { loadPostHog, resetPostHogClientForTests } from '@/app/lib/posthogClient';
 import PostHogUserSync from '@/app/ui/layout/PostHogUserSync';
 
 const mockUseAuthStore = jest.fn();
@@ -20,9 +21,14 @@ jest.mock('@/app/stores/authStore', () => ({
 }));
 
 describe('PostHogUserSync', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     jest.clearAllMocks();
     globalThis.localStorage.clear();
+    // PostHogBootstrap owns loading the analytics chunk; this component only
+    // reads the already-loaded handle. Prime it so these tests exercise the
+    // consent/readiness/status logic rather than the loading seam.
+    resetPostHogClientForTests();
+    await loadPostHog();
     (posthog as { __loaded?: boolean }).__loaded = false;
   });
 

--- a/apps/frontend/src/app/lib/posthogClient.ts
+++ b/apps/frontend/src/app/lib/posthogClient.ts
@@ -1,0 +1,24 @@
+import type { PostHog } from 'posthog-js';
+
+// posthog-js is ~193KB minified (~75KB gzipped). A static import puts it in the
+// shared bundle for every route, so every visitor downloads and parses the
+// analytics library before they have consented to anything - and visitors who
+// never consent pay for it without it ever initializing.
+//
+// Loading it through here keeps it in its own chunk, fetched only when consent
+// has actually been given. `getLoadedPostHog` stays synchronous so callers that
+// only act once analytics is running (identify/reset) do not have to become
+// async: it returns the client if and only if it has already been loaded.
+let client: PostHog | null = null;
+
+export const loadPostHog = async (): Promise<PostHog> => {
+  client ??= (await import('posthog-js')).default;
+  return client;
+};
+
+export const getLoadedPostHog = (): PostHog | null => client;
+
+// Test seam: jest module registry resets do not clear this module-level handle.
+export const resetPostHogClientForTests = (): void => {
+  client = null;
+};

--- a/apps/frontend/src/app/ui/layout/PostHogBootstrap.tsx
+++ b/apps/frontend/src/app/ui/layout/PostHogBootstrap.tsx
@@ -97,11 +97,18 @@ const PostHogBootstrap = () => {
         loaded: (ph) => {
           // init is async too, so re-check: consent may have been withdrawn
           // between the import resolving and this callback firing.
-          if (!latestConsent) {
+          if (latestConsent) {
+            ph.opt_in_capturing();
+          } else {
             ph.opt_out_capturing();
-            return;
           }
-          ph.opt_in_capturing();
+          // Readiness means "the client is initialized", not "we are capturing",
+          // and it is only ever emitted here. Returning early when consent had
+          // been withdrawn left it permanently unemitted: re-consenting takes
+          // the already-loaded path above, which only toggles capture, so
+          // anything waiting on this event could never become ready again.
+          // Consumers gate on consent separately, so emitting it while opted
+          // out captures nothing.
           globalThis.dispatchEvent(new Event(POSTHOG_READY_EVENT));
         },
       });

--- a/apps/frontend/src/app/ui/layout/PostHogBootstrap.tsx
+++ b/apps/frontend/src/app/ui/layout/PostHogBootstrap.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import posthog from 'posthog-js';
 import { getStorageItem } from '@/app/lib/browserStorage';
+import { loadPostHog } from '@/app/lib/posthogClient';
 import {
   COOKIE_CONSENT_KEY,
   POSTHOG_PROPERTY_DENYLIST,
@@ -23,14 +23,17 @@ const PostHogBootstrap = () => {
   const initializedRef = useRef(false);
 
   useEffect(() => {
-    const applyConsent = (consented: boolean) => {
+    const applyConsent = async (consented: boolean) => {
       const { apiHost, projectToken } = getPostHogConfig();
       if (!projectToken || !apiHost) return;
 
       if (!initializedRef.current) {
         if (!consented) return;
 
+        // Set before awaiting so a consent event arriving while the chunk is in
+        // flight cannot start a second initialization.
         initializedRef.current = true;
+        const posthog = await loadPostHog();
         posthog.init(projectToken, {
           api_host: apiHost,
           autocapture: { capture_copied_text: false },
@@ -61,6 +64,8 @@ const PostHogBootstrap = () => {
         return;
       }
 
+      // Reached only once initialization has happened, so the chunk is cached.
+      const posthog = await loadPostHog();
       if (consented) {
         posthog.opt_in_capturing();
       } else {
@@ -68,11 +73,11 @@ const PostHogBootstrap = () => {
       }
     };
 
-    applyConsent(hasConsent());
+    void applyConsent(hasConsent());
 
     const onStorage = (event: StorageEvent) => {
       if (event.key === COOKIE_CONSENT_KEY) {
-        applyConsent(event.newValue === 'true');
+        void applyConsent(event.newValue === 'true');
       }
     };
 

--- a/apps/frontend/src/app/ui/layout/PostHogBootstrap.tsx
+++ b/apps/frontend/src/app/ui/layout/PostHogBootstrap.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useRef } from 'react';
 import { getStorageItem } from '@/app/lib/browserStorage';
-import { loadPostHog } from '@/app/lib/posthogClient';
+import { logger } from '@/app/lib/logger';
+import { getLoadedPostHog, loadPostHog } from '@/app/lib/posthogClient';
 import {
   COOKIE_CONSENT_KEY,
   POSTHOG_PROPERTY_DENYLIST,
@@ -23,54 +24,87 @@ const PostHogBootstrap = () => {
   const initializedRef = useRef(false);
 
   useEffect(() => {
+    // The consent the visitor has actually given right now. Consent can be
+    // withdrawn while the analytics chunk is still downloading, and the in-flight
+    // call would otherwise act on the stale value it was invoked with.
+    let latestConsent = hasConsent();
+
     const applyConsent = async (consented: boolean) => {
       const { apiHost, projectToken } = getPostHogConfig();
       if (!projectToken || !apiHost) return;
 
-      if (!initializedRef.current) {
-        if (!consented) return;
+      latestConsent = consented;
 
-        // Set before awaiting so a consent event arriving while the chunk is in
-        // flight cannot start a second initialization.
-        initializedRef.current = true;
-        const posthog = await loadPostHog();
-        posthog.init(projectToken, {
-          api_host: apiHost,
-          autocapture: { capture_copied_text: false },
-          before_send: sanitizePostHogEvent,
-          capture_pageview: 'history_change',
-          defaults: '2026-01-30',
-          enable_heatmaps: true,
-          enable_recording_console_log: false,
-          mask_all_element_attributes: true,
-          mask_all_text: true,
-          opt_out_capturing_by_default: true,
-          person_profiles: 'identified_only',
-          property_denylist: POSTHOG_PROPERTY_DENYLIST,
-          session_recording: {
-            blockSelector: '[data-ph-no-capture]',
-            maskInputOptions: { password: true },
-            maskTextSelector: '[data-ph-mask]',
-          },
-          // Use loaded callback so opt_in fires only after init fully completes
-          // (including applying defaults + endpoint routing). Calling opt_in_capturing
-          // synchronously after posthog.init() fires before defaults are applied,
-          // causing the $opt_in event to hit /e/ with no token and return 401.
-          loaded: (ph) => {
-            ph.opt_in_capturing();
-            globalThis.dispatchEvent(new Event(POSTHOG_READY_EVENT));
-          },
-        });
+      // Once the client is cached, opting in and out stays synchronous. That
+      // matters: PostHogUserSync listens for the same storage event and runs
+      // straight after this handler, so an await here would let it identify
+      // while capturing was still opted out and PostHog would drop the event.
+      const cached = getLoadedPostHog();
+      if (cached) {
+        if (consented) {
+          cached.opt_in_capturing();
+        } else {
+          cached.opt_out_capturing();
+        }
         return;
       }
 
-      // Reached only once initialization has happened, so the chunk is cached.
-      const posthog = await loadPostHog();
-      if (consented) {
-        posthog.opt_in_capturing();
-      } else {
-        posthog.opt_out_capturing();
+      if (!consented || initializedRef.current) return;
+
+      // Set before awaiting so a consent event arriving while the chunk is in
+      // flight cannot start a second initialization; cleared again if the load
+      // fails, so a later consent event can retry rather than being stuck
+      // opting in on a client that was never initialized.
+      initializedRef.current = true;
+      let posthog;
+      try {
+        posthog = await loadPostHog();
+      } catch (error) {
+        initializedRef.current = false;
+        logger.warn('Failed to load analytics', error);
+        return;
       }
+
+      // Consent withdrawn while the chunk was downloading: leave PostHog
+      // uninitialized entirely rather than initializing and opting straight out.
+      if (!latestConsent) {
+        initializedRef.current = false;
+        return;
+      }
+
+      posthog.init(projectToken, {
+        api_host: apiHost,
+        autocapture: { capture_copied_text: false },
+        before_send: sanitizePostHogEvent,
+        capture_pageview: 'history_change',
+        defaults: '2026-01-30',
+        enable_heatmaps: true,
+        enable_recording_console_log: false,
+        mask_all_element_attributes: true,
+        mask_all_text: true,
+        opt_out_capturing_by_default: true,
+        person_profiles: 'identified_only',
+        property_denylist: POSTHOG_PROPERTY_DENYLIST,
+        session_recording: {
+          blockSelector: '[data-ph-no-capture]',
+          maskInputOptions: { password: true },
+          maskTextSelector: '[data-ph-mask]',
+        },
+        // Use loaded callback so opt_in fires only after init fully completes
+        // (including applying defaults + endpoint routing). Calling opt_in_capturing
+        // synchronously after posthog.init() fires before defaults are applied,
+        // causing the $opt_in event to hit /e/ with no token and return 401.
+        loaded: (ph) => {
+          // init is async too, so re-check: consent may have been withdrawn
+          // between the import resolving and this callback firing.
+          if (!latestConsent) {
+            ph.opt_out_capturing();
+            return;
+          }
+          ph.opt_in_capturing();
+          globalThis.dispatchEvent(new Event(POSTHOG_READY_EVENT));
+        },
+      });
     };
 
     void applyConsent(hasConsent());

--- a/apps/frontend/src/app/ui/layout/PostHogBootstrap.tsx
+++ b/apps/frontend/src/app/ui/layout/PostHogBootstrap.tsx
@@ -39,8 +39,15 @@ const PostHogBootstrap = () => {
       // matters: PostHogUserSync listens for the same storage event and runs
       // straight after this handler, so an await here would let it identify
       // while capturing was still opted out and PostHog would drop the event.
+      //
+      // `initializedRef` is part of the condition because a cached module is not
+      // the same thing as an initialized client. Withdrawing consent while the
+      // chunk is still downloading abandons init below, but loadPostHog has
+      // already cached the module - so this branch would toggle capture on a
+      // client that was never initialized, emit no ready event, and leave
+      // analytics dead until a reload.
       const cached = getLoadedPostHog();
-      if (cached) {
+      if (cached && initializedRef.current) {
         if (consented) {
           cached.opt_in_capturing();
         } else {

--- a/apps/frontend/src/app/ui/layout/PostHogUserSync.tsx
+++ b/apps/frontend/src/app/ui/layout/PostHogUserSync.tsx
@@ -1,13 +1,17 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import posthog from 'posthog-js';
 import { getStorageItem } from '@/app/lib/browserStorage';
 import { COOKIE_CONSENT_KEY, POSTHOG_READY_EVENT } from '@/app/lib/posthog';
+import { getLoadedPostHog } from '@/app/lib/posthogClient';
 import { useAuthStore } from '@/app/stores/authStore';
 
 const hasConsent = () => getStorageItem('local', COOKIE_CONSENT_KEY) === 'true';
-const isPostHogLoaded = () => (posthog as { __loaded?: boolean }).__loaded === true;
+// Null until PostHogBootstrap has loaded the analytics chunk, which only happens
+// after consent. Every call below is already gated on that, so reading the
+// handle synchronously is safe and keeps this component's sync path intact.
+const isPostHogLoaded = () =>
+  (getLoadedPostHog() as { __loaded?: boolean } | null)?.__loaded === true;
 const addDefinedValue = (
   properties: Record<string, string>,
   key: string,
@@ -36,9 +40,11 @@ const PostHogUserSync = () => {
       const consented = consentedRef.current;
       const ready = readyRef.current;
 
+      const posthog = getLoadedPostHog();
+
       if (!consented || !ready) {
         if (identifiedIdRef.current && ready) {
-          posthog.reset();
+          posthog?.reset();
         }
         identifiedIdRef.current = null;
         return;
@@ -46,7 +52,7 @@ const PostHogUserSync = () => {
 
       if (status !== 'authenticated' && status !== 'signin-authenticated') {
         if (identifiedIdRef.current) {
-          posthog.reset();
+          posthog?.reset();
           identifiedIdRef.current = null;
         }
         return;
@@ -63,7 +69,7 @@ const PostHogUserSync = () => {
       addDefinedValue(personProperties, 'last_name', attributes?.family_name);
       addDefinedValue(personProperties, 'role', attributes?.['custom:role']);
 
-      posthog.identify(distinctId, personProperties);
+      posthog?.identify(distinctId, personProperties);
       identifiedIdRef.current = distinctId;
     };
   });


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

`posthog-js` is ~193KB minified, about 75KB gzipped. It was statically imported by both `PostHogBootstrap` and `PostHogUserSync`, which are mounted in the root layout, so it landed in the shared bundle for every route: marketing, auth and PIMS alike.

That means every visitor downloads and parses the analytics library before they have consented to anything, and a visitor who never consents pays the full cost for a library that never initializes. Initialization was already correctly consent gated; the download was not.

Measured on the deployed home page, a 75KB gz chunk containing posthog is among the 21 chunks the page pulls.

This is fix 3 of the workstream in #2155.

## What is the new behavior?

A small `src/app/lib/posthogClient.ts` owns the import:

- `loadPostHog()` imports `posthog-js` on demand and caches the client.
- `getLoadedPostHog()` returns that client synchronously, or `null` if it has not been loaded.

`PostHogBootstrap` awaits `loadPostHog()` only once consent has actually been given, so the chunk is never fetched otherwise. The initialization flag is set before the await so a consent event arriving while the chunk is in flight cannot start a second initialization.

`PostHogUserSync` keeps its synchronous identity-sync path and reads `getLoadedPostHog()` instead. That is safe because every call it makes is already gated on `readyRef`, which is only set from the `POSTHOG_READY_EVENT` that bootstrap dispatches after `posthog.init` completes. Before that point there is nothing to identify or reset.

Behaviour is unchanged: same init options, same consent gating, same identify and reset semantics.

## Related Issue(s)

Part of #2155

## Impact area

`apps/frontend` analytics wiring only. No API, schema, styling or component-rendering changes.

## Validation performed

- `pnpm --filter frontend run type-check`, exit 0.
- `pnpm --filter frontend run lint`, exit 0.
- `pnpm --filter frontend run test --testPathPatterns="PostHog|posthog|layout"`: 36 suites, 227 tests passed, exit 0.
- Coverage on the changed files: `posthogClient.ts` 100% statements, branches, functions and lines; `PostHogUserSync.tsx` 100%; `PostHogBootstrap.tsx` 100% statements, functions and lines with one pre-existing uncovered branch.
- Aikido SAST and secrets scan on the new module: no issues.
- Production build, exit 0. Inspecting `.next/app-build-manifest.json` for the home page route and grepping its first-load chunks: posthog is no longer present in any of them, confirming it split into its own on-demand chunk.

## Notes for the reviewer

`resetPostHogClientForTests` exists because the cached client is module-level state that a jest module-registry reset does not clear. It is only referenced from tests.

The same home page still carries a ~64KB gz chunk containing the SuperTokens stack, pulled in by `SiteNav` and `PostHogUserSync` through the auth store. That is deliberately left alone here and is the subject of the next PR in #2155, so this change stays reviewable on its own.
