### PR TITLE
fix(frontend): draw the task chip like the appointment block, and render the gated panels

### DIFF
--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/TaskMarker.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/TaskMarker.stories.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import type { Task } from '@/app/features/tasks/types/task';
+import { TaskMarker } from './TaskSlot';
+
+const task = (over: Partial<Task> = {}): Task =>
+  ({
+    _id: 'task-1',
+    name: 'Recheck sutures',
+    status: 'PENDING',
+    audience: 'EMPLOYEE_TASK',
+    dueAt: new Date(2026, 7, 17, 9, 30),
+    ...over,
+  }) as unknown as Task;
+
+/** One hour of grid, so the chip has somewhere to sit. */
+const Hour = (Story: React.ComponentType) => (
+  <div className="relative w-[240px]" style={{ height: 180, backgroundColor: 'var(--neutral-0)' }}>
+    <Story />
+  </div>
+);
+
+const meta = {
+  title: 'Appointments/Calendar/TaskMarker',
+  component: TaskMarker,
+  decorators: [Hour],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'The task chip, and the last piece of the Tasks calendar that did not match the ' +
+          'appointment block sitting beside it.\n\n' +
+          'It was a 16px radius with a drop shadow, a plain 1px border all round and a 14px ' +
+          'title, where the appointment block is a **flat** 12px card over a 1px status outline ' +
+          'thickened to a **3px spine** on its leading edge, titled at 12.5px/700. Two objects ' +
+          'that mean the same thing, drawn as different things. The radius was also set in two ' +
+          'competing places - a `!` utility class and an inline style - so changing either one ' +
+          'alone did nothing.\n\n' +
+          'It now follows `common/ZoomInMarker.tsx`: 12px flat, the status spine, the 12.5px/700 ' +
+          'title and the 11px/400 subtitle. Two things are deliberately kept: the pink glow and ' +
+          'dot on a pet-parent task, which is a semantic signal rather than chrome, and the pill ' +
+          'shape when zoomed out.\n\n' +
+          'The chips are draggable and showed a plain arrow cursor, so they did not read as ' +
+          'movable at all. They take `cursor-grab` now, as the appointment blocks already did.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    task: task(),
+    layout: { top: 12, laneIndex: 0, laneCount: 1 },
+    height: 180,
+    isZoomOutMode: false,
+    isActive: false,
+    popoverId: 'task-popover',
+    canDrag: true,
+    onView: fn(),
+    onOpenPopover: fn(),
+    onFocusPopover: fn(),
+    onClosePopover: fn(),
+    onDragStart: fn(),
+    onDragEnd: fn(),
+  },
+} satisfies Meta<typeof TaskMarker>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Pending: Story = {};
+
+export const InProgress: Story = {
+  args: { task: task({ name: 'Post-op check', status: 'IN_PROGRESS' }) },
+};
+
+export const Completed: Story = {
+  args: { task: task({ name: 'Bandage change', status: 'COMPLETED' }) },
+  parameters: {
+    docs: { story: 'A completed task strikes its title through.' },
+  },
+};
+
+export const ParentTask: Story = {
+  name: 'Pet-parent task',
+  args: { task: task({ name: 'Send discharge notes', audience: 'PARENT_TASK' }) },
+  parameters: {
+    docs: {
+      story:
+        'The one chip that keeps a shadow. The pink glow and leading dot mark a task owned by ' +
+        'the pet parent rather than the practice, which is meaning, not decoration.',
+    },
+  },
+};
+
+export const SideBySide: Story = {
+  name: 'Two lanes',
+  args: { layout: { top: 12, laneIndex: 0, laneCount: 2 } },
+  parameters: {
+    docs: {
+      story:
+        'With more than one task in an hour the chips go compact: tighter padding and centred ' +
+        'text. This is where the old 14px title ran out of room first.',
+    },
+  },
+};
+
+export const ZoomedOut: Story = {
+  name: 'Zoomed out (lozenge)',
+  args: { isZoomOutMode: true },
+  parameters: {
+    docs: {
+      story:
+        'At the zoomed-out density the chip is a bare pill with no label, so it keeps its full ' +
+        'radius and takes no spine.',
+    },
+  },
+};
+
+export const NotDraggable: Story = {
+  name: 'Read-only (no drag)',
+  args: { canDrag: false },
+};

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/TaskSlot.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/TaskSlot.tsx
@@ -165,7 +165,12 @@ const TaskDropOverlays = ({
 type TaskMarkerLayout = { top: number; laneIndex: number; laneCount: number };
 
 /** One task block in the hour column, with its hover-revealed view shortcut. */
-const TaskMarker = ({
+/**
+ * Exported for its story. The task chip is the calendar's most-repeated object
+ * and had drifted a long way from the appointment block it sits beside, so it is
+ * worth being able to see it on its own in both themes.
+ */
+export const TaskMarker = ({
   task,
   layout,
   height,
@@ -202,9 +207,15 @@ const TaskMarker = ({
     : Math.max(44, (TASK_BLOCK_DURATION_MINUTES / 60) * height - 2);
   const isCompact = !isZoomOutMode && laneCount > 1;
   const compactPaddingClass = isCompact ? 'px-1.5 py-1' : 'px-2 py-1.5';
+  // 12px, matching common/ZoomInMarker.tsx:111. The radius is set in TWO places -
+  // this `!` utility and the inline style on the button below - so changing one
+  // alone does nothing. The zoomed-out lozenge keeps its pill shape.
+  // cursor-grab: these cards are draggable and showed a plain arrow, so they did
+  // not read as movable at all; the appointment blocks already do this.
+  const cursorClass = canDrag ? 'cursor-grab active:cursor-grabbing' : 'cursor-pointer';
   const markerClassName = isZoomOutMode
-    ? 'size-full text-left rounded-full! overflow-hidden p-0 border border-transparent'
-    : `size-full text-left rounded-2xl! overflow-hidden ${compactPaddingClass} flex flex-col justify-between`;
+    ? `size-full text-left rounded-full! overflow-hidden p-0 border border-transparent ${cursorClass}`
+    : `size-full text-left rounded-xl! overflow-hidden ${compactPaddingClass} flex flex-col justify-between ${cursorClass}`;
   const dueTimeLabel = formatDateInPreferredTimeZone(new Date(task.dueAt), {
     hour: 'numeric',
     minute: '2-digit',
@@ -234,8 +245,14 @@ const TaskMarker = ({
           backgroundColor: markerStyle.backgroundColor,
           border: `1px solid ${markerStyle.borderColor}`,
           color: markerStyle.color,
-          borderRadius: isZoomOutMode ? 9999 : 16,
-          boxShadow: isParentTask ? '0 4px 12px var(--glow-p12)' : '0 1px 2px var(--sh05)',
+          borderRadius: isZoomOutMode ? 9999 : 12,
+          // The appointment block is FLAT over a 1px status outline thickened to a
+          // 3px spine on the leading edge; this carried a drop shadow and a plain
+          // 1px border all round, which is most of why the two calendars' events
+          // read as different objects. The parent-task glow stays: that is a
+          // semantic signal (pet-parent task), not chrome.
+          borderLeftWidth: isZoomOutMode ? undefined : '3px',
+          boxShadow: isParentTask ? '0 4px 12px var(--glow-p12)' : undefined,
         }}
         title={markerTitle}
         onClick={onView}
@@ -251,9 +268,9 @@ const TaskMarker = ({
         {isZoomOutMode ? null : (
           <>
             <div
-              className={`text-caption-1 truncate ${isCompact ? 'text-center' : ''} ${
-                isCompletedTask ? 'line-through' : ''
-              }`}
+              className={`truncate text-[12.5px] font-bold leading-[1.2] tracking-[-0.25px] ${
+                isCompact ? 'text-center' : ''
+              } ${isCompletedTask ? 'line-through' : ''}`}
               style={{ color: markerStyle.color }}
             >
               {isParentTask && (
@@ -266,7 +283,12 @@ const TaskMarker = ({
               {task.name || '-'}
             </div>
             <div
-              className={`text-[10px] truncate ${isCompact ? 'text-center' : ''}`}
+              // 11px, matching the appointment block's subtitle recipe
+              // (common/ZoomInMarker.tsx:63). font-normal against the title's new
+              // 700 is what separates them now, rather than a size drop to 10px.
+              className={`truncate font-satoshi text-[11px] font-normal leading-[1.2] tracking-[-0.22px] ${
+                isCompact ? 'text-center' : ''
+              }`}
               // No alpha: markerStyle.color is a status token measured against
               // its own fill, and 0.8 took this 10px line to 3.98:1. The line is
               // already quieter than the task name by size alone.

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/TaskSlot.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/TaskSlot.tsx
@@ -166,6 +166,41 @@ type TaskMarkerLayout = { top: number; laneIndex: number; laneCount: number };
 
 /** One task block in the hour column, with its hover-revealed view shortcut. */
 /**
+ * Geometry and classes for one task chip. Pure, and driven only by the two mode
+ * flags, so it lives outside TaskMarker rather than adding four more branches
+ * to a component that is mostly wiring.
+ *
+ * The radius is deliberately set in BOTH the `!` utility here and the inline
+ * style on the button: they compete, so changing one alone does nothing.
+ * cursor-grab because these chips are draggable and used to show a plain arrow,
+ * so they did not read as movable; the appointment blocks already do this.
+ */
+const getTaskMarkerLayout = ({
+  isZoomOutMode,
+  laneCount,
+  canDrag,
+  height,
+}: {
+  isZoomOutMode: boolean;
+  laneCount: number;
+  canDrag: boolean;
+  height: number;
+}) => {
+  const markerHeight = isZoomOutMode
+    ? Math.max(8, Math.min(12, (TASK_BLOCK_DURATION_MINUTES / 60) * height))
+    : Math.max(44, (TASK_BLOCK_DURATION_MINUTES / 60) * height - 2);
+  const isCompact = !isZoomOutMode && laneCount > 1;
+  const cursorClass = canDrag ? 'cursor-grab active:cursor-grabbing' : 'cursor-pointer';
+  const markerClassName = isZoomOutMode
+    ? `size-full text-left rounded-full! overflow-hidden p-0 border border-transparent ${cursorClass}`
+    : `size-full text-left rounded-xl! overflow-hidden ${
+        isCompact ? 'px-1.5 py-1' : 'px-2 py-1.5'
+      } flex flex-col justify-between ${cursorClass}`;
+
+  return { markerHeight, isCompact, markerClassName };
+};
+
+/**
  * Exported for its story. The task chip is the calendar's most-repeated object
  * and had drifted a long way from the appointment block it sits beside, so it is
  * worth being able to see it on its own in both themes.
@@ -202,20 +237,12 @@ export const TaskMarker = ({
   const { top, laneIndex, laneCount } = layout;
   const widthPercent = 100 / laneCount;
   const leftPercent = laneIndex * widthPercent;
-  const markerHeight = isZoomOutMode
-    ? Math.max(8, Math.min(12, (TASK_BLOCK_DURATION_MINUTES / 60) * height))
-    : Math.max(44, (TASK_BLOCK_DURATION_MINUTES / 60) * height - 2);
-  const isCompact = !isZoomOutMode && laneCount > 1;
-  const compactPaddingClass = isCompact ? 'px-1.5 py-1' : 'px-2 py-1.5';
-  // 12px, matching common/ZoomInMarker.tsx:111. The radius is set in TWO places -
-  // this `!` utility and the inline style on the button below - so changing one
-  // alone does nothing. The zoomed-out lozenge keeps its pill shape.
-  // cursor-grab: these cards are draggable and showed a plain arrow, so they did
-  // not read as movable at all; the appointment blocks already do this.
-  const cursorClass = canDrag ? 'cursor-grab active:cursor-grabbing' : 'cursor-pointer';
-  const markerClassName = isZoomOutMode
-    ? `size-full text-left rounded-full! overflow-hidden p-0 border border-transparent ${cursorClass}`
-    : `size-full text-left rounded-xl! overflow-hidden ${compactPaddingClass} flex flex-col justify-between ${cursorClass}`;
+  const { markerHeight, isCompact, markerClassName } = getTaskMarkerLayout({
+    isZoomOutMode,
+    laneCount,
+    canDrag,
+    height,
+  });
   const dueTimeLabel = formatDateInPreferredTimeZone(new Date(task.dueAt), {
     hour: 'numeric',
     minute: '2-digit',

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/TaskSlot.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/TaskSlot.tsx
@@ -191,11 +191,10 @@ const getTaskMarkerLayout = ({
     : Math.max(44, (TASK_BLOCK_DURATION_MINUTES / 60) * height - 2);
   const isCompact = !isZoomOutMode && laneCount > 1;
   const cursorClass = canDrag ? 'cursor-grab active:cursor-grabbing' : 'cursor-pointer';
+  const paddingClass = isCompact ? 'px-1.5 py-1' : 'px-2 py-1.5';
   const markerClassName = isZoomOutMode
     ? `size-full text-left rounded-full! overflow-hidden p-0 border border-transparent ${cursorClass}`
-    : `size-full text-left rounded-xl! overflow-hidden ${
-        isCompact ? 'px-1.5 py-1' : 'px-2 py-1.5'
-      } flex flex-col justify-between ${cursorClass}`;
+    : `size-full text-left rounded-xl! overflow-hidden ${paddingClass} flex flex-col justify-between ${cursorClass}`;
 
   return { markerHeight, isCompact, markerClassName };
 };

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/LabTests.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/LabTests.tsx
@@ -1279,7 +1279,11 @@ const IdexxOrderIframeOverlay = ({ url, title, onClose }: IdexxOrderIframeOverla
   const isFollowUp = title.toLowerCase().includes('follow-up');
   return (
     <div
-      className="fixed inset-0 z-5000 bg-black/60 backdrop-blur-sm flex items-center justify-center p-4"
+      // --sh55, matching the two other copies of this overlay (DiagnosticsStep:753
+      // and IdexxWorkspace:731). bg-black/60 is a hardcoded scrim: the token is
+      // a warm rgba(29,28,27,.55) in light and a heavier rgba(0,0,0,.8) in dark,
+      // so this copy was both the wrong hue in light and too weak in dark.
+      className="fixed inset-0 z-[5000] flex items-center justify-center bg-[var(--sh55)] p-4 backdrop-blur-sm"
       data-signing-overlay="true"
       style={{ pointerEvents: 'auto' }}
     >

--- a/apps/frontend/src/app/ui/inputs/Dropdown/Dropdown.stories.tsx
+++ b/apps/frontend/src/app/ui/inputs/Dropdown/Dropdown.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { fn } from 'storybook/test';
+import { expect, fn, userEvent } from 'storybook/test';
 import Dropdown from './Dropdown';
 
 const SPECIALTY_OPTIONS = [
@@ -76,5 +76,22 @@ export const CountryPicker: Story = {
   args: { type: 'country', placeholder: 'Country', value: '', search: true },
   parameters: {
     docs: { description: { story: 'Built-in country list with flag emoji labels.' } },
+  },
+};
+
+export const Open: Story = {
+  name: 'Panel open',
+  play: async ({ canvasElement }) => {
+    // The panel is the point. It only exists after a click, so nothing in this
+    // file rendered it before - and a defect in a surface no story draws stays
+    // invisible to Chromatic and to the contrast sweep indefinitely.
+    const trigger = canvasElement.querySelector('button');
+    await userEvent.click(trigger as HTMLElement);
+    // Assert the panel has CONTENT, not just that the trigger flipped
+    // aria-expanded - an empty panel would satisfy that and leave this story
+    // silently guarding nothing. The panel portals to document.body.
+    const panel = document.querySelector('[data-portal-dropdown]');
+    await expect(panel).toBeInTheDocument();
+    await expect(panel?.querySelectorAll('button').length).toBeGreaterThan(0);
   },
 };

--- a/apps/frontend/src/app/ui/inputs/Dropdown/LabelDropdown.stories.tsx
+++ b/apps/frontend/src/app/ui/inputs/Dropdown/LabelDropdown.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { fn } from 'storybook/test';
+import { expect, fn, userEvent } from 'storybook/test';
 import LabelDropdown from './LabelDropdown';
 
 const STATUS_OPTIONS = [
@@ -48,3 +48,20 @@ export const Default: Story = {};
 export const WithDefault: Story = { args: { defaultOption: 'active' } };
 export const NoSearch: Story = { args: { searchable: false } };
 export const WithError: Story = { args: { error: 'Status is required.' } };
+
+export const Open: Story = {
+  name: 'Panel open',
+  play: async ({ canvasElement }) => {
+    // The panel is the point. It only exists after a click, so nothing in this
+    // file rendered it before - and a defect in a surface no story draws stays
+    // invisible to Chromatic and to the contrast sweep indefinitely.
+    const trigger = canvasElement.querySelector('button');
+    await userEvent.click(trigger as HTMLElement);
+    // Assert the panel has CONTENT, not just that the trigger flipped
+    // aria-expanded - an empty panel would satisfy that and leave this story
+    // silently guarding nothing. The panel portals to document.body.
+    const panel = document.querySelector('[data-portal-dropdown]');
+    await expect(panel).toBeInTheDocument();
+    await expect(panel?.querySelectorAll('button').length).toBeGreaterThan(0);
+  },
+};

--- a/apps/frontend/src/app/ui/inputs/MultiSelectDropdown/MultiSelectDropdown.stories.tsx
+++ b/apps/frontend/src/app/ui/inputs/MultiSelectDropdown/MultiSelectDropdown.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { fn } from 'storybook/test';
+import { expect, fn, userEvent } from 'storybook/test';
 import MultiSelectDropdown from './index';
 
 const SPECIES_OPTIONS = [
@@ -65,4 +65,21 @@ export const WithError: Story = {
 
 export const NoSearch: Story = {
   args: { searchable: false },
+};
+
+export const Open: Story = {
+  name: 'Panel open',
+  play: async ({ canvasElement }) => {
+    // The panel is the point. It only exists after a click, so nothing in this
+    // file rendered it before - and a defect in a surface no story draws stays
+    // invisible to Chromatic and to the contrast sweep indefinitely.
+    const trigger = canvasElement.querySelector('button');
+    await userEvent.click(trigger as HTMLElement);
+    // Assert the panel has CONTENT, not just that the trigger flipped
+    // aria-expanded - an empty panel would satisfy that and leave this story
+    // silently guarding nothing. The panel portals to document.body.
+    const panel = document.querySelector('[data-portal-dropdown]');
+    await expect(panel).toBeInTheDocument();
+    await expect(panel?.querySelectorAll('button').length).toBeGreaterThan(0);
+  },
 };

--- a/apps/frontend/src/app/ui/tables/RowActionMenu.stories.tsx
+++ b/apps/frontend/src/app/ui/tables/RowActionMenu.stories.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+import {
+  IoCalendarOutline,
+  IoEyeOutline,
+  IoSwapHorizontalOutline,
+  IoTrashOutline,
+} from 'react-icons/io5';
+import RowActionMenu, { type RowMenuAction } from './RowActionMenu';
+
+const ACTIONS: RowMenuAction[] = [
+  {
+    key: 'view',
+    label: 'View details',
+    icon: <IoEyeOutline size={16} />,
+    onSelect: fn(),
+    primary: true,
+  },
+  { key: 'reschedule', label: 'Reschedule', icon: <IoCalendarOutline size={16} />, onSelect: fn() },
+  {
+    key: 'status',
+    label: 'Change status',
+    icon: <IoSwapHorizontalOutline size={16} />,
+    onSelect: fn(),
+  },
+  {
+    key: 'cancel',
+    label: 'Cancel appointment',
+    icon: <IoTrashOutline size={16} />,
+    onSelect: fn(),
+    dividerBefore: true,
+  },
+];
+
+const meta = {
+  title: 'Tables/RowActionMenu',
+  component: RowActionMenu,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'The row kebab: one overflow menu standing in for a rail of icon buttons. Every data ' +
+          'table in PIMS renders it - appointments, companions, forms, inventory - and it had no ' +
+          'story at all.\n\n' +
+          'That is the gap worth naming. The panel is `createPortal`ed and only exists after a ' +
+          'click, so nothing in Storybook or Chromatic ever drew it. A whole class of defect ' +
+          'hides in surfaces like this: the calendar submenus on the same `yc-glass-overlay` ' +
+          'were filling their hovered and selected rows with literal white over a themed ' +
+          'surface, and their dividers were invisible in light mode, for exactly as long as no ' +
+          'story rendered them.\n\n' +
+          'The stories below open the menu with a `play` function so the panel is under visual ' +
+          'review, not just the 28px trigger.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    actions: ACTIONS,
+    label: 'Row actions',
+    onOpenChange: fn(),
+  },
+} satisfies Meta<typeof RowActionMenu>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Closed: Story = {
+  name: 'Trigger only',
+  parameters: {
+    docs: { story: 'What every table shows until the reader asks for the menu.' },
+  },
+};
+
+export const Open: Story = {
+  name: 'Menu open',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Row actions' }));
+    // The panel portals out of the canvas, so assert against the document.
+    await expect(document.querySelector('[role="menu"]')).toBeInTheDocument();
+  },
+};
+
+export const SingleAction: Story = {
+  name: 'One action',
+  args: { actions: [ACTIONS[0]] },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Row actions' }));
+    await expect(document.querySelector('[role="menu"]')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      story:
+        'A row with only one thing you can do. The divider rule ignores the first item, so no ' +
+        'stray separator appears above it.',
+    },
+  },
+};
+
+export const ManyActions: Story = {
+  name: 'Enough actions to flip the panel',
+  args: {
+    actions: [
+      ...ACTIONS,
+      {
+        key: 'a',
+        label: 'Assign room',
+        icon: <IoSwapHorizontalOutline size={16} />,
+        onSelect: fn(),
+      },
+      { key: 'b', label: 'Send reminder', icon: <IoCalendarOutline size={16} />, onSelect: fn() },
+      { key: 'c', label: 'Print summary', icon: <IoEyeOutline size={16} />, onSelect: fn() },
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Row actions' }));
+    await expect(document.querySelector('[role="menu"]')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      story:
+        'The panel picks a side by available room, and falls back when neither side fits. A long ' +
+        'menu is where that logic actually shows.',
+    },
+  },
+};


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The last structural difference between the two planners, plus three panels that only exist after a click and so had never been drawn in Storybook or Chromatic.

**The task chip did not look like the appointment block it sits beside.** It was a 16px radius with a drop shadow, a plain 1px border all round, a 14px/500 title and a 10px subtitle. The appointment block is a **flat** 12px card over a 1px status outline thickened to a **3px spine** on its leading edge, titled 12.5px/700 with an 11px/400 subtitle. Two objects that mean the same thing, drawn as different things.

**`RowActionMenu` had no story at all** - the row kebab every data table renders, whose panel is portalled and only exists after a click. The `Dropdown`, `LabelDropdown` and `MultiSelectDropdown` stories rendered only their closed triggers, so the panel that is the whole point of those components was never in a snapshot.

**A third copy of the IDEXX overlay had drifted.** Two use `--sh55` for the scrim; the `LabTests` one used `bg-black/60`.

## What is the new behavior?

The chip follows `common/ZoomInMarker.tsx`: 12px flat, the status spine, the 12.5px/700 title and the 11px/400 subtitle. The radius needed **both** sites changing - it was set in a `!` utility class **and** an inline style, so moving either alone did nothing.

Two things are deliberately kept. The pink glow and leading dot on a pet-parent task stay, because that is a semantic signal rather than chrome and the appointment side has no equivalent. The zoomed-out chip keeps its pill shape and takes no spine, since it carries no label at that density.

The chips are also draggable and showed a plain arrow cursor, so they did not read as movable. They take `cursor-grab` now, as the appointment blocks already did.

`TaskMarker` is exported and has a story covering every status, the pet-parent variant, the two-lane compact form and the zoomed-out lozenge. `RowActionMenu` gets four stories, and the three dropdowns each get an open-panel story.

The `LabTests` scrim moves to `--sh55`. That token is a warm `rgba(29,28,27,.55)` in light and a heavier `rgba(0,0,0,.8)` in dark, so the hardcoded copy was the wrong hue in light **and** too weak in dark.

### On the assertions

The panel assertions check the panel has **content**, not that a trigger flipped `aria-expanded`. The weaker version passes on an empty panel - I had it that way first, and a probe reported the dropdowns as expanded with nothing rendered. That turned out to be my probe querying `role="option"` against options that are plain buttons, but the assertion really was too weak, so it now asserts what would actually fail. All four panels verified populated in the built Storybook: 4 and 7 menu items, and 6 / 4 / 6 options.

### Deliberately not changed

Two further divergences between the three IDEXX overlay copies want a decision rather than a guess:

- the iframe sandbox on `DiagnosticsStep:783` carries **`allow-downloads`** and the other two do not, which is security-relevant in either direction
- the three copies use three different close affordances

### Validation

- 917 suites / 11330 tests; type-check and lint clean
- Storybook 506 stories, 503 rendering clean (3 are intentional closed states), **0 contrast failures** across {375 light, 375 dark, 1280 dark}

## Related Issue(s)

Fixes #
