### PR TITLE
fix(ci): unbreak the TLS expiry check and stop it crying wolf

### DIFF
--- a/.github/workflows/tls-expiry.yml
+++ b/.github/workflows/tls-expiry.yml
@@ -44,13 +44,15 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Node
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v6.0.0
-        with:
-          node-version: 22
-
-      # No install step: the check deliberately uses only node:tls, so a broken
-      # lockfile can never stop a certificate warning from being delivered.
+      # Deliberately no setup-node and no install step. The check imports only
+      # node: builtins, so the runner's preinstalled Node is enough, and nothing
+      # about the workspace can stop a certificate warning from being delivered.
+      #
+      # setup-node was here and broke the job every day: the root package.json
+      # declares `packageManager: pnpm@...`, which setup-node v6 auto-detects and
+      # then fails on with "Unable to locate executable file: pnpm" because pnpm
+      # is not installed at that point. The check never ran, and the handler below
+      # filed a certificate issue about it.
       - name: Check TLS expiry
         id: check
         run: |
@@ -70,28 +72,53 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            let report = 'The report could not be read; see the job log.';
+            let report = '';
             try {
-              report = fs.readFileSync('tls-report.txt', 'utf8');
+              report = fs.readFileSync('tls-report.txt', 'utf8').trim();
             } catch {}
-            const marker = '<!-- tls-expiry-tracker -->';
-            const title = 'TLS certificate expiring or untrusted';
-            const body = [
-              marker,
-              '',
-              'The daily TLS expiry check failed. Latest report:',
-              '',
-              '```',
-              report.trim(),
-              '```',
-              '',
-              'For an Amplify or ACM managed domain, renewal succeeds only while the',
-              "domain's DNS validation CNAME resolves. Add it in the zone's DNS and",
-              'leave it there permanently, otherwise every future renewal fails the',
-              'same silent way.',
-              '',
-              `Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-            ].join('\n');
+
+            // A job failure means one of two very different things, and saying
+            // "certificate expiring or untrusted" for both is how a broken runner
+            // gets reported as a security incident. The report file is the
+            // discriminator: the check writes it before it can fail on a finding,
+            // so no report means the check never got that far.
+            const checkRan = report.length > 0;
+            const run = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            const marker = checkRan
+              ? '<!-- tls-expiry-tracker -->'
+              : '<!-- tls-expiry-tooling -->';
+            const title = checkRan
+              ? 'TLS certificate expiring or untrusted'
+              : 'TLS expiry check could not run';
+            const labels = checkRan ? ['security'] : ['CI/CD'];
+
+            const body = checkRan
+              ? [
+                  marker,
+                  '',
+                  'The daily TLS expiry check reported a problem:',
+                  '',
+                  '```',
+                  report,
+                  '```',
+                  '',
+                  'For an Amplify or ACM managed domain, renewal succeeds only while the',
+                  "domain's DNS validation CNAME resolves. Add it in the zone's DNS and",
+                  'leave it there permanently, otherwise every future renewal fails the',
+                  'same silent way.',
+                  '',
+                  `Run: ${run}`,
+                ].join('\n')
+              : [
+                  marker,
+                  '',
+                  'The daily TLS expiry job failed **before** it could check any',
+                  'certificate, so this says nothing about their validity. Read the job',
+                  'log for the real cause.',
+                  '',
+                  `Run: ${run}`,
+                ].join('\n');
             const existing = await github.rest.search.issuesAndPullRequests({
               q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open in:body "${marker}"`,
             });
@@ -104,7 +131,7 @@ jobs:
                 ...context.repo,
                 title,
                 body,
-                labels: ['security'],
+                labels,
               });
               core.info(`opened issue #${created.data.number}`);
             }


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The daily TLS expiry job has been failing since it landed, and #2170 is what that produced: an issue titled **"TLS certificate expiring or untrusted"**, labelled `security`, whose entire report reads *"The report could not be read; see the job log."*

**No certificate is expiring or untrusted.** Verified directly against every host in the check:

| Host | Expires | Days | Verify |
| --- | --- | --- | --- |
| yosemitecrew.com | 2027-02-20 | 190 | ok |
| www.yosemitecrew.com | 2027-02-09 | 179 | ok |
| dev.yosemitecrew.com | 2027-02-26 | 196 | ok |
| api.yosemitecrew.com | 2026-11-01 | 79 | ok |
| devapi.yosemitecrew.com | 2026-10-22 | 69 | ok |
| ds.yosemitecrew.com | 2026-10-01 | 48 | ok |

The job died before checking anything:

```
##[error]Unable to locate executable file: pnpm.
```

The root `package.json` declares `packageManager: pnpm@8.15.6`. `actions/setup-node` v6 auto-detects that and fails, because pnpm is not installed at that point in the job. So the check never ran, and the `if: failure()` handler filed a certificate issue about a Node setup problem.

That is the worse of the two bugs. A workflow that reports tooling failures as security incidents trains everyone to ignore it, which defeats the point of a check that exists because a silent ACM renewal failure served an expired certificate to every visitor on 2026-08-13.

## What is the new behavior?

**`setup-node` is gone.** The check imports only `node:` builtins, so the runner's preinstalled Node runs it. The workflow already claimed this property in a comment ("No install step ... so a broken lockfile can never stop a certificate warning from being delivered"); removing the package-manager coupling makes it true.

**The failure handler distinguishes the two cases it was conflating.** The report file is the discriminator: the script writes every host line to stdout before it exits non-zero, so a report with content means the check ran and found something, and an empty one means it never got that far.

| Situation | Title | Label |
| --- | --- | --- |
| Check ran, found a problem | TLS certificate expiring or untrusted | `security` |
| Check could not run | TLS expiry check could not run | `CI/CD` |

They use different HTML markers, so a tooling failure cannot overwrite a live certificate warning or vice versa.

## Related Issue(s)

Fixes #2170

## Impact area

`.github/workflows/tls-expiry.yml` only. The check script is unchanged.

## Validation performed

- Ran `node scripts/ci/check-tls-expiry.mjs --warn-days 30 --fail-days 14` locally: exit 0, all six hosts PASS. This is the command the workflow runs, and it needs no install step, which is the point of dropping `setup-node`.
- Confirmed the discriminator on both branches:
  - Check runs and finds a problem (`--fail-days 9999`): exit 1 and `tls-report.txt` is 1154 bytes, so `checkRan` is true and the certificate issue is filed.
  - Check cannot run: no report file, so `checkRan` is false and the tooling issue is filed instead.
- Workflow YAML parses; steps are Checkout, Check TLS expiry, Open or update the tracking issue.
- Independently verified all six certificates with `openssl s_client`, table above.

## Notes for the reviewer

#2170 can be closed once this merges; there is nothing to remediate on the certificate side. The soonest real expiry is `ds.yosemitecrew.com` at 48 days, comfortably outside the 30-day warn threshold.

Worth knowing for other workflows in this repo: any job that uses `actions/setup-node` v6 without installing pnpm first will hit the same failure, because the detection is driven by the root `packageManager` field rather than by anything in the job.
