### PR TITLE
fix(frontend): use <output> for the inline permission-denied notice

### DIFF
--- a/apps/frontend/src/app/ui/layout/states/PermissionDeniedState.tsx
+++ b/apps/frontend/src/app/ui/layout/states/PermissionDeniedState.tsx
@@ -50,7 +50,9 @@ const PermissionDeniedState = ({
 
   if (variant === 'inline') {
     return (
-      <div className="yc-state-inline" role="status">
+      // <output> carries an implicit `status` role and is announced more
+      // reliably than role="status" across assistive tech (sonar Web:S6819).
+      <output className="yc-state-inline">
         <span className="yc-state-inline-icon" aria-hidden>
           <IoLockClosedOutline size={15} />
         </span>
@@ -60,7 +62,7 @@ const PermissionDeniedState = ({
             Request access
           </button>
         </span>
-      </div>
+      </output>
     );
   }
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

SonarCloud flagged `Web:S6819` on `PermissionDeniedState.tsx` after #2186: the inline denial notice used an explicit `role="status"` on a `div`.

## What is the new behavior?

Uses `<output>`, which carries an implicit `status` role and is announced more reliably across assistive tech. Semantics are unchanged, so the existing `getByRole('status')` assertion still passes and no CSS changes were needed (`.yc-state-inline` is class-based and already sets `display: flex`).

Caught before promoting to `main`, so the smell never reaches the release branch.

## Impact area

`apps/frontend` only, one element in one component. No behaviour change.

## Validation performed

type-check, lint, and 5 suites / 21 tests all pass.

## Related Issue(s)

Refs #2185