### PR TITLE
fix(frontend): stop every Tasks week hour rendering at double height

### DIFF
--- a/apps/frontend/src/app/__tests__/components/Calendar/Task/WeekCalendar.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/Task/WeekCalendar.test.tsx
@@ -136,6 +136,30 @@ describe('WeekCalendar (Task)', () => {
     expect(screen.getByText('9:41 AM')).toBeInTheDocument();
   });
 
+  it('gives every grid row exactly as many children as its template has columns', () => {
+    // The rows are `grid-cols-[64px_minmax(0,1fr)]` - TWO columns. When the arrow
+    // rails were removed the template dropped from three columns to two, but the
+    // hour row kept a third child: the right rail's spacer. A third child in a
+    // two-column grid wraps onto an implicit SECOND row, so every hour rendered
+    // at 360px instead of 180 with an empty 180px band under it. On the deployed
+    // planner that read as large blank areas down the calendar.
+    const { container } = render(
+      <WeekCalendar
+        events={events}
+        date={weekStart}
+        handleViewTask={handleViewTask}
+        weekStart={weekStart}
+      />
+    );
+
+    const twoColumnRows = [...container.querySelectorAll('div')].filter((d) =>
+      d.className.includes('grid-cols-[64px_minmax(0,1fr)]')
+    );
+
+    expect(twoColumnRows.length).toBeGreaterThan(0);
+    twoColumnRows.forEach((row) => expect(row.children).toHaveLength(2));
+  });
+
   it('renders no pager of its own - paging belongs to the toolbar', () => {
     // The grid used to carry its own prev/next arrows in two 64px rails either
     // side of the day strip. common/WeekCalendar.css states the intent plainly:

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/WeekCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/WeekCalendar.tsx
@@ -231,10 +231,6 @@ const WeekCalendar: React.FC<WeekCalendarProps> = ({
                       );
                     })}
                   </div>
-                  <div
-                    className="sticky right-0 z-20 bg-neutral-0"
-                    style={{ height: `${height}px` }}
-                  />
                 </div>
               ))}
               <div style={{ height: zoomMode === 'out' ? 30 : 40 }} />


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

**A regression I shipped in #2237**, reported from deployed dev as large blank areas down the Tasks planner.

Removing the arrow rails dropped the hour row's grid template from three columns to two, but the row kept a **third child**: the right rail's sticky spacer. A third child in a two-column grid wraps onto an implicit **second row**, so every hour rendered 360px tall - 180px of content with an empty 180px band beneath it.

Measured on dev before the fix:

| | hour row height |
| --- | --- |
| Appointments week | **180px** |
| Tasks week | **360px** |

Both derive from the same `getHourRowHeightPx(zoomMode)`, which returns 180. Only two hours filled the viewport, and the gridline-free bands between them read as white.

## What is the new behavior?

The spacer is removed. The row now has exactly the two children its template declares.

A test asserts the invariant that actually broke - every element carrying the two-column template has exactly two children - rather than asserting a pixel height, which would not have explained the cause. Mutation-checked by putting the spacer back, which fails it.

The component's two other rows, the header strip and the now-line overlay, already had two children and were unaffected. I checked both rather than assuming.

## Related Issue(s)

Fixes #
