### PR TITLE
fix(auth): accept the apple service id audience for android sign-in

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -21,6 +21,9 @@ AUTH_WEBSITE_DOMAIN=""
 AUTH_GOOGLE_CLIENT_ID=""
 AUTH_GOOGLE_CLIENT_SECRET=""
 AUTH_APPLE_CLIENT_ID=""
+# Apple Service ID used by the Android web flow; the id_token it mints is
+# scoped to this instead of the iOS bundle identifier
+AUTH_APPLE_SERVICE_ID=""
 AUTH_APPLE_KEY_ID=""
 AUTH_APPLE_PRIVATE_KEY=""
 AUTH_APPLE_TEAM_ID=""

--- a/apps/backend/test/auth/supertokens.config.test.ts
+++ b/apps/backend/test/auth/supertokens.config.test.ts
@@ -257,12 +257,39 @@ describe("@yosemite-crew/auth supertokens config", () => {
       expect(audiencesVerifiedAgainst).toEqual([SERVICE_ID]);
     });
 
+    it("matches an allowed audience that is not first in the array", async () => {
+      const provider = buildAppleProvider({ serviceId: SERVICE_ID });
+
+      const { audiencesVerifiedAgainst } = await runGetUserInfo(
+        provider,
+        makeIdToken(["https://appleid.apple.com", SERVICE_ID]),
+      );
+
+      expect(audiencesVerifiedAgainst).toEqual([SERVICE_ID]);
+    });
+
+    it("skips non-string entries when matching the audience array", async () => {
+      const provider = buildAppleProvider({ serviceId: SERVICE_ID });
+
+      const { audiencesVerifiedAgainst } = await runGetUserInfo(
+        provider,
+        makeIdToken([null, 7, SERVICE_ID]),
+      );
+
+      expect(audiencesVerifiedAgainst).toEqual([SERVICE_ID]);
+    });
+
     it.each([
       ["an audience that is not ours", makeIdToken("com.attacker.app")],
       ["a token that is not a jwt", "not-a-jwt"],
       ["a token with an unparseable payload", "header.%%%.signature"],
       ["a non-string token", 42],
       ["a missing audience claim", makeIdToken(undefined)],
+      [
+        "an audience array with no id of ours",
+        makeIdToken(["com.attacker.app"]),
+      ],
+      ["an empty audience array", makeIdToken([])],
     ])(
       "falls back to the configured client id for %s",
       async (_label, token) => {

--- a/apps/backend/test/auth/supertokens.config.test.ts
+++ b/apps/backend/test/auth/supertokens.config.test.ts
@@ -10,6 +10,21 @@ jest.mock("supertokens-node/recipe/passwordless", () => ({
   },
 }));
 
+const mockThirdPartyInit = jest.fn((config: unknown) => ({
+  name: "thirdparty",
+  config,
+}));
+
+jest.mock("supertokens-node/recipe/thirdparty", () => {
+  const actual = jest.requireActual("supertokens-node/recipe/thirdparty");
+
+  return {
+    ...actual,
+    __esModule: true,
+    default: { ...actual.default, init: mockThirdPartyInit },
+  };
+});
+
 const ORIGINAL_ENV = {
   AUTH_API_DOMAIN: process.env.AUTH_API_DOMAIN,
   AUTH_WEBSITE_DOMAIN: process.env.AUTH_WEBSITE_DOMAIN,
@@ -23,6 +38,11 @@ const ORIGINAL_ENV = {
   SMTP_PASSWORD: process.env.SMTP_PASSWORD,
   SMTP_FROM_NAME: process.env.SMTP_FROM_NAME,
   SMTP_FROM_EMAIL: process.env.SMTP_FROM_EMAIL,
+  AUTH_APPLE_CLIENT_ID: process.env.AUTH_APPLE_CLIENT_ID,
+  AUTH_APPLE_SERVICE_ID: process.env.AUTH_APPLE_SERVICE_ID,
+  AUTH_APPLE_KEY_ID: process.env.AUTH_APPLE_KEY_ID,
+  AUTH_APPLE_PRIVATE_KEY: process.env.AUTH_APPLE_PRIVATE_KEY,
+  AUTH_APPLE_TEAM_ID: process.env.AUTH_APPLE_TEAM_ID,
 };
 
 const restoreEnv = () => {
@@ -39,6 +59,12 @@ describe("@yosemite-crew/auth supertokens config", () => {
   beforeEach(() => {
     jest.resetModules();
     mockPasswordlessInit.mockClear();
+    mockThirdPartyInit.mockClear();
+    delete process.env.AUTH_APPLE_CLIENT_ID;
+    delete process.env.AUTH_APPLE_SERVICE_ID;
+    delete process.env.AUTH_APPLE_KEY_ID;
+    delete process.env.AUTH_APPLE_PRIVATE_KEY;
+    delete process.env.AUTH_APPLE_TEAM_ID;
     process.env.AUTH_API_DOMAIN = "https://api.example.com";
     process.env.AUTH_WEBSITE_DOMAIN = "https://app.example.com";
     process.env.SUPERTOKENS_CONNECTION_URI = "http://localhost:3567";
@@ -130,6 +156,167 @@ describe("@yosemite-crew/auth supertokens config", () => {
     expect(originalSendEmail).toHaveBeenCalledTimes(1);
     expect(originalSendEmail).toHaveBeenCalledWith({
       email: "someone@example.com",
+    });
+  });
+  describe("apple id_token audience selection", () => {
+    const BUNDLE_ID = "com.example.mobile";
+    const SERVICE_ID = "com.example.mobile.auth";
+
+    const makeIdToken = (aud: unknown): string =>
+      [
+        "eyJhbGciOiJSUzI1NiJ9",
+        Buffer.from(JSON.stringify({ aud })).toString("base64url"),
+        "signature",
+      ].join(".");
+
+    const buildAppleProvider = (options: { serviceId?: string } = {}) => {
+      process.env.SMTP_HOST = "smtp.example.test";
+      process.env.SMTP_PORT = "465";
+      process.env.SMTP_SECURE = "true";
+      process.env.SMTP_USER = "smtp-user";
+      process.env.SMTP_PASSWORD = "smtp-password";
+      process.env.SMTP_FROM_NAME = "Yosemite Crew";
+      process.env.SMTP_FROM_EMAIL = "auth@example.test";
+      process.env.AUTH_APPLE_CLIENT_ID = BUNDLE_ID;
+      process.env.AUTH_APPLE_KEY_ID = "KEY123";
+      process.env.AUTH_APPLE_PRIVATE_KEY = "-----BEGIN PRIVATE KEY-----";
+      process.env.AUTH_APPLE_TEAM_ID = "TEAM123";
+
+      if (options.serviceId) {
+        process.env.AUTH_APPLE_SERVICE_ID = options.serviceId;
+      }
+
+      const { getSuperTokensConfig } = require("@yosemite-crew/auth");
+      getSuperTokensConfig();
+
+      const initArg = mockThirdPartyInit.mock.calls[0]?.[0] as any;
+
+      return initArg.signInAndUpFeature.providers.find(
+        (provider: any) => provider.config.thirdPartyId === "apple",
+      );
+    };
+
+    const runGetUserInfo = async (provider: any, idToken: unknown) => {
+      const audiencesVerifiedAgainst: string[] = [];
+      const implementation: any = {
+        type: "oauth2",
+        config: { clientId: BUNDLE_ID },
+        getUserInfo: jest.fn(async () => {
+          audiencesVerifiedAgainst.push(implementation.config.clientId);
+          return { thirdPartyUserId: "apple-user" };
+        }),
+      };
+
+      const overridden = provider.override(implementation);
+
+      await overridden.getUserInfo({ oAuthTokens: { id_token: idToken } });
+
+      return {
+        audiencesVerifiedAgainst,
+        clientIdAfterCall: implementation.config.clientId,
+      };
+    };
+
+    it("registers exactly one client so requests without a clientType still resolve", () => {
+      const provider = buildAppleProvider({ serviceId: SERVICE_ID });
+
+      expect(provider.config.clients).toHaveLength(1);
+      expect(provider.config.clients[0].clientId).toBe(BUNDLE_ID);
+    });
+
+    it("verifies an android token against the apple service id", async () => {
+      const provider = buildAppleProvider({ serviceId: SERVICE_ID });
+
+      const { audiencesVerifiedAgainst } = await runGetUserInfo(
+        provider,
+        makeIdToken(SERVICE_ID),
+      );
+
+      expect(audiencesVerifiedAgainst).toEqual([SERVICE_ID]);
+    });
+
+    it("verifies an ios token against the bundle identifier", async () => {
+      const provider = buildAppleProvider({ serviceId: SERVICE_ID });
+
+      const { audiencesVerifiedAgainst } = await runGetUserInfo(
+        provider,
+        makeIdToken(BUNDLE_ID),
+      );
+
+      expect(audiencesVerifiedAgainst).toEqual([BUNDLE_ID]);
+    });
+
+    it("accepts an audience supplied as an array", async () => {
+      const provider = buildAppleProvider({ serviceId: SERVICE_ID });
+
+      const { audiencesVerifiedAgainst } = await runGetUserInfo(
+        provider,
+        makeIdToken([SERVICE_ID]),
+      );
+
+      expect(audiencesVerifiedAgainst).toEqual([SERVICE_ID]);
+    });
+
+    it.each([
+      ["an audience that is not ours", makeIdToken("com.attacker.app")],
+      ["a token that is not a jwt", "not-a-jwt"],
+      ["a token with an unparseable payload", "header.%%%.signature"],
+      ["a non-string token", 42],
+      ["a missing audience claim", makeIdToken(undefined)],
+    ])(
+      "falls back to the configured client id for %s",
+      async (_label, token) => {
+        const provider = buildAppleProvider({ serviceId: SERVICE_ID });
+
+        const { audiencesVerifiedAgainst } = await runGetUserInfo(
+          provider,
+          token,
+        );
+
+        expect(audiencesVerifiedAgainst).toEqual([BUNDLE_ID]);
+      },
+    );
+
+    it("ignores the service id audience when AUTH_APPLE_SERVICE_ID is unset", async () => {
+      const provider = buildAppleProvider();
+
+      const { audiencesVerifiedAgainst } = await runGetUserInfo(
+        provider,
+        makeIdToken(SERVICE_ID),
+      );
+
+      expect(audiencesVerifiedAgainst).toEqual([BUNDLE_ID]);
+    });
+
+    it("restores the configured client id after verification succeeds", async () => {
+      const provider = buildAppleProvider({ serviceId: SERVICE_ID });
+
+      const { clientIdAfterCall } = await runGetUserInfo(
+        provider,
+        makeIdToken(SERVICE_ID),
+      );
+
+      expect(clientIdAfterCall).toBe(BUNDLE_ID);
+    });
+
+    it("restores the configured client id when verification throws", async () => {
+      const provider = buildAppleProvider({ serviceId: SERVICE_ID });
+      const implementation: any = {
+        type: "oauth2",
+        config: { clientId: BUNDLE_ID },
+        getUserInfo: jest.fn(async () => {
+          throw new Error('unexpected "aud" claim value');
+        }),
+      };
+
+      const overridden = provider.override(implementation);
+
+      await expect(
+        overridden.getUserInfo({
+          oAuthTokens: { id_token: makeIdToken(SERVICE_ID) },
+        }),
+      ).rejects.toThrow('unexpected "aud" claim value');
+      expect(implementation.config.clientId).toBe(BUNDLE_ID);
     });
   });
 });

--- a/packages/auth/src/config/supertokens.config.ts
+++ b/packages/auth/src/config/supertokens.config.ts
@@ -107,6 +107,33 @@ function resolvePasswordlessRecipientEmail(input: {
   return input.email ?? input.templateVars?.email;
 }
 
+/**
+ * Reads the `aud` claim without verifying the signature. The value is only used
+ * to pick between client ids we configured ourselves; supertokens-node still
+ * verifies the token against Apple's JWKS using the id chosen here, so a forged
+ * audience cannot widen what the provider accepts.
+ */
+function readIdTokenAudience(idToken: string): string | undefined {
+  const segments = idToken.split('.');
+
+  if (segments.length !== 3) {
+    return undefined;
+  }
+
+  try {
+    const payload: unknown = JSON.parse(Buffer.from(segments[1], 'base64url').toString('utf8'));
+    const audience = (payload as { aud?: unknown } | null)?.aud;
+
+    if (typeof audience === 'string') {
+      return audience;
+    }
+
+    return Array.isArray(audience) && typeof audience[0] === 'string' ? audience[0] : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function buildThirdPartyProviders(): ProviderInput[] {
   const providers: ProviderInput[] = [];
 
@@ -125,13 +152,20 @@ function buildThirdPartyProviders(): ProviderInput[] {
   }
 
   if (process.env.AUTH_APPLE_CLIENT_ID) {
+    // For native iOS sign-in this is the app bundle identifier.
+    const appleClientId = requireEnv('AUTH_APPLE_CLIENT_ID');
+    // Sign in with Apple on Android runs Apple's web flow, so the id_token is
+    // minted for the Service ID rather than the bundle identifier. Both are ours
+    // and both must be accepted.
+    const appleServiceId = process.env.AUTH_APPLE_SERVICE_ID;
+    const appleAudiences = appleServiceId ? [appleClientId, appleServiceId] : [appleClientId];
+
     providers.push({
       config: {
         thirdPartyId: 'apple',
         clients: [
           {
-            // For native iOS sign-in this is the app bundle identifier.
-            clientId: requireEnv('AUTH_APPLE_CLIENT_ID'),
+            clientId: appleClientId,
             additionalConfig: {
               keyId: requireEnv('AUTH_APPLE_KEY_ID'),
               privateKey: requireEnv('AUTH_APPLE_PRIVATE_KEY'),
@@ -139,6 +173,33 @@ function buildThirdPartyProviders(): ProviderInput[] {
             },
           },
         ],
+      },
+      // supertokens-node verifies the id_token against a single configured
+      // clientId, and refuses to hold more than one client unless the caller
+      // sends a clientType, which the mobile app does not. Select the audience
+      // the token was actually minted for before verification reads it.
+      override: (originalImplementation) => {
+        if (originalImplementation.type !== 'oauth2') {
+          return originalImplementation;
+        }
+
+        const originalGetUserInfo = originalImplementation.getUserInfo;
+
+        originalImplementation.getUserInfo = async (input) => {
+          const idToken: unknown = input.oAuthTokens.id_token;
+          const audience = typeof idToken === 'string' ? readIdTokenAudience(idToken) : undefined;
+
+          originalImplementation.config.clientId =
+            audience && appleAudiences.includes(audience) ? audience : appleClientId;
+
+          try {
+            return await originalGetUserInfo(input);
+          } finally {
+            originalImplementation.config.clientId = appleClientId;
+          }
+        };
+
+        return originalImplementation;
       },
     });
   }

--- a/packages/auth/src/config/supertokens.config.ts
+++ b/packages/auth/src/config/supertokens.config.ts
@@ -108,16 +108,20 @@ function resolvePasswordlessRecipientEmail(input: {
 }
 
 /**
- * Reads the `aud` claim without verifying the signature. The value is only used
- * to pick between client ids we configured ourselves; supertokens-node still
- * verifies the token against Apple's JWKS using the id chosen here, so a forged
- * audience cannot widen what the provider accepts.
+ * Reads the `aud` claim without verifying the signature. The values are only
+ * used to pick between client ids we configured ourselves; supertokens-node
+ * still verifies the token against Apple's JWKS using the id chosen here, so a
+ * forged audience cannot widen what the provider accepts.
+ *
+ * `aud` may be a single string or an array, so every entry is returned and
+ * matched on membership. Reading only the first entry would make acceptance
+ * depend on ordering and reject a token whose allowed audience is not first.
  */
-function readIdTokenAudience(idToken: string): string | undefined {
+function readIdTokenAudiences(idToken: string): string[] {
   const segments = idToken.split('.');
 
   if (segments.length !== 3) {
-    return undefined;
+    return [];
   }
 
   try {
@@ -125,12 +129,14 @@ function readIdTokenAudience(idToken: string): string | undefined {
     const audience = (payload as { aud?: unknown } | null)?.aud;
 
     if (typeof audience === 'string') {
-      return audience;
+      return [audience];
     }
 
-    return Array.isArray(audience) && typeof audience[0] === 'string' ? audience[0] : undefined;
+    return Array.isArray(audience)
+      ? audience.filter((entry): entry is string => typeof entry === 'string')
+      : [];
   } catch {
-    return undefined;
+    return [];
   }
 }
 
@@ -187,10 +193,10 @@ function buildThirdPartyProviders(): ProviderInput[] {
 
         originalImplementation.getUserInfo = async (input) => {
           const idToken: unknown = input.oAuthTokens.id_token;
-          const audience = typeof idToken === 'string' ? readIdTokenAudience(idToken) : undefined;
+          const audiences = typeof idToken === 'string' ? readIdTokenAudiences(idToken) : [];
 
           originalImplementation.config.clientId =
-            audience && appleAudiences.includes(audience) ? audience : appleClientId;
+            audiences.find((entry) => appleAudiences.includes(entry)) ?? appleClientId;
 
           try {
             return await originalGetUserInfo(input);


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

Sign in with Apple works on iOS and always fails on Android.

Apple mints a different id_token audience per platform. Native iOS sign-in returns a
token scoped to the app bundle identifier. The Android path runs Apple's web authorize
endpoint with the Apple Service ID as `client_id`, so the token is scoped to the Service
ID instead.

supertokens-node 24.0.3 verifies the id_token against a single configured clientId
(`providers/custom.js` passes `audience: impl.config.clientId`) and throws at config
resolution if more than one client is registered while the request omits `clientType`.
The mobile app's `buildSignInUpBody` never sends `clientType`, so exactly one audience
can be accepted. `AUTH_APPLE_CLIENT_ID` holds the bundle identifier, so Android tokens
are rejected with `unexpected "aud" claim value`.

## What is the new behavior?

The Apple provider still registers exactly one client, so requests without a
`clientType` continue to resolve. Before verification reads the audience, the provider
selects whichever of our own client ids the token was actually minted for, restricted to
an allowlist built from `AUTH_APPLE_CLIENT_ID` and the new optional
`AUTH_APPLE_SERVICE_ID`.

The `aud` claim is read without verifying the signature, which is safe here because it
only chooses between ids we configured ourselves. supertokens-node still verifies the
token against Apple's JWKS using the selected id, so an unrecognised or forged audience
falls back to the bundle identifier and is rejected exactly as before.

Why not register two clients with `clientType`: that route throws at config resolution
for any request that omits `clientType`, which is every build already installed on a
user's device. It would break Apple sign-in on both platforms rather than fixing one.

Behaviour is unchanged while `AUTH_APPLE_SERVICE_ID` is unset, so this is inert until
the variable is configured.

### Validation performed

- `pnpm --filter @yosemite-crew/auth run type-check` passes.
- `pnpm --filter @yosemite-crew/auth run build` passes.
- 15/15 tests pass in `apps/backend/test/auth/supertokens.config.test.ts`, including
  audience selection for both platforms, array audiences, malformed and non-string
  tokens, an audience that is not ours, and client id restoration on both the success
  and throwing paths.
- Mutation checked: reverting the fix in place makes exactly the two audience tests
  fail, confirming the tests detect the defect rather than passing vacuously.
- Behaviour was first reproduced against the real supertokens-node provider code with a
  JWKS under test control, which is also where the allowlist was confirmed to still
  reject a forged audience.
- Backend lint error count is identical on this branch and on dev (12248 both), and
  neither changed file appears in the lint output.

## Related Issue(s)

Fixes #2284
