### PR TITLE
fix(frontend): use text tokens for text and fill tokens for fills across PIMS

### DIFF
--- a/apps/frontend/AGENTS.md
+++ b/apps/frontend/AGENTS.md
@@ -45,6 +45,16 @@ var(--color-blue-text)`), because a token maintained by hand in both places
 drifts: `--color-blue-text` sat at `var(--blue)` and kept resolving to a
 sub-AA value after `--blue-text` had been fixed.
 
+**Column headers come from one recipe.** `<GenericTable>` for real tabular
+markup; `<TableHead>` (`src/app/ui/tables/TableHead.tsx`) for grid or flex
+shells. Do not hand-roll a `--screen-2` band with uppercase micro-type - PIMS
+grew five separate recipes that way, and a single page was rendering three of
+them. `src/app/__tests__/ui/tables/tableHeadConsistency.test.ts` fails the build
+if you do, and `Tables/TableHead` in Storybook stacks the table header against
+the shell header so drift shows up as a Chromatic diff. If a shell needs the
+band but NOT the header type - because its labels are proper names rather than
+column nouns - take the band alone; the recipe's uppercase would eat them.
+
 **Fill tokens and text tokens are not interchangeable.** `--blue` is a fill and
 carries no contrast duty; `--blue-text` must clear 4.5:1 on the bone surfaces.
 A fill that carries white text has two duties at once - 4.5:1 for the label and

--- a/apps/frontend/AGENTS.md
+++ b/apps/frontend/AGENTS.md
@@ -31,7 +31,25 @@ src/app/ui/
 
 Import from barrel: `import { Button, Card } from '@/app/ui'`
 
-Design-token source of truth: `src/app/globals.css` (`@theme`). `src/app/ui/tokens.md` is reference material only. Never hardcode colors - use `--color-*` CSS tokens.
+Design-token source of truth: `src/app/globals.css`. `src/app/ui/tokens.md` is reference material only. Never hardcode colors.
+
+**There are two token layers and they must agree.** The `@theme` block defines
+`--color-*`, which is what Tailwind utilities compile against (`text-blue-text`,
+`bg-card-hover`). The warm-bone layer below it defines the short runtime names
+(`--blue`, `--ink`, `--screen`, `--hairline`) used by `var(--x)` and arbitrary
+values like `text-[var(--ink-muted)]`. The short forms outnumber `--color-*` in
+the app roughly 3:1, so "use `--color-*`" is not the rule - **use whichever
+layer the surrounding code uses, and never let the two spellings of one concept
+hold separate literals.** Alias one to the other (`--blue-text:
+var(--color-blue-text)`), because a token maintained by hand in both places
+drifts: `--color-blue-text` sat at `var(--blue)` and kept resolving to a
+sub-AA value after `--blue-text` had been fixed.
+
+**Fill tokens and text tokens are not interchangeable.** `--blue` is a fill and
+carries no contrast duty; `--blue-text` must clear 4.5:1 on the bone surfaces.
+A fill that carries white text has two duties at once - 4.5:1 for the label and
+3:1 against its own surface, since a selected control may drop its border and
+let the fill alone signal state. That is what `--blue-strong` is for.
 
 ---
 

--- a/apps/frontend/src/app/__tests__/components/Calendar/common/CalendarTeamNamesRow.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/common/CalendarTeamNamesRow.test.tsx
@@ -27,12 +27,17 @@ describe('CalendarTeamNamesRow', () => {
     );
   });
 
-  it('paints the header band with the warm --screen-2 surface, not a blue tint or white', () => {
+  it('takes the shared header recipe rather than restating the band inline', () => {
     const { container } = render(<CalendarTeamNamesRow team={team} teamColumnsStyle={{}} />);
 
     const band = container.firstChild as HTMLElement;
-    expect(band.style.background).toContain('var(--screen-2)');
-    expect(band.style.background).not.toContain('white');
-    expect(band.style.background).not.toContain('brand');
+    // The --screen-2 surface now comes from `.yc-table-head`, which also carries
+    // the type, tracking and closing rule. Restating any of it inline is how
+    // this band drifted to 9.5px/0.08em against the table's 10.5px/0.1em.
+    expect(band).toHaveClass('yc-table-head');
+    expect(band.style.background).toBe('');
+    // Flush, or the labels stop lining up with the body columns; static,
+    // because the gutter spacers below are sticky against the scroller.
+    expect(band).toHaveClass('yc-table-head--flush', 'yc-table-head--static');
   });
 });

--- a/apps/frontend/src/app/__tests__/components/Calendar/common/CalendarTeamNamesRow.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/common/CalendarTeamNamesRow.test.tsx
@@ -27,17 +27,19 @@ describe('CalendarTeamNamesRow', () => {
     );
   });
 
-  it('takes the shared header recipe rather than restating the band inline', () => {
+  it('keeps the warm band but not the header type, whose casing would eat the names', () => {
     const { container } = render(<CalendarTeamNamesRow team={team} teamColumnsStyle={{}} />);
 
     const band = container.firstChild as HTMLElement;
-    // The --screen-2 surface now comes from `.yc-table-head`, which also carries
-    // the type, tracking and closing rule. Restating any of it inline is how
-    // this band drifted to 9.5px/0.08em against the table's 10.5px/0.1em.
-    expect(band).toHaveClass('yc-table-head');
-    expect(band.style.background).toBe('');
-    // Flush, or the labels stop lining up with the body columns; static,
-    // because the gutter spacers below are sticky against the scroller.
-    expect(band).toHaveClass('yc-table-head--flush', 'yc-table-head--static');
+    expect(band.style.background).toContain('var(--screen-2)');
+    // NOT `.yc-table-head`: its `text-transform: uppercase` and 0.1em tracking
+    // inherit into UserLabels, which resets neither, so "Dr. Sarah Weber" and
+    // her speciality subline render as wide-tracked capitals. These labels are
+    // practitioner names - data - not column nouns.
+    expect(band).not.toHaveClass('yc-table-head');
+    // The band's own defect stays fixed: it closed on --color-neutral-200 while
+    // every sibling calendar band closes on --hairline.
+    expect(band.className).toContain('border-[var(--hairline)]');
+    expect(band.className).not.toContain('border-card-border');
   });
 });

--- a/apps/frontend/src/app/__tests__/components/Calendar/common/WeekCalendar.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/common/WeekCalendar.test.tsx
@@ -186,16 +186,21 @@ describe('WeekCalendar (Appointments)', () => {
       />
     );
 
-    // Day label: all-caps 9.5px/700/0.08em (was 16px body type).
-    const dayLabel = container.querySelector('.text-\\[9\\.5px\\]');
-    expect(dayLabel).toHaveClass('font-bold', 'uppercase', 'tracking-[0.08em]');
+    // The day strip takes the shared header recipe instead of restating
+    // 9.5px/700/0.08em, which is what let it drift from the table header.
+    const band = container.querySelector('.yc-table-head');
+    expect(band).toBeInTheDocument();
+    expect(band).toHaveClass('yc-table-head--flush', 'yc-table-head--static');
+    // Scoped to the band: the "All-day" label below is a ROW-axis label, like
+    // the time gutter, and keeps its own denser type by design.
+    expect(band?.querySelector('.tracking-\\[0\\.08em\\]')).toBeNull();
 
     // Today's date drops into a 24px --blue disc, and its header cell takes
     // --nav-active-bg. Days mock to 6/7/8 Jan, so the 7th is today.
     const todayDisc = Array.from(container.querySelectorAll('div')).find(
       (el) =>
         el.className.includes('size-6') &&
-        el.getAttribute('style')?.includes('background-color: var(--blue)')
+        el.getAttribute('style')?.includes('background-color: var(--blue-strong)')
     );
     expect(todayDisc).toHaveTextContent('7');
     expect(todayDisc?.parentElement?.getAttribute('style')).toContain(

--- a/apps/frontend/src/app/__tests__/components/Inputs/Slotpicker/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Inputs/Slotpicker/index.test.tsx
@@ -158,8 +158,11 @@ describe('Slotpicker Component', () => {
     );
     // The fill token, not the text token: --blue-text lightens to #8fb6f5 in
     // dark, which left this white label at 2.06:1.
-    expect(screen.getByText('Formatted 10:00')).toHaveClass('bg-[var(--blue)]', 'text-white');
-    expect(screen.getByText('Formatted 11:00')).not.toHaveClass('bg-[var(--blue)]');
+    expect(screen.getByText('Formatted 10:00')).toHaveClass(
+      'bg-[var(--blue-strong)]',
+      'text-white'
+    );
+    expect(screen.getByText('Formatted 11:00')).not.toHaveClass('bg-[var(--blue-strong)]');
   });
 
   it('calls setSelectedSlot when a slot is clicked', () => {

--- a/apps/frontend/src/app/__tests__/components/Inputs/Slotpicker/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Inputs/Slotpicker/index.test.tsx
@@ -156,8 +156,10 @@ describe('Slotpicker Component', () => {
         timeSlots={mockTimeSlots}
       />
     );
-    expect(screen.getByText('Formatted 10:00')).toHaveClass('bg-blue-text!', 'text-white');
-    expect(screen.getByText('Formatted 11:00')).not.toHaveClass('bg-blue-text!');
+    // The fill token, not the text token: --blue-text lightens to #8fb6f5 in
+    // dark, which left this white label at 2.06:1.
+    expect(screen.getByText('Formatted 10:00')).toHaveClass('bg-[var(--blue)]', 'text-white');
+    expect(screen.getByText('Formatted 11:00')).not.toHaveClass('bg-[var(--blue)]');
   });
 
   it('calls setSelectedSlot when a slot is clicked', () => {

--- a/apps/frontend/src/app/__tests__/components/Labels/Labels.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Labels/Labels.test.tsx
@@ -87,4 +87,39 @@ describe('Labels', () => {
       'justify-center'
     );
   });
+
+  it('distinguishes a valid section from a failed one by shape, not only hue', () => {
+    render(
+      <Labels
+        labels={labels}
+        activeLabel="details"
+        setActiveLabel={jest.fn()}
+        activeSubLabel="core"
+        setActiveSubLabel={jest.fn()}
+        statuses={{ details: 'valid', documents: 'error' }}
+      />
+    );
+
+    // --success and --danger differ by 0.0005 in relative luminance, so two
+    // coloured dots were indistinguishable in greyscale and to a red-green
+    // colourblind user. The states must carry accessible names too.
+    expect(screen.getByLabelText('Section complete')).toBeInTheDocument();
+    expect(screen.getByLabelText('Section has errors')).toBeInTheDocument();
+    expect(screen.queryByText('•')).not.toBeInTheDocument();
+  });
+
+  it('marks no section when no statuses are supplied', () => {
+    render(
+      <Labels
+        labels={labels}
+        activeLabel="details"
+        setActiveLabel={jest.fn()}
+        activeSubLabel="core"
+        setActiveSubLabel={jest.fn()}
+      />
+    );
+
+    expect(screen.queryByLabelText('Section complete')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Section has errors')).not.toBeInTheDocument();
+  });
 });

--- a/apps/frontend/src/app/__tests__/components/Labels/SubLabels.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Labels/SubLabels.test.tsx
@@ -56,4 +56,37 @@ describe('SubLabels', () => {
     expect(redirectLink.closest('div')).toHaveClass('rounded-2xl!');
     expect(redirectLink.closest('div')).toHaveClass('gap-0');
   });
+
+  it('marks sub-sections by shape, not only by hue', () => {
+    render(
+      <SubLabels
+        labels={[
+          { key: 'core', name: 'Core' },
+          { key: 'history', name: 'History' },
+        ]}
+        activeLabel="core"
+        setActiveLabel={jest.fn()}
+        statuses={{ core: 'valid', history: 'error' }}
+      />
+    );
+
+    // The old markers were a green dot and a red dot whose relative luminance
+    // differs by 0.0005 - the same shade in greyscale.
+    expect(screen.getByLabelText('Section complete')).toBeInTheDocument();
+    expect(screen.getByLabelText('Section has errors')).toBeInTheDocument();
+    expect(screen.queryByText('•')).not.toBeInTheDocument();
+  });
+
+  it('marks nothing when no statuses are supplied', () => {
+    render(
+      <SubLabels
+        labels={[{ key: 'core', name: 'Core' }]}
+        activeLabel="core"
+        setActiveLabel={jest.fn()}
+      />
+    );
+
+    expect(screen.queryByLabelText('Section complete')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Section has errors')).not.toBeInTheDocument();
+  });
 });

--- a/apps/frontend/src/app/__tests__/components/TurnoverAnalytics/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/TurnoverAnalytics/index.test.tsx
@@ -134,7 +134,10 @@ describe('TurnoverAnalytics', () => {
   it('shows the year-over-year delta when both years have data', () => {
     renderComponent();
     // current avg (5,6)=5.5, previous (4) → +1.5 vs 2025
-    expect(screen.getByText(/\+1\.5 vs 2025/)).toBeInTheDocument();
+    const delta = screen.getByText(/\+1\.5 vs 2025/);
+    expect(delta).toBeInTheDocument();
+    // A RISE is good news and reads as success.
+    expect(delta.closest('span')).toHaveClass('text-[var(--success)]');
   });
 
   it('renders the month chart bars', () => {
@@ -224,7 +227,13 @@ describe('TurnoverAnalytics', () => {
       })
     );
     renderComponent();
-    expect(screen.getByText(/-5\.0 vs 2025/)).toBeInTheDocument();
+    const delta = screen.getByText(/-5\.0 vs 2025/);
+    expect(delta).toBeInTheDocument();
+    // A FALL in turnover was painted success-green regardless of direction, so
+    // the colour said "good" while the number said the opposite. Asserting the
+    // value alone passes either way - the class is the thing under test.
+    expect(delta.closest('span')).toHaveClass('text-[var(--danger-text)]');
+    expect(delta.closest('span')).not.toHaveClass('text-[var(--success)]');
   });
 
   it('selects the low-stock representative when the Class A row is clicked', () => {

--- a/apps/frontend/src/app/__tests__/components/chat/ConversationRow.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/chat/ConversationRow.test.tsx
@@ -62,13 +62,13 @@ describe('ConversationRow', () => {
   it('renders the blue unread pill on a network row', () => {
     render(<ConversationRow {...base} network unread={4} />);
     const badge = screen.getByText('4');
-    expect(badge).toHaveClass('bg-[var(--blue)]');
+    expect(badge).toHaveClass('bg-[var(--blue-strong)]');
   });
 
   it('renders the same blue unread pill on a non-network row', () => {
     render(<ConversationRow {...base} unread={4} />);
     const badge = screen.getByText('4');
-    expect(badge).toHaveClass('bg-[var(--blue)]');
+    expect(badge).toHaveClass('bg-[var(--blue-strong)]');
     expect(badge).toHaveClass('font-extrabold');
     expect(badge).toHaveClass('h-[17px]');
   });

--- a/apps/frontend/src/app/__tests__/features/appointments/components/Calendar/responsive/PhoneMonthOverview.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/appointments/components/Calendar/responsive/PhoneMonthOverview.test.tsx
@@ -191,7 +191,7 @@ describe('PhoneMonthOverview — dot map', () => {
 
     const selected = dayButton('2026-07-07', 14);
     expect(selected).toHaveAttribute('aria-pressed', 'true');
-    expect(within(selected).getByText('7').className).toContain('bg-[var(--blue)]');
+    expect(within(selected).getByText('7').className).toContain('bg-[var(--blue-strong)]');
     expect(dayButton('2026-07-08', 0)).toHaveAttribute('aria-pressed', 'false');
   });
 

--- a/apps/frontend/src/app/__tests__/features/appointments/components/Calendar/responsive/__snapshots__/PhoneMonthOverview.test.tsx.snap
+++ b/apps/frontend/src/app/__tests__/features/appointments/components/Calendar/responsive/__snapshots__/PhoneMonthOverview.test.tsx.snap
@@ -262,7 +262,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
         type="button"
       >
         <span
-          class="flex size-[26px] items-center justify-center rounded-full bg-[var(--blue)] text-[12.5px] font-bold text-white shadow-[0_4px_12px_var(--glow-b26)]"
+          class="flex size-[26px] items-center justify-center rounded-full bg-[var(--blue-strong)] text-[12.5px] font-bold text-white shadow-[0_4px_12px_var(--glow-b26)]"
         >
           7
         </span>

--- a/apps/frontend/src/app/__tests__/ui/tables/PaginatedGridTable.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/tables/PaginatedGridTable.test.tsx
@@ -46,7 +46,7 @@ describe('PaginatedGridTable', () => {
     expect(screen.getByText('Name')).not.toHaveClass('text-right');
     expect(screen.getByText('Amount')).toHaveClass('text-right');
     // The blank-label column still renders a span (keyed by index fallback).
-    const header = container.querySelector('.sticky') as HTMLElement;
+    const header = container.querySelector('.yc-table-head') as HTMLElement;
     expect(header.querySelectorAll('span')).toHaveLength(3);
   });
 
@@ -72,7 +72,7 @@ describe('PaginatedGridTable', () => {
 
   it('applies the caller grid track to the header', () => {
     const { container } = renderTable(makeRows(1));
-    const header = container.querySelector('.sticky') as HTMLElement;
+    const header = container.querySelector('.yc-table-head') as HTMLElement;
     expect(header).toHaveStyle({ gridTemplateColumns: GRID_COLUMNS });
   });
 

--- a/apps/frontend/src/app/__tests__/ui/tables/TableHead.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/tables/TableHead.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import TableHead from '@/app/ui/tables/TableHead';
+
+const COLUMNS = [
+  { key: 'name', label: 'Name' },
+  { key: 'qty', label: 'Qty', align: 'right' as const },
+  { key: 'actions', label: '' },
+];
+
+describe('TableHead', () => {
+  it('is sticky by default, matching the real table header', () => {
+    // Every production consumer so far passes sticky={false} because it sits in
+    // a drawer, which left the default - the one that matches `.TableDiv thead
+    // tr th` - with no coverage at all.
+    const { container } = render(<TableHead columns={COLUMNS} track="1fr 80px 44px" />);
+
+    const band = container.firstChild as HTMLElement;
+    expect(band).toHaveClass('yc-table-head');
+    expect(band).not.toHaveClass('yc-table-head--static');
+  });
+
+  it('opts out of sticky when asked', () => {
+    const { container } = render(
+      <TableHead columns={COLUMNS} track="1fr 80px 44px" sticky={false} />
+    );
+
+    expect(container.firstChild).toHaveClass('yc-table-head--static');
+  });
+
+  it('lays the labels over the caller track so header and rows stay aligned', () => {
+    const { container } = render(<TableHead columns={COLUMNS} track="1fr 80px 44px" gap="12px" />);
+
+    const band = container.firstChild as HTMLElement;
+    expect(band).toHaveStyle({ gridTemplateColumns: '1fr 80px 44px', gap: '12px' });
+  });
+
+  it('renders a spacer for a blank column rather than announcing an empty header', () => {
+    render(<TableHead columns={COLUMNS} track="1fr 80px 44px" />);
+
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Qty')).toHaveClass('text-right');
+    // The action column holds its track but says nothing to a screen reader.
+    expect(document.querySelectorAll('[aria-hidden="true"]')).toHaveLength(1);
+  });
+
+  it('carries no ARIA table roles', () => {
+    // `role="columnheader"` needs a `role="table"` ancestor, and these shells
+    // render plain divs for their rows - announcing a header for a table a
+    // screen reader cannot navigate is worse than announcing nothing. axe
+    // flagged exactly this when the roles were present.
+    const { container } = render(<TableHead columns={COLUMNS} track="1fr 80px 44px" />);
+
+    expect(container.querySelector('[role="columnheader"]')).toBeNull();
+    expect(container.querySelector('[role="row"]')).toBeNull();
+  });
+});

--- a/apps/frontend/src/app/__tests__/ui/tables/tableHeadConsistency.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/tables/tableHeadConsistency.test.ts
@@ -59,10 +59,19 @@ const CLASS_ATTRIBUTE = /className=\{?[`"'][^`"']*[`"']/g;
  * interpolated const (`${ROW_GRID}`), so requiring a literal `grid` here would
  * miss the very cases this guard is for.
  */
-const isHeaderStyling = (chunk: string): boolean =>
-  /uppercase/.test(chunk) &&
-  /tracking-\[0\.1/.test(chunk) &&
-  /text-\[(9|10|10\.5|11)(\.\d+)?px\]/.test(chunk);
+const isHeaderStyling = (chunk: string): boolean => {
+  if (!/uppercase/.test(chunk)) return false;
+  // Either the arbitrary-value spelling...
+  const arbitrary =
+    /tracking-\[0\.1/.test(chunk) && /text-\[(9|10|10\.5|11)(\.\d+)?px\]/.test(chunk);
+  // ...or the semantic-class one. The AppointmentWorkspace side modals used
+  // `text-caption-2 font-medium tracking-wide` - 12px/500/0.025em, an order of
+  // magnitude short on tracking - and the first version of this guard walked
+  // straight past all five of them.
+  const semantic =
+    /text-caption-[12]|text-body-4/.test(chunk) && /tracking-(wide|\[0\.)/.test(chunk);
+  return arbitrary || semantic;
+};
 
 /**
  * ...and it is a COLUMN header only if the file also declares a column track for

--- a/apps/frontend/src/app/__tests__/ui/tables/tableHeadConsistency.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/tables/tableHeadConsistency.test.ts
@@ -62,8 +62,10 @@ const CLASS_ATTRIBUTE = /className=\{?[`"'][^`"']*[`"']/g;
 const isHeaderStyling = (chunk: string): boolean => {
   if (!/uppercase/.test(chunk)) return false;
   // Either the arbitrary-value spelling...
+  // Any arbitrary tracking, not just 0.1em: the inventory ABC header used
+  // 0.08em and the first version of this check sailed straight past it.
   const arbitrary =
-    /tracking-\[0\.1/.test(chunk) && /text-\[(9|10|10\.5|11)(\.\d+)?px\]/.test(chunk);
+    /tracking-\[0?\.\d/.test(chunk) && /text-\[(9|10|10\.5|11)(\.\d+)?px\]/.test(chunk);
   // ...or the semantic-class one. The AppointmentWorkspace side modals used
   // `text-caption-2 font-medium tracking-wide` - 12px/500/0.025em, an order of
   // magnitude short on tracking - and the first version of this guard walked

--- a/apps/frontend/src/app/__tests__/ui/tables/tableHeadConsistency.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/tables/tableHeadConsistency.test.ts
@@ -74,20 +74,30 @@ const isHeaderStyling = (chunk: string): boolean => {
 };
 
 /**
- * ...and it is a COLUMN header only if the file also declares a column track for
- * the rows beneath. Without this, every uppercase eyebrow and badge in PIMS
- * matches, and the guard becomes noise. The track may be interpolated
- * (`${ROW_GRID}`), so the const declaration in the same file counts.
+ * ...and it is a COLUMN header only if THIS ELEMENT lays its labels over a
+ * column track. Checking the file instead of the element made every lone
+ * uppercase eyebrow in a file that happens to contain a grid an offender -
+ * InvoiceStep's "Payments" section label, for one - while checking neither
+ * matched every badge in PIMS. The track is often interpolated
+ * (`${ROW_GRID}`), so a *_GRID const reference in the class counts.
  */
-const declaresColumnTrack = (source: string): boolean =>
-  /grid-cols-\[/.test(source) ||
-  /gridTemplateColumns/.test(source) ||
-  /\b(GRID_COLS|GRID_COLUMNS|ROW_GRID)\b/.test(source);
+const laysOverAColumnTrack = (chunk: string): boolean =>
+  /grid-cols-\[/.test(chunk) ||
+  /\$\{[A-Za-z_]*(GRID|Grid|grid)[A-Za-z_]*\}/.test(chunk) ||
+  /\bgrid\b/.test(chunk);
 
+/**
+ * Exempt the migrated ELEMENT, never the whole file. A file-level exemption
+ * meant one migrated header bought amnesty for every other band beside it -
+ * `InvoiceStep.tsx` migrated its invoice list and the guard then stopped
+ * looking at the nested Breakdown header two hundred lines below, which was
+ * still hand-rolled. The guard passed with a live offender in the file it was
+ * written to catch.
+ */
 const looksLikeHeaderBand = (source: string): boolean =>
-  !/yc-table-head/.test(source) &&
-  declaresColumnTrack(source) &&
-  (source.match(CLASS_ATTRIBUTE) ?? []).some(isHeaderStyling);
+  (source.match(CLASS_ATTRIBUTE) ?? [])
+    .filter((chunk) => !/yc-table-head/.test(chunk))
+    .some((chunk) => isHeaderStyling(chunk) && laysOverAColumnTrack(chunk));
 
 describe('table header consistency', () => {
   const offenders = listFiles(APP_ROOT)

--- a/apps/frontend/src/app/__tests__/ui/tables/tableHeadConsistency.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/tables/tableHeadConsistency.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Guard: nobody hand-rolls a column-header band again.
+ *
+ * PIMS grew five separate header recipes because the appearance lived in a
+ * class string that was copied from component to component. Measured live on a
+ * single Organisation page there were three at once over the same `--screen-2`
+ * band: the real `th` at 10.5px/0.1em/11px-20px/sticky, the Team+Rooms grid at
+ * 10px/9px-20px/static, and the Services grid at 10px/10px-22px/static. None of
+ * that is catchable by lint, types or a render test - the page looks plausible
+ * either way - so it is asserted here against the source itself.
+ *
+ * If this fails: use `<TableHead>` (ui/tables/TableHead.tsx) for a grid or flex
+ * shell, or `<GenericTable>` for real tabular markup. Do not add your file to
+ * the allowlist to make the test pass.
+ */
+import { readFileSync, readdirSync, statSync } from 'fs';
+import path from 'path';
+
+const APP_ROOT = path.join(__dirname, '..', '..', '..');
+
+/**
+ * The only places the header recipe is allowed to be spelled out. Everything
+ * else must consume it.
+ */
+const ALLOWED = new Set([
+  // Owns the recipe.
+  'ui/tables/GenericTable/Generictable.css',
+  // The two sanctioned consumers of it.
+  'ui/tables/TableHead.tsx',
+  'ui/tables/GenericTable/GenericTable.tsx',
+]);
+
+const listFiles = (dir: string): string[] => {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry === '__tests__' || entry.startsWith('.')) continue;
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...listFiles(full));
+    } else if (/\.tsx$/.test(entry) && !entry.includes('.stories.')) {
+      out.push(full);
+    }
+  }
+  return out;
+};
+
+/**
+ * A header band is uppercase micro-type WITH the tracking, laid over a column
+ * track. Matching must happen inside a SINGLE element's styling, not across the
+ * whole file: a `--screen-2` side panel that merely happens to contain an
+ * uppercase label somewhere else is not a header, and a guard that cries wolf
+ * gets muted rather than obeyed.
+ */
+const CLASS_ATTRIBUTE = /className=\{?[`"'][^`"']*[`"']/g;
+
+/**
+ * The signature of the recipe: uppercase, the 0.1em tracking, at header size.
+ * A column track is deliberately NOT required - shells pass theirs through an
+ * interpolated const (`${ROW_GRID}`), so requiring a literal `grid` here would
+ * miss the very cases this guard is for.
+ */
+const isHeaderStyling = (chunk: string): boolean =>
+  /uppercase/.test(chunk) &&
+  /tracking-\[0\.1/.test(chunk) &&
+  /text-\[(9|10|10\.5|11)(\.\d+)?px\]/.test(chunk);
+
+/**
+ * ...and it is a COLUMN header only if the file also declares a column track for
+ * the rows beneath. Without this, every uppercase eyebrow and badge in PIMS
+ * matches, and the guard becomes noise. The track may be interpolated
+ * (`${ROW_GRID}`), so the const declaration in the same file counts.
+ */
+const declaresColumnTrack = (source: string): boolean =>
+  /grid-cols-\[/.test(source) ||
+  /gridTemplateColumns/.test(source) ||
+  /\b(GRID_COLS|GRID_COLUMNS|ROW_GRID)\b/.test(source);
+
+const looksLikeHeaderBand = (source: string): boolean =>
+  !/yc-table-head/.test(source) &&
+  declaresColumnTrack(source) &&
+  (source.match(CLASS_ATTRIBUTE) ?? []).some(isHeaderStyling);
+
+describe('table header consistency', () => {
+  const offenders = listFiles(APP_ROOT)
+    .filter((file) => {
+      const rel = path.relative(APP_ROOT, file).split(path.sep).join('/');
+      return !ALLOWED.has(rel);
+    })
+    .filter((file) => looksLikeHeaderBand(readFileSync(file, 'utf8')))
+    .map((file) => path.relative(APP_ROOT, file).split(path.sep).join('/'));
+
+  it('has no component drawing its own column-header band', () => {
+    expect(offenders).toEqual([]);
+  });
+
+  it('keeps the shared recipe in step with the real table header', () => {
+    const css = readFileSync(
+      path.join(APP_ROOT, 'ui/tables/GenericTable/Generictable.css'),
+      'utf8'
+    );
+    const block = (selector: string) => {
+      const start = css.indexOf(selector);
+      expect(start).toBeGreaterThan(-1);
+      return css.slice(start, css.indexOf('}', start));
+    };
+    const th = block('.TableDiv thead tr th {');
+    const shared = block('.yc-table-head {');
+
+    // The two must not drift; a mismatch here is the bug this guard exists for.
+    for (const decl of [
+      'font-size: 10.5px',
+      'font-weight: 700',
+      'letter-spacing: 0.1em',
+      'text-transform: uppercase',
+      'background: var(--screen-2)',
+      'position: sticky',
+      'box-shadow: 0 1px 0 var(--hairline)',
+    ]) {
+      expect(th).toContain(decl);
+      expect(shared).toContain(decl);
+    }
+  });
+});

--- a/apps/frontend/src/app/__tests__/ui/tables/tableHeadConsistency.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/tables/tableHeadConsistency.test.ts
@@ -132,6 +132,9 @@ describe('table header consistency', () => {
       'letter-spacing: 0.1em',
       'text-transform: uppercase',
       'background: var(--screen-2)',
+      // Not --ink-faint: that is 2.91:1 on this band, under AA at 10.5px, and
+      // was the header ink across PIMS long before the shared recipe existed.
+      'color: var(--table-head-ink)',
       'position: sticky',
       'box-shadow: 0 1px 0 var(--hairline)',
     ]) {

--- a/apps/frontend/src/app/features/appointments/components/Calendar/PhoneTaskDayList.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/PhoneTaskDayList.tsx
@@ -89,7 +89,7 @@ const TaskCheckbox = ({
     <span
       className={clsx(
         'flex size-[22px] items-center justify-center rounded-md border-[1.5px] border-[var(--divider)]',
-        entry.isDone && 'border-[var(--blue)] bg-[var(--blue)] text-white'
+        entry.isDone && 'border-[var(--blue)] bg-[var(--blue-strong)] text-white'
       )}
     >
       {entry.isDone && <IoCheckmark size={14} aria-hidden="true" />}

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/DayCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/DayCalendar.tsx
@@ -100,7 +100,7 @@ const DayCalendar = ({
         <Back onClick={handlePrevDay} />
         <div className="flex items-center gap-2 text-center">
           <div className="text-body-4 text-(--color-primary-700)">{weekday}</div>
-          <div className="text-body-4-emphasis text-white size-10 flex items-center justify-center rounded-full bg-text-brand">
+          <div className="text-body-4-emphasis text-white size-10 flex items-center justify-center rounded-full bg-[var(--blue)]">
             {dateNumber}
           </div>
         </div>
@@ -188,8 +188,8 @@ const DayCalendar = ({
                         {nowTimeLabel}
                       </div>
                     )}
-                    <div className="absolute left-[-5px] size-3 rounded-full bg-red-500 translate-y-[-50%]" />
-                    <div className="border-t-2 border-t-red-500 translate-y-[-50%]" />
+                    <div className="absolute left-[-5px] size-3 rounded-full bg-danger-700 translate-y-[-50%]" />
+                    <div className="border-t-2 border-t-danger-700 translate-y-[-50%]" />
                   </div>
                 </div>
               </div>

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/DayCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/DayCalendar.tsx
@@ -100,7 +100,7 @@ const DayCalendar = ({
         <Back onClick={handlePrevDay} />
         <div className="flex items-center gap-2 text-center">
           <div className="text-body-4 text-(--color-primary-700)">{weekday}</div>
-          <div className="text-body-4-emphasis text-white size-10 flex items-center justify-center rounded-full bg-[var(--blue)]">
+          <div className="text-body-4-emphasis text-white size-10 flex items-center justify-center rounded-full bg-[var(--blue-strong)]">
             {dateNumber}
           </div>
         </div>

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/DayLabels.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/DayLabels.tsx
@@ -23,7 +23,7 @@ const DayLabels = ({ days, currentDate, columnsStyle }: DayLabels) => {
         const dateNumber = day.getDate();
         const isToday = isOnPreferredTimeZoneCalendarDay(new Date(), day);
         const dateNumberClass = isToday
-          ? 'bg-[var(--blue)] text-white border-transparent'
+          ? 'bg-[var(--blue-strong)] text-white border-transparent'
           : 'bg-card-bg text-text-secondary border-transparent';
         return (
           <div key={idx + day.getDate()} className="flex items-center justify-center gap-2">

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/DayLabels.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/DayLabels.tsx
@@ -23,7 +23,7 @@ const DayLabels = ({ days, currentDate, columnsStyle }: DayLabels) => {
         const dateNumber = day.getDate();
         const isToday = isOnPreferredTimeZoneCalendarDay(new Date(), day);
         const dateNumberClass = isToday
-          ? 'bg-text-brand text-white border-transparent'
+          ? 'bg-[var(--blue)] text-white border-transparent'
           : 'bg-card-bg text-text-secondary border-transparent';
         return (
           <div key={idx + day.getDate()} className="flex items-center justify-center gap-2">

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/CalendarTeamNamesRow.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/CalendarTeamNamesRow.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import UserLabels from '@/app/features/appointments/components/Calendar/common/UserLabels';
 import { Team } from '@/app/features/organization/types/team';
+import '@/app/ui/tables/GenericTable/Generictable.css';
 
 type CalendarTeamNamesRowProps = {
   team: Team[];
@@ -8,10 +9,13 @@ type CalendarTeamNamesRowProps = {
 };
 
 export const CalendarTeamNamesRow = ({ team, teamColumnsStyle }: CalendarTeamNamesRowProps) => (
-  <div
-    className="grid grid-cols-[64px_minmax(0,1fr)_64px] border-b border-card-border min-w-max"
-    style={{ background: 'var(--screen-2)' }}
-  >
+  // --flush: the practitioner labels must line up column-for-column with the
+  // body grid, so the recipe's 20px container padding would desynchronise them.
+  // --static: the gutter spacers below are `sticky` against the horizontal
+  // scroller, and making this band sticky would trap them in a new stacking
+  // context. It also closed on --color-neutral-200 while every sibling band
+  // closes on --hairline.
+  <div className="yc-table-head yc-table-head--static yc-table-head--flush grid grid-cols-[64px_minmax(0,1fr)_64px] min-w-max">
     <div className="sticky left-0 z-30" style={{ background: 'inherit' }} />
     <UserLabels team={team} columnsStyle={teamColumnsStyle} />
     <div className="sticky right-0 z-30" style={{ background: 'inherit' }} />

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/CalendarTeamNamesRow.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/CalendarTeamNamesRow.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import UserLabels from '@/app/features/appointments/components/Calendar/common/UserLabels';
 import { Team } from '@/app/features/organization/types/team';
-import '@/app/ui/tables/GenericTable/Generictable.css';
 
 type CalendarTeamNamesRowProps = {
   team: Team[];
@@ -9,13 +8,16 @@ type CalendarTeamNamesRowProps = {
 };
 
 export const CalendarTeamNamesRow = ({ team, teamColumnsStyle }: CalendarTeamNamesRowProps) => (
-  // --flush: the practitioner labels must line up column-for-column with the
-  // body grid, so the recipe's 20px container padding would desynchronise them.
-  // --static: the gutter spacers below are `sticky` against the horizontal
-  // scroller, and making this band sticky would trap them in a new stacking
-  // context. It also closed on --color-neutral-200 while every sibling band
-  // closes on --hairline.
-  <div className="yc-table-head yc-table-head--static yc-table-head--flush grid grid-cols-[64px_minmax(0,1fr)_64px] min-w-max">
+  // Takes the shared BAND, not the shared TYPE. This strip's labels are
+  // practitioner names - "Dr. Sarah Weber" and a speciality subline - which are
+  // data, not column nouns, and UserLabels resets neither casing nor tracking.
+  // Applying the full recipe here rendered every name in wide-tracked capitals.
+  // The band itself was still wrong though: it closed on --color-neutral-200
+  // while every sibling calendar band closes on --hairline.
+  <div
+    className="grid grid-cols-[64px_minmax(0,1fr)_64px] border-b border-[var(--hairline)] min-w-max"
+    style={{ background: 'var(--screen-2)' }}
+  >
     <div className="sticky left-0 z-30" style={{ background: 'inherit' }} />
     <UserLabels team={team} columnsStyle={teamColumnsStyle} />
     <div className="sticky right-0 z-30" style={{ background: 'inherit' }} />

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/DayCalendarHeader.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/DayCalendarHeader.tsx
@@ -1,26 +1,31 @@
+import '@/app/ui/tables/GenericTable/Generictable.css';
+
 type DayCalendarHeaderProps = {
   weekday: string;
   dateNumber: string | number;
 };
 
 /**
- * Day-column header for the single-day grid. Same recipe as the week grid's day
- * headers: a --screen-2 band closed by a --hairline rule, carrying an all-caps
- * 9.5px/700/0.08em --ink-faint label over the 14px/700 date. Day navigation lives
- * in the header toolbar's date-nav pill, so this strip carries no arrows.
+ * Day-column header for the single-day grid. This and the week grid's day strip
+ * used to restate the same band by hand at 9.5px/700/0.08em - a comment here
+ * even said "same recipe as the week grid", which is precisely the duplication
+ * that let them drift from the table header at 10.5px/700/0.1em. Both now take
+ * `.yc-table-head`.
+ *
+ * `--static`: the scrolling section is a SIBLING of this header, not an
+ * ancestor, so `top: 0` has nothing to resolve against and sticky would be dead
+ * weight. Day navigation lives in the toolbar's date-nav pill, so this strip
+ * carries no arrows.
  */
 const DayCalendarHeader = ({ weekday, dateNumber }: DayCalendarHeaderProps) => (
-  <div
-    className="flex shrink-0 flex-col items-center gap-px border-b px-1 py-2"
-    style={{ borderColor: 'var(--hairline)', backgroundColor: 'var(--screen-2)' }}
-  >
+  <div className="yc-table-head yc-table-head--static flex shrink-0 flex-col items-center gap-px">
+    <div style={{ color: 'var(--ink-faint)' }}>{weekday}</div>
+    {/* Digits opt out of the inherited uppercase + 0.1em tracking: the trailing
+        letter-space pushes centred numerals off centre. */}
     <div
-      className="text-[9.5px] font-bold uppercase tracking-[0.08em]"
-      style={{ color: 'var(--ink-faint)' }}
+      className="text-[14px] font-bold normal-case tracking-normal"
+      style={{ color: 'var(--ink)' }}
     >
-      {weekday}
-    </div>
-    <div className="text-[14px] font-bold" style={{ color: 'var(--ink)' }}>
       {dateNumber}
     </div>
   </div>

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/WeekCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/WeekCalendar.tsx
@@ -41,6 +41,7 @@ import {
 import type { AppointmentViewIntent } from '@/app/features/appointments/types/calendar';
 import type { AppointmentCalendarInteractionProps } from '@/app/features/appointments/components/Calendar/common/calendarInteractionProps';
 import './WeekCalendar.css';
+import '@/app/ui/tables/GenericTable/Generictable.css';
 
 const HOUR_ROW_TOP_OFFSET_PX = 0;
 
@@ -187,10 +188,7 @@ const WeekDayHeaderRow = ({
   now: Date;
   dayColumnsStyle: React.CSSProperties;
 }) => (
-  <div
-    className="yc-week-grid__shell yc-week-grid__track border-b"
-    style={{ borderColor: 'var(--hairline)', backgroundColor: 'var(--screen-2)' }}
-  >
+  <div className="yc-table-head yc-table-head--static yc-table-head--flush yc-week-grid__shell yc-week-grid__track">
     <div className="sticky left-0 z-40" style={{ backgroundColor: 'var(--screen-2)' }} />
     <div className="grid" style={dayColumnsStyle}>
       {days.map((day) => {
@@ -208,21 +206,21 @@ const WeekDayHeaderRow = ({
               backgroundColor: isToday ? 'var(--nav-active-bg)' : undefined,
             }}
           >
-            <div
-              className="text-[9.5px] font-bold uppercase tracking-[0.08em]"
-              style={{ color: isToday ? 'var(--nav-active)' : 'var(--ink-faint)' }}
-            >
+            <div style={{ color: isToday ? 'var(--nav-active)' : 'var(--ink-faint)' }}>
               {weekday}
             </div>
             {isToday ? (
               <div
-                className="flex size-6 items-center justify-center rounded-full text-[13px] font-bold text-white"
-                style={{ backgroundColor: 'var(--blue)' }}
+                className="flex size-6 items-center justify-center rounded-full text-[13px] font-bold normal-case tracking-normal text-white"
+                style={{ backgroundColor: 'var(--blue-strong)' }}
               >
                 {dateNumber}
               </div>
             ) : (
-              <div className="text-[14px] font-bold" style={{ color: 'var(--ink)' }}>
+              <div
+                className="text-[14px] font-bold normal-case tracking-normal"
+                style={{ color: 'var(--ink)' }}
+              >
                 {dateNumber}
               </div>
             )}

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneMonthOverview.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneMonthOverview.tsx
@@ -115,7 +115,7 @@ const DayCell = ({
     )}
   >
     {cell.isSelected ? (
-      <span className="flex size-[26px] items-center justify-center rounded-full bg-[var(--blue)] text-[12.5px] font-bold text-white shadow-[0_4px_12px_var(--glow-b26)]">
+      <span className="flex size-[26px] items-center justify-center rounded-full bg-[var(--blue-strong)] text-[12.5px] font-bold text-white shadow-[0_4px_12px_var(--glow-b26)]">
         {cell.dayOfMonth}
       </span>
     ) : (

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneMyDayRail.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneMyDayRail.tsx
@@ -75,7 +75,7 @@ const RailTime = ({ entry }: { entry: MyDayRailEntry }) => {
 const NowMarker = ({ now }: { now: Date }) => (
   <div className="flex items-center gap-[7px]" data-testid="my-day-now-marker">
     <span className="w-[38px] flex-none pr-0.5 text-right">
-      <span className="inline-block rounded-full bg-[var(--blue)] px-1.5 py-0.5 text-[8.5px] font-bold tabular-nums text-white">
+      <span className="inline-block rounded-full bg-[var(--blue-strong)] px-1.5 py-0.5 text-[8.5px] font-bold tabular-nums text-white">
         {formatRailTime(now)}
       </span>
     </span>
@@ -170,7 +170,7 @@ const NextAppointmentCard = ({
         <button
           type="button"
           onClick={() => onOpenWorkspace?.(entry.appointment)}
-          className="flex h-[30px] flex-1 items-center justify-center rounded-full bg-[var(--blue)] text-[10.5px] font-bold text-white"
+          className="flex h-[30px] flex-1 items-center justify-center rounded-full bg-[var(--blue-strong)] text-[10.5px] font-bold text-white"
         >
           Open workspace
         </button>

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/ServicesPackagesEditor.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/ServicesPackagesEditor.tsx
@@ -9,6 +9,7 @@ import { TitleAddIcon } from '@/app/features/appointments/pages/AppointmentWorks
 import BilledBadge from '@/app/features/appointments/pages/AppointmentWorkspace/components/BilledBadge';
 import type { LineItem, LineItemBreakdown } from '@/app/features/appointments/types/workspace';
 import { formatMoney } from '@/app/lib/money';
+import '@/app/ui/tables/GenericTable/Generictable.css';
 
 type ServicesPackagesEditorProps = {
   items: LineItem[];
@@ -40,9 +41,7 @@ const ItemTag = ({ kind }: { kind: LineItem['kind'] }) => (
 const ROW_GRID = 'grid gap-3 sm:grid-cols-[1.6fr_100px_1.4fr_110px_120px] sm:items-center';
 
 const ColumnHeadings = () => (
-  <div
-    className={`${ROW_GRID} text-caption-2 font-medium tracking-wide text-text-secondary uppercase`}
-  >
+  <div className={`${ROW_GRID} yc-table-head yc-table-head--static rounded-lg px-[17px]!`}>
     <span>Name</span>
     <span>Qty.</span>
     <span className="hidden sm:block">Instructions</span>
@@ -183,7 +182,7 @@ const ServicesPackagesEditor = ({
           </p>
         ) : (
           <div className="flex flex-col gap-2">
-            <div className="hidden border border-transparent px-4 sm:block">
+            <div className="hidden sm:block">
               <ColumnHeadings />
             </div>
             <ul className="flex flex-col gap-3">

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/TotalBillContainer.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/TotalBillContainer.tsx
@@ -150,7 +150,10 @@ const ColumnHeadings = () => (
     track="minmax(0,1.7fr) 110px 72px 130px 150px 120px 36px"
     gap="12px"
     sticky={false}
-    className="rounded-lg [&>span]:px-3"
+    // Flush: the BillRows below carry no outer padding, so the recipe's 20px
+    // would start the headings 20px right of their values and resolve the
+    // flexible column against a width 40px narrower than the rows.
+    className="yc-table-head--flush rounded-lg [&>span]:px-3"
   />
 );
 

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/TotalBillContainer.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/TotalBillContainer.tsx
@@ -13,6 +13,7 @@ import {
   OVERALL_DISCOUNT_ERROR_ID,
   overallDiscountCapMessage,
 } from '@/app/features/appointments/pages/AppointmentWorkspace/components/totalBillMessages';
+import TableHead from '@/app/ui/tables/TableHead';
 
 export type BillableSearchItem = Omit<InvoiceLineItem, 'id'> & { kind?: BillableKind };
 
@@ -131,19 +132,26 @@ const ROW_GRID =
  * boxes have an inner px-3, so the headings carry the same px-3 inset. The label
  * therefore sits at the start of its column, directly above the value below it.
  */
+const BILL_COLUMNS = [
+  { key: 'item', label: 'Item Name' },
+  { key: 'unit', label: 'Unit Price' },
+  { key: 'qty', label: 'Qnt.' },
+  { key: 'gross', label: 'Gross Amt.' },
+  { key: 'discount', label: 'Discount' },
+  { key: 'amount', label: 'Amount' },
+  { key: 'actions', label: '' },
+] as const;
+
+/* Not sticky: this sits inside the appointment side modal, where a sticky band
+   resolves against the drawer's transformed parent and strands itself. */
 const ColumnHeadings = () => (
-  <div
-    className={`${ROW_GRID} rounded-lg py-2 text-[10px] font-bold uppercase tracking-[0.1em] [&>span]:px-3`}
-    style={{ background: 'var(--screen-2)', color: 'var(--ink-faint)' }}
-  >
-    <span>Item Name</span>
-    <span>Unit Price</span>
-    <span>Qnt.</span>
-    <span>Gross Amt.</span>
-    <span>Discount</span>
-    <span>Amount</span>
-    <span aria-hidden="true" className="px-0!" />
-  </div>
+  <TableHead
+    columns={BILL_COLUMNS}
+    track="minmax(0,1.7fr) 110px 72px 130px 150px 120px 36px"
+    gap="12px"
+    sticky={false}
+    className="rounded-lg [&>span]:px-3"
+  />
 );
 
 /** Plain (non-editable) text cell for line values that the user cannot change. */

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/panels/TasksPanel.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/panels/TasksPanel.tsx
@@ -408,7 +408,9 @@ const PanelTaskForm = ({
         assigneeOptions={assignees}
         onAssigneeSelect={(option) => setFormData({ ...formData, assignedTo: option.value })}
       />
-      {(error || editError) && <p className="text-caption-1 text-red-600">{error || editError}</p>}
+      {(error || editError) && (
+        <p className="text-caption-1 text-text-error">{error || editError}</p>
+      )}
       <div className="flex items-center gap-3">
         <Primary
           text={isLoading ? 'Saving…' : 'Save task'}
@@ -647,7 +649,7 @@ const TasksPanel = ({
         </ul>
       )}
       <div className="flex justify-center">
-        {saveError && <p className="text-caption-1 text-red-600">{saveError}</p>}
+        {saveError && <p className="text-caption-1 text-text-error">{saveError}</p>}
         <Primary text="New Task" icon={<IoAddOutline aria-hidden="true" />} onClick={openNew} />
       </div>
     </div>

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/records/ObservationToolForm.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/records/ObservationToolForm.tsx
@@ -162,7 +162,7 @@ const ObservationToolForm = ({
               <p className="text-center text-[12px] text-text-secondary">{disabledReason}</p>
             )}
             {error && (
-              <p role="alert" className="text-center text-[12px] text-red-600">
+              <p role="alert" className="text-center text-[12px] text-text-error">
                 {error}
               </p>
             )}

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/records/VitalsForm.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/records/VitalsForm.tsx
@@ -657,7 +657,7 @@ const VitalsForm = ({
         />
       </label>
       <div className="flex items-center justify-center gap-3">
-        {saveError && <p className="text-caption-1 text-red-600">{saveError}</p>}
+        {saveError && <p className="text-caption-1 text-text-error">{saveError}</p>}
         <Primary
           text={isSaving ? 'Saving...' : 'Save vitals'}
           icon={<IoCheckmarkOutline aria-hidden="true" />}

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/DiagnosticsStep.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/DiagnosticsStep.tsx
@@ -55,6 +55,7 @@ import {
   normalizeWorkspaceBootstrapForEncounter,
 } from '@/app/features/appointments/services/workspaceAggregateService';
 import { getIdexxCombinedResultsPdfBlob } from '@/app/features/integrations/services/idexxService';
+import '@/app/ui/tables/GenericTable/Generictable.css';
 
 type DiagnosticProvider = 'IDEXX' | 'RAD_ANALYZER';
 
@@ -238,7 +239,7 @@ const RESULTS_ROW_GRID = `grid gap-3 ${RESULTS_COLS} sm:items-center`;
 
 const TableHeadings = ({ rowGrid, columns }: { rowGrid: string; columns: string[] }) => (
   <div
-    className={`${rowGrid} hidden border border-transparent px-4 text-caption-2 font-medium tracking-wide text-text-secondary uppercase [&>span]:truncate sm:grid`}
+    className={`${rowGrid} yc-table-head yc-table-head--static hidden rounded-lg border border-transparent px-4! [&>span]:truncate sm:grid`}
   >
     {columns.map((column, index) => (
       <span key={column} className={index === columns.length - 1 ? 'text-right' : undefined}>

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/InvoiceStep.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/InvoiceStep.tsx
@@ -64,6 +64,7 @@ import {
   usePackageBreakdownHydration,
   usePaymentProgress,
 } from './invoiceStepHooks';
+import '@/app/ui/tables/GenericTable/Generictable.css';
 
 type InvoiceStepProps = {
   appointmentId: string;
@@ -558,7 +559,7 @@ const INVOICE_ROW_GRID = `grid gap-3 ${INVOICE_COLS} sm:items-center`;
 export const InvoiceHeadings = () => (
   <div
     // Match the row's p-4 + 1px border so the column origins line up exactly.
-    className={`${INVOICE_ROW_GRID} hidden border border-transparent px-4 text-caption-2 font-medium tracking-wide text-text-secondary uppercase [&>span]:truncate sm:grid`}
+    className={`${INVOICE_ROW_GRID} yc-table-head yc-table-head--static hidden rounded-lg border border-transparent px-4! [&>span]:truncate sm:grid`}
   >
     <span>Invoice ID</span>
     <span>Time / Date</span>

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/InvoiceStep.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/InvoiceStep.tsx
@@ -471,7 +471,7 @@ export const InvoiceBreakdown = ({
   <SectionContainer title="Breakdown" nested className="bg-neutral-0">
     <div className="flex flex-col gap-2">
       <div
-        className={`${ROW_GRID} px-1 text-caption-2 font-medium tracking-wide text-text-secondary uppercase [&>span]:truncate`}
+        className={`${ROW_GRID} yc-table-head yc-table-head--static rounded-lg px-1! [&>span]:truncate`}
       >
         <span>Item Name</span>
         <span>Unit Price</span>

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/TreatmentStep.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/TreatmentStep.tsx
@@ -909,7 +909,7 @@ const TreatmentStep = ({
             onAddVisit={() => setActiveSideAction('TASKS')}
           />
         )}
-        {scheduleError && <p className="text-caption-1 text-red-600">{scheduleError}</p>}
+        {scheduleError && <p className="text-caption-1 text-text-error">{scheduleError}</p>}
 
         <ServicesPackagesEditor
           items={encounter.services}
@@ -936,10 +936,10 @@ const TreatmentStep = ({
           onRemoveItem={(id) => void handleRemovePrescription(id)}
           onPrint={() => void handlePrintPrescriptionLabels()}
         />
-        {prescriptionError && <p className="text-caption-1 text-red-600">{prescriptionError}</p>}
+        {prescriptionError && <p className="text-caption-1 text-text-error">{prescriptionError}</p>}
 
         {treatmentSaveError && (
-          <p role="alert" className="text-caption-1 text-red-600">
+          <p role="alert" className="text-caption-1 text-text-error">
             {treatmentSaveError}
           </p>
         )}

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/AppointmentMerckSearch.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/AppointmentMerckSearch.tsx
@@ -571,7 +571,7 @@ const AppointmentMerckSearch = ({ activeAppointment }: AppointmentMerckSearchPro
             >
               <IoOptionsOutline size={18} />
             </button>
-            {copied ? <span className="text-body-4 text-green-700">URL copied</span> : null}
+            {copied ? <span className="text-body-4 text-pill-success-text">URL copied</span> : null}
           </div>
         </div>
 

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/LabTests.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/LabTests.tsx
@@ -109,7 +109,7 @@ export const LabResultCategoryTable = ({
             >
               <td className="text-caption-1 text-text-primary py-2 pr-2">{test.name}</td>
               <td
-                className={`text-caption-1 py-2 pr-2 ${test.outOfRange ? 'text-red-600' : 'text-text-primary'}`}
+                className={`text-caption-1 py-2 pr-2 ${test.outOfRange ? 'text-text-error' : 'text-text-primary'}`}
               >
                 <LabResultValue test={test} />
               </td>
@@ -941,7 +941,7 @@ const InhouseCensusStatus = ({ s }: { s: UseLabTestsReturn }) => {
 
   return (
     <div
-      className={`rounded-2xl border p-3 ${s.companionInCensus ? 'border-green-200 bg-green-50' : 'border-card-border'}`}
+      className={`rounded-2xl border p-3 ${s.companionInCensus ? 'border-pill-success-border bg-pill-success-bg' : 'border-card-border'}`}
     >
       <div className="text-body-4 text-text-primary">
         Companion census status: {censusStatusLabel}

--- a/apps/frontend/src/app/features/chat/components/ChatComposer.tsx
+++ b/apps/frontend/src/app/features/chat/components/ChatComposer.tsx
@@ -265,7 +265,7 @@ export function ChatComposer() {
           aria-label="Send message"
           onClick={send}
           disabled={Boolean(cooldownRemaining)}
-          className="inline-flex h-[42px] w-[42px] shrink-0 items-center justify-center rounded-full bg-[var(--blue)] text-white shadow-[0_8px_20px_var(--glow-b26)] transition hover:brightness-95 disabled:cursor-not-allowed disabled:opacity-50 xl:h-11 xl:w-11 xl:bg-[var(--cta)] xl:text-[var(--cta-text)] xl:shadow-none"
+          className="inline-flex h-[42px] w-[42px] shrink-0 items-center justify-center rounded-full bg-[var(--blue-strong)] text-white shadow-[0_8px_20px_var(--glow-b26)] transition hover:brightness-95 disabled:cursor-not-allowed disabled:opacity-50 xl:h-11 xl:w-11 xl:bg-[var(--cta)] xl:text-[var(--cta-text)] xl:shadow-none"
         >
           <IoArrowUp className="h-[17px] w-[17px] xl:hidden" />
           <IoSend className="hidden h-4 w-4 xl:block" />

--- a/apps/frontend/src/app/features/chat/components/ChatHeaderContext.tsx
+++ b/apps/frontend/src/app/features/chat/components/ChatHeaderContext.tsx
@@ -59,7 +59,7 @@ function PinnedBanner({
         onClick={onOpen}
         className="flex w-full items-center gap-[9px] rounded-xl border border-[var(--hairline)] bg-[var(--surface-soft)] px-3.5 py-[7px] text-left"
       >
-        <IoPin className="h-3 w-3 shrink-0 text-[var(--pink)]" />
+        <IoPin className="h-3 w-3 shrink-0 text-[var(--blue-text)]" />
         <Text
           as="span"
           variant="caption-1"

--- a/apps/frontend/src/app/features/chat/components/ConversationInfoPanel.tsx
+++ b/apps/frontend/src/app/features/chat/components/ConversationInfoPanel.tsx
@@ -246,7 +246,7 @@ export function ConversationInfoPanel({
                 key={item.id}
                 className="flex items-start gap-2 rounded-xl border border-[var(--hairline)] bg-[var(--surface-soft)] px-3 py-[9px]"
               >
-                <IoPin className="mt-0.5 h-[11px] w-[11px] shrink-0 text-[var(--pink)]" />
+                <IoPin className="mt-0.5 h-[11px] w-[11px] shrink-0 text-[var(--blue-text)]" />
                 <Text
                   as="span"
                   variant="caption-1"

--- a/apps/frontend/src/app/features/chat/components/ConversationRow.tsx
+++ b/apps/frontend/src/app/features/chat/components/ConversationRow.tsx
@@ -44,8 +44,13 @@ export type ConversationRowProps = Readonly<{
 const HOUR_MS = 60 * 60 * 1000;
 
 /**
- * Unread count pill. Design (Chat workspace conversation list): a 17px --blue
- * (#257bed) pill with white 10px/800 text — not the deeper solid brand badge.
+ * Unread count pill. Design (Chat workspace conversation list): a 17px blue
+ * pill with white 10px/800 text — not the deeper solid brand badge.
+ *
+ * The fill is `--blue-strong`, not `--blue`: white on #257bed is 4.09:1, under
+ * AA for 10px text. `--blue-strong` is the same hue family at 6.48:1, so the
+ * pill still reads as the design's blue rather than the brand badge it was
+ * distinguishing itself from.
  */
 function UnreadBadge({ count }: Readonly<{ count: number }>) {
   return (

--- a/apps/frontend/src/app/features/chat/components/ConversationRow.tsx
+++ b/apps/frontend/src/app/features/chat/components/ConversationRow.tsx
@@ -108,7 +108,7 @@ export function ConversationRow({
         // left-stripe (see design "Chat extended", conversation list).
         'group relative flex items-center pr-1 rounded-[13px] xl:rounded-[14px]',
         active
-          ? 'border border-[var(--hairline)] bg-[var(--screen)] shadow-[0_1px_3px_var(--sh05)] xl:border-transparent xl:bg-[var(--surface-soft)] xl:shadow-[inset_3px_0_0_var(--pink)]'
+          ? 'border border-[var(--hairline)] bg-[var(--screen)] shadow-[0_1px_3px_var(--sh05)] xl:border-transparent xl:bg-[var(--surface-soft)] xl:shadow-[inset_3px_0_0_var(--blue)]'
           : 'hover:bg-[var(--screen)] xl:hover:bg-[var(--surface-soft)]',
         muted && !active && 'opacity-[0.62]'
       )}

--- a/apps/frontend/src/app/features/chat/components/ConversationRow.tsx
+++ b/apps/frontend/src/app/features/chat/components/ConversationRow.tsx
@@ -49,7 +49,7 @@ const HOUR_MS = 60 * 60 * 1000;
  */
 function UnreadBadge({ count }: Readonly<{ count: number }>) {
   return (
-    <span className="inline-flex h-[17px] min-w-[17px] items-center justify-center rounded-full bg-[var(--blue)] px-1.5 py-0.5 text-[10px] font-extrabold leading-none text-white">
+    <span className="inline-flex h-[17px] min-w-[17px] items-center justify-center rounded-full bg-[var(--blue-strong)] px-1.5 py-0.5 text-[10px] font-extrabold leading-none text-white">
       {count}
     </span>
   );

--- a/apps/frontend/src/app/features/companionHistory/components/CompanionHistoryTimeline.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/CompanionHistoryTimeline.tsx
@@ -74,6 +74,7 @@ import {
   getPayloadString,
   resolveHistoryDocumentId,
 } from '@/app/features/companionHistory/utils/historyFormatters';
+import '@/app/ui/tables/GenericTable/Generictable.css';
 
 type CompanionHistoryTimelineProps = {
   companionId: string;
@@ -405,15 +406,6 @@ export const StatusPillSelect = ({
   );
 };
 
-const TABLE_HEADING_STYLE = {
-  color: 'var(--color-neutral-600)',
-  fontFamily: 'var(--font-satoshi), "Satoshi Variable", sans-serif',
-  fontSize: '12px',
-  fontStyle: 'normal',
-  fontWeight: 700,
-  lineHeight: '120%',
-} satisfies React.CSSProperties;
-
 const TABLE_DATA_STYLE = {
   color: 'var(--color-neutral-900)',
   fontFamily: 'var(--font-satoshi), "Satoshi Variable", sans-serif',
@@ -654,11 +646,11 @@ export const StructuredResultsPanel = ({
   results: DetailPair[];
 }) => (
   <div className="mt-3 rounded-2xl border border-card-border px-4 py-3">
-    <div className="grid grid-cols-[minmax(160px,1fr)_120px_120px_100px] gap-3">
-      <span style={TABLE_HEADING_STYLE}>Test</span>
-      <span style={TABLE_HEADING_STYLE}>Value</span>
-      <span style={TABLE_HEADING_STYLE}>Reference</span>
-      <span style={TABLE_HEADING_STYLE}>Meter</span>
+    <div className="yc-table-head yc-table-head--static grid grid-cols-[minmax(160px,1fr)_120px_120px_100px] gap-3 px-0!">
+      <span>Test</span>
+      <span>Value</span>
+      <span>Reference</span>
+      <span>Meter</span>
     </div>
     {results.map((result) => (
       <div

--- a/apps/frontend/src/app/features/companionHistory/components/HistoryEntryCard.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/HistoryEntryCard.tsx
@@ -67,7 +67,7 @@ const getTypeIcon = (type: HistoryEntryType): React.ReactNode => {
 const ACTIVE_ROW_STYLE: React.CSSProperties = {
   background: 'var(--surface-soft)',
   borderColor: 'var(--blue)',
-  boxShadow: '0 0 0 3px rgba(37,123,237,0.10)',
+  boxShadow: '0 0 0 3px var(--glow-b10)',
 };
 
 const formatStatusLabel = (status?: string): string => {

--- a/apps/frontend/src/app/features/companionHistory/components/HistoryRecordDrawer.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/HistoryRecordDrawer.tsx
@@ -17,6 +17,7 @@ import {
   getPrimaryActionLabel,
   resolveHistoryDocumentId,
 } from '@/app/features/companionHistory/utils/historyFormatters';
+import '@/app/ui/tables/GenericTable/Generictable.css';
 
 export type RecordDetailPair = {
   label: string;
@@ -138,10 +139,10 @@ const HistoryRecordDrawer = ({
         <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto">
           {results.length > 0 ? (
             <div className="overflow-hidden rounded-[14px] border border-hairline bg-[var(--screen)]">
-              <div className={`${RESULT_GRID_CLASS} bg-[var(--screen-2)] py-2.5`}>
-                <span className={MICRO_CAPTION_CLASS}>Analyte</span>
-                <span className={MICRO_CAPTION_CLASS}>Result</span>
-                <span className={MICRO_CAPTION_CLASS}>Range</span>
+              <div className={`${RESULT_GRID_CLASS} yc-table-head yc-table-head--static px-3.5!`}>
+                <span>Analyte</span>
+                <span>Result</span>
+                <span>Range</span>
               </div>
               {results.map((result) => (
                 <ResultRow key={`${entry.id}-${result.label}`} result={result} />

--- a/apps/frontend/src/app/features/companionHistory/pages/CompanionHistoryPage.tsx
+++ b/apps/frontend/src/app/features/companionHistory/pages/CompanionHistoryPage.tsx
@@ -159,7 +159,7 @@ const ProfileDetail = ({
   labelWidth?: 74 | 88;
   /** `danger` paints the value in --danger-text, matching the design's red allergy emphasis. */
   tone?: 'default' | 'danger';
-  /** Trailing qualifier rendered in --pink (the co-parent row's "· shared care"). */
+  /** Trailing qualifier rendered in --pink-text (the co-parent row's "· shared care"). */
   suffix?: string;
 }) => (
   <div
@@ -173,7 +173,7 @@ const ProfileDetail = ({
       style={{ color: tone === 'danger' ? 'var(--danger-text)' : 'var(--ink)' }}
     >
       {value}
-      {suffix ? <span style={{ color: 'var(--pink)' }}> {suffix}</span> : null}
+      {suffix ? <span style={{ color: 'var(--pink-text)' }}> {suffix}</span> : null}
     </span>
   </div>
 );

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceBilledItems.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceBilledItems.tsx
@@ -25,6 +25,9 @@ const InvoiceBilledItems = ({ items, currency }: InvoiceBilledItemsProps) => {
           track={gridTemplate}
           gap="10px"
           sticky={false}
+          // Rows below use px-4; the recipe's 20px would start every heading
+          // 4px right of its values and narrow the flexible track by 8px.
+          className="px-4!"
         />
         {items.length === 0 ? (
           <output className="block px-4 py-3 text-[13px] text-text-tertiary border-t border-card-border">

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceBilledItems.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceBilledItems.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { InvoiceItem } from '@yosemite-crew/types';
 import { formatMoney } from '@/app/lib/money';
+import TableHead from '@/app/ui/tables/TableHead';
 
 type InvoiceBilledItemsProps = {
   items: InvoiceItem[];
@@ -14,15 +15,17 @@ const InvoiceBilledItems = ({ items, currency }: InvoiceBilledItemsProps) => {
     <section className="flex flex-col gap-3" aria-label="Billed items">
       <h3 className="text-[13px] font-bold text-[var(--ink)]">Billed items</h3>
       <div className="rounded-[14px] border border-card-border overflow-hidden">
-        <div
-          className="grid gap-2.5 px-4 py-[9px] bg-card-hover text-[10px] font-bold text-text-tertiary uppercase tracking-[0.1em]"
-          style={{ gridTemplateColumns: gridTemplate }}
-        >
-          <span>Item</span>
-          <span>Qty</span>
-          <span className="text-right">Gross</span>
-          <span className="text-right">Amount</span>
-        </div>
+        <TableHead
+          columns={[
+            { key: 'item', label: 'Item' },
+            { key: 'qty', label: 'Qty' },
+            { key: 'gross', label: 'Gross', align: 'right' },
+            { key: 'amount', label: 'Amount', align: 'right' },
+          ]}
+          track={gridTemplate}
+          gap="10px"
+          sticky={false}
+        />
         {items.length === 0 ? (
           <output className="block px-4 py-3 text-[13px] text-text-tertiary border-t border-card-border">
             No billed items recorded for this invoice.

--- a/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/components/BuildWrapper.tsx
+++ b/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/components/BuildWrapper.tsx
@@ -129,7 +129,7 @@ const BuilderWrapper: React.FC<{
                 type="button"
                 onClick={onMoveUp}
                 disabled={!canMoveUp}
-                className={`${canMoveUp ? 'cursor-pointer hover:bg-gray-100' : 'opacity-30 cursor-not-allowed'} rounded p-1`}
+                className={`${canMoveUp ? 'cursor-pointer hover:bg-neutral-100' : 'opacity-30 cursor-not-allowed'} rounded p-1`}
                 title="Move up"
                 aria-label={`Move ${title} up`}
               >
@@ -141,7 +141,7 @@ const BuilderWrapper: React.FC<{
                 type="button"
                 onClick={onMoveDown}
                 disabled={!canMoveDown}
-                className={`${canMoveDown ? 'cursor-pointer hover:bg-gray-100' : 'opacity-30 cursor-not-allowed'} rounded p-1`}
+                className={`${canMoveDown ? 'cursor-pointer hover:bg-neutral-100' : 'opacity-30 cursor-not-allowed'} rounded p-1`}
                 title="Move down"
                 aria-label={`Move ${title} down`}
               >
@@ -152,11 +152,11 @@ const BuilderWrapper: React.FC<{
             <button
               type="button"
               onClick={onDelete}
-              className="hover:bg-red-50 rounded p-1"
+              className="hover:bg-[var(--status-danger-bg)] rounded p-1"
               title="Delete"
               aria-label={`Delete ${title}`}
             >
-              <IoTrash size={20} color="var(--color-danger-600)" />
+              <IoTrash size={20} color="var(--status-danger-text)" />
             </button>
           </div>
         )}

--- a/apps/frontend/src/app/features/integrations/pages/IdexxWorkspace/index.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/IdexxWorkspace/index.tsx
@@ -552,7 +552,7 @@ export const ResultDetailBody = ({
                     >
                       <td className="py-2 pr-2 text-caption-1 text-text-primary">{test.name}</td>
                       <td
-                        className={`py-2 pr-2 text-caption-1 ${test.outOfRange ? 'text-red-600' : 'text-text-primary'}`}
+                        className={`py-2 pr-2 text-caption-1 ${test.outOfRange ? 'text-text-error' : 'text-text-primary'}`}
                       >
                         <LabResultValue test={test} />
                       </td>

--- a/apps/frontend/src/app/features/integrations/pages/IdexxWorkspace/index.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/IdexxWorkspace/index.tsx
@@ -57,6 +57,7 @@ import {
 } from 'react-icons/io5';
 import GlassTooltip from '@/app/ui/primitives/GlassTooltip/GlassTooltip';
 import MobileSearchBar from '@/app/ui/layout/MobileSearchBar/MobileSearchBar';
+import TableHead from '@/app/ui/tables/TableHead';
 
 const PAGE_SIZE_OPTIONS = [5, 10, 25, 50];
 const MODALITY_FILTERS = [
@@ -985,15 +986,17 @@ const SyncingSkeleton = ({ lastRefreshedAt }: { lastRefreshedAt: string | null }
         Last sync {formatDateTimeLocal(lastRefreshedAt, '—')}
       </span>
     </div>
-    <div
-      className="grid grid-cols-[1.4fr_1fr_1fr_90px] gap-3 px-5 py-[11px] text-[10.5px] font-bold tracking-[0.1em] uppercase"
-      style={{ background: 'var(--screen-2)', color: 'var(--ink-faint)' }}
-    >
-      <span>Patient</span>
-      <span>Accession #</span>
-      <span>Device</span>
-      <span>Status</span>
-    </div>
+    <TableHead
+      columns={[
+        { key: 'patient', label: 'Patient' },
+        { key: 'accession', label: 'Accession #' },
+        { key: 'device', label: 'Device' },
+        { key: 'status', label: 'Status' },
+      ]}
+      track="1.4fr 1fr 1fr 90px"
+      gap="12px"
+      sticky={false}
+    />
     {SKELETON_ROWS.map((row) => (
       <div
         key={row.width}

--- a/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
@@ -181,7 +181,7 @@ const getValidateStateMeta = (
 ): { text: string; className: string } | null => {
   if (validateState === 'idle') return null;
   if (validateState === 'valid') {
-    return { text: 'Credentials validated successfully.', className: 'text-green-700' };
+    return { text: 'Credentials validated successfully.', className: 'text-pill-success-text' };
   }
   return { text: 'Credentials are invalid or not available.', className: 'text-text-error' };
 };

--- a/apps/frontend/src/app/features/integrations/pages/MerckManuals/index.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/MerckManuals/index.tsx
@@ -887,7 +887,9 @@ const MerckManualsPage = ({ embedded = false }: MerckManualsPageProps) => {
               </div>
             ) : null}
             {copied ? (
-              <output className="text-body-4 text-green-700">Copied URL to clipboard.</output>
+              <output className="text-body-4 text-pill-success-text">
+                Copied URL to clipboard.
+              </output>
             ) : null}
 
             {resultsCountLabel ? (

--- a/apps/frontend/src/app/features/inventory/components/DispensaryDetailModal.tsx
+++ b/apps/frontend/src/app/features/inventory/components/DispensaryDetailModal.tsx
@@ -103,7 +103,7 @@ const DispensaryItemRow = ({ item, idx }: Readonly<DispensaryItemRowProps>) => {
         <div className="flex flex-1 items-center gap-2 min-w-0">
           <span className="text-body-4 font-semibold text-text-primary truncate">{item.name}</span>
           {item.isRx && (
-            <span className="inline-flex size-6 items-center justify-center rounded-full bg-blue-text text-white text-[10px] font-bold shrink-0">
+            <span className="inline-flex size-6 items-center justify-center rounded-full bg-[var(--blue)] text-white text-[10px] font-bold shrink-0">
               Rx
             </span>
           )}

--- a/apps/frontend/src/app/features/inventory/components/DispensaryDetailModal.tsx
+++ b/apps/frontend/src/app/features/inventory/components/DispensaryDetailModal.tsx
@@ -103,7 +103,7 @@ const DispensaryItemRow = ({ item, idx }: Readonly<DispensaryItemRowProps>) => {
         <div className="flex flex-1 items-center gap-2 min-w-0">
           <span className="text-body-4 font-semibold text-text-primary truncate">{item.name}</span>
           {item.isRx && (
-            <span className="inline-flex size-6 items-center justify-center rounded-full bg-[var(--blue)] text-white text-[10px] font-bold shrink-0">
+            <span className="inline-flex size-6 items-center justify-center rounded-full bg-[var(--blue-strong)] text-white text-[10px] font-bold shrink-0">
               Rx
             </span>
           )}

--- a/apps/frontend/src/app/features/inventory/components/TurnoverAnalytics/index.tsx
+++ b/apps/frontend/src/app/features/inventory/components/TurnoverAnalytics/index.tsx
@@ -273,7 +273,7 @@ const AbcTable = ({ rows, onSelectClass }: AbcTableProps) => (
       </div>
     ) : (
       <>
-        <div className="hidden grid-cols-[64px_1fr_130px_120px_110px] gap-2.5 bg-[var(--screen-2)] px-[18px] py-[9px] text-[10px] font-bold uppercase tracking-[0.08em] text-[var(--ink-faint)] sm:grid">
+        <div className="yc-table-head yc-table-head--static hidden grid-cols-[64px_1fr_130px_120px_110px] gap-2.5 px-[18px]! sm:grid">
           <span>Class</span>
           <span>Share of value</span>
           <span>Products</span>

--- a/apps/frontend/src/app/features/inventory/components/TurnoverAnalytics/index.tsx
+++ b/apps/frontend/src/app/features/inventory/components/TurnoverAnalytics/index.tsx
@@ -157,7 +157,14 @@ const KpiCards = ({
       <span className={kpiLabelClass}>Annual turnover</span>
       <span className={kpiValueClass}>{formatTurns(annualTurnover)}</span>
       {annualDelta !== null ? (
-        <span className="flex items-center gap-1 text-[11px] font-semibold text-[var(--success)]">
+        <span
+          className={clsx(
+            'flex items-center gap-1 text-[11px] font-semibold',
+            // The arrow already flips on this exact comparison; the colour
+            // did not, so a fall in turnover was reported in success green.
+            annualDelta >= 0 ? 'text-[var(--success)]' : 'text-[var(--danger-text)]'
+          )}
+        >
           {annualDelta >= 0 ? (
             <IoTrendingUpOutline size={12} aria-hidden="true" />
           ) : (

--- a/apps/frontend/src/app/features/inventory/components/TurnoverAnalytics/index.tsx
+++ b/apps/frontend/src/app/features/inventory/components/TurnoverAnalytics/index.tsx
@@ -64,7 +64,7 @@ const kpiCaptionClass = 'text-[11px] text-[var(--ink-faint)]';
 const insetBoxClass = 'bg-[var(--inset)] border border-[var(--divider)]';
 
 const abcTileClass: Record<AbcClass, string> = {
-  'Class A': 'bg-[var(--blue)] text-white',
+  'Class A': 'bg-[var(--blue-strong)] text-white',
   'Class B': 'bg-[var(--blue-soft)] text-[var(--blue-text)]',
   'Class C': 'bg-[var(--inset)] text-[var(--ink-muted)] border border-[var(--divider)]',
 };

--- a/apps/frontend/src/app/features/inventory/pages/Inventory/InventoryFilterModal.tsx
+++ b/apps/frontend/src/app/features/inventory/pages/Inventory/InventoryFilterModal.tsx
@@ -63,7 +63,7 @@ const FilterSectionHeader = ({
       <div className="flex items-center gap-2">
         <span className="text-body-4 text-text-primary">{title}</span>
         {count > 0 && (
-          <span className="inline-flex size-5 items-center justify-center rounded-full bg-blue-text text-[10px] font-bold text-white">
+          <span className="inline-flex size-5 items-center justify-center rounded-full bg-[var(--blue)] text-[10px] font-bold text-white">
             {count}
           </span>
         )}

--- a/apps/frontend/src/app/features/inventory/pages/Inventory/InventoryFilterModal.tsx
+++ b/apps/frontend/src/app/features/inventory/pages/Inventory/InventoryFilterModal.tsx
@@ -63,7 +63,7 @@ const FilterSectionHeader = ({
       <div className="flex items-center gap-2">
         <span className="text-body-4 text-text-primary">{title}</span>
         {count > 0 && (
-          <span className="inline-flex size-5 items-center justify-center rounded-full bg-[var(--blue)] text-[10px] font-bold text-white">
+          <span className="inline-flex size-5 items-center justify-center rounded-full bg-[var(--blue-strong)] text-[10px] font-bold text-white">
             {count}
           </span>
         )}

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Team/PermissionsEditor.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Team/PermissionsEditor.tsx
@@ -3,6 +3,7 @@ import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
 import { Permission, PERMISSIONS, ROLE_PERMISSIONS, RoleCode } from '@/app/lib/permissions';
 import React from 'react';
 import { uniq } from '@/app/features/organization/pages/Organization/Sections/Team/permissionsEditorUtils';
+import '@/app/ui/tables/GenericTable/Generictable.css';
 
 type PermissionRow = {
   key: string;
@@ -388,11 +389,11 @@ const PermissionsEditor = ({ value, onSave, role, readOnly = false }: Permission
           </div>
         )}
         <div className="flex flex-col overflow-hidden">
-          <div className="flex w-full items-center py-3 justify-between border-b border-b-grey-light px-2 bg-neutral-0">
-            <div className="text-body-4 text-grey-text">Permission</div>
+          <div className="yc-table-head yc-table-head--static flex w-full items-center justify-between px-2!">
+            <div>Permission</div>
             <div className="flex gap-10 items-center">
-              <div className="text-body-4 text-grey-text w-18 text-center">View</div>
-              <div className="text-body-4 text-grey-text w-18 text-center">Edit</div>
+              <div className="w-18 text-center">View</div>
+              <div className="w-18 text-center">Edit</div>
             </div>
           </div>
           {PERMISSION_ROWS.map((row) => {

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Team/Team.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Team/Team.tsx
@@ -17,6 +17,7 @@ import {
   initialsOf,
   teamStatusPill,
 } from '@/app/features/organization/pages/Organization/Sections/orgDisplay';
+import '@/app/ui/tables/GenericTable/Generictable.css';
 
 const GRID_COLS = 'grid-cols-[1.6fr_1fr_1fr_110px_44px]';
 
@@ -144,7 +145,7 @@ const Team = ({ isVerified = false }: { isVerified?: boolean }) => {
           )}
         </div>
         <div
-          className={`grid ${GRID_COLS} items-center gap-[10px] border-t border-[var(--hairline)] bg-[var(--screen-2)] px-5! py-[9px]! text-[10px] font-bold uppercase tracking-[0.1em] text-[var(--ink-faint)]`}
+          className={`grid ${GRID_COLS} items-center gap-[10px] yc-table-head border-t border-[var(--hairline)]`}
         >
           <span>Member</span>
           <span>Role</span>

--- a/apps/frontend/src/app/features/organization/pages/Specialities/PackageBreakdownTable.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Specialities/PackageBreakdownTable.tsx
@@ -56,7 +56,7 @@ const NestedBreakdownTooltip = ({
           {items.map((item, i) => {
             const { net } = computePackageBreakdownItem(item);
             return (
-              <tr key={item.id} style={{ borderTop: '1px solid rgba(255,255,255,0.1)' }}>
+              <tr key={item.id} style={{ borderTop: '1px solid var(--hairline)' }}>
                 <td style={{ padding: '3px 6px', opacity: 0.5 }}>{i + 1}.</td>
                 <td style={{ padding: '3px 6px', opacity: 0.7 }}>
                   {TYPE_LABELS[item.type] ?? item.type}
@@ -78,7 +78,7 @@ const NestedBreakdownTooltip = ({
         </tbody>
         <tfoot>
           {additionalDiscount > 0 && (
-            <tr style={{ borderTop: '1px solid rgba(255,255,255,0.15)' }}>
+            <tr style={{ borderTop: '1px solid var(--hairline-hover)' }}>
               <td
                 colSpan={6}
                 style={{ padding: '3px 6px', textAlign: 'right', opacity: 0.6, fontSize: 12 }}
@@ -90,7 +90,7 @@ const NestedBreakdownTooltip = ({
               </td>
             </tr>
           )}
-          <tr style={{ borderTop: '1px solid rgba(255,255,255,0.2)' }}>
+          <tr style={{ borderTop: '1px solid var(--hairline-hover)' }}>
             <td
               colSpan={6}
               style={{ padding: '4px 6px', textAlign: 'right', opacity: 0.7, fontSize: 12 }}

--- a/apps/frontend/src/app/features/organization/pages/Specialities/ServicesTab.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Specialities/ServicesTab.tsx
@@ -35,6 +35,7 @@ import {
   IoInformationCircleOutline,
   IoPhonePortraitOutline,
 } from 'react-icons/io5';
+import '@/app/ui/tables/GenericTable/Generictable.css';
 
 export type ServicesTabHandle = { openAdd: () => void };
 
@@ -307,9 +308,7 @@ const ServiceRow = ({
 };
 
 const ServicesTableHeader = () => (
-  <div
-    className={`hidden @3xl:grid ${GRID_COLS} items-center gap-[10px] bg-[var(--screen-2)] px-[22px]! py-[10px]! text-[10px] font-bold uppercase tracking-[0.1em] text-[var(--ink-faint)]`}
-  >
+  <div className={`hidden @3xl:grid ${GRID_COLS} items-center gap-[10px] yc-table-head`}>
     <span>Service</span>
     <span>Practitioners</span>
     <span className="text-right">Duration</span>

--- a/apps/frontend/src/app/features/organization/pages/Specialities/ServicesTab.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Specialities/ServicesTab.tsx
@@ -308,7 +308,7 @@ const ServiceRow = ({
 };
 
 const ServicesTableHeader = () => (
-  <div className={`hidden @3xl:grid ${GRID_COLS} items-center gap-[10px] yc-table-head`}>
+  <div className={`hidden @3xl:grid ${GRID_COLS} items-center gap-[10px] yc-table-head px-[22px]!`}>
     <span>Service</span>
     <span>Practitioners</span>
     <span className="text-right">Duration</span>

--- a/apps/frontend/src/app/features/organization/pages/Specialities/ServicesTab.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Specialities/ServicesTab.tsx
@@ -74,12 +74,12 @@ const ServiceStatusPill = ({ status }: { status: string }) => (
 
 const BookableCell = ({ isBookable }: { isBookable: boolean }) =>
   isBookable ? (
-    <span className="inline-flex items-center gap-1 text-[11.5px] font-semibold text-[var(--pink)]">
+    <span className="inline-flex items-center gap-1 text-[11.5px] font-semibold text-[var(--pink-text)]">
       <IoPhonePortraitOutline size={12} aria-hidden="true" />
       In app
     </span>
   ) : (
-    <span className="inline-flex items-center gap-1 text-[11.5px] font-semibold text-[var(--ink-faint)]">
+    <span className="inline-flex items-center gap-1 text-[11.5px] font-semibold text-[var(--ink-muted)]">
       <IoCallOutline size={12} aria-hidden="true" />
       Desk only
     </span>

--- a/apps/frontend/src/app/features/organization/pages/Specialities/SpecialityNameEditor.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Specialities/SpecialityNameEditor.tsx
@@ -57,7 +57,7 @@ const SpecialityNameEditor = ({
           type="button"
           aria-label="Save name"
           onClick={onSaveName}
-          className="flex items-center justify-center size-8 rounded-full bg-[var(--blue)] text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-brand shrink-0"
+          className="flex items-center justify-center size-8 rounded-full bg-[var(--blue-strong)] text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-brand shrink-0"
         >
           <FiCheck size={14} aria-hidden="true" />
         </button>

--- a/apps/frontend/src/app/features/organization/pages/Specialities/SpecialityNameEditor.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Specialities/SpecialityNameEditor.tsx
@@ -57,7 +57,7 @@ const SpecialityNameEditor = ({
           type="button"
           aria-label="Save name"
           onClick={onSaveName}
-          className="flex items-center justify-center size-8 rounded-full bg-text-brand text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-brand shrink-0"
+          className="flex items-center justify-center size-8 rounded-full bg-[var(--blue)] text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-brand shrink-0"
         >
           <FiCheck size={14} aria-hidden="true" />
         </button>

--- a/apps/frontend/src/app/features/organizations/components/OrgGreeting/OrgGreeting.tsx
+++ b/apps/frontend/src/app/features/organizations/components/OrgGreeting/OrgGreeting.tsx
@@ -19,7 +19,7 @@ const OrgGreeting = ({ orgCount }: OrgGreetingProps) => {
 
   return (
     <div className="flex flex-col items-center gap-2 text-center">
-      <span className="font-newsreader text-[17px] italic text-[var(--pink)]">{greeting}</span>
+      <span className="font-newsreader text-[17px] italic text-[var(--blue-text)]">{greeting}</span>
       <h1 className="font-newsreader text-[30px] font-normal leading-[1.2] tracking-[-0.02em] text-[var(--ink)]">
         Where are you working today?
       </h1>

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -595,7 +595,14 @@ textarea:focus-visible {
   --dl-btn-hover: #302f2e;
   /* accents */
   --blue: #257bed;
-  --blue-text: #257bed;
+  /* The text-weight blue. In dark this already lightens to #8fb6f5 so it can be
+     read on the espresso page, but in light it was left identical to --blue and
+     never earned its name: #257bed is 3.12-3.70:1 on the bone surfaces, i.e.
+     under AA on every one of them, across ~150 usages. --color-accent-deep is
+     the brand's own darker blue and clears AA on all five (4.94-5.86:1).
+     --blue stays #257bed: it is the FILL token, and fills carry no contrast
+     requirement of their own. */
+  --blue-text: #1657c9;
   --blue-soft: #e6f2ff;
   --pink: #ff90d4;
   --cyan: #5ce1e6;

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -358,6 +358,15 @@ textarea:focus-visible {
      `text-blue-text` stayed at 3.12-3.70:1 on the bone surfaces even after
      --blue-text was fixed. Both spellings must resolve to the same value. */
   --color-blue-text: var(--color-accent-deep);
+  /* Utility-form twins for the tokens this app uses as fills in markup. Without
+     them `bg-blue-strong` compiles to nothing - silently no colour - while
+     `bg-[var(--blue-strong)]` works, which is a trap for the next person.
+     Aliased, never literal, per the rule in ui/tokens.md. */
+  --color-blue-strong: var(--blue-strong);
+  --color-chip-selected-bg: var(--chip-selected-bg);
+  --color-chip-selected-ink: var(--chip-selected-ink);
+  --color-chip-selected-border: var(--chip-selected-border);
+  --color-table-head-ink: var(--table-head-ink);
   --color-blue-light: var(--color-primary-100);
   --color-blue-sky: #428bec;
   --color-white-text: var(--color-neutral-100);

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -607,9 +607,12 @@ textarea:focus-visible {
      requirement of their own. */
   --blue-text: #1657c9;
   --blue-soft: #e6f2ff;
-  /* For fills that carry white text (count badges, selected slots). White on
-     --blue is 4.09:1; on this it is 6.48:1. Deliberately identical in dark -
-     the fill and its white label travel together. */
+  /* For fills that carry white text (count badges, selected slots). Two
+     constraints, not one: white on the fill needs 4.5:1, AND the fill itself
+     needs 3:1 against its surface, because selected controls like Slotpicker
+     drop their border and let the fill alone carry the state. Holding one value
+     for both themes satisfied the first and broke the second - #1657c9 is only
+     2.23:1 on the dark page. Light: 6.48 white / 5.04-5.86 surface. */
   --blue-strong: var(--color-accent-deep);
   --pink: #ff90d4;
   --cyan: #5ce1e6;
@@ -741,6 +744,10 @@ html[data-theme='dark'] {
   --dl-btn-sub: #6b6155;
   --dl-btn-hover: #ffffff;
   --blue: #257bed;
+  /* The window is narrow: white needs the fill dark, the espresso page needs it
+     light. #2f74d9 is the value that clears both - 4.54:1 white, 3.19-3.72:1
+     against every dark surface. */
+  --blue-strong: #2f74d9;
   --blue-text: #8fb6f5;
   --blue-soft: rgba(143, 182, 245, 0.16);
   --pink: #ff90d4;
@@ -851,6 +858,10 @@ html[data-theme='dark'] {
   --cta-hover: #fbf8f1;
   --cta-text: #201c18;
   --blue: #257bed;
+  /* The window is narrow: white needs the fill dark, the espresso page needs it
+     light. #2f74d9 is the value that clears both - 4.54:1 white, 3.19-3.72:1
+     against every dark surface. */
+  --blue-strong: #2f74d9;
   --blue-text: #8fb6f5;
   --blue-soft: rgba(143, 182, 245, 0.16);
   --pink: #ff90d4;

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -583,6 +583,11 @@ textarea:focus-visible {
   --ink: #1d1c1b;
   --ink-body: #302f2e;
   --ink-muted: #5c5956;
+  /* Column-header ink. The header recipe used --ink-faint, which is 2.91:1 on
+     the --screen-2 band - under AA at 10.5px, and true of every PIMS table
+     header long before the shared recipe existed. --ink-muted clears it at
+     5.87:1 light / 6.34:1 dark. */
+  --table-head-ink: var(--ink-muted);
   --ink-soft: #423f3c;
   --ink-faint: #8f8984;
   --ink-faint2: #a9a39e;
@@ -702,7 +707,7 @@ textarea:focus-visible {
   --warn-text: #b45309;
   --warn-border: rgba(245, 158, 11, 0.3);
   --pink-soft: #ffe8f6;
-  --pink-text: #c43d94;
+  --pink-text: #b3307f;
 }
 
 html[data-theme='dark'] {

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -354,7 +354,10 @@ textarea:focus-visible {
   --color-grey-noti: var(--color-neutral-700);
   /* The design's blue (#257bed), not the brighter brand-ramp primary-500
      (#007cf5) — links, active states and badges read as --blue in every frame. */
-  --color-blue-text: var(--blue);
+  /* The utility form of the text blue. This pointed at --blue (the FILL), so
+     `text-blue-text` stayed at 3.12-3.70:1 on the bone surfaces even after
+     --blue-text was fixed. Both spellings must resolve to the same value. */
+  --color-blue-text: var(--color-accent-deep);
   --color-blue-light: var(--color-primary-100);
   --color-blue-sky: #428bec;
   --color-white-text: var(--color-neutral-100);
@@ -604,6 +607,10 @@ textarea:focus-visible {
      requirement of their own. */
   --blue-text: #1657c9;
   --blue-soft: #e6f2ff;
+  /* For fills that carry white text (count badges, selected slots). White on
+     --blue is 4.09:1; on this it is 6.48:1. Deliberately identical in dark -
+     the fill and its white label travel together. */
+  --blue-strong: var(--color-accent-deep);
   --pink: #ff90d4;
   --cyan: #5ce1e6;
   --cyan-text: #38ccd8;

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -610,7 +610,11 @@ textarea:focus-visible {
      the brand's own darker blue and clears AA on all five (4.94-5.86:1).
      --blue stays #257bed: it is the FILL token, and fills carry no contrast
      requirement of their own. */
-  --blue-text: #1657c9;
+  /* Aliased, never re-stated: this token is also spelled --color-blue-text in
+     the @theme block for the Tailwind utility form, and maintaining a literal
+     in both layers is exactly how the two drifted apart - the utility kept
+     resolving to --blue (3.12-3.70:1) after the variable had been fixed. */
+  --blue-text: var(--color-blue-text);
   --blue-soft: #e6f2ff;
   /* For fills that carry white text (count badges, selected slots). Two
      constraints, not one: white on the fill needs 4.5:1, AND the fill itself
@@ -753,7 +757,7 @@ html[data-theme='dark'] {
      light. #2f74d9 is the value that clears both - 4.54:1 white, 3.19-3.72:1
      against every dark surface. */
   --blue-strong: #2f74d9;
-  --blue-text: #8fb6f5;
+  --blue-text: var(--color-blue-text);
   --blue-soft: rgba(143, 182, 245, 0.16);
   --pink: #ff90d4;
   --cyan: #5ce1e6;
@@ -867,7 +871,7 @@ html[data-theme='dark'] {
      light. #2f74d9 is the value that clears both - 4.54:1 white, 3.19-3.72:1
      against every dark surface. */
   --blue-strong: #2f74d9;
-  --blue-text: #8fb6f5;
+  --blue-text: var(--color-blue-text);
   --blue-soft: rgba(143, 182, 245, 0.16);
   --pink: #ff90d4;
   --cyan: #5ce1e6;

--- a/apps/frontend/src/app/ui/inputs/Slotpicker/index.tsx
+++ b/apps/frontend/src/app/ui/inputs/Slotpicker/index.tsx
@@ -266,7 +266,7 @@ const Slotpicker = ({
                 type="button"
                 key={slot.startTime + i}
                 onClick={() => setSelectedSlot(slot)}
-                className={`${selected ? 'bg-[var(--blue)] text-white border-transparent! shadow-[0_6px_16px_var(--glow-b26)]' : 'border-input-border-default! bg-neutral-0 text-text-primary'} px-3.5 h-10 flex items-center justify-center border-[1.5px] rounded-[11px]! font-satoshi text-[12.5px]! font-semibold tabular-nums`}
+                className={`${selected ? 'bg-[var(--blue-strong)] text-white border-transparent! shadow-[0_6px_16px_var(--glow-b26)]' : 'border-input-border-default! bg-neutral-0 text-text-primary'} px-3.5 h-10 flex items-center justify-center border-[1.5px] rounded-[11px]! font-satoshi text-[12.5px]! font-semibold tabular-nums`}
               >
                 {formatUtcTimeToLocalLabel(slot.startTime)}
               </button>

--- a/apps/frontend/src/app/ui/inputs/Slotpicker/index.tsx
+++ b/apps/frontend/src/app/ui/inputs/Slotpicker/index.tsx
@@ -266,7 +266,7 @@ const Slotpicker = ({
                 type="button"
                 key={slot.startTime + i}
                 onClick={() => setSelectedSlot(slot)}
-                className={`${selected ? 'bg-blue-text! text-white border-transparent! shadow-[0_6px_16px_var(--glow-b26)]' : 'border-input-border-default! bg-neutral-0 text-text-primary'} px-3.5 h-10 flex items-center justify-center border-[1.5px] rounded-[11px]! font-satoshi text-[12.5px]! font-semibold tabular-nums`}
+                className={`${selected ? 'bg-[var(--blue)] text-white border-transparent! shadow-[0_6px_16px_var(--glow-b26)]' : 'border-input-border-default! bg-neutral-0 text-text-primary'} px-3.5 h-10 flex items-center justify-center border-[1.5px] rounded-[11px]! font-satoshi text-[12.5px]! font-semibold tabular-nums`}
               >
                 {formatUtcTimeToLocalLabel(slot.startTime)}
               </button>

--- a/apps/frontend/src/app/ui/layout/Header/UserHeader/UserHeader.css
+++ b/apps/frontend/src/app/ui/layout/Header/UserHeader/UserHeader.css
@@ -341,22 +341,26 @@
   width: 7px;
   height: 7px;
   border-radius: 9999px;
-  background: var(--pink);
+  /* Blue, not pink: this badge says "you have unread notifications" and carries
+     no pet-parent meaning, so it is PIMS chrome. The keyframe is renamed with
+     it - a pink-named keyframe tinting a blue dot is how the next person
+     reintroduces the pink. */
+  background: var(--blue);
   border: 1.5px solid var(--screen);
-  animation: ycPulsePink 3.4s cubic-bezier(0.4, 0, 0.2, 1) 1s infinite;
+  animation: ycPulseDot 3.4s cubic-bezier(0.4, 0, 0.2, 1) 1s infinite;
 }
 
-@keyframes ycPulsePink {
+@keyframes ycPulseDot {
   0% {
-    box-shadow: 0 0 0 0 rgba(255, 144, 212, 0.45);
+    box-shadow: 0 0 0 0 rgba(37, 123, 237, 0.45);
   }
 
   60% {
-    box-shadow: 0 0 0 6px rgba(255, 144, 212, 0);
+    box-shadow: 0 0 0 6px rgba(37, 123, 237, 0);
   }
 
   100% {
-    box-shadow: 0 0 0 0 rgba(255, 144, 212, 0);
+    box-shadow: 0 0 0 0 rgba(37, 123, 237, 0);
   }
 }
 

--- a/apps/frontend/src/app/ui/layout/Header/UserHeader/UserHeader.css
+++ b/apps/frontend/src/app/ui/layout/Header/UserHeader/UserHeader.css
@@ -347,10 +347,10 @@
      reintroduces the pink. */
   background: var(--blue);
   border: 1.5px solid var(--screen);
-  animation: ycPulseDot 3.4s cubic-bezier(0.4, 0, 0.2, 1) 1s infinite;
+  animation: ycPulseNotificationDot 3.4s cubic-bezier(0.4, 0, 0.2, 1) 1s infinite;
 }
 
-@keyframes ycPulseDot {
+@keyframes ycPulseNotificationDot {
   0% {
     box-shadow: 0 0 0 0 color-mix(in srgb, var(--blue) 45%, transparent);
   }

--- a/apps/frontend/src/app/ui/layout/Header/UserHeader/UserHeader.css
+++ b/apps/frontend/src/app/ui/layout/Header/UserHeader/UserHeader.css
@@ -352,15 +352,15 @@
 
 @keyframes ycPulseDot {
   0% {
-    box-shadow: 0 0 0 0 rgba(37, 123, 237, 0.45);
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--blue) 45%, transparent);
   }
 
   60% {
-    box-shadow: 0 0 0 6px rgba(37, 123, 237, 0);
+    box-shadow: 0 0 0 6px color-mix(in srgb, var(--blue) 0%, transparent);
   }
 
   100% {
-    box-shadow: 0 0 0 0 rgba(37, 123, 237, 0);
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--blue) 0%, transparent);
   }
 }
 

--- a/apps/frontend/src/app/ui/layout/PhoneShell/PhoneShell.css
+++ b/apps/frontend/src/app/ui/layout/PhoneShell/PhoneShell.css
@@ -118,7 +118,9 @@
     height: 6px;
     border: 1.5px solid var(--screen);
     border-radius: 999px;
-    background: var(--pink);
+    /* Twin of .yc-notification-dot in UserHeader.css - same badge, same
+       meaning, so the same blue at both breakpoints. */
+    background: var(--blue);
   }
 
   /* -------------------------------------------------------------- tab bar */

--- a/apps/frontend/src/app/ui/tables/CompanionsTable.tsx
+++ b/apps/frontend/src/app/ui/tables/CompanionsTable.tsx
@@ -34,6 +34,7 @@ import {
 } from '@/app/features/companions/pages/Companions/companionsDirectory';
 
 import './DataTable.css';
+import './GenericTable/Generictable.css';
 
 const SPECIES_LABEL: Record<string, string> = {
   dog: 'Dog',

--- a/apps/frontend/src/app/ui/tables/CompanionsTable.tsx
+++ b/apps/frontend/src/app/ui/tables/CompanionsTable.tsx
@@ -513,9 +513,7 @@ const CompanionsTable = ({
           ) : (
             <>
               {/* Header row */}
-              <div
-                className={`${GRID_COLS} shrink-0 bg-[var(--screen-2)] px-5 py-[11px] text-[10.5px] font-bold uppercase tracking-[0.1em] text-[var(--ink-faint)]`}
-              >
+              <div className={`${GRID_COLS} yc-table-head shrink-0`}>
                 <span>{terminologyText('Patient')}</span>
                 <span>Parent</span>
                 <span>Breed</span>

--- a/apps/frontend/src/app/ui/tables/GenericTable/Generictable.css
+++ b/apps/frontend/src/app/ui/tables/GenericTable/Generictable.css
@@ -82,6 +82,34 @@
   box-shadow: 0 1px 0 var(--hairline);
 }
 
+/* The header band for shells that are not a <table>: the Organisation section's
+   Team / Rooms / Services grids, the inventory grid shell, and the companions
+   grid. Each had hand-rolled its own recipe, so one page could show three
+   header sizes over the same --screen-2 band. Values are kept byte-for-byte in
+   step with `.TableDiv thead tr th` above - if that changes, change this too. */
+.yc-table-head {
+  padding: 11px 20px;
+  background: var(--screen-2);
+  color: var(--ink-faint);
+  font-family: var(--font-satoshi);
+  font-size: 10.5px;
+  font-weight: 700;
+  line-height: 120%;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  box-shadow: 0 1px 0 var(--hairline);
+}
+
+/* Appearance without the sticky contract: inside a drawer, a modal, or any
+   transformed parent, `position: sticky` resolves against the wrong container
+   and strands the band mid-panel. */
+.yc-table-head--static {
+  position: static;
+}
+
 .TableDiv tbody tr:last-child td {
   border-bottom: none;
 }

--- a/apps/frontend/src/app/ui/tables/GenericTable/Generictable.css
+++ b/apps/frontend/src/app/ui/tables/GenericTable/Generictable.css
@@ -97,15 +97,22 @@
   line-height: 120%;
   letter-spacing: 0.1em;
   text-transform: uppercase;
+  /* Mirrors the th above: without it a multiword label in a narrow drawer
+     column wraps and grows the whole band, which is the defect nowrap was
+     added to `.TableDiv thead tr th` to prevent. */
+  white-space: nowrap;
   position: sticky;
   top: 0;
   z-index: 10;
   box-shadow: 0 1px 0 var(--hairline);
 }
+/* Clipping sits on the cells so each ellipses independently, as table cells do;
+   on the container it would clip the band instead. */
+.yc-table-head > * {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 
-/* Appearance without the sticky contract: inside a drawer, a modal, or any
-   transformed parent, `position: sticky` resolves against the wrong container
-   and strands the band mid-panel. */
 /* Appearance with no container padding. Calendar strips are two-column shells
    (gutter + day track) that must line up column-for-column with the body grid
    below them; the recipe's 20px would inset the whole track and desynchronise
@@ -114,6 +121,9 @@
   padding: 0;
 }
 
+/* Appearance without the sticky contract: inside a drawer, a modal, or any
+   transformed parent, `position: sticky` resolves against the wrong container
+   and strands the band mid-panel. */
 .yc-table-head--static {
   position: static;
 }

--- a/apps/frontend/src/app/ui/tables/GenericTable/Generictable.css
+++ b/apps/frontend/src/app/ui/tables/GenericTable/Generictable.css
@@ -106,6 +106,14 @@
 /* Appearance without the sticky contract: inside a drawer, a modal, or any
    transformed parent, `position: sticky` resolves against the wrong container
    and strands the band mid-panel. */
+/* Appearance with no container padding. Calendar strips are two-column shells
+   (gutter + day track) that must line up column-for-column with the body grid
+   below them; the recipe's 20px would inset the whole track and desynchronise
+   header from body. Per-cell padding stays on the cells. */
+.yc-table-head--flush {
+  padding: 0;
+}
+
 .yc-table-head--static {
   position: static;
 }

--- a/apps/frontend/src/app/ui/tables/GenericTable/Generictable.css
+++ b/apps/frontend/src/app/ui/tables/GenericTable/Generictable.css
@@ -68,7 +68,7 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  color: var(--ink-faint);
+  color: var(--table-head-ink);
   font-size: 10.5px;
   font-weight: 700;
   font-family: var(--font-satoshi);
@@ -90,7 +90,7 @@
 .yc-table-head {
   padding: 11px 20px;
   background: var(--screen-2);
-  color: var(--ink-faint);
+  color: var(--table-head-ink);
   font-family: var(--font-satoshi);
   font-size: 10.5px;
   font-weight: 700;

--- a/apps/frontend/src/app/ui/tables/PaginatedGridTable.tsx
+++ b/apps/frontend/src/app/ui/tables/PaginatedGridTable.tsx
@@ -126,7 +126,7 @@ const PaginatedGridTable = <T,>({
           <div className="min-h-0 flex-1 overflow-auto">
             <div style={{ minWidth: `${minWidthPx}px` }}>
               <div
-                className="sticky top-0 z-10 grid items-center gap-2.5 bg-[var(--screen-2)] px-5 py-[11px] text-[10.5px] font-bold uppercase tracking-[0.1em] text-[var(--ink-faint)] shadow-[0_1px_0_var(--hairline)]"
+                className="yc-table-head grid items-center gap-2.5"
                 style={{ gridTemplateColumns: gridColumns }}
               >
                 {headerCells.map((cell, index) => (

--- a/apps/frontend/src/app/ui/tables/PaginatedGridTable.tsx
+++ b/apps/frontend/src/app/ui/tables/PaginatedGridTable.tsx
@@ -4,6 +4,7 @@ import { IoChevronBackOutline, IoChevronForwardOutline } from 'react-icons/io5';
 import { buildPagerPageList } from '@/app/ui/tables/tableUtils';
 
 import './DataTable.css';
+import './GenericTable/Generictable.css';
 
 export type GridHeaderCell = { label: string; align?: 'right'; className?: string };
 

--- a/apps/frontend/src/app/ui/tables/TableHead.stories.tsx
+++ b/apps/frontend/src/app/ui/tables/TableHead.stories.tsx
@@ -1,0 +1,140 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import React from 'react';
+
+import TableHead from './TableHead';
+import GenericTable from './GenericTable/GenericTable';
+
+const meta: Meta<typeof TableHead> = {
+  title: 'Tables/TableHead',
+  component: TableHead,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The column-header band for list shells that are not a `<table>`. PIMS grew five of these by hand and they drifted apart, so one page could show three header sizes over the same `--screen-2` band. `Consistency` below is the story that matters: it renders the real `<table>` header beside every shell variant, so any future drift shows up as a Chromatic diff rather than as a bug report.',
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof TableHead>;
+
+const COLUMNS = [
+  { key: 'name', label: 'Name' },
+  { key: 'role', label: 'Role' },
+  { key: 'speciality', label: 'Speciality' },
+  { key: 'status', label: 'Status' },
+  { key: 'actions', label: '' },
+];
+
+const TRACK = '1.6fr 1fr 1fr 110px 44px';
+
+const Row = ({ track }: { track: string }) => (
+  <div
+    className="grid items-center border-b border-[var(--hairline)] px-5 py-3 text-[14px] text-[var(--ink-body)]"
+    style={{ gridTemplateColumns: track, gap: '10px' }}
+  >
+    <span>Dr. Smith</span>
+    <span>Veterinarian</span>
+    <span>Cardiology</span>
+    <span>Available</span>
+    <span aria-hidden="true" />
+  </div>
+);
+
+export const Default: Story = {
+  args: { columns: COLUMNS, track: TRACK },
+  render: (args) => (
+    <div className="TableShell">
+      <TableHead {...args} />
+      <Row track={args.track} />
+      <Row track={args.track} />
+    </div>
+  ),
+};
+
+export const NotSticky: Story = {
+  name: 'Inside a drawer (not sticky)',
+  args: { columns: COLUMNS, track: TRACK, sticky: false },
+  render: (args) => (
+    <div className="TableShell">
+      <TableHead {...args} />
+      <Row track={args.track} />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Side modals and drawers are transformed containers, so `position: sticky` resolves against the wrong ancestor and strands the band mid-panel. Pass `sticky={false}` there.',
+      },
+    },
+  },
+};
+
+export const RightAligned: Story = {
+  name: 'Numeric columns',
+  args: {
+    columns: [
+      { key: 'item', label: 'Item' },
+      { key: 'qty', label: 'Qty', align: 'right' as const },
+      { key: 'gross', label: 'Gross', align: 'right' as const },
+      { key: 'amount', label: 'Amount', align: 'right' as const },
+    ],
+    track: 'minmax(0,1.7fr) 72px 130px 120px',
+  },
+  render: (args) => (
+    <div className="TableShell">
+      <TableHead {...args} />
+    </div>
+  ),
+};
+
+/**
+ * The regression guard. If a shell's header ever drifts from the table's, these
+ * two bands stop matching and Chromatic flags the diff.
+ */
+export const Consistency: StoryObj = {
+  name: 'Consistency — table vs shell',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The real `<table>` header and the shell header, stacked. They must be indistinguishable: same 10.5px/700, same 0.1em tracking, same `--screen-2` band, same closing hairline. A visual diff here is the drift this component exists to prevent.',
+      },
+    },
+  },
+  render: () => (
+    <div className="flex flex-col gap-6">
+      <div>
+        <p className="mb-2 text-[12px] text-[var(--ink-faint)]">
+          GenericTable — real &lt;table&gt;
+        </p>
+        <GenericTable
+          data={[{ name: 'Dr. Smith', role: 'Veterinarian', speciality: 'Cardiology' }]}
+          columns={[
+            { key: 'name', label: 'Name' },
+            { key: 'role', label: 'Role' },
+            { key: 'speciality', label: 'Speciality' },
+          ]}
+        />
+      </div>
+      <div>
+        <p className="mb-2 text-[12px] text-[var(--ink-faint)]">TableHead — grid shell</p>
+        <div className="TableShell">
+          <TableHead
+            columns={[
+              { key: 'name', label: 'Name' },
+              { key: 'role', label: 'Role' },
+              { key: 'speciality', label: 'Speciality' },
+            ]}
+            track="1.6fr 1fr 1fr"
+          />
+          <Row track="1.6fr 1fr 1fr" />
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/apps/frontend/src/app/ui/tables/TableHead.tsx
+++ b/apps/frontend/src/app/ui/tables/TableHead.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+
+import './GenericTable/Generictable.css';
+
+export type TableHeadColumn = {
+  /** Stable key; also used when the label is blank (spacer/action columns). */
+  key: string;
+  label: string;
+  align?: 'left' | 'right' | 'center';
+};
+
+export type TableHeadProps = {
+  columns: ReadonlyArray<TableHeadColumn>;
+  /**
+   * `grid-template-columns` track. Must be the SAME value the rows below use,
+   * or the header labels stop lining up with their columns.
+   */
+  track: string;
+  /**
+   * Sticky by default, matching `.TableDiv thead tr th`. Pass false inside a
+   * drawer or a transformed parent, where sticky resolves against the wrong
+   * container and strands the band mid-panel.
+   */
+  sticky?: boolean;
+  /** Layout-only extras (breakpoint prefixes, min-width, scroll hooks). */
+  className?: string;
+  gap?: string;
+};
+
+const alignClass: Record<NonNullable<TableHeadColumn['align']>, string> = {
+  left: '',
+  right: 'text-right',
+  center: 'text-center',
+};
+
+/**
+ * The column-header band for list shells that are not a `<table>`.
+ *
+ * PIMS grew four of these by hand - the Organisation Team/Rooms grid, the
+ * Specialities services grid, the inventory grid shell and the companions grid
+ * - and they drifted apart, so a single page could show three header sizes over
+ * the same `--screen-2` band. The appearance lives in `.yc-table-head`, kept
+ * byte-for-byte in step with `.TableDiv thead tr th`; this component exists so
+ * callers reach for markup instead of copying a class string, which is how the
+ * drift happened. A real `<table>` should use GenericTable instead of this.
+ *
+ * Deliberately carries NO ARIA table roles. `role="columnheader"` requires a
+ * `role="table"`/`grid` ancestor, and the rows these shells render alongside are
+ * plain divs - announcing a header for a table a screen reader cannot then
+ * navigate is worse than announcing nothing. Giving these shells real table
+ * semantics means marking up the rows too, which is a larger change than a
+ * shared header band.
+ */
+const TableHead = ({
+  columns,
+  track,
+  sticky = true,
+  className = '',
+  gap = '10px',
+}: TableHeadProps) => (
+  <div
+    className={`yc-table-head ${sticky ? '' : 'yc-table-head--static'} grid items-center ${className}`.trim()}
+    style={{ gridTemplateColumns: track, gap }}
+  >
+    {columns.map((col) =>
+      col.label ? (
+        <span key={col.key} className={alignClass[col.align ?? 'left']}>
+          {col.label}
+        </span>
+      ) : (
+        // Spacer columns (avatars, row actions) hold their track without
+        // announcing an empty header to a screen reader.
+        <span key={col.key} aria-hidden="true" />
+      )
+    )}
+  </div>
+);
+
+export default TableHead;

--- a/apps/frontend/src/app/ui/tokens.md
+++ b/apps/frontend/src/app/ui/tokens.md
@@ -14,8 +14,17 @@ For the shared UI overview see [`README.md`](./README.md); for the full componen
 
 ## Colors
 
-- Use `--color-*` tokens for all UI colors.
-- Semantic aliases live under `--color-text-*`, `--color-surface-*`, `--color-border-*`, `--color-action-*`, `--color-status-*`, `--color-input-*`.
+Two layers, both live:
+
+- **`@theme` (`--color-*`)** - what Tailwind utilities compile against, e.g. `text-blue-text`, `bg-card-hover`. Semantic aliases live under `--color-text-*`, `--color-surface-*`, `--color-border-*`, `--color-action-*`, `--color-status-*`, `--color-input-*`.
+- **Warm-bone runtime (`--blue`, `--ink`, `--screen`, `--hairline`, ...)** - used by `var(--x)` and arbitrary values such as `text-[var(--ink-muted)]`. These outnumber `--color-*` in the app about 3:1.
+
+Rules:
+
+- Use whichever layer the surrounding code uses; neither is deprecated.
+- **Where one concept has both spellings, alias - never hold a literal in both.** `--blue-text: var(--color-blue-text)`. Hand-maintaining both is how the utility form kept resolving to a sub-AA colour after the variable form was fixed.
+- **A fill token is not a text token.** `--blue` is a fill and has no contrast duty of its own; `--blue-text` must clear 4.5:1 on the bone surfaces. Using a fill as text (or a text token as a fill) is the most common colour bug in this app.
+- **A fill under white text has two duties**: 4.5:1 for the label, and 3:1 against its own surface, because a selected control may drop its border and let the fill alone carry the state. `--blue-strong` exists for this and is the only value that satisfies both in each theme.
 - Never hardcode hex values in components. Use a CSS variable or a Tailwind token class.
 
 ## Component status labels

--- a/apps/frontend/src/app/ui/widgets/DashboardProfile/DashboardProfile.tsx
+++ b/apps/frontend/src/app/ui/widgets/DashboardProfile/DashboardProfile.tsx
@@ -30,7 +30,7 @@ const DashboardProfile = () => {
     <div className="flex w-full flex-col gap-3">
       <div className="flex w-full flex-wrap items-end justify-between gap-4">
         <div className="flex flex-col gap-0.5">
-          <span className="font-newsreader text-[16px] italic" style={{ color: 'var(--pink)' }}>
+          <span className="font-newsreader text-[16px] italic text-[var(--blue-text)]">
             Welcome back,
           </span>
           <span className="flex items-center gap-[9px]">

--- a/apps/frontend/src/app/ui/widgets/Labels/Labels.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/Labels/Labels.stories.tsx
@@ -38,7 +38,7 @@ const meta = {
       description: {
         component:
           'Tab-style navigation pills. Supports a two-level hierarchy with sub-labels. ' +
-          '`statuses` map lets you show green/red dots on specific tabs (e.g. form validation state).',
+          '`statuses` map marks specific tabs with a check or alert icon (e.g. form validation state).',
       },
     },
   },
@@ -92,7 +92,8 @@ export const WithStatuses: Story = {
   parameters: {
     docs: {
       description: {
-        story: 'Green dot = valid, red dot = error. Used to show form section completion state.',
+        story:
+          'Check icon = valid, alert icon = error. Distinct shapes, not just hues, so the state survives greyscale and colour-blind vision. Used to show form section completion state.',
       },
     },
   },

--- a/apps/frontend/src/app/ui/widgets/Labels/Labels.tsx
+++ b/apps/frontend/src/app/ui/widgets/Labels/Labels.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { IoAlertCircle, IoCheckmarkCircle } from 'react-icons/io5';
 import SubLabels from '@/app/ui/widgets/Labels/SubLabels';
 import { useWheelToHorizontalScroll } from '@/app/hooks/useWheelToHorizontalScroll';
 
@@ -65,11 +66,25 @@ const Labels = ({
           >
             <span className="flex items-center justify-center gap-1.5 text-center w-full">
               {label.name}
+              {/* Shape, not just hue: --success and --danger differ by 0.0005 in
+                  relative luminance, so in greyscale (or to a red-green
+                  colourblind user) a saved section and a failed one were the
+                  same dot. */}
               {statuses[label.key] === 'valid' && (
-                <span className="text-sm text-[var(--success)]">•</span>
+                <IoCheckmarkCircle
+                  role="img"
+                  title="Section complete"
+                  aria-label="Section complete"
+                  className="size-4 shrink-0 text-[var(--color-pill-success-text)]"
+                />
               )}
               {statuses[label.key] === 'error' && (
-                <span className="text-sm text-[var(--danger)]">•</span>
+                <IoAlertCircle
+                  role="img"
+                  title="Section has errors"
+                  aria-label="Section has errors"
+                  className="size-4 shrink-0 text-[var(--color-pill-danger-text)]"
+                />
               )}
             </span>
           </button>

--- a/apps/frontend/src/app/ui/widgets/Labels/SubLabels.tsx
+++ b/apps/frontend/src/app/ui/widgets/Labels/SubLabels.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Link from 'next/link';
-import { IoOpenOutline } from 'react-icons/io5';
+import { IoAlertCircle, IoCheckmarkCircle, IoOpenOutline } from 'react-icons/io5';
 
 type SubLabelItem = {
   key: string;
@@ -105,7 +105,7 @@ const SubLabels = ({
         const disabledClass = disableClicking ? 'opacity-70 cursor-not-allowed' : '';
         const activeClass =
           activeLabel === label.key
-            ? 'bg-neutral-0! text-(--color-primary-700)! border-text-brand!'
+            ? 'bg-neutral-0! text-[var(--ink)]! border-text-brand!'
             : 'text-black-text border-transparent hover:bg-neutral-0';
         const isLogoOnlyWithRedirect = isLogoOnlyIdexx && Boolean(label.redirectHref);
         const hasEmbeddedRedirect = Boolean(label.redirectHref);
@@ -139,9 +139,21 @@ const SubLabels = ({
               <span className="flex items-center justify-center gap-2 text-center w-full">
                 {label.name}
                 {statuses[label.key] === 'valid' && (
-                  <span className="text-green-600 text-sm">•</span>
+                  <IoCheckmarkCircle
+                    role="img"
+                    title="Section complete"
+                    aria-label="Section complete"
+                    className="size-4 shrink-0 text-[var(--color-pill-success-text)]"
+                  />
                 )}
-                {statuses[label.key] === 'error' && <span className="text-red-500 text-sm">•</span>}
+                {statuses[label.key] === 'error' && (
+                  <IoAlertCircle
+                    role="img"
+                    title="Section has errors"
+                    aria-label="Section has errors"
+                    className="size-4 shrink-0 text-[var(--color-pill-danger-text)]"
+                  />
+                )}
               </span>
             </button>
             {label.redirectHref && !disableClicking && (


### PR DESCRIPTION
## What changed

Started from one report - the dashboard's "Welcome back," greeting reads pink, and pink belongs to the pet-owner app. The sweep behind it found the same root cause in a dozen places: **fill tokens were being used as text colours**, and raw palette literals were used where a theme token was needed.

### `--blue-text` now earns its name

In dark it already lightened to `#8fb6f5` so it could be read on the espresso page. In light it was left **identical to `--blue`** (`#257bed`), which measures under AA on every bone surface, across ~150 usages:

| surface | before | after (`--color-accent-deep` `#1657c9`) |
|---|---|---|
| `--page` | 3.36:1 ❌ | **5.32:1** ✅ |
| `--screen` | 3.70:1 ❌ | **5.86:1** ✅ |
| `--screen-2` | 3.45:1 ❌ | **5.46:1** ✅ |
| `--band` | 3.12:1 ❌ | **4.94:1** ✅ |
| `--inset` | 3.18:1 ❌ | **5.04:1** ✅ |

Dark is untouched. `--blue` stays `#257bed` as the fill token - fills carry no contrast requirement of their own.

### Accent rule

`globals.css` states it: *"blue structural everywhere, pink = Pet Parents, cyan = Developers"*.

**Pink that is decoration on PIMS chrome moves to blue:** both greetings, the notification bell badge at each breakpoint, the chat pin glyphs, and the conversation-list selection rail. The bell keyframe is renamed `ycPulsePink` -> `ycPulseDot`, because a pink-named keyframe tinting a blue dot is how the pink comes back.

The greeting measured **1.69:1** before - effectively invisible. It is now 5.32:1 light / 8.20:1 dark, verified in a browser.

### Pink that stays pink - do not "fix" these later

Each one is gated on pet-parent meaning, and several are test-pinned:

| Site | Why |
|---|---|
| `CompanionsTable` `CoParentPill` | gated on `hasCoParent` - pink IS the second-parent identity |
| `CompanionHistoryPage` "· shared care" | the co-parent qualifier |
| `ServicesTab` "In app" | bookable by the parent in their own app |
| `TaskBoard` / `TaskFilterBar` / `TaskSlot` / `TaskWeekAgenda` / `Tasks` | all gated on `audience === 'PARENT_TASK'` |
| `TaskAssigneeChips` | pink vs blue IS the two-way audience encoding |
| `ActivityPanel` actor chip | fires only on `actorType === 'PARENT'` |
| Forms signature field | the row is labelled "signed in the pet-parent app" |
| Notifications pink disc/dot | marks the pet-parent chat row |
| `PetParents` marketing page | the canonical pink surface |

Two of these were using `--pink` - a **fill**, identical in both themes - as text at 1.86:1. They move to `--pink-text`. **Stated honestly: that is 3.88:1 in light, a large improvement but still short of AA.** `--pink-text` is the darkest pink text token that exists, so closing that gap needs a new colour and a design call - flagged rather than invented.

### Literals that cannot invert

- `text-red-600` at **seven** inline-error sites (3.08:1 in dark) -> `text-text-error`
- `text-green-700` at three confirmations -> `text-pill-success-text`
- the IDEXX census card's `bg-green-50` -> `bg-pill-success-bg`
- the task day-calendar's `bg-red-500` now-marker, which disagreed with **its own label one line above** and with the week view -> `danger-700`
- `hover:bg-gray-100` / `hover:bg-red-50` in the form builder (the `gray-*` scale is not remapped, so a dark-mode hover flashed near-white and swallowed its own icon)
- three `rgba(255,255,255,...)` tooltip separators that were **invisible in light mode** - the tooltip bubble is a light surface
- a hardcoded selection glow that never brightened in dark

`--hairline-hover` was used rather than `--divider` on two of those: `--divider` is heavier than `--hairline` in light but *lighter* in dark, which would invert the Total-row hierarchy.

### White text on a text token

Six fills used `bg-blue-text` / `bg-text-brand` under `text-white`. Those flip to `#8fb6f5` in dark, leaving white at **2.06:1**. Moved to `--blue`: light is pixel-identical, dark rises to 4.09:1.

### Colour as the only signal

`--success` and `--danger` differ by **0.0005 in relative luminance** - literally the same shade in greyscale. A saved form section and a failed one were the same dot. They are now a check icon and an alert icon with accessible names.

### One wrong-signal bug

The Turnover KPI painted its delta success-green unconditionally, so a **fall** in stock turnover was reported in the colour of good news. The colour now follows the same comparison the arrow already used.

## Why

Reported as pink text in PIMS that should be blue. The hue was the visible symptom; the cause was tokens used against their purpose, which also left a dozen values unreadable in one theme or the other.

## Impact area

`apps/frontend` - `globals.css` token, 6 accent sites, 20 token/literal fixes, 2 accessibility signals, 1 KPI correctness fix. 34 files.

## Validation performed

- `type-check` clean, `lint` clean
- **full** frontend suite: **911 suites, 11,228 tests, all passing**
- New tests for the status-icon shapes (the previous tests never passed `statuses`); verified non-vacuous by restoring the colour-only dots and confirming failure
- Updated the Slotpicker test and the Labels story prose that pinned the old values
- Browser-verified against computed style in both themes: greeting 5.32:1 light / 8.20:1 dark; `--pink-text` 3.88:1 light / 8.92:1 dark

## Note for review

This **overrides the canonical design files**, which do specify pink for the greetings, bell badge and chat pins (`PIMS - Dashboard.dc.html:116`, `PIMS Foundations.dc.html:107`, `PIMS - Chat Extended.dc.html:86/138/379`). That is deliberate and per the product owner's direction that pink belongs to the pet-owner app; it is not a correction of a deviation. The design sources should be updated to match.