### PR TITLE
docs(repo): link diff-coverage gate doc from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ pnpm --filter frontend run test -- --testPathPattern="Availability"
 - When you modify behaviour, update existing tests for the changed path AND add new cases for new branches.
 - For every file you touch, check `src/app/__tests__/` (mirroring source path) for an existing test file. If one exists: run it, fix any failures your change introduced.
 - Report actual test + coverage output at each COMMIT CHECKPOINT. Never skip or fabricate results.
+- Separate from this local bar, CI enforces an added-line diff-coverage gate on pull requests (`scripts/ci/diff-coverage.mjs`, `DIFF_COVERAGE_FLOORS`) that requires a share of the executable lines your branch adds to be covered - see [docs/ci/coverage.md](docs/ci/coverage.md), which also covers the desktop source-map caveat where missing maps let dead code count as covered.
 
 For backend/mobile/shared-package only changes, run the workspace-appropriate checks instead of frontend checks.
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The "Coverage mandate" section in the root `CLAUDE.md` describes only the local frontend coverage bar. It does not mention that CI additionally enforces an added-line diff-coverage gate on pull requests, and it provides no pointer to `docs/ci/coverage.md`, so agents reading `CLAUDE.md` have no in-context link to the gate's rules or the desktop source-map caveat.

## What is the new behavior?

Appends a single bullet to the end of the "Coverage mandate" list in `CLAUDE.md`. The bullet:

- Clarifies that the CI added-line diff-coverage gate is separate from the local coverage bar.
- Names the enforcing script and config (`scripts/ci/diff-coverage.mjs`, `DIFF_COVERAGE_FLOORS`).
- Links to `docs/ci/coverage.md` via a relative Markdown link.
- Notes the desktop source-map caveat, where missing maps let dead code count as covered.

This is a documentation-only change to agent instructions. No source code or CI configuration is modified.

## Related Issue(s)

Fixes #

## Validation performed

- `git diff HEAD` reviewed to confirm the change is limited to one added bullet in `CLAUDE.md`.
- Confirmed the link target `docs/ci/coverage.md` exists.
- Confirmed the reference `docs/ci/coverage.md` grep-matches in the edited file.

Not run: typecheck, lint, and unit tests do not apply to a Markdown-only change and were not executed.

