### PR TITLE
chore(mobile): set both platforms to 1.6.0 for the next release

### DIFF
--- a/apps/mobileAppYC/android/app/build.gradle
+++ b/apps/mobileAppYC/android/app/build.gradle
@@ -143,8 +143,8 @@ android {
         applicationId "com.mobileappyc"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 15
-        versionName "1.0.12"
+        versionCode 16
+        versionName "1.6.0"
         manifestPlaceholders = [
             MAPS_API_KEY: localProperties['MAPS_API_KEY'] ?: System.getenv('MAPS_API_KEY') ?: ''
         ]

--- a/apps/mobileAppYC/ios/mobileAppYC.xcodeproj/project.pbxproj
+++ b/apps/mobileAppYC/ios/mobileAppYC.xcodeproj/project.pbxproj
@@ -373,7 +373,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = mobileAppYC/mobileAppYC.entitlements;
-				CURRENT_PROJECT_VERSION = 12;
+				CURRENT_PROJECT_VERSION = 16;
 				DEVELOPMENT_TEAM = 9TZWPYQ45S;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = mobileAppYC/Info.plist;
@@ -384,7 +384,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.7;
+				MARKETING_VERSION = 1.6.0;
 				NEW_SETTING = "";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -407,7 +407,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = mobileAppYC/mobileAppYC.entitlements;
-				CURRENT_PROJECT_VERSION = 12;
+				CURRENT_PROJECT_VERSION = 16;
 				DEVELOPMENT_TEAM = 9TZWPYQ45S;
 				INFOPLIST_FILE = mobileAppYC/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Yosemite Crew";
@@ -417,7 +417,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.7;
+				MARKETING_VERSION = 1.6.0;
 				NEW_SETTING = "";
 				OTHER_LDFLAGS = (
 					"$(inherited)",


### PR DESCRIPTION
## What changed

Android and iOS both move to `1.6.0`, build `16`.

| | before | after | live in store |
|---|---|---|---|
| Android `versionName` / `versionCode` | 1.0.12 / 15 | **1.6.0 / 16** | 1.0.12 on Play |
| iOS `MARKETING_VERSION` / `CURRENT_PROJECT_VERSION` | 1.0.7 / 12 | **1.6.0 / 16** | 1.5 on the App Store |

## Why

Both stores would reject what the repo currently declares.

Play is live at `1.0.12` and the repo said `1.0.12`. Identical, so the upload is refused outright. The App Store is live at `1.5` while the repo said `1.0.7`, so iOS was behind by a wide margin. Both figures are confirmed from the public listings, not inferred.

That iOS gap is worth a second look independently of this PR: a repo four minor versions behind its own App Store listing suggests recent iOS releases were cut somewhere other than this repository.

## Why 1.6.0

It is the smallest single number that clears both live versions at once, keeping the two platforms on one version rather than letting them drift again. Build number goes to `16`, above the higher of the two previous build numbers, so it cannot collide or regress on either platform.

If you would rather track the App Store line more closely (for example `1.6.0` on iOS but a lower Android number), say so and I will split them, but a single shared version is what `version:check` enforces.

## How it was produced

```
pnpm --filter mobileAppYC run version:set 1.6.0
```

That script (merged in #2270) rewrites **every** `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION` occurrence across both Xcode build configurations, not just the first, which is the usual way a manual bump leaves Debug and Release disagreeing.

## Impact area

Version metadata only. No application code, no dependencies, no build configuration.

## Validation performed

- `version:check` passes: both platforms agree, exit 0. It failed before this change.
- Diff is 6 lines across 2 files: `versionCode`, `versionName`, and `MARKETING_VERSION` / `CURRENT_PROJECT_VERSION` for each of the two Xcode configurations. Nothing else touched.
- Both new values verified greater than the live store versions above.