### PR TITLE
fix(frontend): resolve the tsconfig paths in the Storybook production build

### DIFF
--- a/apps/frontend/.storybook/main.ts
+++ b/apps/frontend/.storybook/main.ts
@@ -13,9 +13,9 @@ const config: StorybookConfig = {
     name: '@storybook/nextjs-vite',
     options: {},
   },
-  docs: {
-    autodocs: 'tag',
-  },
+  // No `docs.autodocs`: it was removed in Storybook 9 (this repo is on 10.5.7),
+  // so it was inert config that also failed type-check as soon as a test
+  // imported this file. Autodocs come from the `autodocs` tag on a story.
   /**
    * Mirror the tsconfig `paths` for the production build.
    *
@@ -30,8 +30,20 @@ const config: StorybookConfig = {
    */
   viteFinal: (viteConfig) => {
     viteConfig.resolve = viteConfig.resolve ?? {};
+    // Vite accepts either form, and the framework hands us the OBJECT one: it
+    // arrives holding styled-jsx's preset aliases. Treating a non-array as
+    // empty would silently drop those while fixing the `@/` paths, so both
+    // forms are normalised to entries before appending.
+    const existing = viteConfig.resolve.alias;
+    const inherited = Array.isArray(existing)
+      ? existing
+      : Object.entries(existing ?? {}).map(([find, replacement]) => ({
+          find,
+          replacement: replacement as string,
+        }));
+
     viteConfig.resolve.alias = [
-      ...(Array.isArray(viteConfig.resolve.alias) ? viteConfig.resolve.alias : []),
+      ...inherited,
       { find: /^@\/features\//, replacement: `${path.join(src, 'app/features')}/` },
       { find: /^@\/ui\//, replacement: `${path.join(src, 'app/ui')}/` },
       { find: /^@\/lib\//, replacement: `${path.join(src, 'app/lib')}/` },

--- a/apps/frontend/.storybook/main.ts
+++ b/apps/frontend/.storybook/main.ts
@@ -1,4 +1,10 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import type { StorybookConfig } from '@storybook/nextjs-vite';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const src = path.resolve(here, '../src');
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.stories.@(ts|tsx)'],
@@ -9,6 +15,30 @@ const config: StorybookConfig = {
   },
   docs: {
     autodocs: 'tag',
+  },
+  /**
+   * Mirror the tsconfig `paths` for the production build.
+   *
+   * The dev server resolves `@/...` fine, so this looked healthy locally, but
+   * `storybook:build` failed with `Rollup failed to resolve import
+   * "@/app/ui/primitives/Buttons"` - which meant Chromatic could never publish.
+   * The check had been skipping on a missing `CHROMATIC_CONFIGURED`, so nothing
+   * surfaced the breakage until the gate was switched on.
+   *
+   * Order matters: the more specific aliases must precede the bare `@/`, or it
+   * swallows them. They are kept byte-for-byte in step with tsconfig.json.
+   */
+  viteFinal: async (viteConfig) => {
+    viteConfig.resolve = viteConfig.resolve ?? {};
+    viteConfig.resolve.alias = [
+      ...(Array.isArray(viteConfig.resolve.alias) ? viteConfig.resolve.alias : []),
+      { find: /^@\/features\//, replacement: `${path.join(src, 'app/features')}/` },
+      { find: /^@\/ui\//, replacement: `${path.join(src, 'app/ui')}/` },
+      { find: /^@\/lib\//, replacement: `${path.join(src, 'app/lib')}/` },
+      { find: /^@\/constants\//, replacement: `${path.join(src, 'app/constants')}/` },
+      { find: /^@\//, replacement: `${src}/` },
+    ];
+    return viteConfig;
   },
   staticDirs: [
     { from: '../public/fonts', to: '/fonts' },

--- a/apps/frontend/.storybook/main.ts
+++ b/apps/frontend/.storybook/main.ts
@@ -28,7 +28,7 @@ const config: StorybookConfig = {
    * Order matters: the more specific aliases must precede the bare `@/`, or it
    * swallows them. They are kept byte-for-byte in step with tsconfig.json.
    */
-  viteFinal: async (viteConfig) => {
+  viteFinal: (viteConfig) => {
     viteConfig.resolve = viteConfig.resolve ?? {};
     viteConfig.resolve.alias = [
       ...(Array.isArray(viteConfig.resolve.alias) ? viteConfig.resolve.alias : []),

--- a/apps/frontend/src/app/__tests__/storybook/mainViteAlias.test.ts
+++ b/apps/frontend/src/app/__tests__/storybook/mainViteAlias.test.ts
@@ -1,0 +1,61 @@
+/**
+ * `viteFinal` must preserve whatever aliases the framework already set.
+ *
+ * Storybook hands the hook `resolve.alias` as an OBJECT holding styled-jsx's
+ * preset aliases. An earlier version treated any non-array as empty, which
+ * fixed the `@/` paths while silently dropping those - the kind of breakage
+ * that shows up later as one story failing to render, far from its cause.
+ */
+import config from '../../../../.storybook/main';
+
+type AliasEntry = { find: string | RegExp; replacement: string };
+
+const run = (alias: unknown) => {
+  // ViteFinal is (config, options); the hook ignores options, so the cast goes
+  // through unknown rather than pretending the signature is narrower.
+  const viteFinal = config.viteFinal as unknown as (c: { resolve?: { alias?: unknown } }) => {
+    resolve: { alias: AliasEntry[] };
+  };
+  return viteFinal({ resolve: { alias } }).resolve.alias;
+};
+
+const finds = (out: AliasEntry[]) => out.map((a) => String(a.find));
+
+describe('.storybook viteFinal alias handling', () => {
+  it('keeps framework aliases supplied in object form', () => {
+    const out = run({ 'styled-jsx/style': '/preset/styled-jsx-style.js' });
+
+    expect(out.some((a) => a.find === 'styled-jsx/style')).toBe(true);
+    expect(out.find((a) => a.find === 'styled-jsx/style')?.replacement).toBe(
+      '/preset/styled-jsx-style.js'
+    );
+  });
+
+  it('keeps framework aliases supplied in array form', () => {
+    const out = run([{ find: /^preset$/, replacement: '/preset/entry.js' }]);
+
+    expect(finds(out)).toContain('/^preset$/');
+  });
+
+  it('adds the tsconfig paths on top of whatever was inherited', () => {
+    const out = finds(run({ 'styled-jsx/style': '/preset/styled-jsx-style.js' }));
+
+    for (const p of ['@\\/features\\/', '@\\/ui\\/', '@\\/lib\\/', '@\\/constants\\/']) {
+      expect(out.some((f) => f.includes(p))).toBe(true);
+    }
+  });
+
+  it('orders the specific prefixes before the bare @/ so it cannot swallow them', () => {
+    const out = finds(run(undefined));
+    const bare = out.findIndex((f) => f === '/^@\\//');
+
+    expect(bare).toBeGreaterThan(-1);
+    for (const specific of ['features', 'ui', 'lib', 'constants']) {
+      expect(out.findIndex((f) => f.includes(specific))).toBeLessThan(bare);
+    }
+  });
+
+  it('copes with no inherited aliases at all', () => {
+    expect(run(undefined).length).toBe(5);
+  });
+});


### PR DESCRIPTION
## What changed

`storybook:build` has been failing on dev with:

```
[vite]: Rollup failed to resolve import "@/app/ui/primitives/Buttons"
```

`viteFinal` now mirrors `tsconfig.json`'s `paths`, with the specific prefixes ordered before the bare `@/` so it cannot swallow them.

## Why this went unnoticed

The Chromatic job gates on `vars.CHROMATIC_CONFIGURED`, which was unset - so the check reported **skipped**, not red. A broken build was hiding behind a disabled gate. Enabling the gate surfaced it on the first run.

The dev server resolves `@/...` fine, which is why Storybook looked healthy locally; only the Rollup production pass needed the aliases spelled out.

## This is pre-existing

Confirmed, not inferred: the same build fails identically at `29d9de3bf`, the commit before both #2214 and #2215.

```
$ git checkout 29d9de3bf && pnpm run storybook:build
[vite]: Rollup failed to resolve import "@/app/ui/primitives/Buttons"
ELIFECYCLE  Command failed with exit code 1.
```

## Impact

Until this lands, Chromatic cannot publish at all - so there is no visual regression coverage on any frontend change, and the recent design work (~35 restyled files across #2214 and #2215) has had none.

## Validation performed

- `pnpm run storybook:build` - **exit code 0**, zero resolve failures, 242 stories indexed
- All four `Tables/TableHead` stories present, including `Consistency`, which stacks the real table header against the shell header so drift shows as a diff
- `type-check` clean, `lint` clean

## Note

The first Chromatic run after this will surface a large baseline for approval, since nothing has ever been snapshotted. That is the baseline being established, not regressions.