### PR TITLE
fix(mobile): detect placeholder config instead of only checking presence

### DIFF
--- a/scripts/mobile/doctor.mjs
+++ b/scripts/mobile/doctor.mjs
@@ -66,11 +66,14 @@ else
 // worse than reporting nothing.
 const PLACEHOLDER = /YOUR_[A-Z_]+|CHANGE_?ME|REPLACE_?ME|<[A-Z_]+>/;
 
+// Returns true, false, or null for "could not read". Collapsing unreadable to
+// false would report OK for a file nobody can open, which is the failure shape
+// this check exists to remove.
 const isPlaceholder = (file) => {
   try {
     return PLACEHOLDER.test(readFileSync(file, 'utf8'));
   } catch {
-    return false;
+    return null;
   }
 };
 
@@ -86,44 +89,61 @@ const siblingWorktrees = () => {
 };
 const siblings = siblingWorktrees();
 
-// The secrets backup stores real config in folders whose names encode the
-// destination path, so a filename search is the reliable way in.
-const BACKUP_ROOT = join(
-  process.env.HOME ?? '',
-  'Library/Mobile Documents/com~apple~CloudDocs/Yosemite Crew Important Secrets/June 2026 backup/mobileAppYC'
-);
+// Opt-in via env var. This repository is public, so hardcoding the location of
+// anyone's secrets store would publish its name and layout to every reader, and
+// the path is machine-specific besides. Point this at a directory holding real
+// config to have the doctor suggest it:
+//   export YC_MOBILE_SECRETS_BACKUP="/path/to/backup/mobileAppYC"
+const BACKUP_ROOT = process.env.YC_MOBILE_SECRETS_BACKUP ?? '';
 const findInBackup = (rel) => {
+  if (!BACKUP_ROOT || !existsSync(BACKUP_ROOT)) return null;
   const wanted = rel.split('/').pop();
+  // Collect every match and take the shallowest. Returning the first hit made
+  // the answer depend on readdir order, so a deeper file could beat a
+  // shallower one and two real configs would resolve arbitrarily.
+  const found = [];
   const walk = (dir, depth = 0) => {
-    if (depth > 4) return null;
+    if (depth > 4) return;
     let entries;
     try {
       entries = readdirSync(dir, { withFileTypes: true });
     } catch {
-      return null;
+      return;
     }
     for (const e of entries) {
       const full = join(dir, e.name);
-      if (e.isFile() && e.name === wanted && !isPlaceholder(full)) return full;
-      if (e.isDirectory()) {
-        const hit = walk(full, depth + 1);
-        if (hit) return hit;
+      if (e.isFile() && e.name === wanted && isPlaceholder(full) === false) {
+        found.push({ full, depth });
+      } else if (e.isDirectory()) {
+        walk(full, depth + 1);
       }
     }
-    return null;
   };
-  return existsSync(BACKUP_ROOT) ? walk(BACKUP_ROOT) : null;
+  walk(BACKUP_ROOT);
+  if (found.length === 0) return null;
+  found.sort((a, b) => a.depth - b.depth);
+  if (found.length > 1) {
+    warn(rel, `${found.length} candidates in the backup; suggesting the shallowest`);
+  }
+  return found[0].full;
 };
 
 /** exists -> not a placeholder -> sibling worktree -> secrets backup -> console. */
 const checkFile = (rel, fallbackHow, level) => {
   const here = join(root, rel);
-  if (existsSync(here) && !isPlaceholder(here)) {
-    ok(rel);
-    return;
+  if (existsSync(here)) {
+    const placeholder = isPlaceholder(here);
+    if (placeholder === false) {
+      ok(rel);
+      return;
+    }
+    if (placeholder === null) {
+      level(rel, 'exists but could not be read; check permissions');
+      return;
+    }
   }
   const source =
-    siblings.map((w) => join(w, rel)).find((f) => existsSync(f) && !isPlaceholder(f)) ??
+    siblings.map((w) => join(w, rel)).find((f) => existsSync(f) && isPlaceholder(f) === false) ??
     findInBackup(rel);
   const problem = existsSync(here) ? 'is a PLACEHOLDER template' : 'missing';
   level(
@@ -145,17 +165,25 @@ for (const [rel, how] of [
 for (const [rel, how] of [
   ['ios/GoogleService-Info.plist', 're-download from the Firebase console'],
   ['ios/mobileAppYC/Secrets.xcconfig', 'ask a maintainer'],
-  ['ios/mobileAppYC/Info.plist', 'ask a maintainer; an iOS build is impossible without it'],
 ]) {
   checkFile(rel, how, warn);
 }
+// Its absence makes an iOS build impossible, so it blocks rather than warns.
+checkFile('ios/mobileAppYC/Info.plist', 'ask a maintainer', bad);
 
 // Android Maps silently renders a blank map with no key, and this one is empty
 // even on machines that have every other file.
 const localProps = join(root, 'android/local.properties');
-if (existsSync(localProps)) {
+if (!existsSync(localProps)) {
+  // Saying nothing reads as "fine".
+  warn('MAPS_API_KEY', 'android/local.properties is missing; Android maps will render blank');
+} else {
   const maps = /^MAPS_API_KEY=(.*)$/m.exec(readFileSync(localProps, 'utf8'))?.[1]?.trim();
-  if (maps) ok('MAPS_API_KEY', 'set');
+  // Presence is not enough here either: local.properties.example ships
+  // MAPS_API_KEY=YOUR_ANDROID_GOOGLE_MAPS_API_KEY, which is truthy.
+  if (maps && !PLACEHOLDER.test(maps)) ok('MAPS_API_KEY', 'set');
+  else if (maps)
+    warn('MAPS_API_KEY', 'is still the placeholder value; Android maps will render blank');
   else warn('MAPS_API_KEY', 'empty in android/local.properties; Android maps will render blank');
 }
 
@@ -263,6 +291,58 @@ try {
 }
 
 // --- report ----------------------------------------------------------------
+// `--self-test` pins the placeholder vocabulary against the templates the repo
+// already ships, so an edit that makes the regex too narrow (missing a real
+// placeholder) or too broad (condemning real config) fails loudly rather than
+// silently reporting OK.
+// `--self-test` pins the placeholder vocabulary against the shipped templates
+// for the files this tool actually inspects, so an edit that makes the regex
+// too narrow (missing a real placeholder) or too broad (condemning real
+// config) fails loudly rather than silently reporting OK.
+//
+// Only these six are asserted. Other templates in config-templates/ are
+// instructional or carry no secret values, so they legitimately contain no
+// placeholder markers and flagging them would be wrong.
+if (process.argv.includes('--self-test')) {
+  const templates = join(root, 'config-templates');
+  const mustFlag = [
+    'android/google-services.example.json',
+    'android/strings.example.xml',
+    'android/local.properties.example',
+    'ios/GoogleService-Info.example.plist',
+    'ios/Info.plist.example',
+    'ios/Secrets.xcconfig.example',
+  ];
+  let failures = 0;
+  for (const rel of mustFlag) {
+    const full = join(templates, rel);
+    const flagged = isPlaceholder(full);
+    if (flagged === null) {
+      console.log(`ABSENT   ${rel}`);
+      failures += 1;
+    } else if (flagged) {
+      console.log(`FLAGGED  ${rel}`);
+    } else {
+      console.log(`MISSED   ${rel}  <- regex no longer catches this template`);
+      failures += 1;
+    }
+  }
+  // Real config must not be condemned: that is the opposite failure and would
+  // tell someone their working setup is broken.
+  const filled = [
+    '{"project_info":{"project_id":"yosemite-crew"},"api_key":"AIzaSyReal"}',
+    '<resources><string name="app_name">Yosemite Crew</string></resources>',
+    'MAPS_API_KEY=AIzaSyRealLookingKey123',
+  ];
+  const falsePositives = filled.filter((c) => PLACEHOLDER.test(c));
+  if (falsePositives.length > 0) {
+    console.log(`FALSE POSITIVE on ${falsePositives.length} realistic config sample(s)`);
+    failures += falsePositives.length;
+  }
+  console.log(`\nself-test: ${failures === 0 ? 'passed' : failures + ' failure(s)'}`);
+  process.exit(failures === 0 ? 0 : 1);
+}
+
 const width = Math.max(...rows.map((r) => r.what.length));
 for (const { level, what, detail } of rows) {
   console.log(`${level.padEnd(8)} ${what.padEnd(width)}  ${detail}`);

--- a/scripts/mobile/doctor.mjs
+++ b/scripts/mobile/doctor.mjs
@@ -291,10 +291,6 @@ try {
 }
 
 // --- report ----------------------------------------------------------------
-// `--self-test` pins the placeholder vocabulary against the templates the repo
-// already ships, so an edit that makes the regex too narrow (missing a real
-// placeholder) or too broad (condemning real config) fails loudly rather than
-// silently reporting OK.
 // `--self-test` pins the placeholder vocabulary against the shipped templates
 // for the files this tool actually inspects, so an edit that makes the regex
 // too narrow (missing a real placeholder) or too broad (condemning real

--- a/scripts/mobile/doctor.mjs
+++ b/scripts/mobile/doctor.mjs
@@ -54,9 +54,26 @@ else
 
 // --- untracked files the build requires ------------------------------------
 // Each is gitignored on purpose, so a clone will not have it.
-// These are gitignored, so they never arrive in a fresh worktree. They usually
-// DO exist in a sibling checkout though, which makes recovery a copy rather
-// than a console round-trip - so look there before sending anyone to Firebase.
+// These are gitignored, so they never arrive in a fresh worktree. Recovery is
+// usually a copy rather than a console round-trip, so look for a real copy
+// before sending anyone to Firebase.
+//
+// Presence is NOT enough. The repo ships placeholder templates with the same
+// filenames, and they propagate between worktrees exactly like real config.
+// An APK built against them compiles and installs: the Google Services plugin
+// validates shape and package name, not values. Push, auth and Maps are simply
+// dead at runtime. Checking only for existence reports OK on those, which is
+// worse than reporting nothing.
+const PLACEHOLDER = /YOUR_[A-Z_]+|CHANGE_?ME|REPLACE_?ME|<[A-Z_]+>/;
+
+const isPlaceholder = (file) => {
+  try {
+    return PLACEHOLDER.test(readFileSync(file, 'utf8'));
+  } catch {
+    return false;
+  }
+};
+
 const siblingWorktrees = () => {
   const repoRoot = dirname(dirname(root));
   try {
@@ -69,13 +86,50 @@ const siblingWorktrees = () => {
 };
 const siblings = siblingWorktrees();
 
+// The secrets backup stores real config in folders whose names encode the
+// destination path, so a filename search is the reliable way in.
+const BACKUP_ROOT = join(
+  process.env.HOME ?? '',
+  'Library/Mobile Documents/com~apple~CloudDocs/Yosemite Crew Important Secrets/June 2026 backup/mobileAppYC'
+);
+const findInBackup = (rel) => {
+  const wanted = rel.split('/').pop();
+  const walk = (dir, depth = 0) => {
+    if (depth > 4) return null;
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return null;
+    }
+    for (const e of entries) {
+      const full = join(dir, e.name);
+      if (e.isFile() && e.name === wanted && !isPlaceholder(full)) return full;
+      if (e.isDirectory()) {
+        const hit = walk(full, depth + 1);
+        if (hit) return hit;
+      }
+    }
+    return null;
+  };
+  return existsSync(BACKUP_ROOT) ? walk(BACKUP_ROOT) : null;
+};
+
+/** exists -> not a placeholder -> sibling worktree -> secrets backup -> console. */
 const checkFile = (rel, fallbackHow, level) => {
-  if (existsSync(join(root, rel))) {
+  const here = join(root, rel);
+  if (existsSync(here) && !isPlaceholder(here)) {
     ok(rel);
     return;
   }
-  const found = siblings.find((w) => existsSync(join(w, rel)));
-  level(rel, found ? `copy it from ${join(found, rel)}` : fallbackHow);
+  const source =
+    siblings.map((w) => join(w, rel)).find((f) => existsSync(f) && !isPlaceholder(f)) ??
+    findInBackup(rel);
+  const problem = existsSync(here) ? 'is a PLACEHOLDER template' : 'missing';
+  level(
+    rel,
+    source ? `${problem}; copy the real one from ${source}` : `${problem}; ${fallbackHow}`
+  );
 };
 
 for (const [rel, how] of [
@@ -83,22 +137,26 @@ for (const [rel, how] of [
     'android/gradle.properties',
     'cp android/gradle.properties.example android/gradle.properties, then put signing in ~/.gradle/gradle.properties',
   ],
-  [
-    'android/app/google-services.json',
-    'not in any sibling worktree; re-download from the Firebase console',
-  ],
-  ['android/app/src/main/res/values/strings.xml', 'not in any sibling worktree; ask a maintainer'],
+  ['android/app/google-services.json', 're-download from the Firebase console'],
+  ['android/app/src/main/res/values/strings.xml', 'ask a maintainer'],
 ]) {
   checkFile(rel, how, bad);
 }
 for (const [rel, how] of [
-  [
-    'ios/GoogleService-Info.plist',
-    'not in any sibling worktree; re-download from the Firebase console',
-  ],
-  ['ios/mobileAppYC/Secrets.xcconfig', 'not in any sibling worktree; ask a maintainer'],
+  ['ios/GoogleService-Info.plist', 're-download from the Firebase console'],
+  ['ios/mobileAppYC/Secrets.xcconfig', 'ask a maintainer'],
+  ['ios/mobileAppYC/Info.plist', 'ask a maintainer; an iOS build is impossible without it'],
 ]) {
   checkFile(rel, how, warn);
+}
+
+// Android Maps silently renders a blank map with no key, and this one is empty
+// even on machines that have every other file.
+const localProps = join(root, 'android/local.properties');
+if (existsSync(localProps)) {
+  const maps = /^MAPS_API_KEY=(.*)$/m.exec(readFileSync(localProps, 'utf8'))?.[1]?.trim();
+  if (maps) ok('MAPS_API_KEY', 'set');
+  else warn('MAPS_API_KEY', 'empty in android/local.properties; Android maps will render blank');
 }
 
 // --- release signing -------------------------------------------------------


### PR DESCRIPTION
## The bug

`doctor` reported `OK` for config files that were pure placeholder templates:

```
project_id:  YOUR_FIREBASE_PROJECT_ID
api_key:     YOUR_FIREBASE_API_KEY
strings.xml: YOUR_FACEBOOK_APP_ID, YOUR_FACEBOOK_CLIENT_TOKEN
```

This matters more than a cosmetic miss. An APK built against those **compiles and installs**: the Google Services plugin validates file shape and package name, not values. Push, auth and Maps are dead only at runtime, with nothing failing at build time to say so.

Worse, the sibling-worktree hint added in #2270 was **actively propagating the placeholders** between checkouts, and telling the reader they had recovered their config.

Reporting `OK` there is worse than reporting nothing, because it ends the investigation.

## The fix

Files are now checked for placeholder markers as well as existence, and the recovery order is:

```
exists -> not a placeholder -> sibling worktree -> iCloud secrets backup -> Firebase console
```

The console moved from first to last. It is the slowest and least reliable route, while the secrets backup is a straight copy. Same reasoning as the sibling-worktree lookup already in the tool.

Output now distinguishes the two failure modes:

```
MISSING  android/app/google-services.json  is a PLACEHOLDER template; copy the real one from <path>
WARN     ios/mobileAppYC/Info.plist        missing; copy the real one from <path>
```

## Two further gaps found alongside

- **`ios/mobileAppYC/Info.plist`** is gitignored and absent from every worktree here. On its own it makes an iOS build impossible, and it was not in the list of files anyone had identified.
- **`MAPS_API_KEY` is empty** in `android/local.properties`, so Android maps render blank with no other symptom. Reported as a warning rather than a blocker, since the build succeeds.

## Impact area

`scripts/mobile/doctor.mjs` only. No application code, no dependencies, no CI changes.

## Validation performed

Checked both directions rather than only the failing one:

- the local template `google-services.json` is detected as a placeholder
- a real config from another worktree is **not** flagged
- `doctor` now reports the two Android files as placeholders where it previously reported them `OK`, and points at a real source for each
- eslint clean

## Credit

The placeholder problem was found by the session working on the build toolchains, which noticed the copied files were byte-identical to `config-templates/`. Without that, this tool would have kept telling people their config was fine.