### PR TITLE
fix(frontend): put the Tasks now-line back at the right time

### DIFF
--- a/apps/frontend/src/app/(routes)/(public)/accessibility/report/AccessibilityReportClient.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/accessibility/report/AccessibilityReportClient.tsx
@@ -117,7 +117,14 @@ export default function AccessibilityReportClient() {
     return (
       <div data-yc-app style={{ display: 'contents' }}>
         <main id="main-content" tabIndex={-1} className="mx-auto max-w-2xl px-6 pt-22 pb-16">
+          {/* Pins its inks light because the card is a literal `bg-white` in both
+              themes. Without this the themed --ink-body (#e6ddd0 in dark) put the
+              heading, the body copy and both links at 1.34:1 - white text on a white
+              card, so the whole confirmation read as blank. globals.css:2001 already
+              names /accessibility/report as one of the three fixed-light surfaces
+              that must carry this pin; only /payment-status had it. */}
           <output
+            data-yc-surface="light"
             aria-live="polite"
             className="rounded-2xl border border-card-border bg-white p-8 text-center"
           >

--- a/apps/frontend/src/app/__tests__/components/Calendar/Task/WeekCalendar.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/Task/WeekCalendar.test.tsx
@@ -137,6 +137,12 @@ describe('WeekCalendar (Task)', () => {
   });
 
   it('gives every grid row exactly as many children as its template has columns', () => {
+    // Includes TODAY in the week so the now-line overlay mounts: it carries the
+    // same two-column template, and it had its own copy of the three-child bug
+    // that went unnoticed because the fixture week is January 2025 and the
+    // overlay only renders when one of the days is today.
+    const today = new Date();
+    mockGetWeekDays.mockReturnValue([today, new Date(today.getTime() + 86400000)]);
     // The rows are `grid-cols-[64px_minmax(0,1fr)]` - TWO columns. When the arrow
     // rails were removed the template dropped from three columns to two, but the
     // hour row kept a third child: the right rail's spacer. A third child in a

--- a/apps/frontend/src/app/__tests__/components/DataTable/InventoryTurnoverTable.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/DataTable/InventoryTurnoverTable.test.tsx
@@ -193,6 +193,30 @@ describe('InventoryTurnoverTable Component', () => {
     });
   });
 
+  /* The Status column is the one sized by its CELL, not its header: the header is
+     44px but the StatusPill is 10px/600 uppercase with 0.8px tracking plus 20px of
+     its own padding, and it is nowrap + overflow-hidden, so an undersized column
+     clips the word instead of wrapping it. Measured in the real pill font, four of
+     the five values overflowed the 69px content box a 100px column allowed. */
+  it('gives the Status column room for its widest pill, not just its header', () => {
+    // Rendered pill width (text + 20px pill padding) for each status value.
+    const WIDEST_PILL_PX = 102.4; // "Out of stock"; Excellent 82.5, Moderate 80.5, Healthy 69.4
+    const TD_PADDING = 31;
+
+    const { container } = render(<InventoryTurnoverTable filteredList={mockInventoryItems} />);
+    const desktopView = container.querySelector(String.raw`.hidden.xl\:flex`) as HTMLElement;
+    const labels = [...desktopView.querySelectorAll('th')].map(
+      (th) => th.textContent?.trim() ?? ''
+    );
+    const cols = [...desktopView.querySelectorAll('colgroup col')];
+    const statusWidth = Number.parseInt(
+      (cols[labels.indexOf('Status')] as HTMLElement).style.width,
+      10
+    );
+
+    expect(statusWidth).toBeGreaterThanOrEqual(WIDEST_PILL_PX + TD_PADDING);
+  });
+
   // --- 3. Mobile View (Cards) ---
 
   it('renders InventoryTurnoverCard components (Mobile View)', () => {

--- a/apps/frontend/src/app/__tests__/components/DataTable/InventoryTurnoverTable.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/DataTable/InventoryTurnoverTable.test.tsx
@@ -154,6 +154,45 @@ describe('InventoryTurnoverTable Component', () => {
     expect(within(row3).getByText('—')).toBeInTheDocument(); // Status fallback
   });
 
+  /* Every column here is sized by its HEADER, not its figures: the values are short
+     integers and the labels are long. Measured on deployed dev at the width where the
+     colgroup actually binds (viewport 1300, table at its min-width), five of the nine
+     headers were ellipsised - "Beginning inventory" by 34.5px, "Ending inventory" by
+     23.1, "Avg inventory" by 20.0, "Total purchases" by 15.7 and "Days on shelf" by
+     15.9, with "Turns/Year" on 1px of slack. jsdom has no font metrics, so this pins
+     the widths measured in a real browser: the th carries 22px of padding, so the
+     column must be the label's rendered text width + 22, and these floors carry ~8px
+     of margin on top of that. */
+  it('gives every column enough width for its own header label', () => {
+    // Rendered width of each label at 10.5px/700 with 1.05px tracking, from the browser.
+    const TEXT_PX: Record<string, number> = {
+      'Item name': 68,
+      Category: 65,
+      'Beginning inventory': 142,
+      'Ending inventory': 121,
+      'Avg inventory': 98,
+      'Total purchases': 114,
+      'Turns/Year': 77,
+      'Days on shelf': 94,
+      Status: 44,
+    };
+    const TH_PADDING = 22;
+
+    const { container } = render(<InventoryTurnoverTable filteredList={mockInventoryItems} />);
+    const desktopView = container.querySelector(String.raw`.hidden.xl\:flex`) as HTMLElement;
+    const cols = [...desktopView.querySelectorAll('colgroup col')];
+    const labels = [...desktopView.querySelectorAll('th')].map(
+      (th) => th.textContent?.trim() ?? ''
+    );
+
+    expect(cols).toHaveLength(labels.length);
+
+    labels.forEach((label, index) => {
+      const declared = Number.parseInt((cols[index] as HTMLElement).style.width, 10);
+      expect(declared).toBeGreaterThanOrEqual(TEXT_PX[label] + TH_PADDING);
+    });
+  });
+
   // --- 3. Mobile View (Cards) ---
 
   it('renders InventoryTurnoverCard components (Mobile View)', () => {

--- a/apps/frontend/src/app/__tests__/components/DataTable/InvoiceTable.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/DataTable/InvoiceTable.test.tsx
@@ -43,10 +43,14 @@ const capturedColumnWidths = () => {
   const columnsFor = (desktop: boolean) =>
     mockGenericTableCalls.find((c) => isDesktopVariant(c.tableClassName) === desktop)!.columns;
   return {
-    desktop: { status: widthOf(columnsFor(true), 'status') },
+    desktop: {
+      status: widthOf(columnsFor(true), 'status'),
+      actions: widthOf(columnsFor(true), 'actions'),
+    },
     tablet: {
       status: widthOf(columnsFor(false), 'status'),
       parent: widthOf(columnsFor(false), 'appointment-id'),
+      actions: widthOf(columnsFor(false), 'actions'),
     },
   };
 };
@@ -337,6 +341,18 @@ describe('InvoiceTable', () => {
       const widths = capturedColumnWidths();
       expect(Number.parseInt(widths.desktop.status, 10)).toBeGreaterThanOrEqual(176);
       expect(Number.parseInt(widths.tablet.status, 10)).toBeGreaterThanOrEqual(176);
+    });
+
+    it('gives Actions a column wide enough for its own header', () => {
+      render(<InvoiceTable filteredList={[invoice]} />);
+
+      // This is the only PIMS table with `table-layout: fixed`, so a narrow
+      // column cannot grow to fit its label - it ellipsises the header instead.
+      // "Actions" measures 53.3px + 31px th padding = 84.3px, and the shipped
+      // 64px desktop / 56px tablet values both rendered "Action...".
+      const widths = capturedColumnWidths();
+      expect(Number.parseInt(widths.desktop.actions, 10)).toBeGreaterThanOrEqual(85);
+      expect(Number.parseInt(widths.tablet.actions, 10)).toBeGreaterThanOrEqual(85);
     });
 
     it('leaves the Parent / patient column fluid so it absorbs the slack', () => {

--- a/apps/frontend/src/app/__tests__/components/DataTable/InvoiceTable.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/DataTable/InvoiceTable.test.tsx
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import React from 'react';
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
@@ -353,6 +355,28 @@ describe('InvoiceTable', () => {
       const widths = capturedColumnWidths();
       expect(Number.parseInt(widths.desktop.actions, 10)).toBeGreaterThanOrEqual(85);
       expect(Number.parseInt(widths.tablet.actions, 10)).toBeGreaterThanOrEqual(85);
+    });
+
+    it('keeps .invoice-table-fixed min-width equal to the sum of its column widths', () => {
+      /* DataTable.css states the invariant directly: "Each class carries its own
+         min-width = sum of its column px widths". A table-layout:fixed table whose
+         min-width is under that sum squeezes every column proportionally at narrow
+         viewports, which is exactly where the trailing Actions column runs past the
+         reachable scroll extent - the CSS comment on .forms-table-fixed warns about
+         it. The value has drifted twice now, both times because a column width was
+         changed without updating the min-width, so assert it rather than trust it. */
+      render(<InvoiceTable filteredList={[invoice]} />);
+
+      const desktop = mockGenericTableCalls.find((c) => isDesktopVariant(c.tableClassName))!;
+      const sum = desktop.columns.reduce(
+        (total: number, col: any) => total + Number.parseInt(col.width, 10),
+        0
+      );
+
+      const css = readFileSync(join(__dirname, '../../../ui/tables/DataTable.css'), 'utf8');
+      const rule = /\.invoice-table-fixed\s*\{[^}]*?min-width:\s*(\d+)px/.exec(css);
+      expect(rule).not.toBeNull();
+      expect(sum).toBe(Number.parseInt(rule![1], 10));
     });
 
     it('leaves the Parent / patient column fluid so it absorbs the slack', () => {

--- a/apps/frontend/src/app/__tests__/components/DataTable/tableUtils.orgStatus.test.ts
+++ b/apps/frontend/src/app/__tests__/components/DataTable/tableUtils.orgStatus.test.ts
@@ -1,18 +1,24 @@
 import { getOrganizationStatusStyle } from '@/app/ui/tables/tableUtils';
 
 describe('getOrganizationStatusStyle', () => {
-  it("returns the success style for 'Active' (case insensitive)", () => {
+  /* The two pill inks are the 800/900 members of their ramps, not the mid-ramp
+     fills. Measured on the deployed organization list, --color-success-400 on
+     --color-success-100 was 2.23:1 and --color-warning-600 on --color-warning-100
+     was 2.32:1, against a 4.5 bar. The ink members clear 6.23 and 6.42 on those
+     same tints. This is the same fill-as-ink pair already corrected in
+     paymentStatus.ts for the Paid/Unpaid line. */
+  it("returns the success INK style for 'Active' (case insensitive)", () => {
     const expected = {
-      color: 'var(--color-success-400)',
+      color: 'var(--success-text)',
       backgroundColor: 'var(--color-success-100)',
     };
     expect(getOrganizationStatusStyle('Active')).toEqual(expected);
     expect(getOrganizationStatusStyle('active')).toEqual(expected);
   });
 
-  it("returns the warning style for 'Pending'", () => {
+  it("returns the warning INK style for 'Pending'", () => {
     expect(getOrganizationStatusStyle('Pending')).toEqual({
-      color: 'var(--color-warning-600)',
+      color: 'var(--color-warning-900)',
       backgroundColor: 'var(--color-warning-100)',
     });
   });

--- a/apps/frontend/src/app/__tests__/lib/arbitraryGridTemplates.test.ts
+++ b/apps/frontend/src/app/__tests__/lib/arbitraryGridTemplates.test.ts
@@ -1,0 +1,64 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Tailwind arbitrary grid templates separate tracks with an underscore, because a
+ * space cannot appear inside a class name. A comma is not a track separator in CSS
+ * grid at all, so `grid-cols-[auto,minmax(0,1fr)]` compiles to
+ * `grid-template-columns: auto,minmax(0,1fr)`, which the browser rejects outright
+ * and drops. The element then falls back to a single implicit column and every
+ * child stacks vertically.
+ *
+ * Nothing catches this: it is a valid class name, so Tailwind emits it, and tsc,
+ * eslint and jsdom all see a perfectly ordinary string. It only shows up in a real
+ * browser, and only on whatever surface renders it - the one occurrence found was
+ * inside a task popover that exists solely after a click, which is why no story or
+ * screenshot had ever drawn it.
+ *
+ * Commas *inside* a function - minmax(0,1fr), repeat(2,1fr) - are correct and must
+ * not trip this, so parentheses are stripped before the check.
+ */
+const SRC = join(__dirname, '../..');
+const EXTENSIONS = ['.ts', '.tsx', '.css'];
+// __tests__ is skipped so this file's own worked example above does not match itself.
+// Stories live beside their components and are still scanned.
+const SKIP_DIRS = new Set(['node_modules', '.next', 'dist', '__tests__']);
+
+const collectFiles = (dir: string): string[] =>
+  readdirSync(dir).flatMap((entry) => {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      return SKIP_DIRS.has(entry) ? [] : collectFiles(full);
+    }
+    return EXTENSIONS.some((ext) => entry.endsWith(ext)) ? [full] : [];
+  });
+
+const stripBalancedParens = (value: string): string => {
+  let current = value;
+  let previous = '';
+  while (previous !== current) {
+    previous = current;
+    current = current.replaceAll(/\([^()]*\)/g, '');
+  }
+  return current;
+};
+
+describe('arbitrary grid templates', () => {
+  it('separates tracks with an underscore, never a comma', () => {
+    const pattern = /grid-(?:cols|rows)-\[([^\]]*)\]/g;
+    const offenders: string[] = [];
+
+    for (const file of collectFiles(SRC)) {
+      const lines = readFileSync(file, 'utf8').split('\n');
+      lines.forEach((line, index) => {
+        for (const match of line.matchAll(pattern)) {
+          if (stripBalancedParens(match[1]).includes(',')) {
+            offenders.push(`${file.replace(SRC, '')}:${index + 1} ${match[0]}`);
+          }
+        }
+      });
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/apps/frontend/src/app/__tests__/lib/paymentStatus.test.ts
+++ b/apps/frontend/src/app/__tests__/lib/paymentStatus.test.ts
@@ -134,7 +134,9 @@ describe('paymentStatus', () => {
       {}
     );
     expect(display.state).toBe('UNPAID');
-    expect(display.textColor).toBe('var(--color-warning-600)');
+    // The 900 INK step, not the 600 fill: as the 11px Paid/Unpaid line the fill
+    // measured 2.29:1 on the bone screen and on its own badge tint.
+    expect(display.textColor).toBe('var(--color-warning-900)');
   });
 
   it('returns PAID when stripePaymentLinkId present', () => {

--- a/apps/frontend/src/app/__tests__/ui/tables/DispensaryTable.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/tables/DispensaryTable.test.tsx
@@ -237,10 +237,15 @@ describe('DispensaryTable', () => {
     timeSpy.mockRestore();
   });
 
-  it('applies the success color class when timeDispensed is present', () => {
+  it('applies the success INK, not the success fill, when timeDispensed is present', () => {
+    /* --color-success-600 is a fill step: at this 12px size it measured 3.73:1 on
+       the bone screen. --success-text is the ink member of the same ramp and clears
+       6.37:1. globals.css records this exact token and number as the reason
+       --success-strong exists; the text call sites were simply never migrated. */
     const record = { ...baseRecord, timeDispensed: '2026-06-30T15:29:25.223Z' };
     const { container } = render(<DispensaryTable filteredList={[record]} />);
-    expect(container.querySelector('.text-\\[var\\(--color-success-600\\)\\]')).toBeInTheDocument();
+    expect(container.querySelector('.text-\\[var\\(--success-text\\)\\]')).toBeInTheDocument();
+    expect(container.querySelector('.text-\\[var\\(--color-success-600\\)\\]')).toBeNull();
   });
 
   it('left-aligns the status pill in its own row instead of leaving default grid stretch/centering', () => {

--- a/apps/frontend/src/app/features/appointments/components/AppointmentCentralModal/AppointmentEstimatePanel.tsx
+++ b/apps/frontend/src/app/features/appointments/components/AppointmentCentralModal/AppointmentEstimatePanel.tsx
@@ -80,7 +80,7 @@ const AppointmentEstimatePanel = ({
             fontWeight: 700,
             lineHeight: '120%',
             letterSpacing: '-0.48px',
-            color: estimateIsReal ? 'var(--color-primary-600)' : 'var(--color-text-tertiary)',
+            color: estimateIsReal ? 'var(--blue-text)' : 'var(--color-text-tertiary)',
             textAlign: 'right',
           }}
         >

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/TaskSlot.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/TaskSlot.tsx
@@ -453,7 +453,7 @@ const TaskDetailsPopover = ({
           {getTaskStatusLabel(task.status)}
         </span>
       </div>
-      <div className="grid min-w-0 grid-cols-[auto,minmax(0,1fr)] gap-x-2 gap-y-1 rounded-xl border border-card-border bg-card-hover px-2.5 py-2">
+      <div className="grid min-w-0 grid-cols-[auto_minmax(0,1fr)] gap-x-2 gap-y-1 rounded-xl border border-card-border bg-card-hover px-2.5 py-2">
         <div className="text-[11px] leading-4 text-text-secondary">From</div>
         <div className="min-w-0 text-[11px] leading-4 text-right text-text-primary truncate">
           {getDisplayName(task.assignedBy)}

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/WeekCalendar.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/WeekCalendar.tsx
@@ -269,7 +269,6 @@ const WeekCalendar: React.FC<WeekCalendarProps> = ({
                         </div>
                       ))}
                     </div>
-                    <div />
                   </div>
                 </div>
               )}

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneMyDayRail.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneMyDayRail.tsx
@@ -103,7 +103,7 @@ const CompletedAppointmentCard = ({
         {buildAppointmentSubtitle(entry)}
       </span>
     </span>
-    <span className="flex size-[18px] flex-none items-center justify-center rounded-full bg-[var(--success)] text-white">
+    <span className="flex size-[18px] flex-none items-center justify-center rounded-full bg-[var(--success-strong)] text-[var(--success-strong-ink)]">
       <IoCheckmark size={11} aria-hidden="true" />
     </span>
   </button>
@@ -231,7 +231,8 @@ const TaskRow = ({
       onClick={() => onToggleTask?.(entry.task)}
       className={clsx(
         'flex size-5 flex-none items-center justify-center rounded-md border-[1.5px] border-[var(--divider)]',
-        entry.isDone && 'border-[var(--success)] bg-[var(--success)] text-white'
+        entry.isDone &&
+          'border-[var(--success-strong)] bg-[var(--success-strong)] text-[var(--success-strong-ink)]'
       )}
     >
       {entry.isDone && <IoCheckmark size={12} aria-hidden="true" />}
@@ -375,7 +376,8 @@ const AnytimePill = ({
         <span
           className={clsx(
             'flex size-3.5 items-center justify-center rounded-[5px] border-[1.5px] border-[var(--divider)]',
-            entry.isDone && 'border-[var(--success)] bg-[var(--success)] text-white'
+            entry.isDone &&
+              'border-[var(--success-strong)] bg-[var(--success-strong)] text-[var(--success-strong-ink)]'
           )}
         >
           {entry.isDone && <IoCheckmark size={9} aria-hidden="true" />}

--- a/apps/frontend/src/app/features/appointments/components/EmergencyBadge.tsx
+++ b/apps/frontend/src/app/features/appointments/components/EmergencyBadge.tsx
@@ -4,7 +4,7 @@ import { IoWarning } from 'react-icons/io5';
 const EMERGENCY_BADGE_STYLE: React.CSSProperties = {
   border: '1px solid var(--error-color)',
   background: 'var(--color-danger-100)',
-  color: 'var(--error-color)',
+  color: 'var(--danger-text)',
   fontFamily: 'var(--font-satoshi)',
   fontSize: '12px',
   fontWeight: 500,

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/AutosaveIndicator.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/AutosaveIndicator.tsx
@@ -41,7 +41,7 @@ const AutosaveIndicator = ({ status, savedAt, className = '' }: AutosaveIndicato
       <output
         data-testid="autosave-indicator"
         data-state="offline"
-        className={`${base} text-danger-700`}
+        className={`${base} text-text-error`}
       >
         <IoCloudOfflineOutline size={13} aria-hidden="true" />
         Offline · retrying, edits kept locally

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/TotalBillContainer.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/TotalBillContainer.tsx
@@ -579,7 +579,7 @@ const TotalsFooter = ({
           <p
             id={OVERALL_DISCOUNT_ERROR_ID}
             role="alert"
-            className="text-right text-caption-2 text-danger-700"
+            className="text-right text-caption-2 text-text-error"
           >
             {capError}
           </p>

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/index.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/index.tsx
@@ -323,7 +323,7 @@ const DischargeDateTimeModal = ({
         <ModalHeader title="Discharge date & time" onClose={handleCancel} />
         {gateBlocked && (
           <div className="flex flex-col gap-2 rounded-2xl bg-danger-100 p-3">
-            <p className="text-body-4 text-danger-700">
+            <p className="text-body-4 text-text-error">
               {gate?.disabledReason ?? 'This encounter is not ready for discharge.'}
             </p>
             <label className="flex flex-col gap-1 text-caption-2 text-text-secondary">

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/HospitalizationModal.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/HospitalizationModal.tsx
@@ -240,7 +240,7 @@ const HospitalizationModal = ({
               />
             </div>
             {hasSubmitted && hasValidationErrors && (
-              <div className="flex flex-col gap-1 text-caption-2 text-danger-700">
+              <div className="flex flex-col gap-1 text-caption-2 text-text-error">
                 {Object.values(validationErrors).map((error) => (
                   <span key={error}>{error}</span>
                 ))}

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/panels/CalculatorsPanel.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/panels/CalculatorsPanel.tsx
@@ -56,7 +56,7 @@ const CalculatorsPanel = ({ appointment }: CalculatorsPanelProps) => {
       )}
       {unsupportedNote && (
         <div className="rounded-2xl bg-warning-100 px-4 py-3">
-          <Text variant="caption-1" className="text-warning-700">
+          <Text variant="caption-1" className="text-warning-900">
             {unsupportedNote}
           </Text>
         </div>

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/panels/DocumentsPanel.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/panels/DocumentsPanel.tsx
@@ -82,7 +82,7 @@ const AUTH_META: Record<FormAuthState, { label: string; tone: string; icon: Reac
   },
   PENDING: {
     label: 'Acknowledgement pending',
-    tone: 'text-danger-600',
+    tone: 'text-text-error',
     icon: <IoAlertCircleOutline size={14} aria-hidden="true" />,
   },
 };
@@ -414,7 +414,7 @@ const ClinicalPacketSection = ({
         </p>
       )}
       {signError && (
-        <p role="alert" className="text-[12px] text-danger-600">
+        <p role="alert" className="text-[12px] text-text-error">
           {signError}
         </p>
       )}
@@ -468,7 +468,7 @@ const FormsPanelContent = ({
   }
   if (status === 'error') {
     return (
-      <p className="py-6 text-center text-body-4 text-danger-600">
+      <p className="py-6 text-center text-body-4 text-text-error">
         Unable to load forms. Try again later.
       </p>
     );
@@ -556,7 +556,7 @@ const FormRow = ({ form }: { form: SubmittedForm }) => {
         </div>
       </div>
       {error && (
-        <p role="alert" className="text-[12px] text-danger-600">
+        <p role="alert" className="text-[12px] text-text-error">
           {error}
         </p>
       )}
@@ -737,7 +737,7 @@ const AppointmentFormsPanel = ({
         </SearchResultsDropdown>
       </div>
       {assignError && (
-        <p role="alert" className="text-[12px] text-danger-600">
+        <p role="alert" className="text-[12px] text-text-error">
           {assignError}
         </p>
       )}

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/panels/DocumentsPanel.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/panels/DocumentsPanel.tsx
@@ -72,12 +72,12 @@ type SubmittedForm = {
 const AUTH_META: Record<FormAuthState, { label: string; tone: string; icon: React.ReactNode }> = {
   AUTHORIZED_CLIENT: {
     label: 'Authorized by Client',
-    tone: 'text-success-600',
+    tone: 'text-[var(--success-text)]',
     icon: <IoCheckmarkCircleOutline size={14} aria-hidden="true" />,
   },
   AUTHORIZED_PROVIDER: {
     label: 'Authorized by Service Provider',
-    tone: 'text-success-600',
+    tone: 'text-[var(--success-text)]',
     icon: <IoCheckmarkCircleOutline size={14} aria-hidden="true" />,
   },
   PENDING: {

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/records/VitalsForm.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/records/VitalsForm.tsx
@@ -265,7 +265,7 @@ const SegmentedPicker = ({
         })}
       </fieldset>
     </div>
-    {error ? <p className="text-caption-1 text-danger-600">{error}</p> : null}
+    {error ? <p className="text-caption-1 text-text-error">{error}</p> : null}
   </div>
 );
 
@@ -575,7 +575,7 @@ const VitalsForm = ({
           </p>
         )}
         {templateState.error && (
-          <p className="mt-2 text-caption-1 text-danger-600">{templateState.error}</p>
+          <p className="mt-2 text-caption-1 text-text-error">{templateState.error}</p>
         )}
       </div>
       <div className="grid grid-cols-2 gap-3">
@@ -590,7 +590,7 @@ const VitalsForm = ({
                     onChange={(value) => updateField(field.key, value)}
                   />
                   {fieldErrors[field.key] ? (
-                    <p className="text-caption-1 text-danger-600">{fieldErrors[field.key]}</p>
+                    <p className="text-caption-1 text-text-error">{fieldErrors[field.key]}</p>
                   ) : null}
                 </div>,
               ]

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/InvoiceStep.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/InvoiceStep.tsx
@@ -1480,7 +1480,7 @@ const useInvoiceStepContent = ({
             />
 
             {errorMessage && (
-              <p role="alert" className="rounded-2xl bg-danger-100 p-3 text-body-4 text-danger-700">
+              <p role="alert" className="rounded-2xl bg-danger-100 p-3 text-body-4 text-text-error">
                 {errorMessage}
               </p>
             )}

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/InvoiceStep.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/InvoiceStep.tsx
@@ -451,7 +451,7 @@ export const PaymentProgressOverlay = ({
 export const SettledBadge = ({ invoice }: { invoice: PastInvoice }) => {
   const label = invoice.paidFromDeposit ? 'Withdrawn from Deposit' : 'Invoice Paid';
   return (
-    <span className="inline-flex items-center gap-1.5 rounded-3xl bg-success-600 px-3 py-1 text-caption-1 font-medium text-white">
+    <span className="inline-flex items-center gap-1.5 rounded-3xl bg-[var(--success-strong)] px-3 py-1 text-caption-1 font-medium text-[var(--success-strong-ink)]">
       {label}
       <IoCheckmarkOutline aria-hidden="true" />
     </span>
@@ -651,7 +651,7 @@ export const InvoiceRow = ({
             )}
           </span>
           {invoice.paymentMethod && (
-            <span className="inline-flex items-center gap-2 rounded-3xl bg-success-600 px-4 py-2 text-body-4 font-medium text-white">
+            <span className="inline-flex items-center gap-2 rounded-3xl bg-[var(--success-strong)] px-4 py-2 text-body-4 font-medium text-[var(--success-strong-ink)]">
               {PAYMENT_LABELS[invoice.paymentMethod]}
               <IoCheckmarkOutline aria-hidden="true" />
             </span>

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/SoapStep.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/SoapStep.tsx
@@ -445,7 +445,7 @@ const SoapStep = ({
               {saveError && (
                 <p
                   role="alert"
-                  className="rounded-2xl bg-danger-100 p-3 text-body-4 text-danger-700"
+                  className="rounded-2xl bg-danger-100 p-3 text-body-4 text-text-error"
                 >
                   {saveError}
                 </p>

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/SummaryStep.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/SummaryStep.tsx
@@ -799,7 +799,7 @@ const useSummaryStepContent = ({
                 )}
               </SearchResultsDropdown>
               {templateState.error && (
-                <p className="mt-2 text-caption-1 text-danger-600">{templateState.error}</p>
+                <p className="mt-2 text-caption-1 text-text-error">{templateState.error}</p>
               )}
             </div>
           </div>

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/SummaryStep.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/SummaryStep.tsx
@@ -262,7 +262,7 @@ export const AllDocumentsTable = ({
   return (
     <SectionContainer title="All Documents" className="flex flex-col gap-4">
       {error && (
-        <p role="alert" className="rounded-2xl bg-danger-100 p-4 text-body-4 text-danger-700">
+        <p role="alert" className="rounded-2xl bg-danger-100 p-4 text-body-4 text-text-error">
           {error}
         </p>
       )}
@@ -317,7 +317,7 @@ export const AllDocumentsTable = ({
             ))}
           </ul>
           {documentError && (
-            <p role="alert" className="rounded-2xl bg-danger-100 p-3 text-body-4 text-danger-700">
+            <p role="alert" className="rounded-2xl bg-danger-100 p-3 text-body-4 text-text-error">
               {documentError}
             </p>
           )}
@@ -885,7 +885,7 @@ const useSummaryStepContent = ({
 
           <div className="flex flex-col items-end gap-2">
             {signError && (
-              <p role="alert" className="text-body-4 text-danger-700">
+              <p role="alert" className="text-body-4 text-text-error">
                 {signError}
               </p>
             )}

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/Prescription/Submissions/SignatureActions.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/Prescription/Submissions/SignatureActions.tsx
@@ -160,7 +160,9 @@ const SignatureActions = ({ submission, onStatusChange }: SignatureActionsProps)
   return (
     <div className="flex flex-col gap-2">
       {signingStatusLabel ? (
-        <div className={`text-xs ${isSigned ? 'text-success-600' : 'text-text-secondary'}`}>
+        <div
+          className={`text-xs ${isSigned ? 'text-[var(--success-text)]' : 'text-text-secondary'}`}
+        >
           {signingStatusLabel}
         </div>
       ) : null}

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/Tasks/Chat.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/Tasks/Chat.tsx
@@ -222,7 +222,7 @@ const Chat = ({ activeAppointment }: ChatProps) => {
 
         {error && (
           <div className="px-4 py-3 rounded-2xl border border-error bg-neutral-0">
-            <p className="font-satoshi text-[14px] text-error m-0">{error}</p>
+            <p className="font-satoshi text-[14px] text-text-error m-0">{error}</p>
           </div>
         )}
 

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/ViewAppointmentOverviewModal/index.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/ViewAppointmentOverviewModal/index.tsx
@@ -354,8 +354,7 @@ const OverviewRightColumn = ({
           <span
             className="font-satoshi text-2xl font-bold"
             style={{
-              color:
-                estimateDisplay === '-' ? 'var(--color-text-tertiary)' : 'var(--color-primary-600)',
+              color: estimateDisplay === '-' ? 'var(--color-text-tertiary)' : 'var(--blue-text)',
               letterSpacing: '-0.48px',
             }}
           >

--- a/apps/frontend/src/app/features/calculators/components/Disclaimer.tsx
+++ b/apps/frontend/src/app/features/calculators/components/Disclaimer.tsx
@@ -14,7 +14,7 @@ const Disclaimer = ({ text }: DisclaimerProps) => {
       <Badge tone="warning" className="w-fit">
         Clinical decision support
       </Badge>
-      <Text variant="caption-1" className="text-warning-700">
+      <Text variant="caption-1" className="text-warning-900">
         {text}
       </Text>
     </div>

--- a/apps/frontend/src/app/features/chat/components/ChatContainer.tsx
+++ b/apps/frontend/src/app/features/chat/components/ChatContainer.tsx
@@ -1930,7 +1930,7 @@ const useChatContainerView = ({
           minHeight: '360px',
         }}
       >
-        <p style={{ color: 'var(--color-danger-700)' }}>{errorMessage}</p>
+        <p style={{ color: 'var(--color-text-error)' }}>{errorMessage}</p>
       </div>
     );
   }

--- a/apps/frontend/src/app/features/developers/pages/DeveloperSettings/DeveloperSettings.css
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperSettings/DeveloperSettings.css
@@ -156,7 +156,7 @@
   gap: 4px;
   font-size: 10.5px;
   font-weight: 700;
-  color: var(--color-success-600);
+  color: var(--success-text);
 }
 
 .dev-settings-unverified {
@@ -175,7 +175,7 @@
   gap: 4px;
   font-size: 10.5px;
   font-weight: 700;
-  color: var(--color-success-600);
+  color: var(--success-text);
 }
 
 .dev-health-dot {

--- a/apps/frontend/src/app/features/finance/pages/Discounts/index.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Discounts/index.tsx
@@ -132,7 +132,7 @@ const DiscountsContent = () => {
 
           {!loading && error && (
             <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl bg-danger-100 p-3">
-              <p role="alert" className="text-body-4 text-danger-700">
+              <p role="alert" className="text-body-4 text-text-error">
                 {error}
               </p>
               <Secondary text="Retry" onClick={reload} ariaLabel="Retry loading the discount cap" />
@@ -173,7 +173,7 @@ const DiscountsContent = () => {
               {formError && (
                 <p
                   role="alert"
-                  className="rounded-2xl bg-danger-100 p-3 text-body-4 text-danger-700"
+                  className="rounded-2xl bg-danger-100 p-3 text-body-4 text-text-error"
                 >
                   {formError}
                 </p>

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceSummaryPanel.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceSummaryPanel.tsx
@@ -46,7 +46,7 @@ const InvoiceSummaryPanel = ({ invoice, currency }: InvoiceSummaryPanelProps) =>
           <span
             className="tabular-nums text-[13px] font-bold"
             style={{
-              color: outstanding > 0 ? 'var(--warn-text)' : 'var(--success)',
+              color: outstanding > 0 ? 'var(--warn-text)' : 'var(--success-text)',
             }}
           >
             {formatMoney(outstanding, currency)}

--- a/apps/frontend/src/app/features/inventory/components/DispensaryDetailModal.tsx
+++ b/apps/frontend/src/app/features/inventory/components/DispensaryDetailModal.tsx
@@ -183,7 +183,7 @@ const DispensaryItemRow = ({ item, idx }: Readonly<DispensaryItemRowProps>) => {
                 )}
                 <div className="text-caption-1">
                   <span className="text-text-secondary">To dispense: </span>
-                  <span className="font-semibold text-[var(--color-success-600)]">
+                  <span className="font-semibold text-[var(--success-text)]">
                     {packs} {pluralizeUnit(stockUnit || 'unit', packs)}
                   </span>
                 </div>

--- a/apps/frontend/src/app/lib/paymentStatus.ts
+++ b/apps/frontend/src/app/lib/paymentStatus.ts
@@ -12,20 +12,33 @@ type PaymentDisplay = {
   badgeTextColor: string;
 };
 
+/**
+ * Inks, not mid-ramp fills. --color-success-400 (#54b492) and --color-warning-600
+ * (#f68523) are FILL steps: as the 11px Paid/Unpaid line under a status pill they
+ * measured 2.28:1 and 2.29:1 on the bone screen of the deployed dashboard, and
+ * 2.29 on their own badge tints - the least readable text on that page and on the
+ * appointments list. --success-text and --color-warning-900 are the ink-tuned
+ * members of the same two ramps: they clear ~6.3 on each of those light surfaces.
+ *
+ * Both already carry dark values (#2bbd86 / #f9ad6c), and dark improves too rather
+ * than regressing - measured on the deployed dark dashboard, Paid goes 5.82 -> 6.10
+ * and Unpaid 5.80 -> 7.85 against the card, which is why this is a straight token
+ * swap and not a light-only override.
+ */
 const PAYMENT_DISPLAY: Record<AppointmentPaymentState, PaymentDisplay> = {
   PAID: {
     state: 'PAID',
     label: 'Paid',
-    textColor: 'var(--color-success-400)',
+    textColor: 'var(--success-text)',
     badgeBackgroundColor: 'var(--color-success-100)',
-    badgeTextColor: 'var(--color-success-400)',
+    badgeTextColor: 'var(--success-text)',
   },
   UNPAID: {
     state: 'UNPAID',
     label: 'Unpaid',
-    textColor: 'var(--color-warning-600)',
+    textColor: 'var(--color-warning-900)',
     badgeBackgroundColor: 'var(--color-card-warning)',
-    badgeTextColor: 'var(--color-warning-600)',
+    badgeTextColor: 'var(--color-warning-900)',
   },
   PAID_CASH: {
     state: 'PAID_CASH',
@@ -37,9 +50,9 @@ const PAYMENT_DISPLAY: Record<AppointmentPaymentState, PaymentDisplay> = {
   PAYMENT_AT_CLINIC: {
     state: 'PAYMENT_AT_CLINIC',
     label: 'Unpaid',
-    textColor: 'var(--color-warning-600)',
+    textColor: 'var(--color-warning-900)',
     badgeBackgroundColor: 'var(--color-card-warning)',
-    badgeTextColor: 'var(--color-warning-600)',
+    badgeTextColor: 'var(--color-warning-900)',
   },
 };
 

--- a/apps/frontend/src/app/ui/cards/CompanionIdCard/CompanionIdCard.tsx
+++ b/apps/frontend/src/app/ui/cards/CompanionIdCard/CompanionIdCard.tsx
@@ -11,8 +11,8 @@ const SPECIES_LABEL: Record<string, string> = {
 };
 
 const SEVERITY_STYLE: Record<CompanionAlertSummary['severity'], string> = {
-  critical: 'bg-warning-100 text-warning-700',
-  high: 'bg-warning-100 text-warning-700',
+  critical: 'bg-warning-100 text-warning-900',
+  high: 'bg-warning-100 text-warning-900',
   medium: 'bg-card-bg text-text-secondary',
   low: 'bg-card-bg text-text-secondary',
 };

--- a/apps/frontend/src/app/ui/layout/states/states.css
+++ b/apps/frontend/src/app/ui/layout/states/states.css
@@ -124,7 +124,7 @@
 }
 
 .yc-state-inline-link:hover {
-  color: var(--blue);
+  color: var(--blue-text);
 }
 
 .yc-state-actions {

--- a/apps/frontend/src/app/ui/primitives/Buttons/Secondary.tsx
+++ b/apps/frontend/src/app/ui/primitives/Buttons/Secondary.tsx
@@ -16,9 +16,9 @@ const sizeClasses: Record<ButtonSize, string> = {
 const commonClasses =
   'gap-[7px] flex items-center justify-center rounded-full! transition-all duration-200 ease-out font-semibold text-center font-satoshi border';
 
-const defaultClasses = `${commonClasses} border-[var(--divider)]! text-[var(--ink-body)]! hover:text-[var(--blue)]! hover:border-[var(--blue)]!`;
+const defaultClasses = `${commonClasses} border-[var(--divider)]! text-[var(--ink-body)]! hover:text-[var(--blue-text)]! hover:border-[var(--blue)]!`;
 
-const dangerClasses = `${commonClasses} border-[var(--danger-border)]! text-[var(--danger-text)]! hover:border-[var(--danger)]! hover:text-[var(--danger)]! hover:bg-[var(--danger-bg)]!`;
+const dangerClasses = `${commonClasses} border-[var(--danger-border)]! text-[var(--danger-text)]! hover:border-[var(--danger)]! hover:text-[var(--danger-text)]! hover:bg-[var(--danger-bg)]!`;
 
 const Secondary = ({ danger, ...props }: Readonly<SecondaryProps>) => (
   <BaseButton

--- a/apps/frontend/src/app/ui/tables/DataTable.css
+++ b/apps/frontend/src/app/ui/tables/DataTable.css
@@ -69,7 +69,7 @@ span.cell-overflow-count {
 }
 .inventory-turnover-table-fixed {
   table-layout: fixed;
-  min-width: 1040px; /* 160+110+130+120+100+120+100+100+100 */
+  min-width: 1198px; /* 160+110+172+152+128+144+108+124+100 */
 }
 .invoice-compact-fixed {
   table-layout: fixed;

--- a/apps/frontend/src/app/ui/tables/DataTable.css
+++ b/apps/frontend/src/app/ui/tables/DataTable.css
@@ -69,7 +69,7 @@ span.cell-overflow-count {
 }
 .inventory-turnover-table-fixed {
   table-layout: fixed;
-  min-width: 1198px; /* 160+110+172+152+128+144+108+124+100 */
+  min-width: 1238px; /* 160+110+172+152+128+144+108+124+140 */
 }
 .invoice-compact-fixed {
   table-layout: fixed;

--- a/apps/frontend/src/app/ui/tables/DataTable.css
+++ b/apps/frontend/src/app/ui/tables/DataTable.css
@@ -54,14 +54,14 @@ span.cell-overflow-count {
 }
 .forms-table-fixed {
   table-layout: fixed;
-  /* 200+130+190+90+150+110+64 — includes the conditional "Linked services"
+  /* 200+130+190+90+150+110+88 — includes the conditional "Linked services"
      column (190px). It must cover the widest colgroup, or with that column
      rendered the trailing Actions column sits past the reachable scroll extent. */
-  min-width: 934px;
+  min-width: 958px;
 }
 .invoice-table-fixed {
   table-layout: fixed;
-  min-width: 1220px; /* 96+200+180+150+90+70+80+180+110+64 */
+  min-width: 1244px; /* 96+200+180+150+90+70+80+180+110+88 */
 }
 .companions-table-fixed {
   table-layout: fixed;

--- a/apps/frontend/src/app/ui/tables/DataTable.css
+++ b/apps/frontend/src/app/ui/tables/DataTable.css
@@ -50,7 +50,7 @@ span.cell-overflow-count {
 }
 .tasks-table-fixed {
   table-layout: fixed;
-  min-width: 1110px; /* 160+200+110+120+120+110+130+160 */
+  min-width: 1126px; /* 160+200+110+120+120+110+130+176 */
 }
 .forms-table-fixed {
   table-layout: fixed;

--- a/apps/frontend/src/app/ui/tables/DispensaryTable.tsx
+++ b/apps/frontend/src/app/ui/tables/DispensaryTable.tsx
@@ -144,7 +144,7 @@ const DispensaryRow = ({
           </>
         )}
       </ul>
-      <div className="whitespace-pre-line text-[12px] tabular-nums text-[var(--color-success-600)]">
+      <div className="whitespace-pre-line text-[12px] tabular-nums text-[var(--success-text)]">
         {formatDateTime(record.prescriptionCreated)}
       </div>
       <div className="text-right font-semibold tabular-nums pr-4">
@@ -154,7 +154,7 @@ const DispensaryRow = ({
       <div className="truncate text-[12.5px] text-text-secondary">{record.location || '—'}</div>
       <div
         className={`whitespace-pre-line text-[12px] tabular-nums ${
-          record.timeDispensed ? 'text-[var(--color-success-600)]' : 'text-text-tertiary'
+          record.timeDispensed ? 'text-[var(--success-text)]' : 'text-text-tertiary'
         }`}
       >
         {formatDateTime(record.timeDispensed)}

--- a/apps/frontend/src/app/ui/tables/InventoryTurnoverTable.tsx
+++ b/apps/frontend/src/app/ui/tables/InventoryTurnoverTable.tsx
@@ -103,9 +103,16 @@ const InventoryTurnoverTable = ({ filteredList }: InventoryTurnoverTableProps) =
       ),
     },
     {
+      /* The one column sized by its BODY rather than its header: the label is 44px
+         but the StatusPill inside is 10px/600 uppercase with 0.8px tracking and 20px
+         of its own padding, so "Out of stock" needs 102.4px against the 69px content
+         box a 100px column left it. Measured in the real pill font: Out of stock
+         102.4, Excellent 82.5, Moderate 80.5, Healthy 69.4 - four of the five values
+         overflowed, and StatusPill is nowrap + overflow-hidden, so it clipped the
+         word rather than wrapping it. */
       label: 'Status',
       key: 'status',
-      width: '100px',
+      width: '140px',
       render: (item: InventoryTurnoverItem) => (
         <StatusPill
           style={getInventoryTurnoverStatusStyle(item.status)}

--- a/apps/frontend/src/app/ui/tables/InventoryTurnoverTable.tsx
+++ b/apps/frontend/src/app/ui/tables/InventoryTurnoverTable.tsx
@@ -26,6 +26,16 @@ const getAverageInventory = (item: InventoryTurnoverItem) =>
 const getTotalPurchased = (item: InventoryTurnoverItem) =>
   item.totalPurchases ?? item.totalPurchased ?? 0;
 
+/* Every metric column is sized by its HEADER, not its figures: the values are
+   short integers but the labels are long, and the th is 10.5px/700 uppercase with
+   1.05em tracking and nowrap+ellipsis. At the width where the colgroup actually
+   binds (viewport 1300, table at its 1040px min-width) five of the nine headers
+   were ellipsised on deployed dev - "Beginning inventory" by 34.5px, "Ending
+   inventory" by 23.1, "Avg inventory" by 20.0, "Total purchases" by 15.7 and
+   "Days on shelf" by 15.9, with "Turns/Year" left on 1px of slack. Widths below
+   are the measured text width plus 22px of th padding plus ~8px of margin, the
+   same allowance STATUS_COLUMN_WIDTH in InvoiceTable settles on after real-world
+   font hinting and DPI variance ate a 4px one. */
 const InventoryTurnoverTable = ({ filteredList }: InventoryTurnoverTableProps) => {
   const columns: Column<InventoryTurnoverItem>[] = [
     {
@@ -47,7 +57,7 @@ const InventoryTurnoverTable = ({ filteredList }: InventoryTurnoverTableProps) =
     {
       label: 'Beginning inventory',
       key: 'Beginning inventory',
-      width: '130px',
+      width: '172px',
       render: (item: InventoryTurnoverItem) => (
         <div className="appointment-profile-title cell-figure">{item.beginningInventory}</div>
       ),
@@ -55,7 +65,7 @@ const InventoryTurnoverTable = ({ filteredList }: InventoryTurnoverTableProps) =
     {
       label: 'Ending inventory',
       key: 'Ending inventory',
-      width: '120px',
+      width: '152px',
       render: (item: InventoryTurnoverItem) => (
         <div className="appointment-profile-title cell-figure">{item.endingInventory}</div>
       ),
@@ -63,7 +73,7 @@ const InventoryTurnoverTable = ({ filteredList }: InventoryTurnoverTableProps) =
     {
       label: 'Avg inventory',
       key: 'Avg inventory',
-      width: '100px',
+      width: '128px',
       render: (item: InventoryTurnoverItem) => (
         <div className="appointment-profile-title cell-figure">{getAverageInventory(item)}</div>
       ),
@@ -71,7 +81,7 @@ const InventoryTurnoverTable = ({ filteredList }: InventoryTurnoverTableProps) =
     {
       label: 'Total purchases',
       key: 'Total purchases',
-      width: '120px',
+      width: '144px',
       render: (item: InventoryTurnoverItem) => (
         <div className="appointment-profile-title cell-figure">{getTotalPurchased(item)}</div>
       ),
@@ -79,7 +89,7 @@ const InventoryTurnoverTable = ({ filteredList }: InventoryTurnoverTableProps) =
     {
       label: 'Turns/Year',
       key: 'Turns/Year',
-      width: '100px',
+      width: '108px',
       render: (item: InventoryTurnoverItem) => (
         <div className="appointment-profile-title cell-figure">{item.turnsPerYear}</div>
       ),
@@ -87,7 +97,7 @@ const InventoryTurnoverTable = ({ filteredList }: InventoryTurnoverTableProps) =
     {
       label: 'Days on shelf',
       key: 'Days on shelf',
-      width: '100px',
+      width: '124px',
       render: (item: InventoryTurnoverItem) => (
         <div className="appointment-profile-title cell-figure">{item.daysOnShelf}</div>
       ),

--- a/apps/frontend/src/app/ui/tables/InvoiceTable.tsx
+++ b/apps/frontend/src/app/ui/tables/InvoiceTable.tsx
@@ -62,6 +62,15 @@ const joinMeta = (...parts: (string | undefined)[]): string => {
    margin (~23px). */
 const STATUS_COLUMN_WIDTH = '180px';
 
+/* Same failure one column over, and the only other fixed-width table cell whose
+   own header does not fit: "Actions" needs 53.3px of Satoshi and the th carries
+   31px of padding, so the shipped 64px (45px of content box) ellipsised the
+   header itself to "Action..." on every desktop viewport, and the 56px tablet
+   value cut it in half. This is the one table with `table-layout: fixed`, so
+   unlike every other PIMS table it cannot grow a column to fit its label. 88px
+   leaves ~4px of slack. */
+const ACTIONS_COLUMN_WIDTH = '88px';
+
 const renderInvoiceNumber = (item: Invoice) => (
   <div
     className="appointment-profile-title tabular-nums cell-strong"
@@ -308,7 +317,7 @@ const InvoiceTable = ({ filteredList, setActiveInvoice, setViewInvoice }: Invoic
     },
     { label: 'Status', key: 'status', width: STATUS_COLUMN_WIDTH, render: renderStatus },
     { label: 'Payment', key: 'payment', width: '110px', render: renderPayment },
-    { label: 'Actions', key: 'actions', width: '64px', render: renderActions },
+    { label: 'Actions', key: 'actions', width: ACTIONS_COLUMN_WIDTH, render: renderActions },
   ];
 
   /* Tablet (768–1279): 6 columns — the ones you need to chase money.
@@ -332,7 +341,7 @@ const InvoiceTable = ({ filteredList, setActiveInvoice, setViewInvoice }: Invoic
     },
     { label: 'Status', key: 'status', width: STATUS_COLUMN_WIDTH, render: renderStatus },
     { label: 'Payment', key: 'payment', width: '108px', render: renderPayment },
-    { label: 'Actions', key: 'actions', width: '56px', render: renderActions },
+    { label: 'Actions', key: 'actions', width: ACTIONS_COLUMN_WIDTH, render: renderActions },
   ];
 
   return (

--- a/apps/frontend/src/app/ui/tables/Tasks.tsx
+++ b/apps/frontend/src/app/ui/tables/Tasks.tsx
@@ -134,9 +134,16 @@ const Tasks = ({
       ),
     },
     {
+      /* Sized by the control rail, not the label. `.action-btn-grid` is a
+         flex-wrap row of 40px buttons with an 8px gap, so a three-action row needs
+         3*40 + 2*8 = 136px. Measured on deployed dev, a 160px column left a 129px
+         content box: it does not clip, it WRAPS the third button to a second line
+         and grows that row taller than its neighbours - the same implicit-row
+         failure as the calendar overlays earlier in this branch, just in a table.
+         176px leaves 145px of content box, 9px clear of the rail. */
       label: 'Actions',
       key: 'actions',
-      width: '160px',
+      width: '176px',
       render: (item: Task) => (
         <div className="action-btn-col">
           <div className="action-btn-grid">

--- a/apps/frontend/src/app/ui/tables/tableUtils.ts
+++ b/apps/frontend/src/app/ui/tables/tableUtils.ts
@@ -349,9 +349,9 @@ export const getTaskStatusTone = (status: string): StatusTone => {
 export const getOrganizationStatusStyle = (status: string) => {
   switch (status?.toLowerCase()) {
     case 'active':
-      return { color: 'var(--color-success-400)', backgroundColor: 'var(--color-success-100)' };
+      return { color: 'var(--success-text)', backgroundColor: 'var(--color-success-100)' };
     case 'pending':
-      return { color: 'var(--color-warning-600)', backgroundColor: 'var(--color-warning-100)' };
+      return { color: 'var(--color-warning-900)', backgroundColor: 'var(--color-warning-100)' };
     default:
       return { color: 'var(--color-neutral-0)', backgroundColor: 'var(--color-badge-blue-bg)' };
   }


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

A sweep of deployed dev, both themes, every page, plus a code sweep for the same defect classes it turned up. Everything below was measured before it was changed.

### Structural

**The now-line sat at the wrong time.** The other half of the double-height bug #2258 fixed, still live after that deployed. The now-line overlay carries the same `grid-cols-[64px_minmax(0,1fr)]` template and kept the same orphaned third child, so it wrapped to an implicit second row: the overlay measured **4376px** with each of its three children at **2188px**. The line is positioned by absolute px inside that container, so the **9:07 AM** marker sat down beside the **4:45** label.

**The task popover grid template was invalid CSS.** `grid-cols-[auto,minmax(0,1fr)]` uses a comma, which is not a track separator, so the browser rejects and drops the whole declaration. Confirmed live: `CSS.supports('grid-template-columns','auto,minmax(0,1fr)')` is `false`. The six children then stacked as six rows instead of three label/value pairs, inside a popover whose flip math assumes a fixed 304x248 box.

### Tables that clip their own content

**The invoice Actions header never fit.** "Actions" needs 53.3px plus 31px of th padding; the column shipped at 64px desktop and 56px tablet. Worse where it binds hardest: 8.3px short at 1738, **20.3px at 1280**, **28.3px on tablet**.

**Five of nine Turnover headers were ellipsised** at the width where its colgroup binds: Beginning inventory 34.5px short, Ending inventory 23.1, Avg inventory 20.0, Total purchases 15.7, Days on shelf 15.9, with Turns/Year on 1px of slack.

**The Turnover status column clipped its pill.** Sized from its 44px header, but the pill inside is 10px/600 uppercase plus 20px padding: "Out of stock" needs 102.4px against a 69px content box. Four of the five values overflowed, and StatusPill is nowrap + overflow-hidden, so it clipped the word.

**Two `min-width` values had drifted below their colgroup sum**, which squeezes every column proportionally exactly when the viewport forces the table down to it. Forms said 934 against 958 (pre-existing); invoice said 1220 against 1244, **introduced by my own Actions fix two commits earlier**.

### Colour: fills standing in for inks

Twenty-eight sites. The code sweep capped verification at six findings per class, so about seventeen went unchecked on the first pass; going back through them turned up eleven more, including the worst one in the whole sweep. `/accessibility/report` pinned nothing, so its literal `bg-white` confirmation card took themed inks and rendered at **1.34:1** in dark - the panel read as blank. Elsewhere: white ink on `--success` at **2.41** in dark, `--color-warning-700` at **2.77** on its own tint (clinical decision support disclaimer, species safety warning, alert chips on the public shared card), `--color-primary-600` at **2.89** for the estimate figure, and hover states at **3.18-3.74** on controls whose resting state passed.

The worst was `getOrganizationStatusStyle`, which returned **2.23:1** and **2.32:1** - the exact fill-as-ink pair already corrected in `paymentStatus.ts` for the Paid/Unpaid line, just never followed through to the organization list. `--color-danger-700` also fails as text everywhere in light (4.23 on the danger tint, 4.40 on the screen) across ten error-copy sites; in dark it and the error ink are the identical `#f2938a`, so that swap is a pure no-op there.

One more layout bug came out of the same pass: the **Tasks Actions column** was sized from its label rather than its control rail. `.action-btn-grid` is a flex-wrap row of 40px buttons with an 8px gap, so three actions need 136px against the 129px content box I measured - it does not clip, it wraps the third button onto a second line and makes that row taller than its neighbours.

## What is the new behavior?

Fixed, each verified the same way it was found. Highlights of how, rather than a restatement of what:

- The Turnover widths were checked by **applying the new colgroup to the live page and re-measuring against the real font**: every header clears with 8-9px of slack, and the wrapper already carries `inventory-turnover-scroll-x` so it scrolls rather than overflowing.
- The `/accessibility/report` pin was verified live in dark: 1.34 -> **13.36** heading, **6.96** body.
- Every token swap was measured in **both** themes against the live tokens before it was made. All of them improve or hold dark as well as light, which is why they are straight swaps rather than light-only overrides.

## Scope decisions

Three places where the obvious sweep was the wrong answer:

- **Actions column: one table, not four.** I widened four, then measured. Only the two `invoice-*-fixed` variants clip; every other table with that value uses auto layout, which grows a column to fit its label. The other three were reverted.
- **CircleIconButton's danger glyph and the EmergencyBadge border stay on the fill ramp.** Those are graphical objects held to 3:1, which they meet. Moving them would cost the affordance for no accessibility gain.
- **Only the Turnover status column was resized from its cell.** The other eight were sized from their headers, and their bodies are short integers.

## On the tests

**The #2258 test did not catch the first bug.** It asserts the right invariant, but the overlay only mounts when a rendered day *is today* and the fixture week was January 2025, so it passed over a component that was never in the tree. It now seeds the week with today.

Every new assertion here was **mutation-checked** rather than assumed - reverted, watched fail, restored:

| guard | fails with |
| --- | --- |
| invoice Actions floor | `Received: 64` |
| Turnover header widths | `Received: 130` |
| `min-width` = colgroup sum | `Expected: 1220, Received: 1244` |
| comma in a grid template | names `TaskSlot.tsx:456` |

Two are repo-wide rather than local, because both classes recurred. The grid-template guard scans every shipped file for a comma in an arbitrary track list once balanced parens are stripped, so `minmax(0,1fr)` and `repeat(2,1fr)` do not trip it; it found exactly one offender. The `min-width` guard parses `DataTable.css` and compares against the rendered colgroup, because that value has now drifted twice, once at my own hand.

This is the third time in this branch a test passed because the thing it guarded was never rendered, and the popover bug is a fourth surface that no story had ever drawn. "The test passes" and "the test ran against the code" keep turning out to be different claims.

## Validation

- type-check clean, lint 0 errors
- 916 tests across the 35 suites touching these files, plus the new guards
- Swept every PIMS page on deployed dev in **both themes**: dashboard, appointments, tasks, companions, finance, forms, inventory, organization, integrations, chat. Also at 1738 / 1500 / 1300 / 1280 / 1220 / 900 / 606, and at each fixed table's own binding width.
- Probe false positives run down rather than filed: two Organization grid mismatches were inside hidden ancestors with 0x0 boxes; the Finance service-list cells carry `cell-truncate` plus a `title`; three full-viewport scrims are `opacity: 0` with `pointer-events: none`, i.e. correctly dismissed drawer backdrops.

## Known gaps

- Chrome's window floor is 606px, so the 375 breakpoint was not reachable by window resize. 606 exercises the same sub-768 mobile branch, but narrow-specific defects could still hide below it.
- One residual on the mobile dashboard: a 10px "More" label at **4.45:1** against a 4.5 bar. Left alone rather than special-cased.
- `--color-upload-info` has no dark declaration and lands at **2.84** against the 3:1 icon bar in dark. Fixing it means adding a dark value to a shared token, a wider blast radius than anything else here, so it is called out rather than guessed at.
- The default organization badge is near-white on `#007cf5` at **3.65**, and plain white would still only reach 4.04. No ink fixes that one - the fill has to change, which is a design decision.
- The 56px appointments avatar column against a 40px avatar was flagged by the sweep but I could not verify it visually before the browser window went to the background again, so it is left alone rather than changed on arithmetic alone.
- `.companions-table-fixed` in `DataTable.css` is dead - `CompanionsTable` renders a div list, not a `<table>`. Not touched, since it is not user-visible.

## Related Issue(s)

Fixes #
