### PR TITLE
ci(repo): run CodeQL's security-extended query suite

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,2 +1,18 @@
 paths-ignore:
   - apps/frontend/public/dev-docs/assets/**
+
+# The default query suite is tuned for very low false positives, which means it
+# stays quiet about whole classes of finding this codebase cares about. Aikido
+# has been the only thing looking for them, and it is an external SaaS with no
+# coupling to this repo, so the coverage disappears the day it lapses.
+#
+# security-extended adds the lower-precision security queries. It does not add
+# the maintainability and code-smell queries: that is security-and-quality, and
+# those overlap with the SonarCloud gate this repo already enforces at 95/0/0,
+# so pulling them in would add noise without adding safety.
+#
+# Declared here rather than as `queries:` on the init step, because a list there
+# REPLACES the config file's queries unless it is prefixed with `+`. Keeping the
+# suite in one place removes that footgun.
+queries:
+  - uses: security-extended

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -93,12 +93,10 @@ jobs:
           config-file: ./.github/codeql/codeql-config.yml
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
-          # If you wish to specify custom queries, you can do so here or in a config file.
-          # By default, queries listed here will override any specified in a config file.
-          # Prefix the list here with "+" to use these queries and those in the config file.
-
-          # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-          # queries: security-extended,security-and-quality
+          # Query suites live in the config file above, NOT here. A `queries:`
+          # list on this step replaces the config file's queries unless it is
+          # prefixed with `+`, so declaring them in one place avoids silently
+          # dropping the other. See .github/codeql/codeql-config.yml.
 
       # If the analyze step fails for one of the languages you are analyzing with
       # "We were unable to automatically build your code", modify the matrix above


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

CodeQL runs its default query suite, which is deliberately tuned for very low false positives and therefore stays silent about whole classes of finding. The line enabling a broader suite has sat commented out in `codeql.yml` since the workflow was scaffolded.

Aikido has been the only thing looking for those classes. It is an external SaaS with no coupling to this repo, so that coverage disappears the day it lapses.

## What is the new behavior?

`security-extended` is enabled in `.github/codeql/codeql-config.yml`.

- **`security-extended`, not `security-and-quality`.** The quality queries overlap with the SonarCloud gate this repo already enforces at 95/0/0, so they would add noise without adding safety.
- **Declared in the config file, not on the init step.** A `queries:` list on `codeql-action/init` *replaces* the config file's queries unless prefixed with `+`. Keeping the suite in one place removes that footgun, and the workflow comment now says so instead of suggesting the opposite.

## Impact area

CodeQL analysis only. No code, no build, no tests.

## Expected fallout, worth reviewing before merge

A broader suite means new alerts, and they will be pre-existing conditions the tool is only now looking for rather than anything this PR introduces. **Please look at the alert count on this run before merging.** If it is large, the sensible move is probably to merge and triage in a follow-up, since the alerts describe conditions that already exist either way - but that should be a deliberate decision, not a surprise found afterwards.

I called this a "one-liner" earlier and that was wrong: the config change is one line, the triage may not be.

## Validation performed

- Config and workflow both parse; the suite resolves as `queries: [{'uses': 'security-extended'}]`.
- Prettier clean; gitleaks and secretlint pass via pre-commit hooks.

## Related Issue(s)

Refs #1721
