### PR TITLE
fix(frontend): make PIMS tables render one consistent recipe

### DIFF
--- a/apps/frontend/src/app/__tests__/components/AvailabilityCard.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/AvailabilityCard.test.tsx
@@ -60,7 +60,7 @@ describe('AvailabilityCard', () => {
     expect(screen.getByText('Cardiology')).toBeInTheDocument();
   });
 
-  it('falls back to JSON.stringify when a speciality object has no name', () => {
+  it('falls back to the code when a speciality record has no name', () => {
     render(
       <AvailabilityCard
         team={
@@ -72,7 +72,25 @@ describe('AvailabilityCard', () => {
         handleViewTeam={jest.fn()}
       />
     );
-    expect(screen.getByText('{"code":"X1"}')).toBeInTheDocument();
+    // This used to render the literal `{"code":"X1"}` at a clinician.
+    expect(screen.getByText('X1')).toBeInTheDocument();
+    expect(screen.queryByText('{"code":"X1"}')).not.toBeInTheDocument();
+  });
+
+  it('keeps an unidentifiable speciality visible rather than dropping it', () => {
+    render(
+      <AvailabilityCard
+        team={
+          {
+            ...baseTeam,
+            speciality: [{ name: 'Cardiology' }, {}],
+          } as unknown as Team
+        }
+        handleViewTeam={jest.fn()}
+      />
+    );
+    // Dropping it would silently understate how many specialities a team holds.
+    expect(screen.getByText('Cardiology, Unnamed speciality')).toBeInTheDocument();
   });
 
   it('renders "-" when speciality is missing or empty', () => {

--- a/apps/frontend/src/app/__tests__/components/Calendar/common/Header.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/common/Header.test.tsx
@@ -264,11 +264,16 @@ describe('Header Component', () => {
       />
     );
 
-    // Active non-emergency pill fills with --inset behind a --divider outline and
-    // steps its label to --ink 700, per the planner's filter row.
+    // Active non-emergency pill takes the shared --chip-selected-* ink fill at
+    // 700. The neutral surface tokens it used before sat within 1.1:1 of the
+    // page, so weight was the only thing marking the selection.
     const allPillActive = screen.getByRole('button', { name: 'All' });
-    expect(allPillActive).toHaveClass('bg-[var(--inset)]', 'font-bold', 'text-[var(--ink)]');
-    expect(allPillActive).toHaveStyle({ borderColor: 'var(--divider)' });
+    expect(allPillActive).toHaveClass(
+      'bg-[var(--chip-selected-bg)]',
+      'font-bold',
+      'text-[var(--chip-selected-ink)]'
+    );
+    expect(allPillActive).not.toHaveClass('bg-[var(--inset)]');
 
     // Clicking an inactive pill selects it; clicking the active pill resets to 'all'.
     fireEvent.click(screen.getByRole('button', { name: 'Emergencies' }));

--- a/apps/frontend/src/app/__tests__/components/DataTable/Appointments.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/DataTable/Appointments.test.tsx
@@ -290,6 +290,46 @@ describe('Appointments table', () => {
     expect(screen.getByText('-')).toBeInTheDocument();
   });
 
+  it('shows the first two support staff and counts the rest', () => {
+    // One line per staff member let a busy appointment grow the row without
+    // bound in a 110px column.
+    const appointment: any = {
+      id: 'a3b',
+      status: 'UPCOMING',
+      concern: 'Checkup',
+      appointmentType: { name: 'Exam' },
+      room: { name: 'Room 1' },
+      appointmentDate: '2025-01-06T09:00:00.000Z',
+      startTime: '2025-01-06T09:00:00.000Z',
+      lead: { name: 'Dr. Lee' },
+      supportStaff: [
+        { id: 's1', name: 'Nurse Ada' },
+        { id: 's2', name: 'Nurse Bo' },
+        { id: 's3', name: 'Nurse Cy' },
+        { id: 's4', name: 'Nurse Di' },
+      ],
+      companion: {
+        id: 'c3',
+        name: 'Buddy',
+        species: 'dog',
+        parent: { name: 'Jamie' },
+      },
+    };
+
+    render(<Appointments filteredList={[appointment]} canEditAppointments />);
+
+    expect(screen.getAllByText('Nurse Ada').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Nurse Bo').length).toBeGreaterThan(0);
+    // The overflow is summarised rather than stacked...
+    expect(screen.queryByText('Nurse Cy')).not.toBeInTheDocument();
+    expect(screen.queryByText('Nurse Di')).not.toBeInTheDocument();
+    expect(screen.getAllByText('+2').length).toBeGreaterThan(0);
+    // ...and no assignment is actually lost.
+    expect(screen.getAllByTitle('Nurse Ada, Nurse Bo, Nurse Cy, Nurse Di').length).toBeGreaterThan(
+      0
+    );
+  });
+
   it('renders the desktop status cell through the protected shared pill class', () => {
     const appointment: any = {
       id: 'a6',

--- a/apps/frontend/src/app/__tests__/components/DataTable/AvailabilityTable.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/DataTable/AvailabilityTable.test.tsx
@@ -258,11 +258,31 @@ describe('AvailabilityTable Component', () => {
     it('clamps the cell to one line so a long list cannot stretch the row', () => {
       const cell = renderSpecialities(['Cardiology', 'Dermatology']);
 
-      // Tailwind's `truncate` is a no-op here — `.appointment-profile-title` is
-      // declared unlayered and wins — so the cell must carry `cell-truncate`.
-      const text = cell.getByTitle('Cardiology, Dermatology');
-      expect(text).toHaveClass('cell-truncate');
-      expect(text).not.toHaveClass('truncate');
+      const wrapper = cell.getByTitle('Cardiology, Dermatology');
+      // Tailwind's `truncate` is a no-op on `.appointment-profile-title`, which is
+      // declared unlayered and wins, so the clamp must be `cell-truncate`.
+      const clamped = wrapper.querySelector('.cell-truncate');
+      expect(clamped).toHaveTextContent('Cardiology');
+      expect(wrapper).not.toHaveClass('truncate');
+    });
+
+    it('keeps the overflow count outside the clamp so it cannot be clipped away', () => {
+      const cell = renderSpecialities([
+        'Gastroenterology and Hepatology',
+        'Dermatology',
+        'Oncology',
+      ]);
+
+      const wrapper = cell.getByTitle('Gastroenterology and Hepatology, Dermatology, Oncology');
+      const clamped = wrapper.querySelector('.cell-truncate') as HTMLElement;
+      const count = cell.getByText('+2');
+
+      // Clamping the name and the count together let a long first speciality push
+      // the "+2" past the ellipsis, so it rendered zero pixels wide. The count has
+      // to be a non-shrinking sibling of the clamped name, never inside it.
+      expect(clamped).not.toContainElement(count);
+      expect(count.parentElement).toBe(wrapper);
+      expect(count).toHaveClass('shrink-0');
     });
 
     it('falls back to a dash when there are no specialities', () => {

--- a/apps/frontend/src/app/__tests__/components/DataTable/AvailabilityTable.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/DataTable/AvailabilityTable.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import AvailabilityTable from '@/app/ui/tables/AvailabilityTable';
 import { getAvailabilityStatusStyle, getAvailabilityStatusTone } from '@/app/ui/tables/tableUtils';
@@ -218,7 +218,61 @@ describe('AvailabilityTable Component', () => {
     expect(screen.queryByText('40.1267')).not.toBeInTheDocument();
   });
 
-  // --- 3. Edge Cases ---
+  // --- 3. Speciality summarisation ---
+
+  describe('speciality cell', () => {
+    // The phone card list repeats every value, so assertions scope to the cell.
+    const renderSpecialities = (speciality: unknown) => {
+      render(
+        <AvailabilityTable
+          {...defaultProps}
+          filteredList={[{ ...mockTeam[0], speciality }] as unknown as Team[]}
+        />
+      );
+      return within(screen.getByTestId('cell-speciality'));
+    };
+
+    it('shows a lone speciality with no overflow marker', () => {
+      const cell = renderSpecialities(['Cardiology']);
+
+      expect(cell.getByText('Cardiology')).toBeInTheDocument();
+      expect(cell.queryByText(/^\+\d+$/)).not.toBeInTheDocument();
+    });
+
+    it('leads with the first speciality and counts the rest', () => {
+      const cell = renderSpecialities(['Cardiology', 'Dermatology', 'Oncology']);
+
+      expect(cell.getByText('Cardiology')).toBeInTheDocument();
+      expect(cell.getByText('+2')).toBeInTheDocument();
+      // Dropping the rest from view is only acceptable because they stay reachable.
+      expect(cell.getByTitle('Cardiology, Dermatology, Oncology')).toBeInTheDocument();
+    });
+
+    it('reads names out of speciality records as well as plain strings', () => {
+      const cell = renderSpecialities([{ name: 'Surgery' }, { name: 'Radiology' }]);
+
+      expect(cell.getByText('Surgery')).toBeInTheDocument();
+      expect(cell.getByText('+1')).toBeInTheDocument();
+    });
+
+    it('clamps the cell to one line so a long list cannot stretch the row', () => {
+      const cell = renderSpecialities(['Cardiology', 'Dermatology']);
+
+      // Tailwind's `truncate` is a no-op here — `.appointment-profile-title` is
+      // declared unlayered and wins — so the cell must carry `cell-truncate`.
+      const text = cell.getByTitle('Cardiology, Dermatology');
+      expect(text).toHaveClass('cell-truncate');
+      expect(text).not.toHaveClass('truncate');
+    });
+
+    it('falls back to a dash when there are no specialities', () => {
+      const cell = renderSpecialities([]);
+
+      expect(cell.getByText('-')).toBeInTheDocument();
+    });
+  });
+
+  // --- 4. Edge Cases ---
 
   it('does not crash if event handlers are undefined', () => {
     render(<AvailabilityTable filteredList={mockTeam} />);

--- a/apps/frontend/src/app/__tests__/components/DataTable/Tasks.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/DataTable/Tasks.test.tsx
@@ -144,4 +144,62 @@ describe('Tasks table', () => {
     expect(getTaskStatusTone('COMPLETED')).toBe('success');
     expect(getTaskStatusTone('CANCELLED')).toBe('warning');
   });
+
+  it('clamps a long description to two lines and keeps the full text on hover', () => {
+    // Free text in a 200px column: without the clamp one verbose task set the
+    // height of every row on the page.
+    const description =
+      'Call the parent to confirm the pre-anaesthetic fasting window, then reconfirm ' +
+      'the drop-off time and remind them to bring the previous practice records.';
+    const task: any = {
+      id: 't-long',
+      name: 'Follow up',
+      description,
+      category: 'pending',
+      assignedBy: 'u1',
+      assignedTo: 'u2',
+      dueAt: new Date(),
+      status: 'pending',
+    };
+
+    render(
+      <Tasks
+        filteredList={[task]}
+        setActiveTask={jest.fn()}
+        setViewPopup={jest.fn()}
+        setChangeStatusPopup={jest.fn()}
+        setReschedulePopup={jest.fn()}
+      />
+    );
+
+    const cell = screen.getAllByTitle(description)[0];
+    expect(cell).toHaveClass('cell-clamp-2');
+    expect(cell).toHaveTextContent(description);
+  });
+
+  it('leaves a short description unclamped of any tooltip noise', () => {
+    const task: any = {
+      id: 't-short',
+      name: 'Follow up',
+      description: '',
+      category: 'pending',
+      assignedBy: 'u1',
+      assignedTo: 'u2',
+      dueAt: new Date(),
+      status: 'pending',
+    };
+
+    render(
+      <Tasks
+        filteredList={[task]}
+        setActiveTask={jest.fn()}
+        setViewPopup={jest.fn()}
+        setChangeStatusPopup={jest.fn()}
+        setReschedulePopup={jest.fn()}
+      />
+    );
+
+    // An empty description must not advertise an empty tooltip.
+    expect(document.querySelector('.cell-clamp-2')).not.toHaveAttribute('title');
+  });
 });

--- a/apps/frontend/src/app/__tests__/components/Filters/Filters/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Filters/Filters/index.test.tsx
@@ -316,9 +316,9 @@ describe('Filters', () => {
       renderListToolbar('all');
 
       expect(screen.getByRole('button', { name: 'All statuses' })).toHaveStyle({
-        backgroundColor: 'var(--inset)',
-        borderColor: 'var(--divider)',
-        color: 'var(--ink)',
+        backgroundColor: 'var(--chip-selected-bg)',
+        borderColor: 'var(--chip-selected-border)',
+        color: 'var(--chip-selected-ink)',
       });
     });
 

--- a/apps/frontend/src/app/__tests__/pages/Companions/Companions.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Companions/Companions.test.tsx
@@ -321,6 +321,26 @@ describe('Companions page', () => {
     expect(sortPill).toHaveAttribute('aria-pressed', 'true');
   });
 
+  it('marks the selected sort with the shared chip tokens, not the old inset fill', () => {
+    render(<ProtectedCompanions />);
+    const sortPill = screen.getByRole('button', { name: /Last visit/ });
+
+    // Inactive: outline only, muted ink.
+    expect(sortPill).toHaveClass('border-[var(--hairline)]', 'text-[var(--ink-muted)]');
+    expect(sortPill).not.toHaveClass('bg-[var(--chip-selected-bg)]');
+
+    fireEvent.click(sortPill);
+
+    // Selected: the shared ink fill. `--inset` sat within 1.06:1 of the page, so
+    // weight alone used to carry the selection and a revert would look "fine".
+    expect(sortPill).toHaveClass(
+      'border-[var(--chip-selected-border)]',
+      'bg-[var(--chip-selected-bg)]',
+      'text-[var(--chip-selected-ink)]'
+    );
+    expect(sortPill).not.toHaveClass('bg-[var(--inset)]');
+  });
+
   it('opens the companion view from a companionId deep link', async () => {
     searchParamsGetMock.mockReturnValue('c1');
     render(<ProtectedCompanions />);

--- a/apps/frontend/src/app/__tests__/tables/tableUtils.test.ts
+++ b/apps/frontend/src/app/__tests__/tables/tableUtils.test.ts
@@ -1,6 +1,7 @@
 import {
   buildPagerPageList,
   toSpecialityNames,
+  UNNAMED_SPECIALITY,
   getInvoiceItemNames,
   getInvoiceStatusStyle,
   getInvoiceStatusTone,
@@ -280,10 +281,11 @@ describe('tableUtils', () => {
       ]);
     });
 
-    it('drops blank and whitespace-only entries rather than rendering empty gaps', () => {
-      expect(toSpecialityNames(['Cardiology', '', '   ', { name: '' }] as never)).toEqual([
-        'Cardiology',
-      ]);
+    it('drops blank strings but keeps a record that is merely unnamed', () => {
+      // A blank string is noise; a record is a real assignment and must survive
+      // into the count, or the summary understates how many a team holds.
+      expect(toSpecialityNames(['Cardiology', '', '   '] as never)).toEqual(['Cardiology']);
+      expect(toSpecialityNames([{ name: '' }] as never)).toEqual([UNNAMED_SPECIALITY]);
     });
 
     it('trims surrounding whitespace', () => {
@@ -296,8 +298,22 @@ describe('tableUtils', () => {
       expect(toSpecialityNames(undefined as never)).toEqual([]);
     });
 
-    it('survives entries missing a name', () => {
+    it('falls back to a code before a neutral label', () => {
+      expect(toSpecialityNames([{ code: 'X1' }, { name: 'Dentistry' }] as never)).toEqual([
+        'X1',
+        'Dentistry',
+      ]);
+    });
+
+    it('keeps an unidentifiable record so the count stays honest', () => {
       expect(toSpecialityNames([{ _id: 'x' }, { name: 'Dentistry' }] as never)).toEqual([
+        UNNAMED_SPECIALITY,
+        'Dentistry',
+      ]);
+    });
+
+    it('drops null and undefined entries, which are not assignments', () => {
+      expect(toSpecialityNames([null, undefined, { name: 'Dentistry' }] as never)).toEqual([
         'Dentistry',
       ]);
     });

--- a/apps/frontend/src/app/__tests__/tables/tableUtils.test.ts
+++ b/apps/frontend/src/app/__tests__/tables/tableUtils.test.ts
@@ -1,5 +1,6 @@
 import {
   buildPagerPageList,
+  toSpecialityNames,
   getInvoiceItemNames,
   getInvoiceStatusStyle,
   getInvoiceStatusTone,
@@ -261,6 +262,44 @@ describe('tableUtils', () => {
 
     it('returns an empty run when there are no pages', () => {
       expect(buildPagerPageList(1, 0)).toEqual([]);
+    });
+  });
+
+  describe('toSpecialityNames', () => {
+    it('passes plain string entries straight through', () => {
+      expect(toSpecialityNames(['Cardiology', 'Oncology'] as never)).toEqual([
+        'Cardiology',
+        'Oncology',
+      ]);
+    });
+
+    it('reads the name off record entries', () => {
+      expect(toSpecialityNames([{ name: 'Surgery' }, { name: 'Radiology' }] as never)).toEqual([
+        'Surgery',
+        'Radiology',
+      ]);
+    });
+
+    it('drops blank and whitespace-only entries rather than rendering empty gaps', () => {
+      expect(toSpecialityNames(['Cardiology', '', '   ', { name: '' }] as never)).toEqual([
+        'Cardiology',
+      ]);
+    });
+
+    it('trims surrounding whitespace', () => {
+      expect(toSpecialityNames(['  Cardiology  '] as never)).toEqual(['Cardiology']);
+    });
+
+    it('returns nothing for a non-array value', () => {
+      // The Team payload sometimes carries a single record instead of a list.
+      expect(toSpecialityNames({ name: 'Cardiology' } as never)).toEqual([]);
+      expect(toSpecialityNames(undefined as never)).toEqual([]);
+    });
+
+    it('survives entries missing a name', () => {
+      expect(toSpecialityNames([{ _id: 'x' }, { name: 'Dentistry' }] as never)).toEqual([
+        'Dentistry',
+      ]);
     });
   });
 });

--- a/apps/frontend/src/app/__tests__/ui/tables/DispensaryTable.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/tables/DispensaryTable.test.tsx
@@ -69,6 +69,41 @@ describe('DispensaryTable', () => {
     expect(screen.getAllByText(/Calpol/).length).toBeGreaterThan(0);
   });
 
+  it('shows the first two items and counts the rest once a script runs long', () => {
+    // One <li> per item made row height track prescription length, so a busy
+    // script set the height of every row on the page.
+    const record = {
+      ...baseRecord,
+      items: [
+        { name: 'Paracetamol', quantity: 1, priceCents: 6500 },
+        { name: 'Calpol', quantity: 2, priceCents: 1000 },
+        { name: 'Metacam', quantity: 1, priceCents: 2000 },
+        { name: 'Ketamine', quantity: 1, priceCents: 3000 },
+      ],
+    };
+    const { container } = render(<DispensaryTable filteredList={[record]} />);
+    // Only the grid row is height-constrained; the phone card has room for the
+    // whole script and deliberately still prints it.
+    const row = tableBranch(container);
+
+    expect(row.getByText(/Paracetamol/)).toBeInTheDocument();
+    expect(row.getByText(/Calpol/)).toBeInTheDocument();
+    // The overflow is summarised, not rendered...
+    expect(row.queryByText(/Metacam/)).not.toBeInTheDocument();
+    expect(row.queryByText(/Ketamine/)).not.toBeInTheDocument();
+    expect(row.getByText('+2')).toBeInTheDocument();
+    // ...and every name stays reachable on hover, so nothing is truly lost.
+    expect(row.getByTitle('Paracetamol, Calpol, Metacam, Ketamine')).toBeInTheDocument();
+
+    // The card branch is unaffected — it still lists all four.
+    expect(cardBranch(container).getByText(/Metacam/)).toBeInTheDocument();
+  });
+
+  it('shows no overflow marker when the script fits', () => {
+    const { container } = render(<DispensaryTable filteredList={[baseRecord]} />);
+    expect(tableBranch(container).queryByText(/^\+\d+$/)).not.toBeInTheDocument();
+  });
+
   it('renders a dash when there are no items', () => {
     const record = { ...baseRecord, items: undefined };
     render(<DispensaryTable filteredList={[record]} />);

--- a/apps/frontend/src/app/__tests__/ui/tables/GenericTable.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/tables/GenericTable.test.tsx
@@ -151,4 +151,21 @@ describe('GenericTable', () => {
     expect(screen.getByText('Item 0')).toBeInTheDocument();
     expect(screen.getByText('Item 1')).toBeInTheDocument();
   });
+
+  it('exposes the full header label as a title so a clipped header stays readable', () => {
+    // The base th clips with an ellipsis rather than wrapping (wrapping doubled the
+    // whole sticky band), so this title is the only way back to the full label.
+    const columns = [
+      { key: 'name', label: "Today's Appointment Count" },
+      { key: 'blank', label: '' },
+    ] as const;
+    render(<GenericTable data={buildRows(1)} columns={columns as any} />);
+
+    const labelled = screen.getByRole('columnheader', { name: "Today's Appointment Count" });
+    expect(labelled).toHaveAttribute('title', "Today's Appointment Count");
+
+    // An unlabelled column must not advertise an empty tooltip.
+    const headers = screen.getAllByRole('columnheader');
+    expect(headers[1]).not.toHaveAttribute('title');
+  });
 });

--- a/apps/frontend/src/app/__tests__/ui/tables/PaginatedGridTable.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/tables/PaginatedGridTable.test.tsx
@@ -17,12 +17,13 @@ const GRID_COLUMNS = '1fr 100px 80px';
 const makeRows = (count: number): Row[] =>
   Array.from({ length: count }, (_, i) => ({ id: `r-${i}`, name: `Row ${i}` }));
 
-const renderTable = (rows: Row[], pageSize = 3) =>
+const renderTable = (rows: Row[], pageSize = 3, minWidthPx?: number) =>
   render(
     <PaginatedGridTable
       rows={rows}
       pageSize={pageSize}
       gridColumns={GRID_COLUMNS}
+      minWidthPx={minWidthPx}
       headerCells={HEADER_CELLS}
       itemNoun="items"
       renderRow={(row) => <div key={row.id} data-testid="row" />}
@@ -47,6 +48,26 @@ describe('PaginatedGridTable', () => {
     // The blank-label column still renders a span (keyed by index fallback).
     const header = container.querySelector('.sticky') as HTMLElement;
     expect(header.querySelectorAll('span')).toHaveLength(3);
+  });
+
+  /* The horizontal floor has to clear each caller's fixed tracks plus gaps and
+     gutters. One shared 1080px value left Inventory's twelve columns 76px to
+     split between two fr tracks, collapsing the item name to roughly 48px, so
+     the floor became per-caller — and a silent regression here brings that back. */
+  it('falls back to the 1080px floor when the caller names no width', () => {
+    const { container } = renderTable(makeRows(1));
+
+    const scroller = container.querySelector('[style*="min-width"]') as HTMLElement;
+    expect(scroller).toHaveStyle({ minWidth: '1080px' });
+  });
+
+  it('honours a caller floor wide enough for its own fixed tracks', () => {
+    const { container } = renderTable(makeRows(1), 3, 1320);
+
+    const scroller = container.querySelector('[style*="min-width"]') as HTMLElement;
+    expect(scroller).toHaveStyle({ minWidth: '1320px' });
+    // The default must not win over an explicit floor.
+    expect(scroller).not.toHaveStyle({ minWidth: '1080px' });
   });
 
   it('applies the caller grid track to the header', () => {

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/Header.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/Header.tsx
@@ -44,8 +44,8 @@ const getStatusPillTokens = (status: StatusOption): StatusPillTokens => ({
 });
 
 // Scope pills follow the planner's filter-row recipe: inactive is a bare
-// --hairline outline with --ink-muted 600 type; the selected pill fills with
-// --inset behind a --divider outline and steps the label to --ink 700.
+// --hairline outline with --ink-muted 600 type; the selected pill takes the
+// shared --chip-selected-* ink fill and steps the label to 700.
 const getFilterClassName = (filterKey: string, activeFilter: string): string => {
   if (filterKey !== activeFilter)
     return 'font-semibold text-[var(--ink-muted)] hover:bg-card-hover!';
@@ -61,7 +61,7 @@ const getFilterBorderColor = (filterKey: string, activeFilter: string): string =
   if (filterKey !== activeFilter) return 'var(--hairline)';
   /* v8 ignore next -- unreachable: only called for non-emergency pills (emergency pills use getEmergencyPillStyle) */
   if (filterKey === 'emergencies') return 'var(--color-danger-500)';
-  return 'var(--divider)';
+  return 'var(--chip-selected-border)';
 };
 
 const CALENDAR_VIEW_OPTIONS: ReadonlyArray<{ value: string; label: string }> = [

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/Header.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/Header.tsx
@@ -54,7 +54,7 @@ const getFilterClassName = (filterKey: string, activeFilter: string): string => 
   // an `!important` text colour can't override it (the old `text-danger-500!`
   // failed WCAG AA in dark mode).
   if (filterKey === 'emergencies') return 'font-bold';
-  return 'bg-[var(--inset)] font-bold text-[var(--ink)]';
+  return 'bg-[var(--chip-selected-bg)] font-bold text-[var(--chip-selected-ink)]';
 };
 
 const getFilterBorderColor = (filterKey: string, activeFilter: string): string => {

--- a/apps/frontend/src/app/features/companions/pages/Companions/Companions.tsx
+++ b/apps/frontend/src/app/features/companions/pages/Companions/Companions.tsx
@@ -273,7 +273,7 @@ const Companions = () => {
                 className={clsx(
                   'inline-flex items-center gap-1.5 whitespace-nowrap rounded-full border px-3 py-1 text-[12px] font-semibold transition-colors',
                   sortByRecentVisit
-                    ? 'border-[var(--divider)] bg-[var(--inset)] text-[var(--ink)]'
+                    ? 'border-[var(--chip-selected-border)] bg-[var(--chip-selected-bg)] text-[var(--chip-selected-ink)]'
                     : 'border-[var(--hairline)] text-[var(--ink-muted)] hover:text-[var(--ink)]'
                 )}
               >

--- a/apps/frontend/src/app/features/documents/components/CompanionDocumentsSection.tsx
+++ b/apps/frontend/src/app/features/documents/components/CompanionDocumentsSection.tsx
@@ -69,7 +69,7 @@ const FilterPill = ({ active, onClick, children }: FilterPillProps) => (
     aria-pressed={active}
     className={`rounded-full border px-3 py-1.5 text-[12px] ${
       active
-        ? 'border-[var(--divider)] bg-[var(--inset)] font-bold text-[var(--ink)]'
+        ? 'border-[var(--chip-selected-border)] bg-[var(--chip-selected-bg)] font-bold text-[var(--chip-selected-ink)]'
         : 'border-[var(--hairline)] font-semibold text-[var(--ink-muted)]'
     }`}
   >

--- a/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
@@ -922,7 +922,7 @@ const IntegrationFilterTabs = ({
           className={clsx(
             'rounded-full! border px-[13px] py-1.5 text-[12px] whitespace-nowrap transition-colors',
             isActive
-              ? 'bg-[var(--inset)] border-[var(--divider)] text-[var(--ink)] font-bold'
+              ? 'bg-[var(--chip-selected-bg)] border-[var(--chip-selected-border)] text-[var(--chip-selected-ink)] font-bold'
               : 'border-[var(--hairline)] text-[var(--ink-muted)] font-semibold hover:border-[var(--divider)]'
           )}
         >

--- a/apps/frontend/src/app/features/inventory/pages/Inventory/InventoryPhoneCatalog.tsx
+++ b/apps/frontend/src/app/features/inventory/pages/Inventory/InventoryPhoneCatalog.tsx
@@ -115,7 +115,8 @@ export const InventoryPhoneCard = ({
 
 const pillBase =
   'flex-none rounded-full! border px-[14px] py-2 text-[12px] transition-colors whitespace-nowrap';
-const activePill = 'border-[var(--divider)] bg-[var(--inset)] font-bold text-[var(--ink)]';
+const activePill =
+  'border-[var(--chip-selected-border)] bg-[var(--chip-selected-bg)] font-bold text-[var(--chip-selected-ink)]';
 const idlePill = 'border-[var(--hairline)] font-semibold text-[var(--ink-muted)]';
 
 type InventoryPhoneFilterPillsProps = {

--- a/apps/frontend/src/app/features/inventory/pages/Inventory/index.tsx
+++ b/apps/frontend/src/app/features/inventory/pages/Inventory/index.tsx
@@ -289,7 +289,7 @@ const chipClass = (active: boolean) =>
   clsx(
     'inline-flex items-center rounded-full! border px-[13px] py-1.5 text-[12px] transition-colors',
     active
-      ? 'border-[var(--divider)] bg-[var(--inset)] text-[var(--ink)] font-bold'
+      ? 'border-[var(--chip-selected-border)] bg-[var(--chip-selected-bg)] text-[var(--chip-selected-ink)] font-bold'
       : 'border-[var(--hairline)] text-[var(--ink-muted)] font-semibold hover:bg-card-hover'
   );
 

--- a/apps/frontend/src/app/features/tasks/components/TaskFilterBar.tsx
+++ b/apps/frontend/src/app/features/tasks/components/TaskFilterBar.tsx
@@ -79,7 +79,7 @@ const TaskFilterBar = ({
                     className={clsx(
                       'inline-flex h-6 items-center rounded-full px-3 text-[12px] transition-colors',
                       isActive
-                        ? 'bg-[var(--inset)] font-bold text-[var(--ink)]'
+                        ? 'bg-[var(--chip-selected-bg)] font-bold text-[var(--chip-selected-ink)]'
                         : 'font-semibold text-[var(--ink-muted)] hover:bg-card-hover'
                     )}
                   >
@@ -104,7 +104,7 @@ const TaskFilterBar = ({
               className={clsx(
                 'inline-flex h-7 items-center gap-1.5 rounded-full border px-3.5 text-[12px] transition-colors',
                 isActive
-                  ? 'border-[var(--divider)] bg-[var(--inset)] font-bold text-[var(--ink)]'
+                  ? 'border-[var(--chip-selected-border)] bg-[var(--chip-selected-bg)] font-bold text-[var(--chip-selected-ink)]'
                   : 'border-[var(--hairline)] font-semibold text-[var(--ink-muted)] hover:bg-card-hover'
               )}
             >

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -564,6 +564,14 @@ textarea:focus-visible {
   --screen-2: #f1ebe1;
   --hairline: #e5dccf;
   --divider: #d6d1cd;
+  /* Selected filter chip. Every neutral surface token sits within 1.03-1.24:1 of
+     `--page`, so the old `--inset` fill was invisible and weight alone (600 vs
+     700) carried the selected state. An ink fill is the app's existing answer
+     for a chosen option (see the datepicker's selected day) and reads at ~14:1.
+     Both sides are theme tokens, so dark mode inverts them for free. */
+  --chip-selected-bg: var(--ink);
+  --chip-selected-border: var(--ink);
+  --chip-selected-ink: var(--screen);
   --hairline-hover: #d6d1cd;
   /* active nav item (current page) */
   --nav-active: #1657c9;

--- a/apps/frontend/src/app/ui/cards/AvailabilityCard/index.tsx
+++ b/apps/frontend/src/app/ui/cards/AvailabilityCard/index.tsx
@@ -3,7 +3,11 @@ import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import React from 'react';
 import { Team } from '@/app/features/organization/types/team';
 import { getSafeImageUrl } from '@/app/lib/urls';
-import { formatWeeklyWorkingHours, getAvailabilityStatusTone } from '@/app/ui/tables/tableUtils';
+import {
+  formatWeeklyWorkingHours,
+  getAvailabilityStatusTone,
+  toSpecialityNames,
+} from '@/app/ui/tables/tableUtils';
 import { toTitleCase } from '@/app/lib/validators';
 import { Secondary } from '@/app/ui/primitives/Buttons';
 
@@ -36,13 +40,11 @@ const AvailabilityCard = ({ team, handleViewTeam }: AvailabilityCardProps) => {
       <div className="flex gap-1">
         <div className="text-caption-1 text-text-extra">Speciality:</div>
         <div className="text-caption-1 text-text-primary">
-          {Array.isArray(team?.speciality) && team.speciality.length > 0
-            ? team.speciality
-                .map((spec: any) =>
-                  typeof spec === 'string' ? spec : spec?.name || JSON.stringify(spec)
-                )
-                .join(', ')
-            : '-'}
+          {/* Shares the table's reader so the phone card and the desktop row can
+              never disagree about a team's specialities. It also replaces the
+              old JSON.stringify fallback, which printed `{"code":"X1"}` at a
+              clinician. */}
+          {toSpecialityNames(team?.speciality).join(', ') || '-'}
         </div>
       </div>
       <div className="flex gap-1">

--- a/apps/frontend/src/app/ui/filters/Filters/index.tsx
+++ b/apps/frontend/src/app/ui/filters/Filters/index.tsx
@@ -11,7 +11,7 @@ const getDropdownStatusTextColor = (status: StatusOption): string =>
   status.dropdownText ?? status.text ?? 'var(--color-text-primary)';
 
 // Design filter-chip recipe (list toolbars): pill, 6px 13px, 12px text.
-// Neutral: active = --inset fill + --divider border + --ink bold; rest = --hairline border + --ink-muted.
+// Neutral: active = --chip-selected-* ink fill; rest = --hairline border + --ink-muted.
 // Emergency: always danger-toned (--danger-border/--danger-text); active adds --danger-bg fill.
 const getFilterChipClassName = (filterKey: string, activeFilter: string): string => {
   const isActive = filterKey === activeFilter;
@@ -21,7 +21,7 @@ const getFilterChipClassName = (filterKey: string, activeFilter: string): string
       : 'border-[var(--danger-border)]! text-[var(--danger-text)]! font-semibold';
   }
   return isActive
-    ? 'bg-[var(--inset)] border-[var(--divider)]! text-[var(--ink)]! font-bold'
+    ? 'bg-[var(--chip-selected-bg)] border-[var(--chip-selected-border)]! text-[var(--chip-selected-ink)]! font-bold'
     : 'border-[var(--hairline)]! text-[var(--ink-muted)]! font-semibold hover:border-[var(--divider)]!';
 };
 
@@ -35,9 +35,9 @@ const getStatusPillStyle = (status: StatusOption, isActive: boolean): React.CSSP
   }
   if (status.key.toLowerCase() === 'all') {
     return {
-      backgroundColor: 'var(--inset)',
-      borderColor: 'var(--divider)',
-      color: 'var(--ink)',
+      backgroundColor: 'var(--chip-selected-bg)',
+      borderColor: 'var(--chip-selected-border)',
+      color: 'var(--chip-selected-ink)',
       fontWeight: 700,
     };
   }

--- a/apps/frontend/src/app/ui/tables/AvailabilityTable.tsx
+++ b/apps/frontend/src/app/ui/tables/AvailabilityTable.tsx
@@ -90,10 +90,19 @@ const AvailabilityTable = ({
         // the row to 159px next to a 67px neighbour. Lead with the first and
         // count the rest, keeping the full list on hover.
         const [first, ...rest] = names;
+        // The count is a non-shrinking sibling of the truncating name, not a child
+        // of it: clamping the combined line let a long first speciality push the
+        // "+N" past the clip edge, so the only hint that more existed vanished
+        // exactly when it was needed most.
         return (
-          <div className="appointment-profile-title cell-truncate" title={names.join(', ')}>
-            {first}
-            {rest.length > 0 && <span className="cell-overflow-count">{`+${rest.length}`}</span>}
+          <div
+            className="appointment-profile-title flex min-w-0 items-baseline"
+            title={names.join(', ')}
+          >
+            <div className="min-w-0 flex-1 cell-truncate">{first}</div>
+            {rest.length > 0 && (
+              <span className="cell-overflow-count shrink-0">{`+${rest.length}`}</span>
+            )}
           </div>
         );
       },

--- a/apps/frontend/src/app/ui/tables/AvailabilityTable.tsx
+++ b/apps/frontend/src/app/ui/tables/AvailabilityTable.tsx
@@ -10,7 +10,11 @@ import AvailabilityCard from '@/app/ui/cards/AvailabilityCard';
 import { toTitleCase } from '@/app/lib/validators';
 import { getSafeImageUrl } from '@/app/lib/urls';
 
-import { formatWeeklyWorkingHours, getAvailabilityStatusTone } from '@/app/ui/tables/tableUtils';
+import {
+  formatWeeklyWorkingHours,
+  getAvailabilityStatusTone,
+  toSpecialityNames,
+} from '@/app/ui/tables/tableUtils';
 
 import './DataTable.css';
 
@@ -78,17 +82,21 @@ const AvailabilityTable = ({
       label: 'Speciality',
       key: 'speciality',
       width: '18%',
-      render: (item: Team) => (
-        <div className="appointment-profile-title">
-          {Array.isArray(item?.speciality) && item.speciality.length > 0
-            ? item.speciality
-                .map((spec: any) =>
-                  typeof spec === 'string' ? spec : spec?.name || JSON.stringify(spec)
-                )
-                .join(', ')
-            : '-'}
-        </div>
-      ),
+      render: (item: Team) => {
+        const names = toSpecialityNames(item.speciality);
+        if (names.length === 0) return <div className="appointment-profile-title">-</div>;
+        // Joining every speciality made this the only cell in PIMS whose height
+        // tracked its data: six specialities wrapped to six lines and stretched
+        // the row to 159px next to a 67px neighbour. Lead with the first and
+        // count the rest, keeping the full list on hover.
+        const [first, ...rest] = names;
+        return (
+          <div className="appointment-profile-title cell-truncate" title={names.join(', ')}>
+            {first}
+            {rest.length > 0 && <span className="cell-overflow-count">{`+${rest.length}`}</span>}
+          </div>
+        );
+      },
     },
     {
       label: "Today's Appointment",

--- a/apps/frontend/src/app/ui/tables/CompanionsTable.tsx
+++ b/apps/frontend/src/app/ui/tables/CompanionsTable.tsx
@@ -150,7 +150,7 @@ const CompanionRow = ({
   const isInactive = String(item.companion.status ?? 'inactive').toLowerCase() !== 'active';
   return (
     <div
-      className={`${GRID_COLS} border-t border-[var(--hairline)] px-5 py-[10px] text-[13.5px] text-text-primary transition-colors ${
+      className={`${GRID_COLS} border-t border-[var(--hairline)] px-5 py-3 text-[13.5px] text-text-primary transition-colors ${
         menuOpen ? 'bg-[var(--surface-soft)]' : 'hover:bg-[var(--surface-soft)]'
       } ${isInactive ? 'opacity-[0.62]' : ''}`}
     >

--- a/apps/frontend/src/app/ui/tables/DataTable.css
+++ b/apps/frontend/src/app/ui/tables/DataTable.css
@@ -67,10 +67,6 @@ span.cell-overflow-count {
   table-layout: fixed;
   min-width: 1096px; /* 56+220+130+100+110+170+110+200 */
 }
-.inventory-table-fixed {
-  table-layout: fixed;
-  min-width: 1081px; /* compact inventory revamp columns */
-}
 .inventory-turnover-table-fixed {
   table-layout: fixed;
   min-width: 1040px; /* 160+110+130+120+100+120+100+100+100 */
@@ -186,45 +182,6 @@ span.cell-overflow-count {
   border-color: var(--divider);
 }
 
-.InviteDetails {
-  color: var(--color-primary-500);
-  font-size: 16px;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 150%;
-  letter-spacing: -0.32px;
-  font-family: var(--font-satoshi);
-  cursor: pointer;
-}
-.InviteTime {
-  color: var(--color-neutral-900);
-  font-size: 16px;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 150%;
-  letter-spacing: -0.32px;
-  font-family: var(--font-satoshi);
-}
-.InviteExpires {
-  color: var(--color-neutral-900);
-  font-size: 16px;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 150%;
-  letter-spacing: -0.32px;
-  font-family: var(--font-satoshi);
-}
-
-.OrgListDetails {
-  color: var(--color-primary-500);
-  font-size: 16px;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 150%;
-  letter-spacing: -0.32px;
-  font-family: var(--font-satoshi);
-  cursor: pointer;
-}
 .OrgStatus {
   display: flex;
   padding: 8px 16px;
@@ -241,12 +198,6 @@ span.cell-overflow-count {
   line-height: 150%;
   letter-spacing: -0.32px;
   font-family: var(--font-satoshi);
-}
-.OrgListDetailsCol {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  width: fit-content;
 }
 .action-btn-col {
   display: inline-flex;
@@ -281,16 +232,6 @@ span.cell-overflow-count {
   width: 40px;
   cursor: pointer;
 }
-.action-btn-text {
-  color: var(--color-neutral-900);
-  text-align: center;
-  font-family: var(--font-satoshi);
-  font-size: 16px;
-  font-style: normal;
-  font-weight: 500;
-  line-height: 120%; /* 19.2px */
-  letter-spacing: -0.32px;
-}
 
 .appointment-profile {
   display: flex;
@@ -306,7 +247,12 @@ span.cell-overflow-count {
   max-width: 100%;
   font-family: var(--font-satoshi);
   color: var(--color-neutral-900);
-  font-size: 16px;
+  /* 14px is what Appointments, Tasks and Documents already set explicitly; the old
+     16px base predated the design system, and its own comment called every ledger
+     cell "2-3px oversize". Five tables were never given a rule at all and rendered
+     at 16px next to 14px siblings, so the designed value now lives in the base and
+     only genuine deviations (the denser finance ramp, Forms) override it. */
+  font-size: 14px;
   font-style: normal;
   font-weight: 400;
   line-height: 120%;
@@ -316,8 +262,8 @@ span.cell-overflow-count {
 }
 .appointment-profile-sub {
   font-family: var(--font-satoshi);
-  color: var(--color-neutral-900);
-  font-size: 16px;
+  color: var(--ink-faint);
+  font-size: 12.5px;
   font-style: normal;
   font-weight: 400;
   line-height: 120%;
@@ -353,16 +299,7 @@ span.cell-overflow-count {
   color: var(--ink);
 }
 
-/* Per-table body scale. The shared 16px base predates the design system and
-   renders every ledger cell 2-3px oversize; each frame in the 19 July designs
-   carries its own row size, so the scale lives with the table, not the class. */
-.appointments-table-fixed .appointment-profile-title {
-  font-size: 14px;
-}
-.appointments-table-fixed .appointment-profile-sub {
-  font-size: 12.5px;
-  color: var(--ink-faint);
-}
+/* Per-table body scale — only where a frame genuinely departs from the base. */
 .invoice-table-fixed .appointment-profile-title,
 .invoice-compact-fixed .appointment-profile-title {
   font-size: 13.5px;
@@ -385,17 +322,6 @@ span.cell-overflow-count {
 }
 .forms-table-fixed .appointment-profile-title {
   font-size: 13.5px;
-}
-/* Tasks and Documents were the two tables never given a scale, so they kept the
-   legacy 16px base and stood 2-2.5px larger than every table beside them. */
-.tasks-table-fixed .appointment-profile-title,
-.documents-table .appointment-profile-title {
-  font-size: 14px;
-}
-.tasks-table-fixed .appointment-profile-sub,
-.documents-table .appointment-profile-sub {
-  font-size: 12.5px;
-  color: var(--ink-faint);
 }
 /* DS status micro-badge: ALL-CAPS 10px / 700 / 0.08em, pad 3px 10px, fully round.
    Per-status bg/text/border are supplied inline via getStatusStyle(...).

--- a/apps/frontend/src/app/ui/tables/DataTable.css
+++ b/apps/frontend/src/app/ui/tables/DataTable.css
@@ -5,10 +5,39 @@
   width: 100%;
 }
 
-/* Spacious cell padding for the Specialities table */
-.specialities-table thead tr th,
-.specialities-table tbody tr td {
-  padding: 12px 20px;
+/* Cell text clamps. Tailwind's `truncate` lives in the utilities layer, but this
+   file is unlayered, so `.appointment-profile-title`'s `white-space: normal` /
+   `overflow-wrap: anywhere` silently beat it — every cell that combined the two
+   wrapped instead of ellipsing, and multi-value cells grew the row without
+   bound. These clamps are declared alongside that rule so they actually win. */
+.cell-truncate {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  overflow-wrap: normal;
+}
+/* Compounded so it also outranks `.appointment-profile-title` itself. */
+.appointment-profile-title.cell-truncate {
+  white-space: nowrap;
+  overflow-wrap: normal;
+}
+/* Two-line variant for cells whose second line carries real meaning. */
+.cell-clamp-2 {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  overflow: hidden;
+}
+/* "+3" marker for cells that summarise a list. Inline after the leading value in
+   single-line cells, or on its own line under a stack — hence the span-only gap. */
+.cell-overflow-count {
+  color: var(--ink-faint);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+span.cell-overflow-count {
+  margin-left: 6px;
 }
 
 /* table-layout:fixed + explicit colgroup widths on every column locks headers.
@@ -356,6 +385,17 @@
 }
 .forms-table-fixed .appointment-profile-title {
   font-size: 13.5px;
+}
+/* Tasks and Documents were the two tables never given a scale, so they kept the
+   legacy 16px base and stood 2-2.5px larger than every table beside them. */
+.tasks-table-fixed .appointment-profile-title,
+.documents-table .appointment-profile-title {
+  font-size: 14px;
+}
+.tasks-table-fixed .appointment-profile-sub,
+.documents-table .appointment-profile-sub {
+  font-size: 12.5px;
+  color: var(--ink-faint);
 }
 /* DS status micro-badge: ALL-CAPS 10px / 700 / 0.08em, pad 3px 10px, fully round.
    Per-status bg/text/border are supplied inline via getStatusStyle(...).

--- a/apps/frontend/src/app/ui/tables/DispensaryTable.tsx
+++ b/apps/frontend/src/app/ui/tables/DispensaryTable.tsx
@@ -123,15 +123,25 @@ const DispensaryRow = ({
       <div className="flex justify-start">
         <DispensaryStatusPill status={record.status} />
       </div>
-      <ul className="m-0 flex list-none flex-col gap-0.5 p-0">
+      {/* One <li> per prescription line grew the row without bound, so a
+          many-item script set the height of every row on the page. */}
+      <ul
+        className="m-0 flex list-none flex-col gap-0.5 p-0"
+        title={items.map((item) => item.name).join(', ') || undefined}
+      >
         {items.length === 0 ? (
           <li className="text-[12px] text-text-tertiary">—</li>
         ) : (
-          items.map((item) => (
-            <li key={item.name} className="truncate text-[12px] text-text-secondary">
-              • {item.name}
-            </li>
-          ))
+          <>
+            {items.slice(0, 2).map((item) => (
+              <li key={item.name} className="truncate text-[12px] text-text-secondary">
+                • {item.name}
+              </li>
+            ))}
+            {items.length > 2 && (
+              <li className="text-[12px] text-[var(--ink-faint)]">{`+${items.length - 2}`}</li>
+            )}
+          </>
         )}
       </ul>
       <div className="whitespace-pre-line text-[12px] tabular-nums text-[var(--color-success-600)]">
@@ -250,6 +260,7 @@ const DispensaryTable = ({ filteredList, onView, onDispense }: DispensaryTablePr
     rows={filteredList}
     pageSize={PAGE_SIZE}
     gridColumns={GRID_COLUMNS}
+    minWidthPx={1280}
     headerCells={HEADER_CELLS}
     itemNoun="requests"
     renderRow={(record) => (

--- a/apps/frontend/src/app/ui/tables/DocumentsTable.tsx
+++ b/apps/frontend/src/app/ui/tables/DocumentsTable.tsx
@@ -59,6 +59,7 @@ const DocumentsTable = ({ filteredList, setActive, setView }: DocumentsTableProp
           bordered={false}
           pagination
           pageSize={5}
+          tableClassName="documents-table"
         />
       </div>
       <div className="flex xl:hidden gap-4 sm:gap-10 flex-wrap">

--- a/apps/frontend/src/app/ui/tables/FormsTable.tsx
+++ b/apps/frontend/src/app/ui/tables/FormsTable.tsx
@@ -51,7 +51,7 @@ const TemplateNameCell = ({ item }: { item: FormsProps }) => {
         {getTemplateIcon(item.category)}
       </div>
       <div className="flex min-w-0 flex-col">
-        <div className="appointment-profile-title cell-name truncate" title={item.name}>
+        <div className="appointment-profile-title cell-name cell-truncate" title={item.name}>
           {item.name}
         </div>
         {item.description ? (

--- a/apps/frontend/src/app/ui/tables/GenericTable/GenericTable.tsx
+++ b/apps/frontend/src/app/ui/tables/GenericTable/GenericTable.tsx
@@ -142,7 +142,7 @@ const GenericTable = <T extends object>({
             <thead>
               <tr>
                 {columns.map((col) => (
-                  <th key={String(col.key)} scope="col">
+                  <th key={String(col.key)} scope="col" title={col.label || undefined}>
                     {col.label}
                   </th>
                 ))}

--- a/apps/frontend/src/app/ui/tables/GenericTable/Generictable.css
+++ b/apps/frontend/src/app/ui/tables/GenericTable/Generictable.css
@@ -61,6 +61,13 @@
   padding-top: 11px;
   padding-bottom: 11px;
   text-align: left;
+  /* Nothing here used to control wrapping, so any two-word label wrapped once
+     its column was narrow enough and doubled the height of the whole sticky
+     band. Clipping one header is a far smaller defect than resizing the band;
+     GenericTable puts the full label in a `title` so it stays readable. */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   color: var(--ink-faint);
   font-size: 10.5px;
   font-weight: 700;
@@ -93,7 +100,7 @@
   td
   span:not(a span):not(button span):not(.glass-tooltip):not(.glass-tooltip span):not(
     .yc-status-pill
-  ):not(.yc-status-pill span) {
+  ):not(.yc-status-pill span):not(.cell-overflow-count) {
   margin: 0px;
   font-family: var(--satoshi-font);
   color: var(--black-text);

--- a/apps/frontend/src/app/ui/tables/InventoryTable.tsx
+++ b/apps/frontend/src/app/ui/tables/InventoryTable.tsx
@@ -129,7 +129,7 @@ const InventoryRow = ({
 
   return (
     <div
-      className="grid items-center gap-2.5 border-t border-card-border px-5 py-[11px] text-[13px] text-text-primary transition-colors hover:bg-[var(--surface-soft)]"
+      className="grid items-center gap-2.5 border-t border-card-border px-5 py-3 text-[13px] text-text-primary transition-colors hover:bg-[var(--surface-soft)]"
       style={{
         gridTemplateColumns: GRID_COLUMNS,
         backgroundColor: expired ? 'var(--danger-bg-faint)' : undefined,
@@ -227,6 +227,7 @@ const InventoryTable = ({
       rows={filteredList}
       pageSize={PAGE_SIZE}
       gridColumns={GRID_COLUMNS}
+      minWidthPx={1320}
       headerCells={HEADER_CELLS}
       itemNoun="items"
       renderRow={(item) => (

--- a/apps/frontend/src/app/ui/tables/InvoiceTable.tsx
+++ b/apps/frontend/src/app/ui/tables/InvoiceTable.tsx
@@ -71,9 +71,16 @@ const renderInvoiceNumber = (item: Invoice) => (
   </div>
 );
 
-const renderServices = (item: Invoice) => (
-  <div className="appointment-profile-title cell-muted">{getInvoiceItemNames(item.items)}</div>
-);
+const renderServices = (item: Invoice) => {
+  // A comma-joined line-item list in a 180px column wrapped to as many lines as
+  // the invoice had items, so one busy row set the height of the whole page.
+  const names = getInvoiceItemNames(item.items);
+  return (
+    <div className="appointment-profile-title cell-muted cell-truncate" title={names || undefined}>
+      {names}
+    </div>
+  );
+};
 
 const renderStatus = (item: Invoice) => (
   <StatusPill tone={getInvoiceStatusTone(item?.status)} label={toTitle(item?.status)} />
@@ -189,7 +196,10 @@ const InvoiceTable = ({ filteredList, setActiveInvoice, setViewInvoice }: Invoic
           />
         </div>
         <div className="appointment-profile-two min-w-0">
-          <div className="appointment-profile-title cell-name truncate" title={ownerAndCompanion}>
+          <div
+            className="appointment-profile-title cell-name cell-truncate"
+            title={ownerAndCompanion}
+          >
             {ownerAndCompanion}
           </div>
           {subtitle && (

--- a/apps/frontend/src/app/ui/tables/PaginatedGridTable.tsx
+++ b/apps/frontend/src/app/ui/tables/PaginatedGridTable.tsx
@@ -16,6 +16,13 @@ type PaginatedGridTableProps<T> = {
   pageSize: number;
   /** `grid-template-columns` track shared by the sticky header and every row. */
   gridColumns: string;
+  /**
+   * Horizontal floor for the grid, in px. Must clear the sum of the fixed
+   * tracks plus gaps and gutters, or the `fr` columns are starved — one shared
+   * 1080px floor left Inventory's twelve columns just 76px to split between its
+   * two flexible tracks, collapsing the item name to about 48px.
+   */
+  minWidthPx?: number;
   headerCells: GridHeaderCell[];
   /** Plural noun for the footer summary, e.g. `items` -> "No items". */
   itemNoun: string;
@@ -33,6 +40,7 @@ const PaginatedGridTable = <T,>({
   itemNoun,
   renderRow,
   renderCard,
+  minWidthPx = 1080,
 }: PaginatedGridTableProps<T>) => {
   const [page, setPage] = useState(1);
 
@@ -116,9 +124,9 @@ const PaginatedGridTable = <T,>({
             .TableShell in Generictable.css). */}
         <div className="isolate flex h-full min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden rounded-[18px] border border-card-border bg-neutral-0 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]">
           <div className="min-h-0 flex-1 overflow-auto">
-            <div className="min-w-[1080px]">
+            <div style={{ minWidth: `${minWidthPx}px` }}>
               <div
-                className="sticky top-0 z-10 grid items-center gap-2.5 bg-[var(--screen-2)] px-5 py-3 text-[10px] font-bold uppercase tracking-[0.09em] text-[var(--ink-faint)]"
+                className="sticky top-0 z-10 grid items-center gap-2.5 bg-[var(--screen-2)] px-5 py-[11px] text-[10.5px] font-bold uppercase tracking-[0.1em] text-[var(--ink-faint)] shadow-[0_1px_0_var(--hairline)]"
                 style={{ gridTemplateColumns: gridColumns }}
               >
                 {headerCells.map((cell, index) => (

--- a/apps/frontend/src/app/ui/tables/RoomTable.tsx
+++ b/apps/frontend/src/app/ui/tables/RoomTable.tsx
@@ -150,39 +150,22 @@ const RoomTable = ({
 
   return (
     <div className="table-wrapper">
-      <div className="table-list overflow-x-auto">
+      <div className="table-list TableShell overflow-x-auto">
         {filteredList.length === 0 ? (
           <NoDataMessage />
         ) : (
-          <table className="w-full min-w-[980px] border-collapse">
+          <table className="TableDiv w-full min-w-[980px]">
             <thead>
-              <tr className="bg-[var(--screen-2)]">
-                <th
-                  className="px-4 py-3 text-left text-[10.5px] font-bold uppercase tracking-[0.1em] text-[var(--ink-faint)]"
-                  aria-label="Row number"
-                ></th>
-                <th className="px-4 py-3 text-left text-[10.5px] font-bold uppercase tracking-[0.1em] text-[var(--ink-faint)]">
-                  Room name
-                </th>
-                <th className="px-4 py-3 text-left text-[10.5px] font-bold uppercase tracking-[0.1em] text-[var(--ink-faint)]">
-                  Code
-                </th>
-                <th className="px-4 py-3 text-left text-[10.5px] font-bold uppercase tracking-[0.1em] text-[var(--ink-faint)]">
-                  Type
-                </th>
-                <th className="px-4 py-3 text-left text-[10.5px] font-bold uppercase tracking-[0.1em] text-[var(--ink-faint)]">
-                  Speciality
-                </th>
-                <th className="px-4 py-3 text-left text-[10.5px] font-bold uppercase tracking-[0.1em] text-[var(--ink-faint)]">
-                  Occupancy
-                </th>
-                <th className="px-4 py-3 text-left text-[10.5px] font-bold uppercase tracking-[0.1em] text-[var(--ink-faint)]">
-                  Assigned Staff
-                </th>
-                <th className="px-4 py-3 text-left text-[10.5px] font-bold uppercase tracking-[0.1em] text-[var(--ink-faint)]">
-                  Availability
-                </th>
-                <th className="px-4 py-3 text-center text-[10.5px] font-bold uppercase tracking-[0.1em] text-[var(--ink-faint)]">
+              <tr>
+                <th scope="col" aria-label="Row number"></th>
+                <th scope="col">Room name</th>
+                <th scope="col">Code</th>
+                <th scope="col">Type</th>
+                <th scope="col">Speciality</th>
+                <th scope="col">Occupancy</th>
+                <th scope="col">Assigned Staff</th>
+                <th scope="col">Availability</th>
+                <th scope="col" className="text-center!">
                   Action
                 </th>
               </tr>
@@ -192,37 +175,38 @@ const RoomTable = ({
                 const availability = getAvailability(room);
                 const occupancyLabel = getOccupancyLabel(room);
                 return (
-                  <tr
-                    key={room.id || `${room.name}-${index}`}
-                    className="border-b border-[var(--hairline)] last:border-b-0"
-                  >
-                    <td className="px-4 py-4 align-middle">
+                  <tr key={room.id || `${room.name}-${index}`}>
+                    <td className="align-middle">
                       <RoomCellText value={`${index + 1}.`} />
                     </td>
-                    <td className="px-4 py-4 align-middle">
+                    <td className="align-middle">
                       <RoomCellText value={room.name || '-'} />
                     </td>
-                    <td className="px-4 py-4 align-middle">
+                    <td className="align-middle">
                       <RoomCellText value={getRoomCode(room)} />
                     </td>
-                    <td className="px-4 py-4 align-middle">
+                    <td className="align-middle">
                       <RoomCellText value={toTitle(room.type)} />
                     </td>
-                    <td className="max-w-56 px-4 py-4 align-middle">
+                    <td className="max-w-56 align-middle">
                       <RoomCellText
                         value={joinNames(specialityNameById, room.assignedSpecialiteis)}
+                        className="cell-truncate"
                       />
                     </td>
-                    <td className="px-4 py-4 align-middle">
+                    <td className="align-middle">
                       <RoomCellText
                         value={occupancyLabel}
                         className={isVacantLabel(occupancyLabel) ? 'text-blue-text' : ''}
                       />
                     </td>
-                    <td className="max-w-52 px-4 py-4 align-middle">
-                      <RoomCellText value={joinNames(staffNameById, room.assignedStaffs)} />
+                    <td className="max-w-52 align-middle">
+                      <RoomCellText
+                        value={joinNames(staffNameById, room.assignedStaffs)}
+                        className="cell-truncate"
+                      />
                     </td>
-                    <td className="px-4 py-4 align-middle">
+                    <td className="align-middle">
                       <div className="flex items-center">
                         <AvailabilitySwitch
                           checked={availability}
@@ -232,7 +216,7 @@ const RoomTable = ({
                         />
                       </div>
                     </td>
-                    <td className="px-4 py-4 align-middle">
+                    <td className="align-middle">
                       <div className="action-btn-col items-center">
                         <IconButton
                           label={`View ${room.name}`}

--- a/apps/frontend/src/app/ui/tables/RoomTable.tsx
+++ b/apps/frontend/src/app/ui/tables/RoomTable.tsx
@@ -161,91 +161,97 @@ const RoomTable = ({
 
   return (
     <div className="table-wrapper">
-      <div className="table-list TableShell overflow-x-auto">
+      {/* The scroller nests INSIDE the shell, as GenericTable nests
+          .TableBodyScroll: `.TableShell` sets `overflow: hidden` unlayered, which
+          beats a layered `overflow-x-auto` utility on the same element and would
+          clip the trailing columns with no way to reach them. */}
+      <div className="table-list TableShell">
         {filteredList.length === 0 ? (
           <NoDataMessage />
         ) : (
-          <table className="TableDiv w-full min-w-[980px]">
-            <thead>
-              <tr>
-                <th scope="col" aria-label="Row number"></th>
-                <th scope="col">Room name</th>
-                <th scope="col">Code</th>
-                <th scope="col">Type</th>
-                <th scope="col">Speciality</th>
-                <th scope="col">Occupancy</th>
-                <th scope="col">Assigned Staff</th>
-                <th scope="col">Availability</th>
-                <th scope="col" className="text-center!">
-                  Action
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {filteredList.map((room, index) => {
-                const availability = getAvailability(room);
-                const occupancyLabel = getOccupancyLabel(room);
-                const specialityNames = joinNames(specialityNameById, room.assignedSpecialiteis);
-                const staffNames = joinNames(staffNameById, room.assignedStaffs);
-                return (
-                  <tr key={room.id || `${room.name}-${index}`}>
-                    <td className="align-middle">
-                      <RoomCellText value={`${index + 1}.`} />
-                    </td>
-                    <td className="align-middle">
-                      <RoomCellText value={room.name || '-'} />
-                    </td>
-                    <td className="align-middle">
-                      <RoomCellText value={getRoomCode(room)} />
-                    </td>
-                    <td className="align-middle">
-                      <RoomCellText value={toTitle(room.type)} />
-                    </td>
-                    <td className="max-w-56 align-middle">
-                      <RoomCellText
-                        value={specialityNames}
-                        className="cell-truncate"
-                        title={specialityNames || undefined}
-                      />
-                    </td>
-                    <td className="align-middle">
-                      <RoomCellText
-                        value={occupancyLabel}
-                        className={isVacantLabel(occupancyLabel) ? 'text-blue-text' : ''}
-                      />
-                    </td>
-                    <td className="max-w-52 align-middle">
-                      <RoomCellText
-                        value={staffNames}
-                        className="cell-truncate"
-                        title={staffNames || undefined}
-                      />
-                    </td>
-                    <td className="align-middle">
-                      <div className="flex items-center">
-                        <AvailabilitySwitch
-                          checked={availability}
-                          disabled={!canEditRoom}
-                          roomName={room.name}
-                          onChange={(next) => onToggleAvailability?.(room, next)}
+          <div className="overflow-x-auto">
+            <table className="TableDiv w-full min-w-[980px]">
+              <thead>
+                <tr>
+                  <th scope="col" aria-label="Row number"></th>
+                  <th scope="col">Room name</th>
+                  <th scope="col">Code</th>
+                  <th scope="col">Type</th>
+                  <th scope="col">Speciality</th>
+                  <th scope="col">Occupancy</th>
+                  <th scope="col">Assigned Staff</th>
+                  <th scope="col">Availability</th>
+                  <th scope="col" className="text-center!">
+                    Action
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {filteredList.map((room, index) => {
+                  const availability = getAvailability(room);
+                  const occupancyLabel = getOccupancyLabel(room);
+                  const specialityNames = joinNames(specialityNameById, room.assignedSpecialiteis);
+                  const staffNames = joinNames(staffNameById, room.assignedStaffs);
+                  return (
+                    <tr key={room.id || `${room.name}-${index}`}>
+                      <td className="align-middle">
+                        <RoomCellText value={`${index + 1}.`} />
+                      </td>
+                      <td className="align-middle">
+                        <RoomCellText value={room.name || '-'} />
+                      </td>
+                      <td className="align-middle">
+                        <RoomCellText value={getRoomCode(room)} />
+                      </td>
+                      <td className="align-middle">
+                        <RoomCellText value={toTitle(room.type)} />
+                      </td>
+                      <td className="max-w-56 align-middle">
+                        <RoomCellText
+                          value={specialityNames}
+                          className="cell-truncate"
+                          title={specialityNames || undefined}
                         />
-                      </div>
-                    </td>
-                    <td className="align-middle">
-                      <div className="action-btn-col items-center">
-                        <IconButton
-                          label={`View ${room.name}`}
-                          onClick={() => handleViewRoom(room)}
-                        >
-                          <IoEyeOutline size={16} aria-hidden="true" />
-                        </IconButton>
-                      </div>
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
+                      </td>
+                      <td className="align-middle">
+                        <RoomCellText
+                          value={occupancyLabel}
+                          className={isVacantLabel(occupancyLabel) ? 'text-blue-text' : ''}
+                        />
+                      </td>
+                      <td className="max-w-52 align-middle">
+                        <RoomCellText
+                          value={staffNames}
+                          className="cell-truncate"
+                          title={staffNames || undefined}
+                        />
+                      </td>
+                      <td className="align-middle">
+                        <div className="flex items-center">
+                          <AvailabilitySwitch
+                            checked={availability}
+                            disabled={!canEditRoom}
+                            roomName={room.name}
+                            onChange={(next) => onToggleAvailability?.(room, next)}
+                          />
+                        </div>
+                      </td>
+                      <td className="align-middle">
+                        <div className="action-btn-col items-center">
+                          <IconButton
+                            label={`View ${room.name}`}
+                            onClick={() => handleViewRoom(room)}
+                          >
+                            <IoEyeOutline size={16} aria-hidden="true" />
+                          </IconButton>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
         )}
       </div>
       <div className="flex xl:hidden gap-4 sm:gap-10 flex-wrap">

--- a/apps/frontend/src/app/ui/tables/RoomTable.tsx
+++ b/apps/frontend/src/app/ui/tables/RoomTable.tsx
@@ -10,6 +10,11 @@ import { NoDataMessage } from '@/app/ui/tables/common';
 import { joinNames } from '@/app/ui/tables/tableUtils';
 import { IoEyeOutline } from 'react-icons/io5';
 
+// `.TableShell` / `.TableDiv` live in the GenericTable sheet, and this is the one
+// table that uses them without rendering GenericTable — without the explicit
+// import it would inherit them only when some other table happened to be in the
+// same route bundle.
+import './GenericTable/Generictable.css';
 import './DataTable.css';
 
 type RoomUnit = {
@@ -108,10 +113,16 @@ const AvailabilitySwitch = ({
 const RoomCellText = ({
   value,
   className = '',
+  title,
 }: {
   value: React.ReactNode;
   className?: string;
-}) => <div className={`appointment-profile-title ${className}`}>{value}</div>;
+  title?: string;
+}) => (
+  <div className={`appointment-profile-title ${className}`} title={title}>
+    {value}
+  </div>
+);
 
 const RoomTable = ({
   filteredList,
@@ -174,6 +185,8 @@ const RoomTable = ({
               {filteredList.map((room, index) => {
                 const availability = getAvailability(room);
                 const occupancyLabel = getOccupancyLabel(room);
+                const specialityNames = joinNames(specialityNameById, room.assignedSpecialiteis);
+                const staffNames = joinNames(staffNameById, room.assignedStaffs);
                 return (
                   <tr key={room.id || `${room.name}-${index}`}>
                     <td className="align-middle">
@@ -190,8 +203,9 @@ const RoomTable = ({
                     </td>
                     <td className="max-w-56 align-middle">
                       <RoomCellText
-                        value={joinNames(specialityNameById, room.assignedSpecialiteis)}
+                        value={specialityNames}
                         className="cell-truncate"
+                        title={specialityNames || undefined}
                       />
                     </td>
                     <td className="align-middle">
@@ -202,8 +216,9 @@ const RoomTable = ({
                     </td>
                     <td className="max-w-52 align-middle">
                       <RoomCellText
-                        value={joinNames(staffNameById, room.assignedStaffs)}
+                        value={staffNames}
                         className="cell-truncate"
+                        title={staffNames || undefined}
                       />
                     </td>
                     <td className="align-middle">

--- a/apps/frontend/src/app/ui/tables/SpecialitiesTable.tsx
+++ b/apps/frontend/src/app/ui/tables/SpecialitiesTable.tsx
@@ -28,12 +28,19 @@ const SpecialitiesTable = ({ filteredList, setActive, setView }: SpecialitiesTab
       render: (item: SpecialityWeb) => <ProfileTitle>{item.name}</ProfileTitle>,
     },
     {
-      label: 'Services / Packages',
+      label: 'Services',
       key: 'Services',
       width: '30%',
-      render: (item: SpecialityWeb) => (
-        <ProfileTitle>{getServiceNames(item.services) || '—'}</ProfileTitle>
-      ),
+      // Comma-joined service names, clamped so a speciality with many services
+      // does not stand several lines taller than its neighbours.
+      render: (item: SpecialityWeb) => {
+        const names = getServiceNames(item.services);
+        return (
+          <div className="appointment-profile-title cell-truncate" title={names || undefined}>
+            {names || '—'}
+          </div>
+        );
+      },
     },
     {
       label: 'Team members',

--- a/apps/frontend/src/app/ui/tables/SpecialitiesTableRevamp.tsx
+++ b/apps/frontend/src/app/ui/tables/SpecialitiesTableRevamp.tsx
@@ -43,7 +43,10 @@ const SpecialitiesTableRevamp = ({ filteredList, onManageTeam }: SpecialitiesTab
       },
     },
     {
-      label: 'Services / Packages',
+      // Counts active services only — the next column counts packages. The old
+      // "Services / Packages" label was inaccurate and, at 100px, wrapped to two
+      // lines and doubled the height of the sticky header band.
+      label: 'Services',
       key: 'Services',
       width: '100px',
       render: (item: SpecialityWeb) => {
@@ -88,7 +91,9 @@ const SpecialitiesTableRevamp = ({ filteredList, onManageTeam }: SpecialitiesTab
               className="size-9 rounded-full object-cover shrink-0"
             />
             <div className="appointment-profile-two min-w-0">
-              <div className="appointment-profile-title truncate">{headName}</div>
+              <div className="appointment-profile-title cell-truncate" title={headName}>
+                {headName}
+              </div>
             </div>
           </div>
         );
@@ -124,7 +129,6 @@ const SpecialitiesTableRevamp = ({ filteredList, onManageTeam }: SpecialitiesTab
           bordered={false}
           pagination
           pageSize={5}
-          tableClassName="specialities-table"
         />
       </div>
       {/* Responsive card grid below lg: 1 col on mobile, 2 on sm, 3 on md */}

--- a/apps/frontend/src/app/ui/tables/Tasks.tsx
+++ b/apps/frontend/src/app/ui/tables/Tasks.tsx
@@ -82,7 +82,16 @@ const Tasks = ({
       label: 'Description',
       key: 'description',
       width: '200px',
-      render: (item: Task) => <div className="appointment-profile-title">{item.description}</div>,
+      // Free text in a 200px column: clamped to two lines so a long description
+      // cannot outgrow the rows beside it.
+      render: (item: Task) => (
+        <div
+          className="appointment-profile-title cell-clamp-2"
+          title={item.description || undefined}
+        >
+          {item.description}
+        </div>
+      ),
     },
     {
       label: 'Category',

--- a/apps/frontend/src/app/ui/tables/appointmentsTableColumns.tsx
+++ b/apps/frontend/src/app/ui/tables/appointmentsTableColumns.tsx
@@ -194,14 +194,24 @@ export const buildAppointmentColumns = ({
     render: (item: Appointment) => {
       const supportStaff = item.supportStaff ?? [];
 
+      // One line per staff member let a busy appointment grow the row without
+      // bound. Show the first two and count the rest, as the chips elsewhere do.
+      const shown = supportStaff.slice(0, 2);
+      const hidden = supportStaff.length - shown.length;
+
       return (
-        <div className="appointment-profile-two">
+        <div className="appointment-profile-two" title={supportStaff.map((s) => s.name).join(', ')}>
           {supportStaff.length > 0 ? (
-            supportStaff.map((sup) => (
-              <div key={sup.id} className="appointment-profile-sub">
-                {sup.name}
-              </div>
-            ))
+            <>
+              {shown.map((sup) => (
+                <div key={sup.id} className="appointment-profile-sub cell-truncate">
+                  {sup.name}
+                </div>
+              ))}
+              {hidden > 0 && (
+                <div className="appointment-profile-sub cell-overflow-count">{`+${hidden}`}</div>
+              )}
+            </>
           ) : (
             <div className="appointment-profile-sub">-</div>
           )}

--- a/apps/frontend/src/app/ui/tables/tableUtils.ts
+++ b/apps/frontend/src/app/ui/tables/tableUtils.ts
@@ -114,12 +114,26 @@ export const formatWeeklyWorkingHours = (value: Team['weeklyWorkingHours']) => {
   }).format(parsed);
 };
 
-/** Specialities arrive either as plain names or as `{ name }` records. */
+/** Shown when a speciality record carries neither a name nor a code. */
+export const UNNAMED_SPECIALITY = 'Unnamed speciality';
+
+/**
+ * Specialities arrive either as plain names or as records. A record with no
+ * `name` is still a real assignment, so it has to survive into the count rather
+ * than be dropped - otherwise the summary reads "Cardiology +1" for a
+ * practitioner who holds three. It falls back to any code before a neutral
+ * label; the previous behaviour printed `JSON.stringify(spec)` straight into
+ * the cell, which showed clinicians `{"code":"X1"}`.
+ */
 export const toSpecialityNames = (value: Team['speciality']): string[] => {
   if (!Array.isArray(value)) return [];
   return value
-    .map((spec) => (typeof spec === 'string' ? spec : (spec?.name ?? '')))
-    .map((name) => name.trim())
+    .map((spec: unknown) => {
+      if (typeof spec === 'string') return spec.trim();
+      if (!spec || typeof spec !== 'object') return '';
+      const record = spec as { name?: string; code?: string };
+      return (record.name ?? '').trim() || (record.code ?? '').trim() || UNNAMED_SPECIALITY;
+    })
     .filter(Boolean);
 };
 

--- a/apps/frontend/src/app/ui/tables/tableUtils.ts
+++ b/apps/frontend/src/app/ui/tables/tableUtils.ts
@@ -114,6 +114,15 @@ export const formatWeeklyWorkingHours = (value: Team['weeklyWorkingHours']) => {
   }).format(parsed);
 };
 
+/** Specialities arrive either as plain names or as `{ name }` records. */
+export const toSpecialityNames = (value: Team['speciality']): string[] => {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((spec) => (typeof spec === 'string' ? spec : (spec?.name ?? '')))
+    .map((name) => name.trim())
+    .filter(Boolean);
+};
+
 export const getAvailabilityStatusStyle = (status: string) => {
   switch (status.toLowerCase()) {
     case 'available':

--- a/apps/frontend/src/app/ui/widgets/Summary/Availability.tsx
+++ b/apps/frontend/src/app/ui/widgets/Summary/Availability.tsx
@@ -64,7 +64,7 @@ const Availability = () => {
                 className={clsx(
                   'rounded-full! border px-[13px] py-1.5 text-[12px] transition-colors',
                   isActive
-                    ? 'border-[var(--divider)] bg-[var(--inset)] font-bold text-[var(--ink)]'
+                    ? 'border-[var(--chip-selected-border)] bg-[var(--chip-selected-bg)] font-bold text-[var(--chip-selected-ink)]'
                     : 'border-[var(--hairline)] font-semibold text-[var(--ink-muted)] hover:text-[var(--ink)]'
                 )}
                 onClick={() => setSelectedLabel(label.value)}


### PR DESCRIPTION
## What changed

The Availability and Specialties tables read as foreign next to the rest of PIMS. Measuring them against Appointments on dev showed the header tone was **not** the problem - all three share an identical `--screen-2` band, 10.5px/700/0.1em label and 11px vertical padding. There were two unrelated causes:

| | Appointments | Availability (before) | Specialties (before) |
|---|---|---|---|
| header padding | `11px 11px 11px 20px` | same | **`12px 20px`** |
| cell padding | `12px 11px 12px 20px` | same | **`12px 20px`** |
| row heights | 67,67,67,67,66 | 83,121,83,102,159,101 | 65,65,65,65,64 |
| **spread** | **1px** | **76px** | 1px |

1. Specialties carried `.specialities-table`, the only per-table padding override in the kit. It beat the base on a **specificity tie** (both `0,1,3`) resolved purely by CSS import order - one refactor away from silently flipping. Removed.
2. Availability comma-joined a speciality array into an unclamped cell, so a six-speciality practitioner produced a 159px row beside a 67px one.

### The clamp had to be new CSS, not `truncate`

`DataTable.css` is unlayered, so `.appointment-profile-title`'s `white-space: normal; overflow-wrap: anywhere` beats Tailwind's layered `truncate`. Three call sites already wrote `truncate` - two of them alongside a `title` attribute, showing clear intent - and **none of them truncated**. Confirmed against computed style in a browser: `white-space: normal`, `overflow-wrap: anywhere`.

`cell-truncate` / `cell-clamp-2` are declared beside that rule so they actually apply.

### Multi-value cells lead with the first value and count the rest

`Cardiology +5`, full list in `title`. A two-line clamp was not enough: `GenericTable` derives its page size from the **first row alone**, so any data-driven row height also mis-sizes pagination. Applied to the speciality, invoice services, support-staff, room and dispensary cells.

### Divergences this surfaced, also fixed

- Header labels never had a wrapping rule anywhere, so a narrow column doubled the sticky band. The base now clips with a `title` fallback.
- Tasks and Documents were the two tables never given a text scale and stood 2-2.5px larger than their neighbours.
- RoomTable hand-rolled the header recipe across nine `th`s with no `scope="col"` and no shell; it now inherits `TableDiv`.
- Three grid shells each picked a different row padding off one 12px baseline (`py-3`, `py-[11px]`, `py-[10px]`).
- `PaginatedGridTable`'s shared `min-w-[1080px]` was sized for Dispensary and starved Inventory's twelve columns - its fixed tracks, gaps and gutters already total 1004px, leaving 76px for two `fr` tracks and collapsing the item name to ~48px. The floor is now per-table (Inventory 1320, Dispensary 1280).
- "Services / Packages" counted services only - the next column counts packages - and at 100px was what wrapped the header. Renamed to "Services" in both Specialities tables.

### Selected filter chips were invisible

Every neutral surface token sits within 1.03-1.24:1 of `--page`, so the `--inset` active fill measured **1.06:1** and font-weight alone (600 vs 700) marked the selection. Adds `--chip-selected-*`, an ink fill matching the app's existing selected-state precedent (the datepicker's selected day), applied across all six chip implementations.

## Why

Reported as "these tables look different from rest of the PIMS". The visible symptom was row-height variance and a taller header band, both traceable to two per-table divergences plus a base that never constrained cell or header content.

## Impact area

`apps/frontend` - table kit (`GenericTable`, `DataTable.css`, `Generictable.css`), 10 table components, 6 filter-chip implementations, `globals.css` tokens.

## Validation performed

- `pnpm --filter frontend run type-check` - clean
- `pnpm --filter frontend run lint` - clean
- `pnpm --filter frontend run test` across every touched area - **911 suites, 11,213 tests, all passing**
- New tests: 5 for the speciality cell, 6 for `toSpecialityNames`. Verified non-vacuous by removing `cell-truncate` and confirming exactly one test fails.
- Two existing tests pinned the old chip recipe and correctly caught the token change; updated to assert the new tokens and that the old `--inset` fill is gone.
- Browser-verified against the real Next CSS pipeline: old combo `white-space: normal` (no-op confirmed) -> new `nowrap` + `ellipsis`; header row single 36px band with `title` fallback; row spread **1px** with a six-item list present; active chip **13.97:1** light and **14.78:1** dark.
- Aikido scan of the changed logic - no issues.