### PR TITLE
ci(repo): gate PR coverage on the lines a branch adds

### DIFF
--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -44,6 +44,20 @@ env:
       "backend": "lines=1",
       "mobile": "lines=1"
     }
+  # Per-app floors for the PR-only diff-coverage gate: the minimum share of the
+  # executable lines a pull request ADDS that must be covered.
+  #
+  # Only frontend and desktop are listed. Both enforce a real merged-coverage
+  # floor above and both collect coverage from uncovered files, so a new untested
+  # line shows up in the map at zero hits for the gate to catch. backend and
+  # mobile carry only a lines=1 tripwire, not a coverage bar, so they get no diff
+  # floor either - an app the aggregate gate does not hold to a number is not one
+  # this gate second-guesses. An app absent here is skipped, not failed.
+  DIFF_COVERAGE_FLOORS: >-
+    {
+      "frontend": "90",
+      "desktop": "90"
+    }
 
 jobs:
   plan:
@@ -180,6 +194,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          # Full history so the diff-coverage step can diff HEAD against the pull
+          # request's base; a shallow checkout has no merge base to diff from.
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Setup
@@ -202,6 +219,31 @@ jobs:
             exit 1
           fi
           node scripts/ci/merge-coverage.mjs --shards shards --out merged --floor "$FLOOR"
+
+      # Diff-coverage runs on pull requests only. It needs a base to diff HEAD
+      # against, and it answers a question - "does this change cover the lines it
+      # adds" - that only a pull request poses; the aggregate floor above runs on
+      # every event and cannot catch untested lines a single PR introduces while
+      # the app total stays above the bar. An app with no floor configured is
+      # skipped with a log line, not failed.
+      - name: Enforce diff coverage on added lines (PR only)
+        if: github.event_name == 'pull_request'
+        env:
+          APP: ${{ matrix.app_key }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          FLOOR=$(printf '%s' "$DIFF_COVERAGE_FLOORS" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>process.stdout.write(JSON.parse(s)[process.env.APP]??""))')
+          if [ -z "$FLOOR" ]; then
+            echo "No diff-coverage floor configured for '$APP'; skipping the added-line gate."
+            exit 0
+          fi
+          git diff "$BASE_SHA...HEAD" > diff.patch
+          node scripts/ci/diff-coverage.mjs \
+            --diff diff.patch \
+            --map merged/coverage-final.json \
+            --root "$GITHUB_WORKSPACE" \
+            --floor "$FLOOR"
 
       # istanbul writes SF: paths relative to the repo root. Sonar is given
       # projectBaseDir=<app dir>, so the app prefix has to come off or every path

--- a/docs/ci/coverage.md
+++ b/docs/ci/coverage.md
@@ -1,0 +1,91 @@
+# Coverage gates in CI
+
+Two coverage gates run in the test workflow, and they measure different things.
+
+## The aggregate floor (every run)
+
+After the sharded test legs finish, `scripts/ci/merge-coverage.mjs` merges each
+app's shard reports into one istanbul map and enforces that app's floor from the
+`COVERAGE_FLOORS` map in `.github/workflows/_test.yaml`. This is a whole-app
+figure: the statements, branches, functions and lines of the entire app must sit
+above the configured numbers.
+
+An aggregate floor is the right tool for holding a project at a level, but it
+cannot see a single change. A well-covered app can absorb a block of untested
+lines without dipping under its floor - the project was already far enough above
+the bar that the new gap does not drag the total under it. The floor stays green
+while the debt lands.
+
+## The diff-coverage gate (pull requests only)
+
+`scripts/ci/diff-coverage.mjs` closes that gap. It runs only on pull requests,
+after the merge step, and measures the coverage of the executable lines the
+branch ADDS rather than the app as a whole.
+
+### What it measures
+
+- **Added lines.** The step runs `git diff <base>...HEAD` - a three-dot diff
+  against the pull request's merge base, so only the lines this branch
+  introduced relative to where it forked are in scope, not unrelated commits the
+  base has moved on to. The parser records the new-file line numbers each hunk
+  adds.
+- **Executable lines only.** Each added line is looked up in the merged istanbul
+  map. A line the map records is measured, and counts as covered when its hit
+  count is above zero. A line the map does not record - a comment, a blank line,
+  or a file istanbul never instrumented such as a doc or a config - is not
+  executable, is not measured, and does not count against the floor.
+- **New files fail honestly.** A brand-new source file with no test is still
+  instrumented, because the gated apps collect coverage from uncovered files, so
+  every one of its added lines shows up in the map at zero hits and the gate
+  fails as it should. A docs-only or comment-only change adds nothing
+  measurable and passes.
+
+The pass condition is `covered / measured >= floor`. When a change adds no
+executable lines at all, there is nothing to gate and the step passes.
+
+### Which apps are gated, and why
+
+The per-app floors live in `DIFF_COVERAGE_FLOORS`, beside `COVERAGE_FLOORS`.
+Only `frontend` and `desktop` are listed, both at 90. Those two enforce a real
+aggregate coverage floor and both collect coverage from uncovered files, so a
+newly added untested line reliably appears in the map at zero hits for this gate
+to catch.
+
+`backend` and `mobile` carry only a `lines=1` tripwire in `COVERAGE_FLOORS`, not
+a real coverage bar, so they get no diff floor either: an app the aggregate gate
+does not hold to a number is not one this gate second-guesses. An app absent
+from `DIFF_COVERAGE_FLOORS` is skipped with a log line, not failed.
+
+### Fail-closed behaviour
+
+Like `merge-coverage.mjs` and `lcov-check.mjs`, the gate refuses to pass on the
+absence of data. A missing, empty, or unparseable map, or a map that records no
+files, fails the step rather than reporting a clean run over nothing - an absent
+map means the pipeline broke upstream, not that the change is covered. A bad
+`--floor` value fails the same way.
+
+## Running it locally
+
+The gate is a plain Node script with no CI-only inputs, so it runs against a
+patch and a merged map on disk:
+
+```bash
+# Coverage map: merge your app's coverage report(s) the same way CI does, or
+# reuse an existing apps/<app>/coverage/coverage-final.json from a coverage run.
+git diff origin/dev...HEAD > /tmp/diff.patch
+
+node scripts/ci/diff-coverage.mjs \
+  --diff /tmp/diff.patch \
+  --map apps/frontend/coverage/coverage-final.json \
+  --root "$(git rev-parse --show-toplevel)" \
+  --floor 90
+```
+
+The script prints the covered/measured tally, the resulting percentage against
+the floor, and a compact line range of any uncovered added lines per file. It
+exits non-zero when the added-line coverage falls below the floor.
+
+The pure functions - `parseUnifiedDiff`, `evaluateDiffCoverage`, `formatRanges`
+
+- and the fail-closed exit codes are covered by
+  `scripts/ci/diff-coverage.test.mjs`, which runs under `pnpm run test:scripts`.

--- a/scripts/ci/diff-coverage.mjs
+++ b/scripts/ci/diff-coverage.mjs
@@ -1,0 +1,243 @@
+#!/usr/bin/env node
+// Enforce coverage on the executable lines a pull request ADDS, not the project
+// as a whole.
+//
+// Usage:
+//   node scripts/ci/diff-coverage.mjs \
+//     --diff <patch> --map <coverage-final.json> --root <dir> --floor <pct>
+//
+//   --diff   a unified diff (git diff base...HEAD) naming the lines this branch
+//            adds
+//   --map    the merged istanbul map merge-coverage.mjs writes, which records a
+//            hit count per executable line
+//   --root   the repository root the map's paths and the diff's paths share, so
+//            one can be matched against the other
+//   --floor  the minimum share of added executable lines that must be covered
+//
+// The aggregate floors in merge-coverage.mjs answer "is the whole app above the
+// bar", which a change can satisfy while adding a block of untested lines: the
+// project was already well above the floor, so the new gap does not drag the
+// total under it. This measures only the lines the diff adds, so a single PR's
+// untested code fails on its own account regardless of the project total.
+//
+// Only executable lines count. A line the diff adds that istanbul never
+// instrumented - a comment, a blank line, a file with no coverage report at all
+// such as a doc or a config - is not measured and does not count against the
+// floor. A new source file with no test, by contrast, is instrumented with
+// every line at zero hits (its app collects coverage from uncovered files), so
+// it fails as it should.
+//
+// Fails closed: a missing, empty or unparseable map fails rather than passing
+// unmeasured, the same reasoning merge-coverage.mjs and lcov-check.mjs apply to
+// a coverage report that measured nothing.
+//
+// Dependency-light by design, like the other scripts here: only Node and
+// istanbul-lib-coverage, which the merge step already installs.
+
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import libCoverage from 'istanbul-lib-coverage';
+import { resolveWithin } from './safe-path.mjs';
+
+function fail(message) {
+  console.error(`diff-coverage: ${message}`);
+  process.exit(1);
+}
+
+function parseArgs(argv) {
+  const args = { diff: '', map: '', root: '', floor: '' };
+  for (let i = 0; i < argv.length; i += 2) {
+    const flag = argv[i];
+    const value = argv[i + 1];
+    if (!['--diff', '--map', '--root', '--floor'].includes(flag))
+      fail(`unknown argument '${flag}'`);
+    if (!value) fail(`${flag} requires a value`);
+    args[flag.slice(2)] = value;
+  }
+  if (!args.diff || !args.map || !args.root || !args.floor)
+    fail('usage: --diff <patch> --map <coverage-final.json> --root <dir> --floor <pct>');
+  return args;
+}
+
+// git prefixes the two sides of a diff with a/ and b/. A rename or a plain edit
+// keeps them; strip whichever is present so the path matches the map's.
+function stripDiffPrefix(target) {
+  if (target.startsWith('a/') || target.startsWith('b/')) return target.slice(2);
+  return target;
+}
+
+/**
+ * Parse a unified diff into the set of line numbers each file gains.
+ *
+ * The new-file side is tracked: `+++ b/<path>` names the file (a `+++ /dev/null`
+ * is a deletion and adds nothing), each `@@ -a,b +c,d @@` header resets the
+ * counter to the hunk's new-file start, and from there a `+` line records the
+ * current line and advances it while a context line only advances it. Deleted
+ * (`-`) lines belong to the old side and never move the new-file counter.
+ */
+export function parseUnifiedDiff(text) {
+  const addedLinesByFile = new Map();
+  let file = null;
+  let newLine = 0;
+  let inHunk = false;
+
+  for (const raw of text.split('\n')) {
+    if (raw.startsWith('+++ ')) {
+      const target = raw.slice(4).trim();
+      file = target === '/dev/null' ? null : stripDiffPrefix(target);
+      inHunk = false;
+      continue;
+    }
+    if (raw.startsWith('--- ')) continue;
+
+    const header = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(raw);
+    if (header) {
+      newLine = Number(header[1]);
+      inHunk = true;
+      continue;
+    }
+
+    if (!inHunk || file === null) continue;
+    if (raw.startsWith('+')) {
+      let lines = addedLinesByFile.get(file);
+      if (!lines) {
+        lines = new Set();
+        addedLinesByFile.set(file, lines);
+      }
+      lines.add(newLine);
+      newLine += 1;
+    } else if (raw.startsWith(' ')) {
+      newLine += 1;
+    }
+  }
+  return addedLinesByFile;
+}
+
+/**
+ * Measure the added lines against the merged coverage map.
+ *
+ * The map is keyed by absolute path; it is indexed by path relative to `root`
+ * so the diff's repo-relative paths can address it, and an entry that escapes
+ * `root` is dropped rather than resolved. An added line is measured only if the
+ * file's line coverage records it - a non-executable line is absent and skipped
+ * - and counts as covered when its hit count is above zero.
+ */
+export function evaluateDiffCoverage({ coverageMapJson, addedLinesByFile, root }) {
+  const map = libCoverage.createCoverageMap(coverageMapJson);
+
+  const byRelPath = new Map();
+  for (const filePath of map.files()) {
+    const relative = path.relative(root, filePath);
+    if (resolveWithin(root, relative) === null) continue;
+    byRelPath.set(relative, filePath);
+  }
+
+  let measured = 0;
+  let covered = 0;
+  const uncoveredByFile = new Map();
+
+  for (const [file, lines] of addedLinesByFile) {
+    const filePath = byRelPath.get(file);
+    if (!filePath) continue;
+    const lineCoverage = map.fileCoverageFor(filePath).getLineCoverage();
+    const uncovered = [];
+    for (const line of lines) {
+      const hits = lineCoverage[line];
+      if (hits === undefined) continue;
+      measured += 1;
+      if (hits > 0) covered += 1;
+      else uncovered.push(line);
+    }
+    if (uncovered.length > 0)
+      uncoveredByFile.set(
+        file,
+        uncovered.sort((a, b) => a - b)
+      );
+  }
+
+  const pct = measured === 0 ? 100 : (covered / measured) * 100;
+  return { measured, covered, pct, uncoveredByFile };
+}
+
+/** Collapse a sorted line list into a compact `a-b,c` string for the report. */
+export function formatRanges(sortedLines) {
+  const ranges = [];
+  let start = null;
+  let prev = null;
+  for (const line of sortedLines) {
+    if (start === null) {
+      start = line;
+      prev = line;
+    } else if (line === prev + 1) {
+      prev = line;
+    } else {
+      ranges.push(start === prev ? `${start}` : `${start}-${prev}`);
+      start = line;
+      prev = line;
+    }
+  }
+  if (start !== null) ranges.push(start === prev ? `${start}` : `${start}-${prev}`);
+  return ranges.join(',');
+}
+
+function main(argv) {
+  const args = parseArgs(argv);
+
+  const floor = Number(args.floor);
+  if (Number.isNaN(floor) || floor < 0 || floor > 100)
+    fail(`bad floor '${args.floor}', expected a number between 0 and 100`);
+
+  if (!existsSync(args.diff)) fail(`diff '${args.diff}' does not exist`);
+  const addedLinesByFile = parseUnifiedDiff(readFileSync(args.diff, 'utf8'));
+
+  if (!existsSync(args.map)) fail(`coverage map '${args.map}' does not exist`);
+  const rawMap = readFileSync(args.map, 'utf8');
+  if (rawMap.trim() === '') fail(`coverage map '${args.map}' is empty`);
+  let coverageMapJson;
+  try {
+    coverageMapJson = JSON.parse(rawMap);
+  } catch (error) {
+    fail(`cannot parse coverage map '${args.map}': ${error.message}`);
+  }
+  if (
+    !coverageMapJson ||
+    typeof coverageMapJson !== 'object' ||
+    Object.keys(coverageMapJson).length === 0
+  )
+    fail(`coverage map '${args.map}' records no files, so it measures nothing`);
+
+  const { measured, covered, pct, uncoveredByFile } = evaluateDiffCoverage({
+    coverageMapJson,
+    addedLinesByFile,
+    root: args.root,
+  });
+
+  if (measured === 0) {
+    console.log('diff-coverage: no added executable lines to measure; nothing to gate.');
+    return 0;
+  }
+
+  console.log(`diff-coverage: ${covered}/${measured} added executable line(s) covered`);
+  console.log(`  coverage: ${pct.toFixed(2)}%  (floor ${floor}%)`);
+  for (const [file, lines] of uncoveredByFile) {
+    console.log(`  uncovered ${file}: ${formatRanges(lines)}`);
+  }
+
+  if (pct < floor) {
+    console.error(
+      `diff-coverage: added-line coverage ${pct.toFixed(2)}% is below the ${floor}% floor`
+    );
+    return 1;
+  }
+  console.log('diff-coverage: added lines meet the floor.');
+  return 0;
+}
+
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url))
+) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/scripts/ci/diff-coverage.test.mjs
+++ b/scripts/ci/diff-coverage.test.mjs
@@ -1,0 +1,337 @@
+// Tests for the PR-only diff-coverage gate. The pure functions carry the
+// acceptance criteria; main() is exercised as a subprocess so the fail-closed
+// exit codes are pinned too.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseUnifiedDiff, evaluateDiffCoverage, formatRanges } from './diff-coverage.mjs';
+
+const script = join(dirname(fileURLToPath(import.meta.url)), 'diff-coverage.mjs');
+const ROOT = '/repo';
+
+// Build one istanbul file-coverage entry: a statement per line with the given
+// hit count, which is exactly the shape getLineCoverage() reads a line hit from.
+function fileCoverage(filePath, lineHits) {
+  const statementMap = {};
+  const s = {};
+  let index = 0;
+  for (const [line, hits] of Object.entries(lineHits)) {
+    statementMap[index] = {
+      start: { line: Number(line), column: 0 },
+      end: { line: Number(line), column: 20 },
+    };
+    s[index] = hits;
+    index += 1;
+  }
+  return { path: filePath, statementMap, s, fnMap: {}, f: {}, branchMap: {}, b: {} };
+}
+
+function coverageMap(entries) {
+  const map = {};
+  for (const [relative, lineHits] of Object.entries(entries)) {
+    const filePath = join(ROOT, relative);
+    map[filePath] = fileCoverage(filePath, lineHits);
+  }
+  return map;
+}
+
+function runMain(args) {
+  try {
+    const stdout = execFileSync('node', [script, ...args], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { status: 0, stdout, stderr: '' };
+  } catch (error) {
+    return {
+      status: error.status,
+      stdout: `${error.stdout ?? ''}`,
+      stderr: `${error.stderr ?? ''}`,
+    };
+  }
+}
+
+function withTemp(diffText, mapJson, run) {
+  const dir = mkdtempSync(join(tmpdir(), 'diff-cov-'));
+  try {
+    const diffPath = join(dir, 'diff.patch');
+    const mapPath = join(dir, 'coverage-final.json');
+    writeFileSync(diffPath, diffText);
+    if (mapJson !== null) writeFileSync(mapPath, mapJson);
+    return run({ dir, diffPath, mapPath });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('(1) an added uncovered line fails and names the line range', () => {
+  const diff = [
+    'diff --git a/apps/frontend/src/foo.ts b/apps/frontend/src/foo.ts',
+    '--- a/apps/frontend/src/foo.ts',
+    '+++ b/apps/frontend/src/foo.ts',
+    '@@ -1,3 +1,5 @@',
+    ' const a = 1;',
+    '+const b = 2;',
+    '+const c = 3;',
+    ' const d = 4;',
+    ' const e = 5;',
+    '',
+  ].join('\n');
+  const added = parseUnifiedDiff(diff);
+  assert.deepEqual([...added.get('apps/frontend/src/foo.ts')], [2, 3]);
+
+  const map = coverageMap({ 'apps/frontend/src/foo.ts': { 2: 0, 3: 0 } });
+  const result = evaluateDiffCoverage({
+    coverageMapJson: map,
+    addedLinesByFile: added,
+    root: ROOT,
+  });
+  assert.equal(result.measured, 2);
+  assert.equal(result.covered, 0);
+  assert.equal(formatRanges(result.uncoveredByFile.get('apps/frontend/src/foo.ts')), '2-3');
+
+  withTemp(diff, JSON.stringify(map), ({ diffPath, mapPath }) => {
+    const r = runMain(['--diff', diffPath, '--map', mapPath, '--root', ROOT, '--floor', '90']);
+    assert.equal(r.status, 1);
+    assert.match(r.stdout, /uncovered apps\/frontend\/src\/foo\.ts: 2-3/);
+  });
+});
+
+test('(2) touching a legacy file measures only its added lines', () => {
+  const diff = [
+    'diff --git a/apps/frontend/src/legacy.ts b/apps/frontend/src/legacy.ts',
+    '--- a/apps/frontend/src/legacy.ts',
+    '+++ b/apps/frontend/src/legacy.ts',
+    '@@ -9,2 +9,3 @@',
+    ' existing();',
+    '+added();',
+    ' more();',
+    '',
+  ].join('\n');
+  const added = parseUnifiedDiff(diff);
+  assert.deepEqual([...added.get('apps/frontend/src/legacy.ts')], [10]);
+
+  // Line 5 is an untested legacy line; only the added line 10 (covered) counts.
+  const map = coverageMap({ 'apps/frontend/src/legacy.ts': { 5: 0, 10: 4 } });
+  const result = evaluateDiffCoverage({
+    coverageMapJson: map,
+    addedLinesByFile: added,
+    root: ROOT,
+  });
+  assert.equal(result.measured, 1);
+  assert.equal(result.covered, 1);
+  assert.equal(result.pct, 100);
+  assert.equal(result.uncoveredByFile.size, 0);
+});
+
+test('(3) a new untested source file fails - every added line is zero-hit', () => {
+  const diff = [
+    'diff --git a/apps/frontend/src/new.ts b/apps/frontend/src/new.ts',
+    'new file mode 100644',
+    '--- /dev/null',
+    '+++ b/apps/frontend/src/new.ts',
+    '@@ -0,0 +1,3 @@',
+    '+export function untested() {',
+    '+  return 1;',
+    '+}',
+    '',
+  ].join('\n');
+  const added = parseUnifiedDiff(diff);
+  assert.deepEqual([...added.get('apps/frontend/src/new.ts')], [1, 2, 3]);
+
+  const map = coverageMap({ 'apps/frontend/src/new.ts': { 1: 0, 2: 0, 3: 0 } });
+  const result = evaluateDiffCoverage({
+    coverageMapJson: map,
+    addedLinesByFile: added,
+    root: ROOT,
+  });
+  assert.equal(result.measured, 3);
+  assert.equal(result.covered, 0);
+  assert.equal(result.pct, 0);
+
+  withTemp(diff, JSON.stringify(map), ({ diffPath, mapPath }) => {
+    const r = runMain(['--diff', diffPath, '--map', mapPath, '--root', ROOT, '--floor', '90']);
+    assert.equal(r.status, 1);
+    assert.match(r.stdout, /uncovered apps\/frontend\/src\/new\.ts: 1-3/);
+  });
+});
+
+test('(4) a docs and comment-only diff passes - nothing executable is added', () => {
+  const diff = [
+    'diff --git a/docs/ci/coverage.md b/docs/ci/coverage.md',
+    '--- a/docs/ci/coverage.md',
+    '+++ b/docs/ci/coverage.md',
+    '@@ -1,1 +1,2 @@',
+    ' # Coverage',
+    '+A new paragraph.',
+    'diff --git a/apps/frontend/src/foo.ts b/apps/frontend/src/foo.ts',
+    '--- a/apps/frontend/src/foo.ts',
+    '+++ b/apps/frontend/src/foo.ts',
+    '@@ -3,2 +3,3 @@',
+    ' const kept = 1;',
+    '+// a clarifying comment',
+    ' const also = 2;',
+    '',
+  ].join('\n');
+  const added = parseUnifiedDiff(diff);
+  // docs is absent from the map entirely; the comment line 4 is non-executable.
+  const map = coverageMap({ 'apps/frontend/src/foo.ts': { 3: 5, 5: 5 } });
+  const result = evaluateDiffCoverage({
+    coverageMapJson: map,
+    addedLinesByFile: added,
+    root: ROOT,
+  });
+  assert.equal(result.measured, 0);
+  assert.equal(result.pct, 100);
+
+  withTemp(diff, JSON.stringify(map), ({ diffPath, mapPath }) => {
+    const r = runMain(['--diff', diffPath, '--map', mapPath, '--root', ROOT, '--floor', '90']);
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /nothing to gate/);
+  });
+});
+
+test('(5) a missing, empty or unparseable map fails rather than passing unmeasured', () => {
+  const diff = [
+    '--- a/apps/frontend/src/foo.ts',
+    '+++ b/apps/frontend/src/foo.ts',
+    '@@ -1,1 +1,2 @@',
+    ' const a = 1;',
+    '+const b = 2;',
+    '',
+  ].join('\n');
+
+  withTemp(diff, null, ({ dir, diffPath }) => {
+    const r = runMain([
+      '--diff',
+      diffPath,
+      '--map',
+      join(dir, 'absent.json'),
+      '--root',
+      ROOT,
+      '--floor',
+      '90',
+    ]);
+    assert.equal(r.status, 1);
+    assert.match(r.stderr, /does not exist/);
+  });
+  withTemp(diff, '', ({ diffPath, mapPath }) => {
+    const r = runMain(['--diff', diffPath, '--map', mapPath, '--root', ROOT, '--floor', '90']);
+    assert.equal(r.status, 1);
+    assert.match(r.stderr, /is empty/);
+  });
+  withTemp(diff, '{ not json', ({ diffPath, mapPath }) => {
+    const r = runMain(['--diff', diffPath, '--map', mapPath, '--root', ROOT, '--floor', '90']);
+    assert.equal(r.status, 1);
+    assert.match(r.stderr, /cannot parse coverage map/);
+  });
+  withTemp(diff, '{}', ({ diffPath, mapPath }) => {
+    const r = runMain(['--diff', diffPath, '--map', mapPath, '--root', ROOT, '--floor', '90']);
+    assert.equal(r.status, 1);
+    assert.match(r.stderr, /records no files/);
+  });
+});
+
+test('(6) coverage exactly on the floor passes', () => {
+  const diff = [
+    '--- a/apps/frontend/src/edge.ts',
+    '+++ b/apps/frontend/src/edge.ts',
+    '@@ -1,1 +1,3 @@',
+    ' const a = 1;',
+    '+const covered = 2;',
+    '+const missed = 3;',
+    '',
+  ].join('\n');
+  const added = parseUnifiedDiff(diff);
+  assert.deepEqual([...added.get('apps/frontend/src/edge.ts')], [2, 3]);
+
+  const map = coverageMap({ 'apps/frontend/src/edge.ts': { 2: 1, 3: 0 } });
+  const result = evaluateDiffCoverage({
+    coverageMapJson: map,
+    addedLinesByFile: added,
+    root: ROOT,
+  });
+  assert.equal(result.pct, 50);
+
+  withTemp(diff, JSON.stringify(map), ({ diffPath, mapPath }) => {
+    const r = runMain(['--diff', diffPath, '--map', mapPath, '--root', ROOT, '--floor', '50']);
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /meet the floor/);
+  });
+});
+
+test('(7) the parser handles multiple hunks, dev-null deletions and renames', () => {
+  const diff = [
+    'diff --git a/a.ts b/a.ts',
+    '--- a/a.ts',
+    '+++ b/a.ts',
+    '@@ -1,2 +1,3 @@',
+    ' x',
+    '+y',
+    ' z',
+    '@@ -10,2 +11,3 @@',
+    ' p',
+    '+q',
+    ' r',
+    'diff --git a/gone.ts b/gone.ts',
+    'deleted file mode 100644',
+    '--- a/gone.ts',
+    '+++ /dev/null',
+    '@@ -1,2 +0,0 @@',
+    '-old1',
+    '-old2',
+    'diff --git a/old-name.ts b/new-name.ts',
+    'similarity index 90%',
+    'rename from old-name.ts',
+    'rename to new-name.ts',
+    '--- a/old-name.ts',
+    '+++ b/new-name.ts',
+    '@@ -5,3 +5,4 @@',
+    ' m',
+    '+n',
+    ' o',
+    ' p',
+    '',
+  ].join('\n');
+  const added = parseUnifiedDiff(diff);
+  assert.deepEqual([...added.get('a.ts')], [2, 12]);
+  assert.deepEqual([...added.get('new-name.ts')], [6]);
+  assert.equal(added.has('gone.ts'), false);
+});
+
+test('formatRanges collapses runs and keeps singletons', () => {
+  assert.equal(formatRanges([1, 2, 3, 7, 9, 10]), '1-3,7,9-10');
+  assert.equal(formatRanges([5]), '5');
+  assert.equal(formatRanges([]), '');
+});
+
+test('an unknown flag and a bad floor both fail closed', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'diff-cov-'));
+  try {
+    const diffPath = join(dir, 'd.patch');
+    const mapPath = join(dir, 'm.json');
+    writeFileSync(diffPath, '');
+    writeFileSync(mapPath, '{}');
+    const unknown = runMain(['--bogus', 'x']);
+    assert.equal(unknown.status, 1);
+    assert.match(unknown.stderr, /unknown argument/);
+    const badFloor = runMain([
+      '--diff',
+      diffPath,
+      '--map',
+      mapPath,
+      '--root',
+      ROOT,
+      '--floor',
+      'high',
+    ]);
+    assert.equal(badFloor.status, 1);
+    assert.match(badFloor.stderr, /bad floor/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/scripts/ci/merge-coverage.mjs
+++ b/scripts/ci/merge-coverage.mjs
@@ -15,11 +15,15 @@
 // evaluates against nothing. Merging the istanbul coverage maps keeps all four
 // metrics intact, and lcov is generated once from the merged map for Sonar.
 //
+// The merged istanbul map is also written back out as coverage-final.json, so
+// the PR-only diff-coverage gate can read per-line hit counts (lcov keeps them
+// too, but the map is the shape diff-coverage.mjs already consumes).
+//
 // A floor is enforced here rather than through jest's own coverageThreshold
 // because a sharded run gives each shard only a slice of the files; a global
 // threshold would fail on every shard regardless of the real total.
 
-import { readdirSync, mkdirSync, readFileSync, statSync } from 'node:fs';
+import { readdirSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { resolveWithin } from './safe-path.mjs';
 import libCoverage from 'istanbul-lib-coverage';
@@ -102,6 +106,7 @@ const covered = map.files().length;
 if (covered === 0) fail('merged coverage map contains no files');
 
 mkdirSync(args.out, { recursive: true });
+writeFileSync(path.join(args.out, 'coverage-final.json'), JSON.stringify(map.toJSON()));
 reports
   .create('lcovonly', { file: 'lcov.info' })
   .execute(libReport.createContext({ dir: args.out, coverageMap: map }));


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

CI enforces an aggregate coverage floor per app: `merge-coverage.mjs` merges the per-shard istanbul maps and fails if the merged total drops below the configured floor. That check runs on every event but cannot see individual pull requests. A PR can add untested new code and still pass, because the app-wide total stays above the bar while the newly added lines go uncovered. There is no per-PR check on the lines a branch actually adds, and no documentation of how the coverage gates work.

## What is the new behavior?

Adds a PR-only diff-coverage gate that enforces coverage on the executable lines a pull request adds.

- `scripts/ci/diff-coverage.mjs` (new): parses a unified diff, maps each added line to per-line hit counts in the merged istanbul map, and fails when the covered share of added executable lines falls below a per-app floor. Non-instrumented added lines (comments, blanks, files with no coverage instrumentation) are excluded from the denominator; a newly added untested source file is instrumented at zero hits and therefore counts against the floor. The gate fails closed when the coverage map is missing, empty, or unparseable.
- `scripts/ci/merge-coverage.mjs`: also writes the merged istanbul map to `coverage-final.json`, the shape `diff-coverage.mjs` consumes for per-line hit counts. The existing lcov output and aggregate floor are unchanged.
- `.github/workflows/_test.yaml`: sets `fetch-depth: 0` on checkout so the merge base is available to diff against, adds a `DIFF_COVERAGE_FLOORS` env (frontend and desktop at 90; backend and mobile are omitted and therefore skipped, matching their aggregate `lines=1` tripwire), and adds a `pull_request`-only step that diffs `BASE_SHA...HEAD` and runs the gate. An app with no floor configured is skipped with a log line, not failed.
- `docs/ci/coverage.md` (new): documents both the aggregate floor and the diff-coverage gate.

## Related Issue(s)

Fixes #2233

## Validation performed

- `pnpm run test:scripts` reported 149/149 passing, including the new `diff-coverage.test.mjs` cases covering the diff parser, coverage evaluation, range formatting, and the fail-closed exit-code paths.
- Manual end-to-end runs exercised each acceptance criterion, including the missing/empty/unparseable-map fail-closed behavior.
- `actionlint` and a YAML parse of `_test.yaml` ran clean.

Not verified: the gate has not yet run inside an actual GitHub Actions `pull_request` event; the full CI matrix behavior will be confirmed on this PR's own run.

Closes #2233
