### PR TITLE
chore(repo): stop dependabot reverting the react-native-screens pin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,8 +60,11 @@ updates:
       # test suite; reanimated and worklets are pinned since the Android build
       # fix (#2052); stripe-react-native and the nitro modules are 0.x native
       # code; react-test-renderer must exactly match the react version RN pins
-      # (its 19.2.8 ride-along failed all 457 suites). RN upgrades are
-      # deliberate migrations with device builds, never weekly PRs.
+      # (its 19.2.8 ride-along failed all 457 suites); react-native-screens is
+      # pinned to 4.24.0 because 4.25+ emit React.ComponentRef<> in their
+      # src/fabric/ codegen specs, which RN 0.81.6's parser rejects, breaking
+      # both the Android codegen task and iOS pod install (#2271, #2272).
+      # RN upgrades are deliberate migrations with device builds, never weekly PRs.
       - dependency-name: 'react-native'
         update-types: ['version-update:semver-minor', 'version-update:semver-major']
       - dependency-name: '@react-native/*'
@@ -75,6 +78,8 @@ updates:
       - dependency-name: 'react-native-nitro-*'
         update-types: ['version-update:semver-minor', 'version-update:semver-major']
       - dependency-name: '@stripe/stripe-react-native'
+        update-types: ['version-update:semver-minor', 'version-update:semver-major']
+      - dependency-name: 'react-native-screens'
         update-types: ['version-update:semver-minor', 'version-update:semver-major']
       # react-test-renderer is fully frozen: @testing-library/react-native
       # requires it to EXACTLY equal the react version RN pins, so even the

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,9 +61,14 @@ updates:
       # fix (#2052); stripe-react-native and the nitro modules are 0.x native
       # code; react-test-renderer must exactly match the react version RN pins
       # (its 19.2.8 ride-along failed all 457 suites); react-native-screens is
-      # pinned to 4.24.0 because 4.25+ emit React.ComponentRef<> in their
-      # src/fabric/ codegen specs, which RN 0.81.6's parser rejects, breaking
-      # both the Android codegen task and iOS pod install (#2271, #2272).
+      # pinned to 4.24.0 for two separate reasons. 4.26.0+ emit
+      # React.ComponentRef<> in their src/fabric/ codegen specs and RN 0.81.6's
+      # parser accepts only React.ElementRef<>, which was observed failing on
+      # 4.27.0 and 4.26.2 - both iOS pod install and the Android codegen task,
+      # each on a different command (showColumn, setToolbarMenuElementOptions).
+      # 4.25.0's specs are clean and it does build, but it declares
+      # react-native >=0.82.0, so it is unsupported here. 4.24.0 is the last
+      # version that both builds and claims to support 0.81.6 (#2271, #2272).
       # RN upgrades are deliberate migrations with device builds, never weekly PRs.
       - dependency-name: 'react-native'
         update-types: ['version-update:semver-minor', 'version-update:semver-major']


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

#2272 pinned `react-native-screens` to `4.24.0` exactly, because 4.25+ emit `React.ComponentRef<>` in their `src/fabric/` codegen specs and RN 0.81.6's codegen parser accepts only `React.ElementRef<>`. That breaks the Android `generateCodegenSchemaFromJavaScript` task and iOS `pod install` through the same path.

The pin was only half the fix. Every other member of the native cluster already has an ignore entry in `.github/dependabot.yml`:

- `react-native`
- `@react-native/*`
- `@react-native-community/cli*`
- `react-native-reanimated`
- `react-native-worklets`
- `react-native-nitro-*`
- `@stripe/stripe-react-native`

`react-native-screens` did not. Dependabot proposed `4.24.0` -> `4.27.0` in #2275 twenty-two minutes after #2272 merged. Merging that would re-break both platforms.

## What is the new behavior?

Adds the missing `react-native-screens` entry, using the same `update-types` as its siblings, and records the reason in the stanza comment so the next person does not have to rediscover it.

Deliberately `update-types: ['version-update:semver-minor', 'version-update:semver-major']` rather than omitting the list. The file's own comment documents that omitting `update-types` ignores ALL updates; that would also block `4.24.x` patches, which stay on the `ElementRef` specs and are safe. Only minor and major need blocking, and `4.24.0` -> `4.27.0` is a minor, so this stops exactly the proposal that triggered it.

### Important: this does not take effect until it reaches `main`

Dependabot reads its configuration from the repository's default branch, which is `main`. A copy sitting on `dev` is inert. This PR targets `dev` to respect the convention that `main` only receives merges from `dev`, so the guard becomes active at the next `dev` -> `main` merge, not when this lands.

Until then dependabot will keep regenerating the proposal on schedule. That is repeated noise rather than repeated risk: #2275 is `BLOCKED` with no auto-merge, so nothing lands on its own.

### On #2275 itself

It should not be merged as-is, but closing it is probably wrong too. It carries 23 other updates that look like ordinary patch traffic, so rebasing it once this guard is active is the better outcome than making someone re-raise them.

### Verification

- `.github/dependabot.yml` still parses as valid YAML (3 `updates` entries), and `react-native-screens` is present in the resolved ignore list.
- No source, dependency or lockfile changes; this is CI configuration only.

## Related Issue(s)

Refs #2271, #2275
