### PR TITLE
fix(mobile): clear Sonar duplication and deprecated navigation signatures

### DIFF
--- a/apps/mobileAppYC/__tests__/features/adverseEventReporting/screens/ThankYouScreen.test.tsx
+++ b/apps/mobileAppYC/__tests__/features/adverseEventReporting/screens/ThankYouScreen.test.tsx
@@ -15,7 +15,12 @@ import {mockTheme} from '../../../setup/mockTheme';
 
 // 1. Navigation
 const mockNavigate = jest.fn();
-const mockNavigation = {navigate: mockNavigate} as any;
+const mockParentNavigate = jest.fn();
+const mockGetParent = jest.fn(() => ({navigate: mockParentNavigate}));
+const mockNavigation = {
+  navigate: mockNavigate,
+  getParent: mockGetParent,
+} as any;
 
 // 2. React Native Linking
 // We do NOT mock the whole 'react-native' module. logic handles inside beforeEach.
@@ -147,7 +152,17 @@ describe('ThankYouScreen', () => {
       <ThankYouScreen navigation={mockNavigation} route={{} as any} />,
     );
     fireEvent.press(getByTestId('back-to-home'));
-    expect(mockNavigate).toHaveBeenCalledWith('Home');
+    expect(mockGetParent).toHaveBeenCalled();
+    expect(mockParentNavigate).toHaveBeenCalledWith('Home');
+  });
+
+  it('does not throw on footer button press when no parent navigator exists', () => {
+    mockGetParent.mockReturnValueOnce(undefined as any);
+    const {getByTestId} = render(
+      <ThankYouScreen navigation={mockNavigation} route={{} as any} />,
+    );
+    fireEvent.press(getByTestId('back-to-home'));
+    expect(mockParentNavigate).not.toHaveBeenCalled();
   });
 
   it('toggles checkbox and validates consent error', () => {
@@ -207,7 +222,7 @@ describe('ThankYouScreen', () => {
       expect.stringContaining('manufacturer'),
     );
     expect(mockResetDraft).toHaveBeenCalled();
-    expect(mockNavigate).toHaveBeenCalledWith('Home');
+    expect(mockParentNavigate).toHaveBeenCalledWith('Home');
   });
 
   it('submits report successfully to hospital (no returned files)', async () => {

--- a/apps/mobileAppYC/__tests__/features/tasks/screens/AddTaskScreen/AddTaskScreen.test.tsx
+++ b/apps/mobileAppYC/__tests__/features/tasks/screens/AddTaskScreen/AddTaskScreen.test.tsx
@@ -12,12 +12,14 @@ import {mockTheme} from '../../../../setup/mockTheme';
 // 1. Navigation
 const mockGoBack = jest.fn();
 const mockNavigate = jest.fn();
+const mockPopTo = jest.fn();
 const mockCanGoBack = jest.fn().mockReturnValue(true);
 let mockRouteParams: Record<string, unknown> = {};
 jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({
     goBack: mockGoBack,
     navigate: mockNavigate,
+    popTo: mockPopTo,
     canGoBack: mockCanGoBack,
   }),
   useRoute: () => ({
@@ -894,8 +896,10 @@ describe('AddTaskScreen', () => {
       });
 
       // eventId null → no setTaskCalendarEventId, but navigation still happens
-      expect(mockNavigate).toHaveBeenCalledWith(
-        expect.objectContaining({name: 'TasksMain'}),
+      expect(mockPopTo).toHaveBeenCalledWith(
+        'TasksMain',
+        expect.objectContaining({}),
+        {merge: true},
       );
     });
 

--- a/apps/mobileAppYC/__tests__/shared/components/common/shared/floatingLabelStyles.test.ts
+++ b/apps/mobileAppYC/__tests__/shared/components/common/shared/floatingLabelStyles.test.ts
@@ -2,6 +2,8 @@ import {Platform} from 'react-native';
 import {mockTheme} from '../../../../setup/mockTheme';
 import {
   getInputContainerBaseStyle,
+  getInputErrorStyle,
+  getInputLabelStyle,
   getValueTextStyle,
 } from '@/shared/components/common/shared/floatingLabelStyles';
 
@@ -23,6 +25,25 @@ describe('floatingLabelStyles', () => {
         borderColor: mockTheme.colors.hairline,
       }),
     );
+  });
+
+  it('returns the static label style above the field in dark ink', () => {
+    expect(getInputLabelStyle(mockTheme)).toEqual({
+      ...mockTheme.typography.inputLabel,
+      color: mockTheme.colors.inkBody,
+      marginBottom: mockTheme.spacing['2'],
+      marginLeft: mockTheme.spacing['1'],
+    });
+  });
+
+  it('returns the red error message style below the field', () => {
+    expect(getInputErrorStyle(mockTheme)).toEqual({
+      ...mockTheme.typography.labelXxsBold,
+      color: mockTheme.colors.error,
+      marginTop: mockTheme.spacing['1'],
+      marginBottom: mockTheme.spacing['3'],
+      marginLeft: mockTheme.spacing['1'],
+    });
   });
 
   it('returns platform-specific value text spacing for filled and empty states', () => {

--- a/apps/mobileAppYC/__tests__/styles/emptyGateScreenStyles.test.ts
+++ b/apps/mobileAppYC/__tests__/styles/emptyGateScreenStyles.test.ts
@@ -1,0 +1,20 @@
+import {createEmptyGateScreenStyles} from '../../src/shared/styles/emptyGateScreenStyles';
+import {mockTheme} from '../setup/mockTheme';
+
+describe('createEmptyGateScreenStyles', () => {
+  it('returns a screen-colored safe area and a centered container', () => {
+    const styles = createEmptyGateScreenStyles(mockTheme as any);
+
+    expect(styles.safeArea).toEqual({
+      flex: 1,
+      backgroundColor: mockTheme.colors.screen,
+    });
+
+    expect(styles.container).toEqual({
+      flex: 1,
+      backgroundColor: mockTheme.colors.screen,
+      alignItems: 'center',
+      justifyContent: 'center',
+    });
+  });
+});

--- a/apps/mobileAppYC/__tests__/styles/screenHeaderStyles.test.ts
+++ b/apps/mobileAppYC/__tests__/styles/screenHeaderStyles.test.ts
@@ -1,0 +1,51 @@
+import {createScreenHeaderStyles} from '../../src/shared/styles/screenHeaderStyles';
+import {mockTheme} from '../setup/mockTheme';
+
+describe('createScreenHeaderStyles', () => {
+  it('returns the header row and circle button styles from the theme', () => {
+    const styles = createScreenHeaderStyles(mockTheme);
+
+    expect(styles.header).toEqual({
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: mockTheme.spacing['3'],
+      paddingHorizontal: mockTheme.spacing['5'],
+      paddingVertical: mockTheme.spacing['2'],
+    });
+
+    expect(styles.circleButton).toEqual({
+      width: mockTheme.spacing['10'],
+      height: mockTheme.spacing['10'],
+      borderRadius: mockTheme.borderRadius.full,
+      backgroundColor: mockTheme.colors.screen2,
+      borderWidth: 1,
+      borderColor: mockTheme.colors.hairline,
+      alignItems: 'center',
+      justifyContent: 'center',
+    });
+  });
+
+  it('returns centered title and subtitle text styles without a weight override', () => {
+    const styles = createScreenHeaderStyles(mockTheme);
+
+    expect(styles.headerTitleBlock).toEqual({
+      flex: 1,
+      alignItems: 'center',
+    });
+
+    expect(styles.headerTitle).toEqual({
+      ...mockTheme.typography.labelSmall,
+      fontSize: 15.5,
+      letterSpacing: -0.2,
+      color: mockTheme.colors.ink,
+      textAlign: 'center',
+    });
+
+    expect(styles.headerSubtitle).toEqual({
+      ...mockTheme.typography.body12,
+      color: mockTheme.colors.inkFaint,
+      textAlign: 'center',
+      marginTop: 1,
+    });
+  });
+});

--- a/apps/mobileAppYC/src/features/adverseEventReporting/screens/ThankYouScreen.tsx
+++ b/apps/mobileAppYC/src/features/adverseEventReporting/screens/ThankYouScreen.tsx
@@ -13,10 +13,14 @@ import {
 import Ionicons from 'react-native-vector-icons/Ionicons';
 import {PressableOpacity} from '@/shared/components/common/PressableOpacity/PressableOpacity';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
+import type {NativeStackNavigationProp} from '@react-navigation/native-stack';
 import {useTheme} from '@/hooks';
 import {SafeArea} from '@/shared/components/common';
 import {Checkbox} from '@/shared/components/common/Checkbox/Checkbox';
-import type {AdverseEventStackParamList} from '@/navigation/types';
+import type {
+  AdverseEventStackParamList,
+  HomeStackParamList,
+} from '@/navigation/types';
 import {useSelector} from 'react-redux';
 import type {RootState} from '@/app/store';
 import {useAdverseEventReport} from '@/features/adverseEventReporting/state/AdverseEventReportContext';
@@ -97,7 +101,9 @@ export const ThankYouScreen: React.FC<Props> = ({navigation}) => {
   };
 
   const handleBack = () => {
-    navigation.navigate('Home' as never);
+    navigation
+      .getParent<NativeStackNavigationProp<HomeStackParamList>>()
+      ?.navigate('Home');
   };
 
   const requireContactConsent = async (action: () => void | Promise<void>) => {

--- a/apps/mobileAppYC/src/features/documents/screens/DocumentPreviewScreen/DocumentPreviewScreen.tsx
+++ b/apps/mobileAppYC/src/features/documents/screens/DocumentPreviewScreen/DocumentPreviewScreen.tsx
@@ -14,6 +14,7 @@ import type {DocumentStackParamList} from '@/navigation/types';
 import type {DocumentFile} from '@/features/documents/types';
 import type {Theme} from '@/theme';
 import {createAllCommonStyles} from '@/shared/utils/screenStyles';
+import {createScreenHeaderStyles} from '@/shared/styles/screenHeaderStyles';
 import DocumentAttachmentViewer from '@/features/documents/components/DocumentAttachmentViewer';
 import {fetchDocumentView} from '@/features/documents/documentSlice';
 import {LiquidGlassHeaderScreen} from '@/shared/components/common/LiquidGlassHeader/LiquidGlassHeaderScreen';
@@ -445,40 +446,7 @@ const createStyles = (theme: any) => {
       paddingHorizontal: theme.spacing['5'],
       paddingBottom: theme.spacing['4'],
     },
-    header: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      gap: theme.spacing['3'],
-      paddingHorizontal: theme.spacing['5'],
-      paddingVertical: theme.spacing['2'],
-    },
-    circleButton: {
-      width: theme.spacing['10'],
-      height: theme.spacing['10'],
-      borderRadius: theme.borderRadius.full,
-      backgroundColor: theme.colors.screen2,
-      borderWidth: 1,
-      borderColor: theme.colors.hairline,
-      alignItems: 'center',
-      justifyContent: 'center',
-    },
-    headerTitleBlock: {
-      flex: 1,
-      alignItems: 'center',
-    },
-    headerTitle: {
-      ...theme.typography.labelSmall,
-      fontSize: 15.5,
-      letterSpacing: -0.2,
-      color: theme.colors.ink,
-      textAlign: 'center',
-    },
-    headerSubtitle: {
-      ...theme.typography.body12,
-      color: theme.colors.inkFaint,
-      textAlign: 'center',
-      marginTop: 1,
-    },
+    ...createScreenHeaderStyles(theme),
     documentPage: {
       backgroundColor: theme.colors.screen2,
       borderWidth: 1,

--- a/apps/mobileAppYC/src/features/documents/screens/EmptyDocumentsScreen/EmptyDocumentsScreen.tsx
+++ b/apps/mobileAppYC/src/features/documents/screens/EmptyDocumentsScreen/EmptyDocumentsScreen.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {View, StyleSheet} from 'react-native';
+import {View} from 'react-native';
 import Ionicons from 'react-native-vector-icons/Ionicons';
 import {useNavigation} from '@react-navigation/native';
 import type {NativeStackNavigationProp} from '@react-navigation/native-stack';
@@ -7,7 +7,7 @@ import {Header} from '@/shared/components/common/Header/Header';
 import {LiquidGlassHeaderScreen} from '@/shared/components/common/LiquidGlassHeader/LiquidGlassHeaderScreen';
 import {EmptyState} from '@/shared/components/common/EmptyState/EmptyState';
 import {useTheme} from '@/hooks';
-import type {Theme} from '@/theme';
+import {createEmptyGateScreenStyles} from '@/shared/styles/emptyGateScreenStyles';
 import type {DocumentStackParamList} from '@/navigation/types';
 
 type DocumentsNavigationProp =
@@ -16,7 +16,10 @@ type DocumentsNavigationProp =
 export const EmptyDocumentsScreen: React.FC = () => {
   const {theme} = useTheme();
   const navigation = useNavigation<DocumentsNavigationProp>();
-  const styles = React.useMemo(() => createStyles(theme), [theme]);
+  const styles = React.useMemo(
+    () => createEmptyGateScreenStyles(theme),
+    [theme],
+  );
 
   // Documents always belong to a companion. If none exists yet, the
   // "AddDocument" form has no companion to attach to and can't be
@@ -64,17 +67,3 @@ export const EmptyDocumentsScreen: React.FC = () => {
     </LiquidGlassHeaderScreen>
   );
 };
-
-const createStyles = (theme: Theme) =>
-  StyleSheet.create({
-    safeArea: {
-      flex: 1,
-      backgroundColor: theme.colors.screen,
-    },
-    container: {
-      flex: 1,
-      backgroundColor: theme.colors.screen,
-      alignItems: 'center',
-      justifyContent: 'center',
-    },
-  });

--- a/apps/mobileAppYC/src/features/forms/screens/AppointmentFormScreen.tsx
+++ b/apps/mobileAppYC/src/features/forms/screens/AppointmentFormScreen.tsx
@@ -39,6 +39,7 @@ import {
 } from '@/features/forms/utils';
 import type {FormField} from '@yosemite-crew/types';
 import {createFormStyles} from '@/shared/utils/formStyles';
+import {createScreenHeaderStyles} from '@/shared/styles/screenHeaderStyles';
 import {formatDateToISODate} from '@/shared/utils/dateHelpers';
 import {LiquidGlassHeaderScreen} from '@/shared/components/common/LiquidGlassHeader/LiquidGlassHeaderScreen';
 import type {Appointment} from '@/features/appointments/types';
@@ -1074,6 +1075,7 @@ const renderValueForDisplay = (field: FormField, value: any): string => {
 
 const createStyles = (theme: any) => {
   const formStyles = createFormStyles(theme);
+  const headerStyles = createScreenHeaderStyles(theme);
   return StyleSheet.create({
     keyboardAvoidingView: {
       flex: 1,
@@ -1081,40 +1083,10 @@ const createStyles = (theme: any) => {
     flex: {
       flex: 1,
     },
-    header: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      gap: theme.spacing['3'],
-      paddingHorizontal: theme.spacing['5'],
-      paddingVertical: theme.spacing['2'],
-    },
-    circleButton: {
-      width: theme.spacing['10'],
-      height: theme.spacing['10'],
-      borderRadius: theme.borderRadius.full,
-      backgroundColor: theme.colors.screen2,
-      borderWidth: 1,
-      borderColor: theme.colors.hairline,
-      alignItems: 'center',
-      justifyContent: 'center',
-    },
-    headerTitleBlock: {
-      flex: 1,
-      alignItems: 'center',
-    },
+    ...headerStyles,
     headerTitle: {
-      ...theme.typography.labelSmall,
-      fontSize: 15.5,
+      ...headerStyles.headerTitle,
       fontWeight: '600',
-      letterSpacing: -0.2,
-      color: theme.colors.ink,
-      textAlign: 'center',
-    },
-    headerSubtitle: {
-      ...theme.typography.body12,
-      color: theme.colors.inkFaint,
-      textAlign: 'center',
-      marginTop: 1,
     },
     headerRightSlot: {
       width: theme.spacing['10'],

--- a/apps/mobileAppYC/src/features/tasks/screens/AddTaskScreen/AddTaskScreen.tsx
+++ b/apps/mobileAppYC/src/features/tasks/screens/AddTaskScreen/AddTaskScreen.tsx
@@ -325,11 +325,11 @@ export const AddTaskScreen: React.FC = () => {
         }
       }
 
-      navigation.navigate({
-        name: 'TasksMain',
-        params: {autoSelectDate: created.date},
-        merge: true,
-      });
+      navigation.popTo(
+        'TasksMain',
+        {autoSelectDate: created.date},
+        {merge: true},
+      );
     } catch (error) {
       showErrorAlert('Unable to add task', error);
     } finally {

--- a/apps/mobileAppYC/src/features/tasks/screens/EmptyTasksScreen/EmptyTasksScreen.tsx
+++ b/apps/mobileAppYC/src/features/tasks/screens/EmptyTasksScreen/EmptyTasksScreen.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {View, StyleSheet} from 'react-native';
+import {View} from 'react-native';
 import Ionicons from 'react-native-vector-icons/Ionicons';
 import {useTranslation} from 'react-i18next';
 import {useNavigation} from '@react-navigation/native';
@@ -8,7 +8,7 @@ import {Header} from '@/shared/components/common/Header/Header';
 import {LiquidGlassHeaderScreen} from '@/shared/components/common/LiquidGlassHeader/LiquidGlassHeaderScreen';
 import {EmptyState} from '@/shared/components/common/EmptyState/EmptyState';
 import {useTheme} from '@/hooks';
-import type {Theme} from '@/theme';
+import {createEmptyGateScreenStyles} from '@/shared/styles/emptyGateScreenStyles';
 import type {TaskStackParamList} from '@/navigation/types';
 
 type TasksNavigationProp = NativeStackNavigationProp<TaskStackParamList>;
@@ -17,7 +17,10 @@ export const EmptyTasksScreen: React.FC = () => {
   const {theme} = useTheme();
   const {t} = useTranslation();
   const navigation = useNavigation<TasksNavigationProp>();
-  const styles = React.useMemo(() => createStyles(theme), [theme]);
+  const styles = React.useMemo(
+    () => createEmptyGateScreenStyles(theme),
+    [theme],
+  );
 
   // Tasks always belong to a companion. If none exists yet, the "AddTask"
   // form has no companion to attach to and can't be submitted — send the
@@ -65,19 +68,5 @@ export const EmptyTasksScreen: React.FC = () => {
     </LiquidGlassHeaderScreen>
   );
 };
-
-const createStyles = (theme: Theme) =>
-  StyleSheet.create({
-    safeArea: {
-      flex: 1,
-      backgroundColor: theme.colors.screen,
-    },
-    container: {
-      flex: 1,
-      backgroundColor: theme.colors.screen,
-      alignItems: 'center',
-      justifyContent: 'center',
-    },
-  });
 
 export default EmptyTasksScreen;

--- a/apps/mobileAppYC/src/shared/components/common/Input/Input.tsx
+++ b/apps/mobileAppYC/src/shared/components/common/Input/Input.tsx
@@ -19,6 +19,8 @@ import {PressableOpacity} from '@/shared/components/common/PressableOpacity/Pres
 import {useTheme} from '@/hooks';
 import {
   getInputContainerBaseStyle,
+  getInputErrorStyle,
+  getInputLabelStyle,
   getValueTextStyle,
 } from '@/shared/components/common/shared/floatingLabelStyles';
 
@@ -133,23 +135,6 @@ export const Input: React.FC<InputProps> = ({
     };
   };
 
-  // Static label sits above the field in dark ink; the error is carried by the
-  // red field border and the red message below (matching the design).
-  const getLabelStyle = (): TextStyle => ({
-    ...theme.typography.inputLabel,
-    color: theme.colors.inkBody,
-    marginBottom: theme.spacing['2'],
-    marginLeft: theme.spacing['1'],
-  });
-
-  const getErrorStyle = (): TextStyle => ({
-    ...theme.typography.labelXxsBold,
-    color: theme.colors.error,
-    marginTop: theme.spacing['1'],
-    marginBottom: theme.spacing['3'],
-    marginLeft: theme.spacing['1'],
-  });
-
   let IconWrapper = null;
   if (icon) {
     IconWrapper = onIconPress ? PressableOpacity : View;
@@ -157,7 +142,9 @@ export const Input: React.FC<InputProps> = ({
 
   return (
     <View style={containerStyle}>
-      {label && <Text style={[getLabelStyle(), labelStyle]}>{label}</Text>}
+      {label && (
+        <Text style={[getInputLabelStyle(theme), labelStyle]}>{label}</Text>
+      )}
       <View style={getInputContainerStyle()}>
         {leftComponent}
         <TextInput
@@ -186,7 +173,9 @@ export const Input: React.FC<InputProps> = ({
           </IconWrapper>
         )}
       </View>
-      {error && <Text style={[getErrorStyle(), errorStyle]}>{error}</Text>}
+      {error && (
+        <Text style={[getInputErrorStyle(theme), errorStyle]}>{error}</Text>
+      )}
     </View>
   );
 };

--- a/apps/mobileAppYC/src/shared/components/common/TouchableInput/TouchableInput.tsx
+++ b/apps/mobileAppYC/src/shared/components/common/TouchableInput/TouchableInput.tsx
@@ -5,6 +5,8 @@ import {PressableOpacity} from '@/shared/components/common/PressableOpacity/Pres
 import {useTheme} from '@/hooks';
 import {
   getInputContainerBaseStyle,
+  getInputErrorStyle,
+  getInputLabelStyle,
   getValueTextStyle,
 } from '../shared/floatingLabelStyles';
 
@@ -49,23 +51,6 @@ export const TouchableInput: React.FC<TouchableInputProps> = ({
 
   const valueStyle = getValueTextStyle(theme, hasValue);
 
-  // Static label sits above the field in dark ink; the error is carried by the
-  // red field border and the red message below (matching the design).
-  const getLabelStyle = (): TextStyle => ({
-    ...theme.typography.inputLabel,
-    color: theme.colors.inkBody,
-    marginBottom: theme.spacing['2'],
-    marginLeft: theme.spacing['1'],
-  });
-
-  const getErrorStyle = (): TextStyle => ({
-    ...theme.typography.labelXxsBold,
-    color: theme.colors.error,
-    marginTop: theme.spacing['1'],
-    marginBottom: theme.spacing['3'],
-    marginLeft: theme.spacing['1'],
-  });
-
   const leftComponentWrapperStyle = {
     marginRight: theme.spacing['3'],
   };
@@ -76,7 +61,9 @@ export const TouchableInput: React.FC<TouchableInputProps> = ({
 
   return (
     <View style={containerStyle}>
-      {label && <Text style={[getLabelStyle(), labelStyle]}>{label}</Text>}
+      {label && (
+        <Text style={[getInputLabelStyle(theme), labelStyle]}>{label}</Text>
+      )}
       <PressableOpacity
         onPress={onPress}
         activeOpacity={0.7}
@@ -99,7 +86,9 @@ export const TouchableInput: React.FC<TouchableInputProps> = ({
         </View>
       </PressableOpacity>
 
-      {error && <Text style={[getErrorStyle(), errorStyle]}>{error}</Text>}
+      {error && (
+        <Text style={[getInputErrorStyle(theme), errorStyle]}>{error}</Text>
+      )}
     </View>
   );
 };

--- a/apps/mobileAppYC/src/shared/components/common/shared/floatingLabelStyles.ts
+++ b/apps/mobileAppYC/src/shared/components/common/shared/floatingLabelStyles.ts
@@ -17,6 +17,23 @@ export const getInputContainerBaseStyle = (theme: Theme, error?: string) => ({
   justifyContent: 'center' as const,
 });
 
+// Static label sits above the field in dark ink; the error is carried by the
+// red field border and the red message below (matching the design).
+export const getInputLabelStyle = (theme: Theme): TextStyle => ({
+  ...theme.typography.inputLabel,
+  color: theme.colors.inkBody,
+  marginBottom: theme.spacing['2'],
+  marginLeft: theme.spacing['1'],
+});
+
+export const getInputErrorStyle = (theme: Theme): TextStyle => ({
+  ...theme.typography.labelXxsBold,
+  color: theme.colors.error,
+  marginTop: theme.spacing['1'],
+  marginBottom: theme.spacing['3'],
+  marginLeft: theme.spacing['1'],
+});
+
 export const getValueTextStyle = (
   theme: Theme,
   hasValue: boolean,

--- a/apps/mobileAppYC/src/shared/hooks/useNavigateToLegalPages.ts
+++ b/apps/mobileAppYC/src/shared/hooks/useNavigateToLegalPages.ts
@@ -30,7 +30,7 @@ export const useNavigateToLegalPages = () => {
     (screen: 'TermsAndConditions' | 'PrivacyPolicy') => {
       const navWithTarget = findNavigatorWithRoute(screen);
       if (navWithTarget) {
-        navWithTarget.navigate?.(screen as never);
+        navWithTarget.navigate?.(screen);
         return;
       }
 

--- a/apps/mobileAppYC/src/shared/styles/emptyGateScreenStyles.ts
+++ b/apps/mobileAppYC/src/shared/styles/emptyGateScreenStyles.ts
@@ -1,0 +1,20 @@
+import {StyleSheet} from 'react-native';
+import type {Theme} from '@/theme';
+
+/**
+ * Shared layout for the "add a companion first" gate screens: a full-height
+ * screen-colored safe area with a centered empty state.
+ */
+export const createEmptyGateScreenStyles = (theme: Theme) =>
+  StyleSheet.create({
+    safeArea: {
+      flex: 1,
+      backgroundColor: theme.colors.screen,
+    },
+    container: {
+      flex: 1,
+      backgroundColor: theme.colors.screen,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+  });

--- a/apps/mobileAppYC/src/shared/styles/screenHeaderStyles.ts
+++ b/apps/mobileAppYC/src/shared/styles/screenHeaderStyles.ts
@@ -1,0 +1,51 @@
+import type {TextStyle, ViewStyle} from 'react-native';
+
+/**
+ * Shared header layout for screens with a circular back button flanking a
+ * centered title/subtitle block. Returns plain style objects so callers can
+ * spread them into their own StyleSheet.create and override individual keys.
+ */
+export const createScreenHeaderStyles = (
+  theme: any,
+): {
+  header: ViewStyle;
+  circleButton: ViewStyle;
+  headerTitleBlock: ViewStyle;
+  headerTitle: TextStyle;
+  headerSubtitle: TextStyle;
+} => ({
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: theme.spacing['3'],
+    paddingHorizontal: theme.spacing['5'],
+    paddingVertical: theme.spacing['2'],
+  },
+  circleButton: {
+    width: theme.spacing['10'],
+    height: theme.spacing['10'],
+    borderRadius: theme.borderRadius.full,
+    backgroundColor: theme.colors.screen2,
+    borderWidth: 1,
+    borderColor: theme.colors.hairline,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  headerTitleBlock: {
+    flex: 1,
+    alignItems: 'center',
+  },
+  headerTitle: {
+    ...theme.typography.labelSmall,
+    fontSize: 15.5,
+    letterSpacing: -0.2,
+    color: theme.colors.ink,
+    textAlign: 'center',
+  },
+  headerSubtitle: {
+    ...theme.typography.body12,
+    color: theme.colors.inkFaint,
+    textAlign: 'center',
+    marginTop: 1,
+  },
+});


### PR DESCRIPTION
<!--
We, the rest of the Yosemite Crew community, thank you for your
contribution!
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

MobileAppYC sits below the repo's new Sonar quality bar (95/0/0, part of the remediation tracked by issue #2191 / PR #2192). SonarCloud reports:

- Three typescript:S1874 issues (deprecated React Navigation signatures forced through casts):
  - `AddTaskScreen.tsx` uses the deprecated object-form `navigation.navigate({name: 'TasksMain', params, merge: true})`.
  - `useNavigateToLegalPages.ts` casts `screen as never`, resolving the deprecated overload.
  - `ThankYouScreen.tsx` (adverse event reporting) calls `navigation.navigate('Home' as never)` for a route outside its own param list.
- Three cross-file CPD duplication pairs:
  - A ~25 line screen-header style block duplicated between `AppointmentFormScreen.tsx` and `DocumentPreviewScreen.tsx`.
  - A ~24 line block (empty-gate JSX tail plus identical `createStyles`) duplicated between `EmptyDocumentsScreen.tsx` and `EmptyTasksScreen.tsx`.
  - Identical `getLabelStyle`/`getErrorStyle` factories duplicated between `Input.tsx` and `TouchableInput.tsx`.

## What is the new behavior?

Zero behavioral or visual change; the flagged findings are cleared structurally:

- `AddTaskScreen.tsx` now uses the React Navigation 7 helper `navigation.popTo('TasksMain', {autoSelectDate: created.date}, {merge: true})` (the non-deprecated way to go back to a screen with merged params; `popTo` exists in the installed @react-navigation/routers 7.6.4 types).
- `useNavigateToLegalPages.ts` drops the `as never` cast so the string overload resolves.
- `ThankYouScreen.tsx` uses a typed parent call: `navigation.getParent<NativeStackNavigationProp<HomeStackParamList>>()?.navigate('Home')` - runtime behavior identical to the old bubbling navigate.
- New `src/shared/styles/screenHeaderStyles.ts` exports `createScreenHeaderStyles(theme)` (header, circleButton, headerTitleBlock, headerTitle, headerSubtitle as plain objects); both screens spread it into their `StyleSheet.create`, with `AppointmentFormScreen` overriding only `headerTitle.fontWeight: '600'` as before. All values extracted verbatim - pixel-identical output.
- New `src/shared/styles/emptyGateScreenStyles.ts` exports `createEmptyGateScreenStyles(theme)` (safeArea + container), used by both empty screens.
- `getInputLabelStyle(theme)` / `getInputErrorStyle(theme)` moved into the existing shared `floatingLabelStyles.ts`; `Input` and `TouchableInput` import them and the local copies are deleted.

Impact area: apps/mobileAppYC only (tasks, documents, forms, adverse event reporting screens plus two shared input components and shared styles).

Validation performed (real outputs):

- `pnpm --filter mobileAppYC run type-check` (tsc --noEmit): clean, no errors.
- `pnpm --filter mobileAppYC run lint` (eslint .): clean, no errors.
- Targeted Jest (Jest 30, `--testPathPatterns` over all touched screens/hooks/components plus the new style module tests): 15 suites passed, 261 tests passed, 0 failed.
- Coverage on touched files: AddTaskScreen 100/98.93/100/100, ThankYouScreen 98.21/96.2/100/98.09, useNavigateToLegalPages 100/90/100/100, AppointmentFormScreen 100/100/100/100, DocumentPreviewScreen 100/98.8/100/100, EmptyDocumentsScreen 100/100, EmptyTasksScreen 100/100, Input 100/100, TouchableInput 100/100, floatingLabelStyles 100/100; both new modules `screenHeaderStyles.ts` and `emptyGateScreenStyles.ts` at 100/100/100/100 (Stmts/Branch/Funcs/Lines).
- Test updates: AddTaskScreen asserts `popTo('TasksMain', params, {merge: true})` instead of the object-form navigate; ThankYouScreen asserts `getParent().navigate('Home')` plus a new no-parent branch test; new unit tests added for both shared style factories and for the moved label/error style helpers.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #2195

<!-- If this PR contains a breaking change, please describe the impact for existing applications below. -->

<!--
BREAKING CHANGES:


[Describe the impact of the changes here.]

-->
