### PR TITLE
fix(frontend): show the empty state when a dashboard chart is all zeros

### DIFF
--- a/apps/frontend/src/app/__tests__/features/dashboard/hooks/useDashboardAnalytics.test.ts
+++ b/apps/frontend/src/app/__tests__/features/dashboard/hooks/useDashboardAnalytics.test.ts
@@ -117,6 +117,58 @@ describe('useDashboardAnalytics', () => {
     expect(fetchDashboardRevenueTrend).toHaveBeenCalledWith('org-day', 'last_week', 'day');
   });
 
+  it('treats an all-zero day series as empty, not as a chart', async () => {
+    /* The trend endpoints return one point per day in the range, so a quiet week comes
+       back as several points of zeros rather than an empty array. Both day charts are
+       drawn with hideYAxis and no axis line, so a length-only empty check rendered
+       zero-height bars on a blank card - no chart and no "No data available", which is
+       exactly what the dashboard showed for a week with no completed appointments and
+       no revenue. */
+    currentOrgId = 'org-quiet';
+    (fetchDashboardAppointmentTrend as jest.Mock).mockResolvedValue([
+      { label: 'Mon', completed: 0, cancelled: 0 },
+      { label: 'Tue', completed: 0, cancelled: 0 },
+    ]);
+    (fetchDashboardRevenueTrend as jest.Mock).mockResolvedValue([
+      { label: 'Mon', revenue: 0 },
+      { label: 'Tue', revenue: 0 },
+    ]);
+
+    const { result } = renderHook(() => useDashboardAnalytics('last_week'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // The points are still mapped through - only the empty flag changes.
+    expect(result.current.charts.appointments).toHaveLength(2);
+    expect(result.current.charts.revenue).toHaveLength(2);
+    expect(result.current.emptyState.appointmentsChart).toBe(true);
+    expect(result.current.emptyState.revenueChart).toBe(true);
+  });
+
+  it('keeps a series with any non-zero point as a real chart', async () => {
+    currentOrgId = 'org-mixed';
+    (fetchDashboardAppointmentTrend as jest.Mock).mockResolvedValue([
+      { label: 'Mon', completed: 0, cancelled: 0 },
+      { label: 'Tue', completed: 0, cancelled: 2 },
+    ]);
+    (fetchDashboardRevenueTrend as jest.Mock).mockResolvedValue([
+      { label: 'Mon', revenue: 0 },
+      { label: 'Tue', revenue: 40 },
+    ]);
+
+    const { result } = renderHook(() => useDashboardAnalytics('last_week'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // A single cancelled appointment, or one day of revenue, is still worth drawing.
+    expect(result.current.emptyState.appointmentsChart).toBe(false);
+    expect(result.current.emptyState.revenueChart).toBe(false);
+  });
+
   it('uses month bucket for long durations', async () => {
     currentOrgId = 'org-month';
 

--- a/apps/frontend/src/app/features/dashboard/hooks/useDashboardAnalytics.ts
+++ b/apps/frontend/src/app/features/dashboard/hooks/useDashboardAnalytics.ts
@@ -277,8 +277,17 @@ const fetchDashboardAnalyticsData = async (
         clampNumber(summary?.appointments) === 0 &&
         clampNumber(summary?.tasks) === 0 &&
         clampNumber(summary?.staffOnDuty) === 0,
-      appointmentsChart: appointmentsChart.length === 0,
-      revenueChart: revenueChart.length === 0,
+      /* All-zero counts as empty, not just a zero-length series. The trend endpoints
+         return one point per day in the range, so a quiet week comes back as seven
+         points of zeros - a non-empty array. Both day charts are drawn with hideYAxis
+         and no axis line, so that rendered as bars of zero height on a blank card:
+         no chart, no "No data available", just an empty box. appointmentLeaders two
+         lines below already used the all-zero test; these two were left on length.
+         `.every` on an empty array is true, so this still covers the no-points case. */
+      appointmentsChart: appointmentsChart.every(
+        (point) => point.Completed === 0 && point.Cancelled === 0
+      ),
+      revenueChart: revenueChart.every((point) => point.Revenue === 0),
       appointmentLeaders: appointmentLeaderChart.every(
         (leader) => leader.Completed === 0 && leader.Cancelled === 0
       ),


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The Appointments and Revenue cards on the dashboard render as blank boxes - a title, a legend, and nothing underneath.

**They are not failing to load.** Checked against deployed dev rather than assumed:

- all seven dashboard requests complete, including `/v1/dashboard/appointments/{org}/trend` and `/v1/dashboard/revenue/{org}/trend`
- the trend endpoint returns one point per day in the range: Aug 11 through Aug 18, eight points, every value zero
- on the page, `.recharts-wrapper` is present and `.recharts-rectangle` count is **0**

The empty check was `appointmentsChart.length === 0`. A series of eight zeros passes that, so the card fell through to the chart instead of the empty state, and both day charts are drawn with `hideYAxis` and no axis line - so eight bars of zero height is a blank card.

The giveaway was on the same screen: the two leader cards directly below were correctly showing **"No data available"** for the same quiet week, because `appointmentLeaders` in the very same object already tests that every point is zero. Only the two day charts were left on a length check.

## What is the new behavior?

Both day charts use the all-zero test that the leaders card already used, so a quiet week says "No data available" instead of showing an empty rectangle.

`.every` on an empty array is `true`, so this still covers the zero-length case the original check existed for.

## Worth knowing

The Appointments chart plots only **Completed** and **Cancelled**. A week whose appointments are all upcoming or checked in is therefore legitimately all-zero even though the Explore tile above it counts them - which is exactly the state this org is in (Explore reads `Appointments 2`). That is why the card can be empty while the number beside it is not. It now says so instead of leaving a blank rectangle to be interpreted.

## Validation

- type-check clean, lint 0 errors
- 68 tests across the dashboard hook, chart card, chart canvas and stat widgets
- Two new cases: an all-zero series is empty, and a series with any non-zero point is still a real chart, so the fix cannot swallow a chart that has one cancelled appointment or one day of revenue
- Mutation-checked: restoring the `length === 0` check fails the new test with `Expected: true, Received: false`

## Related Issue(s)

Fixes #
