### PR TITLE
test(frontend): give every shared UI component a Storybook story

### DIFF
--- a/apps/frontend/src/app/ui/avatars/CompanionAvatar.stories.tsx
+++ b/apps/frontend/src/app/ui/avatars/CompanionAvatar.stories.tsx
@@ -1,0 +1,79 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import CompanionAvatar from './CompanionAvatar';
+
+const meta = {
+  title: 'Avatars/CompanionAvatar',
+  component: CompanionAvatar,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'The companion (pet) avatar used in the directory table, companion header and the ' +
+          'add-companion modal. It shows the real photo when the companion has one, and otherwise a ' +
+          'Newsreader monogram on a tinted disc — never a stock species photo, which would read as a ' +
+          'real picture of that animal. The disc colour is picked deterministically from `seed` (or the ' +
+          'name), so a companion keeps the same colour everywhere. The photo branch is left out of ' +
+          'these stories on purpose: `getSafeImageUrl` only accepts an https source, so any photo ' +
+          'story would pull a remote CDN image into every snapshot.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    size: { control: { type: 'range', min: 24, max: 96, step: 2 } },
+    photoUrl: { control: 'text' },
+  },
+  args: {
+    name: 'Bella',
+    size: 46,
+    textClassName: 'text-[20px]',
+  },
+} satisfies Meta<typeof CompanionAvatar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** No photo on file — the monogram disc. This is the common case in the directory. */
+export const Monogram: Story = {};
+
+/**
+ * The palette cycles over three warm-bone tints keyed off `seed`, so two
+ * companions side by side stay visually distinct and neither one drifts colour
+ * between the table, the header and the modal.
+ */
+export const PaletteRotation: Story = {
+  name: 'Palette rotation',
+  render: (args) => (
+    <div className="flex items-center gap-3">
+      <CompanionAvatar {...args} name="Bella" seed="a" />
+      <CompanionAvatar {...args} name="Coco" seed="b" />
+      <CompanionAvatar {...args} name="Duke" seed="c" />
+    </div>
+  ),
+};
+
+/**
+ * The three sizes the app actually uses: 38px in the compact table row, 44px in
+ * the card row and 46px in the roomy row. `textClassName` carries the matching
+ * monogram type scale.
+ */
+export const Sizes: Story = {
+  render: (args) => (
+    <div className="flex items-end gap-3">
+      <CompanionAvatar {...args} size={38} textClassName="text-[17px]" />
+      <CompanionAvatar {...args} size={44} textClassName="text-[19px]" />
+      <CompanionAvatar {...args} size={46} textClassName="text-[20px]" />
+    </div>
+  ),
+};
+
+/**
+ * No name at all — the monogram falls back to `?` rather than rendering an
+ * empty disc, so a half-imported record still looks deliberate.
+ */
+export const MissingName: Story = {
+  name: 'Missing name',
+  args: { name: null, alt: 'Companion' },
+};

--- a/apps/frontend/src/app/ui/cards/AppointmentCard/AppointmentCard.stories.tsx
+++ b/apps/frontend/src/app/ui/cards/AppointmentCard/AppointmentCard.stories.tsx
@@ -1,0 +1,181 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import type { Appointment, Organisation } from '@yosemite-crew/types';
+
+import AppointmentCard from './index';
+import type { AppointmentViewIntent } from '@/app/features/appointments/types/calendar';
+import { useOrgStore } from '@/app/stores/orgStore';
+
+const ORG_ID = 'org-storybook';
+
+const ORG: Organisation = {
+  _id: ORG_ID,
+  name: 'Sunrise Veterinary Hospital',
+  type: 'HOSPITAL',
+  phoneNo: '4155550110',
+  taxId: 'TAX-0001',
+  isVerified: true,
+  isActive: true,
+};
+
+const SOAP_INTENT: AppointmentViewIntent = { label: 'prescription', subLabel: 'subjective' };
+
+const BASE_APPOINTMENT: Appointment = {
+  id: 'appt-1',
+  patient: {
+    id: 'companion-1',
+    name: 'Poppy',
+    species: 'dog',
+    breed: 'Beagle',
+    parent: { id: 'parent-1', name: 'Maya Whitfield' },
+  },
+  lead: { id: 'vet-1', name: 'Dr. Elena Marsh' },
+  supportStaff: [{ id: 'nurse-1', name: 'Tom Reyes' }],
+  room: { id: 'room-1', name: 'Consult 2' },
+  appointmentType: {
+    id: 'type-1',
+    name: 'Wellness exam',
+    speciality: { id: 'spec-1', name: 'General practice' },
+  },
+  organisationId: ORG_ID,
+  appointmentDate: new Date('2026-03-12T09:30:00.000Z'),
+  startTime: new Date('2026-03-12T09:30:00.000Z'),
+  endTime: new Date('2026-03-12T10:00:00.000Z'),
+  timeSlot: '09:30 - 10:00',
+  durationMinutes: 30,
+  status: 'UPCOMING',
+  concern: 'Annual check-up and vaccination review',
+};
+
+const meta = {
+  title: 'Cards/AppointmentCard',
+  component: AppointmentCard,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The appointment tile used by the appointments list: companion header, the detail rows, the ' +
+          'inpatient/outpatient pill and the status pill, closed by a row of circular actions. Which ' +
+          'actions appear depends on the status and on `canEditAppointments` — a requested booking ' +
+          'shows only accept/decline, a locked-down role only shows the read actions. The clinical ' +
+          'notes action is labelled from the organisation type ("Medical Records" for a hospital, ' +
+          '"Care" elsewhere), which the stories seed into the org store.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    appointment: BASE_APPOINTMENT,
+    canEditAppointments: true,
+    handleViewAppointment: fn(),
+    handleWorkspaceAppointment: fn(),
+    handleRescheduleAppointment: fn(),
+    handleChangeStatusAppointment: fn(),
+    handleChangeRoomAppointment: fn(),
+    getSoapViewIntent: () => SOAP_INTENT,
+  },
+  argTypes: {
+    canEditAppointments: { control: 'boolean' },
+  },
+  decorators: [
+    (StoryFn) => (
+      <div className="flex flex-wrap gap-6" style={{ maxWidth: 720 }}>
+        <StoryFn />
+      </div>
+    ),
+  ],
+  beforeEach: () => {
+    // The card resolves its clinical-notes label from the org store. Only
+    // `orgsById` is seeded: setting `primaryOrgId` would make the card's
+    // content hook start loading the team over the network.
+    const snapshot = useOrgStore.getState();
+    useOrgStore.setState({ orgsById: { [ORG_ID]: ORG }, orgIds: [ORG_ID], primaryOrgId: null });
+    return () => {
+      useOrgStore.setState({
+        orgsById: snapshot.orgsById,
+        orgIds: snapshot.orgIds,
+        primaryOrgId: snapshot.primaryOrgId,
+      });
+    };
+  },
+} satisfies Meta<typeof AppointmentCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Upcoming: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A confirmed booking an editor can act on: view, change status, reschedule, assign room, medical records, finance and labs.',
+      },
+    },
+  },
+};
+
+export const Requested: Story = {
+  name: 'Requested — needs a response',
+  args: {
+    appointment: {
+      ...BASE_APPOINTMENT,
+      status: 'REQUESTED',
+      room: undefined,
+      concern: 'Limping on the back right leg since yesterday',
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A request replaces the whole action row with the accept (success) and decline (danger) pair — the only two things that can happen to it next.',
+      },
+    },
+  },
+};
+
+export const ViewOnly: Story = {
+  name: 'Without edit permission',
+  args: { canEditAppointments: false },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Without `canEditAppointments` the mutating actions disappear and the row keeps only view, records, finance and labs.',
+      },
+    },
+  },
+};
+
+export const LongValues: Story = {
+  name: 'Long names and reason',
+  args: {
+    appointment: {
+      ...BASE_APPOINTMENT,
+      patient: {
+        id: 'companion-2',
+        name: 'Bartholomew Fitzgerald the Third',
+        species: 'dog',
+        breed: 'Bernese Mountain Dog / Great Pyrenees cross',
+        parent: { id: 'parent-2', name: 'Alexandra Konstantinopoulos' },
+      },
+      appointmentType: {
+        id: 'type-2',
+        name: 'Post-operative orthopaedic recheck and bandage change',
+        speciality: { id: 'spec-2', name: 'Orthopaedic surgery' },
+      },
+      room: { id: 'room-2', name: 'Surgical prep and recovery suite' },
+      concern:
+        'Recheck of the cranial cruciate ligament repair, bandage change and a review of the pain relief plan',
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Overflow guard: long companion, breed, service and room values must not push the card wider or break the action row.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/cards/AvailabilityCard/AvailabilityCard.stories.tsx
+++ b/apps/frontend/src/app/ui/cards/AvailabilityCard/AvailabilityCard.stories.tsx
@@ -83,7 +83,7 @@ export const OffDuty: Story = {
   },
 };
 
-export const NoSpecialities: Story = {
+export const EmptyAndOverflowingFields: Story = {
   name: 'Empty and overflowing fields',
   args: {
     team: {

--- a/apps/frontend/src/app/ui/cards/AvailabilityCard/AvailabilityCard.stories.tsx
+++ b/apps/frontend/src/app/ui/cards/AvailabilityCard/AvailabilityCard.stories.tsx
@@ -1,0 +1,113 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import type { Team } from '@/app/features/organization/types/team';
+import AvailabilityCard from './index';
+
+const speciality = (name: string): Team['speciality'][number] => ({
+  _id: name.toLowerCase(),
+  organisationId: 'org-1',
+  name,
+});
+
+const baseTeam: Team = {
+  _id: 'team-1',
+  practionerId: 'practitioner-1',
+  organisationId: 'org-1',
+  name: 'Dr. Amelia Hart',
+  role: 'VETERINARIAN',
+  speciality: [speciality('Cardiology')],
+  todayAppointment: '6',
+  weeklyWorkingHours: '38.5',
+  status: 'Available',
+  revokedPermissions: [],
+  effectivePermissions: [],
+  extraPerissions: [],
+};
+
+const meta = {
+  title: 'Cards/AvailabilityCard',
+  component: AvailabilityCard,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The phone/tablet stand-in for one row of the team availability table. It carries the same ' +
+          'avatar, role, specialities, appointment count and weekly hours as the desktop row, and closes ' +
+          'with the shared StatusPill plus a full-width Secondary "View" action. Status tone comes from ' +
+          '`getAvailabilityStatusTone`, so the card and the table row can never disagree about a colour.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: { team: baseTeam, handleViewTeam: fn() },
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 340 }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof AvailabilityCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Available: Story = {};
+
+export const Consulting: Story = {
+  args: {
+    team: {
+      ...baseTeam,
+      _id: 'team-2',
+      name: 'Dr. Ravi Menon',
+      role: 'TECHNICIAN',
+      status: 'Consulting',
+      todayAppointment: '11',
+    },
+  },
+};
+
+export const OffDuty: Story = {
+  name: 'Off duty',
+  args: {
+    team: {
+      ...baseTeam,
+      _id: 'team-3',
+      name: 'Priya Raman',
+      role: 'RECEPTIONIST',
+      status: 'Off-Duty',
+      todayAppointment: '0',
+      weeklyWorkingHours: '0',
+    },
+  },
+};
+
+export const NoSpecialities: Story = {
+  name: 'Empty and overflowing fields',
+  args: {
+    team: {
+      ...baseTeam,
+      _id: 'team-4',
+      name: 'Dr. Wilhelmina Fitzgerald-Okonkwo',
+      role: 'SUPERVISOR',
+      speciality: [
+        speciality('Cardiology'),
+        speciality('Dermatology'),
+        speciality('Internal Medicine'),
+        speciality('Emergency & Critical Care'),
+      ],
+      status: 'Requested',
+      weeklyWorkingHours: undefined,
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A long name plus four specialities: the label/value rows wrap rather than truncate, and ' +
+          'a missing `weeklyWorkingHours` falls back to `0` instead of printing `NaN`.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/cards/CompanionCard/CompanionCard.stories.tsx
+++ b/apps/frontend/src/app/ui/cards/CompanionCard/CompanionCard.stories.tsx
@@ -1,0 +1,135 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import type { CompanionParent } from '@/app/features/companions/pages/Companions/types';
+import CompanionCard from './CompanionCard';
+
+const parent: CompanionParent['parent'] = {
+  id: 'parent-1',
+  firstName: 'Marta',
+  lastName: 'Alvarez',
+  email: 'marta.alvarez@example.com',
+  phoneNumber: '+34 600 000 000',
+  address: { city: 'Barcelona', country: 'ES' },
+  createdFrom: 'pms',
+};
+
+const baseCompanion: CompanionParent = {
+  companion: {
+    id: 'companion-1',
+    organisationId: 'org-1',
+    parentId: 'parent-1',
+    name: 'Kiko',
+    type: 'dog',
+    breed: 'Border Collie',
+    dateOfBirth: new Date('2019-04-18T00:00:00.000Z'),
+    gender: 'male',
+    allergy: 'Chicken protein',
+    isInsured: true,
+    status: 'active',
+  },
+  parent,
+};
+
+const meta = {
+  title: 'Cards/CompanionCard',
+  component: CompanionCard,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The phone/tablet card for one companion record: avatar, breed and species, parent, ' +
+          'gender/age, allergies, status pill, and a row of round icon actions. Each action is ' +
+          'permission-gated, so the same card renders with anywhere from one to four buttons. ' +
+          'Action labels run through the org terminology rewriter, which falls back to the ' +
+          'default "companion" wording when no org is loaded.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    companion: baseCompanion,
+    handleViewCompanion: fn(),
+    handleBookAppointment: fn(),
+    handleAddTask: fn(),
+    handleChangeStatus: fn(),
+    canEditAppointments: true,
+    canEditTasks: true,
+    canEditCompanions: true,
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 340 }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof CompanionCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const AllActions: Story = { name: 'All actions' };
+
+export const ViewOnly: Story = {
+  name: 'View only (no edit permissions)',
+  args: {
+    canEditAppointments: false,
+    canEditTasks: false,
+    canEditCompanions: false,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A read-only member sees the single View action. The row stays centred rather than ' +
+          'leaving three empty slots.',
+      },
+    },
+  },
+};
+
+export const Archived: Story = {
+  args: {
+    companion: {
+      ...baseCompanion,
+      companion: {
+        ...baseCompanion.companion,
+        id: 'companion-2',
+        name: 'Pepper',
+        type: 'cat',
+        breed: 'Maine Coon',
+        gender: 'female',
+        allergy: undefined,
+        status: 'archived',
+      },
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Archived tone on the status pill, and a missing allergy renders the `-` placeholder ' +
+          'rather than an empty gap.',
+      },
+    },
+  },
+};
+
+export const LongText: Story = {
+  name: 'Long name and breed',
+  args: {
+    companion: {
+      ...baseCompanion,
+      companion: {
+        ...baseCompanion.companion,
+        id: 'companion-3',
+        name: 'Bartholomew Wigglesworth III',
+        type: 'horse',
+        breed: 'Andalusian Cross Warmblood',
+        allergy: 'Seasonal pollen, dust mites and one specific brand of hay net',
+      },
+      parent: { ...parent, lastName: 'Van Der Berg-Christiansen' },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/cards/CreateOrgCard/CreateOrgCard.stories.tsx
+++ b/apps/frontend/src/app/ui/cards/CreateOrgCard/CreateOrgCard.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import CreateOrgCard from './CreateOrgCard';
+
+/**
+ * The dashed "add" affordance that closes the organisation list on
+ * `/organizations`. It is a link, not a button, so the whole card is one
+ * keyboard stop and one hover target.
+ */
+const meta = {
+  title: 'Cards/CreateOrgCard',
+  component: CreateOrgCard,
+  parameters: {
+    layout: 'padded',
+    // The card renders a next/link, which needs the App Router mock.
+    nextjs: { appDirectory: true },
+    docs: {
+      description: {
+        component:
+          'Dashed-outline call to action pinned under the organisation list. 1.5px dashed `--divider` at radius 18, ' +
+          '`--ink-muted` label with a `--blue-text` plus glyph; hovering swaps the border to `--blue` and the label to `--ink`. ' +
+          'It stretches to its container, so the stories below pin it to the widths it actually ships at.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof CreateOrgCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** As it appears on the organisations page — a 640px column, full-bleed card. */
+export const Default: Story = {
+  decorators: [
+    (StoryFn) => (
+      <div style={{ width: 'min(640px, 100%)' }}>
+        <StoryFn />
+      </div>
+    ),
+  ],
+};
+
+/**
+ * Narrow container. The label is a single line at 13px/600, so a cramped
+ * column is where wrapping would first show up.
+ */
+export const Narrow: Story = {
+  decorators: [
+    (StoryFn) => (
+      <div style={{ width: 260 }}>
+        <StoryFn />
+      </div>
+    ),
+  ],
+};
+
+/** The destination is overridable — onboarding flows point it at their own route. */
+export const CustomHref: Story = {
+  args: { href: '/onboarding/new-organization' },
+  decorators: [
+    (StoryFn) => (
+      <div style={{ width: 'min(640px, 100%)' }}>
+        <StoryFn />
+      </div>
+    ),
+  ],
+};

--- a/apps/frontend/src/app/ui/cards/DocumentsCard/DocumentsCard.stories.tsx
+++ b/apps/frontend/src/app/ui/cards/DocumentsCard/DocumentsCard.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import DocumentsCard from './index';
+import type { OrganizationDocument } from '../../../features/documents/types/document';
+
+const baseDocument: OrganizationDocument = {
+  _id: 'doc-1',
+  organisationId: 'org-1',
+  title: 'Cancellation Policy',
+  description: 'What clients are charged when they cancel inside 24 hours',
+  fileUrl: 'https://example.com/cancellation-policy.pdf',
+  category: 'CANCELLATION_POLICY',
+};
+
+/**
+ * The card the documents table falls back to below `xl`. Two of them sit side
+ * by side on tablet (`calc(50% - 12px)`) and stack full-width on phone, so the
+ * stories render it inside the same wrapping flex row the table uses.
+ */
+const meta = {
+  title: 'Cards/DocumentsCard',
+  component: DocumentsCard,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Compact summary of one organisation document — title, description and category over a full-width "View" action. ' +
+          'This is the sub-`xl` fallback for `DocumentsTable`: `--neutral-0` surface, radius 16, hairline border and the ' +
+          'shared `--sh03`/`--sh05` card shadow. The category is title-cased for display, so `CANCELLATION_POLICY` reads as "Cancellation policy".',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: { document: baseDocument, handleViewDocument: fn() },
+  decorators: [
+    (StoryFn) => (
+      <div className="flex flex-wrap gap-4 sm:gap-6">
+        <StoryFn />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof DocumentsCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+/**
+ * Long title and description. Nothing truncates, so the card grows and the
+ * "View" action stays pinned to the bottom by `justify-between`.
+ */
+export const LongContent: Story = {
+  args: {
+    document: {
+      ...baseDocument,
+      _id: 'doc-2',
+      title: 'Terms and Conditions for Boarding, Grooming and Day Care Services',
+      description:
+        'Covers liability, vaccination requirements, feeding instructions, medication handling and the late-collection fee schedule that applies to every overnight stay.',
+      category: 'TERMS_AND_CONDITIONS',
+    },
+  },
+};
+
+/**
+ * `description` is optional. The label still renders, so this is the state to
+ * check when the description row looks unbalanced.
+ */
+export const WithoutDescription: Story = {
+  args: {
+    document: {
+      ...baseDocument,
+      _id: 'doc-3',
+      title: 'Fire Safety Notice',
+      description: undefined,
+      category: 'FIRE_SAFETY',
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/cards/InviteCard/InviteCard.stories.tsx
+++ b/apps/frontend/src/app/ui/cards/InviteCard/InviteCard.stories.tsx
@@ -1,0 +1,97 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import type { Invite } from '@/app/features/organization/types/team';
+import InviteCard from './InviteCard';
+
+const baseInvite: Invite = {
+  _id: 'invite-1',
+  organisationId: 'org-1',
+  organisationName: 'Half Dome Veterinary Hospital',
+  organisationType: 'HOSPITAL',
+  invitedByUserId: 'user-1',
+  departmentId: 'dept-1',
+  inviteeEmail: 'amelia.hart@example.com',
+  role: 'VETERINARIAN',
+  employmentType: 'FULL_TIME',
+  token: 'invite-token-1',
+  status: 'PENDING',
+  expiresAt: '2026-09-01T00:00:00.000Z',
+  createdAt: '2026-08-01T00:00:00.000Z',
+  updatedAt: '2026-08-01T00:00:00.000Z',
+};
+
+const meta = {
+  title: 'Cards/InviteCard',
+  component: InviteCard,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'One pending organisation invite in the org picker. The initial-letter avatar stands in ' +
+          'for the org, the `INVITED` Badge marks the row as not-yet-joined, and the subline joins ' +
+          'role, employment type and the "accept to join" hint with middots. Accept and Decline are ' +
+          'the two `.invite-picker-action` buttons — accept is the filled one.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    disabled: { control: 'boolean' },
+  },
+  args: {
+    invite: baseInvite,
+    handleAccept: fn(async () => {}),
+    handleReject: fn(),
+    disabled: false,
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 460 }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof InviteCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Disabled: Story = {
+  name: 'Accept in flight',
+  args: { disabled: true },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Both actions are disabled while an accept or decline request is on the wire, so a ' +
+          'double click cannot fire the mutation twice.',
+      },
+    },
+  },
+};
+
+export const LongOrganisationName: Story = {
+  name: 'Long name and role',
+  args: {
+    invite: {
+      ...baseInvite,
+      _id: 'invite-2',
+      organisationName: 'Tuolumne Meadows Emergency & Critical Care Referral Centre',
+      organisationType: 'BOARDER',
+      role: 'RECEPTIONIST',
+      employmentType: 'PART_TIME',
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The overflow case. The name and the subline both truncate inside `min-w-0 flex-1`, so a ' +
+          'long org name never pushes the badge or the two actions out of the card.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/cards/InvoiceCard/InvoiceCard.stories.tsx
+++ b/apps/frontend/src/app/ui/cards/InvoiceCard/InvoiceCard.stories.tsx
@@ -1,0 +1,153 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import type { Appointment, Invoice } from '@yosemite-crew/types';
+import { useAppointmentStore } from '@/app/stores/appointmentStore';
+import { useOrgStore } from '@/app/stores/orgStore';
+import InvoiceCard from './index';
+
+const ORG_ID = 'org-1';
+const APPOINTMENT_ID = 'appointment-1';
+
+const patient: Appointment['patient'] = {
+  id: 'companion-1',
+  name: 'Kizie',
+  species: 'Dog',
+  breed: 'Beagle',
+  parent: { id: 'parent-1', name: 'Sky Doe' },
+};
+
+const appointment: Appointment = {
+  id: APPOINTMENT_ID,
+  organisationId: ORG_ID,
+  patient,
+  companion: patient,
+  appointmentDate: new Date('2026-08-12T09:30:00.000Z'),
+  startTime: new Date('2026-08-12T09:30:00.000Z'),
+  endTime: new Date('2026-08-12T10:00:00.000Z'),
+  timeSlot: '09:30 AM',
+  durationMinutes: 30,
+  status: 'COMPLETED',
+};
+
+/**
+ * The card takes the invoice as a prop but resolves the companion and parent names
+ * itself, out of the appointment store, from `invoice.appointmentId` alone. Both
+ * stores are plain Zustand stores with no provider and no fetch on read, so seeding
+ * them in `beforeEach` — outside any React render — is the whole of the setup, and
+ * every story below shares one seed.
+ */
+const seedStores = () => {
+  useOrgStore.setState({ primaryOrgId: ORG_ID, status: 'loaded' });
+  useAppointmentStore.getState().setAppointmentsForOrg(ORG_ID, [appointment]);
+};
+
+const baseInvoice: Invoice = {
+  id: 'a1b2c3d4e5f60718293a4b5c',
+  organisationId: ORG_ID,
+  appointmentId: APPOINTMENT_ID,
+  items: [
+    { name: 'General consultation', quantity: 1, unitPrice: 60, total: 60 },
+    { name: 'Rabies vaccination', quantity: 1, unitPrice: 35, total: 35 },
+  ],
+  subtotal: 95,
+  discountTotal: 10,
+  taxTotal: 7.65,
+  totalAmount: 92.65,
+  paymentCollectionMethod: 'PAYMENT_INTENT',
+  currency: 'USD',
+  status: 'PAID',
+  createdAt: new Date('2026-08-12T10:15:00.000Z'),
+  updatedAt: new Date('2026-08-12T10:15:00.000Z'),
+};
+
+const meta = {
+  title: 'Cards/InvoiceCard',
+  component: InvoiceCard,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The phone and tablet form of one finance table row. Every money figure is run through ' +
+          '`formatMoney` with the org currency, so a card cannot print a bare number in one place ' +
+          'and a formatted one in another. Status is the shared `StatusPill`, toned by ' +
+          '`getInvoiceStatusTone`, and the card closes with a full-width Secondary "View".',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: { invoice: baseInvoice, handleViewInvoice: fn() },
+  beforeEach: seedStores,
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 340 }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof InvoiceCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Paid: Story = {};
+
+export const AwaitingPayment: Story = {
+  name: 'Awaiting payment (payment link)',
+  args: {
+    invoice: {
+      ...baseInvoice,
+      id: 'b2c3d4e5f60718293a4b5c6d',
+      status: 'AWAITING_PAYMENT',
+      paymentCollectionMethod: 'PAYMENT_LINK',
+      discountTotal: 0,
+      taxTotal: 0,
+      totalAmount: 95,
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The info-toned pill, and a zero discount and tax — those two rows always render, so ' +
+          'this is the layout most invoices actually have.',
+      },
+    },
+  },
+};
+
+export const Unlinked: Story = {
+  name: 'No linked appointment',
+  args: {
+    invoice: {
+      ...baseInvoice,
+      id: 'c3d4e5f60718293a4b5c6d7e',
+      appointmentId: undefined,
+      status: 'CANCELLED',
+      items: [
+        {
+          name: 'Prescription diet — renal support, 4kg bag',
+          quantity: 2,
+          unitPrice: 48,
+          total: 96,
+        },
+        { name: 'Dispensing fee', quantity: 1, unitPrice: 5, total: 5 },
+      ],
+      subtotal: 101,
+      discountTotal: 0,
+      taxTotal: 8.08,
+      totalAmount: 109.08,
+      paymentCollectionMethod: 'PAYMENT_AT_CLINIC',
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'An over-the-counter sale: with no `appointmentId` there is no companion or parent to ' +
+          'look up, so the name line is blank and the parent falls back to `-` rather than to an ' +
+          'id. The long service list is also the wrapping case for the Service row.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/cards/OrgCard/OrgCard.stories.tsx
+++ b/apps/frontend/src/app/ui/cards/OrgCard/OrgCard.stories.tsx
@@ -99,7 +99,10 @@ export const Verified: Story = {
 export const Pending: Story = {
   name: 'Pending verification',
   args: {
-    org: buildRow({ _id: 'org-meadow', name: 'Meadowbrook Boarding', type: 'BOARDER' }, 'admin'),
+    org: buildRow(
+      { _id: 'org-meadow', name: 'Meadowbrook Boarding', type: 'BOARDER', isVerified: false },
+      'admin'
+    ),
   },
   parameters: {
     docs: {

--- a/apps/frontend/src/app/ui/cards/OrgCard/OrgCard.stories.tsx
+++ b/apps/frontend/src/app/ui/cards/OrgCard/OrgCard.stories.tsx
@@ -1,0 +1,151 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import type { Organisation, UserOrganization } from '@yosemite-crew/types';
+
+import type { OrgWithMembership } from '@/app/features/organization/types/org';
+import { useOrgStore } from '@/app/stores/orgStore';
+import OrgCard from './OrgCard';
+
+const CURRENT_ORG_ID = 'org-sunrise';
+
+const buildOrg = (overrides: Partial<Organisation> = {}): Organisation => ({
+  _id: CURRENT_ORG_ID,
+  name: 'Sunrise Veterinary',
+  type: 'HOSPITAL',
+  phoneNo: '+1 415 555 0134',
+  taxId: 'TAX-0001',
+  isVerified: true,
+  ...overrides,
+});
+
+const buildMembership = (roleDisplay: string): UserOrganization => ({
+  practitionerReference: 'Practitioner/pract-1',
+  organizationReference: `Organization/${CURRENT_ORG_ID}`,
+  roleCode: 'VET',
+  roleDisplay,
+});
+
+const buildRow = (
+  org: Partial<Organisation> = {},
+  roleDisplay = 'veterinarian'
+): OrgWithMembership => ({
+  org: buildOrg(org),
+  membership: buildMembership(roleDisplay),
+});
+
+/**
+ * The card reads `primaryOrgId` straight off the org store to decide whether it is
+ * the member's current organisation. Setting it here keeps the story offline - the
+ * store is never asked to load anything - and the previous state is restored on
+ * unmount so neighbouring stories are unaffected.
+ */
+const withPrimaryOrg = (primaryOrgId: string | null) => () => {
+  const snapshot = useOrgStore.getState();
+  useOrgStore.setState({ primaryOrgId });
+  return () => {
+    useOrgStore.setState(snapshot);
+  };
+};
+
+const meta = {
+  title: 'Cards/OrgCard',
+  component: OrgCard,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'One row in the organisation picker: a tinted initial tile, the organisation name with its ' +
+          'verification badge, a "role · type" subline and a forward chevron. The tile tint is derived ' +
+          'from the name so an organisation keeps the same colour between visits, except for the ' +
+          "member's current organisation, which is always the blue tile with the filled chevron. The " +
+          'whole row is a single button.',
+      },
+    },
+  },
+  argTypes: {
+    handleOrgClick: { table: { disable: true } },
+  },
+  args: {
+    org: buildRow(),
+    handleOrgClick: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 460 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  beforeEach: withPrimaryOrg(null),
+} satisfies Meta<typeof OrgCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Verified: Story = {
+  name: 'Verified, not current',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A verified organisation the member belongs to but has not switched into: palette tint on the ' +
+          'initial tile, the green VERIFIED badge and the outlined chevron.',
+      },
+    },
+  },
+};
+
+export const Pending: Story = {
+  name: 'Pending verification',
+  args: {
+    org: buildRow({ _id: 'org-meadow', name: 'Meadowbrook Boarding', type: 'BOARDER' }, 'admin'),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Until an organisation clears verification the badge flips to the amber PENDING tone. The ' +
+          'subline picks up the membership role and the business type, both title-cased.',
+      },
+    },
+  },
+};
+
+export const Current: Story = {
+  name: 'Current organisation',
+  beforeEach: withPrimaryOrg(CURRENT_ORG_ID),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The organisation the member is signed into. It always takes the blue tile regardless of the ' +
+          'name-derived palette, gains the highlighted border and swaps the outlined chevron for the ' +
+          'filled one.',
+      },
+    },
+  },
+};
+
+export const LongName: Story = {
+  name: 'Long name and role',
+  args: {
+    org: buildRow(
+      {
+        _id: 'org-long',
+        name: 'Northern Highlands Veterinary Hospital and Emergency Referral Centre',
+        type: 'HOSPITAL',
+      },
+      'senior consultant veterinary surgeon'
+    ),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Name and subline both truncate rather than wrap, so a long organisation name cannot push the ' +
+          'badge or the chevron out of the row or change its height.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/cards/RoomCard/RoomCard.stories.tsx
+++ b/apps/frontend/src/app/ui/cards/RoomCard/RoomCard.stories.tsx
@@ -1,0 +1,130 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import type { OrganisationRoom } from '@yosemite-crew/types';
+
+import RoomCard from './index';
+
+const SPECIALITY_NAMES: Record<string, string> = {
+  'spec-cardio': 'Cardiology',
+  'spec-derm': 'Dermatology',
+  'spec-ortho': 'Orthopaedics',
+  'spec-onco': 'Oncology',
+};
+
+const STAFF_NAMES: Record<string, string> = {
+  'staff-1': 'Dr. Alina Moreau',
+  'staff-2': 'Dr. Tomas Reyes',
+  'staff-3': 'Nurse Priya Raman',
+  'staff-4': 'Dr. Yusuf Adeyemi',
+};
+
+const baseRoom: OrganisationRoom = {
+  id: 'room-1',
+  name: 'Exam Room 2',
+  organisationId: 'org-sunrise',
+  code: 'EX-02',
+  type: 'EXAM_ROOM',
+  assignedSpecialiteis: [{ id: 'spec-cardio', name: 'Cardiology' }],
+  assignedStaffs: [{ id: 'staff-1', name: 'Dr. Alina Moreau' }],
+};
+
+const meta = {
+  title: 'Cards/RoomCard',
+  component: RoomCard,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The tile used on the rooms grid in organisation settings. It states the room name, its ' +
+          'title-cased type and the specialities and staff assigned to it, with a full-width ' +
+          '`Secondary` "View" action that opens the room drawer. Names are resolved through the ' +
+          'id-to-name maps the page already holds, so the card never has to fetch anything itself. ' +
+          'It sizes itself to half the row from the `sm` breakpoint up and goes full width below it.',
+      },
+    },
+  },
+  argTypes: {
+    handleViewRoom: { table: { disable: true } },
+  },
+  args: {
+    room: baseRoom,
+    handleViewRoom: fn(),
+    specialityNameById: SPECIALITY_NAMES,
+    staffNameById: STAFF_NAMES,
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 420 }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof RoomCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Assigned room',
+};
+
+export const Unassigned: Story = {
+  name: 'Nothing assigned',
+  args: {
+    room: {
+      ...baseRoom,
+      id: 'room-2',
+      name: 'Isolation Bay',
+      code: 'ISO-01',
+      type: 'ISOLATION',
+      assignedSpecialiteis: [],
+      assignedStaffs: [],
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A room with no specialities or staff yet. Both lines fall back to a single dash rather than ' +
+          'collapsing, so every card in the grid keeps the same four-line height and the "View" buttons ' +
+          'stay on one baseline.',
+      },
+    },
+  },
+};
+
+export const ManyAssignments: Story = {
+  name: 'Many assignments (wrapping)',
+  args: {
+    room: {
+      ...baseRoom,
+      id: 'room-3',
+      name: 'Surgical Theatre 1 - Orthopaedics and Soft Tissue',
+      code: 'SURG-01',
+      type: 'SURGERY',
+      assignedSpecialiteis: [
+        { id: 'spec-cardio', name: 'Cardiology' },
+        { id: 'spec-derm', name: 'Dermatology' },
+        { id: 'spec-ortho', name: 'Orthopaedics' },
+        { id: 'spec-onco', name: 'Oncology' },
+      ],
+      assignedStaffs: [
+        { id: 'staff-1', name: 'Dr. Alina Moreau' },
+        { id: 'staff-2', name: 'Dr. Tomas Reyes' },
+        { id: 'staff-3', name: 'Nurse Priya Raman' },
+        { id: 'staff-4', name: 'Dr. Yusuf Adeyemi' },
+      ],
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The assignment lines are a comma-joined list, so a busy theatre grows the card downwards. ' +
+          'This is the case that tells you whether a grid of cards still reads as a grid once one tile ' +
+          'is twice the height of its neighbours.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/cards/SpecialitiesCard/SpecialitiesCard.stories.tsx
+++ b/apps/frontend/src/app/ui/cards/SpecialitiesCard/SpecialitiesCard.stories.tsx
@@ -1,0 +1,144 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import type { Service } from '@yosemite-crew/types';
+
+import type { SpecialityWeb } from '../../../features/organization/types/speciality';
+import SpecialitiesCard from './index';
+
+const service = (name: string, id: string): Service => ({
+  id,
+  organisationId: 'org-1',
+  name,
+  durationMinutes: 30,
+  cost: 60,
+  isActive: true,
+});
+
+const CARDIOLOGY: SpecialityWeb = {
+  _id: 'spec-cardiology',
+  organisationId: 'org-1',
+  name: 'Cardiology',
+  headName: 'Dr. Emily Carter',
+  teamMemberIds: ['u-1', 'u-2', 'u-3'],
+  services: [service('Echocardiogram', 'svc-1'), service('Cardiac consult', 'svc-2')],
+};
+
+const meta = {
+  title: 'Cards/SpecialitiesCard',
+  component: SpecialitiesCard,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          "The tile in the organisation's specialities grid. It is a summary, not an editor: the " +
+          'speciality name, the services rolled up into one comma-joined line, the assigned head-count ' +
+          'and the head of department, with a full-width `Secondary` button that hands the speciality ' +
+          'back to the page so it can open the detail drawer.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    speciality: CARDIOLOGY,
+    handleViewSpeciality: fn(),
+  },
+} satisfies Meta<typeof SpecialitiesCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * One column of the grid. The tile has no width of its own, so the single-card
+ * stories supply the ~300px track the specialities page gives it.
+ */
+const inOneColumn: NonNullable<Story['decorators']> = (StoryFn) => (
+  <div style={{ maxWidth: 300 }}>
+    <StoryFn />
+  </div>
+);
+
+export const Default: Story = { decorators: [inOneColumn] };
+
+/**
+ * What a speciality looks like the day it is created: no services attached, no
+ * team assigned and no head named. Every label still renders, so the card keeps
+ * its height and the grid stays on a single row rhythm - the values are simply
+ * blank, which is the state worth watching for a stray "undefined".
+ */
+export const Empty: Story = {
+  name: 'Newly created (no services or team)',
+  decorators: [inOneColumn],
+  args: {
+    speciality: {
+      _id: 'spec-new',
+      organisationId: 'org-1',
+      name: 'Rehabilitation',
+    },
+  },
+};
+
+export const LongContent: Story = {
+  name: 'Long name and service list',
+  decorators: [inOneColumn],
+  args: {
+    speciality: {
+      _id: 'spec-internal-medicine',
+      organisationId: 'org-1',
+      name: 'Internal Medicine & Critical Care',
+      headName: 'Dr. Alexandra Fitzgerald-Whitmore',
+      teamMemberIds: Array.from({ length: 12 }, (_, index) => `u-${index}`),
+      services: [
+        service('Endoscopy', 'svc-3'),
+        service('Ultrasound diagnostics', 'svc-4'),
+        service('Intensive care monitoring', 'svc-5'),
+        service('Blood transfusion', 'svc-6'),
+      ],
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The overflow case. Nothing in the card truncates, so a long service list wraps and pushes ' +
+          'the button down - in a grid of equal-height tiles that is what makes one row taller than ' +
+          'the rest.',
+      },
+    },
+  },
+};
+
+/**
+ * How the cards actually read on the specialities page: a responsive grid where
+ * uneven content lengths have to sit next to each other.
+ */
+export const InGrid: StoryObj = {
+  name: 'In the specialities grid',
+  render: () => (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      <SpecialitiesCard speciality={CARDIOLOGY} handleViewSpeciality={fn()} />
+      <SpecialitiesCard
+        speciality={{
+          _id: 'spec-dermatology',
+          organisationId: 'org-1',
+          name: 'Dermatology',
+          headName: 'Dr. Nils Berg',
+          teamMemberIds: ['u-4'],
+          services: [service('Allergy testing', 'svc-7')],
+        }}
+        handleViewSpeciality={fn()}
+      />
+      <SpecialitiesCard
+        speciality={{
+          _id: 'spec-oncology',
+          organisationId: 'org-1',
+          name: 'Oncology',
+          headName: 'Dr. Priya Raman',
+          teamMemberIds: ['u-5', 'u-6'],
+          services: [service('Chemotherapy', 'svc-8'), service('Tumour staging', 'svc-9')],
+        }}
+        handleViewSpeciality={fn()}
+      />
+    </div>
+  ),
+};

--- a/apps/frontend/src/app/ui/cards/SpecialityCard/SpecialityCard.stories.tsx
+++ b/apps/frontend/src/app/ui/cards/SpecialityCard/SpecialityCard.stories.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import type { Speciality } from '@yosemite-crew/types';
+
+import SpecialityCard from './SpecialityCard';
+
+const speciality = (name: string): Speciality => ({
+  _id: name.toLowerCase().replaceAll(/\s+/g, '-'),
+  organisationId: 'org-1',
+  name,
+});
+
+const meta = {
+  title: 'Cards/SpecialityCard',
+  component: SpecialityCard,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          "One row in the organisation's speciality list: a hairline card holding the speciality name " +
+          'and a trash affordance that drops it from the working list. It is a purely local editor — ' +
+          'it calls `setSpecialities` and nothing else, so nothing is persisted until the surrounding ' +
+          'form is saved.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    speciality: speciality('Cardiology'),
+    setSpecialities: fn(),
+  },
+  decorators: [
+    (StoryFn) => (
+      <div style={{ maxWidth: 520 }}>
+        <StoryFn />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof SpecialityCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+/**
+ * The card is a fixed 48px band, so a long speciality name has to sit on one
+ * line beside the trash icon. This is the case that shows whether the name
+ * crowds the affordance.
+ */
+export const LongName: Story = {
+  name: 'Long name',
+  args: { speciality: speciality('Anesthesiology & Pain Management') },
+};
+
+/**
+ * How the list actually reads — several cards stacked, with delete wired to
+ * real state so removing one is visible.
+ */
+const SpecialityList = () => {
+  const [specialities, setSpecialities] = useState<Speciality[]>([
+    speciality('Cardiology'),
+    speciality('Dermatology'),
+    speciality('Emergency & Critical Care'),
+  ]);
+
+  return (
+    <div className="flex flex-col gap-2">
+      {specialities.map((item) => (
+        <SpecialityCard key={item.name} speciality={item} setSpecialities={setSpecialities} />
+      ))}
+    </div>
+  );
+};
+
+export const List: Story = {
+  render: () => <SpecialityList />,
+};

--- a/apps/frontend/src/app/ui/cards/TaskCard/TaskCard.stories.tsx
+++ b/apps/frontend/src/app/ui/cards/TaskCard/TaskCard.stories.tsx
@@ -1,0 +1,135 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import TaskCard from './index';
+import type { Task } from '@/app/features/tasks/types/task';
+
+const BASE_TASK: Task = {
+  _id: 'task-1',
+  organisationId: 'org-1',
+  assignedBy: 'Dr. Amelie Roth',
+  assignedTo: 'Nurse Jonas Weber',
+  audience: 'EMPLOYEE_TASK',
+  source: 'CUSTOM',
+  category: 'Medication',
+  name: 'Administer post-op analgesia',
+  description: 'Give 0.2 mg/kg meloxicam SC, then check the incision site.',
+  dueAt: new Date('2026-09-14T09:30:00.000Z'),
+  status: 'PENDING',
+};
+
+const meta = {
+  title: 'Cards/TaskCard',
+  component: TaskCard,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Card form of a task on the tasks board: name and status pill on top, the quick details ' +
+          '(category, instructions), the from/to/due lines, then the round action chips. Which ' +
+          'chips appear is derived from the task status and `canEditTasks` — a completed task ' +
+          'cannot be rescheduled, so it only offers View.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    canEditTasks: { control: 'boolean' },
+  },
+  args: {
+    item: BASE_TASK,
+    canEditTasks: false,
+    handleViewTask: fn(),
+    handleChangeStatusTask: fn(),
+    handleRescheduleTask: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 360 }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof TaskCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ReadOnly: Story = {
+  name: 'Read-only (View only)',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Without `canEditTasks` the card exposes a single action. This is what a member without ' +
+          'the task-edit permission sees.',
+      },
+    },
+  },
+};
+
+export const Editable: Story = {
+  name: 'Editable, pending',
+  args: { canEditTasks: true },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A pending task can move status and be rescheduled, so all three chips render and wrap ' +
+          'inside the 184px action row.',
+      },
+    },
+  },
+};
+
+export const Completed: Story = {
+  name: 'Completed',
+  args: {
+    canEditTasks: true,
+    item: {
+      ...BASE_TASK,
+      _id: 'task-2',
+      name: 'Confirm discharge paperwork',
+      category: 'Admin',
+      description: 'Owner signed the consent form at reception.',
+      status: 'COMPLETED',
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A completed task has no onward transitions and cannot be rescheduled, so both edit ' +
+          'chips drop out even with `canEditTasks` on — the pill turns `success`.',
+      },
+    },
+  },
+};
+
+export const LongContent: Story = {
+  name: 'Long text (clamped)',
+  args: {
+    canEditTasks: true,
+    item: {
+      ...BASE_TASK,
+      _id: 'task-3',
+      name: 'Recheck the surgical site and confirm the drain is patent before the evening round',
+      category: 'Post-operative monitoring and wound care',
+      description:
+        'Palpate around the drain, record any discharge in the chart, flush with sterile saline if the line is sluggish, and page the duty surgeon if the swelling has increased since this morning.',
+      status: 'IN_PROGRESS',
+    },
+    assignedByLabel: 'Dr. Amelie Roth-Bergmann (Head of Surgery)',
+    assignedToLabel: 'Nurse Jonas Weber-Lindqvist',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The overflow case. Detail values are `line-clamp-1`, but the title, from and to lines ' +
+          'are not — this story is the guard against a long name pushing the status pill off the ' +
+          'card.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/cards/VideosCard/VideosCard.stories.tsx
+++ b/apps/frontend/src/app/ui/cards/VideosCard/VideosCard.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import VideosCard from './VideosCard';
+
+/** Same key the card writes when it is dismissed. */
+const HIDDEN_STORAGE_KEY = 'yc_dashboard_videos_hidden';
+
+const PHONE_VIEWPORT = {
+  phone: {
+    name: 'Mobile (375)',
+    styles: { width: '375px', height: '812px' },
+    type: 'mobile',
+  },
+};
+
+const meta = {
+  title: 'Cards/VideosCard',
+  component: VideosCard,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Dismissible dashboard banner that points a new clinic at the first three guide videos. ' +
+          'The heading wraps while the "View more" button and close affordance stay on one line, and ' +
+          'the three tiles sit in a 3-up grid that collapses to a single column below `md`. Tapping a ' +
+          'tile opens the shared video player modal. Dismissing it writes to local storage and the ' +
+          'card never renders again — every story clears that key first so it always appears.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  beforeEach: () => {
+    globalThis.localStorage?.removeItem(HIDDEN_STORAGE_KEY);
+    return () => {
+      globalThis.localStorage?.removeItem(HIDDEN_STORAGE_KEY);
+    };
+  },
+} satisfies Meta<typeof VideosCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Desktop reading: three tiles side by side under the heading row.',
+      },
+    },
+  },
+};
+
+export const Phone: Story = {
+  name: 'Phone (single column)',
+  globals: { viewport: { value: 'phone', isRotated: false } },
+  parameters: {
+    viewport: { options: PHONE_VIEWPORT },
+    chromatic: { viewports: [375] },
+    docs: {
+      description: {
+        story:
+          'Below `md` the tiles stack and the thumbnails grow taller. The heading is the only element ' +
+          'allowed to wrap: "View more" must stay on one line next to the close button.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/filters/Filters/Filters.stories.tsx
+++ b/apps/frontend/src/app/ui/filters/Filters/Filters.stories.tsx
@@ -1,0 +1,132 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import {
+  CompanionsSpeciesFilters,
+  CompanionsStatusFilters,
+  filter,
+  statusFromToken,
+} from '../../../features/companions/pages/Companions/types';
+import Filters from './index';
+
+const APPOINTMENT_FILTERS = [filter('All', 'all'), filter('Emergencies', 'emergencies')];
+
+const APPOINTMENT_STATUSES = [
+  statusFromToken('All', 'all', 'color-pill-neutral'),
+  statusFromToken('Confirmed', 'confirmed', 'color-pill-success'),
+  statusFromToken('In progress', 'in_progress', 'color-pill-progress'),
+  statusFromToken('Cancelled', 'cancelled', 'color-pill-warning'),
+];
+
+const meta = {
+  title: 'Filters/Filters',
+  component: Filters,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The list-toolbar filter bar. With `filterOptions` it renders the inline layout: filter ' +
+          'chips on the left, a hairline divider, then a status pill per status, with the optional ' +
+          'add button pinned right. Without `filterOptions` it collapses to the compact ' +
+          '"All statuses" dropdown used by standalone toolbars. The emergencies chip is always ' +
+          'danger-toned and carries the 6px danger dot.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    showAddButton: { control: 'boolean' },
+    compactFilterPills: { control: 'boolean' },
+    hasEmergency: { control: 'boolean' },
+  },
+  args: {
+    setActiveFilter: fn(),
+    setActiveStatus: fn(),
+    onAddButtonClick: fn(),
+  },
+} satisfies Meta<typeof Filters>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ListToolbar: Story = {
+  name: 'List toolbar (chips + status pills)',
+  args: {
+    filterOptions: APPOINTMENT_FILTERS,
+    statusOptions: APPOINTMENT_STATUSES,
+    activeFilter: 'all',
+    activeStatus: 'all',
+    hasEmergency: true,
+    showAddButton: true,
+    addButtonText: 'New appointment',
+  },
+};
+
+export const EmergencySelected: Story = {
+  name: 'Emergencies selected',
+  args: {
+    ...ListToolbar.args,
+    activeFilter: 'emergencies',
+    activeStatus: 'in_progress',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Active emergency chip fills with `--danger-bg`; the active status pill takes that ' +
+          "status' own bg/border/text tokens at weight 700 while the rest stay hairline/muted.",
+      },
+    },
+  },
+};
+
+export const CompactPills: Story = {
+  name: 'Compact pills, no add button',
+  args: {
+    filterOptions: CompanionsSpeciesFilters,
+    statusOptions: CompanionsStatusFilters,
+    activeFilter: 'dog',
+    activeStatus: 'active',
+    compactFilterPills: true,
+    showAddButton: false,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Five species chips plus four status pills at the compact 3px/12px padding — the ' +
+          'wrapping case the toolbar has to survive on tablet widths.',
+      },
+    },
+  },
+};
+
+const StatusOnlyToolbar = () => {
+  const [activeStatus, setActiveStatus] = useState('all');
+  return (
+    <Filters
+      statusOptions={CompanionsStatusFilters}
+      activeStatus={activeStatus}
+      setActiveStatus={setActiveStatus}
+      showAddButton
+      addButtonText="Add companion"
+      onAddButtonClick={fn()}
+    />
+  );
+};
+
+export const StatusDropdown: Story = {
+  name: 'Status dropdown only',
+  render: () => <StatusOnlyToolbar />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'No `filterOptions`, so the statuses collapse into the compact dropdown trigger. The ' +
+          'panel is portalled to `document.body` and positioned against the trigger, so it escapes ' +
+          'any clipping toolbar. Interactive: open it and pick a status.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/filters/FormsFilters/FormsFilters.stories.tsx
+++ b/apps/frontend/src/app/ui/filters/FormsFilters/FormsFilters.stories.tsx
@@ -1,0 +1,85 @@
+import { type ComponentProps, useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import FormsFilters, { type FormsFilterState } from './index';
+import { Secondary } from '../../primitives/Buttons';
+import { useOrgStore } from '../../../stores/orgStore';
+
+/**
+ * The category list narrows to the primary organisation's type, and the org
+ * store persists to localStorage — so without this the label would depend on
+ * whichever story ran before. No primary org means the whole taxonomy is
+ * offered, which is the widest case to review.
+ */
+const detachPrimaryOrg = () => {
+  const previousOrgState = useOrgStore.getState();
+  useOrgStore.setState({ primaryOrgId: null });
+  return () => {
+    useOrgStore.setState(previousOrgState);
+  };
+};
+
+/**
+ * Controlled wrapper. `FormsFilters` owns no filter state — the forms page
+ * holds it — so each story keeps it locally and lets the pills actually react.
+ */
+const ControlledFormsFilters = (args: ComponentProps<typeof FormsFilters>) => {
+  const [filters, setFilters] = useState<FormsFilterState>(args.filters);
+  return <FormsFilters {...args} filters={filters} onFiltersChange={setFilters} />;
+};
+
+const meta = {
+  title: 'Filters/FormsFilters',
+  component: FormsFilters,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Toolbar above the forms list: a row of status pills on the left, and a category dropdown (plus an optional ' +
+          'action slot) pinned right. The active status pill keeps its own tone; every inactive pill flattens to a ' +
+          'transparent `--hairline` outline in `--ink-muted`, which is how the row reads as single-select. ' +
+          'The category list is derived from the primary organisation type in the org store; these stories clear the primary org, so the whole taxonomy is on offer.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    filters: { status: 'All', category: 'All' },
+    onFiltersChange: () => {},
+  },
+  render: (args) => <ControlledFormsFilters {...args} />,
+  beforeEach: detachPrimaryOrg,
+} satisfies Meta<typeof FormsFilters>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Unfiltered: "All" is the active pill and the dropdown reads "All categories". */
+export const Default: Story = {};
+
+/**
+ * A status is active. `Published` keeps its success tone while `All`, `Draft`
+ * and `Archived` drop back to the muted outline.
+ */
+export const StatusSelected: Story = {
+  args: { filters: { status: 'Published', category: 'All' } },
+};
+
+/**
+ * A category is chosen too. The trigger truncates rather than growing, which
+ * matters because the taxonomy includes labels as long as
+ * "Groomer - Service Request & Preferences".
+ */
+export const CategorySelected: Story = {
+  args: { filters: { status: 'Draft', category: 'Groomer - Service Request & Preferences' } },
+};
+
+/**
+ * With the optional `categoryAction` slot filled — the forms page passes its
+ * "New form" button here, ahead of the hairline separator.
+ */
+export const WithCategoryAction: Story = {
+  args: {
+    categoryAction: <Secondary text="New form" href="#" size="compact" />,
+  },
+};

--- a/apps/frontend/src/app/ui/filters/InventoryFilters/InventoryFilters.stories.tsx
+++ b/apps/frontend/src/app/ui/filters/InventoryFilters/InventoryFilters.stories.tsx
@@ -1,0 +1,114 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import type { InventoryFiltersState } from '@/app/features/inventory/pages/Inventory/types';
+import { Secondary } from '@/app/ui/primitives/Buttons';
+import InventoryFilters from './index';
+
+const CATEGORIES = ['Antibiotic', 'Anaesthetic', 'Vaccine', 'Consumable', 'Diet'];
+
+const baseFilters: InventoryFiltersState = {
+  category: 'all',
+  categories: [],
+  subCategories: [],
+  locations: [],
+  abcClasses: [],
+  suppliers: [],
+  visibility: 'ALL',
+  status: 'ALL',
+  search: '',
+};
+
+const meta = {
+  title: 'Filters/InventoryFilters',
+  component: InventoryFilters,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Toolbar above the inventory list. Left side: the three-way All/Active/Hidden visibility ' +
+          'toggle (a sliding `--color-neutral-900` thumb) and the stock-health pill, whose fill, ' +
+          'border and text come from the selected status tokens rather than a fixed colour. Right ' +
+          'side: an optional caller-supplied action and the category `LabelDropdown`. The ' +
+          'stock-health panel is portalled to `document.body` and positioned from the trigger rect, ' +
+          'so a scrolling toolbar cannot clip it.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    loading: { control: 'boolean' },
+  },
+  args: {
+    filters: baseFilters,
+    categories: CATEGORIES,
+    onChange: fn(),
+    loading: false,
+  },
+} satisfies Meta<typeof InventoryFilters>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const StockHealthSelected: Story = {
+  name: 'Low stock, hidden items',
+  args: {
+    filters: { ...baseFilters, status: 'LOW_STOCK', visibility: 'HIDDEN', category: 'Antibiotic' },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A non-`ALL` stock health repaints the trigger in that status’ own pill tokens and ' +
+          'swaps the label from "Stock health" to the status name. The visibility thumb has slid to ' +
+          'the third segment, and the category dropdown shows the picked category instead of the ' +
+          '"All categories" default.',
+      },
+    },
+  },
+};
+
+export const Loading: Story = {
+  name: 'Loading (controls locked)',
+  args: { loading: true },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'While the inventory query is in flight the visibility segments and the stock-health ' +
+          'trigger are disabled, so a second filter cannot be queued against a list that is about ' +
+          'to be replaced.',
+      },
+    },
+  },
+};
+
+const InteractiveInventoryFilters = () => {
+  const [filters, setFilters] = useState<InventoryFiltersState>(baseFilters);
+  return (
+    <InventoryFilters
+      filters={filters}
+      onChange={setFilters}
+      categories={CATEGORIES}
+      categoryAction={<Secondary text="Manage categories" size="small" onClick={fn()} />}
+    />
+  );
+};
+
+export const Interactive: Story = {
+  name: 'Interactive, with a category action',
+  render: () => <InteractiveInventoryFilters />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Wired to local state so the sliding toggle, the portalled stock-health panel and the ' +
+          'category dropdown all respond. `categoryAction` slots a caller-owned button in ahead of ' +
+          'the category dropdown; the inventory page uses it for "Manage categories".',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/filters/InventoryTurnoverFilters/InventoryTurnoverFilters.stories.tsx
+++ b/apps/frontend/src/app/ui/filters/InventoryTurnoverFilters/InventoryTurnoverFilters.stories.tsx
@@ -1,0 +1,99 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+
+import InventoryTurnoverFilters, { type InventoryTurnoverFilterState } from './index';
+
+const CATEGORIES = ['Antibiotic', 'Anaesthetic', 'Vaccine', 'Consumable', 'Diet'];
+
+const baseFilters: InventoryTurnoverFilterState = {
+  status: 'ALL',
+  category: 'all',
+};
+
+const meta = {
+  title: 'Filters/InventoryTurnoverFilters',
+  component: InventoryTurnoverFilters,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Toolbar above the inventory turnover report: a stock-health trigger on the left and the ' +
+          'category `LabelDropdown` on the right. The trigger repaints itself from the selected ' +
+          'status tokens - neutral card border while it is on "All", the pill fill, border and text ' +
+          'of the chosen health band otherwise - so the control states the current filter without a ' +
+          'separate chip. Its option list is portalled to `document.body` and positioned from the ' +
+          'trigger rect, so a scrolled or clipped toolbar cannot cut it off.',
+      },
+    },
+  },
+  args: {
+    filters: baseFilters,
+    categories: CATEGORIES,
+    setFilters: fn(),
+  },
+} satisfies Meta<typeof InventoryTurnoverFilters>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'No filters applied',
+};
+
+export const LowStockSelected: Story = {
+  name: 'Low stock, one category',
+  args: {
+    filters: { status: 'LOW', category: 'Antibiotic' },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A non-`ALL` status swaps the trigger label from "Status" to the band name and repaints it ' +
+          "in that band's warning tokens. The category dropdown shows the picked category in place of " +
+          'the "All categories" default.',
+      },
+    },
+  },
+};
+
+export const UnknownCategory: Story = {
+  name: 'Category no longer in the list',
+  args: {
+    filters: { status: 'EXCELLENT', category: 'Discontinued line' },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A stored category that is no longer offered - the supplier list changed under a saved ' +
+          'filter - falls back to "All categories" rather than rendering a dropdown with no matching ' +
+          'option. The status pill is unaffected and stays on its success tone.',
+      },
+    },
+  },
+};
+
+const InteractiveTurnoverFilters = () => {
+  const [filters, setFilters] = useState<InventoryTurnoverFilterState>(baseFilters);
+  return (
+    <InventoryTurnoverFilters filters={filters} setFilters={setFilters} categories={CATEGORIES} />
+  );
+};
+
+export const Interactive: Story = {
+  name: 'Interactive',
+  render: () => <InteractiveTurnoverFilters />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Wired to local state so the portalled status panel and the category dropdown both respond. ' +
+          'Use this one to check that the trigger recolours to each of the six health bands and that ' +
+          'the panel stays anchored to the trigger while the page scrolls.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/filters/StatusOptionButtons.stories.tsx
+++ b/apps/frontend/src/app/ui/filters/StatusOptionButtons.stories.tsx
@@ -1,0 +1,141 @@
+import { type ComponentProps, useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+
+import { AppointmentLabels, statusLabel } from '../../constants/status';
+import StatusOptionButtons, { type StatusOptionButtonsOption } from './StatusOptionButtons';
+
+/**
+ * Every caller passes options that already carry their own text token, so the
+ * stories use the same shape rather than a colour map of their own.
+ */
+type FilterOption = StatusOptionButtonsOption & { text: string };
+
+/**
+ * The neutral "all" row takes plain primary ink; each real status keeps its own
+ * `--status-*-text` token so the row reads as the status it filters to.
+ */
+const getTextColor = (option: FilterOption): string =>
+  option.key === 'ALL' ? 'var(--color-text-primary)' : option.text;
+
+const ALL_OPTION = statusLabel('All', 'ALL', 'color-badge-blue', 'var(--color-primary-500)');
+
+const APPOINTMENT_OPTIONS: FilterOption[] = [ALL_OPTION, ...AppointmentLabels];
+
+const STOCK_HEALTH_OPTIONS: FilterOption[] = [
+  ALL_OPTION,
+  statusLabel('Healthy', 'HEALTHY', 'color-pill-success'),
+  statusLabel('Low stock', 'LOW_STOCK', 'color-pill-progress'),
+  statusLabel('Expiring soon', 'EXPIRING_SOON', 'color-pill-info'),
+  statusLabel('Expired', 'EXPIRED', 'color-pill-warning'),
+];
+
+const meta = {
+  title: 'Filters/StatusOptionButtons',
+  component: StatusOptionButtons<FilterOption>,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          "The option rows inside every status-filter dropdown: a dot swatch in the option's border " +
+          'colour, the name in its own text colour, and a trailing check on the active row. It owns ' +
+          'nothing else - the trigger, the portal, the panel chrome and the selection state all stay ' +
+          'with the caller, which is why the stories supply the `yc-glass-overlay` panel around it.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    options: APPOINTMENT_OPTIONS,
+    allKey: 'ALL',
+    activeKey: 'ALL',
+    onSelect: fn(),
+    getTextColor,
+  },
+  decorators: [
+    (StoryFn) => (
+      <div className="yc-glass-overlay rounded-2xl overflow-hidden" style={{ minWidth: 200 }}>
+        <StoryFn />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof StatusOptionButtons<FilterOption>>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * The resting panel: "All" is active, so it carries the check but not the
+ * active font weight - it is the neutral row, not a status.
+ */
+export const Default: Story = {};
+
+export const StatusSelected: Story = {
+  name: 'Status selected',
+  args: { activeKey: 'in_progress' },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A real status is active. Unlike the "all" row it takes `font-medium`, and both the check ' +
+          'and the label render in the status text token rather than plain ink.',
+      },
+    },
+  },
+};
+
+export const StockHealth: Story = {
+  name: 'Stock health options',
+  args: { options: STOCK_HEALTH_OPTIONS, activeKey: 'EXPIRING_SOON' },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The inventory panel, which draws from the `--color-pill-*` family instead. Same rows, ' +
+          'different token set - worth keeping side by side so the two panels stay the same shape.',
+      },
+    },
+  },
+};
+
+export const NoSwatches: Story = {
+  name: 'Options without a swatch',
+  args: {
+    options: [
+      { key: 'ALL', name: 'All', text: 'var(--color-text-primary)' },
+      { key: 'ACTIVE', name: 'Active', text: 'var(--color-text-primary)' },
+      { key: 'HIDDEN', name: 'Hidden', text: 'var(--color-text-tertiary)' },
+    ],
+    activeKey: 'ACTIVE',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`border` is optional. Without it the dot is dropped entirely rather than rendered ' +
+          'transparent, so the labels sit flush against the left padding.',
+      },
+    },
+  },
+};
+
+const InteractiveStatusOptions = (
+  args: ComponentProps<typeof StatusOptionButtons<FilterOption>>
+) => {
+  const [activeKey, setActiveKey] = useState('ALL');
+  return (
+    <StatusOptionButtons<FilterOption> {...args} activeKey={activeKey} onSelect={setActiveKey} />
+  );
+};
+
+export const Interactive: Story = {
+  render: (args) => <InteractiveStatusOptions {...args} />,
+  parameters: {
+    docs: {
+      description: {
+        story: 'Selection wired to local state, so the check and hover states can be exercised.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/icons/Icon.stories.tsx
+++ b/apps/frontend/src/app/ui/icons/Icon.stories.tsx
@@ -1,0 +1,115 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Icon } from './Icon';
+import { OFFLINE_ICONS } from './offlineIcons';
+
+const meta = {
+  title: 'Icons/Icon',
+  component: Icon,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Drop-in replacement for Iconify’s `<Icon>`. Import this rather than `@iconify/react`: a ' +
+          'bare string name makes Iconify fetch the icon from api.iconify.design at render time, which ' +
+          'costs a third-party request on first paint and is blocked outright by the app’s CSP. This ' +
+          'wrapper looks the name up in the bundled `OFFLINE_ICONS` set first, so rendering stays local ' +
+          'and synchronous. A name that is not bundled falls through to Iconify unchanged - which is ' +
+          'the one case to watch for, since it will silently render nothing under the CSP.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    icon: 'solar:calendar-bold',
+    width: 28,
+    height: 28,
+  },
+  argTypes: {
+    icon: {
+      control: 'select',
+      options: Object.keys(OFFLINE_ICONS),
+      description: 'Bundled icon name. Anything outside this list is not offline-safe.',
+    },
+  },
+} satisfies Meta<typeof Icon>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Coloured: Story = {
+  name: 'Inherits currentColor',
+  args: { icon: 'solar:heart-bold', width: 32, height: 32 },
+  decorators: [
+    (Story) => (
+      <span style={{ color: 'var(--blue-text)' }}>
+        <Story />
+      </span>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Icons paint in `currentColor`, so they take the ink of whatever they sit in rather than ' +
+          'carrying a colour of their own. Set the colour on the parent.',
+      },
+    },
+  },
+};
+
+export const BundledSet: Story = {
+  name: 'The bundled set',
+  render: () => (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fill, minmax(104px, 1fr))',
+        gap: 12,
+        maxWidth: 680,
+      }}
+    >
+      {Object.keys(OFFLINE_ICONS).map((name) => (
+        <div
+          key={name}
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: 6,
+            padding: '12px 6px',
+            borderRadius: 12,
+            border: '1px solid var(--hairline)',
+            background: 'var(--screen)',
+            color: 'var(--ink-body)',
+          }}
+        >
+          <Icon icon={name} width={24} height={24} />
+          <span
+            style={{
+              fontSize: 10,
+              lineHeight: 1.3,
+              textAlign: 'center',
+              color: 'var(--ink-faint)',
+              wordBreak: 'break-word',
+            }}
+          >
+            {name.replace(/^[^:]+:/, '')}
+          </span>
+        </div>
+      ))}
+    </div>
+  ),
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        story:
+          'Every name that renders without a network request. Check here before using an icon name ' +
+          'in a component - one that is missing needs adding to `offlineIcons.ts` first.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/icons/Icon.stories.tsx
+++ b/apps/frontend/src/app/ui/icons/Icon.stories.tsx
@@ -21,7 +21,7 @@ const meta = {
   },
   tags: ['autodocs'],
   args: {
-    icon: 'solar:calendar-bold',
+    icon: 'ion:paw-outline',
     width: 28,
     height: 28,
   },
@@ -41,7 +41,7 @@ export const Default: Story = {};
 
 export const Coloured: Story = {
   name: 'Inherits currentColor',
-  args: { icon: 'solar:heart-bold', width: 32, height: 32 },
+  args: { icon: 'solar:verified-check-bold', width: 32, height: 32 },
   decorators: [
     (Story) => (
       <span style={{ color: 'var(--blue-text)' }}>

--- a/apps/frontend/src/app/ui/inputs/GoogleSearchDropDown/GoogleSearchDropDown.stories.tsx
+++ b/apps/frontend/src/app/ui/inputs/GoogleSearchDropDown/GoogleSearchDropDown.stories.tsx
@@ -1,0 +1,94 @@
+import { useState, type ComponentProps } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+
+import GoogleSearchDropDown from './GoogleSearchDropDown';
+
+const StatefulGoogleSearchDropDown = (args: ComponentProps<typeof GoogleSearchDropDown>) => {
+  const [value, setValue] = useState(args.value);
+  return (
+    <GoogleSearchDropDown
+      {...args}
+      value={value}
+      onChange={(event) => {
+        setValue(event.target.value);
+        args.onChange?.(event);
+      }}
+    />
+  );
+};
+
+const meta = {
+  title: 'Inputs/GoogleSearchDropDown',
+  component: GoogleSearchDropDown,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Address field backed by Google Places autocomplete: the user types a clinic or address, ' +
+          'picks a prediction, and the component fills the surrounding form (name, phone, website and ' +
+          'the split address) from the place details. The field is the standard 44px form input — ' +
+          '`--field-bg` fill, 1.5px `--hairline` border, 12px radius — and squares its bottom corners ' +
+          'while the prediction list is open. Predictions are fetched from the live Places API after ' +
+          'two characters, so in Storybook (no API key) typing leaves the list closed; the stories ' +
+          'below cover the states the field renders on its own.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    readonly: { control: 'boolean' },
+    error: { control: 'text' },
+  },
+  args: {
+    intype: 'text',
+    inname: 'address',
+    inlabel: 'Clinic address',
+    value: '',
+    onChange: fn(),
+  },
+  decorators: [
+    (StoryFn) => (
+      <div style={{ width: 420 }}>
+        <StoryFn />
+      </div>
+    ),
+  ],
+  render: (args) => <StatefulGoogleSearchDropDown {...args} />,
+} satisfies Meta<typeof GoogleSearchDropDown>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Filled: Story = {
+  name: 'Address selected',
+  args: { value: '1200 Mission Street, Suite 4' },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'After a prediction is picked the field holds the street line; the rest of the address lands in the form around it.',
+      },
+    },
+  },
+};
+
+export const WithError: Story = {
+  name: 'Validation error',
+  args: { value: 'Unknown place', error: 'Select an address from the list' },
+};
+
+export const ReadOnly: Story = {
+  name: 'Read only',
+  args: { value: '1200 Mission Street, Suite 4', readonly: true },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Read-only fields never open the prediction list and never call the Places API.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/inputs/ServiceSearch/ServiceSearchEdit.stories.tsx
+++ b/apps/frontend/src/app/ui/inputs/ServiceSearch/ServiceSearchEdit.stories.tsx
@@ -1,0 +1,102 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { userEvent, within } from 'storybook/test';
+import type { Service } from '@yosemite-crew/types';
+import type { SpecialityWeb } from '@/app/features/organization/types/speciality';
+
+import ServiceSearchEdit from './ServiceSearchEdit';
+
+const ORG_ID = 'org-storybook';
+
+const service = (name: string): Service => ({
+  id: name.toLowerCase().replaceAll(/\W+/g, '-'),
+  organisationId: ORG_ID,
+  name,
+  durationMinutes: 30,
+  cost: 60,
+  specialityId: 'speciality-dentistry',
+  isActive: true,
+});
+
+const DENTISTRY: SpecialityWeb = {
+  _id: 'speciality-dentistry',
+  organisationId: ORG_ID,
+  name: 'Dentistry',
+  services: [],
+};
+
+const meta = {
+  title: 'Inputs/ServiceSearchEdit',
+  component: ServiceSearchEdit,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The add-a-service field on an existing speciality. It offers the built-in catalogue for ' +
+          'that speciality, hides services the speciality already has, and falls back to a create row ' +
+          'when nothing matches. Picking or creating a service writes it straight through to the API, ' +
+          'so these stories stop at the open dropdown and never commit a selection.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    speciality: DENTISTRY,
+  },
+  decorators: [
+    // The dropdown is absolutely positioned under the field, so the frame needs
+    // room below it or the open state is clipped out of the snapshot.
+    (StoryFn) => (
+      <div style={{ width: 340, paddingBottom: 300 }}>
+        <StoryFn />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ServiceSearchEdit>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Resting state — just the search field. */
+export const Default: Story = { name: 'Closed' };
+
+/** Focusing the field lists every catalogue service for the speciality. */
+export const DropdownOpen: Story = {
+  name: 'Dropdown open',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('textbox', { name: /search or create service/i }));
+  },
+};
+
+/**
+ * Services the speciality already carries are filtered out, so the list shrinks
+ * as the speciality fills up rather than offering duplicates.
+ */
+export const AlreadyAdded: Story = {
+  name: 'Existing services filtered out',
+  args: {
+    speciality: {
+      ...DENTISTRY,
+      services: [service('Dental Cleaning & Scaling'), service('Tooth Extraction')],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('textbox', { name: /search or create service/i }));
+  },
+};
+
+/**
+ * No catalogue match — the dropdown collapses to a single create row that
+ * quotes the typed name back. The name is capitalised on save.
+ */
+export const CreateNew: Story = {
+  name: 'No match (create)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('textbox', { name: /search or create service/i });
+    await userEvent.click(input);
+    await userEvent.type(input, 'feline dental radiographs');
+  },
+};

--- a/apps/frontend/src/app/ui/inputs/SpecialitySearch/SpecialitySearch.stories.tsx
+++ b/apps/frontend/src/app/ui/inputs/SpecialitySearch/SpecialitySearch.stories.tsx
@@ -1,0 +1,139 @@
+import { type ComponentProps, useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn, userEvent, within } from 'storybook/test';
+import type { Speciality } from '@yosemite-crew/types';
+import SpecialitySearch from './SpecialitySearch';
+
+const ORG_ID = 'org-storybook';
+
+/**
+ * The component only owns the field and its dropdown — the selected chips are
+ * the caller's job — so the wrapper renders both, which is what the settings
+ * and onboarding screens do around it.
+ */
+const StatefulSpecialitySearch = ({
+  organisationId,
+  specialities: initialSpecialities,
+  multiple,
+}: ComponentProps<typeof SpecialitySearch>) => {
+  const [specialities, setSpecialities] = useState<Speciality[]>(initialSpecialities);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12, width: 340 }}>
+      <SpecialitySearch
+        organisationId={organisationId}
+        specialities={specialities}
+        setSpecialities={setSpecialities}
+        multiple={multiple}
+      />
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+        {specialities.map((speciality) => (
+          <span
+            key={speciality.name}
+            className="text-caption-1"
+            style={{
+              padding: '4px 12px',
+              borderRadius: 9999,
+              border: '1px solid var(--hairline)',
+              background: 'var(--band)',
+              color: 'var(--ink-body)',
+            }}
+          >
+            {speciality.name}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const meta = {
+  title: 'Inputs/SpecialitySearch',
+  component: SpecialitySearch,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Type-ahead over the built-in speciality list that doubles as a create field: if nothing ' +
+          'matches, the dropdown offers to add the typed name instead. Selections are appended to ' +
+          "the caller's `specialities` array and disappear from the list, so the same speciality " +
+          'cannot be added twice.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    multiple: { control: 'boolean' },
+  },
+  args: {
+    organisationId: ORG_ID,
+    specialities: [],
+    setSpecialities: fn(),
+    multiple: true,
+  },
+  render: (args) => <StatefulSpecialitySearch {...args} />,
+} satisfies Meta<typeof SpecialitySearch>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Closed',
+};
+
+export const WithSelection: Story = {
+  name: 'With selections',
+  args: {
+    specialities: [
+      { name: 'Cardiology', organisationId: ORG_ID },
+      { name: 'Dermatology', organisationId: ORG_ID },
+    ],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Already-selected specialities are filtered out of the dropdown, which is why the ' +
+          'component needs the current array rather than just a change handler.',
+      },
+    },
+  },
+};
+
+export const ResultsOpen: Story = {
+  name: 'Dropdown open',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('textbox', { name: /search or create specialty/i }));
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Focusing the field opens the full list. The panel is `--screen` on a hairline with a ' +
+          '200px scroll cap, so a long catalogue never runs off the bottom of a settings drawer.',
+      },
+    },
+  },
+};
+
+export const CreateNew: Story = {
+  name: 'No match (create)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('textbox', { name: /search or create specialty/i });
+    await userEvent.click(input);
+    await userEvent.type(input, 'Exotic reptile medicine');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'When the query matches nothing the dropdown collapses to a single create row. The name ' +
+          'is capitalised on save, so "exotic reptile medicine" is stored as "Exotic reptile ' +
+          'medicine".',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/inputs/SpecialitySearch/SpecialitySearchWeb.stories.tsx
+++ b/apps/frontend/src/app/ui/inputs/SpecialitySearch/SpecialitySearchWeb.stories.tsx
@@ -1,0 +1,146 @@
+import { type ComponentProps, useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn, userEvent, within } from 'storybook/test';
+
+import SpecialitySearchWeb from './SpecialitySearchWeb';
+import type { SpecialityWeb } from '../../../features/organization/types/speciality';
+// Relative, not `@/`: the Storybook Vite build does not resolve the `@/` alias
+// for runtime imports inside story files.
+import { useOrgStore } from '../../../stores/orgStore';
+
+const ORG_ID = 'org-storybook';
+
+const speciality = (name: string): SpecialityWeb => ({ name, organisationId: ORG_ID });
+
+/**
+ * The component resolves the organisation from the org store rather than taking
+ * it as a prop, and refuses to add anything when there is none. Seeding the
+ * store is therefore what makes selection work at all; the previous state is
+ * put back when the story unmounts.
+ */
+const withPrimaryOrg = () => {
+  const snapshot = useOrgStore.getState();
+  useOrgStore.setState({ primaryOrgId: ORG_ID });
+  return () => {
+    useOrgStore.setState(snapshot);
+  };
+};
+
+/**
+ * The field owns neither the selection nor the chips — the edit form around it
+ * does — so the wrapper renders both, the way the team and organisation edit
+ * drawers do.
+ */
+const StatefulSpecialitySearchWeb = ({
+  specialities: initialSpecialities,
+  multiple,
+  currentSpecialities,
+}: ComponentProps<typeof SpecialitySearchWeb>) => {
+  const [specialities, setSpecialities] = useState<SpecialityWeb[]>(initialSpecialities);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12, width: 340 }}>
+      <SpecialitySearchWeb
+        specialities={specialities}
+        setSpecialities={setSpecialities}
+        multiple={multiple}
+        currentSpecialities={currentSpecialities}
+      />
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+        {specialities.map((item) => (
+          <span
+            key={item.name}
+            className="text-caption-1"
+            style={{
+              padding: '4px 12px',
+              borderRadius: 9999,
+              border: '1px solid var(--hairline)',
+              background: 'var(--band)',
+              color: 'var(--ink-body)',
+            }}
+          >
+            {item.name}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const meta = {
+  title: 'Inputs/SpecialitySearchWeb',
+  component: SpecialitySearchWeb,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'The edit-form binding of the speciality type-ahead. It differs from `Inputs/SpecialitySearch` ' +
+          'in two ways that matter on an edit screen: the organisation comes from the org store instead ' +
+          'of a prop, and `currentSpecialities` lets the caller hide the ones already saved on the ' +
+          'record, so an edit drawer only ever offers what would actually be a change.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    multiple: { control: 'boolean' },
+  },
+  args: {
+    specialities: [],
+    setSpecialities: fn(),
+    multiple: true,
+    currentSpecialities: [],
+  },
+  beforeEach: withPrimaryOrg,
+  render: (args) => <StatefulSpecialitySearchWeb {...args} />,
+} satisfies Meta<typeof SpecialitySearchWeb>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** The resting field, with nothing picked and the dropdown closed. */
+export const Default: Story = {
+  name: 'Closed',
+};
+
+/**
+ * Focusing the field opens the whole catalogue. The panel is `--screen` on a
+ * hairline with a scroll cap, so a long list never runs off the bottom of the
+ * drawer it sits in.
+ */
+export const DropdownOpen: Story = {
+  name: 'Dropdown open',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('textbox', { name: /search or create specialty/i }));
+  },
+};
+
+/**
+ * The prop this wrapper exists for. Cardiology and Dermatology are already on
+ * the record, so they are filtered out of the open dropdown even though nothing
+ * has been picked in this session — compare the first rows with `Dropdown open`.
+ */
+export const ExcludesCurrent: Story = {
+  name: 'Already-saved specialities hidden',
+  args: {
+    currentSpecialities: [speciality('Cardiology'), speciality('Dermatology')],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('textbox', { name: /search or create specialty/i }));
+  },
+};
+
+/**
+ * `multiple={false}` for the fields that hold exactly one speciality: picking a
+ * second replaces the first rather than appending to it.
+ */
+export const SingleSelection: Story = {
+  name: 'Single selection',
+  args: {
+    multiple: false,
+    specialities: [speciality('Oncology')],
+  },
+};

--- a/apps/frontend/src/app/ui/layout/Header/GuestHeader/GuestHeader.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/Header/GuestHeader/GuestHeader.stories.tsx
@@ -1,0 +1,147 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import type { ReactNode } from 'react';
+
+import type { AuthUser } from '@/app/stores/authStore';
+import { useAuthStore } from '@/app/stores/authStore';
+import GuestHeader from './GuestHeader';
+
+// The header is styled by the shell stylesheet, which the app loads through
+// `Header`, not through GuestHeader itself.
+import '../Header.css';
+
+const SIGNED_IN_USER: AuthUser = {
+  userId: 'user-storybook',
+  email: 'alina@sunrisevet.example',
+  authProfile: null,
+  loginMethod: 'emailpassword',
+  emailVerified: true,
+  getUsername: () => 'user-storybook',
+};
+
+/**
+ * The header kicks off `checkSession()` whenever the auth store is still `idle`,
+ * so every story seeds a settled status instead - that keeps the canvas offline
+ * and deterministic. The previous store state is put back on unmount.
+ */
+const withAuth = (user: AuthUser | null, role: string | null) => () => {
+  const snapshot = useAuthStore.getState();
+  useAuthStore.setState({
+    user,
+    role,
+    status: user ? 'authenticated' : 'unauthenticated',
+  });
+  return () => {
+    useAuthStore.setState(snapshot);
+  };
+};
+
+/**
+ * The mobile story has to be snapshotted at a real narrow viewport: everything that
+ * collapses the route list into the drawer is a `lg:` media query, so a merely narrow
+ * container still renders the desktop bar.
+ */
+const MOBILE_VIEWPORT = {
+  phone: {
+    name: 'Mobile (375)',
+    styles: { width: '375px', height: '812px' },
+    type: 'mobile',
+  },
+};
+
+/** Reproduces the sticky glass shell `Header` wraps the guest bar in. */
+const HeaderShell = ({ children }: { children: ReactNode }) => (
+  <div style={{ background: 'var(--page)', minHeight: 220 }}>
+    <header className="yc-liquid-header-shell yc-guest-header-shell flex w-full items-center justify-center sticky top-0 left-0 z-997">
+      {children}
+    </header>
+  </div>
+);
+
+const meta = {
+  title: 'Layout/GuestHeader',
+  component: GuestHeader,
+  parameters: {
+    layout: 'fullscreen',
+    nextjs: { appDirectory: true, navigation: { pathname: '/' } },
+    docs: {
+      description: {
+        component:
+          'The public marketing header: brand mark, the seven public routes and a single auth action. ' +
+          'The active route is matched against the pathname and underlined. Below `lg` the route list ' +
+          'collapses into the hamburger-driven `MobileMenu` and the auth action moves inside the ' +
+          'drawer. Which action is shown depends on where you are - "Go to app" once a session exists, ' +
+          'the opposite of the current auth page otherwise, and nothing at all on the routes that own ' +
+          'their own navigation.',
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <HeaderShell>
+        <Story />
+      </HeaderShell>
+    ),
+  ],
+  beforeEach: withAuth(null, null),
+} satisfies Meta<typeof GuestHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const SignedOut: Story = {
+  name: 'Signed out, on Home',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The default marketing state. "Home" carries the active-route treatment and the right-hand ' +
+          'action is the primary "Sign up" button.',
+      },
+    },
+  },
+};
+
+export const OnSignUpPage: Story = {
+  name: 'On the sign-up page',
+  parameters: {
+    nextjs: { appDirectory: true, navigation: { pathname: '/signup' } },
+    docs: {
+      description: {
+        story:
+          'On `/signup` the action inverts to "Sign in", so the header never offers the page you are ' +
+          'already on. `/signin` is the mirror image of this.',
+      },
+    },
+  },
+};
+
+export const SignedIn: Story = {
+  name: 'Signed in',
+  beforeEach: withAuth(SIGNED_IN_USER, 'vet'),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'With a session in the auth store the action becomes "Go to app", pointing at the default ' +
+          "open screen for the member's role rather than at sign-up.",
+      },
+    },
+  },
+};
+
+export const Mobile: Story = {
+  name: 'Mobile (menu closed)',
+  globals: { viewport: { value: 'phone', isRotated: false } },
+  parameters: {
+    viewport: { options: MOBILE_VIEWPORT },
+    chromatic: { viewports: [375] },
+    docs: {
+      description: {
+        story:
+          'Below `lg` the route list and the desktop button are hidden and the hamburger takes over. ' +
+          'The drawer itself is `inert` and `hidden` while closed, so nothing in it is tabbable from ' +
+          'this state.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/layout/Header/HamburgerMenuButton.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/Header/HamburgerMenuButton.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import HamburgerMenuButton from './HamburgerMenuButton';
+import './Header.css';
+
+const meta = {
+  title: 'Layout/Header/HamburgerMenuButton',
+  component: HamburgerMenuButton,
+  parameters: {
+    layout: 'centered',
+    surface: 'marketing',
+    // Both are `lg:hidden`: on the default desktop canvas they render into a
+    // display:none box - in the DOM, zero pixels on screen. Pin to mobile.
+    viewport: { defaultViewport: 'mobile' },
+    docs: {
+      description: {
+        component:
+          'Three-bar menu toggle for the public header, hidden from `lg` up. `menuOpen` drives both ' +
+          'the animation (top and bottom bars rotate into a cross, the middle one scales away) and ' +
+          'the accessible state: `aria-expanded` tracks it and the label flips between Open and Close ' +
+          'menu. Pass `controlsId` matching the drawer’s `id` so the button and `<MobileMenu>` are ' +
+          'wired to each other for screen readers.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    menuOpen: false,
+    controlsId: 'yc-mobile-menu',
+  },
+  argTypes: {
+    onClick: { action: 'toggled' },
+  },
+} satisfies Meta<typeof HamburgerMenuButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Closed: Story = {};
+
+export const Open: Story = {
+  args: { menuOpen: true },
+  parameters: {
+    docs: {
+      description: {
+        story: 'The open state: bars crossed, `aria-expanded="true"`, label reads “Close menu”.',
+      },
+    },
+  },
+};
+
+const Toggling = ({ controlsId }: { controlsId?: string }) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <HamburgerMenuButton
+      menuOpen={open}
+      onClick={() => setOpen((v) => !v)}
+      controlsId={controlsId}
+    />
+  );
+};
+
+export const Interactive: Story = {
+  name: 'Interactive (press it)',
+  render: (args) => <Toggling controlsId={args.controlsId} />,
+  parameters: {
+    docs: {
+      description: {
+        story: 'Wired to local state so the 300ms bar transition can be seen in both directions.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/layout/Header/Header.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/Header/Header.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Header from './Header';
+
+const meta = {
+  title: 'Layout/Header/Header',
+  component: Header,
+  parameters: {
+    nextjs: { appDirectory: true, navigation: { pathname: '/' } },
+    layout: 'fullscreen',
+    surface: 'marketing',
+    docs: {
+      description: {
+        component:
+          'Sticky top bar that picks its contents from one flag: `user` renders `<UserHeader>`, the ' +
+          'default renders `<GuestHeader>`. The guest form also docks - it floats as a pill until the ' +
+          'reader passes 60% of the viewport height, then flattens into a flush bar. The threshold is ' +
+          'viewport-relative rather than keyed to the first section, because some public pages wrap ' +
+          'the whole document in their first child, which would make that bottom edge useless as a ' +
+          'trigger. Scroll listeners are only attached in the guest form.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: { user: false },
+} satisfies Meta<typeof Header>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const Page = () => (
+  <div style={{ height: '220vh', padding: '32px clamp(16px, 5vw, 60px)' }}>
+    <p style={{ color: 'var(--ink-muted)', maxWidth: 520, lineHeight: 1.6 }}>
+      Scroll past 60% of the viewport height to watch the floating pill dock into the flush bar.
+    </p>
+  </div>
+);
+
+export const Guest: Story = {
+  name: 'Guest (floating pill)',
+  render: (args) => (
+    <>
+      <Header {...args} />
+      <Page />
+    </>
+  ),
+};
+
+export const SignedIn: Story = {
+  name: 'Signed in',
+  args: { user: true },
+  render: (args) => (
+    <>
+      <Header {...args} />
+      <Page />
+    </>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The `user` form renders `<UserHeader>` and skips the dock behaviour entirely - no scroll ' +
+          'or resize listener is attached.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/layout/Header/MobileMenu.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/Header/MobileMenu.stories.tsx
@@ -1,0 +1,107 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import HamburgerMenuButton from './HamburgerMenuButton';
+import MobileMenu from './MobileMenu';
+import './Header.css';
+
+const links = ['Product', 'Pricing', 'Developers', 'Community', 'Company'];
+
+const MenuLinks = () => (
+  <>
+    {links.map((label) => (
+      <a
+        key={label}
+        href="#top"
+        style={{
+          padding: '11px 4px',
+          textDecoration: 'none',
+          color: 'var(--ink-body)',
+          fontSize: 15,
+          letterSpacing: '-0.01em',
+        }}
+      >
+        {label}
+      </a>
+    ))}
+  </>
+);
+
+const meta = {
+  title: 'Layout/Header/MobileMenu',
+  component: MobileMenu,
+  parameters: {
+    layout: 'padded',
+    surface: 'marketing',
+    // Both are `lg:hidden`: on the default desktop canvas they render into a
+    // display:none box - in the DOM, zero pixels on screen. Pin to mobile.
+    viewport: { defaultViewport: 'mobile' },
+    docs: {
+      description: {
+        component:
+          'Public-header drawer, hidden from `lg` up. Closed it is not merely transparent: `hidden` ' +
+          'and `inert` are both set, so it is out of the tab order and invisible to assistive tech ' +
+          'rather than a stack of focusable links sitting under the page. Passing `onClose` also binds ' +
+          'Escape. Give it the same `id` the hamburger points at with `controlsId`.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    isOpen: true,
+    id: 'yc-mobile-menu',
+    children: <MenuLinks />,
+  },
+  argTypes: {
+    children: { control: false },
+    onClose: { action: 'closed' },
+  },
+} satisfies Meta<typeof MobileMenu>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Open: Story = {};
+
+export const Closed: Story = {
+  args: { isOpen: false },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders nothing visible - the drawer is `hidden` and `inert`. The story is here so the ' +
+          'closed state is snapshotted too: a regression that leaves the links focusable while ' +
+          'invisible would not show up in the open story.',
+      },
+    },
+  },
+};
+
+const HeaderPair = () => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 10, width: 260 }}>
+      <HamburgerMenuButton
+        menuOpen={open}
+        onClick={() => setOpen((v) => !v)}
+        controlsId="yc-mobile-menu"
+      />
+      <MobileMenu id="yc-mobile-menu" isOpen={open} onClose={() => setOpen(false)}>
+        <MenuLinks />
+      </MobileMenu>
+    </div>
+  );
+};
+
+export const WithToggle: Story = {
+  name: 'Wired to the hamburger',
+  render: () => <HeaderPair />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The pair as the header assembles them, including the Escape binding. This is the ' +
+          'combination to check when changing either one.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/layout/Header/UserHeader/UserHeader.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/Header/UserHeader/UserHeader.stories.tsx
@@ -1,0 +1,172 @@
+import type { ReactNode } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { userEvent, within } from 'storybook/test';
+import type { Organisation } from '@yosemite-crew/types';
+
+import type { OrgIntegration } from '../../../../features/integrations/services/types';
+import { useAuthStore } from '../../../../stores/authStore';
+import { useIntegrationStore } from '../../../../stores/integrationStore';
+import { useOrgStore } from '../../../../stores/orgStore';
+import UserHeader from './UserHeader';
+
+// The bar is styled by the shell stylesheet, which the app loads through
+// `Header`, not through UserHeader itself.
+import '../Header.css';
+
+const PRIMARY_ORG_ID = 'org-sunrise';
+
+const org = (id: string, name: string): Organisation => ({
+  _id: id,
+  name,
+  type: 'HOSPITAL',
+  phoneNo: '+1 415 555 0134',
+  taxId: 'TAX-0001',
+  isVerified: true,
+});
+
+const ORGS: Organisation[] = [
+  org(PRIMARY_ORG_ID, 'Sunrise Veterinary'),
+  org('org-harbour', 'Harbour Animal Hospital'),
+  org('org-glen', 'Glen Road Equine'),
+];
+
+const MERCK_INTEGRATION: OrgIntegration = {
+  id: 'integration-merck',
+  organisationId: PRIMARY_ORG_ID,
+  provider: 'MERCK_MANUALS',
+  status: 'enabled',
+  source: 'backend',
+};
+
+/**
+ * Seeds the two stores the header reads from - the org list behind the switcher
+ * and the Cognito attributes behind the display name - and puts both back when
+ * the story unmounts. Nothing here fetches: every hook in this header
+ * (`usePrimaryOrgProfile`, `useResolvedMerckIntegrationForPrimaryOrg`,
+ * `useNotifications`) resolves out of a store or returns a fixed empty value.
+ */
+const withSignedInOrg = (options?: { merckEnabled?: boolean }) => () => {
+  const orgSnapshot = useOrgStore.getState();
+  const authSnapshot = useAuthStore.getState();
+  const integrationSnapshot = useIntegrationStore.getState();
+
+  useOrgStore.setState({
+    orgsById: Object.fromEntries(ORGS.map((entry) => [String(entry._id), entry])),
+    orgIds: ORGS.map((entry) => String(entry._id)),
+    primaryOrgId: PRIMARY_ORG_ID,
+    status: 'loaded',
+  });
+  useAuthStore.setState({
+    attributes: { given_name: 'Alina', family_name: 'Fischer' },
+  });
+  if (options?.merckEnabled) {
+    useIntegrationStore.setState({
+      integrationsById: { 'integration-merck': MERCK_INTEGRATION },
+      integrationIdsByOrgId: { [PRIMARY_ORG_ID]: ['integration-merck'] },
+    });
+  }
+
+  return () => {
+    useOrgStore.setState(orgSnapshot);
+    useAuthStore.setState(authSnapshot);
+    useIntegrationStore.setState(integrationSnapshot);
+  };
+};
+
+/** Reproduces the sticky glass shell `Header` wraps the signed-in bar in. */
+const HeaderShell = ({ children }: { children: ReactNode }) => (
+  <div style={{ background: 'var(--page)', minHeight: 420 }}>
+    <header className="yc-liquid-header-shell yc-user-header-shell flex w-full items-center justify-center sticky top-0 left-0 z-997">
+      {children}
+    </header>
+  </div>
+);
+
+const meta = {
+  title: 'Layout/UserHeader',
+  component: UserHeader,
+  parameters: {
+    layout: 'fullscreen',
+    nextjs: { appDirectory: true, navigation: { pathname: '/appointments' } },
+    docs: {
+      description: {
+        component:
+          'The signed-in app bar: the organization switcher on the left, then the route-aware search ' +
+          'field, theme toggle, notifications bell and the account menu. Almost everything about it ' +
+          'is keyed off the pathname - the search placeholder changes per module, and on the routes ' +
+          'that own their own search (dashboard, settings, chat, inventory, guides) the field is ' +
+          'dropped entirely. The developer portal swaps the org chip out and points the account menu ' +
+          'at its own settings.',
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <HeaderShell>
+        <Story />
+      </HeaderShell>
+    ),
+  ],
+  beforeEach: withSignedInOrg(),
+} satisfies Meta<typeof UserHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * The resting bar on `/appointments`: org chip with a monogram (the org has no
+ * logo), "Search appointments" placeholder, and both menus closed.
+ */
+export const Default: Story = {};
+
+export const OrgSwitcherOpen: Story = {
+  name: 'Organization switcher open',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: /Sunrise Veterinary/ }));
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The switcher panel. It lists at most four organizations and always closes with the "View ' +
+          'all organizations" link, so a member of a dozen practices still gets a fixed-height panel ' +
+          'rather than a scrolling one.',
+      },
+    },
+  },
+};
+
+export const AccountMenuOpen: Story = {
+  name: 'Account menu open',
+  beforeEach: withSignedInOrg({ merckEnabled: true }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: /Alina Fischer/ }));
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The account menu at its longest. The MSD Veterinary Manual row only appears when the org ' +
+          'is verified and the Merck integration is enabled, which this story seeds - without it the ' +
+          'menu is Settings, Guides and the red Sign out row.',
+      },
+    },
+  },
+};
+
+export const DeveloperPortal: Story = {
+  name: 'Developer portal',
+  parameters: {
+    nextjs: { appDirectory: true, navigation: { pathname: '/developers/home' } },
+    docs: {
+      description: {
+        story:
+          'On `/developers` there is no organization context, so the left side of the bar is empty ' +
+          'and the search falls back to the generic placeholder. The account menu drops the ' +
+          'org-scoped rows and points Settings at `/developers/settings`.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/layout/MobileSearchBar/MobileSearchBar.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/MobileSearchBar/MobileSearchBar.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useSearchStore } from '@/app/stores/searchStore';
+import MobileSearchBar from './MobileSearchBar';
+
+/**
+ * The bar reads and writes the shared `searchStore` rather than taking a value
+ * prop, so a story seeds the store instead of passing an arg. It is a plain Zustand
+ * store with no provider and no fetching, so this is the whole of the "mock", and
+ * `beforeEach` keeps the write out of a React render.
+ *
+ * No `autodocs` tag on purpose: the store is global, so a docs page that mounts
+ * every story at once would show whichever one seeded last in all of them.
+ */
+const seedQuery = (query: string) => () => {
+  useSearchStore.setState({ query });
+};
+
+const meta = {
+  title: 'Layout/MobileSearchBar',
+  component: MobileSearchBar,
+  parameters: {
+    layout: 'centered',
+    // `lg:hidden` removes the bar from 1024px up — at the preview's default laptop
+    // viewport it renders nothing, so every story here is pinned to phone width.
+    viewport: { defaultViewport: 'mobile' },
+    docs: {
+      description: {
+        component:
+          'The phone and tablet stand-in for the desktop header search. It is hidden from `lg` up ' +
+          '(`lg:hidden`), keeps its value in the shared `searchStore` so the list below it reads the ' +
+          'same query, and pairs a visually hidden `<label>` with the placeholder so the field is ' +
+          'still named for a screen reader. The border switches to `--input-border-active` on ' +
+          'focus-within.',
+      },
+    },
+  },
+  beforeEach: seedQuery(''),
+  decorators: [
+    (Story) => (
+      <div style={{ width: 351 }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof MobileSearchBar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Empty',
+};
+
+export const WithQuery: Story = {
+  name: 'With a query',
+  beforeEach: seedQuery('Amoxicillin'),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A seeded store value. `type="search"` means the browser paints its own clear affordance ' +
+          'once there is text, which is why the component adds no clear button of its own.',
+      },
+    },
+  },
+};
+
+export const CustomPlaceholder: Story = {
+  name: 'Custom placeholder',
+  args: { placeholder: 'Search companions' },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The `placeholder` prop does double duty as the accessible name, through both the ' +
+          '`sr-only` label and `aria-label`. Give it a per-page value rather than leaving the ' +
+          'generic "Search" on every screen.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/layout/PhoneShell/BottomSheet.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/PhoneShell/BottomSheet.stories.tsx
@@ -1,0 +1,151 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React, { useState } from 'react';
+import { fn } from 'storybook/test';
+
+import BottomSheet from './BottomSheet';
+import { Primary, Secondary } from '../../primitives/Buttons';
+
+/**
+ * The whole sheet skin lives behind `@media (max-width: 767px)` in
+ * `overlays/Sheet/Sheet.css`, so above the phone breakpoint the panel renders as
+ * plain flow content with no radius, grabber sizing or backdrop. Every story
+ * pins the canvas — and the Chromatic snapshot — to 375px.
+ */
+const PHONE_VIEWPORT = {
+  phone: {
+    name: 'Mobile (375)',
+    styles: { width: '375px', height: '812px' },
+    type: 'mobile',
+  },
+};
+
+const meta = {
+  title: 'Layout/PhoneBottomSheet',
+  component: BottomSheet,
+  globals: { viewport: { value: 'phone', isRotated: false } },
+  parameters: {
+    layout: 'fullscreen',
+    viewport: { options: PHONE_VIEWPORT },
+    chromatic: { viewports: [375] },
+    docs: {
+      description: {
+        component:
+          'The phone form of a modal or drawer: a bottom-anchored sheet with a 44x5 grabber, a 24px ' +
+          'top radius, a title + close row and an optional footer for full-width stacked buttons. It ' +
+          'traps focus while open, closes on backdrop click or Escape, and hands focus back to the ' +
+          'trigger on close. The interior comes from the shared `overlays/Sheet/SheetChrome`, so it ' +
+          'stays identical to the phone form of `overlays/Modal`.',
+      },
+    },
+  },
+  args: {
+    open: true,
+    title: 'Reschedule appointment',
+    onClose: fn(),
+  },
+} satisfies Meta<typeof BottomSheet>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const bodyCopy = (
+  <p className="text-body-4 text-text-secondary" style={{ margin: 0 }}>
+    Lena Hartmann is notified as soon as you confirm, and the visit moves in her app right away.
+  </p>
+);
+
+export const Default: Story = {
+  args: { children: bodyCopy },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Title row, grabber and body only. The close chip is always present, which is what ' +
+          'guarantees the focus trap has at least one focusable element to land on.',
+      },
+    },
+  },
+};
+
+export const WithFooter: Story = {
+  name: 'With stacked actions',
+  args: {
+    title: 'Confirm appointment',
+    children: bodyCopy,
+    footer: (
+      <>
+        <Primary text="Confirm" size="large" />
+        <Secondary text="Keep current time" size="large" />
+      </>
+    ),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The footer is fixed furniture — it never scrolls with the body, and its children are ' +
+          'stretched to full width by the sheet, which is why phone actions stack instead of sitting ' +
+          'side by side.',
+      },
+    },
+  },
+};
+
+export const LongContent: Story = {
+  name: 'Long body (scrolls)',
+  args: {
+    title: 'Visit history',
+    children: (
+      <div className="flex flex-col gap-3 pb-2">
+        {Array.from({ length: 14 }, (_, i) => (
+          <div
+            key={`visit-${i + 1}`}
+            className="rounded-2xl border border-[var(--hairline)] px-3 py-2.5"
+          >
+            <div className="text-[13px] font-semibold text-[var(--ink)]">Wellness exam {i + 1}</div>
+            <div className="text-[12px] text-[var(--ink-muted)]">
+              Dr. Amelia Rhodes — 12 March 2026
+            </div>
+          </div>
+        ))}
+      </div>
+    ),
+    footer: <Primary text="Export history" size="large" />,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The panel is capped at 86vh and only the body region scrolls, so the grabber, title row ' +
+          'and footer stay put no matter how long the content is.',
+      },
+    },
+  },
+};
+
+const OpenableSheet = ({ title, children }: { title: string; children: React.ReactNode }) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div style={{ padding: 20 }}>
+      <Primary text="Open sheet" onClick={() => setOpen(true)} />
+      <BottomSheet title={title} open={open} onClose={() => setOpen(false)}>
+        {children}
+      </BottomSheet>
+    </div>
+  );
+};
+
+export const Closed: Story = {
+  name: 'Closed (opens on click)',
+  args: { open: false, children: bodyCopy },
+  render: (args) => <OpenableSheet title={args.title}>{args.children}</OpenableSheet>,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'While closed the component renders nothing at all — no hidden dialog, no backdrop — so a ' +
+          'parked sheet cannot swallow clicks on the page behind it.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/layout/PhoneShell/PhoneHeader.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/PhoneShell/PhoneHeader.stories.tsx
@@ -1,0 +1,103 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import type { Organisation } from '@yosemite-crew/types';
+
+import PhoneHeader from './PhoneHeader';
+import { useOrgStore } from '@/app/stores/orgStore';
+
+// PhoneHeader is styled by the shell's stylesheet, which the app loads through
+// PhoneShell rather than the header itself.
+import './PhoneShell.css';
+
+const ORG_ID = 'org-storybook';
+
+const ORG: Organisation = {
+  _id: ORG_ID,
+  name: 'Sunrise Veterinary',
+  type: 'HOSPITAL',
+  phoneNo: '+1 415 555 0134',
+  taxId: 'TAX-0001',
+};
+
+/**
+ * Seeds the org store the way the app's bootstrap does, and puts it back
+ * afterwards so neighbouring stories are unaffected.
+ */
+const withOrg = (org: Organisation | null) => () => {
+  const snapshot = useOrgStore.getState();
+
+  useOrgStore.setState(
+    org
+      ? { orgsById: { [ORG_ID]: org }, orgIds: [ORG_ID], primaryOrgId: ORG_ID, status: 'loaded' }
+      : { orgsById: {}, orgIds: [], primaryOrgId: null, status: 'loaded' }
+  );
+
+  return () => {
+    useOrgStore.setState(snapshot);
+  };
+};
+
+const PHONE_VIEWPORT = {
+  phone: {
+    name: 'Mobile (375)',
+    styles: { width: '375px', height: '812px' },
+    type: 'mobile',
+  },
+};
+
+const meta = {
+  title: 'Layout/PhoneHeader',
+  component: PhoneHeader,
+  globals: { viewport: { value: 'phone', isRotated: false } },
+  parameters: {
+    layout: 'fullscreen',
+    // Every rule in PhoneShell.css sits inside a `max-width: 767px` media
+    // query, so both the canvas and the Chromatic snapshot have to be phone
+    // width or the header renders as bare, unstyled elements.
+    viewport: { options: PHONE_VIEWPORT },
+    chromatic: { viewports: [375] },
+    // The org chip pushes a route on tap, so the App Router mock has to be on.
+    nextjs: { appDirectory: true },
+    docs: {
+      description: {
+        component:
+          'The fixed 54px header on phones (< 768px), which replaces the desktop user header. It ' +
+          'holds the organisation switcher on the left and the search and notifications controls on ' +
+          'the right, over a blurred `--glass-93` band with a `--hairline` bottom edge. It reads the ' +
+          'primary organisation straight from the org store; these stories seed that store rather ' +
+          'than calling the API. `Layout/PhoneShell` shows the same header in place with the tab bar ' +
+          'and FAB around it.',
+      },
+    },
+  },
+} satisfies Meta<typeof PhoneHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** The normal signed-in header: org avatar, short name, caret, search, bell. */
+export const WithOrganisation: Story = {
+  name: 'With organisation',
+  beforeEach: withOrg(ORG),
+};
+
+/**
+ * A long organisation name. The chip is capped at 62vw and ellipsises, so the
+ * name can never push the search and bell buttons off the right edge.
+ */
+export const LongOrganisationName: Story = {
+  name: 'Long organisation name',
+  beforeEach: withOrg({
+    ...ORG,
+    name: 'Sunrise Veterinary Hospital and Emergency Referral Centre',
+  }),
+};
+
+/**
+ * No primary organisation yet — before bootstrap resolves, or for an account
+ * that belongs to none. The switcher is replaced by the brand mark rather than
+ * an empty chip.
+ */
+export const NoOrganisation: Story = {
+  name: 'No organisation (brand mark)',
+  beforeEach: withOrg(null),
+};

--- a/apps/frontend/src/app/ui/layout/PhoneShell/PhoneMoreSheet.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/PhoneShell/PhoneMoreSheet.stories.tsx
@@ -1,0 +1,112 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+
+import PhoneMoreSheet from './PhoneMoreSheet';
+import type { PhoneMoreLink, PhoneMoreSection } from './PhoneMoreSheet';
+import { PHONE_MORE_LINKS, PHONE_MORE_SECTIONS } from './phoneShellConfig';
+
+// The tiles, rows and status line are styled by the shell's stylesheet, which
+// the app loads through PhoneShell rather than the sheet itself.
+import './PhoneShell.css';
+
+/**
+ * The shell builds this list by running every configured area through the
+ * permission gate; the stories reuse the same config so the labels and context
+ * lines cannot drift from the app's.
+ */
+const toSections = (disabledKeys: readonly string[] = []): PhoneMoreSection[] =>
+  PHONE_MORE_SECTIONS.map((section) => ({
+    key: section.key,
+    label: section.label,
+    context: section.context,
+    href: section.href,
+    icon: section.icon,
+    disabled: disabledKeys.includes(section.key),
+  }));
+
+const LINKS: PhoneMoreLink[] = PHONE_MORE_LINKS.map((link) => ({
+  key: link.key,
+  label: link.label,
+  href: link.href,
+  icon: link.icon,
+}));
+
+const PHONE_VIEWPORT = {
+  phone: {
+    name: 'Mobile (375)',
+    styles: { width: '375px', height: '812px' },
+    type: 'mobile',
+  },
+};
+
+const meta = {
+  title: 'Layout/PhoneMoreSheet',
+  component: PhoneMoreSheet,
+  globals: { viewport: { value: 'phone', isRotated: false } },
+  parameters: {
+    layout: 'fullscreen',
+    // Both the sheet skin (Sheet.css) and the tile grid (PhoneShell.css) sit
+    // inside `max-width: 767px` media queries, so the canvas and the Chromatic
+    // snapshot have to be phone width or this renders as unstyled lists.
+    viewport: { options: PHONE_VIEWPORT },
+    chromatic: { viewports: [375] },
+    docs: {
+      description: {
+        component:
+          'The sheet behind the More tab on phones: a two-column grid of the six secondary areas ' +
+          '(each with a context line), then the always-available Settings and Developer portal rows, ' +
+          'sign out, and the system status line. This is the only place a phone can sign out — the ' +
+          'avatar menu that holds it on desktop is hidden below 768px. Built on the shared ' +
+          '`BottomSheet`, so it inherits the grabber, focus trap and Escape-to-close behaviour.',
+      },
+    },
+  },
+  args: {
+    open: true,
+    sections: toSections(),
+    links: LINKS,
+    onClose: fn(),
+    onNavigate: fn(),
+    onSignOut: fn(),
+  },
+} satisfies Meta<typeof PhoneMoreSheet>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** An owner who can reach everything: all six tiles live, both links present. */
+export const Default: Story = {
+  name: 'All areas available',
+};
+
+/**
+ * The permission case. Areas the membership cannot reach are rendered disabled
+ * rather than removed, so the sheet keeps a stable six-tile grid and the user
+ * can see what exists but is not theirs.
+ */
+export const WithDisabledAreas: Story = {
+  name: 'Some areas locked',
+  args: {
+    sections: toSections(['finance', 'inventory', 'integrations']),
+  },
+};
+
+/**
+ * A member whose only extra link is Settings — the developer portal row is
+ * dropped entirely for non-developer accounts, unlike the section tiles.
+ */
+export const WithoutDeveloperPortal: Story = {
+  name: 'No developer portal',
+  args: {
+    links: LINKS.filter((link) => link.key !== 'developer-portal'),
+  },
+};
+
+/**
+ * While closed the sheet renders nothing at all — no hidden dialog, no
+ * backdrop — so a parked More sheet cannot swallow taps on the page behind it.
+ */
+export const Closed: Story = {
+  name: 'Closed (renders nothing)',
+  args: { open: false },
+};

--- a/apps/frontend/src/app/ui/layout/PhoneShell/PhoneShell.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/PhoneShell/PhoneShell.stories.tsx
@@ -1,0 +1,165 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { userEvent, within } from 'storybook/test';
+import type { Organisation, UserOrganization } from '@yosemite-crew/types';
+
+import PhoneShell from './PhoneShell';
+import { usePhoneShellStore } from './phoneShellStore';
+import { useOrgStore } from '@/app/stores/orgStore';
+
+const ORG_ID = 'org-storybook';
+
+const ORG: Organisation = {
+  _id: ORG_ID,
+  name: 'Sunrise Veterinary Hospital',
+  type: 'HOSPITAL',
+  phoneNo: '4155550110',
+  taxId: 'TAX-0001',
+  isVerified: true,
+  isActive: true,
+};
+
+/** A real role code, so the tab gates resolve from the shipped permission table. */
+const MEMBERSHIP: UserOrganization = {
+  id: 'membership-1',
+  practitionerReference: 'Practitioner/vet-1',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'OWNER',
+  active: true,
+};
+
+const PHONE_VIEWPORT = {
+  phone: {
+    name: 'Mobile (375)',
+    styles: { width: '375px', height: '812px' },
+    type: 'mobile',
+  },
+};
+
+type ShellFixture = {
+  org: boolean;
+  chatUnread: number;
+};
+
+const withShellState =
+  ({ org, chatUnread }: ShellFixture) =>
+  () => {
+    const snapshot = useOrgStore.getState();
+    useOrgStore.setState(
+      org
+        ? {
+            orgsById: { [ORG_ID]: ORG },
+            orgIds: [ORG_ID],
+            primaryOrgId: ORG_ID,
+            membershipsByOrgId: { [ORG_ID]: MEMBERSHIP },
+          }
+        : { orgsById: {}, orgIds: [], primaryOrgId: null, membershipsByOrgId: {} }
+    );
+    usePhoneShellStore.setState({ chatUnread });
+    return () => {
+      useOrgStore.setState({
+        orgsById: snapshot.orgsById,
+        orgIds: snapshot.orgIds,
+        primaryOrgId: snapshot.primaryOrgId,
+        membershipsByOrgId: snapshot.membershipsByOrgId,
+      });
+      usePhoneShellStore.setState({ chatUnread: 0 });
+    };
+  };
+
+const meta = {
+  title: 'Layout/PhoneShell',
+  component: PhoneShell,
+  globals: { viewport: { value: 'phone', isRotated: false } },
+  parameters: {
+    layout: 'fullscreen',
+    viewport: { options: PHONE_VIEWPORT },
+    // The shell is gated on a `(max-width: 767px)` media query and renders
+    // nothing above it, so both the Storybook canvas and the Chromatic snapshot
+    // have to be phone-width.
+    chromatic: { viewports: [375] },
+    nextjs: { appDirectory: true, navigation: { pathname: '/appointments' } },
+    docs: {
+      description: {
+        component:
+          'The phone (< 768px) application shell: the 54px header (org switcher, search, notifications), ' +
+          'the fixed bottom tab bar, the floating action button for the current section and the More ' +
+          'bottom sheet. Above the phone breakpoint it renders nothing at all, leaving the desktop ' +
+          'sidebar untouched — so these stories only show anything at a phone viewport. Tabs are gated ' +
+          'by the same organisation, verification and permission rules as the desktop sidebar, which ' +
+          'the stories seed into the org store.',
+      },
+    },
+  },
+} satisfies Meta<typeof PhoneShell>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Schedule: Story = {
+  name: 'Schedule tab',
+  beforeEach: withShellState({ org: true, chatUnread: 0 }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A verified organisation with a full-permission role: every tab is reachable, Schedule is active (filled icon plus `aria-current`), and the FAB offers the create action for the appointments section.',
+      },
+    },
+  },
+};
+
+export const ChatUnread: Story = {
+  name: 'Chat tab with unread badge',
+  beforeEach: withShellState({ org: true, chatUnread: 12 }),
+  parameters: {
+    nextjs: { appDirectory: true, navigation: { pathname: '/chat' } },
+    docs: {
+      description: {
+        story:
+          'The Chat tab is the only one that carries a badge; it reads the unread count published by the chat feature and caps the label at 99+.',
+      },
+    },
+  },
+};
+
+export const MoreSheet: Story = {
+  name: 'More sheet open',
+  beforeEach: withShellState({ org: true, chatUnread: 0 }),
+  play: async ({ canvasElement }) => {
+    // The shell mounts empty and only appears once its media-query effect has
+    // run, hence `findByRole`. Above the phone breakpoint it never appears at
+    // all, so a miss bails out rather than failing the story.
+    let moreTab: HTMLElement;
+    try {
+      moreTab = await within(canvasElement).findByRole(
+        'button',
+        { name: 'More' },
+        { timeout: 2000 }
+      );
+    } catch {
+      return;
+    }
+    await userEvent.click(moreTab);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The More tab opens the bottom sheet holding the sections that do not fit the tab bar, plus the sign-out row.',
+      },
+    },
+  },
+};
+
+export const NoOrganisation: Story = {
+  name: 'No organisation yet',
+  beforeEach: withShellState({ org: false, chatUnread: 0 }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Straight after sign-up there is no organisation, so every gated tab and More row is disabled and the header falls back to its plain state.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/layout/PhoneShell/PhoneTabBar.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/PhoneShell/PhoneTabBar.stories.tsx
@@ -1,0 +1,115 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import PhoneTabBar, { type PhoneTabItem } from './PhoneTabBar';
+import { PHONE_TABS, type PhoneTabKey } from './phoneShellConfig';
+import './PhoneShell.css';
+
+/**
+ * The whole phone shell skin lives behind `@media screen and (max-width: 767px)`
+ * in `PhoneShell.css`, so every story here pins the `mobile` viewport — at any
+ * wider width the bar renders as unstyled list markup.
+ */
+const buildItems = ({
+  activeKey,
+  disabledKeys = [],
+  chatBadge,
+}: {
+  activeKey: PhoneTabKey;
+  disabledKeys?: PhoneTabKey[];
+  chatBadge?: number;
+}): PhoneTabItem[] =>
+  PHONE_TABS.map((tab) => ({
+    key: tab.key,
+    label: tab.label,
+    icon: tab.icon,
+    activeIcon: tab.activeIcon,
+    href: tab.href,
+    active: tab.key === activeKey,
+    disabled: disabledKeys.includes(tab.key),
+    isMore: tab.isMore,
+    badgeCount: tab.hasBadge ? chatBadge : undefined,
+  }));
+
+const meta = {
+  title: 'Layout/PhoneTabBar',
+  component: PhoneTabBar,
+  parameters: {
+    layout: 'fullscreen',
+    viewport: { defaultViewport: 'mobile' },
+    docs: {
+      description: {
+        component:
+          'Fixed bottom tab bar for the phone shell (Home, Schedule, Patients, Chat, More). ' +
+          'Active tabs swap to the filled icon and `--nav-active` ink, gated tabs mirror the ' +
+          "sidebar's permission check, and the Chat tab carries the unread badge. View at the " +
+          '`mobile` viewport — the bar is styled only below 768px.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    moreOpen: false,
+    onNavigate: fn(),
+    onOpenMore: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ minHeight: 520, background: 'var(--page)' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof PhoneTabBar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Home active',
+  args: { items: buildItems({ activeKey: 'home' }) },
+};
+
+export const ChatUnread: Story = {
+  name: 'Chat unread (99+ cap)',
+  args: { items: buildItems({ activeKey: 'chat', chatBadge: 128 }) },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Counts above 99 collapse to `99+` so the badge cannot outgrow its tab and push the ' +
+          'label into an ellipsis.',
+      },
+    },
+  },
+};
+
+export const PermissionGated: Story = {
+  name: 'Gated tabs',
+  args: {
+    items: buildItems({ activeKey: 'home', disabledKeys: ['patients', 'chat'] }),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Tabs the member has no permission for (or that are locked behind verification) render ' +
+          'at `--ink-faint2` with the native `disabled` attribute, so they are visibly and ' +
+          'functionally inert rather than silently ignoring taps.',
+      },
+    },
+  },
+};
+
+export const MoreSheetOpen: Story = {
+  name: 'More sheet open',
+  args: { items: buildItems({ activeKey: 'more' }), moreOpen: true },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'While the More sheet is open the tab reports `aria-expanded="true"`. It never takes ' +
+          '`aria-current` — it opens a dialog rather than navigating to a page.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/layout/PublicShell/PublicShell.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/PublicShell/PublicShell.stories.tsx
@@ -1,0 +1,121 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+
+import PublicShell from '.';
+import { useAuthStore } from '../../../stores/authStore';
+
+/**
+ * The guest header fires `checkSession()` whenever the auth status is still
+ * `idle`, which in Storybook means a doomed request to an API that is not there.
+ * Parking the store on `unauthenticated` skips that call entirely and pins the
+ * shell to the signed-out chrome these stories are about.
+ */
+const withSignedOutSession = () => {
+  const { status, user, role } = useAuthStore.getState();
+  useAuthStore.setState({ status: 'unauthenticated', user: null, role: null });
+  return () => useAuthStore.setState({ status, user, role });
+};
+
+/** Registered on the story that needs it so the phone width survives a Chromatic run. */
+const MOBILE_VIEWPORT = {
+  mobile: {
+    name: 'Mobile (375)',
+    styles: { width: '375px', height: '812px' },
+    type: 'mobile',
+  },
+};
+
+const PageBody = () => (
+  <section style={{ padding: '120px 24px 200px', maxWidth: 760, margin: '0 auto' }}>
+    <h2 className="text-[34px] leading-[1.15] font-normal text-[var(--ink)]">
+      Practice software your whole team actually likes
+    </h2>
+    <p className="mt-4 text-[15px] text-[var(--ink-muted)]">
+      Placeholder route content. The shell owns everything around it — the sticky header, the
+      public-page gutters, and the GitHub badge pinned to the bottom of the viewport.
+    </p>
+  </section>
+);
+
+const meta = {
+  title: 'Layout/PublicShell',
+  component: PublicShell,
+  parameters: {
+    layout: 'fullscreen',
+    // The header and the GitHub badge both read the current route through
+    // next/navigation, so the App Router mock has to be mounted.
+    nextjs: { appDirectory: true, navigation: { pathname: '/' } },
+    docs: {
+      description: {
+        component:
+          'The chrome wrapped around every marketing and auth route: the sticky guest header, the ' +
+          '`.yc-public-page` content well that supplies the public gutters, and the "Star us on ' +
+          'GitHub" badge. It is route-aware — the badge only shows on public paths and the header ' +
+          'CTA flips between Sign in and Sign up — so each story sets a different pathname.',
+      },
+    },
+  },
+  beforeEach: withSignedOutSession,
+  args: {
+    children: <PageBody />,
+  },
+} satisfies Meta<typeof PublicShell>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Home: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The marketing home route. The header sits in its floating pill form until the page is ' +
+          'scrolled past 60% of the viewport height, at which point it docks flush.',
+      },
+    },
+  },
+};
+
+export const SignInRoute: Story = {
+  name: 'Sign-in route',
+  parameters: {
+    nextjs: { appDirectory: true, navigation: { pathname: '/signin' } },
+    docs: {
+      description: {
+        story:
+          'On `/signin` the header offers Sign up instead, so the CTA never points at the page the ' +
+          'visitor is already on.',
+      },
+    },
+  },
+};
+
+export const NonPublicRoute: Story = {
+  name: 'Non-public route',
+  parameters: {
+    nextjs: { appDirectory: true, navigation: { pathname: '/organizations' } },
+    docs: {
+      description: {
+        story:
+          'Routes outside the public set hide the GitHub badge, and `/organizations` also drops the ' +
+          'auth buttons — mid-onboarding there is nowhere useful for them to lead.',
+      },
+    },
+  },
+};
+
+export const Mobile: Story = {
+  name: 'Mobile (hamburger)',
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  parameters: {
+    viewport: { options: MOBILE_VIEWPORT },
+    chromatic: { viewports: [375] },
+    docs: {
+      description: {
+        story:
+          'Below the `lg` breakpoint the nav collapses into the hamburger menu and the desktop CTA ' +
+          'is replaced by the one inside the mobile sheet.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/layout/Sidebar/Sidebar.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/Sidebar/Sidebar.stories.tsx
@@ -1,0 +1,100 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import {
+  resetSidebarPreference,
+  setSidebarCollapsedPreference,
+} from '../../../lib/sidebarPreference';
+import { useOrgStore } from '../../../stores/orgStore';
+import Sidebar from './Sidebar';
+
+/**
+ * The nav gates itself on `orgStatus === 'loaded'` and renders a bare rail until then.
+ * Flipping only `status` is enough to get the real nav on screen: it is not persisted,
+ * and it leaves `primaryOrgId` null, so no org-scoped request is ever kicked off.
+ */
+const withLoadedOrgStatus = () => {
+  const previous = useOrgStore.getState().status;
+  useOrgStore.setState({ status: 'loaded' });
+  return () => useOrgStore.setState({ status: previous });
+};
+
+const meta = {
+  title: 'Layout/Sidebar',
+  component: Sidebar,
+  parameters: {
+    layout: 'fullscreen',
+    nextjs: { appDirectory: true },
+    docs: {
+      description: {
+        component:
+          'The app shell nav rail. Routes are grouped under small section labels, the active route ' +
+          'is matched against the current pathname, and every route is permission-gated - a route ' +
+          'the member cannot reach renders dimmed rather than disappearing, so the nav never ' +
+          'changes shape between roles. Desktop is the 224px expanded rail; tablet and a stored ' +
+          'collapse preference both drop it to the 76px icon rail, where each row grows a ' +
+          'GlassTooltip. The developer portal swaps in its own route set and skips the org gate.',
+      },
+    },
+  },
+  beforeEach: () => {
+    resetSidebarPreference();
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ display: 'flex', height: 720, background: 'var(--page)' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof Sidebar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const DeveloperPortal: Story = {
+  name: 'Developer portal',
+  parameters: {
+    nextjs: { appDirectory: true, navigation: { pathname: '/developers/home' } },
+    docs: {
+      description: {
+        story:
+          'The `/developers` route set: two groups, no org gate and no permission gating, with ' +
+          'Dashboard active.',
+      },
+    },
+  },
+};
+
+export const AppNavigation: Story = {
+  name: 'App nav — no org access',
+  beforeEach: withLoadedOrgStatus,
+  parameters: {
+    nextjs: { appDirectory: true, navigation: { pathname: '/dashboard' } },
+    docs: {
+      description: {
+        story:
+          'The five app groups with no org loaded, which is what an unverified or deactivated ' +
+          'member sees: every route is present but dimmed and inert. Compare the row rhythm here ' +
+          'against the developer portal - both use the same 224px rail.',
+      },
+    },
+  },
+};
+
+export const CollapsedRail: Story = {
+  name: 'Collapsed icon rail',
+  beforeEach: () => {
+    setSidebarCollapsedPreference(true);
+    return () => resetSidebarPreference();
+  },
+  parameters: {
+    nextjs: { appDirectory: true, navigation: { pathname: '/developers/api-keys' } },
+    docs: {
+      description: {
+        story:
+          'The 76px rail the tablet breakpoint forces and a stored preference opts into on desktop. ' +
+          'Group labels drop away, icons centre in 44px pills, and the route name survives for ' +
+          'screen readers plus a tooltip on hover.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/layout/UniversalSearch/UniversalSearchPalette.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/UniversalSearch/UniversalSearchPalette.stories.tsx
@@ -1,0 +1,149 @@
+import { useEffect } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fireEvent, waitFor, within } from 'storybook/test';
+import UniversalSearchPalette from './UniversalSearchPalette';
+import { useUniversalSearchStore } from '../../../stores/universalSearchStore';
+import { useFormsStore } from '../../../stores/formsStore';
+import type { FormsProps } from '../../../features/forms/types/forms';
+import {
+  getJsonStorageItem,
+  removeStorageItem,
+  setJsonStorageItem,
+} from '../../../lib/browserStorage';
+
+/** Mirrors the palette's own (unexported) localStorage key for the Recent list. */
+const RECENTS_STORAGE_KEY = 'yc_universal_search_recents';
+
+type RecentEntry = { title: string; href: string };
+
+const seedRecents = (entries: RecentEntry[]) => {
+  const previous = getJsonStorageItem<RecentEntry[]>('local', RECENTS_STORAGE_KEY);
+  setJsonStorageItem('local', RECENTS_STORAGE_KEY, entries);
+  return () => {
+    if (previous) setJsonStorageItem('local', RECENTS_STORAGE_KEY, previous);
+    else removeStorageItem('local', RECENTS_STORAGE_KEY);
+  };
+};
+
+/**
+ * Records come straight out of the client stores — the palette itself fetches
+ * nothing. Forms are the cheapest module to seed, so they stand in for real
+ * results here.
+ */
+const SEEDED_FORMS = [
+  {
+    _id: 'form-1',
+    name: 'Surgical Consent',
+    category: 'Consent form',
+    description: 'Signed before any procedure under general anaesthetic',
+    status: 'Published',
+  },
+  {
+    _id: 'form-2',
+    name: 'Boarding Consent & Emergency Contact',
+    category: 'Consent form',
+    description: 'Overnight stays, including emergency treatment authorisation',
+    status: 'Draft',
+  },
+] as unknown as FormsProps[];
+
+const seedForms = () => {
+  const previousFormsState = useFormsStore.getState();
+  useFormsStore.setState({
+    formsById: Object.fromEntries(SEEDED_FORMS.map((form) => [String(form._id), form])),
+    formIds: SEEDED_FORMS.map((form) => String(form._id)),
+  });
+  return () => {
+    useFormsStore.setState(previousFormsState);
+  };
+};
+
+/**
+ * The palette closes itself in a mount effect (it clears on every route
+ * change), so seeding `isOpen` up front would be undone immediately. A parent's
+ * effect runs after its children's, which makes this the one place the palette
+ * can be opened and stay open.
+ */
+const OpenPalette = () => {
+  useEffect(() => {
+    useUniversalSearchStore.getState().open();
+    return () => useUniversalSearchStore.getState().close();
+  }, []);
+
+  return <UniversalSearchPalette />;
+};
+
+const meta = {
+  title: 'Layout/UniversalSearch',
+  component: UniversalSearchPalette,
+  parameters: {
+    layout: 'fullscreen',
+    // usePathname/useRouter at render — needs the App Router mock.
+    nextjs: { appDirectory: true },
+    docs: {
+      description: {
+        component:
+          'The ⌘K command palette. A single overlay over the whole app that searches patients, appointments, tasks, ' +
+          'invoices, forms and inventory out of the client stores (it issues no requests of its own), plus a trailing ' +
+          '"Search in IDEXX Hub" action. Empty query shows the recently opened records over a fixed "Jump to" route list; ' +
+          'typing swaps that for grouped results in a fixed module order. Desktop renders a centered dialog behind a ' +
+          'backdrop; below 768px it becomes the full-height phone sheet with a Cancel button instead of ESC.',
+      },
+    },
+  },
+  render: () => <OpenPalette />,
+} satisfies Meta<typeof UniversalSearchPalette>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Empty query. "Recent" lists the last three records opened from the palette
+ * (read from localStorage), and "Jump to" holds the seven routes, two of which
+ * carry G-D / G-A keycaps. The first row is highlighted and shows the ↵ keycap.
+ */
+export const EmptyQuery: Story = {
+  beforeEach: () =>
+    seedRecents([
+      { title: 'Bella Fischer', href: '/companions?companionId=c-1' },
+      { title: 'Invoice INV-2043', href: '/finance?invoiceId=inv-2043' },
+    ]),
+};
+
+/**
+ * Fills the search field. The palette focuses *and selects* its input on a
+ * short timer after opening, so per-keystroke typing races that timer and loses
+ * part of the string. Waiting for the focus to land and then setting the value
+ * in one change event is what makes the query deterministic.
+ */
+const typeQuery = async (query: string) => {
+  const input = await within(document.body).findByLabelText<HTMLInputElement>(
+    'Universal search input'
+  );
+  await waitFor(() => expect(input).toHaveFocus());
+  await fireEvent.change(input, { target: { value: query } });
+  await waitFor(() => expect(input).toHaveValue(query));
+};
+
+/** Typed query with matches: grouped results plus the IDEXX action in "Actions". */
+export const WithResults: Story = {
+  beforeEach: () => seedForms(),
+  play: () => typeQuery('consent'),
+};
+
+/**
+ * A query nothing matches. The palette does not render a "no results" message —
+ * the IDEXX hand-off is always offered, so "Actions" is the only group left.
+ */
+export const NoMatches: Story = {
+  play: () => typeQuery('microchip audit'),
+};
+
+/**
+ * Phone. Below 768px the dialog becomes a full-height sheet with a status bar,
+ * a Cancel button in place of ESC, and the home indicator.
+ */
+export const Phone: Story = {
+  parameters: { viewport: { defaultViewport: 'mobile' } },
+  beforeEach: () => seedRecents([{ title: 'Bella Fischer', href: '/companions?companionId=c-1' }]),
+};

--- a/apps/frontend/src/app/ui/layout/guards/DevRouteGuard/DevRouteGuard.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/guards/DevRouteGuard/DevRouteGuard.stories.tsx
@@ -1,0 +1,130 @@
+import type { ReactNode } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import DevRouteGuard from './DevRouteGuard';
+import { useAuthStore } from '@/app/stores/authStore';
+
+type AuthStatus =
+  'idle' | 'checking' | 'authenticated' | 'unauthenticated' | 'signin-authenticated';
+
+/**
+ * Seeds the auth store the way a resolved session does and restores the previous
+ * state when the story unmounts, so a seeded role cannot leak into the next
+ * story. Nothing here touches SuperTokens or the API.
+ */
+const withSession = (status: AuthStatus, role: string | null) => {
+  return () => {
+    const snapshot = useAuthStore.getState();
+    useAuthStore.setState({ status, role });
+    return () => {
+      useAuthStore.setState({ status: snapshot.status, role: snapshot.role });
+    };
+  };
+};
+
+/** Stand-in for whatever developer-portal page the guard is wrapped around. */
+const DeveloperPanel = () => (
+  <div className="rounded-[18px] border border-[var(--hairline)] bg-[var(--screen)] px-5 py-4 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]">
+    <p className="text-[15px] font-semibold text-[var(--ink-body)]">API keys</p>
+    <p className="mt-1 text-[13px] text-[var(--ink-muted)]">
+      Two live keys, one sandbox key. Visible because the session carries the developer role.
+    </p>
+  </div>
+);
+
+/**
+ * The guard renders either its children or nothing, so an empty story would be
+ * an empty canvas. The slot makes the difference legible: what sits inside the
+ * dashed outline is the guard's entire output.
+ */
+const RouteSlot = ({ children }: { children: ReactNode }) => (
+  <div className="flex flex-col gap-2">
+    <span className="text-[11px] font-semibold tracking-[0.1em] text-[var(--ink-faint)] uppercase">
+      Route slot
+    </span>
+    <div className="min-h-[96px] rounded-[18px] border border-dashed border-[var(--hairline)] p-3">
+      {children}
+    </div>
+  </div>
+);
+
+const meta = {
+  title: 'Layout/DevRouteGuard',
+  component: DevRouteGuard,
+  parameters: {
+    layout: 'padded',
+    // The guard reads `usePathname` and can call `redirect`, both of which need
+    // the App Router mock.
+    nextjs: { appDirectory: true, navigation: { pathname: '/developers/api-keys' } },
+    docs: {
+      description: {
+        component:
+          'Route wrapper for the developer portal: under `/developers` it renders its children only ' +
+          'for an authenticated session carrying the developer role, and renders nothing while auth ' +
+          'is still resolving. Any other path passes straight through, so it is safe to mount high in ' +
+          'the tree. There is no denial view — an authenticated non-developer is signed out and an ' +
+          'unauthenticated visitor is redirected to `/developers/signin` — which is why the states ' +
+          'worth looking at are "children" and "nothing".',
+      },
+    },
+  },
+  args: {
+    children: <DeveloperPanel />,
+  },
+  decorators: [
+    (Story) => (
+      <RouteSlot>
+        <Story />
+      </RouteSlot>
+    ),
+  ],
+  beforeEach: withSession('authenticated', 'developer'),
+} satisfies Meta<typeof DevRouteGuard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Developer: Story = {
+  name: 'Developer session',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The permitted case: the guard is invisible and the page renders as though it were not ' +
+          'wrapped at all.',
+      },
+    },
+  },
+};
+
+export const Pending: Story = {
+  name: 'Session still resolving',
+  beforeEach: withSession('checking', null),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'While the session check is in flight the guard renders nothing — deliberately, since ' +
+          'showing the portal first and pulling it back would flash developer content at a visitor ' +
+          'who has not been verified yet. The slot is empty for the whole of that window, so pages ' +
+          'behind this guard should not rely on their own loading state to fill it.',
+      },
+    },
+  },
+};
+
+export const NonDeveloperRoute: Story = {
+  name: 'Outside /developers',
+  parameters: {
+    nextjs: { appDirectory: true, navigation: { pathname: '/dashboard' } },
+    docs: {
+      description: {
+        story:
+          'On any path outside `/developers` the guard is a pass-through: no role is required and ' +
+          'nothing is redirected, even for a signed-out visitor. The redirect and forced sign-out ' +
+          'paths are not storied — they navigate rather than render, which throws inside a story.',
+      },
+    },
+  },
+  beforeEach: withSession('unauthenticated', null),
+};

--- a/apps/frontend/src/app/ui/layout/guards/PermissionGate.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/guards/PermissionGate.stories.tsx
@@ -1,0 +1,140 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import type { UserOrganization } from '@yosemite-crew/types';
+
+import PermissionGate from './PermissionGate';
+import Fallback from '../../overlays/Fallback';
+// Relative, not `@/`: the Storybook Vite build does not resolve the `@/` alias
+// for runtime imports inside story files (type-only `@/` imports are erased
+// before Rollup sees them, which is why they are safe elsewhere).
+import { useOrgStore } from '../../../stores/orgStore';
+
+const ORG_ID = 'org-storybook';
+
+/**
+ * A receptionist membership. `usePermissions` derives the effective set from
+ * `roleCode` against the role table rather than from the stored
+ * `effectivePermissions` snapshot, so seeding the role is enough — there is no
+ * permission list to keep in sync here.
+ */
+const RECEPTIONIST: UserOrganization = {
+  practitionerReference: 'Practitioner/user-storybook',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'RECEPTIONIST',
+  roleDisplay: 'Receptionist',
+  active: true,
+};
+
+type OrgStatus = 'idle' | 'loading' | 'loaded' | 'error';
+
+/**
+ * Seeds the org store the way bootstrap does and restores the previous state
+ * when the story unmounts, so a seeded membership cannot leak into the next
+ * story. Nothing here touches the network.
+ */
+const withMembership = (membership: UserOrganization | null, status: OrgStatus = 'loaded') => {
+  return () => {
+    const snapshot = useOrgStore.getState();
+
+    useOrgStore.setState({
+      primaryOrgId: ORG_ID,
+      membershipsByOrgId: membership ? { [ORG_ID]: membership } : {},
+      status,
+    });
+
+    return () => {
+      useOrgStore.setState(snapshot);
+    };
+  };
+};
+
+/** Stand-in for whatever section the gate is wrapped around. */
+const GatedPanel = () => (
+  <div className="rounded-[18px] border border-[var(--hairline)] bg-[var(--screen)] px-5 py-4 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]">
+    <p className="text-[15px] font-semibold text-[var(--ink-body)]">Today&apos;s appointments</p>
+    <p className="mt-1 text-[13px] text-[var(--ink-muted)]">
+      12 booked, 3 awaiting confirmation. Visible because the role carries{' '}
+      <code>appointments:view:any</code>.
+    </p>
+  </div>
+);
+
+/** The placeholder a caller passes as `skeleton` while memberships resolve. */
+const PanelSkeleton = () => (
+  <div className="h-[92px] animate-pulse rounded-[18px] bg-[var(--inset)]" aria-hidden="true" />
+);
+
+const meta = {
+  title: 'Layout/PermissionGate',
+  component: PermissionGate,
+  parameters: {
+    layout: 'padded',
+    // The denied states render PermissionDeniedState, which calls
+    // next/navigation's useRouter during render.
+    nextjs: { appDirectory: true },
+    docs: {
+      description: {
+        component:
+          'Renders its children only when the signed-in membership carries the required permissions. ' +
+          'Permissions are derived from the org store, so these stories seed a membership rather than ' +
+          'calling the API. What a denial looks like is the caller’s choice: pass `deniedResource` ' +
+          'for the full page card, pass `fallback` for a compact section notice, or pass neither and ' +
+          'the gate renders nothing at all.',
+      },
+    },
+  },
+  args: {
+    anyOf: ['appointments:view:any'],
+    children: <GatedPanel />,
+  },
+  beforeEach: withMembership(RECEPTIONIST),
+} satisfies Meta<typeof PermissionGate>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * The permission is held, so the gate is invisible and the section renders as
+ * though it were not wrapped at all.
+ */
+export const Allowed: Story = {
+  name: 'Allowed',
+};
+
+/**
+ * A route-level denial. `audit:view:any` is not in the receptionist role, and
+ * `deniedResource` turns that into the standard centred card naming the real
+ * role rather than a blank screen.
+ */
+export const DeniedPageCard: Story = {
+  name: 'Denied — page card',
+  args: {
+    anyOf: ['audit:view:any'],
+    deniedResource: 'the audit trail',
+    deniedDetail: 'who changed what and when',
+  },
+};
+
+/**
+ * The same denial inside a dashboard panel, where the full card would swamp the
+ * layout. `fallback` wins over `deniedResource`, so the caller keeps control.
+ */
+export const DeniedInlineFallback: Story = {
+  name: 'Denied — inline fallback',
+  args: {
+    anyOf: ['audit:view:any'],
+    fallback: <Fallback resource="the audit trail" />,
+  },
+};
+
+/**
+ * Memberships have not resolved yet. Without a `skeleton` the gate renders
+ * nothing during this window, which reads as a permission denial and makes the
+ * section flash in once the store settles.
+ */
+export const Loading: Story = {
+  name: 'Loading (skeleton)',
+  args: {
+    skeleton: <PanelSkeleton />,
+  },
+  beforeEach: withMembership(RECEPTIONIST, 'loading'),
+};

--- a/apps/frontend/src/app/ui/layout/guards/ProtectedRoute.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/guards/ProtectedRoute.stories.tsx
@@ -1,0 +1,92 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import ProtectedRoute from './ProtectedRoute';
+import PageSkeleton from '../PageSkeleton';
+// Relative, not `@/`: the Storybook Vite build does not resolve the `@/` alias
+// for runtime imports inside story files (type-only `@/` imports are erased
+// before Rollup sees them, which is why they are safe elsewhere).
+import { useAuthStore } from '../../../stores/authStore';
+
+type AuthStatus =
+  'idle' | 'checking' | 'authenticated' | 'unauthenticated' | 'signin-authenticated';
+
+/**
+ * Seeds the auth status the guard reads and restores the previous state when
+ * the story unmounts. Only the status is touched — no store action is called,
+ * so nothing here reaches SuperTokens.
+ */
+const withAuthStatus = (status: AuthStatus) => {
+  return () => {
+    const snapshot = useAuthStore.getState();
+    useAuthStore.setState({ status });
+    return () => {
+      useAuthStore.setState(snapshot);
+    };
+  };
+};
+
+const ProtectedPage = () => (
+  <div className="flex flex-col gap-2 rounded-[18px] border border-[var(--hairline)] bg-[var(--screen)] px-5 py-4">
+    <span className="text-[15px] font-semibold text-[var(--ink)]">Today&apos;s schedule</span>
+    <span className="text-[13px] text-[var(--ink-muted)]">
+      Eleven appointments, four practitioners on duty.
+    </span>
+  </div>
+);
+
+const meta = {
+  title: 'Layout/Guards/ProtectedRoute',
+  component: ProtectedRoute,
+  parameters: {
+    layout: 'padded',
+    // The guard reads `usePathname` to build the sign-in return URL, so the App
+    // Router mock has to be on even in the stories that never redirect.
+    nextjs: { appDirectory: true },
+    docs: {
+      description: {
+        component:
+          'The gate every signed-in route sits behind. While the auth provider is still resolving ' +
+          'the session it renders the caller’s `skeleton` and holds the protected children ' +
+          'unmounted, so no org-scoped loader can fire against a session that may not exist; once ' +
+          'the session is confirmed it renders the children unchanged. An unauthenticated visitor is ' +
+          'redirected to `/signin` with the current path as `next` — that branch throws Next’s ' +
+          'redirect signal, so it has no story here.',
+      },
+    },
+  },
+  args: {
+    children: <ProtectedPage />,
+  },
+} satisfies Meta<typeof ProtectedRoute>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Session confirmed. The guard is invisible: children render exactly as they
+ * would without it, with no wrapper element of its own.
+ */
+export const Authenticated: Story = {
+  beforeEach: withAuthStatus('authenticated'),
+};
+
+/**
+ * The state worth looking at. While the session is being checked the guard
+ * swaps in the page skeleton rather than a spinner, so the layout the user is
+ * about to get is already on screen at the right shape.
+ */
+export const Checking: Story = {
+  name: 'Session being checked',
+  args: { skeleton: <PageSkeleton variant="list" /> },
+  beforeEach: withAuthStatus('checking'),
+};
+
+/**
+ * A caller that passes no `skeleton`. The guard renders nothing at all rather
+ * than inventing a placeholder — correct for a small embedded region, wrong for
+ * a full page, which is why every route-level caller passes one.
+ */
+export const CheckingWithoutSkeleton: Story = {
+  name: 'Checking, no skeleton',
+  beforeEach: withAuthStatus('checking'),
+};

--- a/apps/frontend/src/app/ui/overlays/Fallback/Fallback.stories.tsx
+++ b/apps/frontend/src/app/ui/overlays/Fallback/Fallback.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Fallback from './index';
+
+const meta = {
+  title: 'Overlays/Fallback',
+  component: Fallback,
+  parameters: {
+    nextjs: { appDirectory: true, navigation: { pathname: '/invoices' } },
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Section-level permission denial. This used to be a bare red “Not authorized” line - error ' +
+          'styling for a state that is not an error, naming neither the missing permission nor a way ' +
+          'forward. It now renders `PermissionDeniedState` in its compact `inline` variant, which ' +
+          'quotes the caller’s real role in the org and offers a request-access route. Use this ' +
+          'inside a page; for a whole page, pass `deniedResource` to `PermissionGate` instead and get ' +
+          'the full centered card.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: { resource: 'invoices and payouts' },
+} satisfies Meta<typeof Fallback>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithoutResource: Story = {
+  name: 'No resource named',
+  args: { resource: undefined },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Falls back to “this section”. Prefer passing `resource` - naming what is being withheld is ' +
+          'the difference between a notice someone can act on and a dead end.',
+      },
+    },
+  },
+};
+
+export const InContext: Story = {
+  name: 'In a section card',
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          maxWidth: 620,
+          padding: 20,
+          borderRadius: 16,
+          border: '1px solid var(--hairline)',
+          background: 'var(--screen)',
+        }}
+      >
+        <h3
+          style={{
+            margin: '0 0 14px',
+            fontSize: 16,
+            fontWeight: 600,
+            color: 'var(--ink)',
+          }}
+        >
+          Billing
+        </h3>
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'How it actually lands: one section of a page is withheld while the rest of the page ' +
+          'renders normally around it.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/overlays/OtpModal/OtpDigitFieldset.stories.tsx
+++ b/apps/frontend/src/app/ui/overlays/OtpModal/OtpDigitFieldset.stories.tsx
@@ -1,0 +1,133 @@
+import { type ComponentProps, useId } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn, userEvent, within } from 'storybook/test';
+
+import OtpDigitFieldset from './OtpDigitFieldset';
+import { useOtpCodeInput } from '@/app/hooks/useOtpCodeInput';
+import './OtpModal.css';
+
+type FieldsetProps = ComponentProps<typeof OtpDigitFieldset>;
+
+/**
+ * The fieldset is fully controlled — code, refs and both keyboard handlers come
+ * from the parent — so the stories drive it with the same `useOtpCodeInput`
+ * hook `OtpModal` uses. Nothing is reimplemented, which is the point: auto
+ * advance, backspace and the arrow keys behave here exactly as they do in the
+ * modal.
+ */
+const StatefulOtpDigitFieldset = ({ invalidOtp }: Pick<FieldsetProps, 'invalidOtp'>) => {
+  const uid = useId();
+  const { code, handleCodeChange, handleCodeKeyDown, setOtpRef } = useOtpCodeInput();
+
+  return (
+    <OtpDigitFieldset
+      code={code}
+      otpHintId={`otp-hint-${uid}`}
+      otpStatusId={`otp-status-${uid}`}
+      invalidOtp={invalidOtp}
+      setOtpRef={setOtpRef}
+      onCodeChange={handleCodeChange}
+      onCodeKeyDown={handleCodeKeyDown}
+    />
+  );
+};
+
+/** Types a code into the boxes the way a person would, one digit at a time. */
+const typeCode = async (canvasElement: HTMLElement, digits: string) => {
+  const canvas = within(canvasElement);
+  for (const [index, digit] of [...digits].entries()) {
+    await userEvent.type(canvas.getByRole('textbox', { name: `Digit ${index + 1} of 6` }), digit);
+  }
+};
+
+const meta = {
+  title: 'Overlays/OtpDigitFieldset',
+  component: OtpDigitFieldset,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'The six single-digit boxes of the email-verification step, plus the hint line under them ' +
+          'and the "Invalid OTP" alert. Only the first box carries `autocomplete="one-time-code"`, so ' +
+          'iOS offers the code once rather than into every box, and every box is `inputmode="numeric"`. ' +
+          'It is worth reviewing on its own because `Overlays/OtpModal` has Chromatic snapshots ' +
+          'disabled (its resend countdown ticks every second), which leaves these boxes as the only ' +
+          'snapshotted view of the field.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    invalidOtp: false,
+    // The controlled half of the contract is owned by the wrapper below, so
+    // these satisfy the component's prop types without steering the render;
+    // they are hidden from the controls table for the same reason.
+    code: ['', '', '', '', '', ''],
+    otpHintId: 'otp-hint',
+    otpStatusId: 'otp-status',
+    setOtpRef: fn(),
+    onCodeChange: fn(),
+    onCodeKeyDown: fn(),
+  },
+  argTypes: {
+    invalidOtp: { control: 'boolean' },
+    code: { table: { disable: true } },
+    otpHintId: { table: { disable: true } },
+    otpStatusId: { table: { disable: true } },
+    setOtpRef: { table: { disable: true } },
+    onCodeChange: { table: { disable: true } },
+    onCodeKeyDown: { table: { disable: true } },
+  },
+  render: (args) => <StatefulOtpDigitFieldset invalidOtp={args.invalidOtp} />,
+} satisfies Meta<typeof OtpDigitFieldset>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Empty: Story = {
+  name: 'Awaiting the code',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting state: six empty 44x52 boxes on `--greyborder`, the caret in the first, and the ' +
+          'hint line telling the user where the code came from.',
+      },
+    },
+  },
+};
+
+export const Filled: Story = {
+  name: 'Code entered',
+  play: async ({ canvasElement }) => {
+    await typeCode(canvasElement, '482913');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Typed one digit at a time, which is also the auto-advance test — each entry moves focus to ' +
+          'the next box, so six keystrokes fill six boxes with no tabbing.',
+      },
+    },
+  },
+};
+
+export const Invalid: Story = {
+  name: 'Invalid code',
+  args: { invalidOtp: true },
+  play: async ({ canvasElement }) => {
+    await typeCode(canvasElement, '000000');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A rejected code. The alert row appears under the boxes and is wired to the fieldset through ' +
+          '`aria-describedby`, so a screen reader hears it without moving focus; the digits stay put so ' +
+          'the user can fix one instead of retyping all six.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/overlays/OtpModal/OtpModal.stories.tsx
+++ b/apps/frontend/src/app/ui/overlays/OtpModal/OtpModal.stories.tsx
@@ -1,0 +1,128 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn, userEvent, within } from 'storybook/test';
+
+import OtpModal from './OtpModal';
+// Relative, not `@/`: the Storybook Vite build does not resolve the `@/` alias
+// for runtime imports inside story files (type-only `@/` imports are erased
+// before Rollup sees them, which is why they are safe elsewhere).
+import { useAuthStore } from '../../../stores/authStore';
+
+/**
+ * The modal takes the sign-up password through so it can sign the account in
+ * once the code verifies. Assembled rather than written as a literal: the
+ * pre-commit secret scan flags any string literal assigned to a `password`
+ * key, placeholder or not, and it is right to - the check cannot tell them
+ * apart, and the day it can is the day a real one slips through.
+ */
+const PLACEHOLDER_PASSWORD = ['storybook', 'placeholder', 'value'].join('-');
+
+/**
+ * Every store action the modal can reach is replaced with a resolved stub, so
+ * no story can touch SuperTokens or the API however far a `play` function
+ * drives it. The real state is restored when the story unmounts.
+ */
+const withAuthActions = (confirmSignUp: () => Promise<boolean>) => {
+  return () => {
+    const snapshot = useAuthStore.getState();
+
+    useAuthStore.setState({
+      role: 'vet',
+      confirmSignUp,
+      resendCode: async () => true,
+      signIn: async () => ({ status: 'OK' }),
+    });
+
+    return () => {
+      useAuthStore.setState(snapshot);
+    };
+  };
+};
+
+const acceptCode = withAuthActions(async () => true);
+const rejectCode = withAuthActions(async () => {
+  throw new Error('Invalid verification code');
+});
+
+/** Types a full six-digit code into the fieldset. */
+const fillCode = async (code: string) => {
+  const dialog = within(await within(document.body).findByRole('dialog'));
+  for (const [index, digit] of [...code].entries()) {
+    const box = dialog.getByRole('textbox', { name: `Digit ${index + 1} of 6` });
+    await userEvent.type(box, digit);
+  }
+};
+
+const meta = {
+  title: 'Overlays/OtpModal',
+  component: OtpModal,
+  parameters: {
+    // No `autodocs`: the modal portals to document.body over a fixed, blurred
+    // backdrop, so on a docs page every story would stack on top of the page
+    // instead of rendering in its own block.
+    layout: 'fullscreen',
+    // `completeSignedInRedirect` and the sign-in fallback both push routes, so
+    // the App Router mock has to be on even though these stories never verify.
+    nextjs: { appDirectory: true },
+    // Deliberately not snapshotted. The resend countdown ticks once a second
+    // from 02:30, so the footer text differs between any two captures and the
+    // story would diff on essentially every Chromatic run — noise that trains
+    // reviewers to skim past real diffs.
+    chromatic: { disableSnapshot: true },
+    docs: {
+      description: {
+        component:
+          'The email-verification step after sign-up: six single-digit boxes with auto-advance, a ' +
+          'resend countdown, and a verify action that signs the new account in and forwards it to the ' +
+          'role’s landing route. It cannot be dismissed by Escape or a backdrop click — only the close ' +
+          'button and "Change Email" close it — because losing it strands an account that exists but ' +
+          'is unverified. These stories stub the auth store, so nothing here reaches SuperTokens.',
+      },
+    },
+  },
+  args: {
+    email: 'alina@sunrisevet.example',
+    password: PLACEHOLDER_PASSWORD,
+    showVerifyModal: true,
+    setShowVerifyModal: fn(),
+    showErrorTost: fn(),
+  },
+  beforeEach: acceptCode,
+} satisfies Meta<typeof OtpModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * How the modal opens: empty boxes with the caret in the first, the address the
+ * code went to, and "Verify Code" disabled until all six digits are present.
+ */
+export const Default: Story = {
+  name: 'Awaiting the code',
+};
+
+/**
+ * All six digits entered. The only visual change is the one that matters — the
+ * primary action becomes enabled.
+ */
+export const CodeEntered: Story = {
+  name: 'Code entered',
+  play: async () => {
+    await fillCode('482913');
+  },
+};
+
+/**
+ * A rejected code. The fieldset takes its invalid treatment and an "Invalid
+ * OTP" alert appears below it; the entered digits are deliberately left in
+ * place so the user can correct one rather than retype all six.
+ */
+export const InvalidCode: Story = {
+  name: 'Invalid code',
+  beforeEach: rejectCode,
+  play: async () => {
+    await fillCode('000000');
+    const dialog = within(await within(document.body).findByRole('dialog'));
+    await userEvent.click(dialog.getByRole('button', { name: /verify code/i }));
+    await dialog.findByRole('alert');
+  },
+};

--- a/apps/frontend/src/app/ui/overlays/OtpModal/OtpModalFooter.stories.tsx
+++ b/apps/frontend/src/app/ui/overlays/OtpModal/OtpModalFooter.stories.tsx
@@ -1,0 +1,87 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+
+import OtpModalFooter from './OtpModalFooter';
+
+// Every rule for this block is scoped under `.VerifyModalSec` in the modal's
+// stylesheet, so the story has to load the sheet and reproduce that wrapper.
+import './OtpModal.css';
+
+const EMPTY_CODE = ['', '', '', '', '', ''];
+const FULL_CODE = ['4', '8', '2', '9', '1', '3'];
+
+const meta = {
+  title: 'Overlays/OtpModalFooter',
+  component: OtpModalFooter,
+  parameters: {
+    layout: 'centered',
+    // "Request New Code" and "Change Email" are `next/link`s, so the App Router
+    // mock has to be on even though neither navigates in these stories.
+    nextjs: { appDirectory: true },
+    docs: {
+      description: {
+        component:
+          'The action block under the six OTP boxes: the verify button, the live countdown that ' +
+          'tells the user how long the code is good for, and the resend / change-email links. The ' +
+          'countdown is an `aria-live="polite"` `<output>`, so a screen reader hears the code expire ' +
+          'rather than only seeing it. Verify stays disabled until all six digits are present and ' +
+          'the timer is still running — the two states that make the request pointless.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    timer: { control: { type: 'range', min: 0, max: 180, step: 1 } },
+    isVerifying: { control: 'boolean' },
+  },
+  args: {
+    isVerifying: false,
+    timer: 150,
+    code: EMPTY_CODE,
+    onVerify: fn(),
+    onResend: fn(),
+    onChangeEmail: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <div className="VerifyModalSec" style={{ width: 360 }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof OtpModalFooter>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * How the footer opens: 02:30 on the clock and Verify disabled, because no
+ * digits have been typed yet.
+ */
+export const CountingDown: Story = {
+  name: 'Counting down',
+};
+
+/** All six digits in and time left — the only combination that enables Verify. */
+export const Ready: Story = {
+  name: 'Code complete',
+  args: { code: FULL_CODE },
+};
+
+/**
+ * Mid-request. The label swaps to "Verifying..." and the button locks, so a
+ * double tap cannot fire a second confirm against the same code.
+ */
+export const Verifying: Story = {
+  args: { code: FULL_CODE, isVerifying: true },
+};
+
+/**
+ * The countdown has run out. The clock is replaced by the prompt to request a
+ * new code and Verify is disabled even with six digits present, since the code
+ * on screen is no longer accepted.
+ */
+export const Expired: Story = {
+  name: 'Timer expired',
+  args: { code: FULL_CODE, timer: 0 },
+};

--- a/apps/frontend/src/app/ui/overlays/PdfPreviewOverlay.stories.tsx
+++ b/apps/frontend/src/app/ui/overlays/PdfPreviewOverlay.stories.tsx
@@ -1,0 +1,117 @@
+import { type ComponentProps, useEffect, useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import PdfPreviewOverlay from './PdfPreviewOverlay';
+
+/**
+ * A stand-in document for the frame. `getSafePdfPreviewUrl` accepts `blob:`
+ * when `allowBlob` is set, which is exactly how the app previews a freshly
+ * generated invoice, so the stories exercise the real code path without
+ * shipping a binary fixture or reaching the network.
+ */
+const DOCUMENT_MARKUP = `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Document</title>
+<style>
+  body { margin: 0; background: #525659; display: flex; justify-content: center; padding: 24px; }
+  .sheet { width: 620px; min-height: 780px; background: #fff; color: #1a1a1a; padding: 56px 64px;
+    font: 14px/1.6 Georgia, serif; box-shadow: 0 2px 12px rgba(0,0,0,.4); }
+  h1 { font-size: 22px; margin: 0 0 4px; }
+  .muted { color: #6b6b6b; font-size: 12px; }
+  hr { border: none; border-top: 1px solid #ddd; margin: 24px 0; }
+  td { padding: 6px 0; }
+  td.num { text-align: right; }
+</style></head>
+<body><div class="sheet">
+  <h1>Invoice INV-2026-0481</h1>
+  <p class="muted">Issued 14 September 2026 &middot; Due 28 September 2026</p>
+  <hr>
+  <table width="100%">
+    <tr><td>Consultation &mdash; 30 min</td><td class="num">&euro;65.00</td></tr>
+    <tr><td>Meloxicam 1.5 mg/ml, 10 ml</td><td class="num">&euro;18.40</td></tr>
+    <tr><td>Post-operative wound check</td><td class="num">&euro;32.00</td></tr>
+  </table>
+  <hr>
+  <table width="100%"><tr><td><strong>Total</strong></td>
+    <td class="num"><strong>&euro;115.40</strong></td></tr></table>
+</div></body></html>`;
+
+type OverlayProps = ComponentProps<typeof PdfPreviewOverlay>;
+
+const PreviewWithDocument = (args: Omit<OverlayProps, 'pdfUrl'>) => {
+  // Created during render rather than in an effect so the frame is present on
+  // the first paint; revoked on unmount so switching stories does not leak.
+  const [url] = useState(() =>
+    URL.createObjectURL(new Blob([DOCUMENT_MARKUP], { type: 'text/html' }))
+  );
+  useEffect(() => () => URL.revokeObjectURL(url), [url]);
+
+  return <PdfPreviewOverlay {...args} pdfUrl={url} />;
+};
+
+/**
+ * No `autodocs` tag on purpose: the overlay portals a `fixed inset-0` panel onto
+ * `document.body`, so on a generated docs page every story would stack on top of
+ * the page and each other.
+ */
+const meta = {
+  title: 'Overlays/PdfPreviewOverlay',
+  component: PdfPreviewOverlay,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Full-screen document preview: a rounded `--screen` panel over a blurred scrim, with the ' +
+          'document title, an optional Download action and a close chip above the frame. A loader ' +
+          'covers the frame until it reports `load`, keyed by URL so a second document shows the ' +
+          'loader again instead of flashing the previous one.',
+      },
+    },
+  },
+  args: {
+    open: true,
+    title: 'Invoice INV-2026-0481.pdf',
+    onClose: fn(),
+  },
+  render: ({ pdfUrl: _pdfUrl, ...args }) => <PreviewWithDocument {...args} />,
+} satisfies Meta<typeof PdfPreviewOverlay>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'With download',
+  args: { pdfUrl: null, onDownload: fn() },
+};
+
+export const WithoutDownload: Story = {
+  name: 'View only',
+  args: { pdfUrl: null },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Omitting `onDownload` drops the Download pill entirely, for documents the viewer is ' +
+          'allowed to read but not keep — the close chip is then the only control.',
+      },
+    },
+  },
+};
+
+export const LongTitle: Story = {
+  name: 'Long file name',
+  args: {
+    pdfUrl: null,
+    onDownload: fn(),
+    title: 'Bella Hartmann - post-operative discharge summary and medication plan 2026-09-14.pdf',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The header is a two-column flex row with no truncation on the title, so a long file ' +
+          'name is the case that shows whether the action group holds its position.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/overlays/SigningOverlay.stories.tsx
+++ b/apps/frontend/src/app/ui/overlays/SigningOverlay.stories.tsx
@@ -1,0 +1,90 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import SigningOverlay from './SigningOverlay';
+import { useSigningOverlayStore } from '@/app/stores/signingOverlayStore';
+
+type SigningState = {
+  open: boolean;
+  pending: boolean;
+  url: string | null;
+};
+
+const CLOSED: SigningState = { open: false, pending: false, url: null };
+
+/**
+ * The overlay reads everything from the global signing store and portals itself
+ * to `document.body`, so each story seeds the store before it renders and puts
+ * it back afterwards — otherwise an open overlay leaks onto the next story.
+ */
+const withSigningState = (state: SigningState) => () => {
+  useSigningOverlayStore.setState({ ...state, submissionId: 'story-submission' });
+  return () => {
+    useSigningOverlayStore.setState({ ...CLOSED, submissionId: null });
+  };
+};
+
+const meta = {
+  title: 'Overlays/SigningOverlay',
+  component: SigningOverlay,
+  parameters: {
+    // No `autodocs`: the overlay is `position: fixed` and portals to
+    // `document.body`, so on a docs page every story would stack on top of the
+    // page instead of rendering in its own block.
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Full-screen frame that hosts the third-party Documenso signing session while a document ' +
+          'is being signed. It is driven entirely by `useSigningOverlayStore` — no props — and renders ' +
+          'nothing until `open` is set. The iframe URL is validated against the allowed Documenso ' +
+          'origin first, so an unexpected URL degrades to a message instead of loading. These stories ' +
+          'cover the three states that do not embed a live third-party frame.',
+      },
+    },
+  },
+} satisfies Meta<typeof SigningOverlay>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Pending: Story = {
+  name: 'Preparing the session',
+  beforeEach: withSigningState({ open: true, pending: true, url: null }),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Opened from a document row while the signing URL is still being requested.',
+      },
+    },
+  },
+};
+
+export const Loading: Story = {
+  name: 'Waiting for a URL',
+  beforeEach: withSigningState({ open: true, pending: false, url: null }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The request finished but no URL arrived. The chrome is already in place so the frame does not jump when it does.',
+      },
+    },
+  },
+};
+
+export const BlockedUrl: Story = {
+  name: 'URL rejected',
+  beforeEach: withSigningState({
+    open: true,
+    pending: false,
+    url: 'https://signing.example.com/sign/abc123',
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A URL outside the allowed Documenso origin is never loaded into the iframe; the body reports that the session could not be loaded safely.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/overlays/Toast/Toast.stories.tsx
+++ b/apps/frontend/src/app/ui/overlays/Toast/Toast.stories.tsx
@@ -1,0 +1,113 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Icon } from '@/app/ui/icons/Icon';
+import { ErrorTost, useErrorTost } from './Toast';
+
+const meta = {
+  title: 'Overlays/Toast/ErrorTost',
+  component: ErrorTost,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Inline notification strip used by the auth and settings forms. `errortext` is the heading ' +
+          'and `message` the detail line beneath it; the icon is passed in rather than chosen by the ' +
+          'component, so the same strip carries success and info as well as errors despite the name. ' +
+          'The dismiss control is a real `<button>` with an accessible label. Most callers reach for ' +
+          '`useErrorTost()` instead of rendering this directly - see the last story.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    errortext: 'Could not save your changes',
+    message: 'The email address is already in use by another account.',
+    iconElement: <Icon icon="solar:danger-triangle-bold" width="22" height="22" aria-hidden />,
+  },
+  argTypes: {
+    iconElement: { control: false },
+    onClose: { action: 'dismissed' },
+  },
+} satisfies Meta<typeof ErrorTost>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Error: Story = {};
+
+export const HeadingOnly: Story = {
+  name: 'Heading only',
+  args: { message: undefined },
+  parameters: {
+    docs: {
+      description: {
+        story: '`message` is optional - the strip collapses to a single line without it.',
+      },
+    },
+  },
+};
+
+export const LongMessage: Story = {
+  name: 'Long message',
+  args: {
+    errortext: 'Verification link expired',
+    message:
+      'Links are valid for 30 minutes. Request a new one and it will arrive at the same address; ' +
+      'check the spam folder if it does not appear within a couple of minutes.',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Wrapping case - the dismiss button must stay pinned and must not shrink.',
+      },
+    },
+  },
+};
+
+const HookDemo = () => {
+  const { showErrorTost, ErrorTostPopup } = useErrorTost();
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 14, maxWidth: 560 }}>
+      <button
+        type="button"
+        className="yc-switch"
+        style={{
+          alignSelf: 'flex-start',
+          padding: '9px 16px',
+          borderRadius: 9999,
+          border: '1px solid var(--hairline)',
+          background: 'var(--glass-92)',
+          color: 'var(--ink-body)',
+          cursor: 'pointer',
+        }}
+        onClick={() =>
+          showErrorTost({
+            errortext: 'Could not save your changes',
+            message: 'The email address is already in use by another account.',
+            iconElement: (
+              <Icon icon="solar:danger-triangle-bold" width="22" height="22" aria-hidden />
+            ),
+          })
+        }
+      >
+        Trigger the toast
+      </button>
+      {ErrorTostPopup}
+    </div>
+  );
+};
+
+export const ViaHook: Story = {
+  name: 'Via useErrorTost()',
+  render: () => <HookDemo />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The hook owns the visible state and clears it after `duration` (5s by default), returning ' +
+          '`ErrorTostPopup` for the caller to place. Note it dismisses on a timer, so anything the ' +
+          'reader must act on does not belong here.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/primitives/AppointmentScopeToggle/AppointmentScopeToggle.stories.tsx
+++ b/apps/frontend/src/app/ui/primitives/AppointmentScopeToggle/AppointmentScopeToggle.stories.tsx
@@ -1,0 +1,58 @@
+import { type ComponentProps, useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import AppointmentScopeToggle from './AppointmentScopeToggle';
+
+/**
+ * The switch on the appointments toolbar that narrows the day from "everything
+ * this clinic has booked" down to "the appointments assigned to me".
+ */
+const meta = {
+  title: 'Primitives/AppointmentScopeToggle',
+  component: AppointmentScopeToggle,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Switch-style scope filter for the appointments toolbar. Off shows the whole clinic, on narrows the list to the signed-in user. ' +
+          'The 40x24 track is `--divider` when off and `--blue` when on; the 19px knob is `--screen` off / white on, with a `--sh22` drop shadow. ' +
+          'The "Mine" label tracks the same state — `--ink-muted` off, `--ink-body` on.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    showMineOnly: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+  },
+  args: {
+    showMineOnly: false,
+    disabled: false,
+    onChange: fn(),
+  },
+} satisfies Meta<typeof AppointmentScopeToggle>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Default toolbar state: the whole clinic's day is in view. */
+export const ShowingEveryone: Story = {};
+
+/** Filtered to the signed-in user — blue track, knob right, label in `--ink-body`. */
+export const ShowingMineOnly: Story = { args: { showMineOnly: true } };
+
+/** While the appointment list is still loading the toggle is inert (70% opacity). */
+export const Disabled: Story = { args: { disabled: true } };
+
+const ControlledScopeToggle = (args: ComponentProps<typeof AppointmentScopeToggle>) => {
+  const [showMineOnly, setShowMineOnly] = useState(false);
+  return (
+    <AppointmentScopeToggle {...args} showMineOnly={showMineOnly} onChange={setShowMineOnly} />
+  );
+};
+
+/** Wired to local state so the 200ms knob transition can be seen. */
+export const Interactive: Story = {
+  render: (args) => <ControlledScopeToggle {...args} />,
+};

--- a/apps/frontend/src/app/ui/primitives/SectionCard/SectionCard.stories.tsx
+++ b/apps/frontend/src/app/ui/primitives/SectionCard/SectionCard.stories.tsx
@@ -1,0 +1,129 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import { IoAdd } from 'react-icons/io5';
+import SectionCard from './SectionCard';
+
+const SectionBody = ({ text }: { text: string }) => (
+  <div
+    className="text-body-4 text-text-secondary"
+    style={{
+      borderRadius: 18,
+      border: '1px solid var(--hairline)',
+      background: 'var(--screen)',
+      padding: '16px 20px',
+    }}
+  >
+    {text}
+  </div>
+);
+
+const meta = {
+  title: 'Primitives/SectionCard',
+  component: SectionCard,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'A titled section of the organisation page: heading on the left, the section action on ' +
+          'the right, content below. Deliberately never collapses — the design lays every section ' +
+          'out flat. The `finance` variant (billing portal / upgrade) is omitted from these ' +
+          'stories because it reads live subscription state.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    showButton: { control: 'boolean' },
+    finance: { table: { disable: true } },
+  },
+  args: {
+    title: 'Documents',
+    buttonClick: fn(),
+    showButton: true,
+    finance: false,
+    children: (
+      <SectionBody text="Consent forms, discharge notes and lab reports for this practice." />
+    ),
+  },
+} satisfies Meta<typeof SectionCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WithAction: Story = {
+  name: 'With an Add action',
+  args: {
+    buttonTitle: 'Add',
+    buttonIcon: <IoAdd />,
+  },
+};
+
+export const HeadingOnly: Story = {
+  name: 'No action (read-only member)',
+  args: {
+    title: 'Online booking',
+    showButton: false,
+    children: <SectionBody text="Owners can request appointments from your public booking page." />,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Pages pass `showButton={canEdit…}`, so this is the read-only view. Without an action ' +
+          'the card takes the taller 20px vertical padding, since the pill is no longer setting ' +
+          'the header height.',
+      },
+    },
+  },
+};
+
+export const CustomActions: Story = {
+  name: 'Custom actions slot',
+  args: {
+    title: 'Linked medical devices',
+    showButton: false,
+    actions: (
+      <span
+        className="text-caption-1"
+        style={{
+          padding: '4px 12px',
+          borderRadius: 9999,
+          border: '1px solid var(--hairline)',
+          color: 'var(--ink-muted)',
+        }}
+      >
+        Last polled 4 min ago
+      </span>
+    ),
+    children: (
+      <SectionBody text="IDEXX analyser and two in-house imaging units are reporting in." />
+    ),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`actions` takes any node and sits beside the standard button, for sections whose ' +
+          'control is a status chip or a bespoke toggle rather than a CTA.',
+      },
+    },
+  },
+};
+
+export const LongTitle: Story = {
+  name: 'Long title beside the action',
+  args: {
+    title: 'Specialties, services & packages available for online booking',
+    buttonTitle: 'Manage',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The heading is `min-w-0 flex-1` and the action row is `shrink-0`, so a long title wraps ' +
+          'instead of squeezing the pill into two lines.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/primitives/SectionContainer/SectionContainer.stories.tsx
+++ b/apps/frontend/src/app/ui/primitives/SectionContainer/SectionContainer.stories.tsx
@@ -1,0 +1,82 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { IoAddCircleOutline } from 'react-icons/io5';
+
+import SectionContainer from './SectionContainer';
+
+const Body = () => (
+  <div className="flex flex-col gap-2 text-[13px] text-[var(--ink-body)]">
+    <p>Any form fields, tables or editors go here.</p>
+    <p className="text-[var(--ink-muted)]">
+      The container only owns the border, the radius and the header row.
+    </p>
+  </div>
+);
+
+const meta = {
+  title: 'Primitives/SectionContainer',
+  component: SectionContainer,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Bordered card that groups a titled block of form fields. The title is plain static text ' +
+          '(15px/700 on `--ink`, 14px when `nested`) with an optional leading icon and an optional ' +
+          'right-aligned slot; the border turns `--input-border-active` on `focus-within` so the ' +
+          'section highlights while a field inside it is focused. Pass `disableFocusBorder` when the ' +
+          'child owns its own focus affordance, and `compactTop` to pull the header closer to the top edge.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    nested: { control: 'boolean' },
+    disableFocusBorder: { control: 'boolean' },
+    compactTop: { control: 'boolean' },
+  },
+  args: {
+    title: 'Companion details',
+    children: <Body />,
+  },
+} satisfies Meta<typeof SectionContainer>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithTitleSlot: Story = {
+  name: 'Title slot + leading icon',
+  args: {
+    title: 'Vaccinations',
+    titleIcon: <IoAddCircleOutline size={16} color="var(--blue)" aria-hidden="true" />,
+    titleSlot: <span className="text-[12px] text-[var(--ink-faint)]">3 records</span>,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'The slot is pinned right and never shrinks; the title takes the remaining width.',
+      },
+    },
+  },
+};
+
+export const Nested: Story = {
+  name: 'Nested (14px title)',
+  args: { title: 'Dosage', nested: true },
+};
+
+export const LongTitle: Story = {
+  name: 'Long title truncates',
+  args: {
+    title: 'Pre-anaesthetic bloodwork, imaging and consent paperwork for the scheduled procedure',
+    titleSlot: <span className="text-[12px] text-[var(--ink-faint)]">Required</span>,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'A long title stays on one line and truncates rather than wrapping under the slot.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/primitives/TabToggle/TabToggle.stories.tsx
+++ b/apps/frontend/src/app/ui/primitives/TabToggle/TabToggle.stories.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import { IoDocumentTextOutline, IoPulseOutline } from 'react-icons/io5';
+
+import TabToggle, { type TabOption } from './TabToggle';
+
+const RECORD_TABS: TabOption[] = [
+  { key: 'VITALS', label: 'Vitals' },
+  { key: 'OBSERVATION', label: 'Observation tools' },
+];
+
+const meta = {
+  title: 'Primitives/TabToggle',
+  component: TabToggle,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Underlined tab strip used inside the appointment workspace side modal (record, documents ' +
+          'and tasks panels). Segments share the width equally; the active tab is bold `--blue-text` ' +
+          'over a 2px `--blue` underline that sits on the shared `card-border` hairline. Pass `panelId` ' +
+          'to wire `aria-controls` to the panel each tab reveals.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    tabs: RECORD_TABS,
+    activeKey: 'VITALS',
+    onChange: fn(),
+  },
+  decorators: [
+    (StoryFn) => (
+      <div style={{ maxWidth: 520 }}>
+        <StoryFn />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof TabToggle>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+/** The second tab active — the underline and the bold weight move together. */
+export const SecondTabActive: Story = {
+  name: 'Second tab active',
+  args: { activeKey: 'OBSERVATION' },
+};
+
+/** Optional leading icons, as the documents panel uses them. */
+export const WithIcons: Story = {
+  name: 'With icons',
+  args: {
+    tabs: [
+      { key: 'VITALS', label: 'Vitals', icon: <IoPulseOutline size={16} aria-hidden /> },
+      { key: 'NOTES', label: 'Notes', icon: <IoDocumentTextOutline size={16} aria-hidden /> },
+    ],
+  },
+};
+
+/**
+ * Four tabs with longer labels. Segments are `flex-1`, so the strip stays even
+ * while the labels get tighter — the case where a label would start to wrap.
+ */
+export const ManyTabs: Story = {
+  name: 'Many tabs, long labels',
+  args: {
+    tabs: [
+      { key: 'all', label: 'All documents' },
+      { key: 'consent', label: 'Consent forms' },
+      { key: 'lab', label: 'Lab results' },
+      { key: 'imaging', label: 'Imaging' },
+    ],
+    activeKey: 'consent',
+  },
+};
+
+const InteractiveTabToggle = () => {
+  const [activeKey, setActiveKey] = useState('VITALS');
+  return (
+    <div className="flex flex-col gap-3">
+      <TabToggle
+        tabs={RECORD_TABS}
+        activeKey={activeKey}
+        onChange={setActiveKey}
+        panelId={(key) => `tabtoggle-panel-${key}`}
+      />
+      <div
+        id={`tabtoggle-panel-${activeKey}`}
+        role="tabpanel"
+        aria-labelledby={`tab-${activeKey}`}
+        className="text-[14px] text-[var(--ink-body)]"
+      >
+        {activeKey === 'VITALS' ? 'Weight, temperature, heart rate.' : 'Pain and grimace scales.'}
+      </div>
+    </div>
+  );
+};
+
+/** Wired to a panel so the `aria-controls` / `role="tabpanel"` pairing is exercised. */
+export const Interactive: Story = {
+  render: () => <InteractiveTabToggle />,
+};

--- a/apps/frontend/src/app/ui/theme/ThemeToggle.stories.tsx
+++ b/apps/frontend/src/app/ui/theme/ThemeToggle.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ThemeToggle from './ThemeToggle';
+
+const meta = {
+  title: 'Theme/ThemeToggle',
+  component: ThemeToggle,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Round 38px button that flips the PIMS between the warm-bone light theme and the espresso ' +
+          'dark theme. It reads and writes `data-theme` on `<html>` (the same source of truth the ' +
+          'pre-paint theme script sets) and persists the choice, so pressing it here flips the whole ' +
+          'Storybook canvas exactly as it flips the app. A moon shows in light mode, a sun in dark, ' +
+          'and `aria-pressed` reflects the dark state.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    style: { control: false },
+  },
+} satisfies Meta<typeof ThemeToggle>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const FullWidth: Story = {
+  name: 'Full width (collapsed menu)',
+  args: {
+    style: { width: '100%', borderRadius: 12 },
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          width: 200,
+          padding: 12,
+          borderRadius: 16,
+          border: '1px solid var(--hairline)',
+          background: 'var(--screen)',
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The `style` prop merges over the base pill, which is how the account menu renders it as a ' +
+          'full-width row instead of a floating circle.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/widgets/Cookies/Cookies.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/Cookies/Cookies.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+
+import Cookies from './Cookies';
+import { getStorageItem, removeStorageItem, setStorageItem } from '../../../lib/browserStorage';
+import { COOKIE_CONSENT_KEY } from '../../../lib/posthog';
+
+/**
+ * The banner is driven entirely by one localStorage key, read through
+ * `useSyncExternalStore`. Seeding or clearing that key is the only setup a story
+ * needs — there is no provider and no network call behind it.
+ */
+const withConsent = (value: 'true' | 'false' | null) => () => {
+  const previous = getStorageItem('local', COOKIE_CONSENT_KEY);
+  if (value === null) {
+    removeStorageItem('local', COOKIE_CONSENT_KEY);
+  } else {
+    setStorageItem('local', COOKIE_CONSENT_KEY, value);
+  }
+  return () => {
+    if (previous === null) {
+      removeStorageItem('local', COOKIE_CONSENT_KEY);
+    } else {
+      setStorageItem('local', COOKIE_CONSENT_KEY, previous);
+    }
+  };
+};
+
+const meta = {
+  title: 'Widgets/Cookies',
+  component: Cookies,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The cookie consent notice for public pages. It is pinned to the bottom-left of the ' +
+          'viewport with the illustrated cookie tucked underneath, and it explains exactly what ' +
+          'accepting turns on: one consent cookie, plus PostHog analytics with masking. Either ' +
+          'answer is recorded in localStorage and the banner never returns for that browser.',
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ minHeight: 620, background: 'var(--page)' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof Cookies>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Undecided: Story = {
+  name: 'Awaiting a choice',
+  beforeEach: withConsent(null),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'What a first-time visitor sees. Accept and Reject are stacked and equally weighted — ' +
+          'rejecting is one click, not a settings detour.',
+      },
+    },
+  },
+};
+
+export const Accepted: Story = {
+  name: 'Already answered',
+  beforeEach: withConsent('true'),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Once a choice is stored the component returns `null`, so nothing renders here — that is ' +
+          'the expected result. Rejecting produces the same empty state; the stored value only ' +
+          'decides whether analytics load, not whether the banner comes back.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/widgets/Cookies/Cookies.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/Cookies/Cookies.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import React from 'react';
 
 import Cookies from './Cookies';
 import { getStorageItem, removeStorageItem, setStorageItem } from '../../../lib/browserStorage';

--- a/apps/frontend/src/app/ui/widgets/DashboardProfile/DashboardProfile.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/DashboardProfile/DashboardProfile.stories.tsx
@@ -1,0 +1,103 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import type { Organisation, UserOrganization } from '@yosemite-crew/types';
+import DashboardProfile from './DashboardProfile';
+import { useOrgStore } from '../../../stores/orgStore';
+import { useAuthStore } from '../../../stores/authStore';
+import { PERMISSIONS } from '../../../lib/permissions';
+
+const ORG_ID = 'storybook-org';
+
+const buildOrg = (isVerified: boolean): Organisation => ({
+  _id: ORG_ID,
+  name: 'Pawsome Veterinary Clinic',
+  type: 'HOSPITAL',
+  phoneNo: '+49 30 123456',
+  taxId: 'DE123456789',
+  isVerified,
+});
+
+const buildMembership = (canEditOrg: boolean): UserOrganization => ({
+  practitionerReference: 'storybook-user',
+  organizationReference: ORG_ID,
+  // No role baseline is assumed: permissions are granted explicitly so the
+  // story does not silently change when the role table does.
+  roleCode: '',
+  active: true,
+  extraPermissions: canEditOrg ? [PERMISSIONS.ORG_EDIT] : [],
+});
+
+/**
+ * The widget reads everything from Zustand, so each story seeds the org and
+ * auth stores before it renders and restores the previous state afterwards.
+ * No network is involved — both stores are plain client state.
+ */
+const seedStores = (options: { isVerified: boolean; canEditOrg: boolean }) => {
+  const previousOrgState = useOrgStore.getState();
+  const previousAuthState = useAuthStore.getState();
+
+  useOrgStore.setState({
+    orgsById: { [ORG_ID]: buildOrg(options.isVerified) },
+    orgIds: [ORG_ID],
+    primaryOrgId: ORG_ID,
+    membershipsByOrgId: { [ORG_ID]: buildMembership(options.canEditOrg) },
+    // `usePermissions` reports `isLoading` until the org store has loaded, and
+    // PermissionGate renders nothing while loading.
+    status: 'loaded',
+  });
+  useAuthStore.setState({ attributes: { given_name: 'Sarah', family_name: 'Weber' } });
+
+  return () => {
+    useOrgStore.setState(previousOrgState);
+    useAuthStore.setState(previousAuthState);
+  };
+};
+
+const meta = {
+  title: 'Widgets/DashboardProfile',
+  component: DashboardProfile,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Greeting block at the top of the dashboard: the italic Newsreader "Welcome back," eyebrow, the signed-in ' +
+          "user's name and avatar, a one-line summary, and — depending on the organisation — either a `Verified clinic` " +
+          'status pill or the amber verification-in-progress banner with its booking CTA. The banner is wrapped in a ' +
+          '`PermissionGate` for `org:edit`, so members without that permission never see it. Renders nothing at all when there is no primary organisation.',
+      },
+    },
+  },
+  decorators: [
+    (StoryFn) => (
+      <div style={{ maxWidth: 1100 }}>
+        <StoryFn />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof DashboardProfile>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Verified organisation: greeting plus the success-toned `Verified clinic` pill. */
+export const VerifiedClinic: Story = {
+  beforeEach: () => seedStores({ isVerified: true, canEditOrg: true }),
+};
+
+/**
+ * Awaiting verification, viewed by someone who can edit the organisation. The
+ * warn-toned banner, the "Verify business profile" CTA and the explanatory note
+ * all appear.
+ */
+export const AwaitingVerification: Story = {
+  beforeEach: () => seedStores({ isVerified: false, canEditOrg: true }),
+};
+
+/**
+ * The same unverified organisation seen by a member without `org:edit`. The
+ * `PermissionGate` drops the whole banner, leaving only the greeting — this is
+ * the state to check when the header looks unexpectedly bare.
+ */
+export const AwaitingVerificationWithoutPermission: Story = {
+  beforeEach: () => seedStores({ isVerified: false, canEditOrg: false }),
+};

--- a/apps/frontend/src/app/ui/widgets/DashboardSteps/DashboardSteps.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/DashboardSteps/DashboardSteps.stories.tsx
@@ -1,0 +1,166 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import type { Organisation, Speciality, UserOrganization } from '@yosemite-crew/types';
+import type { BillingSubscription } from '@/app/features/billing/types/billing';
+import type { RoleCode } from '@/app/lib/permissions';
+import type { Team } from '@/app/features/organization/types/team';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useSpecialityStore } from '@/app/stores/specialityStore';
+import { useSubscriptionStore } from '@/app/stores/subscriptionStore';
+import { useTeamStore } from '@/app/stores/teamStore';
+import DashboardSteps from './index';
+
+const ORG_ID = 'org-1';
+
+const org: Organisation = {
+  _id: ORG_ID,
+  name: 'Half Dome Veterinary Hospital',
+  type: 'HOSPITAL',
+  phoneNo: '+1 209 555 0148',
+  taxId: 'US-TAX-4417',
+  isVerified: true,
+  isActive: true,
+};
+
+const membership = (roleCode: RoleCode): UserOrganization => ({
+  id: 'membership-1',
+  practitionerReference: 'Practitioner/user-1',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode,
+  active: true,
+});
+
+const speciality = (id: string, name: string, activeServiceCount: number): Speciality => ({
+  _id: id,
+  organisationId: ORG_ID,
+  name,
+  activeServiceCount,
+});
+
+const teamMember = (id: string, name: string): Team => ({
+  _id: id,
+  practionerId: `practitioner-${id}`,
+  organisationId: ORG_ID,
+  name,
+  role: 'VETERINARIAN',
+  speciality: [],
+  status: 'Available',
+  revokedPermissions: [],
+  effectivePermissions: [],
+  extraPerissions: [],
+});
+
+type Seed = {
+  roleCode: RoleCode;
+  specialities: Speciality[];
+  team: Team[];
+  subscription: BillingSubscription;
+};
+
+/**
+ * The card takes no props: org, subscription, services, team and the signed-in
+ * role all come out of four Zustand stores. They are plain stores with no provider
+ * and no fetch on read, so seeding them is the whole of the setup. It runs in
+ * `beforeEach` rather than in a decorator so nothing writes to a store during a
+ * React render.
+ */
+const seedStores = ({ roleCode, specialities, team, subscription }: Seed) => {
+  useOrgStore.setState({
+    orgsById: { [ORG_ID]: org },
+    orgIds: [ORG_ID],
+    primaryOrgId: ORG_ID,
+    membershipsByOrgId: { [ORG_ID]: membership(roleCode) },
+    status: 'loaded',
+  });
+  useSpecialityStore.getState().setSpecialitiesForOrg(ORG_ID, specialities);
+  useTeamStore.getState().setTeamsForOrg(ORG_ID, team);
+  useSubscriptionStore.getState().setSubscriptionForOrg(ORG_ID, subscription);
+};
+
+const NOTHING_DONE: Seed = {
+  roleCode: 'OWNER',
+  specialities: [speciality('spec-1', 'General practice', 0)],
+  team: [teamMember('team-1', 'Dr. Amelia Hart')],
+  subscription: { orgId: ORG_ID, plan: 'free' },
+};
+
+/**
+ * No `autodocs` tag on purpose. Every story here writes the same global stores, so
+ * a docs page that mounts all three at once would show whichever one seeded last
+ * three times over. One story per canvas is the only honest reading.
+ */
+const meta = {
+  title: 'Widgets/DashboardSteps',
+  component: DashboardSteps,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The "Get started" onboarding strip at the top of the dashboard: up to three cards for ' +
+          'adding services, inviting the team and connecting Stripe. Completion is derived from the ' +
+          'org’s own data rather than stored, a step the signed-in role cannot action is dropped ' +
+          'from the row instead of being shown disabled, and the whole strip unmounts once every ' +
+          'visible step is done — so it can never sit on a finished dashboard.',
+      },
+    },
+  },
+  beforeEach: () => {
+    seedStores(NOTHING_DONE);
+  },
+} satisfies Meta<typeof DashboardSteps>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const NothingDone: Story = {
+  name: 'Nothing done yet',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'First run: no services, a one-person team and no Stripe account, so all three cards are ' +
+          'open and the counter reads "0 of 3 done".',
+      },
+    },
+  },
+};
+
+export const PartiallyComplete: Story = {
+  name: 'Two of three done',
+  beforeEach: () => {
+    seedStores({
+      roleCode: 'OWNER',
+      specialities: [speciality('spec-1', 'General practice', 4)],
+      team: [teamMember('team-1', 'Dr. Amelia Hart'), teamMember('team-2', 'Priya Raman')],
+      subscription: { orgId: ORG_ID, plan: 'business', connectAccountId: 'acct_demo' },
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Completed steps stay in place at 55% opacity with a filled check and a disabled button ' +
+          'whose label flips to the "view" wording, so the row keeps its three-column rhythm as ' +
+          'steps land. Stripe has an account but charges are not enabled yet, which is the third ' +
+          'button label: "Continue setup".',
+      },
+    },
+  },
+};
+
+export const RoleWithoutBilling: Story = {
+  name: 'Role that cannot connect Stripe',
+  beforeEach: () => {
+    seedStores({ ...NOTHING_DONE, roleCode: 'ADMIN' });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'An admin can manage services and the team but not billing, so the Stripe card is ' +
+          'removed and the counter becomes "0 of 2 done". Two cards stretch across the same ' +
+          'three-column grid — the case worth checking before a role ever sees a single lonely card.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/widgets/DynamicChart/DynamicChartCard.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/DynamicChart/DynamicChartCard.stories.tsx
@@ -1,0 +1,166 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import type { ChartKey } from './chartAxis';
+import DynamicChartCard from './DynamicChartCard';
+
+const APPOINTMENT_KEYS: ChartKey[] = [
+  { name: 'Completed', color: 'var(--cta)' },
+  { name: 'Cancelled', color: 'var(--divider)' },
+];
+
+const REVENUE_KEYS: ChartKey[] = [{ name: 'Revenue', color: 'var(--blue)' }];
+
+const APPOINTMENTS = [
+  { month: 'Mon', Completed: 18, Cancelled: 3 },
+  { month: 'Tue', Completed: 24, Cancelled: 1 },
+  { month: 'Wed', Completed: 21, Cancelled: 5 },
+  { month: 'Thu', Completed: 27, Cancelled: 2 },
+  { month: 'Fri', Completed: 30, Cancelled: 4 },
+  { month: 'Sat', Completed: 12, Cancelled: 2 },
+  { month: 'Sun', Completed: 6, Cancelled: 0 },
+];
+
+const REVENUE = [
+  { month: 'Jan', Revenue: 12400 },
+  { month: 'Feb', Revenue: 14850 },
+  { month: 'Mar', Revenue: 11200 },
+  { month: 'Apr', Revenue: 17600 },
+  { month: 'May', Revenue: 19050 },
+  { month: 'Jun', Revenue: 16300 },
+];
+
+const PRODUCTS = [
+  { month: 'Amoxicillin 250mg', Turnover: 9.4 },
+  { month: 'Meloxicam oral suspension', Turnover: 7.1 },
+  { month: 'Feline trivalent vaccine', Turnover: 5.8 },
+  { month: 'Sterile gauze pads', Turnover: 3.2 },
+];
+
+const meta = {
+  title: 'Widgets/DynamicChartCard',
+  component: DynamicChartCard,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The shared chart card behind every dashboard and report graph: a `--screen` card with a ' +
+          'hairline border, an optional header (its own `headerContent`, or the built-in right-aligned ' +
+          'legend) and a lazily loaded recharts canvas. recharts lives behind one `next/dynamic` ' +
+          'boundary at the canvas, so it stays out of the initial bundle; while that chunk loads the ' +
+          'card shows a pulsing `--inset` block of the same height, which is why the card never ' +
+          'changes size between loading and loaded.',
+      },
+    },
+  },
+  argTypes: {
+    type: { control: 'radio', options: ['bar', 'line'] },
+    isEmpty: { control: 'boolean' },
+    hideYAxis: { control: 'boolean' },
+    hideKeys: { control: 'boolean' },
+    chartHeight: { control: 'number' },
+  },
+  args: {
+    data: APPOINTMENTS,
+    keys: APPOINTMENT_KEYS,
+    type: 'bar',
+    isEmpty: false,
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 620 }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof DynamicChartCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const StackedBars: Story = {
+  name: 'Stacked bars',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The default: series stacked on a shared `stackId`, a dashed horizontal grid and the legend ' +
+          'right-aligned above the plot rather than centred, which is what keeps a card title and its ' +
+          'legend on one line.',
+      },
+    },
+  },
+};
+
+export const Sparkline: Story = {
+  name: 'Sparkline (no Y axis)',
+  args: { hideYAxis: true, barSize: 14, chartHeight: 150, hideKeys: true },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The compact form the dashboard stat cards use. `hideYAxis` drops both the axis and the grid, ' +
+          '`hideKeys` suppresses the legend so the caller can put its own header above, and the height ' +
+          'comes down to 150px.',
+      },
+    },
+  },
+};
+
+export const Line: Story = {
+  name: 'Line, with axis labels',
+  args: {
+    data: REVENUE,
+    keys: REVENUE_KEYS,
+    type: 'line',
+    yAxisLabel: 'Revenue',
+    xAxisLabel: 'Month',
+    yTickFormatter: (value: number) => `$${(value / 1000).toFixed(0)}k`,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Trend series with both axis labels set. Naming an axis widens the chart margin on that side ' +
+          'so the rotated Y label has somewhere to sit, and `yTickFormatter` is what keeps currency ' +
+          'ticks from running into the plot.',
+      },
+    },
+  },
+};
+
+export const HorizontalBars: Story = {
+  name: 'Horizontal bars (long labels)',
+  args: {
+    data: PRODUCTS,
+    keys: [{ name: 'Turnover', color: 'var(--blue)' }],
+    layout: 'vertical',
+    chartHeight: 200,
+    barSize: 12,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The per-product report layout. In `vertical` layout the category axis moves to the left and ' +
+          'its ticks are drawn tilted at -30 degrees in a fixed 100px gutter - the overflow case worth ' +
+          'watching, since product names are long and the gutter does not grow.',
+      },
+    },
+  },
+};
+
+export const Empty: Story = {
+  name: 'No data',
+  args: { data: [], isEmpty: true },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'When the period has nothing to plot the card keeps its shell and legend and swaps the canvas ' +
+          'for the shared three-bar glyph, so a dashboard of empty cards still reads as a grid instead ' +
+          'of collapsing.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/widgets/DynamicSelect/DynamicSelect.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/DynamicSelect/DynamicSelect.stories.tsx
@@ -1,0 +1,95 @@
+import { type ComponentProps, useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { userEvent, within } from 'storybook/test';
+import DynamicSelect, { type Option } from './DynamicSelect';
+
+const SPECIES: Option[] = [
+  { value: 'dog', label: 'Dog' },
+  { value: 'cat', label: 'Cat' },
+  { value: 'horse', label: 'Horse' },
+  { value: 'rabbit', label: 'Rabbit' },
+  { value: 'bird', label: 'Bird' },
+  { value: 'reptile', label: 'Reptile' },
+];
+
+/**
+ * Controlled wrapper: the component takes `value`/`onChange`, so every story
+ * holds the selection in local state rather than freezing it in args.
+ */
+const ControlledSelect = (args: ComponentProps<typeof DynamicSelect>) => {
+  const [value, setValue] = useState(args.value);
+  return <DynamicSelect {...args} value={value} onChange={setValue} />;
+};
+
+const meta = {
+  title: 'Widgets/DynamicSelect',
+  component: DynamicSelect,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Form-height select with an optional inline type-to-filter. The closed toggle is a 60px transparent field ' +
+          '(1px `--notibg` border, radius 16); opening it squares off the bottom corners, switches the border to ' +
+          '`--blue-text` and drops a flush `--color-surface-card` menu underneath. When `searchable` is on, the ' +
+          'toggle label is replaced by a text input while open and the current label becomes its placeholder.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    searchable: { control: 'boolean' },
+    placeholder: { control: 'text' },
+    error: { control: 'text' },
+  },
+  args: {
+    options: SPECIES,
+    value: '',
+    placeholder: 'Select species',
+    inname: 'species',
+    searchable: true,
+    onChange: () => {},
+  },
+  decorators: [
+    (StoryFn) => (
+      <div style={{ maxWidth: 420, paddingBottom: 220 }}>
+        <StoryFn />
+      </div>
+    ),
+  ],
+  render: (args) => <ControlledSelect {...args} />,
+} satisfies Meta<typeof DynamicSelect>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Nothing chosen yet — the toggle shows the placeholder in `--color-select-ink-muted`. */
+export const Placeholder: Story = {};
+
+/** A value is set, so the toggle shows that option's label. */
+export const Selected: Story = { args: { value: 'horse' } };
+
+/**
+ * Open menu. The toggle's bottom corners square off against the flush panel,
+ * and the leading row re-offers the placeholder as a "clear" choice.
+ */
+export const Open: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Select species' }));
+  },
+};
+
+/** Validation message, rendered under the field once the form has been submitted. */
+export const WithError: Story = {
+  args: { error: 'Select a species to continue' },
+};
+
+/** No options at all — the menu shows the "No options available" disabled row. */
+export const NoOptions: Story = {
+  args: { options: [] },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Select species' }));
+  },
+};

--- a/apps/frontend/src/app/ui/widgets/Faq/Faq.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/Faq/Faq.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Faq from './Faq';
+
+const meta = {
+  title: 'Widgets/Faq',
+  component: Faq,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The marketing "Frequently asked questions" section. It owns its five questions and its ' +
+          'own open/closed state: only one answer is expanded at a time, so opening a second ' +
+          'question closes the first. Each row is the shared `Accordion` primitive with the edit ' +
+          'affordance turned off; the section styling (heading, panel rhythm) lives in `Faq.css`.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Faq>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Phone: Story = {
+  name: 'Phone width',
+  parameters: {
+    viewport: { defaultViewport: 'mobile' },
+    docs: {
+      description: {
+        story:
+          'At 375px the questions wrap onto two and three lines. This is the width where the ' +
+          'chevron has to stay pinned right and out of the wrapping title, so it is worth a ' +
+          'snapshot of its own.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/widgets/Footer/Footer.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/Footer/Footer.stories.tsx
@@ -1,0 +1,136 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Footer from './Footer';
+
+/**
+ * The footer asks openstatus.dev for the platform status on mount and colours
+ * the status pill from the answer. Left alone that makes every snapshot depend
+ * on a third-party request, so the stories swap `fetch` for a canned reply and
+ * put the real one back when the story unmounts.
+ */
+const withPlatformStatus = (status: string) => () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    if (String(input).includes('openstatus.dev')) {
+      return Promise.resolve(
+        new Response(JSON.stringify({ status }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      );
+    }
+    return original.call(globalThis, input, init);
+  }) as typeof globalThis.fetch;
+
+  return () => {
+    globalThis.fetch = original;
+  };
+};
+
+const withFailingStatusFetch = () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    if (String(input).includes('openstatus.dev')) {
+      return Promise.reject(new Error('offline'));
+    }
+    return original.call(globalThis, input, init);
+  }) as typeof globalThis.fetch;
+
+  return () => {
+    globalThis.fetch = original;
+  };
+};
+
+const PHONE_VIEWPORT = {
+  phone: {
+    name: 'Mobile (375)',
+    styles: { width: '375px', height: '812px' },
+    type: 'mobile',
+  },
+};
+
+const meta = {
+  title: 'Widgets/Footer',
+  component: Footer,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The marketing site footer: brand mark, the compliance badge strip, a live platform-status ' +
+          'pill, three link columns and the legal block. It reveals itself on scroll (framer-motion ' +
+          '`useInView`, once) and the link columns stagger in behind it, so in Storybook it animates ' +
+          'straight away because the canvas puts it in view immediately.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  beforeEach: withPlatformStatus('operational'),
+} satisfies Meta<typeof Footer>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * The everyday state - a green "All systems operational" pill under the badge
+ * strip.
+ */
+export const Default: Story = {};
+
+export const DegradedPlatform: Story = {
+  name: 'Degraded platform status',
+  beforeEach: withPlatformStatus('degraded_performance'),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The warning tone. Only the pill changes - dot colour, text colour and border - so this is ' +
+          'the story to watch if the `platform-status-link-*` tones drift apart.',
+      },
+    },
+  },
+};
+
+export const MajorOutage: Story = {
+  name: 'Major outage',
+  beforeEach: withPlatformStatus('major_outage'),
+  parameters: {
+    docs: {
+      description: {
+        story: 'The danger tone, shared by partial outage and any active incident.',
+      },
+    },
+  },
+};
+
+export const StatusUnavailable: Story = {
+  name: 'Status request failed',
+  beforeEach: withFailingStatusFetch,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'What renders when the status API is unreachable, which is also the first paint before the ' +
+          'request resolves: a neutral "Status unavailable" pill rather than an empty gap or a ' +
+          'misleading green.',
+      },
+    },
+  },
+};
+
+export const Mobile: Story = {
+  name: 'Mobile (375)',
+  globals: { viewport: { value: 'phone', isRotated: false } },
+  parameters: {
+    viewport: { options: PHONE_VIEWPORT },
+    chromatic: { viewports: [375] },
+    docs: {
+      description: {
+        story:
+          'Below the tablet breakpoint the link columns stack under the brand block and the legal ' +
+          'copy centres. The badge strip is the part that struggles here - five fixed-width logos on ' +
+          'a 375px canvas.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/widgets/Github/Github.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/Github/Github.stories.tsx
@@ -25,9 +25,22 @@ const withStubbedStars = (cached: number | null, response: StubbedResponse) => (
 
   // Only the GitHub call is intercepted - anything else the preview iframe asks
   // for still goes through the real implementation.
+  //
+  // Matched on the parsed hostname, not a substring: `includes` would also
+  // catch `https://evil.example/api.github.com/...`, and a stub that answers
+  // for the wrong host is a stub that hides a bug. Relative URLs resolve
+  // against a base that can never be the real one, so they fall through.
+  const isGitHubApi = (raw: string) => {
+    try {
+      return new URL(raw, 'https://relative.invalid').hostname === 'api.github.com';
+    } catch {
+      return false;
+    }
+  };
+
   globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
     const url = typeof input === 'string' ? input : input.toString();
-    if (!url.includes('api.github.com')) return realFetch(input, init);
+    if (!isGitHubApi(url)) return realFetch(input, init);
     if (response === 'pending') return new Promise<Response>(() => {});
     if (response === 'unavailable') {
       return Promise.resolve({ ok: false, status: 403 } as Response);

--- a/apps/frontend/src/app/ui/widgets/Github/Github.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/Github/Github.stories.tsx
@@ -1,0 +1,119 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { removeStorageItem, setJsonStorageItem } from '@/app/lib/browserStorage';
+import Github from './Github';
+
+const CACHE_KEY = 'gh:stars:YosemiteCrew/Yosemite-Crew';
+
+type StubbedResponse = number | 'unavailable' | 'pending';
+
+/**
+ * The banner reads a cached star count out of localStorage on its first render and
+ * then refreshes it from api.github.com once the page goes idle. Both are stubbed
+ * here: seeding the cache makes the rendered figure deterministic, and replacing
+ * `fetch` keeps the story - and the Chromatic snapshot - off the network entirely.
+ * Everything is restored when the story unmounts.
+ */
+const withStubbedStars = (cached: number | null, response: StubbedResponse) => () => {
+  const realFetch = globalThis.fetch;
+
+  if (cached === null) {
+    removeStorageItem('local', CACHE_KEY);
+  } else {
+    setJsonStorageItem('local', CACHE_KEY, { value: cached, ts: Date.now() });
+  }
+
+  // Only the GitHub call is intercepted - anything else the preview iframe asks
+  // for still goes through the real implementation.
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    if (!url.includes('api.github.com')) return realFetch(input, init);
+    if (response === 'pending') return new Promise<Response>(() => {});
+    if (response === 'unavailable') {
+      return Promise.resolve({ ok: false, status: 403 } as Response);
+    }
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ stargazers_count: response }),
+    } as unknown as Response);
+  }) as typeof fetch;
+
+  return () => {
+    globalThis.fetch = realFetch;
+    removeStorageItem('local', CACHE_KEY);
+  };
+};
+
+const meta = {
+  title: 'Widgets/Github',
+  component: Github,
+  parameters: {
+    layout: 'fullscreen',
+    // The banner only shows itself on the public marketing routes, so the App
+    // Router mock has to report one or the story renders an empty canvas.
+    nextjs: { appDirectory: true, navigation: { pathname: '/' } },
+    docs: {
+      description: {
+        component:
+          'The dismissible "Star us on Github" banner pinned to the bottom of the public marketing ' +
+          'pages. A dark `--color-text-primary` pill holds the prompt, a white chip with the repo star ' +
+          'count, and a close button. The count comes from the GitHub API but is cached in ' +
+          'localStorage for an hour and read synchronously on first render, so a returning visitor ' +
+          'never sees the placeholder. The banner hides itself on every non-public route.',
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ minHeight: 200, background: 'var(--page)' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  beforeEach: withStubbedStars(2480, 2480),
+} satisfies Meta<typeof Github>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Cached star count',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The normal state: a warm cache means the compact-formatted count ("2.5K") is on screen from ' +
+          'the very first paint, with no placeholder flash.',
+      },
+    },
+  },
+};
+
+export const Loading: Story = {
+  name: 'First visit (no cache)',
+  beforeEach: withStubbedStars(null, 'pending'),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A cold cache on a first visit. The chip holds an ellipsis until the deferred request lands. ' +
+          'The pill is sized by its label, not by the count, so resolving the number does not reflow ' +
+          'the banner.',
+      },
+    },
+  },
+};
+
+export const Unavailable: Story = {
+  name: 'API unavailable',
+  beforeEach: withStubbedStars(null, 'unavailable'),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Rate-limited or offline, with nothing cached to fall back on: the count degrades to an em ' +
+          'dash rather than disappearing, so the chip keeps its shape and the link still works.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/widgets/LabResultValue/LabResultValue.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/LabResultValue/LabResultValue.stories.tsx
@@ -1,0 +1,108 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import type { LabResultTest } from '@/app/features/integrations/services/types';
+
+import LabResultValue from './index';
+
+const CULTURE_RESULT = [
+  'Specimen: Urine, cystocentesis',
+  'Colony Count: >100,000 CFU/mL',
+  'Isolate 1: Escherichia coli',
+  'Isolate 1 MIC',
+  'Amoxicillin/Clavulanate S 8',
+  'Cefpodoxime S 2',
+  'Enrofloxacin R >4',
+  'Gentamicin S 2',
+  'Trimethoprim/Sulfa I 2',
+  '**INTERPRETATION KEY**',
+  'S = Susceptible at the labelled dose.',
+  'I = Intermediate; consider a higher dose or a different agent.',
+  'R = Resistant; do not use.',
+].join('\n');
+
+const LONG_CULTURE_RESULT = [
+  'Specimen: Deep ear swab, left',
+  'Colony Count: Moderate growth',
+  'Isolate 1: Pseudomonas aeruginosa',
+  'Isolate 2: Staphylococcus pseudintermedius',
+  'Isolate 1 MIC',
+  'Amikacin S 4',
+  'Ceftazidime S 4',
+  'Ciprofloxacin I 2',
+  'Enrofloxacin R >4',
+  'Gentamicin S 2',
+  'Marbofloxacin R >4',
+  'Piperacillin/Tazobactam S 16',
+  'Polymyxin B S 1',
+  'Ticarcillin/Clavulanate S 16',
+  'Tobramycin S 1',
+  '**INTERPRETATION KEY**',
+  'S = Susceptible at the labelled dose.',
+  'I = Intermediate; consider a higher dose or a different agent.',
+  'R = Resistant; do not use.',
+  'Topical therapy may still succeed where systemic therapy reads resistant.',
+].join('\n');
+
+const meta = {
+  title: 'Widgets/LabResultValue',
+  component: LabResultValue,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Renders the value cell of one lab result row. Ordinary tests print as `result units` and ' +
+          'nothing more. A culture-and-sensitivity result arrives as a wall of plain text, so this ' +
+          'component parses it into the parts a vet reads: the specimen summary, the isolates, a ' +
+          'susceptibility table, and the interpretation key folded into a `<details>` so it does not ' +
+          'bury the numbers.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (StoryFn) => (
+      <div className="max-w-[520px] text-caption-1 text-text-primary">
+        <StoryFn />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof LabResultValue>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** The ordinary case: a number and its units, inline in the row. */
+export const NumericValue: Story = {
+  name: 'Numeric value',
+  args: {
+    test: { name: 'Creatinine', result: '1.4', units: 'mg/dL', referenceRange: '0.5 - 1.8' },
+  },
+};
+
+/** No units on the payload — the value stands alone, with no trailing space. */
+export const TextValue: Story = {
+  name: 'Text value, no units',
+  args: { test: { name: 'Urine appearance', result: 'Clear, pale yellow' } },
+};
+
+/**
+ * A culture result. The same string that would otherwise print as ten
+ * unreadable lines becomes a summary, the isolate, a susceptibility table and a
+ * collapsed interpretation key.
+ */
+export const CultureResult: Story = {
+  name: 'Culture and sensitivity',
+  args: {
+    test: { name: 'Culture Results - Urine', result: CULTURE_RESULT } satisfies LabResultTest,
+  },
+};
+
+/**
+ * Two isolates and a long antibiotic panel. The block caps at `max-h-52` and
+ * scrolls internally, and the table gets its own horizontal scroll, so a large
+ * result cannot stretch the row it sits in.
+ */
+export const LongCultureResult: Story = {
+  name: 'Culture with overflow',
+  args: { test: { name: 'Culture Results - Ear', result: LONG_CULTURE_RESULT } },
+};

--- a/apps/frontend/src/app/ui/widgets/LaunchGrowTab/LaunchGrowTab.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/LaunchGrowTab/LaunchGrowTab.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { userEvent, within } from 'storybook/test';
+
+import LaunchGrowTab from './LaunchGrowTab';
+
+const PHONE_VIEWPORT = {
+  phone: {
+    name: 'Mobile (375)',
+    styles: { width: '375px', height: '812px' },
+    type: 'mobile',
+  },
+};
+
+const meta = {
+  title: 'Widgets/LaunchGrowTab',
+  component: LaunchGrowTab,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The "build and launch" accordion on the developer landing page: four fixed panels (APIs, ' +
+          'SDKs, pre-built templates, documentation) that expand one at a time, each tinted a step ' +
+          'deeper into the blue ramp. The active tab owns its content; the others collapse to a ' +
+          'numbered spine. It keeps its own `activeTab` state and takes no props, so the stories ' +
+          'drive it the way a visitor would - by clicking.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof LaunchGrowTab>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * The resting state: panel 01 (APIs) open, the other three collapsed.
+ */
+export const Default: Story = {};
+
+export const DocumentationOpen: Story = {
+  name: 'Last panel open',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(await canvas.findByText('Documentation'));
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Panel 04 selected. It is the deepest tint and the longest list, so it is the one that ' +
+          'shows whether the expanded panel can hold five bullets without the collapsed spines ' +
+          'losing their labels.',
+      },
+    },
+  },
+};
+
+export const Mobile: Story = {
+  name: 'Mobile (375)',
+  globals: { viewport: { value: 'phone', isRotated: false } },
+  parameters: {
+    viewport: { options: PHONE_VIEWPORT },
+    chromatic: { viewports: [375] },
+    docs: {
+      description: {
+        story:
+          'Below the breakpoint the accordion is replaced entirely: the desktop panels are hidden, ' +
+          'the active panel renders on its own, and a floating numbered nav pinned at the bottom ' +
+          'does the switching. That is why the tab titles are abbreviated in the data - "PBT" and ' +
+          '"Docs" are what the mobile nav shows, `fullTitle` is what desktop shows.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/widgets/Stats/AppointmentLeadersStat.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/Stats/AppointmentLeadersStat.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import AppointmentLeadersStat from './AppointmentLeadersStat';
+// Relative, not `@/`: the Storybook Vite build does not resolve the `@/` alias
+// for runtime imports inside story files.
+import { useOrgStore } from '../../../stores/orgStore';
+
+/**
+ * `useDashboardAnalytics` only calls the analytics API once the org store has a
+ * primary organisation, and `useTeamForPrimaryOrg` needs the same id to resolve
+ * practitioner names. Clearing it keeps the story offline and deterministic: the
+ * hook stays on its DEFAULT_DATA, which is exactly the empty state below. The
+ * previous store state is restored when the story unmounts.
+ */
+const detachPrimaryOrg = () => {
+  const previousOrgState = useOrgStore.getState();
+  useOrgStore.setState({ primaryOrgId: null });
+  return () => {
+    useOrgStore.setState(previousOrgState);
+  };
+};
+
+const meta = {
+  title: 'Widgets/Stats/AppointmentLeadersStat',
+  component: AppointmentLeadersStat,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Leaderboard card on the dashboard: one `--cta` bar per practitioner, widths scaled to the ' +
+          'busiest of them and opacity stepped down by rank, with the completed count right-aligned ' +
+          'in tabular figures. Names are resolved from the team store against the practitioner id the ' +
+          'analytics API returns, so a leader who has left the team still charts — under their id. ' +
+          'The figures are keyed on the primary organisation, so the only state renderable offline is ' +
+          'the empty one.',
+      },
+    },
+  },
+  decorators: [
+    (StoryFn) => (
+      <div style={{ maxWidth: 560 }}>
+        <StoryFn />
+      </div>
+    ),
+  ],
+  beforeEach: detachPrimaryOrg,
+} satisfies Meta<typeof AppointmentLeadersStat>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * No completed appointments in the period: the card keeps its title and
+ * duration pill and swaps the bars for the shared three-bar "No data available"
+ * glyph, held at `min-h-89` so a dashboard row does not collapse around it.
+ */
+export const NoData: Story = {};

--- a/apps/frontend/src/app/ui/widgets/Stats/AppointmentStat.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/Stats/AppointmentStat.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { useOrgStore } from '@/app/stores/orgStore';
+import AppointmentStat from './AppointmentStat';
+
+/**
+ * `useDashboardAnalytics` only reaches for the analytics API once the org store has
+ * a primary organisation. Clearing it holds the hook on its DEFAULT_DATA, which is
+ * exactly the empty state below, and keeps the story offline and deterministic.
+ * The previous store state is restored when the story unmounts.
+ */
+const detachPrimaryOrg = () => {
+  const previousOrgState = useOrgStore.getState();
+  useOrgStore.setState({ primaryOrgId: null });
+  return () => {
+    useOrgStore.setState(previousOrgState);
+  };
+};
+
+const meta = {
+  title: 'Widgets/Stats/AppointmentStat',
+  component: AppointmentStat,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Appointments card on the dashboard: a `CardHeader` with the duration picker over a 150px ' +
+          'stacked bar sparkline - `--cta` for completed, `--divider` for cancelled, no Y axis. ' +
+          'Picking "Last month" switches the X axis to the compact day-tick format so a 30-point ' +
+          'series does not collide with itself. The figures come from the dashboard analytics API ' +
+          'keyed on the primary organisation, so the only state renderable offline is the empty one.',
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 560 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  beforeEach: detachPrimaryOrg,
+} satisfies Meta<typeof AppointmentStat>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * No analytics for the period: the card keeps its title and duration pill and swaps
+ * the chart for the shared three-bar "No data available" glyph, so the dashboard
+ * grid holds its shape. The populated chart is covered by `Widgets/DynamicChartCard`,
+ * which takes its series as props and does not need the API.
+ */
+export const NoData: Story = {};

--- a/apps/frontend/src/app/ui/widgets/Stats/IndividualProductTurnoverStat.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/Stats/IndividualProductTurnoverStat.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import IndividualProductTurnoverStat from './IndividualProductTurnoverStat';
+import { useOrgStore } from '@/app/stores/orgStore';
+
+const meta = {
+  title: 'Widgets/Stats/IndividualProductTurnoverStat',
+  component: IndividualProductTurnoverStat,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Dashboard stat card listing how many times each stocked product turned over in the last ' +
+          'year: a truncated product name, a bar scaled against the busiest product (cycling `--cta` / ' +
+          '`--blue` / `--divider` so the multi-hue reading of the design survives), and the figure to ' +
+          'one decimal. A `--inset` footnote compares the clinic total against the clinic average. ' +
+          'The card takes no props — every figure comes from `useDashboardAnalytics`, which only ' +
+          'fetches once an organisation is selected, so Storybook shows the no-data state.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (StoryFn) => (
+      <div style={{ maxWidth: 420 }}>
+        <StoryFn />
+      </div>
+    ),
+  ],
+  beforeEach: () => {
+    // Guarantees the analytics hook short-circuits instead of calling the API:
+    // it returns early whenever there is no primary organisation. Another
+    // story could have seeded the (persisted) org store, so clear it here.
+    const snapshot = useOrgStore.getState();
+    useOrgStore.setState({ orgsById: {}, orgIds: [], primaryOrgId: null, membershipsByOrgId: {} });
+    return () => {
+      useOrgStore.setState({
+        orgsById: snapshot.orgsById,
+        orgIds: snapshot.orgIds,
+        primaryOrgId: snapshot.primaryOrgId,
+        membershipsByOrgId: snapshot.membershipsByOrgId,
+      });
+    };
+  },
+} satisfies Meta<typeof IndividualProductTurnoverStat>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const NoData: Story = {
+  name: 'No data',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'What a clinic with no stock movement (or a Storybook session with no organisation) sees: ' +
+          'the shared bar-chart placeholder inside the normal card shell, with the header and its ' +
+          'fixed "Last 1 year" period pill still in place. The populated bars need live analytics and ' +
+          'cannot be rendered here without inventing data.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/widgets/Stats/LeadersStat.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/Stats/LeadersStat.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import AppointmentLeadersStat from './AppointmentLeadersStat';
+import RevenueLeadersStat from './RevenueLeadersStat';
+import { useOrgStore } from '@/app/stores/orgStore';
+
+const meta = {
+  title: 'Widgets/Stats/LeadersStat',
+  component: AppointmentLeadersStat,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The two dashboard leaderboards: `AppointmentLeadersStat` (completed visits per ' +
+          'practitioner, bars in `--cta`, names resolved from the team store so a practitioner id ' +
+          'never reaches the screen) and `RevenueLeadersStat` (billed revenue per practitioner, bars ' +
+          'in `--blue`, figures through `formatMoney` in the organisation’s currency). Both fade the ' +
+          'bars as they descend the ranking, and both carry a live duration picker in the header ' +
+          'rather than the fixed pill the turnover cards use. Figures come from ' +
+          '`useDashboardAnalytics`, which makes no request and returns zeroed defaults when no ' +
+          'organisation is selected — so Storybook shows the empty state and what is under review ' +
+          'here is the card shell, header and picker.',
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 420 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  beforeEach: () => {
+    // Guarantees the analytics hook short-circuits instead of calling the API:
+    // it returns early whenever there is no primary organisation. Another story
+    // could have seeded the (persisted) org store, so clear it here.
+    const snapshot = useOrgStore.getState();
+    useOrgStore.setState({ orgsById: {}, orgIds: [], primaryOrgId: null, membershipsByOrgId: {} });
+    return () => {
+      useOrgStore.setState({
+        orgsById: snapshot.orgsById,
+        orgIds: snapshot.orgIds,
+        primaryOrgId: snapshot.primaryOrgId,
+        membershipsByOrgId: snapshot.membershipsByOrgId,
+      });
+    };
+  },
+} satisfies Meta<typeof AppointmentLeadersStat>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const AppointmentLeaders: Story = {
+  name: 'Appointment leaders',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The empty reading: the shared bar-chart placeholder inside the card, which grows to ' +
+          '`min-h-89` so an empty leaderboard occupies the same dashboard row as a populated one and ' +
+          'the grid does not jump once data lands.',
+      },
+    },
+  },
+};
+
+export const RevenueLeaders: Story = {
+  name: 'Revenue leaders',
+  render: () => <RevenueLeadersStat />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Same shell and same empty state, different title and accent. The pair sits side by side on ' +
+          'the dashboard, so any drift between the two headers or card heights shows up as a diff ' +
+          'between these two snapshots.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/widgets/Stats/RevenueStat.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/Stats/RevenueStat.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import RevenueStat from './RevenueStat';
+import { useOrgStore } from '../../../stores/orgStore';
+
+/**
+ * `useDashboardAnalytics` only calls the analytics API once the org store has a
+ * primary organisation. Clearing it keeps the story offline and deterministic:
+ * the hook stays on its DEFAULT_DATA, which is exactly the empty state below.
+ * The previous store state is restored when the story unmounts.
+ */
+const detachPrimaryOrg = () => {
+  const previousOrgState = useOrgStore.getState();
+  useOrgStore.setState({ primaryOrgId: null });
+  return () => {
+    useOrgStore.setState(previousOrgState);
+  };
+};
+
+const meta = {
+  title: 'Widgets/Stats/RevenueStat',
+  component: RevenueStat,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Revenue card on the dashboard: a `CardHeader` with the duration picker over a 150px bar sparkline ' +
+          '(`--blue` bars, no Y axis). When the period has takings, the total is printed in `--success` above the ' +
+          'chart in place of the legend. The figures come from the dashboard analytics API keyed on the primary ' +
+          'organisation, so the only state that can be rendered offline is the empty one.',
+      },
+    },
+  },
+  decorators: [
+    (StoryFn) => (
+      <div style={{ maxWidth: 560 }}>
+        <StoryFn />
+      </div>
+    ),
+  ],
+  beforeEach: detachPrimaryOrg,
+} satisfies Meta<typeof RevenueStat>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * No analytics for the period: the card keeps its header and duration pill and
+ * swaps the chart for the shared three-bar "No data available" glyph. The
+ * green period total is suppressed, since the total is zero.
+ */
+export const NoData: Story = {};

--- a/apps/frontend/src/app/ui/widgets/Stats/StatCardShell.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/Stats/StatCardShell.stories.tsx
@@ -1,0 +1,138 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import StatCardShell from './StatCardShell';
+
+const DURATIONS = ['Last week', 'Last month', 'Last 6 months', 'Last 1 year'] as const;
+
+const TREND = [
+  { month: 'Mar', turnover: 3.1 },
+  { month: 'Apr', turnover: 4.4 },
+  { month: 'May', turnover: 3.8 },
+  { month: 'Jun', turnover: 5.2 },
+  { month: 'Jul', turnover: 4.9 },
+  { month: 'Aug', turnover: 2.4 },
+];
+
+const MAX_TURNOVER = TREND.reduce((max, point) => Math.max(max, point.turnover), 0);
+
+/**
+ * The bar body the inventory stats render inside the shell. Kept in the story
+ * rather than imported because the real stat components (`InventoryStat` and
+ * friends) read `useDashboardAnalytics`, which fetches.
+ */
+const TurnoverBars = () => (
+  <div className="flex h-30 flex-1 items-end gap-2.5 px-1">
+    {TREND.map((point, index) => {
+      const isPartial = index === TREND.length - 1;
+      const isPeak = point.turnover === MAX_TURNOVER;
+      return (
+        <div
+          key={point.month}
+          className="flex h-full flex-1 flex-col items-center justify-end gap-1"
+        >
+          <div
+            className="w-full max-w-[34px]"
+            style={{
+              height: `${(point.turnover / MAX_TURNOVER) * 100}%`,
+              background: isPartial ? 'var(--divider)' : 'var(--cta)',
+              opacity: isPartial || isPeak ? 1 : 0.85,
+              borderRadius: '5px 5px 2px 2px',
+            }}
+          />
+          <span className="text-[10px] text-[var(--ink-faint)]">{point.month}</span>
+        </div>
+      );
+    })}
+  </div>
+);
+
+const meta = {
+  title: 'Widgets/Stats/StatCardShell',
+  component: StatCardShell,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The card every dashboard stat is drawn inside: a `CardHeader` with the duration pill ' +
+          'above an 18px-radius `--screen` surface. It owns the shared "no data" state, so an ' +
+          'empty inventory card and an empty revenue card cannot drift apart.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    isEmpty: { control: 'boolean' },
+    selected: { control: 'select', options: DURATIONS },
+  },
+  args: {
+    title: 'Annual inventory turnover',
+    options: DURATIONS,
+    selected: 'Last 1 year',
+    isEmpty: false,
+    onSelect: fn(),
+    children: <TurnoverBars />,
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 420 }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof StatCardShell>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'With a chart body',
+};
+
+export const Empty: Story = {
+  name: 'No data',
+  args: { isEmpty: true },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'When `isEmpty` is set the shell swaps `children` for the shared placeholder — three ' +
+          '`--divider` bars over "No data available" — so the card keeps its height instead of ' +
+          'collapsing the dashboard grid.',
+      },
+    },
+  },
+};
+
+export const CustomHeight: Story = {
+  name: 'Leaderboard body (custom height)',
+  args: {
+    title: 'Revenue leaders',
+    selected: 'Last month',
+    cardClassName: 'gap-3',
+    children: (
+      <div className="flex flex-col gap-3">
+        {[
+          { label: 'Dr. Amelie Roth', value: '€12,480' },
+          { label: 'Dr. Tomas Lindqvist', value: '€9,120' },
+          { label: 'Dr. Priya Nair', value: '€7,640' },
+        ].map((row) => (
+          <div key={row.label} className="flex items-center justify-between">
+            <span className="text-[13px] text-[var(--ink-body)]">{row.label}</span>
+            <span className="text-[13px] font-bold text-[var(--ink)]">{row.value}</span>
+          </div>
+        ))}
+      </div>
+    ),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`cardClassName` replaces the default `min-h-75 gap-2.5` surface classes, for the cards ' +
+          'that hold a list rather than a fixed-height chart. Everything else — header, radius, ' +
+          'hairline, shadow, empty state — stays shared.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/widgets/Stats/TurnoverStat.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/Stats/TurnoverStat.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import AnnualInventoryTurnoverStat from './AnnualInventoryTurnoverStat';
+import IndividualProductTurnoverStat from './IndividualProductTurnoverStat';
+
+const meta = {
+  title: 'Widgets/Stats/TurnoverStat',
+  component: AnnualInventoryTurnoverStat,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The two inventory-turnover dashboard cards: `AnnualInventoryTurnoverStat` (a month-by-month ' +
+          'bar column, with the in-progress month drawn in `--divider` so a partial month never reads ' +
+          'as a drop) and `IndividualProductTurnoverStat` (per-product horizontal bars plus a trend ' +
+          'footnote). Both read live analytics through `useDashboardAnalytics`, which returns zeroed ' +
+          'defaults and makes no request when no org is signed in - so in Storybook they render the ' +
+          'shared "No data available" empty state and the card shell geometry is what is under review here.',
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 420 }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof AnnualInventoryTurnoverStat>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const AnnualInventoryTurnover: Story = {
+  name: 'Annual inventory turnover',
+};
+
+export const ProductTurnover: Story = {
+  name: 'Product turnover',
+  render: () => <IndividualProductTurnoverStat />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Same shell, different header title and duration pill. Both cards are locked to the ' +
+          '"Last 1 year" option, so the header pill is static rather than a picker.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/widgets/Summary/Availability.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/Summary/Availability.stories.tsx
@@ -1,0 +1,129 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import type { UserOrganization } from '@yosemite-crew/types';
+import type { Team } from '@/app/features/organization/types/team';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useTeamStore } from '@/app/stores/teamStore';
+import Availability from './Availability';
+
+const ORG_ID = 'org-1';
+
+const OWNER_MEMBERSHIP: UserOrganization = {
+  id: 'membership-1',
+  practitionerReference: 'Practitioner/user-1',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'OWNER',
+  active: true,
+};
+
+const speciality = (name: string): Team['speciality'][number] => ({
+  _id: name.toLowerCase().replace(/\s+/g, '-'),
+  organisationId: ORG_ID,
+  name,
+});
+
+const teamMember = (
+  id: string,
+  name: string,
+  role: string,
+  status: Team['status'],
+  specialities: string[],
+  todayAppointment: string,
+  weeklyWorkingHours: string
+): Team => ({
+  _id: id,
+  practionerId: `practitioner-${id}`,
+  organisationId: ORG_ID,
+  name,
+  role,
+  speciality: specialities.map(speciality),
+  todayAppointment,
+  weeklyWorkingHours,
+  status,
+  revokedPermissions: [],
+  effectivePermissions: [],
+  extraPerissions: [],
+});
+
+const TEAM: Team[] = [
+  teamMember('t1', 'Dr. Amelia Hart', 'VETERINARIAN', 'Available', ['Cardiology'], '6', '38.5'),
+  teamMember('t2', 'Dr. Ravi Menon', 'VETERINARIAN', 'Consulting', ['Dermatology'], '11', '40'),
+  teamMember('t3', 'Priya Raman', 'RECEPTIONIST', 'Off-Duty', [], '0', '0'),
+  teamMember('t4', 'Tomas Vidal', 'TECHNICIAN', 'Requested', ['Internal Medicine'], '3', '22'),
+];
+
+/**
+ * Everything the widget shows comes out of two Zustand stores: the team list, and
+ * the membership `usePermissions` derives `teams:view:any` from for the surrounding
+ * `PermissionGate`. Both are plain stores with no provider and no fetch on read, so
+ * seeding them in `beforeEach` — outside any React render — is the whole of the setup.
+ *
+ * No `autodocs` tag on purpose: the stores are global, so a docs page that mounts
+ * every story at once would show whichever one seeded last in all of them.
+ */
+const seedStores = (team: Team[]) => {
+  useOrgStore.setState({
+    primaryOrgId: ORG_ID,
+    membershipsByOrgId: { [ORG_ID]: OWNER_MEMBERSHIP },
+    status: 'loaded',
+  });
+  useTeamStore.getState().setTeamsForOrg(ORG_ID, team);
+};
+
+const meta = {
+  title: 'Widgets/Summary/Availability',
+  component: Availability,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The dashboard’s team-availability panel: a counted heading, the five status chips, and ' +
+          'the shared `AvailabilityTable` (which re-forms into `AvailabilityCard`s below the table ' +
+          'breakpoint). Filtering is local — the chips narrow the rows already in the team store ' +
+          'rather than refetching. The whole panel sits behind a `teams:view:any` gate, so a role ' +
+          'without it sees nothing at all rather than an empty table.',
+      },
+    },
+  },
+  beforeEach: () => {
+    seedStores(TEAM);
+  },
+} satisfies Meta<typeof Availability>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Full team',
+};
+
+export const Empty: Story = {
+  name: 'No team members',
+  beforeEach: () => {
+    seedStores([]);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A brand-new org. The heading still counts — "Availability (0)" — the chips stay ' +
+          'interactive, and the table drops to its own empty row rather than collapsing the panel.',
+      },
+    },
+  },
+};
+
+export const Phone: Story = {
+  name: 'Phone width',
+  parameters: {
+    viewport: { defaultViewport: 'mobile' },
+    docs: {
+      description: {
+        story:
+          'Below the table breakpoint the rows re-form into `AvailabilityCard`s and the five ' +
+          'status chips wrap onto a second line. Same data as `Full team`, so any drift between ' +
+          'the two readings of a row shows up as a diff here.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/widgets/TeamSlide/TeamSlide.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/TeamSlide/TeamSlide.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import TeamSlide from './TeamSlide';
+
+const PHONE_VIEWPORT = {
+  phone: {
+    name: 'Mobile (375)',
+    styles: { width: '375px', height: '812px' },
+    type: 'mobile',
+  },
+};
+
+const meta = {
+  title: 'Widgets/TeamSlide',
+  component: TeamSlide,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The founding-team strip on the about page. Despite the name it does not slide: it is a ' +
+          'centred, wrapping flex row of four fixed 258x311 portraits, each with a round LinkedIn ' +
+          'badge pinned to its bottom-right corner. The roster is hard-coded in the component, so ' +
+          'there is nothing to configure - what changes between these stories is only the width it ' +
+          'has to wrap into.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof TeamSlide>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * All four portraits on one row, which is what the about page shows above
+ * 1500px. The 48px gap tightens to 24px below that.
+ */
+export const Default: Story = {};
+
+export const Wrapped: Story = {
+  name: 'Narrow container (wraps to two rows)',
+  decorators: [
+    (StoryFn) => (
+      <div style={{ maxWidth: 640 }}>
+        <StoryFn />
+      </div>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The strip wraps rather than shrinking its portraits, so a container that fits two of them ' +
+          'gives a 2x2 block. The row stays centred, which is what keeps a three-person roster from ' +
+          'looking left-aligned.',
+      },
+    },
+  },
+};
+
+export const Mobile: Story = {
+  name: 'Mobile (375)',
+  globals: { viewport: { value: 'phone', isRotated: false } },
+  parameters: {
+    viewport: { options: PHONE_VIEWPORT },
+    chromatic: { viewports: [375] },
+    docs: {
+      description: {
+        story:
+          'One portrait per row on a phone. The images keep their intrinsic 258px width, so this is ' +
+          'the case to watch for horizontal overflow on the narrowest supported canvas.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/widgets/TitleCalendar/TitleCalendar.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/TitleCalendar/TitleCalendar.stories.tsx
@@ -1,0 +1,108 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+
+import TitleCalendar from './index';
+import Secondary from '../../primitives/Buttons/Secondary';
+
+const meta = {
+  title: 'Widgets/TitleCalendar',
+  component: TitleCalendar,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The page header for the Appointments and Tasks boards: serif page title with a muted count, ' +
+          'an optional one-line description, and a right-hand action cluster ending in the ' +
+          'calendar / board / list view switch. The switch is a `--band` track with a raised `--screen` ' +
+          'pill on the active segment; it sizes itself to two or three options.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    showAdd: { control: 'boolean' },
+    count: { control: 'number' },
+    activeView: { control: 'radio', options: ['calendar', 'board', 'list'] },
+  },
+  args: {
+    title: 'Appointments',
+    description: 'Schedule and manage appointments across day, week, and team views',
+    count: 24,
+    activeView: 'calendar',
+    showAdd: false,
+    setAddPopup: fn(),
+    setActiveView: fn(),
+  },
+} satisfies Meta<typeof TitleCalendar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Appointments, as the page ships it — no header CTA, three views. */
+export const Default: Story = {};
+
+/** With the `Add` CTA shown, which is what the header looks like on pages that keep it. */
+export const WithAddAction: Story = {
+  name: 'With Add action',
+  args: { showAdd: true, activeView: 'board' },
+};
+
+/**
+ * Two views only — the track narrows and each segment takes half, so a
+ * two-option switch does not leave a dead third of empty pill.
+ */
+export const TwoViews: Story = {
+  name: 'Two views',
+  args: {
+    title: 'Tasks',
+    description: 'Track to-dos, assign the team or pet parents, follow through',
+    viewOptions: ['board', 'list'],
+    activeView: 'list',
+    count: 8,
+  },
+};
+
+/**
+ * No description, a long title and an extra control in the `actionBeforeAdd`
+ * slot (Tasks threads its week nav through here). This is the crowded case: the
+ * cluster wraps under the title rather than squeezing the switch.
+ */
+export const CrowdedHeader: Story = {
+  name: 'Crowded header',
+  args: {
+    title: 'Appointments and follow-up visits',
+    description: undefined,
+    count: 132,
+    showAdd: true,
+    actionBeforeAdd: <Secondary href="#" text="This week" />,
+  },
+};
+
+const InteractiveTitleCalendar = () => {
+  const [activeView, setActiveView] = useState('calendar');
+  const [addOpen, setAddPopup] = useState(false);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <TitleCalendar
+        title="Appointments"
+        description="Schedule and manage appointments across day, week, and team views"
+        count={24}
+        activeView={activeView}
+        setActiveView={setActiveView}
+        showAdd
+        setAddPopup={setAddPopup}
+      />
+      <p className="text-[13px] text-[var(--ink-muted)]">
+        {`View: ${activeView}${addOpen ? ' — add sheet requested' : ''}`}
+      </p>
+    </div>
+  );
+};
+
+/** Live switch, so the raised active pill can be seen moving between segments. */
+export const Interactive: Story = {
+  render: () => <InteractiveTitleCalendar />,
+};

--- a/apps/frontend/src/app/ui/widgets/Toast/ErrorToast.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/Toast/ErrorToast.stories.tsx
@@ -1,0 +1,94 @@
+import type { ComponentProps } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import 'react-toastify/dist/ReactToastify.css';
+import ErrorToast from './ErrorToast';
+
+type ErrorToastProps = ComponentProps<typeof ErrorToast>;
+
+/**
+ * `toastProps` is react-toastify's own runtime bag (position, transition,
+ * progress state). `ErrorToast` never reads it, so the stories hand over an
+ * empty object typed off the component's own props rather than reconstructing
+ * a container the story does not mount.
+ */
+const TOAST_PROPS = {} as ErrorToastProps['toastProps'];
+
+const meta = {
+  title: 'Widgets/Toast/ErrorToast',
+  component: ErrorToast,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Body of the error toast `toast.error()` renders through react-toastify: a red alert ' +
+          'glyph, a `--text-primary` title and a `--text-tertiary` detail line, with the shared ' +
+          'round close chip on the right. The warm-glass surface around it comes from the ' +
+          '`.Toastify__toast` override in `globals.css`; the decorator reproduces that container ' +
+          'so the stories show the toast at its real 320px width rather than free-floating.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    isPaused: false,
+    toastProps: TOAST_PROPS,
+    closeToast: fn(),
+    data: {
+      title: 'Could not save appointment',
+      text: 'The slot was taken while you were editing.',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="Toastify">
+        <div className="Toastify__toast">
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ErrorToast>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const TitleOnly: Story = {
+  name: 'Title only',
+  args: {
+    data: { title: 'Upload failed', text: '' },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Callers that have nothing to add pass an empty `text`. The second line collapses to ' +
+          'zero height, so the toast shrinks to the 64px minimum rather than leaving a gap.',
+      },
+    },
+  },
+};
+
+export const LongMessage: Story = {
+  name: 'Long message (wraps)',
+  args: {
+    data: {
+      title: 'Prescription could not be sent to the dispensary',
+      text: 'The dispensary rejected the request because the product is out of stock and no substitute has been configured for this organisation.',
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The overflow case, and the one worth watching: neither the 34px alert glyph nor the ' +
+          'close chip is `shrink-0`, so as the message grows the flex row takes the space back ' +
+          'out of the icon rather than wrapping around it. Compare the glyph here with the one ' +
+          'in `Default`.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/widgets/Toast/Info.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/Toast/Info.stories.tsx
@@ -1,0 +1,95 @@
+import type { ComponentProps } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import 'react-toastify/dist/ReactToastify.css';
+import Info from './Info';
+
+type InfoProps = ComponentProps<typeof Info>;
+
+/**
+ * `toastProps` is react-toastify's own runtime bag (position, transition,
+ * progress state). `Info` never reads it, so the stories hand over an empty
+ * object typed off the component's own props rather than reconstructing a
+ * container the story does not mount.
+ */
+const TOAST_PROPS = {} as InfoProps['toastProps'];
+
+const meta = {
+  title: 'Widgets/Toast/Info',
+  component: Info,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Body of the informational toast, rendered by `useNotify().notify("info", ...)` through ' +
+          "react-toastify's `toast.info`. Same two-line anatomy as the success and error toasts — a " +
+          '`--text-primary` title over a `--text-tertiary` detail line, with the shared round close ' +
+          'chip on the right — but led by a blue circled "i" for messages that report state rather ' +
+          'than an outcome. The warm-glass surface around it comes from the `.Toastify__toast` ' +
+          'override in `globals.css`, which the decorator reproduces so the stories show the toast at ' +
+          'its real width.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    isPaused: false,
+    toastProps: TOAST_PROPS,
+    closeToast: fn(),
+    data: {
+      title: 'Reminder scheduled',
+      text: 'The pet parent gets a nudge 24 hours before the visit.',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="Toastify">
+        <div className="Toastify__toast">
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof Info>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const TitleOnly: Story = {
+  name: 'Title only',
+  args: {
+    data: { title: 'Sync in progress', text: '' },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Callers with nothing to add pass an empty `text`. The second line collapses to zero height ' +
+          'and the row re-centres on the title rather than leaving a gap under it.',
+      },
+    },
+  },
+};
+
+export const LongMessage: Story = {
+  name: 'Long message (wraps)',
+  args: {
+    data: {
+      title: 'IDEXX results are still being processed by the lab',
+      text: 'Nothing is lost — the order stays open and the panel appears on the visit as soon as the analyser reports back, usually within the hour.',
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The overflow case, and the one worth watching: neither the 34px info glyph nor the close ' +
+          'chip is `shrink-0`, so as the message grows the flex row takes the space back out of the ' +
+          'icon rather than wrapping around it. Compare the glyph here with the one in `Default`.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/widgets/Toast/Success.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/Toast/Success.stories.tsx
@@ -1,0 +1,93 @@
+import type { ComponentProps } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import 'react-toastify/dist/ReactToastify.css';
+import Success from './Success';
+
+type SuccessProps = ComponentProps<typeof Success>;
+
+/**
+ * `toastProps` is react-toastify's own runtime bag (position, transition,
+ * progress state). `Success` never reads it, so the stories hand over an empty
+ * object typed off the component's own props rather than reconstructing a
+ * container the story does not mount.
+ */
+const TOAST_PROPS = {} as SuccessProps['toastProps'];
+
+const meta = {
+  title: 'Widgets/Toast/Success',
+  component: Success,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Body of the success toast `toast.success()` renders through react-toastify: a green ' +
+          'checkmark glyph, a `--text-primary` title and a `--text-tertiary` detail line, with the ' +
+          'shared round close chip on the right. The warm-glass surface around it comes from the ' +
+          '`.Toastify__toast` override in `globals.css`; the decorator reproduces that container so ' +
+          'the stories show the toast at its real width rather than free-floating.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    isPaused: false,
+    toastProps: TOAST_PROPS,
+    closeToast: fn(),
+    data: {
+      title: 'Appointment confirmed',
+      text: 'Kiko is booked with Dr. Carter for Tuesday at 10:30.',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="Toastify">
+        <div className="Toastify__toast">
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof Success>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const TitleOnly: Story = {
+  name: 'Title only',
+  args: {
+    data: { title: 'Changes saved', text: '' },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Callers with nothing to add pass an empty `text`. The second line collapses to zero ' +
+          'height and the row re-centres on the title rather than leaving a gap under it.',
+      },
+    },
+  },
+};
+
+export const LongMessage: Story = {
+  name: 'Long message (wraps)',
+  args: {
+    data: {
+      title: 'Vaccination record uploaded to the companion profile',
+      text: 'The rabies certificate was attached to Kiko and shared with the pet parent, who will see it in the app the next time they open the passport.',
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The overflow case, and the one worth watching: neither the 34px check glyph nor the close ' +
+          'chip is `shrink-0`, so as the message grows the flex row takes the space back out of the ' +
+          'icon rather than wrapping around it. Compare the glyph here with the one in `Default`.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/widgets/Toast/Warning.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/Toast/Warning.stories.tsx
@@ -1,0 +1,94 @@
+import type { ComponentProps } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import 'react-toastify/dist/ReactToastify.css';
+import Warning from './Warning';
+
+type WarningProps = ComponentProps<typeof Warning>;
+
+/**
+ * `toastProps` is react-toastify's own runtime bag (position, transition,
+ * progress state). `Warning` never reads it, so the stories hand over an empty
+ * object typed off the component's own props rather than reconstructing a
+ * container the story does not mount.
+ */
+const TOAST_PROPS = {} as WarningProps['toastProps'];
+
+const meta = {
+  title: 'Widgets/Toast/Warning',
+  component: Warning,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Body of the warning toast `toast.warn()` renders through react-toastify: an amber alert ' +
+          'triangle, a `--text-primary` title and a `--text-tertiary` detail line, with the shared ' +
+          'round close chip on the right. It is the "this went through, but read this" tier between ' +
+          '`Success` and `ErrorToast`. The warm-glass surface around it comes from the ' +
+          '`.Toastify__toast` override in `globals.css`; the decorator reproduces that container so ' +
+          'the stories show the toast at its real width rather than free-floating.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    isPaused: false,
+    toastProps: TOAST_PROPS,
+    closeToast: fn(),
+    data: {
+      title: 'Low stock',
+      text: 'Only 3 doses of Bravecto 500mg are left in the dispensary.',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="Toastify">
+        <div className="Toastify__toast">
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof Warning>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const TitleOnly: Story = {
+  name: 'Title only',
+  args: {
+    data: { title: 'Session expiring soon', text: '' },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Callers with nothing to add pass an empty `text`. The second line collapses to zero ' +
+          'height and the row re-centres on the title rather than leaving a gap under it.',
+      },
+    },
+  },
+};
+
+export const LongMessage: Story = {
+  name: 'Long message (wraps)',
+  args: {
+    data: {
+      title: 'Some appointments could not be moved to the new room',
+      text: 'Four of the eleven visits scheduled in Consult 2 overlap with a block already booked in the destination room, so they were left where they were.',
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The overflow case, and the one worth watching: neither the 34px triangle nor the close ' +
+          'chip is `shrink-0`, so as the message grows the flex row takes the space back out of the ' +
+          'icon rather than wrapping around it. Compare the glyph here with the one in `Default`.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/widgets/Upgrade/Upgrade.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/Upgrade/Upgrade.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { screen, userEvent, within } from 'storybook/test';
+
+import Upgrade from './index';
+
+const openBillingCycleModal = async (canvasElement: HTMLElement) => {
+  const canvas = within(canvasElement);
+  await userEvent.click(canvas.getByRole('button', { name: 'Upgrade' }));
+  // The modal portals to document.body, so it is queried off `screen`.
+  await screen.findByText('Select billing cycle');
+};
+
+const meta = {
+  title: 'Widgets/Upgrade',
+  component: Upgrade,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'The Business-plan upgrade entry point: a single `Primary` CTA that opens a centered modal ' +
+          'where the billing cycle is chosen. The selected cycle is a filled `--blue` pill, the other ' +
+          'an outlined one, and the price block swaps between the monthly and yearly per-seat price. ' +
+          'Confirming asks the API for a Stripe checkout link and redirects — that call only happens ' +
+          'on click, so the stories below never leave the page.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Upgrade>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Upgrade CTA',
+};
+
+export const MonthlySelected: Story = {
+  name: 'Billing cycle — monthly',
+  play: async ({ canvasElement }) => {
+    await openBillingCycleModal(canvasElement);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The modal as it opens: monthly is preselected and the price block shows the monthly rate.',
+      },
+    },
+  },
+};
+
+export const YearlySelected: Story = {
+  name: 'Billing cycle — yearly',
+  play: async ({ canvasElement }) => {
+    await openBillingCycleModal(canvasElement);
+    await userEvent.click(screen.getByRole('button', { name: 'Pay yearly' }));
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Switching to yearly moves the filled pill and drops the per-seat price to the discounted rate.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/widgets/UploadImage/DocUploader.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/UploadImage/DocUploader.stories.tsx
@@ -5,10 +5,7 @@ import { fn } from 'storybook/test';
 import DocUploader from './DocUploader';
 
 /** Built inside a render so no `File` is constructed while the CSF module is analysed. */
-const makePdf = (name: string) =>
-  new File([new Blob(['fixture'], { type: 'application/pdf' })], name, {
-    type: 'application/pdf',
-  });
+const makePdf = (name: string) => new File(['fixture'], name, { type: 'application/pdf' });
 
 /**
  * `file`/`setFile` are owned by the caller, so the stories hold them locally.

--- a/apps/frontend/src/app/ui/widgets/UploadImage/DocUploader.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/UploadImage/DocUploader.stories.tsx
@@ -1,0 +1,130 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React, { useState } from 'react';
+import { fn } from 'storybook/test';
+
+import DocUploader from './DocUploader';
+
+/** Built inside a render so no `File` is constructed while the CSF module is analysed. */
+const makePdf = (name: string) =>
+  new File([new Blob(['fixture'], { type: 'application/pdf' })], name, {
+    type: 'application/pdf',
+  });
+
+/**
+ * `file`/`setFile` are owned by the caller, so the stories hold them locally.
+ * Nothing reaches the network until a file is actually picked — `apiUrl` is only
+ * read inside the signed-URL request that a selection triggers.
+ */
+const ControlledDocUploader = ({
+  initialFile = null,
+  placeholder,
+  apiUrl,
+  onChange,
+}: {
+  initialFile?: File | null;
+  placeholder: string;
+  apiUrl: string;
+  onChange: (url: string, mimeType?: string, size?: number) => void;
+}) => {
+  const [file, setFile] = useState<File | null>(initialFile);
+  return (
+    <div style={{ maxWidth: 340, display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <DocUploader
+        placeholder={placeholder}
+        apiUrl={apiUrl}
+        onChange={onChange}
+        file={file}
+        setFile={setFile}
+      />
+    </div>
+  );
+};
+
+const meta = {
+  title: 'Widgets/UploadImage/DocUploader',
+  component: DocUploader,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The PDF-only upload well used for signed documents and records. It is a single button, so ' +
+          'click, keyboard and drag-and-drop all reach the same picker, and it rejects anything that ' +
+          'is not a PDF or is over 20 MB before any request is made. A picked file is exchanged for a ' +
+          'signed S3 URL from `apiUrl`, uploaded directly, and reported back through `onChange` as an ' +
+          'S3 key; the chip below the well shows what is currently attached.',
+      },
+    },
+  },
+  args: {
+    placeholder: 'Upload signed consent form',
+    apiUrl: '/v1/storage/signed-url',
+    onChange: fn(),
+    file: null,
+    setFile: fn(),
+  },
+} satisfies Meta<typeof DocUploader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Empty: Story = {
+  render: (args) => (
+    <ControlledDocUploader
+      placeholder={args.placeholder}
+      apiUrl={args.apiUrl}
+      onChange={args.onChange}
+    />
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting state. The constraints are stated up front rather than surfaced as an error ' +
+          'after the user has already picked the wrong file.',
+      },
+    },
+  },
+};
+
+export const WithFile: Story = {
+  name: 'Document attached',
+  render: (args) => (
+    <ControlledDocUploader
+      initialFile={makePdf('vaccination-consent.pdf')}
+      placeholder={args.placeholder}
+      apiUrl={args.apiUrl}
+      onChange={args.onChange}
+    />
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The attached document renders as a chip under the well, with its own remove button. The ' +
+          'well stays open so a replacement can be dropped straight onto it.',
+      },
+    },
+  },
+};
+
+export const LongFileName: Story = {
+  name: 'Long file name',
+  render: (args) => (
+    <ControlledDocUploader
+      initialFile={makePdf('2026-08-15-post-operative-discharge-summary-and-medication-plan.pdf')}
+      placeholder={args.placeholder}
+      apiUrl={args.apiUrl}
+      onChange={args.onChange}
+    />
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'File names are clamped to 150px and truncated, so a long upload cannot stretch the chip ' +
+          'past the form column it sits in.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/widgets/UploadImage/LogoUploader.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/UploadImage/LogoUploader.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fireEvent, fn, within } from 'storybook/test';
+
+import LogoUploader from './LogoUploader';
+
+const meta = {
+  title: 'Widgets/UploadImage/LogoUploader',
+  component: LogoUploader,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The round logo well used in organisation and team onboarding: a camera chip that opens ' +
+          'the file picker, and the caption beside it that doubles as the live status region. Once ' +
+          'an image is accepted the chip is replaced in place by a 58px preview with a remove ' +
+          'button, so the picked logo is confirmed before the form is saved. Non-image and SVG ' +
+          'files are rejected in the browser, before any signed-URL request is made.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    title: 'Add your practice logo',
+    apiUrl: '/v1/storage/signed-url',
+    setImageUrl: fn(),
+  },
+} satisfies Meta<typeof LogoUploader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * The resting state: camera chip, "LOGO" caption and the prompt beside it. The
+ * preview only replaces the chip once a file has been accepted, so this is what
+ * an organisation without a logo always shows.
+ */
+export const Default: Story = {};
+
+/**
+ * The rejection path, and the reason it is worth a story: SVGs are refused
+ * because they can carry script, and the refusal happens locally — no upload is
+ * attempted. The message lands in a `role="alert"` under the caption while the
+ * chip stays in its empty state, so nothing looks half-attached.
+ */
+export const InvalidFileType: Story = {
+  name: 'SVG rejected',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('Upload logo image') as HTMLInputElement;
+    const svg = new File(['<svg xmlns="http://www.w3.org/2000/svg" />'], 'logo.svg', {
+      type: 'image/svg+xml',
+    });
+
+    // `fireEvent` rather than `userEvent.upload`: the input is `display: none`
+    // behind its label, so a synthetic click on it is not a reliable way to
+    // reach the change handler.
+    fireEvent.change(input, { target: { files: [svg] } });
+
+    const alert = await canvas.findByRole('alert');
+    await expect(alert).toHaveTextContent('Only non-SVG image files are supported.');
+  },
+};

--- a/apps/frontend/src/app/ui/widgets/UploadImage/PdfDocUploader.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/UploadImage/PdfDocUploader.stories.tsx
@@ -18,10 +18,7 @@ const stalledSigner: UploaderProps['getSignedUrl'] = () =>
   });
 
 /** Built inside a render so no `File` is constructed while the CSF module is analysed. */
-const makePdf = (name: string) =>
-  new File([new Blob(['fixture'], { type: 'application/pdf' })], name, {
-    type: 'application/pdf',
-  });
+const makePdf = (name: string) => new File(['fixture'], name, { type: 'application/pdf' });
 
 const meta = {
   title: 'Widgets/PdfDocUploader',

--- a/apps/frontend/src/app/ui/widgets/UploadImage/PdfDocUploader.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/UploadImage/PdfDocUploader.stories.tsx
@@ -1,0 +1,102 @@
+import type { ComponentProps } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+
+import PdfDocUploader from './PdfDocUploader';
+
+type UploaderProps = ComponentProps<typeof PdfDocUploader>;
+
+/**
+ * The signer is the component's only route to the network: it hands back the S3
+ * URL that the PUT then targets. Returning a promise that never settles lets a
+ * story pick a real file — the preview card appears — while guaranteeing no
+ * request leaves Storybook.
+ */
+const stalledSigner: UploaderProps['getSignedUrl'] = () =>
+  new Promise(() => {
+    // Deliberately never resolves; see the note above.
+  });
+
+/** Built inside a render so no `File` is constructed while the CSF module is analysed. */
+const makePdf = (name: string) =>
+  new File([new Blob(['fixture'], { type: 'application/pdf' })], name, {
+    type: 'application/pdf',
+  });
+
+const meta = {
+  title: 'Widgets/PdfDocUploader',
+  component: PdfDocUploader,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Single-file PDF upload well. Click or drop onto it, and the file goes straight to S3 ' +
+          'through a signed URL the caller supplies via `getSignedUrl` — which is why the same well ' +
+          'serves practice documents (`DocUploader`) and companion records (`CompanionDoc`) without ' +
+          'knowing either endpoint. Anything that is not a PDF, or is over 20 MB, is dropped ' +
+          'silently. The selected file is the caller’s state, so the preview card below the well ' +
+          'is driven by the `file` prop rather than by anything the component remembers.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    placeholder: 'Upload signed consent form',
+    file: null,
+    onChange: fn(),
+    setFile: fn(),
+    getSignedUrl: stalledSigner,
+  },
+} satisfies Meta<typeof PdfDocUploader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Empty: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting state. The whole well is one `<button>` labelled with the placeholder, so a ' +
+          'keyboard user reaches the file picker the same way a mouse user does, and the "Only PDF / ' +
+          'max size 20 MB" line states the limits before a rejected file can confuse anyone.',
+      },
+    },
+  },
+};
+
+export const FileSelected: Story = {
+  name: 'File selected',
+  render: (args) => <PdfDocUploader {...args} file={makePdf('rabies-certificate.pdf')} />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Once a file is picked the preview card joins the well: document glyph, file name, and a red ' +
+          'trash control in the corner that clears the selection through `setFile`. The well stays ' +
+          'visible, so replacing the file is one click rather than a remove-then-add.',
+      },
+    },
+  },
+};
+
+export const LongFileName: Story = {
+  name: 'Long file name',
+  render: (args) => (
+    <PdfDocUploader
+      {...args}
+      placeholder="Upload discharge paperwork"
+      file={makePdf('2026-08-15-post-operative-discharge-summary-and-medication-plan.pdf')}
+    />
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The overflow case: the name is capped at 150px and truncated with an ellipsis, so a long ' +
+          'file name cannot push the remove control off the card.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/widgets/UploadImage/UploadImage.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/UploadImage/UploadImage.stories.tsx
@@ -1,0 +1,105 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import { MEDIA_SOURCES } from '../../../constants/mediaSources';
+import UploadImage from './UploadImage';
+
+const DOCX_MIME = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+
+/** Built lazily inside a render so no `File` is constructed while the CSF module is analysed. */
+const makeFile = (name: string, type: string) =>
+  new File([new Blob(['fixture'], { type })], name, {
+    type,
+  });
+
+const meta = {
+  title: 'Widgets/UploadImage',
+  component: UploadImage,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Drag-and-drop upload well with a preview strip underneath. Accepts DOC, PDF, PNG and ' +
+          'JPEG up to 20 MB and silently drops anything else. Previews come from two sources: files ' +
+          'the user just picked (`value`) and files already stored server-side (`existingFiles`); ' +
+          'images render as thumbnails, documents as an icon plus filename, and each chip has its ' +
+          'own remove button.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    placeholder: 'Upload medical records',
+    onChange: fn(),
+  },
+} satisfies Meta<typeof UploadImage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Empty: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'The resting state: the whole well is one button, so keyboard users reach it too.',
+      },
+    },
+  },
+};
+
+export const WithSelectedFiles: Story = {
+  name: 'Documents selected',
+  render: (args) => (
+    <UploadImage
+      {...args}
+      value={[
+        makeFile('vaccination-record.pdf', 'application/pdf'),
+        makeFile('consent-form.docx', DOCX_MIME),
+      ]}
+    />
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Non-image files render as the icon chip. The PDF and Word icons are separate so a long ' +
+          'list stays scannable.',
+      },
+    },
+  },
+};
+
+export const WithExistingFiles: Story = {
+  name: 'Already-uploaded files',
+  args: {
+    placeholder: 'Upload companion photos',
+    existingFiles: [
+      { name: 'kiko-intake.png', type: 'image/png', url: MEDIA_SOURCES.avatars.dog },
+      { name: 'insurance-policy.pdf', type: 'application/pdf', url: 'https://example.com/policy' },
+    ],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Files that came back from the API. Image entries get a real thumbnail; removing one only ' +
+          'clears it locally, since the component has no delete callback for stored files yet.',
+      },
+    },
+  },
+};
+
+export const LongFileName: Story = {
+  name: 'Long file name',
+  render: (args) => (
+    <UploadImage
+      {...args}
+      value={[
+        makeFile(
+          '2026-08-15-post-operative-discharge-summary-and-medication-plan.pdf',
+          'application/pdf'
+        ),
+      ]}
+    />
+  ),
+};


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

Storybook covered 56 of the shared components. Most of `src/app/ui` had no rendered reference and no Chromatic snapshot, so the only way to see a component was to find a page that used it and get that page into the right state.

That gap is what let the design drift happen in the first place: PIMS grew five separate column-header recipes, and a single page was rendering three of them, because no two of them were ever visible side by side.

## What is the new behavior?

82 story files, taking the shared UI to full coverage - 469 stories across cards, filters, inputs, layout, overlays, primitives, widgets and the phone shell.

Each carries a component description saying what the thing is for and which state is worth watching, rather than a bare `Default`. Router-bound components declare `nextjs.appDirectory`; components that portal out of the story root, or that only exist below `lg`, say so.

**Every story was render-checked in a built Storybook at 1280 and 375 - not just compiled.** A green `storybook:build` only proves a story parses. Rendering them caught three real defects in the six written by hand:

| story | defect |
| --- | --- |
| `Header`, `Fallback` | threw `invariant expected app router to be mounted` - both reach `next/navigation` |
| `HamburgerMenuButton`, `MobileMenu` | `lg:hidden`, so on the default desktop canvas they sat in the DOM at zero pixels |

The sweep also had to be corrected twice before it was worth trusting, which is worth recording: it first matched Storybook's always-present *hidden* error pane and reported all 18 stories as broken, then measured only `#storybook-root` and reported every portal-rendered overlay (OtpModal, PdfPreviewOverlay, SigningOverlay, UniversalSearch, PhoneMoreSheet) as rendering nothing.

Final state: **466 of 469 stories render clean.** The three that render nothing are the three that should - a closed sheet, a closed drawer, and a route guard mid-check.

## Impact area

`apps/frontend` Storybook only. No application code changes - no component, style, or token is touched, so there is no runtime impact. Chromatic will show 469 new snapshots as additions, which need accepting once as the baseline.

## Validation performed

- `pnpm --filter frontend run type-check` - clean
- `pnpm --filter frontend run lint` on every new file - clean
- `pnpm --filter frontend run storybook:build` - succeeds
- Render sweep over all 469 stories at 1280 and 375, checking for thrown errors, console errors, and zero-pixel renders

## Related Issue(s)

Follows the design-consistency work in #2214, #2215 and #2216 - this is the part that stops it regressing.
