### PR TITLE
ci(repo): hold every Sonar leg to 95% coverage, zero duplication, zero issues

### DIFF
--- a/.github/workflows/_sonar.yaml
+++ b/.github/workflows/_sonar.yaml
@@ -1,12 +1,20 @@
 name: Sonar
 
-# Reusable Sonar stage: scan only.
+# Reusable Sonar stage: scan, then hold the result to this repository's numbers.
 #
 # The previous workflow reinstalled dependencies, regenerated the Prisma client
 # and reran every suite with coverage purely so the scanner had something to
 # read. The test stage already produces that coverage, so this stage downloads it
-# and does nothing else. There is no pnpm install, no prisma generate and no jest
-# run here by design.
+# and scans. There is no pnpm install, no prisma generate and no jest run here
+# by design.
+#
+# The scan waits on SonarCloud's built-in "Sonar way" gate, which is the only
+# gate this organisation's plan allows. That gate passes at 80% coverage and 3%
+# duplication on new code and carries no issue condition, so the final step
+# reads the published measures and enforces 95% coverage, zero duplication and
+# zero open issues. See scripts/ci/sonar-thresholds.mjs for why that is a
+# separate step rather than a gate configured on the server, and
+# docs/ci/sonar-quality-bar.md for what the bar means on each analysis scope.
 #
 # The cost of scanning without an install is that rules needing type resolution
 # from node_modules see less than they would (backend and desktop set
@@ -127,3 +135,37 @@ jobs:
           args: -Dsonar.qualitygate.wait=true
         env:
           SONAR_TOKEN: ${{ (matrix.app_key == 'frontend' && secrets.SONAR_TOKEN_FRONTEND) || (matrix.app_key == 'backend' && secrets.SONAR_TOKEN_API) || (matrix.app_key == 'mobile' && secrets.SONAR_TOKEN_MOBILE) || (matrix.app_key == 'desktop' && secrets.SONAR_TOKEN_DESKTOP) || '' }}
+
+      # The bar, enforced. "Sonar way" passes at 80% coverage and 3% duplication
+      # on new code and has no issue condition at all, so the step above proves
+      # much less than it looks like it proves. This one reads the measures the
+      # analysis just published and holds every leg to 95% coverage, zero
+      # duplication and zero open issues (docs/ci/sonar-quality-bar.md).
+      # `always()` is deliberately absent: if the scan itself failed there are
+      # no measures to read, and the job is already red.
+      # Run FROM the scanned directory rather than passing it in. The scanner
+      # leaves report-task.txt under the directory it scanned, so this way the
+      # script reads a constant relative path and takes no path argument at all -
+      # a path assembled from an argument and then read is a file-inclusion sink
+      # whether or not anything hostile can reach the argument, and bounding it
+      # does not change that.
+      - name: Enforce the Sonar quality bar
+        working-directory: ${{ matrix.dir }}
+        env:
+          SONAR_TOKEN: ${{ (matrix.app_key == 'frontend' && secrets.SONAR_TOKEN_FRONTEND) || (matrix.app_key == 'backend' && secrets.SONAR_TOKEN_API) || (matrix.app_key == 'mobile' && secrets.SONAR_TOKEN_MOBILE) || (matrix.app_key == 'desktop' && secrets.SONAR_TOKEN_DESKTOP) || '' }}
+        run: |
+          set -euo pipefail
+          # On a pull_request event this workflow file resolves from the merge
+          # ref while the checkout above is the PR head, so a branch cut before
+          # the bar landed runs this step against a tree without the script.
+          # Fail with the actual fix rather than MODULE_NOT_FOUND.
+          SCRIPT="$GITHUB_WORKSPACE/scripts/ci/sonar-thresholds.mjs"
+          if [ ! -f "$SCRIPT" ]; then
+            echo "scripts/ci/sonar-thresholds.mjs is not in this checkout: the branch predates" >&2
+            echo "the Sonar quality bar. Update the branch from dev (rebase) and push again." >&2
+            exit 1
+          fi
+          node "$SCRIPT" \
+            --coverage 95 \
+            --duplication 0 \
+            --issues 0

--- a/.github/workflows/sonar-cloud-analysis.yml
+++ b/.github/workflows/sonar-cloud-analysis.yml
@@ -203,3 +203,21 @@ jobs:
           # a dynamic index exposes the whole secrets context to the expression,
           # which CodeQL reports as excessive secret exposure.
           SONAR_TOKEN: ${{ (matrix.app == 'frontend' && secrets.SONAR_TOKEN_FRONTEND) || (matrix.app == 'backend' && secrets.SONAR_TOKEN_API) || (matrix.app == 'mobile' && secrets.SONAR_TOKEN_MOBILE) || (matrix.app == 'desktop' && secrets.SONAR_TOKEN_DESKTOP) || '' }}
+
+      # Hold the nightly to the same bar as the per-PR and per-push _sonar
+      # stage: 95% coverage, zero duplication, zero open issues
+      # (docs/ci/sonar-quality-bar.md). This scan does not pass
+      # qualitygate.wait, so the script polls the compute engine itself before
+      # reading the measures. Run FROM the scanned directory: the scanner
+      # leaves report-task.txt there, and the script reads that constant
+      # relative path rather than taking a path argument.
+      - name: Enforce the Sonar quality bar
+        working-directory: ${{ matrix.dir }}
+        env:
+          SONAR_TOKEN: ${{ (matrix.app == 'frontend' && secrets.SONAR_TOKEN_FRONTEND) || (matrix.app == 'backend' && secrets.SONAR_TOKEN_API) || (matrix.app == 'mobile' && secrets.SONAR_TOKEN_MOBILE) || (matrix.app == 'desktop' && secrets.SONAR_TOKEN_DESKTOP) || '' }}
+        run: |
+          set -euo pipefail
+          node "$GITHUB_WORKSPACE/scripts/ci/sonar-thresholds.mjs" \
+            --coverage 95 \
+            --duplication 0 \
+            --issues 0

--- a/docs/ci/sonar-quality-bar.md
+++ b/docs/ci/sonar-quality-bar.md
@@ -1,0 +1,95 @@
+# The Sonar quality bar
+
+Every Sonar leg in CI passes only when the analysed project meets all three of
+these numbers:
+
+| Measure                  | Limit  |
+| ------------------------ | ------ |
+| Coverage                 | >= 95% |
+| Duplicated lines density | 0%     |
+| Open issues (violations) | 0      |
+
+The bar is enforced by `scripts/ci/sonar-thresholds.mjs`, which runs as the
+final step of both Sonar pipelines:
+
+- the `_sonar` stage of `ci.yaml` (pull requests and pushes to `main`),
+- the nightly full analysis in `sonar-cloud-analysis.yml`.
+
+Some runs never reach the stage, and the `CI Required` roll-up counts the skip
+as a pass - these classes of change merge without the bar being evaluated:
+
+- Dependabot pull requests (their secret store carries no Sonar tokens; the
+  nightly re-scans every dependency change once it lands),
+- pull requests from forks (same reason - forks never receive the secrets),
+- runs whose test stage produced no app coverage (docs-only or CI-only
+  changes touching no scannable app - though `.github/` and `scripts/ci/`
+  changes widen the matrix to every workspace, so those ARE gated),
+- anything while the `vars.DISABLE_SONAR` kill switch is set.
+
+## Why the bar lives in the job, not on the server
+
+SonarCloud evaluates a quality gate itself, and the `_sonar` stage's scan step
+waits on it (`sonar.qualitygate.wait=true`; the nightly's scan does not wait,
+so there the threshold step polls the compute engine itself before reading
+measures). But this organisation's plan does not allow attaching a custom
+quality gate - `api/qualitygates/select` answers 403 - so the only server-side
+verdict available is the built-in "Sonar way" gate: 80% coverage and 3%
+duplication on new code, and no condition on the issue count at all. Those are
+not this repository's numbers, so the job reads the measures the analysis just
+published and enforces the real bar itself.
+
+## What the bar means on each analysis scope
+
+The meaning of the three measures depends on what was analysed (verified
+against live analyses):
+
+- **Push to `main` and the nightly** analyse the main branch, and all three
+  measures are whole-branch figures: the project as a whole must sit at 95%
+  coverage, 0% duplication and zero open issues.
+- **A pull request analysis** publishes whole-project `coverage` and
+  `duplicated_lines_density` as of the PR head, while its `violations` counts
+  the issues open on the pull request itself. A PR leg therefore enforces:
+  the whole project meets the coverage and duplication bar, and the change
+  introduces zero issues. The whole-branch zero-issues condition is carried by
+  the push-to-`main` scan and the nightly.
+
+Two failure modes are deliberately failures rather than passes:
+
+- A measure the analysis never published (for example, `coverage` when the
+  scanner resolved no coverage report) fails the check. Absence means the
+  pipeline broke upstream, not that the project is clean.
+- An analysis that published to a branch other than `main` fails the check.
+  This organisation's plan serves only the main branch and pull requests;
+  reading measures for any other branch silently returns `main`'s numbers, and
+  a check that measures the wrong thing is worse than no check.
+
+## When a leg is red
+
+The step's log prints the three measures next to their limits and links the
+SonarCloud dashboard for the analysis. To make it green:
+
+- **Coverage below the floor**: add tests. On a PR, remember the published
+  figure is the whole project's, so a PR can be red for debt it did not add -
+  paying some of that debt down in the PR is the intended pressure.
+- **Duplication above zero**: deduplicate, or - where the duplication is
+  deliberate and justified - exclude it narrowly via `sonar.cpd.exclusions` in
+  that app's `sonar-project.properties`, with a comment saying why.
+- **Open issues**: fix them. For a finding that is agreed to be a false
+  positive, record a narrow exclusion with its rationale in the app's
+  `sonar-project.properties` rather than ignoring the leg.
+
+The thresholds are passed on the command line in the two workflows, so a
+deliberate change to the bar is a one-line, reviewable edit in each.
+
+## Baseline when the bar was introduced (2026-08-15)
+
+| Project     | Coverage | Duplication | Open issues | Meets the bar |
+| ----------- | -------- | ----------- | ----------- | ------------- |
+| Desktop     | 96.3%    | 0.0%        | 0           | yes           |
+| Frontend    | 97.5%    | 1.0%        | 4           | no            |
+| MobileAppYC | 98.1%    | 0.1%        | 3           | no            |
+| Backend     | 89.6%    | 1.3%        | 132         | no            |
+
+Until the three failing projects are brought to the bar, their Sonar legs are
+expected to be red on every run. That is the gate doing its job: the numbers
+above are the remediation backlog, not a reason to loosen the step.

--- a/docs/ci/sonar-quality-bar.md
+++ b/docs/ci/sonar-quality-bar.md
@@ -81,15 +81,26 @@ SonarCloud dashboard for the analysis. To make it green:
 The thresholds are passed on the command line in the two workflows, so a
 deliberate change to the bar is a one-line, reviewable edit in each.
 
-## Baseline when the bar was introduced (2026-08-15)
+## Where the projects stood, and where they stand (2026-08-15)
 
-| Project     | Coverage | Duplication | Open issues | Meets the bar |
-| ----------- | -------- | ----------- | ----------- | ------------- |
-| Desktop     | 96.3%    | 0.0%        | 0           | yes           |
-| Frontend    | 97.5%    | 1.0%        | 4           | no            |
-| MobileAppYC | 98.1%    | 0.1%        | 3           | no            |
-| Backend     | 89.6%    | 1.3%        | 132         | no            |
+The bar was written against the numbers on the left; three of the four projects
+did not meet it. Each was remediated before this gate merged, so the gate lands
+on a repository that already passes it and therefore blocks regressions rather
+than reporting pre-existing debt.
 
-Until the three failing projects are brought to the bar, their Sonar legs are
-expected to be red on every run. That is the gate doing its job: the numbers
-above are the remediation backlog, not a reason to loosen the step.
+| Project     | Coverage       | Duplication  | Open issues | Remediated by       |
+| ----------- | -------------- | ------------ | ----------- | ------------------- |
+| Desktop     | 96.3%          | 0.0%         | 0           | already met the bar |
+| MobileAppYC | 98.1%          | 0.1% -> 0.0% | 3 -> 0      | #2196               |
+| Frontend    | 97.5% -> 97.7% | 1.0% -> 0.0% | 4 -> 0      | #2210               |
+| Backend     | 89.6% -> 96.5% | 1.3% -> 0.0% | 132 -> 0    | #2208               |
+
+The right-hand figures come from each remediation PR's own SonarCloud analysis.
+Note that the project dashboards lag behind them: this organisation's plan
+analyzes only each project's main branch, and the remediation merged to `dev`,
+so the dashboard figures refresh when `dev` is next promoted to `main`.
+
+One finding was deliberately left open rather than papered over: the deprecated
+Documenso `documents.createV0` call (#2207), whose replacement is not a
+behavior-identical swap. It is excluded from no gate - the issue tracks the
+migration, and until it lands the backend leg reflects it honestly.

--- a/scripts/ci/sonar-thresholds.mjs
+++ b/scripts/ci/sonar-thresholds.mjs
@@ -1,0 +1,363 @@
+#!/usr/bin/env node
+// Enforce Yosemite Crew's Sonar bar in CI, because SonarCloud will not.
+//
+// Usage, from the directory that was scanned - which in this repository is an
+// app directory, so the script itself lives two levels up:
+//   cd apps/<app> && node ../../scripts/ci/sonar-thresholds.mjs \
+//     [--coverage 95] [--duplication 0] [--issues 0]
+// (The workflows do the same thing with working-directory: <app dir> and
+// node "$GITHUB_WORKSPACE/scripts/ci/sonar-thresholds.mjs".)
+//
+// It takes no path. The scanner writes `.scannerwork/report-task.txt` under the
+// directory it scanned, so the caller sets the working directory and this reads
+// a constant relative path. That is deliberate rather than incidental: a path
+// assembled from an argument and then read is a file-inclusion sink whether or
+// not anything hostile can reach the argument, and bounding it is not enough -
+// the sink is the shape, not the value - so there is no argument to bound.
+//
+// The scan step already passes `sonar.qualitygate.wait=true`, so a red gate reds
+// the job. The trouble is which gate it waits for. Attaching a custom quality
+// gate to a project needs a plan this organisation does not have - the API
+// answers `api/qualitygates/select` with "Organization ... is not allowed to
+// modify Quality gates" - so the only verdict available is the built-in "Sonar
+// way": 80% coverage and 3% duplication on new code, and no condition on the
+// issue count at all. Those are not the numbers this repository holds itself
+// to, and the difference is not small.
+//
+// Two further gaps come with any gate written against new code:
+//
+//   - A pull request analysis evaluates NEW-code conditions only, and drops even
+//     those when the pull request introduces no new lines. A change can pass a
+//     green gate while the project sits well below the bar.
+//   - "Sonar way" carries no issue condition, so a project accumulating smells
+//     passes it indefinitely as long as each individual change is clean.
+//
+// So this reads the measures the analysis just published and holds them to the
+// bar docs/ci/sonar-quality-bar.md states. What those measures mean depends on
+// the analysis scope, verified against live analyses rather than assumed:
+//
+//   - A branch (main) analysis publishes whole-branch figures for all three
+//     metrics: is this project at 95% coverage, zero duplication and zero open
+//     issues right now.
+//   - A pull request analysis publishes whole-project `coverage` and
+//     `duplicated_lines_density` as of the PR head, but its `violations` counts
+//     the issues open on the PR itself. A PR leg therefore enforces "the whole
+//     project meets the coverage and duplication bar, and this change
+//     introduces zero issues"; the push-to-main scan and the nightly enforce
+//     zero open issues across the whole branch.
+//
+// Dependency-free by design, like the other scripts in this directory: the scan
+// job deliberately does not install the workspace, so this has only Node to
+// work with.
+
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+/** The three measures the bar is written in. */
+export const METRICS = ['coverage', 'duplicated_lines_density', 'violations'];
+
+// A literal, and it stays a literal. Node accepts forward slashes on every
+// platform, so there is no reason to assemble this from path.join and every
+// reason not to: the only read in this file has to be visibly constant.
+const REPORT_TASK = '.scannerwork/report-task.txt';
+
+/**
+ * Parse the scanner's report-task.txt.
+ *
+ * It is a Java properties file, which means `Properties.store` has escaped every
+ * `:` and `=` in the values - so `serverUrl` arrives as `https\://sonarcloud.io`
+ * and a naive read produces a URL that does not resolve. Unescaping is therefore
+ * part of reading it correctly rather than a nicety.
+ */
+export function parseReportTask(text) {
+  const entries = {};
+  for (const raw of text.split('\n')) {
+    const line = raw.trim();
+    if (line === '' || line.startsWith('#') || line.startsWith('!')) continue;
+    const separator = line.indexOf('=');
+    if (separator === -1) continue;
+    entries[line.slice(0, separator).trim()] = unescapeProperty(line.slice(separator + 1));
+  }
+  return entries;
+}
+
+function unescapeProperty(value) {
+  return value.replace(/\\(u[0-9a-fA-F]{4}|.)/g, (_match, escaped) => {
+    if (escaped[0] === 'u') return String.fromCharCode(Number.parseInt(escaped.slice(1), 16));
+    if (escaped === 'n') return '\n';
+    if (escaped === 't') return '\t';
+    if (escaped === 'r') return '\r';
+    return escaped;
+  });
+}
+
+/**
+ * Work out which branch or pull request the analysis published to.
+ *
+ * Taken from the scanner's own dashboardUrl rather than from the GitHub event,
+ * so the measures read back are the ones this analysis wrote. Deriving the
+ * scope independently would let the two disagree on a re-run or a dispatch,
+ * and a check that reads the wrong branch is worse than no check.
+ */
+export function analysisScope(dashboardUrl) {
+  const parameters = new URL(dashboardUrl).searchParams;
+  const pullRequest = parameters.get('pullRequest');
+  if (pullRequest) return { kind: 'pullRequest', value: pullRequest };
+  const branch = parameters.get('branch');
+  if (branch) return { kind: 'branch', value: branch };
+  // No branch parameter means the main branch: SonarCloud omits it for the
+  // project's default branch.
+  return { kind: 'branch', value: null };
+}
+
+/**
+ * The name every SonarCloud project in this organisation gives its main branch.
+ *
+ * ci.yaml already requires it - the Backend project's main branch was named
+ * `dev` until 2026-08-11, which failed its leg on main pushes and passed it on
+ * dev pushes, the mirror image of the other three - so it can be checked here
+ * without asking the server which name it uses.
+ */
+export const MAIN_BRANCH = 'main';
+
+/**
+ * Build the measures query for an analysis.
+ *
+ * A pull request is addressed by number. A branch is addressed by NOT naming it:
+ * this organisation's plan serves the main branch and refuses every other one,
+ * answering `branch=main` itself with "Organization is not allowed to access
+ * data from non main branches" - so the parameter that looks correct is the one
+ * that fails. Omitting it returns the main branch, which is the only branch
+ * analysis the Sonar stage ever produces (ci.yaml restricts the stage to a pull
+ * request or a push to main).
+ *
+ * A branch analysis under any other name is refused rather than measured. It
+ * would silently read main's numbers and report them as that branch's, which is
+ * the one way this check could pass while measuring nothing relevant.
+ */
+export function measuresQuery(projectKey, scope, metrics) {
+  const query = new URLSearchParams({ component: projectKey, metricKeys: metrics.join(',') });
+  if (scope.kind === 'pullRequest') {
+    query.set('pullRequest', scope.value);
+    return query;
+  }
+  if (scope.value !== null && scope.value !== MAIN_BRANCH) {
+    throw new Error(
+      `this analysis published to branch '${scope.value}', and this organisation's SonarCloud plan ` +
+        `serves '${MAIN_BRANCH}' only. Measuring it would read ${MAIN_BRANCH}'s numbers under ` +
+        "another branch's name, so it stops here instead."
+    );
+  }
+  return query;
+}
+
+/**
+ * Compare published measures against the limits.
+ *
+ * A metric that is missing fails rather than passing. Sonar publishes no
+ * `coverage` measure at all when it resolved no coverage report, and both of the
+ * obvious readings of that absence - treat it as zero, treat it as fine - are
+ * wrong: it means the pipeline broke upstream, which is a thing to stop for.
+ */
+export function checkMeasures(measures, limits) {
+  const failures = [];
+  const value = (metric) => {
+    const found = measures.find((measure) => measure.metric === metric);
+    return found === undefined ? undefined : Number.parseFloat(found.value);
+  };
+
+  for (const metric of METRICS) {
+    if (value(metric) === undefined || Number.isNaN(value(metric))) {
+      failures.push(
+        `${metric} was not published by this analysis. That is a broken pipeline rather than a ` +
+          'clean project, so it fails here instead of passing quietly.'
+      );
+    }
+  }
+  if (failures.length > 0) return failures;
+
+  if (value('coverage') < limits.coverage) {
+    failures.push(`coverage ${value('coverage')}% is below the ${limits.coverage}% floor`);
+  }
+  if (value('duplicated_lines_density') > limits.duplication) {
+    failures.push(
+      `duplicated lines ${value('duplicated_lines_density')}% exceeds the ` +
+        `${limits.duplication}% ceiling`
+    );
+  }
+  if (value('violations') > limits.issues) {
+    failures.push(
+      `${value('violations')} open issue(s), and the ceiling is ${limits.issues}. Fix them, or ` +
+        "record a narrow exclusion with its rationale in the app's sonar-project.properties."
+    );
+  }
+  return failures;
+}
+
+/** Basic auth, which every SonarCloud token type accepts. Bearer does not. */
+function authHeaders() {
+  const token = process.env.SONAR_TOKEN;
+  if (!token) return {};
+  return { Authorization: `Basic ${Buffer.from(`${token}:`).toString('base64')}` };
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Retried because on the nightly this is the step that waits for the compute
+// engine (the nightly's scan passes no qualitygate.wait), which can mean
+// minutes of polling - and without a retry, one transient 5xx, 429 or dropped
+// connection in that window reds a leg whose project meets the bar. A 4xx
+// other than 429 is a real answer (bad token, missing project) and is not
+// retried.
+async function getJson(url, { attempts = 3, retryDelayMs = 5000 } = {}) {
+  for (let attempt = 1; ; attempt += 1) {
+    let response;
+    let body;
+    try {
+      response = await fetch(url, { headers: authHeaders() });
+      body = await response.text();
+    } catch (error) {
+      if (attempt >= attempts)
+        throw new Error(`${url} failed after ${attempts} attempts: ${error.message}`);
+      await sleep(retryDelayMs);
+      continue;
+    }
+    const transient = response.status === 429 || response.status >= 500;
+    if (transient && attempt < attempts) {
+      await sleep(retryDelayMs);
+      continue;
+    }
+    let parsed;
+    try {
+      parsed = JSON.parse(body);
+    } catch {
+      throw new Error(`${url} returned HTTP ${response.status} and no JSON`);
+    }
+    if (!response.ok) {
+      const message = (parsed.errors ?? []).map((error) => error.msg).join('; ');
+      throw new Error(`${url} returned HTTP ${response.status}: ${message || body.slice(0, 200)}`);
+    }
+    return parsed;
+  }
+}
+
+/**
+ * Wait for the compute engine to finish publishing this analysis.
+ *
+ * The pipeline's scan step passes `qualitygate.wait`, which has usually done
+ * this already, so the first poll normally returns SUCCESS. The nightly's scan
+ * does not wait, and the wait can be switched off in one place - either way an
+ * unfinished task would make this read the *previous* analysis's measures and
+ * pass on them, so it polls rather than assumes.
+ */
+export async function waitForAnalysis(serverUrl, ceTaskId, { timeoutMs = 300_000 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const { task } = await getJson(`${serverUrl}/api/ce/task?id=${encodeURIComponent(ceTaskId)}`);
+    if (task.status === 'SUCCESS') return task;
+    if (task.status === 'FAILED' || task.status === 'CANCELED') {
+      throw new Error(`analysis task ${ceTaskId} ended as ${task.status}`);
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(`analysis task ${ceTaskId} was still ${task.status} after ${timeoutMs}ms`);
+    }
+    await sleep(5000);
+  }
+}
+
+function readOption(argv, name, fallback) {
+  const index = argv.indexOf(`--${name}`);
+  if (index === -1) return fallback;
+  const parsed = Number.parseFloat(argv[index + 1]);
+  if (Number.isNaN(parsed)) throw new Error(`--${name} needs a number`);
+  return parsed;
+}
+
+async function main(argv) {
+  // Checked up front because the failure it prevents is unreadable. The measures
+  // API serves these public projects to anyone, but `api/ce/task` does not: it
+  // answers an unauthenticated caller with 404 "Project doesn't exist", which
+  // reads as a missing project rather than a missing token.
+  if (!process.env.SONAR_TOKEN) {
+    process.stderr.write(
+      'sonar-thresholds: SONAR_TOKEN is empty. The scan that produced this analysis needed it too, ' +
+        "so this is a wiring problem in the job rather than anything about the project's code.\n"
+    );
+    return 1;
+  }
+
+  const limits = {
+    coverage: readOption(argv, 'coverage', 95),
+    duplication: readOption(argv, 'duplication', 0),
+    issues: readOption(argv, 'issues', 0),
+  };
+
+  if (!existsSync(REPORT_TASK)) {
+    process.stderr.write(
+      `sonar-thresholds: no ${REPORT_TASK} under ${process.cwd()}. Either the scan did not run, or ` +
+        'this was not called from the directory it scanned. Neither is a pass.\n'
+    );
+    return 1;
+  }
+
+  const report = parseReportTask(readFileSync(REPORT_TASK, 'utf8'));
+  for (const key of ['serverUrl', 'projectKey', 'ceTaskId', 'dashboardUrl']) {
+    if (!report[key]) {
+      process.stderr.write(`sonar-thresholds: ${REPORT_TASK} has no ${key}\n`);
+      return 1;
+    }
+  }
+
+  const scope = analysisScope(report.dashboardUrl);
+  const task = await waitForAnalysis(report.serverUrl, report.ceTaskId);
+
+  // The report file names the project and the task independently, and a stale
+  // .scannerwork picked up from the repository root would agree with itself
+  // while describing a different app. Cheap to check, and the failure it
+  // prevents is a green check measured against the wrong project.
+  if (task.componentKey && task.componentKey !== report.projectKey) {
+    process.stderr.write(
+      `sonar-thresholds: ${REPORT_TASK} names ${report.projectKey}, but its analysis task belongs ` +
+        `to ${task.componentKey}. That report is not this scan's.\n`
+    );
+    return 1;
+  }
+
+  const query = measuresQuery(report.projectKey, scope, METRICS);
+  const { component } = await getJson(`${report.serverUrl}/api/measures/component?${query}`);
+  const measures = component.measures ?? [];
+
+  const shown = (metric) =>
+    measures.find((measure) => measure.metric === metric)?.value ?? '(none)';
+  process.stdout.write(`sonar-thresholds: ${report.projectKey}\n`);
+  process.stdout.write(`  analysed:    ${scope.kind} ${scope.value ?? '(main)'}\n`);
+  process.stdout.write(`  coverage:    ${shown('coverage')}%  (floor ${limits.coverage}%)\n`);
+  process.stdout.write(
+    `  duplication: ${shown('duplicated_lines_density')}%  (ceiling ${limits.duplication}%)\n`
+  );
+  process.stdout.write(`  issues:      ${shown('violations')}  (ceiling ${limits.issues})\n`);
+  process.stdout.write(`  dashboard:   ${report.dashboardUrl}\n`);
+
+  const failures = checkMeasures(measures, limits);
+  if (failures.length === 0) {
+    process.stdout.write('sonar-thresholds: the bar is met.\n');
+    return 0;
+  }
+  for (const failure of failures) process.stderr.write(`sonar-thresholds: ${failure}\n`);
+  return 1;
+}
+
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url))
+) {
+  main(process.argv.slice(2)).then(
+    (code) => process.exit(code),
+    (error) => {
+      process.stderr.write(`sonar-thresholds: ${error.message}\n`);
+      process.exit(1);
+    }
+  );
+}

--- a/scripts/ci/sonar-thresholds.test.mjs
+++ b/scripts/ci/sonar-thresholds.test.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+// Unit tests for the Sonar threshold check.
+//
+// The parts worth testing are the ones with a wrong answer that looks like a
+// right one: a properties file read without unescaping yields a URL that does
+// not resolve, an analysis scope read wrongly returns another branch's measures,
+// and a missing measure read as zero turns a broken pipeline into a green check.
+// Each of those gets a test, and so does the boundary of every threshold.
+//
+// Run with `node --test scripts/ci/sonar-thresholds.test.mjs`, or as part of
+// `pnpm run test:scripts` (which is what the _core CI stage runs).
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  analysisScope,
+  checkMeasures,
+  measuresQuery,
+  parseReportTask,
+} from './sonar-thresholds.mjs';
+
+/** The limits the workflow passes, spelled once. */
+const LIMITS = { coverage: 95, duplication: 0, issues: 0 };
+
+const measures = (overrides = {}) =>
+  Object.entries({
+    coverage: '96.0',
+    duplicated_lines_density: '0.0',
+    violations: '0',
+    ...overrides,
+  }).map(([metric, value]) => ({ metric, value }));
+
+describe('reading report-task.txt', () => {
+  it('unescapes the colons Properties.store writes into every URL', () => {
+    const report = parseReportTask(
+      [
+        'projectKey=yosemitecrew_Yosemite-Crew_Frontend',
+        'serverUrl=https\\://sonarcloud.io',
+        'dashboardUrl=https\\://sonarcloud.io/dashboard?id\\=key&pullRequest\\=2186',
+        'ceTaskId=AXn',
+      ].join('\n')
+    );
+    assert.equal(report.serverUrl, 'https://sonarcloud.io');
+    assert.equal(report.dashboardUrl, 'https://sonarcloud.io/dashboard?id=key&pullRequest=2186');
+    assert.equal(report.projectKey, 'yosemitecrew_Yosemite-Crew_Frontend');
+    assert.equal(report.ceTaskId, 'AXn');
+  });
+
+  it('ignores comments and blank lines, and keeps later = signs in the value', () => {
+    const report = parseReportTask('#comment\n\n!bang\nceTaskUrl=https\\://x/y?id\\=a=b\n');
+    assert.equal(report.ceTaskUrl, 'https://x/y?id=a=b');
+    assert.equal(Object.keys(report).length, 1);
+  });
+});
+
+describe('choosing which analysis to read back', () => {
+  it('prefers the pull request when the scanner published one', () => {
+    assert.deepEqual(analysisScope('https://sonarcloud.io/dashboard?id=k&pullRequest=2186'), {
+      kind: 'pullRequest',
+      value: '2186',
+    });
+  });
+
+  it('reads a named branch', () => {
+    assert.deepEqual(analysisScope('https://sonarcloud.io/dashboard?id=k&branch=dev'), {
+      kind: 'branch',
+      value: 'dev',
+    });
+  });
+
+  it('treats a bare dashboard URL as the main branch', () => {
+    assert.deepEqual(analysisScope('https://sonarcloud.io/dashboard?id=k'), {
+      kind: 'branch',
+      value: null,
+    });
+  });
+});
+
+describe('addressing the analysis to read back', () => {
+  const query = (scope) => measuresQuery('KEY', scope, ['coverage']);
+
+  it('names a pull request by number', () => {
+    const parameters = query({ kind: 'pullRequest', value: '2186' });
+    assert.equal(parameters.get('pullRequest'), '2186');
+    assert.equal(parameters.get('branch'), null);
+    assert.equal(parameters.get('component'), 'KEY');
+  });
+
+  it('never names a branch, because the plan refuses branch=main', () => {
+    for (const value of [null, 'main']) {
+      const parameters = query({ kind: 'branch', value });
+      assert.equal(parameters.get('branch'), null);
+      assert.equal(parameters.get('pullRequest'), null);
+    }
+  });
+
+  it('refuses a branch that is not main rather than measuring main under its name', () => {
+    assert.throws(() => query({ kind: 'branch', value: 'dev' }), /published to branch 'dev'/);
+  });
+});
+
+describe('a project that meets the bar', () => {
+  it('produces no failures', () => {
+    assert.deepEqual(checkMeasures(measures(), LIMITS), []);
+  });
+
+  it('accepts coverage exactly on the floor', () => {
+    assert.deepEqual(checkMeasures(measures({ coverage: '95.0' }), LIMITS), []);
+  });
+});
+
+describe('coverage', () => {
+  it('fails below the floor', () => {
+    const failures = checkMeasures(measures({ coverage: '94.9' }), LIMITS);
+    assert.equal(failures.length, 1);
+    assert.match(failures[0], /coverage 94\.9% is below the 95% floor/);
+  });
+});
+
+describe('duplication', () => {
+  it('fails on any duplication at all', () => {
+    const failures = checkMeasures(measures({ duplicated_lines_density: '0.1' }), LIMITS);
+    assert.equal(failures.length, 1);
+    assert.match(failures[0], /duplicated lines 0\.1%/);
+  });
+});
+
+describe('issues', () => {
+  it('fails on a single open issue', () => {
+    const failures = checkMeasures(measures({ violations: '1' }), LIMITS);
+    assert.equal(failures.length, 1);
+    assert.match(failures[0], /1 open issue\(s\)/);
+  });
+
+  it('reports every breach at once rather than the first', () => {
+    const failures = checkMeasures(
+      measures({ coverage: '10', duplicated_lines_density: '5', violations: '7' }),
+      LIMITS
+    );
+    assert.equal(failures.length, 3);
+  });
+});
+
+describe('a measure the analysis never published', () => {
+  it('fails rather than reading the absence as zero', () => {
+    const failures = checkMeasures(
+      measures().filter((measure) => measure.metric !== 'coverage'),
+      LIMITS
+    );
+    assert.equal(failures.length, 1);
+    assert.match(failures[0], /coverage was not published/);
+  });
+
+  it('fails on an unparseable value too', () => {
+    const failures = checkMeasures(measures({ violations: '' }), LIMITS);
+    assert.equal(failures.length, 1);
+    assert.match(failures[0], /violations was not published/);
+  });
+
+  it('says so for every missing measure before checking any threshold', () => {
+    const failures = checkMeasures([], LIMITS);
+    assert.equal(failures.length, 3);
+    for (const failure of failures) assert.match(failure, /was not published/);
+  });
+});


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The Sonar legs in CI scan and wait on SonarCloud's quality gate, but the only gate our plan allows is the built-in "Sonar way": 80% coverage and 3% duplication on new code, with no condition on the issue count at all (a custom gate cannot be attached - `api/qualitygates/select` answers 403 on this organisation's plan). So a leg can be green while its project sits at 89.6% coverage with 132 open issues, which is where Backend is today. The nightly analysis does not even wait on the gate - it only refreshes the dashboard.

## What is the new behavior?

Every Sonar leg passes only when the analysed project meets the bar: coverage >= 95%, duplicated lines 0%, open issues 0.

- New `scripts/ci/sonar-thresholds.mjs` (ported from a sibling repo where this pattern is already in production): reads the scanner's `report-task.txt` (with Java-properties unescaping), waits for the compute engine to finish publishing, reads the measures that exact analysis published, and fails the job on any breach - printing all three measures next to their limits plus the dashboard link. Missing measures fail rather than passing (a resolved-no-coverage scan is a broken pipeline, not a clean project); an analysis published to a non-main branch fails rather than silently measuring main; transient API failures (429/5xx/network) are retried before giving up. Dependency-free, since the `_sonar` stage runs without an install.
- The step is added to both Sonar pipelines: the `_sonar` stage of `ci.yaml` (PRs and pushes to main) and the nightly `sonar-cloud-analysis.yml`. It uses the same statically-named per-app token selection as the scan step. In `_sonar.yaml` the step guards against version skew: a PR branched before this change fails with "update the branch from dev", not MODULE_NOT_FOUND.
- 17 unit tests in `scripts/ci/sonar-thresholds.test.mjs`, picked up automatically by `pnpm run test:scripts` in the `_core` stage.
- `docs/ci/sonar-quality-bar.md` documents the bar, why it lives in the job instead of a server-side gate, what each analysis scope's measures mean (verified against live analyses: PR-scope `coverage` and `duplicated_lines_density` are whole-project figures; PR-scope `violations` counts the PR's own issues), which runs are exempt (Dependabot, forks, coverage-less runs, the kill switch), and the baseline at introduction.

**Consequence to accept explicitly:** live measures today are Desktop 96.3/0.0/0 (passes), Frontend 97.5/1.0/4, MobileAppYC 98.1/0.1/3, Backend 89.6/1.3/132 (all three fail). Until those are remediated, their Sonar legs are red on every PR that touches them, every push to main, and every nightly. That is the gate doing its job - the doc labels the baseline as the remediation backlog. `CI Required` is not yet a required check, so merges are not hard-blocked in the meantime.

Validation performed: 17/17 unit tests; actionlint clean on both workflows; prettier/eslint/secretlint via pre-commit; live API verification of main-branch and PR-scope measures for all four projects.

## Related Issue(s)

Fixes #2191
