### PR TITLE
fix(frontend): write the IDEXX order notes for vets, not for us

### DIFF
--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/DiagnosticsStep.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/DiagnosticsStep.test.tsx
@@ -453,7 +453,7 @@ describe('DiagnosticsStep (workspace, real IDEXX backend)', () => {
   it('renders the in-house census variant and triggers add/refresh census', () => {
     const { hook } = renderStep({ modality: 'INHOUSE', selectedIvls: '1234567890' });
 
-    expect(screen.getByText(/In-house IDEXX workflow/i)).toBeInTheDocument();
+    expect(screen.getByText(/In-house tests run on your IVLS device/i)).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: /add to census/i }));
     expect(hook.handleAddToCensus).toHaveBeenCalled();
@@ -520,7 +520,7 @@ describe('DiagnosticsStep (workspace, real IDEXX backend)', () => {
       devices: [{ deviceSerialNumber: '99887', displayName: '' }],
     } as unknown as Partial<UseLabTestsReturn>);
 
-    expect(screen.getByText(/In-house IDEXX workflow/i)).toBeInTheDocument();
+    expect(screen.getByText(/In-house tests run on your IVLS device/i)).toBeInTheDocument();
   });
 
   it('toggles the result breakdown with the view action', () => {

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/DiagnosticsStep.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/DiagnosticsStep.tsx
@@ -358,8 +358,8 @@ const ReferenceOrderBuilder = ({ s }: { s: UseLabTestsReturn }) => (
       />
       <PendingTestConfirmation s={s} />
       <p className="max-w-2xl text-body-4 text-text-secondary">
-        IDEXX test reference data does not explicitly flag tests as in-house vs device-specific in
-        this contract. Use reference lab for external IDEXX ordering.
+        Reference lab tests are submitted to IDEXX for processing. Add the tests you need and place
+        the order; results attach to this appointment when IDEXX returns them.
       </p>
       <div className="flex min-h-24 flex-1 [&>div]:h-full [&>div>div]:h-full [&_textarea]:h-full [&_textarea]:resize-none">
         <FormDesc
@@ -406,7 +406,7 @@ const InhouseOrderBuilder = ({ s }: { s: UseLabTestsReturn }) => {
       <div className="flex flex-col gap-4">
         <p className="max-w-2xl text-body-4 text-text-secondary">
           {terminologyText(
-            'In-house IDEXX workflow requires selecting an IVLS device, then adding the patient to census here. Complete ordering on the IDEXX machine after census is confirmed.'
+            'In-house tests run on your IVLS device. Select the device and add the patient to census here, then complete the order on the IDEXX machine.'
           )}
         </p>
         <output

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/LabTests.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/LabTests.tsx
@@ -976,9 +976,12 @@ const InhouseCensusStatus = ({ s }: { s: UseLabTestsReturn }) => {
 
 const ReferenceLabForm = ({ s }: { s: UseLabTestsReturn }) => (
   <>
-    <div className="text-caption-1 text-text-secondary">
-      IDEXX test reference data does not explicitly flag tests as in-house vs device-specific in
-      this contract. Use reference lab for external IDEXX ordering.
+    {/* text-body-4, matching the In-house note in the sibling form below and the
+        same paragraph on the workspace step. These two notes are a pair and were
+        rendering at different type scales. */}
+    <div className="text-body-4 text-text-secondary">
+      Reference lab tests are submitted to IDEXX for processing. Add the tests you need and place
+      the order; results attach to this appointment when IDEXX returns them.
     </div>
     <SearchDropdown
       placeholder="Search IDEXX tests"
@@ -1073,8 +1076,8 @@ const ReferenceLabForm = ({ s }: { s: UseLabTestsReturn }) => (
 const InhouseLabForm = ({ s }: { s: UseLabTestsReturn }) => (
   <>
     <div className="text-body-4 text-text-secondary">
-      In-house IDEXX workflow requires selecting an IVLS device, then adding the companion to census
-      here. Complete ordering on the IDEXX machine after census is confirmed.
+      In-house tests run on your IVLS device. Select the device and add the companion to census
+      here, then complete the order on the IDEXX machine.
     </div>
     <LabelDropdown
       placeholder="Select IVLS device"


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The Order Builder on the appointment workspace Diagnostics step tells a clinician this:

> IDEXX test reference data does not explicitly flag tests as in-house vs device-specific in this contract. Use reference lab for external IDEXX ordering.

Two problems. It describes **our data model** rather than the reader's task, and its one instruction is circular: the paragraph only renders **because** Reference lab is already the selected mode, so "use reference lab" is advice they have already taken.

The In-house note on the other branch of the same control has the same problem in milder form. It opens with the implementation ("In-house IDEXX workflow requires...") rather than the task, though it is at least actionable once you reach the end of it.

Seen live at [the Diagnostics step](https://dev.yosemitecrew.com/appointments/93e9f2f6-f544-45bb-8179-f9af791c44e1/workspace?step=DIAGNOSTICS).

## What is the new behavior?

Each note now leads with what the reader does and what happens next.

**Reference lab**
> Reference lab tests are submitted to IDEXX for processing. Add the tests you need and place the order; results attach to this appointment when IDEXX returns them.

**In-house**
> In-house tests run on your IVLS device. Select the device and add the patient to census here, then complete the order on the IDEXX machine.

Both notes appear **twice** - on the workspace Diagnostics step and in the appointment-info LabTests forms - so all four strings are updated. The In-house one keeps its `terminologyText` wrapper, so "patient" still follows the organisation's chosen term.

One thing found while in these exact elements: in `LabTests` the two notes were rendering at **different type scales** (`text-caption-1` against `text-body-4`) despite being a matched pair on two branches of one control. The Reference lab one now uses the `text-body-4` its sibling and the workspace copy already use.

### Wording

Confirmed with the product owner before shipping, along with the decision to include the In-house note rather than scope this to the flagged string alone.

### Validation

- `pnpm --filter frontend run type-check` clean
- `pnpm --filter frontend run lint` clean
- 101 tests across `LabTests` and `DiagnosticsStep`; two assertions had pinned the old wording and now pin the new
- Worked on a fresh worktree branched off `dev`

No behaviour changes - copy and one type-scale correction.

## Related Issue(s)

Fixes #
