### PR TITLE
fix(mobile): unbreak the android release build by holding @babel/runtime on 7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -130,10 +130,11 @@ updates:
         update-types: ['version-update:semver-major']
       # @babel/runtime 8 is blocked by the same Babel-8-too-early constraint,
       # but fails differently and later: 8.0.0 drops the "./regenerator"
-      # export subpath, keeping only "./helpers/regenerator*". Three packages
-      # still import the old path - posthog-react-native (including its
-      # current 4.63.2), react-native-vector-icons and toastify-react-native -
-      # so Metro cannot resolve it and :app:createBundleReleaseJsAndAssets
+      # export subpath, keeping only "./helpers/regenerator*". Two packages
+      # still import the old path - posthog-react-native (4 files, including
+      # in its current 4.63.2, so there is nothing to upgrade to) and
+      # react-native-vector-icons (1 file) - so Metro cannot resolve it and
+      # :app:createBundleReleaseJsAndAssets
       # dies. That task only runs for RELEASE builds, so assembleDebug and
       # every jest suite stay green while release is broken (#2109 shipped it
       # unnoticed on 2026-08-09). Unfreeze alongside @babel/core.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -128,6 +128,17 @@ updates:
       # upgrade that ships a Babel 8 compatible preset.
       - dependency-name: '@babel/core'
         update-types: ['version-update:semver-major']
+      # @babel/runtime 8 is blocked by the same Babel-8-too-early constraint,
+      # but fails differently and later: 8.0.0 drops the "./regenerator"
+      # export subpath, keeping only "./helpers/regenerator*". Three packages
+      # still import the old path - posthog-react-native (including its
+      # current 4.63.2), react-native-vector-icons and toastify-react-native -
+      # so Metro cannot resolve it and :app:createBundleReleaseJsAndAssets
+      # dies. That task only runs for RELEASE builds, so assembleDebug and
+      # every jest suite stay green while release is broken (#2109 shipped it
+      # unnoticed on 2026-08-09). Unfreeze alongside @babel/core.
+      - dependency-name: '@babel/runtime'
+        update-types: ['version-update:semver-major']
       # eslint 10 is blocked in two workspaces at once (#2180), so the repo
       # stays on 9 until both clear:
       #   frontend - eslint-config-next 15.x loads @rushstack/eslint-patch,

--- a/apps/mobileAppYC/package.json
+++ b/apps/mobileAppYC/package.json
@@ -96,7 +96,7 @@
   "devDependencies": {
     "@babel/core": "^7.29.6",
     "@babel/preset-env": "^8.0.2",
-    "@babel/runtime": "^8.0.0",
+    "@babel/runtime": "^7.29.7",
     "@react-native-community/cli": "20.0.2",
     "@react-native-community/cli-platform-android": "20.0.2",
     "@react-native-community/cli-platform-ios": "20.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -888,8 +888,8 @@ importers:
         specifier: ^8.0.2
         version: 8.0.2(@babel/core@7.29.7)
       '@babel/runtime':
-        specifier: ^8.0.0
-        version: 8.0.0
+        specifier: ^7.29.7
+        version: 7.29.7
       '@react-native-community/cli':
         specifier: 20.0.2
         version: 20.0.2(typescript@5.9.3)
@@ -4641,10 +4641,6 @@ packages:
   /@babel/runtime@7.29.7:
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
-
-  /@babel/runtime@8.0.0:
-    resolution: {integrity: sha512-sL6cvO2IfkSu/iU+zs2S/w01B7A8V7suXSIKEN4hPFFdZoiPGxrj5pAG0lCaqLWiEIrjKzdznIWuaLcxPR53qw==}
-    dev: true
 
   /@babel/template@7.29.7:
     resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The Android **release** build has been broken on `dev` since 2026-08-09 and nothing reported it.

`./gradlew assembleRelease` fails at `:app:createBundleReleaseJsAndAssets`:

```
Unable to resolve module @babel/runtime/regenerator
  from posthog-react-native/dist/posthog-rn.js
```

`@babel/runtime` 7.x exports `"./regenerator"`. **8.0.0 removed it**, keeping only `"./helpers/regenerator*"`. `apps/mobileAppYC/package.json` declares `"@babel/runtime": "^8.0.0"`, introduced by dependabot in #2109.

Upgrading the importer does not help, and it is not a single bad package. Two still import the old subpath:

| Package | Files importing `@babel/runtime/regenerator` |
| --- | --- |
| `posthog-react-native@4.63.0` (and current `4.63.2`) | 4 |
| `react-native-vector-icons@10.3.0` | 1 |

### Why nobody noticed

`createBundleReleaseJsAndAssets` only runs for release builds. `assembleDebug` does not bundle JS, so debug builds and all 7526 tests stay green while release is broken. No CI job builds the mobile app at all, so there was nothing left to catch it.

### The structural cause

`.github/dependabot.yml` already documents that Babel 8 cannot be installed while the app is on React Native 0.81, because `@react-native/babel-preset` asserts Babel `^7.0.0-0` at load time (#2116). It guards `@babel/core` against majors on exactly that basis.

There was no entry for `@babel/runtime`. The same written-down constraint was enforced on one package in the family and not its sibling, so the blocked major walked in through the unguarded door.

This is the third instance of that shape today, after `react-native-screens` (#2272, guard in #2279) and `react-native-nitro-modules` (#2272).

## What is the new behavior?

Holds `@babel/runtime` on `^7.29.7`, and adds the missing dependabot guard so the pin cannot be reverted the way the screens pin was 22 minutes after it landed.

Uses `update-types: ['version-update:semver-major']`, matching `@babel/core` rather than a full freeze, because 7.x patches are wanted. Unfreeze both together with the React Native upgrade that ships a Babel 8 compatible preset.

Note the guard only takes effect once it reaches `main`, since dependabot reads config from the default branch.

### Verification

Run against `apps/mobileAppYC`:

- `./gradlew assembleRelease` **BUILD SUCCESSFUL in 7m 42s**, 132M `app-release.apk` (the same command failed in 29m 34s before this change)
- `apksigner verify --print-certs`: `Verifies`, v2 scheme, signer SHA-1 `76:9C:CA:FD:7A:D0:9A:2C:BC:AA:4B:0F:48:4B:21:18:98:66:45:18`, which is the Play **upload key** certificate for `com.mobileappyc`. So this is a genuinely uploadable artifact, not merely a compile that finished.
- `pnpm --filter mobileAppYC run test`: 7526 tests across 461 suites pass

Toolchain: Gradle 8.14.3, JDK 17, NDK 27.1.12297006, AGP as pinned.

### Scope note

This does not touch `react-native-screens`. #2279 carries that guard and edits a different stanza of the same file, so the two should merge independently.

## Related Issue(s)

Refs #2109, #2116
