### PR TITLE
fix(database): enable row level security on every public table

### DIFF
--- a/.github/workflows/_migration.yaml
+++ b/.github/workflows/_migration.yaml
@@ -132,6 +132,42 @@ jobs:
       - name: Apply migrations
         run: pnpm --filter @yosemite-crew/database run prisma:deploy
 
+      # The Supabase advisor caught public."OrganizationDocumentAcknowledgements"
+      # shipping with RLS off. The cause was structural: RLS was only ever enabled
+      # by hand in the dashboard, so every new table was unprotected until someone
+      # remembered. This asserts it against the freshly migrated database, so a
+      # table added without RLS fails here rather than in a security advisor.
+      - name: Check row level security is enabled on every public table
+        shell: bash
+        env:
+          PGPASSWORD: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          # DATABASE_URL carries Prisma's ?schema= parameter, which psql rejects,
+          # so connect with explicit flags like the shadow-database step above.
+          missing=$(psql -h localhost -U postgres -d yosemite_ci -tAc "
+            SELECT c.relname
+            FROM pg_class c
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE n.nspname = 'public'
+              AND c.relkind = 'r'
+              AND c.relname <> '_prisma_migrations'
+              AND NOT c.relrowsecurity
+            ORDER BY c.relname;")
+
+          if [ -n "$missing" ]; then
+            echo "::error::Tables in the public schema have row level security disabled."
+            echo "Supabase exposes public tables over PostgREST to the anon and"
+            echo "authenticated keys; without RLS those keys can read them directly."
+            echo "Add the table to the RLS migration rather than enabling it in the dashboard."
+            echo "--- tables without RLS ---"
+            echo "$missing"
+            exit 1
+          fi
+
+          echo "Row level security is enabled on every public table."
+
       - name: Check schema and migrations have not drifted
         shell: bash
         run: |

--- a/packages/database/prisma/migrations/20260818090000_enable_row_level_security/migration.sql
+++ b/packages/database/prisma/migrations/20260818090000_enable_row_level_security/migration.sql
@@ -1,0 +1,36 @@
+-- Enable row level security on every table in the public schema.
+--
+-- Supabase's security advisor flagged public."OrganizationDocumentAcknowledgements"
+-- as "RLS Disabled in Public". It was not a one-off: this repository has never
+-- contained a single ENABLE ROW LEVEL SECURITY statement across 186 models, so
+-- RLS has only ever been switched on by hand in the dashboard. Every new table
+-- therefore ships unprotected until somebody remembers to click it, and this
+-- release adds a large batch of new tables.
+--
+-- Why enabling with no policy is the right default here: the API connects as the
+-- owning role, which bypasses RLS, so application queries through Prisma are
+-- unaffected. What it does close is the PostgREST surface - Supabase exposes
+-- every table in `public` over its REST API to the `anon` and `authenticated`
+-- keys, and with RLS off those keys can read the table directly. With RLS on and
+-- no policy, that path is denied by default. Tenant scoping stays where it
+-- already lives, in the application's organisation filters.
+--
+-- Written as a loop rather than 186 literal statements so a table added later is
+-- covered the moment this runs again, and so the statement cannot drift out of
+-- sync with the schema. ENABLE is idempotent, so re-running is a no-op.
+DO $$
+DECLARE
+  target record;
+BEGIN
+  FOR target IN
+    SELECT c.relname
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relkind = 'r'                       -- ordinary tables only
+      AND c.relname <> '_prisma_migrations'     -- Prisma's own bookkeeping
+      AND NOT c.relrowsecurity                  -- skip ones already enabled
+  LOOP
+    EXECUTE format('ALTER TABLE public.%I ENABLE ROW LEVEL SECURITY', target.relname);
+  END LOOP;
+END $$;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] All existing tests and lints pass.

## What is the current behavior?

Supabase's security advisor reports `public."OrganizationDocumentAcknowledgements"` as **RLS Disabled in Public**.

That table is a symptom rather than the bug. This repository has never contained a single `ENABLE ROW LEVEL SECURITY` statement, across 186 models. RLS has only ever been switched on by hand in the Supabase dashboard, so every new table ships unprotected until somebody remembers to click it. The Digital Pet Passport release (#1675) added a large batch of new tables through the same gap.

Why it matters beyond the advisor warning: Supabase exposes every table in the `public` schema over PostgREST to the `anon` and `authenticated` keys. With RLS off, those keys can read the table directly, whatever the application's own authorization does.

## What is the new behavior?

**1. A migration that enables RLS on every public table.**

It loops over `pg_class` rather than listing 186 tables, so it cannot drift out of sync with the schema and covers anything added later. `ENABLE` is idempotent, so re-running is a no-op. `_prisma_migrations` is excluded.

Enabling RLS with no policy is the right default here:

- Application queries are unaffected. The API connects as the owning role, which bypasses RLS. Tenant scoping stays where it already lives, in the organisation filters.
- The PostgREST path is denied by default, which is the hole the advisor is pointing at.

**2. A CI gate, because a dashboard click is not a control.**

The migration stage now queries `pg_class` after applying migrations and fails if any public table has `relrowsecurity` false, printing the table names. A table added without RLS fails in CI rather than surfacing in a security advisor weeks later.

## Before merging, please confirm

The API's database role must be the table owner or carry `BYPASSRLS`. If any environment connects as a non-owner role, enabling RLS with no policies would deny it too. The migration gate applies this against a real Postgres, but it runs as `postgres`, so it does not exercise the deployed role.

## Related

Follows up the Supabase security advisor finding on project `ukqklrksqzolanmopwiv`, and covers the tables added by #1675.