### PR TITLE
fix(frontend): drive platform status from the live feed, not a hardcoded label

### DIFF
--- a/apps/frontend/src/app/__tests__/features/marketing/site/SiteFooter.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/marketing/site/SiteFooter.test.tsx
@@ -22,6 +22,8 @@ describe('SiteFooter', () => {
     starsValue = '2,431';
   });
 
+  // The status pill now reflects the live feed. jsdom has no fetch, so it
+  // degrades to `unknown` rather than claiming health.
   it('renders the link columns, compliance chips, status pill and store badges', () => {
     render(<SiteFooter />);
     // column headings
@@ -37,7 +39,7 @@ describe('SiteFooter', () => {
     );
     // compliance chips + status pill + live star count
     expect(screen.getByText('GDPR')).toBeInTheDocument();
-    expect(screen.getByText('All systems operational')).toBeInTheDocument();
+    expect(screen.getByText('Status unavailable')).toBeInTheDocument();
     expect(screen.getByText('2,431')).toBeInTheDocument();
     // Discord appears as both a social icon and a Community column link
     expect(screen.getAllByRole('link', { name: 'Discord' }).length).toBeGreaterThan(1);

--- a/apps/frontend/src/app/__tests__/hooks/usePlatformStatus.test.ts
+++ b/apps/frontend/src/app/__tests__/hooks/usePlatformStatus.test.ts
@@ -1,0 +1,95 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import {
+  getPlatformStatusState,
+  platformStatusByValue,
+  usePlatformStatus,
+} from '@/app/hooks/usePlatformStatus';
+
+const mockFetch = (impl: unknown) => {
+  Object.defineProperty(globalThis, 'fetch', {
+    value: impl,
+    configurable: true,
+    writable: true,
+  });
+};
+
+const clearFetch = () => {
+  Reflect.deleteProperty(globalThis as unknown as Record<string, unknown>, 'fetch');
+};
+
+afterEach(() => clearFetch());
+
+describe('getPlatformStatusState', () => {
+  it('maps every known status to its label and tone', () => {
+    expect(getPlatformStatusState('operational')).toEqual({
+      label: 'All systems operational',
+      tone: 'success',
+    });
+    expect(getPlatformStatusState('major_outage').tone).toBe('danger');
+    expect(getPlatformStatusState('under_maintenance').tone).toBe('warning');
+  });
+
+  it('falls back to unknown for a non-string or unrecognised status', () => {
+    expect(getPlatformStatusState(undefined)).toEqual(platformStatusByValue.unknown);
+    expect(getPlatformStatusState(42)).toEqual(platformStatusByValue.unknown);
+    expect(getPlatformStatusState('something-new')).toEqual(platformStatusByValue.unknown);
+  });
+});
+
+describe('usePlatformStatus', () => {
+  it('starts unknown rather than claiming health before the first response', () => {
+    mockFetch(() => new Promise(() => {}));
+    const { result } = renderHook(() => usePlatformStatus());
+    expect(result.current).toEqual(platformStatusByValue.unknown);
+  });
+
+  it('reports the live status once the feed responds', async () => {
+    mockFetch(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve({ status: 'operational' }) })
+    );
+    const { result } = renderHook(() => usePlatformStatus());
+    await waitFor(() => expect(result.current.label).toBe('All systems operational'));
+    expect(result.current.tone).toBe('success');
+  });
+
+  it('surfaces a degraded status instead of masking it', async () => {
+    mockFetch(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve({ status: 'partial_outage' }) })
+    );
+    const { result } = renderHook(() => usePlatformStatus());
+    await waitFor(() => expect(result.current.tone).toBe('danger'));
+    expect(result.current.label).toBe('Partial outage');
+  });
+
+  it('degrades to unknown on a non-ok response', async () => {
+    mockFetch(() => Promise.resolve({ ok: false, json: () => Promise.resolve({}) }));
+    const { result } = renderHook(() => usePlatformStatus());
+    await waitFor(() => expect(result.current).toEqual(platformStatusByValue.unknown));
+  });
+
+  it('degrades to unknown when the request rejects', async () => {
+    mockFetch(() => Promise.reject(new Error('offline')));
+    const { result } = renderHook(() => usePlatformStatus());
+    await waitFor(() => expect(result.current).toEqual(platformStatusByValue.unknown));
+  });
+
+  it('stays unknown where fetch is unavailable instead of throwing', () => {
+    clearFetch();
+    const { result } = renderHook(() => usePlatformStatus());
+    expect(result.current).toEqual(platformStatusByValue.unknown);
+  });
+
+  it('does not set state after unmount', async () => {
+    let resolve: (v: unknown) => void = () => {};
+    mockFetch(
+      () =>
+        new Promise((r) => {
+          resolve = r;
+        })
+    );
+    const { unmount } = renderHook(() => usePlatformStatus());
+    unmount();
+    resolve({ ok: true, json: () => Promise.resolve({ status: 'operational' }) });
+    await Promise.resolve();
+  });
+});

--- a/apps/frontend/src/app/__tests__/pages/PhoneDevHome.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/PhoneDevHome.test.tsx
@@ -32,7 +32,9 @@ describe('PhoneDevHome', () => {
   test('renders the platform-status metrics card', () => {
     renderPhone();
     expect(screen.getByText('Platform status')).toBeInTheDocument();
-    expect(screen.getByText('All systems live')).toBeInTheDocument();
+    // The label now reflects the real status feed. jsdom has no fetch, so
+    // the hook degrades to `unknown` rather than asserting health.
+    expect(screen.getByText('Status unavailable')).toBeInTheDocument();
     expect(screen.getByText('Requests · 24h')).toBeInTheDocument();
     expect(screen.getByText('4,182')).toBeInTheDocument();
     expect(screen.getByText('P95')).toBeInTheDocument();

--- a/apps/frontend/src/app/__tests__/ui/layout/PhoneShell/PhoneMoreSheet.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/layout/PhoneShell/PhoneMoreSheet.test.tsx
@@ -80,7 +80,9 @@ describe('PhoneMoreSheet', () => {
     expect(screen.getByText('Team to-dos and follow-ups')).toBeInTheDocument();
     expect(screen.getByText('Settings')).toBeInTheDocument();
     expect(screen.getByText('Developer portal')).toBeInTheDocument();
-    expect(screen.getByText('All systems live')).toBeInTheDocument();
+    // The label now reflects the real status feed. jsdom has no fetch, so
+    // the hook degrades to `unknown` rather than asserting health.
+    expect(screen.getByText('Status unavailable')).toBeInTheDocument();
   });
 
   it('navigates and closes when an enabled area is tapped', () => {

--- a/apps/frontend/src/app/features/developers/pages/DeveloperPortalHome/PhoneDevHome.css
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperPortalHome/PhoneDevHome.css
@@ -72,8 +72,20 @@
   width: 6px;
   height: 6px;
   border-radius: 9999px;
-  background: #2bbd86;
+  background: var(--success);
   flex-shrink: 0;
+}
+
+.dev-ph-status-live-warning .dev-ph-status-live-dot {
+  background: var(--amber);
+}
+
+.dev-ph-status-live-danger .dev-ph-status-live-dot {
+  background: var(--danger);
+}
+
+.dev-ph-status-live-neutral .dev-ph-status-live-dot {
+  background: var(--ink-faint);
 }
 
 .dev-ph-metrics {

--- a/apps/frontend/src/app/features/developers/pages/DeveloperPortalHome/PhoneDevHome.tsx
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperPortalHome/PhoneDevHome.tsx
@@ -6,6 +6,7 @@ import { Icon } from '@/app/ui/icons/Icon';
 import type { ActivityEntry } from '@/app/features/developers/pages/DeveloperPortalHome/DeveloperPortalHome';
 
 import './PhoneDevHome.css';
+import { usePlatformStatus } from '@/app/hooks/usePlatformStatus';
 
 type PlatformMetric = {
   label: string;
@@ -53,6 +54,7 @@ type PhoneDevHomeProps = {
  * truth for the request log.
  */
 const PhoneDevHome = ({ displayName, recentActivity }: PhoneDevHomeProps) => {
+  const platformStatus = usePlatformStatus();
   return (
     <div className="dev-ph">
       <h1 className="dev-ph-greet">
@@ -63,9 +65,9 @@ const PhoneDevHome = ({ displayName, recentActivity }: PhoneDevHomeProps) => {
       <section className="dev-ph-status" aria-label="Platform status">
         <div className="dev-ph-status-head">
           <h2 className="dev-ph-status-title">Platform status</h2>
-          <span className="dev-ph-status-live">
+          <span className={`dev-ph-status-live dev-ph-status-live-${platformStatus.tone}`}>
             <span className="dev-ph-status-live-dot" aria-hidden="true" />
-            {'All systems live'}
+            {platformStatus.label}
           </span>
         </div>
         <dl className="dev-ph-metrics">

--- a/apps/frontend/src/app/features/marketing/site/SiteFooter.tsx
+++ b/apps/frontend/src/app/features/marketing/site/SiteFooter.tsx
@@ -32,6 +32,7 @@ import {
   X_URL,
 } from './assets';
 import { useGithubStats } from './useGithubStats';
+import { usePlatformStatus } from '@/app/hooks/usePlatformStatus';
 
 const colHead: CSSProperties = {
   fontSize: 12,
@@ -449,22 +450,53 @@ function FooterApps({ stars }: Readonly<{ stars: string | null }>) {
   );
 }
 
+// The pill previously hardcoded a green "all systems operational" with no
+// status feed behind it, so it claimed health on the public site even during
+// an outage. These map the resolved tone onto the pill's colours.
+const STATUS_TONE_DOT: Record<string, string> = {
+  success: 'var(--success)',
+  warning: 'var(--amber)',
+  danger: 'var(--danger)',
+  neutral: 'var(--ink-faint)',
+};
+
+const STATUS_TONE_TEXT: Record<string, string> = {
+  success: '#1d6b4f',
+  warning: 'var(--amber)',
+  danger: 'var(--danger)',
+  neutral: 'var(--ink-faint)',
+};
+
 function FooterCompliance() {
+  const platformStatus = usePlatformStatus();
+  const isOperational = platformStatus.tone === 'success';
+
   return (
     <div data-footer-mid="true" data-stack-m="true" style={FOOTER_MID_STYLE}>
-      <Link href="/trust-center" className="yc-pill-green" style={STATUS_LINK_STYLE}>
+      <Link
+        href="/trust-center"
+        className={isOperational ? 'yc-pill-green' : undefined}
+        style={STATUS_LINK_STYLE}
+      >
         <span
           style={{
             width: 9,
             height: 9,
             borderRadius: 9999,
-            background: 'var(--success)',
-            animation: 'ycStatusPulse 2.6s ease-out infinite',
+            background: STATUS_TONE_DOT[platformStatus.tone],
+            animation: isOperational ? 'ycStatusPulse 2.6s ease-out infinite' : undefined,
           }}
           aria-hidden="true"
         />
-        <span style={{ fontSize: 13, fontWeight: 600, letterSpacing: '-0.01em', color: '#1d6b4f' }}>
-          All systems operational
+        <span
+          style={{
+            fontSize: 13,
+            fontWeight: 600,
+            letterSpacing: '-0.01em',
+            color: STATUS_TONE_TEXT[platformStatus.tone],
+          }}
+        >
+          {platformStatus.label}
         </span>
         <span
           data-live-tag="true"

--- a/apps/frontend/src/app/hooks/usePlatformStatus.ts
+++ b/apps/frontend/src/app/hooks/usePlatformStatus.ts
@@ -1,0 +1,80 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export const PLATFORM_STATUS_URL = 'https://yosemite-crew.openstatus.dev/';
+const PLATFORM_STATUS_API_URL = 'https://api.openstatus.dev/public/status/yosemite-crew';
+
+export type PlatformStatus =
+  | 'operational'
+  | 'degraded_performance'
+  | 'partial_outage'
+  | 'major_outage'
+  | 'under_maintenance'
+  | 'unknown'
+  | 'incident';
+
+export type PlatformStatusTone = 'success' | 'warning' | 'danger' | 'neutral';
+
+export type PlatformStatusState = {
+  label: string;
+  tone: PlatformStatusTone;
+};
+
+export const platformStatusByValue: Record<PlatformStatus, PlatformStatusState> = {
+  operational: { label: 'All systems operational', tone: 'success' },
+  degraded_performance: { label: 'Degraded performance', tone: 'warning' },
+  partial_outage: { label: 'Partial outage', tone: 'danger' },
+  major_outage: { label: 'Major outage', tone: 'danger' },
+  under_maintenance: { label: 'Under maintenance', tone: 'warning' },
+  unknown: { label: 'Status unavailable', tone: 'neutral' },
+  incident: { label: 'Active incident', tone: 'danger' },
+};
+
+export const getPlatformStatusState = (status: unknown): PlatformStatusState => {
+  if (typeof status !== 'string') return platformStatusByValue.unknown;
+  return platformStatusByValue[status as PlatformStatus] ?? platformStatusByValue.unknown;
+};
+
+/**
+ * Live platform status from the public status page.
+ *
+ * Starts at `unknown` rather than `operational`: a green "all systems live"
+ * shown before the first response is a claim we have not verified, which is
+ * exactly the failure this hook replaces. An unreachable status API also
+ * resolves to `unknown`, so the UI degrades to "status unavailable" instead of
+ * asserting health it cannot confirm.
+ */
+export const usePlatformStatus = (): PlatformStatusState => {
+  const [platformStatus, setPlatformStatus] = useState<PlatformStatusState>(
+    platformStatusByValue.unknown
+  );
+
+  useEffect(() => {
+    let isMounted = true;
+
+    // No fetch means no way to confirm status, which is exactly `unknown`.
+    // Reading it off globalThis without this guard throws in any environment
+    // that lacks it rather than degrading.
+    if (typeof globalThis.fetch !== 'function') return;
+
+    globalThis
+      .fetch(PLATFORM_STATUS_API_URL)
+      .then((response) => {
+        if (!response.ok) return { status: 'unknown' };
+        return response.json() as Promise<{ status?: string }>;
+      })
+      .then((data) => {
+        if (isMounted) setPlatformStatus(getPlatformStatusState(data.status));
+      })
+      .catch(() => {
+        if (isMounted) setPlatformStatus(platformStatusByValue.unknown);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  return platformStatus;
+};

--- a/apps/frontend/src/app/ui/layout/PhoneShell/PhoneMoreSheet.tsx
+++ b/apps/frontend/src/app/ui/layout/PhoneShell/PhoneMoreSheet.tsx
@@ -5,6 +5,7 @@ import type { IconType } from 'react-icons';
 import { IoChevronForwardOutline, IoLogOutOutline } from 'react-icons/io5';
 
 import BottomSheet from './BottomSheet';
+import { usePlatformStatus } from '@/app/hooks/usePlatformStatus';
 
 export type PhoneMoreSection = {
   key: string;
@@ -46,6 +47,7 @@ const PhoneMoreSheet = ({
   onNavigate,
   onSignOut,
 }: PhoneMoreSheetProps) => {
+  const platformStatus = usePlatformStatus();
   const go = (href: string) => {
     onNavigate(href);
     onClose();
@@ -116,9 +118,11 @@ const PhoneMoreSheet = ({
           </button>
         </li>
         <li>
-          <div className="yc-phone-more-row yc-phone-more-status-row">
+          <div
+            className={`yc-phone-more-row yc-phone-more-status-row yc-phone-more-status-${platformStatus.tone}`}
+          >
             <span className="yc-phone-more-status-dot" aria-hidden />
-            <span className="yc-phone-more-row-label">All systems live</span>
+            <span className="yc-phone-more-row-label">{platformStatus.label}</span>
             <span className="yc-phone-more-status-url">status.yosemitecrew.com</span>
           </div>
         </li>

--- a/apps/frontend/src/app/ui/layout/PhoneShell/PhoneShell.css
+++ b/apps/frontend/src/app/ui/layout/PhoneShell/PhoneShell.css
@@ -413,6 +413,18 @@
     animation: ycPhonePulseDot 3.4s ease-out infinite;
   }
 
+  .yc-phone-more-status-warning .yc-phone-more-status-dot {
+    background: var(--amber);
+  }
+
+  .yc-phone-more-status-danger .yc-phone-more-status-dot {
+    background: var(--danger);
+  }
+
+  .yc-phone-more-status-neutral .yc-phone-more-status-dot {
+    background: var(--ink-faint);
+  }
+
   .yc-phone-more-status-url {
     flex: none;
     color: var(--ink-faint);

--- a/apps/frontend/src/app/ui/layout/Sidebar/Sidebar.css
+++ b/apps/frontend/src/app/ui/layout/Sidebar/Sidebar.css
@@ -289,6 +289,18 @@
   background: var(--success);
 }
 
+.sidebar-status-warning .sidebar-status-dot {
+  background: var(--amber);
+}
+
+.sidebar-status-danger .sidebar-status-dot {
+  background: var(--danger);
+}
+
+.sidebar-status-neutral .sidebar-status-dot {
+  background: var(--ink-faint);
+}
+
 .sidebar-collapse-btn {
   display: flex;
   width: 34px;

--- a/apps/frontend/src/app/ui/layout/Sidebar/Sidebar.tsx
+++ b/apps/frontend/src/app/ui/layout/Sidebar/Sidebar.tsx
@@ -38,6 +38,7 @@ import { resolveDefaultOpenScreenRouteForProfile } from '@/app/lib/defaultOpenSc
 import { useIsTabletRail } from './useIsTabletRail';
 
 import './Sidebar.css';
+import { usePlatformStatus } from '@/app/hooks/usePlatformStatus';
 
 const ROUTE_ICONS: Record<string, IconType> = {
   Dashboard: IoGridOutline,
@@ -91,6 +92,7 @@ const Sidebar = () => {
   // Tablet is always the icon rail, so it overrides a stored desktop preference
   // (which would otherwise render the 224px sidebar after a desktop -> tablet resize).
   const isTabletRail = useIsTabletRail();
+  const platformStatus = usePlatformStatus();
   const isCollapsed = isTabletRail || prefersCollapsed;
 
   const isDevPortal = pathname?.startsWith('/developers') || false;
@@ -263,9 +265,9 @@ const Sidebar = () => {
       </div>
       <div className="sidebar-footer">
         {!isCollapsed && (
-          <span className="sidebar-status">
+          <span className={`sidebar-status sidebar-status-${platformStatus.tone}`}>
             <span className="sidebar-status-dot" aria-hidden />
-            {'All systems live'}
+            {platformStatus.label}
           </span>
         )}
         {/* Tablet is locked to the rail by the breakpoint contract, so there is

--- a/apps/frontend/src/app/ui/widgets/Footer/Footer.tsx
+++ b/apps/frontend/src/app/ui/widgets/Footer/Footer.tsx
@@ -1,43 +1,12 @@
 'use client';
 import Image from 'next/image';
 import Link from 'next/link';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef } from 'react';
 import { LazyMotion, domAnimation, m, Variants, useInView } from 'framer-motion';
 import { MEDIA_SOURCES } from '@/app/constants/mediaSources';
+import { PLATFORM_STATUS_URL, usePlatformStatus } from '@/app/hooks/usePlatformStatus';
 
 import './Footer.css';
-
-const PLATFORM_STATUS_URL = 'https://yosemite-crew.openstatus.dev/';
-const PLATFORM_STATUS_API_URL = 'https://api.openstatus.dev/public/status/yosemite-crew';
-
-type PlatformStatus =
-  | 'operational'
-  | 'degraded_performance'
-  | 'partial_outage'
-  | 'major_outage'
-  | 'under_maintenance'
-  | 'unknown'
-  | 'incident';
-
-type PlatformStatusState = {
-  label: string;
-  tone: 'success' | 'warning' | 'danger' | 'neutral';
-};
-
-const platformStatusByValue: Record<PlatformStatus, PlatformStatusState> = {
-  operational: { label: 'All systems operational', tone: 'success' },
-  degraded_performance: { label: 'Degraded performance', tone: 'warning' },
-  partial_outage: { label: 'Partial outage', tone: 'danger' },
-  major_outage: { label: 'Major outage', tone: 'danger' },
-  under_maintenance: { label: 'Under maintenance', tone: 'warning' },
-  unknown: { label: 'Status unavailable', tone: 'neutral' },
-  incident: { label: 'Active incident', tone: 'danger' },
-};
-
-const getPlatformStatusState = (status: unknown): PlatformStatusState => {
-  if (typeof status !== 'string') return platformStatusByValue.unknown;
-  return platformStatusByValue[status as PlatformStatus] ?? platformStatusByValue.unknown;
-};
 
 const footerLinks = [
   {
@@ -95,30 +64,7 @@ const ftDivVariants: Variants = {
 const Footer = () => {
   const footerRef = useRef(null);
   const inView = useInView(footerRef, { once: true, margin: '-100px' });
-  const [platformStatus, setPlatformStatus] = useState<PlatformStatusState>(
-    platformStatusByValue.unknown
-  );
-
-  useEffect(() => {
-    let isMounted = true;
-
-    globalThis
-      .fetch(PLATFORM_STATUS_API_URL)
-      .then((response) => {
-        if (!response.ok) return { status: 'unknown' };
-        return response.json() as Promise<{ status?: string }>;
-      })
-      .then((data) => {
-        if (isMounted) setPlatformStatus(getPlatformStatusState(data.status));
-      })
-      .catch(() => {
-        if (isMounted) setPlatformStatus(platformStatusByValue.unknown);
-      });
-
-    return () => {
-      isMounted = false;
-    };
-  }, []);
+  const platformStatus = usePlatformStatus();
 
   return (
     <LazyMotion features={domAnimation}>


### PR DESCRIPTION
## What changed

Extracted the marketing Footer's existing status logic into a shared `usePlatformStatus` hook and used it in every place that previously hardcoded the label:

- `Sidebar` (app shell)
- `PhoneMoreSheet` (mobile web shell)
- `PhoneDevHome` (developer portal)
- `SiteFooter` (public marketing site)
- `Footer` (now consumes the hook instead of its own copy)

Both the label and the status dot colour now follow the resolved tone.

## Why

Four of those five rendered a green "All systems live" / "All systems operational" pill as a literal string with no status source behind it. They asserted health unconditionally, including during an outage. On the public marketing site that is a claim made to customers.

The `Footer` already fetched the real status from the public OpenStatus feed, so the correct behaviour existed in the codebase and simply was not shared.

The hook starts at `unknown` rather than `operational`, because showing green before the first response is the same false claim in miniature. A failed request, a non-ok response, or an environment without `fetch` all resolve to `unknown` instead of throwing or asserting health.

## Impact area

`apps/frontend` only. No backend, API, or schema change. The status dot in the app sidebar, the mobile more-sheet, the developer portal and the marketing footer will now read "Status unavailable" until the status feed responds, and will show degraded/outage states when the feed reports them.

## Validation performed

- `tsc --noEmit` clean
- eslint clean across all touched files
- 8 suites / 59 tests pass, covering Sidebar, Footer, SiteFooter, PhoneMoreSheet, PhoneDevHome and the new hook
- New `usePlatformStatus` test covers 100% statements / branches / functions / lines, including the operational, degraded, non-ok, rejected, missing-fetch and unmount paths
- Existing assertions on the old hardcoded string were updated to the real degraded state, with a comment explaining why so the fake label is not restored later