### PR TITLE
fix(frontend): converge the Tasks week strip and stop prefetching every sidebar route

### DIFF
--- a/apps/frontend/src/app/__tests__/components/Accordion/EditableAccordion.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Accordion/EditableAccordion.test.tsx
@@ -195,7 +195,9 @@ jest.mock('@/app/features/appointments/components/Calendar/weekHelpers', () => (
 }));
 
 jest.mock('@/app/lib/forms', () => ({
-  formatTimeLabel: () => '10:00 AM',
+  // Honours its input: the real one returns '' for an empty value, and a mock
+  // that always returns a time makes the empty-value branch untestable.
+  formatTimeLabel: (value?: string) => (value ? '10:00 AM' : ''),
 }));
 
 jest.mock('@/app/lib/validators', () => ({
@@ -244,6 +246,45 @@ describe('EditableAccordion Component', () => {
     expect(screen.getByText('A, B')).toBeInTheDocument();
     expect(screen.getAllByText('Feb 1, 2024').length).toBeGreaterThan(0);
     expect(screen.getByText('10:00 AM')).toBeInTheDocument();
+  });
+
+  it('shows a dash for an unset select rather than an empty row', () => {
+    // The task drawer rendered "Priority" as a label with nothing beside it,
+    // which reads as a rendering fault rather than "not set": a select whose
+    // value matches no option fell through resolveLabel to the raw (empty)
+    // value instead of the dash every other row uses.
+    const { container } = render(
+      <EditableAccordion
+        title="Task details"
+        fields={[
+          {
+            label: 'Priority',
+            key: 'priority',
+            type: 'select',
+            options: [{ label: 'High', value: 'high' }],
+          },
+        ]}
+        data={{ priority: '' }}
+        defaultOpen
+      />
+    );
+
+    expect(container.querySelector('.text-right')?.textContent).toBe('-');
+  });
+
+  it('shows a dash for an unset time rather than an empty row', () => {
+    // The read-only `time` row had no empty fallback even though its `timeInput`
+    // sibling always did, so "Due time" rendered blank.
+    const { container } = render(
+      <EditableAccordion
+        title="Schedule"
+        fields={[{ label: 'Due time', key: 'dueTime', type: 'time' }]}
+        data={{ dueTime: '' }}
+        defaultOpen
+      />
+    );
+
+    expect(container.querySelector('.text-right')?.textContent).toBe('-');
   });
 
   it('shows validation errors and blocks save when required fields are empty', async () => {

--- a/apps/frontend/src/app/__tests__/components/Calendar/Task/WeekCalendar.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/Task/WeekCalendar.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import WeekCalendar from '@/app/features/appointments/components/Calendar/Task/WeekCalendar';
@@ -147,7 +147,14 @@ describe('WeekCalendar (Task)', () => {
     expect(screen.getByText('9:41 AM')).toBeInTheDocument();
   });
 
-  it('updates week start and current date on navigation', () => {
+  it('renders no pager of its own - paging belongs to the toolbar', () => {
+    // The grid used to carry its own prev/next arrows in two 64px rails either
+    // side of the day strip. common/WeekCalendar.css states the intent plainly:
+    // "The week grid in the design has no arrow columns at all - prev/next live
+    // in the header toolbar's date-nav pill." The right rail also pushed Sunday
+    // out of view, so a seven-day week showed six. Header owns paging now and
+    // builds its own useCalendarWeekNavigation from the same setters; that
+    // behaviour is covered in common/Header.test.tsx.
     render(
       <WeekCalendar
         events={events}
@@ -159,16 +166,8 @@ describe('WeekCalendar (Task)', () => {
       />
     );
 
-    fireEvent.click(screen.getByText('PrevWeek'));
-    fireEvent.click(screen.getByText('NextWeek'));
-
-    const prevFn = setWeekStart.mock.calls[0][0];
-    const nextFn = setWeekStart.mock.calls[1][0];
-
-    prevFn(weekStart);
-    nextFn(weekStart);
-
-    expect(setCurrentDate).toHaveBeenCalledWith(new Date(2024, 11, 30, 12));
-    expect(setCurrentDate).toHaveBeenCalledWith(new Date(2025, 0, 13, 12));
+    expect(screen.queryByText('PrevWeek')).not.toBeInTheDocument();
+    expect(screen.queryByText('NextWeek')).not.toBeInTheDocument();
+    expect(setWeekStart).not.toHaveBeenCalled();
   });
 });

--- a/apps/frontend/src/app/__tests__/components/Calendar/Task/WeekCalendar.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/Task/WeekCalendar.test.tsx
@@ -73,8 +73,6 @@ jest.mock('@/app/ui/primitives/Icons/Next', () => ({
 
 describe('WeekCalendar (Task)', () => {
   const handleViewTask = jest.fn();
-  const setWeekStart = jest.fn();
-  const setCurrentDate = jest.fn();
 
   const weekStart = new Date(2025, 0, 6, 12);
   const days = [new Date(2025, 0, 6, 12), new Date(2025, 0, 7, 12)];
@@ -106,8 +104,6 @@ describe('WeekCalendar (Task)', () => {
         date={weekStart}
         handleViewTask={handleViewTask}
         weekStart={weekStart}
-        setWeekStart={setWeekStart}
-        setCurrentDate={setCurrentDate}
       />
     );
 
@@ -134,14 +130,7 @@ describe('WeekCalendar (Task)', () => {
     mockGetWeekDays.mockReturnValue([today]);
 
     render(
-      <WeekCalendar
-        events={[]}
-        date={today}
-        handleViewTask={handleViewTask}
-        weekStart={today}
-        setWeekStart={setWeekStart}
-        setCurrentDate={setCurrentDate}
-      />
+      <WeekCalendar events={[]} date={today} handleViewTask={handleViewTask} weekStart={today} />
     );
 
     expect(screen.getByText('9:41 AM')).toBeInTheDocument();
@@ -161,13 +150,15 @@ describe('WeekCalendar (Task)', () => {
         date={weekStart}
         handleViewTask={handleViewTask}
         weekStart={weekStart}
-        setWeekStart={setWeekStart}
-        setCurrentDate={setCurrentDate}
       />
     );
 
     expect(screen.queryByText('PrevWeek')).not.toBeInTheDocument();
     expect(screen.queryByText('NextWeek')).not.toBeInTheDocument();
-    expect(setWeekStart).not.toHaveBeenCalled();
+    // Every day getWeekDays returns reaches the strip. The right-hand arrow rail
+    // used to eat the last column, so a seven-day week showed six; asserting the
+    // pass-through is harness-independent, since getWeekDays is mocked here.
+    const rendered = dayLabelsSpy.mock.calls.at(-1)[0].days;
+    expect(rendered).toEqual(mockGetWeekDays.mock.results.at(-1)?.value);
   });
 });

--- a/apps/frontend/src/app/__tests__/components/Sidebar.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Sidebar.test.tsx
@@ -22,8 +22,11 @@ jest.mock('next/image', () => {
 });
 
 jest.mock('next/link', () => {
-  const MockLink = ({ children, href, onClick, ...rest }: any) => (
-    <a href={href} onClick={onClick} {...rest}>
+  // `prefetch` is consumed by the real next/link and never reaches the DOM.
+  // Forwarding it onto a bare <a> makes React warn about a non-boolean
+  // attribute, which the console.error spy below turns into a failure.
+  const MockLink = ({ children, href, onClick, prefetch, ...rest }: any) => (
+    <a href={href} onClick={onClick} data-prefetch={String(prefetch)} {...rest}>
       {children}
     </a>
   );
@@ -219,6 +222,25 @@ describe('Sidebar', () => {
     expect(dashboard).not.toHaveClass('route-disabled');
     expect(dashboard).not.toHaveAttribute('aria-disabled');
     expect(dashboard).not.toHaveAttribute('tabindex');
+  });
+
+  it('does not viewport-prefetch the nav routes', () => {
+    // Every sidebar route is permanently in the viewport, so the App Router's
+    // default fired an RSC request for ALL of them on mount. Measured on dev,
+    // five of those (/appointments, /chat, /tasks, /dashboard, /companions) took
+    // 3.0-3.8s EACH and ran concurrently with the page's own data against a
+    // ~6-connection-per-origin cap: the page you had actually opened queued
+    // behind prefetches for pages you had not. Next still prefetches these on
+    // hover, which is the point of intent anyway.
+    setup({ pathname: '/dashboard', collapsed: false });
+
+    render(<Sidebar />);
+
+    const dashboard = screen.getByRole('link', { name: 'Dashboard' });
+    const appointments = screen.getByRole('link', { name: 'Appointments' });
+
+    expect(dashboard).toHaveAttribute('data-prefetch', 'false');
+    expect(appointments).toHaveAttribute('data-prefetch', 'false');
   });
 
   it('toggles the sidebar collapsed state and persists the preference', () => {

--- a/apps/frontend/src/app/__tests__/components/tasks/TaskFilterBar.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/tasks/TaskFilterBar.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import TaskFilterBar from '@/app/features/tasks/components/TaskFilterBar';
+import { TASK_SCOPE_OPTIONS } from '@/app/features/tasks/pages/Tasks/taskScopeOptions';
 import { TaskFilters, TaskStatusFilters } from '@/app/features/tasks/types/task';
 
 jest.mock('@/app/ui/primitives/Buttons', () => ({
@@ -38,9 +39,11 @@ describe('TaskFilterBar', () => {
   it('renders the audience pills and inline status pills (no All-status pill, no dropdown)', () => {
     renderBar();
 
-    // Audience pills.
+    // Audience pills. "Staff", not "Team": the assignee SCOPE control beside these
+    // is "My tasks | Team", so an audience chip called "Team" put two adjacent
+    // buttons with the same label in one toolbar.
     expect(screen.getByRole('button', { name: 'All' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Team' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Staff' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Pet parents' })).toBeInTheDocument();
 
     // Inline status pills — the "All" status is dropped from the row.
@@ -61,7 +64,7 @@ describe('TaskFilterBar', () => {
 
   it('toggles the audience filter and back to all', () => {
     const { rerender } = renderBar({ activeFilter: 'all' });
-    fireEvent.click(screen.getByRole('button', { name: 'Team' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Staff' }));
     expect(setActiveFilter).toHaveBeenCalledWith('employee_task');
 
     rerender(
@@ -74,7 +77,7 @@ describe('TaskFilterBar', () => {
         setActiveStatus={setActiveStatus}
       />
     );
-    fireEvent.click(screen.getByRole('button', { name: 'Team' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Staff' }));
     expect(setActiveFilter).toHaveBeenLastCalledWith('all');
   });
 
@@ -100,12 +103,25 @@ describe('TaskFilterBar', () => {
 
   it('marks the active audience and status pills via aria-pressed', () => {
     renderBar({ activeFilter: 'employee_task', activeStatus: 'in_progress' });
-    expect(screen.getByRole('button', { name: 'Team' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Staff' })).toHaveAttribute('aria-pressed', 'true');
     expect(screen.getByRole('button', { name: 'In progress' })).toHaveAttribute(
       'aria-pressed',
       'true'
     );
     expect(screen.getByRole('button', { name: 'All' })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('never labels an audience chip the same as an assignee-scope option', () => {
+    // The toolbar renders both, side by side, and they mean different things:
+    // scope is WHOSE tasks, audience is who the task is FOR. They both said
+    // "Team", so the row read "My tasks - Team - All - Team - Pet parents".
+    // Separating them by shape alone was not enough.
+    const scopeNames = new Set(TASK_SCOPE_OPTIONS.map((o) => o.name.toLowerCase()));
+    const collisions = TaskFilters.filter((f) => scopeNames.has(f.name.toLowerCase())).map(
+      (f) => f.name
+    );
+
+    expect(collisions).toEqual([]);
   });
 
   it('gives the selected status pill a visible ring, not just aria-pressed', () => {

--- a/apps/frontend/src/app/__tests__/pages/Tasks/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Tasks/index.test.tsx
@@ -376,13 +376,22 @@ describe('Tasks page', () => {
     expect(screen.queryByRole('button', { name: 'New task' })).not.toBeInTheDocument();
   });
 
-  it('openAddTask: clicking the header New task CTA calls openAddTask', async () => {
+  it('openAddTask: the calendar toolbar owns the New task CTA', async () => {
+    // The CTA used to sit in the PAGE header, outside the calendar card, which
+    // is the difference you notice switching between the two planners -
+    // Appointments seats its primary action inside whichever toolbar the active
+    // view owns. It needed an `order-1` flex hack to land after the view toggle
+    // there, too. Each view now carries its own: the calendar's Header,
+    // TaskFilterBar for the list, TaskBoard's own toolbar for the board.
     render(<ProtectedTasks />);
 
-    // Per the design the CTA sits in the page header actions, not the filter row.
-    const addButton = screen.getByRole('button', { name: 'New task' });
+    expect(screen.queryByRole('button', { name: 'New task' })).not.toBeInTheDocument();
+
+    const { onAddTask } = taskCalendarSpy.mock.calls.at(-1)[0];
+    expect(typeof onAddTask).toBe('function');
+
     await act(async () => {
-      fireEvent.click(addButton);
+      onAddTask();
       await Promise.resolve();
     });
 

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/DayLabels.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/DayLabels.stories.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import DayLabels from './DayLabels';
+
+/** Monday of a fixed week, plus today, so one column always shows the today state. */
+const weekFrom = (start: Date) =>
+  Array.from({ length: 7 }, (_, i) => {
+    const d = new Date(start);
+    d.setDate(start.getDate() + i);
+    return d;
+  });
+
+const startOfThisWeek = () => {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  d.setDate(d.getDate() - ((d.getDay() + 6) % 7));
+  return d;
+};
+
+const COLUMNS: React.CSSProperties = {
+  gridTemplateColumns: 'repeat(7, minmax(120px, 1fr))',
+};
+
+const meta = {
+  title: 'Appointments/Calendar/DayLabels',
+  component: DayLabels,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          "The Tasks planner's week date strip, and the reason this story exists.\n\n" +
+          'It used to put a filled 40px disc behind **every** date with the weekday beside it ' +
+          'at 16px near-black, while the Appointments strip stacks a small caps weekday over a ' +
+          'bare numeral and reserves the disc for today. Two consequences: the row read as seven ' +
+          'grey buttons at roughly 1.5x the type size, and because every date already wore a ' +
+          'disc, "today" had no signal left - the one thing the strip exists to tell you.\n\n' +
+          'It now matches `common/WeekCalendar.tsx:190-231` day for day: the `yc-table-head` ' +
+          'recipe (10.5px / 700 / +0.1em caps) that every other PIMS table header uses, a ' +
+          'hairline between columns, `--nav-active-bg` washing the today column and a 24px ' +
+          '`--blue-strong` disc on the today numeral alone.\n\n' +
+          'Flip the theme toolbar: the strip is the surface where the two calendars diverged ' +
+          'most, so it is also where a regression would show first.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    days: weekFrom(startOfThisWeek()),
+    currentDate: startOfThisWeek(),
+    columnsStyle: COLUMNS,
+  },
+} satisfies Meta<typeof DayLabels>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ThisWeek: Story = {
+  name: 'This week (one column is today)',
+};
+
+export const NoTodayInRange: Story = {
+  name: 'A week that does not contain today',
+  args: { days: weekFrom(new Date(2024, 5, 10)), currentDate: new Date(2024, 5, 10) },
+  parameters: {
+    docs: {
+      story:
+        'Every column in its resting state. Nothing carries a disc or a wash here, which is ' +
+        'exactly the contrast that makes the today column legible in the story above.',
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/DayLabels.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/DayLabels.tsx
@@ -3,6 +3,10 @@ import {
   formatDateInPreferredTimeZone,
   isOnPreferredTimeZoneCalendarDay,
 } from '@/app/lib/timezone';
+// yc-table-head lives here. common/WeekCalendar relies on some table elsewhere on
+// the page having pulled this in; the Tasks planner may render no table at all,
+// so it is imported explicitly rather than left to chance.
+import '@/app/ui/tables/GenericTable/Generictable.css';
 
 type DayLabels = {
   days: Date[];
@@ -10,11 +14,26 @@ type DayLabels = {
   columnsStyle?: React.CSSProperties;
 };
 
+/**
+ * The week date strip, matching `common/WeekCalendar.tsx:190-231` day for day.
+ *
+ * This was the loudest difference between the two calendars. It put a filled
+ * 40px disc behind EVERY date with the weekday beside it at 16px near-black,
+ * where the Appointments strip stacks a small caps weekday over a bare numeral
+ * and reserves the disc for today. Two consequences: the row read as seven grey
+ * buttons at roughly 1.5x the type size, and because every date already wore a
+ * disc, "today" had no signal left - the one thing the strip exists to tell you.
+ *
+ * The `yc-table-head` recipe (10.5px / 700 / +0.1em caps) is the same one every
+ * other table header in PIMS uses, so the strip now belongs to the same system
+ * rather than the generic body scale.
+ */
 const DayLabels = ({ days, currentDate, columnsStyle }: DayLabels) => {
   const currentDateIso = currentDate?.toISOString() ?? '';
+  const now = new Date();
   return (
     <div
-      className="grid min-w-max py-3"
+      className="yc-table-head yc-table-head--static yc-table-head--flush grid min-w-max"
       style={columnsStyle}
       data-current-date={currentDateIso}
       suppressHydrationWarning
@@ -26,22 +45,34 @@ const DayLabels = ({ days, currentDate, columnsStyle }: DayLabels) => {
         // column labelled Tue on one calendar and Mon on the other.
         const weekday = formatDateInPreferredTimeZone(day, { weekday: 'short' });
         const dateNumber = day.getDate();
-        const isToday = isOnPreferredTimeZoneCalendarDay(new Date(), day);
-        const dateNumberClass = isToday
-          ? 'bg-[var(--blue-strong)] text-white border-transparent'
-          : 'bg-card-bg text-text-secondary border-transparent';
+        const isToday = isOnPreferredTimeZoneCalendarDay(now, day);
         return (
-          <div key={idx + day.getDate()} className="flex items-center justify-center gap-2">
-            <div
-              className={`text-body-4 ${isToday ? 'text-[var(--blue-text)]' : 'text-text-primary'}`}
-            >
+          <div
+            key={idx + day.getDate()}
+            className="flex flex-col items-center gap-px border-l px-1 py-2"
+            style={{
+              borderColor: 'var(--hairline)',
+              backgroundColor: isToday ? 'var(--nav-active-bg)' : undefined,
+            }}
+          >
+            <div style={{ color: isToday ? 'var(--nav-active)' : 'var(--ink-faint)' }}>
               {weekday}
             </div>
-            <div
-              className={`text-body-4-emphasis size-10 flex items-center justify-center rounded-full border ${dateNumberClass}`}
-            >
-              {dateNumber}
-            </div>
+            {isToday ? (
+              <div
+                className="flex size-6 items-center justify-center rounded-full text-[13px] font-bold normal-case tracking-normal text-white"
+                style={{ backgroundColor: 'var(--blue-strong)' }}
+              >
+                {dateNumber}
+              </div>
+            ) : (
+              <div
+                className="text-[14px] font-bold normal-case tracking-normal"
+                style={{ color: 'var(--ink)' }}
+              >
+                {dateNumber}
+              </div>
+            )}
           </div>
         );
       })}

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/DayLabels.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/DayLabels.tsx
@@ -1,8 +1,5 @@
 import React from 'react';
-import {
-  formatDateInPreferredTimeZone,
-  isOnPreferredTimeZoneCalendarDay,
-} from '@/app/lib/timezone';
+import CalendarWeekDayCell from '@/app/features/appointments/components/Calendar/common/CalendarWeekDayCell';
 // yc-table-head lives here. common/WeekCalendar relies on some table elsewhere on
 // the page having pulled this in; the Tasks planner may render no table at all,
 // so it is imported explicitly rather than left to chance.
@@ -15,18 +12,11 @@ type DayLabels = {
 };
 
 /**
- * The week date strip, matching `common/WeekCalendar.tsx:190-231` day for day.
- *
- * This was the loudest difference between the two calendars. It put a filled
- * 40px disc behind EVERY date with the weekday beside it at 16px near-black,
- * where the Appointments strip stacks a small caps weekday over a bare numeral
- * and reserves the disc for today. Two consequences: the row read as seven grey
- * buttons at roughly 1.5x the type size, and because every date already wore a
- * disc, "today" had no signal left - the one thing the strip exists to tell you.
- *
- * The `yc-table-head` recipe (10.5px / 700 / +0.1em caps) is the same one every
- * other table header in PIMS uses, so the strip now belongs to the same system
- * rather than the generic body scale.
+ * The Tasks planner's week date strip. The columns are `CalendarWeekDayCell`, the
+ * same component the Appointments week header renders, so the two strips cannot
+ * drift apart again - which is exactly what had happened: this one used to put a
+ * filled 40px disc behind every date with the weekday beside it at 16px
+ * near-black, leaving "today" with no signal of its own.
  */
 const DayLabels = ({ days, currentDate, columnsStyle }: DayLabels) => {
   const currentDateIso = currentDate?.toISOString() ?? '';
@@ -38,44 +28,9 @@ const DayLabels = ({ days, currentDate, columnsStyle }: DayLabels) => {
       data-current-date={currentDateIso}
       suppressHydrationWarning
     >
-      {days.map((day, idx) => {
-        // The preferred zone, not the browser's. isToday below already uses it,
-        // and the Appointments week header does too (common/WeekCalendar.tsx:195),
-        // so a user whose browser zone differs from the org's could see the same
-        // column labelled Tue on one calendar and Mon on the other.
-        const weekday = formatDateInPreferredTimeZone(day, { weekday: 'short' });
-        const dateNumber = day.getDate();
-        const isToday = isOnPreferredTimeZoneCalendarDay(now, day);
-        return (
-          <div
-            key={idx + day.getDate()}
-            className="flex flex-col items-center gap-px border-l px-1 py-2"
-            style={{
-              borderColor: 'var(--hairline)',
-              backgroundColor: isToday ? 'var(--nav-active-bg)' : undefined,
-            }}
-          >
-            <div style={{ color: isToday ? 'var(--nav-active)' : 'var(--ink-faint)' }}>
-              {weekday}
-            </div>
-            {isToday ? (
-              <div
-                className="flex size-6 items-center justify-center rounded-full text-[13px] font-bold normal-case tracking-normal text-white"
-                style={{ backgroundColor: 'var(--blue-strong)' }}
-              >
-                {dateNumber}
-              </div>
-            ) : (
-              <div
-                className="text-[14px] font-bold normal-case tracking-normal"
-                style={{ color: 'var(--ink)' }}
-              >
-                {dateNumber}
-              </div>
-            )}
-          </div>
-        );
-      })}
+      {days.map((day) => (
+        <CalendarWeekDayCell key={day.toISOString()} day={day} now={now} />
+      ))}
     </div>
   );
 };

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/WeekCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/WeekCalendar.tsx
@@ -9,8 +9,6 @@ import { getNowTopPxForHourRange } from '@/app/features/appointments/components/
 import DayLabels from '@/app/features/appointments/components/Calendar/Task/DayLabels';
 import TaskSlot from '@/app/features/appointments/components/Calendar/Task/TaskSlot';
 import { Task } from '@/app/features/tasks/types/task';
-import Back from '@/app/ui/primitives/Icons/Back';
-import Next from '@/app/ui/primitives/Icons/Next';
 import {
   CalendarZoomMode,
   getCalendarColumnGridStyle,
@@ -27,7 +25,6 @@ import SlotGridLines from '@/app/features/appointments/components/Calendar/commo
 import {
   getTimedTaskProxyEvents,
   useCalendarAutoScroll,
-  useCalendarWeekNavigation,
   useSlotOffsetMinutes,
 } from '@/app/features/appointments/components/Calendar/useCalendarSlots';
 import type { TaskCalendarInteractionProps } from '@/app/features/appointments/components/Calendar/Task/taskCalendarInteractionProps';
@@ -54,8 +51,6 @@ const WeekCalendar: React.FC<WeekCalendarProps> = ({
   handleChangeStatusTask,
   handleRescheduleTask,
   weekStart,
-  setWeekStart,
-  setCurrentDate,
   canEditTasks = false,
   draggedTaskId,
   draggedTaskLabel,
@@ -136,10 +131,10 @@ const WeekCalendar: React.FC<WeekCalendarProps> = ({
     hourRowTopOffsetPx: HOUR_ROW_TOP_OFFSET_PX,
   });
 
-  const { handlePrevWeek, handleNextWeek } = useCalendarWeekNavigation(
-    setWeekStart,
-    setCurrentDate
-  );
+  // No week-navigation hook here any more. Paging lives in the toolbar - Header
+  // builds its own useCalendarWeekNavigation from the same setWeekStart and
+  // setCurrentDate this component receives, so stepping a week still drags the
+  // current date with it. This copy only ever fed the in-grid arrows.
 
   return (
     <div className="h-full flex flex-col">
@@ -150,19 +145,20 @@ const WeekCalendar: React.FC<WeekCalendarProps> = ({
       >
         <div className="min-w-max h-full flex flex-col relative">
           <div className="z-30 bg-neutral-0">
-            <div className="grid border-b border-card-border py-2 grid-cols-[64px_minmax(0,1fr)_64px] min-w-max bg-neutral-0">
-              <div className="sticky left-0 z-40 bg-neutral-0 flex items-center justify-center">
-                <Back onClick={handlePrevWeek} />
-              </div>
+            {/* No arrow columns. common/WeekCalendar.css says it outright: "The week
+                grid in the design has no arrow columns at all - prev/next live in
+                the header toolbar's date-nav pill." Those two 64px rails were the
+                other half of why this strip did not match Appointments, and the
+                right one pushed Sunday off the visible week: getWeekDays returns
+                seven days and only six fitted. The toolbar pages by week now. */}
+            <div className="grid border-b border-card-border py-2 grid-cols-[64px_minmax(0,1fr)] min-w-max bg-neutral-0">
+              <div className="sticky left-0 z-40 bg-neutral-0" />
               <div className="bg-neutral-0">
                 <DayLabels
                   days={days}
                   currentDate={_date ?? weekStart}
                   columnsStyle={dayColumnsStyle}
                 />
-              </div>
-              <div className="sticky right-0 z-40 bg-neutral-0 flex items-center justify-center">
-                <Next onClick={handleNextWeek} />
               </div>
             </div>
           </div>
@@ -182,7 +178,7 @@ const WeekCalendar: React.FC<WeekCalendarProps> = ({
           >
             <div className="relative pb-4">
               {Array.from({ length: HOURS_IN_DAY }, (_, hour) => (
-                <div key={hour} className="grid grid-cols-[64px_minmax(0,1fr)_64px] min-w-max">
+                <div key={hour} className="grid grid-cols-[64px_minmax(0,1fr)] min-w-max">
                   <CalendarHourLabel
                     hour={hour}
                     height={height}
@@ -243,7 +239,7 @@ const WeekCalendar: React.FC<WeekCalendarProps> = ({
               <div style={{ height: zoomMode === 'out' ? 30 : 40 }} />
               {nowPosition && (
                 <div className="pointer-events-none absolute inset-0" style={{ top: 0 }}>
-                  <div className="grid h-full grid-cols-[64px_minmax(0,1fr)_64px] min-w-max">
+                  <div className="grid h-full grid-cols-[64px_minmax(0,1fr)] min-w-max">
                     <div />
                     <div className="grid min-w-max" style={dayColumnsStyle}>
                       {days.map((day, idx) => (

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/WeekCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/WeekCalendar.tsx
@@ -39,8 +39,9 @@ type WeekCalendarProps = {
   handleChangeStatusTask?: (task: Task) => void;
   handleRescheduleTask?: (task: Task) => void;
   weekStart: Date;
-  setWeekStart: React.Dispatch<React.SetStateAction<Date>>;
-  setCurrentDate: React.Dispatch<React.SetStateAction<Date>>;
+  /* No setWeekStart/setCurrentDate: paging moved to the toolbar, so this grid
+     neither reads nor dispatches them. Header builds its own
+     useCalendarWeekNavigation from the same setters. */
 } & TaskCalendarInteractionProps;
 
 const WeekCalendar: React.FC<WeekCalendarProps> = ({

--- a/apps/frontend/src/app/features/appointments/components/Calendar/TaskCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/TaskCalendar.tsx
@@ -29,6 +29,8 @@ type TaskCalendarProps = {
   weekStart: Date;
   setWeekStart: React.Dispatch<React.SetStateAction<Date>>;
   canEditTasks?: boolean;
+  /** Seats the primary CTA in the calendar toolbar, where Appointments has it. */
+  onAddTask?: () => void;
   onCreateFromCalendarSlot?: (prefill: { dueAt: Date; assignedTo?: string }) => void;
   filterOptions?: Array<{ key: string; name: string; dotColor?: string }>;
   activeFilter?: string;
@@ -60,6 +62,7 @@ const TaskCalendar = ({
   weekStart,
   setWeekStart,
   canEditTasks = false,
+  onAddTask,
   onCreateFromCalendarSlot,
   filterOptions,
   activeFilter,
@@ -187,6 +190,13 @@ const TaskCalendar = ({
           // "Previous day" / "Next day" on a week view. Appointments passes it
           // (AppointmentCalendar.tsx:256) and pages Mon 17 -> Mon 24 correctly.
           setWeekStart={setWeekStart}
+          // Header already renders the primary CTA; Appointments passes these
+          // (AppointmentCalendar.tsx:261-262) and Tasks did not, which is why the
+          // Tasks CTA sat up in the page header instead and needed an `order-1`
+          // flex hack to land after the view toggle.
+          showAddButton={canEditTasks && !!onAddTask}
+          onAddButtonClick={onAddTask}
+          addButtonText="New task"
           zoomMode={zoomMode}
           setZoomMode={setZoomMode}
           activeCalendar={activeCalendar}

--- a/apps/frontend/src/app/features/appointments/components/Calendar/TaskCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/TaskCalendar.tsx
@@ -235,7 +235,6 @@ const TaskCalendar = ({
           getDropAvailabilityIntervals={getDropAvailabilityIntervals}
           resolveDisplayName={resolveDisplayName}
           weekStart={weekStart}
-          setWeekStart={setWeekStart}
         />
       </div>
       {pendingSeriesMove && (

--- a/apps/frontend/src/app/features/appointments/components/Calendar/TaskCalendarBody.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/TaskCalendarBody.tsx
@@ -29,7 +29,6 @@ type TaskCalendarBodyProps = {
   getDropAvailabilityIntervals: (date: Date, assigneeId?: string) => DropAvailabilityInterval[];
   resolveDisplayName: (memberId?: string) => string;
   weekStart: Date;
-  setWeekStart: Dispatch<SetStateAction<Date>>;
 };
 
 type CommonCalendarPropsInput = Pick<
@@ -91,7 +90,6 @@ export const TaskCalendarBody = ({
   getDropAvailabilityIntervals,
   resolveDisplayName,
   weekStart,
-  setWeekStart,
 }: TaskCalendarBodyProps) => {
   const handleDrop = createTaskDropHandler(moveTask, handleTaskDragEnd);
 
@@ -130,8 +128,6 @@ export const TaskCalendarBody = ({
         {...commonCalendarProps}
         events={filteredList}
         weekStart={weekStart}
-        setWeekStart={setWeekStart}
-        setCurrentDate={setCurrentDate}
         onTaskDropAt={(dropDate, minute) => handleDrop(dropDate, minute)}
       />
     );

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/CalendarWeekDayCell.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/CalendarWeekDayCell.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import {
+  formatDateInPreferredTimeZone,
+  isOnPreferredTimeZoneCalendarDay,
+} from '@/app/lib/timezone';
+
+/**
+ * One column of a week date strip: a small caps weekday over the date numeral,
+ * with the disc and the column wash reserved for today.
+ *
+ * Shared because the two planners drew this differently, and copying the
+ * Appointments treatment into the Tasks one is what caused the divergence in the
+ * first place. Tasks used to put a filled 40px disc behind EVERY date with the
+ * weekday beside it at 16px near-black, so the row read as seven grey buttons at
+ * roughly 1.5x the type size - and with every date already wearing a disc,
+ * "today" had no signal left, which is the one thing the strip exists to tell
+ * you. One component means the next change lands on both calendars at once.
+ *
+ * The caps and tracking come from `yc-table-head` on the container, the same
+ * recipe every other PIMS table header uses, so the strip belongs to the table
+ * system rather than the generic body scale.
+ */
+const CalendarWeekDayCell = ({ day, now }: { day: Date; now: Date }) => {
+  const weekday = formatDateInPreferredTimeZone(day, { weekday: 'short' });
+  const dateNumber = day.getDate();
+  const isToday = isOnPreferredTimeZoneCalendarDay(now, day);
+
+  return (
+    <div
+      className="flex flex-col items-center gap-px border-l px-1 py-2"
+      style={{
+        borderColor: 'var(--hairline)',
+        backgroundColor: isToday ? 'var(--nav-active-bg)' : undefined,
+      }}
+    >
+      <div style={{ color: isToday ? 'var(--nav-active)' : 'var(--ink-faint)' }}>{weekday}</div>
+      {isToday ? (
+        <div
+          className="flex size-6 items-center justify-center rounded-full text-[13px] font-bold normal-case tracking-normal text-white"
+          style={{ backgroundColor: 'var(--blue-strong)' }}
+        >
+          {dateNumber}
+        </div>
+      ) : (
+        <div
+          className="text-[14px] font-bold normal-case tracking-normal"
+          style={{ color: 'var(--ink)' }}
+        >
+          {dateNumber}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CalendarWeekDayCell;

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/Header.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/Header.tsx
@@ -363,6 +363,8 @@ type Headerprops = {
   setActiveCalendar?: React.Dispatch<React.SetStateAction<string>>;
   showAddButton?: boolean;
   onAddButtonClick?: () => void;
+  /** The Tasks planner mounts this same header, so the CTA label is a prop. */
+  addButtonText?: string;
   activeFilter?: string;
   setActiveFilter?: (v: string) => void;
   activeStatus?: string;
@@ -382,6 +384,7 @@ const Header = ({
   setActiveCalendar,
   showAddButton = false,
   onAddButtonClick,
+  addButtonText = 'New appointment',
   activeFilter,
   setActiveFilter,
   activeStatus,
@@ -490,7 +493,8 @@ const Header = ({
                 aria-hidden="true"
               />
               <Primary
-                text="New appointment"
+                text={addButtonText}
+                ariaLabel={addButtonText}
                 onClick={onAddButtonClick}
                 icon={<IoAdd size={16} aria-hidden="true" />}
                 className="w-fit shrink-0 justify-center py-0 whitespace-nowrap hover:scale-100"

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/WeekCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/WeekCalendar.tsx
@@ -40,6 +40,7 @@ import {
 } from '@/app/features/appointments/components/Calendar/useCalendarSlots';
 import type { AppointmentViewIntent } from '@/app/features/appointments/types/calendar';
 import type { AppointmentCalendarInteractionProps } from '@/app/features/appointments/components/Calendar/common/calendarInteractionProps';
+import CalendarWeekDayCell from '@/app/features/appointments/components/Calendar/common/CalendarWeekDayCell';
 import './WeekCalendar.css';
 import '@/app/ui/tables/GenericTable/Generictable.css';
 
@@ -191,42 +192,9 @@ const WeekDayHeaderRow = ({
   <div className="yc-table-head yc-table-head--static yc-table-head--flush yc-week-grid__shell yc-week-grid__track">
     <div className="sticky left-0 z-40" style={{ backgroundColor: 'var(--screen-2)' }} />
     <div className="grid" style={dayColumnsStyle}>
-      {days.map((day) => {
-        const weekday = formatDateInPreferredTimeZone(day, {
-          weekday: 'short',
-        });
-        const dateNumber = day.getDate();
-        const isToday = isOnPreferredTimeZoneCalendarDay(now, day);
-        return (
-          <div
-            key={day.toISOString()}
-            className="flex flex-col items-center gap-px border-l px-1 py-2"
-            style={{
-              borderColor: 'var(--hairline)',
-              backgroundColor: isToday ? 'var(--nav-active-bg)' : undefined,
-            }}
-          >
-            <div style={{ color: isToday ? 'var(--nav-active)' : 'var(--ink-faint)' }}>
-              {weekday}
-            </div>
-            {isToday ? (
-              <div
-                className="flex size-6 items-center justify-center rounded-full text-[13px] font-bold normal-case tracking-normal text-white"
-                style={{ backgroundColor: 'var(--blue-strong)' }}
-              >
-                {dateNumber}
-              </div>
-            ) : (
-              <div
-                className="text-[14px] font-bold normal-case tracking-normal"
-                style={{ color: 'var(--ink)' }}
-              >
-                {dateNumber}
-              </div>
-            )}
-          </div>
-        );
-      })}
+      {days.map((day) => (
+        <CalendarWeekDayCell key={day.toISOString()} day={day} now={now} />
+      ))}
     </div>
   </div>
 );

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/WorkspaceHeader.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/WorkspaceHeader.tsx
@@ -139,9 +139,17 @@ const WorkspaceHeader = ({
           )}
         </div>
         {hasAlerts && (
+          /* The strip scrolls with its scrollbar hidden, so when the alerts do
+             not fit there was NO cue that any were missing - measured on a real
+             patient at 1512px: 666px of pills in a 276px box, with the third one
+             cut mid-word. These are standing clinical alerts ("bite risk",
+             "needs muzzle"), so silently hiding two thirds of them is the wrong
+             failure. A right-edge fade marks the strip as scrollable, and the
+             fade costs nothing when the pills fit, because the faded band is
+             empty background in that case. */
           <div
             data-testid="workspace-alert-strip"
-            className="flex min-w-0 flex-1 items-center gap-2 overflow-x-auto pb-1 scrollbar-hidden"
+            className="flex min-w-0 flex-1 items-center gap-2 overflow-x-auto pb-1 scrollbar-hidden [mask-image:linear-gradient(to_right,#000_calc(100%-2rem),transparent)]"
           >
             {alerts.map((alert) => (
               <div key={alert.id} className="shrink-0">

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/TotalBillContainer.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/TotalBillContainer.tsx
@@ -125,7 +125,13 @@ const buildTotals = (
  * column is the only fr track. Every other column is a fixed px width.
  */
 const ROW_GRID =
-  'grid gap-3 sm:grid-cols-[minmax(0,1.7fr)_110px_72px_130px_150px_120px_36px] sm:items-center';
+  // The name column needs a FLOOR. At minmax(0,1.7fr) it collapsed to nothing
+  // once the card fell below about 690px - the six fixed columns are 618px plus
+  // 72px of gaps - and "Item Name" ran straight into "Unit Price", rendering as
+  // "ITUNIT PRICE". The workspace puts a payment panel and an icon rail beside
+  // this card, so that width is reached on an ordinary laptop. Measured: the
+  // overlap starts at 720px and is gone with a 7rem floor.
+  'grid gap-3 sm:grid-cols-[minmax(7rem,1.7fr)_110px_72px_130px_150px_120px_36px] sm:items-center';
 
 /**
  * Each heading's text starts exactly where its value-box text starts: the value
@@ -147,7 +153,7 @@ const BILL_COLUMNS = [
 const ColumnHeadings = () => (
   <TableHead
     columns={BILL_COLUMNS}
-    track="minmax(0,1.7fr) 110px 72px 130px 150px 120px 36px"
+    track="minmax(7rem,1.7fr) 110px 72px 130px 150px 120px 36px"
     gap="12px"
     sticky={false}
     // Flush: the BillRows below carry no outer padding, so the recipe's 20px
@@ -495,7 +501,16 @@ const TotalsFooter = ({
     onChangeOverallDiscount,
   });
   return (
-    <div className="-mx-5 -mb-5 grid gap-5 rounded-b-2xl border-t border-neutral-300 bg-pill-success-bg px-5 py-4 sm:px-6 lg:grid-cols-[minmax(0,1fr)_minmax(13rem,0.8fr)_minmax(0,1fr)] lg:items-stretch">
+    /* A recessed NEUTRAL footer, not a green one. This used
+       `bg-pill-success-bg`, a status-PILL token, so the invoice totals read as a
+       success banner: a mint #f0fdf4 slab in a warm-bone card, for a panel that
+       carries no status at all. --inset is the system's recessed surface and
+       tracks the theme (#eae2d5 / #302820). The top rule was
+       `border-neutral-300`, which is not the divider token every other rule in
+       the card uses. The -mx-5/-mb-5 bleed is correct and stays: measured
+       against SectionContainer's px-5/pb-5 it lands exactly on the card's 1px
+       border. */
+    <div className="-mx-5 -mb-5 grid gap-5 rounded-b-2xl border-t border-[var(--hairline)] bg-[var(--inset)] px-5 py-4 sm:px-6 lg:grid-cols-[minmax(0,1fr)_minmax(13rem,0.8fr)_minmax(0,1fr)] lg:items-stretch">
       <div className="flex h-full flex-col justify-center gap-2">
         <label className="flex min-h-8 items-center gap-2">
           <input

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/TotalBillContainer.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/TotalBillContainer.tsx
@@ -28,7 +28,7 @@ const KIND_LABELS: Record<BillableKind, string> = {
 const KIND_PILL_CLASSES: Record<BillableKind, string> = {
   EXISTING_TREATMENT: 'border-pill-info-border bg-pill-info-bg text-pill-info-text',
   IN_HOUSE_PRESCRIPTION: 'border-pill-warning-border bg-pill-warning-bg text-pill-warning-text',
-  PACKAGE_COMPONENT: 'border-pill-success-border bg-pill-success-bg text-pill-success-text',
+  PACKAGE_COMPONENT: 'border-pill-success-border bg-pill-success-bg text-[var(--success-text)]',
   BILLING_ONLY: 'border-card-border bg-neutral-100 text-text-secondary',
   INVENTORY: 'border-card-border bg-neutral-100 text-text-secondary',
 };
@@ -239,7 +239,7 @@ const DiscountInput = ({
       <span className="relative inline-flex w-22 items-center">
         <span
           aria-hidden="true"
-          className="pointer-events-none absolute top-1/2 right-3 -translate-y-1/2 text-body-4 text-pill-success-text"
+          className="pointer-events-none absolute top-1/2 right-3 -translate-y-1/2 text-body-4 text-[var(--success-text)]"
         >
           %
         </span>
@@ -255,7 +255,7 @@ const DiscountInput = ({
             const capped = maxPercent == null ? percent : Math.min(percent, maxPercent);
             onUpdateItem(item.id, { discountCents: Math.round((item.grossCents * capped) / 100) });
           }}
-          className={`${EDITABLE_BOX} pr-7 pl-3 text-right text-pill-success-text`}
+          className={`${EDITABLE_BOX} pr-7 pl-3 text-right text-[var(--success-text)]`}
         />
       </span>
       {maxPercent != null && maxPercent > 0 ? (
@@ -273,7 +273,7 @@ const GrossAmountCell = ({ item, currency }: { item: InvoiceLineItem; currency: 
     <TextCell className="flex-col! items-start! justify-center font-medium">
       <span>{formatCents(item.grossCents, currency)}</span>
       {item.discountCents > 0 ? (
-        <span className="truncate text-caption-2 text-pill-success-text">
+        <span className="truncate text-caption-2 text-[var(--success-text)]">
           − {formatCents(item.discountCents, currency)}
         </span>
       ) : null}
@@ -342,7 +342,11 @@ const FOOTER_BREAKDOWN_ROW =
 const FOOTER_FONT = '"Satoshi Variable", var(--font-satoshi), sans-serif';
 const NEUTRAL_TEXT = 'var(--color-neutral-900)';
 const PRIMARY_TEXT = 'var(--color-text-brand)';
-const DISCOUNT_TEXT = 'var(--color-success-700)';
+// --success-text, not the 700 step. The footer moved from a mint tint to the
+// warm --inset surface, and 700 (#008255) only measured 3.78:1 there - the
+// lighter mint had been carrying it. --success-text is the ink step (#006642,
+// 5.48) and it already inverts for dark.
+const DISCOUNT_TEXT = 'var(--success-text)';
 
 const FOOTER_HELPER_TEXT_STYLE: React.CSSProperties = {
   color: NEUTRAL_TEXT,

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/VisitTimer.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/VisitTimer.tsx
@@ -12,7 +12,12 @@ type VisitTimerProps = {
    */
   startAt?: string | Date;
   /** Booked slot end (`appointment.endTime`); when the elapsed time passes it, the
-   *  pill turns amber ("Over booked slot"). It never blocks actions. */
+   *  pill turns amber ("Over booked slot"). It never blocks actions.
+   *
+   *  The label takes the 900 ink step, not 700. The 700 step is a mid-ramp FILL
+   *  and measured 2.77:1 on its own warning-100 tint - this pill sits on every
+   *  workspace step, so it was the least readable thing on the busiest screen.
+   *  900 clears at 6.42 and already carries a dark-mode value. */
   bookedEndAt?: string | Date;
   className?: string;
   /**
@@ -85,7 +90,7 @@ const VisitTimerInner = ({ startMs, bookedEndAt, className, isPhone }: VisitTime
         <span
           data-testid="visit-timer"
           data-state="over"
-          className={`inline-flex shrink-0 items-center gap-1 rounded-full border border-warning-300 bg-warning-100 px-[9px] py-[5px] text-[10px] font-bold tabular-nums text-warning-700 ${className}`}
+          className={`inline-flex shrink-0 items-center gap-1 rounded-full border border-warning-300 bg-warning-100 px-[9px] py-[5px] text-[10px] font-bold tabular-nums text-warning-900 ${className}`}
         >
           <IoTimeOutline size={11} aria-hidden="true" />
           {toCompactElapsed(elapsed)}
@@ -96,7 +101,7 @@ const VisitTimerInner = ({ startMs, bookedEndAt, className, isPhone }: VisitTime
       <span
         data-testid="visit-timer"
         data-state="over"
-        className={`inline-flex shrink-0 items-center gap-1.5 rounded-full border border-warning-300 bg-warning-100 px-3 py-1.5 text-caption-1 font-semibold tabular-nums text-warning-700 ${className}`}
+        className={`inline-flex shrink-0 items-center gap-1.5 rounded-full border border-warning-300 bg-warning-100 px-3 py-1.5 text-caption-1 font-semibold tabular-nums text-warning-900 ${className}`}
       >
         <IoTimeOutline size={13} aria-hidden="true" />
         Over booked slot · {elapsed}

--- a/apps/frontend/src/app/features/tasks/pages/Tasks/Sections/TaskInfo/useTaskInfoFields.ts
+++ b/apps/frontend/src/app/features/tasks/pages/Tasks/Sections/TaskInfo/useTaskInfoFields.ts
@@ -34,11 +34,16 @@ export const useTaskInfoFields = ({
   const companions = useCompanionsForPrimaryOrg();
   const { resolveMemberName } = useMemberMap();
 
+  // An unresolvable member - one who left the practice, or belongs to another
+  // organisation - used to fall back to the raw id, so the task drawer's From and
+  // To rows read "c3b4a812-4051-701e-08ce-cb5c2a489951" where a name belongs. A
+  // UUID means nothing to the reader and is an internal identifier; it is not
+  // shown at all. Same fallback the Templates linked-services column had.
   const resolveMemberDisplay = useMemo(() => {
     return (id?: string) => {
       if (!id) return '-';
       const resolved = resolveMemberName(id);
-      return resolved === '-' ? id : resolved;
+      return resolved === '-' ? 'Unavailable member' : resolved;
     };
   }, [resolveMemberName]);
 
@@ -65,7 +70,7 @@ export const useTaskInfoFields = ({
         const parentId = companion.parentId;
         if (!parentId) return items;
         items.push({
-          label: resolveMemberDisplay(parentId) || parentId || companion.id,
+          label: resolveMemberDisplay(parentId),
           value: parentId,
         });
         return items;

--- a/apps/frontend/src/app/features/tasks/pages/Tasks/index.tsx
+++ b/apps/frontend/src/app/features/tasks/pages/Tasks/index.tsx
@@ -305,6 +305,14 @@ const Tasks = () => {
   return (
     <div className="flex flex-col relative">
       <div className="yc-page-content">
+        {/* No CTA in this header. Appointments seats its primary action inside
+            whichever toolbar the active view owns, and Tasks now does the same:
+            the calendar's Header, TaskFilterBar for the list, TaskBoard's own
+            toolbar for the board. Keeping one up here as well put "New task"
+            outside the calendar card, which is the difference you notice when
+            switching between the two planners, and it needed an `order-1` flex
+            hack to sit after the view toggle at all. On phone the create action
+            is the shell FAB either way. */}
         <TitleCalendar
           title="Tasks"
           description="Track to-dos, assign the team or pet parents, follow through"
@@ -317,18 +325,6 @@ const Tasks = () => {
           setActiveView={setActiveView}
           showAdd={false}
           viewOptions={['calendar', 'board', 'list']}
-          actionBeforeAdd={
-            // On phone the create action is the shell FAB, so the header CTA
-            // would be a duplicate - the design's "primary action -> FAB" rule.
-            // No CTA here. Appointments seats its primary action inside whichever
-            // toolbar the active view owns, and Tasks now does the same: the
-            // calendar's Header, TaskFilterBar for the list, TaskBoard's own
-            // toolbar for the board. Keeping one up here as well put "New task"
-            // outside the calendar card, which is the difference you notice when
-            // switching between the two planners - and it needed an `order-1`
-            // flex hack to sit after the view toggle at all.
-            undefined
-          }
         />
         <MobileSearchBar placeholder="Search tasks" />
 

--- a/apps/frontend/src/app/features/tasks/pages/Tasks/index.tsx
+++ b/apps/frontend/src/app/features/tasks/pages/Tasks/index.tsx
@@ -3,8 +3,6 @@ import React, { Suspense, useCallback, useMemo, useState } from 'react';
 import type { SetStateAction } from 'react';
 import dynamic from 'next/dynamic';
 import { useSearchParams } from 'next/navigation';
-import { IoAdd } from 'react-icons/io5';
-import { Primary } from '@/app/ui/primitives/Buttons';
 import ProtectedRoute from '@/app/ui/layout/guards/ProtectedRoute';
 import PageSkeleton from '@/app/ui/layout/PageSkeleton';
 import TitleCalendar from '@/app/ui/widgets/TitleCalendar';
@@ -25,6 +23,7 @@ import { PermissionGate } from '@/app/ui/layout/guards/PermissionGate';
 import { getPlannerLayoutClassNames, usePlannerAutoLock } from '@/app/hooks/usePlannerLayout';
 import MobileSearchBar from '@/app/ui/layout/MobileSearchBar/MobileSearchBar';
 import { usePhonePrimaryAction } from '@/app/ui/layout/PhoneShell/usePhonePrimaryAction';
+import { TASK_SCOPE_OPTIONS } from '@/app/features/tasks/pages/Tasks/taskScopeOptions';
 
 const TASKS_PAGE_SKELETON = <PageSkeleton variant="planner" />;
 
@@ -46,16 +45,6 @@ const PARENT_AUDIENCE_KEY = 'parent_task';
 const TASK_CALENDAR_FILTERS = TaskFilters.flatMap((option) =>
   option.key === PARENT_AUDIENCE_KEY ? [{ ...option, dotColor: 'var(--pink)' }] : []
 );
-
-/**
- * Assignee scope, kept as a segmented control (not an audience chip) so its
- * "Team" label never reads as the "Team" audience pill sitting next to it.
- * "My tasks" narrows every view to the tasks assigned to the signed-in member.
- */
-const TASK_SCOPE_OPTIONS = [
-  { key: 'mine', name: 'My tasks' },
-  { key: 'team', name: 'Team' },
-];
 
 const TaskPlannerSkeleton = () => (
   <div className="h-full min-h-125 rounded-2xl bg-card-hover animate-pulse" aria-hidden="true" />
@@ -277,6 +266,7 @@ const Tasks = () => {
         weekStart={weekStart}
         setWeekStart={setWeekStart}
         canEditTasks={canEditTasks}
+        onAddTask={openAddTask}
         onCreateFromCalendarSlot={handleCreateFromCalendarSlot}
         filterOptions={TASK_CALENDAR_FILTERS}
         activeFilter={appliedFilter}
@@ -330,17 +320,14 @@ const Tasks = () => {
           actionBeforeAdd={
             // On phone the create action is the shell FAB, so the header CTA
             // would be a duplicate - the design's "primary action -> FAB" rule.
-            canEditTasks && !isPhone ? (
-              <Primary
-                text="New task"
-                ariaLabel="New task"
-                onClick={openAddTask}
-                icon={<IoAdd size={16} aria-hidden="true" />}
-                // The design seats the CTA after the view toggle; this slot
-                // renders before it, so flex order restores that sequence.
-                className="order-1 whitespace-nowrap hover:scale-100"
-              />
-            ) : undefined
+            // No CTA here. Appointments seats its primary action inside whichever
+            // toolbar the active view owns, and Tasks now does the same: the
+            // calendar's Header, TaskFilterBar for the list, TaskBoard's own
+            // toolbar for the board. Keeping one up here as well put "New task"
+            // outside the calendar card, which is the difference you notice when
+            // switching between the two planners - and it needed an `order-1`
+            // flex hack to sit after the view toggle at all.
+            undefined
           }
         />
         <MobileSearchBar placeholder="Search tasks" />
@@ -356,6 +343,8 @@ const Tasks = () => {
                 filterOptions={TaskFilters}
                 statusOptions={TASK_STATUS_PILLS}
                 scopeOptions={TASK_SCOPE_OPTIONS}
+                showAddButton={canEditTasks && !isPhone}
+                onAddButtonClick={openAddTask}
                 activeFilter={activeFilter}
                 activeStatus={activeStatus}
                 activeScope={activeScope}

--- a/apps/frontend/src/app/features/tasks/pages/Tasks/taskScopeOptions.ts
+++ b/apps/frontend/src/app/features/tasks/pages/Tasks/taskScopeOptions.ts
@@ -1,0 +1,16 @@
+/**
+ * Assignee scope: whose tasks, as against the audience chips beside it, which say
+ * who the task is for. It is a segmented control rather than a chip to mark that
+ * difference, but shape alone was not enough - the audience chip for
+ * `employee_task` was also called "Team", so two adjacent buttons in the same
+ * toolbar carried the same word. That chip is "Staff" now (../../types/task.ts).
+ *
+ * Lifted out of the page component so the guard in TaskFilterBar.test.tsx can
+ * compare these names against the audience labels without importing the page.
+ *
+ * "My tasks" narrows every view to the tasks assigned to the signed-in member.
+ */
+export const TASK_SCOPE_OPTIONS = [
+  { key: 'mine', name: 'My tasks' },
+  { key: 'team', name: 'Team' },
+];

--- a/apps/frontend/src/app/features/tasks/types/task.ts
+++ b/apps/frontend/src/app/features/tasks/types/task.ts
@@ -219,8 +219,16 @@ export const TaskStatusFilters: StatusOption[] = [
   ),
 ];
 
+/**
+ * Audience: who the task is FOR. "Staff", not "Team" - the assignee SCOPE control
+ * sitting immediately to the left of these chips is "My tasks | Team", so the
+ * toolbar read "My tasks - Team - All - Team - Pet parents", two adjacent buttons
+ * with the same label meaning different things. Tasks/index.tsx tried to separate
+ * them by SHAPE (segmented control vs chip) and that was not enough. "Staff" also
+ * pairs properly with "Pet parents": staff-facing against client-facing.
+ */
 export const TaskFilters: FilterOption[] = [
   filter('All', 'all'),
-  filter('Team', 'employee_task'),
+  filter('Staff', 'employee_task'),
   filter('Pet parents', 'parent_task'),
 ];

--- a/apps/frontend/src/app/ui/layout/Sidebar/Sidebar.tsx
+++ b/apps/frontend/src/app/ui/layout/Sidebar/Sidebar.tsx
@@ -214,6 +214,7 @@ const Sidebar = () => {
                       <Link
                         className={routeClassName}
                         href={route.href}
+                        prefetch={false}
                         onClick={onClick}
                         aria-current={isActive ? 'page' : undefined}
                         aria-disabled={isDisabled || undefined}
@@ -231,6 +232,16 @@ const Sidebar = () => {
                     key={route.name}
                     className={routeClassName}
                     href={route.href}
+                    // Every sidebar route is permanently in the viewport, so the
+                    // App Router's default viewport prefetch fired an RSC request
+                    // for ALL of them on mount. Measured on dev: five of those
+                    // (/appointments, /chat, /tasks, /dashboard, /companions) took
+                    // 3.0-3.8s EACH and ran concurrently with the page's own data,
+                    // against a ~6-connection-per-origin cap - so the page you had
+                    // actually opened queued behind prefetches for pages you had
+                    // not. prefetch={false} drops the viewport prefetch; Next still
+                    // prefetches on hover, which is the point of intent anyway.
+                    prefetch={false}
                     onClick={onClick}
                     aria-current={isActive ? 'page' : undefined}
                     // A disabled route was disabled to the EYE only - greyed, with

--- a/apps/frontend/src/app/ui/primitives/Accordion/EditableAccordion.tsx
+++ b/apps/frontend/src/app/ui/primitives/Accordion/EditableAccordion.tsx
@@ -239,8 +239,26 @@ const normalizeOptions = (options?: Array<string | { label: string; value: strin
     typeof option === 'string' ? { label: option, value: option } : option
   ) ?? [];
 
+const formatDisplayValue = (value: unknown): string => {
+  if (Array.isArray(value)) {
+    return value.length > 0 ? value.join(', ') : '-';
+  }
+  if (value === undefined || value === null || value === '') {
+    return '-';
+  }
+  if (typeof value === 'object') return '-';
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  return '-';
+};
+
+// A value with no matching option falls back to the value itself, but an UNSET
+// one has to become the dash every other row uses - otherwise the row renders
+// with a label and nothing beside it, which reads as a rendering fault rather
+// than "not set". The task drawer's Priority row showed exactly that.
 const resolveLabel = (options: Array<{ label: string; value: string }>, value: string) =>
-  options.find((o) => o.value === value)?.label ?? value;
+  options.find((o) => o.value === value)?.label ?? formatDisplayValue(value);
 
 const EditableField = ({ field, value, error, onChange, onMultiChange }: EditableFieldProps) => {
   const type = field.type || 'text';
@@ -258,20 +276,6 @@ const EditableField = ({ field, value, error, onChange, onMultiChange }: Editabl
 
 const isCurrencyField = (fieldKey: string) => {
   return fieldKey === 'purchaseCost' || fieldKey === 'selling';
-};
-
-const formatDisplayValue = (value: unknown): string => {
-  if (Array.isArray(value)) {
-    return value.length > 0 ? value.join(', ') : '-';
-  }
-  if (value === undefined || value === null || value === '') {
-    return '-';
-  }
-  if (typeof value === 'object') return '-';
-  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
-    return String(value);
-  }
-  return '-';
 };
 
 const FieldValueRow = ({ label, children }: { label: string; children: React.ReactNode }) => (
@@ -345,7 +349,7 @@ const FieldValueComponents: Record<string, React.FC<FieldValueProps>> = {
   },
   time: ({ field, formValues }) => {
     const value = formValues[field.key];
-    return <FieldValueRow label={field.label}>{formatTimeLabel(value)}</FieldValueRow>;
+    return <FieldValueRow label={field.label}>{formatTimeLabel(value) || '-'}</FieldValueRow>;
   },
   timeInput: ({ field, formValues }) => {
     const value = formValues[field.key];


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

Follows #2232. The two planners look different because the warm-bone redesign only ever reached one of them - they are not a fork, they share `common/Header`, the hour labels are byte-identical, and the Team view has no divergence at all.

**The week date strip** was the loudest of it. Tasks put a filled 40px disc behind **every** date with the weekday beside it at 16px near-black; Appointments stacks a small caps weekday over a bare numeral and reserves the disc for today. The row read as seven grey buttons at roughly 1.5x the type size, and because every date already wore a disc, **"today" had no signal left** - the one thing the strip exists to tell you.

**Two 64px arrow rails** flanked it. `common/WeekCalendar.css` states the intent outright: "The week grid in the design has no arrow columns at all - prev/next live in the header toolbar's date-nav pill." The right rail also pushed Sunday out of view, so `getWeekDays` returned seven days and six fitted.

**The CTA sat outside the card.** Appointments seats its primary action in whichever toolbar the active view owns; Tasks kept "New task" up in the page header, where it needed an `order-1` flex hack to land after the view toggle at all.

**Two adjacent buttons both said "Team".** The assignee scope control is `My tasks | Team` and the audience chips were `All | Team | Pet parents`, so the toolbar read `My tasks · Team · All · Team · Pet parents`. A comment in the page had already noticed this and tried to fix it by **shape** (segmented control vs chip), which was not enough.

**Every sidebar route was prefetched on mount.** They are all permanently in the viewport, so the App Router's default fired an RSC request for all of them.

## What is the new behavior?

The strip matches `common/WeekCalendar.tsx:190-231` day for day, on the same `yc-table-head` recipe (10.5px / 700 / +0.1em caps) every other PIMS table header uses. That CSS is now imported explicitly rather than left to whichever table happened to pull it in - the Tasks planner may render no table at all.

Both rails are gone and the three grid tracks drop to two columns. Paging moved to the toolbar in #2232, and `Task/WeekCalendar` no longer builds a week-navigation hook it cannot use.

Each view carries its own CTA: the calendar's `Header`, `TaskFilterBar` for the list, `TaskBoard`'s own toolbar. `Header`'s label is a prop now, defaulting to the appointments wording.

The audience chip is **"Staff"**, which also pairs properly with "Pet parents" - staff-facing against client-facing. A guard fails the build if a scope name and an audience label ever collide again.

### The load-time complaint

Measured on dev rather than guessed. The five slowest resources on `/tasks` were all RSC route prefetches:

| Resource | Duration |
| --- | --- |
| `/appointments?_rsc=` | 3824 ms |
| `/chat?_rsc=` | 3823 ms |
| `/tasks?_rsc=` | 3822 ms |
| `/dashboard?_rsc=` | 3020 ms |
| `/companions?_rsc=` | 3015 ms |

Those ran concurrently with the page's own data against a ~6-connection-per-origin cap, so **the page you had actually opened queued behind prefetches for pages you had not**. The same load issues 83 XHR/fetch calls of its own that those five were competing with. `prefetch={false}` drops the viewport prefetch; Next still prefetches on hover, which is the point of intent anyway.

That is one of the four root causes in the perf diagnosis, not all of them - the 83-call boot waterfall is untouched here and wants its own change.

### Verification

- `DayLabels` gets a story, screenshotted in both themes; the strip is where the two calendars diverged most, so it is where a regression shows first
- Every behavioural change is pinned by a test, and the sidebar prefetch guard plus the week-pager guard were both mutation-checked
- 916 suites / 11275 tests; type-check and lint clean
- Storybook 492 stories, 489 rendering clean (3 are intentional closed states), **0 contrast failures** across {375 light, 375 dark, 1280 dark}

### Deliberately not in this change

The event-block geometry - radius, type scale, duration-scaling and the status spine. Structural, and it wants its own change with before/after screenshots.

## Related Issue(s)

Fixes #
