### PR TITLE
fix(frontend): anchor week calendar day columns on preferred timezone

### DIFF
--- a/apps/frontend/src/app/__tests__/components/Calendar/AppointmentCalendar.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/AppointmentCalendar.test.tsx
@@ -100,6 +100,17 @@ jest.mock('@/app/lib/timezone', () => ({
     next.setUTCHours(0, minuteOfDay, 0, 0);
     return next;
   }),
+  buildPreferredTimeZoneDayInstant: jest.fn(
+    (year: number, month: number, day: number) =>
+      new Date(Date.UTC(year, month - 1, day, 12, 0, 0, 0))
+  ),
+  getDatePartsInPreferredTimeZone: jest.fn((value: Date) => ({
+    year: value.getUTCFullYear(),
+    month: value.getUTCMonth() + 1,
+    day: value.getUTCDate(),
+    hour: value.getUTCHours(),
+    minute: value.getUTCMinutes(),
+  })),
   formatDateInPreferredTimeZone: jest.fn((date: Date, options: Intl.DateTimeFormatOptions) => {
     if (options.weekday) {
       return 'MONDAY';

--- a/apps/frontend/src/app/__tests__/components/Calendar/Task/WeekCalendar.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/Task/WeekCalendar.test.tsx
@@ -17,6 +17,15 @@ jest.mock('@/app/features/appointments/components/Calendar/weekHelpers', () => (
 }));
 
 jest.mock('@/app/lib/timezone', () => ({
+  buildPreferredTimeZoneDayInstant: (year: number, month: number, day: number) =>
+    new Date(year, month - 1, day, 12, 0, 0, 0),
+  getDatePartsInPreferredTimeZone: (value: Date) => ({
+    year: value.getFullYear(),
+    month: value.getMonth() + 1,
+    day: value.getDate(),
+    hour: value.getHours(),
+    minute: value.getMinutes(),
+  }),
   getHourInPreferredTimeZone: (value: Date) => value.getHours(),
   getMinutesSinceStartOfDayInPreferredTimeZone: (value: Date) =>
     value.getHours() * 60 + value.getMinutes(),

--- a/apps/frontend/src/app/__tests__/components/Calendar/useCalendarSlots.test.ts
+++ b/apps/frontend/src/app/__tests__/components/Calendar/useCalendarSlots.test.ts
@@ -1,9 +1,41 @@
+import type { SetStateAction } from 'react';
+import { act, renderHook } from '@testing-library/react';
 import {
   getTimedTaskProxyEvents,
   getUnavailableSegmentsForHourRange,
   getVisibleHourRange,
   getVisibleHours,
+  useCalendarWeekNavigation,
 } from '@/app/features/appointments/components/Calendar/useCalendarSlots';
+import { startOfDay } from '@/app/features/appointments/components/Calendar/weekHelpers';
+import { setPreferredTimeZone } from '@/app/lib/timezone';
+
+/** Monday 6 July 2026 at browser-local midnight. */
+const WEEK_START = new Date(2026, 6, 6);
+
+/** Minutes `timeZone` sits ahead of UTC at `instant`. */
+const zoneOffsetMinutes = (timeZone: string, instant: Date): number => {
+  const utc = new Date(instant.toLocaleString('en-US', { timeZone: 'UTC' }));
+  const zoned = new Date(instant.toLocaleString('en-US', { timeZone }));
+  return Math.round((zoned.getTime() - utc.getTime()) / 60_000);
+};
+
+const CANDIDATE_ZONES = [
+  'Pacific/Pago_Pago',
+  'America/Los_Angeles',
+  'America/Sao_Paulo',
+  'Europe/London',
+];
+
+/** A zone at least six hours west of the test host. */
+const pickZoneWestOfHost = (reference: Date): string => {
+  const hostOffset = -reference.getTimezoneOffset();
+  const zone = CANDIDATE_ZONES.find(
+    (candidate) => zoneOffsetMinutes(candidate, reference) <= hostOffset - 360
+  );
+  if (!zone) throw new Error('No candidate timezone is far enough west of the test host.');
+  return zone;
+};
 
 describe('useCalendarSlots helpers', () => {
   it('builds a bounded visible hour range from event and availability minutes', () => {
@@ -116,5 +148,48 @@ describe('useCalendarSlots helpers', () => {
       // endHour should be clamped to 23
       expect(result.endHour).toBe(23);
     });
+  });
+});
+
+describe('useCalendarWeekNavigation', () => {
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  // The page re-derives weekStart from currentDate with browser-local
+  // startOfDay (Appointments/index.tsx). So whatever currentDate the handler
+  // writes must round-trip through startOfDay back to the weekStart it set,
+  // even when the preferred zone sits a full calendar day west of the browser.
+  // A noon-in-org-tz currentDate would drift a day here and shift the columns.
+  const expectCurrentDateRoundTripsToWeekStart = (
+    navigate: (nav: ReturnType<typeof useCalendarWeekNavigation>) => void,
+    expectedWeekStart: Date
+  ) => {
+    const zone = pickZoneWestOfHost(WEEK_START);
+    expect(setPreferredTimeZone(zone)).toBe(true);
+
+    let committedWeekStart: Date | null = null;
+    const setWeekStart = jest.fn((value: SetStateAction<Date>) => {
+      committedWeekStart = typeof value === 'function' ? value(WEEK_START) : value;
+    });
+    const setCurrentDate = jest.fn();
+
+    const { result } = renderHook(() => useCalendarWeekNavigation(setWeekStart, setCurrentDate));
+    act(() => {
+      navigate(result.current);
+    });
+
+    expect(committedWeekStart).not.toBeNull();
+    expect((committedWeekStart as unknown as Date).getTime()).toBe(expectedWeekStart.getTime());
+    const passed = setCurrentDate.mock.calls[0][0] as Date;
+    expect(startOfDay(passed).getTime()).toBe(expectedWeekStart.getTime());
+  };
+
+  it('keeps the derived week aligned when paging forward', () => {
+    expectCurrentDateRoundTripsToWeekStart((nav) => nav.handleNextWeek(), new Date(2026, 6, 13));
+  });
+
+  it('keeps the derived week aligned when paging backward', () => {
+    expectCurrentDateRoundTripsToWeekStart((nav) => nav.handlePrevWeek(), new Date(2026, 5, 29));
   });
 });

--- a/apps/frontend/src/app/__tests__/components/Calendar/weekHelpers.test.ts
+++ b/apps/frontend/src/app/__tests__/components/Calendar/weekHelpers.test.ts
@@ -15,6 +15,15 @@ import { DEFAULT_TIMEZONE } from '@/app/lib/timezone';
 
 jest.mock('@/app/lib/timezone', () => ({
   DEFAULT_TIMEZONE: 'UTC',
+  buildPreferredTimeZoneDayInstant: (year: number, month: number, day: number) =>
+    new Date(year, month - 1, day, 12, 0, 0, 0),
+  getDatePartsInPreferredTimeZone: (date: Date) => ({
+    year: date.getFullYear(),
+    month: date.getMonth() + 1,
+    day: date.getDate(),
+    hour: date.getHours(),
+    minute: date.getMinutes(),
+  }),
   getHourInPreferredTimeZone: (date: Date) => date.getHours(),
   formatDateInPreferredTimeZone: (date: Date, options?: Intl.DateTimeFormatOptions) =>
     new Intl.DateTimeFormat('en-US', { timeZone: 'UTC', ...options }).format(date),
@@ -58,8 +67,9 @@ describe('Calendar Week Helpers', () => {
       expect(days[1].getDate()).toBe(2);
       expect(days[6].getDate()).toBe(7);
 
-      // Verify items are new Date objects based on startOfDay
-      expect(days[3].getHours()).toBe(0);
+      // Columns are anchored on the preferred-timezone day instant (local noon),
+      // not browser-local midnight.
+      expect(days[3].getHours()).toBe(12);
     });
 
     it('handles month rollover correctly', () => {

--- a/apps/frontend/src/app/__tests__/components/Calendar/weekHelpers.tz.test.ts
+++ b/apps/frontend/src/app/__tests__/components/Calendar/weekHelpers.tz.test.ts
@@ -1,0 +1,109 @@
+import { Appointment } from '@yosemite-crew/types';
+import {
+  eventsForDayHour,
+  getNextWeek,
+  getWeekDays,
+} from '@/app/features/appointments/components/Calendar/weekHelpers';
+import { filterAppointmentsForWeek } from '@/app/features/appointments/components/Calendar/availabilityIntervals';
+import {
+  buildDateInPreferredTimeZone,
+  buildPreferredTimeZoneDayInstant,
+  getDatePartsInPreferredTimeZone,
+  getHourInPreferredTimeZone,
+  setPreferredTimeZone,
+} from '@/app/lib/timezone';
+
+/** Monday 6 July 2026 at browser-local midnight — the week the desktop grid renders. */
+const WEEK_START = new Date(2026, 6, 6);
+
+/** Minutes `timeZone` sits ahead of UTC at `instant`. */
+const zoneOffsetMinutes = (timeZone: string, instant: Date): number => {
+  const utc = new Date(instant.toLocaleString('en-US', { timeZone: 'UTC' }));
+  const zoned = new Date(instant.toLocaleString('en-US', { timeZone }));
+  return Math.round((zoned.getTime() - utc.getTime()) / 60_000);
+};
+
+const CANDIDATE_ZONES = [
+  'Pacific/Pago_Pago',
+  'America/Los_Angeles',
+  'America/Sao_Paulo',
+  'Europe/London',
+];
+
+/**
+ * A zone at least six hours west of whatever zone the test host runs in, so the
+ * divergence between browser-local midnight and the preferred calendar day this
+ * suite relies on exists on a UTC CI box and on a developer's laptop alike.
+ */
+const pickZoneWestOfHost = (reference: Date): string => {
+  const hostOffset = -reference.getTimezoneOffset();
+  const zone = CANDIDATE_ZONES.find(
+    (candidate) => zoneOffsetMinutes(candidate, reference) <= hostOffset - 360
+  );
+  if (!zone) throw new Error('No candidate timezone is far enough west of the test host.');
+  return zone;
+};
+
+const makeEvent = (startTime: Date, endTime: Date = startTime): Appointment =>
+  ({ startTime, endTime }) as unknown as Appointment;
+
+afterEach(() => {
+  window.localStorage.clear();
+});
+
+describe('getWeekDays in a preferred timezone west of the host', () => {
+  it('labels each column with the preferred calendar day, not the browser day', () => {
+    const zone = pickZoneWestOfHost(WEEK_START);
+    expect(setPreferredTimeZone(zone)).toBe(true);
+
+    const days = getWeekDays(WEEK_START);
+    expect(days).toHaveLength(7);
+    // Monday 6 July through Sunday 12 July, in the preferred zone.
+    days.forEach((day, index) => {
+      expect(getDatePartsInPreferredTimeZone(day).day).toBe(6 + index);
+    });
+  });
+
+  it('buckets an event by its preferred-zone day and hour', () => {
+    const zone = pickZoneWestOfHost(WEEK_START);
+    expect(setPreferredTimeZone(zone)).toBe(true);
+
+    const days = getWeekDays(WEEK_START);
+    // Local noon on the preferred Wednesday (8 July) — hour 12 in the preferred zone.
+    const eventInstant = buildPreferredTimeZoneDayInstant(2026, 7, 8);
+    expect(getHourInPreferredTimeZone(eventInstant)).toBe(12);
+
+    expect(eventsForDayHour([makeEvent(eventInstant)], days[2], 12)).toHaveLength(1);
+    expect(eventsForDayHour([makeEvent(eventInstant)], days[1], 12)).toHaveLength(0);
+  });
+
+  it('keeps labelling and bucketing after paging to the next week', () => {
+    const zone = pickZoneWestOfHost(WEEK_START);
+    expect(setPreferredTimeZone(zone)).toBe(true);
+
+    const nextWeekStart = getNextWeek(WEEK_START);
+    const days = getWeekDays(nextWeekStart);
+    // Monday 13 July through Sunday 19 July, in the preferred zone.
+    days.forEach((day, index) => {
+      expect(getDatePartsInPreferredTimeZone(day).day).toBe(13 + index);
+    });
+
+    const eventInstant = buildPreferredTimeZoneDayInstant(2026, 7, 15);
+    expect(eventsForDayHour([makeEvent(eventInstant)], days[2], 12)).toHaveLength(1);
+    expect(eventsForDayHour([makeEvent(eventInstant)], days[3], 12)).toHaveLength(0);
+  });
+
+  it('retains an early-morning event on the first preferred day of the week', () => {
+    const zone = pickZoneWestOfHost(WEEK_START);
+    expect(setPreferredTimeZone(zone)).toBe(true);
+
+    // 00:30 on the preferred Monday (6 July) — before the noon anchor, so a
+    // noon-based lower bound would wrongly drop it.
+    const firstDayAnchor = buildPreferredTimeZoneDayInstant(2026, 7, 6);
+    const earlyMorning = buildDateInPreferredTimeZone(firstDayAnchor, 30);
+    expect(getDatePartsInPreferredTimeZone(earlyMorning).day).toBe(6);
+
+    const retained = filterAppointmentsForWeek([makeEvent(earlyMorning)], WEEK_START);
+    expect(retained).toHaveLength(1);
+  });
+});

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/DayLabels.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/DayLabels.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {
   formatDateInPreferredTimeZone,
+  getDatePartsInPreferredTimeZone,
   isOnPreferredTimeZoneCalendarDay,
 } from '@/app/lib/timezone';
 
@@ -25,7 +26,7 @@ const DayLabels = ({ days, currentDate, columnsStyle }: DayLabels) => {
         // so a user whose browser zone differs from the org's could see the same
         // column labelled Tue on one calendar and Mon on the other.
         const weekday = formatDateInPreferredTimeZone(day, { weekday: 'short' });
-        const dateNumber = day.getDate();
+        const dateNumber = getDatePartsInPreferredTimeZone(day).day;
         const isToday = isOnPreferredTimeZoneCalendarDay(new Date(), day);
         const dateNumberClass = isToday
           ? 'bg-[var(--blue-strong)] text-white border-transparent'

--- a/apps/frontend/src/app/features/appointments/components/Calendar/availabilityIntervals.ts
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/availabilityIntervals.ts
@@ -1,7 +1,7 @@
 import { ApiDayAvailability } from '@/app/features/appointments/components/Availability/utils';
 import { Appointment } from '@yosemite-crew/types';
 import { getWeekDays } from '@/app/features/appointments/components/Calendar/weekHelpers';
-import { PreferredTimeZoneClock } from '@/app/lib/timezone';
+import { buildDateInPreferredTimeZone, PreferredTimeZoneClock } from '@/app/lib/timezone';
 
 export type DropAvailabilityInterval = {
   startMinute: number;
@@ -10,14 +10,15 @@ export type DropAvailabilityInterval = {
 
 export const filterAppointmentsForWeek = (appointments: Appointment[], weekStart: Date) => {
   const weekDays = getWeekDays(weekStart);
-  const weekRangeStart = weekDays[0];
-  const weekRangeEnd = new Date(weekDays.at(-1) ?? weekRangeStart);
-  weekRangeEnd.setDate(weekRangeEnd.getDate() + 1);
+  // The week days are noon anchors, so derive the preferred-timezone start of the
+  // first day and end of the last day to get the full week's instant boundaries.
+  const weekRangeStart = buildDateInPreferredTimeZone(weekDays[0], 0);
+  const weekRangeEnd = buildDateInPreferredTimeZone(weekDays.at(-1) ?? weekDays[0], 24 * 60 - 1);
 
   return appointments.filter((event) => {
     const eventStart = new Date(event.startTime);
     const eventEnd = new Date(event.endTime);
-    return eventEnd > weekRangeStart && eventStart < weekRangeEnd;
+    return eventEnd >= weekRangeStart && eventStart <= weekRangeEnd;
   });
 };
 

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/WeekCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/WeekCalendar.tsx
@@ -25,6 +25,7 @@ import {
 import CalendarHourLabel from '@/app/features/appointments/components/Calendar/common/CalendarHourLabel';
 import {
   formatDateInPreferredTimeZone,
+  getDatePartsInPreferredTimeZone,
   getMinutesSinceStartOfDayInPreferredTimeZone,
   isOnPreferredTimeZoneCalendarDay,
 } from '@/app/lib/timezone';
@@ -195,7 +196,7 @@ const WeekDayHeaderRow = ({
         const weekday = formatDateInPreferredTimeZone(day, {
           weekday: 'short',
         });
-        const dateNumber = day.getDate();
+        const dateNumber = getDatePartsInPreferredTimeZone(day).day;
         const isToday = isOnPreferredTimeZoneCalendarDay(now, day);
         return (
           <div

--- a/apps/frontend/src/app/features/appointments/components/Calendar/weekHelpers.ts
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/weekHelpers.ts
@@ -1,6 +1,10 @@
 import { Appointment } from '@yosemite-crew/types';
 import { formatDisplayDate } from '@/app/lib/date';
-import { getHourInPreferredTimeZone, isOnPreferredTimeZoneCalendarDay } from '@/app/lib/timezone';
+import {
+  buildPreferredTimeZoneDayInstant,
+  getHourInPreferredTimeZone,
+  isOnPreferredTimeZoneCalendarDay,
+} from '@/app/lib/timezone';
 
 export const HOURS_IN_DAY = 24;
 
@@ -11,12 +15,15 @@ export function startOfDay(date: Date): Date {
 }
 
 export function getWeekDays(weekStart: Date): Date[] {
-  const base = startOfDay(weekStart);
-  return Array.from({ length: 7 }, (_, i) => {
-    const d = new Date(base);
-    d.setDate(base.getDate() + i);
-    return d;
-  });
+  const year = weekStart.getFullYear();
+  const month = weekStart.getMonth() + 1;
+  const date = weekStart.getDate();
+  // Anchor each column on a preferred-timezone instant instead of browser-local
+  // midnight so the day number and event bucketing follow the org's calendar day.
+  // JS Date normalizes month/year rollover when date + i overflows the month.
+  return Array.from({ length: 7 }, (_, i) =>
+    buildPreferredTimeZoneDayInstant(year, month, date + i)
+  );
 }
 
 export function eventsForDayHour(events: Appointment[], day: Date, hour: number): Appointment[] {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

The desktop week calendar derived its seven day columns from browser-local midnight: `getWeekDays` called `startOfDay(weekStart)` and then stepped `setDate(base.getDate() + i)`. The rendered day numbers came from `Date.getDate()` and event bucketing used browser-local day boundaries.

For a user whose browser timezone sits a full calendar day west of the org's preferred timezone, this made the column day numbers and the events bucketed into them drift by a day relative to the org's calendar. The same column could read Tue on one calendar and Mon on another.

## What is the new behavior?

Day columns are now anchored on a timezone-correct instant instead of browser-local midnight.

- `getWeekDays` builds each of the seven columns from `buildPreferredTimeZoneDayInstant(year, month, date + i)`, relying on JS `Date` to normalize month and year rollover. Each column is now a preferred-timezone day instant (local noon) rather than browser-local midnight.
- Because columns are noon anchors, the day number shown in `DayLabels` and in `WeekCalendar`'s header row is read via `getDatePartsInPreferredTimeZone(day).day` instead of `day.getDate()`.
- `filterAppointmentsForWeek` derives the week's instant boundaries with `buildDateInPreferredTimeZone` (start of the first day, end-of-day of the last day) and uses inclusive comparisons, so an event at 00:30 on the first preferred day is no longer dropped by a noon-based lower bound.

Net effect: day labeling and event bucketing follow the org's calendar day regardless of the browser's timezone.

## Related Issue(s)

Related to #1868

## Validation performed

- Type check: `npx tsc --noemit` clean.
- Lint: `pnpm --filter frontend run lint` exit 0, no findings.
- Targeted tests pass (11 suites / 170 tests), including two new unmocked suites:
  - `weekHelpers.tz.test.ts` proves preferred-timezone labeling, bucketing, paging, and first-day retention in a zone at least six hours west of the test host.
  - `useCalendarSlots.test.ts` week-navigation cases prove the `currentDate` written on paging round-trips through browser-local `startOfDay` back to the same `weekStart`, so paging does not shift the columns.

Not verified: no live desktop/browser visual QA was run in this environment. The behavior a visual pass would target is covered by the automated tests above.

Closes #1868
