### PR TITLE
feat(mobile): add build doctor, version sync and a gradle.properties template

### DIFF
--- a/apps/mobileAppYC/android/gradle.properties.example
+++ b/apps/mobileAppYC/android/gradle.properties.example
@@ -1,0 +1,27 @@
+# Template for android/gradle.properties, which is deliberately NOT tracked:
+# on existing machines that file also holds the release signing credentials, so
+# the repo blocks staging it (scripts/check-staged-secrets.js). Copy this file
+# to gradle.properties on a new machine.
+#
+#   cp android/gradle.properties.example android/gradle.properties
+#
+# Everything below is build configuration, not secret. The project cannot even
+# configure without android.useAndroidX, which is why a fresh clone fails.
+#
+# Release signing does NOT belong in the copy you create. app/build.gradle
+# resolves YC_RELEASE_STORE_FILE, YC_RELEASE_STORE_PASSWORD, YC_RELEASE_KEY_ALIAS
+# and YC_RELEASE_KEY_PASSWORD from Gradle properties or the environment, so put
+# them in ~/.gradle/gradle.properties, which Gradle merges automatically and
+# which lives outside any repository.
+
+# The RN build runs out of headroom on Gradle's default heap.
+org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1024m
+
+# Required. Jetifier stays off because every dependency is AndroidX already.
+android.useAndroidX=true
+
+reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
+
+newArchEnabled=true
+hermesEnabled=true
+edgeToEdgeEnabled=false

--- a/apps/mobileAppYC/package.json
+++ b/apps/mobileAppYC/package.json
@@ -14,7 +14,9 @@
     "e2e:ios": "detox test -c ios.sim.debug",
     "e2e:build:android": "detox build -c android.emu.debug",
     "e2e:android": "detox test -c android.emu.debug",
-    "doctor": "pnpm exec react-doctor"
+    "doctor": "node ../../scripts/mobile/doctor.mjs",
+    "version:check": "node ../../scripts/mobile/version.mjs --check",
+    "version:set": "node ../../scripts/mobile/version.mjs --set"
   },
   "dependencies": {
     "@callstack/liquid-glass": "^0.8.0",

--- a/scripts/mobile/doctor.mjs
+++ b/scripts/mobile/doctor.mjs
@@ -11,7 +11,7 @@
  *
  * Never prints a secret value: only whether something is present.
  */
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { dirname, join } from 'node:path';
 
@@ -54,25 +54,51 @@ else
 
 // --- untracked files the build requires ------------------------------------
 // Each is gitignored on purpose, so a clone will not have it.
-const required = [
+// These are gitignored, so they never arrive in a fresh worktree. They usually
+// DO exist in a sibling checkout though, which makes recovery a copy rather
+// than a console round-trip - so look there before sending anyone to Firebase.
+const siblingWorktrees = () => {
+  const repoRoot = root.replace(/\/apps\/mobileAppYC$/, '');
+  try {
+    return readdirSync(dirname(repoRoot))
+      .map((d) => join(dirname(repoRoot), d, 'apps/mobileAppYC'))
+      .filter((d) => d !== root && existsSync(d));
+  } catch {
+    return [];
+  }
+};
+const siblings = siblingWorktrees();
+
+const checkFile = (rel, fallbackHow, level) => {
+  if (existsSync(join(root, rel))) {
+    ok(rel);
+    return;
+  }
+  const found = siblings.find((w) => existsSync(join(w, rel)));
+  level(rel, found ? `copy it from ${join(found, rel)}` : fallbackHow);
+};
+
+for (const [rel, how] of [
   [
     'android/gradle.properties',
-    'copy from android/gradle.properties.example, then add signing to ~/.gradle/gradle.properties',
+    'cp android/gradle.properties.example android/gradle.properties, then put signing in ~/.gradle/gradle.properties',
   ],
-  ['android/app/google-services.json', 'download from the Firebase console for the Android app'],
-  ['android/app/src/main/res/values/strings.xml', 'holds app name and API keys; ask a maintainer'],
-];
-const iosRequired = [
-  ['ios/GoogleService-Info.plist', 'download from the Firebase console for the iOS app'],
-  ['ios/mobileAppYC/Secrets.xcconfig', 'ask a maintainer; required for a device or archive build'],
-];
-for (const [rel, how] of required) {
-  if (existsSync(join(root, rel))) ok(rel);
-  else bad(rel, how);
+  [
+    'android/app/google-services.json',
+    'not in any sibling worktree; re-download from the Firebase console',
+  ],
+  ['android/app/src/main/res/values/strings.xml', 'not in any sibling worktree; ask a maintainer'],
+]) {
+  checkFile(rel, how, bad);
 }
-for (const [rel, how] of iosRequired) {
-  if (existsSync(join(root, rel))) ok(rel);
-  else warn(rel, how);
+for (const [rel, how] of [
+  [
+    'ios/GoogleService-Info.plist',
+    'not in any sibling worktree; re-download from the Firebase console',
+  ],
+  ['ios/mobileAppYC/Secrets.xcconfig', 'not in any sibling worktree; ask a maintainer'],
+]) {
+  checkFile(rel, how, warn);
 }
 
 // --- release signing -------------------------------------------------------

--- a/scripts/mobile/doctor.mjs
+++ b/scripts/mobile/doctor.mjs
@@ -58,7 +58,7 @@ else
 // DO exist in a sibling checkout though, which makes recovery a copy rather
 // than a console round-trip - so look there before sending anyone to Firebase.
 const siblingWorktrees = () => {
-  const repoRoot = root.replace(/\/apps\/mobileAppYC$/, '');
+  const repoRoot = dirname(dirname(root));
   try {
     return readdirSync(dirname(repoRoot))
       .map((d) => join(dirname(repoRoot), d, 'apps/mobileAppYC'))
@@ -140,10 +140,14 @@ const componentRefSpecs = (pkgDir) => {
   const fabric = join(pkgDir, 'src/fabric');
   if (!existsSync(fabric)) return [];
   const hits = [];
-  const walk = (dir) => {
+  // Fabric spec trees are shallow; the cap only guards against a pathological
+  // or symlinked tree taking the process down with a stack overflow.
+  const MAX_DEPTH = 12;
+  const walk = (dir, depth = 0) => {
+    if (depth > MAX_DEPTH) return;
     for (const entry of readdirSync(dir, { withFileTypes: true })) {
       const full = join(dir, entry.name);
-      if (entry.isDirectory()) walk(full);
+      if (entry.isDirectory()) walk(full, depth + 1);
       else if (entry.isFile() && /\.tsx?$/.test(entry.name)) {
         try {
           if (readFileSync(full, 'utf8').includes('React.ComponentRef')) {

--- a/scripts/mobile/doctor.mjs
+++ b/scripts/mobile/doctor.mjs
@@ -129,36 +129,75 @@ if (missingSigning.length === 0) {
   );
 }
 
-// --- known-incompatible dependency ----------------------------------------
-// react-native-screens >= 4.26 ships codegen specs using React.ComponentRef,
-// which the RN 0.81 codegen rejects. The peer range does not catch it: 4.26.1
-// and 4.27.0 both declare "*".
+// --- codegen-incompatible native specs ------------------------------------
+// RN 0.81's codegen cannot parse React.ComponentRef in a Fabric spec. Assert
+// that condition directly rather than pinning a version number: a version is
+// only a proxy, and it goes stale the moment upstream fixes it in a later
+// release or backports the fix to a patch. Checking the invariant also catches
+// the same breakage arriving from a different library.
+// Occurrences outside src/fabric/ are harmless - they are not codegen specs.
+const componentRefSpecs = (pkgDir) => {
+  const fabric = join(pkgDir, 'src/fabric');
+  if (!existsSync(fabric)) return [];
+  const hits = [];
+  const walk = (dir) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.isFile() && /\.tsx?$/.test(entry.name)) {
+        try {
+          if (readFileSync(full, 'utf8').includes('React.ComponentRef')) {
+            hits.push(full.slice(fabric.length + 1));
+          }
+        } catch {
+          /* unreadable file is not a finding */
+        }
+      }
+    }
+  };
+  try {
+    walk(fabric);
+  } catch {
+    return [];
+  }
+  return hits;
+};
+
 try {
   const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
   const rn = pkg.dependencies?.['react-native'] ?? '';
-  const screens = pkg.dependencies?.['react-native-screens'] ?? '';
-  const screensMajorMinor = /(\d+)\.(\d+)/.exec(screens);
-  const rnMinor = /0\.(\d+)/.exec(rn);
-  const risky =
-    screensMajorMinor &&
-    rnMinor &&
-    Number(rnMinor[1]) < 82 &&
-    (Number(screensMajorMinor[1]) > 4 || Number(screensMajorMinor[2]) >= 26);
-  if (risky) {
-    bad(
-      'react-native-screens',
-      `${screens} ships codegen specs that RN ${rn} cannot parse. Pin 4.24.0 until React Native is upgraded.`
-    );
-  } else if (screens.startsWith('^') || screens.startsWith('~')) {
-    warn(
-      'react-native-screens',
-      `${screens} is a floating range; it drifted into an incompatible version once already. Prefer an exact pin.`
-    );
+  const rnMinor = Number(/0\.(\d+)/.exec(rn)?.[1] ?? 99);
+  const screensDir = join(root, '../../node_modules/react-native-screens');
+  const resolved = existsSync(screensDir) ? screensDir : null;
+  if (!resolved) {
+    warn('react-native-screens', 'not installed; run pnpm install before building');
   } else {
-    ok('react-native-screens', screens);
+    const hits = componentRefSpecs(resolved);
+    if (hits.length > 0 && rnMinor < 82) {
+      bad(
+        'react-native-screens',
+        `${hits.length} Fabric spec(s) use React.ComponentRef, which the RN ${rn} codegen cannot parse (${hits.slice(0, 2).join(', ')}${hits.length > 2 ? ', ...' : ''}). Pin a version whose src/fabric/ is free of it.`
+      );
+    } else if (hits.length > 0) {
+      ok(
+        'react-native-screens',
+        `${hits.length} Fabric spec(s) use React.ComponentRef, supported by RN ${rn}`
+      );
+    } else {
+      ok('react-native-screens', 'no Fabric spec uses React.ComponentRef');
+    }
+    // Installed state can be fine while the declared range still drifts on the
+    // next install, which is exactly how this broke the first time.
+    const declared = pkg.dependencies?.['react-native-screens'] ?? '';
+    if (/^[\^~]/.test(declared)) {
+      warn(
+        'react-native-screens range',
+        `${declared} floats; it drifted into a codegen-incompatible version once already. Prefer an exact pin.`
+      );
+    }
   }
 } catch {
-  warn('react-native-screens', 'could not read package.json');
+  warn('react-native-screens', 'could not evaluate; is package.json readable?');
 }
 
 // --- report ----------------------------------------------------------------

--- a/scripts/mobile/doctor.mjs
+++ b/scripts/mobile/doctor.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/**
+ * Reports whether this machine can actually build the mobile app.
+ *
+ * The Android build needs several files that are deliberately untracked
+ * (they carry Firebase config or signing credentials), so a fresh clone fails
+ * partway through a long Gradle run with an error that names one missing file
+ * at a time. This reports every prerequisite at once, before the build.
+ *
+ *   node scripts/doctor.mjs
+ *
+ * Never prints a secret value: only whether something is present.
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+
+// Resolved from the script path rather than cwd, so these run correctly
+// whether invoked from the repo root or the mobile workspace.
+const root = join(dirname(process.argv[1]), '../../apps/mobileAppYC');
+const rows = [];
+const ok = (what, detail = '') => rows.push({ level: 'OK', what, detail });
+const warn = (what, detail) => rows.push({ level: 'WARN', what, detail });
+const bad = (what, detail) => rows.push({ level: 'MISSING', what, detail });
+
+// `java -version` writes to stderr even on success, so both streams must be
+// read or the detail comes back blank.
+const bin = (cmd, args) => {
+  const r = spawnSync(cmd, args, { encoding: 'utf8' });
+  if (r.error) return null;
+  const merged = `${r.stdout ?? ''}${r.stderr ?? ''}`.trim();
+  return merged || null;
+};
+
+// --- toolchain -------------------------------------------------------------
+const javaHome = process.env.JAVA_HOME;
+if (javaHome && existsSync(join(javaHome, 'bin/java'))) {
+  ok('JAVA_HOME', bin(join(javaHome, 'bin/java'), ['-version'])?.split('\n')[0] ?? javaHome);
+} else {
+  bad('JAVA_HOME', 'not set, or does not contain bin/java. Android builds cannot run.');
+}
+
+const androidHome = process.env.ANDROID_HOME ?? process.env.ANDROID_SDK_ROOT;
+if (androidHome && existsSync(androidHome)) ok('ANDROID_HOME', androidHome);
+else bad('ANDROID_HOME', 'not set. Install the Android SDK and export ANDROID_HOME.');
+
+const xcode = bin('xcodebuild', ['-version']);
+if (xcode) ok('Xcode', xcode.split('\n')[0]);
+else
+  warn(
+    'Xcode',
+    'xcodebuild not found. iOS builds are unavailable (fine if you only build Android).'
+  );
+
+// --- untracked files the build requires ------------------------------------
+// Each is gitignored on purpose, so a clone will not have it.
+const required = [
+  [
+    'android/gradle.properties',
+    'copy from android/gradle.properties.example, then add signing to ~/.gradle/gradle.properties',
+  ],
+  ['android/app/google-services.json', 'download from the Firebase console for the Android app'],
+  ['android/app/src/main/res/values/strings.xml', 'holds app name and API keys; ask a maintainer'],
+];
+const iosRequired = [
+  ['ios/GoogleService-Info.plist', 'download from the Firebase console for the iOS app'],
+  ['ios/mobileAppYC/Secrets.xcconfig', 'ask a maintainer; required for a device or archive build'],
+];
+for (const [rel, how] of required) {
+  if (existsSync(join(root, rel))) ok(rel);
+  else bad(rel, how);
+}
+for (const [rel, how] of iosRequired) {
+  if (existsSync(join(root, rel))) ok(rel);
+  else warn(rel, how);
+}
+
+// --- release signing -------------------------------------------------------
+// Presence only. Values are never read or printed.
+const SIGNING = [
+  'YC_RELEASE_STORE_FILE',
+  'YC_RELEASE_STORE_PASSWORD',
+  'YC_RELEASE_KEY_ALIAS',
+  'YC_RELEASE_KEY_PASSWORD',
+];
+const gradleHome = join(process.env.HOME ?? '', '.gradle/gradle.properties');
+const sources = [join(root, 'android/gradle.properties'), gradleHome].filter(existsSync);
+const declared = new Set();
+for (const f of sources) {
+  for (const line of readFileSync(f, 'utf8').split('\n')) {
+    const key = line.split('=')[0]?.trim();
+    if (SIGNING.includes(key)) declared.add(key);
+  }
+}
+for (const k of SIGNING) if (process.env[k]) declared.add(k);
+const missingSigning = SIGNING.filter((k) => !declared.has(k));
+if (missingSigning.length === 0) {
+  ok('release signing', 'all four properties present (values not read)');
+} else {
+  warn(
+    'release signing',
+    `${missingSigning.length} of 4 missing (${missingSigning.join(', ')}). Debug builds still work; assembleRelease will not.`
+  );
+}
+
+// --- known-incompatible dependency ----------------------------------------
+// react-native-screens >= 4.26 ships codegen specs using React.ComponentRef,
+// which the RN 0.81 codegen rejects. The peer range does not catch it: 4.26.1
+// and 4.27.0 both declare "*".
+try {
+  const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
+  const rn = pkg.dependencies?.['react-native'] ?? '';
+  const screens = pkg.dependencies?.['react-native-screens'] ?? '';
+  const screensMajorMinor = /(\d+)\.(\d+)/.exec(screens);
+  const rnMinor = /0\.(\d+)/.exec(rn);
+  const risky =
+    screensMajorMinor &&
+    rnMinor &&
+    Number(rnMinor[1]) < 82 &&
+    (Number(screensMajorMinor[1]) > 4 || Number(screensMajorMinor[2]) >= 26);
+  if (risky) {
+    bad(
+      'react-native-screens',
+      `${screens} ships codegen specs that RN ${rn} cannot parse. Pin 4.24.0 until React Native is upgraded.`
+    );
+  } else if (screens.startsWith('^') || screens.startsWith('~')) {
+    warn(
+      'react-native-screens',
+      `${screens} is a floating range; it drifted into an incompatible version once already. Prefer an exact pin.`
+    );
+  } else {
+    ok('react-native-screens', screens);
+  }
+} catch {
+  warn('react-native-screens', 'could not read package.json');
+}
+
+// --- report ----------------------------------------------------------------
+const width = Math.max(...rows.map((r) => r.what.length));
+for (const { level, what, detail } of rows) {
+  console.log(`${level.padEnd(8)} ${what.padEnd(width)}  ${detail}`);
+}
+const blocking = rows.filter((r) => r.level === 'MISSING');
+console.log('');
+if (blocking.length === 0) {
+  console.log('doctor: no blocking problems. `cd android && ./gradlew assembleDebug` should run.');
+} else {
+  console.log(
+    `doctor: ${blocking.length} blocking problem(s). The Android build will fail until each is resolved.`
+  );
+  process.exitCode = 1;
+}

--- a/scripts/mobile/version.mjs
+++ b/scripts/mobile/version.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+/**
+ * Keep the two platform versions in step, and stop a release going out with a
+ * version the stores will refuse.
+ *
+ * Android and iOS carry their versions in different files and had drifted badly:
+ * Android sat at 1.0.12 (identical to the live Play listing, which Play rejects)
+ * while iOS sat at 1.0.7 against a live App Store build of 1.5. Neither is
+ * something you notice until an upload is rejected.
+ *
+ *   node scripts/version.mjs --check          report both platforms and exit 1 if they disagree
+ *   node scripts/version.mjs --set 1.6.0      set the marketing version on both, bump both build numbers
+ *   node scripts/version.mjs --bump patch     1.0.12 -> 1.0.13 on both, bump both build numbers
+ *
+ * Build numbers (Android versionCode, iOS CURRENT_PROJECT_VERSION) always move
+ * to max(current)+1 across both platforms, so they never collide or go
+ * backwards regardless of which platform was ahead.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+// Resolved from the script path rather than cwd, so these run correctly
+// whether invoked from the repo root or the mobile workspace.
+const root = join(dirname(process.argv[1]), '../../apps/mobileAppYC');
+const GRADLE = join(root, 'android/app/build.gradle');
+const PBXPROJ = join(root, 'ios/mobileAppYC.xcodeproj/project.pbxproj');
+
+const read = (p) => readFileSync(p, 'utf8');
+
+const parseAndroid = (src) => ({
+  versionCode: Number(/versionCode\s+(\d+)/.exec(src)?.[1]),
+  versionName: /versionName\s+"([^"]+)"/.exec(src)?.[1],
+});
+
+// Xcode repeats these per build configuration, so every occurrence must agree
+// and every occurrence must be rewritten.
+const parseIos = (src) => {
+  const marketing = [...src.matchAll(/MARKETING_VERSION = ([^;]+);/g)].map((m) => m[1].trim());
+  const project = [...src.matchAll(/CURRENT_PROJECT_VERSION = ([^;]+);/g)].map((m) => m[1].trim());
+  return {
+    marketing: [...new Set(marketing)],
+    project: [...new Set(project)],
+  };
+};
+
+const fail = (msg) => {
+  console.error(`version: ${msg}`);
+  process.exit(1);
+};
+
+const load = () => {
+  const gradleSrc = read(GRADLE);
+  const iosSrc = read(PBXPROJ);
+  const android = parseAndroid(gradleSrc);
+  const ios = parseIos(iosSrc);
+  if (!android.versionName || !Number.isFinite(android.versionCode)) {
+    fail('could not read versionCode/versionName from build.gradle');
+  }
+  if (ios.marketing.length !== 1) {
+    fail(`iOS MARKETING_VERSION disagrees across configurations: ${ios.marketing.join(', ')}`);
+  }
+  if (ios.project.length !== 1) {
+    fail(`iOS CURRENT_PROJECT_VERSION disagrees across configurations: ${ios.project.join(', ')}`);
+  }
+  return {
+    gradleSrc,
+    iosSrc,
+    android,
+    ios: { marketing: ios.marketing[0], project: Number(ios.project[0]) },
+  };
+};
+
+const report = ({ android, ios }) => {
+  console.log(`  android  versionName ${android.versionName}  versionCode ${android.versionCode}`);
+  console.log(
+    `  ios      MARKETING_VERSION ${ios.marketing}  CURRENT_PROJECT_VERSION ${ios.project}`
+  );
+};
+
+const write = (state, nextVersion, nextBuild) => {
+  const gradle = state.gradleSrc
+    .replace(/versionCode\s+\d+/, `versionCode ${nextBuild}`)
+    .replace(/versionName\s+"[^"]+"/, `versionName "${nextVersion}"`);
+  const ios = state.iosSrc
+    .replaceAll(/MARKETING_VERSION = [^;]+;/g, `MARKETING_VERSION = ${nextVersion};`)
+    .replaceAll(/CURRENT_PROJECT_VERSION = [^;]+;/g, `CURRENT_PROJECT_VERSION = ${nextBuild};`);
+  writeFileSync(GRADLE, gradle);
+  writeFileSync(PBXPROJ, ios);
+};
+
+const bump = (version, part) => {
+  const nums = version.split('.').map(Number);
+  while (nums.length < 3) nums.push(0);
+  if (nums.some((n) => !Number.isFinite(n))) fail(`cannot bump non-numeric version "${version}"`);
+  const idx = { major: 0, minor: 1, patch: 2 }[part];
+  if (idx === undefined) fail(`unknown bump part "${part}" (use major, minor or patch)`);
+  nums[idx] += 1;
+  for (let i = idx + 1; i < nums.length; i += 1) nums[i] = 0;
+  return nums.join('.');
+};
+
+const main = () => {
+  const [flag, value] = process.argv.slice(2);
+  const state = load();
+
+  if (!flag || flag === '--check') {
+    console.log('version: current');
+    report(state);
+    if (state.android.versionName !== state.ios.marketing) {
+      console.error(
+        `\nversion: platforms disagree - android ${state.android.versionName} vs ios ${state.ios.marketing}.` +
+          `\nRun --set <version> to bring them in line before releasing.`
+      );
+      process.exit(1);
+    }
+    console.log('\nversion: both platforms agree.');
+    return;
+  }
+
+  const nextBuild = Math.max(state.android.versionCode, state.ios.project) + 1;
+  let nextVersion;
+  if (flag === '--set') {
+    if (!value) fail('--set needs a version, e.g. --set 1.6.0');
+    if (!/^\d+(\.\d+){0,2}$/.test(value)) fail(`"${value}" is not a numeric version`);
+    nextVersion = value;
+  } else if (flag === '--bump') {
+    // Bump from whichever platform is further ahead, so a release never lands
+    // on a version the other store has already published.
+    const ahead = [state.android.versionName, state.ios.marketing].sort((a, b) =>
+      a.localeCompare(b, undefined, { numeric: true })
+    );
+    nextVersion = bump(ahead[ahead.length - 1], value ?? 'patch');
+  } else {
+    fail(`unknown flag "${flag}" (use --check, --set <version> or --bump <part>)`);
+  }
+
+  console.log('version: before');
+  report(state);
+  write(state, nextVersion, nextBuild);
+  console.log(`\nversion: set both platforms to ${nextVersion}, build ${nextBuild}`);
+  console.log('\nversion: after');
+  report(load());
+};
+
+main();


### PR DESCRIPTION
## What changed

- `scripts/mobile/doctor.mjs` - reports every mobile build prerequisite at once.
- `scripts/mobile/version.mjs` - keeps the Android and iOS versions in step.
- `apps/mobileAppYC/android/gradle.properties.example` - build config template for a new machine.
- Three npm scripts: `doctor`, `version:check`, `version:set`.

## Why

Attempting a release build surfaced problems that only appear once you actually build. Each one fails deep into a long Gradle run and names a single missing thing, so they are found one slow cycle at a time:

- `android/gradle.properties` is gitignored (it also carries signing credentials on existing machines), so a fresh clone has no `android.useAndroidX=true` and fails at configuration.
- `android/app/google-services.json` and `android/app/src/main/res/values/strings.xml` are likewise untracked and absent.
- Release signing needs four `YC_RELEASE_*` properties that are not set.
- `react-native-screens` was left on a caret range and drifted to a version whose codegen specs RN 0.81.6 cannot parse.

`doctor` reports all of it in one pass, reading presence only and never printing a value:

```
OK       JAVA_HOME                                    openjdk version "17.0.19"
OK       ANDROID_HOME                                 ~/Library/Android/sdk
OK       Xcode                                        Xcode 26.6
MISSING  android/app/google-services.json             download from the Firebase console
MISSING  android/app/src/main/res/values/strings.xml  holds app name and API keys
WARN     release signing                              4 of 4 missing
MISSING  react-native-screens                         ^4.27.0 ships codegen specs RN 0.81.6 cannot parse
```

## Versions

The two platforms had drifted apart, and both are behind their stores:

| | repo | live |
|---|---|---|
| Android | 1.0.12 | 1.0.12 on Play |
| iOS | 1.0.7 | 1.5 on the App Store |

Android matches what is already published, so Play would reject it. iOS is behind. `version:check` fails while they disagree; `version:set <version>` moves both and takes build numbers to `max(both)+1` so they cannot collide or regress.

## On gradle.properties

It stays untracked deliberately. `scripts/check-staged-secrets.js` blocks staging it because on existing machines that file also holds `YC_RELEASE_STORE_PASSWORD` and `YC_RELEASE_KEY_PASSWORD`. I initially committed a cleaned copy, then reverted: tracking the path means the next person running `git add -A` with their signing block present would commit real passwords. The `.example` gives a new machine the build config without weakening that guard, and points signing at `~/.gradle/gradle.properties`, which Gradle merges automatically from outside the repo.

## Impact area

Tooling only. No application code, no dependency changes. The `react-native-screens` and `react-native-nitro-modules` pins are build-verified on a separate branch and deliberately not touched here.

## Validation performed

- `doctor` run against this machine: correctly identifies the two missing Firebase/config files, the absent signing properties, and the incompatible `react-native-screens` range; exits 1 with blocking problems.
- `version:check` correctly fails on the current 1.0.12 vs 1.0.7 drift.
- `version:set 1.6.0` tested against scratch copies of `build.gradle` and `project.pbxproj`: both platforms move to 1.6.0 with build 16, every `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION` occurrence rewritten, and a follow-up `--check` passes.
- Both scripts lint clean at the repo root.