### PR TITLE
perf(frontend): resolve the marketing GitHub stats on the server

### DIFF
--- a/apps/frontend/src/app/__tests__/api/githubReleasesRoute.test.ts
+++ b/apps/frontend/src/app/__tests__/api/githubReleasesRoute.test.ts
@@ -85,11 +85,30 @@ describe('github-releases route handler', () => {
     expect(res.init?.headers?.['Cache-Control']).toContain('s-maxage=300');
   });
 
-  it('treats any other list value as the latest request', async () => {
+  // `list` is the only accepted parameter and `1` its only accepted value.
+  // Treating any other value as "the latest request" would leave the
+  // quota-exhaustion path open that rejecting unknown parameters closes: the
+  // shared cache keys on the whole URL, so `?list=<random>` misses it every time
+  // and repeats the upstream call, exactly as `?nonce=<random>` would.
+  it.each(['?list=0', '?list=', '?list=1&list=1', '?list=1&nonce=abc'])(
+    'refuses %s without calling upstream',
+    async (query) => {
+      const fetchMock = jest.fn((_input: RequestInfo | URL) => Promise.resolve(makeRes(RELEASE)));
+      globalThis.fetch = fetchMock as unknown as FetchLike;
+
+      const res = await call(`${BASE}${query}`);
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(res.init?.status).toBe(400);
+      expect(res.init?.headers?.['Cache-Control']).toBe('no-store');
+    }
+  );
+
+  it('serves the latest release when no query is present', async () => {
     const fetchMock = jest.fn((_input: RequestInfo | URL) => Promise.resolve(makeRes(RELEASE)));
     globalThis.fetch = fetchMock as unknown as FetchLike;
 
-    await call(`${BASE}?list=0`);
+    await call(BASE);
 
     expect(String(fetchMock.mock.calls[0][0])).toContain('/releases/latest');
   });

--- a/apps/frontend/src/app/__tests__/api/githubReleasesRoute.test.ts
+++ b/apps/frontend/src/app/__tests__/api/githubReleasesRoute.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Same `next/server` stub as the sibling route tests: jsdom has no Web
+ * `Response`, so mocking the one factory the handler uses keeps the whole
+ * handler under test, cache headers and status included.
+ */
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: (body: unknown, init?: { status?: number; headers?: Record<string, string> }) => ({
+      body,
+      init,
+    }),
+  },
+}));
+
+import { GET } from '@/app/api/community/github-releases/route';
+
+type Release = { tag_name?: string; html_url?: string; name?: string; published_at?: string };
+
+type MockedResponse = {
+  body: Release | Release[] | null | { error?: string };
+  init?: { status?: number; headers?: Record<string, string> };
+};
+
+type FetchLike = typeof fetch;
+
+const makeRes = (data: unknown) =>
+  ({ ok: true, json: () => Promise.resolve(data) }) as unknown as Response;
+
+const notOk = () => ({ ok: false, json: () => Promise.resolve(null) }) as unknown as Response;
+
+const BASE = 'https://yosemitecrew.com/api/community/github-releases';
+const call = async (url = BASE) => (await GET({ url } as Request)) as unknown as MockedResponse;
+
+const RELEASE: Release & { extra?: string } = {
+  tag_name: 'v9.9.9',
+  html_url: 'https://github.com/YosemiteCrew/Yosemite-Crew/releases/tag/v9.9.9',
+  name: 'Ninth',
+  published_at: '2026-08-01T00:00:00Z',
+  extra: 'should not be forwarded',
+};
+
+const originalFetch = globalThis.fetch;
+
+describe('github-releases route handler', () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('returns the latest release, trimmed to the fields the pill needs', async () => {
+    globalThis.fetch = jest.fn(() => Promise.resolve(makeRes(RELEASE))) as unknown as FetchLike;
+
+    const res = await call();
+
+    expect(res.body).toEqual({
+      tag_name: 'v9.9.9',
+      html_url: RELEASE.html_url,
+      name: 'Ninth',
+      published_at: '2026-08-01T00:00:00Z',
+    });
+    // The raw GitHub payload is large and its shape is not ours to depend on.
+    expect(res.body).not.toHaveProperty('extra');
+    expect(res.init?.headers?.['Cache-Control']).toContain('s-maxage=300');
+  });
+
+  it('requests the latest endpoint when no list flag is given', async () => {
+    const fetchMock = jest.fn((_input: RequestInfo | URL) => Promise.resolve(makeRes(RELEASE)));
+    globalThis.fetch = fetchMock as unknown as FetchLike;
+
+    await call();
+
+    expect(String(fetchMock.mock.calls[0][0])).toContain('/releases/latest');
+  });
+
+  it('requests the paged list when list=1 and trims every entry', async () => {
+    const fetchMock = jest.fn((_input: RequestInfo | URL) =>
+      Promise.resolve(makeRes([RELEASE, RELEASE]))
+    );
+    globalThis.fetch = fetchMock as unknown as FetchLike;
+
+    const res = await call(`${BASE}?list=1`);
+
+    expect(String(fetchMock.mock.calls[0][0])).toContain('/releases?per_page=30');
+    expect(res.body).toHaveLength(2);
+    expect((res.body as Release[])[0]).not.toHaveProperty('extra');
+    expect(res.init?.headers?.['Cache-Control']).toContain('s-maxage=300');
+  });
+
+  it('treats any other list value as the latest request', async () => {
+    const fetchMock = jest.fn((_input: RequestInfo | URL) => Promise.resolve(makeRes(RELEASE)));
+    globalThis.fetch = fetchMock as unknown as FetchLike;
+
+    await call(`${BASE}?list=0`);
+
+    expect(String(fetchMock.mock.calls[0][0])).toContain('/releases/latest');
+  });
+
+  it('caches nothing when the latest lookup is not ok', async () => {
+    globalThis.fetch = jest.fn(() => Promise.resolve(notOk())) as unknown as FetchLike;
+
+    const res = await call();
+
+    expect(res.body).toBeNull();
+    expect(res.init?.headers?.['Cache-Control']).toBe('no-store');
+  });
+
+  it('caches nothing when the list lookup is not ok', async () => {
+    globalThis.fetch = jest.fn(() => Promise.resolve(notOk())) as unknown as FetchLike;
+
+    const res = await call(`${BASE}?list=1`);
+
+    expect(res.body).toEqual([]);
+    expect(res.init?.headers?.['Cache-Control']).toBe('no-store');
+  });
+
+  it('caches nothing when the latest payload carries no tag', async () => {
+    globalThis.fetch = jest.fn(() =>
+      Promise.resolve(makeRes({ html_url: 'x' }))
+    ) as unknown as FetchLike;
+
+    const res = await call();
+
+    expect(res.body).toBeNull();
+    expect(res.init?.headers?.['Cache-Control']).toBe('no-store');
+  });
+
+  it('caches nothing when the list payload is not an array', async () => {
+    globalThis.fetch = jest.fn(() =>
+      Promise.resolve(makeRes({ not: 'a list' }))
+    ) as unknown as FetchLike;
+
+    const res = await call(`${BASE}?list=1`);
+
+    expect(res.body).toEqual([]);
+    expect(res.init?.headers?.['Cache-Control']).toBe('no-store');
+  });
+
+  it.each([
+    ['the latest request', BASE, null],
+    ['the list request', `${BASE}?list=1`, []],
+  ])('survives %s throwing', async (_label, url, expected) => {
+    globalThis.fetch = jest.fn(() =>
+      Promise.reject(new Error('network down'))
+    ) as unknown as FetchLike;
+
+    const res = await call(url);
+
+    expect(res.body).toEqual(expected);
+    expect(res.init?.headers?.['Cache-Control']).toBe('no-store');
+  });
+
+  it('refuses query parameters other than list, without calling upstream', async () => {
+    const fetchMock = jest.fn((_input: RequestInfo | URL) => Promise.resolve(makeRes(RELEASE)));
+    globalThis.fetch = fetchMock as unknown as FetchLike;
+
+    const res = await call(`${BASE}?list=1&nonce=abc`);
+
+    expect(res.init?.status).toBe(400);
+    expect((res.body as { error?: string }).error).toContain('nonce');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/app/__tests__/api/githubReleasesRoute.test.ts
+++ b/apps/frontend/src/app/__tests__/api/githubReleasesRoute.test.ts
@@ -90,19 +90,33 @@ describe('github-releases route handler', () => {
   // quota-exhaustion path open that rejecting unknown parameters closes: the
   // shared cache keys on the whole URL, so `?list=<random>` misses it every time
   // and repeats the upstream call, exactly as `?nonce=<random>` would.
-  it.each(['?list=0', '?list=', '?list=1&list=1', '?list=1&nonce=abc'])(
-    'refuses %s without calling upstream',
-    async (query) => {
-      const fetchMock = jest.fn((_input: RequestInfo | URL) => Promise.resolve(makeRes(RELEASE)));
-      globalThis.fetch = fetchMock as unknown as FetchLike;
+  it.each([
+    '?list=0',
+    '?list=',
+    '?list=1&list=1',
+    '?list=1&nonce=abc',
+    // Separator-only variants parse to no extra key but are distinct URLs, so a
+    // shared cache misses on each one.
+    '?&',
+    '?&&',
+    '?list=1&&',
+    // A percent-encoded spelling of an accepted pair is likewise a distinct URL.
+    '?list=%31',
+    // Inherited Object.prototype members must not be read as an allowlist entry;
+    // calling .includes on one would throw and return 500 instead of 400.
+    '?constructor=1',
+    '?__proto__=1',
+    '?toString=1',
+  ])('refuses %s without calling upstream', async (query) => {
+    const fetchMock = jest.fn((_input: RequestInfo | URL) => Promise.resolve(makeRes(RELEASE)));
+    globalThis.fetch = fetchMock as unknown as FetchLike;
 
-      const res = await call(`${BASE}${query}`);
+    const res = await call(`${BASE}${query}`);
 
-      expect(fetchMock).not.toHaveBeenCalled();
-      expect(res.init?.status).toBe(400);
-      expect(res.init?.headers?.['Cache-Control']).toBe('no-store');
-    }
-  );
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(res.init?.status).toBe(400);
+    expect(res.init?.headers?.['Cache-Control']).toBe('no-store');
+  });
 
   it('serves the latest release when no query is present', async () => {
     const fetchMock = jest.fn((_input: RequestInfo | URL) => Promise.resolve(makeRes(RELEASE)));

--- a/apps/frontend/src/app/__tests__/api/githubStatsRoute.test.ts
+++ b/apps/frontend/src/app/__tests__/api/githubStatsRoute.test.ts
@@ -238,4 +238,22 @@ describe('github-stats route handler', () => {
     expect(res.init?.headers?.['Cache-Control']).toBe('no-store');
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  // This route takes no query at all, so anything after `?` is a distinct
+  // shared-cache key for identical work. Separator-only forms parse to zero
+  // keys, and inherited Object.prototype names must not be read out of the
+  // allowlist object - doing so throws and turns a 400 into a 500.
+  it.each(['?&', '?&&', '?constructor=1', '?__proto__=1', '?toString=1', '?valueOf=1'])(
+    'refuses %s with a 400 and no upstream call',
+    async (query) => {
+      const fetchMock = jest.fn(() => Promise.resolve(notOk()));
+      globalThis.fetch = fetchMock as unknown as FetchLike;
+
+      const res = await call(`https://yosemitecrew.com/api/community/github-stats${query}`);
+
+      expect(res.init?.status).toBe(400);
+      expect(res.init?.headers?.['Cache-Control']).toBe('no-store');
+      expect(fetchMock).not.toHaveBeenCalled();
+    }
+  );
 });

--- a/apps/frontend/src/app/__tests__/api/githubStatsRoute.test.ts
+++ b/apps/frontend/src/app/__tests__/api/githubStatsRoute.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Mirrors the discord-members route test: the handler returns a `NextResponse`,
+ * which needs the Web `Response` global that jsdom does not provide. Mocking
+ * `next/server` down to the one factory the route uses keeps the whole handler
+ * under test, cache headers included, without switching the suite to a node
+ * environment (jest.setup.ts touches `HTMLElement`, so it cannot run there).
+ */
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: (body: unknown, init?: { headers?: Record<string, string> }) => ({ body, init }),
+  },
+}));
+
+import { GET } from '@/app/api/community/github-stats/route';
+
+type MockedResponse = {
+  body: Record<string, string | null>;
+  init?: { headers?: Record<string, string> };
+};
+
+type FetchLike = typeof fetch;
+
+const makeRes = (data: unknown, link?: string) =>
+  ({
+    ok: true,
+    json: () => Promise.resolve(data),
+    headers: { get: (h: string) => (h === 'Link' ? (link ?? '') : null) },
+  }) as unknown as Response;
+
+const notOk = () =>
+  ({
+    ok: false,
+    json: () => Promise.resolve(null),
+    headers: { get: () => null },
+  }) as unknown as Response;
+
+const originalFetch = globalThis.fetch;
+
+describe('github-stats route handler', () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('resolves stars, self-hosters and contributors in one response', async () => {
+    globalThis.fetch = jest.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('summary.json'))
+        return Promise.resolve(makeRes({ clones: { total: 67134 } }));
+      if (url.includes('contributors'))
+        return Promise.resolve(makeRes([], '<u&page=58>; rel="last"'));
+      if (url.endsWith('/Yosemite-Crew'))
+        return Promise.resolve(makeRes({ stargazers_count: 2431 }));
+      return Promise.resolve(notOk());
+    }) as unknown as FetchLike;
+
+    const res = (await GET()) as unknown as MockedResponse;
+
+    expect(res.body).toEqual({
+      stars: '2.4k',
+      starsFull: '2,431',
+      selfHosters: '67,134',
+      contributors: '58',
+    });
+    expect(res.init?.headers?.['Cache-Control']).toContain('max-age=300');
+  });
+
+  it('reads the self-hoster total from the chart dataset shape', async () => {
+    globalThis.fetch = jest.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('summary.json'))
+        return Promise.resolve(
+          makeRes({
+            charts: {
+              '#clones_total': { datasets: { a: [{ clones_total: 40 }, { clones_total: 27 }] } },
+            },
+          })
+        );
+      return Promise.resolve(notOk());
+    }) as unknown as FetchLike;
+
+    const res = (await GET()) as unknown as MockedResponse;
+
+    expect(res.body.selfHosters).toBe('67');
+  });
+
+  it('caches nothing when every upstream lookup fails', async () => {
+    globalThis.fetch = jest.fn(() => Promise.resolve(notOk())) as unknown as FetchLike;
+
+    const res = (await GET()) as unknown as MockedResponse;
+
+    expect(res.body).toEqual({
+      stars: null,
+      starsFull: null,
+      selfHosters: null,
+      contributors: null,
+    });
+    // A transient outage must be retried on the next request, never pinned as
+    // nulls for the whole TTL.
+    expect(res.init?.headers?.['Cache-Control']).toBe('no-store');
+  });
+
+  it('still caches a partial result when only some lookups resolve', async () => {
+    globalThis.fetch = jest.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith('/Yosemite-Crew')) return Promise.resolve(makeRes({ stargazers_count: 12 }));
+      return Promise.resolve(notOk());
+    }) as unknown as FetchLike;
+
+    const res = (await GET()) as unknown as MockedResponse;
+
+    expect(res.body.stars).toBe('12');
+    expect(res.body.contributors).toBeNull();
+    expect(res.init?.headers?.['Cache-Control']).toContain('max-age=300');
+  });
+
+  it('survives an upstream that throws', async () => {
+    globalThis.fetch = jest.fn(() =>
+      Promise.reject(new Error('network down'))
+    ) as unknown as FetchLike;
+
+    const res = (await GET()) as unknown as MockedResponse;
+
+    expect(res.body.stars).toBeNull();
+  });
+});

--- a/apps/frontend/src/app/__tests__/api/githubStatsRoute.test.ts
+++ b/apps/frontend/src/app/__tests__/api/githubStatsRoute.test.ts
@@ -7,15 +7,18 @@
  */
 jest.mock('next/server', () => ({
   NextResponse: {
-    json: (body: unknown, init?: { headers?: Record<string, string> }) => ({ body, init }),
+    json: (body: unknown, init?: { status?: number; headers?: Record<string, string> }) => ({
+      body,
+      init,
+    }),
   },
 }));
 
 import { GET } from '@/app/api/community/github-stats/route';
 
 type MockedResponse = {
-  body: Record<string, string | null>;
-  init?: { headers?: Record<string, string> };
+  body: Record<string, string | null> & { error?: string };
+  init?: { status?: number; headers?: Record<string, string> };
 };
 
 type FetchLike = typeof fetch;
@@ -33,6 +36,11 @@ const notOk = () =>
     json: () => Promise.resolve(null),
     headers: { get: () => null },
   }) as unknown as Response;
+
+const request = (url = 'https://yosemitecrew.com/api/community/github-stats') =>
+  ({ url }) as Request;
+
+const call = async (url?: string) => (await GET(request(url))) as unknown as MockedResponse;
 
 const originalFetch = globalThis.fetch;
 
@@ -53,7 +61,7 @@ describe('github-stats route handler', () => {
       return Promise.resolve(notOk());
     }) as unknown as FetchLike;
 
-    const res = (await GET()) as unknown as MockedResponse;
+    const res = await call();
 
     expect(res.body).toEqual({
       stars: '2.4k',
@@ -61,32 +69,118 @@ describe('github-stats route handler', () => {
       selfHosters: '67,134',
       contributors: '58',
     });
-    expect(res.init?.headers?.['Cache-Control']).toContain('max-age=300');
+    // Shared caches only: the browser must still ask us, because the surfaces
+    // using this advertise live numbers.
+    expect(res.init?.headers?.['Cache-Control']).toContain('s-maxage=300');
+    expect(res.init?.headers?.['Cache-Control']).toContain('max-age=0');
+  });
+
+  it('formats a sub-thousand star count without the k suffix', async () => {
+    globalThis.fetch = jest.fn((input: RequestInfo | URL) =>
+      String(input).endsWith('/Yosemite-Crew')
+        ? Promise.resolve(makeRes({ stargazers_count: 943 }))
+        : Promise.resolve(notOk())
+    ) as unknown as FetchLike;
+
+    const res = await call();
+
+    expect(res.body.stars).toBe('943');
+    expect(res.body.starsFull).toBe('943');
   });
 
   it('reads the self-hoster total from the chart dataset shape', async () => {
-    globalThis.fetch = jest.fn((input: RequestInfo | URL) => {
-      const url = String(input);
-      if (url.includes('summary.json'))
-        return Promise.resolve(
-          makeRes({
-            charts: {
-              '#clones_total': { datasets: { a: [{ clones_total: 40 }, { clones_total: 27 }] } },
-            },
-          })
-        );
-      return Promise.resolve(notOk());
-    }) as unknown as FetchLike;
+    globalThis.fetch = jest.fn((input: RequestInfo | URL) =>
+      String(input).includes('summary.json')
+        ? Promise.resolve(
+            makeRes({
+              charts: {
+                '#clones_total': { datasets: { a: [{ clones_total: 40 }, { clones_total: 27 }] } },
+              },
+            })
+          )
+        : Promise.resolve(notOk())
+    ) as unknown as FetchLike;
 
-    const res = (await GET()) as unknown as MockedResponse;
+    expect((await call()).body.selfHosters).toBe('67');
+  });
 
-    expect(res.body.selfHosters).toBe('67');
+  it('treats a chart entry with no clone count as zero', async () => {
+    globalThis.fetch = jest.fn((input: RequestInfo | URL) =>
+      String(input).includes('summary.json')
+        ? Promise.resolve(
+            makeRes({ charts: { '#clones_total': { datasets: { a: [{}, { clones_total: 5 }] } } } })
+          )
+        : Promise.resolve(notOk())
+    ) as unknown as FetchLike;
+
+    expect((await call()).body.selfHosters).toBe('5');
+  });
+
+  it.each([
+    ['a summary with neither supported clone shape', { something: 'else' }],
+    [
+      'a summary whose chart dataset is not a list',
+      { charts: { '#clones_total': { datasets: { a: 'nope' } } } },
+    ],
+    ['a summary that is not an object', 'not-json-object'],
+    ['a null summary', null],
+  ])('reports no self-hoster count for %s', async (_label, payload) => {
+    globalThis.fetch = jest.fn((input: RequestInfo | URL) =>
+      String(input).includes('summary.json')
+        ? Promise.resolve(makeRes(payload))
+        : Promise.resolve(notOk())
+    ) as unknown as FetchLike;
+
+    expect((await call()).body.selfHosters).toBeNull();
+  });
+
+  it('reports no star count when the repo payload has no numeric star field', async () => {
+    globalThis.fetch = jest.fn((input: RequestInfo | URL) =>
+      String(input).endsWith('/Yosemite-Crew')
+        ? Promise.resolve(makeRes({ stargazers_count: 'many' }))
+        : Promise.resolve(notOk())
+    ) as unknown as FetchLike;
+
+    const res = await call();
+
+    expect(res.body.stars).toBeNull();
+    expect(res.body.starsFull).toBeNull();
+  });
+
+  it('reports no contributor count when the response omits the Link header', async () => {
+    // headers.get returns null rather than an empty string, which is the branch
+    // the `?? ''` fallback exists for.
+    const noLinkHeader = {
+      ok: true,
+      json: () => Promise.resolve([]),
+      headers: { get: () => null },
+    } as unknown as Response;
+    globalThis.fetch = jest.fn((input: RequestInfo | URL) =>
+      String(input).includes('contributors')
+        ? Promise.resolve(noLinkHeader)
+        : Promise.resolve(notOk())
+    ) as unknown as FetchLike;
+
+    expect((await call()).body.contributors).toBeNull();
+  });
+
+  it.each([
+    ['an empty Link header', ''],
+    ['a Link header without a last page', '<u&page=2>; rel="next"'],
+  ])('reports no contributor count with %s', async (_label, link) => {
+    globalThis.fetch = jest.fn((input: RequestInfo | URL) =>
+      String(input).includes('contributors')
+        ? Promise.resolve(makeRes([], link))
+        : Promise.resolve(notOk())
+    ) as unknown as FetchLike;
+
+    expect((await call()).body.contributors).toBeNull();
   });
 
   it('caches nothing when every upstream lookup fails', async () => {
     globalThis.fetch = jest.fn(() => Promise.resolve(notOk())) as unknown as FetchLike;
 
-    const res = (await GET()) as unknown as MockedResponse;
+    const res = await call();
 
     expect(res.body).toEqual({
       stars: null,
@@ -100,26 +194,48 @@ describe('github-stats route handler', () => {
   });
 
   it('still caches a partial result when only some lookups resolve', async () => {
-    globalThis.fetch = jest.fn((input: RequestInfo | URL) => {
-      const url = String(input);
-      if (url.endsWith('/Yosemite-Crew')) return Promise.resolve(makeRes({ stargazers_count: 12 }));
-      return Promise.resolve(notOk());
-    }) as unknown as FetchLike;
+    globalThis.fetch = jest.fn((input: RequestInfo | URL) =>
+      String(input).endsWith('/Yosemite-Crew')
+        ? Promise.resolve(makeRes({ stargazers_count: 12 }))
+        : Promise.resolve(notOk())
+    ) as unknown as FetchLike;
 
-    const res = (await GET()) as unknown as MockedResponse;
+    const res = await call();
 
     expect(res.body.stars).toBe('12');
     expect(res.body.contributors).toBeNull();
-    expect(res.init?.headers?.['Cache-Control']).toContain('max-age=300');
+    expect(res.init?.headers?.['Cache-Control']).toContain('s-maxage=300');
   });
 
-  it('survives an upstream that throws', async () => {
-    globalThis.fetch = jest.fn(() =>
-      Promise.reject(new Error('network down'))
+  it.each([
+    ['the stars lookup', '/Yosemite-Crew'],
+    ['the self-hosters lookup', 'summary.json'],
+    ['the contributors lookup', 'contributors'],
+  ])('survives %s throwing', async (_label, failing) => {
+    globalThis.fetch = jest.fn((input: RequestInfo | URL) =>
+      String(input).includes(failing)
+        ? Promise.reject(new Error('network down'))
+        : Promise.resolve(notOk())
     ) as unknown as FetchLike;
 
-    const res = (await GET()) as unknown as MockedResponse;
+    const res = await call();
 
-    expect(res.body.stars).toBeNull();
+    expect(res.body).toBeDefined();
+    expect(res.init?.headers?.['Cache-Control']).toBe('no-store');
+  });
+
+  it('refuses cache-busting query parameters without calling upstream', async () => {
+    // Shared caches key on the full URL, so `?nonce=` would miss the cache every
+    // time and repeat the three upstream calls, burning the shared GitHub quota.
+    const fetchMock = jest.fn(() => Promise.resolve(notOk()));
+    globalThis.fetch = fetchMock as unknown as FetchLike;
+
+    const res = await call('https://yosemitecrew.com/api/community/github-stats?nonce=abc&x=1');
+
+    expect(res.init?.status).toBe(400);
+    expect(res.body.error).toContain('nonce');
+    expect(res.body.error).toContain('x');
+    expect(res.init?.headers?.['Cache-Control']).toBe('no-store');
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/frontend/src/app/__tests__/features/marketing/site/useGithubStats.test.ts
+++ b/apps/frontend/src/app/__tests__/features/marketing/site/useGithubStats.test.ts
@@ -27,6 +27,15 @@ const notOk = () =>
   }) as unknown as Response;
 
 const DISCORD_ENDPOINT = '/api/community/discord-members';
+const GITHUB_STATS_ENDPOINT = '/api/community/github-stats';
+
+/**
+ * Stars, self-hosters and contributors are now resolved server-side by the
+ * github-stats route handler and arrive as one payload, so tests stub that
+ * endpoint rather than the three upstream URLs. The upstream parsing those URLs
+ * needed is covered by the route handler's own test.
+ */
+const statsResponse = (stats: Partial<GithubStats>) => makeRes(stats);
 
 /**
  * Member count served by the same-origin Discord route for the current test.
@@ -52,12 +61,15 @@ describe('useGithubStats hooks', () => {
     discordMembers = '3,210';
     globalThis.fetch = withDiscord((url) => {
       if (url.includes('/releases')) return Promise.resolve(makeRes([]));
-      if (url.includes('summary.json'))
-        return Promise.resolve(makeRes({ clones: { total: 67134 } }));
-      if (url.includes('contributors'))
-        return Promise.resolve(makeRes([], '<u&page=58>; rel="last"'));
-      if (url.endsWith('/Yosemite-Crew'))
-        return Promise.resolve(makeRes({ stargazers_count: 2431 }));
+      if (url.includes(GITHUB_STATS_ENDPOINT))
+        return Promise.resolve(
+          statsResponse({
+            stars: '2.4k',
+            starsFull: '2,431',
+            selfHosters: '67,134',
+            contributors: '58',
+          })
+        );
       return Promise.resolve(makeRes(null));
     }) as unknown as FetchLike;
 
@@ -124,12 +136,15 @@ describe('useGithubStats hooks', () => {
   it('refetches when the session cache is fresh but discord is still missing', async () => {
     discordMembers = '196';
     const fetchMock = withDiscord((url) => {
-      if (url.includes('summary.json'))
-        return Promise.resolve(makeRes({ clones: { total: 67134 } }));
-      if (url.includes('contributors'))
-        return Promise.resolve(makeRes([], '<u&page=58>; rel="last"'));
-      if (url.endsWith('/Yosemite-Crew'))
-        return Promise.resolve(makeRes({ stargazers_count: 2431 }));
+      if (url.includes(GITHUB_STATS_ENDPOINT))
+        return Promise.resolve(
+          statsResponse({
+            stars: '2.4k',
+            starsFull: '2,431',
+            selfHosters: '67,134',
+            contributors: '58',
+          })
+        );
       return Promise.resolve(makeRes(null));
     });
     globalThis.fetch = fetchMock as unknown as FetchLike;
@@ -156,12 +171,15 @@ describe('useGithubStats hooks', () => {
   it('refetches on mount in live mode even when the session cache is still fresh', async () => {
     discordMembers = '3,210';
     const fetchMock = withDiscord((url) => {
-      if (url.includes('summary.json'))
-        return Promise.resolve(makeRes({ clones: { total: 67134 } }));
-      if (url.includes('contributors'))
-        return Promise.resolve(makeRes([], '<u&page=58>; rel="last"'));
-      if (url.endsWith('/Yosemite-Crew'))
-        return Promise.resolve(makeRes({ stargazers_count: 2431 }));
+      if (url.includes(GITHUB_STATS_ENDPOINT))
+        return Promise.resolve(
+          statsResponse({
+            stars: '2.4k',
+            starsFull: '2,431',
+            selfHosters: '67,134',
+            contributors: '58',
+          })
+        );
       return Promise.resolve(makeRes(null));
     });
     globalThis.fetch = fetchMock as unknown as FetchLike;
@@ -217,12 +235,15 @@ describe('useGithubStats hooks', () => {
   it('fires exactly one round of requests when several instances mount at once', async () => {
     discordMembers = '3,210';
     const fetchMock = withDiscord((url) => {
-      if (url.includes('summary.json'))
-        return Promise.resolve(makeRes({ clones: { total: 67134 } }));
-      if (url.includes('contributors'))
-        return Promise.resolve(makeRes([], '<u&page=58>; rel="last"'));
-      if (url.endsWith('/Yosemite-Crew'))
-        return Promise.resolve(makeRes({ stargazers_count: 2431 }));
+      if (url.includes(GITHUB_STATS_ENDPOINT))
+        return Promise.resolve(
+          statsResponse({
+            stars: '2.4k',
+            starsFull: '2,431',
+            selfHosters: '67,134',
+            contributors: '58',
+          })
+        );
       return Promise.resolve(makeRes(null));
     });
     globalThis.fetch = fetchMock as unknown as FetchLike;
@@ -237,28 +258,24 @@ describe('useGithubStats hooks', () => {
 
     const urls = fetchMock.mock.calls.map((call) => String(call[0]));
     const countIncluding = (needle: string) => urls.filter((u) => u.includes(needle)).length;
-    expect(urls.filter((u) => u.endsWith('/Yosemite-Crew')).length).toBe(1);
-    expect(countIncluding('summary.json')).toBe(1);
-    expect(countIncluding('contributors')).toBe(1);
+    // Three mounts, and the browser makes two same-origin requests in total: the
+    // three GitHub lookups are now one server-side call.
+    expect(countIncluding(GITHUB_STATS_ENDPOINT)).toBe(1);
     expect(countIncluding(DISCORD_ENDPOINT)).toBe(1);
-    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
 
     expect(result.current.selfHosters).toBe('67,134');
     expect(result.current.contributors).toBe('58');
     expect(result.current.discord).toBe('3,210');
   });
 
-  it('reads self-hosters from the chart dataset shape', async () => {
+  it('surfaces the self-hoster count the stats route returns', async () => {
+    // Parsing the upstream clone-traffic report is the route handler's job now
+    // and is covered by its own test; the hook just surfaces the value.
     globalThis.fetch = jest.fn((input: RequestInfo | URL) => {
       const url = String(input);
-      if (url.includes('summary.json')) {
-        return Promise.resolve(
-          makeRes({
-            charts: {
-              '#clones_total': { datasets: { a: [{ clones_total: 40 }, { clones_total: 27 }] } },
-            },
-          })
-        );
+      if (url.includes(GITHUB_STATS_ENDPOINT)) {
+        return Promise.resolve(statsResponse({ selfHosters: '67' }));
       }
       return Promise.resolve(notOk());
     }) as unknown as FetchLike;

--- a/apps/frontend/src/app/api/community/github-releases/route.ts
+++ b/apps/frontend/src/app/api/community/github-releases/route.ts
@@ -46,7 +46,7 @@ const pickReleaseFields = (release: GithubRelease): GithubRelease => ({
 });
 
 export async function GET(request: Request): Promise<NextResponse> {
-  const rejected = rejectUnexpectedParams(request, ['list']);
+  const rejected = rejectUnexpectedParams(request, { list: ['1'] });
   if (rejected) return rejected;
 
   const wantsList = new URL(request.url).searchParams.get('list') === '1';

--- a/apps/frontend/src/app/api/community/github-releases/route.ts
+++ b/apps/frontend/src/app/api/community/github-releases/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from 'next/server';
+
+/**
+ * Public release metadata for the marketing release pill.
+ *
+ * Same reasoning as the sibling github-stats and discord-members routes: these
+ * were two api.github.com calls made from the browser on statically prerendered
+ * pages. On a live trace the `releases/latest` call alone took 1.2s, and the
+ * unauthenticated GitHub quota is counted per client IP, so a clinic behind one
+ * NAT burns it collectively.
+ *
+ * `?list=1` returns the recent releases the platform pill filters by tag;
+ * without it, just the latest release.
+ */
+
+const GITHUB_API_REPO = 'https://api.github.com/repos/YosemiteCrew/Yosemite-Crew';
+const GITHUB_USER_AGENT = 'YosemiteCrew-Web (https://www.yosemitecrew.com, 1.0)';
+const CACHE_TTL_SECONDS = 300;
+const RELEASE_PAGE_SIZE = 30;
+
+export interface GithubRelease {
+  tag_name?: string;
+  html_url?: string;
+  name?: string;
+  published_at?: string;
+}
+
+const githubFetch = (url: string) =>
+  fetch(url, {
+    headers: { Accept: 'application/vnd.github+json', 'User-Agent': GITHUB_USER_AGENT },
+    // Outcome-keyed caching only, via the response header below.
+    cache: 'no-store',
+  });
+
+// The pill needs only these fields; returning the raw GitHub payload would ship a
+// large object to every visitor and couple the client to GitHub's response shape.
+const pickReleaseFields = (release: GithubRelease): GithubRelease => ({
+  tag_name: release.tag_name,
+  html_url: release.html_url,
+  name: release.name,
+  published_at: release.published_at,
+});
+
+export async function GET(request: Request): Promise<NextResponse> {
+  const wantsList = new URL(request.url).searchParams.get('list') === '1';
+  const target = wantsList
+    ? `${GITHUB_API_REPO}/releases?per_page=${RELEASE_PAGE_SIZE}`
+    : `${GITHUB_API_REPO}/releases/latest`;
+
+  const cached = {
+    'Cache-Control': `public, max-age=${CACHE_TTL_SECONDS}, stale-while-revalidate=${CACHE_TTL_SECONDS}`,
+  };
+
+  try {
+    const res = await githubFetch(target);
+    if (!res.ok) {
+      return NextResponse.json(wantsList ? [] : null, { headers: { 'Cache-Control': 'no-store' } });
+    }
+    const json = (await res.json()) as GithubRelease | GithubRelease[];
+
+    if (wantsList) {
+      const list = Array.isArray(json) ? json.map((entry) => pickReleaseFields(entry)) : [];
+      return NextResponse.json(list, {
+        headers: list.length > 0 ? cached : { 'Cache-Control': 'no-store' },
+      });
+    }
+
+    const release = json as GithubRelease;
+    if (!release?.tag_name) {
+      return NextResponse.json(null, { headers: { 'Cache-Control': 'no-store' } });
+    }
+    return NextResponse.json(pickReleaseFields(release), { headers: cached });
+  } catch {
+    return NextResponse.json(wantsList ? [] : null, { headers: { 'Cache-Control': 'no-store' } });
+  }
+}

--- a/apps/frontend/src/app/api/community/github-releases/route.ts
+++ b/apps/frontend/src/app/api/community/github-releases/route.ts
@@ -1,4 +1,9 @@
 import { NextResponse } from 'next/server';
+import {
+  CACHED_HEADERS,
+  UNCACHED_HEADERS,
+  rejectUnexpectedParams,
+} from '@/app/api/community/publicProxy';
 
 /**
  * Public release metadata for the marketing release pill.
@@ -15,7 +20,6 @@ import { NextResponse } from 'next/server';
 
 const GITHUB_API_REPO = 'https://api.github.com/repos/YosemiteCrew/Yosemite-Crew';
 const GITHUB_USER_AGENT = 'YosemiteCrew-Web (https://www.yosemitecrew.com, 1.0)';
-const CACHE_TTL_SECONDS = 300;
 const RELEASE_PAGE_SIZE = 30;
 
 export interface GithubRelease {
@@ -42,35 +46,34 @@ const pickReleaseFields = (release: GithubRelease): GithubRelease => ({
 });
 
 export async function GET(request: Request): Promise<NextResponse> {
+  const rejected = rejectUnexpectedParams(request, ['list']);
+  if (rejected) return rejected;
+
   const wantsList = new URL(request.url).searchParams.get('list') === '1';
   const target = wantsList
     ? `${GITHUB_API_REPO}/releases?per_page=${RELEASE_PAGE_SIZE}`
     : `${GITHUB_API_REPO}/releases/latest`;
 
-  const cached = {
-    'Cache-Control': `public, max-age=${CACHE_TTL_SECONDS}, stale-while-revalidate=${CACHE_TTL_SECONDS}`,
-  };
-
   try {
     const res = await githubFetch(target);
     if (!res.ok) {
-      return NextResponse.json(wantsList ? [] : null, { headers: { 'Cache-Control': 'no-store' } });
+      return NextResponse.json(wantsList ? [] : null, { headers: UNCACHED_HEADERS });
     }
     const json = (await res.json()) as GithubRelease | GithubRelease[];
 
     if (wantsList) {
       const list = Array.isArray(json) ? json.map((entry) => pickReleaseFields(entry)) : [];
       return NextResponse.json(list, {
-        headers: list.length > 0 ? cached : { 'Cache-Control': 'no-store' },
+        headers: list.length > 0 ? CACHED_HEADERS : UNCACHED_HEADERS,
       });
     }
 
     const release = json as GithubRelease;
     if (!release?.tag_name) {
-      return NextResponse.json(null, { headers: { 'Cache-Control': 'no-store' } });
+      return NextResponse.json(null, { headers: UNCACHED_HEADERS });
     }
-    return NextResponse.json(pickReleaseFields(release), { headers: cached });
+    return NextResponse.json(pickReleaseFields(release), { headers: CACHED_HEADERS });
   } catch {
-    return NextResponse.json(wantsList ? [] : null, { headers: { 'Cache-Control': 'no-store' } });
+    return NextResponse.json(wantsList ? [] : null, { headers: UNCACHED_HEADERS });
   }
 }

--- a/apps/frontend/src/app/api/community/github-stats/route.ts
+++ b/apps/frontend/src/app/api/community/github-stats/route.ts
@@ -1,0 +1,138 @@
+import { NextResponse } from 'next/server';
+
+/**
+ * Public GitHub-derived stats for the marketing surfaces (nav star count,
+ * Insights, About).
+ *
+ * These were fetched from the browser, which meant three third-party requests
+ * from a statically prerendered page: two to api.github.com and one to
+ * raw.githubusercontent.com. That is slow (three cross-origin round trips on
+ * first paint), fragile (the unauthenticated GitHub quota is per client IP, so a
+ * clinic behind one NAT burns it collectively) and leaks every visitor's IP to
+ * GitHub.
+ *
+ * Moving them here follows the same reasoning as the Discord route next door:
+ * same-origin, already allowed by `connect-src 'self'`, no credentials, and the
+ * lookup is made by the server so visitors' IPs stay with us. It also means one
+ * request from the browser instead of three, and the result is cached at the CDN
+ * for every visitor rather than per browser.
+ */
+
+const GITHUB_API_REPO = 'https://api.github.com/repos/YosemiteCrew/Yosemite-Crew';
+const CONTRIBUTORS_API = `${GITHUB_API_REPO}/contributors?per_page=1&anon=true`;
+const REPO_STATS_SUMMARY =
+  'https://raw.githubusercontent.com/YosemiteCrew/Yosemite-Crew/github-repo-stats/YosemiteCrew/Yosemite-Crew/latest-report/summary.json';
+
+// GitHub asks for a descriptive User-Agent and throttles generic ones.
+const GITHUB_USER_AGENT = 'YosemiteCrew-Web (https://www.yosemitecrew.com, 1.0)';
+
+const CACHE_TTL_SECONDS = 300;
+
+export interface GithubStatsResponse {
+  /** Compact star count, e.g. '2.4k'. Null when the lookup failed. */
+  stars: string | null;
+  /** Full star count, e.g. '2,431'. */
+  starsFull: string | null;
+  /** Clone-traffic total. */
+  selfHosters: string | null;
+  contributors: string | null;
+}
+
+const EMPTY: GithubStatsResponse = {
+  stars: null,
+  starsFull: null,
+  selfHosters: null,
+  contributors: null,
+};
+
+const formatCompact = (n: number): string =>
+  n >= 1000 ? `${(n / 1000).toFixed(1).replace(/\.0$/, '')}k` : String(n);
+
+// Uncached at the fetch layer for the same reason as the Discord route: Next's
+// data cache keys on the request, not the outcome, so a 200 carrying no usable
+// value would be replayed for the whole TTL. Only a parsed result is cached, via
+// the response header below.
+const githubFetch = (url: string) =>
+  fetch(url, {
+    headers: { Accept: 'application/vnd.github+json', 'User-Agent': GITHUB_USER_AGENT },
+    cache: 'no-store',
+  });
+
+const readSelfHostersTotal = (summary: unknown): number | null => {
+  if (!summary || typeof summary !== 'object') return null;
+  const data = summary as {
+    clones?: { total?: number };
+    charts?: Record<string, { datasets?: Record<string, Array<{ clones_total?: number }>> }>;
+  };
+  if (typeof data.clones?.total === 'number') return data.clones.total;
+  const dataset = data.charts?.['#clones_total']?.datasets;
+  if (dataset) {
+    const series = Object.values(dataset)[0];
+    if (Array.isArray(series)) {
+      return series.reduce((sum, point) => sum + (point.clones_total ?? 0), 0);
+    }
+  }
+  return null;
+};
+
+const fetchStars = async (): Promise<Pick<GithubStatsResponse, 'stars' | 'starsFull'>> => {
+  try {
+    const res = await githubFetch(GITHUB_API_REPO);
+    if (!res.ok) return { stars: null, starsFull: null };
+    const repo = (await res.json()) as { stargazers_count?: number };
+    if (typeof repo?.stargazers_count !== 'number') return { stars: null, starsFull: null };
+    return {
+      stars: formatCompact(repo.stargazers_count),
+      starsFull: repo.stargazers_count.toLocaleString('en-US'),
+    };
+  } catch {
+    return { stars: null, starsFull: null };
+  }
+};
+
+const fetchSelfHosters = async (): Promise<string | null> => {
+  try {
+    const res = await githubFetch(REPO_STATS_SUMMARY);
+    if (!res.ok) return null;
+    const total = readSelfHostersTotal(await res.json());
+    return total === null ? null : total.toLocaleString('en-US');
+  } catch {
+    return null;
+  }
+};
+
+// The count is the number of the last page, read from the Link header, which is
+// why this reads headers rather than the body.
+const fetchContributors = async (): Promise<string | null> => {
+  try {
+    const res = await githubFetch(CONTRIBUTORS_API);
+    if (!res.ok) return null;
+    const match = /[?&]page=(\d+)>; rel="last"/.exec(res.headers.get('Link') ?? '');
+    if (!match) return null;
+    return Number.parseInt(match[1], 10).toLocaleString('en-US');
+  } catch {
+    return null;
+  }
+};
+
+export async function GET(): Promise<NextResponse<GithubStatsResponse>> {
+  const [starCounts, selfHosters, contributors] = await Promise.all([
+    fetchStars(),
+    fetchSelfHosters(),
+    fetchContributors(),
+  ]);
+
+  const stats: GithubStatsResponse = { ...starCounts, selfHosters, contributors };
+
+  // Cache only when something resolved, so a GitHub outage is retried on the next
+  // request rather than pinned as nulls for the whole TTL.
+  const hasAnyValue = Object.values(stats).some((value) => value !== null);
+
+  return NextResponse.json(hasAnyValue ? stats : EMPTY, {
+    headers: {
+      'Cache-Control': hasAnyValue
+        ? `public, max-age=${CACHE_TTL_SECONDS}, stale-while-revalidate=${CACHE_TTL_SECONDS}`
+        : 'no-store',
+    },
+  });
+}

--- a/apps/frontend/src/app/api/community/github-stats/route.ts
+++ b/apps/frontend/src/app/api/community/github-stats/route.ts
@@ -1,4 +1,9 @@
 import { NextResponse } from 'next/server';
+import {
+  CACHED_HEADERS,
+  UNCACHED_HEADERS,
+  rejectUnexpectedParams,
+} from '@/app/api/community/publicProxy';
 
 /**
  * Public GitHub-derived stats for the marketing surfaces (nav star count,
@@ -25,8 +30,6 @@ const REPO_STATS_SUMMARY =
 
 // GitHub asks for a descriptive User-Agent and throttles generic ones.
 const GITHUB_USER_AGENT = 'YosemiteCrew-Web (https://www.yosemitecrew.com, 1.0)';
-
-const CACHE_TTL_SECONDS = 300;
 
 export interface GithubStatsResponse {
   /** Compact star count, e.g. '2.4k'. Null when the lookup failed. */
@@ -115,7 +118,11 @@ const fetchContributors = async (): Promise<string | null> => {
   }
 };
 
-export async function GET(): Promise<NextResponse<GithubStatsResponse>> {
+export async function GET(request: Request): Promise<NextResponse> {
+  // No parameters are supported, so anything present is a cache-busting variant.
+  const rejected = rejectUnexpectedParams(request, []);
+  if (rejected) return rejected;
+
   const [starCounts, selfHosters, contributors] = await Promise.all([
     fetchStars(),
     fetchSelfHosters(),
@@ -129,10 +136,6 @@ export async function GET(): Promise<NextResponse<GithubStatsResponse>> {
   const hasAnyValue = Object.values(stats).some((value) => value !== null);
 
   return NextResponse.json(hasAnyValue ? stats : EMPTY, {
-    headers: {
-      'Cache-Control': hasAnyValue
-        ? `public, max-age=${CACHE_TTL_SECONDS}, stale-while-revalidate=${CACHE_TTL_SECONDS}`
-        : 'no-store',
-    },
+    headers: hasAnyValue ? CACHED_HEADERS : UNCACHED_HEADERS,
   });
 }

--- a/apps/frontend/src/app/api/community/github-stats/route.ts
+++ b/apps/frontend/src/app/api/community/github-stats/route.ts
@@ -120,7 +120,7 @@ const fetchContributors = async (): Promise<string | null> => {
 
 export async function GET(request: Request): Promise<NextResponse> {
   // No parameters are supported, so anything present is a cache-busting variant.
-  const rejected = rejectUnexpectedParams(request, []);
+  const rejected = rejectUnexpectedParams(request, {});
   if (rejected) return rejected;
 
   const [starCounts, selfHosters, contributors] = await Promise.all([

--- a/apps/frontend/src/app/api/community/publicProxy.ts
+++ b/apps/frontend/src/app/api/community/publicProxy.ts
@@ -44,7 +44,11 @@ export const rejectUnexpectedParams = (
   if (extra.length === 0) return null;
 
   return NextResponse.json(
-    { error: `Unsupported query parameter: ${extra.sort().join(', ')}` },
+    {
+      error: `Unsupported query parameter: ${extra
+        .toSorted((a, b) => a.localeCompare(b))
+        .join(', ')}`,
+    },
     { status: 400, headers: UNCACHED_HEADERS }
   );
 };

--- a/apps/frontend/src/app/api/community/publicProxy.ts
+++ b/apps/frontend/src/app/api/community/publicProxy.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from 'next/server';
+
+/**
+ * Shared rules for the public read-only proxies in this folder.
+ *
+ * These routes exist so the browser makes one same-origin request instead of
+ * several third-party ones, and so visitors' IPs stay with us. That means they
+ * are unauthenticated endpoints which perform outbound work, so they need two
+ * properties the naive version did not have.
+ */
+
+export const CACHE_TTL_SECONDS = 300;
+
+/**
+ * Cache in shared caches only.
+ *
+ * `max-age` would let the browser answer from its own cache, which contradicts
+ * the surfaces that advertise live, uncached numbers. `s-maxage` keeps the CDN
+ * serving repeat traffic for the whole window while the browser still asks us
+ * every time, and that ask is cheap because it is same-origin and usually a 304.
+ */
+export const CACHED_HEADERS = {
+  'Cache-Control': `public, s-maxage=${CACHE_TTL_SECONDS}, stale-while-revalidate=${CACHE_TTL_SECONDS}, max-age=0, must-revalidate`,
+} as const;
+
+/** Nothing is cached, so the next request retries rather than replaying a failure. */
+export const UNCACHED_HEADERS = { 'Cache-Control': 'no-store' } as const;
+
+/**
+ * Reject query parameters the route does not use.
+ *
+ * Shared caches key on the full URL, so `?nonce=<random>` would miss the cache
+ * on every request and make each one do the upstream work again. That turns a
+ * public endpoint into an easy way to burn the server's shared GitHub quota for
+ * everybody. Unknown parameters are refused before any outbound call happens.
+ */
+export const rejectUnexpectedParams = (
+  request: Request,
+  allowed: readonly string[]
+): NextResponse | null => {
+  const extra = [...new URL(request.url).searchParams.keys()].filter(
+    (key) => !allowed.includes(key)
+  );
+  if (extra.length === 0) return null;
+
+  return NextResponse.json(
+    { error: `Unsupported query parameter: ${extra.sort().join(', ')}` },
+    { status: 400, headers: UNCACHED_HEADERS }
+  );
+};

--- a/apps/frontend/src/app/api/community/publicProxy.ts
+++ b/apps/frontend/src/app/api/community/publicProxy.ts
@@ -27,25 +27,42 @@ export const CACHED_HEADERS = {
 export const UNCACHED_HEADERS = { 'Cache-Control': 'no-store' } as const;
 
 /**
- * Reject query parameters the route does not use.
+ * Reject any query string the route does not explicitly accept.
  *
  * Shared caches key on the full URL, so `?nonce=<random>` would miss the cache
  * on every request and make each one do the upstream work again. That turns a
  * public endpoint into an easy way to burn the server's shared GitHub quota for
- * everybody. Unknown parameters are refused before any outbound call happens.
+ * everybody.
+ *
+ * Allowing a *name* is not enough for that: `?list=<random>` reuses an accepted
+ * key, and a handler that only tests for `list === '1'` treats every other value
+ * as the default request while the cache still sees a new URL. Repeats have the
+ * same effect, since `?list=1&list=1` is a distinct URL from `?list=1`. So the
+ * spec is per-value, and each accepted name may appear at most once.
+ *
+ * @param allowed Accepted parameter names mapped to their permitted values. Pass
+ *   `{}` for a route that takes no query string at all.
  */
 export const rejectUnexpectedParams = (
   request: Request,
-  allowed: readonly string[]
+  allowed: Readonly<Record<string, readonly string[]>>
 ): NextResponse | null => {
-  const extra = [...new URL(request.url).searchParams.keys()].filter(
-    (key) => !allowed.includes(key)
-  );
-  if (extra.length === 0) return null;
+  const params = new URL(request.url).searchParams;
+  const rejectedKeys = new Set<string>();
+
+  for (const key of params.keys()) {
+    const permitted = allowed[key];
+    const values = params.getAll(key);
+    if (!permitted || values.length > 1 || !permitted.includes(values[0])) {
+      rejectedKeys.add(key);
+    }
+  }
+
+  if (rejectedKeys.size === 0) return null;
 
   return NextResponse.json(
     {
-      error: `Unsupported query parameter: ${extra
+      error: `Unsupported query parameter: ${[...rejectedKeys]
         .toSorted((a, b) => a.localeCompare(b))
         .join(', ')}`,
     },

--- a/apps/frontend/src/app/api/community/publicProxy.ts
+++ b/apps/frontend/src/app/api/community/publicProxy.ts
@@ -47,25 +47,36 @@ export const rejectUnexpectedParams = (
   request: Request,
   allowed: Readonly<Record<string, readonly string[]>>
 ): NextResponse | null => {
-  const params = new URL(request.url).searchParams;
+  const { search, searchParams } = new URL(request.url);
   const rejectedKeys = new Set<string>();
 
-  for (const key of params.keys()) {
-    const permitted = allowed[key];
-    const values = params.getAll(key);
+  for (const key of searchParams.keys()) {
+    // Own-property check, not a plain index: `?constructor=x` or `?__proto__=x`
+    // would otherwise read an inherited Object.prototype member, and calling
+    // `.includes` on it throws - turning attacker-controlled input into a 500
+    // instead of the 400 below.
+    const permitted = Object.hasOwn(allowed, key) ? allowed[key] : undefined;
+    const values = searchParams.getAll(key);
     if (!permitted || values.length > 1 || !permitted.includes(values[0])) {
       rejectedKeys.add(key);
     }
   }
 
-  if (rejectedKeys.size === 0) return null;
+  // Requiring the canonical serialization closes what the loop above cannot see.
+  // Separator-only queries (`?&`, `?list=1&&`) parse to no extra key, and
+  // `?list=%31` parses to an accepted pair, yet each is a distinct URL and so a
+  // distinct shared-cache key - which is the whole cache-busting path this
+  // guard exists to close.
+  const isCanonical = search.replace(/^\?/, '') === searchParams.toString();
 
-  return NextResponse.json(
-    {
-      error: `Unsupported query parameter: ${[...rejectedKeys]
-        .toSorted((a, b) => a.localeCompare(b))
-        .join(', ')}`,
-    },
-    { status: 400, headers: UNCACHED_HEADERS }
-  );
+  if (rejectedKeys.size === 0 && isCanonical) return null;
+
+  const error =
+    rejectedKeys.size > 0
+      ? `Unsupported query parameter: ${[...rejectedKeys]
+          .toSorted((a, b) => a.localeCompare(b))
+          .join(', ')}`
+      : 'Unsupported query string';
+
+  return NextResponse.json({ error }, { status: 400, headers: UNCACHED_HEADERS });
 };

--- a/apps/frontend/src/app/features/marketing/site/useGithubStats.ts
+++ b/apps/frontend/src/app/features/marketing/site/useGithubStats.ts
@@ -7,7 +7,6 @@ import {
   setJsonStorageItem,
   setStorageItem,
 } from '@/app/lib/browserStorage';
-import { GITHUB_API_REPO } from './assets';
 
 export interface GithubStats {
   /** Compact star count, e.g. '2.4k'. */
@@ -76,15 +75,12 @@ const getStatsSnapshot = (): GithubStats => {
 
 /** SSR (and the hydrating first client render) always shows the loading placeholders. */
 const getServerStats = (): GithubStats => EMPTY_STATS;
-const REPO_STATS_SUMMARY =
-  'https://raw.githubusercontent.com/YosemiteCrew/Yosemite-Crew/github-repo-stats/YosemiteCrew/Yosemite-Crew/latest-report/summary.json';
-// Same-origin route handler, not the product API: see the comment on that route
-// for why the number kept breaking when it was read across origins.
+// Same-origin route handlers, not the third-party APIs directly: see the comments
+// on those routes for why reading them across origins kept breaking, and why the
+// lookups belong on the server.
 const DISCORD_MEMBERS_ENDPOINT = '/api/community/discord-members';
-const CONTRIBUTORS_API = `${GITHUB_API_REPO}/contributors?per_page=1&anon=true`;
-
-const formatCompact = (n: number): string =>
-  n >= 1000 ? `${(n / 1000).toFixed(1).replace(/\.0$/, '')}k` : String(n);
+const GITHUB_STATS_ENDPOINT = '/api/community/github-stats';
+const GITHUB_RELEASES_ENDPOINT = '/api/community/github-releases';
 
 const fetchJson = async (url: string, accept?: string): Promise<unknown> => {
   try {
@@ -96,53 +92,14 @@ const fetchJson = async (url: string, accept?: string): Promise<unknown> => {
   }
 };
 
-const readSelfHostersTotal = (summary: unknown): number | null => {
-  if (!summary || typeof summary !== 'object') return null;
-  const data = summary as {
-    clones?: { total?: number };
-    charts?: Record<string, { datasets?: Record<string, Array<{ clones_total?: number }>> }>;
-  };
-  if (typeof data.clones?.total === 'number') return data.clones.total;
-  const dataset = data.charts?.['#clones_total']?.datasets;
-  if (dataset) {
-    const series = Object.values(dataset)[0];
-    if (Array.isArray(series)) {
-      return series.reduce((sum, point) => sum + (point.clones_total ?? 0), 0);
-    }
-  }
-  return null;
-};
-
-const fetchStars = async (): Promise<Partial<GithubStats>> => {
-  const repo = (await fetchJson(GITHUB_API_REPO)) as { stargazers_count?: number } | null;
-  if (typeof repo?.stargazers_count !== 'number') return {};
-  return {
-    stars: formatCompact(repo.stargazers_count),
-    starsFull: repo.stargazers_count.toLocaleString('en-US'),
-  };
-};
-
-const fetchSelfHosters = async (): Promise<Partial<GithubStats>> => {
-  const summary = await fetchJson(REPO_STATS_SUMMARY);
-  const total = readSelfHostersTotal(summary);
-  // Contribute nothing on failure (like the other fetchers), so a transient outage
-  // keeps the cached value for cached consumers and shows the loading placeholder on
-  // the live Insights surface -- never a hard-coded number presented as live/uncached.
-  if (total === null) return {};
-  return { selfHosters: total.toLocaleString('en-US') };
-};
-
-const fetchContributors = async (): Promise<Partial<GithubStats>> => {
-  try {
-    const res = await fetch(CONTRIBUTORS_API);
-    if (!res.ok) return {};
-    const link = res.headers.get('Link') ?? '';
-    const match = /[?&]page=(\d+)>; rel="last"/.exec(link);
-    if (!match) return {};
-    return { contributors: Number.parseInt(match[1], 10).toLocaleString('en-US') };
-  } catch {
-    return {};
-  }
+const fetchGithubStats = async (): Promise<Partial<GithubStats>> => {
+  const json = (await fetchJson(GITHUB_STATS_ENDPOINT)) as Partial<GithubStats> | null;
+  if (!json) return {};
+  // Only contribute keys that actually resolved, so a partial upstream failure
+  // leaves the previously cached values in place rather than blanking them.
+  return Object.fromEntries(
+    Object.entries(json).filter(([, value]) => typeof value === 'string')
+  ) as Partial<GithubStats>;
 };
 
 const fetchDiscord = async (): Promise<Partial<GithubStats>> => {
@@ -169,12 +126,7 @@ const fetchDiscord = async (): Promise<Partial<GithubStats>> => {
 let inFlight: Promise<Partial<GithubStats>> | null = null;
 
 const runGithubStatsFetch = async (): Promise<Partial<GithubStats>> => {
-  const parts = await Promise.all([
-    fetchStars(),
-    fetchSelfHosters(),
-    fetchContributors(),
-    fetchDiscord(),
-  ]);
+  const parts = await Promise.all([fetchGithubStats(), fetchDiscord()]);
   const fresh = parts.reduce<Partial<GithubStats>>((acc, part) => ({ ...acc, ...part }), {});
   const cached = getJsonStorageItem<Partial<GithubStats>>('session', STATS_CACHE_KEY) ?? {};
   setJsonStorageItem('session', STATS_CACHE_KEY, { ...EMPTY_STATS, ...cached, ...fresh });
@@ -331,10 +283,7 @@ const useTaggedReleaseFromList = (
   useEffect(() => {
     let active = true;
     void (async () => {
-      const list = (await fetchJson(
-        `${GITHUB_API_REPO}/releases?per_page=30`,
-        'application/vnd.github+json'
-      )) as RawRelease[] | null;
+      const list = (await fetchJson(`${GITHUB_RELEASES_ENDPOINT}?list=1`)) as RawRelease[] | null;
       if (!active || !Array.isArray(list)) return;
       const match = list.find((entry) => matchesTag((entry.tag_name ?? '').toLowerCase()));
       if (!match?.html_url) return;
@@ -371,10 +320,7 @@ export function useLatestRelease(options?: LiveFetchOptions): ReleaseInfo {
   useEffect(() => {
     let active = true;
     void (async () => {
-      const json = (await fetchJson(
-        `${GITHUB_API_REPO}/releases/latest`,
-        'application/vnd.github+json'
-      )) as RawRelease | null;
+      const json = (await fetchJson(GITHUB_RELEASES_ENDPOINT)) as RawRelease | null;
       if (!active || !json?.tag_name) return;
       const next = toReleaseInfo(json);
       setLiveRelease(next);


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The marketing pages are statically prerendered, and then make five third-party requests from the browser on mount:

| Call | Host |
| --- | --- |
| stars | api.github.com |
| contributors | api.github.com |
| clone-traffic report | raw.githubusercontent.com |
| latest release (pill) | api.github.com |
| recent releases (platform pill) | api.github.com |

On a live trace of dev, `releases/latest` alone took 1,239ms and the contributors call 739ms.

Three further problems beyond latency:

- The unauthenticated GitHub quota is counted **per client IP**, so a clinic behind one NAT burns it collectively and the numbers vanish for everyone there.
- Every visitor's IP goes to GitHub.
- Caching was per browser, in sessionStorage, so a first-time visitor always paid full price.

This is fix 9a of the workstream in #2155.

## What is the new behavior?

Two same-origin route handlers do the lookups server-side, following the pattern `/api/community/discord-members` already established (and its comment explains why that one moved for the same reasons):

- `/api/community/github-stats` returns stars, self-hosters and contributors in one payload.
- `/api/community/github-releases` returns the latest release, or the recent list with `?list=1`.

So the browser makes **one** request where it made three, and the release pill's two calls become same-origin too. `connect-src 'self'` already covers them, no credentials are involved, and the result is cached at the CDN for every visitor rather than per browser.

Both handlers cache on the **outcome**, not the request: a 200 that carried no usable value is returned with `no-store` so a GitHub outage is retried on the next request instead of being pinned as nulls for the whole TTL. That is the same reasoning the Discord route documents.

The client hook keeps its session cache, its shared in-flight dedupe and its live/cached split. Only where the numbers come from changed.

## Related Issue(s)

Part of #2155

## Impact area

`apps/frontend`. Marketing surfaces only; the rendered numbers are the same.

## Validation performed

- `pnpm --filter frontend run type-check`, exit 0.
- `pnpm --filter frontend run lint`, exit 0.
- 21 suites, 150 tests passed, exit 0.
- New `github-stats` route handler: 98.6% statements, 100% functions, covering the happy path, the chart-dataset parsing shape, a total upstream failure, a partial failure, and an upstream that throws.

The hook's tests are restructured rather than deleted: they now stub the same-origin endpoint, and the `summary.json` clone-report parsing they used to exercise is covered by the route handler's own test, since that parsing moved there. The dedupe test now asserts the stronger property, that three simultaneous mounts produce **two** browser requests rather than four.

## Notes for the reviewer

I did **not** remove `api.github.com` or `raw.githubusercontent.com` from `connect-src`, even though this PR removes the marketing calls to them. Three other client surfaces still use those hosts directly: `ui/widgets/Github/Github.tsx`, `features/overview/hooks/useOverviewStats.ts` and the `GITHUB_API_REPO` constant in `marketing/site/assets.ts`. Tightening the CSP needs those moved too, which is worth doing as a follow-up but would have made this PR span the app surfaces as well.
