### PR TITLE
fix(frontend): wire the permission-denied state contract and repair the Storybook build

### DIFF
--- a/apps/frontend/.storybook/main.ts
+++ b/apps/frontend/.storybook/main.ts
@@ -11,7 +11,6 @@ const config: StorybookConfig = {
     autodocs: 'tag',
   },
   staticDirs: [
-    { from: '../public/assets', to: '/assets' },
     { from: '../public/fonts', to: '/fonts' },
     { from: '../public/images', to: '/images' },
     { from: '../public/static', to: '/static' },

--- a/apps/frontend/src/app/__tests__/components/Fallback/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Fallback/index.test.tsx
@@ -1,12 +1,57 @@
-import React from "react";
-import { render, screen } from "@testing-library/react";
-import "@testing-library/jest-dom";
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
 
-import Fallback from "@/app/ui/overlays/Fallback";
+import Fallback from '@/app/ui/overlays/Fallback';
 
-describe("Fallback", () => {
-  it("renders not authorized message", () => {
+const push = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push, back: jest.fn() }),
+}));
+
+describe('Fallback', () => {
+  beforeEach(() => {
+    push.mockClear();
+  });
+
+  it("names the missing resource instead of a bare 'Not authorized' line", () => {
+    render(<Fallback resource="billing and subscription" />);
+
+    expect(screen.getByText(/billing and subscription/)).toBeInTheDocument();
+    expect(screen.queryByText('Not authorized')).not.toBeInTheDocument();
+  });
+
+  it("quotes the caller's role so the denial explains itself", () => {
+    render(<Fallback resource="documents" />);
+
+    // With no resolvable membership the shared state falls back to a neutral
+    // phrase rather than inventing a role.
+    expect(screen.getByText(/your current role/)).toBeInTheDocument();
+  });
+
+  it('falls back to a generic section label when no resource is given', () => {
     render(<Fallback />);
-    expect(screen.getByText("Not authorized")).toBeInTheDocument();
+
+    expect(screen.getByText(/this section/)).toBeInTheDocument();
+  });
+
+  it('offers a route forward rather than a dead end', async () => {
+    const user = userEvent.setup();
+    render(<Fallback resource="rooms" />);
+
+    const requestAccess = screen.getByRole('button', { name: 'Request access' });
+    expect(requestAccess).toBeInTheDocument();
+
+    await user.click(requestAccess);
+    expect(push).toHaveBeenCalledWith('/organization');
+  });
+
+  it('renders as a status, not an error', () => {
+    render(<Fallback resource="rooms" />);
+
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/index.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/index.tsx
@@ -57,7 +57,6 @@ import {
 import { usePermissions } from '@/app/hooks/usePermissions';
 import { PERMISSIONS } from '@/app/lib/permissions';
 import { PermissionGate } from '@/app/ui/layout/guards/PermissionGate';
-import Fallback from '@/app/ui/overlays/Fallback';
 import { resolveDefaultAppointmentsView } from '@/app/lib/defaultAppointmentsView';
 import { allowReschedule, normalizeAppointmentStatus } from '@/app/lib/appointments';
 import { useNotify } from '@/app/hooks/useNotify';
@@ -586,7 +585,11 @@ const useAppointmentsView = () => {
         />
         <MobileSearchBar placeholder="Search appointments" />
 
-        <PermissionGate allOf={[PERMISSIONS.APPOINTMENTS_VIEW_ANY]} fallback={<Fallback />}>
+        <PermissionGate
+          allOf={[PERMISSIONS.APPOINTMENTS_VIEW_ANY]}
+          deniedResource="Appointments"
+          deniedDetail="the appointment schedule"
+        >
           <div className={wrapperClassName}>
             {activeView === 'list' && (
               <Filters

--- a/apps/frontend/src/app/features/dashboard/pages/Dashboard.tsx
+++ b/apps/frontend/src/app/features/dashboard/pages/Dashboard.tsx
@@ -6,6 +6,7 @@ import DashboardProfile from '@/app/ui/widgets/DashboardProfile/DashboardProfile
 import OrgGuard from '@/app/ui/layout/guards/OrgGuard';
 import PageSkeleton from '@/app/ui/layout/PageSkeleton';
 import { PermissionGate } from '@/app/ui/layout/guards/PermissionGate';
+import Fallback from '@/app/ui/overlays/Fallback';
 import { PERMISSIONS } from '@/app/lib/permissions';
 
 const DASHBOARD_PAGE_SKELETON = <PageSkeleton variant="dashboard" />;
@@ -62,7 +63,10 @@ const Dashboard = () => {
       <DashboardProfile />
       <DashboardSteps />
       <VideosCard />
-      <PermissionGate allOf={[PERMISSIONS.ANALYTICS_VIEW_ANY]}>
+      <PermissionGate
+        allOf={[PERMISSIONS.ANALYTICS_VIEW_ANY]}
+        fallback={<Fallback resource="practice analytics" />}
+      >
         <Explorecard />
         {/* Vertical day charts: tablet (>=768) and desktop only. The 390px phone
             frames omit them and jump from the stat tiles straight to the schedule. */}
@@ -74,7 +78,10 @@ const Dashboard = () => {
       {/* Schedule follows the charts row, matching the design scroll order
           (explore -> charts -> schedule -> leaders -> turnover -> availability). */}
       <AppointmentTask />
-      <PermissionGate allOf={[PERMISSIONS.ANALYTICS_VIEW_ANY]}>
+      <PermissionGate
+        allOf={[PERMISSIONS.ANALYTICS_VIEW_ANY]}
+        fallback={<Fallback resource="practice analytics" />}
+      >
         <div className="grid grid-cols-1 gap-3 md:grid-cols-2 md:gap-3 xl:gap-3.5">
           <AppointmentLeadersStat />
           <RevenueLeadersStat />

--- a/apps/frontend/src/app/features/forms/pages/Forms/index.tsx
+++ b/apps/frontend/src/app/features/forms/pages/Forms/index.tsx
@@ -21,7 +21,6 @@ import OrgGuard from '@/app/ui/layout/guards/OrgGuard';
 import { usePermissions } from '@/app/hooks/usePermissions';
 import { PERMISSIONS } from '@/app/lib/permissions';
 import { PermissionGate } from '@/app/ui/layout/guards/PermissionGate';
-import Fallback from '@/app/ui/overlays/Fallback';
 import { getPlannerLayoutClassNames, usePlannerAutoLock } from '@/app/hooks/usePlannerLayout';
 import MobileSearchBar from '@/app/ui/layout/MobileSearchBar/MobileSearchBar';
 
@@ -288,7 +287,11 @@ const Forms = () => {
       </div>
 
       <MobileSearchBar placeholder="Search templates" />
-      <PermissionGate allOf={[PERMISSIONS.FORMS_VIEW_ANY]} fallback={<Fallback />}>
+      <PermissionGate
+        allOf={[PERMISSIONS.FORMS_VIEW_ANY]}
+        deniedResource="Templates"
+        deniedDetail="form and document templates"
+      >
         <div className={wrapperClassName}>
           <FormsFilters
             filters={filters}

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/DocumentESigning.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/DocumentESigning.tsx
@@ -4,6 +4,7 @@ import clsx from 'clsx';
 import { IoShieldCheckmarkOutline } from 'react-icons/io5';
 import SectionCard from '@/app/ui/primitives/SectionCard/SectionCard';
 import { PermissionGate } from '@/app/ui/layout/guards/PermissionGate';
+import Fallback from '@/app/ui/overlays/Fallback';
 import { PERMISSIONS } from '@/app/lib/permissions';
 import DocSigningPortal from '@/app/features/docSigning/components/DocSigningPortal';
 import { useNotify } from '@/app/hooks/useNotify';
@@ -62,7 +63,10 @@ const DocumentESigning = () => {
   };
 
   return (
-    <PermissionGate allOf={[PERMISSIONS.DOCUMENT_VIEW_ANY]}>
+    <PermissionGate
+      allOf={[PERMISSIONS.DOCUMENT_VIEW_ANY]}
+      fallback={<Fallback resource="document e-signing settings" />}
+    >
       <SectionCard title="E-signing" showButton={false}>
         <div className="rounded-[18px] border border-[var(--hairline)] bg-[var(--screen)] overflow-hidden shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]">
           <div className="px-5! py-3! border-b border-[var(--hairline)] text-[11.5px] text-[var(--ink-faint)]">

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Documents/Documents.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Documents/Documents.tsx
@@ -8,6 +8,7 @@ import { OrganizationDocument } from '@/app/features/documents/types/document';
 import { usePermissions } from '@/app/hooks/usePermissions';
 import { PERMISSIONS } from '@/app/lib/permissions';
 import { PermissionGate } from '@/app/ui/layout/guards/PermissionGate';
+import Fallback from '@/app/ui/overlays/Fallback';
 import { toTitle } from '@/app/lib/validators';
 import StatusPill, { type StatusPillTokens } from '@/app/ui/primitives/StatusPill/StatusPill';
 import {
@@ -62,7 +63,10 @@ const Documents = () => {
   };
 
   return (
-    <PermissionGate allOf={[PERMISSIONS.DOCUMENT_VIEW_ANY]}>
+    <PermissionGate
+      allOf={[PERMISSIONS.DOCUMENT_VIEW_ANY]}
+      fallback={<Fallback resource="documents" />}
+    >
       <SectionCard
         title="Documents"
         buttonTitle="Add"

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Payment.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Payment.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { IoCardOutline } from 'react-icons/io5';
 import { useSubscriptionForPrimaryOrg } from '@/app/hooks/useBilling';
 import { PermissionGate } from '@/app/ui/layout/guards/PermissionGate';
+import Fallback from '@/app/ui/overlays/Fallback';
 import { PERMISSIONS } from '@/app/lib/permissions';
 import { usePermissions } from '@/app/hooks/usePermissions';
 
@@ -36,7 +37,10 @@ const Payment = () => {
   const showManage = canManageStripe && !!orgId;
 
   return (
-    <PermissionGate allOf={[PERMISSIONS.SUBSCRIPTION_VIEW_ANY]}>
+    <PermissionGate
+      allOf={[PERMISSIONS.SUBSCRIPTION_VIEW_ANY]}
+      fallback={<Fallback resource="billing and subscription" />}
+    >
       <div className="flex items-center gap-3 rounded-[18px] border border-[var(--hairline)] bg-[var(--screen)] px-5! py-[15px]! shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]">
         <span className="flex size-9 flex-none items-center justify-center rounded-[11px] bg-[var(--blue-soft)] text-[var(--blue-text)]">
           <IoCardOutline size={16} aria-hidden="true" />

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/Rooms.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/Rooms.tsx
@@ -11,6 +11,7 @@ import RoomInfo from '@/app/features/organization/pages/Organization/Sections/Ro
 import { useRoomsForPrimaryOrg } from '@/app/hooks/useRooms';
 import { OrganisationRoom } from '@yosemite-crew/types';
 import { PermissionGate } from '@/app/ui/layout/guards/PermissionGate';
+import Fallback from '@/app/ui/overlays/Fallback';
 import { PERMISSIONS } from '@/app/lib/permissions';
 import { usePermissions } from '@/app/hooks/usePermissions';
 import { humanize } from '@/app/features/organization/pages/Organization/Sections/orgDisplay';
@@ -124,7 +125,7 @@ const Rooms = () => {
   };
 
   return (
-    <PermissionGate allOf={[PERMISSIONS.ROOM_VIEW_ANY]}>
+    <PermissionGate allOf={[PERMISSIONS.ROOM_VIEW_ANY]} fallback={<Fallback resource="rooms" />}>
       <section className="overflow-hidden rounded-[18px] border border-[var(--hairline)] bg-[var(--screen)] shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]">
         <div className="flex items-center justify-between gap-3 px-5! pt-4! pb-3!">
           <h2 className="text-[15.5px] font-bold tracking-[-0.01em] text-[var(--ink)]">

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Specialities/Specialities.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Specialities/Specialities.tsx
@@ -6,6 +6,7 @@ import SpecialityInfo from '@/app/features/organization/pages/Organization/Secti
 import { useSpecialitiesWithServiceNamesForPrimaryOrg } from '@/app/hooks/useSpecialities';
 import { SpecialityWeb } from '@/app/features/organization/types/speciality';
 import { PermissionGate } from '@/app/ui/layout/guards/PermissionGate';
+import Fallback from '@/app/ui/overlays/Fallback';
 import { PERMISSIONS } from '@/app/lib/permissions';
 import { usePermissions } from '@/app/hooks/usePermissions';
 import { useOrgStore } from '@/app/stores/orgStore';
@@ -70,7 +71,10 @@ const Specialities = () => {
     : [];
 
   return (
-    <PermissionGate allOf={[PERMISSIONS.SPECIALITIES_VIEW_ANY]}>
+    <PermissionGate
+      allOf={[PERMISSIONS.SPECIALITIES_VIEW_ANY]}
+      fallback={<Fallback resource="specialities, services and packages" />}
+    >
       <SectionCard
         title="Specialties, services & packages"
         buttonTitle="Manage"

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Team/Team.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Team/Team.tsx
@@ -6,6 +6,7 @@ import TeamInfo from '@/app/features/organization/pages/Organization/Sections/Te
 import { useTeamForPrimaryOrg } from '@/app/hooks/useTeam';
 import { Team as TeamProp } from '@/app/features/organization/types/team';
 import { PermissionGate } from '@/app/ui/layout/guards/PermissionGate';
+import Fallback from '@/app/ui/overlays/Fallback';
 import { PERMISSIONS } from '@/app/lib/permissions';
 import { usePermissions } from '@/app/hooks/usePermissions';
 import { getSafeImageUrl } from '@/app/lib/urls';
@@ -122,7 +123,10 @@ const Team = ({ isVerified = false }: { isVerified?: boolean }) => {
   };
 
   return (
-    <PermissionGate allOf={[PERMISSIONS.TEAMS_VIEW_ANY]}>
+    <PermissionGate
+      allOf={[PERMISSIONS.TEAMS_VIEW_ANY]}
+      fallback={<Fallback resource="the team roster" />}
+    >
       <section className="flex flex-col overflow-hidden rounded-[18px] border border-[var(--hairline)] bg-[var(--screen)] shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]">
         <div className="flex items-center justify-between gap-3 px-5! pt-4! pb-3!">
           <h2 className="text-[15.5px] font-bold tracking-[-0.01em] text-[var(--ink)]">

--- a/apps/frontend/src/app/features/tasks/pages/Tasks/index.tsx
+++ b/apps/frontend/src/app/features/tasks/pages/Tasks/index.tsx
@@ -22,7 +22,6 @@ import { useIsPhone } from '@/app/ui/layout/PhoneShell/useIsPhone';
 import { usePermissions } from '@/app/hooks/usePermissions';
 import { PERMISSIONS } from '@/app/lib/permissions';
 import { PermissionGate } from '@/app/ui/layout/guards/PermissionGate';
-import Fallback from '@/app/ui/overlays/Fallback';
 import { getPlannerLayoutClassNames, usePlannerAutoLock } from '@/app/hooks/usePlannerLayout';
 import MobileSearchBar from '@/app/ui/layout/MobileSearchBar/MobileSearchBar';
 import { usePhonePrimaryAction } from '@/app/ui/layout/PhoneShell/usePhonePrimaryAction';
@@ -346,7 +345,11 @@ const Tasks = () => {
         />
         <MobileSearchBar placeholder="Search tasks" />
 
-        <PermissionGate allOf={[PERMISSIONS.TASKS_VIEW_ANY]} fallback={<Fallback />}>
+        <PermissionGate
+          allOf={[PERMISSIONS.TASKS_VIEW_ANY]}
+          deniedResource="Tasks"
+          deniedDetail="tasks and assignments"
+        >
           <div className={wrapperClassName}>
             {showsTaskFilterBar && (
               <TaskFilterBar

--- a/apps/frontend/src/app/ui/layout/states/PermissionDeniedState.tsx
+++ b/apps/frontend/src/app/ui/layout/states/PermissionDeniedState.tsx
@@ -16,6 +16,12 @@ export type PermissionDeniedStateProps = {
   role?: string;
   /** Org whose membership role is shown; defaults to the primary org. */
   orgId?: string | null;
+  /**
+   * `page` (default) renders the centered card for a whole route.
+   * `inline` renders a compact notice sized for a section or panel, where a
+   * full-page card would overwhelm the surrounding layout.
+   */
+  variant?: 'page' | 'inline';
   onRequestAccess?: () => void;
   onBack?: () => void;
 };
@@ -25,6 +31,7 @@ const PermissionDeniedState = ({
   detail,
   role,
   orgId,
+  variant = 'page',
   onRequestAccess,
   onBack,
 }: PermissionDeniedStateProps) => {
@@ -40,6 +47,22 @@ const PermissionDeniedState = ({
 
   const handleRequestAccess = onRequestAccess ?? (() => router.push('/organization'));
   const handleBack = onBack ?? (() => router.back());
+
+  if (variant === 'inline') {
+    return (
+      <div className="yc-state-inline" role="status">
+        <span className="yc-state-inline-icon" aria-hidden>
+          <IoLockClosedOutline size={15} />
+        </span>
+        <span className="yc-state-inline-text">
+          Your role ({resolvedRole}) can&apos;t view {resolvedDetail}.{' '}
+          <button type="button" className="yc-state-inline-link" onClick={handleRequestAccess}>
+            Request access
+          </button>
+        </span>
+      </div>
+    );
+  }
 
   return (
     <div className="yc-state-wrap">

--- a/apps/frontend/src/app/ui/layout/states/StateScreens.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/states/StateScreens.stories.tsx
@@ -2,12 +2,22 @@ import type { Meta, StoryObj } from '@storybook/react';
 import FilteredEmptyState from './FilteredEmptyState';
 import NotFoundState from './NotFoundState';
 import PermissionDeniedState from './PermissionDeniedState';
+import Fallback from '../../overlays/Fallback';
 
 /**
  * The app-wide global state screens from the "Chrome & States" design: a
  * `--screen` card (hairline, radius-20, layered shadow) centered on the page,
  * with an icon disc / Newsreader 404, a title, muted body copy and pill
  * actions. Light + dark resolve through the shared token layer.
+ *
+ * `PermissionDeniedState` ships two variants:
+ * - `page` (default) — the centered card, for a whole route. Reached by passing
+ *   `deniedResource` to `PermissionGate`.
+ * - `inline` — a compact notice for a section or panel, where the full card
+ *   would overwhelm the layout. This is what `<Fallback />` now renders.
+ *
+ * A permission boundary is an *expected* state, not a failure, so neither
+ * variant uses error styling.
  */
 const meta = {
   title: 'Layout/States',
@@ -33,7 +43,11 @@ export const NotFound: Story = {
   ),
 };
 
-/** Permission denied — warn-toned lock disc, request-access + back actions. */
+/**
+ * Permission denied, page variant — warn-toned lock disc, request-access +
+ * back actions. Rendered when a route-level `PermissionGate` is given
+ * `deniedResource`.
+ */
 export const PermissionDenied: Story = {
   render: () => (
     <div className="yc-state-wrap">
@@ -46,11 +60,65 @@ export const PermissionDenied: Story = {
   ),
 };
 
+/**
+ * Permission denied, inline variant — the compact section notice. Names the
+ * caller's real role and the missing resource, and offers a way forward,
+ * instead of the bare red "Not authorized" line this replaced.
+ */
+export const PermissionDeniedInline: Story = {
+  render: () => (
+    <div style={{ maxWidth: 560, padding: 24, display: 'grid', gap: 12 }}>
+      <PermissionDeniedState
+        variant="inline"
+        resource="billing and subscription"
+        detail="billing and subscription"
+        role="Receptionist"
+      />
+      <PermissionDeniedState
+        variant="inline"
+        resource="the team roster"
+        detail="the team roster"
+        role="Assistant"
+      />
+    </div>
+  ),
+};
+
+/**
+ * `<Fallback />` — the section-level denial used by `PermissionGate`'s
+ * `fallback` prop at ~16 call sites. Now a thin wrapper over the inline
+ * variant; previously a bare red "Not authorized" line.
+ */
+export const SectionFallback: Story = {
+  render: () => (
+    <div style={{ maxWidth: 560, padding: 24, display: 'grid', gap: 12 }}>
+      <Fallback resource="practice analytics" />
+      <Fallback resource="documents" />
+      <Fallback />
+    </div>
+  ),
+};
+
 /** Filtered-empty — blue filter disc, "Clear all filters" action. */
 export const FilteredEmpty: Story = {
   render: () => (
     <div className="yc-state-wrap">
       <FilteredEmptyState onClearFilters={() => {}} />
+    </div>
+  ),
+};
+
+/**
+ * Filtered-empty without a clear handler — the action is hidden rather than
+ * rendering a dead button.
+ */
+export const FilteredEmptyNoAction: Story = {
+  render: () => (
+    <div className="yc-state-wrap">
+      <FilteredEmptyState
+        title="No invoices in this range"
+        message="Adjust the date range or clear the status filter to see more."
+      />
     </div>
   ),
 };

--- a/apps/frontend/src/app/ui/layout/states/states.css
+++ b/apps/frontend/src/app/ui/layout/states/states.css
@@ -77,6 +77,56 @@
   line-height: 1.6;
 }
 
+/* Compact denial notice for a section or panel, where the full page card would
+   overwhelm the surrounding layout. Informational tone, not error tone: a
+   permission boundary is an expected state, so it must not read as a failure. */
+.yc-state-inline {
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+  width: 100%;
+  border: 1px solid var(--hairline);
+  border-radius: 12px;
+  background: var(--inset);
+  padding: 11px 13px;
+}
+
+.yc-state-inline-icon {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 999px;
+  background: var(--warn-bg);
+  color: var(--warn-text);
+}
+
+.yc-state-inline-text {
+  color: var(--ink-muted);
+  font-family: var(--font-satoshi);
+  font-size: 12.5px;
+  font-weight: 500;
+  line-height: 1.5;
+}
+
+.yc-state-inline-link {
+  border: 0;
+  background: none;
+  padding: 0;
+  color: var(--blue-text);
+  font: inherit;
+  font-weight: 650;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.yc-state-inline-link:hover {
+  color: var(--blue);
+}
+
 .yc-state-actions {
   display: flex;
   flex-wrap: wrap;

--- a/apps/frontend/src/app/ui/overlays/Fallback/index.tsx
+++ b/apps/frontend/src/app/ui/overlays/Fallback/index.tsx
@@ -1,9 +1,35 @@
-import React from "react";
+import React from 'react';
+import PermissionDeniedState from '@/app/ui/layout/states/PermissionDeniedState';
 
-const Fallback = () => {
-  return (
-    <div className="w-full text-danger-600 text-body-4">Not authorized</div>
-  );
+export type FallbackProps = {
+  /**
+   * What the caller could not see, e.g. "invoices and payouts". Naming it lets
+   * the notice say which permission is missing instead of just "Not authorized".
+   */
+  resource?: string;
+  /** Org whose membership role is quoted; defaults to the primary org. */
+  orgId?: string | null;
 };
+
+/**
+ * Section-level permission denial.
+ *
+ * Previously this rendered a bare red "Not authorized" line: error styling for
+ * a non-error state, with no role named and no way forward. A permission
+ * boundary is an expected condition, so it now renders the shared
+ * PermissionDeniedState in its compact `inline` variant, which quotes the
+ * caller's real role and offers a request-access route.
+ *
+ * Page-level gates should pass `deniedResource` to PermissionGate instead,
+ * which renders the full centered card.
+ */
+const Fallback = ({ resource, orgId }: FallbackProps = {}) => (
+  <PermissionDeniedState
+    variant="inline"
+    resource={resource ?? 'this section'}
+    detail={resource}
+    orgId={orgId}
+  />
+);
 
 export default Fallback;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

**1. The permission-denied state contract is built but unreachable.**

`PermissionDeniedState` exists, resolves the caller's real role from org membership, and offers a request-access route. Nothing renders it: **0 of 35** `<PermissionGate>` call sites pass `deniedResource`. A denied check therefore renders one of two things:

- `null` at 19 sites, so the content silently vanishes with no explanation, or
- `Fallback`, used at 16 sites, which was literally:

```jsx
<div className="w-full text-danger-600 text-body-4">Not authorized</div>
```

That is error styling for a state that is not an error, naming no role and offering no way forward. Only 1 of 35 gates passed `skeleton`, so the rest blank-then-pop while permissions resolve.

**2. `storybook:build` fails on a clean checkout of `dev`.**

```
Error: Failed to load static files, no such directory: apps/frontend/public/assets
```

`.storybook/main.ts` still listed `../public/assets` in `staticDirs`, but that directory was removed by #2156. Storybook hard-errors on a missing staticDir, so `storybook:build` and `chromatic` (which runs `--build-script-name=storybook:build`) were both broken. This is the likely reason the component library had gone stale.

## What is the new behavior?

- `PermissionDeniedState` gains a `variant: 'page' | 'inline'` prop. `page` keeps the existing centered card; `inline` is a compact section notice, so a denial inside a panel no longer needs a full-page card. Both use informational tone, not error tone, because a permission boundary is an expected state.
- `Fallback` is rewritten over the inline variant. It names the missing resource and quotes the caller's real role, with a request-access route. The `resource` prop is optional, so all 16 existing call sites improve with no churn.
- Three page-level gates now pass `deniedResource` + `deniedDetail`: Tasks, Templates, Appointments. `PermissionDeniedState` is no longer dead code.
- Eight section gates that previously rendered nothing now render the inline notice naming the resource: Organization > Specialities, Team, Rooms, Payment, Documents, DocumentESigning, and Dashboard analytics (x2).
- The dead `staticDirs` entry is removed. All 16 remaining entries were verified to exist, and nothing in Storybook references `/assets`.
- `StateScreens.stories.tsx` gains `PermissionDeniedInline`, `SectionFallback` and `FilteredEmptyNoAction`.

The previous `Fallback` test asserted the defect being fixed here (`getByText("Not authorized")`). It is replaced with five cases covering resource naming, role quoting, the generic fallback, the request-access route, and `role="status"` rather than `alert`.

## Impact area

`apps/frontend` only. No API, schema or backend change. No change to who is allowed to see what - this only changes what a denied user is shown.

## Validation performed

| Check | Result |
| --- | --- |
| `pnpm --filter frontend run type-check` | pass |
| `pnpm --filter frontend run lint` | pass |
| `pnpm --filter frontend run test` (targeted) | 147 suites / 2021 tests pass |
| Coverage on changed files | 100% statements, branches, functions, lines on `Fallback/index.tsx`, `PermissionDeniedState.tsx`, `PermissionGate.tsx` |
| `pnpm --filter frontend run storybook:build` | pass (was failing on `dev` before this PR) |
| Pre-commit hooks | eslint, prettier and secretlint all ran and passed |

Visual verification was done in the real Next runtime (not only Storybook): both variants were rendered against the real `globals.css` token layer in light and dark, and the inline surface was confirmed to resolve to `--inset` `#eae2d5` with a `--hairline` `#e5dccf` border, with zero occurrences of the old red "Not authorized" line. Storybook stories were also checked in the built output.

Note for reviewers: a full end-to-end check of a denial against the deployed API could not be run locally, because `devapi` does not allow the `localhost` origin (pre-existing CORS infra issue, unrelated to this change). Worth a quick look on deployed dev after merge.

## Related Issue(s)

Fixes #2185
