### PR TITLE
fix(backend): add .js extension to validator deep import for ESM

### DIFF
--- a/apps/backend/src/services/organisation-invite.service.ts
+++ b/apps/backend/src/services/organisation-invite.service.ts
@@ -1,4 +1,4 @@
-import isEmail from "validator/lib/isEmail";
+import isEmail from "validator/lib/isEmail.js";
 
 import { type CreateOrganisationInviteInput } from "../models/organisationInvite";
 import { type OrganizationMongo } from "../models/organization";

--- a/apps/backend/src/services/user.service.ts
+++ b/apps/backend/src/services/user.service.ts
@@ -1,4 +1,4 @@
-import isEmail from "validator/lib/isEmail";
+import isEmail from "validator/lib/isEmail.js";
 import { User } from "@yosemite-crew/types";
 import { getAuthService } from "@yosemite-crew/auth";
 import { OrganizationService } from "./organization.service";


### PR DESCRIPTION
## What changed

Added the `.js` extension to the two `validator/lib/isEmail` deep imports in `apps/backend`.

## Why

`apps/backend` is `"type": "module"`. Node's ESM loader requires an explicit file extension on deep imports into a package. The extensionless specifier resolved correctly under `tsc`, `eslint` and `jest`, but threw at runtime on boot:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../validator/lib/isEmail'
imported from .../apps/backend/dist/index.js
Did you mean to import "validator/lib/isEmail.js"?
```

This crash-looped the API behind a 502. It was introduced in 6e344e5bd (#2208) and only surfaced now because the dev host had been pinned to an older commit and was redeployed today.

## Impact area

`apps/backend` boot path. The API cannot start on any host running current `dev` without this fix.

## Validation performed

- `pnpm --filter backend run type-check` clean
- `eslint` on both touched files clean
- `jest --testPathPatterns="(user|organisation-invite)\.service"` 2 suites, 60 tests passed
- Built `dist/` and booted it: zero `ERR_MODULE_NOT_FOUND`. Boot now proceeds past module resolution and stops on local env config, confirming the module graph resolves.
- Confirmed `validator/lib/isEmail.js` exports via `module.exports = exports.default`, so the default import stays callable under ESM interop.

## Follow-up

CI builds the backend but never boots the built artifact, which is why every gate passed on a build that could not start. A boot smoke test asserting no module resolution error would catch this whole class of defect.