### PR TITLE
perf(frontend): point the hero media at re-encoded assets

### DIFF
--- a/apps/frontend/src/app/constants/mediaSources.ts
+++ b/apps/frontend/src/app/constants/mediaSources.ts
@@ -41,7 +41,7 @@ export const MEDIA_SOURCES = {
     afterPattern: ycCdn('Images/ftafter.png'),
   },
   auth: {
-    background: ycCdn('Images/SignUpBg.png'),
+    background: ycCdn('Images/SignUpBg-v2.webp'),
     passwordEye: ycCdn('Images/eyes.png'),
   },
   cookies: {
@@ -114,16 +114,16 @@ export const MEDIA_SOURCES = {
     slide3: ycCdn('Images/landingbg3.jpg'),
     hero: {
       home: {
-        video: ycCdn('assets/landing/home-dog-field.mp4'),
+        video: ycCdn('assets/landing/home-dog-field-v2.mp4'),
         poster: ycCdn('assets/landing/home-dog-portrait.jpg'),
       },
       businesses: {
-        video: ycCdn('assets/landing/businesses-horse-vet.mp4'),
+        video: ycCdn('assets/landing/businesses-horse-vet-v2.mp4'),
         poster: ycCdn('assets/landing/businesses-horse-portrait.jpg'),
         image: ycCdn('assets/landing/businesses-dog-vet.jpg'),
       },
       petParents: {
-        video: ycCdn('assets/landing/parents-cat-kid.mp4'),
+        video: ycCdn('assets/landing/parents-cat-kid-v2.mp4'),
         poster: ycCdn('assets/landing/parents-cat-portrait.jpg'),
       },
     },


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The landing hero videos and the verify-email background ship far more bytes than their use needs. All three videos are muted, looping and decorative, sitting behind a scrim; the background is a **5760x4120 PNG - 23 megapixels for a CSS background** - carrying an alpha channel that is fully opaque in every pixel.

| Asset | Size |
| --- | --- |
| `parents-cat-kid.mp4` | 5.25 MB |
| `businesses-horse-vet.mp4` | 5.29 MB |
| `home-dog-field.mp4` | 1.27 MB |
| `SignUpBg.png` | 6.78 MB |

This is fix 4 of the workstream in #2155.

## What is the new behavior?

Re-encoded and uploaded to the CDN under `-v2` keys, which this PR points at:

| Asset | Before | After | Saving |
| --- | --- | --- | --- |
| parents-cat-kid | 5.25 MB | 1.56 MB | -70% |
| businesses-horse-vet | 5.29 MB | 1.87 MB | -65% |
| home-dog-field | 1.27 MB | 0.38 MB | -71% |
| SignUpBg (PNG to WebP) | 6.78 MB | 0.06 MB | -99% |

**18.59 MB down to 3.87 MB.**

Video is H.264 high profile at CRF 30-32 with `faststart`, same 720p, no audio (there was none to begin with). The background moves to WebP at 2560px wide; nothing is lost dropping alpha because it was opaque everywhere.

WebM variants are also on the CDN for `home-dog-field` (0.20 MB) and `parents-cat-kid` (1.51 MB), where VP9 beat H.264. They are not wired up in this PR - `HeroVideo` renders a single `<source>`, and adding format negotiation is a component change better kept separate. For `businesses-horse-vet` VP9 came out *larger* than H.264, so only the MP4 is used there.

## Related Issue(s)

Part of #2155

## Impact area

`apps/frontend` - one constants file. The CDN objects are already live.

## Validation performed

- `pnpm --filter frontend run type-check`, exit 0.
- `pnpm --filter frontend run lint`, exit 0.
- 22 suites, 174 tests passed, exit 0.
- Every new key verified live through CloudFront: HTTP 200, correct `Content-Type` (`video/mp4`, `video/webm`, `image/webp`) and `Cache-Control: public, max-age=31536000, immutable`.
- Quality checked rather than assumed: SSIM of the re-encode against the original is **0.956** on `businesses-horse-vet`, the highest-motion clip of the three, and higher on the other two. I also compared extracted frames side by side; the difference is not visible, and these play behind a scrim.

## Notes for the reviewer

**New keys, not overwrites.** The originals are untouched, so reverting this commit reverts the site with no CDN work, and no URL can be served as a mix of old and new while edges expire at different rates. The old objects can be deleted once this has been live for a while.

Two follow-ups worth their own issues: wiring up the WebM sources where they win, and `businesses-horse-portrait.jpg` (592 KB) plus `parents-cat-portrait.jpg` (492 KB) are poster frames that would also compress well.
