### PR TITLE
perf(frontend): warm the API connection and stop busting the finance cache

### DIFF
--- a/apps/frontend/src/app/__tests__/services/invoiceService.test.ts
+++ b/apps/frontend/src/app/__tests__/services/invoiceService.test.ts
@@ -78,10 +78,8 @@ describe('invoiceService', () => {
     expect(invoiceState.startLoading).toHaveBeenCalled();
     expect(getData).toHaveBeenCalledWith(
       '/v1/finance/invoices',
-      expect.objectContaining({
-        organisationId: 'org-1',
-        _cacheBust: expect.any(Number),
-      })
+      { organisationId: 'org-1' },
+      { dedupe: false }
     );
     expect(invoiceState.setInvoicesForOrg).toHaveBeenCalledWith('org-1', []);
   });
@@ -419,11 +417,8 @@ describe('invoiceService', () => {
 
     expect(getData).toHaveBeenCalledWith(
       '/v1/finance/invoices',
-      expect.objectContaining({
-        organisationId: 'org-1',
-        appointmentId: 'apt-1',
-        _cacheBust: expect.any(Number),
-      })
+      { organisationId: 'org-1', appointmentId: 'apt-1' },
+      { dedupe: false }
     );
     expect(invoiceState.upsertInvoice).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'inv-1', appointmentId: 'apt-1' })
@@ -1205,11 +1200,8 @@ describe('invoiceService', () => {
 
     expect(getData).toHaveBeenCalledWith(
       '/v1/finance/invoices',
-      expect.objectContaining({
-        organisationId: 'org-1',
-        appointmentId: 'appt-1',
-        _cacheBust: expect.any(Number),
-      })
+      { organisationId: 'org-1', appointmentId: 'appt-1' },
+      { dedupe: false }
     );
     expect(billing.pastInvoices).toHaveLength(1);
     expect(billing.pastInvoices[0].items.map((item) => item.name)).toEqual([
@@ -1244,7 +1236,8 @@ describe('invoiceService', () => {
 
       expect(getData).toHaveBeenCalledWith(
         '/v1/finance/invoices',
-        expect.objectContaining({ organisationId: 'org-1', appointmentId: 'appt-1' })
+        { organisationId: 'org-1', appointmentId: 'appt-1' },
+        { dedupe: false }
       );
       expect(invoiceState.upsertInvoice).toHaveBeenCalledTimes(1);
     });

--- a/apps/frontend/src/app/features/billing/services/invoiceService.ts
+++ b/apps/frontend/src/app/features/billing/services/invoiceService.ts
@@ -103,14 +103,14 @@ const FINANCE_BASE_PATH = '/v1/finance';
 const APPOINTMENT_ID_EXTENSION_URL =
   'https://yosemitecrew.com/fhir/StructureDefinition/appointment-id';
 
-const withFreshFinanceParams = <T extends Record<string, unknown>>(
-  params: T
-): T & {
-  _cacheBust: number;
-} => ({
-  ...params,
-  _cacheBust: Date.now(),
-});
+// Finance reads must never come back stale, but a `Date.now()` query parameter
+// was an expensive way to guarantee it: a unique URL per call misses the CORS
+// preflight cache (so every read pays an extra round trip), defeats the
+// in-flight GET dedupe, and prevents conditional revalidation. The API sets no
+// Cache-Control on these responses, so freshness is already guaranteed; the only
+// thing worth keeping is not piggybacking on an older in-flight request, which
+// `dedupe: false` expresses directly.
+const FRESH_FINANCE_READ = { dedupe: false } as const;
 
 const normalizeReferenceTail = (value: unknown): string | undefined => {
   let raw = '';
@@ -311,9 +311,8 @@ export const loadInvoicesForOrgPrimaryOrg = async (opts?: {
   try {
     const res = await getData<FinanceEnvelope<unknown[]> | unknown[]>(
       `${FINANCE_BASE_PATH}/invoices`,
-      withFreshFinanceParams({
-        organisationId: primaryOrgId,
-      })
+      { organisationId: primaryOrgId },
+      FRESH_FINANCE_READ
     );
     const invoicePayload = unwrapFinanceData(res.data) ?? [];
     const invoices = invoicePayload.map((invoice) =>
@@ -341,10 +340,8 @@ export const loadInvoicesForAppointment = async (appointmentId: string): Promise
   try {
     const res = await getData<FinanceEnvelope<unknown[]> | unknown[]>(
       `${FINANCE_BASE_PATH}/invoices`,
-      withFreshFinanceParams({
-        organisationId: primaryOrgId,
-        appointmentId,
-      })
+      { organisationId: primaryOrgId, appointmentId },
+      FRESH_FINANCE_READ
     );
     const invoicePayload = unwrapFinanceData(res.data) ?? [];
     const invoices = invoicePayload.map((invoice) =>
@@ -427,7 +424,8 @@ export const loadAppointmentBilling = async (
 
   const res = await getData<FinanceEnvelope<unknown[]> | unknown[]>(
     `${FINANCE_BASE_PATH}/invoices`,
-    withFreshFinanceParams({ organisationId, appointmentId })
+    { organisationId, appointmentId },
+    FRESH_FINANCE_READ
   );
   const invoicePayload = unwrapFinanceData(res.data) ?? [];
   // The backend scopes `GET /invoices?organisationId&appointmentId` to the

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -23,6 +23,20 @@ import RouteAnnouncer from '@/app/ui/layout/RouteAnnouncer';
 import SkipLink from '@/app/ui/layout/SkipLink';
 import Cookies from '@/app/ui/widgets/Cookies/Cookies';
 
+// The API lives on its own origin, so only its origin (not the full base path)
+// is useful to preconnect. An unset or malformed value simply skips the hint.
+const resolveApiOrigin = (): string | null => {
+  const base = process.env.NEXT_PUBLIC_BASE_URL;
+  if (!base) return null;
+  try {
+    return new URL(base).origin;
+  } catch {
+    return null;
+  }
+};
+
+const apiOrigin = resolveApiOrigin();
+
 export const metadata: Metadata = {
   title: 'Yosemite Crew',
   description: 'Get Yosemite Crew for your pet business',
@@ -52,6 +66,18 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning className={newsreader.variable}>
+      <head>
+        {/* The session check is the first thing the app does after hydration and
+            it goes cross-origin to the API, so the DNS lookup, TCP handshake and
+            TLS negotiation all sit on the critical path. Warming the connection
+            while the document is still parsing takes them off it. */}
+        {apiOrigin ? (
+          <>
+            <link rel="preconnect" href={apiOrigin} crossOrigin="use-credentials" />
+            <link rel="dns-prefetch" href={apiOrigin} />
+          </>
+        ) : null}
+      </head>
       <body>
         <SkipLink />
         <Cookies />


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

Two independent costs on the way to first content.

**No connection warm-up for the API.** The app's first act after hydration is a cross-origin session check against the API origin, so the DNS lookup, TCP handshake and TLS negotiation all sit on the critical path before that request can even start. There is no `preconnect` or `dns-prefetch` anywhere in the app. On a live dev trace, `auth/session/refresh` took 1110ms.

**Finance reads bust their own cache.** Every finance invoice read appended `_cacheBust: Date.now()`:

```ts
const withFreshFinanceParams = (params) => ({ ...params, _cacheBust: Date.now() });
```

A unique URL per call means:

- it misses the CORS preflight cache, so every read pays an extra preflight round trip (these are credentialed cross-origin requests with a custom `x-org-id` header, and the API returns `Access-Control-Max-Age: 86400`, which the changing URL makes useless);
- it defeats the in-flight GET dedupe in the axios layer;
- it prevents conditional revalidation, so a full body comes back every time.

This is fix 2 of the workstream in #2155.

## What is the new behavior?

**Preconnect.** The root layout emits `preconnect` and `dns-prefetch` for the API origin while the document is still parsing. The origin is derived from `NEXT_PUBLIC_BASE_URL`; an unset or malformed value simply skips the hint rather than emitting a broken one. `crossOrigin="use-credentials"` matches how the API is actually called, so the warmed connection is the one that gets reused.

**Finance reads.** `_cacheBust` is gone. The API sets no `Cache-Control` on these responses (verified in the backend source and against the live API, which returns only an `ETag`), so freshness never depended on that parameter. The calls now pass `dedupe: false` instead, which states the one property that was actually wanted: never piggyback on an older in-flight request, for example one that started before a mutation. Preflight caching, conditional revalidation and stable URLs all come back.

## Related Issue(s)

Part of #2155

## Impact area

`apps/frontend`. No API, schema or rendering changes.

## Validation performed

- `pnpm --filter frontend run type-check`, exit 0.
- `pnpm --filter frontend run lint`, exit 0.
- `pnpm --filter frontend run test --testPathPatterns="invoiceService|invoice|layout|securityHeaders"`: 55 suites, 592 tests passed, exit 0.
- The four `invoiceService` assertions that pinned the `_cacheBust` parameter now assert the new call shape, including the `dedupe: false` option.

## Notes for the reviewer

I looked at the three duplicated bootstrap fetches flagged in #2155 (`loadOrgs`, `loadProfiles` and `loadAvailability` are called both by their loader hooks and again inside the `Promise.allSettled` block in `SessionInitializer`) and deliberately left them alone. Both paths fire in the same commit when `primaryOrgId` changes, so the axios in-flight GET dedupe already collapses them into one request each. Removing them would change org-refresh semantics for no measurable network saving, which is not a trade worth making in a performance PR. The genuinely expensive part of that block is the 13-request unpaginated fan-out itself, which is the structural work tracked separately in #2155.
