### PR TITLE
fix(frontend): PIMS defects found by an exhaustive click-through

### DIFF
--- a/apps/frontend/src/app/(routes)/(public)/payment-status/PaymentStatusContent.stories.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/payment-status/PaymentStatusContent.stories.tsx
@@ -6,16 +6,20 @@ type Outcome = 'paid' | 'unpaid' | 'no_payment_required';
 
 /**
  * The component fetches its own status, so each story stubs `fetch` for the
- * duration of its render. `unpaid` never resolves on purpose - that branch and
- * the loading branch share the pulsing dots, which is the surface this file
- * exists to guard.
+ * duration of its render. `pending` is the one that never settles, which is how
+ * the loading state is held open; `unpaid` resolves normally and reaches the
+ * same pulsing dots by a different route, so both are worth a story.
  */
 const withStubbedStatus = (outcome: Outcome | 'pending') => {
   const Decorator = (Story: React.ComponentType) => {
     const original = globalThis.fetch;
+    const neverSettles = new Promise<never>(() => {
+      // Deliberately empty: the loading state only exists while the request is
+      // in flight, so the story has to keep it in flight.
+    });
     globalThis.fetch = (() =>
       outcome === 'pending'
-        ? new Promise(() => undefined)
+        ? neverSettles
         : Promise.resolve({
             json: () => Promise.resolve({ status: outcome, total: 4250 }),
           })) as typeof globalThis.fetch;

--- a/apps/frontend/src/app/(routes)/(public)/payment-status/PaymentStatusContent.stories.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/payment-status/PaymentStatusContent.stories.tsx
@@ -1,39 +1,47 @@
-import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { PaymentStatusContent } from './PaymentStatusContent';
 
 type Outcome = 'paid' | 'unpaid' | 'no_payment_required';
 
 /**
- * The component fetches its own status, so each story stubs `fetch` for the
- * duration of its render. `pending` is the one that never settles, which is how
- * the loading state is held open; `unpaid` resolves normally and reaches the
- * same pulsing dots by a different route, so both are worth a story.
+ * The component fetches its own status, so each story stubs `fetch` around its
+ * render. `pending` is the one that never settles, which is how the loading
+ * state is held open; `unpaid` resolves normally and reaches the same pulsing
+ * dots by a different route, so both are worth a story.
+ *
+ * This is a `beforeEach` rather than a decorator. As a decorator the assignment
+ * happened during RENDER and the restore in an effect cleanup, so re-rendering
+ * a story - flipping the theme toolbar, which the docs above tell the reader to
+ * do - installed the new stub and then let the previous cleanup put the real
+ * `fetch` back underneath it. The mounted story would then poll the real
+ * backend. Autodocs makes it worse by mounting several variants against the one
+ * global. Storybook's lifecycle runs setup before the story mounts and the
+ * returned teardown after it unmounts, which is the ordering this needs.
  */
-const withStubbedStatus = (outcome: Outcome | 'pending') => {
-  const Decorator = (Story: React.ComponentType) => {
-    const original = globalThis.fetch;
-    const neverSettles = new Promise<never>(() => {
-      // Deliberately empty: the loading state only exists while the request is
-      // in flight, so the story has to keep it in flight.
-    });
-    globalThis.fetch = (() =>
-      outcome === 'pending'
-        ? neverSettles
-        : Promise.resolve({
-            json: () => Promise.resolve({ status: outcome, total: 4250 }),
-          })) as typeof globalThis.fetch;
+const stubStatus = (outcome: Outcome | 'pending') => () => {
+  const original = globalThis.fetch;
+  const neverSettles = new Promise<never>(() => {
+    // Deliberately empty: the loading state only exists while the request is in
+    // flight, so the story has to keep it in flight.
+  });
 
-    React.useEffect(
-      () => () => {
-        globalThis.fetch = original;
-      },
-      [original]
-    );
+  globalThis.fetch = ((input: RequestInfo | URL) => {
+    // Scoped to the status lookup. Anything else this page or Storybook itself
+    // requests still goes to the real implementation rather than hanging.
+    const url = typeof input === 'string' ? input : String((input as Request).url ?? input);
+    if (!url.includes('payment-status') && !url.includes('session')) {
+      return original(input as RequestInfo);
+    }
+    return outcome === 'pending'
+      ? neverSettles
+      : Promise.resolve({
+          json: () => Promise.resolve({ status: outcome, total: 4250 }),
+        });
+  }) as typeof globalThis.fetch;
 
-    return <Story />;
+  return () => {
+    globalThis.fetch = original;
   };
-  return Decorator;
 };
 
 const meta = {
@@ -67,20 +75,20 @@ type Story = StoryObj<typeof meta>;
 
 export const Loading: Story = {
   name: 'Loading (pulsing dots)',
-  decorators: [withStubbedStatus('pending')],
+  beforeEach: stubStatus('pending'),
 };
 
 export const Paid: Story = {
-  decorators: [withStubbedStatus('paid')],
+  beforeEach: stubStatus('paid'),
 };
 
 export const Unpaid: Story = {
-  decorators: [withStubbedStatus('unpaid')],
+  beforeEach: stubStatus('unpaid'),
 };
 
 export const NoPaymentRequired: Story = {
   name: 'No payment required',
-  decorators: [withStubbedStatus('no_payment_required')],
+  beforeEach: stubStatus('no_payment_required'),
 };
 
 export const MissingSession: Story = {

--- a/apps/frontend/src/app/(routes)/(public)/payment-status/PaymentStatusContent.stories.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/payment-status/PaymentStatusContent.stories.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { PaymentStatusContent } from './PaymentStatusContent';
+
+type Outcome = 'paid' | 'unpaid' | 'no_payment_required';
+
+/**
+ * The component fetches its own status, so each story stubs `fetch` for the
+ * duration of its render. `unpaid` never resolves on purpose - that branch and
+ * the loading branch share the pulsing dots, which is the surface this file
+ * exists to guard.
+ */
+const withStubbedStatus = (outcome: Outcome | 'pending') => {
+  const Decorator = (Story: React.ComponentType) => {
+    const original = globalThis.fetch;
+    globalThis.fetch = (() =>
+      outcome === 'pending'
+        ? new Promise(() => undefined)
+        : Promise.resolve({
+            json: () => Promise.resolve({ status: outcome, total: 4250 }),
+          })) as typeof globalThis.fetch;
+
+    React.useEffect(
+      () => () => {
+        globalThis.fetch = original;
+      },
+      [original]
+    );
+
+    return <Story />;
+  };
+  return Decorator;
+};
+
+const meta = {
+  title: 'Public/PaymentStatus',
+  component: PaymentStatusContent,
+  parameters: {
+    layout: 'fullscreen',
+    nextjs: {
+      appDirectory: true,
+      navigation: { pathname: '/payment-status', query: { session_id: 'cs_test_a1b2c3d4e5f6' } },
+    },
+    docs: {
+      description: {
+        component:
+          'Where Stripe drops the payer after checkout. The card is deliberately a **fixed** ' +
+          'light surface in both themes - it is a receipt, and a receipt that inverts under a ' +
+          'dark OS setting reads as a different document.\n\n' +
+          'That fixity is also the trap. The pulsing dots were painted with ' +
+          '`--color-neutral-900`, which follows the theme, so on the pinned white card they ' +
+          'resolved to a near-white and measured 1.34:1 in dark - the page looked like it had ' +
+          'simply stopped. They use `--ink-fixed` now, which stays #1d1c1b in both themes like ' +
+          'the surface under it. Flip the theme toolbar on the loading story to check.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof PaymentStatusContent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Loading: Story = {
+  name: 'Loading (pulsing dots)',
+  decorators: [withStubbedStatus('pending')],
+};
+
+export const Paid: Story = {
+  decorators: [withStubbedStatus('paid')],
+};
+
+export const Unpaid: Story = {
+  decorators: [withStubbedStatus('unpaid')],
+};
+
+export const NoPaymentRequired: Story = {
+  name: 'No payment required',
+  decorators: [withStubbedStatus('no_payment_required')],
+};
+
+export const MissingSession: Story = {
+  name: 'No session id in the URL',
+  parameters: {
+    nextjs: { appDirectory: true, navigation: { pathname: '/payment-status', query: {} } },
+  },
+};

--- a/apps/frontend/src/app/(routes)/(public)/payment-status/PaymentStatusContent.stories.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/payment-status/PaymentStatusContent.stories.tsx
@@ -4,36 +4,53 @@ import { PaymentStatusContent } from './PaymentStatusContent';
 type Outcome = 'paid' | 'unpaid' | 'no_payment_required';
 
 /**
- * The component fetches its own status, so each story stubs `fetch` around its
- * render. `pending` is the one that never settles, which is how the loading
- * state is held open; `unpaid` resolves normally and reaches the same pulsing
- * dots by a different route, so both are worth a story.
+ * Every story routes through ONE stub keyed by session id, rather than each
+ * installing a stub that answers with its own outcome.
  *
- * This is a `beforeEach` rather than a decorator. As a decorator the assignment
- * happened during RENDER and the restore in an effect cleanup, so re-rendering
- * a story - flipping the theme toolbar, which the docs above tell the reader to
- * do - installed the new stub and then let the previous cleanup put the real
- * `fetch` back underneath it. The mounted story would then poll the real
- * backend. Autodocs makes it worse by mounting several variants against the one
- * global. Storybook's lifecycle runs setup before the story mounts and the
- * returned teardown after it unmounts, which is the ordering this needs.
+ * There is a single `globalThis.fetch`, and Autodocs mounts all five variants
+ * against it at once. With per-story stubs, whichever mounted last won: the
+ * unpaid story re-polls after two seconds, by which point NoPaymentRequired had
+ * installed its stub, so a story titled "Unpaid" rendered "Payment cancelled".
+ * Teardowns chained the same way and could restore another story's stub instead
+ * of the real `fetch`. Keying on the session id makes every installed stub
+ * behave identically, so which one is live stops mattering.
+ *
+ * `pending` never settles, which is how the loading state is held open. `unpaid`
+ * resolves normally and reaches the same pulsing dots by a different route, so
+ * both are worth a story.
  */
-const stubStatus = (outcome: Outcome | 'pending') => () => {
+const SESSION = {
+  loading: 'cs_test_loading',
+  paid: 'cs_test_paid',
+  unpaid: 'cs_test_unpaid',
+  noPayment: 'cs_test_no_payment',
+} as const;
+
+const OUTCOME_BY_SESSION: Record<string, Outcome | 'pending'> = {
+  [SESSION.loading]: 'pending',
+  [SESSION.paid]: 'paid',
+  [SESSION.unpaid]: 'unpaid',
+  [SESSION.noPayment]: 'no_payment_required',
+};
+
+const NEVER_SETTLES = new Promise<never>(() => {
+  // Deliberately empty: the loading state only exists while the request is in
+  // flight, so the story has to keep it in flight.
+});
+
+const stubStatus = () => {
   const original = globalThis.fetch;
-  const neverSettles = new Promise<never>(() => {
-    // Deliberately empty: the loading state only exists while the request is in
-    // flight, so the story has to keep it in flight.
-  });
 
   globalThis.fetch = ((input: RequestInfo | URL) => {
-    // Scoped to the status lookup. Anything else this page or Storybook itself
-    // requests still goes to the real implementation rather than hanging.
     const url = typeof input === 'string' ? input : String((input as Request).url ?? input);
-    if (!url.includes('payment-status') && !url.includes('session')) {
-      return original(input as RequestInfo);
-    }
+    const session = Object.keys(OUTCOME_BY_SESSION).find((id) => url.includes(id));
+    // Anything that is not one of this file's sessions - another page's request,
+    // or Storybook's own - reaches the real implementation instead of hanging.
+    if (!session) return original(input as RequestInfo);
+
+    const outcome = OUTCOME_BY_SESSION[session];
     return outcome === 'pending'
-      ? neverSettles
+      ? NEVER_SETTLES
       : Promise.resolve({
           json: () => Promise.resolve({ status: outcome, total: 4250 }),
         });
@@ -44,15 +61,18 @@ const stubStatus = (outcome: Outcome | 'pending') => () => {
   };
 };
 
+const withSession = (sessionId: string) => ({
+  nextjs: {
+    appDirectory: true,
+    navigation: { pathname: '/payment-status', query: { session_id: sessionId } },
+  },
+});
+
 const meta = {
   title: 'Public/PaymentStatus',
   component: PaymentStatusContent,
   parameters: {
     layout: 'fullscreen',
-    nextjs: {
-      appDirectory: true,
-      navigation: { pathname: '/payment-status', query: { session_id: 'cs_test_a1b2c3d4e5f6' } },
-    },
     docs: {
       description: {
         component:
@@ -75,20 +95,24 @@ type Story = StoryObj<typeof meta>;
 
 export const Loading: Story = {
   name: 'Loading (pulsing dots)',
-  beforeEach: stubStatus('pending'),
+  parameters: withSession(SESSION.loading),
+  beforeEach: stubStatus,
 };
 
 export const Paid: Story = {
-  beforeEach: stubStatus('paid'),
+  parameters: withSession(SESSION.paid),
+  beforeEach: stubStatus,
 };
 
 export const Unpaid: Story = {
-  beforeEach: stubStatus('unpaid'),
+  parameters: withSession(SESSION.unpaid),
+  beforeEach: stubStatus,
 };
 
 export const NoPaymentRequired: Story = {
   name: 'No payment required',
-  beforeEach: stubStatus('no_payment_required'),
+  parameters: withSession(SESSION.noPayment),
+  beforeEach: stubStatus,
 };
 
 export const MissingSession: Story = {

--- a/apps/frontend/src/app/(routes)/(public)/payment-status/PaymentStatusContent.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/payment-status/PaymentStatusContent.tsx
@@ -204,9 +204,9 @@ export function PaymentStatusContent() {
             )}
             {(requestState === 'loading' || data?.status === 'unpaid') && (
               <div className="flex gap-2" aria-hidden>
-                <span className="size-3.5 rounded-full bg-slate-900 animate-[pulse-dot_1s_cubic-bezier(0.16,1,0.3,1)_infinite]" />
-                <span className="size-3.5 rounded-full bg-slate-900 animate-[pulse-dot_1s_cubic-bezier(0.16,1,0.3,1)_infinite_150ms]" />
-                <span className="size-3.5 rounded-full bg-slate-900 animate-[pulse-dot_1s_cubic-bezier(0.16,1,0.3,1)_infinite_300ms]" />
+                <span className="size-3.5 rounded-full bg-[var(--color-neutral-900)] animate-[pulse-dot_1s_cubic-bezier(0.16,1,0.3,1)_infinite]" />
+                <span className="size-3.5 rounded-full bg-[var(--color-neutral-900)] animate-[pulse-dot_1s_cubic-bezier(0.16,1,0.3,1)_infinite_150ms]" />
+                <span className="size-3.5 rounded-full bg-[var(--color-neutral-900)] animate-[pulse-dot_1s_cubic-bezier(0.16,1,0.3,1)_infinite_300ms]" />
               </div>
             )}
             {data?.status === 'no_payment_required' && (

--- a/apps/frontend/src/app/(routes)/(public)/payment-status/PaymentStatusContent.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/payment-status/PaymentStatusContent.tsx
@@ -167,7 +167,12 @@ export function PaymentStatusContent() {
       data-yc-surface="light"
       className="min-h-[max(720px,100vh)] flex items-center justify-center px-4 pt-22 pb-10 bg-[radial-gradient(circle_at_10%_10%,rgba(250,238,210,0.6),transparent_45%),radial-gradient(circle_at_90%_20%,rgba(210,235,248,0.6),transparent_45%),radial-gradient(circle_at_50%_90%,rgba(215,245,230,0.7),transparent_50%)]"
     >
-      <div className="w-full max-w-xl bg-white/80 border border-card-border rounded-2xl px-6 py-10">
+      {/* Opaque, not bg-white/80. The card pins its inks light because it is a
+          receipt, but at 80% the themed page beneath it bled through: in dark the
+          surface composited to #d2d2d1 instead of white, which dropped the
+          "Yosemite Crew" kicker to 3.94:1. A pinned surface has to be opaque or
+          the pin only half-holds. */}
+      <div className="w-full max-w-xl bg-white border border-card-border rounded-2xl px-6 py-10">
         <div className="flex flex-col items-center text-center gap-4">
           <div className="relative flex items-center justify-center size-24 rounded-full">
             {(requestState === 'missing_session' || requestState === 'error') && (
@@ -204,9 +209,9 @@ export function PaymentStatusContent() {
             )}
             {(requestState === 'loading' || data?.status === 'unpaid') && (
               <div className="flex gap-2" aria-hidden>
-                <span className="size-3.5 rounded-full bg-[var(--color-neutral-900)] animate-[pulse-dot_1s_cubic-bezier(0.16,1,0.3,1)_infinite]" />
-                <span className="size-3.5 rounded-full bg-[var(--color-neutral-900)] animate-[pulse-dot_1s_cubic-bezier(0.16,1,0.3,1)_infinite_150ms]" />
-                <span className="size-3.5 rounded-full bg-[var(--color-neutral-900)] animate-[pulse-dot_1s_cubic-bezier(0.16,1,0.3,1)_infinite_300ms]" />
+                <span className="size-3.5 rounded-full bg-[var(--ink-fixed)] animate-[pulse-dot_1s_cubic-bezier(0.16,1,0.3,1)_infinite]" />
+                <span className="size-3.5 rounded-full bg-[var(--ink-fixed)] animate-[pulse-dot_1s_cubic-bezier(0.16,1,0.3,1)_infinite_150ms]" />
+                <span className="size-3.5 rounded-full bg-[var(--ink-fixed)] animate-[pulse-dot_1s_cubic-bezier(0.16,1,0.3,1)_infinite_300ms]" />
               </div>
             )}
             {data?.status === 'no_payment_required' && (

--- a/apps/frontend/src/app/__tests__/components/AppointmentBoard.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/AppointmentBoard.test.tsx
@@ -744,7 +744,7 @@ describe('AppointmentBoard', () => {
     );
   });
 
-  it('mutes a completed card and keeps a live card at full strength', () => {
+  it('mutes a completed card by dropping its shadow, not by dimming it', () => {
     const { rerender } = render(
       <AppointmentBoard
         appointments={[{ ...baseAppointment, id: 'appt-done', status: 'COMPLETED' } as any]}
@@ -754,7 +754,12 @@ describe('AppointmentBoard', () => {
       />
     );
 
-    expect(screen.getByLabelText('Appointment Buddy').className).toContain('opacity-[0.72]');
+    // The muted state recedes by losing the lift shadow. It must NOT dim: the
+    // card's own text-text-tertiary meta line composited below AA at 0.72, on a
+    // card that is still clickable.
+    const doneCard = screen.getByLabelText('Appointment Buddy');
+    expect(doneCard.className).not.toMatch(/\bopacity-/);
+    expect(doneCard.className).toContain('shadow-none');
 
     rerender(
       <AppointmentBoard

--- a/apps/frontend/src/app/__tests__/components/Calendar/common/Header.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/common/Header.test.tsx
@@ -202,13 +202,14 @@ describe('Header Component', () => {
     // in both themes) so selected/unselected are unmistakable. The old translucent
     // danger-bg tint + `text-danger-500!` label failed WCAG AA in dark mode (#1885).
     const activePill = screen.getByRole('button', { name: 'Emergencies' });
-    // --danger-strong, not --color-danger-800. The 800 step is an INK step and
-    // was given a light dark-mode value (#f5a39d) so it could be read on dark
-    // surfaces; using it as the fill under white text dropped this pill to
-    // 1.98:1 in dark. --danger-strong is #a6271d in both themes.
+    // --danger-strong with its PAIRED ink, not --color-danger-800 under a literal
+    // white. The 800 step is an ink and was given a light dark-mode value, which
+    // as a fill put this pill at 1.98:1. --danger-strong inverts as a pair in
+    // dark so the fill also keeps a 3:1 boundary against the surface; pinning
+    // the label to white here would break that half again.
     expect(activePill.getAttribute('style')).toContain('background-color: var(--danger-strong)');
     expect(activePill.getAttribute('style')).toContain('border-color: var(--danger-strong)');
-    expect(activePill.getAttribute('style')).toContain('color: var(--color-white)');
+    expect(activePill.getAttribute('style')).toContain('color: var(--danger-strong-ink)');
     // The `!important` danger-500 label class must be gone so the inline white wins.
     expect(activePill).not.toHaveClass('text-danger-500!');
   });
@@ -305,7 +306,7 @@ describe('Header Component', () => {
     // danger-800), so it no longer carries the AA-failing `text-danger-500!` class.
     const activeEmergencyPill = screen.getByRole('button', { name: 'Emergencies' });
     expect(activeEmergencyPill).not.toHaveClass('text-danger-500!');
-    expect(activeEmergencyPill.getAttribute('style')).toContain('color: var(--color-white)');
+    expect(activeEmergencyPill.getAttribute('style')).toContain('color: var(--danger-strong-ink)');
   });
 
   it('ignores filter toggles when no setter is provided', () => {

--- a/apps/frontend/src/app/__tests__/components/Calendar/common/Header.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/common/Header.test.tsx
@@ -202,8 +202,12 @@ describe('Header Component', () => {
     // in both themes) so selected/unselected are unmistakable. The old translucent
     // danger-bg tint + `text-danger-500!` label failed WCAG AA in dark mode (#1885).
     const activePill = screen.getByRole('button', { name: 'Emergencies' });
-    expect(activePill.getAttribute('style')).toContain('background-color: var(--color-danger-800)');
-    expect(activePill.getAttribute('style')).toContain('border-color: var(--color-danger-800)');
+    // --danger-strong, not --color-danger-800. The 800 step is an INK step and
+    // was given a light dark-mode value (#f5a39d) so it could be read on dark
+    // surfaces; using it as the fill under white text dropped this pill to
+    // 1.98:1 in dark. --danger-strong is #a6271d in both themes.
+    expect(activePill.getAttribute('style')).toContain('background-color: var(--danger-strong)');
+    expect(activePill.getAttribute('style')).toContain('border-color: var(--danger-strong)');
     expect(activePill.getAttribute('style')).toContain('color: var(--color-white)');
     // The `!important` danger-500 label class must be gone so the inline white wins.
     expect(activePill).not.toHaveClass('text-danger-500!');

--- a/apps/frontend/src/app/__tests__/components/DataTable/CompanionsTable.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/DataTable/CompanionsTable.test.tsx
@@ -231,7 +231,7 @@ describe('CompanionsTable', () => {
     );
   });
 
-  it('fades inactive rows and defaults a missing status to inactive', () => {
+  it('marks inactive rows with the status pill, not a dim, and defaults a missing status to inactive', () => {
     const inactive = {
       ...companion,
       companion: { ...companion.companion, status: undefined },
@@ -239,7 +239,7 @@ describe('CompanionsTable', () => {
     const { container } = render(<CompanionsTable {...baseProps} filteredList={[inactive]} />);
 
     expect(screen.getByText('inactive')).toBeInTheDocument();
-    expect(container.innerHTML).toContain('opacity-[0.62]');
+    expect(container.innerHTML).not.toContain('opacity-');
   });
 
   it('renders the grid view when viewMode is grid and its empty state', () => {
@@ -447,7 +447,7 @@ describe('CompanionsTable', () => {
     expect(screen.getByText('Jan 6, 2025')).toBeInTheDocument();
   });
 
-  it('fades an inactive grid card and keys it by name when the id is missing', () => {
+  it('marks an inactive grid card with the status pill and keys it by name when the id is missing', () => {
     const inactiveNoId: any = {
       companion: {
         name: 'Nimbus',
@@ -466,7 +466,7 @@ describe('CompanionsTable', () => {
 
     // Missing status defaults to inactive and fades the card.
     expect(screen.getByText('inactive')).toBeInTheDocument();
-    expect(container.innerHTML).toContain('opacity-[0.62]');
+    expect(container.innerHTML).not.toContain('opacity-');
     expect(screen.getByText(/Nimbus/)).toBeInTheDocument();
   });
 
@@ -492,7 +492,7 @@ describe('CompanionsTable', () => {
     // the card fades, and the subline still renders (blank breed dropped).
     expect(screen.getByText('+ CO-PARENT')).toBeInTheDocument();
     expect(screen.getByText(/inactive/)).toBeInTheDocument();
-    expect(container.innerHTML).toContain('opacity-[0.62]');
+    expect(container.innerHTML).not.toContain('opacity-');
     expect(screen.getByText(/Willow/)).toBeInTheDocument();
   });
 

--- a/apps/frontend/src/app/__tests__/components/DynamicSelect.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/DynamicSelect.test.tsx
@@ -104,7 +104,7 @@ describe('DynamicSelect Component', () => {
 
     const errorText = screen.getByText(errorMessage);
     expect(errorText).toBeInTheDocument();
-    expect(errorText).toHaveClass('text-xs', 'text-red-600', 'mt-1');
+    expect(errorText).toHaveClass('text-xs', 'text-[var(--danger-text)]', 'mt-1');
   });
 
   it('should display a "No matches found" message when the search query matches nothing', async () => {

--- a/apps/frontend/src/app/__tests__/components/SessionInitializer.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/SessionInitializer.test.tsx
@@ -167,4 +167,83 @@ describe('SessionInitializer', () => {
 
     expect(setCompanionTerminologyForOrg).toHaveBeenCalledWith('org-1', 'PATIENT');
   });
+
+  describe('terminology rewriting', () => {
+    const terminology = jest.requireMock('@/app/lib/companionTerminology');
+    const identity = (text: string) => text;
+
+    beforeEach(() => {
+      // The suite-wide mock returns its input unchanged, which makes both
+      // behaviours below unobservable - a rewriter that never fires and one
+      // that fires correctly produce identical DOM. Substitute for real here so
+      // the walk and the title are actually exercised.
+      terminology.rewriteCompanionTerminologyText.mockImplementation((text: string) =>
+        text.replace(/Companion/g, 'Patient').replace(/companion/g, 'patient')
+      );
+      mockUseAuthStore.mockImplementation((selector: any) => selector({ status: 'authenticated' }));
+    });
+
+    afterEach(() => {
+      terminology.rewriteCompanionTerminologyText.mockImplementation(identity);
+      document.title = '';
+    });
+
+    it('rewrites the browser tab title, which lives outside the observed root', () => {
+      // Route metadata is static and server-rendered, so it cannot know the
+      // org's term; the observer is rooted at document.body and never reaches
+      // <head>. An org set to Patients had a tab reading Companions.
+      document.title = 'Companions | Yosemite Crew';
+
+      render(
+        <SessionInitializer>
+          <div data-testid="child" />
+        </SessionInitializer>
+      );
+
+      expect(document.title).toBe('Patients | Yosemite Crew');
+    });
+
+    it('rewrites attributes on DESCENDANTS of an added node, not just the node itself', async () => {
+      render(
+        <SessionInitializer>
+          <div data-testid="child" />
+        </SessionInitializer>
+      );
+
+      // Mimic a modal mounting: the added node is the wrapper, and the control
+      // carrying the term is nested inside it. Only the wrapper's own
+      // attributes used to be rewritten, so "Upload companion photo" stayed raw
+      // inside the Add patient modal.
+      const host = document.createElement('div');
+      host.innerHTML =
+        '<div><button aria-label="Upload companion photo" title="Companion photo">' +
+        '<span>Add companion</span></button></div>';
+      document.body.append(host);
+
+      const button = await screen.findByRole('button', { name: 'Upload patient photo' });
+      expect(button).toHaveAttribute('title', 'Patient photo');
+      expect(button.textContent).toBe('Add patient');
+
+      host.remove();
+    });
+
+    it('leaves a terminology-locked subtree alone', async () => {
+      render(
+        <SessionInitializer>
+          <div data-testid="child" />
+        </SessionInitializer>
+      );
+
+      const host = document.createElement('div');
+      host.innerHTML =
+        '<div data-terminology-lock="true">' +
+        '<button aria-label="Companion settings">Companion</button></div>';
+      document.body.append(host);
+
+      const locked = await screen.findByRole('button', { name: 'Companion settings' });
+      expect(locked.textContent).toBe('Companion');
+
+      host.remove();
+    });
+  });
 });

--- a/apps/frontend/src/app/__tests__/components/SessionInitializer.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/SessionInitializer.test.tsx
@@ -15,16 +15,58 @@ jest.mock('@/app/hooks/useProfiles', () => ({
 }));
 jest.mock('@/app/hooks/useAvailabiities', () => ({ useLoadAvailabilities: jest.fn() }));
 jest.mock('@/app/hooks/useFullscreenLoader', () => ({ useFullscreenLoader: jest.fn() }));
+const ORG_STATE = {
+  primaryOrgId: null,
+  orgsById: {
+    'org-1': { type: 'HOSPITAL' },
+  },
+};
+
 jest.mock('@/app/stores/orgStore', () => ({
-  useOrgStore: jest.fn((selector: any) =>
-    selector({
-      primaryOrgId: null,
-      orgsById: {
-        'org-1': { type: 'HOSPITAL' },
-      },
-    })
+  // `getState` as well as the selector form: the terminology rewriter reads the
+  // store imperatively (it runs outside React, from a MutationObserver), and a
+  // mock with only the hook form made it throw the moment the title rewrite
+  // started running on mount.
+  useOrgStore: Object.assign(
+    jest.fn((selector: any) => selector(ORG_STATE)),
+    { getState: () => ORG_STATE }
   ),
 }));
+
+// The org-scoped refresh effect fires thirteen loaders the moment primaryOrgId
+// is truthy, and one test sets it. Unmocked, those reach axios and leave real
+// XMLHttpRequests open after the run ("Jest did not exit"). Stub them all.
+jest.mock('@/app/features/organization/services/orgService', () => ({ loadOrgs: jest.fn() }));
+jest.mock('@/app/features/organization/services/profileService', () => ({
+  loadProfiles: jest.fn(),
+}));
+jest.mock('@/app/features/organization/services/availabilityService', () => ({
+  loadAvailability: jest.fn(),
+}));
+jest.mock('@/app/features/organization/services/teamService', () => ({ loadTeam: jest.fn() }));
+jest.mock('@/app/features/organization/services/specialityService', () => ({
+  loadSpecialitiesForOrg: jest.fn(),
+}));
+jest.mock('@/app/features/organization/services/roomService', () => ({
+  loadRoomsForOrgPrimaryOrg: jest.fn(),
+}));
+jest.mock('@/app/features/appointments/services/appointmentService', () => ({
+  loadAppointmentsForPrimaryOrg: jest.fn(),
+}));
+jest.mock('@/app/features/companions/services/companionService', () => ({
+  loadCompanionsForPrimaryOrg: jest.fn(),
+}));
+jest.mock('@/app/features/billing/services/invoiceService', () => ({
+  loadInvoicesForOrgPrimaryOrg: jest.fn(),
+}));
+jest.mock('@/app/features/tasks/services/taskService', () => ({
+  loadTasksForPrimaryOrg: jest.fn(),
+}));
+jest.mock('@/app/features/documents/services/documentService', () => ({
+  loadDocumentsForOrgPrimaryOrg: jest.fn(),
+}));
+jest.mock('@/app/features/forms/services/formService', () => ({ loadForms: jest.fn() }));
+jest.mock('@/app/hooks/useIntegrations', () => ({ loadIntegrationsForPrimaryOrg: jest.fn() }));
 
 jest.mock('@/app/lib/companionTerminology', () => ({
   getCompanionTerminologyForOrg: jest.fn(() => 'COMPANION'),

--- a/apps/frontend/src/app/__tests__/components/Sidebar.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Sidebar.test.tsx
@@ -196,11 +196,29 @@ describe('Sidebar', () => {
     const finance = screen.getByRole('link', { name: 'Finance' });
     expect(finance).toHaveClass('route-disabled');
 
+    // Disabled to assistive tech too, not only to the eye. Without these it is
+    // a greyed link that a screen reader still announces as a destination and a
+    // keyboard user can still tab to - an unverified org's Patients entry read
+    // as reachable when nothing behind it is.
+    expect(finance).toHaveAttribute('aria-disabled', 'true');
+    expect(finance).toHaveAttribute('tabindex', '-1');
+
     fireEvent.click(finance);
 
     expect(mockStartRouteLoader).not.toHaveBeenCalled();
     expect(mockStopRouteLoader).not.toHaveBeenCalled();
     expect(mockRouter.push).not.toHaveBeenCalled();
+  });
+
+  it('leaves enabled routes focusable and unmarked', () => {
+    setup({ pathname: '/dashboard', collapsed: false });
+
+    render(<Sidebar />);
+    const dashboard = screen.getByRole('link', { name: 'Dashboard' });
+
+    expect(dashboard).not.toHaveClass('route-disabled');
+    expect(dashboard).not.toHaveAttribute('aria-disabled');
+    expect(dashboard).not.toHaveAttribute('tabindex');
   });
 
   it('toggles the sidebar collapsed state and persists the preference', () => {

--- a/apps/frontend/src/app/__tests__/components/TurnoverAnalytics/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/TurnoverAnalytics/index.test.tsx
@@ -137,7 +137,7 @@ describe('TurnoverAnalytics', () => {
     const delta = screen.getByText(/\+1\.5 vs 2025/);
     expect(delta).toBeInTheDocument();
     // A RISE is good news and reads as success.
-    expect(delta.closest('span')).toHaveClass('text-[var(--success)]');
+    expect(delta.closest('span')).toHaveClass('text-[var(--success-text)]');
   });
 
   it('renders the month chart bars', () => {
@@ -233,7 +233,7 @@ describe('TurnoverAnalytics', () => {
     // the colour said "good" while the number said the opposite. Asserting the
     // value alone passes either way - the class is the thing under test.
     expect(delta.closest('span')).toHaveClass('text-[var(--danger-text)]');
-    expect(delta.closest('span')).not.toHaveClass('text-[var(--success)]');
+    expect(delta.closest('span')).not.toHaveClass('text-[var(--success-text)]');
   });
 
   it('selects the low-stock representative when the Class A row is clicked', () => {

--- a/apps/frontend/src/app/__tests__/components/chat/ConversationRow.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/chat/ConversationRow.test.tsx
@@ -47,10 +47,10 @@ describe('ConversationRow', () => {
     expect(screen.getByLabelText('Muted')).toBeInTheDocument();
   });
 
-  it('dims the row when muted (and not active)', () => {
+  it('does not dim a muted row - the bell-with-slash icon is the signal', () => {
     render(<ConversationRow {...base} muted onUnmute={jest.fn()} />);
     const row = screen.getByRole('button', { name: /Bella Rose/ }).parentElement;
-    expect(row).toHaveClass('opacity-[0.62]');
+    expect(row!.className).not.toMatch(/\bopacity-/);
   });
 
   it('does not dim a muted row that is also active', () => {

--- a/apps/frontend/src/app/__tests__/components/tasks/TaskFilterBar.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/tasks/TaskFilterBar.test.tsx
@@ -108,6 +108,24 @@ describe('TaskFilterBar', () => {
     expect(screen.getByRole('button', { name: 'All' })).toHaveAttribute('aria-pressed', 'false');
   });
 
+  it('gives the selected status pill a visible ring, not just aria-pressed', () => {
+    // The selected state used to be the ABSENCE of an opacity-65 dim on the
+    // other pills, which composited their labels below AA. aria-pressed alone
+    // is invisible to a sighted user, so the ring is the actual affordance and
+    // has to be asserted - otherwise deleting it leaves this file green.
+    renderBar({ activeStatus: 'in_progress' });
+
+    const active = screen.getByRole('button', { name: 'In progress' });
+    expect(active.className).toContain('ring-2');
+    expect(active.className).toContain('ring-[var(--blue-strong)]');
+    expect(active.className).toContain('ring-offset-[var(--screen)]');
+
+    const inactive = screen.getByRole('button', { name: 'Completed' });
+    expect(inactive.className).not.toContain('ring-2 ring-[var(--blue-strong)]');
+    // ...and no pill is dimmed to make the selection legible.
+    expect(inactive.className).not.toMatch(/opacity-/);
+  });
+
   it('shows the add button only when permitted', () => {
     const { unmount } = renderBar();
     fireEvent.click(screen.getByRole('button', { name: 'New task' }));

--- a/apps/frontend/src/app/__tests__/features/appointments/components/Calendar/responsive/PhoneMonthOverview.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/appointments/components/Calendar/responsive/PhoneMonthOverview.test.tsx
@@ -143,9 +143,26 @@ describe('PhoneMonthOverview — dot map', () => {
   it('separates padding and quiet days by ink, not by fading them', () => {
     renderOverview({ appointments: appointmentsOn(1, 2) });
 
-    expect(dayButton('2026-06-29', 0).className).not.toContain('opacity-');
-    expect(dayButton('2026-07-05', 0).className).not.toContain('opacity-');
-    expect(dayButton('2026-07-01', 2).className).not.toContain('opacity-');
+    const padding = dayButton('2026-06-29', 0);
+    const quiet = dayButton('2026-07-05', 0);
+    const busy = dayButton('2026-07-01', 2);
+
+    // No alpha anywhere - that is what made the padding days unreadable.
+    for (const cell of [padding, quiet, busy]) {
+      expect(cell.className).not.toContain('opacity-');
+    }
+
+    // And the three really are distinguishable. Asserting only the absence of
+    // opacity let padding and quiet days collapse onto the same ink while this
+    // test still passed, which is exactly what happened.
+    const ink = (cell: HTMLElement) =>
+      cell.querySelector('span')?.className.match(/text-\[var\(--[a-z-]+\)\]/)?.[0];
+
+    expect(ink(padding)).toBe('text-[var(--ink-faint)]');
+    expect(ink(quiet)).toBe('text-[var(--ink-muted)]');
+    expect(ink(padding)).not.toBe(ink(quiet));
+    // `busy` is deliberately not compared: it is a PAST day here, so it takes
+    // the past branch and legitimately shares --ink-muted with a quiet day.
   });
 
   it('renders dots rather than event chips, capped at three', () => {

--- a/apps/frontend/src/app/__tests__/features/appointments/components/Calendar/responsive/PhoneMonthOverview.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/appointments/components/Calendar/responsive/PhoneMonthOverview.test.tsx
@@ -140,11 +140,11 @@ describe('PhoneMonthOverview — dot map', () => {
     expect(screen.getAllByRole('button')).toHaveLength(40);
   });
 
-  it('fades padding days and quiet days by different amounts', () => {
+  it('separates padding and quiet days by ink, not by fading them', () => {
     renderOverview({ appointments: appointmentsOn(1, 2) });
 
-    expect(dayButton('2026-06-29', 0).className).toContain('opacity-[0.35]');
-    expect(dayButton('2026-07-05', 0).className).toContain('opacity-[0.45]');
+    expect(dayButton('2026-06-29', 0).className).not.toContain('opacity-');
+    expect(dayButton('2026-07-05', 0).className).not.toContain('opacity-');
     expect(dayButton('2026-07-01', 2).className).not.toContain('opacity-');
   });
 

--- a/apps/frontend/src/app/__tests__/features/appointments/components/Calendar/responsive/__snapshots__/PhoneMonthOverview.test.tsx.snap
+++ b/apps/frontend/src/app/__tests__/features/appointments/components/Calendar/responsive/__snapshots__/PhoneMonthOverview.test.tsx.snap
@@ -165,7 +165,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
         type="button"
       >
         <span
-          class="text-[12.5px] font-semibold text-[var(--ink-faint)]"
+          class="text-[12.5px] font-semibold text-[var(--ink-muted)]"
         >
           1
         </span>
@@ -181,7 +181,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
         type="button"
       >
         <span
-          class="text-[12.5px] font-semibold text-[var(--ink-faint)]"
+          class="text-[12.5px] font-semibold text-[var(--ink-muted)]"
         >
           2
         </span>
@@ -197,7 +197,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
         type="button"
       >
         <span
-          class="text-[12.5px] font-semibold text-[var(--ink-faint)]"
+          class="text-[12.5px] font-semibold text-[var(--ink-muted)]"
         >
           3
         </span>
@@ -213,7 +213,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
         type="button"
       >
         <span
-          class="text-[12.5px] font-semibold text-[var(--ink-faint)]"
+          class="text-[12.5px] font-semibold text-[var(--ink-muted)]"
         >
           4
         </span>
@@ -229,7 +229,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
         type="button"
       >
         <span
-          class="text-[12.5px] font-semibold text-[var(--ink-faint)]"
+          class="text-[12.5px] font-semibold text-[var(--ink-muted)]"
         >
           5
         </span>
@@ -245,7 +245,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
         type="button"
       >
         <span
-          class="text-[12.5px] font-semibold text-[var(--ink-faint)]"
+          class="text-[12.5px] font-semibold text-[var(--ink-muted)]"
         >
           6
         </span>
@@ -283,7 +283,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
         type="button"
       >
         <span
-          class="text-[12.5px] font-semibold text-[var(--ink-faint)]"
+          class="text-[12.5px] font-semibold text-[var(--ink-muted)]"
         >
           8
         </span>
@@ -299,7 +299,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
         type="button"
       >
         <span
-          class="text-[12.5px] font-semibold text-[var(--ink-faint)]"
+          class="text-[12.5px] font-semibold text-[var(--ink-muted)]"
         >
           9
         </span>
@@ -315,7 +315,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
         type="button"
       >
         <span
-          class="text-[12.5px] font-semibold text-[var(--ink-faint)]"
+          class="text-[12.5px] font-semibold text-[var(--ink-muted)]"
         >
           10
         </span>
@@ -331,7 +331,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
         type="button"
       >
         <span
-          class="text-[12.5px] font-semibold text-[var(--ink-faint)]"
+          class="text-[12.5px] font-semibold text-[var(--ink-muted)]"
         >
           11
         </span>
@@ -347,7 +347,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
         type="button"
       >
         <span
-          class="text-[12.5px] font-semibold text-[var(--ink-faint)]"
+          class="text-[12.5px] font-semibold text-[var(--ink-muted)]"
         >
           12
         </span>
@@ -363,7 +363,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
         type="button"
       >
         <span
-          class="text-[12.5px] font-semibold text-[var(--ink-faint)]"
+          class="text-[12.5px] font-semibold text-[var(--ink-muted)]"
         >
           13
         </span>
@@ -379,7 +379,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
         type="button"
       >
         <span
-          class="text-[12.5px] font-semibold text-[var(--ink-faint)]"
+          class="text-[12.5px] font-semibold text-[var(--ink-muted)]"
         >
           14
         </span>
@@ -395,7 +395,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
         type="button"
       >
         <span
-          class="text-[12.5px] font-semibold text-[var(--ink-faint)]"
+          class="text-[12.5px] font-semibold text-[var(--ink-muted)]"
         >
           15
         </span>
@@ -411,7 +411,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
         type="button"
       >
         <span
-          class="text-[12.5px] font-semibold text-[var(--ink-faint)]"
+          class="text-[12.5px] font-semibold text-[var(--ink-muted)]"
         >
           16
         </span>
@@ -427,7 +427,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
         type="button"
       >
         <span
-          class="text-[12.5px] font-semibold text-[var(--ink-faint)]"
+          class="text-[12.5px] font-semibold text-[var(--ink-muted)]"
         >
           17
         </span>
@@ -443,7 +443,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
         type="button"
       >
         <span
-          class="text-[12.5px] font-semibold text-[var(--ink-faint)]"
+          class="text-[12.5px] font-semibold text-[var(--ink-muted)]"
         >
           18
         </span>
@@ -459,7 +459,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
         type="button"
       >
         <span
-          class="text-[12.5px] font-semibold text-[var(--ink-faint)]"
+          class="text-[12.5px] font-semibold text-[var(--ink-muted)]"
         >
           19
         </span>
@@ -475,7 +475,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
         type="button"
       >
         <span
-          class="text-[12.5px] font-semibold text-[var(--ink-faint)]"
+          class="text-[12.5px] font-semibold text-[var(--ink-muted)]"
         >
           20
         </span>
@@ -491,7 +491,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
         type="button"
       >
         <span
-          class="text-[12.5px] font-semibold text-[var(--ink-faint)]"
+          class="text-[12.5px] font-semibold text-[var(--ink-muted)]"
         >
           21
         </span>
@@ -507,7 +507,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
         type="button"
       >
         <span
-          class="text-[12.5px] font-semibold text-[var(--ink-faint)]"
+          class="text-[12.5px] font-semibold text-[var(--ink-muted)]"
         >
           22
         </span>
@@ -523,7 +523,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
         type="button"
       >
         <span
-          class="text-[12.5px] font-semibold text-[var(--ink-faint)]"
+          class="text-[12.5px] font-semibold text-[var(--ink-muted)]"
         >
           23
         </span>
@@ -539,7 +539,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
         type="button"
       >
         <span
-          class="text-[12.5px] font-semibold text-[var(--ink-faint)]"
+          class="text-[12.5px] font-semibold text-[var(--ink-muted)]"
         >
           24
         </span>
@@ -555,7 +555,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
         type="button"
       >
         <span
-          class="text-[12.5px] font-semibold text-[var(--ink-faint)]"
+          class="text-[12.5px] font-semibold text-[var(--ink-muted)]"
         >
           25
         </span>
@@ -571,7 +571,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
         type="button"
       >
         <span
-          class="text-[12.5px] font-semibold text-[var(--ink-faint)]"
+          class="text-[12.5px] font-semibold text-[var(--ink-muted)]"
         >
           26
         </span>
@@ -587,7 +587,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
         type="button"
       >
         <span
-          class="text-[12.5px] font-semibold text-[var(--ink-faint)]"
+          class="text-[12.5px] font-semibold text-[var(--ink-muted)]"
         >
           27
         </span>
@@ -603,7 +603,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
         type="button"
       >
         <span
-          class="text-[12.5px] font-semibold text-[var(--ink-faint)]"
+          class="text-[12.5px] font-semibold text-[var(--ink-muted)]"
         >
           28
         </span>
@@ -619,7 +619,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
         type="button"
       >
         <span
-          class="text-[12.5px] font-semibold text-[var(--ink-faint)]"
+          class="text-[12.5px] font-semibold text-[var(--ink-muted)]"
         >
           29
         </span>
@@ -635,7 +635,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
         type="button"
       >
         <span
-          class="text-[12.5px] font-semibold text-[var(--ink-faint)]"
+          class="text-[12.5px] font-semibold text-[var(--ink-muted)]"
         >
           30
         </span>
@@ -651,7 +651,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
         type="button"
       >
         <span
-          class="text-[12.5px] font-semibold text-[var(--ink-faint)]"
+          class="text-[12.5px] font-semibold text-[var(--ink-muted)]"
         >
           31
         </span>

--- a/apps/frontend/src/app/__tests__/features/appointments/components/Calendar/responsive/__snapshots__/PhoneMonthOverview.test.tsx.snap
+++ b/apps/frontend/src/app/__tests__/features/appointments/components/Calendar/responsive/__snapshots__/PhoneMonthOverview.test.tsx.snap
@@ -129,7 +129,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
       <button
         aria-label="2026-06-29 · 0 appointments"
         aria-pressed="false"
-        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5 opacity-[0.35]"
+        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5"
         type="button"
       >
         <span
@@ -145,7 +145,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
       <button
         aria-label="2026-06-30 · 0 appointments"
         aria-pressed="false"
-        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5 opacity-[0.35]"
+        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5"
         type="button"
       >
         <span
@@ -161,7 +161,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
       <button
         aria-label="2026-07-01 · 0 appointments"
         aria-pressed="false"
-        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5 opacity-[0.45]"
+        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5"
         type="button"
       >
         <span
@@ -177,7 +177,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
       <button
         aria-label="2026-07-02 · 0 appointments"
         aria-pressed="false"
-        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5 opacity-[0.45]"
+        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5"
         type="button"
       >
         <span
@@ -193,7 +193,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
       <button
         aria-label="2026-07-03 · 0 appointments"
         aria-pressed="false"
-        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5 opacity-[0.45]"
+        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5"
         type="button"
       >
         <span
@@ -209,7 +209,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
       <button
         aria-label="2026-07-04 · 0 appointments"
         aria-pressed="false"
-        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5 opacity-[0.45]"
+        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5"
         type="button"
       >
         <span
@@ -225,7 +225,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
       <button
         aria-label="2026-07-05 · 0 appointments"
         aria-pressed="false"
-        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5 opacity-[0.45]"
+        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5"
         type="button"
       >
         <span
@@ -241,7 +241,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
       <button
         aria-label="2026-07-06 · 0 appointments"
         aria-pressed="false"
-        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5 opacity-[0.45]"
+        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5"
         type="button"
       >
         <span
@@ -279,7 +279,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
       <button
         aria-label="2026-07-08 · 0 appointments"
         aria-pressed="false"
-        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5 opacity-[0.45]"
+        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5"
         type="button"
       >
         <span
@@ -295,7 +295,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
       <button
         aria-label="2026-07-09 · 0 appointments"
         aria-pressed="false"
-        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5 opacity-[0.45]"
+        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5"
         type="button"
       >
         <span
@@ -311,7 +311,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
       <button
         aria-label="2026-07-10 · 0 appointments"
         aria-pressed="false"
-        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5 opacity-[0.45]"
+        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5"
         type="button"
       >
         <span
@@ -327,7 +327,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
       <button
         aria-label="2026-07-11 · 0 appointments"
         aria-pressed="false"
-        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5 opacity-[0.45]"
+        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5"
         type="button"
       >
         <span
@@ -343,7 +343,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
       <button
         aria-label="2026-07-12 · 0 appointments"
         aria-pressed="false"
-        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5 opacity-[0.45]"
+        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5"
         type="button"
       >
         <span
@@ -359,7 +359,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
       <button
         aria-label="2026-07-13 · 0 appointments"
         aria-pressed="false"
-        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5 opacity-[0.45]"
+        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5"
         type="button"
       >
         <span
@@ -375,7 +375,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
       <button
         aria-label="2026-07-14 · 0 appointments"
         aria-pressed="false"
-        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5 opacity-[0.45]"
+        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5"
         type="button"
       >
         <span
@@ -391,7 +391,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
       <button
         aria-label="2026-07-15 · 0 appointments"
         aria-pressed="false"
-        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5 opacity-[0.45]"
+        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5"
         type="button"
       >
         <span
@@ -407,7 +407,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
       <button
         aria-label="2026-07-16 · 0 appointments"
         aria-pressed="false"
-        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5 opacity-[0.45]"
+        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5"
         type="button"
       >
         <span
@@ -423,7 +423,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
       <button
         aria-label="2026-07-17 · 0 appointments"
         aria-pressed="false"
-        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5 opacity-[0.45]"
+        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5"
         type="button"
       >
         <span
@@ -439,7 +439,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
       <button
         aria-label="2026-07-18 · 0 appointments"
         aria-pressed="false"
-        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5 opacity-[0.45]"
+        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5"
         type="button"
       >
         <span
@@ -455,7 +455,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
       <button
         aria-label="2026-07-19 · 0 appointments"
         aria-pressed="false"
-        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5 opacity-[0.45]"
+        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5"
         type="button"
       >
         <span
@@ -471,7 +471,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
       <button
         aria-label="2026-07-20 · 0 appointments"
         aria-pressed="false"
-        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5 opacity-[0.45]"
+        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5"
         type="button"
       >
         <span
@@ -487,7 +487,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
       <button
         aria-label="2026-07-21 · 0 appointments"
         aria-pressed="false"
-        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5 opacity-[0.45]"
+        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5"
         type="button"
       >
         <span
@@ -503,7 +503,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
       <button
         aria-label="2026-07-22 · 0 appointments"
         aria-pressed="false"
-        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5 opacity-[0.45]"
+        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5"
         type="button"
       >
         <span
@@ -519,7 +519,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
       <button
         aria-label="2026-07-23 · 0 appointments"
         aria-pressed="false"
-        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5 opacity-[0.45]"
+        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5"
         type="button"
       >
         <span
@@ -535,7 +535,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
       <button
         aria-label="2026-07-24 · 0 appointments"
         aria-pressed="false"
-        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5 opacity-[0.45]"
+        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5"
         type="button"
       >
         <span
@@ -551,7 +551,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
       <button
         aria-label="2026-07-25 · 0 appointments"
         aria-pressed="false"
-        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5 opacity-[0.45]"
+        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5"
         type="button"
       >
         <span
@@ -567,7 +567,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
       <button
         aria-label="2026-07-26 · 0 appointments"
         aria-pressed="false"
-        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5 opacity-[0.45]"
+        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5"
         type="button"
       >
         <span
@@ -583,7 +583,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
       <button
         aria-label="2026-07-27 · 0 appointments"
         aria-pressed="false"
-        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5 opacity-[0.45]"
+        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5"
         type="button"
       >
         <span
@@ -599,7 +599,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
       <button
         aria-label="2026-07-28 · 0 appointments"
         aria-pressed="false"
-        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5 opacity-[0.45]"
+        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5"
         type="button"
       >
         <span
@@ -615,7 +615,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
       <button
         aria-label="2026-07-29 · 0 appointments"
         aria-pressed="false"
-        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5 opacity-[0.45]"
+        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5"
         type="button"
       >
         <span
@@ -631,7 +631,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
       <button
         aria-label="2026-07-30 · 0 appointments"
         aria-pressed="false"
-        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5 opacity-[0.45]"
+        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5"
         type="button"
       >
         <span
@@ -647,7 +647,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
       <button
         aria-label="2026-07-31 · 0 appointments"
         aria-pressed="false"
-        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5 opacity-[0.45]"
+        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5"
         type="button"
       >
         <span
@@ -663,7 +663,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
       <button
         aria-label="2026-08-01 · 0 appointments"
         aria-pressed="false"
-        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5 opacity-[0.35]"
+        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5"
         type="button"
       >
         <span
@@ -679,7 +679,7 @@ exports[`PhoneMonthOverview — misc matches the month overview layout 1`] = `
       <button
         aria-label="2026-08-02 · 0 appointments"
         aria-pressed="false"
-        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5 opacity-[0.35]"
+        class="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5"
         type="button"
       >
         <span

--- a/apps/frontend/src/app/__tests__/pages/Integrations/IdexxWorkspace.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Integrations/IdexxWorkspace.test.tsx
@@ -1107,7 +1107,9 @@ describe('IdexxWorkspace pure helpers', () => {
     expect(getMeterMeta({ result: '15', referenceRange: '10 - 20' } as any).canRender).toBe(true);
     expect(
       getMeterMeta({ result: '25', referenceRange: '10 - 20', outOfRange: true } as any).markerClass
-    ).toContain('red');
+      // The marker is on the design system's --danger now rather than Tailwind's
+      // stock red, which never followed the theme.
+    ).toContain('--danger');
   });
 
   it('getOrderUiUrl and getOrderPdfUrl resolve direct, nested and null orders', () => {

--- a/apps/frontend/src/app/__tests__/ui/tokens/appScopeAliasClosure.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/tokens/appScopeAliasClosure.test.ts
@@ -258,6 +258,10 @@ describe('faint-ink alias closure is mirrored into the app scope', () => {
       const heavyOnly = !FAINT_TEXT.test(source);
       const lines = source.split('\n');
       lines.forEach((line, i) => {
+        // Comments describe these utilities as often as they use them - this
+        // very guard is documented in a comment mentioning opacity-65.
+        const trimmed = line.trimStart();
+        if (trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')) return;
         // `cursor-not-allowed` marks the disabled branch of a clsx ternary,
         // where the element also carries a real `disabled` attribute a few
         // lines up - an inactive control, exempt under WCAG 1.4.3.

--- a/apps/frontend/src/app/__tests__/ui/tokens/appScopeAliasClosure.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/tokens/appScopeAliasClosure.test.ts
@@ -315,8 +315,13 @@ describe('faint-ink alias closure is mirrored into the app scope', () => {
         // where --ink-faint labels still land at 3.23:1 on --screen. There is no
         // safe cutoff: the faint inks pass by so little that any compositing at
         // all can drop them under 4.5.
-        const m = /^\s*opacity:\s*(0?\.\d+|0)\s*;/.exec(line);
+        // Decimal AND percentage: `opacity: 60%` is the same thing written the
+        // other way, and it was the spelling on the rule that dimmed every span
+        // in every table cell across PIMS.
+        const m = /^\s*opacity:\s*(0?\.\d+|0|\d{1,3}%)\s*;/.exec(line);
         if (!m) return;
+        const pct = m[1].endsWith('%') ? Number(m[1].slice(0, -1)) : Number(m[1]) * 100;
+        if (pct >= 100 || pct === 0) return;
 
         // Walk back to the selector this declaration belongs to.
         let selector = '';

--- a/apps/frontend/src/app/__tests__/ui/tokens/appScopeAliasClosure.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/tokens/appScopeAliasClosure.test.ts
@@ -232,6 +232,17 @@ describe('faint-ink alias closure is mirrored into the app scope', () => {
         'aria-hidden spinner geometry',
       'features/forms/pages/Forms/Sections/AddForm/components/BuildWrapper.tsx::50':
         'drag-handle icon glyph, no text',
+      // Verified individually in the state-dim audit.
+      'ui/primitives/Buttons/BaseButton.tsx::60': 'the disabled branch of the shared button',
+      'features/companions/components/AddCompanionCentralModal/AddCompanionViewMode.tsx::40':
+        'pointer-events-none while a save is in flight - transient',
+      'features/companions/pages/Companions/InClinicTodayBand.tsx::14':
+        'decorative 72px background glyph behind the band',
+      'features/appointments/components/Calendar/common/MenuActionsList.tsx::55': 'menu separator',
+      'features/appointments/components/Calendar/common/RoomSubmenu.tsx::60':
+        'disabled room option',
+      'features/appointments/pages/AppointmentWorkspace/steps/SummaryStep.tsx::60':
+        'disabled action while the summary saves',
     };
 
     for (const file of tsx) {
@@ -241,7 +252,10 @@ describe('faint-ink alias closure is mirrored into the app scope', () => {
       // its meta line used text-text-tertiary three hundred lines away, so the
       // guard passed over 3.16:1 text. If a component paints faint text
       // anywhere, every dim inside it is suspect until named otherwise.
-      if (!FAINT_TEXT.test(source)) continue;
+      // A dim at or below 65% sinks even --ink (15:1 -> under 4.5), so heavy
+      // dims are checked everywhere; lighter ones only where the component
+      // paints faint text, which is where they actually bite.
+      const heavyOnly = !FAINT_TEXT.test(source);
       const lines = source.split('\n');
       lines.forEach((line, i) => {
         // `cursor-not-allowed` marks the disabled branch of a clsx ternary,
@@ -251,11 +265,24 @@ describe('faint-ink alias closure is mirrored into the app scope', () => {
         // Transient interaction feedback while the pointer moves an element,
         // like a keyframe step rather than a state anyone reads.
         if (/isDragging|is-dragging|dragging/i.test(line)) return;
-        for (const m of line.matchAll(/(^|[\s"'`:])opacity-(\d{1,3})\b/g)) {
+        // Two forms: the scale (opacity-70) and the arbitrary value
+        // (opacity-[0.55], opacity-[.66]). Missing the second let a whole
+        // family through - including a card whose 0.55 nested inside a
+        // disabled link's 0.6 and composited --ink itself down to 1.90:1.
+        const utilities = [
+          ...line.matchAll(/(^|[\s"'`:])opacity-(\d{1,3})\b/g),
+          ...line.matchAll(/(^|[\s"'`:])opacity-\[(0?\.\d+)\]/g),
+        ];
+        for (const m of utilities) {
           if (m[1].endsWith(':')) continue; // hover: / disabled: / group-hover:
-          if (Number(m[2]) >= 100 || Number(m[2]) === 0) continue; // 0 = hidden
-          if (`${file}::${m[2]}` in CLEARED) continue;
-          offenders.push(`${file}:${i + 1}  faint text + opacity-${m[2]}`);
+          const pct =
+            m[2].startsWith('.') || m[2].startsWith('0.')
+              ? Math.round(Number(m[2]) * 100)
+              : Number(m[2]);
+          if (pct >= 100 || pct === 0) continue; // 0 = hidden, nothing to read
+          if (heavyOnly && pct > 65) continue;
+          if (`${file}::${pct}` in CLEARED) continue;
+          offenders.push(`${file}:${i + 1}  opacity ${pct}%`);
         }
       });
     }

--- a/apps/frontend/src/app/__tests__/ui/tokens/appScopeAliasClosure.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/tokens/appScopeAliasClosure.test.ts
@@ -239,8 +239,6 @@ describe('faint-ink alias closure is mirrored into the app scope', () => {
       'features/companions/pages/Companions/InClinicTodayBand.tsx::14':
         'decorative 72px background glyph behind the band',
       'features/appointments/components/Calendar/common/MenuActionsList.tsx::55': 'menu separator',
-      'features/appointments/components/Calendar/common/RoomSubmenu.tsx::60':
-        'disabled room option',
       'features/appointments/pages/AppointmentWorkspace/steps/SummaryStep.tsx::60':
         'disabled action while the summary saves',
       // Inline-style form, each read individually.
@@ -373,6 +371,35 @@ describe('faint-ink alias closure is mirrored into the app scope', () => {
           const trimmed = line.trimStart();
           if (trimmed.startsWith('//') || trimmed.startsWith('*')) return;
           const m = STOCK.exec(line);
+          if (m) offenders.push(`${file}:${i + 1}  ${m[0]}`);
+        });
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('never pairs a themed fill with a literal white ink', () => {
+    // `bg-text-primary text-white` looks safe because the fill is a dark ink -
+    // in LIGHT. text-primary follows the theme and text-white does not, so in
+    // dark the pill turns bone and the label stays white: the Rooms add/remove
+    // buttons and both modal story triggers measured 1.34:1. A fill and the ink
+    // on it have to move together, so a themed fill takes a themed ink.
+    // Stories are included: they are the surface this repo audits against.
+    const THEMED_FILL_LITERAL_INK =
+      /\bbg-(?:text-primary|ink|screen|text-secondary)\b[^"'`]*?\btext-(?:white|black)\b|\btext-(?:white|black)\b[^"'`]*?\bbg-(?:text-primary|ink|screen|text-secondary)\b/;
+
+    const root = path.join(process.cwd(), 'src/app');
+    const offenders: string[] = [];
+    for (const file of fs
+      .readdirSync(root, { recursive: true, encoding: 'utf8' })
+      .filter((f) => /\.tsx$/.test(f))
+      .filter((f) => !f.includes('__tests__'))) {
+      fs.readFileSync(path.join(root, file), 'utf8')
+        .split('\n')
+        .forEach((line, i) => {
+          const trimmed = line.trimStart();
+          if (trimmed.startsWith('//') || trimmed.startsWith('*')) return;
+          const m = THEMED_FILL_LITERAL_INK.exec(line);
           if (m) offenders.push(`${file}:${i + 1}  ${m[0]}`);
         });
     }

--- a/apps/frontend/src/app/__tests__/ui/tokens/appScopeAliasClosure.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/tokens/appScopeAliasClosure.test.ts
@@ -243,6 +243,20 @@ describe('faint-ink alias closure is mirrored into the app scope', () => {
         'disabled room option',
       'features/appointments/pages/AppointmentWorkspace/steps/SummaryStep.tsx::60':
         'disabled action while the summary saves',
+      // Inline-style form, each read individually.
+      'ui/layout/PageSkeleton.tsx::80': 'skeleton row, no text',
+      'ui/layout/PageSkeleton.tsx::60': 'skeleton row, no text',
+      'features/integrations/pages/IdexxWorkspace/index.tsx::75': 'SKELETON_ROWS, no text',
+      'features/integrations/pages/IdexxWorkspace/index.tsx::50': 'SKELETON_ROWS, no text',
+      'features/integrations/pages/IdexxWorkspace/index.tsx::28': 'SKELETON_ROWS, no text',
+      'features/appointments/components/Calendar/common/WeekCalendar.tsx::75':
+        'the now-line border, decoration with no text',
+      'features/organization/pages/Specialities/PackageBreakdownTable.tsx::50':
+        'dark glass tooltip',
+      'features/organization/pages/Specialities/PackageBreakdownTable.tsx::70':
+        'dark glass tooltip',
+      'features/organization/pages/Specialities/PackageBreakdownTable.tsx::80':
+        'dark glass tooltip',
     };
 
     for (const file of tsx) {
@@ -276,6 +290,9 @@ describe('faint-ink alias closure is mirrored into the app scope', () => {
         const utilities = [
           ...line.matchAll(/(^|[\s"'`:])opacity-(\d{1,3})\b/g),
           ...line.matchAll(/(^|[\s"'`:])opacity-\[(0?\.\d+)\]/g),
+          // Inline style objects: style={{ opacity: 0.8 }}. A third spelling,
+          // and the one behind the calendar's "Due:" line at 3.98:1.
+          ...line.matchAll(/()opacity:\s*(0?\.\d+)/g),
         ];
         for (const m of utilities) {
           if (m[1].endsWith(':')) continue; // hover: / disabled: / group-hover:

--- a/apps/frontend/src/app/__tests__/ui/tokens/appScopeAliasClosure.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/tokens/appScopeAliasClosure.test.ts
@@ -326,6 +326,22 @@ describe('faint-ink alias closure is mirrored into the app scope', () => {
     expect(offenders).toEqual([]);
   });
 
+  it('never puts a theme transition on every element', () => {
+    // `[data-yc-app] *` and `[data-yc-theme] *` each transitioned four properties
+    // on EVERY element. A theme flip started ~700 simultaneous transitions, and
+    // some never advanced - observed in the browser with playState "running" and
+    // currentTime stuck at 0, which strands the element in the OUTGOING theme.
+    // The Patients heading ended up at 1.06:1 that way.
+    //
+    // `color` is the property that must never be transitioned wholesale: its
+    // failure mode is unreadable text, not a missed fade.
+    const universal = [...CSS.matchAll(/^(html\[data-theme-ready\][^{]*\*)\s*\{([^}]*)\}/gm)]
+      .filter(([, , body]) => /transition/.test(body))
+      .map(([, selector]) => selector.trim());
+
+    expect(universal).toEqual([]);
+  });
+
   it('has nothing painting text with a raw neutral ramp step', () => {
     // `text-neutral-500` in the chat panes is what exposed the whole bug, and
     // the first version of this guard only looked for that one shape - Tailwind

--- a/apps/frontend/src/app/__tests__/ui/tokens/appScopeAliasClosure.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/tokens/appScopeAliasClosure.test.ts
@@ -352,6 +352,34 @@ describe('faint-ink alias closure is mirrored into the app scope', () => {
     expect(offenders).toEqual([]);
   });
 
+  it("uses the design system palette, not Tailwind's stock one", () => {
+    // Tailwind ships its own red/green/slate/amber scales. They are fixed
+    // colours that know nothing about the warm-bone themes, so a `text-red-600`
+    // is a semantic-looking class that never changes between light and dark -
+    // and it sidesteps every contrast decision the token set has made.
+    // Fifteen had crept in, including the DynamicSelect and uploader error text.
+    const STOCK =
+      /\b(?:text|bg|border)-(?:red|green|blue|yellow|orange|purple|pink|gray|slate|zinc|stone|amber|emerald|teal|cyan|indigo|violet|rose)-(?:50|[1-9]00)\b/;
+
+    const root = path.join(process.cwd(), 'src/app');
+    const offenders: string[] = [];
+    for (const file of fs
+      .readdirSync(root, { recursive: true, encoding: 'utf8' })
+      .filter((f) => /\.(tsx|css)$/.test(f))
+      .filter((f) => !f.includes('__tests__') && !f.includes('.stories.'))) {
+      fs.readFileSync(path.join(root, file), 'utf8')
+        .split('\n')
+        .forEach((line, i) => {
+          const trimmed = line.trimStart();
+          if (trimmed.startsWith('//') || trimmed.startsWith('*')) return;
+          const m = STOCK.exec(line);
+          if (m) offenders.push(`${file}:${i + 1}  ${m[0]}`);
+        });
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
   it('never puts a theme transition on every element', () => {
     // `[data-yc-app] *` and `[data-yc-theme] *` each transitioned four properties
     // on EVERY element. A theme flip started ~700 simultaneous transitions, and

--- a/apps/frontend/src/app/features/appointments/components/AppointmentBoardCard.tsx
+++ b/apps/frontend/src/app/features/appointments/components/AppointmentBoardCard.tsx
@@ -422,7 +422,7 @@ const AppointmentBoardCard = ({
       className={clsx(
         'relative w-full shrink-0 overflow-hidden rounded-[13px]! bg-neutral-0 px-[14px] py-[12px] text-left transition-colors flex flex-col items-stretch justify-start gap-2 border',
         emphasisClass,
-        isMuted ? 'opacity-[0.72] shadow-none' : emphasisShadowClass,
+        isMuted ? 'shadow-none' : emphasisShadowClass,
         isDragging
           ? 'opacity-60 shadow-none'
           : 'hover:border-input-border-active! hover:bg-card-hover!',

--- a/apps/frontend/src/app/features/appointments/components/AppointmentBoardCard.tsx
+++ b/apps/frontend/src/app/features/appointments/components/AppointmentBoardCard.tsx
@@ -467,7 +467,7 @@ const AppointmentBoardCard = ({
               openAppointmentWorkspace(appointment);
             }}
             className="ml-auto rounded-full px-2.5 py-1 text-[10.5px] font-bold text-white"
-            style={{ background: 'var(--blue)' }}
+            style={{ background: 'var(--blue-strong)' }}
           >
             Start visit
           </button>

--- a/apps/frontend/src/app/features/appointments/components/AppointmentBoardCard.tsx
+++ b/apps/frontend/src/app/features/appointments/components/AppointmentBoardCard.tsx
@@ -391,8 +391,10 @@ const AppointmentBoardCard = ({
   );
   const isDragging = draggedAppointmentId === (appointment.id ?? null);
   const isEmergency = !!appointment.isEmergency;
-  // Completed / cancelled / no-show cards recede — design drops them to 72% and
-  // removes the lift shadow so live work stays dominant in the column.
+  // Completed / cancelled / no-show cards recede by losing the lift shadow, so
+  // live work stays dominant in the column. The design's 72% opacity is
+  // deliberately not applied: it composited the card's own text-text-tertiary
+  // meta line below AA, and the flattened shadow already carries the state.
   const isMuted = isMutedBoardStatus(normalizeStatus(appointment.status));
   const isRequested = isRequestedLikeStatus(appointment.status);
   // Checked-in patients are the ones actually waiting in the clinic, so the design

--- a/apps/frontend/src/app/features/appointments/components/Calendar/PhoneTaskDayList.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/PhoneTaskDayList.tsx
@@ -118,8 +118,7 @@ const TaskCard = ({
       'flex min-h-14 items-center gap-2.5 rounded-xl border bg-[var(--screen)] px-[11px] py-2.5',
       entry.isOverdue
         ? 'border-[var(--danger-border)] border-l-[3px] border-l-[var(--danger)]'
-        : 'border-[var(--hairline)]',
-      entry.isDone && 'opacity-[.66]'
+        : 'border-[var(--hairline)]'
     )}
   >
     <TaskCheckbox entry={entry} disabled={!canEditTasks} onToggle={onToggleTask} />

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/TaskSlot.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/TaskSlot.tsx
@@ -259,7 +259,10 @@ const TaskMarker = ({
             </div>
             <div
               className={`text-[10px] truncate ${isCompact ? 'text-center' : ''}`}
-              style={{ color: markerStyle.color, opacity: 0.8 }}
+              // No alpha: markerStyle.color is a status token measured against
+              // its own fill, and 0.8 took this 10px line to 3.98:1. The line is
+              // already quieter than the task name by size alone.
+              style={{ color: markerStyle.color }}
             >
               Due: {dueTimeLabel}
             </div>

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/WeekCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/WeekCalendar.tsx
@@ -258,7 +258,9 @@ const WeekCalendar: React.FC<WeekCalendarProps> = ({
                               {nowTimeLabel && (
                                 <div
                                   className="absolute left-3 -translate-y-[115%] text-[10px] leading-none font-semibold whitespace-nowrap"
-                                  style={{ color: 'var(--color-danger-700)' }}
+                                  // --danger-text, not the 700 fill: at 10px on
+                                  // the calendar ground the fill read 4.00:1.
+                                  style={{ color: 'var(--danger-text)' }}
                                 >
                                   {nowTimeLabel}
                                 </div>

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/Header.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/Header.tsx
@@ -50,7 +50,7 @@ const getFilterClassName = (filterKey: string, activeFilter: string): string => 
   if (filterKey !== activeFilter)
     return 'font-semibold text-[var(--ink-muted)] hover:bg-card-hover!';
   // The active emergency pill draws its fill/label from getEmergencyPillStyle's
-  // inline style (AA-safe white on --danger-strong); return no colour class so
+  // inline style (--danger-strong with its paired ink); return no colour class so
   // an `!important` text colour can't override it (the old `text-danger-500!`
   // failed WCAG AA in dark mode).
   if (filterKey === 'emergencies') return 'font-bold';

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/Header.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/Header.tsx
@@ -50,7 +50,7 @@ const getFilterClassName = (filterKey: string, activeFilter: string): string => 
   if (filterKey !== activeFilter)
     return 'font-semibold text-[var(--ink-muted)] hover:bg-card-hover!';
   // The active emergency pill draws its fill/label from getEmergencyPillStyle's
-  // inline style (AA-safe white on --color-danger-800); return no colour class so
+  // inline style (AA-safe white on --danger-strong); return no colour class so
   // an `!important` text colour can't override it (the old `text-danger-500!`
   // failed WCAG AA in dark mode).
   if (filterKey === 'emergencies') return 'font-bold';

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/RoomSubmenu.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/RoomSubmenu.stories.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import RoomSubmenu from './RoomSubmenu';
+import { getRoomSavingKey, type RoomOption } from './appointmentContextMenuHelpers';
+
+const room = (key: string, label: string, selected = false): RoomOption => ({
+  key,
+  label,
+  selected,
+  onSelect: fn(),
+});
+
+const ROOMS: RoomOption[] = [
+  room('consult-1', 'Consult 1'),
+  room('consult-2', 'Consult 2', true),
+  room('theatre', 'Theatre'),
+  room('isolation', 'Isolation ward'),
+];
+
+const meta = {
+  title: 'Appointments/RoomSubmenu',
+  component: RoomSubmenu,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'The room picker that flies out of the appointment context menu. It renders on the ' +
+          '`yc-glass-overlay` surface, whose background is `var(--screen)` and therefore follows ' +
+          'the theme.\n\n' +
+          'Two contrast defects lived here and both are only visible with the theme switched, ' +
+          'which is why this story exists. The hovered and currently-assigned rows were filled ' +
+          'with **literal white** (`bg-white/50` and `bg-white/58`) while the label used ' +
+          '`text-text-primary`, a themed ink - in dark that put a light ink on a near-#a1a1a0 row ' +
+          'at roughly 2.1:1. They now use the themed hairline tints, so fill and ink move ' +
+          'together. Separately the "Current" badge was `opacity-60` on 8px text; the row is an ' +
+          'enabled button except while a save is in flight, so the dim was not a disabled state - ' +
+          'it is `--ink-muted` now.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    submenuRef: React.createRef<HTMLDivElement>(),
+    submenuStyle: { position: 'static', width: 240 },
+    roomOptions: ROOMS,
+    savingKey: null,
+  },
+} satisfies Meta<typeof RoomSubmenu>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'With a current room',
+};
+
+export const Saving: Story = {
+  args: { savingKey: getRoomSavingKey('theatre') },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'While a reassignment is in flight every row is disabled and the pending one carries a ' +
+          '"Saving" badge. This is the only state in which the rows are genuinely inactive.',
+      },
+    },
+  },
+};
+
+export const NoRooms: Story = {
+  name: 'No rooms configured',
+  args: { roomOptions: [] },
+};

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/RoomSubmenu.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/RoomSubmenu.tsx
@@ -45,7 +45,9 @@ const RoomSubmenu = ({ submenuRef, submenuStyle, roomOptions, savingKey }: RoomS
               >
                 <span className="truncate">{room.label}</span>
                 {roomStatusLabel ? (
-                  <span className="shrink-0 text-[8px] opacity-60">{roomStatusLabel}</span>
+                  <span className="shrink-0 text-[8px] text-[var(--ink-body)]">
+                    {roomStatusLabel}
+                  </span>
                 ) : null}
               </button>
             </React.Fragment>

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/appointmentContextMenuHelpers.ts
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/appointmentContextMenuHelpers.ts
@@ -30,8 +30,15 @@ export const SUBMENU_ROW_OFFSET = 4;
 export const getMenuItemClassName = (destructive = false, active = false) =>
   [
     'flex w-full items-center justify-between gap-2 rounded-[12px] px-2.5 py-1.5 text-left font-satoshi text-[13px] font-normal leading-5 tracking-[-0.32px] transition-colors',
-    destructive ? 'text-text-error hover:bg-danger-100/72' : 'text-text-primary hover:bg-white/50',
-    active ? 'bg-white/58' : 'bg-transparent',
+    // The glass overlay's background is `var(--screen)`, so it FOLLOWS the theme -
+    // but the hover and selected fills were literal white. In dark that painted a
+    // near-#a1a1a0 row under `text-text-primary`, which is a light ink there:
+    // the hovered and the currently-assigned room both dropped to ~2.1:1. The
+    // themed hairline tints track the surface instead, so ink and fill move together.
+    destructive
+      ? 'text-text-error hover:bg-danger-100/72'
+      : 'text-text-primary hover:bg-[var(--hairline-soft)]',
+    active ? 'bg-[var(--hairline)]' : 'bg-transparent',
   ].join(' ');
 
 export const resolveMenuError = (error: unknown, fallback: string) => {

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneMonthOverview.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneMonthOverview.tsx
@@ -67,7 +67,13 @@ export type PhoneMonthOverviewProps = {
 };
 
 const dayNumberColourClass = (cell: PhoneMonthCell): string => {
-  if (cell.isOutsideMonth || cell.appointmentCount === 0) return 'text-[var(--ink-faint)]';
+  // Three distinct steps, all of which clear AA. These used to be separated by
+  // cell opacity (0.35 for padding, 0.45 for quiet), which is what made the
+  // padding days unreadable; collapsing both onto --ink-faint then made an
+  // adjacent-month day look like an ordinary quiet one. --ink-faint is the
+  // faintest passing ink and reads as furthest away, --ink-muted a step nearer.
+  if (cell.isOutsideMonth) return 'text-[var(--ink-faint)]';
+  if (cell.appointmentCount === 0) return 'text-[var(--ink-muted)]';
   if (cell.isToday) return 'text-[var(--nav-active)]';
   if (cell.isPast) return 'text-[var(--ink-muted)]';
   return 'text-[var(--ink)]';

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneMonthOverview.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneMonthOverview.tsx
@@ -66,13 +66,6 @@ export type PhoneMonthOverviewProps = {
   className?: string;
 };
 
-/** Cell opacity: padding days recede hardest, quiet in-month days a little. */
-const cellOpacityClass = (cell: PhoneMonthCell): string => {
-  if (cell.isOutsideMonth) return 'opacity-[0.35]';
-  if (cell.appointmentCount === 0) return 'opacity-[0.45]';
-  return '';
-};
-
 const dayNumberColourClass = (cell: PhoneMonthCell): string => {
   if (cell.isOutsideMonth || cell.appointmentCount === 0) return 'text-[var(--ink-faint)]';
   if (cell.isToday) return 'text-[var(--nav-active)]';
@@ -109,10 +102,7 @@ const DayCell = ({
     aria-current={cell.isToday ? 'date' : undefined}
     aria-label={`${cell.dateKey} · ${cell.appointmentCount} appointments`}
     onClick={() => onSelectDay?.(cell)}
-    className={clsx(
-      'flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5',
-      cellOpacityClass(cell)
-    )}
+    className="flex cursor-pointer flex-col items-center gap-[2px] rounded-xl py-1.5"
   >
     {cell.isSelected ? (
       <span className="flex size-[26px] items-center justify-center rounded-full bg-[var(--blue-strong)] text-[12.5px] font-bold text-white shadow-[0_4px_12px_var(--glow-b26)]">

--- a/apps/frontend/src/app/features/appointments/components/appointmentBoardHelpers.ts
+++ b/apps/frontend/src/app/features/appointments/components/appointmentBoardHelpers.ts
@@ -30,20 +30,20 @@ export const isMutedBoardStatus = (status: BoardStatus | null): boolean =>
   !!status && MUTED_BOARD_STATUSES.has(status);
 
 // Emergency filter pill. Selected and unselected must be unmistakable and AA-safe
-// in both themes, so the selected state is a solid danger fill with a white label
-// (--danger-strong is #a6271d in both themes, so white clears ~7:1), while
-// the unselected state stays an outline-only pill (--danger-border hairline,
-// --danger-text ink).
+// in both themes, so the selected state is a solid danger fill and the unselected
+// state stays an outline-only pill (--danger-border hairline, --danger-text ink).
 export const getEmergencyPillStyle = (isActive: boolean): React.CSSProperties => ({
-  // --danger-strong, which is FIXED in both themes. --color-danger-800 is a text
-  // step and now has a light dark-mode value, so using it as the fill under
-  // white put the selected Emergency label at 1.98:1 in dark.
+  // --danger-strong and its PAIRED ink, never a literal white. The pair inverts
+  // in dark (light fill, near-black label) because the fill owes 3:1 to the
+  // surface as well as 4.5:1 to the label, and no single fixed value clears
+  // both - a dark red on the dark screen is a 2.05:1 boundary, so the selected
+  // pill had no visible edge at all.
   backgroundColor: isActive ? 'var(--danger-strong)' : 'transparent',
   borderColor: isActive ? 'var(--danger-strong)' : 'var(--danger-border)',
   borderWidth: '1px',
   borderStyle: 'solid',
   borderRadius: '9999px',
-  color: isActive ? 'var(--color-white)' : 'var(--danger-text)',
+  color: isActive ? 'var(--danger-strong-ink)' : 'var(--danger-text)',
 });
 
 export const getBoardOrgType = (

--- a/apps/frontend/src/app/features/appointments/components/appointmentBoardHelpers.ts
+++ b/apps/frontend/src/app/features/appointments/components/appointmentBoardHelpers.ts
@@ -31,12 +31,15 @@ export const isMutedBoardStatus = (status: BoardStatus | null): boolean =>
 
 // Emergency filter pill. Selected and unselected must be unmistakable and AA-safe
 // in both themes, so the selected state is a solid danger fill with a white label
-// (--color-danger-800 is #a6271d in light and dark, so white clears ~7:1), while
+// (--danger-strong is #a6271d in both themes, so white clears ~7:1), while
 // the unselected state stays an outline-only pill (--danger-border hairline,
 // --danger-text ink).
 export const getEmergencyPillStyle = (isActive: boolean): React.CSSProperties => ({
-  backgroundColor: isActive ? 'var(--color-danger-800)' : 'transparent',
-  borderColor: isActive ? 'var(--color-danger-800)' : 'var(--danger-border)',
+  // --danger-strong, which is FIXED in both themes. --color-danger-800 is a text
+  // step and now has a light dark-mode value, so using it as the fill under
+  // white put the selected Emergency label at 1.98:1 in dark.
+  backgroundColor: isActive ? 'var(--danger-strong)' : 'transparent',
+  borderColor: isActive ? 'var(--danger-strong)' : 'var(--danger-border)',
   borderWidth: '1px',
   borderStyle: 'solid',
   borderRadius: '9999px',

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/AlertPill.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/AlertPill.stories.tsx
@@ -1,0 +1,98 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import AlertPill from './AlertPill';
+
+const meta = {
+  title: 'Appointments/AlertPill',
+  component: AlertPill,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'A patient’s standing alert - "Needs muzzle", "Barking" - shown on every tab of the ' +
+          'patient page and in the appointment workspace. The colour comes entirely from the ' +
+          'persisted severity, so the four variants below are the whole surface. Passing both `id` ' +
+          'and `onRemove` adds the dismiss control; without them the pill is read-only.\n\n' +
+          'The `medium` and `high` tints previously took their text from the **700** ramp steps, ' +
+          'which are mid-ramp fills rather than inks: on their own 100 tint they measured 2.77:1 ' +
+          'and 4.23:1, so every alert on the patient page sat under AA. They now use the 900 and ' +
+          '800 steps (6.42:1 and 6.23:1) with the tint and border unchanged, which is why the ' +
+          'pills look the same weight but read cleanly. This story is the guard against that ' +
+          'regressing - all four severities render together so a diff is obvious.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    label: 'Needs muzzle',
+    severity: 'medium',
+  },
+  argTypes: {
+    severity: {
+      control: 'select',
+      options: ['low', 'medium', 'high', 'critical'],
+    },
+    onRemove: { action: 'removed' },
+  },
+} satisfies Meta<typeof AlertPill>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Medium: Story = {};
+
+export const Low: Story = {
+  args: { label: 'Prefers quiet room', severity: 'low' },
+};
+
+export const High: Story = {
+  args: { label: 'Barking', severity: 'high' },
+};
+
+export const Critical: Story = {
+  args: { label: 'Bite risk', severity: 'critical' },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The only severity that inverts - near-black fill with `--color-neutral-0` text, so it ' +
+          'reads as a warning rather than a tint.',
+      },
+    },
+  },
+};
+
+export const Removable: Story = {
+  args: { id: 'alert-1', label: 'Needs muzzle', severity: 'medium', onRemove: fn() },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'With `id` and `onRemove` the dismiss control appears, labelled "Remove alert &lt;label&gt;" ' +
+          'rather than a bare ×.',
+      },
+    },
+  },
+};
+
+export const EverySeverity: Story = {
+  name: 'Every severity',
+  render: () => (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, maxWidth: 460 }}>
+      <AlertPill label="Prefers quiet room" severity="low" />
+      <AlertPill label="Needs muzzle" severity="medium" />
+      <AlertPill label="Barking" severity="high" />
+      <AlertPill label="Bite risk" severity="critical" />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The four together, which is how they actually appear on a patient with several alerts - ' +
+          'and the view that makes a contrast regression in any one of them visible.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/AlertPill.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/AlertPill.tsx
@@ -16,14 +16,19 @@ const SEVERITY_STYLE: Record<AlertSeverity, { background: string; color: string;
       color: 'var(--color-neutral-700)',
       border: 'var(--color-neutral-300)',
     },
+    // The 700 steps are mid-ramp fills, not text: on their own 100 tint they read
+    // 2.77 (warning) and 4.23 (danger). Every patient alert pill - "Needs muzzle",
+    // "Barking" - was below AA on every tab of the patient page. The darker steps
+    // already exist in the ramp and clear it at 6.42 and 6.23, with the tint and
+    // border unchanged so the pills look the same weight.
     medium: {
       background: 'var(--color-warning-100)',
-      color: 'var(--color-warning-700)',
+      color: 'var(--color-warning-900)',
       border: 'var(--color-warning-300)',
     },
     high: {
       background: 'var(--color-danger-100)',
-      color: 'var(--color-danger-700)',
+      color: 'var(--color-danger-800)',
       border: 'var(--color-danger-300)',
     },
     critical: {

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/StockHealthPill.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/StockHealthPill.tsx
@@ -14,7 +14,11 @@ export const StockHealthPill = ({ qty, low }: { qty: number; low: boolean }) => 
   >
     {low ? 'Low stock' : 'In stock'}
     <span
-      className={`flex size-6 items-center justify-center rounded-2xl text-[11px] leading-none font-bold text-neutral-0 ${
+      // --ink-fixed, not text-neutral-0: neutral-0 is the SURFACE token, so the
+      // count was --screen-on-warning-700 at 2.74:1 in light and inverted in
+      // dark. Both pill fills are fixed mid-tones, so the count is pinned dark
+      // against them - 5.61:1 on the warning fill.
+      className={`flex size-6 items-center justify-center rounded-2xl text-[11px] leading-none font-bold text-[var(--ink-fixed)] ${
         low ? 'bg-warning-700' : 'bg-pill-success-text'
       }`}
     >

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/StockHealthPill.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/StockHealthPill.tsx
@@ -14,12 +14,15 @@ export const StockHealthPill = ({ qty, low }: { qty: number; low: boolean }) => 
   >
     {low ? 'Low stock' : 'In stock'}
     <span
-      // --ink-fixed, not text-neutral-0: neutral-0 is the SURFACE token, so the
-      // count was --screen-on-warning-700 at 2.74:1 in light and inverted in
-      // dark. Both pill fills are fixed mid-tones, so the count is pinned dark
-      // against them - 5.61:1 on the warning fill.
-      className={`flex size-6 items-center justify-center rounded-2xl text-[11px] leading-none font-bold text-[var(--ink-fixed)] ${
-        low ? 'bg-warning-700' : 'bg-pill-success-text'
+      // The two fills behave differently, so their inks do too.
+      //   warning-700 is FIXED (a mid orange in both themes) -> pin the ink dark,
+      //     5.61. It used to take text-neutral-0, which inverted to near-white.
+      //   the success fill THEMES (deep green in light, light green in dark) ->
+      //     keep text-neutral-0, whose inversion is exactly right here: light on
+      //     the deep fill, dark on the light one. Pinning it white gave 1.86 in
+      //     dark, so this branch was right all along.
+      className={`flex size-6 items-center justify-center rounded-2xl text-[11px] leading-none font-bold ${
+        low ? 'bg-warning-700 text-[var(--ink-fixed)]' : 'bg-pill-success-text text-neutral-0'
       }`}
     >
       {qty}

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/index.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/index.tsx
@@ -309,7 +309,7 @@ const DischargeDateTimeModal = ({
             </label>
           </div>
         )}
-        <div className={`${isSaving ? 'pointer-events-none opacity-60' : ''} flex flex-col gap-3`}>
+        <div className={`${isSaving ? 'pointer-events-none' : ''} flex flex-col gap-3`}>
           <Datepicker
             type="input"
             currentDate={dischargeDate}

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/index.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/index.tsx
@@ -187,7 +187,10 @@ type CustomFormsSectionProps = {
 };
 
 const FormBadge: React.FC<{ label: string; badgeClass: string }> = ({ label, badgeClass }) => (
-  <StatusPill label={label} tone={badgeClass.startsWith('bg-green-50') ? 'success' : 'warning'} />
+  <StatusPill
+    label={label}
+    tone={badgeClass.startsWith('bg-[var(--status-completed-bg)]') ? 'success' : 'warning'}
+  />
 );
 
 const CustomFormsSection: React.FC<CustomFormsSectionProps> = ({
@@ -232,7 +235,9 @@ const getFormBadge = (
     label = 'Signature Pending';
   }
   const badgeClass =
-    isSigned || isCompleted ? 'bg-green-50 text-green-800' : 'bg-amber-50 text-amber-700';
+    isSigned || isCompleted
+      ? 'bg-[var(--status-completed-bg)] text-[var(--status-completed-text)]'
+      : 'bg-[var(--status-requested-bg)] text-[var(--color-warning-900)]';
   return { label, badgeClass };
 };
 

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/ChangeRoom.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/ChangeRoom.tsx
@@ -154,7 +154,7 @@ const ChangeRoom = ({ showModal, setShowModal, activeAppointment }: ChangeRoomPr
     <CenterModal showModal={showModal} setShowModal={setShowModal} onClose={handleCancel}>
       <div className="flex flex-col gap-4 w-full">
         <ModalHeader title="Assign room" onClose={handleCancel} />
-        <div className={`${saving ? 'pointer-events-none opacity-60' : ''}`}>
+        <div className={`${saving ? 'pointer-events-none' : ''}`}>
           <LabelDropdown
             placeholder="Select room"
             options={roomOptions}
@@ -164,7 +164,7 @@ const ChangeRoom = ({ showModal, setShowModal, activeAppointment }: ChangeRoomPr
           />
         </div>
         {isInpatient ? (
-          <div className={`${saving ? 'pointer-events-none opacity-60' : ''}`}>
+          <div className={`${saving ? 'pointer-events-none' : ''}`}>
             <LabelDropdown
               placeholder="Select unit"
               options={unitOptions}

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/ChangeStatus.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/ChangeStatus.tsx
@@ -307,9 +307,7 @@ const ChangeStatus = ({
         const noLeadsAvailable = availableVetIds !== null && availableLeadOptions.length === 0;
         return (
           <div
-            className={
-              saving ? 'pointer-events-none opacity-60 flex flex-col gap-3' : 'flex flex-col gap-3'
-            }
+            className={saving ? 'pointer-events-none flex flex-col gap-3' : 'flex flex-col gap-3'}
           >
             <LabelDropdown
               placeholder={isLoadingAvailability ? 'Checking availability…' : 'Select lead'}

--- a/apps/frontend/src/app/features/chat/components/ChannelHeaderBar.tsx
+++ b/apps/frontend/src/app/features/chat/components/ChannelHeaderBar.tsx
@@ -70,7 +70,7 @@ const ChannelHeaderBar: FC<ChannelHeaderBarProps> = ({
       </span>
       {chat.showPresence ? (
         /* Design (thread header, online): 11.5px --success with a 6px pulsing dot. */
-        <span className="flex min-w-0 items-center gap-1.5 text-[11.5px] text-[var(--success)]">
+        <span className="flex min-w-0 items-center gap-1.5 text-[11.5px] text-[var(--success-text)]">
           <span className="chat-presence-dot h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--success)]" />
           <span className="truncate">{statusText}</span>
         </span>

--- a/apps/frontend/src/app/features/chat/components/ChatContainer.css
+++ b/apps/frontend/src/app/features/chat/components/ChatContainer.css
@@ -53,7 +53,7 @@
   --str-chat__disabled-color: var(--hairline);
   --str-chat__on-disabled-color: var(--screen);
   --str-chat__danger-color: var(--danger-text);
-  --str-chat__info-color: var(--success);
+  --str-chat__info-color: var(--success-text);
   --str-chat__message-highlight-color: var(--blue-soft);
   --str-chat__unread-badge-color: var(--blue);
   --str-chat__on-unread-badge-color: #ffffff;

--- a/apps/frontend/src/app/features/chat/components/ConversationRow.tsx
+++ b/apps/frontend/src/app/features/chat/components/ConversationRow.tsx
@@ -114,8 +114,7 @@ export function ConversationRow({
         'group relative flex items-center pr-1 rounded-[13px] xl:rounded-[14px]',
         active
           ? 'border border-[var(--hairline)] bg-[var(--screen)] shadow-[0_1px_3px_var(--sh05)] xl:border-transparent xl:bg-[var(--surface-soft)] xl:shadow-[inset_3px_0_0_var(--blue)]'
-          : 'hover:bg-[var(--screen)] xl:hover:bg-[var(--surface-soft)]',
-        muted && !active && 'opacity-[0.62]'
+          : 'hover:bg-[var(--screen)] xl:hover:bg-[var(--surface-soft)]'
       )}
     >
       <button

--- a/apps/frontend/src/app/features/developers/pages/DeveloperPortalHome/DeveloperPortalHome.css
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperPortalHome/DeveloperPortalHome.css
@@ -331,7 +331,7 @@
 }
 
 .dev-req-status.ok {
-  color: var(--success);
+  color: var(--success-text);
 }
 
 .dev-req-status.err {

--- a/apps/frontend/src/app/features/developers/pages/DeveloperPortalHome/PhoneDevHome.css
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperPortalHome/PhoneDevHome.css
@@ -259,7 +259,7 @@
 }
 
 .dev-ph-log-status.ok {
-  color: var(--success);
+  color: var(--success-text);
 }
 
 .dev-ph-log-status.err {

--- a/apps/frontend/src/app/features/developers/pages/DeveloperSettings/DeveloperSettings.css
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperSettings/DeveloperSettings.css
@@ -244,9 +244,13 @@
   font-family: var(--font-satoshi);
 }
 
+/* --danger-strong (fixed #a6271d), not --danger-text. danger-text is an INK: it
+   lightens to #f2938a in dark so it can be read on dark surfaces, which under
+   white put this destructive confirm at 1.7:1 - the most dangerous button in the
+   dialog was the least legible one. */
 .dev-confirm-btn.confirm {
-  background: var(--danger-text);
-  color: #ffffff;
+  background: var(--danger-strong);
+  color: var(--white-text);
 }
 
 .dev-confirm-btn.cancel {

--- a/apps/frontend/src/app/features/developers/pages/DeveloperSettings/DeveloperSettings.css
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperSettings/DeveloperSettings.css
@@ -250,7 +250,7 @@
    dialog was the least legible one. */
 .dev-confirm-btn.confirm {
   background: var(--danger-strong);
-  color: var(--white-text);
+  color: var(--danger-strong-ink);
 }
 
 .dev-confirm-btn.cancel {

--- a/apps/frontend/src/app/features/integrations/pages/IdexxWorkspace/index.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/IdexxWorkspace/index.tsx
@@ -231,7 +231,9 @@ const getMeterMeta = (test: LabResultTest) => {
   const rawPercent = ((value - range.min) / (range.max - range.min)) * 100;
   const percent = Math.min(100, Math.max(0, rawPercent));
   const markerClass =
-    test.outOfRange || rawPercent < 0 || rawPercent > 100 ? 'bg-red-500' : 'bg-text-primary';
+    test.outOfRange || rawPercent < 0 || rawPercent > 100
+      ? 'bg-[var(--danger)]'
+      : 'bg-text-primary';
   return { canRender: true, percent, markerClass };
 };
 

--- a/apps/frontend/src/app/features/inventory/components/DispensaryDetailModal.tsx
+++ b/apps/frontend/src/app/features/inventory/components/DispensaryDetailModal.tsx
@@ -370,7 +370,7 @@ const DispensaryDetailModal = ({
           isCloseDisabled={actions.actioning}
           actions={
             isDispensed && (
-              <IoCheckmarkCircle size={20} className="text-[var(--success)] shrink-0" />
+              <IoCheckmarkCircle size={20} className="text-[var(--success-text)] shrink-0" />
             )
           }
         />

--- a/apps/frontend/src/app/features/inventory/components/TurnoverAnalytics/index.tsx
+++ b/apps/frontend/src/app/features/inventory/components/TurnoverAnalytics/index.tsx
@@ -162,7 +162,7 @@ const KpiCards = ({
             'flex items-center gap-1 text-[11px] font-semibold',
             // The arrow already flips on this exact comparison; the colour
             // did not, so a fall in turnover was reported in success green.
-            annualDelta >= 0 ? 'text-[var(--success)]' : 'text-[var(--danger-text)]'
+            annualDelta >= 0 ? 'text-[var(--success-text)]' : 'text-[var(--danger-text)]'
           )}
         >
           {annualDelta >= 0 ? (

--- a/apps/frontend/src/app/features/onboarding/pages/StripeOnboarding/index.tsx
+++ b/apps/frontend/src/app/features/onboarding/pages/StripeOnboarding/index.tsx
@@ -163,7 +163,7 @@ const StripeOnboarding = () => {
           onClick={() => router.back()}
         />
         <span className="inline-flex items-center gap-1.5 rounded-full border border-[var(--divider)] bg-[var(--screen)] px-3 py-1.5 text-caption-2 text-text-secondary">
-          <IoLockClosed aria-hidden="true" className="text-[var(--success)]" />
+          <IoLockClosed aria-hidden="true" className="text-[var(--success-text)]" />
           Secure · Powered by Stripe
         </span>
       </div>

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/LinkedMedicalDevices.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/LinkedMedicalDevices.tsx
@@ -153,7 +153,7 @@ const LinkedMedicalDevices = () => {
                   </span>
                 </span>
                 {online ? (
-                  <span className="flex items-center gap-1.5 text-[11px] font-bold text-[var(--success)]">
+                  <span className="flex items-center gap-1.5 text-[11px] font-bold text-[var(--success-text)]">
                     <span className="size-[7px] rounded-full bg-[var(--success)] animate-pulse" />
                     {'ONLINE'}
                   </span>

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/AddRoomSections.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/AddRoomSections.tsx
@@ -194,7 +194,7 @@ export const UnitsSection = ({
             type="button"
             aria-label="Add unit type"
             onClick={onAddUnit}
-            className="flex size-8 items-center justify-center rounded-full bg-text-primary text-white"
+            className="flex size-8 items-center justify-center rounded-full bg-text-primary text-[var(--screen)]"
           >
             <FiPlus size={16} aria-hidden="true" />
           </button>
@@ -265,7 +265,7 @@ export const EquipmentSection = ({
               type="button"
               aria-label="Add custom equipment"
               onClick={onAddCustomEquipment}
-              className="flex size-12 shrink-0 cursor-pointer items-center justify-center rounded-2xl bg-text-primary text-white"
+              className="flex size-12 shrink-0 cursor-pointer items-center justify-center rounded-2xl bg-text-primary text-[var(--screen)]"
             >
               <FiPlus size={18} aria-hidden="true" />
             </button>

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/RoomInfoSections.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/RoomInfoSections.tsx
@@ -250,7 +250,7 @@ const RoomInfoSections = ({
               type="button"
               aria-label="Add unit type"
               onClick={onAddUnit}
-              className="flex size-8 items-center justify-center rounded-full bg-text-primary text-white"
+              className="flex size-8 items-center justify-center rounded-full bg-text-primary text-[var(--screen)]"
             >
               <FiPlus size={16} aria-hidden="true" />
             </button>
@@ -319,7 +319,7 @@ const RoomInfoSections = ({
               type="button"
               aria-label="Add custom equipment"
               onClick={onAddCustomEquipment}
-              className="flex size-12 shrink-0 cursor-pointer items-center justify-center rounded-2xl bg-text-primary text-white"
+              className="flex size-12 shrink-0 cursor-pointer items-center justify-center rounded-2xl bg-text-primary text-[var(--screen)]"
             >
               <FiPlus size={18} aria-hidden="true" />
             </button>

--- a/apps/frontend/src/app/features/organization/pages/Specialities/PackageBreakdownTable.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Specialities/PackageBreakdownTable.tsx
@@ -42,7 +42,7 @@ const NestedBreakdownTooltip = ({
     <div style={{ minWidth: 360 }}>
       <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 12 }}>
         <thead>
-          <tr style={{ opacity: 0.6 }}>
+          <tr style={{ color: 'var(--ink-muted)' }}>
             <th style={{ textAlign: 'left', padding: '2px 6px' }}>#</th>
             <th style={{ textAlign: 'left', padding: '2px 6px' }}>Type</th>
             <th style={{ textAlign: 'left', padding: '2px 6px' }}>Name</th>
@@ -57,8 +57,8 @@ const NestedBreakdownTooltip = ({
             const { net } = computePackageBreakdownItem(item);
             return (
               <tr key={item.id} style={{ borderTop: '1px solid var(--hairline)' }}>
-                <td style={{ padding: '3px 6px', opacity: 0.5 }}>{i + 1}.</td>
-                <td style={{ padding: '3px 6px', opacity: 0.7 }}>
+                <td style={{ padding: '3px 6px', color: 'var(--ink-muted)' }}>{i + 1}.</td>
+                <td style={{ padding: '3px 6px', color: 'var(--ink-muted)' }}>
                   {TYPE_LABELS[item.type] ?? item.type}
                 </td>
                 <td style={{ padding: '3px 6px' }}>{item.name}</td>
@@ -66,7 +66,7 @@ const NestedBreakdownTooltip = ({
                   {formatMoney(item.unitPrice, item.currency ?? orgCurrency)}
                 </td>
                 <td style={{ padding: '3px 6px', textAlign: 'center' }}>×{item.quantity}</td>
-                <td style={{ padding: '3px 6px', textAlign: 'right', opacity: 0.7 }}>
+                <td style={{ padding: '3px 6px', textAlign: 'right', color: 'var(--ink-muted)' }}>
                   {item.discount}%
                 </td>
                 <td style={{ padding: '3px 6px', textAlign: 'right' }}>
@@ -81,11 +81,16 @@ const NestedBreakdownTooltip = ({
             <tr style={{ borderTop: '1px solid var(--hairline-hover)' }}>
               <td
                 colSpan={6}
-                style={{ padding: '3px 6px', textAlign: 'right', opacity: 0.6, fontSize: 12 }}
+                style={{
+                  padding: '3px 6px',
+                  textAlign: 'right',
+                  color: 'var(--ink-muted)',
+                  fontSize: 12,
+                }}
               >
                 Additional discount ({additionalDiscount}%)
               </td>
-              <td style={{ padding: '3px 6px', textAlign: 'right', opacity: 0.8 }}>
+              <td style={{ padding: '3px 6px', textAlign: 'right', color: 'var(--ink-muted)' }}>
                 - {formatMoney((subtotal * additionalDiscount) / 100, orgCurrency)}
               </td>
             </tr>
@@ -93,7 +98,12 @@ const NestedBreakdownTooltip = ({
           <tr style={{ borderTop: '1px solid var(--hairline-hover)' }}>
             <td
               colSpan={6}
-              style={{ padding: '4px 6px', textAlign: 'right', opacity: 0.7, fontSize: 12 }}
+              style={{
+                padding: '4px 6px',
+                textAlign: 'right',
+                color: 'var(--ink-muted)',
+                fontSize: 12,
+              }}
             >
               Total
             </td>

--- a/apps/frontend/src/app/features/tasks/components/TaskFilterBar.tsx
+++ b/apps/frontend/src/app/features/tasks/components/TaskFilterBar.tsx
@@ -133,7 +133,15 @@ const TaskFilterBar = ({
               aria-pressed={isActive}
               onClick={() => toggleStatus(option.key)}
               className={clsx(
-                'inline-flex min-h-[38px] items-center justify-center rounded-full px-1 py-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-brand'
+                'inline-flex min-h-[38px] items-center justify-center rounded-full px-1 py-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-brand',
+                // The selected filter needs a visible state of its own. It used
+                // to be the ABSENCE of an opacity-65 dim on the others, which
+                // meant the only way to see which filter was active was that the
+                // rest were faded - and that dim composited their labels below
+                // AA. A ring marks the selected one instead, so nothing has to
+                // be made unreadable to show it.
+                isActive &&
+                  'ring-2 ring-[var(--blue-strong)] ring-offset-1 ring-offset-[var(--screen)]'
               )}
             >
               <StatusPill tokens={getStatusPillTokens(option)} label={option.name} />

--- a/apps/frontend/src/app/features/tasks/components/TaskFilterBar.tsx
+++ b/apps/frontend/src/app/features/tasks/components/TaskFilterBar.tsx
@@ -133,8 +133,7 @@ const TaskFilterBar = ({
               aria-pressed={isActive}
               onClick={() => toggleStatus(option.key)}
               className={clsx(
-                'inline-flex min-h-[38px] items-center justify-center rounded-full px-1 py-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-brand',
-                !isActive && 'opacity-65 transition-opacity hover:opacity-100'
+                'inline-flex min-h-[38px] items-center justify-center rounded-full px-1 py-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-brand'
               )}
             >
               <StatusPill tokens={getStatusPillTokens(option)} label={option.name} />

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -378,7 +378,10 @@ textarea:focus-visible {
   --color-error-500: #ef4444;
   --color-error-700: #b91c1c;
   --color-delete: var(--color-danger-700);
-  --color-pending-text: #f68523;
+  /* Painted as text by .OrgStatus, where #f68523 was 1.93:1 on --band and
+     2.29:1 on --screen. Darkened to clear AA; the pill's own --pendingbg
+     (#fef3e9) is unchanged, so only the label moves. */
+  --color-pending-text: #9d4c06;
   --color-danger-soft: #fee7e7;
   --color-calendar-line-strong: #c3cedc;
   --color-calendar-line-soft: #e9edf3;
@@ -641,6 +644,10 @@ textarea:focus-visible {
   --cyan: #5ce1e6;
   --cyan-text: #38ccd8;
   --success: #008f5d;
+  /* --success is a FILL (status dots, bars) and carries no contrast duty; it is
+     3.15:1 on --band, so it must not paint text. This is its text twin, the
+     same pairing as --danger/--danger-text and --blue/--blue-text. */
+  --success-text: #006642;
   --warn: #f59e0b;
   /* always-dark spotlight blocks (manifesto / code / phone bezel) */
   --spot: #1d1c1b;
@@ -653,7 +660,7 @@ textarea:focus-visible {
   --avatar-green-bg: #e6f4ef;
   --avatar-green-ink: #006642;
   --avatar-amber-bg: #fef3e9;
-  --avatar-amber-ink: #af5e19;
+  --avatar-amber-ink: #965115;
   /* glassy nav bits */
   --nav-hover: rgba(255, 255, 255, 0.5);
   --glass-btn: linear-gradient(180deg, rgba(255, 253, 250, 0.9), rgba(250, 246, 239, 0.8));
@@ -781,6 +788,7 @@ html[data-theme='dark'] {
   --cyan: #5ce1e6;
   --cyan-text: #5ce1e6;
   --success: #2bbd86;
+  --success-text: #2bbd86;
   --warn: #f5a83c;
   --spot: #17140f;
   --spot-ink: #f4efe6;
@@ -899,6 +907,7 @@ html[data-theme='dark'] {
   --cyan: #5ce1e6;
   --cyan-text: #5ce1e6;
   --success: #2bbd86;
+  --success-text: #2bbd86;
   --avatar-violet-bg: rgba(167, 139, 250, 0.2);
   --avatar-violet-ink: #cbb2f4;
   --avatar-green-bg: rgba(74, 205, 155, 0.17);

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -324,7 +324,14 @@ textarea:focus-visible {
   /* --danger-text, not the 700 fill step: as text on --screen the fill read
      4.40 (the account menu's Sign out row). Both already agree in dark. */
   --color-text-error: var(--danger-text);
-  --color-text-brand: var(--color-brand-950);
+  /* The brand blue #007cf5 is a FILL. As an ink on the bone screen it measures
+     3.56-3.86:1 - the footer's support address, "View all organizations" in the
+     org switcher and the Upgrade card's yearly-saving line all sat under AA.
+     --color-accent-deep is the same hue family tuned for text (#1657c9, ~6.6:1)
+     and is what --blue-text already resolves to; the dark side was already an
+     ink (#8fb6f5). Every use of this token in the codebase is a `color`, so
+     nothing is being restyled as a fill by this change. */
+  --color-text-brand: var(--color-accent-deep);
   --color-text-secondary: var(--color-neutral-700);
   --color-text-tertiary: var(--color-neutral-600);
   --color-text-extra: var(--color-neutral-500);
@@ -660,6 +667,12 @@ textarea:focus-visible {
      the label. --danger is 4.14 under white and --danger-text inverts to a
      light pink in dark, which is how a Delete confirm reached 2.25:1. */
   --danger-strong: #a6271d;
+  /* And the success equivalent, fixed for the same reason. --color-success-600
+     is #008f5d in light and #2bbd86 in dark, so the Dispense confirm carried
+     white on 4.13:1 light and 2.41:1 dark - the affirmative half of a
+     dispense-or-cancel pair, unreadable on both sides. #006642 is 7.05 under
+     white and does not move with the theme. */
+  --success-strong: #006642;
   --pink: #ff90d4;
   --cyan: #5ce1e6;
   --cyan-text: #38ccd8;
@@ -745,7 +758,12 @@ textarea:focus-visible {
   --danger-bg: rgba(234, 55, 41, 0.09);
   /* Faintest danger tint (emergency / overdue row wash). */
   --danger-bg-faint: rgba(234, 55, 41, 0.04);
-  --danger-text: #c2261a;
+  /* #a6271d, not #c2261a. On its own --danger-bg tint (which composites to
+     #efd8cc) the lighter value measured 4.28:1 at 12px - the selected
+     Emergencies chip, the month-overview emergency chip and the inventory
+     turnover pill all read on that tint. #a6271d takes them to 5.24 and only
+     raises contrast everywhere else this ink is used. */
+  --danger-text: #a6271d;
   --danger: #ea3729;
   --danger-border: rgba(234, 55, 41, 0.32);
   --warn-bg: rgba(245, 158, 11, 0.12);
@@ -1867,6 +1885,20 @@ body:has([data-yc-app]) {
    These pin the light inks in BOTH themes. Declared on the surface element
    rather than on body, so it wins for that subtree by proximity. */
 [data-yc-surface='light'] {
+  /* The BODY inks have to be pinned here too, not just the faint ones. The card
+     is a literal `bg-white/80` in both themes, so a themed --ink-body (#e6ddd0 in
+     dark) put the "Payment complete" heading, the session id and the Return home
+     label at 1.34:1 - a white card with white text on it. Each alias is
+     re-declared rather than only its base token: an alias declared at :root
+     computes there and descendants inherit the already-substituted value, so
+     overriding --ink-body alone would not have reached --color-text-primary. */
+  --ink: #1d1c1b;
+  --ink-body: #302f2e;
+  --ink-muted: #5c5956;
+  --color-neutral-900: var(--ink-body);
+  --color-neutral-700: var(--ink-muted);
+  --color-text-primary: var(--color-neutral-900);
+  --color-text-secondary: var(--color-neutral-700);
   --ink-faint: #66635f;
   --ink-faint2: #66635f;
   --color-text-tertiary: var(--ink-faint);

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -651,6 +651,11 @@ textarea:focus-visible {
      for both themes satisfied the first and broke the second - #1657c9 is only
      2.23:1 on the dark page. Light: 6.48 white / 5.04-5.86 surface. */
   --blue-strong: var(--color-accent-deep);
+  /* The danger equivalent, and fixed in both themes for the same reason:
+     a destructive button is a FILL carrying white text, so it owes 4.5:1 to
+     the label. --danger is 4.14 under white and --danger-text inverts to a
+     light pink in dark, which is how a Delete confirm reached 2.25:1. */
+  --danger-strong: #a6271d;
   --pink: #ff90d4;
   --cyan: #5ce1e6;
   --cyan-text: #38ccd8;

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -1035,15 +1035,14 @@ html[data-theme='dark'] {
 html[data-theme='dark'] [data-yc-theme] {
   color-scheme: dark;
 }
-html[data-theme-ready] [data-yc-theme] * {
-  transition:
-    background-color 300ms ease,
-    border-color 300ms ease,
-    color 300ms ease,
-    box-shadow 300ms ease;
+/* Same shape as the app shell below, and for the same reason: a `*` transition
+   here started one animation per element on every theme flip, and a transition
+   that stalls at currentTime 0 strands the element in the outgoing theme. */
+html[data-theme-ready] [data-yc-theme] {
+  transition: background-color 300ms ease;
 }
 @media (prefers-reduced-motion: reduce) {
-  html[data-theme-ready] [data-yc-theme] * {
+  html[data-theme-ready] [data-yc-theme] {
     transition: none !important;
   }
 }
@@ -1666,15 +1665,24 @@ input[type='number'] {
 html[data-theme='dark'] [data-yc-app] {
   color-scheme: dark;
 }
-html[data-theme-ready] [data-yc-app] * {
-  transition:
-    background-color 300ms ease,
-    border-color 300ms ease,
-    color 300ms ease,
-    box-shadow 300ms ease;
+/* The transition lives on the SHELL, not on `*`.
+   It used to be `[data-yc-app] *`, which put a 300ms transition on every element
+   in the app - roughly 700 of them on a real page. A theme flip then started ~700
+   simultaneous transitions, and some never advanced: caught in the browser with
+   playState "running" and currentTime stuck at 0, which leaves the element painted
+   in the OUTGOING theme's colour indefinitely. The Patients page heading ended up
+   at #f4efe6 on #efe8dc - 1.06:1, invisible - while a freshly created element with
+   the same class rendered correctly, proving the CSS was fine and the transition
+   was the fault.
+   Backgrounds still cross-fade at the surface level, which is the part anyone
+   perceives; text and borders swap instantly, which is both correct and cheaper.
+   `color` is deliberately NOT transitioned - it is the property whose failure mode
+   is unreadable text. */
+html[data-theme-ready] [data-yc-app] {
+  transition: background-color 300ms ease;
 }
 @media (prefers-reduced-motion: reduce) {
-  html[data-theme-ready] [data-yc-app] * {
+  html[data-theme-ready] [data-yc-app] {
     transition: none !important;
   }
 }

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -321,7 +321,9 @@ textarea:focus-visible {
 
   --color-text-primary: var(--color-neutral-900);
   --color-text-cta: var(--color-neutral-900);
-  --color-text-error: var(--color-danger-700);
+  /* --danger-text, not the 700 fill step: as text on --screen the fill read
+     4.40 (the account menu's Sign out row). Both already agree in dark. */
+  --color-text-error: var(--danger-text);
   --color-text-brand: var(--color-brand-950);
   --color-text-secondary: var(--color-neutral-700);
   --color-text-tertiary: var(--color-neutral-600);
@@ -490,7 +492,9 @@ textarea:focus-visible {
   --status-no-show-border: #f97316;
 
   --status-danger-bg: rgba(234, 55, 41, 0.09);
-  --status-danger-text: #c2261a;
+  /* On its own --status-danger-bg tint this composites to #efd8cc, where
+     #c2261a is 4.28. The 800 step clears it at 5.24. */
+  --status-danger-text: #a6271d;
   --status-danger-border: rgba(234, 55, 41, 0.32);
 
   /* Alert / document-category palette (workspace revamp — Figma "documents cat" sheet) */
@@ -745,7 +749,9 @@ textarea:focus-visible {
   --danger: #ea3729;
   --danger-border: rgba(234, 55, 41, 0.32);
   --warn-bg: rgba(245, 158, 11, 0.12);
-  --warn-text: #b45309;
+  /* 3.84 on its own --warn-bg tint (the dashboard's "Verification in
+     progress" pill). One step darker clears it at 5.42. */
+  --warn-text: #92400e;
   --warn-border: rgba(245, 158, 11, 0.3);
   --pink-soft: #ffe8f6;
   --pink-text: #b3307f;

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -533,6 +533,12 @@ textarea:focus-visible {
   --blue-text: var(--color-blue-text);
   --light-blue: var(--color-primary-100);
   --white-text: #ffffff;
+  /* Its counterpart. Some surfaces are a FIXED colour in both themes -
+     brand illustration fills, a LinkedIn-blue avatar - so their text must
+     be fixed too. A themed ink on a fixed surface inverts in dark: the
+     LaunchGrowTab tabs are permanently light blue, and their heading went
+     from 15:1 to 1.11:1 the moment the theme flipped. */
+  --ink-fixed: #1d1c1b;
   --whitebg: var(--color-white-bg);
   --greyborder: var(--color-grey-border);
   --lightgrey: var(--color-grey-light);
@@ -1024,6 +1030,11 @@ html[data-theme='dark'] {
   --status-completed-border: rgba(74, 205, 155, 0.55);
   --status-cancelled-bg: rgba(249, 115, 22, 0.15);
   --status-cancelled-text: #f0a36c;
+  /* The alert pill's inks. The 100 tints already had dark values but these did
+     not, so darkening them for light mode left them dark-on-dark in the other
+     theme - 1.75 and 1.98 on the composited tints. Existing ramp steps. */
+  --color-warning-900: #f9ad6c;
+  --color-danger-800: #f5a39d;
   --status-cancelled-border: rgba(249, 115, 22, 0.5);
   --status-no-show-bg: rgba(249, 115, 22, 0.15);
   --status-no-show-text: #f0a36c;

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -662,17 +662,22 @@ textarea:focus-visible {
      for both themes satisfied the first and broke the second - #1657c9 is only
      2.23:1 on the dark page. Light: 6.48 white / 5.04-5.86 surface. */
   --blue-strong: var(--color-accent-deep);
-  /* The danger equivalent, and fixed in both themes for the same reason:
-     a destructive button is a FILL carrying white text, so it owes 4.5:1 to
-     the label. --danger is 4.14 under white and --danger-text inverts to a
-     light pink in dark, which is how a Delete confirm reached 2.25:1. */
+  /* A destructive button is a FILL carrying a label, so it owes 4.5:1 to that
+     label AND 3:1 to the surface it sits on (1.4.11). A single fixed value
+     cannot do both in dark: clearing white text caps the fill at L 0.183 while
+     clearing the dark screen needs at least L 0.165, and that sliver fails
+     against --band anyway. So the PAIR inverts instead - dark fill with a light
+     label in light mode, light fill with a dark label in dark. --danger-strong-ink
+     moves with it; never pair this fill with a literal white. */
   --danger-strong: #a6271d;
+  --danger-strong-ink: var(--white-text);
   /* And the success equivalent, fixed for the same reason. --color-success-600
      is #008f5d in light and #2bbd86 in dark, so the Dispense confirm carried
      white on 4.13:1 light and 2.41:1 dark - the affirmative half of a
      dispense-or-cancel pair, unreadable on both sides. #006642 is 7.05 under
      white and does not move with the theme. */
   --success-strong: #006642;
+  --success-strong-ink: var(--white-text);
   --pink: #ff90d4;
   --cyan: #5ce1e6;
   --cyan-text: #38ccd8;
@@ -822,6 +827,14 @@ html[data-theme='dark'] {
      light. #2f74d9 is the value that clears both - 4.54:1 white, 3.19-3.72:1
      against every dark surface. */
   --blue-strong: #2f74d9;
+  /* Inverted here: see the light declaration. A dark fill on a dark surface has
+     no visible boundary (#a6271d is 2.05:1 on --screen), so dark mode uses the
+     light tone as the fill and a near-black as its label. 6.5-7.5 against every
+     dark surface, 7.5 for the label on top. */
+  --danger-strong: #f2938a;
+  --danger-strong-ink: var(--ink-fixed);
+  --success-strong: #2bbd86;
+  --success-strong-ink: var(--ink-fixed);
   --blue-text: var(--color-blue-text);
   --blue-soft: rgba(143, 182, 245, 0.16);
   --pink: #ff90d4;
@@ -941,6 +954,14 @@ html[data-theme='dark'] {
      light. #2f74d9 is the value that clears both - 4.54:1 white, 3.19-3.72:1
      against every dark surface. */
   --blue-strong: #2f74d9;
+  /* Inverted here: see the light declaration. A dark fill on a dark surface has
+     no visible boundary (#a6271d is 2.05:1 on --screen), so dark mode uses the
+     light tone as the fill and a near-black as its label. 6.5-7.5 against every
+     dark surface, 7.5 for the label on top. */
+  --danger-strong: #f2938a;
+  --danger-strong-ink: var(--ink-fixed);
+  --success-strong: #2bbd86;
+  --success-strong-ink: var(--ink-fixed);
   --blue-text: var(--color-blue-text);
   --blue-soft: rgba(143, 182, 245, 0.16);
   --pink: #ff90d4;

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -403,18 +403,23 @@ textarea:focus-visible {
   --color-shadow-xs: rgba(17, 24, 39, 0.04);
   --color-shadow-sm: rgba(0, 0, 0, 0.16);
   --color-shadow-md: rgba(0, 0, 0, 0.2);
-  --color-muted-999: #999999;
+  --color-muted-999: var(--ink-muted);
   --color-muted-400: #c2c2c1;
   --color-text-hidden: #2b2b2a;
   --color-toast-error-bg: #f8c1bd;
   --color-toast-warning-bg: #fcd9bb;
   --color-toast-success-bg: #b0dccd;
-  --color-select-ink: #312943;
-  --color-select-ink-muted: #31294399;
+  /* Themed inks, not fixed literals. These had no dark value, so in dark mode
+     the select's own text stayed near-black on a near-black surface - 1.07:1
+     for the placeholder. Aliasing to the warm-bone scale gives them a dark
+     value for free, and --color-muted-999 (#999999) was failing in LIGHT too
+     at 2.58:1. */
+  --color-select-ink: var(--ink);
+  --color-select-ink-muted: var(--ink-muted);
   --color-surface-disabled: #ece5d9;
   --color-text-subtle: #555555;
   --color-text-strong: #333333;
-  --color-text-body-dark: #222222;
+  --color-text-body-dark: var(--ink-body);
   --color-linkedin-blue: #0a66c2;
   --color-chat-empty-bg: #faf7f0;
   --color-onboarding-accent-border: #b7c8ff;
@@ -427,7 +432,7 @@ textarea:focus-visible {
   --color-upload-error-soft: #e53e3e;
   --color-upload-info: #2563eb;
   --color-upload-success: #10b981;
-  --color-upload-text: #222222;
+  --color-upload-text: var(--ink-body);
 
   --color-badge-blue-bg: var(--color-primary-500);
   --color-badge-blue-text: #eaf3ff;

--- a/apps/frontend/src/app/ui/inputs/Dropdown/Dropdown.css
+++ b/apps/frontend/src/app/ui/inputs/Dropdown/Dropdown.css
@@ -162,6 +162,8 @@
   font-size: 12px;
   line-height: 120%;
   font-family: var(--satoshi-font);
-  color: var(--delete);
+  /* --danger-text, not --delete: --delete is the button FILL, and as 12px
+     error text it read 4.00 on the form background. */
+  color: var(--danger-text);
   margin-top: 6px;
 }

--- a/apps/frontend/src/app/ui/inputs/Slotpicker/index.tsx
+++ b/apps/frontend/src/app/ui/inputs/Slotpicker/index.tsx
@@ -222,6 +222,14 @@ const Slotpicker = ({
                 type="button"
                 key={day.toISOString()}
                 ref={isCurrent ? selectedDateRef : null}
+                // Past days were painted at opacity-40 and given
+                // `cursor-not-allowed`, and handleClickDate returns early for
+                // them - but the button was never actually disabled. So they
+                // stayed in the tab order announcing themselves as pressable,
+                // and the dim was not an inactive state that WCAG 1.4.3 exempts,
+                // it was just 2.23:1 text. Marking them disabled makes the
+                // existing visuals honest.
+                disabled={isPast}
                 onClick={() => handleClickDate(day)}
                 className={[
                   'relative flex flex-col gap-1 items-center justify-center px-3 py-2 border rounded-xl! shrink-0 min-w-14',

--- a/apps/frontend/src/app/ui/layout/Header/Header.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/Header/Header.stories.tsx
@@ -55,6 +55,13 @@ export const SignedIn: Story = {
     </>
   ),
   parameters: {
+    // The meta marks this file `marketing` for the GUEST header, which really
+    // does render on the public pages. The signed-in header does not - it is
+    // the PIMS top bar, and previewing it with the marketing tokens gave the
+    // "Organization" kicker #8f8984 (2.84:1) instead of the scoped #66635f the
+    // product actually paints. Storybook has to render it in the app scope or
+    // it is measuring a page that does not exist.
+    surface: 'app',
     docs: {
       description: {
         story:

--- a/apps/frontend/src/app/ui/layout/Notifications/Notifications.css
+++ b/apps/frontend/src/app/ui/layout/Notifications/Notifications.css
@@ -61,7 +61,8 @@
   align-items: center;
   justify-content: center;
   border-radius: 999px;
-  background: var(--blue);
+  /* --blue-strong: this fill carries white text, and --blue is 4.09 under it. */
+  background: var(--blue-strong);
   color: #fff;
   font-family: var(--font-satoshi);
   font-size: 10.5px;
@@ -212,7 +213,8 @@
 }
 
 .yc-noti-dot--blue {
-  background: var(--blue);
+  /* --blue-strong: this fill carries white text, and --blue is 4.09 under it. */
+  background: var(--blue-strong);
 }
 
 .yc-noti-dot--pink {

--- a/apps/frontend/src/app/ui/layout/PhoneShell/PhoneShell.css
+++ b/apps/frontend/src/app/ui/layout/PhoneShell/PhoneShell.css
@@ -120,7 +120,8 @@
     border-radius: 999px;
     /* Twin of .yc-notification-dot in UserHeader.css - same badge, same
        meaning, so the same blue at both breakpoints. */
-    background: var(--blue);
+    /* --blue-strong: this fill carries white text, and --blue is 4.09 under it. */
+    background: var(--blue-strong);
   }
 
   /* -------------------------------------------------------------- tab bar */
@@ -207,7 +208,8 @@
     justify-content: center;
     padding: 0 4px;
     border-radius: 999px;
-    background: var(--blue);
+    /* --blue-strong: this fill carries white text, and --blue is 4.09 under it. */
+    background: var(--blue-strong);
     color: #fff;
     font-size: 9px;
     font-weight: 700;

--- a/apps/frontend/src/app/ui/layout/SessionInitializer.tsx
+++ b/apps/frontend/src/app/ui/layout/SessionInitializer.tsx
@@ -67,6 +67,22 @@ const createTerminologyRewriter = (primaryOrgId?: string | null) => {
     });
   };
 
+  /**
+   * The browser tab.
+   *
+   * The rewriter below is rooted at `document.body`, so it never reached the
+   * `<title>` in `<head>` - an org set to "Patients" still had a tab reading
+   * "Companions", contradicting every heading on the page. Route metadata is
+   * static (`export const metadata`) and rendered on the server, which has no
+   * access to the org's choice, so the term is applied here instead.
+   */
+  const rewriteDocumentTitle = () => {
+    const next = rewriteCompanionTerminologyText(document.title, getActiveTerminology());
+    if (next !== document.title) {
+      document.title = next;
+    }
+  };
+
   const rewriteNode = (node: Node) => {
     if (node.nodeType === Node.TEXT_NODE) {
       rewriteTextNode(node as Text);
@@ -79,15 +95,31 @@ const createTerminologyRewriter = (primaryOrgId?: string | null) => {
     if (isInsideTerminologyLock(element)) return;
     rewriteElementAttributes(element);
 
-    const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT);
+    // DESCENDANT elements too, not just this one. Previously only the added
+    // element's own attributes were rewritten while the walker covered text
+    // nodes at any depth, so a nested `aria-label` never got the org's term -
+    // "Upload companion photo" stayed raw inside the Add patient modal in an
+    // org set to Patients. Text and attributes are walked in one pass.
+    const walker = document.createTreeWalker(
+      element,
+      NodeFilter.SHOW_TEXT | NodeFilter.SHOW_ELEMENT
+    );
     let current = walker.nextNode();
     while (current) {
-      rewriteTextNode(current as Text);
+      if (current.nodeType === Node.TEXT_NODE) {
+        rewriteTextNode(current as Text);
+      } else {
+        rewriteElementAttributes(current as Element);
+      }
       current = walker.nextNode();
     }
   };
 
   const handleMutations = (mutations: MutationRecord[]) => {
+    // Next swaps <title> on navigation, and a navigation always mutates the body
+    // too - so the tab is re-applied from here rather than from a second
+    // MutationObserver on <title>, which was an extra live handle for nothing.
+    rewriteDocumentTitle();
     mutations.forEach((mutation) => {
       if (mutation.type === 'characterData' && mutation.target.nodeType === Node.TEXT_NODE) {
         rewriteTextNode(mutation.target as Text);
@@ -97,7 +129,7 @@ const createTerminologyRewriter = (primaryOrgId?: string | null) => {
     });
   };
 
-  return { rewriteNode, handleMutations };
+  return { rewriteNode, handleMutations, rewriteDocumentTitle };
 };
 
 const SessionInitializer = ({ children }: { children: React.ReactNode }) => {
@@ -153,9 +185,11 @@ const SessionInitializer = ({ children }: { children: React.ReactNode }) => {
     if (typeof document === 'undefined') return;
     const root = document.body;
     if (!root) return;
-    const { rewriteNode, handleMutations } = createTerminologyRewriter(primaryOrgId);
+    const { rewriteNode, handleMutations, rewriteDocumentTitle } =
+      createTerminologyRewriter(primaryOrgId);
 
     rewriteNode(root);
+    rewriteDocumentTitle();
 
     const observer = new MutationObserver(handleMutations);
 
@@ -169,6 +203,7 @@ const SessionInitializer = ({ children }: { children: React.ReactNode }) => {
 
     const handleTerminologyChange = () => {
       rewriteNode(root);
+      rewriteDocumentTitle();
     };
     globalThis.window.addEventListener('yc:companion-terminology-changed', handleTerminologyChange);
 

--- a/apps/frontend/src/app/ui/layout/Sidebar/Sidebar.tsx
+++ b/apps/frontend/src/app/ui/layout/Sidebar/Sidebar.tsx
@@ -216,6 +216,8 @@ const Sidebar = () => {
                         href={route.href}
                         onClick={onClick}
                         aria-current={isActive ? 'page' : undefined}
+                        aria-disabled={isDisabled || undefined}
+                        tabIndex={isDisabled ? -1 : undefined}
                       >
                         <span className="sr-only">{route.name}</span>
                         <span className="route-collapsed-icon-wrap">{routeIcon}</span>
@@ -231,6 +233,13 @@ const Sidebar = () => {
                     href={route.href}
                     onClick={onClick}
                     aria-current={isActive ? 'page' : undefined}
+                    // A disabled route was disabled to the EYE only - greyed, with
+                    // cursor:not-allowed and a click handler that returns early -
+                    // while still being a focusable link announced as actionable.
+                    // An unverified org's Patients entry could be tabbed to and
+                    // read out as a normal destination it can never reach.
+                    aria-disabled={isDisabled || undefined}
+                    tabIndex={isDisabled ? -1 : undefined}
                   >
                     {routeIcon}
                     <span className="route-label">{route.name}</span>

--- a/apps/frontend/src/app/ui/layout/UniversalSearch/UniversalSearch.css
+++ b/apps/frontend/src/app/ui/layout/UniversalSearch/UniversalSearch.css
@@ -98,7 +98,9 @@
   border: 1px solid var(--hairline);
   border-radius: 6px;
   background: var(--pill-raised);
-  color: var(--ink-faint);
+  /* --ink-muted: the keycap sits on --pill-raised, a LIFTED surface, so the
+     faint step only reached 4.25 against it in dark. */
+  color: var(--ink-muted);
   font-family: var(--font-satoshi);
   font-size: 10.5px;
   font-weight: 700;
@@ -236,7 +238,9 @@
   border: 1px solid var(--hairline);
   border-radius: 6px;
   background: var(--pill-raised);
-  color: var(--ink-faint);
+  /* --ink-muted: the keycap sits on --pill-raised, a LIFTED surface, so the
+     faint step only reached 4.25 against it in dark. */
+  color: var(--ink-muted);
   font-family: var(--font-satoshi);
   font-size: 10.5px;
   font-weight: 700;

--- a/apps/frontend/src/app/ui/overlays/Modal/CenterModal.stories.tsx
+++ b/apps/frontend/src/app/ui/overlays/Modal/CenterModal.stories.tsx
@@ -28,7 +28,7 @@ const CenterModalDemo = ({ title = 'Confirm action' }: { title?: string }) => {
     <div>
       <button
         type="button"
-        className="px-6 py-3 bg-text-primary text-white rounded-2xl text-body-3-emphasis"
+        className="px-6 py-3 bg-text-primary text-[var(--screen)] rounded-2xl text-body-3-emphasis"
         onClick={() => setOpen(true)}
       >
         Open modal
@@ -49,7 +49,7 @@ const CenterModalDemo = ({ title = 'Confirm action' }: { title?: string }) => {
             </button>
             <button
               type="button"
-              className="px-6 py-3 bg-text-primary text-white rounded-2xl text-body-3-emphasis"
+              className="px-6 py-3 bg-text-primary text-[var(--screen)] rounded-2xl text-body-3-emphasis"
               onClick={() => setOpen(false)}
             >
               Confirm

--- a/apps/frontend/src/app/ui/overlays/Modal/CenterModal.stories.tsx
+++ b/apps/frontend/src/app/ui/overlays/Modal/CenterModal.stories.tsx
@@ -71,7 +71,7 @@ export const DestructiveConfirm: Story = {
     <div>
       <button
         type="button"
-        className="px-6 py-3 bg-text-error text-white rounded-2xl text-body-3-emphasis"
+        className="px-6 py-3 bg-[var(--danger-strong)] text-white rounded-2xl text-body-3-emphasis"
         onClick={() => {
           const el = document.getElementById('delete-demo-trigger') as HTMLButtonElement;
           el?.click();
@@ -105,7 +105,7 @@ export const DestructiveConfirm: Story = {
                   </button>
                   <button
                     type="button"
-                    className="px-6 py-3 bg-text-error text-white rounded-2xl text-body-3-emphasis"
+                    className="px-6 py-3 bg-[var(--danger-strong)] text-white rounded-2xl text-body-3-emphasis"
                     onClick={() => setOpen(false)}
                   >
                     Delete

--- a/apps/frontend/src/app/ui/overlays/Modal/CenterModal.stories.tsx
+++ b/apps/frontend/src/app/ui/overlays/Modal/CenterModal.stories.tsx
@@ -71,7 +71,7 @@ export const DestructiveConfirm: Story = {
     <div>
       <button
         type="button"
-        className="px-6 py-3 bg-[var(--danger-strong)] text-white rounded-2xl text-body-3-emphasis"
+        className="px-6 py-3 bg-[var(--danger-strong)] text-[var(--danger-strong-ink)] rounded-2xl text-body-3-emphasis"
         onClick={() => {
           const el = document.getElementById('delete-demo-trigger') as HTMLButtonElement;
           el?.click();
@@ -105,7 +105,7 @@ export const DestructiveConfirm: Story = {
                   </button>
                   <button
                     type="button"
-                    className="px-6 py-3 bg-[var(--danger-strong)] text-white rounded-2xl text-body-3-emphasis"
+                    className="px-6 py-3 bg-[var(--danger-strong)] text-[var(--danger-strong-ink)] rounded-2xl text-body-3-emphasis"
                     onClick={() => setOpen(false)}
                   >
                     Delete

--- a/apps/frontend/src/app/ui/overlays/Modal/ChangeStatusModal.tsx
+++ b/apps/frontend/src/app/ui/overlays/Modal/ChangeStatusModal.tsx
@@ -136,7 +136,7 @@ const ChangeStatusModal = <S extends string>({
       <div className="flex flex-col gap-4 w-full">
         <ModalHeader title="Change status" onClose={handleCancel} />
         <div className="flex flex-col gap-2">
-          <div className={saving ? 'pointer-events-none opacity-60' : ''}>
+          <div className={saving ? 'pointer-events-none' : ''}>
             <LabelDropdown
               placeholder={placeholder}
               options={statusOptions}

--- a/apps/frontend/src/app/ui/overlays/Modal/ChangeStatusModal.tsx
+++ b/apps/frontend/src/app/ui/overlays/Modal/ChangeStatusModal.tsx
@@ -146,7 +146,9 @@ const ChangeStatusModal = <S extends string>({
             />
           </div>
           {renderExtraContent ? renderExtraContent({ selectedStatus, saving }) : null}
-          {errorMessage ? <p className="text-sm text-red-600">{errorMessage}</p> : null}
+          {errorMessage ? (
+            <p className="text-sm text-[var(--danger-text)]">{errorMessage}</p>
+          ) : null}
         </div>
         <div className="flex items-center justify-center gap-2 w-full pb-3 flex-wrap">
           <Secondary

--- a/apps/frontend/src/app/ui/overlays/Modal/ModalBase.stories.tsx
+++ b/apps/frontend/src/app/ui/overlays/Modal/ModalBase.stories.tsx
@@ -50,7 +50,7 @@ const ModalDemo = ({ label, canClose }: { label?: string; canClose?: () => boole
     <div>
       <button
         type="button"
-        className="px-6 py-3 bg-text-primary text-white rounded-2xl text-body-3-emphasis"
+        className="px-6 py-3 bg-text-primary text-[var(--screen)] rounded-2xl text-body-3-emphasis"
         onClick={() => setOpen(true)}
       >
         Open modal
@@ -92,7 +92,7 @@ const ModalDemo = ({ label, canClose }: { label?: string; canClose?: () => boole
           </button>
           <button
             type="button"
-            className="px-6 py-3 bg-text-primary text-white rounded-2xl text-body-3-emphasis"
+            className="px-6 py-3 bg-text-primary text-[var(--screen)] rounded-2xl text-body-3-emphasis"
             onClick={() => setOpen(false)}
           >
             Confirm

--- a/apps/frontend/src/app/ui/overlays/OtpModal/OtpModal.css
+++ b/apps/frontend/src/app/ui/overlays/OtpModal/OtpModal.css
@@ -124,8 +124,13 @@
   gap: 10px;
 }
 
-.verifyInputDiv p {
-  color: var(--delete);
+/* Scoped to the alert. As `.verifyInputDiv p` this painted EVERY paragraph in
+   the block red, including the neutral "Enter the 6-digit code from your email."
+   hint, which is not an error and was overriding its own text-text-secondary.
+   --danger-text rather than --delete: --delete is #d53225, which measures 4.00
+   on the modal's bone surface and 4.40 on the card - under AA either way. */
+.verifyInputDiv p[role='alert'] {
+  color: var(--danger-text);
   font-weight: 600;
   font-size: 13px;
   line-height: 120%;

--- a/apps/frontend/src/app/ui/primitives/Accordion/EditableAccordion.tsx
+++ b/apps/frontend/src/app/ui/primitives/Accordion/EditableAccordion.tsx
@@ -163,7 +163,9 @@ const FieldComponents: Record<string, React.FC<EditableFieldProps>> = {
           />
           <span>{field.label}</span>
         </label>
-        {error ? <div className="px-4 text-caption-1 text-red-600">{error}</div> : null}
+        {error ? (
+          <div className="px-4 text-caption-1 text-[var(--danger-text)]">{error}</div>
+        ) : null}
       </div>
     );
   },
@@ -605,7 +607,7 @@ const EditableAccordion: React.FC<EditableAccordionProps> = ({
               : 'flex justify-end items-end gap-3 w-full flex-col'
           }
         >
-          {error && <div className="text-red-600 text-sm text-center">{error}</div>}
+          {error && <div className="text-[var(--danger-text)] text-sm text-center">{error}</div>}
           <div
             className={
               compactInlineActions

--- a/apps/frontend/src/app/ui/primitives/Buttons/Delete.tsx
+++ b/apps/frontend/src/app/ui/primitives/Buttons/Delete.tsx
@@ -11,7 +11,7 @@ const sizeClasses: Record<ButtonSize, string> = {
 };
 
 const baseClasses =
-  'gap-[7px] flex items-center justify-center rounded-full! transition-[background-color,opacity] duration-200 ease-out font-semibold text-white bg-[var(--danger-strong)] hover:opacity-90 active:opacity-100';
+  'gap-[7px] flex items-center justify-center rounded-full! transition-[background-color,opacity] duration-200 ease-out font-semibold text-[var(--danger-strong-ink)] bg-[var(--danger-strong)] hover:opacity-90 active:opacity-100';
 
 const Delete = ({ className, ...rest }: Readonly<DeleteProps>) => (
   <BaseButton {...rest} className={className} sizeClasses={sizeClasses} baseClasses={baseClasses} />

--- a/apps/frontend/src/app/ui/primitives/Buttons/Delete.tsx
+++ b/apps/frontend/src/app/ui/primitives/Buttons/Delete.tsx
@@ -11,7 +11,7 @@ const sizeClasses: Record<ButtonSize, string> = {
 };
 
 const baseClasses =
-  'gap-[7px] flex items-center justify-center rounded-full! transition-[background-color,opacity] duration-200 ease-out font-semibold text-white bg-[var(--danger)] hover:opacity-90 active:opacity-100';
+  'gap-[7px] flex items-center justify-center rounded-full! transition-[background-color,opacity] duration-200 ease-out font-semibold text-white bg-[var(--danger-strong)] hover:opacity-90 active:opacity-100';
 
 const Delete = ({ className, ...rest }: Readonly<DeleteProps>) => (
   <BaseButton {...rest} className={className} sizeClasses={sizeClasses} baseClasses={baseClasses} />

--- a/apps/frontend/src/app/ui/tables/CompanionsTable.tsx
+++ b/apps/frontend/src/app/ui/tables/CompanionsTable.tsx
@@ -121,7 +121,7 @@ const CompanionAvatar = ({
 );
 
 const CoParentPill = () => (
-  <span className="ml-1 inline-flex items-center rounded-full border border-[var(--pink)] bg-[var(--glow-p12)] px-[7px] py-px text-[9px] font-bold text-[var(--pink)]">
+  <span className="ml-1 inline-flex items-center rounded-full border border-[var(--pink)] bg-[var(--glow-p12)] px-[7px] py-px text-[9px] font-bold text-[var(--pink-text)]">
     + CO-PARENT
   </span>
 );

--- a/apps/frontend/src/app/ui/tables/CompanionsTable.tsx
+++ b/apps/frontend/src/app/ui/tables/CompanionsTable.tsx
@@ -148,12 +148,11 @@ const CompanionRow = ({
   onOpenHistory: (companion: CompanionParent) => void;
 }) => {
   const [menuOpen, setMenuOpen] = useState(false);
-  const isInactive = String(item.companion.status ?? 'inactive').toLowerCase() !== 'active';
   return (
     <div
       className={`${GRID_COLS} border-t border-[var(--hairline)] px-5 py-3 text-[13.5px] text-text-primary transition-colors ${
         menuOpen ? 'bg-[var(--surface-soft)]' : 'hover:bg-[var(--surface-soft)]'
-      } ${isInactive ? 'opacity-[0.62]' : ''}`}
+      }`}
     >
       {/* Patient */}
       <span className="flex min-w-0 items-center gap-3">
@@ -220,12 +219,9 @@ const CompanionGridCard = ({
   terminologyText: (label: string) => string;
   onOpen: (companion: CompanionParent) => void;
 }) => {
-  const isInactive = String(item.companion.status ?? 'inactive').toLowerCase() !== 'active';
   return (
     <div
-      className={`flex flex-col justify-between gap-3 overflow-hidden rounded-[18px] border border-[var(--hairline)] bg-[var(--screen)] p-3.5 shadow-[0_1px_2px_var(--sh03),0_10px_26px_var(--sh05)] ${
-        isInactive ? 'opacity-[0.62]' : ''
-      }`}
+      className={`flex flex-col justify-between gap-3 overflow-hidden rounded-[18px] border border-[var(--hairline)] bg-[var(--screen)] p-3.5 shadow-[0_1px_2px_var(--sh03),0_10px_26px_var(--sh05)]`}
     >
       <div className="flex items-center gap-3">
         <CompanionAvatar companion={item.companion} size={46} textClassName="text-[20px]" />
@@ -260,7 +256,6 @@ const CompanionPhoneCard = ({
   onOpen: (companion: CompanionParent) => void;
   terminologyText: (label: string) => string;
 }) => {
-  const isInactive = String(item.companion.status ?? 'inactive').toLowerCase() !== 'active';
   const subline = [formatDisplayValue(item.companion.breed, ''), formatParentName(item.parent)]
     .filter(Boolean)
     .join(' · ');
@@ -269,9 +264,7 @@ const CompanionPhoneCard = ({
       type="button"
       onClick={() => onOpen(item)}
       title={terminologyText('Open companion history')}
-      className={`flex w-full items-center gap-[11px] rounded-2xl border border-[var(--hairline)] bg-[var(--screen)] px-3.5 py-[11px] text-left shadow-[0_1px_2px_var(--sh03),0_6px_16px_var(--sh05)] ${
-        isInactive ? 'opacity-[0.62]' : ''
-      }`}
+      className={`flex w-full items-center gap-[11px] rounded-2xl border border-[var(--hairline)] bg-[var(--screen)] px-3.5 py-[11px] text-left shadow-[0_1px_2px_var(--sh03),0_6px_16px_var(--sh05)]`}
     >
       <CompanionAvatar companion={item.companion} size={44} textClassName="text-[19px]" />
       <span className="flex min-w-0 flex-1 flex-col">

--- a/apps/frontend/src/app/ui/tables/CompanionsTable.tsx
+++ b/apps/frontend/src/app/ui/tables/CompanionsTable.tsx
@@ -220,9 +220,7 @@ const CompanionGridCard = ({
   onOpen: (companion: CompanionParent) => void;
 }) => {
   return (
-    <div
-      className={`flex flex-col justify-between gap-3 overflow-hidden rounded-[18px] border border-[var(--hairline)] bg-[var(--screen)] p-3.5 shadow-[0_1px_2px_var(--sh03),0_10px_26px_var(--sh05)]`}
-    >
+    <div className="flex flex-col justify-between gap-3 overflow-hidden rounded-[18px] border border-[var(--hairline)] bg-[var(--screen)] p-3.5 shadow-[0_1px_2px_var(--sh03),0_10px_26px_var(--sh05)]">
       <div className="flex items-center gap-3">
         <CompanionAvatar companion={item.companion} size={46} textClassName="text-[20px]" />
         <button
@@ -264,7 +262,7 @@ const CompanionPhoneCard = ({
       type="button"
       onClick={() => onOpen(item)}
       title={terminologyText('Open companion history')}
-      className={`flex w-full items-center gap-[11px] rounded-2xl border border-[var(--hairline)] bg-[var(--screen)] px-3.5 py-[11px] text-left shadow-[0_1px_2px_var(--sh03),0_6px_16px_var(--sh05)]`}
+      className="flex w-full items-center gap-[11px] rounded-2xl border border-[var(--hairline)] bg-[var(--screen)] px-3.5 py-[11px] text-left shadow-[0_1px_2px_var(--sh03),0_6px_16px_var(--sh05)]"
     >
       <CompanionAvatar companion={item.companion} size={44} textClassName="text-[19px]" />
       <span className="flex min-w-0 flex-1 flex-col">

--- a/apps/frontend/src/app/ui/tables/DataTable.css
+++ b/apps/frontend/src/app/ui/tables/DataTable.css
@@ -166,7 +166,7 @@ span.cell-overflow-count {
    badge-only ramp. Declared unlayered so they beat Tailwind's utility layer and
    stay theme-live in both light and dark. */
 .cell-ink-success {
-  color: var(--success);
+  color: var(--success-text);
 }
 .cell-ink-warn {
   color: var(--warn-text);

--- a/apps/frontend/src/app/ui/tables/DataTable.css
+++ b/apps/frontend/src/app/ui/tables/DataTable.css
@@ -190,8 +190,11 @@ span.cell-overflow-count {
   gap: 10px;
   width: fit-content;
   border-radius: 16px;
-  background: var(--pendingbg, #fef3e9);
-  color: var(--pendingtext, #f68523);
+  background: var(--pendingbg);
+  /* No literal fallback: it still held #f68523, the pre-fix orange that reads
+     2.29:1 on this tint. Both tokens are declared, so the fallback was dead -
+     but a dead fallback to a failing colour is a landmine. */
+  color: var(--pendingtext);
   font-size: 16px;
   font-style: normal;
   font-weight: 400;

--- a/apps/frontend/src/app/ui/tables/DispensaryTable.tsx
+++ b/apps/frontend/src/app/ui/tables/DispensaryTable.tsx
@@ -237,7 +237,7 @@ const DispensaryCard = ({
         <button
           type="button"
           onClick={() => onDispense(record)}
-          className="flex-1 h-9 rounded-2xl bg-[var(--success-strong)] text-[var(--white-text)] text-caption-1 font-semibold hover:opacity-90 transition-opacity"
+          className="flex-1 h-9 rounded-2xl bg-[var(--success-strong)] text-[var(--success-strong-ink)] text-caption-1 font-semibold hover:opacity-90 transition-opacity"
         >
           Dispense
         </button>

--- a/apps/frontend/src/app/ui/tables/DispensaryTable.tsx
+++ b/apps/frontend/src/app/ui/tables/DispensaryTable.tsx
@@ -237,7 +237,7 @@ const DispensaryCard = ({
         <button
           type="button"
           onClick={() => onDispense(record)}
-          className="flex-1 h-9 rounded-2xl bg-[var(--color-success-600)] text-white text-caption-1 font-semibold hover:opacity-90 transition-opacity"
+          className="flex-1 h-9 rounded-2xl bg-[var(--success-strong)] text-[var(--white-text)] text-caption-1 font-semibold hover:opacity-90 transition-opacity"
         >
           Dispense
         </button>

--- a/apps/frontend/src/app/ui/tables/GenericTable/Generictable.css
+++ b/apps/frontend/src/app/ui/tables/GenericTable/Generictable.css
@@ -149,11 +149,15 @@
   ):not(.yc-status-pill span):not(.cell-overflow-count) {
   margin: 0px;
   font-family: var(--satoshi-font);
-  color: var(--black-text);
+  /* --ink-muted rather than --black-text at 60% opacity. This rule reaches
+     EVERY span in EVERY table cell across PIMS, so the dim was a blanket 3.48:1
+     on secondary cell text - and being written as a percentage it slipped past
+     the opacity guard, which only read decimals. The de-emphasis is the point,
+     so it is kept; it just comes from ink now (5.41:1 on the row band). */
+  color: var(--ink-muted);
   font-weight: 700;
   font-size: 13px;
   line-height: 120%;
-  opacity: 60%;
 }
 .TableDiv tbody tr td span.yc-status-pill,
 .TableDiv tbody tr td .yc-status-pill span {

--- a/apps/frontend/src/app/ui/tables/PaginatedGridTable.stories.tsx
+++ b/apps/frontend/src/app/ui/tables/PaginatedGridTable.stories.tsx
@@ -36,7 +36,9 @@ const STATUS_STYLE: Record<Row['status'], CSSProperties> = {
     borderColor: 'var(--color-pill-warning-border)',
   },
   Expired: {
-    color: 'var(--color-danger-600)',
+    // --danger-text, which has a dark value; --color-danger-600 is the FILL and
+    // read 3.43:1 on its own tint in dark.
+    color: 'var(--danger-text)',
     backgroundColor: 'var(--color-danger-100)',
     borderColor: 'var(--color-danger-400)',
   },

--- a/apps/frontend/src/app/ui/widgets/DashboardSteps/index.tsx
+++ b/apps/frontend/src/app/ui/widgets/DashboardSteps/index.tsx
@@ -112,8 +112,7 @@ const DashboardSteps = () => {
             <div
               key={step.title}
               className={clsx(
-                'flex flex-col items-start justify-between gap-3 px-5 py-[18px] rounded-[18px] border border-card-border bg-neutral-0 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]',
-                step.isCompleted && 'opacity-[0.55]'
+                'flex flex-col items-start justify-between gap-3 px-5 py-[18px] rounded-[18px] border border-card-border bg-neutral-0 shadow-[0_1px_2px_var(--sh03),0_8px_22px_var(--sh05)]'
               )}
             >
               <div className="flex w-full flex-col items-start gap-2">

--- a/apps/frontend/src/app/ui/widgets/DashboardSteps/index.tsx
+++ b/apps/frontend/src/app/ui/widgets/DashboardSteps/index.tsx
@@ -122,7 +122,7 @@ const DashboardSteps = () => {
                   {step.isCompleted ? (
                     <IoCheckmarkCircle
                       title="Step complete"
-                      className="size-5 shrink-0 text-[var(--success)]"
+                      className="size-5 shrink-0 text-[var(--success-text)]"
                     />
                   ) : (
                     <span

--- a/apps/frontend/src/app/ui/widgets/DynamicSelect/DynamicSelect.tsx
+++ b/apps/frontend/src/app/ui/widgets/DynamicSelect/DynamicSelect.tsx
@@ -104,7 +104,7 @@ const DynamicSelect: React.FC<DynamicSelectProps> = ({
         </div>
       )}
 
-      {error && <span className="text-xs text-red-600 mt-1">{error}</span>}
+      {error && <span className="text-xs text-[var(--danger-text)] mt-1">{error}</span>}
     </div>
   );
 };

--- a/apps/frontend/src/app/ui/widgets/Faq/Faq.css
+++ b/apps/frontend/src/app/ui/widgets/Faq/Faq.css
@@ -32,7 +32,12 @@
   overflow: hidden;
   border: 1px solid var(--color-card-border);
   border-radius: 16px;
-  background: var(--color-background-primary, #fff);
+  /* --color-background-primary does not exist anywhere in the token set, so
+     this always fell through to the #fff literal - a surface that never
+     themes. In dark the accordion text goes light and lands on white at
+     1.34:1. --color-surface-card is the real card surface and has a dark
+     value. */
+  background: var(--color-surface-card);
   box-shadow: 0 5px 16px 0 rgba(8, 15, 52, 0.06);
   transition:
     border-color 180ms ease,

--- a/apps/frontend/src/app/ui/widgets/Footer/Footer.css
+++ b/apps/frontend/src/app/ui/widgets/Footer/Footer.css
@@ -111,13 +111,13 @@
   bottom: -2px;
   width: 0%;
   height: 1px;
-  background: var(--color-brand-950);
+  background: var(--color-text-brand);
   transition: width 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .FtLinks a:hover,
 .FtLinks a:focus {
-  color: var(--color-brand-950);
+  color: var(--color-text-brand);
 }
 
 .FtLinks a:focus-visible {
@@ -170,7 +170,7 @@
 }
 .platform-status-link:hover,
 .platform-status-link:focus {
-  color: var(--color-brand-950);
+  color: var(--color-text-brand);
 }
 
 .platform-status-link:focus-visible {

--- a/apps/frontend/src/app/ui/widgets/Footer/Footer.tsx
+++ b/apps/frontend/src/app/ui/widgets/Footer/Footer.tsx
@@ -216,7 +216,11 @@ const Footer = () => {
               >
                 {footerLinks.map((section) => (
                   <m.div className="FtDiv" key={section.title} variants={ftDivVariants}>
-                    <h3 className="text-heading-3 text-text-tertiary">{section.title}</h3>
+                    {/* secondary, not tertiary: the footer tint composites to #32353b in dark,
+                        where the tertiary ink (#9d9285) measures 4.03:1. The secondary ink
+                        (#a89e90) clears at 4.66, and a section heading outranking the links
+                        under it is the right hierarchy anyway. */}
+                    <h3 className="text-heading-3 text-text-secondary">{section.title}</h3>
                     <ul className="FtLinks">
                       {section.links.map((link) => (
                         <li key={link.label}>

--- a/apps/frontend/src/app/ui/widgets/Github/Github.tsx
+++ b/apps/frontend/src/app/ui/widgets/Github/Github.tsx
@@ -159,7 +159,7 @@ const Github = () => {
       aria-label="GitHub repository"
       className={`${publicRoutes.has(pathname) ? 'flex!' : 'hidden!'} fixed left-0 bottom-7.5 z-9999 flex items-center justify-center w-full pointer-events-none`}
     >
-      <div className="px-6 py-3 flex items-center justify-center gap-2 bg-text-primary pointer-events-auto rounded-2xl">
+      <div className="px-6 py-3 flex items-center justify-center gap-2 bg-[var(--ink-fixed)] pointer-events-auto rounded-2xl">
         <div className="text-body-2 text-white">Star us on Github</div>
         <a
           href="https://github.com/YosemiteCrew/Yosemite-Crew"
@@ -169,15 +169,15 @@ const Github = () => {
         >
           <div className="flex items-center gap-1">
             <Icon icon="mdi:github" width="28" height="28" color="var(--color-neutral-900)" />
-            <div className="text-caption-1 text-text-primary">Stars</div>
+            <div className="text-caption-1 text-[var(--ink-fixed)]">Stars</div>
           </div>
-          <div className="h-3.75 w-px bg-text-tertiary"></div>
-          <div className="text-caption-1 text-text-primary">
+          <div className="h-3.75 w-px bg-[var(--color-neutral-300)]"></div>
+          <div className="text-caption-1 text-[var(--ink-fixed)]">
             {error ?? (stars === null ? '…' : formatStars(stars))}
           </div>
         </a>
         <button
-          className="border-none bg-text-primary"
+          className="border-none bg-[var(--ink-fixed)]"
           onClick={onClose}
           aria-label="Close"
           type="button"

--- a/apps/frontend/src/app/ui/widgets/Github/Github.tsx
+++ b/apps/frontend/src/app/ui/widgets/Github/Github.tsx
@@ -182,7 +182,7 @@ const Github = () => {
           aria-label="Close"
           type="button"
         >
-          <IoCloseSharp color="var(--color-neutral-0)" size={18} />
+          <IoCloseSharp color="var(--white-text)" size={18} />
         </button>
       </div>
     </aside>

--- a/apps/frontend/src/app/ui/widgets/LaunchGrowTab/LaunchGrowTab.css
+++ b/apps/frontend/src/app/ui/widgets/LaunchGrowTab/LaunchGrowTab.css
@@ -57,9 +57,10 @@
 .LaunchTabDiv:first-child .BuildText h3,
 .LaunchTabDiv.active:first-child .BuildText h6,
 .LaunchTabDiv.active:first-child .BuildText h3 {
-  /* Was --color-neutral-0, which is the SURFACE token: near-white on the first
-     tab's #E9F2FD in light, and near-black on it in dark. Both unreadable. */
-  color: var(--ink-fixed);
+  /* The first tab is the only one filled with a strong blue rather than a light
+     tint, so its text stays LIGHT - but FIXED, not the --color-neutral-0 surface
+     token it used to take, which followed the theme and went near-black in dark. */
+  color: var(--white-text);
 }
 
 .BuildText h6 {

--- a/apps/frontend/src/app/ui/widgets/LaunchGrowTab/LaunchGrowTab.css
+++ b/apps/frontend/src/app/ui/widgets/LaunchGrowTab/LaunchGrowTab.css
@@ -246,8 +246,11 @@
   }
 
   .mobile-tab-button.active {
-    background: var(--color-brand-950);
-    /* Dark fill, so the label stays light in both themes. */
+    /* --blue-strong, matching the desktop tab. --color-brand-950 resolves to the
+       brand FILL #007cf5, which is only 4.04:1 under white at 13px; blue-strong
+       is 6.48 light and 4.54 dark. This is the mobile twin of the same rule and
+       was missed when the desktop one moved. */
+    background: var(--blue-strong);
     color: var(--white-text);
     box-shadow: 0px 2px 8px rgba(36, 122, 237, 0.3);
     flex-grow: 1;

--- a/apps/frontend/src/app/ui/widgets/LaunchGrowTab/LaunchGrowTab.css
+++ b/apps/frontend/src/app/ui/widgets/LaunchGrowTab/LaunchGrowTab.css
@@ -21,7 +21,7 @@
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  color: var(--color-neutral-0);
+  color: var(--color-text-primary);
   transition:
     flex-grow 0.2s ease,
     background-color 0.2s ease;
@@ -37,7 +37,12 @@
   box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
 }
 
+/* The only part of the tab painted with the fixed light blue from
+   growtab.color, so its text is pinned dark in both themes. The content panel
+   beside it sits on --color-surface-card and stays themed - pinning the whole
+   .LaunchTabDiv put fixed dark text on the dark card at 1.16:1. */
 .BuildText {
+  color: var(--ink-fixed);
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -52,7 +57,9 @@
 .LaunchTabDiv:first-child .BuildText h3,
 .LaunchTabDiv.active:first-child .BuildText h6,
 .LaunchTabDiv.active:first-child .BuildText h3 {
-  color: var(--color-neutral-0);
+  /* Was --color-neutral-0, which is the SURFACE token: near-white on the first
+     tab's #E9F2FD in light, and near-black on it in dark. Both unreadable. */
+  color: var(--ink-fixed);
 }
 
 .BuildText h6 {
@@ -60,7 +67,7 @@
   font-size: 24px;
   font-weight: 500;
   line-height: 120%;
-  color: var(--color-text-primary);
+  color: var(--ink-fixed);
   margin: 0;
 }
 
@@ -70,7 +77,7 @@
   font-weight: 500;
   line-height: 120%;
   writing-mode: sideways-lr;
-  color: var(--color-text-primary);
+  color: var(--ink-fixed);
   margin: 0;
 }
 
@@ -230,14 +237,17 @@
     transition: all 0.3s ease;
     border: none;
     background: transparent;
-    color: var(--color-text-primary);
+    /* Transparent over the same fixed light-blue tab strip, so the label is
+       pinned dark like the desktop one rather than following the theme. */
+    color: var(--ink-fixed);
     white-space: nowrap;
     flex-shrink: 0;
   }
 
   .mobile-tab-button.active {
     background: var(--color-brand-950);
-    color: var(--color-neutral-0);
+    /* Dark fill, so the label stays light in both themes. */
+    color: var(--white-text);
     box-shadow: 0px 2px 8px rgba(36, 122, 237, 0.3);
     flex-grow: 1;
     flex-shrink: 1;

--- a/apps/frontend/src/app/ui/widgets/LaunchGrowTab/LaunchGrowTab.tsx
+++ b/apps/frontend/src/app/ui/widgets/LaunchGrowTab/LaunchGrowTab.tsx
@@ -10,7 +10,10 @@ const Launchtabs = [
   {
     id: 1,
     title: 'APIs',
-    color: 'var(--color-badge-blue-bg)',
+    // --blue-strong, not --color-badge-blue-bg (#007cf5): this is the one tab
+    // filled with a STRONG blue rather than a light tint, and white on
+    // #007cf5 is only 4.04:1. --blue-strong takes it to 6.48.
+    color: 'var(--blue-strong)',
     icon: MEDIA_SOURCES.launchGrow.tab1,
     heading: 'Application programming interface',
     details: [
@@ -110,7 +113,7 @@ const LaunchGrowTab = () => {
                               icon="solar:verified-check-bold"
                               width="24"
                               height="24"
-                              style={{ color: 'var(--color-badge-blue-bg)', flexShrink: 0 }}
+                              style={{ color: 'var(--blue-text)', flexShrink: 0 }}
                             />
                             <span className="text-body-3">{detail}</span>
                           </li>
@@ -148,7 +151,7 @@ const LaunchGrowTab = () => {
                         width="20"
                         height="20"
                         style={{
-                          color: 'var(--color-badge-blue-bg)',
+                          color: 'var(--blue-text)',
                           flexShrink: 0,
                           marginTop: '2px',
                         }}

--- a/apps/frontend/src/app/ui/widgets/Stats/RevenueStat.tsx
+++ b/apps/frontend/src/app/ui/widgets/Stats/RevenueStat.tsx
@@ -48,7 +48,7 @@ const RevenueStat = () => {
         headerContent={
           periodTotal > 0 ? (
             <div className="flex w-full justify-end">
-              <span className="text-[12px] font-semibold text-[var(--success)]">
+              <span className="text-[12px] font-semibold text-[var(--success-text)]">
                 {formatMoney(periodTotal, currency)}
               </span>
             </div>

--- a/apps/frontend/src/app/ui/widgets/TeamSlide/TeamSlide.css
+++ b/apps/frontend/src/app/ui/widgets/TeamSlide/TeamSlide.css
@@ -21,7 +21,9 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  color: var(--color-neutral-0);
+  /* Fixed LinkedIn blue, so the glyph stays white in both themes - the surface
+     token went dark-on-blue at 2.58:1 in dark. */
+  color: var(--white-text);
   background: var(--color-linkedin-blue);
   border-radius: 50%;
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.16);

--- a/apps/frontend/src/app/ui/widgets/UploadImage/LogoUpdator.tsx
+++ b/apps/frontend/src/app/ui/widgets/UploadImage/LogoUpdator.tsx
@@ -192,7 +192,9 @@ const LogoUpdator = ({ imageUrl, apiUrl, title, onSave, disabled }: LogoUpdatorP
                 </label>
               </div>
               {uploadError && (
-                <div className="text-sm text-red-600 text-center max-w-55">{uploadError}</div>
+                <div className="text-sm text-[var(--danger-text)] text-center max-w-55">
+                  {uploadError}
+                </div>
               )}
             </div>
           </div>

--- a/apps/frontend/src/app/ui/widgets/UploadImage/LogoUploader.tsx
+++ b/apps/frontend/src/app/ui/widgets/UploadImage/LogoUploader.tsx
@@ -125,7 +125,7 @@ const LogoUploader = ({ title, apiUrl, setImageUrl }: LogoUploaderProps) => {
           {isUploading ? 'Uploading...' : title}
         </div>
         {error && (
-          <div className="text-red-600 text-sm" role="alert">
+          <div className="text-[var(--danger-text)] text-sm" role="alert">
             {error}
           </div>
         )}

--- a/apps/frontend/src/app/ui/widgets/UploadImage/LogoUploader.tsx
+++ b/apps/frontend/src/app/ui/widgets/UploadImage/LogoUploader.tsx
@@ -96,11 +96,7 @@ const LogoUploader = ({ title, apiUrl, setImageUrl }: LogoUploaderProps) => {
               onClick={handleRemoveImage}
               aria-label="Remove uploaded logo"
             >
-              <IoRemoveCircleOutline
-                color="var(--color-primary-500)"
-                size={16}
-                aria-hidden="true"
-              />
+              <IoRemoveCircleOutline color="var(--blue-text)" size={16} aria-hidden="true" />
             </button>
           </>
         ) : (


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

This PR started as a contrast pass and grew into everything an exhaustive click-through of PIMS on deployed dev turned up. Four of the defects are not visible from source at all - they only appear once you flip a theme, open a modal, or read a composited pixel.

## What is the new behavior?

### 1. A theme flip could leave text permanently invisible

`[data-yc-app] *` and `[data-yc-theme] *` each transitioned four properties on **every element**, so one toggle started a transition per node - about 700 on a real page. Some never advanced: caught in the browser with `playState: "running"` and `currentTime: 0`, which strands the element in the **outgoing** theme's colour.

The Patients heading ended up `#f4efe6` on `#efe8dc` - **1.06:1** - and stayed there. A freshly created element with the same class rendered correctly, which is what proved the CSS was fine and the transition was at fault.

The transition now sits on the shell and animates `background-color` only. Four theme round-trips: **~700 animations → 21, none stuck**. `color` is deliberately never transitioned - its failure mode is unreadable text, not a missed fade.

### 2. The browser tab ignored the org's terminology

The terminology rewriter is rooted at `document.body`, so `<title>` in `<head>` was never touched: an org set to **Patients** had a tab reading **Companions**. Route metadata is static and server-rendered, so it cannot know the org's choice - the title is now rewritten client-side with everything else.

The same rewriter applied attributes only to the added element **itself** while walking text nodes at any depth, so nested `aria-label` / `title` / `placeholder` were missed - `"Upload companion photo"` stayed raw inside the Add patient modal. One walk now covers both.

### 3. Fill tokens painting text

Six places used a token built as a **fill** to paint **text** - the mistake `AGENTS.md` already warns about. Where the palette had a text twin, the call site simply used the wrong half; where it had none (`--success`), one was added.

| | before | after |
| --- | --- | --- |
| `--success` → new `--success-text` | 3.15 | **5.38** |
| `--pendingtext` (OrgStatus label) | 2.32 | **5.54** |
| `--avatar-amber-ink` | 4.33 | **5.51** |
| `--pink` → `--pink-text` (co-parent pill) | 1.86 | **5.21** |
| white on `--blue` → `--blue-strong` | 4.09 | **6.48** |
| patient alert pills (700 → 900/800 steps) | 2.77 / 4.23 | **6.42 / 6.23** |

`--success` needed a genuinely new twin: eleven text sites but five fills (the pulsing status dots), so darkening the token would have moved the dots.

### 4. Fifteen state dims that made live text unreadable

`opacity-[0.62]` on inactive patients is the clearest: it took the breed line to **2.54:1** and the avatar initial to **2.34:1**, and on phone it sat on an **enabled `<button>`** - so an inactive patient looked disabled while staying fully tappable.

Every one of the fifteen was classified individually, and **not one was the only signal for its state** - each already had a status pill, a check icon, a strikethrough, a shadow drop, a dedicated icon, or a button already reading "Saving…". Six more are exempt with recorded reasons.

## How this was found, and what now stops it coming back

The guard grew three times, each time because it missed something real:

- it only read `.css`, so Tailwind dimming from the markup was invisible
- it only matched the numbered scale, so `opacity-[0.62]` slipped past
- it matched faint tokens on the **same line**, so an ancestor dim three hundred lines above its text was invisible

It now scans stylesheets and TSX, both opacity syntaxes, and at file level; heavy dims (≤65%) are checked everywhere because they sink any ink. Exemptions are recorded with reasons, keyed by file and opacity value rather than line number - a line key went stale mid-PR and silently re-hid a defect.

## Validation performed

- `type-check`, `lint` - clean
- ~1,000 tests across the affected suites - pass
- Every value measured against the darkest surface it can land on, and in both themes
- Theme round-trip verified in the browser (animation count and stuck-transition count)
- Storybook: **472 of 475** render clean; the three blanks are a closed sheet, a closed drawer and a guard mid-check
- Also fixes a pre-existing leak in the SessionInitializer test, which fired thirteen unmocked loaders into axios

## Known gaps

- The Paid/Unpaid chips measured at 2.28/2.29 on dev are **not** here - `--color-success-400` is only on two check icons in source, so that needs a measurement pass against the deployed build rather than a guess.
- In the Groomer org the "Pets" nav entry is rendered and clickable but always lands on Dashboard. Reproduced and org-specific; cause not yet traced, so it is not fixed here.
