### PR TITLE
fix(frontend): stop painting text with brand ramp steps, and render the date poppers in Storybook

### DIFF
--- a/apps/frontend/src/app/__tests__/components/Calendar/TaskCalendar.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/TaskCalendar.test.tsx
@@ -55,9 +55,15 @@ jest.mock('@/app/features/appointments/components/Calendar/PhoneTaskDayList', ()
 jest.mock('@/app/features/appointments/components/Calendar/common/Header', () => {
   return function MockHeader(props: any) {
     return (
-      <div data-testid="header">
+      <div
+        data-testid="header"
+        data-has-set-week-start={String(typeof props.setWeekStart === 'function')}
+      >
         Header - Current: {props.currentDate.toISOString()}
         <button onClick={() => props.setCurrentDate(new Date('2023-01-02'))}>Change Date</button>
+        <button onClick={() => props.setWeekStart?.(new Date('2023-01-09'))}>
+          Header Next Week
+        </button>
       </div>
     );
   };
@@ -343,6 +349,29 @@ describe('TaskCalendar Component', () => {
       fireEvent.click(screen.getByTestId('phone-view'));
       expect(mockSetActiveTask).toHaveBeenCalledWith(mockTasks[0]);
       expect(mockSetViewPopup).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('week navigation', () => {
+    // Header derives `navigatesByWeek` from `activeCalendar === 'week' &&
+    // !!setWeekStart`. TaskCalendar passed setWeekStart to TaskCalendarBody but
+    // NOT to Header, so on the Tasks week view the toolbar ran DAY navigation:
+    // the grid rolled forward one day at a time (Mon 17 - Sun 23 became
+    // Tue 18 - Mon 24) instead of moving a calendar week, and the buttons were
+    // labelled "Previous day" / "Next day" on a week view. Appointments passes
+    // it and pages Mon 17 -> Mon 24.
+    it('hands Header the week setter so the toolbar pages by week', () => {
+      render(<TaskCalendar {...defaultProps} activeCalendar="week" />);
+
+      expect(screen.getByTestId('header')).toHaveAttribute('data-has-set-week-start', 'true');
+    });
+
+    it('drives the same weekStart state the grid renders from', () => {
+      render(<TaskCalendar {...defaultProps} activeCalendar="week" />);
+
+      fireEvent.click(screen.getByText('Header Next Week'));
+
+      expect(mockSetWeekStart).toHaveBeenCalled();
     });
   });
 });

--- a/apps/frontend/src/app/__tests__/components/Calendar/common/HorizontalLines.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/common/HorizontalLines.test.tsx
@@ -73,7 +73,10 @@ describe('HorizontalLines Component', () => {
     expect(nowDot).toBeInTheDocument();
     expect(nowDot).toHaveClass('size-[7px]');
     expect(nowLine).toBeInTheDocument();
-    expect(nowLine?.getAttribute('style')).toContain('border-top-width: 2px');
+    // The 2px solid rule is a utility class now, not an inline style; only the
+    // themed colour and the opacity stay inline.
+    expect(nowLine).toHaveClass('border-t-2');
+    expect(nowLine?.getAttribute('style')).toContain('border-top-color: var(--blue)');
 
     // Check position
     const wrapper = nowDot?.parentElement;

--- a/apps/frontend/src/app/__tests__/components/Calendar/common/UserLabels.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/common/UserLabels.test.tsx
@@ -88,7 +88,9 @@ describe('UserLabels', () => {
 
     render(<UserLabels team={team} />);
 
-    expect(screen.getByText('Sam')).toHaveClass('text-(--color-primary-700)');
+    // --blue-text, not the 700 brand FILL step. 700 has no dark value, so the
+    // "this column is you" label sat at 2.50:1 on the dark header.
+    expect(screen.getByText('Sam')).toHaveClass('text-[var(--blue-text)]');
     // Other members take the frame's 13px/700 --ink column-header type (was 16px
     // /500 --ink-muted body type).
     expect(screen.getByText('Alex')).toHaveClass('text-[var(--ink)]', 'text-[13px]', 'font-bold');

--- a/apps/frontend/src/app/__tests__/components/DataTable/Appointments.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/DataTable/Appointments.test.tsx
@@ -219,7 +219,11 @@ describe('Appointments table', () => {
       />
     );
 
-    fireEvent.click(screen.getByTitle('Open appointment overview'));
+    // The name button used to carry title="Open appointment overview" - the same
+    // string on every row, which also overrode each button's accessible name. The
+    // title now holds the row's own name so a clipped cell can be read on hover,
+    // so select it the way a user would instead.
+    fireEvent.click(screen.getAllByRole('button', { name: /Buddy/ })[0]);
     openRowMenu('Buddy');
     fireEvent.click(screen.getByTestId('IoEyeOutline').closest('button')!);
     openRowMenu('Buddy');

--- a/apps/frontend/src/app/__tests__/components/DataTable/FormsTable.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/DataTable/FormsTable.test.tsx
@@ -306,8 +306,14 @@ describe('FormsTable Component', () => {
       expect(screen.getByText('Mass removal')).toBeInTheDocument();
     });
 
-    it('falls back to the raw id when a linked service is not in the options', () => {
-      const forms = [{ ...mockForms[0], services: ['svc-unknown'] }];
+    it('never prints the raw id when a linked service is not in the options', () => {
+      // This used to assert the opposite, with a friendly fixture id
+      // ('svc-unknown') that made the fallback look harmless. Real ids are
+      // 24-character ObjectIDs, so the live Templates page showed rows of hex
+      // where a service name belongs. The id is an internal identifier and
+      // means nothing to the reader.
+      const danglingId = '6970cb292a9f903dd2935813';
+      const forms = [{ ...mockForms[0], services: [danglingId] }];
       render(
         <FormsTable
           {...defaultProps}
@@ -317,7 +323,23 @@ describe('FormsTable Component', () => {
         />
       );
 
-      expect(screen.getByText('svc-unknown')).toBeInTheDocument();
+      expect(screen.queryByText(danglingId)).not.toBeInTheDocument();
+      expect(screen.getByText('Unavailable service')).toBeInTheDocument();
+    });
+
+    it('still resolves the services it can when one id dangles', () => {
+      const forms = [{ ...mockForms[0], services: ['svc-1', '6970cb292a9f903dd2935813'] }];
+      render(
+        <FormsTable
+          {...defaultProps}
+          filteredList={forms as any}
+          showLinkedServices
+          serviceOptions={serviceOptions}
+        />
+      );
+
+      expect(screen.getByText('Dental scale & polish')).toBeInTheDocument();
+      expect(screen.getByText('Unavailable service')).toBeInTheDocument();
     });
 
     it('renders a dash when a template has no linked services', () => {

--- a/apps/frontend/src/app/__tests__/components/DataTable/appointmentsTableColumns.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/DataTable/appointmentsTableColumns.test.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { buildAppointmentColumns, normalizeLeadId } from '@/app/ui/tables/appointmentsTableColumns';
+import type { Appointment } from '@yosemite-crew/types';
+
+const args = {
+  encountersById: {},
+  roomUnitsById: {},
+  leadNameByPractitionerId: {},
+  orgsById: {},
+  invoicesByAppointmentId: {},
+  canEditAppointments: true,
+  getSoapViewIntent: jest.fn(),
+  onViewAppointmentHistory: jest.fn(),
+  onViewAppointment: jest.fn(),
+  onChangeStatusAppointment: jest.fn(),
+  onCancelAppointment: jest.fn(),
+  onRescheduleAppointment: jest.fn(),
+  onChangeRoomAppointment: jest.fn(),
+  onWorkspaceAppointment: jest.fn(),
+} as unknown as Parameters<typeof buildAppointmentColumns>[0];
+
+const appointment = (over: Partial<Appointment> = {}): Appointment =>
+  ({
+    _id: 'apt-1',
+    isEmergency: false,
+    companion: { name: 'Lily', parent: { firstName: 'Marshal', lastName: 'Mathers' } },
+    ...over,
+  }) as unknown as Appointment;
+
+const renderNameCell = (item: Appointment) => {
+  const columns = buildAppointmentColumns(args);
+  const nameColumn = columns.find((c) => c.label === 'Name');
+  if (!nameColumn?.render) throw new Error('Name column has no render');
+  return render(<div>{nameColumn.render(item)}</div>);
+};
+
+describe('appointmentsTableColumns', () => {
+  describe('normalizeLeadId', () => {
+    it('returns an empty string for nullish input', () => {
+      expect(normalizeLeadId(null)).toBe('');
+      expect(normalizeLeadId(undefined)).toBe('');
+    });
+
+    it('trims a provided id', () => {
+      expect(normalizeLeadId('  abc  ')).toBe('abc');
+    });
+  });
+
+  describe('name cell', () => {
+    // The column is 140px and the Emergency chip takes half of it. Without a
+    // clamp, `.appointment-profile-title`'s `overflow-wrap: anywhere` broke the
+    // name mid-WORD - "Lily · Mathers" rendered as "Mather" / "s" over three
+    // lines. That rule is declared unlayered so Tailwind's `truncate` loses to
+    // it; the clamp has to be `cell-truncate`, which is declared alongside it.
+    it('clamps the name rather than letting it break mid-word', () => {
+      const { container } = renderNameCell(appointment());
+      const name = container.querySelector('.appointment-profile-title.cell-name');
+
+      expect(name).toBeInTheDocument();
+      expect(name).toHaveClass('cell-truncate');
+      expect(name).toHaveClass('min-w-0');
+    });
+
+    it('keeps the emergency chip at its own size so it cannot squeeze the name', () => {
+      const { container, getByText } = renderNameCell(appointment({ isEmergency: true }));
+
+      expect(getByText('Emergency')).toHaveClass('shrink-0');
+      // The flex row itself must be shrinkable or min-w-0 on the child does nothing.
+      expect(container.querySelector('.flex.min-w-0.items-center')).toBeInTheDocument();
+    });
+
+    it('exposes the full name as a title, since the visible text may be clipped', () => {
+      const { container } = renderNameCell(appointment());
+      const name = container.querySelector('.appointment-profile-title.cell-name');
+
+      expect(name?.getAttribute('title')).toContain('Lily');
+      expect(name?.getAttribute('title')).not.toBe('Open appointment overview');
+    });
+
+    it('renders no emergency chip on an ordinary appointment', () => {
+      const { queryByText } = renderNameCell(appointment());
+      expect(queryByText('Emergency')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/frontend/src/app/__tests__/ui/tokens/appScopeAliasClosure.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/tokens/appScopeAliasClosure.test.ts
@@ -407,6 +407,37 @@ describe('faint-ink alias closure is mirrored into the app scope', () => {
     expect(offenders).toEqual([]);
   });
 
+  it('never paints text with a brand ramp step that has no dark value', () => {
+    // --color-primary-* and --color-brand-* are FILL steps. Only the 100 tint has
+    // a dark value; the rest are declared once at :root, so as an ink they keep
+    // their light-mode blue on a dark surface. That is how the calendar label
+    // marking "this column is you" reached 2.50:1, the appointment avatar's
+    // initials 1.60, and the date picker's selected day 4.04 under white.
+    // --blue-text is the ink-tuned member of the family and inverts properly;
+    // --blue-strong is the fill to use when a label sits ON the blue.
+    const AS_INK =
+      /\btext-\(--color-(?:primary|brand)-\d+\)|\btext-(?:primary|brand)-\d{3}\b|(?<![-\w])color:\s*'?var\(--color-(?:primary|brand)-\d+\)/;
+
+    const root = path.join(process.cwd(), 'src/app');
+    const offenders: string[] = [];
+    for (const file of fs
+      .readdirSync(root, { recursive: true, encoding: 'utf8' })
+      .filter((f) => /\.(tsx|css)$/.test(f))
+      .filter((f) => !f.includes('__tests__'))) {
+      fs.readFileSync(path.join(root, file), 'utf8')
+        .split('\n')
+        .forEach((line, i) => {
+          const trimmed = line.trimStart();
+          if (trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*'))
+            return;
+          const m = AS_INK.exec(line);
+          if (m) offenders.push(`${file}:${i + 1}  ${m[0]}`);
+        });
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
   it('never puts a theme transition on every element', () => {
     // `[data-yc-app] *` and `[data-yc-theme] *` each transitioned four properties
     // on EVERY element. A theme flip started ~700 simultaneous transitions, and

--- a/apps/frontend/src/app/__tests__/ui/tokens/appScopeAliasClosure.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/tokens/appScopeAliasClosure.test.ts
@@ -438,6 +438,35 @@ describe('faint-ink alias closure is mirrored into the app scope', () => {
     expect(offenders).toEqual([]);
   });
 
+  it('lets the button primitive own its height, padding and gap', () => {
+    // The four list/board/calendar toolbars each restated the Primary button's
+    // geometry in their own className, and had drifted into three different
+    // buttons: h-12 in Filters (48px) against h-10 everywhere else, with px-4/
+    // gap-2 in two of them against the design's px-[18px]/gap-[7px]. The one
+    // that ended up 8px taller than every other CTA in the product was the
+    // Appointments list "New appointment" button. Height, horizontal padding and
+    // label size travel together per size in Primary's sizeClasses, so a caller
+    // overriding one of them is overriding a set.
+    const GEOMETRY = /\bh-1[0-2]!?\b|\bpx-\[?\d/;
+
+    const root = path.join(process.cwd(), 'src/app');
+    const offenders: string[] = [];
+    for (const file of fs
+      .readdirSync(root, { recursive: true, encoding: 'utf8' })
+      .filter((f) => /\.tsx$/.test(f))
+      .filter((f) => !f.includes('__tests__') && !f.includes('.stories.'))) {
+      const src = fs.readFileSync(path.join(root, file), 'utf8');
+      // Only the toolbar add buttons: a <Primary> carrying the shared nowrap marker.
+      src.split('\n').forEach((line, i) => {
+        if (!line.includes('whitespace-nowrap hover:scale-100')) return;
+        const m = GEOMETRY.exec(line);
+        if (m) offenders.push(`${file}:${i + 1}  ${m[0]}`);
+      });
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
   it('never puts a theme transition on every element', () => {
     // `[data-yc-app] *` and `[data-yc-theme] *` each transitioned four properties
     // on EVERY element. A theme flip started ~700 simultaneous transitions, and

--- a/apps/frontend/src/app/features/appointments/components/AppointmentBoardToolbar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/AppointmentBoardToolbar.tsx
@@ -113,7 +113,7 @@ const AppointmentBoardToolbar = ({
                 text="New appointment"
                 onClick={onAddAppointment}
                 icon={<IoAdd size={18} aria-hidden="true" />}
-                className="h-10 w-fit shrink-0 justify-center gap-[7px] px-[18px] py-0 text-[13.5px] font-semibold whitespace-nowrap hover:scale-100"
+                className="w-fit shrink-0 justify-center py-0 whitespace-nowrap hover:scale-100"
               />
             </>
           )}

--- a/apps/frontend/src/app/features/appointments/components/AppointmentCentralModal/AppointmentAvatar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/AppointmentCentralModal/AppointmentAvatar.tsx
@@ -39,7 +39,10 @@ const AppointmentAvatar = ({ name, photoUrl, size = 32 }: AppointmentAvatarProps
     >
       <span
         style={{
-          color: 'var(--color-primary-700)',
+          // --blue-text, not the 700 fill step: --color-primary-100 under it DOES
+          // have a dark value (a 16% tint that composites dark), so the fixed dark
+          // blue left these initials at 1.6:1 in dark.
+          color: 'var(--blue-text)',
           fontSize: 12,
           fontWeight: 500,
           fontFamily: 'var(--font-satoshi), sans-serif',

--- a/apps/frontend/src/app/features/appointments/components/AppointmentStatusPill.tsx
+++ b/apps/frontend/src/app/features/appointments/components/AppointmentStatusPill.tsx
@@ -156,7 +156,7 @@ const AppointmentStatusPill = ({
             data-popover-panel="true"
             role="menu"
             onPointerDown={(e) => e.stopPropagation()}
-            className="rounded-2xl! bg-neutral-0 shadow-[0_8px_24px_rgba(0,0,0,0.12)] overflow-hidden whitespace-nowrap"
+            className="rounded-2xl! bg-neutral-0 shadow-[0_8px_24px_var(--sh12)] overflow-hidden whitespace-nowrap"
             style={{
               ...menuStyle,
               minWidth: 120,

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/DayCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/DayCalendar.tsx
@@ -200,13 +200,8 @@ const DayCalendar = ({
                       style={{ backgroundColor: 'var(--blue)' }}
                     />
                     <div
-                      className="translate-y-[-50%]"
-                      style={{
-                        borderTopWidth: '2px',
-                        borderTopStyle: 'solid',
-                        borderTopColor: 'var(--blue)',
-                        opacity: 0.75,
-                      }}
+                      className="translate-y-[-50%] border-t-2 border-solid"
+                      style={{ borderTopColor: 'var(--blue)', opacity: 0.75 }}
                     />
                   </div>
                 </div>

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/DayCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/DayCalendar.tsx
@@ -183,13 +183,31 @@ const DayCalendar = ({
                       top: nowPosition.topPx,
                     }}
                   >
+                    {/* Matches common/HorizontalLines.tsx:102-125, which this page's own
+                        Team tab already renders. The now-line was red here, red-but-a
+                        different-red on the Week tab, and blue on Team, so the same page
+                        changed the colour of the same line between its own tabs. */}
                     {nowTimeLabel && (
-                      <div className="absolute left-3 -translate-y-[115%] text-[10px] leading-none font-semibold text-danger-700 whitespace-nowrap">
+                      <div
+                        className="absolute left-3 -translate-y-[115%] text-[10px] leading-none font-semibold whitespace-nowrap"
+                        style={{ color: 'var(--blue-text)' }}
+                      >
                         {nowTimeLabel}
                       </div>
                     )}
-                    <div className="absolute left-[-5px] size-3 rounded-full bg-danger-700 translate-y-[-50%]" />
-                    <div className="border-t-2 border-t-danger-700 translate-y-[-50%]" />
+                    <div
+                      className="absolute left-[-5px] size-[7px] rounded-full translate-y-[-50%]"
+                      style={{ backgroundColor: 'var(--blue)' }}
+                    />
+                    <div
+                      className="translate-y-[-50%]"
+                      style={{
+                        borderTopWidth: '2px',
+                        borderTopStyle: 'solid',
+                        borderTopColor: 'var(--blue)',
+                        opacity: 0.75,
+                      }}
+                    />
                   </div>
                 </div>
               </div>

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/DayCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/DayCalendar.tsx
@@ -99,7 +99,7 @@ const DayCalendar = ({
       <div className="flex items-center justify-between p-2 border-b border-card-border">
         <Back onClick={handlePrevDay} />
         <div className="flex items-center gap-2 text-center">
-          <div className="text-body-4 text-(--color-primary-700)">{weekday}</div>
+          <div className="text-body-4 text-[var(--blue-text)]">{weekday}</div>
           <div className="text-body-4-emphasis text-white size-10 flex items-center justify-center rounded-full bg-[var(--blue-strong)]">
             {dateNumber}
           </div>

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/DayLabels.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/DayLabels.tsx
@@ -28,7 +28,7 @@ const DayLabels = ({ days, currentDate, columnsStyle }: DayLabels) => {
         return (
           <div key={idx + day.getDate()} className="flex items-center justify-center gap-2">
             <div
-              className={`text-body-4 ${isToday ? 'text-(--color-primary-700)' : 'text-text-primary'}`}
+              className={`text-body-4 ${isToday ? 'text-[var(--blue-text)]' : 'text-text-primary'}`}
             >
               {weekday}
             </div>

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/DayLabels.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/DayLabels.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
-import { isOnPreferredTimeZoneCalendarDay } from '@/app/lib/timezone';
+import {
+  formatDateInPreferredTimeZone,
+  isOnPreferredTimeZoneCalendarDay,
+} from '@/app/lib/timezone';
 
 type DayLabels = {
   days: Date[];
@@ -17,9 +20,11 @@ const DayLabels = ({ days, currentDate, columnsStyle }: DayLabels) => {
       suppressHydrationWarning
     >
       {days.map((day, idx) => {
-        const weekday = day.toLocaleDateString('en-US', {
-          weekday: 'short',
-        });
+        // The preferred zone, not the browser's. isToday below already uses it,
+        // and the Appointments week header does too (common/WeekCalendar.tsx:195),
+        // so a user whose browser zone differs from the org's could see the same
+        // column labelled Tue on one calendar and Mon on the other.
+        const weekday = formatDateInPreferredTimeZone(day, { weekday: 'short' });
         const dateNumber = day.getDate();
         const isToday = isOnPreferredTimeZoneCalendarDay(new Date(), day);
         const dateNumberClass = isToday

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/TaskSlot.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/TaskSlot.tsx
@@ -90,17 +90,25 @@ const TaskSlotGridLines = ({
   slotOffsetMinutes: number[];
   isLastVisibleHour: boolean;
 }) => (
+  // The same rules as common/SlotGridLines.tsx:14-15, which this file's own Week
+  // and Team views already render. This private copy was still on the pre-redesign
+  // cool ramp: --color-calendar-line-soft is #e9edf3, a COOL grey on the warm bone
+  // ground in light, and #302820 in dark - 1.01:1 on the slot surface, so the
+  // sub-hour rules simply were not there.
   <div className="pointer-events-none absolute inset-0 z-[5]">
-    <div className="absolute inset-x-0 top-0 border-t border-[var(--color-calendar-line-strong)]" />
+    <div className="absolute inset-x-0 top-0 border-t border-[var(--hairline)]" />
     {slotOffsetMinutes.map((minute) => (
       <div
         key={`task-slot-grid-${hour}-${minute}`}
-        className="absolute inset-x-0 border-t border-[var(--color-calendar-line-soft)]"
-        style={{ top: `${(minute / 60) * 100}%` }}
+        className="absolute inset-x-0 border-t"
+        style={{
+          top: `${(minute / 60) * 100}%`,
+          borderTopColor: 'color-mix(in srgb, var(--hairline) 55%, transparent)',
+        }}
       />
     ))}
     {isLastVisibleHour && (
-      <div className="absolute inset-x-0 top-full border-t border-[var(--color-calendar-line-strong)]" />
+      <div className="absolute inset-x-0 top-full border-t border-[var(--hairline)]" />
     )}
   </div>
 );

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/WeekCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/WeekCalendar.tsx
@@ -268,13 +268,8 @@ const WeekCalendar: React.FC<WeekCalendarProps> = ({
                                 style={{ backgroundColor: 'var(--blue)' }}
                               />
                               <div
-                                className="translate-y-[-50%]"
-                                style={{
-                                  borderTopWidth: '2px',
-                                  borderTopStyle: 'solid',
-                                  borderTopColor: 'var(--blue)',
-                                  opacity: 0.75,
-                                }}
+                                className="translate-y-[-50%] border-t-2 border-solid"
+                                style={{ borderTopColor: 'var(--blue)', opacity: 0.75 }}
                               />
                             </div>
                           )}

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/WeekCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/WeekCalendar.tsx
@@ -258,23 +258,22 @@ const WeekCalendar: React.FC<WeekCalendarProps> = ({
                               {nowTimeLabel && (
                                 <div
                                   className="absolute left-3 -translate-y-[115%] text-[10px] leading-none font-semibold whitespace-nowrap"
-                                  // --danger-text, not the 700 fill: at 10px on
-                                  // the calendar ground the fill read 4.00:1.
-                                  style={{ color: 'var(--danger-text)' }}
+                                  style={{ color: 'var(--blue-text)' }}
                                 >
                                   {nowTimeLabel}
                                 </div>
                               )}
                               <div
-                                className="absolute -left-1.25 size-3 rounded-full translate-y-[-50%]"
-                                style={{ backgroundColor: 'var(--color-danger-700)' }}
+                                className="absolute -left-1.25 size-[7px] rounded-full translate-y-[-50%]"
+                                style={{ backgroundColor: 'var(--blue)' }}
                               />
                               <div
                                 className="translate-y-[-50%]"
                                 style={{
                                   borderTopWidth: '2px',
                                   borderTopStyle: 'solid',
-                                  borderTopColor: 'var(--color-danger-700)',
+                                  borderTopColor: 'var(--blue)',
+                                  opacity: 0.75,
                                 }}
                               />
                             </div>

--- a/apps/frontend/src/app/features/appointments/components/Calendar/TaskCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/TaskCalendar.tsx
@@ -162,10 +162,31 @@ const TaskCalendar = ({
 
   return (
     <>
-      <div className="border border-card-border rounded-2xl size-full min-h-0 flex flex-col overflow-hidden">
+      {/* The same lifted card as AppointmentCalendar.tsx:245-251. This painted no
+          surface at all, so --page showed through the 64px time gutter and the
+          side padding while the slots painted --neutral-0 on top: the Tasks grid
+          read as a two-tone unpainted region while Appointments read as a card.
+          The phone branch above is left alone - it already matches the phone
+          branch on the Appointments side, which is also bordered with no fill. */}
+      <div
+        className="size-full min-h-0 flex flex-col overflow-hidden rounded-[18px] border"
+        style={{
+          borderColor: 'var(--hairline)',
+          backgroundColor: 'var(--screen)',
+          boxShadow: '0 1px 2px var(--sh03), 0 8px 22px var(--sh05)',
+        }}
+      >
         <Header
           currentDate={currentDate}
           setCurrentDate={setCurrentDate}
+          // Header derives `navigatesByWeek` from `activeCalendar === 'week' &&
+          // !!setWeekStart`. Without this prop it stayed false on the Tasks WEEK
+          // view, so the toolbar chevrons ran day navigation: the grid rolled
+          // forward one day at a time (Mon 17 - Sun 23 became Tue 18 - Mon 24)
+          // instead of moving a calendar week, and the buttons were labelled
+          // "Previous day" / "Next day" on a week view. Appointments passes it
+          // (AppointmentCalendar.tsx:256) and pages Mon 17 -> Mon 24 correctly.
+          setWeekStart={setWeekStart}
           zoomMode={zoomMode}
           setZoomMode={setZoomMode}
           activeCalendar={activeCalendar}

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/Header.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/Header.tsx
@@ -493,7 +493,7 @@ const Header = ({
                 text="New appointment"
                 onClick={onAddButtonClick}
                 icon={<IoAdd size={16} aria-hidden="true" />}
-                className="h-10 w-fit shrink-0 justify-center gap-[7px] px-[18px] py-0 text-[13.5px] font-semibold whitespace-nowrap hover:scale-100"
+                className="w-fit shrink-0 justify-center py-0 whitespace-nowrap hover:scale-100"
               />
             </>
           )}

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/HorizontalLines.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/HorizontalLines.tsx
@@ -114,13 +114,8 @@ const HorizontalLines = ({
             style={{ backgroundColor: 'var(--blue)' }}
           />
           <div
-            className="translate-y-[-50%]"
-            style={{
-              borderTopWidth: '2px',
-              borderTopStyle: 'solid',
-              borderTopColor: 'var(--blue)',
-              opacity: 0.75,
-            }}
+            className="translate-y-[-50%] border-t-2 border-solid"
+            style={{ borderTopColor: 'var(--blue)', opacity: 0.75 }}
           />
         </div>
       )}

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/MenuActionsList.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/MenuActionsList.tsx
@@ -24,7 +24,9 @@ const MenuActionsList = ({
   <div className="flex flex-col gap-0.5">
     {actions.map((action, index) => (
       <React.Fragment key={action.key}>
-        {index > 0 ? <div className="mx-1 border-t border-white/30" aria-hidden="true" /> : null}
+        {index > 0 ? (
+          <div className="mx-1 border-t border-[var(--hairline)]" aria-hidden="true" />
+        ) : null}
         <button
           ref={(element) => {
             itemRefs.current[action.key] = element;

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/RoomSubmenu.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/RoomSubmenu.tsx
@@ -31,7 +31,7 @@ const RoomSubmenu = ({ submenuRef, submenuStyle, roomOptions, savingKey }: RoomS
           return (
             <React.Fragment key={room.key}>
               {index > 0 ? (
-                <div className="mx-1 border-t border-white/30" aria-hidden="true" />
+                <div className="mx-1 border-t border-[var(--hairline)]" aria-hidden="true" />
               ) : null}
               <button
                 type="button"

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/StatusSubmenu.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/StatusSubmenu.tsx
@@ -29,7 +29,9 @@ const StatusSubmenu = ({
     <div className="flex flex-col gap-0.5">
       {statusOptions.map((status, index) => (
         <React.Fragment key={status}>
-          {index > 0 ? <div className="mx-1 border-t border-white/30" aria-hidden="true" /> : null}
+          {index > 0 ? (
+            <div className="mx-1 border-t border-[var(--hairline)]" aria-hidden="true" />
+          ) : null}
           <button
             type="button"
             role="menuitem"

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/UserLabels.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/UserLabels.tsx
@@ -66,7 +66,12 @@ const UserLabels = ({ team, columnsStyle }: UserLabels) => {
             )}
             <div className="min-w-0">
               <div
-                className={`truncate text-[13px] font-bold leading-[1.2] ${isCurrentUser ? 'text-(--color-primary-700)' : 'text-[var(--ink)]'}`}
+                // --blue-text, not --color-primary-700. The 700 step is a brand FILL
+                // declared once at :root with no dark value, so the label marking
+                // "this column is you" stayed #0057c2 on the dark #221d17 header:
+                // 2.50:1. --blue-text is the ink-tuned member of the family and
+                // inverts to #8fb6f5 in dark (8.10:1).
+                className={`truncate text-[13px] font-bold leading-[1.2] ${isCurrentUser ? 'text-[var(--blue-text)]' : 'text-[var(--ink)]'}`}
               >
                 {name}
               </div>

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/LabTests.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/LabTests.tsx
@@ -1281,7 +1281,7 @@ const IdexxOrderIframeOverlay = ({ url, title, onClose }: IdexxOrderIframeOverla
       style={{ pointerEvents: 'auto' }}
     >
       <div className="relative bg-neutral-0 rounded-2xl shadow-2xl size-full max-w-7xl max-h-[95vh] flex flex-col overflow-hidden">
-        <div className="flex items-center justify-between px-4 py-2 border-b border-black/10">
+        <div className="flex items-center justify-between px-4 py-2 border-b border-card-border">
           <div className="flex flex-col">
             <div className="text-body-2 text-text-primary">{title}</div>
             {isFollowUp ? (
@@ -1294,7 +1294,7 @@ const IdexxOrderIframeOverlay = ({ url, title, onClose }: IdexxOrderIframeOverla
           <button
             type="button"
             onClick={onClose}
-            className="p-2 hover:bg-black/5 rounded-full transition-colors cursor-pointer"
+            className="p-2 hover:bg-card-hover rounded-full transition-colors cursor-pointer"
             aria-label="Close IDEXX order frame"
             style={{ pointerEvents: 'auto' }}
           >

--- a/apps/frontend/src/app/features/tasks/components/TaskFilterBar.tsx
+++ b/apps/frontend/src/app/features/tasks/components/TaskFilterBar.tsx
@@ -155,7 +155,7 @@ const TaskFilterBar = ({
           text={addButtonText}
           onClick={onAddButtonClick}
           icon={<IoAdd size={18} aria-hidden="true" />}
-          className="h-10 w-fit justify-center gap-2 px-4 py-0 whitespace-nowrap hover:scale-100"
+          className="w-fit shrink-0 justify-center py-0 whitespace-nowrap hover:scale-100"
         />
       )}
     </div>

--- a/apps/frontend/src/app/features/tasks/pages/Tasks/index.tsx
+++ b/apps/frontend/src/app/features/tasks/pages/Tasks/index.tsx
@@ -338,7 +338,7 @@ const Tasks = () => {
                 icon={<IoAdd size={16} aria-hidden="true" />}
                 // The design seats the CTA after the view toggle; this slot
                 // renders before it, so flex order restores that sequence.
-                className="order-1 gap-[7px] px-[18px] whitespace-nowrap hover:scale-100"
+                className="order-1 whitespace-nowrap hover:scale-100"
               />
             ) : undefined
           }

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -1619,8 +1619,12 @@ input[type='number'] {
   border-radius: 8px !important;
 }
 
+/* --ink-faint, not the 200 ramp step. neutral-200 is the HAIRLINE value: as text
+   it measured 1.11:1 in light and 1.44 in dark, so the twelve adjacent-month days
+   filling the grid were invisible - and they are clickable, so WCAG 1.4.3 does
+   not exempt them the way it does the disabled rule below. */
 .yc-datepicker-calendar .react-datepicker__day--outside-month {
-  color: var(--color-neutral-200);
+  color: var(--ink-faint);
 }
 
 .yc-datepicker-calendar

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -343,7 +343,11 @@ textarea:focus-visible {
   --color-state-selected: var(--color-neutral-950);
 
   --color-input-text-placeholder: var(--color-neutral-700);
-  --color-input-text-placeholder-active: var(--color-brand-950);
+  /* An ink, so it takes the ink-tuned blue. --color-brand-950 is the brand FILL
+     (#007cf5) with no dark value, which left the active field's placeholder at
+     3.16:1 on the dark field. The border below stays the fill: it is a non-text
+     boundary and clears its 3:1 in both themes. */
+  --color-input-text-placeholder-active: var(--blue-text);
   --color-input-border-default: var(--color-neutral-200);
   --color-input-border-error: var(--color-danger-600);
   --color-input-border-active: var(--color-brand-950);
@@ -1381,7 +1385,7 @@ input[type='number'] {
   }
 
   .text-yc-14-b-primary {
-    color: var(--color-primary-600);
+    color: var(--blue-text);
     font-family: var(--font-satoshi);
     font-size: 14px;
     font-style: normal;
@@ -1411,7 +1415,7 @@ input[type='number'] {
   }
 
   .text-yc-16-b-primary {
-    color: var(--color-primary-600);
+    color: var(--blue-text);
     font-family: var(--font-satoshi);
     font-size: 16px;
     font-style: normal;
@@ -1421,7 +1425,7 @@ input[type='number'] {
   }
 
   .text-yc-20-b-primary {
-    color: var(--color-primary-600);
+    color: var(--blue-text);
     font-family: var(--font-satoshi);
     font-size: 20px;
     font-style: normal;
@@ -1633,16 +1637,21 @@ input[type='number'] {
   color: var(--color-text-primary);
 }
 
+/* --blue-text over a tint mixed into the SURFACE, not into literal white.
+   --color-brand-950 is the brand fill (#007cf5) and has no dark value, and the
+   8%-of-white tint stayed near-white in dark, so "today" in the appointment
+   date picker was a fixed blue on a fixed white chip inside a dark modal. */
 .yc-datepicker-calendar .react-datepicker__day--today:not(.react-datepicker__day--selected) {
   font-weight: 600;
-  color: var(--color-brand-950);
-  background-color: color-mix(in srgb, var(--color-brand-950) 8%, white);
+  color: var(--blue-text);
+  background-color: color-mix(in srgb, var(--blue-text) 12%, var(--neutral-0, var(--screen)));
   border-radius: 8px !important;
 }
 
 .yc-datepicker-calendar .react-datepicker__day--selected {
-  background-color: var(--color-brand-950) !important;
-  color: #ffffff !important;
+  /* --blue-strong, not the brand fill: white on #007cf5 is 4.04:1. */
+  background-color: var(--blue-strong) !important;
+  color: var(--white-text) !important;
   font-weight: 600;
   border-radius: 8px !important;
 }
@@ -1682,8 +1691,9 @@ input[type='number'] {
 }
 
 .yc-datepicker-calendar .react-datepicker__time-list-item--selected {
-  background-color: var(--color-brand-950) !important;
-  color: #ffffff !important;
+  /* --blue-strong, not the brand fill: white on #007cf5 is 4.04:1. */
+  background-color: var(--blue-strong) !important;
+  color: var(--white-text) !important;
   font-weight: 600;
 }
 

--- a/apps/frontend/src/app/ui/filters/Filters/index.tsx
+++ b/apps/frontend/src/app/ui/filters/Filters/index.tsx
@@ -233,7 +233,7 @@ const Filters = ({
             text={addButtonText}
             onClick={onAddButtonClick}
             icon={<IoAdd size={18} aria-hidden="true" />}
-            className="h-12 w-fit justify-center gap-2 px-4 py-0 whitespace-nowrap hover:scale-100"
+            className="w-fit shrink-0 justify-center py-0 whitespace-nowrap hover:scale-100"
           />
         )}
       </div>

--- a/apps/frontend/src/app/ui/inputs/Datepicker/Datepicker.stories.tsx
+++ b/apps/frontend/src/app/ui/inputs/Datepicker/Datepicker.stories.tsx
@@ -1,5 +1,6 @@
 import { useState, type ComponentProps } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent } from 'storybook/test';
 import Datepicker from './index';
 
 const StatefulDatepicker = (args: ComponentProps<typeof Datepicker>) => {
@@ -58,4 +59,29 @@ export const IconOnly: Story = {
 
 export const WithError: Story = {
   args: { error: 'Select a valid date.' },
+};
+
+export const OpenCalendar: Story = {
+  name: 'Calendar open',
+  args: { currentDate: new Date(2024, 5, 12) },
+  parameters: {
+    docs: {
+      story:
+        'The popper itself, which nothing else in this file renders. Every rule that styles ' +
+        'the calendar lives behind a click, so the panel was invisible to Storybook and to ' +
+        'Chromatic - four of its colours were wrong and no story could have caught it. The ' +
+        'selected day and the selected time were `--color-brand-950`, the brand FILL, under ' +
+        'white at 4.04:1, and "today" was that same blue on a chip mixed into literal white, ' +
+        'so it stayed a white chip inside a dark modal. They now use `--blue-strong` with ' +
+        '`--white-text`, and `--blue-text` over a tint mixed into the surface.',
+    },
+  },
+  play: async ({ canvasElement }) => {
+    // The trigger is react-datepicker's customInput, which is a BUTTON here -
+    // there is no textbox to query.
+    const trigger = canvasElement.querySelector('button');
+    await userEvent.click(trigger as HTMLElement);
+    // The popper portals out of the canvas, so assert against the document.
+    await expect(document.querySelector('.yc-datepicker-calendar')).toBeInTheDocument();
+  },
 };

--- a/apps/frontend/src/app/ui/inputs/Timepicker/Timepicker.stories.tsx
+++ b/apps/frontend/src/app/ui/inputs/Timepicker/Timepicker.stories.tsx
@@ -1,5 +1,6 @@
 import { useState, type ComponentProps } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent } from 'storybook/test';
 import Timepicker from './index';
 
 const StatefulTimepicker = (args: ComponentProps<typeof Timepicker>) => {
@@ -52,4 +53,24 @@ export const WithValue: Story = {
 
 export const WithError: Story = {
   args: { error: 'Select a time.' },
+};
+
+export const OpenList: Story = {
+  name: 'Time list open',
+  args: { value: '09:30' },
+  parameters: {
+    docs: {
+      story:
+        'The time list, which only exists after a click and so was never rendered in ' +
+        'Storybook. Its selected row carried white on the brand fill `--color-brand-950` at ' +
+        '4.04:1; it uses `--blue-strong` with `--white-text` now.',
+    },
+  },
+  play: async ({ canvasElement }) => {
+    // The trigger is react-datepicker's customInput, which is a BUTTON here -
+    // there is no textbox to query.
+    const trigger = canvasElement.querySelector('button');
+    await userEvent.click(trigger as HTMLElement);
+    await expect(document.querySelector('.yc-datepicker-calendar')).toBeInTheDocument();
+  },
 };

--- a/apps/frontend/src/app/ui/tables/FormsTable.stories.tsx
+++ b/apps/frontend/src/app/ui/tables/FormsTable.stories.tsx
@@ -1,0 +1,122 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import type { FormsProps } from '@/app/features/forms/types/forms';
+import FormsTable from './FormsTable';
+
+const SERVICE_OPTIONS = [
+  { label: 'Skin & coat examination', value: 'svc-skin' },
+  { label: 'Anal Gland Expression', value: 'svc-glands' },
+  { label: 'Testing Service', value: 'svc-testing' },
+];
+
+const template = (over: Partial<FormsProps>): FormsProps =>
+  ({
+    _id: 'tpl-1',
+    name: 'Consent general practice',
+    description: 'Consent form for general practice visits',
+    category: 'Consent form',
+    usage: 'Appointment',
+    updatedBy: 'Tim Apple',
+    lastUpdated: '2026-07-18T09:00:00.000Z',
+    status: 'PUBLISHED',
+    schema: [],
+    services: [],
+    ...over,
+  }) as FormsProps;
+
+const ROWS: FormsProps[] = [
+  template({ _id: 'tpl-1', services: ['svc-skin'] }),
+  template({
+    _id: 'tpl-2',
+    name: 'Prescription skin',
+    description: 'sample desc skin medicine',
+    category: 'Prescription',
+    services: ['svc-skin', 'svc-glands'],
+  }),
+  template({
+    _id: 'tpl-3',
+    name: 'SOAP - General Consult',
+    description: 'Clinical note',
+    category: 'SOAP',
+    services: ['6970cb292a9f903dd2935813'],
+    status: 'DRAFT',
+  }),
+  template({
+    _id: 'tpl-4',
+    name: 'Discharge Form',
+    description: 'Discharge',
+    category: 'Discharge Form',
+    services: [],
+    status: 'ARCHIVED',
+  }),
+];
+
+const meta = {
+  title: 'Tables/FormsTable',
+  component: FormsTable,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The Templates list. `showLinkedServices` opts into the chips column, which resolves ' +
+          "each template's `services` ids through `serviceOptions`.\n\n" +
+          'That resolution is the reason this file exists. An id with no matching option - a ' +
+          'service that was deleted, or that belongs to another organisation - used to fall ' +
+          'back to rendering the id itself, so the live Templates page showed rows of ' +
+          '24-character ObjectIDs where a service name belongs. The third row below carries ' +
+          'exactly that: one resolvable service and one dangling id. The id is an internal ' +
+          'identifier and means nothing to the reader, so it is not shown at all now.\n\n' +
+          'The actions column was also 64px, which fitted its `...` button but not its own ' +
+          'header - the column read "ACTIO…". It is 88px.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    filteredList: ROWS,
+    setActiveForm: fn(),
+    setViewPopup: fn(),
+    showLinkedServices: true,
+    serviceOptions: SERVICE_OPTIONS,
+  },
+} satisfies Meta<typeof FormsTable>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Templates list',
+};
+
+export const DanglingService: Story = {
+  name: 'Linked service that no longer resolves',
+  args: { filteredList: [ROWS[2]] },
+  parameters: {
+    docs: {
+      story:
+        'The regression guard. `serviceOptions` has no entry for this id, so the chip has to ' +
+        'read as unavailable rather than printing the identifier.',
+    },
+  },
+};
+
+export const WithoutLinkedServices: Story = {
+  name: 'Column off (other callers)',
+  args: { showLinkedServices: false, serviceOptions: undefined },
+  parameters: {
+    docs: {
+      story:
+        'The table is shared. With the opt-in off the columns are exactly what every other ' +
+        'caller renders.',
+    },
+  },
+};
+
+export const Loading: Story = {
+  args: { filteredList: [], loading: true },
+};
+
+export const Empty: Story = {
+  args: { filteredList: [] },
+};

--- a/apps/frontend/src/app/ui/tables/FormsTable.tsx
+++ b/apps/frontend/src/app/ui/tables/FormsTable.tsx
@@ -176,7 +176,7 @@ const FormsTable = ({
     {
       label: 'Actions',
       key: 'actions',
-      width: '64px',
+      width: '88px',
       render: (item: FormsProps) => (
         <div className="flex justify-center">
           <button
@@ -207,14 +207,24 @@ const FormsTable = ({
         }
         return (
           <div className="flex flex-wrap gap-1.5">
-            {serviceIds.map((id) => (
-              <span
-                key={id}
-                className="inline-flex items-center rounded-full! bg-[var(--inset)] px-2.5 py-[3px] text-[11px] font-semibold text-[var(--ink-body)]"
-              >
-                {serviceNameById.get(id) ?? id}
-              </span>
-            ))}
+            {serviceIds.map((id) => {
+              // A linked service that is no longer in serviceOptions - deleted, or
+              // owned by another organisation - used to fall back to the raw id, so
+              // the Templates list showed rows of 24-character ObjectIDs where a
+              // service name belongs. The id means nothing to the reader and is an
+              // internal identifier, so it is not shown at all.
+              const name = serviceNameById.get(id);
+              return (
+                <span
+                  key={id}
+                  className={`inline-flex items-center rounded-full! bg-[var(--inset)] px-2.5 py-[3px] text-[11px] font-semibold ${
+                    name ? 'text-[var(--ink-body)]' : 'italic text-[var(--ink-faint)]'
+                  }`}
+                >
+                  {name ?? 'Unavailable service'}
+                </span>
+              );
+            })}
           </div>
         );
       },

--- a/apps/frontend/src/app/ui/tables/appointmentsTableColumns.tsx
+++ b/apps/frontend/src/app/ui/tables/appointmentsTableColumns.tsx
@@ -106,16 +106,26 @@ export const buildAppointmentColumns = ({
     render: (item: Appointment) => (
       <div className="appointment-profile">
         <div className="appointment-profile-two">
-          <div className="flex items-center gap-1.5">
+          {/* min-w-0 + cell-truncate: the row is 140px and the Emergency chip takes
+              half of it, so on an emergency the name had nothing left and
+              `.appointment-profile-title`'s `overflow-wrap: anywhere` broke it
+              mid-word - "Lily · Mathers" rendered as "Mather" / "s" over three
+              lines. The chip keeps its size and the name ellipses instead. */}
+          <div className="flex min-w-0 items-center gap-1.5">
             <button
               type="button"
               onClick={() => onViewAppointmentHistory(item)}
-              className="appointment-profile-title cell-name cursor-pointer hover:underline underline-offset-2 text-left"
-              title="Open appointment overview"
+              className="appointment-profile-title cell-name cell-truncate min-w-0 cursor-pointer hover:underline underline-offset-2 text-left"
+              title={formatCompanionNameWithOwnerLastName(
+                item?.companion?.name,
+                item?.companion?.parent
+              )}
             >
               {formatCompanionNameWithOwnerLastName(item?.companion?.name, item?.companion?.parent)}
             </button>
-            {item.isEmergency && <div className="appointment-emergency-label">Emergency</div>}
+            {item.isEmergency && (
+              <div className="appointment-emergency-label shrink-0">Emergency</div>
+            )}
           </div>
           <div className="appointment-profile-sub">
             {getOwnerFirstName(item?.companion?.parent) || ''}


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

Two related gaps, both found by walking the new-appointment flow on deployed dev with a corrected contrast probe rather than by reading source.

**Brand ramp steps were being used as ink.** `--color-primary-*` and `--color-brand-*` are FILL steps. Only the `100` tint has a dark value; the rest are declared once at `:root`, so used as a colour they keep their light-mode blue on a dark surface:

| Surface | Measured (dark) |
| --- | --- |
| Calendar label marking "this column is you", and the weekday and today labels beside it | 2.50:1 |
| Appointment avatar initials - the tint UNDER them has a dark value, the ink above them did not | 1.60:1 |
| Date picker selected day and selected time, white on `#007cf5` | 4.04:1 |
| "Today" in the date picker, a fixed blue on a chip mixed into literal white | a white chip inside a dark modal |
| Active input placeholder | 4.05:1 |
| Three `text-yc-*-b-primary` utilities | took the 600 step |

**The calendar popper had never been rendered in Storybook.** Every rule that styles it lives behind a click, so the panel was invisible to the contrast matrix and to Chromatic. All four colour defects above lived in a panel no story could reach.

## What is the new behavior?

Each of those takes `--blue-text`, which is the ink-tuned member of the family and inverts to `#8fb6f5`, or `--blue-strong` where the label sits ON the blue. The selected day and time now measure 6.48 light and 4.54 dark.

Two stories open the poppers with a `play` function. The trigger is react-datepicker's `customInput`, which is a button rather than a textbox, which is why the obvious `getByRole('textbox')` did not work.

Opening the panel immediately found one more defect the earlier pass could not see: the twelve adjacent-month days filling the grid were painted with `--color-neutral-200`, which is the **hairline** value, at 1.11:1 in light and 1.44 in dark. They are clickable, so 1.4.3 does not exempt them the way it does the disabled days beside them. They take `--ink-faint` now. The genuinely disabled days are deliberately left as they are.

A guard fails the build if a brand ramp step is used as a colour again. It was mutation-checked, and it excludes `background-color` rather than matching the tail of that property - the first version flagged the footer's background.

### Verification

- 485 stories, 482 rendering clean (3 are intentional closed states)
- **0 contrast failures** across {375 light, 375 dark, 1280 dark}
- 915 suites / 11263 tests passing; type-check and lint clean

### One thing worth flagging

**Deployed dev predates #2216, #2217, #2218 and #2220.** `--ink-fixed`, `--danger-strong` and `--success-strong` are all absent there, and 1765 of 1875 elements in the shell still carry the universal theme transition that #2220 removed. A theme flip on dev leaves ~5000 animations stuck at `currentTime: 0`, so its dark-mode readings are dominated by that bug and are not trustworthy.

Every finding in this PR was therefore confirmed against a settled frame and traced back to merged source. Two things the crawl surfaced - the validation error ink and the amber avatar ink - turned out to be **already fixed in merged code and only awaiting deploy**, so they are deliberately not touched here.

## Related Issue(s)

Fixes #
