### PR TITLE
chore(ci): hold the eslint and babel majors that React Native and Next block

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -79,6 +79,31 @@ updates:
       # patches) so the pair only moves atomically with the runtime upgrade
       # (#2125) - a patch bump here without the override recreates the mismatch.
       - dependency-name: 'playwright'
+      # @babel/core 8 cannot be installed while the app is on React Native
+      # 0.81: @react-native/babel-preset asserts Babel "^7.0.0-0" at load time
+      # and throws "Requires Babel ^7.0.0-0, but was loaded with 8.0.1" for
+      # every mobile file (#2116). This is a hard assertion inside the preset,
+      # not something a config can work around. Unfreeze with the React Native
+      # upgrade that ships a Babel 8 compatible preset.
+      - dependency-name: '@babel/core'
+        update-types: ['version-update:semver-major']
+      # eslint 10 is blocked in two workspaces at once (#2180), so the repo
+      # stays on 9 until both clear:
+      #   frontend - eslint-config-next 15.x loads @rushstack/eslint-patch,
+      #     which refuses to patch an ESLint it does not recognise and fails
+      #     with "Failed to patch ESLint because the calling module was not
+      #     recognized". eslint-config-next 16 drops the patch and declares
+      #     eslint >=9, so this clears with the Next 16 upgrade.
+      #   mobileAppYC - @react-native/eslint-config parses with
+      #     @babel/eslint-parser, whose scope manager ESLint 10 rejects
+      #     ("scopeManager.addGlobals is not a function"). Only
+      #     @babel/eslint-parser 8 supports ESLint 10, and it requires
+      #     @babel/core ^8, which React Native blocks per the entry above.
+      # Backend and desktop were verified to lint clean on 10 already; the hold
+      # is only so all four workspaces move together rather than splitting the
+      # toolchain across two ESLint majors.
+      - dependency-name: 'eslint'
+        update-types: ['version-update:semver-major']
     groups:
       # Every group is minor-and-patch only, including the named ones below. A
       # named group without `update-types` silently swallows MAJORS too, which is


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

Two dependabot major PRs have been open and red and cannot be made green from inside this repo. Both were attempted on a branch rather than judged on the failure text.

**#2116, @babel/core 7 to 8.** `@react-native/babel-preset@0.81.4` asserts the Babel version at load time and throws for every mobile file:

```
Requires Babel "^7.0.0-0", but was loaded with "8.0.1".
```

That assertion lives inside the preset. No config, resolution or override changes it, and the preset also carries `@babel/core: ^7.25.2` as a direct dependency of its own.

**#2180, eslint 8/9 to 10.** Blocked independently in two workspaces.

On the frontend, `eslint-config-next@15.5.18` loads `@rushstack/eslint-patch`, which refuses an ESLint it does not recognise:

```
Failed to patch ESLint because the calling module was not recognized.
```

`eslint-config-next` 16 drops the patch entirely and declares `eslint: >=9.0.0`, so this clears with the Next 16 upgrade. It could also be worked around today by dropping `eslint-config-next` and rebuilding Next's preset by hand from `@next/eslint-plugin-next`, which does have flat config exports and no patch. That was tried and rejected: it replaces a maintained shareable config with a local approximation of it, so any rule Next adds or changes later silently stops applying. That is not a trade worth making for a version bump.

On mobile, `@react-native/eslint-config` parses through `@babel/eslint-parser`, and ESLint 10 rejects the scope manager it returns:

```
TypeError: scopeManager.addGlobals is not a function
```

Only `@babel/eslint-parser@8` supports ESLint 10, and it requires `@babel/core: ^8.0.0`, which is the React Native constraint above. Overriding the whole `@typescript-eslint` family from 7 to 8 was also tried; it moves the failure from a plugin load error to this parser error but does not clear it.

## What is the new behavior?

Both majors are held in `.github/dependabot.yml`, in the same documented style as the existing entries, so they stop arriving as unmergeable weekly PRs. Minor and patch updates for both continue as normal, since only `version-update:semver-major` is ignored.

Each entry records the exact upstream blocker and the condition that unfreezes it.

## Impact area

Dependabot scheduling only. No application code, dependency or lockfile changes.

## Validation performed

Everything above was reproduced on a branch with the bumps installed, not read off CI:

- `eslint 10.8.1` installed repo wide. **backend and desktop lint clean on it**, root lints clean on it once its config is converted to flat. frontend and mobile fail as quoted.
- Flat configs were written for the root and for mobile and confirmed to be the blocking factor only for mobile, where the failure is the parser, not the config format.
- `@typescript-eslint` 7 to 8 override applied and re-run, to check the mobile failure was not just the plugin major.
- `@babel/core 8` failure text taken from the mobile lint run on #2116.
- `.github/dependabot.yml` parses, and the npm ecosystem block now carries 15 ignore entries including the two added here.

## Related Issue(s)

Closes #2116 and closes #2180. Revisit conditions are tracked in the file comments: the Next 16 upgrade for the frontend, and a React Native release with a Babel 8 compatible preset for mobile.
