### PR TITLE
fix(repo): hide passport wallet actions until the passport is issued

### DIFF
--- a/apps/frontend/src/app/__tests__/features/petPassport/components/PetPassportModal.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/petPassport/components/PetPassportModal.test.tsx
@@ -45,6 +45,13 @@ jest.mock('@/app/ui/overlays/Modal/ModalHeader', () => ({
 const notifyMock = jest.fn();
 jest.mock('@/app/hooks/useNotify', () => ({ useNotify: () => ({ notify: notifyMock }) }));
 
+// Wallet passes only exist for an ISSUED passport, so every wallet test needs
+// an issuance block. A passport without one renders the explainer instead.
+const ISSUED = {
+  identity: { name: 'Doggy' },
+  issuance: { passportNumber: 'PN-1', issueDate: '2026-01-01' },
+};
+
 const mockedFetch = getPetPassport as jest.Mock;
 const mockedDownload = downloadApplePass as jest.Mock;
 const mockedGoogle = getGoogleWalletUrl as jest.Mock;
@@ -194,7 +201,7 @@ describe('PetPassportModal', () => {
   });
 
   it('adds the passport to Apple Wallet, passing the pet name', async () => {
-    mockedFetch.mockResolvedValue({ identity: { name: 'Doggy' } });
+    mockedFetch.mockResolvedValue(ISSUED);
     mockedDownload.mockResolvedValue(undefined);
     render(
       <PetPassportModal open companionId="p1" companionName="Doggy Wandhare" onClose={jest.fn()} />
@@ -205,7 +212,7 @@ describe('PetPassportModal', () => {
   });
 
   it('shows a busy label while the pass is generated', async () => {
-    mockedFetch.mockResolvedValue({ identity: { name: 'Doggy' } });
+    mockedFetch.mockResolvedValue(ISSUED);
     let resolve: () => void = () => {};
     mockedDownload.mockReturnValue(
       new Promise<void>((r) => {
@@ -224,7 +231,7 @@ describe('PetPassportModal', () => {
   });
 
   it('notifies when the wallet download fails', async () => {
-    mockedFetch.mockResolvedValue({ identity: { name: 'Doggy' } });
+    mockedFetch.mockResolvedValue(ISSUED);
     mockedDownload.mockRejectedValue(new Error('501'));
     render(<PetPassportModal open companionId="p1" companionName="Doggy" onClose={jest.fn()} />);
     fireEvent.click(await screen.findByRole('button', { name: 'Add to Apple Wallet' }));
@@ -237,7 +244,7 @@ describe('PetPassportModal', () => {
   });
 
   it('opens the Google Wallet save url on button click', async () => {
-    mockedFetch.mockResolvedValue({ identity: { name: 'Doggy' } });
+    mockedFetch.mockResolvedValue(ISSUED);
     mockedGoogle.mockResolvedValue('https://pay.google.com/gp/v/save/tok');
     const openSpy = jest.spyOn(globalThis.window, 'open').mockImplementation(() => null);
     render(<PetPassportModal open companionId="p1" companionName="Doggy" onClose={jest.fn()} />);
@@ -252,7 +259,7 @@ describe('PetPassportModal', () => {
   });
 
   it('notifies when the Google Wallet url cannot be built', async () => {
-    mockedFetch.mockResolvedValue({ identity: { name: 'Doggy' } });
+    mockedFetch.mockResolvedValue(ISSUED);
     mockedGoogle.mockRejectedValue(new Error('501'));
     render(<PetPassportModal open companionId="p1" companionName="Doggy" onClose={jest.fn()} />);
     fireEvent.click(await screen.findByRole('button', { name: 'Add to Google Wallet' }));
@@ -262,5 +269,17 @@ describe('PetPassportModal', () => {
         expect.objectContaining({ title: 'Wallet pass unavailable' })
       )
     );
+  });
+  it('hides the wallet actions until the passport is issued', async () => {
+    mockedFetch.mockResolvedValue({ identity: { name: 'Doggy' } });
+    render(<PetPassportModal open companionId="p1" companionName="Doggy" onClose={jest.fn()} />);
+    await screen.findByTestId('passport');
+    expect(
+      screen.getByText('Wallet passes become available once a vet issues this passport.')
+    ).toBeInTheDocument();
+    // The wallet endpoints 404 without an issued passport, so offering these
+    // would guarantee a failed download.
+    expect(screen.queryByRole('button', { name: 'Add to Apple Wallet' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Add to Google Wallet' })).not.toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/app/features/petPassport/components/PetPassportModal.tsx
+++ b/apps/frontend/src/app/features/petPassport/components/PetPassportModal.tsx
@@ -111,20 +111,30 @@ const PetPassportModalContent = ({
         {state === 'ready' && passport && (
           <>
             <PetPassportView passport={passport} />
-            <div className="flex flex-col gap-2 sm:flex-row">
-              <Button
-                variant="primary"
-                text={busy === 'apple' ? 'Adding to Apple Wallet...' : 'Add to Apple Wallet'}
-                onClick={handleAddToApple}
-                isDisabled={busy !== null}
-              />
-              <Button
-                variant="secondary"
-                text={busy === 'google' ? 'Adding to Google Wallet...' : 'Add to Google Wallet'}
-                onClick={handleAddToGoogle}
-                isDisabled={busy !== null}
-              />
-            </div>
+            {/* A wallet pass is built from an ISSUED passport: its QR carries the
+                public token, and a pet without one has nothing to verify against,
+                so the wallet endpoints 404. Offering the buttons regardless would
+                guarantee a failed download, so gate them on issuance. */}
+            {passport.issuance ? (
+              <div className="flex flex-col gap-2 sm:flex-row">
+                <Button
+                  variant="primary"
+                  text={busy === 'apple' ? 'Adding to Apple Wallet...' : 'Add to Apple Wallet'}
+                  onClick={handleAddToApple}
+                  isDisabled={busy !== null}
+                />
+                <Button
+                  variant="secondary"
+                  text={busy === 'google' ? 'Adding to Google Wallet...' : 'Add to Google Wallet'}
+                  onClick={handleAddToGoogle}
+                  isDisabled={busy !== null}
+                />
+              </div>
+            ) : (
+              <Text variant="caption-1" className="text-text-secondary">
+                Wallet passes become available once a vet issues this passport.
+              </Text>
+            )}
           </>
         )}
       </div>

--- a/apps/mobileAppYC/__tests__/features/passport/screens/PassportScreen/PassportScreen.test.tsx
+++ b/apps/mobileAppYC/__tests__/features/passport/screens/PassportScreen/PassportScreen.test.tsx
@@ -759,6 +759,22 @@ describe('PassportScreen', () => {
       Platform.OS = 'ios';
     });
 
+    it('hides both wallet actions until the passport is issued', () => {
+      // Wallet passes are built from an issued passport, so the endpoints 404
+      // without one. Offering the buttons would guarantee a failed download.
+      const unissued = {...mockPassport, issuance: undefined};
+      const {queryByText} = render(
+        <Provider
+          store={buildStore({
+            passport: passportState({[mockCompanionId]: unissued}),
+          })}>
+          <PassportScreen />
+        </Provider>,
+      );
+      expect(queryByText('Add to Apple Wallet')).toBeNull();
+      expect(queryByText('Add to Google Wallet')).toBeNull();
+    });
+
     it('shows the Apple Wallet button on iOS and hides it on Android', () => {
       Platform.OS = 'ios';
       const iosRender = render(

--- a/apps/mobileAppYC/src/features/passport/components/PassportDetails.tsx
+++ b/apps/mobileAppYC/src/features/passport/components/PassportDetails.tsx
@@ -152,11 +152,17 @@ export const PassportDetails: React.FC<{
         )}
       />
 
-      <PassportWalletButtons
-        companionId={companionId}
-        styles={styles}
-        theme={theme}
-      />
+      {/* Wallet passes are built from an ISSUED passport: the pass QR carries
+          the public token, and a pet without one has nothing to verify against,
+          so the wallet endpoints 404. Hide the actions until a vet issues it
+          rather than offering a download that cannot succeed. */}
+      {passport.issuance && (
+        <PassportWalletButtons
+          companionId={companionId}
+          styles={styles}
+          theme={theme}
+        />
+      )}
 
       <HistoricalUploadsSection
         records={historicalRecords}


### PR DESCRIPTION
## What changed

Gate the Apple Wallet and Google Wallet actions on `passport.issuance` in both the web passport modal and the mobile passport screen.

- Web: shows an explainer line in place of the buttons.
- Mobile: hides the actions entirely.

## Why

A wallet pass is built from an **issued** passport. The pass QR carries the public token, and `ensurePublicToken` throws 404 for a pet with no issued passport because there is nothing to verify against. Both surfaces rendered the wallet actions unconditionally, so any un-issued patient got a guaranteed "Wallet pass unavailable" toast.

Found while testing on dev. For a real patient the passport view returned 200 while both wallet endpoints returned 404:

```
GET .../companion/<id>/passport        200
GET .../companion/<id>/wallet/google   404  {"message":"Passport not found."}
GET .../companion/<id>/wallet/apple    404  {"message":"Passport not found."}
```

The backend behaviour is correct and unchanged. The DTO already carries `issuance`, and `PetPassportView` and `PublicPassportView` already gate on it, so this brings the two wallet entry points in line with the rest of the passport UI.

## Impact area

`apps/frontend` pet passport modal, `apps/mobileAppYC` passport screen. No backend or schema change.

## Validation performed

- Frontend: `tsc --noEmit` clean, eslint clean, `PetPassportModal` 16 tests pass (was 15), coverage on the changed file 100% statements / branches / functions / lines.
- Mobile: `tsc --noEmit` clean, eslint clean, `PassportScreen` 31 tests pass (was 30). Full mobile suite 7525 tests pass.
- Mutation checked the new mobile test: removing the gate fails exactly that one test, confirming it targets the fix rather than passing vacuously.