### PR TITLE
fix(repo): bump nanoid override to 3.3.18 for CVE-2026-67213

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
       "inline-style-parser@<=0.2.9": "0.2.9",
       "nodemailer": "9.0.2",
       "immer": "11.1.15",
-      "nanoid@3": "3.3.17",
+      "nanoid@3": "3.3.18",
       "tar": "7.5.22",
       "tar-fs@<=3.1.3": "3.1.3",
       "fast-uri": "4.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,7 +96,7 @@ overrides:
   inline-style-parser@<=0.2.9: 0.2.9
   nodemailer: 9.0.2
   immer: 11.1.15
-  nanoid@3: 3.3.17
+  nanoid@3: 3.3.18
   tar: 7.5.22
   tar-fs@<=3.1.3: 3.1.3
   fast-uri: 4.1.2
@@ -8166,7 +8166,7 @@ packages:
       react: '*'
       react-native: '*'
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       react: 19.1.0
       react-native: 0.81.6(@babel/core@7.29.7)(@react-native-community/cli@20.0.2)(@react-native/metro-config@0.81.6)(@types/react@19.2.11)(react@19.1.0)
     dev: false
@@ -11281,7 +11281,7 @@ packages:
       '@react-navigation/routers': 7.6.4
       escape-string-regexp: 4.0.0
       fast-deep-equal: 3.1.3
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       query-string: 7.1.3
       react: 19.1.0
       react-is: 19.2.8
@@ -11368,7 +11368,7 @@ packages:
       '@react-navigation/core': 7.21.12(react@19.1.0)
       escape-string-regexp: 4.0.0
       fast-deep-equal: 3.1.3
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       react: 19.1.0
       react-native: 0.81.6(@babel/core@7.29.7)(@react-native-community/cli@20.0.2)(@react-native/metro-config@0.81.6)(@types/react@19.2.11)(react@19.1.0)
       standard-navigation: 0.0.8(react@19.1.0)
@@ -11378,7 +11378,7 @@ packages:
   /@react-navigation/routers@7.6.4:
     resolution: {integrity: sha512-GI7eJm8/KsZUQaYcXvEExikKurRZRgEsSzyZ7faENfi65yqJBCXjDMwyN1pF6pNW1MoLH1ErDwDivFxY6BzD3w==}
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
     dev: false
 
   /@react-types/shared@3.36.1(react@19.2.4):
@@ -24615,8 +24615,8 @@ packages:
     dev: true
     optional: true
 
-  /nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  /nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -26449,7 +26449,7 @@ packages:
     resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -29654,7 +29654,7 @@ packages:
       lodash.mergewith: 4.6.2
       lodash.throttle: 4.1.1
       lodash.uniqby: 4.7.0
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       react-dropzone: 14.4.1(react@19.2.4)


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

On the middle box: our bug template says security problems must not be filed as public issues. This is an already published upstream advisory rather than a report against our own code, so it is tracked by the GitHub code scanning alert rather than by a new public issue.

## What is the current behavior?

The root `package.json` pins `pnpm.overrides["nanoid@3"]` to `3.3.17`, which is inside the vulnerable range of a newer advisory:

- GHSA-2v37-7h3g-55p8 / CVE-2026-67213, published 2026-07-29, high severity
- "custom generators can loop indefinitely when size is zero"
- 3.x vulnerable range `< 3.3.18`, first patched `3.3.18`

Every nanoid in the tree therefore resolved to a vulnerable version. Grype reports it in two places:

- `/pnpm-lock.yaml`
- `/node_modules/.pnpm/nanoid@3.3.17/node_modules/nanoid/package.json`

The pin was not wrong when it was written. `3.3.17` cleared GHSA-28wg-ghj8-5hjv, whose range is `< 3.3.16`. The later advisory raised the patched floor by a single patch version and the existing pin quietly fell below it. This is worth noting as a pattern: a pin that fixes one advisory is not self-maintaining, because a later advisory can move the floor above it.

nanoid is not a direct dependency of any workspace. It arrives through six transitive edges, all of which request a 3.x range, so the single `nanoid@3` override key covers all of them:

| Parent | Requested range |
| --- | --- |
| `postcss` | `^3.3.16` |
| `stream-chat-react` | `^3.3.4` |
| `@react-navigation/core` | `^3.3.11` |
| `@react-navigation/native` | `^3.3.11` |
| `@react-navigation/routers` | `^3.3.11` |
| `@gorhom/portal` | `^3.3.1` |

## What is the new behavior?

`pnpm.overrides["nanoid@3"]` is bumped to `3.3.18`, the first patched release and also the final release on the 3.x line (`legacy` dist tag).

After `pnpm install`:

- `pnpm-lock.yaml` contains a single package entry, `/nanoid@3.3.18`, and all six edges point at it
- `node_modules/.pnpm` contains exactly one nanoid directory, `nanoid@3.3.18`
- the lockfile integrity hash matches the tarball published on the registry
- all 103 override entries in `pnpm-lock.yaml` still match `package.json` exactly, so a `--frozen-lockfile` install stays valid

`3.3.18` sits outside the range of every published nanoid advisory. Checked with semver against the GitHub advisory API rather than read by eye:

| Advisory | Affected range | 3.3.17 | 3.3.18 |
| --- | --- | --- | --- |
| GHSA-28wg-ghj8-5hjv | `< 3.3.16` | not affected | not affected |
| GHSA-2v37-7h3g-55p8 | `< 3.3.18` | **affected** | not affected |
| GHSA-mwcw-c2x4-8c55 | `< 3.3.8` | not affected | not affected |
| GHSA-qrpm-p2h7-hrv2 | `>= 3.0.0, < 3.1.31` | not affected | not affected |

### Why this is safe to take

The upstream change between the two versions is three files: the version string, three README lines, and one functional hunk. That hunk is a purely additive guard in `async/index.native.js`, which was the only entry point that still lacked it:

```js
-  return size => tick('', size)
+  return (size = defaultSize) => {
+    if (size <= 0) return Promise.resolve('')
+    return tick('', size)
+  }
```

No public API, export map, `engines`, or type surface changed, so there is nothing for a consumer to adapt to. Behaviour only differs on the path that previously hung.

### Validation

Run on this branch, per workspace:

| Workspace | Result |
| --- | --- |
| `frontend` | type-check, lint, test, build all pass (58/58 static pages) |
| `mobileAppYC` | type-check, lint pass; 456 suites / 7446 tests pass |
| `@yosemite-crew/desktop` | type-check, lint, test, build all pass |
| `dev-docs` | build passes |
| `backend` | type-check, lint, test all pass |

One note on `backend`: in a freshly created worktree its type-check and lint fail before `packages/*/dist` exists, with `TS2307: Cannot find module '@yosemite-crew/auth'` and roughly 9700 cascading `no-unsafe-*` lint errors. That is a worktree setup requirement, not a consequence of this change. Building the shared packages first takes it to exit 0 on all three with no source changes.

### Known residual, out of scope for this PR

Next.js vendors its own ncc-bundled copy of nanoid at `next/dist/compiled/nanoid/`. That copy is still the pre-fix implementation: it has no `size <= 0` guard and retains the unbounded `while (true)` loop. `pnpm.overrides` structurally cannot reach it, because it is a bundled file rather than a resolvable dependency edge.

Two things make this genuinely out of scope rather than something deferred out of convenience:

- It is not fixed upstream either. `next@16.3.1`, the current latest, still ships the same unpatched vendored copy, so a Next upgrade would not resolve it.
- Grype does not flag it, and this PR does clear the reported alert. The vendored `package.json` carries no version field, so it cannot be range-matched. Every nanoid alert on the repo points at the two locations listed above, and none point at a `dist/compiled` path.

Recording it here so the next reader does not conclude from the green scan that no vulnerable nanoid code remains anywhere on disk. Reachability was not established in either direction; Next's own usage is consistent with fixed-size ID generation.

## Related Issue(s)

Tracked by the GitHub code scanning alert for GHSA-2v37-7h3g-55p8 (nanoid).

Advisory: https://github.com/advisories/GHSA-2v37-7h3g-55p8
