### PR TITLE
fix(ci): restore the mobile app config in release builds

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -28,6 +28,14 @@
 #     IOS_GOOGLE_SERVICE_INFO_PLIST  base64 of ios/GoogleService-Info.plist
 #     IOS_SECRETS_XCCONFIG           base64 of ios/mobileAppYC/Secrets.xcconfig
 #     APP_STORE_CONNECT_KEY_ID / _ISSUER_ID / _KEY_BASE64   (.p8 API key)
+#   Both platforms
+#     MOBILE_VARIABLES_LOCAL_TS      base64 of src/config/variables.local.ts,
+#                                    which carries appleServiceId, appleRedirectUri,
+#                                    googleWebClientId and facebookAppId. It is
+#                                    gitignored, and variables.ts falls back to
+#                                    templates SILENTLY when CI=true, so a build
+#                                    without it uploads working-looking binaries
+#                                    whose social sign-in cannot succeed.
 #
 # An App Store Connect API key is used rather than an Apple ID plus
 # app-specific password: it is scopable, revocable, and does not carry a human
@@ -106,12 +114,21 @@ jobs:
         env:
           GOOGLE_SERVICES_JSON: ${{ secrets.ANDROID_GOOGLE_SERVICES_JSON }}
           STRINGS_XML: ${{ secrets.ANDROID_STRINGS_XML }}
+          VARIABLES_LOCAL_TS: ${{ secrets.MOBILE_VARIABLES_LOCAL_TS }}
         run: |
           cd apps/mobileAppYC
           cp android/gradle.properties.example android/gradle.properties
           echo "$GOOGLE_SERVICES_JSON" | base64 -d > android/app/google-services.json
           mkdir -p android/app/src/main/res/values
           echo "$STRINGS_XML" | base64 -d > android/app/src/main/res/values/strings.xml
+          echo "$VARIABLES_LOCAL_TS" | base64 -d > src/config/variables.local.ts
+
+      # variables.local.ts supplies appleServiceId, appleRedirectUri,
+      # googleWebClientId and facebookAppId. Without it the app silently falls
+      # back to the templates in variables.ts and ships a build whose social
+      # sign-in cannot work, so this must fail the release rather than warn.
+      - name: Verify the app config restored
+        run: node scripts/mobile/doctor.mjs --require-app-config
 
       - name: Restore keystore
         env:
@@ -145,7 +162,8 @@ jobs:
         if: always()
         run: rm -f "${RUNNER_TEMP}/release.keystore" \
           apps/mobileAppYC/android/app/google-services.json \
-          apps/mobileAppYC/android/app/src/main/res/values/strings.xml
+          apps/mobileAppYC/android/app/src/main/res/values/strings.xml \
+          apps/mobileAppYC/src/config/variables.local.ts
 
   ios:
     name: iOS (TestFlight)
@@ -174,6 +192,7 @@ jobs:
           GOOGLE_SERVICE_INFO: ${{ secrets.IOS_GOOGLE_SERVICE_INFO_PLIST }}
           SECRETS_XCCONFIG: ${{ secrets.IOS_SECRETS_XCCONFIG }}
           INFO_PLIST: ${{ secrets.IOS_INFO_PLIST }}
+          VARIABLES_LOCAL_TS: ${{ secrets.MOBILE_VARIABLES_LOCAL_TS }}
         run: |
           cd apps/mobileAppYC
           echo "$GOOGLE_SERVICE_INFO" | base64 -d > ios/GoogleService-Info.plist
@@ -182,6 +201,12 @@ jobs:
           # proceed without it, which is easy to miss because the failure comes
           # from xcodebuild rather than from a missing-file check.
           echo "$INFO_PLIST" | base64 -d > ios/mobileAppYC/Info.plist
+          echo "$VARIABLES_LOCAL_TS" | base64 -d > src/config/variables.local.ts
+
+      # See the android job: without this the app ships template social sign-in
+      # config, and nothing in the build itself would say so.
+      - name: Verify the app config restored
+        run: node scripts/mobile/doctor.mjs --require-app-config
 
       # A dedicated keychain, deleted in cleanup, so the signing identity never
       # persists on the runner beyond this job.
@@ -240,3 +265,4 @@ jobs:
           rm -rf ~/.appstoreconnect/private_keys
           rm -f ~/Library/MobileDevice/Provisioning\ Profiles/release.mobileprovision
           rm -f apps/mobileAppYC/ios/GoogleService-Info.plist apps/mobileAppYC/ios/mobileAppYC/Secrets.xcconfig apps/mobileAppYC/ios/mobileAppYC/Info.plist
+          rm -f apps/mobileAppYC/src/config/variables.local.ts

--- a/scripts/mobile/doctor.mjs
+++ b/scripts/mobile/doctor.mjs
@@ -290,6 +290,60 @@ try {
   warn('react-native-screens', 'could not evaluate; is package.json readable?');
 }
 
+// --- release gate ------------------------------------------------------------
+// `--require-app-config` guards src/config/variables.local.ts, which supplies
+// appleServiceId, appleRedirectUri, googleWebClientId and facebookAppId. The
+// file is gitignored, and variables.ts swallows its absence SILENTLY when
+// CI=true, so a release build without it produces binaries that install and run
+// but whose social sign-in cannot succeed. Nothing else in the build says so.
+//
+// The templates in variables.ts read `com.yourAppName.mobile.auth` and
+// `https://yourDomain.firebaseapp.com/...`. PLACEHOLDER targets SHOUTING
+// markers and deliberately does not match those, so they are matched here.
+const APP_CONFIG_TEMPLATE = /yourAppName|yourDomain/;
+const REQUIRED_APP_CONFIG = [
+  'appleServiceId',
+  'appleRedirectUri',
+  'googleWebClientId',
+  'facebookAppId',
+];
+
+const appConfigProblems = () => {
+  const rel = 'src/config/variables.local.ts';
+  const file = join(root, rel);
+
+  if (!existsSync(file)) {
+    return [`${rel} missing; the MOBILE_VARIABLES_LOCAL_TS secret did not restore`];
+  }
+
+  const body = readFileSync(file, 'utf8');
+  const problems = [];
+
+  if (APP_CONFIG_TEMPLATE.test(body)) {
+    problems.push(`${rel} still carries variables.ts template values`);
+  }
+  for (const key of REQUIRED_APP_CONFIG) {
+    const match = new RegExp(`${key}\\s*:\\s*'([^']*)'`).exec(body);
+    if (!match) {
+      problems.push(`${key} is absent from ${rel}`);
+    } else if (match[1].trim() === '') {
+      problems.push(`${key} is empty in ${rel}`);
+    }
+  }
+  return problems;
+};
+
+if (process.argv.includes('--require-app-config')) {
+  const problems = appConfigProblems();
+  for (const problem of problems) {
+    console.log(`MISSING  ${problem}`);
+  }
+  if (problems.length === 0) {
+    console.log('OK       src/config/variables.local.ts present, social sign-in values set');
+  }
+  process.exit(problems.length === 0 ? 0 : 1);
+}
+
 // --- report ----------------------------------------------------------------
 // `--self-test` pins the placeholder vocabulary against the shipped templates
 // for the files this tool actually inspects, so an edit that makes the regex
@@ -330,6 +384,30 @@ if (process.argv.includes('--self-test')) {
     '<resources><string name="app_name">Yosemite Crew</string></resources>',
     'MAPS_API_KEY=AIzaSyRealLookingKey123',
   ];
+  // The app-config vocabulary is pinned the same way: it must catch the
+  // variables.ts templates and must not condemn the real values.
+  const appTemplates = [
+    "appleServiceId: 'com.yourAppName.mobile.auth',",
+    "appleRedirectUri: 'https://yourDomain.firebaseapp.com/__/auth/handler',",
+  ];
+  const appReal = [
+    "appleServiceId: 'com.yosemitecrew.mobile.auth',",
+    "appleRedirectUri: 'https://yosemite-crew.firebaseapp.com/__/auth/handler',",
+  ];
+  for (const sample of appTemplates) {
+    if (APP_CONFIG_TEMPLATE.test(sample)) {
+      console.log(`FLAGGED  ${sample.slice(0, 40)}`);
+    } else {
+      console.log(`MISSED   ${sample.slice(0, 40)}  <- app-config regex too narrow`);
+      failures += 1;
+    }
+  }
+  const appFalse = appReal.filter((c) => APP_CONFIG_TEMPLATE.test(c));
+  if (appFalse.length > 0) {
+    console.log(`FALSE POSITIVE on ${appFalse.length} real app-config sample(s)`);
+    failures += appFalse.length;
+  }
+
   const falsePositives = filled.filter((c) => PLACEHOLDER.test(c));
   if (falsePositives.length > 0) {
     console.log(`FALSE POSITIVE on ${falsePositives.length} realistic config sample(s)`);


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

`mobile-release.yml` restores `google-services.json`, `strings.xml` and the iOS plists
from secrets, but never restores `apps/mobileAppYC/src/config/variables.local.ts`. That
file is gitignored and is the only source for `appleServiceId`, `appleRedirectUri`,
`googleWebClientId` and `facebookAppId`. The single `process.env` reference in
`variables.ts` is a CI check, so there is no environment variable path for these values.

A release build therefore falls back to the templates in `variables.ts`, and
`variables.ts:244` suppresses its own "No variables.local.ts found" warning when
`CI === 'true'`, so nothing in the build log reports it. The uploaded artifact installs
and runs normally while shipping:

| value | shipped |
| --- | --- |
| `appleServiceId` | `com.yourAppName.mobile.auth` |
| `appleRedirectUri` | `https://yourDomain.firebaseapp.com/__/auth/handler` |
| `googleWebClientId` | empty |

Apple sign in on Android would fail with `Invalid client.` (confirmed directly against
`https://appleid.apple.com/auth/authorize`: our real Service ID returns a 132KB sign in
page with no server error, while a wrong client id returns a ~11KB page carrying
`"errorMessage":"Invalid client."`). Google sign in would take its unconfigured branch on
the empty client id.

This also makes the backend fix in #2285 unobservable, because the app would never send
the real Service ID.

## What is the new behavior?

Both build jobs restore the file from a new `MOBILE_VARIABLES_LOCAL_TS` secret on the
protected `release` environment, remove it in the existing cleanup steps, and gate the
build on `node scripts/mobile/doctor.mjs --require-app-config`. If the secret fails to
restore, or restores something that still carries template values or has an empty
required value, the release stops instead of uploading.

The gate is a separate step from the existing `doctor.mjs` call because that one is
`continue-on-error: true` and so cannot block a bad build.

The templates read `yourAppName` and `yourDomain`. The doctor's existing `PLACEHOLDER`
pattern targets SHOUTING markers (`YOUR_[A-Z_]+`, `CHANGE_ME`) and deliberately does not
match those, so the new check carries its own vocabulary, and `--self-test` now pins that
vocabulary in both directions: it must flag the two `variables.ts` templates and must not
flag the two real values.

### Validation performed

- `--require-app-config` exercised in five states: file absent (fails, naming the secret),
  file is the placeholder copy taken from another worktree (fails on both the template
  marker and the empty values), file is the real config (passes), a required value emptied
  (fails), and a required key removed entirely (fails).
- One of those checks initially passed for the wrong reason: the edit that was supposed to
  empty `googleWebClientId` was a line based substitution and the value is prettier wrapped
  across two lines, so it silently changed nothing. Redone with a multiline aware edit,
  after which it fails as intended.
- `node scripts/mobile/doctor.mjs --self-test` passes, including the two new assertions.
- Workflow YAML parses; both build jobs carry the secret and the gate step.
- `apps/mobileAppYC` config tests pass (9/9).

### Not included

An earlier revision also removed the `CI !== 'true'` suppression in `variables.ts` so a
missing file would be loud in CI. That is covered by an existing test,
"suppresses console warning in CI even outside test environment", so the suppression is a
deliberate documented choice and was left alone. The gate here blocks releases
deterministically and does not depend on anyone reading a warning.

## Related Issue(s)

Follow-up to #2285, which fixed the backend half of Apple sign in on Android. Found while
verifying that fix end to end. No separate issue.
