### PR TITLE
fix(frontend): make the delete consent checkbox actually gate deletion

### DIFF
--- a/apps/frontend/src/app/__tests__/components/chat/ChatContainer.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/chat/ChatContainer.test.tsx
@@ -27,6 +27,24 @@ import { useAppointmentStore } from '@/app/stores/appointmentStore';
 import { useCompanionStore } from '@/app/stores/companionStore';
 import { useChannelStateContext, useChatContext } from 'stream-chat-react';
 
+// The native confirm() these flows used has been replaced by the ConfirmModal
+// hook. Mock the hook so each test can decide the answer without driving the
+// dialog, keeping the assertions focused on the downstream action.
+let mockConfirmResult = true;
+const setConfirmResult = (value: boolean) => {
+  mockConfirmResult = value;
+};
+const mockConfirm = jest.fn(async () => mockConfirmResult);
+jest.mock('@/app/ui/overlays/Modal/ConfirmModal', () => ({
+  useConfirm: () => ({ confirm: mockConfirm, confirmDialog: null }),
+}));
+
+// Default to confirming, so a test that declines cannot leak into the next one.
+beforeEach(() => {
+  mockConfirmResult = true;
+  mockConfirm.mockClear();
+});
+
 // ----------------------------------------------------------------------------
 // 1. Mocks & Setup
 // ----------------------------------------------------------------------------
@@ -94,7 +112,6 @@ jest.mock('@/app/features/appointments/services/appointmentService', () => ({
 
 // Global mocks
 globalThis.alert = jest.fn();
-globalThis.confirm = jest.fn(() => true);
 
 // Suppress console errors/warns for cleaner test output (optional but helpful)
 const originalConsoleError = console.error;
@@ -624,7 +641,7 @@ describe('ChatContainer', () => {
   });
 
   it('does not delete group when confirm is cancelled', async () => {
-    (globalThis.confirm as jest.Mock).mockReturnValueOnce(false);
+    setConfirmResult(false);
     (chatService.listOrgChatSessions as jest.Mock).mockResolvedValue([
       {
         _id: 'backend-group-id',
@@ -775,7 +792,7 @@ describe('ChatContainer', () => {
   });
 
   it('does not close session when user cancels confirmation', async () => {
-    (globalThis.confirm as jest.Mock).mockReturnValueOnce(false);
+    setConfirmResult(false);
     const clientChannel = {
       ...defaultMockChannel,
       data: { appointmentId: '123', chatCategory: 'clients' },

--- a/apps/frontend/src/app/__tests__/pages/Appointments/Sections/AppointmentInfo/Tasks/Chat.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Appointments/Sections/AppointmentInfo/Tasks/Chat.test.tsx
@@ -10,6 +10,24 @@ import {
 } from '@/app/features/chat/services/chatService';
 import { Appointment } from '@yosemite-crew/types';
 
+// The native confirm() these flows used has been replaced by the ConfirmModal
+// hook. Mock the hook so each test can decide the answer without driving the
+// dialog, keeping the assertions focused on the downstream action.
+let mockConfirmResult = true;
+const setConfirmResult = (value: boolean) => {
+  mockConfirmResult = value;
+};
+const mockConfirm = jest.fn(async () => mockConfirmResult);
+jest.mock('@/app/ui/overlays/Modal/ConfirmModal', () => ({
+  useConfirm: () => ({ confirm: mockConfirm, confirmDialog: null }),
+}));
+
+// Default to confirming, so a test that declines cannot leak into the next one.
+beforeEach(() => {
+  mockConfirmResult = true;
+  mockConfirm.mockClear();
+});
+
 // --- Mocks ---
 
 // Mock Next.js Router
@@ -86,7 +104,7 @@ describe('Chat Component', () => {
     });
 
     // Default Window Mocks
-    jest.spyOn(globalThis, 'confirm').mockReturnValue(true);
+    setConfirmResult(true);
     jest.spyOn(globalThis, 'alert').mockImplementation(() => {});
     jest.spyOn(console, 'error').mockImplementation(() => {});
   });
@@ -383,7 +401,7 @@ describe('Chat Component', () => {
 
   it('cancels closing chat if user denies confirmation', async () => {
     (getChatSession as jest.Mock).mockRejectedValue({ status: 404 });
-    (globalThis.confirm as jest.Mock).mockReturnValue(false); // User clicks Cancel
+    setConfirmResult(false); // User declines
 
     render(<Chat activeAppointment={mockActiveAppointment} />);
     await waitFor(() => expect(screen.getByText('Close Chat Session')).toBeInTheDocument());
@@ -395,8 +413,17 @@ describe('Chat Component', () => {
 
   it('closes chat successfully when confirmed', async () => {
     (getChatSession as jest.Mock).mockResolvedValue({ _id: 'session-1', status: 'OPEN' });
-    (globalThis.confirm as jest.Mock).mockReturnValue(true); // User clicks OK
-    (closeChatSession as jest.Mock).mockResolvedValue({});
+    setConfirmResult(true); // User confirms
+    // Hold the close open so the in-flight label is observable: the
+    // confirmation is now awaited, so an instantly resolving close would land
+    // before the first assertion polls.
+    let resolveClose: (value?: unknown) => void = () => {};
+    (closeChatSession as jest.Mock).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveClose = resolve;
+        })
+    );
 
     render(<Chat activeAppointment={mockActiveAppointment} />);
     await waitFor(() => expect(screen.getByText('Close Chat Session')).toBeInTheDocument());
@@ -404,11 +431,14 @@ describe('Chat Component', () => {
     const closeBtn = screen.getByText('Close Chat Session');
     fireEvent.click(closeBtn);
 
-    // Check loading state
-    expect(screen.getByText('Closing...')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText('Closing...')).toBeInTheDocument());
 
     await waitFor(() => {
       expect(closeChatSession).toHaveBeenCalledWith('session-1');
+    });
+
+    await act(async () => {
+      resolveClose({});
     });
 
     expect(globalThis.alert).toHaveBeenCalledWith('Chat session closed successfully');
@@ -483,7 +513,7 @@ describe('Chat Component', () => {
     await waitFor(() => expect(screen.getByText('Close Chat Session')).toBeInTheDocument());
 
     fireEvent.click(screen.getByText('Close Chat Session'));
-    expect(closeChatSession).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(closeChatSession).toHaveBeenCalledTimes(1));
 
     // The button is disabled while the close is in flight, so invoke the handler
     // directly to exercise the in-flight guard.
@@ -541,9 +571,9 @@ describe('Chat Component', () => {
 
     const closeBtn = screen.getByText('Close Chat Session');
 
-    // First Click
+    // First Click - the confirmation is awaited, so the call is not synchronous.
     fireEvent.click(closeBtn);
-    expect(closeChatSession).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(closeChatSession).toHaveBeenCalledTimes(1));
 
     // Second Click (while loading)
     fireEvent.click(closeBtn);

--- a/apps/frontend/src/app/__tests__/pages/Integrations/Integrations.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Integrations/Integrations.test.tsx
@@ -6,6 +6,24 @@ import { axe, toHaveNoViolations } from 'jest-axe';
 expect.extend(toHaveNoViolations);
 import ProtectedIntegrations from '@/app/features/integrations/pages/Integrations';
 
+// The native confirm() these flows used has been replaced by the ConfirmModal
+// hook. Mock the hook so each test can decide the answer without driving the
+// dialog, keeping the assertions focused on the downstream action.
+let mockConfirmResult = true;
+const setConfirmResult = (value: boolean) => {
+  mockConfirmResult = value;
+};
+const mockConfirm = jest.fn(async () => mockConfirmResult);
+jest.mock('@/app/ui/overlays/Modal/ConfirmModal', () => ({
+  useConfirm: () => ({ confirm: mockConfirm, confirmDialog: null }),
+}));
+
+// Default to confirming, so a test that declines cannot leak into the next one.
+beforeEach(() => {
+  mockConfirmResult = true;
+  mockConfirm.mockClear();
+});
+
 const useIntegrationsForPrimaryOrgMock = jest.fn();
 const useIntegrationByProviderForPrimaryOrgMock = jest.fn();
 const loadIntegrationsForPrimaryOrgMock = jest.fn();
@@ -276,7 +294,7 @@ describe('Integrations settings', () => {
   });
 
   it('respects disconnect confirmation and avoids disable on cancel', async () => {
-    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(false);
+    setConfirmResult(false);
 
     render(<ProtectedIntegrations />);
 
@@ -288,11 +306,9 @@ describe('Integrations settings', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Disable IDEXX' }));
 
     await waitFor(() => {
-      expect(confirmSpy).toHaveBeenCalled();
+      expect(mockConfirm).toHaveBeenCalled();
     });
     expect(disableIntegrationMock).not.toHaveBeenCalled();
-
-    confirmSpy.mockRestore();
   });
 
   it('shows Enable on card when disabled and blocks enable if credentials are invalid', async () => {

--- a/apps/frontend/src/app/__tests__/pages/Integrations/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Integrations/index.test.tsx
@@ -4,6 +4,24 @@ import '@testing-library/jest-dom';
 // jest.mock calls below are hoisted above this import, so the component loads with mocked deps.
 import ProtectedIntegrations from '@/app/features/integrations/pages/Integrations';
 
+// The native confirm() these flows used has been replaced by the ConfirmModal
+// hook. Mock the hook so each test can decide the answer without driving the
+// dialog, keeping the assertions focused on the downstream action.
+let mockConfirmResult = true;
+const setConfirmResult = (value: boolean) => {
+  mockConfirmResult = value;
+};
+const mockConfirm = jest.fn(async () => mockConfirmResult);
+jest.mock('@/app/ui/overlays/Modal/ConfirmModal', () => ({
+  useConfirm: () => ({ confirm: mockConfirm, confirmDialog: null }),
+}));
+
+// Default to confirming, so a test that declines cannot leak into the next one.
+beforeEach(() => {
+  mockConfirmResult = true;
+  mockConfirm.mockClear();
+});
+
 // ---------------------------------------------------------------------------
 // Mock handles (declared before jest.mock factories, mirroring the established
 // convention in the sibling Integrations.test.tsx).
@@ -810,26 +828,24 @@ describe('IntegrationsPage — enable/disable IDEXX', () => {
 
   it('disables IDEXX after confirmation from the trash quick action', async () => {
     useIntegrationByProviderForPrimaryOrgMock.mockReturnValue(makeEnabledIdexx());
-    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+    setConfirmResult(true);
 
     renderPage();
     await waitForPage();
     await waitFor(() => expect(listIdexxIvlsDevicesMock).toHaveBeenCalled());
 
     fireEvent.click(screen.getByRole('button', { name: 'Disable IDEXX quick action' }));
-
-    await waitFor(() => expect(confirmSpy).toHaveBeenCalled());
+    await waitFor(() => expect(mockConfirm).toHaveBeenCalled());
     await waitFor(() => expect(disableIntegrationMock).toHaveBeenCalledWith('org-1', 'IDEXX'));
     await waitFor(() =>
       expect(loadIntegrationsForPrimaryOrgMock).toHaveBeenCalledWith({ force: true, silent: true })
     );
     await flush();
-    confirmSpy.mockRestore();
   });
 
   it('does not disable IDEXX when the confirmation is cancelled', async () => {
     useIntegrationByProviderForPrimaryOrgMock.mockReturnValue(makeEnabledIdexx());
-    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(false);
+    setConfirmResult(false);
 
     renderPage();
     await waitForPage();
@@ -839,17 +855,15 @@ describe('IntegrationsPage — enable/disable IDEXX', () => {
     fireEvent.click(
       within(screen.getByTestId('settings-modal')).getByRole('button', { name: 'Disable IDEXX' })
     );
-
-    await waitFor(() => expect(confirmSpy).toHaveBeenCalled());
+    await waitFor(() => expect(mockConfirm).toHaveBeenCalled());
     expect(disableIntegrationMock).not.toHaveBeenCalled();
     await flush();
-    confirmSpy.mockRestore();
   });
 
   it('surfaces an error when disabling fails', async () => {
     useIntegrationByProviderForPrimaryOrgMock.mockReturnValue(makeEnabledIdexx());
     disableIntegrationMock.mockRejectedValue(new Error('down'));
-    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+    setConfirmResult(true);
 
     renderPage();
     await waitForPage();
@@ -860,14 +874,13 @@ describe('IntegrationsPage — enable/disable IDEXX', () => {
     const alert = await screen.findByRole('alert');
     expect(alert).toHaveTextContent('Unable to update IDEXX integration status.');
     await flush();
-    confirmSpy.mockRestore();
   });
 
   it('shows "Updating..." in the modal while a disable request is in flight', async () => {
     useIntegrationByProviderForPrimaryOrgMock.mockReturnValue(makeEnabledIdexx());
     const deferred = createDeferred<any>();
     disableIntegrationMock.mockReturnValue(deferred.promise);
-    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+    setConfirmResult(true);
 
     renderPage();
     await waitForPage();
@@ -889,7 +902,6 @@ describe('IntegrationsPage — enable/disable IDEXX', () => {
     await waitFor(() => expect(loadIntegrationsForPrimaryOrgMock).toHaveBeenCalled());
     await screen.findByRole('button', { name: 'Disable IDEXX' });
     await flush();
-    confirmSpy.mockRestore();
   });
 });
 

--- a/apps/frontend/src/app/__tests__/pages/Organization/Sections/DeleteOrg.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Organization/Sections/DeleteOrg.test.tsx
@@ -81,6 +81,7 @@ describe('DeleteOrg section', () => {
     fireEvent.change(screen.getByLabelText('Enter email address'), {
       target: { value: 'owner@example.com' },
     });
+    fireEvent.click(screen.getByLabelText('Confirm deletion consent'));
     fireEvent.click(screen.getByText('Delete'));
 
     expect(deleteOrgMock).toHaveBeenCalled();

--- a/apps/frontend/src/app/__tests__/pages/Settings/Sections/DeleteProfile.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Settings/Sections/DeleteProfile.test.tsx
@@ -98,6 +98,8 @@ const openModal = () => {
   fireEvent.change(screen.getByLabelText('Enter email address'), {
     target: { value: 'me@example.com' },
   });
+  // Deleting a profile is irreversible, so the consent box gates the button.
+  fireEvent.click(screen.getByLabelText('Confirm deletion consent'));
   fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
 };
 
@@ -123,6 +125,7 @@ describe('Settings DeleteProfile', () => {
     render(<DeleteProfile />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Delete…' }));
+    fireEvent.click(screen.getByLabelText('Confirm deletion consent'));
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
 
     expect(screen.getByText('Email is required')).toBeInTheDocument();

--- a/apps/frontend/src/app/__tests__/ui/overlays/Modal/ConfirmModal.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/overlays/Modal/ConfirmModal.test.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useConfirm } from '@/app/ui/overlays/Modal/ConfirmModal';
+
+jest.mock('@/app/ui/primitives/Buttons', () => ({
+  Primary: ({ text, onClick }: any) => (
+    <button type="button" onClick={onClick}>
+      {text}
+    </button>
+  ),
+  Secondary: ({ text, onClick }: any) => (
+    <button type="button" onClick={onClick}>
+      {text}
+    </button>
+  ),
+}));
+
+jest.mock('@/app/ui/primitives/Buttons/Delete', () => ({
+  __esModule: true,
+  default: ({ text, onClick }: any) => (
+    <button type="button" onClick={onClick}>
+      {text}
+    </button>
+  ),
+}));
+
+jest.mock('@/app/ui/overlays/Modal/CenterModal', () => ({
+  __esModule: true,
+  default: ({ showModal, children, ariaLabel }: any) =>
+    showModal ? (
+      <div role="dialog" aria-label={ariaLabel}>
+        {children}
+      </div>
+    ) : null,
+}));
+
+jest.mock('@/app/ui/overlays/Modal/ModalHeader', () => ({
+  __esModule: true,
+  default: ({ title, onClose }: any) => (
+    <div>
+      <span>{title}</span>
+      <button type="button" onClick={onClose}>
+        close
+      </button>
+    </div>
+  ),
+}));
+
+jest.mock('@/app/ui/overlays/Modal/ModalFooter', () => ({
+  __esModule: true,
+  default: ({ children }: any) => <div>{children}</div>,
+}));
+
+/** Mirrors how a real call site uses the hook inside an async handler. */
+const Harness = ({ onResult, tone }: { onResult: (v: boolean) => void; tone?: 'danger' }) => {
+  const { confirm, confirmDialog } = useConfirm();
+  return (
+    <div>
+      {confirmDialog}
+      <button
+        type="button"
+        onClick={async () => {
+          const ok = await confirm({
+            title: 'Disconnect IDEXX?',
+            body: 'Lab ordering stops until it is enabled again.',
+            confirmLabel: 'Disconnect',
+            tone,
+          });
+          onResult(ok);
+        }}
+      >
+        trigger
+      </button>
+    </div>
+  );
+};
+
+describe('useConfirm', () => {
+  it('renders nothing until confirm is called', () => {
+    render(<Harness onResult={jest.fn()} />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('resolves true when the confirm action is taken', async () => {
+    const onResult = jest.fn();
+    render(<Harness onResult={onResult} />);
+
+    fireEvent.click(screen.getByText('trigger'));
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
+    expect(screen.getByText('Lab ordering stops until it is enabled again.')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Disconnect'));
+    await waitFor(() => expect(onResult).toHaveBeenCalledWith(true));
+    // The dialog closes once settled.
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('resolves false when cancelled', async () => {
+    const onResult = jest.fn();
+    render(<Harness onResult={onResult} />);
+
+    fireEvent.click(screen.getByText('trigger'));
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Cancel'));
+
+    await waitFor(() => expect(onResult).toHaveBeenCalledWith(false));
+  });
+
+  it('resolves false when dismissed via the close control', async () => {
+    const onResult = jest.fn();
+    render(<Harness onResult={onResult} />);
+
+    fireEvent.click(screen.getByText('trigger'));
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('close'));
+
+    // Dismissing is a decline, matching what the native confirm() did.
+    await waitFor(() => expect(onResult).toHaveBeenCalledWith(false));
+  });
+
+  it('gives the dialog an accessible name from the title', async () => {
+    render(<Harness onResult={jest.fn()} />);
+    fireEvent.click(screen.getByText('trigger'));
+
+    await waitFor(() =>
+      expect(screen.getByRole('dialog', { name: 'Disconnect IDEXX?' })).toBeInTheDocument()
+    );
+  });
+
+  it('can be reopened after settling', async () => {
+    const onResult = jest.fn();
+    render(<Harness onResult={onResult} />);
+
+    fireEvent.click(screen.getByText('trigger'));
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Cancel'));
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('trigger'));
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Disconnect'));
+
+    await waitFor(() => expect(onResult).toHaveBeenNthCalledWith(2, true));
+  });
+});

--- a/apps/frontend/src/app/__tests__/ui/overlays/Modal/DeleteConfirmationModal.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/overlays/Modal/DeleteConfirmationModal.test.tsx
@@ -16,8 +16,10 @@ jest.mock('@/app/ui/primitives/Buttons', () => ({
 
 jest.mock('@/app/ui/primitives/Buttons/Delete', () => ({
   __esModule: true,
-  default: ({ text, onClick }: any) => (
-    <button type="button" onClick={onClick}>
+  // Mirrors BaseButton: isDisabled must actually disable, otherwise the
+  // assertions below would pass without exercising the gate.
+  default: ({ text, onClick, isDisabled }: any) => (
+    <button type="button" onClick={onClick} disabled={isDisabled}>
       {text}
     </button>
   ),
@@ -114,6 +116,7 @@ describe('DeleteConfirmationModal', () => {
   it('shows email validation error when deleting without email', async () => {
     render(<DeleteConfirmationModal {...baseProps} />);
 
+    fireEvent.click(screen.getByLabelText('Confirm deletion consent'));
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
 
     expect(await screen.findByText('Email is required')).toBeInTheDocument();
@@ -126,6 +129,7 @@ describe('DeleteConfirmationModal', () => {
     fireEvent.change(screen.getByLabelText('Enter email address'), {
       target: { value: 'not-an-email' },
     });
+    fireEvent.click(screen.getByLabelText('Confirm deletion consent'));
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
 
     expect(await screen.findByText('Enter a valid email')).toBeInTheDocument();
@@ -138,11 +142,79 @@ describe('DeleteConfirmationModal', () => {
     fireEvent.change(screen.getByLabelText('Enter email address'), {
       target: { value: 'owner@yosemite.com' },
     });
+    fireEvent.click(screen.getByLabelText('Confirm deletion consent'));
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
 
     await waitFor(() => {
       expect(baseProps.onDelete).toHaveBeenCalledTimes(1);
       expect(baseProps.setShowModal).toHaveBeenCalledWith(false);
     });
+  });
+});
+
+describe('DeleteConfirmationModal consent gate', () => {
+  const baseProps = {
+    showModal: true,
+    setShowModal: jest.fn(),
+    title: 'Delete organization',
+    confirmationQuestion: 'Are you sure?',
+    itemsToRemove: ['All records'],
+    emailPrompt: 'Type your email to confirm',
+    consentLabel: 'I understand this is permanent',
+    noteText: 'This cannot be undone.',
+  };
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('keeps Delete disabled until both consent and an email are given', () => {
+    render(<DeleteConfirmationModal {...baseProps} onDelete={jest.fn()} />);
+    const deleteButton = screen.getByRole('button', { name: 'Delete' });
+
+    expect(deleteButton).toBeDisabled();
+
+    // Consent is the gate. It was read by nothing before, so the checkbox was
+    // decorative on an irreversible action.
+    fireEvent.click(screen.getByLabelText('Confirm deletion consent'));
+    expect(deleteButton).toBeEnabled();
+  });
+
+  it('deletes once consent is given and the email is valid', async () => {
+    const onDelete = jest.fn().mockResolvedValue(undefined);
+    render(<DeleteConfirmationModal {...baseProps} onDelete={onDelete} />);
+
+    fireEvent.change(screen.getByLabelText('Enter email address'), {
+      target: { value: 'owner@clinic.com' },
+    });
+    fireEvent.click(screen.getByLabelText('Confirm deletion consent'));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => expect(onDelete).toHaveBeenCalledTimes(1));
+  });
+
+  it('cannot be triggered while consent is unticked', () => {
+    const onDelete = jest.fn();
+    render(<DeleteConfirmationModal {...baseProps} onDelete={onDelete} />);
+
+    fireEvent.change(screen.getByLabelText('Enter email address'), {
+      target: { value: 'owner@clinic.com' },
+    });
+    // A disabled button swallows the click, so the irreversible action is
+    // unreachable without consent. This is the hole that existed before:
+    // handleDelete read the email but never the checkbox.
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it('still blocks an invalid email once consent is given', async () => {
+    const onDelete = jest.fn().mockResolvedValue(undefined);
+    render(<DeleteConfirmationModal {...baseProps} onDelete={onDelete} />);
+
+    fireEvent.change(screen.getByLabelText('Enter email address'), {
+      target: { value: 'not-an-email' },
+    });
+    fireEvent.click(screen.getByLabelText('Confirm deletion consent'));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => expect(onDelete).not.toHaveBeenCalled());
   });
 });

--- a/apps/frontend/src/app/__tests__/ui/overlays/Modal/ModalBaseStacking.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/overlays/Modal/ModalBaseStacking.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * A modal opened from inside another modal must not take its parent down with
+ * it. Each ModalBase installs document-level Escape and outside-mousedown
+ * listeners and shares one body scroll lock, so before this was stack-aware a
+ * nested confirmation dismissed the editor underneath it and released the
+ * parent's scroll lock on close.
+ */
+import React, { useState } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import CenterModal from '@/app/ui/overlays/Modal/CenterModal';
+
+/** Parent modal that can open a nested child, mirroring the real flows. */
+const Nested = () => {
+  const [parentOpen, setParentOpen] = useState(true);
+  const [childOpen, setChildOpen] = useState(false);
+  return (
+    <div>
+      <CenterModal showModal={parentOpen} setShowModal={setParentOpen} ariaLabel="Parent editor">
+        <p>parent body</p>
+        <button type="button" onClick={() => setChildOpen(true)}>
+          open child
+        </button>
+      </CenterModal>
+      <CenterModal showModal={childOpen} setShowModal={setChildOpen} ariaLabel="Child confirmation">
+        <p>child body</p>
+      </CenterModal>
+      <span data-testid="state">{`${parentOpen ? 'parent-open' : 'parent-closed'} ${childOpen ? 'child-open' : 'child-closed'}`}</span>
+    </div>
+  );
+};
+
+const state = () => screen.getByTestId('state').textContent;
+
+describe('nested modals', () => {
+  afterEach(() => {
+    document.body.style.overflow = '';
+    document.documentElement.style.overflow = '';
+    document.body.style.paddingRight = '';
+  });
+
+  it('closes only the topmost modal on Escape', () => {
+    render(<Nested />);
+    fireEvent.click(screen.getByText('open child'));
+    expect(state()).toBe('parent-open child-open');
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    // The child goes; the parent and any unsaved state in it survive.
+    expect(state()).toBe('parent-open child-closed');
+  });
+
+  it('closes only the topmost modal on an outside mousedown', () => {
+    render(<Nested />);
+    fireEvent.click(screen.getByText('open child'));
+    expect(state()).toBe('parent-open child-open');
+
+    // A click on the child's backdrop sits outside .yc-modal-dialog, which is
+    // exactly the case that used to dismiss both.
+    fireEvent.mouseDown(document.body);
+
+    expect(state()).toBe('parent-open child-closed');
+  });
+
+  it('keeps the parent scroll lock when the child closes', () => {
+    render(<Nested />);
+    expect(document.body.style.overflow).toBe('hidden');
+
+    fireEvent.click(screen.getByText('open child'));
+    expect(document.body.style.overflow).toBe('hidden');
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    // The parent is still open, so the page behind it must stay locked.
+    expect(state()).toBe('parent-open child-closed');
+    expect(document.body.style.overflow).toBe('hidden');
+  });
+
+  it('releases the scroll lock once the last modal closes', () => {
+    render(<Nested />);
+    fireEvent.click(screen.getByText('open child'));
+    fireEvent.keyDown(document, { key: 'Escape' });
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(state()).toBe('parent-closed child-closed');
+    expect(document.body.style.overflow).toBe('');
+    expect(document.documentElement.style.overflow).toBe('');
+  });
+
+  it('restores focus to the opener when a modal unmounts while open', () => {
+    const Unmounting = () => {
+      const [mounted, setMounted] = useState(false);
+      return (
+        <div>
+          <button type="button" data-testid="opener" onClick={() => setMounted(true)}>
+            open
+          </button>
+          {mounted && (
+            <CenterModal showModal setShowModal={() => setMounted(false)} ariaLabel="Transient">
+              <button type="button" onClick={() => setMounted(false)}>
+                resolve
+              </button>
+            </CenterModal>
+          )}
+        </div>
+      );
+    };
+    render(<Unmounting />);
+    const opener = screen.getByTestId('opener');
+    opener.focus();
+    fireEvent.click(opener);
+
+    // Resolving unmounts the modal outright rather than rerendering it closed,
+    // which is how the promise-based confirmation settles.
+    fireEvent.click(screen.getByText('resolve'));
+
+    expect(document.activeElement).toBe(opener);
+  });
+});

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/Tasks/Chat.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/Tasks/Chat.tsx
@@ -13,6 +13,7 @@ import {
 import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
 
 import { useAuthStore } from '@/app/stores/authStore';
+import { useConfirm } from '@/app/ui/overlays/Modal/ConfirmModal';
 
 type ChatProps = {
   activeAppointment: Appointment | null;
@@ -20,6 +21,7 @@ type ChatProps = {
 
 const Chat = ({ activeAppointment }: ChatProps) => {
   const router = useRouter();
+  const { confirm, confirmDialog } = useConfirm();
   const { attributes } = useAuthStore();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -120,9 +122,12 @@ const Chat = ({ activeAppointment }: ChatProps) => {
     // Prevent duplicate calls if already closing or already closed
     if (closingSession || sessionClosed) return;
 
-    const confirmed = confirm(
-      'Are you sure you want to close this chat session? The client will no longer be able to send messages.'
-    );
+    const confirmed = await confirm({
+      title: 'Close this chat session?',
+      body: 'The client will no longer be able to send messages in this conversation.',
+      confirmLabel: 'Close session',
+      tone: 'danger',
+    });
     if (!confirmed) {
       return;
     }
@@ -250,6 +255,7 @@ const Chat = ({ activeAppointment }: ChatProps) => {
 
   return (
     <div className="flex flex-col gap-6 w-full flex-1 justify-between overflow-y-auto">
+      {confirmDialog}
       <div className="flex flex-col gap-6">
         <div className="flex items-center justify-between">
           <div className="font-satoshi font-medium text-black-text text-[23px]">

--- a/apps/frontend/src/app/features/chat/components/ChatContainer.tsx
+++ b/apps/frontend/src/app/features/chat/components/ChatContainer.tsx
@@ -126,6 +126,7 @@ const ChatBackContext = createContext<{ showBack: boolean; onBack: () => void }>
 import ProtectedRoute from '@/app/ui/layout/guards/ProtectedRoute';
 import OrgGuard from '@/app/ui/layout/guards/OrgGuard';
 import PageSkeleton from '@/app/ui/layout/PageSkeleton';
+import { useConfirm } from '@/app/ui/overlays/Modal/ConfirmModal';
 
 const CHAT_PAGE_SKELETON = <PageSkeleton variant="list" />;
 
@@ -350,6 +351,7 @@ const ChannelHeaderWithCounterpart: FC<{
     appointmentId ? s.appointmentsById[appointmentId] : undefined
   );
   const companion = useCompanionStore((s) => (patientId ? s.companionsById[patientId] : undefined));
+  const { confirm, confirmDialog } = useConfirm();
 
   const {
     sessionClosed,
@@ -367,6 +369,7 @@ const ChannelHeaderWithCounterpart: FC<{
     appointmentId,
     backendStatus,
     refreshStatuses,
+    confirm,
   });
 
   const {
@@ -391,6 +394,7 @@ const ChannelHeaderWithCounterpart: FC<{
 
   return (
     <>
+      {confirmDialog}
       <ChannelHeaderBar
         title={title}
         statusText={statusText}
@@ -1085,6 +1089,7 @@ const useChatContainerView = ({
     []
   );
   const groupModalBackendIdRef = useRef<string | undefined>(undefined);
+  const { confirm, confirmDialog } = useConfirm();
   // Rendered into the modal, so state (not a ref); only written in the open
   // handlers below.
   const [groupModalOwner, setGroupModalOwner] = useState<string | undefined>(undefined);
@@ -1819,7 +1824,12 @@ const useChatContainerView = ({
       });
       return;
     }
-    const confirmed = confirm('Delete this group? This cannot be undone.');
+    const confirmed = await confirm({
+      title: 'Delete this group?',
+      body: 'The group and its messages are removed for everyone. This cannot be undone.',
+      confirmLabel: 'Delete group',
+      tone: 'danger',
+    });
     if (!confirmed) return;
     setGroupModalBusy(true);
     try {
@@ -1849,7 +1859,7 @@ const useChatContainerView = ({
     } finally {
       setGroupModalBusy(false);
     }
-  }, [groupModalChannel, onChannelSelect, notify, setGroupModalBusy, setGroupModalOpen]);
+  }, [groupModalChannel, onChannelSelect, notify, setGroupModalBusy, setGroupModalOpen, confirm]);
 
   const groupModalContextValue = useMemo(
     () => ({
@@ -2002,6 +2012,7 @@ const useChatContainerView = ({
 
   return (
     <ChatSessionStatusContext.Provider value={chatSessionStatusContextValue}>
+      {confirmDialog}
       <GroupModalContext.Provider value={groupModalContextValue}>
         <ChatShareContext.Provider value={shareContextValue}>
           <div className={className}>

--- a/apps/frontend/src/app/features/chat/hooks/useChannelSessionActions.ts
+++ b/apps/frontend/src/app/features/chat/hooks/useChannelSessionActions.ts
@@ -9,6 +9,7 @@ import { getChatSession } from '@/app/features/chat/services/chatService';
 import { endChatChannel } from '@/app/features/chat/services/streamChatService';
 import { buildWorkspaceHref } from '@/app/lib/appointmentWorkspace';
 import { useNotify } from '@/app/hooks/useNotify';
+import type { ConfirmOptions } from '@/app/ui/overlays/Modal/ConfirmModal';
 
 type UseChannelSessionActionsArgs = {
   channel: StreamChannel | null | undefined;
@@ -16,6 +17,11 @@ type UseChannelSessionActionsArgs = {
   appointmentId?: string;
   backendStatus?: 'active' | 'ended';
   refreshStatuses: () => void;
+  /**
+   * Confirmation for closing a client's session. Supplied by the consumer so a
+   * single dialog instance serves the whole chat surface.
+   */
+  confirm: (options: ConfirmOptions) => Promise<boolean>;
 };
 
 export type ChannelSessionActions = {
@@ -41,6 +47,7 @@ export const useChannelSessionActions = ({
   appointmentId,
   backendStatus,
   refreshStatuses,
+  confirm,
 }: UseChannelSessionActionsArgs): ChannelSessionActions => {
   const { notify } = useNotify();
   const router = useRouter();
@@ -72,9 +79,12 @@ export const useChannelSessionActions = ({
       return;
     }
 
-    const confirmed = confirm(
-      'Are you sure you want to close this chat session? The client will no longer be able to send messages.'
-    );
+    const confirmed = await confirm({
+      title: 'Close this chat session?',
+      body: 'The client will no longer be able to send messages in this conversation.',
+      confirmLabel: 'Close session',
+      tone: 'danger',
+    });
     if (!confirmed) {
       return;
     }

--- a/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
@@ -47,6 +47,7 @@ import {
 import clsx from 'clsx';
 import GlassTooltip from '@/app/ui/primitives/GlassTooltip/GlassTooltip';
 import SharedStatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
+import { useConfirm } from '@/app/ui/overlays/Modal/ConfirmModal';
 
 type StatusTokens = { bg: string; text: string; border: string };
 
@@ -357,6 +358,7 @@ type IdexxActionsState = {
 };
 
 const useIdexxActions = (s: IdexxActionsState) => {
+  const { confirm, confirmDialog } = useConfirm();
   const handleManualRefresh = useCallback(async () => {
     if (!s.primaryOrgId || s.refreshing) return;
     s.setRefreshing(true);
@@ -445,9 +447,12 @@ const useIdexxActions = (s: IdexxActionsState) => {
     }
     const isDisconnecting = (s.idexxIntegration.status ?? '').toLowerCase() === 'enabled';
     if (isDisconnecting) {
-      const ok = globalThis.confirm(
-        'Disconnect IDEXX for this organization? Lab ordering and result syncing will be unavailable until re-enabled.'
-      );
+      const ok = await confirm({
+        title: 'Disconnect IDEXX?',
+        body: 'Lab ordering and result syncing stop for this organization until IDEXX is enabled again.',
+        confirmLabel: 'Disconnect',
+        tone: 'danger',
+      });
       if (!ok) return;
     }
     s.setSaving(true);
@@ -472,9 +477,15 @@ const useIdexxActions = (s: IdexxActionsState) => {
     } finally {
       s.setSaving(false);
     }
-  }, [s, validateBeforeEnable]);
+  }, [s, validateBeforeEnable, confirm]);
 
-  return { handleManualRefresh, handleStoreCredentials, handleValidate, handleEnableDisable };
+  return {
+    handleManualRefresh,
+    handleStoreCredentials,
+    handleValidate,
+    handleEnableDisable,
+    confirmDialog,
+  };
 };
 
 const useIntegrationsPage = () => {
@@ -565,21 +576,26 @@ const useIntegrationsPage = () => {
     setValidateState(resolveValidateState(idexxIntegration?.credentialsStatus));
   }
 
-  const { handleManualRefresh, handleStoreCredentials, handleValidate, handleEnableDisable } =
-    useIdexxActions({
-      primaryOrgId,
-      refreshing,
-      saving,
-      username,
-      password,
-      idexxIntegration,
-      setDevices,
-      setError,
-      setRefreshing,
-      setSaving,
-      setValidateState,
-      setShowSettings,
-    });
+  const {
+    handleManualRefresh,
+    handleStoreCredentials,
+    handleValidate,
+    handleEnableDisable,
+    confirmDialog,
+  } = useIdexxActions({
+    primaryOrgId,
+    refreshing,
+    saving,
+    username,
+    password,
+    idexxIntegration,
+    setDevices,
+    setError,
+    setRefreshing,
+    setSaving,
+    setValidateState,
+    setShowSettings,
+  });
 
   const linkedCount = useMemo(() => {
     const enabledProviders = integrations.reduce<Set<string>>((providers, integration) => {
@@ -630,6 +646,7 @@ const useIntegrationsPage = () => {
   }, [primaryOrgId, merckEnabled, merckSaving, refreshMerckIntegration]);
 
   return {
+    confirmDialog,
     primaryOrg,
     primaryOrgId,
     canEditIntegrations,
@@ -1275,6 +1292,7 @@ const IntegrationsPage = () => {
 
   return (
     <div className="yc-page-content">
+      {s.confirmDialog}
       <div className="flex justify-between items-start gap-3 flex-wrap">
         <div className="flex flex-col gap-1">
           <h1 className="text-page-title flex items-center gap-2">

--- a/apps/frontend/src/app/ui/overlays/Modal/CenterModal.tsx
+++ b/apps/frontend/src/app/ui/overlays/Modal/CenterModal.tsx
@@ -7,6 +7,13 @@ type ModalProps = {
   setShowModal: React.Dispatch<React.SetStateAction<boolean>>;
   onClose?: () => void;
   containerClassName?: string;
+  /**
+   * Accessible name for the dialog. ModalBase already applies it; CenterModal
+   * previously declared no way to pass one, so every dialog built on it
+   * rendered without a name for screen readers.
+   */
+  ariaLabel?: string;
+  ariaLabelledBy?: string;
 };
 
 const ignorePortalDropdownClick = (target: HTMLElement | null) =>
@@ -18,11 +25,15 @@ const CenterModal = ({
   setShowModal,
   onClose,
   containerClassName,
+  ariaLabel,
+  ariaLabelledBy,
 }: ModalProps) => (
   <ModalBase
     showModal={showModal}
     setShowModal={setShowModal}
     onClose={onClose}
+    aria-label={ariaLabel}
+    aria-labelledby={ariaLabelledBy}
     ignoreOutsideClick={ignorePortalDropdownClick}
     overlayClassName={`fixed backdrop-blur-[6px] inset-0 z-[1100] transition-opacity duration-200 ease-in-out ${
       showModal ? 'opacity-100' : 'opacity-0 pointer-events-none'

--- a/apps/frontend/src/app/ui/overlays/Modal/ConfirmModal.stories.tsx
+++ b/apps/frontend/src/app/ui/overlays/Modal/ConfirmModal.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
+import { Primary } from '@/app/ui/primitives/Buttons';
 import { useConfirm } from './ConfirmModal';
 
 /**
@@ -37,17 +38,15 @@ const Demo = ({
   return (
     <div className="flex flex-col items-start gap-4 p-6">
       {confirmDialog}
-      <button
-        type="button"
-        data-testid="open-confirm"
-        className="btn btn--primary rounded-full bg-[var(--cta)] px-5 py-2 text-[var(--cta-text)]"
-        onClick={async () => {
-          const ok = await confirm({ title, body, confirmLabel, tone });
-          setResult(ok ? 'confirmed' : 'declined');
-        }}
-      >
-        {title}
-      </button>
+      <span data-testid="open-confirm-wrap">
+        <Primary
+          text={title}
+          onClick={async () => {
+            const ok = await confirm({ title, body, confirmLabel, tone });
+            setResult(ok ? 'confirmed' : 'declined');
+          }}
+        />
+      </span>
       <span data-testid="confirm-result" className="text-body-4 text-[var(--ink-muted)]">
         Result: {result}
       </span>

--- a/apps/frontend/src/app/ui/overlays/Modal/ConfirmModal.stories.tsx
+++ b/apps/frontend/src/app/ui/overlays/Modal/ConfirmModal.stories.tsx
@@ -1,0 +1,93 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { useConfirm } from './ConfirmModal';
+
+/**
+ * Confirmation for irreversible actions, replacing the browser's native
+ * confirm(). Rendered through the hook exactly as call sites use it, so the
+ * story exercises the real promise flow rather than a static shell.
+ */
+const meta: Meta = {
+  title: 'Overlays/ConfirmModal',
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Promise-based confirmation. `confirm()` resolves true on the confirm action and false on cancel, Escape, backdrop click or the close control.',
+      },
+    },
+  },
+};
+export default meta;
+
+const Demo = ({
+  tone,
+  title,
+  body,
+  confirmLabel,
+}: {
+  tone?: 'default' | 'danger';
+  title: string;
+  body: string;
+  confirmLabel: string;
+}) => {
+  const { confirm, confirmDialog } = useConfirm();
+  const [result, setResult] = React.useState<string>('no answer yet');
+
+  return (
+    <div className="flex flex-col items-start gap-4 p-6">
+      {confirmDialog}
+      <button
+        type="button"
+        data-testid="open-confirm"
+        className="btn btn--primary rounded-full bg-[var(--cta)] px-5 py-2 text-[var(--cta-text)]"
+        onClick={async () => {
+          const ok = await confirm({ title, body, confirmLabel, tone });
+          setResult(ok ? 'confirmed' : 'declined');
+        }}
+      >
+        {title}
+      </button>
+      <span data-testid="confirm-result" className="text-body-4 text-[var(--ink-muted)]">
+        Result: {result}
+      </span>
+    </div>
+  );
+};
+
+type Story = StoryObj<typeof Demo>;
+
+export const DangerousAction: Story = {
+  name: 'Danger (disconnect IDEXX)',
+  render: () => (
+    <Demo
+      tone="danger"
+      title="Disconnect IDEXX?"
+      body="Lab ordering and result syncing stop for this organization until IDEXX is enabled again."
+      confirmLabel="Disconnect"
+    />
+  ),
+};
+
+export const DeleteGroup: Story = {
+  name: 'Danger (delete group)',
+  render: () => (
+    <Demo
+      tone="danger"
+      title="Delete this group?"
+      body="The group and its messages are removed for everyone. This cannot be undone."
+      confirmLabel="Delete group"
+    />
+  ),
+};
+
+export const NeutralAction: Story = {
+  name: 'Default tone',
+  render: () => (
+    <Demo
+      title="Close this chat session?"
+      body="The client will no longer be able to send messages in this conversation."
+      confirmLabel="Close session"
+    />
+  ),
+};

--- a/apps/frontend/src/app/ui/overlays/Modal/ConfirmModal.tsx
+++ b/apps/frontend/src/app/ui/overlays/Modal/ConfirmModal.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import React, { useCallback, useRef, useState } from 'react';
+import CenterModal from '@/app/ui/overlays/Modal/CenterModal';
+import ModalHeader from '@/app/ui/overlays/Modal/ModalHeader';
+import ModalFooter from '@/app/ui/overlays/Modal/ModalFooter';
+import Delete from '@/app/ui/primitives/Buttons/Delete';
+import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
+
+export type ConfirmOptions = {
+  title: string;
+  /** One sentence on what happens, written so the consequence is unambiguous. */
+  body: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  /** `danger` renders the confirm action in the danger style. */
+  tone?: 'default' | 'danger';
+};
+
+/**
+ * Promise-based confirmation for irreversible actions.
+ *
+ * The native `confirm()` this replaces is an unstyled, unthemed OS dialog that
+ * cannot carry the product's voice, cannot be reviewed in Storybook, and is
+ * suppressible by the browser. It is also synchronous, which is why call sites
+ * reached for it: they sit inside an async handler and need a yes/no before
+ * continuing. `confirm()` here returns a promise, so those handlers keep their
+ * shape and only the one line changes.
+ *
+ *   const { confirm, confirmDialog } = useConfirm();
+ *   ...
+ *   if (!(await confirm({ title, body, tone: 'danger' }))) return;
+ *   ...
+ *   return (<>{confirmDialog}...</>);
+ */
+export const useConfirm = () => {
+  const [options, setOptions] = useState<ConfirmOptions | null>(null);
+  // The resolver lives in a ref rather than state so that settling never
+  // depends on a state updater running exactly once.
+  const resolverRef = useRef<((value: boolean) => void) | null>(null);
+
+  const confirm = useCallback(
+    (next: ConfirmOptions) =>
+      new Promise<boolean>((resolve) => {
+        resolverRef.current = resolve;
+        setOptions(next);
+      }),
+    []
+  );
+
+  const settle = useCallback((value: boolean) => {
+    const resolve = resolverRef.current;
+    resolverRef.current = null;
+    setOptions(null);
+    resolve?.(value);
+  }, []);
+
+  const confirmDialog = options ? <ConfirmModal options={options} onResolve={settle} /> : null;
+
+  return { confirm, confirmDialog };
+};
+
+const ConfirmModal = ({
+  options,
+  onResolve,
+}: Readonly<{ options: ConfirmOptions; onResolve: (value: boolean) => void }>) => {
+  const {
+    title,
+    body,
+    confirmLabel = 'Confirm',
+    cancelLabel = 'Cancel',
+    tone = 'default',
+  } = options;
+  const ConfirmButton = tone === 'danger' ? Delete : Primary;
+
+  return (
+    <CenterModal
+      showModal
+      // Dismissing by backdrop, Escape or the close button is a decline, which
+      // matches what the native dialog did.
+      setShowModal={() => onResolve(false)}
+      onClose={() => onResolve(false)}
+      ariaLabel={title}
+    >
+      <ModalHeader title={title} onClose={() => onResolve(false)} />
+      <p className="text-body-4 text-text-primary">{body}</p>
+      <ModalFooter>
+        <Secondary text={cancelLabel} onClick={() => onResolve(false)} />
+        <ConfirmButton text={confirmLabel} onClick={() => onResolve(true)} />
+      </ModalFooter>
+    </CenterModal>
+  );
+};
+
+export default ConfirmModal;

--- a/apps/frontend/src/app/ui/overlays/Modal/DeleteConfirmationModal.tsx
+++ b/apps/frontend/src/app/ui/overlays/Modal/DeleteConfirmationModal.tsx
@@ -76,12 +76,6 @@ const DeleteConfirmationModal: React.FC<DeleteConfirmationModalProps> = ({
     setShowModal(false);
   };
 
-  // Gate on consent only. The email field keeps its own inline validation, so
-  // folding it in here would make "Email is required" unreachable. Consent was
-  // the actual hole: it was read by nothing, so a user could delete an
-  // organization or a profile without ever ticking "this is permanent".
-  const canDelete = consent;
-
   const handleDelete = async () => {
     // Defence in depth: the button is disabled without consent, but this modal
     // fronts irreversible actions so the guard is enforced here as well.
@@ -140,7 +134,12 @@ const DeleteConfirmationModal: React.FC<DeleteConfirmationModalProps> = ({
         </div>
         <div className="grid grid-cols-2 gap-2">
           <Secondary href="#" text="Cancel" onClick={handleCancel} />
-          <Delete href="#" onClick={handleDelete} text="Delete" isDisabled={!canDelete} />
+          {/* Gated on consent only: the email keeps its own inline validation,
+              so folding it in here would make "Email is required" unreachable.
+              Consent was the actual hole - it was read by nothing, so an
+              organization or profile could be deleted without ever ticking
+              "this is permanent". */}
+          <Delete href="#" onClick={handleDelete} text="Delete" isDisabled={!consent} />
         </div>
         <div className="text-caption-1 text-text-primary">
           <span className="text-blue-text">Note : </span> {noteText}

--- a/apps/frontend/src/app/ui/overlays/Modal/DeleteConfirmationModal.tsx
+++ b/apps/frontend/src/app/ui/overlays/Modal/DeleteConfirmationModal.tsx
@@ -76,7 +76,16 @@ const DeleteConfirmationModal: React.FC<DeleteConfirmationModalProps> = ({
     setShowModal(false);
   };
 
+  // Gate on consent only. The email field keeps its own inline validation, so
+  // folding it in here would make "Email is required" unreachable. Consent was
+  // the actual hole: it was read by nothing, so a user could delete an
+  // organization or a profile without ever ticking "this is permanent".
+  const canDelete = consent;
+
   const handleDelete = async () => {
+    // Defence in depth: the button is disabled without consent, but this modal
+    // fronts irreversible actions so the guard is enforced here as well.
+    if (!consent) return;
     if (!validateEmail()) return;
     try {
       await onDelete();
@@ -120,7 +129,6 @@ const DeleteConfirmationModal: React.FC<DeleteConfirmationModalProps> = ({
           <input
             type="checkbox"
             aria-label="Confirm deletion consent"
-            placeholder="Demo"
             id="consent-checkbox"
             checked={consent}
             onChange={(e) => setConsent(e.target.checked)}
@@ -132,7 +140,7 @@ const DeleteConfirmationModal: React.FC<DeleteConfirmationModalProps> = ({
         </div>
         <div className="grid grid-cols-2 gap-2">
           <Secondary href="#" text="Cancel" onClick={handleCancel} />
-          <Delete href="#" onClick={handleDelete} text="Delete" />
+          <Delete href="#" onClick={handleDelete} text="Delete" isDisabled={!canDelete} />
         </div>
         <div className="text-caption-1 text-text-primary">
           <span className="text-blue-text">Note : </span> {noteText}

--- a/apps/frontend/src/app/ui/overlays/Modal/ModalBase.tsx
+++ b/apps/frontend/src/app/ui/overlays/Modal/ModalBase.tsx
@@ -84,10 +84,7 @@ const ModalBase = ({
   const previousFocusRef = useRef<HTMLElement | null>(null);
   // Stable per-instance identity used as this modal's token in `modalStack`.
   const stackTokenRef = useRef<object>({});
-  const isTopmostModal = useCallback(
-    () => modalStack[modalStack.length - 1] === stackTokenRef.current,
-    []
-  );
+  const isTopmostModal = useCallback(() => modalStack.at(-1) === stackTokenRef.current, []);
   // React 19 owns the inert attribute via this boolean prop (true = inert, undefined = not inert).
   // Never mix with imperative setAttribute to avoid the empty-string boolean warning.
   // Derived directly from showModal — no need to copy it into state and sync it in an effect.

--- a/apps/frontend/src/app/ui/overlays/Modal/ModalBase.tsx
+++ b/apps/frontend/src/app/ui/overlays/Modal/ModalBase.tsx
@@ -22,6 +22,46 @@ type ModalBaseProps = {
   'aria-describedby'?: string;
 };
 
+/**
+ * Every modal portals to document.body and installs its own document-level
+ * Escape and outside-mousedown listeners. A modal opened from inside another
+ * one (a confirmation over the group editor, say) therefore had BOTH respond to
+ * the same key or backdrop click, dismissing the parent and discarding its
+ * state. `stopPropagation` cannot prevent that: both listeners sit on the same
+ * node, so only the topmost dialog may act.
+ */
+const modalStack: object[] = [];
+
+/**
+ * The scroll lock is shared, so releasing it must be ref-counted. Otherwise
+ * closing a nested modal cleared body overflow while its parent was still open
+ * and the page behind it started scrolling.
+ */
+let scrollLockCount = 0;
+
+const acquireScrollLock = () => {
+  if (scrollLockCount === 0) {
+    const scrollbarWidth =
+      globalThis.window === undefined
+        ? 0
+        : globalThis.window.innerWidth - document.documentElement.clientWidth;
+    document.body.style.overflow = 'hidden';
+    document.body.style.paddingRight = `${scrollbarWidth}px`;
+    // Safari requires overflow:hidden on <html> to prevent body scroll
+    document.documentElement.style.overflow = 'hidden';
+  }
+  scrollLockCount += 1;
+};
+
+const releaseScrollLock = () => {
+  scrollLockCount = Math.max(0, scrollLockCount - 1);
+  if (scrollLockCount === 0) {
+    document.body.style.overflow = '';
+    document.body.style.paddingRight = '';
+    document.documentElement.style.overflow = '';
+  }
+};
+
 /** Focusable element selectors used for focus-trap logic. */
 const FOCUSABLE =
   'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
@@ -42,6 +82,12 @@ const ModalBase = ({
 }: ModalBaseProps) => {
   const containerRef = useRef<HTMLDialogElement | null>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
+  // Stable per-instance identity used as this modal's token in `modalStack`.
+  const stackTokenRef = useRef<object>({});
+  const isTopmostModal = useCallback(
+    () => modalStack[modalStack.length - 1] === stackTokenRef.current,
+    []
+  );
   // React 19 owns the inert attribute via this boolean prop (true = inert, undefined = not inert).
   // Never mix with imperative setAttribute to avoid the empty-string boolean warning.
   // Derived directly from showModal — no need to copy it into state and sync it in an effect.
@@ -75,19 +121,18 @@ const ModalBase = ({
       return;
     }
     previousFocusRef.current = document.activeElement as HTMLElement;
-    const scrollbarWidth =
-      globalThis.window === undefined
-        ? 0
-        : globalThis.window.innerWidth - document.documentElement.clientWidth;
-    document.body.style.overflow = 'hidden';
-    document.body.style.paddingRight = `${scrollbarWidth}px`;
-    // Safari requires overflow:hidden on <html> to prevent body scroll
-    document.documentElement.style.overflow = 'hidden';
+    const token = stackTokenRef.current;
+    modalStack.push(token);
+    acquireScrollLock();
     // Released via cleanup so unmounting while open cannot strand the lock.
     return () => {
-      document.body.style.overflow = '';
-      document.body.style.paddingRight = '';
-      document.documentElement.style.overflow = '';
+      const index = modalStack.lastIndexOf(token);
+      if (index !== -1) modalStack.splice(index, 1);
+      releaseScrollLock();
+      // A modal that unmounts while still open never reaches the `!showModal`
+      // branch above, so without this the opener loses focus to document.body.
+      previousFocusRef.current?.focus();
+      previousFocusRef.current = null;
     };
   }, [showModal]);
 
@@ -107,6 +152,10 @@ const ModalBase = ({
   useEffect(() => {
     if (!showModal) return;
     const handleClickOutside = (e: MouseEvent) => {
+      // Only the topmost dialog dismisses: the child's backdrop sits outside
+      // `.yc-modal-dialog`, so without this a backdrop click closed the parent
+      // underneath it too.
+      if (!isTopmostModal()) return;
       const target = e.target as HTMLElement | null;
       if (ignoreOutsideClickRef.current?.(target)) return;
       // Every modal portals to document.body, so a modal opened from inside
@@ -122,20 +171,22 @@ const ModalBase = ({
     };
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [showModal]);
+  }, [showModal, isTopmostModal]);
 
   // Escape key handler.
   useEffect(() => {
     if (!showModal) return;
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.stopPropagation();
-        closeModalRef.current();
-      }
+      if (e.key !== 'Escape') return;
+      // Both modals' listeners live on `document`, so stopPropagation cannot
+      // shield the parent. The stack decides who responds.
+      if (!isTopmostModal()) return;
+      e.stopPropagation();
+      closeModalRef.current();
     };
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [showModal]);
+  }, [showModal, isTopmostModal]);
 
   // Focus trap: keep focus inside the modal while it is open.
   useEffect(() => {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines
- [ ] There is an issue for the bug/feature this PR is for
- [x] All existing tests and lints pass

## What is the current behavior?

The "I understand this is permanent" checkbox on `DeleteConfirmationModal` is
decorative. `handleDelete` validates the email and **never reads `consent`**,
and the Delete button carries no disabled state.

That modal fronts two irreversible actions:

- `Organization/Sections/DeleteOrg.tsx` - deletes the clinic and revokes all
  team access
- `Settings/Sections/DeleteProfile.tsx` - leaves every organization and erases
  the account

So either can be completed with a valid email and the consent box untouched.

The reason this survived is that both consuming test suites drove the modal to
completion **without ever ticking the box** and passed, so the tests encoded the
hole rather than catching it.

## What is the new behavior?

- The Delete button is disabled until consent is given, and `handleDelete`
  re-checks it as defence in depth.
- The gate is **consent only**, deliberately. Folding the email into it would
  make the existing "Email is required" message unreachable, and the email
  field already has its own inline validation.
- Drops a stray `placeholder` attribute from the checkbox, which does nothing on
  that input type.

## Validation

- `npx tsc --noemit` clean
- `pnpm --filter frontend run lint` clean
- **1136 tests across 86 suites** pass
- Aikido SAST and secrets scan clean

Both consuming suites now tick the box. The modal suite gains four cases: the
disabled state, the guard, that an invalid email is still blocked once consent
is given, and that consent alone enables the button.

One note for the reviewer: the existing `Delete` mock in the modal suite
swallowed `isDisabled`, so any assertion about the disabled button would have
passed vacuously. The mock now mirrors `BaseButton`.

## Notes

Found during a design review of the signed-in product. Separate from #2211,
which covers the design-consistency batch; there is no file overlap.

Three sibling issues from the same review are **not** in this PR - four native
`confirm()` dialogs still gate irreversible actions (disconnect IDEXX, delete
group, and closing a client's chat session in two places). Happy to take those
next.

## Related Issue(s)

<!-- none; found during a design review -->
