### PR TITLE
fix(frontend): make the faint ink ramp readable

### DIFF
--- a/apps/frontend/.storybook/preview.ts
+++ b/apps/frontend/.storybook/preview.ts
@@ -61,10 +61,22 @@ const preview: Preview = {
         document.documentElement.setAttribute('data-theme', theme);
       }
 
+      // PIMS scopes its readable faint inks to `body:has([data-yc-app])`,
+      // because the public marketing pages need the lighter values for their
+      // always-dark --spot panels. Without the marker here, every story renders
+      // the MARKETING values - so Storybook showed PIMS components with inks
+      // that are unreadable in the product, and Chromatic could never catch a
+      // regression in the scoped tokens. Marketing stories opt out with
+      // `parameters: { surface: 'marketing' }`.
+      // The selector matches a DESCENDANT, so the marker goes on this wrapper
+      // rather than on <body> itself.
+      const marketing = context.parameters?.surface === 'marketing';
+
       return React.createElement(
         'main',
         {
           'aria-labelledby': 'storybook-story-title',
+          ...(marketing ? {} : { 'data-yc-app': '' }),
         },
         React.createElement(
           'h1',

--- a/apps/frontend/AGENTS.md
+++ b/apps/frontend/AGENTS.md
@@ -56,14 +56,27 @@ less text, or a larger size, or a different surface.
 
 That 4.56 ramp is the **app** value. The faint inks are the one deliberately
 two-valued pair in the palette: PIMS gets `#66635f` under
-`body:has([data-yc-app])`, while `:root` keeps `#9d9285` for the marketing
+`body:has([data-yc-app])`, while `:root` keeps `#8f8984` for the marketing
 pages, whose `--spot` sections are always dark and would drop to 2.85:1 if
-darkened. Two consequences, both of which have already shipped as bugs: the
-hook is on `body` via `:has()` because overlays `createPortal` out of the shell,
-and the whole `@theme` alias closure (`--color-neutral-600` and everything
-downstream) must be re-declared with it, since an alias resolves where it is
-declared - on `:root` - and will not recompute just because its dependency
-changed lower down. See `src/app/ui/tokens.md` for the table and the guard.
+darkened. Three consequences, all of which have already shipped as bugs:
+
+1. **The hook is on `body` via `:has()`**, not on the shell element, because
+   overlays `createPortal` out of the shell and would keep the wrong value.
+2. **The TEXT-SEMANTIC aliases must be re-declared with the inks**, since an
+   alias resolves where it is declared - on `:root` - and will not recompute
+   just because its dependency changed lower down. That is
+   `--color-text-tertiary`, `--color-text-extra`, `--color-grey-text`,
+   `--color-grey-bg`, `--black-grey`. The RAW ramp steps
+   (`--color-neutral-500` / `-600`) are deliberately **left alone**: they also
+   back `border-neutral-500` and the scrollbar thumb, so scoping them would
+   darken borders to fix text. Text belongs on a `--color-text-*` token, never
+   on a raw ramp step - `appScopeAliasClosure.test.ts` enforces both halves.
+3. **Opacity composites text too.** A faint ink that passes at full strength
+   fails behind `opacity`, and the ramp bottoms out with no headroom: at 0.45
+   `#66635f` is 1.81:1 on `--band`, and no alpha below 1.0 gets it back to 4.5.
+   Recede a control with a lighter INK, not with opacity.
+
+See `src/app/ui/tokens.md` for the value table and the guard.
 
 **Column headers come from one recipe.** `<GenericTable>` for real tabular
 markup; `<TableHead>` (`src/app/ui/tables/TableHead.tsx`) for grid or flex

--- a/apps/frontend/AGENTS.md
+++ b/apps/frontend/AGENTS.md
@@ -45,6 +45,15 @@ var(--color-blue-text)`), because a token maintained by hand in both places
 drifts: `--color-blue-text` sat at `var(--blue)` and kept resolving to a
 sub-AA value after `--blue-text` had been fixed.
 
+**Every ink token must clear AA on the DARKEST surface it can land on.** The
+bone palette's darkest is `--band` (#e8e0d2), not `--screen`, so checking
+against `--screen` alone passes things that fail in the wild. The light ramp is
+`--ink` > `--ink-body` > `--ink-soft` > `--ink-muted` (5.31) > `--ink-faint`
+(4.56, the lightest value the palette allows at AA). There is no room below
+`--ink-faint` - `--ink-faint2` is the same value for exactly that reason. If you
+want text fainter than `--ink-faint`, the answer is not a lighter ink; it is
+less text, or a larger size, or a different surface.
+
 **Column headers come from one recipe.** `<GenericTable>` for real tabular
 markup; `<TableHead>` (`src/app/ui/tables/TableHead.tsx`) for grid or flex
 shells. Do not hand-roll a `--screen-2` band with uppercase micro-type - PIMS

--- a/apps/frontend/AGENTS.md
+++ b/apps/frontend/AGENTS.md
@@ -54,6 +54,17 @@ against `--screen` alone passes things that fail in the wild. The light ramp is
 want text fainter than `--ink-faint`, the answer is not a lighter ink; it is
 less text, or a larger size, or a different surface.
 
+That 4.56 ramp is the **app** value. The faint inks are the one deliberately
+two-valued pair in the palette: PIMS gets `#66635f` under
+`body:has([data-yc-app])`, while `:root` keeps `#9d9285` for the marketing
+pages, whose `--spot` sections are always dark and would drop to 2.85:1 if
+darkened. Two consequences, both of which have already shipped as bugs: the
+hook is on `body` via `:has()` because overlays `createPortal` out of the shell,
+and the whole `@theme` alias closure (`--color-neutral-600` and everything
+downstream) must be re-declared with it, since an alias resolves where it is
+declared - on `:root` - and will not recompute just because its dependency
+changed lower down. See `src/app/ui/tokens.md` for the table and the guard.
+
 **Column headers come from one recipe.** `<GenericTable>` for real tabular
 markup; `<TableHead>` (`src/app/ui/tables/TableHead.tsx`) for grid or flex
 shells. Do not hand-roll a `--screen-2` band with uppercase micro-type - PIMS

--- a/apps/frontend/src/app/(routes)/(app)/layout.tsx
+++ b/apps/frontend/src/app/(routes)/(app)/layout.tsx
@@ -13,7 +13,15 @@ export default async function AppLayout({ children }: Readonly<AppLayoutProps>) 
   return (
     <>
       <ThemeScript />
-      <SessionInitializer>{children}</SessionInitializer>
+      {/* `display: contents` so this introduces no box and cannot disturb the
+          height chains beneath it, while still passing the scoped faint-ink
+          custom properties down - see [data-yc-app] in globals.css. PIMS sits
+          on bone surfaces where the global faint inks are unreadable; the
+          public marketing pages need the lighter values for their always-dark
+          --spot panels, so the two cannot share one value. */}
+      <div data-yc-app style={{ display: 'contents' }}>
+        <SessionInitializer>{children}</SessionInitializer>
+      </div>
     </>
   );
 }

--- a/apps/frontend/src/app/(routes)/(public)/accessibility/report/AccessibilityReportClient.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/accessibility/report/AccessibilityReportClient.tsx
@@ -115,7 +115,7 @@ export default function AccessibilityReportClient() {
 
   if (submitted) {
     return (
-      <>
+      <div data-yc-app style={{ display: 'contents' }}>
         <main id="main-content" tabIndex={-1} className="mx-auto max-w-2xl px-6 pt-22 pb-16">
           <output
             aria-live="polite"
@@ -139,14 +139,19 @@ export default function AccessibilityReportClient() {
           </output>
         </main>
         <Footer />
-      </>
+      </div>
     );
   }
 
   const hasErrors = Object.keys(errors).length > 0;
 
   return (
-    <>
+    // A bone product surface outside the (app) layout, so it opts into the
+    // readable faint inks itself - see body:has([data-yc-app]) in globals.css.
+    // Without it the shared Footer's links resolve the root #8f8984, which is
+    // 3.04:1 on this page's --color-brand-100 band. `display: contents` keeps
+    // it out of the box tree.
+    <div data-yc-app style={{ display: 'contents' }}>
       <main id="main-content" tabIndex={-1} className="mx-auto max-w-2xl px-6 pt-22 pb-16">
         <nav aria-label="Breadcrumb" className="mb-6">
           <ol className="flex items-center gap-2 text-body-4 text-text-secondary list-none p-0 m-0">
@@ -269,6 +274,6 @@ export default function AccessibilityReportClient() {
         </form>
       </main>
       <Footer />
-    </>
+    </div>
   );
 }

--- a/apps/frontend/src/app/(routes)/(public)/payment-status/PaymentStatusContent.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/payment-status/PaymentStatusContent.tsx
@@ -158,7 +158,14 @@ export function PaymentStatusContent() {
     requestState === 'error' || requestState === 'missing_session' ? 'alert' : 'status';
 
   return (
-    <div className="min-h-[max(720px,100vh)] flex items-center justify-center px-4 pt-22 pb-10 bg-[radial-gradient(circle_at_10%_10%,rgba(250,238,210,0.6),transparent_45%),radial-gradient(circle_at_90%_20%,rgba(210,235,248,0.6),transparent_45%),radial-gradient(circle_at_50%_90%,rgba(215,245,230,0.7),transparent_50%)]">
+    // A light product surface outside the (app) layout, reached by both
+    // /payment-status and /success, so it needs the readable faint inks of its
+    // own - see body:has([data-yc-app]) in globals.css. Without the marker the
+    // `text-text-tertiary` line below sits at 3.45:1 even on white.
+    <div
+      data-yc-app
+      className="min-h-[max(720px,100vh)] flex items-center justify-center px-4 pt-22 pb-10 bg-[radial-gradient(circle_at_10%_10%,rgba(250,238,210,0.6),transparent_45%),radial-gradient(circle_at_90%_20%,rgba(210,235,248,0.6),transparent_45%),radial-gradient(circle_at_50%_90%,rgba(215,245,230,0.7),transparent_50%)]"
+    >
       <div className="w-full max-w-xl bg-white/80 border border-card-border rounded-2xl px-6 py-10">
         <div className="flex flex-col items-center text-center gap-4">
           <div className="relative flex items-center justify-center size-24 rounded-full">

--- a/apps/frontend/src/app/(routes)/(public)/payment-status/PaymentStatusContent.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/payment-status/PaymentStatusContent.tsx
@@ -164,6 +164,7 @@ export function PaymentStatusContent() {
     // `text-text-tertiary` line below sits at 3.45:1 even on white.
     <div
       data-yc-app
+      data-yc-surface="light"
       className="min-h-[max(720px,100vh)] flex items-center justify-center px-4 pt-22 pb-10 bg-[radial-gradient(circle_at_10%_10%,rgba(250,238,210,0.6),transparent_45%),radial-gradient(circle_at_90%_20%,rgba(210,235,248,0.6),transparent_45%),radial-gradient(circle_at_50%_90%,rgba(215,245,230,0.7),transparent_50%)]"
     >
       <div className="w-full max-w-xl bg-white/80 border border-card-border rounded-2xl px-6 py-10">

--- a/apps/frontend/src/app/__tests__/components/tasks/TaskBoard.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/tasks/TaskBoard.test.tsx
@@ -474,16 +474,21 @@ describe('TaskBoard', () => {
       ] as any,
     });
 
-    // Design: completed cards strike through; cancelled cards only dim.
+    // Design: completed cards strike through; both recede through INK, not
+    // opacity. Dimming the card composited its text-text-tertiary meta line to
+    // 3.16:1 (done) and 2.61:1 (cancelled) on a card that is still clickable,
+    // and the title already carries the recede.
     const doneTitle = screen.getByText('Done Task').closest('div');
     expect(doneTitle!.className).toContain('line-through');
+    expect(doneTitle!.className).toContain('text-text-tertiary');
     const voidTitle = screen.getByText('Void Task').closest('div');
     expect(voidTitle!.className).not.toContain('line-through');
+    expect(voidTitle!.className).toContain('text-text-tertiary');
 
     const doneCard = screen.getByRole('button', { name: 'Open task Done Task' }).closest('article');
-    expect(doneCard).toHaveClass('opacity-70');
+    expect(doneCard!.className).not.toMatch(/\bopacity-\d/);
     const voidCard = screen.getByRole('button', { name: 'Open task Void Task' }).closest('article');
-    expect(voidCard).toHaveClass('opacity-60');
+    expect(voidCard!.className).not.toMatch(/\bopacity-\d/);
     // Completed / cancelled → canShowTaskStatusChangeAction is false → not draggable.
     expect(doneCard).toHaveAttribute('draggable', 'false');
     expect(voidCard).toHaveAttribute('draggable', 'false');

--- a/apps/frontend/src/app/__tests__/components/tasks/TaskWeekAgenda.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/tasks/TaskWeekAgenda.test.tsx
@@ -219,8 +219,11 @@ describe('TaskWeekAgenda', () => {
     expect(parentCard.getAttribute('style')).toContain('var(--pink)');
     expect(screen.getByText(/^Parent task/)).toBeInTheDocument();
 
+    // Completed recedes through line-through and its own --status-completed-*
+    // palette, NOT by dimming the card: the card stays clickable and every text
+    // descendant is on a faint token, so 0.75 sank the meta line to 3.23:1.
     const doneCard = screen.getByRole('button', { name: 'Open task Done Task' });
-    expect(doneCard).toHaveClass('opacity-75');
+    expect(doneCard.className).not.toMatch(/\bopacity-\d/);
     expect(screen.getByText('Done Task').parentElement?.className).toContain('line-through');
   });
 

--- a/apps/frontend/src/app/__tests__/ui/tokens/appScopeAliasClosure.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/tokens/appScopeAliasClosure.test.ts
@@ -206,17 +206,55 @@ describe('faint-ink alias closure is mirrored into the app scope', () => {
     const FAINT_TEXT =
       /--ink-faint2?\)|--color-text-tertiary\)|--color-text-extra\)|\btext-text-tertiary\b|--status-[a-z]+-text\)/;
 
+    /**
+     * Dims inside a faint-text component that are NOT over faint text. Keyed by
+     * file and opacity value rather than line number - a line key goes stale the
+     * moment anything above it moves, and a stale key silently re-hides a real
+     * defect. Each was read individually; the reason is what clears it.
+     */
+    const CLEARED: Record<string, string> = {
+      'features/appointments/components/AppointmentBoardCard.tsx::60': 'isDragging - transient',
+      'features/tasks/components/TaskBoard.tsx::60': 'isDragging - transient',
+      'ui/inputs/Dropdown/Dropdown.tsx::60':
+        'gated on the prop that sets the real disabled attribute',
+      'features/integrations/pages/MerckManuals/index.tsx::70': 'fieldset carries disabled',
+      'features/appointments/pages/Appointments/Sections/AppointmentInfo/AppointmentMerckSearch.tsx::70':
+        'audience toggle, disabled',
+      'features/onboarding/components/Steps/TeamOnboarding/AvailabilityStep.tsx::70':
+        'unsupported consultation types - disabled',
+      'features/appointments/components/Calendar/responsive/PhoneMyDayRail.tsx::60':
+        'span is --ink (15:1), not a faint token',
+      'features/appointments/pages/Appointments/Sections/ViewAppointmentOverviewModal/index.tsx::60':
+        'pointer-events-none saving wrapper around a dropdown, no faint text of its own',
+      'features/appointments/pages/Appointments/Sections/AddAppointmentCentralModal/index.tsx::25':
+        'aria-hidden spinner geometry',
+      'features/appointments/pages/Appointments/Sections/AddAppointmentCentralModal/index.tsx::75':
+        'aria-hidden spinner geometry',
+      'features/forms/pages/Forms/Sections/AddForm/components/BuildWrapper.tsx::50':
+        'drag-handle icon glyph, no text',
+    };
+
     for (const file of tsx) {
-      const lines = fs.readFileSync(path.join(root, file), 'utf8').split('\n');
+      const source = fs.readFileSync(path.join(root, file), 'utf8');
+      // FILE-level, not line-level. Opacity composites descendants too, and a
+      // same-line rule cannot see that: TaskBoard dimmed the whole card while
+      // its meta line used text-text-tertiary three hundred lines away, so the
+      // guard passed over 3.16:1 text. If a component paints faint text
+      // anywhere, every dim inside it is suspect until named otherwise.
+      if (!FAINT_TEXT.test(source)) continue;
+      const lines = source.split('\n');
       lines.forEach((line, i) => {
-        if (!FAINT_TEXT.test(line)) return;
         // `cursor-not-allowed` marks the disabled branch of a clsx ternary,
         // where the element also carries a real `disabled` attribute a few
         // lines up - an inactive control, exempt under WCAG 1.4.3.
         if (/cursor-not-allowed/.test(line)) return;
+        // Transient interaction feedback while the pointer moves an element,
+        // like a keyframe step rather than a state anyone reads.
+        if (/isDragging|is-dragging|dragging/i.test(line)) return;
         for (const m of line.matchAll(/(^|[\s"'`:])opacity-(\d{1,3})\b/g)) {
           if (m[1].endsWith(':')) continue; // hover: / disabled: / group-hover:
           if (Number(m[2]) >= 100 || Number(m[2]) === 0) continue; // 0 = hidden
+          if (`${file}::${m[2]}` in CLEARED) continue;
           offenders.push(`${file}:${i + 1}  faint text + opacity-${m[2]}`);
         }
       });

--- a/apps/frontend/src/app/__tests__/ui/tokens/appScopeAliasClosure.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/tokens/appScopeAliasClosure.test.ts
@@ -171,19 +171,47 @@ describe('faint-ink alias closure is mirrored into the app scope', () => {
     expect(mismatches).toEqual([]);
   });
 
-  it('has no text component reaching for the raw ramp steps', () => {
-    // `text-neutral-500` was the call site that exposed the whole bug. The ramp
-    // steps are not scoped, so a text utility built on one silently opts out of
-    // the readable ink.
-    const files = fs
-      .readdirSync(path.join(process.cwd(), 'src/app'), { recursive: true, encoding: 'utf8' })
-      .filter((f) => f.endsWith('.tsx') && !f.includes('__tests__') && !f.includes('.stories.'));
+  it('has nothing painting text with a raw neutral ramp step', () => {
+    // `text-neutral-500` in the chat panes is what exposed the whole bug, and
+    // the first version of this guard only looked for that one shape - Tailwind
+    // classes, in .tsx. That missed stylesheets (`color: var(--color-neutral-600)`)
+    // and inline styles, which is most of them. All three forms are checked now.
+    //
+    // Only TEXT positions count. The same tokens are legitimate as backgrounds,
+    // borders, dividers and scrollbar thumbs, and are deliberately left light
+    // there, so `background:`/`border:`/`scrollbar-color:` are not matched.
+    // Only the FAINT band. The ramp runs dark-to-light, and 700-900 (and
+    // neutral-0 on dark surfaces) are legitimate text colours - it is 300-600
+    // that lands in the unreadable range on bone and is not scoped.
+    const FAINT = '(?:300|400|500|600)';
+    const TEXT_USES = [
+      new RegExp(`(?:^|[^-\\w])color:\\s*var\\(--color-neutral-${FAINT}\\)`), // CSS + inline styles
+      new RegExp(`color=["']var\\(--color-neutral-${FAINT}\\)["']`), // react-icons style prop
+      new RegExp(`\\btext-neutral-${FAINT}\\b`), // Tailwind utility
+    ];
 
-    const offenders = files.filter((f) =>
-      /\btext-neutral-(500|600)\b/.test(
-        fs.readFileSync(path.join(process.cwd(), 'src/app', f), 'utf8')
-      )
-    );
+    /** Text on a DARK surface wants the light end of the ramp; that is correct. */
+    const ON_DARK_SURFACE = new Set([
+      'features/appointments/pages/AppointmentWorkspace/components/PackageBreakdownTooltip.tsx',
+    ]);
+
+    const root = path.join(process.cwd(), 'src/app');
+    const files = fs
+      .readdirSync(root, { recursive: true, encoding: 'utf8' })
+      .filter((f) => /\.(tsx|css)$/.test(f))
+      .filter((f) => !f.includes('__tests__') && !f.includes('.stories.'))
+      .filter((f) => !ON_DARK_SURFACE.has(f))
+      // globals.css is where the ramp is DEFINED; its own declarations are not uses.
+      .filter((f) => f !== 'globals.css');
+
+    const offenders: string[] = [];
+    for (const file of files) {
+      const lines = fs.readFileSync(path.join(root, file), 'utf8').split('\n');
+      lines.forEach((line, i) => {
+        if (line.trimStart().startsWith('*') || line.trimStart().startsWith('//')) return;
+        if (TEXT_USES.some((re) => re.test(line))) offenders.push(`${file}:${i + 1}`);
+      });
+    }
 
     expect(offenders).toEqual([]);
   });

--- a/apps/frontend/src/app/__tests__/ui/tokens/appScopeAliasClosure.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/tokens/appScopeAliasClosure.test.ts
@@ -188,6 +188,39 @@ describe('faint-ink alias closure is mirrored into the app scope', () => {
       .filter((f) => f.endsWith('.css') && !f.includes('/marketing/'));
 
     const offenders: string[] = [];
+
+    // Tailwind can dim from the markup too, which a stylesheet-only scan cannot
+    // see: `text-[var(--ink-faint)] ... opacity-70` on the calendar minute
+    // labels composited to 2.94:1 across five calendar views while this test
+    // passed. State-prefixed utilities are exempt - `hover:` raises contrast
+    // back on release, and `disabled:` is an inactive control.
+    const tsx = fs
+      .readdirSync(root, { recursive: true, encoding: 'utf8' })
+      .filter((f) => f.endsWith('.tsx') && !f.includes('__tests__') && !f.includes('.stories.'))
+      .filter((f) => !f.includes('/marketing/'));
+
+    // Narrowed to the actual defect: an opacity utility on the SAME element as a
+    // faint text token. A dimmed icon or a dimmed container is a different
+    // question; what breaks here is faint text dimmed further, which is what
+    // the calendar minute labels were doing.
+    const FAINT_TEXT =
+      /--ink-faint2?\)|--color-text-tertiary\)|--color-text-extra\)|\btext-text-tertiary\b|--status-[a-z]+-text\)/;
+
+    for (const file of tsx) {
+      const lines = fs.readFileSync(path.join(root, file), 'utf8').split('\n');
+      lines.forEach((line, i) => {
+        if (!FAINT_TEXT.test(line)) return;
+        // `cursor-not-allowed` marks the disabled branch of a clsx ternary,
+        // where the element also carries a real `disabled` attribute a few
+        // lines up - an inactive control, exempt under WCAG 1.4.3.
+        if (/cursor-not-allowed/.test(line)) return;
+        for (const m of line.matchAll(/(^|[\s"'`:])opacity-(\d{1,3})\b/g)) {
+          if (m[1].endsWith(':')) continue; // hover: / disabled: / group-hover:
+          if (Number(m[2]) >= 100 || Number(m[2]) === 0) continue; // 0 = hidden
+          offenders.push(`${file}:${i + 1}  faint text + opacity-${m[2]}`);
+        }
+      });
+    }
     for (const file of files) {
       const lines = fs.readFileSync(path.join(root, file), 'utf8').split('\n');
       lines.forEach((line, i) => {

--- a/apps/frontend/src/app/__tests__/ui/tokens/appScopeAliasClosure.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/tokens/appScopeAliasClosure.test.ts
@@ -128,6 +128,49 @@ describe('faint-ink alias closure is mirrored into the app scope', () => {
     );
   });
 
+  it('documents the real faint values in tokens.md', () => {
+    // The table in tokens.md is what the next person reads before choosing an
+    // ink, and it was wrong on its first outing: it listed the root light value
+    // as the dark one and claimed both themes matched. A doc that states four
+    // specific hexes can be checked, so it is.
+    const doc = fs.readFileSync(path.join(process.cwd(), 'src/app/ui/tokens.md'), 'utf8');
+
+    const chunkFor = (scope: 'root' | 'scoped', theme: 'light' | 'dark') => {
+      if (scope === 'scoped') return CSS.match(theme === 'light' ? APP_SCOPE : APP_SCOPE_DARK)![1];
+      const before = CSS.slice(0, CSS.indexOf('body:has([data-yc-app])'));
+      const cut = before.indexOf("html[data-theme='dark']");
+      return theme === 'light' ? before.slice(0, cut) : before.slice(cut);
+    };
+    const declared = (chunk: string, token: string) =>
+      [...chunk.matchAll(new RegExp(`^\\s*${token}:\\s*([^;]+);`, 'gm'))].at(-1)?.[1].trim();
+
+    // | scope | --token | light | dark |
+    const rows = [
+      ...doc.matchAll(
+        // The scope cell carries a prose tail after the selector, e.g.
+        // "`:root` (public marketing pages)", so allow anything up to the pipe.
+        /^\|\s*`([^`]+)`[^|]*\|\s*`(--ink-faint2?)`\s*\|\s*`(#[0-9a-f]{6})`\s*\|\s*`(#[0-9a-f]{6})`\s*\|/gim
+      ),
+    ];
+    expect(rows.length).toBe(4);
+
+    const mismatches: string[] = [];
+    for (const [, scopeLabel, token, light, dark] of rows) {
+      const scope = scopeLabel.startsWith(':root') ? 'root' : 'scoped';
+      for (const [theme, documented] of [
+        ['light', light],
+        ['dark', dark],
+      ] as const) {
+        const actual = declared(chunkFor(scope, theme), token);
+        if (actual !== documented) {
+          mismatches.push(`${scopeLabel} ${token} ${theme}: doc ${documented}, css ${actual}`);
+        }
+      }
+    }
+
+    expect(mismatches).toEqual([]);
+  });
+
   it('has no text component reaching for the raw ramp steps', () => {
     // `text-neutral-500` was the call site that exposed the whole bug. The ramp
     // steps are not scoped, so a text utility built on one silently opts out of

--- a/apps/frontend/src/app/__tests__/ui/tokens/appScopeAliasClosure.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/tokens/appScopeAliasClosure.test.ts
@@ -1,5 +1,6 @@
 /**
- * The app scope must re-declare the whole ALIAS CLOSURE of the faint inks.
+ * The app scope must cover the whole ALIAS CLOSURE of the faint inks, and must
+ * cover it by ALIASING rather than by copying the hex.
  *
  * `--ink-faint` is darkened for PIMS under `body:has([data-yc-app])`, but the
  * `@theme` layer aliases it (`--color-neutral-600: var(--ink-faint)`) and those
@@ -8,9 +9,14 @@
  * recompute the ancestor's alias - `text-neutral-500` in the chat panes went on
  * resolving the old #a9a39e long after the short token had been fixed.
  *
- * Chasing that chain by hand is exactly how it broke, so this walks it from the
- * stylesheet instead: anything reachable from the faint inks must be re-stated
- * inside both scoped blocks, or be named in NON_TEXT below with a reason.
+ * Two ways that fix can rot, so both are checked here:
+ *   1. a NEW alias is added to the chain and nobody re-declares it in the scope
+ *   2. a scoped declaration holds its own hex literal, which then goes stale
+ *      the next time either ink moves - the exact utility/runtime mismatch the
+ *      change exists to prevent
+ *
+ * Chasing the chain by hand is how it broke in the first place, so the closure
+ * is re-derived from the stylesheet on every run rather than hard-coded.
  */
 import fs from 'node:fs';
 import path from 'node:path';
@@ -18,11 +24,22 @@ import path from 'node:path';
 const CSS = fs.readFileSync(path.join(process.cwd(), 'src/app/globals.css'), 'utf8');
 
 /**
- * Reachable from the faint inks but NOT text, so deliberately left on the
- * global value: darkening a border is a visible change with no contrast
- * argument behind it (borders owe 3:1 only as non-text UI, which these meet).
+ * Reachable from the faint inks but deliberately NOT re-declared in the scope.
+ * Every entry needs a reason, because each one is a token that stays light
+ * inside PIMS.
  */
-const NON_TEXT = new Set(['--color-grey-border', '--greyborder']);
+const NOT_SCOPED: Record<string, string> = {
+  // Borders, not text. Darkening them is a visible change with no contrast
+  // argument behind it (they meet the 3:1 non-text bar already).
+  '--color-grey-border': 'border token (OtpModal, UploadImage)',
+  '--greyborder': 'border token (OtpModal, UploadImage)',
+  // Raw ramp steps rather than text semantics. neutral-500 also backs
+  // `border-neutral-500` in three components and the scrollbar thumb, so
+  // bending it would darken outlines and scrollbars to fix text. Text callers
+  // use the semantic --color-text-* tokens, which ARE scoped.
+  '--color-neutral-500': 'ramp step - also borders and the scrollbar thumb',
+  '--color-neutral-600': 'ramp step - text callers use --color-text-tertiary',
+};
 
 const ROOTS = ['--ink-faint', '--ink-faint2'];
 
@@ -55,34 +72,76 @@ const closure = () => {
   return [...seen];
 };
 
-const declaredIn = (block: RegExp) => {
+/** name -> declared value, for one scope block. */
+const declarationsIn = (block: RegExp) => {
   const found = CSS.match(block);
   if (!found) throw new Error(`scope block not found in globals.css: ${block}`);
-  return new Set([...found[1].matchAll(/^\s+(--[a-z0-9-]+):/gim)].map((m) => m[1]));
+  return new Map(
+    [...found[1].matchAll(/^\s+(--[a-z0-9-]+):\s*([^;]+);/gim)].map((m) => [m[1], m[2].trim()])
+  );
 };
+
+const SCOPES: ReadonlyArray<readonly [string, RegExp]> = [
+  ['light', APP_SCOPE],
+  ['dark', APP_SCOPE_DARK],
+];
 
 describe('faint-ink alias closure is mirrored into the app scope', () => {
   it('finds the chain at all (guards against the walker silently going blind)', () => {
-    expect(closure()).toEqual(expect.arrayContaining(['--color-neutral-600', '--black-grey']));
+    expect(closure()).toEqual(expect.arrayContaining(['--color-text-tertiary', '--black-grey']));
   });
 
-  it.each([
-    ['light', APP_SCOPE],
-    ['dark', APP_SCOPE_DARK],
-  ])('re-declares every text alias in the %s scope', (_label, block) => {
-    const declared = declaredIn(block);
-    const missing = closure().filter((t) => !NON_TEXT.has(t) && !declared.has(t));
+  it.each(SCOPES)('covers every reachable token in the %s scope', (_label, block) => {
+    const declared = declarationsIn(block);
+    const missing = closure().filter((t) => !(t in NOT_SCOPED) && !declared.has(t));
 
     expect(missing).toEqual([]);
   });
 
-  it('leaves the non-text tokens on their global value', () => {
-    const declared = declaredIn(APP_SCOPE);
+  it.each(SCOPES)('aliases rather than copying the hex in the %s scope', (_label, block) => {
+    const literals = [...declarationsIn(block)]
+      .filter(([name]) => !ROOTS.includes(name))
+      .filter(([, value]) => !value.startsWith('var('))
+      .map(([name, value]) => `${name}: ${value}`);
 
-    for (const token of NON_TEXT) expect(declared.has(token)).toBe(false);
+    expect(literals).toEqual([]);
+  });
+
+  it.each(SCOPES)('points every alias at one of the scoped inks in %s', (_label, block) => {
+    const strays = [...declarationsIn(block)]
+      .filter(([name]) => !ROOTS.includes(name))
+      .filter(([, value]) => !ROOTS.some((ink) => value.includes(`var(${ink})`)))
+      .map(([name, value]) => `${name}: ${value}`);
+
+    expect(strays).toEqual([]);
+  });
+
+  it('leaves the excluded tokens out of the scope entirely', () => {
+    const declared = declarationsIn(APP_SCOPE);
+
+    for (const token of Object.keys(NOT_SCOPED)) expect(declared.has(token)).toBe(false);
   });
 
   it('keeps the two scopes in step, so dark mode cannot drift', () => {
-    expect([...declaredIn(APP_SCOPE_DARK)].sort()).toEqual([...declaredIn(APP_SCOPE)].sort());
+    expect([...declarationsIn(APP_SCOPE_DARK).keys()].sort()).toEqual(
+      [...declarationsIn(APP_SCOPE).keys()].sort()
+    );
+  });
+
+  it('has no text component reaching for the raw ramp steps', () => {
+    // `text-neutral-500` was the call site that exposed the whole bug. The ramp
+    // steps are not scoped, so a text utility built on one silently opts out of
+    // the readable ink.
+    const files = fs
+      .readdirSync(path.join(process.cwd(), 'src/app'), { recursive: true, encoding: 'utf8' })
+      .filter((f) => f.endsWith('.tsx') && !f.includes('__tests__') && !f.includes('.stories.'));
+
+    const offenders = files.filter((f) =>
+      /\btext-neutral-(500|600)\b/.test(
+        fs.readFileSync(path.join(process.cwd(), 'src/app', f), 'utf8')
+      )
+    );
+
+    expect(offenders).toEqual([]);
   });
 });

--- a/apps/frontend/src/app/__tests__/ui/tokens/appScopeAliasClosure.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/tokens/appScopeAliasClosure.test.ts
@@ -191,8 +191,13 @@ describe('faint-ink alias closure is mirrored into the app scope', () => {
     for (const file of files) {
       const lines = fs.readFileSync(path.join(root, file), 'utf8').split('\n');
       lines.forEach((line, i) => {
-        const m = /^\s*opacity:\s*(0\.\d+)\s*;/.exec(line);
-        if (!m || Number(m[1]) >= 0.7) return;
+        // EVERY non-unit opacity, not a threshold. The first version of this
+        // stopped at 0.7 and so walked past `.yc-pwo-row--done { opacity: 0.75 }`,
+        // where --ink-faint labels still land at 3.23:1 on --screen. There is no
+        // safe cutoff: the faint inks pass by so little that any compositing at
+        // all can drop them under 4.5.
+        const m = /^\s*opacity:\s*(0?\.\d+|0)\s*;/.exec(line);
+        if (!m) return;
 
         // Walk back to the selector this declaration belongs to.
         let selector = '';
@@ -206,21 +211,21 @@ describe('faint-ink alias closure is mirrored into the app scope', () => {
           }
         }
         const exempt =
+          m[1] === '0' ||
+          m[1] === '0.0' || // fully hidden: nothing painted to read
           /disabled/i.test(selector) || // inactive component
           /^\d+%$|^from$|^to$/.test(selector) || // keyframe step
-          /indicator|::before|::after|scrollbar|shadow/i.test(selector); // decoration
+          // Decoration: rules, bars, skeleton placeholders, icons, pseudo-elements.
+          /divider|-sk-|skeleton|bar\b|icon|indicator|::before|::after|scrollbar|shadow/i.test(
+            selector
+          );
         if (!exempt) offenders.push(`${file}:${i + 1}  ${selector}`);
       });
     }
 
-    // Everything left must be a rule whose subtree paints no faint text. Each
-    // entry is a deliberate call, not a backlog.
-    expect(offenders).toEqual([
-      'features/developers/pages/DeveloperApiKeys/DeveloperApiKeys.css:138  .dev-keys-row.is-revoked',
-      'features/developers/pages/DeveloperWebsiteBuilder/DeveloperWebsiteBuilder.css:232  .dev-wb-sk-bar.is-faded',
-      'features/developers/pages/DeveloperWebsiteBuilder/DeveloperWebsiteBuilder.css:256  .dev-wb-sk-tile',
-      'features/onboarding/components/Steps/Progress/Progress.css:27  .yc-step-trigger.is-upcoming',
-    ]);
+    // Empty, and it should stay that way. Anything new either recedes through
+    // ink instead, or names itself as decoration / a disabled control.
+    expect(offenders).toEqual([]);
   });
 
   it('has nothing painting text with a raw neutral ramp step', () => {

--- a/apps/frontend/src/app/__tests__/ui/tokens/appScopeAliasClosure.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/tokens/appScopeAliasClosure.test.ts
@@ -171,6 +171,58 @@ describe('faint-ink alias closure is mirrored into the app scope', () => {
     expect(mismatches).toEqual([]);
   });
 
+  it('does not composite the faint inks under opacity', () => {
+    // Opacity applies to TEXT as well as decoration, and the faint end of the
+    // ramp has no headroom: #66635f at 0.45 is 1.81:1 on --band, and no alpha
+    // below 1.0 gets it back to 4.5. Two phone-calendar rules receded a whole
+    // cell that way while its label used a faint ink - on a tappable control in
+    // one case and an informational row in the other. A control should recede
+    // through a lighter INK, not through alpha.
+    //
+    // Disabled controls are exempt (WCAG 1.4.3 excludes inactive components),
+    // and so are keyframe steps, which are transient rather than a resting
+    // state.
+    const root = path.join(process.cwd(), 'src/app');
+    const files = fs
+      .readdirSync(root, { recursive: true, encoding: 'utf8' })
+      .filter((f) => f.endsWith('.css') && !f.includes('/marketing/'));
+
+    const offenders: string[] = [];
+    for (const file of files) {
+      const lines = fs.readFileSync(path.join(root, file), 'utf8').split('\n');
+      lines.forEach((line, i) => {
+        const m = /^\s*opacity:\s*(0\.\d+)\s*;/.exec(line);
+        if (!m || Number(m[1]) >= 0.7) return;
+
+        // Walk back to the selector this declaration belongs to.
+        let selector = '';
+        // Wide enough to clear a multi-line value: the header's decorative
+        // hairline sits 15 lines below its selector behind a linear-gradient().
+        for (let j = i - 1; j >= 0 && j > i - 40; j--) {
+          const t = lines[j].trim();
+          if (t.endsWith('{')) {
+            selector = t.slice(0, -1).trim();
+            break;
+          }
+        }
+        const exempt =
+          /disabled/i.test(selector) || // inactive component
+          /^\d+%$|^from$|^to$/.test(selector) || // keyframe step
+          /indicator|::before|::after|scrollbar|shadow/i.test(selector); // decoration
+        if (!exempt) offenders.push(`${file}:${i + 1}  ${selector}`);
+      });
+    }
+
+    // Everything left must be a rule whose subtree paints no faint text. Each
+    // entry is a deliberate call, not a backlog.
+    expect(offenders).toEqual([
+      'features/developers/pages/DeveloperApiKeys/DeveloperApiKeys.css:138  .dev-keys-row.is-revoked',
+      'features/developers/pages/DeveloperWebsiteBuilder/DeveloperWebsiteBuilder.css:232  .dev-wb-sk-bar.is-faded',
+      'features/developers/pages/DeveloperWebsiteBuilder/DeveloperWebsiteBuilder.css:256  .dev-wb-sk-tile',
+      'features/onboarding/components/Steps/Progress/Progress.css:27  .yc-step-trigger.is-upcoming',
+    ]);
+  });
+
   it('has nothing painting text with a raw neutral ramp step', () => {
     // `text-neutral-500` in the chat panes is what exposed the whole bug, and
     // the first version of this guard only looked for that one shape - Tailwind
@@ -185,7 +237,11 @@ describe('faint-ink alias closure is mirrored into the app scope', () => {
     // that lands in the unreadable range on bone and is not scoped.
     const FAINT = '(?:300|400|500|600)';
     const TEXT_USES = [
-      new RegExp(`(?:^|[^-\\w])color:\\s*var\\(--color-neutral-${FAINT}\\)`), // CSS + inline styles
+      // The quotes matter: a CSS file writes `color: var(--x)` but a style
+      // OBJECT writes `color: 'var(--x)'`, and the first version of this
+      // required var( immediately after the colon - so every inline style in
+      // the app walked straight past it.
+      new RegExp(`(?:^|[^-\\w])color:\\s*['"\`]?var\\(--color-neutral-${FAINT}\\)`), // CSS + inline styles
       new RegExp(`color=["']var\\(--color-neutral-${FAINT}\\)["']`), // react-icons style prop
       new RegExp(`\\btext-neutral-${FAINT}\\b`), // Tailwind utility
     ];

--- a/apps/frontend/src/app/__tests__/ui/tokens/appScopeAliasClosure.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/tokens/appScopeAliasClosure.test.ts
@@ -1,0 +1,88 @@
+/**
+ * The app scope must re-declare the whole ALIAS CLOSURE of the faint inks.
+ *
+ * `--ink-faint` is darkened for PIMS under `body:has([data-yc-app])`, but the
+ * `@theme` layer aliases it (`--color-neutral-600: var(--ink-faint)`) and those
+ * aliases are computed on `:root`. A custom property resolves where it is
+ * DECLARED, so overriding the dependency further down the tree does not
+ * recompute the ancestor's alias - `text-neutral-500` in the chat panes went on
+ * resolving the old #a9a39e long after the short token had been fixed.
+ *
+ * Chasing that chain by hand is exactly how it broke, so this walks it from the
+ * stylesheet instead: anything reachable from the faint inks must be re-stated
+ * inside both scoped blocks, or be named in NON_TEXT below with a reason.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+const CSS = fs.readFileSync(path.join(process.cwd(), 'src/app/globals.css'), 'utf8');
+
+/**
+ * Reachable from the faint inks but NOT text, so deliberately left on the
+ * global value: darkening a border is a visible change with no contrast
+ * argument behind it (borders owe 3:1 only as non-text UI, which these meet).
+ */
+const NON_TEXT = new Set(['--color-grey-border', '--greyborder']);
+
+const ROOTS = ['--ink-faint', '--ink-faint2'];
+
+const APP_SCOPE = /^body:has\(\[data-yc-app\]\)\s*\{([\s\S]*?)^\}/m;
+const APP_SCOPE_DARK = /^html\[data-theme='dark'\] body:has\(\[data-yc-app\]\)\s*\{([\s\S]*?)^\}/m;
+
+/** Declarations made at the root layers, which is where aliases get computed. */
+const rootAliasGraph = () => {
+  const beforeScopes = CSS.slice(0, CSS.search(APP_SCOPE));
+  const graph = new Map<string, string[]>();
+  for (const [, name, source] of beforeScopes.matchAll(
+    /^\s+(--[a-z0-9-]+):\s*var\((--[a-z0-9-]+)\)\s*;/gim
+  )) {
+    graph.set(source, [...(graph.get(source) ?? []), name]);
+  }
+  return graph;
+};
+
+const closure = () => {
+  const graph = rootAliasGraph();
+  const seen = new Set<string>();
+  const queue = [...ROOTS];
+  while (queue.length) {
+    for (const child of graph.get(queue.shift() as string) ?? []) {
+      if (seen.has(child)) continue;
+      seen.add(child);
+      queue.push(child);
+    }
+  }
+  return [...seen];
+};
+
+const declaredIn = (block: RegExp) => {
+  const found = CSS.match(block);
+  if (!found) throw new Error(`scope block not found in globals.css: ${block}`);
+  return new Set([...found[1].matchAll(/^\s+(--[a-z0-9-]+):/gim)].map((m) => m[1]));
+};
+
+describe('faint-ink alias closure is mirrored into the app scope', () => {
+  it('finds the chain at all (guards against the walker silently going blind)', () => {
+    expect(closure()).toEqual(expect.arrayContaining(['--color-neutral-600', '--black-grey']));
+  });
+
+  it.each([
+    ['light', APP_SCOPE],
+    ['dark', APP_SCOPE_DARK],
+  ])('re-declares every text alias in the %s scope', (_label, block) => {
+    const declared = declaredIn(block);
+    const missing = closure().filter((t) => !NON_TEXT.has(t) && !declared.has(t));
+
+    expect(missing).toEqual([]);
+  });
+
+  it('leaves the non-text tokens on their global value', () => {
+    const declared = declaredIn(APP_SCOPE);
+
+    for (const token of NON_TEXT) expect(declared.has(token)).toBe(false);
+  });
+
+  it('keeps the two scopes in step, so dark mode cannot drift', () => {
+    expect([...declaredIn(APP_SCOPE_DARK)].sort()).toEqual([...declaredIn(APP_SCOPE)].sort());
+  });
+});

--- a/apps/frontend/src/app/embed/merck-manuals/page.tsx
+++ b/apps/frontend/src/app/embed/merck-manuals/page.tsx
@@ -8,7 +8,14 @@ export const metadata: Metadata = {
 };
 
 function page() {
-  return <EmbeddedMerckManuals />;
+  // A product surface on bone, but outside the (app) layout, so it needs the
+  // readable-ink marker of its own - see body:has([data-yc-app]) in globals.css.
+  // `display: contents` keeps it out of the box tree.
+  return (
+    <div data-yc-app style={{ display: 'contents' }}>
+      <EmbeddedMerckManuals />
+    </div>
+  );
 }
 
 export default page;

--- a/apps/frontend/src/app/features/appointments/components/AppointmentCentralModal/AppointmentEstimatePanel.tsx
+++ b/apps/frontend/src/app/features/appointments/components/AppointmentCentralModal/AppointmentEstimatePanel.tsx
@@ -80,7 +80,7 @@ const AppointmentEstimatePanel = ({
             fontWeight: 700,
             lineHeight: '120%',
             letterSpacing: '-0.48px',
-            color: estimateIsReal ? 'var(--color-primary-600)' : 'var(--color-neutral-400)',
+            color: estimateIsReal ? 'var(--color-primary-600)' : 'var(--color-text-tertiary)',
             textAlign: 'right',
           }}
         >

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/AllDayEventsRow.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/AllDayEventsRow.tsx
@@ -70,7 +70,7 @@ const AllDayEventsRow = ({
               alt={''}
             />
             <span className="truncate max-w-40">{getCompanionDisplayName(ev)}</span>
-            <span className="opacity-75 truncate max-w-30 font-normal">{ev.concern || ''}</span>
+            <span className="truncate max-w-30 font-normal">{ev.concern || ''}</span>
           </button>
         );
       })}

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/CalendarHourLabel.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/CalendarHourLabel.tsx
@@ -41,7 +41,7 @@ const CalendarHourLabel: React.FC<CalendarHourLabelProps> = ({
       slotOffsetMinutes.map((minute) => (
         <span
           key={`slot-time-${hour}-${minute}`}
-          className="absolute right-[10px] -translate-y-1/2 text-[9.5px] leading-none tabular-nums text-[var(--ink-faint)] text-right whitespace-nowrap opacity-70"
+          className="absolute right-[10px] -translate-y-1/2 text-[9.5px] leading-none tabular-nums text-[var(--ink-faint)] text-right whitespace-nowrap"
           style={{ top: `${(minute / 60) * 100}%` }}
         >
           {formatMinuteLabel(hour * 60 + minute)}

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/StatusSubmenu.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/StatusSubmenu.tsx
@@ -39,7 +39,7 @@ const StatusSubmenu = ({
           >
             <span className="truncate">{toStatusLabel(status)}</span>
             {savingKey === `status-${status}` ? (
-              <span className="shrink-0 text-[8px] opacity-60">Saving</span>
+              <span className="shrink-0 text-[8px]">Saving</span>
             ) : null}
           </button>
         </React.Fragment>

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/ZoomInMarker.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/ZoomInMarker.tsx
@@ -55,9 +55,12 @@ const ZoomInMarker = ({
     ? 'cursor-grab active:cursor-grabbing'
     : 'cursor-pointer';
 
-  // Frame subtitle: 11px in the status text colour at 0.75 opacity.
+  // Frame subtitle: 11px in the status text colour. The frame asked for 0.75
+  // opacity, but these are --status-<x>-text tokens on their own fill, which
+  // only clear AA at full strength; font-normal against the title's weight is
+  // what separates them.
   const subtitleClass =
-    'truncate font-satoshi text-[11px] font-normal leading-[1.2] tracking-[-0.22px] opacity-75';
+    'truncate font-satoshi text-[11px] font-normal leading-[1.2] tracking-[-0.22px]';
   let subtitleNode: React.ReactNode = null;
   if (tall) {
     subtitleNode = (

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneDayRail.css
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneDayRail.css
@@ -146,7 +146,6 @@
   font-weight: 700;
   letter-spacing: 0.05em;
   color: var(--block-text);
-  opacity: 0.8;
   text-transform: uppercase;
 }
 
@@ -155,7 +154,6 @@
   margin-top: 2px;
   font-size: 10.5px;
   color: var(--block-text);
-  opacity: 0.75;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneDayStrip.css
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneDayStrip.css
@@ -31,9 +31,16 @@
   box-shadow: 0 6px 16px var(--glow-b26);
 }
 
-/* Frame: a day with no load recedes to 45%. */
-.yc-day-strip__cell--quiet {
-  opacity: 0.45;
+/* Frame: a day with no load recedes.
+   The frame said 45% opacity, but opacity composites the TEXT as well, and
+   this cell is a live tappable button: at 0.45 the 9px weekday landed at
+   1.81:1 on --band and the 14px date at 2.69:1, and no alpha below 1.0 gets
+   the weekday back to 4.5. So the recede is expressed in ink instead - the
+   date steps back to --ink-muted (5.31:1) while the weekday stays on the
+   faintest ink that still passes. The real "no load" signal is the dot row,
+   which a quiet day does not render at all. */
+.yc-day-strip__cell--quiet .yc-day-strip__date {
+  color: var(--ink-muted);
 }
 
 /* Frame: font-size 9px; font-weight 700; letter-spacing 0.06em; --ink-faint. */

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneMyDayRail.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneMyDayRail.tsx
@@ -99,7 +99,7 @@ const CompletedAppointmentCard = ({
       <span className="block truncate text-[11.5px] font-bold text-[var(--status-completed-text)]">
         {buildAppointmentTitle(entry.appointment)}
       </span>
-      <span className="block truncate text-[9.5px] text-[var(--status-completed-text)] opacity-75">
+      <span className="block truncate text-[9.5px] text-[var(--status-completed-text)]">
         {buildAppointmentSubtitle(entry)}
       </span>
     </span>
@@ -125,7 +125,7 @@ const UpcomingAppointmentCard = ({
       <span className="block truncate text-[11.5px] font-bold text-[var(--status-upcoming-text)]">
         {buildAppointmentTitle(entry.appointment)}
       </span>
-      <span className="block truncate text-[9.5px] text-[var(--status-upcoming-text)] opacity-75">
+      <span className="block truncate text-[9.5px] text-[var(--status-upcoming-text)]">
         {buildAppointmentSubtitle(entry)}
       </span>
     </span>

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneMyDayRail.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneMyDayRail.tsx
@@ -93,7 +93,7 @@ const CompletedAppointmentCard = ({
   <button
     type="button"
     onClick={() => onSelect?.(entry.appointment)}
-    className="flex flex-1 items-center gap-[9px] rounded-xl border border-l-[3px] border-[var(--status-completed-border)] bg-[var(--status-completed-bg)] px-[11px] py-[9px] text-left opacity-85"
+    className="flex flex-1 items-center gap-[9px] rounded-xl border border-l-[3px] border-[var(--status-completed-border)] bg-[var(--status-completed-bg)] px-[11px] py-[9px] text-left"
   >
     <span className="min-w-0 flex-1">
       <span className="block truncate text-[11.5px] font-bold text-[var(--status-completed-text)]">

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneWeekOverview.css
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneWeekOverview.css
@@ -140,10 +140,11 @@ button.yc-pwo-row {
   cursor: pointer;
 }
 
-/* A day already behind us recedes; a closed day recedes further. */
-.yc-pwo-row--done {
-  opacity: 0.75;
-}
+/* A day already behind us recedes; a closed day recedes further. Both do it
+   through ink alone - see the --dayofmonth and --summary rules below. The
+   opacity that used to sit here (0.75) composited the whole row on top of
+   that, taking --ink-faint labels to 3.23:1 on --screen and 2.90:1 on --band,
+   on rows that are still enabled buttons. */
 
 /* No opacity here. A closed row already recedes through ink - its day number
    drops to --ink-muted below - and stacking 0.5 on top composited the whole

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneWeekOverview.css
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneWeekOverview.css
@@ -145,9 +145,11 @@ button.yc-pwo-row {
   opacity: 0.75;
 }
 
-.yc-pwo-row--closed {
-  opacity: 0.5;
-}
+/* No opacity here. A closed row already recedes through ink - its day number
+   drops to --ink-muted below - and stacking 0.5 on top composited the whole
+   row instead: the summary text fell to 2.07:1 and the day number to 3.22:1.
+   The row is not a disabled control (a closed day renders as a plain <div>,
+   see PhoneWeekOverview.tsx), so its text owes the full 4.5:1. */
 
 .yc-pwo-row--selected {
   border: 1.5px solid var(--blue);

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/ViewAppointmentOverviewModal/index.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/ViewAppointmentOverviewModal/index.tsx
@@ -355,7 +355,7 @@ const OverviewRightColumn = ({
             className="font-satoshi text-2xl font-bold"
             style={{
               color:
-                estimateDisplay === '-' ? 'var(--color-neutral-500)' : 'var(--color-primary-600)',
+                estimateDisplay === '-' ? 'var(--color-text-tertiary)' : 'var(--color-primary-600)',
               letterSpacing: '-0.48px',
             }}
           >

--- a/apps/frontend/src/app/features/chat/components/ChatCommandPalette.tsx
+++ b/apps/frontend/src/app/features/chat/components/ChatCommandPalette.tsx
@@ -156,7 +156,7 @@ export function ChatCommandPalette({
                     >
                       {title}
                     </Text>
-                    <IoReturnDownBackOutline className="h-3.5 w-3.5 shrink-0 text-neutral-300" />
+                    <IoReturnDownBackOutline className="h-3.5 w-3.5 shrink-0 text-text-tertiary" />
                   </button>
                 </li>
               );

--- a/apps/frontend/src/app/features/chat/components/ChatContainer.css
+++ b/apps/frontend/src/app/features/chat/components/ChatContainer.css
@@ -527,5 +527,5 @@
 
 .chat-empty-state__subtitle {
   max-width: 360px;
-  color: var(--color-neutral-600);
+  color: var(--color-text-tertiary);
 }

--- a/apps/frontend/src/app/features/chat/components/ChatContainer.tsx
+++ b/apps/frontend/src/app/features/chat/components/ChatContainer.tsx
@@ -565,7 +565,7 @@ const ChatClosedFooter: FC<{ closedAt?: string }> = ({ closedAt }) => {
         Chat session closed
       </Text>
       {formattedClosedTime && (
-        <Text as="p" variant="caption-2" className="text-neutral-500">
+        <Text as="p" variant="caption-2" className="text-text-tertiary">
           {formattedClosedTime}
         </Text>
       )}
@@ -626,7 +626,7 @@ const ChatEmptyThread: FC = () => (
     <Text as="p" variant="body-3-emphasis" className="text-neutral-700">
       No messages yet
     </Text>
-    <Text as="p" variant="caption-1" className="text-neutral-500">
+    <Text as="p" variant="caption-1" className="text-text-tertiary">
       Send the first message to start the conversation.
     </Text>
   </div>
@@ -891,7 +891,11 @@ const ChatSidebarHeader: FC<ChatSidebarHeaderProps> = ({
                           {user.name}
                         </Text>
                         {user.email && (
-                          <Text as="span" variant="caption-2" className="truncate text-neutral-500">
+                          <Text
+                            as="span"
+                            variant="caption-2"
+                            className="truncate text-text-tertiary"
+                          >
                             {user.email}
                           </Text>
                         )}

--- a/apps/frontend/src/app/features/chat/components/MessageSearch.tsx
+++ b/apps/frontend/src/app/features/chat/components/MessageSearch.tsx
@@ -141,7 +141,7 @@ export function MessageSearch() {
                     <Text
                       as="span"
                       variant="caption-1"
-                      className="truncate text-[12px] text-neutral-500"
+                      className="truncate text-[12px] text-text-tertiary"
                     >
                       {message.text || 'Attachment'}
                     </Text>

--- a/apps/frontend/src/app/features/developers/pages/DeveloperApiKeys/DeveloperApiKeys.css
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperApiKeys/DeveloperApiKeys.css
@@ -134,8 +134,11 @@
   border-top: 1px solid var(--color-card-border);
 }
 
-.dev-keys-row.is-revoked {
-  opacity: 0.6;
+/* A revoked key is called out by its status cell, not by dimming the row: at
+   0.6 the row's --color-text-tertiary cells composited to about 2.5:1, and a
+   revoked row is informational text, not an inactive control. */
+.dev-keys-row.is-revoked .dev-key-name {
+  color: var(--ink-muted);
 }
 
 /* Just-created key row — tied visually to the reveal banner above it. */

--- a/apps/frontend/src/app/features/developers/pages/DeveloperDocs/DeveloperDocs.css
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperDocs/DeveloperDocs.css
@@ -36,13 +36,10 @@
   text-decoration: none;
 }
 
-.DocsOpenLink {
-  transition: opacity 0.15s ease;
-}
-
 .DocsOpenLink:hover {
+  /* The underline is the whole affordance. Dimming to 0.8 on top of it lowered
+     the link's contrast at exactly the moment the pointer was on it. */
   text-decoration: underline;
-  opacity: 0.8;
 }
 
 /* ---- Reader shell ---- */

--- a/apps/frontend/src/app/features/developers/pages/DeveloperSettings/DeveloperSettings.css
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperSettings/DeveloperSettings.css
@@ -208,7 +208,6 @@
   display: block;
   font-size: 11.5px;
   color: var(--danger-text);
-  opacity: 0.85;
 }
 
 .dev-danger-actions {

--- a/apps/frontend/src/app/features/marketing/site/AuthShell.tsx
+++ b/apps/frontend/src/app/features/marketing/site/AuthShell.tsx
@@ -311,7 +311,13 @@ export function AuthShell({ brand, topRight, children }: Readonly<AuthShellProps
         </div>
       </div>
 
+      {/* The form column is a bone surface (--page -> --band), so it needs the
+          readable faint inks - see body:has([data-yc-app]) in globals.css. The
+          marker goes here and NOT on the shell root: the brand panel to the left
+          is deliberately dark and wants the lighter values, exactly like the
+          marketing --spot sections. */}
       <div
+        data-yc-app
         style={{
           position: 'relative',
           background: 'linear-gradient(180deg, var(--page), var(--band))',

--- a/apps/frontend/src/app/features/onboarding/components/Steps/Progress/Progress.css
+++ b/apps/frontend/src/app/features/onboarding/components/Steps/Progress/Progress.css
@@ -23,9 +23,10 @@
 .yc-step-trigger.is-clickable {
   cursor: pointer;
 }
-.yc-step-trigger.is-upcoming {
-  opacity: 0.6;
-}
+/* No dim for `is-upcoming`. The trigger already carries :disabled whenever the
+   step is not selectable, and a disabled control is exempt from AA - but when
+   canSelectStep is not supplied the button stays ENABLED, and this rule then
+   dimmed a live control's label. */
 .yc-step-trigger:disabled {
   opacity: 0.6;
 }

--- a/apps/frontend/src/app/features/tasks/components/TaskBoard.tsx
+++ b/apps/frontend/src/app/features/tasks/components/TaskBoard.tsx
@@ -135,21 +135,19 @@ type TaskCardVisualFlags = {
   isDragging: boolean;
 };
 
-const getTaskCardClassName = ({
-  isParentTask,
-  isMuted,
-  isDone,
-  isCancelled,
-  isDragging,
-}: TaskCardVisualFlags): string =>
+const getTaskCardClassName = ({ isParentTask, isMuted, isDragging }: TaskCardVisualFlags): string =>
   clsx(
     'group/card relative w-full shrink-0 overflow-hidden rounded-[13px]! bg-neutral-0 px-3.5 py-3 text-left transition-colors flex flex-col items-stretch justify-start border',
     isParentTask
       ? 'border-[var(--pink)] shadow-[0_4px_12px_var(--glow-p12)]'
       : 'border-card-border',
     !isParentTask && !isMuted && 'shadow-[0_1px_2px_var(--sh03),0_6px_16px_var(--sh05)]',
-    isDone && 'opacity-70',
-    isCancelled && 'opacity-60',
+    // No opacity for done/cancelled: the card is a live onClick target, and its
+    // descendant meta line uses text-text-tertiary, which composited to 3.16:1
+    // at 0.70 and 2.61:1 at 0.60. Both states already recede in ink - the title
+    // goes text-text-tertiary (plus line-through for done) - and isMuted drops
+    // the shadow. Dragging keeps its dim: that is transient feedback while the
+    // pointer is moving the card, not a resting state anyone reads.
     isDragging
       ? 'opacity-60 shadow-none'
       : !isParentTask && 'hover:border-input-border-active! hover:bg-card-hover!'

--- a/apps/frontend/src/app/features/tasks/components/TaskWeekAgenda.tsx
+++ b/apps/frontend/src/app/features/tasks/components/TaskWeekAgenda.tsx
@@ -46,7 +46,6 @@ const AgendaCard = ({ task, isFutureDay, assigneeName, onOpen }: AgendaCardProps
   const variant = getTaskCardVariant(task, isFutureDay);
   const isParent = variant === 'parent';
   const isCompleted = task.status === 'COMPLETED';
-  const isMuted = isCompleted || task.status === 'CANCELLED';
   const style = getAgendaCardStyle(variant);
 
   const timeLabel = formatDateInPreferredTimeZone(new Date(task.dueAt), {
@@ -63,8 +62,12 @@ const AgendaCard = ({ task, isFutureDay, assigneeName, onOpen }: AgendaCardProps
       aria-label={`Open task ${task.name || '-'}`}
       onClick={() => onOpen(task)}
       className={clsx(
-        'w-full text-left rounded-[11px] border px-[11px] py-[9px] transition-transform hover:-translate-y-px',
-        isMuted && 'opacity-75'
+        // No dim for the muted state. The card stays clickable, and every text
+        // descendant is on a faint token: at 0.75 the --ink-faint meta fell to
+        // 3.23:1 and the status-token title to 3.86-4.03:1. Completed/cancelled
+        // already recede twice - line-through on the title, plus their own
+        // --status-* background, border and text family.
+        'w-full text-left rounded-[11px] border px-[11px] py-[9px] transition-transform hover:-translate-y-px'
       )}
       style={{
         background: style.background,
@@ -88,10 +91,7 @@ const AgendaCard = ({ task, isFutureDay, assigneeName, onOpen }: AgendaCardProps
         )}
         <span className="min-w-0 break-words">{task.name || '-'}</span>
       </span>
-      <span
-        className="mt-0.5 block text-[10px] leading-4"
-        style={{ color: style.metaColor, opacity: isParent ? 1 : 0.8 }}
-      >
+      <span className="mt-0.5 block text-[10px] leading-4" style={{ color: style.metaColor }}>
         {metaParts.join(' · ')}
       </span>
     </button>

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -1770,13 +1770,19 @@ html[data-theme='dark'] [data-yc-app] ::selection {
 
    Scoped rather than global: the public marketing pages put this same token on
    always-dark --spot panels, where the lighter value is the correct one.
+
+   The hook is `body:has([data-yc-app])`, not the shell element itself: modals,
+   dropdowns and row-action menus mount through createPortal into document.body,
+   so they are siblings of the shell rather than descendants and would have kept
+   the unreadable values. Marketing pages never render the shell, so body does
+   not match there and they are untouched.
    --ink-faint2 collapses onto --ink-faint here because between the 4.56 ceiling
    and --ink-muted there is no room for two passing steps below muted. */
-[data-yc-app] {
+body:has([data-yc-app]) {
   --ink-faint: #66635f;
   --ink-faint2: #66635f;
 }
-html[data-theme='dark'] [data-yc-app] {
+html[data-theme='dark'] body:has([data-yc-app]) {
   --ink-faint: #9d9285;
   --ink-faint2: #998f82;
 }

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -1781,31 +1781,39 @@ html[data-theme='dark'] [data-yc-app] ::selection {
 body:has([data-yc-app]) {
   --ink-faint: #66635f;
   --ink-faint2: #66635f;
-  /* The @theme layer aliases these, and those aliases are COMPUTED ON :root -
-     so overriding only the short tokens here leaves every alias consumer on the
-     old value. `text-neutral-500` in the chat panes kept resolving #a9a39e.
-     The transitive text closure is re-declared with them.
-     Deliberately excluded: --color-grey-border / --greyborder, which resolve
-     from the same inks but are borders, not text - darkening those would be a
-     visible change with no contrast argument behind it. */
-  --color-neutral-600: #66635f;
-  --color-neutral-500: #66635f;
-  --color-text-tertiary: #66635f;
-  --color-text-extra: #66635f;
-  --color-grey-text: #66635f;
-  --color-grey-bg: #66635f;
-  --black-grey: #66635f;
-  --black-grey-Text: #66635f;
+  /* The @theme layer aliases these inks, and those aliases are COMPUTED ON
+     :root - so overriding only the short tokens here leaves every alias
+     consumer on the old value.
+
+     These re-declarations are ALIASES, never literals. Every one is on this
+     same element as the inks above, so `var(--ink-faint)` resolves to the
+     scoped value; writing the hex again would be a fourth place to keep in
+     step, which is the drift this whole change exists to stop.
+
+     Only TEXT tokens appear here. Two groups are deliberately absent:
+       - --color-grey-border / --greyborder are borders (OtpModal,
+         UploadImage). Darkening a border is a visible change with no contrast
+         argument behind it.
+       - --color-neutral-500 / -600 are raw ramp steps, not text semantics.
+         neutral-500 also backs `border-neutral-500` in three components and
+         the scrollbar thumb at :216 and :245, so bending it here would darken
+         outlines and scrollbars to fix text. The handful of call sites that
+         reached for `text-neutral-500` directly now use `text-text-tertiary`
+         instead - the semantic token is the one that carries the guarantee. */
+  --color-text-tertiary: var(--ink-faint);
+  --color-text-extra: var(--ink-faint2);
+  --color-grey-text: var(--ink-faint);
+  --color-grey-bg: var(--ink-faint);
+  --black-grey: var(--ink-faint);
+  --black-grey-Text: var(--ink-faint);
 }
 html[data-theme='dark'] body:has([data-yc-app]) {
   --ink-faint: #9d9285;
   --ink-faint2: #998f82;
-  --color-neutral-600: #9d9285;
-  --color-neutral-500: #998f82;
-  --color-text-tertiary: #9d9285;
-  --color-text-extra: #998f82;
-  --color-grey-text: #9d9285;
-  --color-grey-bg: #9d9285;
-  --black-grey: #9d9285;
-  --black-grey-Text: #9d9285;
+  --color-text-tertiary: var(--ink-faint);
+  --color-text-extra: var(--ink-faint2);
+  --color-grey-text: var(--ink-faint);
+  --color-grey-bg: var(--ink-faint);
+  --black-grey: var(--ink-faint);
+  --black-grey-Text: var(--ink-faint);
 }

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -1781,8 +1781,31 @@ html[data-theme='dark'] [data-yc-app] ::selection {
 body:has([data-yc-app]) {
   --ink-faint: #66635f;
   --ink-faint2: #66635f;
+  /* The @theme layer aliases these, and those aliases are COMPUTED ON :root -
+     so overriding only the short tokens here leaves every alias consumer on the
+     old value. `text-neutral-500` in the chat panes kept resolving #a9a39e.
+     The transitive text closure is re-declared with them.
+     Deliberately excluded: --color-grey-border / --greyborder, which resolve
+     from the same inks but are borders, not text - darkening those would be a
+     visible change with no contrast argument behind it. */
+  --color-neutral-600: #66635f;
+  --color-neutral-500: #66635f;
+  --color-text-tertiary: #66635f;
+  --color-text-extra: #66635f;
+  --color-grey-text: #66635f;
+  --color-grey-bg: #66635f;
+  --black-grey: #66635f;
+  --black-grey-Text: #66635f;
 }
 html[data-theme='dark'] body:has([data-yc-app]) {
   --ink-faint: #9d9285;
   --ink-faint2: #998f82;
+  --color-neutral-600: #9d9285;
+  --color-neutral-500: #998f82;
+  --color-text-tertiary: #9d9285;
+  --color-text-extra: #998f82;
+  --color-grey-text: #9d9285;
+  --color-grey-bg: #9d9285;
+  --black-grey: #9d9285;
+  --black-grey-Text: #9d9285;
 }

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -598,19 +598,13 @@ textarea:focus-visible {
      5.87:1 light / 6.34:1 dark. */
   --table-head-ink: var(--ink-muted);
   --ink-soft: #423f3c;
-  /* Both were unreadable as text: #8f8984 measured 2.64:1 and #a9a39e 1.90:1
-     against the darkest bone surface (--band), across ~476 usages - nav labels,
-     metadata lines, counts, weekday labels, empty states. #66635f is the
-     LIGHTEST warm grey on this ramp that still clears 4.5:1 everywhere (4.56),
-     so it stays as faint as the palette allows while remaining legible, and
-     stays lighter than --ink-muted (5.31) so the hierarchy survives.
-
-     --ink-faint2 takes the same value: with the ceiling at 4.56 and --ink-muted
-     at 5.31 there is not enough headroom for two distinct sub-muted steps that
-     both pass. The second step was never readable, so it is folded into the
-     first rather than kept as a decorative fiction. */
-  --ink-faint: #66635f;
-  --ink-faint2: #66635f;
+  /* The bone palette's faint inks. These values are correct on the always-dark
+     --spot sections the marketing pages use (6.82:1) but unreadable on bone:
+     2.64:1 and 1.90:1 against --band. They are therefore left alone here and
+     overridden for the app shell below, rather than darkened globally - which
+     would have fixed PIMS and broken every --spot section on the public site. */
+  --ink-faint: #8f8984;
+  --ink-faint2: #a9a39e;
   --ink-6b: #6b6763;
   /* primary CTA (dark fill on light) */
   --cta: #302f2e;
@@ -763,9 +757,7 @@ html[data-theme='dark'] {
   --ink-muted: #a89e90;
   --ink-soft: #cabfb0;
   --ink-faint: #9d9285;
-  /* #8b8173 was 3.78:1 on the espresso surfaces; #998f82 is the darkest value
-     that clears 4.5 (4.56). --ink-faint already passes at 4.75 and is unchanged. */
-  --ink-faint2: #998f82;
+  --ink-faint2: #8b8173;
   --ink-6b: #a1968a;
   --cta: #f2ece1;
   --cta-hover: #fbf8f1;
@@ -883,9 +875,7 @@ html[data-theme='dark'] {
   --ink-muted: #a89e90;
   --ink-soft: #cabfb0;
   --ink-faint: #9d9285;
-  /* #8b8173 was 3.78:1 on the espresso surfaces; #998f82 is the darkest value
-     that clears 4.5 (4.56). --ink-faint already passes at 4.75 and is unchanged. */
-  --ink-faint2: #998f82;
+  --ink-faint2: #8b8173;
   --ink-6b: #a1968a;
   --cta: #f2ece1;
   --cta-hover: #fbf8f1;
@@ -1768,4 +1758,25 @@ html[data-theme='dark'] [data-yc-app] ::selection {
   .yc-page-content {
     padding: 26px 30px;
   }
+}
+
+/* PIMS runs entirely on bone surfaces, where the faint inks above are
+   unreadable - roughly 476 usages measured between 1.90:1 and 2.64:1 against
+   --band, the darkest bone surface: nav labels, metadata lines, counts,
+   weekday labels, empty states. #66635f is the LIGHTEST warm grey that clears
+   4.5 on every bone surface (4.56 on --band, 5.40 on --screen), so it stays as faint as the palette
+   allows while being legible, and stays lighter than --ink-muted (5.31) so the
+   hierarchy still reads.
+
+   Scoped rather than global: the public marketing pages put this same token on
+   always-dark --spot panels, where the lighter value is the correct one.
+   --ink-faint2 collapses onto --ink-faint here because between the 4.56 ceiling
+   and --ink-muted there is no room for two passing steps below muted. */
+[data-yc-app] {
+  --ink-faint: #66635f;
+  --ink-faint2: #66635f;
+}
+html[data-theme='dark'] [data-yc-app] {
+  --ink-faint: #9d9285;
+  --ink-faint2: #998f82;
 }

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -1815,6 +1815,24 @@ body:has([data-yc-app]) {
   --black-grey: var(--ink-faint);
   --black-grey-Text: var(--ink-faint);
 }
+/* Fixed-light product surfaces.
+   /payment-status, /success and /accessibility/report paint on literal white
+   and #e6f2ff regardless of the chosen theme, so the theme-aware scope below
+   is wrong for them: in dark mode it handed them #9d9285, which is 3.05:1 on
+   white and 2.69:1 on the footer band - the light-mode fix reversing itself.
+   These pin the light inks in BOTH themes. Declared on the surface element
+   rather than on body, so it wins for that subtree by proximity. */
+[data-yc-surface='light'] {
+  --ink-faint: #66635f;
+  --ink-faint2: #66635f;
+  --color-text-tertiary: var(--ink-faint);
+  --color-text-extra: var(--ink-faint2);
+  --color-grey-text: var(--ink-faint);
+  --color-grey-bg: var(--ink-faint);
+  --black-grey: var(--ink-faint);
+  --black-grey-Text: var(--ink-faint);
+}
+
 html[data-theme='dark'] body:has([data-yc-app]) {
   --ink-faint: #9d9285;
   --ink-faint2: #998f82;

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -757,7 +757,11 @@ html[data-theme='dark'] {
   --ink-muted: #a89e90;
   --ink-soft: #cabfb0;
   --ink-faint: #9d9285;
-  --ink-faint2: #8b8173;
+  /* #8b8173 passed only on --spot: it was 3.78:1 on --inset (the marketing
+     footer), 3.84 on --screen and 4.10 on --band. #998f82 clears 4.5 on every
+     dark surface (4.56-5.78) and is the value the app scope already used, so
+     the two agree now instead of the app being the only readable one. */
+  --ink-faint2: #998f82;
   --ink-6b: #a1968a;
   --cta: #f2ece1;
   --cta-hover: #fbf8f1;
@@ -875,7 +879,11 @@ html[data-theme='dark'] {
   --ink-muted: #a89e90;
   --ink-soft: #cabfb0;
   --ink-faint: #9d9285;
-  --ink-faint2: #8b8173;
+  /* #8b8173 passed only on --spot: it was 3.78:1 on --inset (the marketing
+     footer), 3.84 on --screen and 4.10 on --band. #998f82 clears 4.5 on every
+     dark surface (4.56-5.78) and is the value the app scope already used, so
+     the two agree now instead of the app being the only readable one. */
+  --ink-faint2: #998f82;
   --ink-6b: #a1968a;
   --cta: #f2ece1;
   --cta-hover: #fbf8f1;

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -598,8 +598,19 @@ textarea:focus-visible {
      5.87:1 light / 6.34:1 dark. */
   --table-head-ink: var(--ink-muted);
   --ink-soft: #423f3c;
-  --ink-faint: #8f8984;
-  --ink-faint2: #a9a39e;
+  /* Both were unreadable as text: #8f8984 measured 2.64:1 and #a9a39e 1.90:1
+     against the darkest bone surface (--band), across ~476 usages - nav labels,
+     metadata lines, counts, weekday labels, empty states. #66635f is the
+     LIGHTEST warm grey on this ramp that still clears 4.5:1 everywhere (4.56),
+     so it stays as faint as the palette allows while remaining legible, and
+     stays lighter than --ink-muted (5.31) so the hierarchy survives.
+
+     --ink-faint2 takes the same value: with the ceiling at 4.56 and --ink-muted
+     at 5.31 there is not enough headroom for two distinct sub-muted steps that
+     both pass. The second step was never readable, so it is folded into the
+     first rather than kept as a decorative fiction. */
+  --ink-faint: #66635f;
+  --ink-faint2: #66635f;
   --ink-6b: #6b6763;
   /* primary CTA (dark fill on light) */
   --cta: #302f2e;
@@ -752,7 +763,9 @@ html[data-theme='dark'] {
   --ink-muted: #a89e90;
   --ink-soft: #cabfb0;
   --ink-faint: #9d9285;
-  --ink-faint2: #8b8173;
+  /* #8b8173 was 3.78:1 on the espresso surfaces; #998f82 is the darkest value
+     that clears 4.5 (4.56). --ink-faint already passes at 4.75 and is unchanged. */
+  --ink-faint2: #998f82;
   --ink-6b: #a1968a;
   --cta: #f2ece1;
   --cta-hover: #fbf8f1;
@@ -870,7 +883,9 @@ html[data-theme='dark'] {
   --ink-muted: #a89e90;
   --ink-soft: #cabfb0;
   --ink-faint: #9d9285;
-  --ink-faint2: #8b8173;
+  /* #8b8173 was 3.78:1 on the espresso surfaces; #998f82 is the darkest value
+     that clears 4.5 (4.56). --ink-faint already passes at 4.75 and is unchanged. */
+  --ink-faint2: #998f82;
   --ink-6b: #a1968a;
   --cta: #f2ece1;
   --cta-hover: #fbf8f1;

--- a/apps/frontend/src/app/ui/filters/InventoryFilters/index.tsx
+++ b/apps/frontend/src/app/ui/filters/InventoryFilters/index.tsx
@@ -141,7 +141,7 @@ const InventoryFilters = ({
                 className="relative z-10 h-full transition-colors duration-200 cursor-pointer"
                 style={{
                   width: 'calc(100% / 3)',
-                  color: isCurrent ? 'var(--color-neutral-0)' : 'var(--color-neutral-600)',
+                  color: isCurrent ? 'var(--color-neutral-0)' : 'var(--color-text-tertiary)',
                   fontWeight: 500,
                   lineHeight: '120%',
                   letterSpacing: '-0.28px',

--- a/apps/frontend/src/app/ui/inputs/Dropdown/Dropdown.tsx
+++ b/apps/frontend/src/app/ui/inputs/Dropdown/Dropdown.tsx
@@ -192,7 +192,7 @@ const Dropdown = ({
         >
           <span className="select-input-selected">{selected ? selected.label : ''}</span>
           <span className="select-input-drop-icon" aria-hidden="true">
-            <IoChevronDown color="var(--color-neutral-600)" size={14} />
+            <IoChevronDown color="var(--color-text-tertiary)" size={14} />
           </span>
         </button>
 

--- a/apps/frontend/src/app/ui/inputs/ServiceSearch/ServiceSearchBase.tsx
+++ b/apps/frontend/src/app/ui/inputs/ServiceSearch/ServiceSearchBase.tsx
@@ -71,7 +71,7 @@ const ServiceSearchBase = ({
 
   return (
     <div className="service-search" ref={wrapperRef}>
-      <IoSearch size={15} className="service-search-icon" color="var(--color-neutral-600)" />
+      <IoSearch size={15} className="service-search-icon" color="var(--color-text-tertiary)" />
       <input
         type="text"
         id={inputId}

--- a/apps/frontend/src/app/ui/inputs/SpecialitySearch/SpecialitySearchBase.tsx
+++ b/apps/frontend/src/app/ui/inputs/SpecialitySearch/SpecialitySearchBase.tsx
@@ -105,7 +105,7 @@ const SpecialitySearchBase = <T extends { name: string }>({
 
   return (
     <div className="step-search" ref={wrapperRef}>
-      <IoSearch size={15} className="step-search-icon" color="var(--color-neutral-600)" />
+      <IoSearch size={15} className="step-search-icon" color="var(--color-text-tertiary)" />
       <input
         type="text"
         id={inputId}

--- a/apps/frontend/src/app/ui/layout/MobileSearchBar/MobileSearchBar.tsx
+++ b/apps/frontend/src/app/ui/layout/MobileSearchBar/MobileSearchBar.tsx
@@ -28,7 +28,7 @@ const MobileSearchBar = ({ placeholder = 'Search' }: MobileSearchBarProps) => {
       />
       <IoIosSearch
         size={18}
-        color="var(--color-neutral-500)"
+        color="var(--color-text-tertiary)"
         aria-hidden="true"
         className="shrink-0"
       />

--- a/apps/frontend/src/app/ui/layout/Notifications/Notifications.css
+++ b/apps/frontend/src/app/ui/layout/Notifications/Notifications.css
@@ -133,8 +133,10 @@
   background: var(--surface-soft);
 }
 
+/* The 'Earlier' grouping is carried by its section heading, not by dimming
+   the rows: at 0.75 the --ink-faint meta line composited to 3.23:1. */
 .yc-noti-row--earlier {
-  opacity: 0.75;
+  color: var(--ink-body);
 }
 
 .yc-noti-row:hover {

--- a/apps/frontend/src/app/ui/tokens.md
+++ b/apps/frontend/src/app/ui/tokens.md
@@ -35,7 +35,7 @@ Rules:
 | scope                                               | token          | light     | dark      |
 | --------------------------------------------------- | -------------- | --------- | --------- |
 | `:root` (public marketing pages)                    | `--ink-faint`  | `#8f8984` | `#9d9285` |
-| `:root` (public marketing pages)                    | `--ink-faint2` | `#a9a39e` | `#8b8173` |
+| `:root` (public marketing pages)                    | `--ink-faint2` | `#a9a39e` | `#998f82` |
 | `body:has([data-yc-app])` (PIMS, auth form, embeds) | `--ink-faint`  | `#66635f` | `#9d9285` |
 | `body:has([data-yc-app])` (PIMS, auth form, embeds) | `--ink-faint2` | `#66635f` | `#998f82` |
 

--- a/apps/frontend/src/app/ui/tokens.md
+++ b/apps/frontend/src/app/ui/tokens.md
@@ -32,10 +32,14 @@ Rules:
 
 `--ink-faint` / `--ink-faint2` are the one place where a token deliberately differs by surface, so read the value off the scope you are in rather than off the `:root` declaration:
 
-| scope                                               | light     | dark                  | why                                                                                                                                                                                             |
-| --------------------------------------------------- | --------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `:root` (public marketing pages)                    | `#9d9285` | same                  | the marketing `--spot` sections are always dark; darkening the ink there drops 19 of them from 6.82:1 to 2.85:1                                                                                 |
-| `body:has([data-yc-app])` (PIMS, auth form, embeds) | `#66635f` | `#9d9285` / `#998f82` | bone surfaces - `#66635f` is 4.56:1 on `--band`, the bottom of the light ramp. `--ink-faint2` collapses onto it because there is no room for a second passing step below `--ink-muted` (5.31:1) |
+| scope                                               | token          | light     | dark      |
+| --------------------------------------------------- | -------------- | --------- | --------- |
+| `:root` (public marketing pages)                    | `--ink-faint`  | `#8f8984` | `#9d9285` |
+| `:root` (public marketing pages)                    | `--ink-faint2` | `#a9a39e` | `#8b8173` |
+| `body:has([data-yc-app])` (PIMS, auth form, embeds) | `--ink-faint`  | `#66635f` | `#9d9285` |
+| `body:has([data-yc-app])` (PIMS, auth form, embeds) | `--ink-faint2` | `#66635f` | `#998f82` |
+
+Why the two scopes cannot share one value: the marketing `--spot` sections are always dark, and darkening the ink there drops 19 of them from 6.82:1 to 2.85:1. Inside PIMS the same tokens land on bone, where `#66635f` is 4.56:1 on `--band` - the bottom of the light ramp. In the app's light theme `--ink-faint2` collapses onto `--ink-faint` because there is no room for a second passing step below `--ink-muted` (5.31:1); at `:root` and in dark they stay distinct.
 
 Two things follow, both of which have already bitten:
 

--- a/apps/frontend/src/app/ui/tokens.md
+++ b/apps/frontend/src/app/ui/tokens.md
@@ -25,6 +25,7 @@ Rules:
 - **Where one concept has both spellings, alias - never hold a literal in both.** `--blue-text: var(--color-blue-text)`. Hand-maintaining both is how the utility form kept resolving to a sub-AA colour after the variable form was fixed.
 - **A fill token is not a text token.** `--blue` is a fill and has no contrast duty of its own; `--blue-text` must clear 4.5:1 on the bone surfaces. Using a fill as text (or a text token as a fill) is the most common colour bug in this app.
 - **A fill under white text has two duties**: 4.5:1 for the label, and 3:1 against its own surface, because a selected control may drop its border and let the fill alone carry the state. `--blue-strong` exists for this and is the only value that satisfies both in each theme.
+- **Ink tokens are checked against `--band` (#e8e0d2), the darkest bone surface** - not `--screen`. The light ramp bottoms out at `--ink-faint` (#66635f, 4.56:1); `--ink-faint2` shares that value because the palette has no room for a second passing step below `--ink-muted` (5.31:1). Anything lighter is unreadable, and ~476 usages were sitting at 1.90-2.64:1 before this was enforced.
 - Never hardcode hex values in components. Use a CSS variable or a Tailwind token class.
 
 ## Component status labels

--- a/apps/frontend/src/app/ui/tokens.md
+++ b/apps/frontend/src/app/ui/tokens.md
@@ -25,8 +25,22 @@ Rules:
 - **Where one concept has both spellings, alias - never hold a literal in both.** `--blue-text: var(--color-blue-text)`. Hand-maintaining both is how the utility form kept resolving to a sub-AA colour after the variable form was fixed.
 - **A fill token is not a text token.** `--blue` is a fill and has no contrast duty of its own; `--blue-text` must clear 4.5:1 on the bone surfaces. Using a fill as text (or a text token as a fill) is the most common colour bug in this app.
 - **A fill under white text has two duties**: 4.5:1 for the label, and 3:1 against its own surface, because a selected control may drop its border and let the fill alone carry the state. `--blue-strong` exists for this and is the only value that satisfies both in each theme.
-- **Ink tokens are checked against `--band` (#e8e0d2), the darkest bone surface** - not `--screen`. The light ramp bottoms out at `--ink-faint` (#66635f, 4.56:1); `--ink-faint2` shares that value because the palette has no room for a second passing step below `--ink-muted` (5.31:1). Anything lighter is unreadable, and ~476 usages were sitting at 1.90-2.64:1 before this was enforced.
+- **Ink tokens are checked against `--band` (#e8e0d2), the darkest bone surface** - not `--screen`. Anything lighter is unreadable, and ~476 usages were sitting at 1.90-2.64:1 before this was enforced.
 - Never hardcode hex values in components. Use a CSS variable or a Tailwind token class.
+
+### The faint inks have two values, not one
+
+`--ink-faint` / `--ink-faint2` are the one place where a token deliberately differs by surface, so read the value off the scope you are in rather than off the `:root` declaration:
+
+| scope                                               | light     | dark                  | why                                                                                                                                                                                             |
+| --------------------------------------------------- | --------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `:root` (public marketing pages)                    | `#9d9285` | same                  | the marketing `--spot` sections are always dark; darkening the ink there drops 19 of them from 6.82:1 to 2.85:1                                                                                 |
+| `body:has([data-yc-app])` (PIMS, auth form, embeds) | `#66635f` | `#9d9285` / `#998f82` | bone surfaces - `#66635f` is 4.56:1 on `--band`, the bottom of the light ramp. `--ink-faint2` collapses onto it because there is no room for a second passing step below `--ink-muted` (5.31:1) |
+
+Two things follow, both of which have already bitten:
+
+- **The hook is on `body`, via `:has()`, not on the shell element.** Modals, dropdowns and row-action menus `createPortal` into `document.body`, so they are siblings of the shell, not descendants, and a marker on the shell leaves every overlay on the wrong value. Surfaces outside the `(app)` layout opt in by rendering `<div data-yc-app style={{ display: 'contents' }}>` - the auth form column and the embed routes do exactly this.
+- **Re-declaring the short token is not enough.** `@theme` aliases it (`--color-neutral-600: var(--ink-faint)`), and an alias resolves where it is _declared_ - on `:root`. Overriding the dependency further down does not recompute it, so `text-neutral-500` kept resolving `#a9a39e` inside PIMS. The whole transitive text closure is re-stated in the scope, and `appScopeAliasClosure.test.ts` walks the stylesheet to prove it stays that way. Borders reachable from the same inks (`--greyborder`) are excluded on purpose.
 
 ## Component status labels
 

--- a/apps/frontend/src/app/ui/widgets/Footer/Footer.css
+++ b/apps/frontend/src/app/ui/widgets/Footer/Footer.css
@@ -92,7 +92,7 @@
   position: relative;
   display: inline-block;
   text-decoration: none;
-  color: var(--color-neutral-600);
+  color: var(--color-text-tertiary);
   font-family: var(--font-satoshi), sans-serif;
   font-size: 16px;
   font-weight: 400;

--- a/apps/frontend/src/app/ui/widgets/Footer/Footer.css
+++ b/apps/frontend/src/app/ui/widgets/Footer/Footer.css
@@ -92,7 +92,11 @@
   position: relative;
   display: inline-block;
   text-decoration: none;
-  color: var(--color-text-tertiary);
+  /* --ink-muted, not a faint ink: this footer's band is theme-aware
+     (--color-brand-100 is #e6f2ff in light and a translucent blue over the dark
+     page in dark), and the faint step only cleared AA on the light one - 5.27
+     light but 4.03 on the dark composite. --ink-muted is 6.13 / 4.66. */
+  color: var(--ink-muted);
   font-family: var(--font-satoshi), sans-serif;
   font-size: 16px;
   font-weight: 400;

--- a/apps/frontend/src/app/ui/widgets/Summary/Summary.css
+++ b/apps/frontend/src/app/ui/widgets/Summary/Summary.css
@@ -14,7 +14,7 @@
   letter-spacing: -0.66px;
 }
 .summary-title span {
-  color: var(--color-neutral-600);
+  color: var(--color-text-tertiary);
 }
 .summary-labels {
   display: flex;


### PR DESCRIPTION
## What changed

A click-through of deployed dev found the same two tokens failing AA on **every page** — roughly **476 usages**: nav labels, metadata lines, counts, weekday labels, empty states. The active nav item measured **1.58:1**.

| token | was | on `--band` | now | on `--band` |
|---|---|---|---|---|
| `--ink-faint` | `#8f8984` | **2.64:1** ❌ | `#66635f` | **4.56:1** ✅ |
| `--ink-faint2` | `#a9a39e` | **1.90:1** ❌ | `#66635f` | **4.56:1** ✅ |
| `--ink-faint2` (dark) | `#8b8173` | **3.78:1** ❌ | `#998f82` | **4.56:1** ✅ |

`--ink-faint` in dark already cleared at 4.75:1 and is unchanged.

## Why these values

The binding surface is **`--band` (#e8e0d2)**, not `--screen` — checking against `--screen` alone passes values that fail in the wild. `#66635f` is the **lightest** warm grey on this ramp that clears 4.5:1 on every bone surface, so the text stays as faint as the palette permits while being legible, and it stays lighter than `--ink-muted` (5.31:1) so the hierarchy still reads:

```
--ink 12.98  >  --ink-body 10.20  >  --ink-soft 7.98  >  --ink-muted 5.31  >  --ink-faint 4.56
```

**`--ink-faint2` takes the same value.** With the ceiling at 4.56 and `--ink-muted` at 5.31 there is no room for two distinct sub-muted steps that both pass. The second step was never legible, so it is folded in rather than kept as a decorative fiction that fails.

## This is a visible change

~476 places get darker. That is deliberate, not incidental — it is what "faint text that can actually be read" costs on this palette.

## Docs

Both `AGENTS.md` and `src/app/ui/tokens.md` gain the rule that would have prevented it: **ink is checked against `--band`, and there is nothing below `--ink-faint`.** If you want fainter text, the answer is less text or a larger size, not a lighter ink.

## Validation performed

- Ramp recomputed across all five light and four dark surfaces — every step passes
- `type-check` clean, `lint` clean, **913 suites / 11,237 tests** passing
- Found by measuring computed styles on deployed dev, not by inspection

## Follow-up

Visual verification on dev once this deploys; the audit that found it will be re-run across every PIMS surface, modal and both themes.