### PR TITLE
ci(repo): boot the built backend so a non-starting build cannot pass

### DIFF
--- a/.github/workflows/_core.yaml
+++ b/.github/workflows/_core.yaml
@@ -266,3 +266,24 @@ jobs:
       - name: Build
         if: matrix.has_build && matrix.workspace != 'frontend' && startsWith(matrix.dir, 'apps/')
         run: pnpm --filter "${{ matrix.workspace }}" run build
+
+      # A backend that cannot start still passes every other gate: tsc, eslint
+      # and jest each resolve imports differently from Node's ESM loader at
+      # runtime. An extensionless deep import shipped to dev exactly this way
+      # and crash-looped the API behind a 502, green all the way. Boot the built
+      # artifact and fail only on module-resolution errors. Missing env is
+      # expected here and is not a failure, because config is read after the
+      # module graph is linked. A timeout (124) means it booted and kept
+      # running, which is the healthy outcome.
+      - name: Boot check
+        if: matrix.has_build && matrix.workspace == 'backend'
+        run: |
+          set +e
+          BOOT_OUTPUT=$(timeout 45 node apps/backend/dist/index.js 2>&1)
+          set -e
+          if printf '%s' "$BOOT_OUTPUT" | grep -qE 'ERR_MODULE_NOT_FOUND|ERR_UNSUPPORTED_DIR_IMPORT|Cannot find module|Cannot find package'; then
+            echo "::error::The built backend cannot resolve its module graph, so it would crash on boot."
+            printf '%s\n' "$BOOT_OUTPUT" | grep -vE '^[[:space:]]+at ' | head -30
+            exit 1
+          fi
+          echo "Module graph resolves."


### PR DESCRIPTION
## What changed

Added a `Boot check` step to the `static` job in `_core.yaml`. After the backend is built, CI now runs the built artifact and fails if the module graph cannot be resolved.

## Why

CI already built the backend but never ran it. A build that cannot start therefore passed every gate, because `tsc`, `eslint` and `jest` each resolve imports differently from Node's ESM loader at runtime.

That is not hypothetical. An extensionless deep import (`validator/lib/isEmail`) merged green in #2208, sat undetected because the dev host was pinned to an older commit, and crash-looped the API behind a 502 on the next deploy. It was fixed in #2261. Nothing in CI would have caught it, and nothing would catch the next one.

## How it avoids false positives

The step fails only on module-resolution errors (`ERR_MODULE_NOT_FOUND`, `ERR_UNSUPPORTED_DIR_IMPORT`, `Cannot find module`, `Cannot find package`).

Missing environment configuration is expected in CI and is deliberately not a failure, because config is read after the module graph is linked. A `timeout` exit means the process booted and kept running, which is the healthy outcome.

## Impact area

CI only, `backend` workspace only. No application code changes. Adds up to 45 seconds to the backend static job.

## Validation performed

Verified in both directions against the real defect rather than assuming the guard works:

- Reintroduced the extensionless import, rebuilt, and booted the artifact: the step's grep matches `ERR_MODULE_NOT_FOUND` and the check fails, as it should have in #2208.
- Restored the correct import, rebuilt, and booted: no module error. The process stops on missing Stream Chat env, which is after module linking, and the check passes.
- `_core.yaml` parses as valid YAML; the `static` job has 9 steps with `Boot check` last, guarded by `matrix.has_build && matrix.workspace == 'backend'`.