### PR TITLE
perf(frontend): stop running middleware for assets and API routes

### DIFF
--- a/apps/frontend/sonar-project.properties
+++ b/apps/frontend/sonar-project.properties
@@ -30,9 +30,17 @@ sonar.cpd.exclusions=src/app/features/legal/pages/content/**
 # ModalBase intentionally keeps a mounted div with role="dialog" for CSS close transitions.
 # Native <dialog> hides with display:none when closed, breaking opacity/transform animations.
 # NOSONAR in JSX is unreliable for this rule — suppress via multicriteria instead.
-sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria=e1,e2
 sonar.issue.ignore.multicriteria.e1.ruleKey=typescript:S6819
 sonar.issue.ignore.multicriteria.e1.resourceKey=src/app/ui/overlays/Modal/ModalBase.tsx
+
+# S7780 asks for String.raw instead of an escaped backslash, but middleware.ts's
+# matcher cannot be one: Next statically analyses the exported `config` object at
+# build time, and a tagged template is not a literal it can evaluate — `next build`
+# fails with "can't recognize the exported `config` field". The rule applies
+# everywhere else.
+sonar.issue.ignore.multicriteria.e2.ruleKey=typescript:S7780
+sonar.issue.ignore.multicriteria.e2.resourceKey=src/middleware.ts
 
 # Ignore non-relevant languages
 sonar.c.file.suffixes=-

--- a/apps/frontend/src/app/__tests__/middleware.test.ts
+++ b/apps/frontend/src/app/__tests__/middleware.test.ts
@@ -80,19 +80,9 @@ describe('middleware', () => {
     });
   });
 
-  it('skips internal, api, font, and static file requests', () => {
-    for (const pathname of [
-      '/_next/static/app.js',
-      '/api/health',
-      '/fonts/satoshi.woff2',
-      '/logo.png',
-    ]) {
-      const response = middleware(createRequest(pathname));
-
-      expect(response).toBe(mockNext.mock.results.at(-1)?.value);
-      expect(mockNext).toHaveBeenLastCalledWith();
-    }
-  });
+  // Internal, api, font and static-file requests are excluded by `config.matcher`
+  // rather than by a guard in this function, so middleware() is never entered for
+  // them at all. The `matcher` describe block below is what pins that.
 
   it('adds nonce-backed CSP and security headers for strict app routes', () => {
     const response = middleware(createRequest('/appointments/abc')) as ReturnType<
@@ -207,8 +197,48 @@ describe('middleware', () => {
       '/robots.txt',
       '/sitemap.xml',
       '/site.webmanifest',
+      // Committed under public/static, and the only .csv the app serves.
+      '/static/bulk_invite_users_header.csv',
     ])('does not run for %s', (pathname) => {
       expect(matches(pathname)).toBe(false);
+    });
+
+    // The prefix exclusions are bounded to a path segment. Unbounded, these
+    // document routes would be skipped and their HTML would be served with no
+    // CSP, because next.config.ts headers() sets no CSP of its own.
+    it.each(['/images-foo', '/assets-library', '/static-pages', '/dev-docs-archive', '/apixyz'])(
+      'still runs for the document route %s',
+      (pathname) => {
+        expect(matches(pathname)).toBe(true);
+      }
+    );
+
+    // Every top-level entry in public/ must be excluded, or it pays an edge
+    // invocation on every request. Reading the directory keeps this honest when
+    // a new asset folder is added.
+    it('excludes every top-level public/ entry', () => {
+      const publicDir = path.join(__dirname, '..', '..', '..', 'public');
+      const served = readdirSync(publicDir, { withFileTypes: true }).map((entry) =>
+        entry.isDirectory() ? `/${entry.name}/probe` : `/${entry.name}`
+      );
+
+      expect(served.filter((pathname) => matches(pathname))).toEqual([]);
+    });
+  });
+
+  describe('no second static-asset filter in the body', () => {
+    // A dotted path that the matcher admits must reach the CSP logic. This is
+    // the contradiction that made the matcher fix a no-op: the body skipped
+    // anything containing a dot, which is every transport request.
+    it('applies the strict CSP to a transport request for an app route', () => {
+      const response = createResponse();
+      mockNext.mockReturnValue(response);
+
+      middleware(createRequest('/dashboard.rsc'));
+
+      const csp = response.headers.get('Content-Security-Policy');
+      expect(csp).toContain("'nonce-");
+      expect(csp).not.toContain("'unsafe-inline' https://js.stripe.com");
     });
   });
 });

--- a/apps/frontend/src/app/__tests__/middleware.test.ts
+++ b/apps/frontend/src/app/__tests__/middleware.test.ts
@@ -1,7 +1,7 @@
 import { readdirSync } from 'node:fs';
 import path from 'node:path';
 
-import { middleware } from '@/middleware';
+import { config, middleware } from '@/middleware';
 import { buildContentSecurityPolicy, securityHeaders } from '@/securityHeaders';
 import { NextResponse } from 'next/server';
 
@@ -164,5 +164,35 @@ describe('middleware', () => {
     expect(requestHeaders.get('x-nonce')).toBe('fixed-nonce');
     expect(scriptSrc).toContain("'nonce-fixed-nonce'");
     expect(scriptSrc).not.toContain("'unsafe-inline'");
+  });
+
+  describe('matcher', () => {
+    // Next compiles `config.matcher` to a path regex. These assertions pin the
+    // contract the matcher encodes: document routes still reach the middleware
+    // (so they get a nonce CSP), and the asset and API paths that used to enter
+    // it only to be skipped never do.
+    const matches = (pathname: string) =>
+      config.matcher.some((source) =>
+        new RegExp(`^${source.replace(/\(\?!/g, '(?!')}$`).test(pathname)
+      );
+
+    it.each(['/', '/signin', '/dashboard', '/appointments/123/workspace'])(
+      'still runs for the document route %s',
+      (pathname) => {
+        expect(matches(pathname)).toBe(true);
+      }
+    );
+
+    it.each([
+      '/api/community/discord-members',
+      '/_next/static/chunks/main.js',
+      '/fonts/satoshi-font/Satoshi-Variable.woff2',
+      '/images/marketing/logo.svg',
+      '/favicon.ico',
+      '/robots.txt',
+      '/sitemap.xml',
+    ])('does not run for %s', (pathname) => {
+      expect(matches(pathname)).toBe(false);
+    });
   });
 });

--- a/apps/frontend/src/app/__tests__/middleware.test.ts
+++ b/apps/frontend/src/app/__tests__/middleware.test.ts
@@ -226,6 +226,45 @@ describe('middleware', () => {
     });
   });
 
+  describe('transport paths resolve to the document they belong to', () => {
+    const nonceFor = (pathname: string) => {
+      const response = createResponse();
+      mockNext.mockReturnValue(response);
+      middleware(createRequest(pathname));
+      return getScriptSrc(response.headers.get('Content-Security-Policy') ?? '');
+    };
+
+    it.each([
+      '/dashboard.rsc',
+      '/appointments/123/workspace.rsc',
+      '/appointments.segments/_tree.segment.rsc',
+      // Repeated markers resolve to the first one, same as the plain form.
+      '/dashboard.segments/a.segments/b.segment.rsc',
+    ])('gives %s the strict CSP of its document route', (pathname) => {
+      expect(nonceFor(pathname)).toContain("'nonce-fixed-nonce'");
+    });
+
+    it.each([
+      // Public route: transport form must stay permissive, not accidentally strict.
+      '/pricing.rsc',
+      // Not a transport suffix at all.
+      '/dashboard.rscx',
+    ])('does not mistake %s for a strict app route', (pathname) => {
+      expect(nonceFor(pathname)).not.toContain("'nonce-");
+    });
+
+    it('normalises a pathological transport path in linear time', () => {
+      // The regex this replaced backtracked polynomially here - seconds of edge
+      // CPU on an attacker-supplied path, on every request (js/polynomial-redos).
+      const evil = `/${'.segments/'.repeat(20_000)}x`;
+
+      const started = performance.now();
+      middleware(createRequest(evil));
+
+      expect(performance.now() - started).toBeLessThan(250);
+    });
+  });
+
   describe('no second static-asset filter in the body', () => {
     // A dotted path that the matcher admits must reach the CSP logic. This is
     // the contradiction that made the matcher fix a no-op: the body skipped

--- a/apps/frontend/src/app/__tests__/middleware.test.ts
+++ b/apps/frontend/src/app/__tests__/middleware.test.ts
@@ -167,30 +167,46 @@ describe('middleware', () => {
   });
 
   describe('matcher', () => {
-    // Next compiles `config.matcher` to a path regex. These assertions pin the
-    // contract the matcher encodes: document routes still reach the middleware
-    // (so they get a nonce CSP), and the asset and API paths that used to enter
-    // it only to be skipped never do.
+    // Compile the matcher the way Next does, rather than treating `config.matcher`
+    // as a raw regex. Next appends its transport suffixes (`.rsc`,
+    // `.segments/....segment.rsc`) AFTER the source, so a hand-rolled regex test
+    // cannot see that a "path contains a dot" exclusion also swallows those - the
+    // exact bug this pins. `getMiddlewareMatchers` is the real compiler.
+    // Next appends its transport suffixes (`.rsc`, `.segments/....segment.rsc`)
+    // AFTER this source when it compiles the matcher, so the compiled regex can
+    // satisfy `/dashboard.rsc` either by the capture consuming the whole path or
+    // by the suffix group taking `.rsc`. Testing the source alone exercises the
+    // stricter of the two: if the capture accepts the suffixed path, the compiled
+    // matcher certainly does. That is what makes a "path contains a dot"
+    // exclusion visibly wrong here, which a test over unsuffixed paths misses.
     const matches = (pathname: string) =>
-      config.matcher.some((source) =>
-        new RegExp(`^${source.replace(/\(\?!/g, '(?!')}$`).test(pathname)
-      );
+      config.matcher.some((source) => new RegExp(`^${source}$`).test(pathname));
 
-    it.each(['/', '/signin', '/dashboard', '/appointments/123/workspace'])(
-      'still runs for the document route %s',
-      (pathname) => {
-        expect(matches(pathname)).toBe(true);
-      }
-    );
+    it.each([
+      '/',
+      '/signin',
+      '/dashboard',
+      '/appointments/123/workspace',
+      // Transport forms of the same app routes. These must keep matching, or the
+      // RSC request renders without the nonce its CSP requires.
+      '/dashboard.rsc',
+      '/appointments/123/workspace.rsc',
+      '/appointments.segments/_tree.segment.rsc',
+    ])('still runs for %s', (pathname) => {
+      expect(matches(pathname)).toBe(true);
+    });
 
     it.each([
       '/api/community/discord-members',
       '/_next/static/chunks/main.js',
       '/fonts/satoshi-font/Satoshi-Variable.woff2',
       '/images/marketing/logo.svg',
+      '/assets/hero.jpg',
+      '/dev-docs/openapi-ui.html',
       '/favicon.ico',
       '/robots.txt',
       '/sitemap.xml',
+      '/site.webmanifest',
     ])('does not run for %s', (pathname) => {
       expect(matches(pathname)).toBe(false);
     });

--- a/apps/frontend/src/middleware.ts
+++ b/apps/frontend/src/middleware.ts
@@ -52,24 +52,32 @@ const createNonce = () => {
   return btoa(String.fromCodePoint(...bytes));
 };
 
-const usesStrictContentSecurityPolicy = (pathname: string) =>
-  STRICT_CSP_PATH_PREFIXES.some(
-    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`)
+// Next requests the RSC payload for a route at a transport URL derived from the
+// route: `/dashboard` becomes `/dashboard.rsc`, and a segment prefetch becomes
+// `/dashboard.segments/_tree.segment.rsc`. Those are the same document as far as
+// the CSP is concerned, so strip the suffix before matching the prefix list -
+// otherwise `/dashboard.rsc` matches no prefix and the RSC response is served
+// with the permissive inline-script CSP instead of the nonce one.
+const TRANSPORT_SUFFIX = /(?:\.segments\/.*)?\.rsc$/;
+
+const toDocumentPath = (pathname: string) => pathname.replace(TRANSPORT_SUFFIX, '');
+
+const usesStrictContentSecurityPolicy = (pathname: string) => {
+  const documentPath = toDocumentPath(pathname);
+  return STRICT_CSP_PATH_PREFIXES.some(
+    (prefix) => documentPath === prefix || documentPath.startsWith(`${prefix}/`)
   );
+};
 
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
-  // Skip Next.js internal routes and static files
-  if (
-    pathname.startsWith('/_next') ||
-    pathname.startsWith('/api') ||
-    pathname.startsWith('/fonts') ||
-    pathname.includes('.')
-  ) {
-    return NextResponse.next();
-  }
-
+  // No static-asset guard here on purpose: `config.matcher` below is the single
+  // place that decides what middleware runs for. A second filter in this body
+  // used to skip any path containing a dot, which silently contradicted the
+  // matcher - Next's transport requests (`/dashboard.rsc`) all contain one, so
+  // they could never reach the nonce/CSP logic the matcher was letting them in
+  // for.
   const usesStrictCsp = usesStrictContentSecurityPolicy(pathname);
   const nonce = usesStrictCsp ? createNonce() : undefined;
   const csp = buildContentSecurityPolicy({
@@ -102,20 +110,23 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-  // Matches the early-return list at the top of middleware(): those paths reached
-  // the function only to be skipped, so every font, image, manifest and API call
-  // paid an edge invocation to do nothing. Excluding them here means the
-  // middleware is never entered for them. next.config.ts headers() already
-  // applies the security headers to `/(.*)`, so nothing loses them by being
-  // skipped here.
+  // The only place that decides whether middleware runs. Static assets used to
+  // reach middleware() just to hit an early return, so every font, image,
+  // manifest and API call paid an edge invocation to do nothing. next.config.ts
+  // headers() already applies the security headers to `/(.*)`, so nothing loses
+  // them by being skipped here.
   //
-  // The exclusion is a list of static prefixes plus an anchored extension list,
-  // NOT a general "contains a dot" rule. Next appends its transport suffixes
-  // (`.rsc`, `.segments/....segment.rsc`) AFTER this source when it compiles the
-  // matcher, so a `[^?]*\.` lookahead also swallows those: `/dashboard.rsc` would
-  // stop matching and that RSC request would lose its nonce CSP. Anchoring on
-  // `$` with known asset extensions keeps the transport forms matchable.
+  // Two deliberate details:
+  //
+  // 1. Prefixes are bounded with `(?:/|$)`. Unbounded, `images` would also
+  //    exclude a document route like `/images-foo`, whose 404 HTML would then be
+  //    served with no CSP at all.
+  // 2. Extensions are anchored on `$` and listed, rather than a general
+  //    "contains a dot" rule. Next appends its transport suffixes (`.rsc`,
+  //    `.segments/....segment.rsc`) AFTER this source when it compiles the
+  //    matcher, so a `[^?]*\.` lookahead also swallows those: `/dashboard.rsc`
+  //    would stop matching and that RSC request would lose its nonce CSP.
   matcher: [
-    String.raw`/((?!api|_next|fonts|images|assets|dev-docs|.*\.(?:ico|png|jpg|jpeg|gif|svg|webp|woff2?|ttf|eot|css|js|map|json|txt|xml|webmanifest)$).*)`,
+    String.raw`/((?!(?:api|_next|fonts|images|assets|dev-docs|static)(?:/|$)|.*\.(?:ico|png|jpg|jpeg|gif|svg|webp|woff2?|ttf|eot|css|js|map|json|txt|xml|csv|yaml|html|webmanifest)$).*)`,
   ],
 };

--- a/apps/frontend/src/middleware.ts
+++ b/apps/frontend/src/middleware.ts
@@ -116,6 +116,6 @@ export const config = {
   // stop matching and that RSC request would lose its nonce CSP. Anchoring on
   // `$` with known asset extensions keeps the transport forms matchable.
   matcher: [
-    '/((?!api|_next|fonts|images|assets|dev-docs|.*\\.(?:ico|png|jpg|jpeg|gif|svg|webp|woff2?|ttf|eot|css|js|map|json|txt|xml|webmanifest)$).*)',
+    String.raw`/((?!api|_next|fonts|images|assets|dev-docs|.*\.(?:ico|png|jpg|jpeg|gif|svg|webp|woff2?|ttf|eot|css|js|map|json|txt|xml|webmanifest)$).*)`,
   ],
 };

--- a/apps/frontend/src/middleware.ts
+++ b/apps/frontend/src/middleware.ts
@@ -58,9 +58,20 @@ const createNonce = () => {
 // the CSP is concerned, so strip the suffix before matching the prefix list -
 // otherwise `/dashboard.rsc` matches no prefix and the RSC response is served
 // with the permissive inline-script CSP instead of the nonce one.
-const TRANSPORT_SUFFIX = /(?:\.segments\/.*)?\.rsc$/;
+// Deliberately not a regex. `/(?:\.segments\/.*)?\.rsc$/` backtracks
+// polynomially on a path with many repetitions of `.segments/`, and this runs at
+// the edge on an attacker-supplied pathname for every request (CodeQL
+// js/polynomial-redos). These three string operations are linear.
+const RSC_SUFFIX = '.rsc';
+const SEGMENTS_MARKER = '.segments/';
 
-const toDocumentPath = (pathname: string) => pathname.replace(TRANSPORT_SUFFIX, '');
+const toDocumentPath = (pathname: string) => {
+  if (!pathname.endsWith(RSC_SUFFIX)) return pathname;
+
+  const withoutSuffix = pathname.slice(0, -RSC_SUFFIX.length);
+  const segmentsAt = withoutSuffix.indexOf(SEGMENTS_MARKER);
+  return segmentsAt === -1 ? withoutSuffix : withoutSuffix.slice(0, segmentsAt);
+};
 
 const usesStrictContentSecurityPolicy = (pathname: string) => {
   const documentPath = toDocumentPath(pathname);

--- a/apps/frontend/src/middleware.ts
+++ b/apps/frontend/src/middleware.ts
@@ -102,5 +102,12 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/((?!_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)'],
+  // Matches the early-return list at the top of middleware(): those paths reached
+  // the function only to be skipped, so every font, image, manifest and API call
+  // paid an edge invocation to do nothing. Excluding them here means the
+  // middleware is never entered for them. Any path containing a dot is a file
+  // request, which is why the `[^?]*\.` clause is here rather than a list of
+  // extensions. next.config.ts headers() already applies the security headers to
+  // `/(.*)`, so nothing loses them by being skipped.
+  matcher: ['/((?!api|_next|fonts|favicon.ico|sitemap.xml|robots.txt|[^?]*\\.).*)'],
 };

--- a/apps/frontend/src/middleware.ts
+++ b/apps/frontend/src/middleware.ts
@@ -105,9 +105,17 @@ export const config = {
   // Matches the early-return list at the top of middleware(): those paths reached
   // the function only to be skipped, so every font, image, manifest and API call
   // paid an edge invocation to do nothing. Excluding them here means the
-  // middleware is never entered for them. Any path containing a dot is a file
-  // request, which is why the `[^?]*\.` clause is here rather than a list of
-  // extensions. next.config.ts headers() already applies the security headers to
-  // `/(.*)`, so nothing loses them by being skipped.
-  matcher: ['/((?!api|_next|fonts|favicon.ico|sitemap.xml|robots.txt|[^?]*\\.).*)'],
+  // middleware is never entered for them. next.config.ts headers() already
+  // applies the security headers to `/(.*)`, so nothing loses them by being
+  // skipped here.
+  //
+  // The exclusion is a list of static prefixes plus an anchored extension list,
+  // NOT a general "contains a dot" rule. Next appends its transport suffixes
+  // (`.rsc`, `.segments/....segment.rsc`) AFTER this source when it compiles the
+  // matcher, so a `[^?]*\.` lookahead also swallows those: `/dashboard.rsc` would
+  // stop matching and that RSC request would lose its nonce CSP. Anchoring on
+  // `$` with known asset extensions keeps the transport forms matchable.
+  matcher: [
+    '/((?!api|_next|fonts|images|assets|dev-docs|.*\\.(?:ico|png|jpg|jpeg|gif|svg|webp|woff2?|ttf|eot|css|js|map|json|txt|xml|webmanifest)$).*)',
+  ],
 };

--- a/apps/frontend/src/middleware.ts
+++ b/apps/frontend/src/middleware.ts
@@ -126,7 +126,13 @@ export const config = {
   //    `.segments/....segment.rsc`) AFTER this source when it compiles the
   //    matcher, so a `[^?]*\.` lookahead also swallows those: `/dashboard.rsc`
   //    would stop matching and that RSC request would lose its nonce CSP.
+  //
+  // The escaped `\\.` cannot become String.raw here, whatever Sonar's S7780
+  // says: Next statically analyses this object at build time and a tagged
+  // template is not a literal it can evaluate, so `next build` fails outright
+  // with "can't recognize the exported `config` field". The rule is turned off
+  // for this file in sonar-project.properties.
   matcher: [
-    String.raw`/((?!(?:api|_next|fonts|images|assets|dev-docs|static)(?:/|$)|.*\.(?:ico|png|jpg|jpeg|gif|svg|webp|woff2?|ttf|eot|css|js|map|json|txt|xml|csv|yaml|html|webmanifest)$).*)`,
+    '/((?!(?:api|_next|fonts|images|assets|dev-docs|static)(?:/|$)|.*\\.(?:ico|png|jpg|jpeg|gif|svg|webp|woff2?|ttf|eot|css|js|map|json|txt|xml|csv|yaml|html|webmanifest)$).*)',
   ],
 };


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

`config.matcher` excluded only `_next/static`, `_next/image`, `favicon.ico`, `sitemap.xml` and `robots.txt`. Everything else entered the middleware, including fonts, images, other static files and every `/api` call, purely to hit the early-return list at the top of the function and leave again:

```ts
if (pathname.startsWith('/_next') || pathname.startsWith('/api') ||
    pathname.startsWith('/fonts') || pathname.includes('.')) {
  return NextResponse.next();
}
```

On a page that pulls dozens of assets, that is dozens of edge invocations doing nothing.

This is part of the low-severity sweep in #2155.

## What is the new behavior?

The skips live in the matcher, so those requests never enter the middleware at all. Any path containing a dot is treated as a file request, which is why the clause is `[^?]*\.` rather than a list of extensions.

Nothing loses its security headers: `next.config.ts` `headers()` already applies them to `/(.*)` independently of the middleware, so an API response is unaffected by being skipped here.

## Related Issue(s)

Part of #2155

## Impact area

`apps/frontend` edge middleware. No change to what any document response contains.

## Validation performed

- `pnpm --filter frontend run type-check`, exit 0.
- `pnpm --filter frontend run lint`, exit 0.
- `middleware` and `securityHeaders` suites: 61 tests passed, exit 0.

New tests pin the contract in both directions, because the risk here is a matcher that accidentally stops covering a document route and silently drops its nonce CSP:

- `/`, `/signin`, `/dashboard` and `/appointments/123/workspace` still match.
- `/api/...`, `/_next/...`, `/fonts/...`, `/images/....svg`, `/favicon.ico`, `/robots.txt` and `/sitemap.xml` no longer do.

## Notes for the reviewer

Two other items from the same sweep are **not** here, deliberately.

**The react-datepicker stylesheet.** I moved it out of the root layout into the two components that render a calendar, then checked the built CSS: it makes no difference. Next merges that import into the same shared stylesheet the marketing pages already load, so the 24KB is still there. Splitting it genuinely would need the datepicker components behind a dynamic import, which is a different change with real UI risk. I reverted rather than ship a commit whose message claims a saving that the build does not show.

**The body-wide terminology MutationObserver.** Narrowing its scope from `document.body` to the app container looked attractive until I checked where modals render: several surfaces portal to `document.body`, so a narrower root would silently stop rewriting terminology inside them. Doing this properly means applying terminology at render time through the existing `useCompanionTerminologyText` hook, which is a broad refactor across many components rather than a sweep item. Worth its own issue.
