### PR TITLE
test(frontend): property-based tests for the dosing and fluid engines

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -84,7 +84,9 @@
     "chromatic": "^16.0.0",
     "eslint": "^9",
     "eslint-config-next": "16.3.0",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-sonarjs": "^4.2.0",
+    "fast-check": "^4.9.0",
     "jest": "^30.4.2",
     "jest-axe": "^11.0.0",
     "jest-environment-jsdom": "^30.4.1",
@@ -93,7 +95,6 @@
     "tailwindcss": "^4.3.3",
     "ts-jest": "^29.4.12",
     "ts-node": "^10.9.2",
-    "typescript": "^5",
-    "eslint-plugin-react-hooks": "^7.1.1"
+    "typescript": "^5"
   }
 }

--- a/apps/frontend/src/app/features/calculators/__tests__/engine.properties.test.ts
+++ b/apps/frontend/src/app/features/calculators/__tests__/engine.properties.test.ts
@@ -1,0 +1,330 @@
+// Property-based tests for the dosing and fluid engines.
+//
+// The example-based suites next to this one pin specific clinical cases: a 20 kg
+// dog on a named protocol produces a named number. That catches a wrong formula,
+// but it cannot catch the failures that matter most here, because those only
+// appear away from the examples someone thought to write down. A dose that goes
+// non-monotonic at the top of the weight range, a division that yields Infinity
+// for an input the form actually permits, a NaN that renders as a blank field
+// beside the word "mg" - each is a plausible number produced for a real patient,
+// and each survives an example suite indefinitely.
+//
+// So these tests assert the properties that must hold across the whole
+// physiologic input space rather than at chosen points:
+//
+//   totality      every accepted input yields finite numbers, never NaN or
+//                 Infinity, because a drug volume of Infinity must never reach
+//                 a syringe
+//   monotonicity  more weight or a higher dose rate never yields less drug;
+//                 a faster fluid rate never makes a bag last longer
+//   rejection     inputs outside the physiologic range are refused with a typed
+//                 CalculatorInputError, not silently computed
+//
+// Ranges are chosen to span real veterinary practice: 0.1 kg covers a neonatal
+// kitten, 90 kg a giant-breed dog.
+//
+// Rounding makes every monotonicity property NON-strict. Two weights a gram
+// apart legitimately round to the same displayed dose, so these assert `>=`
+// rather than `>`; asserting strict growth would fail on correct code.
+
+import fc from 'fast-check';
+
+import { calculateConcentration } from '@/app/features/calculators/engine/concentration';
+import { calculateCri } from '@/app/features/calculators/engine/cri';
+import { calculateDripRate } from '@/app/features/calculators/engine/drip-rate';
+import { calculateEnergyRequirement } from '@/app/features/calculators/engine/energy';
+import { CalculatorInputError, roundTo } from '@/app/features/calculators/utils/shared';
+import { lbsToKg } from '@/app/features/calculators/utils/units';
+
+// Bounded, non-fractional-noise generators. `noNaN`/`noDefaultInfinity` keep the
+// arbitrary inside the domain the engines document as valid, so a failure means
+// the engine mishandled a legitimate input rather than that the test fed it
+// something the form would have rejected first.
+const weightKg = fc.double({ min: 0.1, max: 90, noNaN: true, noDefaultInfinity: true });
+const positive = (min: number, max: number) =>
+  fc.double({ min, max, noNaN: true, noDefaultInfinity: true });
+
+const isFiniteNumber = (value: number) => typeof value === 'number' && Number.isFinite(value);
+
+// Non-positive and non-finite values every engine must refuse. -0 is included on
+// purpose: it is <= 0, so it must be rejected, but a `value < 0` check would let
+// it through and produce a zero dose.
+const invalidInputs = [0, -0, -1, -0.0001, Number.NaN, Number.POSITIVE_INFINITY, -Infinity];
+
+describe('shared primitives', () => {
+  it('roundTo never invents a value, and stays within half a unit of the last place', () => {
+    fc.assert(
+      fc.property(
+        fc.double({ min: -1e6, max: 1e6, noNaN: true, noDefaultInfinity: true }),
+        fc.integer({ min: 0, max: 6 }),
+        (value, decimals) => {
+          const rounded = roundTo(value, decimals);
+          expect(Number.isFinite(rounded)).toBe(true);
+          expect(Math.abs(rounded - value)).toBeLessThanOrEqual(0.5 * 10 ** -decimals);
+        }
+      )
+    );
+  });
+
+  it('roundTo is monotonic, so rounding never reorders two doses', () => {
+    fc.assert(
+      fc.property(
+        fc.double({ min: 0, max: 1e5, noNaN: true, noDefaultInfinity: true }),
+        fc.double({ min: 0, max: 1e5, noNaN: true, noDefaultInfinity: true }),
+        fc.integer({ min: 0, max: 4 }),
+        (a, b, decimals) => {
+          const [low, high] = a <= b ? [a, b] : [b, a];
+          expect(roundTo(high, decimals)).toBeGreaterThanOrEqual(roundTo(low, decimals));
+        }
+      )
+    );
+  });
+});
+
+describe('lbsToKg', () => {
+  it('is order-preserving and finite across recorded patient weights', () => {
+    fc.assert(
+      fc.property(positive(0.1, 250), positive(0.1, 250), (a, b) => {
+        expect(isFiniteNumber(lbsToKg(a))).toBe(true);
+        const [low, high] = a <= b ? [a, b] : [b, a];
+        expect(lbsToKg(high)).toBeGreaterThanOrEqual(lbsToKg(low));
+      })
+    );
+  });
+
+  it('round-trips back to the original pounds within the rounding it applies', () => {
+    // The conversion rounds to two decimal places of kilograms, so a round trip
+    // can only be asserted to that tolerance, scaled back into pounds.
+    fc.assert(
+      fc.property(positive(1, 250), (lbs) => {
+        const backToLbs = lbsToKg(lbs) * 2.20462;
+        expect(Math.abs(backToLbs - lbs)).toBeLessThanOrEqual(0.02);
+      })
+    );
+  });
+});
+
+describe('calculateEnergyRequirement', () => {
+  it('produces finite energy figures for every valid weight', () => {
+    fc.assert(
+      fc.property(weightKg, fc.option(positive(0.8, 3), { nil: undefined }), (kg, merFactor) => {
+        const result = calculateEnergyRequirement({ weightKg: kg, merFactor });
+        expect(isFiniteNumber(result.rerKcalPerDay)).toBe(true);
+        expect(isFiniteNumber(result.merKcalPerDay)).toBe(true);
+        expect(result.rerKcalPerDay).toBeGreaterThanOrEqual(0);
+      })
+    );
+  });
+
+  it('never returns less energy for a heavier patient', () => {
+    fc.assert(
+      fc.property(weightKg, weightKg, (a, b) => {
+        const [low, high] = a <= b ? [a, b] : [b, a];
+        const lighter = calculateEnergyRequirement({ weightKg: low });
+        const heavier = calculateEnergyRequirement({ weightKg: high });
+        expect(heavier.rerKcalPerDay).toBeGreaterThanOrEqual(lighter.rerKcalPerDay);
+        expect(heavier.merKcalPerDay).toBeGreaterThanOrEqual(lighter.merKcalPerDay);
+      })
+    );
+  });
+
+  it('keeps maintenance at or above resting whenever the factor is at least 1', () => {
+    fc.assert(
+      fc.property(weightKg, positive(1, 3), (kg, merFactor) => {
+        const result = calculateEnergyRequirement({ weightKg: kg, merFactor });
+        expect(result.merKcalPerDay).toBeGreaterThanOrEqual(result.rerKcalPerDay);
+      })
+    );
+  });
+
+  it('reports grams per day only when a diet density is supplied', () => {
+    fc.assert(
+      fc.property(weightKg, fc.option(positive(50, 600), { nil: undefined }), (kg, density) => {
+        const result = calculateEnergyRequirement({ weightKg: kg, dietKcalPer100g: density });
+        if (density === undefined) {
+          expect(result.gramsPerDay).toBeNull();
+        } else {
+          expect(isFiniteNumber(result.gramsPerDay as number)).toBe(true);
+          expect(result.gramsPerDay as number).toBeGreaterThanOrEqual(0);
+        }
+      })
+    );
+  });
+
+  it.each(invalidInputs)('refuses weight %p with a typed error', (weight) => {
+    expect(() => calculateEnergyRequirement({ weightKg: weight })).toThrow(CalculatorInputError);
+  });
+});
+
+describe('calculateCri', () => {
+  // A constant-rate infusion is the highest-consequence calculation here: the
+  // output is milligrams of drug added to a bag that then runs into a patient
+  // unattended for hours.
+  const criInput = fc.record({
+    doseMcgPerKgMin: positive(0.1, 50),
+    weightKg,
+    bagVolumeMl: positive(50, 1000),
+    fluidRateMlPerHr: positive(1, 500),
+  });
+
+  it('produces finite quantities for every valid infusion', () => {
+    fc.assert(
+      fc.property(criInput, (input) => {
+        const result = calculateCri(input);
+        expect(isFiniteNumber(result.drugPerHourMcg)).toBe(true);
+        expect(isFiniteNumber(result.bagDurationHr)).toBe(true);
+        expect(isFiniteNumber(result.drugToAddMg)).toBe(true);
+        expect(result.drugToAddMg).toBeGreaterThanOrEqual(0);
+      })
+    );
+  });
+
+  it('never asks for less drug when the dose rate goes up', () => {
+    fc.assert(
+      fc.property(criInput, positive(1, 10), (input, multiplier) => {
+        const base = calculateCri(input);
+        const higher = calculateCri({
+          ...input,
+          doseMcgPerKgMin: input.doseMcgPerKgMin * multiplier,
+        });
+        expect(higher.drugPerHourMcg).toBeGreaterThanOrEqual(base.drugPerHourMcg);
+        expect(higher.drugToAddMg).toBeGreaterThanOrEqual(base.drugToAddMg);
+      })
+    );
+  });
+
+  it('never asks for less drug for a heavier patient', () => {
+    fc.assert(
+      fc.property(criInput, positive(1, 10), (input, multiplier) => {
+        const base = calculateCri(input);
+        const heavier = calculateCri({ ...input, weightKg: input.weightKg * multiplier });
+        expect(heavier.drugPerHourMcg).toBeGreaterThanOrEqual(base.drugPerHourMcg);
+      })
+    );
+  });
+
+  it('never makes a bag last longer by running it faster', () => {
+    fc.assert(
+      fc.property(criInput, positive(1, 10), (input, multiplier) => {
+        const base = calculateCri(input);
+        const faster = calculateCri({
+          ...input,
+          fluidRateMlPerHr: input.fluidRateMlPerHr * multiplier,
+        });
+        expect(faster.bagDurationHr).toBeLessThanOrEqual(base.bagDurationHr);
+      })
+    );
+  });
+
+  it('reports a drug volume only when a concentration is supplied', () => {
+    fc.assert(
+      fc.property(criInput, fc.option(positive(0.1, 500), { nil: undefined }), (input, conc) => {
+        const result = calculateCri({ ...input, drugConcentrationMgPerMl: conc });
+        if (conc === undefined) {
+          expect(result.drugVolumeToAddMl).toBeNull();
+        } else {
+          expect(isFiniteNumber(result.drugVolumeToAddMl as number)).toBe(true);
+        }
+      })
+    );
+  });
+
+  it.each(invalidInputs)('refuses a dose rate of %p with a typed error', (dose) => {
+    expect(() =>
+      calculateCri({
+        doseMcgPerKgMin: dose,
+        weightKg: 10,
+        bagVolumeMl: 500,
+        fluidRateMlPerHr: 50,
+      })
+    ).toThrow(CalculatorInputError);
+  });
+
+  it.each(invalidInputs)('refuses a fluid rate of %p rather than dividing by it', (rate) => {
+    // Without the guard this is a division by zero, and a bag duration of
+    // Infinity propagates into the milligrams of drug to add.
+    expect(() =>
+      calculateCri({
+        doseMcgPerKgMin: 5,
+        weightKg: 10,
+        bagVolumeMl: 500,
+        fluidRateMlPerHr: rate,
+      })
+    ).toThrow(CalculatorInputError);
+  });
+});
+
+describe('calculateConcentration', () => {
+  it('converts percent to mg/mL and scales volume with dose', () => {
+    fc.assert(
+      fc.property(positive(0.1, 100), positive(0.1, 5000), (percent, doseMg) => {
+        const result = calculateConcentration({ percentSolution: percent, doseMg });
+        expect(isFiniteNumber(result.concentrationMgPerMl)).toBe(true);
+        expect(isFiniteNumber(result.volumeMl as number)).toBe(true);
+        expect(result.volumeMl as number).toBeGreaterThanOrEqual(0);
+      })
+    );
+  });
+
+  it('never requires more volume from a stronger solution', () => {
+    fc.assert(
+      fc.property(positive(0.1, 100), positive(1, 20), positive(1, 5000), (percent, mult, dose) => {
+        const weaker = calculateConcentration({ percentSolution: percent, doseMg: dose });
+        const stronger = calculateConcentration({
+          percentSolution: percent * mult,
+          doseMg: dose,
+        });
+        expect(stronger.volumeMl as number).toBeLessThanOrEqual(weaker.volumeMl as number);
+      })
+    );
+  });
+
+  it.each(invalidInputs)('refuses a solution strength of %p', (percent) => {
+    expect(() => calculateConcentration({ percentSolution: percent })).toThrow(
+      CalculatorInputError
+    );
+  });
+});
+
+describe('calculateDripRate', () => {
+  it('produces finite figures for every valid rate', () => {
+    fc.assert(
+      fc.property(
+        positive(1, 1000),
+        fc.option(positive(10, 60), { nil: undefined }),
+        (rate, gtt) => {
+          const result = calculateDripRate({ rateMlPerHr: rate, dropFactorGttPerMl: gtt });
+          expect(isFiniteNumber(result.dropsPerMin)).toBe(true);
+          expect(isFiniteNumber(result.secondsPerDrop)).toBe(true);
+        }
+      )
+    );
+  });
+
+  it('never counts fewer drops per minute at a faster rate', () => {
+    fc.assert(
+      fc.property(positive(1, 1000), positive(1, 10), (rate, multiplier) => {
+        const base = calculateDripRate({ rateMlPerHr: rate });
+        const faster = calculateDripRate({ rateMlPerHr: rate * multiplier });
+        expect(faster.dropsPerMin).toBeGreaterThanOrEqual(base.dropsPerMin);
+      })
+    );
+  });
+
+  it('displays 0 drops per minute below roughly 1.5 mL/hr on a standard set', () => {
+    // Pinning existing behaviour rather than asserting it is desirable. With the
+    // default 20 gtt/mL set, 1 mL/hr is a third of a drop per minute and rounds
+    // to zero, so the field reads "0" while fluid is genuinely running. It is
+    // defensible - drops are not countable at that rate, and such patients are
+    // on a syringe pump - but it is behaviour worth being deliberate about, and
+    // secondsPerDrop stays finite because it is derived before the rounding.
+    const result = calculateDripRate({ rateMlPerHr: 1 });
+    expect(result.dropsPerMin).toBe(0);
+    expect(Number.isFinite(result.secondsPerDrop)).toBe(true);
+    expect(result.secondsPerDrop).toBeGreaterThan(0);
+  });
+
+  it.each(invalidInputs)('refuses a fluid rate of %p', (rate) => {
+    expect(() => calculateDripRate({ rateMlPerHr: rate })).toThrow(CalculatorInputError);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -616,6 +616,9 @@ importers:
       eslint-plugin-sonarjs:
         specifier: ^4.2.0
         version: 4.2.0(eslint@9.39.2)
+      fast-check:
+        specifier: ^4.9.0
+        version: 4.9.0
       jest:
         specifier: ^30.4.2
         version: 30.4.2(@types/node@26.2.0)(ts-node@10.9.2)
@@ -19696,6 +19699,13 @@ packages:
       pure-rand: 8.4.0
     dev: true
 
+  /fast-check@4.9.0:
+    resolution: {integrity: sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==}
+    engines: {node: '>=12.17.0'}
+    dependencies:
+      pure-rand: 8.4.0
+    dev: true
+
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -22103,7 +22113,7 @@ packages:
       pretty-format: 30.4.1
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.2(@types/node@26.2.0)(typescript@5.0.4)
+      ts-node: 10.9.2(@types/node@26.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

The clinical calculators compute drug doses, infusion rates and fluid volumes for real patients, and every existing suite is example-based: a 20 kg dog on a named protocol produces a named number.

That catches a wrong formula. It cannot catch the failures that matter most here, because those only appear away from the examples someone thought to write down:

- a dose that goes non-monotonic at the top of the weight range
- a division that yields `Infinity` for an input the form actually permits
- a `NaN` that renders as a blank field beside the word "mg"

Each is a plausible-looking number produced for a real patient, and each survives an example suite indefinitely.

## What is the new behavior?

`fast-check` is added as a frontend devDependency, and one property suite asserts what must hold across the whole physiologic input space, from a 0.1 kg neonatal kitten to a 90 kg giant breed:

| property | assertion |
| --- | --- |
| totality | every accepted input yields finite numbers, never NaN or Infinity |
| monotonicity | more weight or a higher dose rate never yields less drug; a faster fluid rate never makes a bag last longer |
| rejection | zero, negative, NaN and Infinity are refused with a typed `CalculatorInputError` |

Covers `cri`, `energy`, `concentration` and `drip-rate`, plus the shared `roundTo` and the `lbsToKg` conversion every calculator depends on.

Two details worth reviewing:

- **`-0` is in the invalid-input set on purpose.** It is `<= 0` so it must be rejected, but a `value < 0` check would admit it and produce a zero dose.
- **Monotonicity is asserted non-strictly.** Two weights a gram apart legitimately round to the same displayed dose, so `>=` is the true property; `>` would fail on correct code.

## Impact area

Tests only. No engine code changed. One new devDependency (`fast-check`) and the lockfile.

## One behaviour pinned rather than endorsed

Below roughly 1.5 mL/hr on a standard 20 gtt/mL set, drops per minute rounds to **0** while fluid is genuinely running. A test now pins this so it cannot change silently.

It is defensible: drops are not countable at that rate and such patients are on a syringe pump. `secondsPerDrop` stays finite because it is derived before the rounding. But it is worth someone deciding it deliberately rather than inheriting it. Happy to open a follow-up if you would rather the field showed something other than `0`.

## Validation performed

- 53 property tests pass; full calculator suite 40 files / 317 tests pass.
- `npx tsc --noemit` clean, `pnpm --filter frontend run lint` clean, prettier clean.
- **The properties were verified to have teeth by mutation rather than trusted for passing.** Removing the CRI fluid-rate guard (the divide-by-zero protection) fails 7 of them; inverting the metabolic exponent from `0.75` to `-0.75` fails monotonicity. Both engines were restored afterwards and the working tree confirmed clean.

## Related Issue(s)

Refs #1721
