### PR TITLE
perf(frontend): keep the auth stack out of public pages

### DIFF
--- a/apps/frontend/src/app/__tests__/features/marketing/site/SiteNav.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/marketing/site/SiteNav.test.tsx
@@ -13,11 +13,13 @@ jest.mock('@/app/features/marketing/site/useGithubStats', () => ({
 jest.mock('@/app/features/marketing/site/motion', () => ({
   useScrolled: () => scrolledValue,
 }));
-jest.mock('@/app/stores/authStore', () => {
-  const useAuthStore = (selector: (s: typeof mockAuthState) => unknown) => selector(mockAuthState);
-  useAuthStore.getState = () => ({ checkSession: mockCheckSession });
-  return { useAuthStore };
-});
+// The nav reads auth through the lazy seam so public pages don't bundle the
+// SuperTokens stack. Mock the seam synchronously here: its own async loading
+// behaviour is covered by useLazyAuthStore.test.ts.
+jest.mock('@/app/hooks/useLazyAuthStore', () => ({
+  useLazyAuthSlice: (selector: (s: typeof mockAuthState) => unknown) => selector(mockAuthState),
+  ensureSessionChecked: () => mockCheckSession(),
+}));
 jest.mock('next/image', () => ({
   __esModule: true,
   default: jest.requireActual('@/app/__tests__/support/marketingTestMocks').NextImageMock,

--- a/apps/frontend/src/app/__tests__/hooks/useLazyAuthStore.test.tsx
+++ b/apps/frontend/src/app/__tests__/hooks/useLazyAuthStore.test.tsx
@@ -18,13 +18,23 @@ const setState = (partial: Partial<FakeState>) => {
   listeners.forEach((listener) => listener());
 };
 
+const mockModule = {
+  get useAuthStore() {
+    return realStore;
+  },
+};
+
+const realStore = {
+  getState: () => state,
+  subscribe: (listener: () => void) => {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  },
+};
+
 jest.mock('@/app/stores/authStore', () => ({
-  useAuthStore: {
-    getState: () => state,
-    subscribe: (listener: () => void) => {
-      listeners.add(listener);
-      return () => listeners.delete(listener);
-    },
+  get useAuthStore() {
+    return mockModule.useAuthStore;
   },
 }));
 
@@ -104,6 +114,59 @@ describe('useLazyAuthStore', () => {
     unmount();
 
     expect(listeners.size).toBe(0);
+  });
+
+  it('fetches nothing while disabled, and subscribes once enabled', async () => {
+    // The point of the gate: a public visitor who never consents must not pay for
+    // the auth chunk just because a root-layout component is mounted.
+    const Probe = ({ enabled }: { enabled: boolean }) => {
+      const role = useLazyAuthSlice(
+        selectRole as never,
+        'pending' as string | null,
+        Object.is,
+        enabled
+      );
+      return <span data-testid="role">{role ?? 'none'}</span>;
+    };
+
+    setState({ role: 'vet' });
+    const { rerender } = render(<Probe enabled={false} />);
+    await act(async () => {});
+
+    expect(screen.getByTestId('role')).toHaveTextContent('pending');
+    expect(listeners.size).toBe(0);
+
+    await act(async () => {
+      rerender(<Probe enabled />);
+    });
+
+    expect(screen.getByTestId('role')).toHaveTextContent('vet');
+    expect(listeners.size).toBe(1);
+  });
+
+  it('neither reads nor subscribes when unmounted before the import resolves', async () => {
+    // Unmount synchronously, before the dynamic import's microtask runs. Without
+    // the active guard this would read state after unmount and leave a
+    // subscription that cleanup can no longer remove.
+    const { unmount } = render(<RoleProbe />);
+    unmount();
+
+    await act(async () => {});
+
+    expect(listeners.size).toBe(0);
+  });
+
+  it('retries after a failed chunk load instead of caching the rejection', async () => {
+    const spy = jest.spyOn(mockModule, 'useAuthStore', 'get').mockImplementationOnce(() => {
+      throw new Error('chunk load failed');
+    });
+
+    await expect(ensureSessionChecked()).rejects.toThrow('chunk load failed');
+    spy.mockRestore();
+
+    // The cached promise must have been cleared, so this attempt succeeds.
+    await ensureSessionChecked();
+    expect(mockCheckSession).toHaveBeenCalledTimes(1);
   });
 
   it('starts the session check only when the status is idle', async () => {

--- a/apps/frontend/src/app/__tests__/hooks/useLazyAuthStore.test.tsx
+++ b/apps/frontend/src/app/__tests__/hooks/useLazyAuthStore.test.tsx
@@ -161,12 +161,71 @@ describe('useLazyAuthStore', () => {
       throw new Error('chunk load failed');
     });
 
-    await expect(ensureSessionChecked()).rejects.toThrow('chunk load failed');
+    // Resolves rather than rejects: SiteNav calls this as `void
+    // ensureSessionChecked()`, so a rejection would surface as an unhandled one.
+    await expect(ensureSessionChecked()).resolves.toBeUndefined();
+    expect(mockCheckSession).not.toHaveBeenCalled();
     spy.mockRestore();
 
     // The cached promise must have been cleared, so this attempt succeeds.
     await ensureSessionChecked();
     expect(mockCheckSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the fallback and stays quiet when the chunk fails for a subscriber', async () => {
+    const rejections: unknown[] = [];
+    const onUnhandled = (reason: unknown) => rejections.push(reason);
+    process.on('unhandledRejection', onUnhandled);
+    const spy = jest.spyOn(mockModule, 'useAuthStore', 'get').mockImplementationOnce(() => {
+      throw new Error('chunk load failed');
+    });
+
+    setState({ role: 'vet' });
+    render(<RoleProbe />);
+    await act(async () => {});
+    // Let any unhandled rejection be reported before asserting on it.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(screen.getByTestId('role')).toHaveTextContent('pending');
+    expect(listeners.size).toBe(0);
+    expect(rejections).toEqual([]);
+
+    process.off('unhandledRejection', onUnhandled);
+    spy.mockRestore();
+  });
+
+  it('drops back to the fallback when the caller disables it', async () => {
+    // Retaining the last slice would hand a revoked caller the previous
+    // session's auth state - PostHogUserSync would then identify analytics
+    // events to an account that has since signed out.
+    const Probe = ({ enabled }: { enabled: boolean }) => {
+      const role = useLazyAuthSlice(
+        selectRole as never,
+        'pending' as string | null,
+        Object.is,
+        enabled
+      );
+      return <span data-testid="role">{role ?? 'none'}</span>;
+    };
+
+    setState({ role: 'vet' });
+    const { rerender } = render(<Probe enabled />);
+    await waitFor(() => expect(screen.getByTestId('role')).toHaveTextContent('vet'));
+
+    await act(async () => {
+      rerender(<Probe enabled={false} />);
+    });
+
+    expect(screen.getByTestId('role')).toHaveTextContent('pending');
+    expect(listeners.size).toBe(0);
+
+    // Re-enabling must re-read rather than replay the value it held before.
+    setState({ role: 'nurse' });
+    await act(async () => {
+      rerender(<Probe enabled />);
+    });
+
+    expect(screen.getByTestId('role')).toHaveTextContent('nurse');
   });
 
   it('starts the session check only when the status is idle', async () => {

--- a/apps/frontend/src/app/__tests__/hooks/useLazyAuthStore.test.tsx
+++ b/apps/frontend/src/app/__tests__/hooks/useLazyAuthStore.test.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import {
+  ensureSessionChecked,
+  resetLazyAuthStoreForTests,
+  useLazyAuthSlice,
+} from '@/app/hooks/useLazyAuthStore';
+
+type FakeState = { status: string; role: string | null; checkSession: jest.Mock };
+
+const mockCheckSession = jest.fn();
+let state: FakeState;
+const listeners = new Set<() => void>();
+
+const setState = (partial: Partial<FakeState>) => {
+  state = { ...state, ...partial };
+  listeners.forEach((listener) => listener());
+};
+
+jest.mock('@/app/stores/authStore', () => ({
+  useAuthStore: {
+    getState: () => state,
+    subscribe: (listener: () => void) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+  },
+}));
+
+const selectRole = (s: unknown) => (s as FakeState).role;
+
+const RoleProbe = () => {
+  const role = useLazyAuthSlice(selectRole as never, 'pending' as string | null);
+  return <span data-testid="role">{role ?? 'none'}</span>;
+};
+
+describe('useLazyAuthStore', () => {
+  beforeEach(() => {
+    listeners.clear();
+    mockCheckSession.mockReset().mockResolvedValue(null);
+    state = { status: 'idle', role: null, checkSession: mockCheckSession };
+    resetLazyAuthStoreForTests();
+  });
+
+  it('returns the fallback until the auth store chunk has loaded', async () => {
+    render(<RoleProbe />);
+
+    // Synchronously after the first render the dynamic import has not resolved.
+    expect(screen.getByTestId('role')).toHaveTextContent('pending');
+
+    // Let the import settle so its state update lands inside act.
+    await act(async () => {});
+  });
+
+  it('swaps in the selected slice once the store loads', async () => {
+    setState({ role: 'developer' });
+
+    await act(async () => {
+      render(<RoleProbe />);
+    });
+
+    expect(screen.getByTestId('role')).toHaveTextContent('developer');
+  });
+
+  it('re-renders when the subscribed slice changes', async () => {
+    render(<RoleProbe />);
+    await waitFor(() => expect(screen.getByTestId('role')).toHaveTextContent('none'));
+
+    await act(async () => {
+      setState({ role: 'vet' });
+    });
+
+    expect(screen.getByTestId('role')).toHaveTextContent('vet');
+  });
+
+  it('does not re-render when the slice is unchanged', async () => {
+    // Counted in an effect rather than during render: an effect without deps
+    // runs after every committed render, so its length is the commit count.
+    const commits: (string | null)[] = [];
+    const CountingProbe = () => {
+      const role = useLazyAuthSlice(selectRole as never, null as string | null);
+      React.useEffect(() => {
+        commits.push(role);
+      });
+      return <span data-testid="role">{role ?? 'none'}</span>;
+    };
+
+    render(<CountingProbe />);
+    await waitFor(() => expect(screen.getByTestId('role')).toHaveTextContent('none'));
+    const before = commits.length;
+
+    await act(async () => {
+      setState({ status: 'unauthenticated' }); // role untouched
+    });
+
+    expect(commits.length).toBe(before);
+  });
+
+  it('unsubscribes on unmount', async () => {
+    const { unmount } = render(<RoleProbe />);
+    await waitFor(() => expect(listeners.size).toBe(1));
+
+    unmount();
+
+    expect(listeners.size).toBe(0);
+  });
+
+  it('starts the session check only when the status is idle', async () => {
+    await ensureSessionChecked();
+    expect(mockCheckSession).toHaveBeenCalledTimes(1);
+
+    setState({ status: 'authenticated' });
+    await ensureSessionChecked();
+
+    expect(mockCheckSession).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/frontend/src/app/__tests__/ui/layout/PostHogUserSync.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/layout/PostHogUserSync.test.tsx
@@ -16,8 +16,11 @@ jest.mock('posthog-js', () => ({
   },
 }));
 
-jest.mock('@/app/stores/authStore', () => ({
-  useAuthStore: (selector: (state: unknown) => unknown) => mockUseAuthStore(selector),
+// This component reads auth through the lazy seam so the root layout doesn't put
+// the SuperTokens stack in every public page's bundle. Mock the seam
+// synchronously; its async loading is covered by useLazyAuthStore.test.ts.
+jest.mock('@/app/hooks/useLazyAuthStore', () => ({
+  useLazyAuthSlice: (selector: (state: unknown) => unknown) => mockUseAuthStore(selector),
 }));
 
 describe('PostHogUserSync', () => {

--- a/apps/frontend/src/app/__tests__/ui/layout/PostHogUserSync.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/layout/PostHogUserSync.test.tsx
@@ -19,8 +19,17 @@ jest.mock('posthog-js', () => ({
 // This component reads auth through the lazy seam so the root layout doesn't put
 // the SuperTokens stack in every public page's bundle. Mock the seam
 // synchronously; its async loading is covered by useLazyAuthStore.test.ts.
+//
+// The `enabled` argument is honoured rather than ignored: returning the live
+// slice regardless would make this component look correct while consent is
+// revoked, which is exactly the state the real hook falls back in.
 jest.mock('@/app/hooks/useLazyAuthStore', () => ({
-  useLazyAuthSlice: (selector: (state: unknown) => unknown) => mockUseAuthStore(selector),
+  useLazyAuthSlice: <T,>(
+    selector: (state: unknown) => T,
+    initial: T,
+    _isEqual?: (a: T, b: T) => boolean,
+    enabled = true
+  ): T => (enabled ? (mockUseAuthStore(selector) as T) : initial),
 }));
 
 describe('PostHogUserSync', () => {
@@ -141,6 +150,55 @@ describe('PostHogUserSync', () => {
     });
 
     await waitFor(() => expect(posthog.reset).toHaveBeenCalledTimes(1));
+  });
+
+  it('does not identify the previous account when consent returns after a sign-out', async () => {
+    // Revoking consent disables the lazy auth slices, so they fall back. If they
+    // held their last value instead, re-consenting after the user switched
+    // accounts would attribute the new session's events to the old account.
+    globalThis.localStorage.setItem(COOKIE_CONSENT_KEY, 'true');
+    const asUser = (sub: string, status = 'authenticated') =>
+      mockUseAuthStore.mockImplementation((selector: (state: unknown) => unknown) =>
+        selector({ attributes: { sub, email: `${sub}@example.com` }, status })
+      );
+
+    asUser('user-sub-1');
+    render(<PostHogUserSync />);
+
+    act(() => {
+      (posthog as { __loaded?: boolean }).__loaded = true;
+      globalThis.dispatchEvent(new Event(POSTHOG_READY_EVENT));
+    });
+    await waitFor(() =>
+      expect(posthog.identify).toHaveBeenCalledWith('user-sub-1', {
+        email: 'user-sub-1@example.com',
+      })
+    );
+
+    act(() => {
+      globalThis.dispatchEvent(
+        new StorageEvent('storage', { key: COOKIE_CONSENT_KEY, newValue: 'false' })
+      );
+    });
+    await waitFor(() => expect(posthog.reset).toHaveBeenCalled());
+
+    // The visitor signs out and a different account signs in while analytics is off.
+    (posthog.identify as jest.Mock).mockClear();
+    asUser('user-sub-2');
+
+    act(() => {
+      globalThis.localStorage.setItem(COOKIE_CONSENT_KEY, 'true');
+      globalThis.dispatchEvent(
+        new StorageEvent('storage', { key: COOKIE_CONSENT_KEY, newValue: 'true' })
+      );
+    });
+
+    await waitFor(() =>
+      expect(posthog.identify).toHaveBeenCalledWith('user-sub-2', {
+        email: 'user-sub-2@example.com',
+      })
+    );
+    expect(posthog.identify).not.toHaveBeenCalledWith('user-sub-1', expect.anything());
   });
 
   it('uses email as a fallback distinct id', async () => {

--- a/apps/frontend/src/app/features/marketing/site/SiteNav.tsx
+++ b/apps/frontend/src/app/features/marketing/site/SiteNav.tsx
@@ -11,8 +11,8 @@ import {
 import Image from 'next/image';
 import Link from 'next/link';
 import { IoLogoGithub, IoMenuOutline, IoCloseOutline } from 'react-icons/io5';
-import { useShallow } from 'zustand/react/shallow';
-import { useAuthStore, type AuthUser } from '@/app/stores/authStore';
+import { ensureSessionChecked, useLazyAuthSlice } from '@/app/hooks/useLazyAuthStore';
+import type { AuthStore, AuthUser } from '@/app/stores/authStore';
 import { resolveDefaultOpenScreenRoute } from '@/app/lib/defaultOpenScreen';
 import { GITHUB_REPO_URL, MARKETING_LOGO } from './assets';
 import { useGithubStats } from './useGithubStats';
@@ -371,6 +371,16 @@ function useEscapeToClose(open: boolean, close: () => void): void {
   }, [open, close]);
 }
 
+type NavAuth = { status: AuthStore['status']; user: AuthUser | null; role: string | null };
+
+// What the nav renders before the auth store chunk has loaded: the same thing it
+// renders for a signed-out visitor, which is what an unauthenticated visitor -
+// the overwhelming majority on a marketing page - ends up seeing anyway.
+const IDLE_NAV_AUTH: NavAuth = { status: 'idle', user: null, role: null };
+const selectNavAuth = (s: AuthStore): NavAuth => ({ status: s.status, user: s.user, role: s.role });
+const isSameNavAuth = (a: NavAuth, b: NavAuth) =>
+  a.status === b.status && a.user === b.user && a.role === b.role;
+
 export function SiteNav({ active }: Readonly<SiteNavProps>) {
   const scrolled = useScrolled();
   const [menuOpen, setMenuOpen] = useState(false);
@@ -379,9 +389,7 @@ export function SiteNav({ active }: Readonly<SiteNavProps>) {
   const starsLabel = stars ? `★ ${stars}` : '★';
   const closeMenu = useCallback(() => setMenuOpen(false), []);
   const toggleMenu = useCallback(() => setMenuOpen((v) => !v), []);
-  const { status, user, role } = useAuthStore(
-    useShallow((s) => ({ status: s.status, user: s.user, role: s.role }))
-  );
+  const { status, user, role } = useLazyAuthSlice(selectNavAuth, IDLE_NAV_AUTH, isSameNavAuth);
   const defaultAppRoute =
     role === 'developer' ? '/developers/home' : resolveDefaultOpenScreenRoute(role);
 
@@ -392,7 +400,7 @@ export function SiteNav({ active }: Readonly<SiteNavProps>) {
   // so `user` resolves and the "Go to app" affordance is shown instead.
   useEffect(() => {
     if (status === 'idle') {
-      void useAuthStore.getState().checkSession();
+      void ensureSessionChecked();
     }
   }, [status]);
 

--- a/apps/frontend/src/app/hooks/useLazyAuthStore.ts
+++ b/apps/frontend/src/app/hooks/useLazyAuthStore.ts
@@ -1,0 +1,82 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import type { AuthStore } from '@/app/stores/authStore';
+
+// Importing the auth store pulls in the whole authenticated-app stack: six
+// SuperTokens recipes, the axios instance and the org store behind it. Public
+// pages need almost none of that - the marketing nav only wants to know whether
+// to say "Sign in" or "Go to app" - but a static import puts it in their entry
+// bundle anyway.
+//
+// These helpers load the store after hydration instead, so public routes ship
+// without it and fetch it in parallel with the session check it triggers. The
+// type import above is erased at build time and adds nothing to the bundle.
+let storeModulePromise: Promise<typeof import('@/app/stores/authStore')> | null = null;
+
+const loadAuthStoreModule = () => (storeModulePromise ??= import('@/app/stores/authStore'));
+
+/**
+ * Subscribe to a slice of the auth store without importing it eagerly.
+ *
+ * Returns `initial` until the store chunk has loaded, then the selected slice,
+ * re-rendering only when `isEqual` says the slice actually changed.
+ */
+export function useLazyAuthSlice<T>(
+  select: (state: AuthStore) => T,
+  initial: T,
+  isEqual: (a: T, b: T) => boolean = Object.is
+): T {
+  const [value, setValue] = useState<T>(initial);
+  const selectRef = useRef(select);
+  const isEqualRef = useRef(isEqual);
+
+  // No dep array: refresh the closures after every render, before the
+  // subscribing effect below (declaration order) ever reads them.
+  useEffect(() => {
+    selectRef.current = select;
+    isEqualRef.current = isEqual;
+  });
+
+  useEffect(() => {
+    let active = true;
+    let unsubscribe: (() => void) | undefined;
+
+    void loadAuthStoreModule().then(({ useAuthStore }) => {
+      if (!active) return;
+      const read = () =>
+        setValue((previous) => {
+          const next = selectRef.current(useAuthStore.getState());
+          return isEqualRef.current(previous, next) ? previous : next;
+        });
+
+      read();
+      unsubscribe = useAuthStore.subscribe(read);
+    });
+
+    return () => {
+      active = false;
+      unsubscribe?.();
+    };
+  }, []);
+
+  return value;
+}
+
+/**
+ * Kick off the SuperTokens session check if nothing has done so yet.
+ *
+ * Public pages do not otherwise bootstrap it, so an already authenticated
+ * visitor would keep being shown the signed-out affordances.
+ */
+export const ensureSessionChecked = async (): Promise<void> => {
+  const { useAuthStore } = await loadAuthStoreModule();
+  if (useAuthStore.getState().status !== 'idle') return;
+  await useAuthStore.getState().checkSession();
+};
+
+// Test seam: the cached module promise is module-level state that a jest
+// module-registry reset does not clear.
+export const resetLazyAuthStoreForTests = (): void => {
+  storeModulePromise = null;
+};

--- a/apps/frontend/src/app/hooks/useLazyAuthStore.ts
+++ b/apps/frontend/src/app/hooks/useLazyAuthStore.ts
@@ -14,7 +14,17 @@ import type { AuthStore } from '@/app/stores/authStore';
 // type import above is erased at build time and adds nothing to the bundle.
 let storeModulePromise: Promise<typeof import('@/app/stores/authStore')> | null = null;
 
-const loadAuthStoreModule = () => (storeModulePromise ??= import('@/app/stores/authStore'));
+const loadAuthStoreModule = () => {
+  // On failure the cached promise is cleared, so a later subscription or session
+  // check retries. Caching a rejected promise would strand an authenticated
+  // visitor on the signed-out UI for the life of the page after one flaky chunk
+  // fetch or a deploy that moved the file.
+  storeModulePromise ??= import('@/app/stores/authStore').catch((error) => {
+    storeModulePromise = null;
+    throw error;
+  });
+  return storeModulePromise;
+};
 
 /**
  * Subscribe to a slice of the auth store without importing it eagerly.
@@ -25,7 +35,11 @@ const loadAuthStoreModule = () => (storeModulePromise ??= import('@/app/stores/a
 export function useLazyAuthSlice<T>(
   select: (state: AuthStore) => T,
   initial: T,
-  isEqual: (a: T, b: T) => boolean = Object.is
+  isEqual: (a: T, b: T) => boolean = Object.is,
+  // Loading the store is the expensive part, so a caller that cannot use the
+  // value yet should not trigger it. Passing false keeps the fallback and fetches
+  // nothing; flipping it to true subscribes then.
+  enabled = true
 ): T {
   const [value, setValue] = useState<T>(initial);
   const selectRef = useRef(select);
@@ -39,6 +53,8 @@ export function useLazyAuthSlice<T>(
   });
 
   useEffect(() => {
+    if (!enabled) return undefined;
+
     let active = true;
     let unsubscribe: (() => void) | undefined;
 
@@ -58,7 +74,7 @@ export function useLazyAuthSlice<T>(
       active = false;
       unsubscribe?.();
     };
-  }, []);
+  }, [enabled]);
 
   return value;
 }

--- a/apps/frontend/src/app/hooks/useLazyAuthStore.ts
+++ b/apps/frontend/src/app/hooks/useLazyAuthStore.ts
@@ -44,31 +44,49 @@ export function useLazyAuthSlice<T>(
   const [value, setValue] = useState<T>(initial);
   const selectRef = useRef(select);
   const isEqualRef = useRef(isEqual);
+  const initialRef = useRef(initial);
 
   // No dep array: refresh the closures after every render, before the
   // subscribing effect below (declaration order) ever reads them.
   useEffect(() => {
     selectRef.current = select;
     isEqualRef.current = isEqual;
+    initialRef.current = initial;
   });
 
   useEffect(() => {
-    if (!enabled) return undefined;
+    if (!enabled) {
+      // Drop back to the fallback rather than keeping the last slice read. A
+      // caller disables this hook because it is no longer entitled to the value
+      // - PostHogUserSync does it when analytics consent is revoked - and
+      // retaining it would hand back the previous session's auth state. If the
+      // user then signs out and re-consents, the stale value would identify
+      // analytics events to the account that just left.
+      setValue(initialRef.current);
+      return undefined;
+    }
 
     let active = true;
     let unsubscribe: (() => void) | undefined;
 
-    void loadAuthStoreModule().then(({ useAuthStore }) => {
-      if (!active) return;
-      const read = () =>
-        setValue((previous) => {
-          const next = selectRef.current(useAuthStore.getState());
-          return isEqualRef.current(previous, next) ? previous : next;
-        });
+    loadAuthStoreModule()
+      .then(({ useAuthStore }) => {
+        if (!active) return;
+        const read = () =>
+          setValue((previous) => {
+            const next = selectRef.current(useAuthStore.getState());
+            return isEqualRef.current(previous, next) ? previous : next;
+          });
 
-      read();
-      unsubscribe = useAuthStore.subscribe(read);
-    });
+        read();
+        unsubscribe = useAuthStore.subscribe(read);
+      })
+      // A failed chunk fetch leaves the caller on its fallback, which is the
+      // signed-out affordance - degraded but correct. Swallowing it here is what
+      // keeps it from surfacing as an unhandled rejection; loadAuthStoreModule
+      // has already dropped the cached promise, so the next mount or `enabled`
+      // flip fetches again rather than replaying the failure.
+      .catch(() => {});
 
     return () => {
       active = false;
@@ -84,11 +102,20 @@ export function useLazyAuthSlice<T>(
  *
  * Public pages do not otherwise bootstrap it, so an already authenticated
  * visitor would keep being shown the signed-out affordances.
+ *
+ * Best-effort, and never rejects: every caller is fire-and-forget (`void
+ * ensureSessionChecked()`), so a rejection here would be unhandled. If the chunk
+ * or the session check fails the visitor keeps the signed-out affordances, and
+ * the cleared module cache means the next caller retries.
  */
 export const ensureSessionChecked = async (): Promise<void> => {
-  const { useAuthStore } = await loadAuthStoreModule();
-  if (useAuthStore.getState().status !== 'idle') return;
-  await useAuthStore.getState().checkSession();
+  try {
+    const { useAuthStore } = await loadAuthStoreModule();
+    if (useAuthStore.getState().status !== 'idle') return;
+    await useAuthStore.getState().checkSession();
+  } catch {
+    // Intentionally swallowed - see the contract above.
+  }
 };
 
 // Test seam: the cached module promise is module-level state that a jest

--- a/apps/frontend/src/app/stores/authStore.ts
+++ b/apps/frontend/src/app/stores/authStore.ts
@@ -63,7 +63,7 @@ type UserProfileResponse = {
   lastName?: string;
 };
 
-type AuthStore = {
+export type AuthStore = {
   user: AuthUser | null;
   attributes: Record<string, string> | null;
   status: Status;

--- a/apps/frontend/src/app/ui/layout/PostHogUserSync.tsx
+++ b/apps/frontend/src/app/ui/layout/PostHogUserSync.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { getStorageItem } from '@/app/lib/browserStorage';
 import { COOKIE_CONSENT_KEY, POSTHOG_READY_EVENT } from '@/app/lib/posthog';
 import { getLoadedPostHog } from '@/app/lib/posthogClient';
@@ -28,10 +28,14 @@ const selectStatus = (state: AuthStore) => state.status;
 
 const PostHogUserSync = () => {
   // Mounted in the root layout, so importing the auth store here would put the
-  // SuperTokens stack in every public page's bundle. Nothing is identified until
-  // analytics is both consented and ready, so loading it lazily costs nothing.
-  const attributes = useLazyAuthSlice(selectAttributes, null);
-  const status = useLazyAuthSlice(selectStatus, 'idle');
+  // SuperTokens stack on every route. Lazy-loading alone is not enough: the
+  // subscription would still fetch that chunk after hydration for every public
+  // visitor, including the ones who never consent. Nothing here can identify
+  // anyone until analytics is both consented and running, so the auth store is
+  // not fetched until then either.
+  const [analyticsActive, setAnalyticsActive] = useState(false);
+  const attributes = useLazyAuthSlice(selectAttributes, null, Object.is, analyticsActive);
+  const status = useLazyAuthSlice(selectStatus, 'idle', Object.is, analyticsActive);
   const identifiedIdRef = useRef<string | null>(null);
   const consentedRef = useRef(false);
   const readyRef = useRef(false);
@@ -84,16 +88,22 @@ const PostHogUserSync = () => {
   useEffect(() => {
     consentedRef.current = hasConsent();
     readyRef.current = isPostHogLoaded();
+    // Mirrors the refs into state, which is what actually releases the auth
+    // store fetch above.
+    const refreshActive = () => setAnalyticsActive(consentedRef.current && readyRef.current);
+    refreshActive();
     syncIdentityRef.current();
 
     const onStorage = (event: StorageEvent) => {
       if (event.key === COOKIE_CONSENT_KEY) {
         consentedRef.current = event.newValue === 'true';
+        refreshActive();
         syncIdentityRef.current();
       }
     };
     const onPostHogReady = () => {
       readyRef.current = true;
+      refreshActive();
       syncIdentityRef.current();
     };
 

--- a/apps/frontend/src/app/ui/layout/PostHogUserSync.tsx
+++ b/apps/frontend/src/app/ui/layout/PostHogUserSync.tsx
@@ -4,7 +4,8 @@ import { useEffect, useRef } from 'react';
 import { getStorageItem } from '@/app/lib/browserStorage';
 import { COOKIE_CONSENT_KEY, POSTHOG_READY_EVENT } from '@/app/lib/posthog';
 import { getLoadedPostHog } from '@/app/lib/posthogClient';
-import { useAuthStore } from '@/app/stores/authStore';
+import { useLazyAuthSlice } from '@/app/hooks/useLazyAuthStore';
+import type { AuthStore } from '@/app/stores/authStore';
 
 const hasConsent = () => getStorageItem('local', COOKIE_CONSENT_KEY) === 'true';
 // Null until PostHogBootstrap has loaded the analytics chunk, which only happens
@@ -22,9 +23,15 @@ const addDefinedValue = (
   }
 };
 
+const selectAttributes = (state: AuthStore) => state.attributes;
+const selectStatus = (state: AuthStore) => state.status;
+
 const PostHogUserSync = () => {
-  const attributes = useAuthStore((state) => state.attributes);
-  const status = useAuthStore((state) => state.status);
+  // Mounted in the root layout, so importing the auth store here would put the
+  // SuperTokens stack in every public page's bundle. Nothing is identified until
+  // analytics is both consented and ready, so loading it lazily costs nothing.
+  const attributes = useLazyAuthSlice(selectAttributes, null);
+  const status = useLazyAuthSlice(selectStatus, 'idle');
   const identifiedIdRef = useRef<string | null>(null);
   const consentedRef = useRef(false);
   const readyRef = useRef(false);


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

> Stacked on #2157, so it is based on `perf/lazy-posthog` rather than `dev`. Retarget to `dev` once that merges. Only the last commit belongs to this PR.

## What is the current behavior?

Importing the auth store pulls in the entire authenticated-app stack: six SuperTokens recipes, the axios instance, and the org store behind it. Two components put it in every public page's entry bundle:

- `SiteNav`, so the marketing nav can render "Sign in" versus "Go to app".
- `PostHogUserSync`, which is mounted in the root layout and therefore reaches every route.

So an anonymous visitor to the marketing site downloads and parses the whole sign-in stack in order to render one nav button.

This is fix 3b of the workstream in #2155.

## What is the new behavior?

A small `useLazyAuthStore` seam:

- `useLazyAuthSlice(select, initial, isEqual?)` imports the store after hydration, subscribes to a selected slice, and returns `initial` until it lands. It re-renders only when the selected slice actually changes.
- `ensureSessionChecked()` starts the SuperTokens session check that public pages otherwise never bootstrap.

Both components now read auth through it. The type-only imports are erased at build time and add nothing to the bundle.

Rendering is unchanged. The nav already rendered the signed-out state until the session check resolved, so the only difference is that the store chunk is fetched in parallel with the check it triggers, instead of sitting in the entry bundle.

## Related Issue(s)

Part of #2155

## Impact area

`apps/frontend`. `AuthStore` is now an exported type; there are no runtime changes to the store itself.

## Validation performed

- `pnpm --filter frontend run type-check`, exit 0.
- `pnpm --filter frontend run lint`, exit 0.
- `pnpm --filter frontend run test --testPathPatterns="useLazyAuthStore|SiteNav|PostHog|posthog|marketing"`: 22 suites, 161 tests passed, exit 0.
- New `useLazyAuthStore.ts`: 100% statements, functions and lines, 93.3% branches. The uncovered branch is the unmount-before-import-resolves race guard.
- Aikido SAST and secrets scan on the new hook: no issues.
- Production build, exit 0.

### Measured bundle effect

The first-load JS for the marketing home page is the union of the `/layout`, `/(routes)/(public)/layout` and `/(routes)/(public)/page` entries in `app-build-manifest.json`. Baseline is a build of `origin/dev`:

| | chunks | raw | gzipped | SuperTokens chunk | posthog vendor chunk |
| --- | --- | --- | --- | --- | --- |
| origin/dev | 15 | 1394KB | 378KB | present | present |
| this branch (with #2157) | 13 | 653KB | 185KB | absent | absent |

193KB gzipped off the marketing home page's first-load JS, a little over half. The same holds for `/pricing` and `/about`. Both vendor chunks are still emitted and load on demand.

Splitting the credit honestly: this is the combined effect of #2157 and this PR. The posthog vendor chunk accounts for 76KB gz of it; the rest is the SuperTokens and org-store graph this PR removes.

## Notes for the reviewer

`resetLazyAuthStoreForTests` exists because the cached module promise is module-level state that a jest module-registry reset does not clear. It is only referenced from tests.

Component tests mock the seam synchronously and the hook's own async loading is covered directly in `useLazyAuthStore.test.tsx`, which keeps the `act()` handling in one place rather than spread across every component that reads auth.

A tradeoff worth naming: a signed-in visitor landing on a marketing page now sees "Sign in" for one extra chunk fetch before it flips to "Go to app". That flash already existed, because the nav rendered the signed-out state until the cross-origin session check resolved; this makes the window slightly longer, in exchange for every anonymous visitor not downloading the sign-in stack.
