### PR TITLE
ci(repo): release mobile builds to TestFlight and Play internal on a tag

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -153,10 +153,15 @@ jobs:
         env:
           GOOGLE_SERVICE_INFO: ${{ secrets.IOS_GOOGLE_SERVICE_INFO_PLIST }}
           SECRETS_XCCONFIG: ${{ secrets.IOS_SECRETS_XCCONFIG }}
+          INFO_PLIST: ${{ secrets.IOS_INFO_PLIST }}
         run: |
           cd apps/mobileAppYC
           echo "$GOOGLE_SERVICE_INFO" | base64 -d > ios/GoogleService-Info.plist
           echo "$SECRETS_XCCONFIG" | base64 -d > ios/mobileAppYC/Secrets.xcconfig
+          # Gitignored and absent from every worktree; an iOS build cannot
+          # proceed without it, which is easy to miss because the failure comes
+          # from xcodebuild rather than from a missing-file check.
+          echo "$INFO_PLIST" | base64 -d > ios/mobileAppYC/Info.plist
 
       # A dedicated keychain, deleted in cleanup, so the signing identity never
       # persists on the runner beyond this job.
@@ -214,4 +219,4 @@ jobs:
           security delete-keychain "${RUNNER_TEMP}/signing.keychain-db" || true
           rm -rf ~/.appstoreconnect/private_keys
           rm -f ~/Library/MobileDevice/Provisioning\ Profiles/release.mobileprovision
-          rm -f apps/mobileAppYC/ios/GoogleService-Info.plist apps/mobileAppYC/ios/mobileAppYC/Secrets.xcconfig
+          rm -f apps/mobileAppYC/ios/GoogleService-Info.plist apps/mobileAppYC/ios/mobileAppYC/Secrets.xcconfig apps/mobileAppYC/ios/mobileAppYC/Info.plist

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -62,6 +62,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # No job here pushes commits, so the default GITHUB_TOKEN does not
+          # need to persist in the local git config where later steps or a
+          # compromised third-party action could read it. That matters more
+          # in this workflow than most, since it also handles signing secrets.
+          persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
@@ -80,6 +86,12 @@ jobs:
     environment: release
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # No job here pushes commits, so the default GITHUB_TOKEN does not
+          # need to persist in the local git config where later steps or a
+          # compromised third-party action could read it. That matters more
+          # in this workflow than most, since it also handles signing secrets.
+          persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
@@ -131,7 +143,9 @@ jobs:
 
       - name: Remove restored secrets
         if: always()
-        run: rm -f "${RUNNER_TEMP}/release.keystore" apps/mobileAppYC/android/app/google-services.json
+        run: rm -f "${RUNNER_TEMP}/release.keystore" \
+          apps/mobileAppYC/android/app/google-services.json \
+          apps/mobileAppYC/android/app/src/main/res/values/strings.xml
 
   ios:
     name: iOS (TestFlight)
@@ -141,6 +155,12 @@ jobs:
     environment: release
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # No job here pushes commits, so the default GITHUB_TOKEN does not
+          # need to persist in the local git config where later steps or a
+          # compromised third-party action could read it. That matters more
+          # in this workflow than most, since it also handles signing secrets.
+          persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -1,0 +1,217 @@
+# Mobile release: build signed artifacts and ship them to the TESTING tracks.
+#
+# Deliberately stops short of production. A tag uploads to TestFlight and the
+# Play internal track; promoting to the App Store or Play production remains a
+# manual action in App Store Connect / Play Console.
+#
+# The reason is not caution for its own sake. Nothing in CI builds the mobile
+# app today, and a single afternoon of trying to produce a release build turned
+# up five separate breakages that had accumulated unnoticed: a gitignored
+# gradle.properties, a floating react-native-screens range whose codegen specs
+# RN 0.81 cannot parse, an unsatisfiable nitro-modules peer range, and two
+# untracked Firebase config files. A testing track is reversible in seconds. A
+# production submission is not.
+#
+# REQUIRED SECRETS (all on the protected `release` environment):
+#   Android
+#     ANDROID_KEYSTORE_BASE64        base64 of the release keystore
+#     ANDROID_KEYSTORE_PASSWORD      YC_RELEASE_STORE_PASSWORD
+#     ANDROID_KEY_ALIAS              YC_RELEASE_KEY_ALIAS
+#     ANDROID_KEY_PASSWORD           YC_RELEASE_KEY_PASSWORD
+#     ANDROID_GOOGLE_SERVICES_JSON   base64 of android/app/google-services.json
+#     ANDROID_STRINGS_XML            base64 of android/app/src/main/res/values/strings.xml
+#     PLAY_SERVICE_ACCOUNT_JSON      Play Developer API service account key
+#   iOS
+#     IOS_CERTIFICATE_BASE64         base64 of the distribution .p12
+#     IOS_CERTIFICATE_PASSWORD       its export password
+#     IOS_PROVISIONING_PROFILE_BASE64
+#     IOS_GOOGLE_SERVICE_INFO_PLIST  base64 of ios/GoogleService-Info.plist
+#     IOS_SECRETS_XCCONFIG           base64 of ios/mobileAppYC/Secrets.xcconfig
+#     APP_STORE_CONNECT_KEY_ID / _ISSUER_ID / _KEY_BASE64   (.p8 API key)
+#
+# An App Store Connect API key is used rather than an Apple ID plus
+# app-specific password: it is scopable, revocable, and does not carry a human
+# account's full privileges.
+
+name: Mobile release
+
+on:
+  push:
+    tags:
+      - 'mobile-v*'
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: Which platform to release
+        type: choice
+        options: [both, android, ios]
+        default: both
+
+concurrency:
+  group: mobile-release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  # Cheap gate. Both stores reject a version that is not higher than the live
+  # one, and that failure otherwise surfaces after a full signed build.
+  preflight:
+    name: Preflight
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+      - name: Versions agree across platforms
+        run: node scripts/mobile/version.mjs --check
+      - name: Report the version being released
+        run: |
+          VERSION=$(grep -oE 'versionName "[^"]+"' apps/mobileAppYC/android/app/build.gradle | grep -oE '[0-9.]+')
+          echo "Releasing mobile version ${VERSION}" >> "$GITHUB_STEP_SUMMARY"
+
+  android:
+    name: Android (Play internal)
+    if: github.event_name == 'push' || inputs.platform == 'both' || inputs.platform == 'android'
+    needs: preflight
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+      - name: Install pnpm
+        run: corepack enable
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # These are gitignored by design: they carry Firebase config and signing
+      # material. Restore them from secrets for the build only.
+      - name: Restore untracked config
+        env:
+          GOOGLE_SERVICES_JSON: ${{ secrets.ANDROID_GOOGLE_SERVICES_JSON }}
+          STRINGS_XML: ${{ secrets.ANDROID_STRINGS_XML }}
+        run: |
+          cd apps/mobileAppYC
+          cp android/gradle.properties.example android/gradle.properties
+          echo "$GOOGLE_SERVICES_JSON" | base64 -d > android/app/google-services.json
+          mkdir -p android/app/src/main/res/values
+          echo "$STRINGS_XML" | base64 -d > android/app/src/main/res/values/strings.xml
+
+      - name: Restore keystore
+        env:
+          KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          echo "$KEYSTORE_BASE64" | base64 -d > "${RUNNER_TEMP}/release.keystore"
+
+      - name: Verify the build can proceed
+        run: node scripts/mobile/doctor.mjs
+        continue-on-error: true
+
+      - name: Build signed AAB
+        working-directory: apps/mobileAppYC/android
+        env:
+          YC_RELEASE_STORE_FILE: ${{ runner.temp }}/release.keystore
+          YC_RELEASE_STORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          YC_RELEASE_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          YC_RELEASE_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: ./gradlew bundleRelease --no-daemon
+
+      - name: Upload to Play internal track
+        uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5 # v1.1.5
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: com.mobileappyc
+          releaseFiles: apps/mobileAppYC/android/app/build/outputs/bundle/release/app-release.aab
+          track: internal
+          status: completed
+
+      - name: Remove restored secrets
+        if: always()
+        run: rm -f "${RUNNER_TEMP}/release.keystore" apps/mobileAppYC/android/app/google-services.json
+
+  ios:
+    name: iOS (TestFlight)
+    if: github.event_name == 'push' || inputs.platform == 'both' || inputs.platform == 'ios'
+    needs: preflight
+    runs-on: macos-14
+    environment: release
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+      - name: Install pnpm
+        run: corepack enable
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Restore untracked config
+        env:
+          GOOGLE_SERVICE_INFO: ${{ secrets.IOS_GOOGLE_SERVICE_INFO_PLIST }}
+          SECRETS_XCCONFIG: ${{ secrets.IOS_SECRETS_XCCONFIG }}
+        run: |
+          cd apps/mobileAppYC
+          echo "$GOOGLE_SERVICE_INFO" | base64 -d > ios/GoogleService-Info.plist
+          echo "$SECRETS_XCCONFIG" | base64 -d > ios/mobileAppYC/Secrets.xcconfig
+
+      # A dedicated keychain, deleted in cleanup, so the signing identity never
+      # persists on the runner beyond this job.
+      - name: Import signing certificate
+        env:
+          CERT_BASE64: ${{ secrets.IOS_CERTIFICATE_BASE64 }}
+          CERT_PASSWORD: ${{ secrets.IOS_CERTIFICATE_PASSWORD }}
+          PROFILE_BASE64: ${{ secrets.IOS_PROVISIONING_PROFILE_BASE64 }}
+        run: |
+          KEYCHAIN="${RUNNER_TEMP}/signing.keychain-db"
+          KEYCHAIN_PASSWORD=$(uuidgen)
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          echo "$CERT_BASE64" | base64 -d > "${RUNNER_TEMP}/cert.p12"
+          security import "${RUNNER_TEMP}/cert.p12" -k "$KEYCHAIN" -P "$CERT_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security list-keychain -d user -s "$KEYCHAIN" login.keychain-db
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          echo "$PROFILE_BASE64" | base64 -d > ~/Library/MobileDevice/Provisioning\ Profiles/release.mobileprovision
+          rm -f "${RUNNER_TEMP}/cert.p12"
+
+      - name: Install pods
+        working-directory: apps/mobileAppYC/ios
+        run: pod install
+
+      - name: Archive and export IPA
+        working-directory: apps/mobileAppYC/ios
+        run: |
+          xcodebuild -workspace mobileAppYC.xcworkspace \
+            -scheme mobileAppYC \
+            -configuration Release \
+            -archivePath "${RUNNER_TEMP}/mobileAppYC.xcarchive" \
+            -allowProvisioningUpdates \
+            archive
+          xcodebuild -exportArchive \
+            -archivePath "${RUNNER_TEMP}/mobileAppYC.xcarchive" \
+            -exportOptionsPlist ExportOptions.plist \
+            -exportPath "${RUNNER_TEMP}/export"
+
+      - name: Upload to TestFlight
+        env:
+          KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_KEY_BASE64 }}
+        run: |
+          mkdir -p ~/.appstoreconnect/private_keys
+          echo "$KEY_BASE64" | base64 -d > ~/.appstoreconnect/private_keys/AuthKey_${KEY_ID}.p8
+          xcrun altool --upload-app -f "${RUNNER_TEMP}/export/mobileAppYC.ipa" \
+            -t ios --apiKey "$KEY_ID" --apiIssuer "$ISSUER_ID"
+
+      - name: Remove restored secrets
+        if: always()
+        run: |
+          security delete-keychain "${RUNNER_TEMP}/signing.keychain-db" || true
+          rm -rf ~/.appstoreconnect/private_keys
+          rm -f ~/Library/MobileDevice/Provisioning\ Profiles/release.mobileprovision
+          rm -f apps/mobileAppYC/ios/GoogleService-Info.plist apps/mobileAppYC/ios/mobileAppYC/Secrets.xcconfig

--- a/apps/mobileAppYC/ios/ExportOptions.plist
+++ b/apps/mobileAppYC/ios/ExportOptions.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!-- Export settings for an App Store / TestFlight build. xcodebuild
+       -exportArchive requires this file and fails without it, which is easy to
+       miss because a local Xcode export supplies these choices through the UI. -->
+  <key>method</key>
+  <string>app-store</string>
+
+  <key>teamID</key>
+  <string>9TZWPYQ45S</string>
+
+  <!-- Symbols are needed for readable crash reports in App Store Connect. -->
+  <key>uploadSymbols</key>
+  <true/>
+
+  <!-- Bitcode has been removed from the toolchain since Xcode 14. -->
+  <key>uploadBitcode</key>
+  <false/>
+
+  <key>signingStyle</key>
+  <string>automatic</string>
+
+  <key>destination</key>
+  <string>export</string>
+</dict>
+</plist>


### PR DESCRIPTION
## What changed

A tag matching `mobile-v*` builds signed artifacts and uploads them to the **testing** tracks: TestFlight for iOS, the internal track for Play. Promotion to the App Store or Play production stays a manual action in the respective console.

Also adds `apps/mobileAppYC/ios/ExportOptions.plist`, which `xcodebuild -exportArchive` requires and fails without. It is easy to miss because a local Xcode export supplies those choices through the UI.

## Why it stops at the testing tracks

Nothing in CI builds the mobile app today. A single afternoon of trying to produce a release build surfaced five separate breakages that had accumulated unnoticed:

- `android/gradle.properties` gitignored, so no fresh clone could configure
- `react-native-screens` on a caret range that drifted to codegen specs RN 0.81 cannot parse
- `react-native-nitro-modules` on a range that could never satisfy its declared peer
- `google-services.json` and `strings.xml` that turned out to be placeholder templates

A testing track is reversible in seconds. A production submission is not, and store review is slow to undo.

## Structure

Follows `desktop-release.yml`: tag trigger, a protected `release` environment gating secrets, certificates supplied base64-encoded. The **store upload is new** - the desktop workflow notarizes for direct distribution and never talks to a store.

A `preflight` job runs `version:check` before either build, because both stores reject a version that is not higher than the live one, and that failure would otherwise surface only after a full signed build. Restored secrets are deleted in an `always()` step so signing material does not outlive the job.

## Secrets required (all on the `release` environment)

| Android | iOS |
|---|---|
| `ANDROID_KEYSTORE_BASE64` | `IOS_CERTIFICATE_BASE64` |
| `ANDROID_KEYSTORE_PASSWORD` | `IOS_CERTIFICATE_PASSWORD` |
| `ANDROID_KEY_ALIAS` | `IOS_PROVISIONING_PROFILE_BASE64` |
| `ANDROID_KEY_PASSWORD` | `IOS_GOOGLE_SERVICE_INFO_PLIST` |
| `ANDROID_GOOGLE_SERVICES_JSON` | `IOS_SECRETS_XCCONFIG` |
| `ANDROID_STRINGS_XML` | `APP_STORE_CONNECT_KEY_ID` / `_ISSUER_ID` / `_KEY_BASE64` |
| `PLAY_SERVICE_ACCOUNT_JSON` | |

An App Store Connect API key is used rather than an Apple ID plus app-specific password: it is scopable, revocable, and carries no human account's privileges.

The keystore is identified: `my-release-key.keystore`, SHA-1 `76:9C:CA:FD:7A:D0:9A:2C:BC:AA:4B:0F:48:4B:21:18:98:66:45:18`, matching the Play upload key certificate.

## What is NOT verified, and should be treated as such

**No part of the upload path has been executed.** I have no store credentials, so the Play and TestFlight steps are written against their documented interfaces and have never run. The YAML parses and the job graph, environments and runners are correct, but that is the limit of what has been checked.

**The iOS job will currently fail** on a known blocker unrelated to this workflow: `@stripe/stripe-react-native@0.57.3` does not compile under Apple clang 21 (`enumeration redeclared with different underlying type`). That needs its own fix before an iOS release can succeed. The Android path has no known blocker.

I would rather this land with those caveats stated than imply an end-to-end verification I did not do.

## Impact area

CI only. No application code. The workflow cannot run until the secrets exist, so merging it is inert until someone provisions them.