### PR TITLE
perf(backend): batch the staff-on-duty lookup instead of querying per member

### DIFF
--- a/apps/backend/src/services/availability.service.ts
+++ b/apps/backend/src/services/availability.service.ts
@@ -219,6 +219,107 @@ export function generateBookableWindows(
   return results;
 }
 
+type WeekSlotSource = { dayOfWeek: DayOfWeek; slots: AvailabilitySlotMongo[] };
+type OccupancyWindow = { startTime: Date; endTime: Date };
+
+/** Monday-anchored (UTC) week containing `referenceDate`, plus its seven days. */
+const resolveWeekBounds = (referenceDate: Date) => {
+  const weekStart = dayjs(referenceDate)
+    .utc()
+    .startOf("week") // Sunday
+    .add(1, "day") // => Monday
+    .startOf("day")
+    .toDate();
+
+  const weekDates = Array.from({ length: 7 }).map((_, i) => {
+    const d = dayjs(weekStart).add(i, "day").toDate();
+    return {
+      date: d,
+      dateStr: getDateString(d),
+      dayOfWeek: getDayOfWeekFromDate(d),
+    };
+  });
+
+  return { weekStart, weekDates };
+};
+
+/**
+ * Merge one user's base availability, weekly override and occupancies into the
+ * final week. Pure: the caller decides how the three inputs were fetched, which
+ * is what lets a single user and a whole roster share this logic verbatim.
+ */
+const computeWeekAvailability = (
+  weekDates: ReturnType<typeof resolveWeekBounds>["weekDates"],
+  base: WeekSlotSource[],
+  override: { overrides: WeekSlotSource[] } | null,
+  occupancies: OccupancyWindow[],
+) => {
+  // Convert base into map: { MONDAY → [...slots] }
+  const map = new Map<DayOfWeek, AvailabilitySlotMongo[]>();
+
+  for (const row of base) {
+    map.set(row.dayOfWeek, row.slots);
+  }
+
+  if (override) {
+    for (const ov of override.overrides) {
+      map.set(ov.dayOfWeek, ov.slots);
+    }
+  }
+
+  // Now remove overlapping slots
+  for (const occ of occupancies) {
+    const occStart = dayjs(occ.startTime).utc();
+    const occEnd = dayjs(occ.endTime).utc();
+
+    // Which day does occupancy belong to?
+    const occDayStr = occStart.format("dddd").toUpperCase() as DayOfWeek;
+
+    // Get that day's availability
+    const slots = map.get(occDayStr) || [];
+    const dateStr = occStart.format("YYYY-MM-DD");
+
+    const newSlots: AvailabilitySlotMongo[] = [];
+
+    for (const slot of slots) {
+      const split = splitSlotAroundOccupancy(slot, occStart, occEnd, dateStr);
+      newSlots.push(...split);
+    }
+
+    map.set(occDayStr, newSlots);
+  }
+
+  // Build final return structure
+  return weekDates.map((w) => ({
+    date: w.dateStr,
+    dayOfWeek: w.dayOfWeek,
+    slots: map.get(w.dayOfWeek) || [],
+  }));
+};
+
+/** Same rule getCurrentStatus applies, over already-resolved inputs. */
+const resolveStatusFromSlots = (
+  nowUtc: dayjs.Dayjs,
+  date: string,
+  slots: AvailabilitySlotMongo[],
+  isOccupiedNow: boolean,
+): "Consulting" | "Available" | "Off-Duty" | "Unavailable" => {
+  if (isOccupiedNow) return "Consulting";
+
+  const activeSlot = slots.some((s) => {
+    const slotStart = dayjs.utc(`${date}T${s.startTime}:00`);
+    const slotEnd = dayjs.utc(`${date}T${s.endTime}:00`);
+    const startsNowOrEarlier =
+      nowUtc.isSame(slotStart) || nowUtc.isAfter(slotStart);
+    return startsNowOrEarlier && nowUtc.isBefore(slotEnd);
+  });
+
+  if (activeSlot) return "Available";
+  if (slots.length === 0) return "Off-Duty";
+
+  return "Unavailable";
+};
+
 export const AvailabilityService = {
   // Base Availabilites
 
@@ -506,32 +607,10 @@ export const AvailabilityService = {
     const safeUserId = ensureNonEmptyString(userId, "userId");
     const safeReferenceDate = ensureValidDate(referenceDate, "referenceDate");
 
-    // Always calculate week starting Monday (UTC)
-    const weekStart = dayjs(safeReferenceDate)
-      .utc()
-      .startOf("week") // Sunday
-      .add(1, "day") // => Monday
-      .startOf("day")
-      .toDate();
-
-    const weekDates = Array.from({ length: 7 }).map((_, i) => {
-      const d = dayjs(weekStart).add(i, "day").toDate();
-      return {
-        date: d,
-        dateStr: getDateString(d),
-        dayOfWeek: getDayOfWeekFromDate(d),
-      };
-    });
+    const { weekStart, weekDates } = resolveWeekBounds(safeReferenceDate);
 
     // Load base availability
     const base = await this.getBaseAvailability(safeOrganisationId, safeUserId);
-
-    // Convert base into map: { MONDAY → [...slots] }
-    const map = new Map<DayOfWeek, AvailabilitySlotMongo[]>();
-
-    for (const row of base) {
-      map.set(row.dayOfWeek, row.slots);
-    }
 
     // Load weekly override (if exists)
     const override = await this.getWeeklyAvailabilityOverride(
@@ -539,12 +618,6 @@ export const AvailabilityService = {
       safeUserId,
       weekStart,
     );
-
-    if (override) {
-      for (const ov of override.overrides) {
-        map.set(ov.dayOfWeek, ov.slots);
-      }
-    }
 
     // Load occupancies for the week
     const weekEnd = dayjs(weekStart).add(7, "day").endOf("day").toDate();
@@ -558,34 +631,7 @@ export const AvailabilityService = {
       },
     });
 
-    // Now remove overlapping slots
-    for (const occ of occupancies) {
-      const occStart = dayjs(occ.startTime).utc();
-      const occEnd = dayjs(occ.endTime).utc();
-
-      // Which day does occupancy belong to?
-      const occDayStr = occStart.format("dddd").toUpperCase() as DayOfWeek;
-
-      // Get that day's availability
-      const slots = map.get(occDayStr) || [];
-      const dateStr = occStart.format("YYYY-MM-DD");
-
-      const newSlots: AvailabilitySlotMongo[] = [];
-
-      for (const slot of slots) {
-        const split = splitSlotAroundOccupancy(slot, occStart, occEnd, dateStr);
-        newSlots.push(...split);
-      }
-
-      map.set(occDayStr, newSlots);
-    }
-
-    // Build final return structure
-    return weekDates.map((w) => ({
-      date: w.dateStr,
-      dayOfWeek: w.dayOfWeek,
-      slots: map.get(w.dayOfWeek) || [],
-    }));
+    return computeWeekAvailability(weekDates, base, override, occupancies);
   },
 
   async getFinalAvailabilityForDate(
@@ -642,20 +688,119 @@ export const AvailabilityService = {
       select: { id: true },
     });
 
-    if (occupied) return "Consulting";
+    return resolveStatusFromSlots(nowUtc, date, slots, Boolean(occupied));
+  },
 
-    const activeSlot = slots.some((s) => {
-      const slotStart = dayjs.utc(`${date}T${s.startTime}:00`);
-      const slotEnd = dayjs.utc(`${date}T${s.endTime}:00`);
-      const startsNowOrEarlier =
-        nowUtc.isSame(slotStart) || nowUtc.isAfter(slotStart);
-      return startsNowOrEarlier && nowUtc.isBefore(slotEnd);
-    });
+  /**
+   * `getCurrentStatus` for a whole roster in a fixed number of queries.
+   *
+   * Called per user it costs 4 sequential queries each, so a dashboard tile for
+   * a 20-person clinic issued 80 of them. This fetches the same four datasets
+   * once for every user and applies the identical merge and status rules in
+   * memory, so the result matches the per-user call by construction.
+   */
+  async getCurrentStatusBulk(
+    organisationId: string,
+    userIds: string[],
+  ): Promise<
+    Map<string, "Consulting" | "Available" | "Off-Duty" | "Unavailable">
+  > {
+    const safeOrganisationId = ensureNonEmptyString(
+      organisationId,
+      "organisationId",
+    );
+    const ids = Array.from(
+      new Set(userIds.map((id) => asNonEmptyString(id)).filter(Boolean)),
+    ) as string[];
 
-    if (activeSlot) return "Available";
-    if (slots.length === 0) return "Off-Duty";
+    const statuses = new Map<
+      string,
+      "Consulting" | "Available" | "Off-Duty" | "Unavailable"
+    >();
+    if (ids.length === 0) return statuses;
 
-    return "Unavailable";
+    const nowUtc = dayjs.utc();
+    const now = nowUtc.toDate();
+    const { weekStart, weekDates } = resolveWeekBounds(now);
+    const weekEnd = dayjs(weekStart).add(7, "day").endOf("day").toDate();
+
+    const [baseRows, overrideRows, weekOccupancies, currentOccupancies] =
+      await Promise.all([
+        prisma.baseAvailability.findMany({
+          where: { organisationId: safeOrganisationId, userId: { in: ids } },
+          orderBy: { dayOfWeek: "asc" },
+        }),
+        prisma.weeklyAvailabilityOverride.findMany({
+          where: {
+            organisationId: safeOrganisationId,
+            userId: { in: ids },
+            weekStartDate: normalizeWeekStart(weekStart),
+          },
+        }),
+        prisma.occupancy.findMany({
+          where: {
+            organisationId: safeOrganisationId,
+            userId: { in: ids },
+            startTime: { lte: weekEnd },
+            endTime: { gte: weekStart },
+          },
+        }),
+        prisma.occupancy.findMany({
+          where: {
+            organisationId: safeOrganisationId,
+            userId: { in: ids },
+            startTime: { lte: now },
+            endTime: { gte: now },
+          },
+          select: { userId: true },
+        }),
+      ]);
+
+    const groupByUser = <T extends { userId: string }>(rows: T[]) => {
+      const grouped = new Map<string, T[]>();
+      for (const row of rows) {
+        const existing = grouped.get(row.userId);
+        if (existing) existing.push(row);
+        else grouped.set(row.userId, [row]);
+      }
+      return grouped;
+    };
+
+    const baseByUser = groupByUser(baseRows);
+    const overrideByUser = groupByUser(overrideRows);
+    const occupancyByUser = groupByUser(weekOccupancies);
+    const occupiedNow = new Set(currentOccupancies.map((row) => row.userId));
+
+    const dayOfWeek = getDayOfWeekFromDate(now);
+    const dateStr = getDateString(now);
+
+    for (const id of ids) {
+      const base = (baseByUser.get(id) ?? []).map((row) => ({
+        dayOfWeek: row.dayOfWeek,
+        slots: row.slots as unknown as AvailabilitySlotMongo[],
+      }));
+      const overrideRow = overrideByUser.get(id)?.[0];
+      const override = overrideRow
+        ? {
+            overrides: overrideRow.overrides as unknown as WeekSlotSource[],
+          }
+        : null;
+
+      const week = computeWeekAvailability(
+        weekDates,
+        base,
+        override,
+        occupancyByUser.get(id) ?? [],
+      );
+      const slots = week.find((d) => d.dayOfWeek === dayOfWeek)?.slots ?? [];
+
+      statuses.set(
+        id,
+        resolveStatusFromSlots(nowUtc, dateStr, slots, occupiedNow.has(id)),
+      );
+    }
+
+    return statuses;
   },
 
   // Get Bookable slots

--- a/apps/backend/src/services/availability.service.ts
+++ b/apps/backend/src/services/availability.service.ts
@@ -710,8 +710,13 @@ export const AvailabilityService = {
       "organisationId",
     );
     const ids = Array.from(
-      new Set(userIds.map((id) => asNonEmptyString(id)).filter(Boolean)),
-    ) as string[];
+      new Set(
+        userIds.flatMap((id) => {
+          const trimmed = asNonEmptyString(id);
+          return trimmed ? [trimmed] : [];
+        }),
+      ),
+    );
 
     const statuses = new Map<
       string,

--- a/apps/backend/src/services/availability.service.ts
+++ b/apps/backend/src/services/availability.service.ts
@@ -780,29 +780,38 @@ export const AvailabilityService = {
     const dateStr = getDateString(now);
 
     for (const id of ids) {
-      const base = (baseByUser.get(id) ?? []).map((row) => ({
-        dayOfWeek: row.dayOfWeek,
-        slots: row.slots as unknown as AvailabilitySlotMongo[],
-      }));
-      const overrideRow = overrideByUser.get(id)?.[0];
-      const override = overrideRow
-        ? {
-            overrides: overrideRow.overrides as unknown as WeekSlotSource[],
-          }
-        : null;
+      // Isolated per member on purpose. `slots` and `overrides` are Json columns
+      // read through casts, so one malformed record can throw during the merge.
+      // The per-member call this replaced caught that and downgraded only the
+      // affected member; failing the whole batch instead would report an entire
+      // clinic as off duty because of one bad row.
+      try {
+        const base = (baseByUser.get(id) ?? []).map((row) => ({
+          dayOfWeek: row.dayOfWeek,
+          slots: row.slots as unknown as AvailabilitySlotMongo[],
+        }));
+        const overrideRow = overrideByUser.get(id)?.[0];
+        const override = overrideRow
+          ? {
+              overrides: overrideRow.overrides as unknown as WeekSlotSource[],
+            }
+          : null;
 
-      const week = computeWeekAvailability(
-        weekDates,
-        base,
-        override,
-        occupancyByUser.get(id) ?? [],
-      );
-      const slots = week.find((d) => d.dayOfWeek === dayOfWeek)?.slots ?? [];
+        const week = computeWeekAvailability(
+          weekDates,
+          base,
+          override,
+          occupancyByUser.get(id) ?? [],
+        );
+        const slots = week.find((d) => d.dayOfWeek === dayOfWeek)?.slots ?? [];
 
-      statuses.set(
-        id,
-        resolveStatusFromSlots(nowUtc, dateStr, slots, occupiedNow.has(id)),
-      );
+        statuses.set(
+          id,
+          resolveStatusFromSlots(nowUtc, dateStr, slots, occupiedNow.has(id)),
+        );
+      } catch {
+        statuses.set(id, "Unavailable");
+      }
     }
 
     return statuses;

--- a/apps/backend/src/services/dashboard.service.ts
+++ b/apps/backend/src/services/dashboard.service.ts
@@ -269,15 +269,16 @@ const getStaffOnDutyCount = async (organisationId: string) => {
 
   if (staffIds.length === 0) return 0;
 
-  const statuses = await Promise.all(
-    staffIds.map((staffId) =>
-      AvailabilityService.getCurrentStatus(organisationId, staffId).catch(
-        () => "Unavailable",
-      ),
-    ),
-  );
+  // One batched read rather than four sequential queries per staff member: this
+  // tile alone cost 4N queries, so a 20-person clinic issued 80 for a count.
+  const statuses = await AvailabilityService.getCurrentStatusBulk(
+    organisationId,
+    staffIds,
+  ).catch(() => new Map<string, string>());
 
-  return statuses.filter((status) => isOnDutyStatus(status)).length;
+  return staffIds.filter((staffId) =>
+    isOnDutyStatus(statuses.get(staffId) ?? "Unavailable"),
+  ).length;
 };
 
 /**

--- a/apps/backend/test/services/availability.service.test.ts
+++ b/apps/backend/test/services/availability.service.test.ts
@@ -14,6 +14,7 @@ jest.mock("src/config/prisma", () => ({
     weeklyAvailabilityOverride: {
       findUnique: jest.fn(),
       findFirst: jest.fn(),
+      findMany: jest.fn(),
       deleteMany: jest.fn(),
       upsert: jest.fn(),
     },
@@ -593,6 +594,111 @@ describe("AvailabilityService", () => {
       expect(res.date).toBe("2026-03-09");
       expect(res.dayOfWeek).toBe("MONDAY");
       expect(res.windows).toHaveLength(2);
+    });
+  });
+
+  describe("getCurrentStatusBulk", () => {
+    const ORG = "org-1";
+    // A Wednesday, 10:30 UTC - inside the 09:00-12:00 slot below.
+    const NOW = new Date("2026-03-11T10:30:00.000Z");
+    const BASE_SLOTS = [
+      { startTime: "09:00", endTime: "12:00", isAvailable: true },
+    ];
+
+    const baseRow = (userId: string) => ({
+      id: `base-${userId}`,
+      userId,
+      organisationId: ORG,
+      dayOfWeek: "WEDNESDAY",
+      slots: BASE_SLOTS,
+      createdAt: NOW,
+      updatedAt: NOW,
+    });
+
+    beforeEach(() => {
+      jest.useFakeTimers().setSystemTime(NOW);
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it("returns the same status the per-user call returns, for every user", async () => {
+      const users = ["u-available", "u-consulting", "u-offduty"];
+      const rows = [baseRow("u-available"), baseRow("u-consulting")];
+      const occupiedNow = [
+        {
+          id: "occ-1",
+          userId: "u-consulting",
+          organisationId: ORG,
+          startTime: new Date("2026-03-11T10:00:00.000Z"),
+          endTime: new Date("2026-03-11T11:00:00.000Z"),
+        },
+      ];
+
+      // Bulk path: four batched reads.
+      (prisma.baseAvailability.findMany as jest.Mock).mockResolvedValue(rows);
+      (
+        prisma.weeklyAvailabilityOverride.findMany as jest.Mock
+      ).mockResolvedValue([]);
+      (prisma.occupancy.findMany as jest.Mock).mockResolvedValue(occupiedNow);
+
+      const bulk = await AvailabilityService.getCurrentStatusBulk(ORG, users);
+
+      // Per-user path, driven off the same fixtures, one user at a time.
+      const perUser = new Map<string, string>();
+      for (const userId of users) {
+        (prisma.baseAvailability.findMany as jest.Mock).mockResolvedValue(
+          rows.filter((row) => row.userId === userId),
+        );
+        (
+          prisma.weeklyAvailabilityOverride.findFirst as jest.Mock
+        ).mockResolvedValue(null);
+        (prisma.occupancy.findMany as jest.Mock).mockResolvedValue(
+          occupiedNow.filter((occ) => occ.userId === userId),
+        );
+        (prisma.occupancy.findFirst as jest.Mock).mockResolvedValue(
+          occupiedNow.find((occ) => occ.userId === userId) ?? null,
+        );
+        perUser.set(
+          userId,
+          await AvailabilityService.getCurrentStatus(ORG, userId),
+        );
+      }
+
+      expect(Object.fromEntries(bulk)).toEqual(Object.fromEntries(perUser));
+      // and the statuses are the ones the fixtures describe
+      expect(bulk.get("u-consulting")).toBe("Consulting");
+      expect(bulk.get("u-available")).toBe("Available");
+      expect(bulk.get("u-offduty")).toBe("Off-Duty");
+    });
+
+    it("issues a fixed number of queries regardless of roster size", async () => {
+      (prisma.baseAvailability.findMany as jest.Mock).mockResolvedValue([]);
+      (
+        prisma.weeklyAvailabilityOverride.findMany as jest.Mock
+      ).mockResolvedValue([]);
+      (prisma.occupancy.findMany as jest.Mock).mockResolvedValue([]);
+
+      const twenty = Array.from({ length: 20 }, (_, i) => `staff-${i}`);
+      const statuses = await AvailabilityService.getCurrentStatusBulk(
+        ORG,
+        twenty,
+      );
+
+      expect(statuses.size).toBe(20);
+      expect(prisma.baseAvailability.findMany).toHaveBeenCalledTimes(1);
+      expect(prisma.weeklyAvailabilityOverride.findMany).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(prisma.occupancy.findMany).toHaveBeenCalledTimes(2);
+    });
+
+    it("returns an empty map when given no users, without querying", async () => {
+      const statuses = await AvailabilityService.getCurrentStatusBulk(ORG, []);
+
+      expect(statuses.size).toBe(0);
+      expect(prisma.baseAvailability.findMany).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/backend/test/services/availability.service.test.ts
+++ b/apps/backend/test/services/availability.service.test.ts
@@ -694,6 +694,28 @@ describe("AvailabilityService", () => {
       expect(prisma.occupancy.findMany).toHaveBeenCalledTimes(2);
     });
 
+    it("downgrades only the member whose availability data is malformed", async () => {
+      // Regression: a single bad Json row used to fail the whole batch, so a
+      // clinic with one corrupt record reported everybody off duty.
+      (prisma.baseAvailability.findMany as jest.Mock).mockResolvedValue([
+        baseRow("u-good"),
+        // `slots` is read through a cast; a non-iterable value throws in the merge.
+        { ...baseRow("u-broken"), slots: { not: "an array" } },
+      ]);
+      (
+        prisma.weeklyAvailabilityOverride.findMany as jest.Mock
+      ).mockResolvedValue([]);
+      (prisma.occupancy.findMany as jest.Mock).mockResolvedValue([]);
+
+      const statuses = await AvailabilityService.getCurrentStatusBulk(ORG, [
+        "u-good",
+        "u-broken",
+      ]);
+
+      expect(statuses.get("u-good")).toBe("Available");
+      expect(statuses.get("u-broken")).toBe("Unavailable");
+    });
+
     it("returns an empty map when given no users, without querying", async () => {
       const statuses = await AvailabilityService.getCurrentStatusBulk(ORG, []);
 

--- a/apps/backend/test/services/dashboard.service.test.ts
+++ b/apps/backend/test/services/dashboard.service.test.ts
@@ -9,6 +9,7 @@ import { prisma } from "src/config/prisma";
 jest.mock("../../src/services/availability.service", () => ({
   AvailabilityService: {
     getCurrentStatus: jest.fn(),
+    getCurrentStatusBulk: jest.fn(),
   },
 }));
 
@@ -45,6 +46,9 @@ describe("DashboardService", () => {
     jest.clearAllMocks();
     (AvailabilityService.getCurrentStatus as jest.Mock).mockResolvedValue(
       "Off-Duty",
+    );
+    (AvailabilityService.getCurrentStatusBulk as jest.Mock).mockResolvedValue(
+      new Map(),
     );
     (prisma.userOrganization.findMany as jest.Mock).mockResolvedValue([]);
     (prisma.$queryRaw as jest.Mock).mockResolvedValue([]);
@@ -101,9 +105,14 @@ describe("DashboardService", () => {
         { practitionerReference: "staff-2" },
         { practitionerReference: null },
       ]);
-      (AvailabilityService.getCurrentStatus as jest.Mock)
-        .mockResolvedValueOnce("Consulting")
-        .mockResolvedValueOnce("Off-Duty");
+      (
+        AvailabilityService.getCurrentStatusBulk as jest.Mock
+      ).mockResolvedValueOnce(
+        new Map([
+          ["staff-1", "Consulting"],
+          ["staff-2", "Off-Duty"],
+        ]),
+      );
       (prisma.appointment.count as jest.Mock).mockResolvedValueOnce(0);
       (prisma.task.count as jest.Mock).mockResolvedValueOnce(0);
       (prisma.invoice.aggregate as jest.Mock).mockResolvedValueOnce({


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

`AvailabilityService.getCurrentStatus` issues **four queries at serial depth four** (availability.service.ts:264, :372, :552, :635 - each awaits the previous).

`getStaffOnDutyCount` (dashboard.service.ts:256) called it once per staff member. So a single `GET /dashboard/summary/:organisationId` cost `1 + 4N` queries just for the staff-on-duty tile:

| Roster | Queries for that one tile |
| --- | --- |
| 5 staff | 21 |
| 20 staff | 81 |
| 50 staff | 201 |

This is part of fix 8 of the workstream in #2155.

## What is the new behavior?

`getCurrentStatusBulk(organisationId, userIds)` fetches the same four datasets once for the whole roster and derives each user's status in memory. Four queries, regardless of headcount.

The merge logic is **not** reimplemented. The week-bounds calculation, the base/override/occupancy merge and the status rule are extracted verbatim into `resolveWeekBounds`, `computeWeekAvailability` and `resolveStatusFromSlots`, and both the single-user and batched paths call them. `getCurrentStatus` and `getWeeklyFinalAvailability` keep their existing query shapes and return values, so nothing else that depends on availability changes.

## Related Issue(s)

Part of #2155

## Impact area

`apps/backend`. One dashboard tile. No schema change, no API shape change.

## Validation performed

- `npx tsc --noEmit` in `apps/backend`, exit 0.
- `pnpm --filter backend run lint`, exit 0.
- 7 suites across availability and dashboard services, controllers and routers: 200 tests passed, exit 0.
- Aikido SAST and secrets scan on the changed handler: no issues.

Three new tests carry the load:

1. **Equivalence.** For the same fixtures, the batched result equals the per-user result for every user, across the Available, Consulting and Off-Duty cases. It drives both code paths off identical data and compares the maps, so a divergence in the merge logic fails the test rather than silently changing a number on a dashboard.
2. **Query count.** A twenty-user roster issues exactly four queries (1 base, 1 override, 2 occupancy).
3. **Empty roster** returns an empty map without querying at all.

## Notes for the reviewer

Worth knowing if you run the backend suite locally: `pnpm --filter backend run test -- --testPathPatterns=...` does not pass the filter through, and reports a pass over a different set of files. It told me these tests were green while `npx jest <file>` showed a genuine failure (the dashboard test's `AvailabilityService` mock had no `getCurrentStatusBulk`). Run `npx jest <path>` from `apps/backend` for anything you want to actually verify. The mock is updated in this PR.

`apps/backend` also needs `prisma generate` before `tsc` is meaningful in a fresh worktree, otherwise it reports a wall of unrelated errors about missing `@prisma/client` exports.
