### PR TITLE
fix(repo): only offer a PIMS wallet pass when a share link exists

### DIFF
--- a/apps/backend/src/services/pet-passport.service.ts
+++ b/apps/backend/src/services/pet-passport.service.ts
@@ -217,6 +217,19 @@ const withAttestation = {
 // are read from the ClinicalArtifact children linked to the patient's encounters;
 // owner data is included only for authenticated callers (the public record is
 // owner-free).
+/**
+ * A share link counts only while it exists and has not been revoked.
+ *
+ * Kept out of `assemblePassport` deliberately: inlining the optional chain and
+ * the negation tips that function over the cognitive-complexity ceiling.
+ */
+const hasActivePublicShare = (
+  row: {
+    publicToken: string | null;
+    publicTokenRevokedAt: Date | null;
+  } | null,
+): boolean => Boolean(row?.publicToken && !row.publicTokenRevokedAt);
+
 const assemblePassport = async (
   patientId: string,
   organisationId: string,
@@ -339,10 +352,7 @@ const assemblePassport = async (
   const issuance = passportRow
     ? { ...toIssuanceDTO(passportRow), issuingPractice: organisation?.name }
     : undefined;
-  // Derived from the row already loaded above, so this costs no extra query.
-  const publicShareActive = Boolean(
-    passportRow?.publicToken && !passportRow.publicTokenRevokedAt,
-  );
+  const publicShareActive = hasActivePublicShare(passportRow);
   const vaccinations = immunizationRows.map((row) =>
     toVaccinationDTO(patientId, row),
   );

--- a/apps/backend/src/services/pet-passport.service.ts
+++ b/apps/backend/src/services/pet-passport.service.ts
@@ -339,6 +339,10 @@ const assemblePassport = async (
   const issuance = passportRow
     ? { ...toIssuanceDTO(passportRow), issuingPractice: organisation?.name }
     : undefined;
+  // Derived from the row already loaded above, so this costs no extra query.
+  const publicShareActive = Boolean(
+    passportRow?.publicToken && !passportRow.publicTokenRevokedAt,
+  );
   const vaccinations = immunizationRows.map((row) =>
     toVaccinationDTO(patientId, row),
   );
@@ -376,6 +380,7 @@ const assemblePassport = async (
     ),
     clinicalExams: examRows.map((row) => toExamDTO(patientId, row)),
     issuance,
+    publicShareActive,
     owner,
   };
 };

--- a/apps/backend/test/services/pet-passport.service.test.ts
+++ b/apps/backend/test/services/pet-passport.service.test.ts
@@ -174,6 +174,38 @@ describe("PetPassportService.getPassport", () => {
     ).rejects.toMatchObject({ statusCode: 404 });
   });
 
+  // A wallet pass embeds the public share link in its QR, so PIMS needs to know
+  // whether one is live before offering the action. Derived from the passport
+  // row already loaded, so it costs no extra query.
+  it("reports publicShareActive when the share link is live", async () => {
+    prismaMock.petPassport.findFirst.mockResolvedValue({
+      passportNumber: "GB-YC-1",
+      issueDate: new Date("2024-06-24T00:00:00.000Z"),
+      publicToken: "tok-live",
+      publicTokenRevokedAt: null,
+    });
+    const passport = await PetPassportService.getPassport("pat-1", "org-1");
+    expect(passport.publicShareActive).toBe(true);
+  });
+
+  it("reports publicShareActive false once the share link is revoked", async () => {
+    prismaMock.petPassport.findFirst.mockResolvedValue({
+      passportNumber: "GB-YC-1",
+      issueDate: new Date("2024-06-24T00:00:00.000Z"),
+      publicToken: "tok-dead",
+      publicTokenRevokedAt: new Date("2024-07-01T00:00:00.000Z"),
+    });
+    const passport = await PetPassportService.getPassport("pat-1", "org-1");
+    expect(passport.publicShareActive).toBe(false);
+  });
+
+  it("reports publicShareActive false when no passport has been issued", async () => {
+    prismaMock.petPassport.findFirst.mockResolvedValue(null);
+    const passport = await PetPassportService.getPassport("pat-1", "org-1");
+    expect(passport.issuance).toBeUndefined();
+    expect(passport.publicShareActive).toBe(false);
+  });
+
   it("assembles identity, microchip, marks, issuance, owner and records", async () => {
     prismaMock.petPassport.findFirst.mockResolvedValue({
       passportNumber: "GB-YC-1",

--- a/apps/frontend/src/app/__tests__/features/petPassport/components/PetPassportModal.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/petPassport/components/PetPassportModal.test.tsx
@@ -50,6 +50,7 @@ jest.mock('@/app/hooks/useNotify', () => ({ useNotify: () => ({ notify: notifyMo
 const ISSUED = {
   identity: { name: 'Doggy' },
   issuance: { passportNumber: 'PN-1', issueDate: '2026-01-01' },
+  publicShareActive: true,
 };
 
 const mockedFetch = getPetPassport as jest.Mock;
@@ -270,6 +271,21 @@ describe('PetPassportModal', () => {
       )
     );
   });
+  it('explains that the owner must create a share link before a pass can be built', async () => {
+    // Issued, but no live share link: staff cannot mint one, so the wallet
+    // endpoints return 409. Saying so beats a button that always fails.
+    mockedFetch.mockResolvedValue({ ...ISSUED, publicShareActive: false });
+    render(<PetPassportModal open companionId="p1" companionName="Doggy" onClose={jest.fn()} />);
+    await screen.findByTestId('passport');
+    expect(
+      screen.getByText(
+        'The owner needs to create a share link in the Yosemite Crew app before this passport can be added to a wallet.'
+      )
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Add to Apple Wallet' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Add to Google Wallet' })).not.toBeInTheDocument();
+  });
+
   it('hides the wallet actions until the passport is issued', async () => {
     mockedFetch.mockResolvedValue({ identity: { name: 'Doggy' } });
     render(<PetPassportModal open companionId="p1" companionName="Doggy" onClose={jest.fn()} />);

--- a/apps/frontend/src/app/features/petPassport/components/PetPassportModal.tsx
+++ b/apps/frontend/src/app/features/petPassport/components/PetPassportModal.tsx
@@ -67,6 +67,11 @@ const PetPassportModalContent = ({
 
   const petName = companionName.split(' ')[0] || companionName;
 
+  let walletState: 'not-issued' | 'no-share-link' | 'ready' = 'not-issued';
+  if (passport?.issuance) {
+    walletState = passport.publicShareActive ? 'ready' : 'no-share-link';
+  }
+
   const handleAddToApple = () => {
     setBusy('apple');
     downloadApplePass(companionId, petName)
@@ -111,11 +116,14 @@ const PetPassportModalContent = ({
         {state === 'ready' && passport && (
           <>
             <PetPassportView passport={passport} />
-            {/* A wallet pass is built from an ISSUED passport: its QR carries the
-                public token, and a pet without one has nothing to verify against,
-                so the wallet endpoints 404. Offering the buttons regardless would
-                guarantee a failed download, so gate them on issuance. */}
-            {passport.issuance ? (
+            {/* A staff-built wallet pass needs BOTH an issued passport and a live
+                public share link, because its QR embeds that link. Staff cannot
+                mint the link: it is an owner credential the pet's owner creates
+                from the mobile app, so this route only ever reads an existing
+                one and returns 409 when there is none. Offering the buttons in
+                either gap guarantees a failure the user cannot act on, so each
+                gap says what is actually missing. */}
+            {walletState === 'ready' ? (
               <div className="flex flex-col gap-2 sm:flex-row">
                 <Button
                   variant="primary"
@@ -132,7 +140,9 @@ const PetPassportModalContent = ({
               </div>
             ) : (
               <Text variant="caption-1" className="text-text-secondary">
-                Wallet passes become available once a vet issues this passport.
+                {walletState === 'not-issued'
+                  ? 'Wallet passes become available once a vet issues this passport.'
+                  : 'The owner needs to create a share link in the Yosemite Crew app before this passport can be added to a wallet.'}
               </Text>
             )}
           </>

--- a/packages/types/src/pet-passport.ts
+++ b/packages/types/src/pet-passport.ts
@@ -167,4 +167,13 @@ export interface PetPassportDTO {
   rabiesTitrations: RabiesTitrationDTO[];
   clinicalExams: ClinicalExamDTO[];
   issuance?: PetPassportIssuanceDTO;
+  /**
+   * True when the passport has a live public share link.
+   *
+   * A wallet pass embeds that link in its QR, so a pass can only be built when
+   * this is true. Staff cannot mint the link - it is an owner credential the
+   * pet's owner creates from the mobile app - so PIMS uses this to avoid
+   * offering a wallet action that cannot succeed.
+   */
+  publicShareActive?: boolean;
 }


### PR DESCRIPTION
## What changed

- `PetPassportDTO` gains `publicShareActive`, derived in `assemblePassport` from the passport row it already loads, so it costs no extra query.
- The PIMS passport modal now has three wallet states instead of two: not issued, issued but no share link, and ready.

## Why

A staff-built wallet pass needs **two** things, not one:

1. an issued passport, and
2. a live public share link, because the pass QR embeds that link.

Staff cannot mint the link. It is an owner credential the pet's owner creates from the mobile app, so the PIMS route only reads an existing one (`getExistingPublicToken`) and returns 409 when there is none. That restriction is deliberate: minting it from PIMS would hand staff the pet's public bearer credential.

#2263 gated the buttons on issuance alone, which was necessary but not sufficient.

Confirmed on dev against a real issued passport (`TEST-PP-0001`):

```
/passport       200  issuance: TEST-PP-0001
/wallet/google  409  "This passport has no active public share link..."
/wallet/apple   409  same
```

The modal still rendered both buttons, and clicking one produced "Wallet pass unavailable ... could not be added to Google Wallet yet" - which discards the server's actionable reason. Each gap now states what is actually missing.

## Mobile is deliberately unchanged

The owner's routes use `ensurePublicToken`, which mints on demand, so a pass can always be built once the passport is issued. Issuance alone is the correct gate there, and #2263 already applies it.

## Impact area

`packages/types`, `apps/backend` passport DTO assembly, `apps/frontend` passport modal. No route, permission or schema change. Mobile untouched.

## Validation performed

- Backend `tsc` clean; `pet-passport` suites 34 tests pass (was 31), with new cases for share link live, revoked, and never issued.
- Frontend `tsc` clean, eslint clean; `PetPassportModal` 17 tests pass (was 16); coverage on the changed file 100% statements / branches / functions / lines.
- Mobile `tsc` clean against the changed shared type.
- Behaviour reproduced live on dev before the fix, which is where the 409s above come from.