### PR TITLE
fix(backend): bind clinical records to the caller's organisation

### DIFF
--- a/apps/backend/src/services/deceased-record.service.ts
+++ b/apps/backend/src/services/deceased-record.service.ts
@@ -1,6 +1,7 @@
 import { prisma } from "src/config/prisma";
 import { AuditTrailService } from "./audit-trail.service";
 import type { Prisma } from "@prisma/client";
+import { assertPatientOrgMembership } from "./shared/patient-org-membership";
 
 export class DeceasedRecordError extends Error {
   constructor(
@@ -89,6 +90,13 @@ const assertDeceasedRecord = async (id: string, organisationId: string) => {
 export const DeceasedRecordService = {
   async create(params: CreateDeceasedRecordParams) {
     const { organisationId, patientId, recordedBy, ...rest } = params;
+
+    // The caller is authenticated against this organisation, but the patient id
+    // arrives from the request. Without this the row would be written against
+    // another tenant's companion, invisible to every view that scopes by org.
+    await assertPatientOrgMembership(patientId, organisationId, () => {
+      throw new DeceasedRecordError("Companion not found.", 404);
+    });
 
     const existing = await prisma.deceasedRecord.findUnique({
       where: { patientId },

--- a/apps/backend/src/services/estimate.service.ts
+++ b/apps/backend/src/services/estimate.service.ts
@@ -1,6 +1,7 @@
 import { prisma } from "src/config/prisma";
 import { AuditTrailService } from "./audit-trail.service";
 import type { Prisma } from "@prisma/client";
+import { assertPatientOrgMembership } from "./shared/patient-org-membership";
 
 export class EstimateError extends Error {
   constructor(
@@ -13,12 +14,7 @@ export class EstimateError extends Error {
 }
 
 type EstimateStatus =
-  | "DRAFT"
-  | "SENT"
-  | "APPROVED"
-  | "DECLINED"
-  | "EXPIRED"
-  | "CONVERTED";
+  "DRAFT" | "SENT" | "APPROVED" | "DECLINED" | "EXPIRED" | "CONVERTED";
 
 export interface EstimateItemInput {
   description: string;
@@ -111,6 +107,13 @@ const assertEstimate = async (id: string, organisationId: string) => {
 export const EstimateService = {
   async create(params: CreateEstimateParams) {
     const { organisationId, patientId, createdBy, items, ...rest } = params;
+
+    // The caller is authenticated against this organisation, but the patient id
+    // arrives from the request. Without this the row would be written against
+    // another tenant's companion, invisible to every view that scopes by org.
+    await assertPatientOrgMembership(patientId, organisationId, () => {
+      throw new EstimateError("Companion not found.", 404);
+    });
     const { subtotal, taxAmount, total } = computeTotals(items);
 
     const estimate = await prisma.estimate.create({

--- a/apps/backend/src/services/medical-certificate.service.ts
+++ b/apps/backend/src/services/medical-certificate.service.ts
@@ -1,6 +1,7 @@
 import { prisma } from "src/config/prisma";
 import { AuditTrailService } from "./audit-trail.service";
 import type { Prisma } from "@prisma/client";
+import { assertPatientOrgMembership } from "./shared/patient-org-membership";
 
 export class MedicalCertificateError extends Error {
   constructor(
@@ -85,6 +86,16 @@ const assertCertificate = async (id: string, organisationId: string) => {
 
 export const MedicalCertificateService = {
   async create(params: CreateCertificateParams) {
+    // The caller is authenticated against this organisation, but the patient id
+    // arrives from the request. Without this the row would be written against
+    // another tenant's companion, invisible to every view that scopes by org.
+    await assertPatientOrgMembership(
+      params.patientId,
+      params.organisationId,
+      () => {
+        throw new MedicalCertificateError("Companion not found.", 404);
+      },
+    );
     return prisma.medicalCertificate.create({
       data: {
         organisationId: params.organisationId,

--- a/apps/backend/src/services/patient-flag.service.ts
+++ b/apps/backend/src/services/patient-flag.service.ts
@@ -1,6 +1,7 @@
 import { prisma } from "src/config/prisma";
 import { AuditTrailService } from "./audit-trail.service";
 import type { Prisma } from "@prisma/client";
+import { assertPatientOrgMembership } from "./shared/patient-org-membership";
 
 export class PatientFlagError extends Error {
   constructor(
@@ -62,6 +63,16 @@ const assertFlag = async (id: string, organisationId: string) => {
 
 export const PatientFlagService = {
   async create(params: CreateFlagParams) {
+    // The caller is authenticated against this organisation, but the patient id
+    // arrives from the request. Without this the row would be written against
+    // another tenant's companion, invisible to every view that scopes by org.
+    await assertPatientOrgMembership(
+      params.patientId,
+      params.organisationId,
+      () => {
+        throw new PatientFlagError("Companion not found.", 404);
+      },
+    );
     const flag = await prisma.patientFlag.create({
       data: {
         organisationId: params.organisationId,

--- a/apps/backend/src/services/qol-assessment.service.ts
+++ b/apps/backend/src/services/qol-assessment.service.ts
@@ -1,6 +1,7 @@
 import { prisma } from "src/config/prisma";
 import { AuditTrailService } from "./audit-trail.service";
 import type { Prisma } from "@prisma/client";
+import { assertPatientOrgMembership } from "./shared/patient-org-membership";
 
 export class QolAssessmentError extends Error {
   constructor(
@@ -80,6 +81,13 @@ const assertRecord = async (id: string, organisationId: string) => {
 export const QolAssessmentService = {
   async create(params: CreateQolParams) {
     const { organisationId, patientId, assessedBy, ...rest } = params;
+
+    // The caller is authenticated against this organisation, but the patient id
+    // arrives from the request. Without this the row would be written against
+    // another tenant's companion, invisible to every view that scopes by org.
+    await assertPatientOrgMembership(patientId, organisationId, () => {
+      throw new QolAssessmentError("Companion not found.", 404);
+    });
 
     const record = await prisma.qualityOfLifeAssessment.create({
       data: {

--- a/apps/backend/src/services/surgical-checklist.service.ts
+++ b/apps/backend/src/services/surgical-checklist.service.ts
@@ -1,6 +1,7 @@
 import { prisma } from "src/config/prisma";
 import { AuditTrailService } from "./audit-trail.service";
 import type { Prisma } from "@prisma/client";
+import { assertPatientOrgMembership } from "./shared/patient-org-membership";
 
 export class SurgicalChecklistError extends Error {
   constructor(
@@ -91,6 +92,13 @@ export const SurgicalChecklistService = {
       conductedBy,
       ...rest
     } = params;
+
+    // The caller is authenticated against this organisation, but the patient id
+    // arrives from the request. Without this the row would be written against
+    // another tenant's companion, invisible to every view that scopes by org.
+    await assertPatientOrgMembership(patientId, organisationId, () => {
+      throw new SurgicalChecklistError("Companion not found.", 404);
+    });
 
     const checklist = await prisma.surgicalChecklist.create({
       data: {

--- a/apps/backend/src/services/treatment-outcome.service.ts
+++ b/apps/backend/src/services/treatment-outcome.service.ts
@@ -1,6 +1,7 @@
 import { prisma } from "src/config/prisma";
 import { AuditTrailService } from "./audit-trail.service";
 import type { Prisma } from "@prisma/client";
+import { assertPatientOrgMembership } from "./shared/patient-org-membership";
 
 export class TreatmentOutcomeError extends Error {
   constructor(
@@ -64,6 +65,16 @@ const assertOutcome = async (id: string, organisationId: string) => {
 
 export const TreatmentOutcomeService = {
   async record(params: CreateOutcomeParams) {
+    // The caller is authenticated against this organisation, but the patient id
+    // arrives from the request. Without this the row would be written against
+    // another tenant's companion, invisible to every view that scopes by org.
+    await assertPatientOrgMembership(
+      params.patientId,
+      params.organisationId,
+      () => {
+        throw new TreatmentOutcomeError("Companion not found.", 404);
+      },
+    );
     const outcome = await prisma.treatmentOutcome.create({
       data: {
         organisationId: params.organisationId,

--- a/apps/backend/test/services/deceased-record.service.test.ts
+++ b/apps/backend/test/services/deceased-record.service.test.ts
@@ -2,6 +2,7 @@ import { DeceasedRecordService } from "../../src/services/deceased-record.servic
 
 jest.mock("src/config/prisma", () => ({
   prisma: {
+    patientOrganisation: { findFirst: jest.fn() },
     patient: { update: jest.fn() },
     $transaction: jest.fn(),
     deceasedRecord: {
@@ -49,6 +50,9 @@ const baseRecord = {
 };
 
 beforeEach(() => {
+  (prisma.patientOrganisation.findFirst as jest.Mock).mockResolvedValue({
+    id: "patient-org-1",
+  });
   jest.clearAllMocks();
   // create() deactivates the patient alongside the record in one transaction.
   mockPatientUpdate.mockResolvedValue({ id: "pat-1", status: "inactive" });
@@ -182,5 +186,25 @@ describe("DeceasedRecordService.update", () => {
     await expect(
       DeceasedRecordService.update("dr-x", "org-1", { notes: "x" }),
     ).rejects.toMatchObject({ statusCode: 404 });
+  });
+});
+
+describe("DeceasedRecordService cross-tenant protection", () => {
+  it("refuses to write against a companion in another organisation", async () => {
+    // The caller is a legitimate member of org-1; the companion is not.
+    (prisma.patientOrganisation.findFirst as jest.Mock).mockResolvedValue(null);
+
+    await expect(
+      DeceasedRecordService.create({
+        organisationId: "org-1",
+        patientId: "pat-1",
+        deceasedAt: new Date("2026-08-01T10:00:00Z"),
+        causeOfDeathType: "EUTHANASIA",
+      }),
+    ).rejects.toThrow("Companion not found.");
+
+    // Rejecting is not enough - nothing may be persisted on the way out.
+    expect(prisma.$transaction as jest.Mock).not.toHaveBeenCalled();
+    expect(prisma.patient.update as jest.Mock).not.toHaveBeenCalled();
   });
 });

--- a/apps/backend/test/services/estimate.service.test.ts
+++ b/apps/backend/test/services/estimate.service.test.ts
@@ -2,6 +2,7 @@ import { EstimateService } from "../../src/services/estimate.service";
 
 jest.mock("src/config/prisma", () => ({
   prisma: {
+    patientOrganisation: { findFirst: jest.fn() },
     estimate: {
       create: jest.fn(),
       findFirst: jest.fn(),
@@ -57,7 +58,19 @@ const baseEstimate = {
   items: [baseItem],
 };
 
-beforeEach(() => jest.clearAllMocks());
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  // Default: the companion belongs to the caller's organisation, so every
+
+  // pre-existing case keeps its original meaning. Cross-tenant is asserted
+
+  // explicitly in its own test below.
+
+  (prisma.patientOrganisation.findFirst as jest.Mock).mockResolvedValue({
+    id: "patient-org-1",
+  });
+});
 
 describe("EstimateService.create", () => {
   it("creates estimate and computes totals from items", async () => {
@@ -243,5 +256,31 @@ describe("EstimateService.delete", () => {
     await expect(
       EstimateService.delete("est-x", "org-1"),
     ).rejects.toMatchObject({ statusCode: 404 });
+  });
+});
+
+describe("EstimateService cross-tenant protection", () => {
+  it("refuses to write against a companion in another organisation", async () => {
+    // The caller is a legitimate member of org-1; the companion is not.
+    (prisma.patientOrganisation.findFirst as jest.Mock).mockResolvedValue(null);
+
+    await expect(
+      EstimateService.create({
+        organisationId: "org-1",
+        patientId: "pat-1",
+        items: [
+          {
+            description: "Spay procedure",
+            quantity: 1,
+            unitPrice: 250,
+            taxRate: 20,
+          },
+        ],
+        createdBy: "vet-1",
+      }),
+    ).rejects.toThrow("Companion not found.");
+
+    // Rejecting is not enough - nothing may be persisted on the way out.
+    expect(prisma.estimate.create as jest.Mock).not.toHaveBeenCalled();
   });
 });

--- a/apps/backend/test/services/medical-certificate.service.test.ts
+++ b/apps/backend/test/services/medical-certificate.service.test.ts
@@ -1,5 +1,6 @@
 jest.mock("src/config/prisma", () => ({
   prisma: {
+    patientOrganisation: { findFirst: jest.fn() },
     medicalCertificate: {
       create: jest.fn(),
       findFirst: jest.fn(),
@@ -45,7 +46,15 @@ const baseCert = {
 };
 
 describe("MedicalCertificateService", () => {
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: the companion belongs to the caller's organisation, so every
+    // pre-existing case keeps its original meaning. Cross-tenant is asserted
+    // explicitly in its own test below.
+    (prisma.patientOrganisation.findFirst as jest.Mock).mockResolvedValue({
+      id: "patient-org-1",
+    });
+  });
 
   describe("create", () => {
     it("creates a certificate in DRAFT status", async () => {
@@ -227,5 +236,26 @@ describe("MedicalCertificateService", () => {
         MedicalCertificateService.expire("cert-1", "org-1"),
       ).rejects.toThrow(MedicalCertificateError);
     });
+  });
+});
+
+describe("MedicalCertificateService cross-tenant protection", () => {
+  it("refuses to write against a companion in another organisation", async () => {
+    // The caller is a legitimate member of org-1; the companion is not.
+    (prisma.patientOrganisation.findFirst as jest.Mock).mockResolvedValue(null);
+
+    await expect(
+      MedicalCertificateService.create({
+        organisationId: "org-1",
+        patientId: "patient-1",
+        clientId: "client-1",
+        certificateType: "HEALTH_CERTIFICATE",
+      }),
+    ).rejects.toThrow("Companion not found.");
+
+    // Rejecting is not enough - nothing may be persisted on the way out.
+    expect(
+      prisma.medicalCertificate.create as jest.Mock,
+    ).not.toHaveBeenCalled();
   });
 });

--- a/apps/backend/test/services/patient-flag.service.test.ts
+++ b/apps/backend/test/services/patient-flag.service.test.ts
@@ -5,6 +5,7 @@ import {
 
 jest.mock("src/config/prisma", () => ({
   prisma: {
+    patientOrganisation: { findFirst: jest.fn() },
     patientFlag: {
       create: jest.fn(),
       findFirst: jest.fn(),
@@ -50,7 +51,19 @@ const resolvedFlag = {
   resolvedBy: "user-2",
 };
 
-beforeEach(() => jest.clearAllMocks());
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  // Default: the companion belongs to the caller's organisation, so every
+
+  // pre-existing case keeps its original meaning. Cross-tenant is asserted
+
+  // explicitly in its own test below.
+
+  (prisma.patientOrganisation.findFirst as jest.Mock).mockResolvedValue({
+    id: "patient-org-1",
+  });
+});
 
 describe("PatientFlagService.create", () => {
   it("defaults severity to MEDIUM, activates the flag and records an audit event", async () => {
@@ -324,5 +337,24 @@ describe("PatientFlagService.resolve", () => {
       PatientFlagService.resolve("flag-1", "org-2"),
     ).rejects.toMatchObject({ statusCode: 404 });
     expect(mockUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe("PatientFlagService cross-tenant protection", () => {
+  it("refuses to write against a companion in another organisation", async () => {
+    // The caller is a legitimate member of org-1; the companion is not.
+    (prisma.patientOrganisation.findFirst as jest.Mock).mockResolvedValue(null);
+
+    await expect(
+      PatientFlagService.create({
+        organisationId: "org-1",
+        patientId: "pat-1",
+        flagType: "ESCAPE_RISK",
+        title: "Slips the lead",
+      }),
+    ).rejects.toThrow("Companion not found.");
+
+    // Rejecting is not enough - nothing may be persisted on the way out.
+    expect(prisma.patientFlag.create as jest.Mock).not.toHaveBeenCalled();
   });
 });

--- a/apps/backend/test/services/qol-assessment.service.test.ts
+++ b/apps/backend/test/services/qol-assessment.service.test.ts
@@ -2,6 +2,7 @@ import { QolAssessmentService } from "../../src/services/qol-assessment.service"
 
 jest.mock("src/config/prisma", () => ({
   prisma: {
+    patientOrganisation: { findFirst: jest.fn() },
     qualityOfLifeAssessment: {
       create: jest.fn(),
       findFirst: jest.fn(),
@@ -47,7 +48,19 @@ const baseAssessment = {
   updatedAt: new Date(),
 };
 
-beforeEach(() => jest.clearAllMocks());
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  // Default: the companion belongs to the caller's organisation, so every
+
+  // pre-existing case keeps its original meaning. Cross-tenant is asserted
+
+  // explicitly in its own test below.
+
+  (prisma.patientOrganisation.findFirst as jest.Mock).mockResolvedValue({
+    id: "patient-org-1",
+  });
+});
 
 describe("QolAssessmentService.create", () => {
   it("creates a QoL assessment with HHHHHMM score", async () => {
@@ -142,5 +155,28 @@ describe("QolAssessmentService.delete", () => {
     ).rejects.toMatchObject({
       statusCode: 404,
     });
+  });
+});
+
+describe("QolAssessmentService cross-tenant protection", () => {
+  it("refuses to write against a companion in another organisation", async () => {
+    // The caller is a legitimate member of org-1; the companion is not.
+    (prisma.patientOrganisation.findFirst as jest.Mock).mockResolvedValue(null);
+
+    await expect(
+      QolAssessmentService.create({
+        organisationId: "org-1",
+        patientId: "pat-1",
+        assessedAt: new Date("2026-06-30T10:00:00Z"),
+        hhhhhmmScore: 42,
+        overallScore: 45,
+        euthanasiaDiscussed: true,
+      }),
+    ).rejects.toThrow("Companion not found.");
+
+    // Rejecting is not enough - nothing may be persisted on the way out.
+    expect(
+      prisma.qualityOfLifeAssessment.create as jest.Mock,
+    ).not.toHaveBeenCalled();
   });
 });

--- a/apps/backend/test/services/surgical-checklist.service.test.ts
+++ b/apps/backend/test/services/surgical-checklist.service.test.ts
@@ -2,6 +2,7 @@ import { SurgicalChecklistService } from "../../src/services/surgical-checklist.
 
 jest.mock("src/config/prisma", () => ({
   prisma: {
+    patientOrganisation: { findFirst: jest.fn() },
     surgicalChecklist: {
       create: jest.fn(),
       findFirst: jest.fn(),
@@ -55,7 +56,19 @@ const baseChecklist = {
   items: [baseItem],
 };
 
-beforeEach(() => jest.clearAllMocks());
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  // Default: the companion belongs to the caller's organisation, so every
+
+  // pre-existing case keeps its original meaning. Cross-tenant is asserted
+
+  // explicitly in its own test below.
+
+  (prisma.patientOrganisation.findFirst as jest.Mock).mockResolvedValue({
+    id: "patient-org-1",
+  });
+});
 
 describe("SurgicalChecklistService.create", () => {
   it("creates a SIGN_IN checklist with items", async () => {
@@ -238,5 +251,25 @@ describe("SurgicalChecklistService.delete", () => {
     await expect(
       SurgicalChecklistService.delete("sc-1", "org-1"),
     ).rejects.toMatchObject({ statusCode: 409 });
+  });
+});
+
+describe("SurgicalChecklistService cross-tenant protection", () => {
+  it("refuses to write against a companion in another organisation", async () => {
+    // The caller is a legitimate member of org-1; the companion is not.
+    (prisma.patientOrganisation.findFirst as jest.Mock).mockResolvedValue(null);
+
+    await expect(
+      SurgicalChecklistService.create({
+        organisationId: "org-1",
+        patientId: "pat-1",
+        encounterId: "enc-1",
+        phase: "SIGN_IN",
+        items: [{ label: "Patient identity confirmed" }],
+      }),
+    ).rejects.toThrow("Companion not found.");
+
+    // Rejecting is not enough - nothing may be persisted on the way out.
+    expect(prisma.surgicalChecklist.create as jest.Mock).not.toHaveBeenCalled();
   });
 });

--- a/apps/backend/test/services/treatment-outcome.service.test.ts
+++ b/apps/backend/test/services/treatment-outcome.service.test.ts
@@ -1,5 +1,6 @@
 jest.mock("src/config/prisma", () => ({
   prisma: {
+    patientOrganisation: { findFirst: jest.fn() },
     treatmentOutcome: {
       create: jest.fn(),
       findFirst: jest.fn(),
@@ -39,7 +40,15 @@ const baseOutcome = {
 };
 
 describe("TreatmentOutcomeService", () => {
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: the companion belongs to the caller's organisation, so every
+    // pre-existing case keeps its original meaning. Cross-tenant is asserted
+    // explicitly in its own test below.
+    (prisma.patientOrganisation.findFirst as jest.Mock).mockResolvedValue({
+      id: "patient-org-1",
+    });
+  });
 
   describe("record", () => {
     it("creates an outcome record", async () => {
@@ -207,5 +216,26 @@ describe("TreatmentOutcomeService", () => {
       );
       expect(result.resolved).toBe(true);
     });
+  });
+});
+
+describe("TreatmentOutcomeService cross-tenant protection", () => {
+  it("refuses to write against a companion in another organisation", async () => {
+    // The caller is a legitimate member of org-1; the companion is not.
+    (prisma.patientOrganisation.findFirst as jest.Mock).mockResolvedValue(null);
+
+    await expect(
+      TreatmentOutcomeService.record({
+        organisationId: "org-1",
+        patientId: "patient-1",
+        recordedAt: new Date("2026-08-01T10:00:00Z"),
+        recordedBy: "vet-1",
+        outcomeType: "IMPROVED",
+        clinicalNotes: "Patient showing improvement",
+      }),
+    ).rejects.toThrow("Companion not found.");
+
+    // Rejecting is not enough - nothing may be persisted on the way out.
+    expect(prisma.treatmentOutcome.create as jest.Mock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What changed

Seven services accepted a `patientId` from the request and persisted against it without checking that the companion belongs to the caller's organisation. Each create path now asserts membership first.

Guarded: `deceased-record`, `medical-certificate`, `patient-flag`, `qol-assessment`, `surgical-checklist`, `treatment-outcome`, `estimate`.

## Why

`withOrgPermissions()` (`middlewares/rbac.ts`) proves the **caller** belongs to the organisation named in the URL. It does not prove the **companion** does. The controllers read `organisationId` and `patientId` from `req.params` and pass both straight through, so an authenticated user of org A holding an org B patient id could write clinical records against another tenant's companion.

`deceased-record` is the sharpest case, because `create()` also ran:

```ts
prisma.patient.update({ where: { id: patientId }, data: { status: "inactive" } })
```

a global update by id. A user with `companions:edit:any` - which includes `RECEPTIONIST` - could mark another organisation's pet deceased and suppress its vaccine reminders. Patient ids are obtainable rather than secret: the public passport and companion card responses expose `identity.id`.

Originally reported by the Codex reviewer on #2287 against `deceased-record` alone. Auditing the family found the same gap in six more.

## Approach

No new mechanism. `assertPatientOrgMembership` already exists in `src/services/shared/patient-org-membership.ts`, its doc comment describes precisely this failure mode, and `pet-passport.service.ts` already calls it. These seven had simply never adopted it.

Each service raises its own typed error through the helper's `throwNotFound` callback, all with the uniform `"Companion not found."` 404, so the endpoints cannot be used to probe which patient ids exist. In `deceased-record` the assertion runs before the existing-record lookup, so it cannot leak whether another tenant's companion already has a record.

## Validation performed

- **252 tests across 14 suites pass** (245 before, plus 7 new).
- Each service gains a test that mocks the membership lookup empty and asserts **both** that the call rejects **and** that nothing was persisted. Rejecting is not enough on its own.
- **Mutation-checked.** With all seven guards deleted, exactly seven tests fail, one per service. The tests detect the guard's absence rather than merely passing alongside it. Guards restored, suite green again.
- `tsc`: no new errors against `dev` - 411 on both sides, error sets identical once line numbers are normalised.
- Backend eslint: 12367 problems vs 12368 on `dev`. One fewer, because the added `await` satisfies a `require-await` finding. The 12k are a pre-existing prisma type-resolution issue in the worktree and affect files this PR does not touch.

## Not in scope

- `task.service.ts` has the same shape - `assertCompanionRequirement` checks that a `patientId` is present, never that it belongs to the org - across four create paths. It is a 1700-line core service and its create inputs do not obviously carry an `organisationId`, so it needs its own change rather than being bolted onto this one.
- `appointment-reminder-log` keys on `appointmentId` and `clientId` rather than `patientId`. Same class of question, different entity, not assessed here.

Both are worth their own issue.

## Impact area

`apps/backend` only. No schema change, no API surface change. Callers acting within their own organisation are unaffected; cross-tenant writes that previously succeeded now return 404.