### PR TITLE
ci(repo): wait out a cooldown before proposing new dependency versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,27 @@ updates:
       timezone: 'UTC'
     target-branch: dev
     open-pull-requests-limit: 10
+    # Wait this long after a release before proposing it. This is the only
+    # defence in the repo against a compromised maintainer publishing a
+    # malicious version: the attacks that matter are caught and yanked within
+    # hours to days, so the whole value is in not being first to install.
+    #
+    # Dependabot already applies a 3 day cooldown when this block is absent, so
+    # what is bought here is the extra margin, and majors get the longest wait
+    # because they are the least reversible.
+    #
+    # Cooldown does NOT apply to security updates - GitHub exempts them - so an
+    # advisory-driven bump still arrives immediately. Nothing here delays a
+    # patch for a known vulnerability.
+    #
+    # Patches get the same 7 days as minors deliberately. The instinct is to let
+    # patches through faster, but a hijacked package is typically published AS a
+    # patch, so that is the release line the wait most needs to cover.
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 7
     # Only labels that exist in the repo. Dependabot cannot create labels, so an
     # unknown name makes it post a config error on every PR it opens instead of
     # applying the label.
@@ -181,6 +202,11 @@ updates:
       timezone: 'UTC'
     target-branch: dev
     open-pull-requests-limit: 5
+    # Same rationale as the npm entry above. Bundler supports cooldown; only
+    # `default-days` is used because the CocoaPods toolchain gems are few and
+    # do not need per-semver tuning.
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: 'chore(mobile)'
     labels:
@@ -202,6 +228,12 @@ updates:
       timezone: 'UTC'
     target-branch: dev
     open-pull-requests-limit: 10
+    # No `cooldown` here, and that is not an oversight: GitHub does not support
+    # cooldown for the github-actions ecosystem, and it is listed as "not
+    # currently supported" in the options reference. Adding it would be an
+    # unrecognised key rather than a longer wait. Actions are pinned by commit
+    # SHA throughout .github/workflows, which is the mitigation that applies to
+    # this ecosystem instead.
     commit-message:
       prefix: 'ci(repo)'
     labels:


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

Nothing in the repository detects a malicious or typosquatted dependency release. Aikido is the only source of malware detection, it is an external SaaS with no coupling to this repo, and unlike SAST, secrets and SCA - which are already covered by CodeQL, Gitleaks and Grype/Dependabot - there is no open-source equivalent to fall back on if it lapses.

pnpm 8.15.6 has no `minimumReleaseAge`, so the package manager cannot provide the wait either.

## What is the new behavior?

A cooldown on the npm and bundler ecosystems, so a freshly published version is not proposed until it has been in the wild for a while. Hijacked packages are typically caught and yanked within hours to days, so the entire defence is not being first to install.

| ecosystem | default | major | minor | patch |
| --- | --- | --- | --- | --- |
| npm | 7 days | 14 days | 7 days | 7 days |
| bundler | 7 days | - | - | - |
| github-actions | not supported | | | |

Three points worth reviewing:

- **Patches wait as long as minors, on purpose.** The instinct is to let patches through faster, but a compromised maintainer typically publishes AS a patch, so that is the release line the wait most needs to cover.
- **Security fixes are not delayed.** GitHub exempts security updates from cooldown, so an advisory-driven bump still arrives immediately. This only slows routine version updates.
- **github-actions gets nothing, deliberately.** GitHub lists that ecosystem as not supporting cooldown, so the key would be unrecognised rather than effective. Those actions are pinned by commit SHA across `.github/workflows`, which is the mitigation that applies there. The config now says so, to stop the inconsistency being "fixed" later.

Worth being straight about the size of the win: Dependabot already applies a **3 day** cooldown when unconfigured. This buys the extra margin and the explicit major/minor/patch shape, not the concept.

## Impact area

`.github/dependabot.yml` only. No code, no CI behaviour, no tests.

## Deployment caveat, please read

Per the note at the top of the file, **Dependabot reads this config from `main`, not `dev`**. Merging this to dev does not make it take effect. It stays inert until a dev to main promotion.

While checking that, I found the two branches have already drifted. `origin/dev` carries 12 lines that `origin/main` does not - the entire **TypeScript 7 major freeze**:

```yaml
- dependency-name: 'typescript'
  update-types: ['version-update:semver-major']
```

Since Dependabot reads main, that freeze is **not currently in effect**, and a TypeScript 7 major PR can still be opened on any Monday run. That is the same class of problem PR #2079 fixed, recurring. It is a release decision rather than something to fold into this PR, so flagging it rather than acting on it.

## Validation performed

- Config parses and the cooldown blocks land on the intended ecosystems:
  ```
  npm              cooldown={'default-days': 7, 'semver-major-days': 14, 'semver-minor-days': 7, 'semver-patch-days': 7}
  bundler          cooldown={'default-days': 7}
  github-actions   cooldown=None
  ```
- Schema and the security-update exemption verified against GitHub's Dependabot options reference rather than assumed.
- Prettier clean; gitleaks and secretlint pass via pre-commit hooks.

## Related Issue(s)

Refs #1721