### PR TITLE
test(mobile): pin the clock for the TaskCard dosage tests

### DIFF
--- a/apps/mobileAppYC/__tests__/components/tasks/TaskCard.test.tsx
+++ b/apps/mobileAppYC/__tests__/components/tasks/TaskCard.test.tsx
@@ -311,6 +311,49 @@ describe('TaskCard', () => {
       details: {taskType: 'give-medication'},
     };
 
+    // Two assertions here depend on whether a hardcoded HH:MM has already
+    // passed: the ones using 00:01 and 00:02 to exercise the "all dosages are
+    // in the past" fallback. Against the real clock they fail between midnight
+    // and 00:02, when 00:02 is still upcoming and the component correctly picks
+    // the nearest future dose instead. CI hit exactly that in run 31915744151,
+    // which executed at 00:01:44-00:02:02 UTC.
+    //
+    // The 23:59 cases are safe either way: with a single valid dosage the
+    // nearest-future path and the fallback path select the same entry. Pinning
+    // the whole block regardless keeps the next 23:59-style test from
+    // reintroducing the problem.
+    //
+    // The instant is built from local components so it is 14:30 in whatever
+    // zone the runner uses: mid-afternoon leaves 23:59 comfortably in the
+    // future and 00:01/00:02 comfortably in the past.
+    //
+    // Only Date is faked. Faking the timer APIs as well would stall React
+    // Native's rendering, and none of these tests need to advance time.
+    beforeEach(() => {
+      jest.useFakeTimers({
+        doNotFake: [
+          'cancelAnimationFrame',
+          'cancelIdleCallback',
+          'clearImmediate',
+          'clearInterval',
+          'clearTimeout',
+          'nextTick',
+          'performance',
+          'queueMicrotask',
+          'requestAnimationFrame',
+          'requestIdleCallback',
+          'setImmediate',
+          'setInterval',
+          'setTimeout',
+        ],
+      });
+      jest.setSystemTime(new Date(2026, 7, 16, 14, 30, 0, 0));
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
     it('shows the nearest future dosage time', () => {
       renderCard({
         ...medicationProps,


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines
- [ ] There is an issue for the bug/feature this PR is for
- [x] All existing tests and lints pass

## What is the current behavior?

Two assertions in `TaskCard > Medication nearest dosage context` depend on the
wall clock. They use dosage times `00:01` and `00:02` to exercise the "all
dosages are in the past" fallback and expect `12:01 AM`, which only holds once
the clock is past `00:02`.

Between midnight and `00:02` the `00:02` dose is still upcoming, so the
component correctly picks the nearest future dose and both tests fail:

- `falls back to the earliest dosage when all are in the past`
- `picks the earliest of two past dosages (fallback reduce comparison arm)`

CI hit exactly that in [run 31915744151](https://github.com/YosemiteCrew/Yosemite-Crew/actions/runs/31915744151), whose log timestamps show it
executing at `00:01:44`-`00:02:02` UTC. It passed on a re-run ten minutes
later, so it would have kept recurring nightly.

## What is the new behavior?

Only `Date` is faked for that describe block, pinned to `14:30` built from
local components so it lands mid-afternoon in whatever zone the runner uses:
`00:01`/`00:02` are comfortably in the past and `23:59` comfortably in the
future.

The timer APIs stay real. Faking them stalls React Native's rendering and none
of these tests advance time.

## Validation

- `npx tsc --noemit` clean
- `pnpm --filter mobileAppYC run lint` clean
- **81 tests across 2 TaskCard suites** pass

The fix was verified to actually control the outcome, not just coexist with it:

- pinning to `00:01:30` reproduces **both original failures by name**
- pinning to `14:30` passes all 81

## One correction to the original report

I had also suspected the `23:59` cases were time-dependent in the mirror
direction. They are not. Pinning to `23:59:30` leaves all 81 passing, because
with a single valid dosage the nearest-future path and the fallback path select
the same entry.

The block is pinned regardless, so a future `23:59`-style test with two dosages
cannot reintroduce the problem.

## Related Issue(s)

<!-- none; found while working on unrelated frontend PR #2211, which touches no mobile files -->
