### PR TITLE
chore(frontend): take eslint-config-next 16 and drop the FlatCompat bridge

### DIFF
--- a/apps/frontend/eslint.config.mjs
+++ b/apps/frontend/eslint.config.mjs
@@ -1,13 +1,9 @@
-import { dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { FlatCompat } from '@eslint/eslintrc';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-});
+// eslint-config-next ships flat configs from v16, so these are imported
+// directly rather than bridged through FlatCompat. The bridge cannot be used
+// any more: @eslint/eslintrc validates whatever it loads by JSON.stringify-ing
+// it, and v16 exposes live plugin objects, which are circular.
+import nextCoreWebVitals from 'eslint-config-next/core-web-vitals';
+import nextTypescript from 'eslint-config-next/typescript';
 
 const eslintConfig = [
   {
@@ -21,7 +17,8 @@ const eslintConfig = [
       'next-env.d.ts',
     ],
   },
-  ...compat.extends('next/core-web-vitals', 'next/typescript'),
+  ...nextCoreWebVitals,
+  ...nextTypescript,
   {
     rules: {
       '@typescript-eslint/no-explicit-any': 'off',

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -62,7 +62,6 @@
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.13.0",
-    "@eslint/eslintrc": "^3",
     "@iconify/react": "^6.0.0",
     "@playwright/test": "^1.62.1",
     "@storybook/addon-a11y": "^10.5.7",
@@ -84,7 +83,7 @@
     "@yosemite-crew/types": "workspace:^",
     "chromatic": "^16.0.0",
     "eslint": "^9",
-    "eslint-config-next": "15.5.18",
+    "eslint-config-next": "16.3.0",
     "eslint-plugin-sonarjs": "^4.2.0",
     "jest": "^30.4.2",
     "jest-axe": "^11.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -544,9 +544,6 @@ importers:
       '@axe-core/playwright':
         specifier: ^4.13.0
         version: 4.13.0(playwright-core@1.61.1)
-      '@eslint/eslintrc':
-        specifier: ^3
-        version: 3.3.6
       '@iconify/react':
         specifier: ^6.0.0
         version: 6.0.2(react@19.2.4)
@@ -611,8 +608,8 @@ importers:
         specifier: ^9
         version: 9.39.2
       eslint-config-next:
-        specifier: 15.5.18
-        version: 15.5.18(eslint@9.39.2)(typescript@5.9.3)
+        specifier: 16.3.0
+        version: 16.3.0(@typescript-eslint/parser@8.67.0)(eslint@9.39.2)(typescript@5.9.3)
       eslint-plugin-react-hooks:
         specifier: ^7.1.1
         version: 7.1.1(eslint@9.39.2)
@@ -9644,10 +9641,13 @@ packages:
     resolution: {integrity: sha512-s5j2iFGp38QsG1LWRQaE2iUY3h1jc014/melHFfLdrsMJPqxqDQwWNwyQTcNoUSGZlCVZuM7t7JDMmSyRilsnA==}
     dev: true
 
-  /@next/eslint-plugin-next@15.5.18:
-    resolution: {integrity: sha512-w4MYq8M26a8PNrfto0JosLf5/3ssln1rsyP96g2DkC8uFVymStM5DLSz5ElxxrPRg2XnTMnFo3kREFlhYvxhWw==}
+  /@next/eslint-plugin-next@16.3.0(eslint@9.39.2):
+    resolution: {integrity: sha512-OqgJ8PN0d04KcPhDX/PTY5tJUJZxlbrt7O7FBsm4XE0XW2JDrKnDXsc9uo9WUimJGPoo2j+JRGhyXApC//mvbw==}
     dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2)
       fast-glob: 3.3.1
+    transitivePeerDependencies:
+      - eslint
     dev: true
 
   /@next/swc-darwin-arm64@15.5.21:
@@ -11898,10 +11898,6 @@ packages:
 
   /@rtsao/scc@1.1.0:
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
-    dev: true
-
-  /@rushstack/eslint-patch@1.15.0:
-    resolution: {integrity: sha512-ojSshQPKwVvSMR8yT2L/QtUkV5SXi/IfDiJ4/8d6UbTPjiHVmxZzUAzGD8Tzks1b9+qQkZa0isUOvYObedITaw==}
     dev: true
 
   /@secretlint/config-creator@11.3.1:
@@ -18796,28 +18792,28 @@ packages:
     engines: {node: '>=12'}
     dev: false
 
-  /eslint-config-next@15.5.18(eslint@9.39.2)(typescript@5.9.3):
-    resolution: {integrity: sha512-HuoJU6uUPD00eyiud78IBnT4HLhztFj2V+ild2Uon5ZUrYZKe0Olu2QRD99e9IgL4/H1eg5Onka3BsfRW2U0Xw==}
+  /eslint-config-next@16.3.0(@typescript-eslint/parser@8.67.0)(eslint@9.39.2)(typescript@5.9.3):
+    resolution: {integrity: sha512-lPrf1kHsMJEZqO0uXkNB400c5MGrhrTk3BNX7P0ol4gt61+iUlQfjy9TyIOEA9eOXrf+5+mYbT/JsY8+zqUByQ==}
     peerDependencies:
-      eslint: ^7.23.0 || ^8.0.0 || ^9.0.0
+      eslint: '>=9.0.0'
       typescript: '>=3.3.1'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@next/eslint-plugin-next': 15.5.18
-      '@rushstack/eslint-patch': 1.15.0
-      '@typescript-eslint/eslint-plugin': 8.67.0(@typescript-eslint/parser@8.67.0)(eslint@9.39.2)(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.67.0(eslint@9.39.2)(typescript@5.9.3)
+      '@next/eslint-plugin-next': 16.3.0(eslint@9.39.2)
       eslint: 9.39.2
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.67.0)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2)
       eslint-plugin-react: 7.37.5(eslint@9.39.2)
-      eslint-plugin-react-hooks: 5.2.0(eslint@9.39.2)
+      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.2)
+      globals: 16.4.0
       typescript: 5.9.3
+      typescript-eslint: 8.67.0(eslint@9.39.2)(typescript@5.9.3)
     transitivePeerDependencies:
+      - '@typescript-eslint/parser'
       - eslint-import-resolver-webpack
       - eslint-plugin-import-x
       - supports-color
@@ -18951,7 +18947,7 @@ packages:
       object.groupby: 1.0.3
       object.values: 1.2.1
       semver: 6.3.1
-      string.prototype.trimend: 1.0.9
+      string.prototype.trimend: 1.0.10
       tsconfig-paths: 3.15.0
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
@@ -19012,15 +19008,6 @@ packages:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
     dependencies:
       eslint: 8.57.1
-    dev: true
-
-  /eslint-plugin-react-hooks@5.2.0(eslint@9.39.2):
-    resolution: {integrity: sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
-    dependencies:
-      eslint: 9.39.2
     dev: true
 
   /eslint-plugin-react-hooks@7.1.1(eslint@9.39.2):
@@ -20556,6 +20543,11 @@ packages:
 
   /globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+    dev: true
+
+  /globals@16.4.0:
+    resolution: {integrity: sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==}
     engines: {node: '>=18'}
     dev: true
 
@@ -29818,16 +29810,6 @@ packages:
       es-object-atoms: 1.1.2
     dev: true
 
-  /string.prototype.trimend@1.0.9:
-    resolution: {integrity: sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: 1.0.9
-      call-bound: 1.0.4
-      define-properties: 1.2.1
-      es-object-atoms: 1.1.2
-    dev: true
-
   /string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
@@ -30953,6 +30935,23 @@ packages:
       '@typescript-eslint/utils': 8.67.0(eslint@9.39.2)(typescript@5.0.4)
       eslint: 9.39.2
       typescript: 5.0.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /typescript-eslint@8.67.0(eslint@9.39.2)(typescript@5.9.3):
+    resolution: {integrity: sha512-S2udFs8tCKEKffuJ4TB1idGUZiXdCPGi3IPBGWXarbLQ5UPXORV8QEVzJ4gCRduURMb5EkpNCdjbk0eDIuI8Yg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.67.0(@typescript-eslint/parser@8.67.0)(eslint@9.39.2)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.67.0(eslint@9.39.2)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.67.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.67.0(eslint@9.39.2)(typescript@5.9.3)
+      eslint: 9.39.2
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
     dev: true


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

Dependabot's `eslint-config-next` 16 bump (#2201) fails `core / Static (frontend)` at the `Lint` step, which takes `Type-check` and `Build` down with it.

`eslint-config-next` changed shape between 15 and 16. v15's `index.js` exported an eslintrc object (`extends`, `parser`, `overrides`, `env`, `settings`, `rules`). v16 exports a **flat config array** whose entries carry live plugin objects: `{ react: <plugin>, 'react-hooks': <plugin>, import: <plugin>, 'jsx-a11y': <plugin>, '@next/next': <plugin> }`.

`apps/frontend/eslint.config.mjs` consumed it through the eslintrc bridge, `FlatCompat`. `@eslint/eslintrc` validates whatever it loads by `JSON.stringify`-ing it, and plugin objects are circular, so the whole run died before reading a single file:

```
TypeError: Converting circular structure to JSON
    --> starting at object with constructor 'Object'
    |     property 'configs' -> object with constructor 'Object'
    ...
    |     property 'plugins' -> object with constructor 'Object'
    --- property 'react' closes the circle
    at JSON.stringify (<anonymous>)
    at ConfigValidator.formatErrors (.../@eslint/eslintrc/lib/shared/config-validator.js:299:23)
```

## What is the new behavior?

The bridge is removed. v16 ships flat configs natively, so `next/core-web-vitals` and `next/typescript` are imported directly from the package's own `exports` subpaths:

```js
import nextCoreWebVitals from 'eslint-config-next/core-web-vitals';
import nextTypescript from 'eslint-config-next/typescript';
```

Both subpaths were confirmed to resolve to real arrays (4 and 5 entries respectively), not to objects needing translation. Everything below them in the config is untouched: the ignores block, the `no-unused-vars` override, `react/display-name: off`, the `no-restricted-imports` auth-boundary guard from #1672, and the test-file `no-img-element` exemption.

`@eslint/eslintrc` has no remaining importer in the frontend, so it is dropped from `apps/frontend/package.json`.

**Relevant to #2180.** The ESLint 10 upgrade was closed because two workspaces blocked it. The frontend blocker was exactly this package: v15 loaded `@rushstack/eslint-patch`, which refuses an ESLint it does not recognise. v16 has no rushstack dependency and peers `eslint >=9.0.0`. This clears one of the two blockers. Mobile is still held by `@babel/eslint-parser` needing `@babel/core` 8, which React Native 0.81 forbids, so ESLint 10 stays frozen for now.

## Impact area

`apps/frontend` lint configuration only. No application code changes, no runtime effect.

## Validation performed

Run locally on Node 20:

- `pnpm --filter frontend run lint` - **passes**, which is the check that was failing
- `pnpm run lint` - 10/10 tasks
- `pnpm run type-check` - 17/17 tasks
- `pnpm --filter frontend run build` - compiled successfully in 35.8s
- All 7 shared packages build

### Proving the rules are still enforced

A lint config that silently applies nothing also exits 0, so a clean run is not on its own evidence that v16's rules are live. I linted a deliberately bad file covering each rule family and confirmed every one still fires:

| Rule | Source | Fired |
| --- | --- | --- |
| `@next/next/no-img-element` | Next's own rules, via core-web-vitals | yes |
| `react-hooks/rules-of-hooks` | plugin wired by the flat config | yes |
| `@typescript-eslint/no-unused-vars` | this repo's override | yes |
| `no-restricted-imports` | the #1672 auth-boundary guard | yes |

The same probe was re-run after removing `@eslint/eslintrc`, and all four still fire, so the removal does not quietly unwire anything.

## Related Issue(s)

Supersedes #2201. Removes the frontend half of the #2180 blocker.
