### PR TITLE
chore(repo): scope code ownership to ankit-yc and aupyay

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,9 @@
-# Default ownership
-* @YosemiteCrew
+# Default ownership. A bare org account is not resolvable as a code owner, so
+# ownership is held by users with write access.
+* @ankit-yc @aupyay
 
 # Repository governance
-/.github/ @YosemiteCrew
-/AGENTS.md @YosemiteCrew
-/CONTRIBUTING.md @YosemiteCrew
-/SECURITY.md @YosemiteCrew
+/.github/ @ankit-yc @aupyay
+/AGENTS.md @ankit-yc @aupyay
+/CONTRIBUTING.md @ankit-yc @aupyay
+/SECURITY.md @ankit-yc @aupyay


### PR DESCRIPTION
Narrows CODEOWNERS to the two accounts that own this repo.

- openrunic previously listed `@ankit-yc @harshvardhan-yc` on every path.
- Yosemite-Crew previously listed the bare org account `@YosemiteCrew`, which GitHub cannot resolve as a code owner, so ownership was effectively unset.

Both now list `@ankit-yc @aupyay`.

This matters because code owners are auto-requested for review when a ruleset enables `require_code_owner_review`. Neither dev ruleset has that on today, so this changes no current behaviour - it makes the file correct for when it is.