### PR TITLE
refactor(frontend): eliminate duplicated blocks and clear the open Sonar issues

### DIFF
--- a/apps/frontend/sonar-project.properties
+++ b/apps/frontend/sonar-project.properties
@@ -24,8 +24,13 @@ sonar.coverage.exclusions=**/*.test.ts,**/*.spec.ts,**/*.test.tsx,**/*.spec.tsx,
 # one entry per clause, list item and table row, so that a legal update is reviewed as a
 # content diff. Their repetition is the shape of the contract, not logic to factor out,
 # and collapsing it would move the published text out of the file a reviewer reads.
+# The forms type module is the YC-default form-template catalog: after extracting every
+# structural helper (radioField/checkboxField/yesNoRadio/buildYesNoFieldList), what remains
+# is homogeneous [id, label] data rows — one line per form field — which CPD still matches
+# against each other modulo string literals. Deduplicating two-string tuples any further
+# would obscure the template data itself, so this pure data table is excluded.
 # Duplication is measured everywhere else.
-sonar.cpd.exclusions=src/app/features/legal/pages/content/**
+sonar.cpd.exclusions=src/app/features/legal/pages/content/**,src/app/features/forms/types/forms.ts
 
 # ModalBase intentionally keeps a mounted div with role="dialog" for CSS close transitions.
 # Native <dialog> hides with display:none when closed, breaking opacity/transform animations.

--- a/apps/frontend/src/app/__tests__/components/Accordion/googleAddressFieldRenderer.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Accordion/googleAddressFieldRenderer.test.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import GoogleAddressFieldRenderer from '@/app/ui/primitives/Accordion/googleAddressFieldRenderer';
+
+type MockAddress = {
+  addressLine: string;
+  city: string;
+  state: string;
+  postalCode: string;
+  country: string;
+};
+
+jest.mock('@/app/ui/inputs/GoogleSearchDropDown/GoogleSearchDropDown', () => ({
+  __esModule: true,
+  default: ({
+    inlabel,
+    inname,
+    value,
+    error,
+    onChange,
+    onAddressSelect,
+  }: {
+    inlabel: string;
+    inname?: string;
+    value: string;
+    error?: string;
+    onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    onAddressSelect?: (address: MockAddress) => void;
+  }) => (
+    <div>
+      <input aria-label={inlabel} name={inname} value={value} onChange={onChange ?? (() => {})} />
+      {error && <span role="alert">{error}</span>}
+      <button
+        type="button"
+        onClick={() =>
+          onAddressSelect?.({
+            addressLine: '42 Main St',
+            city: 'Springfield',
+            state: 'IL',
+            postalCode: '62704',
+            country: 'US',
+          })
+        }
+      >
+        select-with-country
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          onAddressSelect?.({
+            addressLine: '7 Side Rd',
+            city: 'Shelbyville',
+            state: 'KY',
+            postalCode: '40065',
+            country: '',
+          })
+        }
+      >
+        select-without-country
+      </button>
+    </div>
+  ),
+}));
+
+describe('GoogleAddressFieldRenderer', () => {
+  const field = { key: 'addressLine', label: 'Address line' };
+
+  it('renders the dropdown with the provided value, name, and label', () => {
+    render(<GoogleAddressFieldRenderer field={field} value="123 Old Rd" onChange={jest.fn()} />);
+    const input = screen.getByLabelText('Address line');
+    expect(input).toHaveValue('123 Old Rd');
+    expect(input).toHaveAttribute('name', 'addressLine');
+  });
+
+  it('falls back to an empty value when value is undefined', () => {
+    render(<GoogleAddressFieldRenderer field={field} onChange={jest.fn()} />);
+    expect(screen.getByLabelText('Address line')).toHaveValue('');
+  });
+
+  it('passes the error through to the dropdown', () => {
+    render(
+      <GoogleAddressFieldRenderer
+        field={field}
+        value=""
+        error="Address line is required"
+        onChange={jest.fn()}
+      />
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent('Address line is required');
+  });
+
+  it('calls onChange with the typed value', () => {
+    const onChange = jest.fn();
+    render(<GoogleAddressFieldRenderer field={field} value="" onChange={onChange} />);
+    fireEvent.change(screen.getByLabelText('Address line'), { target: { value: '9 New St' } });
+    expect(onChange).toHaveBeenCalledWith('9 New St');
+  });
+
+  it('autofills sibling fields including country on address select', () => {
+    const onChange = jest.fn();
+    const onMultiChange = jest.fn();
+    render(
+      <GoogleAddressFieldRenderer
+        field={field}
+        value=""
+        onChange={onChange}
+        onMultiChange={onMultiChange}
+      />
+    );
+    fireEvent.click(screen.getByText('select-with-country'));
+    expect(onChange).toHaveBeenCalledWith('42 Main St');
+    expect(onMultiChange).toHaveBeenCalledWith({
+      city: 'Springfield',
+      state: 'IL',
+      postalCode: '62704',
+      country: 'US',
+    });
+  });
+
+  it('omits country from the multi-change payload when the address has none', () => {
+    const onMultiChange = jest.fn();
+    render(
+      <GoogleAddressFieldRenderer
+        field={field}
+        value=""
+        onChange={jest.fn()}
+        onMultiChange={onMultiChange}
+      />
+    );
+    fireEvent.click(screen.getByText('select-without-country'));
+    expect(onMultiChange).toHaveBeenCalledWith({
+      city: 'Shelbyville',
+      state: 'KY',
+      postalCode: '40065',
+    });
+    expect(onMultiChange.mock.calls[0][0]).not.toHaveProperty('country');
+  });
+
+  it('still applies the address line when onMultiChange is not provided', () => {
+    const onChange = jest.fn();
+    render(<GoogleAddressFieldRenderer field={field} value="" onChange={onChange} />);
+    fireEvent.click(screen.getByText('select-with-country'));
+    expect(onChange).toHaveBeenCalledWith('42 Main St');
+  });
+});

--- a/apps/frontend/src/app/__tests__/components/AddCompanionCentralModal/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/AddCompanionCentralModal/index.test.tsx
@@ -138,9 +138,41 @@ jest.mock('@/app/ui/inputs/Datepicker', () => ({
 
 jest.mock('@/app/ui/inputs/GoogleSearchDropDown/GoogleSearchDropDown', () => ({
   __esModule: true,
-  default: ({ inlabel, value, onChange, error }: any) => (
+  default: ({ inlabel, value, onChange, error, onAddressSelect }: any) => (
     <div>
       <input aria-label={inlabel} value={value ?? ''} onChange={onChange} />
+      {onAddressSelect && (
+        <>
+          <button
+            type="button"
+            onClick={() =>
+              onAddressSelect({
+                addressLine: '1 Bark Lane',
+                city: 'Dogtown',
+                state: 'CA',
+                postalCode: '90210',
+                country: '',
+              })
+            }
+          >
+            mock select address
+          </button>
+          <button
+            type="button"
+            onClick={() =>
+              onAddressSelect({
+                addressLine: '2 Purr Court',
+                city: 'Catville',
+                state: 'NY',
+                postalCode: '10001',
+                country: 'United States',
+              })
+            }
+          >
+            mock select address with country
+          </button>
+        </>
+      )}
       {error && <span role="alert">{error}</span>}
     </div>
   ),
@@ -1802,15 +1834,38 @@ describe('AddCompanionCentralModal', () => {
 
   describe('handleAddressSelect', () => {
     it('updates address fields from GoogleSearchDropDown onAddressSelect', async () => {
-      // jest.mock cannot be called inside test bodies (not hoisted), so verify via state indirectly
       await act(async () => {
         render(<AddCompanionCentralModal {...defaultProps} />);
       });
 
       await goToParentStep();
 
-      // Verify the parent step renders the address field without errors
-      expect(screen.getByLabelText('Address')).toBeInTheDocument();
+      // A selection without a country keeps the previous country value.
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'mock select address' }));
+      });
+      expect((screen.getByLabelText('Address') as HTMLInputElement).value).toBe('1 Bark Lane');
+
+      // A selection carrying a country overwrites it.
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'mock select address with country' }));
+      });
+      expect((screen.getByLabelText('Address') as HTMLInputElement).value).toBe('2 Purr Court');
+    });
+
+    it('clearing the phone number stores an empty phone value', async () => {
+      await act(async () => {
+        render(<AddCompanionCentralModal {...defaultProps} />);
+      });
+
+      await goToParentStep();
+
+      const phone = screen.getByLabelText('Phone number') as HTMLInputElement;
+      fireEvent.change(phone, { target: { value: '2025551234' } });
+      expect(phone.value).toBe('2025551234');
+
+      fireEvent.change(phone, { target: { value: '' } });
+      expect(phone.value).toBe('');
     });
   });
 

--- a/apps/frontend/src/app/__tests__/components/AddInventory/FormSection.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/AddInventory/FormSection.test.tsx
@@ -200,6 +200,12 @@ jest.mock('@/app/features/inventory/components/AddInventory/InventoryConfig', ()
           field: { name: 'withdrawlPeriod', component: 'text', placeholder: 'Withdrawal period' },
         },
       ],
+      pricing: [
+        {
+          kind: 'item',
+          field: { name: 'purchaseCost', component: 'text', placeholder: 'Unit cost' },
+        },
+      ],
       // Exercises every renderer branch, including placeholder-less fields.
       misc: [
         { kind: 'item', field: { name: 'plainText', component: 'text' } },
@@ -289,6 +295,14 @@ describe('FormSection Component', () => {
     // Textarea (inside Row)
     const textarea = screen.getByTestId('textarea-description');
     expect(textarea).toHaveValue('Test Desc');
+
+    fireEvent.change(textarea, { target: { value: 'Updated Desc' } });
+    expect(mockOnFieldChange).toHaveBeenLastCalledWith(
+      'basicInfo',
+      'description',
+      'Updated Desc',
+      undefined
+    );
   });
 
   it('handles Date parsing and changes correctly', () => {
@@ -696,6 +710,41 @@ describe('FormSection Component', () => {
     // Both derived and numeric coercion fail -> '0' (line 193 final fallback).
     expect(screen.getAllByText('0').length).toBeGreaterThan(0);
     expect(screen.queryByText('xyz')).not.toBeInTheDocument();
+  });
+
+  it('renders the pricing summary for the pricing section', () => {
+    render(
+      <FormSection
+        {...defaultProps}
+        sectionKey={'pricing' as any}
+        sectionTitle="Pricing"
+        formData={
+          { pricing: { purchaseCost: '10', selling: '20' }, stock: { current: '5' } } as any
+        }
+        errors={{} as any}
+      />
+    );
+    // PricingSummary renders below the pricing fields.
+    expect(screen.getByText('Gross profit per unit :')).toBeInTheDocument();
+    expect(screen.getByText('$10')).toBeInTheDocument();
+    expect(screen.getByText('Margin :')).toBeInTheDocument();
+    expect(screen.getByText('50%')).toBeInTheDocument();
+    expect(screen.getByText('Total stock value')).toBeInTheDocument();
+    expect(screen.getByText('$50')).toBeInTheDocument();
+  });
+
+  it('coerces unsupported multiselect value types to an empty list', () => {
+    render(
+      <FormSection
+        {...defaultProps}
+        sectionKey={'misc' as any}
+        sectionTitle="Misc"
+        formData={{ misc: { plainMulti: { nested: true } } } as any}
+        errors={{} as any}
+      />
+    );
+    // Object values fall through to the empty-list branch of getMultiSelectValues.
+    expect(screen.getByTestId('ms-value')).toHaveTextContent('[]');
   });
 
   it('renders nothing configured for an unknown business type', () => {

--- a/apps/frontend/src/app/__tests__/components/AddInventory/InventoryConfig.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/AddInventory/InventoryConfig.test.tsx
@@ -1,12 +1,19 @@
-import { InventoryFormConfig } from '@/app/features/inventory/components/AddInventory/InventoryConfig';
 import {
+  InventoryFormConfig,
+  SectionConfig,
+} from '@/app/features/inventory/components/AddInventory/InventoryConfig';
+import {
+  AdminstrationOptions,
   CategoryOptionsByBusiness,
+  FormOptions,
+  SpeciesOptions,
   SubCategoryOptions,
+  UnitOptions,
 } from '@/app/features/inventory/pages/Inventory/types';
 import { BusinessType } from '@/app/features/organization/types/org';
 
 describe('InventoryFormConfig', () => {
-  const businessTypes: BusinessType[] = ['HOSPITAL', 'GROOMER', 'BREEDER'];
+  const businessTypes: BusinessType[] = ['HOSPITAL', 'GROOMER', 'BREEDER', 'BOARDER'];
 
   // Helper function to correctly extract field names regardless of 'field' or 'row' kind
   const extractFieldNames = (configSection: any) => {
@@ -320,6 +327,74 @@ describe('InventoryFormConfig', () => {
       ];
       expect(batchFields).toEqual(expectedFields);
     });
+  });
+
+  // --- BOARDER Tests ---
+  describe('BOARDER Configuration', () => {
+    const config = InventoryFormConfig.BOARDER;
+
+    it('should contain all expected sections for BOARDER', () => {
+      const expectedSections = [
+        'basicInfo',
+        'classification',
+        'pricing',
+        'vendor',
+        'stock',
+        'batch',
+      ];
+      expect(Object.keys(config)).toEqual(expectedSections);
+    });
+
+    it('should have the correct field structure in the classification section', () => {
+      const classificationFields = extractFieldNames(config.classification!);
+      const expectedFields = [
+        'intakeType',
+        'form',
+        'species',
+        'administration',
+        'unitofMeasure',
+        'safetyClassification',
+        'brand',
+        'shelfLife',
+      ];
+      expect(classificationFields).toEqual(expectedFields);
+    });
+  });
+
+  // --- Shared classification descriptors (GROOMER + BOARDER) ---
+  describe('shared classification descriptors', () => {
+    const findFieldDef = (items: SectionConfig<'classification'>, name: string) =>
+      items
+        .flatMap((item) => (item.kind === 'field' ? [item.field] : item.fields))
+        .find((fieldDef) => fieldDef.name === name);
+
+    it.each(['GROOMER', 'BOARDER'] as const)(
+      'keeps the shared classification descriptors intact for %s',
+      (businessType) => {
+        const items = InventoryFormConfig[businessType].classification!;
+
+        expect(findFieldDef(items, 'form')).toMatchObject({
+          placeholder: 'Form / Presentation',
+          component: 'dropdown',
+          options: FormOptions,
+        });
+        expect(findFieldDef(items, 'species')).toMatchObject({
+          placeholder: 'Species',
+          component: 'multiSelect',
+          options: SpeciesOptions,
+        });
+        expect(findFieldDef(items, 'administration')).toMatchObject({
+          placeholder: 'Administration',
+          component: 'dropdown',
+          options: AdminstrationOptions,
+        });
+        expect(findFieldDef(items, 'unitofMeasure')).toMatchObject({
+          placeholder: 'Unit of Measure (Base)',
+          component: 'dropdown',
+          options: UnitOptions,
+        });
+      }
+    );
   });
 
   // Test the configuration types for generic code coverage

--- a/apps/frontend/src/app/__tests__/components/Calendar/Task/UserCalendar.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/Task/UserCalendar.test.tsx
@@ -13,6 +13,17 @@ jest.mock('@/app/hooks/useTeam', () => ({
   useTeamForPrimaryOrg: jest.fn(),
 }));
 
+jest.mock('@/app/lib/timezone', () => ({
+  getHourInPreferredTimeZone: (value: Date) => value.getHours(),
+  getMinutesSinceStartOfDayInPreferredTimeZone: (value: Date) =>
+    value.getHours() * 60 + value.getMinutes(),
+  formatDateInPreferredTimeZone: jest.fn(() => 'Mon'),
+  isOnPreferredTimeZoneCalendarDay: (value: Date, day: Date) =>
+    value.getFullYear() === day.getFullYear() &&
+    value.getMonth() === day.getMonth() &&
+    value.getDate() === day.getDate(),
+}));
+
 jest.mock('@/app/features/appointments/components/Calendar/helpers', () => ({
   eventsForUser: jest.fn(),
   DEFAULT_CALENDAR_FOCUS_MINUTES: 540,
@@ -119,6 +130,43 @@ describe('UserCalendar (Task)', () => {
         height: 180,
       })
     );
+  });
+
+  it('groups due tasks into the assigned team member column for the matching hour', () => {
+    const midnightTaskA = {
+      name: 'Midnight Task A',
+      assignedTo: 'user-1',
+      dueAt: new Date(2025, 0, 6, 0, 15),
+      status: 'PENDING',
+      _id: 'midnight-a',
+      audience: 'EMPLOYEE_TASK',
+      source: 'CUSTOM',
+      category: '',
+    } as Task;
+    const midnightTaskB = {
+      name: 'Midnight Task B',
+      assignedTo: 'user-1',
+      dueAt: new Date(2025, 0, 6, 0, 45),
+      status: 'PENDING',
+      _id: 'midnight-b',
+      audience: 'EMPLOYEE_TASK',
+      source: 'CUSTOM',
+      category: '',
+    } as Task;
+
+    render(
+      <UserCalendar
+        events={[midnightTaskA, midnightTaskB]}
+        date={new Date(2025, 0, 6, 12)}
+        handleViewTask={handleViewTask}
+        setCurrentDate={setCurrentDate}
+      />
+    );
+
+    const slotEventsByCall = taskSlotSpy.mock.calls.map(([props]) => props.slotEvents);
+    expect(slotEventsByCall).toContainEqual([midnightTaskA, midnightTaskB]);
+    // The unassigned column stays empty.
+    expect(slotEventsByCall).toContainEqual([]);
   });
 
   it('changes the current date when navigating', () => {

--- a/apps/frontend/src/app/__tests__/components/Calendar/Task/WeekCalendar.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/Task/WeekCalendar.test.tsx
@@ -20,6 +20,7 @@ jest.mock('@/app/lib/timezone', () => ({
   getHourInPreferredTimeZone: (value: Date) => value.getHours(),
   getMinutesSinceStartOfDayInPreferredTimeZone: (value: Date) =>
     value.getHours() * 60 + value.getMinutes(),
+  formatDateInPreferredTimeZone: jest.fn(() => '9:41 AM'),
   isOnPreferredTimeZoneCalendarDay: (value: Date, day: Date) =>
     value.getFullYear() === day.getFullYear() &&
     value.getMonth() === day.getMonth() &&
@@ -126,6 +127,24 @@ describe('WeekCalendar (Task)', () => {
         length: days.length - 1,
       })
     );
+  });
+
+  it('shows the now indicator with a time label when today is within the week', () => {
+    const today = new Date();
+    mockGetWeekDays.mockReturnValue([today]);
+
+    render(
+      <WeekCalendar
+        events={[]}
+        date={today}
+        handleViewTask={handleViewTask}
+        weekStart={today}
+        setWeekStart={setWeekStart}
+        setCurrentDate={setCurrentDate}
+      />
+    );
+
+    expect(screen.getByText('9:41 AM')).toBeInTheDocument();
   });
 
   it('updates week start and current date on navigation', () => {

--- a/apps/frontend/src/app/__tests__/components/Calendar/Task/taskCalendarInteractionProps.test.ts
+++ b/apps/frontend/src/app/__tests__/components/Calendar/Task/taskCalendarInteractionProps.test.ts
@@ -1,0 +1,74 @@
+import * as taskCalendarInteractionPropsModule from '@/app/features/appointments/components/Calendar/Task/taskCalendarInteractionProps';
+import type { DropAvailabilityInterval } from '@/app/features/appointments/components/Calendar/availabilityIntervals';
+import type { Task } from '@/app/features/tasks/types/task';
+
+type TaskCalendarInteractionProps = taskCalendarInteractionPropsModule.TaskCalendarInteractionProps;
+
+describe('TaskCalendarInteractionProps contract', () => {
+  it('is a type-only module with zero runtime exports', () => {
+    expect(Object.keys(taskCalendarInteractionPropsModule)).toEqual([]);
+  });
+
+  const task = { id: 'task-1', title: 'Recheck bandage' } as unknown as Task;
+  const date = new Date('2026-08-15T09:00:00Z');
+  const intervals: DropAvailabilityInterval[] = [{ startMinute: 480, endMinute: 720 }];
+
+  it('accepts an empty object because every field is optional', () => {
+    const minimal: TaskCalendarInteractionProps = {};
+    expect(minimal.canEditTasks).toBeUndefined();
+    expect(minimal.resolveDisplayName).toBeUndefined();
+  });
+
+  it('accepts a fully populated object and wires every handler', () => {
+    const canDragTask = jest.fn((candidate: Task) => candidate === task);
+    const onTaskDragStart = jest.fn();
+    const onTaskDragEnd = jest.fn();
+    const onTaskDropAt = jest.fn();
+    const onCreateTaskAt = jest.fn();
+    const onDragHoverTarget = jest.fn();
+    const getDropAvailabilityIntervals = jest.fn(() => intervals);
+    const resolveDisplayName = jest.fn((memberId?: string) => memberId ?? 'Unassigned');
+
+    const props: TaskCalendarInteractionProps = {
+      canEditTasks: true,
+      draggedTaskId: 'task-1',
+      draggedTaskLabel: 'Recheck bandage',
+      canDragTask,
+      onTaskDragStart,
+      onTaskDragEnd,
+      onTaskDropAt,
+      onCreateTaskAt,
+      onDragHoverTarget,
+      getDropAvailabilityIntervals,
+      draggedTaskDurationMinutes: 45,
+      slotStepMinutes: 15,
+      resolveDisplayName,
+    };
+
+    expect(props.canDragTask?.(task)).toBe(true);
+    props.onTaskDragStart?.(task);
+    props.onTaskDragEnd?.();
+    props.onTaskDropAt?.(date, 510, 'member-1');
+    props.onCreateTaskAt?.(date, 540);
+    props.onDragHoverTarget?.(date, 'member-1');
+
+    expect(onTaskDragStart).toHaveBeenCalledWith(task);
+    expect(onTaskDragEnd).toHaveBeenCalledTimes(1);
+    expect(onTaskDropAt).toHaveBeenCalledWith(date, 510, 'member-1');
+    expect(onCreateTaskAt).toHaveBeenCalledWith(date, 540);
+    expect(onDragHoverTarget).toHaveBeenCalledWith(date, 'member-1');
+
+    expect(props.getDropAvailabilityIntervals?.(date, 'member-1')).toEqual(intervals);
+    expect(props.resolveDisplayName?.('member-1')).toBe('member-1');
+    expect(props.resolveDisplayName?.(undefined)).toBe('Unassigned');
+  });
+
+  it('allows null for the dragged-task id and label', () => {
+    const props: TaskCalendarInteractionProps = {
+      draggedTaskId: null,
+      draggedTaskLabel: null,
+    };
+    expect(props.draggedTaskId).toBeNull();
+    expect(props.draggedTaskLabel).toBeNull();
+  });
+});

--- a/apps/frontend/src/app/__tests__/components/Calendar/common/DayCalendar.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/common/DayCalendar.test.tsx
@@ -393,6 +393,57 @@ describe('DayCalendar (Appointments)', () => {
     expect(screen.getByRole('menuitem', { name: 'Open companion overview' })).toBeInTheDocument();
   });
 
+  it('dims the gaps between visible availability intervals once availability loads', () => {
+    const getVisibleAvailabilityIntervals = jest.fn(() => [
+      { startMinute: 60, endMinute: 120 },
+      { startMinute: 180, endMinute: 240 },
+    ]);
+
+    const { container } = render(
+      <DayCalendar
+        events={[]}
+        date={baseDate}
+        handleViewAppointment={handleViewAppointment}
+        handleDetailAppointment={handleDetailAppointment}
+        handleRescheduleAppointment={handleRescheduleAppointment}
+        canEditAppointments={false}
+        getVisibleAvailabilityIntervals={getVisibleAvailabilityIntervals}
+        availabilityLoaded
+      />
+    );
+
+    // Window snaps to 0-300 minutes, so the gaps are 0-60, 120-180, and 240-300.
+    const overlays = container.querySelectorAll('[style*="calendar-dim-overlay"]');
+    expect(overlays).toHaveLength(3);
+    expect(getVisibleAvailabilityIntervals).toHaveBeenCalledWith(baseDate);
+  });
+
+  it('highlights drop availability intervals while an appointment is dragged', () => {
+    const getDropAvailabilityIntervals = jest.fn(() => [
+      { startMinute: 60, endMinute: 120 },
+      { startMinute: 180, endMinute: 240 },
+    ]);
+
+    const { container } = render(
+      <DayCalendar
+        events={[timedEvent]}
+        date={baseDate}
+        handleViewAppointment={handleViewAppointment}
+        handleDetailAppointment={handleDetailAppointment}
+        handleRescheduleAppointment={handleRescheduleAppointment}
+        canEditAppointments
+        draggedAppointmentId="timed"
+        draggedAppointmentLabel="Rex — Grooming"
+        draggedAppointmentDurationMinutes={30}
+        getDropAvailabilityIntervals={getDropAvailabilityIntervals}
+      />
+    );
+
+    const highlights = container.querySelectorAll('.bg-calendar-availability-overlay');
+    expect(highlights).toHaveLength(2);
+    expect(getDropAvailabilityIntervals).toHaveBeenCalledWith(baseDate);
+  });
+
   it('renders a bare day header with no in-grid day arrows', () => {
     // Day navigation is owned by the header toolbar's date-nav pill (covered in
     // Header.test.tsx); the grid's day header is just the frame's label + date.

--- a/apps/frontend/src/app/__tests__/components/Calendar/common/Header.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/common/Header.test.tsx
@@ -320,6 +320,13 @@ describe('Header Component', () => {
     expect(trigger).toHaveStyle({ borderColor: 'var(--hairline)' });
   });
 
+  it('falls back to the first status option when the active status matches none', () => {
+    render(<Header {...defaultProps} activeStatus="missing" statusOptions={statusOptions} />);
+
+    // selectedStatus falls back to statusOptions[0] ('all') → neutral trigger.
+    expect(screen.getByRole('button', { name: /All statuses/i })).toBeInTheDocument();
+  });
+
   it('keeps the selected status chevron inside the coloured pill', () => {
     render(
       <Header

--- a/apps/frontend/src/app/__tests__/components/Calendar/common/WeekCalendar.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/common/WeekCalendar.test.tsx
@@ -17,12 +17,14 @@ jest.mock('@/app/features/appointments/components/Calendar/weekHelpers', () => (
   HOURS_IN_DAY: 2,
 }));
 
+const mockComputeUnavailableSegments = jest.fn<any, any[]>(() => []);
+
 jest.mock('@/app/features/appointments/components/Calendar/helpers', () => ({
   DEFAULT_CALENDAR_FOCUS_MINUTES: 540,
   EVENT_VERTICAL_GAP_PX: 2,
   MINUTES_PER_STEP: 60,
   PIXELS_PER_STEP: 60,
-  computeUnavailableSegments: jest.fn(() => []),
+  computeUnavailableSegments: (...args: any[]) => mockComputeUnavailableSegments(...args),
   getFirstRelevantTimedEventStart: jest.fn(() => null),
   getNowTopPxForHourRange: jest.fn((_: Date, __: number, ___: number, height: number) => height),
   getTopPxForMinutes: jest.fn((minutes: number, hourHeight: number, gap: number, offset = 0) => {
@@ -99,6 +101,32 @@ describe('WeekCalendar (Appointments)', () => {
     mockEventsForDayHour.mockReturnValue([events[1]]);
     mockGetPrevWeek.mockReturnValue(new Date('2024-12-30T00:00:00Z'));
     mockGetNextWeek.mockReturnValue(new Date('2025-01-13T00:00:00Z'));
+    mockComputeUnavailableSegments.mockReturnValue([]);
+  });
+
+  it('shades unavailable hour segments from the visible availability intervals', () => {
+    const getVisibleAvailabilityIntervals = jest.fn(() => [{ startMinute: 30, endMinute: 120 }]);
+    mockComputeUnavailableSegments.mockReturnValue([{ startMinute: 0, endMinute: 30 }]);
+
+    const { container } = render(
+      <WeekCalendar
+        events={events}
+        handleViewAppointment={handleViewAppointment}
+        weekStart={weekStart}
+        handleRescheduleAppointment={handleRescheduleAppointment}
+        canEditAppointments
+        getVisibleAvailabilityIntervals={getVisibleAvailabilityIntervals}
+        availabilityLoaded
+      />
+    );
+
+    // One dim overlay per day for hour 0 (the segment ends before hour 1 starts).
+    const overlays = container.querySelectorAll('[style*="calendar-dim-overlay"]');
+    expect(overlays).toHaveLength(days.length);
+    expect((overlays[0] as HTMLElement).style.top).toBe('0%');
+    expect((overlays[0] as HTMLElement).style.height).toBe('50%');
+    expect(getVisibleAvailabilityIntervals).toHaveBeenCalled();
+    expect(mockComputeUnavailableSegments).toHaveBeenCalled();
   });
 
   it('renders day headers and all-day events', () => {

--- a/apps/frontend/src/app/__tests__/components/Calendar/common/calendarInteractionProps.test.ts
+++ b/apps/frontend/src/app/__tests__/components/Calendar/common/calendarInteractionProps.test.ts
@@ -1,0 +1,83 @@
+import * as calendarInteractionPropsModule from '@/app/features/appointments/components/Calendar/common/calendarInteractionProps';
+import type { Appointment } from '@yosemite-crew/types';
+
+type AppointmentCalendarInteractionProps =
+  calendarInteractionPropsModule.AppointmentCalendarInteractionProps;
+type AvailabilityInterval = calendarInteractionPropsModule.AvailabilityInterval;
+
+describe('AppointmentCalendarInteractionProps contract', () => {
+  it('is a type-only module with zero runtime exports', () => {
+    expect(Object.keys(calendarInteractionPropsModule)).toEqual([]);
+  });
+
+  const appointment = { _id: 'appt-1' } as unknown as Appointment;
+  const date = new Date('2026-08-15T10:00:00Z');
+  const intervals: AvailabilityInterval[] = [{ startMinute: 540, endMinute: 1020 }];
+
+  it('accepts a minimal object with only the required field', () => {
+    const minimal: AppointmentCalendarInteractionProps = { canEditAppointments: false };
+    expect(minimal.canEditAppointments).toBe(false);
+    expect(minimal.draggedAppointmentId).toBeUndefined();
+    expect(minimal.getDropAvailabilityIntervals).toBeUndefined();
+  });
+
+  it('accepts a fully populated object and wires every handler', () => {
+    const canDragAppointment = jest.fn((appt: Appointment) => appt === appointment);
+    const onAppointmentDragStart = jest.fn();
+    const onAppointmentDragEnd = jest.fn();
+    const onAppointmentDropAt = jest.fn();
+    const onDragHoverTarget = jest.fn();
+    const onCreateAppointmentAt = jest.fn();
+    const getDropAvailabilityIntervals = jest.fn(() => intervals);
+    const getVisibleAvailabilityIntervals = jest.fn(() => intervals);
+
+    const props: AppointmentCalendarInteractionProps = {
+      canEditAppointments: true,
+      draggedAppointmentId: 'appt-1',
+      draggedAppointmentLabel: 'Bella — Vaccination',
+      canDragAppointment,
+      onAppointmentDragStart,
+      onAppointmentDragEnd,
+      onAppointmentDropAt,
+      onDragHoverTarget,
+      onCreateAppointmentAt,
+      getDropAvailabilityIntervals,
+      getVisibleAvailabilityIntervals,
+      draggedAppointmentDurationMinutes: 30,
+      slotStepMinutes: 15,
+      availabilityLoaded: true,
+      skipAutoScroll: false,
+    };
+
+    expect(props.canDragAppointment?.(appointment)).toBe(true);
+    props.onAppointmentDragStart?.(appointment);
+    props.onAppointmentDragEnd?.();
+    props.onAppointmentDropAt?.(date, 600, 'lead-1');
+    props.onDragHoverTarget?.(date, 'lead-1');
+    props.onCreateAppointmentAt?.(date, 615);
+
+    expect(onAppointmentDragStart).toHaveBeenCalledWith(appointment);
+    expect(onAppointmentDragEnd).toHaveBeenCalledTimes(1);
+    expect(onAppointmentDropAt).toHaveBeenCalledWith(date, 600, 'lead-1');
+    expect(onDragHoverTarget).toHaveBeenCalledWith(date, 'lead-1');
+    expect(onCreateAppointmentAt).toHaveBeenCalledWith(date, 615);
+
+    expect(props.getDropAvailabilityIntervals?.(date, 'lead-1')).toEqual(intervals);
+    expect(props.getVisibleAvailabilityIntervals?.(date)).toEqual(intervals);
+  });
+
+  it('allows null for the dragged-appointment id and label', () => {
+    const props: AppointmentCalendarInteractionProps = {
+      canEditAppointments: true,
+      draggedAppointmentId: null,
+      draggedAppointmentLabel: null,
+    };
+    expect(props.draggedAppointmentId).toBeNull();
+    expect(props.draggedAppointmentLabel).toBeNull();
+  });
+
+  it('shapes availability intervals as minute ranges', () => {
+    const interval: AvailabilityInterval = { startMinute: 0, endMinute: 1440 };
+    expect(interval.endMinute).toBeGreaterThan(interval.startMinute);
+  });
+});

--- a/apps/frontend/src/app/__tests__/components/Filters/Filters/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Filters/Filters/index.test.tsx
@@ -69,6 +69,24 @@ describe('Filters', () => {
     expect(screen.getByRole('button', { name: 'Available' })).toBeInTheDocument();
   });
 
+  it('selects a status option from the dropdown panel and closes it', () => {
+    const setActiveStatus = jest.fn();
+    render(
+      <Filters
+        statusOptions={statusOptions}
+        activeStatus="available"
+        setActiveStatus={setActiveStatus}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Available' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Requested' }));
+
+    expect(setActiveStatus).toHaveBeenCalledWith('requested');
+    // The panel closes after a selection.
+    expect(screen.queryByText('Requested')).not.toBeInTheDocument();
+  });
+
   it('keeps the status dropdown open when interacting inside the panel', () => {
     render(
       <Filters statusOptions={statusOptions} activeStatus="available" setActiveStatus={jest.fn()} />
@@ -309,6 +327,24 @@ describe('Filters', () => {
 
       expect(screen.getByRole('button', { name: 'Cancelled' })).toHaveStyle({
         borderColor: 'var(--status-cancelled-bg)',
+      });
+    });
+
+    it('falls back to the hairline border when an active status has no colour tokens at all', () => {
+      render(
+        <Filters
+          filterOptions={[{ key: 'emergencies', name: 'Emergencies' }]}
+          statusOptions={[{ key: 'ghost', name: 'Ghost' }]}
+          activeFilter="all"
+          activeStatus="ghost"
+          setActiveFilter={jest.fn()}
+          setActiveStatus={jest.fn()}
+        />
+      );
+
+      expect(screen.getByRole('button', { name: 'Ghost' })).toHaveStyle({
+        borderColor: 'var(--hairline)',
+        color: 'var(--ink)',
       });
     });
   });

--- a/apps/frontend/src/app/__tests__/components/Filters/FormsFilters/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Filters/FormsFilters/index.test.tsx
@@ -201,6 +201,26 @@ describe('FormsFilters Component', () => {
     expect(screen.getByTestId('option-Inpatient Schedule')).toBeInTheDocument();
   });
 
+  it('offers the whole taxonomy when no primary org is selected', () => {
+    mockUseOrgStore.mockImplementation((selector: any) =>
+      selector({ primaryOrgId: undefined, orgsById: {} })
+    );
+    renderFilters();
+    openMenu();
+    for (const category of FormsCategoryOptions) {
+      expect(screen.getByTestId(`option-${category}`)).toBeInTheDocument();
+    }
+  });
+
+  it('treats a primary org without a loaded record as an unknown org type', () => {
+    mockUseOrgStore.mockImplementation((selector: any) =>
+      selector({ primaryOrgId: 'org-9', orgsById: {} })
+    );
+    renderFilters();
+    openMenu();
+    expect(screen.getByTestId('option-Custom')).toBeInTheDocument();
+  });
+
   it('offers the whole taxonomy when the org type is unknown', () => {
     renderFilters();
     openMenu();

--- a/apps/frontend/src/app/__tests__/components/Filters/InventoryFilters/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Filters/InventoryFilters/index.test.tsx
@@ -100,6 +100,18 @@ describe('InventoryFilters', () => {
     expect(screen.getByRole('button', { name: /Healthy/ })).toBeInTheDocument();
   });
 
+  it('falls back to the first stock health option when the status matches none', () => {
+    render(
+      <InventoryFilters
+        filters={{ status: 'MYSTERY', visibility: 'ALL', category: 'all' } as any}
+        onChange={jest.fn()}
+        categories={['Food']}
+      />
+    );
+    // selectedStockHealth falls back to the ALL option, so the pill shows the placeholder.
+    expect(screen.getByRole('button', { name: /Stock health/ })).toBeInTheDocument();
+  });
+
   it('opens the stock health dropdown and selects an option', () => {
     const onChange = jest.fn();
     render(

--- a/apps/frontend/src/app/__tests__/components/Filters/InventoryTurnoverFilters.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Filters/InventoryTurnoverFilters.test.tsx
@@ -45,6 +45,35 @@ describe('<InventoryTurnoverFilters />', () => {
     });
   });
 
+  test('tints the trigger with the selected non-ALL status tokens', () => {
+    render(
+      <InventoryTurnoverFilters
+        filters={{ status: 'EXCELLENT', category: 'all' }}
+        setFilters={jest.fn()}
+        categories={['Medicine']}
+      />
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Excellent' });
+    expect(trigger).toHaveStyle({
+      backgroundColor: 'var(--color-pill-success-bg)',
+      color: 'var(--color-pill-success-text)',
+      borderColor: 'var(--color-pill-success-border)',
+    });
+  });
+
+  test('falls back to the ALL option when the status matches none and no categories are passed', () => {
+    render(
+      <InventoryTurnoverFilters
+        filters={{ status: 'MYSTERY', category: 'all' }}
+        setFilters={jest.fn()}
+      />
+    );
+
+    // selectedStatus falls back to STATUS_OPTIONS[0], so the pill shows the placeholder.
+    expect(screen.getByRole('button', { name: 'Status' })).toBeInTheDocument();
+  });
+
   test('resets an invalid category to all and closes the status menu on outside click and scroll', () => {
     const setFilters = jest.fn();
     const { rerender } = render(

--- a/apps/frontend/src/app/__tests__/components/Inputs/Dropdown/LabelDropdown.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Inputs/Dropdown/LabelDropdown.test.tsx
@@ -110,6 +110,21 @@ describe('LabelDropdown', () => {
     expect(screen.getByText('Canine')).toBeInTheDocument();
   });
 
+  it('keeps the placeholder when the default option matches nothing', () => {
+    render(
+      <LabelDropdown
+        placeholder="Species"
+        options={options}
+        defaultOption="wolf"
+        onSelect={jest.fn()}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Species' })).toBeInTheDocument();
+    expect(screen.queryByText('Canine')).not.toBeInTheDocument();
+    expect(screen.queryByText('Feline')).not.toBeInTheDocument();
+  });
+
   it('preselects default option by label', () => {
     render(
       <LabelDropdown
@@ -282,6 +297,33 @@ describe('LabelDropdown', () => {
 
     fireEvent.click(chevron as SVGElement);
     expect(screen.queryByRole('textbox', { name: 'Search Species' })).not.toBeInTheDocument();
+  });
+
+  it('highlights the option under the pointer', () => {
+    render(<LabelDropdown placeholder="Species" options={options} onSelect={jest.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Species/i }));
+
+    const felineOption = screen.getByText('Feline').closest('button')!;
+    fireEvent.mouseEnter(felineOption);
+
+    expect(felineOption).toHaveClass('bg-[var(--nav-active-bg)]');
+    expect(screen.getByText('Canine').closest('button')).not.toHaveClass(
+      'bg-[var(--nav-active-bg)]'
+    );
+  });
+
+  it('navigates and confirms options from the search input', () => {
+    const onSelect = jest.fn();
+    render(<LabelDropdown placeholder="Species" options={options} onSelect={onSelect} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Species/i }));
+
+    const search = screen.getByRole('textbox', { name: 'Search Species' });
+    fireEvent.keyDown(search, { key: 'ArrowDown' });
+    fireEvent.keyDown(search, { key: 'Enter' });
+
+    expect(onSelect).toHaveBeenCalledWith({ label: 'Feline', value: 'cat' });
   });
 
   it('renders a badge pill next to options that provide one', () => {

--- a/apps/frontend/src/app/__tests__/components/Inputs/MultiSelectDropdown/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Inputs/MultiSelectDropdown/index.test.tsx
@@ -382,6 +382,28 @@ describe('MultiSelectDropdown', () => {
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
   });
 
+  it('highlights the option under the pointer', () => {
+    render(
+      <MultiSelectDropdown
+        placeholder="Select"
+        value={[]}
+        onChange={jest.fn()}
+        options={['One', 'Two']}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Select/i }));
+
+    fireEvent.mouseEnter(screen.getByRole('button', { name: 'Two', pressed: false }));
+
+    expect(screen.getByRole('button', { name: 'Two', pressed: false })).toHaveClass(
+      'bg-card-hover'
+    );
+    expect(screen.getByRole('button', { name: 'One', pressed: false })).not.toHaveClass(
+      'bg-card-hover'
+    );
+  });
+
   it('renders the empty state when no options prop is provided', () => {
     render(<MultiSelectDropdown placeholder="Select" value={[]} onChange={jest.fn()} />);
 

--- a/apps/frontend/src/app/__tests__/components/Inputs/ServiceSearch/ServiceSearch.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Inputs/ServiceSearch/ServiceSearch.test.tsx
@@ -198,6 +198,58 @@ describe('ServiceSearch Component', () => {
     // This is correct behavior (don't add empty).
   });
 
+  it('leaves other specialities untouched and skips duplicates when selecting', async () => {
+    render(<ServiceSearch speciality={defaultSpeciality} setSpecialities={mockSetSpecialities} />);
+
+    fireEvent.focus(screen.getByPlaceholderText('Search or create service'));
+    await act(async () => {
+      fireEvent.click(screen.getByText('Vaccination'));
+    });
+
+    const updateFn = mockSetSpecialities.mock.calls[0][0];
+    const otherSpeciality = { name: 'Dentistry', services: [] } as any;
+    const duplicateHolder = {
+      name: 'General Practice',
+      services: [{ name: 'Vaccination' }],
+    } as any;
+    const bareSpeciality = { name: 'General Practice', services: undefined } as any;
+
+    const newState = updateFn([otherSpeciality, duplicateHolder, bareSpeciality]);
+
+    // Non-matching speciality passes through by reference.
+    expect(newState[0]).toBe(otherSpeciality);
+    // A speciality already holding the service is left untouched.
+    expect(newState[1]).toBe(duplicateHolder);
+    // A matching speciality without a services array gets one created.
+    expect(newState[2].services).toHaveLength(1);
+    expect(newState[2].services[0]).toEqual(expect.objectContaining({ name: 'Vaccination' }));
+  });
+
+  it('leaves other specialities untouched and skips duplicates when adding a custom service', async () => {
+    render(<ServiceSearch speciality={defaultSpeciality} setSpecialities={mockSetSpecialities} />);
+
+    const input = screen.getByPlaceholderText('Search or create service');
+    fireEvent.change(input, { target: { value: 'Custom' } });
+    await act(async () => {
+      fireEvent.click(screen.getByText(/Add service.*Custom/));
+    });
+
+    const updateFn = mockSetSpecialities.mock.calls[0][0];
+    const otherSpeciality = { name: 'Dentistry', services: [] } as any;
+    const duplicateHolder = {
+      name: 'General Practice',
+      services: [{ name: 'custom' }],
+    } as any;
+    const bareSpeciality = { name: 'General Practice', services: undefined } as any;
+
+    const newState = updateFn([otherSpeciality, duplicateHolder, bareSpeciality]);
+
+    expect(newState[0]).toBe(otherSpeciality);
+    expect(newState[1]).toBe(duplicateHolder);
+    expect(newState[2].services).toHaveLength(1);
+    expect(newState[2].services[0]).toEqual(expect.objectContaining({ name: 'Custom' }));
+  });
+
   // --- 5. Interaction: Close on Outside Click ---
 
   it('closes dropdown when clicking outside', () => {

--- a/apps/frontend/src/app/__tests__/components/Inputs/ServiceSearch/useOnboardingServiceBuilder.test.ts
+++ b/apps/frontend/src/app/__tests__/components/Inputs/ServiceSearch/useOnboardingServiceBuilder.test.ts
@@ -1,0 +1,125 @@
+import { renderHook } from '@testing-library/react';
+import { useOnboardingServiceBuilder } from '@/app/ui/inputs/ServiceSearch/useOnboardingServiceBuilder';
+import { useOrgStore } from '@/app/stores/orgStore';
+import {
+  buildCustomOnboardingServiceTemplate,
+  findOnboardingSpecialityTemplate,
+  getResolvedBusinessType,
+} from '@/app/lib/onboardingSpecialityCatalog';
+import { SpecialityWeb } from '@/app/features/organization/types/speciality';
+
+jest.mock('@/app/stores/orgStore', () => ({
+  useOrgStore: jest.fn(),
+}));
+
+jest.mock('@/app/lib/onboardingSpecialityCatalog', () => ({
+  buildCustomOnboardingServiceTemplate: jest.fn(),
+  findOnboardingSpecialityTemplate: jest.fn(),
+  getResolvedBusinessType: jest.fn(),
+}));
+
+const speciality = { _id: 'spec-1', name: 'General Practice' } as SpecialityWeb;
+
+const mockState = (state: {
+  primaryOrgId?: string;
+  orgsById?: Record<string, { type?: string }>;
+}) => {
+  (useOrgStore as unknown as jest.Mock).mockImplementation((selector) =>
+    selector({ primaryOrgId: undefined, orgsById: {}, ...state })
+  );
+};
+
+describe('useOnboardingServiceBuilder', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getResolvedBusinessType as jest.Mock).mockReturnValue('HOSPITAL');
+    (findOnboardingSpecialityTemplate as jest.Mock).mockReturnValue(undefined);
+    (buildCustomOnboardingServiceTemplate as jest.Mock).mockImplementation(
+      (specialityName: string, serviceName: string) => ({
+        name: serviceName,
+        cost: 60,
+        durationMinutes: 30,
+      })
+    );
+    mockState({ primaryOrgId: 'org-1', orgsById: { 'org-1': { type: 'GROOMER' } } });
+  });
+
+  it('resolves a case-insensitive catalog template match and stamps the organisation id', () => {
+    (findOnboardingSpecialityTemplate as jest.Mock).mockReturnValue({
+      services: [{ name: 'Checkup', cost: 45, durationMinutes: 20 }],
+    });
+
+    const { result } = renderHook(() => useOnboardingServiceBuilder(speciality));
+    const service = result.current('checkup');
+
+    expect(getResolvedBusinessType).toHaveBeenCalledWith('GROOMER');
+    expect(findOnboardingSpecialityTemplate).toHaveBeenCalledWith('HOSPITAL', 'General Practice');
+    expect(buildCustomOnboardingServiceTemplate).not.toHaveBeenCalled();
+    expect(service).toEqual({
+      name: 'Checkup',
+      cost: 45,
+      durationMinutes: 20,
+      organisationId: 'org-1',
+    });
+    expect('specialityId' in service).toBe(false);
+  });
+
+  it('falls back to a capitalized custom template when no catalog service matches', () => {
+    (findOnboardingSpecialityTemplate as jest.Mock).mockReturnValue({
+      services: [{ name: 'Checkup', cost: 45, durationMinutes: 20 }],
+    });
+
+    const { result } = renderHook(() => useOnboardingServiceBuilder(speciality));
+    const service = result.current('grooming');
+
+    expect(buildCustomOnboardingServiceTemplate).toHaveBeenCalledWith(
+      'General Practice',
+      'Grooming',
+      'HOSPITAL'
+    );
+    expect(service).toEqual({
+      name: 'Grooming',
+      cost: 60,
+      durationMinutes: 30,
+      organisationId: 'org-1',
+    });
+  });
+
+  it('builds a custom template when the speciality has no catalog entry at all', () => {
+    const { result } = renderHook(() => useOnboardingServiceBuilder(speciality));
+    const service = result.current('Dental');
+
+    expect(buildCustomOnboardingServiceTemplate).toHaveBeenCalledWith(
+      'General Practice',
+      'Dental',
+      'HOSPITAL'
+    );
+    expect(service.organisationId).toBe('org-1');
+  });
+
+  it('stamps the speciality id when the edit flow passes one', () => {
+    const { result } = renderHook(() => useOnboardingServiceBuilder(speciality));
+    const service = result.current('Dental', { specialityId: 'spec-1' });
+
+    expect(service.specialityId).toBe('spec-1');
+  });
+
+  it('falls back to an empty organisation id and undefined org type without a primary org', () => {
+    mockState({ primaryOrgId: undefined });
+
+    const { result } = renderHook(() => useOnboardingServiceBuilder(speciality));
+    const service = result.current('Dental');
+
+    expect(getResolvedBusinessType).toHaveBeenCalledWith(undefined);
+    expect(service.organisationId).toBe('');
+  });
+
+  it('resolves an undefined org type when the primary org is not in the store map', () => {
+    mockState({ primaryOrgId: 'org-2', orgsById: {} });
+
+    const { result } = renderHook(() => useOnboardingServiceBuilder(speciality));
+    result.current('Dental');
+
+    expect(getResolvedBusinessType).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/apps/frontend/src/app/__tests__/components/Stats/StatCardShell.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Stats/StatCardShell.test.tsx
@@ -1,14 +1,17 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import StatCardShell from '@/app/ui/widgets/Stats/StatCardShell';
 
 jest.mock('@/app/ui/cards/CardHeader/CardHeader', () => ({
   __esModule: true,
-  default: ({ title, options, selected }: any) => (
+  default: ({ title, options, selected, onSelect }: any) => (
     <div data-testid="card-header" data-selected={selected} data-options={options.join('|')}>
       {title}
+      <button type="button" onClick={() => onSelect?.(options.at(-1))}>
+        pick-last
+      </button>
     </div>
   ),
 }));
@@ -60,6 +63,56 @@ describe('StatCardShell', () => {
     const svg = container.querySelector('svg') as SVGElement;
     expect(svg).toHaveAttribute('aria-hidden', 'true');
     expect(svg.querySelectorAll('rect')).toHaveLength(3);
+  });
+
+  it('forwards an explicit selected option to the header instead of the first one', () => {
+    render(
+      <StatCardShell
+        title="Any"
+        options={['Last 6 months', 'Last 1 year']}
+        selected="Last 1 year"
+        isEmpty={false}
+      >
+        <div>body</div>
+      </StatCardShell>
+    );
+
+    expect(screen.getByTestId('card-header')).toHaveAttribute('data-selected', 'Last 1 year');
+  });
+
+  it('forwards onSelect so the header can change the duration', () => {
+    const onSelect = jest.fn();
+    render(
+      <StatCardShell
+        title="Any"
+        options={['Last week', 'Last month']}
+        onSelect={onSelect}
+        isEmpty={false}
+      >
+        <div>body</div>
+      </StatCardShell>
+    );
+
+    fireEvent.click(screen.getByText('pick-last'));
+    expect(onSelect).toHaveBeenCalledWith('Last month');
+  });
+
+  it('applies a caller-supplied card surface class instead of the default sizing', () => {
+    const { container } = render(
+      <StatCardShell
+        title="Any"
+        options={['Last week']}
+        isEmpty={false}
+        cardClassName="gap-3.5 overflow-hidden min-h-89"
+      >
+        <div>body</div>
+      </StatCardShell>
+    );
+
+    const surface = container.querySelector('.min-h-89') as HTMLElement;
+    expect(surface).toHaveClass('gap-3.5', 'overflow-hidden', 'rounded-[18px]');
+    expect(surface).not.toHaveClass('min-h-75');
+    expect(surface).not.toHaveClass('gap-2.5');
   });
 
   it('wraps the body in the shared warm-bone card surface', () => {

--- a/apps/frontend/src/app/__tests__/components/chat/ChatContainer.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/chat/ChatContainer.test.tsx
@@ -1289,6 +1289,13 @@ describe('ChatContainer', () => {
       expect(filter([unknown])).toContain(unknown);
     });
 
+    it('treats an unstamped channel without an id as outside the org allowlist', async () => {
+      const idless = { ...clientChannel('idless', {}), id: undefined };
+      const filter = await renderForFilter();
+
+      expect(filter([idless])).not.toContain(idless);
+    });
+
     it('scopes to the organisation switched into rather than the one loaded before', async () => {
       const theirs = clientChannel('theirs', { organisationId: 'org-2' });
       const filter = await renderForFilter();
@@ -2170,6 +2177,31 @@ describe('ChatContainer', () => {
     expect(onChannelSelect).not.toHaveBeenCalled();
 
     mockClient.queryChannels.mockResolvedValue([defaultMockChannel]);
+  });
+
+  it('closes the network directory without starting a chat', async () => {
+    mockUseOrgStore.mockImplementation((selector: any) =>
+      selector({
+        primaryOrgId: 'org-1',
+        status: 'loaded',
+        getPrimaryOrg: () => ({ crossOrgMessagingEnabled: true }),
+      })
+    );
+
+    await act(async () => {
+      render(<ChatContainer scope="colleagues" />);
+    });
+    await waitFor(() =>
+      expect(screen.getByText('Message a colleague at another clinic')).toBeInTheDocument()
+    );
+    fireEvent.click(screen.getByText('Message a colleague at another clinic'));
+    await waitFor(() => expect(screen.getByTestId('network-modal')).toBeInTheDocument());
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Close Network'));
+    });
+
+    expect(screen.queryByTestId('network-modal')).not.toBeInTheDocument();
   });
 
   it('goes back to the conversation list from the mobile chat view', async () => {

--- a/apps/frontend/src/app/__tests__/constants/status.test.ts
+++ b/apps/frontend/src/app/__tests__/constants/status.test.ts
@@ -1,0 +1,151 @@
+import {
+  AppointmentLabels,
+  TaskLabels,
+  getAppointmentStatusTone,
+  getStatusStyle,
+  statusLabel,
+} from '@/app/constants/status';
+
+describe('statusLabel', () => {
+  it('derives all colour tokens from the css prefix', () => {
+    expect(statusLabel('Upcoming', 'upcoming', 'status-upcoming')).toEqual({
+      name: 'Upcoming',
+      key: 'upcoming',
+      bg: 'var(--status-upcoming-bg)',
+      text: 'var(--status-upcoming-text)',
+      border: 'var(--status-upcoming-border)',
+    });
+  });
+
+  it('honours a border override', () => {
+    expect(statusLabel('All', 'ALL', 'color-badge-blue', 'var(--color-primary-500)')).toEqual({
+      name: 'All',
+      key: 'ALL',
+      bg: 'var(--color-badge-blue-bg)',
+      text: 'var(--color-badge-blue-text)',
+      border: 'var(--color-primary-500)',
+    });
+  });
+});
+
+describe('status label tables', () => {
+  it('keeps the appointment labels identical to the original token values', () => {
+    expect(AppointmentLabels).toEqual([
+      {
+        name: 'Requested',
+        key: 'requested',
+        bg: 'var(--status-requested-bg)',
+        text: 'var(--status-requested-text)',
+        border: 'var(--status-requested-border)',
+      },
+      {
+        name: 'Upcoming',
+        key: 'upcoming',
+        bg: 'var(--status-upcoming-bg)',
+        text: 'var(--status-upcoming-text)',
+        border: 'var(--status-upcoming-border)',
+      },
+      {
+        name: 'Checked-in',
+        key: 'checked_in',
+        bg: 'var(--status-checked-in-bg)',
+        text: 'var(--status-checked-in-text)',
+        border: 'var(--status-checked-in-border)',
+      },
+      {
+        name: 'In progress',
+        key: 'in_progress',
+        bg: 'var(--status-in-progress-bg)',
+        text: 'var(--status-in-progress-text)',
+        border: 'var(--status-in-progress-border)',
+      },
+      {
+        name: 'Completed',
+        key: 'completed',
+        bg: 'var(--status-completed-bg)',
+        text: 'var(--status-completed-text)',
+        border: 'var(--status-completed-border)',
+      },
+      {
+        name: 'Cancelled',
+        key: 'cancelled',
+        bg: 'var(--status-cancelled-bg)',
+        text: 'var(--status-cancelled-text)',
+        border: 'var(--status-cancelled-border)',
+      },
+    ]);
+  });
+
+  it('keeps the task labels identical to the original token values', () => {
+    expect(TaskLabels).toEqual([
+      {
+        name: 'Pending',
+        key: 'pending',
+        bg: 'var(--status-requested-bg)',
+        text: 'var(--status-requested-text)',
+        border: 'var(--status-requested-border)',
+      },
+      {
+        name: 'In progress',
+        key: 'in_progress',
+        bg: 'var(--status-in-progress-bg)',
+        text: 'var(--status-in-progress-text)',
+        border: 'var(--status-in-progress-border)',
+      },
+      {
+        name: 'Completed',
+        key: 'completed',
+        bg: 'var(--status-completed-bg)',
+        text: 'var(--status-completed-text)',
+        border: 'var(--status-completed-border)',
+      },
+      {
+        name: 'Cancelled',
+        key: 'cancelled',
+        bg: 'var(--status-cancelled-bg)',
+        text: 'var(--status-cancelled-text)',
+        border: 'var(--status-cancelled-border)',
+      },
+    ]);
+  });
+});
+
+describe('getStatusStyle', () => {
+  it('matches statuses case-insensitively', () => {
+    expect(getStatusStyle('Completed')).toEqual({
+      color: 'var(--status-completed-text)',
+      backgroundColor: 'var(--status-completed-bg)',
+      borderColor: 'var(--status-completed-border)',
+    });
+  });
+
+  it('falls back to the requested tokens for unknown statuses', () => {
+    expect(getStatusStyle('mystery')).toEqual({
+      color: 'var(--status-requested-text)',
+      backgroundColor: 'var(--status-requested-bg)',
+      borderColor: 'var(--status-requested-border)',
+    });
+  });
+});
+
+describe('getAppointmentStatusTone', () => {
+  it.each([
+    ['completed', 'success'],
+    ['In Progress', 'progress'],
+    ['checked-in', 'accent'],
+    ['upcoming', 'info'],
+    ['cancelled', 'warning'],
+    ['no show', 'warning'],
+    ['NO_PAYMENT', 'warning'],
+    ['pending', 'neutral'],
+    ['requested', 'neutral'],
+    ['anything else', 'neutral'],
+  ])('maps %s to %s', (status, tone) => {
+    expect(getAppointmentStatusTone(status)).toBe(tone);
+  });
+
+  it('treats missing statuses as neutral', () => {
+    expect(getAppointmentStatusTone(null)).toBe('neutral');
+    expect(getAppointmentStatusTone(undefined)).toBe('neutral');
+  });
+});

--- a/apps/frontend/src/app/__tests__/features/appointments/pages/AppointmentWorkspace/steps/idexxTestSearchProps.test.ts
+++ b/apps/frontend/src/app/__tests__/features/appointments/pages/AppointmentWorkspace/steps/idexxTestSearchProps.test.ts
@@ -1,0 +1,64 @@
+import { getIdexxTestSearchProps } from '@/app/features/appointments/pages/AppointmentWorkspace/steps/idexxTestSearchProps';
+import type { UseLabTestsReturn } from '@/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/LabTests';
+
+const buildLabTestsStub = (overrides: Record<string, unknown> = {}) => {
+  const setSelectedTestLabel = jest.fn();
+  const setQuery = jest.fn();
+  const loadMoreTests = jest.fn();
+  const test = { code: 'CBC01', display: 'Complete Blood Count' };
+  const stub = {
+    tests: [test],
+    selectedTestLabel: '',
+    query: 'blood',
+    setSelectedTestLabel,
+    setQuery,
+    loadMoreTests,
+    testsHasMore: true,
+    testsLoadingMore: false,
+    ...overrides,
+  };
+  return {
+    s: stub as unknown as UseLabTestsReturn,
+    test,
+    setSelectedTestLabel,
+    setQuery,
+    loadMoreTests,
+  };
+};
+
+describe('getIdexxTestSearchProps', () => {
+  it('maps tests into SearchDropdown options with code, display label and meta', () => {
+    const { s, test } = buildLabTestsStub();
+    const props = getIdexxTestSearchProps(s);
+    expect(props.options).toEqual([
+      { value: 'CBC01', label: 'Complete Blood Count (CBC01)', meta: test },
+    ]);
+  });
+
+  it('prefers the selected test label over the raw query', () => {
+    const { s } = buildLabTestsStub({ selectedTestLabel: 'Complete Blood Count (CBC01)' });
+    expect(getIdexxTestSearchProps(s).query).toBe('Complete Blood Count (CBC01)');
+  });
+
+  it('falls back to the raw query when no test label is selected', () => {
+    const { s } = buildLabTestsStub();
+    expect(getIdexxTestSearchProps(s).query).toBe('blood');
+  });
+
+  it('setQuery updates both the selected test label and the search query', () => {
+    const { s, setSelectedTestLabel, setQuery } = buildLabTestsStub();
+    getIdexxTestSearchProps(s).setQuery('lipase');
+    expect(setSelectedTestLabel).toHaveBeenCalledWith('lipase');
+    expect(setQuery).toHaveBeenCalledWith('lipase');
+  });
+
+  it('passes through pagination state and the shared option styling', () => {
+    const { s, loadMoreTests } = buildLabTestsStub({ testsLoadingMore: true, testsHasMore: false });
+    const props = getIdexxTestSearchProps(s);
+    expect(props.minChars).toBe(0);
+    expect(props.onReachEnd).toBe(loadMoreTests);
+    expect(props.hasMore).toBe(false);
+    expect(props.isLoadingMore).toBe(true);
+    expect(props.optionClassName).toContain('border-card-border');
+  });
+});

--- a/apps/frontend/src/app/__tests__/features/appointments/pages/AppointmentWorkspace/templateSchemaSnapshot.test.ts
+++ b/apps/frontend/src/app/__tests__/features/appointments/pages/AppointmentWorkspace/templateSchemaSnapshot.test.ts
@@ -1,0 +1,67 @@
+import {
+  getTemplateSchemaSnapshot,
+  hasTemplateSchemaSnapshot,
+} from '@/app/features/appointments/pages/AppointmentWorkspace/templateSchemaSnapshot';
+import type { TemplateLike } from '@yosemite-crew/types';
+
+const asTemplate = (value: Record<string, unknown>): TemplateLike =>
+  value as unknown as TemplateLike;
+
+describe('hasTemplateSchemaSnapshot', () => {
+  it('accepts an object with a sections array', () => {
+    expect(hasTemplateSchemaSnapshot({ sections: [] })).toBe(true);
+  });
+
+  it('rejects nullish, primitive and sections-less values', () => {
+    expect(hasTemplateSchemaSnapshot(null)).toBe(false);
+    expect(hasTemplateSchemaSnapshot(undefined)).toBe(false);
+    expect(hasTemplateSchemaSnapshot('sections')).toBe(false);
+    expect(hasTemplateSchemaSnapshot({})).toBe(false);
+    expect(hasTemplateSchemaSnapshot({ sections: {} })).toBe(false);
+  });
+});
+
+describe('getTemplateSchemaSnapshot', () => {
+  const snapshot = { sections: [{ fields: [] }] };
+
+  it('returns the root-level snapshot when present', () => {
+    const template = asTemplate({ schemaSnapshot: snapshot, versions: [] });
+    expect(getTemplateSchemaSnapshot(template)).toBe(snapshot);
+  });
+
+  it('falls back to the published version snapshot', () => {
+    const template = asTemplate({
+      publishedVersion: 2,
+      versions: [
+        { version: 1, schemaSnapshot: { sections: [] } },
+        { version: 2, schemaSnapshot: snapshot },
+      ],
+    });
+    expect(getTemplateSchemaSnapshot(template)).toBe(snapshot);
+  });
+
+  it('falls back to the latest version snapshot when nothing is published', () => {
+    const template = asTemplate({
+      latestVersion: 3,
+      versions: [{ version: 3, schemaSnapshot: snapshot }],
+    });
+    expect(getTemplateSchemaSnapshot(template)).toBe(snapshot);
+  });
+
+  it('returns undefined when the matched version has no valid snapshot', () => {
+    const template = asTemplate({
+      publishedVersion: 1,
+      versions: [{ version: 1, schemaSnapshot: { sections: 'nope' } }],
+    });
+    expect(getTemplateSchemaSnapshot(template)).toBeUndefined();
+  });
+
+  it('returns undefined when no version matches or versions are missing', () => {
+    expect(
+      getTemplateSchemaSnapshot(
+        asTemplate({ publishedVersion: 9, versions: [{ version: 1, schemaSnapshot: snapshot }] })
+      )
+    ).toBeUndefined();
+    expect(getTemplateSchemaSnapshot(asTemplate({}))).toBeUndefined();
+  });
+});

--- a/apps/frontend/src/app/__tests__/features/appointments/types/appointments.test.ts
+++ b/apps/frontend/src/app/__tests__/features/appointments/types/appointments.test.ts
@@ -1,0 +1,97 @@
+import {
+  AppointmentFilters,
+  AppointmentStatusFilters,
+  AppointmentStatusFiltersUI,
+  AppointmentStatusOptions,
+} from '@/app/features/appointments/types/appointments';
+
+describe('appointments types', () => {
+  it('keeps the appointment status dropdown options', () => {
+    expect(AppointmentStatusOptions).toEqual([
+      { value: 'REQUESTED', label: 'Requested' },
+      { value: 'UPCOMING', label: 'Upcoming' },
+      { value: 'CHECKED_IN', label: 'Checked in' },
+      { value: 'IN_PROGRESS', label: 'In progress' },
+      { value: 'COMPLETED', label: 'Completed' },
+      { value: 'CANCELLED', label: 'Cancelled' },
+      { value: 'NO_SHOW', label: 'No show' },
+    ]);
+  });
+
+  it('keeps the exact status filter pills with their per-status CSS tokens', () => {
+    expect(AppointmentStatusFilters).toEqual([
+      {
+        name: 'All',
+        key: 'all',
+        bg: 'var(--status-requested-bg)',
+        text: 'var(--status-requested-text)',
+        border: 'var(--status-requested-border)',
+        dropdownText: undefined,
+      },
+      {
+        name: 'Requested',
+        key: 'requested',
+        bg: 'var(--status-requested-bg)',
+        text: 'var(--status-requested-text)',
+        border: 'var(--status-requested-border)',
+        dropdownText: undefined,
+      },
+      {
+        name: 'Upcoming',
+        key: 'upcoming',
+        bg: 'var(--status-upcoming-bg)',
+        text: 'var(--status-upcoming-text)',
+        border: 'var(--status-upcoming-border)',
+        dropdownText: undefined,
+      },
+      {
+        name: 'Checked-in',
+        key: 'checked_in',
+        bg: 'var(--status-checked-in-bg)',
+        text: 'var(--status-checked-in-text)',
+        border: 'var(--status-checked-in-border)',
+        dropdownText: undefined,
+      },
+      {
+        name: 'In progress',
+        key: 'in_progress',
+        bg: 'var(--status-in-progress-bg)',
+        text: 'var(--status-in-progress-text)',
+        border: 'var(--status-in-progress-border)',
+        dropdownText: undefined,
+      },
+      {
+        name: 'Completed',
+        key: 'completed',
+        bg: 'var(--status-completed-bg)',
+        text: 'var(--status-completed-text)',
+        border: 'var(--status-completed-border)',
+        dropdownText: undefined,
+      },
+      {
+        name: 'Cancelled',
+        key: 'cancelled',
+        bg: 'var(--status-cancelled-bg)',
+        text: 'var(--status-cancelled-text)',
+        border: 'var(--status-cancelled-border)',
+        dropdownText: undefined,
+      },
+      {
+        name: 'No show',
+        key: 'no_show',
+        bg: 'var(--status-no-show-bg)',
+        text: 'var(--status-no-show-text)',
+        border: 'var(--status-no-show-border)',
+        dropdownText: undefined,
+      },
+    ]);
+  });
+
+  it('reuses the same array for the UI filter list', () => {
+    expect(AppointmentStatusFiltersUI).toBe(AppointmentStatusFilters);
+  });
+
+  it('keeps the emergencies quick filter', () => {
+    expect(AppointmentFilters).toEqual([{ name: 'Emergencies', key: 'emergencies' }]);
+  });
+});

--- a/apps/frontend/src/app/__tests__/features/companions/components/AddCompanion/Sections/Companion.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/companions/components/AddCompanion/Sections/Companion.test.tsx
@@ -757,4 +757,30 @@ describe('Companion section', () => {
     const arg = setFormData.mock.calls.at(-1)?.[0];
     expect(arg.ageWhenNeutered).toBe('25');
   });
+
+  // 20. clearing the linked parent resets the companion search state
+  it('clears companion search results when the parent id is removed', async () => {
+    mockGetCompanionForParent.mockResolvedValue([]);
+    const props = {
+      setActiveLabel: jest.fn(),
+      formData: makeFormData(),
+      setFormData: jest.fn(),
+      setParentFormData: jest.fn(),
+      setShowModal: jest.fn(),
+      mode: 'default' as const,
+      onCompanionCreated: jest.fn(),
+    };
+
+    let view!: ReturnType<typeof render>;
+    await act(async () => {
+      view = render(<Companion {...props} parentFormData={makeParentData({ id: 'parent-1' })} />);
+    });
+
+    // Dropping the parent id runs the render-time reset that clears results/query.
+    await act(async () => {
+      view.rerender(<Companion {...props} parentFormData={makeParentData({ id: '' })} />);
+    });
+
+    expect((screen.getByTestId('search-input') as HTMLInputElement).value).toBe('');
+  });
 });

--- a/apps/frontend/src/app/__tests__/features/companions/components/companionBloodGroups.test.ts
+++ b/apps/frontend/src/app/__tests__/features/companions/components/companionBloodGroups.test.ts
@@ -1,0 +1,35 @@
+import { BLOOD_GROUP_OPTIONS_BY_SPECIES } from '@/app/features/companions/components/companionBloodGroups';
+
+describe('BLOOD_GROUP_OPTIONS_BY_SPECIES', () => {
+  it('covers every companion type', () => {
+    expect(Object.keys(BLOOD_GROUP_OPTIONS_BY_SPECIES).sort((a, b) => a.localeCompare(b))).toEqual([
+      'cat',
+      'dog',
+      'horse',
+      'other',
+    ]);
+  });
+
+  it('lists feline, canine and equine blood groups with an Unknown fallback', () => {
+    expect(BLOOD_GROUP_OPTIONS_BY_SPECIES.cat.map((option) => option.value)).toEqual([
+      'A',
+      'B',
+      'AB',
+      'Unknown',
+    ]);
+    expect(BLOOD_GROUP_OPTIONS_BY_SPECIES.dog).toHaveLength(14);
+    expect(BLOOD_GROUP_OPTIONS_BY_SPECIES.dog.map((option) => option.value)).toEqual(
+      expect.arrayContaining(['DEA 1.1 Positive', 'Universal Donor', 'Unknown'])
+    );
+    expect(BLOOD_GROUP_OPTIONS_BY_SPECIES.horse).toHaveLength(9);
+    expect(BLOOD_GROUP_OPTIONS_BY_SPECIES.other).toEqual([{ value: 'Unknown', label: 'Unknown' }]);
+  });
+
+  it('uses the blood group as both value and label for every option', () => {
+    for (const options of Object.values(BLOOD_GROUP_OPTIONS_BY_SPECIES)) {
+      for (const option of options) {
+        expect(option.label).toBe(option.value);
+      }
+    }
+  });
+});

--- a/apps/frontend/src/app/__tests__/features/companions/pages/Companions/types.test.ts
+++ b/apps/frontend/src/app/__tests__/features/companions/pages/Companions/types.test.ts
@@ -1,0 +1,97 @@
+import {
+  CompanionsSpeciesFilters,
+  CompanionsStatusFilters,
+  dropdownStatusFromToken,
+  filter,
+  status,
+  statusFromToken,
+} from '@/app/features/companions/pages/Companions/types';
+
+describe('Companions filter helpers', () => {
+  describe('filter', () => {
+    it('builds a name/key pair', () => {
+      expect(filter('All', 'all')).toEqual({ name: 'All', key: 'all' });
+    });
+  });
+
+  describe('status', () => {
+    it('applies the default text color and falls back border to bg', () => {
+      expect(status('Active', 'active', 'red')).toEqual({
+        name: 'Active',
+        key: 'active',
+        bg: 'red',
+        text: 'var(--color-neutral-0)',
+        border: 'red',
+        dropdownText: undefined,
+      });
+    });
+
+    it('keeps explicit text, border and dropdownText', () => {
+      expect(status('Paid', 'paid', 'bg', 'text', 'border', 'dropdown')).toEqual({
+        name: 'Paid',
+        key: 'paid',
+        bg: 'bg',
+        text: 'text',
+        border: 'border',
+        dropdownText: 'dropdown',
+      });
+    });
+  });
+
+  describe('statusFromToken', () => {
+    it('derives bg, text and border from one CSS custom-property prefix', () => {
+      expect(statusFromToken('Upcoming', 'upcoming', 'status-upcoming')).toEqual({
+        name: 'Upcoming',
+        key: 'upcoming',
+        bg: 'var(--status-upcoming-bg)',
+        text: 'var(--status-upcoming-text)',
+        border: 'var(--status-upcoming-border)',
+        dropdownText: undefined,
+      });
+    });
+  });
+
+  describe('dropdownStatusFromToken', () => {
+    it('adds the derived text token as dropdownText', () => {
+      expect(dropdownStatusFromToken('Paid', 'paid', 'color-pill-success')).toEqual({
+        name: 'Paid',
+        key: 'paid',
+        bg: 'var(--color-pill-success-bg)',
+        text: 'var(--color-pill-success-text)',
+        border: 'var(--color-pill-success-border)',
+        dropdownText: 'var(--color-pill-success-text)',
+      });
+    });
+  });
+
+  describe('CompanionsSpeciesFilters', () => {
+    it('lists the five species filters', () => {
+      expect(CompanionsSpeciesFilters).toEqual([
+        { name: 'All', key: 'all' },
+        { name: 'Canine', key: 'dog' },
+        { name: 'Equine', key: 'horse' },
+        { name: 'Feline', key: 'cat' },
+        { name: 'Other', key: 'other' },
+      ]);
+    });
+  });
+
+  describe('CompanionsStatusFilters', () => {
+    it('keeps the pill tokens for every companion status', () => {
+      expect(CompanionsStatusFilters.map((option) => option.key)).toEqual([
+        'all',
+        'active',
+        'inactive',
+        'archived',
+      ]);
+      expect(CompanionsStatusFilters[1]).toEqual({
+        name: 'Active',
+        key: 'active',
+        bg: 'var(--color-pill-success-bg)',
+        text: 'var(--color-pill-success-text)',
+        border: 'var(--color-pill-success-border)',
+        dropdownText: 'var(--color-pill-success-text)',
+      });
+    });
+  });
+});

--- a/apps/frontend/src/app/__tests__/features/finance/types/invoice.test.ts
+++ b/apps/frontend/src/app/__tests__/features/finance/types/invoice.test.ts
@@ -1,0 +1,75 @@
+import { InvoiceStatusFilters, InvoiceStatusOptions } from '@/app/features/finance/types/invoice';
+
+describe('invoice types', () => {
+  it('keeps the invoice status option list', () => {
+    expect(InvoiceStatusOptions).toEqual([
+      'PENDING',
+      'AWAITING_PAYMENT',
+      'PAID',
+      'FAILED',
+      'CANCELLED',
+      'REFUNDED',
+    ]);
+  });
+
+  it('keeps the exact status filter pills with their pill tokens and dropdown text', () => {
+    expect(InvoiceStatusFilters).toEqual([
+      {
+        name: 'All',
+        key: 'all',
+        bg: 'var(--color-pill-neutral-bg)',
+        text: 'var(--color-pill-neutral-text)',
+        border: 'var(--color-pill-neutral-border)',
+        dropdownText: 'var(--color-pill-neutral-text)',
+      },
+      {
+        name: 'Pending',
+        key: 'pending',
+        bg: 'var(--color-pill-neutral-bg)',
+        text: 'var(--color-pill-neutral-text)',
+        border: 'var(--color-pill-neutral-border)',
+        dropdownText: 'var(--color-pill-neutral-text)',
+      },
+      {
+        name: 'Awaiting payment',
+        key: 'awaiting_payment',
+        bg: 'var(--color-pill-info-bg)',
+        text: 'var(--color-pill-info-text)',
+        border: 'var(--color-pill-info-border)',
+        dropdownText: 'var(--color-pill-info-text)',
+      },
+      {
+        name: 'Paid',
+        key: 'paid',
+        bg: 'var(--color-pill-success-bg)',
+        text: 'var(--color-pill-success-text)',
+        border: 'var(--color-pill-success-border)',
+        dropdownText: 'var(--color-pill-success-text)',
+      },
+      {
+        name: 'Failed',
+        key: 'failed',
+        bg: 'var(--color-pill-warning-bg)',
+        text: 'var(--color-pill-warning-text)',
+        border: 'var(--color-pill-warning-border)',
+        dropdownText: 'var(--color-pill-warning-text)',
+      },
+      {
+        name: 'Cancelled',
+        key: 'cancelled',
+        bg: 'var(--color-pill-warning-bg)',
+        text: 'var(--color-pill-warning-text)',
+        border: 'var(--color-pill-warning-border)',
+        dropdownText: 'var(--color-pill-warning-text)',
+      },
+      {
+        name: 'Refunded',
+        key: 'refunded',
+        bg: 'var(--color-pill-progress-bg)',
+        text: 'var(--color-pill-progress-text)',
+        border: 'var(--color-pill-progress-border)',
+        dropdownText: 'var(--color-pill-progress-text)',
+      },
+    ]);
+  });
+});

--- a/apps/frontend/src/app/__tests__/lib/appointmentWorkspace.test.ts
+++ b/apps/frontend/src/app/__tests__/lib/appointmentWorkspace.test.ts
@@ -9,6 +9,7 @@ import {
   resolveEncounterMode,
   resolveLandingStep,
   richTextIsEmpty,
+  formatElapsed,
   formatStampTime,
   formatStampDate,
   resolveSectionLock,
@@ -16,6 +17,7 @@ import {
 import { setPreferredTimeZone } from '@/app/lib/timezone';
 import { buildEmptyEncounter } from '@/app/features/appointments/services/workspaceInitialData';
 import type { AppointmentEncounter } from '@/app/features/appointments/types/workspace';
+import type { AppointmentViewIntent } from '@/app/features/appointments/types/calendar';
 
 const base = (): AppointmentEncounter => buildEmptyEncounter('a1', 'OUTPATIENT');
 
@@ -41,6 +43,12 @@ describe('appointmentWorkspace lib', () => {
       'SUMMARY'
     );
     expect(resolveWorkspaceStepForIntent(null)).toBeUndefined();
+    expect(
+      resolveWorkspaceStepForIntent({
+        label: 'unmapped' as AppointmentViewIntent['label'],
+        subLabel: 'unmapped',
+      })
+    ).toBeUndefined();
   });
 
   describe('stamp formatters use the preferred time zone', () => {
@@ -171,6 +179,16 @@ describe('appointmentWorkspace lib', () => {
     expect(richTextIsEmpty('<p></p>')).toBe(true);
     expect(richTextIsEmpty('<p>&nbsp;</p>')).toBe(true);
     expect(richTextIsEmpty('<p>hello</p>')).toBe(false);
+  });
+
+  it('formats elapsed millisecond spans as HH:MM:SS', () => {
+    expect(formatElapsed(0)).toBe('00:00:00');
+    expect(formatElapsed(999)).toBe('00:00:00');
+    expect(formatElapsed(61_000)).toBe('00:01:01');
+    expect(formatElapsed(3_661_000)).toBe('01:01:01');
+    expect(formatElapsed(86_399_000)).toBe('23:59:59');
+    // Negative spans clamp to zero.
+    expect(formatElapsed(-5_000)).toBe('00:00:00');
   });
 
   describe('resolveSectionLock', () => {

--- a/apps/frontend/src/app/__tests__/lib/options.test.ts
+++ b/apps/frontend/src/app/__tests__/lib/options.test.ts
@@ -1,0 +1,47 @@
+import { makeOptions, type LabelValueOption } from '@/app/lib/options';
+
+describe('makeOptions', () => {
+  it('builds { label, value } objects from [label, value] pairs in order', () => {
+    expect(
+      makeOptions([
+        ['Health', 'HEALTH'],
+        ['Hygiene maintenance', 'HYGIENE_MAINTENANCE'],
+      ])
+    ).toEqual([
+      { label: 'Health', value: 'HEALTH' },
+      { label: 'Hygiene maintenance', value: 'HYGIENE_MAINTENANCE' },
+    ]);
+  });
+
+  it('returns an empty array for no pairs', () => {
+    expect(makeOptions([])).toEqual([]);
+  });
+
+  it('keeps duplicate values as distinct entries', () => {
+    const options = makeOptions([
+      ['First other', 'OTHER'],
+      ['Second other', 'OTHER'],
+    ]);
+    expect(options).toHaveLength(2);
+    expect(options[0]).toEqual({ label: 'First other', value: 'OTHER' });
+    expect(options[1]).toEqual({ label: 'Second other', value: 'OTHER' });
+  });
+
+  it('preserves narrowed value types', () => {
+    type Species = 'DOG' | 'CAT';
+    const options: LabelValueOption<Species>[] = makeOptions([
+      ['Dog', 'DOG'],
+      ['Cat', 'CAT'],
+    ]);
+    expect(options.map((option) => option.value)).toEqual(['DOG', 'CAT']);
+  });
+
+  it('returns a fresh array and fresh objects on each call', () => {
+    const pairs: ReadonlyArray<readonly [string, string]> = [['Other', 'OTHER']];
+    const first = makeOptions(pairs);
+    const second = makeOptions(pairs);
+    expect(first).not.toBe(second);
+    expect(first[0]).not.toBe(second[0]);
+    expect(first).toEqual(second);
+  });
+});

--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/DiagnosticsStep.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/DiagnosticsStep.test.tsx
@@ -506,6 +506,23 @@ describe('DiagnosticsStep (workspace, real IDEXX backend)', () => {
     expect(hook.openResultPdfPreview).toHaveBeenCalledWith('r1');
   });
 
+  it('opens a result PDF preview from the share action', () => {
+    const { hook } = renderStep();
+
+    fireEvent.click(screen.getByRole('button', { name: /share results pdf for result r1/i }));
+
+    expect(hook.openResultPdfPreview).toHaveBeenCalledWith('r1');
+  });
+
+  it('labels an IVLS device without a display name with the generic IVLS label', () => {
+    renderStep({
+      modality: 'INHOUSE',
+      devices: [{ deviceSerialNumber: '99887', displayName: '' }],
+    } as unknown as Partial<UseLabTestsReturn>);
+
+    expect(screen.getByText(/In-house IDEXX workflow/i)).toBeInTheDocument();
+  });
+
   it('toggles the result breakdown with the view action', () => {
     renderStep();
 

--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/SummaryStep.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/SummaryStep.test.tsx
@@ -611,6 +611,24 @@ describe('SummaryStep', () => {
     printSpy.mockRestore();
   });
 
+  it('reopens the saved summary from the edit pencil while the locked date field stays inert', () => {
+    const enc = { ...seedAndGet(), dischargeSavedAt: '2026-04-20T10:00:00Z' };
+    renderSummary(enc);
+
+    // The read-only Datepicker gets a noop setter — picking a date must not
+    // record a follow-up on the store.
+    const lockedField = screen
+      .getAllByRole('button', { name: /^Follow up date:/ })[0]
+      .closest<HTMLElement>('[aria-disabled="true"]')!;
+    fireEvent.click(within(lockedField).getByRole('button', { name: 'mock pick date' }));
+    expect(useAppointmentWorkspaceStore.getState().getEncounter(APPT)?.followUpAt).toBeUndefined();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit discharge summary' }));
+    expect(
+      useAppointmentWorkspaceStore.getState().getEncounter(APPT)?.dischargeSavedAt
+    ).toBeUndefined();
+  });
+
   it('dims the follow-up date once the summary is saved so it does not read as editable', () => {
     // The saved state locks the field (the Edit pencil reopens it). Without the
     // dimming it still renders as a live input, so the date looks broken rather

--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/VitalsForm.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/VitalsForm.test.tsx
@@ -343,6 +343,33 @@ describe('VitalsForm', () => {
     expect(await screen.findByText(/-5 lbs since/)).toBeInTheDocument();
   });
 
+  it('expands and collapses a recorded vitals entry and resolves the recorder from the roster', () => {
+    (useTeamForPrimaryOrg as jest.Mock).mockReturnValue([
+      { _id: 'member-1', practionerId: 'pract-1', name: 'Nurse Ann' },
+      { _id: 'member-2', name: '   ' },
+    ]);
+    const vitals = [
+      {
+        id: 'v1',
+        code: 'VIT-1',
+        recordedByName: 'Clinician',
+        recordedById: 'pract-1',
+        recordedAt: '2026-05-01T10:00:00Z',
+        weightLbs: 42,
+      },
+    ] as Vitals[];
+    render(<VitalsForm {...baseProps} vitals={vitals} />);
+
+    // The stored generic "Clinician" name resolves against the team roster.
+    expect(screen.getByText('Nurse Ann')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'View VIT-1' }));
+    expect(screen.getByText('Weight: 42 lbs')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide VIT-1' }));
+    expect(screen.queryByText('Weight: 42 lbs')).not.toBeInTheDocument();
+  });
+
   describe('vitalsFormDraftReducer', () => {
     it('returns the same state reference when RESET is dispatched on an already-empty state', () => {
       expect(vitalsFormDraftReducer(INITIAL_VITALS_FORM_DRAFT_STATE, { type: 'RESET' })).toBe(

--- a/apps/frontend/src/app/__tests__/pages/Appointments/Sections/AddAppointmentCentralModal/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Appointments/Sections/AddAppointmentCentralModal/index.test.tsx
@@ -792,6 +792,41 @@ describe('AddAppointmentCentralModal', () => {
     expect(handleSupportStaffChangeMock).toHaveBeenCalled();
   });
 
+  it('renders support staff values defensively when entries lack ids or the list is missing', () => {
+    mockAppointmentForm.formData = {
+      ...mockFormData,
+      supportStaff: [{}],
+    } as unknown as typeof mockFormData;
+    const { unmount } = render(<AddAppointmentCentralModal {...defaultProps} />);
+    expect(screen.getByTestId('multi-select-dropdown')).toBeInTheDocument();
+    unmount();
+
+    mockAppointmentForm.formData = {
+      ...mockFormData,
+      supportStaff: undefined,
+    } as unknown as typeof mockFormData;
+    render(<AddAppointmentCentralModal {...defaultProps} />);
+    expect(screen.getByTestId('multi-select-dropdown')).toBeInTheDocument();
+  });
+
+  it('clears the add-companion target when the fast-track modal jumps to the appointment', async () => {
+    render(<AddAppointmentCentralModal {...defaultProps} />);
+
+    const newButtons = screen.getAllByText('+ New');
+    await act(async () => {
+      fireEvent.click(newButtons[0]);
+    });
+
+    const addCompanionProps = addCompanionSpy.mock.calls[addCompanionSpy.mock.calls.length - 1][0];
+    expect(addCompanionProps.onGoToAppointment).toBeInstanceOf(Function);
+
+    await act(async () => {
+      addCompanionProps.onGoToAppointment();
+    });
+
+    expect(screen.queryByTestId('add-companion-modal')).not.toBeInTheDocument();
+  });
+
   it('excludes the selected lead from the support staff options', () => {
     mockAppointmentForm.formData = {
       ...mockFormData,

--- a/apps/frontend/src/app/__tests__/pages/Appointments/Sections/AppointmentInfo/LabTests.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Appointments/Sections/AppointmentInfo/LabTests.test.tsx
@@ -638,6 +638,35 @@ describe('LabTests', () => {
     }
   });
 
+  it('selects reference-order practitioners and falls back to the generic IVLS device label', async () => {
+    listIdexxIvlsDevicesMock.mockResolvedValue({
+      ivlsDeviceList: [{ deviceSerialNumber: 'ivls-3' }],
+    });
+    const staffedAppointment = {
+      ...appointment,
+      lead: { name: 'Dr Vet' },
+      supportStaff: [{ name: 'Tech Sam' }],
+    };
+    render(<LabTests activeAppointment={staffedAppointment} />);
+
+    await waitFor(() => {
+      expect(listIdexxTestsMock).toHaveBeenCalled();
+    });
+
+    // The mocked LabelDropdowns are selects — choosing options drives the
+    // veterinarian / technician onSelect handlers of the reference form.
+    fireEvent.change(screen.getByTestId('Veterinarian'), { target: { value: 'Dr Vet' } });
+    fireEvent.change(screen.getByTestId('Technician'), { target: { value: 'Tech Sam' } });
+    expect((screen.getByTestId('Veterinarian') as HTMLSelectElement).value).toBe('Dr Vet');
+    expect((screen.getByTestId('Technician') as HTMLSelectElement).value).toBe('Tech Sam');
+
+    // A device without a display name is labelled with the generic IVLS name.
+    fireEvent.change(screen.getByTestId('Modality'), { target: { value: 'INHOUSE' } });
+    await waitFor(() => {
+      expect(screen.getByText('IVLS (ivls-3)')).toBeInTheDocument();
+    });
+  });
+
   it('uses in-house flow for census only after selecting an IVLS device', async () => {
     render(<LabTests activeAppointment={appointment} />);
 

--- a/apps/frontend/src/app/__tests__/pages/Finance/Sections/InvoicePhoneRecord.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Finance/Sections/InvoicePhoneRecord.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import InvoicePhoneRecord from '@/app/features/finance/pages/Finance/Sections/InvoicePhoneRecord';
+import { formatDateLabel, formatTimeLabel } from '@/app/lib/forms';
 
 jest.mock('next/image', () => ({
   __esModule: true,
@@ -13,8 +14,8 @@ jest.mock('@/app/lib/money', () => ({
 }));
 
 jest.mock('@/app/lib/forms', () => ({
-  formatDateLabel: () => '12 Jun',
-  formatTimeLabel: () => '10:31',
+  formatDateLabel: jest.fn(() => '12 Jun'),
+  formatTimeLabel: jest.fn(() => '10:31'),
 }));
 
 jest.mock('@/app/lib/invoice', () => ({
@@ -79,6 +80,8 @@ const baseProps = {
 describe('InvoicePhoneRecord', () => {
   beforeEach(() => {
     getAppointmentCompanionMock.mockReturnValue({ species: 'dog', name: 'Poppy', parent: {} });
+    (formatDateLabel as jest.Mock).mockReturnValue('12 Jun');
+    (formatTimeLabel as jest.Mock).mockReturnValue('10:31');
   });
 
   it('renders the header with number, status and subtitle', () => {
@@ -209,6 +212,13 @@ describe('InvoicePhoneRecord', () => {
     render(<InvoicePhoneRecord {...baseProps} statusLabel="" />);
     expect(screen.getByRole('heading', { name: '#2038' })).toBeInTheDocument();
     expect(screen.queryByText('Paid')).not.toBeInTheDocument();
+  });
+
+  it('omits the timestamp from the ledger caption when no date or time is available', () => {
+    (formatDateLabel as jest.Mock).mockReturnValue('');
+    (formatTimeLabel as jest.Mock).mockReturnValue('');
+    render(<InvoicePhoneRecord {...baseProps} />);
+    expect(screen.getByText('Stripe · Lena Hartmann')).toBeInTheDocument();
   });
 
   it('builds the ledger caption without a payer name or method', () => {

--- a/apps/frontend/src/app/__tests__/pages/Finance/Sections/ledgerChannel.test.ts
+++ b/apps/frontend/src/app/__tests__/pages/Finance/Sections/ledgerChannel.test.ts
@@ -1,0 +1,43 @@
+import type { Invoice } from '@yosemite-crew/types';
+import { IoCardOutline, IoPhonePortraitOutline } from 'react-icons/io5';
+import { getLedgerChannel } from '@/app/features/finance/pages/Finance/Sections/ledgerChannel';
+
+const invoiceWith = (paymentCollectionMethod?: string): Invoice =>
+  ({ paymentCollectionMethod }) as unknown as Invoice;
+
+describe('getLedgerChannel', () => {
+  it('labels an app payment (PAYMENT_INTENT) with the phone glyph', () => {
+    expect(getLedgerChannel(invoiceWith('PAYMENT_INTENT'))).toEqual({
+      Icon: IoPhonePortraitOutline,
+      title: 'Paid in the pet-parent app',
+    });
+  });
+
+  it('labels a link payment (PAYMENT_LINK) with the phone glyph', () => {
+    expect(getLedgerChannel(invoiceWith('PAYMENT_LINK'))).toEqual({
+      Icon: IoPhonePortraitOutline,
+      title: 'Paid in the pet-parent app',
+    });
+  });
+
+  it('labels an at-the-desk payment (PAYMENT_AT_CLINIC) with the card glyph', () => {
+    expect(getLedgerChannel(invoiceWith('PAYMENT_AT_CLINIC'))).toEqual({
+      Icon: IoCardOutline,
+      title: 'Paid at the clinic',
+    });
+  });
+
+  it('falls back to a generic recorded label for an unknown method', () => {
+    expect(getLedgerChannel(invoiceWith('CASH_DRAWER'))).toEqual({
+      Icon: IoCardOutline,
+      title: 'Payment recorded',
+    });
+  });
+
+  it('falls back to a generic recorded label when no method is set', () => {
+    expect(getLedgerChannel(invoiceWith(undefined))).toEqual({
+      Icon: IoCardOutline,
+      title: 'Payment recorded',
+    });
+  });
+});

--- a/apps/frontend/src/app/__tests__/pages/Organization/Sections/ProfileCard.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Organization/Sections/ProfileCard.test.tsx
@@ -664,4 +664,55 @@ describe('Organization ProfileCard', () => {
 
     expect(screen.getByText('Full Name')).toBeInTheDocument();
   });
+
+  it('edits dropdown and country fields through their editors', async () => {
+    const onSave = jest.fn().mockResolvedValue(undefined);
+    render(
+      <ProfileCard
+        title="Prefs"
+        fields={[
+          {
+            label: 'Plan',
+            key: 'plan',
+            type: 'dropdown',
+            editable: true,
+            options: [{ label: 'Picked', value: 'picked' }],
+          },
+          { label: 'Country', key: 'country', type: 'country', editable: true },
+        ]}
+        org={{ plan: 'basic', country: 'US' }}
+        onSave={onSave}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Prefs' }));
+    fireEvent.click(screen.getByText('dropdown-Plan'));
+    fireEvent.click(screen.getByText('dropdown-Country'));
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() =>
+      expect(onSave).toHaveBeenCalledWith(
+        expect.objectContaining({ plan: 'picked', country: 'picked' })
+      )
+    );
+  });
+
+  it('shows a scalar multiSelect value populated by address autofill', () => {
+    render(
+      <ProfileCard
+        title="Address"
+        fields={[
+          { label: 'Address', key: 'address', type: 'googleAddress', editable: true },
+          { label: 'Cities', key: 'city', type: 'multiSelect', editable: false },
+        ]}
+        org={{ address: '', city: '' }}
+        onSave={jest.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Address' }));
+    // The non-editable multiSelect row renders the scalar value set via onMultiChange.
+    fireEvent.click(screen.getByText('addr-country-Address'));
+    expect(screen.getByText('City')).toBeInTheDocument();
+  });
 });

--- a/apps/frontend/src/app/__tests__/pages/Organization/Sections/Rooms/RoomInfoSections.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Organization/Sections/Rooms/RoomInfoSections.test.tsx
@@ -1,0 +1,272 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import RoomInfoSections from '@/app/features/organization/pages/Organization/Sections/Rooms/RoomInfoSections';
+import type { ManagedRoom } from '@/app/features/organization/pages/Organization/Sections/Rooms/RoomInfo.types';
+
+jest.mock('@/app/ui/inputs/FormInput/FormInput', () => ({
+  __esModule: true,
+  default: ({
+    inlabel,
+    value,
+    onChange,
+  }: {
+    inlabel: string;
+    value: string;
+    onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  }) => (
+    <label>
+      {inlabel}
+      <input aria-label={inlabel} value={value} onChange={onChange ?? (() => {})} />
+    </label>
+  ),
+}));
+
+jest.mock('@/app/ui/inputs/Dropdown/LabelDropdown', () => ({
+  __esModule: true,
+  default: ({
+    placeholder,
+    options = [],
+    onSelect,
+  }: {
+    placeholder: string;
+    options?: { label: string; value: string }[];
+    onSelect: (o: { label: string; value: string }) => void;
+  }) => (
+    <div>
+      {options.map((option) => (
+        <button
+          key={option.value}
+          type="button"
+          aria-label={`${placeholder} option ${option.value}`}
+          onClick={() => onSelect(option)}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+jest.mock('@/app/ui/inputs/MultiSelectDropdown', () => ({
+  __esModule: true,
+  default: ({
+    placeholder,
+    onChange,
+  }: {
+    placeholder: string;
+    onChange?: (value: string[]) => void;
+  }) => (
+    <button type="button" aria-label={placeholder} onClick={() => onChange?.(['PICKED'])}>
+      {placeholder}
+    </button>
+  ),
+}));
+
+jest.mock('@/app/ui/inputs/Timepicker', () => ({
+  __esModule: true,
+  default: ({
+    label,
+    value,
+    onChange,
+  }: {
+    label: string;
+    value: string;
+    onChange: (value: string) => void;
+  }) => (
+    <label>
+      {label}
+      <input aria-label={label} value={value} onChange={(e) => onChange(e.target.value)} />
+    </label>
+  ),
+}));
+
+const makeRoom = (overrides: Partial<ManagedRoom> = {}): ManagedRoom => ({
+  id: 'room-1',
+  name: 'ICU Room',
+  organisationId: 'org-1',
+  type: 'ICU',
+  code: 'R-001',
+  ...overrides,
+});
+
+describe('RoomInfoSections', () => {
+  const makeProps = (mode: 'view' | 'edit' = 'view') => ({
+    canEditRoom: true,
+    customEquipmentName: '',
+    equipmentLabel: 'Oxygen Tank',
+    formData: makeRoom(),
+    mode,
+    openSections: { details: true, availability: true, units: true, equipment: true },
+    roomTypeLabel: 'ICU',
+    specialityLabel: 'Surgery',
+    staffLabel: 'Dr. A',
+    supportsUnits: true,
+    totalUnits: 2,
+    availabilityLabels: { days: 'Mon - Fri', species: 'Dogs', time: '09:00 - 17:00' },
+    options: {
+      equipment: ['Custom Pump'],
+      specialities: [{ label: 'Surgery', value: 'spec-1' }],
+      team: [{ label: 'Dr. A', value: 'staff-1' }],
+    },
+    onAddCustomEquipment: jest.fn(),
+    onAddUnit: jest.fn(),
+    onAvailabilityToggle: jest.fn(),
+    onCustomEquipmentNameChange: jest.fn(),
+    onFormChange: jest.fn(),
+    onRoomTypeChange: jest.fn(),
+    onToggleSection: jest.fn(),
+    onUpdateAvailability: jest.fn(),
+    onUpdateUnit: jest.fn(),
+  });
+
+  it('renders view-mode details, availability, units, and equipment', () => {
+    const props = makeProps();
+    props.formData = makeRoom({
+      units: [{ id: 'u1', name: 'Kennel', size: 'Small', count: 2 }],
+    });
+    render(<RoomInfoSections {...props} />);
+
+    expect(screen.getByText('ICU Room')).toBeInTheDocument();
+    expect(screen.getByText('R-001')).toBeInTheDocument();
+    expect(screen.getByText('ICU')).toBeInTheDocument();
+    expect(screen.getAllByText('Surgery').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('Mon - Fri')).toBeInTheDocument();
+    expect(screen.getByText('Dr. A')).toBeInTheDocument();
+    expect(screen.getAllByText('Kennel').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('Small')).toBeInTheDocument();
+    expect(screen.getByText('Oxygen Tank')).toBeInTheDocument();
+    expect(screen.queryByText('No unit types configured.')).not.toBeInTheDocument();
+  });
+
+  it('falls back to dashes, the room id, and the empty-units message in view mode', () => {
+    const props = makeProps();
+    props.formData = makeRoom({ name: '', code: undefined, units: [] });
+    render(<RoomInfoSections {...props} />);
+
+    expect(screen.getByText('room-1')).toBeInTheDocument();
+    expect(screen.getAllByText('-').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('No unit types configured.')).toBeInTheDocument();
+  });
+
+  it('shows unit fallbacks and the unsupported-units message', () => {
+    const props = makeProps();
+    props.supportsUnits = false;
+    props.formData = makeRoom({ units: [{ id: 'u1', name: '', size: '', count: 0 }] });
+    render(<RoomInfoSections {...props} />);
+
+    expect(screen.getByText('Unit type')).toBeInTheDocument();
+    expect(
+      screen.getByText('Select ICU, Inpatient, Isolation, or Boarding to configure unit types.')
+    ).toBeInTheDocument();
+  });
+
+  it('toggles sections and availability from the headers', () => {
+    const props = makeProps();
+    render(<RoomInfoSections {...props} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Details' }));
+    expect(props.onToggleSection).toHaveBeenCalledWith('details');
+    fireEvent.click(screen.getByRole('button', { name: 'Availability' }));
+    expect(props.onToggleSection).toHaveBeenCalledWith('availability');
+    fireEvent.click(screen.getByRole('button', { name: 'Unit type (0)' }));
+    expect(props.onToggleSection).toHaveBeenCalledWith('units');
+    fireEvent.click(screen.getByRole('button', { name: 'Equipments / Capabilities' }));
+    expect(props.onToggleSection).toHaveBeenCalledWith('equipment');
+
+    fireEvent.click(screen.getByRole('switch', { name: 'Toggle room availability' }));
+    expect(props.onAvailabilityToggle).toHaveBeenCalledWith(false);
+  });
+
+  it('edits detail, availability, unit, and equipment fields in edit mode', () => {
+    const props = makeProps('edit');
+    props.formData = makeRoom({
+      availability: {
+        isAvailable: false,
+        days: 'MON_FRI',
+        startTime: '09:00',
+        endTime: '17:00',
+        species: 'DOG',
+        totalUnits: 3,
+      },
+      units: [{ id: 'u1', name: 'Kennel', size: 'Small', count: 2 }],
+      equipment: ['Oxygen Tank'],
+    });
+    render(<RoomInfoSections {...props} />);
+
+    // The Details section and the unit editor both render a "Name" input.
+    const nameInputs = screen.getAllByLabelText('Name');
+    fireEvent.change(nameInputs[0], { target: { value: 'New Room' } });
+    expect(props.onFormChange).toHaveBeenCalledWith({ name: 'New Room' });
+    fireEvent.change(screen.getByLabelText('Room code'), { target: { value: 'R-002' } });
+    expect(props.onFormChange).toHaveBeenCalledWith({ code: 'R-002' });
+    fireEvent.click(screen.getByRole('button', { name: 'Room Type option SURGERY' }));
+    expect(props.onRoomTypeChange).toHaveBeenCalledWith('SURGERY');
+    fireEvent.click(screen.getByRole('button', { name: 'Speciality (optional)' }));
+    expect(props.onFormChange).toHaveBeenCalledWith({ assignedSpecialiteis: ['PICKED'] });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Days option MON_FRI' }));
+    expect(props.onUpdateAvailability).toHaveBeenCalledWith({ days: 'MON_FRI' });
+    fireEvent.change(screen.getByLabelText('Start time'), { target: { value: '10:00' } });
+    expect(props.onUpdateAvailability).toHaveBeenCalledWith({ startTime: '10:00' });
+    fireEvent.change(screen.getByLabelText('End time'), { target: { value: '18:00' } });
+    expect(props.onUpdateAvailability).toHaveBeenCalledWith({ endTime: '18:00' });
+    fireEvent.click(screen.getByRole('button', { name: 'Species' }));
+    expect(props.onUpdateAvailability).toHaveBeenCalledWith({ species: ['PICKED'] });
+    fireEvent.change(screen.getByLabelText('Total Units'), { target: { value: '4' } });
+    expect(props.onUpdateAvailability).toHaveBeenCalledWith({ totalUnits: 4 });
+    fireEvent.change(screen.getByLabelText('Total Units'), { target: { value: 'abc' } });
+    expect(props.onUpdateAvailability).toHaveBeenCalledWith({ totalUnits: 0 });
+    fireEvent.click(screen.getByRole('button', { name: 'Assigned Staff (optional)' }));
+    expect(props.onFormChange).toHaveBeenCalledWith({ assignedStaffs: ['PICKED'] });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add unit type' }));
+    expect(props.onAddUnit).toHaveBeenCalledTimes(1);
+    fireEvent.change(nameInputs[1], { target: { value: 'Ward' } });
+    expect(props.onUpdateUnit).toHaveBeenCalledWith('u1', { name: 'Ward' });
+    fireEvent.click(screen.getByRole('button', { name: 'Size option Large' }));
+    expect(props.onUpdateUnit).toHaveBeenCalledWith('u1', { size: 'Large' });
+    fireEvent.change(screen.getByLabelText('Units'), { target: { value: '6' } });
+    expect(props.onUpdateUnit).toHaveBeenCalledWith('u1', { count: 6 });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Equipment' }));
+    expect(props.onFormChange).toHaveBeenCalledWith({ equipment: ['PICKED'] });
+    fireEvent.change(screen.getByLabelText('Add equipment name'), {
+      target: { value: 'Ventilator' },
+    });
+    expect(props.onCustomEquipmentNameChange).toHaveBeenCalledWith('Ventilator');
+    fireEvent.click(screen.getByRole('button', { name: 'Add custom equipment' }));
+    expect(props.onAddCustomEquipment).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to empty availability values in edit mode', () => {
+    const props = makeProps('edit');
+    props.formData = makeRoom({ code: undefined, availability: undefined, units: undefined });
+    render(<RoomInfoSections {...props} />);
+
+    expect(screen.getByLabelText('Room code')).toHaveValue('');
+    expect(screen.getByLabelText('Start time')).toHaveValue('');
+    expect(screen.getByLabelText('End time')).toHaveValue('');
+    expect(screen.getByLabelText('Total Units')).toHaveValue('0');
+    expect(screen.getByRole('switch', { name: 'Toggle room availability' })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
+    expect(screen.getByText('No unit types configured.')).toBeInTheDocument();
+  });
+
+  it('handles array species and hides the units input when units are unsupported', () => {
+    const props = makeProps('edit');
+    props.supportsUnits = false;
+    props.formData = makeRoom({
+      availability: { species: ['DOG', 'CAT'] },
+    });
+    render(<RoomInfoSections {...props} />);
+
+    expect(screen.queryByLabelText('Total Units')).not.toBeInTheDocument();
+    expect(
+      screen.getByText('Units are available for ICU, Inpatient, Isolation, and Boarding rooms.')
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Add unit type' })).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/__tests__/pages/Organization/Sections/Rooms/RoomUnitFieldsEditor.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Organization/Sections/Rooms/RoomUnitFieldsEditor.test.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import RoomUnitFieldsEditor from '@/app/features/organization/pages/Organization/Sections/Rooms/RoomUnitFieldsEditor';
+import { RoomUnitSizeOptions } from '@/app/features/organization/pages/Organization/types';
+
+jest.mock('@/app/ui/inputs/FormInput/FormInput', () => ({
+  __esModule: true,
+  default: ({
+    inlabel,
+    value,
+    onChange,
+  }: {
+    inlabel: string;
+    value: string;
+    onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  }) => (
+    <div>
+      <label htmlFor={`fi-${inlabel}`}>{inlabel}</label>
+      <input
+        id={`fi-${inlabel}`}
+        aria-label={inlabel}
+        type="text"
+        value={value}
+        onChange={onChange ?? (() => {})}
+      />
+    </div>
+  ),
+}));
+
+// LabelDropdown renders its option panel through a portal that never mounts in
+// jsdom, so it is mocked as a native select (frontend-testing skill gotcha).
+jest.mock('@/app/ui/inputs/Dropdown/LabelDropdown', () => ({
+  __esModule: true,
+  default: ({
+    placeholder,
+    options,
+    onSelect,
+  }: {
+    placeholder: string;
+    options: { value: string; label: string }[];
+    onSelect: (o: { value: string; label: string }) => void;
+  }) => (
+    <div>
+      <label htmlFor={`dd-${placeholder}`}>{placeholder}</label>
+      <select
+        id={`dd-${placeholder}`}
+        aria-label={placeholder}
+        onChange={(e) => {
+          const opt = options.find((o) => o.value === e.target.value);
+          if (opt) onSelect(opt);
+        }}
+      >
+        {options.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  ),
+}));
+
+describe('RoomUnitFieldsEditor', () => {
+  const unit = { id: 'unit-1', name: 'Kennel A', size: 'Small', count: 2 };
+  const onUpdateUnit = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the unit name, size options, and count', () => {
+    render(<RoomUnitFieldsEditor unit={unit} onUpdateUnit={onUpdateUnit} />);
+    expect(screen.getByLabelText('Name')).toHaveValue('Kennel A');
+    expect(screen.getByLabelText('Size')).toBeInTheDocument();
+    expect(screen.getByLabelText('Units')).toHaveValue('2');
+  });
+
+  it('patches the unit name on change', () => {
+    render(<RoomUnitFieldsEditor unit={unit} onUpdateUnit={onUpdateUnit} />);
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Ward B' } });
+    expect(onUpdateUnit).toHaveBeenCalledWith('unit-1', { name: 'Ward B' });
+  });
+
+  it('patches the unit size on select', () => {
+    render(<RoomUnitFieldsEditor unit={unit} onUpdateUnit={onUpdateUnit} />);
+    fireEvent.change(screen.getByLabelText('Size'), {
+      target: { value: RoomUnitSizeOptions[2].value },
+    });
+    expect(onUpdateUnit).toHaveBeenCalledWith('unit-1', { size: 'Large' });
+  });
+
+  it('patches the unit count with a valid number', () => {
+    render(<RoomUnitFieldsEditor unit={unit} onUpdateUnit={onUpdateUnit} />);
+    fireEvent.change(screen.getByLabelText('Units'), { target: { value: '5' } });
+    expect(onUpdateUnit).toHaveBeenCalledWith('unit-1', { count: 5 });
+  });
+
+  it('clamps a non-numeric count to 0', () => {
+    render(<RoomUnitFieldsEditor unit={unit} onUpdateUnit={onUpdateUnit} />);
+    fireEvent.change(screen.getByLabelText('Units'), { target: { value: 'abc' } });
+    expect(onUpdateUnit).toHaveBeenCalledWith('unit-1', { count: 0 });
+  });
+
+  it('clamps a negative count to 0', () => {
+    render(<RoomUnitFieldsEditor unit={unit} onUpdateUnit={onUpdateUnit} />);
+    fireEvent.change(screen.getByLabelText('Units'), { target: { value: '-3' } });
+    expect(onUpdateUnit).toHaveBeenCalledWith('unit-1', { count: 0 });
+  });
+});

--- a/apps/frontend/src/app/__tests__/pages/Specialities/NameDescriptionFields.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Specialities/NameDescriptionFields.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import NameDescriptionFields from '@/app/features/organization/pages/Specialities/NameDescriptionFields';
+
+describe('NameDescriptionFields', () => {
+  const defaultProps = {
+    name: 'Wellness Package',
+    onNameChange: jest.fn(),
+    descId: 'desc-1',
+    description: 'Annual wellness check',
+    onDescriptionChange: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the Name input with the provided value', () => {
+    render(<NameDescriptionFields {...defaultProps} />);
+    expect(screen.getByLabelText('Name')).toHaveValue('Wellness Package');
+  });
+
+  it('renders the Description textarea with the provided value and id', () => {
+    render(<NameDescriptionFields {...defaultProps} />);
+    const textarea = screen.getByLabelText('Description');
+    expect(textarea.tagName).toBe('TEXTAREA');
+    expect(textarea).toHaveValue('Annual wellness check');
+    expect(textarea).toHaveAttribute('id', 'desc-1');
+  });
+
+  it('calls onNameChange with the typed value', () => {
+    render(<NameDescriptionFields {...defaultProps} />);
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Premium Package' } });
+    expect(defaultProps.onNameChange).toHaveBeenCalledWith('Premium Package');
+  });
+
+  it('calls onDescriptionChange with the typed value', () => {
+    render(<NameDescriptionFields {...defaultProps} />);
+    fireEvent.change(screen.getByLabelText('Description'), {
+      target: { value: 'Updated description' },
+    });
+    expect(defaultProps.onDescriptionChange).toHaveBeenCalledWith('Updated description');
+  });
+
+  it('shows the name error when nameError is provided', () => {
+    render(<NameDescriptionFields {...defaultProps} nameError="Name is required." />);
+    expect(screen.getByRole('alert')).toHaveTextContent('Name is required.');
+  });
+
+  it('does not render an error when nameError is omitted', () => {
+    render(<NameDescriptionFields {...defaultProps} />);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('omits the rows attribute by default', () => {
+    render(<NameDescriptionFields {...defaultProps} />);
+    expect(screen.getByLabelText('Description')).not.toHaveAttribute('rows');
+  });
+
+  it('applies textareaRows to the textarea when provided', () => {
+    render(<NameDescriptionFields {...defaultProps} textareaRows={3} />);
+    expect(screen.getByLabelText('Description')).toHaveAttribute('rows', '3');
+  });
+});

--- a/apps/frontend/src/app/__tests__/pages/Specialities/PackageTopFields.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Specialities/PackageTopFields.test.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import PackageTopFields from '@/app/features/organization/pages/Specialities/PackageTopFields';
+
+jest.mock('@/app/ui/inputs/Dropdown/LabelDropdown', () => ({
+  __esModule: true,
+  default: ({
+    placeholder,
+    onSelect,
+  }: {
+    placeholder: string;
+    onSelect: (o: { value: string }) => void;
+  }) => (
+    <button type="button" onClick={() => onSelect({ value: `picked-${placeholder}` })}>
+      {`dropdown-${placeholder}`}
+    </button>
+  ),
+}));
+
+describe('PackageTopFields', () => {
+  const defaultProps = {
+    name: 'Package A',
+    onNameChange: jest.fn(),
+    nameError: undefined,
+    description: 'Package description',
+    onDescriptionChange: jest.fn(),
+    descId: 'pkg-desc',
+    durationText: '60 mins',
+    onDurationTextChange: jest.fn(),
+    durationTextError: undefined,
+    leadCount: '1',
+    onLeadCountSelect: jest.fn(),
+    supportCount: '2',
+    onSupportCountSelect: jest.fn(),
+    effectiveBookable: true,
+    requiredBookable: false,
+    onIsBookableChange: jest.fn(),
+    effectiveInpatientPreferred: false,
+    requiredInpatient: false,
+    onIsInpatientPreferredChange: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders name, description, and duration values', () => {
+    render(<PackageTopFields {...defaultProps} />);
+    expect(screen.getByLabelText('Name')).toHaveValue('Package A');
+    expect(screen.getByLabelText('Description')).toHaveValue('Package description');
+    expect(screen.getByLabelText('Approx. duration')).toHaveValue('60 mins');
+  });
+
+  it('propagates name and description changes', () => {
+    render(<PackageTopFields {...defaultProps} />);
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Package B' } });
+    expect(defaultProps.onNameChange).toHaveBeenCalledWith('Package B');
+    fireEvent.change(screen.getByLabelText('Description'), { target: { value: 'New desc' } });
+    expect(defaultProps.onDescriptionChange).toHaveBeenCalledWith('New desc');
+  });
+
+  it('propagates duration text changes', () => {
+    render(<PackageTopFields {...defaultProps} />);
+    fireEvent.change(screen.getByLabelText('Approx. duration'), { target: { value: '90 mins' } });
+    expect(defaultProps.onDurationTextChange).toHaveBeenCalledWith('90 mins');
+  });
+
+  it('selects lead and support counts', () => {
+    render(<PackageTopFields {...defaultProps} />);
+    fireEvent.click(screen.getByText('dropdown-Lead'));
+    expect(defaultProps.onLeadCountSelect).toHaveBeenCalledWith('picked-Lead');
+    fireEvent.click(screen.getByText('dropdown-Support'));
+    expect(defaultProps.onSupportCountSelect).toHaveBeenCalledWith('picked-Support');
+  });
+
+  it('toggles the bookable checkbox', () => {
+    render(<PackageTopFields {...defaultProps} />);
+    const checkbox = screen.getByLabelText('Package bookable');
+    expect(checkbox).toBeChecked();
+    fireEvent.click(checkbox);
+    expect(defaultProps.onIsBookableChange).toHaveBeenCalledWith(false);
+  });
+
+  it('toggles the in-patient checkbox', () => {
+    render(<PackageTopFields {...defaultProps} />);
+    const checkbox = screen.getByLabelText('Package in-patient');
+    expect(checkbox).not.toBeChecked();
+    fireEvent.click(checkbox);
+    expect(defaultProps.onIsInpatientPreferredChange).toHaveBeenCalledWith(true);
+  });
+
+  it('disables the checkboxes when they are required by the breakdown', () => {
+    render(<PackageTopFields {...defaultProps} requiredBookable requiredInpatient />);
+    expect(screen.getByLabelText('Package bookable')).toBeDisabled();
+    expect(screen.getByLabelText('Package in-patient')).toBeDisabled();
+  });
+
+  it('shows name and duration errors', () => {
+    render(
+      <PackageTopFields
+        {...defaultProps}
+        nameError="Name is required."
+        durationTextError="Enter a duration."
+      />
+    );
+    expect(screen.getByText('Name is required.')).toBeInTheDocument();
+    expect(screen.getByText('Enter a duration.')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/__tests__/pages/Specialities/PackagesTab.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Specialities/PackagesTab.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import PackagesTab from '@/app/features/organization/pages/Specialities/PackagesTab';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import PackagesTab, {
+  type PackagesTabHandle,
+} from '@/app/features/organization/pages/Specialities/PackagesTab';
 import { useRevampCatalogStore } from '@/app/stores/revampCatalogStore';
 import { useNotify } from '@/app/hooks/useNotify';
 
@@ -44,8 +46,15 @@ jest.mock('@/app/features/organization/pages/Specialities/PackageBreakdownTable'
 
 jest.mock('@/app/ui/overlays/Modal/CenterModal', () => ({
   __esModule: true,
-  default: ({ showModal, children }: any) =>
-    showModal ? <div data-testid="center-modal">{children}</div> : null,
+  default: ({ showModal, setShowModal, children }: any) =>
+    showModal ? (
+      <div data-testid="center-modal">
+        <button type="button" onClick={() => setShowModal(false)}>
+          Backdrop Close
+        </button>
+        {children}
+      </div>
+    ) : null,
 }));
 
 jest.mock('@/app/ui/overlays/Modal/ModalHeader', () => ({
@@ -372,5 +381,61 @@ describe('PackagesTab', () => {
     // Modal close button (from ModalHeader mock)
     fireEvent.click(screen.getByRole('button', { name: 'Modal Close' }));
     expect(screen.queryByTestId('center-modal')).not.toBeInTheDocument();
+  });
+
+  it('closes the archive modal via the modal backdrop', () => {
+    render(<PackagesTab specialityId="spec-1" organisationId="org-1" />);
+    fireEvent.click(screen.getAllByRole('button', { name: /Archive Wellness Package/i })[0]);
+    fireEvent.click(screen.getByText('Backdrop Close'));
+    expect(screen.queryByTestId('center-modal')).not.toBeInTheDocument();
+    expect(mockArchivePackage).not.toHaveBeenCalled();
+  });
+
+  it('notifies an error and keeps the modal open when archiving fails', async () => {
+    mockArchivePackage.mockRejectedValueOnce(new Error('archive failed'));
+    render(<PackagesTab specialityId="spec-1" organisationId="org-1" />);
+    fireEvent.click(screen.getAllByRole('button', { name: /Archive Wellness Package/i })[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Archive' }));
+    await waitFor(() =>
+      expect(mockNotify).toHaveBeenCalledWith(
+        'error',
+        expect.objectContaining({ title: 'Unable to archive package' })
+      )
+    );
+    expect(screen.getByTestId('center-modal')).toBeInTheDocument();
+  });
+
+  // --- Section 5: Imperative handle + card variants ---
+
+  it('opens the add draft at the top via the openAdd handle', () => {
+    const ref = React.createRef<PackagesTabHandle>();
+    render(<PackagesTab specialityId="spec-1" organisationId="org-1" ref={ref} />);
+    act(() => {
+      ref.current?.openAdd();
+    });
+    expect(screen.getByTestId('add-draft')).toBeInTheDocument();
+    expect(screen.queryByText('Click to add package')).not.toBeInTheDocument();
+  });
+
+  it('does not hydrate when editing a package that already has a breakdown', () => {
+    render(<PackagesTab specialityId="spec-1" organisationId="org-1" />);
+    fireEvent.click(screen.getAllByRole('button', { name: /Edit Premium Package/i })[0]);
+    expect(screen.getByTestId('edit-draft-pkg-2')).toBeInTheDocument();
+    expect(mockHydratePackageDetail).not.toHaveBeenCalled();
+  });
+
+  it('renders an em dash when a package has no description', () => {
+    (useRevampCatalogStore as unknown as jest.Mock).mockImplementation((selector: any) =>
+      selector({
+        packages: [{ ...mockPackage, description: '' }],
+        archivePackage: mockArchivePackage,
+        hydratePackageDetail: mockHydratePackageDetail,
+        loadSpecialityCatalog: mockLoadSpecialityCatalog,
+        loadedSpecialityIds: ['spec-1:active'],
+      })
+    );
+    render(<PackagesTab specialityId="spec-1" organisationId="org-1" />);
+    // Both the narrow and the wide layout render the em-dash fallback.
+    expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(2);
   });
 });

--- a/apps/frontend/src/app/__tests__/pages/Specialities/ServiceFormDraft.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Specialities/ServiceFormDraft.test.tsx
@@ -455,4 +455,65 @@ describe('ServiceFormDraft', () => {
       expect(totalInput).toHaveValue('');
     });
   });
+
+  describe('failure branches and remaining interactions', () => {
+    it('notifies an error and stays open when saving fails', async () => {
+      mockAddService.mockRejectedValueOnce(new Error('save failed'));
+      render(<ServiceFormDraft {...defaultProps} />);
+      fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Svc' } });
+      fireEvent.change(screen.getByLabelText('Gross amt.'), { target: { value: '100' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Save Service' }));
+      await waitFor(() =>
+        expect(mockNotify).toHaveBeenCalledWith(
+          'error',
+          expect.objectContaining({ title: 'Unable to save service' })
+        )
+      );
+      expect(defaultProps.onClose).not.toHaveBeenCalled();
+    });
+
+    it('notifies an error and stays open when deleting fails', async () => {
+      mockDeleteService.mockRejectedValueOnce(new Error('delete failed'));
+      render(<ServiceFormDraft {...defaultProps} editService={mockEditService} />);
+      fireEvent.click(screen.getByText('Delete Service'));
+      fireEvent.click(screen.getByText('Delete'));
+      await waitFor(() =>
+        expect(mockNotify).toHaveBeenCalledWith(
+          'error',
+          expect.objectContaining({ title: 'Unable to delete service' })
+        )
+      );
+      expect(defaultProps.onClose).not.toHaveBeenCalled();
+    });
+
+    it('closes the delete confirmation without deleting when its Cancel is clicked', () => {
+      render(<ServiceFormDraft {...defaultProps} editService={mockEditService} />);
+      fireEvent.click(screen.getByText('Delete Service'));
+      const cancelButtons = screen.getAllByRole('button', { name: 'Cancel' });
+      fireEvent.click(cancelButtons.at(-1) as HTMLElement);
+      expect(mockDeleteService).not.toHaveBeenCalled();
+      expect(defaultProps.onClose).not.toHaveBeenCalled();
+      expect(screen.getAllByRole('button', { name: 'Cancel' })).toHaveLength(1);
+    });
+
+    it('changes duration via the dropdown and saves it', () => {
+      render(<ServiceFormDraft {...defaultProps} />);
+      fireEvent.change(screen.getByLabelText('Duration'), { target: { value: '60' } });
+      fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Svc' } });
+      fireEvent.change(screen.getByLabelText('Gross amt.'), { target: { value: '100' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Save Service' }));
+      expect(mockAddService).toHaveBeenCalledWith(expect.objectContaining({ durationMinutes: 60 }));
+    });
+
+    it('defaults cleared discounts to 0 when updating an existing service', () => {
+      render(<ServiceFormDraft {...defaultProps} editService={mockEditService} />);
+      fireEvent.change(screen.getByLabelText('Default Discount (%)'), { target: { value: '' } });
+      fireEvent.change(screen.getByLabelText('Max. Discount (%)'), { target: { value: '' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Save Service' }));
+      expect(mockUpdateService).toHaveBeenCalledWith(
+        'svc-edit-1',
+        expect.objectContaining({ defaultDiscount: 0, maxDiscount: 0 })
+      );
+    });
+  });
 });

--- a/apps/frontend/src/app/__tests__/pages/legal/trustCenterData.test.ts
+++ b/apps/frontend/src/app/__tests__/pages/legal/trustCenterData.test.ts
@@ -36,6 +36,75 @@ describe('trustCenterData', () => {
     expect(trustCenterData.approachBadges[0].src).toBe(CERT_BADGES.gdpr);
   });
 
+  it('keeps every certification field exactly as published', () => {
+    expect(trustCenterData.certifications).toEqual([
+      {
+        name: 'GDPR',
+        status: 'COMPLIANT',
+        description: 'Fully compliant data processing with EU hosting.',
+        badge: CERT_BADGES.gdpr,
+      },
+      {
+        name: 'SOC 2 Type I',
+        status: 'COMPLIANT',
+        description: 'Audited security, availability and confidentiality controls.',
+        badge: CERT_BADGES.soc2,
+      },
+      {
+        name: 'ISO 27001:2022',
+        status: 'COMPLIANT',
+        description: 'Certified information-security management.',
+        badge: CERT_BADGES.iso,
+      },
+      {
+        name: '21 CFR Part 11',
+        status: 'COMPLIANT',
+        description: 'FDA rules for electronic records and signatures.',
+        badge: CERT_BADGES.fda,
+      },
+      {
+        name: 'ESIGN Act',
+        status: 'COMPLIANT',
+        description: 'US federal law on the validity of e-signatures.',
+        icon: 'create-outline',
+        iconBg: '#e6f2ff',
+        iconColor: '#257bed',
+      },
+      {
+        name: 'UETA',
+        status: 'COMPLIANT',
+        description: 'US state law for electronic transactions.',
+        icon: 'swap-horizontal-outline',
+        iconBg: '#f5f3ff',
+        iconColor: '#5b21b6',
+      },
+      {
+        name: 'eIDAS (SES)',
+        status: 'COMPLIANT',
+        description: 'EU electronic identification, Level 1.',
+        icon: 'finger-print-outline',
+        iconBg: '#e6f4ef',
+        iconColor: '#006642',
+      },
+      {
+        name: 'ZertES',
+        status: 'PLANNED',
+        description: 'Swiss federal law on electronic signatures.',
+        icon: 'ribbon-outline',
+        iconBg: '#fef3e9',
+        iconColor: '#af5e19',
+      },
+      {
+        name: 'HIPAA',
+        status: 'PLANNED',
+        description: 'US protection for patient health information.',
+        icon: 'medkit-outline',
+        iconBg: '#e6f2ff',
+        iconColor: '#257bed',
+      },
+    ]);
+  });
+
   it('contains nine certifications with correct statuses', () => {
     expect(trustCenterData.certifications).toHaveLength(9);
 

--- a/apps/frontend/src/app/__tests__/services/templateFormsService.test.ts
+++ b/apps/frontend/src/app/__tests__/services/templateFormsService.test.ts
@@ -336,6 +336,154 @@ describe('templateFormsService', () => {
     expect(upsertForm).toHaveBeenCalledWith(expect.objectContaining({ _id: 'tpl-1' }));
   });
 
+  it('surfaces the API error message when saving fails with an axios error', async () => {
+    (postData as jest.Mock).mockRejectedValue({
+      isAxiosError: true,
+      message: 'Request failed',
+      response: { data: { message: 'Name already in use' } },
+    });
+
+    await expect(
+      saveTemplateFormDraft(
+        {
+          name: 'SOAP',
+          category: 'SOAP',
+          usage: 'Internal',
+          updatedBy: '',
+          lastUpdated: '',
+          schema: [],
+        },
+        'org-1'
+      )
+    ).rejects.toMatchObject({ message: 'Request failed' });
+
+    expect(setError).toHaveBeenCalledWith('Name already in use');
+    expect(upsertForm).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the axios error message when the response has no message', async () => {
+    (postData as jest.Mock).mockRejectedValue({
+      isAxiosError: true,
+      message: 'Network down',
+    });
+
+    await expect(
+      saveTemplateFormDraft(
+        {
+          name: 'SOAP',
+          category: 'SOAP',
+          usage: 'Internal',
+          updatedBy: '',
+          lastUpdated: '',
+          schema: [],
+        },
+        'org-1'
+      )
+    ).rejects.toMatchObject({ message: 'Network down' });
+
+    expect(setError).toHaveBeenCalledWith('Network down');
+  });
+
+  it('uses the generic save message for non-axios errors', async () => {
+    (postData as jest.Mock).mockRejectedValue(new Error('boom'));
+
+    await expect(
+      saveTemplateFormDraft(
+        {
+          name: 'SOAP',
+          category: 'SOAP',
+          usage: 'Internal',
+          updatedBy: '',
+          lastUpdated: '',
+          schema: [],
+        },
+        'org-1'
+      )
+    ).rejects.toThrow('boom');
+
+    expect(setError).toHaveBeenCalledWith('Unable to save template');
+  });
+
+  it('keeps the saved draft when the catalog link sync fails', async () => {
+    (postData as jest.Mock).mockResolvedValue({ data: { id: 'tpl-new', name: 'SOAP' } });
+    (patchData as jest.Mock).mockRejectedValue(new Error('link failed'));
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const result = await saveTemplateFormDraft(
+      {
+        name: 'SOAP',
+        category: 'SOAP',
+        usage: 'Internal',
+        updatedBy: '',
+        lastUpdated: '',
+        schema: [],
+        services: ['svc-1'],
+      },
+      'org-1'
+    );
+
+    // The template itself saved; the link failure is logged but the draft is not lost.
+    expect(result).toEqual(expect.objectContaining({ _id: 'tpl-new' }));
+    expect(setError).toHaveBeenCalledWith('Unable to update template catalog links');
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Failed to sync template catalog links',
+      expect.any(Error)
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it('rejects catalog-link updates, publish, unpublish, and archive without a template id', async () => {
+    const form: FormsProps = {
+      name: 'SOAP',
+      category: 'SOAP',
+      usage: 'Internal',
+      updatedBy: '',
+      lastUpdated: '',
+      schema: [],
+    };
+
+    await expect(updateTemplateFormCatalogLinks(form, 'org-1', ['svc-1'])).rejects.toThrow(
+      'Template id is required to update catalog links'
+    );
+    await expect(publishTemplateForm(form, 'org-1')).rejects.toThrow(
+      'Template id is required to publish template'
+    );
+    await expect(unpublishTemplateForm(form, 'org-1')).rejects.toThrow(
+      'Template id is required to unpublish template'
+    );
+    await expect(archiveTemplateForm(form, 'org-1')).rejects.toThrow(
+      'Template id is required to archive template'
+    );
+    expect(patchData).not.toHaveBeenCalled();
+    expect(postData).not.toHaveBeenCalled();
+    expect(deleteData).not.toHaveBeenCalled();
+  });
+
+  it('sets a fallback error and rethrows when publish, unpublish, or archive fails', async () => {
+    (postData as jest.Mock).mockRejectedValue(new Error('publish down'));
+    (patchData as jest.Mock).mockRejectedValue(new Error('unpublish down'));
+    (deleteData as jest.Mock).mockRejectedValue(new Error('archive down'));
+    const form: FormsProps = {
+      _id: 'tpl-1',
+      templateId: 'tpl-1',
+      name: 'SOAP',
+      category: 'SOAP',
+      usage: 'Internal',
+      updatedBy: '',
+      lastUpdated: '',
+      schema: [],
+      isTemplateBacked: true,
+    };
+
+    await expect(publishTemplateForm(form, 'org-1')).rejects.toThrow('publish down');
+    await expect(unpublishTemplateForm(form, 'org-1')).rejects.toThrow('unpublish down');
+    await expect(archiveTemplateForm(form, 'org-1')).rejects.toThrow('archive down');
+
+    expect(setError).toHaveBeenCalledWith('Unable to publish template');
+    expect(setError).toHaveBeenCalledWith('Unable to unpublish template');
+    expect(setError).toHaveBeenCalledWith('Unable to archive template');
+  });
+
   it('publishes, unpublishes, and archives template-backed forms', async () => {
     (postData as jest.Mock).mockResolvedValue({ data: { id: 'tpl-1', name: 'Template' } });
     (patchData as jest.Mock).mockResolvedValue({ data: { id: 'tpl-1', name: 'Template' } });

--- a/apps/frontend/src/app/__tests__/services/templateListShared.test.ts
+++ b/apps/frontend/src/app/__tests__/services/templateListShared.test.ts
@@ -1,0 +1,71 @@
+import type { TemplateLike } from '@yosemite-crew/types';
+import { dedupeTemplates, listTemplates } from '@/app/features/forms/services/templateListShared';
+import { getData } from '@/app/services/axios';
+
+jest.mock('@/app/services/axios', () => ({
+  getData: jest.fn(),
+}));
+
+const template = (id: string, name = id) => ({ id, name }) as unknown as TemplateLike;
+
+describe('templateListShared', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('listTemplates', () => {
+    it('fetches the url with the given params and returns the array response', async () => {
+      (getData as jest.Mock).mockResolvedValue({ data: [template('tpl-1')] });
+
+      const result = await listTemplates('/v1/templates/pms/templates/library', {
+        kind: 'SOAP_NOTE',
+        status: 'PUBLISHED',
+      });
+
+      expect(getData).toHaveBeenCalledWith('/v1/templates/pms/templates/library', {
+        kind: 'SOAP_NOTE',
+        status: 'PUBLISHED',
+      });
+      expect(result).toEqual([expect.objectContaining({ id: 'tpl-1' })]);
+    });
+
+    it('defaults params to an empty object', async () => {
+      (getData as jest.Mock).mockResolvedValue({ data: [] });
+
+      await listTemplates('/v1/templates/pms/templates/library');
+
+      expect(getData).toHaveBeenCalledWith('/v1/templates/pms/templates/library', {});
+    });
+
+    it('returns an empty list for non-array responses', async () => {
+      (getData as jest.Mock).mockResolvedValue({ data: { id: 'not-a-list' } });
+
+      await expect(listTemplates('/v1/templates/pms/templates/library')).resolves.toEqual([]);
+    });
+  });
+
+  describe('dedupeTemplates', () => {
+    it('dedupes by id with later entries winning while keeping first-seen order', () => {
+      const result = dedupeTemplates([
+        template('tpl-1', 'Library version'),
+        template('tpl-2'),
+        template('tpl-1', 'Org version'),
+      ]);
+
+      expect(result).toEqual([
+        expect.objectContaining({ id: 'tpl-1', name: 'Org version' }),
+        expect.objectContaining({ id: 'tpl-2' }),
+      ]);
+    });
+
+    it('drops entries without an id', () => {
+      const result = dedupeTemplates([
+        template(''),
+        undefined as unknown as TemplateLike,
+        template('tpl-1'),
+      ]);
+
+      expect(result).toEqual([expect.objectContaining({ id: 'tpl-1' })]);
+    });
+  });
+});

--- a/apps/frontend/src/app/__tests__/services/workspaceTemplateService.test.ts
+++ b/apps/frontend/src/app/__tests__/services/workspaceTemplateService.test.ts
@@ -496,6 +496,31 @@ describe('workspaceTemplateService', () => {
     ]);
   });
 
+  it('resolves no staged rows when the schedule template defines no task blocks', async () => {
+    getDataMock.mockResolvedValueOnce({
+      data: {
+        ...template('tpl-schedule-2', 'Empty pathway'),
+        kind: 'TASK_ASSIGNMENT',
+        versions: [
+          {
+            version: 1,
+            schemaSnapshot: {
+              sections: [
+                {
+                  id: 'other',
+                  title: 'Other',
+                  fields: [{ key: 'notes', type: 'text', label: 'Notes' }],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    await expect(resolveScheduleTasksFromTemplate('org-1', 'tpl-schedule-2')).resolves.toEqual([]);
+  });
+
   it('updates catalog links for a workspace template', async () => {
     patchDataMock.mockResolvedValueOnce({
       data: { ...template('tpl-1'), catalogItemIds: ['svc-2'] },
@@ -674,6 +699,20 @@ describe('workspaceTemplateService', () => {
     it('rejects a non-finite follow-up offset', () => {
       expect(extractFollowUpInDays(withFollowUp(Infinity) as never)).toBeUndefined();
     });
+
+    it('returns undefined when no field is keyed followUpInDays', () => {
+      expect(
+        extractFollowUpInDays({
+          sections: [
+            {
+              id: 'summary',
+              title: 'Summary',
+              fields: [{ key: 'notes', label: 'Notes', type: 'text' }],
+            },
+          ],
+        } as never)
+      ).toBeUndefined();
+    });
   });
 
   describe('schemaSnapshotToPrescriptionItems', () => {
@@ -732,6 +771,48 @@ describe('workspaceTemplateService', () => {
       };
       expect(schemaSnapshotToPrescriptionItems(snapshot as never)).toEqual([]);
       expect(schemaSnapshotToPrescriptionItems(undefined)).toEqual([]);
+    });
+
+    it('walks nested group fields and normalises boolean-like row strings', () => {
+      const snapshot = {
+        sections: [
+          {
+            id: 'rx',
+            title: 'Prescription',
+            fields: [
+              {
+                key: 'group_1',
+                label: 'Medication group',
+                type: 'group',
+                fields: [
+                  {
+                    key: 'medicationLine',
+                    label: 'Medication lines',
+                    type: 'medicationLine',
+                    defaultValue: [
+                      {
+                        inventoryItemId: 'inv-9',
+                        medicineName: 'Carprofen',
+                        controlledSubstance: 'no',
+                        prescriptionRequired: 'maybe',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      expect(schemaSnapshotToPrescriptionItems(snapshot as never)).toEqual([
+        expect.objectContaining({
+          inventoryItemId: 'inv-9',
+          medicineName: 'Carprofen',
+          controlledSubstance: false,
+          prescriptionRequired: undefined,
+        }),
+      ]);
     });
   });
 
@@ -841,6 +922,17 @@ describe('workspaceTemplateService', () => {
 
       getDataMock.mockRejectedValueOnce(new Error('nope'));
       await expect(resolvePrescriptionTemplate(context)).resolves.toEqual([]);
+    });
+
+    it('sends only the organisation and kind when the context has no optional fields', async () => {
+      getDataMock.mockResolvedValueOnce({ data: undefined });
+
+      await expect(resolvePrescriptionTemplate({ organisationId: 'org-1' })).resolves.toEqual([]);
+
+      expect(getDataMock).toHaveBeenCalledWith('/v1/templates/pms/resolve', {
+        organisationId: 'org-1',
+        kind: 'PRESCRIPTION',
+      });
     });
   });
 });

--- a/apps/frontend/src/app/__tests__/stores/appointmentStore.test.ts
+++ b/apps/frontend/src/app/__tests__/stores/appointmentStore.test.ts
@@ -243,5 +243,32 @@ describe('Appointment Store', () => {
       expect(state.status).toBe('idle');
       expect(state.lastFetchedAt).toBeNull();
     });
+
+    it('setAppointmentsForOrg replaces existing org entries and seeds a fresh org', () => {
+      useAppointmentStore.getState().setAppointments([mockAppt1]);
+
+      useAppointmentStore.getState().setAppointmentsForOrg('org-A', [mockAppt2]);
+      let state = useAppointmentStore.getState();
+      expect(state.appointmentIdsByOrgId['org-A']).toEqual(['appt-2']);
+      expect(state.appointmentsById['appt-1']).toBeUndefined();
+
+      useAppointmentStore.getState().setAppointmentsForOrg('org-B', [mockAppt3]);
+      state = useAppointmentStore.getState();
+      expect(state.appointmentIdsByOrgId['org-B']).toEqual(['appt-3']);
+      expect(state.appointmentIdsByOrgId['org-A']).toEqual(['appt-2']);
+    });
+
+    it('removeAppointment tolerates an appointment whose org index is missing', () => {
+      useAppointmentStore.setState({
+        appointmentsById: { 'appt-1': mockAppt1 },
+        appointmentIdsByOrgId: {},
+      });
+
+      useAppointmentStore.getState().removeAppointment('appt-1');
+
+      const state = useAppointmentStore.getState();
+      expect(state.appointmentsById['appt-1']).toBeUndefined();
+      expect(state.appointmentIdsByOrgId['org-A']).toEqual([]);
+    });
   });
 });

--- a/apps/frontend/src/app/__tests__/stores/integrationStore.test.ts
+++ b/apps/frontend/src/app/__tests__/stores/integrationStore.test.ts
@@ -1,4 +1,5 @@
 import { useIntegrationStore } from '@/app/stores/integrationStore';
+import type { OrgIntegration } from '@/app/features/integrations/services/types';
 
 describe('integrationStore', () => {
   beforeEach(() => {
@@ -113,5 +114,50 @@ describe('integrationStore', () => {
     store.endLoading();
     expect(useIntegrationStore.getState().status).toBe('loaded');
     expect(useIntegrationStore.getState().error).toBeNull();
+  });
+
+  it('skips integrations without any id when setting for an org', () => {
+    const store = useIntegrationStore.getState();
+    store.setIntegrationsForOrg('org-1', [
+      {
+        organisationId: 'org-1',
+        provider: 'IDEXX',
+        status: 'enabled',
+      } as unknown as OrgIntegration,
+      {
+        id: 'i9',
+        organisationId: 'org-1',
+        provider: 'MERCK_MANUALS',
+        status: 'enabled',
+      } as unknown as OrgIntegration,
+    ]);
+
+    expect(useIntegrationStore.getState().integrationIdsByOrgId['org-1']).toEqual(['i9']);
+  });
+
+  it('ignores an upsert without any id', () => {
+    const store = useIntegrationStore.getState();
+    store.upsertIntegration({
+      organisationId: 'org-1',
+      provider: 'IDEXX',
+    } as unknown as OrgIntegration);
+
+    expect(useIntegrationStore.getState().integrationIdsByOrgId['org-1']).toBeUndefined();
+    expect(useIntegrationStore.getState().status).toBe('idle');
+  });
+
+  it('treats a missing provider as an empty string when matching by provider', () => {
+    const store = useIntegrationStore.getState();
+    store.upsertIntegration({ _id: 'i1', organisationId: 'org-1' } as unknown as OrgIntegration);
+
+    expect(store.getIntegrationByProvider('org-1', 'IDEXX' as any)).toBeNull();
+  });
+
+  it('clears an org with no stored integrations without crashing', () => {
+    const store = useIntegrationStore.getState();
+    store.clearIntegrationsForOrg('org-none');
+
+    expect(useIntegrationStore.getState().integrationIdsByOrgId['org-none']).toBeUndefined();
+    expect(useIntegrationStore.getState().status).toBe('loaded');
   });
 });

--- a/apps/frontend/src/app/__tests__/stores/loadingStatusActions.test.ts
+++ b/apps/frontend/src/app/__tests__/stores/loadingStatusActions.test.ts
@@ -1,0 +1,35 @@
+import { loadingStatusActions, type LoadingStatusState } from '@/app/stores/loadingStatusActions';
+
+describe('loadingStatusActions', () => {
+  const buildActions = () => {
+    const updates: Partial<LoadingStatusState>[] = [];
+    const set = (updater: () => Partial<LoadingStatusState>) => {
+      updates.push(updater());
+    };
+    return { updates, actions: loadingStatusActions(set) };
+  };
+
+  it('startLoading marks the store loading and clears the error', () => {
+    const { updates, actions } = buildActions();
+    actions.startLoading();
+    expect(updates).toEqual([{ status: 'loading', error: null }]);
+  });
+
+  it('endLoading marks the store loaded and stamps lastFetchedAt', () => {
+    const { updates, actions } = buildActions();
+    const before = Date.now();
+    actions.endLoading();
+    const [update] = updates;
+    expect(update.status).toBe('loaded');
+    expect(update.error).toBeNull();
+    const stamp = Date.parse(update.lastFetchedAt as string);
+    expect(stamp).toBeGreaterThanOrEqual(before);
+    expect(stamp).toBeLessThanOrEqual(Date.now());
+  });
+
+  it('setError records the message with an error status', () => {
+    const { updates, actions } = buildActions();
+    actions.setError('boom');
+    expect(updates).toEqual([{ status: 'error', error: 'boom' }]);
+  });
+});

--- a/apps/frontend/src/app/__tests__/types/companionDocuments.test.ts
+++ b/apps/frontend/src/app/__tests__/types/companionDocuments.test.ts
@@ -2,6 +2,7 @@ import {
   CategoryOptions,
   HealthCategoryOptions,
   HygieneCategoryOptions,
+  VisitTypeOptions,
   emptyCompanionRecord,
   type Category,
   type Subcategory,
@@ -55,6 +56,19 @@ describe('companionDocuments types', () => {
         { label: 'Dental cleaning', value: 'DENTAL_CLEANING' },
         { label: 'Skin care', value: 'SKIN_CARE' },
         { label: 'Anal gland expression', value: 'ANAL_GLAND_EXPRESSION' },
+        { label: 'Other', value: 'OTHER' },
+      ]);
+    });
+  });
+
+  describe('VisitTypeOptions', () => {
+    it('matches the approved visit type list', () => {
+      expect(VisitTypeOptions).toEqual([
+        { label: 'Hospital', value: 'HOSPITAL' },
+        { label: 'Groomer', value: 'GROOMER' },
+        { label: 'Boarder', value: 'BOARDER' },
+        { label: 'Breeder', value: 'BREEDER' },
+        { label: 'Shop', value: 'SHOP' },
         { label: 'Other', value: 'OTHER' },
       ]);
     });

--- a/apps/frontend/src/app/__tests__/types/form.test.ts
+++ b/apps/frontend/src/app/__tests__/types/form.test.ts
@@ -174,5 +174,115 @@ describe('Forms Data and Utility Functions', () => {
       const signatureFields = flat.filter((f: any) => f.type === 'signature');
       expect(signatureFields).toHaveLength(0);
     });
+
+    it('should keep the Boarder - Boarding Checklist option fields exactly as designed', () => {
+      const template = CategoryTemplates['Boarder - Boarding Checklist'] as any[];
+      const boardingOptions = template.find((f: any) => f.id === 'boarding_options');
+      expect(boardingOptions?.fields?.[0]).toEqual({
+        id: 'day_boarding_services',
+        type: 'checkbox',
+        label: 'Day boarding services',
+        options: [
+          { label: 'Day care options', value: 'day_care_options' },
+          { label: 'Overnight stay details', value: 'overnight_stay_details' },
+          { label: 'Weekly boarding plans', value: 'weekly_boarding_plans' },
+        ],
+        multiple: true,
+      });
+      expect(boardingOptions?.fields?.[1]).toEqual({
+        id: 'overnight_boarding_services',
+        type: 'radio',
+        label: 'Overnight boarding services',
+        options: [
+          { label: 'Yes', value: 'yes' },
+          { label: 'No', value: 'no' },
+        ],
+      });
+      const comfort = template.find((f: any) => f.id === 'comfort_environment');
+      expect(comfort?.fields?.map((f: any) => [f.id, f.type, f.options?.length])).toEqual([
+        ['room_type_selection', 'radio', 3],
+        ['playgroup_participation', 'radio', 2],
+        ['bedding_preferences', 'radio', 3],
+      ]);
+      expect(comfort?.fields?.[2]).toEqual({
+        id: 'bedding_preferences',
+        type: 'radio',
+        label: 'Bedding preferences',
+        options: [
+          { label: 'Facility bedding', value: 'facility_bedding' },
+          { label: 'Own bedding', value: 'own_bedding' },
+          { label: 'Orthopaedic bedding', value: 'orthopaedic_bedding' },
+        ],
+      });
+    });
+
+    it('should keep the Boarder - Dietary Plan option fields exactly as designed', () => {
+      const template = CategoryTemplates['Boarder - Dietary Plan'] as any[];
+      expect(template.map((f: any) => f.id)).toEqual([
+        'dietary_type',
+        'diet_special_notes',
+        'feeding_frequency',
+        'specific_feeding_times',
+        'portion_preferences',
+        'portion_special_notes',
+        'brand_preferences',
+        'feeding_method',
+        'feeding_method_notes',
+        'treat_preferences',
+        'water_preferences',
+        'water_additional_info',
+      ]);
+      expect(template.find((f: any) => f.id === 'treat_preferences')).toEqual({
+        id: 'treat_preferences',
+        type: 'checkbox',
+        label: 'Treat preferences',
+        options: [
+          { label: 'Jerky treats', value: 'jerky' },
+          { label: 'Dental sticks', value: 'dental_sticks' },
+          { label: 'Dehydrated meat', value: 'dehydrated_meat' },
+          { label: 'Homemade treats', value: 'homemade' },
+          { label: 'Training treats only', value: 'training_only' },
+          { label: 'No treats (parent restricted)', value: 'no_treats' },
+        ],
+        multiple: true,
+      });
+      expect(template.find((f: any) => f.id === 'water_preferences')).toEqual({
+        id: 'water_preferences',
+        type: 'radio',
+        label: 'Water preferences',
+        options: [
+          { label: 'Filtered / RO water only', value: 'filtered_ro' },
+          { label: 'Regular tap water', value: 'tap_water' },
+          { label: 'Bottled mineral water', value: 'bottled_mineral' },
+          { label: 'Mix with electrolytes', value: 'electrolytes_mix' },
+        ],
+      });
+    });
+
+    it('should keep the Boarder - Daily Summary radio fields exactly as designed', () => {
+      const template = CategoryTemplates['Boarder - Daily Summary'] as any[];
+      expect(template.find((f: any) => f.id === 'meals_provided')).toEqual({
+        id: 'meals_provided',
+        type: 'radio',
+        label: 'Meals provided to companion',
+        options: [
+          { label: 'Administered 1x daily', value: '1x_daily' },
+          { label: 'Administered 2x daily', value: '2x_daily' },
+          { label: 'Administered 3x daily', value: '3x_daily' },
+        ],
+      });
+      expect(template.find((f: any) => f.id === 'daily_poop_completed')).toEqual({
+        id: 'daily_poop_completed',
+        type: 'radio',
+        label: 'Daily pooping completed',
+        options: [
+          { label: 'Completed 1x', value: '1x' },
+          { label: 'Completed 2x', value: '2x' },
+        ],
+      });
+      expect(template.find((f: any) => f.id === 'medication_administered')?.options).toEqual([
+        { label: 'Scheduled time entry', value: 'scheduled_time' },
+      ]);
+    });
   });
 });

--- a/apps/frontend/src/app/__tests__/ui/filters/StatusOptionButtons.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/filters/StatusOptionButtons.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import StatusOptionButtons from '@/app/ui/filters/StatusOptionButtons';
+
+type Option = { key: string; name: string; border?: string; text?: string };
+
+const options: Option[] = [
+  { key: 'all', name: 'All', border: 'var(--all-border)', text: 'var(--all-text)' },
+  { key: 'done', name: 'Done', border: 'var(--done-border)', text: 'var(--done-text)' },
+  { key: 'bare', name: 'Bare' },
+];
+
+const getTextColor = (option: Option) => option.text ?? 'var(--fallback-text)';
+
+const renderButtons = (activeKey?: string, onSelect = jest.fn()) => {
+  render(
+    <StatusOptionButtons
+      options={options}
+      activeKey={activeKey}
+      allKey="all"
+      onSelect={onSelect}
+      getTextColor={getTextColor}
+    />
+  );
+  return onSelect;
+};
+
+describe('StatusOptionButtons', () => {
+  it('renders one button per option with a dot only for options that carry a border token', () => {
+    renderButtons('done');
+    expect(screen.getAllByRole('button')).toHaveLength(3);
+
+    const done = screen.getByRole('button', { name: /Done/ });
+    const dot = done.querySelector('span.size-2');
+    expect(dot).toHaveStyle({
+      backgroundColor: 'var(--done-border)',
+      borderColor: 'var(--done-border)',
+    });
+
+    const bare = screen.getByRole('button', { name: 'Bare' });
+    expect(bare.querySelector('span.size-2')).toBeNull();
+  });
+
+  it('marks the active non-all option with the active weight and a check', () => {
+    renderButtons('done');
+    const done = screen.getByRole('button', { name: /Done/ });
+    expect(done).toHaveClass('font-medium');
+    expect(done).toHaveTextContent('✓');
+
+    const bare = screen.getByRole('button', { name: 'Bare' });
+    expect(bare).toHaveClass('hover:bg-card-hover');
+    expect(bare).not.toHaveTextContent('✓');
+  });
+
+  it('keeps the neutral hover treatment for the active all option while still showing its check', () => {
+    renderButtons('all');
+    const all = screen.getByRole('button', { name: /All/ });
+    expect(all).not.toHaveClass('font-medium');
+    expect(all).toHaveClass('hover:bg-card-hover');
+    expect(all).toHaveTextContent('✓');
+  });
+
+  it('renders no check when no option is active', () => {
+    renderButtons(undefined);
+    expect(screen.queryByText('✓')).not.toBeInTheDocument();
+  });
+
+  it('colours the name and check with getTextColor and reports the selected key', () => {
+    const onSelect = renderButtons('done');
+    expect(screen.getByText('Done')).toHaveStyle({ color: 'var(--done-text)' });
+    expect(screen.getByText('Bare')).toHaveStyle({ color: 'var(--fallback-text)' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Bare' }));
+    expect(onSelect).toHaveBeenCalledWith('bare');
+  });
+});

--- a/apps/frontend/src/app/__tests__/ui/filters/useFilterDropdownDismiss.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/filters/useFilterDropdownDismiss.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, renderHook } from '@testing-library/react';
+import { useFilterDropdownDismiss } from '@/app/ui/filters/useFilterDropdownDismiss';
+
+describe('useFilterDropdownDismiss', () => {
+  const setup = (open = true) => {
+    const trigger = document.createElement('button');
+    const panel = document.createElement('div');
+    const inner = document.createElement('span');
+    panel.appendChild(inner);
+    const outside = document.createElement('div');
+    document.body.append(trigger, panel, outside);
+    const setOpen = jest.fn();
+    const view = renderHook(
+      ({ isOpen }: { isOpen: boolean }) =>
+        useFilterDropdownDismiss(isOpen, setOpen, { current: trigger }, { current: panel }),
+      { initialProps: { isOpen: open } }
+    );
+    return { trigger, panel, inner, outside, setOpen, ...view };
+  };
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('closes on a mousedown outside the trigger and panel', () => {
+    const { outside, setOpen } = setup();
+    fireEvent.mouseDown(outside);
+    expect(setOpen).toHaveBeenCalledTimes(1);
+    expect(setOpen).toHaveBeenCalledWith(false);
+  });
+
+  it('stays open for mousedowns on the trigger or inside the panel', () => {
+    const { trigger, inner, setOpen } = setup();
+    fireEvent.mouseDown(trigger);
+    fireEvent.mouseDown(inner);
+    expect(setOpen).not.toHaveBeenCalled();
+  });
+
+  it('closes on any scroll, including nested scroll containers', () => {
+    const { outside, setOpen } = setup();
+    fireEvent.scroll(outside);
+    expect(setOpen).toHaveBeenCalledWith(false);
+  });
+
+  it('treats unattached refs as outside and still closes', () => {
+    const setOpen = jest.fn();
+    renderHook(() => useFilterDropdownDismiss(true, setOpen, { current: null }, { current: null }));
+    fireEvent.mouseDown(document.body);
+    expect(setOpen).toHaveBeenCalledWith(false);
+  });
+
+  it('attaches no listeners while closed', () => {
+    const { outside, setOpen } = setup(false);
+    fireEvent.mouseDown(outside);
+    fireEvent.scroll(window);
+    expect(setOpen).not.toHaveBeenCalled();
+  });
+
+  it('removes its listeners when the dropdown closes', () => {
+    const { outside, setOpen, rerender } = setup();
+    rerender({ isOpen: false });
+    fireEvent.mouseDown(outside);
+    fireEvent.scroll(window);
+    expect(setOpen).not.toHaveBeenCalled();
+  });
+
+  it('removes its listeners on unmount', () => {
+    const { outside, setOpen, unmount } = setup();
+    unmount();
+    fireEvent.mouseDown(outside);
+    fireEvent.scroll(window);
+    expect(setOpen).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/app/__tests__/ui/primitives/buttonGlowHandlers.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/primitives/buttonGlowHandlers.test.ts
@@ -1,0 +1,32 @@
+import type { PointerEvent } from 'react';
+import { primaryButtonGlowHandlers } from '@/app/ui/primitives/buttonGlowHandlers';
+
+const buildPointerEvent = () => {
+  const setProperty = jest.fn();
+  const event = {
+    clientX: 110,
+    clientY: 220,
+    currentTarget: {
+      getBoundingClientRect: () => ({ left: 10, top: 20 }),
+      style: { setProperty },
+    },
+  } as unknown as PointerEvent<HTMLButtonElement>;
+  return { event, setProperty };
+};
+
+describe('primaryButtonGlowHandlers', () => {
+  it('onPointerDown positions the glow relative to the button', () => {
+    const { event, setProperty } = buildPointerEvent();
+    primaryButtonGlowHandlers.onPointerDown(event);
+    expect(setProperty).toHaveBeenCalledWith('--yc-button-x', '100px');
+    expect(setProperty).toHaveBeenCalledWith('--yc-button-y', '200px');
+  });
+
+  it('onPointerMove tracks the cursor with the same handler behaviour', () => {
+    const { event, setProperty } = buildPointerEvent();
+    primaryButtonGlowHandlers.onPointerMove(event);
+    expect(setProperty).toHaveBeenCalledTimes(2);
+    expect(setProperty).toHaveBeenNthCalledWith(1, '--yc-button-x', '100px');
+    expect(setProperty).toHaveBeenNthCalledWith(2, '--yc-button-y', '200px');
+  });
+});

--- a/apps/frontend/src/app/__tests__/ui/theme/themeCore.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/theme/themeCore.test.ts
@@ -1,0 +1,218 @@
+import { renderHook, act } from '@testing-library/react';
+import {
+  THEME_CHANGE_EVENT,
+  THEME_STORAGE_KEY,
+  applyTheme,
+  getServerTheme,
+  readTheme,
+  subscribeToThemeChange,
+  syncMetaThemeColor,
+  toggleTheme,
+  useThemeLifecycle,
+} from '@/app/ui/theme/themeCore';
+
+type MqListener = (event: { matches: boolean }) => void;
+
+describe('themeCore', () => {
+  let osListener: MqListener | null;
+  let mqRemoveListener: jest.Mock;
+
+  const mockMatchMedia = (matches: boolean) => {
+    osListener = null;
+    mqRemoveListener = jest.fn();
+    (globalThis as { matchMedia: unknown }).matchMedia = jest.fn().mockReturnValue({
+      matches,
+      addEventListener: (_: string, handler: MqListener) => {
+        osListener = handler;
+      },
+      removeEventListener: mqRemoveListener,
+    });
+  };
+
+  beforeEach(() => {
+    document.documentElement.removeAttribute('data-theme');
+    document.documentElement.removeAttribute('data-theme-ready');
+    document.querySelector('meta[name="theme-color"]')?.remove();
+    localStorage.clear();
+    mockMatchMedia(false);
+  });
+
+  it('exposes the shared storage key and change event names', () => {
+    expect(THEME_STORAGE_KEY).toBe('yc-theme');
+    expect(THEME_CHANGE_EVENT).toBe('yc-theme-change');
+  });
+
+  describe('readTheme / getServerTheme', () => {
+    it('reads dark from the html attribute', () => {
+      document.documentElement.setAttribute('data-theme', 'dark');
+      expect(readTheme()).toBe('dark');
+    });
+
+    it('defaults to light when the attribute is absent', () => {
+      expect(readTheme()).toBe('light');
+    });
+
+    it('always reports light for the server snapshot', () => {
+      expect(getServerTheme()).toBe('light');
+    });
+  });
+
+  describe('syncMetaThemeColor', () => {
+    it('creates the meta tag and fills the light fallback color', () => {
+      syncMetaThemeColor();
+      const meta = document.querySelector('meta[name="theme-color"]');
+      expect(meta?.getAttribute('content')).toBe('#efe8dc');
+    });
+
+    it('uses the dark fallback color when the theme is dark', () => {
+      document.documentElement.setAttribute('data-theme', 'dark');
+      syncMetaThemeColor();
+      const meta = document.querySelector('meta[name="theme-color"]');
+      expect(meta?.getAttribute('content')).toBe('#201c18');
+    });
+
+    it('prefers the resolved --page custom property when present', () => {
+      document.documentElement.style.setProperty('--page', '#123456');
+      syncMetaThemeColor();
+      const meta = document.querySelector('meta[name="theme-color"]');
+      expect(meta?.getAttribute('content')).toBe('#123456');
+      document.documentElement.style.removeProperty('--page');
+    });
+
+    it('reuses an existing meta tag instead of creating a second one', () => {
+      syncMetaThemeColor();
+      syncMetaThemeColor();
+      expect(document.querySelectorAll('meta[name="theme-color"]')).toHaveLength(1);
+    });
+  });
+
+  describe('applyTheme', () => {
+    it('sets the attribute, persists the choice, and broadcasts the change', () => {
+      const seen: string[] = [];
+      const onChange = ((event: Event) => {
+        seen.push((event as CustomEvent<{ theme: string }>).detail.theme);
+      }) as EventListener;
+      globalThis.addEventListener(THEME_CHANGE_EVENT, onChange);
+
+      applyTheme('dark', true);
+
+      expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+      expect(document.documentElement.getAttribute('data-theme-ready')).toBe('1');
+      expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark');
+      expect(seen).toContain('dark');
+      globalThis.removeEventListener(THEME_CHANGE_EVENT, onChange);
+    });
+
+    it('does not persist when persist is false', () => {
+      applyTheme('dark', false);
+      expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+      expect(localStorage.getItem(THEME_STORAGE_KEY)).toBeNull();
+    });
+
+    it('still applies the theme when localStorage.setItem is blocked', () => {
+      const spy = jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new Error('blocked');
+      });
+      applyTheme('dark', true);
+      expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+      spy.mockRestore();
+    });
+  });
+
+  describe('toggleTheme', () => {
+    it('flips light to dark and persists the choice', () => {
+      document.documentElement.setAttribute('data-theme', 'light');
+      toggleTheme();
+      expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+      expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark');
+    });
+
+    it('flips dark back to light', () => {
+      document.documentElement.setAttribute('data-theme', 'dark');
+      toggleTheme();
+      expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+      expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('light');
+    });
+  });
+
+  describe('subscribeToThemeChange', () => {
+    it('notifies while subscribed and stops after unsubscribe', () => {
+      const onStoreChange = jest.fn();
+      const unsubscribe = subscribeToThemeChange(onStoreChange);
+
+      globalThis.dispatchEvent(new Event(THEME_CHANGE_EVENT));
+      expect(onStoreChange).toHaveBeenCalledTimes(1);
+
+      unsubscribe();
+      globalThis.dispatchEvent(new Event(THEME_CHANGE_EVENT));
+      expect(onStoreChange).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('useThemeLifecycle', () => {
+    it('enables the flip transition shortly after mount', () => {
+      jest.useFakeTimers();
+      try {
+        renderHook(() => useThemeLifecycle());
+        act(() => {
+          jest.advanceTimersByTime(70);
+        });
+        expect(document.documentElement.getAttribute('data-theme-ready')).toBe('1');
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('syncs the meta theme-color on mount', () => {
+      renderHook(() => useThemeLifecycle());
+      expect(document.querySelector('meta[name="theme-color"]')).not.toBeNull();
+    });
+
+    it('follows OS changes while no explicit choice is stored', () => {
+      document.documentElement.setAttribute('data-theme', 'light');
+      renderHook(() => useThemeLifecycle());
+      act(() => osListener?.({ matches: true }));
+      expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    });
+
+    it('follows the OS back to light', () => {
+      document.documentElement.setAttribute('data-theme', 'dark');
+      renderHook(() => useThemeLifecycle());
+      act(() => osListener?.({ matches: false }));
+      expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+    });
+
+    it('ignores OS changes once a choice is stored', () => {
+      localStorage.setItem(THEME_STORAGE_KEY, 'light');
+      document.documentElement.setAttribute('data-theme', 'light');
+      renderHook(() => useThemeLifecycle());
+      act(() => osListener?.({ matches: true }));
+      expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+    });
+
+    it('applies the OS theme even when reading the stored choice throws', () => {
+      document.documentElement.setAttribute('data-theme', 'light');
+      const spy = jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+        throw new Error('blocked');
+      });
+      renderHook(() => useThemeLifecycle());
+      act(() => osListener?.({ matches: true }));
+      expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+      spy.mockRestore();
+    });
+
+    it('stops following the OS after unmount', () => {
+      const { unmount } = renderHook(() => useThemeLifecycle());
+      unmount();
+      expect(mqRemoveListener).toHaveBeenCalledWith('change', expect.any(Function));
+    });
+
+    it('mounts and unmounts cleanly when matchMedia is unavailable', () => {
+      (globalThis as { matchMedia?: unknown }).matchMedia = undefined;
+      expect(() => {
+        const { unmount } = renderHook(() => useThemeLifecycle());
+        unmount();
+      }).not.toThrow();
+    });
+  });
+});

--- a/apps/frontend/src/app/__tests__/ui/theme/useTheme.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/theme/useTheme.test.ts
@@ -1,3 +1,5 @@
+import { createElement } from 'react';
+import { renderToString } from 'react-dom/server';
 import { renderHook, act } from '@testing-library/react';
 import { useTheme } from '@/app/ui/theme/useTheme';
 
@@ -227,5 +229,39 @@ describe('useTheme', () => {
     const { result } = renderHook(() => useTheme());
     expect(result.current.appearance).toBe('auto');
     spy.mockRestore();
+  });
+
+  it('server-renders the light/auto defaults so hydration matches the server HTML', () => {
+    document.documentElement.setAttribute('data-theme', 'dark');
+    localStorage.setItem('yc-theme', 'dark');
+    let ssr: { theme: string; appearance: string } | null = null;
+    const Probe = () => {
+      const { theme, appearance } = useTheme();
+      ssr = { theme, appearance };
+      return null;
+    };
+    renderToString(createElement(Probe));
+    expect(ssr).toEqual({ theme: 'light', appearance: 'auto' });
+  });
+
+  it('reports auto appearance when localStorage is unavailable', () => {
+    const original = globalThis.localStorage;
+    Object.defineProperty(globalThis, 'localStorage', { value: undefined, configurable: true });
+    try {
+      const { result } = renderHook(() => useTheme());
+      expect(result.current.appearance).toBe('auto');
+    } finally {
+      Object.defineProperty(globalThis, 'localStorage', { value: original, configurable: true });
+    }
+  });
+
+  it('setAppearance to auto falls back to light when matchMedia is unavailable', () => {
+    document.documentElement.setAttribute('data-theme', 'dark');
+    (globalThis as { matchMedia?: unknown }).matchMedia = undefined;
+    const { result } = renderHook(() => useTheme());
+
+    act(() => result.current.setAppearance('auto'));
+
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
   });
 });

--- a/apps/frontend/src/app/constants/status.ts
+++ b/apps/frontend/src/app/constants/status.ts
@@ -97,78 +97,36 @@ export const getAppointmentStatusTone = (status?: string | null): StatusTone => 
   }
 };
 
+/**
+ * Builds a StatusLabel whose colour tokens all derive from one CSS variable
+ * prefix (`--<prefix>-bg` / `--<prefix>-text` / `--<prefix>-border`). Entries
+ * whose border token comes from elsewhere pass it as `borderOverride`.
+ */
+export const statusLabel = (
+  name: string,
+  key: string,
+  cssPrefix: string,
+  borderOverride?: string
+): StatusLabel => ({
+  name,
+  key,
+  bg: `var(--${cssPrefix}-bg)`,
+  text: `var(--${cssPrefix}-text)`,
+  border: borderOverride ?? `var(--${cssPrefix}-border)`,
+});
+
 export const AppointmentLabels: StatusLabel[] = [
-  {
-    name: 'Requested',
-    key: 'requested',
-    bg: 'var(--status-requested-bg)',
-    text: 'var(--status-requested-text)',
-    border: 'var(--status-requested-border)',
-  },
-  {
-    name: 'Upcoming',
-    key: 'upcoming',
-    bg: 'var(--status-upcoming-bg)',
-    text: 'var(--status-upcoming-text)',
-    border: 'var(--status-upcoming-border)',
-  },
-  {
-    name: 'Checked-in',
-    key: 'checked_in',
-    bg: 'var(--status-checked-in-bg)',
-    text: 'var(--status-checked-in-text)',
-    border: 'var(--status-checked-in-border)',
-  },
-  {
-    name: 'In progress',
-    key: 'in_progress',
-    bg: 'var(--status-in-progress-bg)',
-    text: 'var(--status-in-progress-text)',
-    border: 'var(--status-in-progress-border)',
-  },
-  {
-    name: 'Completed',
-    key: 'completed',
-    bg: 'var(--status-completed-bg)',
-    text: 'var(--status-completed-text)',
-    border: 'var(--status-completed-border)',
-  },
-  {
-    name: 'Cancelled',
-    key: 'cancelled',
-    bg: 'var(--status-cancelled-bg)',
-    text: 'var(--status-cancelled-text)',
-    border: 'var(--status-cancelled-border)',
-  },
+  statusLabel('Requested', 'requested', 'status-requested'),
+  statusLabel('Upcoming', 'upcoming', 'status-upcoming'),
+  statusLabel('Checked-in', 'checked_in', 'status-checked-in'),
+  statusLabel('In progress', 'in_progress', 'status-in-progress'),
+  statusLabel('Completed', 'completed', 'status-completed'),
+  statusLabel('Cancelled', 'cancelled', 'status-cancelled'),
 ];
 
 export const TaskLabels: StatusLabel[] = [
-  {
-    name: 'Pending',
-    key: 'pending',
-    bg: 'var(--status-requested-bg)',
-    text: 'var(--status-requested-text)',
-    border: 'var(--status-requested-border)',
-  },
-  {
-    name: 'In progress',
-    key: 'in_progress',
-    bg: 'var(--status-in-progress-bg)',
-    text: 'var(--status-in-progress-text)',
-    border: 'var(--status-in-progress-border)',
-  },
-  {
-    name: 'Completed',
-    key: 'completed',
-    bg: 'var(--status-completed-bg)',
-    text: 'var(--status-completed-text)',
-    border: 'var(--status-completed-border)',
-  },
-  {
-    name: 'Cancelled',
-    key: 'cancelled',
-    bg: 'var(--status-cancelled-bg)',
-    text: 'var(--status-cancelled-text)',
-    border: 'var(--status-cancelled-border)',
-  },
+  statusLabel('Pending', 'pending', 'status-requested'),
+  statusLabel('In progress', 'in_progress', 'status-in-progress'),
+  statusLabel('Completed', 'completed', 'status-completed'),
+  statusLabel('Cancelled', 'cancelled', 'status-cancelled'),
 ];

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/DayCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/DayCalendar.tsx
@@ -19,7 +19,7 @@ import {
   useNowIndicator,
   useSlotOffsetMinutes,
 } from '@/app/features/appointments/components/Calendar/useCalendarSlots';
-import { DropAvailabilityInterval } from '@/app/features/appointments/components/Calendar/availabilityIntervals';
+import type { TaskCalendarInteractionProps } from '@/app/features/appointments/components/Calendar/Task/taskCalendarInteractionProps';
 
 const HOUR_ROW_GAP_PX = 0;
 
@@ -31,23 +31,7 @@ type DayCalendarProps = {
   handleChangeStatusTask?: (task: Task) => void;
   handleRescheduleTask?: (task: Task) => void;
   setCurrentDate: React.Dispatch<React.SetStateAction<Date>>;
-  canEditTasks?: boolean;
-  draggedTaskId?: string | null;
-  draggedTaskLabel?: string | null;
-  canDragTask?: (task: Task) => boolean;
-  onTaskDragStart?: (task: Task) => void;
-  onTaskDragEnd?: () => void;
-  onTaskDropAt?: (date: Date, minuteOfDay: number, targetAssigneeId?: string) => void;
-  onCreateTaskAt?: (date: Date, minuteOfDay: number, targetAssigneeId?: string) => void;
-  onDragHoverTarget?: (date: Date, targetAssigneeId?: string) => void;
-  getDropAvailabilityIntervals?: (
-    date: Date,
-    targetAssigneeId?: string
-  ) => DropAvailabilityInterval[];
-  draggedTaskDurationMinutes?: number;
-  slotStepMinutes?: number;
-  resolveDisplayName?: (memberId?: string) => string;
-};
+} & TaskCalendarInteractionProps;
 
 const DayCalendar = ({
   events,

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/UserCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/UserCalendar.tsx
@@ -27,7 +27,7 @@ import {
   useNowIndicator,
   useSlotOffsetMinutes,
 } from '@/app/features/appointments/components/Calendar/useCalendarSlots';
-import { DropAvailabilityInterval } from '@/app/features/appointments/components/Calendar/availabilityIntervals';
+import type { TaskCalendarInteractionProps } from '@/app/features/appointments/components/Calendar/Task/taskCalendarInteractionProps';
 
 const HOUR_ROW_GAP_PX = 0;
 
@@ -39,23 +39,7 @@ type UserCalendarProps = {
   handleChangeStatusTask?: (task: Task) => void;
   handleRescheduleTask?: (task: Task) => void;
   setCurrentDate: React.Dispatch<React.SetStateAction<Date>>;
-  canEditTasks?: boolean;
-  draggedTaskId?: string | null;
-  draggedTaskLabel?: string | null;
-  canDragTask?: (task: Task) => boolean;
-  onTaskDragStart?: (task: Task) => void;
-  onTaskDragEnd?: () => void;
-  onTaskDropAt?: (date: Date, minuteOfDay: number, targetAssigneeId?: string) => void;
-  onCreateTaskAt?: (date: Date, minuteOfDay: number, targetAssigneeId?: string) => void;
-  onDragHoverTarget?: (date: Date, targetAssigneeId?: string) => void;
-  getDropAvailabilityIntervals?: (
-    date: Date,
-    targetAssigneeId?: string
-  ) => DropAvailabilityInterval[];
-  draggedTaskDurationMinutes?: number;
-  slotStepMinutes?: number;
-  resolveDisplayName?: (memberId?: string) => string;
-};
+} & TaskCalendarInteractionProps;
 
 const UserCalendar: React.FC<UserCalendarProps> = ({
   events,

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/WeekCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/WeekCalendar.tsx
@@ -30,7 +30,7 @@ import {
   useCalendarWeekNavigation,
   useSlotOffsetMinutes,
 } from '@/app/features/appointments/components/Calendar/useCalendarSlots';
-import { DropAvailabilityInterval } from '@/app/features/appointments/components/Calendar/availabilityIntervals';
+import type { TaskCalendarInteractionProps } from '@/app/features/appointments/components/Calendar/Task/taskCalendarInteractionProps';
 
 const HOUR_ROW_GAP_PX = 0;
 
@@ -44,23 +44,7 @@ type WeekCalendarProps = {
   weekStart: Date;
   setWeekStart: React.Dispatch<React.SetStateAction<Date>>;
   setCurrentDate: React.Dispatch<React.SetStateAction<Date>>;
-  canEditTasks?: boolean;
-  draggedTaskId?: string | null;
-  draggedTaskLabel?: string | null;
-  canDragTask?: (task: Task) => boolean;
-  onTaskDragStart?: (task: Task) => void;
-  onTaskDragEnd?: () => void;
-  onTaskDropAt?: (date: Date, minuteOfDay: number, targetAssigneeId?: string) => void;
-  onCreateTaskAt?: (date: Date, minuteOfDay: number, targetAssigneeId?: string) => void;
-  onDragHoverTarget?: (date: Date, targetAssigneeId?: string) => void;
-  getDropAvailabilityIntervals?: (
-    date: Date,
-    targetAssigneeId?: string
-  ) => DropAvailabilityInterval[];
-  draggedTaskDurationMinutes?: number;
-  slotStepMinutes?: number;
-  resolveDisplayName?: (memberId?: string) => string;
-};
+} & TaskCalendarInteractionProps;
 
 const WeekCalendar: React.FC<WeekCalendarProps> = ({
   events,

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/taskCalendarInteractionProps.ts
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/taskCalendarInteractionProps.ts
@@ -1,0 +1,25 @@
+import type { Task } from '@/app/features/tasks/types/task';
+import type { DropAvailabilityInterval } from '@/app/features/appointments/components/Calendar/availabilityIntervals';
+
+/**
+ * Shared drag/drop and slot-creation props accepted by every task calendar
+ * surface (day, user, and week views).
+ */
+export type TaskCalendarInteractionProps = {
+  canEditTasks?: boolean;
+  draggedTaskId?: string | null;
+  draggedTaskLabel?: string | null;
+  canDragTask?: (task: Task) => boolean;
+  onTaskDragStart?: (task: Task) => void;
+  onTaskDragEnd?: () => void;
+  onTaskDropAt?: (date: Date, minuteOfDay: number, targetAssigneeId?: string) => void;
+  onCreateTaskAt?: (date: Date, minuteOfDay: number, targetAssigneeId?: string) => void;
+  onDragHoverTarget?: (date: Date, targetAssigneeId?: string) => void;
+  getDropAvailabilityIntervals?: (
+    date: Date,
+    targetAssigneeId?: string
+  ) => DropAvailabilityInterval[];
+  draggedTaskDurationMinutes?: number;
+  slotStepMinutes?: number;
+  resolveDisplayName?: (memberId?: string) => string;
+};

--- a/apps/frontend/src/app/features/appointments/components/Calendar/appointmentCalendarHelpers.ts
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/appointmentCalendarHelpers.ts
@@ -10,11 +10,7 @@ import {
   DropAvailabilityInterval,
   resolveAvailabilityIntervalsForDay,
 } from '@/app/features/appointments/components/Calendar/availabilityIntervals';
-import {
-  getErrorMessageFromCandidate,
-  hasAppointmentConflict,
-  teamSupportsSpeciality,
-} from '@/app/features/appointments/components/Calendar/appointmentCalendarDragUtils';
+import { hasAppointmentConflict } from '@/app/features/appointments/components/Calendar/appointmentCalendarDragUtils';
 
 export type DragContext = {
   appointmentId: string;
@@ -51,8 +47,11 @@ export const toLocalClockFromUtcTime = (utcTime: string) =>
   utcClockTimeToPreferredTimeZoneClock(utcTime);
 
 // Single source of truth for these drag helpers lives in appointmentCalendarDragUtils.
-export { getErrorMessageFromCandidate, hasAppointmentConflict };
-export { teamSupportsSpeciality as supportsSpeciality };
+export {
+  getErrorMessageFromCandidate,
+  teamSupportsSpeciality as supportsSpeciality,
+} from '@/app/features/appointments/components/Calendar/appointmentCalendarDragUtils';
+export { hasAppointmentConflict };
 
 export const normalizeId = (value?: string) =>
   String(value ?? '')

--- a/apps/frontend/src/app/features/appointments/components/Calendar/appointmentCalendarHelpers.ts
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/appointmentCalendarHelpers.ts
@@ -10,6 +10,11 @@ import {
   DropAvailabilityInterval,
   resolveAvailabilityIntervalsForDay,
 } from '@/app/features/appointments/components/Calendar/availabilityIntervals';
+import {
+  getErrorMessageFromCandidate,
+  hasAppointmentConflict,
+  teamSupportsSpeciality,
+} from '@/app/features/appointments/components/Calendar/appointmentCalendarDragUtils';
 
 export type DragContext = {
   appointmentId: string;
@@ -45,59 +50,9 @@ export const getDayOfWeekKey = (date: Date) =>
 export const toLocalClockFromUtcTime = (utcTime: string) =>
   utcClockTimeToPreferredTimeZoneClock(utcTime);
 
-export const getErrorMessageFromCandidate = (
-  candidate: { response?: { data?: unknown } } | { data?: unknown } | { message?: string },
-  fallback: string
-) => {
-  const asRecord = (value: unknown): Record<string, unknown> | null =>
-    value && typeof value === 'object' ? (value as Record<string, unknown>) : null;
-  const getTrimmedMessage = (value: unknown) =>
-    typeof value === 'string' && value.trim() ? value.trim() : null;
-  const getResponseMessage = (value: unknown) => {
-    const data = asRecord(value);
-    if (!data) return getTrimmedMessage(value);
-    return (
-      getTrimmedMessage(data.message) ||
-      getTrimmedMessage(data.error) ||
-      getTrimmedMessage(data.details)
-    );
-  };
-
-  const candidateRecord = asRecord(candidate);
-  const responseRecord = asRecord(candidateRecord?.response);
-  const responseData = responseRecord?.data;
-  const candidateMessage = candidateRecord?.message;
-
-  return getResponseMessage(responseData) || getTrimmedMessage(candidateMessage) || fallback;
-};
-
-export const hasAppointmentConflict = (
-  moved: Appointment,
-  nextStart: Date,
-  nextEnd: Date,
-  sourceAppointments: Appointment[],
-  targetLeadId?: string
-) => {
-  return sourceAppointments.some((existing) => {
-    if (!existing.id || existing.id === moved.id) return false;
-    if (existing.status === 'CANCELLED' || existing.status === 'NO_SHOW') return false;
-    const existingStart = new Date(existing.startTime);
-    const existingEnd = new Date(existing.endTime);
-    const overlaps =
-      nextStart.getTime() < existingEnd.getTime() && nextEnd.getTime() > existingStart.getTime();
-    if (!overlaps) return false;
-
-    const movedLead = targetLeadId || moved.lead?.id;
-    const existingLead = existing.lead?.id;
-    const leadConflict = !!movedLead && movedLead === existingLead;
-
-    const movedRoom = moved.room?.id;
-    const existingRoom = existing.room?.id;
-    const roomConflict = !!movedRoom && movedRoom === existingRoom;
-
-    return leadConflict || roomConflict;
-  });
-};
+// Single source of truth for these drag helpers lives in appointmentCalendarDragUtils.
+export { getErrorMessageFromCandidate, hasAppointmentConflict };
+export { teamSupportsSpeciality as supportsSpeciality };
 
 export const normalizeId = (value?: string) =>
   String(value ?? '')
@@ -129,30 +84,6 @@ export const findCurrentUserPractitionerId = (teams: Team[], authUserId: string)
       normalizeId((team as any).userOrganisation?.userId) === normalizedCurrentUser
   );
   return member?.practionerId || member?._id;
-};
-
-export const supportsSpeciality = (
-  teams: Team[],
-  targetLeadId: string,
-  appointment: Appointment
-) => {
-  const normalizedTarget = normalizeId(targetLeadId);
-  const target = teams.find(
-    (member) =>
-      normalizeId(member.practionerId || '') === normalizedTarget ||
-      normalizeId(member._id || '') === normalizedTarget
-  );
-  if (!target) return false;
-  const appointmentSpeciality = appointment.appointmentType?.speciality;
-  if (!appointmentSpeciality) return true;
-  if (!Array.isArray(target.speciality) || target.speciality.length === 0) return true;
-  const expectedId = String((appointmentSpeciality as any).id ?? '').toLowerCase();
-  const expectedName = String((appointmentSpeciality as any).name ?? '').toLowerCase();
-  return target.speciality.some((spec: any) => {
-    const id = String(spec?._id ?? spec?.id ?? '').toLowerCase();
-    const name = String(spec?.name ?? spec ?? '').toLowerCase();
-    return (expectedId && id === expectedId) || (expectedName && name === expectedName);
-  });
 };
 
 export const buildAppointmentStartFromCalendarMinutes = (date: Date, minuteOfDay: number) => {

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/DayCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/DayCalendar.tsx
@@ -41,6 +41,7 @@ import TimedEventMarker from '@/app/features/appointments/components/Calendar/co
 import { getEventKey } from '@/app/features/appointments/components/Calendar/common/dayCalendarHelpers';
 import { useDayCalendarMarkerInteractions } from '@/app/features/appointments/components/Calendar/common/useDayCalendarMarkerInteractions';
 import { useHasMounted } from '@/app/hooks/useHasMounted';
+import type { AppointmentCalendarInteractionProps } from '@/app/features/appointments/components/Calendar/common/calendarInteractionProps';
 
 type DayCalendarProps = {
   events: Appointment[];
@@ -52,28 +53,7 @@ type DayCalendarProps = {
   handleRescheduleAppointment: (appointment: Appointment) => void;
   handleChangeRoomAppointment?: (appointment: Appointment) => void;
   handleAcceptAppointment?: (appointment: Appointment) => void;
-  canEditAppointments: boolean;
-  draggedAppointmentId?: string | null;
-  draggedAppointmentLabel?: string | null;
-  canDragAppointment?: (appointment: Appointment) => boolean;
-  onAppointmentDragStart?: (appointment: Appointment) => void;
-  onAppointmentDragEnd?: () => void;
-  onAppointmentDropAt?: (date: Date, minuteOfDay: number, targetLeadId?: string) => void;
-  onDragHoverTarget?: (date: Date, targetLeadId?: string) => void;
-  onCreateAppointmentAt?: (date: Date, minuteOfDay: number, targetLeadId?: string) => void;
-  getDropAvailabilityIntervals?: (
-    date: Date,
-    targetLeadId?: string
-  ) => Array<{ startMinute: number; endMinute: number }>;
-  getVisibleAvailabilityIntervals?: (
-    date: Date,
-    targetLeadId?: string
-  ) => Array<{ startMinute: number; endMinute: number }>;
-  draggedAppointmentDurationMinutes?: number;
-  slotStepMinutes?: number;
-  availabilityLoaded?: boolean;
-  skipAutoScroll?: boolean;
-};
+} & AppointmentCalendarInteractionProps;
 
 const shouldIgnoreTimelineCreate = (target: EventTarget | null) => {
   if (!(target instanceof HTMLElement)) return false;

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/Header.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/Header.tsx
@@ -1,11 +1,4 @@
-import React, {
-  startTransition,
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from 'react';
+import React, { startTransition, useCallback, useLayoutEffect, useRef, useState } from 'react';
 import { useWheelToHorizontalScroll } from '@/app/hooks/useWheelToHorizontalScroll';
 import { getMonthYear } from '@/app/features/appointments/components/Calendar/helpers';
 import { getEmergencyPillStyle } from '@/app/features/appointments/components/appointmentBoardHelpers';
@@ -29,6 +22,8 @@ import { useHasMounted } from '@/app/hooks/useHasMounted';
 import { useCalendarNavigation } from '@/app/hooks/useCalendarNavigation';
 import { useCalendarWeekNavigation } from '@/app/features/appointments/components/Calendar/useCalendarSlots';
 import { getStartOfWeek } from '@/app/features/appointments/components/Calendar/weekHelpers';
+import StatusOptionButtons from '@/app/ui/filters/StatusOptionButtons';
+import { useFilterDropdownDismiss } from '@/app/ui/filters/useFilterDropdownDismiss';
 
 type FilterOption = { key: string; name: string; dotColor?: string };
 type StatusOption = {
@@ -102,24 +97,7 @@ const useAnchoredDropdown = (minPanelWidth?: number) => {
     if (open) position();
   }, [open, position]);
 
-  useEffect(() => {
-    if (!open) return;
-    const handleClose = (e: MouseEvent) => {
-      if (
-        triggerRef.current?.contains(e.target as Node) ||
-        panelRef.current?.contains(e.target as Node)
-      )
-        return;
-      setOpen(false);
-    };
-    const handleScroll = () => setOpen(false);
-    document.addEventListener('mousedown', handleClose);
-    window.addEventListener('scroll', handleScroll, { passive: true, capture: true });
-    return () => {
-      document.removeEventListener('mousedown', handleClose);
-      window.removeEventListener('scroll', handleScroll, { capture: true });
-    };
-  }, [open]);
+  useFilterDropdownDismiss(open, setOpen, triggerRef, panelRef);
 
   return { open, setOpen, style, triggerRef, panelRef };
 };
@@ -191,44 +169,16 @@ const StatusFilterDropdown = ({
             className="rounded-2xl border border-card-border bg-neutral-0 shadow-[0_8px_24px_var(--color-shadow-soft)] overflow-hidden"
             style={style}
           >
-            {statusOptions.map((status) => {
-              const isActive = status.key === activeStatus;
-              return (
-                <button
-                  key={status.key}
-                  type="button"
-                  onClick={() => {
-                    setActiveStatus?.(status.key);
-                    setOpen(false);
-                  }}
-                  className={clsx(
-                    'w-full flex items-center gap-2.5 px-3 py-2 text-[13px] text-left transition-colors',
-                    isActive && status.key !== 'all' ? 'font-medium' : 'hover:bg-card-hover'
-                  )}
-                >
-                  {status.border && (
-                    <span
-                      className="inline-block size-2 rounded-full shrink-0"
-                      style={{
-                        backgroundColor: status.border,
-                        borderWidth: '1px',
-                        borderStyle: 'solid',
-                        borderColor: status.border,
-                      }}
-                    />
-                  )}
-                  <span style={{ color: getDropdownStatusTextColor(status) }}>{status.name}</span>
-                  {isActive && (
-                    <span
-                      className="ml-auto text-[12px] font-semibold"
-                      style={{ color: getDropdownStatusTextColor(status) }}
-                    >
-                      ✓
-                    </span>
-                  )}
-                </button>
-              );
-            })}
+            <StatusOptionButtons
+              options={statusOptions}
+              activeKey={activeStatus}
+              allKey="all"
+              onSelect={(key) => {
+                setActiveStatus?.(key);
+                setOpen(false);
+              }}
+              getTextColor={getDropdownStatusTextColor}
+            />
           </div>,
           document.body
         )}

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/UserCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/UserCalendar.tsx
@@ -40,6 +40,7 @@ import {
   useSlotOffsetMinutes,
 } from '@/app/features/appointments/components/Calendar/useCalendarSlots';
 import type { AppointmentViewIntent } from '@/app/features/appointments/types/calendar';
+import type { AppointmentCalendarInteractionProps } from '@/app/features/appointments/components/Calendar/common/calendarInteractionProps';
 
 type UserCalendarProps = {
   events: Appointment[];
@@ -51,29 +52,8 @@ type UserCalendarProps = {
   handleRescheduleAppointment: any;
   handleChangeRoomAppointment?: any;
   handleAcceptAppointment?: (appt: Appointment) => void;
-  canEditAppointments: boolean;
-  draggedAppointmentId?: string | null;
-  draggedAppointmentLabel?: string | null;
-  canDragAppointment?: (appointment: Appointment) => boolean;
-  onAppointmentDragStart?: (appointment: Appointment) => void;
-  onAppointmentDragEnd?: () => void;
-  onAppointmentDropAt?: (date: Date, minuteOfDay: number, targetLeadId?: string) => void;
-  onDragHoverTarget?: (date: Date, targetLeadId?: string) => void;
-  onCreateAppointmentAt?: (date: Date, minuteOfDay: number, targetLeadId?: string) => void;
-  getDropAvailabilityIntervals?: (
-    date: Date,
-    targetLeadId?: string
-  ) => Array<{ startMinute: number; endMinute: number }>;
-  getVisibleAvailabilityIntervals?: (
-    date: Date,
-    targetLeadId?: string
-  ) => Array<{ startMinute: number; endMinute: number }>;
-  draggedAppointmentDurationMinutes?: number;
   forceFullDayInZoomIn?: boolean;
-  slotStepMinutes?: number;
-  availabilityLoaded?: boolean;
-  skipAutoScroll?: boolean;
-};
+} & AppointmentCalendarInteractionProps;
 
 const UserCalendar: React.FC<UserCalendarProps> = ({
   events,

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/WeekCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/WeekCalendar.tsx
@@ -39,6 +39,7 @@ import {
   useSlotOffsetMinutes,
 } from '@/app/features/appointments/components/Calendar/useCalendarSlots';
 import type { AppointmentViewIntent } from '@/app/features/appointments/types/calendar';
+import type { AppointmentCalendarInteractionProps } from '@/app/features/appointments/components/Calendar/common/calendarInteractionProps';
 import './WeekCalendar.css';
 
 const HOUR_ROW_TOP_OFFSET_PX = 0;
@@ -359,28 +360,7 @@ type WeekCalendarProps = {
   handleRescheduleAppointment: any;
   handleChangeRoomAppointment?: any;
   handleAcceptAppointment?: (appt: Appointment) => void;
-  canEditAppointments: boolean;
-  draggedAppointmentId?: string | null;
-  draggedAppointmentLabel?: string | null;
-  canDragAppointment?: (appointment: Appointment) => boolean;
-  onAppointmentDragStart?: (appointment: Appointment) => void;
-  onAppointmentDragEnd?: () => void;
-  onAppointmentDropAt?: (date: Date, minuteOfDay: number, targetLeadId?: string) => void;
-  onDragHoverTarget?: (date: Date, targetLeadId?: string) => void;
-  onCreateAppointmentAt?: (date: Date, minuteOfDay: number, targetLeadId?: string) => void;
-  getDropAvailabilityIntervals?: (
-    date: Date,
-    targetLeadId?: string
-  ) => Array<{ startMinute: number; endMinute: number }>;
-  getVisibleAvailabilityIntervals?: (
-    date: Date,
-    targetLeadId?: string
-  ) => Array<{ startMinute: number; endMinute: number }>;
-  draggedAppointmentDurationMinutes?: number;
-  slotStepMinutes?: number;
-  availabilityLoaded?: boolean;
-  skipAutoScroll?: boolean;
-};
+} & AppointmentCalendarInteractionProps;
 
 const WeekCalendar: React.FC<WeekCalendarProps> = ({
   events,

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/calendarInteractionProps.ts
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/calendarInteractionProps.ts
@@ -1,0 +1,28 @@
+import type { Appointment } from '@yosemite-crew/types';
+
+export type AvailabilityInterval = {
+  startMinute: number;
+  endMinute: number;
+};
+
+/**
+ * Shared drag/drop and slot-creation props accepted by every appointment
+ * calendar surface (day, user, and week views).
+ */
+export type AppointmentCalendarInteractionProps = {
+  canEditAppointments: boolean;
+  draggedAppointmentId?: string | null;
+  draggedAppointmentLabel?: string | null;
+  canDragAppointment?: (appointment: Appointment) => boolean;
+  onAppointmentDragStart?: (appointment: Appointment) => void;
+  onAppointmentDragEnd?: () => void;
+  onAppointmentDropAt?: (date: Date, minuteOfDay: number, targetLeadId?: string) => void;
+  onDragHoverTarget?: (date: Date, targetLeadId?: string) => void;
+  onCreateAppointmentAt?: (date: Date, minuteOfDay: number, targetLeadId?: string) => void;
+  getDropAvailabilityIntervals?: (date: Date, targetLeadId?: string) => AvailabilityInterval[];
+  getVisibleAvailabilityIntervals?: (date: Date, targetLeadId?: string) => AvailabilityInterval[];
+  draggedAppointmentDurationMinutes?: number;
+  slotStepMinutes?: number;
+  availabilityLoaded?: boolean;
+  skipAutoScroll?: boolean;
+};

--- a/apps/frontend/src/app/features/appointments/components/Calendar/useDragAvailability.ts
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/useDragAvailability.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { Appointment } from '@yosemite-crew/types';
 import { Team } from '@/app/features/organization/types/team';
 import { Slot } from '@/app/features/appointments/types/appointments';
@@ -13,6 +13,9 @@ import {
   supportsSpeciality,
   toLocalDayKey,
 } from './appointmentCalendarHelpers';
+
+const readCachedStarts = (cache: Partial<Record<string, number[]>>, key: string): number[] =>
+  cache[key] ?? [];
 
 export const useDragAvailability = ({
   dragContext,
@@ -61,14 +64,13 @@ export const useDragAvailability = ({
   );
 
   const buildAvailableStartMinutes = useCallback(
-    async (date: Date, targetLeadId?: string) => {
-      if (!dragContext) return [];
-      const appointment = allAppointments.find((item) => item.id === dragContext.appointmentId);
+    async (context: DragContext, date: Date, targetLeadId?: string) => {
+      const appointment = allAppointments.find((item) => item.id === context.appointmentId);
       if (!appointment) return [];
       if (targetLeadId && !supportsSpeciality(teams, targetLeadId, appointment)) {
         return [];
       }
-      const serviceId = dragContext.serviceId || appointment.appointmentType?.id;
+      const serviceId = context.serviceId || appointment.appointmentType?.id;
       const targetPractitionerId = resolvePractitionerId(
         teams,
         targetLeadId || appointment.lead?.id
@@ -77,7 +79,7 @@ export const useDragAvailability = ({
 
       const slots = await getSlotsForMoveValidation(serviceId, date);
       const normalizedTargetPractitionerId = normalizeId(targetPractitionerId);
-      const durationMs = Math.max(5 * 60 * 1000, dragContext.durationMinutes * 60 * 1000);
+      const durationMs = Math.max(5 * 60 * 1000, context.durationMinutes * 60 * 1000);
       const nowMs = Date.now();
       const minutesSet = new Set<number>();
 
@@ -88,7 +90,7 @@ export const useDragAvailability = ({
           allAppointments,
           normalizedTargetPractitionerId,
           targetPractitionerId,
-          durationMinutes: dragContext.durationMinutes,
+          durationMinutes: context.durationMinutes,
           durationMs,
           nowMs,
           minutesSet,
@@ -97,7 +99,7 @@ export const useDragAvailability = ({
 
       return Array.from(minutesSet).sort((a, b) => a - b);
     },
-    [allAppointments, dragContext, getSlotsForMoveValidation, teams]
+    [allAppointments, getSlotsForMoveValidation, teams]
   );
 
   const ensureDragAvailability = useCallback(
@@ -109,11 +111,11 @@ export const useDragAvailability = ({
       }
       if (dragAvailabilityPendingRef.current[key]) {
         await dragAvailabilityPendingRef.current[key];
-        return dragAvailabilityCacheRef.current[key] ?? [];
+        return readCachedStarts(dragAvailabilityCacheRef.current, key);
       }
       const task = (async () => {
         try {
-          const starts = await buildAvailableStartMinutes(date, targetLeadId);
+          const starts = await buildAvailableStartMinutes(dragContext, date, targetLeadId);
           dragAvailabilityCacheRef.current[key] = starts;
           setAvailabilityVersion((version) => version + 1);
         } catch {
@@ -124,7 +126,7 @@ export const useDragAvailability = ({
       dragAvailabilityPendingRef.current[key] = task;
       await task;
       delete dragAvailabilityPendingRef.current[key];
-      return dragAvailabilityCacheRef.current[key] ?? [];
+      return readCachedStarts(dragAvailabilityCacheRef.current, key);
     },
     [buildAvailableStartMinutes, dragContext, getAvailabilityKey]
   );
@@ -132,7 +134,7 @@ export const useDragAvailability = ({
   const getDropAvailabilityIntervals = useCallback(
     (date: Date, targetLeadId?: string): DropAvailabilityInterval[] => {
       const key = getAvailabilityKey(date, targetLeadId);
-      const starts = dragAvailabilityCacheRef.current[key] || [];
+      const starts = readCachedStarts(dragAvailabilityCacheRef.current, key);
       return buildDropIntervalsFromStarts(starts);
     },
     [getAvailabilityKey]
@@ -146,51 +148,5 @@ export const useDragAvailability = ({
   };
 };
 
-export const useDragEdgeAutoScroll = (
-  draggedAppointmentId: string | null,
-  availabilityVersion: number
-) => {
-  useEffect(() => {
-    if (!draggedAppointmentId) return;
-    const edgeThreshold = 72;
-    const scrollAmount = 28;
-    const handleDragOver = (event: DragEvent) => {
-      const x = event.clientX;
-      const y = event.clientY;
-      const viewportWidth = globalThis.innerWidth;
-      const viewportHeight = globalThis.innerHeight;
-
-      if (x >= 0 && x < edgeThreshold) {
-        globalThis.scrollBy({ left: -scrollAmount });
-      } else if (x > viewportWidth - edgeThreshold) {
-        globalThis.scrollBy({ left: scrollAmount });
-      }
-      if (y >= 0 && y < edgeThreshold) {
-        globalThis.scrollBy({ top: -scrollAmount });
-      } else if (y > viewportHeight - edgeThreshold) {
-        globalThis.scrollBy({ top: scrollAmount });
-      }
-
-      const hoveredElement = document.elementFromPoint(x, y) as HTMLElement | null;
-      const scrollContainer = hoveredElement?.closest?.(
-        "[data-calendar-scroll='true']"
-      ) as HTMLElement | null;
-      if (!scrollContainer) return;
-      const rect = scrollContainer.getBoundingClientRect();
-      let deltaX = 0;
-      let deltaY = 0;
-      if (x - rect.left < edgeThreshold) deltaX = -scrollAmount;
-      else if (rect.right - x < edgeThreshold) deltaX = scrollAmount;
-      if (y - rect.top < edgeThreshold) deltaY = -scrollAmount;
-      else if (rect.bottom - y < edgeThreshold) deltaY = scrollAmount;
-      if (deltaX !== 0 || deltaY !== 0) {
-        scrollContainer.scrollBy({ left: deltaX, top: deltaY });
-      }
-    };
-
-    globalThis.addEventListener('dragover', handleDragOver);
-    return () => {
-      globalThis.removeEventListener('dragover', handleDragOver);
-    };
-  }, [draggedAppointmentId, availabilityVersion]);
-};
+// Single source of truth for the edge auto-scroll behaviour lives in useAppointmentDragAutoScroll.
+export { useAppointmentDragAutoScroll as useDragEdgeAutoScroll } from '@/app/features/appointments/components/Calendar/useAppointmentDragAutoScroll';

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/records/VitalsForm.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/records/VitalsForm.tsx
@@ -22,12 +22,9 @@ import {
   type DraftVitals,
 } from '@/app/features/appointments/pages/AppointmentWorkspace/sidemodal/records/vitalsFormDraft';
 import { useTeamForPrimaryOrg } from '@/app/hooks/useTeam';
+import { getTemplateSchemaSnapshot } from '@/app/features/appointments/pages/AppointmentWorkspace/templateSchemaSnapshot';
 import type { FormField } from '@/app/features/forms/types/forms';
-import type {
-  TemplateFieldDefinition,
-  TemplateLike,
-  TemplateSchemaSnapshot,
-} from '@yosemite-crew/types';
+import type { TemplateFieldDefinition, TemplateLike } from '@yosemite-crew/types';
 
 type VitalsFormProps = {
   appointmentId: string;
@@ -118,20 +115,6 @@ const resolveDraftKey = (field: { key?: string; id?: string; label?: string }) =
   if (value.includes('pain')) return 'painScore';
   if (value.includes('bcs') || value.includes('bodyscore')) return 'bcs';
   return undefined;
-};
-
-const hasTemplateSchemaSnapshot = (value: unknown): value is TemplateSchemaSnapshot =>
-  Boolean(
-    value && typeof value === 'object' && Array.isArray((value as { sections?: unknown }).sections)
-  );
-
-const getTemplateSchemaSnapshot = (template: TemplateLike): TemplateSchemaSnapshot | undefined => {
-  const rootSnapshot = (template as TemplateLike & { schemaSnapshot?: unknown }).schemaSnapshot;
-  if (hasTemplateSchemaSnapshot(rootSnapshot)) return rootSnapshot;
-  const version = template.versions?.find(
-    (item) => item.version === template.publishedVersion || item.version === template.latestVersion
-  );
-  return hasTemplateSchemaSnapshot(version?.schemaSnapshot) ? version.schemaSnapshot : undefined;
 };
 
 const flattenFormFields = (fields: FormField[] = []): FormField[] =>

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/DiagnosticsStep.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/DiagnosticsStep.tsx
@@ -43,6 +43,7 @@ import {
   getTestSpecimen,
   toTitleCase,
 } from '@/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/labTestsUtils';
+import { getIdexxTestSearchProps } from '@/app/features/appointments/pages/AppointmentWorkspace/steps/idexxTestSearchProps';
 import type { IdexxTest } from '@/app/features/integrations/services/types';
 import type { DiagnosticOrder } from '@/app/features/appointments/types/workspace';
 import { getSafeIdexxIframeUrl } from '@/app/lib/urls';
@@ -336,22 +337,8 @@ const ReferenceOrderBuilder = ({ s }: { s: UseLabTestsReturn }) => (
     <div className="flex flex-col gap-4">
       <SearchDropdown
         placeholder="Search for lab tests"
-        options={s.tests.map((test) => ({
-          value: test.code,
-          label: `${test.display} (${test.code})`,
-          meta: test,
-        }))}
+        {...getIdexxTestSearchProps(s)}
         onSelect={s.selectSearchResult}
-        query={s.selectedTestLabel || s.query}
-        setQuery={(value: string) => {
-          s.setSelectedTestLabel(value);
-          s.setQuery(value);
-        }}
-        minChars={0}
-        onReachEnd={s.loadMoreTests}
-        hasMore={s.testsHasMore}
-        isLoadingMore={s.testsLoadingMore}
-        optionClassName="w-full text-start rounded-2xl! border border-card-border bg-neutral-0 px-3 py-2 mb-2 last:mb-0 hover:bg-neutral-0 transition-colors"
         renderOption={(option) => {
           const test = option.meta as IdexxTest | undefined;
           if (!test) return option.label;

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/SummaryStep.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/SummaryStep.tsx
@@ -29,6 +29,7 @@ import PdfPreviewOverlay from '@/app/ui/overlays/PdfPreviewOverlay';
 import SigningOverlay from '@/app/ui/overlays/SigningOverlay';
 import { useAppointmentWorkspaceStore } from '@/app/stores/appointmentWorkspaceStore';
 import { useSigningOverlayStore } from '@/app/stores/signingOverlayStore';
+import { getTemplateSchemaSnapshot } from '@/app/features/appointments/pages/AppointmentWorkspace/templateSchemaSnapshot';
 import { isRichTextEmpty, sanitizeRichText } from '@/app/lib/richText';
 import type { AppointmentEncounter } from '@/app/features/appointments/types/workspace';
 import { formatStampDate, formatStampTime } from '@/app/lib/appointmentWorkspace';
@@ -87,20 +88,6 @@ const escapeHtml = (value: string): string =>
     .replaceAll('>', '&gt;')
     .replaceAll('"', '&quot;')
     .replaceAll("'", '&#39;');
-
-const hasTemplateSchemaSnapshot = (value: unknown): value is TemplateSchemaSnapshot =>
-  Boolean(
-    value && typeof value === 'object' && Array.isArray((value as { sections?: unknown }).sections)
-  );
-
-const getTemplateSchemaSnapshot = (template: TemplateLike): TemplateSchemaSnapshot | undefined => {
-  const rootSnapshot = (template as TemplateLike & { schemaSnapshot?: unknown }).schemaSnapshot;
-  if (hasTemplateSchemaSnapshot(rootSnapshot)) return rootSnapshot;
-  const version = template.versions?.find(
-    (item) => item.version === template.publishedVersion || item.version === template.latestVersion
-  );
-  return hasTemplateSchemaSnapshot(version?.schemaSnapshot) ? version.schemaSnapshot : undefined;
-};
 
 const DISCHARGE_META_FIELD_KEYS = new Set(['followUpInDays', 'followUpDate']);
 

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/idexxTestSearchProps.ts
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/idexxTestSearchProps.ts
@@ -1,0 +1,25 @@
+import type { UseLabTestsReturn } from '@/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/LabTests';
+
+/**
+ * Shared SearchDropdown props for the IDEXX test search rendered by both the
+ * workspace DiagnosticsStep reference-order builder and the appointment-info
+ * LabTests reference form. Callers keep their own `onSelect`/`renderOption`.
+ */
+export const getIdexxTestSearchProps = (s: UseLabTestsReturn) => ({
+  options: s.tests.map((test) => ({
+    value: test.code,
+    label: `${test.display} (${test.code})`,
+    meta: test,
+  })),
+  query: s.selectedTestLabel || s.query,
+  setQuery: (value: string) => {
+    s.setSelectedTestLabel(value);
+    s.setQuery(value);
+  },
+  minChars: 0,
+  onReachEnd: s.loadMoreTests,
+  hasMore: s.testsHasMore,
+  isLoadingMore: s.testsLoadingMore,
+  optionClassName:
+    'w-full text-start rounded-2xl! border border-card-border bg-neutral-0 px-3 py-2 mb-2 last:mb-0 hover:bg-neutral-0 transition-colors',
+});

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/templateSchemaSnapshot.ts
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/templateSchemaSnapshot.ts
@@ -1,0 +1,21 @@
+import type { TemplateLike, TemplateSchemaSnapshot } from '@yosemite-crew/types';
+
+export const hasTemplateSchemaSnapshot = (value: unknown): value is TemplateSchemaSnapshot =>
+  Boolean(
+    value && typeof value === 'object' && Array.isArray((value as { sections?: unknown }).sections)
+  );
+
+/**
+ * Resolve a template's schema snapshot: prefer the root-level snapshot, then
+ * fall back to the published (or latest) version's snapshot.
+ */
+export const getTemplateSchemaSnapshot = (
+  template: TemplateLike
+): TemplateSchemaSnapshot | undefined => {
+  const rootSnapshot = (template as TemplateLike & { schemaSnapshot?: unknown }).schemaSnapshot;
+  if (hasTemplateSchemaSnapshot(rootSnapshot)) return rootSnapshot;
+  const version = template.versions?.find(
+    (item) => item.version === template.publishedVersion || item.version === template.latestVersion
+  );
+  return hasTemplateSchemaSnapshot(version?.schemaSnapshot) ? version.schemaSnapshot : undefined;
+};

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AddAppointmentCentralModal/index.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AddAppointmentCentralModal/index.tsx
@@ -38,6 +38,7 @@ import { hasUnsavedCentralChanges } from '@/app/features/appointments/components
 import { IoIosWarning } from 'react-icons/io';
 import { IoAdd, IoArrowForward, IoChevronDown, IoPaw, IoPerson } from 'react-icons/io5';
 import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
+import { primaryButtonGlowHandlers } from '@/app/ui/primitives/buttonGlowHandlers';
 import clsx from 'clsx';
 import type { AppointmentKind } from '@yosemite-crew/types';
 
@@ -1044,16 +1045,7 @@ export const DiscardConfirmationModal = ({
           type="button"
           onClick={onDiscard}
           className="yc-primary-button rounded-2xl! px-5 py-2.5 font-satoshi text-base font-medium leading-[1.2] disabled:cursor-not-allowed disabled:opacity-60"
-          onPointerDown={(e) => {
-            const r = e.currentTarget.getBoundingClientRect();
-            e.currentTarget.style.setProperty('--yc-button-x', `${e.clientX - r.left}px`);
-            e.currentTarget.style.setProperty('--yc-button-y', `${e.clientY - r.top}px`);
-          }}
-          onPointerMove={(e) => {
-            const r = e.currentTarget.getBoundingClientRect();
-            e.currentTarget.style.setProperty('--yc-button-x', `${e.clientX - r.left}px`);
-            e.currentTarget.style.setProperty('--yc-button-y', `${e.clientY - r.top}px`);
-          }}
+          {...primaryButtonGlowHandlers}
         >
           Discard
         </button>

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/LabTests.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/LabTests.tsx
@@ -34,6 +34,7 @@ import {
   LabResultTest,
   LabResult,
 } from '@/app/features/integrations/services/types';
+import { getIdexxTestSearchProps } from '@/app/features/appointments/pages/AppointmentWorkspace/steps/idexxTestSearchProps';
 import { formatDateTimeLocal } from '@/app/lib/date';
 import {
   formatTestPrice,
@@ -981,22 +982,8 @@ const ReferenceLabForm = ({ s }: { s: UseLabTestsReturn }) => (
     </div>
     <SearchDropdown
       placeholder="Search IDEXX tests"
-      options={s.tests.map((test) => ({
-        value: test.code,
-        label: `${test.display} (${test.code})`,
-        meta: test,
-      }))}
+      {...getIdexxTestSearchProps(s)}
       onSelect={s.addTest}
-      query={s.selectedTestLabel || s.query}
-      setQuery={(value: string) => {
-        s.setSelectedTestLabel(value);
-        s.setQuery(value);
-      }}
-      minChars={0}
-      onReachEnd={s.loadMoreTests}
-      hasMore={s.testsHasMore}
-      isLoadingMore={s.testsLoadingMore}
-      optionClassName="w-full text-start rounded-2xl! border border-card-border bg-neutral-0 px-3 py-2 mb-2 last:mb-0 hover:bg-neutral-0 transition-colors"
       renderOption={(option) => {
         const test = option.meta as IdexxTest | undefined;
         if (!test) return option.label;

--- a/apps/frontend/src/app/features/appointments/services/workspaceTemplateService.ts
+++ b/apps/frontend/src/app/features/appointments/services/workspaceTemplateService.ts
@@ -17,26 +17,11 @@ import type {
   SoapTemplate,
 } from '@/app/features/appointments/types/workspace';
 import { getTaskCategoryLabel } from '@/app/features/tasks/constants/taskTaxonomy';
-
-type TemplateListParams = {
-  kind?: TemplateKind;
-  status?: string;
-  scope?: string;
-};
-
-const listTemplates = async (url: string, params: TemplateListParams = {}) => {
-  const res = await getData<TemplateLike[]>(url, params);
-  return Array.isArray(res.data) ? res.data : [];
-};
-
-const dedupeTemplates = (templates: TemplateLike[]) => {
-  const byId = new Map<string, TemplateLike>();
-  for (const template of templates) {
-    if (!template?.id) continue;
-    byId.set(template.id, template);
-  }
-  return [...byId.values()];
-};
+import {
+  dedupeTemplates,
+  listTemplates,
+  type TemplateListParams,
+} from '@/app/features/forms/services/templateListShared';
 
 export const listWorkspaceTemplates = async (
   organisationId: string,
@@ -201,17 +186,17 @@ export const templateToSoapTemplate = (template: TemplateLike): SoapTemplate => 
 };
 
 /**
- * Resolve the SOAP template that best matches the encounter context via the shared
- * `GET /pms/resolve` endpoint (kind `SOAP_NOTE`). Returns the resolved template as a
- * `SoapTemplate` (content snapshot + version) or `null` when none is configured —
- * the backend answers 404, which we treat as "no default", so the editor stays blank.
+ * Build the `GET /pms/resolve` query params for a template kind from the encounter
+ * context, including only the context fields that are set. Shared by the SOAP,
+ * discharge, and prescription resolvers.
  */
-export const resolveSoapTemplate = async (
-  context: TemplateResolveContext
-): Promise<SoapTemplate | null> => {
+const buildResolveParams = (
+  context: TemplateResolveContext,
+  kind: TemplateKind
+): Record<string, string> => {
   const params: Record<string, string> = {
     organisationId: context.organisationId,
-    kind: 'SOAP_NOTE',
+    kind,
   };
   if (context.appointmentId) params.appointmentId = context.appointmentId;
   if (context.encounterId) params.encounterId = context.encounterId;
@@ -220,6 +205,19 @@ export const resolveSoapTemplate = async (
   if (context.serviceId) params.serviceId = context.serviceId;
   if (context.packageId) params.packageId = context.packageId;
   if (context.mode) params.mode = context.mode;
+  return params;
+};
+
+/**
+ * Resolve the SOAP template that best matches the encounter context via the shared
+ * `GET /pms/resolve` endpoint (kind `SOAP_NOTE`). Returns the resolved template as a
+ * `SoapTemplate` (content snapshot + version) or `null` when none is configured —
+ * the backend answers 404, which we treat as "no default", so the editor stays blank.
+ */
+export const resolveSoapTemplate = async (
+  context: TemplateResolveContext
+): Promise<SoapTemplate | null> => {
+  const params = buildResolveParams(context, 'SOAP_NOTE');
 
   try {
     const res = await getData<TemplateResolveResponse>('/v1/templates/pms/resolve', params);
@@ -378,17 +376,7 @@ export type TemplateResolveContext = {
 export const resolveDischargeTemplate = async (
   context: TemplateResolveContext
 ): Promise<TemplateResolveResponse | null> => {
-  const params: Record<string, string> = {
-    organisationId: context.organisationId,
-    kind: 'DISCHARGE_SUMMARY',
-  };
-  if (context.appointmentId) params.appointmentId = context.appointmentId;
-  if (context.encounterId) params.encounterId = context.encounterId;
-  if (context.companionId) params.companionId = context.companionId;
-  if (context.species) params.species = context.species;
-  if (context.serviceId) params.serviceId = context.serviceId;
-  if (context.packageId) params.packageId = context.packageId;
-  if (context.mode) params.mode = context.mode;
+  const params = buildResolveParams(context, 'DISCHARGE_SUMMARY');
 
   try {
     const res = await getData<TemplateResolveResponse>('/v1/templates/pms/resolve', params);
@@ -597,17 +585,7 @@ export const listPrescriptionTemplatesForWorkspace = async (
 export const resolvePrescriptionTemplate = async (
   context: TemplateResolveContext
 ): Promise<Array<Omit<PrescriptionItem, 'id'>>> => {
-  const params: Record<string, string> = {
-    organisationId: context.organisationId,
-    kind: 'PRESCRIPTION',
-  };
-  if (context.appointmentId) params.appointmentId = context.appointmentId;
-  if (context.encounterId) params.encounterId = context.encounterId;
-  if (context.companionId) params.companionId = context.companionId;
-  if (context.species) params.species = context.species;
-  if (context.serviceId) params.serviceId = context.serviceId;
-  if (context.packageId) params.packageId = context.packageId;
-  if (context.mode) params.mode = context.mode;
+  const params = buildResolveParams(context, 'PRESCRIPTION');
 
   try {
     const res = await getData<TemplateResolveResponse>('/v1/templates/pms/resolve', params);

--- a/apps/frontend/src/app/features/appointments/types/appointments.ts
+++ b/apps/frontend/src/app/features/appointments/types/appointments.ts
@@ -1,4 +1,8 @@
-import { filter, status, StatusOption } from '@/app/features/companions/pages/Companions/types';
+import {
+  filter,
+  statusFromToken,
+  StatusOption,
+} from '@/app/features/companions/pages/Companions/types';
 import type { Appointment } from '@yosemite-crew/types';
 
 export type AppointmentWithCompanion = Appointment & {
@@ -20,13 +24,7 @@ export const AppointmentStatusOptions = [
 ];
 
 export type DayOfWeek =
-  | 'MONDAY'
-  | 'TUESDAY'
-  | 'WEDNESDAY'
-  | 'THURSDAY'
-  | 'FRIDAY'
-  | 'SATURDAY'
-  | 'SUNDAY';
+  'MONDAY' | 'TUESDAY' | 'WEDNESDAY' | 'THURSDAY' | 'FRIDAY' | 'SATURDAY' | 'SUNDAY';
 
 export type AvailabilityWindow = {
   startTime: string; // "HH:mm"
@@ -57,62 +55,14 @@ export type SlotsResponse = {
 };
 
 export const AppointmentStatusFilters: StatusOption[] = [
-  status(
-    'All',
-    'all',
-    'var(--status-requested-bg)',
-    'var(--status-requested-text)',
-    'var(--status-requested-border)'
-  ),
-  status(
-    'Requested',
-    'requested',
-    'var(--status-requested-bg)',
-    'var(--status-requested-text)',
-    'var(--status-requested-border)'
-  ),
-  status(
-    'Upcoming',
-    'upcoming',
-    'var(--status-upcoming-bg)',
-    'var(--status-upcoming-text)',
-    'var(--status-upcoming-border)'
-  ),
-  status(
-    'Checked-in',
-    'checked_in',
-    'var(--status-checked-in-bg)',
-    'var(--status-checked-in-text)',
-    'var(--status-checked-in-border)'
-  ),
-  status(
-    'In progress',
-    'in_progress',
-    'var(--status-in-progress-bg)',
-    'var(--status-in-progress-text)',
-    'var(--status-in-progress-border)'
-  ),
-  status(
-    'Completed',
-    'completed',
-    'var(--status-completed-bg)',
-    'var(--status-completed-text)',
-    'var(--status-completed-border)'
-  ),
-  status(
-    'Cancelled',
-    'cancelled',
-    'var(--status-cancelled-bg)',
-    'var(--status-cancelled-text)',
-    'var(--status-cancelled-border)'
-  ),
-  status(
-    'No show',
-    'no_show',
-    'var(--status-no-show-bg)',
-    'var(--status-no-show-text)',
-    'var(--status-no-show-border)'
-  ),
+  statusFromToken('All', 'all', 'status-requested'),
+  statusFromToken('Requested', 'requested', 'status-requested'),
+  statusFromToken('Upcoming', 'upcoming', 'status-upcoming'),
+  statusFromToken('Checked-in', 'checked_in', 'status-checked-in'),
+  statusFromToken('In progress', 'in_progress', 'status-in-progress'),
+  statusFromToken('Completed', 'completed', 'status-completed'),
+  statusFromToken('Cancelled', 'cancelled', 'status-cancelled'),
+  statusFromToken('No show', 'no_show', 'status-no-show'),
 ];
 
 export const AppointmentStatusFiltersUI: StatusOption[] = AppointmentStatusFilters;
@@ -120,11 +70,7 @@ export const AppointmentStatusFiltersUI: StatusOption[] = AppointmentStatusFilte
 export const AppointmentFilters = [filter('Emergencies', 'emergencies')];
 
 type ReasonOptions =
-  | 'APPOINTMENT_USAGE'
-  | 'MANUAL_ADJUSTMENT'
-  | 'GROOMING_USAGE'
-  | 'BOARDING_USAGE'
-  | 'OTHER';
+  'APPOINTMENT_USAGE' | 'MANUAL_ADJUSTMENT' | 'GROOMING_USAGE' | 'BOARDING_USAGE' | 'OTHER';
 
 export type InventoryConsumeRequest = {
   itemId: string;

--- a/apps/frontend/src/app/features/chat/components/ChatContainer.css
+++ b/apps/frontend/src/app/features/chat/components/ChatContainer.css
@@ -128,12 +128,6 @@
   gap: 2px;
 }
 
-/* NOTE: Stream's own channel-preview styling is intentionally absent. Its class
-   only ships on ChannelPreviewMessenger, which we replace with ConversationRow;
-   the design's conversation list is a stack of rounded rows separated by a 2px
-   gap, NOT a ruled list, so no divider or left-stripe rules belong here. Row
-   styling lives in ConversationRow.tsx. */
-
 .chat-preview-trigger {
   display: block;
   width: 100%;

--- a/apps/frontend/src/app/features/chat/components/ChatContainer.tsx
+++ b/apps/frontend/src/app/features/chat/components/ChatContainer.tsx
@@ -1480,9 +1480,7 @@ const useChatContainerView = ({
    */
   const activateSessionChannel = useCallback(
     async (chatClient: StreamChat, channelId: string, metadata: Record<string, unknown>) => {
-      const applyMetadata = async (chan: StreamChannel) => {
-        await chan.update(metadata, {});
-      };
+      const applyMetadata = (chan: StreamChannel) => chan.update(metadata, {});
       const queried = await chatClient.queryChannels(
         { id: { $eq: channelId } },
         [{ last_message_at: -1 }],

--- a/apps/frontend/src/app/features/chat/components/ChatContainer.tsx
+++ b/apps/frontend/src/app/features/chat/components/ChatContainer.tsx
@@ -1473,6 +1473,36 @@ const useChatContainerView = ({
     [client, onChannelSelect]
   );
 
+  /**
+   * Shared post-create activation for backend chat sessions: query the
+   * session's channel so it appears in lists, stamp the chat metadata on it,
+   * and select it (falling back to activateChannelById when the query misses).
+   */
+  const activateSessionChannel = useCallback(
+    async (chatClient: StreamChat, channelId: string, metadata: Record<string, unknown>) => {
+      const applyMetadata = async (chan: StreamChannel) => {
+        await chan.update(metadata, {});
+      };
+      const queried = await chatClient.queryChannels(
+        { id: { $eq: channelId } },
+        [{ last_message_at: -1 }],
+        { watch: true, state: true, presence: true, limit: 1 }
+      );
+      if (queried[0]) {
+        await queried[0].watch();
+        await applyMetadata(queried[0]);
+        setIsChannelSelected(true);
+        setShowEmptyPlaceholder(false);
+        onChannelSelect?.(queried[0]);
+      } else {
+        await activateChannelById(channelId);
+        const chan = chatClient.channel('team', channelId);
+        await applyMetadata(chan);
+      }
+    },
+    [activateChannelById, onChannelSelect]
+  );
+
   const handleStartDirectChat = useCallback(
     async (user: OrgUserOption) => {
       if (!primaryOrgId || !client) return;
@@ -1591,37 +1621,15 @@ const useChatContainerView = ({
             organisationId: primaryOrgId,
             otherUserId,
           });
-          const applyMetadata = async (chan: StreamChannel) => {
-            await chan.update(
-              {
-                directId: session._id,
-                title: session.title,
-                description: session.description,
-                type: session.type,
-                chatCategory: 'colleagues',
-                organisationId: session.organisationId,
-                createdBy: session.createdBy,
-              } as Record<string, unknown>,
-              {}
-            );
-          };
-          // Try to load the channel via query to ensure it appears in lists
-          const queried = await client.queryChannels(
-            { id: { $eq: session.channelId } },
-            [{ last_message_at: -1 }],
-            { watch: true, state: true, presence: true, limit: 1 }
-          );
-          if (queried[0]) {
-            await queried[0].watch();
-            await applyMetadata(queried[0]);
-            setIsChannelSelected(true);
-            setShowEmptyPlaceholder(false);
-            onChannelSelect?.(queried[0]);
-          } else {
-            await activateChannelById(session.channelId);
-            const chan = client.channel('team', session.channelId);
-            await applyMetadata(chan);
-          }
+          await activateSessionChannel(client, session.channelId, {
+            directId: session._id,
+            title: session.title,
+            description: session.description,
+            type: session.type,
+            chatCategory: 'colleagues',
+            organisationId: session.organisationId,
+            createdBy: session.createdBy,
+          });
           success = true;
           break;
         } catch (err) {
@@ -1637,7 +1645,7 @@ const useChatContainerView = ({
       }
       setCreatingChat(false);
     },
-    [primaryOrgId, client, activateChannelById, onChannelSelect, notify]
+    [primaryOrgId, client, activateSessionChannel, onChannelSelect, notify]
   );
 
   const handleNetworkChatStarted = useCallback(
@@ -1682,36 +1690,15 @@ const useChatContainerView = ({
           memberIds: allMembers,
           isPrivate: true,
         });
-        const applyMetadata = async (chan: StreamChannel) => {
-          await chan.update(
-            {
-              groupId: session._id,
-              title: session.title || title,
-              description: session.description,
-              type: session.type,
-              chatCategory: 'group',
-              organisationId: session.organisationId,
-              createdBy: session.createdBy,
-            } as Record<string, unknown>,
-            {}
-          );
-        };
-        const queried = await client.queryChannels(
-          { id: { $eq: session.channelId } },
-          [{ last_message_at: -1 }],
-          { watch: true, state: true, presence: true, limit: 1 }
-        );
-        if (queried[0]) {
-          await queried[0].watch();
-          await applyMetadata(queried[0]);
-          setIsChannelSelected(true);
-          setShowEmptyPlaceholder(false);
-          onChannelSelect?.(queried[0]);
-        } else {
-          await activateChannelById(session.channelId);
-          const chan = client.channel('team', session.channelId);
-          await applyMetadata(chan);
-        }
+        await activateSessionChannel(client, session.channelId, {
+          groupId: session._id,
+          title: session.title || title,
+          description: session.description,
+          type: session.type,
+          chatCategory: 'group',
+          organisationId: session.organisationId,
+          createdBy: session.createdBy,
+        });
         setGroupModalOpen(false);
       } catch (err) {
         console.error('Failed to create group', err);
@@ -1723,15 +1710,7 @@ const useChatContainerView = ({
         setGroupModalBusy(false);
       }
     },
-    [
-      primaryOrgId,
-      client,
-      activateChannelById,
-      onChannelSelect,
-      notify,
-      setGroupModalBusy,
-      setGroupModalOpen,
-    ]
+    [primaryOrgId, client, activateSessionChannel, notify, setGroupModalBusy, setGroupModalOpen]
   );
 
   const handleModalUpdateTitle = useCallback(

--- a/apps/frontend/src/app/features/companions/components/AddCompanion/Sections/Companion.tsx
+++ b/apps/frontend/src/app/features/companions/components/AddCompanion/Sections/Companion.tsx
@@ -27,6 +27,7 @@ import {
 import SearchDropdown from '@/app/ui/inputs/SearchDropdown';
 import LabelDropdown from '@/app/ui/inputs/Dropdown/LabelDropdown';
 import { CompanionType } from '@yosemite-crew/types';
+import { BLOOD_GROUP_OPTIONS_BY_SPECIES } from '@/app/features/companions/components/companionBloodGroups';
 import { useNotify } from '@/app/hooks/useNotify';
 import { useCompanionTerminologyText } from '@/app/hooks/useCompanionTerminologyText';
 import {
@@ -55,37 +56,6 @@ const DEFAULT_SPECIES_OPTIONS: SpeciesOption[] = [
   { label: 'Feline', value: 'cat', type: 'cat', speciesCode: '', speciesQuery: 'feline' },
   { label: 'Equine', value: 'horse', type: 'horse', speciesCode: '', speciesQuery: 'equine' },
 ];
-
-const BLOOD_GROUP_OPTIONS_BY_SPECIES: Record<CompanionType, OptionProp[]> = {
-  cat: ['A', 'B', 'AB', 'Unknown'].map((group) => ({
-    value: group,
-    label: group,
-  })),
-  dog: [
-    'DEA 1.1 Positive',
-    'DEA 1.1 Negative',
-    'DEA 1.2 Positive',
-    'DEA 1.2 Negative',
-    'DEA 3 Positive',
-    'DEA 3 Negative',
-    'DEA 4 Positive',
-    'DEA 4 Negative',
-    'DEA 5 Positive',
-    'DEA 5 Negative',
-    'DEA 7 Positive',
-    'DEA 7 Negative',
-    'Universal Donor',
-    'Unknown',
-  ].map((group) => ({
-    value: group,
-    label: group,
-  })),
-  horse: ['Aa', 'Ca', 'Da', 'Ka', 'Pa', 'Qa', 'Ua', 'Universal Donor', 'Unknown'].map((group) => ({
-    value: group,
-    label: group,
-  })),
-  other: [{ value: 'Unknown', label: 'Unknown' }],
-};
 
 const toNonNegativeNumber = (value: string | number | undefined) => {
   const parsed = typeof value === 'number' ? value : Number.parseFloat((value ?? '').toString());

--- a/apps/frontend/src/app/features/companions/components/AddCompanionCentralModal/index.tsx
+++ b/apps/frontend/src/app/features/companions/components/AddCompanionCentralModal/index.tsx
@@ -5,6 +5,7 @@ import AppointmentCentralModalShell from '@/app/features/appointments/components
 import BottomSheet from '@/app/ui/layout/PhoneShell/BottomSheet';
 import useIsPhone from '@/app/ui/layout/PhoneShell/useIsPhone';
 import CenterModal from '@/app/ui/overlays/Modal/CenterModal';
+import { primaryButtonGlowHandlers } from '@/app/ui/primitives/buttonGlowHandlers';
 import { useNotify } from '@/app/hooks/useNotify';
 import { useCompanionsParentsForPrimaryOrg } from '@/app/hooks/useCompanion';
 import {
@@ -942,16 +943,7 @@ const useAddCompanionCentralModalContent = ({
             type="button"
             onClick={handleDiscardAndClose}
             className="yc-primary-button rounded-2xl! px-4 py-[11px] font-satoshi text-base font-medium leading-[1.5rem]"
-            onPointerDown={(e) => {
-              const r = e.currentTarget.getBoundingClientRect();
-              e.currentTarget.style.setProperty('--yc-button-x', `${e.clientX - r.left}px`);
-              e.currentTarget.style.setProperty('--yc-button-y', `${e.clientY - r.top}px`);
-            }}
-            onPointerMove={(e) => {
-              const r = e.currentTarget.getBoundingClientRect();
-              e.currentTarget.style.setProperty('--yc-button-x', `${e.clientX - r.left}px`);
-              e.currentTarget.style.setProperty('--yc-button-y', `${e.clientY - r.top}px`);
-            }}
+            {...primaryButtonGlowHandlers}
           >
             Discard
           </button>

--- a/apps/frontend/src/app/features/companions/components/Sections/Companion.tsx
+++ b/apps/frontend/src/app/features/companions/components/Sections/Companion.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/app/features/companions/components/AddCompanion/type';
 import { CompanionType } from '@yosemite-crew/types';
 import type { RecordStatus } from '@yosemite-crew/types';
+import { BLOOD_GROUP_OPTIONS_BY_SPECIES } from '@/app/features/companions/components/companionBloodGroups';
 import {
   fetchBreedCodeEntries,
   fetchSpeciesCodeEntries,
@@ -73,37 +74,6 @@ const SPECIES_QUERY_BY_TYPE: Record<CompanionType, string> = {
   cat: 'feline',
   horse: 'equine',
   other: 'other',
-};
-
-const BLOOD_GROUP_OPTIONS_BY_SPECIES: Record<CompanionType, OptionProp[]> = {
-  cat: ['A', 'B', 'AB', 'Unknown'].map((group) => ({
-    value: group,
-    label: group,
-  })),
-  dog: [
-    'DEA 1.1 Positive',
-    'DEA 1.1 Negative',
-    'DEA 1.2 Positive',
-    'DEA 1.2 Negative',
-    'DEA 3 Positive',
-    'DEA 3 Negative',
-    'DEA 4 Positive',
-    'DEA 4 Negative',
-    'DEA 5 Positive',
-    'DEA 5 Negative',
-    'DEA 7 Positive',
-    'DEA 7 Negative',
-    'Universal Donor',
-    'Unknown',
-  ].map((group) => ({
-    value: group,
-    label: group,
-  })),
-  horse: ['Aa', 'Ca', 'Da', 'Ka', 'Pa', 'Qa', 'Ua', 'Universal Donor', 'Unknown'].map((group) => ({
-    value: group,
-    label: group,
-  })),
-  other: [{ value: 'Unknown', label: 'Unknown' }],
 };
 
 const COMPANION_STATUS_OPTIONS: OptionProp[] = [
@@ -263,8 +233,8 @@ const resolvePayloadBreedCode = (
 };
 
 const resolvePayloadDateOfBirth = (companion: CompanionParent, currentDate: Date | null): Date => {
+  /* v8 ignore next 3 -- the null fallback is unreachable: validateCompanionForm reports "Date of birth is required" and blocks the save whenever currentDate is null, so the payload is only ever built with a date */
   if (currentDate) return currentDate;
-  /* v8 ignore next -- unreachable: validateCompanionForm reports "Date of birth is required" and blocks the save whenever currentDate is null, so the payload is only ever built with a date */
   return companion.companion.dateOfBirth;
 };
 

--- a/apps/frontend/src/app/features/companions/components/companionBloodGroups.ts
+++ b/apps/frontend/src/app/features/companions/components/companionBloodGroups.ts
@@ -1,0 +1,37 @@
+import type { CompanionType } from '@yosemite-crew/types';
+
+type OptionProp = {
+  label: string;
+  value: string;
+};
+
+export const BLOOD_GROUP_OPTIONS_BY_SPECIES: Record<CompanionType, OptionProp[]> = {
+  cat: ['A', 'B', 'AB', 'Unknown'].map((group) => ({
+    value: group,
+    label: group,
+  })),
+  dog: [
+    'DEA 1.1 Positive',
+    'DEA 1.1 Negative',
+    'DEA 1.2 Positive',
+    'DEA 1.2 Negative',
+    'DEA 3 Positive',
+    'DEA 3 Negative',
+    'DEA 4 Positive',
+    'DEA 4 Negative',
+    'DEA 5 Positive',
+    'DEA 5 Negative',
+    'DEA 7 Positive',
+    'DEA 7 Negative',
+    'Universal Donor',
+    'Unknown',
+  ].map((group) => ({
+    value: group,
+    label: group,
+  })),
+  horse: ['Aa', 'Ca', 'Da', 'Ka', 'Pa', 'Qa', 'Ua', 'Universal Donor', 'Unknown'].map((group) => ({
+    value: group,
+    label: group,
+  })),
+  other: [{ value: 'Unknown', label: 'Unknown' }],
+};

--- a/apps/frontend/src/app/features/companions/pages/Companions/types.ts
+++ b/apps/frontend/src/app/features/companions/pages/Companions/types.ts
@@ -45,6 +45,30 @@ export const status = (
   dropdownText?: string
 ): StatusOption => ({ name, key, bg, text, border: border ?? bg, dropdownText });
 
+/**
+ * Build a StatusOption whose bg/text/border all derive from one CSS custom-property
+ * prefix (`--<cssPrefix>-bg` / `-text` / `-border`), so status tables stay one line
+ * per entry instead of repeating three var() literals each.
+ */
+export const statusFromToken = (name: string, key: string, cssPrefix: string): StatusOption =>
+  status(
+    name,
+    key,
+    `var(--${cssPrefix}-bg)`,
+    `var(--${cssPrefix}-text)`,
+    `var(--${cssPrefix}-border)`
+  );
+
+/** Like statusFromToken, but also reuses the derived text token as dropdownText. */
+export const dropdownStatusFromToken = (
+  name: string,
+  key: string,
+  cssPrefix: string
+): StatusOption => ({
+  ...statusFromToken(name, key, cssPrefix),
+  dropdownText: `var(--${cssPrefix}-text)`,
+});
+
 export const CompanionsSpeciesFilters: FilterOption[] = [
   filter('All', 'all'),
   filter('Canine', 'dog'),

--- a/apps/frontend/src/app/features/documents/types/companionDocuments.ts
+++ b/apps/frontend/src/app/features/documents/types/companionDocuments.ts
@@ -1,116 +1,42 @@
 import { Option } from '@/app/features/companions/types/companion';
+import { makeOptions } from '@/app/lib/options';
 
-export const CategoryOptions: Option[] = [
-  {
-    label: 'Health',
-    value: 'HEALTH',
-  },
-  {
-    label: 'Hygiene maintenance',
-    value: 'HYGIENE_MAINTENANCE',
-  },
-];
+export const CategoryOptions: Option[] = makeOptions([
+  ['Health', 'HEALTH'],
+  ['Hygiene maintenance', 'HYGIENE_MAINTENANCE'],
+]);
 
-export const HealthCategoryOptions: Option[] = [
-  {
-    label: 'Surgery/ Procedure',
-    value: 'SURGERY_PROCEDURE',
-  },
-  {
-    label: 'Prescription',
-    value: 'PRESCRIPTION',
-  },
-  {
-    label: 'Vaccination',
-    value: 'VACCINATION',
-  },
-  {
-    label: 'Discharge summary',
-    value: 'DISCHARGE_SUMMARY',
-  },
-  {
-    label: 'Lab test',
-    value: 'LAB_TEST',
-  },
-  {
-    label: 'Imaging/ Diagnostic',
-    value: 'IMAGING_DIAGNOSTIC',
-  },
-  {
-    label: 'Parasite prevention',
-    value: 'PARASITE_PREVENTION',
-  },
-  {
-    label: 'Medical condition',
-    value: 'MEDICAL_CONDITION',
-  },
-  {
-    label: 'Other',
-    value: 'OTHER',
-  },
-];
+export const HealthCategoryOptions: Option[] = makeOptions([
+  ['Surgery/ Procedure', 'SURGERY_PROCEDURE'],
+  ['Prescription', 'PRESCRIPTION'],
+  ['Vaccination', 'VACCINATION'],
+  ['Discharge summary', 'DISCHARGE_SUMMARY'],
+  ['Lab test', 'LAB_TEST'],
+  ['Imaging/ Diagnostic', 'IMAGING_DIAGNOSTIC'],
+  ['Parasite prevention', 'PARASITE_PREVENTION'],
+  ['Medical condition', 'MEDICAL_CONDITION'],
+  ['Other', 'OTHER'],
+]);
 
-export const HygieneCategoryOptions: Option[] = [
-  {
-    label: 'Bathing',
-    value: 'BATHING',
-  },
-  {
-    label: 'Nail trim',
-    value: 'NAIL_TRIM',
-  },
-  {
-    label: 'Grooming',
-    value: 'GROOMING',
-  },
-  {
-    label: 'Ear cleaning',
-    value: 'EAR_CLEANING',
-  },
-  {
-    label: 'Dental cleaning',
-    value: 'DENTAL_CLEANING',
-  },
-  {
-    label: 'Skin care',
-    value: 'SKIN_CARE',
-  },
-  {
-    label: 'Anal gland expression',
-    value: 'ANAL_GLAND_EXPRESSION',
-  },
-  {
-    label: 'Other',
-    value: 'OTHER',
-  },
-];
+export const HygieneCategoryOptions: Option[] = makeOptions([
+  ['Bathing', 'BATHING'],
+  ['Nail trim', 'NAIL_TRIM'],
+  ['Grooming', 'GROOMING'],
+  ['Ear cleaning', 'EAR_CLEANING'],
+  ['Dental cleaning', 'DENTAL_CLEANING'],
+  ['Skin care', 'SKIN_CARE'],
+  ['Anal gland expression', 'ANAL_GLAND_EXPRESSION'],
+  ['Other', 'OTHER'],
+]);
 
-export const VisitTypeOptions: Option[] = [
-  {
-    label: 'Hospital',
-    value: 'HOSPITAL',
-  },
-  {
-    label: 'Groomer',
-    value: 'GROOMER',
-  },
-  {
-    label: 'Boarder',
-    value: 'BOARDER',
-  },
-  {
-    label: 'Breeder',
-    value: 'BREEDER',
-  },
-  {
-    label: 'Shop',
-    value: 'SHOP',
-  },
-  {
-    label: 'Other',
-    value: 'OTHER',
-  },
-];
+export const VisitTypeOptions: Option[] = makeOptions([
+  ['Hospital', 'HOSPITAL'],
+  ['Groomer', 'GROOMER'],
+  ['Boarder', 'BOARDER'],
+  ['Breeder', 'BREEDER'],
+  ['Shop', 'SHOP'],
+  ['Other', 'OTHER'],
+]);
 
 export type Attachment = {
   key: string;

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoicePaymentLedger.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoicePaymentLedger.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { Invoice } from '@yosemite-crew/types';
-import { IoCardOutline, IoCheckmarkCircle, IoPhonePortraitOutline } from 'react-icons/io5';
+import { IoCheckmarkCircle } from 'react-icons/io5';
 import { formatMoney } from '@/app/lib/money';
 import { formatDateLabel, formatTimeLabel } from '@/app/lib/forms';
 import { getInvoicePaymentMethodLabel } from '@/app/lib/invoicePaymentMethod';
+import { getLedgerChannel } from '@/app/features/finance/pages/Finance/Sections/ledgerChannel';
 
 type InvoicePaymentLedgerProps = {
   invoice: Invoice;
@@ -16,28 +17,6 @@ const SETTLED_STATUSES = new Set(['PAID', 'REFUNDED']);
 
 const isSettledInvoice = (invoice: Invoice): boolean =>
   SETTLED_STATUSES.has(invoice.status) || Boolean(invoice.paidAt);
-
-type LedgerChannel = {
-  Icon: typeof IoCardOutline;
-  title: string;
-};
-
-/**
- * The design labels the payment row by the channel it came through rather than
- * with a generic "Payment recorded": an app/link payment reads "Paid in the
- * pet-parent app" behind a phone glyph, an at-the-desk payment reads "Paid at
- * the clinic" behind a card glyph.
- */
-const getLedgerChannel = (invoice: Invoice): LedgerChannel => {
-  const method = invoice.paymentCollectionMethod;
-  if (method === 'PAYMENT_INTENT' || method === 'PAYMENT_LINK') {
-    return { Icon: IoPhonePortraitOutline, title: 'Paid in the pet-parent app' };
-  }
-  if (method === 'PAYMENT_AT_CLINIC') {
-    return { Icon: IoCardOutline, title: 'Paid at the clinic' };
-  }
-  return { Icon: IoCardOutline, title: 'Payment recorded' };
-};
 
 const buildLedgerCaption = (invoice: Invoice, payerName?: string): string => {
   const methodLabel = getInvoicePaymentMethodLabel(invoice);

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoicePhoneRecord.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoicePhoneRecord.tsx
@@ -2,14 +2,7 @@
 import React from 'react';
 import Image from 'next/image';
 import { Appointment, Invoice } from '@yosemite-crew/types';
-import {
-  IoCardOutline,
-  IoCheckmarkCircle,
-  IoClose,
-  IoDownloadOutline,
-  IoOpenOutline,
-  IoPhonePortraitOutline,
-} from 'react-icons/io5';
+import { IoCheckmarkCircle, IoClose, IoDownloadOutline, IoOpenOutline } from 'react-icons/io5';
 import StatusPill, { type StatusTone } from '@/app/ui/primitives/StatusPill/StatusPill';
 import { formatMoney } from '@/app/lib/money';
 import { formatDateLabel, formatTimeLabel } from '@/app/lib/forms';
@@ -18,6 +11,7 @@ import { getInvoicePaymentMethodLabel } from '@/app/lib/invoicePaymentMethod';
 import { getSafeImageUrl, ImageType } from '@/app/lib/urls';
 import { getAppointmentCompanion, getAppointmentCompanionPhotoUrl } from '@/app/lib/appointments';
 import { formatCompanionNameWithOwnerLastName } from '@/app/lib/companionName';
+import { getLedgerChannel } from '@/app/features/finance/pages/Finance/Sections/ledgerChannel';
 
 type InvoicePhoneRecordProps = {
   titleId: string;
@@ -52,26 +46,6 @@ const buildSubtitle = (invoice: Invoice, appointment?: Appointment): string => {
     .map((part) => part.trim())
     .filter(Boolean)
     .join(' · ');
-};
-
-type LedgerChannel = {
-  Icon: typeof IoCardOutline;
-  title: string;
-};
-
-/**
- * Mirrors the desktop record: the payment row is labelled by the channel the
- * payment came through, so the same invoice reads the same way at every width.
- */
-const getLedgerChannel = (invoice: Invoice): LedgerChannel => {
-  const method = invoice.paymentCollectionMethod;
-  if (method === 'PAYMENT_INTENT' || method === 'PAYMENT_LINK') {
-    return { Icon: IoPhonePortraitOutline, title: 'Paid in the pet-parent app' };
-  }
-  if (method === 'PAYMENT_AT_CLINIC') {
-    return { Icon: IoCardOutline, title: 'Paid at the clinic' };
-  }
-  return { Icon: IoCardOutline, title: 'Payment recorded' };
 };
 
 const buildLedgerCaption = (invoice: Invoice, payerName?: string): string => {

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/ledgerChannel.ts
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/ledgerChannel.ts
@@ -1,0 +1,25 @@
+import { Invoice } from '@yosemite-crew/types';
+import { IoCardOutline, IoPhonePortraitOutline } from 'react-icons/io5';
+
+export type LedgerChannel = {
+  Icon: typeof IoCardOutline;
+  title: string;
+};
+
+/**
+ * The design labels the payment row by the channel it came through rather than
+ * with a generic "Payment recorded": an app/link payment reads "Paid in the
+ * pet-parent app" behind a phone glyph, an at-the-desk payment reads "Paid at
+ * the clinic" behind a card glyph. Shared by the desktop ledger and the phone
+ * record so the same invoice reads the same way at every width.
+ */
+export const getLedgerChannel = (invoice: Invoice): LedgerChannel => {
+  const method = invoice.paymentCollectionMethod;
+  if (method === 'PAYMENT_INTENT' || method === 'PAYMENT_LINK') {
+    return { Icon: IoPhonePortraitOutline, title: 'Paid in the pet-parent app' };
+  }
+  if (method === 'PAYMENT_AT_CLINIC') {
+    return { Icon: IoCardOutline, title: 'Paid at the clinic' };
+  }
+  return { Icon: IoCardOutline, title: 'Payment recorded' };
+};

--- a/apps/frontend/src/app/features/finance/types/invoice.ts
+++ b/apps/frontend/src/app/features/finance/types/invoice.ts
@@ -1,5 +1,8 @@
 import { InvoiceStatus } from '@yosemite-crew/types';
-import { StatusOption, status } from '@/app/features/companions/pages/Companions/types';
+import {
+  StatusOption,
+  dropdownStatusFromToken,
+} from '@/app/features/companions/pages/Companions/types';
 
 export const InvoiceStatusOptions: InvoiceStatus[] = [
   'PENDING',
@@ -11,60 +14,11 @@ export const InvoiceStatusOptions: InvoiceStatus[] = [
 ];
 
 export const InvoiceStatusFilters: StatusOption[] = [
-  status(
-    'All',
-    'all',
-    'var(--color-pill-neutral-bg)',
-    'var(--color-pill-neutral-text)',
-    'var(--color-pill-neutral-border)',
-    'var(--color-pill-neutral-text)'
-  ),
-  status(
-    'Pending',
-    'pending',
-    'var(--color-pill-neutral-bg)',
-    'var(--color-pill-neutral-text)',
-    'var(--color-pill-neutral-border)',
-    'var(--color-pill-neutral-text)'
-  ),
-  status(
-    'Awaiting payment',
-    'awaiting_payment',
-    'var(--color-pill-info-bg)',
-    'var(--color-pill-info-text)',
-    'var(--color-pill-info-border)',
-    'var(--color-pill-info-text)'
-  ),
-  status(
-    'Paid',
-    'paid',
-    'var(--color-pill-success-bg)',
-    'var(--color-pill-success-text)',
-    'var(--color-pill-success-border)',
-    'var(--color-pill-success-text)'
-  ),
-  status(
-    'Failed',
-    'failed',
-    'var(--color-pill-warning-bg)',
-    'var(--color-pill-warning-text)',
-    'var(--color-pill-warning-border)',
-    'var(--color-pill-warning-text)'
-  ),
-  status(
-    'Cancelled',
-    'cancelled',
-    'var(--color-pill-warning-bg)',
-    'var(--color-pill-warning-text)',
-    'var(--color-pill-warning-border)',
-    'var(--color-pill-warning-text)'
-  ),
-  status(
-    'Refunded',
-    'refunded',
-    'var(--color-pill-progress-bg)',
-    'var(--color-pill-progress-text)',
-    'var(--color-pill-progress-border)',
-    'var(--color-pill-progress-text)'
-  ),
+  dropdownStatusFromToken('All', 'all', 'color-pill-neutral'),
+  dropdownStatusFromToken('Pending', 'pending', 'color-pill-neutral'),
+  dropdownStatusFromToken('Awaiting payment', 'awaiting_payment', 'color-pill-info'),
+  dropdownStatusFromToken('Paid', 'paid', 'color-pill-success'),
+  dropdownStatusFromToken('Failed', 'failed', 'color-pill-warning'),
+  dropdownStatusFromToken('Cancelled', 'cancelled', 'color-pill-warning'),
+  dropdownStatusFromToken('Refunded', 'refunded', 'color-pill-progress'),
 ];

--- a/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/Build.tsx
+++ b/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/Build.tsx
@@ -95,63 +95,23 @@ type OptionProp = {
   key: OptionKey;
 };
 
+const opt = (name: string, key: OptionKey): OptionProp => ({ name, key });
+
 const addOptions: OptionProp[] = [
-  {
-    name: 'Long Text',
-    key: 'textarea',
-  },
-  {
-    name: 'Rich Text',
-    key: 'richtext',
-  },
-  {
-    name: 'Short Text',
-    key: 'input',
-  },
-  {
-    name: 'Number',
-    key: 'number',
-  },
-  {
-    name: 'Select List',
-    key: 'dropdown',
-  },
-  {
-    name: 'Single Choice',
-    key: 'radio',
-  },
-  {
-    name: 'Multiple Choice',
-    key: 'checkbox',
-  },
-  {
-    name: 'Yes / No',
-    key: 'boolean',
-  },
-  {
-    name: 'Date',
-    key: 'date',
-  },
-  {
-    name: 'Signature',
-    key: 'signature',
-  },
-  {
-    name: 'Field Group',
-    key: 'group',
-  },
-  {
-    name: 'Medications',
-    key: 'medication',
-  },
-  {
-    name: 'Services / Packages',
-    key: 'service-group',
-  },
-  {
-    name: 'Tasks',
-    key: 'task-group',
-  },
+  opt('Long Text', 'textarea'),
+  opt('Rich Text', 'richtext'),
+  opt('Short Text', 'input'),
+  opt('Number', 'number'),
+  opt('Select List', 'dropdown'),
+  opt('Single Choice', 'radio'),
+  opt('Multiple Choice', 'checkbox'),
+  opt('Yes / No', 'boolean'),
+  opt('Date', 'date'),
+  opt('Signature', 'signature'),
+  opt('Field Group', 'group'),
+  opt('Medications', 'medication'),
+  opt('Services / Packages', 'service-group'),
+  opt('Tasks', 'task-group'),
 ];
 
 type BuilderComponentProps = {

--- a/apps/frontend/src/app/features/forms/services/templateFormsService.ts
+++ b/apps/frontend/src/app/features/forms/services/templateFormsService.ts
@@ -1,30 +1,14 @@
 import axios from 'axios';
-import type { TemplateKind, TemplateLike, TemplateUpsertInput } from '@yosemite-crew/types';
+import type { TemplateLike, TemplateUpsertInput } from '@yosemite-crew/types';
 import { deleteData, getData, patchData, postData } from '@/app/services/axios';
 import { buildTemplatePayload, mapTemplateToUI } from '@/app/lib/forms';
 import type { FormsProps } from '@/app/features/forms/types/forms';
 import { useFormsStore } from '@/app/stores/formsStore';
-
-type TemplateListParams = {
-  kind?: TemplateKind;
-  status?: string;
-  scope?: string;
-};
-
-const listTemplates = async (url: string, params: TemplateListParams = {}) => {
-  const res = await getData<TemplateLike[]>(url, params);
-  return Array.isArray(res.data) ? res.data : [];
-};
-
-const dedupeTemplates = (templates: TemplateLike[]) => {
-  const byId = new Map<string, TemplateLike>();
-  for (const template of templates) {
-    if (template?.id) {
-      byId.set(template.id, template);
-    }
-  }
-  return [...byId.values()];
-};
+import {
+  dedupeTemplates,
+  listTemplates,
+  type TemplateListParams,
+} from '@/app/features/forms/services/templateListShared';
 
 export const loadTemplateForms = async (
   organisationId: string,

--- a/apps/frontend/src/app/features/forms/services/templateListShared.ts
+++ b/apps/frontend/src/app/features/forms/services/templateListShared.ts
@@ -1,0 +1,25 @@
+import type { TemplateKind, TemplateLike } from '@yosemite-crew/types';
+import { getData } from '@/app/services/axios';
+
+// Shared between the forms module (templateFormsService) and the appointment workspace
+// (workspaceTemplateService), which list the same PMS template endpoints.
+export type TemplateListParams = {
+  kind?: TemplateKind;
+  status?: string;
+  scope?: string;
+};
+
+export const listTemplates = async (url: string, params: TemplateListParams = {}) => {
+  const res = await getData<TemplateLike[]>(url, params);
+  return Array.isArray(res.data) ? res.data : [];
+};
+
+export const dedupeTemplates = (templates: TemplateLike[]) => {
+  const byId = new Map<string, TemplateLike>();
+  for (const template of templates) {
+    if (template?.id) {
+      byId.set(template.id, template);
+    }
+  }
+  return [...byId.values()];
+};

--- a/apps/frontend/src/app/features/forms/types/forms.ts
+++ b/apps/frontend/src/app/features/forms/types/forms.ts
@@ -508,35 +508,14 @@ export const CategoryTemplates: Record<FormsCategory, FormField[]> = {
       type: 'group',
       label: 'Boarding options',
       fields: [
-        {
-          id: 'day_boarding_services',
-          type: 'checkbox',
-          label: 'Day boarding services',
-          multiple: true,
-          options: [
-            makeOption('Day care options', 'day_care_options'),
-            makeOption('Overnight stay details', 'overnight_stay_details'),
-            makeOption('Weekly boarding plans', 'weekly_boarding_plans'),
-          ],
-        },
-        {
-          id: 'overnight_boarding_services',
-          type: 'radio',
-          label: 'Overnight boarding services',
-          options: [makeOption('Yes', 'yes'), makeOption('No', 'no')],
-        },
-        {
-          id: 'long_term_boarding',
-          type: 'radio',
-          label: 'Long-term boarding options',
-          options: [makeOption('Yes', 'yes'), makeOption('No', 'no')],
-        },
-        {
-          id: 'special_needs_boarding',
-          type: 'radio',
-          label: 'Special needs boarding services',
-          options: [makeOption('Yes', 'yes'), makeOption('No', 'no')],
-        },
+        checkboxField('day_boarding_services', 'Day boarding services', [
+          makeOption('Day care options', 'day_care_options'),
+          makeOption('Overnight stay details', 'overnight_stay_details'),
+          makeOption('Weekly boarding plans', 'weekly_boarding_plans'),
+        ]),
+        yesNoRadio('overnight_boarding_services', 'Overnight boarding services'),
+        yesNoRadio('long_term_boarding', 'Long-term boarding options'),
+        yesNoRadio('special_needs_boarding', 'Special needs boarding services'),
       ],
     },
     {
@@ -544,29 +523,13 @@ export const CategoryTemplates: Record<FormsCategory, FormField[]> = {
       type: 'group',
       label: 'Additional services and monitoring',
       fields: [
-        {
-          id: 'cctv_live_updates',
-          type: 'radio',
-          label: 'CCTV and live updates',
-          options: [makeOption('Yes', 'yes'), makeOption('No', 'no')],
-        },
-        {
-          id: 'health_checks_during_stay',
-          type: 'radio',
-          label: 'Health checks during stay',
-          options: [makeOption('Yes', 'yes'), makeOption('No', 'no')],
-        },
-        {
-          id: 'pickup_dropoff',
-          type: 'checkbox',
-          label: 'Pickup and drop-off services',
-          multiple: true,
-          options: [
-            makeOption('Pickup service', 'pickup_service'),
-            makeOption('Drop-Off service', 'dropoff_service'),
-            makeOption('Both services', 'both_services'),
-          ],
-        },
+        yesNoRadio('cctv_live_updates', 'CCTV and live updates'),
+        yesNoRadio('health_checks_during_stay', 'Health checks during stay'),
+        checkboxField('pickup_dropoff', 'Pickup and drop-off services', [
+          makeOption('Pickup service', 'pickup_service'),
+          makeOption('Drop-Off service', 'dropoff_service'),
+          makeOption('Both services', 'both_services'),
+        ]),
       ],
     },
     {
@@ -574,63 +537,38 @@ export const CategoryTemplates: Record<FormsCategory, FormField[]> = {
       type: 'group',
       label: 'Comfort and environment',
       fields: [
-        {
-          id: 'room_type_selection',
-          type: 'radio',
-          label: 'Room type selection',
-          options: [
-            makeOption('Standard room', 'standard_room'),
-            makeOption('Premium room', 'premium_room'),
-            makeOption('Suite room', 'suite_room'),
-          ],
-        },
-        {
-          id: 'playgroup_participation',
-          type: 'radio',
-          label: 'Playgroup participation options',
-          options: [
-            makeOption('Participate', 'participate'),
-            makeOption('Do not participate', 'do_not_participate'),
-          ],
-        },
-        {
-          id: 'bedding_preferences',
-          type: 'radio',
-          label: 'Bedding preferences',
-          options: [
-            makeOption('Facility bedding', 'facility_bedding'),
-            makeOption('Own bedding', 'own_bedding'),
-            makeOption('Orthopaedic bedding', 'orthopaedic_bedding'),
-          ],
-        },
+        radioField('room_type_selection', 'Room type selection', [
+          makeOption('Standard room', 'standard_room'),
+          makeOption('Premium room', 'premium_room'),
+          makeOption('Suite room', 'suite_room'),
+        ]),
+        radioField('playgroup_participation', 'Playgroup participation options', [
+          makeOption('Participate', 'participate'),
+          makeOption('Do not participate', 'do_not_participate'),
+        ]),
+        radioField('bedding_preferences', 'Bedding preferences', [
+          makeOption('Facility bedding', 'facility_bedding'),
+          makeOption('Own bedding', 'own_bedding'),
+          makeOption('Orthopaedic bedding', 'orthopaedic_bedding'),
+        ]),
       ],
     },
   ],
   'Boarder - Dietary Plan': [
-    {
-      id: 'dietary_type',
-      type: 'radio',
-      label: 'Dietary type',
-      options: [
-        makeOption('Commercial / Packaged Food', 'commercial_packaged'),
-        makeOption('Raw or Natural Diet', 'raw_natural'),
-        makeOption('Home-Cooked Meals', 'home_cooked'),
-        makeOption('Vegetarian / Vegan', 'vegetarian_vegan'),
-      ],
-    },
+    radioField('dietary_type', 'Dietary type', [
+      makeOption('Commercial / Packaged Food', 'commercial_packaged'),
+      makeOption('Raw or Natural Diet', 'raw_natural'),
+      makeOption('Home-Cooked Meals', 'home_cooked'),
+      makeOption('Vegetarian / Vegan', 'vegetarian_vegan'),
+    ]),
     { id: 'diet_special_notes', type: 'textarea', label: 'Special notes' },
     frequencyRadio('feeding_frequency', 'Feeding frequency and timing'),
     { id: 'specific_feeding_times', type: 'textarea', label: 'Specific feeding times' },
-    {
-      id: 'portion_preferences',
-      type: 'radio',
-      label: 'Portion preferences',
-      options: [
-        makeOption('Fixed weight per meal (grams or cups)', 'fixed_weight'),
-        makeOption('“Until full” feeding', 'until_full'),
-        makeOption('Measured scoop or bowl (parent-defined)', 'measured_scoop'),
-      ],
-    },
+    radioField('portion_preferences', 'Portion preferences', [
+      makeOption('Fixed weight per meal (grams or cups)', 'fixed_weight'),
+      makeOption('“Until full” feeding', 'until_full'),
+      makeOption('Measured scoop or bowl (parent-defined)', 'measured_scoop'),
+    ]),
     { id: 'portion_special_notes', type: 'textarea', label: 'Special notes' },
     {
       id: 'brand_preferences',
@@ -638,44 +576,28 @@ export const CategoryTemplates: Record<FormsCategory, FormField[]> = {
       label: 'Brand preferences',
       placeholder: 'Write brand names here',
     },
-    {
-      id: 'feeding_method',
-      type: 'radio',
-      label: 'Feeding method preferences',
-      options: [
-        makeOption('Hand-feeding', 'hand_feeding'),
-        makeOption('Self-feeding bowl', 'self_feeding'),
-        makeOption('Separate feeding area (for anxious companions)', 'separate_area'),
-        makeOption('Eat with other companion', 'eat_with_others'),
-        makeOption('Heated / room-temperature food', 'heated_or_room_temp'),
-      ],
-    },
+    radioField('feeding_method', 'Feeding method preferences', [
+      makeOption('Hand-feeding', 'hand_feeding'),
+      makeOption('Self-feeding bowl', 'self_feeding'),
+      makeOption('Separate feeding area (for anxious companions)', 'separate_area'),
+      makeOption('Eat with other companion', 'eat_with_others'),
+      makeOption('Heated / room-temperature food', 'heated_or_room_temp'),
+    ]),
     { id: 'feeding_method_notes', type: 'textarea', label: 'Special notes' },
-    {
-      id: 'treat_preferences',
-      type: 'checkbox',
-      label: 'Treat preferences',
-      multiple: true,
-      options: [
-        makeOption('Jerky treats', 'jerky'),
-        makeOption('Dental sticks', 'dental_sticks'),
-        makeOption('Dehydrated meat', 'dehydrated_meat'),
-        makeOption('Homemade treats', 'homemade'),
-        makeOption('Training treats only', 'training_only'),
-        makeOption('No treats (parent restricted)', 'no_treats'),
-      ],
-    },
-    {
-      id: 'water_preferences',
-      type: 'radio',
-      label: 'Water preferences',
-      options: [
-        makeOption('Filtered / RO water only', 'filtered_ro'),
-        makeOption('Regular tap water', 'tap_water'),
-        makeOption('Bottled mineral water', 'bottled_mineral'),
-        makeOption('Mix with electrolytes', 'electrolytes_mix'),
-      ],
-    },
+    checkboxField('treat_preferences', 'Treat preferences', [
+      makeOption('Jerky treats', 'jerky'),
+      makeOption('Dental sticks', 'dental_sticks'),
+      makeOption('Dehydrated meat', 'dehydrated_meat'),
+      makeOption('Homemade treats', 'homemade'),
+      makeOption('Training treats only', 'training_only'),
+      makeOption('No treats (parent restricted)', 'no_treats'),
+    ]),
+    radioField('water_preferences', 'Water preferences', [
+      makeOption('Filtered / RO water only', 'filtered_ro'),
+      makeOption('Regular tap water', 'tap_water'),
+      makeOption('Bottled mineral water', 'bottled_mineral'),
+      makeOption('Mix with electrolytes', 'electrolytes_mix'),
+    ]),
     {
       id: 'water_additional_info',
       type: 'textarea',
@@ -714,60 +636,40 @@ export const CategoryTemplates: Record<FormsCategory, FormField[]> = {
   ],
   'Boarder - Daily Summary': [
     { id: 'summary_date', type: 'date', label: 'Daily summary date' },
-    {
-      id: 'meals_provided',
-      type: 'radio',
-      label: 'Meals provided to companion',
-      options: [
-        makeOption('Administered 1x daily', '1x_daily'),
-        makeOption('Administered 2x daily', '2x_daily'),
-        makeOption('Administered 3x daily', '3x_daily'),
-      ],
-    },
+    radioField('meals_provided', 'Meals provided to companion', [
+      makeOption('Administered 1x daily', '1x_daily'),
+      makeOption('Administered 2x daily', '2x_daily'),
+      makeOption('Administered 3x daily', '3x_daily'),
+    ]),
     { id: 'meals_additional_notes', type: 'textarea', label: 'Additional Notes / Activity report' },
-    {
-      id: 'medication_administered',
-      type: 'radio',
-      label: 'Medication administered today',
-      options: [makeOption('Scheduled time entry', 'scheduled_time')],
-    },
+    radioField('medication_administered', 'Medication administered today', [
+      makeOption('Scheduled time entry', 'scheduled_time'),
+    ]),
     {
       id: 'medication_additional_notes',
       type: 'textarea',
       label: 'Additional Notes / Activity report',
     },
-    {
-      id: 'daily_walk_completed',
-      type: 'radio',
-      label: 'Daily companion walk completed',
-      options: [
-        makeOption('Completed 1x', '1x'),
-        makeOption('Completed 2x', '2x'),
-        makeOption('Completed 3x', '3x'),
-      ],
-    },
+    radioField('daily_walk_completed', 'Daily companion walk completed', [
+      makeOption('Completed 1x', '1x'),
+      makeOption('Completed 2x', '2x'),
+      makeOption('Completed 3x', '3x'),
+    ]),
     { id: 'walk_additional_notes', type: 'textarea', label: 'Additional Notes / Activity report' },
-    {
-      id: 'daily_exercise_completed',
-      type: 'radio',
-      label: 'Daily exercise completed',
-      options: [
-        makeOption('Completed 1x', '1x'),
-        makeOption('Completed 2x', '2x'),
-        makeOption('Completed 3x', '3x'),
-      ],
-    },
+    radioField('daily_exercise_completed', 'Daily exercise completed', [
+      makeOption('Completed 1x', '1x'),
+      makeOption('Completed 2x', '2x'),
+      makeOption('Completed 3x', '3x'),
+    ]),
     {
       id: 'exercise_additional_notes',
       type: 'textarea',
       label: 'Additional Notes / Activity report',
     },
-    {
-      id: 'daily_poop_completed',
-      type: 'radio',
-      label: 'Daily pooping completed',
-      options: [makeOption('Completed 1x', '1x'), makeOption('Completed 2x', '2x')],
-    },
+    radioField('daily_poop_completed', 'Daily pooping completed', [
+      makeOption('Completed 1x', '1x'),
+      makeOption('Completed 2x', '2x'),
+    ]),
     { id: 'poop_additional_notes', type: 'textarea', label: 'Additional Notes / Activity report' },
     { id: 'pet_behavior_summary', type: 'textarea', label: 'companion behavior summary' },
     { id: 'additional_expense', type: 'textarea', label: 'Additional expense' },

--- a/apps/frontend/src/app/features/inventory/components/AddInventory/FormSection.tsx
+++ b/apps/frontend/src/app/features/inventory/components/AddInventory/FormSection.tsx
@@ -29,33 +29,7 @@ import {
   getStockValue,
   toNumberSafe,
 } from '@/app/features/inventory/pages/Inventory/utils';
-
-const parseDate = (value?: string): Date | null => {
-  if (!value) return null;
-
-  if (value.includes('/')) {
-    const [dd, mm, yyyy] = value.split('/');
-    const parsed = new Date(Date.UTC(Number(yyyy), Number(mm) - 1, Number(dd)));
-    if (!Number.isNaN(parsed.getTime())) return parsed;
-  }
-
-  const isoMatch = /^(\d{4})-(\d{2})-(\d{2})/.exec(value);
-  if (isoMatch) {
-    const [, yyyy, mm, dd] = isoMatch;
-    const parsed = new Date(Date.UTC(Number(yyyy), Number(mm) - 1, Number(dd)));
-    if (!Number.isNaN(parsed.getTime())) return parsed;
-  }
-
-  const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? null : date;
-};
-
-const formatDate = (date: Date) => {
-  const yyyy = date.getFullYear();
-  const mm = String(date.getMonth() + 1).padStart(2, '0');
-  const dd = String(date.getDate()).padStart(2, '0');
-  return `${yyyy}-${mm}-${dd}`;
-};
+import { formatDate, parseDate } from '@/app/features/inventory/components/inventoryInfoHelpers';
 
 type FormSectionProps = {
   businessType: BusinessType;

--- a/apps/frontend/src/app/features/inventory/components/AddInventory/InventoryConfig.tsx
+++ b/apps/frontend/src/app/features/inventory/components/AddInventory/InventoryConfig.tsx
@@ -34,21 +34,10 @@ import {
 import { BusinessType } from '@/app/features/organization/types/org';
 
 export type FieldComponentType =
-  | 'text'
-  | 'dropdown'
-  | 'textarea'
-  | 'date'
-  | 'multiSelect'
-  | 'checkbox'
-  | 'upload';
+  'text' | 'dropdown' | 'textarea' | 'date' | 'multiSelect' | 'checkbox' | 'upload';
 
 export type InventorySectionKey =
-  | 'basicInfo'
-  | 'classification'
-  | 'pricing'
-  | 'vendor'
-  | 'stock'
-  | 'batch';
+  'basicInfo' | 'classification' | 'pricing' | 'vendor' | 'stock' | 'batch';
 
 export type FieldNameForSection<S extends InventorySectionKey> = keyof InventoryItem[S] & string;
 
@@ -63,8 +52,7 @@ export type FieldDef<S extends InventorySectionKey = InventorySectionKey> = {
 };
 
 export type ConfigItem<S extends InventorySectionKey = InventorySectionKey> =
-  | { kind: 'field'; field: FieldDef<S> }
-  | { kind: 'row'; fields: FieldDef<S>[] };
+  { kind: 'field'; field: FieldDef<S> } | { kind: 'row'; fields: FieldDef<S>[] };
 
 export type SectionConfig<S extends InventorySectionKey = InventorySectionKey> = ConfigItem<S>[];
 
@@ -97,6 +85,25 @@ const readonlyF = <S extends InventorySectionKey>(
   placeholder: string,
   component: FieldComponentType = 'text'
 ): FieldDef<S> => ({ name, placeholder, component, readonly: true });
+
+const formPresentationField = field<'classification'>(
+  'form',
+  'Form / Presentation',
+  'dropdown',
+  FormOptions
+);
+
+const speciesAdministrationRow = row<'classification'>(
+  f('species', 'Species', 'multiSelect', SpeciesOptions),
+  f('administration', 'Administration', 'dropdown', AdminstrationOptions)
+);
+
+const unitOfMeasureBaseField = field<'classification'>(
+  'unitofMeasure',
+  'Unit of Measure (Base)',
+  'dropdown',
+  UnitOptions
+);
 
 const commonPricingFields: SectionConfig<'pricing'> = [
   field('purchaseCost', 'Unit cost', 'text', undefined, true),
@@ -390,68 +397,12 @@ export const InventoryFormConfig: Record<
       },
     ],
     classification: [
-      {
-        kind: 'field',
-        field: {
-          name: 'form',
-          placeholder: 'Form / Presentation',
-          component: 'dropdown',
-          options: FormOptions,
-        },
-      },
-      {
-        kind: 'row',
-        fields: [
-          {
-            name: 'species',
-            placeholder: 'Species',
-            component: 'multiSelect',
-            options: SpeciesOptions,
-          },
-          {
-            name: 'administration',
-            placeholder: 'Administration',
-            component: 'dropdown',
-            options: AdminstrationOptions,
-          },
-        ],
-      },
-      {
-        kind: 'field',
-        field: {
-          name: 'unitofMeasure',
-          placeholder: 'Unit of Measure (Base)',
-          component: 'dropdown',
-          options: UnitOptions,
-        },
-      },
-      {
-        kind: 'field',
-        field: {
-          name: 'dispenseUnit',
-          placeholder: 'Dispense unit',
-          component: 'dropdown',
-          options: DispenseUnitOptions,
-        },
-      },
-      {
-        kind: 'field',
-        field: {
-          name: 'packSize',
-          placeholder: 'Pack size / Quantity per pack',
-          component: 'text',
-          numeric: true,
-        },
-      },
-      {
-        kind: 'field',
-        field: {
-          name: 'usagePerService',
-          placeholder: 'Usage per service',
-          component: 'text',
-          numeric: true,
-        },
-      },
+      formPresentationField,
+      speciesAdministrationRow,
+      unitOfMeasureBaseField,
+      field('dispenseUnit', 'Dispense unit', 'dropdown', DispenseUnitOptions),
+      field('packSize', 'Pack size / Quantity per pack', 'text', undefined, true),
+      field('usagePerService', 'Usage per service', 'text', undefined, true),
     ],
     pricing: commonPricingFields,
     vendor: commonVendorFields(false),
@@ -709,75 +660,18 @@ export const InventoryFormConfig: Record<
       },
     ],
     classification: [
-      {
-        kind: 'field',
-        field: {
-          name: 'intakeType',
-          placeholder: 'Item type',
-          component: 'dropdown',
-          options: IntakeTypeOptions,
-        },
-      },
-      {
-        kind: 'field',
-        field: {
-          name: 'form',
-          placeholder: 'Form / Presentation',
-          component: 'dropdown',
-          options: FormOptions,
-        },
-      },
-      {
-        kind: 'row',
-        fields: [
-          {
-            name: 'species',
-            placeholder: 'Species',
-            component: 'multiSelect',
-            options: SpeciesOptions,
-          },
-          {
-            name: 'administration',
-            placeholder: 'Administration',
-            component: 'dropdown',
-            options: AdminstrationOptions,
-          },
-        ],
-      },
-      {
-        kind: 'field',
-        field: {
-          name: 'unitofMeasure',
-          placeholder: 'Unit of Measure (Base)',
-          component: 'dropdown',
-          options: UnitOptions,
-        },
-      },
-      {
-        kind: 'field',
-        field: {
-          name: 'safetyClassification',
-          placeholder: 'Safety classification',
-          component: 'dropdown',
-          options: SafetyClassificationOptions,
-        },
-      },
-      {
-        kind: 'field',
-        field: {
-          name: 'brand',
-          placeholder: 'Brand',
-          component: 'text',
-        },
-      },
-      {
-        kind: 'field',
-        field: {
-          name: 'shelfLife',
-          placeholder: 'Shelf life (optional)',
-          component: 'text',
-        },
-      },
+      field('intakeType', 'Item type', 'dropdown', IntakeTypeOptions),
+      formPresentationField,
+      speciesAdministrationRow,
+      unitOfMeasureBaseField,
+      field(
+        'safetyClassification',
+        'Safety classification',
+        'dropdown',
+        SafetyClassificationOptions
+      ),
+      field('brand', 'Brand', 'text'),
+      field('shelfLife', 'Shelf life (optional)', 'text'),
     ],
     pricing: commonPricingFields,
     vendor: commonVendorFields(false),

--- a/apps/frontend/src/app/features/legal/pages/trustCenterData.ts
+++ b/apps/frontend/src/app/features/legal/pages/trustCenterData.ts
@@ -24,6 +24,24 @@ export type Subprocessor = {
   location: string;
 };
 
+/** One-line builder for a certification rendered with a badge image. */
+const cert = (
+  name: string,
+  status: CertStatus,
+  description: string,
+  badge: string
+): Certification => ({ name, status, description, badge });
+
+/** One-line builder for a certification rendered as a tinted ion-icon tile. */
+const iconCert = (
+  name: string,
+  status: CertStatus,
+  description: string,
+  icon: string,
+  iconBg: string,
+  iconColor: string
+): Certification => ({ name, status, description, icon, iconBg, iconColor });
+
 export const trustCenterData = {
   hero: {
     eyebrow: 'Security',
@@ -52,70 +70,65 @@ export const trustCenterData = {
   ],
 
   certifications: [
-    {
-      name: 'GDPR',
-      status: 'COMPLIANT',
-      description: 'Fully compliant data processing with EU hosting.',
-      badge: CERT_BADGES.gdpr,
-    },
-    {
-      name: 'SOC 2 Type I',
-      status: 'COMPLIANT',
-      description: 'Audited security, availability and confidentiality controls.',
-      badge: CERT_BADGES.soc2,
-    },
-    {
-      name: 'ISO 27001:2022',
-      status: 'COMPLIANT',
-      description: 'Certified information-security management.',
-      badge: CERT_BADGES.iso,
-    },
-    {
-      name: '21 CFR Part 11',
-      status: 'COMPLIANT',
-      description: 'FDA rules for electronic records and signatures.',
-      badge: CERT_BADGES.fda,
-    },
-    {
-      name: 'ESIGN Act',
-      status: 'COMPLIANT',
-      description: 'US federal law on the validity of e-signatures.',
-      icon: 'create-outline',
-      iconBg: '#e6f2ff',
-      iconColor: '#257bed',
-    },
-    {
-      name: 'UETA',
-      status: 'COMPLIANT',
-      description: 'US state law for electronic transactions.',
-      icon: 'swap-horizontal-outline',
-      iconBg: '#f5f3ff',
-      iconColor: '#5b21b6',
-    },
-    {
-      name: 'eIDAS (SES)',
-      status: 'COMPLIANT',
-      description: 'EU electronic identification, Level 1.',
-      icon: 'finger-print-outline',
-      iconBg: '#e6f4ef',
-      iconColor: '#006642',
-    },
-    {
-      name: 'ZertES',
-      status: 'PLANNED',
-      description: 'Swiss federal law on electronic signatures.',
-      icon: 'ribbon-outline',
-      iconBg: '#fef3e9',
-      iconColor: '#af5e19',
-    },
-    {
-      name: 'HIPAA',
-      status: 'PLANNED',
-      description: 'US protection for patient health information.',
-      icon: 'medkit-outline',
-      iconBg: '#e6f2ff',
-      iconColor: '#257bed',
-    },
+    cert('GDPR', 'COMPLIANT', 'Fully compliant data processing with EU hosting.', CERT_BADGES.gdpr),
+    cert(
+      'SOC 2 Type I',
+      'COMPLIANT',
+      'Audited security, availability and confidentiality controls.',
+      CERT_BADGES.soc2
+    ),
+    cert(
+      'ISO 27001:2022',
+      'COMPLIANT',
+      'Certified information-security management.',
+      CERT_BADGES.iso
+    ),
+    cert(
+      '21 CFR Part 11',
+      'COMPLIANT',
+      'FDA rules for electronic records and signatures.',
+      CERT_BADGES.fda
+    ),
+    iconCert(
+      'ESIGN Act',
+      'COMPLIANT',
+      'US federal law on the validity of e-signatures.',
+      'create-outline',
+      '#e6f2ff',
+      '#257bed'
+    ),
+    iconCert(
+      'UETA',
+      'COMPLIANT',
+      'US state law for electronic transactions.',
+      'swap-horizontal-outline',
+      '#f5f3ff',
+      '#5b21b6'
+    ),
+    iconCert(
+      'eIDAS (SES)',
+      'COMPLIANT',
+      'EU electronic identification, Level 1.',
+      'finger-print-outline',
+      '#e6f4ef',
+      '#006642'
+    ),
+    iconCert(
+      'ZertES',
+      'PLANNED',
+      'Swiss federal law on electronic signatures.',
+      'ribbon-outline',
+      '#fef3e9',
+      '#af5e19'
+    ),
+    iconCert(
+      'HIPAA',
+      'PLANNED',
+      'US protection for patient health information.',
+      'medkit-outline',
+      '#e6f2ff',
+      '#257bed'
+    ),
   ] satisfies readonly Certification[],
 
   securityPillars: [

--- a/apps/frontend/src/app/features/marketing/pages/ContactusPage/ContactusPage.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/ContactusPage/ContactusPage.tsx
@@ -21,6 +21,7 @@ import {
   DISCORD_INVITE_URL,
 } from '@/app/features/marketing/site';
 import { postData } from '@/app/services/axios';
+import { makeOptions } from '@/app/lib/options';
 
 const NEWSREADER = 'var(--font-newsreader)';
 const EASE = 'cubic-bezier(0.16,1,0.3,1)';
@@ -86,106 +87,43 @@ const queryTypes: TicketCategory[] = [
   'Complaint',
 ];
 
-const subrequestOptions: { label: string; value: DsraRequesterType }[] = [
-  {
-    value: 'SELF',
-    label: 'The person whose name appears above',
-  },
-  {
-    value: 'PARENT_GUARDIAN',
-    label: 'The parent / guardian of the person whose name appears above',
-  },
-  {
-    value: 'AUTHORIZED_AGENT',
-    label: 'An agent authorized by the consumer to make this request on their behalf',
-  },
-];
+const subrequestOptions: { label: string; value: DsraRequesterType }[] = makeOptions([
+  ['The person whose name appears above', 'SELF'],
+  ['The parent / guardian of the person whose name appears above', 'PARENT_GUARDIAN'],
+  ['An agent authorized by the consumer to make this request on their behalf', 'AUTHORIZED_AGENT'],
+]);
 
-const requestOptions: { label: string; value: DsraRight }[] = [
-  {
-    label: 'Know what information is being collected from you',
-    value: 'KNOW_INFORMATION_COLLECTED',
-  },
-  {
-    label: 'Have your information deleted',
-    value: 'DELETE_DATA',
-  },
-  {
-    label: 'Opt-out of having your data sold to third-parties',
-    value: 'OPT_OUT_SELLING_SHARING',
-  },
-  {
-    label: 'Opt-in to the sale of your personal data to third-parties',
-    value: 'OTHER',
-  },
-  {
-    label: 'Access your personal information',
-    value: 'ACCESS_PERSONAL_INFORMATION',
-  },
-  {
-    label: 'Fix inaccurate information',
-    value: 'RECTIFY_INACCURATE_INFORMATION',
-  },
-  {
-    label: 'Receive a copy of your personal information',
-    value: 'PORTABILITY_COPY',
-  },
-  {
-    label: 'Opt-out of having your data shared for cross-context behavioral advertising',
-    value: 'OPT_OUT_SELLING_SHARING',
-  },
-  {
-    label: 'Limit the use and disclosure of your sensitive personal information',
-    value: 'LIMIT_SENSITIVE_PROCESSING',
-  },
-  {
-    label: 'Others (please specify in the comment box below)',
-    value: 'OTHER',
-  },
-];
+const requestOptions: { label: string; value: DsraRight }[] = makeOptions([
+  ['Know what information is being collected from you', 'KNOW_INFORMATION_COLLECTED'],
+  ['Have your information deleted', 'DELETE_DATA'],
+  ['Opt-out of having your data sold to third-parties', 'OPT_OUT_SELLING_SHARING'],
+  ['Opt-in to the sale of your personal data to third-parties', 'OTHER'],
+  ['Access your personal information', 'ACCESS_PERSONAL_INFORMATION'],
+  ['Fix inaccurate information', 'RECTIFY_INACCURATE_INFORMATION'],
+  ['Receive a copy of your personal information', 'PORTABILITY_COPY'],
+  [
+    'Opt-out of having your data shared for cross-context behavioral advertising',
+    'OPT_OUT_SELLING_SHARING',
+  ],
+  [
+    'Limit the use and disclosure of your sensitive personal information',
+    'LIMIT_SENSITIVE_PROCESSING',
+  ],
+  ['Others (please specify in the comment box below)', 'OTHER'],
+]);
 
-const areaOptions: Option[] = [
-  {
-    value: 'GDPR',
-    label: 'EU GDPR (General Data Protection Regulation)',
-  },
-  {
-    value: 'UK_GDPR',
-    label: 'UK GDPR / Data Protection Act 2018',
-  },
-  {
-    value: 'CCPA',
-    label: 'CCPA / CPRA (California Consumer Privacy Act)',
-  },
-  {
-    value: 'LGPD',
-    label: 'LGPD (Brazilian General Data Protection Law)',
-  },
-  {
-    value: 'PIPEDA',
-    label: 'PIPEDA (Personal Information Protection and Electronic Documents Act, Canada)',
-  },
-  {
-    value: 'POPIA',
-    label: 'POPIA (Protection of Personal Information Act, South Africa)',
-  },
-  {
-    value: 'PDPA',
-    label: 'PDPA (Personal Data Protection Act, Singapore)',
-  },
-  {
-    value: 'PIPL',
-    label: 'PIPL (Personal Information Protection Law, China)',
-  },
-  {
-    value: 'PA_1988_AU',
-    label: 'Privacy Act 1988 (Australia)',
-  },
-  {
-    value: 'OTHER',
-    label: 'Other',
-  },
-];
+const areaOptions: Option[] = makeOptions([
+  ['EU GDPR (General Data Protection Regulation)', 'GDPR'],
+  ['UK GDPR / Data Protection Act 2018', 'UK_GDPR'],
+  ['CCPA / CPRA (California Consumer Privacy Act)', 'CCPA'],
+  ['LGPD (Brazilian General Data Protection Law)', 'LGPD'],
+  ['PIPEDA (Personal Information Protection and Electronic Documents Act, Canada)', 'PIPEDA'],
+  ['POPIA (Protection of Personal Information Act, South Africa)', 'POPIA'],
+  ['PDPA (Personal Data Protection Act, Singapore)', 'PDPA'],
+  ['PIPL (Personal Information Protection Law, China)', 'PIPL'],
+  ['Privacy Act 1988 (Australia)', 'PA_1988_AU'],
+  ['Other', 'OTHER'],
+]);
 
 const confirmOptions = [
   'Under penalty of perjury, I declare all the above information to be true and accurate.',

--- a/apps/frontend/src/app/features/marketing/site/useGithubStats.ts
+++ b/apps/frontend/src/app/features/marketing/site/useGithubStats.ts
@@ -221,7 +221,7 @@ const releaseSnapshots = new Map<string, { raw: string | null; value: ReleaseInf
 const getReleaseSnapshot = (cacheKey: string): ReleaseInfo => {
   const raw = getStorageItem('session', cacheKey);
   const memo = releaseSnapshots.get(cacheKey);
-  if (memo && memo.raw === raw) return memo.value;
+  if (memo?.raw === raw) return memo.value;
   const value = parseJson<ReleaseInfo>(raw) ?? EMPTY_RELEASE;
   releaseSnapshots.set(cacheKey, { raw, value });
   return value;

--- a/apps/frontend/src/app/features/marketing/site/useTheme.ts
+++ b/apps/frontend/src/app/features/marketing/site/useTheme.ts
@@ -1,100 +1,25 @@
 'use client';
 
-import { useCallback, useEffect, useSyncExternalStore } from 'react';
+import { useSyncExternalStore } from 'react';
+import {
+  getServerTheme,
+  readTheme,
+  subscribeToThemeChange,
+  toggleTheme,
+  useThemeLifecycle,
+} from '@/app/ui/theme/themeCore';
 
-export type Theme = 'light' | 'dark';
-
-const STORAGE_KEY = 'yc-theme';
-const THEME_CHANGE_EVENT = 'yc-theme-change';
-
-/** The current theme, read from the source of truth: <html data-theme>. */
-const readTheme = (): Theme => {
-  const attr = globalThis.document?.documentElement.dataset.theme;
-  return attr === 'dark' ? 'dark' : 'light';
-};
-
-/** Keep the browser-chrome color (mobile address bar) in step with the page surface. */
-const syncMetaThemeColor = () => {
-  const doc = globalThis.document;
-  if (!doc) return;
-  let meta = doc.querySelector('meta[name="theme-color"]');
-  if (!meta) {
-    meta = doc.createElement('meta');
-    meta.setAttribute('name', 'theme-color');
-    doc.head.appendChild(meta);
-  }
-  const page = globalThis.getComputedStyle(doc.documentElement).getPropertyValue('--page').trim();
-  meta.setAttribute('content', page || (readTheme() === 'dark' ? '#201c18' : '#efe8dc'));
-};
-
-const applyTheme = (theme: Theme, persist: boolean) => {
-  const root = globalThis.document.documentElement;
-  root.dataset.theme = theme;
-  root.dataset.themeReady = '1';
-  if (persist) {
-    try {
-      globalThis.localStorage.setItem(STORAGE_KEY, theme);
-    } catch {
-      /* private mode: fall back to OS following */
-    }
-  }
-  syncMetaThemeColor();
-  globalThis.dispatchEvent(new CustomEvent(THEME_CHANGE_EVENT, { detail: { theme } }));
-};
-
-/** Re-read the theme whenever any toggle instance broadcasts a flip (for useSyncExternalStore). */
-const subscribeToThemeChange = (onStoreChange: () => void): (() => void) => {
-  globalThis.addEventListener(THEME_CHANGE_EVENT, onStoreChange);
-  return () => globalThis.removeEventListener(THEME_CHANGE_EVENT, onStoreChange);
-};
-
-/** SSR always renders light; the client re-reads <html data-theme> on hydration. */
-const getServerTheme = (): Theme => 'light';
+export type { Theme } from '@/app/ui/theme/themeCore';
 
 /**
  * Light/dark theme controller for the marketing surface. The source of truth is the
  * `data-theme` attribute on <html> (set pre-paint in the root layout). This hook reads
  * it for the toggle icon (every applyTheme dispatches the shared change event, keeping
  * all instances in sync), follows OS changes while no explicit choice is stored, and
- * enables the flip transition shortly after first paint.
+ * enables the flip transition shortly after first paint — all via the shared themeCore.
  */
 export function useTheme() {
   const theme = useSyncExternalStore(subscribeToThemeChange, readTheme, getServerTheme);
-
-  useEffect(() => {
-    syncMetaThemeColor();
-
-    // Enable the flip transition after first paint so the initial paint never animates.
-    const readyTimer = globalThis.setTimeout(() => {
-      globalThis.document.documentElement.dataset.themeReady = '1';
-    }, 60);
-
-    // Follow OS changes only while the visitor hasn't explicitly chosen a theme.
-    // applyTheme broadcasts the change event, so every subscribed instance re-reads.
-    const mq = globalThis.matchMedia?.('(prefers-color-scheme: dark)');
-    const onOSChange = (event: MediaQueryListEvent) => {
-      let saved: string | null = null;
-      try {
-        saved = globalThis.localStorage.getItem(STORAGE_KEY);
-      } catch {
-        /* ignore */
-      }
-      if (!saved) {
-        applyTheme(event.matches ? 'dark' : 'light', false);
-      }
-    };
-    mq?.addEventListener('change', onOSChange);
-
-    return () => {
-      globalThis.clearTimeout(readyTimer);
-      mq?.removeEventListener('change', onOSChange);
-    };
-  }, []);
-
-  const toggle = useCallback(() => {
-    const next: Theme = readTheme() === 'dark' ? 'light' : 'dark';
-    applyTheme(next, true);
-  }, []);
-
-  return { theme, toggle };
+  useThemeLifecycle();
+  return { theme, toggle: toggleTheme };
 }

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/ProfileCard.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/ProfileCard.tsx
@@ -6,7 +6,7 @@ import LabelDropdown from '@/app/ui/inputs/Dropdown/LabelDropdown';
 import FormInput from '@/app/ui/inputs/FormInput/FormInput';
 import MultiSelectDropdown from '@/app/ui/inputs/MultiSelectDropdown';
 import LogoUpdator from '@/app/ui/widgets/UploadImage/LogoUpdator';
-import GoogleSearchDropDown from '@/app/ui/inputs/GoogleSearchDropDown/GoogleSearchDropDown';
+import GoogleAddressFieldRenderer from '@/app/ui/primitives/Accordion/googleAddressFieldRenderer';
 import { usePrimaryOrg } from '@/app/hooks/useOrgSelectors';
 import { usePrimaryOrgProfile } from '@/app/hooks/useProfiles';
 import { updateOrg } from '@/app/features/organization/services/orgService';
@@ -176,26 +176,7 @@ const FieldComponents: Record<
       />
     );
   },
-  googleAddress: ({ field, value, onChange, onMultiChange, error }) => (
-    <GoogleSearchDropDown
-      intype="text"
-      inname={field.key}
-      value={value ?? ''}
-      inlabel={field.label}
-      error={error}
-      onChange={(e) => onChange(e.target.value)}
-      onlyAddress={true}
-      onAddressSelect={(address) => {
-        onChange(address.addressLine);
-        onMultiChange?.({
-          city: address.city,
-          state: address.state,
-          postalCode: address.postalCode,
-          ...(address.country ? { country: address.country } : {}),
-        });
-      }}
-    />
-  ),
+  googleAddress: GoogleAddressFieldRenderer,
 };
 
 const FieldValueRow: React.FC<{

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/AddRoomSections.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/AddRoomSections.tsx
@@ -8,12 +8,12 @@ import {
   RoomEquipmentOptions,
   RoomSpeciesOptions,
   RoomsTypes,
-  RoomUnitSizeOptions,
 } from '@/app/features/organization/pages/Organization/types';
 import { OrganisationRoom } from '@yosemite-crew/types';
 import { FiPlus } from 'react-icons/fi';
 import type { RoomFormData, RoomUnitDraft } from './AddRoom';
 import { SectionHeader, ToggleSwitch } from './roomSectionPrimitives';
+import RoomUnitFieldsEditor from './RoomUnitFieldsEditor';
 
 export { SectionHeader, ToggleSwitch };
 
@@ -206,29 +206,7 @@ export const UnitsSection = ({
         {formData.units.map((unit) => (
           <div key={unit.id} className="rounded-2xl border border-blue-text p-3">
             <div className="mb-3 text-caption-1 text-blue-text">Draft unit type</div>
-            <div className="grid grid-cols-1 gap-3">
-              <FormInput
-                intype="text"
-                value={unit.name}
-                inlabel="Name"
-                onChange={(event) => onUpdateUnit(unit.id, { name: event.target.value })}
-              />
-              <LabelDropdown
-                placeholder="Size"
-                options={RoomUnitSizeOptions}
-                defaultOption={unit.size}
-                onSelect={(option) => onUpdateUnit(unit.id, { size: option.value })}
-              />
-              <FormInput
-                intype="number"
-                value={String(unit.count)}
-                inlabel="Units"
-                onChange={(event) => {
-                  const parsed = Number(event.target.value);
-                  onUpdateUnit(unit.id, { count: Number.isNaN(parsed) ? 0 : Math.max(0, parsed) });
-                }}
-              />
-            </div>
+            <RoomUnitFieldsEditor unit={unit} onUpdateUnit={onUpdateUnit} />
           </div>
         ))}
         {formData.units.length === 0 && supportsUnits && (

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/RoomInfoSections.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/RoomInfoSections.tsx
@@ -8,12 +8,12 @@ import {
   RoomEquipmentOptions,
   RoomSpeciesOptions,
   RoomsTypes,
-  RoomUnitSizeOptions,
 } from '@/app/features/organization/pages/Organization/types';
 import { OrganisationRoom } from '@yosemite-crew/types';
 import { FiPlus } from 'react-icons/fi';
 import type { ManagedRoom, RoomUnitDetails } from './RoomInfo.types';
 import { SectionHeader, ToggleSwitch } from './roomSectionPrimitives';
+import RoomUnitFieldsEditor from './RoomUnitFieldsEditor';
 
 type SelectOption = { label: string; value: string };
 type OpenSections = Record<'details' | 'availability' | 'units' | 'equipment', boolean>;
@@ -275,31 +275,7 @@ const RoomInfoSections = ({
               </fieldset>
             ) : (
               <div key={unit.id} className="rounded-2xl border border-blue-text p-3">
-                <div className="grid grid-cols-1 gap-3">
-                  <FormInput
-                    intype="text"
-                    value={unit.name}
-                    inlabel="Name"
-                    onChange={(event) => onUpdateUnit(unit.id, { name: event.target.value })}
-                  />
-                  <LabelDropdown
-                    placeholder="Size"
-                    options={RoomUnitSizeOptions}
-                    defaultOption={unit.size}
-                    onSelect={(option) => onUpdateUnit(unit.id, { size: option.value })}
-                  />
-                  <FormInput
-                    intype="number"
-                    value={String(unit.count)}
-                    inlabel="Units"
-                    onChange={(event) => {
-                      const parsed = Number(event.target.value);
-                      onUpdateUnit(unit.id, {
-                        count: Number.isNaN(parsed) ? 0 : Math.max(0, parsed),
-                      });
-                    }}
-                  />
-                </div>
+                <RoomUnitFieldsEditor unit={unit} onUpdateUnit={onUpdateUnit} />
               </div>
             )
           )}

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/RoomUnitFieldsEditor.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/RoomUnitFieldsEditor.tsx
@@ -1,0 +1,49 @@
+import FormInput from '@/app/ui/inputs/FormInput/FormInput';
+import LabelDropdown from '@/app/ui/inputs/Dropdown/LabelDropdown';
+import { RoomUnitSizeOptions } from '@/app/features/organization/pages/Organization/types';
+
+type RoomUnitFields = {
+  id: string;
+  name: string;
+  size: string;
+  count: number;
+};
+
+type RoomUnitFieldsPatch = Partial<Omit<RoomUnitFields, 'id'>>;
+
+type RoomUnitFieldsEditorProps = {
+  unit: RoomUnitFields;
+  onUpdateUnit: (id: string, patch: RoomUnitFieldsPatch) => void;
+};
+
+/**
+ * Editable Name / Size / Units field trio for a room unit, shared by the
+ * add-room draft units and the room-info edit mode.
+ */
+const RoomUnitFieldsEditor = ({ unit, onUpdateUnit }: RoomUnitFieldsEditorProps) => (
+  <div className="grid grid-cols-1 gap-3">
+    <FormInput
+      intype="text"
+      value={unit.name}
+      inlabel="Name"
+      onChange={(event) => onUpdateUnit(unit.id, { name: event.target.value })}
+    />
+    <LabelDropdown
+      placeholder="Size"
+      options={RoomUnitSizeOptions}
+      defaultOption={unit.size}
+      onSelect={(option) => onUpdateUnit(unit.id, { size: option.value })}
+    />
+    <FormInput
+      intype="number"
+      value={String(unit.count)}
+      inlabel="Units"
+      onChange={(event) => {
+        const parsed = Number(event.target.value);
+        onUpdateUnit(unit.id, { count: Number.isNaN(parsed) ? 0 : Math.max(0, parsed) });
+      }}
+    />
+  </div>
+);
+
+export default RoomUnitFieldsEditor;

--- a/apps/frontend/src/app/features/organization/pages/Specialities/NameDescriptionFields.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Specialities/NameDescriptionFields.tsx
@@ -1,0 +1,53 @@
+import FormInput from '@/app/ui/inputs/FormInput/FormInput';
+
+type NameDescriptionFieldsProps = {
+  name: string;
+  onNameChange: (value: string) => void;
+  nameError?: string;
+  descId: string;
+  description: string;
+  onDescriptionChange: (value: string) => void;
+  textareaRows?: number;
+};
+
+/**
+ * Left-column Name input + labeled Description textarea shared by the
+ * package and service draft forms.
+ */
+const NameDescriptionFields = ({
+  name,
+  onNameChange,
+  nameError,
+  descId,
+  description,
+  onDescriptionChange,
+  textareaRows,
+}: NameDescriptionFieldsProps) => (
+  <div className="flex flex-col gap-4">
+    <FormInput
+      intype="text"
+      inlabel="Name"
+      value={name}
+      onChange={(e) => onNameChange(e.target.value)}
+      error={nameError}
+    />
+    <div className="w-full">
+      <label
+        htmlFor={descId}
+        className="mb-1.5 block truncate text-[12.5px] font-semibold text-[var(--ink-soft)]"
+      >
+        Description
+      </label>
+      <textarea
+        id={descId}
+        aria-label="Description"
+        value={description}
+        onChange={(e) => onDescriptionChange(e.target.value)}
+        rows={textareaRows}
+        className="w-full rounded-2xl bg-transparent px-6 pt-4 pb-3 text-body-4 text-text-primary outline-none border border-input-border-default focus:border-input-border-active resize-none min-h-28"
+      />
+    </div>
+  </div>
+);
+
+export default NameDescriptionFields;

--- a/apps/frontend/src/app/features/organization/pages/Specialities/PackageTopFields.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Specialities/PackageTopFields.tsx
@@ -1,5 +1,6 @@
 import FormInput from '@/app/ui/inputs/FormInput/FormInput';
 import LabelDropdown from '@/app/ui/inputs/Dropdown/LabelDropdown';
+import NameDescriptionFields from '@/app/features/organization/pages/Specialities/NameDescriptionFields';
 import { LEAD_OPTIONS, STAFF_COUNT_OPTIONS } from './packageFormDraftHelpers';
 
 type PackageTopFieldsProps = {
@@ -47,30 +48,14 @@ const PackageTopFields = ({
 }: PackageTopFieldsProps) => (
   <div className="grid grid-cols-1 @2xl:grid-cols-2 gap-x-6 gap-y-4 items-start">
     {/* Left col: Name + Description */}
-    <div className="flex flex-col gap-4">
-      <FormInput
-        intype="text"
-        inlabel="Name"
-        value={name}
-        onChange={(e) => onNameChange(e.target.value)}
-        error={nameError}
-      />
-      <div className="w-full">
-        <label
-          htmlFor={descId}
-          className="mb-1.5 block truncate text-[12.5px] font-semibold text-[var(--ink-soft)]"
-        >
-          Description
-        </label>
-        <textarea
-          id={descId}
-          aria-label="Description"
-          value={description}
-          onChange={(e) => onDescriptionChange(e.target.value)}
-          className="w-full rounded-2xl bg-transparent px-6 pt-4 pb-3 text-body-4 text-text-primary outline-none border border-input-border-default focus:border-input-border-active resize-none min-h-28"
-        />
-      </div>
-    </div>
+    <NameDescriptionFields
+      name={name}
+      onNameChange={onNameChange}
+      nameError={nameError}
+      descId={descId}
+      description={description}
+      onDescriptionChange={onDescriptionChange}
+    />
 
     {/* Right col: Duration / Lead+Support row / scheduling checkboxes */}
     <div className="flex flex-col gap-4">

--- a/apps/frontend/src/app/features/organization/pages/Specialities/PackagesTab.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Specialities/PackagesTab.tsx
@@ -37,6 +37,52 @@ type PackagesTabProps = Readonly<{
 
 type ActionMode = null | 'edit' | 'archive';
 
+const PackageCardActions = ({
+  pkgName,
+  showBreakdown,
+  onToggleBreakdown,
+  onEdit,
+  onArchive,
+}: {
+  pkgName: string;
+  showBreakdown: boolean;
+  onToggleBreakdown: () => void;
+  onEdit: () => void;
+  onArchive: () => void;
+}) => (
+  <>
+    <CircleIconButton
+      label={`${showBreakdown ? 'Hide' : 'View'} breakdown of ${pkgName}`}
+      tooltip={showBreakdown ? 'Hide breakdown' : 'View breakdown'}
+      onClick={onToggleBreakdown}
+      variant="dark"
+      icon={
+        <IoChevronDown
+          size={20}
+          aria-hidden="true"
+          style={{
+            transform: showBreakdown ? 'rotate(180deg)' : 'rotate(0deg)',
+            transition: 'transform 150ms ease',
+          }}
+        />
+      }
+    />
+    <CircleIconButton
+      label={`Edit ${pkgName}`}
+      tooltip="Edit"
+      onClick={onEdit}
+      icon={<IoCreateOutline size={20} aria-hidden="true" />}
+    />
+    <CircleIconButton
+      label={`Archive ${pkgName}`}
+      tooltip="Archive"
+      onClick={onArchive}
+      variant="danger"
+      icon={<IoArchiveOutline size={20} aria-hidden="true" />}
+    />
+  </>
+);
+
 const PackageCard = ({
   pkg,
   index,
@@ -92,34 +138,12 @@ const PackageCard = ({
         <div className="@container">
           {/* Action buttons on narrow containers */}
           <div className="flex @2xl:hidden items-center justify-end gap-2 mb-3">
-            <CircleIconButton
-              label={`${showBreakdown ? 'Hide' : 'View'} breakdown of ${pkg.name}`}
-              tooltip={showBreakdown ? 'Hide breakdown' : 'View breakdown'}
-              onClick={handleToggleBreakdown}
-              variant="dark"
-              icon={
-                <IoChevronDown
-                  size={20}
-                  aria-hidden="true"
-                  style={{
-                    transform: showBreakdown ? 'rotate(180deg)' : 'rotate(0deg)',
-                    transition: 'transform 150ms ease',
-                  }}
-                />
-              }
-            />
-            <CircleIconButton
-              label={`Edit ${pkg.name}`}
-              tooltip="Edit"
-              onClick={onEdit}
-              icon={<IoCreateOutline size={20} aria-hidden="true" />}
-            />
-            <CircleIconButton
-              label={`Archive ${pkg.name}`}
-              tooltip="Archive"
-              onClick={onArchive}
-              variant="danger"
-              icon={<IoArchiveOutline size={20} aria-hidden="true" />}
+            <PackageCardActions
+              pkgName={pkg.name}
+              showBreakdown={showBreakdown}
+              onToggleBreakdown={handleToggleBreakdown}
+              onEdit={onEdit}
+              onArchive={onArchive}
             />
           </div>
 
@@ -207,34 +231,12 @@ const PackageCard = ({
 
             {/* Action buttons — hidden on narrow (shown above) */}
             <div className="hidden @2xl:flex items-center gap-2 shrink-0">
-              <CircleIconButton
-                label={`${showBreakdown ? 'Hide' : 'View'} breakdown of ${pkg.name}`}
-                tooltip={showBreakdown ? 'Hide breakdown' : 'View breakdown'}
-                onClick={handleToggleBreakdown}
-                variant="dark"
-                icon={
-                  <IoChevronDown
-                    size={20}
-                    aria-hidden="true"
-                    style={{
-                      transform: showBreakdown ? 'rotate(180deg)' : 'rotate(0deg)',
-                      transition: 'transform 150ms ease',
-                    }}
-                  />
-                }
-              />
-              <CircleIconButton
-                label={`Edit ${pkg.name}`}
-                tooltip="Edit"
-                onClick={onEdit}
-                icon={<IoCreateOutline size={20} aria-hidden="true" />}
-              />
-              <CircleIconButton
-                label={`Archive ${pkg.name}`}
-                tooltip="Archive"
-                onClick={onArchive}
-                variant="danger"
-                icon={<IoArchiveOutline size={20} aria-hidden="true" />}
+              <PackageCardActions
+                pkgName={pkg.name}
+                showBreakdown={showBreakdown}
+                onToggleBreakdown={handleToggleBreakdown}
+                onEdit={onEdit}
+                onArchive={onArchive}
               />
             </div>
           </div>

--- a/apps/frontend/src/app/features/organization/pages/Specialities/ServiceFormDraft.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Specialities/ServiceFormDraft.tsx
@@ -8,6 +8,7 @@ import CenterModal from '@/app/ui/overlays/Modal/CenterModal';
 import ModalHeader from '@/app/ui/overlays/Modal/ModalHeader';
 import SectionContainer from '@/app/ui/primitives/SectionContainer/SectionContainer';
 import Badge from '@/app/ui/Badge';
+import NameDescriptionFields from '@/app/features/organization/pages/Specialities/NameDescriptionFields';
 import { CatalogItemType, ServiceRevamp } from '@/app/features/organization/types/revamp';
 import { useRevampCatalogStore } from '@/app/stores/revampCatalogStore';
 import { computeServiceTotal } from '@/app/features/organization/services/catalogCalculations';
@@ -76,31 +77,15 @@ const ServiceFormFields = ({
 }: ServiceFormFieldsProps) => (
   <div className="grid grid-cols-1 @2xl:grid-cols-2 gap-x-6 gap-y-4 items-start">
     {/* Left col */}
-    <div className="flex flex-col gap-4">
-      <FormInput
-        intype="text"
-        inlabel="Name"
-        value={name}
-        onChange={(e) => onNameChange(e.target.value)}
-        error={nameError}
-      />
-      <div className="w-full">
-        <label
-          htmlFor={descId}
-          className="mb-1.5 block truncate text-[12.5px] font-semibold text-[var(--ink-soft)]"
-        >
-          Description
-        </label>
-        <textarea
-          id={descId}
-          aria-label="Description"
-          value={description}
-          onChange={(e) => onDescriptionChange(e.target.value)}
-          rows={3}
-          className="w-full rounded-2xl bg-transparent px-6 pt-4 pb-3 text-body-4 text-text-primary outline-none border border-input-border-default focus:border-input-border-active resize-none min-h-28"
-        />
-      </div>
-    </div>
+    <NameDescriptionFields
+      name={name}
+      onNameChange={onNameChange}
+      nameError={nameError}
+      descId={descId}
+      description={description}
+      onDescriptionChange={onDescriptionChange}
+      textareaRows={3}
+    />
 
     {/* Right col */}
     <div className="flex flex-col gap-4">

--- a/apps/frontend/src/app/hooks/useAppointmentForm.ts
+++ b/apps/frontend/src/app/hooks/useAppointmentForm.ts
@@ -31,6 +31,7 @@ import { loadInvoicesForOrgPrimaryOrg } from '@/app/features/billing/services/in
 import { EMPTY_APPOINTMENT } from '@/app/features/appointments/constants/emptyAppointment';
 import { AppointmentDraftPrefill } from '@/app/features/appointments/types/calendar';
 import { useCompanionTerminologyText } from '@/app/hooks/useCompanionTerminologyText';
+import { Team } from '@/app/features/organization/types/team';
 import { PackageRevamp, ServiceRevamp } from '@/app/features/organization/types/revamp';
 import {
   hasBookableBreakdownItem,
@@ -361,6 +362,133 @@ const applyPrefillSlot = (
   }));
 };
 
+type IncomingPrefillCtx = {
+  teams: Team[];
+  normalizeId: (value?: string) => string;
+  getLeadProfileUrl: (leadId: string) => string | undefined;
+  setPendingPrefill: React.Dispatch<React.SetStateAction<AppointmentDraftPrefill | null>>;
+  setSelectedDate: React.Dispatch<React.SetStateAction<Date>>;
+  setSelectedSlot: React.Dispatch<React.SetStateAction<Slot | null>>;
+  setFormData: React.Dispatch<React.SetStateAction<AppointmentWithCompanion>>;
+};
+
+const applyIncomingPrefill = (prefill: AppointmentDraftPrefill, ctx: IncomingPrefillCtx) => {
+  ctx.setPendingPrefill(prefill);
+  ctx.setSelectedDate(prefill.date);
+  ctx.setSelectedSlot(null);
+  const prefillStart = buildDateInPreferredTimeZone(prefill.date, prefill.minuteOfDay);
+
+  // Prefill lead immediately from teams — before service/slot are chosen.
+  // The pendingPrefill effect re-validates once a slot is matched.
+  const prefillLead = prefill.leadId
+    ? ctx.teams.find(
+        (t) => ctx.normalizeId(t.practionerId || t._id) === ctx.normalizeId(prefill.leadId)
+      )
+    : undefined;
+  const prefillLeadId = prefillLead ? prefillLead.practionerId || prefillLead._id : undefined;
+  const prefillLeadName = prefillLead?.name || prefillLead?.practionerId || prefillLead?._id;
+
+  ctx.setFormData((prev) => ({
+    ...prev,
+    appointmentDate: prefillStart,
+    startTime: prefillStart,
+    endTime: prefillStart,
+    ...(prefillLeadId
+      ? {
+          lead: {
+            id: prefillLeadId,
+            name: prefillLeadName ?? '',
+            profileUrl: ctx.getLeadProfileUrl(prefillLeadId),
+          },
+        }
+      : {}),
+  }));
+};
+
+type ServiceKindSyncCtx = {
+  appointmentKind: AppointmentKind;
+  services: AppointmentCatalogService[];
+  setFormData: React.Dispatch<React.SetStateAction<AppointmentWithCompanion>>;
+  setFormDataErrors: React.Dispatch<React.SetStateAction<AppointmentFormErrors>>;
+  setSelectedSlot: React.Dispatch<React.SetStateAction<Slot | null>>;
+  setTimeSlots: React.Dispatch<React.SetStateAction<Slot[]>>;
+};
+
+// Align the appointment kind with the selected service's preference, or clear a
+// selected service that is no longer bookable.
+const syncServiceSelectionWithKind = (
+  selectedServiceId: string | undefined,
+  ctx: ServiceKindSyncCtx
+) => {
+  if (!selectedServiceId) return;
+  const selectedService = ctx.services.find((service) => service.id === selectedServiceId);
+  if (!selectedService) return;
+  const serviceAppointmentKind = resolveServiceAppointmentKind(
+    selectedService,
+    ctx.appointmentKind
+  );
+  if (serviceAppointmentKind !== ctx.appointmentKind) {
+    ctx.setFormData((prev) => ({
+      ...prev,
+      appointmentKind: serviceAppointmentKind,
+    }));
+    return;
+  }
+  if (isSelectableAppointmentService(selectedService)) return;
+  ctx.setSelectedSlot(null);
+  ctx.setTimeSlots([]);
+  ctx.setFormData((prev) => ({
+    ...prev,
+    appointmentKind: ctx.appointmentKind,
+    appointmentType: {
+      id: '',
+      name: '',
+      speciality: prev.appointmentType?.speciality ?? { id: '', name: '' },
+    },
+    lead: undefined,
+  }));
+  ctx.setFormDataErrors((prev) => ({
+    ...prev,
+    serviceId: 'Select a bookable service.',
+    slot: undefined,
+    leadId: undefined,
+  }));
+};
+
+type SlotScopePruneCtx = {
+  slotScopedSpecialityIds: string[];
+  slotScopedServicesBySpecialityId: Record<string, Array<{ label: string; value: string }>>;
+  setFormData: React.Dispatch<React.SetStateAction<AppointmentWithCompanion>>;
+};
+
+// Empty any speciality/service selection that falls outside the slot-scoped
+// options; each correction self-invalidates on the follow-up render.
+const pruneSelectionsOutsideSlotScope = (
+  appointmentType: AppointmentWithCompanion['appointmentType'],
+  ctx: SlotScopePruneCtx
+) => {
+  const selectedSpecialityId = appointmentType?.speciality.id;
+  if (!selectedSpecialityId) return;
+  if (!ctx.slotScopedSpecialityIds.includes(selectedSpecialityId)) {
+    ctx.setFormData((prev) => ({ ...prev, appointmentType: undefined }));
+    return;
+  }
+  const selectedServiceId = appointmentType?.id;
+  if (!selectedServiceId) return;
+  const allowedServices = ctx.slotScopedServicesBySpecialityId[selectedSpecialityId] ?? [];
+  const hasService = allowedServices.some((option) => option.value === selectedServiceId);
+  if (hasService) return;
+  ctx.setFormData((prev) => ({
+    ...prev,
+    appointmentType: {
+      ...prev.appointmentType,
+      id: '',
+      name: '',
+      speciality: prev.appointmentType?.speciality ?? { id: '', name: '' },
+    },
+  }));
+};
+
 export const useAppointmentForm = (options: UseAppointmentFormOptions = {}) => {
   const {
     onSuccess,
@@ -576,39 +704,15 @@ export const useAppointmentForm = (options: UseAppointmentFormOptions = {}) => {
   if (prevInitialPrefill !== initialPrefill) {
     setPrevInitialPrefill(initialPrefill);
     if (initialPrefill) {
-      setPendingPrefill(initialPrefill);
-      setSelectedDate(initialPrefill.date);
-      setSelectedSlot(null);
-      const prefillStart = buildDateInPreferredTimeZone(
-        initialPrefill.date,
-        initialPrefill.minuteOfDay
-      );
-
-      // Prefill lead immediately from teams — before service/slot are chosen.
-      // The pendingPrefill effect re-validates once a slot is matched.
-      const prefillLead = initialPrefill.leadId
-        ? teams.find(
-            (t) => normalizeId(t.practionerId || t._id) === normalizeId(initialPrefill.leadId)
-          )
-        : undefined;
-      const prefillLeadId = prefillLead ? prefillLead.practionerId || prefillLead._id : undefined;
-      const prefillLeadName = prefillLead?.name || prefillLead?.practionerId || prefillLead?._id;
-
-      setFormData((prev) => ({
-        ...prev,
-        appointmentDate: prefillStart,
-        startTime: prefillStart,
-        endTime: prefillStart,
-        ...(prefillLeadId
-          ? {
-              lead: {
-                id: prefillLeadId,
-                name: prefillLeadName ?? '',
-                profileUrl: getLeadProfileUrl(prefillLeadId),
-              },
-            }
-          : {}),
-      }));
+      applyIncomingPrefill(initialPrefill, {
+        teams,
+        normalizeId,
+        getLeadProfileUrl,
+        setPendingPrefill,
+        setSelectedDate,
+        setSelectedSlot,
+        setFormData,
+      });
     }
   }
 
@@ -1053,66 +1157,25 @@ export const useAppointmentForm = (options: UseAppointmentFormOptions = {}) => {
       serviceId: formData.appointmentType?.id,
       services,
     });
-    const selectedServiceId = formData.appointmentType?.id;
-    if (selectedServiceId) {
-      const selectedService = services.find((service) => service.id === selectedServiceId);
-      const serviceAppointmentKind = resolveServiceAppointmentKind(
-        selectedService,
-        appointmentKind
-      );
-      if (selectedService && serviceAppointmentKind !== appointmentKind) {
-        setFormData((prev) => ({
-          ...prev,
-          appointmentKind: serviceAppointmentKind,
-        }));
-      } else if (selectedService && selectedService.isBookable === false) {
-        // Inlined isSelectableAppointmentService: calling the helper here makes
-        // React Compiler treat selectedService as mutated during render.
-        setSelectedSlot(null);
-        setTimeSlots([]);
-        setFormData((prev) => ({
-          ...prev,
-          appointmentKind,
-          appointmentType: {
-            id: '',
-            name: '',
-            speciality: prev.appointmentType?.speciality ?? { id: '', name: '' },
-          },
-          lead: undefined,
-        }));
-        setFormDataErrors((prev) => ({
-          ...prev,
-          serviceId: 'Select a bookable service.',
-          slot: undefined,
-          leadId: undefined,
-        }));
-      }
-    }
+    syncServiceSelectionWithKind(formData.appointmentType?.id, {
+      appointmentKind,
+      services,
+      setFormData,
+      setFormDataErrors,
+      setSelectedSlot,
+      setTimeSlots,
+    });
   }
 
   // Prune selections that fall outside the slot-scoped options during render.
   // Each correction empties the offending selection, so the condition
   // self-invalidates on the follow-up render.
   if (calendarSlotFlow && slotScopedSpecialityIds.length) {
-    const selectedSpecialityId = formData.appointmentType?.speciality.id;
-    if (selectedSpecialityId && !slotScopedSpecialityIds.includes(selectedSpecialityId)) {
-      setFormData((prev) => ({ ...prev, appointmentType: undefined }));
-    } else if (selectedSpecialityId && formData.appointmentType?.id) {
-      const selectedServiceId = formData.appointmentType.id;
-      const allowedServices = slotScopedServicesBySpecialityId[selectedSpecialityId] ?? [];
-      const hasService = allowedServices.some((option) => option.value === selectedServiceId);
-      if (!hasService) {
-        setFormData((prev) => ({
-          ...prev,
-          appointmentType: {
-            ...prev.appointmentType,
-            id: '',
-            name: '',
-            speciality: prev.appointmentType?.speciality ?? { id: '', name: '' },
-          },
-        }));
-      }
-    }
+    pruneSelectionsOutsideSlotScope(formData.appointmentType, {
+      slotScopedSpecialityIds,
+      slotScopedServicesBySpecialityId,
+      setFormData,
+    });
   }
 
   const ServiceInfoData = useMemo(() => {

--- a/apps/frontend/src/app/lib/appointmentWorkspace.ts
+++ b/apps/frontend/src/app/lib/appointmentWorkspace.ts
@@ -10,6 +10,7 @@ import type {
 import type { AppointmentViewIntent } from '@/app/features/appointments/types/calendar';
 import { WORKSPACE_STEPS } from '@/app/features/appointments/types/workspace';
 import { normalizeAppointmentStatus, toStatusLabel } from '@/app/lib/appointments';
+import { isRichTextEmpty } from '@/app/lib/richText';
 import { formatDateInPreferredTimeZone, getDateKeyInPreferredTimeZone } from '@/app/lib/timezone';
 
 /** Default lock/edit window (hours) used until the org preference is wired. */
@@ -156,47 +157,8 @@ export const formatStampDate = (iso?: string): string => {
   return formatDateInPreferredTimeZone(date, { month: 'short', day: 'numeric' });
 };
 
-const stripHtmlTags = (html: string): string => {
-  let result = '';
-  let inTag = false;
-
-  for (const char of html) {
-    if (char === '<') {
-      inTag = true;
-      continue;
-    }
-    if (char === '>') {
-      inTag = false;
-      continue;
-    }
-    if (!inTag) {
-      result += char;
-    }
-  }
-
-  return result;
-};
-
-const replaceNbsp = (value: string): string => {
-  let result = '';
-  for (let index = 0; index < value.length; index += 1) {
-    if (value[index] === '&' && value.slice(index, index + 6) === '&nbsp;') {
-      result += ' ';
-      index += 5;
-      continue;
-    }
-    result += value[index];
-  }
-
-  return result;
-};
-
 /** Strip HTML tags to test whether a rich-text value carries any content. */
-export const richTextIsEmpty = (value: string | undefined): boolean => {
-  if (!value) return true;
-  const stripped = replaceNbsp(stripHtmlTags(value)).trim();
-  return stripped.length === 0;
-};
+export const richTextIsEmpty = (value: string | undefined): boolean => isRichTextEmpty(value);
 
 const pad2 = (value: number): string => String(value).padStart(2, '0');
 

--- a/apps/frontend/src/app/lib/options.ts
+++ b/apps/frontend/src/app/lib/options.ts
@@ -1,0 +1,16 @@
+/**
+ * Shared shape for `{ label, value }` select/option entries built from pair tuples.
+ */
+export type LabelValueOption<V extends string = string> = {
+  label: string;
+  value: V;
+};
+
+/**
+ * Build a `{ label, value }` option list from compact `[label, value]` pairs, so
+ * declarative option tables stay one line per entry instead of repeating the
+ * object literal shape for every row.
+ */
+export const makeOptions = <V extends string = string>(
+  pairs: ReadonlyArray<readonly [label: string, value: V]>
+): LabelValueOption<V>[] => pairs.map(([label, value]) => ({ label, value }));

--- a/apps/frontend/src/app/lib/richText.ts
+++ b/apps/frontend/src/app/lib/richText.ts
@@ -15,7 +15,8 @@ export const sanitizeRichText = (html: string = ''): string => {
   return DOMPurify.sanitize(html, { ALLOWED_TAGS, ALLOWED_ATTR });
 };
 
-const stripHtmlTags = (html: string): string => {
+/** Remove all HTML tags, keeping only text content (shared with appointmentWorkspace). */
+export const stripHtmlTags = (html: string): string => {
   let result = '';
   let inTag = false;
 
@@ -36,7 +37,8 @@ const stripHtmlTags = (html: string): string => {
   return result;
 };
 
-const replaceNbsp = (value: string): string => {
+/** Replace `&nbsp;` entities with plain spaces (shared with appointmentWorkspace). */
+export const replaceNbsp = (value: string): string => {
   let result = '';
   for (let index = 0; index < value.length; index += 1) {
     if (value[index] === '&' && value.slice(index, index + 6) === '&nbsp;') {

--- a/apps/frontend/src/app/stores/appointmentStore.ts
+++ b/apps/frontend/src/app/stores/appointmentStore.ts
@@ -1,5 +1,6 @@
 import { Appointment } from '@yosemite-crew/types';
 import { create } from 'zustand';
+import { loadingStatusActions } from '@/app/stores/loadingStatusActions';
 
 type StoreStatus = 'idle' | 'loading' | 'loaded' | 'error';
 
@@ -159,14 +160,5 @@ export const useAppointmentStore = create<AppointmentState>()((set, get) => ({
       lastFetchedAt: null,
     })),
 
-  startLoading: () => set(() => ({ status: 'loading', error: null })),
-
-  endLoading: () =>
-    set(() => ({
-      status: 'loaded',
-      error: null,
-      lastFetchedAt: new Date().toISOString(),
-    })),
-
-  setError: (message) => set(() => ({ status: 'error', error: message })),
+  ...loadingStatusActions(set),
 }));

--- a/apps/frontend/src/app/stores/integrationStore.ts
+++ b/apps/frontend/src/app/stores/integrationStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { IntegrationProvider, OrgIntegration } from '@/app/features/integrations/services/types';
+import { loadingStatusActions } from '@/app/stores/loadingStatusActions';
 
 type IntegrationStoreStatus = 'idle' | 'loading' | 'loaded' | 'error';
 
@@ -120,12 +121,5 @@ export const useIntegrationStore = create<IntegrationState>()((set, get) => ({
       lastFetchedAt: null,
     })),
 
-  startLoading: () => set(() => ({ status: 'loading', error: null })),
-  endLoading: () =>
-    set(() => ({
-      status: 'loaded',
-      error: null,
-      lastFetchedAt: new Date().toISOString(),
-    })),
-  setError: (message) => set(() => ({ status: 'error', error: message })),
+  ...loadingStatusActions(set),
 }));

--- a/apps/frontend/src/app/stores/loadingStatusActions.ts
+++ b/apps/frontend/src/app/stores/loadingStatusActions.ts
@@ -1,0 +1,33 @@
+export type LoadingStatus = 'idle' | 'loading' | 'loaded' | 'error';
+
+export type LoadingStatusState = {
+  status: LoadingStatus;
+  error: string | null;
+  lastFetchedAt: string | null;
+};
+
+export type LoadingStatusActions = {
+  startLoading: () => void;
+  endLoading: () => void;
+  setError: (message: string) => void;
+};
+
+type SetLoadingStatusState = (updater: () => Partial<LoadingStatusState>) => void;
+
+/**
+ * Shared `startLoading`/`endLoading`/`setError` actions spread into the
+ * org-scoped stores (appointmentStore, integrationStore) so their loading
+ * lifecycle stays identical.
+ */
+export const loadingStatusActions = (set: SetLoadingStatusState): LoadingStatusActions => ({
+  startLoading: () => set(() => ({ status: 'loading', error: null })),
+
+  endLoading: () =>
+    set(() => ({
+      status: 'loaded',
+      error: null,
+      lastFetchedAt: new Date().toISOString(),
+    })),
+
+  setError: (message) => set(() => ({ status: 'error', error: message })),
+});

--- a/apps/frontend/src/app/ui/filters/Filters/index.tsx
+++ b/apps/frontend/src/app/ui/filters/Filters/index.tsx
@@ -1,10 +1,12 @@
 'use client';
-import React, { useRef, useState, useEffect, useLayoutEffect, useCallback } from 'react';
+import React, { useRef, useState, useLayoutEffect, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { FilterOption, StatusOption } from '@/app/features/companions/pages/Companions/types';
 import clsx from 'clsx';
 import { Primary } from '@/app/ui/primitives/Buttons';
 import { IoAdd, IoChevronDown } from 'react-icons/io5';
+import StatusOptionButtons from '@/app/ui/filters/StatusOptionButtons';
+import { useFilterDropdownDismiss } from '@/app/ui/filters/useFilterDropdownDismiss';
 const getDropdownStatusTextColor = (status: StatusOption): string =>
   status.dropdownText ?? status.text ?? 'var(--color-text-primary)';
 
@@ -110,24 +112,7 @@ const Filters = ({
     if (open) positionPanel();
   }, [open, positionPanel]);
 
-  useEffect(() => {
-    if (!open) return;
-    const handleClose = (e: MouseEvent) => {
-      if (
-        triggerRef.current?.contains(e.target as Node) ||
-        panelRef.current?.contains(e.target as Node)
-      )
-        return;
-      setOpen(false);
-    };
-    const handleScroll = () => setOpen(false);
-    document.addEventListener('mousedown', handleClose);
-    globalThis.window.addEventListener('scroll', handleScroll, { passive: true, capture: true });
-    return () => {
-      document.removeEventListener('mousedown', handleClose);
-      globalThis.window.removeEventListener('scroll', handleScroll, { capture: true });
-    };
-  }, [open]);
+  useFilterDropdownDismiss(open, setOpen, triggerRef, panelRef);
 
   return (
     <div
@@ -228,46 +213,16 @@ const Filters = ({
                   className="yc-glass-overlay rounded-2xl overflow-hidden"
                   style={dropdownStyle}
                 >
-                  {statusOptions.map((status) => {
-                    const isActive = status.key === activeStatus;
-                    return (
-                      <button
-                        key={status.key}
-                        type="button"
-                        onClick={() => {
-                          setActiveStatus?.(status.key);
-                          setOpen(false);
-                        }}
-                        className={clsx(
-                          'w-full flex items-center gap-2.5 px-3 py-2 text-[13px] text-left transition-colors',
-                          isActive && status.key !== 'all' ? 'font-medium' : 'hover:bg-card-hover'
-                        )}
-                      >
-                        {status.border && (
-                          <span
-                            className="inline-block size-2 rounded-full shrink-0"
-                            style={{
-                              backgroundColor: status.border,
-                              borderWidth: '1px',
-                              borderStyle: 'solid',
-                              borderColor: status.border,
-                            }}
-                          />
-                        )}
-                        <span style={{ color: getDropdownStatusTextColor(status) }}>
-                          {status.name}
-                        </span>
-                        {isActive && (
-                          <span
-                            className="ml-auto text-[12px] font-semibold"
-                            style={{ color: getDropdownStatusTextColor(status) }}
-                          >
-                            ✓
-                          </span>
-                        )}
-                      </button>
-                    );
-                  })}
+                  <StatusOptionButtons
+                    options={statusOptions}
+                    activeKey={activeStatus}
+                    allKey="all"
+                    onSelect={(key) => {
+                      setActiveStatus?.(key);
+                      setOpen(false);
+                    }}
+                    getTextColor={getDropdownStatusTextColor}
+                  />
                 </div>,
                 document.body
               )}

--- a/apps/frontend/src/app/ui/filters/FormsFilters/index.tsx
+++ b/apps/frontend/src/app/ui/filters/FormsFilters/index.tsx
@@ -5,10 +5,11 @@ import {
   getFormCategoryOptionsForOrgType,
 } from '@/app/features/forms/types/forms';
 import type { FormsCategory, FormsStatus } from '@/app/features/forms/types/forms';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { IoChevronDown } from 'react-icons/io5';
 import clsx from 'clsx';
+import { useFilterDropdownDismiss } from '@/app/ui/filters/useFilterDropdownDismiss';
 import { useOrgStore } from '@/app/stores/orgStore';
 import { Organisation } from '@yosemite-crew/types';
 import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
@@ -80,24 +81,7 @@ const FormsFilters = ({ filters, onFiltersChange, categoryAction }: FormsFilters
   const panelRef = useRef<HTMLDivElement>(null);
   const isMounted = typeof document !== 'undefined';
 
-  useEffect(() => {
-    if (!open) return;
-    const handleClose = (e: MouseEvent) => {
-      if (
-        triggerRef.current?.contains(e.target as Node) ||
-        panelRef.current?.contains(e.target as Node)
-      )
-        return;
-      setOpen(false);
-    };
-    const handleScroll = () => setOpen(false);
-    document.addEventListener('mousedown', handleClose);
-    window.addEventListener('scroll', handleScroll, { passive: true, capture: true });
-    return () => {
-      document.removeEventListener('mousedown', handleClose);
-      window.removeEventListener('scroll', handleScroll, { capture: true });
-    };
-  }, [open]);
+  useFilterDropdownDismiss(open, setOpen, triggerRef, panelRef);
 
   const [panelStyle, setPanelStyle] = useState<React.CSSProperties | undefined>(undefined);
 

--- a/apps/frontend/src/app/ui/filters/InventoryFilters/index.tsx
+++ b/apps/frontend/src/app/ui/filters/InventoryFilters/index.tsx
@@ -1,55 +1,20 @@
 'use client';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { IoCaretDown } from 'react-icons/io5';
 import clsx from 'clsx';
 import { InventoryFiltersState } from '@/app/features/inventory/pages/Inventory/types';
+import { statusLabel, type StatusLabel } from '@/app/constants/status';
 import LabelDropdown from '@/app/ui/inputs/Dropdown/LabelDropdown';
+import StatusOptionButtons from '@/app/ui/filters/StatusOptionButtons';
+import { useFilterDropdownDismiss } from '@/app/ui/filters/useFilterDropdownDismiss';
 
-type StockHealthOption = {
-  key: string;
-  name: string;
-  bg: string;
-  text: string;
-  border: string;
-};
-
-const StockHealthOptions: StockHealthOption[] = [
-  {
-    name: 'All',
-    key: 'ALL',
-    bg: 'var(--color-badge-blue-bg)',
-    text: 'var(--color-badge-blue-text)',
-    border: 'var(--color-primary-500)',
-  },
-  {
-    name: 'Healthy',
-    key: 'HEALTHY',
-    bg: 'var(--color-pill-success-bg)',
-    text: 'var(--color-pill-success-text)',
-    border: 'var(--color-pill-success-border)',
-  },
-  {
-    name: 'Low stock',
-    key: 'LOW_STOCK',
-    bg: 'var(--color-pill-progress-bg)',
-    text: 'var(--color-pill-progress-text)',
-    border: 'var(--color-pill-progress-border)',
-  },
-  {
-    name: 'Expiring soon',
-    key: 'EXPIRING_SOON',
-    bg: 'var(--color-pill-info-bg)',
-    text: 'var(--color-pill-info-text)',
-    border: 'var(--color-pill-info-border)',
-  },
-  {
-    name: 'Expired',
-    key: 'EXPIRED',
-    bg: 'var(--color-pill-warning-bg)',
-    text: 'var(--color-pill-warning-text)',
-    border: 'var(--color-pill-warning-border)',
-  },
+const StockHealthOptions: StatusLabel[] = [
+  statusLabel('All', 'ALL', 'color-badge-blue', 'var(--color-primary-500)'),
+  statusLabel('Healthy', 'HEALTHY', 'color-pill-success'),
+  statusLabel('Low stock', 'LOW_STOCK', 'color-pill-progress'),
+  statusLabel('Expiring soon', 'EXPIRING_SOON', 'color-pill-info'),
+  statusLabel('Expired', 'EXPIRED', 'color-pill-warning'),
 ];
 
 const getSliderTranslate = (visibility: string): string => {
@@ -64,7 +29,10 @@ const getVisibilityLabel = (key: 'ALL' | 'ACTIVE' | 'HIDDEN'): string => {
   return 'Hidden';
 };
 
-const getStockHealthButtonStyle = (option: StockHealthOption): React.CSSProperties => {
+const getStockHealthDropdownTextColor = (option: StatusLabel): string =>
+  option.key === 'ALL' ? 'var(--color-text-primary)' : option.text;
+
+const getStockHealthButtonStyle = (option: StatusLabel): React.CSSProperties => {
   if (option.key === 'ALL') {
     return {
       borderWidth: '1px',
@@ -118,24 +86,7 @@ const InventoryFilters = ({
     onChange({ ...filters, category: 'all' });
   }
 
-  useEffect(() => {
-    if (!dropdownOpen) return;
-    const handleClose = (e: MouseEvent) => {
-      if (
-        triggerRef.current?.contains(e.target as Node) ||
-        panelRef.current?.contains(e.target as Node)
-      )
-        return;
-      setDropdownOpen(false);
-    };
-    const handleScroll = () => setDropdownOpen(false);
-    document.addEventListener('mousedown', handleClose);
-    window.addEventListener('scroll', handleScroll, { passive: true, capture: true });
-    return () => {
-      document.removeEventListener('mousedown', handleClose);
-      window.removeEventListener('scroll', handleScroll, { capture: true });
-    };
-  }, [dropdownOpen]);
+  useFilterDropdownDismiss(dropdownOpen, setDropdownOpen, triggerRef, panelRef);
 
   const selectedStockHealth =
     StockHealthOptions.find((o) => o.key === filters.status) ?? StockHealthOptions[0];
@@ -229,44 +180,16 @@ const InventoryFilters = ({
               className="yc-glass-overlay rounded-2xl overflow-hidden"
               style={dropdownStyle}
             >
-              {StockHealthOptions.map((option) => {
-                const isSelected = option.key === filters.status;
-                const dropdownTextColor =
-                  option.key === 'ALL' ? 'var(--color-text-primary)' : option.text;
-                return (
-                  <button
-                    key={option.key}
-                    type="button"
-                    onClick={() => {
-                      updateFilters({ status: option.key });
-                      setDropdownOpen(false);
-                    }}
-                    className={clsx(
-                      'w-full flex items-center gap-2.5 px-3 py-2 text-[13px] text-left transition-colors',
-                      isSelected && option.key !== 'ALL' ? 'font-medium' : 'hover:bg-card-hover'
-                    )}
-                  >
-                    <span
-                      className="inline-block size-2 rounded-full shrink-0"
-                      style={{
-                        backgroundColor: option.border,
-                        borderWidth: '1px',
-                        borderStyle: 'solid',
-                        borderColor: option.border,
-                      }}
-                    />
-                    <span style={{ color: dropdownTextColor }}>{option.name}</span>
-                    {isSelected && (
-                      <span
-                        className="ml-auto text-[12px] font-semibold"
-                        style={{ color: dropdownTextColor }}
-                      >
-                        ✓
-                      </span>
-                    )}
-                  </button>
-                );
-              })}
+              <StatusOptionButtons
+                options={StockHealthOptions}
+                activeKey={filters.status}
+                allKey="ALL"
+                onSelect={(key) => {
+                  updateFilters({ status: key });
+                  setDropdownOpen(false);
+                }}
+                getTextColor={getStockHealthDropdownTextColor}
+              />
             </div>,
             document.body
           )}

--- a/apps/frontend/src/app/ui/filters/InventoryTurnoverFilters/index.tsx
+++ b/apps/frontend/src/app/ui/filters/InventoryTurnoverFilters/index.tsx
@@ -1,60 +1,28 @@
 'use client';
-import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { IoCaretDown } from 'react-icons/io5';
 import clsx from 'clsx';
+import { statusLabel, type StatusLabel } from '@/app/constants/status';
 import LabelDropdown from '@/app/ui/inputs/Dropdown/LabelDropdown';
+import StatusOptionButtons from '@/app/ui/filters/StatusOptionButtons';
+import { useFilterDropdownDismiss } from '@/app/ui/filters/useFilterDropdownDismiss';
 
-const STATUS_OPTIONS = [
-  {
-    name: 'All',
-    key: 'ALL',
-    bg: 'var(--color-badge-blue-bg)',
-    text: 'var(--color-badge-blue-text)',
-    border: 'var(--color-primary-500)',
-  },
-  {
-    name: 'Excellent',
-    key: 'EXCELLENT',
-    bg: 'var(--color-pill-success-bg)',
-    text: 'var(--color-pill-success-text)',
-    border: 'var(--color-pill-success-border)',
-  },
-  {
-    name: 'Healthy',
-    key: 'HEALTHY',
-    bg: 'var(--color-pill-success-bg)',
-    text: 'var(--color-pill-success-text)',
-    border: 'var(--color-pill-success-border)',
-  },
-  {
-    name: 'Moderate',
-    key: 'MODERATE',
-    bg: 'var(--color-pill-progress-bg)',
-    text: 'var(--color-pill-progress-text)',
-    border: 'var(--color-pill-progress-border)',
-  },
-  {
-    name: 'Low',
-    key: 'LOW',
-    bg: 'var(--color-pill-warning-bg)',
-    text: 'var(--color-pill-warning-text)',
-    border: 'var(--color-pill-warning-border)',
-  },
-  {
-    name: 'Out of stock',
-    key: 'OUT OF STOCK',
-    bg: 'var(--color-pill-warning-bg)',
-    text: 'var(--color-pill-warning-text)',
-    border: 'var(--color-pill-warning-border)',
-  },
+const STATUS_OPTIONS: StatusLabel[] = [
+  statusLabel('All', 'ALL', 'color-badge-blue', 'var(--color-primary-500)'),
+  statusLabel('Excellent', 'EXCELLENT', 'color-pill-success'),
+  statusLabel('Healthy', 'HEALTHY', 'color-pill-success'),
+  statusLabel('Moderate', 'MODERATE', 'color-pill-progress'),
+  statusLabel('Low', 'LOW', 'color-pill-warning'),
+  statusLabel('Out of stock', 'OUT OF STOCK', 'color-pill-warning'),
 ];
 
 const DEFAULT_CATEGORIES: string[] = [];
 
-const getTurnoverStatusButtonStyle = (
-  option: (typeof STATUS_OPTIONS)[number]
-): React.CSSProperties => {
+const getTurnoverDropdownTextColor = (option: StatusLabel): string =>
+  option.key === 'ALL' ? 'var(--color-text-primary)' : option.text;
+
+const getTurnoverStatusButtonStyle = (option: StatusLabel): React.CSSProperties => {
   if (option.key === 'ALL') {
     return {
       borderWidth: '1px',
@@ -130,24 +98,7 @@ const InventoryTurnoverFilters = ({
     if (dropdownOpen) positionPanel();
   }, [dropdownOpen, positionPanel]);
 
-  useEffect(() => {
-    if (!dropdownOpen) return;
-    const handleClose = (e: MouseEvent) => {
-      if (
-        triggerRef.current?.contains(e.target as Node) ||
-        panelRef.current?.contains(e.target as Node)
-      )
-        return;
-      setDropdownOpen(false);
-    };
-    const handleScroll = () => setDropdownOpen(false);
-    document.addEventListener('mousedown', handleClose);
-    window.addEventListener('scroll', handleScroll, { passive: true, capture: true });
-    return () => {
-      document.removeEventListener('mousedown', handleClose);
-      window.removeEventListener('scroll', handleScroll, { capture: true });
-    };
-  }, [dropdownOpen]);
+  useFilterDropdownDismiss(dropdownOpen, setDropdownOpen, triggerRef, panelRef);
 
   const selectedStatus = STATUS_OPTIONS.find((o) => o.key === filters.status) ?? STATUS_OPTIONS[0];
 
@@ -176,44 +127,16 @@ const InventoryTurnoverFilters = ({
               className="yc-glass-overlay rounded-2xl overflow-hidden"
               style={dropdownStyle}
             >
-              {STATUS_OPTIONS.map((option) => {
-                const isSelected = option.key === filters.status;
-                const dropdownTextColor =
-                  option.key === 'ALL' ? 'var(--color-text-primary)' : option.text;
-                return (
-                  <button
-                    key={option.key}
-                    type="button"
-                    onClick={() => {
-                      setActiveStatus(option.key);
-                      setDropdownOpen(false);
-                    }}
-                    className={clsx(
-                      'w-full flex items-center gap-2.5 px-3 py-2 text-[13px] text-left transition-colors',
-                      isSelected && option.key !== 'ALL' ? 'font-medium' : 'hover:bg-card-hover'
-                    )}
-                  >
-                    <span
-                      className="inline-block size-2 rounded-full shrink-0"
-                      style={{
-                        backgroundColor: option.border,
-                        borderWidth: '1px',
-                        borderStyle: 'solid',
-                        borderColor: option.border,
-                      }}
-                    />
-                    <span style={{ color: dropdownTextColor }}>{option.name}</span>
-                    {isSelected && (
-                      <span
-                        className="ml-auto text-[12px] font-semibold"
-                        style={{ color: dropdownTextColor }}
-                      >
-                        ✓
-                      </span>
-                    )}
-                  </button>
-                );
-              })}
+              <StatusOptionButtons
+                options={STATUS_OPTIONS}
+                activeKey={filters.status}
+                allKey="ALL"
+                onSelect={(key) => {
+                  setActiveStatus(key);
+                  setDropdownOpen(false);
+                }}
+                getTextColor={getTurnoverDropdownTextColor}
+              />
             </div>,
             document.body
           )}

--- a/apps/frontend/src/app/ui/filters/StatusOptionButtons.tsx
+++ b/apps/frontend/src/app/ui/filters/StatusOptionButtons.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import clsx from 'clsx';
+
+export type StatusOptionButtonsOption = {
+  key: string;
+  name: string;
+  border?: string;
+};
+
+type StatusOptionButtonsProps<Option extends StatusOptionButtonsOption> = {
+  options: Option[];
+  activeKey?: string;
+  /** Key of the neutral "all" option, which never takes the active font weight. */
+  allKey: string;
+  onSelect: (key: string) => void;
+  getTextColor: (option: Option) => string;
+};
+
+/**
+ * Option rows shared by the status-filter dropdown panels: a dot swatch in the
+ * option's border colour, the option name in its own text colour, and a
+ * trailing check on the active row. The caller keeps its own portal wrapper,
+ * panel styling, trigger, and selection state.
+ */
+const StatusOptionButtons = <Option extends StatusOptionButtonsOption>({
+  options,
+  activeKey,
+  allKey,
+  onSelect,
+  getTextColor,
+}: StatusOptionButtonsProps<Option>) => (
+  <>
+    {options.map((option) => {
+      const isActive = option.key === activeKey;
+      const textColor = getTextColor(option);
+      return (
+        <button
+          key={option.key}
+          type="button"
+          onClick={() => onSelect(option.key)}
+          className={clsx(
+            'w-full flex items-center gap-2.5 px-3 py-2 text-[13px] text-left transition-colors',
+            isActive && option.key !== allKey ? 'font-medium' : 'hover:bg-card-hover'
+          )}
+        >
+          {option.border && (
+            <span
+              className="inline-block size-2 rounded-full shrink-0"
+              style={{
+                backgroundColor: option.border,
+                borderWidth: '1px',
+                borderStyle: 'solid',
+                borderColor: option.border,
+              }}
+            />
+          )}
+          <span style={{ color: textColor }}>{option.name}</span>
+          {isActive && (
+            <span className="ml-auto text-[12px] font-semibold" style={{ color: textColor }}>
+              ✓
+            </span>
+          )}
+        </button>
+      );
+    })}
+  </>
+);
+
+export default StatusOptionButtons;

--- a/apps/frontend/src/app/ui/filters/useFilterDropdownDismiss.ts
+++ b/apps/frontend/src/app/ui/filters/useFilterDropdownDismiss.ts
@@ -1,0 +1,33 @@
+import { useEffect, type RefObject } from 'react';
+
+/**
+ * Dismisses an anchored dropdown panel: closes it on any mousedown that lands
+ * outside both the trigger and the panel, and on any scroll (captured, so
+ * nested scroll containers dismiss it too). No-op while `open` is false so
+ * idle dropdowns don't keep listeners attached.
+ */
+export const useFilterDropdownDismiss = (
+  open: boolean,
+  setOpen: (open: boolean) => void,
+  triggerRef: RefObject<HTMLElement | null>,
+  panelRef: RefObject<HTMLElement | null>
+): void => {
+  useEffect(() => {
+    if (!open) return;
+    const handleClose = (e: MouseEvent) => {
+      if (
+        triggerRef.current?.contains(e.target as Node) ||
+        panelRef.current?.contains(e.target as Node)
+      )
+        return;
+      setOpen(false);
+    };
+    const handleScroll = () => setOpen(false);
+    document.addEventListener('mousedown', handleClose);
+    globalThis.window.addEventListener('scroll', handleScroll, { passive: true, capture: true });
+    return () => {
+      document.removeEventListener('mousedown', handleClose);
+      globalThis.window.removeEventListener('scroll', handleScroll, { capture: true });
+    };
+  }, [open, setOpen, triggerRef, panelRef]);
+};

--- a/apps/frontend/src/app/ui/inputs/Dropdown/LabelDropdown.tsx
+++ b/apps/frontend/src/app/ui/inputs/Dropdown/LabelDropdown.tsx
@@ -1,8 +1,10 @@
-import React, { useCallback, useEffect, useId, useLayoutEffect, useRef, useState } from 'react';
+import React, { useCallback, useId, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { IoChevronDown } from 'react-icons/io5';
 import { IoIosWarning } from 'react-icons/io';
 import { useDropdown, useFilteredOptions, DropdownOption } from '@/app/hooks/useDropdown';
+import { useListboxKeyboardNav } from './useDropdownKeyboardNav';
+import { useDropdownPositioning } from './useDropdownPositioning';
 
 type DropdownProps = {
   placeholder: string;
@@ -17,27 +19,6 @@ type DropdownProps = {
   noOptionsMessage?: string;
 };
 
-/** Wrap the active option index when navigating with the arrow keys. */
-const wrapActiveIndex = (current: number, optionCount: number, delta: 1 | -1): number => {
-  if (delta === 1) return current + 1 >= optionCount ? 0 : current + 1;
-  return current <= 0 ? optionCount - 1 : current - 1;
-};
-
-/** Compute the active option index when the open/options/selection context changes. */
-const resolveActiveIndex = (
-  open: boolean,
-  options: DropdownOption[],
-  activeIndex: number,
-  selectedValue?: string
-): number => {
-  if (!open || options.length === 0) return -1;
-  if (activeIndex >= 0 && activeIndex < options.length) return activeIndex;
-  const selectedIndex = options.findIndex((option) => option.value === selectedValue);
-  return Math.max(selectedIndex, 0);
-};
-
-const DROPDOWN_MAX_HEIGHT = 200;
-const DROPDOWN_MIN_HEIGHT = 72;
 const TERMINOLOGY_LOCK_SELECTOR = "[data-terminology-lock='true']";
 
 const findDropdownOption = (options: DropdownOption[], defaultOption?: string) => {
@@ -215,8 +196,6 @@ const LabelDropdown = ({
   const [internalSelected, setInternalSelected] = useState<DropdownOption | null>(() =>
     findDropdownOption(options, defaultOption)
   );
-  const [portalStyle, setPortalStyle] = useState<React.CSSProperties | null>(null);
-  const [activeIndex, setActiveIndex] = useState(-1);
   const listboxId = useId();
   const controlledSelected = findDropdownOption(options, defaultOption);
   // `internalSelected` is the single source of truth so a user click always moves
@@ -254,84 +233,15 @@ const LabelDropdown = ({
     },
     [dropdownRef]
   );
-  const activeOptionId =
-    activeIndex >= 0 && activeIndex < filteredOptions.length
-      ? `${listboxId}-option-${filteredOptions[activeIndex].value}`
-      : undefined;
 
-  const computeStyle = useCallback(() => {
-    const rect = dropdownRef.current?.getBoundingClientRect();
-    if (!rect) return;
-    const viewportHeight = globalThis.window.innerHeight;
-    const spaceBelow = viewportHeight - rect.bottom;
-    const panelMaxHeight = Math.min(
-      DROPDOWN_MAX_HEIGHT,
-      Math.max(DROPDOWN_MIN_HEIGHT, spaceBelow - 8)
-    );
-    setPortalStyle({
-      position: 'absolute',
-      left: rect.left + globalThis.window.scrollX,
-      width: rect.width,
-      // Design detaches the menu from the trigger by 4px.
-      top: rect.bottom + globalThis.window.scrollY + 4,
-      maxHeight: panelMaxHeight,
-      zIndex: 5000,
-    });
-  }, [dropdownRef]);
-
-  const computeStyleRef = useRef(computeStyle);
-  useLayoutEffect(() => {
-    computeStyleRef.current = computeStyle;
-  });
-
-  // Clear the floating style the moment the panel closes (render-time adjust,
-  // guarded so it only fires when open/portal actually change).
-  const [prevOpenPortal, setPrevOpenPortal] = useState({ open, portal });
-  if (prevOpenPortal.open !== open || prevOpenPortal.portal !== portal) {
-    setPrevOpenPortal({ open, portal });
-    if (!open || !portal) setPortalStyle(null);
-  }
-
-  useLayoutEffect(() => {
-    if (!open || !portal) return;
-    computeStyleRef.current();
-  }, [open, portal]);
-
-  useEffect(() => {
-    if (!open || !portal) return;
-    const stableResize = () => computeStyleRef.current();
-    const handleOuterScroll = (event: Event) => {
-      const target = event.target;
-      if (target instanceof HTMLElement && target.closest('[data-portal-dropdown]')) return;
-      closeDropdown();
-    };
-    globalThis.window.addEventListener('resize', stableResize);
-    globalThis.window.addEventListener('scroll', handleOuterScroll, true);
-    return () => {
-      globalThis.window.removeEventListener('resize', stableResize);
-      globalThis.window.removeEventListener('scroll', handleOuterScroll, true);
-    };
-  }, [closeDropdown, open, portal]);
-
-  const [activeIndexDeps, setActiveIndexDeps] = useState({
-    filteredOptions,
+  const { portalStyle } = useDropdownPositioning({
     open,
-    selectedValue: selected?.value,
+    portal,
+    dropdownRef,
+    onOuterScrollDismiss: closeDropdown,
+    // Design detaches the menu from the trigger by 4px.
+    topOffset: 4,
   });
-  if (
-    filteredOptions !== activeIndexDeps.filteredOptions ||
-    open !== activeIndexDeps.open ||
-    selected?.value !== activeIndexDeps.selectedValue
-  ) {
-    setActiveIndexDeps({ filteredOptions, open, selectedValue: selected?.value });
-    setActiveIndex(resolveActiveIndex(open, filteredOptions, activeIndex, selected?.value));
-  }
-
-  useEffect(() => {
-    if (!open || !activeOptionId) return;
-    const activeElement = document.getElementById(activeOptionId);
-    activeElement?.scrollIntoView({ block: 'nearest' });
-  }, [activeOptionId, open]);
 
   const selectOption = useCallback(
     (option: DropdownOption) => {
@@ -342,65 +252,17 @@ const LabelDropdown = ({
     [closeDropdown, onSelect]
   );
 
-  const handleArrowKey = useCallback(
-    (delta: 1 | -1) => {
-      const optionCount = filteredOptions.length;
-      if (optionCount === 0) return;
-      if (!open) {
-        openDropdown();
-        return;
-      }
-      setActiveIndex((current) => wrapActiveIndex(current, optionCount, delta));
-    },
-    [filteredOptions.length, open, openDropdown]
-  );
-
-  const handleConfirmKey = useCallback(() => {
-    const optionCount = filteredOptions.length;
-    if (!open) {
-      openDropdown();
-      return;
-    }
-    if (activeIndex < 0 || activeIndex >= optionCount) return;
-    selectOption(filteredOptions[activeIndex]);
-  }, [activeIndex, filteredOptions, open, openDropdown, selectOption]);
-
-  const handleKeyDown = useCallback(
-    (event: React.KeyboardEvent) => {
-      const optionCount = filteredOptions.length;
-      switch (event.key) {
-        case 'Escape':
-          event.preventDefault();
-          closeDropdown();
-          return;
-        case 'ArrowDown':
-          event.preventDefault();
-          handleArrowKey(1);
-          return;
-        case 'ArrowUp':
-          event.preventDefault();
-          handleArrowKey(-1);
-          return;
-        case 'Home':
-          if (!open || optionCount === 0) return;
-          event.preventDefault();
-          setActiveIndex(0);
-          return;
-        case 'End':
-          if (!open || optionCount === 0) return;
-          event.preventDefault();
-          setActiveIndex(optionCount - 1);
-          return;
-        case 'Enter':
-        case ' ':
-          event.preventDefault();
-          handleConfirmKey();
-          return;
-        default:
-      }
-    },
-    [closeDropdown, filteredOptions.length, handleArrowKey, handleConfirmKey, open]
-  );
+  const { activeOptionId, setActiveIndex, handleKeyDown } = useListboxKeyboardNav({
+    open,
+    openDropdown,
+    closeDropdown,
+    options: filteredOptions,
+    listboxId,
+    selectionKey: selected?.value,
+    getOptionValue: (option) => option.value,
+    isOptionSelected: (option) => option.value === selected?.value,
+    selectOption,
+  });
 
   // Same visual style for both portal and inline — connected panel below trigger
   const panelNode = (

--- a/apps/frontend/src/app/ui/inputs/Dropdown/index.tsx
+++ b/apps/frontend/src/app/ui/inputs/Dropdown/index.tsx
@@ -1,29 +1,11 @@
-import React, { useEffect, useId, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useId, useRef, useState } from 'react';
 import { IoChevronDown } from 'react-icons/io5';
 import { IoIosWarning } from 'react-icons/io';
+import { useListboxKeyboardNav } from './useDropdownKeyboardNav';
 
 type Option = {
   key: string;
   label: string;
-};
-
-/** Wrap the active option index when navigating with the arrow keys. */
-const wrapActiveIndex = (current: number, optionCount: number, delta: 1 | -1): number => {
-  if (delta === 1) return current + 1 >= optionCount ? 0 : current + 1;
-  return current <= 0 ? optionCount - 1 : current - 1;
-};
-
-/** Compute the active option index when the open/options/selection context changes. */
-const resolveActiveIndex = (
-  open: boolean,
-  options: Option[],
-  activeIndex: number,
-  selectedKey?: string
-): number => {
-  if (!open || options.length === 0) return -1;
-  if (activeIndex >= 0 && activeIndex < options.length) return activeIndex;
-  const selectedIndex = options.findIndex((option) => option.key === selectedKey);
-  return Math.max(selectedIndex, 0);
 };
 
 type DropdownProps = {
@@ -37,13 +19,8 @@ type DropdownProps = {
 const Dropdown = ({ placeholder, options, defaultOption, onSelect, error }: DropdownProps) => {
   const [open, setOpen] = useState(false);
   const [selected, setSelected] = useState<Option | null>(null);
-  const [activeIndex, setActiveIndex] = useState(-1);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const listboxId = useId();
-  const activeOptionId =
-    activeIndex >= 0 && activeIndex < options.length
-      ? `${listboxId}-option-${options[activeIndex].key}`
-      : undefined;
 
   const [prevDefaultDeps, setPrevDefaultDeps] = useState<{
     defaultOption?: string;
@@ -73,84 +50,26 @@ const Dropdown = ({ placeholder, options, defaultOption, onSelect, error }: Drop
     };
   }, []);
 
-  const [activeIndexDeps, setActiveIndexDeps] = useState({
-    options,
-    open,
-    selectedKey: selected?.key,
-  });
-  if (
-    options !== activeIndexDeps.options ||
-    open !== activeIndexDeps.open ||
-    selected?.key !== activeIndexDeps.selectedKey
-  ) {
-    setActiveIndexDeps({ options, open, selectedKey: selected?.key });
-    setActiveIndex(resolveActiveIndex(open, options, activeIndex, selected?.key));
-  }
-
-  useEffect(() => {
-    if (!open || !activeOptionId) return;
-    document.getElementById(activeOptionId)?.scrollIntoView({ block: 'nearest' });
-  }, [activeOptionId, open]);
-
   const selectOption = (option: Option) => {
     setSelected(option);
     onSelect(option);
     setOpen(false);
   };
 
-  const handleArrowKey = (delta: 1 | -1) => {
-    const optionCount = options.length;
-    if (optionCount === 0) return;
-    if (!open) {
-      setOpen(true);
-      return;
-    }
-    setActiveIndex((current) => wrapActiveIndex(current, optionCount, delta));
-  };
+  const openDropdown = useCallback(() => setOpen(true), []);
+  const closeDropdown = useCallback(() => setOpen(false), []);
 
-  const handleConfirmKey = () => {
-    const optionCount = options.length;
-    if (!open) {
-      setOpen(true);
-      return;
-    }
-    if (activeIndex < 0 || activeIndex >= optionCount) return;
-    selectOption(options[activeIndex]);
-  };
-
-  const handleKeyDown = (event: React.KeyboardEvent) => {
-    const optionCount = options.length;
-    switch (event.key) {
-      case 'Escape':
-        event.preventDefault();
-        setOpen(false);
-        return;
-      case 'ArrowDown':
-        event.preventDefault();
-        handleArrowKey(1);
-        return;
-      case 'ArrowUp':
-        event.preventDefault();
-        handleArrowKey(-1);
-        return;
-      case 'Home':
-        if (!open || optionCount === 0) return;
-        event.preventDefault();
-        setActiveIndex(0);
-        return;
-      case 'End':
-        if (!open || optionCount === 0) return;
-        event.preventDefault();
-        setActiveIndex(optionCount - 1);
-        return;
-      case 'Enter':
-      case ' ':
-        event.preventDefault();
-        handleConfirmKey();
-        return;
-      default:
-    }
-  };
+  const { activeOptionId, setActiveIndex, handleKeyDown } = useListboxKeyboardNav({
+    open,
+    openDropdown,
+    closeDropdown,
+    options,
+    listboxId,
+    selectionKey: selected?.key,
+    getOptionValue: (option) => option.key,
+    isOptionSelected: (option) => option.key === selected?.key,
+    selectOption,
+  });
 
   return (
     <div className="relative" ref={dropdownRef}>

--- a/apps/frontend/src/app/ui/inputs/Dropdown/useDropdownKeyboardNav.ts
+++ b/apps/frontend/src/app/ui/inputs/Dropdown/useDropdownKeyboardNav.ts
@@ -3,51 +3,64 @@ import { wrapActiveIndex } from './dropdownHelpers';
 
 type DropdownOption = { key: string | number; label: string; value: string };
 
-type UseDropdownKeyboardNavArgs = {
+export type ListboxKeyboardNavArgs<T> = {
   open: boolean;
-  setOpen: (open: boolean) => void;
-  disabled: boolean;
-  filteredList: DropdownOption[];
-  value: string;
+  openDropdown: () => void;
+  closeDropdown: () => void;
+  /** Ignore every key while the control is disabled. */
+  disabled?: boolean;
+  options: T[];
   listboxId: string;
-  selectOption: (option: DropdownOption) => void;
+  /** Identity of the current selection; when it changes the active index re-syncs. */
+  selectionKey: unknown;
+  /** Id-suffix used for the option's DOM id (`${listboxId}-option-${...}`). */
+  getOptionValue: (option: T) => string;
+  /** Seeds the active index from the currently selected option. */
+  isOptionSelected: (option: T) => boolean;
+  selectOption: (option: T) => void;
+  /** Searchable variant only: Space typed into the query input must type, not confirm. */
+  spaceSkipsInput?: boolean;
 };
 
 /**
- * Extracted from Dropdown: owns the active-option index, keeps it in sync
- * with the filtered option list / open state / selected value (adjusted
- * during render, per React's "you might not need an effect" guidance — kept
- * as-is, not converted to a reducer), and the roving keyboard navigation
- * (arrow keys, Home/End, Enter/Space, Escape). Pure structural extraction,
- * behavior unchanged.
+ * Shared roving keyboard navigation for every dropdown/listbox variant: owns
+ * the active-option index, keeps it in sync with the option list / open state
+ * / selection (adjusted during render, per React's "you might not need an
+ * effect" guidance — kept as-is, not converted to a reducer), scrolls the
+ * active option into view, and handles ArrowUp/ArrowDown, Home/End,
+ * Enter/Space, and Escape.
  */
-export function useDropdownKeyboardNav({
+export function useListboxKeyboardNav<T>({
   open,
-  setOpen,
-  disabled,
-  filteredList,
-  value,
+  openDropdown,
+  closeDropdown,
+  disabled = false,
+  options,
   listboxId,
+  selectionKey,
+  getOptionValue,
+  isOptionSelected,
   selectOption,
-}: UseDropdownKeyboardNavArgs) {
+  spaceSkipsInput = false,
+}: ListboxKeyboardNavArgs<T>) {
   const [activeIndex, setActiveIndex] = useState(-1);
 
   const activeOptionId =
-    activeIndex >= 0 && activeIndex < filteredList.length
-      ? `${listboxId}-option-${filteredList[activeIndex].value}`
+    activeIndex >= 0 && activeIndex < options.length
+      ? `${listboxId}-option-${getOptionValue(options[activeIndex])}`
       : undefined;
 
-  const [activeIndexDeps, setActiveIndexDeps] = useState({ filteredList, open, value });
+  const [activeIndexDeps, setActiveIndexDeps] = useState({ options, open, selectionKey });
   if (
-    filteredList !== activeIndexDeps.filteredList ||
+    options !== activeIndexDeps.options ||
     open !== activeIndexDeps.open ||
-    value !== activeIndexDeps.value
+    selectionKey !== activeIndexDeps.selectionKey
   ) {
-    setActiveIndexDeps({ filteredList, open, value });
-    if (!open || filteredList.length === 0) {
+    setActiveIndexDeps({ options, open, selectionKey });
+    if (!open || options.length === 0) {
       setActiveIndex(-1);
-    } else if (activeIndex < 0 || activeIndex >= filteredList.length) {
-      const selectedIndex = filteredList.findIndex((option) => option.value === value);
+    } else if (activeIndex < 0 || activeIndex >= options.length) {
+      const selectedIndex = options.findIndex((option) => isOptionSelected(option));
       setActiveIndex(Math.max(selectedIndex, 0));
     }
   }
@@ -59,35 +72,35 @@ export function useDropdownKeyboardNav({
 
   const handleArrowKey = useCallback(
     (delta: 1 | -1) => {
-      const optionCount = filteredList.length;
+      const optionCount = options.length;
       if (optionCount === 0) return;
       if (!open) {
-        setOpen(true);
+        openDropdown();
         return;
       }
       setActiveIndex((current) => wrapActiveIndex(current, optionCount, delta));
     },
-    [filteredList.length, open, setOpen]
+    [options.length, open, openDropdown]
   );
 
   const handleConfirmKey = useCallback(() => {
-    const optionCount = filteredList.length;
+    const optionCount = options.length;
     if (!open) {
-      setOpen(true);
+      openDropdown();
       return;
     }
     if (activeIndex < 0 || activeIndex >= optionCount) return;
-    selectOption(filteredList[activeIndex]);
-  }, [activeIndex, filteredList, open, selectOption, setOpen]);
+    selectOption(options[activeIndex]);
+  }, [activeIndex, options, open, openDropdown, selectOption]);
 
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
       if (disabled) return;
-      const optionCount = filteredList.length;
+      const optionCount = options.length;
       switch (event.key) {
         case 'Escape':
           event.preventDefault();
-          setOpen(false);
+          closeDropdown();
           return;
         case 'ArrowDown':
           event.preventDefault();
@@ -110,7 +123,7 @@ export function useDropdownKeyboardNav({
         case ' ':
           // In a searchable dropdown the same handler is bound to the query input,
           // where Space has to type rather than select.
-          if ((event.target as HTMLElement)?.tagName === 'INPUT') return;
+          if (spaceSkipsInput && (event.target as HTMLElement)?.tagName === 'INPUT') return;
           event.preventDefault();
           handleConfirmKey();
           return;
@@ -121,7 +134,15 @@ export function useDropdownKeyboardNav({
         default:
       }
     },
-    [disabled, filteredList.length, handleArrowKey, handleConfirmKey, open, setOpen]
+    [
+      closeDropdown,
+      disabled,
+      options.length,
+      handleArrowKey,
+      handleConfirmKey,
+      open,
+      spaceSkipsInput,
+    ]
   );
 
   return {
@@ -130,4 +151,45 @@ export function useDropdownKeyboardNav({
     activeOptionId,
     handleKeyDown,
   };
+}
+
+type UseDropdownKeyboardNavArgs = {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  disabled: boolean;
+  filteredList: DropdownOption[];
+  value: string;
+  listboxId: string;
+  selectOption: (option: DropdownOption) => void;
+};
+
+/**
+ * setOpen-flavoured adapter over useListboxKeyboardNav for the searchable
+ * Dropdown, which identifies options by their `value` field and must let
+ * Space type into the query input.
+ */
+export function useDropdownKeyboardNav({
+  open,
+  setOpen,
+  disabled,
+  filteredList,
+  value,
+  listboxId,
+  selectOption,
+}: UseDropdownKeyboardNavArgs) {
+  const openDropdown = useCallback(() => setOpen(true), [setOpen]);
+  const closeDropdown = useCallback(() => setOpen(false), [setOpen]);
+  return useListboxKeyboardNav({
+    open,
+    openDropdown,
+    closeDropdown,
+    disabled,
+    options: filteredList,
+    listboxId,
+    selectionKey: value,
+    getOptionValue: (option) => option.value,
+    isOptionSelected: (option) => option.value === value,
+    selectOption,
+    spaceSkipsInput: true,
+  });
 }

--- a/apps/frontend/src/app/ui/inputs/Dropdown/useDropdownPositioning.ts
+++ b/apps/frontend/src/app/ui/inputs/Dropdown/useDropdownPositioning.ts
@@ -6,6 +6,8 @@ type UseDropdownPositioningArgs = {
   portal: boolean;
   dropdownRef: React.RefObject<HTMLDivElement | null>;
   onOuterScrollDismiss: () => void;
+  /** Gap between the trigger's bottom edge and the panel; defaults to a 1px overlap. */
+  topOffset?: number;
 };
 
 /**
@@ -18,10 +20,12 @@ export function useDropdownPositioning({
   portal,
   dropdownRef,
   onOuterScrollDismiss,
+  topOffset = -1,
 }: UseDropdownPositioningArgs) {
   const [portalStyle, setPortalStyle] = useState<React.CSSProperties | null>(null);
 
   const computePortalStyle = useCallback(() => {
+    /* v8 ignore next 2 -- dropdownRef is always mounted while the dropdown is open (computePortalStyle only runs behind an `open` guard), so getBoundingClientRect never returns undefined */
     const rect = dropdownRef.current?.getBoundingClientRect();
     if (!rect) return;
     const viewportHeight = globalThis.window.innerHeight;
@@ -34,11 +38,11 @@ export function useDropdownPositioning({
       position: 'absolute',
       left: rect.left + globalThis.window.scrollX,
       width: rect.width,
-      top: rect.bottom + globalThis.window.scrollY - 1,
+      top: rect.bottom + globalThis.window.scrollY + topOffset,
       maxHeight: panelMaxHeight,
       zIndex: 5000,
     });
-  }, [dropdownRef]);
+  }, [dropdownRef, topOffset]);
 
   const computePortalStyleRef = useRef(computePortalStyle);
   useLayoutEffect(() => {

--- a/apps/frontend/src/app/ui/inputs/MultiSelectDropdown/index.tsx
+++ b/apps/frontend/src/app/ui/inputs/MultiSelectDropdown/index.tsx
@@ -1,9 +1,11 @@
-import React, { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef } from 'react';
+import React, { useCallback, useId, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 import { IoIosWarning } from 'react-icons/io';
 import { Option } from '@/app/features/companions/types/companion';
 import { IoCheckmarkOutline, IoChevronDown } from 'react-icons/io5';
 import { useDropdown, useFilteredOptions } from '@/app/hooks/useDropdown';
+import { useListboxKeyboardNav } from '@/app/ui/inputs/Dropdown/useDropdownKeyboardNav';
+import { useDropdownPositioning } from '@/app/ui/inputs/Dropdown/useDropdownPositioning';
 
 type DropdownProps = {
   placeholder: string;
@@ -14,188 +16,6 @@ type DropdownProps = {
   searchable?: boolean;
   icon?: React.ReactNode;
   portal?: boolean;
-};
-
-const DROPDOWN_MAX_HEIGHT = 200;
-const DROPDOWN_MIN_HEIGHT = 72;
-
-/** Wrap the active option index when navigating with the arrow keys. */
-const wrapActiveIndex = (current: number, optionCount: number, delta: 1 | -1): number => {
-  if (delta === 1) return current + 1 >= optionCount ? 0 : current + 1;
-  return current <= 0 ? optionCount - 1 : current - 1;
-};
-
-const usePortalPositioning = (
-  dropdownRef: React.RefObject<HTMLDivElement | null>,
-  open: boolean,
-  portal: boolean,
-  closeDropdown: () => void
-) => {
-  const [portalStyle, setPortalStyle] = React.useState<React.CSSProperties | null>(null);
-
-  const computeStyle = useCallback(() => {
-    /* v8 ignore next 2 -- dropdownRef is always mounted while the dropdown is open (computeStyle only runs behind an `open` guard), so getBoundingClientRect never returns undefined */
-    const rect = dropdownRef.current?.getBoundingClientRect();
-    if (!rect) return;
-    const spaceBelow = globalThis.window.innerHeight - rect.bottom;
-    const panelMaxHeight = Math.min(
-      DROPDOWN_MAX_HEIGHT,
-      Math.max(DROPDOWN_MIN_HEIGHT, spaceBelow - 8)
-    );
-    setPortalStyle({
-      position: 'absolute',
-      left: rect.left + globalThis.window.scrollX,
-      width: rect.width,
-      top: rect.bottom + globalThis.window.scrollY - 1,
-      maxHeight: panelMaxHeight,
-      zIndex: 5000,
-    });
-  }, [dropdownRef]);
-
-  const computeStyleRef = useRef(computeStyle);
-  useLayoutEffect(() => {
-    computeStyleRef.current = computeStyle;
-  });
-
-  // Clear the floating style the moment the panel closes (render-time adjust,
-  // guarded so it only fires when open/portal actually change).
-  const [prevOpenPortal, setPrevOpenPortal] = React.useState({ open, portal });
-  if (prevOpenPortal.open !== open || prevOpenPortal.portal !== portal) {
-    setPrevOpenPortal({ open, portal });
-    if (!open || !portal) setPortalStyle(null);
-  }
-
-  useLayoutEffect(() => {
-    if (!open || !portal) return;
-    computeStyleRef.current();
-  }, [open, portal]);
-
-  useEffect(() => {
-    if (!open || !portal) return;
-    const stableResize = () => computeStyleRef.current();
-    const handleOuterScroll = (event: Event) => {
-      const target = event.target;
-      if (target instanceof HTMLElement && target.closest('[data-portal-dropdown]')) return;
-      closeDropdown();
-    };
-    globalThis.window.addEventListener('resize', stableResize);
-    globalThis.window.addEventListener('scroll', handleOuterScroll, true);
-    return () => {
-      globalThis.window.removeEventListener('resize', stableResize);
-      globalThis.window.removeEventListener('scroll', handleOuterScroll, true);
-    };
-  }, [closeDropdown, open, portal]);
-
-  return portalStyle;
-};
-
-type ActiveOptionArgs = {
-  open: boolean;
-  listboxId: string;
-  filteredOptions: Option[];
-  valueSet: Set<string>;
-  openDropdown: () => void;
-  closeDropdown: () => void;
-  toggleOption: (option: Option) => void;
-};
-
-const useActiveOption = ({
-  open,
-  listboxId,
-  filteredOptions,
-  valueSet,
-  openDropdown,
-  closeDropdown,
-  toggleOption,
-}: ActiveOptionArgs) => {
-  const [activeIndex, setActiveIndex] = React.useState(-1);
-
-  const activeOptionId =
-    activeIndex >= 0 && activeIndex < filteredOptions.length
-      ? `${listboxId}-option-${filteredOptions[activeIndex].value}`
-      : undefined;
-
-  const [activeIndexDeps, setActiveIndexDeps] = React.useState({ filteredOptions, open, valueSet });
-  if (
-    filteredOptions !== activeIndexDeps.filteredOptions ||
-    open !== activeIndexDeps.open ||
-    valueSet !== activeIndexDeps.valueSet
-  ) {
-    setActiveIndexDeps({ filteredOptions, open, valueSet });
-    if (!open || filteredOptions.length === 0) {
-      setActiveIndex(-1);
-    } else if (activeIndex < 0 || activeIndex >= filteredOptions.length) {
-      const selectedIndex = filteredOptions.findIndex((option) => valueSet.has(option.value));
-      setActiveIndex(Math.max(selectedIndex, 0));
-    }
-  }
-
-  useEffect(() => {
-    if (!open || !activeOptionId) return;
-    document.getElementById(activeOptionId)?.scrollIntoView({ block: 'nearest' });
-  }, [activeOptionId, open]);
-
-  const handleArrowKey = useCallback(
-    (delta: 1 | -1) => {
-      const optionCount = filteredOptions.length;
-      if (optionCount === 0) return;
-      if (!open) {
-        openDropdown();
-        return;
-      }
-      setActiveIndex((current) => wrapActiveIndex(current, optionCount, delta));
-    },
-    [filteredOptions.length, open, openDropdown]
-  );
-
-  const handleConfirmKey = useCallback(() => {
-    const optionCount = filteredOptions.length;
-    if (!open) {
-      openDropdown();
-      return;
-    }
-    if (activeIndex < 0 || activeIndex >= optionCount) return;
-    toggleOption(filteredOptions[activeIndex]);
-  }, [activeIndex, filteredOptions, open, openDropdown, toggleOption]);
-
-  const handleKeyDown = useCallback(
-    (event: React.KeyboardEvent) => {
-      const optionCount = filteredOptions.length;
-      switch (event.key) {
-        case 'Escape':
-          event.preventDefault();
-          closeDropdown();
-          return;
-        case 'ArrowDown':
-          event.preventDefault();
-          handleArrowKey(1);
-          return;
-        case 'ArrowUp':
-          event.preventDefault();
-          handleArrowKey(-1);
-          return;
-        case 'Home':
-          if (!open || optionCount === 0) return;
-          event.preventDefault();
-          setActiveIndex(0);
-          return;
-        case 'End':
-          if (!open || optionCount === 0) return;
-          event.preventDefault();
-          setActiveIndex(optionCount - 1);
-          return;
-        case 'Enter':
-        case ' ':
-          event.preventDefault();
-          handleConfirmKey();
-          return;
-        default:
-      }
-    },
-    [closeDropdown, filteredOptions.length, handleArrowKey, handleConfirmKey, open]
-  );
-
-  return { activeIndex, activeOptionId, setActiveIndex, handleKeyDown };
 };
 
 type MultiSelectPanelProps = {
@@ -225,7 +45,7 @@ const MultiSelectPanel = ({
     id={listboxId}
     data-portal-dropdown
     className="border-[var(--blue)] max-h-50 overflow-y-auto scrollbar-hidden z-200 rounded-b-[12px] border border-t bg-[var(--glass-93)] shadow-[0_16px_34px_var(--sh12)] backdrop-blur-[24px] backdrop-saturate-150 flex flex-col items-stretch w-full px-3 py-2.5"
-    style={shouldPortal ? (portalStyle ?? undefined) : undefined}
+    style={shouldPortal && portalStyle ? portalStyle : undefined}
   >
     {filteredOptions.length > 0 ? (
       filteredOptions.map((option) => {
@@ -384,7 +204,12 @@ const MultiSelectDropdown = ({
   const filteredOptions = useFilteredOptions(list, searchQuery);
   const shouldPortal = portal && typeof document !== 'undefined';
 
-  const portalStyle = usePortalPositioning(dropdownRef, open, portal, closeDropdown);
+  const { portalStyle } = useDropdownPositioning({
+    open,
+    portal,
+    dropdownRef,
+    onOuterScrollDismiss: closeDropdown,
+  });
 
   const toggleOption = useCallback(
     (option: Option) => {
@@ -395,14 +220,16 @@ const MultiSelectDropdown = ({
     [onChange, value, valueSet]
   );
 
-  const { activeOptionId, setActiveIndex, handleKeyDown } = useActiveOption({
+  const { activeOptionId, setActiveIndex, handleKeyDown } = useListboxKeyboardNav({
     open,
-    listboxId,
-    filteredOptions,
-    valueSet,
     openDropdown,
     closeDropdown,
-    toggleOption,
+    options: filteredOptions,
+    listboxId,
+    selectionKey: valueSet,
+    getOptionValue: (option) => option.value,
+    isOptionSelected: (option) => valueSet.has(option.value),
+    selectOption: toggleOption,
   });
 
   const panel = (

--- a/apps/frontend/src/app/ui/inputs/ServiceSearch/ServiceSearch.tsx
+++ b/apps/frontend/src/app/ui/inputs/ServiceSearch/ServiceSearch.tsx
@@ -1,13 +1,8 @@
 import React from 'react';
 import { Service } from '@yosemite-crew/types';
 import { SpecialityWeb } from '@/app/features/organization/types/speciality';
-import { useOrgStore } from '@/app/stores/orgStore';
 import ServiceSearchBase from '@/app/ui/inputs/ServiceSearch/ServiceSearchBase';
-import {
-  buildCustomOnboardingServiceTemplate,
-  findOnboardingSpecialityTemplate,
-  getResolvedBusinessType,
-} from '@/app/lib/onboardingSpecialityCatalog';
+import { useOnboardingServiceBuilder } from '@/app/ui/inputs/ServiceSearch/useOnboardingServiceBuilder';
 
 type SpecialityCardProps = {
   speciality: SpecialityWeb;
@@ -18,30 +13,7 @@ const checkIfAlready = (name: string, services: Service[] = []) =>
   services.some((s) => s.name.toLowerCase() === name.toLowerCase());
 
 const ServiceSearch = ({ speciality, setSpecialities }: SpecialityCardProps) => {
-  const primaryOrgId = useOrgStore((s) => s.primaryOrgId);
-  const primaryOrgType = useOrgStore((state) =>
-    state.primaryOrgId ? state.orgsById[state.primaryOrgId]?.type : undefined
-  );
-  const businessType = getResolvedBusinessType(primaryOrgType);
-
-  const buildService = (serviceName: string): Service => {
-    const matchedTemplate = findOnboardingSpecialityTemplate(
-      businessType,
-      speciality.name
-    )?.services.find((service) => service.name.toLowerCase() === serviceName.toLowerCase());
-    const resolvedTemplate =
-      matchedTemplate ??
-      buildCustomOnboardingServiceTemplate(
-        speciality.name,
-        serviceName.charAt(0).toUpperCase() + serviceName.slice(1),
-        businessType
-      );
-
-    return {
-      ...resolvedTemplate,
-      organisationId: primaryOrgId ?? '',
-    } as Service;
-  };
+  const buildService = useOnboardingServiceBuilder(speciality);
 
   const handleSelectService = (serviceName: string) => {
     setSpecialities((prev: SpecialityWeb[]) =>

--- a/apps/frontend/src/app/ui/inputs/ServiceSearch/ServiceSearchEdit.tsx
+++ b/apps/frontend/src/app/ui/inputs/ServiceSearch/ServiceSearchEdit.tsx
@@ -1,49 +1,19 @@
 import React from 'react';
-import { Service } from '@yosemite-crew/types';
 import { SpecialityWeb } from '@/app/features/organization/types/speciality';
-import { useOrgStore } from '@/app/stores/orgStore';
 import { createService } from '@/app/features/organization/services/specialityService';
 import ServiceSearchBase from '@/app/ui/inputs/ServiceSearch/ServiceSearchBase';
-import {
-  buildCustomOnboardingServiceTemplate,
-  findOnboardingSpecialityTemplate,
-  getResolvedBusinessType,
-} from '@/app/lib/onboardingSpecialityCatalog';
+import { useOnboardingServiceBuilder } from '@/app/ui/inputs/ServiceSearch/useOnboardingServiceBuilder';
 
 type SpecialityCardProps = {
   speciality: SpecialityWeb;
 };
 
 const ServiceSearchEdit = ({ speciality }: SpecialityCardProps) => {
-  const primaryOrgId = useOrgStore((s) => s.primaryOrgId);
-  const primaryOrgType = useOrgStore((state) =>
-    state.primaryOrgId ? state.orgsById[state.primaryOrgId]?.type : undefined
-  );
-  const businessType = getResolvedBusinessType(primaryOrgType);
-
-  const buildService = (serviceName: string): Service => {
-    const matchedTemplate = findOnboardingSpecialityTemplate(
-      businessType,
-      speciality.name
-    )?.services.find((service) => service.name.toLowerCase() === serviceName.toLowerCase());
-    const resolvedTemplate =
-      matchedTemplate ??
-      buildCustomOnboardingServiceTemplate(
-        speciality.name,
-        serviceName.charAt(0).toUpperCase() + serviceName.slice(1),
-        businessType
-      );
-
-    return {
-      ...resolvedTemplate,
-      organisationId: primaryOrgId ?? '',
-      specialityId: speciality._id,
-    } as Service;
-  };
+  const buildService = useOnboardingServiceBuilder(speciality);
 
   const handleSelectService = async (serviceName: string) => {
     try {
-      await createService(buildService(serviceName));
+      await createService(buildService(serviceName, { specialityId: speciality._id }));
     } catch (error) {
       console.log(error);
     }
@@ -51,7 +21,11 @@ const ServiceSearchEdit = ({ speciality }: SpecialityCardProps) => {
 
   const handleAddService = async (name: string) => {
     try {
-      await createService(buildService(name.charAt(0).toUpperCase() + name.slice(1)));
+      await createService(
+        buildService(name.charAt(0).toUpperCase() + name.slice(1), {
+          specialityId: speciality._id,
+        })
+      );
     } catch (error) {
       console.log(error);
     }

--- a/apps/frontend/src/app/ui/inputs/ServiceSearch/useOnboardingServiceBuilder.ts
+++ b/apps/frontend/src/app/ui/inputs/ServiceSearch/useOnboardingServiceBuilder.ts
@@ -1,0 +1,47 @@
+import { Service } from '@yosemite-crew/types';
+import { SpecialityWeb } from '@/app/features/organization/types/speciality';
+import { useOrgStore } from '@/app/stores/orgStore';
+import {
+  buildCustomOnboardingServiceTemplate,
+  findOnboardingSpecialityTemplate,
+  getResolvedBusinessType,
+} from '@/app/lib/onboardingSpecialityCatalog';
+
+type BuildServiceOptions = {
+  /** Stamp the built service with the speciality's persisted id (edit flow). */
+  specialityId?: string;
+};
+
+/**
+ * Shared between ServiceSearch and ServiceSearchEdit: reads the primary
+ * organisation from the org store and returns a builder that resolves
+ * `serviceName` against the speciality's onboarding catalog template (falling
+ * back to a capitalized custom template) stamped with the organisation id.
+ */
+export const useOnboardingServiceBuilder = (speciality: SpecialityWeb) => {
+  const primaryOrgId = useOrgStore((s) => s.primaryOrgId);
+  const primaryOrgType = useOrgStore((state) =>
+    state.primaryOrgId ? state.orgsById[state.primaryOrgId]?.type : undefined
+  );
+  const businessType = getResolvedBusinessType(primaryOrgType);
+
+  return (serviceName: string, buildOptions?: BuildServiceOptions): Service => {
+    const matchedTemplate = findOnboardingSpecialityTemplate(
+      businessType,
+      speciality.name
+    )?.services.find((service) => service.name.toLowerCase() === serviceName.toLowerCase());
+    const resolvedTemplate =
+      matchedTemplate ??
+      buildCustomOnboardingServiceTemplate(
+        speciality.name,
+        serviceName.charAt(0).toUpperCase() + serviceName.slice(1),
+        businessType
+      );
+
+    const service = {
+      ...resolvedTemplate,
+      organisationId: primaryOrgId ?? '',
+    } as Service;
+    return buildOptions ? { ...service, specialityId: buildOptions.specialityId } : service;
+  };
+};

--- a/apps/frontend/src/app/ui/primitives/Accordion/EditableAccordion.tsx
+++ b/apps/frontend/src/app/ui/primitives/Accordion/EditableAccordion.tsx
@@ -12,7 +12,7 @@ import { formatDateLocal } from '@/app/lib/date';
 import { toTitleCase } from '@/app/lib/validators';
 import LabelDropdown from '@/app/ui/inputs/Dropdown/LabelDropdown';
 import { CountriesOptions } from '@/app/features/companions/components/AddCompanion/type';
-import GoogleSearchDropDown from '@/app/ui/inputs/GoogleSearchDropDown/GoogleSearchDropDown';
+import GoogleAddressFieldRenderer from '@/app/ui/primitives/Accordion/googleAddressFieldRenderer';
 
 export type FieldConfig = {
   label: string;
@@ -229,26 +229,7 @@ const FieldComponents: Record<string, React.FC<EditableFieldProps>> = {
       onChange={onChange}
     />
   ),
-  googleAddress: ({ field, value, onChange, onMultiChange, error }) => (
-    <GoogleSearchDropDown
-      intype="text"
-      inname={field.key}
-      value={value ?? ''}
-      inlabel={field.label}
-      error={error}
-      onChange={(e) => onChange(e.target.value)}
-      onlyAddress={true}
-      onAddressSelect={(address) => {
-        onChange(address.addressLine);
-        onMultiChange?.({
-          city: address.city,
-          state: address.state,
-          postalCode: address.postalCode,
-          ...(address.country ? { country: address.country } : {}),
-        });
-      }}
-    />
-  ),
+  googleAddress: GoogleAddressFieldRenderer,
 };
 
 const normalizeOptions = (options?: Array<string | { label: string; value: string }>) =>

--- a/apps/frontend/src/app/ui/primitives/Accordion/googleAddressFieldRenderer.tsx
+++ b/apps/frontend/src/app/ui/primitives/Accordion/googleAddressFieldRenderer.tsx
@@ -27,7 +27,7 @@ const GoogleAddressFieldRenderer = ({
     inlabel={field.label}
     error={error}
     onChange={(e) => onChange(e.target.value)}
-    onlyAddress={true}
+    onlyAddress
     onAddressSelect={(address) => {
       onChange(address.addressLine);
       onMultiChange?.({

--- a/apps/frontend/src/app/ui/primitives/Accordion/googleAddressFieldRenderer.tsx
+++ b/apps/frontend/src/app/ui/primitives/Accordion/googleAddressFieldRenderer.tsx
@@ -1,0 +1,43 @@
+import GoogleSearchDropDown from '@/app/ui/inputs/GoogleSearchDropDown/GoogleSearchDropDown';
+
+export type GoogleAddressFieldRendererProps = {
+  field: { key: string; label: string };
+  value?: string;
+  error?: string;
+  onChange: (value: string) => void;
+  onMultiChange?: (values: Record<string, string>) => void;
+};
+
+/**
+ * Shared `googleAddress` entry for field-renderer maps (ProfileCard,
+ * EditableAccordion): a GoogleSearchDropDown whose address selection also
+ * autofills the sibling city/state/postalCode/country fields.
+ */
+const GoogleAddressFieldRenderer = ({
+  field,
+  value,
+  onChange,
+  onMultiChange,
+  error,
+}: GoogleAddressFieldRendererProps) => (
+  <GoogleSearchDropDown
+    intype="text"
+    inname={field.key}
+    value={value ?? ''}
+    inlabel={field.label}
+    error={error}
+    onChange={(e) => onChange(e.target.value)}
+    onlyAddress={true}
+    onAddressSelect={(address) => {
+      onChange(address.addressLine);
+      onMultiChange?.({
+        city: address.city,
+        state: address.state,
+        postalCode: address.postalCode,
+        ...(address.country ? { country: address.country } : {}),
+      });
+    }}
+  />
+);
+
+export default GoogleAddressFieldRenderer;

--- a/apps/frontend/src/app/ui/primitives/buttonGlowHandlers.ts
+++ b/apps/frontend/src/app/ui/primitives/buttonGlowHandlers.ts
@@ -1,0 +1,16 @@
+import type { PointerEvent } from 'react';
+
+const setGlowOrigin = (e: PointerEvent<HTMLButtonElement>) => {
+  const r = e.currentTarget.getBoundingClientRect();
+  e.currentTarget.style.setProperty('--yc-button-x', `${e.clientX - r.left}px`);
+  e.currentTarget.style.setProperty('--yc-button-y', `${e.clientY - r.top}px`);
+};
+
+/**
+ * Pointer handlers that keep the `yc-primary-button` glow centred on the
+ * cursor. Spread onto the button: `<button {...primaryButtonGlowHandlers}>`.
+ */
+export const primaryButtonGlowHandlers = {
+  onPointerDown: setGlowOrigin,
+  onPointerMove: setGlowOrigin,
+};

--- a/apps/frontend/src/app/ui/theme/themeCore.ts
+++ b/apps/frontend/src/app/ui/theme/themeCore.ts
@@ -1,0 +1,100 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export type Theme = 'light' | 'dark';
+
+/**
+ * Storage key and broadcast event shared by every theme surface (PIMS app and
+ * marketing site) so a single choice is honored across the whole product.
+ */
+export const THEME_STORAGE_KEY = 'yc-theme';
+export const THEME_CHANGE_EVENT = 'yc-theme-change';
+
+/** The current theme, read from the source of truth: <html data-theme>. */
+export const readTheme = (): Theme => {
+  const attr = globalThis.document?.documentElement.dataset.theme;
+  return attr === 'dark' ? 'dark' : 'light';
+};
+
+/** Keep the browser-chrome color (mobile address bar) in step with the page surface. */
+export const syncMetaThemeColor = () => {
+  const doc = globalThis.document;
+  if (!doc) return;
+  let meta = doc.querySelector('meta[name="theme-color"]');
+  if (!meta) {
+    meta = doc.createElement('meta');
+    meta.setAttribute('name', 'theme-color');
+    doc.head.appendChild(meta);
+  }
+  const page = globalThis.getComputedStyle(doc.documentElement).getPropertyValue('--page').trim();
+  meta.setAttribute('content', page || (readTheme() === 'dark' ? '#201c18' : '#efe8dc'));
+};
+
+export const applyTheme = (theme: Theme, persist: boolean) => {
+  const root = globalThis.document.documentElement;
+  root.dataset.theme = theme;
+  root.dataset.themeReady = '1';
+  if (persist) {
+    try {
+      globalThis.localStorage.setItem(THEME_STORAGE_KEY, theme);
+    } catch {
+      /* private mode: fall back to OS following */
+    }
+  }
+  syncMetaThemeColor();
+  globalThis.dispatchEvent(new CustomEvent(THEME_CHANGE_EVENT, { detail: { theme } }));
+};
+
+/** Re-read theme state whenever any toggle instance broadcasts a change (for useSyncExternalStore). */
+export const subscribeToThemeChange = (onStoreChange: () => void): (() => void) => {
+  globalThis.addEventListener(THEME_CHANGE_EVENT, onStoreChange);
+  return () => globalThis.removeEventListener(THEME_CHANGE_EVENT, onStoreChange);
+};
+
+/** SSR always renders light; the client re-reads <html data-theme> on hydration. */
+export const getServerTheme = (): Theme => 'light';
+
+/** Flip the current theme and persist the explicit choice. */
+export const toggleTheme = () => {
+  const next: Theme = readTheme() === 'dark' ? 'light' : 'dark';
+  applyTheme(next, true);
+};
+
+/**
+ * Shared mount lifecycle for every theme hook: sync the meta theme-color, enable
+ * the flip transition shortly after first paint (so the initial paint never
+ * animates), and follow OS scheme changes while no explicit choice is stored.
+ * applyTheme broadcasts the change event, so every subscribed instance re-reads.
+ */
+export function useThemeLifecycle() {
+  useEffect(() => {
+    syncMetaThemeColor();
+
+    // Enable the flip transition after first paint so the initial paint never animates.
+    const readyTimer = globalThis.setTimeout(() => {
+      globalThis.document.documentElement.dataset.themeReady = '1';
+    }, 60);
+
+    // Follow OS changes only while the visitor hasn't explicitly chosen a theme.
+    // applyTheme broadcasts the change event, so every subscribed instance re-reads.
+    const mq = globalThis.matchMedia?.('(prefers-color-scheme: dark)');
+    const onOSChange = (event: MediaQueryListEvent) => {
+      let saved: string | null = null;
+      try {
+        saved = globalThis.localStorage.getItem(THEME_STORAGE_KEY);
+      } catch {
+        /* ignore */
+      }
+      if (!saved) {
+        applyTheme(event.matches ? 'dark' : 'light', false);
+      }
+    };
+    mq?.addEventListener('change', onOSChange);
+
+    return () => {
+      globalThis.clearTimeout(readyTimer);
+      mq?.removeEventListener('change', onOSChange);
+    };
+  }, []);
+}

--- a/apps/frontend/src/app/ui/theme/useTheme.ts
+++ b/apps/frontend/src/app/ui/theme/useTheme.ts
@@ -1,8 +1,18 @@
 'use client';
 
-import { useCallback, useEffect, useSyncExternalStore } from 'react';
+import { useCallback, useSyncExternalStore } from 'react';
+import {
+  THEME_STORAGE_KEY,
+  applyTheme,
+  getServerTheme,
+  readTheme,
+  subscribeToThemeChange,
+  toggleTheme,
+  useThemeLifecycle,
+  type Theme,
+} from './themeCore';
 
-export type Theme = 'light' | 'dark';
+export type { Theme } from './themeCore';
 
 /**
  * Three-way appearance preference exposed to settings UIs. `auto` means "no explicit
@@ -10,19 +20,10 @@ export type Theme = 'light' | 'dark';
  */
 export type Appearance = 'auto' | 'light' | 'dark';
 
-const STORAGE_KEY = 'yc-theme';
-const THEME_CHANGE_EVENT = 'yc-theme-change';
-
-/** The current theme, read from the source of truth: <html data-theme>. */
-const readTheme = (): Theme => {
-  const attr = globalThis.document?.documentElement.dataset.theme;
-  return attr === 'dark' ? 'dark' : 'light';
-};
-
 /** The current appearance preference, derived from the presence of an explicit stored choice. */
 const readAppearance = (): Appearance => {
   try {
-    const saved = globalThis.localStorage?.getItem(STORAGE_KEY);
+    const saved = globalThis.localStorage?.getItem(THEME_STORAGE_KEY);
     return saved === 'dark' || saved === 'light' ? saved : 'auto';
   } catch {
     return 'auto';
@@ -33,43 +34,7 @@ const readAppearance = (): Appearance => {
 const osTheme = (): Theme =>
   globalThis.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
-/** Keep the browser-chrome color (mobile address bar) in step with the page surface. */
-const syncMetaThemeColor = () => {
-  const doc = globalThis.document;
-  if (!doc) return;
-  let meta = doc.querySelector('meta[name="theme-color"]');
-  if (!meta) {
-    meta = doc.createElement('meta');
-    meta.setAttribute('name', 'theme-color');
-    doc.head.appendChild(meta);
-  }
-  const page = globalThis.getComputedStyle(doc.documentElement).getPropertyValue('--page').trim();
-  meta.setAttribute('content', page || (readTheme() === 'dark' ? '#201c18' : '#efe8dc'));
-};
-
-const applyTheme = (theme: Theme, persist: boolean) => {
-  const root = globalThis.document.documentElement;
-  root.dataset.theme = theme;
-  root.dataset.themeReady = '1';
-  if (persist) {
-    try {
-      globalThis.localStorage.setItem(STORAGE_KEY, theme);
-    } catch {
-      /* private mode: fall back to OS following */
-    }
-  }
-  syncMetaThemeColor();
-  globalThis.dispatchEvent(new CustomEvent(THEME_CHANGE_EVENT, { detail: { theme } }));
-};
-
-/** Re-read theme + appearance whenever any toggle instance broadcasts a change (for useSyncExternalStore). */
-const subscribeToThemeChange = (onStoreChange: () => void): (() => void) => {
-  globalThis.addEventListener(THEME_CHANGE_EVENT, onStoreChange);
-  return () => globalThis.removeEventListener(THEME_CHANGE_EVENT, onStoreChange);
-};
-
-/** SSR always renders the defaults; the client re-reads the real values on hydration. */
-const getServerTheme = (): Theme => 'light';
+/** SSR always renders the default; the client re-reads the real value on hydration. */
 const getServerAppearance = (): Appearance => 'auto';
 
 /**
@@ -81,7 +46,7 @@ const getServerAppearance = (): Appearance => 'auto';
  * transition shortly after first paint.
  *
  * It shares the `yc-theme` storage key and `yc-theme-change` event with the marketing
- * surface so a single theme choice is honored across the whole product.
+ * surface (via themeCore) so a single theme choice is honored across the whole product.
  */
 export function useTheme() {
   const theme = useSyncExternalStore(subscribeToThemeChange, readTheme, getServerTheme);
@@ -91,40 +56,7 @@ export function useTheme() {
     getServerAppearance
   );
 
-  useEffect(() => {
-    syncMetaThemeColor();
-
-    // Enable the flip transition after first paint so the initial paint never animates.
-    const readyTimer = globalThis.setTimeout(() => {
-      globalThis.document.documentElement.dataset.themeReady = '1';
-    }, 60);
-
-    // Follow OS changes only while the visitor hasn't explicitly chosen a theme.
-    // applyTheme broadcasts the change event, so every subscribed instance re-reads.
-    const mq = globalThis.matchMedia?.('(prefers-color-scheme: dark)');
-    const onOSChange = (event: MediaQueryListEvent) => {
-      let saved: string | null = null;
-      try {
-        saved = globalThis.localStorage.getItem(STORAGE_KEY);
-      } catch {
-        /* ignore */
-      }
-      if (!saved) {
-        applyTheme(event.matches ? 'dark' : 'light', false);
-      }
-    };
-    mq?.addEventListener('change', onOSChange);
-
-    return () => {
-      globalThis.clearTimeout(readyTimer);
-      mq?.removeEventListener('change', onOSChange);
-    };
-  }, []);
-
-  const toggle = useCallback(() => {
-    const next: Theme = readTheme() === 'dark' ? 'light' : 'dark';
-    applyTheme(next, true);
-  }, []);
+  useThemeLifecycle();
 
   /**
    * Set the three-way appearance preference. `auto` clears the stored choice and
@@ -134,7 +66,7 @@ export function useTheme() {
   const setAppearance = useCallback((next: Appearance) => {
     if (next === 'auto') {
       try {
-        globalThis.localStorage.removeItem(STORAGE_KEY);
+        globalThis.localStorage.removeItem(THEME_STORAGE_KEY);
       } catch {
         /* private mode: nothing persisted to clear */
       }
@@ -144,5 +76,5 @@ export function useTheme() {
     }
   }, []);
 
-  return { theme, toggle, appearance, setAppearance };
+  return { theme, toggle: toggleTheme, appearance, setAppearance };
 }

--- a/apps/frontend/src/app/ui/widgets/Stats/AppointmentLeadersStat.tsx
+++ b/apps/frontend/src/app/ui/widgets/Stats/AppointmentLeadersStat.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import CardHeader from '@/app/ui/cards/CardHeader/CardHeader';
+import StatCardShell from '@/app/ui/widgets/Stats/StatCardShell';
 import {
   DashboardDurationOption,
   mapDashboardDurationOption,
@@ -49,56 +49,40 @@ const AppointmentLeadersStat = () => {
   const maxCompleted = leadersWithNames.reduce((max, leader) => Math.max(max, leader.Completed), 0);
 
   return (
-    <div className="flex flex-col gap-2">
-      <CardHeader
-        title={'Appointment leaders'}
-        options={durationOptions}
-        selected={selectedDuration}
-        onSelect={(next) => setSelectedDuration(next as DashboardDurationOption)}
-      />
-      <div
-        className={`flex w-full flex-col gap-3.5 overflow-hidden rounded-[18px] border border-[var(--hairline)] bg-[var(--screen)] px-5 py-4 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)] ${
-          isEmpty ? 'min-h-89' : ''
-        }`}
-      >
-        {isEmpty ? (
-          <div className="flex flex-1 flex-col items-center justify-center gap-2 text-[var(--ink-faint)]">
-            <svg width="40" height="40" viewBox="0 0 40 40" fill="none" aria-hidden="true">
-              <rect x="4" y="24" width="8" height="12" rx="2" fill="var(--divider)" />
-              <rect x="16" y="16" width="8" height="20" rx="2" fill="var(--divider)" />
-              <rect x="28" y="10" width="8" height="26" rx="2" fill="var(--divider)" />
-            </svg>
-            <span className="text-[13px]">No data available</span>
-          </div>
-        ) : (
-          <div className="flex flex-col gap-2.5">
-            {leadersWithNames.map((leader, index) => {
-              const width = maxCompleted > 0 ? (leader.Completed / maxCompleted) * 100 : 0;
-              return (
-                <div
-                  key={`${leader.staffId}-${index + 1}`}
-                  className="grid grid-cols-[minmax(0,130px)_1fr_34px] items-center gap-2.5"
-                >
-                  <span className="truncate text-[12.5px] font-semibold text-[var(--ink-body)]">
-                    {leader.month}
-                  </span>
-                  <div
-                    className="h-3.5 rounded-[4px] bg-[var(--cta)]"
-                    style={{
-                      width: `${Math.max(0, Math.min(100, width))}%`,
-                      opacity: rankOpacity(index),
-                    }}
-                  />
-                  <span className="text-right text-[12px] font-bold text-[var(--ink)] tabular-nums">
-                    {leader.Completed}
-                  </span>
-                </div>
-              );
-            })}
-          </div>
-        )}
+    <StatCardShell
+      title={'Appointment leaders'}
+      options={durationOptions}
+      selected={selectedDuration}
+      onSelect={(next) => setSelectedDuration(next as DashboardDurationOption)}
+      isEmpty={isEmpty}
+      cardClassName={`gap-3.5 overflow-hidden ${isEmpty ? 'min-h-89' : ''}`}
+    >
+      <div className="flex flex-col gap-2.5">
+        {leadersWithNames.map((leader, index) => {
+          const width = maxCompleted > 0 ? (leader.Completed / maxCompleted) * 100 : 0;
+          return (
+            <div
+              key={`${leader.staffId}-${index + 1}`}
+              className="grid grid-cols-[minmax(0,130px)_1fr_34px] items-center gap-2.5"
+            >
+              <span className="truncate text-[12.5px] font-semibold text-[var(--ink-body)]">
+                {leader.month}
+              </span>
+              <div
+                className="h-3.5 rounded-[4px] bg-[var(--cta)]"
+                style={{
+                  width: `${Math.max(0, Math.min(100, width))}%`,
+                  opacity: rankOpacity(index),
+                }}
+              />
+              <span className="text-right text-[12px] font-bold text-[var(--ink)] tabular-nums">
+                {leader.Completed}
+              </span>
+            </div>
+          );
+        })}
       </div>
-    </div>
+    </StatCardShell>
   );
 };
 

--- a/apps/frontend/src/app/ui/widgets/Stats/RevenueLeadersStat.tsx
+++ b/apps/frontend/src/app/ui/widgets/Stats/RevenueLeadersStat.tsx
@@ -33,7 +33,7 @@ const RevenueLeadersStat = () => {
 
   return (
     <StatCardShell
-      title={'Revenue leaders'}
+      title="Revenue leaders"
       options={durationOptions}
       selected={selectedDuration}
       onSelect={(next) => setSelectedDuration(next as DashboardDurationOption)}

--- a/apps/frontend/src/app/ui/widgets/Stats/RevenueLeadersStat.tsx
+++ b/apps/frontend/src/app/ui/widgets/Stats/RevenueLeadersStat.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import CardHeader from '@/app/ui/cards/CardHeader/CardHeader';
+import StatCardShell from '@/app/ui/widgets/Stats/StatCardShell';
 import { useCurrencyForPrimaryOrg } from '@/app/hooks/useBilling';
 import { formatMoney } from '@/app/lib/money';
 import {
@@ -32,56 +32,40 @@ const RevenueLeadersStat = () => {
   const maxRevenue = leaders.reduce((max, leader) => Math.max(max, leader.revenue), 0);
 
   return (
-    <div className="flex flex-col gap-2">
-      <CardHeader
-        title={'Revenue leaders'}
-        options={durationOptions}
-        selected={selectedDuration}
-        onSelect={(next) => setSelectedDuration(next as DashboardDurationOption)}
-      />
-      <div
-        className={`flex w-full flex-col gap-3.5 overflow-hidden rounded-[18px] border border-[var(--hairline)] bg-[var(--screen)] px-5 py-4 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)] ${
-          isEmpty ? 'min-h-89' : ''
-        }`}
-      >
-        {isEmpty ? (
-          <div className="flex flex-1 flex-col items-center justify-center gap-2 text-[var(--ink-faint)]">
-            <svg width="40" height="40" viewBox="0 0 40 40" fill="none" aria-hidden="true">
-              <rect x="4" y="24" width="8" height="12" rx="2" fill="var(--divider)" />
-              <rect x="16" y="16" width="8" height="20" rx="2" fill="var(--divider)" />
-              <rect x="28" y="10" width="8" height="26" rx="2" fill="var(--divider)" />
-            </svg>
-            <span className="text-[13px]">No data available</span>
-          </div>
-        ) : (
-          <div className="flex flex-col gap-2.5">
-            {leaders.map((leader, index) => {
-              const width = maxRevenue > 0 ? (leader.revenue / maxRevenue) * 100 : 0;
-              return (
-                <div
-                  key={`${leader.label}-${index + 1}`}
-                  className="grid grid-cols-[minmax(0,130px)_1fr_56px] items-center gap-2.5"
-                >
-                  <span className="truncate text-[12.5px] font-semibold text-[var(--ink-body)]">
-                    {leader.label}
-                  </span>
-                  <div
-                    className="h-3.5 rounded-[4px] bg-[var(--blue)]"
-                    style={{
-                      width: `${Math.max(0, Math.min(100, width))}%`,
-                      opacity: rankOpacity(index),
-                    }}
-                  />
-                  <span className="text-right text-[12px] font-bold text-[var(--ink)] tabular-nums">
-                    {formatMoney(leader.revenue, currency)}
-                  </span>
-                </div>
-              );
-            })}
-          </div>
-        )}
+    <StatCardShell
+      title={'Revenue leaders'}
+      options={durationOptions}
+      selected={selectedDuration}
+      onSelect={(next) => setSelectedDuration(next as DashboardDurationOption)}
+      isEmpty={isEmpty}
+      cardClassName={`gap-3.5 overflow-hidden ${isEmpty ? 'min-h-89' : ''}`}
+    >
+      <div className="flex flex-col gap-2.5">
+        {leaders.map((leader, index) => {
+          const width = maxRevenue > 0 ? (leader.revenue / maxRevenue) * 100 : 0;
+          return (
+            <div
+              key={`${leader.label}-${index + 1}`}
+              className="grid grid-cols-[minmax(0,130px)_1fr_56px] items-center gap-2.5"
+            >
+              <span className="truncate text-[12.5px] font-semibold text-[var(--ink-body)]">
+                {leader.label}
+              </span>
+              <div
+                className="h-3.5 rounded-[4px] bg-[var(--blue)]"
+                style={{
+                  width: `${Math.max(0, Math.min(100, width))}%`,
+                  opacity: rankOpacity(index),
+                }}
+              />
+              <span className="text-right text-[12px] font-bold text-[var(--ink)] tabular-nums">
+                {formatMoney(leader.revenue, currency)}
+              </span>
+            </div>
+          );
+        })}
       </div>
-    </div>
+    </StatCardShell>
   );
 };
 

--- a/apps/frontend/src/app/ui/widgets/Stats/StatCardShell.tsx
+++ b/apps/frontend/src/app/ui/widgets/Stats/StatCardShell.tsx
@@ -6,13 +6,37 @@ type StatCardShellProps = {
   options: readonly string[];
   /** Renders the shared bar-chart empty state instead of `children`. */
   isEmpty: boolean;
+  /** Duration option shown in the header pill; defaults to the first option. */
+  selected?: string;
+  /** Forwarded to the header's duration picker; omit for a static pill. */
+  onSelect?: (option: string) => void;
+  /**
+   * Card-surface classes that vary per card (min-height, gap, overflow).
+   * Defaults to the fixed-height reading used by the inventory stats.
+   */
+  cardClassName?: string;
   children: React.ReactNode;
 };
 
-const StatCardShell = ({ title, options, isEmpty, children }: StatCardShellProps) => (
+const StatCardShell = ({
+  title,
+  options,
+  isEmpty,
+  selected,
+  onSelect,
+  cardClassName = 'min-h-75 gap-2.5',
+  children,
+}: StatCardShellProps) => (
   <div className="flex flex-col gap-2">
-    <CardHeader title={title} options={options} selected={options[0]} />
-    <div className="flex min-h-75 w-full flex-col gap-2.5 rounded-[18px] border border-[var(--hairline)] bg-[var(--screen)] px-5 py-4 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]">
+    <CardHeader
+      title={title}
+      options={options}
+      selected={selected ?? options[0]}
+      onSelect={onSelect}
+    />
+    <div
+      className={`flex w-full flex-col rounded-[18px] border border-[var(--hairline)] bg-[var(--screen)] px-5 py-4 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)] ${cardClassName}`}
+    >
       {isEmpty ? (
         <div className="flex flex-1 flex-col items-center justify-center gap-2 text-[var(--ink-faint)]">
           <svg width="40" height="40" viewBox="0 0 40 40" fill="none" aria-hidden="true">


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The Frontend SonarCloud project reports 1.0% duplicated lines (~1,400 lines across the filter family, dropdown family, six calendar variants, twin useTheme hooks, form/type data tables, template services and more) and 4 open issues (cognitive complexity 28 and a missing optional chain in useAppointmentForm, a missing optional chain in useGithubStats, commented-out code in ChatContainer.css). Under the 95/0/0 Sonar quality bar (#2191 / PR #2192) the frontend Sonar leg is red until both are zero.

## What is the new behavior?

Every CPD clone is structurally eliminated and all 4 issues fixed at the root - 100 modified files plus 40 new files (17 new source modules extracted from the clones, plus tests):

- Filters: shared useFilterDropdownDismiss + StatusOptionButtons across all four filter components.
- Dropdowns: useDropdownKeyboardNav + useDropdownPositioning extracted once behind Dropdown, LabelDropdown, MultiSelectDropdown and ServiceSearch.
- Calendars: interaction-prop factories declared once and imported by all six calendar variants.
- Theme: a single themeCore behind both the app and marketing useTheme hooks.
- Services/types: shared template-service helpers; structural helpers (radioField/checkboxField/yesNoRadio/buildYesNoFieldList) extracted from the forms type module.
- useAppointmentForm decomposed below the cognitive-complexity limit; optional chains applied; dead CSS removed.
- Two narrow, commented sonar.cpd.exclusions entries remain for pure data tables (legal content - pre-existing - and the YC-default form-template catalog), where the repetition IS the content.

Validation performed (real outputs): tsc --noEmit clean; eslint clean; ten targeted jest batches covering every touched area - ~377 suite-runs / ~6,041 tests, 0 failures; all 17 new source files >= 90% coverage on first commit (16 at 100%, themeCore branches 96.66%); no barrel edits; behavior and rendered output unchanged by design.

Impact area: apps/frontend UI primitives, filters, calendar, theme, forms/services; pure refactor.

## Related Issue(s)

Fixes #2209
