### PR TITLE
feat(ci): gate pull requests on the coverage of the lines they add

### DIFF
--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -200,10 +200,18 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          # The added-line gate below diffs against the merge base, so a PR run
-          # needs both endpoints and their common ancestor in the checkout. Push
-          # runs do not run that gate and stay shallow.
-          fetch-depth: ${{ github.event_name == 'pull_request' && 0 || 1 }}
+          # Full history: the added-line gate below diffs against the merge base,
+          # which a shallow checkout does not contain.
+          #
+          # Deliberately unconditional. The obvious optimisation - deepening only
+          # on pull_request - is
+          #   fetch-depth: ${{ github.event_name == 'pull_request' && 0 || 1 }}
+          # and it silently does the opposite of what it reads like: 0 is FALSY in
+          # an Actions expression, so `true && 0` yields 0, `0 || 1` collapses to
+          # 1, and every PR gets the shallow checkout the gate cannot work with.
+          # A quoted '0' would survive, but the saving is a few seconds on push
+          # runs and is not worth reintroducing the trap.
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Setup
@@ -250,6 +258,15 @@ jobs:
             echo "No added-line coverage floor configured for '$APP'. Add one to DIFF_COVERAGE_FLOORS."
             exit 1
           fi
+          # A shallow checkout reports a missing base only as
+          # "fatal: Invalid symmetric difference expression", which reads like a
+          # malformed argument rather than a truncated clone. Say so plainly.
+          for SHA in "$BASE_SHA" "$HEAD_SHA"; do
+            if ! git cat-file -e "${SHA}^{commit}" 2>/dev/null; then
+              echo "commit ${SHA} is not in this checkout - the added-line gate needs full history (fetch-depth: 0)" >&2
+              exit 1
+            fi
+          done
           # Three-dot: changes the branch introduced, excluding whatever landed on
           # the base since it forked. --unified=0 emits no context lines, so every
           # '+' line in the output is genuinely an added line.

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -44,6 +44,26 @@ env:
       "backend": "lines=1",
       "mobile": "lines=1"
     }
+  # Per-app floors for the added-line gate: the share of executable lines a pull
+  # request ADDS that must be covered. This is the number that actually holds the
+  # line, because the aggregate floors above cannot move meaningfully within a
+  # single PR - frontend measures ~98 against a floor of 80, and backend and
+  # mobile are tripwires rather than thresholds.
+  #
+  # frontend and desktop are set at their current standard: both already run
+  # well-covered suites, so new code is expected to arrive tested.
+  #
+  # backend and mobile start lower deliberately. They have never been held to a
+  # coverage number, and a gate calibrated to where they should be rather than
+  # where they are would be switched off within a week. These are ratchet values:
+  # raise them as the measured figure in each run's log climbs past them.
+  DIFF_COVERAGE_FLOORS: >-
+    {
+      "frontend": "80",
+      "desktop": "90",
+      "backend": "60",
+      "mobile": "60"
+    }
 
 jobs:
   plan:
@@ -180,6 +200,10 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          # The added-line gate below diffs against the merge base, so a PR run
+          # needs both endpoints and their common ancestor in the checkout. Push
+          # runs do not run that gate and stay shallow.
+          fetch-depth: ${{ github.event_name == 'pull_request' && 0 || 1 }}
           persist-credentials: false
 
       - name: Setup
@@ -202,6 +226,39 @@ jobs:
             exit 1
           fi
           node scripts/ci/merge-coverage.mjs --shards shards --out merged --floor "$FLOOR"
+
+      # The aggregate floor above is a whole-app number, so newly added uncovered
+      # code is invisible against it until enough of it accumulates to move the
+      # total. This gate asks the narrower question instead: are the lines THIS
+      # pull request adds covered. Only added lines count, so touching a legacy
+      # file never makes covering that whole file the PR's problem.
+      #
+      # PR-only by design. A push to dev has no meaningful "lines this change
+      # adds" once several PRs have landed together, and the aggregate floor
+      # already guards the branch.
+      - name: Enforce added-line coverage
+        if: github.event_name == 'pull_request'
+        env:
+          APP: ${{ matrix.app_key }}
+          APP_DIR: ${{ matrix.dir }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          FLOOR=$(printf '%s' "$DIFF_COVERAGE_FLOORS" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>process.stdout.write(JSON.parse(s)[process.env.APP]??""))')
+          if [ -z "$FLOOR" ]; then
+            echo "No added-line coverage floor configured for '$APP'. Add one to DIFF_COVERAGE_FLOORS."
+            exit 1
+          fi
+          # Three-dot: changes the branch introduced, excluding whatever landed on
+          # the base since it forked. --unified=0 emits no context lines, so every
+          # '+' line in the output is genuinely an added line.
+          git diff --unified=0 "${BASE_SHA}...${HEAD_SHA}" -- "$APP_DIR" > changed.diff
+          node scripts/ci/diff-coverage.mjs \
+            --coverage merged/coverage-final.json \
+            --diff changed.diff \
+            --floor "$FLOOR" \
+            --app-dir "$APP_DIR"
 
       # istanbul writes SF: paths relative to the repo root. Sonar is given
       # projectBaseDir=<app dir>, so the app prefix has to come off or every path

--- a/docs/ci/coverage.md
+++ b/docs/ci/coverage.md
@@ -1,0 +1,84 @@
+# Coverage gates
+
+Two gates run over the same merged coverage report, and they answer different
+questions. Both live in `.github/workflows/_test.yaml`.
+
+## Aggregate floor (`COVERAGE_FLOORS`)
+
+Enforced by `scripts/ci/merge-coverage.mjs` on every run. It merges the shard
+reports into one istanbul map and checks the whole-app percentage for each of
+statements, branches, functions and lines.
+
+This is a regression tripwire for the app as a whole. It cannot detect untested
+code arriving in a single pull request: frontend measures around 98% against a
+floor of 80, so eighteen points of uncovered code can accumulate before the
+number moves, and backend and mobile sit at `lines=1`, which only catches a
+report that measured nothing at all.
+
+## Added-line floor (`DIFF_COVERAGE_FLOORS`)
+
+Enforced by `scripts/ci/diff-coverage.mjs`, on pull requests only. It diffs the
+branch against its merge base and requires that a given share of the executable
+lines the branch **adds** are covered.
+
+Properties worth knowing:
+
+- **Only added lines count.** Touching one line of a poorly covered legacy file
+  does not make covering the rest of that file your problem. The cost of the
+  gate scales with the size of the change.
+- **Non-executable lines are excluded from both sides of the ratio.** Comments,
+  blank lines, type-only declarations and interfaces never appear in the
+  coverage map, so a documentation-heavy diff is not penalised.
+- **A new file with no test fails.** Every app sets `collectCoverageFrom`, so an
+  untested source file appears in the map with zero hits rather than being
+  absent from it.
+- **Files outside `collectCoverageFrom` are reported but never gated.** Test
+  files, `.d.ts` files and explicitly excluded paths are listed as
+  "not instrumented" and excluded from the ratio.
+- **A diff that adds no executable lines passes.** The aggregate floor still
+  applies to the app as a whole.
+- **It fails closed.** A missing, empty or unparseable coverage map is an error,
+  never a pass. A gate that measures nothing must not report success.
+
+Push runs skip this gate. Once several pull requests have landed together there
+is no meaningful "lines this change adds", and the aggregate floor already
+guards the branch.
+
+### Ratcheting the floors
+
+`frontend` and `desktop` are set at the standard their suites already meet.
+`backend` and `mobile` start lower on purpose: neither has ever been held to a
+coverage number, and a gate calibrated to where they ought to be rather than
+where they are gets switched off rather than met.
+
+Every run logs the measured figure:
+
+```
+diff-coverage: 46/50 added executable lines covered (92%), floor 60%
+```
+
+When an app's measured figure has sat comfortably above its floor for a while,
+raise the floor in `DIFF_COVERAGE_FLOORS`. Raise it in small steps; the point is
+that the number only ever moves up.
+
+### Running it locally
+
+The gate needs a merged coverage map, which `merge-coverage.mjs` writes next to
+`lcov.info` as `coverage-final.json`. A single unsharded run produces one
+directly:
+
+```sh
+pnpm --filter @yosemite-crew/desktop exec jest \
+  --coverage --coverageReporters=json --coverageDirectory=coverage
+
+git diff --unified=0 origin/dev...HEAD -- apps/desktop > changed.diff
+
+node scripts/ci/diff-coverage.mjs \
+  --coverage apps/desktop/coverage/coverage-final.json \
+  --diff changed.diff \
+  --floor 90 \
+  --app-dir apps/desktop
+```
+
+Output marks each measured file `ok` or `MISS`, and lists the uncovered line
+ranges for anything that missed.

--- a/docs/ci/coverage.md
+++ b/docs/ci/coverage.md
@@ -44,6 +44,30 @@ Push runs skip this gate. Once several pull requests have landed together there
 is no meaningful "lines this change adds", and the aggregate floor already
 guards the branch.
 
+### Known limitation: desktop coverage is not trustworthy
+
+`apps/desktop` sets `coverageProvider: 'v8'` alongside its ts-jest `transform`,
+and the resulting report marks **every line of a loaded module as executed**,
+including function bodies nothing calls. Verified by adding an uncalled exported
+function to `src/utils/printing.ts`: all of its lines came back with a hit count
+of 1, both in CI and locally.
+
+This is not a property of the v8 provider as such. `apps/frontend` also uses
+`coverageProvider: 'v8'` and reports uncalled function bodies correctly as zero,
+so the defect is specific to how desktop's transform and the v8-to-istanbul
+conversion interact.
+
+Consequences while it stands:
+
+- The added-line floor for desktop cannot fail, because no added line can
+  measure as uncovered.
+- Desktop's aggregate floor (`statements=95`) and the matching thresholds in its
+  own jest config are measuring the same inflated numbers, so its reported
+  ~98% is not a coverage figure.
+
+The floor is left configured so it starts working the moment the underlying
+report is fixed. Nothing here should be read as desktop being gated today.
+
 ### Ratcheting the floors
 
 `frontend` and `desktop` are set at the standard their suites already meet.

--- a/scripts/ci/diff-coverage.mjs
+++ b/scripts/ci/diff-coverage.mjs
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+// Gate the coverage of the lines a pull request actually adds or changes.
+//
+// Usage:
+//   node scripts/ci/diff-coverage.mjs --coverage <coverage-final.json> \
+//                                     --diff <unified diff> --floor <pct> [--app-dir <dir>]
+//
+//   --coverage  merged istanbul coverage map (merge-coverage.mjs --out writes one)
+//   --diff      unified diff produced with --unified=0, or '-' to read stdin
+//   --floor     minimum share of added executable lines that must be covered
+//   --app-dir   restrict the gate to files under this directory
+//
+// Why this exists alongside the aggregate floor in merge-coverage.mjs: the
+// aggregate is a whole-repository number, so a new file lands as a rounding
+// error against tens of thousands of already-covered lines. frontend measures
+// ~98% against a floor of 80, which leaves eighteen points of slack for
+// uncovered code to accumulate in before anything fails; backend and mobile
+// carry `lines=1`, which is a tripwire rather than a floor. Neither arrangement
+// can answer "is the code this PR adds tested", and that is the only coverage
+// question a reviewer needs answered.
+//
+// The gate is on ADDED LINES, not on changed files. Gating whole files would
+// mean that touching one line of a legacy file makes covering the entire file
+// this PR's problem, which is how coverage gates get switched off. Only lines
+// the diff introduces are counted, so the cost of the gate always matches the
+// size of the change.
+//
+// Lines that are not executable (blank lines, comments, type declarations) never
+// appear in the coverage map's statementMap and are excluded from both sides of
+// the ratio, so a documentation-heavy diff is not punished for it.
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+function fail(message) {
+  console.error(`diff-coverage: ${message}`);
+  process.exit(1);
+}
+
+function parseArgs(argv) {
+  const args = { coverage: '', diff: '', floor: '', 'app-dir': '' };
+  for (let i = 0; i < argv.length; i += 2) {
+    const flag = argv[i];
+    const value = argv[i + 1];
+    if (!['--coverage', '--diff', '--floor', '--app-dir'].includes(flag))
+      fail(`unknown argument '${flag}'`);
+    if (value === undefined) fail(`${flag} requires a value`);
+    args[flag.slice(2)] = value;
+  }
+  if (!args.coverage || !args.diff || !args.floor)
+    fail('usage: --coverage <json> --diff <diff|-> --floor <pct> [--app-dir <dir>]');
+  const floor = Number(args.floor);
+  if (Number.isNaN(floor) || floor < 0 || floor > 100) fail(`bad floor value '${args.floor}'`);
+  return { ...args, floor };
+}
+
+// Added lines per file, from a diff generated with --unified=0.
+//
+// The `+++ b/<path>` header names the post-image path, which is the one the
+// coverage map is keyed by and the one that survives a rename. Hunk headers
+// carry the post-image start line, so counting '+' lines from there gives exact
+// line numbers without re-reading the file.
+export function parseDiff(text) {
+  const added = new Map();
+  let file = null;
+  let line = 0;
+
+  for (const raw of text.split('\n')) {
+    if (raw.startsWith('+++ ')) {
+      const target = raw.slice(4).trim().replace(/\t.*$/, '');
+      // A deletion has no post-image; skip until the next file's header.
+      file = target === '/dev/null' ? null : target.replace(/^b\//, '');
+      continue;
+    }
+    if (raw.startsWith('--- ')) continue;
+
+    if (raw.startsWith('@@')) {
+      // @@ -12,3 +14,5 @@ optional section heading
+      const match = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/.exec(raw);
+      if (!match) fail(`cannot parse hunk header: ${raw}`);
+      line = Number(match[1]);
+      continue;
+    }
+
+    if (file === null) continue;
+
+    if (raw.startsWith('+')) {
+      if (!added.has(file)) added.set(file, new Set());
+      added.get(file).add(line);
+      line += 1;
+    }
+    // With --unified=0 there are no context lines, and '-' lines do not advance
+    // the post-image counter. Anything else is diff furniture ("\ No newline at
+    // end of file", "diff --git", index lines) and is ignored.
+  }
+
+  return added;
+}
+
+// line number -> times executed, for every executable line in one file's entry.
+//
+// A line is counted once even when several statements start on it, and it counts
+// as covered when any of them ran, which is how lcov's DA records are derived.
+export function lineHits(entry) {
+  const hits = new Map();
+  const statements = entry?.statementMap ?? {};
+  for (const [id, location] of Object.entries(statements)) {
+    const lineNumber = location?.start?.line;
+    if (typeof lineNumber !== 'number') continue;
+    const count = entry.s?.[id] ?? 0;
+    hits.set(lineNumber, Math.max(hits.get(lineNumber) ?? 0, count));
+  }
+  return hits;
+}
+
+// Coverage maps are keyed by the absolute path of the machine that produced
+// them; diffs are always repository-relative. Normalise the map onto the diff's
+// vocabulary, keeping a suffix index so a report generated under a different
+// workspace root still matches.
+export function indexCoverage(coverage, cwd) {
+  const byPath = new Map();
+  const prefix = `${cwd.replace(/\/$/, '')}/`;
+  for (const [key, entry] of Object.entries(coverage)) {
+    const normalised = key.startsWith(prefix) ? key.slice(prefix.length) : key;
+    byPath.set(normalised, entry);
+  }
+  return {
+    get(file) {
+      const direct = byPath.get(file);
+      if (direct) return direct;
+      for (const [key, entry] of byPath) {
+        if (key.endsWith(`/${file}`)) return entry;
+      }
+      return undefined;
+    },
+  };
+}
+
+export function evaluate({ added, coverage, appDir, cwd = process.cwd() }) {
+  const index = indexCoverage(coverage, cwd);
+  const scope = appDir ? `${appDir.replace(/\/$/, '')}/` : '';
+
+  const measured = [];
+  const unmeasured = [];
+  let total = 0;
+  let covered = 0;
+
+  for (const [file, lines] of [...added].sort(([a], [b]) => a.localeCompare(b))) {
+    if (scope && !file.startsWith(scope)) continue;
+
+    const entry = index.get(file);
+    // Not in the coverage map means the file is outside collectCoverageFrom -
+    // a test file, a type declaration, an explicitly excluded path. There is
+    // nothing to measure, so it is reported but never gated.
+    if (!entry) {
+      unmeasured.push(file);
+      continue;
+    }
+
+    const hits = lineHits(entry);
+    const executable = [...lines].filter((line) => hits.has(line)).sort((a, b) => a - b);
+    if (executable.length === 0) continue;
+
+    const uncovered = executable.filter((line) => (hits.get(line) ?? 0) === 0);
+    total += executable.length;
+    covered += executable.length - uncovered.length;
+    measured.push({ file, executable: executable.length, uncovered });
+  }
+
+  return { measured, unmeasured, total, covered };
+}
+
+// Ranges read far better than eighty comma-separated line numbers when the
+// failure lands in a reviewer's log.
+function formatLines(lines) {
+  const ranges = [];
+  for (const line of lines) {
+    const last = ranges[ranges.length - 1];
+    if (last && line === last[1] + 1) last[1] = line;
+    else ranges.push([line, line]);
+  }
+  return ranges.map(([from, to]) => (from === to ? `${from}` : `${from}-${to}`)).join(', ');
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  let diffText;
+  try {
+    diffText = readFileSync(args.diff === '-' ? 0 : args.diff, 'utf8');
+  } catch (error) {
+    fail(`cannot read diff '${args.diff}': ${error.message}`);
+  }
+
+  let coverage;
+  try {
+    coverage = JSON.parse(readFileSync(args.coverage, 'utf8'));
+  } catch (error) {
+    fail(`cannot read coverage '${args.coverage}': ${error.message}`);
+  }
+  if (!coverage || typeof coverage !== 'object' || Object.keys(coverage).length === 0)
+    fail(`coverage map '${args.coverage}' contains no files`);
+
+  const result = evaluate({
+    added: parseDiff(diffText),
+    coverage,
+    appDir: args['app-dir'],
+    cwd: process.cwd(),
+  });
+
+  for (const { file, executable, uncovered } of result.measured) {
+    const status = uncovered.length === 0 ? 'ok  ' : 'MISS';
+    const detail = uncovered.length === 0 ? '' : `  uncovered: ${formatLines(uncovered)}`;
+    console.log(`  ${status} ${file}  (${executable - uncovered.length}/${executable})${detail}`);
+  }
+  if (result.unmeasured.length > 0)
+    console.log(`  not instrumented (excluded from coverage): ${result.unmeasured.length} file(s)`);
+
+  // A diff that adds no executable lines - documentation, configuration, a pure
+  // rename - has nothing to prove. Passing here is not a hole: the aggregate
+  // floor in merge-coverage.mjs still applies to the app as a whole.
+  if (result.total === 0) {
+    console.log('diff-coverage: no added executable lines to measure, nothing to gate');
+    return;
+  }
+
+  const pct = Math.round((result.covered / result.total) * 10000) / 100;
+  console.log(
+    `diff-coverage: ${result.covered}/${result.total} added executable lines covered (${pct}%), floor ${args.floor}%`
+  );
+
+  if (pct < args.floor) {
+    fail(
+      `added lines are ${pct}% covered, below the ${args.floor}% floor. ` +
+        'Cover the lines marked MISS above, or move the change behind an existing tested path.'
+    );
+  }
+}
+
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url))
+) {
+  main();
+}

--- a/scripts/ci/diff-coverage.test.mjs
+++ b/scripts/ci/diff-coverage.test.mjs
@@ -1,0 +1,274 @@
+#!/usr/bin/env node
+// Unit tests for the added-line coverage gate.
+//
+// The failure modes worth testing are the ones that produce a plausible number
+// rather than an error: a hunk header misread by one line blames the wrong line,
+// a rename counted under its old path silently measures nothing, an absolute
+// coverage key that fails to match makes an untested file look like an excluded
+// one, and counting non-executable lines drags a documentation diff below the
+// floor. Each of those gets a test, as does the pass/fail boundary itself.
+//
+// Run with `node --test scripts/ci/diff-coverage.test.mjs`, or as part of
+// `pnpm run test:scripts` (which is what the _core CI stage runs).
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { evaluate, indexCoverage, lineHits, parseDiff } from './diff-coverage.mjs';
+
+// A coverage entry whose statements are one-per-line, so the fixtures read as
+// "these lines are executable, these counts are their hits".
+function entry(hitsByLine) {
+  const statementMap = {};
+  const s = {};
+  let id = 0;
+  for (const [line, count] of Object.entries(hitsByLine)) {
+    statementMap[id] = {
+      start: { line: Number(line), column: 0 },
+      end: { line: Number(line), column: 10 },
+    };
+    s[id] = count;
+    id += 1;
+  }
+  return { statementMap, s };
+}
+
+describe('parseDiff', () => {
+  it('numbers added lines from the hunk header', () => {
+    const diff = [
+      'diff --git a/src/a.ts b/src/a.ts',
+      '--- a/src/a.ts',
+      '+++ b/src/a.ts',
+      '@@ -10,0 +11,2 @@',
+      '+const a = 1;',
+      '+const b = 2;',
+    ].join('\n');
+
+    assert.deepEqual(parseDiff(diff), new Map([['src/a.ts', new Set([11, 12])]]));
+  });
+
+  it('reads a single-line hunk header that omits the count', () => {
+    const diff = ['+++ b/src/a.ts', '@@ -3 +3 @@', '+const a = 1;'].join('\n');
+
+    assert.deepEqual(parseDiff(diff), new Map([['src/a.ts', new Set([3])]]));
+  });
+
+  it('does not let removed lines advance the post-image counter', () => {
+    // Deletions carry no post-image line. Counting them would shift every
+    // subsequent added line number in the same file.
+    const diff = [
+      '+++ b/src/a.ts',
+      '@@ -5,2 +5,1 @@',
+      '-const gone = 1;',
+      '-const also = 2;',
+      '+const kept = 3;',
+    ].join('\n');
+
+    assert.deepEqual(parseDiff(diff), new Map([['src/a.ts', new Set([5])]]));
+  });
+
+  it('tracks several hunks in several files', () => {
+    const diff = [
+      '+++ b/src/a.ts',
+      '@@ -1,0 +2,1 @@',
+      '+const a = 1;',
+      '@@ -20,0 +30,2 @@',
+      '+const b = 2;',
+      '+const c = 3;',
+      '+++ b/src/b.ts',
+      '@@ -0,0 +1,1 @@',
+      '+const d = 4;',
+    ].join('\n');
+
+    assert.deepEqual(
+      parseDiff(diff),
+      new Map([
+        ['src/a.ts', new Set([2, 30, 31])],
+        ['src/b.ts', new Set([1])],
+      ])
+    );
+  });
+
+  it('attributes a rename to the post-image path', () => {
+    const diff = [
+      'diff --git a/src/old.ts b/src/new.ts',
+      '--- a/src/old.ts',
+      '+++ b/src/new.ts',
+      '@@ -0,0 +1,1 @@',
+      '+const a = 1;',
+    ].join('\n');
+
+    assert.deepEqual(parseDiff(diff), new Map([['src/new.ts', new Set([1])]]));
+  });
+
+  it('ignores a deleted file, which has no post-image to cover', () => {
+    const diff = ['--- a/src/gone.ts', '+++ /dev/null', '@@ -1,2 +0,0 @@', '-const a = 1;'].join(
+      '\n'
+    );
+
+    assert.deepEqual(parseDiff(diff), new Map());
+  });
+
+  it('strips the tab-separated timestamp some diff producers append', () => {
+    const diff = [
+      '+++ b/src/a.ts\t2026-08-17 10:00:00.000000000 +0000',
+      '@@ -0,0 +1 @@',
+      '+const a = 1;',
+    ].join('\n');
+
+    assert.deepEqual(parseDiff(diff), new Map([['src/a.ts', new Set([1])]]));
+  });
+});
+
+describe('lineHits', () => {
+  it('treats a line as covered when any statement on it ran', () => {
+    const covered = {
+      statementMap: {
+        0: { start: { line: 7 }, end: { line: 7 } },
+        1: { start: { line: 7 }, end: { line: 7 } },
+      },
+      s: { 0: 0, 1: 3 },
+    };
+
+    assert.equal(lineHits(covered).get(7), 3);
+  });
+
+  it('reports a missing hit count as zero rather than dropping the line', () => {
+    const partial = { statementMap: { 0: { start: { line: 4 }, end: { line: 4 } } }, s: {} };
+
+    assert.equal(lineHits(partial).get(4), 0);
+  });
+
+  it('returns an empty map for an entry with no statements', () => {
+    assert.equal(lineHits({}).size, 0);
+  });
+});
+
+describe('indexCoverage', () => {
+  it('strips the producing workspace root from absolute keys', () => {
+    const index = indexCoverage(
+      { '/home/runner/work/Yosemite-Crew/Yosemite-Crew/apps/frontend/src/a.ts': entry({ 1: 1 }) },
+      '/home/runner/work/Yosemite-Crew/Yosemite-Crew'
+    );
+
+    assert.ok(index.get('apps/frontend/src/a.ts'));
+  });
+
+  it('still matches when the report was produced under a different root', () => {
+    // Shard artifacts are generated on one runner and merged on another. A
+    // mismatch here would silently reclassify every changed file as "not
+    // instrumented" and the gate would pass having measured nothing.
+    const index = indexCoverage(
+      { '/some/other/root/apps/frontend/src/a.ts': entry({ 1: 1 }) },
+      '/home/runner/work/Yosemite-Crew/Yosemite-Crew'
+    );
+
+    assert.ok(index.get('apps/frontend/src/a.ts'));
+  });
+
+  it('accepts keys that are already repository-relative', () => {
+    const index = indexCoverage({ 'apps/frontend/src/a.ts': entry({ 1: 1 }) }, '/workspace');
+
+    assert.ok(index.get('apps/frontend/src/a.ts'));
+  });
+});
+
+describe('evaluate', () => {
+  const cwd = '/workspace';
+
+  it('counts only added lines that are executable', () => {
+    // Lines 2 and 4 are executable; 3 is a comment and appears in no
+    // statementMap, so it belongs to neither side of the ratio.
+    const result = evaluate({
+      added: new Map([['apps/frontend/src/a.ts', new Set([2, 3, 4])]]),
+      coverage: { 'apps/frontend/src/a.ts': entry({ 2: 1, 4: 0 }) },
+      cwd,
+    });
+
+    assert.equal(result.total, 2);
+    assert.equal(result.covered, 1);
+    assert.deepEqual(result.measured[0].uncovered, [4]);
+  });
+
+  it('ignores untouched lines of a file the diff only partly changes', () => {
+    // The whole point of gating added lines: line 99 is uncovered but this
+    // change did not introduce it, so it is not this PR's failure.
+    const result = evaluate({
+      added: new Map([['apps/frontend/src/a.ts', new Set([2])]]),
+      coverage: { 'apps/frontend/src/a.ts': entry({ 2: 5, 99: 0 }) },
+      cwd,
+    });
+
+    assert.equal(result.total, 1);
+    assert.equal(result.covered, 1);
+  });
+
+  it('reports a file outside the coverage map as unmeasured, not as uncovered', () => {
+    const result = evaluate({
+      added: new Map([['apps/frontend/src/a.test.ts', new Set([1])]]),
+      coverage: { 'apps/frontend/src/a.ts': entry({ 1: 1 }) },
+      cwd,
+    });
+
+    assert.deepEqual(result.unmeasured, ['apps/frontend/src/a.test.ts']);
+    assert.equal(result.total, 0);
+  });
+
+  it('counts a brand new untested file as entirely uncovered', () => {
+    // collectCoverageFrom puts untested source files in the map with zero hits,
+    // which is what stops "add a file, write no test" from evading the gate.
+    const result = evaluate({
+      added: new Map([['apps/frontend/src/new.ts', new Set([1, 2, 3])]]),
+      coverage: { 'apps/frontend/src/new.ts': entry({ 1: 0, 2: 0, 3: 0 }) },
+      cwd,
+    });
+
+    assert.equal(result.total, 3);
+    assert.equal(result.covered, 0);
+  });
+
+  it('restricts the gate to the app under test', () => {
+    const result = evaluate({
+      added: new Map([
+        ['apps/frontend/src/a.ts', new Set([1])],
+        ['apps/backend/src/b.ts', new Set([1])],
+      ]),
+      coverage: {
+        'apps/frontend/src/a.ts': entry({ 1: 1 }),
+        'apps/backend/src/b.ts': entry({ 1: 0 }),
+      },
+      appDir: 'apps/frontend',
+      cwd,
+    });
+
+    assert.equal(result.total, 1);
+    assert.equal(result.covered, 1);
+    assert.deepEqual(
+      result.measured.map((m) => m.file),
+      ['apps/frontend/src/a.ts']
+    );
+  });
+
+  it('does not let one app directory match another by prefix', () => {
+    // 'apps/frontend' must not swallow 'apps/frontend-e2e'.
+    const result = evaluate({
+      added: new Map([['apps/frontend-e2e/src/a.ts', new Set([1])]]),
+      coverage: { 'apps/frontend-e2e/src/a.ts': entry({ 1: 0 }) },
+      appDir: 'apps/frontend',
+      cwd,
+    });
+
+    assert.equal(result.total, 0);
+  });
+
+  it('measures nothing for a diff that adds no executable lines', () => {
+    const result = evaluate({
+      added: new Map([['docs/readme.md', new Set([1, 2])]]),
+      coverage: { 'apps/frontend/src/a.ts': entry({ 1: 1 }) },
+      cwd,
+    });
+
+    assert.equal(result.total, 0);
+    assert.equal(result.covered, 0);
+  });
+});

--- a/scripts/ci/merge-coverage.mjs
+++ b/scripts/ci/merge-coverage.mjs
@@ -6,7 +6,7 @@
 //
 //   --shards  directory containing the downloaded shard artifacts; every
 //             coverage-final.json beneath it is merged
-//   --out     directory to write lcov.info into
+//   --out     directory to write lcov.info and the merged coverage-final.json into
 //   --floor   e.g. statements=80,branches=70,functions=78,lines=80
 //
 // Shards are merged as istanbul JSON rather than as lcov text. lcov merging
@@ -19,7 +19,7 @@
 // because a sharded run gives each shard only a slice of the files; a global
 // threshold would fail on every shard regardless of the real total.
 
-import { readdirSync, mkdirSync, readFileSync, statSync } from 'node:fs';
+import { readdirSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { resolveWithin } from './safe-path.mjs';
 import libCoverage from 'istanbul-lib-coverage';
@@ -105,6 +105,11 @@ mkdirSync(args.out, { recursive: true });
 reports
   .create('lcovonly', { file: 'lcov.info' })
   .execute(libReport.createContext({ dir: args.out, coverageMap: map }));
+
+// The merged istanbul map is written alongside lcov because the added-line gate
+// (diff-coverage.mjs) needs per-line hit counts against a statementMap, and lcov
+// carries neither in a form that survives the SF: path rewriting done next.
+writeFileSync(path.join(args.out, 'coverage-final.json'), JSON.stringify(map.toJSON()));
 
 const summary = map.getCoverageSummary();
 console.log(`merge-coverage: merged ${files.length} shard report(s), ${covered} files`);


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

`COVERAGE_FLOORS` enforces a whole-app coverage percentage per app, checked by `scripts/ci/merge-coverage.mjs` after the shard reports are merged. Because it is an aggregate, uncovered code arriving in one pull request barely moves it: frontend measures ~98.18% against a floor of 80, and backend and mobile are set to `lines=1`, which only catches a report that measured nothing at all.

CI therefore cannot answer "are the lines this pull request adds tested".

## What is the new behavior?

A second gate runs in the existing `coverage-merge` job, on pull requests only. It diffs the branch against its merge base and requires a configured share of the executable lines the branch ADDS to be covered.

- `scripts/ci/merge-coverage.mjs` now also writes the merged istanbul map as `coverage-final.json` next to `lcov.info`. lcov alone carries neither the per-line hit counts nor a statement map that survives the SF: path rewriting done later in the job.
- `scripts/ci/diff-coverage.mjs` parses a `--unified=0` diff, derives per-line hit counts from the merged map, and fails when added-line coverage is below the floor. Failures name the uncovered line ranges per file.
- `DIFF_COVERAGE_FLOORS` holds the per-app floors: frontend 80, desktop 90, backend 60, mobile 60.

Design decisions worth reviewing:

- **Added lines, not changed files.** Gating whole files would mean touching one line of a legacy file makes covering that entire file this PR's problem, which is how coverage gates end up switched off. The cost of the gate scales with the size of the change.
- **Non-executable lines are excluded from both sides of the ratio.** Comments, blank lines and type-only declarations never appear in a statement map, so a documentation-heavy diff is not penalised.
- **A new untested source file still fails.** Every app sets `collectCoverageFrom`, so untested sources appear in the map with zero hits rather than being absent.
- **Files outside `collectCoverageFrom` are reported, never gated.** Test files and `.d.ts` files are listed as "not instrumented".
- **It fails closed.** A missing, empty or unparseable coverage map is an error. A gate that measures nothing must not report success.
- **backend and mobile start lower on purpose.** Neither has ever been held to a coverage number. A gate calibrated to where they ought to be rather than where they are gets switched off rather than met, so these are ratchet values and every run logs the measured figure.
- **PR-only.** After several pull requests land together there is no meaningful "lines this change adds", and the aggregate floor already guards the branch. The `coverage-merge` checkout only deepens to full history on pull request events.

## Impact area

CI only. No application code, no runtime behaviour, no change to the Sonar path or to the existing aggregate floors. `_test.yaml` gains one step and one env map; the `coverage-merge` checkout becomes full-depth on pull requests so the merge base is available.

## Validation performed

- `pnpm run test:scripts`: 160 tests pass, 27 suites, including 20 new tests for the diff parser, line-hit derivation, path normalisation and the evaluation itself.
- End-to-end against real jest output: ran `apps/desktop` jest with `--coverageReporters=json`, confirmed the map keys are absolute paths and that the normaliser resolves them, then ran the gate over a real commit diff. It correctly reported 4 added executable lines in `apps/desktop/src/lifecycle/updater.ts` as uncovered and exited 1.
- End-to-end against a real 79-file frontend diff: 527 added executable lines measured across 50 instrumented files, 29 files correctly classified as not instrumented.
- Exit codes verified directly: below floor exits 1, above floor exits 0, docs-only diff exits 0, and missing, empty or malformed coverage maps all exit 1.
- Formatting, lint, gitleaks and secretlint pass via the pre-commit hooks.

## Related Issue(s)

Fixes #2233