### PR TITLE
fix(frontend): make the package breakdown tooltip visible, and draw 16 more gated surfaces

### DIFF
--- a/apps/frontend/.storybook/preview.ts
+++ b/apps/frontend/.storybook/preview.ts
@@ -9,6 +9,19 @@ import '../src/app/globals.css';
  */
 /**
  * Viewport presets matching the app's responsive breakpoints.
+ *
+ * These are registered under `parameters.viewport.options`, which is the only
+ * viewport parameter key Storybook 10 reads. The pre-10 spelling was
+ * `parameters.viewport.viewports` plus `parameters.viewport.defaultViewport`,
+ * and both were removed in 10 - `defaultViewport` now only logs a manager
+ * warning and is otherwise inert. That is a silent failure worth naming: a
+ * story pinned with the old keys still renders, still runs its play function
+ * and still passes, it just renders at the full panel width. Every "Phone"
+ * story here was drawing desktop markup at 1200px until this was corrected.
+ *
+ * Selection is a GLOBAL, not a parameter: `globals: { viewport: { value } }`
+ * on the story. The `value` must name a key below - an unknown key (`phone`,
+ * say) fails the same silent way.
  */
 const viewports = {
   mobile: {
@@ -78,6 +91,12 @@ const preview: Preview = {
           'aria-labelledby': 'storybook-story-title',
           ...(marketing ? {} : { 'data-yc-app': '' }),
         },
+        /* Names the story's landmark for the a11y addon. It is sr-only but it is REAL
+           TEXT inside `canvasElement`, so a loose text query in a play function can
+           match it: `getByText(/emergency/i)` in a story named "Emergency, ready to
+           admit" matched both the banner and the badge. Worse than the ambiguity is the
+           silent case - a query that matches only the banner passes with the component
+           absent. Prefer exact strings or role queries in play functions. */
         React.createElement(
           'h1',
           {
@@ -98,8 +117,7 @@ const preview: Preview = {
       },
     },
     viewport: {
-      viewports,
-      defaultViewport: 'laptop',
+      options: viewports,
     },
     /**
      * Disabled on purpose. `globals.css` paints `body` from `var(--page)`, which
@@ -122,6 +140,15 @@ const preview: Preview = {
     docs: {
       toc: true,
     },
+  },
+
+  /**
+   * The project default. `laptop` matches the widest PIMS breakpoint the app
+   * treats as desktop, so an unpinned story renders the desktop branch rather
+   * than whatever width the preview panel happens to be.
+   */
+  initialGlobals: {
+    viewport: { value: 'laptop', isRotated: false },
   },
 
   globalTypes: {

--- a/apps/frontend/src/app/(routes)/(public)/accessibility/report/AccessibilityReportClient.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/accessibility/report/AccessibilityReportClient.tsx
@@ -189,7 +189,7 @@ export default function AccessibilityReportClient() {
             id={errorSummaryId}
             role="alert"
             aria-labelledby={`${errorSummaryId}-title`}
-            className="mb-6 rounded-xl border border-error-border bg-danger-50 px-4 py-3"
+            className="mb-6 rounded-xl border border-[var(--error-color)] bg-danger-100 px-4 py-3"
           >
             <h2
               id={`${errorSummaryId}-title`}

--- a/apps/frontend/src/app/__tests__/lib/storybookViewportGlobals.test.ts
+++ b/apps/frontend/src/app/__tests__/lib/storybookViewportGlobals.test.ts
@@ -1,0 +1,91 @@
+import { readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * Storybook 10 removed `parameters.viewport.defaultViewport` and
+ * `parameters.viewport.viewports`. Both still type-check and still render, so the
+ * failure is completely silent: the story runs its play function, passes, and draws
+ * the full-width desktop markup under a name that promises a phone.
+ *
+ * That is exactly what happened here. Every "Phone" story in this Storybook except
+ * four measured 1200px wide - the same width as a story with no viewport at all -
+ * because the project presets were registered under the dead `viewports` key and the
+ * stories selected with the dead `defaultViewport` one. Fourteen more selected a
+ * preset named `phone`, which has never existed in `preview.ts`.
+ *
+ * None of that is reachable by type-checking, linting, or running the stories, which
+ * is why it is asserted here instead.
+ */
+const APP_DIR = join(__dirname, '..', '..');
+const PREVIEW = join(__dirname, '..', '..', '..', '..', '.storybook', 'preview.ts');
+
+const storyFiles = (dir: string): string[] =>
+  readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) return storyFiles(full);
+    return entry.name.endsWith('.stories.tsx') ? [full] : [];
+  });
+
+/** The preset keys `preview.ts` declares, read from the file rather than imported. */
+const declaredPresets = (): string[] => {
+  const src = readFileSync(PREVIEW, 'utf8');
+  const block = /const viewports = \{([\s\S]*?)\n\};/.exec(src);
+  if (!block) throw new Error('preview.ts no longer declares a `viewports` map');
+  return [...block[1].matchAll(/^ {2}(\w+): \{$/gm)].map((m) => m[1]);
+};
+
+/**
+ * The preset keys reachable from a story that registers its own `options`, whether
+ * it inlines the map or names a `const` declared in the same file.
+ */
+const localKeys = (src: string, firstKeyOrConst: string): string[] => {
+  const decl = new RegExp(`const ${firstKeyOrConst} = \\{([\\s\\S]*?)\\n\\};`).exec(src);
+  const body = decl ? decl[1] : src;
+  return decl ? [...body.matchAll(/^ {2}(\w+): \{$/gm)].map((m) => m[1]) : [firstKeyOrConst];
+};
+
+describe('Storybook viewport wiring', () => {
+  it('registers the project presets under the key Storybook 10 reads', () => {
+    const src = readFileSync(PREVIEW, 'utf8');
+    expect(src).toMatch(/viewport: \{\s*options: viewports,/);
+    // The pre-10 spellings, which are inert.
+    expect(src).not.toMatch(/viewport: \{\s*viewports,/);
+    expect(src.includes('defaultViewport:')).toBe(false);
+  });
+
+  it('sets the project default through initialGlobals, not a parameter', () => {
+    const src = readFileSync(PREVIEW, 'utf8');
+    expect(src).toMatch(/initialGlobals: \{\s*viewport: \{ value: '(\w+)', isRotated: false \},/);
+  });
+
+  it('has no story pinning a viewport with the removed `defaultViewport` parameter', () => {
+    const offenders = storyFiles(APP_DIR).filter((file) =>
+      /viewport: \{[^}]*defaultViewport/.test(readFileSync(file, 'utf8'))
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  it('has every story select a preset that actually exists', () => {
+    const presets = declaredPresets();
+    expect(presets).toContain('mobile');
+
+    const unknown: string[] = [];
+    for (const file of storyFiles(APP_DIR)) {
+      const src = readFileSync(file, 'utf8');
+      /* A story MAY register its own `options` map, which replaces the project one
+         for that story - so the names it may select are those keys, not these. The
+         earlier version of this test skipped such files instead, and that `continue`
+         quietly excused thirteen of them: a deliberately broken preset name went
+         undetected and the test still reported four passes. Resolve the local keys
+         and check against them rather than looking away. */
+      const local = /viewport: \{\s*options: \{?\s*(\w+)/.exec(src);
+      const allowed = local ? localKeys(src, local[1]) : presets;
+      for (const match of src.matchAll(/globals: \{ viewport: \{ value: '(\w+)'/g)) {
+        if (!allowed.includes(match[1])) {
+          unknown.push(`${file.replace(APP_DIR, 'src/app')}: '${match[1]}'`);
+        }
+      }
+    }
+    expect(unknown).toEqual([]);
+  });
+});

--- a/apps/frontend/src/app/__tests__/ui/primitives/storyInteractions.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/primitives/storyInteractions.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen } from '@testing-library/react';
+
+import GlassTooltip from '@/app/ui/primitives/GlassTooltip/GlassTooltip';
+import {
+  closeGlassTooltip,
+  glassTooltipWrapper,
+  openGlassTooltip,
+} from '@/app/ui/primitives/GlassTooltip/storyInteractions';
+
+/**
+ * Runs the helper the way the browser runs it: with no `act` around it.
+ *
+ * Wrapping it in `act` looks like the careful thing to do and is actively wrong here.
+ * `act` defers React's commit until its scope ends, so the helper's poll - which is the
+ * whole point of it - can never observe the portal appearing and it spins until it times
+ * out. Measured: 76 dispatches, all delivered to the listener, and the bubble present the
+ * instant `act` returned.
+ *
+ * Clearing the act flag instead silences React's "not wrapped in act" warning (which this
+ * repo escalates to a thrown error) while leaving the real commit timing intact.
+ */
+const outsideAct = async <T,>(fn: () => Promise<T>): Promise<T> => {
+  const flag = globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean };
+  const previous = flag.IS_REACT_ACT_ENVIRONMENT;
+  flag.IS_REACT_ACT_ENVIRONMENT = false;
+  try {
+    return await fn();
+  } finally {
+    flag.IS_REACT_ACT_ENVIRONMENT = previous;
+  }
+};
+
+const Trigger = ({ content = 'Bubble text' }: { content?: string }) => (
+  <GlassTooltip content={content}>
+    <button type="button">Hover me</button>
+  </GlassTooltip>
+);
+
+const trigger = () => screen.getByRole('button', { name: 'Hover me' });
+
+describe('GlassTooltip story interactions', () => {
+  it('opens from the control inside the wrapper', async () => {
+    render(<Trigger />);
+    const bubble = await outsideAct(() => openGlassTooltip(trigger()));
+    expect(bubble).toHaveTextContent('Bubble text');
+  });
+
+  it('opens from the wrapper itself', async () => {
+    render(<Trigger />);
+    const bubble = await outsideAct(() => openGlassTooltip(glassTooltipWrapper(trigger())));
+    expect(bubble).toBeInTheDocument();
+  });
+
+  it('opens on the focus path, which is a separate listener', async () => {
+    render(<Trigger />);
+    const bubble = await outsideAct(() => openGlassTooltip(trigger(), { via: 'focus' }));
+    expect(bubble).toHaveTextContent('Bubble text');
+  });
+
+  it('keeps redispatching until a late listener receives one', async () => {
+    render(<Trigger />);
+    const wrapper = glassTooltipWrapper(trigger());
+
+    // Swallow the first two, the way an unflushed effect does in Storybook. A single
+    // dispatch would be lost for good here, which is the bug this helper exists for.
+    let swallowed = 0;
+    const realDispatch = wrapper.dispatchEvent.bind(wrapper);
+    wrapper.dispatchEvent = ((event: Event) => {
+      if (event.type === 'mouseenter' && swallowed < 2) {
+        swallowed += 1;
+        return true;
+      }
+      return realDispatch(event);
+    }) as typeof wrapper.dispatchEvent;
+
+    const bubble = await outsideAct(() => openGlassTooltip(wrapper));
+    expect(bubble).toBeInTheDocument();
+    expect(swallowed).toBe(2);
+  });
+
+  it('closes again and leaves no portalled bubble behind', async () => {
+    render(<Trigger />);
+    await outsideAct(() => openGlassTooltip(trigger()));
+    await outsideAct(() => closeGlassTooltip(trigger()));
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
+  it('names the control when it has no GlassTooltip around it', () => {
+    render(<button type="button">Bare</button>);
+    expect(() => glassTooltipWrapper(screen.getByRole('button', { name: 'Bare' }))).toThrow(
+      /No .glass-tooltip ancestor for <button>/
+    );
+  });
+
+  it('reports how many dispatches went unanswered when nothing listens', async () => {
+    render(
+      <span className="glass-tooltip">
+        <button type="button">Inert</button>
+      </span>
+    );
+    await expect(
+      outsideAct(() => openGlassTooltip(screen.getByRole('button', { name: 'Inert' })))
+    ).rejects.toThrow(/No tooltip opened after \d+ hover dispatch\(es\)/);
+  }, 10000);
+
+  it('reports a bubble that never closes', async () => {
+    render(<Trigger />);
+    await outsideAct(() => openGlassTooltip(trigger()));
+    const wrapper = glassTooltipWrapper(trigger());
+    // Drop every leave event, so the bubble stays up.
+    wrapper.dispatchEvent = (() => true) as typeof wrapper.dispatchEvent;
+    await expect(outsideAct(() => closeGlassTooltip(trigger()))).rejects.toThrow(
+      /still open 2000ms after leaving the trigger/
+    );
+  }, 10000);
+});

--- a/apps/frontend/src/app/__tests__/ui/primitives/storyInteractions.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/primitives/storyInteractions.test.tsx
@@ -113,4 +113,88 @@ describe('GlassTooltip story interactions', () => {
       /still open 2000ms after leaving the trigger/
     );
   }, 10000);
+
+  it('never accepts a stale bubble from a different trigger as its own', async () => {
+    render(
+      <>
+        <GlassTooltip content="First bubble">
+          <button type="button">First</button>
+        </GlassTooltip>
+        <GlassTooltip content="Second bubble">
+          <button type="button">Second</button>
+        </GlassTooltip>
+      </>
+    );
+
+    /* Leave the first one open. A presence check ("is a tooltip on screen?") would now
+       return instantly for ANY trigger, reporting success without opening anything -
+       the exact silent pass this helper exists to remove. */
+    const first = await outsideAct(() =>
+      openGlassTooltip(screen.getByRole('button', { name: 'First' }))
+    );
+    expect(first).toHaveTextContent('First bubble');
+
+    const second = await outsideAct(() =>
+      openGlassTooltip(screen.getByRole('button', { name: 'Second' }))
+    );
+    expect(second).toHaveTextContent('Second bubble');
+    expect(second).not.toBe(first);
+    // Both are open at once, which is why identity rather than presence is the test.
+    expect(screen.getAllByRole('tooltip')).toHaveLength(2);
+  });
+
+  it('closes the bubble it opened, not merely some bubble', async () => {
+    render(
+      <>
+        <GlassTooltip content="First bubble">
+          <button type="button">First</button>
+        </GlassTooltip>
+        <GlassTooltip content="Second bubble">
+          <button type="button">Second</button>
+        </GlassTooltip>
+      </>
+    );
+    const firstTrigger = screen.getByRole('button', { name: 'First' });
+    await outsideAct(() => openGlassTooltip(firstTrigger));
+    await outsideAct(() => openGlassTooltip(screen.getByRole('button', { name: 'Second' })));
+
+    /* Waiting for "no bubbles remain" would hang here forever, because the second one
+       is still up and this wrapper's leave events cannot close it. */
+    await outsideAct(() => closeGlassTooltip(firstTrigger));
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Second bubble');
+  });
+
+  it('says so when a leftover bubble is the reason nothing opened', async () => {
+    render(
+      <>
+        <GlassTooltip content="First bubble">
+          <button type="button">First</button>
+        </GlassTooltip>
+        <span className="glass-tooltip">
+          <button type="button">Inert</button>
+        </span>
+      </>
+    );
+    await outsideAct(() => openGlassTooltip(screen.getByRole('button', { name: 'First' })));
+    await expect(
+      outsideAct(() => openGlassTooltip(screen.getByRole('button', { name: 'Inert' })))
+    ).rejects.toThrow(/1 unrelated bubble\(s\) were already open/);
+  }, 10000);
+
+  it('falls back to waiting for an empty screen when it never opened one itself', async () => {
+    render(<Trigger />);
+    const button = trigger();
+    // Opened WITHOUT the helper, so nothing was recorded for this wrapper.
+    const wrapper = glassTooltipWrapper(button);
+    await outsideAct(async () => {
+      wrapper.dispatchEvent(new MouseEvent('mouseenter', { bubbles: false }));
+      await new Promise((resolve) => {
+        setTimeout(resolve, 60);
+      });
+    });
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+
+    await outsideAct(() => closeGlassTooltip(button));
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
 });

--- a/apps/frontend/src/app/__tests__/ui/tokens/appScopeAliasClosure.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/tokens/appScopeAliasClosure.test.ts
@@ -188,6 +188,12 @@ describe('faint-ink alias closure is mirrored into the app scope', () => {
       .filter((f) => f.endsWith('.css') && !f.includes('/marketing/'));
 
     const offenders: string[] = [];
+    /* Which clearances an actual dim matched. An entry that matches nothing is not
+       harmless: the justification beside it rots, and the next opacity added to that
+       file inherits it silently. Three entries here read "dark glass tooltip" for a
+       bubble that commit 2ca7017e4 made opaque cream, and the file they name has had
+       no opacity at all since. */
+    const usedClearances = new Set<string>();
 
     // Tailwind can dim from the markup too, which a stylesheet-only scan cannot
     // see: `text-[var(--ink-faint)] ... opacity-70` on the calendar minute
@@ -249,12 +255,6 @@ describe('faint-ink alias closure is mirrored into the app scope', () => {
       'features/integrations/pages/IdexxWorkspace/index.tsx::28': 'SKELETON_ROWS, no text',
       'features/appointments/components/Calendar/common/WeekCalendar.tsx::75':
         'the now-line border, decoration with no text',
-      'features/organization/pages/Specialities/PackageBreakdownTable.tsx::50':
-        'dark glass tooltip',
-      'features/organization/pages/Specialities/PackageBreakdownTable.tsx::70':
-        'dark glass tooltip',
-      'features/organization/pages/Specialities/PackageBreakdownTable.tsx::80':
-        'dark glass tooltip',
     };
 
     for (const file of tsx) {
@@ -300,7 +300,11 @@ describe('faint-ink alias closure is mirrored into the app scope', () => {
               : Number(m[2]);
           if (pct >= 100 || pct === 0) continue; // 0 = hidden, nothing to read
           if (heavyOnly && pct > 65) continue;
-          if (`${file}::${pct}` in CLEARED) continue;
+          const key = `${file}::${pct}`;
+          if (key in CLEARED) {
+            usedClearances.add(key);
+            continue;
+          }
           offenders.push(`${file}:${i + 1}  opacity ${pct}%`);
         }
       });
@@ -348,6 +352,13 @@ describe('faint-ink alias closure is mirrored into the app scope', () => {
     // Empty, and it should stay that way. Anything new either recedes through
     // ink instead, or names itself as decoration / a disabled control.
     expect(offenders).toEqual([]);
+
+    /* And no clearance may sit here matching nothing. A dead entry is a defect
+       waiting to be excused: it survives whatever removed the dim it was written
+       for, keeps a justification that has stopped being true, and then silently
+       clears the next opacity someone adds to that file. */
+    const dead = Object.keys(CLEARED).filter((key) => !usedClearances.has(key));
+    expect(dead).toEqual([]);
   });
 
   it("uses the design system palette, not Tailwind's stock one", () => {

--- a/apps/frontend/src/app/__tests__/ui/tokens/colorUtilityExists.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/tokens/colorUtilityExists.test.ts
@@ -1,0 +1,116 @@
+import { readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * A Tailwind colour utility naming a token that does not exist emits NO CSS at all.
+ * The element simply inherits, so the text renders in the surrounding ink and looks
+ * deliberate. Nothing catches it: it type-checks, it lints, the component's own tests
+ * pass, and a screenshot shows readable text.
+ *
+ * `text-error-main` shipped exactly that way. There is no `--color-error-main` in
+ * `globals.css` and no `.text-error-main` rule in the built stylesheet, so FIVE error
+ * messages across PIMS - the appointment submit error, the prescription signature
+ * error, the companion-history load failure and the document-signing portal error -
+ * rendered in ordinary body ink with no colour signal that anything had gone wrong.
+ * Found by a story that asserted the error colour differed from the normal one and
+ * measured both as rgb(48, 47, 46).
+ *
+ * Tailwind v4 generates `text-x`, `bg-x` and `border-x` from a `--color-x` token, so
+ * that is what this checks. Arbitrary values (`text-[var(--ink)]`) are generated from
+ * the value itself and need no token.
+ */
+const APP = join(__dirname, '..', '..', '..');
+const GLOBALS = join(APP, 'globals.css');
+
+/** Class selectors written by hand in any project stylesheet. */
+const handWrittenClasses = (): Set<string> => {
+  const names = new Set<string>();
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.name.endsWith('.css')) {
+        for (const m of readFileSync(full, 'utf8').matchAll(/\.([a-z][a-z0-9-]*)\s*[,{:]/g)) {
+          names.add(m[1]);
+        }
+      }
+    }
+  };
+  walk(APP);
+  return names;
+};
+
+/** `--color-<name>` declarations, which are what Tailwind turns into utilities. */
+const declaredColorTokens = (): Set<string> => {
+  const css = readFileSync(GLOBALS, 'utf8');
+  return new Set([...css.matchAll(/^\s*--color-([a-z0-9-]+):/gm)].map((m) => m[1]));
+};
+
+const sourceFiles = (dir: string): string[] =>
+  readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) return entry.name === '__tests__' ? [] : sourceFiles(full);
+    return /\.tsx$/.test(entry.name) && !entry.name.includes('.stories.') ? [full] : [];
+  });
+
+/**
+ * Utility prefixes whose suffix is a colour token. `text-` also spells typography
+ * (`text-body-3`, `text-center`, `text-[13px]`), and `border-` also spells width and
+ * style, so those are filtered by shape below rather than by prefix.
+ */
+/* `(?<![-\w])` anchors the prefix to the START of a class. Without it, `\b` happily
+   matches the `text-` inside `border-input-text-placeholder-active` and reports a real,
+   working utility as missing - which it did, on the first run of this test. */
+const CANDIDATE =
+  /(?<![-\w])(?:text|bg|border|ring|fill|stroke|divide|outline|shadow)-([a-z][a-z0-9]*(?:-[a-z0-9]+)+)\b/g;
+
+/**
+ * Suffixes Tailwind itself owns: sides and widths (`border-b-2`), keyword values
+ * (`bg-no-repeat`), and ring geometry (`ring-offset-2`). These generate real CSS
+ * without any project token, so they are not candidates for this check.
+ */
+const TAILWIND_OWN =
+  /^(?:[trblxyse]-\d+|no-repeat|offset-\d+|clip-\w+|origin-\w+|gradient-to-\w+|\d+)$/;
+
+/** Names that are Tailwind's own or are not colours at all. */
+const NOT_A_COLOR_TOKEN =
+  /^(?:body|caption|heading|display|title|label|sm|md|lg|xl|2xl|3xl|4xl|5xl|6xl|7xl|8xl|9xl|left|right|center|justify|start|end|top|bottom|solid|dashed|dotted|double|none|hidden|clip|ellipsis|wrap|nowrap|balance|pretty|auto|inherit|current|transparent|black|white|opacity|separate|collapse|spacing|inner|xs)\b/;
+
+describe('colour utilities resolve to a declared token', () => {
+  const tokens = declaredColorTokens();
+  const handWritten = handWrittenClasses();
+
+  it('reads the token table it checks against', () => {
+    expect(tokens.size).toBeGreaterThan(50);
+    // The pair the miss was found through.
+    expect(tokens.has('text-error')).toBe(true);
+    expect(tokens.has('error-main')).toBe(false);
+    // The hand-written side of the lookup, so a miss there cannot pass silently.
+    expect(handWritten.has('text-page-title')).toBe(true);
+  });
+
+  it('has no component naming a colour token that does not exist', () => {
+    const offenders: string[] = [];
+
+    for (const file of sourceFiles(APP)) {
+      const src = readFileSync(file, 'utf8');
+      for (const match of src.matchAll(CANDIDATE)) {
+        const name = match[1];
+        if (NOT_A_COLOR_TOKEN.test(name)) continue;
+        if (TAILWIND_OWN.test(name)) continue;
+        if (tokens.has(name)) continue;
+        // `border-t-card-border` is a side plus a colour: strip the side and retry.
+        if (/^border-/.test(match[0]) && tokens.has(name.replace(/^[trblxyse]-/, ''))) continue;
+        // Hand-written classes are real CSS even though no token generates them.
+        if (handWritten.has(match[0])) continue;
+        // Tailwind's built-in ramps (`slate-500`) and numeric steps of declared
+        // families (`primary-600` where `--color-primary-600` exists) are covered
+        // by the token check above; anything left is a name nothing defines.
+        if (/^[a-z]+-\d{2,3}$/.test(name) && tokens.has(name.replace(/-\d+$/, ''))) continue;
+        offenders.push(`${file.replace(APP, 'src/app')}: ${match[0]}`);
+      }
+    }
+
+    expect([...new Set(offenders)]).toEqual([]);
+  });
+});

--- a/apps/frontend/src/app/__tests__/ui/tokens/colorUtilityExists.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/tokens/colorUtilityExists.test.ts
@@ -7,13 +7,18 @@ import { join } from 'path';
  * deliberate. Nothing catches it: it type-checks, it lints, the component's own tests
  * pass, and a screenshot shows readable text.
  *
- * `text-error-main` shipped exactly that way. There is no `--color-error-main` in
- * `globals.css` and no `.text-error-main` rule in the built stylesheet, so FIVE error
- * messages across PIMS - the appointment submit error, the prescription signature
- * error, the companion-history load failure and the document-signing portal error -
- * rendered in ordinary body ink with no colour signal that anything had gone wrong.
- * Found by a story that asserted the error colour differed from the normal one and
- * measured both as rgb(48, 47, 46).
+ * `text-error-main` once shipped exactly that way, and is FIXED - this note is history,
+ * not a live defect. There was no `--color-error-main` in `globals.css` and no
+ * `.text-error-main` rule in the built stylesheet, so five error messages across PIMS
+ * (the appointment submit error, the prescription signature error, the
+ * companion-history load failure and the document-signing portal error) rendered in
+ * ordinary body ink with no colour signal that anything had gone wrong. All five now
+ * use `text-text-error`. Found by a story that asserted the error colour differed from
+ * the normal one and measured both as rgb(48, 47, 46).
+ *
+ * Eight more dead utilities came out of the same audit: `border-error-border`,
+ * `bg-danger-50`, `bg-blue-soft` (x4), `border-input-border`, `bg-surface-1`,
+ * `bg-card-subtle` and `text-capton-1`. This test is what keeps them from returning.
  *
  * Tailwind v4 generates `text-x`, `bg-x` and `border-x` from a `--color-x` token, so
  * that is what this checks. Arbitrary values (`text-[var(--ink)]`) are generated from

--- a/apps/frontend/src/app/features/appointments/components/AppointmentBoardCard.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/AppointmentBoardCard.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { expect, fn, userEvent, within } from 'storybook/test';
+import { expect, fn, within } from 'storybook/test';
+
+import { openGlassTooltip } from '@/app/ui/primitives/GlassTooltip/storyInteractions';
 import type { Appointment } from '@yosemite-crew/types';
 
 import AppointmentBoardCard from './AppointmentBoardCard';
@@ -140,10 +142,10 @@ export const TooltipOnHover: Story = {
   name: 'Action tooltip (hover)',
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await userEvent.hover(canvas.getByRole('button', { name: 'Assign room' }));
-    // The bubble portals to document.body, so it is outside canvasElement - and
-    // it is asserted to carry its copy, not merely to exist.
-    const tooltip = await within(document.body).findByRole('tooltip');
+    /* The bubble portals to document.body, so it is outside canvasElement - and it is
+       asserted to carry its copy, not merely to exist. `openGlassTooltip` because the
+       wrapper binds its listeners in an effect that a play function can outrun. */
+    const tooltip = await openGlassTooltip(canvas.getByRole('button', { name: 'Assign room' }));
     await expect(tooltip).toHaveTextContent('Assign room');
   },
   parameters: {
@@ -162,10 +164,13 @@ export const TooltipOnKeyboardFocus: Story = {
   name: 'Action tooltip (keyboard focus)',
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    // `focusin` bubbles to the GlassTooltip wrapper, which is the whole reason a
-    // keyboard user gets the label at all. This path is separate code from hover.
-    canvas.getByRole('button', { name: 'Lab tests' }).focus();
-    const tooltip = await within(document.body).findByRole('tooltip');
+    /* `focusin` reaches the GlassTooltip wrapper, which is the whole reason a keyboard
+       user gets the label at all - separate code from the hover path. Dispatched at the
+       wrapper rather than via `.focus()`, which fires nothing unless the page itself has
+       focus, and no automated run can guarantee that. */
+    const tooltip = await openGlassTooltip(canvas.getByRole('button', { name: 'Lab tests' }), {
+      via: 'focus',
+    });
     await expect(tooltip).toHaveTextContent('Lab tests');
   },
   parameters: {
@@ -186,8 +191,7 @@ export const NonHospitalClinicalNotes: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(canvas.queryByRole('button', { name: 'Medical Records' })).toBeNull();
-    await userEvent.hover(canvas.getByRole('button', { name: 'Care' }));
-    const tooltip = await within(document.body).findByRole('tooltip');
+    const tooltip = await openGlassTooltip(canvas.getByRole('button', { name: 'Care' }));
     await expect(tooltip).toHaveTextContent('Care');
   },
   parameters: {

--- a/apps/frontend/src/app/features/appointments/components/AppointmentBoardToolbar.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/AppointmentBoardToolbar.stories.tsx
@@ -2,6 +2,8 @@ import { useState, type ComponentProps } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { expect, fn, userEvent, within } from 'storybook/test';
 
+import { openGlassTooltip } from '@/app/ui/primitives/GlassTooltip/storyInteractions';
+
 import AppointmentBoardToolbar from './AppointmentBoardToolbar';
 
 /**
@@ -147,12 +149,12 @@ export const CalendarOpen: Story = {
 export const DateTooltip: Story = {
   name: 'Select date tooltip',
   play: async ({ canvasElement }) => {
-    // GlassTooltip listens on its own wrapper span, not on the Datepicker inside it.
+    /* GlassTooltip listens on its own wrapper span, not on the Datepicker inside it,
+       and binds those listeners in an effect that has not necessarily flushed when this
+       play function starts - so the dispatch is retried rather than sent once. */
     const trigger = canvasElement.querySelector('.glass-tooltip') as HTMLElement;
     await expect(trigger).toBeTruthy();
-    await userEvent.hover(trigger);
-
-    const bubble = await within(document.body).findByRole('tooltip');
+    const bubble = await openGlassTooltip(trigger);
     await expect(bubble).toHaveTextContent('Select date');
     /* side="bottom" positions the bubble under the field, and the transform is
        the only thing distinguishing it from the default "top" placement. Read

--- a/apps/frontend/src/app/features/appointments/components/AppointmentBoardToolbar.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/AppointmentBoardToolbar.stories.tsx
@@ -1,0 +1,221 @@
+import { useState, type ComponentProps } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import AppointmentBoardToolbar from './AppointmentBoardToolbar';
+
+/**
+ * The toolbar owns no state at all - the board above it holds the date, the
+ * emergency filter and the mine-only scope - so a story that hands it plain
+ * `fn()` callbacks renders a toolbar whose Back/Next arrows and toggles do
+ * nothing. This harness gives those props somewhere to land so the interactive
+ * halves are actually reviewable, and still forwards to the story's mocks so
+ * the actions panel logs every call.
+ */
+const StatefulToolbar = (args: ComponentProps<typeof AppointmentBoardToolbar>) => {
+  const [currentDate, setCurrentDate] = useState<Date>(args.currentDate);
+  const [emergencyActive, setEmergencyActive] = useState(args.emergency.active);
+  const [mineOnly, setMineOnly] = useState(args.scope.mineOnly);
+
+  return (
+    <AppointmentBoardToolbar
+      {...args}
+      currentDate={currentDate}
+      setCurrentDate={setCurrentDate}
+      emergency={{
+        ...args.emergency,
+        active: emergencyActive,
+        onToggle: () => {
+          args.emergency.onToggle();
+          setEmergencyActive((value) => !value);
+        },
+      }}
+      scope={{
+        mineOnly,
+        onMineOnlyChange: (value) => {
+          args.scope.onMineOnlyChange(value);
+          setMineOnly(value);
+        },
+      }}
+    />
+  );
+};
+
+/** The calendar popper drops below the toolbar, so the canvas needs room under it. */
+const Room = (Story: React.ComponentType) => (
+  <div className="min-h-[520px] bg-[var(--screen)]">
+    <Story />
+  </div>
+);
+
+const meta = {
+  title: 'Appointments/AppointmentBoardToolbar',
+  component: AppointmentBoardToolbar,
+  decorators: [Room],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The band above the appointment board: date field, day stepper, the Emergencies filter ' +
+          'pill, the New appointment CTA and the mine-only scope toggle.\n\n' +
+          'Two of its surfaces exist only after an interaction and had never been drawn. The first ' +
+          'is the react-datepicker popper. It is portalled out of the toolbar entirely - ' +
+          '`portalId="yc-datepicker-portal"` on a `.yc-datepicker-calendar` panel - so it is not ' +
+          'even a descendant of this component in the DOM, and every rule that styles it (the ' +
+          'selected day, the "today" chip, the month/year `<select>`s that `dropdownMode="select"` ' +
+          'renders) lives behind a click. The second is the `GlassTooltip` reading "Select date" ' +
+          'wrapped around that field, whose bubble is created on `mouseenter` and then ' +
+          '`createPortal`ed to `document.body`.\n\n' +
+          'Both matter here more than in isolation because the toolbar row is `overflow-x-auto` ' +
+          'with `z-20` on the scroller: a panel that failed to escape it would be clipped rather ' +
+          'than merely misplaced, and no closed-state snapshot can show that.\n\n' +
+          'The stories below open each surface and assert it has real content - 42 day cells and ' +
+          'the two dropdown selects, tooltip text plus its side transform - rather than asserting ' +
+          'that a trigger flipped a flag, which an empty panel would also satisfy.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    currentDate: new Date(2026, 2, 12),
+    setCurrentDate: fn(),
+    onWheelHorizontal: fn(),
+    emergency: {
+      active: false,
+      color: 'var(--danger)',
+      present: true,
+      onToggle: fn(),
+    },
+    permissions: { editAppointments: true },
+    onAddAppointment: fn(),
+    scope: { mineOnly: false, onMineOnlyChange: fn() },
+  },
+  render: (args) => <StatefulToolbar {...args} />,
+} satisfies Meta<typeof AppointmentBoardToolbar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Resting',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'What the board shows before anything is touched: the emergency pill in its outline ' +
+          'state with the unread dot, the full-permission CTA, and the scope toggle off.',
+      },
+    },
+  },
+};
+
+export const CalendarOpen: Story = {
+  name: 'Datepicker popper open',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Toggle calendar' }));
+
+    // The popper portals to #yc-datepicker-portal on document.body, so it is
+    // outside canvasElement.
+    const calendar = document.querySelector('.yc-datepicker-calendar');
+    await expect(calendar).toBeInTheDocument();
+
+    /* Assert the panel actually has a month in it. `fixedHeight` pins the grid
+       to six weeks, so a healthy popper paints a full month of day cells - an
+       empty or collapsed panel would still satisfy "the popper is in the
+       document", which is exactly how a broken panel stays invisible. */
+    const days = (calendar as HTMLElement).querySelectorAll('.react-datepicker__day');
+    await expect(days.length).toBeGreaterThanOrEqual(28);
+
+    // showMonthDropdown + showYearDropdown with dropdownMode="select" render two
+    // native selects in the header; they are the part most likely to lose styling.
+    await expect(within(calendar as HTMLElement).getAllByRole('combobox')).toHaveLength(2);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The calendar itself. It is right-aligned to the icon trigger (`popperPlacement="bottom-end"` ' +
+          "for the icon variant) and lands in a body portal, so it clears the toolbar's " +
+          '`overflow-x-auto` scroller instead of being cut off by it.',
+      },
+    },
+  },
+};
+
+export const DateTooltip: Story = {
+  name: 'Select date tooltip',
+  play: async ({ canvasElement }) => {
+    // GlassTooltip listens on its own wrapper span, not on the Datepicker inside it.
+    const trigger = canvasElement.querySelector('.glass-tooltip') as HTMLElement;
+    await expect(trigger).toBeTruthy();
+    await userEvent.hover(trigger);
+
+    const bubble = await within(document.body).findByRole('tooltip');
+    await expect(bubble).toHaveTextContent('Select date');
+    /* side="bottom" positions the bubble under the field, and the transform is
+       the only thing distinguishing it from the default "top" placement. Read
+       the inline value, not the computed one: a laid-out element resolves any
+       transform to a `matrix(...)`, so a computed-style check can never tell
+       the two placements apart. */
+    await expect(bubble.style.transform).toMatch(/^translate\(-50%, 0(px)?\)$/);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The hover hint on the date field. It is created on `mouseenter`, portalled to ' +
+          '`document.body` and positioned from the trigger rect, so it can only be reviewed by ' +
+          'actually hovering - the resting toolbar contains no trace of it.',
+      },
+    },
+  },
+};
+
+export const EmergencyActive: Story = {
+  name: 'Emergency filter on',
+  args: { emergency: { active: true, color: 'var(--danger)', present: true, onToggle: fn() } },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The filled pill: `--danger-strong` with its paired ink rather than a literal white, so ' +
+          'the label clears the fill in both themes and the pill keeps a visible edge on the dark ' +
+          'screen. The unread dot outlines itself in `--screen`, which only reads correctly ' +
+          'against the filled state.',
+      },
+    },
+  },
+};
+
+export const NoEmergencies: Story = {
+  name: 'No emergencies present',
+  args: { emergency: { active: false, color: 'var(--danger)', present: false, onToggle: fn() } },
+  parameters: {
+    docs: {
+      description: {
+        story: 'With `present: false` the corner dot is not rendered at all - the pill stays.',
+      },
+    },
+  },
+};
+
+export const ReadOnly: Story = {
+  name: 'Without edit permission',
+  args: { permissions: { editAppointments: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.queryByRole('button', { name: /new appointment/i })).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Without `editAppointments` the CTA and its hairline divider are both dropped rather ' +
+          'than disabled, so the scope toggle slides left against the emergency pill. That ' +
+          're-flow is the reason this needs its own story.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/components/AppointmentDetailsSection.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/AppointmentDetailsSection.stories.tsx
@@ -101,7 +101,7 @@ export const Expanded: Story = {
     const canvas = within(canvasElement);
     await userEvent.click(canvas.getByRole('button', { name: 'Appointment details' }));
     // Assert the body actually mounted its fields - not just that aria-expanded flipped.
-    await expect(await canvas.findByRole('button', { name: 'Speciality' })).toBeInTheDocument();
+    expect(await canvas.findByRole('button', { name: 'Speciality' })).toBeInTheDocument();
     await expect(canvas.getByRole('button', { name: 'Services / Packages' })).toBeInTheDocument();
     await expect(canvas.getByRole('textbox', { name: 'Describe concern' })).toBeInTheDocument();
     await expect(canvas.getByRole('button', { name: 'Next' })).toBeInTheDocument();

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/TaskDetailsPopover.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/TaskDetailsPopover.stories.tsx
@@ -135,6 +135,11 @@ export const LongValues: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    /* One "Category" row, not two. The popover used to print it in this grid AND again
+       in the quick-details list below, because `getTaskQuickDetails` leads with Category
+       and the popover took its first two entries. This query would have been ambiguous
+       either way, and that ambiguity is what found the duplication. */
+    await expect(canvas.getAllByText('Category')).toHaveLength(1);
     const grid = canvas.getByText('Category').parentElement as HTMLElement;
     await expect(getComputedStyle(grid).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(2);
   },

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/TaskDetailsPopover.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/TaskDetailsPopover.tsx
@@ -113,8 +113,12 @@ export const TaskDetailsPopover = ({
           </div>
         </div>
         <div className="flex flex-col gap-1">
+          {/* Category is already the third row of the grid above, and `getTaskQuickDetails`
+              leads with it - so taking the first two entries printed it twice inside one
+              304px popover. Filtered rather than re-sliced, because the helper is shared
+              with TaskCard, where the grid does not exist and Category belongs. */}
           {getTaskQuickDetails(task)
-            .slice(0, 2)
+            .filter((detail) => detail.label !== 'Category')
             .map((detail) => (
               <div key={detail.label} className="flex min-w-0 items-start gap-2">
                 <div className="w-16 shrink-0 text-[11px] leading-4 text-text-secondary">

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/TaskDetailsPopover.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/TaskDetailsPopover.tsx
@@ -115,11 +115,12 @@ export const TaskDetailsPopover = ({
         <div className="flex flex-col gap-1">
           {/* Category is already the third row of the grid above, and `getTaskQuickDetails`
               leads with it - so taking the first two entries printed it twice inside one
-              304px popover. Filtered rather than re-sliced, because the helper is shared
-              with TaskCard, where the grid does not exist and Category belongs. */}
-          {getTaskQuickDetails(task)
-            .filter((detail) => detail.label !== 'Category')
-            .map((detail) => (
+              304px popover. Skipped inside the map rather than filtered ahead of it, so
+              the list is walked once; and skipped by label rather than by index, because
+              the helper is shared with TaskCard, where the grid does not exist and
+              Category belongs. */}
+          {getTaskQuickDetails(task).map((detail) =>
+            detail.label === 'Category' ? null : (
               <div key={detail.label} className="flex min-w-0 items-start gap-2">
                 <div className="w-16 shrink-0 text-[11px] leading-4 text-text-secondary">
                   {detail.label}
@@ -128,7 +129,8 @@ export const TaskDetailsPopover = ({
                   {detail.value}
                 </div>
               </div>
-            ))}
+            )
+          )}
         </div>
         <div className="mt-1 flex min-w-0 flex-wrap items-center justify-end gap-1.5 border-t border-card-border pt-2">
           <TaskPopoverActionButton tooltip="View task" label="View task" onPress={onView}>

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/Header.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/Header.stories.tsx
@@ -1,0 +1,286 @@
+import { useState, type ComponentProps } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import {
+  AppointmentFilters,
+  AppointmentStatusFilters,
+} from '@/app/features/appointments/types/appointments';
+import type { CalendarZoomMode } from '@/app/features/appointments/components/Calendar/calendarLayout';
+import Header from './Header';
+
+const DEFAULT_DATE = new Date('2026-03-12T09:00:00');
+
+type HeaderProps = ComponentProps<typeof Header>;
+
+type HarnessProps = Omit<
+  HeaderProps,
+  | 'currentDate'
+  | 'setCurrentDate'
+  | 'setWeekStart'
+  | 'activeStatus'
+  | 'setActiveStatus'
+  | 'activeFilter'
+  | 'setActiveFilter'
+  | 'activeCalendar'
+  | 'setActiveCalendar'
+  | 'zoomMode'
+  | 'setZoomMode'
+> & {
+  initialDate?: Date;
+  initialStatus?: string;
+  initialFilter?: string;
+  /** Non-empty renders the Day / Week / Team `SegmentedPill`. */
+  initialCalendar?: string;
+  /** Renders the +/- zoom toggle at the far right of the scroller. */
+  withZoom?: boolean;
+};
+
+/**
+ * `Header` is fully controlled - date, status, filter, view and zoom all live in
+ * the calendar page above it - so nothing about it can be reached from static
+ * args. This holds that state so the panels can actually be opened.
+ */
+const CalendarHeaderHarness = ({
+  initialDate = DEFAULT_DATE,
+  initialStatus = 'all',
+  initialFilter = 'all',
+  initialCalendar,
+  withZoom = false,
+  ...rest
+}: HarnessProps) => {
+  const [currentDate, setCurrentDate] = useState(initialDate);
+  const [, setWeekStart] = useState(initialDate);
+  const [activeStatus, setActiveStatus] = useState(initialStatus);
+  const [activeFilter, setActiveFilter] = useState(initialFilter);
+  const [activeCalendar, setActiveCalendar] = useState(initialCalendar ?? 'day');
+  const [zoomMode, setZoomMode] = useState<CalendarZoomMode>('in');
+
+  return (
+    <Header
+      {...rest}
+      currentDate={currentDate}
+      setCurrentDate={setCurrentDate}
+      setWeekStart={setWeekStart}
+      activeStatus={activeStatus}
+      setActiveStatus={setActiveStatus}
+      activeFilter={activeFilter}
+      setActiveFilter={setActiveFilter}
+      activeCalendar={initialCalendar ? activeCalendar : undefined}
+      setActiveCalendar={initialCalendar ? setActiveCalendar : undefined}
+      zoomMode={withZoom ? zoomMode : undefined}
+      setZoomMode={withZoom ? setZoomMode : undefined}
+    />
+  );
+};
+
+/** Opens the status dropdown and returns its portalled panel. */
+const openStatusPanel = async (canvasElement: HTMLElement, triggerName: string | RegExp) => {
+  const canvas = within(canvasElement);
+  await userEvent.click(canvas.getByRole('button', { name: triggerName }));
+  // "No show" only ever exists inside the panel, so it is an unambiguous handle
+  // on a portal that carries no role, id or label of its own. Its parent IS the
+  // panel: StatusOptionButtons renders a bare fragment of buttons.
+  const row = await within(document.body).findByRole('button', { name: 'No show' });
+  return row.parentElement as HTMLElement;
+};
+
+const meta = {
+  title: 'Appointments/Calendar/Header',
+  component: CalendarHeaderHarness,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The toolbar above every calendar view - Appointments day/week/team and the Tasks ' +
+          'planner - carrying the date picker, the prev/label/next nav pill, Today, the view ' +
+          'switcher, the status filter, the scope pills, the CTA and the zoom toggle in one ' +
+          'horizontally scrolling row.\n\n' +
+          'Two of those controls are surfaces no snapshot has ever held. `StatusFilterDropdown` ' +
+          'is **module-private** - it is not exported, has no story of its own, and its panel is ' +
+          '`createPortal`ed to `document.body`, so it can only be drawn by mounting `Header` and ' +
+          'clicking. The panel is positioned imperatively by `useAnchoredDropdown(180)`: ' +
+          '`position: fixed`, `top = trigger.bottom + 6`, `right = innerWidth - trigger.right`, ' +
+          '`minWidth = max(triggerWidth, 180)`, `zIndex: 9999`. None of that is expressible as a ' +
+          'class, so nothing but a rendered instance can show whether it lands under its trigger ' +
+          'or off the edge of the toolbar.\n\n' +
+          'The rows inside are the exact shape of the token bug this branch shipped elsewhere: ' +
+          '`getDropdownStatusTextColor` resolves each label to `dropdownText ?? text ?? ' +
+          '--color-text-primary`. Those tokens are `--status-*-text` **ink**, and the dot beside ' +
+          'each label paints `--status-*-border`. Substituting the pill *fill* token for the ink ' +
+          'one there produces text that is legible on the pill and nearly invisible on the ' +
+          "panel's `bg-neutral-0` - and no test that only checks `aria-expanded` would notice.\n\n" +
+          'The trigger itself has two disjoint renderings, not one styled two ways. With `all` ' +
+          'selected it is a bare hairline pill reading “All statuses” at 12px/600 in ' +
+          '`--ink-muted`; with any other status it is a `StatusPill` in that status’ own ' +
+          'token set, with the chevron folded into the pill label. The stories draw both.\n\n' +
+          'The second gated surface is the `Datepicker` popper, which react-datepicker renders ' +
+          'into its own `#yc-datepicker-portal` node - also outside the story canvas, also only ' +
+          'after a click.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    statusOptions: AppointmentStatusFilters,
+    filterOptions: AppointmentFilters,
+    hasEmergency: false,
+    showAddButton: true,
+    addButtonText: 'New appointment',
+    onAddButtonClick: fn(),
+  },
+} satisfies Meta<typeof CalendarHeaderHarness>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Resting toolbar',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Everything closed - the state every existing snapshot of a calendar page has held. ' +
+          'The left cluster (date picker, nav pill, Today) is `shrink-0`; the right cluster lives ' +
+          'in the `overflow-x-auto` half so the pills scroll rather than compress.',
+      },
+    },
+  },
+};
+
+export const StatusPanelOpen: Story = {
+  name: 'Status panel open',
+  play: async ({ canvasElement }) => {
+    const panel = await openStatusPanel(canvasElement, 'All statuses');
+    // Assert the panel has its eight rows AND their swatches. Checking only that
+    // the trigger flipped would pass on an empty portal - which is how a dropped
+    // panel stays invisible.
+    await expect(within(panel).getAllByRole('button')).toHaveLength(8);
+    await expect(within(panel).getByText('Requested')).toBeInTheDocument();
+    await expect(within(panel).getByText('Cancelled')).toBeInTheDocument();
+    await expect(panel.querySelectorAll('span.rounded-full')).toHaveLength(8);
+    // The imperative geometry: fixed rather than absolute, so it escapes the
+    // toolbar's own horizontal scroller instead of being clipped by it.
+    await expect(getComputedStyle(panel).position).toBe('fixed');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'All eight appointment statuses, each with a 8px dot in its `--status-*-border` tone and ' +
+          'its label in the matching ink token, inside a `rounded-2xl` `bg-neutral-0` card with a ' +
+          '`0 8px 24px --color-shadow-soft` drop shadow. The "All" row is the `allKey`, so it ' +
+          'never takes the active font weight even while selected.',
+      },
+    },
+  },
+};
+
+export const SelectedStatusPanelOpen: Story = {
+  name: 'Status panel open (status selected)',
+  args: { initialStatus: 'in_progress' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The trigger is now a StatusPill, not the "All statuses" outline pill.
+    await expect(canvas.queryByRole('button', { name: 'All statuses' })).not.toBeInTheDocument();
+    const panel = await openStatusPanel(canvasElement, 'In progress');
+    await expect(within(panel).getAllByRole('button')).toHaveLength(8);
+    // The selected row is marked by a trailing check only - there is no
+    // background change - so its absence is the whole regression.
+    await expect(within(panel).getByText('✓')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The other trigger branch. `getStatusPillTokens` hands the pill the status’ ' +
+          '`bg`/`text`/`border`, falling back to the `--color-pill-neutral-*` set, and the ' +
+          'chevron rides inside the pill rather than beside it. Worth seeing against the default: ' +
+          'the two triggers share no markup at all.',
+      },
+    },
+  },
+};
+
+export const DatepickerOpen: Story = {
+  name: 'Date picker popper open',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: /toggle calendar/i }));
+    // react-datepicker portals the popper into #yc-datepicker-portal, outside
+    // the canvas. Assert the grid actually has day cells, not just that the
+    // popper node exists.
+    const calendar = document.querySelector('.yc-datepicker-calendar');
+    await expect(calendar).toBeInTheDocument();
+    await expect(
+      (calendar as HTMLElement).querySelectorAll('.react-datepicker__day').length
+    ).toBeGreaterThan(27);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The header wraps the picker in a `GlassTooltip` and a `relative z-150` box so the ' +
+          'popper clears the `z-140` sticky toolbar. Both the tooltip bubble and the calendar ' +
+          'portal out of the canvas, so this is the only way either is drawn.',
+      },
+    },
+  },
+};
+
+export const EmergencyFilterActive: Story = {
+  name: 'Emergency pill active, with waiting emergency',
+  args: { initialFilter: 'emergencies', hasEmergency: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const pill = canvas.getByRole('button', { name: 'Emergencies' });
+    // Active emergency deliberately carries NO colour class: the fill and label
+    // come from getEmergencyPillStyle's inline style, so an `!important` text
+    // colour cannot override it. Only the weight class is applied.
+    await expect(pill).toHaveClass('font-bold');
+    await expect(pill.className).not.toContain('text-danger');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The one filter pill with a third state: selected, plus a `--danger` notification dot ' +
+          'ringed in `--screen` pinned to its top-right corner when an emergency is waiting. That ' +
+          'dot is `-top-0.5 -right-0.5` and overflows the pill, so it only reads correctly with ' +
+          'the neighbouring controls composited around it.',
+      },
+    },
+  },
+};
+
+export const PlannerToolbar: Story = {
+  name: 'Planner toolbar (view switcher + zoom)',
+  args: {
+    initialCalendar: 'week',
+    withZoom: true,
+    addButtonText: 'New task',
+    statusOptions: [],
+    filterOptions: [],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('button', { name: 'Zoom in timeline' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'New task' })).toBeInTheDocument();
+    // The week view swaps the arrows from day-stepping to week-stepping, and the
+    // labels are the only signal of which is wired up.
+    await expect(canvas.getByRole('button', { name: 'Next week' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same component as the Tasks planner mounts: the Day/Week/Team `SegmentedPill` and ' +
+          'the zoom toggle appear, the status dropdown and scope pills do not, and the CTA is ' +
+          'relabelled. `activeCalendar === "week"` **and** a `setWeekStart` dispatch both being ' +
+          'present is what flips the nav arrows from day-stepping to week-stepping - the arrow ' +
+          'labels are the only thing that says which handler is wired up.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/MenuActionsList.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/MenuActionsList.stories.tsx
@@ -1,0 +1,241 @@
+import { useRef, useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import MenuActionsList from './MenuActionsList';
+import type { MenuAction, MenuSubmenu } from './appointmentContextMenuHelpers';
+
+const ACTIONS: MenuAction[] = [
+  { key: 'open', label: 'Open appointment', onSelect: fn() },
+  { key: 'status', label: 'Change status', submenu: 'status' },
+  { key: 'room', label: 'Move to room', submenu: 'room' },
+  { key: 'reschedule', label: 'Reschedule', onSelect: fn() },
+  { key: 'cancel', label: 'Cancel appointment', destructive: true, onSelect: fn() },
+];
+
+/**
+ * The real list lives inside `AppointmentContextMenu`, which owns the `role="menu"`
+ * container, the `itemRefs` map used to measure a submenu's flyout position, and the
+ * `activeSubmenu` state that hovering a row sets. The harness supplies all three so the
+ * hover-driven active row can be reached from a story rather than only from a live
+ * right-click on a calendar marker.
+ */
+const Harness = ({
+  actions,
+  initialSubmenu,
+  onActivate,
+}: {
+  actions: MenuAction[];
+  initialSubmenu: MenuSubmenu;
+  onActivate: (action: MenuAction) => void;
+}) => {
+  const itemRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+  const [activeSubmenu, setActiveSubmenu] = useState<MenuSubmenu>(initialSubmenu);
+
+  return (
+    <div
+      role="menu"
+      aria-label="Appointment actions"
+      className="yc-glass-overlay w-[220px] overflow-hidden rounded-[22px] px-1.5 py-2"
+    >
+      <MenuActionsList
+        actions={actions}
+        activeSubmenu={activeSubmenu}
+        itemRefs={itemRefs}
+        onHover={(action) => setActiveSubmenu(action.submenu ?? null)}
+        onActivate={onActivate}
+      />
+    </div>
+  );
+};
+
+/** The two rows the fill assertions compare: the submenu row and a plain sibling. */
+const rowsByLabel = (canvasElement: HTMLElement) => {
+  const canvas = within(canvasElement);
+  return {
+    canvas,
+    status: canvas.getByRole('menuitem', { name: 'Change status' }),
+    plain: canvas.getByRole('menuitem', { name: 'Open appointment' }),
+  };
+};
+
+const meta = {
+  title: 'Appointments/Calendar/MenuActionsList',
+  component: Harness,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'The action rows of the appointment context menu. The menu itself is portalled and only ' +
+          'exists after a right-click on a calendar marker, and the state that matters here is one ' +
+          'interaction deeper still: the **active row**, which is set by `onMouseEnter` and by ' +
+          'nothing else. No prop opens it, so nothing had ever drawn it.\n\n' +
+          'That active row is a fill swap, and a fill swap on this surface is exactly where this ' +
+          'family of components has already shipped a bug. `getMenuItemClassName` picks between ' +
+          '`bg-[var(--hairline)]` when active and `bg-transparent` when not, on a row whose ink is ' +
+          '`text-text-primary` - both themed. The sibling submenus previously filled the same rows ' +
+          'with literal `bg-white/50`, which put a light ink on a near-#a1a1a0 row at about 2.1:1 in ' +
+          'dark mode and survived precisely as long as no story rendered the hovered state. The ' +
+          'stories below therefore compare the computed `background-color` of the active row against ' +
+          'a plain sibling instead of only reading `aria-expanded`: a dropped or transparent fill ' +
+          'still satisfies the attribute.\n\n' +
+          'Two more things are only checkable with the list drawn. The dividers render between rows ' +
+          'rather than around them (`index > 0`, `mx-1 border-t border-[var(--hairline)]`), so a ' +
+          'single-action menu must show no rule at all. And the 10px `IoChevronForward` at ' +
+          '`opacity-55` is the only affordance telling a reader a row leads somewhere - it is ' +
+          'rendered from `action.submenu`, so it must be present on exactly the two submenu rows.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    actions: ACTIONS,
+    initialSubmenu: null,
+    onActivate: fn(),
+  },
+} satisfies Meta<typeof Harness>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Resting (nothing hovered)',
+  play: async ({ canvasElement }) => {
+    const { canvas } = rowsByLabel(canvasElement);
+    const items = canvas.getAllByRole('menuitem');
+    await expect(items).toHaveLength(5);
+    // Dividers sit between rows only, so five rows means four rules.
+    await expect(canvasElement.querySelectorAll('div[aria-hidden="true"]')).toHaveLength(4);
+    // The chevron is rendered from `action.submenu`, so it belongs to exactly two rows.
+    const withChevron = items.filter((item) => item.querySelector('svg') !== null);
+    await expect(withChevron).toHaveLength(2);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'What a freshly opened context menu shows before the pointer touches a row.',
+      },
+    },
+  },
+};
+
+export const SubmenuRowActive: Story = {
+  name: 'Submenu row hovered (active fill)',
+  play: async ({ canvasElement }) => {
+    const { status, plain } = rowsByLabel(canvasElement);
+    await expect(status).toHaveAttribute('aria-expanded', 'false');
+
+    await userEvent.hover(status);
+
+    await expect(status).toHaveAttribute('aria-expanded', 'true');
+    /* The attribute alone is the weak check - it flips whether or not the fill
+       survived. Compare the painted background against a plain sibling instead:
+       an active row that resolves to the same colour as an inactive one, or to a
+       fully transparent one, means the `bg-[var(--hairline)]` branch was dropped. */
+    const activeFill = getComputedStyle(status).backgroundColor;
+    const plainFill = getComputedStyle(plain).backgroundColor;
+    await expect(activeFill).not.toBe(plainFill);
+    await expect(activeFill).not.toBe('rgba(0, 0, 0, 0)');
+    await expect(activeFill).not.toBe('transparent');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Hovering "Change status" is what opens the status flyout in the real menu, and the row ' +
+          'has to read as the open one while that flyout is up. This is the state a pointer holds ' +
+          'the whole time the submenu is being used, and the only one where the tinted fill is ' +
+          'visible at all.',
+      },
+    },
+  },
+};
+
+export const SubmenuRowPreOpened: Story = {
+  name: 'Submenu already open (room)',
+  args: { initialSubmenu: 'room' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const room = canvas.getByRole('menuitem', { name: 'Move to room' });
+    const status = canvas.getByRole('menuitem', { name: 'Change status' });
+    await expect(room).toHaveAttribute('aria-expanded', 'true');
+    // Only one row may be active at a time - two tinted rows is its own defect.
+    await expect(status).toHaveAttribute('aria-expanded', 'false');
+    await expect(getComputedStyle(room).backgroundColor).not.toBe(
+      getComputedStyle(status).backgroundColor
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same active state reached through the prop rather than the pointer, so the tint can ' +
+          'be inspected without a hover held open. `activeSubmenu` is a single value, so exactly one ' +
+          'row can carry it.',
+      },
+    },
+  },
+};
+
+export const DestructiveRow: Story = {
+  name: 'Destructive row',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const cancel = canvas.getByRole('menuitem', { name: 'Cancel appointment' });
+    const plain = canvas.getByRole('menuitem', { name: 'Open appointment' });
+    // `text-text-error` vs `text-text-primary` - the destructive row is distinguished
+    // by ink alone at rest, so the two must not resolve to the same colour.
+    await expect(getComputedStyle(cancel).color).not.toBe(getComputedStyle(plain).color);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Cancel is the only row carrying `destructive`, which swaps its ink to `text-text-error` ' +
+          'and its hover fill to `danger-100/72`. At rest there is no icon and no divider treatment ' +
+          'setting it apart, so the colour is doing all the work.',
+      },
+    },
+  },
+};
+
+export const SingleAction: Story = {
+  name: 'Single action (no divider)',
+  args: { actions: [ACTIONS[0]] },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getAllByRole('menuitem')).toHaveLength(1);
+    // `index > 0` guards the rule, so a one-row menu must render none.
+    await expect(canvasElement.querySelectorAll('div[aria-hidden="true"]')).toHaveLength(0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A read-only appointment offers one action. The between-rows divider rule must not render ' +
+          'at all here, and the 22px container radius has to hold against a single 13px row.',
+      },
+    },
+  },
+};
+
+export const LongLabels: Story = {
+  name: 'Long labels truncate',
+  args: {
+    actions: [
+      { key: 'open', label: 'Open appointment in the clinical workspace', onSelect: fn() },
+      { key: 'status', label: 'Change appointment status', submenu: 'status' },
+      { key: 'room', label: 'Move to a different consulting room', submenu: 'room' },
+    ],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The label is `truncate` and the chevron is `shrink-0`, so an over-long action gives up ' +
+          'width rather than pushing the chevron out of the 220px menu.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/MenuActionsList.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/MenuActionsList.stories.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { expect, fn, userEvent, within } from 'storybook/test';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 
 import MenuActionsList from './MenuActionsList';
 import type { MenuAction, MenuSubmenu } from './appointmentContextMenuHelpers';
@@ -132,12 +132,16 @@ export const SubmenuRowActive: Story = {
     /* The attribute alone is the weak check - it flips whether or not the fill
        survived. Compare the painted background against a plain sibling instead:
        an active row that resolves to the same colour as an inactive one, or to a
-       fully transparent one, means the `bg-[var(--hairline)]` branch was dropped. */
-    const activeFill = getComputedStyle(status).backgroundColor;
-    const plainFill = getComputedStyle(plain).backgroundColor;
-    await expect(activeFill).not.toBe(plainFill);
-    await expect(activeFill).not.toBe('rgba(0, 0, 0, 0)');
-    await expect(activeFill).not.toBe('transparent');
+       fully transparent one, means the `bg-[var(--hairline)]` branch was dropped.
+       The row carries `transition-colors`, so for the first frame after the class
+       swaps the computed value is still the colour it is leaving - the read has to
+       be polled rather than taken once. */
+    await waitFor(() => {
+      const activeFill = getComputedStyle(status).backgroundColor;
+      expect(activeFill).not.toBe(getComputedStyle(plain).backgroundColor);
+      expect(activeFill).not.toBe('rgba(0, 0, 0, 0)');
+      expect(activeFill).not.toBe('transparent');
+    });
   },
   parameters: {
     docs: {

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/RequestActionButtons.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/RequestActionButtons.stories.tsx
@@ -1,0 +1,200 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+import type { Appointment } from '@yosemite-crew/types';
+
+import RequestActionButtons from './RequestActionButtons';
+
+const REQUEST: Appointment = {
+  id: 'appt-request-1',
+  patient: {
+    id: 'companion-1',
+    name: 'Poppy',
+    species: 'dog',
+    breed: 'Beagle',
+    parent: { id: 'parent-1', name: 'Maya Whitfield' },
+  },
+  organisationId: 'org-storybook',
+  appointmentDate: new Date('2026-03-12T09:30:00.000Z'),
+  startTime: new Date('2026-03-12T09:30:00.000Z'),
+  endTime: new Date('2026-03-12T10:00:00.000Z'),
+  timeSlot: '09:30 - 10:00',
+  durationMinutes: 30,
+  status: 'REQUESTED',
+};
+
+/**
+ * Both bubbles are `side="top"`, so they are placed at the trigger's top edge with a
+ * 10px gap and then clamped 8px inside the viewport. Without headroom the clamp is the
+ * only thing keeping them on screen, and the story would show the clamped placement
+ * rather than the real one.
+ */
+const Room = (Story: React.ComponentType) => (
+  <div className="flex min-h-[200px] items-end justify-center pb-8">
+    <Story />
+  </div>
+);
+
+/**
+ * Hovers one of the two circles and returns the bubble it opened, matched by its own
+ * text so a stale bubble from a neighbouring story can never satisfy the assertion.
+ * The bubble is `createPortal`ed to `document.body`, so it is outside `canvasElement`.
+ */
+const hoverFor = async (canvasElement: HTMLElement, label: string) => {
+  const canvas = within(canvasElement);
+  await userEvent.hover(canvas.getByRole('button', { name: label }));
+  return within(document.body).findByRole('tooltip', { name: label });
+};
+
+const meta = {
+  title: 'Appointments/RequestActionButtons',
+  component: RequestActionButtons,
+  decorators: [Room],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The Accept / Decline pair the calendar popover shows on a booking request. It is gated ' +
+          'twice over: `AppointmentPopover` renders it only when the popover is open, the viewer ' +
+          '`canEditAppointments`, and `isRequestedLikeStatus(appointment.status)` holds - so on any ' +
+          'other status this row does not exist at all. Nothing in Storybook had ever drawn it.\n\n' +
+          'Each circle is a 40px `rounded-full!` button (`size-10`) carrying a tinted border and ' +
+          'fill from the semantic ramps - `border-success-200 bg-success-100` for Accept, ' +
+          '`border-danger-200 bg-danger-100` for Decline - with the glyph itself coloured from ' +
+          '`--color-success-400` / `--color-danger-600`. The two are told apart by colour and by an ' +
+          'icon alone: there is no label, which is exactly why the tooltip is load-bearing rather ' +
+          'than decorative.\n\n' +
+          'That tooltip is the second gated surface. `GlassTooltip` mounts nothing until the ' +
+          'wrapper sees `mouseenter` or `focusin`, then `createPortal`s a `role="tooltip"` bubble to ' +
+          '`document.body` and positions it from the trigger rect. So the bubble lives outside the ' +
+          'component tree, outside `canvasElement`, and outside every snapshot taken of this row.\n\n' +
+          'The stories hover (and separately focus) each circle and assert the bubble carries its ' +
+          'copy, not merely that something portalled - an empty bubble would satisfy the weaker ' +
+          'check. Decline is never clicked: its handler calls `rejectAppointment`, a real axios ' +
+          'write, so these stories drive it only as far as its tooltip.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    appointment: REQUEST,
+    onAccept: fn(),
+    onClose: fn(),
+  },
+} satisfies Meta<typeof RequestActionButtons>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'At rest',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting pair: two 40px circles, `gap-2` apart, in a `shrink-0` flex row so the ' +
+          "popover's justify-between row cannot squeeze them.",
+      },
+    },
+  },
+};
+
+export const AcceptTooltip: Story = {
+  name: 'Accept tooltip',
+  play: async ({ canvasElement }) => {
+    const bubble = await hoverFor(canvasElement, 'Accept request');
+    await expect(bubble).toHaveTextContent('Accept request');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Hovering the green circle. The bubble is the only place the word "Accept" appears - the ' +
+          'button itself is a bare check glyph - so a bubble that mounts empty leaves the two ' +
+          'circles distinguishable by colour alone.',
+      },
+    },
+  },
+};
+
+export const DeclineTooltip: Story = {
+  name: 'Decline tooltip',
+  play: async ({ canvasElement }) => {
+    const bubble = await hoverFor(canvasElement, 'Decline request');
+    await expect(bubble).toHaveTextContent('Decline request');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The destructive half. Its click handler awaits `rejectAppointment` and only then calls ' +
+          '`onClose`, so a failed request leaves the popover open with the row still live - this ' +
+          'story deliberately stops at the tooltip rather than firing that write.',
+      },
+    },
+  },
+};
+
+export const FocusedTooltip: Story = {
+  name: 'Tooltip via keyboard focus',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // `focusin` is a separate listener from `mouseenter` and a separate code path;
+    // focusing directly (rather than tabbing) keeps the story independent of whatever
+    // else happens to be focusable on the page around it.
+    canvas.getByRole('button', { name: 'Accept request' }).focus();
+    const bubble = await within(document.body).findByRole('tooltip', { name: 'Accept request' });
+    await expect(bubble).toHaveTextContent('Accept request');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The keyboard path. `GlassTooltip` opens on `focusin` as well as `mouseenter`, which is ' +
+          'the only way a keyboard user learns which circle is which - and it is a branch no hover ' +
+          'story exercises.',
+      },
+    },
+  },
+};
+
+export const Accepted: Story = {
+  name: 'Accept pressed',
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Accept request' }));
+    await expect(args.onAccept).toHaveBeenCalledWith(REQUEST);
+    // Accept closes the popover unconditionally - unlike Decline, it does not wait
+    // on a network round trip before dismissing.
+    await expect(args.onClose).toHaveBeenCalled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Accept hands the whole appointment back to the popover and closes it in the same tick. ' +
+          'The optimistic close is the design: the parent owns the write and its own error surface.',
+      },
+    },
+  },
+};
+
+export const NoAcceptHandler: Story = {
+  name: 'Without an onAccept handler',
+  args: { onAccept: undefined },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Accept request' }));
+    await expect(args.onClose).toHaveBeenCalled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`onAccept` is optional and called through `?.`, so a caller that omits it still gets the ' +
+          'close. Worth pinning: the row looks identical, and the difference is only visible in ' +
+          'what happens after the press.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/RequestActionButtons.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/RequestActionButtons.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { expect, fn, userEvent, within } from 'storybook/test';
+
+import { openGlassTooltip } from '@/app/ui/primitives/GlassTooltip/storyInteractions';
 import type { Appointment } from '@yosemite-crew/types';
 
 import RequestActionButtons from './RequestActionButtons';
@@ -35,14 +37,23 @@ const Room = (Story: React.ComponentType) => (
 );
 
 /**
- * Hovers one of the two circles and returns the bubble it opened, matched by its own
- * text so a stale bubble from a neighbouring story can never satisfy the assertion.
- * The bubble is `createPortal`ed to `document.body`, so it is outside `canvasElement`.
+ * `GlassTooltip` binds `mouseenter` / `focusin` natively to its own wrapper span, and it
+ * binds them inside an effect. Storybook starts a play function before that effect has
+ * necessarily flushed, so a single dispatch at the top of a play can land on an element
+ * that is not listening yet. Measured in a probe story: the events were delivered, the
+ * bubble never opened, and it was still shut 350ms later; a redispatch loop needed three
+ * attempts. `findByRole` retries the query, never the event, so the loss is permanent.
+ *
+ * The bubble is matched by its own text so a stale one from a neighbouring story - it is
+ * `createPortal`ed to `document.body`, outside `canvasElement` - can never satisfy the
+ * assertion.
  */
+const wrapperFor = (canvasElement: HTMLElement, label: string) =>
+  within(canvasElement).getByRole('button', { name: label });
+
 const hoverFor = async (canvasElement: HTMLElement, label: string) => {
-  const canvas = within(canvasElement);
-  await userEvent.hover(canvas.getByRole('button', { name: label }));
-  return within(document.body).findByRole('tooltip', { name: label });
+  await openGlassTooltip(wrapperFor(canvasElement, label));
+  return within(document.body).getByRole('tooltip', { name: label });
 };
 
 const meta = {
@@ -138,12 +149,12 @@ export const DeclineTooltip: Story = {
 export const FocusedTooltip: Story = {
   name: 'Tooltip via keyboard focus',
   play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    // `focusin` is a separate listener from `mouseenter` and a separate code path;
-    // focusing directly (rather than tabbing) keeps the story independent of whatever
-    // else happens to be focusable on the page around it.
-    canvas.getByRole('button', { name: 'Accept request' }).focus();
-    const bubble = await within(document.body).findByRole('tooltip', { name: 'Accept request' });
+    // `focusin` is a separate listener from `mouseenter` and a separate code path.
+    // `.focus()` is not used: it dispatches no focus events at all unless the page
+    // itself has focus, which no automated run can guarantee, so the event is
+    // dispatched directly at the wrapper the component bound it to.
+    await openGlassTooltip(wrapperFor(canvasElement, 'Accept request'), { via: 'focus' });
+    const bubble = within(document.body).getByRole('tooltip', { name: 'Accept request' });
     await expect(bubble).toHaveTextContent('Accept request');
   },
   parameters: {

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/WorkspaceQuickActions.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/WorkspaceQuickActions.stories.tsx
@@ -176,9 +176,7 @@ export const EveryTooltip: Story = {
          fresh pointer position each call, so it never emits the `mouseleave`
          that closes the previous bubble - without this the portals accumulate. */
       await userEvent.unhover(wrapper);
-      await waitFor(async () => {
-        await expect(within(document.body).queryByRole('tooltip')).toBeNull();
-      });
+      await waitFor(() => expect(within(document.body).queryByRole('tooltip')).toBeNull());
     }
   },
   parameters: {

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/WorkspaceQuickActions.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/WorkspaceQuickActions.stories.tsx
@@ -1,0 +1,259 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import type { Appointment } from '@yosemite-crew/types';
+
+import WorkspaceQuickActions from './WorkspaceQuickActions';
+
+const APPOINTMENT: Appointment = {
+  id: 'appt-quick-actions-1',
+  patient: {
+    id: 'companion-1',
+    name: 'Poppy',
+    species: 'dog',
+    breed: 'Beagle',
+    parent: { id: 'parent-1', name: 'Maya Whitfield' },
+  },
+  companion: {
+    id: 'companion-1',
+    name: 'Poppy',
+    species: 'dog',
+    breed: 'Beagle',
+    parent: { id: 'parent-1', name: 'Maya Whitfield' },
+  },
+  organisationId: 'org-storybook',
+  appointmentDate: new Date('2026-03-12T09:30:00.000Z'),
+  startTime: new Date('2026-03-12T09:30:00.000Z'),
+  endTime: new Date('2026-03-12T10:00:00.000Z'),
+  timeSlot: '09:30 - 10:00',
+  durationMinutes: 30,
+  status: 'UPCOMING',
+};
+
+const withStatus = (status: Appointment['status']): Appointment => ({ ...APPOINTMENT, status });
+
+/**
+ * Stands in for the popover the rail lives in: the same 440px panel width, and
+ * enough height above it for the `side="top"` bubbles, which are positioned from
+ * the trigger rect and clamp themselves to the viewport.
+ */
+const Popover = (Story: React.ComponentType) => (
+  <div className="flex min-h-[240px] items-end justify-center p-6">
+    <div className="w-[440px] rounded-3xl border border-card-border bg-neutral-0 p-5">
+      <Story />
+    </div>
+  </div>
+);
+
+/** GlassTooltip binds mouseenter/focusin to its own wrapper span, not the button. */
+const wrapperFor = (canvasElement: HTMLElement, accessibleName: string) =>
+  within(canvasElement)
+    .getByRole('button', { name: accessibleName })
+    .closest('.glass-tooltip') as HTMLElement;
+
+/** Hovers a rail button's tooltip wrapper and returns the portalled bubble. */
+const hoverAction = async (canvasElement: HTMLElement, accessibleName: string) => {
+  await userEvent.hover(wrapperFor(canvasElement, accessibleName));
+  return within(document.body).findByRole('tooltip');
+};
+
+const meta = {
+  title: 'Appointments/WorkspaceQuickActions',
+  component: WorkspaceQuickActions,
+  decorators: [Popover],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The round action rail inside the calendar appointment popover: overview, finance, labs, ' +
+          'and - depending on status and permission - reschedule, assign room, and the clinical ' +
+          'notes entry point.\n\n' +
+          'Every label on this rail is **doubly gated**. The rail itself only exists while the ' +
+          'popover is open, and each label is a `GlassTooltip` bubble that is not constructed until ' +
+          '`mouseenter` or `focusin` fires, at which point it is `createPortal`ed to ' +
+          '`document.body` and positioned from the trigger rect. Nothing about a resting render - ' +
+          'in Storybook, in Chromatic, or in a DOM snapshot - contains a single one of them.\n\n' +
+          'The layout fact worth drawing is the overflow. The rail is a fixed `w-48` (192px) with ' +
+          '`overflow-x-auto` and `scrollbar-hidden`, while six 48px buttons and five 8px gaps come ' +
+          'to 328px. So on an UPCOMING appointment more than a third of the rail is off-panel ' +
+          'behind an invisible scrollbar, reachable only by the wheel handler. That is a real ' +
+          'discoverability question, and it is only visible with the popover open and every ' +
+          'conditional button rendered.\n\n' +
+          'Which buttons render is derived, not passed: `allowReschedule` admits only NO_PAYMENT, ' +
+          'REQUESTED and UPCOMING, while `canAssignAppointmentRoom` admits UPCOMING, CHECKED_IN and ' +
+          'IN_PROGRESS - so the two conditional buttons overlap on exactly one status. The stories ' +
+          'below walk that, and assert each opened bubble has its text rather than asserting a ' +
+          'trigger changed state, which an empty bubble would also satisfy.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    appointment: APPOINTMENT,
+    canEditAppointments: true,
+    clinicalNotesLabel: 'Medical Records',
+    onActionBarWheel: fn(),
+    onOpenCompanionHistory: fn(),
+    onOpenWorkspace: fn(),
+    onReschedule: fn(),
+    onChangeRoom: fn(),
+  },
+} satisfies Meta<typeof WorkspaceQuickActions>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Full rail (upcoming)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // UPCOMING is the only status where both conditional buttons render, so this
+    // is the widest the rail ever gets.
+    await expect(canvas.getAllByRole('button')).toHaveLength(6);
+
+    /* The rail is 192px and its content is not. Assert the overflow rather than
+       describing it: if a future change unfixes the width, this is the story
+       that notices. */
+    const rail = canvasElement.querySelector('.scrollbar-hidden') as HTMLElement;
+    await expect(rail.scrollWidth).toBeGreaterThan(rail.clientWidth);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'All six buttons, with the last two sitting outside the 192px window. Nothing marks the ' +
+          'rail as scrollable, so this render is the argument for the wheel handler existing.',
+      },
+    },
+  },
+};
+
+export const OverviewTooltip: Story = {
+  name: 'Tooltip: Overview',
+  play: async ({ canvasElement }) => {
+    const bubble = await hoverAction(canvasElement, 'Appointment overview');
+    await expect(bubble).toHaveTextContent('Overview');
+    /* side="top" - the bubble sits above the button, which is the placement that
+       has to clear the popover's own chrome. Read the inline transform, not the
+       computed one: a laid-out element resolves any transform to a `matrix(...)`,
+       so a computed-style check cannot tell the placements apart. */
+    await expect(bubble.style.transform).toBe('translate(-50%, -100%)');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The first bubble. Its label ("Overview") is deliberately not the button\'s accessible ' +
+          'name ("Appointment overview"), so the visible text here cannot be read off the resting ' +
+          'markup at all.',
+      },
+    },
+  },
+};
+
+export const EveryTooltip: Story = {
+  name: 'Tooltips: whole rail',
+  play: async ({ canvasElement }) => {
+    const expectations: Array<[string, string]> = [
+      ['Appointment overview', 'Overview'],
+      ['Finance summary', 'Finance summary'],
+      ['Lab tests', 'Lab tests'],
+      ['Reschedule appointment', 'Reschedule'],
+      ['Assign room', 'Assign room'],
+      ['Medical Records', 'Medical Records'],
+    ];
+
+    for (const [accessibleName, label] of expectations) {
+      const wrapper = wrapperFor(canvasElement, accessibleName);
+      await userEvent.hover(wrapper);
+      const bubble = await within(document.body).findByRole('tooltip');
+      await expect(bubble).toHaveTextContent(label);
+      // Exactly one live portal at a time - two would stack on top of each other
+      // on document.body, since both are absolutely positioned there.
+      await expect(within(document.body).getAllByRole('tooltip')).toHaveLength(1);
+
+      /* Unhover explicitly. `userEvent.hover` from the direct API starts with a
+         fresh pointer position each call, so it never emits the `mouseleave`
+         that closes the previous bubble - without this the portals accumulate. */
+      await userEvent.unhover(wrapper);
+      await waitFor(async () => {
+        await expect(within(document.body).queryByRole('tooltip')).toBeNull();
+      });
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Every label on the rail, opened and dismissed in turn. It also pins the teardown down: ' +
+          'each bubble must be gone before the next opens, since they are absolutely positioned ' +
+          'siblings on `document.body` and would otherwise overlap rather than replace each other.',
+      },
+    },
+  },
+};
+
+export const ClinicalNotesLabel: Story = {
+  name: 'Clinic wording (Care)',
+  args: { clinicalNotesLabel: 'Care' },
+  play: async ({ canvasElement }) => {
+    const bubble = await hoverAction(canvasElement, 'Care');
+    await expect(bubble).toHaveTextContent('Care');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A clinic that is not a HOSPITAL gets "Care" instead of "Medical Records" for the same ' +
+          'button. The label reaches the tooltip, the `title`, and the `aria-label` from one prop, ' +
+          'so the shorter wording changes the bubble width - and only the open bubble shows it.',
+      },
+    },
+  },
+};
+
+export const InProgress: Story = {
+  name: 'In progress (no reschedule)',
+  args: { appointment: withStatus('IN_PROGRESS') },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getAllByRole('button')).toHaveLength(5);
+    await expect(canvas.queryByRole('button', { name: 'Reschedule appointment' })).toBeNull();
+    await expect(canvas.getByRole('button', { name: 'Assign room' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'An in-progress appointment can still be moved to another room but can no longer be ' +
+          'rescheduled, so the two conditionals disagree. This is the only render that separates ' +
+          'them.',
+      },
+    },
+  },
+};
+
+export const ReadOnly: Story = {
+  name: 'Read-only (no edit permission)',
+  args: { canEditAppointments: false },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Both conditional buttons are gated on the permission first, so the rail
+    // drops to the four unconditional actions regardless of status.
+    await expect(canvas.getAllByRole('button')).toHaveLength(4);
+    // Still wider than its 192px window: 4 x 48px plus 3 x 8px is 216px, so even
+    // the narrowest rail hides its last button.
+    const rail = canvasElement.querySelector('.scrollbar-hidden') as HTMLElement;
+    await expect(rail.scrollWidth).toBeGreaterThan(rail.clientWidth);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Without edit permission the rail is four buttons - and still overflows, because four ' +
+          '48px buttons and three 8px gaps come to 216px against a 192px window. The rail never ' +
+          'fits at any status, which is easier to argue with this story beside the full one.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/WorkspaceQuickActions.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/WorkspaceQuickActions.stories.tsx
@@ -60,10 +60,9 @@ const wrapperFor = (canvasElement: HTMLElement, accessibleName: string) =>
     .getByRole('button', { name: accessibleName })
     .closest('.glass-tooltip') as HTMLElement;
 
-/** Hovers a rail button's tooltip wrapper and returns the portalled bubble. */
-const hoverAction = async (canvasElement: HTMLElement, accessibleName: string) => {
-  return openGlassTooltip(wrapperFor(canvasElement, accessibleName));
-};
+/** Opens a rail button's bubble and returns it. */
+const hoverAction = (canvasElement: HTMLElement, accessibleName: string) =>
+  openGlassTooltip(wrapperFor(canvasElement, accessibleName));
 
 const meta = {
   title: 'Appointments/WorkspaceQuickActions',

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/WorkspaceQuickActions.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/WorkspaceQuickActions.stories.tsx
@@ -1,5 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import { expect, fn, within } from 'storybook/test';
+
+import {
+  closeGlassTooltip,
+  openGlassTooltip,
+} from '@/app/ui/primitives/GlassTooltip/storyInteractions';
 import type { Appointment } from '@yosemite-crew/types';
 
 import WorkspaceQuickActions from './WorkspaceQuickActions';
@@ -44,7 +49,12 @@ const Popover = (Story: React.ComponentType) => (
   </div>
 );
 
-/** GlassTooltip binds mouseenter/focusin to its own wrapper span, not the button. */
+/**
+ * GlassTooltip binds mouseenter/focusin to its own wrapper span, not the button - and
+ * binds them in an effect, which has not necessarily flushed when a play function
+ * starts. `openGlassTooltip` redispatches until the listener is there to receive one;
+ * a single hover is silently dropped and no query-level retry can recover it.
+ */
 const wrapperFor = (canvasElement: HTMLElement, accessibleName: string) =>
   within(canvasElement)
     .getByRole('button', { name: accessibleName })
@@ -52,8 +62,7 @@ const wrapperFor = (canvasElement: HTMLElement, accessibleName: string) =>
 
 /** Hovers a rail button's tooltip wrapper and returns the portalled bubble. */
 const hoverAction = async (canvasElement: HTMLElement, accessibleName: string) => {
-  await userEvent.hover(wrapperFor(canvasElement, accessibleName));
-  return within(document.body).findByRole('tooltip');
+  return openGlassTooltip(wrapperFor(canvasElement, accessibleName));
 };
 
 const meta = {
@@ -165,18 +174,17 @@ export const EveryTooltip: Story = {
 
     for (const [accessibleName, label] of expectations) {
       const wrapper = wrapperFor(canvasElement, accessibleName);
-      await userEvent.hover(wrapper);
-      const bubble = await within(document.body).findByRole('tooltip');
+      const bubble = await openGlassTooltip(wrapper);
       await expect(bubble).toHaveTextContent(label);
       // Exactly one live portal at a time - two would stack on top of each other
       // on document.body, since both are absolutely positioned there.
       await expect(within(document.body).getAllByRole('tooltip')).toHaveLength(1);
 
-      /* Unhover explicitly. `userEvent.hover` from the direct API starts with a
-         fresh pointer position each call, so it never emits the `mouseleave`
-         that closes the previous bubble - without this the portals accumulate. */
-      await userEvent.unhover(wrapper);
-      await waitFor(() => expect(within(document.body).queryByRole('tooltip')).toBeNull());
+      /* Close it explicitly. Opening the next chip does not close this one: each
+         wrapper owns its own portal and only its own `mouseleave` tears it down, so
+         without this the bubbles accumulate on `document.body` and the count above
+         starts passing for the wrong reason. */
+      await closeGlassTooltip(wrapper);
     }
   },
   parameters: {

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneMonthOverview.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneMonthOverview.stories.tsx
@@ -109,14 +109,6 @@ const MONTH = new Date('2026-07-14T12:00:00.000Z');
 /** Pinned so `isToday` / `isPast` never drift with the machine clock. */
 const TODAY = new Date('2026-07-14T12:00:00.000Z');
 
-const PHONE_VIEWPORT = {
-  phone: {
-    name: 'Mobile (375)',
-    styles: { width: '375px', height: '812px' },
-    type: 'mobile',
-  },
-};
-
 /** The overview is a phone surface; a desktop-width canvas stretches the dot grid. */
 const Phone = (Story: React.ComponentType) => (
   <div className="mx-auto w-[375px] bg-[var(--screen)] p-4">
@@ -153,10 +145,9 @@ const meta = {
   title: 'Appointments/Calendar/PhoneMonthOverview',
   component: PhoneMonthOverview,
   decorators: [Phone],
-  globals: { viewport: { value: 'phone', isRotated: false } },
+  globals: { viewport: { value: 'mobile', isRotated: false } },
   parameters: {
     layout: 'fullscreen',
-    viewport: { options: PHONE_VIEWPORT },
     chromatic: { viewports: [375] },
     docs: {
       description: {

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneMonthOverview.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneMonthOverview.stories.tsx
@@ -234,7 +234,7 @@ export const TapRevealsPeek: Story = {
 
     // Assert the peek has real content, not just that a day flipped aria-pressed:
     // a header, three rows, the overflow line and the Open day affordance.
-    await expect(await canvas.findByText('Wed 8 · 12 appointments')).toBeInTheDocument();
+    expect(await canvas.findByText('Wed 8 · 12 appointments')).toBeInTheDocument();
     await expect(canvas.getByRole('button', { name: /open day/i })).toBeInTheDocument();
     await expect(canvas.getByText('+9 more · swipe up')).toBeInTheDocument();
     await expect(canvas.getByText('EMERGENCY')).toBeInTheDocument();

--- a/apps/frontend/src/app/features/appointments/components/DateTimePickerSection.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/DateTimePickerSection.stories.tsx
@@ -1,0 +1,280 @@
+import { useState, type ComponentProps } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+
+import type { Slot } from '@/app/features/appointments/types/appointments';
+import DateTimePickerSection from './DateTimePickerSection';
+
+const SELECTED_DATE = new Date('2026-03-12T00:00:00');
+
+const TIME_SLOTS: Slot[] = [
+  { startTime: '09:00', endTime: '09:30', vetIds: ['vet-1'] },
+  { startTime: '09:30', endTime: '10:00', vetIds: ['vet-1', 'vet-2'] },
+  { startTime: '10:00', endTime: '10:30', vetIds: ['vet-2'] },
+  { startTime: '10:30', endTime: '11:00', vetIds: ['vet-1'] },
+];
+
+const LEAD_OPTIONS = [
+  { label: 'Dr. Lena Hartmann', value: 'vet-1' },
+  { label: 'Dr. Ravi Chandrasekaran', value: 'vet-2' },
+  { label: 'Dr. Amara Osei', value: 'vet-3' },
+];
+
+const TEAM_OPTIONS = [
+  { label: 'Nurse Priya Raman', value: 'staff-1' },
+  { label: 'Nurse Tom Aldridge', value: 'staff-2' },
+  { label: 'Tech Marisol Vega', value: 'staff-3' },
+  { label: 'Tech Jonas Berg', value: 'staff-4' },
+];
+
+type SectionProps = ComponentProps<typeof DateTimePickerSection>;
+
+type HarnessProps = Omit<
+  SectionProps,
+  'selectedDate' | 'setSelectedDate' | 'selectedSlot' | 'setSelectedSlot' | 'supportStaffIds'
+> & {
+  initialDate?: Date;
+  initialSlot?: Slot | null;
+  initialSupportStaff?: string[];
+};
+
+/**
+ * The section is fully controlled by the appointment modal above it, so the
+ * date, the chosen slot and the support-staff selection all have to live
+ * somewhere for the panels to be openable at all.
+ */
+const DateTimePickerHarness = ({
+  initialDate = SELECTED_DATE,
+  initialSlot = null,
+  initialSupportStaff = [],
+  onSupportStaffChange,
+  ...rest
+}: HarnessProps) => {
+  const [selectedDate, setSelectedDate] = useState(initialDate);
+  const [selectedSlot, setSelectedSlot] = useState<Slot | null>(initialSlot);
+  const [supportStaffIds, setSupportStaffIds] = useState<string[]>(initialSupportStaff);
+
+  return (
+    <DateTimePickerSection
+      {...rest}
+      selectedDate={selectedDate}
+      setSelectedDate={setSelectedDate}
+      selectedSlot={selectedSlot}
+      setSelectedSlot={setSelectedSlot}
+      supportStaffIds={supportStaffIds}
+      onSupportStaffChange={(ids) => {
+        setSupportStaffIds(ids);
+        onSupportStaffChange?.(ids);
+      }}
+    />
+  );
+};
+
+/**
+ * Both dropdowns portal their panel to document.body and tag it the same way.
+ * The panel renders one frame after the click - it waits on the layout effect
+ * that measures the trigger - so this polls rather than reading once.
+ */
+const findPortalPanel = async (): Promise<HTMLElement> => {
+  await waitFor(() => expect(document.querySelector('[data-portal-dropdown]')).toBeInTheDocument());
+  return document.querySelector('[data-portal-dropdown]') as HTMLElement;
+};
+
+const meta = {
+  title: 'Appointments/DateTimePickerSection',
+  component: DateTimePickerHarness,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The scheduling half of the add/edit appointment modal: the horizontal `Slotpicker`, a ' +
+          'read-only Date/Time pair in a `grid grid-cols-2 gap-3`, the Lead `LabelDropdown` and ' +
+          'the support-staff `MultiSelectDropdown`.\n\n' +
+          'Both dropdowns hide their entire panel behind a click **and** behind a portal. ' +
+          '`useDropdownPositioning` measures the trigger and writes ' +
+          '`position: absolute; left: rect.left + scrollX; top: rect.bottom + scrollY; ' +
+          'width: rect.width; zIndex: 5000` onto a list `createPortal`ed to `document.body`. The ' +
+          "panel is therefore not a descendant of this section at all - it is not in the story's " +
+          'canvas element, and no snapshot of the closed section contains a single one of its ' +
+          'rows. The height is measured too: `maxHeight` is clamped to the space below the ' +
+          'trigger, between 72px and 200px, so the same list scrolls or does not depending purely ' +
+          'on where the modal sits on screen.\n\n' +
+          'The two panels are also visually unrelated, which is only apparent side by side. Lead ' +
+          'renders a detached `rounded-[13px]` card 4px below the trigger with `p-1.5` and ' +
+          '`rounded-[8px]` 12.5px/600 rows on `--nav-active-bg`. Support renders a *connected* ' +
+          'panel: the trigger loses its bottom border and its bottom radius ' +
+          '(`border-b-0 rounded-t-[12px]`) while the panel takes `rounded-b-[12px]` and a ' +
+          '`--blue` border, so trigger and list read as one control. A change to either radius ' +
+          'or border on its own splits the seam, and nothing but an open panel shows it.\n\n' +
+          'Two further states replace whole subtrees rather than restyling them: `isLoadingSlot` ' +
+          'swaps both the Time field and the entire Lead dropdown for `min-h-12` pulse ' +
+          'skeletons, and `hideDateSlotPicker` drops the `Slotpicker` so the section starts at ' +
+          'the Date/Time row.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    timeSlots: TIME_SLOTS,
+    leadOptions: LEAD_OPTIONS,
+    teamOptions: TEAM_OPTIONS,
+    onLeadSelect: fn(),
+    onSupportStaffChange: fn(),
+    showSupportStaff: true,
+    hideDateSlotPicker: false,
+    isLoadingSlot: false,
+  },
+} satisfies Meta<typeof DateTimePickerHarness>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Resting',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Slot strip, the read-only Date/Time pair, and both dropdowns closed. The Date and Time ' +
+          'inputs are `readonly` with `tabIndex={-1}` and blur themselves on focus - they are ' +
+          'display surfaces for the picker above, never typed into.',
+      },
+    },
+  },
+};
+
+export const LeadPanelOpen: Story = {
+  name: 'Lead panel open',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Lead' }));
+    const panel = await findPortalPanel();
+    // Assert the panel really mounted its three clinicians. `aria-expanded` on
+    // the trigger flips whether or not the list rendered anything.
+    await expect(within(panel).getAllByRole('button')).toHaveLength(3);
+    await expect(within(panel).getByText('Dr. Ravi Chandrasekaran')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The portalled listbox, detached 4px below a trigger whose border turns `--blue` with a ' +
+          '3px `--glow-b10` ring. Opening it also swaps the trigger content: the selected label is ' +
+          'replaced by a search input (`aria-label="Search Lead"`), so the resting and open ' +
+          'triggers are different DOM.',
+      },
+    },
+  },
+};
+
+export const LeadSelected: Story = {
+  name: 'Lead panel open (one selected)',
+  args: { leadId: 'vet-2' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Lead: Dr. Ravi Chandrasekaran' }));
+    const panel = await findPortalPanel();
+    await expect(within(panel).getAllByRole('button')).toHaveLength(3);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'With a lead resolved, the active row takes the `--nav-active-bg` wash and ' +
+          '`--nav-active` ink. That is the only difference between the selected row and its ' +
+          'neighbours - there is no check mark here, unlike the multi-select panel below.',
+      },
+    },
+  },
+};
+
+export const SupportPanelOpen: Story = {
+  name: 'Support panel open',
+  args: { initialSupportStaff: ['staff-1', 'staff-3'] },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', {
+      name: 'Support: Nurse Priya Raman, Tech Marisol Vega',
+    });
+    await userEvent.click(trigger);
+    const panel = await findPortalPanel();
+    const rows = within(panel).getAllByRole('button');
+    await expect(rows).toHaveLength(4);
+    // The selected rows are marked with aria-pressed plus a trailing check. An
+    // empty or unmarked panel would still satisfy the trigger's aria-expanded.
+    await expect(rows.filter((row) => row.getAttribute('aria-pressed') === 'true')).toHaveLength(2);
+    // The seam: while open the trigger drops its bottom border so it joins the panel.
+    await expect(trigger.className).toContain('border-b-0!');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Four staff, two already chosen, each selected row carrying an `IoCheckmarkOutline` in ' +
+          '`--text-brand`. The trigger collapses its selection to a comma-joined `truncate` label, ' +
+          'so the full list only exists in the accessible name and in this panel.',
+      },
+    },
+  },
+};
+
+export const LoadingSlots: Story = {
+  name: 'Loading slots',
+  args: { isLoadingSlot: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Not a dimmed dropdown - the whole Lead control is unmounted and replaced.
+    await expect(canvas.queryByRole('button', { name: 'Lead' })).not.toBeInTheDocument();
+    await expect(canvas.queryByLabelText('Time')).not.toBeInTheDocument();
+    // The Date field is deliberately NOT skeletonised, so the grid stays half real.
+    await expect(canvas.getByLabelText('Date')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'While availability is in flight the Time field and the Lead dropdown become ' +
+          '`min-h-12 rounded-xl bg-neutral-100 animate-pulse` blocks, but the Date field and the ' +
+          'support dropdown stay live. The asymmetric result - a 44px real field beside a 48px ' +
+          'skeleton in the same two-column grid - is the thing to look at here.',
+      },
+    },
+  },
+};
+
+export const SlotError: Story = {
+  name: 'Slot error',
+  args: { slotError: 'Pick a time slot to continue', leadError: 'Assign a lead clinician' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Pick a time slot to continue')).toBeInTheDocument();
+    await expect(canvas.getByText('Assign a lead clinician')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Both error lines at once. They sit *below* their fields inside the same flex column, so ' +
+          'they push the Lead dropdown and the support dropdown down - the Time error only ' +
+          'reserves `min-h-6`, the Lead error does not, and the two rows end up at different ' +
+          'heights.',
+      },
+    },
+  },
+};
+
+export const WithoutSlotPicker: Story = {
+  name: 'Reschedule (picker hidden)',
+  args: { hideDateSlotPicker: true, showSupportStaff: false, initialSlot: TIME_SLOTS[1] },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The variant used where the date is already fixed by the caller: no `Slotpicker`, no ' +
+          'support dropdown, just the read-only pair and the lead. A third of the section is ' +
+          'gone, and the remaining fields keep their own `gap-3` rather than re-flowing.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/DischargeDateTimeModal.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/DischargeDateTimeModal.stories.tsx
@@ -1,0 +1,665 @@
+import { useState, type ComponentProps } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+
+import type { WorkspaceFinalizationGate } from '@/app/features/appointments/types/workspace';
+
+import { DischargeDateTimeModal } from './index';
+
+type DischargeModalProps = ComponentProps<typeof DischargeDateTimeModal>;
+
+/** Fixed so the two picker buttons carry stable accessible names in every story. */
+const DISCHARGE_DATE = new Date(2026, 7, 19, 14, 30);
+const DATE_BUTTON = 'Discharge date: Aug 19, 2026, toggle calendar';
+const TIME_BUTTON = 'Discharge time: 14:30';
+const OVERRIDE_LABEL = 'Override reason (required)';
+
+const GATE_REASON =
+  'Two lab results are still pending and the invoice has not been marked ready for billing.';
+
+const BLOCKED_GATE: WorkspaceFinalizationGate = {
+  enabled: false,
+  disabledReason: GATE_REASON,
+  requiredSoapOrDischargeComplete: true,
+  requiredFormsSigned: true,
+  pendingLabsResolved: false,
+  billingReady: false,
+};
+
+const CLEAR_GATE: WorkspaceFinalizationGate = {
+  enabled: true,
+  requiredSoapOrDischargeComplete: true,
+  requiredFormsSigned: true,
+  pendingLabsResolved: true,
+  billingReady: true,
+};
+
+/* ------------------------------------------------------------------ *
+ * Contrast measurement
+ *
+ * `--color-danger-100` is a flat `#fdebea` in light but `rgba(234, 55, 41,
+ * 0.18)` in dark, so in dark what the reader sees behind the override panel is
+ * that red composited over the dialog's own `--color-neutral-0`. Reading one
+ * `backgroundColor` therefore proves nothing there: it returns the declared
+ * translucent value, not the colour on screen. These helpers composite the
+ * layers in paint order, which is the only way to compare an ink against the
+ * ground it actually lands on.
+ * ------------------------------------------------------------------ */
+
+type Rgb = { r: number; g: number; b: number; a: number };
+
+const OPAQUE_WHITE: Rgb = { r: 255, g: 255, b: 255, a: 1 };
+
+/**
+ * Throws rather than guessing on anything that is not `rgb()`/`rgba()`.
+ * Chrome serializes `oklch()` back as `oklch()`, and a silent misparse of one
+ * would turn every ratio below into a number that means nothing while still
+ * passing - the exact failure mode this file exists to catch.
+ */
+const parseRgb = (value: string): Rgb => {
+  if (!value.startsWith('rgb')) {
+    throw new Error(`Expected an rgb()/rgba() computed colour, got "${value}"`);
+  }
+  const parts = value.match(/[\d.]+/g)?.map(Number) ?? [];
+  return { r: parts[0] ?? 0, g: parts[1] ?? 0, b: parts[2] ?? 0, a: parts[3] ?? 1 };
+};
+
+/** `top` painted over `bottom`, in sRGB, the way the compositor does it. */
+const composite = (top: Rgb, bottom: Rgb): Rgb => ({
+  r: top.r * top.a + bottom.r * (1 - top.a),
+  g: top.g * top.a + bottom.g * (1 - top.a),
+  b: top.b * top.a + bottom.b * (1 - top.a),
+  a: 1,
+});
+
+/**
+ * The opaque colour painted at `start`, including `start`'s own background.
+ *
+ * The walk deliberately begins at the element rather than at its parent. An
+ * element's own background is part of the ground its text sits on, and the
+ * override textarea here is one `bg-*` class away from having one: a parent-up
+ * walk would then keep measuring the ink against the status tint it no longer
+ * touches and report a ratio for a pairing that is not on screen.
+ */
+const groundAt = (start: HTMLElement | null): Rgb => {
+  const layers: Rgb[] = [];
+  let node = start;
+  while (node) {
+    const layer = parseRgb(getComputedStyle(node).backgroundColor);
+    if (layer.a > 0) layers.push(layer);
+    if (layer.a === 1) break;
+    node = node.parentElement;
+  }
+  // layers[0] is nearest the element, so composite from the bottom of the stack up.
+  return layers.reduceRight((under, layer) => composite(layer, under), OPAQUE_WHITE);
+};
+
+const channel = (value: number): number => {
+  const srgb = value / 255;
+  return srgb <= 0.04045 ? srgb / 12.92 : ((srgb + 0.055) / 1.055) ** 2.4;
+};
+
+const luminance = ({ r, g, b }: Rgb): number =>
+  0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+
+const contrastRatio = (ink: Rgb, ground: Rgb): number => {
+  const inkL = luminance(ink);
+  const groundL = luminance(ground);
+  return (Math.max(inkL, groundL) + 0.05) / (Math.min(inkL, groundL) + 0.05);
+};
+
+/**
+ * How far a ground leans red: how far the red channel outruns the other two.
+ *
+ * Used instead of a contrast ratio between the tint and the dialog, because in
+ * light those two are `#fdebea` on `#f7f3ec` - 1.04:1, by design. A "they are
+ * different colours" assertion therefore passes on a one-digit difference and
+ * proves nothing. The hue lean is what actually separates a status tint from
+ * the surface: 18.5 vs 7.5 in light, 44 vs 12.5 in dark. A `--color-danger-100`
+ * that collapsed onto the neutral surface would land inside a point of it.
+ */
+const redness = ({ r, g, b }: Rgb): number => r - (g + b) / 2;
+
+const rgbString = ({ r, g, b }: Rgb): string =>
+  `rgb(${Math.round(r)}, ${Math.round(g)}, ${Math.round(b)})`;
+
+/**
+ * Asserts an ink is not the colour of the ground under it, and clears AA.
+ *
+ * Polled rather than read once: the dialog fades in on a `transition-opacity`
+ * and several controls carry `transition-colors`, so a single synchronous read
+ * can land on an interpolated frame and either pass or fail for the wrong
+ * reason.
+ */
+const expectReadable = (el: HTMLElement, minRatio = 4.5) =>
+  waitFor(() => {
+    const ground = groundAt(el);
+    const ink = composite(parseRgb(getComputedStyle(el).color), ground);
+    expect(rgbString(ink)).not.toBe(rgbString(ground));
+    expect(contrastRatio(ink, ground)).toBeGreaterThanOrEqual(minRatio);
+  });
+
+/** `ModalBase` portals to `document.body`, so nothing here is in `canvasElement`. */
+const openPanel = async (): Promise<HTMLElement> => {
+  await waitFor(() => {
+    expect(document.querySelector('dialog[open]')).toBeInTheDocument();
+  });
+  return document.querySelector('dialog[open]') as HTMLElement;
+};
+
+/**
+ * Real state behind the four setters the component drives.
+ *
+ * `showModal` stays arg-driven (the harness only records a dismissal) so the
+ * Closed story still works from args alone, while the date, time and override
+ * reason are held locally - without that the textarea is read-only and the
+ * override branch cannot be reached at all.
+ */
+const Harness = ({
+  showModal,
+  setShowModal,
+  dischargeDate,
+  setDischargeDate,
+  dischargeTime,
+  setDischargeTime,
+  overrideReason,
+  setOverrideReason,
+  ...rest
+}: DischargeModalProps) => {
+  const [dismissed, setDismissed] = useState(false);
+  const [date, setDate] = useState<Date | null>(dischargeDate);
+  const [time, setTime] = useState(dischargeTime);
+  const [reason, setReason] = useState(overrideReason);
+  const isOpen = showModal && !dismissed;
+
+  return (
+    <div className="min-h-[560px] bg-[var(--page)] p-6">
+      <p className="text-body-4 text-[var(--ink-muted)]">
+        The Summary step behind the scrim. The dialog is opened from the terminal action there, so
+        the backdrop tint and blur are part of what this surface looks like.
+      </p>
+      <DischargeDateTimeModal
+        {...rest}
+        showModal={isOpen}
+        setShowModal={(next) => {
+          const value = typeof next === 'function' ? next(isOpen) : next;
+          setDismissed(!value);
+          setShowModal(value);
+        }}
+        dischargeDate={date}
+        setDischargeDate={(next) => {
+          setDate(next);
+          setDischargeDate(next);
+        }}
+        dischargeTime={time}
+        setDischargeTime={(next) => {
+          setTime(next);
+          setDischargeTime(next);
+        }}
+        overrideReason={reason}
+        setOverrideReason={(next) => {
+          setReason(next);
+          setOverrideReason(next);
+        }}
+      />
+    </div>
+  );
+};
+
+/**
+ * The whole point of this file. Shared by the light and dark gate stories so
+ * the two measure exactly the same inks against exactly the same grounds.
+ */
+const assertBlockedGate = async () => {
+  const dialog = await openPanel();
+  const panel = within(dialog);
+
+  await expect(panel.getByRole('heading', { name: 'Discharge date & time' })).toBeInTheDocument();
+
+  const reason = panel.getByText(GATE_REASON);
+  const tint = reason.parentElement as HTMLElement;
+  const label = panel.getByText(OVERRIDE_LABEL);
+  // One field, and it is the one the label names - the textarea is wrapped by
+  // the <label> rather than wired with htmlFor, which is easy to break silently.
+  await expect(panel.getAllByRole('textbox')).toHaveLength(1);
+  const field = panel.getByLabelText(OVERRIDE_LABEL);
+  await expect(field).toHaveAttribute('rows', '2');
+
+  /* Two children, stacked: the refusal sentence then the labelled field. A tint
+     that lost its `flex-col` puts the sentence and the textarea side by side at
+     roughly half width each, which no colour assertion would notice. */
+  await expect(tint.children).toHaveLength(2);
+  await expect(tint.children[0]).toBe(reason);
+  await expect(tint.children[1]).toBe(label);
+  await expect(getComputedStyle(tint).flexDirection).toBe('column');
+
+  /* And it sits above the fields it is refusing, not under them. The panel is
+     rendered before the picker column in JSX and nothing else enforces that. */
+  const dateButton = panel.getByRole('button', { name: DATE_BUTTON });
+  await expect(tint.getBoundingClientRect().bottom).toBeLessThanOrEqual(
+    dateButton.getBoundingClientRect().top
+  );
+
+  /* The tint has to read as its own ground. If `--color-danger-100` collapsed
+     onto the dialog's `--color-neutral-0` the panel would still be in the tree,
+     still hold its text, and be invisible - which is how PackageBreakdownTooltip
+     shipped a seven-column table at 1.00:1 in both themes. Asserting only that
+     the two differ is not enough here: in light they are legitimately 1.04:1
+     apart, so that check passes on a single-digit drift. The hue lean is the
+     thing that separates a status tint from a surface. */
+  await waitFor(() => {
+    const tintGround = groundAt(tint);
+    const dialogGround = groundAt(tint.parentElement);
+    expect(rgbString(tintGround)).not.toBe(rgbString(dialogGround));
+    expect(redness(tintGround) - redness(dialogGround)).toBeGreaterThanOrEqual(8);
+  });
+
+  // Three separate inks, all of them on that tint rather than on the dialog.
+  await expectReadable(reason);
+  await expectReadable(label);
+
+  // The confirm is relabelled and inert until a reason exists; cancel is not.
+  await expect(panel.getByRole('button', { name: 'Override & discharge' })).toBeDisabled();
+  await expect(panel.getByRole('button', { name: 'Cancel' })).toBeEnabled();
+  await expect(panel.queryByRole('button', { name: 'Confirm discharge' })).not.toBeInTheDocument();
+
+  await userEvent.type(field, 'Owner collecting early against advice.');
+  await expect(field).toHaveValue('Owner collecting early against advice.');
+  // The textarea declares no background of its own, so the typed ink lands
+  // straight on the tint too - measured only now that there is real text in it.
+  await expectReadable(field);
+  await expect(panel.getByRole('button', { name: 'Override & discharge' })).toBeEnabled();
+};
+
+const meta = {
+  title: 'Workspace/DischargeDateTimeModal',
+  component: DischargeDateTimeModal,
+  render: (args) => <Harness {...args} />,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The confirmation dialog for discharging an inpatient encounter, and the only place in ' +
+          "the product where a clinician can discharge against the backend's own readiness " +
+          'gate.\n\n' +
+          'It was declared as a module-private const inside `AppointmentWorkspace/index.tsx`, ' +
+          'mounted from `sharedModals` behind `isSummaryDischargeModalOpen`. Reaching it through ' +
+          'its parent means faking the entire workspace bootstrap aggregate - an appointment, an ' +
+          'encounter in an inpatient state, a room unit, a catalog - so it is exported now and ' +
+          'drawn directly.\n\n' +
+          'The branch worth drawing is `gate.enabled === false`. When the backend says the ' +
+          'encounter is not ready, the dialog grows a `bg-danger-100` panel carrying the refusal ' +
+          'sentence, a required override-reason textarea, and a confirm button relabelled ' +
+          '"Override & discharge" that stays disabled until the reason is non-blank. **Every ink ' +
+          "in that panel sits on a status tint rather than on the dialog's own " +
+          '`--color-neutral-0`**: the sentence is `text-text-error` (`--danger-text`), the field ' +
+          'label is `text-text-secondary` (`--ink-muted`), and the textarea declares no ' +
+          'background at all, so its `text-text-primary` (`--ink-body`) lands on the tint as ' +
+          'well.\n\n' +
+          'That is the same arrangement that broke `PackageBreakdownTooltip`, where `--ink` and ' +
+          '`--screen` resolved to one value and a seven-column table rendered at 1.00:1 in both ' +
+          'themes for months - undetected, because no story had ever opened it. Here the dark ' +
+          'tint is not even opaque: `--color-danger-100` is `rgba(234, 55, 41, 0.18)`, so the ' +
+          'ground is that red composited over `--screen`, and no class name says whether the ' +
+          'result is legible.\n\n' +
+          'So the stories measure it rather than describe it. They composite the translucent ' +
+          'layers in paint order, starting at the ink-bearing element itself, and assert the ' +
+          'resulting ground both differs from the ink and clears 4.5:1 - in light and in dark. ' +
+          'Measured: light 6.23 / 6.05 / 11.6, dark 5.49 / **4.69** / 9.20. The field label in ' +
+          'dark is the pairing with no headroom left.\n\n' +
+          'The tint itself is checked by hue lean rather than by contrast against the dialog, ' +
+          'because in light `#fdebea` on `#f7f3ec` is 1.04:1 on purpose - a "these are different ' +
+          'colours" assertion would pass on a token that had drifted to within one digit of the ' +
+          'surface.\n\n' +
+          'Two behaviours are also only reachable from a play function. `isSaving` locks the ' +
+          'pickers by inheritance (`pointer-events: none` on their column, not a `disabled` ' +
+          'attribute), and the `isSaving` guard in `handleCancel` covers the Cancel and header ' +
+          'close controls but **not** Escape: `ModalBase` sets `showModal` to false itself before ' +
+          'calling `onClose`, so a discharge already in flight can still be dismissed with a ' +
+          'keypress.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    showModal: true,
+    setShowModal: fn(),
+    dischargeDate: DISCHARGE_DATE,
+    setDischargeDate: fn(),
+    dischargeTime: '14:30',
+    setDischargeTime: fn(),
+    onConfirm: fn(),
+    isSaving: false,
+    gate: CLEAR_GATE,
+    overrideReason: '',
+    setOverrideReason: fn(),
+  },
+} satisfies Meta<typeof DischargeDateTimeModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const GateClear: Story = {
+  name: 'Gate clear (ordinary discharge)',
+  play: async ({ args }) => {
+    const dialog = await openPanel();
+    const panel = within(dialog);
+
+    await expect(panel.getByRole('heading', { name: 'Discharge date & time' })).toBeInTheDocument();
+    // Both pickers carry the values passed in, not placeholders.
+    await expect(panel.getByRole('button', { name: DATE_BUTTON })).toBeInTheDocument();
+    await expect(panel.getByRole('button', { name: TIME_BUTTON })).toBeInTheDocument();
+
+    // No tinted panel, no override field, and the plain confirm label.
+    await expect(panel.queryByRole('textbox')).not.toBeInTheDocument();
+    await expect(panel.queryByText(OVERRIDE_LABEL)).not.toBeInTheDocument();
+    const confirm = panel.getByRole('button', { name: 'Confirm discharge' });
+    await expect(confirm).toBeEnabled();
+
+    /* Two actions, in this order, on one row. The row is `flex-wrap` over a
+       `min-w-30` cancel and a `min-w-36` confirm; at the 500px desktop width
+       they have 474px of content box to share and must not wrap. */
+    const actions = confirm.parentElement as HTMLElement;
+    await expect(actions.children).toHaveLength(2);
+    await expect(Array.from(actions.children).map((child) => child.textContent)).toEqual([
+      'Cancel',
+      'Confirm discharge',
+    ]);
+    await expect(getComputedStyle(actions).flexWrap).toBe('wrap');
+    const [cancelTop, confirmTop] = Array.from(actions.children).map(
+      (child) => child.getBoundingClientRect().top
+    );
+    await expect(Math.abs(cancelTop - confirmTop)).toBeLessThanOrEqual(1);
+
+    await userEvent.click(confirm);
+    await expect(args.onConfirm).toHaveBeenCalledTimes(1);
+    /* Confirming does not close anything by itself - the parent dismisses the
+       dialog once the discharge mutation resolves, which is what leaves room for
+       the in-flight state below. */
+    await expect(document.querySelector('dialog[open]')).toBeInTheDocument();
+    await expect(args.setShowModal).not.toHaveBeenCalled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'What the dialog is 95% of the time: a header, a date and a time, and two pill actions. ' +
+          'The date button reads `Aug 19, 2026` from the `MMM d, yyyy` format inside `Datepicker` ' +
+          'while the time button reads the raw `14:30` string - the two pickers disagree on ' +
+          'format, which is only visible with them stacked.',
+      },
+    },
+  },
+};
+
+export const GateBlocked: Story = {
+  name: 'Gate blocked (override required)',
+  args: { gate: BLOCKED_GATE },
+  play: assertBlockedGate,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The branch nothing had drawn. A `rounded-2xl bg-danger-100 p-3` panel slides in above ' +
+          "the pickers with the backend's own sentence, a two-row textarea and a relabelled " +
+          'confirm. In light the tint is a flat `#fdebea` and the sentence is `#a6271d` on it, ' +
+          'measured here at 6.23:1. The play function types a reason, so the field ink is checked ' +
+          'against real text rather than against a placeholder, and the confirm is asserted to ' +
+          'flip from disabled to enabled on the first non-blank character.',
+      },
+    },
+  },
+};
+
+export const GateBlockedDark: Story = {
+  name: 'Gate blocked (dark)',
+  args: { gate: BLOCKED_GATE },
+  globals: { theme: 'dark' },
+  play: assertBlockedGate,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same measurements against a ground that no longer exists as a single colour. ' +
+          '`--color-danger-100` flips from `#fdebea` to `rgba(234, 55, 41, 0.18)`, so the panel ' +
+          "is red at 18% over the dialog's `#2f271e` - `rgb(81, 42, 32)` once composited. " +
+          'Against it the sentence reads 5.49:1, the field label 4.69:1 and the typed text ' +
+          '9.20:1. The label is the one with no headroom left, which is exactly the pairing a ' +
+          'token sweep would break silently.',
+      },
+    },
+  },
+};
+
+export const GateBlockedNoReason: Story = {
+  name: 'Gate blocked, no reason supplied',
+  args: { gate: { enabled: false } },
+  play: async () => {
+    const dialog = await openPanel();
+    const panel = within(dialog);
+
+    // The fallback sentence, not an empty tinted box - and not a stale render of
+    // the seeded reason the other gate stories use.
+    const fallback = panel.getByText('This encounter is not ready for discharge.');
+    await expect(panel.queryByText(GATE_REASON)).not.toBeInTheDocument();
+    await expectReadable(fallback);
+
+    // Same two-child panel as the reasoned variant, so only the sentence changed.
+    const tint = fallback.parentElement as HTMLElement;
+    await expect(tint.children).toHaveLength(2);
+    await expect(tint.children[0]).toBe(fallback);
+    await expect(panel.getByLabelText(OVERRIDE_LABEL)).toHaveValue('');
+    await expect(panel.getByRole('button', { name: 'Override & discharge' })).toBeDisabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A gate that refuses without saying why. The backend contract makes `disabledReason` ' +
+          'optional, so the panel falls back to "This encounter is not ready for discharge." - ' +
+          'the clinician is asked to justify an override against a requirement the dialog cannot ' +
+          'name. Worth seeing, because it is the state that makes the override reason field ' +
+          'unanswerable.',
+      },
+    },
+  },
+};
+
+export const Saving: Story = {
+  name: 'Discharge in flight',
+  args: { isSaving: true, gate: BLOCKED_GATE, overrideReason: 'Owner collecting against advice.' },
+  play: async ({ args }) => {
+    const dialog = await openPanel();
+    const panel = within(dialog);
+
+    // The label is the progress indicator - there is no spinner anywhere here.
+    const confirm = panel.getByRole('button', { name: 'Discharging...' });
+    const cancel = panel.getByRole('button', { name: 'Cancel' });
+    await expect(confirm).toBeDisabled();
+    await expect(cancel).toBeDisabled();
+    // `isDisabled` on these pills is a real `disabled` plus `opacity-60`, so the
+    // dim is measurable rather than a claim about a class name.
+    await waitFor(() => {
+      expect(getComputedStyle(confirm).opacity).toBe('0.6');
+      expect(getComputedStyle(cancel).opacity).toBe('0.6');
+    });
+
+    /* The pickers are not disabled elements, and they are not dimmed either.
+       Their column carries `pointer-events-none` and the property inherits, so
+       the buttons compute `none` while keeping every resting style including
+       full opacity - the combination that reads as clickable and is not. */
+    const dateButton = panel.getByRole('button', { name: DATE_BUTTON });
+    const timeButton = panel.getByRole('button', { name: TIME_BUTTON });
+    await expect(getComputedStyle(dateButton).pointerEvents).toBe('none');
+    await expect(getComputedStyle(timeButton).pointerEvents).toBe('none');
+    await expect(getComputedStyle(dateButton).opacity).toBe('1');
+    await expect(dateButton).toBeEnabled();
+
+    /* The header close is NOT disabled - `ModalHeader` is called without
+       `isCloseDisabled` - so it stays a live, focusable control that swallows
+       its own click. Clicking it must leave the dialog open. */
+    const close = panel.getByRole('button', { name: 'Close' });
+    await expect(close).toBeEnabled();
+    await userEvent.click(close);
+    await expect(document.querySelector('dialog[open]')).toBeInTheDocument();
+    await expect(args.setShowModal).not.toHaveBeenCalled();
+    // Still the in-flight label, so nothing re-rendered its way out of the state.
+    await expect(panel.getByRole('button', { name: 'Discharging...' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The state between clicking confirm and the encounter closing. The two footer pills go ' +
+          'to `opacity-60` and take a real `disabled`; the pickers do neither. They go inert by ' +
+          'inheriting `pointer-events: none` from their column, so they keep full-contrast ' +
+          'resting styling and stay in the tab order while refusing the pointer - a combination ' +
+          'that reads as "clickable" and is not. The header close is the sharper problem: it is ' +
+          'enabled, focusable and does nothing.',
+      },
+    },
+  },
+};
+
+export const SavingEscapes: Story = {
+  name: 'Escape dismisses a discharge in flight',
+  args: { isSaving: true, gate: BLOCKED_GATE, overrideReason: 'Owner collecting against advice.' },
+  play: async ({ args }) => {
+    await openPanel();
+    await userEvent.keyboard('{Escape}');
+
+    /* A closed dialog stays MOUNTED without its `open` attribute, so this has
+       to be asserted against `dialog[open]` rather than against the text. */
+    await waitFor(() => {
+      expect(document.querySelector('dialog[open]')).toBeNull();
+    });
+    await expect(args.setShowModal).toHaveBeenCalledWith(false);
+
+    /* Dismissed, not unmounted, and not cancelled either: the shell, the gate
+       panel and the typed override reason are all still there, held out of the
+       tab order by `inert` alone while the discharge request keeps running. */
+    const dialog = document.querySelector('dialog') as HTMLElement;
+    await expect(dialog).toHaveAttribute('inert');
+    await expect(within(dialog).getByText(GATE_REASON)).toBeInTheDocument();
+    await expect(within(dialog).getByLabelText(OVERRIDE_LABEL)).toHaveValue(
+      'Owner collecting against advice.'
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The gap in the guard. `handleCancel` returns early while `isSaving`, which is why the ' +
+          'Cancel button and the header close do nothing - but Escape never reaches it in a ' +
+          'state to be refused. `ModalBase.closeModal` calls `setShowModal(false)` first and ' +
+          '`onClose` second, so the dialog is already gone by the time the guard runs. The ' +
+          'request is still in flight; only its confirmation UI has left. Asserted as current ' +
+          'behaviour, not as intended behaviour.',
+      },
+    },
+  },
+};
+
+export const GateBlockedPhone: Story = {
+  name: 'Gate blocked at 375',
+  args: { gate: BLOCKED_GATE },
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async () => {
+    const dialog = await openPanel();
+    const panel = within(dialog);
+
+    // Proves the viewport global took: an unpinned story renders at 1280 here.
+    await expect(window.innerWidth).toBeLessThanOrEqual(375);
+
+    /* `CenterModal` is `w-[90%] sm:w-[500px]`, so below the 640px breakpoint the
+       panel tracks the viewport instead of the fixed desktop width. */
+    const width = dialog.getBoundingClientRect().width;
+    await expect(width).toBeLessThan(375);
+    await expect(width).toBeGreaterThan(320);
+
+    await expect(panel.getByText(GATE_REASON)).toBeInTheDocument();
+    await expect(panel.getByLabelText(OVERRIDE_LABEL)).toHaveAttribute('rows', '2');
+
+    /* Both pickers stay stacked and full-bleed. Each is `w-full` inside a
+       `flex-col` column, so a dropped width class shows up here as two unequal
+       buttons or as a pair that shares a row. */
+    const dateBox = panel.getByRole('button', { name: DATE_BUTTON }).getBoundingClientRect();
+    const timeBox = panel.getByRole('button', { name: TIME_BUTTON }).getBoundingClientRect();
+    await expect(Math.abs(dateBox.width - timeBox.width)).toBeLessThanOrEqual(1);
+    await expect(dateBox.width).toBeGreaterThan(280);
+    await expect(timeBox.top).toBeGreaterThanOrEqual(dateBox.bottom);
+
+    /* Nothing may spill sideways. The action row is `flex-wrap` over a
+       `min-w-30` cancel and a `min-w-36` confirm whose label is the longest
+       string in the component, and those minimums do not shrink. */
+    await expect(dialog.scrollWidth).toBeLessThanOrEqual(dialog.clientWidth + 1);
+
+    /* And the footer has to stay on screen. The dialog is centred with
+       `-translate-y-1/2` and owns no scroll container, so a confirm below the
+       fold is simply unreachable rather than scrolled to. */
+    const confirm = panel
+      .getByRole('button', { name: 'Override & discharge' })
+      .getBoundingClientRect();
+    await expect(confirm.bottom).toBeLessThanOrEqual(window.innerHeight);
+    await expect(Math.round(confirm.right)).toBeLessThanOrEqual(
+      Math.round(dialog.getBoundingClientRect().right)
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The tallest variant on the shortest viewport. `CenterModal` drops from its fixed 500px ' +
+          'to `w-[90%]` below 640px, and the dialog is centred with `top-1/2 -translate-y-1/2` ' +
+          'with no scroll container of its own - so once the tinted panel, the textarea and both ' +
+          'pickers are stacked, the footer is the first thing at risk of leaving the screen with ' +
+          'no way to reach it. This asserts the confirm is still inside the viewport and that ' +
+          'nothing in the panel overflows sideways at 337px.',
+      },
+    },
+  },
+};
+
+export const Closed: Story = {
+  name: 'Closed (shell still mounted)',
+  args: { showModal: false, gate: BLOCKED_GATE },
+  play: async () => {
+    /* Not unmounted: `ModalBase` keeps the portal and drops `open`. Asserting
+       absence against the copy would pass on a dialog that is merely
+       transparent and still tabbable. */
+    await expect(document.querySelector('dialog[open]')).toBeNull();
+    const dialog = document.querySelector('dialog') as HTMLElement;
+    await expect(dialog).toBeInTheDocument();
+    await expect(dialog).toHaveAttribute('inert');
+
+    /* `dialog:not([open])` is `display: none` in the UA sheet, but the
+       container carries `flex`, which is an author style and wins - so this
+       dialog is laid out and painted at zero alpha rather than removed. The
+       `inert` and `pointer-events-none` above are the only things keeping it
+       out of reach, which is worth seeing measured. */
+    await waitFor(() => {
+      expect(getComputedStyle(dialog).display).toBe('flex');
+      expect(getComputedStyle(dialog).opacity).toBe('0');
+      expect(getComputedStyle(dialog).pointerEvents).toBe('none');
+    });
+
+    // The override field and the gate copy are still in the tree behind all that.
+    const panel = within(dialog);
+    await expect(panel.getByText(GATE_REASON)).toBeInTheDocument();
+    await expect(panel.getByRole('button', { name: 'Override & discharge' })).toBeDisabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'What "closed" means for this dialog: a `<dialog>` without `open` that is still laid ' +
+          "out - the container's `flex` beats the UA `dialog:not([open]) { display: none }` - " +
+          'carrying `inert` and `pointer-events-none` at zero opacity behind a faded backdrop, ' +
+          'with the gate panel and the typed override reason still in the DOM. Nothing resets ' +
+          'that state on close - the parent holds `dischargeOverrideReason` across openings - so ' +
+          'reopening shows whatever was typed last time.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/WorkspaceHeader.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/WorkspaceHeader.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { expect, fn, userEvent, within } from 'storybook/test';
+import { expect, fn, within } from 'storybook/test';
+
+import { openGlassTooltip } from '@/app/ui/primitives/GlassTooltip/storyInteractions';
 import type { Appointment } from '@yosemite-crew/types';
 
 import type { CompanionAlert } from '@/app/features/appointments/types/workspace';
@@ -35,12 +37,19 @@ const MANY_ALERTS: CompanionAlert[] = [
   { id: 'alert-5', label: 'Fear of clippers', severity: 'low' },
 ];
 
-/** Hovers the tooltip's wrapper span, which is the element carrying the listeners. */
+/**
+ * Opens the bubble for a control.
+ *
+ * The wrapper span carries the listeners and binds them in an effect, which has not
+ * necessarily flushed when a play function starts - so the dispatch is retried rather
+ * than sent once. `findByRole` retries the query but never re-sends the event, so a
+ * dispatch that arrives too early is lost for good and the story fails with "unable to
+ * find role=tooltip" for a component that works perfectly in a browser.
+ */
 const hoverTooltipTrigger = async (control: HTMLElement) => {
   const trigger = control.closest('.glass-tooltip');
   await expect(trigger).toBeInTheDocument();
-  await userEvent.hover(trigger as HTMLElement);
-  return within(document.body).findByRole('tooltip');
+  return openGlassTooltip(trigger as HTMLElement);
 };
 
 const meta = {
@@ -247,7 +256,12 @@ export const EmergencyReadyToAdmit: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(canvas.getByRole('button', { name: 'Admit' })).toBeInTheDocument();
-    await expect(canvas.getByText(/emergency/i)).toBeInTheDocument();
+    /* Exact, not /emergency/i. The preview decorator injects an sr-only <h1> reading
+       "<title> - <story name>" into the canvas, and this story is named "Emergency,
+       ready to admit" - so the loose regex matched the banner as well as the badge and
+       the query was ambiguous. A looser assertion elsewhere could just as easily match
+       ONLY the banner and pass with the component missing. */
+    await expect(canvas.getByText('Emergency')).toBeInTheDocument();
   },
   parameters: {
     docs: {

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/PackageBreakdownTooltip.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/PackageBreakdownTooltip.stories.tsx
@@ -67,13 +67,11 @@ const PACKAGE_ITEM: InvoiceLineItem = {
  * `findByRole` retries the query but never re-sends the event, so a dispatch that lands
  * before the listener exists is lost for good.
  */
-const openBubble = async (canvasElement: HTMLElement, itemName: string) => {
-  const canvas = within(canvasElement);
+const openBubble = (canvasElement: HTMLElement, itemName: string) =>
   // GlassTooltip portals to document.body, so the bubble is outside canvasElement.
-  return openGlassTooltip(
-    canvas.getByRole('button', { name: `View ${itemName} package breakdown` })
+  openGlassTooltip(
+    within(canvasElement).getByRole('button', { name: `View ${itemName} package breakdown` })
   );
-};
 
 const meta = {
   title: 'Workspace/PackageBreakdownTooltip',

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/PackageBreakdownTooltip.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/PackageBreakdownTooltip.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { expect, userEvent, within } from 'storybook/test';
+import { expect, within } from 'storybook/test';
+
+import { openGlassTooltip } from '@/app/ui/primitives/GlassTooltip/storyInteractions';
 
 import PackageBreakdownTooltip from './PackageBreakdownTooltip';
 import type {
@@ -57,12 +59,20 @@ const PACKAGE_ITEM: InvoiceLineItem = {
   breakdown: BREAKDOWN,
 };
 
-/** Opens the portalled bubble and hands back its root for assertions. */
+/**
+ * Opens the portalled bubble and hands back its root for assertions.
+ *
+ * The wrapper span carries the listeners and binds them in an effect, which a play
+ * function can start ahead of - so the dispatch is retried rather than sent once.
+ * `findByRole` retries the query but never re-sends the event, so a dispatch that lands
+ * before the listener exists is lost for good.
+ */
 const openBubble = async (canvasElement: HTMLElement, itemName: string) => {
   const canvas = within(canvasElement);
-  await userEvent.hover(canvas.getByRole('button', { name: `View ${itemName} package breakdown` }));
   // GlassTooltip portals to document.body, so the bubble is outside canvasElement.
-  return within(document.body).findByRole('tooltip');
+  return openGlassTooltip(
+    canvas.getByRole('button', { name: `View ${itemName} package breakdown` })
+  );
 };
 
 const meta = {
@@ -232,10 +242,13 @@ export const KeyboardFocus: Story = {
   name: 'Opened by keyboard focus',
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    // focusin, not hover: the path a keyboard user gets, and the one that rots
-    // unnoticed because every manual check is done with a mouse.
-    canvas.getByRole('button', { name: `View ${PACKAGE_ITEM.name} package breakdown` }).focus();
-    const bubble = await within(document.body).findByRole('tooltip');
+    /* focusin, not hover: the path a keyboard user gets, and the one that rots unnoticed
+       because every manual check is done with a mouse. Dispatched at the wrapper rather
+       than via `.focus()`, which fires nothing unless the page itself has focus. */
+    const bubble = await openGlassTooltip(
+      canvas.getByRole('button', { name: `View ${PACKAGE_ITEM.name} package breakdown` }),
+      { via: 'focus' }
+    );
     await expect(within(bubble).getAllByRole('columnheader')).toHaveLength(7);
   },
   parameters: {

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/PackageBreakdownTooltip.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/PackageBreakdownTooltip.tsx
@@ -13,6 +13,13 @@ const formatCents = (cents: number, currency = 'USD'): string => formatMoney(cen
 
 const formatPercent = (value: number): number => Number(value.toFixed(2));
 
+/* Inks, not neutrals. `--color-neutral-0` resolves to `var(--screen)` and
+   `--color-neutral-200` to `var(--hairline)`, and `.glass-tooltip-bubble` paints its
+   background with that same `var(--screen)`. This table was written against the old
+   translucent-dark bubble (`--glass-93`); commit 2ca7017e4 made the bubble opaque and
+   did not touch this file, so every cell has been rendering at 1.00:1 - the same colour
+   as the surface behind it - in BOTH themes ever since. Nothing caught it because no
+   story had ever opened the tooltip. */
 const PackageBreakdownTooltip = ({ item, currency }: PackageBreakdownTooltipProps) => {
   const breakdown = item.breakdown ?? [];
   if (breakdown.length === 0) return null;
@@ -27,12 +34,12 @@ const PackageBreakdownTooltip = ({ item, currency }: PackageBreakdownTooltipProp
       content={
         <div className="flex min-w-130 flex-col gap-3 text-left">
           <div className="flex flex-col gap-0.5">
-            <span className="text-caption-1 font-semibold text-neutral-0">{item.name}</span>
-            <span className="text-caption-2 text-neutral-200">Package breakdown</span>
+            <span className="text-caption-1 font-semibold text-[var(--ink)]">{item.name}</span>
+            <span className="text-caption-2 text-[var(--ink-muted)]">Package breakdown</span>
           </div>
           <table className="w-full border-collapse text-caption-2">
             <thead>
-              <tr className="border-b border-neutral-0/20 text-neutral-200">
+              <tr className="border-b border-[var(--hairline)] text-[var(--ink-muted)]">
                 <th className="w-8 px-2 py-1 text-left font-medium">#</th>
                 <th className="px-2 py-1 text-left font-medium">Item</th>
                 <th className="px-2 py-1 text-left font-medium">Type</th>
@@ -46,15 +53,15 @@ const PackageBreakdownTooltip = ({ item, currency }: PackageBreakdownTooltipProp
               {breakdown.map((row, index) => (
                 <tr key={row.id} className="border-b border-neutral-0/10 last:border-b-0">
                   <td className="px-2 py-1.5 text-neutral-300">{index + 1}.</td>
-                  <td className="max-w-44 px-2 py-1.5 font-medium text-neutral-0">
+                  <td className="max-w-44 px-2 py-1.5 font-medium text-[var(--ink)]">
                     <span className="block truncate">{row.name}</span>
                   </td>
-                  <td className="px-2 py-1.5 text-neutral-200">{row.instructions ?? '-'}</td>
-                  <td className="px-2 py-1.5 text-right text-neutral-0">
+                  <td className="px-2 py-1.5 text-[var(--ink-muted)]">{row.instructions ?? '-'}</td>
+                  <td className="px-2 py-1.5 text-right text-[var(--ink)]">
                     {formatCents(row.unitPriceCents ?? row.amountCents, currency)}
                   </td>
-                  <td className="px-2 py-1.5 text-center text-neutral-0">x{row.qty}</td>
-                  <td className="px-2 py-1.5 text-right text-neutral-200">
+                  <td className="px-2 py-1.5 text-center text-[var(--ink)]">x{row.qty}</td>
+                  <td className="px-2 py-1.5 text-right text-[var(--ink-muted)]">
                     {row.discountPercent != null && row.discountPercent > 0
                       ? `${formatPercent(row.discountPercent)}% / -${formatCents(
                           row.discountCents ?? 0,
@@ -62,7 +69,7 @@ const PackageBreakdownTooltip = ({ item, currency }: PackageBreakdownTooltipProp
                         )}`
                       : '-'}
                   </td>
-                  <td className="px-2 py-1.5 text-right font-medium text-neutral-0">
+                  <td className="px-2 py-1.5 text-right font-medium text-[var(--ink)]">
                     {formatCents(row.amountCents, currency)}
                   </td>
                 </tr>
@@ -70,28 +77,37 @@ const PackageBreakdownTooltip = ({ item, currency }: PackageBreakdownTooltipProp
             </tbody>
             <tfoot>
               <tr className="border-t border-neutral-0/25">
-                <td colSpan={6} className="px-2 pt-2 text-right font-medium text-neutral-200">
+                <td
+                  colSpan={6}
+                  className="px-2 pt-2 text-right font-medium text-[var(--ink-muted)]"
+                >
                   Component total
                 </td>
-                <td className="px-2 pt-2 text-right font-semibold text-neutral-0">
+                <td className="px-2 pt-2 text-right font-semibold text-[var(--ink)]">
                   {formatCents(breakdownTotalCents, currency)}
                 </td>
               </tr>
               {packageDiscountCents > 0 && (
                 <tr>
-                  <td colSpan={6} className="px-2 pt-1 text-right font-medium text-neutral-200">
+                  <td
+                    colSpan={6}
+                    className="px-2 pt-1 text-right font-medium text-[var(--ink-muted)]"
+                  >
                     Package discount ({formatPercent(packageDiscountPercent)}%)
                   </td>
-                  <td className="px-2 pt-1 text-right font-medium text-neutral-0">
+                  <td className="px-2 pt-1 text-right font-medium text-[var(--ink)]">
                     -{formatCents(packageDiscountCents, currency)}
                   </td>
                 </tr>
               )}
               <tr className="border-t border-neutral-0/25">
-                <td colSpan={6} className="px-2 pt-2 text-right font-medium text-neutral-200">
+                <td
+                  colSpan={6}
+                  className="px-2 pt-2 text-right font-medium text-[var(--ink-muted)]"
+                >
                   Total
                 </td>
-                <td className="px-2 pt-2 text-right font-semibold text-neutral-0">
+                <td className="px-2 pt-2 text-right font-semibold text-[var(--ink)]">
                   {formatCents(packageTotalCents, currency)}
                 </td>
               </tr>

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/PastItemsList.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/PastItemsList.stories.tsx
@@ -114,7 +114,7 @@ export const Expanded: Story = {
     await userEvent.click(canvas.getByRole('button', { name: 'View By Dr. Tim Apple' }));
     // Assert the detail block has its real content, not just that the button relabelled -
     // the weaker check passes on an empty panel, which is how a regression stays invisible.
-    await expect(
+    expect(
       await canvas.findByText(/Suspected partial cranial cruciate ligament tear/)
     ).toBeInTheDocument();
     await expect(canvas.getByText(/Grade 2\/4 lameness/)).toBeInTheDocument();
@@ -138,7 +138,7 @@ export const TwoExpanded: Story = {
     const canvas = within(canvasElement);
     await userEvent.click(canvas.getByRole('button', { name: 'View By Dr. Tim Apple' }));
     await userEvent.click(canvas.getByRole('button', { name: 'View By Dr. Ravi Menon' }));
-    await expect(
+    expect(
       await canvas.findByText(/Suspected partial cranial cruciate ligament tear/)
     ).toBeInTheDocument();
     await expect(

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/PrescriptionEditor.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/PrescriptionEditor.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 import PrescriptionEditor from './PrescriptionEditor';
 import type { PrescriptionItem } from '@/app/features/appointments/types/workspace';
+import type { PrescriptionTemplateOption } from '@/app/features/appointments/services/workspaceTemplateService';
 
 // Seeded prescriptions for visual verification of the Treatment-step Prescription
 // section (Bug 8: the printer button now prints each saved item's label PDF).
@@ -34,16 +36,126 @@ const items: PrescriptionItem[] = [
   },
 ];
 
+/**
+ * Inventory rows the search matches against. `matches` searches medicineName, brand,
+ * genericName and sku joined together, so `AMX-250` and `Clavulanate` both find the
+ * same row as `amox` does.
+ */
+const CATALOG: Omit<PrescriptionItem, 'id'>[] = [
+  {
+    medicineName: 'Amoxicillin 625mg',
+    brand: 'Clavamox',
+    genericName: 'Amoxicillin/Clavulanate',
+    sku: 'AMX-625',
+    dosageForm: 'Tablet',
+    route: 'Oral',
+    fulfillment: 'IN_HOUSE',
+    priceCents: 16500,
+    stockQty: 14,
+  },
+  {
+    medicineName: 'Amoxicillin 250mg',
+    brand: 'Clavamox',
+    sku: 'AMX-250',
+    dosageForm: 'Tablet',
+    route: 'Oral',
+    fulfillment: 'IN_HOUSE',
+    priceCents: 9800,
+    stockQty: 40,
+  },
+  {
+    medicineName: 'Meloxicam 1.5mg/ml',
+    brand: 'Metacam',
+    sku: 'MLX-15',
+    dosageForm: 'Oral suspension',
+    route: 'Oral',
+    fulfillment: 'PRESCRIPTION_ONLY',
+    priceCents: 4200,
+    stockQty: 6,
+    lowStock: true,
+  },
+  {
+    medicineName: 'Prednisone 10mg',
+    genericName: 'Prednisolone',
+    sku: 'PRD-10',
+    fulfillment: 'IN_HOUSE',
+    priceCents: 9000,
+    stockQty: 3,
+    lowStock: true,
+  },
+];
+
+const TEMPLATES: PrescriptionTemplateOption[] = [
+  {
+    id: 'tpl-amox',
+    name: 'Amoxicillin course - canine',
+    source: 'CLINIC',
+    items: [CATALOG[0], CATALOG[3]],
+  },
+  {
+    id: 'tpl-postop',
+    name: 'Post-operative pain relief',
+    source: 'CLINIC',
+    items: [CATALOG[2]],
+  },
+];
+
+/** Types a query into the search field and hands back the portalled results list. */
+const openResults = async (canvasElement: HTMLElement, query: string) => {
+  const canvas = within(canvasElement);
+  const field = canvas.getByRole('searchbox', {
+    name: 'Search medicines or prescription templates',
+  });
+  await userEvent.clear(field);
+  await userEvent.type(field, query);
+  const firstRow = await within(document.body).findByRole('button', {
+    name: new RegExp(query, 'i'),
+  });
+  const list = firstRow.closest('ul');
+  await expect(list).not.toBeNull();
+  return list as HTMLElement;
+};
+
 const meta = {
   title: 'Workspace/PrescriptionEditor',
   component: PrescriptionEditor,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The Treatment-step prescription section: saved medication rows, and above them the ' +
+          'search that adds new ones.\n\n' +
+          'That search is why this file was extended. Its results panel is `createPortal`ed to ' +
+          '`document.body` at a `position: fixed` rect measured from the input, and it opens on ' +
+          '`hasSearchMatches` alone - there is no `open` prop. The two stories that existed here ' +
+          'passed neither `catalogItems` nor `templateItems` and had no `play`, so `matches` and ' +
+          '`templateMatches` were permanently empty arrays: the dropdown was not merely unopened, ' +
+          'it was unreachable. Everything below the input had never been rendered anywhere.\n\n' +
+          'What that hid is a two-kind list rendered from one `<ul>`. Templates come first with a ' +
+          'neutral `Template` badge and an origin line counting their rows, then medications with a ' +
+          'blue `Medication` badge and their brand folded into the name as `Name (Brand)`. The two ' +
+          'kinds share `WorkspaceSearchResultRow`, so a badge or origin regression lands on both at ' +
+          'once, and the item-count line has a singular branch - `1 medication` against ' +
+          '`2 medications` - that only one of the two templates below reaches.\n\n' +
+          'The stories assert the list actually holds rows rather than that a flag flipped: an empty ' +
+          'portal is indistinguishable from a healthy one from the trigger side, which is how a ' +
+          'dropdown regression stayed invisible on this branch before. They also assert the list is ' +
+          'genuinely outside `canvasElement`, since the portal is the whole point of the component.',
+      },
+    },
+  },
+  tags: ['autodocs'],
   args: {
     items,
+    catalogItems: CATALOG,
+    templateItems: TEMPLATES,
     readOnly: false,
-    onAddItem: () => undefined,
-    onUpdateItem: () => undefined,
-    onRemoveItem: () => undefined,
-    onPrint: () => undefined,
+    onAddItem: fn(),
+    onApplyTemplate: fn(),
+    onUpdateItem: fn(),
+    onRemoveItem: fn(),
+    onPrint: fn(),
   },
 } satisfies Meta<typeof PrescriptionEditor>;
 
@@ -55,4 +167,129 @@ export const WithSavedPrescriptions: Story = {};
 
 export const Empty: Story = {
   args: { items: [] },
+};
+
+export const SearchResultsOpen: Story = {
+  name: 'Search dropdown (templates + medications)',
+  play: async ({ canvasElement }) => {
+    const list = await openResults(canvasElement, 'amox');
+
+    // The panel escapes the canvas entirely - that escape is the component's job.
+    await expect(canvasElement.contains(list)).toBe(false);
+
+    /* Assert the list has its rows, not merely that something mounted. Three
+       matches: the template plus both Amoxicillin strengths. */
+    const rows = within(list).getAllByRole('button');
+    await expect(rows).toHaveLength(3);
+
+    // Templates sort above medications, and each kind carries its own badge.
+    await expect(rows[0]).toHaveTextContent('Amoxicillin course - canine');
+    await expect(within(list).getByText('Template')).toBeInTheDocument();
+    await expect(within(list).getAllByText('Medication')).toHaveLength(2);
+
+    // The brand is folded into the medication name rather than shown as a chip.
+    await expect(within(list).getByText('Amoxicillin 625mg (Clavamox)')).toBeInTheDocument();
+
+    // Plural branch of the item-count origin line.
+    await expect(within(list).getByText('2 medications')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A query that hits both kinds at once, which is the only arrangement where their two row ' +
+          'treatments are visible side by side: the neutral `Template` badge with a count line under ' +
+          'the name, then the blue `Medication` badge with the brand inside the name.',
+      },
+    },
+  },
+};
+
+export const SingleTemplateResult: Story = {
+  name: 'Search dropdown (one template, singular count)',
+  play: async ({ canvasElement }) => {
+    const list = await openResults(canvasElement, 'post-operative');
+    await expect(within(list).getAllByRole('button')).toHaveLength(1);
+    // Singular branch: `1 medication`, not `1 medications`.
+    await expect(within(list).getByText('1 medication')).toBeInTheDocument();
+    await expect(within(list).queryByText('Medication')).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A template-only query. One row, so the panel is a single 40px-ish strip anchored to a ' +
+          '360px input, and the count line takes its singular form - the branch the mixed story ' +
+          'never reaches.',
+      },
+    },
+  },
+};
+
+export const SelectMedicationFromSearch: Story = {
+  name: 'Selecting a medication closes the panel',
+  play: async ({ args, canvasElement }) => {
+    const list = await openResults(canvasElement, 'meloxicam');
+    const row = within(list).getByRole('button', { name: /Meloxicam 1\.5mg\/ml \(Metacam\)/ });
+    await userEvent.click(row);
+
+    await expect(args.onAddItem).toHaveBeenCalledWith(CATALOG[2]);
+    // `setSearch('')` empties the match arrays, which unmounts the portal.
+    await waitFor(() => expect(row).not.toBeInTheDocument());
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The add path. Choosing a row hands the whole inventory record to `onAddItem` - price, ' +
+          'stock, brand and SKU included, not just a name - and clears the query, which is what ' +
+          'takes the portal back down.',
+      },
+    },
+  },
+};
+
+export const ApplyTemplateFromSearch: Story = {
+  name: 'Applying a template',
+  play: async ({ args, canvasElement }) => {
+    const list = await openResults(canvasElement, 'amoxicillin course');
+    await userEvent.click(
+      within(list).getByRole('button', { name: /Amoxicillin course - canine/ })
+    );
+    await expect(args.onApplyTemplate).toHaveBeenCalledWith(TEMPLATES[0]);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Templates and medications resolve through different callbacks off the same list, so a ' +
+          'row that looks right can still be wired to the wrong one. This asserts the template row ' +
+          'reaches `onApplyTemplate` with all of its rows attached.',
+      },
+    },
+  },
+};
+
+export const ReadOnlyHidesSearch: Story = {
+  name: 'Read-only (search block removed)',
+  args: { readOnly: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The whole search block is behind `!readOnly`, so it is absent rather than disabled.
+    await expect(
+      canvas.queryByRole('searchbox', { name: 'Search medicines or prescription templates' })
+    ).toBeNull();
+    // Print survives, since a finalised prescription still gets its labels.
+    await expect(canvas.getByRole('button', { name: 'Print Labels' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A locked prescription drops the search entirely instead of dimming it, so there is no ' +
+          'affordance offering an add that cannot happen. Print stays, because labels are still ' +
+          'reprintable after the record is closed.',
+      },
+    },
+  },
 };

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/PrescriptionEditor.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/PrescriptionEditor.stories.tsx
@@ -100,17 +100,19 @@ const TEMPLATES: PrescriptionTemplateOption[] = [
   },
 ];
 
-/** Types a query into the search field and hands back the portalled results list. */
-const openResults = async (canvasElement: HTMLElement, query: string) => {
+/**
+ * Types a query into the search field and hands back the portalled results `<ul>`.
+ * The panel carries no role or label of its own, so it is reached through one of its
+ * rows - `findAllBy` rather than `findBy`, since a query is expected to hit several.
+ */
+const openResults = async (canvasElement: HTMLElement, query: string, firstRowName: RegExp) => {
   const canvas = within(canvasElement);
   const field = canvas.getByRole('searchbox', {
     name: 'Search medicines or prescription templates',
   });
   await userEvent.clear(field);
   await userEvent.type(field, query);
-  const firstRow = await within(document.body).findByRole('button', {
-    name: new RegExp(query, 'i'),
-  });
+  const [firstRow] = await within(document.body).findAllByRole('button', { name: firstRowName });
   const list = firstRow.closest('ul');
   await expect(list).not.toBeNull();
   return list as HTMLElement;
@@ -172,7 +174,7 @@ export const Empty: Story = {
 export const SearchResultsOpen: Story = {
   name: 'Search dropdown (templates + medications)',
   play: async ({ canvasElement }) => {
-    const list = await openResults(canvasElement, 'amox');
+    const list = await openResults(canvasElement, 'amox', /^Amoxicillin course - canine/);
 
     // The panel escapes the canvas entirely - that escape is the component's job.
     await expect(canvasElement.contains(list)).toBe(false);
@@ -208,7 +210,7 @@ export const SearchResultsOpen: Story = {
 export const SingleTemplateResult: Story = {
   name: 'Search dropdown (one template, singular count)',
   play: async ({ canvasElement }) => {
-    const list = await openResults(canvasElement, 'post-operative');
+    const list = await openResults(canvasElement, 'post-operative', /^Post-operative pain relief/);
     await expect(within(list).getAllByRole('button')).toHaveLength(1);
     // Singular branch: `1 medication`, not `1 medications`.
     await expect(within(list).getByText('1 medication')).toBeInTheDocument();
@@ -229,7 +231,7 @@ export const SingleTemplateResult: Story = {
 export const SelectMedicationFromSearch: Story = {
   name: 'Selecting a medication closes the panel',
   play: async ({ args, canvasElement }) => {
-    const list = await openResults(canvasElement, 'meloxicam');
+    const list = await openResults(canvasElement, 'meloxicam', /^Meloxicam 1\.5mg\/ml \(Metacam\)/);
     const row = within(list).getByRole('button', { name: /Meloxicam 1\.5mg\/ml \(Metacam\)/ });
     await userEvent.click(row);
 
@@ -252,7 +254,11 @@ export const SelectMedicationFromSearch: Story = {
 export const ApplyTemplateFromSearch: Story = {
   name: 'Applying a template',
   play: async ({ args, canvasElement }) => {
-    const list = await openResults(canvasElement, 'amoxicillin course');
+    const list = await openResults(
+      canvasElement,
+      'amoxicillin course',
+      /^Amoxicillin course - canine/
+    );
     await userEvent.click(
       within(list).getByRole('button', { name: /Amoxicillin course - canine/ })
     );

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/SoapNotesList.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/SoapNotesList.stories.tsx
@@ -1,0 +1,253 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, within } from 'storybook/test';
+
+import SoapNotesList, { type SoapNoteListItem } from './SoapNotesList';
+
+/**
+ * Registered per story so the width survives a Chromatic run as well as a local one.
+ * The expanded card is the only responsive thing here - `grid-cols-1 lg:grid-cols-2` -
+ * so a story that asserts a track count has to own the width it asserts at.
+ */
+const DESKTOP_VIEWPORT = {
+  desktop: {
+    name: 'Desktop (1440)',
+    styles: { width: '1440px', height: '900px' },
+    type: 'desktop',
+  },
+};
+const MOBILE_VIEWPORT = {
+  mobile: { name: 'Mobile (375)', styles: { width: '375px', height: '812px' }, type: 'mobile' },
+};
+
+const FIELDS: SoapNoteListItem['fields'] = [
+  { label: 'Chief complaint', text: 'Limping on the left hind leg since Sunday.' },
+  { label: 'Subjective', html: '<p>Owner reports reluctance to jump onto the sofa.</p>' },
+  {
+    label: 'Objective',
+    html:
+      '<ul><li>BCS 5/9, weight 12.4kg</li><li>Pain on hip extension, left</li>' +
+      '<li>No effusion, full range of motion right</li></ul>',
+  },
+  { label: 'Assessment', html: '<p>Suspected <strong>soft tissue strain</strong>, left hip.</p>' },
+  {
+    label: 'Plan',
+    html: '<ol><li>Meloxicam 0.1mg/kg PO SID x5d</li><li>Rest, recheck in 7 days</li></ol>',
+  },
+  { label: 'Follow up', text: 'Recheck 19 March, sooner if lameness worsens.' },
+];
+
+const ITEMS: SoapNoteListItem[] = [
+  {
+    id: 'soap-1',
+    signedByName: 'Dr Elena Ruiz',
+    date: '12 Mar 2026',
+    time: '10:04',
+    fields: FIELDS,
+  },
+  {
+    id: 'soap-2',
+    signedByName: 'Dr Amara Okonkwo',
+    date: '02 Feb 2026',
+    time: '16:41',
+    fields: FIELDS.slice(0, 3),
+  },
+];
+
+/** Opens one note and hands back the expanded card, found by the `grid` it is built on. */
+const expand = async (canvasElement: HTMLElement, signedByName: string) => {
+  const canvas = within(canvasElement);
+  await userEvent.click(canvas.getByRole('button', { name: `View SOAP note by ${signedByName}` }));
+  const label = await canvas.findByText('Chief complaint');
+  return label.closest('.grid') as HTMLElement;
+};
+
+const meta = {
+  title: 'Appointments/SoapNotesList',
+  component: SoapNotesList,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The "All SOAP notes" read-out on a finished visit. The list itself is cheap - a clipboard ' +
+          'glyph, the signer, the date - but every one of those rows hides the note behind an eye ' +
+          'button, and the note is where all the layout lives.\n\n' +
+          'That expanded card is the surface no snapshot contained. It is held in `open` state ' +
+          'inside `SoapNoteRow`, a component that is not exported and has no prop to force it, so ' +
+          'the only way to draw it is to press the eye. It renders as ' +
+          '`grid grid-cols-1 gap-x-8 ... lg:grid-cols-2` - one column on a phone, two side by side ' +
+          'from `lg` up - which means the layout being reviewed depends on the viewport the story ' +
+          'is pinned to. Each story below states which width it asserts at rather than inheriting ' +
+          'one.\n\n' +
+          'Asserting the computed `grid-template-columns` is the point of the exercise. A grid ' +
+          'template the browser rejects does not fall back to something visibly broken: the ' +
+          'declaration is simply dropped and every child stacks into a single column, which reads ' +
+          'as a deliberate layout. That is precisely the bug this sweep exists for.\n\n' +
+          'The values are rich-text HTML written through `dangerouslySetInnerHTML`, re-sanitized at ' +
+          'render by `sanitizeRichText` even though the write path already sanitized. The list and ' +
+          'ordered-list styling comes from arbitrary-variant classes on the value container ' +
+          '(`[&_ul]:list-disc [&_ol]:list-decimal`, both `pl-5`), so bullets only appear when that ' +
+          'container is the one holding the markup - another thing that has to be rendered to be ' +
+          'seen.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    items: ITEMS,
+  },
+} satisfies Meta<typeof SoapNotesList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Collapsed: Story = {
+  name: 'Collapsed rows',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getAllByText('SOAP Note')).toHaveLength(2);
+    // Nothing of the note itself is in the DOM until the eye is pressed.
+    await expect(canvas.queryByText('Chief complaint')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'What the workspace shows on arrival. The signer and the date/time are `sm:`-gated, so ' +
+          'below 640px the row is glyph, "SOAP Note" and the eye alone.',
+      },
+    },
+  },
+};
+
+export const ExpandedDesktop: Story = {
+  name: 'Expanded note (1440 - two columns)',
+  globals: { viewport: { value: 'desktop', isRotated: false } },
+  parameters: {
+    viewport: {
+      options: DESKTOP_VIEWPORT,
+      viewports: DESKTOP_VIEWPORT,
+      defaultViewport: 'desktop',
+    },
+    chromatic: { viewports: [1440] },
+    docs: {
+      description: {
+        story:
+          'Pinned at 1440, above the `lg` breakpoint, so `lg:grid-cols-2` applies and the six ' +
+          'label/value rows pair up into two columns with a 32px `gap-x-8` between them. The play ' +
+          'function asserts the computed template really resolves to two tracks holding all six ' +
+          'children - a dropped or malformed template collapses them into one column and still ' +
+          'looks intentional.',
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const card = await expand(canvasElement, 'Dr Elena Ruiz');
+    await expect(card).toBeInTheDocument();
+    // Content first: an empty card would satisfy "the panel opened" on its own.
+    const scope = within(card);
+    await expect(scope.getByText('Limping on the left hind leg since Sunday.')).toBeInTheDocument();
+    await expect(scope.getByText(/left hip/)).toBeInTheDocument();
+    await expect(scope.getByText('soft tissue strain')).toBeInTheDocument();
+    await expect(scope.getAllByRole('listitem').length).toBeGreaterThanOrEqual(5);
+    await expect(card.children).toHaveLength(6);
+    // Two tracks at this width, and the eye has flipped to its hide label.
+    await expect(getComputedStyle(card).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(2);
+    await expect(
+      within(canvasElement).getByRole('button', { name: 'Hide SOAP note by Dr Elena Ruiz' })
+    ).toBeInTheDocument();
+  },
+};
+
+export const ExpandedMobile: Story = {
+  name: 'Expanded note (375 - one column)',
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  parameters: {
+    viewport: { options: MOBILE_VIEWPORT, viewports: MOBILE_VIEWPORT, defaultViewport: 'mobile' },
+    chromatic: { viewports: [375] },
+    docs: {
+      description: {
+        story:
+          'The same note at 375, below `lg`, where the card is a single column and each label ' +
+          'stacks above its value (the row itself is `flex-col` until `sm`). The assertion here is ' +
+          'that the template resolves to exactly one *measured* track: a grid whose template was ' +
+          'dropped computes to `none`, which is the failure this story is meant to catch, and it ' +
+          'would otherwise be indistinguishable from the intended single column.',
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const card = await expand(canvasElement, 'Dr Elena Ruiz');
+    const tracks = getComputedStyle(card).gridTemplateColumns.trim().split(/\s+/);
+    await expect(tracks).toHaveLength(1);
+    await expect(tracks[0]).toMatch(/px$/);
+    await expect(card.children).toHaveLength(6);
+  },
+};
+
+export const Sanitized: Story = {
+  name: 'Rich text is re-sanitized at render',
+  args: {
+    items: [
+      {
+        id: 'soap-untrusted',
+        signedByName: 'Dr Elena Ruiz',
+        date: '12 Mar 2026',
+        time: '10:04',
+        fields: [
+          { label: 'Chief complaint', text: 'Stored note replayed from the API.' },
+          {
+            label: 'Assessment',
+            html:
+              '<p>Stable on <strong>meloxicam</strong>.</p>' +
+              '<img src="x" onerror="alert(1)"><a href="javascript:alert(1)">tap</a>',
+          },
+        ],
+      },
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const card = await expand(canvasElement, 'Dr Elena Ruiz');
+    await expect(within(card).getByText('meloxicam')).toBeInTheDocument();
+    // `sanitizeRichText` allows only p/br/strong/b/em/i/u/s/ul/ol/li, so the image and
+    // the anchor are gone while the prose around them survives. This is the second
+    // sanitization pass - the write path already ran one - and it is the one that
+    // protects a note that reached the database before the allow-list tightened.
+    await expect(card.querySelector('img')).toBeNull();
+    await expect(card.querySelector('a')).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Every value is injected with `dangerouslySetInnerHTML`, so what the allow-list drops is ' +
+          'worth seeing rather than assuming. Anything outside p/br/strong/b/em/i/u/s/ul/ol/li is ' +
+          'stripped at render, leaving the surrounding prose intact.',
+      },
+    },
+  },
+};
+
+export const Empty: Story = {
+  name: 'No notes recorded',
+  args: { items: [] },
+  play: async ({ canvasElement }) => {
+    await expect(
+      within(canvasElement).getByText('No SOAP notes recorded yet.')
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A visit with nothing signed yet: the `<ul>` is replaced by a filled `--neutral-100` ' +
+          'block rather than an empty bordered section, so the card never reads as broken.',
+      },
+    },
+  },
+};
+
+export const CustomEmptyLabel: Story = {
+  name: 'No notes (caller copy)',
+  args: { items: [], emptyLabel: 'No SOAP notes for this visit yet.' },
+};

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/SoapNotesList.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/SoapNotesList.stories.tsx
@@ -8,17 +8,6 @@ import SoapNotesList, { type SoapNoteListItem } from './SoapNotesList';
  * The expanded card is the only responsive thing here - `grid-cols-1 lg:grid-cols-2` -
  * so a story that asserts a track count has to own the width it asserts at.
  */
-const DESKTOP_VIEWPORT = {
-  desktop: {
-    name: 'Desktop (1440)',
-    styles: { width: '1440px', height: '900px' },
-    type: 'desktop',
-  },
-};
-const MOBILE_VIEWPORT = {
-  mobile: { name: 'Mobile (375)', styles: { width: '375px', height: '812px' }, type: 'mobile' },
-};
-
 const FIELDS: SoapNoteListItem['fields'] = [
   { label: 'Chief complaint', text: 'Limping on the left hind leg since Sunday.' },
   { label: 'Subjective', html: '<p>Owner reports reluctance to jump onto the sofa.</p>' },
@@ -124,11 +113,6 @@ export const ExpandedDesktop: Story = {
   name: 'Expanded note (1440 - two columns)',
   globals: { viewport: { value: 'desktop', isRotated: false } },
   parameters: {
-    viewport: {
-      options: DESKTOP_VIEWPORT,
-      viewports: DESKTOP_VIEWPORT,
-      defaultViewport: 'desktop',
-    },
     chromatic: { viewports: [1440] },
     docs: {
       description: {
@@ -163,7 +147,6 @@ export const ExpandedMobile: Story = {
   name: 'Expanded note (375 - one column)',
   globals: { viewport: { value: 'mobile', isRotated: false } },
   parameters: {
-    viewport: { options: MOBILE_VIEWPORT, viewports: MOBILE_VIEWPORT, defaultViewport: 'mobile' },
     chromatic: { viewports: [375] },
     docs: {
       description: {

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/TotalBillContainer.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/TotalBillContainer.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { expect, fn, userEvent, within } from 'storybook/test';
+
+import { openGlassTooltip } from '@/app/ui/primitives/GlassTooltip/storyInteractions';
 import TotalBillContainer, { type BillableSearchItem } from './TotalBillContainer';
 import type { InvoiceLineItem } from '@/app/features/appointments/types/workspace';
 
@@ -112,13 +114,14 @@ const BILLABLE_ITEMS: BillableSearchItem[] = [
   },
 ];
 
-/** Hovers a 16px (i) button and returns the portalled GlassTooltip bubble. */
-const hoverInfoIcon = async (canvasElement: HTMLElement, accessibleName: string) => {
-  const button = within(canvasElement).getByRole('button', { name: accessibleName });
-  // GlassTooltip binds mouseenter/focusin to its own wrapper span, not the button.
-  await userEvent.hover(button.closest('.glass-tooltip') as HTMLElement);
-  return within(document.body).findByRole('tooltip');
-};
+/**
+ * Opens a 16px (i) button's bubble and returns it.
+ *
+ * GlassTooltip binds mouseenter/focusin to its own wrapper span, not the button, and
+ * binds them in an effect a play function can outrun - so the dispatch is retried.
+ */
+const hoverInfoIcon = async (canvasElement: HTMLElement, accessibleName: string) =>
+  openGlassTooltip(within(canvasElement).getByRole('button', { name: accessibleName }));
 
 const meta = {
   title: 'Workspace/TotalBillContainer',

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/TotalBillContainer.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/TotalBillContainer.stories.tsx
@@ -120,7 +120,7 @@ const BILLABLE_ITEMS: BillableSearchItem[] = [
  * GlassTooltip binds mouseenter/focusin to its own wrapper span, not the button, and
  * binds them in an effect a play function can outrun - so the dispatch is retried.
  */
-const hoverInfoIcon = async (canvasElement: HTMLElement, accessibleName: string) =>
+const hoverInfoIcon = (canvasElement: HTMLElement, accessibleName: string) =>
   openGlassTooltip(within(canvasElement).getByRole('button', { name: accessibleName }));
 
 const meta = {

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/TotalBillContainer.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/TotalBillContainer.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import TotalBillContainer from './TotalBillContainer';
+import { expect, fn, userEvent, within } from 'storybook/test';
+import TotalBillContainer, { type BillableSearchItem } from './TotalBillContainer';
 import type { InvoiceLineItem } from '@/app/features/appointments/types/workspace';
 
 // Total Bill seeded with lines mapped from saved Treatment items (Bug 9: saved
@@ -26,9 +27,133 @@ const items: InvoiceLineItem[] = [
   },
 ];
 
+/**
+ * A package line, which is the only shape that renders `PackageBreakdownTooltip`
+ * at all - the component returns `null` when `breakdown` is empty, so a fixture
+ * without one removes the trigger from the DOM rather than merely leaving it
+ * unhovered.
+ */
+const PACKAGE_LINE: InvoiceLineItem = {
+  id: 'inv-3',
+  name: 'Puppy wellness package',
+  unitPriceCents: 24000,
+  qty: 1,
+  grossCents: 24000,
+  discountCents: 2400,
+  amountCents: 21600,
+  maxDiscountPercent: 15,
+  breakdown: [
+    {
+      id: 'brk-1',
+      name: 'Physical examination',
+      qty: 1,
+      instructions: 'Service',
+      unitPriceCents: 6000,
+      amountCents: 6000,
+    },
+    {
+      id: 'brk-2',
+      name: 'DHPP vaccination',
+      qty: 2,
+      instructions: 'Vaccination',
+      unitPriceCents: 4500,
+      discountPercent: 10,
+      discountCents: 900,
+      amountCents: 8100,
+    },
+    {
+      id: 'brk-3',
+      name: 'Faecal flotation',
+      qty: 1,
+      instructions: 'Diagnostic',
+      unitPriceCents: 5400,
+      amountCents: 5400,
+    },
+  ],
+};
+
+/** Catalogue the search bar filters. Names deliberately share the token "dent". */
+const BILLABLE_ITEMS: BillableSearchItem[] = [
+  {
+    name: 'Dental radiograph (full mouth)',
+    unitPriceCents: 12000,
+    qty: 1,
+    grossCents: 12000,
+    discountCents: 0,
+    amountCents: 12000,
+    kind: 'EXISTING_TREATMENT',
+  },
+  {
+    name: 'Dental extraction - single tooth',
+    unitPriceCents: 9500,
+    qty: 1,
+    grossCents: 9500,
+    discountCents: 0,
+    amountCents: 9500,
+    kind: 'PACKAGE_COMPONENT',
+  },
+  {
+    name: 'Dentalcare chews (30 pack)',
+    unitPriceCents: 2200,
+    qty: 1,
+    grossCents: 2200,
+    discountCents: 0,
+    amountCents: 2200,
+    kind: 'INVENTORY',
+  },
+  {
+    name: 'Metronidazole 250mg',
+    unitPriceCents: 1400,
+    qty: 1,
+    grossCents: 1400,
+    discountCents: 0,
+    amountCents: 1400,
+    kind: 'IN_HOUSE_PRESCRIPTION',
+  },
+];
+
+/** Hovers a 16px (i) button and returns the portalled GlassTooltip bubble. */
+const hoverInfoIcon = async (canvasElement: HTMLElement, accessibleName: string) => {
+  const button = within(canvasElement).getByRole('button', { name: accessibleName });
+  // GlassTooltip binds mouseenter/focusin to its own wrapper span, not the button.
+  await userEvent.hover(button.closest('.glass-tooltip') as HTMLElement);
+  return within(document.body).findByRole('tooltip');
+};
+
 const meta = {
   title: 'Workspace/TotalBillContainer',
   component: TotalBillContainer,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The invoice table in the appointment workspace: a search bar that adds billable items, ' +
+          'the line rows with their editable quantity and per-line discount, and the recessed ' +
+          'totals footer.\n\n' +
+          'Three of its surfaces only exist after an interaction, and the fixtures this file ' +
+          'shipped with removed all three from the DOM before anyone could hover them: ' +
+          '`billableItems` was `[]`, so the search never matched and the dropdown never mounted; no ' +
+          'line carried a `breakdown`, so `PackageBreakdownTooltip` returned `null` and its (i) ' +
+          'button was not rendered; and `incompleteItemNames` was an empty `Set`, so no row got the ' +
+          '"Fill information in previous step" hint. The stories below give it real data.\n\n' +
+          'Each surface is portalled, so none of them is a descendant of the card in the DOM. The ' +
+          'search results are `position: fixed` at `zIndex 1000` on `document.body`, deliberately ' +
+          'escaping the card and the sticky workspace chrome that used to paint over them. Both ' +
+          'tooltips are `GlassTooltip` bubbles created on `mouseenter`/`focusin` and appended to ' +
+          '`document.body`, positioned from the trigger rect.\n\n' +
+          'The package bubble is the one worth drawing most: it is a seven-column `<table>` inside a ' +
+          'floating panel with `min-w-130` (520px) against a `maxWidth` of 560px, holding a head, ' +
+          'the component rows and a three-row `tfoot`. That is a whole table layout that no ' +
+          'snapshot of this component has ever contained - and rendering it turns out to expose a ' +
+          'live defect, described on that story below.\n\n' +
+          'The play functions assert the opened panels have their content - option rows, column ' +
+          'headers, footer labels - rather than that a trigger changed state, because an empty ' +
+          'panel satisfies the weaker check and that is precisely how such regressions survive.',
+      },
+    },
+  },
+  tags: ['autodocs'],
   args: {
     items,
     billableItems: [],
@@ -38,11 +163,11 @@ const meta = {
     overallDiscountPercent: 0,
     taxPercent: 8,
     incompleteItemNames: new Set<string>(),
-    onToggleWithdrawDeposit: () => undefined,
-    onChangeOverallDiscount: () => undefined,
-    onAddItem: () => undefined,
-    onUpdateItem: () => undefined,
-    onRemoveItem: () => undefined,
+    onToggleWithdrawDeposit: fn(),
+    onChangeOverallDiscount: fn(),
+    onAddItem: fn(),
+    onUpdateItem: fn(),
+    onRemoveItem: fn(),
   },
 } satisfies Meta<typeof TotalBillContainer>;
 
@@ -56,4 +181,184 @@ export const SavedItemsInBill: Story = {};
 // Overall discount 10% -> -$10.80 -> Total $97.20.
 export const WithOverallDiscount: Story = {
   args: { overallDiscountPercent: 10 },
+};
+
+export const SearchResultsOpen: Story = {
+  name: 'Billable-item dropdown open',
+  args: { billableItems: BILLABLE_ITEMS },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The dropdown has no `open` prop of its own: it is derived from the
+    // internal query matching `billableItems`, so it can only be reached by typing.
+    await userEvent.type(canvas.getByRole('searchbox', { name: 'Search invoice items' }), 'dent');
+
+    /* The panel is a body portal, so it is outside canvasElement. Anchor on one
+       option and walk up to its list rather than matching a layout class. */
+    const option = await within(document.body).findByRole('button', {
+      name: /Dental radiograph/i,
+    });
+    const list = option.closest('ul') as HTMLElement;
+    await expect(list).toBeTruthy();
+
+    // Three of the four catalogue items contain "dent"; the fourth must not be
+    // there. Asserting the row count is the check an empty panel would fail.
+    await expect(within(list).getAllByRole('listitem')).toHaveLength(3);
+    await expect(within(list).queryByText('Metronidazole 250mg')).toBeNull();
+
+    // Each row carries its kind pill and its formatted price - the two slots
+    // most likely to be dropped by a mapping change.
+    await expect(within(list).getByText('Package component')).toBeInTheDocument();
+    await expect(within(list).getByText('$120')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The results panel, anchored under the search field and painted at `zIndex 1000` on the ' +
+          'body so it clears the card, the line rows and the workspace chrome. Rows are plain ' +
+          '`<button>`s inside `<li>`s - not `role="option"` - so anything querying a listbox here ' +
+          'would find nothing and pass.',
+      },
+    },
+  },
+};
+
+export const SearchNoMatches: Story = {
+  name: 'Search with no matches',
+  args: { billableItems: BILLABLE_ITEMS },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.type(canvas.getByRole('searchbox', { name: 'Search invoice items' }), 'zzz');
+    // `open` is `matches.length > 0`, so a miss renders no panel at all rather
+    // than an empty one - there is no "No results" affordance to review.
+    await expect(within(document.body).queryByText(/Dental radiograph/i)).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A query that matches nothing. Worth its own story because the component has no ' +
+          'empty-state row: the panel simply does not mount, so the field looks identical to one ' +
+          'that has not been typed in.',
+      },
+    },
+  },
+};
+
+export const PackageBreakdown: Story = {
+  name: 'Package breakdown tooltip',
+  args: { items: [...items, PACKAGE_LINE] },
+  play: async ({ canvasElement }) => {
+    const bubble = await hoverInfoIcon(
+      canvasElement,
+      'View Puppy wellness package package breakdown'
+    );
+
+    // A seven-column table lives inside this bubble. Assert the structure, not
+    // just that a bubble appeared.
+    await expect(within(bubble).getAllByRole('columnheader')).toHaveLength(7);
+    await expect(within(bubble).getByText('Package breakdown')).toBeInTheDocument();
+    await expect(within(bubble).getByText('DHPP vaccination')).toBeInTheDocument();
+    await expect(within(bubble).getByText('Faecal flotation')).toBeInTheDocument();
+    // The tfoot carries three rows once a package discount exists: component
+    // total, the discount line, and the total.
+    await expect(within(bubble).getByText('Component total')).toBeInTheDocument();
+    await expect(within(bubble).getByText(/Package discount/)).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The package line expanded: 520px of table inside a 560px cap, with the discount row ' +
+          'appearing only when the line actually carries one.\n\n' +
+          '**This story renders a live bug.** Look at it rather than at this text: the component ' +
+          'names, the package title and every money figure are invisible. `PackageBreakdownTooltip` ' +
+          'paints its primary text `text-neutral-0` and its secondary text `text-neutral-200`, but ' +
+          'in this system `--color-neutral-0` is `var(--screen)` - the panel FILL - and ' +
+          '`--color-neutral-200` is `var(--hairline)` - a BORDER token. `.glass-tooltip-bubble` ' +
+          'paints its background from that same `var(--screen)`, so the primary text is measurably ' +
+          'the same colour as the surface under it: `rgb(247,243,236)` on `rgb(247,243,236)` in ' +
+          'light and `rgb(47,39,30)` on `rgb(47,39,30)` in dark. That is 1.00:1 in **both** themes, ' +
+          'and the secondary rows sit at roughly 1.25:1.\n\n' +
+          'It is the exact failure this Storybook work exists to catch - a dropdown panel whose text ' +
+          'reaches for fill tokens instead of ink tokens - and it survived because the surface is ' +
+          'built on `mouseenter`, so nothing had ever drawn it. The bubble already inherits ' +
+          '`color: var(--ink)` from `.glass-tooltip-bubble`, which is the pair that actually ' +
+          'inverts; the fix is to drop the `text-neutral-*` overrides rather than to add more. ' +
+          'The assertions here are structural on purpose, so the story stays green and the defect ' +
+          'stays visible until the component is changed.',
+      },
+    },
+  },
+};
+
+export const IncompleteItemHint: Story = {
+  name: 'Incomplete prescription hint',
+  args: { incompleteItemNames: new Set(['amoxicillin (in-house)']) },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The hint is keyed on a lower-cased, trimmed name match, so it is present
+    // on exactly one of the two rows.
+    await expect(canvas.getAllByRole('button', { name: /Fill information/i })).toHaveLength(1);
+
+    const bubble = await hoverInfoIcon(canvasElement, 'Fill information in previous step');
+    await expect(bubble).toHaveTextContent(
+      'Fill prescription information in the Treatment step before finalizing this invoice.'
+    );
+    /* side="bottom" - it hangs under the row rather than covering the row above.
+       Read the inline transform, not the computed one: a laid-out element
+       resolves any transform to a `matrix(...)`, so a computed-style check
+       cannot tell the two placements apart. */
+    await expect(bubble.style.transform).toMatch(/^translate\(-50%, 0(px)?\)$/);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A billed medication whose prescription details were never filled in. The row gets a ' +
+          'second 16px (i) beside the name, and the sentence explaining what to do exists only ' +
+          'inside the hovered bubble - the row itself says nothing.',
+      },
+    },
+  },
+};
+
+export const PerLineDiscountCap: Story = {
+  name: 'Per-line discount cap',
+  args: {
+    items: [
+      {
+        ...items[0],
+        maxDiscountPercent: 20,
+        discountCents: 1500,
+        amountCents: 8500,
+      },
+      items[1],
+    ],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'With a catalogue ceiling the discount cell grows a second line ("Max discount 20% / $20") ' +
+          'under the input, and the row adds `pb-2` so that caption cannot collide with ' +
+          'the next row. The gross cell simultaneously grows its struck discount line, so this is ' +
+          'the render where the row is at its tallest.',
+      },
+    },
+  },
+};
+
+export const EmptyBill: Story = {
+  name: 'No line items',
+  args: { items: [] },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'With no lines the column headings are dropped entirely rather than left over an empty ' +
+          'table, and the footer still renders with its zeroed totals.',
+      },
+    },
+  },
 };

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/index.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/index.tsx
@@ -290,7 +290,14 @@ const hasMeaningfulSoapContent = (notes: SoapNoteEntry[]): boolean =>
       )
   );
 
-const DischargeDateTimeModal = ({
+/**
+ * Exported rather than kept private to this module so Storybook can draw it on
+ * its own. Reaching it through the workspace needs the whole bootstrap
+ * aggregate - an appointment, an inpatient encounter, a room unit and a
+ * backend-owned finalization gate - so the gate-blocked branch below had never
+ * been rendered anywhere outside the running app.
+ */
+export const DischargeDateTimeModal = ({
   showModal,
   setShowModal,
   dischargeDate,

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/HospitalizationModal.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/HospitalizationModal.stories.tsx
@@ -224,7 +224,7 @@ export const ValidationErrors: Story = {
   play: async ({ canvasElement }) => {
     const panel = within(await openModal(canvasElement));
     await userEvent.click(panel.getByRole('button', { name: 'Convert to Inpatient' }));
-    await expect(await panel.findByText('Room is required.')).toBeInTheDocument();
+    expect(await panel.findByText('Room is required.')).toBeInTheDocument();
     await expect(panel.getByText('Unit is required.')).toBeInTheDocument();
   },
   parameters: {

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/HospitalizationModal.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/HospitalizationModal.stories.tsx
@@ -202,7 +202,7 @@ export const UnitFollowsRoom: Story = {
     const listbox = await within(document.body).findByLabelText('Room');
     await userEvent.click(within(listbox).getByText('Ward B'));
     // Ward B has no critical-care unit, so the unit falls to the room's first option.
-    await expect(
+    expect(
       await panel.findByRole('button', { name: 'Unit: General inpatient' })
     ).toBeInTheDocument();
   },

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/QuickActionsModal.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/QuickActionsModal.stories.tsx
@@ -1,0 +1,517 @@
+import { useState, type ComponentProps } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import type { Appointment } from '@yosemite-crew/types';
+
+import type { AppointmentEncounter, SideAction } from '@/app/features/appointments/types/workspace';
+import { CALCULATOR_CATEGORIES } from '@/app/features/calculators/registry';
+import { useAppointmentWorkspaceStore } from '@/app/stores/appointmentWorkspaceStore';
+import QuickActionsModal from './QuickActionsModal';
+
+const APPOINTMENT_ID = 'appt-workspace-1';
+const ORG_ID = 'org-storybook';
+
+const APPOINTMENT: Appointment = {
+  id: APPOINTMENT_ID,
+  patient: {
+    id: 'companion-1',
+    name: 'Poppy Hartmann',
+    species: 'dog',
+    breed: 'Beagle',
+    parent: { id: 'parent-1', name: 'Lena Hartmann' },
+  },
+  lead: { id: 'prac-amara', name: 'Dr. Amara Weber' },
+  organisationId: ORG_ID,
+  appointmentDate: new Date('2026-03-12T09:30:00.000Z'),
+  startTime: new Date('2026-03-12T09:30:00.000Z'),
+  endTime: new Date('2026-03-12T10:00:00.000Z'),
+  timeSlot: '09:30 - 10:00',
+  durationMinutes: 30,
+  status: 'IN_PROGRESS',
+};
+
+/**
+ * The encounter the Record panel reads.
+ *
+ * `RecordPanel` returns `null` outright when `encountersById[appointmentId]` is
+ * missing, so without this seed the Record tab renders an empty panel and a story
+ * asserting "the tab routed" would pass against nothing. Seeding the real store is
+ * also what keeps the mount off the network - the panel never fetches, it only
+ * reads.
+ */
+const ENCOUNTER: AppointmentEncounter = {
+  appointmentId: APPOINTMENT_ID,
+  mode: 'OUTPATIENT',
+  consultationType: 'Outpatient consult',
+  leadId: 'prac-amara',
+  leadName: 'Dr. Amara Weber',
+  alerts: [],
+  soap: [],
+  soapTemplates: [],
+  vitals: [
+    {
+      id: 'vt-1',
+      code: 'VT-001',
+      weightLbs: 62.4,
+      tempF: 101.6,
+      heartRateBpm: 96,
+      respRateBpm: 24,
+      crtSec: '<2',
+      mucousMembrane: 'Pink',
+      painScore: 2,
+      bcs: 5,
+      recordedByName: 'Dr. Amara Weber',
+      recordedAt: '2026-03-12T12:00:00.000Z',
+    },
+  ],
+  observations: [],
+  diagnosticTests: [],
+  diagnosticOrders: [],
+  services: [],
+  prescription: [],
+  schedule: [],
+  invoiceLineItems: [],
+  pastInvoices: [],
+  depositCents: 0,
+  currency: 'USD',
+  withdrawDeposit: false,
+  taxPercent: 0,
+  overallDiscountPercent: 0,
+  dischargeSummary: '',
+  documents: [],
+  readyForBilling: { value: false },
+  readyForDischarge: { value: false },
+  stepStatus: {
+    SOAP: 'IN_PROGRESS',
+    DIAGNOSTICS: 'EMPTY',
+    TREATMENT: 'EMPTY',
+    PASSPORT: 'EMPTY',
+    INVOICE: 'EMPTY',
+    SUMMARY: 'EMPTY',
+  },
+  viewOnly: false,
+};
+
+const seedEncounter = () => {
+  const snapshot = useAppointmentWorkspaceStore.getState();
+  useAppointmentWorkspaceStore.setState({
+    encountersById: { ...snapshot.encountersById, [APPOINTMENT_ID]: ENCOUNTER },
+  });
+  return () => {
+    useAppointmentWorkspaceStore.setState({ encountersById: snapshot.encountersById });
+  };
+};
+
+type QuickActionsProps = ComponentProps<typeof QuickActionsModal>;
+
+/**
+ * `activeAction` is a controlled prop owned by the workspace route, so a bare
+ * render can never change tabs. The harness holds it locally the way the route
+ * does. It is keyed on the arg in `render`, so changing the control still
+ * remounts at the requested tab.
+ */
+const QuickActionsHarness = (args: QuickActionsProps) => {
+  const [action, setAction] = useState<SideAction | null>(args.activeAction);
+  return (
+    <div className="min-h-[720px] bg-[var(--screen)] p-6">
+      <p className="text-[13px] text-[var(--ink-muted)]">
+        Workspace content behind the drawer, so the scrim tint and 2px blur are visible.
+      </p>
+      <QuickActionsModal
+        {...args}
+        activeAction={action}
+        onChangeAction={(next) => {
+          setAction(next);
+          args.onChangeAction(next);
+        }}
+      />
+    </div>
+  );
+};
+
+/** The panel, once the drawer is actually open. */
+const openPanel = async (): Promise<HTMLElement> => {
+  await waitFor(() => {
+    expect(document.querySelector('dialog[open]')).not.toBeNull();
+  });
+  return document.querySelector('dialog[open]') as HTMLElement;
+};
+
+/** The nav rail's round icon buttons, in render order. */
+const navButtons = (panel: HTMLElement): HTMLButtonElement[] => {
+  const nav = panel.querySelector('nav[aria-label="Quick actions"]') as HTMLElement;
+  return [...nav.querySelectorAll('button')] as HTMLButtonElement[];
+};
+
+const meta = {
+  title: 'Workspace/QuickActionsModal',
+  component: QuickActionsModal,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The right-docked quick-actions drawer: a rail of seven round icon tabs over one ' +
+          'lazily-loaded panel. It had no story, and three things about it are invisible from ' +
+          'the source alone.\n\n' +
+          'First, **the drawer is always mounted**. `Modal` renders its children whether or not ' +
+          'it is open and only drops the `open` attribute (adding `inert`), so a closed ' +
+          'quick-actions drawer still has its whole nav rail parked in `document.body`. Any ' +
+          'assertion written against the nav text rather than against `dialog[open]` passes with ' +
+          'the drawer shut.\n\n' +
+          'Second, **every panel is a separate `next/dynamic` chunk**. Opening a tab for the ' +
+          'first time renders `PanelSkeleton` - a pulsing `min-h-50` block - and only then the ' +
+          'panel, so the tab switch is a two-frame transition rather than an instant swap.\n\n' +
+          'Third, **the rail is seven items in a 530px drawer**, and six of them come from one ' +
+          '`NavButton` while MSD is hand-rolled around a branded `next/image` glyph. The MSD tile ' +
+          'is the only one that tints its background when active (`bg-primary-100`) instead of ' +
+          'only its border and ink, which is exactly the kind of drift a rail like this collects.\n\n' +
+          'The Record and Calculators panels are pure store reads, so they mount here for real. ' +
+          'Tasks, Documents, Chat, Activity and MSD each fetch on mount and are covered by their ' +
+          'own stories where they can be reached without a service stub.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    appointment: APPOINTMENT,
+    appointmentId: APPOINTMENT_ID,
+    organisationId: ORG_ID,
+    encounterId: 'enc-1',
+    authorId: 'prac-amara',
+    activeAction: 'RECORD',
+    onChangeAction: fn(),
+    onClose: fn(),
+  },
+  render: (args) => <QuickActionsHarness key={String(args.activeAction)} {...args} />,
+  beforeEach: seedEncounter,
+} satisfies Meta<typeof QuickActionsModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Closed: Story = {
+  name: 'Closed (still mounted)',
+  args: { activeAction: null },
+  play: async () => {
+    // No open dialog ...
+    await expect(document.querySelector('dialog[open]')).toBeNull();
+    // ... but the drawer itself, and its whole nav rail, are in the DOM.
+    const parked = document.querySelector('dialog.yc-modal-dialog') as HTMLElement | null;
+    await expect(parked).not.toBeNull();
+    await expect(parked).toHaveAttribute('inert');
+
+    const dialog = parked as HTMLElement;
+
+    /* Every assertion below this line is a raw DOM query, on purpose. The UA
+       stylesheet carries `dialog:not([open]) { display: none }` and the app's
+       `.yc-modal-dialog` reset overrides position/inset/margin/border but never
+       `display`, so a closed drawer's subtree is display:none. Testing Library's
+       role and text queries skip anything display:none, which means every
+       `getByRole` here would throw and - far worse - every `queryByRole(...)
+       .not.toBeInTheDocument()` would pass no matter what the rail contained.
+       `querySelectorAll` does not consult the accessibility tree, so it reports
+       what is actually mounted, which is the only thing this story claims. */
+    await expect(navButtons(dialog).map((button) => button.textContent)).toEqual([
+      'Record',
+      'Tasks',
+      'Documents',
+      'Chat',
+      'Activity',
+      'MSD',
+      'Calculators',
+    ]);
+    await expect(dialog.querySelector('h2')?.textContent).toBe('Quick actions');
+
+    // Nothing is pressed and no panel is mounted while there is no active action.
+    await expect(dialog.querySelectorAll('[aria-pressed="true"]')).toHaveLength(0);
+    await expect(dialog.querySelectorAll('[aria-pressed="false"]')).toHaveLength(7);
+    await expect(dialog.querySelector('[role="tablist"]')).toBeNull();
+    await expect(dialog.querySelector('[role="tabpanel"]')).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The closed drawer, which is not an unmounted one. `showModal` only controls the ' +
+          '`open` attribute, the slide transform and `inert`; the header and the seven-tab rail ' +
+          'stay in `document.body` the whole time. Absence has to be asserted against ' +
+          '`dialog[open]` here, never against the nav copy.\n\n' +
+          'Two consequences a reviewer should look at. The exit transition is never seen: ' +
+          '`open` is dropped in the same render as `translate-x-[120%]`, and a `<dialog>` ' +
+          'without `open` is `display: none` per the UA stylesheet, so the 300ms slide-out ' +
+          'plays on an already-hidden element. And because the subtree is display:none rather ' +
+          'than unmounted, the seven tab buttons stay in the DOM with `aria-pressed="false"` - ' +
+          'out of the accessibility tree today only by virtue of that `display`, not by ' +
+          'anything the component does.',
+      },
+    },
+  },
+};
+
+export const RecordPanel: Story = {
+  name: 'Record tab',
+  play: async () => {
+    const panel = await openPanel();
+    const inPanel = within(panel);
+
+    await expect(inPanel.getByRole('heading', { name: 'Quick actions' })).toBeInTheDocument();
+
+    // Seven tabs, in order, exactly one pressed.
+    const buttons = navButtons(panel);
+    await expect(buttons).toHaveLength(7);
+    await expect(buttons.map((button) => button.textContent)).toEqual([
+      'Record',
+      'Tasks',
+      'Documents',
+      'Chat',
+      'Activity',
+      'MSD',
+      'Calculators',
+    ]);
+    await expect(panel.querySelectorAll('[aria-pressed="true"]')).toHaveLength(1);
+    await expect(inPanel.getByRole('button', { name: 'Record' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+
+    /* The panel is a `next/dynamic` chunk, so it arrives a frame after the rail.
+       Asserting the real Record panel drew - its two tabs and the seeded vital -
+       rather than that some node appeared where the skeleton was. */
+    expect(await inPanel.findByRole('tab', { name: 'Vitals' })).toBeInTheDocument();
+    await expect(inPanel.getByRole('tab', { name: 'Observation Tool' })).toBeInTheDocument();
+    await expect(inPanel.getByText('VT-001')).toBeInTheDocument();
+    await expect(inPanel.getByText('Dr. Amara Weber')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The drawer as the workspace first opens it. Header, the rail with a 1px rule under ' +
+          'it, then the panel in a `min-h-0 flex-1 overflow-y-auto scrollbar-hidden` column - so ' +
+          'the panel scrolls inside the drawer while the header and rail stay put.',
+      },
+    },
+  },
+};
+
+export const ActiveTabStyling: Story = {
+  name: 'Active tab styling',
+  play: async () => {
+    const panel = await openPanel();
+    const inPanel = within(panel);
+    const active = inPanel.getByRole('button', { name: 'Record' });
+    const idle = inPanel.getByRole('button', { name: 'Tasks' });
+
+    // The circle is the first span inside the button; the label is the second.
+    const activeCircle = active.querySelector('span') as HTMLElement;
+    const idleCircle = idle.querySelector('span') as HTMLElement;
+
+    /* Polled rather than read once: the circle carries `transition-colors
+       duration-150`, so a synchronous read taken in the same frame as the mount
+       can catch an interpolated border colour and compare equal by accident. */
+    await waitFor(() => {
+      expect(getComputedStyle(activeCircle).borderColor).not.toBe(
+        getComputedStyle(idleCircle).borderColor
+      );
+      expect(getComputedStyle(activeCircle).color).not.toBe(getComputedStyle(idleCircle).color);
+    });
+
+    const activeLabel = active.querySelectorAll('span')[1] as HTMLElement;
+    const idleLabel = idle.querySelectorAll('span')[1] as HTMLElement;
+
+    /* PINNED TO CURRENT BEHAVIOUR - the active label does not actually go bold.
+       The component asks for it: `QuickActionsModal.tsx` renders the active
+       label as `text-caption-2 font-bold`. But `.text-caption-2` is declared
+       OUTSIDE `@layer` in `globals.css` with `font-weight: 500 !important`, and
+       an unlayered `!important` declaration beats every Tailwind utility, so
+       `font-bold` never lands and both labels compute to 500. That is a
+       stylesheet defect the component is a victim of, not a component defect -
+       tracked as issue #2297.
+
+       The class assertions are here so the contradiction is in the failure
+       output rather than hidden behind a soft assertion: the markup says
+       `font-bold`, the computed weight says 500. When #2297 is fixed the two
+       weights will diverge, this block will fail loudly, and it should then be
+       restored to `expect(active).not.toBe(idle)`. */
+    await expect(activeLabel).toHaveClass('text-caption-2');
+    await expect(activeLabel).toHaveClass('font-bold');
+    await expect(idleLabel).not.toHaveClass('font-bold');
+    await waitFor(() => {
+      expect(getComputedStyle(activeLabel).fontWeight).toBe('500');
+      expect(getComputedStyle(idleLabel).fontWeight).toBe('500');
+    });
+
+    /* The distinction the active label does deliver is colour: `text-blue-text`
+       against the idle `text-neutral-700`. `.text-caption-2` sets no `color`, so
+       this is the one half of the active treatment that survives #2297, and it
+       is what the tab actually reads as today. Polled because the tile animates
+       with `transition-colors`. */
+    await waitFor(() => {
+      expect(getComputedStyle(activeLabel).color).not.toBe(getComputedStyle(idleLabel).color);
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The active tab asks for three changes at once - `--text-brand` border, `--blue-text` ' +
+          'ink and a bold label - and none of them is a background fill. Only two of the three ' +
+          'arrive: the `font-bold` on the label is dead, because `.text-caption-2` is declared ' +
+          'outside `@layer` with `font-weight: 500 !important` and unlayered `!important` beats ' +
+          'any utility (issue #2297). The play function is pinned to that, and asserts the ' +
+          '`font-bold` class is present so the contradiction is visible rather than papered ' +
+          'over. The MSD tile breaks the no-fill pattern by filling with `bg-primary-100` when ' +
+          'active, which is visible by switching to it in the story below.',
+      },
+    },
+  },
+};
+
+export const SwitchToCalculators: Story = {
+  name: 'Switching tab loads another chunk',
+  play: async ({ args }) => {
+    const panel = await openPanel();
+    const inPanel = within(panel);
+    expect(await inPanel.findByRole('tab', { name: 'Vitals' })).toBeInTheDocument();
+
+    await userEvent.click(inPanel.getByRole('button', { name: 'Calculators' }));
+    await expect(args.onChangeAction).toHaveBeenCalledWith('CALCULATORS');
+
+    // The previous panel is unmounted, not hidden - only one panel exists at a time.
+    await waitFor(() => {
+      expect(inPanel.queryByRole('tab', { name: 'Vitals' })).not.toBeInTheDocument();
+    });
+
+    /* Assert the calculators panel really drew: the category track carries one
+       segment per registry category, so a truncated or empty track fails here
+       rather than passing on "something rendered". */
+    const track = await inPanel.findByRole('group', { name: 'Calculator category' });
+    await expect(within(track).getAllByRole('button')).toHaveLength(CALCULATOR_CATEGORIES.length);
+    await expect(
+      within(track).getByRole('button', { name: CALCULATOR_CATEGORIES[0] })
+    ).toBeInTheDocument();
+
+    // Pressed state moved with it.
+    await expect(inPanel.getByRole('button', { name: 'Calculators' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    await expect(inPanel.getByRole('button', { name: 'Record' })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+
+    /* Counted over the nav rail, not over the whole drawer. `aria-pressed` is
+       not a rail-only attribute: the calculators panel's category track is a
+       `SegmentedPill`, and every segment in it carries `aria-pressed`, so a
+       drawer-wide count reads two here - the Calculators tab plus the selected
+       category - and would keep climbing as panels add toggles. Exactly one
+       pressed *tab* is what this story claims, so the query is scoped to the
+       seven rail buttons. */
+    await expect(
+      navButtons(panel).filter((button) => button.getAttribute('aria-pressed') === 'true')
+    ).toHaveLength(1);
+
+    // And the track that supplied the second one keeps exactly one segment pressed.
+    await expect(track.querySelectorAll('[aria-pressed="true"]')).toHaveLength(1);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Tabs are exclusive `activeAction === X` branches, so switching unmounts the previous ' +
+          'panel entirely and any unsaved draft in it goes with it. The category track scrolls ' +
+          'horizontally inside the 530px drawer rather than wrapping, which is the reason the ' +
+          'registry can carry more categories than fit.',
+      },
+    },
+  },
+};
+
+export const MsdTabActive: Story = {
+  name: 'MSD tile active',
+  args: { activeAction: 'MSD' },
+  play: async () => {
+    const panel = await openPanel();
+    const inPanel = within(panel);
+    const msd = inPanel.getByRole('button', { name: 'MSD' });
+    const record = inPanel.getByRole('button', { name: 'Record' });
+
+    await expect(msd).toHaveAttribute('aria-pressed', 'true');
+
+    /* MSD is the only tile that fills. Every `NavButton` keeps a transparent
+       circle and changes border + ink only, so comparing backgrounds against an
+       idle sibling is what shows the divergence. */
+    const msdCircle = msd.querySelector('span') as HTMLElement;
+    const recordCircle = record.querySelector('span') as HTMLElement;
+    await waitFor(() => {
+      expect(getComputedStyle(msdCircle).backgroundColor).not.toBe(
+        getComputedStyle(recordCircle).backgroundColor
+      );
+    });
+
+    // The branded glyph is decorative, so it must not add a name to the tile.
+    const glyph = msd.querySelector('img') as HTMLImageElement;
+    await expect(glyph).toHaveAttribute('alt', '');
+    await expect(msd).toHaveTextContent('MSD');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The MSD tab, whose tile is hand-rolled rather than a `NavButton`: it swaps a ' +
+          '`next/image` of the Merck glyph for the icon and fills the circle with ' +
+          '`bg-primary-100` when active. The six `NavButton` tiles set no background at all, so ' +
+          'their circles stay transparent in both states and change only border and ink - the ' +
+          'MSD tile is also the only one carrying an explicit idle fill (`bg-neutral-0`). The ' +
+          'panel below it fetches on mount, so this story is about the rail, not the panel.',
+      },
+    },
+  },
+};
+
+export const PhoneFullScreen: Story = {
+  name: 'Phone: drawer goes full-screen',
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async () => {
+    const panel = await openPanel();
+    const inPanel = within(panel);
+
+    /* "Full-screen" is the claim in the component's own docs, so measure it
+       rather than trust the story name: the panel must span the viewport exactly,
+       not merely be wide. Polled because `useIsPhone` is false through SSR and
+       the first client render - the class swap is a post-mount effect, so a read
+       taken immediately still sees the desktop drawer. */
+    await waitFor(() => {
+      const width = panel.getBoundingClientRect().width;
+      expect(Math.abs(width - document.documentElement.clientWidth)).toBeLessThanOrEqual(1);
+    });
+
+    // All seven tabs survive the 375px rail; none is dropped at this width.
+    const buttons = navButtons(panel);
+    await expect(buttons).toHaveLength(7);
+    await expect(inPanel.getByRole('button', { name: 'Calculators' })).toBeInTheDocument();
+
+    /* The rail is `flex justify-between` and flex does not wrap by default, so
+       the seven tiles stay on one line. Read rather than assumed - adding
+       `flex-wrap` to that nav would drop the last tiles onto a second row and
+       change the drawer's whole header height. */
+    const first = buttons[0].getBoundingClientRect();
+    const last = buttons[6].getBoundingClientRect();
+    await expect(Math.abs(first.top - last.top)).toBeLessThan(1);
+
+    expect(await inPanel.findByRole('tab', { name: 'Vitals' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Under 768px the shared `Modal` re-forms a drawer into a full-screen panel, so the ' +
+          'quick actions take the whole phone. Seven 44px circles plus their labels across 375px ' +
+          'minus the rail padding is the tightest this component ever gets - the labels are ' +
+          '`text-caption-2` and "Calculators" is the one that sets the column width.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/panels/ActivityPanel.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/panels/ActivityPanel.stories.tsx
@@ -1,0 +1,215 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, within } from 'storybook/test';
+import type { Appointment, UserOrganization } from '@yosemite-crew/types';
+
+import { useOrgStore } from '@/app/stores/orgStore';
+import ActivityPanel from './ActivityPanel';
+
+const ORG_ID = 'org-storybook';
+
+/**
+ * The appointment deliberately carries no `id`.
+ *
+ * `useAppointmentAuditTrail` short-circuits to an empty list when there is no
+ * appointment id and never touches the network; with an id it POSTs to
+ * `/v1/audit-trail/appointment`, and offline that request fails into the same
+ * empty list a beat later. So this fixture reaches exactly the state a real
+ * appointment reaches in Storybook, just deterministically and without a
+ * request. It is not a shortcut around a state the panel could otherwise show.
+ */
+const APPOINTMENT: Appointment = {
+  patient: {
+    id: 'companion-1',
+    name: 'Poppy Hartmann',
+    species: 'dog',
+    breed: 'Beagle',
+    parent: { id: 'parent-1', name: 'Lena Hartmann' },
+  },
+  organisationId: ORG_ID,
+  appointmentDate: new Date('2026-03-12T09:30:00.000Z'),
+  startTime: new Date('2026-03-12T09:30:00.000Z'),
+  endTime: new Date('2026-03-12T10:00:00.000Z'),
+  timeSlot: '09:30 - 10:00',
+  durationMinutes: 30,
+  status: 'IN_PROGRESS',
+};
+
+const membership = (roleCode: string, roleDisplay: string): UserOrganization => ({
+  practitionerReference: 'Practitioner/user-storybook',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode,
+  roleDisplay,
+  active: true,
+});
+
+type OrgStatus = 'idle' | 'loading' | 'loaded' | 'error';
+
+/**
+ * Seeds the org store the way bootstrap does and restores it on unmount.
+ *
+ * `usePermissions` derives the effective set from `roleCode` against the role
+ * table rather than from the stored `effectivePermissions` snapshot, so seeding
+ * the role is the whole fixture - `audit:view:any` belongs to OWNER, ADMIN and
+ * SUPERVISOR only, which is why VETERINARIAN is the denial case here.
+ */
+const withMembership = (member: UserOrganization | null, status: OrgStatus = 'loaded') => {
+  return () => {
+    const snapshot = useOrgStore.getState();
+    useOrgStore.setState({
+      primaryOrgId: ORG_ID,
+      membershipsByOrgId: member ? { [ORG_ID]: member } : {},
+      status,
+    });
+    return () => {
+      useOrgStore.setState(snapshot);
+    };
+  };
+};
+
+const meta = {
+  title: 'Workspace/ActivityPanel',
+  component: ActivityPanel,
+  parameters: {
+    layout: 'padded',
+    // The denial path renders PermissionDeniedState, which calls next/navigation's
+    // useRouter during render.
+    nextjs: { appDirectory: true },
+    docs: {
+      description: {
+        component:
+          "The Activity tab of the quick-actions drawer: the appointment's audit trail as a " +
+          'vertical timeline. It had no story, and the states below are the ones reachable ' +
+          'without a backend.\n\n' +
+          'The panel is wrapped in a `PermissionGate` on `audit:view:any`, which only OWNER, ' +
+          'ADMIN and SUPERVISOR carry - so for a veterinarian, a technician or a receptionist ' +
+          'this tab is a permission notice, not a timeline. That is a third of the roles in the ' +
+          'product seeing a different panel from the one the design shows, and it had never been ' +
+          'drawn. The gate is also passed no `skeleton`, so while memberships are still ' +
+          'resolving it renders **nothing at all** - a blank panel that reads as "no activity" ' +
+          'rather than "still loading".\n\n' +
+          '**Not covered here: the populated timeline.** The entries come from ' +
+          '`useAppointmentAuditTrail`, which POSTs to the audit endpoint on mount with no store ' +
+          'or cache in front of it, and this Storybook has no request-mocking layer. So the ' +
+          'four `ActorChip` variants (team-member initials on a rotating warm palette, the pink ' +
+          'parent glyph, the blue system flask, the neutral bordered fallback), the 1.5px ' +
+          'connector rail that stops on the last row, and the `Entity · timestamp` detail line ' +
+          'are all still undrawn. Reaching them needs a service stub, which is a separate piece ' +
+          'of Storybook wiring rather than something a story file can do.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    appointment: APPOINTMENT,
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[498px] max-w-full bg-[var(--screen)] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+  beforeEach: withMembership(membership('OWNER', 'Owner')),
+} satisfies Meta<typeof ActivityPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Empty: Story = {
+  name: 'Permitted, nothing recorded',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Nothing to show')).toBeInTheDocument();
+    // The empty copy replaces the timeline outright - there is no empty <ol>.
+    await expect(canvasElement.querySelectorAll('ol')).toHaveLength(0);
+    await expect(canvasElement.querySelectorAll('li')).toHaveLength(0);
+    // And it is the permitted branch, not the denial one.
+    await expect(canvas.queryByRole('status')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'An owner opening Activity on an appointment with no recorded events. The copy is a ' +
+          'single centred `text-body-4` line with no icon and no explanation of what would ' +
+          'appear here - worth comparing against the richer empty states elsewhere in the ' +
+          'workspace before this ships as the real "no history yet" screen.',
+      },
+    },
+  },
+};
+
+export const PermissionDenied: Story = {
+  name: 'Role without audit:view:any',
+  beforeEach: withMembership(membership('VETERINARIAN', 'Veterinarian')),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* `Fallback` renders PermissionDeniedState's inline variant inside an
+       <output>, whose implicit role is `status` - so the notice is announced
+       when it replaces the panel. */
+    const notice = canvas.getByRole('status');
+    await expect(notice).toBeInTheDocument();
+
+    // The role is quoted from the seeded membership, not hardcoded in the copy.
+    await expect(
+      within(notice).getByText(/^Your role \(Veterinarian\) can.t view this section\.$/)
+    ).toBeInTheDocument();
+    await expect(
+      within(notice).getByRole('button', { name: 'Request access' })
+    ).toBeInTheDocument();
+
+    // The timeline and its empty copy are both absent - this is a third branch.
+    await expect(canvas.queryByText('Nothing to show')).not.toBeInTheDocument();
+    await expect(canvasElement.querySelectorAll('ol')).toHaveLength(0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'What a veterinarian, technician, assistant or receptionist actually sees on this tab. ' +
+          '`audit:view:any` sits with OWNER, ADMIN and SUPERVISOR, so the clinical roles get the ' +
+          'compact lock notice with their own role name and a route to request access. Changing ' +
+          'the seeded `roleCode` in this story is enough to check any other role - the ' +
+          'permission set is derived from the role table, never from a stored snapshot.',
+      },
+    },
+  },
+};
+
+export const PermissionsResolving: Story = {
+  name: 'Blank while memberships resolve',
+  beforeEach: withMembership(null, 'loading'),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* "Renders nothing" has to be measured, not inferred from a handful of
+       missing strings - a story that failed to mount looks identical to one that
+       rendered null. So the story's own wrapper is read directly: the decorator
+       div is the panel's only parent, and the gate's null leaves it with zero
+       element children and no text at all. If ActivityPanel ever gained a
+       skeleton, a border or even a spacer, this is the assertion that fails. */
+    const wrapper = canvasElement.querySelector('div.max-w-full') as HTMLElement;
+    await expect(wrapper).not.toBeNull();
+    await expect(wrapper.children).toHaveLength(0);
+    await expect(wrapper.textContent).toBe('');
+
+    /* And it is genuinely the loading branch, not the permitted-but-empty one or
+       the denial: both of those render inside that wrapper. */
+    await expect(canvas.queryByText('Nothing to show')).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('status')).not.toBeInTheDocument();
+    await expect(canvasElement.querySelectorAll('ol, li')).toHaveLength(0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The gap between the drawer opening and the org memberships landing. Every other panel ' +
+          'in this drawer shows the pulsing `PanelSkeleton` while its chunk loads, then its own ' +
+          'loading copy; Activity shows an empty box instead, because the gate falls back to ' +
+          '`null`. Passing a `skeleton` to the gate would be a one-line fix, and this story is ' +
+          'where the difference is visible.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/panels/DocumentsPanel.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/panels/DocumentsPanel.stories.tsx
@@ -1,0 +1,327 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import {
+  closeGlassTooltip,
+  openGlassTooltip,
+} from '@/app/ui/primitives/GlassTooltip/storyInteractions';
+import DocumentsPanel from './DocumentsPanel';
+
+const SIGN_GATE_REASON = 'Signing is available only while the appointment is In progress.';
+
+const meta = {
+  title: 'Workspace/DocumentsPanel',
+  component: DocumentsPanel,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The Documents tab of the quick-actions drawer: a Forms tab carrying the combined ' +
+          "clinical packet plus the appointment's assigned forms, and a Records tab carrying " +
+          "the companion's document library.\n\n" +
+          'The surface these stories cover is the **clinical packet card and its gate**. The ' +
+          "card is the workspace's only in-drawer route to Print All / Sign / Download Signed, " +
+          'and every one of those actions is conditional: without an org **and** an encounter ' +
+          'the card swaps its status badges for a one-line explanation and disables Print; and ' +
+          'Sign is additionally gated on the appointment being In progress, which is expressed ' +
+          'by wrapping the disabled button in a `GlassTooltip` that names the reason. That ' +
+          'wrapper appears and disappears with the status - the button looks identical either ' +
+          'way, so the only way to see which state you are in is to hover it.\n\n' +
+          "The Records tab's own empty state is here too: with no companion on the appointment " +
+          'the whole `CompanionDocumentsSection` is skipped rather than rendered empty.\n\n' +
+          '**Not covered here: the loaded `FormRow` list and its auth badges.** ' +
+          '`fetchAppointmentForms` POSTs on mount with no store in front of it, and the ' +
+          'signed/pending badge state is computed from that response - `Authorized by Client`, ' +
+          '`Authorized by Service Provider` and the red `Acknowledgement pending`, each with its ' +
+          'own icon, plus the download/print pair that disables until a submission id exists. ' +
+          "Same for the packet's Draft/Final and signing badges, which come from " +
+          '`createEncounterDocumentPacket`. All of that needs a request-mocking layer this ' +
+          'Storybook does not have, so it stays undrawn rather than being faked here.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    appointmentId: 'appt-workspace-1',
+    appointmentStatus: 'CHECKED_IN',
+  },
+  decorators: [
+    /* The drawer is 530px wide and the packet card's action row is `flex-wrap`,
+       so the width is what decides whether Print All and Sign share a line. */
+    (Story) => (
+      <div className="w-[498px] max-w-full bg-[var(--screen)] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof DocumentsPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const FormsTab: Story = {
+  name: 'Forms tab, no encounter context',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Two tabs, Forms selected, and the tab is wired to its panel.
+    const forms = canvas.getByRole('tab', { name: 'Forms' });
+    const records = canvas.getByRole('tab', { name: 'Records' });
+    await expect(forms).toHaveAttribute('aria-selected', 'true');
+    await expect(records).toHaveAttribute('aria-selected', 'false');
+    await expect(forms).toHaveAttribute('aria-controls', 'docs-panel-FORMS');
+    await expect(canvasElement.querySelector('#docs-panel-FORMS')).not.toBeNull();
+
+    /* The packet card, in its no-context form: title, subtitle, the explanation
+       that replaces the status badges, and both actions disabled. */
+    const packet = within(canvas.getByLabelText('Clinical packet'));
+    await expect(packet.getByText('Clinical packet')).toBeInTheDocument();
+    await expect(
+      packet.getByText('Combined SOAP, prescription and discharge documents.')
+    ).toBeInTheDocument();
+    await expect(
+      packet.getByText('Open this from an encounter to print or sign the combined packet.')
+    ).toBeInTheDocument();
+    await expect(packet.getByRole('button', { name: 'Print All' })).toBeDisabled();
+    await expect(packet.getByRole('button', { name: 'Sign' })).toBeDisabled();
+    // Download Signed only exists once the packet is signed, so not here.
+    await expect(packet.queryByRole('button', { name: 'Download Signed' })).not.toBeInTheDocument();
+
+    // The forms search sits under the card and is always present.
+    await expect(
+      canvas.getByRole('searchbox', { name: 'Search forms to add' })
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The tab as it renders without an encounter - which is the state the drawer opens in ' +
+          'for any appointment that has not started one. Note that the two status badges (Draft ' +
+          'or Final, plus the signing state) are absent rather than empty: the card swaps them ' +
+          'for a single explanatory line, so the card is two rows shorter here than it is with ' +
+          'a live packet.',
+      },
+    },
+  },
+};
+
+export const SignGateTooltip: Story = {
+  name: 'Sign gate reason (tooltip)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const sign = canvas.getByRole('button', { name: 'Sign' });
+
+    // The button carries no visible reason - it is disabled and unlabelled.
+    await expect(sign).toBeDisabled();
+    // Here it IS wrapped, which is the difference the "gate lifted" story below
+    // asserts the absence of.
+    await expect(sign.closest('.glass-tooltip')).not.toBeNull();
+
+    /* Opened through the shared helper rather than `userEvent.hover`: the
+       tooltip binds `mouseenter` on its wrapper inside an effect, so a single
+       dispatch sent before that effect flushes is lost for good and a
+       `findByRole('tooltip')` would retry the query without re-sending it. */
+    const bubble = await openGlassTooltip(sign);
+    /* The whole reason, exactly - not a substring match on "Signing", which the
+       button's own label would satisfy. The bubble is portalled to
+       `document.body`, so it is outside `canvasElement` and a canvas-scoped
+       query would never have found it. */
+    await expect(bubble).toHaveAttribute('role', 'tooltip');
+    await expect(bubble.textContent?.trim()).toBe(SIGN_GATE_REASON);
+    await expect(canvasElement.contains(bubble)).toBe(false);
+
+    /* Closed by identity: the helper waits for THIS bubble to leave the
+       document, and asserting the same node is what distinguishes a real close
+       from a second bubble appearing next to a stranded one. */
+    await closeGlassTooltip(sign);
+    await expect(document.contains(bubble)).toBe(false);
+    await expect(document.querySelectorAll('[role="tooltip"]')).toHaveLength(0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Why Sign is dead on a checked-in appointment. The reason exists only in a hover ' +
+          'bubble portalled to `document.body`, so on a touch device - and for anyone reading ' +
+          'the panel rather than pointing at it - the button is simply an unexplained disabled ' +
+          "control. That is the thing to look at here, more than the bubble's styling.",
+      },
+    },
+  },
+};
+
+export const SignGateLifted: Story = {
+  name: 'Sign gate lifts while In progress',
+  args: { appointmentStatus: 'IN_PROGRESS' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const sign = canvas.getByRole('button', { name: 'Sign' });
+
+    /* With the appointment in progress `signGateReason` is undefined, so the
+       GlassTooltip wrapper is not rendered at all - the button is a bare
+       Secondary. Asserting the wrapper's absence is the only observable
+       difference; the button itself still reads "Sign" and is still disabled,
+       because this story has no org or encounter either. */
+    await expect(sign.closest('.glass-tooltip')).toBeNull();
+    await expect(sign).toBeDisabled();
+    await expect(sign).toHaveTextContent('Sign');
+
+    /* The negative is only worth anything because the positive is asserted a
+       story above, where the same button DOES resolve a `.glass-tooltip`
+       ancestor - so this is a real difference in the tree, not a selector that
+       never matches anything. */
+    await expect(document.querySelectorAll('[role="tooltip"]')).toHaveLength(0);
+
+    /* The reason is gone from the whole card, not just from a wrapper: the
+       string exists nowhere in the packet section, while the card is otherwise
+       identical to the gated story - same title, same no-context explanation,
+       same disabled Print. Without these the story would pass against a card
+       that had failed to render at all. */
+    const packet = canvas.getByLabelText('Clinical packet');
+    await expect(packet).not.toHaveTextContent(SIGN_GATE_REASON);
+    await expect(within(packet).getByText('Clinical packet')).toBeInTheDocument();
+    await expect(
+      within(packet).getByText('Open this from an encounter to print or sign the combined packet.')
+    ).toBeInTheDocument();
+    await expect(within(packet).getByRole('button', { name: 'Print All' })).toBeDisabled();
+    // Two actions on the row, still: Download Signed only joins once signed.
+    await expect(within(packet).getAllByRole('button')).toHaveLength(2);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same card once the visit starts. Two different reasons can disable Sign - the ' +
+          'status gate and the missing encounter - and only the status gate is ever explained. ' +
+          'Here the explanation is gone while the button stays disabled, which is the worse of ' +
+          'the two states to land on.',
+      },
+    },
+  },
+};
+
+export const AddFormsDropdownEmpty: Story = {
+  name: 'Add-forms dropdown with nothing to add',
+  args: { organisationId: 'org-storybook' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* The dropdown opens on focus, not only on typing, so the clinician can
+       browse the org's assignable forms without a query. It needs an org id -
+       without one `dropdownOpen` is false however much you type. */
+    const search = canvas.getByRole('searchbox', { name: 'Search forms to add' });
+    await userEvent.click(search);
+
+    // It is portalled to document.body with fixed positioning, so it is outside
+    // the canvas entirely.
+    const copy = await within(document.body).findByText('No assignable forms available to add.');
+    await expect(canvasElement.contains(copy)).toBe(false);
+
+    /* The empty branch is one paragraph, not an empty list, and the panel around
+       it is the real portalled dropdown: `position: fixed` and anchored to the
+       search input's own width. Reading the width is what proves the anchoring
+       ran - a portal that never measured its anchor renders at width 0 and is
+       invisible while every text assertion above still passes. */
+    const panel = copy.parentElement as HTMLElement;
+    await expect(panel.querySelectorAll('ul')).toHaveLength(0);
+    await expect(panel.children).toHaveLength(1);
+    await expect(getComputedStyle(panel).position).toBe('fixed');
+    const anchor = search.closest('div.relative') as HTMLElement;
+    await waitFor(() => {
+      const anchorWidth = anchor.getBoundingClientRect().width;
+      expect(anchorWidth).toBeGreaterThan(0);
+      expect(Math.abs(panel.getBoundingClientRect().width - anchorWidth)).toBeLessThanOrEqual(1);
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The browse-on-focus dropdown when the org has no assignable form templates. Only ' +
+          '`FORM` and `CONSENT` templates in `PUBLISHED` status are ever offered here - SOAP, ' +
+          'vitals, prescription, discharge, tasks and inpatient-schedule templates are authored ' +
+          'elsewhere in the workspace and are filtered out - so this empty panel is what an org ' +
+          'with a full template library but no consent forms sees. The copy also changes once ' +
+          'something has been typed, to "No forms available to add for this search."',
+      },
+    },
+  },
+};
+
+export const RecordsTabEmpty: Story = {
+  name: 'Records tab with no companion',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const records = canvas.getByRole('tab', { name: 'Records' });
+
+    await userEvent.click(records);
+    await expect(records).toHaveAttribute('aria-selected', 'true');
+
+    // The Forms panel is unmounted, not hidden - the packet card goes with it.
+    await waitFor(() => {
+      expect(canvasElement.querySelector('#docs-panel-FORMS')).toBeNull();
+    });
+    await expect(canvas.queryByLabelText('Clinical packet')).not.toBeInTheDocument();
+
+    const panel = canvasElement.querySelector('#docs-panel-RECORDS') as HTMLElement;
+    await expect(panel).not.toBeNull();
+    await expect(within(panel).getByText('No companion records available.')).toBeInTheDocument();
+
+    /* The selected tab goes bold as well as blue and takes the 2px underline.
+       Polled: `TabToggle` carries `transition-colors duration-150`, so a read in
+       the same frame as the click can catch an interpolated value. */
+    await waitFor(() => {
+      expect(getComputedStyle(records).fontWeight).not.toBe(
+        getComputedStyle(canvas.getByRole('tab', { name: 'Forms' })).fontWeight
+      );
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Records without a companion id. The tab does not render an empty document library - ' +
+          "it renders a single line of copy instead, so none of the library's own filter chips " +
+          'or sort control appear. Switching tabs also unmounts the Forms panel, which means the ' +
+          'packet card re-resolves its state from the server every time the clinician comes back.',
+      },
+    },
+  },
+};
+
+export const PhoneFormsTab: Story = {
+  name: 'Phone: Forms tab',
+  // The meta decorator is `w-[498px] max-w-full`, so it collapses to the phone
+  // width here rather than forcing a horizontal scroll. No second wrapper needed.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Both tabs still share the row at 375; TabToggle gives each `flex-1`.
+    const forms = canvas.getByRole('tab', { name: 'Forms' });
+    const records = canvas.getByRole('tab', { name: 'Records' });
+    const drift = Math.abs(forms.getBoundingClientRect().top - records.getBoundingClientRect().top);
+    await expect(drift).toBeLessThan(1);
+
+    const packet = within(canvas.getByLabelText('Clinical packet'));
+    await expect(packet.getByRole('button', { name: 'Print All' })).toBeDisabled();
+    await expect(packet.getByRole('button', { name: 'Sign' })).toBeDisabled();
+    await expect(
+      packet.getByText('Open this from an encounter to print or sign the combined packet.')
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'At 375 the drawer is full-screen, so the packet card runs the full phone width. Its ' +
+          'action row is `flex-wrap justify-end`, which is the detail to check here: Print All ' +
+          'and Sign are the only two actions until a packet is signed, and a third button ' +
+          '(Download Signed) joins them at that point - the width at which the row breaks onto ' +
+          'two lines is not reachable in Storybook without the packet state.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/records/ObservationToolForm.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/records/ObservationToolForm.stories.tsx
@@ -1,0 +1,369 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import type { ObservationRecord } from '@/app/features/appointments/types/workspace';
+import ObservationToolForm from './ObservationToolForm';
+
+/**
+ * A scored Feline Grimace Scale submission. `scores` is an open
+ * `Record<string, number | string>` written by the backend from the tool
+ * definition, so the breakdown renders whatever keys arrive - there is no fixed
+ * field list the way `VitalRow` has one.
+ */
+const FGS_RECORD: ObservationRecord = {
+  id: 'ot-2',
+  code: 'OT-002',
+  toolKey: 'FGS',
+  toolName: 'Feline grimace scale',
+  scores: {
+    'Ear position': 1,
+    'Orbital tightening': 2,
+    'Muzzle tension': 1,
+    'Whiskers change': 0,
+    'Head position': 1,
+  },
+  total: 5,
+  recordedByName: 'Dr. Amara Weber',
+  recordedAt: '2026-03-12T12:00:00.000Z',
+};
+
+/** No `total`, and one categorical value - both legal, both change the breakdown. */
+const CSU_RECORD: ObservationRecord = {
+  id: 'ot-1',
+  code: 'OT-001',
+  toolKey: 'CSU_CAP',
+  toolName: 'Canine acute pain scale',
+  scores: {
+    'Psychological and behavioral': 2,
+    'Response to palpation': 1,
+    'Body tension': 'Mild',
+  },
+  recordedByName: 'Jonah Pike',
+  recordedAt: '2026-03-05T12:00:00.000Z',
+};
+
+const OBSERVATIONS: ObservationRecord[] = [FGS_RECORD, CSU_RECORD];
+
+/** Opens one recorded observation's breakdown and returns the breakdown block. */
+const expandRow = async (canvasElement: HTMLElement, code: string) => {
+  const canvas = within(canvasElement);
+  await userEvent.click(canvas.getByRole('button', { name: `View ${code}` }));
+  expect(await canvas.findByRole('button', { name: `Hide ${code}` })).toBeInTheDocument();
+  const row = canvas.getByText(code).closest('li') as HTMLElement;
+  const panel = row.querySelector('.rounded-2xl.border') as HTMLElement | null;
+  await expect(panel).toBeInTheDocument();
+  return panel as HTMLElement;
+};
+
+/** The value cell sitting opposite a score label inside a breakdown. */
+const valueFor = (panel: HTMLElement, label: string): string =>
+  within(panel).getByText(label).nextElementSibling?.textContent ?? '';
+
+const meta = {
+  title: 'Workspace/ObservationToolForm',
+  component: ObservationToolForm,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The Observation Tool tab of the quick-actions Record panel: pick a scoring tool, read ' +
+          'its licence-bearing intro, press Start, and review what has already been scored.\n\n' +
+          'The surface that had never been drawn is the **expanded `ObservationRow`**. It is ' +
+          'module-private, holds its own `useState`, and unlike the vitals breakdown next to it ' +
+          'the block is not a fixed grid - it walks `Object.entries(entry.scores)` and emits one ' +
+          '`flex justify-between` line per key. The keys come from the backend tool definition, ' +
+          'so the number of lines, their labels and whether a value is a number or a word are ' +
+          'all data, not layout. The `Total score` line above them is conditional on `total` ' +
+          'being present, and the Colorado scale submissions in this story arrive without one.\n\n' +
+          'The tool picker is also worth seeing move: `activeTool` drives both the heading and a ' +
+          'long licence paragraph, so switching tools replaces most of the panel and shifts the ' +
+          'Start button by a couple of lines.\n\n' +
+          'Start is disabled unless the org, companion and clinician are all resolved, with the ' +
+          'reason spelled out underneath - the component refuses to write a fabricated local row ' +
+          'when it cannot reach the scoring endpoint. These stories never press it, because the ' +
+          'submission itself is a real backend call.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    appointmentId: 'appt-workspace-1',
+    organisationId: 'org-storybook',
+    encounterId: 'enc-1',
+    companionId: 'companion-1',
+    filledBy: 'prac-amara',
+    filledByName: 'Dr. Amara Weber',
+    observations: OBSERVATIONS,
+  },
+  decorators: [
+    /* The quick-actions drawer is 530px wide; the intro paragraph is the longest
+       run of text in the panel and its line count is what pushes Start down. */
+    (Story) => (
+      <div className="w-[498px] max-w-full bg-[var(--screen)] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ObservationToolForm>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ToolPicker: Story = {
+  name: 'Tool picker and recorded list',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Two chips, the first one pressed, and the heading follows the pressed chip.
+    const fgs = canvas.getByRole('button', { name: 'Feline grimace scale' });
+    const csu = canvas.getByRole('button', { name: 'Canine acute pain scale' });
+    await expect(fgs).toHaveAttribute('aria-pressed', 'true');
+    await expect(csu).toHaveAttribute('aria-pressed', 'false');
+    await expect(canvas.getByRole('heading', { name: 'Feline grimace scale' })).toBeInTheDocument();
+    await expect(canvas.getByText(/^The Feline Grimace Scale \(FGS\)/)).toBeInTheDocument();
+
+    // Both recorded rows, closed.
+    await expect(canvasElement.querySelectorAll('li')).toHaveLength(2);
+    await expect(canvas.getByText('OT-002')).toBeInTheDocument();
+    await expect(canvas.getByText('OT-001')).toBeInTheDocument();
+    await expect(canvas.getByText('Jonah Pike')).toBeInTheDocument();
+    await expect(canvas.queryByText(/^Total score: /)).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The panel at rest. Each recorded row stacks stamp, tool name and code on the left - ' +
+          'three lines at `leading-[120%]`, which is why the row is taller than the vitals row ' +
+          'next to it despite carrying the same controls.',
+      },
+    },
+  },
+};
+
+export const ToolSwitch: Story = {
+  name: 'Switching tool rewrites the panel',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const csu = canvas.getByRole('button', { name: 'Canine acute pain scale' });
+
+    await userEvent.click(csu);
+    await expect(csu).toHaveAttribute('aria-pressed', 'true');
+    await expect(canvas.getByRole('button', { name: 'Feline grimace scale' })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+
+    /* The heading and the whole licence paragraph are replaced, not just the
+       chip tint. Asserting the new intro's opening words, and that the previous
+       one is gone, so a picker that flipped its pressed state without swapping
+       content would fail here. */
+    expect(
+      await canvas.findByRole('heading', { name: 'Canine acute pain scale' })
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByText(/^The Colorado State University Canine Acute Pain Scale/)
+    ).toBeInTheDocument();
+    await expect(canvas.queryByText(/^The Feline Grimace Scale \(FGS\)/)).not.toBeInTheDocument();
+
+    // The pressed chip inverts to the brand skin; polled, because the chip
+    // carries `transition-colors` and a single read can catch it mid-swap.
+    await waitFor(() => {
+      const pressed = getComputedStyle(csu);
+      const idle = getComputedStyle(canvas.getByRole('button', { name: 'Feline grimace scale' }));
+      expect(pressed.backgroundColor).not.toBe(idle.backgroundColor);
+    });
+
+    // The recorded list is not filtered by the selected tool.
+    await expect(canvasElement.querySelectorAll('li')).toHaveLength(2);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Selecting a tool swaps the heading and the intro. The two intros differ by several ' +
+          'lines, so the Start button and the recorded list move vertically when the tool ' +
+          'changes - the panel does not reserve a fixed block for the copy.',
+      },
+    },
+  },
+};
+
+export const RowExpandedWithTotal: Story = {
+  name: 'Row breakdown with a total',
+  play: async ({ canvasElement }) => {
+    const panel = await expandRow(canvasElement, 'OT-002');
+
+    // One total line plus one line per score key - six paragraphs, built from data.
+    await expect(panel.querySelectorAll('p')).toHaveLength(6);
+    await expect(within(panel).getByText('Total score: 5')).toBeInTheDocument();
+
+    await expect(valueFor(panel, 'Ear position')).toBe('1');
+    await expect(valueFor(panel, 'Orbital tightening')).toBe('2');
+    await expect(valueFor(panel, 'Muzzle tension')).toBe('1');
+    await expect(valueFor(panel, 'Whiskers change')).toBe('0');
+    await expect(valueFor(panel, 'Head position')).toBe('1');
+
+    // Each line is a label/value pair pushed to opposite edges.
+    const line = within(panel).getByText('Ear position').parentElement as HTMLElement;
+    await expect(getComputedStyle(line).display).toBe('flex');
+    await expect(getComputedStyle(line).justifyContent).toBe('space-between');
+
+    // The second row stays closed - each ObservationRow owns its own flag.
+    await expect(within(canvasElement).getByRole('button', { name: 'View OT-001' })).toBeVisible();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A Feline Grimace Scale submission: five action units, each 0-2, and the total the ' +
+          'backend computed. Note the zero - `Whiskers change: 0` is a real score, not a missing ' +
+          'value, and the breakdown gives it no different treatment from a 2.',
+      },
+    },
+  },
+};
+
+export const RowExpandedWithoutTotal: Story = {
+  name: 'Row breakdown with no total',
+  play: async ({ canvasElement }) => {
+    const panel = await expandRow(canvasElement, 'OT-001');
+
+    // Three lines and no total: `total` is optional and this record has none.
+    await expect(panel.querySelectorAll('p')).toHaveLength(3);
+    await expect(within(panel).queryByText(/^Total score: /)).not.toBeInTheDocument();
+
+    await expect(valueFor(panel, 'Psychological and behavioral')).toBe('2');
+    await expect(valueFor(panel, 'Response to palpation')).toBe('1');
+    // `scores` values are `number | string`, so a categorical grade renders as-is.
+    await expect(valueFor(panel, 'Body tension')).toBe('Mild');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Without a total the breakdown opens straight onto the first score line, so the block ' +
+          'loses the one bold row that anchored it. "Psychological and behavioral" is also the ' +
+          'longest label either tool produces - it is the line that shows how a long label and ' +
+          'its value share the width.',
+      },
+    },
+  },
+};
+
+export const RecordingBlocked: Story = {
+  name: 'Start disabled without encounter context',
+  args: { filledBy: undefined, filledByName: undefined },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const start = canvas.getByRole('button', { name: 'Start' });
+    await expect(start).toBeDisabled();
+    await expect(
+      canvas.getByText('Recording is available once the encounter and clinician are loaded.')
+    ).toBeInTheDocument();
+    // Blocking the write does not hide what is already recorded.
+    await expect(canvasElement.querySelectorAll('li')).toHaveLength(2);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Opened before the encounter and clinician resolve. The panel disables Start and names ' +
+          'the reason underneath rather than letting the click write a locally-scored row the ' +
+          'backend never saw. The reason line is centred under the button and adds a second row ' +
+          'to the action block, which is why the list below it shifts down.',
+      },
+    },
+  },
+};
+
+export const RecordingAvailable: Story = {
+  name: 'Start enabled',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const start = canvas.getByRole('button', { name: 'Start' });
+    await expect(start).toBeEnabled();
+    // The label is the resting one, not the in-flight 'Recording…'.
+    await expect(start).toHaveTextContent('Start');
+
+    /* The action block is the enabled pill and nothing else: the reason line and
+       the error line are both siblings inside it, so counting the block's
+       paragraphs is what proves it collapsed rather than merely that one
+       specific string went missing. */
+    const actionBlock = start.parentElement as HTMLElement;
+    await expect(actionBlock.querySelectorAll('p')).toHaveLength(0);
+    await expect(
+      canvas.queryByText('Recording is available once the encounter and clinician are loaded.')
+    ).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('alert')).not.toBeInTheDocument();
+
+    // The panel around it is unchanged - same tool, same intro, same two rows.
+    await expect(canvas.getByRole('heading', { name: 'Feline grimace scale' })).toBeInTheDocument();
+    await expect(canvasElement.querySelectorAll('li')).toHaveLength(2);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'With org, companion and clinician all present the reason line disappears and the ' +
+          'action block collapses to the single pill. Pressing Start posts a real scoring ' +
+          'submission, so no story here clicks it.',
+      },
+    },
+  },
+};
+
+export const NoObservations: Story = {
+  name: 'Nothing scored yet',
+  args: { observations: [] },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The list is not an empty list - the whole <ul> is conditional.
+    await expect(canvasElement.querySelectorAll('ul')).toHaveLength(0);
+    await expect(canvasElement.querySelectorAll('li')).toHaveLength(0);
+    await expect(canvas.getByRole('heading', { name: 'Feline grimace scale' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Start' })).toBeEnabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'First visit. Unlike the Vitals tab, which prints "No vitals recorded yet.", this tab ' +
+          'renders no empty-state copy at all - the recorded list simply does not exist, and the ' +
+          'panel ends at the Start button. Worth deciding whether that silence is intended.',
+      },
+    },
+  },
+};
+
+export const PhoneRowExpanded: Story = {
+  name: 'Phone: row breakdown',
+  // The meta decorator is `w-[498px] max-w-full`, so it collapses to the phone
+  // width here rather than forcing a horizontal scroll. No second wrapper needed.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const panel = await expandRow(canvasElement, 'OT-002');
+    await expect(panel.querySelectorAll('p')).toHaveLength(6);
+
+    /* Each line is `flex justify-between gap-3` with no wrap, so at 375 a long
+       label and its value stay on one row and the label truncates against the
+       gap rather than pushing the value off. Read here because this is the width
+       where it first matters. */
+    const line = within(panel).getByText('Orbital tightening').parentElement as HTMLElement;
+    await expect(getComputedStyle(line).display).toBe('flex');
+    await expect(getComputedStyle(line).justifyContent).toBe('space-between');
+    await expect(valueFor(panel, 'Orbital tightening')).toBe('2');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'At 375 the quick-actions drawer is full-screen, so this is the phone form of the ' +
+          'breakdown. The collapsed row above it is the tighter case: stamp, tool name and code ' +
+          'on the left against a recorder chip and a 38px button on the right, all in one ' +
+          '`justify-between` row with no wrapping.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/records/VitalsForm.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/records/VitalsForm.stories.tsx
@@ -1,0 +1,639 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import type { Vitals } from '@/app/features/appointments/types/workspace';
+import type { Team } from '@/app/features/organization/types/team';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useTeamStore } from '@/app/stores/teamStore';
+import VitalsForm from './VitalsForm';
+
+const ORG_ID = 'org-storybook';
+
+/**
+ * Newest first, which is the order the store keeps them in and the order the
+ * weight trend depends on.
+ *
+ * `VT-001` deliberately carries nothing but a weight: the breakdown grid always
+ * renders all eight cells, so a sparse record is the only way to see the seven
+ * `-` placeholders. `VT-002` carries `recordedById` and the placeholder name
+ * `Clinician`, which is the shape a hydrated (server-loaded) vital arrives in.
+ */
+const VITALS: Vitals[] = [
+  {
+    id: 'vt-3',
+    code: 'VT-003',
+    weightLbs: 62.4,
+    tempF: 101.6,
+    heartRateBpm: 96,
+    respRateBpm: 24,
+    crtSec: '<2',
+    mucousMembrane: 'Pink',
+    painScore: 2,
+    bcs: 5,
+    notes: 'Settled once the second exam finished.',
+    recordedByName: 'Dr. Amara Weber',
+    recordedAt: '2026-03-12T12:00:00.000Z',
+  },
+  {
+    id: 'vt-2',
+    code: 'VT-002',
+    weightLbs: 60,
+    tempF: 102.1,
+    heartRateBpm: 104,
+    respRateBpm: 28,
+    crtSec: '2',
+    mucousMembrane: 'Pale',
+    painScore: 4,
+    bcs: 5,
+    recordedByName: 'Clinician',
+    recordedById: 'prac-jonah',
+    recordedAt: '2026-03-05T12:00:00.000Z',
+  },
+  {
+    id: 'vt-1',
+    code: 'VT-001',
+    weightLbs: 58.2,
+    recordedByName: 'Clinician',
+    recordedAt: '2026-02-19T12:00:00.000Z',
+  },
+];
+
+/** Same three records, but the newest weight is below the previous one. */
+const LOSING_WEIGHT: Vitals[] = [{ ...VITALS[0], weightLbs: 58.2 }, VITALS[1], VITALS[2]];
+
+const JONAH: Team = {
+  _id: 'team-jonah',
+  practionerId: 'prac-jonah',
+  organisationId: ORG_ID,
+  name: 'Jonah Pike',
+  role: 'TECHNICIAN',
+  speciality: [],
+  status: 'Available',
+  revokedPermissions: [],
+  effectivePermissions: [],
+  extraPerissions: [],
+};
+
+/**
+ * Seeds the roster the real way and restores it afterwards.
+ *
+ * `useTeamForPrimaryOrg` is a pure store read - the fetch lives in the separate
+ * `useLoadTeam`, which this form never calls - so seeding `teamStore` plus the
+ * primary org id is enough to exercise the id-to-name resolution with no network
+ * and no service stub.
+ */
+const seedRoster = (members: Team[]) => () => {
+  const orgSnapshot = useOrgStore.getState();
+  const teamSnapshot = useTeamStore.getState();
+  useOrgStore.setState({ primaryOrgId: ORG_ID, status: 'loaded' });
+  useTeamStore.setState({
+    teamsById: Object.fromEntries(members.map((member) => [member._id, member])),
+    teamIdsByOrgId: { [ORG_ID]: members.map((member) => member._id) },
+    status: 'loaded',
+  });
+  return () => {
+    useOrgStore.setState(orgSnapshot);
+    useTeamStore.setState(teamSnapshot);
+  };
+};
+
+/** Opens one recorded vital's breakdown and returns its grid. */
+const expandRow = async (canvasElement: HTMLElement, code: string) => {
+  const canvas = within(canvasElement);
+  await userEvent.click(canvas.getByRole('button', { name: `View ${code}` }));
+  // The toggle relabels, which is the only announced signal that the row opened.
+  expect(await canvas.findByRole('button', { name: `Hide ${code}` })).toBeInTheDocument();
+  const grid = canvasElement.querySelector('.grid.grid-cols-2') as HTMLElement | null;
+  await expect(grid).toBeInTheDocument();
+  return grid as HTMLElement;
+};
+
+/** Switches the form from the recorded list into the "New vitals" editor. */
+const openEditor = async (canvasElement: HTMLElement) => {
+  const canvas = within(canvasElement);
+  await userEvent.click(canvas.getByRole('button', { name: 'New Vital' }));
+  expect(await canvas.findByText('New vitals')).toBeInTheDocument();
+  return canvas;
+};
+
+const meta = {
+  title: 'Workspace/VitalsForm',
+  component: VitalsForm,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The Vitals tab of the quick-actions Record panel. Two surfaces inside it had never ' +
+          'been drawn, and both are behind a click.\n\n' +
+          'The first is the **expanded `VitalRow` breakdown**. `VitalRow` holds its own ' +
+          '`useState`, is module-private, and renders a `grid-cols-2` block of eight fixed ' +
+          'cells - weight, temp, heart rate, resp. rate, CRT, MM, pain and BCS - each with its ' +
+          'unit baked into the string. It always renders all eight whatever the record holds, so ' +
+          'a vital saved with only a weight draws seven `-` placeholders. Nothing about that is ' +
+          'visible from the collapsed row, which shows only the stamp, the code and the recorder.\n\n' +
+          'The second is the **"New vitals" editor**, which replaces the list entirely rather ' +
+          'than appearing under it (`if (!creating) return` early). Its numeric grid renders five ' +
+          'inputs, not eight: BCS, pain score and mucous membrane are pulled out of the grid by ' +
+          "`OBSERVATION_GRID_KEYS` and re-rendered below as segmented pickers on the app's real " +
+          'ranges (1..9, 0..10, three membrane colours) rather than the narrower windows the ' +
+          'design shows. They are still validated as required fields, which is only observable ' +
+          'by pressing Save on an empty draft.\n\n' +
+          'The weight trend chip lives in the editor too, not in the list, and needs **two** ' +
+          'records carrying a weight before it renders at all.\n\n' +
+          'Nothing here needs the network: the vitals arrive as a prop, the recorder roster is a ' +
+          'plain store read, and `listVitalsTemplates` funnels three requests through ' +
+          '`Promise.allSettled`, so offline it resolves to an empty template list instead of ' +
+          'rejecting. The template search therefore reaches its own no-match state here.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    appointmentId: 'appt-workspace-1',
+    organisationId: ORG_ID,
+    encounterId: 'enc-1',
+    authorId: 'prac-amara',
+    authorName: 'Dr. Amara Weber',
+    vitals: VITALS,
+  },
+  decorators: [
+    /* The drawer this lives in is 530px wide, and `VitalsField`'s floating label
+       paints its own notch with `background: var(--screen)`. On any other ground
+       the notch reads as a stripe through the border, so the wrapper sets both
+       the drawer width and the drawer's surface colour. */
+    (Story) => (
+      <div className="w-[498px] max-w-full bg-[var(--screen)] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof VitalsForm>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const RecordedList: Story = {
+  name: 'Recorded vitals (collapsed)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const rows = canvasElement.querySelectorAll('li');
+    await expect(rows).toHaveLength(3);
+    await expect(canvas.getByText('VT-003')).toBeInTheDocument();
+    await expect(canvas.getByText('VT-002')).toBeInTheDocument();
+    await expect(canvas.getByText('VT-001')).toBeInTheDocument();
+    await expect(canvas.getByText('Dr. Amara Weber')).toBeInTheDocument();
+
+    /* The stamp is `formatStampDate`, which prints "Today" for today and a
+       "Mon D" short date otherwise. Asserting the shape rather than a literal,
+       because the formatter renders in the preferred time zone and a literal
+       would flip a day either side of UTC. */
+    await expect(canvas.getAllByText(/^[A-Z][a-z]{2} \d{1,2}$/)).toHaveLength(3);
+
+    // No breakdown until a row is opened - all three start closed independently.
+    await expect(canvas.queryByText(/^Weight: /)).not.toBeInTheDocument();
+    await expect(canvasElement.querySelectorAll('.grid.grid-cols-2')).toHaveLength(0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting list. Each row is stamp / code on the left, recorder chip and the round ' +
+          'dark eye toggle on the right. The stamp is tinted `--pill-success-text`, which is the ' +
+          'only colour in the row and is doing the work of a "recent" cue.',
+      },
+    },
+  },
+};
+
+export const RowExpanded: Story = {
+  name: 'Row breakdown (expanded)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const grid = await expandRow(canvasElement, 'VT-003');
+
+    /* Eight cells against a two-track template. Neither side is enforced: the
+       cells are eight loose spans and the template is a utility class, so a
+       template that ever collapses to one track silently stacks them into a
+       column and nothing fails. Read both. */
+    await expect(getComputedStyle(grid).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(2);
+    await expect(grid.children).toHaveLength(8);
+
+    await expect(canvas.getByText('Weight: 62.4 lbs')).toBeInTheDocument();
+    await expect(canvas.getByText('Temp: 101.6 °F')).toBeInTheDocument();
+    await expect(canvas.getByText('Heart rate: 96 bpm')).toBeInTheDocument();
+    await expect(canvas.getByText('Resp. rate: 24 bpm')).toBeInTheDocument();
+    await expect(canvas.getByText('CRT: <2')).toBeInTheDocument();
+    await expect(canvas.getByText('MM: Pink')).toBeInTheDocument();
+    await expect(canvas.getByText('Pain: 2 / 10')).toBeInTheDocument();
+    await expect(canvas.getByText('BCS: 5 / 9')).toBeInTheDocument();
+
+    // The other two rows stay shut: each VitalRow owns its own open flag.
+    await expect(canvasElement.querySelectorAll('.grid.grid-cols-2')).toHaveLength(1);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The full breakdown for a complete record. The units are part of the cell text rather ' +
+          'than separate nodes, so "Pain: 2 / 10" and "BCS: 5 / 9" carry their scale inline - ' +
+          "the same denominators the editor's segmented pickers offer.",
+      },
+    },
+  },
+};
+
+export const RowExpandedSparse: Story = {
+  name: 'Row breakdown with missing values',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const grid = await expandRow(canvasElement, 'VT-001');
+
+    // Still eight cells and two tracks - the grid is not built from the record.
+    await expect(getComputedStyle(grid).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(2);
+    await expect(grid.children).toHaveLength(8);
+
+    await expect(canvas.getByText('Weight: 58.2 lbs')).toBeInTheDocument();
+    await expect(canvas.getByText('Temp: - °F')).toBeInTheDocument();
+    await expect(canvas.getByText('Heart rate: - bpm')).toBeInTheDocument();
+    await expect(canvas.getByText('Resp. rate: - bpm')).toBeInTheDocument();
+    await expect(canvas.getByText('CRT: -')).toBeInTheDocument();
+    await expect(canvas.getByText('MM: -')).toBeInTheDocument();
+    await expect(canvas.getByText('Pain: - / 10')).toBeInTheDocument();
+    await expect(canvas.getByText('BCS: - / 9')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A weight-only record, which is what a quick weigh-in leaves behind. Seven of the eight ' +
+          'cells fall back to `-` and the unit stays, so the row reads "Pain: - / 10". Worth ' +
+          'reviewing: at a glance a `-` with a unit is easy to misread as a zero reading rather ' +
+          'than an unrecorded one.',
+      },
+    },
+  },
+};
+
+export const RowsExpandIndependently: Story = {
+  name: 'Two rows open at once',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expandRow(canvasElement, 'VT-003');
+    await expandRow(canvasElement, 'VT-002');
+
+    await expect(canvasElement.querySelectorAll('.grid.grid-cols-2')).toHaveLength(2);
+    // Both breakdowns are real, not one node reused: their values differ.
+    await expect(canvas.getByText('Heart rate: 96 bpm')).toBeInTheDocument();
+    await expect(canvas.getByText('Heart rate: 104 bpm')).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Hide VT-003' }));
+    await waitFor(() => {
+      expect(canvasElement.querySelectorAll('.grid.grid-cols-2')).toHaveLength(1);
+    });
+    await expect(canvas.getByText('Heart rate: 104 bpm')).toBeInTheDocument();
+    await expect(canvas.queryByText('Heart rate: 96 bpm')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The list is not an accordion. Each row holds its own `open` state, so opening a second ' +
+          'row leaves the first one open and closing it leaves the second alone. That is a real ' +
+          'layout case - two eight-cell blocks stacked inside a 530px drawer - and it is the ' +
+          'state a clinician comparing two readings actually ends up in.',
+      },
+    },
+  },
+};
+
+export const RecorderResolvedFromRoster: Story = {
+  name: 'Recorder resolved from the team roster',
+  beforeEach: seedRoster([JONAH]),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* VT-002 stores the placeholder name "Clinician" plus a practitioner id.
+       `resolveRecorderName` treats "Clinician" as "no real name" and looks the id
+       up in the roster, so the chip must read the person, not the placeholder. */
+    expect(await canvas.findByText('Jonah Pike')).toBeInTheDocument();
+
+    // VT-001 has no recorder id at all, so it keeps the placeholder.
+    await expect(canvas.getByText('Clinician')).toBeInTheDocument();
+    // VT-003 stored a real name and never consults the roster.
+    await expect(canvas.getByText('Dr. Amara Weber')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "A vital loaded from the server often carries only the recorder's practitioner id and " +
+          'the literal string "Clinician". The form maps every roster member by both ' +
+          '`practionerId` and `_id` and swaps the placeholder for the real name. With an empty ' +
+          'roster the same three rows read "Clinician" twice, which is what the other stories ' +
+          'here show - so this is the difference the roster makes, not a different component.',
+      },
+    },
+  },
+};
+
+export const Empty: Story = {
+  name: 'No vitals recorded',
+  args: { vitals: [] },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('No vitals recorded yet.')).toBeInTheDocument();
+    // The empty copy replaces the list, but the entry point stays.
+    await expect(canvas.getByRole('button', { name: 'New Vital' })).toBeInTheDocument();
+    // The whole <ul> is conditional, so there is no empty list wrapper either.
+    await expect(canvasElement.querySelectorAll('ul')).toHaveLength(0);
+    await expect(canvasElement.querySelectorAll('li')).toHaveLength(0);
+    // And it is the list branch, not the editor: `creating` is still false.
+    await expect(canvas.queryByText('New vitals')).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByRole('searchbox', { name: 'Search vitals templates' })
+    ).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A first visit, before anything has been weighed. The copy is one centred ' +
+          '`text-body-4` line where the bordered list would be, so the panel loses its card edge ' +
+          'entirely and the New Vital pill sits directly under a line of text. Worth comparing ' +
+          'against the Observation Tool tab, which renders no empty-state copy at all.',
+      },
+    },
+  },
+};
+
+export const NewVitalsEditor: Story = {
+  name: 'New vitals editor',
+  play: async ({ canvasElement }) => {
+    const canvas = await openEditor(canvasElement);
+
+    // The list is gone, not pushed down: `creating` swaps the whole return.
+    await expect(canvas.queryByText('VT-003')).not.toBeInTheDocument();
+
+    /* Five inputs across two tracks, not eight. The schema resolves eight vital
+       fields and `OBSERVATION_GRID_KEYS` removes three of them from the grid, so
+       a change to either side silently re-flows this block. */
+    const grid = canvasElement.querySelector('.grid.grid-cols-2') as HTMLElement;
+    await expect(getComputedStyle(grid).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(2);
+    await expect(grid.children).toHaveLength(5);
+    for (const label of ['Weight', 'Temperature', 'Heart rate', 'Respiratory rate', 'CRT']) {
+      await expect(canvas.getByRole('textbox', { name: label })).toBeInTheDocument();
+    }
+    // The three pulled out of the grid must not also exist as text fields.
+    await expect(canvas.queryByRole('textbox', { name: 'BCS' })).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('textbox', { name: 'Pain score' })).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByRole('textbox', { name: 'Mucous membrane' })
+    ).not.toBeInTheDocument();
+
+    // They are segmented pickers instead, on the app's full ranges.
+    await expect(canvas.getByText('Observation tools')).toBeInTheDocument();
+    const bcs = canvas.getByRole('group', { name: 'Body condition score' });
+    await expect(within(bcs).getAllByRole('button')).toHaveLength(9);
+    await expect(within(bcs).getByRole('button', { name: 'Body condition score 9' })).toBeEnabled();
+    const pain = canvas.getByRole('group', { name: 'Pain score' });
+    await expect(within(pain).getAllByRole('button')).toHaveLength(11);
+    await expect(within(pain).getByRole('button', { name: 'Pain score 0' })).toBeInTheDocument();
+    const mucous = canvas.getByRole('group', { name: 'Mucous membranes' });
+    await expect(within(mucous).getAllByRole('button')).toHaveLength(3);
+    await expect(within(mucous).getByText('Cyanotic')).toBeInTheDocument();
+
+    await expect(canvas.getByRole('textbox', { name: 'Vitals notes' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Save vitals' })).toBeEnabled();
+    await expect(canvas.getByRole('button', { name: 'Discard' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The editor at rest. The two square tracks are 26px cells and the membrane track is ' +
+          'pills, all right-aligned against their labels and free to wrap - a 9-cell BCS row and ' +
+          'an 11-cell pain row inside a 530px drawer is the tightest thing on this surface.',
+      },
+    },
+  },
+};
+
+export const SelectedObservationScores: Story = {
+  name: 'Segmented pickers, selected',
+  play: async ({ canvasElement }) => {
+    const canvas = await openEditor(canvasElement);
+    const bcs = within(canvas.getByRole('group', { name: 'Body condition score' }));
+    const chosen = bcs.getByRole('button', { name: 'Body condition score 7' });
+    const other = bcs.getByRole('button', { name: 'Body condition score 3' });
+
+    await expect(chosen).toHaveAttribute('aria-pressed', 'false');
+    await userEvent.click(chosen);
+    await expect(chosen).toHaveAttribute('aria-pressed', 'true');
+
+    /* The selected cell inverts to the filled dark skin. Polled rather than read
+       once: `segmentClass` carries `transition-colors`, so a single synchronous
+       read can land on an interpolated colour part-way through the swap. */
+    await waitFor(() => {
+      const selected = getComputedStyle(chosen);
+      const unselected = getComputedStyle(other);
+      expect(selected.backgroundColor).not.toBe(unselected.backgroundColor);
+      expect(selected.color).not.toBe(unselected.color);
+    });
+
+    // Selection is single-value, so picking another one releases the first.
+    await userEvent.click(other);
+    await expect(chosen).toHaveAttribute('aria-pressed', 'false');
+    await expect(other).toHaveAttribute('aria-pressed', 'true');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Selection is announced through `aria-pressed` on plain buttons inside a bare ' +
+          '`fieldset`, not through radio semantics, so the pressed state is the only signal a ' +
+          'screen reader gets. The visual difference is a full inversion to `bg-neutral-900`, ' +
+          'which is why the contrast pair is worth reading here rather than assumed.',
+      },
+    },
+  },
+};
+
+export const ValidationErrors: Story = {
+  name: 'Save with an empty draft',
+  play: async ({ canvasElement }) => {
+    const canvas = await openEditor(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Save vitals' }));
+
+    expect(
+      await canvas.findByText('Please fix the highlighted vitals fields.')
+    ).toBeInTheDocument();
+
+    // Four in the grid ...
+    await expect(canvas.getByText('Weight is required.')).toBeInTheDocument();
+    await expect(canvas.getByText('Temperature is required.')).toBeInTheDocument();
+    await expect(canvas.getByText('Heart rate is required.')).toBeInTheDocument();
+    await expect(canvas.getByText('Respiratory rate is required.')).toBeInTheDocument();
+    // ... and two under the segmented pickers, which is the surprise.
+    await expect(canvas.getByText('Pain score is required.')).toBeInTheDocument();
+    await expect(canvas.getByText('BCS is required.')).toBeInTheDocument();
+
+    // CRT has no bounds entry, so it is the one rendered field that is optional.
+    await expect(canvas.queryByText('CRT is required.')).not.toBeInTheDocument();
+
+    // Typing clears that field's error without touching the others.
+    await userEvent.type(canvas.getByRole('textbox', { name: 'Weight' }), '62.4');
+    await waitFor(() => {
+      expect(canvas.queryByText('Weight is required.')).not.toBeInTheDocument();
+    });
+    await expect(canvas.getByText('Temperature is required.')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Validation runs over the fields the active template renders, which includes the three ' +
+          'that were moved out of the grid - so pain score and BCS block the save even though ' +
+          'they look like optional pickers. Their messages appear under the picker row rather ' +
+          'than under an input, which is the layout worth checking: six error lines appear at ' +
+          'once and push the notes field and the footer down.',
+      },
+    },
+  },
+};
+
+export const WeightGain: Story = {
+  name: 'Weight trend (gain)',
+  play: async ({ canvasElement }) => {
+    const canvas = await openEditor(canvasElement);
+    // Trend compares the two most recent records carrying a weight: 62.4 vs 60.
+    /* The whole string, not a prefix: `formatStampDate` renders the "since" date
+       in the preferred time zone, so the day is matched by shape rather than
+       pinned to a literal that would flip either side of UTC. */
+    const label = canvas.getByText(/^\+2\.4 lbs since [A-Z][a-z]{2} \d{1,2}$/);
+
+    /* The chip is a tinted arrow plus that one line, and the arrow carries its
+       own `--success` colour rather than inheriting the chip's `--ink-muted`.
+       Comparing the two computed colours is what shows the tint is really being
+       applied; polled, because the chip mounts with the editor. */
+    const chip = label.parentElement as HTMLElement;
+    const icon = chip.querySelector('span') as HTMLElement;
+    await expect(icon.querySelectorAll('svg')).toHaveLength(1);
+    await waitFor(() => {
+      expect(getComputedStyle(icon).color).not.toBe(getComputedStyle(label).color);
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The trend chip only exists inside the editor, and only once two records carry a ' +
+          'weight - so it is invisible on a first visit and appears on the second. The delta is ' +
+          'rounded to one decimal and always signed on a gain.',
+      },
+    },
+  },
+};
+
+export const WeightLoss: Story = {
+  name: 'Weight trend (loss)',
+  args: { vitals: LOSING_WEIGHT },
+  play: async ({ canvasElement }) => {
+    const canvas = await openEditor(canvasElement);
+    // No `+` on a loss, and the same "since <short date>" tail as the gain.
+    const label = canvas.getByText(/^-1\.8 lbs since [A-Z][a-z]{2} \d{1,2}$/);
+
+    /* The identical tint check the gain story runs, which is the point of the
+       pair: the arrow flips but nothing about the colour does, so a loss reads
+       as reassuringly green as a gain. */
+    const chip = label.parentElement as HTMLElement;
+    const icon = chip.querySelector('span') as HTMLElement;
+    await expect(icon.querySelectorAll('svg')).toHaveLength(1);
+    await waitFor(() => {
+      expect(getComputedStyle(icon).color).not.toBe(getComputedStyle(label).color);
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A loss swaps the glyph to `IoTrendingDownOutline` and drops the `+`, but the chip ' +
+          'keeps the same `--success` tint on the icon in both directions. Weight loss between ' +
+          'visits is not good news, so the two directions reading identically apart from the ' +
+          'arrow is the thing to look at here.',
+      },
+    },
+  },
+};
+
+export const TemplateSearchNoMatches: Story = {
+  name: 'Template search with no matches',
+  play: async ({ canvasElement }) => {
+    const canvas = await openEditor(canvasElement);
+    await userEvent.type(
+      canvas.getByRole('searchbox', { name: 'Search vitals templates' }),
+      'oncology'
+    );
+    const notice = await canvas.findByText('No vitals templates match this search.');
+
+    /* The claim in the prose is that the notice COVERS the inputs rather than
+       pushing them down, so it is measured: `absolute` positioning, and the
+       five-input grid underneath still has all five children at its original
+       two tracks. A notice that had been rendered in flow would leave both
+       intact too, which is why the overlap itself is read as well. */
+    await expect(getComputedStyle(notice).position).toBe('absolute');
+    const grid = canvasElement.querySelector('.grid.grid-cols-2') as HTMLElement;
+    await expect(getComputedStyle(grid).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(2);
+    await expect(grid.children).toHaveLength(5);
+    await expect(notice.getBoundingClientRect().bottom).toBeGreaterThan(
+      grid.getBoundingClientRect().top
+    );
+
+    /* The matches list and this notice are mutually exclusive branches of the
+       same block, so the search wrapper must hold the notice and no <ul>. */
+    const searchBlock = notice.parentElement as HTMLElement;
+    await expect(searchBlock.querySelectorAll('ul')).toHaveLength(0);
+    await expect(searchBlock.querySelectorAll('p')).toHaveLength(1);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The no-match notice is absolutely positioned over the grid below it, on `--neutral-0` ' +
+          'with the dropdown shadow, so it covers the first row of inputs rather than pushing ' +
+          'them down. Reachable offline because `listWorkspaceTemplates` gathers its three ' +
+          'requests with `Promise.allSettled` and resolves to an empty list instead of erroring.',
+      },
+    },
+  },
+};
+
+export const PhoneRowExpanded: Story = {
+  name: 'Phone: row breakdown stays two columns',
+  // The meta decorator is `w-[498px] max-w-full`, so it collapses to the phone
+  // width here rather than forcing a horizontal scroll. No second wrapper needed.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const grid = await expandRow(canvasElement, 'VT-003');
+
+    /* `grid-cols-2` has no responsive variant here, so the breakdown keeps two
+       tracks at 375 where the drawer is full-screen. Asserted rather than
+       assumed: this is the width where "Resp. rate: 24 bpm" is closest to
+       wrapping inside its cell. */
+    await expect(getComputedStyle(grid).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(2);
+    await expect(grid.children).toHaveLength(8);
+    await expect(canvas.getByText('Resp. rate: 24 bpm')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'At 375 the quick-actions drawer goes full-screen, so this is the real phone width for ' +
+          'the breakdown. The grid does not collapse to one column, which keeps the eight ' +
+          'readings in the same shape as on desktop but leaves each cell about 150px wide.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/AllDocumentsTable.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/AllDocumentsTable.stories.tsx
@@ -276,7 +276,7 @@ export const LoadFailed: Story = {
   args: { error: 'Documents are unavailable for this visit.' },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(await canvas.findByRole('alert')).toHaveTextContent(
+    expect(await canvas.findByRole('alert')).toHaveTextContent(
       'Documents are unavailable for this visit.'
     );
     // `error` replaces the list outright rather than sitting above it.

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/DepositModal.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/DepositModal.stories.tsx
@@ -81,7 +81,7 @@ export const OnlineDeposit: Story = {
     const panel = within(dialog);
     await userEvent.click(panel.getByRole('button', { name: 'Online link' }));
     // The primary action is relabelled by the method choice, not by a separate prop.
-    await expect(await panel.findByRole('button', { name: 'Generate link' })).toBeInTheDocument();
+    expect(await panel.findByRole('button', { name: 'Generate link' })).toBeInTheDocument();
     await expect(panel.queryByRole('button', { name: 'Collect deposit' })).not.toBeInTheDocument();
   },
   parameters: {

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/InvoicesSection.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/InvoicesSection.stories.tsx
@@ -109,7 +109,7 @@ const BREAKDOWN_HEADINGS = ['Item Name', 'Unit Price', 'Qnt.', 'Gross Amt.', 'Di
 
 const expectBreakdownDrawn = async (canvas: ReturnType<typeof within>) => {
   // Assert the expanded panel actually has its grid, not merely that a row is flagged open.
-  await expect(await canvas.findByText('Breakdown')).toBeInTheDocument();
+  expect(await canvas.findByText('Breakdown')).toBeInTheDocument();
   for (const heading of BREAKDOWN_HEADINGS) {
     await expect(canvas.getByText(heading)).toBeInTheDocument();
   }

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/AppointmentMerckSearch.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/AppointmentMerckSearch.tsx
@@ -277,7 +277,7 @@ const MerckReaderOverlay = ({
     <div className="relative flex size-full max-h-[95vh] max-w-7xl flex-col overflow-hidden rounded-2xl border border-hairline bg-[var(--screen)] shadow-2xl">
       <div className="flex items-center justify-between gap-2 border-b border-hairline px-5 py-3">
         <div className="flex min-w-0 items-center gap-2.5 pr-2">
-          <span className="flex size-8 flex-none items-center justify-center rounded-[9px] bg-blue-soft text-blue-text">
+          <span className="flex size-8 flex-none items-center justify-center rounded-[9px] bg-[var(--blue-soft)] text-blue-text">
             <IoBookOutline size={15} aria-hidden="true" />
           </span>
           <span className="truncate text-[13.5px] font-bold text-[var(--ink)]">{title}</span>
@@ -300,7 +300,7 @@ const MerckReaderOverlay = ({
           // Safety net for a manual that never finishes loading (network stall, MSD
           // outage). Rather than spin forever, offer the working new-tab path.
           <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 bg-[var(--screen)] px-6 text-center">
-            <span className="flex size-11 items-center justify-center rounded-full bg-blue-soft text-blue-text">
+            <span className="flex size-11 items-center justify-center rounded-full bg-[var(--blue-soft)] text-blue-text">
               <IoOpenOutline size={20} aria-hidden="true" />
             </span>
             <span className="text-[13.5px] font-bold text-[var(--ink)]">
@@ -517,7 +517,7 @@ const AppointmentMerckSearch = ({ activeAppointment }: AppointmentMerckSearchPro
       >
         <div className="flex items-center justify-between gap-2">
           <span className="flex items-center gap-2 text-[13px] font-bold text-[var(--ink)]">
-            <span className="flex size-7 items-center justify-center rounded-[9px] bg-blue-soft text-blue-text">
+            <span className="flex size-7 items-center justify-center rounded-[9px] bg-[var(--blue-soft)] text-blue-text">
               <IoBookOutline size={14} aria-hidden="true" />
             </span>
             {'MSD Manual'}

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/Prescription/Submissions/SignatureActions.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/Prescription/Submissions/SignatureActions.tsx
@@ -187,7 +187,7 @@ const SignatureActions = ({ submission, onStatusChange }: SignatureActionsProps)
           />
         ) : null}
       </div>
-      {error ? <div className="text-xs text-error-main">{error}</div> : null}
+      {error ? <div className="text-xs text-text-error">{error}</div> : null}
     </div>
   );
 };

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/index.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/index.tsx
@@ -457,7 +457,7 @@ const CustomFormsView = ({
     return <div className="text-body-3 text-text-primary">Loading forms…</div>;
   }
   if (error) {
-    return <div className="text-body-3 text-error-main">{error}</div>;
+    return <div className="text-body-3 text-text-error">{error}</div>;
   }
 
   return (
@@ -657,7 +657,7 @@ const CustomFormsView = ({
             <div className="text-body-3 text-text-secondary">No past form submissions.</div>
           </Accordion>
         ) : null}
-        {submitError ? <div className="text-error-main text-body-4">{submitError}</div> : null}
+        {submitError ? <div className="text-text-error text-body-4">{submitError}</div> : null}
       </div>
     </Accordion>
   );

--- a/apps/frontend/src/app/features/chat/components/ChannelHeaderBar.stories.tsx
+++ b/apps/frontend/src/app/features/chat/components/ChannelHeaderBar.stories.tsx
@@ -1,0 +1,550 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+
+import ChannelHeaderBar from './ChannelHeaderBar';
+import './ChatContainer.css';
+
+/** The bar is the only `<header>` in the canvas, so this is unambiguous. */
+const headerOf = (canvasElement: HTMLElement) =>
+  canvasElement.querySelector('header') as HTMLElement;
+
+/**
+ * The trailing cluster in order. Named controls report their `aria-label`; the
+ * `--cta` pills have none, so they fall back to their label text.
+ */
+const actionNames = (header: HTMLElement) =>
+  within(header)
+    .getAllByRole('button')
+    .map((button) => button.getAttribute('aria-label') ?? button.textContent);
+
+/** Circle controls are `box-sizing: border-box`, and `getComputedStyle().width` resolves to the
+ *  CONTENT box - a 34px bordered circle reads back as 32px. Measured off the border box instead,
+ *  which is what the design specifies and what the house stories use. */
+const widthOf = (el: HTMLElement) => Math.round(el.getBoundingClientRect().width);
+
+const HeaderFrame = (Story: React.ComponentType) => (
+  <div className="w-[640px] max-w-full overflow-hidden rounded-2xl border border-[var(--hairline)] bg-[var(--screen)]">
+    <Story />
+    <div className="p-5 text-[12.5px] text-[var(--ink-faint)]">
+      Thread body - here only so the bar sits on its hairline the way it does over the message list.
+    </div>
+  </div>
+);
+
+const meta = {
+  title: 'Chat/ChannelHeaderBar',
+  component: ChannelHeaderBar,
+  decorators: [HeaderFrame],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'The thread header: back control, avatar, name over a status subtitle, then the trailing ' +
+          'action cluster. It is presentational - every branch is a prop - but it had never been ' +
+          'drawn, because in the app it only exists inside a mounted Stream `Channel`, which needs ' +
+          'a live client and a real channel.\n\n' +
+          'Five props decide what the right-hand cluster contains, and the combinations do not ' +
+          'overlap: a client chat gets the info toggle plus either a Close session pill or a ' +
+          '"Session closed" badge; a group chat gets a Group Info pill and no info toggle at all; ' +
+          'the back control exists only on a phone. So the bar has no single canonical form, and ' +
+          'the four shapes below are the ones that actually ship.\n\n' +
+          'The status line is two different elements rather than one line with two colours. With ' +
+          '`showPresence` it is a flex row carrying a 6px `--success` dot that pulses through the ' +
+          '`.chat-presence-dot` keyframes in `ChatContainer.css` (imported here for that reason, ' +
+          'and honoured only when the viewer has not asked for reduced motion); without it, it is ' +
+          'a plain `caption-2` in `--ink-faint`. Presence also lights the halo on the avatar, so ' +
+          'the online bar has two pulsing dots, not one.\n\n' +
+          'Three things a reviewer should look at rather than take on trust. First, the circular ' +
+          'controls are three different diameters in one 44px row - back 34px, search 36px, info ' +
+          '30px - which the Phone story measures. Second, the offline subtitle asks for 11px and ' +
+          'renders at 12px: `globals.css` redefines `.text-caption-2` outside any `@layer` with ' +
+          '`font-size: 0.75rem !important`, so the `text-[11px]` utility on that element loses and ' +
+          'the "quiet" offline line ends up bigger than the 11.5px online one (**Client chat, ' +
+          'offline** measures it). Third, the embedded `MessageSearch` reads ' +
+          "Stream's channel contexts, and outside a `Channel` those hooks return `{}` after a " +
+          'console warning. The trigger still renders, still opens, and - because its empty-state ' +
+          'line is gated on the query rather than on the response - still answers "No messages ' +
+          'found" to anything typed into it, with no request ever made. So the popover you can ' +
+          'open from these stories is chrome around a dead query. It is storied properly under ' +
+          '**Chat/MessageSearch**, whose last story measures exactly that.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    title: 'Marta Alvarez',
+    statusText: 'Online',
+    chat: { isClientChat: true, isGroupChat: false, sessionClosed: false, showPresence: true },
+    info: { open: false, onToggle: fn() },
+    session: { closing: false, onClose: fn() },
+    onOpenGroupInfo: fn(),
+  },
+} satisfies Meta<typeof ChannelHeaderBar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ClientOnline: Story = {
+  name: 'Client chat, online',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const header = headerOf(canvasElement);
+
+    await expect(canvas.getByText('Marta Alvarez')).toBeInTheDocument();
+    // Deterministic monogram from the same name - a wrong avatar here means the
+    // header and the sidebar row disagree about who this thread is with.
+    await expect(canvas.getByText('MA')).toBeInTheDocument();
+
+    // Two dots when online: the avatar halo and the one in the status line.
+    const dots = canvasElement.querySelectorAll('.chat-presence-dot');
+    await expect(dots).toHaveLength(2);
+    // Proves the keyframes actually reached the element rather than the class
+    // merely being present. Reduced motion legitimately switches it off, so the
+    // expectation follows the media query rather than assuming a value.
+    const reduced = globalThis.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    await expect(getComputedStyle(dots[0]).animationName).toBe(reduced ? 'none' : 'ycPulseDot');
+
+    // Search, info, Close session - and nothing else.
+    await expect(actionNames(header)).toEqual([
+      'Search messages',
+      'Conversation info',
+      'Close session',
+    ]);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The everyday client thread. The name is `min-w-0 flex-1 truncate` at 13.5px bold, the ' +
+          'status is 11.5px `--success-text`, and the whole bar is 44-48px tall depending on ' +
+          'breakpoint - the actions are `shrink-0`, so the name is the only thing that gives way.',
+      },
+    },
+  },
+};
+
+export const ClientOffline: Story = {
+  name: 'Client chat, offline',
+  args: {
+    statusText: 'Last seen 2 hours ago',
+    chat: { isClientChat: true, isGroupChat: false, sessionClosed: false, showPresence: false },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const subtitle = canvas.getByText('Last seen 2 hours ago');
+    // A different ELEMENT, not a recoloured one - the offline line is a
+    // `caption-2` Text, the online line a green flex row with a dot.
+    await expect(subtitle.querySelector('.chat-presence-dot')).toBeNull();
+
+    /* And it renders at 12px, not the 11px the component asks for. `globals.css`
+       defines `.text-caption-2` a SECOND time outside any @layer, with
+       `font-size: 0.75rem !important`, and an unlayered important rule beats the
+       `text-[11px]` utility no matter the specificity. So the offline subtitle -
+       meant to be the quietest line in the bar - is actually LARGER than the
+       11.5px online one. Asserted as it really renders, because a story that
+       asserted the intent would be red on shipping code and tell a reviewer
+       nothing about what is on screen. */
+    await expect(getComputedStyle(subtitle).fontSize).toBe('12px');
+    await expect(subtitle).toHaveClass('text-[11px]');
+    // No presence anywhere: the avatar halo goes with the status dot, since both
+    // read the same `showPresence` flag.
+    await expect(canvasElement.querySelectorAll('.chat-presence-dot')).toHaveLength(0);
+    // The action cluster is unchanged - same controls, same order, only the
+    // subtitle differs. Asserted by name rather than by count, because three
+    // buttons in the wrong order would satisfy a count.
+    await expect(actionNames(headerOf(canvasElement))).toEqual([
+      'Search messages',
+      'Conversation info',
+      'Close session',
+    ]);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same thread with the counterpart offline. `statusText` carries a last-seen string ' +
+          'instead of "Online", and the line is meant to drop to 11px `--ink-faint`.\n\n' +
+          'It does not. The play function measures 12px, because `globals.css` redefines ' +
+          '`.text-caption-2` outside any `@layer` with `font-size: 0.75rem !important`, which the ' +
+          '`text-[11px]` utility on the same element cannot outrank. The offline subtitle is ' +
+          'therefore the LARGEST status line in this bar - bigger than the 11.5px online one it is ' +
+          'supposed to be quieter than. Nothing about the rendered bar reveals that; only the ' +
+          'measurement does.',
+      },
+    },
+  },
+};
+
+export const PresenceComparison: Story = {
+  name: 'Online vs offline, side by side',
+  render: (args) => (
+    <div className="flex flex-col">
+      <ChannelHeaderBar {...args} statusText="Online now" />
+      <ChannelHeaderBar
+        {...args}
+        statusText="Last seen yesterday"
+        chat={{ ...args.chat, showPresence: false }}
+      />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const online = canvas.getByText('Online now');
+    const offline = canvas.getByText('Last seen yesterday');
+
+    /* The two subtitles are different elements, not one element with a swapped
+       class, so this compares live computed colour rather than class names.
+       Read inside waitFor: both lines sit in a `transition-colors` subtree and a
+       synchronous read can land mid-interpolation. */
+    await waitFor(() => {
+      expect(getComputedStyle(online).color).not.toBe(getComputedStyle(offline).color);
+    });
+    // One presence dot in the status row plus one avatar halo, from the top bar only.
+    await expect(canvasElement.querySelectorAll('.chat-presence-dot')).toHaveLength(2);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Both presence states stacked, which is the only way to see how far apart the two ' +
+          'subtitles really are. The online line is a green flex row with a dot; the offline line ' +
+          'is a plain faint caption. Nothing else in the bar changes, so any visible difference in ' +
+          'bar height between the two rows is a bug in the status block.',
+      },
+    },
+  },
+};
+
+export const SessionClosed: Story = {
+  name: 'Client chat, session closed',
+  args: {
+    statusText: 'Session ended 14:20',
+    chat: { isClientChat: true, isGroupChat: false, sessionClosed: true, showPresence: false },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The badge replaces the action rather than sitting beside a disabled one -
+    // and it is a static label, not a control, so it carries no button role.
+    const badge = canvas.getByText('Session closed');
+    await expect(badge.closest('button')).toBeNull();
+    await expect(canvas.queryByRole('button', { name: 'Close session' })).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Closing…' })).not.toBeInTheDocument();
+    // Search and info survive: a closed session is still readable and still has
+    // a conversation-info drawer. Named, so a reordered cluster fails.
+    await expect(actionNames(headerOf(canvasElement))).toEqual([
+      'Search messages',
+      'Conversation info',
+    ]);
+    // The subtitle carries the closing time; the badge says nothing about when.
+    await expect(canvas.getByText('Session ended 14:20')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'After the vet closes the consultation. The `neutral` badge is a 10px uppercase ' +
+          'micro-pill, so the trailing cluster loses its only `--cta` element and the bar goes ' +
+          'visually flat - which is the intended signal that nothing here is actionable any more.',
+      },
+    },
+  },
+};
+
+export const ClosingSession: Story = {
+  name: 'Client chat, closing in flight',
+  args: {
+    session: { closing: true, onClose: fn() },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const pill = canvas.getByRole('button', { name: 'Closing…' });
+    // Really disabled, not just repainted: `isDisabled` reaches the DOM attribute.
+    await expect(pill).toBeDisabled();
+    await expect(pill).toHaveAttribute('aria-disabled', 'true');
+    await expect(canvas.queryByRole('button', { name: 'Close session' })).not.toBeInTheDocument();
+    // The dimming treatment, measured - `pointer-events-none opacity-60` is what
+    // stops a second click reaching an in-flight request.
+    const style = getComputedStyle(pill);
+    await expect(style.opacity).toBe('0.6');
+    await expect(style.pointerEvents).toBe('none');
+    // Only the label swapped. The cluster keeps its members and its order, which
+    // is why the row does not reflow while the request is out.
+    await expect(actionNames(headerOf(canvasElement))).toEqual([
+      'Search messages',
+      'Conversation info',
+      'Closing…',
+    ]);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The in-flight state of the close-session call, which lasts exactly as long as one API ' +
+          'round trip and is therefore invisible in normal use. The label swaps to "Closing…" and ' +
+          'the pill takes `pointer-events-none opacity-60` - so it dims in place rather than ' +
+          'resizing, and the cluster does not reflow while the request is out.',
+      },
+    },
+  },
+};
+
+export const GroupChat: Story = {
+  name: 'Group chat',
+  args: {
+    title: 'Ward round · ICU',
+    statusText: '6 members',
+    chat: { isClientChat: false, isGroupChat: true, sessionClosed: false, showPresence: false },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const header = headerOf(canvasElement);
+
+    // Search plus Group Info, in that order, and no client-chat controls.
+    await expect(actionNames(header)).toEqual(['Search messages', 'Group Info']);
+    await expect(
+      canvas.queryByRole('button', { name: 'Conversation info' })
+    ).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Session closed')).not.toBeInTheDocument();
+
+    // A group avatar is the people glyph, not initials - so "WR" must not appear.
+    await expect(canvas.queryByText('WR')).not.toBeInTheDocument();
+    await expect(canvas.getByText('Ward round · ICU')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A team group thread. The conversation-info drawer is client-only, so a group gets a ' +
+          '`--cta` Group Info pill opening the member editor instead - two different surfaces ' +
+          'behind two controls that occupy the same slot in the row.',
+      },
+    },
+  },
+};
+
+export const InfoOpen: Story = {
+  name: 'Info toggle pressed',
+  args: { info: { open: true, onToggle: fn() } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const toggle = canvas.getByRole('button', { name: 'Conversation info' });
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+    /* And nothing else changed, which is the finding rather than an aside. The
+       open toggle is measured against the neighbouring search control, which is
+       in its own resting state: same border colour, same transparent fill. If a
+       pressed treatment is ever added, this is the assertion that fails. */
+    const search = canvas.getByRole('button', { name: 'Search messages' });
+    await waitFor(() => {
+      const pressed = getComputedStyle(toggle);
+      expect(pressed.backgroundColor).toBe('rgba(0, 0, 0, 0)');
+      expect(pressed.borderTopColor).toBe(getComputedStyle(search).borderTopColor);
+    });
+    // Its geometry is untouched too - still the 30px circle, still last of the
+    // three round controls in size.
+    await expect(widthOf(toggle)).toBe(30);
+    await expect(toggle.querySelector('svg')).not.toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`aria-expanded` is the only thing that changes while the info drawer is open - the ' +
+          'button keeps its resting border and ink. Worth flagging: a sighted user gets no ' +
+          'indication from this control that the drawer they are looking at belongs to it.',
+      },
+    },
+  },
+};
+
+export const InfoToggleFires: Story = {
+  name: 'Info toggle fires',
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const toggle = canvas.getByRole('button', { name: 'Conversation info' });
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    await userEvent.click(toggle);
+    // The bar is controlled, so the state lives in ChatContainer; the callback is
+    // the whole contract this component owes it.
+    await expect(args.info.onToggle).toHaveBeenCalledTimes(1);
+    await expect(args.session.onClose).not.toHaveBeenCalled();
+    /* And the bar does NOT update itself: `info.open` is still false, so
+       aria-expanded is still false after a click that visibly "worked". A
+       component that flipped it locally would drift out of step with the drawer
+       ChatContainer actually renders. */
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    // The click changed no other part of the row.
+    await expect(actionNames(headerOf(canvasElement))).toEqual([
+      'Search messages',
+      'Conversation info',
+      'Close session',
+    ]);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Confirms the two adjacent circular controls are wired to different handlers. They are ' +
+          '6px apart and similar in size, so a swapped callback would close the consultation ' +
+          'instead of opening a drawer and nothing on screen would look wrong.',
+      },
+    },
+  },
+};
+
+export const Phone: Story = {
+  name: 'Phone: back control and three circle sizes',
+  args: { back: { onBack: fn() } },
+  // Pinned as a GLOBAL: `parameters.viewport.defaultViewport` was removed in
+  // Storybook 10 and silently renders at full panel width instead.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const header = headerOf(canvasElement);
+
+    const back = canvas.getByRole('button', { name: 'Back to conversations' });
+    // First child of the header, ahead of the avatar - the design merged the old
+    // separate back strip into this row.
+    await expect(header.firstElementChild).toBe(back);
+
+    await expect(actionNames(header)).toEqual([
+      'Back to conversations',
+      'Search messages',
+      'Conversation info',
+      'Close session',
+    ]);
+
+    /* Three round controls, three diameters, in one row. Measured rather than
+       asserted from the class names, because that is the discrepancy: the design
+       has one circular control size and this bar ships 34 / 36 / 30. */
+    const search = canvas.getByRole('button', { name: 'Search messages' });
+    const infoToggle = canvas.getByRole('button', { name: 'Conversation info' });
+    await expect(widthOf(back)).toBe(34);
+    await expect(widthOf(search)).toBe(36);
+    await expect(widthOf(infoToggle)).toBe(30);
+    // Square, not merely wide: an oval here would still satisfy the widths.
+    await expect(Math.round(back.getBoundingClientRect().height)).toBe(34);
+
+    await userEvent.click(back);
+    await expect(args.back?.onBack).toHaveBeenCalledTimes(1);
+  },
+  parameters: {
+    /* The viewport global alone is not enough - see the long note on **Phone:
+       long name truncates**. Under `layout: 'centered'` the 640px `HeaderFrame`
+       keeps `#storybook-root` 672px wide inside the 375px window, so both phone
+       stories were drawing the DESKTOP bar. These three circles happen to be
+       fixed sizes and measured the same either way, which is precisely why
+       nothing here caught it. */
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        story:
+          'The phone bar. `back` is passed only below the `md` breakpoint, so on desktop this ' +
+          'control does not exist at all. At 375px the row is back + avatar + name + three ' +
+          'trailing controls, and the padding drops from `px-4 py-3` to `px-3.5 py-2.5`.',
+      },
+    },
+  },
+};
+
+export const PhoneLongTitle: Story = {
+  name: 'Phone: long name truncates',
+  args: {
+    title: 'Konstantina Papadopoulou-Fitzgerald',
+    statusText: 'Last seen 3 days ago',
+    chat: { isClientChat: true, isGroupChat: false, sessionClosed: false, showPresence: false },
+    back: { onBack: fn() },
+  },
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const title = canvas.getByText('Konstantina Papadopoulou-Fitzgerald');
+    const header = headerOf(canvasElement);
+
+    /* THE PREMISE, asserted rather than assumed - everything below is a claim
+       about a row that is too narrow, so a frame that quietly rendered at
+       desktop width would make all of it vacuous.
+
+       Which is what was happening. The mobile viewport global is honoured, but
+       `layout: 'centered'` sizes `#storybook-root` shrink-to-fit and
+       `HeaderFrame`'s `w-[640px]` is a min-content floor the root cannot go
+       below: root stayed 672px wide inside the 375px window, `max-w-full` never
+       bit, and this "phone" story drew the 640px DESKTOP bar. The name then got
+       a 317px column, its 260px of text fitted, and the overflow assertion
+       below compared 317 to 317 - a story that read as an off-by-one but was
+       really the viewport never reaching the component. `layout: 'fullscreen'`
+       on this story is the fix; this line is what fails loudly if it regresses. */
+    await expect(widthOf(header)).toBeLessThanOrEqual(375);
+
+    /* `truncate` is three declarations, and it no-ops whenever an unlayered
+       plain-CSS rule wins over the utility - which has bitten this codebase
+       before, and `ChatContainer.css` is exactly that kind of unlayered sheet.
+       So this reads the computed values rather than trusting the class. */
+    const style = getComputedStyle(title);
+    await expect(style.textOverflow).toBe('ellipsis');
+    await expect(style.overflow).toBe('hidden');
+    await expect(style.whiteSpace).toBe('nowrap');
+
+    /* And the name is genuinely clipped, not merely styled to clip. Measured
+       against the text's OWN laid-out width - a Range over the text node
+       reports the ~260px the name needs against the ~52px column it is given -
+       because `scrollWidth` and `clientWidth` are integers, so a real overflow
+       under a pixel reads back as equal and a truncation bug would pass. */
+    const laidOut = document.createRange();
+    laidOut.selectNodeContents(title);
+    await expect(laidOut.getBoundingClientRect().width).toBeGreaterThan(
+      title.getBoundingClientRect().width
+    );
+    await expect(title.scrollWidth).toBeGreaterThan(title.clientWidth);
+
+    /* Pinned to CURRENT behaviour, not to intent (issue #2297). The name asks
+       for 13.5px/700 through `text-[13.5px] font-bold`; at <=768px `globals.css`
+       redefines `.text-body-3-emphasis` outside any `@layer` with
+       `font-size: 1rem !important; font-weight: 500 !important`, and an
+       unlayered important rule beats any utility. So the PHONE header draws the
+       name at 16px/500 - larger and lighter than the 14.5px bold desktop one it
+       is supposed to be a compact version of, and 3px of extra type in the row
+       that has the least width to give. The losing classes are asserted next to
+       the measured values so the contradiction is in the failure output. */
+    await expect(title).toHaveClass('text-body-3-emphasis', 'text-[13.5px]', 'font-bold');
+    await expect(style.fontSize).toBe('16px');
+    await expect(style.fontWeight).toBe('500');
+
+    // The controls kept their size instead of being squeezed by the long name.
+    const search = canvas.getByRole('button', { name: 'Search messages' });
+    await expect(widthOf(search)).toBe(36);
+    await expect(widthOf(canvas.getByRole('button', { name: 'Back to conversations' }))).toBe(34);
+    // And the whole cluster still fits inside the 375px bar rather than
+    // overflowing it, which is the failure a long name would cause.
+    await expect(header.scrollWidth).toBeLessThanOrEqual(header.clientWidth + 1);
+  },
+  /* Not decoration: `centered` centres by making `#storybook-root` shrink-to-fit,
+     and a fixed-width child then sets a min-content floor that the mobile
+     viewport cannot push it below. `fullscreen` is what lets `max-w-full` on
+     `HeaderFrame` actually collapse the frame to 375px. */
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        story:
+          'The worst case for this row: a long double-barrelled name, a back control and the full ' +
+          'client cluster on a 375px screen. The name is the only `min-w-0 flex-1` element, so it ' +
+          'is what clips; everything else is `shrink-0`. If a control ever appears squashed here, ' +
+          'the flex minimums are wrong rather than the name being too long.\n\n' +
+          'The bar itself is sound: given a real 375px row the name takes a 52px column and lays ' +
+          'out 260px of text behind an ellipsis, and the cluster still fits. Two things this story ' +
+          'measures are not.\n\n' +
+          "First, the story was not a phone. `layout: 'centered'` plus the 640px `HeaderFrame` " +
+          'held `#storybook-root` at 672px inside the 375px window, so the mobile viewport never ' +
+          'reached the component and the "phone" bar was the desktop bar. The play function now ' +
+          'asserts its own premise before measuring anything.\n\n' +
+          'Second, the name renders at 16px/500 here, not the 13.5px/700 it asks for: below 768px ' +
+          '`globals.css` redefines `.text-body-3-emphasis` outside any `@layer` with ' +
+          '`font-size: 1rem !important; font-weight: 500 !important` (issue #2297). The phone ' +
+          'header therefore sets the name LARGER and lighter than the desktop one, in the row with ' +
+          'the least width to spare - which is also why it clips this early.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/chat/components/ChatCommandPalette.stories.tsx
+++ b/apps/frontend/src/app/features/chat/components/ChatCommandPalette.stories.tsx
@@ -1,0 +1,557 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import type { Channel, ChannelFilters, StreamChat } from 'stream-chat';
+
+import ChatCommandPalette from './ChatCommandPalette';
+
+const ME = 'u-me';
+
+/**
+ * The palette touches four things on a channel - `id`, `cid`, `data.name` and
+ * `state.members` - and one thing on the client: `queryChannels`. Objects with
+ * that shape are a complete stand-in, so these stories run with no Stream
+ * client, no token and no socket.
+ */
+type FakeChannel = {
+  id: string;
+  cid: string;
+  data?: { name?: string; organisationId?: string };
+  state?: { members?: Record<string, { user?: { id: string; name?: string } }> };
+};
+
+const CHANNELS: FakeChannel[] = [
+  {
+    id: 'c-ward',
+    cid: 'messaging:c-ward',
+    data: { name: 'Ward round · ICU', organisationId: 'org-mine' },
+  },
+  {
+    id: 'c-triage',
+    cid: 'messaging:c-triage',
+    data: { name: 'Ward triage · front desk', organisationId: 'org-mine' },
+  },
+  {
+    id: 'c-lab',
+    cid: 'messaging:c-lab',
+    data: { name: 'Lab results', organisationId: 'org-mine' },
+  },
+  {
+    // No `data.name`: a direct message, whose title is derived from the member
+    // who is not the signed-in user.
+    id: 'c-dm-marta',
+    cid: 'messaging:c-dm-marta',
+    data: { organisationId: 'org-mine' },
+    state: {
+      members: {
+        [ME]: { user: { id: ME, name: 'Yara Osman' } },
+        'u-marta': { user: { id: 'u-marta', name: 'Marta Alvarez' } },
+      },
+    },
+  },
+  {
+    // A direct message with a member who has no display name at all: the title
+    // falls back to the raw user id rather than rendering blank.
+    id: 'c-dm-anon',
+    cid: 'messaging:c-dm-anon',
+    data: { organisationId: 'org-mine' },
+    state: {
+      members: {
+        [ME]: { user: { id: ME, name: 'Yara Osman' } },
+        'u-8814': { user: { id: 'u-8814' } },
+      },
+    },
+  },
+];
+
+const FOREIGN: FakeChannel = {
+  id: 'c-other-org',
+  cid: 'messaging:c-other-org',
+  data: { name: 'Ward round · Riverbend', organisationId: 'org-somebody-else' },
+};
+
+const clientWith = (channels: FakeChannel[]) =>
+  ({
+    userID: ME,
+    queryChannels: () => Promise.resolve(channels),
+  }) as unknown as StreamChat;
+
+const FILTERS: ChannelFilters = { type: 'messaging' };
+
+const belongsToMyOrg = (channel: Channel) =>
+  (channel.data as { organisationId?: string } | undefined)?.organisationId === 'org-mine';
+
+/** A real wait, for the assertion that has to prove a keystroke did nothing. */
+const settle = (ms: number) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+/** The palette unmounts when closed, so this is null rather than a hidden node. */
+const paletteOf = (canvasElement: HTMLElement) =>
+  canvasElement.querySelector('dialog[open]') as HTMLElement | null;
+
+/**
+ * Opens the palette with the real shortcut, re-sending it until it lands.
+ *
+ * The ⌘K listener is registered inside an effect, and a play function can start
+ * before that effect has flushed - the failure mode that left every GlassTooltip
+ * story green while proving nothing. `findBy*` retries the QUERY, never the
+ * KEYSTROKE, so one lost dispatch would be permanent and invisible. Re-sending
+ * is safe because a lost dispatch toggles nothing: each attempt checks before
+ * pressing again.
+ */
+const openPalette = async (canvasElement: HTMLElement) => {
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    if (paletteOf(canvasElement)) break;
+    await userEvent.keyboard('{Meta>}k{/Meta}');
+    await settle(100);
+  }
+  const palette = paletteOf(canvasElement);
+  if (!palette) throw new Error('The palette never opened after 5 Cmd+K presses.');
+  return palette;
+};
+
+/** The jump rows, scoped to the palette's own list. */
+const rowsOf = (palette: HTMLElement) =>
+  within(palette.querySelector('ul') as HTMLElement).queryAllByRole('button');
+
+/**
+ * A row's `textContent` starts with the avatar monogram ("WR" before "Ward round
+ * · ICU"), so the title is read off the `flex-1` span instead of the whole row.
+ */
+const rowTitles = (palette: HTMLElement) =>
+  rowsOf(palette).map((row) => row.querySelector('.flex-1')?.textContent);
+
+const PageBehind = (Story: React.ComponentType) => (
+  <div className="min-h-[620px] bg-[var(--screen-2)] p-6">
+    <p className="text-[13px] text-[var(--ink-muted)]">
+      The chat shell. The palette is `fixed inset-0`, so it covers this whole surface - the tint and
+      the 96px top offset are only judgeable with something behind them.
+    </p>
+    <Story />
+  </div>
+);
+
+const meta = {
+  title: 'Chat/ChatCommandPalette',
+  component: ChatCommandPalette,
+  decorators: [PageBehind],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The ⌘K / Ctrl-K jump-to-conversation palette. `ChatContainer` mounts it once, and it ' +
+          'returns `null` until the shortcut fires - so there is no closed state to capture and ' +
+          'nothing had ever drawn it. Every story here opens it with the real key combination ' +
+          'rather than a prop, because there is no prop.\n\n' +
+          'It is also the only place in the product that resolves a conversation title without ' +
+          'Stream doing it: `titleOf` prefers `data.name`, and for a direct message falls back to ' +
+          "the first member who is not the signed-in user, then to that member's raw user id, " +
+          'then to the literal "Conversation". Two of the fixtures below are DMs for that reason - ' +
+          "one named, one with no display name - because a title bug here shows the operator's own " +
+          'name back at them and nothing else in the UI would look wrong.\n\n' +
+          'The filtering is client-side and substring-only over the resolved title, on the 30 most ' +
+          'recent channels. There is no fuzzy matching despite the shape of the control, no ' +
+          'highlighting of the matched span, and no keyboard traversal of the list: arrow keys do ' +
+          'nothing, and Enter always jumps to `results[0]` whatever the pointer is over.\n\n' +
+          'The organisation filter is the part worth reviewing carefully. Stream has no ' +
+          'server-side org scope, so `queryChannels` genuinely returns conversations from other ' +
+          'clinics and `channelBelongsToOrg` drops them in the client. The **Cross-org channel ' +
+          'dropped** story feeds one in to show it never reaches a row - without that predicate ' +
+          'the palette would open a channel the active organisation cannot otherwise see.\n\n' +
+          'One more thing this component does that is invisible from the outside: its keydown ' +
+          'listener is registered on the capture phase and calls `stopImmediatePropagation`, so ' +
+          'while chat is mounted ⌘K opens this palette instead of the app-wide UniversalSearch. ' +
+          'Two palettes on one shortcut, and the winner is decided by listener phase.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    client: clientWith(CHANNELS),
+    filters: FILTERS,
+    onJump: fn(),
+  },
+} satisfies Meta<typeof ChatCommandPalette>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Open: Story = {
+  name: 'Open (⌘K)',
+  play: async ({ canvasElement }) => {
+    const palette = await openPalette(canvasElement);
+    const canvas = within(palette);
+
+    await expect(palette).toHaveAttribute('aria-label', 'Jump to conversation');
+    await expect(canvas.getByLabelText('Search conversations')).toHaveAttribute(
+      'placeholder',
+      'Jump to a conversation…'
+    );
+    // The caret is already in the field: ⌘K then type, with no click in between.
+    await expect(document.activeElement).toBe(canvas.getByLabelText('Search conversations'));
+
+    /* All five, in the order `queryChannels` returned them - the palette does not
+       re-sort, so this is `last_message_at` descending straight from Stream. The
+       last two are the derived DM titles: the other member's name, then their id.
+       Polled, because the channels arrive from a promise after the open. */
+    await waitFor(() => {
+      expect(rowTitles(palette)).toEqual([
+        'Ward round · ICU',
+        'Ward triage · front desk',
+        'Lab results',
+        'Marta Alvarez',
+        'u-8814',
+      ]);
+    });
+    // The signed-in user is never the title of their own DM.
+    await expect(canvas.queryByText('Yara Osman')).not.toBeInTheDocument();
+
+    // The card, measured: 512px (`max-w-lg`) over a 320px (`max-h-80`) scroller.
+    const card = palette.querySelector('ul')?.parentElement as HTMLElement;
+    await expect(getComputedStyle(card).maxWidth).toBe('512px');
+    await expect(getComputedStyle(palette.querySelector('ul') as HTMLElement).maxHeight).toBe(
+      '320px'
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The palette as it opens: a 512px card 96px down from the top of a `neutral-900/30` ' +
+          'wash, a search row with a ⌘K chip on the right, and the 30 most recent conversations ' +
+          'below it. Each row is avatar, title, and a return-arrow glyph that is decoration only - ' +
+          'the whole row is the button.',
+      },
+    },
+  },
+};
+
+export const FiltersAsYouType: Story = {
+  name: 'Filtering the list',
+  play: async ({ canvasElement }) => {
+    const palette = await openPalette(canvasElement);
+    const canvas = within(palette);
+    const field = canvas.getByLabelText('Search conversations');
+    await waitFor(() => {
+      expect(rowsOf(palette)).toHaveLength(5);
+    });
+
+    await userEvent.type(field, 'ward');
+
+    // Substring, case-insensitive, over the RESOLVED title - so it matches the
+    // derived DM names too, not only `data.name`.
+    await waitFor(() => {
+      expect(rowTitles(palette)).toEqual(['Ward round · ICU', 'Ward triage · front desk']);
+    });
+
+    await userEvent.clear(field);
+    await userEvent.type(field, 'marta');
+    await waitFor(() => {
+      expect(rowTitles(palette)).toEqual(['Marta Alvarez']);
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Typing narrows the list in place - no request, no spinner, no debounce, because the ' +
+          'channels were fetched once when the palette opened. Nothing marks which part of the ' +
+          'title matched, which is most noticeable on a query like "ward" that hits two very ' +
+          'different conversations.',
+      },
+    },
+  },
+};
+
+export const NoMatches: Story = {
+  name: 'No matches',
+  play: async ({ canvasElement }) => {
+    const palette = await openPalette(canvasElement);
+    const canvas = within(palette);
+    const field = canvas.getByLabelText('Search conversations');
+    await waitFor(() => {
+      expect(rowsOf(palette)).toHaveLength(5);
+    });
+    await userEvent.type(field, 'zzz');
+
+    const line = await canvas.findByText('No conversations found');
+    await expect(rowsOf(palette)).toHaveLength(0);
+
+    /* The line replaces the whole list - it is the only `<li>` in the scroller,
+       centred - and the query stays in the field, so the card is a search box
+       over one grey sentence. */
+    const list = palette.querySelector('ul') as HTMLElement;
+    await expect(list.children).toHaveLength(1);
+    await expect(line.closest('li')).toBe(list.children[0]);
+    await expect(getComputedStyle(list.children[0] as HTMLElement).textAlign).toBe('center');
+    await expect(field).toHaveValue('zzz');
+    // No "create a conversation" escape hatch appears with the empty arm: the
+    // scrim button is still the only other control in the dialog.
+    await expect(
+      within(palette)
+        .getAllByRole('button')
+        .map((button) => button.getAttribute('aria-label'))
+    ).toEqual(['Close palette']);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The empty arm: a single centred `body-4` line in `--ink-faint` with `py-6`, so the card ' +
+          'collapses to about a third of its height. There is no "create a conversation" action ' +
+          'from here - the palette only jumps to what already exists.',
+      },
+    },
+  },
+};
+
+export const EmptyDirectory: Story = {
+  name: 'No conversations at all',
+  args: { client: clientWith([]) },
+  play: async ({ canvasElement }) => {
+    const palette = await openPalette(canvasElement);
+    const canvas = within(palette);
+    // Same line as a failed query, reached without typing anything.
+    const line = canvas.getByText('No conversations found');
+    await expect(rowsOf(palette)).toHaveLength(0);
+    await expect(line.textContent).toBe('No conversations found');
+
+    /* Which is the finding: with an empty field the card is indistinguishable
+       from the No-matches story - same single centred `<li>`, same copy - so a
+       first-run account is told its search failed. */
+    const list = palette.querySelector('ul') as HTMLElement;
+    await expect(list.children).toHaveLength(1);
+    await expect(canvas.getByLabelText('Search conversations')).toHaveValue('');
+    // The chrome above it is fully drawn, so nothing hints at "nothing here yet".
+    await expect(canvas.getByLabelText('Search conversations')).toHaveAttribute(
+      'placeholder',
+      'Jump to a conversation…'
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A brand-new account opening the palette. Identical copy to a query that matched ' +
+          'nothing, which is worth seeing: the first-run case reads as though the search failed ' +
+          'rather than as though there is nothing to search yet.',
+      },
+    },
+  },
+};
+
+export const CrossOrgChannelDropped: Story = {
+  name: 'Cross-org channel dropped',
+  args: {
+    client: clientWith([FOREIGN, ...CHANNELS]),
+    channelBelongsToOrg: belongsToMyOrg,
+  },
+  play: async ({ canvasElement }) => {
+    const palette = await openPalette(canvasElement);
+    const canvas = within(palette);
+
+    // `queryChannels` returned six; the predicate keeps five.
+    await waitFor(() => {
+      expect(rowsOf(palette)).toHaveLength(5);
+    });
+    await expect(canvas.queryByText('Ward round · Riverbend')).not.toBeInTheDocument();
+    await expect(canvas.getByText('Ward round · ICU')).toBeInTheDocument();
+
+    // It stays dropped under a query that would otherwise match it - the filter
+    // runs on the already-scoped list, not on the raw response.
+    await userEvent.type(canvas.getByLabelText('Search conversations'), 'ward');
+    await waitFor(() => {
+      expect(rowTitles(palette)).toEqual(['Ward round · ICU', 'Ward triage · front desk']);
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The security-relevant case. Stream has no server-side organisation scope, so the ' +
+          "foreign clinic's channel really is in the response; `channelBelongsToOrg` is the only " +
+          'thing keeping it off the list. Note the two remaining rows both match the query, so a ' +
+          'reviewer cannot tell from the picture alone that a third one was removed - which is why ' +
+          'this is asserted rather than eyeballed.',
+      },
+    },
+  },
+};
+
+export const EnterJumpsToFirst: Story = {
+  name: 'Enter jumps to the first result',
+  play: async ({ args, canvasElement }) => {
+    const palette = await openPalette(canvasElement);
+    const canvas = within(palette);
+    await userEvent.type(canvas.getByLabelText('Search conversations'), 'lab');
+    // Waited for on purpose: Enter reads `results[0]`, so pressing it before the
+    // filter has applied would jump to the wrong conversation and still pass a
+    // "was called" assertion.
+    await waitFor(() => {
+      expect(rowTitles(palette)).toEqual(['Lab results']);
+    });
+
+    await userEvent.keyboard('{Enter}');
+
+    await expect(args.onJump).toHaveBeenCalledTimes(1);
+    await expect(args.onJump).toHaveBeenCalledWith('c-lab');
+    // Closing unmounts the whole dialog rather than dropping the `open`
+    // attribute, so there is nothing left in the DOM to query.
+    await expect(paletteOf(canvasElement)).toBeNull();
+    await expect(canvasElement.querySelector('dialog')).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Enter always takes `results[0]`, and there is no visible selection to tell the user ' +
+          'which row that is - the first row is not highlighted, and arrow keys do not move ' +
+          'anything. With one match it is unambiguous; the risk is a two-word query that leaves ' +
+          'several rows, where Enter picks silently.',
+      },
+    },
+  },
+};
+
+export const ClickingARowJumps: Story = {
+  name: 'Clicking a row jumps',
+  play: async ({ args, canvasElement }) => {
+    const palette = await openPalette(canvasElement);
+    await waitFor(() => {
+      expect(rowsOf(palette)).toHaveLength(5);
+    });
+    // The fourth row is the derived-title DM, so this also proves the row's id
+    // survived the title derivation.
+    await userEvent.click(rowsOf(palette)[3]);
+
+    await expect(args.onJump).toHaveBeenCalledWith('c-dm-marta');
+    await expect(paletteOf(canvasElement)).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The pointer path. `onJump` is `activateChannelById` in the app, which watches the ' +
+          'channel and makes it active - so the palette closes immediately and the thread behind ' +
+          'it changes under the fading scrim.',
+      },
+    },
+  },
+};
+
+export const EscapeCloses: Story = {
+  name: 'Escape closes it',
+  play: async ({ args, canvasElement }) => {
+    const palette = await openPalette(canvasElement);
+    // Five rows and a field were on screen a moment ago, so the disappearance
+    // below is a real teardown rather than a story that never opened.
+    await waitFor(() => {
+      expect(rowsOf(palette)).toHaveLength(5);
+    });
+
+    await userEvent.keyboard('{Escape}');
+    await settle(100);
+
+    await expect(paletteOf(canvasElement)).toBeNull();
+    /* Unmounted, not merely un-`open`ed: `if (!open) return null` removes the
+       whole dialog, so a `dialog[open]` check and a bare `dialog` check agree.
+       A component that dropped only the attribute would leave the card in the
+       accessibility tree. */
+    await expect(canvasElement.querySelector('dialog')).toBeNull();
+    await expect(
+      within(canvasElement).queryByLabelText('Search conversations')
+    ).not.toBeInTheDocument();
+    // Dismissing is not jumping: nothing was activated on the way out.
+    await expect(args.onJump).not.toHaveBeenCalled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Escape is handled by the same window-level listener as ⌘K, not by the `<dialog>` ' +
+          'element - the dialog is rendered with the `open` attribute rather than shown as a modal, ' +
+          'so the browser gives it neither the top layer nor its built-in Escape behaviour. That ' +
+          'is also why focus is not trapped inside the card.',
+      },
+    },
+  },
+};
+
+export const BackdropCloses: Story = {
+  name: 'Clicking the scrim closes it',
+  play: async ({ args, canvasElement }) => {
+    const palette = await openPalette(canvasElement);
+    const backdrop = within(palette).getByRole('button', { name: 'Close palette' });
+    const card = palette.querySelector('ul')?.parentElement as HTMLElement;
+    await waitFor(() => {
+      expect(rowsOf(palette)).toHaveLength(5);
+    });
+
+    /* Full-bleed and BENEATH the card, which is the whole reason the rows stay
+       clickable: the card is `relative z-10`, the scrim is a plain `absolute`
+       with no z-index of its own. Level those out and the palette looks perfect
+       and dismisses itself on the first row click. */
+    await expect(getComputedStyle(backdrop).position).toBe('absolute');
+    await expect(getComputedStyle(backdrop).zIndex).toBe('auto');
+    await expect(getComputedStyle(card).zIndex).toBe('10');
+    await expect(backdrop.getBoundingClientRect().width).toBeGreaterThan(
+      card.getBoundingClientRect().width
+    );
+    // It is also first in the dialog, so the first Tab out of the field lands on
+    // "Close palette" rather than on a conversation.
+    await expect(palette.firstElementChild).toBe(backdrop);
+
+    await userEvent.click(backdrop);
+
+    await expect(paletteOf(canvasElement)).toBeNull();
+    await expect(canvasElement.querySelector('dialog')).toBeNull();
+    await expect(args.onJump).not.toHaveBeenCalled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The scrim is a real labelled button rather than a click handler on the wash, so it is ' +
+          'reachable by keyboard - it is also the first thing in the dialog, which means the very ' +
+          'first Tab from the search field lands on "Close palette".',
+      },
+    },
+  },
+};
+
+export const QueryResetsOnReopen: Story = {
+  name: 'Reopening starts empty',
+  play: async ({ canvasElement }) => {
+    const palette = await openPalette(canvasElement);
+    await userEvent.type(within(palette).getByLabelText('Search conversations'), 'lab');
+    await waitFor(() => {
+      expect(rowsOf(palette)).toHaveLength(1);
+    });
+
+    await userEvent.keyboard('{Escape}');
+    await settle(100);
+    await expect(paletteOf(canvasElement)).toBeNull();
+
+    const reopened = await openPalette(canvasElement);
+    const field = within(reopened).getByLabelText('Search conversations');
+    /* Cleared during render by the `prevOpen` compare guard rather than in an
+       effect, so the reopened palette never paints one frame of the old query or
+       of the single row it had filtered to. */
+    await expect(field).toHaveValue('');
+    await waitFor(() => {
+      expect(rowsOf(reopened)).toHaveLength(5);
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Open, filter, dismiss, reopen. The palette is a jump tool rather than a search page, so ' +
+          'it deliberately forgets - and the reset is computed during render, which is the ' +
+          'difference between reopening on a clean list and reopening on a stale one that blinks.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/chat/components/ChatContainer.tsx
+++ b/apps/frontend/src/app/features/chat/components/ChatContainer.tsx
@@ -741,7 +741,11 @@ const ChatLayout: FC<ChatLayoutProps> = ({
   );
 };
 
-const ChatSidebarHeader: FC<ChatSidebarHeaderProps> = ({
+// Exported for Storybook only. The header is mounted deep inside the Stream
+// `ChannelList` shell, so the only way to draw it was to build a real chat
+// client first; exporting it lets the stories mount the real component with
+// plain props instead.
+export const ChatSidebarHeader: FC<ChatSidebarHeaderProps> = ({
   showArchived,
   onToggleArchived,
   scope,

--- a/apps/frontend/src/app/features/chat/components/ChatHeaderContext.stories.tsx
+++ b/apps/frontend/src/app/features/chat/components/ChatHeaderContext.stories.tsx
@@ -1,0 +1,346 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+import type { Appointment } from '@yosemite-crew/types';
+
+import { ChatHeaderContext } from './ChatHeaderContext';
+
+/**
+ * Only `startTime`, `status` and `patient.name` are read; the rest of `Appointment` is
+ * required by the type and never touched, so it is filled once here and cast.
+ */
+const appointment = (over: Partial<Appointment> = {}): Appointment =>
+  ({
+    id: 'appt-88',
+    organisationId: 'org-sb',
+    patient: {
+      id: 'companion-12',
+      name: 'Kiko',
+      species: 'Dog',
+      parent: { id: 'parent-3', name: 'Marta Alvarez' },
+    },
+    startTime: new Date('2026-03-26T09:15:00.000Z'),
+    status: 'UPCOMING',
+    ...over,
+  }) as unknown as Appointment;
+
+/**
+ * The chip's timestamp goes through `formatDateInPreferredTimeZone`, which reads a
+ * localStorage token and falls back to Europe/Berlin. A story that ran after anything
+ * that set a timezone would render a different clock time and the assertion would fail
+ * for a reason that has nothing to do with this component - so the key is cleared for
+ * the story and put back afterwards. 09:15Z is 10:15 in Berlin on 26 March 2026 (CET;
+ * DST starts on the 29th).
+ */
+const pinnedTimeZone = () => {
+  const key = 'yc_preferred_timezone';
+  const previous = window.localStorage.getItem(key);
+  window.localStorage.removeItem(key);
+  return () => {
+    if (previous !== null) window.localStorage.setItem(key, previous);
+  };
+};
+
+/** The banner row that holds the appointment chip and its actions. */
+const apptBanner = (canvasElement: HTMLElement): HTMLElement =>
+  within(canvasElement).getByText('Appointment').closest('div') as HTMLElement;
+
+/** Visible quick actions, in DOM order. */
+const actionNames = (canvasElement: HTMLElement): string[] =>
+  within(apptBanner(canvasElement))
+    .getAllByRole('button')
+    .map((button) => button.textContent?.trim() ?? '');
+
+const meta = {
+  title: 'Chat/ChatHeaderContext',
+  component: ChatHeaderContext,
+  decorators: [
+    // `data-testid` so the "returns null" story can assert emptiness against THIS
+    // element rather than by counting divs in the canvas - Storybook's own layout
+    // wrappers are not part of the contract and a count would break on them.
+    (Story) => (
+      <div
+        data-testid="context-frame"
+        className="w-full max-w-[860px] border border-[var(--hairline)] bg-[var(--screen)]"
+      >
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The strip between the channel header and the message thread: a clinical safety band, ' +
+          'an appointment context chip with quick actions, and the pinned-message banner.\n\n' +
+          'It is mounted unconditionally by `ChatContainer` and then **returns `null`** unless it ' +
+          'has something to say - `flags.length === 0 && !appointment && pinned.length === 0` is ' +
+          'an early return. On a staff-to-staff conversation that is every render, so the strip ' +
+          'is invisible for most of the product and had never been drawn with all three blocks ' +
+          'stacked.\n\n' +
+          'The interesting part is not the layout, it is **which actions exist**. The four quick ' +
+          'actions are filtered per appointment status by three different rules that live in ' +
+          'three different modules: `allowReschedule` (requested/upcoming only), ' +
+          '`canTransitionAppointmentStatus(status, "COMPLETED")` (in-progress only, in practice), ' +
+          'and `canEnterAppointmentWorkspace` for **Send form**, which is gated on the same check ' +
+          'the workspace route enforces so the button cannot deep-link the user into a dead end. ' +
+          'Only "Book follow-up" is unconditional. The result is that no two statuses show the ' +
+          'same row, and a regression in any one of those helpers silently removes or adds a ' +
+          'button rather than throwing. Each story below asserts the whole visible set, in order, ' +
+          'rather than probing for one button.\n\n' +
+          '`completing` is a fourth axis on top of status: it hides **Mark complete** while the ' +
+          'status round-trip is in flight, which is the only thing stopping a double click from ' +
+          'firing two completions. That is a state with no resting form at all.\n\n' +
+          'The safety band is a filter too. Only `critical` and `high` alerts appear, only if ' +
+          'they carry a title, and the allergy is prepended - all joined into one ' +
+          '`--danger-bg` line rather than stacked, so a companion with several flags still costs ' +
+          'one row of thread height.\n\n' +
+          'Below `sm` the banner is a column and the actions become a horizontal scroller; from ' +
+          '`sm` up it is a row with the actions wrapped right. Both are drawn.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    allergy: 'Penicillin',
+    alerts: [
+      { title: 'Anticoagulant therapy', severity: 'critical' },
+      // Dropped: below the severity cut.
+      { title: 'Nervous around other dogs', severity: 'medium' },
+      // Dropped: high enough, but no title to render.
+      { severity: 'high' },
+    ],
+    appointment: appointment(),
+    pinned: [
+      { id: 'p1', text: 'Recheck booked for 26 March at 10:15 - bring the medication box.' },
+      { id: 'p2', text: 'Owner prefers WhatsApp for reminders.' },
+      { id: 'p3', text: 'Weight to be recorded at every visit.' },
+    ],
+    onOpenPinned: fn(),
+    onAction: fn(),
+  },
+  beforeEach: pinnedTimeZone,
+} satisfies Meta<typeof ChatHeaderContext>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const FullContext: Story = {
+  name: 'All three blocks (upcoming)',
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    // One band, one line, filtered: the medium alert and the title-less high alert are
+    // both absent, and the survivors are joined with " · " rather than stacked.
+    await expect(
+      canvas.getByText('Allergy: Penicillin · Anticoagulant therapy')
+    ).toBeInTheDocument();
+    await expect(canvas.queryByText(/Nervous around other dogs/)).not.toBeInTheDocument();
+
+    // The chip carries the formatted local time and the patient name.
+    await expect(canvas.getByText('Thu, Mar 26, 10:15 AM · Kiko')).toBeInTheDocument();
+
+    // UPCOMING: reschedulable, enterable by the workspace, not completable.
+    await expect(actionNames(canvasElement)).toEqual(['Reschedule', 'Send form', 'Book follow-up']);
+
+    // "Pinned · “first” + 2 more" - the count is of the OTHERS, not of all pins.
+    const banner = canvas.getByRole('button', { name: /^Pinned/ });
+    await expect(banner).toHaveTextContent(
+      'Pinned · “Recheck booked for 26 March at 10:15 - bring the medication box.” + 2 more'
+    );
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Reschedule' }));
+    await expect(args.onAction).toHaveBeenCalledWith('Reschedule');
+    await userEvent.click(banner);
+    await expect(args.onOpenPinned).toHaveBeenCalled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Everything at once, which in the app means a pet-parent conversation attached to a ' +
+          'booked appointment on a companion with flags. Three stacked bands eat about 130px of ' +
+          'thread height - worth seeing together, because each block was designed on its own and ' +
+          'this is the only place they meet.',
+      },
+    },
+  },
+};
+
+export const InProgress: Story = {
+  name: 'In progress (Mark complete appears)',
+  args: { appointment: appointment({ status: 'IN_PROGRESS' }) },
+  play: async ({ canvasElement }) => {
+    // Reschedule drops out and Mark complete arrives - the row is not a superset of the
+    // upcoming one, it is a different row.
+    await expect(actionNames(canvasElement)).toEqual([
+      'Send form',
+      'Mark complete',
+      'Book follow-up',
+    ]);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The only status where **Mark complete** is offered, because `IN_PROGRESS -> COMPLETED` ' +
+          'is the only transition into `COMPLETED` the status machine allows. Rescheduling is ' +
+          'gone by now: the consultation has started.',
+      },
+    },
+  },
+};
+
+export const Completing: Story = {
+  name: 'Completion in flight',
+  args: { appointment: appointment({ status: 'IN_PROGRESS' }), completing: true },
+  play: async ({ canvasElement }) => {
+    // The button is REMOVED, not disabled - so the row reflows and the two survivors
+    // shift left. That reflow is the whole reason to look at this state.
+    await expect(actionNames(canvasElement)).toEqual(['Send form', 'Book follow-up']);
+    // The name list alone would still pass if the hidden action left a non-button
+    // placeholder behind holding its gap open, so the container's child count is
+    // asserted too: two children, nothing standing in for the third.
+    const actions = apptBanner(canvasElement).lastElementChild as HTMLElement;
+    await expect(actions.children).toHaveLength(2);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same appointment while the status PATCH is open. `completing` hides Mark complete ' +
+          'so it cannot be pressed twice, and there is no spinner or disabled pill standing in ' +
+          'for it - the row simply gets shorter. Whether that reads as "working" or as "the ' +
+          'button vanished" is the design question this story exists to put in front of someone.',
+      },
+    },
+  },
+};
+
+export const CancelledAppointment: Story = {
+  name: 'Cancelled (one action left)',
+  args: { appointment: appointment({ status: 'CANCELLED' }), allergy: undefined, alerts: [] },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Every gated action fails its gate; only the unconditional one survives.
+    await expect(actionNames(canvasElement)).toEqual(['Book follow-up']);
+    // Send form is gated on `canEnterAppointmentWorkspace`, which refuses cancelled
+    // appointments - offering it here would strand the user on the workspace's
+    // "cannot be opened" message.
+    await expect(canvas.queryByRole('button', { name: 'Send form' })).not.toBeInTheDocument();
+    await expect(canvas.queryByText(/^Allergy:/)).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A cancelled booking, and the narrowest the banner ever gets: chip on the left, a ' +
+          'single pill on the right, and a lot of space between them. The chip is still shown ' +
+          'because the conversation is still about that appointment.',
+      },
+    },
+  },
+};
+
+export const PinnedOnly: Story = {
+  name: 'Pinned banner only',
+  args: {
+    allergy: undefined,
+    alerts: [],
+    appointment: undefined,
+    pinned: [{ id: 'p1', text: 'Discharge instructions are in the attached PDF.' }],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const banner = canvas.getByRole('button', { name: /^Pinned/ });
+    // A single pin gets no "+ N more" suffix at all, rather than "+ 0 more".
+    await expect(banner).toHaveTextContent(
+      'Pinned · “Discharge instructions are in the attached PDF.”'
+    );
+    await expect(banner.textContent).not.toContain('more');
+    // The other two blocks are absent, so the banner sits directly under the header
+    // with only its own 6px top padding above it.
+    await expect(canvas.queryByText('Appointment')).not.toBeInTheDocument();
+    await expect(canvas.getAllByRole('button')).toHaveLength(1);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The staff-conversation case: no clinical record behind the thread, just pins. This is ' +
+          'the only block that renders on its own in practice, and it is the one with no ' +
+          'background of its own - a `--surface-soft` pill inset from the thread edges rather ' +
+          'than a full-bleed band like the two above it.',
+      },
+    },
+  },
+};
+
+export const RendersNothing: Story = {
+  name: 'Nothing to show (returns null)',
+  args: { allergy: undefined, alerts: [], appointment: undefined, pinned: [] },
+  play: async ({ canvasElement }) => {
+    // Asserted structurally rather than with a text query: the preview decorator puts an
+    // sr-only <h1> in the canvas, so `canvasElement` is never empty and "no text" would
+    // be true even for a component that rendered an empty shell.
+    //
+    // Measured against THIS story's own frame rather than by counting divs in the whole
+    // canvas - the canvas also holds Storybook's layout wrappers, which are not part of
+    // the contract. An empty frame is the only honest way to say the early return fired:
+    // a component that returned `<div className="shrink-0" />` would still satisfy "no
+    // text" and "no buttons".
+    const frame = within(canvasElement).getByTestId('context-frame');
+    await expect(frame.children).toHaveLength(0);
+    await expect(frame.textContent).toBe('');
+    await expect(canvasElement.querySelectorAll('button')).toHaveLength(0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A staff thread with no pins - by volume, the most common state in the product. The ' +
+          'component returns `null`, so the thread starts immediately under the channel header ' +
+          "with no residual padding or hairline. This story's own frame is left completely " +
+          'empty, which is what the play function checks.',
+      },
+    },
+  },
+};
+
+export const Phone: Story = {
+  name: 'Phone: banner stacks, actions scroll',
+  args: { appointment: appointment({ status: 'IN_PROGRESS' }) },
+  // Pinned as a GLOBAL. `parameters.viewport.defaultViewport` was removed in Storybook
+  // 10 and is inert, so a story pinned that way silently renders the desktop branch.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const banner = apptBanner(canvasElement);
+    const chip = canvas.getByText('Appointment').parentElement?.parentElement as HTMLElement;
+    const actions = banner.lastElementChild as HTMLElement;
+
+    // Below `sm` the banner is a column: chip on its own line, actions under it.
+    await expect(getComputedStyle(banner).flexDirection).toBe('column');
+    // `self-start` keeps the chip its own width instead of stretching across the column.
+    await expect(getComputedStyle(chip).alignSelf).toBe('flex-start');
+    // The actions do not wrap on a phone, they scroll - three pills on a 375px screen
+    // would otherwise become three stacked rows.
+    await expect(getComputedStyle(actions).flexWrap).toBe('nowrap');
+    await expect(getComputedStyle(actions).overflowX).toBe('auto');
+    await expect(actionNames(canvasElement)).toEqual([
+      'Send form',
+      'Mark complete',
+      'Book follow-up',
+    ]);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'At 375px the same three actions are a horizontal scroller with `-mx-1` bleed, so the ' +
+          'first pill starts at the thread edge and the last one is reachable by swiping rather ' +
+          'than by the row growing a second line. The chip keeps its own width above it.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/chat/components/ChatMessage.stories.tsx
+++ b/apps/frontend/src/app/features/chat/components/ChatMessage.stories.tsx
@@ -1,0 +1,693 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import {
+  ChannelActionProvider,
+  MessageProvider,
+  type ChannelActionContextValue,
+  type MessageContextValue,
+} from 'stream-chat-react';
+
+import { ChatMessage } from './ChatMessage';
+import type { SharedEntityData } from './SharedEntityCard';
+
+/**
+ * Everything `ChatMessage` renders comes out of two Stream contexts, so the fixture is
+ * those two contexts and nothing else - no client, no channel, no socket, no token.
+ * The component reads five keys off `MessageContext` (`message`, `isMyMessage`,
+ * `handleReaction`, `handleOpenThread`, `readBy`) and two off `ChannelActionContext`
+ * (`editMessage`, `deleteMessage`); the rest of both types is required by Stream and
+ * never touched here, which is why each value is cast rather than filled in.
+ */
+type HarnessProps = {
+  mine: boolean;
+  text: string;
+  senderName: string;
+  createdAt: string;
+  firstOfGroup?: boolean;
+  deleted?: boolean;
+  seen?: boolean;
+  reactionGroups?: Record<string, { count?: number }>;
+  ownReactions?: { type?: string }[];
+  sharedEntity?: SharedEntityData;
+  handleReaction: (emoji: string, event: unknown) => void;
+  handleOpenThread: (event: unknown) => void;
+  editMessage: (message: unknown) => void;
+  deleteMessage: (message: unknown) => void;
+};
+
+const Harness = ({
+  mine,
+  text,
+  senderName,
+  createdAt,
+  firstOfGroup,
+  deleted,
+  seen,
+  reactionGroups,
+  ownReactions,
+  sharedEntity,
+  handleReaction,
+  handleOpenThread,
+  editMessage,
+  deleteMessage,
+}: HarnessProps) => {
+  const message = {
+    id: 'msg-1',
+    text,
+    type: deleted ? 'deleted' : 'regular',
+    created_at: new Date(createdAt),
+    user: { id: mine ? 'me' : 'them', name: senderName },
+    attachments: [],
+    reaction_groups: reactionGroups,
+    own_reactions: ownReactions,
+    ...(deleted ? { deleted_at: createdAt } : {}),
+    ...(sharedEntity ? { sharedEntity } : {}),
+  };
+
+  return (
+    <ChannelActionProvider
+      value={{ editMessage, deleteMessage } as unknown as ChannelActionContextValue}
+    >
+      <MessageProvider
+        value={
+          {
+            message,
+            isMyMessage: () => mine,
+            handleReaction,
+            handleOpenThread,
+            readBy: seen ? [{ id: 'them' }] : [],
+          } as unknown as MessageContextValue
+        }
+      >
+        <ChatMessage firstOfGroup={firstOfGroup} />
+      </MessageProvider>
+    </ChannelActionProvider>
+  );
+};
+
+/**
+ * The popovers are `createPortal`ed to `document.body`, so nothing they render is inside
+ * `canvasElement` and a canvas-scoped query finds nothing however long it retries. They
+ * are also the only direct `<body>` children carrying these two classes, which makes a
+ * count of them the honest way to assert "exactly one popover is open".
+ */
+const openPanels = (): HTMLElement[] =>
+  [...document.body.children].filter((el): el is HTMLElement =>
+    el.matches('div.rounded-full, div.w-36')
+  );
+
+const body = () => within(document.body);
+
+/**
+ * The meta line is formatted through `formatDateInPreferredTimeZone`, which reads a
+ * localStorage token and falls back to Europe/Berlin. Cleared for the story and restored
+ * afterwards so the clock does not depend on which story ran before this one: 09:15Z is
+ * 10:15 in Berlin on 26 March 2026.
+ */
+const pinnedTimeZone = () => {
+  const key = 'yc_preferred_timezone';
+  const previous = window.localStorage.getItem(key);
+  window.localStorage.removeItem(key);
+  return () => {
+    if (previous !== null) window.localStorage.setItem(key, previous);
+  };
+};
+
+const meta = {
+  title: 'Chat/ChatMessage',
+  component: Harness,
+  decorators: [
+    (Story) => (
+      <div className="w-[560px] bg-[var(--screen)] p-4 pb-32">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'One row of the message thread, and the three surfaces hanging off it that nothing had ' +
+          'ever drawn: the **reaction picker**, the **edit/delete menu** and the **inline ' +
+          'editor**.\n\n' +
+          'All three are module-private (`MessageActions`, `AnchoredPopover`, `MessageEditor` are ' +
+          'not exported), so they are driven through the real `ChatMessage` rather than exported ' +
+          'for the sake of a story. That costs two context providers and nothing else.\n\n' +
+          'They are hidden three times over, which is why they had never been reviewed. The whole ' +
+          'action strip is `opacity-0` until `group-hover`, so at rest the row shows no ' +
+          'affordance at all. The picker and the menu are then gated on their own state. And ' +
+          'both panels are **portalled to `document.body`** - deliberately, because Stream’s ' +
+          'message list is `overflow: auto` and would clip them - which means they are outside ' +
+          '`canvasElement` and outside every snapshot ever taken of this component.\n\n' +
+          'The positioning is measured, not declared. `useAnchoredPopoverStyle` renders the panel ' +
+          'hidden at 0,0 first, measures it, then places it 6px below the trigger - flipping it ' +
+          '6px **above** when there is no room before the viewport bottom, which is the ' +
+          'last-message case that used to crop the picker. It also aligns left for incoming ' +
+          'messages and right for outgoing ones, and clamps to an 8px viewport margin. Every one ' +
+          'of those numbers is asserted below, because a measurement pass that silently fails ' +
+          'leaves the panel at 0,0 - top-left of the screen, still "rendered", still passing any ' +
+          'test that only checks it appeared.\n\n' +
+          '`closeAll()` before each open is what keeps the picker and the menu mutually ' +
+          'exclusive; there is a story for that too, since two open panels overlap each other ' +
+          'exactly.\n\n' +
+          'The editor is the one piece with a commit rule: `save()` fires `editMessage` **only** ' +
+          'when the trimmed text differs from the original, and otherwise cancels. Enter saves, ' +
+          'Escape cancels. Because the message here is a static fixture rather than a live Stream ' +
+          'message, a successful save closes the editor and the bubble shows the original text ' +
+          'again - in the app the Stream state update is what puts the new text back.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    mine: false,
+    text: 'Bloodwork is back and the panel is clean.',
+    senderName: 'Dr. Amelia Hart',
+    createdAt: '2026-03-26T09:15:00.000Z',
+    handleReaction: fn(),
+    handleOpenThread: fn(),
+    editMessage: fn(),
+    deleteMessage: fn(),
+  },
+  beforeEach: pinnedTimeZone,
+} satisfies Meta<typeof Harness>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Incoming: Story = {
+  name: 'Incoming (actions invisible at rest)',
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Bloodwork is back and the panel is clean.')).toBeInTheDocument();
+    await expect(canvas.getByText('10:15 AM')).toBeInTheDocument();
+
+    // Two actions for someone else's message, and no third one.
+    const react = canvas.getByRole('button', { name: 'React' });
+    await expect(canvas.getByRole('button', { name: 'Reply' })).toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'More' })).not.toBeInTheDocument();
+
+    // The strip is in the DOM and fully transparent - present to the accessibility tree
+    // and to the keyboard, invisible to the eye until the row is hovered. Nothing else
+    // in this component depends on hover, so this is the one thing a static review of
+    // the row cannot see.
+    const strip = react.parentElement as HTMLElement;
+    await waitFor(() => {
+      expect(getComputedStyle(strip).opacity).toBe('0');
+    });
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Reply' }));
+    await expect(args.handleOpenThread).toHaveBeenCalled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting row: avatar gutter, `--inset` bubble with a `--divider` edge and a 4px ' +
+          'bottom-left corner, and the time under it. The React and Reply buttons occupy their ' +
+          'space at zero opacity, which is why the bubble does not shift sideways when the row ' +
+          'is hovered.',
+      },
+    },
+  },
+};
+
+export const ReactionPicker: Story = {
+  name: 'Reaction picker',
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'React' });
+    await userEvent.click(trigger);
+
+    await waitFor(() => {
+      expect(openPanels()).toHaveLength(1);
+    });
+    const [panel] = openPanels();
+
+    // Portalled: querying the canvas for it would retry forever.
+    await expect(canvasElement.contains(panel)).toBe(false);
+
+    // Six emoji, in the order `REACTION_EMOJIS` declares them. Asserting the sequence
+    // rather than the count catches a reordering, which changes muscle memory for every
+    // user of the thread.
+    const emoji = within(panel)
+      .getAllByRole('button')
+      .map((button) => button.textContent);
+    await expect(emoji).toEqual(['👍', '❤️', '😂', '🎉', '🙏', '✅']);
+
+    // The measurement pass ran: the panel is visible (it renders hidden first), sits 6px
+    // under the trigger, and is left-aligned to it because this is an incoming message.
+    // A failed measure leaves it hidden at 0,0 while still being "in the document".
+    const panelRect = panel.getBoundingClientRect();
+    const triggerRect = trigger.getBoundingClientRect();
+    await expect(getComputedStyle(panel).visibility).toBe('visible');
+    await expect(panelRect.top).toBeCloseTo(triggerRect.bottom + 6, 0);
+    await expect(panelRect.left).toBeCloseTo(triggerRect.left, 0);
+
+    await userEvent.click(within(panel).getByRole('button', { name: '🎉' }));
+    await expect(args.handleReaction).toHaveBeenCalledWith('🎉', expect.anything());
+    // Picking closes it - the picker is not a palette you stay in.
+    await waitFor(() => {
+      expect(openPanels()).toHaveLength(0);
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The picker open under the React button: a `rounded-full` bar of six 32px emoji ' +
+          'buttons on `--screen` with a two-layer shadow. The emoji **is** the Stream reaction ' +
+          'type - there is no code mapping in between - so this list is also the vocabulary the ' +
+          'API stores.',
+      },
+    },
+  },
+};
+
+export const ReactionPickerFlipsUp: Story = {
+  name: 'Reaction picker flips above the trigger',
+  decorators: [
+    // Pins the row to the bottom of the VIEWPORT, which is where the last message in a
+    // real thread sits and the only place the flip happens. `fixed` rather than a tall
+    // spacer on purpose: the meta decorator wraps this one, so an in-flow height would
+    // still leave the row 100+px clear of the bottom edge and the flip would never fire -
+    // the story would pass while proving the opposite of its name.
+    (Story) => (
+      <div className="fixed inset-x-0 bottom-0 flex justify-center bg-[var(--screen)] p-3">
+        <div className="w-[560px]">
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'React' });
+    await userEvent.click(trigger);
+
+    await waitFor(() => {
+      expect(openPanels()).toHaveLength(1);
+    });
+    const [panel] = openPanels();
+    const panelRect = panel.getBoundingClientRect();
+    const triggerRect = trigger.getBoundingClientRect();
+
+    // Flipped: 6px ABOVE the trigger rather than below it, and still fully on screen.
+    await expect(panelRect.bottom).toBeCloseTo(triggerRect.top - 6, 0);
+    await expect(panelRect.top).toBeGreaterThanOrEqual(8);
+    await expect(panelRect.bottom).toBeLessThanOrEqual(window.innerHeight);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same picker on the last message in a thread. Without the flip the panel is drawn ' +
+          'below the viewport edge and the bottom two rows of a conversation cannot be reacted ' +
+          'to at all - a bug that only exists at one scroll position, which is why it survived ' +
+          'until it was drawn deliberately.',
+      },
+    },
+  },
+};
+
+export const OwnMessageMenu: Story = {
+  name: 'Edit/delete menu (own message)',
+  args: { mine: true, senderName: 'Dr. Weber', text: 'Sending the discharge notes now.' },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    // Own messages get the meta line with the sender appended, and a read receipt.
+    await expect(canvas.getByText('10:15 AM · Dr. Weber')).toBeInTheDocument();
+    await expect(canvas.getByLabelText('Sent')).toBeInTheDocument();
+
+    const trigger = canvas.getByRole('button', { name: 'More' });
+    await userEvent.click(trigger);
+    await waitFor(() => {
+      expect(openPanels()).toHaveLength(1);
+    });
+    const [panel] = openPanels();
+
+    // Exactly two rows. A menu that grew a third item silently would still satisfy a
+    // "the menu opened" assertion.
+    const items = within(panel).getAllByRole('button');
+    await expect(items.map((item) => item.textContent)).toEqual(['Edit', 'Delete']);
+
+    // Right-aligned to the trigger, because this is an outgoing message and the panel
+    // would otherwise hang off the right edge of the thread column.
+    const panelRect = panel.getBoundingClientRect();
+    const triggerRect = trigger.getBoundingClientRect();
+    await expect(panelRect.right).toBeCloseTo(triggerRect.right, 0);
+
+    // Delete is the only destructive row in the thread and carries `--danger-text`.
+    // Polled and resolved through a probe: the token differs between themes, and the
+    // row has `transition-colors`, so one synchronous read can catch a mid-transition
+    // value.
+    const deleteRow = items[1];
+    const probe = document.createElement('span');
+    probe.style.color = 'var(--danger-text)';
+    panel.append(probe);
+    const danger = getComputedStyle(probe).color;
+    probe.remove();
+    await waitFor(() => {
+      expect(getComputedStyle(within(deleteRow).getByText('Delete')).color).toBe(danger);
+    });
+
+    await userEvent.click(deleteRow);
+    await expect(args.deleteMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'msg-1', text: 'Sending the discharge notes now.' })
+    );
+    // Choosing a row closes the menu; deletion is not confirmed anywhere in this
+    // component, so the press is the commit.
+    await waitFor(() => {
+      expect(openPanels()).toHaveLength(0);
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The `w-36` menu under the kebab, which only exists for your own messages. Worth ' +
+          'noting what is *not* here: no confirmation step for Delete, and no "delete for ' +
+          'everyone" distinction - one press calls `deleteMessage` and Stream tombstones the ' +
+          'message for the whole channel.',
+      },
+    },
+  },
+};
+
+export const EditFlow: Story = {
+  name: 'Inline editor (commits a change)',
+  args: { mine: true, senderName: 'Dr. Weber', text: 'Recheck on Tuesday.' },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'More' }));
+    await userEvent.click(await body().findByRole('button', { name: 'Edit' }));
+
+    // The editor REPLACES the bubble rather than overlaying it, so the original text is
+    // gone from the row and lives only in the field.
+    const field = await canvas.findByLabelText<HTMLInputElement>('Edit message');
+    await expect(field.value).toBe('Recheck on Tuesday.');
+    await expect(canvas.queryByText('Recheck on Tuesday.')).not.toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Save edit' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Cancel edit' })).toBeInTheDocument();
+
+    await userEvent.clear(field);
+    await userEvent.type(field, 'Recheck on Wednesday.{Enter}');
+
+    await expect(args.editMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'msg-1', text: 'Recheck on Wednesday.' })
+    );
+    // Enter closes the editor. The bubble comes back carrying the ORIGINAL text, because
+    // the message object is a fixture here - in the app the Stream state update that
+    // follows `editMessage` is what replaces it.
+    await waitFor(() => {
+      expect(canvas.queryByLabelText('Edit message')).not.toBeInTheDocument();
+    });
+    await expect(canvas.getByText('Recheck on Tuesday.')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The editor is a `--blue`-bordered pill with a fixed `w-48` field and the two icon ' +
+          'buttons the rest of the row uses. It is narrower than most bubbles, so a long message ' +
+          'edits inside a field that scrolls rather than growing - which is the thing to judge ' +
+          'here.',
+      },
+    },
+  },
+};
+
+export const EditCommitsOnlyRealChanges: Story = {
+  name: 'Inline editor (no-op saves)',
+  args: { mine: true, senderName: 'Dr. Weber', text: 'Recheck on Tuesday.' },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const openEditor = async () => {
+      await userEvent.click(canvas.getByRole('button', { name: 'More' }));
+      await userEvent.click(await body().findByRole('button', { name: 'Edit' }));
+      return canvas.findByLabelText<HTMLInputElement>('Edit message');
+    };
+
+    // 1. Enter on untouched text: `save()` compares against the original and cancels.
+    let field = await openEditor();
+    await userEvent.type(field, '{Enter}');
+    await waitFor(() => {
+      expect(canvas.queryByLabelText('Edit message')).not.toBeInTheDocument();
+    });
+    await expect(args.editMessage).not.toHaveBeenCalled();
+
+    // 2. Emptied field: the trimmed value is falsy, so it cancels rather than posting an
+    // empty message. This is the only guard against blanking a message by accident.
+    field = await openEditor();
+    await userEvent.clear(field);
+    await userEvent.click(canvas.getByRole('button', { name: 'Save edit' }));
+    await expect(args.editMessage).not.toHaveBeenCalled();
+
+    // 3. Escape abandons a real change - typed text is discarded, not committed.
+    field = await openEditor();
+    await userEvent.type(field, ' Bring the medication box.');
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => {
+      expect(canvas.queryByLabelText('Edit message')).not.toBeInTheDocument();
+    });
+    await expect(args.editMessage).not.toHaveBeenCalled();
+    await expect(canvas.getByText('Recheck on Tuesday.')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Three ways out of the editor that must all leave the message alone: saving without ' +
+          'typing, saving an emptied field, and Escape after a real edit. All three take the ' +
+          '`onCancel` path, so none of them shows an "edited" marker or fires a request - which ' +
+          'matters because Stream stamps `message_updated` on every edit and clinics read that ' +
+          'as a record change.',
+      },
+    },
+  },
+};
+
+export const OnePopoverAtATime: Story = {
+  name: 'Picker and menu are mutually exclusive',
+  args: { mine: true, senderName: 'Dr. Weber' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'React' }));
+    await waitFor(() => {
+      expect(openPanels()).toHaveLength(1);
+    });
+    await expect(body().getByRole('button', { name: '👍' })).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'More' }));
+    // Still one panel, and it is the menu: `closeAll()` runs before the open, and the
+    // outside-mousedown dismissal on the picker fires for the same click. Two panels
+    // here would overlap each other exactly, since both anchor to the same row.
+    await waitFor(() => {
+      expect(openPanels()).toHaveLength(1);
+    });
+    await expect(body().getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+    await expect(body().queryByRole('button', { name: '👍' })).not.toBeInTheDocument();
+
+    // And back the other way.
+    await userEvent.click(canvas.getByRole('button', { name: 'React' }));
+    await waitFor(() => {
+      expect(openPanels()).toHaveLength(1);
+    });
+    await expect(body().queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Both popovers anchor to buttons 28px apart and are placed by the same hook, so if ' +
+          'both could be open they would sit on top of each other with the second one winning on ' +
+          'z-order alone. Two independent mechanisms prevent it and this story exercises both at ' +
+          'once.',
+      },
+    },
+  },
+};
+
+export const PopoverDismissal: Story = {
+  name: 'Dismissing the picker',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'React' });
+
+    await userEvent.click(trigger);
+    await waitFor(() => {
+      expect(openPanels()).toHaveLength(1);
+    });
+    // The panel that opened is the picker, with its six emoji in it. Counting body
+    // children alone would be satisfied by any stray portal a neighbouring story left
+    // behind, and the dismissal assertions below would then be about the wrong node.
+    await expect(
+      within(openPanels()[0])
+        .getAllByRole('button')
+        .map((button) => button.textContent)
+    ).toEqual(['👍', '❤️', '😂', '🎉', '🙏', '✅']);
+
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => {
+      expect(openPanels()).toHaveLength(0);
+    });
+
+    // A pointer-down anywhere outside the panel and the trigger closes it too. The
+    // listener is on `mousedown`, not `click`, so the press closes the panel before the
+    // element under the pointer gets its click.
+    await userEvent.click(trigger);
+    await waitFor(() => {
+      expect(openPanels()).toHaveLength(1);
+    });
+    await userEvent.click(canvas.getByText('Bloodwork is back and the panel is clean.'));
+    await waitFor(() => {
+      expect(openPanels()).toHaveLength(0);
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Escape and an outside press both close the panel, and so do scroll and resize - the ' +
+          'panel is positioned once in fixed coordinates and never re-measured, so it dismisses ' +
+          'rather than drifting away from its trigger.',
+      },
+    },
+  },
+};
+
+export const WithReactions: Story = {
+  name: 'Reactions on the bubble',
+  args: {
+    mine: false,
+    reactionGroups: { '👍': { count: 2 }, '❤️': { count: 1 } },
+    ownReactions: [{ type: '👍' }],
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    // One combined pill, each emoji individually toggleable, then the running total.
+    const thumbs = canvas.getByRole('button', { name: '2 👍 reaction' });
+    await expect(canvas.getByRole('button', { name: '1 ❤️ reaction' })).toBeInTheDocument();
+    const pill = thumbs.parentElement as HTMLElement;
+    await expect(pill.lastElementChild?.textContent).toBe('3');
+
+    // Own reactions are marked by saturation rather than by a second colour, so the pill
+    // stays one shape whoever reacted.
+    await expect(thumbs).toHaveClass('saturate-150');
+    await expect(canvas.getByRole('button', { name: '1 ❤️ reaction' })).not.toHaveClass(
+      'saturate-150'
+    );
+
+    // The pill straddles the bubble's bottom edge (`-bottom-3`) rather than sitting under
+    // it, which is what the extra `mt-2.5` on the meta line below compensates for.
+    // Measured against the bubble BOX, not the paragraph inside it - the bubble's own
+    // 10px block padding is enough to make the overlap look like a gap.
+    const bubble = canvas.getByText('Bloodwork is back and the panel is clean.')
+      .parentElement as HTMLElement;
+    const pillRect = pill.getBoundingClientRect();
+    const bubbleRect = bubble.getBoundingClientRect();
+    await expect(pillRect.top).toBeLessThan(bubbleRect.bottom);
+    await expect(pillRect.bottom).toBeGreaterThan(bubbleRect.bottom);
+
+    await userEvent.click(thumbs);
+    await expect(args.handleReaction).toHaveBeenCalledWith('👍', expect.anything());
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Reactions read from `reaction_groups` (Stream v13) with `reaction_counts` as the older ' +
+          'fallback, so a payload from either shape renders. Zero-count entries are dropped ' +
+          'rather than rendered as empty chips - Stream leaves a group behind when the last ' +
+          'reaction is removed.',
+      },
+    },
+  },
+};
+
+export const Deleted: Story = {
+  name: 'Deleted message',
+  args: { deleted: true, text: 'Wrong thread, sorry.' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('This message was deleted')).toBeInTheDocument();
+    await expect(canvas.queryByText('Wrong thread, sorry.')).not.toBeInTheDocument();
+    // The early return happens before the action strip is built, so a tombstone has no
+    // React, no Reply and no menu - not even hidden ones.
+    await expect(canvas.queryAllByRole('button')).toHaveLength(0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The tombstone: italic `--ink-faint`, no bubble, no avatar, indented `ml-11` on the ' +
+          'incoming side so it still lines up with the column above it. Reacting to or replying ' +
+          'to a deleted message is impossible because the controls are never rendered.',
+      },
+    },
+  },
+};
+
+export const SharedRecord: Story = {
+  name: 'Shared record instead of a bubble',
+  args: {
+    mine: true,
+    senderName: 'Dr. Weber',
+    seen: true,
+    sharedEntity: {
+      entityType: 'INVOICE',
+      entityId: 'inv-2043',
+      title: 'Invoice INV-2043',
+      snapshot: { subtitle: 'Marta Alvarez · 12 Mar 2026', amount: '€248.50', status: 'PAID' },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The card takes the place of the bubble entirely - `message.text` is not rendered
+    // alongside it.
+    await expect(
+      canvas.queryByText('Bloodwork is back and the panel is clean.')
+    ).not.toBeInTheDocument();
+
+    // The whole card came through, not just its title: header row plus value row, with
+    // the deep link live inside the thread.
+    const card = canvas.getByText('Invoice INV-2043').closest('div.rounded-2xl') as HTMLElement;
+    await expect(card.children).toHaveLength(2);
+    await expect(canvas.getByText('€248.50')).toBeInTheDocument();
+    await expect(canvas.getByRole('link', { name: 'View in Finance' })).toHaveAttribute(
+      'href',
+      '/finance'
+    );
+
+    // Outgoing, so the column is `items-end` and the card must sit flush against the
+    // right edge of the 460px bubble column rather than stretching across it or hugging
+    // the left. The card brings its own fixed width, which is the thing that could get
+    // this wrong without any visible error.
+    const column = card.closest('div.flex-col') as HTMLElement;
+    const cardRect = card.getBoundingClientRect();
+    const columnRect = column.getBoundingClientRect();
+    await expect(cardRect.right).toBeCloseTo(columnRect.right, 0);
+    await expect(cardRect.width).toBeLessThan(columnRect.width);
+
+    // Everything around the body still applies: the actions, the meta line and the read
+    // receipt, which is `Seen` here rather than `Sent`.
+    await expect(canvas.getByRole('button', { name: 'React' })).toBeInTheDocument();
+    await expect(canvas.getByLabelText('Seen')).toBeInTheDocument();
+    await expect(canvas.getByText('10:15 AM · Dr. Weber')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A shared PIMS record as it actually lands in a thread: the `SharedEntityCard` sits ' +
+          'where the bubble would be, inside the same `max-w-[460px]` column and under the same ' +
+          'meta line. Worth seeing here rather than only in the card’s own stories, because the ' +
+          'card brings its own `--screen` background and border into a column designed around ' +
+          '`--cta` bubbles.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/chat/components/ChatSidebarHeader.stories.tsx
+++ b/apps/frontend/src/app/features/chat/components/ChatSidebarHeader.stories.tsx
@@ -1,0 +1,613 @@
+import { useState, type ComponentProps } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+
+import { ChatSidebarHeader } from './ChatContainer';
+import type { OrgUserOption } from './GroupModal';
+
+/**
+ * Ten teammates plus the signed-in user, and the ordering is load-bearing.
+ *
+ * The header drops whoever matches `currentUserId` and then caps the rest at
+ * `slice(0, 8)`. With eleven entries both rules bite, and with the signed-in
+ * user placed SECOND rather than last, her absence proves the self-exclusion
+ * rather than the cap - at the end of the list the cap would have removed her
+ * anyway and the story would pass either way.
+ */
+const ORG_USERS: OrgUserOption[] = [
+  { id: 'u-1', userId: 'u-1', name: 'Amelia Hart', email: 'amelia@clinic.test', role: 'Lead vet' },
+  { id: 'u-me', userId: 'u-me', name: 'Yara Osman', email: 'yara@clinic.test', role: 'Vet' },
+  { id: 'u-2', userId: 'u-2', name: 'Tomas Vidal', email: 'tomas@clinic.test', role: 'Nurse' },
+  {
+    id: 'u-3',
+    userId: 'u-3',
+    name: 'Priya Raghavan',
+    email: 'priya@clinic.test',
+    role: 'Radiologist',
+  },
+  { id: 'u-4', userId: 'u-4', name: 'Ben Okafor', email: 'ben@clinic.test', role: 'Receptionist' },
+  { id: 'u-5', userId: 'u-5', name: 'Sofia Marchetti', email: 'sofia@clinic.test', role: 'Vet' },
+  { id: 'u-6', userId: 'u-6', name: 'Lars Pedersen', email: 'lars@clinic.test', role: 'Vet tech' },
+  { id: 'u-7', userId: 'u-7', name: 'Nina Kowalska', email: 'nina@clinic.test', role: 'Nurse' },
+  { id: 'u-8', userId: 'u-8', name: 'Rafael Sousa', email: 'rafael@clinic.test', role: 'Vet' },
+  {
+    id: 'u-9',
+    userId: 'u-9',
+    name: 'Grace Chen',
+    email: 'grace@clinic.test',
+    role: 'Practice mgr',
+  },
+  { id: 'u-10', userId: 'u-10', name: 'Otto Brenner', email: 'otto@clinic.test', role: 'Vet' },
+];
+
+const SidebarFrame = (Story: React.ComponentType) => (
+  <div className="w-[340px] border-r border-[var(--hairline)] bg-[var(--screen)] pb-6">
+    <Story />
+  </div>
+);
+
+/**
+ * The header is fully controlled - every value it draws comes back in as a prop -
+ * so the stories that need a state change to be *visible* (switching audience,
+ * pressing Archived, typing into the teammate field) drive it through this
+ * wrapper. The callbacks still fire on the spies underneath, so a play function
+ * can assert both the call and the redraw.
+ */
+type HeaderProps = ComponentProps<typeof ChatSidebarHeader>;
+
+const ControlledHeader = (props: HeaderProps) => {
+  const [scope, setScope] = useState(props.scope);
+  const [archived, setArchived] = useState(props.showArchived);
+  const [directSearch, setDirectSearch] = useState(props.directSearch);
+  const [focused, setFocused] = useState(props.searchFocused);
+
+  return (
+    <ChatSidebarHeader
+      {...props}
+      scope={scope}
+      onScopeChange={(next) => {
+        props.onScopeChange?.(next);
+        setScope(next);
+      }}
+      showArchived={archived}
+      onToggleArchived={() => {
+        props.onToggleArchived();
+        setArchived((value) => !value);
+      }}
+      directSearch={directSearch}
+      onDirectSearchChange={(value) => {
+        props.onDirectSearchChange(value);
+        setDirectSearch(value);
+      }}
+      searchFocused={focused}
+      onDirectSearchFocus={() => {
+        props.onDirectSearchFocus();
+        setFocused(true);
+      }}
+      onDirectSearchBlur={() => {
+        props.onDirectSearchBlur();
+        setFocused(false);
+      }}
+    />
+  );
+};
+
+/**
+ * The teammate rows are `<button>`s inside the directory `<ul>`, so this counts them.
+ * The `<ul>` is unambiguous: nothing else in this header is a list - the audience
+ * pill is a `role="group"` of buttons.
+ */
+const directoryList = (canvasElement: HTMLElement) =>
+  canvasElement.querySelector('ul') as HTMLElement;
+
+const directoryRows = (canvasElement: HTMLElement) =>
+  within(directoryList(canvasElement)).queryAllByRole('button');
+
+const meta = {
+  title: 'Chat/ChatSidebarHeader',
+  component: ChatSidebarHeader,
+  decorators: [SidebarFrame],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Everything above the conversation list in the chat sidebar: the "Chat" heading and the ' +
+          'Archived toggle, the Clients / Team / Groups audience pill, the conversation search ' +
+          'field, and - for two of the three audiences - a second block that has no equivalent in ' +
+          'the third.\n\n' +
+          'It had never been drawn because of where it is mounted. `ChatContainer` passes it as ' +
+          "the `channelListHeader` of Stream's `ChannelList`, which only renders once a real " +
+          '`StreamChat` client has connected with a real token, so seeing this header used to mean ' +
+          'booting the whole chat stack. It is exported from `ChatContainer` for these stories; ' +
+          'nothing else imports it.\n\n' +
+          'The audience-specific block is the part worth reviewing. Under **Team** it is a ' +
+          'cross-clinic CTA (itself gated on `crossOrgEnabled`), a teammate field, and a live ' +
+          'directory list; under **Groups** it collapses to a single Create Group pill; under ' +
+          '**Clients** the block is not rendered at all, so the sidebar is around 150px shorter. ' +
+          'Three genuinely different headers behind one component.\n\n' +
+          'The directory list is gated twice over, which is why a static capture of the Team scope ' +
+          'shows an empty box: rows render only while `searchFocused || directListHover`, and the ' +
+          'blur handler in `ChatContainer` runs on a 120ms timer so that moving the pointer from ' +
+          'the field into the list does not empty it mid-reach. On top of that the results are ' +
+          'filtered against name + email + role concatenated, capped at eight, and the signed-in ' +
+          'user is removed - all three are exercised below.\n\n' +
+          'One thing a reviewer should look at rather than take on trust: the rows are `<button>` ' +
+          'elements parented directly by the `<ul>`, with no `<li>` between them, and the loading ' +
+          'and empty strings are bare `<span>`s in the same place. The a11y panel flags it on ' +
+          'every Team story here.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    showArchived: false,
+    onToggleArchived: fn(),
+    scope: 'clients',
+    onScopeChange: fn(),
+    searchTerm: '',
+    onSearchTermChange: fn(),
+    crossOrgEnabled: true,
+    onOpenNetworkDirectory: fn(),
+    directSearch: '',
+    onDirectSearchChange: fn(),
+    onDirectSearchFocus: fn(),
+    onDirectSearchBlur: fn(),
+    onDirectListMouseEnter: fn(),
+    onDirectListMouseLeave: fn(),
+    searchFocused: false,
+    directListHover: false,
+    orgUsersLoading: false,
+    orgUsers: ORG_USERS,
+    currentUserId: 'u-me',
+    creatingChat: false,
+    onStartDirectChat: fn(),
+    onOpenCreateGroupModal: fn(),
+  },
+} satisfies Meta<typeof ChatSidebarHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Clients: Story = {
+  name: 'Clients (no second block)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Exact string, not /chat/i: the preview decorator injects an sr-only
+    // "Chat/ChatSidebarHeader - Clients (no second block)" heading into the same
+    // canvas, and a loose regex matches that instead.
+    await expect(canvas.getByRole('heading', { name: 'Chat', level: 2 })).toBeInTheDocument();
+
+    const audience = canvas.getByRole('group', { name: 'Chat audience' });
+    const segments = within(audience).getAllByRole('button');
+    await expect(segments.map((segment) => segment.textContent)).toEqual([
+      'Clients',
+      'Team',
+      'Groups',
+    ]);
+    // The middle tab reads "Team" while the scope value stays `colleagues` -
+    // easy to regress into "Colleagues" when someone renames the value.
+    await expect(segments[0]).toHaveAttribute('aria-pressed', 'true');
+    await expect(segments[1]).toHaveAttribute('aria-pressed', 'false');
+
+    await expect(canvas.getByLabelText('Search conversations')).toHaveAttribute(
+      'placeholder',
+      'Search conversations…'
+    );
+
+    // The audience block genuinely does not exist here, rather than being hidden.
+    await expect(canvas.queryByLabelText('Search teammate to chat')).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Create Group' })).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByRole('button', { name: 'Message a colleague at another clinic' })
+    ).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The shortest of the three headers, and the one the sidebar opens on. Heading, Archived ' +
+          'toggle, audience pill, search field, and the list starts immediately under the hairline.',
+      },
+    },
+  },
+};
+
+export const TeamResting: Story = {
+  name: 'Team (list not yet revealed)',
+  args: { scope: 'colleagues' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole('button', { name: 'Message a colleague at another clinic' })
+    ).toBeInTheDocument();
+    await expect(canvas.getByLabelText('Search teammate to chat')).toHaveValue('');
+    // Ten teammates are loaded and none of them is drawn: the list is gated on
+    // focus or hover, not on having data. This is the state a screenshot of the
+    // Team scope actually captures.
+    await expect(directoryRows(canvasElement)).toHaveLength(0);
+
+    /* And the box holding them is not collapsed - it is the full `max-h-40`
+       scroller, rendered and empty, which is exactly why the resting Team scope
+       reads as a broken list rather than as a prompt. */
+    const list = directoryList(canvasElement);
+    await expect(list.children).toHaveLength(0);
+    await expect(getComputedStyle(list).maxHeight).toBe('160px');
+    await expect(getComputedStyle(list).overflowY).toBe('auto');
+    // Nothing tells the reader what would fill it: no placeholder copy anywhere
+    // in the block.
+    await expect(canvas.queryByText('Loading teammates…')).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByText('No teammates found. Adjust your search.')
+    ).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Team scope at rest. `orgUsers` is fully populated here - the empty `max-h-40` box under ' +
+          'the field is the double gate, not a loading state and not an empty directory.',
+      },
+    },
+  },
+};
+
+export const TeamDirectory: Story = {
+  name: 'Team directory (focused, capped at 8)',
+  args: { scope: 'colleagues', searchFocused: true },
+  play: async ({ canvasElement }) => {
+    const rows = directoryRows(canvasElement);
+    // Eleven fixtures, minus the signed-in user, capped at eight.
+    await expect(rows).toHaveLength(8);
+    // Monogram, name and email all come from the same record.
+    await expect(rows[0]).toHaveTextContent('AH');
+    await expect(rows[0]).toHaveTextContent('Amelia Hart');
+    await expect(rows[0]).toHaveTextContent('amelia@clinic.test');
+
+    /* Self-exclusion, proved positionally: Yara Osman is the SECOND fixture, so
+       she would be row two here. Row two is Tomas instead, and her name is
+       nowhere in the list. */
+    const canvas = within(canvasElement);
+    await expect(rows[1]).toHaveTextContent('Tomas Vidal');
+    await expect(canvas.queryByText('Yara Osman')).not.toBeInTheDocument();
+
+    // The cap, at its boundary: Rafael is the eighth kept, Grace the ninth dropped.
+    await expect(rows[7]).toHaveTextContent('Rafael Sousa');
+    await expect(canvas.queryByText('Grace Chen')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Otto Brenner')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The revealed directory: 56px rows on `--screen`, monogram avatar, name over email, ' +
+          'inside a `max-h-40` scroller - so at eight rows roughly two and a half are visible and ' +
+          'the rest are scrolled. Every row is a start-a-chat button, not a link.',
+      },
+    },
+  },
+};
+
+export const TeamDirectoryLoading: Story = {
+  name: 'Team directory (loading)',
+  args: { scope: 'colleagues', searchFocused: true, orgUsersLoading: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const line = canvas.getByText('Loading teammates…');
+    // Loading wins over the data: `orgUsers` is still the full eleven here, and
+    // the field is focused, so both other gates are open.
+    await expect(directoryRows(canvasElement)).toHaveLength(0);
+
+    /* The line is the list's only child, and it is a bare `<span>` sitting where
+       the rows go - no skeleton, no spinner element - so the whole loading state
+       is one 12px grey line inside a 160px box. */
+    const list = directoryList(canvasElement);
+    await expect(list.children).toHaveLength(1);
+    await expect(list.children[0]).toBe(line);
+    await expect(line.tagName).toBe('SPAN');
+    await expect(getComputedStyle(list).maxHeight).toBe('160px');
+    await expect(canvasElement.querySelectorAll('svg[class*="animate"]')).toHaveLength(0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'While `fetchOrgUsers` is in flight. The string is a bare `caption-1` span with no ' +
+          'spinner and no skeleton row, so at sidebar width it reads as a single grey line where ' +
+          'the list will be.',
+      },
+    },
+  },
+};
+
+export const TeamNoMatches: Story = {
+  name: 'Team directory (no matches)',
+  args: { scope: 'colleagues', searchFocused: true, directSearch: 'zzz' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const line = canvas.getByText('No teammates found. Adjust your search.');
+    await expect(directoryRows(canvasElement)).toHaveLength(0);
+
+    // Only child of the list, and the query that produced it is still in the
+    // field - the copy tells the reader to adjust it, so it had better be there.
+    const list = directoryList(canvasElement);
+    await expect(list.children).toHaveLength(1);
+    await expect(list.children[0]).toBe(line);
+    await expect(canvas.getByLabelText('Search teammate to chat')).toHaveValue('zzz');
+    // The cross-clinic CTA above is untouched, which matters: "no teammates
+    // found" is the moment that button is most relevant and it does not move.
+    await expect(
+      canvas.getByRole('button', { name: 'Message a colleague at another clinic' })
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`hasNoDirectMatches` needs four conditions at once - not loading, focused, a non-blank ' +
+          'query and zero results - so this line is unreachable by clicking around with an empty ' +
+          'field, and equally unreachable while the fetch is still running.',
+      },
+    },
+  },
+};
+
+export const TeamWithoutCrossOrg: Story = {
+  name: 'Team without cross-clinic messaging',
+  args: { scope: 'colleagues', searchFocused: true, crossOrgEnabled: false },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.queryByRole('button', { name: 'Message a colleague at another clinic' })
+    ).not.toBeInTheDocument();
+    // The rest of the block is untouched, so this is a height change, not a mode.
+    await expect(canvas.getByLabelText('Search teammate to chat')).toBeInTheDocument();
+    await expect(directoryRows(canvasElement)).toHaveLength(8);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'What a practice with the cross-clinic feature off sees. The globe CTA is dropped ' +
+          'entirely rather than disabled, which lifts the teammate field to the top of the block - ' +
+          'worth seeing beside the enabled Team stories, since that is the layout most practices get.',
+      },
+    },
+  },
+};
+
+export const Groups: Story = {
+  name: 'Groups (Create Group only)',
+  args: { scope: 'groups' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const pill = canvas.getByRole('button', { name: 'Create Group' });
+    // The teammate directory belongs to the Team scope only - group membership
+    // is picked inside GroupModal instead.
+    await expect(canvas.queryByLabelText('Search teammate to chat')).not.toBeInTheDocument();
+    await expect(canvasElement.querySelector('ul')).toBeNull();
+    await expect(
+      canvas.queryByRole('button', { name: 'Message a colleague at another clinic' })
+    ).not.toBeInTheDocument();
+
+    /* The block holds exactly one control, and that control is `w-fit` rather
+       than stretched - the difference between the design's left-aligned pill and
+       a full-bleed bar, and the reason this header is ~60px instead of ~200. */
+    const block = pill.parentElement as HTMLElement;
+    await expect(within(block).getAllByRole('button')).toHaveLength(1);
+    await expect(pill.getBoundingClientRect().width).toBeLessThan(
+      block.getBoundingClientRect().width * 0.6
+    );
+    await expect(pill.textContent).toBe('Create Group');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The third header. The same bordered block as Team holds one `w-fit` `--cta` pill, so ' +
+          'the block is about 60px tall instead of 200 and the conversation list starts much higher.',
+      },
+    },
+  },
+};
+
+export const ArchivedOn: Story = {
+  name: 'Archived filter on',
+  args: { showArchived: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const toggle = canvas.getByRole('button', { name: 'Archived' });
+    await expect(toggle).toHaveAttribute('aria-pressed', 'true');
+
+    /* The pressed treatment is a real repaint, not just an aria flip: a filled
+       `--blue-soft` ground where the resting control is transparent, and a border
+       that no longer matches the hairline the search pill uses. Both are read off
+       the live element inside `waitFor`, because the control is
+       `transition-colors` and one synchronous read can land mid-interpolation. */
+    const searchPill = canvas.getByLabelText('Search conversations').parentElement as HTMLElement;
+    await waitFor(() => {
+      const pressed = getComputedStyle(toggle);
+      expect(pressed.backgroundColor).not.toBe('rgba(0, 0, 0, 0)');
+      expect(pressed.borderTopColor).not.toBe(getComputedStyle(searchPill).borderTopColor);
+    });
+    // The label never changes with the state, so `aria-pressed` really is the
+    // whole announcement - and the glyph beside it is decorative.
+    await expect(toggle.textContent).toBe('Archived');
+    await expect(toggle.querySelector('svg')).not.toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The pressed toggle: `--blue` border, `--blue-soft` fill, `--blue-text` label. It is the ' +
+          'only control in the header that changes which conversations the list below queries, and ' +
+          'the only signal that the list is showing archived threads.',
+      },
+    },
+  },
+};
+
+export const ArchivedTogglesLive: Story = {
+  name: 'Archived toggles (live)',
+  render: (args) => <ControlledHeader {...args} />,
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const toggle = canvas.getByRole('button', { name: 'Archived' });
+    const resting = getComputedStyle(toggle).backgroundColor;
+    await expect(toggle).toHaveAttribute('aria-pressed', 'false');
+
+    await userEvent.click(toggle);
+
+    await expect(args.onToggleArchived).toHaveBeenCalled();
+    await expect(toggle).toHaveAttribute('aria-pressed', 'true');
+    // Read the fill inside waitFor: the button carries `transition-colors`, so a
+    // single synchronous read lands on an interpolated value between the
+    // transparent resting state and `--blue-soft`.
+    await waitFor(() => {
+      expect(getComputedStyle(toggle).backgroundColor).not.toBe(resting);
+    });
+    // The label does not change with the state, so aria-pressed is the whole
+    // announcement a screen reader gets.
+    await expect(toggle).toHaveTextContent('Archived');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The transition itself, driven through a wrapper that owns the state the way ' +
+          '`ChatContainer` does. Both the resting and pressed fills are read off the live element, ' +
+          'so a token rename that flattened one into the other would fail here rather than merely ' +
+          'look wrong.',
+      },
+    },
+  },
+};
+
+export const SwitchingAudience: Story = {
+  name: 'Switching audience reveals the block',
+  render: (args) => <ControlledHeader {...args} />,
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const audience = canvas.getByRole('group', { name: 'Chat audience' });
+    const [clients, team, groups] = within(audience).getAllByRole('button');
+
+    await expect(canvas.queryByLabelText('Search teammate to chat')).not.toBeInTheDocument();
+
+    await userEvent.click(team);
+    await expect(args.onScopeChange).toHaveBeenCalledWith('colleagues');
+
+    // The point of the switch: a block that did not exist now does.
+    expect(await canvas.findByLabelText('Search teammate to chat')).toBeInTheDocument();
+    await expect(team).toHaveAttribute('aria-pressed', 'true');
+    await expect(clients).toHaveAttribute('aria-pressed', 'false');
+    // The raised active segment is 700 against 600 on the others; weight is not
+    // transitioned, so this reads cleanly straight after the click.
+    await expect(getComputedStyle(team).fontWeight).toBe('700');
+    await expect(getComputedStyle(clients).fontWeight).toBe('600');
+
+    await userEvent.click(groups);
+    expect(await canvas.findByRole('button', { name: 'Create Group' })).toBeInTheDocument();
+    await expect(canvas.queryByLabelText('Search teammate to chat')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Clients to Team to Groups in one pass. Each step swaps the whole second block, so the ' +
+          'sidebar header changes height twice - which is the thing to watch, because the ' +
+          'conversation list below it is a scroller sized by whatever is left.',
+      },
+    },
+  },
+};
+
+export const TypingFiltersTheDirectory: Story = {
+  name: 'Typing filters the directory',
+  args: { scope: 'colleagues' },
+  render: (args) => <ControlledHeader {...args} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const field = canvas.getByLabelText('Search teammate to chat');
+
+    // Focusing is what reveals the list at all.
+    await userEvent.click(field);
+    await expect(directoryRows(canvasElement)).toHaveLength(8);
+
+    // "Radiologist" is a role, not a name: the filter concatenates
+    // name + email + role, so a role query has to match.
+    await userEvent.type(field, 'radiolog');
+    await waitFor(() => {
+      expect(directoryRows(canvasElement)).toHaveLength(1);
+    });
+    await expect(directoryRows(canvasElement)[0]).toHaveTextContent('Priya Raghavan');
+
+    await userEvent.clear(field);
+    await userEvent.type(field, 'clinic.test');
+    // Every teammate shares the email domain, so the cap is back in force.
+    await waitFor(() => {
+      expect(directoryRows(canvasElement)).toHaveLength(8);
+    });
+
+    await userEvent.clear(field);
+    await userEvent.type(field, 'qqq');
+    expect(await canvas.findByText('No teammates found. Adjust your search.')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The filter is not a name search. It matches against name, email and role joined ' +
+          'together, so `radiolog` finds Priya through her role and `clinic.test` finds everyone ' +
+          'through their address - and the eight-row cap re-applies on every keystroke, silently, ' +
+          'with nothing in the UI saying that more matched than are shown.',
+      },
+    },
+  },
+};
+
+export const Phone: Story = {
+  name: 'Phone: the ⌘K hint is dropped',
+  // Pinned as a GLOBAL. `parameters.viewport.defaultViewport` was removed in
+  // Storybook 10 and is inert - a story using it renders at full panel width and
+  // proves nothing about the breakpoint below.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('Search conversations');
+    // The hint chip is the input's next sibling inside the search pill.
+    const hint = input.nextElementSibling as HTMLElement;
+    // Exact, not a substring: the chip is a ⌘ glyph plus the single letter K,
+    // and the glyph is an svg that contributes no text.
+    await expect(hint.textContent).toBe('K');
+    // `hidden ... sm:flex` is a viewport query, so this is only true under 640px.
+    await expect(getComputedStyle(hint).display).toBe('none');
+    // Removed from layout, not merely invisible - it takes no width at all.
+    await expect(hint.getBoundingClientRect().width).toBe(0);
+
+    /* Everything above the chip is unchanged at 375px, which is the point: the
+       pill keeps its 38px minimum and the field simply runs to the edge. */
+    const pill = input.parentElement as HTMLElement;
+    await expect(Math.round(pill.getBoundingClientRect().height)).toBeGreaterThanOrEqual(38);
+    await expect(getComputedStyle(input).display).not.toBe('none');
+    await expect(canvas.getByRole('heading', { name: 'Chat', level: 2 })).toBeInTheDocument();
+    // The audience pill survives the breakpoint with all three segments.
+    const audience = canvas.getByRole('group', { name: 'Chat audience' });
+    await expect(
+      within(audience)
+        .getAllByRole('button')
+        .map((segment) => segment.textContent)
+    ).toEqual(['Clients', 'Team', 'Groups']);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'On a phone the ⌘K chip is removed from the search pill, which is correct - there is no ' +
+          'keyboard to press it with - but it is also the only place in the product that advertises ' +
+          'the command palette, so on mobile the palette is undiscoverable rather than merely ' +
+          'unreachable. The pill keeps its 38px height and the field simply runs wider.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/chat/components/ConversationRow.stories.tsx
+++ b/apps/frontend/src/app/features/chat/components/ConversationRow.stories.tsx
@@ -1,0 +1,240 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import { ConversationRow } from './ConversationRow';
+
+const meta = {
+  title: 'Chat/ConversationRow',
+  component: ConversationRow,
+  decorators: [
+    // The kebab menu is absolutely positioned at `top-9` under the row and is
+    // 190px wide, so the row needs both a sidebar-ish width and room below it.
+    (Story) => (
+      <div className="min-h-[340px] w-[320px] p-2">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'One row of the chat sidebar: avatar with presence dot, name, network and mute glyphs, ' +
+          'timestamp, preview line and unread pill, with a triage kebab beside it.\n\n' +
+          'Everything to the right of the ellipsis is a surface no snapshot has held. The menu is ' +
+          'gated on `menuOpen`, and opening it mounts **two** siblings, not one: a ' +
+          '`fixed inset-0 z-10` full-screen transparent button that catches the next click ' +
+          'anywhere on the page, and the `absolute right-0 top-9 z-20 w-[190px]` panel above it. ' +
+          'The stacking is load-bearing - a backdrop at or above `z-20` would swallow every ' +
+          'click meant for the menu, and the menu would look perfect while being completely ' +
+          'inert. That is exactly the class of defect a closed-state snapshot cannot see.\n\n' +
+          'Which rows the panel contains is decided by *which callbacks were passed*, not by a ' +
+          'prop enumerating them: `onArchive` and `onUnarchive` are separate props rendering ' +
+          'separate rows, and mute is chosen by `muted ? onUnmute : onMute`, so an archived, muted ' +
+          'conversation and a live one produce panels with no rows in common. Both are drawn ' +
+          'below.\n\n' +
+          'The kebab trigger is itself conditional on interaction below the `xl` breakpoint: it ' +
+          'is `opacity-0` until `group-hover` (or focus), and only at `xl` does it become the ' +
+          'persistent `--inset` filled circle from the wide desktop frame. At sidebar widths the ' +
+          'resting row genuinely has no visible affordance for any of this.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    name: 'Lena Hartmann',
+    preview: 'Poppy is doing much better today, thank you',
+    time: '09:41',
+    onClick: fn(),
+    onArchive: fn(),
+    onMute: fn(),
+    onSnooze: fn(),
+  },
+} satisfies Meta<typeof ConversationRow>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Resting',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'What the sidebar shows before anyone touches the row. Below `xl` the kebab is present ' +
+          'in the DOM but at `opacity-0`, so this is a row with an invisible control on it.',
+      },
+    },
+  },
+};
+
+export const KebabRevealedOnHover: Story = {
+  name: 'Kebab revealed (hover)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const kebab = canvas.getByRole('button', { name: 'Conversation actions' });
+    // Resting: present, but transparent - the affordance only exists on hover
+    // below xl, which is why it never appears in a static capture.
+    await expect(kebab).toHaveClass('opacity-0');
+    await expect(kebab).toHaveClass('group-hover:opacity-100');
+    await userEvent.hover(kebab);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Hovering the row lifts the kebab to full opacity via the parent `group`. Focus does the ' +
+          'same through `focus-visible:opacity-100`, so keyboard users are not locked out of the ' +
+          'triage actions.',
+      },
+    },
+  },
+};
+
+export const MenuOpen: Story = {
+  name: 'Kebab menu open',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Conversation actions' }));
+
+    // Assert the panel has its rows. A check that the trigger merely toggled
+    // would pass on an empty 190px card, which is how a dropped menu survives.
+    const archive = await canvas.findByRole('button', { name: 'Archive' });
+    await expect(archive).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Mute' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Snooze · 1 hour' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Snooze · 1 day' })).toBeInTheDocument();
+
+    // The click-catcher and the stacking that makes the menu usable.
+    const backdrop = canvas.getByRole('button', { name: 'Close menu' });
+    await expect(backdrop).toHaveClass('fixed', 'inset-0', 'z-10');
+    const panel = archive.parentElement as HTMLElement;
+    await expect(panel).toHaveClass('z-20');
+    await expect(panel).toHaveClass('w-[190px]');
+    // Four actions plus the hairline that separates snooze from the rest.
+    await expect(within(panel).getAllByRole('button')).toHaveLength(4);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Archive, Mute, then an `--hairline` rule and the two snooze durations, in a `p-1.5` ' +
+          'card with `rounded-xl` rows. The mute row carries `active`, so it sits on ' +
+          '`bg-chat-surface-soft` while the others are plain until hovered - a selected-looking ' +
+          'row that is not actually a selection.',
+      },
+    },
+  },
+};
+
+export const ArchivedAndMutedMenu: Story = {
+  name: 'Kebab menu open (archived + muted)',
+  args: {
+    muted: true,
+    preview: 'Archived · last message 3 weeks ago',
+    onArchive: undefined,
+    onMute: undefined,
+    onSnooze: undefined,
+    onUnarchive: fn(),
+    onUnmute: fn(),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The muted bell shows on the row itself, before the menu is touched.
+    await expect(canvas.getByLabelText('Muted')).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Conversation actions' }));
+    const unarchive = await canvas.findByRole('button', { name: 'Unarchive' });
+    await expect(unarchive).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Unmute' })).toBeInTheDocument();
+    // The inverse rows are genuinely absent, not disabled.
+    await expect(canvas.queryByRole('button', { name: 'Archive' })).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Mute' })).not.toBeInTheDocument();
+    // Two rows, no snooze block, so the panel is barely a third of its usual height.
+    await expect(
+      within(unarchive.parentElement as HTMLElement).getAllByRole('button')
+    ).toHaveLength(2);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same component with the opposite callbacks: Unarchive and Unmute, no snooze, and no ' +
+          'separator rule. Worth seeing beside the default - the two panels share their chrome and ' +
+          'nothing else, and the short one is where a hard-coded panel height would show up.',
+      },
+    },
+  },
+};
+
+export const NoActions: Story = {
+  name: 'No actions (kebab absent)',
+  args: {
+    onArchive: undefined,
+    onMute: undefined,
+    onSnooze: undefined,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // `hasActions` drops the whole trigger rather than rendering a dead one.
+    await expect(
+      canvas.queryByRole('button', { name: 'Conversation actions' })
+    ).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A read-only row - the directory listings mount it this way. With no triage callbacks ' +
+          'the kebab is not rendered at all, so the row text runs to the full width instead of ' +
+          'reserving a 32px gutter for a control that does nothing.',
+      },
+    },
+  },
+};
+
+export const UnreadActive: Story = {
+  name: 'Unread, active, group',
+  args: {
+    name: 'Ward round · ICU',
+    preview: 'Marisol: bay 3 needs a recheck at 14:00',
+    unread: 4,
+    group: true,
+    active: true,
+    online: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The selected row with unread traffic. The badge is `--blue-strong` rather than `--blue` ' +
+          'on purpose: white on `--blue` is 4.09:1, under AA at 10px, and the stronger tone is ' +
+          '6.48:1. At `xl` the active row also swaps its raised white card for `--surface-soft` ' +
+          'with an `inset 3px 0 0 --blue` left stripe.',
+      },
+    },
+  },
+};
+
+export const NetworkAndApp: Story = {
+  name: 'Across-the-network, via app',
+  args: {
+    name: 'Riverside Veterinary Centre',
+    preview: 'Referral notes attached for Bruno',
+    network: true,
+    viaApp: true,
+    time: 'Tue',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Both provenance glyphs at once, each with its own `aria-label`, competing with the name ' +
+          'for the row. The name is the only flexible element (`min-w-0 flex-1 truncate`); the ' +
+          'glyphs and the timestamp are `shrink-0`, so a long clinic name clips rather than ' +
+          'pushing the time off the row.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/chat/components/GroupModal.stories.tsx
+++ b/apps/frontend/src/app/features/chat/components/GroupModal.stories.tsx
@@ -1,0 +1,461 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+
+import { GroupModal, type OrgUserOption } from './GroupModal';
+
+const ORG_USERS: OrgUserOption[] = [
+  {
+    id: 'u-1',
+    userId: 'u-1',
+    name: 'Ruth Baumann',
+    email: 'ruth@clinic.test',
+    role: 'Veterinarian',
+  },
+  { id: 'u-2', userId: 'u-2', name: 'Ana Okafor', email: 'ana@clinic.test', role: 'Technician' },
+  {
+    id: 'u-3',
+    userId: 'u-3',
+    name: 'Tomás Ferreira',
+    email: 'tomas@clinic.test',
+    role: 'Receptionist',
+  },
+  {
+    id: 'u-4',
+    userId: 'u-4',
+    name: 'Priya Raman',
+    email: 'priya@clinic.test',
+    role: 'Veterinarian',
+  },
+  { id: 'u-5', userId: 'u-5', name: 'Milo Jansen', email: 'milo@clinic.test', role: 'Assistant' },
+  { id: 'me', userId: 'me', name: 'Dr Lena Hartmann', email: 'lena@clinic.test', role: 'Owner' },
+];
+
+/**
+ * `title`, `search` and `members` are controlled by ChatContainer in the app, so the
+ * picker only moves if something holds them. The harness owns those three and forwards
+ * every action to the spies as well, which is what makes add/remove reachable from a
+ * `play` rather than only from a live Stream channel.
+ */
+const Harness = ({
+  open,
+  mode,
+  placeholder,
+  initialTitle,
+  initialMembers,
+  ownerId,
+  currentUserId,
+  busy,
+  orgUsers,
+  orgUsersLoading,
+  onClose,
+  onCreate,
+  onUpdateTitle,
+  onAddMember,
+  onRemoveMember,
+  onDelete,
+}: {
+  open: boolean;
+  mode: 'create' | 'edit';
+  placeholder: string;
+  initialTitle: string;
+  initialMembers: string[];
+  ownerId?: string;
+  currentUserId?: string;
+  busy: boolean;
+  orgUsers: OrgUserOption[];
+  orgUsersLoading: boolean;
+  onClose: () => void;
+  onCreate: (title: string, memberIds: string[]) => Promise<void>;
+  onUpdateTitle: (title: string) => Promise<void>;
+  onAddMember: (userId: string) => Promise<void>;
+  onRemoveMember: (userId: string) => Promise<void>;
+  onDelete: () => Promise<void>;
+}) => {
+  const [title, setTitle] = useState(initialTitle);
+  const [search, setSearch] = useState('');
+  const [members, setMembers] = useState(initialMembers);
+
+  return (
+    <div className="min-h-[640px] bg-[var(--screen)] p-6">
+      <p className="text-[13px] text-[var(--ink-muted)]">
+        Conversation list behind the drawer, so the scrim tint and blur are visible.
+      </p>
+      <GroupModal
+        open={open}
+        mode={mode}
+        title={title}
+        placeholder={placeholder}
+        members={members}
+        ownerId={ownerId}
+        currentUserId={currentUserId}
+        search={search}
+        busy={busy}
+        orgUsers={orgUsers}
+        orgUsersLoading={orgUsersLoading}
+        channel={null}
+        onClose={onClose}
+        onTitleChange={setTitle}
+        onSearchChange={setSearch}
+        onMembersChange={setMembers}
+        onCreate={onCreate}
+        onUpdateTitle={onUpdateTitle}
+        // Edit mode routes through the server callbacks rather than onMembersChange,
+        // so the harness mirrors the optimistic update ChatContainer applies after them.
+        onAddMember={async (userId) => {
+          setMembers((prev) => [...prev, userId]);
+          await onAddMember(userId);
+        }}
+        onRemoveMember={async (userId) => {
+          setMembers((prev) => prev.filter((id) => id !== userId));
+          await onRemoveMember(userId);
+        }}
+        onDelete={onDelete}
+      />
+    </div>
+  );
+};
+
+/** The drawer portals to document.body, so nothing in it is inside `canvasElement`. */
+const panel = () => within(document.body).getByRole('dialog');
+
+const meta = {
+  title: 'Chat/GroupModal',
+  component: Harness,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The create/edit drawer for a group conversation. It is `createPortal`ed to ' +
+          '`document.body` behind a single `open` prop and had no story at all, so none of it had ' +
+          'ever been drawn - not the member rows, not the picker, not the footer.\n\n' +
+          'The reason that matters is that this one component renders four materially different ' +
+          'trees off `mode` and `resolveIsCreator`, and three of them are unreachable without ' +
+          'state a snapshot cannot supply. In create mode there is a title field, a picker and a ' +
+          'stretched "Create Group" primary. In edit mode as the creator the title field gains its ' +
+          'own "Save Title" button, member rows gain an Owner pill and inline Remove links, and the ' +
+          'footer swaps the primary for a full-width `Delete` - the only destructive footer in the ' +
+          'chat feature. In edit mode as anyone else the title field, the picker and the whole ' +
+          'footer are removed and replaced by a single notice card; nothing is merely disabled, so ' +
+          'a regression there silently hands out edit affordances rather than dimming them.\n\n' +
+          'The picker is the part with real logic behind it. `availableUsers` drops the current ' +
+          'user, drops anyone already a member, filters on name + email + role concatenated, and ' +
+          '**breaks at ten** - so a large clinic never renders an eleventh row no matter what is ' +
+          'typed. Its empty state has three different sentences depending on why it is empty, and ' +
+          'only one of them ("All teammates have been added") is reachable by interacting.\n\n' +
+          'The stories below assert the panel holds its rows rather than that `open` flipped: an ' +
+          'empty drawer satisfies the dialog role just as well as a populated one.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    open: true,
+    mode: 'create',
+    placeholder: '',
+    initialTitle: '',
+    initialMembers: [],
+    currentUserId: 'me',
+    busy: false,
+    orgUsers: ORG_USERS,
+    orgUsersLoading: false,
+    onClose: fn(),
+    onCreate: fn(),
+    onUpdateTitle: fn(),
+    onAddMember: fn(),
+    onRemoveMember: fn(),
+    onDelete: fn(),
+  },
+} satisfies Meta<typeof Harness>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const CreateEmpty: Story = {
+  name: 'Create (nothing chosen yet)',
+  play: async () => {
+    const dialog = within(panel());
+    await expect(dialog.getByRole('heading', { name: 'Create group' })).toBeInTheDocument();
+    // The picker must actually be populated - five teammates, with `me` filtered out.
+    const addButtons = dialog.getAllByRole('button', { name: /to group$/ });
+    await expect(addButtons).toHaveLength(5);
+    await expect(dialog.getByText('Members (0)')).toBeInTheDocument();
+    // Create stays blocked until there is both a title and at least one member.
+    await expect(dialog.getByRole('button', { name: 'Create Group' })).toBeDisabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The drawer as it opens from the "+" in the conversation list: an empty title, a zero ' +
+          'member count, and the whole roster in the picker minus the person creating the group.',
+      },
+    },
+  },
+};
+
+export const CreateWithMembers: Story = {
+  name: 'Create (adding members)',
+  play: async () => {
+    const dialog = within(panel());
+    await userEvent.type(dialog.getByRole('textbox', { name: 'Group Title' }), 'Surgery team');
+    await userEvent.click(dialog.getByRole('button', { name: 'Add Ruth Baumann to group' }));
+    await userEvent.click(dialog.getByRole('button', { name: 'Add Ana Okafor to group' }));
+
+    // Chosen teammates move out of the picker and into the member list.
+    await expect(dialog.getByText('Members (2)')).toBeInTheDocument();
+    await expect(dialog.getAllByRole('button', { name: /to group$/ })).toHaveLength(3);
+    // Create mode has no owner, so every member row offers a Remove link.
+    await expect(dialog.getAllByRole('button', { name: /^Remove .* from group$/ })).toHaveLength(2);
+    await expect(dialog.getByRole('button', { name: 'Create Group' })).toBeEnabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A row cannot sit in both lists, so each pick moves it: five available becomes three, and ' +
+          'the Members count and the Create button both follow. This is the state that decides ' +
+          'whether the drawer scrolls, since the two lists grow into the same fixed-height column.',
+      },
+    },
+  },
+};
+
+export const CreateAllTeammatesAdded: Story = {
+  name: 'Create (every teammate added)',
+  args: { initialTitle: 'Whole clinic', initialMembers: ['u-1', 'u-2', 'u-3', 'u-4', 'u-5'] },
+  play: async () => {
+    const dialog = within(panel());
+    // One of three different empty sentences - this is the only one reachable by adding.
+    await expect(dialog.getByText('All teammates have been added.')).toBeInTheDocument();
+    await expect(dialog.queryByRole('button', { name: /to group$/ })).toBeNull();
+    await expect(dialog.getByText('Members (5)')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The picker empties into a sentence rather than collapsing, so the `min-h-30` box holds ' +
+          'its height and the footer does not jump up the drawer.',
+      },
+    },
+  },
+};
+
+export const CreateSearchNoMatch: Story = {
+  name: 'Create (search matches nothing)',
+  play: async () => {
+    const dialog = within(panel());
+    await userEvent.type(dialog.getByRole('textbox', { name: 'Search teammates' }), 'zzz');
+    await expect(dialog.getByText('No teammates match your search.')).toBeInTheDocument();
+    await expect(dialog.queryByRole('button', { name: /to group$/ })).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The second empty sentence. The filter runs over name + email + role joined together, so ' +
+          '"vet" would keep two rows here while "zzz" keeps none - and the copy has to say which of ' +
+          'the two reasons applies.',
+      },
+    },
+  },
+};
+
+export const CreateSearchByRole: Story = {
+  name: 'Create (search hits role, not name)',
+  play: async () => {
+    const dialog = within(panel());
+    await userEvent.type(dialog.getByRole('textbox', { name: 'Search teammates' }), 'veterinarian');
+    // Neither name contains the query - the match came from the role text alone.
+    const rows = dialog.getAllByRole('button', { name: /to group$/ });
+    await expect(rows).toHaveLength(2);
+    await expect(dialog.getByText('Ruth Baumann')).toBeInTheDocument();
+    await expect(dialog.getByText('Priya Raman')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The role is part of the haystack but is never printed on the row, so a search that hits ' +
+          'it leaves a result set with no visible reason for being there. Worth seeing, because it ' +
+          'is the case where the row would want a role line and does not have one.',
+      },
+    },
+  },
+};
+
+export const EditAsCreator: Story = {
+  name: 'Edit as creator',
+  args: {
+    mode: 'edit',
+    placeholder: 'Surgery team',
+    initialTitle: 'Surgery team',
+    initialMembers: ['me', 'u-1', 'u-2'],
+    ownerId: 'me',
+  },
+  play: async () => {
+    const dialog = within(panel());
+    await expect(
+      dialog.getByRole('heading', { name: 'Group chat · Surgery team' })
+    ).toBeInTheDocument();
+    // Edit mode adds a Save Title action the create mode does not have.
+    await expect(dialog.getByRole('button', { name: 'Save Title' })).toBeEnabled();
+    // The owner keeps the pill and loses the Remove link; the other two keep theirs.
+    await expect(dialog.getByText('Owner')).toBeInTheDocument();
+    await expect(dialog.getAllByRole('button', { name: /^Remove .* from group$/ })).toHaveLength(2);
+    await expect(
+      dialog.queryByRole('button', { name: 'Remove Dr Lena Hartmann from group' })
+    ).toBeNull();
+    // The destructive footer replaces the create primary entirely.
+    await expect(dialog.getByRole('button', { name: 'Delete Group' })).toBeInTheDocument();
+    await expect(dialog.queryByRole('button', { name: 'Create Group' })).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The full creator tree, and the only place the Owner pill exists: a soft-blue 9.5px ' +
+          'uppercase chip on a hairline border, deliberately not the solid brand badge. The owner ' +
+          'row has no Remove link at all rather than a disabled one, so a group can never be left ' +
+          'without its creator.',
+      },
+    },
+  },
+};
+
+export const EditRemoveMember: Story = {
+  name: 'Edit (removing a member)',
+  args: {
+    mode: 'edit',
+    placeholder: 'Surgery team',
+    initialTitle: 'Surgery team',
+    initialMembers: ['me', 'u-1', 'u-2'],
+    ownerId: 'me',
+  },
+  play: async ({ args }) => {
+    const dialog = within(panel());
+    await expect(dialog.getByText('Members (3)')).toBeInTheDocument();
+    await userEvent.click(dialog.getByRole('button', { name: 'Remove Ana Okafor from group' }));
+
+    // Edit mode goes through the server callback, not the local members setter.
+    await expect(args.onRemoveMember).toHaveBeenCalledWith('u-2');
+    await waitFor(() => expect(dialog.getByText('Members (2)')).toBeInTheDocument());
+    // The removed teammate returns to the picker.
+    await expect(
+      dialog.getByRole('button', { name: 'Add Ana Okafor to group' })
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Removal is a round trip in edit mode, so the row has to leave the member list and ' +
+          'reappear in the picker below it. The two lists are rendered from the same `orgUsers` ' +
+          'array, which is exactly why a member can only ever be in one of them.',
+      },
+    },
+  },
+};
+
+export const EditAsNonCreator: Story = {
+  name: 'Edit as a non-creator',
+  args: {
+    mode: 'edit',
+    placeholder: 'Surgery team',
+    initialTitle: 'Surgery team',
+    initialMembers: ['u-1', 'u-2', 'me'],
+    ownerId: 'u-1',
+    currentUserId: 'me',
+  },
+  play: async () => {
+    const dialog = within(panel());
+    await expect(
+      dialog.getByText('Only the group creator can modify this group.')
+    ).toBeInTheDocument();
+    // Every write affordance is absent rather than disabled.
+    await expect(dialog.queryByRole('textbox', { name: 'Group Title' })).toBeNull();
+    await expect(dialog.queryByRole('textbox', { name: 'Search teammates' })).toBeNull();
+    await expect(dialog.queryByRole('button', { name: /^Remove .* from group$/ })).toBeNull();
+    await expect(dialog.queryByRole('button', { name: 'Delete Group' })).toBeNull();
+    // The member list itself still renders - this is a read view, not an empty one.
+    await expect(dialog.getByText('Members (3)')).toBeInTheDocument();
+    await expect(dialog.getByText('Ruth Baumann')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The tree a member who did not create the group sees. Nothing here is dimmed: the title ' +
+          'field, the picker and the delete footer are all removed, and a single notice card takes ' +
+          'their place. A dim that still responds to a click would be the defect.',
+      },
+    },
+  },
+};
+
+export const Busy: Story = {
+  name: 'Busy (write in flight)',
+  args: {
+    mode: 'edit',
+    placeholder: 'Surgery team',
+    initialTitle: 'Surgery team',
+    initialMembers: ['me', 'u-1'],
+    ownerId: 'me',
+    busy: true,
+  },
+  play: async () => {
+    const dialog = within(panel());
+    await expect(dialog.getByRole('button', { name: 'Saving...' })).toBeDisabled();
+    await expect(dialog.getByRole('button', { name: 'Deleting...' })).toBeDisabled();
+    // Row-level actions dim rather than vanish, since they come back on settle.
+    await expect(
+      dialog.getByRole('button', { name: 'Remove Ruth Baumann from group' })
+    ).toBeDisabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'One `busy` flag relabels and disables every write in the drawer at once - Save Title, ' +
+          'Delete Group and every per-row Add and Remove. Reachable only while a promise is open, ' +
+          'so it had never been composited with the member rows before.',
+      },
+    },
+  },
+};
+
+export const TeammatesLoading: Story = {
+  name: 'Teammates still loading',
+  args: { orgUsers: [], orgUsersLoading: true },
+  play: async () => {
+    const dialog = within(panel());
+    await expect(dialog.getByText('Loading teammates…')).toBeInTheDocument();
+    await expect(dialog.queryByText('No teammates available. Please wait...')).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The loading branch guards the empty branch, so the drawer never flashes "No teammates ' +
+          'available" while the roster is still in flight.',
+      },
+    },
+  },
+};
+
+export const Closed: Story = {
+  name: 'Closed',
+  args: { open: false },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The drawer still mounts when closed - it slides out on `translate-x-[120%]` rather than ' +
+          'unmounting - so the page behind it is what the reader should see and nothing inside it ' +
+          'should be focusable.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/chat/components/MessageSearch.stories.tsx
+++ b/apps/frontend/src/app/features/chat/components/MessageSearch.stories.tsx
@@ -1,0 +1,601 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import { ChannelActionProvider, ChannelStateProvider } from 'stream-chat-react';
+import type { ChannelActionContextValue, ChannelStateContextValue } from 'stream-chat-react';
+
+import MessageSearch from './MessageSearch';
+
+/**
+ * The component reads exactly two things off Stream: `channel.search` from the
+ * channel state context, and `jumpToMessage` from the channel action context.
+ * Both providers are plain React contexts that stream-chat-react exports, so a
+ * two-key object stands in for the whole SDK - no client, no token, no socket,
+ * and no module mocking (this project has no MSW or `sb.mock` wiring).
+ *
+ * The context values are built once per decorator rather than per render: the
+ * debounced effect lists `channel` in its dependencies, so a fresh object on
+ * every render would restart the 300ms timer forever.
+ */
+type FakeMessage = { id: string; text?: string; user?: { id: string; name?: string } };
+type Search = (query: string) => Promise<{ results: Array<{ message: FakeMessage }> }>;
+
+const withChannel = (search: Search, jumpToMessage: (id: string) => void = fn()) => {
+  const state = { channel: { search } } as unknown as ChannelStateContextValue;
+  const actions = { jumpToMessage } as unknown as ChannelActionContextValue;
+  return (Story: React.ComponentType) => (
+    <ChannelStateProvider value={state}>
+      <ChannelActionProvider value={actions}>
+        <Story />
+      </ChannelActionProvider>
+    </ChannelStateProvider>
+  );
+};
+
+const MATCHES: FakeMessage[] = [
+  {
+    id: 'm-1',
+    text: 'Sutures out on Thursday, and keep the cone on until then.',
+    user: { id: 'u-vet', name: 'Dr. Amelia Hart' },
+  },
+  {
+    id: 'm-2',
+    text: 'Suture line looks clean this morning, no discharge.',
+    user: { id: 'u-nurse', name: 'Tomas Vidal' },
+  },
+  {
+    // No text and no name: the row falls back to the sender id and the literal
+    // word "Attachment", which is the only thing an image-only match can show.
+    id: 'm-3',
+    user: { id: 'u-client' },
+  },
+];
+
+const asResults = (messages: FakeMessage[]) => ({
+  results: messages.map((message) => ({ message })),
+});
+
+const found =
+  (messages: FakeMessage[]): Search =>
+  () =>
+    Promise.resolve(asResults(messages));
+
+const NOTHING_FOUND: Search = () => Promise.resolve(asResults([]));
+const NEVER_RESOLVES: Search = () => new Promise<never>(() => {});
+const FAILS: Search = () => Promise.reject(new Error('search unavailable'));
+
+/** A real wait, for the one assertion that has to prove a state persists. */
+const settle = (ms: number) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+const MANY: FakeMessage[] = Array.from({ length: 12 }, (_, index) => ({
+  id: `bulk-${index}`,
+  text: `Suture check ${index + 1} - wound clean, owner updated by phone.`,
+  user: { id: 'u-vet', name: 'Dr. Amelia Hart' },
+}));
+
+/**
+ * The popover is `absolute right-0 top-11`, anchored to the trigger, so the
+ * frame mimics its real home: pinned to the right of a header row with the
+ * thread underneath it.
+ */
+const HeaderSlot = (Story: React.ComponentType) => (
+  <div className="h-[440px] w-[560px] bg-[var(--screen)]">
+    <div className="flex items-center justify-end border-b border-[var(--hairline)] px-4 py-2.5">
+      <Story />
+    </div>
+  </div>
+);
+
+/** Opens the popover and returns the panel plus its click-catching backdrop. */
+const openSearch = async (canvasElement: HTMLElement) => {
+  const canvas = within(canvasElement);
+  const trigger = canvas.getByRole('button', { name: 'Search messages' });
+  await userEvent.click(trigger);
+  const field = await canvas.findByLabelText('Search in conversation');
+  // input -> the rounded field pill -> the panel itself.
+  const panel = field.parentElement?.parentElement as HTMLElement;
+  return {
+    canvas,
+    trigger,
+    field,
+    panel,
+    backdrop: canvas.getByRole('button', { name: 'Close search' }),
+  };
+};
+
+/** The result rows are the buttons inside the popover's own list. */
+const resultRows = (panel: HTMLElement) =>
+  within(panel.querySelector('ul') as HTMLElement).queryAllByRole('button');
+
+/** Every box here is `border-box` with a 1px border, and `getComputedStyle().width` resolves to
+ *  the CONTENT box - a `w-80` card reads back as 318px, not 320. Measured off the border box,
+ *  which is the number the design names and what the other stories in this repo assert. */
+const widthOf = (el: HTMLElement) => Math.round(el.getBoundingClientRect().width);
+
+const meta = {
+  title: 'Chat/MessageSearch',
+  component: MessageSearch,
+  decorators: [HeaderSlot],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'The in-conversation search popover behind the magnifier in the thread header. Until ' +
+          'someone clicks that 36px circle the component is a single button, and everything ' +
+          'below - the 320px card, the field, all four list states - is unmounted. Nothing had ' +
+          'ever drawn any of it.\n\n' +
+          'The list is a four-way branch and only ever shows one arm: `Searching…` while a request ' +
+          'is out, `No messages found` for a query that matched nothing, the rows themselves, and ' +
+          'a genuinely empty card before anything is typed. Three of the four need a channel ' +
+          'response to reach, which is why each story below supplies its own `channel.search`.\n\n' +
+          'Two behaviours are worth watching. The search is debounced 300ms, so a burst of typing ' +
+          'is one request carrying the trimmed query, not one per keystroke - and the `Searching…` ' +
+          'line appears immediately on the keystroke, during render, well before that request goes ' +
+          'out. And the empty line is not evidence of a search at all: it renders on ' +
+          '`!searching && hasQuery && results.length === 0`, which a rejected request satisfies ' +
+          '(`.catch` sets the results to `[]`) and so does a component with no `channel` to ask. ' +
+          'Three stories below - **No matches**, **Search fails** and **Mounted outside a Stream ' +
+          'channel** - produce the identical sentence from a healthy empty result, a dead API and ' +
+          'a request that never happened. They are the same picture on purpose.\n\n' +
+          'The open popover is two siblings, not one: a `fixed inset-0 z-10` transparent button ' +
+          'covering the whole app to catch the next click anywhere, and the `z-20` card above it. ' +
+          'If those ever level out, the card looks perfect and every row in it stops responding.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof MessageSearch>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Closed: Story = {
+  name: 'Closed (the whole resting surface)',
+  decorators: [withChannel(found(MATCHES))],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'Search messages' });
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    // 36px square, which is the largest of the three circular controls in the
+    // header row - see **Chat/ChannelHeaderBar** for the other two.
+    await expect(widthOf(trigger)).toBe(36);
+    await expect(Math.round(trigger.getBoundingClientRect().height)).toBe(36);
+    // A bordered circle with a glyph and no label, so this is the whole resting
+    // surface: one child, an svg, and no text at all.
+    await expect(trigger.textContent).toBe('');
+    await expect(trigger.querySelector('svg')).not.toBeNull();
+    // Fully round rather than a squircle: the radius is at least half the box.
+    await expect(
+      Number.parseFloat(getComputedStyle(trigger).borderTopLeftRadius)
+    ).toBeGreaterThanOrEqual(18);
+    // Nothing else exists yet - not hidden, not zero-height.
+    await expect(canvas.queryByLabelText('Search in conversation')).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Close search' })).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'What the header actually shows for this component: one bordered circle. The entire ' +
+          'feature is behind it, which is the reason the rest of these stories exist.',
+      },
+    },
+  },
+};
+
+export const Open: Story = {
+  name: 'Open, nothing typed',
+  decorators: [withChannel(found(MATCHES))],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'Search messages' });
+    const restingBorder = getComputedStyle(trigger).borderTopColor;
+
+    const { field, panel, backdrop } = await openSearch(canvasElement);
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    // The card, measured: 320px (`w-80`), positioned off the trigger rather than
+    // laid out in the header flow, and hanging BELOW it (`top-11`) rather than
+    // over it.
+    await expect(widthOf(panel)).toBe(320);
+    await expect(getComputedStyle(panel).position).toBe('absolute');
+    await expect(panel.getBoundingClientRect().top).toBeGreaterThan(
+      trigger.getBoundingClientRect().bottom
+    );
+
+    /* The stacking that makes the card usable at all. The backdrop covers the
+       whole viewport; if it ever sat at or above the card's layer, every row
+       would be unclickable while looking completely normal. */
+    await expect(getComputedStyle(backdrop).position).toBe('fixed');
+    await expect(getComputedStyle(backdrop).zIndex).toBe('10');
+    await expect(getComputedStyle(panel).zIndex).toBe('20');
+
+    // `autoFocus` means the caret is already in the field - no second click.
+    await waitFor(() => {
+      expect(document.activeElement).toBe(field);
+    });
+
+    // Open with no query is a real state: an empty card, not a prompt line.
+    await expect(resultRows(panel)).toHaveLength(0);
+    await expect(canvas.queryByText('Searching…')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('No messages found')).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Clear search' })).not.toBeInTheDocument();
+
+    // The trigger repaints to the active blue treatment. `transition-colors`, so
+    // this is polled rather than read once.
+    await waitFor(() => {
+      expect(getComputedStyle(trigger).borderTopColor).not.toBe(restingBorder);
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The card immediately after opening: a 48px `--field-bg` pill inside a `rounded-2xl` ' +
+          '`--screen` card with a two-layer shadow, and below it nothing at all. Note there is no ' +
+          'empty-state copy here - the card is silent until a query exists, which is a different ' +
+          'choice from the network directory, whose equivalent state carries a prompt line.',
+      },
+    },
+  },
+};
+
+export const Searching: Story = {
+  name: 'Searching (request in flight)',
+  decorators: [withChannel(NEVER_RESOLVES)],
+  play: async ({ canvasElement }) => {
+    const { canvas, field, panel } = await openSearch(canvasElement);
+    await userEvent.type(field, 'suture');
+
+    // Set during render, so it is up before the debounce has even started.
+    expect(await canvas.findByText('Searching…')).toBeInTheDocument();
+    await expect(resultRows(panel)).toHaveLength(0);
+
+    /* And it stays. A `waitFor` would prove nothing here - it resolves on the
+       first passing check - so this waits out the 300ms debounce plus a margin
+       and then reads once. This channel's search never settles, so the line has
+       to still be there. */
+    await settle(600);
+    await expect(canvas.getByText('Searching…')).toBeInTheDocument();
+    await expect(canvas.queryByText('No messages found')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A slow or hanging `channel.search`. In practice this shows for a few hundred ' +
+          'milliseconds and is impossible to catch by hand, so it is worth checking here that the ' +
+          'line is centred and that the card does not jump height when rows replace it.',
+      },
+    },
+  },
+};
+
+const searchCalls: string[] = [];
+const recordingSearch: Search = (query) => {
+  searchCalls.push(query);
+  return Promise.resolve(asResults(MATCHES));
+};
+
+export const Results: Story = {
+  name: 'Results (debounced, trimmed)',
+  decorators: [withChannel(recordingSearch)],
+  play: async ({ canvasElement }) => {
+    searchCalls.length = 0;
+    const { canvas, field, panel } = await openSearch(canvasElement);
+
+    // Trailing space on purpose: the component searches `query.trim()`.
+    await userEvent.type(field, 'suture ');
+
+    await waitFor(() => {
+      expect(resultRows(panel)).toHaveLength(3);
+    });
+
+    const rows = resultRows(panel);
+    // Sender over snippet, both truncated to one line each.
+    await expect(rows[0]).toHaveTextContent('Dr. Amelia Hart');
+    await expect(rows[0]).toHaveTextContent(
+      'Sutures out on Thursday, and keep the cone on until then.'
+    );
+    await expect(rows[1]).toHaveTextContent('Tomas Vidal');
+    // The fallbacks: no display name falls back to the user id, and a message
+    // with no text renders the word "Attachment" rather than an empty row.
+    await expect(rows[2]).toHaveTextContent('u-client');
+    await expect(rows[2]).toHaveTextContent('Attachment');
+
+    // Debounced to a request per pause, not per keystroke, and the query that
+    // travelled is trimmed.
+    await expect(searchCalls.at(-1)).toBe('suture');
+    await expect(searchCalls.length).toBeLessThan('suture '.length);
+
+    // Something to clear now exists, so the clear affordance appears.
+    await expect(canvas.getByRole('button', { name: 'Clear search' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Three matches. Each row is a `rounded-xl` button with a 13px sender line over a 12px ' +
+          'snippet, both `truncate` - so a long message shows its first line only and there is no ' +
+          'highlight of the matched term anywhere in the row. The count of requests is asserted ' +
+          'rather than the exact number, because the debounce collapses a burst by timing rather ' +
+          'than by counting.',
+      },
+    },
+  },
+};
+
+export const ManyResults: Story = {
+  name: 'Results overflow the card',
+  decorators: [withChannel(found(MANY))],
+  play: async ({ canvasElement }) => {
+    const { field, panel } = await openSearch(canvasElement);
+    await userEvent.type(field, 'suture');
+
+    await waitFor(() => {
+      expect(resultRows(panel)).toHaveLength(12);
+    });
+
+    const list = panel.querySelector('ul') as HTMLElement;
+    // `max-h-72` = 288px, and twelve rows are taller than that, so the list is
+    // genuinely scrolling rather than the card growing to fit.
+    await expect(getComputedStyle(list).maxHeight).toBe('288px');
+    await expect(getComputedStyle(list).overflowY).toBe('auto');
+    await expect(list.scrollHeight).toBeGreaterThan(list.clientHeight);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Twelve matches against a list capped at 288px. There is no result count and no "showing ' +
+          '10 of N" line, so the only clue that more exist is the scrollbar - which is the thing ' +
+          'to judge here, since the card sits over the message list with a shadow and the boundary ' +
+          'is easy to lose.',
+      },
+    },
+  },
+};
+
+export const NoMatches: Story = {
+  name: 'No matches',
+  decorators: [withChannel(NOTHING_FOUND)],
+  play: async ({ canvasElement }) => {
+    const { canvas, field, panel } = await openSearch(canvasElement);
+    await userEvent.type(field, 'radiograph');
+
+    const line = await canvas.findByText('No messages found');
+    await expect(resultRows(panel)).toHaveLength(0);
+    await expect(canvas.queryByText('Searching…')).not.toBeInTheDocument();
+
+    /* The line replaces the list rather than sitting above an empty one: it is
+       the single `<li>` in the scroller, centred, and the whole card is that one
+       row plus the field. */
+    const list = panel.querySelector('ul') as HTMLElement;
+    await expect(list.children).toHaveLength(1);
+    await expect(line.closest('li')).toBe(list.children[0]);
+    await expect(getComputedStyle(list.children[0] as HTMLElement).textAlign).toBe('center');
+    // The query is still in the field, so the user can edit rather than retype.
+    await expect(field).toHaveValue('radiograph');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A query the channel has nothing for - the honest version of this line. `searching` ' +
+          'gates it, so it never flashes over a request that is still out; but nothing ties it to ' +
+          'a request having happened, which is what **Search fails** and **Mounted outside a ' +
+          'Stream channel** show reaching the same sentence by other routes.',
+      },
+    },
+  },
+};
+
+export const SearchFails: Story = {
+  name: 'Search fails (indistinguishable)',
+  decorators: [withChannel(FAILS)],
+  play: async ({ canvasElement }) => {
+    const { canvas, field, panel } = await openSearch(canvasElement);
+    await userEvent.type(field, 'radiograph');
+
+    // The rejection is swallowed: same copy, same empty list, no error tone and
+    // no retry. Byte-for-byte the NoMatches story above - asserted with the same
+    // three checks so the two stories are comparable line by line.
+    const line = await canvas.findByText('No messages found');
+    await expect(resultRows(panel)).toHaveLength(0);
+    await expect(canvas.queryByRole('alert')).not.toBeInTheDocument();
+
+    const list = panel.querySelector('ul') as HTMLElement;
+    await expect(list.children).toHaveLength(1);
+    await expect(line.closest('li')).toBe(list.children[0]);
+    await expect(line.textContent).toBe('No messages found');
+    await expect(getComputedStyle(list.children[0] as HTMLElement).textAlign).toBe('center');
+    // No retry affordance is offered either. The only control the card grew is
+    // the clear glyph, which is the same one a successful search grows.
+    const controls = within(panel)
+      .getAllByRole('button')
+      .map((button) => button.getAttribute('aria-label'));
+    await expect(controls).toEqual(['Clear search']);
+    await expect(field).toHaveValue('radiograph');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The failure path, drawn beside the empty one so the problem is visible: `.catch` sets ' +
+          'the results to `[]`, so a broken search API tells the user their conversation contains ' +
+          'no matching messages. Compare this story with **No matches** - they are the same ' +
+          'picture, which is the finding.',
+      },
+    },
+  },
+};
+
+const jumped = fn();
+
+export const JumpsToMessage: Story = {
+  name: 'Selecting a result jumps and closes',
+  decorators: [withChannel(found(MATCHES), jumped)],
+  play: async ({ canvasElement }) => {
+    // Module-scope spy, so it is cleared here rather than relying on the per-story
+    // arg reset that only applies to spies passed through `args`.
+    jumped.mockClear();
+    const { canvas, trigger, field, panel } = await openSearch(canvasElement);
+    await userEvent.type(field, 'suture');
+
+    await waitFor(() => {
+      expect(resultRows(panel)).toHaveLength(3);
+    });
+    await userEvent.click(resultRows(panel)[1]);
+
+    // The id of the row that was clicked, not the first match.
+    await expect(jumped).toHaveBeenCalledWith('m-2');
+    // And the popover closes on selection, handing the thread back.
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    await expect(canvas.queryByLabelText('Search in conversation')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The point of the feature. `jumpToMessage` is the channel action that scrolls the ' +
+          'message list to that id and highlights it, so the popover closes in the same tick - ' +
+          'the user is meant to land on the message, not keep the card over it.',
+      },
+    },
+  },
+};
+
+export const ClearsTheQuery: Story = {
+  name: 'Clearing resets the card',
+  decorators: [withChannel(found(MATCHES))],
+  play: async ({ canvasElement }) => {
+    const { canvas, field, panel } = await openSearch(canvasElement);
+    await userEvent.type(field, 'suture');
+    await waitFor(() => {
+      expect(resultRows(panel)).toHaveLength(3);
+    });
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Clear search' }));
+
+    // Back to the open-and-empty state: rows dropped, no empty-result line, and
+    // the clear control removes itself. This reset happens during render via the
+    // compare guard, not in an effect, so there is no frame showing stale rows.
+    await expect(field).toHaveValue('');
+    await expect(resultRows(panel)).toHaveLength(0);
+    await expect(canvas.queryByText('No messages found')).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Clear search' })).not.toBeInTheDocument();
+
+    // Whitespace is not a query either - `trim()` gates both the request and the
+    // empty-result line, so a space bar leaves the card silent.
+    await userEvent.type(field, '   ');
+    await expect(canvas.queryByText('Searching…')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('No messages found')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The clear glyph inside the field pill. It appears only when there is something to ' +
+          'clear, and clearing returns the card to its opened-but-empty form rather than closing ' +
+          'it - so the caret stays put and the next query starts immediately.',
+      },
+    },
+  },
+};
+
+export const BackdropCloses: Story = {
+  name: 'Clicking outside closes it',
+  decorators: [withChannel(found(MATCHES))],
+  play: async ({ canvasElement }) => {
+    const canvasBefore = within(canvasElement);
+    const restingBorder = getComputedStyle(
+      canvasBefore.getByRole('button', { name: 'Search messages' })
+    ).borderTopColor;
+
+    const { canvas, trigger, backdrop } = await openSearch(canvasElement);
+    // It really does cover the app rather than just the card: the backdrop fills
+    // the whole viewport, which is why the first click anywhere is spent closing.
+    // `clientWidth` on the root, not `innerWidth` - a scrollbar would put those
+    // ~15px apart and the assertion would be measuring the wrong box.
+    await expect(widthOf(backdrop)).toBe(document.documentElement.clientWidth);
+
+    await userEvent.click(backdrop);
+
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    await expect(canvas.queryByLabelText('Search in conversation')).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Close search' })).not.toBeInTheDocument();
+    // The header is back to exactly one control, and that control has repainted
+    // to its resting border rather than staying blue. Polled: `transition-colors`.
+    await expect(within(canvasElement).getAllByRole('button')).toHaveLength(1);
+    await waitFor(() => {
+      expect(getComputedStyle(trigger).borderTopColor).toBe(restingBorder);
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The dismiss path. It is a real full-screen `<button aria-label="Close search">` rather ' +
+          'than a document listener, so it is in the tab order and announced - and because it is ' +
+          '`fixed inset-0`, the first click anywhere in the app after opening the popover is spent ' +
+          'closing it. Escape, by contrast, does nothing here.',
+      },
+    },
+  },
+};
+
+export const WithoutAChannel: Story = {
+  name: 'Mounted outside a Stream channel',
+  // Deliberately no `withChannel` decorator: this is the only story with neither
+  // provider, which is what `ChannelHeaderBar` gives it in Storybook.
+  play: async ({ canvasElement }) => {
+    const { canvas, field, panel } = await openSearch(canvasElement);
+    await userEvent.type(field, 'suture');
+
+    /* `useChannelStateContext` returns `{}` after a console warning, so `channel`
+       is undefined and `searchKey` stays null. No request is ever scheduled and
+       `searching` never flips - and the card answers "No messages found" anyway,
+       because that line is gated on `!searching && hasQuery && results.length === 0`
+       and `channel` is not one of those three. It appears on the first keystroke,
+       with nothing having been asked and nothing to ask. */
+    const line = await canvas.findByText('No messages found');
+    await expect(canvas.queryByText('Searching…')).not.toBeInTheDocument();
+    await expect(resultRows(panel)).toHaveLength(0);
+
+    /* And it is stable rather than a frame before a real search: waiting out the
+       300ms debounce plus a margin leaves the same line, because there is no
+       timer. `waitFor` would resolve on the first passing check and prove
+       nothing here. */
+    await settle(500);
+    const list = panel.querySelector('ul') as HTMLElement;
+    await expect(list.children).toHaveLength(1);
+    await expect(line.closest('li')).toBe(list.children[0]);
+
+    /* The chrome is fully alive, which is what makes this silent: the field took
+       the text, the clear glyph appeared because `hasQuery` is true, and the card
+       is the same 320px surface as a real search. */
+    await expect(field).toHaveValue('suture');
+    await expect(canvas.getByRole('button', { name: 'Clear search' })).toBeInTheDocument();
+    await expect(widthOf(panel)).toBe(320);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The degenerate case, and the one that matters for **Chat/ChannelHeaderBar**: that bar ' +
+          'embeds this component, and outside a mounted `Channel` the state context has no ' +
+          '`channel`. The trigger and the card still render and still open - they just never ' +
+          'search.\n\n' +
+          'They still answer, though, and that is the finding. `No messages found` is gated on ' +
+          '`!searching && hasQuery && results.length === 0`; `channel` is not one of those three, ' +
+          'so the line appears on the first keystroke with no request ever scheduled. Same copy ' +
+          'as **No matches**, same copy as **Search fails** - three different causes, one ' +
+          'sentence, and this one does not even have a channel to search. The play function waits ' +
+          'out the debounce to show it is a settled state rather than a frame on the way to one.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/chat/components/NetworkDirectoryModal.stories.tsx
+++ b/apps/frontend/src/app/features/chat/components/NetworkDirectoryModal.stories.tsx
@@ -135,7 +135,7 @@ export const Searching: Story = {
     const canvas = await search(canvasElement, 'lind');
     // Held open by a request that never settles, so the state stays on screen for
     // review instead of flickering past inside the 300ms debounce.
-    await expect(await canvas.findByText('Searching…')).toBeInTheDocument();
+    expect(await canvas.findByText('Searching…')).toBeInTheDocument();
     await expect(canvas.queryByText('No colleagues found')).not.toBeInTheDocument();
   },
   parameters: {
@@ -184,7 +184,7 @@ export const NoResults: Story = {
   beforeEach: stubApi(async () => ({ colleagues: [] })),
   play: async ({ canvasElement }) => {
     const canvas = await search(canvasElement, 'zzz');
-    await expect(await canvas.findByText('No colleagues found')).toBeInTheDocument();
+    expect(await canvas.findByText('No colleagues found')).toBeInTheDocument();
   },
   parameters: {
     docs: {
@@ -259,7 +259,7 @@ export const Cleared: Story = {
   name: 'Query cleared',
   play: async ({ canvasElement }) => {
     const canvas = await search(canvasElement, 'pri');
-    await expect(await canvas.findByRole('button', { name: /Priya Raghavan/ })).toBeInTheDocument();
+    expect(await canvas.findByRole('button', { name: /Priya Raghavan/ })).toBeInTheDocument();
     await userEvent.click(canvas.getByRole('button', { name: 'Clear search' }));
     // Clearing empties the results synchronously rather than waiting on a request,
     // so the prompt line comes back rather than "No colleagues found".

--- a/apps/frontend/src/app/features/chat/components/NetworkDirectoryModal.stories.tsx
+++ b/apps/frontend/src/app/features/chat/components/NetworkDirectoryModal.stories.tsx
@@ -263,9 +263,7 @@ export const Cleared: Story = {
     await userEvent.click(canvas.getByRole('button', { name: 'Clear search' }));
     // Clearing empties the results synchronously rather than waiting on a request,
     // so the prompt line comes back rather than "No colleagues found".
-    await expect(
-      await canvas.findByText('Search for a colleague at another clinic')
-    ).toBeInTheDocument();
+    expect(await canvas.findByText('Search for a colleague at another clinic')).toBeInTheDocument();
     await expect(canvas.queryByText('Priya Raghavan')).not.toBeInTheDocument();
   },
   parameters: {

--- a/apps/frontend/src/app/features/chat/components/NetworkDirectoryModal.stories.tsx
+++ b/apps/frontend/src/app/features/chat/components/NetworkDirectoryModal.stories.tsx
@@ -1,0 +1,282 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+import type { AxiosAdapter, InternalAxiosRequestConfig } from 'axios';
+
+import api from '@/app/services/axios';
+import type { NetworkColleague } from '../services/chatService';
+import { NetworkDirectoryModal } from './NetworkDirectoryModal';
+
+const COLLEAGUES: NetworkColleague[] = [
+  {
+    userId: 'user-1',
+    name: 'Nadia Alvarez',
+    role: 'Orthopaedic surgeon',
+    organisationId: 'org-riverbend',
+    organisationName: 'Riverbend Veterinary',
+  },
+  {
+    userId: 'user-2',
+    name: 'Tomas Lindqvist',
+    role: 'Radiologist',
+    organisationId: 'org-northgate',
+    organisationName: 'Northgate Referrals',
+  },
+  {
+    userId: 'user-3',
+    name: 'Priya Raghavan',
+    role: 'Internal medicine',
+    organisationId: 'org-harbourside',
+    organisationName: 'Harbourside Animal Hospital',
+  },
+];
+
+/**
+ * Both states worth reviewing here live behind `chatService`, which reaches the API
+ * through the shared axios instance. Rather than mocking the service module - which
+ * would need Storybook's module-mocking wiring and a `#mocks` alias this project does
+ * not have - each story swaps that instance's *adapter*, the documented seam axios
+ * exposes for exactly this. `beforeEach` returns the restore, so the real adapter is
+ * back before the next story runs.
+ */
+const stubApi = (handler: (config: InternalAxiosRequestConfig) => Promise<unknown>) => () => {
+  const previous = api.defaults.adapter;
+  const adapter: AxiosAdapter = async (config) => ({
+    data: await handler(config),
+    status: 200,
+    statusText: 'OK',
+    headers: {},
+    config,
+  });
+  api.defaults.adapter = adapter;
+  return () => {
+    api.defaults.adapter = previous;
+  };
+};
+
+const NEVER = () => new Promise<never>(() => {});
+
+const meta = {
+  title: 'Chat/NetworkDirectoryModal',
+  component: NetworkDirectoryModal,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The cross-clinic colleague directory. The chat sidebar mounts it only while ' +
+          '`networkModalOpen` is set, so it has no closed state and nothing had ever drawn it - ' +
+          'and almost everything inside it is gated a second time, on what the network returns.\n\n' +
+          'The list is a four-way branch that never shows two arms at once: `Searching…` while a ' +
+          'request is in flight, `Search for a colleague at another clinic` when the field is ' +
+          'empty, `No colleagues found` for a query with no matches, and the result rows. Only the ' +
+          'second of those is reachable without a response, which is why the other three had never ' +
+          'been rendered anywhere. Each story below drives one of them by swapping the axios ' +
+          'adapter.\n\n' +
+          'A result row is not a static row either. Pressing it sets `starting` to that ' +
+          "colleague's id, which swaps the `--cta` pill's label from `Message` to `Starting…` and " +
+          'disables the row (`disabled:opacity-60`) - a state that exists only while a POST is in ' +
+          'flight. If that POST rejects, a `role="alert"` band appears *between* the search field ' +
+          'and the list, pushing the list down inside a `max-h-80` scroller; it is the only element ' +
+          'that changes the modal height, and it had never been composited with the rows above it.\n\n' +
+          'The shell itself is a `fixed inset-0` `<dialog open>` over a `--scrim` wash, with a ' +
+          'full-bleed transparent "Close directory" button behind the card as the backdrop, a ' +
+          '38px `--field-bg` search pill (not an underlined row) that swaps its hairline for a ' +
+          '`--blue` edge and a 3px glow on focus, and a fixed `--inset` footnote about what network ' +
+          'messages share.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    organisationId: 'org-storybook',
+    onClose: fn(),
+    onStarted: fn(),
+  },
+  beforeEach: stubApi(async () => ({ colleagues: COLLEAGUES })),
+} satisfies Meta<typeof NetworkDirectoryModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Types into the search pill. Each story uses its own query text on purpose: `getData`
+ * de-duplicates in-flight GETs by endpoint + params, so a story that leaves a request
+ * pending would hand that same promise to any later story searching the same term.
+ */
+const search = async (canvasElement: HTMLElement, query: string) => {
+  const canvas = within(canvasElement);
+  await userEvent.type(canvas.getByLabelText('Search colleagues'), query);
+  return canvas;
+};
+
+export const Idle: Story = {
+  name: 'No query yet',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Search for a colleague at another clinic')).toBeInTheDocument();
+    // The clear affordance is gated on there being something to clear.
+    await expect(canvas.queryByRole('button', { name: 'Clear search' })).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'How the modal opens: an autofocused empty field and the prompt line. No request has been ' +
+          'made, so this is the one arm of the list that needs no response to reach.',
+      },
+    },
+  },
+};
+
+export const Searching: Story = {
+  name: 'Searching (request in flight)',
+  beforeEach: stubApi(NEVER),
+  play: async ({ canvasElement }) => {
+    const canvas = await search(canvasElement, 'lind');
+    // Held open by a request that never settles, so the state stays on screen for
+    // review instead of flickering past inside the 300ms debounce.
+    await expect(await canvas.findByText('Searching…')).toBeInTheDocument();
+    await expect(canvas.queryByText('No colleagues found')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`searching` is set the moment the query changes - not when the request leaves - so this ' +
+          'state covers the 300ms debounce as well as the round trip. Nothing else renders while it ' +
+          'holds, which is what stops the previous results flashing under a new query.',
+      },
+    },
+  },
+};
+
+export const Results: Story = {
+  name: 'Results',
+  play: async ({ canvasElement }) => {
+    const canvas = await search(canvasElement, 'ra');
+    const first = await canvas.findByRole('button', { name: /Nadia Alvarez/ });
+    // Assert the rows carry their content, not merely that the list stopped saying
+    // "Searching…" - an empty list would satisfy that on its own.
+    const list = first.closest('ul') as HTMLElement;
+    await expect(within(list).getAllByRole('listitem')).toHaveLength(3);
+    await expect(
+      within(list).getByText('Orthopaedic surgeon · Riverbend Veterinary')
+    ).toBeInTheDocument();
+    await expect(within(list).getByText('Radiologist · Northgate Referrals')).toBeInTheDocument();
+    await expect(within(list).getAllByText('Message')).toHaveLength(3);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Three colleagues at three different practices. The clinic name is the point of the ' +
+          'second line: without it the row is indistinguishable from an in-house colleague, and the ' +
+          'whole reason this modal exists is that these people are not in your organization. The ' +
+          'name truncates and the clinic line truncates independently, so a long practice name ' +
+          'never pushes the `Message` pill off the row.',
+      },
+    },
+  },
+};
+
+export const NoResults: Story = {
+  name: 'No colleagues found',
+  beforeEach: stubApi(async () => ({ colleagues: [] })),
+  play: async ({ canvasElement }) => {
+    const canvas = await search(canvasElement, 'zzz');
+    await expect(await canvas.findByText('No colleagues found')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A query the network cannot match. The empty line sits in the same `px-3 py-6` centred ' +
+          'row as the other two placeholders, so the modal keeps its height as the arms swap.',
+      },
+    },
+  },
+};
+
+export const Starting: Story = {
+  name: 'Starting a conversation',
+  beforeEach: stubApi(async (config) => {
+    if (config.method === 'post') return NEVER();
+    return { colleagues: COLLEAGUES };
+  }),
+  play: async ({ canvasElement }) => {
+    const canvas = await search(canvasElement, 'nad');
+    const row = await canvas.findByRole('button', { name: /Nadia Alvarez/ });
+    await userEvent.click(row);
+    // Only the pressed row changes: the pill relabels and the row disables while the
+    // POST is open, so a second press cannot open two channels.
+    await expect(row).toBeDisabled();
+    await expect(within(row).getByText('Starting…')).toBeInTheDocument();
+    await expect(canvas.getAllByText('Message')).toHaveLength(2);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Held on a POST that never settles. `starting` stores the colleague id rather than a ' +
+          'boolean, which is what keeps the other two rows live and labelled `Message` while this ' +
+          'one waits.',
+      },
+    },
+  },
+};
+
+export const StartFailed: Story = {
+  name: 'Could not start the conversation',
+  beforeEach: stubApi(async (config) => {
+    if (config.method === 'post') throw new Error('network directory unavailable');
+    return { colleagues: COLLEAGUES };
+  }),
+  play: async ({ canvasElement, args }) => {
+    const canvas = await search(canvasElement, 'tom');
+    await userEvent.click(await canvas.findByRole('button', { name: /Tomas Lindqvist/ }));
+    const alert = await canvas.findByRole('alert');
+    await expect(alert).toHaveTextContent('Could not start the conversation. Please try again.');
+    // The modal must stay open and the rows must stay usable - a failed start is
+    // retryable, and dismissing here would lose the query.
+    await expect(args.onClose).not.toHaveBeenCalled();
+    await expect(args.onStarted).not.toHaveBeenCalled();
+    await expect(canvas.getByRole('button', { name: /Tomas Lindqvist/ })).toBeEnabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The only failure surface in the modal, and the only element that changes its height: the ' +
+          'alert band is inserted between the search pill and the `max-h-80` list, so everything ' +
+          'below it shifts down. It is drawn in `--danger-text` on the plain card background rather ' +
+          'than in a tinted panel, which is worth seeing against the rows it sits above.',
+      },
+    },
+  },
+};
+
+export const Cleared: Story = {
+  name: 'Query cleared',
+  play: async ({ canvasElement }) => {
+    const canvas = await search(canvasElement, 'pri');
+    await expect(await canvas.findByRole('button', { name: /Priya Raghavan/ })).toBeInTheDocument();
+    await userEvent.click(canvas.getByRole('button', { name: 'Clear search' }));
+    // Clearing empties the results synchronously rather than waiting on a request,
+    // so the prompt line comes back rather than "No colleagues found".
+    await expect(
+      await canvas.findByText('Search for a colleague at another clinic')
+    ).toBeInTheDocument();
+    await expect(canvas.queryByText('Priya Raghavan')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The clear glyph appears inside the pill only once there is a query. Clearing resets to ' +
+          'the prompt state in the same render - the results are dropped in the derived-state guard ' +
+          'at the top of the component, not in the effect - so no request is fired for an empty ' +
+          'query.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/chat/components/ShareEntityModal.stories.tsx
+++ b/apps/frontend/src/app/features/chat/components/ShareEntityModal.stories.tsx
@@ -1,0 +1,559 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import type { AxiosAdapter, InternalAxiosRequestConfig } from 'axios';
+import type { Appointment, Organisation } from '@yosemite-crew/types';
+
+import api from '@/app/services/axios';
+import type { StoredCompanion } from '@/app/features/companions/pages/Companions/types';
+import { useAppointmentStore } from '@/app/stores/appointmentStore';
+import { useCompanionStore } from '@/app/stores/companionStore';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { ShareEntityModal } from './ShareEntityModal';
+
+const companion = (id: string, name: string, species: string, breed?: string) =>
+  ({
+    id,
+    name,
+    species,
+    breed,
+    organisationId: 'org-sb',
+    parentId: 'parent-1',
+  }) as unknown as StoredCompanion;
+
+const COMPANIONS: Record<string, StoredCompanion> = {
+  'companion-1': companion('companion-1', 'Kiko', 'Dog', 'Border Collie'),
+  'companion-2': companion('companion-2', 'Momo', 'Cat', 'British Shorthair'),
+  // No breed: the subtitle is built from `[species, breed].filter(Boolean)`, so this
+  // row must read "Rabbit" and not "Rabbit · ".
+  'companion-3': companion('companion-3', 'Pip', 'Rabbit'),
+};
+
+const appointment = (id: string, name: string, startTime: string) =>
+  ({
+    id,
+    organisationId: 'org-sb',
+    patient: { id: `c-${id}`, name, species: 'Dog', parent: { id: 'p-1', name: 'Marta Alvarez' } },
+    startTime: new Date(startTime),
+    status: 'UPCOMING',
+  }) as unknown as Appointment;
+
+const APPOINTMENTS: Record<string, Appointment> = {
+  'appt-1': appointment('appt-1', 'Kiko', '2026-03-26T09:15:00.000Z'),
+  'appt-2': appointment('appt-2', 'Momo', '2026-03-27T13:40:00.000Z'),
+};
+
+/**
+ * Seeds the two stores the picker reads, and the timezone the appointment subtitle is
+ * formatted in.
+ *
+ * No loader is involved: `ShareEntityModal` subscribes to `companionsById` and
+ * `appointmentsById` directly and never fetches, so seeding the real stores is the whole
+ * fixture - the component under review is the real one and the mount touches no network.
+ * `formatDateInPreferredTimeZone` reads a localStorage token and falls back to
+ * Europe/Berlin, so the token is cleared for the story and restored afterwards; 09:15Z is
+ * 10:15 in Berlin on 26 March 2026.
+ */
+const seedStores =
+  (
+    companions: Record<string, StoredCompanion> = COMPANIONS,
+    appointments: Record<string, Appointment> = APPOINTMENTS
+  ) =>
+  () => {
+    const previousCompanions = useCompanionStore.getState().companionsById;
+    const previousAppointments = useAppointmentStore.getState().appointmentsById;
+    const tzKey = 'yc_preferred_timezone';
+    const previousTz = window.localStorage.getItem(tzKey);
+    window.localStorage.removeItem(tzKey);
+
+    // The Companion tab is NOT labelled with the literal "Companions": the component
+    // renders `rewrite('Companions')` (ShareEntityModal.tsx:113), and
+    // `getCompanionTerminologyForOrg` resolves that from the org store, falling back to
+    // the `yc_companion_terminology_pending` key when no org is selected. Both inputs are
+    // module-global AND both are persisted to localStorage (`org-store` partializes
+    // `primaryOrgId`/`orgIds`/`orgsById`), so they outlive not just a story but a page
+    // reload: one hospital org left behind by any story anywhere in this Storybook makes
+    // every tab here read "Patients" from then on. That is precisely how the empty story
+    // failed - `getByRole('button', { name: 'Companions' })` found nothing, because the
+    // control said "Patients". Reproduced against the built Storybook by setting the
+    // pending key to PATIENT: the tab flips and the play function throws that exact error.
+    // Pinned at the meta so the file supplies its own premise rather than inheriting one,
+    // which keeps every exact-label assertion below honest instead of accidentally true.
+    // The hospital story overrides this from its own beforeEach, which runs after it.
+    const { primaryOrgId, orgIds, orgsById } = useOrgStore.getState();
+    const previousOrg = { primaryOrgId, orgIds, orgsById };
+    const termKey = 'yc_companion_terminology_pending';
+    const previousTerm = window.localStorage.getItem(termKey);
+    window.localStorage.removeItem(termKey);
+    useOrgStore.setState({ primaryOrgId: null, orgIds: [], orgsById: {} });
+
+    useCompanionStore.setState({ companionsById: companions });
+    useAppointmentStore.setState({ appointmentsById: appointments });
+
+    return () => {
+      useCompanionStore.setState({ companionsById: previousCompanions });
+      useAppointmentStore.setState({ appointmentsById: previousAppointments });
+      useOrgStore.setState(previousOrg);
+      if (previousTerm !== null) window.localStorage.setItem(termKey, previousTerm);
+      if (previousTz !== null) window.localStorage.setItem(tzKey, previousTz);
+    };
+  };
+
+/**
+ * Swaps the shared axios instance's *adapter* rather than mocking `chatService`.
+ *
+ * The service module is imported directly by the component and this project has no
+ * MSW or `sb.mock` wiring, so the adapter - the seam axios documents for exactly this -
+ * is the only stub that does not require new build config. The captured configs are
+ * handed back so a story can assert what was actually posted, not merely that something
+ * was.
+ */
+const stubShare = (handler: (config: InternalAxiosRequestConfig) => Promise<unknown>) => {
+  const posted: InternalAxiosRequestConfig[] = [];
+  const install = () => {
+    const previous = api.defaults.adapter;
+    const adapter: AxiosAdapter = async (config) => {
+      posted.push(config);
+      return {
+        data: await handler(config),
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config,
+      };
+    };
+    api.defaults.adapter = adapter;
+    return () => {
+      posted.length = 0;
+      api.defaults.adapter = previous;
+    };
+  };
+  return { install, posted };
+};
+
+const NEVER = () => new Promise<never>(() => {});
+
+const share = stubShare(async () => ({ id: 'share-1' }));
+const shareHangs = stubShare(NEVER);
+const shareFails = stubShare(() => Promise.reject(new Error('share endpoint unavailable')));
+
+/** Rows are `<li>` inside the picker's single `<ul>`. */
+const rows = (canvasElement: HTMLElement): HTMLElement[] =>
+  within(canvasElement).getAllByRole('listitem');
+
+const meta = {
+  title: 'Chat/ShareEntityModal',
+  component: ShareEntityModal,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The share-from-PIMS picker: choose a companion or an appointment and post it into the ' +
+          'open conversation as a card.\n\n' +
+          '`ChatContainer` mounts it behind `{shareChannelId && ...}`, so it has no closed form ' +
+          'and nothing had ever drawn it. Everything inside it is gated a second time on store ' +
+          'contents, which in the app arrive from whatever the user happened to load before ' +
+          'opening chat - so the empty list, the 50-item cap and the in-flight row were all ' +
+          'unreachable without the right browsing history.\n\n' +
+          'It is two lists behind one search field, and they are not symmetrical. The companion ' +
+          'tab builds its subtitle from `[species, breed]`, so a companion with no breed shows ' +
+          'one word rather than a dangling separator; the appointment tab formats `startTime` ' +
+          'through the preferred timezone and shows nothing when the appointment has no start. ' +
+          'Both are capped at 50 rows **after** filtering, and the search matches title *or* ' +
+          'subtitle - typing a breed is a legitimate way to find a pet.\n\n' +
+          'The per-row press is the state worth reviewing: `sharing` holds the id of the row ' +
+          'being posted, so exactly one row relabels its `--cta` pill to `Sharing…` and disables ' +
+          'itself while the others stay live. On success the modal closes; on failure it is ' +
+          'silent by design - the error is logged and surfaced by the service layer - so the ' +
+          'only visible outcome is the row coming back. That is a state a reviewer should look ' +
+          'at deliberately, because "nothing happened" is what a broken share looks like too.\n\n' +
+          'Only the **Companions** tab label is rewritten to the org’s animal noun, and only ' +
+          'the label - the tab key stays `COMPANION`. "Appointments" is left alone. Both are ' +
+          'asserted in the hospital story below.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    channelId: 'channel-sb',
+    onClose: fn(),
+  },
+  beforeEach: seedStores(),
+} satisfies Meta<typeof ShareEntityModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Companions: Story = {
+  name: 'Companion tab',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Three rows, each with its own subtitle - a list that rendered the names but lost
+    // the species line would still pass a "three rows" check on its own.
+    await expect(rows(canvasElement)).toHaveLength(3);
+    await expect(canvas.getByText('Dog · Border Collie')).toBeInTheDocument();
+    await expect(canvas.getByText('Cat · British Shorthair')).toBeInTheDocument();
+    // No breed, so the separator is absent rather than trailing.
+    await expect(canvas.getByText('Rabbit')).toBeInTheDocument();
+    await expect(canvas.getAllByText('Share')).toHaveLength(3);
+
+    // The selected tab is the `--blue-soft` pill. Polled: the tab carries
+    // `transition-colors`, so a single synchronous read can catch an interpolated value.
+    const selected = canvas.getByRole('button', { name: 'Companions' });
+    const probe = document.createElement('span');
+    probe.style.backgroundColor = 'var(--blue-soft)';
+    selected.append(probe);
+    const expected = getComputedStyle(probe).backgroundColor;
+    probe.remove();
+    await waitFor(() => {
+      expect(getComputedStyle(selected).backgroundColor).toBe(expected);
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'How the picker opens: the companion tab selected, the full companion list, and an ' +
+          'empty search field. The rows are the same avatar-plus-two-lines shape as the ' +
+          'conversation list, which is deliberate - the point of the picker is that it looks ' +
+          'like chat rather than like a PIMS table.',
+      },
+    },
+  },
+};
+
+export const Appointments: Story = {
+  name: 'Appointment tab',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Appointments' }));
+
+    // The tab swaps the list entirely rather than filtering it.
+    await expect(rows(canvasElement)).toHaveLength(2);
+    await expect(canvas.getByText('Mar 26, 10:15 AM')).toBeInTheDocument();
+    await expect(canvas.getByText('Mar 27, 2:40 PM')).toBeInTheDocument();
+    // Companion-only subtitles are gone, and the shared name "Kiko" now belongs to the
+    // appointment row - so the assertion is on the subtitle, not on the name.
+    await expect(canvas.queryByText('Dog · Border Collie')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The second tab. Rows are titled by the patient name and subtitled with the formatted ' +
+          'start time, so two appointments for the same pet are told apart only by that second ' +
+          'line - which is why it is rendered at the same weight as the companion subtitle ' +
+          'rather than as a faint aside.',
+      },
+    },
+  },
+};
+
+export const Search: Story = {
+  name: 'Search matches subtitle too',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // "collie" appears in no title - only in Kiko's breed line. Matching titles alone
+    // would return nothing here, and the picker would look broken to anyone who searches
+    // the way a vet talks.
+    await userEvent.type(canvas.getByLabelText('Search records'), 'collie');
+    await waitFor(() => {
+      expect(rows(canvasElement)).toHaveLength(1);
+    });
+    await expect(canvas.getByText('Kiko')).toBeInTheDocument();
+    await expect(canvas.queryByText('Momo')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The filter is case-insensitive and runs over title **and** subtitle, which for ' +
+          'companions means species and breed and for appointments means the date line. Filtering ' +
+          'happens before the 50-row cap, so a search can reach records the unfiltered list never ' +
+          'showed.',
+      },
+    },
+  },
+};
+
+export const Empty: Story = {
+  name: 'Nothing loaded yet',
+  beforeEach: seedStores({}, {}),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Exactly one list item, and it is the placeholder - not "at least the placeholder",
+    // which would also be true of a list that rendered the line plus stale rows.
+    const items = rows(canvasElement);
+    await expect(items).toHaveLength(1);
+    await expect(items[0].textContent).toBe('Nothing to share here yet');
+    // The placeholder is a list item, so it inherits the list padding - but it is not a
+    // row: there is nothing to press inside the list at all.
+    await expect(within(items[0]).queryAllByRole('button')).toHaveLength(0);
+    // ...and it is centred in its cell rather than sitting left like a row would.
+    await expect(getComputedStyle(items[0]).textAlign).toBe('center');
+    // Both entity-type controls are still offered; the emptiness is per-tab, not a dead
+    // modal. They are plain `<button>`s in a flex row - no `role="tab"`, no
+    // `aria-selected` - so `role: 'button'` is the right query, and the exact NAME is the
+    // only thing distinguishing them. "Companions" is the ORG'S companion noun rather
+    // than a fixed string (the component renders `rewrite('Companions')`); it is exact
+    // here only because the meta fixture pins the terminology to its default. Before that
+    // pin this line asserted a label the component never promised and failed with
+    // "Unable to find an accessible element with the role \"button\" and name
+    // \"Companions\"" whenever an org or a pending choice survived from another story.
+    // "Appointments" is the literal, never rewritten - so the pair also pins the fact
+    // that the rewrite is scoped to one tab.
+    await expect(canvas.getByRole('button', { name: 'Companions' })).toBeEnabled();
+    await expect(canvas.getByRole('button', { name: 'Appointments' })).toBeEnabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'What a user sees if they open the picker before visiting Companions or Appointments - ' +
+          'the stores are populated by those pages, not by chat. The line is centred in the same ' +
+          '`px-3 py-6` cell the search placeholder uses, so the card does not collapse to a ' +
+          'sliver.',
+      },
+    },
+  },
+};
+
+export const CapAtFifty: Story = {
+  name: 'Capped at 50 rows',
+  beforeEach: seedStores(
+    Object.fromEntries(
+      Array.from({ length: 62 }, (_, index) => [
+        `companion-${index}`,
+        companion(`companion-${index}`, `Patient ${String(index).padStart(2, '0')}`, 'Dog'),
+      ])
+    ),
+    {}
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Exactly the cap, not "some rows".
+    await expect(rows(canvasElement)).toHaveLength(50);
+    await expect(canvas.getByText('Patient 00')).toBeInTheDocument();
+    await expect(canvas.getByText('Patient 49')).toBeInTheDocument();
+    await expect(canvas.queryByText('Patient 50')).not.toBeInTheDocument();
+
+    // The cap is not what keeps the card short - the list is its own `max-h-80` scroller,
+    // and 50 rows overflow it. Both have to hold, or the modal grows past the viewport.
+    const list = canvas.getAllByRole('list')[0];
+    await expect(getComputedStyle(list).maxHeight).toBe('320px');
+    await expect(list.scrollHeight).toBeGreaterThan(list.clientHeight);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A clinic with a real caseload loaded. `MAX_ITEMS` truncates silently - there is no ' +
+          '"showing 50 of 62" line - so the search field is the only way to reach the rest, and ' +
+          'this story is the only place that fact is visible.',
+      },
+    },
+  },
+};
+
+export const Sharing: Story = {
+  name: 'Share in flight',
+  beforeEach: shareHangs.install,
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const row = canvas.getByRole('button', { name: /Kiko/ });
+    await userEvent.click(row);
+
+    // `sharing` stores the row id rather than a boolean, so only this row changes.
+    expect(await within(row).findByText('Sharing…')).toBeInTheDocument();
+    await expect(row).toBeDisabled();
+    await expect(canvas.getAllByText('Share')).toHaveLength(2);
+    await expect(canvas.getByRole('button', { name: /Momo/ })).toBeEnabled();
+    // The modal must stay open while the POST is open - closing early would leave the
+    // user unable to tell whether the card was posted.
+    await expect(args.onClose).not.toHaveBeenCalled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Held on a POST that never settles. Two things are worth checking against the resting ' +
+          'list: the pill is the same `--cta` pill with a different label rather than a spinner, ' +
+          'so the row does not change width; and `disabled:opacity-60` fades the whole row, ' +
+          'avatar included, not just the pill.',
+      },
+    },
+  },
+};
+
+export const ShareFails: Story = {
+  name: 'Share failed (silent)',
+  beforeEach: shareFails.install,
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const row = canvas.getByRole('button', { name: /Momo/ });
+    await userEvent.click(row);
+
+    // The catch swallows the error and `finally` clears `sharing`, so the row comes back
+    // to rest and the modal stays open. There is no in-modal error surface at all.
+    await waitFor(() => {
+      expect(row).toBeEnabled();
+    });
+    await expect(within(row).getByText('Share')).toBeInTheDocument();
+    await expect(canvas.queryByRole('alert')).not.toBeInTheDocument();
+    await expect(args.onClose).not.toHaveBeenCalled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The failure path, which looks almost exactly like never having pressed the row. The ' +
+          'component deliberately renders nothing for the error - it is logged and surfaced by ' +
+          'the service layer - so the reviewer question this story exists to raise is whether a ' +
+          'failed share is distinguishable from a mis-click. Compare it with the ' +
+          'NetworkDirectoryModal, which does draw a `role="alert"` band for the same class of ' +
+          'failure.',
+      },
+    },
+  },
+};
+
+export const SharesAndCloses: Story = {
+  name: 'Successful share',
+  beforeEach: share.install,
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: /Pip/ }));
+
+    await waitFor(() => {
+      expect(args.onClose).toHaveBeenCalled();
+    });
+
+    // Assert the payload, not just that a request left: the endpoint stores the snapshot
+    // verbatim and the CARD in the thread is rendered from it, so a dropped subtitle here
+    // is a permanently subtitle-less card in every conversation it was shared into.
+    const request = share.posted.at(-1);
+    await expect(request?.url).toBe('/v1/chat/pms/share');
+    await expect(JSON.parse(String(request?.data))).toEqual({
+      channelId: 'channel-sb',
+      entityType: 'COMPANION',
+      entityId: 'companion-3',
+      title: 'Pip',
+      snapshot: { subtitle: 'Rabbit' },
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The happy path, end to end: press a row, the POST resolves, the modal closes. The ' +
+          'snapshot posted with it is what the shared card in the thread will render forever ' +
+          'after, so it is asserted field by field rather than by counting requests.',
+      },
+    },
+  },
+};
+
+export const HospitalTerminology: Story = {
+  name: 'Tab label at a hospital org',
+  beforeEach: () => {
+    const previous = useOrgStore.getState();
+    useOrgStore.setState({
+      primaryOrgId: 'org-sb-share-hospital',
+      orgIds: ['org-sb-share-hospital'],
+      orgsById: {
+        'org-sb-share-hospital': {
+          _id: 'org-sb-share-hospital',
+          name: 'Storybook Referral Hospital',
+          type: 'HOSPITAL',
+        } as unknown as Organisation,
+      },
+    });
+    return () => {
+      useOrgStore.setState({
+        primaryOrgId: previous.primaryOrgId,
+        orgIds: previous.orgIds,
+        orgsById: previous.orgsById,
+      });
+    };
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Only the companion tab tracks the org noun.
+    await expect(canvas.getByRole('button', { name: 'Patients' })).toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Companions' })).not.toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Appointments' })).toBeInTheDocument();
+    // The tab is still the selected one after the rewrite - the label changes, the state
+    // key ('COMPANION') does not.
+    await expect(rows(canvasElement)).toHaveLength(3);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same picker at an org whose type is `HOSPITAL`. The tab reads "Patients" while the ' +
+          'tab key stays `COMPANION`, which is the whole point of keeping the rewrite in the ' +
+          'label rather than in the state - a rewritten key would silently select neither tab.',
+      },
+    },
+  },
+};
+
+export const Dismissal: Story = {
+  name: 'Dismissal (backdrop and close)',
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    // The scrim is a real full-bleed button behind the card, not a click handler on the
+    // dialog - so it has an accessible name and is reachable by keyboard.
+    await userEvent.click(canvas.getByRole('button', { name: 'Close picker' }));
+    await expect(args.onClose).toHaveBeenCalledTimes(1);
+    await userEvent.click(canvas.getByRole('button', { name: 'Close' }));
+    await expect(args.onClose).toHaveBeenCalledTimes(2);
+    // Neither path unmounts anything on its own: the modal is controlled entirely by the
+    // parent's `shareChannelId`, so it is still on screen here. Asserted on the `open`
+    // ATTRIBUTE, not on the title text - a `<dialog>` that lost `open` stays mounted and
+    // keeps its text, so a text query cannot tell a live modal from a dismissed one.
+    await expect(document.querySelector('dialog[open]')).not.toBeNull();
+    await expect(rows(canvasElement)).toHaveLength(3);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Both ways out. The backdrop is an `absolute inset-0` transparent button *inside* the ' +
+          'dialog and the card sits above it on `z-10`; get that stacking wrong and the card ' +
+          'itself becomes unclickable while looking perfectly fine.',
+      },
+    },
+  },
+};
+
+export const Phone: Story = {
+  name: 'Phone: card fills the width',
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const card = canvas.getByText('Share to chat').closest('div[class*="max-w-"]') as HTMLElement;
+    // Guards the Storybook 10 viewport trap directly: an inert pin renders the story at
+    // the full preview width, and this assertion is the one that would catch it.
+    const viewportWidth = document.documentElement.clientWidth;
+    await expect(viewportWidth).toBeLessThanOrEqual(430);
+    // The dialog's `p-4` is the only inset. The 470px design width is a cap, not a fixed
+    // size, so at phone widths the card is the screen.
+    await expect(card.getBoundingClientRect().width).toBeCloseTo(viewportWidth - 32, 0);
+    // `pt-24` holds the card clear of the status bar and the channel header behind it.
+    await expect(card.getBoundingClientRect().top).toBeCloseTo(96, 0);
+    await expect(rows(canvasElement)).toHaveLength(3);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'At 375px the picker is effectively a full-width sheet pinned 96px down. The rows keep ' +
+          'their 36px avatars and the `Share` pill stays on the row rather than wrapping, which ' +
+          'is the thing to check - the pill is `shrink-0` and the text column is the only part ' +
+          'allowed to give way.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/chat/components/SharedEntityCard.stories.tsx
+++ b/apps/frontend/src/app/features/chat/components/SharedEntityCard.stories.tsx
@@ -1,0 +1,379 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, waitFor, within } from 'storybook/test';
+import type { Organisation } from '@yosemite-crew/types';
+
+import { useOrgStore } from '@/app/stores/orgStore';
+import { SharedEntityCard } from './SharedEntityCard';
+
+/**
+ * The card is the only element in the message list whose geometry is decided by the
+ * *snapshot*, so the frame is a fixed 380px - wide enough for the `xl:w-[340px]` arm
+ * plus a margin, so the value row is measured rather than squeezed.
+ */
+const CardFrame = (Story: React.ComponentType) => (
+  <div data-testid="card-frame" className="w-[380px] bg-[var(--screen-2)] p-5">
+    <Story />
+  </div>
+);
+
+const cardRoot = (canvasElement: HTMLElement): HTMLElement =>
+  within(canvasElement).getByTestId('card-frame').firstElementChild as HTMLElement;
+
+/**
+ * Computed value of a CSS custom property, read the way the browser will paint it.
+ *
+ * Comparing a pill's `backgroundColor` (`rgb(240, 253, 244)`) against the raw token
+ * text (`#f0fdf4`) never matches, so the token is resolved through a throwaway probe -
+ * and the probe is mounted in the SAME subtree as the element under test on purpose.
+ * The `--status-*` set is declared three times in `globals.css`: once at the root,
+ * again for dark, and again inside the PIMS-scoped block. A probe parked on
+ * `document.body` would resolve a different value than the pill beside it and the
+ * assertion would fail for a reason that has nothing to do with the card.
+ */
+const resolveToken = (near: HTMLElement, token: string): string => {
+  const probe = document.createElement('span');
+  probe.style.backgroundColor = `var(${token})`;
+  near.append(probe);
+  const value = getComputedStyle(probe).backgroundColor;
+  probe.remove();
+  return value;
+};
+
+/**
+ * Seeds the org whose type drives the companion noun, and restores whatever was there.
+ *
+ * `useCompanionTerminologyText` reads `orgStore.primaryOrgId` and that org's `type`;
+ * `HOSPITAL` resolves to "patient". The store persists to localStorage, so the previous
+ * state is put back rather than left pointing at a fixture clinic for every later story.
+ */
+const seedOrgType = (type: Organisation['type']) => () => {
+  const previous = useOrgStore.getState();
+  useOrgStore.setState({
+    primaryOrgId: 'org-sb-shared-entity',
+    orgIds: ['org-sb-shared-entity'],
+    orgsById: {
+      'org-sb-shared-entity': {
+        _id: 'org-sb-shared-entity',
+        name: 'Storybook Referral Hospital',
+        type,
+      } as unknown as Organisation,
+    },
+  });
+  return () => {
+    useOrgStore.setState({
+      primaryOrgId: previous.primaryOrgId,
+      orgIds: previous.orgIds,
+      orgsById: previous.orgsById,
+    });
+  };
+};
+
+const meta = {
+  title: 'Chat/SharedEntityCard',
+  component: SharedEntityCard,
+  decorators: [CardFrame],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'A PIMS record shared into a conversation, as it appears inside a message bubble.\n\n' +
+          'Nothing in the app can draw this without a real shared message: `ChatMessage` renders ' +
+          'it only when `message.sharedEntity` is set, and that field is stamped **server-side** ' +
+          'by the `/v1/chat/pms/share` endpoint. There is no local path that produces one, so the ' +
+          'card had never been rendered outside a live Stream channel with a completed share - ' +
+          'which is also why nobody had seen the shapes below side by side.\n\n' +
+          'It is two cards, not one. `showValueRow` is `Boolean(amount || deepLink)`, and it does ' +
+          'two things at once: it decides whether the second row exists **and** whether the header ' +
+          'carries the `border-b` hairline. Get it wrong in one place and you either get a rule ' +
+          'under nothing or a two-row card with no seam. `PRESCRIPTION` and `DOCUMENT` have no ' +
+          'entry in `DEEP_LINKS`, so they are the single-row form whenever the snapshot omits an ' +
+          'amount; `COMPANION`, `APPOINTMENT`, `INVOICE` and `FORM` always have a link and so are ' +
+          'always two rows.\n\n' +
+          'Everything after `entityType` is optional and comes from an untyped ' +
+          '`Record<string, unknown>` snapshot. `readString` accepts only non-blank strings, so a ' +
+          'numeric `amount`, a `null` subtitle or a whitespace status all take the same path as ' +
+          'an absent one. The status tone is a lookup with a silent fallback: an unmapped status ' +
+          'still renders a pill, in the `--status-requested-*` (neutral) tokens rather than ' +
+          'nothing, so a backend that starts sending a new status word degrades to grey instead ' +
+          'of crashing.\n\n' +
+          'The `COMPANION` label and its deep-link *label* are the only strings this component ' +
+          "rewrites for the org's animal noun. The href never changes, and the snapshot text is " +
+          'never passed through the rewrite at all - which is what leaves a "Pet parent: …" ' +
+          'subtitle standing under a heading that just became "Patient record". All three are ' +
+          'asserted below.\n\n' +
+          '`mine` is in the props table because the component accepts it. It is never read - an ' +
+          'outgoing shared card is identical to an incoming one, and only the bubble column ' +
+          'around it moves.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    entity: {
+      entityType: 'INVOICE',
+      entityId: 'inv-2043',
+      title: 'Invoice INV-2043',
+      snapshot: {
+        subtitle: 'Marta Alvarez · 12 Mar 2026',
+        amount: '€248.50',
+        status: 'PAID',
+      },
+    },
+  },
+} satisfies Meta<typeof SharedEntityCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Invoice: Story = {
+  name: 'Invoice (both rows, status pill)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const card = cardRoot(canvasElement);
+
+    // The full shape: header rule + value row. Two element children, not one.
+    await expect(card.children).toHaveLength(2);
+    const [header, valueRow] = [...card.children] as HTMLElement[];
+    await expect(getComputedStyle(header).borderBottomWidth).toBe('1px');
+
+    await expect(canvas.getByText('Invoice INV-2043')).toBeInTheDocument();
+    await expect(canvas.getByText('Marta Alvarez · 12 Mar 2026')).toBeInTheDocument();
+
+    // The amount lives in the value row, not the header - a card that put it in the
+    // header would still show the right text to a plain text query.
+    await expect(within(valueRow).getByText('€248.50')).toBeInTheDocument();
+    const link = within(valueRow).getByRole('link', { name: 'View in Finance' });
+    await expect(link).toHaveAttribute('href', '/finance');
+
+    // PAID maps to the completed tone. Resolved through a probe beside the pill so the
+    // comparison holds in dark mode as well as light.
+    const pill = canvas.getByText('PAID');
+    const expected = resolveToken(card, '--status-completed-bg');
+    await waitFor(() => {
+      expect(getComputedStyle(pill).backgroundColor).toBe(expected);
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The complete card: 34px blue-soft glyph, title, subtitle, a status pill, then the ' +
+          'hairline and a value row carrying the tabular amount against a right-aligned deep ' +
+          'link. `PAID` is one of the eight statuses with a tone, so the pill is the shared ' +
+          '`--status-completed-*` set rather than a colour invented here.',
+      },
+    },
+  },
+};
+
+export const AppointmentNoAmount: Story = {
+  name: 'Appointment (link only, no amount)',
+  args: {
+    entity: {
+      entityType: 'APPOINTMENT',
+      entityId: 'appt-88',
+      title: 'Kiko · Post-op recheck',
+      snapshot: { subtitle: 'Thu, 26 Mar, 10:15', status: 'UPCOMING' },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const card = cardRoot(canvasElement);
+    await expect(card.children).toHaveLength(2);
+
+    const valueRow = card.children[1] as HTMLElement;
+    // With no amount the left cell is an EMPTY span, deliberately: it is what holds the
+    // `justify-between` open so the link stays hard right. Drop it and the link slides
+    // to the left edge and the row stops matching the invoice above it.
+    const spacer = valueRow.firstElementChild as HTMLElement;
+    await expect(spacer.tagName).toBe('SPAN');
+    await expect(spacer.textContent).toBe('');
+    await expect(
+      within(valueRow).getByRole('link', { name: 'View in Appointments' })
+    ).toHaveAttribute('href', '/appointments');
+
+    const pill = canvas.getByText('UPCOMING');
+    const expected = resolveToken(card, '--status-upcoming-bg');
+    await waitFor(() => {
+      expect(getComputedStyle(pill).backgroundColor).toBe(expected);
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The common case - almost no shared record carries money. The value row survives on the ' +
+          'deep link alone, and the empty left span is the thing to look at: it is the only ' +
+          'reason this row and the invoice row line their links up at the same x.',
+      },
+    },
+  },
+};
+
+export const PrescriptionSingleRow: Story = {
+  name: 'Prescription (single row, no rule)',
+  args: {
+    entity: {
+      entityType: 'PRESCRIPTION',
+      entityId: 'rx-19',
+      title: 'Meloxicam 1.5 mg/ml',
+      snapshot: { subtitle: '0.4 ml once daily, 5 days' },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const card = cardRoot(canvasElement);
+
+    // No amount and no DEEP_LINKS entry, so `showValueRow` is false: one child, and the
+    // header must lose its bottom rule with it. A hairline over nothing is the bug this
+    // story exists to catch.
+    await expect(card.children).toHaveLength(1);
+    await expect(getComputedStyle(card.children[0] as HTMLElement).borderBottomWidth).toBe('0px');
+
+    await expect(canvas.getByText('Meloxicam 1.5 mg/ml')).toBeInTheDocument();
+    await expect(canvas.getByText('0.4 ml once daily, 5 days')).toBeInTheDocument();
+    await expect(canvas.queryByRole('link')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Prescriptions and documents have no route to deep-link into, so they collapse to the ' +
+          'header alone. The card is roughly half the height of the invoice, which is worth ' +
+          'seeing: the two forms sit in the same message column and a fixed-height bubble would ' +
+          'strand one of them.',
+      },
+    },
+  },
+};
+
+export const UnknownType: Story = {
+  name: 'Unknown type and unmapped status',
+  args: {
+    entity: {
+      entityType: 'LAB_RESULT',
+      entityId: 'lab-7',
+      title: null,
+      snapshot: { subtitle: 'Haematology panel', status: 'Awaiting review', amount: '   ' },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const card = cardRoot(canvasElement);
+
+    // No title -> the generic label is the heading. `LAB_RESULT` is in neither ICONS nor
+    // LABELS, so both fall back rather than rendering an empty heading.
+    await expect(canvas.getByText('Shared item')).toBeInTheDocument();
+    await expect(canvas.getByText('Haematology panel')).toBeInTheDocument();
+
+    // A whitespace-only amount is not an amount: `readString` trims and rejects it, so
+    // there is no deep link either and the card is single-row.
+    await expect(card.children).toHaveLength(1);
+
+    // The status word is unmapped, so the pill paints in the neutral requested tokens
+    // instead of disappearing.
+    const pill = canvas.getByText('Awaiting review');
+    const expected = resolveToken(card, '--status-requested-bg');
+    await waitFor(() => {
+      expect(getComputedStyle(pill).backgroundColor).toBe(expected);
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'What the card does with a payload it does not know: an entity type with no icon, no ' +
+          'label and no route, a status outside the tone table, and an amount that is only ' +
+          'spaces. Every one of those degrades rather than throwing - the reason to draw it is ' +
+          'to confirm the degraded card still reads as a card and not as a broken row.',
+      },
+    },
+  },
+};
+
+export const HospitalTerminology: Story = {
+  name: 'Companion record at a hospital org',
+  beforeEach: seedOrgType('HOSPITAL'),
+  args: {
+    entity: {
+      entityType: 'COMPANION',
+      entityId: 'companion-12',
+      title: null,
+      snapshot: { subtitle: 'Pet parent: Marta Alvarez' },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // COMPANION is the one label that tracks the org's animal noun.
+    await expect(canvas.getByText('Patient record')).toBeInTheDocument();
+    await expect(canvas.queryByText('Companion record')).not.toBeInTheDocument();
+
+    // The snapshot subtitle is NOT passed through `rewrite` - only the label and the
+    // deep-link label are - so server text lands verbatim in the same render whose
+    // heading was just rewritten. Worth pinning: the obvious "fix" of rewriting the
+    // whole card would turn this owner into a "patient parent", and the protected-term
+    // exemption that would have caught it lives in `SessionInitializer`, which is not
+    // mounted here.
+    await expect(canvas.getByText('Pet parent: Marta Alvarez')).toBeInTheDocument();
+
+    // The LABEL is rewritten; the HREF is not. A rewritten route would 404.
+    const link = canvas.getByRole('link', { name: 'View in Patients' });
+    await expect(link).toHaveAttribute('href', '/companions');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same card at an org whose type is `HOSPITAL`, which resolves the companion noun to ' +
+          '"patient". Three things have to be true at once and only one of them is obvious: the ' +
+          'label rewrites, the deep-link label rewrites with it, and the href does not. The ' +
+          'subtitle is the fourth: it comes from the server snapshot and this component never ' +
+          'passes it through `rewrite`, so "Pet parent" stands unchanged one line under a heading ' +
+          'that just became "Patient record". The document-wide rewrite in `SessionInitializer` ' +
+          'is what protects that phrase in the running app, and it is not mounted here - which is ' +
+          'exactly why rewriting the whole card inside the component would be a silent way to ' +
+          'produce a "patient parent".',
+      },
+    },
+  },
+};
+
+export const LongTitle: Story = {
+  name: 'Long title and subtitle',
+  args: {
+    entity: {
+      entityType: 'FORM',
+      entityId: 'form-3',
+      title: 'Pre-anaesthetic consent and owner acknowledgement of surgical risk',
+      snapshot: {
+        subtitle: 'Bartholomew Wigglesworth-Christiansen · awaiting signature since 3 March',
+        status: 'REQUESTED',
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const title = canvas.getByText(
+      'Pre-anaesthetic consent and owner acknowledgement of surgical risk'
+    );
+    // Both text runs are single-line `truncate`. The pill and the glyph are `shrink-0`,
+    // so the title is the only thing that may give way - if it does not, the pill is
+    // pushed out of the card.
+    await expect(getComputedStyle(title).textOverflow).toBe('ellipsis');
+    await expect(title.scrollWidth).toBeGreaterThan(title.clientWidth);
+    await expect(canvas.getByText('REQUESTED')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Form titles are authored by the clinic and routinely run past the card width. The ' +
+          'header is a three-part row - fixed glyph, flexible text column, fixed pill - and the ' +
+          'text column is the only `min-w-0` element in it, which is what lets the ellipsis ' +
+          'happen at all.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/companionHistory/components/AuditTimeline.stories.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/AuditTimeline.stories.tsx
@@ -1,0 +1,591 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, waitFor, within } from 'storybook/test';
+
+import { AuditTimeline } from './CompanionHistoryTimeline';
+import type { AuditActorType, AuditEventType, AuditTrail } from '@/app/features/audit/types/audit';
+
+const ORG_ID = 'org-avenger-park';
+const COMPANION_ID = 'companion-1';
+
+const AUDIT_BASE: AuditTrail = {
+  id: 'audit-base',
+  organisationId: ORG_ID,
+  companionId: COMPANION_ID,
+  eventType: 'APPOINTMENT_CREATED',
+  actorType: 'PMS_USER',
+  actorName: 'Dr. Elena Marsh',
+  entityType: 'APPOINTMENT',
+  entityId: 'appt-1',
+  occurredAt: new Date('2026-03-12T09:42:00.000Z'),
+};
+
+const audit = (over: Partial<AuditTrail>): AuditTrail => ({ ...AUDIT_BASE, ...over });
+
+/**
+ * `AuditActorType` and `AuditEventType` are closed unions, but the component's own
+ * fallbacks exist precisely for values outside them - an actor type a later backend
+ * adds, or a row written before the enum settled. Widening through `string` is what
+ * makes those branches reachable from a story; a direct literal cast is rejected.
+ */
+const asActorType = (value: string): AuditActorType => value as AuditActorType;
+const asEventType = (value: string): AuditEventType => value as AuditEventType;
+
+/**
+ * One booking's worth of trail, in the order the service returned it. The component
+ * does not sort, so this order is the rendered order.
+ */
+const ENTRIES: AuditTrail[] = [
+  audit({
+    id: 'a-1',
+    eventType: 'APPOINTMENT_REQUESTED',
+    actorType: 'PARENT',
+    actorName: 'Nina Alvarez',
+    occurredAt: new Date('2026-03-10T08:15:00.000Z'),
+  }),
+  audit({
+    id: 'a-2',
+    eventType: 'APPOINTMENT_APPROVED',
+    occurredAt: new Date('2026-03-10T09:02:00.000Z'),
+  }),
+  audit({
+    id: 'a-3',
+    eventType: 'APPOINTMENT_CHECKED_IN',
+    occurredAt: new Date('2026-03-12T09:42:00.000Z'),
+  }),
+  audit({
+    id: 'a-4',
+    eventType: 'DOCUMENT_ADDED',
+    entityType: 'DOCUMENT',
+    entityId: 'doc-1',
+    actorType: 'SYSTEM',
+    actorName: null,
+    occurredAt: new Date('2026-03-12T10:06:00.000Z'),
+  }),
+  audit({
+    id: 'a-5',
+    eventType: 'COMPANION_ORG_LINK_APPROVED',
+    entityType: undefined,
+    actorName: 'Tom Reyes',
+    occurredAt: new Date('2026-03-12T10:11:00.000Z'),
+  }),
+];
+
+/** The three-part rail between the timestamp and the card: stub, marker, stub. */
+const stampOf = (item: HTMLElement): HTMLElement => item.children[0] as HTMLElement;
+const railOf = (item: HTMLElement): HTMLElement => item.children[1] as HTMLElement;
+const cardOf = (item: HTMLElement): HTMLElement => item.children[2] as HTMLElement;
+
+/**
+ * `Mar 12, 2026, 09:42 AM` - `formatDateTimeLocal` on an en-US `Intl.DateTimeFormat`.
+ *
+ * Read through `stampTextOf`, which collapses runs of whitespace first. Since ICU 72
+ * the separator before AM/PM is U+202F NARROW NO-BREAK SPACE, not U+0020, so a
+ * pattern written with a literal space fails on every current Chrome for a reason
+ * that has nothing to do with this component. The hour is likewise `1,2` rather than
+ * `2`: `hour: '2-digit'` is advisory under `hour12` and ICU has changed its mind
+ * about padding it before now. What the pattern is really pinning is that the value
+ * went through the formatter at all instead of landing on the `'-'` fallback that
+ * `formatDateTimeLocal` is called with.
+ */
+const STAMP_PATTERN = /^[A-Z][a-z]{2} \d{1,2}, \d{4}, \d{1,2}:\d{2} (AM|PM)$/;
+
+const stampTextOf = (item: HTMLElement): string =>
+  (stampOf(item).textContent ?? '').replaceAll(/\s+/g, ' ').trim();
+
+/**
+ * What the browser actually paints for a design token, resolved in this subtree.
+ *
+ * Comparing a computed `rgb(...)` against the hex in `globals.css` needs a converter
+ * and hard-codes a value that the dark theme overrides anyway; painting a throwaway
+ * span with the token and reading it back gets the live value for whichever theme
+ * the story is rendering in.
+ */
+const paintedColour = (host: HTMLElement, token: string): string => {
+  const probe = document.createElement('span');
+  probe.style.color = `var(${token})`;
+  host.append(probe);
+  const painted = getComputedStyle(probe).color;
+  probe.remove();
+  return painted;
+};
+
+const TRANSPARENT = 'rgba(0, 0, 0, 0)';
+
+const meta = {
+  title: 'Companions/AuditTimeline',
+  component: AuditTimeline,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The Audit trail tab of the companion history timeline. It is reachable only by ' +
+          "picking the last filter pill, and it is the one branch of the timeline's body that " +
+          'renders none of the normal entry machinery - a different data type (`AuditTrail`, not ' +
+          '`HistoryEntry`), a different loader, a different row. So none of it had ever been ' +
+          'drawn: not the rows, not the loading line, not the two empty states.\n\n' +
+          'The layout is a three-column flex row per entry: a fixed **160px** right-aligned ' +
+          'timestamp in `--color-pill-success-text` (the green normally reserved for a completed ' +
+          'status pill), a connector rail, then the card. The rail is assembled from three ' +
+          'separate nodes - a 10px top stub, the dot, and a flexing bottom stub - and the top ' +
+          'stub of the first row and the bottom stub of the last are deliberately left ' +
+          'unpainted, so the line starts and stops at the dots instead of bleeding past them. ' +
+          'That is three index comparisons carried in template strings, which is exactly the kind ' +
+          'of thing that silently inverts, so the stories read the computed background of the ' +
+          'individual stubs rather than trusting the classes.\n\n' +
+          "Three content branches are worth a reviewer's attention. `getAuditActorDisplay` maps " +
+          'only three actor types and falls back to **"System"** for anything else, so an actor ' +
+          'type the backend adds later is silently reported as the system rather than as unknown. ' +
+          'The dot has an inactive grey variant keyed on `eventType` being blank - which is ' +
+          'the same condition that makes `toTitle` return an empty string, so the grey dot only ' +
+          'ever appears next to a card with no heading. The error notice used to ask for a ' +
+          'token that does not exist - `text-error-main` needs `--color-error-main`, which this ' +
+          'design system never defines - so the failure message was painted in ordinary body ' +
+          'ink; it now uses `text-text-error`, and the Error story asserts that red positively.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    loading: false,
+    error: null,
+    entries: ENTRIES,
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-full max-w-[820px] bg-[var(--screen)] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof AuditTimeline>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Audit trail',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const items = canvas.getAllByRole('listitem');
+    expect(items).toHaveLength(5);
+
+    // Titles are `toTitle(eventType)`: underscores to spaces, then sentence case.
+    // Only the first word keeps its capital, so "Appointment checked in".
+    expect(within(items[0]).getByText('Appointment requested')).toBeInTheDocument();
+    expect(within(items[2]).getByText('Appointment checked in')).toBeInTheDocument();
+    expect(within(items[4]).getByText('Companion org link approved')).toBeInTheDocument();
+
+    // All three actor renderings, in the order they appear.
+    expect(within(items[0]).getByText('Updated by: Nina Alvarez • Pet parent')).toBeInTheDocument();
+    expect(
+      within(items[1]).getByText('Updated by: Dr. Elena Marsh • Team member')
+    ).toBeInTheDocument();
+    // No actor name, so the bullet and the name are dropped rather than left dangling.
+    expect(within(items[3]).getByText('Updated by: System')).toBeInTheDocument();
+
+    // The entity chip is conditional, and the last entry has no entityType at all -
+    // so its header row holds the title and nothing else.
+    expect(within(items[0]).getByText('Appointment')).toBeInTheDocument();
+    expect(within(items[3]).getByText('Document')).toBeInTheDocument();
+    expect(cardOf(items[0]).children[0].children).toHaveLength(2);
+    expect(cardOf(items[4]).children[0].children).toHaveLength(1);
+
+    // Every stamp resolved through the formatter rather than hitting the '-' fallback,
+    // and the two same-day entries really do differ in their minutes.
+    for (const item of items) {
+      expect(stampTextOf(item)).toMatch(STAMP_PATTERN);
+    }
+    expect(stampTextOf(items[3])).not.toBe(stampTextOf(items[4]));
+
+    /* Rail continuity. Each rail is exactly three nodes; the first row's TOP stub and
+       the last row's BOTTOM stub are unpainted, every stub in between is not. Colours
+       get read inside waitFor - these tokens land through a transition. */
+    const rails = items.map(railOf);
+    for (const rail of rails) {
+      expect(rail.children).toHaveLength(3);
+    }
+    await waitFor(() => {
+      expect(getComputedStyle(rails[0].children[0]).backgroundColor).toBe(TRANSPARENT);
+      expect(getComputedStyle(rails[1].children[0]).backgroundColor).not.toBe(TRANSPARENT);
+      expect(getComputedStyle(rails[3].children[2]).backgroundColor).not.toBe(TRANSPARENT);
+      expect(getComputedStyle(rails[4].children[2]).backgroundColor).toBe(TRANSPARENT);
+    });
+
+    /* The timestamp is not body ink - it is the completed-status green, which is a
+       deliberate call and the thing to sanity-check against the design. Matched
+       against the resolved token rather than against "different from the card", so a
+       change to some OTHER non-body colour fails here instead of passing. */
+    const green = paintedColour(canvasElement, '--color-pill-success-text');
+    await waitFor(() => {
+      expect(getComputedStyle(stampOf(items[0])).color).toBe(green);
+      expect(getComputedStyle(cardOf(items[0])).color).not.toBe(green);
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'One appointment from request to check-in, plus the document and link events that ' +
+          'landed alongside it. Five rows is enough to show every rail case at once: the bare top ' +
+          'stub on row one, the continuous line through rows two to four, and the bare bottom ' +
+          'stub on row five. Note that the component does not sort - this reads chronologically ' +
+          'only because the service returned it that way.',
+      },
+    },
+  },
+};
+
+export const SingleEntry: Story = {
+  name: 'One entry (no rail)',
+  args: { entries: [ENTRIES[2]] },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const items = canvas.getAllByRole('listitem');
+    expect(items).toHaveLength(1);
+    expect(within(items[0]).getByText('Appointment checked in')).toBeInTheDocument();
+    expect(
+      within(items[0]).getByText('Updated by: Dr. Elena Marsh • Team member')
+    ).toBeInTheDocument();
+
+    /* The only row is both `index === 0` and the last one, so BOTH stubs are
+       unpainted and the dot floats with no line through it. Worth pinning: the two
+       conditions are written independently, and a single-entry trail is the state a
+       freshly linked companion is in. */
+    const rail = railOf(items[0]);
+    expect(rail.children).toHaveLength(3);
+    await waitFor(() => {
+      expect(getComputedStyle(rail.children[0]).backgroundColor).toBe(TRANSPARENT);
+      expect(getComputedStyle(rail.children[2]).backgroundColor).toBe(TRANSPARENT);
+      // The dot itself is still painted, so "no rail" is not "nothing rendered".
+      expect(getComputedStyle(rail.children[1].children[0]).backgroundColor).not.toBe(TRANSPARENT);
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A companion with exactly one recorded event. The rail degenerates to a lone dot, ' +
+          'which is correct but leaves 10px of empty gutter above it and a flexing empty stub ' +
+          'below - so the dot does not sit centred on the card it belongs to.',
+      },
+    },
+  },
+};
+
+export const UnknownActor: Story = {
+  name: 'Actor fallbacks',
+  args: {
+    entries: [
+      audit({
+        id: 'u-1',
+        actorType: asActorType('PRACTICE_MANAGER'),
+        actorName: 'Sam Okoro',
+      }),
+      audit({ id: 'u-2', actorType: undefined, actorName: null }),
+      audit({ id: 'u-3', actorType: 'SYSTEM', actorName: '   ' }),
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const items = canvas.getAllByRole('listitem');
+    expect(items).toHaveLength(3);
+
+    /* An actor type outside the three mapped ones is reported as "System" while the
+       human's name is kept - so a real person's action is attributed to the system.
+       That is the line to look at if the backend ever adds a fourth actor type. */
+    expect(within(items[0]).getByText('Updated by: Sam Okoro • System')).toBeInTheDocument();
+
+    // A missing type and a whitespace-only name both collapse to the bare label, so
+    // "no actor recorded" and "the system did it" are indistinguishable here.
+    expect(canvas.getAllByText('Updated by: System')).toHaveLength(2);
+
+    /* The actor line is the last child of the card in every case, and the rest of the
+       row is untouched by the fallback - same title, same chip. A fallback that had
+       leaked into the heading would still satisfy the three queries above. */
+    for (const item of items) {
+      expect(within(item).getByText('Appointment created')).toBeInTheDocument();
+      expect(within(item).getByText('Appointment')).toBeInTheDocument();
+      expect(cardOf(item).children).toHaveLength(2);
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The three ways the actor line degrades. Only `PMS_USER`, `PARENT` and `SYSTEM` are in ' +
+          "the map; everything else - including `undefined` - takes the `|| 'System'` branch. " +
+          'The first row is the interesting one: it keeps "Sam Okoro" and pairs it with "System", ' +
+          'which reads as a contradiction rather than as an unrecognised role.',
+      },
+    },
+  },
+};
+
+export const BlankEventType: Story = {
+  name: 'Blank event type (inactive dot)',
+  args: {
+    entries: [
+      audit({ id: 'b-1', eventType: 'INVOICE_PAID', entityType: 'INVOICE' }),
+      audit({ id: 'b-2', eventType: asEventType(''), entityType: 'INVOICE' }),
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const items = canvas.getAllByRole('listitem');
+    expect(items).toHaveLength(2);
+    expect(within(items[0]).getByText('Invoice paid')).toBeInTheDocument();
+
+    // Same condition drives both: a blank eventType greys the dot AND empties the
+    // heading, so the grey variant only ever renders beside a headless card.
+    const heading = cardOf(items[1]).children[0].children[0];
+    expect(heading.textContent).toBe('');
+    // The chip is still there, so the card is not empty - just unlabelled. Both rows
+    // keep the same two-row card shape, heading plus actor line.
+    expect(canvas.getAllByText('Invoice')).toHaveLength(2);
+    expect(cardOf(items[1]).children).toHaveLength(2);
+    expect(
+      within(items[1]).getByText('Updated by: Dr. Elena Marsh • Team member')
+    ).toBeInTheDocument();
+
+    const activeRing = railOf(items[0]).children[1];
+    const inactiveRing = railOf(items[1]).children[1];
+    /* Resolved outside the waitFor, like the Error story's probes: `paintedColour`
+       mutates the DOM, and waitFor re-runs its callback from a MutationObserver
+       microtask, so a callback that mutates and THEN throws spins forever without
+       letting the timeout timer fire. Harmless while these four pass; a hang that
+       takes out the whole lane the day one of them does not. */
+    const grey = paintedColour(canvasElement, '--color-neutral-300');
+    await waitFor(() => {
+      // Ring and inner fill both switch from brand blue to neutral-300, and the
+      // inactive pair is the SAME neutral in both places rather than two greys.
+      expect(getComputedStyle(activeRing).borderTopColor).not.toBe(grey);
+      expect(getComputedStyle(inactiveRing).borderTopColor).toBe(grey);
+      expect(getComputedStyle(inactiveRing.children[0]).backgroundColor).toBe(grey);
+      expect(getComputedStyle(activeRing.children[0]).backgroundColor).not.toBe(grey);
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The only render in which the inactive marker exists. `active` is ' +
+          "`String(eventType ?? '').trim().length > 0`, so it is false exactly when `toTitle` " +
+          'also returns an empty string - the grey dot and the blank heading are the same ' +
+          'defect, seen twice. The API types `eventType` as a closed union, so this needs a cast ' +
+          'to reproduce, but a payload from an older writer or a partially migrated row lands ' +
+          'here for real.',
+      },
+    },
+  },
+};
+
+export const Loading: Story = {
+  name: 'Loading',
+  // A non-null error AND a full entry list, both of which lose to `loading`.
+  args: { loading: true, error: 'Audit trail is unavailable for this organisation.' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // A plain text line, not a skeleton and not the shared spinner - so the tab jumps
+    // from one line of type to a full rail with no intermediate shape.
+    const line = canvas.getByText('Loading audit trail…');
+    // The other two branches are genuinely unreachable here, not merely empty.
+    expect(canvas.queryByRole('alert')).toBeNull();
+    expect(canvas.queryAllByRole('listitem')).toHaveLength(0);
+    expect(canvas.queryByText('Audit trail is unavailable for this organisation.')).toBeNull();
+
+    /* The indent the prose below is about, measured rather than asserted from the
+       class list: `px-4 py-8` here against the `px-1 py-8` the overview loader uses,
+       so the two loading lines sit 12px apart when a user switches filter pills. */
+    await waitFor(() => {
+      const style = getComputedStyle(line);
+      expect(style.paddingLeft).toBe('16px');
+      expect(style.paddingTop).toBe('32px');
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`loading` wins over everything, including a non-null `error` and a populated ' +
+          '`entries` - the three branches are checked in order. Compare the vertical rhythm ' +
+          'against the "Loading overview…" line the other filters use: same treatment, ' +
+          'different horizontal padding (`px-4` here, `px-1` there), so the two loaders sit at ' +
+          'different indents when switching tabs.',
+      },
+    },
+  },
+};
+
+export const ErrorState: Story = {
+  name: 'Error',
+  args: { error: 'Audit trail is unavailable for this organisation.', entries: [] },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The error path is the only one that gets an assertive role, so a screen reader
+    // hears the failure without moving focus.
+    const alert = canvas.getByRole('alert');
+    expect(alert).toHaveTextContent('Audit trail is unavailable for this organisation.');
+    expect(canvas.queryAllByRole('listitem')).toHaveLength(0);
+    expect(canvas.queryByText('No records yet')).toBeNull();
+
+    const notice = alert.children[0] as HTMLElement;
+
+    /* Both token probes are resolved BEFORE the waitFor and never inside it.
+       `paintedColour` appends and removes a node, and `waitFor` watches `document`
+       with `{subtree, childList}`, re-running its callback from the
+       MutationObserver - which is a MICROTASK. A callback that mutates and then
+       throws therefore re-queues itself forever without ever yielding to the
+       macrotask queue, so waitFor's own `setTimeout` timeout can never fire: the
+       tab wedges instead of failing, taking the whole test lane with it. That is
+       what timed this story out once the assertion below went stale. Token lookups
+       are static, so hoisting them costs nothing; the live nodes are still read
+       inside the callback, so colours are still polled through their transition. */
+    const errorInk = paintedColour(canvasElement, '--color-text-error');
+    const surface = paintedColour(canvasElement, '--color-neutral-0');
+
+    await waitFor(() => {
+      /* Guard first: colour utilities ARE live on this subtree - the card takes its
+         `bg-neutral-0` fill - so the ink assertions below are findings about the
+         notice itself and not about a stylesheet that never loaded. */
+      expect(getComputedStyle(alert).backgroundColor).toBe(surface);
+
+      /* The failure message is red, and specifically the design system's text-error
+         ink: `--color-text-error`, which resolves to `--danger-text` (#a6271d on the
+         bone screen, #f2938a in dark) rather than the `--color-error` FILL step.
+         Matched against the resolved token rather than "differs from body ink", so a
+         drift to some other non-body colour fails here instead of passing.
+
+         This replaces a pin on a defect that has since been fixed. The branch used to
+         ask for `text-error-main`, a class Tailwind compiled to NOTHING because no
+         `--color-error-main` token exists, so the message inherited ordinary body ink
+         and `role="alert"` was the only - invisible - signal of failure. The previous
+         revision of this story pinned that and left a note to flip to a positive check
+         on the red once it was fixed; `HistoryEmptyState` now uses `text-text-error`,
+         so this is that flip. A repo-wide guard
+         (`src/app/__tests__/ui/tokens/colorUtilityExists.test.ts`) now stops any
+         colour utility naming a non-existent token from shipping again. */
+      expect(getComputedStyle(notice).color).toBe(errorInk);
+      // ...and it is therefore visibly distinct from the container's body ink, which
+      // is the accessibility property the old defect defeated.
+      expect(getComputedStyle(notice).color).not.toBe(getComputedStyle(alert).color);
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The failure notice, rendered through the shared `HistoryEmptyState` with `isError`. ' +
+          'It passes the raw service message straight through, so whatever the API says is what ' +
+          'the practice reads, and it is painted in `--color-text-error` - which resolves to ' +
+          '`--danger-text` (#a6271d on the bone screen, #f2938a in dark), not the ' +
+          '`--color-error` fill step.\n\n' +
+          'This branch previously asked for `text-error-main`, a class Tailwind compiled to no ' +
+          'rule at all because no `--color-error-main` token exists (the defined ones are ' +
+          '`--color-error`, `--color-error-100`, `--color-error-500`, `--color-error-700`). The ' +
+          'message inherited body ink, was pixel-identical to the non-error notice, and ' +
+          '`role="alert"` was the only - invisible - signal that anything had failed. That ' +
+          'shipped across five error messages in PIMS before a story measured both inks as ' +
+          'rgb(48, 47, 46) and caught it. All five are fixed, and ' +
+          '`__tests__/ui/tokens/colorUtilityExists.test.ts` now fails any colour utility naming ' +
+          'a token that does not exist.',
+      },
+    },
+  },
+};
+
+export const EmptyState: Story = {
+  name: 'No audit entries',
+  args: { entries: [] },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByText('No audit entries found.')).toBeInTheDocument();
+
+    /* Loaded-and-empty takes the compact notice box, NOT the rich "No records yet"
+       folder illustration - `HistoryEmptyState` only reaches that when both `isError`
+       and `message` are absent, and this branch always passes a message. Assert the
+       folder copy and its supporting line are genuinely not here, because the two
+       states look nothing alike and the other filters show the illustrated one. */
+    expect(canvas.queryByText('No records yet')).toBeNull();
+    expect(canvas.queryByText(/Everything from visits lands here/)).toBeNull();
+    expect(canvas.queryAllByRole('listitem')).toHaveLength(0);
+
+    // ...and it is the notice box, not an alert: the empty branch drops `isError`, so
+    // nothing here is announced assertively.
+    expect(canvas.queryByRole('alert')).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A companion whose trail is genuinely empty. This is the one filter that never shows ' +
+          'the illustrated records empty state, because it always supplies a message - so ' +
+          'switching from Medical records to Audit trail on an empty companion swaps a 64px ' +
+          'illustration for a one-line box.',
+      },
+    },
+  },
+};
+
+export const Phone: Story = {
+  name: 'Phone (375)',
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const items = canvas.getAllByRole('listitem');
+    expect(items).toHaveLength(5);
+
+    /* The timestamp column is `w-40 shrink-0`, so it stays 160px at every width and
+       the card absorbs the whole reduction. */
+    const stamp = stampOf(items[0]);
+    expect(Math.round(stamp.getBoundingClientRect().width)).toBe(160);
+    /* `whitespace-nowrap` keeps date and time on one line rather than stacking them.
+       Counted over a Range rather than the element: the stamp is a flex item, so it is
+       blockified AND stretched to the row height, and its own rects say nothing about
+       how the text inside flowed. A Range over the text returns one rect per line box. */
+    expect(getComputedStyle(stamp).whiteSpace).toBe('nowrap');
+    const stampText = document.createRange();
+    stampText.selectNodeContents(stamp);
+    expect(stampText.getClientRects()).toHaveLength(1);
+    // One line, and it is the whole stamp - not a truncated one.
+    expect(stampTextOf(items[0])).toMatch(STAMP_PATTERN);
+
+    /* What is left for the card: 375 less the wrapper padding, the 160px stamp, the
+       20px dot and two 12px gaps. Under 200px for a bold title, an entity chip and a
+       full actor line, all of which then wrap. */
+    const card = cardOf(items[0]);
+    expect(card.getBoundingClientRect().width).toBeLessThan(200);
+    /* The stamp is wider than the card it annotates - the ratio, not the absolute
+       number, is the design problem here. */
+    expect(stamp.getBoundingClientRect().width).toBeGreaterThan(card.getBoundingClientRect().width);
+
+    /* Title and chip share one `flex-wrap` row, and at this width they no longer fit
+       side by side, so the chip drops under the title and the header row is taller
+       than either child. */
+    const headerRow = card.children[0] as HTMLElement;
+    expect(headerRow.children).toHaveLength(2);
+    const title = headerRow.children[0] as HTMLElement;
+    const chip = headerRow.children[1] as HTMLElement;
+    expect(chip.getBoundingClientRect().top).toBeGreaterThan(
+      title.getBoundingClientRect().bottom - 1
+    );
+
+    // The rail still assembles the same way - the phone layout is not a variant here.
+    expect(railOf(items[0]).children).toHaveLength(3);
+    expect(within(items[0]).getByText('Appointment requested')).toBeInTheDocument();
+    expect(within(items[0]).getByText('Updated by: Nina Alvarez • Pet parent')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The audit tab inside the phone record. Nothing about this component is responsive: ' +
+          'the 160px timestamp gutter is fixed and `shrink-0`, so at 375 it takes close to half ' +
+          'the row, the card is squeezed under 200px, and the gutter ends up wider than the ' +
+          'content it labels. The title and the entity chip stop fitting on one line and the ' +
+          'chip drops beneath the title, which is the trade to look at - either the stamp moves ' +
+          'above the card on narrow widths, or it drops the date and keeps the time.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/companionHistory/components/HistoryEmptyState.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/HistoryEmptyState.tsx
@@ -19,7 +19,7 @@ const HistoryEmptyState = ({ isError = false, message }: HistoryEmptyStateProps)
       className="rounded-2xl border border-card-border bg-neutral-0 px-4 py-6 text-center"
       role={isError ? 'alert' : undefined}
     >
-      <div className={isError ? 'text-body-3 text-error-main' : 'text-body-3 text-text-primary'}>
+      <div className={isError ? 'text-body-3 text-text-error' : 'text-body-3 text-text-primary'}>
         {message || 'Unable to load overview right now.'}
       </div>
     </div>

--- a/apps/frontend/src/app/features/companionHistory/components/PillDropdown.stories.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/PillDropdown.stories.tsx
@@ -1,0 +1,210 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import { PillDropdown } from './CompanionHistoryTimeline';
+
+const SORT_OPTIONS = [
+  { label: 'Newest first', value: 'newest' },
+  { label: 'Oldest first', value: 'oldest' },
+  { label: 'Type', value: 'type' },
+  { label: 'Status', value: 'status' },
+];
+
+const STATUS_OPTIONS = [
+  { label: 'All statuses', value: 'all' },
+  { label: 'Awaiting payment', value: 'no_payment' },
+  { label: 'Checked in', value: 'checked_in' },
+  { label: 'In progress', value: 'in_progress' },
+  { label: 'Completed', value: 'completed' },
+];
+
+/** The panel is absolutely positioned under the pill, so the canvas needs room below it. */
+const Room = (Story: React.ComponentType) => (
+  <div className="flex min-h-[280px] items-start justify-center pt-6">
+    <Story />
+  </div>
+);
+
+/** Opens the panel and returns it - the panel itself carries no role to query by. */
+const openPanel = async (canvasElement: HTMLElement, triggerName: RegExp) => {
+  const canvas = within(canvasElement);
+  await userEvent.click(canvas.getByRole('button', { name: triggerName }));
+  const firstOption = canvas.getAllByRole('button')[1];
+  return firstOption.parentElement as HTMLElement;
+};
+
+const meta = {
+  title: 'Companions/PillDropdown',
+  component: PillDropdown,
+  decorators: [Room],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The Status and Sort-by selectors above the companion history list, styled as filter pills ' +
+          'so they read alongside the history-tab chips rather than as boxed form fields.\n\n' +
+          'The panel is the reason this file exists, and it had never been rendered. It sits behind ' +
+          'an `open` flag and is dismissed by a document-level `mousedown` listener, so it survives ' +
+          'only for as long as an interaction holds it - no static render of this component has ' +
+          'ever contained a single option row.\n\n' +
+          'What is inside it is a text-token surface, which is exactly the shape of the dropdown ' +
+          'bug this work exists to catch: the panel paints `--screen` with a `--hairline` border, ' +
+          'and its rows are `--ink` at `font-bold` when selected against `--ink-muted` at ' +
+          '`font-medium` when not, hovering to `--inset`. Weight and ink are the ONLY thing marking ' +
+          'the current choice - there is no check mark, no dot, no background - so a row that ' +
+          'reached for a fill token instead of an ink token would look deliberate and be ' +
+          'unreadable. The stories assert the weight, not merely that rows exist.\n\n' +
+          'One thing the stories make visible rather than fix: the trigger advertises ' +
+          '`aria-haspopup="menu"`, but the panel it opens is a plain `<div>` of plain `<button>`s ' +
+          'with no `role="menu"` and no `role="menuitem"`. Anything querying this as a menu finds ' +
+          'nothing - which is why the assertions below anchor on the option buttons themselves.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    label: 'Sort by',
+    options: SORT_OPTIONS,
+    value: 'newest',
+    onSelect: fn(),
+  },
+} satisfies Meta<typeof PillDropdown>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Closed: Story = {
+  name: 'Trigger only',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting pill: a 1px `--hairline` border, 12px semibold `--ink-muted` text and a 12px ' +
+          'chevron. It shows the selected option\'s label, not the field label - "Sort by" only ' +
+          'survives in the accessible name.',
+      },
+    },
+  },
+};
+
+export const Open: Story = {
+  name: 'Panel open',
+  play: async ({ canvasElement }) => {
+    const panel = await openPanel(canvasElement, /^Sort by: Newest first$/);
+
+    // Assert the panel has its rows, not that the trigger flipped aria-expanded:
+    // an empty panel satisfies the weaker check.
+    const rows = within(panel).getAllByRole('button');
+    await expect(rows).toHaveLength(4);
+    await expect(within(panel).getByText('Oldest first')).toBeInTheDocument();
+
+    /* Weight is the entire selected-state affordance - there is no check mark.
+       Assert it directly, or a row that lost its bold would still pass. */
+    await expect(within(panel).getByText('Newest first')).toHaveClass('font-bold');
+    await expect(within(panel).getByText('Oldest first')).toHaveClass('font-medium');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The four sort options with the current one bolded. The panel has a `min-w-40` (160px) ' +
+          "floor and grows from the pill's left edge, so it is regularly wider than the pill that " +
+          'opened it.',
+      },
+    },
+  },
+};
+
+export const StatusFilter: Story = {
+  name: 'Status filter (wide options)',
+  args: { label: 'Status', options: STATUS_OPTIONS, value: 'in_progress' },
+  play: async ({ canvasElement }) => {
+    const panel = await openPanel(canvasElement, /^Status: In progress$/);
+    await expect(within(panel).getAllByRole('button')).toHaveLength(5);
+    await expect(within(panel).getByText('In progress')).toHaveClass('font-bold');
+    // "Awaiting payment" is the longest row and sets the panel width.
+    await expect(within(panel).getByText('Awaiting payment')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The other caller, with longer labels and a selection in the middle of the list. Rows do ' +
+          'not truncate, so the panel takes its width from the longest option while the pill keeps ' +
+          'its own - a mismatch only visible with the panel open.',
+      },
+    },
+  },
+};
+
+export const SelectingAnOption: Story = {
+  name: 'Selecting a row',
+  play: async ({ args, canvasElement }) => {
+    const panel = await openPanel(canvasElement, /^Sort by: Newest first$/);
+    await userEvent.click(within(panel).getByText('Type'));
+
+    // The row commits the option VALUE, not its label.
+    await expect(args.onSelect).toHaveBeenCalledWith('type');
+    // The component closes itself even though it is otherwise fully controlled.
+    await expect(within(canvasElement).getAllByRole('button')).toHaveLength(1);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Committing a choice. The pill is controlled - the label only changes once the parent ' +
+          'sends a new `value` back - but the open/closed state is local, so the panel closes on ' +
+          'its own regardless of what the parent does with the selection.',
+      },
+    },
+  },
+};
+
+export const ClosesOnOutsideClick: Story = {
+  name: 'Closes on outside press',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: /^Sort by: Newest first$/ }));
+    await expect(canvas.getAllByRole('button')).toHaveLength(5);
+
+    // A document-level mousedown listener dismisses it; there is no Escape handler.
+    await userEvent.click(canvasElement);
+    await expect(canvas.getAllByRole('button')).toHaveLength(1);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Dismissal is `mousedown` on `document`, scoped to anything outside the pill's own " +
+          'container. Escape does nothing here, which is worth knowing before this pill is reused ' +
+          'inside a modal that does listen for it.',
+      },
+    },
+  },
+};
+
+export const UnknownValue: Story = {
+  name: 'Value not in the options',
+  args: { value: 'relevance' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // With no matching option the trigger falls back to the field label, so the
+    // pill reads "Sort by" and no row is bolded.
+    const trigger = canvas.getByRole('button', { name: /^Sort by: Sort by$/ });
+    await userEvent.click(trigger);
+    const panel = canvas.getAllByRole('button')[1].parentElement as HTMLElement;
+    await expect(within(panel).getAllByRole('button')).toHaveLength(4);
+    await expect(panel.querySelectorAll('.font-bold')).toHaveLength(0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A value the option list does not carry - a stale saved filter, or a status removed from ' +
+          'the vocabulary. The pill degrades to the field label and the panel shows nothing as ' +
+          'selected, which is honest but leaves the accessible name reading "Sort by: Sort by".',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/companionHistory/components/StatusPillSelect.stories.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/StatusPillSelect.stories.tsx
@@ -1,0 +1,231 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import { StatusPillSelect } from './CompanionHistoryTimeline';
+import { AppointmentLabels, TaskLabels } from '@/app/config/statusConfig';
+
+/** The menu is absolutely positioned under the pill, so the canvas needs room below it. */
+const Room = (Story: React.ComponentType) => (
+  <div className="flex min-h-[280px] items-start justify-center pt-6">
+    <Story />
+  </div>
+);
+
+const meta = {
+  title: 'Companions/StatusPillSelect',
+  component: StatusPillSelect,
+  decorators: [Room],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The status control on every appointment and task row of the companion history timeline: ' +
+          'a status pill that is either a read-only badge or, when transitions exist, a trigger for ' +
+          'a `role="menu"` panel.\n\n' +
+          'The panel had never been drawn. It is rendered behind an `open` flag and, crucially, it ' +
+          'is dismissed by `onBlur` on the trigger - so it cannot survive a click anywhere else, ' +
+          'and any review that is not an actual interaction sees only the closed pill. What is ' +
+          "inside it is not decoration: each row pairs an 8px dot filled with that status's " +
+          "`borderColor` against a label in that status's `color`, both pulled from " +
+          '`getStatusStyle`. Six different token pairs render in one panel and none of them appear ' +
+          'anywhere in the resting markup.\n\n' +
+          'Which rows appear is derived twice over. `allowedKeys` filters the option list ' +
+          'case-insensitively against `option.key`, so an allow-list naming a status the option ' +
+          'list does not carry silently drops it; and when the filter leaves nothing - or `locked` ' +
+          'or `disabled` is set - the component stops being a control at all and falls back to a ' +
+          'plain `StatusPill` with no caret and nothing focusable.\n\n' +
+          'The rows commit on `mouseDown` with `preventDefault`, not on `click`, precisely so the ' +
+          "trigger's blur handler cannot close the panel out from under the selection. The stories " +
+          'assert the opened panel has its rows and its dots, rather than that `aria-expanded` ' +
+          'flipped - an empty panel satisfies the weaker check.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    status: 'upcoming',
+    options: AppointmentLabels,
+    onChange: fn(),
+  },
+} satisfies Meta<typeof StatusPillSelect>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Closed: Story = {
+  name: 'Trigger only',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting pill: the compact label plus a 10px chevron that rotates 180 degrees while ' +
+          'the panel is open. The full status wording stays in the `title` attribute, because ' +
+          '"Awaiting payment" is shortened to "Awaiting" on the pill itself.',
+      },
+    },
+  },
+};
+
+export const Open: Story = {
+  name: 'Menu open',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Status' }));
+
+    const menu = canvas.getByRole('menu');
+    await expect(menu).toBeInTheDocument();
+    // Assert the panel has its rows, not merely that the trigger flipped
+    // aria-expanded: an empty panel passes the weaker check.
+    await expect(within(menu).getAllByRole('menuitem')).toHaveLength(6);
+    await expect(within(menu).getByText('In progress')).toBeInTheDocument();
+
+    /* Every row carries a colour dot, and the dot is the only thing separating
+       one status from another at a glance. Six rows must mean six dots. */
+    await expect(menu.querySelectorAll('span[aria-hidden="true"]')).toHaveLength(6);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The whole appointment status vocabulary in one panel. This is the render where all six ' +
+          'status token pairs are visible together, which is the only way to check they read as six ' +
+          'distinct states rather than three plus three near-duplicates.',
+      },
+    },
+  },
+};
+
+export const AllowedTransitions: Story = {
+  name: 'Only the valid transitions',
+  args: { allowedKeys: ['CHECKED_IN', 'CANCELLED'] },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Status' }));
+
+    const menu = canvas.getByRole('menu');
+    // The allow-list is matched case-insensitively against option.key, so the
+    // upper-case keys the transition helpers return still hit the lower-case options.
+    await expect(within(menu).getAllByRole('menuitem')).toHaveLength(2);
+    await expect(within(menu).getByText('Checked in')).toBeInTheDocument();
+    await expect(within(menu).queryByText('Completed')).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'How the timeline actually renders it: the panel offers only what the status machine ' +
+          'permits next, so a two-row panel is the common case and the six-row one is the outlier. ' +
+          'A short panel is where a menu sized from its trigger rather than its content shows up.',
+      },
+    },
+  },
+};
+
+export const SelectingATransition: Story = {
+  name: 'Selecting a row',
+  args: { allowedKeys: ['CHECKED_IN', 'CANCELLED'] },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Status' }));
+    await userEvent.click(within(canvas.getByRole('menu')).getByText('Checked in'));
+
+    // The row commits the option KEY, not its display name.
+    await expect(args.onChange).toHaveBeenCalledWith('checked_in');
+    // ...and the panel closes behind it.
+    await expect(canvas.queryByRole('menu')).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The commit path. It fires on `mouseDown` with `preventDefault`, which is what stops the ' +
+          "trigger's `onBlur` from closing the panel before the click ever lands - a plain `onClick` " +
+          'here would be a dead row.',
+      },
+    },
+  },
+};
+
+export const ClosesOnBlur: Story = {
+  name: 'Closes on blur',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Status' }));
+    await expect(canvas.getByRole('menu')).toBeInTheDocument();
+
+    await userEvent.tab();
+    await expect(canvas.queryByRole('menu')).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Moving focus off the trigger dismisses the panel. Worth pinning down because the panel ' +
+          'is not focusable itself - keyboard users tabbing forward from the pill lose it rather ' +
+          'than entering it.',
+      },
+    },
+  },
+};
+
+export const Locked: Story = {
+  name: 'Locked (terminal status)',
+  args: { status: 'completed', locked: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Not a disabled button - no button at all, so there is no affordance
+    // suggesting a change that cannot happen.
+    await expect(canvas.queryByRole('button')).toBeNull();
+    await expect(canvas.getByText('Completed')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A completed appointment has nowhere to go, so the component renders a badge with no ' +
+          'caret and nothing focusable rather than a dimmed trigger.',
+      },
+    },
+  },
+};
+
+export const NoAllowedTransitions: Story = {
+  name: 'Empty allow-list (badge)',
+  args: { allowedKeys: [] },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.queryByRole('button')).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'An empty `allowedKeys` is not the same as omitting it: an empty array is still truthy, ' +
+          'so the filter runs and removes every option, and the component degrades to the same ' +
+          'badge as `locked`. This is the branch that turns a control into a label without anyone ' +
+          'passing `locked`.',
+      },
+    },
+  },
+};
+
+export const TaskVocabulary: Story = {
+  name: 'Task statuses',
+  args: { status: 'in_progress', options: TaskLabels },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Status' }));
+    await expect(within(canvas.getByRole('menu')).getAllByRole('menuitem')).toHaveLength(4);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same component driven by the task vocabulary, which is four statuses rather than ' +
+          'six and starts at Pending instead of Requested. The two lists share three token pairs ' +
+          'and differ in the fourth, so both belong in review.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/companionHistory/components/StructuredResultsPanel.stories.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/StructuredResultsPanel.stories.tsx
@@ -1,0 +1,532 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, waitFor, within } from 'storybook/test';
+
+import { StructuredResultsPanel } from './CompanionHistoryTimeline';
+import type { HistoryEntry } from '@/app/features/companionHistory/types/history';
+
+/**
+ * Structurally the module-private `DetailPair` the timeline builds in
+ * `getLabResults`. It is not exported, but the panel's props are typed inline, so a
+ * literal of this shape is what the real call site passes.
+ */
+type ResultRow = {
+  label: string;
+  value: string;
+  range?: string;
+  abnormal?: boolean;
+  direction?: string;
+};
+
+/** No `payload.referenceRange`, so a row with no interval of its own falls through to '-'. */
+const LAB_ENTRY: HistoryEntry = {
+  id: 'hist-lab-1',
+  type: 'LAB_RESULT',
+  occurredAt: '2026-03-12T09:42:00.000Z',
+  status: 'COMPLETED',
+  title: 'Complete blood count',
+  subtitle: 'IDEXX ProCyte Dx',
+  actor: { id: 'vet-1', name: 'Dr. Weber', role: 'VET' },
+  link: { kind: 'labResult', id: 'lab-1', appointmentId: 'appt-1', companionId: 'companion-1' },
+  source: 'idexx',
+  payload: {},
+};
+
+/** The same record with the panel-level fallback interval present on the payload. */
+const LAB_ENTRY_WITH_FALLBACK: HistoryEntry = {
+  ...LAB_ENTRY,
+  id: 'hist-lab-2',
+  payload: { referenceRange: 'Species reference interval' },
+};
+
+/**
+ * Six rows, because `getLabResults` slices the payload to six before this panel ever
+ * sees it - six is the most the inline panel can draw, not a story convenience.
+ */
+const CBC_RESULTS: ResultRow[] = [
+  { label: 'Haematocrit', value: '33 %', range: '37 - 55', abnormal: true, direction: '↓' },
+  { label: 'Haemoglobin', value: '11.2 g/dL', range: '12 - 18', abnormal: true, direction: '↓' },
+  {
+    label: 'White cell count',
+    value: '9.4 K/uL',
+    range: '5.05 - 16.76',
+    abnormal: false,
+    direction: '',
+  },
+  { label: 'Platelets', value: '412 K/uL', range: '148 - 484', abnormal: false, direction: '' },
+  { label: 'Reticulocytes', value: '96 K/uL', range: '10 - 110', abnormal: false, direction: '' },
+  {
+    label: 'Segmented neutrophils',
+    value: '7.1 K/uL',
+    range: '2.95 - 11.64',
+    abnormal: false,
+    direction: '',
+  },
+];
+
+/** The header band, which is the only `.yc-table-head` in the canvas. */
+const headerOf = (canvasElement: HTMLElement): HTMLElement =>
+  canvasElement.querySelector('.yc-table-head') as HTMLElement;
+
+/** The bordered card the band and the rows share. */
+const panelOf = (canvasElement: HTMLElement): HTMLElement =>
+  headerOf(canvasElement).parentElement as HTMLElement;
+
+/** Everything after the header band: one node per result row. */
+const rowsOf = (canvasElement: HTMLElement): HTMLElement[] =>
+  [...panelOf(canvasElement).children].slice(1) as HTMLElement[];
+
+const tracks = (el: HTMLElement): string[] =>
+  getComputedStyle(el).gridTemplateColumns.trim().split(/\s+/);
+
+/**
+ * Four cells AND four resolved tracks, asserted together on every grid in the panel.
+ * Either half alone is satisfiable by a broken render: a template that failed to
+ * parse collapses to `none` while the four cells stack, and a template that survived
+ * a dropped cell still reports four tracks.
+ */
+const expectFourColumns = (el: HTMLElement) => {
+  expect(el.children).toHaveLength(4);
+  expect(tracks(el)).toHaveLength(4);
+};
+
+/**
+ * Proof that the unlayered `Generictable.css` recipe actually reached this band.
+ *
+ * `.yc-table-head` is a side-effect import on `CompanionHistoryTimeline`, not a
+ * global. Uppercase and the 10.5px size exist nowhere else, so they are the cheapest
+ * signal that the stylesheet loaded. Without this check the header/row template
+ * equality asserted below would pass TRIVIALLY on an unstyled band - both halves
+ * would have no padding and identical tracks, and the story would be green with the
+ * recipe missing.
+ *
+ * The padding pair is the cascade fix itself: the recipe sets `padding: 11px 20px`
+ * and the markup zeroes the inline sides with `px-0!`. Unlayered CSS outranks a
+ * Tailwind utility, so the `!` is the only reason the header is not indented 20px
+ * away from its rows. `paddingLeft` reading 20px means someone dropped it.
+ */
+const expectHeadRecipeApplied = (header: HTMLElement) => {
+  const style = getComputedStyle(header);
+  expect(style.textTransform).toBe('uppercase');
+  expect(style.fontSize).toBe('10.5px');
+  expect(style.paddingTop).toBe('11px');
+  expect(style.paddingLeft).toBe('0px');
+  expect(style.paddingRight).toBe('0px');
+};
+
+const meta = {
+  title: 'Companions/StructuredResultsPanel',
+  component: StructuredResultsPanel,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The inline analyte table under an expanded lab row in the companion history ' +
+          'timeline. It is rendered as `expandedContent` and only when **both** conditions hold: ' +
+          "the row's id equals `expandedId`, and `getLabResults(entry)` came back non-empty. Two " +
+          'gates in one expression means the panel had never been drawn anywhere - not in ' +
+          'Storybook, and not in any test that stops at the collapsed card.\n\n' +
+          'It is a CSS grid pretending to be a table, and the four-track template ' +
+          '`minmax(160px,1fr) 120px 120px 100px` is written out **twice**: once on the ' +
+          '`.yc-table-head` band and once, independently, on every data row. Nothing in the type ' +
+          'system ties the two copies together. If either drifts, the header stops lining up with ' +
+          'the body and the only symptom is misaligned columns, so the stories assert the two ' +
+          'computed templates are identical rather than merely that each has four tracks.\n\n' +
+          'That equality also depends on one non-obvious cascade detail. `.yc-table-head` is ' +
+          'plain unlayered CSS from `Generictable.css` - a side-effect import on ' +
+          '`CompanionHistoryTimeline`, not a global stylesheet - and it sets `padding: 11px 20px`; ' +
+          'the data rows have no horizontal padding at all. Unlayered rules beat Tailwind ' +
+          'utilities, so the header is zeroed with `px-0!` rather than `px-0` - an important ' +
+          'declaration is the only thing that outranks the plain rule. Drop the `!` and the ' +
+          'header indents 20px while the rows do not. Every story here first checks the recipe ' +
+          'genuinely landed (uppercase, 10.5px, 11px block padding, 0 inline padding), because ' +
+          'on an unstyled band the two templates would match for the wrong reason.\n\n' +
+          'Two things a reviewer should look at directly. **The Meter column is hard-coded to ' +
+          '"N/A"** for every row - it is a placeholder, not data. And **the flags are computed ' +
+          'and then thrown away**: `getResultFlag` does real work upstream (lab flag codes first, ' +
+          'then a numeric comparison against the parsed reference interval) to produce `abnormal` ' +
+          'and a ↑/↓ `direction`, both of which arrive on every row here and neither of which ' +
+          'this panel renders. A haematocrit of 33 against an interval of 37-55 draws exactly ' +
+          'like a normal one. `HistoryRecordDrawer` does render them, so the same result reads as ' +
+          'flagged in the drawer and unflagged in the timeline.\n\n' +
+          'Nothing here is horizontally scrollable, and the tracks sum to a 536px hard floor, ' +
+          'which is what the phone story is for.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    entry: LAB_ENTRY,
+    results: CBC_RESULTS,
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-full max-w-[720px] bg-[var(--screen)] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof StructuredResultsPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Six analytes',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const header = headerOf(canvasElement);
+    const rows = rowsOf(canvasElement);
+
+    // The band really is wearing the recipe, so everything below is measured against
+    // styled markup rather than against a bare div.
+    expectHeadRecipeApplied(header);
+
+    // Four labels, four tracks, six rows of four cells. A template that lost a
+    // track collapses the row onto a second line and nothing throws.
+    expectFourColumns(header);
+    expect(rows).toHaveLength(6);
+    for (const row of rows) {
+      expectFourColumns(row);
+    }
+
+    /* The invariant that matters: header and body carry two separate copies of the
+       same arbitrary template, so they must resolve to the same pixel widths. */
+    expect(tracks(rows[0]).join(' ')).toBe(tracks(header).join(' '));
+
+    /* At the default `laptop` viewport the first track is the `1fr` half of its
+       `minmax()` and has absorbed the slack, so it is wider than the 160px floor.
+       The phone story asserts the same track pinned at exactly 160 - together they
+       show which half of the `minmax()` is binding at each width. */
+    expect(Number.parseFloat(tracks(header)[0])).toBeGreaterThan(160);
+    expect(tracks(header).slice(1)).toEqual(['120px', '120px', '100px']);
+
+    expect(within(header).getByText('Test')).toBeInTheDocument();
+    expect(within(header).getByText('Value')).toBeInTheDocument();
+    expect(within(header).getByText('Reference')).toBeInTheDocument();
+    expect(within(header).getByText('Meter')).toBeInTheDocument();
+
+    // Row one, cell by cell, in order.
+    expect([...rows[0].children].map((cell) => cell.textContent)).toEqual([
+      'Haematocrit',
+      '33 %',
+      '37 - 55',
+      'N/A',
+    ]);
+    expect(within(rows[5]).getByText('Segmented neutrophils')).toBeInTheDocument();
+
+    // Every Meter cell is the same placeholder string - one per row, no exceptions.
+    expect(canvas.getAllByText('N/A')).toHaveLength(6);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A complete blood count as the timeline draws it: the uppercase 10.5px header band on ' +
+          '`--screen-2`, then six 14px medium rows with the analyte name in bold. The header is ' +
+          '`.yc-table-head--static`, which drops the sticky positioning the recipe normally ' +
+          'carries - inside an expanded card there is no scroll container for it to stick to, ' +
+          'and sticky would strand the band mid-panel.',
+      },
+    },
+  },
+};
+
+export const FlagsAreDropped: Story = {
+  name: 'Out-of-range results draw as normal',
+  args: {
+    results: [
+      { label: 'Haematocrit', value: '33 %', range: '37 - 55', abnormal: true, direction: '↓' },
+      { label: 'Platelets', value: '412 K/uL', range: '148 - 484', abnormal: false, direction: '' },
+      { label: 'ALT', value: '186 U/L', range: '10 - 125', abnormal: true, direction: '↑' },
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const header = headerOf(canvasElement);
+    const rows = rowsOf(canvasElement);
+    expectHeadRecipeApplied(header);
+    expect(rows).toHaveLength(3);
+    for (const row of rows) {
+      expectFourColumns(row);
+    }
+
+    /* Both arrows arrived on the props and neither reaches the DOM. Assert against the
+       whole panel's text, because there is no element to query for something absent. */
+    const panel = panelOf(canvasElement);
+    expect(panel.textContent).not.toContain('↑');
+    expect(panel.textContent).not.toContain('↓');
+
+    // The Meter column is where a flag would go, and it is the placeholder on the
+    // flagged rows too.
+    expect([...rows[0].children].map((cell) => cell.textContent)).toEqual([
+      'Haematocrit',
+      '33 %',
+      '37 - 55',
+      'N/A',
+    ]);
+    expect([...rows[2].children].map((cell) => cell.textContent)).toEqual([
+      'ALT',
+      '186 U/L',
+      '10 - 125',
+      'N/A',
+    ]);
+
+    /* A flagged reading and a normal one are the same ink. The row style sets colour
+       inline on the row, so the cells inherit one value - there is no abnormal
+       treatment to catch. Read after the transition settles rather than in the same
+       frame as the mount, and compare weight too: a bold-only flag would slip past a
+       colour check. */
+    await waitFor(() => {
+      const flagged = getComputedStyle(rows[0].children[1]);
+      const clean = getComputedStyle(rows[1].children[1]);
+      expect(flagged.color).toBe(clean.color);
+      expect(flagged.fontWeight).toBe(clean.fontWeight);
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Haematocrit is below its interval and ALT is well above its own; both `abnormal` and ' +
+          'both directions are on the props. The panel renders neither, so all three rows read ' +
+          'identically. This is the surface to compare against `HistoryRecordDrawer`, which ' +
+          'renders the same `abnormal` / `direction` pair as a tinted value and an arrow - the ' +
+          'same lab result therefore looks flagged in the drawer and clean in the timeline.',
+      },
+    },
+  },
+};
+
+export const ReferenceFallback: Story = {
+  name: 'Empty cells and the payload fallback',
+  args: {
+    entry: LAB_ENTRY_WITH_FALLBACK,
+    results: [
+      { label: 'Haematocrit', value: '', range: '' },
+      { label: 'Haemoglobin', value: '11.2 g/dL', range: '' },
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const header = headerOf(canvasElement);
+    const rows = rowsOf(canvasElement);
+    expectHeadRecipeApplied(header);
+    expect(rows).toHaveLength(2);
+    for (const row of rows) {
+      expectFourColumns(row);
+    }
+
+    // A missing reading becomes '-'; a missing interval instead falls back to the
+    // record-level `payload.referenceRange`, which is a different substitution.
+    expect([...rows[0].children].map((cell) => cell.textContent)).toEqual([
+      'Haematocrit',
+      '-',
+      'Species reference interval',
+      'N/A',
+    ]);
+    expect(rows[1].children[2].textContent).toBe('Species reference interval');
+
+    /* Prose, not a number, in a 120px track - it wraps rather than truncating,
+       because the ellipsis rule is scoped to `.yc-table-head > *` and not to rows.
+       The wrap is counted over a Range: every cell is a grid item, so it is
+       blockified and stretched, and its own client rects are one box whatever the
+       text did. A Range over the contents returns one rect per line box. */
+    const reference = rows[0].children[2] as HTMLElement;
+    expect(getComputedStyle(reference).textOverflow).toBe('clip');
+    expect(getComputedStyle(reference).overflow).toBe('visible');
+    const referenceText = document.createRange();
+    referenceText.selectNodeContents(reference);
+    expect(referenceText.getClientRects().length).toBeGreaterThanOrEqual(2);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Both substitutions in one render. The value cell short-circuits to a literal hyphen, ' +
+          'but the reference cell tries `payload.referenceRange` first - so one lab that reports ' +
+          'a single interval for the whole panel repeats that string down every row, in a 120px ' +
+          'column with no truncation of its own. It wraps instead, and every row on the panel ' +
+          'grows to carry the same repeated sentence.',
+      },
+    },
+  },
+};
+
+export const NoReferenceAnywhere: Story = {
+  name: 'No interval on the row or the record',
+  args: {
+    entry: LAB_ENTRY,
+    results: [
+      { label: 'Haematocrit', value: '33 %', range: '' },
+      { label: 'Haemoglobin', value: '11.2 g/dL', range: '' },
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const header = headerOf(canvasElement);
+    const rows = rowsOf(canvasElement);
+    expectHeadRecipeApplied(header);
+    expect(rows).toHaveLength(2);
+    for (const row of rows) {
+      expectFourColumns(row);
+    }
+
+    // `payload` is empty here, so the fallback chain runs out and the Reference
+    // column is a column of hyphens - visually identical to a missing value.
+    expect([...rows[0].children].map((cell) => cell.textContent)).toEqual([
+      'Haematocrit',
+      '33 %',
+      '-',
+      'N/A',
+    ]);
+    expect(rows.map((row) => row.children[2].textContent)).toEqual(['-', '-']);
+
+    /* Two of the four tracks now carry nothing but placeholders, and they still hold
+       their full 120px + 100px. That is the whole argument for the phone story: the
+       220px is spent whether or not there is anything to put in it. */
+    expect(tracks(header).slice(2)).toEqual(['120px', '100px']);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The common shape for a manually entered result: readings, no intervals. Two of the ' +
+          'four columns are then dead - Reference is all hyphens and Meter is all "N/A" - which ' +
+          'is 220px of the template spent on nothing, and the reason the phone width is as tight ' +
+          'as it is.',
+      },
+    },
+  },
+};
+
+export const LongAnalyteNames: Story = {
+  name: 'Long analyte names wrap',
+  args: {
+    results: [
+      {
+        label: 'Segmented neutrophils absolute count (automated differential)',
+        value: '7.1 K/uL',
+        range: '2.95 - 11.64',
+      },
+      { label: 'Platelets', value: '412 K/uL', range: '148 - 484' },
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const header = headerOf(canvasElement);
+    const rows = rowsOf(canvasElement);
+    expectHeadRecipeApplied(header);
+    expect(rows).toHaveLength(2);
+    expectFourColumns(header);
+    for (const row of rows) {
+      expectFourColumns(row);
+    }
+
+    /* The header band is `white-space: nowrap` with `overflow: hidden` +
+       `text-overflow: ellipsis` on its children, from the plain-CSS recipe. Data rows
+       inherit neither, so the two halves of the same table handle overflow in
+       opposite ways. */
+    expect(getComputedStyle(header.children[0]).whiteSpace).toBe('nowrap');
+    expect(getComputedStyle(header.children[0]).textOverflow).toBe('ellipsis');
+    expect(getComputedStyle(rows[0].children[0]).whiteSpace).toBe('normal');
+    expect(getComputedStyle(rows[0].children[0]).textOverflow).toBe('clip');
+
+    /* Counted over a Range, not over the element: every cell is a grid item, so it is
+       blockified and stretched to the row height and its own client rects are one box
+       whatever the text did. A Range over the text contents returns one rect per line
+       box, so this is a direct wrap count. */
+    const label = rows[0].children[0] as HTMLElement;
+    const labelText = document.createRange();
+    labelText.selectNodeContents(label);
+    expect(labelText.getClientRects().length).toBeGreaterThanOrEqual(2);
+
+    /* The wrap is contained: the first column keeps the width the header gave it, so
+       the numeric columns do not shift under a long name. This is the assertion that
+       fails if someone swaps `minmax(160px,1fr)` for `auto` or `max-content`. */
+    expect(tracks(rows[0])).toEqual(tracks(header));
+    expect(Math.round(label.getBoundingClientRect().width)).toBe(
+      Math.round((header.children[0] as HTMLElement).getBoundingClientRect().width)
+    );
+
+    // The wrapped label grows the row past the single-line row below it, and the
+    // short row is unaffected - the growth is local, not a whole-table reflow.
+    expect(rows[0].getBoundingClientRect().height).toBeGreaterThan(
+      rows[1].getBoundingClientRect().height
+    );
+    expect(rows[1].children[0].textContent).toBe('Platelets');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'IDEXX and Merck panels both emit analyte names at this length. The first track is ' +
+          '`minmax(160px,1fr)`, so it absorbs the slack at desktop width and the name wraps ' +
+          'inside it rather than pushing the numeric columns - but the row grows taller than its ' +
+          'neighbours while the other three cells stay top-aligned, so the reading no longer sits ' +
+          'on the same baseline as its name.',
+      },
+    },
+  },
+};
+
+export const Phone: Story = {
+  name: 'Phone (375)',
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const header = headerOf(canvasElement);
+    const panel = panelOf(canvasElement);
+    const rows = rowsOf(canvasElement);
+
+    expectHeadRecipeApplied(header);
+    // The template does not respond to width: still four fixed-ish tracks at 375.
+    expectFourColumns(header);
+    expect(rows).toHaveLength(6);
+    for (const row of rows) {
+      expectFourColumns(row);
+    }
+
+    /* The first track is pinned at the FLOOR of its `minmax()` here - the opposite of
+       the laptop story, where the same track is wider than 160. That is what makes
+       the table wider than the card it lives in. */
+    const widths = tracks(header).map((track) => Number.parseFloat(track));
+    expect(widths).toEqual([160, 120, 120, 100]);
+
+    /* 160 + 120 + 120 + 100 plus three gaps against roughly 309px of content box.
+       Measured from the resolved tracks rather than from `scrollWidth`, which is only
+       loosely specified for an `overflow: visible` box. */
+    const gap = Number.parseFloat(getComputedStyle(header).columnGap);
+    const total = widths.reduce((sum, width) => sum + width, 0) + gap * 3;
+    expect(total).toBeGreaterThan(header.clientWidth + 150);
+
+    // Not merely wider on paper: the Meter cell's right edge is outside the card.
+    const lastCell = rows[0].children[3] as HTMLElement;
+    expect(lastCell.getBoundingClientRect().right).toBeGreaterThan(
+      panel.getBoundingClientRect().right
+    );
+
+    // ...and nothing can scroll it: the panel is plain `overflow: visible`, with no
+    // `overflow-x: auto` wrapper anywhere between it and the card.
+    expect(getComputedStyle(panel).overflowX).toBe('visible');
+    expect(getComputedStyle(header).overflowX).toBe('visible');
+
+    // Rows overflow by the same amount, so the columns stay aligned while they run
+    // off-screen together, and the content is unchanged from the laptop render.
+    expect(tracks(rows[0])).toEqual(tracks(header));
+    expect([...rows[0].children].map((cell) => cell.textContent)).toEqual([
+      'Haematocrit',
+      '33 %',
+      '37 - 55',
+      'N/A',
+    ]);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The phone record renders this same panel - `variant="phone"` changes the timeline ' +
+          'chrome around it, not the expanded content. The four tracks are unconditional, so at ' +
+          '375 the table is about 536px wide inside a ~309px column and simply spills; there is ' +
+          'no `overflow-x` container, so it cannot be scrolled to either. A reviewer should ' +
+          'decide between a scroll container and a stacked form here, and note that Reference and ' +
+          'Meter are the 220px that are worth the least.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/companions/components/AddCompanionCentralModal/AddCompanionFormMode.stories.tsx
+++ b/apps/frontend/src/app/features/companions/components/AddCompanionCentralModal/AddCompanionFormMode.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { expect, fn, userEvent, within } from 'storybook/test';
 
+import { openGlassTooltip } from '@/app/ui/primitives/GlassTooltip/storyInteractions';
+
 import type { StoredParent } from '@/app/features/companions/pages/Companions/types';
 import {
   CountryDialCodeOptions,
@@ -294,13 +296,11 @@ export const DateOfBirthTooltip: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const info = canvas.getByRole('button', { name: 'Date of birth information' });
-    await userEvent.hover(info);
-    // GlassTooltip listens for focusin as well as mouseenter, and focusin
-    // bubbles from the button to the wrapper span that holds the listener.
-    info.focus();
-    // The bubble portals to document.body, outside the story canvas - and assert
-    // it has the copy, not merely that a tooltip node appeared.
-    const tooltip = await within(document.body).findByRole('tooltip');
+    /* The bubble portals to document.body, outside the story canvas - and it is asserted
+       to carry the copy, not merely that a tooltip node appeared. The dispatch is
+       retried because the wrapper binds its listeners in an effect a play function can
+       start ahead of. */
+    const tooltip = await openGlassTooltip(info);
     await expect(tooltip).toHaveTextContent(/age verification and legal consent/i);
   },
   parameters: {
@@ -370,17 +370,8 @@ export const CreateStepTwo: Story = {
 export const PhoneSheet: Story = {
   name: 'Create wizard - phone sheet variant',
   args: { mode: 'create', formStep: 1, variant: 'sheet' },
-  globals: { viewport: { value: 'phone', isRotated: false } },
+  globals: { viewport: { value: 'mobile', isRotated: false } },
   parameters: {
-    viewport: {
-      options: {
-        phone: {
-          name: 'Mobile (375)',
-          styles: { width: '375px', height: '812px' },
-          type: 'mobile',
-        },
-      },
-    },
     chromatic: { viewports: [375] },
     docs: {
       description: {

--- a/apps/frontend/src/app/features/companions/components/AddCompanionCentralModal/AddCompanionFormMode.stories.tsx
+++ b/apps/frontend/src/app/features/companions/components/AddCompanionCentralModal/AddCompanionFormMode.stories.tsx
@@ -1,0 +1,429 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import type { StoredParent } from '@/app/features/companions/pages/Companions/types';
+import {
+  CountryDialCodeOptions,
+  type CompanionAlert,
+  type CountryDialCodeOption,
+} from '@/app/features/companions/components/AddCompanion/type';
+import {
+  DEFAULT_SPECIES_OPTIONS,
+  type BreedOption,
+  type ExtCompanionForValidation,
+} from './addCompanionCentralModalHelpers';
+import AddCompanionFormMode from './AddCompanionFormMode';
+
+const COMPANION: ExtCompanionForValidation = {
+  id: 'companion-1',
+  organisationId: 'org-storybook',
+  parentId: 'parent-1',
+  name: 'Poppy',
+  type: 'dog',
+  speciesCode: 'canine',
+  breed: 'Beagle',
+  breedCode: 'beagle',
+  dateOfBirth: new Date('2021-04-18T00:00:00.000Z'),
+  gender: 'female',
+  isneutered: true,
+  colour: 'Tricolour',
+  bloodGroup: 'DEA 1.1 Negative',
+  currentWeight: 12.4,
+  countryOfOrigin: 'Germany',
+  microchipNumber: '276098106523417',
+  passportNumber: 'DEPP88213',
+  allergy: 'Chicken protein',
+  isInsured: false,
+  insurance: undefined,
+  source: 'breeder',
+  alerts: [
+    { id: 'alert-1', label: 'Bite risk', priority: 'high' },
+    { id: 'alert-2', label: 'Needs muzzle', priority: 'medium' },
+  ],
+};
+
+const INSURED_COMPANION: ExtCompanionForValidation = {
+  ...COMPANION,
+  isInsured: true,
+  insurance: { isInsured: true, companyName: 'Petplan', policyNumber: 'PP-4471-22' },
+};
+
+const PARENT: StoredParent = {
+  id: 'parent-1',
+  firstName: 'Lena',
+  lastName: 'Hartmann',
+  email: 'lena.hartmann@example.com',
+  phoneNumber: '+493090182055',
+  birthDate: new Date('1989-11-02T00:00:00.000Z'),
+  address: {
+    addressLine: 'Wallstrasse 14',
+    city: 'Berlin',
+    state: 'Berlin',
+    postalCode: '10179',
+    country: 'Germany',
+  },
+  createdFrom: 'pms',
+};
+
+const BREED_OPTIONS: BreedOption[] = [
+  { value: 'Beagle', label: 'Beagle', breedCode: 'beagle', speciesCode: 'canine' },
+  { value: 'Border Collie', label: 'Border Collie', breedCode: 'collie', speciesCode: 'canine' },
+  { value: 'Whippet', label: 'Whippet', breedCode: 'whippet', speciesCode: 'canine' },
+];
+
+const CLIENT_ALERTS: CompanionAlert[] = [
+  { id: 'client-alert-1', label: 'Payment on hold', priority: 'medium' },
+];
+
+const GERMANY_DIAL_CODE: CountryDialCodeOption =
+  CountryDialCodeOptions.find((option) => option.countryCode === 'DE') ?? CountryDialCodeOptions[0];
+
+const meta = {
+  title: 'Companions/AddCompanionFormMode',
+  component: AddCompanionFormMode,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The editing half of the companion central modal. `mode: "edit"` renders the ' +
+          'two-column `grid-cols-1 lg:grid-cols-2` sheet with its own footer; `mode: "create"` ' +
+          'renders the two-step wizard instead, one column at a time, with the footer hoisted ' +
+          'into the parent so the phone sheet can pin it.\n\n' +
+          'Two surfaces inside it are unreachable from props alone.\n\n' +
+          'The first is the **"Additional Details" accordion**. It is `defaultOpen={false}` and ' +
+          '`Accordion` *unmounts* its body rather than hiding it (`{open && hasChildren && ...}`), ' +
+          'so colour, blood group, country of origin, microchip, passport, source, insurance and ' +
+          'allergies had never been rendered here at all - eleven controls, four of them portalled ' +
+          'dropdowns, none of which any snapshot contained. The chrome changes with the state too: ' +
+          'the header goes from `border rounded-2xl` to `border-x border-t rounded-t-2xl` so it ' +
+          'joins the `rounded-b-2xl` body into one box, a seam that exists only while open.\n\n' +
+          'Inside that body, insurance is a nested conditional: `isInsured` mounts a further ' +
+          '`grid grid-cols-2` of Company name / Policy number. So the accordion has two quite ' +
+          'different heights, and the second is two interactions deep. Both are drawn below.\n\n' +
+          'The second is the **date-of-birth `GlassTooltip`** in the client column. Its bubble is ' +
+          '`createPortal`ed to `document.body` and positioned imperatively against the trigger ' +
+          '(`side="bottom"`, 10px gap, clamped 8px from the viewport edge, `maxWidth: 360`), and ' +
+          'it opens on `mouseenter`/`focusin` listeners attached in an effect - there is no prop ' +
+          'that reveals it. It carries the only legal-consent copy in the flow.\n\n' +
+          'The alert rows are worth watching while both of those move: each is a fieldset with an ' +
+          'explicit `gridTemplateColumns: "1fr 160px 48px"`. A malformed template there is exactly ' +
+          'the bug that shipped on the task popover - the browser drops the declaration and the ' +
+          'three children collapse into one column, which still looks deliberate.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    alertInput: '',
+    alertPriority: 'medium',
+    breedOptions: BREED_OPTIONS,
+    clientAlertInput: '',
+    clientAlertPriority: 'medium',
+    clientAlerts: CLIENT_ALERTS,
+    companionDOB: new Date('2021-04-18T00:00:00.000Z'),
+    companionErrors: {},
+    companionFormData: COMPANION,
+    companionSearchOptions: [],
+    formStep: 1,
+    genderNeuterValue: 'female-spayed',
+    localPhoneNumber: '3090182055',
+    mode: 'edit',
+    parentDOB: new Date('1989-11-02T00:00:00.000Z'),
+    parentErrors: {},
+    parentFormData: PARENT,
+    parentSearchOptions: [],
+    selectedCountryCode: GERMANY_DIAL_CODE,
+    speciesOptions: DEFAULT_SPECIES_OPTIONS,
+    variant: 'modal',
+    onAddAlert: fn(),
+    onAddClientAlert: fn(),
+    onAddressSelect: fn(),
+    onCompanionDOBChange: fn(),
+    onCompanionSelect: fn(),
+    onCountryCodeSelect: fn(),
+    onParentDOBChange: fn(),
+    onParentSelect: fn(),
+    onPhoneChange: fn(),
+    onPhotoSelected: fn(),
+    onRemoveAlert: fn(),
+    onRemoveClientAlert: fn(),
+    onSexChange: fn(),
+    onSubmit: fn(),
+    onUpdateAddressField: fn(),
+    scheduleParentSearch: fn(),
+    setAlertInput: fn(),
+    setAlertPriority: fn(),
+    setClientAlertInput: fn(),
+    setClientAlertPriority: fn(),
+    setCompanionErrors: fn(),
+    setCompanionFormData: fn(),
+    setMode: fn(),
+    setParentErrors: fn(),
+    setParentFormData: fn(),
+    terminologyText: fn((text: string) => text),
+  },
+} satisfies Meta<typeof AddCompanionFormMode>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const EditCollapsed: Story = {
+  name: 'Edit - additional details collapsed',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const accordion = canvas.getByRole('button', { name: 'Additional Details' });
+    await expect(accordion).toHaveAttribute('aria-expanded', 'false');
+    // The body is unmounted, not hidden: none of its eleven controls exist.
+    await expect(canvas.queryByLabelText('Microchip no.')).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByRole('button', { name: 'Blood group: DEA 1.1 Negative' })
+    ).not.toBeInTheDocument();
+    // The fields above it are unaffected.
+    await expect(canvas.getByLabelText('Weight (kg)')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting two-column sheet - the shape every capture of this modal has held. Patient ' +
+          'on the left, client on the right with an `lg:pl-8` gutter, and a closed accordion whose ' +
+          'contents do not exist in the DOM yet.',
+      },
+    },
+  },
+};
+
+export const AdditionalDetailsOpen: Story = {
+  name: 'Edit - additional details open',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Additional Details' }));
+
+    // Assert the body actually mounted its controls. Checking aria-expanded on
+    // its own would pass on an empty panel, which is how this stayed invisible.
+    await expect(await canvas.findByLabelText('Color (optional)')).toBeInTheDocument();
+    await expect(canvas.getByLabelText('Microchip no.')).toBeInTheDocument();
+    await expect(canvas.getByLabelText('Passport no.')).toBeInTheDocument();
+    await expect(canvas.getByLabelText('Allergies')).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('button', { name: 'Blood group: DEA 1.1 Negative' })
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('button', { name: 'Country of origin: Germany' })
+    ).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Source: Breeder' })).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('button', { name: 'Insurance: Not insured' })
+    ).toBeInTheDocument();
+    // Uninsured: the nested company/policy grid is absent.
+    await expect(canvas.queryByLabelText('Company name')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Eleven controls the closed state never draws, inside the `border-x border-b ' +
+          'rounded-b-2xl` continuation of the header. Four of them - blood group, country of ' +
+          'origin, source, insurance - are `portal`led `LabelDropdown`s, so opening this ' +
+          'accordion also introduces four more escape hatches out of the modal that the ' +
+          "modal's outside-click guard has to recognise.",
+      },
+    },
+  },
+};
+
+export const AdditionalDetailsInsured: Story = {
+  name: 'Edit - additional details open (insured)',
+  args: { companionFormData: INSURED_COMPANION },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Additional Details' }));
+    // Two interactions deep: this row only exists inside an opened accordion,
+    // for a companion whose isInsured is true.
+    await expect(await canvas.findByLabelText('Company name')).toBeInTheDocument();
+    await expect(canvas.getByLabelText('Policy number')).toBeInTheDocument();
+    await expect(canvas.getByDisplayValue('PP-4471-22')).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Insurance: Insured' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Insurance expands the accordion by a further `grid grid-cols-2 gap-3` row, pushing ' +
+          'Allergies down. The two heights are far enough apart that a modal sized off the ' +
+          'collapsed body scrolls unexpectedly here - and nothing short of opening it twice, once ' +
+          'per companion, shows that.',
+      },
+    },
+  },
+};
+
+export const AdditionalDetailsErrors: Story = {
+  name: 'Edit - insurance errors inside the accordion',
+  args: {
+    companionFormData: { ...INSURED_COMPANION, insurance: { isInsured: true } },
+    companionErrors: {
+      insuranceCompany: 'Company name is required',
+      insuranceNumber: 'Policy number is required',
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Additional Details' }));
+    // Validation messages that live behind a closed accordion: the form can be
+    // rejected for two fields the user cannot see until they disclose them.
+    await expect(await canvas.findByText('Company name is required')).toBeInTheDocument();
+    await expect(canvas.getByText('Policy number is required')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`validateCompanionFields` writes `insuranceCompany` and `insuranceNumber` errors for ' +
+          'controls that are inside the collapsed disclosure. Rendering them is the only way to ' +
+          'see how far the two error lines push the rest of the body, and to notice that nothing ' +
+          'on the accordion header signals that there is a problem underneath it.',
+      },
+    },
+  },
+};
+
+export const DateOfBirthTooltip: Story = {
+  name: 'Date-of-birth tooltip',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const info = canvas.getByRole('button', { name: 'Date of birth information' });
+    await userEvent.hover(info);
+    // GlassTooltip listens for focusin as well as mouseenter, and focusin
+    // bubbles from the button to the wrapper span that holds the listener.
+    info.focus();
+    // The bubble portals to document.body, outside the story canvas - and assert
+    // it has the copy, not merely that a tooltip node appeared.
+    const tooltip = await within(document.body).findByRole('tooltip');
+    await expect(tooltip).toHaveTextContent(/age verification and legal consent/i);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The only place in the add-companion flow that explains why a client date of birth is ' +
+          'being asked for. The trigger is an 18px `IoInformationCircleOutline` with `mt-3` to ' +
+          'clear the field label beside it, and the bubble is capped at 360px and clamped 8px ' +
+          'inside the viewport, so its shape depends entirely on where the modal sits.',
+      },
+    },
+  },
+};
+
+export const CreateStepOne: Story = {
+  name: 'Create wizard - step 1 (patient)',
+  args: { mode: 'create', formStep: 1 },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Create mode renders one column at a time, so the client fields are gone
+    // and Sex is a radio row rather than the combined dropdown.
+    await expect(canvas.queryByLabelText('First name')).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: /^Sex/ })).not.toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Additional Details' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The wizard step, capped at `max-w-[760px]` and centred. `sexAsRadio` is true here and ' +
+          'false in edit mode, so the same patient column renders Male/Female radios plus a ' +
+          'Neutered checkbox instead of the five-option `GENDER_NEUTER_OPTIONS` dropdown - two ' +
+          'different controls for one field, decided by a boolean two components down.',
+      },
+    },
+  },
+};
+
+export const CreateStepTwo: Story = {
+  name: 'Create wizard - step 2 (client)',
+  args: { mode: 'create', formStep: 2 },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByLabelText('First name')).toBeInTheDocument();
+    await expect(
+      canvas.queryByRole('button', { name: 'Additional Details' })
+    ).not.toBeInTheDocument();
+    // The tooltip trigger travels with the client column, so it exists on this
+    // step of the wizard and not on the previous one.
+    await expect(
+      canvas.getByRole('button', { name: 'Date of birth information' })
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The second wizard step: the same `ClientDetailsColumn` the edit sheet puts in its right ' +
+          'half, here alone and full width, and without the edit footer - the create flow renders ' +
+          'its own in the parent modal.',
+      },
+    },
+  },
+};
+
+export const PhoneSheet: Story = {
+  name: 'Create wizard - phone sheet variant',
+  args: { mode: 'create', formStep: 1, variant: 'sheet' },
+  globals: { viewport: { value: 'phone', isRotated: false } },
+  parameters: {
+    viewport: {
+      options: {
+        phone: {
+          name: 'Mobile (375)',
+          styles: { width: '375px', height: '812px' },
+          type: 'mobile',
+        },
+      },
+    },
+    chromatic: { viewports: [375] },
+    docs: {
+      description: {
+        story:
+          'The `sheet` variant drops the `mx-auto max-w-[760px]` wrapper for a plain `w-full`, ' +
+          'because the phone bottom sheet already owns the width and the sticky footer. At 375 the ' +
+          'alert fieldset is the pressure point: its `1fr 160px 48px` template leaves the label ' +
+          'input under 130px wide.',
+      },
+    },
+  },
+};
+
+export const ValidationErrors: Story = {
+  name: 'Edit - validation errors',
+  args: {
+    companionFormData: { ...COMPANION, name: '', breed: '' },
+    companionErrors: {
+      name: 'Name is required',
+      breed: 'Breed is required',
+      species: 'Species is required',
+    },
+    parentErrors: {
+      firstName: 'First name is required',
+      email: 'Enter a valid email address',
+      phoneNumber: 'Number is required',
+      addressLine: 'Address is required',
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Name is required')).toBeInTheDocument();
+    await expect(canvas.getByText('Enter a valid email address')).toBeInTheDocument();
+    await expect(canvas.getByText('Address is required')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Errors on both columns at once. They render below their fields inside the shared ' +
+          '`gap-3` column, so a two-column grid row with one failing field and one passing one ' +
+          'goes out of vertical alignment - which is only visible with several of them lit.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/companions/components/AddCompanionCentralModal/AddCompanionFormMode.stories.tsx
+++ b/apps/frontend/src/app/features/companions/components/AddCompanionCentralModal/AddCompanionFormMode.stories.tsx
@@ -204,7 +204,7 @@ export const AdditionalDetailsOpen: Story = {
 
     // Assert the body actually mounted its controls. Checking aria-expanded on
     // its own would pass on an empty panel, which is how this stayed invisible.
-    await expect(await canvas.findByLabelText('Color (optional)')).toBeInTheDocument();
+    expect(await canvas.findByLabelText('Color (optional)')).toBeInTheDocument();
     await expect(canvas.getByLabelText('Microchip no.')).toBeInTheDocument();
     await expect(canvas.getByLabelText('Passport no.')).toBeInTheDocument();
     await expect(canvas.getByLabelText('Allergies')).toBeInTheDocument();
@@ -243,7 +243,7 @@ export const AdditionalDetailsInsured: Story = {
     await userEvent.click(canvas.getByRole('button', { name: 'Additional Details' }));
     // Two interactions deep: this row only exists inside an opened accordion,
     // for a companion whose isInsured is true.
-    await expect(await canvas.findByLabelText('Company name')).toBeInTheDocument();
+    expect(await canvas.findByLabelText('Company name')).toBeInTheDocument();
     await expect(canvas.getByLabelText('Policy number')).toBeInTheDocument();
     await expect(canvas.getByDisplayValue('PP-4471-22')).toBeInTheDocument();
     await expect(canvas.getByRole('button', { name: 'Insurance: Insured' })).toBeInTheDocument();
@@ -275,7 +275,7 @@ export const AdditionalDetailsErrors: Story = {
     await userEvent.click(canvas.getByRole('button', { name: 'Additional Details' }));
     // Validation messages that live behind a closed accordion: the form can be
     // rejected for two fields the user cannot see until they disclose them.
-    await expect(await canvas.findByText('Company name is required')).toBeInTheDocument();
+    expect(await canvas.findByText('Company name is required')).toBeInTheDocument();
     await expect(canvas.getByText('Policy number is required')).toBeInTheDocument();
   },
   parameters: {

--- a/apps/frontend/src/app/features/companions/components/AddCompanionCentralModal/AddCompanionViewMode.stories.tsx
+++ b/apps/frontend/src/app/features/companions/components/AddCompanionCentralModal/AddCompanionViewMode.stories.tsx
@@ -160,7 +160,7 @@ export const AdditionalDetailsOpen: Story = {
     await userEvent.click(canvas.getByRole('button', { name: 'Additional Details' }));
     // Assert the body actually mounted its rows. Checking aria-expanded alone
     // would pass on an empty panel, which is how this stayed invisible.
-    await expect(await canvas.findByText('Color')).toBeInTheDocument();
+    expect(await canvas.findByText('Color')).toBeInTheDocument();
     await expect(canvas.getByText('Blood group')).toBeInTheDocument();
     await expect(canvas.getByText('Weight (kg)')).toBeInTheDocument();
     await expect(canvas.getByText('Country of origin')).toBeInTheDocument();
@@ -197,7 +197,7 @@ export const SparseAdditionalDetails: Story = {
     await userEvent.click(canvas.getByRole('button', { name: 'Additional Details' }));
     // Every row inside is conditional, so the panel collapses to the one
     // unconditional line - a very different shape from the populated case.
-    await expect(await canvas.findByText('Insurance')).toBeInTheDocument();
+    expect(await canvas.findByText('Insurance')).toBeInTheDocument();
     await expect(canvas.getByText('Not insured')).toBeInTheDocument();
     await expect(canvas.queryByText('Microchip')).not.toBeInTheDocument();
     await expect(canvas.queryByText('Insurance company')).not.toBeInTheDocument();

--- a/apps/frontend/src/app/features/companions/components/AddCompanionCentralModal/InputWithDropdown.stories.tsx
+++ b/apps/frontend/src/app/features/companions/components/AddCompanionCentralModal/InputWithDropdown.stories.tsx
@@ -100,16 +100,24 @@ export const Open: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await userEvent.type(canvas.getByLabelText('Pet parent'), 'ma');
-    const panel = document.querySelector('[data-iwd-panel]');
+    const panel = document.querySelector('[data-iwd-panel]') as HTMLElement;
     await expect(panel).toBeInTheDocument();
+    /* Three, not two. `useFilteredOptions` is a plain `label.toLowerCase().includes()`
+       over the WHOLE label, so "ma" also matches the middle of "Priya Raman". Asserting
+       two here was wrong about the component, and the number is the point of the story:
+       a substring filter with no word-boundary rule surfaces mid-surname matches that
+       look like noise to whoever is typing. */
     // Options are plain buttons, not role="option" - assert the content, not the role.
-    await expect(within(panel as HTMLElement).getAllByRole('button')).toHaveLength(2);
+    await expect(within(panel).getAllByRole('button')).toHaveLength(3);
+    await expect(within(panel).getByText('Priya Raman')).toBeInTheDocument();
   },
   parameters: {
     docs: {
       description: {
         story:
-          'Typing "ma" narrows five parents to Maya Whitfield and Marcus Alvarez. The input has ' +
+          'Typing "ma" narrows five parents to three: Maya Whitfield, Marcus Alvarez and - less ' +
+          'obviously - Priya Ra**ma**n, because the filter is a substring test over the whole ' +
+          'label with no word-boundary rule. The input has ' +
           'squared its bottom corners and dropped its bottom border so it joins the panel.',
       },
     },

--- a/apps/frontend/src/app/features/docSigning/components/DocSigningPortal.tsx
+++ b/apps/frontend/src/app/features/docSigning/components/DocSigningPortal.tsx
@@ -49,7 +49,7 @@ const DocSigningPortal = ({ embedded = false }: DocSigningPortalProps) => {
 
   if (error) {
     return (
-      <div role="alert" className="text-body-3 text-error-main">
+      <div role="alert" className="text-body-3 text-text-error">
         {error}
       </div>
     );

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceInfo.stories.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceInfo.stories.tsx
@@ -1,0 +1,584 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import type { Appointment, Invoice } from '@yosemite-crew/types';
+
+import type { StoredParent } from '@/app/features/companions/pages/Companions/types';
+import { useAppointmentStore } from '@/app/stores/appointmentStore';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useParentStore } from '@/app/stores/parentStore';
+import InvoiceInfo from './InvoiceInfo';
+
+const ORG_ID = 'org-avenger-park';
+const APPOINTMENT_ID = 'appointment-8842';
+const PARENT_ID = 'parent-sky-doe';
+
+const patient: Appointment['patient'] = {
+  id: 'companion-kizie',
+  name: 'Kizie',
+  species: 'dog',
+  breed: 'Beagle',
+  parent: { id: PARENT_ID, name: 'Sky Doe' },
+};
+
+const APPOINTMENT: Appointment = {
+  id: APPOINTMENT_ID,
+  organisationId: ORG_ID,
+  patient,
+  companion: patient,
+  appointmentType: {
+    id: 'type-dental',
+    name: 'Dental consultation',
+    speciality: { id: 'spec-dentistry', name: 'Dentistry' },
+  },
+  appointmentDate: new Date('2026-08-12T09:30:00.000Z'),
+  startTime: new Date('2026-08-12T09:30:00.000Z'),
+  endTime: new Date('2026-08-12T10:00:00.000Z'),
+  timeSlot: '09:30 AM',
+  durationMinutes: 30,
+  status: 'COMPLETED',
+};
+
+const PARENT: StoredParent = {
+  id: PARENT_ID,
+  firstName: 'Sky',
+  lastName: 'Doe',
+  email: 'sky.doe@example.com',
+  phoneNumber: '+44 7700 900142',
+  address: {
+    addressLine: '14 Fell Lane',
+    city: 'Keswick',
+    postalCode: 'CA12 4DP',
+    country: 'GB',
+  },
+  createdFrom: 'pms',
+};
+
+/**
+ * Every value the drawer shows beyond `activeInvoice` is read out of a plain
+ * Zustand store - the appointment from `appointmentStore`, the payer from
+ * `parentStore`, the currency from `subscriptionStore` via `orgStore`. None of
+ * those hooks fetches on read, so seeding them is the whole of the setup and the
+ * drawer under review is the real one, with no service stubbed.
+ */
+const seedStores = (parent: StoredParent | null = PARENT) => {
+  useOrgStore.setState({ primaryOrgId: ORG_ID, status: 'loaded' });
+  useAppointmentStore.getState().setAppointmentsForOrg(ORG_ID, [APPOINTMENT]);
+  useParentStore.getState().setParents(parent ? [parent] : []);
+};
+
+/**
+ * `formatMoney` runs at `maximumFractionDigits: 0`, so every figure below is a
+ * whole number on purpose - a 92.65 total would print as "$93" and make the
+ * assertions read as though the arithmetic were wrong.
+ */
+const PAID_INVOICE: Invoice = {
+  id: 'a1b2c3d4e5f60718293a4b5c',
+  organisationId: ORG_ID,
+  appointmentId: APPOINTMENT_ID,
+  parentId: PARENT_ID,
+  metadata: { invoiceNumber: 'INV-2026-0142' },
+  items: [
+    { id: 'line-1', name: 'Dental consultation', quantity: 1, unitPrice: 60, total: 60 },
+    { id: 'line-2', name: 'Scale and polish', quantity: 1, unitPrice: 45, total: 45 },
+  ],
+  subtotal: 105,
+  discountTotal: 10,
+  taxPercent: 20,
+  taxTotal: 19,
+  totalAmount: 114,
+  paymentCollectionMethod: 'PAYMENT_INTENT',
+  currency: 'USD',
+  status: 'PAID',
+  stripeReceiptUrl: 'https://pay.stripe.com/receipts/example',
+  paidAt: new Date('2026-08-12T10:15:00.000Z'),
+  createdAt: new Date('2026-08-12T10:02:00.000Z'),
+  updatedAt: new Date('2026-08-12T10:15:00.000Z'),
+};
+
+/**
+ * The panel portals to `document.body`, so none of it is inside `canvasElement`,
+ * and a closed dialog stays MOUNTED without its `open` attribute - absence has to
+ * be asserted against `dialog[open]`, never against the text.
+ */
+const openDrawer = (): HTMLElement => {
+  const dialog = document.querySelector('dialog[open]');
+  if (!dialog) throw new Error('No open dialog on document.body.');
+  return dialog as HTMLElement;
+};
+
+const section = (dialog: HTMLElement, label: string): HTMLElement | null =>
+  dialog.querySelector(`section[aria-label="${label}"]`);
+
+/** Resolved grid tracks, rounded to whole pixels so subpixel noise cannot fail a match. */
+const tracks = (el: HTMLElement): number[] =>
+  getComputedStyle(el)
+    .gridTemplateColumns.trim()
+    .split(/\s+/)
+    .map((track) => Math.round(Number.parseFloat(track)));
+
+/**
+ * Every billed-items row, header band excluded. Both carry the same four-track
+ * template as separate inline styles, so they are compared rather than trusted.
+ */
+const itemRows = (items: HTMLElement): HTMLElement[] =>
+  [...items.querySelectorAll('.grid')].filter(
+    (el) => !el.classList.contains('yc-table-head')
+  ) as HTMLElement[];
+
+/**
+ * Resolves a design token to the colour the browser actually paints, so a story
+ * can say "outstanding is the warn ink" rather than only "it is not the same
+ * colour as the total". Throws on an unresolved token: `var(--typo)` computes to
+ * transparent, which would otherwise quietly match anything else that also
+ * computes to transparent and turn the assertion into a no-op.
+ */
+const resolveToken = (host: HTMLElement, token: string): string => {
+  const probe = document.createElement('span');
+  probe.style.backgroundColor = `var(${token})`;
+  host.append(probe);
+  const value = getComputedStyle(probe).backgroundColor;
+  probe.remove();
+  if (value === 'rgba(0, 0, 0, 0)') {
+    throw new Error(`Token ${token} resolved to transparent - it does not exist here.`);
+  }
+  return value;
+};
+
+/** The value span of a summary row, read off its label rather than by figure. */
+const summaryValue = (summary: HTMLElement, label: string): HTMLElement => {
+  const value = within(summary).getByText(label).nextElementSibling;
+  if (!value) throw new Error(`Summary row "${label}" has no value beside it.`);
+  return value as HTMLElement;
+};
+
+const meta = {
+  title: 'Finance/InvoiceInfo',
+  component: InvoiceInfo,
+  parameters: {
+    layout: 'fullscreen',
+    // `goToAppointmentFinance` calls next/navigation's useRouter during render.
+    nextjs: { appDirectory: true },
+    docs: {
+      description: {
+        component:
+          'The invoice detail drawer behind every "View" in Finance - six sections assembled from ' +
+          'five section components, and it had no story at all. It opens on a click, so nothing ' +
+          'about it was reviewable except by driving the live app with real invoice data.\n\n' +
+          'It is two entirely different records, not one responsive layout. Above 768px it is a ' +
+          '`centered` Modal at `lg` (840px) holding the desktop record: header, billed-items ' +
+          'table, payment ledger, summary panel and billed-to card in a two-column grid. Below ' +
+          '768px `useIsPhone` swaps the whole body for `InvoicePhoneRecord` - a single stacked ' +
+          'block ending in a --screen-2 tax row and a big total - and the Modal itself re-forms ' +
+          'into a bottom sheet with a grabber. The phone story is the only place that record is ' +
+          'ever drawn.\n\n' +
+          'Three things are conditional and easy to miss. The **payment ledger renders only for a ' +
+          'settled invoice** (`PAID`/`REFUNDED`, or any invoice carrying `paidAt`), so an ' +
+          'awaiting-payment invoice is a shorter panel rather than one with an empty ledger. ' +
+          '**Outstanding is tinted** - `--warn-text` while money is owed, `--success-text` at ' +
+          'zero, and the stories resolve those tokens rather than compare the two figures to each ' +
+          'other. And the **billed-items grid is a CSS grid pretending to be a table**: the header ' +
+          'band and every row carry the same four-track template as an inline style, with nothing ' +
+          'enforcing that they agree.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    showModal: true,
+    setShowModal: fn(),
+    activeInvoice: PAID_INVOICE,
+  },
+  beforeEach: () => {
+    seedStores();
+  },
+  decorators: [
+    (Story) => (
+      <div className="min-h-[720px] bg-[var(--screen)] p-6">
+        <p className="text-[13px] text-[var(--ink-muted)]">
+          The Finance table sits behind the scrim, so the backdrop blur and tint are visible.
+        </p>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof InvoiceInfo>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Paid: Story = {
+  name: 'Paid invoice',
+  play: async ({ canvasElement }) => {
+    const dialog = await waitFor(openDrawer);
+    const panel = within(dialog);
+
+    // The header takes the number from metadata, not from the opaque id.
+    await expect(panel.getByRole('heading', { name: '#INV-2026-0142' })).toBeInTheDocument();
+    await expect(panel.getByText('Paid')).toBeInTheDocument();
+
+    /* The two-column split is keyed on the VIEWPORT (`lg:` = 1024px), not on the
+       840px panel it lives in - so it collapses to one column in a narrow window
+       while the panel itself is unchanged. Reading the track count is the only
+       way to tell which of the two a screenshot is showing, and the child count
+       is what says both columns were actually filled. */
+    const items = section(dialog, 'Billed items') as HTMLElement;
+    const split = items.closest('.grid') as HTMLElement;
+    await expect(tracks(split)).toHaveLength(2);
+    await expect(split.children).toHaveLength(2);
+
+    /* Header band and rows carry the same four-track template as separate inline
+       styles. Nothing keeps them in step, and a drifted header does not break -
+       it just stops sitting above its own column, which is invisible in code
+       review and obvious here. */
+    const head = items.querySelector('.yc-table-head') as HTMLElement;
+    const rows = itemRows(items);
+    await expect(head.children).toHaveLength(4);
+    await expect(rows).toHaveLength(2);
+    await expect(tracks(head)).toHaveLength(4);
+    await expect(tracks(rows[0])).toEqual(tracks(head));
+    await expect(tracks(rows[1])).toEqual(tracks(head));
+
+    /* Four cells per row, in the header's order: name, qty, gross, amount. The
+       row only reads correctly if the cell count matches the track count - a
+       missing cell shifts every figure one column left under the wrong heading. */
+    for (const row of rows) {
+      await expect(row.children).toHaveLength(4);
+    }
+    await expect(rows[0].children[0]).toHaveTextContent('Dental consultation');
+    await expect(rows[0].children[3]).toHaveTextContent('$60');
+    await expect(rows[1].children[0]).toHaveTextContent('Scale and polish');
+    await expect(rows[1].children[3]).toHaveTextContent('$45');
+
+    // Summary arithmetic, in full: subtotal - discount + tax = total.
+    const summarySection = section(dialog, 'Invoice summary') as HTMLElement;
+    const summary = within(summarySection);
+    await expect(summaryValue(summarySection, 'Subtotal')).toHaveTextContent('$105');
+    await expect(summaryValue(summarySection, 'Discount')).toHaveTextContent('$10');
+    // The tax row takes the percent into its label when the invoice carries one.
+    await expect(summary.getByText('Tax · 20%')).toBeInTheDocument();
+    await expect(summaryValue(summarySection, 'Tax · 20%')).toHaveTextContent('$19');
+
+    /* Every summary row is a label span followed by its value span, so the value
+       is read off the label rather than by searching for the figure - which would
+       silently pass by matching the same amount printed in the ledger. */
+    const total = summaryValue(summarySection, 'Total');
+    const outstanding = summaryValue(summarySection, 'Outstanding');
+    await expect(total).toHaveTextContent('$114');
+
+    /* Settled, so outstanding is zero AND carries the success ink rather than the
+       warn ink. The zero alone would pass with the tint broken, and "different
+       from the total" would pass on any colour at all, so both are resolved
+       against their tokens - inside waitFor, because the panel fades in. */
+    await expect(outstanding).toHaveTextContent('$0');
+    await waitFor(() => {
+      expect(getComputedStyle(outstanding).color).toBe(resolveToken(dialog, '--success-text'));
+      expect(getComputedStyle(total).color).toBe(resolveToken(dialog, '--ink'));
+    });
+
+    // The ledger names the channel rather than saying "payment recorded".
+    const paymentsSection = section(dialog, 'Payments') as HTMLElement;
+    const payments = within(paymentsSection);
+    await expect(payments.getByText('Paid in the pet-parent app')).toBeInTheDocument();
+    await expect(payments.getByText('$114')).toBeInTheDocument();
+    await expect(payments.getByRole('link', { name: 'Receipt' })).toBeInTheDocument();
+    await expect(panel.getByText('Receipt sent to sky.doe@example.com')).toBeInTheDocument();
+
+    // Billed-to is composed from the stored parent, not from the appointment.
+    const billedTo = within(section(dialog, 'Billed to') as HTMLElement);
+    await expect(billedTo.getByText('Sky Doe')).toBeInTheDocument();
+    await expect(billedTo.getByText('14 Fell Lane, CA12 4DP Keswick')).toBeInTheDocument();
+    await expect(billedTo.getByText('sky.doe@example.com · +44 7700 900142')).toBeInTheDocument();
+
+    // Nothing the drawer renders is inside the story root; this is the proof.
+    await expect(within(canvasElement).queryByText('#INV-2026-0142')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The complete desktop record: a settled invoice with two lines, a discount, tax at 20% ' +
+          'and a Stripe receipt. This is the only state in which all six sections render at once, ' +
+          'so it is the layout reference for the rest.',
+      },
+    },
+  },
+};
+
+export const AwaitingPayment: Story = {
+  name: 'Awaiting payment (no ledger)',
+  args: {
+    activeInvoice: {
+      ...PAID_INVOICE,
+      metadata: { invoiceNumber: 'INV-2026-0163' },
+      status: 'AWAITING_PAYMENT',
+      paymentCollectionMethod: 'PAYMENT_LINK',
+      paidAt: undefined,
+      stripeReceiptUrl: undefined,
+    },
+  },
+  play: async () => {
+    const dialog = await waitFor(openDrawer);
+    const panel = within(dialog);
+
+    await expect(panel.getByRole('heading', { name: '#INV-2026-0163' })).toBeInTheDocument();
+    await expect(panel.getByText('Awaiting payment')).toBeInTheDocument();
+
+    /* `InvoicePaymentLedger` returns null outright for an unsettled invoice, so
+       the whole section is absent rather than empty - and with it the "Receipt
+       sent to ..." confirmation, which would otherwise claim a receipt exists. */
+    await expect(section(dialog, 'Payments')).toBeNull();
+    await expect(panel.queryByText(/^Receipt sent to /)).not.toBeInTheDocument();
+
+    /* Outstanding is the full total here and carries the warn ink, which is the
+       single strongest signal in the panel that money is owed. Same figure in
+       both rows, so only the resolved token separates them. */
+    const summarySection = section(dialog, 'Invoice summary') as HTMLElement;
+    const total = summaryValue(summarySection, 'Total');
+    const outstanding = summaryValue(summarySection, 'Outstanding');
+    await expect(outstanding).toHaveTextContent('$114');
+    await expect(total).toHaveTextContent('$114');
+    await waitFor(() => {
+      expect(getComputedStyle(outstanding).color).toBe(resolveToken(dialog, '--warn-text'));
+      expect(getComputedStyle(total).color).toBe(resolveToken(dialog, '--ink'));
+    });
+
+    /* Everything else is unchanged - the panel is SHORTER, not different. Both
+       remaining sections are checked by their content rather than by existing,
+       because a section that renders empty would still be non-null. */
+    const items = section(dialog, 'Billed items') as HTMLElement;
+    const head = items.querySelector('.yc-table-head') as HTMLElement;
+    const rows = itemRows(items);
+    await expect(rows).toHaveLength(2);
+    await expect(tracks(rows[0])).toEqual(tracks(head));
+    await expect(rows[0].children[0]).toHaveTextContent('Dental consultation');
+    const billedTo = within(section(dialog, 'Billed to') as HTMLElement);
+    await expect(billedTo.getByText('Sky Doe')).toBeInTheDocument();
+    await expect(billedTo.getByText('sky.doe@example.com · +44 7700 900142')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The state most invoices are in for their first hours. Worth putting beside the paid ' +
+          'story: the panel loses a whole section rather than showing an empty one, which is why ' +
+          'the summary and billed-to cards move up rather than the layout leaving a gap.',
+      },
+    },
+  },
+};
+
+export const PaidAtClinic: Story = {
+  name: 'Paid at the clinic',
+  args: {
+    activeInvoice: {
+      ...PAID_INVOICE,
+      metadata: { invoiceNumber: 'INV-2026-0171' },
+      paymentCollectionMethod: 'PAYMENT_AT_CLINIC',
+      stripeReceiptUrl: undefined,
+    },
+  },
+  play: async () => {
+    const dialog = await waitFor(openDrawer);
+    const payments = within(section(dialog, 'Payments') as HTMLElement);
+
+    /* The channel is derived from `paymentCollectionMethod`, and it changes the
+       glyph as well as the title - an over-the-counter payment must not read as
+       though the client paid in the pet-parent app. */
+    await expect(payments.getByText('Paid at the clinic')).toBeInTheDocument();
+    await expect(payments.queryByText('Paid in the pet-parent app')).not.toBeInTheDocument();
+    // No Stripe receipt for a desk payment, so the link is absent, not disabled.
+    await expect(payments.queryByRole('link', { name: 'Receipt' })).not.toBeInTheDocument();
+    // The row still closes with the amount; only the receipt link went.
+    await expect(payments.getByText('$114')).toBeInTheDocument();
+    /* The caption names the method and the payer. Matched at its two ends rather
+       than in full, because the timestamp between them renders in the viewer's
+       timezone and would differ between machines. */
+    await expect(payments.getByTitle(/^In-person payment · /)).toBeInTheDocument();
+    await expect(payments.getByTitle(/ · by Sky Doe$/)).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same settled invoice taken at the desk. `getLedgerChannel` is shared with the phone ' +
+          'record, so this title and glyph are what a client sees at every width.',
+      },
+    },
+  },
+};
+
+export const NoItemsNoContact: Story = {
+  name: 'Unlinked, no items, no contact',
+  args: {
+    activeInvoice: {
+      ...PAID_INVOICE,
+      metadata: { invoiceNumber: 'INV-2026-0009' },
+      appointmentId: undefined,
+      parentId: undefined,
+      items: [],
+      subtotal: 0,
+      discountTotal: 0,
+      taxPercent: undefined,
+      taxTotal: 0,
+      totalAmount: 0,
+    },
+  },
+  beforeEach: () => {
+    seedStores(null);
+  },
+  play: async () => {
+    const dialog = await waitFor(openDrawer);
+    const panel = within(dialog);
+
+    /* The header band still renders above the empty state, with its full
+       four-track template - so the panel keeps its column structure instead of
+       collapsing to a bare sentence - and there are no rows under it at all,
+       which is what separates "no items" from "a row of blanks". */
+    const items = section(dialog, 'Billed items') as HTMLElement;
+    const head = items.querySelector('.yc-table-head') as HTMLElement;
+    await expect(head.children).toHaveLength(4);
+    await expect(tracks(head)).toHaveLength(4);
+    await expect(itemRows(items)).toHaveLength(0);
+    await expect(panel.getByText('No billed items recorded for this invoice.')).toBeInTheDocument();
+
+    // No stored parent and no appointment to fall back to.
+    await expect(panel.getByText('No billing contact on file.')).toBeInTheDocument();
+
+    /* With no appointment there is no companion, no subtitle and no route to
+       open - so the header action disappears rather than pushing a dead link. */
+    await expect(panel.queryByRole('button', { name: 'Open appointment' })).not.toBeInTheDocument();
+
+    // The tax row loses its percent suffix when the invoice carries none.
+    const summarySection = section(dialog, 'Invoice summary') as HTMLElement;
+    await expect(within(summarySection).getByText('Tax')).toBeInTheDocument();
+
+    /* A zero invoice still prints figures rather than dashes, and nothing is
+       owed on it - so Outstanding takes the success ink even though no money
+       ever moved. That is the one place the tint is not a payment signal. */
+    const total = summaryValue(summarySection, 'Total');
+    const outstanding = summaryValue(summarySection, 'Outstanding');
+    await expect(total.textContent).toBe('$0');
+    await expect(outstanding.textContent).toBe('$0');
+    await waitFor(() => {
+      expect(getComputedStyle(outstanding).color).toBe(resolveToken(dialog, '--success-text'));
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'An over-the-counter sale with nothing attached: no appointment, no stored parent and no ' +
+          'lines. Three separate fallbacks fire at once, and each one is prose rather than a dash, ' +
+          'because a dash in a billing document reads as a zero.',
+      },
+    },
+  },
+};
+
+export const OpensAppointment: Story = {
+  name: 'Open appointment closes the drawer',
+  play: async ({ args }) => {
+    const dialog = await waitFor(openDrawer);
+    const panel = within(dialog);
+
+    /* The button only exists because the invoice resolved to a real appointment,
+       and the header meta is the visible proof of that resolution: companion,
+       owner surname, service, date. Without it, a passing click assertion would
+       not tell you WHICH appointment the drawer thinks it is on. */
+    await expect(panel.getByText(/^Kizie · Doe · Dental consultation · /)).toBeInTheDocument();
+
+    const open = panel.getByRole('button', { name: 'Open appointment' });
+    await expect(args.setShowModal).not.toHaveBeenCalled();
+
+    await userEvent.click(open);
+
+    /* The handler pushes `/appointments?...&open=finance&subLabel=summary` and
+       then closes the drawer, in that order. The route is Storybook's mocked
+       router, so the close is the observable half - and it matters: leaving the
+       drawer open would strand a modal over the appointment workspace. Once,
+       not twice: a second call would mean the click was double-handled. */
+    await waitFor(() => {
+      expect(args.setShowModal).toHaveBeenCalledWith(false);
+    });
+    await expect(args.setShowModal).toHaveBeenCalledTimes(1);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The one navigation the drawer owns. It is a real `<button>` rather than a link because ' +
+          'it has to close the drawer as well as route, and the query it builds is what makes the ' +
+          'appointment workspace land on the Finance step rather than at the top.',
+      },
+    },
+  },
+};
+
+export const Phone: Story = {
+  name: 'Phone: the record becomes a sheet',
+  // Pinned as a GLOBAL. `parameters.viewport.defaultViewport` was removed in
+  // Storybook 10 and is inert - a story using it renders the 1280px desktop
+  // record under a name that promises a phone.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async () => {
+    const dialog = await waitFor(openDrawer);
+    const panel = within(dialog);
+
+    /* `useIsPhone` is false during SSR and the first client render, so both the
+       sheet chrome and the phone record are post-mount swaps - poll for them
+       rather than reading once. */
+    await waitFor(() => {
+      expect(dialog.className).toContain('yc-phone-sheet');
+    });
+
+    /* The grabber is measured, not merely found. Its geometry lives inside the
+       `max-width: 767px` block in Sheet.css, so a 44x5 pill is proof that the
+       phone rules actually applied - a class name in the DOM would still be
+       there with the viewport pin inert and the sheet CSS never matching. */
+    const grabber = dialog.querySelector('.yc-phone-sheet-grabber') as HTMLElement;
+    await expect(grabber).not.toBeNull();
+    const grabberStyle = getComputedStyle(grabber);
+    await expect(grabberStyle.width).toBe('44px');
+    await expect(grabberStyle.height).toBe('5px');
+    // The sheet spans the viewport, and the viewport really is phone-sized.
+    const viewportWidth = document.documentElement.clientWidth;
+    await expect(viewportWidth).toBeLessThanOrEqual(430);
+    await expect(Math.round(dialog.getBoundingClientRect().width)).toBe(viewportWidth);
+
+    /* A different record, not a reflow: every desktop section is gone, including
+       the ones whose text survives, so asserting on the section landmarks rather
+       than on words is what actually proves the swap. */
+    await expect(section(dialog, 'Billed items')).toBeNull();
+    await expect(section(dialog, 'Invoice summary')).toBeNull();
+    await expect(section(dialog, 'Billed to')).toBeNull();
+
+    // The stacked block: both lines, the tax row, and the big total.
+    await expect(panel.getByRole('heading', { name: '#INV-2026-0142' })).toBeInTheDocument();
+    await expect(panel.getByText('Dental consultation')).toBeInTheDocument();
+    await expect(panel.getByText('Scale and polish')).toBeInTheDocument();
+    // The phone record breaks the discount out as its own signed row.
+    await expect(panel.getByText('-$10')).toBeInTheDocument();
+    await expect(panel.getByText('Tax 20%')).toBeInTheDocument();
+    /* Once, not twice: unlike the desktop ledger, the phone payment row prints no
+       amount at all - the total above it is the only figure on the sheet. */
+    await expect(panel.getAllByText('$114')).toHaveLength(1);
+    await expect(panel.getByText('Total').nextElementSibling).toHaveTextContent('$114');
+    // The phone ledger still names the channel, it just drops the amount.
+    await expect(panel.getByText('Paid in the pet-parent app')).toBeInTheDocument();
+
+    // Two full-width actions, per the phone sheet rule.
+    await expect(panel.getByRole('button', { name: 'Open appointment' })).toBeInTheDocument();
+    await expect(panel.getByRole('button', { name: 'Close' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'At 375px `InvoiceInfo` renders `InvoicePhoneRecord` instead of the desktop record, and ' +
+          'the Modal re-forms into a bottom sheet with a grabber. Two details only exist here: the ' +
+          'discount gets its own signed row on a --screen-2 band, and the tax label drops the ' +
+          'middle dot ("Tax 20%", not "Tax · 20%").',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/Build.stories.tsx
+++ b/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/Build.stories.tsx
@@ -1,0 +1,920 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import type { FormField, FormsProps } from '@/app/features/forms/types/forms';
+import {
+  closeGlassTooltip,
+  openGlassTooltip,
+} from '@/app/ui/primitives/GlassTooltip/storyInteractions';
+import Build from './Build';
+
+type ServiceOption = { label: string; value: string; badge?: string };
+
+const SERVICE_OPTIONS: ServiceOption[] = [
+  { label: 'Dental consultation', value: 'svc-dental', badge: 'Service' },
+  { label: 'Senior wellness package', value: 'svc-senior', badge: 'Package' },
+  { label: 'Post-op recheck', value: 'svc-recheck', badge: 'Service' },
+];
+
+/** The 14 palette entries, in the order `addOptions` declares them. */
+const ALL_ADD_OPTIONS = [
+  'Long Text',
+  'Rich Text',
+  'Short Text',
+  'Number',
+  'Select List',
+  'Single Choice',
+  'Multiple Choice',
+  'Yes / No',
+  'Date',
+  'Signature',
+  'Field Group',
+  'Medications',
+  'Services / Packages',
+  'Tasks',
+];
+
+const CONSENT_SCHEMA: FormField[] = [
+  {
+    id: 'presenting_complaint',
+    type: 'input',
+    label: 'Presenting complaint',
+    placeholder: 'Limping on the left hind',
+  },
+  {
+    id: 'observed_signs',
+    type: 'checkbox',
+    label: 'Observed signs',
+    multiple: true,
+    options: [
+      { label: 'Lameness', value: 'lameness' },
+      { label: 'Swelling', value: 'swelling' },
+    ],
+  },
+  { id: 'owner_signature', type: 'signature', label: 'Owner signature' },
+];
+
+const SOAP_SCHEMA: FormField[] = [
+  { id: 'subjective', type: 'textarea', label: 'Subjective', placeholder: '' },
+  { id: 'objective_group', type: 'group', label: 'Objective', fields: [] },
+];
+
+const form = (over: Partial<FormsProps> = {}): FormsProps => ({
+  _id: 'form-2291',
+  name: 'Anaesthesia consent',
+  category: 'Consent form',
+  usage: 'Internal & External',
+  requiredSigner: 'CLIENT',
+  services: ['svc-dental', 'svc-senior'],
+  updatedBy: 'Dr. Elena Marsh',
+  lastUpdated: '2026-06-02T10:15:00.000Z',
+  status: 'Draft',
+  templateSource: 'ORG_TEMPLATE',
+  schema: CONSENT_SCHEMA,
+  ...over,
+});
+
+type HarnessProps = {
+  initialForm: FormsProps;
+  serviceOptions: ServiceOption[];
+  /** Width of the box `Build` is dropped into. 504 is the real AddForm drawer. */
+  width: string;
+};
+
+/**
+ * `Build` is a controlled step: it never holds its own schema, it calls
+ * `setFormData` and re-reads. A story that passed a frozen object would render a
+ * palette whose tiles do nothing, so the harness owns the state the way AddForm does.
+ *
+ * The width is a story argument because everything below the palette is driven by a
+ * container query against this box, not by the viewport.
+ */
+const BuilderHarness = ({ initialForm, serviceOptions, width }: HarnessProps) => {
+  const [formData, setFormData] = useState<FormsProps>(initialForm);
+  return (
+    <div className="bg-[var(--screen)] p-4">
+      <div
+        className="h-[640px] overflow-hidden rounded-2xl border border-[var(--hairline)]"
+        style={{ width, maxWidth: '100%' }}
+      >
+        <Build formData={formData} setFormData={setFormData} serviceOptions={serviceOptions} />
+      </div>
+    </div>
+  );
+};
+
+/** The `@container` div holding the three panes - palette, canvas, settings. */
+const builderRoot = (canvasElement: HTMLElement): HTMLElement =>
+  canvasElement.querySelector('div[class~="@container"]') as HTMLElement;
+
+const paletteOf = (canvasElement: HTMLElement): HTMLElement =>
+  within(canvasElement).getByText('Add a field').parentElement as HTMLElement;
+
+const settingsOf = (canvasElement: HTMLElement): HTMLElement =>
+  within(canvasElement).getByText('Field settings').parentElement as HTMLElement;
+
+const canvasRows = (canvasElement: HTMLElement): HTMLElement[] =>
+  [...canvasElement.querySelectorAll('[data-testid^="canvas-row-"]')] as HTMLElement[];
+
+const rowFor = (canvasElement: HTMLElement, fieldId: string): HTMLElement =>
+  canvasElement.querySelector(`[data-testid="canvas-row-${fieldId}"]`) as HTMLElement;
+
+/** The private AddFieldDropdown trigger sitting beside a group's title. */
+const groupAddTrigger = (settings: HTMLElement, groupTitle: string): Element => {
+  const header = within(settings).getByText(groupTitle).parentElement as HTMLElement;
+  return header.querySelector('svg') as Element;
+};
+
+/**
+ * A fixed observation window, used only where a play function has to assert that
+ * something did NOT appear. `waitFor(() => expect(x).toBeNull())` is no good for that:
+ * it passes on the first poll, which can be the frame before the thing mounts, so it
+ * would call a working panel broken. Waiting a fixed window and then asserting once
+ * gives the panel its full chance to show up first.
+ */
+const settle = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+const groupAddMenu = (settings: HTMLElement, groupTitle: string): HTMLElement | null => {
+  const header = within(settings).getByText(groupTitle).parentElement as HTMLElement;
+  return header.querySelector('div.absolute');
+};
+
+const meta = {
+  title: 'Forms/Build',
+  component: BuilderHarness,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The template builder: palette on one side, canvas of field rows, settings for whatever ' +
+          'row is selected. It had no story, and two of its surfaces are module-private - the ' +
+          '`AddFieldDropdown` that adds a field INSIDE a group, and the whole ' +
+          '`BuilderSettingsPanel` - so both are driven through the exported step here rather than ' +
+          'exported for the sake of a story.\n\n' +
+          'Driving it costs nothing: `Build` reaches the network only through ' +
+          '`MedicationGroupBuilder`, which mounts only while a Medications group is selected. No ' +
+          'story below selects one, so these are the real components with no stub anywhere.\n\n' +
+          "**Three things worth a reviewer's attention.**\n\n" +
+          '*The layout never becomes three panes.* The root carries `@container` and ' +
+          '`@4xl:flex-row` on the SAME element. A container query resolves against an ancestor ' +
+          'container, never the element itself, so `@4xl:flex-row` has nothing to match and the ' +
+          'root stays a column at every width - while the panes inside it, which are genuine ' +
+          'descendants, do take their `@4xl` widths. The "Wide container" story below draws that ' +
+          'split. In the app it is currently masked: AddForm mounts this inside a 530px drawer, so ' +
+          'nothing is above 56rem and everything stacks consistently.\n\n' +
+          "*The in-group dropdown ignores the palette's filters.* The palette is fed " +
+          '`addOptionsForContext`, which removes Signature on a SOAP template or when no signer is ' +
+          'set. `AddFieldDropdown` is rendered with no `options` prop, so it falls back to the ' +
+          'full `addOptions` list - and `addNestedField` runs no guard of its own. A signature can ' +
+          'therefore be added inside a group on a template that refuses one at the top level.\n\n' +
+          '*"Show in summary PDF" is on by default via a negative.* It reads ' +
+          '`meta?.showInSummaryPdf !== false`, so a field with no meta at all shows as enabled and ' +
+          'the first toggle writes `false`. Nothing in the schema records the ON state.\n\n' +
+          "*One layout rule is written against the wrong thing.* The task block's Repeat / " +
+          'Reminder pair is `sm:grid-cols-2` - a viewport media query - inside panes sized by ' +
+          '`@4xl` container queries. It is the only grid in the builder and the only rule that ' +
+          'responds to the browser window rather than to the drawer, so it stays two-up at 470px ' +
+          'while everything around it has already collapsed. The "Task block" story measures it.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    initialForm: form(),
+    serviceOptions: SERVICE_OPTIONS,
+    width: '504px',
+  },
+} satisfies Meta<typeof BuilderHarness>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Builder: Story = {
+  name: 'Builder at drawer width',
+  play: async ({ canvasElement }) => {
+    const palette = paletteOf(canvasElement);
+    const settings = settingsOf(canvasElement);
+
+    // Fourteen tiles, in declaration order. Signature is present because this
+    // template is not SOAP and has a signer set.
+    const tiles = within(palette).getAllByRole('button');
+    await expect(tiles).toHaveLength(14);
+    await expect(tiles.map((tile) => tile.textContent)).toEqual(ALL_ADD_OPTIONS);
+
+    /* Three canvas rows. Each row prints a type name from `fieldTypeName`, which
+       is a different vocabulary from the palette: the tile says "Field Group",
+       the row says "Section", and the wrapper around a nested one says "Group". */
+    await expect(canvasRows(canvasElement)).toHaveLength(3);
+    const firstRow = rowFor(canvasElement, 'presenting_complaint');
+    await expect(within(firstRow).getByText('Presenting complaint')).toBeInTheDocument();
+    await expect(within(firstRow).getByText('Short text · selected')).toBeInTheDocument();
+    await expect(
+      within(rowFor(canvasElement, 'observed_signs')).getByText('Checkbox')
+    ).toBeInTheDocument();
+    await expect(
+      within(rowFor(canvasElement, 'owner_signature')).getByText(
+        'Signature · signed in the pet-parent app'
+      )
+    ).toBeInTheDocument();
+
+    // Nothing was clicked: the first field is selected by derivation, so the
+    // settings panel is never empty while a schema exists.
+    await expect(firstRow).toHaveAttribute('aria-pressed', 'true');
+    await expect(within(settings).getByRole('textbox', { name: 'Label' })).toHaveValue(
+      'Presenting complaint'
+    );
+    await expect(within(settings).getByRole('textbox', { name: 'Placeholder' })).toHaveValue(
+      'Limping on the left hind'
+    );
+
+    /* The two toggles, and the asymmetry between them: Required defaults off,
+       Show in summary PDF defaults ON because it is read as `!== false`. */
+    await expect(within(settings).getByRole('switch', { name: 'Required' })).toHaveAttribute(
+      'aria-checked',
+      'false'
+    );
+    await expect(
+      within(settings).getByRole('switch', { name: 'Show in summary PDF' })
+    ).toHaveAttribute('aria-checked', 'true');
+
+    // Linked services are template-level, not field-level, so this block does not
+    // change as the selection moves. Violet for a package, blue for a service.
+    await expect(within(settings).getByText('Dental consultation')).toBeInTheDocument();
+    await expect(within(settings).getByText('Senior wellness package')).toBeInTheDocument();
+    const servicePill = within(settings).getByText('SERVICE');
+    const packagePill = within(settings).getByText('PACKAGE');
+    await expect(getComputedStyle(servicePill).backgroundColor).not.toBe(
+      getComputedStyle(packagePill).backgroundColor
+    );
+
+    /* At the width AddForm actually gives it, all three panes are full width and
+       stacked. This is what the builder looks like in the product today. */
+    const root = builderRoot(canvasElement);
+    await expect(root.children).toHaveLength(3);
+    await expect(getComputedStyle(root).flexDirection).toBe('column');
+    const canvasPane = root.children[1] as HTMLElement;
+    await expect(
+      Math.abs(palette.getBoundingClientRect().width - canvasPane.getBoundingClientRect().width)
+    ).toBeLessThan(1);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The builder at 504px, which is the content width of the 530px drawer AddForm opens it ' +
+          'in. Everything is full width and stacked, so the palette is a 14-item list a reviewer ' +
+          'has to scroll past before reaching the canvas. That scroll is the real ergonomics of ' +
+          'this screen and it is not visible in any wider mock.',
+      },
+    },
+  },
+};
+
+export const FieldSettingsToggles: Story = {
+  name: 'Field settings toggles',
+  play: async ({ canvasElement }) => {
+    const settings = settingsOf(canvasElement);
+    const row = rowFor(canvasElement, 'presenting_complaint');
+
+    const required = within(settings).getByRole('switch', { name: 'Required' });
+    const restColor = getComputedStyle(required).backgroundColor;
+    await userEvent.click(required);
+
+    // The flag flipped, the track repainted, AND the canvas row re-described
+    // itself. The last one is the point: the row summary is the only place the
+    // required state is visible once the settings panel moves on.
+    await expect(required).toHaveAttribute('aria-checked', 'true');
+    await waitFor(() => {
+      expect(getComputedStyle(required).backgroundColor).not.toBe(restColor);
+    });
+    await expect(within(row).getByText('Short text · required · selected')).toBeInTheDocument();
+
+    /* The summary-PDF toggle writes the negative. Switching it off stores
+       `showInSummaryPdf: false`; switching it back on stores `true`, so the
+       schema can hold either an explicit true or nothing at all for the same
+       rendered state. */
+    const summaryPdf = within(settings).getByRole('switch', { name: 'Show in summary PDF' });
+    await userEvent.click(summaryPdf);
+    await expect(summaryPdf).toHaveAttribute('aria-checked', 'false');
+    await userEvent.click(summaryPdf);
+    await expect(summaryPdf).toHaveAttribute('aria-checked', 'true');
+
+    // Moving the selection swaps the builder shown, and the toggles reset to the
+    // newly selected field's own state rather than carrying over.
+    await userEvent.click(rowFor(canvasElement, 'observed_signs'));
+    await waitFor(() => {
+      expect(rowFor(canvasElement, 'observed_signs')).toHaveAttribute('aria-pressed', 'true');
+    });
+    await expect(row).toHaveAttribute('aria-pressed', 'false');
+    await expect(
+      within(settingsOf(canvasElement)).getByRole('switch', { name: 'Required' })
+    ).toHaveAttribute('aria-checked', 'false');
+    /* Checkbox fields get an option editor, so the panel content changed too -
+       one text input per choice, labelled by index rather than by anything the
+       author wrote. */
+    const panel = settingsOf(canvasElement);
+    await expect(within(panel).getByRole('textbox', { name: 'Label' })).toHaveValue(
+      'Observed signs'
+    );
+    await expect(within(panel).getByRole('textbox', { name: 'Dropdown option 0' })).toHaveValue(
+      'Lameness'
+    );
+    await expect(within(panel).getByRole('textbox', { name: 'Dropdown option 1' })).toHaveValue(
+      'Swelling'
+    );
+    await expect(within(panel).getByRole('button', { name: '+ Add option' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The right-hand panel, driven. Required is the interesting one to watch because it is ' +
+          'echoed into the canvas row summary - that echo is the only feedback an author gets ' +
+          'once they select something else, and it is easy to break by editing either side alone.',
+      },
+    },
+  },
+};
+
+export const AddFieldInsideGroup: Story = {
+  name: 'Add a field inside a group',
+  args: {
+    initialForm: form({
+      name: 'SOAP - general consult',
+      category: 'SOAP',
+      requiredSigner: '',
+      schema: SOAP_SCHEMA,
+      services: [],
+    }),
+  },
+  play: async ({ canvasElement }) => {
+    // SOAP templates cannot carry a signature, so the palette is 13 tiles.
+    const palette = paletteOf(canvasElement);
+    await expect(within(palette).getAllByRole('button')).toHaveLength(13);
+    await expect(
+      within(palette).queryByRole('button', { name: 'Signature' })
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(rowFor(canvasElement, 'objective_group'));
+    const settings = settingsOf(canvasElement);
+    // Selecting a row swaps the whole panel, so wait for the new builder to mount
+    // rather than querying into the one that was there a frame ago.
+    const groupName = await within(settings).findByRole('textbox', { name: 'Group name' });
+    await expect(groupName).toHaveValue('Objective');
+
+    /* The private dropdown. Its trigger is a bare `<svg>` with an onClick and no
+       role, name or keyboard handler, so it is unreachable by keyboard and
+       invisible to a role query - which is part of why it had never been drawn. */
+    await userEvent.click(groupAddTrigger(settings, 'Objective'));
+    const menu = await waitFor(() => {
+      const el = groupAddMenu(settingsOf(canvasElement), 'Objective');
+      expect(el).not.toBeNull();
+      return el as HTMLElement;
+    });
+
+    // All 14 options, in the same order as the palette - including the Signature
+    // the palette just refused to offer on this template.
+    const items = within(menu).getAllByRole('button');
+    await expect(items).toHaveLength(14);
+    await expect(items.map((item) => item.textContent)).toEqual(ALL_ADD_OPTIONS);
+
+    await userEvent.click(within(menu).getByRole('button', { name: 'Short Text' }));
+
+    // The menu closes on select, and the group gained a real nested builder.
+    await waitFor(() => {
+      expect(groupAddMenu(settingsOf(canvasElement), 'Objective')).toBeNull();
+    });
+    const nested = await waitFor(() => {
+      const el = settingsOf(canvasElement).querySelector('section[aria-label="Input field"]');
+      expect(el).not.toBeNull();
+      return el as HTMLElement;
+    });
+    await expect(within(nested).getByRole('textbox', { name: 'Label' })).toHaveValue('Input');
+    await expect(within(nested).getByRole('button', { name: 'Delete Input' })).toBeInTheDocument();
+
+    /* The canvas is unchanged: nested fields never get a row. The group's row
+       still reads "Section", with no count of what is inside it, so the only
+       way to see this field again is to reselect the group. */
+    await expect(canvasRows(canvasElement)).toHaveLength(2);
+    await expect(
+      within(rowFor(canvasElement, 'objective_group')).getByText('Section · selected')
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Selecting a Field Group swaps the settings panel for `GroupBuilder`, whose header ' +
+          'carries the private `AddFieldDropdown`. Three things a reviewer should look at:\n\n' +
+          '- the trigger is an `<svg>` with an `onClick`, so it has no role, no accessible name ' +
+          'and no keyboard path;\n' +
+          '- the menu offers all 14 field types even though the palette beside it offers 13, ' +
+          'because it is rendered without the filtered option list;\n' +
+          '- nested fields never appear on the canvas, and the group row shows no count, so a ' +
+          'group with eight fields in it looks identical to an empty one.',
+      },
+    },
+  },
+};
+
+export const SignatureInsideGroupOnSoap: Story = {
+  name: 'Signature reaches a SOAP template',
+  args: {
+    initialForm: form({
+      name: 'SOAP - general consult',
+      category: 'SOAP',
+      requiredSigner: '',
+      schema: SOAP_SCHEMA,
+      services: [],
+    }),
+  },
+  play: async ({ canvasElement }) => {
+    await userEvent.click(rowFor(canvasElement, 'objective_group'));
+    await within(settingsOf(canvasElement)).findByRole('textbox', { name: 'Group name' });
+    await userEvent.click(groupAddTrigger(settingsOf(canvasElement), 'Objective'));
+
+    const menu = await waitFor(() => {
+      const el = groupAddMenu(settingsOf(canvasElement), 'Objective');
+      expect(el).not.toBeNull();
+      return el as HTMLElement;
+    });
+    await userEvent.click(within(menu).getByRole('button', { name: 'Signature' }));
+
+    /* `addField` guards the top-level path with three checks - SOAP category, no
+       signer selected, one signature per form. `addNestedField` has none of
+       them, so this SOAP template now contains a signature field that the
+       palette would have refused, and `hasSignatureField` (which only walks the
+       top level) will not find it either. */
+    const nested = await waitFor(() => {
+      const el = settingsOf(canvasElement).querySelector('section[aria-label="Signature field"]');
+      expect(el).not.toBeNull();
+      return el as HTMLElement;
+    });
+    await expect(within(nested).getByRole('textbox', { name: 'Label' })).toHaveValue('Signature');
+
+    /* No error is shown anywhere, and the palette still refuses the same field.
+       `buildError` renders inside the canvas pane, so its absence is asserted
+       there rather than against the whole canvas - and the pane is still holding
+       exactly its two original rows plus the drop strip, which is what "nothing
+       upstream noticed" looks like. */
+    await expect(
+      within(paletteOf(canvasElement)).queryByRole('button', { name: 'Signature' })
+    ).not.toBeInTheDocument();
+    await expect(within(paletteOf(canvasElement)).getAllByRole('button')).toHaveLength(13);
+    await expect(
+      within(canvasElement).queryByText('SOAP templates cannot include signature fields.')
+    ).not.toBeInTheDocument();
+    await expect(canvasRows(canvasElement)).toHaveLength(2);
+    await expect(
+      within(rowFor(canvasElement, 'objective_group')).getByText('Section · selected')
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same dropdown, used to do the thing the top-level rules forbid. This is drawn ' +
+          'rather than argued because it is only reproducible through a private control: the ' +
+          'palette on the left has already removed Signature for this template, and the menu on ' +
+          'the right still offers it. Reviewing the fix means deciding whether the guard belongs ' +
+          'in `addNestedField` or in the option list handed to `AddFieldDropdown`.',
+      },
+    },
+  },
+};
+
+export const TaskBlockCard: Story = {
+  name: 'Task block (the one grid in the builder)',
+  args: { initialForm: form({ schema: [], services: [] }) },
+  play: async ({ canvasElement }) => {
+    // Tasks is the last palette tile and the only one that opens a sub-builder
+    // with its own add step, so the card below takes two clicks to reach.
+    await userEvent.click(within(paletteOf(canvasElement)).getByRole('button', { name: 'Tasks' }));
+    const addBlock = await within(settingsOf(canvasElement)).findByRole('button', {
+      name: 'Add task block',
+    });
+    await userEvent.click(addBlock);
+
+    const settings = settingsOf(canvasElement);
+    const repeat = await within(settings).findByRole('button', {
+      name: 'Repeat: Every 6 hours',
+    });
+
+    /* THE GRID. Repeat and Reminder share a `grid gap-3 sm:grid-cols-2` - and
+       `sm:` is a VIEWPORT media query, not a container query, while every other
+       rule in this builder (`@4xl:w-[320px]` on the panel around it) is a
+       container query against the builder box. So at the project's laptop
+       viewport this pair is two-up inside a panel that is only ~470px wide in
+       the real drawer, and it re-forms into a stack from the phone story's
+       viewport instead of from the panel's own width. Track count AND child
+       count, because a template that collapsed to one track would still hold two
+       children and look merely tall. */
+    const grid = repeat.closest('div.grid') as HTMLElement;
+    await expect(getComputedStyle(grid).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(2);
+    await expect(grid.children).toHaveLength(2);
+    await expect(
+      within(grid).getByRole('button', { name: 'Reminder (optional): 5 minutes before' })
+    ).toBeInTheDocument();
+
+    /* The rest of the card, which is where the seeded defaults live: a block
+       arrives with a category, a repeat, a reminder and a duration already
+       chosen, and only the title empty. An author who adds a block and saves
+       gets a real recurring task, not a placeholder. */
+    await expect(within(settings).getByRole('textbox', { name: 'Task title' })).toHaveValue('');
+    await expect(
+      within(settings).getByRole('button', { name: 'Category: Care' })
+    ).toBeInTheDocument();
+    await expect(within(settings).getByRole('spinbutton', { name: 'Duration (days)' })).toHaveValue(
+      3
+    );
+    await expect(within(settings).getByText('Task 1')).toBeInTheDocument();
+
+    /* The two header actions are `CircleIconButton`s, which wrap themselves in a
+       GlassTooltip. Opened through the shared helper because the listeners are
+       bound in an effect a play function outruns - a single `hover` dispatch here
+       is simply lost and the story would pass with nothing open. */
+    const duplicate = within(settings).getByRole('button', { name: 'Duplicate task 1' });
+    const bubble = await openGlassTooltip(duplicate);
+    await expect(bubble).toHaveTextContent('Duplicate task 1');
+    await closeGlassTooltip(duplicate);
+
+    // Duplicating adds a second card. The header index is positional, so both
+    // read "Task 1" and "Task 2" regardless of what the blocks are called.
+    await userEvent.click(duplicate);
+    await waitFor(() => {
+      expect(within(settingsOf(canvasElement)).getByText('Task 2')).toBeInTheDocument();
+    });
+    await expect(
+      within(settingsOf(canvasElement)).getAllByRole('button', { name: /^Remove task / })
+    ).toHaveLength(2);
+
+    // And the canvas still shows one row - a Tasks group with two blocks in it
+    // is indistinguishable from an empty one until you select it.
+    await expect(canvasRows(canvasElement)).toHaveLength(1);
+    await expect(
+      within(canvasRows(canvasElement)[0]).getByText('Tasks · selected')
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The Tasks field type, which is the only place in the builder that lays anything out on ' +
+          'a grid, and the only settings panel that needs two clicks before it shows anything: ' +
+          'adding the field gives you an "Add task block" button, not a block.\n\n' +
+          'Two things a reviewer should look at. The Repeat / Reminder pair is the one responsive ' +
+          'rule in this builder written against the viewport (`sm:grid-cols-2`) rather than ' +
+          'against the builder container, so it stays two-up in the 470px drawer where every ' +
+          'other rule has already collapsed. And a new block is not blank - it arrives set to ' +
+          'Care, every 6 hours, 5 minutes before, 3 days, with only the title empty, so an author ' +
+          'who adds a block and never opens it has still authored a recurring task.',
+      },
+    },
+  },
+};
+
+export const EmptyBuilder: Story = {
+  name: 'Empty canvas',
+  args: { initialForm: form({ schema: [], services: [] }) },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvasRows(canvasElement)).toHaveLength(0);
+    await expect(
+      canvas.getByText('No fields yet. Add a field from the palette to start building.')
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByText(
+        'Select a field in the canvas to edit its settings, or add one from the palette.'
+      )
+    ).toBeInTheDocument();
+    // The drop target is the only affordance suggesting drag works at all.
+    await expect(canvas.getByText('Drop a field here')).toBeInTheDocument();
+
+    /* PINNED TO CURRENT BEHAVIOUR - this asserts a defect, not the shape the panel
+       should have. `BuilderSettingsPanel` renders the entire "Linked services" block -
+       the heading, the "No linked services yet." line, the list, the picker and the
+       "Link another service" button - inside the `selectedField ? (...) : (...)` branch.
+       Linked services are template-level (`formData.services`; the "Linking another
+       service" story below relies on them not moving with the selection), but a template
+       with no fields has no selected field, so the whole block is unrendered: a brand new
+       template cannot be linked to a service at all until some unrelated field is added
+       first, and deleting the last field hides links that are still in the data.
+       Asserted as an absence rather than dropped, and paired with the assertion at the
+       end of this play function that the very same copy DOES appear the moment a field is
+       selected - the two together are the defect. Invert this to `getByText` when the
+       block moves out of the branch. */
+    const emptySettings = settingsOf(canvasElement);
+    await expect(
+      within(emptySettings).queryByText('No linked services yet.')
+    ).not.toBeInTheDocument();
+    await expect(within(emptySettings).queryByText('Linked services')).not.toBeInTheDocument();
+    await expect(
+      within(emptySettings).queryByRole('button', { name: 'Link another service' })
+    ).not.toBeInTheDocument();
+
+    // Palette -> canvas -> settings, in one click.
+    await userEvent.click(within(paletteOf(canvasElement)).getByRole('button', { name: 'Date' }));
+
+    const rows = await waitFor(() => {
+      const found = canvasRows(canvasElement);
+      expect(found).toHaveLength(1);
+      return found;
+    });
+    await expect(rows[0]).toHaveAttribute('aria-pressed', 'true');
+    await expect(within(rows[0]).getByText('Date · selected')).toBeInTheDocument();
+    /* The new field is auto-selected, so the settings panel is already showing
+       its builder, seeded from `fieldFactory` - which for a date is a label and
+       nothing else, so the whole configuration surface for this field is one
+       text box. */
+    await expect(
+      within(settingsOf(canvasElement)).getByRole('textbox', { name: 'Label' })
+    ).toHaveValue('Date');
+    await expect(
+      within(settingsOf(canvasElement)).getByRole('switch', { name: 'Show in summary PDF' })
+    ).toHaveAttribute('aria-checked', 'true');
+
+    /* The other half of the defect above. Nothing about the template changed -
+       `services` is still empty - but one field now exists and is selected, so the
+       template-level block the panel refused to render a moment ago is suddenly there,
+       empty copy and all. */
+    const filledSettings = settingsOf(canvasElement);
+    await expect(within(filledSettings).getByText('Linked services')).toBeInTheDocument();
+    await expect(within(filledSettings).getByText('No linked services yet.')).toBeInTheDocument();
+    await expect(
+      within(filledSettings).getByRole('button', { name: 'Link another service' })
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A brand new template. Both empty states are prose rather than an illustration, and the ' +
+          'dashed "Drop a field here" strip is the only hint that rows can be dragged - it is not ' +
+          'a drop target you can drag a palette tile onto, only a reorder affordance for rows that ' +
+          'already exist.\n\n' +
+          'The pane on the right is missing more than a field editor. The whole template-level ' +
+          '"Linked services" block sits inside the `selectedField` branch, so on a template with ' +
+          'no fields there is nowhere to link a service - the author has to add a field they may ' +
+          'not want before they can reach a property that has nothing to do with fields. Adding ' +
+          'the Date field at the end of this play function makes the block appear with the ' +
+          'template unchanged, which is the clearest way to see it.',
+      },
+    },
+  },
+};
+
+export const StructureLocked: Story = {
+  name: 'Locked structure (YC default)',
+  args: {
+    initialForm: form({
+      name: 'YC discharge instructions',
+      templateSource: 'YC_LIBRARY',
+      isTemplateBacked: true,
+      schema: SOAP_SCHEMA,
+    }),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const palette = paletteOf(canvasElement);
+
+    // The whole palette is replaced by an explanation - no tiles at all.
+    await expect(within(palette).queryAllByRole('button')).toHaveLength(0);
+    await expect(
+      within(palette).getByText(
+        'This template has a locked structure. Field content stays editable, but fields cannot be added, removed, or reordered.'
+      )
+    ).toBeInTheDocument();
+    await expect(canvas.queryByText('Drop a field here')).not.toBeInTheDocument();
+
+    /* Both rows are still drawn in full, with their own summaries, and the first
+       is still selected by derivation - the lock takes away the controls, not the
+       content, so a reviewer should be able to read the whole template here and
+       change none of it. */
+    await expect(canvasRows(canvasElement)).toHaveLength(2);
+    await expect(
+      within(rowFor(canvasElement, 'subjective')).getByText('Paragraph · selected')
+    ).toBeInTheDocument();
+    await expect(
+      within(rowFor(canvasElement, 'objective_group')).getByText('Section')
+    ).toBeInTheDocument();
+
+    // Rows stay selectable, but a selected row grows no controls.
+    await userEvent.click(rowFor(canvasElement, 'objective_group'));
+    const groupRow = rowFor(canvasElement, 'objective_group');
+    await waitFor(() => {
+      expect(groupRow).toHaveAttribute('aria-pressed', 'true');
+    });
+    await expect(within(groupRow).getByText('Section · selected')).toBeInTheDocument();
+    await expect(within(groupRow).queryAllByRole('button')).toHaveLength(0);
+    await expect(
+      within(groupRow).queryByRole('button', { name: 'Move up' })
+    ).not.toBeInTheDocument();
+    await expect(
+      within(groupRow).queryByRole('button', { name: /^Duplicate / })
+    ).not.toBeInTheDocument();
+    await expect(
+      within(groupRow).queryByRole('button', { name: 'delete-objective_group' })
+    ).not.toBeInTheDocument();
+
+    /* Inside the group the lock reaches further than the canvas suggests: the
+       add-field trigger and the group rename input are both gone, so a locked
+       group cannot even be relabelled. Content editing that IS allowed happens
+       on the leaf builders below. */
+    const settings = settingsOf(canvasElement);
+    await expect(within(settings).getByText('Objective')).toBeInTheDocument();
+    await expect(
+      within(settings).queryByRole('textbox', { name: 'Group name' })
+    ).not.toBeInTheDocument();
+    await expect(
+      (within(settings).getByText('Objective').parentElement as HTMLElement).querySelector('svg')
+    ).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'What a YC-library template looks like in the builder. The lock is carried by a context ' +
+          'rather than a prop, so it reaches components several levels down - `GroupBuilder` and ' +
+          '`BuilderWrapper` both read it directly. Worth noting that "content stays editable" is ' +
+          "the promise in the notice, but a group's own name is content by most readings and is " +
+          'locked here too.',
+      },
+    },
+  },
+};
+
+export const LinkedServicePicker: Story = {
+  name: 'Linking another service',
+  play: async ({ canvasElement }) => {
+    const settings = settingsOf(canvasElement);
+    await expect(within(settings).getAllByText('SERVICE')).toHaveLength(1);
+    await expect(within(settings).getAllByText('PACKAGE')).toHaveLength(1);
+    // The picker is hidden until asked for, so the panel reads as a list first.
+    await expect(
+      within(settings).queryByRole('button', { name: /^Link services \/ packages/ })
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(within(settings).getByRole('button', { name: 'Link another service' }));
+    const trigger = await within(settingsOf(canvasElement)).findByRole('button', {
+      name: 'Link services / packages: Dental consultation, Senior wellness package',
+    });
+
+    /* PINNED TO CURRENT BEHAVIOUR - this story used to click the option and assert the
+       third service was linked, and it cannot: the portalled option list is not reachable
+       from here, so "Post-op recheck" is never offered. The assertion is pinned rather
+       than softened, because the copy is right and the control is not.
+
+       What the source makes possible. `MultiSelectDropdown` portals its list to
+       `document.body`, and `useDropdownPositioning` dismisses the open panel on ANY scroll
+       whose target is not inside `[data-portal-dropdown]` - it cannot distinguish the page
+       moving under a panel it cannot follow (the case it was written for) from a scroll the
+       dropdown itself causes while opening, and its `target instanceof HTMLElement` guard
+       fails open, so a scroll targeting `document` dismisses too. This picker sits at the
+       bottom of the builder's own `overflow-y-auto` column, and opening it moves at least
+       two scrollers: focus lands on the trigger and then, in an effect, on the search input
+       it swaps in, and `useListboxKeyboardNav` calls `scrollIntoView` on the seeded active
+       option inside a panel positioned past the viewport bottom. The sibling stories that
+       open this same component successfully (Inputs/MultiSelectDropdown) all sit in a short,
+       centred, non-scrolling box, which fits.
+
+       NOT CONFIRMED IN A BROWSER: which of those scrolls fires here was not measured, only
+       read - so the mechanism above is the likely one, not a proven one. What is pinned is
+       only the outcome: the panel does not survive, and the trigger settles closed while
+       still advertising `aria-haspopup="listbox"` - that pair is asserted together so the
+       failure output reads as the contradiction it is rather than as a missing button.
+       Invert this block back to `findByRole(/Post-op recheck/)` + click + a two-SERVICE list
+       when the dismissal is fixed; it should go red the day the picker works. */
+    await userEvent.click(trigger);
+    await settle(800);
+    await expect(document.querySelector('[data-portal-dropdown]')).toBeNull();
+    await expect(trigger).toHaveAttribute('aria-haspopup', 'listbox');
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    // Nothing was linked, so the list is still the two services it started with.
+    await expect(
+      within(settingsOf(canvasElement)).queryByText('Post-op recheck')
+    ).not.toBeInTheDocument();
+    await expect(within(settingsOf(canvasElement)).getAllByText('SERVICE')).toHaveLength(1);
+    await expect(within(settingsOf(canvasElement)).getAllByText('PACKAGE')).toHaveLength(1);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Linked services sit in the field-settings panel but are a property of the whole ' +
+          'template - selecting a different field does not change them. That placement is the ' +
+          'thing to review: the block is under a "Field settings" heading and edits ' +
+          '`formData.services`.\n\n' +
+          'It also cannot currently be used from here. "Link another service" reveals the ' +
+          'picker, and the picker opens onto nothing: its portalled panel does not survive ' +
+          "being opened at the bottom of the builder's scrolling column. The likely reason " +
+          'is in `useDropdownPositioning`, which dismisses the panel on any scroll outside ' +
+          '`[data-portal-dropdown]` and so cannot tell the page moving under a panel it ' +
+          'cannot follow from the scrolls the dropdown itself causes while opening - focus ' +
+          'moving to the trigger and its search input, and `scrollIntoView` on the seeded ' +
+          'active option. The play function pins the outcome, not the cause: the panel is ' +
+          'gone, the trigger settles closed while still advertising ' +
+          '`aria-haspopup="listbox"`, and the list still holds its original two services.',
+      },
+    },
+  },
+};
+
+export const WideContainer: Story = {
+  name: 'Wide container (the row that never happens)',
+  args: { width: '100%' },
+  play: async ({ canvasElement }) => {
+    const root = builderRoot(canvasElement);
+    const palette = paletteOf(canvasElement);
+    const settings = settingsOf(canvasElement);
+    const canvasPane = root.children[1] as HTMLElement;
+
+    /* The descendant queries fired: at this width the palette takes its 250px,
+       the settings panel its 320px, and both swap their divider from a
+       horizontal rule to a vertical one. So the container IS wider than 56rem
+       and the `@4xl` variant IS resolving. */
+    await expect(Math.round(palette.getBoundingClientRect().width)).toBe(250);
+    await expect(Math.round(settings.getBoundingClientRect().width)).toBe(320);
+    await expect(getComputedStyle(palette).borderBottomWidth).toBe('0px');
+    await expect(getComputedStyle(palette).borderRightWidth).toBe('1px');
+
+    /* And the root did not turn into a row. `@container` and `@4xl:flex-row` are
+       on the same element, and a container query is resolved against an ANCESTOR
+       container - an element is never its own. With no container above it the
+       query is false at every width, so the three panes stay stacked while two
+       of them have shrunk to sidebar widths. Fixing this means moving
+       `@container` onto a wrapper; this assertion should then be inverted. */
+    await expect(getComputedStyle(root).flexDirection).toBe('column');
+    await expect(getComputedStyle(root).overflowY).toBe('auto');
+    await expect(palette.getBoundingClientRect().bottom).toBeLessThanOrEqual(
+      canvasPane.getBoundingClientRect().top + 1
+    );
+    await expect(canvasPane.getBoundingClientRect().bottom).toBeLessThanOrEqual(
+      settings.getBoundingClientRect().top + 1
+    );
+
+    // The panes themselves are unharmed - this is purely the parent axis.
+    await expect(within(palette).getAllByRole('button')).toHaveLength(14);
+    await expect(canvasRows(canvasElement)).toHaveLength(3);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same builder in a container wide enough to trigger every `@4xl` rule, which is how ' +
+          'the code reads as intended: a 250px palette, a flexible canvas, a 320px settings rail.\n\n' +
+          'It does not happen. The palette and the settings rail take their widths because they ' +
+          'are descendants of the `@container` element and query it correctly. The root itself ' +
+          'carries both `@container` and `@4xl:flex-row`, and an element cannot be its own query ' +
+          'container, so the row never applies - the result is three stacked bands, two of them ' +
+          'now narrower than the space they sit in.\n\n' +
+          'This is masked in production only because AddForm mounts the builder in a 530px drawer, ' +
+          'where nothing crosses 56rem and the stacked full-width layout is self-consistent. The ' +
+          'assertions here record the current behaviour deliberately; they are the ones to invert ' +
+          'when `@container` moves onto a wrapper.',
+      },
+    },
+  },
+};
+
+export const Phone: Story = {
+  name: 'Phone (375)',
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  args: { width: '100%' },
+  play: async ({ canvasElement }) => {
+    const root = builderRoot(canvasElement);
+    const palette = paletteOf(canvasElement);
+
+    // Below 56rem nothing in the `@4xl` set applies, so the stacked layout here
+    // is the intended one rather than the accident above.
+    await expect(getComputedStyle(root).flexDirection).toBe('column');
+    await expect(getComputedStyle(palette).borderBottomWidth).toBe('1px');
+    await expect(getComputedStyle(palette).borderRightWidth).toBe('0px');
+    await expect(palette.getBoundingClientRect().width).toBeLessThanOrEqual(375);
+
+    /* Fourteen full-width tiles before the canvas begins. The pane scrolls
+       inside the builder rather than with the page, so on a phone the author
+       starts every session looking at the palette and has to scroll a separate
+       region to reach their own fields. */
+    await expect(within(palette).getAllByRole('button')).toHaveLength(14);
+    await expect(canvasRows(canvasElement)).toHaveLength(3);
+    await expect(
+      within(rowFor(canvasElement, 'presenting_complaint')).getByText('Short text · selected')
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'At 375 the builder is one long column: fourteen palette tiles, then the canvas, then the ' +
+          'settings panel. The panes keep their own scroll containers, so reaching field settings ' +
+          'from the palette is two separate scrolls rather than one.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/components/FormRenderer.stories.tsx
+++ b/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/components/FormRenderer.stories.tsx
@@ -1,0 +1,629 @@
+import { useState } from 'react';
+import type { ComponentProps } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+
+import type { FormField } from '@/app/features/forms/types/forms';
+import FormRenderer from './FormRenderer';
+
+type RendererProps = ComponentProps<typeof FormRenderer>;
+
+/**
+ * Controlled wrapper. `FormRenderer` owns no state at all - it is handed `values`
+ * and an `onChange`, so a story that passed a frozen object would render controls
+ * that visibly refuse every keystroke. The harness holds the answers and still
+ * forwards to `args.onChange`, so a play function can assert the emitted (id, value)
+ * pair as well as the round trip back into the input.
+ */
+const Harness = (args: RendererProps) => {
+  const [values, setValues] = useState<Record<string, unknown>>(args.values);
+  return (
+    <div data-testid="renderer-host" className="w-full max-w-[560px] bg-[var(--screen)] p-4">
+      <FormRenderer
+        {...args}
+        values={values}
+        onChange={(id, value) => {
+          setValues((prev) => ({ ...prev, [id]: value }));
+          args.onChange(id, value);
+        }}
+      />
+    </div>
+  );
+};
+
+/** The FormRenderer root - the flex column that holds exactly one node per field. */
+const rendererRoot = (canvasElement: HTMLElement): HTMLElement =>
+  within(canvasElement).getByTestId('renderer-host').firstElementChild as HTMLElement;
+
+const BCS_OPTIONS = [
+  { label: 'Under (1-3)', value: 'under' },
+  { label: 'Ideal (4-5)', value: 'ideal' },
+  { label: 'Over (6-9)', value: 'over' },
+];
+
+/** One field of every runtime type, in the order `runtimeComponentMap` declares them. */
+const EVERY_TYPE: FormField[] = [
+  {
+    id: 'presenting_complaint',
+    type: 'input',
+    label: 'Presenting complaint',
+    placeholder: 'Limping on the left hind',
+  },
+  { id: 'weight_kg', type: 'number', label: 'Weight (kg)', placeholder: '12.4' },
+  { id: 'history', type: 'textarea', label: 'History', placeholder: '' },
+  { id: 'clinical_narrative', type: 'richtext', label: 'Clinical narrative' },
+  {
+    id: 'body_condition',
+    type: 'dropdown',
+    label: 'Body condition score',
+    options: BCS_OPTIONS,
+  },
+  {
+    id: 'temperament',
+    type: 'radio',
+    label: 'Temperament',
+    options: [
+      { label: 'Relaxed', value: 'relaxed' },
+      { label: 'Nervous', value: 'nervous' },
+    ],
+  },
+  {
+    id: 'observed_signs',
+    type: 'checkbox',
+    label: 'Observed signs',
+    multiple: true,
+    options: [
+      { label: 'Lameness', value: 'lameness' },
+      { label: 'Swelling', value: 'swelling' },
+    ],
+  },
+  { id: 'fasted', type: 'boolean', label: 'Fasted before the visit' },
+  { id: 'seen_on', type: 'date', label: 'Date seen' },
+  { id: 'owner_signature', type: 'signature', label: 'Owner signature' },
+];
+
+/** Three levels of nesting, which is three different container recipes. */
+const NESTED: FormField[] = [
+  {
+    id: 'vitals',
+    type: 'group',
+    label: 'Vitals',
+    fields: [
+      { id: 'temp_c', type: 'number', label: 'Temperature (C)', placeholder: '38.5' },
+      {
+        id: 'cardio',
+        type: 'group',
+        label: 'Cardiovascular',
+        fields: [
+          { id: 'hr_bpm', type: 'number', label: 'Heart rate (bpm)', placeholder: '90' },
+          {
+            id: 'auscultation',
+            type: 'group',
+            label: 'Auscultation',
+            fields: [
+              {
+                id: 'murmur_grade',
+                type: 'dropdown',
+                label: 'Murmur grade',
+                options: [
+                  { label: 'None', value: 'none' },
+                  { label: 'II/VI', value: 'ii' },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+];
+
+/** Two level-2 siblings that differ only in whether `isMedicationLikeGroup` matches. */
+const DEEP_SIBLINGS: FormField[] = [
+  {
+    id: 'plan',
+    type: 'group',
+    label: 'Treatment plan',
+    fields: [
+      {
+        id: 'day_one',
+        type: 'group',
+        label: 'Day 1',
+        fields: [
+          {
+            id: 'medication_round',
+            type: 'group',
+            label: 'Medication round',
+            fields: [{ id: 'drug_name', type: 'input', label: 'Drug', placeholder: 'Meloxicam' }],
+          },
+          {
+            id: 'nursing_notes',
+            type: 'group',
+            label: 'Nursing notes',
+            fields: [{ id: 'note_body', type: 'textarea', label: 'Note', placeholder: '' }],
+          },
+        ],
+      },
+    ],
+  },
+];
+
+const meta = {
+  title: 'Forms/FormRenderer',
+  component: FormRenderer,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The runtime side of the form builder: the component that turns a saved `schema` into ' +
+          'real controls. It is what the pet parent fills in, what the Form preview drawer draws ' +
+          'read-only, and what the appointment workspace mounts for a template. It had no story, ' +
+          'so none of its dispatch rules had ever been drawn.\n\n' +
+          '**It is a dispatch table plus four rules, and the rules are the interesting part.**\n\n' +
+          '`runtimeComponentMap` maps eleven field types onto seven components - `number` reuses ' +
+          '`InputRenderer`, and `radio` and `checkbox` both reuse `DropdownRenderer`, which then ' +
+          're-branches internally on `field.type`. So a `radio` field draws nothing like the select ' +
+          'the map name suggests.\n\n' +
+          '`getGroupContainerClass` gives a group a different box at each nesting level: a 16px ' +
+          'padded card at the top, a 12px one inside that, and from level two down it stops being ' +
+          'a box at all and becomes a 2px left rule. That third recipe is the one nobody sees ' +
+          'while authoring, because the builder canvas only ever shows top-level rows.\n\n' +
+          '`labelForField` invents a label when the schema has none, or when the label is just the ' +
+          'id repeated back - a real shape in imported templates. It humanises the id, with one ' +
+          'special case: any id ending `_services` is titled "Services / Packages" whatever it is ' +
+          'called. A child whose label matches its parent group is then blanked entirely, so the ' +
+          'same words are not printed twice.\n\n' +
+          "`readOnly` is not passed through to the controls. It reaches some of them (`FormInput`'s " +
+          '`readonly`, the checkbox `disabled`) but `TextRenderer` accepts no `readOnly` prop at ' +
+          'all, so a preview textarea is a fully editable textarea. What actually holds the ' +
+          'preview still is a pair of capture-phase handlers on the wrapper that blur anything ' +
+          'focusable the moment it takes focus. That is asserted below, because it is the only ' +
+          'thing standing between "preview" and "editable form".',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    fields: EVERY_TYPE,
+    values: {},
+    onChange: fn(),
+  },
+  render: (args) => <Harness {...args} />,
+} satisfies Meta<typeof FormRenderer>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const EveryFieldType: Story = {
+  name: 'Every field type',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* Ten fields in, ten nodes out. This is the assertion that catches a dropped
+       entry in `runtimeComponentMap`: an unmapped type renders `undefined` as a
+       component and React throws, but a type mapped to a renderer that bails
+       (see the "Fields that render nothing" story) disappears in silence. */
+    const root = rendererRoot(canvasElement);
+    await expect(root.children).toHaveLength(EVERY_TYPE.length);
+    await expect(getComputedStyle(root).flexDirection).toBe('column');
+    await expect(getComputedStyle(root).rowGap).toBe('12px');
+
+    // input and number are the SAME component, distinguished only by `intype`,
+    // so they land on different ARIA roles - textbox vs spinbutton.
+    await expect(canvas.getByRole('textbox', { name: 'Presenting complaint' })).toBeInTheDocument();
+    await expect(canvas.getByRole('spinbutton', { name: 'Weight (kg)' })).toBeInTheDocument();
+    await expect(canvas.getByRole('textbox', { name: 'History' }).tagName).toBe('TEXTAREA');
+
+    // Tiptap is created in an effect (`immediatelyRender: false`), so the
+    // contenteditable does not exist on the first frame.
+    expect(
+      await canvas.findByRole('textbox', { name: 'Clinical narrative' }, { timeout: 4000 })
+    ).toHaveAttribute('contenteditable', 'true');
+
+    /* dropdown / radio / checkbox all resolve to DropdownRenderer and then split
+       three ways inside it. Only `dropdown` is a listbox trigger; the other two
+       are native input lists whose accessible names are composed as
+       "<field label>: <option label>". */
+    await expect(
+      canvas.getByRole('button', { name: 'Body condition score', expanded: false })
+    ).toHaveAttribute('aria-haspopup', 'listbox');
+    await expect(canvas.getByRole('radio', { name: 'Temperament: Relaxed' })).toBeInTheDocument();
+    await expect(canvas.getByRole('radio', { name: 'Temperament: Nervous' })).toBeInTheDocument();
+    await expect(canvas.getAllByRole('radio')).toHaveLength(2);
+    await expect(
+      canvas.getByRole('checkbox', { name: 'Observed signs: Lameness' })
+    ).toBeInTheDocument();
+
+    // The standalone boolean is a checkbox too, named by the field label alone.
+    await expect(
+      canvas.getByRole('checkbox', { name: 'Fasted before the visit' })
+    ).not.toBeChecked();
+
+    // input[type=date] has no ARIA role, so it is reachable only by its label.
+    await expect(canvas.getByLabelText('Date seen')).toHaveAttribute('type', 'date');
+
+    /* Signature is inert here on purpose: the renderer draws a dashed placeholder
+       and the actual signing happens in the parent app, never in this tree. */
+    await expect(canvas.getByText('Owner signature')).toBeInTheDocument();
+    await expect(canvas.getByText('Please Save and Sign')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The full census, one field of each type. Worth reading as a list of what a template ' +
+          'author actually gets: `number` and `input` are the same control with a different ' +
+          'keyboard, `radio` and `checkbox` are native input lists rather than the select their ' +
+          'shared renderer name implies, and `signature` renders a placeholder that cannot be ' +
+          'signed anywhere in PIMS.',
+      },
+    },
+  },
+};
+
+export const ControlledRoundTrip: Story = {
+  name: 'Controlled round trip',
+  args: {
+    fields: [
+      {
+        id: 'presenting_complaint',
+        type: 'input',
+        label: 'Presenting complaint',
+        placeholder: 'Limping on the left hind',
+      },
+      { id: 'fasted', type: 'boolean', label: 'Fasted before the visit' },
+    ],
+    values: {},
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const complaint = canvas.getByRole('textbox', { name: 'Presenting complaint' });
+    await userEvent.type(complaint, 'Left hind lameness');
+    // Both halves of the contract: the id-keyed callback fired, AND the value
+    // came back down into the control. A renderer that emitted the right event
+    // but read `values` by the wrong key would still look alive while typing.
+    await expect(args.onChange).toHaveBeenLastCalledWith(
+      'presenting_complaint',
+      'Left hind lameness'
+    );
+    await expect(complaint).toHaveValue('Left hind lameness');
+
+    const fasted = canvas.getByRole('checkbox', { name: 'Fasted before the visit' });
+    await userEvent.click(fasted);
+    await expect(args.onChange).toHaveBeenLastCalledWith('fasted', true);
+    await expect(fasted).toBeChecked();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Every control is fully controlled - `FormRenderer` keeps no state, so an answer only ' +
+          'appears if the caller writes it back under the same field id. The fallback ladder ' +
+          '(`values[id]` then `field.defaultValue` then a per-type empty) means a mis-keyed write ' +
+          'silently reverts to blank rather than erroring.',
+      },
+    },
+  },
+};
+
+export const NestedGroups: Story = {
+  name: 'Nested groups (three container recipes)',
+  args: { fields: NESTED, values: {} },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // The group title div's parent IS the container, so each box is reachable
+    // from its heading text.
+    const vitals = canvas.getByText('Vitals').parentElement as HTMLElement;
+    const cardio = canvas.getByText('Cardiovascular').parentElement as HTMLElement;
+    const auscultation = canvas.getByText('Auscultation').parentElement as HTMLElement;
+
+    // Level 0: rounded-2xl, a full border, 16px inset.
+    const vitalsStyle = getComputedStyle(vitals);
+    await expect(vitalsStyle.paddingTop).toBe('16px');
+    await expect(vitalsStyle.paddingLeft).toBe('16px');
+    await expect(vitalsStyle.borderTopWidth).toBe('1px');
+    await expect(vitalsStyle.borderRadius).toBe('16px');
+
+    // Level 1: same shape, one step tighter.
+    const cardioStyle = getComputedStyle(cardio);
+    await expect(cardioStyle.paddingTop).toBe('12px');
+    await expect(cardioStyle.paddingLeft).toBe('12px');
+    await expect(cardioStyle.borderTopWidth).toBe('1px');
+    await expect(cardioStyle.borderRadius).toBe('12px');
+
+    /* Level 2 stops being a box. `border-l-2` with no other side means a bare
+       left rule, and the vertical inset halves. This is the recipe the builder
+       never shows, because its canvas only lists top-level rows. */
+    const deepStyle = getComputedStyle(auscultation);
+    await expect(deepStyle.borderLeftWidth).toBe('2px');
+    await expect(deepStyle.borderTopWidth).toBe('0px');
+    await expect(deepStyle.paddingLeft).toBe('12px');
+    await expect(deepStyle.paddingTop).toBe('8px');
+
+    // Titles shrink one step at level 2 and stay there for every level below.
+    await expect(getComputedStyle(canvas.getByText('Vitals')).fontSize).toBe('18px');
+    await expect(getComputedStyle(canvas.getByText('Cardiovascular')).fontSize).toBe('18px');
+    await expect(getComputedStyle(canvas.getByText('Auscultation')).fontSize).toBe('16px');
+
+    // The leaves still rendered, at every depth.
+    await expect(canvas.getByRole('spinbutton', { name: 'Temperature (C)' })).toBeInTheDocument();
+    await expect(canvas.getByRole('spinbutton', { name: 'Heart rate (bpm)' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Murmur grade' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Nesting is unbounded - `FormRenderer` recurses into itself with `depth + 1` and nothing ' +
+          'caps it - but only three container recipes exist, so everything from level two down ' +
+          'looks identical. The insets compound, which is what makes deep templates unusable on a ' +
+          'phone; the phone story below shows the same tree at 375.',
+      },
+    },
+  },
+};
+
+export const MedicationGroupException: Story = {
+  name: 'Medication group keeps its box',
+  args: { fields: DEEP_SIBLINGS, values: {} },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const medication = canvas.getByText('Medication round').parentElement as HTMLElement;
+    const nursing = canvas.getByText('Nursing notes').parentElement as HTMLElement;
+
+    /* Same depth, same author intent, two different boxes. `isMedicationLikeGroup`
+       matches on `meta.medicationGroup`, `meta.medicineId` OR a /medication/i test
+       against the raw id - so `medication_round` qualifies purely by being named
+       that, and would stop qualifying if it were ever renamed `drug_round`. */
+    const medStyle = getComputedStyle(medication);
+    await expect(medStyle.borderTopWidth).toBe('1px');
+    await expect(medStyle.borderLeftWidth).toBe('1px');
+    await expect(medStyle.paddingTop).toBe('12px');
+    await expect(medStyle.paddingLeft).toBe('12px');
+    await expect(medStyle.borderRadius).toBe('12px');
+
+    const nursingStyle = getComputedStyle(nursing);
+    await expect(nursingStyle.borderTopWidth).toBe('0px');
+    await expect(nursingStyle.borderLeftWidth).toBe('2px');
+    await expect(nursingStyle.paddingTop).toBe('8px');
+
+    await expect(canvas.getByRole('textbox', { name: 'Drug' })).toBeInTheDocument();
+    await expect(canvas.getByRole('textbox', { name: 'Note' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Two sibling groups at the same depth drawn two different ways. Medication-like groups ' +
+          'keep a full card below level one so a dose block never collapses into a bare rule, and ' +
+          'the test that decides this includes a regex over the field id. A group called ' +
+          '"Medication round" is treated as clinical structure; the same group renamed is not.',
+      },
+    },
+  },
+};
+
+export const ReadOnlyPreview: Story = {
+  name: 'Read-only preview',
+  args: {
+    readOnly: true,
+    fields: [
+      {
+        id: 'procedure',
+        type: 'input',
+        label: 'Procedure',
+        placeholder: 'Dental scale and polish',
+      },
+      { id: 'history', type: 'textarea', label: 'History', placeholder: '' },
+      { id: 'clinical_narrative', type: 'richtext', label: 'Clinical narrative' },
+      { id: 'risks_understood', type: 'boolean', label: 'Risks explained and understood' },
+      {
+        id: 'observed_signs',
+        type: 'checkbox',
+        label: 'Observed signs',
+        multiple: true,
+        options: [
+          { label: 'Lameness', value: 'lameness' },
+          { label: 'Swelling', value: 'swelling' },
+        ],
+      },
+    ],
+    values: {
+      procedure: 'Dental scale and polish',
+      history: 'Reduced appetite for four days.',
+      clinical_narrative:
+        '<p>Vomited <strong>twice</strong> overnight.</p><script>alert(1)</script>',
+      risks_understood: true,
+      observed_signs: ['lameness'],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // The controls that DO honour readOnly.
+    await expect(canvas.getByRole('textbox', { name: 'Procedure' })).toHaveAttribute('readonly');
+    await expect(
+      canvas.getByRole('checkbox', { name: 'Risks explained and understood' })
+    ).toBeDisabled();
+    await expect(canvas.getByRole('checkbox', { name: 'Observed signs: Lameness' })).toBeDisabled();
+    await expect(canvas.getByRole('checkbox', { name: 'Observed signs: Lameness' })).toBeChecked();
+
+    /* And the one that does not. `TextRenderer` declares no `readOnly` prop, so
+       the textarea is a plain editable textarea with the answer already in it -
+       nothing about the element says "preview". What stops it is the wrapper's
+       capture-phase focus handler, which blurs anything focusable on the way in.
+       If that handler is ever dropped, this textarea becomes silently editable
+       inside a drawer whose header says "View form". */
+    const history = canvas.getByRole('textbox', { name: 'History' });
+    await expect(history).not.toHaveAttribute('readonly');
+    history.focus();
+    await waitFor(() => {
+      expect(document.activeElement).not.toBe(history);
+    });
+
+    // Rich text renders stored HTML, not an editor - and the stored HTML is run
+    // through DOMPurify on the way to the screen.
+    await expect(canvas.getByText('twice').tagName).toBe('STRONG');
+    await expect(
+      canvas.queryByRole('textbox', { name: 'Clinical narrative' })
+    ).not.toBeInTheDocument();
+    await expect(canvasElement.querySelector('script')).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The mode the Form preview drawer uses. Three different mechanisms are doing the work ' +
+          'here and only two of them are visible in the markup: `readonly` on the text input, ' +
+          '`disabled` on the checkboxes, and for everything else a pair of `onPointerDownCapture` ' +
+          '/ `onFocusCapture` handlers that blur the target. The textarea is the case worth ' +
+          'looking at - it carries no read-only attribute of any kind and is held still purely by ' +
+          'that guard.\n\n' +
+          'Rich text swaps the Tiptap editor for sanitized HTML. The seeded value below includes a ' +
+          '`<script>` tag to show it never reaches the DOM.',
+      },
+    },
+  },
+};
+
+export const LabelFallbacks: Story = {
+  name: 'Invented labels',
+  args: {
+    fields: [
+      { id: 'ownerFullName', type: 'input', label: '', placeholder: '' },
+      { id: 'discharge-notes', type: 'textarea', label: 'discharge-notes', placeholder: '' },
+      {
+        id: 'consult_services',
+        type: 'checkbox',
+        label: 'consult_services',
+        multiple: true,
+        options: [
+          { label: 'Dental consultation', value: 'svc-dental' },
+          { label: 'Senior wellness package', value: 'svc-senior' },
+        ],
+      },
+      {
+        id: 'medication',
+        type: 'group',
+        label: 'Medication',
+        fields: [{ id: 'medication_name', type: 'input', label: 'Medication', placeholder: '' }],
+      },
+    ],
+    values: {},
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Empty label -> humanised id. camelCase is split, then title-cased.
+    await expect(canvas.getByRole('textbox', { name: 'Owner Full Name' })).toBeInTheDocument();
+
+    // Label that merely repeats the id counts as no label at all. Hyphens and
+    // underscores collapse to spaces.
+    await expect(canvas.getByRole('textbox', { name: 'Discharge Notes' })).toBeInTheDocument();
+
+    /* The one hard-coded special case: any id ending `_services` is titled
+       "Services / Packages", never humanised. This is how a linked-services
+       block imported from a template gets the right heading. */
+    await expect(canvas.getByText('Services / Packages')).toBeInTheDocument();
+    await expect(canvas.queryByText('Consult Services')).not.toBeInTheDocument();
+    await expect(
+      canvas.getByRole('checkbox', { name: 'Services / Packages: Dental consultation' })
+    ).toBeInTheDocument();
+
+    /* A child whose label equals its parent group's is blanked, so the words are
+       not stacked twice. The input keeps its position and its value binding and
+       loses only its caption - which means the group title is now the only thing
+       naming it, and the input's accessible name is the empty string. */
+    const group = canvas.getByText('Medication').parentElement as HTMLElement;
+    await expect(within(group).getAllByText('Medication')).toHaveLength(1);
+    const nested = group.querySelector('input[type="text"]') as HTMLInputElement;
+    await expect(nested.getAttribute('aria-label')).toBe('');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Schemas reach this renderer from three places - the builder, the YC template library, ' +
+          'and FHIR questionnaire imports - and only the first reliably sets a label. These four ' +
+          'rows are the shapes the other two produce. The last one is the de-duplication rule: it ' +
+          'reads well, but it leaves the input with an empty accessible name, which is a real ' +
+          'accessibility cost worth weighing against the visual repetition it prevents.',
+      },
+    },
+  },
+};
+
+export const SilentlyDroppedField: Story = {
+  name: 'Fields that render nothing',
+  args: {
+    fields: [
+      { id: 'procedure', type: 'input', label: 'Procedure', placeholder: '' },
+      { id: 'referral_reason', type: 'dropdown', label: 'Referral reason', options: [] },
+      { id: 'notes', type: 'textarea', label: 'Notes', placeholder: '' },
+    ],
+    values: {},
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* Three fields in the schema, two nodes on screen. `DropdownRenderer` returns
+       null outright when `options` is empty - no label, no empty select, no
+       warning - so an author who saved a select before adding its choices gets a
+       form that is quietly missing a question. Counting the children is the only
+       way a story catches this; every positive assertion below still passes. */
+    await expect(rendererRoot(canvasElement).children).toHaveLength(2);
+    await expect(canvas.getByRole('textbox', { name: 'Procedure' })).toBeInTheDocument();
+    await expect(canvas.getByRole('textbox', { name: 'Notes' })).toBeInTheDocument();
+    await expect(canvas.queryByText('Referral reason')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A select, a radio group or a checkbox group with zero options disappears completely. ' +
+          'The builder lets you save one - the palette seeds two default options, but deleting ' +
+          'both is allowed - and nothing between there and here objects. The field still exists ' +
+          'in the schema and still submits its fallback value; it just has no way to be answered.',
+      },
+    },
+  },
+};
+
+export const Phone: Story = {
+  name: 'Phone (375)',
+  args: { fields: NESTED, values: {} },
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const vitals = canvas.getByText('Vitals').parentElement as HTMLElement;
+    const cardio = canvas.getByText('Cardiovascular').parentElement as HTMLElement;
+    const auscultation = canvas.getByText('Auscultation').parentElement as HTMLElement;
+
+    const width = (el: HTMLElement) => el.getBoundingClientRect().width;
+
+    // Nothing about the group insets is responsive, so they compound at 375 the
+    // same way they do at 1280 - each level eats another 24-32px of line length.
+    await expect(width(vitals)).toBeLessThanOrEqual(375);
+    await expect(width(vitals)).toBeGreaterThan(width(cardio));
+    await expect(width(cardio)).toBeGreaterThan(width(auscultation));
+    await expect(width(vitals) - width(auscultation)).toBeGreaterThanOrEqual(56);
+
+    // The controls survive the squeeze; it is the reading width that suffers.
+    await expect(canvas.getByRole('spinbutton', { name: 'Heart rate (bpm)' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Murmur grade' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same three-level tree at 375. The container paddings are fixed pixel values with no ' +
+          'breakpoint behind them, so a level-two field on a phone starts at least 56px in from ' +
+          'the screen edge before its own control padding. Worth seeing before anyone adds a ' +
+          'fourth level to a template that pet parents fill in on a phone.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/components/RichText/RichTextBuilder.tsx
+++ b/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/components/RichText/RichTextBuilder.tsx
@@ -21,7 +21,7 @@ const RichTextBuilder: React.FC<{
   const structureLocked = use(StructureLockContext);
   const label = field.label || 'Rich text';
   return (
-    <div className="flex flex-col gap-3 rounded-xl border border-input-border bg-surface-1 p-3">
+    <div className="flex flex-col gap-3 rounded-xl border border-input-border-default bg-[var(--surface-soft)] p-3">
       {structureLocked ? (
         <p className="text-body-2 font-medium text-text-primary">{label}</p>
       ) : (

--- a/apps/frontend/src/app/features/forms/pages/Forms/Sections/FormInfo.stories.tsx
+++ b/apps/frontend/src/app/features/forms/pages/Forms/Sections/FormInfo.stories.tsx
@@ -1,0 +1,708 @@
+import { useState } from 'react';
+import type { ComponentProps } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+
+import type { FormField, FormsProps } from '@/app/features/forms/types/forms';
+import {
+  TASK_CATEGORY_FIELD_OPTIONS,
+  TASK_RECURRENCE_FIELD_OPTIONS,
+  TASK_REMINDER_FIELD_OPTIONS,
+} from '@/app/features/forms/types/forms';
+import FormInfo from './FormInfo';
+
+type FormInfoProps = ComponentProps<typeof FormInfo>;
+
+const SERVICE_OPTIONS = [
+  { label: 'Dental consultation', value: 'svc-dental', badge: 'Service' },
+  { label: 'Senior wellness package', value: 'svc-senior', badge: 'Package' },
+];
+
+const CONSENT_SCHEMA: FormField[] = [
+  { id: 'procedure', type: 'input', label: 'Procedure', placeholder: 'Dental scale and polish' },
+  { id: 'risks_understood', type: 'boolean', label: 'Risks explained and understood' },
+  {
+    id: 'anaesthetic_history',
+    type: 'textarea',
+    label: 'Previous anaesthetic reactions',
+    placeholder: 'None reported',
+  },
+  { id: 'owner_signature', type: 'signature', label: 'Owner signature' },
+];
+
+type TaskBlockSpec = {
+  id: string;
+  name: string;
+  category: string;
+  recurrence: string;
+  reminder: string;
+  durationDays: string;
+  instructions?: string;
+  /** Older library blocks were authored without this key on the title field. */
+  keyedName: boolean;
+};
+
+/** One task block in the shape `TaskTemplateSummary` reads: values live on `defaultValue`. */
+const taskBlock = (spec: TaskBlockSpec): FormField => ({
+  id: spec.id,
+  type: 'group',
+  label: spec.name,
+  fields: [
+    {
+      id: `${spec.id}_name`,
+      type: 'input',
+      label: 'Task title',
+      defaultValue: spec.name,
+      meta: spec.keyedName ? { taskBlockKey: 'name' } : {},
+    },
+    {
+      id: `${spec.id}_category`,
+      type: 'dropdown',
+      label: 'Category',
+      options: TASK_CATEGORY_FIELD_OPTIONS,
+      defaultValue: spec.category,
+      meta: { taskBlockKey: 'category' },
+    },
+    {
+      id: `${spec.id}_recurrence`,
+      type: 'dropdown',
+      label: 'Repeat',
+      options: TASK_RECURRENCE_FIELD_OPTIONS,
+      defaultValue: spec.recurrence,
+      meta: { taskBlockKey: 'recurrence.type' },
+    },
+    {
+      id: `${spec.id}_reminderOffsetMinutes`,
+      type: 'dropdown',
+      label: 'Reminder',
+      options: TASK_REMINDER_FIELD_OPTIONS,
+      defaultValue: spec.reminder,
+      meta: { taskBlockKey: 'reminderOffsetMinutes' },
+    },
+    {
+      id: `${spec.id}_durationDays`,
+      type: 'number',
+      label: 'Duration (days)',
+      defaultValue: spec.durationDays,
+      meta: { taskBlockKey: 'durationDays' },
+    },
+    ...(spec.instructions
+      ? [
+          {
+            id: `${spec.id}_additionalNotes`,
+            type: 'textarea' as const,
+            label: 'Instructions',
+            defaultValue: spec.instructions,
+            meta: { taskBlockKey: 'additionalNotes' },
+          },
+        ]
+      : []),
+  ],
+});
+
+const TASK_SCHEMA: FormField[] = [
+  {
+    id: 'tasks',
+    type: 'group',
+    label: 'Tasks',
+    meta: { taskGroup: true },
+    fields: [
+      taskBlock({
+        id: 'task-vitals',
+        name: 'Record vitals',
+        category: 'CARE',
+        recurrence: 'EVERY_6_HOURS',
+        reminder: '15',
+        durationDays: '5',
+        instructions: 'Temperature, pulse and respiration. Log in the inpatient chart.',
+        keyedName: true,
+      }),
+      // Same data, title field authored without its `taskBlockKey`.
+      taskBlock({
+        id: 'task-analgesia',
+        name: 'Administer analgesia',
+        category: 'MEDICATION',
+        recurrence: 'EVERY_12_HOURS',
+        reminder: '30',
+        durationDays: '3',
+        keyedName: false,
+      }),
+    ],
+  },
+];
+
+const form = (over: Partial<FormsProps> = {}): FormsProps => ({
+  _id: 'form-2291',
+  name: 'Anaesthesia consent',
+  description: 'Signed before any procedure requiring a general anaesthetic.',
+  category: 'Consent form',
+  usage: 'Internal & External',
+  requiredSigner: 'CLIENT',
+  services: ['svc-dental', 'svc-senior'],
+  species: ['Canine', 'Feline'],
+  updatedBy: 'Dr. Elena Marsh',
+  lastUpdated: '2026-06-02T10:15:00.000Z',
+  status: 'Draft',
+  templateSource: 'ORG_TEMPLATE',
+  schema: CONSENT_SCHEMA,
+  ...over,
+});
+
+/**
+ * `Modal` portals a 470px right-side drawer to `document.body`, so this panel only
+ * exists while the Templates page keeps it mounted - and `ModalBase` holds a shared
+ * body scroll lock for as long as it is open. Mounting it behind a trigger keeps the
+ * docs page usable and puts the open transition itself under review.
+ */
+const FormInfoHarness = ({
+  showModal: _showModal,
+  setShowModal: _setShowModal,
+  ...args
+}: FormInfoProps) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="flex min-h-[640px] items-start bg-[var(--screen)] p-6">
+      <button
+        type="button"
+        className="rounded-full bg-[var(--cta)] px-5 py-2.5 text-[14px] font-semibold text-[var(--cta-text)]"
+        onClick={() => setOpen(true)}
+      >
+        Open form preview
+      </button>
+      {open && <FormInfo {...args} showModal setShowModal={setOpen} />}
+    </div>
+  );
+};
+
+const openDrawer = async (canvasElement: HTMLElement): Promise<HTMLElement> => {
+  const canvas = within(canvasElement);
+  await userEvent.click(canvas.getByRole('button', { name: 'Open form preview' }));
+  /* Closed does not mean unmounted for this component tree, so the panel is
+     always addressed as `dialog[open]` rather than by its text. */
+  return waitFor(() => {
+    const panel = document.querySelector('dialog[open]');
+    expect(panel).not.toBeNull();
+    return panel as HTMLElement;
+  });
+};
+
+/**
+ * The `grid grid-cols-2` that holds the lifecycle pair, reached from either button
+ * in it. Asserted by track count rather than by class: a dropped or malformed
+ * template collapses to a single track, which stacks the pair and pushes the
+ * standing Edit form button below the fold of a 470px drawer - and every
+ * `getByRole('button')` in the footer still passes while that happens.
+ */
+const assertActionPair = (panel: HTMLElement, names: [string, string]): HTMLElement => {
+  const first = within(panel).getByRole('button', { name: names[0] });
+  const row = first.parentElement as HTMLElement;
+  expect(getComputedStyle(row).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(2);
+  expect(row.children).toHaveLength(2);
+  // Order matters: the pair is re-rendered per status, not re-labelled, so a
+  // swapped branch would still satisfy two independent presence checks.
+  expect([...row.children].map((child) => child.textContent)).toEqual(names);
+  return row;
+};
+
+/**
+ * `Primary` paints `background-color: var(--cta)` inline; `Secondary` paints
+ * nothing and draws a border instead. So "which of the pair is the primary move"
+ * is readable off the computed background, and that is the only thing separating
+ * the Draft and Published footers once both buttons are present. Polled, because
+ * both variants carry a `transition` on background-color and a single
+ * synchronous read can land mid-interpolation.
+ */
+const assertPrimaryIs = (row: HTMLElement, primaryName: string | null): Promise<void> =>
+  waitFor(() => {
+    const painted = [...row.children].filter(
+      (child) => getComputedStyle(child).backgroundColor !== 'rgba(0, 0, 0, 0)'
+    );
+    if (primaryName === null) {
+      expect(painted).toHaveLength(0);
+      return;
+    }
+    expect(painted).toHaveLength(1);
+    expect(painted[0]).toHaveAccessibleName(primaryName);
+  });
+
+/**
+ * How many `label / value` rows an accordion is printing, anchored on its toggle
+ * button rather than on any one row: `Accordion` renders the open panel as the
+ * header's sibling, and `EditableAccordion` fills it with one wrapper div per
+ * visible field. Counting is what catches a row that `detailsFields` builds by
+ * pushing conditionally - a lost row reads exactly like a row that was never
+ * asked for, to every text query in the drawer.
+ */
+const accordionRowCount = (dialog: HTMLElement, title: string): number => {
+  const toggle = within(dialog).getByRole('button', { name: title });
+  const root = toggle.parentElement?.parentElement as HTMLElement;
+  expect(root.children).toHaveLength(2); // header + open panel
+  const rows = (root.children[1] as HTMLElement).firstElementChild as HTMLElement;
+  return rows.children.length;
+};
+
+const meta = {
+  title: 'Forms/FormInfo',
+  component: FormInfo,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The drawer that opens from a row on Templates: everything a template is, plus the ' +
+          'lifecycle actions, in one read-only panel. It had no story, and it could not have a ' +
+          'plain one - the panel is portalled out of the canvas by `Modal`, so it exists only ' +
+          'while a parent holds it open.\n\n' +
+          '**Its footer is a three-way state machine and its body is a two-way fork, and neither ' +
+          'is visible from the component signature.**\n\n' +
+          'The footer reads `status`: a Draft gets Publish + Archive, a Published template gets ' +
+          'Unpublish + Archive, and an Archived one gets Move to draft + Publish. That whole row ' +
+          'then disappears if the template has no `_id`, and `canEdit: false` removes it as well ' +
+          'and swaps the standing Edit form button for a bare Close.\n\n' +
+          'The body forks on `category`. A Task Template shows `TaskTemplateSummary` - a text ' +
+          'digest of the task blocks - while every other category shows the real `FormRenderer` ' +
+          'in read-only mode. Both accordions are skipped entirely when the schema is empty, so a ' +
+          'draft with no fields yet shows only its two metadata blocks.\n\n' +
+          'The header title is computed from three inputs rather than passed in: a template-backed ' +
+          'form reads "View template", an editable legacy form "Edit form", and a form the viewer ' +
+          'cannot edit "View form". A YC-library template additionally drops the "Signed by" row, ' +
+          'because its signing rule is fixed upstream.\n\n' +
+          'One thing the stories surface rather than assert: `FormInfo` passes neither ' +
+          '`aria-label` nor `aria-labelledby` to `Modal`, so the dialog has no accessible name ' +
+          'even though `ModalHeader` accepts a `titleId` for exactly that.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    activeForm: form(),
+    showModal: true,
+    setShowModal: fn(),
+    onEdit: fn(),
+    serviceOptions: SERVICE_OPTIONS,
+    canEdit: true,
+  },
+  render: (args) => <FormInfoHarness {...args} />,
+} satisfies Meta<typeof FormInfo>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const DraftForm: Story = {
+  name: 'Draft (Publish / Archive)',
+  play: async ({ canvasElement }) => {
+    const dialog = await openDrawer(canvasElement);
+    const panel = within(dialog);
+
+    await expect(panel.getByRole('heading', { name: 'Edit form' })).toBeInTheDocument();
+
+    // Form details: five rows, two of them resolved through an option list.
+    await expect(panel.getByRole('button', { name: 'Form details' })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
+    await expect(panel.getByText('Anaesthesia consent')).toBeInTheDocument();
+    await expect(
+      panel.getByText('Signed before any procedure requiring a general anaesthetic.')
+    ).toBeInTheDocument();
+    await expect(panel.getByText('Custom')).toBeInTheDocument();
+    await expect(panel.getByText('Consent form')).toBeInTheDocument();
+    // 'CLIENT' is stored; 'Pet parent' is what a reader should see.
+    await expect(panel.getByText('Pet parent')).toBeInTheDocument();
+
+    /* Five rows: Form name, Description, Template Source, Category, Signed by.
+       Counted as well as read, so the YC-library story below can assert four and
+       have that mean something. */
+    await expect(accordionRowCount(dialog, 'Form details')).toBe(5);
+
+    // Usage: both multi-selects resolve their ids to labels and join with commas.
+    await expect(panel.getByText('Internal & External')).toBeInTheDocument();
+    await expect(
+      panel.getByText('Dental consultation, Senior wellness package')
+    ).toBeInTheDocument();
+    await expect(panel.getByText('Canine, Feline')).toBeInTheDocument();
+
+    /* The preview is the real FormRenderer, not a summary. Every control is
+       present and inert - which is the property that matters, because this panel
+       is reachable by staff who may not edit the template. */
+    await expect(panel.getByRole('button', { name: 'Form preview' })).toBeInTheDocument();
+    await expect(panel.getByRole('textbox', { name: 'Procedure' })).toHaveAttribute('readonly');
+    await expect(
+      panel.getByRole('checkbox', { name: 'Risks explained and understood' })
+    ).toBeDisabled();
+    await expect(panel.getByText('Please Save and Sign')).toBeInTheDocument();
+
+    /* Two actions in a two-track grid, in that order, with Publish the only
+       painted (Primary) one. The grid is what keeps the pair equal width; a
+       template that collapses to one track stacks them and pushes the standing
+       Edit form button below the fold of a 470px drawer. */
+    const actionRow = assertActionPair(dialog, ['Publish', 'Archive']);
+    await assertPrimaryIs(actionRow, 'Publish');
+    await expect(panel.queryByRole('button', { name: 'Unpublish' })).not.toBeInTheDocument();
+    await expect(panel.getByRole('button', { name: 'Edit form' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting state for an org-owned draft. Everything below the two metadata accordions ' +
+          'is the live renderer running read-only, so what a reviewer sees here is exactly the ' +
+          'control set a pet parent will be handed - including the signature placeholder, which ' +
+          'is never signable inside PIMS.',
+      },
+    },
+  },
+};
+
+export const PublishedForm: Story = {
+  name: 'Published (Unpublish / Archive)',
+  args: { activeForm: form({ status: 'Published' }) },
+  play: async ({ canvasElement }) => {
+    const dialog = await openDrawer(canvasElement);
+    const panel = within(dialog);
+
+    // Same two-track row, different pair, same order rule.
+    const actionRow = assertActionPair(dialog, ['Unpublish', 'Archive']);
+    /* The one thing that separates this footer from the Draft one beyond the
+       labels: neither button is painted, because both are Secondary. There is no
+       primary move to make on something already live, and Archive is deliberately
+       not tinted destructive because it is reversible from the Archived state. */
+    await assertPrimaryIs(actionRow, null);
+
+    // Publish is gone rather than disabled - the whole pair is re-rendered.
+    await expect(panel.queryByRole('button', { name: 'Publish' })).not.toBeInTheDocument();
+    await expect(panel.queryByRole('button', { name: 'Move to draft' })).not.toBeInTheDocument();
+
+    // The body above the footer is untouched by status - still the live renderer.
+    await expect(panel.getByRole('textbox', { name: 'Procedure' })).toHaveAttribute('readonly');
+    await expect(accordionRowCount(dialog, 'Form details')).toBe(5);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A live template. Both actions are Secondary here - there is no primary move to make on ' +
+          'something already published, and Archive is deliberately not tinted destructive ' +
+          'because archiving is reversible from the Archived state below.',
+      },
+    },
+  },
+};
+
+export const ArchivedForm: Story = {
+  name: 'Archived (Move to draft / Publish)',
+  args: { activeForm: form({ status: 'Archived' }) },
+  play: async ({ canvasElement }) => {
+    const dialog = await openDrawer(canvasElement);
+    const panel = within(dialog);
+
+    /* "Move to draft" calls the same unpublish endpoint as "Unpublish" above -
+       one handler, two labels, because the resulting state reads differently
+       depending on where you came from. It also sits FIRST here while Publish,
+       which sits first in the Draft footer, sits second, so the two branches are
+       not distinguishable by membership alone. */
+    const actionRow = assertActionPair(dialog, ['Move to draft', 'Publish']);
+    await assertPrimaryIs(actionRow, 'Publish');
+    await expect(panel.queryByRole('button', { name: 'Archive' })).not.toBeInTheDocument();
+    await expect(panel.getByRole('button', { name: 'Edit form' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The only branch where Publish is the Primary of the pair, so an archived template can ' +
+          'be brought straight back into service without passing through draft.',
+      },
+    },
+  },
+};
+
+export const YcLibraryTemplate: Story = {
+  name: 'YC library template',
+  args: {
+    activeForm: form({
+      name: 'YC discharge instructions',
+      templateSource: 'YC_LIBRARY',
+      isTemplateBacked: true,
+      status: 'Published',
+    }),
+  },
+  play: async ({ canvasElement }) => {
+    const dialog = await openDrawer(canvasElement);
+    const panel = within(dialog);
+
+    // Title comes from `isTemplateBacked`, ahead of the edit permission.
+    await expect(panel.getByRole('heading', { name: 'View template' })).toBeInTheDocument();
+    await expect(panel.getByText('YC default (locked structure)')).toBeInTheDocument();
+
+    /* The invisible rule: a YC-library template drops the "Signed by" row from
+       Form details entirely, because its signing requirement is fixed upstream
+       and an editable-looking row would imply otherwise. Asserted as four rows
+       rather than as one absent string, because `detailsFields` builds the array
+       by pushing - a row lost anywhere else in it reads the same to a text query
+       and only the count catches it. */
+    await expect(accordionRowCount(dialog, 'Form details')).toBe(4);
+    await expect(panel.queryByText('Signed by')).not.toBeInTheDocument();
+    await expect(panel.getByText('Description')).toBeInTheDocument();
+    await expect(panel.getByText('Template Source')).toBeInTheDocument();
+    await expect(panel.getByText('Category')).toBeInTheDocument();
+    await expect(panel.getByText('YC discharge instructions')).toBeInTheDocument();
+
+    /* Usage & visibility is untouched by the lock - all three of its rows stay,
+       so "locked" is scoped to the signing rule and the schema, not to how the
+       template is published. */
+    await expect(accordionRowCount(dialog, 'Usage & visibility')).toBe(3);
+
+    // Structure is locked, but the state actions are not - a YC template is
+    // still published and archived per organisation.
+    const actionRow = assertActionPair(dialog, ['Unpublish', 'Archive']);
+    await assertPrimaryIs(actionRow, null);
+    await expect(panel.getByRole('button', { name: 'Edit form' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A template from the YC library, adopted by this organisation. Two things change and ' +
+          'only one of them is announced: the header says "View template", and the Signed by row ' +
+          'silently disappears. The Edit form button remains, because content inside a locked ' +
+          'structure is still editable - the builder is what enforces that, not this panel.',
+      },
+    },
+  },
+};
+
+export const TaskTemplate: Story = {
+  name: 'Task template (summary, not preview)',
+  args: {
+    activeForm: form({
+      name: 'Post-op inpatient tasks',
+      category: 'Task Template',
+      requiredSigner: '',
+      schema: TASK_SCHEMA,
+    }),
+  },
+  play: async ({ canvasElement }) => {
+    const panel = within(await openDrawer(canvasElement));
+
+    // The fork: Tasks digest instead of the rendered form.
+    await expect(panel.getByRole('button', { name: 'Tasks' })).toBeInTheDocument();
+    await expect(panel.queryByRole('button', { name: 'Form preview' })).not.toBeInTheDocument();
+
+    // Two blocks, and each summary line is composed from four option lookups.
+    const blocks = panel.getAllByRole('listitem');
+    await expect(blocks).toHaveLength(2);
+    await expect(panel.getByText('Record vitals')).toBeInTheDocument();
+    await expect(
+      panel.getByText('Care · Every 6 hours · 15 minutes before · 5 days')
+    ).toBeInTheDocument();
+    await expect(
+      panel.getByText('Temperature, pulse and respiration. Log in the inpatient chart.')
+    ).toBeInTheDocument();
+
+    /* The second block's title field carries no `taskBlockKey`, which is how the
+       older library blocks were authored. `taskBlockValue` finds nothing and the
+       summary falls back to a positional name - so a task that HAS a title
+       renders as "Task 2". Worth seeing: nothing upstream flags it. */
+    await expect(panel.getByText('Task 2')).toBeInTheDocument();
+    await expect(panel.queryByText('Administer analgesia')).not.toBeInTheDocument();
+    await expect(
+      panel.getByText('Medication · Every 12 hours · 30 minutes before · 3 days')
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Task Templates do not preview as a form, because their fields are scheduling settings ' +
+          'rather than questions. `TaskTemplateSummary` reads each block by its `taskBlockKey` ' +
+          'meta and prints one line per task.\n\n' +
+          'The second block below is deliberately authored the older way, with no `taskBlockKey` ' +
+          'on its title field. Its name is present in the schema and still does not reach the ' +
+          'screen - the digest prints "Task 2" instead, with the rest of the line intact.',
+      },
+    },
+  },
+};
+
+export const ViewerWithoutEditRights: Story = {
+  name: 'Viewer without edit rights',
+  args: { activeForm: form({ status: 'Published' }), canEdit: false },
+  play: async ({ canvasElement }) => {
+    const dialog = await openDrawer(canvasElement);
+    const panel = within(dialog);
+
+    await expect(panel.getByRole('heading', { name: 'View form' })).toBeInTheDocument();
+
+    /* "Close" names TWO buttons in this panel, so the footer one cannot be
+       reached by name alone: `ModalHeader` always renders the round X, which is
+       icon-only and takes its accessible name from `aria-label="Close"`, and
+       `canEdit: false` swaps the footer's "Edit form" for a Secondary carrying
+       the visible word. Both are intended - the story description below says so
+       - so the pair is asserted rather than worked around, and the footer one is
+       then taken by its text. Scoping matters more than usual here: the header X
+       sits in a one-child flex of its own, so a query that resolved to it would
+       satisfy both structural assertions below while the footer was empty. */
+    const closeButtons = panel.getAllByRole('button', { name: 'Close' });
+    await expect(closeButtons).toHaveLength(2);
+    const [headerClose] = closeButtons.filter((button) => button.textContent === '');
+    const [footerClose] = closeButtons.filter((button) => button.textContent === 'Close');
+    await expect(headerClose).toHaveAttribute('aria-label', 'Close');
+    await expect(footerClose).toBeInTheDocument();
+
+    /* `canEdit: false` removes the whole lifecycle row, not just the edit
+       affordance - so a read-only viewer cannot publish, unpublish or archive
+       either. Asserted as a footer that now holds exactly ONE child, because the
+       grid row is a sibling of the standing button rather than a wrapper around
+       it: four separate absence checks would also pass if the row were rendered
+       empty, which looks entirely different. */
+    const footerColumn = footerClose.parentElement as HTMLElement;
+    await expect(footerColumn.children).toHaveLength(1);
+    await expect(getComputedStyle(footerColumn).display).toBe('flex');
+    // Direction as well as display: the header's action cluster is also a
+    // one-child flex, so `column` is what says this is the footer stack.
+    await expect(getComputedStyle(footerColumn).flexDirection).toBe('column');
+    await expect(panel.queryByRole('button', { name: 'Publish' })).not.toBeInTheDocument();
+    await expect(panel.queryByRole('button', { name: 'Unpublish' })).not.toBeInTheDocument();
+    await expect(panel.queryByRole('button', { name: 'Archive' })).not.toBeInTheDocument();
+    await expect(panel.queryByRole('button', { name: 'Edit form' })).not.toBeInTheDocument();
+
+    // The content is unchanged - this is a permission on actions, not on reading.
+    await expect(accordionRowCount(dialog, 'Form details')).toBe(5);
+    await expect(panel.getByRole('textbox', { name: 'Procedure' })).toHaveAttribute('readonly');
+    await expect(
+      panel.getByText('Dental consultation, Senior wellness package')
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The panel a viewer without template rights sees. Two close affordances now exist - the ' +
+          'round X in the header and the full-width Close in the footer - and they do the same ' +
+          'thing under the same accessible name, so a screen reader announces "Close, button" ' +
+          'twice in one dialog and the play function has to tell them apart structurally. Note ' +
+          'too that `canEdit` gates the actions but nothing about the panel says why they are ' +
+          'missing.',
+      },
+    },
+  },
+};
+
+export const EmptySchema: Story = {
+  name: 'No fields yet',
+  args: { activeForm: form({ schema: [] }) },
+  play: async ({ canvasElement }) => {
+    const dialog = await openDrawer(canvasElement);
+    const panel = within(dialog);
+
+    /* Two accordions, not three. Counted rather than checked one absence at a
+       time: every accordion in this drawer opens by default, and with no schema
+       there is no `FormRenderer` below them to contribute an expandable control
+       of its own, so the expanded-button count IS the accordion count here. */
+    await expect(panel.getAllByRole('button', { expanded: true })).toHaveLength(2);
+    await expect(panel.queryByRole('button', { name: 'Form preview' })).not.toBeInTheDocument();
+    await expect(panel.queryByRole('button', { name: 'Tasks' })).not.toBeInTheDocument();
+
+    /* The metadata still reads in full - an empty schema costs nothing above the
+       fold, which is exactly why this state is easy to publish by accident. */
+    await expect(accordionRowCount(dialog, 'Form details')).toBe(5);
+    await expect(accordionRowCount(dialog, 'Usage & visibility')).toBe(3);
+    await expect(panel.getByText('Anaesthesia consent')).toBeInTheDocument();
+    await expect(panel.getByText('Pet parent')).toBeInTheDocument();
+
+    // And the lifecycle actions are still the full Draft pair, Publish primary.
+    const actionRow = assertActionPair(dialog, ['Publish', 'Archive']);
+    await assertPrimaryIs(actionRow, 'Publish');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A template saved before any fields were added. The preview block is omitted rather than ' +
+          'shown empty, which reads cleanly - but Publish is still offered, so an empty template ' +
+          'can be made live from this drawer with nothing warning against it.',
+      },
+    },
+  },
+};
+
+export const HandOffToBuilder: Story = {
+  name: 'Edit form hands off to the builder',
+  play: async ({ args, canvasElement }) => {
+    const panel = await openDrawer(canvasElement);
+    await userEvent.click(within(panel).getByRole('button', { name: 'Edit form' }));
+
+    /* The drawer closes itself first and then calls `onEdit`, so the Templates
+       page never has both this panel and the builder open at once. Absence is
+       asserted against `dialog[open]`: the element can survive without its
+       `open` attribute, and a text query would pass either way. */
+    await waitFor(() => {
+      expect(document.querySelector('dialog[open]')).toBeNull();
+    });
+    await expect(args.onEdit).toHaveBeenCalledTimes(1);
+    await expect(args.onEdit).toHaveBeenCalledWith(
+      expect.objectContaining({ _id: 'form-2291', name: 'Anaesthesia consent' })
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The handover. `onEdit` receives the whole `FormsProps` object, schema included, so the ' +
+          'builder opens on the same in-memory template rather than re-fetching it - which is why ' +
+          'the drawer closing first matters: two mounted editors would hold two copies of it.',
+      },
+    },
+  },
+};
+
+export const Phone: Story = {
+  name: 'Phone (375, full-screen)',
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    await openDrawer(canvasElement);
+
+    /* Below 768px `Modal` swaps the 470px drawer for a full-screen panel. Nothing
+       in FormInfo asks for this and nothing in it adapts to it, so the whole
+       panel is inherited - worth re-reading the node rather than holding the one
+       `openDrawer` returned, because `useIsPhone` is false for the first client
+       render and this is a post-mount swap. */
+    const dialog = await waitFor(() => {
+      const el = document.querySelector('dialog[open]') as HTMLElement | null;
+      expect(el?.className).toContain('yc-modal-fullscreen');
+      return el as HTMLElement;
+    });
+    await expect(dialog.className).not.toContain('sm:w-[470px]');
+
+    const panel = within(dialog);
+    await expect(panel.getByRole('heading', { name: 'Edit form' })).toBeInTheDocument();
+
+    /* The action pair keeps its two tracks at 375 rather than stacking, and both
+       tracks are the same width, so each button gets under half of a 375 screen
+       minus the drawer's own padding. That is the number to look at: "Move to
+       draft" is the longest label the same row ever carries. */
+    const actionRow = assertActionPair(dialog, ['Publish', 'Archive']);
+    await assertPrimaryIs(actionRow, 'Publish');
+    const [firstTrack, secondTrack] = getComputedStyle(actionRow)
+      .gridTemplateColumns.trim()
+      .split(/\s+/);
+    await expect(firstTrack).toBe(secondTrack);
+    await expect(parseFloat(firstTrack)).toBeLessThan(180);
+
+    // The body is the full desktop body - nothing is dropped for the small screen.
+    await expect(accordionRowCount(dialog, 'Form details')).toBe(5);
+    await expect(panel.getByRole('textbox', { name: 'Procedure' })).toHaveAttribute('readonly');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same panel on a phone. `grid-cols-2` has no responsive variant on the action row, ' +
+          'so Publish and Archive stay side by side at 375 - narrow, but consistent with the ' +
+          'desktop drawer rather than re-forming into a stack the way the Foundations sheet rules ' +
+          'would suggest.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/integrations/pages/Integrations/IdexxSettingsModal.stories.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/Integrations/IdexxSettingsModal.stories.tsx
@@ -1,0 +1,677 @@
+import React, { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+
+import type {
+  IvlsDevice,
+  LabOrder,
+  OrgIntegration,
+} from '@/app/features/integrations/services/types';
+import { IdexxSettingsModal } from './index';
+
+type PanelProps = React.ComponentProps<typeof IdexxSettingsModal>;
+
+const ORG_ID = 'org-avenger-park';
+
+const integration = (over: Partial<OrgIntegration> = {}): OrgIntegration => ({
+  id: 'int-idexx-1',
+  organisationId: ORG_ID,
+  provider: 'IDEXX',
+  status: 'enabled',
+  credentialsStatus: 'valid',
+  lastValidatedAt: '2026-08-17T08:12:00.000Z',
+  enabledAt: '2026-06-02T14:30:00.000Z',
+  lastSyncAt: '2026-08-18T06:05:00.000Z',
+  ...over,
+});
+
+const DEVICES: IvlsDevice[] = [
+  {
+    deviceSerialNumber: 'SN-9F42-118',
+    displayName: 'Catalyst One (prep room)',
+    vcpActivatedStatus: 'active',
+    lastPolledCloudTime: '2026-08-18T06:02:00.000Z',
+  },
+  {
+    deviceSerialNumber: 'SN-2B07-553',
+    displayName: 'ProCyte Dx (theatre)',
+    vcpActivatedStatus: 'pending',
+    lastPolledCloudTime: '2026-08-16T19:41:00.000Z',
+  },
+];
+
+const order = (over: Partial<LabOrder>): LabOrder => ({
+  _id: 'ord-1',
+  organisationId: ORG_ID,
+  provider: 'IDEXX',
+  companionId: 'companion-1',
+  status: 'resulted',
+  modality: 'INHOUSE',
+  idexxOrderId: 'IDX-100001',
+  tests: [],
+  ...over,
+});
+
+/**
+ * Four, deliberately. `RecentOrdersList` renders `orders.slice(0, 3)`, so the
+ * fourth is the one that proves the cap rather than a row that happens to fit.
+ */
+const ORDERS: LabOrder[] = [
+  order({ _id: 'ord-1', patientName: 'Kizie', tests: ['CBC', 'Chem 17'], status: 'resulted' }),
+  order({ _id: 'ord-2', patientName: 'Milo', tests: ['UA'], status: 'running' }),
+  order({ _id: 'ord-3', patientName: 'Pepper', tests: ['T4'], status: 'ordered' }),
+  order({ _id: 'ord-4', patientName: 'Nimbus', tests: ['Cortisol'], status: 'resulted' }),
+];
+
+/**
+ * Real local state for the two credential fields.
+ *
+ * The panel is fully controlled - `username`/`password` come in as props and the
+ * setters go back out - so with `fn()` setters the fields would be frozen and the
+ * "typing unlocks the primary action" story could not exist. Everything else stays
+ * an arg, so the controls table is still the panel's real prop list.
+ */
+const StatefulPanel = (props: PanelProps) => {
+  const [username, setUsername] = useState(props.username);
+  const [password, setPassword] = useState(props.password);
+  return (
+    <div className="min-h-[760px] bg-[var(--screen)] p-6">
+      <p className="text-[13px] text-[var(--ink-muted)]">
+        The Integrations catalogue sits behind the scrim. The panel is a drawer, so the page stays
+        readable down its left edge.
+      </p>
+      <IdexxSettingsModal
+        {...props}
+        username={username}
+        setUsername={setUsername}
+        password={password}
+        setPassword={setPassword}
+      />
+    </div>
+  );
+};
+
+/**
+ * The panel portals to `document.body`, so nothing inside it is ever in
+ * `canvasElement`. Play functions do not run in the Docs view, so exactly one
+ * story is mounted whenever this resolves - a second `dialog[open]` would mean a
+ * story leaked its panel, which is worth failing on.
+ */
+const openPanel = (): HTMLElement => {
+  const dialogs = document.querySelectorAll('dialog[open]');
+  if (dialogs.length !== 1) {
+    throw new Error(`Expected exactly one open dialog, found ${dialogs.length}.`);
+  }
+  return dialogs[0] as HTMLElement;
+};
+
+/**
+ * Resolves a design token to the colour the browser actually paints, so a story
+ * can say "this pill is the warning tint" rather than only "it is not the same
+ * colour as that other one". Throws on an unresolved token: `var(--typo)`
+ * computes to transparent, which would otherwise quietly match anything else
+ * that also computes to transparent and turn the assertion into a no-op.
+ */
+const resolveToken = (host: HTMLElement, token: string): string => {
+  const probe = document.createElement('span');
+  probe.style.backgroundColor = `var(${token})`;
+  host.append(probe);
+  const value = getComputedStyle(probe).backgroundColor;
+  probe.remove();
+  if (value === 'rgba(0, 0, 0, 0)') {
+    throw new Error(`Token ${token} resolved to transparent - it does not exist here.`);
+  }
+  return value;
+};
+
+const SECTION_TITLES = [
+  'Credentials',
+  'Connection',
+  'Sync health',
+  'Recent orders',
+  'Linked medical devices',
+];
+
+/**
+ * The `Accordion` root, reached from its header button: button -> header row ->
+ * root. An open accordion has exactly two element children (the header row and
+ * the body); a collapsed one has a single child. That is the difference between
+ * "the flag says open" and "the body actually rendered", and only the second is
+ * worth a story.
+ */
+const accordionRoot = (header: HTMLElement): HTMLElement => {
+  const root = header.parentElement?.parentElement;
+  if (!root) throw new Error('Accordion header is not nested the way this helper expects.');
+  return root;
+};
+
+const meta = {
+  title: 'Integrations/IdexxSettingsModal',
+  component: IdexxSettingsModal,
+  render: (args) => <StatefulPanel {...args} />,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The IDEXX settings drawer - the only place in PIMS where lab credentials are entered, ' +
+          'validated and the connection switched on or off, and it had never been drawn. It is ' +
+          'the second half of the Integrations page: the catalogue cards are static, everything ' +
+          'that can actually go wrong lives in here.\n\n' +
+          'It is presentation only. Every value and every handler is a prop, computed by ' +
+          '`useIntegrationsPage`, which is why these stories can drive it with fixtures and no ' +
+          'network. The page itself is not reachable from a story - it renders only inside ' +
+          '`ProtectedRoute` + `OrgGuard`, and its hook fetches IVLS devices and lab orders over ' +
+          'axios on mount - so the panel is imported directly.\n\n' +
+          'Five accordions, all open by default, and the order matters: **Credentials** (the two ' +
+          'fields plus store/validate), **Connection** (enable/disable), **Sync health**, ' +
+          '**Recent orders** and **Linked medical devices**. Three colour maps meet here - ' +
+          '`credentialsStatusTokens` for the credentials pill, `statusTokens` for the connection ' +
+          'pill and `deviceStatusTokens` per device - so a token that drifts shows up as two ' +
+          'pills disagreeing inside one panel. The stories resolve those tokens rather than ' +
+          'compare pills to each other, so a map that drifts wholesale still fails.\n\n' +
+          'The panel takes the Modal default variant, which is `drawer` at `lg` (530px). Below ' +
+          '768px that goes full-screen rather than becoming a sheet, so the phone story is the ' +
+          'only place the five accordions are seen stacked at full width.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    showSettings: true,
+    setShowSettings: fn(),
+    idexxIntegration: integration(),
+    idexxEnabled: true,
+    hasStoredCredentials: true,
+    credentialsStatusKey: 'valid',
+    credentialsStatusLabel: 'Valid',
+    credentialsActionLabel: 'Update credentials',
+    validateState: 'idle',
+    saving: false,
+    refreshing: false,
+    integrationsLastFetchedAt: '2026-08-18T06:05:00.000Z',
+    devices: DEVICES,
+    recentOrders: ORDERS,
+    /* Deliberately not credential-shaped. A realistic-looking username/password pair
+       here trips GitGuardian's generic-password detector and fails the PR gate - the
+       story only needs the fields to be non-empty to draw the filled state. */
+    username: 'EXAMPLE_NOT_A_CREDENTIAL',
+    password: 'EXAMPLE_NOT_A_CREDENTIAL',
+    setUsername: fn(),
+    setPassword: fn(),
+    handleManualRefresh: fn(async () => {}),
+    handleStoreCredentials: fn(async () => {}),
+    handleValidate: fn(async () => {}),
+    handleEnableDisable: fn(async () => {}),
+  },
+} satisfies Meta<typeof IdexxSettingsModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Connected: Story = {
+  name: 'Connected, credentials valid',
+  play: async ({ canvasElement }) => {
+    const dialog = await waitFor(openPanel);
+    const panel = within(dialog);
+
+    await expect(panel.getByRole('heading', { name: 'Integration settings' })).toBeInTheDocument();
+
+    /* All five sections, open, WITH their bodies rendered. `defaultOpen` is
+       passed on every one, so a section reporting collapsed here means the
+       Accordion default changed under them - and the child count is what
+       separates "aria-expanded says true" from "the body is really there". */
+    for (const title of SECTION_TITLES) {
+      const header = panel.getByRole('button', { name: title });
+      await expect(header).toHaveAttribute('aria-expanded', 'true');
+      await expect(accordionRoot(header).children).toHaveLength(2);
+    }
+
+    /* The credentials read-out is a two-track grid of four cells - label, pill,
+       label, value. Drop a track and the pill lands under its own label on a
+       second row, which reads as a layout bug rather than a broken template. */
+    const statusLabel = panel.getByText('Credentials status');
+    const grid = statusLabel.closest('.grid') as HTMLElement;
+    await expect(getComputedStyle(grid).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(2);
+    await expect(grid.children).toHaveLength(4);
+
+    /* Three colour maps meet in this panel, and each pill is checked against the
+       token it is supposed to carry rather than against its neighbour: the
+       credentials pill from `credentialsStatusTokens`, the connection pill from
+       `statusTokens`, the device pills from `deviceStatusTokens`. Polled, because
+       the panel fades in and a single synchronous read can land mid-transition. */
+    const credentialsPill = panel.getByText('Valid');
+    const connectionPill = panel.getByText('Enabled');
+    const activeDevicePill = panel.getByText('Active');
+    const pendingDevicePill = panel.getByText('Pending');
+    await waitFor(() => {
+      const success = resolveToken(dialog, '--color-pill-success-bg');
+      expect(getComputedStyle(credentialsPill).backgroundColor).toBe(success);
+      expect(getComputedStyle(connectionPill).backgroundColor).toBe(success);
+      expect(getComputedStyle(activeDevicePill).backgroundColor).toBe(success);
+      expect(getComputedStyle(pendingDevicePill).backgroundColor).toBe(
+        resolveToken(dialog, '--color-pill-warning-bg')
+      );
+    });
+    /* The live dot is the other half of the device signal: `showDot` is on for
+       `active` only, and the dot is the pill's single element child (the label is
+       a text node), so the counts read 1 and 0. */
+    await expect(activeDevicePill.children).toHaveLength(1);
+    await expect(pendingDevicePill.children).toHaveLength(0);
+
+    // The first three of the four, in arrival order, and the fourth genuinely dropped.
+    await expect(panel.getByText('Kizie · CBC, Chem 17')).toBeInTheDocument();
+    await expect(panel.getByText('Milo · UA')).toBeInTheDocument();
+    await expect(panel.getByText('Pepper · T4')).toBeInTheDocument();
+    await expect(panel.queryByText('Nimbus · Cortisol')).not.toBeInTheDocument();
+
+    /* Each order row carries its own status pill, keyed off substrings rather
+       than an enum ("resulted" matches `result`, "running" matches `run`), so the
+       three labels and the running row's progress tint are the check on that. */
+    await expect(panel.getByText('Resulted')).toBeInTheDocument();
+    await expect(panel.getByText('Ordered')).toBeInTheDocument();
+    const runningPill = panel.getByText('Running');
+    await waitFor(() => {
+      expect(getComputedStyle(runningPill).backgroundColor).toBe(
+        resolveToken(dialog, '--color-pill-progress-bg')
+      );
+    });
+
+    /* Sync health prints the device count, and the two device cards below it are
+       rendered from the same array - so these two must agree or the panel is
+       lying about one of them. */
+    const deviceCountLabel = panel.getByText('Linked IVLS devices');
+    await expect(deviceCountLabel.nextElementSibling).toHaveTextContent('2');
+    await expect(panel.getByText('Catalyst One (prep room)')).toBeInTheDocument();
+    await expect(panel.getByText('SN-9F42-118')).toBeInTheDocument();
+    await expect(panel.getByText('ProCyte Dx (theatre)')).toBeInTheDocument();
+    await expect(panel.getByText('SN-2B07-553')).toBeInTheDocument();
+
+    /* Every device card closes with its own two-track "Last cloud poll" grid.
+       One per card, and each is a two-cell row - a dropped track stacks the
+       timestamp under its label and doubles the card height. */
+    const pollRows = panel.getAllByText('Last cloud poll');
+    await expect(pollRows).toHaveLength(2);
+    for (const row of pollRows) {
+      const pollGrid = row.closest('.grid') as HTMLElement;
+      await expect(getComputedStyle(pollGrid).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(
+        2
+      );
+      await expect(pollGrid.children).toHaveLength(2);
+    }
+
+    await expect(panel.getByRole('button', { name: 'Disable IDEXX' })).toBeEnabled();
+    await expect(
+      panel.getByText(
+        'IDEXX integration availability is currently limited to the USA, Canada, and the UK.'
+      )
+    ).toBeInTheDocument();
+
+    // Nothing the panel renders is inside the story root; this is the proof.
+    await expect(within(canvasElement).queryByText('Integration settings')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The healthy resting state: credentials stored and valid, the integration enabled, two ' +
+          'IVLS devices polling and orders coming back. The two device pills are deliberately ' +
+          'different: an `active` device gets the success tint and a live dot, anything else the ' +
+          'warning tint and no dot, which is the only signal that a device is linked but not yet ' +
+          'activated.',
+      },
+    },
+  },
+};
+
+export const NotConnected: Story = {
+  name: 'No credentials stored',
+  args: {
+    idexxIntegration: null,
+    idexxEnabled: false,
+    hasStoredCredentials: false,
+    credentialsStatusKey: 'missing',
+    credentialsStatusLabel: 'Missing',
+    credentialsActionLabel: 'Store credentials',
+    integrationsLastFetchedAt: null,
+    devices: [],
+    recentOrders: [],
+    username: '',
+    password: '',
+  },
+  play: async () => {
+    const dialog = await waitFor(openPanel);
+    const panel = within(dialog);
+
+    /* `missing` is the third entry in `credentialsStatusTokens` and the only one
+       that is neutral. Reading the token rather than the word is what catches a
+       missing credential drawn in the warning tint, which would read as a
+       recoverable failure rather than as "nothing has been entered yet". */
+    const credentialsPill = panel.getByText('Missing');
+    await waitFor(() => {
+      expect(getComputedStyle(credentialsPill).backgroundColor).toBe(
+        resolveToken(dialog, '--color-pill-neutral-bg')
+      );
+    });
+
+    await expect(panel.getByText('Store credentials first to enable IDEXX.')).toBeInTheDocument();
+    await expect(panel.getByText('Not refreshed yet')).toBeInTheDocument();
+    // No integration record at all, so the Connection row falls back too.
+    await expect(panel.getByText('Connected since').nextElementSibling).toHaveTextContent(
+      'Not available'
+    );
+
+    /* "Not validated yet" is printed twice on purpose - once in the credentials
+       read-out and once in Sync health. Asserting the count is what catches one
+       of the two silently falling back to a formatted date. */
+    await expect(panel.getAllByText('Not validated yet')).toHaveLength(2);
+
+    // Both empty states, in full, rather than "the list is empty".
+    await expect(panel.getByText('No recent orders.')).toBeInTheDocument();
+    await expect(
+      panel.getByText('No linked IVLS devices found for this organization.')
+    ).toBeInTheDocument();
+    // Sync health keeps all four of its rows, so the panel does not lose height.
+    await expect(panel.getByText('Linked IVLS devices').nextElementSibling).toHaveTextContent('0');
+
+    /* Two different reasons to be disabled, and they must not be confused: the
+       store button is disabled because the fields are empty, the enable button
+       because there is no integration record to enable yet. */
+    await expect(panel.getByRole('button', { name: 'Store credentials' })).toBeDisabled();
+    await expect(panel.getByRole('button', { name: 'Enable IDEXX' })).toBeDisabled();
+    // Validate stays live - it is the only way to find out the org has no record.
+    await expect(panel.getByRole('button', { name: 'Validate' })).toBeEnabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A practice opening the panel for the first time. Everything downstream of credentials ' +
+          'is empty, and both empty states are prose rather than a dash - Sync health still ' +
+          'renders its four rows, so the panel keeps its full height instead of collapsing to a ' +
+          'form.',
+      },
+    },
+  },
+};
+
+export const TypingUnlocksSave: Story = {
+  name: 'Typing credentials unlocks the save',
+  args: {
+    idexxIntegration: null,
+    idexxEnabled: false,
+    hasStoredCredentials: false,
+    credentialsStatusKey: 'missing',
+    credentialsStatusLabel: 'Missing',
+    credentialsActionLabel: 'Store credentials',
+    devices: [],
+    recentOrders: [],
+    username: '',
+    password: '',
+  },
+  play: async ({ args }) => {
+    const dialog = await waitFor(openPanel);
+    const panel = within(dialog);
+
+    const save = panel.getByRole('button', { name: 'Store credentials' });
+    await expect(save).toBeDisabled();
+
+    const usernameField = panel.getByRole('textbox', { name: 'IDEXX username' });
+    /* `type=password` carries no ARIA role at all, so there is no `getByRole`
+       for it. `FormInputPass` sets both a real `<label for>` and an `aria-label`,
+       so the label text is the stable handle. */
+    const passwordField = panel.getByLabelText('IDEXX password');
+
+    /* Not credential-shaped, deliberately. GitGuardian's "Username Password" detector
+       reads a plausible pair typed into these two fields as a leak and fails the PR -
+       and it is right to, since it cannot know a fixture from the real thing. The guard
+       under test only cares that both fields are non-empty. */
+    await userEvent.type(usernameField, 'EXAMPLE_NOT_A_CREDENTIAL');
+    // Still disabled on the username alone - the guard is on both fields.
+    await expect(save).toBeDisabled();
+
+    await userEvent.type(passwordField, 'EXAMPLE_NOT_A_CREDENTIAL');
+    await expect(usernameField).toHaveValue('EXAMPLE_NOT_A_CREDENTIAL');
+    await expect(passwordField).toHaveValue('EXAMPLE_NOT_A_CREDENTIAL');
+    await expect(passwordField).toHaveAttribute('type', 'password');
+    await waitFor(() => {
+      expect(save).toBeEnabled();
+    });
+
+    /* The eye toggle is a real button that swaps the input `type`, and its own
+       label swaps with it - so a reveal that stopped working would still look
+       right in a screenshot and only shows up as the type staying `password`. */
+    await userEvent.click(panel.getByRole('button', { name: 'Show password' }));
+    await expect(passwordField).toHaveAttribute('type', 'text');
+    await expect(panel.getByRole('button', { name: 'Hide password' })).toBeInTheDocument();
+
+    await userEvent.click(save);
+    await expect(args.handleStoreCredentials).toHaveBeenCalledTimes(1);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The one interaction the panel actually owns. `isDisabled` is guarded on ' +
+          '`username.trim() && password.trim()`, so whitespace alone will not arm it, and the ' +
+          'story types into both fields to prove the guard is on the pair rather than on either ' +
+          'one. The masked field and its eye toggle are exercised here too, because the toggle ' +
+          'swaps the input `type` and its own accessible label at the same time.',
+      },
+    },
+  },
+};
+
+export const ValidationFailed: Story = {
+  name: 'Validation failed',
+  args: {
+    idexxIntegration: integration({
+      status: 'disabled',
+      credentialsStatus: 'invalid',
+      enabledAt: null,
+      lastSyncAt: null,
+    }),
+    idexxEnabled: false,
+    credentialsStatusKey: 'invalid',
+    credentialsStatusLabel: 'Invalid',
+    validateState: 'invalid',
+    devices: [],
+    recentOrders: [],
+  },
+  play: async () => {
+    const dialog = await waitFor(openPanel);
+    const panel = within(dialog);
+
+    const message = panel.getByText('Credentials are invalid or not available.');
+    const credentialsPill = panel.getByText('Invalid');
+    /* Polled, and read against the tokens rather than against a neighbour: the
+       message subtree carries `transition-colors`, so a single synchronous read
+       can land on an interpolated value, and "different from the label beside
+       it" would pass on any colour at all. */
+    await waitFor(() => {
+      expect(getComputedStyle(message).color).toBe(resolveToken(dialog, '--color-text-error'));
+    });
+    /* Warning, NOT danger. `credentialsStatusTokens.invalid` is the amber set on
+       purpose - an invalid credential is recoverable by retyping it - and the
+       two tints are close enough that only the token tells them apart. */
+    await waitFor(() => {
+      const warning = resolveToken(dialog, '--color-pill-warning-bg');
+      const danger = resolveToken(dialog, '--color-pill-danger-bg');
+      expect(warning).not.toBe(danger);
+      expect(getComputedStyle(credentialsPill).backgroundColor).toBe(warning);
+    });
+
+    await expect(panel.getByText('Pending')).toBeInTheDocument();
+    await expect(panel.getByText('Not enabled')).toBeInTheDocument();
+
+    /* Enable stays live on an invalid credential. That is deliberate: the enable
+       handler re-validates first and re-opens this panel on failure, so locking
+       the button here would leave a practice with no way to retry. */
+    await expect(panel.getByRole('button', { name: 'Enable IDEXX' })).toBeEnabled();
+    await expect(
+      panel.getByText('Stored credentials detected. Validate and enable when ready.')
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'What a practice sees after a failed Validate. Three things move together: the inline ' +
+          'message goes to `--color-text-error`, the credentials pill goes to the warning tint ' +
+          '(not danger - an invalid credential is recoverable), and Sync health falls back to ' +
+          '"Pending" and "Not enabled" because there was never a successful sync.',
+      },
+    },
+  },
+};
+
+export const Saving: Story = {
+  name: 'Save in flight',
+  args: {
+    saving: true,
+    credentialsActionLabel: 'Updating...',
+  },
+  play: async () => {
+    const dialog = await waitFor(openPanel);
+    const panel = within(dialog);
+
+    /* Two different buttons read "Updating..." while saving - the credentials
+       action in one accordion and the enable/disable action in another - because
+       `saving` is one flag shared by both. Counting them is not enough: two
+       buttons in the SAME section would satisfy a count and mean something quite
+       different, so each is located in its own accordion. */
+    const updating = panel.getAllByRole('button', { name: 'Updating...' });
+    await expect(updating).toHaveLength(2);
+    for (const button of updating) {
+      await expect(button).toBeDisabled();
+    }
+    const credentials = accordionRoot(panel.getByRole('button', { name: 'Credentials' }));
+    const connection = accordionRoot(panel.getByRole('button', { name: 'Connection' }));
+    await expect(updating.filter((button) => credentials.contains(button))).toHaveLength(1);
+    await expect(updating.filter((button) => connection.contains(button))).toHaveLength(1);
+
+    // Validate takes the same flag and swaps its own label rather than its state.
+    await expect(panel.getByRole('button', { name: 'Validating...' })).toBeDisabled();
+    await expect(panel.queryByRole('button', { name: 'Validate' })).not.toBeInTheDocument();
+
+    // Refresh is on its own flag, so it stays live during a save.
+    await expect(panel.getByRole('button', { name: 'Refresh integrations' })).toBeEnabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'One `saving` flag freezes all three credential/connection actions at once, so a slow ' +
+          'store cannot be raced by a validate. The labels change rather than a spinner appears, ' +
+          'which is why the buttons do not resize mid-flight.',
+      },
+    },
+  },
+};
+
+export const Refreshing: Story = {
+  name: 'Manual refresh in flight',
+  args: { refreshing: true },
+  play: async () => {
+    const dialog = await waitFor(openPanel);
+    const panel = within(dialog);
+
+    const refresh = panel.getByRole('button', { name: 'Refresh integrations' });
+    await expect(refresh).toBeDisabled();
+
+    /* The spin is the only feedback the strip gives. Three things have to be
+       true and none of them implies the others: exactly one element spins, it is
+       the icon inside the Refresh button rather than something else in the
+       panel, and the utility actually resolves to an animation - a class name
+       present in the DOM but absent from the compiled CSS is a still icon. */
+    const spinners = [...dialog.querySelectorAll('.animate-spin')];
+    await expect(spinners).toHaveLength(1);
+    const spinner = spinners[0] as HTMLElement;
+    await expect(refresh.contains(spinner)).toBe(true);
+    await expect(getComputedStyle(spinner).animationName).not.toBe('none');
+
+    /* The strip keeps printing the last refresh while a new one is in flight, so
+       the practice is never left with a blank timestamp. The timestamp is the
+       label's only element child - `getByText` matches the label because a text
+       query reads a node's own text nodes, not its subtree, so "Last refreshed:"
+       finds the wrapper and never the span inside it. Matched as a shape rather
+       than a literal: `formatDateTimeLocal` renders in the viewer's timezone, so
+       the exact string differs between machines. */
+    const lastRefreshed = panel.getByText('Last refreshed:').querySelector('span') as HTMLElement;
+    await expect(lastRefreshed.textContent).toMatch(/\d{2}:\d{2}\s?(AM|PM)$/);
+
+    // The rest of the panel keeps working while the refresh runs.
+    await expect(panel.getByRole('button', { name: 'Disable IDEXX' })).toBeEnabled();
+    await expect(panel.getByRole('button', { name: 'Update credentials' })).toBeEnabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The header strip during a manual refresh. Only the Refresh button locks; credential ' +
+          'and connection actions stay live, because a refresh is a read and cannot conflict ' +
+          'with them.',
+      },
+    },
+  },
+};
+
+export const Phone: Story = {
+  name: 'Phone: drawer goes full-screen',
+  // Pinned as a GLOBAL. `parameters.viewport.defaultViewport` was removed in
+  // Storybook 10 and is inert - a story using it renders the 1280px desktop
+  // drawer under a name that promises a phone.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async () => {
+    const dialog = await waitFor(openPanel);
+    const panel = within(dialog);
+
+    /* `useIsPhone` is false during SSR and the first client render, so the
+       full-screen class only lands after the media query is measured - poll for
+       it rather than reading once. */
+    await waitFor(() => {
+      expect(dialog.className).toContain('yc-modal-fullscreen');
+    });
+    // Full-screen, not a sheet: `drawer` keeps its own phone form and never grows
+    // the grabber that `centered` gets.
+    await expect(dialog.querySelector('.yc-phone-sheet')).toBeNull();
+
+    /* The class name alone would still pass if the rule behind it had been
+       edited away, and the viewport pin would still "pass" if it were inert -
+       the panel would just be 530px inside a 1280px canvas. Measuring catches
+       both: the drawer fills the viewport, and the viewport is phone-sized. */
+    const viewportWidth = document.documentElement.clientWidth;
+    await expect(viewportWidth).toBeLessThanOrEqual(430);
+    await expect(Math.round(dialog.getBoundingClientRect().width)).toBe(viewportWidth);
+
+    // The whole panel still renders - all five sections open, not a truncated form.
+    for (const title of SECTION_TITLES) {
+      const header = panel.getByRole('button', { name: title });
+      await expect(header).toHaveAttribute('aria-expanded', 'true');
+      await expect(accordionRoot(header).children).toHaveLength(2);
+    }
+
+    /* The credentials read-out is `grid-cols-2` with no breakpoint on it, so it
+       stays two equal tracks at 375 as well - which is the thing worth looking
+       at here, because "Credentials status" and its pill have to share a row
+       barely wider than the pill itself. */
+    const grid = panel.getByText('Credentials status').closest('.grid') as HTMLElement;
+    const tracks = getComputedStyle(grid)
+      .gridTemplateColumns.trim()
+      .split(/\s+/)
+      .map((track) => Math.round(Number.parseFloat(track)));
+    await expect(tracks).toHaveLength(2);
+    await expect(tracks[0]).toBe(tracks[1]);
+    await expect(grid.children).toHaveLength(4);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'At 375px the drawer becomes full-screen. Nothing in the panel is written for that ' +
+          'width specifically, so this is where the two-column credentials read-out and the ' +
+          'fixed-height header strip get their only narrow review.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
@@ -690,7 +690,14 @@ const useIntegrationsPage = () => {
 
 const INTEGRATION_SETTINGS_TITLE_ID = 'integration-settings-title';
 
-const IdexxSettingsModal = ({
+/**
+ * Exported for `IdexxSettingsModal.stories.tsx`. The panel is presentation only -
+ * every value and every handler arrives as a prop - but the page that owns those
+ * props is reachable only through `ProtectedRoute` + `OrgGuard`, and the hook
+ * behind it (`useIntegrationsPage`) fetches devices and orders over axios. So the
+ * only way to draw this surface without a network stub is to render it directly.
+ */
+export const IdexxSettingsModal = ({
   showSettings,
   setShowSettings,
   idexxIntegration,

--- a/apps/frontend/src/app/features/integrations/pages/MerckManuals/index.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/MerckManuals/index.tsx
@@ -624,7 +624,7 @@ const MerckReaderPortal = ({
       <div className="relative flex size-full max-h-[95vh] max-w-7xl flex-col overflow-hidden rounded-2xl border border-hairline bg-[var(--screen)] shadow-2xl">
         <div className="flex items-center justify-between gap-3 border-b border-hairline px-6 py-3.5">
           <div className="flex min-w-0 items-center gap-2.5">
-            <span className="flex size-8 flex-none items-center justify-center rounded-[9px] bg-blue-soft text-blue-text">
+            <span className="flex size-8 flex-none items-center justify-center rounded-[9px] bg-[var(--blue-soft)] text-blue-text">
               <IoBookOutline size={15} aria-hidden="true" />
             </span>
             <div

--- a/apps/frontend/src/app/features/inventory/components/InventoryInfo.stories.tsx
+++ b/apps/frontend/src/app/features/inventory/components/InventoryInfo.stories.tsx
@@ -132,9 +132,7 @@ export const Drawer: Story = {
     // The drawer portals out of the story canvas, so every query goes through
     // document.body rather than canvasElement.
     const body = within(document.body);
-    await expect(
-      await body.findByRole('heading', { name: ITEM.basicInfo.name })
-    ).toBeInTheDocument();
+    expect(await body.findByRole('heading', { name: ITEM.basicInfo.name })).toBeInTheDocument();
     // The tab row and the section body both have to be there - a drawer with a
     // header and an empty body would satisfy a "the dialog opened" assertion.
     await expect(body.getAllByRole('tab')).toHaveLength(6);
@@ -164,15 +162,13 @@ export const DeleteConfirmation: Story = {
   name: 'Nested delete confirmation',
   play: async () => {
     const body = within(document.body);
-    await expect(
-      await body.findByRole('heading', { name: ITEM.basicInfo.name })
-    ).toBeInTheDocument();
+    expect(await body.findByRole('heading', { name: ITEM.basicInfo.name })).toBeInTheDocument();
 
     await userEvent.click(body.getByRole('button', { name: 'Delete item' }));
 
     // Assert the second dialog has its real content, not just that a second
     // dialog exists.
-    await expect(
+    expect(
       await body.findByRole('heading', { name: 'Delete inventory item?' })
     ).toBeInTheDocument();
     await expect(body.getByText(/This will remove/)).toHaveTextContent(ITEM.basicInfo.name);
@@ -198,7 +194,7 @@ export const ConfirmationDiscarded: Story = {
   play: async () => {
     const body = within(document.body);
     await userEvent.click(await body.findByRole('button', { name: 'Delete item' }));
-    await expect(
+    expect(
       await body.findByRole('heading', { name: 'Delete inventory item?' })
     ).toBeInTheDocument();
 
@@ -252,9 +248,7 @@ export const ReadOnly: Story = {
   args: { canEdit: false },
   play: async () => {
     const body = within(document.body);
-    await expect(
-      await body.findByRole('heading', { name: ITEM.basicInfo.name })
-    ).toBeInTheDocument();
+    expect(await body.findByRole('heading', { name: ITEM.basicInfo.name })).toBeInTheDocument();
     // The whole primary action is dropped rather than dimmed: a control that
     // looks inactive but still fires is its own defect.
     await expect(body.queryByRole('button', { name: 'Delete item' })).not.toBeInTheDocument();

--- a/apps/frontend/src/app/features/inventory/components/InventoryInfo.stories.tsx
+++ b/apps/frontend/src/app/features/inventory/components/InventoryInfo.stories.tsx
@@ -232,7 +232,7 @@ export const HiddenItem: Story = {
   },
   play: async () => {
     const body = within(document.body);
-    await expect(await body.findByRole('button', { name: 'Restore item' })).toBeInTheDocument();
+    expect(await body.findByRole('button', { name: 'Restore item' })).toBeInTheDocument();
     await expect(body.queryByRole('button', { name: 'Delete item' })).not.toBeInTheDocument();
   },
   parameters: {
@@ -278,7 +278,7 @@ export const PricingSection: Story = {
   args: { initialSection: 'pricing' },
   play: async () => {
     const body = within(document.body);
-    await expect(await body.findByText('Gross profit per unit :')).toBeInTheDocument();
+    expect(await body.findByText('Gross profit per unit :')).toBeInTheDocument();
     await expect(body.getByText('Margin :')).toBeInTheDocument();
     await expect(body.getByText('Total stock value')).toBeInTheDocument();
     await expect(body.getByText('on-hand stock x unit cost')).toBeInTheDocument();

--- a/apps/frontend/src/app/features/inventory/components/TurnoverAnalytics/index.stories.tsx
+++ b/apps/frontend/src/app/features/inventory/components/TurnoverAnalytics/index.stories.tsx
@@ -1,0 +1,403 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+
+import type {
+  InventoryItem,
+  InventoryTurnoverItem,
+} from '@/app/features/inventory/pages/Inventory/types';
+import { useOrgStore } from '@/app/stores/orgStore';
+// `AbcTable` puts `.yc-table-head` on its header band but imports nothing: the
+// recipe (the --screen-2 band, 10.5px uppercase Satoshi, the hairline shadow)
+// lives in this sheet, and the Inventory page does not pull it in either - it
+// arrives at runtime only because some other component in the same route bundle
+// happens to import it. In Storybook the module graph is just this component, so
+// without the import here the band renders as plain sentence-case text on the
+// card background and the story quietly draws something the product never shows.
+// `SelectsAnAbcClass` asserts `textTransform` for that reason: the class supplies
+// it and no Tailwind utility on that element does, so dropping this line fails a
+// story instead of changing a screenshot nobody re-reads.
+import '@/app/ui/tables/GenericTable/Generictable.css';
+import TurnoverAnalytics from './index';
+
+const item = (id: string, name: string, overrides: Partial<InventoryItem> = {}): InventoryItem => ({
+  id,
+  currency: 'EUR',
+  sku: `SKU-${id}`,
+  status: 'ACTIVE',
+  basicInfo: {
+    name,
+    category: 'Medicine',
+    subCategory: 'NSAID',
+    department: 'Pharmacy',
+    description: '',
+    status: 'Active',
+    skuCode: `SKU-${id}`,
+  },
+  classification: { form: 'Tablet', strength: '50 mg' },
+  pricing: { purchaseCost: '4.20', selling: '7.00' },
+  vendor: {
+    supplierName: 'Nordwest Vet Supply',
+    brand: 'Zoetis',
+    vendor: 'Distributor',
+    license: 'DE-4471',
+    paymentTerms: 'Net 30',
+  },
+  stock: {
+    current: '48',
+    allocated: '6',
+    available: '42',
+    reorderLevel: '12',
+    reorderQuantity: '60',
+    stockLocation: 'Pharmacy',
+    abcClass: 'Class A',
+  },
+  batch: { batch: 'B-2026-04', manufactureDate: '2026-01-08', expiryDate: '2027-02-28' },
+  ...overrides,
+});
+
+const CARPROFEN = item('1', 'Carprofen 50 mg');
+
+/**
+ * The low-stock item, and therefore the one the panel opens on:
+ * `selectDefaultProduct` prefers a low-stock product over a Class A one. 4 on hand
+ * against a reorder point of 12, so `computeSuggestedOrder` asks for 12 x 2 - 4 = 20.
+ */
+const NOBIVAC = item('2', 'Nobivac Rabies 1 ml', {
+  basicInfo: {
+    name: 'Nobivac Rabies 1 ml',
+    category: 'Vaccine',
+    subCategory: 'Rabies',
+    department: 'Pharmacy',
+    description: '',
+    status: 'Active',
+    skuCode: 'SKU-2',
+  },
+  classification: { form: 'Vial', strength: '1 ml' },
+  pricing: { purchaseCost: '12.00', selling: '19.50' },
+  stock: {
+    current: '4',
+    allocated: '0',
+    available: '4',
+    reorderLevel: '12',
+    reorderQuantity: '40',
+    stockLocation: 'Cold chain',
+    abcClass: 'Class B',
+  },
+});
+
+const CHLORHEXIDINE = item('3', 'Chlorhexidine scrub 500 ml', {
+  basicInfo: {
+    name: 'Chlorhexidine scrub 500 ml',
+    category: 'Consumable',
+    subCategory: 'Antiseptic',
+    department: 'Surgery',
+    description: '',
+    status: 'Active',
+    skuCode: 'SKU-3',
+  },
+  classification: { form: 'Bottle', strength: '4%' },
+  pricing: { purchaseCost: '3.10', selling: '6.40' },
+  stock: {
+    current: '9',
+    allocated: '0',
+    available: '9',
+    reorderLevel: '4',
+    reorderQuantity: '20',
+    stockLocation: 'Surgery',
+    abcClass: 'Class C',
+  },
+});
+
+const INVENTORY: InventoryItem[] = [CARPROFEN, NOBIVAC, CHLORHEXIDINE];
+
+/** No reorder level at all, which is the branch where the suggestion disappears. */
+const UNTRACKED: InventoryItem[] = [
+  item('4', 'Meloxicam oral suspension', {
+    classification: { form: 'Bottle', strength: '1.5 mg/ml' },
+    stock: {
+      current: '26',
+      allocated: '0',
+      available: '26',
+      reorderLevel: '',
+      reorderQuantity: '',
+      stockLocation: 'Pharmacy',
+      abcClass: 'Class A',
+    },
+  }),
+];
+
+const TURNOVER: InventoryTurnoverItem[] = [
+  {
+    itemId: '1',
+    name: 'Carprofen 50 mg',
+    beginningInventory: 60,
+    endingInventory: 48,
+    turnsPerYear: 5.2,
+    daysOnShelf: 70,
+  },
+  {
+    itemId: '2',
+    name: 'Nobivac Rabies 1 ml',
+    beginningInventory: 30,
+    endingInventory: 4,
+    turnsPerYear: 2.4,
+    daysOnShelf: 38,
+  },
+  {
+    itemId: '3',
+    name: 'Chlorhexidine scrub 500 ml',
+    beginningInventory: 14,
+    endingInventory: 9,
+    turnsPerYear: 1.1,
+    daysOnShelf: 120,
+  },
+];
+
+/**
+ * The only network this view can reach is `useDashboardAnalytics`, and its effect
+ * returns on its first line when there is no `primaryOrgId` - so clearing that one
+ * store field is the whole isolation, with no service stub anywhere. The trade is
+ * visible and deliberate: the month chart has no trend to draw and shows its
+ * "Not enough history yet" state. Everything the product panel renders comes from
+ * the `inventory` / `turnover` props, which are the props under review here.
+ */
+const seedOrg = () => {
+  const snapshot = useOrgStore.getState();
+  useOrgStore.setState({ primaryOrgId: null });
+  return () => {
+    useOrgStore.setState(snapshot);
+  };
+};
+
+const detailPanel = (canvasElement: HTMLElement) =>
+  canvasElement.querySelector('[data-testid="product-panel"]') as HTMLElement;
+
+const phoneCard = (canvasElement: HTMLElement) =>
+  canvasElement.querySelector('[data-testid="product-card-phone"]') as HTMLElement | null;
+
+const tracksOf = (element: HTMLElement) =>
+  getComputedStyle(element).gridTemplateColumns.trim().split(/\s+/);
+
+const meta = {
+  title: 'Inventory/TurnoverAnalytics',
+  component: TurnoverAnalytics,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The turnover view of Inventory. Two of its parts had never been drawn, and they are the ' +
+          'two that never appear together: **`ProductDetailPanel`**, the tall card on the right at ' +
+          'desktop width, and **`ProductPhoneCard`**, the single row that replaces it below 768px. ' +
+          'Both are module-private and are reached through the exported view.\n\n' +
+          'The swap is decided by `useIsPhone`, which is a `matchMedia` subscription seeded `false` ' +
+          'and corrected in an effect - so it is a post-mount change, and a story that renders at the ' +
+          'panel width and calls itself a phone story shows the desktop card. The viewport is pinned ' +
+          'as a global on each story for that reason.\n\n' +
+          'Which product the panel opens on is not a prop either: `selectDefaultProduct` picks the ' +
+          'first low-stock item, then the first Class A item, then whatever is first. Clicking a row ' +
+          'in the ABC table re-points it at that class, again preferring a low-stock member - which ' +
+          'is the only way the panel ever changes product.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    turnover: TURNOVER,
+    inventory: INVENTORY,
+    setActiveView: fn(),
+    onReorder: fn(),
+    onViewHistory: fn(),
+  },
+  globals: { viewport: { value: 'desktop', isRotated: false } },
+  decorators: [
+    (Story) => (
+      <div className="min-h-[720px] bg-[var(--screen)] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+  beforeEach: seedOrg,
+} satisfies Meta<typeof TurnoverAnalytics>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const DetailPanel: Story = {
+  name: 'Product detail panel (low stock)',
+  play: async ({ args, canvasElement }) => {
+    const panel = detailPanel(canvasElement);
+    await expect(panel).not.toBeNull();
+    const inPanel = within(panel);
+
+    // Identity: the name, and a subtitle assembled from ABC class, sub-category and
+    // the pluralised dose form. `Vial` becomes `vials` in the subtitle AND in the
+    // suggestion sentence below, from the same helper.
+    await expect(inPanel.getByText('Nobivac Rabies 1 ml')).toBeInTheDocument();
+    await expect(inPanel.getByText('Class B · Rabies · vials')).toBeInTheDocument();
+    await expect(inPanel.getByText('LOW STOCK')).toBeInTheDocument();
+
+    /* Four metrics in a two-track grid. Four children and two tracks is the shape;
+       a template that failed to resolve would stack them into one column and still
+       look like a considered layout. */
+    const kpis = panel.querySelector('.grid') as HTMLElement;
+    await expect(tracksOf(kpis)).toHaveLength(2);
+    await expect(kpis.children).toHaveLength(4);
+    await expect(within(kpis).getByText('Turnover')).toBeInTheDocument();
+    await expect(within(kpis).getByText('2.4×')).toBeInTheDocument();
+    await expect(within(kpis).getByText('38')).toBeInTheDocument();
+
+    /* On-hand is the only metric that changes colour, and only when it is under the
+       reorder point - so it is asserted against its neighbour rather than against a
+       hex value, which would just re-state the token. */
+    const onHand = within(kpis).getByText('4');
+    const reorderPoint = within(kpis).getByText('12');
+    await waitFor(() => {
+      expect(getComputedStyle(onHand).color).not.toBe(getComputedStyle(reorderPoint).color);
+    });
+
+    // The suggestion is one sentence built from three values, and it has to agree
+    // with the button label beside it: reorder-up-to-twice-the-point, 12 x 2 - 4.
+    const quantity = inPanel.getByText('20 vials');
+    await expect(quantity.parentElement?.textContent).toBe(
+      'Suggested order: 20 vials brings stock to twice the reorder point of 12.'
+    );
+
+    await expect(inPanel.getByRole('button', { name: 'History' })).toBeInTheDocument();
+    await userEvent.click(inPanel.getByRole('button', { name: 'Reorder 20' }));
+    // The callback carries the selected InventoryItem, not the derived panel model -
+    // the restock drawer needs the item, and that mapping is easy to get wrong.
+    await expect(args.onReorder).toHaveBeenCalledWith(NOBIVAC);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The panel as it opens: the low-stock product, its four metrics, the empty consumption ' +
+          'strip (there is no per-product history endpoint yet, and the dashed box says so rather ' +
+          'than drawing a flat line), the suggested order, and the two footer actions pinned to the ' +
+          'bottom by `mt-auto` so the card matches the height of the chart column beside it.',
+      },
+    },
+  },
+};
+
+export const SelectsAnAbcClass: Story = {
+  name: 'Panel follows an ABC row',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const opening = within(detailPanel(canvasElement));
+    await expect(opening.getByText('Nobivac Rabies 1 ml')).toBeInTheDocument();
+
+    /* The row is the selector, so its own layout is worth pinning before clicking
+       it: five tracks and five cells above the `sm` breakpoint - class tile, share
+       bar, product count, turnover, policy. Below it the row drops to three tracks
+       and the last two cells go `display: none`, which is why "five children" alone
+       would not have caught a collapsed template. */
+    const classARow = canvas.getByText('Weekly review').closest('button') as HTMLElement;
+    await expect(tracksOf(classARow)).toHaveLength(5);
+    await expect(classARow.children).toHaveLength(5);
+    const header = canvasElement.querySelector('.yc-table-head') as HTMLElement;
+    await expect(getComputedStyle(header).textTransform).toBe('uppercase');
+    await expect(tracksOf(header)).toEqual(tracksOf(classARow));
+    await expect(within(classARow).getByText('1 products')).toBeInTheDocument();
+
+    // Class A holds one product and it is fully stocked, so the "prefer a low-stock
+    // member" rule falls through to the first member.
+    await userEvent.click(classARow);
+
+    const panel = within(detailPanel(canvasElement));
+    expect(await panel.findByText('Carprofen 50 mg')).toBeInTheDocument();
+    await expect(panel.getByText('Class A · NSAID · tablets')).toBeInTheDocument();
+    await expect(panel.queryByText('LOW STOCK')).not.toBeInTheDocument();
+
+    /* Worth looking at rather than passing over: a product that is comfortably in
+       stock still draws the suggestion box, because `computeSuggestedOrder` returns
+       0 (a number) rather than null once a reorder point exists. The card therefore
+       offers "Reorder 0". */
+    await expect(panel.getByText('0 tablets')).toBeInTheDocument();
+    await expect(panel.getByRole('button', { name: 'Reorder 0' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The ABC rows are the only selector this panel has - there is no product picker on the ' +
+          'screen - so the row is worth reading as a control rather than as a table line. Each row ' +
+          'picks the low-stock member of its class if there is one, so a click usually lands on the ' +
+          'product that needs attention rather than on the alphabetically first; Class A here holds ' +
+          'one fully stocked product, which is what makes the fallback visible. The header band and ' +
+          'the row are separate grids that have to agree column-for-column, and the story compares ' +
+          'their resolved templates instead of trusting that two copies of the same track list stayed ' +
+          'in step.',
+      },
+    },
+  },
+};
+
+export const NoReorderPoint: Story = {
+  name: 'Panel without a reorder point',
+  args: { inventory: UNTRACKED, turnover: [] },
+  play: async ({ canvasElement }) => {
+    const panel = within(detailPanel(canvasElement));
+
+    await expect(panel.getByText('Meloxicam oral suspension')).toBeInTheDocument();
+    // No reorder level means no low-stock test, no suggestion, and a bare label -
+    // the three consequences all come off the same missing field.
+    await expect(panel.queryByText('LOW STOCK')).not.toBeInTheDocument();
+    await expect(panel.queryByText(/^Suggested order/)).not.toBeInTheDocument();
+    await expect(panel.getByRole('button', { name: 'Reorder' })).toBeInTheDocument();
+    // Turnover and days-on-shelf have no matching row here, so both print the
+    // em-dash placeholder rather than a zero that would read as a measurement.
+    await expect(panel.getAllByText('—')).toHaveLength(2);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A product nobody has given a reorder point. This is the common case for a practice that ' +
+          'has just imported its stock list, so it is worth seeing that the card degrades to four ' +
+          'metrics and one action rather than inventing a target.',
+      },
+    },
+  },
+};
+
+export const PhoneCard: Story = {
+  name: 'Phone - product card replaces the panel',
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ args, canvasElement }) => {
+    /* `useIsPhone` is false during the first render and corrected in an effect, so
+       the phone card arrives one commit late - polled rather than read once. */
+    await waitFor(() => {
+      expect(phoneCard(canvasElement)).not.toBeNull();
+    });
+    const card = phoneCard(canvasElement) as HTMLElement;
+    await expect(detailPanel(canvasElement)).toBeNull();
+
+    /* The same product model, rewritten as one line: name and turnover on top, the
+       stock sentence under it, and a compact reorder pill. Three children in a
+       single flex row - the icon tile, the text block, the action. */
+    await expect(getComputedStyle(card).display).toBe('flex');
+    await expect(card.children).toHaveLength(3);
+    const inCard = within(card);
+    await expect(inCard.getByText('Nobivac Rabies 1 ml · 2.4×')).toBeInTheDocument();
+    // "below" only appears under the reorder point, and it is the phone card's only
+    // low-stock signal apart from the tinted icon tile - there is no pill here.
+    await expect(inCard.getByText('4 on hand · below reorder point 12')).toBeInTheDocument();
+
+    await userEvent.click(inCard.getByRole('button', { name: 'Reorder 20' }));
+    await expect(args.onReorder).toHaveBeenCalledWith(NOBIVAC);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Below 768px the 380px panel would be taller than the screen, so it is replaced entirely ' +
+          'rather than reflowed: one row, no consumption strip, no suggestion sentence, no History ' +
+          'action. Everything dropped is reachable from the product itself - this row is a pointer, ' +
+          'not a summary.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/inventory/pages/Inventory/InventoryFilterBar.stories.tsx
+++ b/apps/frontend/src/app/features/inventory/pages/Inventory/InventoryFilterBar.stories.tsx
@@ -139,8 +139,8 @@ export const SortPanelOpen: Story = {
     /* The measured position is the part no snapshot could hold. A dropped style
        object leaves the panel static at the end of <body>, which still renders
        three healthy-looking rows. */
-    await waitFor(async () => {
-      await expect(getComputedStyle(panel).position).toBe('fixed');
+    await waitFor(() => {
+      expect(getComputedStyle(panel).position).toBe('fixed');
     });
     const triggerRect = sortTrigger(canvasElement, 'Name').getBoundingClientRect();
     const panelRect = panel.getBoundingClientRect();
@@ -166,8 +166,8 @@ export const SortSelection: Story = {
     await userEvent.click(within(panel).getByRole('button', { name: 'Expiry date' }));
 
     // The trigger relabels from the chosen option and the panel goes away.
-    await waitFor(async () => {
-      await expect(
+    await waitFor(() => {
+      expect(
         within(canvasElement).getByRole('button', { name: 'Sort: Expiry date' })
       ).toBeInTheDocument();
     });
@@ -193,8 +193,8 @@ export const SortPanelClosesOnOutsideClick: Story = {
     // The listener is on `mousedown` and ignores the trigger and the panel itself.
     await userEvent.click(canvasElement);
 
-    await waitFor(async () => {
-      await expect(within(document.body).queryByRole('button', { name: 'Expiry date' })).toBeNull();
+    await waitFor(() => {
+      expect(within(document.body).queryByRole('button', { name: 'Expiry date' })).toBeNull();
     });
   },
   parameters: {
@@ -245,12 +245,15 @@ export const HiddenVisibility: Story = {
 
     await userEvent.click(hidden);
 
-    await waitFor(async () => {
-      await expect(getComputedStyle(hidden).fontWeight).toBe('700');
+    /* The chip is `transition-colors`, so both the weight and the settled fill are
+       polled - a single read lands mid-transition and compares two interpolated
+       colours rather than the two end states. */
+    await waitFor(() => {
+      expect(getComputedStyle(hidden).fontWeight).toBe('700');
+      expect(getComputedStyle(hidden).backgroundColor).not.toBe(
+        getComputedStyle(active).backgroundColor
+      );
     });
-    await expect(getComputedStyle(hidden).backgroundColor).not.toBe(
-      getComputedStyle(active).backgroundColor
-    );
   },
   parameters: {
     docs: {

--- a/apps/frontend/src/app/features/inventory/pages/Inventory/InventoryFilterBar.stories.tsx
+++ b/apps/frontend/src/app/features/inventory/pages/Inventory/InventoryFilterBar.stories.tsx
@@ -1,0 +1,265 @@
+import { useState, type Dispatch, type SetStateAction } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+
+import { InventoryFilterBar } from './index';
+import { defaultFilters } from './utils';
+import type { InventoryFiltersState } from './types';
+
+/** Mirrors the module-local unions in `index.tsx`, which are not exported. */
+type SortMode = 'name' | 'expiry' | 'stock';
+type FilterChip = { id: string; label: string; onRemove: () => void };
+
+const CHIPS: FilterChip[] = [
+  { id: 'category-vaccines', label: 'Vaccines', onRemove: fn() },
+  { id: 'location-fridge-1', label: 'Fridge 1', onRemove: fn() },
+  { id: 'abc-a', label: 'Class A', onRemove: fn() },
+];
+
+/**
+ * `filters` and `sortMode` are owned by the Inventory page, so the bar does not move
+ * on its own. The harness holds both, which is what lets a `play` pick a sort option
+ * and see the trigger label follow.
+ */
+const Harness = ({
+  initialFilters,
+  initialSortMode,
+  selectedFilterChips,
+  setFilterOpen,
+}: {
+  initialFilters: InventoryFiltersState;
+  initialSortMode: SortMode;
+  selectedFilterChips: FilterChip[];
+  setFilterOpen: Dispatch<SetStateAction<boolean>>;
+}) => {
+  const [filters, setFilters] = useState<InventoryFiltersState>(initialFilters);
+  const [sortMode, setSortMode] = useState<SortMode>(initialSortMode);
+
+  return (
+    <div className="min-h-[320px] bg-[var(--screen)] p-6">
+      <InventoryFilterBar
+        filters={filters}
+        selectedFilterChips={selectedFilterChips}
+        sortMode={sortMode}
+        setFilterOpen={setFilterOpen}
+        setFilters={setFilters}
+        setSortMode={setSortMode}
+      />
+    </div>
+  );
+};
+
+const sortTrigger = (canvasElement: HTMLElement, mode: string) =>
+  within(canvasElement).getByRole('button', { name: `Sort: ${mode}` });
+
+/** The panel has no role or label, so it is reached through one of its options. */
+const openSortPanel = async (canvasElement: HTMLElement, mode = 'Name') => {
+  await userEvent.click(sortTrigger(canvasElement, mode));
+  const option = await within(document.body).findByRole('button', { name: 'Expiry date' });
+  return option.parentElement as HTMLElement;
+};
+
+const meta = {
+  title: 'Inventory/InventoryFilterBar',
+  component: Harness,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The Active/Hidden pills, the Filter trigger, the Sort trigger and the inventory search, ' +
+          'in one row that reflows to a column below `xl`.\n\n' +
+          'The Sort panel is the reason this file exists. It is `createPortal`ed to ' +
+          '`document.body` and positioned from a `getBoundingClientRect()` read on the trigger in a ' +
+          '`useLayoutEffect` - `top: rect.bottom + 6`, `right: window.innerWidth - rect.right`, ' +
+          '`minWidth: rect.width`, `zIndex: 9999`. None of that is expressible in CSS from the ' +
+          'trigger, and none of it exists until `sortOpen` flips, so a broken measurement renders a ' +
+          'panel pinned to the top-left of the viewport and every static snapshot still passes. The ' +
+          'stories therefore assert the panel is `position: fixed`, sits below the trigger and is at ' +
+          'least as wide as it - not merely that a panel appeared.\n\n' +
+          'The panel is also its own dismissal surface: a `mousedown` anywhere outside both the ' +
+          'trigger and the panel closes it, and so does any capture-phase scroll. A page whose ' +
+          'content scrolls under a fixed panel would otherwise leave it stranded beside nothing, ' +
+          'since the position is measured once rather than tracked.\n\n' +
+          'The Filter trigger has a second gated detail: with no filters applied it ends in a 14px ' +
+          'chevron, and with filters applied that chevron is *replaced* by a count badge. Both are ' +
+          'the same button, so the swap is only visible with chips present.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    initialFilters: defaultFilters,
+    initialSortMode: 'name',
+    selectedFilterChips: [],
+    setFilterOpen: fn(),
+  },
+} satisfies Meta<typeof Harness>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Closed',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('button', { name: 'Sort: Name' })).toBeInTheDocument();
+    // With no chips the Filter trigger carries two glyphs: the sliders and a chevron.
+    const filter = canvas.getByRole('button', { name: /^Filter$/ });
+    await expect(filter.querySelectorAll('svg')).toHaveLength(2);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'The resting bar, with Active selected and sorting by name.',
+      },
+    },
+  },
+};
+
+export const SortPanelOpen: Story = {
+  name: 'Sort panel open',
+  play: async ({ canvasElement }) => {
+    const panel = await openSortPanel(canvasElement);
+
+    // Portalled: the panel is not a descendant of the story canvas at all.
+    await expect(canvasElement.contains(panel)).toBe(false);
+
+    /* Assert the panel has its three options rather than that a flag flipped -
+       an empty portal is indistinguishable from a healthy one at the trigger. */
+    const options = within(panel).getAllByRole('button');
+    await expect(options).toHaveLength(3);
+    await expect(options[0]).toHaveTextContent('Name');
+    await expect(options[1]).toHaveTextContent('Expiry date');
+    await expect(options[2]).toHaveTextContent('Stock level');
+
+    // The current mode is marked by a check glyph, the only selected affordance here.
+    await expect(within(panel).getByText('✓')).toBeInTheDocument();
+
+    /* The measured position is the part no snapshot could hold. A dropped style
+       object leaves the panel static at the end of <body>, which still renders
+       three healthy-looking rows. */
+    await waitFor(async () => {
+      await expect(getComputedStyle(panel).position).toBe('fixed');
+    });
+    const triggerRect = sortTrigger(canvasElement, 'Name').getBoundingClientRect();
+    const panelRect = panel.getBoundingClientRect();
+    await expect(panelRect.top).toBeGreaterThan(triggerRect.bottom);
+    await expect(panelRect.width).toBeGreaterThanOrEqual(triggerRect.width - 1);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The panel right-aligned under its trigger. `minWidth` comes from the trigger rect while ' +
+          'the content sets the real width, so the panel can grow leftwards but never narrower than ' +
+          'the button that opened it.',
+      },
+    },
+  },
+};
+
+export const SortSelection: Story = {
+  name: 'Choosing a sort mode',
+  play: async ({ canvasElement }) => {
+    const panel = await openSortPanel(canvasElement);
+    await userEvent.click(within(panel).getByRole('button', { name: 'Expiry date' }));
+
+    // The trigger relabels from the chosen option and the panel goes away.
+    await waitFor(async () => {
+      await expect(
+        within(canvasElement).getByRole('button', { name: 'Sort: Expiry date' })
+      ).toBeInTheDocument();
+    });
+    await expect(within(document.body).queryByRole('button', { name: 'Stock level' })).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Selection closes the panel in the same tick it sets the mode, so the trigger label is the ' +
+          'only surviving evidence of the choice - there is no chip and no toast.',
+      },
+    },
+  },
+};
+
+export const SortPanelClosesOnOutsideClick: Story = {
+  name: 'Outside click dismisses the panel',
+  play: async ({ canvasElement }) => {
+    const panel = await openSortPanel(canvasElement);
+    await expect(within(panel).getAllByRole('button')).toHaveLength(3);
+
+    // The listener is on `mousedown` and ignores the trigger and the panel itself.
+    await userEvent.click(canvasElement);
+
+    await waitFor(async () => {
+      await expect(within(document.body).queryByRole('button', { name: 'Expiry date' })).toBeNull();
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Dismissal is the half of a portalled panel that is easiest to break, because the panel is ' +
+          'a sibling of the trigger in the DOM rather than a child: a naive "outside" test treats ' +
+          'the panel itself as outside and closes on its own options.',
+      },
+    },
+  },
+};
+
+export const WithSelectedFilters: Story = {
+  name: 'Filter trigger with a count badge',
+  args: { selectedFilterChips: CHIPS },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const filter = canvas.getByRole('button', { name: /^Filter 3$/ });
+    // The chevron is replaced by the badge rather than sitting beside it.
+    await expect(filter.querySelectorAll('svg')).toHaveLength(1);
+    await expect(filter).toHaveTextContent('3');
+
+    await userEvent.click(filter);
+    await expect(args.setFilterOpen).toHaveBeenCalledWith(true);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Three filters applied. The badge takes the chevron's place, so the trigger keeps its " +
+          'width and the row does not reflow when a filter is added - which is the only reason to ' +
+          'swap rather than append.',
+      },
+    },
+  },
+};
+
+export const HiddenVisibility: Story = {
+  name: 'Hidden visibility selected',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const active = canvas.getByRole('button', { name: 'Active' });
+    const hidden = canvas.getByRole('button', { name: 'Hidden' });
+    // Selected is 700 against 600, plus a filled chip - weight alone must not carry it.
+    await expect(getComputedStyle(active).fontWeight).not.toBe(getComputedStyle(hidden).fontWeight);
+
+    await userEvent.click(hidden);
+
+    await waitFor(async () => {
+      await expect(getComputedStyle(hidden).fontWeight).toBe('700');
+    });
+    await expect(getComputedStyle(hidden).backgroundColor).not.toBe(
+      getComputedStyle(active).backgroundColor
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The two visibility pills are the only always-visible filter in the bar. The selected one ' +
+          'takes `--chip-selected-bg` / `--chip-selected-border` / `--chip-selected-ink` together ' +
+          'with the weight change, so the state survives at a glance and in greyscale.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/inventory/pages/Inventory/InventoryFilterModal.stories.tsx
+++ b/apps/frontend/src/app/features/inventory/pages/Inventory/InventoryFilterModal.stories.tsx
@@ -354,7 +354,7 @@ export const SubcategoriesExpanded: Story = {
     await userEvent.click(panel.getByRole('button', { name: 'Expand Medicine' }));
     // Assert the nested list actually has its options, which is the whole point:
     // a chevron that flips while the panel below stays empty is the regression.
-    await expect(await panel.findByRole('checkbox', { name: 'Antibiotic' })).toBeInTheDocument();
+    expect(await panel.findByRole('checkbox', { name: 'Antibiotic' })).toBeInTheDocument();
     await expect(panel.getByRole('checkbox', { name: 'Analgesic' })).toBeInTheDocument();
     await expect(panel.getByRole('checkbox', { name: 'Antiparasitic' })).toBeInTheDocument();
     await expect(panel.getAllByRole('checkbox')).toHaveLength(6);

--- a/apps/frontend/src/app/features/marketing/site/LegalDoc.stories.tsx
+++ b/apps/frontend/src/app/features/marketing/site/LegalDoc.stories.tsx
@@ -60,21 +60,12 @@ const BODY = (
 );
 
 /**
- * Both widths are pinned per story rather than inherited: the fold is decided by a
- * `max-width: 900px` media query, so a story that asserts what is displayed has to own
- * the viewport it asserts at.
+ * Each story pins its own width, because the fold is decided by a `max-width: 900px`
+ * media query - a story that asserts what is displayed has to own the viewport it
+ * asserts at. Pinning is `globals.viewport.value`, naming a preset from
+ * `.storybook/preview.ts`; the `parameters.viewport.defaultViewport` spelling was
+ * removed in Storybook 10 and silently renders at the full panel width instead.
  */
-const MOBILE_VIEWPORT = {
-  mobile: { name: 'Mobile (375)', styles: { width: '375px', height: '812px' }, type: 'mobile' },
-};
-const DESKTOP_VIEWPORT = {
-  desktop: {
-    name: 'Desktop (1440)',
-    styles: { width: '1440px', height: '900px' },
-    type: 'desktop',
-  },
-};
-
 const meta = {
   title: 'Marketing/LegalDoc',
   component: LegalDoc,
@@ -134,11 +125,6 @@ export const Desktop: Story = {
     await expect(getComputedStyle(nav).display).toBe('flex');
   },
   parameters: {
-    viewport: {
-      options: DESKTOP_VIEWPORT,
-      viewports: DESKTOP_VIEWPORT,
-      defaultViewport: 'desktop',
-    },
     chromatic: { viewports: [1440] },
     docs: {
       description: {
@@ -155,7 +141,6 @@ export const MobileCollapsed: Story = {
   name: 'Phone (contents collapsed)',
   globals: { viewport: { value: 'mobile', isRotated: false } },
   parameters: {
-    viewport: { options: MOBILE_VIEWPORT, viewports: MOBILE_VIEWPORT, defaultViewport: 'mobile' },
     chromatic: { viewports: [375] },
     docs: {
       description: {
@@ -170,7 +155,14 @@ export const MobileCollapsed: Story = {
     const canvas = within(canvasElement);
     const toggle = canvas.getByRole('button', { name: 'On this page' });
     await expect(toggle).toHaveAttribute('aria-expanded', 'false');
-    await expect(canvas.getByRole('navigation')).toHaveAttribute('data-open', 'false');
+    /* Queried by id rather than by role on purpose: at this width the list really is
+       `display: none`, so a role query cannot see it - it is excluded from the
+       accessibility tree. That exclusion IS the assertion. The entries are present in
+       the markup the whole time; only the CSS hides them. */
+    const nav = canvasElement.querySelector('#yc-toc-list') as HTMLElement;
+    await expect(nav).toHaveAttribute('data-open', 'false');
+    await expect(getComputedStyle(nav).display).toBe('none');
+    await expect(nav.querySelectorAll('a')).toHaveLength(TOC.length);
   },
 };
 
@@ -178,7 +170,6 @@ export const MobileOpen: Story = {
   name: 'Phone (contents open)',
   globals: { viewport: { value: 'mobile', isRotated: false } },
   parameters: {
-    viewport: { options: MOBILE_VIEWPORT, viewports: MOBILE_VIEWPORT, defaultViewport: 'mobile' },
     chromatic: { viewports: [375] },
     docs: {
       description: {
@@ -223,7 +214,6 @@ export const LongContents: Story = {
   },
   globals: { viewport: { value: 'mobile', isRotated: false } },
   parameters: {
-    viewport: { options: MOBILE_VIEWPORT, viewports: MOBILE_VIEWPORT, defaultViewport: 'mobile' },
     chromatic: { viewports: [375] },
     docs: {
       description: {

--- a/apps/frontend/src/app/features/marketing/site/LegalDoc.stories.tsx
+++ b/apps/frontend/src/app/features/marketing/site/LegalDoc.stories.tsx
@@ -1,0 +1,246 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, within } from 'storybook/test';
+
+import { DocSection, LegalDoc, type TocEntry } from './LegalDoc';
+// The fold is pure CSS: `.yc-toc-toggle` is `display: none` until the 900px media
+// query, and `.yc-toc-list` flips to `display: none` there unless `data-open` is set.
+// Only `(routes)/(public)/layout.tsx` loads this sheet, so without importing it here the
+// component renders with the rail permanently open and the toggle permanently hidden.
+import './marketing.css';
+
+const TOC: TocEntry[] = [
+  { id: 'scope', label: 'Scope' },
+  { id: 'data-we-hold', label: 'Data we hold' },
+  { id: 'processors', label: 'Sub-processors' },
+  { id: 'retention', label: 'Retention' },
+  { id: 'your-rights', label: 'Your rights' },
+  { id: 'contact', label: 'Contact' },
+];
+
+const BODY = (
+  <>
+    <DocSection id="scope" title="Scope">
+      <p>
+        This notice covers the Yosemite Crew practice management system, the pet parent app and the
+        public website. It does not cover a practice&apos;s own systems, which each practice
+        controls as an independent data controller.
+      </p>
+    </DocSection>
+    <DocSection id="data-we-hold" title="Data we hold">
+      <p>
+        Clinical records, appointment history, invoices and the identifiers needed to link them to a
+        companion and its parent. Staff accounts additionally carry a name, a work email and a role
+        within one organisation.
+      </p>
+    </DocSection>
+    <DocSection id="processors" title="Sub-processors">
+      <p>
+        Hosting, transactional email, payments and error reporting are handled by named
+        sub-processors. Each is bound by a data processing agreement and none is permitted to use
+        practice data for its own purposes.
+      </p>
+    </DocSection>
+    <DocSection id="retention" title="Retention">
+      <p>
+        Clinical records are retained for the period the practice&apos;s jurisdiction requires,
+        which is longer than the life of the account. Everything else is deleted within 90 days of
+        the account closing.
+      </p>
+    </DocSection>
+    <DocSection id="your-rights" title="Your rights">
+      <p>
+        Access, rectification, erasure, restriction, portability and objection. Requests are
+        answered within one month, and are free unless they are manifestly unfounded or excessive.
+      </p>
+    </DocSection>
+    <DocSection id="contact" title="Contact">
+      <p>Write to the data protection contact named in your practice agreement.</p>
+    </DocSection>
+  </>
+);
+
+/**
+ * Both widths are pinned per story rather than inherited: the fold is decided by a
+ * `max-width: 900px` media query, so a story that asserts what is displayed has to own
+ * the viewport it asserts at.
+ */
+const MOBILE_VIEWPORT = {
+  mobile: { name: 'Mobile (375)', styles: { width: '375px', height: '812px' }, type: 'mobile' },
+};
+const DESKTOP_VIEWPORT = {
+  desktop: {
+    name: 'Desktop (1440)',
+    styles: { width: '1440px', height: '900px' },
+    type: 'desktop',
+  },
+};
+
+const meta = {
+  title: 'Marketing/LegalDoc',
+  component: LegalDoc,
+  parameters: {
+    layout: 'fullscreen',
+    // Marketing pages keep the lighter faint inks; see the preview decorator.
+    surface: 'marketing',
+    docs: {
+      description: {
+        component:
+          'The shared shell behind the privacy notice, the terms and the trust centre: a warm hero ' +
+          'band, a sticky contents rail and the `.yc-doc` prose column, laid out as a ' +
+          '`220px 1fr` grid.\n\n' +
+          'The surface that had never been drawn is the phone form of that contents rail. Both the ' +
+          'rail heading and a toggle button are always in the markup, and `marketing.css` decides ' +
+          'which one exists at a given width: above 900px `.yc-toc-toggle` is `display: none` and ' +
+          'the list is a plain flex column, so `tocOpen` changes nothing at all. At or below 900px ' +
+          'the grid collapses to one column, `[data-toc]` stops being sticky and becomes a bordered ' +
+          '`--inset` card, the heading is hidden, the 48px toggle appears - and `.yc-toc-list` ' +
+          'becomes `display: none` unless `data-open="true"` is on it.\n\n' +
+          'So the fold is a React state driving a CSS attribute selector across a media query, and ' +
+          'it is invisible at every width Storybook renders by default. Nothing type-checks that ' +
+          "wiring: drop the `data-open` attribute, or the `[data-open='true']` rule, and the " +
+          'desktop rail is unchanged while the phone contents becomes permanently unreachable in a ' +
+          'document tens of thousands of words long.\n\n' +
+          'The stories pin the phone viewport, press the toggle, and assert the list is *displayed ' +
+          'and populated* - not merely that `aria-expanded` flipped, which an empty or still-hidden ' +
+          'list would satisfy just as well.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    eyebrow: 'Legal',
+    title: 'Privacy notice',
+    subtitle:
+      'What Yosemite Crew collects, why it is held, how long it stays and who else can see it.',
+    meta: 'Yosemite Crew Ltd - last updated 12 March 2026',
+    toc: TOC,
+    children: BODY,
+  },
+} satisfies Meta<typeof LegalDoc>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Desktop: Story = {
+  name: 'Desktop (rail always open)',
+  globals: { viewport: { value: 'desktop', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const nav = canvas.getByRole('navigation');
+    await expect(within(nav).getAllByRole('link')).toHaveLength(TOC.length);
+    // Above the breakpoint the toggle is `display: none`, so the rail is open
+    // regardless of state - `data-open` starts false and the list still shows.
+    await expect(nav).toHaveAttribute('data-open', 'false');
+    await expect(getComputedStyle(nav).display).toBe('flex');
+  },
+  parameters: {
+    viewport: {
+      options: DESKTOP_VIEWPORT,
+      viewports: DESKTOP_VIEWPORT,
+      defaultViewport: 'desktop',
+    },
+    chromatic: { viewports: [1440] },
+    docs: {
+      description: {
+        story:
+          'The two-column form: a 220px rail stuck 100px from the top beside the prose. The rail ' +
+          'heading is the small uppercase `--ink-faint2` line, and the toggle that replaces it on a ' +
+          'phone is present in the DOM but not displayed.',
+      },
+    },
+  },
+};
+
+export const MobileCollapsed: Story = {
+  name: 'Phone (contents collapsed)',
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  parameters: {
+    viewport: { options: MOBILE_VIEWPORT, viewports: MOBILE_VIEWPORT, defaultViewport: 'mobile' },
+    chromatic: { viewports: [375] },
+    docs: {
+      description: {
+        story:
+          'At 375 the grid is one column and the contents becomes a bordered `--inset` card at the ' +
+          'top of the document, showing only its 48px toggle row with a `+`. This is the resting ' +
+          'state a reader meets before the prose.',
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const toggle = canvas.getByRole('button', { name: 'On this page' });
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    await expect(canvas.getByRole('navigation')).toHaveAttribute('data-open', 'false');
+  },
+};
+
+export const MobileOpen: Story = {
+  name: 'Phone (contents open)',
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  parameters: {
+    viewport: { options: MOBILE_VIEWPORT, viewports: MOBILE_VIEWPORT, defaultViewport: 'mobile' },
+    chromatic: { viewports: [375] },
+    docs: {
+      description: {
+        story:
+          'The fold opened. Every entry gets a 44px minimum row here rather than the 14px-indented ' +
+          'desktop line, so the list is a genuinely different control at this width - and it is the ' +
+          'only way to navigate a document this long on a phone.',
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const toggle = canvas.getByRole('button', { name: 'On this page' });
+    await userEvent.click(toggle);
+
+    const nav = canvas.getByRole('navigation');
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    // The state alone proves nothing: the list is shown by a CSS attribute selector,
+    // so assert it is actually displayed AND that it holds every entry.
+    await expect(nav).toHaveAttribute('data-open', 'true');
+    await expect(getComputedStyle(nav).display).toBe('flex');
+    const links = within(nav).getAllByRole('link');
+    await expect(links).toHaveLength(TOC.length);
+    await expect(links[0]).toHaveTextContent('Scope');
+    await expect(links[0]).toHaveAttribute('href', '#scope');
+    await expect(links.at(-1)).toHaveTextContent('Contact');
+  },
+};
+
+export const LongContents: Story = {
+  name: 'Phone (long contents)',
+  args: {
+    title: 'Terms and conditions',
+    eyebrow: 'Legal',
+    toc: [
+      ...TOC,
+      { id: 'fees', label: 'Fees, billing and taxes' },
+      { id: 'availability', label: 'Service availability and support' },
+      { id: 'liability', label: 'Limitation of liability' },
+      { id: 'termination', label: 'Termination and data export' },
+    ],
+  },
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  parameters: {
+    viewport: { options: MOBILE_VIEWPORT, viewports: MOBILE_VIEWPORT, defaultViewport: 'mobile' },
+    chromatic: { viewports: [375] },
+    docs: {
+      description: {
+        story:
+          'Ten entries, several of them long enough to wrap. The open fold has no maximum height, ' +
+          'so it pushes the document down by its full length - worth seeing, because it is the ' +
+          'first thing between the hero and the prose on a phone.',
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'On this page' }));
+    const nav = canvas.getByRole('navigation');
+    await expect(within(nav).getAllByRole('link')).toHaveLength(10);
+    await expect(
+      within(nav).getByRole('link', { name: 'Service availability and support' })
+    ).toBeInTheDocument();
+  },
+};

--- a/apps/frontend/src/app/features/marketing/site/SiteNav.stories.tsx
+++ b/apps/frontend/src/app/features/marketing/site/SiteNav.stories.tsx
@@ -1,0 +1,379 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import { SiteNav } from './SiteNav';
+// The collapse is pure CSS and it lives in this sheet, not in the component:
+// `.yc-nav-burger` carries `display: none` as an INLINE style, and only the
+// `max-width: 960px` rule here (with `!important`, which is what lets it beat the
+// inline value) turns it into a flex box. The same media query hides
+// `.yc-nav-links` / `.yc-nav-cta`, and the `min-width: 961px` rule hides
+// `.yc-nav-panel` outright. Only `(routes)/(public)/layout.tsx` loads this file, so
+// without the import the burger can never be clicked, the panel is present at every
+// width, and a story would sit there proving nothing.
+import './marketing.css';
+import { useAuthStore, type AuthStore, type AuthUser } from '@/app/stores/authStore';
+
+/**
+ * Session-cache keys owned by `useGithubStats` (module-private there). Seeding both
+ * makes `isStatsCacheFresh()` true AND gives `discord` a string, which are the two
+ * conditions that keep the hook's effect from firing its `/api/community/*` fetches.
+ * Without this the nav renders a bare star with no count and fires two requests at
+ * the Storybook dev server on every mount.
+ */
+const STATS_CACHE_KEY = 'yc_marketing_stats_v1';
+const STATS_TS_KEY = 'yc_marketing_stats_ts_v1';
+
+const CACHED_STATS = {
+  stars: '2.4k',
+  starsFull: '2,431',
+  selfHosters: '67,134',
+  contributors: '128',
+  discord: '3,182',
+};
+
+const STAFF_USER: AuthUser = {
+  userId: 'user-storybook',
+  email: 'elena@harboursidevet.com',
+  authProfile: 'emailpassword',
+  loginMethod: 'emailpassword',
+  emailVerified: true,
+  getUsername: () => 'user-storybook',
+};
+
+type AuthSeed = Pick<AuthStore, 'status' | 'user' | 'role'>;
+
+const SIGNED_OUT: AuthSeed = { status: 'unauthenticated', user: null, role: null };
+const SIGNED_IN: AuthSeed = { status: 'authenticated', user: STAFF_USER, role: 'owner' };
+
+/**
+ * Seeds the two real sources the nav reads, rather than mocking either module.
+ *
+ * The auth seed matters more than it looks: `useLazyAuthSlice` starts on the `idle`
+ * fallback, and SiteNav answers `idle` by firing `ensureSessionChecked()`. That helper
+ * re-reads `useAuthStore.getState().status` and returns immediately unless it is still
+ * `idle` - so a store seeded to a settled status is what keeps the SuperTokens session
+ * check off the wire, with no stub anywhere.
+ *
+ * `yc_default_open_screen` is cleared because `resolveDefaultOpenScreenRoute` prefers a
+ * saved route over the role default, and a value left in localStorage by any other
+ * story would silently change the "Go to app" target asserted below.
+ */
+const seed = (auth: AuthSeed = SIGNED_OUT) => {
+  return () => {
+    const previousAuth: AuthSeed = {
+      status: useAuthStore.getState().status,
+      user: useAuthStore.getState().user,
+      role: useAuthStore.getState().role,
+    };
+    useAuthStore.setState(auth);
+    globalThis.sessionStorage.setItem(STATS_CACHE_KEY, JSON.stringify(CACHED_STATS));
+    globalThis.sessionStorage.setItem(STATS_TS_KEY, String(Date.now()));
+    globalThis.localStorage.removeItem('yc_default_open_screen');
+
+    return () => {
+      useAuthStore.setState(previousAuth);
+      globalThis.sessionStorage.removeItem(STATS_CACHE_KEY);
+      globalThis.sessionStorage.removeItem(STATS_TS_KEY);
+    };
+  };
+};
+
+const NAV_LABELS = [
+  'Pet Businesses',
+  'Pet Parents',
+  'Developers',
+  'Pricing',
+  'Contact',
+  'About',
+] as const;
+
+const panelOf = (canvasElement: HTMLElement) =>
+  canvasElement.querySelector('.yc-nav-panel') as HTMLElement;
+
+const burgerOf = (canvasElement: HTMLElement) =>
+  within(canvasElement).getByRole('button', { name: /menu$/ });
+
+const meta = {
+  title: 'Marketing/SiteNav',
+  component: SiteNav,
+  parameters: {
+    layout: 'fullscreen',
+    // Marketing surface: without this the preview decorator stamps `data-yc-app` on
+    // the story wrapper, which switches the faint inks to the PIMS-scoped values.
+    // The nav is drawn against the marketing palette, so it opts out.
+    surface: 'marketing',
+    docs: {
+      description: {
+        component:
+          'The public site header, and specifically **the burger panel inside it**, which had never ' +
+          'been drawn. `MobilePanel` is module-private and takes no props a story could set, so it ' +
+          'is driven through the exported `SiteNav` - the same way a visitor reaches it.\n\n' +
+          'Two things make this surface easy to get wrong in Storybook. The collapse is decided by a ' +
+          '**viewport** media query in `marketing.css`, not by a container query and not by the ' +
+          'component, so a story has to import that sheet AND pin the viewport global; a story that ' +
+          'does neither renders the desktop nav under a phone-shaped name. And the panel is **always ' +
+          'mounted** - it stays in the DOM at opacity 0 for the 260ms slide - so "is it closed?" can ' +
+          'only be answered by `inert` / `aria-hidden` / computed opacity, never by absence.\n\n' +
+          'The stories below therefore assert reachability rather than presence: closed, the six nav ' +
+          'links are in the DOM but out of the accessibility tree; open, they are back; and above ' +
+          '960px the panel is `display: none` so it contributes nothing at all.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: { active: 'pricing' },
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  decorators: [
+    /*
+      The header and the panel are both `position: fixed`. A transform on this
+      wrapper makes it their containing block, so they pin to this box instead of
+      the browser viewport - otherwise every story on the docs page would stack its
+      header on top of the last one at the top of the screen. Width is left at 100%
+      on purpose: the media query that decides burger-vs-links reads the VIEWPORT,
+      so narrowing this box would decouple what is drawn from what is asserted.
+    */
+    (Story) => (
+      <div
+        style={{
+          position: 'relative',
+          transform: 'translateZ(0)',
+          minHeight: 520,
+          width: '100%',
+          background: 'var(--page)',
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+  beforeEach: seed(),
+} satisfies Meta<typeof SiteNav>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Collapsed: Story = {
+  name: 'Phone - collapsed',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const burger = burgerOf(canvasElement);
+
+    /* Proves the stylesheet is actually loaded. `BURGER_BUTTON_STYLE` sets
+       `display: none` inline, so this reads `none` - and every interaction story
+       below fails on an unclickable button - the moment the marketing.css import
+       goes missing. */
+    await expect(getComputedStyle(burger).display).toBe('flex');
+    await expect(burger).toHaveAccessibleName('Open menu');
+    await expect(burger).toHaveAttribute('aria-expanded', 'false');
+
+    const panel = panelOf(canvasElement);
+    await expect(panel).toHaveAttribute('aria-hidden', 'true');
+    await expect(panel.hasAttribute('inert')).toBe(true);
+    await expect(getComputedStyle(panel).pointerEvents).toBe('none');
+    await waitFor(() => {
+      expect(getComputedStyle(panel).opacity).toBe('0');
+    });
+
+    /* Mounted but unreachable, which is the whole contract. The eight anchors are
+       in the DOM; none of them is in the accessibility tree, because the panel is
+       `aria-hidden` and the desktop rail is `display: none` at this width. A story
+       that only asserted "the link exists" would pass on a panel that never
+       closed. */
+    await expect(panel.querySelectorAll('a')).toHaveLength(8);
+    for (const label of NAV_LABELS) {
+      await expect(canvas.queryAllByRole('link', { name: label })).toHaveLength(0);
+    }
+    await expect(canvas.queryByRole('link', { name: 'Get started' })).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting phone header: logo, burger, nothing else. The header itself is transparent ' +
+          'until `useScrolled` reports a scroll, so at rest there is no glass and no border - the ' +
+          'tint and blur only appear once the page moves under it.',
+      },
+    },
+  },
+};
+
+export const Open: Story = {
+  name: 'Phone - burger panel open',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const burger = burgerOf(canvasElement);
+    const panel = panelOf(canvasElement);
+
+    await userEvent.click(burger);
+
+    await expect(burger).toHaveAttribute('aria-expanded', 'true');
+    await expect(burger).toHaveAccessibleName('Close menu');
+    await expect(panel.hasAttribute('inert')).toBe(false);
+    /* `aria-hidden="false"`, not an absent attribute: React writes aria-* booleans
+       out literally, so the attribute is always there and only its value moves.
+       Asserting absence here would fail on a correctly opened panel. */
+    await expect(panel).toHaveAttribute('aria-hidden', 'false');
+
+    // Polled: opacity and transform are on a 260ms ease, so a single synchronous
+    // read here catches an interpolated value part-way through the slide.
+    await waitFor(() => {
+      expect(getComputedStyle(panel).opacity).toBe('1');
+      expect(getComputedStyle(panel).transform).toBe('matrix(1, 0, 0, 1, 0, 0)');
+    });
+
+    /* Nine accessible links: the logo plus the panel's eight. The desktop rail and
+       the desktop CTA cluster are `display: none` at this width, so if this ever
+       reads 17 the media query has stopped applying and both sets are live. */
+    await expect(canvas.getAllByRole('link')).toHaveLength(9);
+    for (const label of NAV_LABELS) {
+      await expect(canvas.getByRole('link', { name: label })).toBeInTheDocument();
+    }
+    await expect(canvas.getByRole('link', { name: 'Star on GitHub' })).toBeInTheDocument();
+    await expect(canvas.getByRole('link', { name: 'Get started' })).toBeInTheDocument();
+
+    /* Six links, a hairline rule, the GitHub row, then the CTA row: nine children in
+       the flex column. The CTA row is the only one that is not full width - it pairs
+       the primary with the theme toggle. */
+    await expect(panel.children).toHaveLength(9);
+    await expect(getComputedStyle(panel).flexDirection).toBe('column');
+    const ctaRow = panel.children[8] as HTMLElement;
+    await expect(ctaRow.children).toHaveLength(2);
+    await expect(
+      within(ctaRow).getByRole('button', { name: /Switch to (light|dark) theme/ })
+    ).toBeInTheDocument();
+
+    // `active` is honoured inside the panel too, not only on the desktop rail: the
+    // current page is the one link tinted --nav-active.
+    const pricing = canvas.getByRole('link', { name: 'Pricing' });
+    const about = canvas.getByRole('link', { name: 'About' });
+    await expect(pricing).toHaveAttribute('aria-current', 'page');
+    await expect(about).not.toHaveAttribute('aria-current');
+    await waitFor(() => {
+      expect(getComputedStyle(pricing).color).not.toBe(getComputedStyle(about).color);
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The panel a phone visitor actually sees: a floating 24px card inset 12px from both edges ' +
+          'and dropped 78px from the top, on `--glass-93` behind a 40px blur. The links are 17px ' +
+          'here against 15px on the desktop rail, which is the only place that size exists.',
+      },
+    },
+  },
+};
+
+export const OpenSignedIn: Story = {
+  name: 'Phone - open, signed in',
+  beforeEach: seed(SIGNED_IN),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const panel = panelOf(canvasElement);
+    await userEvent.click(burgerOf(canvasElement));
+
+    /* The panel's primary is the one thing in it that depends on session state, and
+       the route depends on the role: `owner` resolves to /dashboard, everyone else
+       to /appointments. Asserting the href is the point - "Go to app" pointing at
+       the wrong screen looks identical in a snapshot. */
+    const goToApp = await canvas.findByRole('link', { name: 'Go to app' });
+    await expect(goToApp).toHaveAttribute('href', '/dashboard');
+    await expect(canvas.queryByRole('link', { name: 'Get started' })).not.toBeInTheDocument();
+    await expect(canvas.getAllByRole('link')).toHaveLength(9);
+
+    /* Same shape as signed out - nine children, and the CTA row still pairs the
+       primary with the theme toggle. The session swaps ONE link in place; a story
+       that only checked "Go to app" is present would pass just as happily on a
+       panel that had grown a tenth row or lost the toggle. */
+    await expect(panel.children).toHaveLength(9);
+    const ctaRow = panel.children[8] as HTMLElement;
+    await expect(ctaRow.children).toHaveLength(2);
+    await expect(ctaRow.children[0]).toBe(goToApp);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Signed in. Public pages never bootstrap the session check on their own, so the nav kicks ' +
+          'it off itself and swaps "Get started" for "Go to app" once it resolves - the store is ' +
+          'seeded to a settled status here, which is exactly the condition that makes ' +
+          '`ensureSessionChecked` return without touching the network.',
+      },
+    },
+  },
+};
+
+export const ClosesOnEscape: Story = {
+  name: 'Phone - closes on Escape',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const burger = burgerOf(canvasElement);
+    const panel = panelOf(canvasElement);
+
+    await userEvent.click(burger);
+    await expect(canvas.getByRole('link', { name: 'Pricing' })).toBeInTheDocument();
+
+    await userEvent.keyboard('{Escape}');
+
+    await expect(burger).toHaveAttribute('aria-expanded', 'false');
+    await expect(panel).toHaveAttribute('aria-hidden', 'true');
+    await expect(panel.hasAttribute('inert')).toBe(true);
+    await waitFor(() => {
+      expect(getComputedStyle(panel).opacity).toBe('0');
+    });
+    // Back out of the accessibility tree, not merely faded: the panel is still
+    // mounted and its anchors are still in the DOM.
+    await expect(canvas.queryByRole('link', { name: 'Pricing' })).not.toBeInTheDocument();
+    await expect(panel.querySelectorAll('a')).toHaveLength(8);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Escape is bound to `window` by `useEscapeToClose`, and only while the panel is open - ' +
+          'there is no focus trap and no dismissable scrim, so the key handler is the whole ' +
+          'keyboard exit.',
+      },
+    },
+  },
+};
+
+export const Desktop: Story = {
+  name: 'Desktop - panel suppressed',
+  globals: { viewport: { value: 'laptop', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const panel = panelOf(canvasElement);
+
+    // Above 960px the panel is `display: none !important`, so it is not merely
+    // transparent - it draws nothing and contributes nothing to the a11y tree.
+    await expect(getComputedStyle(panel).display).toBe('none');
+    /* Queried by class, not by role: the burger is `display: none` here, which
+       takes it out of the accessibility tree, so a role query would throw before
+       reaching the assertion it was meant to make. */
+    const burger = canvasElement.querySelector('.yc-nav-burger') as HTMLElement;
+    await expect(getComputedStyle(burger).display).toBe('none');
+
+    /* Exactly one accessible link per label. Both copies of every nav item exist at
+       every width - the rail's and the panel's - so a broken media query shows up
+       here as a duplicate rather than as a visual difference. */
+    for (const label of NAV_LABELS) {
+      await expect(canvas.getAllByRole('link', { name: label })).toHaveLength(1);
+    }
+    // "Star" and the count are separate spans, so the accessible name is the two
+    // joined - matched loosely on the count, which is the part the seed controls.
+    await expect(canvas.getByRole('link', { name: /Star .*2\.4k/ })).toBeInTheDocument();
+    await expect(canvas.getByRole('link', { name: 'Get started' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same component above the 960px breakpoint, included because it is what proves the ' +
+          'panel never leaks onto desktop. The star count comes from the session cache the stats ' +
+          'hook reads, which is seeded here, so the number is stable rather than whatever GitHub ' +
+          'last answered.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/PhoneOrganization.stories.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/PhoneOrganization.stories.tsx
@@ -1,0 +1,533 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import type { Organisation, Service, Speciality, UserOrganization } from '@yosemite-crew/types';
+
+import type { Team } from '@/app/features/organization/types/team';
+import type { BillingSubscription } from '@/app/features/billing/types/billing';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useTeamStore } from '@/app/stores/teamStore';
+import { useSpecialityStore } from '@/app/stores/specialityStore';
+import { useServiceStore } from '@/app/stores/serviceStore';
+import { useSubscriptionStore } from '@/app/stores/subscriptionStore';
+import PhoneOrganization from './PhoneOrganization';
+
+const ORG_ID = 'org-storybook-phone';
+const CARDIOLOGY_ID = 'spec-cardiology';
+const DENTISTRY_ID = 'spec-dentistry';
+
+const ORG: Organisation = {
+  _id: ORG_ID,
+  name: 'Sunrise Veterinary Hospital',
+  type: 'HOSPITAL',
+  phoneNo: '4155550110',
+  website: 'sunrisevet.example',
+  taxId: 'DE-8871-2290',
+  DUNSNumber: '15-048-3782',
+  isVerified: true,
+  isActive: true,
+  address: {
+    addressLine: '18 Larkspur Way',
+    city: 'Berlin',
+    state: 'Berlin',
+    postalCode: '10405',
+    country: 'Germany',
+  },
+  appointmentCheckInBufferMinutes: 10,
+  appointmentCheckInRadiusMeters: 150,
+};
+
+/** A real role code, so permissions resolve from the shipped role table rather than a stub. */
+const ownerMembership: UserOrganization = {
+  id: 'membership-owner',
+  practitionerReference: 'Practitioner/vet-1',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'OWNER',
+  active: true,
+};
+
+/** RECEPTIONIST holds `teams:view:any` but neither `org:edit` nor `teams:edit:any`. */
+const receptionistMembership: UserOrganization = {
+  ...ownerMembership,
+  id: 'membership-reception',
+  roleCode: 'RECEPTIONIST',
+};
+
+const speciality = (id: string, name: string): Speciality => ({
+  _id: id,
+  organisationId: ORG_ID,
+  name,
+  isActive: true,
+});
+
+const SPECIALITIES: Speciality[] = [
+  speciality(CARDIOLOGY_ID, 'Cardiology'),
+  speciality(DENTISTRY_ID, 'Dentistry'),
+];
+
+const service = (over: Partial<Service> & Pick<Service, 'id' | 'name'>): Service => ({
+  organisationId: ORG_ID,
+  durationMinutes: 30,
+  cost: 72,
+  isActive: true,
+  ...over,
+});
+
+const SERVICES: Service[] = [
+  service({ id: 'svc-echo', name: 'Echocardiogram', specialityId: CARDIOLOGY_ID }),
+  service({
+    id: 'svc-holter',
+    name: 'Holter monitor fitting',
+    specialityId: CARDIOLOGY_ID,
+    durationMinutes: 45,
+    cost: 130,
+  }),
+  service({
+    id: 'svc-scale',
+    name: 'Scale and polish',
+    specialityId: DENTISTRY_ID,
+    durationMinutes: 90,
+    cost: 310,
+  }),
+];
+
+/**
+ * `employmentType` is read off the team record through a cast in
+ * `teamSubline`, so it is not on the `Team` type. The fixture carries it the
+ * same way the API response does.
+ */
+type TeamFixture = Team & { employmentType?: string };
+
+const team = (over: Partial<TeamFixture> & Pick<TeamFixture, '_id' | 'name'>): TeamFixture => ({
+  practionerId: `practitioner-${over._id}`,
+  organisationId: ORG_ID,
+  role: 'VETERINARIAN',
+  speciality: [],
+  status: 'Available',
+  revokedPermissions: [],
+  effectivePermissions: [],
+  extraPerissions: [],
+  ...over,
+});
+
+const TEAMS: TeamFixture[] = [
+  team({
+    _id: 'team-marsh',
+    name: 'Dr. Elena Marsh',
+    speciality: [speciality(CARDIOLOGY_ID, 'Cardiology')],
+    employmentType: 'FULL_TIME',
+    status: 'Consulting',
+  }),
+  team({
+    _id: 'team-patel',
+    name: 'Dr. Ravi Patel',
+    speciality: [speciality(DENTISTRY_ID, 'Dentistry')],
+    employmentType: 'PART_TIME',
+    status: 'Available',
+  }),
+  team({
+    _id: 'team-reyes',
+    name: 'Tom Reyes',
+    role: 'RECEPTIONIST',
+    employmentType: 'CONTRACTOR',
+    status: 'Requested',
+  }),
+];
+
+/**
+ * The card that holds the team rows, given any text inside one of them.
+ *
+ * The invite row is a SIBLING of the rows inside the same card, not a footer
+ * outside it, so "did the invite affordance render" is a child count on this
+ * element - which is also the only assertion that catches an extra row appearing.
+ */
+const teamCardOf = (inside: HTMLElement): HTMLElement =>
+  inside.closest('div.overflow-hidden') as HTMLElement;
+
+/**
+ * The `label | value` row of a `ProfileCard` in the edit body, given its label.
+ *
+ * `FieldValueRow` is a flex row of exactly two divs, so the label's parent is the
+ * row. Asserting the row's text is what proves the pairing: the three cards share
+ * one form state, and a value rendered under the wrong label leaves every
+ * `getByText(value)` assertion passing.
+ */
+const rowOf = (label: HTMLElement): HTMLElement => label.parentElement as HTMLElement;
+
+const CONNECTED_SUBSCRIPTION: BillingSubscription = {
+  orgId: ORG_ID,
+  connectAccountId: 'acct_storybook',
+  connectChargesEnabled: true,
+  canAcceptPayments: true,
+};
+
+type Fixture = {
+  membership?: UserOrganization;
+  teams?: TeamFixture[];
+  specialities?: Speciality[];
+  services?: Service[];
+  subscription?: BillingSubscription | null;
+};
+
+/**
+ * Seeds the real stores instead of mocking the hooks.
+ *
+ * One caveat worth naming: unlike the specialities catalog, `loadServicesForOrg`
+ * has no "already loaded" guard, so the mount still fires one request for the
+ * org's services. It fails in Storybook and is swallowed by the service's own
+ * catch, which leaves the seeded store untouched - the accordion below is
+ * reading the seed, not a response.
+ */
+const seed =
+  ({
+    membership = ownerMembership,
+    teams = TEAMS,
+    specialities = SPECIALITIES,
+    services = SERVICES,
+    subscription = CONNECTED_SUBSCRIPTION,
+  }: Fixture = {}) =>
+  () => {
+    useOrgStore.setState({
+      orgsById: { [ORG_ID]: ORG },
+      orgIds: [ORG_ID],
+      primaryOrgId: ORG_ID,
+      membershipsByOrgId: { [ORG_ID]: membership },
+      status: 'loaded',
+    });
+    useTeamStore.getState().setTeamsForOrg(ORG_ID, teams);
+    useSpecialityStore.getState().setSpecialitiesForOrg(ORG_ID, specialities);
+    useServiceStore.getState().setServicesForOrg(ORG_ID, services);
+    useSubscriptionStore.setState({
+      subscriptionByOrgId: subscription ? { [ORG_ID]: subscription } : {},
+    });
+
+    return () => {
+      useOrgStore.setState({
+        orgsById: {},
+        orgIds: [],
+        primaryOrgId: null,
+        membershipsByOrgId: {},
+        status: 'idle',
+      });
+      useTeamStore.setState({ teamsById: {}, teamIdsByOrgId: {} });
+      useSpecialityStore.setState({ specialitiesById: {}, specialityIdsByOrgId: {} });
+      useServiceStore.setState({
+        servicesById: {},
+        serviceIdsByOrgId: {},
+        serviceIdsBySpecialityId: {},
+      });
+      useSubscriptionStore.setState({ subscriptionByOrgId: {} });
+    };
+  };
+
+const meta = {
+  title: 'Organization/PhoneOrganization',
+  component: PhoneOrganization,
+  // Pinned as a GLOBAL on the meta, not as `parameters.viewport.defaultViewport`:
+  // that key was removed in Storybook 10 and is inert, so a story using it renders
+  // the full panel width and proves nothing. This whole screen is the phone
+  // (< 768px) organization route, so every story here is 375px.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  parameters: {
+    layout: 'fullscreen',
+    chromatic: { viewports: [375] },
+    nextjs: { appDirectory: true, navigation: { pathname: '/organization' } },
+    docs: {
+      description: {
+        component:
+          'The phone organization screen: one 54px sticky bar over a single column that holds ' +
+          'the compact identity card, the team list, the specialities accordion and the Stripe ' +
+          'row.\n\n' +
+          'The header pencil swaps the entire body. `isEditing` does not turn the resting cards ' +
+          'into fields - it replaces them with `OrgProfileEditCards`, a completely different tree ' +
+          'of three `ProfileCard`s (Organization, Address, Check-in settings), each of which then ' +
+          'has its own edit affordance. Nothing about the resting screen survives the swap, which ' +
+          'is why it is drawn here as its own story rather than left to a reviewer to imagine.\n\n' +
+          'Permissions decide how much of this exists at all: `org:edit` draws the header pencil ' +
+          '(and therefore the whole edit body), `teams:edit:any` draws the invite row, and the ' +
+          'Stripe Manage link needs `org:edit` and `subscription:edit:any` together. The stories ' +
+          'seed a real OWNER and a real RECEPTIONIST membership and let the shipped role table ' +
+          'resolve them.',
+      },
+    },
+  },
+  args: { primaryOrg: ORG },
+  beforeEach: seed(),
+  tags: ['autodocs'],
+} satisfies Meta<typeof PhoneOrganization>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Resting: Story = {
+  name: 'Phone: resting screen',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByText('Sunrise Veterinary Hospital')).toBeInTheDocument();
+    await expect(canvas.getByText('VERIFIED')).toBeInTheDocument();
+    await expect(canvas.getByText('HOSPITAL')).toBeInTheDocument();
+
+    /* The two meta lines are composed here, not by the API: address line, postal
+       code + city and phone join with ' · ' on the first line, website and tax id
+       on the second. They share one <span> separated by a <br/>, so the assertion
+       is on the concatenated text - which is also what proves both lines were
+       built rather than one silently collapsing to ''. */
+    const metaLines = canvas.getByText(/^18 Larkspur Way, 10405 Berlin/);
+    await expect(metaLines.textContent).toBe(
+      '18 Larkspur Way, 10405 Berlin · 4155550110sunrisevet.example · Tax DE-8871-2290'
+    );
+
+    await expect(canvas.getByText('Team · 3')).toBeInTheDocument();
+    await expect(canvas.getByText('Dr. Elena Marsh')).toBeInTheDocument();
+    await expect(canvas.getByText('Veterinarian · Cardiology · Full time')).toBeInTheDocument();
+    await expect(canvas.getByText('Receptionist · Contractor')).toBeInTheDocument();
+    // Requested is the only status the pill helper relabels rather than passing through.
+    await expect(canvas.getByText('INVITED')).toBeInTheDocument();
+
+    /* Four children in the team card: three rows and the invite row. The invite
+       row is a sibling of the rows inside the same card rather than a footer, so
+       a permission regression shows up as a child count and nothing else - see
+       the RECEPTIONIST story below, which asserts the same card at three. */
+    await expect(teamCardOf(canvas.getByText('Dr. Elena Marsh')).children).toHaveLength(4);
+    await expect(canvas.getByText('Invite team member')).toBeInTheDocument();
+
+    /* Exactly one speciality is open at rest: `selectedId` starts undefined, which
+       means "not toggled yet" and falls back to the first speciality, so this is a
+       default rather than a click. */
+    const open = canvas.getByRole('button', { expanded: true });
+    await expect(open.textContent?.replaceAll(/\s+/g, ' ').trim()).toBe('Cardiology · 2 services');
+    const openBody = within(open.parentElement as HTMLElement);
+    await expect(openBody.getByText('Echocardiogram')).toBeInTheDocument();
+    await expect(openBody.getByText('30 min · €72')).toBeInTheDocument();
+    await expect(openBody.getByText('Holter monitor fitting')).toBeInTheDocument();
+    await expect(canvas.queryByText('Scale and polish')).toBeNull();
+
+    await expect(canvas.getByText('Stripe payments connected')).toBeInTheDocument();
+    await expect(canvas.getByRole('link', { name: 'Manage' })).toHaveAttribute(
+      'href',
+      `/stripe-onboarding?orgId=${ORG_ID}`
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The screen as it opens. Worth checking against the design: the identity card is a ' +
+          '48px logo tile beside a wrapping name/pill row, the team rows are a 32px avatar with ' +
+          'a truncating two-line label, and every card is the same 16px radius on `--screen` ' +
+          'with the two-layer warm shadow.',
+      },
+    },
+  },
+};
+
+export const SpecialitySwitch: Story = {
+  name: 'Specialities accordion',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const dentistry = canvas.getByRole('button', { expanded: false });
+    await expect(dentistry.textContent?.replaceAll(/\s+/g, ' ').trim()).toBe(
+      'Dentistry · 1 services'
+    );
+
+    await userEvent.click(dentistry);
+
+    // One open at a time: opening the second closes the first, because the
+    // accordion holds a single selected id rather than a set.
+    await waitFor(() => expect(dentistry).toHaveAttribute('aria-expanded', 'true'));
+    await expect(canvas.getByRole('button', { expanded: true })).toBe(dentistry);
+    await expect(canvas.getByText('Scale and polish')).toBeInTheDocument();
+    await expect(canvas.getByText('90 min · €310')).toBeInTheDocument();
+    await expect(canvas.queryByText('Echocardiogram')).toBeNull();
+
+    // Tapping the open one collapses everything - `selectedId` goes to null, which
+    // is a different state from the initial undefined and no longer re-opens the first.
+    await userEvent.click(dentistry);
+    await waitFor(() => expect(canvas.queryByRole('button', { expanded: true })).toBeNull());
+    await expect(canvas.queryByText('Scale and polish')).toBeNull();
+    await expect(canvas.queryByText('Echocardiogram')).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The service rows only exist while their speciality is open, so they had never been ' +
+          'drawn. Each is name over `duration · price` on the soft warm wash, divided from the ' +
+          'header by the same hairline as the row above it.',
+      },
+    },
+  },
+};
+
+export const Editing: Story = {
+  name: 'Edit body (isEditing swap)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Edit organization' }));
+
+    // The trigger is the same button with a new label and glyph, not a second control.
+    const doneButton = await canvas.findByRole('button', { name: 'Done editing' });
+    await expect(doneButton).toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Edit organization' })).toBeNull();
+
+    // Nothing from the resting screen survives: list, accordion and Stripe row are gone.
+    await expect(canvas.queryByText('Team · 3')).toBeNull();
+    await expect(canvas.queryByText('Dr. Elena Marsh')).toBeNull();
+    await expect(canvas.queryByText('Invite team member')).toBeNull();
+    await expect(canvas.queryByRole('button', { expanded: true })).toBeNull();
+    await expect(canvas.queryByText('Stripe payments connected')).toBeNull();
+
+    /* What replaced it: exactly three cards, in this order, each resting with its
+       own pencil. The count is the assertion that matters - `OrgProfileEditCards`
+       is shared with the desktop Profile band, so a fourth card added there lands
+       on this screen with nobody looking at it. */
+    const pencils = canvas.getAllByRole('button', { name: /^Edit / });
+    await expect(pencils.map((pencil) => pencil.getAttribute('aria-label'))).toEqual([
+      'Edit Organization',
+      'Edit Address',
+      'Edit Check-in settings',
+    ]);
+
+    /* Their read rows carry the org, asserted as label/value pairs rather than as
+       loose texts: all three cards are `ProfileCard`s over the same form state, so
+       a value landing in the wrong card is exactly the failure to catch here. */
+    await expect(rowOf(canvas.getByText('Tax ID')).textContent).toBe('Tax IDDE-8871-2290');
+    await expect(rowOf(canvas.getByText('DUNS number')).textContent).toBe('DUNS number15-048-3782');
+    await expect(rowOf(canvas.getByText('Postal code')).textContent).toBe('Postal code10405');
+    await expect(rowOf(canvas.getByText('City')).textContent).toBe('CityBerlin');
+    await expect(rowOf(canvas.getByText('Maximum check-in distance (meters)')).textContent).toBe(
+      'Maximum check-in distance (meters)150'
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The state the header pencil reveals. It is easy to read the code as "the cards become ' +
+          'editable"; they do not. The resting body is unmounted and three fresh cards take its ' +
+          'place, each still in its own read state until its own pencil is tapped. That second ' +
+          'tap is the story below.',
+      },
+    },
+  },
+};
+
+export const EditingFormOpen: Story = {
+  name: 'Edit body, Organization card open',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Edit organization' }));
+    await userEvent.click(await canvas.findByRole('button', { name: 'Edit Organization' }));
+
+    /* Only the fields flagged `editable` turn into inputs. Type and name stay as
+       read rows inside the open form, which is the detail most reviews miss: three
+       textboxes and one dropdown, not six fields. */
+    const textboxes = await canvas.findAllByRole('textbox');
+    await expect(textboxes).toHaveLength(3);
+    await expect(canvas.getByRole('textbox', { name: 'Tax ID' })).toHaveValue('DE-8871-2290');
+    await expect(canvas.getByRole('textbox', { name: 'DUNS number' })).toHaveValue('15-048-3782');
+    await expect(canvas.getByRole('textbox', { name: 'Phone number' })).toHaveValue('4155550110');
+    await expect(canvas.getByRole('button', { name: 'Country: Germany' })).toBeInTheDocument();
+    await expect(canvas.getByText('Organization type')).toBeInTheDocument();
+    await expect(canvas.getByText('Hospital')).toBeInTheDocument();
+    await expect(canvas.queryByRole('textbox', { name: 'Organization name' })).toBeNull();
+
+    /* The action row is the card's own footer. It is a flex row, not a grid, so
+       there is no grid template to read here - the check that matters is that both
+       actions landed in the one row and it is still end-aligned at 375px, where a
+       wrapped or stretched pair is the likely regression. */
+    const save = canvas.getByRole('button', { name: 'Save' });
+    const footer = save.parentElement as HTMLElement;
+    await expect(footer.children).toHaveLength(2);
+    await expect(within(footer).getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    const footerStyle = getComputedStyle(footer);
+    await expect(footerStyle.display).toBe('flex');
+    await expect(footerStyle.justifyContent).toBe('flex-end');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Two taps deep, and the only place on a phone where the org form is visible at all. ' +
+          'The 44px fields and the 40px action pills are the desktop sizes unchanged, so this is ' +
+          'the story to check for cramped horizontal padding inside the 18px page inset.',
+      },
+    },
+  },
+};
+
+export const ReadOnlyRole: Story = {
+  name: 'Receptionist (no edit rights)',
+  beforeEach: seed({ membership: receptionistMembership }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // No pencil at all, so the entire edit body is unreachable for this role.
+    await expect(canvas.queryByRole('button', { name: 'Edit organization' })).toBeNull();
+    await expect(canvas.queryByRole('button', { name: 'Done editing' })).toBeNull();
+    await expect(canvas.queryByText('Invite team member')).toBeNull();
+    await expect(canvas.queryByRole('link', { name: 'Manage' })).toBeNull();
+
+    /* Everything view-only still renders in full. Three rows and THREE children in
+       the team card, against four in the OWNER story above: the invite row is a
+       sibling of the rows, so dropping it is a child count and nothing else. */
+    await expect(canvas.getByText('Team · 3')).toBeInTheDocument();
+    await expect(teamCardOf(canvas.getByText('Dr. Ravi Patel')).children).toHaveLength(3);
+    await expect(canvas.getByText('Veterinarian · Cardiology · Full time')).toBeInTheDocument();
+    await expect(canvas.getByText('Veterinarian · Dentistry · Part time')).toBeInTheDocument();
+    await expect(canvas.getByText('Receptionist · Contractor')).toBeInTheDocument();
+
+    /* The accordion is unaffected by the role: still open on the first speciality
+       and still rendering its service rows, which is the part a "hide everything
+       for read-only viewers" regression would take out along with the pencil. */
+    const open = canvas.getByRole('button', { expanded: true });
+    await expect(open.textContent?.replaceAll(/\s+/g, ' ').trim()).toBe('Cardiology · 2 services');
+    const openBody = within(open.parentElement as HTMLElement);
+    await expect(openBody.getByText('Echocardiogram')).toBeInTheDocument();
+    await expect(openBody.getByText('30 min · €72')).toBeInTheDocument();
+
+    // The Stripe row keeps its status line and loses only the link.
+    await expect(canvas.getByText('Stripe payments connected')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'RECEPTIONIST resolves to `teams:view:any` without `teams:edit:any` or `org:edit`. ' +
+          'Note the Stripe row keeps its status dot and label and loses only the link: the ' +
+          'connection state is information, the Manage action is the permission.',
+      },
+    },
+  },
+};
+
+export const EmptyOrg: Story = {
+  name: 'Nothing set up yet',
+  beforeEach: seed({ teams: [], specialities: [], services: [], subscription: null }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByText('Team · 0')).toBeInTheDocument();
+    await expect(canvas.getByText('No team members yet.')).toBeInTheDocument();
+    await expect(canvas.getByText('No specialities added yet.')).toBeInTheDocument();
+    await expect(canvas.getByText('Stripe not connected')).toBeInTheDocument();
+    // No subscription row means no orgId to onboard with, so neither link is drawn.
+    await expect(canvas.queryByRole('link', { name: 'Connect' })).toBeNull();
+    // The identity card is unaffected - it reads the org prop, not the loaders.
+    await expect(canvas.getByText('Sunrise Veterinary Hospital')).toBeInTheDocument();
+    // The invite row survives an empty list; it is gated on permission, not on count.
+    await expect(canvas.getByText('Invite team member')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A freshly created organization. Three empty states in one column, each phrased as a ' +
+          'sentence on `--ink-faint` inside its own card rather than as a shared illustration.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/ProfileCard.stories.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/ProfileCard.stories.tsx
@@ -1,0 +1,496 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import type { Organisation, UserOrganization } from '@yosemite-crew/types';
+
+import { useOrgStore } from '@/app/stores/orgStore';
+import {
+  BasicFields,
+  CheckInFields,
+} from '@/app/features/organization/pages/Organization/Sections/profileFields';
+import ProfileCard from './ProfileCard';
+
+const ORG_ID = 'org-storybook-profilecard';
+
+const ORG: Organisation = {
+  _id: ORG_ID,
+  name: 'Sunrise Veterinary Hospital',
+  type: 'HOSPITAL',
+  phoneNo: '4155550110',
+  taxId: 'DE-8871-2290',
+  DUNSNumber: '15-048-3782',
+  isVerified: true,
+  isActive: true,
+  address: {
+    addressLine: '18 Larkspur Way',
+    city: 'Berlin',
+    state: 'Berlin',
+    postalCode: '10405',
+    country: 'Germany',
+  },
+  appointmentCheckInBufferMinutes: 10,
+  appointmentCheckInRadiusMeters: 150,
+};
+
+const membership: UserOrganization = {
+  id: 'membership-owner',
+  practitionerReference: 'Practitioner/vet-1',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'OWNER',
+  active: true,
+};
+
+/**
+ * The record shape the real caller passes: the org flattened, with `country`
+ * lifted out of `address` because `BasicFields` addresses it by a top-level key.
+ */
+const ORG_RECORD: Record<string, unknown> = { ...ORG, country: ORG.address?.country };
+
+const CHECK_IN_RECORD: Record<string, unknown> = {
+  appointmentCheckInBufferMinutes: ORG.appointmentCheckInBufferMinutes,
+  appointmentCheckInRadiusMeters: ORG.appointmentCheckInRadiusMeters,
+};
+
+/**
+ * The `label | value` row that owns a label cell, given the label element.
+ *
+ * `FieldValueRow` is a flex row of exactly two divs, so the label's parent IS the
+ * row. Asserting `row.textContent` rather than two separate `getByText`s is what
+ * proves the PAIRING: a renamed field key leaves both texts on screen, in
+ * different rows, and every existence assertion still passes.
+ */
+const rowOf = (label: HTMLElement): HTMLElement => label.parentElement as HTMLElement;
+
+/** Exactly the six `BasicFields` labels, so a row count cannot be met by other text. */
+const BASIC_LABELS =
+  /^(Organization type|Organization name|Tax ID|Country|DUNS number|Phone number)$/;
+
+/**
+ * Seeds the org store rather than mocking the hooks. The card reads
+ * `usePrimaryOrg` only for the id it hands the two logo endpoints - without it
+ * `LogoUpdator` renders permanently disabled, which is a different picture from
+ * the one the product shows.
+ */
+const seedOrg = () => {
+  useOrgStore.setState({
+    orgsById: { [ORG_ID]: ORG },
+    orgIds: [ORG_ID],
+    primaryOrgId: ORG_ID,
+    membershipsByOrgId: { [ORG_ID]: membership },
+    status: 'loaded',
+  });
+
+  return () => {
+    useOrgStore.setState({
+      orgsById: {},
+      orgIds: [],
+      primaryOrgId: null,
+      membershipsByOrgId: {},
+      status: 'idle',
+    });
+  };
+};
+
+const meta = {
+  title: 'Organization/ProfileCard',
+  component: ProfileCard,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The label/value card behind **six surfaces**: the three organization cards ' +
+          '(Organization, Address, Check-in settings) and the three Settings profile cards ' +
+          '(User profile, Address, Professional details). Every one of them is driven by the ' +
+          'same `fields` array, and none of them had a story.\n\n' +
+          'The pencil swaps the card body for a different tree, not for an editable version of ' +
+          'the same one. Read rows are a two-column `label | value` line with a hairline under ' +
+          'every row but the last; the edit body is a stack of 44px inputs with no dividers at ' +
+          'all, plus an action row that only exists while editing.\n\n' +
+          'The swap is partial, which is the part worth reviewing: only fields flagged ' +
+          '`editable` become inputs. A field that is `required` but not `editable` (organization ' +
+          'type, name, email) stays a read row inside the open form and is skipped by ' +
+          '`validate()` entirely, so it can never block a save. Values also live in the card, ' +
+          'not the caller: Cancel rebuilds them from the `org` prop, and a successful Save keeps ' +
+          'the edited values on screen without waiting for the parent to send fresh ones down.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    title: 'Organization',
+    fields: BasicFields,
+    org: ORG_RECORD,
+    showProfile: true,
+    onSave: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[720px] max-w-full bg-[var(--page)] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+  beforeEach: seedOrg,
+} satisfies Meta<typeof ProfileCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Resting: Story = {
+  name: 'Read rows',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // The name is drawn twice on purpose: once in the identity band that
+    // `showProfile` adds, once as the `Organization name` row below it.
+    await expect(canvas.getAllByText('Sunrise Veterinary Hospital')).toHaveLength(2);
+    await expect(canvas.getByText('Verified')).toBeInTheDocument();
+
+    /* Label and value asserted as ONE row, not as two texts that happen to be on
+       screen. Selects resolve through their options on the way, so the row reads
+       the option label and never the stored code - HOSPITAL is what the record
+       holds and Hospital is what the row must say. */
+    await expect(rowOf(canvas.getByText('Organization type')).textContent).toBe(
+      'Organization typeHospital'
+    );
+    await expect(rowOf(canvas.getByText('Tax ID')).textContent).toBe('Tax IDDE-8871-2290');
+    await expect(rowOf(canvas.getByText('Country')).textContent).toBe('CountryGermany');
+    await expect(rowOf(canvas.getByText('Phone number')).textContent).toBe(
+      'Phone number4155550110'
+    );
+    await expect(canvas.queryByText('HOSPITAL')).toBeNull();
+
+    /* Six rows, and the hairline sits on every one but the last: `showDivider` is
+       `index !== fields.length - 1`, so adding a field silently moves the rule and
+       the regression is a card that ends on a hairline. Read as computed style,
+       because the class is conditional and its absence is invisible in the tree. */
+    await expect(canvas.getAllByText(BASIC_LABELS)).toHaveLength(6);
+    await expect(getComputedStyle(rowOf(canvas.getByText('Tax ID'))).borderBottomWidth).not.toBe(
+      '0px'
+    );
+    await expect(getComputedStyle(rowOf(canvas.getByText('Phone number'))).borderBottomWidth).toBe(
+      '0px'
+    );
+
+    // Nothing editable is mounted at rest, and the action row does not exist yet.
+    await expect(canvas.queryAllByRole('textbox')).toHaveLength(0);
+    await expect(canvas.queryByRole('button', { name: 'Save' })).toBeNull();
+    await expect(canvas.getByRole('button', { name: 'Edit Organization' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting card. Labels are `--ink-faint` on the left, values are ' +
+          '`--ink-body` medium and right-aligned, and the last row deliberately has no rule ' +
+          'under it so the card does not end on a hairline.',
+      },
+    },
+  },
+};
+
+export const Editing: Story = {
+  name: 'Edit form',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Edit Organization' }));
+
+    /* Four of the six fields are editable, and one of those four is a dropdown -
+       so three textboxes, not six inputs. Type and name keep their read rows
+       inside the open form. */
+    const textboxes = await canvas.findAllByRole('textbox');
+    await expect(textboxes).toHaveLength(3);
+    await expect(canvas.getByRole('textbox', { name: 'Tax ID' })).toHaveValue('DE-8871-2290');
+    await expect(canvas.getByRole('textbox', { name: 'DUNS number' })).toHaveValue('15-048-3782');
+    await expect(canvas.getByRole('textbox', { name: 'Phone number' })).toHaveValue('4155550110');
+    await expect(canvas.getByRole('button', { name: 'Country: Germany' })).toHaveAttribute(
+      'aria-haspopup',
+      'listbox'
+    );
+    await expect(canvas.getByText('Organization type')).toBeInTheDocument();
+    await expect(canvas.getByText('Hospital')).toBeInTheDocument();
+    await expect(canvas.queryByRole('textbox', { name: 'Organization name' })).toBeNull();
+
+    // The pencil is gone while the form is open; the actions are the only way out.
+    await expect(canvas.queryByRole('button', { name: 'Edit Organization' })).toBeNull();
+
+    /* The action row is flex, not grid - there is no grid template to read here.
+       What can silently break is the pairing: both actions have to stay in the one
+       end-aligned row rather than wrap or stretch to full width. */
+    const save = canvas.getByRole('button', { name: 'Save' });
+    const footer = save.parentElement as HTMLElement;
+    await expect(footer.children).toHaveLength(2);
+    await expect(within(footer).getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    const footerStyle = getComputedStyle(footer);
+    await expect(footerStyle.display).toBe('flex');
+    await expect(footerStyle.justifyContent).toBe('flex-end');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The tree the pencil reveals. Both controls are 44px tall on `--field-bg` with a ' +
+          '1.5px `--hairline` border, so the text input and the dropdown trigger line up: they ' +
+          'are separate components and the two heights have drifted apart before.',
+      },
+    },
+  },
+};
+
+export const ValidationBlocksSave: Story = {
+  name: 'Required field blocks Save',
+  // Its own spy, so the assertion below cannot be satisfied or broken by a call
+  // another story made to a shared one.
+  args: { onSave: fn() },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Edit Organization' }));
+    await userEvent.clear(await canvas.findByRole('textbox', { name: 'Tax ID' }));
+    await userEvent.click(canvas.getByRole('button', { name: 'Save' }));
+
+    // One alert, naming the field. The card stays open and nothing was sent up.
+    const alert = await canvas.findByRole('alert');
+    await expect(alert).toHaveTextContent('Tax ID is required');
+    await expect(canvas.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+    await expect(args.onSave).not.toHaveBeenCalled();
+
+    /* DUNS number is the control: not required, cleared, and still no error - so
+       the alert above came from the required flag rather than from emptiness. */
+    await userEvent.clear(canvas.getByRole('textbox', { name: 'DUNS number' }));
+    await expect(canvas.getAllByRole('alert')).toHaveLength(1);
+
+    // Typing clears the error for that field on the keystroke, not on the next save.
+    await userEvent.type(canvas.getByRole('textbox', { name: 'Tax ID' }), 'DE-9999-0001');
+    await waitFor(() => expect(canvas.queryByRole('alert')).toBeNull());
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`validate()` walks only the fields that are both `required` and `editable`, so a ' +
+          'required-but-locked field can never trap the user in a form with no way to satisfy ' +
+          'it. The message is the field label plus " is required", rendered under the input in ' +
+          '`--danger` with the border switched to match.',
+      },
+    },
+  },
+};
+
+export const SaveExitsEditing: Story = {
+  name: 'Save returns to read rows',
+  args: { onSave: fn() },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Edit Organization' }));
+    const taxId = await canvas.findByRole('textbox', { name: 'Tax ID' });
+    await userEvent.clear(taxId);
+    await userEvent.type(taxId, 'DE-4410-7788');
+    await userEvent.click(canvas.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(args.onSave).toHaveBeenCalledTimes(1));
+    /* The whole form is handed up, not a diff - including the fields that were
+       never editable, which is what lets the caller spread it straight onto the
+       org record. */
+    await expect(args.onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taxId: 'DE-4410-7788',
+        name: 'Sunrise Veterinary Hospital',
+        type: 'HOSPITAL',
+        country: 'Germany',
+      })
+    );
+
+    await waitFor(() => expect(canvas.queryByRole('button', { name: 'Save' })).toBeNull());
+    /* The whole read body is back - all six rows, not just the one that changed -
+       and the edited value stays on screen: the card renders its own state, not
+       the `org` prop, so it does not blank out while the parent round-trips. */
+    await expect(canvas.getAllByText(BASIC_LABELS)).toHaveLength(6);
+    await expect(rowOf(canvas.getByText('Tax ID')).textContent).toBe('Tax IDDE-4410-7788');
+    await expect(rowOf(canvas.getByText('Country')).textContent).toBe('CountryGermany');
+    await expect(canvas.queryAllByRole('textbox')).toHaveLength(0);
+    await expect(canvas.getByRole('button', { name: 'Edit Organization' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The whole form goes up, not a diff, which is what lets a caller spread it straight ' +
+          'onto its record. Exiting edit mode is conditional on the promise resolving: a ' +
+          'rejected `onSave` is caught, logged to the console and nothing else - the card stays ' +
+          'open with the typed values and says nothing to the user. There is no failure story ' +
+          'here because there is no failure UI to draw.',
+      },
+    },
+  },
+};
+
+export const CancelDiscardsEdits: Story = {
+  name: 'Cancel restores the original values',
+  args: { onSave: fn() },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Edit Organization' }));
+    const taxId = await canvas.findByRole('textbox', { name: 'Tax ID' });
+    await userEvent.clear(taxId);
+    await userEvent.type(taxId, 'NOT-SAVED-0001');
+    await expect(taxId).toHaveValue('NOT-SAVED-0001');
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() => expect(canvas.queryByRole('textbox', { name: 'Tax ID' })).toBeNull());
+    await expect(canvas.getByText('DE-8871-2290')).toBeInTheDocument();
+    await expect(canvas.queryByText('NOT-SAVED-0001')).toBeNull();
+    await expect(args.onSave).not.toHaveBeenCalled();
+
+    // Reopening starts from the record again rather than from the abandoned edit.
+    await userEvent.click(canvas.getByRole('button', { name: 'Edit Organization' }));
+    const reopened = await canvas.findByRole('textbox', { name: 'Tax ID' });
+    await expect(reopened).toHaveValue('DE-8871-2290');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Cancel rebuilds the values from the `org` prop and drops the error map, so a card ' +
+          'left in a failed-validation state comes back clean. There is no confirmation step - ' +
+          'the discard is immediate, which is worth knowing before adding a longer form here.',
+      },
+    },
+  },
+};
+
+export const CheckInNumbers: Story = {
+  name: 'Number fields (Check-in settings)',
+  args: {
+    title: 'Check-in settings',
+    fields: CheckInFields,
+    org: CHECK_IN_RECORD,
+    showProfile: false,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByText('Maximum check-in distance (meters)')).toBeInTheDocument();
+    await expect(canvas.getByText('150')).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Edit Check-in settings' }));
+
+    // Number fields are spinbuttons, not textboxes - the labels are long enough
+    // to wrap, which is the thing to look at here.
+    const spinners = await canvas.findAllByRole('spinbutton');
+    await expect(spinners).toHaveLength(2);
+    await expect(
+      canvas.getByRole('spinbutton', { name: 'Enable check-in this many minutes before start' })
+    ).toHaveValue(10);
+    await expect(
+      canvas.getByRole('spinbutton', { name: 'Maximum check-in distance (meters)' })
+    ).toHaveValue(150);
+    await expect(canvas.queryAllByRole('textbox')).toHaveLength(0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The third organization card, and the only one built entirely from number fields. ' +
+          'Zero is a legitimate value for both of these, which is why `getRequiredError` special ' +
+          'cases `0` instead of treating it as empty.',
+      },
+    },
+  },
+};
+
+export const Unverified: Story = {
+  name: 'Unverified organization',
+  args: { org: { ...ORG_RECORD, isVerified: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByText('Pending')).toBeInTheDocument();
+    await expect(canvas.queryByText('Verified')).toBeNull();
+
+    /* `Primary` renders a <button> rather than a link because its href is '#',
+       so the CTA is keyboard-reachable as an action. Deliberately not clicked:
+       it mounts a third-party booking iframe. */
+    const cta = canvas.getByRole('button', { name: 'Verify business profile' });
+    await expect(cta.tagName).toBe('BUTTON');
+
+    // The whole note, not a prefix - it is the only explanatory copy on the card
+    // and it is easy to truncate a sentence out of it without anyone noticing.
+    const note = canvas.getByText(/^This short chat helps us confirm your business/);
+    await expect(note.textContent?.replaceAll(/\s+/g, ' ').trim()).toBe(
+      'Note : This short chat helps us confirm your business and add you to our trusted network ' +
+        'of verified pet professionals - so you can start connecting with clients faster.'
+    );
+
+    /* `sm:max-w-1/2` caps the note at half the band from 640px up, and this story
+       renders at the project default (laptop, 1280). A dropped cap is invisible in
+       the tree and only shows as a full-width paragraph, so it is measured. */
+    const band = note.parentElement as HTMLElement;
+    await expect(getComputedStyle(note).maxWidth).not.toBe('none');
+    await expect(note.getBoundingClientRect().width).toBeLessThan(
+      band.getBoundingClientRect().width * 0.6
+    );
+
+    // The rows below the band are untouched by verification state.
+    await expect(canvas.getAllByText(BASIC_LABELS)).toHaveLength(6);
+    await expect(rowOf(canvas.getByText('Tax ID')).textContent).toBe('Tax IDDE-8871-2290');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Verification is the only state that adds chrome to the identity band: an amber ' +
+          'Pending pill, a CTA that opens the booking overlay, and an explanatory note capped ' +
+          'at half the card width from `sm` up. The CTA is deliberately not clicked here - it ' +
+          'mounts a third-party booking iframe.',
+      },
+    },
+  },
+};
+
+export const NotEditable: Story = {
+  name: 'Read-only (no onSave)',
+  args: { onSave: undefined },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* `editable` alone is not enough: the pencil needs a save handler too, so a
+       caller that forgets `onSave` gets a permanently read-only card rather than
+       a form whose Save silently does nothing. */
+    await expect(canvas.queryByRole('button', { name: 'Edit Organization' })).toBeNull();
+    await expect(canvas.queryByRole('button', { name: 'Save' })).toBeNull();
+
+    /* The point of the story is that ONLY the affordance is gone. All six rows
+       still render their pairs and the dividers still fall where they did, which
+       is what separates a read-only card from a card that failed to render. */
+    await expect(canvas.getAllByText(BASIC_LABELS)).toHaveLength(6);
+    await expect(rowOf(canvas.getByText('Organization type')).textContent).toBe(
+      'Organization typeHospital'
+    );
+    await expect(rowOf(canvas.getByText('Tax ID')).textContent).toBe('Tax IDDE-8871-2290');
+    await expect(rowOf(canvas.getByText('Phone number')).textContent).toBe(
+      'Phone number4155550110'
+    );
+    await expect(getComputedStyle(rowOf(canvas.getByText('Phone number'))).borderBottomWidth).toBe(
+      '0px'
+    );
+    // The identity band is independent of `onSave` and keeps its logo and pill.
+    await expect(canvas.getAllByText('Sunrise Veterinary Hospital')).toHaveLength(2);
+    await expect(canvas.getByText('Verified')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The shape the Settings cards use for a viewer without edit rights. Note the card is ' +
+          'identical to the resting one minus the 38px pencil - there is no separate read-only ' +
+          'treatment, no muted labels and no lock glyph, so nothing on screen tells the user ' +
+          'why the card cannot be edited.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/AddRoomSections.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/AddRoomSections.tsx
@@ -74,7 +74,7 @@ export const BasicDetailsSection = ({
             options={specialitiesOptions}
           />
         </div>
-        <div className="sm:col-span-2 rounded-2xl border border-card-border bg-card-subtle px-3 py-2 text-caption-1 text-text-secondary">
+        <div className="sm:col-span-2 rounded-2xl border border-card-border bg-card-hover px-3 py-2 text-caption-1 text-text-secondary">
           Assign a specialty if this room is dedicated to a specific speciality or service.
         </div>
       </div>

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/RoomInfoContent.stories.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/RoomInfoContent.stories.tsx
@@ -1,0 +1,364 @@
+import { useState, type ComponentProps } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+import type { OrganisationRoom } from '@yosemite-crew/types';
+
+import RoomInfoContent from './RoomInfoContent';
+import type { ManagedRoom } from './RoomInfo.types';
+
+const ACTIVE_ROOM: OrganisationRoom = {
+  id: 'room-consult-1',
+  name: 'Consult 1',
+  organisationId: 'org-storybook',
+  code: 'C1',
+  type: 'EXAM_ROOM',
+};
+
+const FORM_DATA: ManagedRoom = {
+  ...ACTIVE_ROOM,
+  availability: {
+    isAvailable: true,
+    days: 'MON_FRI',
+    startTime: '09:00',
+    endTime: '17:30',
+    species: ['dog', 'cat'],
+    totalUnits: 0,
+  },
+  units: [],
+  equipment: ['Otoscope', 'Digital scale'],
+  assignedSpecialiteis: ['spec-derm'],
+  assignedStaffs: ['staff-weber'],
+};
+
+const OPTIONS = {
+  equipment: ['Otoscope', 'Digital scale', 'Ophthalmoscope'],
+  specialities: [
+    { label: 'Dermatology', value: 'spec-derm' },
+    { label: 'Cardiology', value: 'spec-cardio' },
+  ],
+  team: [
+    { label: 'Dr. Weber', value: 'staff-weber' },
+    { label: 'Nurse Lindqvist', value: 'staff-lindqvist' },
+  ],
+};
+
+/**
+ * The component is fully controlled: every panel is opened by a `visibility.*`
+ * flag whose setter lives in the page above it. Handing those setters plain
+ * mocks makes the trash and pencil dead, so the nested confirms could only ever
+ * be posed, never reached. This harness gives the flags somewhere to live so the
+ * confirms open the way they do in the product.
+ */
+const RoomInfoHarness = (args: ComponentProps<typeof RoomInfoContent>) => {
+  const [showModal, setShowModal] = useState(args.visibility.showModal);
+  const [showDeleteModal, setShowDeleteModal] = useState(args.visibility.showDeleteModal);
+  const [showDiscardConfirm, setShowDiscardConfirm] = useState(args.visibility.showDiscardConfirm);
+  const [mode, setMode] = useState(args.mode);
+
+  return (
+    <RoomInfoContent
+      {...args}
+      mode={mode}
+      setMode={setMode}
+      visibility={{ showModal, showDeleteModal, showDiscardConfirm }}
+      setShowModal={setShowModal}
+      setShowDeleteModal={setShowDeleteModal}
+      setShowDiscardConfirm={setShowDiscardConfirm}
+    />
+  );
+};
+
+/** Only `<dialog open>` is painted; the closed ones stay mounted and inert. */
+const openDialogs = () => Array.from(document.querySelectorAll<HTMLElement>('dialog[open]'));
+
+const findOpenDialogTitled = (title: string): HTMLElement => {
+  const match = openDialogs().find((dialog) =>
+    within(dialog).queryByRole('heading', { name: title })
+  );
+  if (!match) throw new Error(`No open dialog titled "${title}"`);
+  return match;
+};
+
+const meta = {
+  title: 'Organization/RoomInfoContent',
+  component: RoomInfoContent,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The room detail drawer on the Organization > Rooms screen, and the two confirmation ' +
+          'dialogs that open on top of it.\n\n' +
+          'All three surfaces are gated, and the two confirms are gated **twice over** - the drawer ' +
+          'has to be open before the pencil or the trash exists at all. None of them had ever been ' +
+          'drawn.\n\n' +
+          'They are also not siblings in the tree the way they look on screen. Every one of them ' +
+          'goes through `ModalBase`, which `createPortal`s to `document.body`, so an open confirm is ' +
+          "the drawer's DOM sibling rather than its child. That is load-bearing: `ModalBase` keeps a " +
+          'module-level stack so only the topmost dialog answers Escape or a backdrop press, and ' +
+          'ref-counts the body scroll lock so closing the confirm does not unlock the page behind ' +
+          'the drawer that is still open. Neither behaviour is observable without two dialogs open ' +
+          'at once, which is exactly what the stories below produce.\n\n' +
+          'It also means the closed confirms are always in the DOM. They are `<dialog>` elements ' +
+          'without `open`, marked `inert`, so a text query finds their headings whether or not they ' +
+          'are visible - the assertions here filter on `dialog[open]` for that reason, and a story ' +
+          'that merely asserted the heading exists would pass on a confirm that never opened.\n\n' +
+          'Both confirms end in a `grid grid-cols-2` action pair that mounts only with the dialog. ' +
+          'That is the same shape as the popover bug this work exists to catch - an invalid grid ' +
+          'template is dropped by the browser and six children silently collapse into one column - ' +
+          'so the delete story asserts the computed template really resolves to two tracks.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    activeRoom: ACTIVE_ROOM,
+    availabilityLabels: {
+      days: 'Mon - Fri',
+      species: 'Dog, Cat',
+      time: '09:00 - 17:30',
+    },
+    permissions: { canEditRoom: true },
+    customEquipmentName: '',
+    equipmentLabel: 'Otoscope, Digital scale',
+    formData: FORM_DATA,
+    state: { isDirty: true, saving: false, supportsUnits: false },
+    mode: 'view',
+    openSections: { details: true, availability: true, units: false, equipment: true },
+    roomTypeLabel: 'Exam room',
+    setMode: fn(),
+    setShowDeleteModal: fn(),
+    setShowDiscardConfirm: fn(),
+    setShowModal: fn(),
+    visibility: { showDeleteModal: false, showDiscardConfirm: false, showModal: true },
+    specialityLabel: 'Dermatology',
+    staffLabel: 'Dr. Weber',
+    totalUnits: 0,
+    options: OPTIONS,
+    onAddCustomEquipment: fn(),
+    onAddUnit: fn(),
+    onAvailabilityToggle: fn(),
+    onCloseDrawer: fn(),
+    onCustomEquipmentNameChange: fn(),
+    onDelete: fn(),
+    onDiscardChanges: fn(),
+    onFormChange: fn(),
+    onRoomTypeChange: fn(),
+    onSave: fn(),
+    onToggleSection: fn(),
+    onUpdateAvailability: fn(),
+    onUpdateUnit: fn(),
+  },
+  render: (args) => <RoomInfoHarness {...args} />,
+} satisfies Meta<typeof RoomInfoContent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Drawer: Story = {
+  name: 'Detail drawer (view)',
+  play: async () => {
+    // Exactly one painted dialog: the two confirms are mounted but closed.
+    await expect(openDialogs()).toHaveLength(1);
+
+    const drawer = findOpenDialogTitled('Consult 1');
+    await expect(within(drawer).getByText('Room')).toBeInTheDocument();
+    // The room type appears twice on purpose - as the header meta line and again
+    // as a Details row - so this is getAllByText, not getByText.
+    await expect(within(drawer).getAllByText('Exam room')).toHaveLength(2);
+    await expect(within(drawer).getByText('Dermatology')).toBeInTheDocument();
+    // The view mode is detail rows, not inputs - a form here would mean the
+    // mode branch leaked.
+    await expect(within(drawer).queryByRole('textbox')).toBeNull();
+    await expect(within(drawer).getByRole('button', { name: 'Edit room' })).toBeInTheDocument();
+    await expect(within(drawer).getByRole('button', { name: 'Delete room' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting drawer: a "Room" eyebrow over the room name, the type as meta, then the ' +
+          'Details / Availability / Unit type / Equipment sections as bordered label-value lists. ' +
+          'No footer, because there is nothing to save yet.',
+      },
+    },
+  },
+};
+
+export const DeleteConfirm: Story = {
+  name: 'Nested confirm: Delete room?',
+  play: async () => {
+    const drawer = findOpenDialogTitled('Consult 1');
+    await userEvent.click(within(drawer).getByRole('button', { name: 'Delete room' }));
+
+    // Two painted dialogs now - the confirm is a SIBLING of the drawer on
+    // document.body, not a child of it.
+    await expect(openDialogs()).toHaveLength(2);
+
+    const confirm = findOpenDialogTitled('Delete room?');
+    // Assert the confirm has its content, not merely that a flag flipped: the
+    // closed confirm is in the DOM too, so the weak check always passes.
+    await expect(within(confirm).getByText('Consult 1')).toBeInTheDocument();
+    const cancel = within(confirm).getByRole('button', { name: 'Cancel' });
+    await expect(within(confirm).getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+
+    /* The action pair is a `grid grid-cols-2` that only mounts with the dialog.
+       Assert the computed template really resolves to two tracks - a dropped or
+       malformed template collapses both buttons into one column and still looks
+       deliberate. */
+    const actions = cancel.parentElement as HTMLElement;
+    await expect(getComputedStyle(actions).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(2);
+    await expect(actions.children).toHaveLength(2);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The destructive confirm, opened from the drawer's trash chip. It names the room in bold " +
+          'inside the sentence rather than in its title, and pairs a neutral Cancel against the ' +
+          '`--danger-strong` Delete. This is the only render where the drawer and a confirm are ' +
+          'composited together.',
+      },
+    },
+  },
+};
+
+export const DiscardConfirm: Story = {
+  name: 'Nested confirm: Discard changes?',
+  args: { mode: 'edit' },
+  play: async () => {
+    // The discard confirm has no trigger of its own. It is raised by `canClose`
+    // refusing to dismiss a dirty edit - so Escape on the drawer is the path.
+    await userEvent.keyboard('{Escape}');
+
+    await expect(openDialogs()).toHaveLength(2);
+    const confirm = findOpenDialogTitled('Discard changes?');
+    await expect(within(confirm).getByText(/You have unsaved room changes/)).toBeInTheDocument();
+    await expect(within(confirm).getByRole('button', { name: 'Keep editing' })).toBeInTheDocument();
+    await expect(within(confirm).getByRole('button', { name: 'Discard' })).toBeInTheDocument();
+
+    // The drawer must still be open behind it - refusing to close is the whole
+    // point of the guard.
+    await expect(findOpenDialogTitled('Edit room')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Reached by pressing Escape while the drawer is in edit mode with unsaved changes. ' +
+          '`canClose` returns `false`, which both blocks the dismissal and raises this dialog, so ' +
+          'the confirm and the drawer it is protecting are on screen together. There is no prop or ' +
+          'button that opens it directly.',
+      },
+    },
+  },
+};
+
+export const EditMode: Story = {
+  name: 'Edit mode',
+  args: { mode: 'edit' },
+  play: async () => {
+    const drawer = findOpenDialogTitled('Edit room');
+    // The title changes and the detail rows become editors.
+    await expect(within(drawer).getAllByRole('textbox').length).toBeGreaterThan(0);
+    await expect(within(drawer).getByRole('button', { name: 'Save' })).toBeInTheDocument();
+    await expect(within(drawer).getByRole('button', { name: 'Discard' })).toBeInTheDocument();
+    // The pencil is gone - you are already editing - but the trash stays.
+    await expect(within(drawer).queryByRole('button', { name: 'Edit room' })).toBeNull();
+    await expect(within(drawer).getByRole('button', { name: 'Delete room' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Every section swaps its label-value rows for inputs, the header title becomes "Edit ' +
+          'room", and a footer appears with Discard and Save. The pencil is dropped rather than ' +
+          'disabled, so the header actions re-flow - which is only visible against the view story.',
+      },
+    },
+  },
+};
+
+export const Saving: Story = {
+  name: 'Edit mode (saving)',
+  args: { mode: 'edit', state: { isDirty: true, saving: true, supportsUnits: false } },
+  play: async () => {
+    const drawer = findOpenDialogTitled('Edit room');
+    await expect(within(drawer).getByRole('button', { name: 'Saving...' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'While a save is in flight the primary relabels to "Saving..." but keeps its check icon ' +
+          'and stays pressable - the guard is upstream, not here.',
+      },
+    },
+  },
+};
+
+export const ReadOnly: Story = {
+  name: 'Without edit permission',
+  args: { permissions: { canEditRoom: false } },
+  play: async () => {
+    const drawer = findOpenDialogTitled('Consult 1');
+    // Both header chips are dropped, not disabled, so there is no affordance
+    // suggesting an edit that cannot happen - and the delete confirm is
+    // unreachable from this render at all.
+    await expect(within(drawer).queryByRole('button', { name: 'Edit room' })).toBeNull();
+    await expect(within(drawer).queryByRole('button', { name: 'Delete room' })).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A member without room-edit permission gets the same detail drawer with an empty actions ' +
+          'slot, so the close button sits alone against the title.',
+      },
+    },
+  },
+};
+
+export const SupportsUnits: Story = {
+  name: 'Ward room with units',
+  args: {
+    activeRoom: { ...ACTIVE_ROOM, id: 'room-icu', name: 'ICU ward', code: 'ICU', type: 'ICU' },
+    formData: {
+      ...FORM_DATA,
+      id: 'room-icu',
+      name: 'ICU ward',
+      code: 'ICU',
+      type: 'ICU',
+      availability: { ...FORM_DATA.availability, totalUnits: 3 },
+      units: [
+        { id: 'unit-1', name: 'Kennel A', size: 'Large', count: 1, occupied: true },
+        { id: 'unit-2', name: 'Kennel B', size: 'Medium', count: 2 },
+      ],
+    },
+    state: { isDirty: false, saving: false, supportsUnits: true },
+    openSections: { details: true, availability: true, units: true, equipment: true },
+    roomTypeLabel: 'ICU',
+    totalUnits: 3,
+  },
+  play: async () => {
+    const drawer = findOpenDialogTitled('ICU ward');
+    // The units section only has content for ICU/Inpatient/Isolation/Boarding;
+    // every other type shows a "select one of these" note instead.
+    await expect(within(drawer).getByText('Unit type (2)')).toBeInTheDocument();
+    /* Each unit name renders twice on purpose - once as the fieldset's legend
+       and again as the "Name" row inside that same fieldset - so this is
+       getAllByText. Two fieldsets means two pairs. */
+    await expect(within(drawer).getAllByText('Kennel A')).toHaveLength(2);
+    await expect(within(drawer).getAllByText('Kennel B')).toHaveLength(2);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The only room types that carry units are ICU, Inpatient, Isolation and Boarding. Each ' +
+          'unit renders as a `<fieldset>` with its name as the legend, which is a different box ' +
+          'from every other section in the drawer.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/RoomInfoSections.stories.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/RoomInfoSections.stories.tsx
@@ -1,0 +1,379 @@
+import { useState, type ComponentProps } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+
+import type { ManagedRoom } from './RoomInfo.types';
+import RoomInfoSections, { type OpenSections } from './RoomInfoSections';
+
+const ROOM: ManagedRoom = {
+  id: 'room-icu-1',
+  organisationId: 'org-storybook',
+  name: 'ICU Bay A',
+  code: 'ICU-A',
+  type: 'ICU',
+  assignedSpecialiteis: ['spec-surgery'],
+  assignedStaffs: ['staff-1', 'staff-2'],
+  availability: {
+    isAvailable: true,
+    days: 'MON_SAT',
+    startTime: '08:00',
+    endTime: '20:00',
+    species: ['CANINE', 'FELINE'],
+    totalUnits: 6,
+  },
+  units: [
+    { id: 'unit-1', name: 'Small kennel', size: 'Small', count: 4 },
+    { id: 'unit-2', name: 'Oxygen cage', size: 'Large', count: 2 },
+  ],
+  equipment: ['Oxygen Tank', 'Heating Support'],
+};
+
+const EXAM_ROOM: ManagedRoom = {
+  ...ROOM,
+  id: 'room-exam-2',
+  name: 'Exam 2',
+  code: 'EX-02',
+  type: 'EXAM_ROOM',
+  units: [],
+  availability: { ...ROOM.availability, totalUnits: 0 },
+};
+
+const OPTIONS = {
+  equipment: ['Warming blanket'],
+  specialities: [
+    { label: 'Surgery', value: 'spec-surgery' },
+    { label: 'Internal medicine', value: 'spec-internal' },
+    { label: 'Dermatology', value: 'spec-derm' },
+  ],
+  team: [
+    { label: 'Dr. Lena Hartmann', value: 'staff-1' },
+    { label: 'Nurse Priya Raman', value: 'staff-2' },
+    { label: 'Tech Marisol Vega', value: 'staff-3' },
+  ],
+};
+
+const ALL_OPEN: OpenSections = {
+  details: true,
+  availability: true,
+  units: true,
+  equipment: true,
+};
+
+const ALL_CLOSED: OpenSections = {
+  details: false,
+  availability: false,
+  units: false,
+  equipment: false,
+};
+
+type SectionsProps = ComponentProps<typeof RoomInfoSections>;
+type HarnessProps = Omit<SectionsProps, 'onToggleSection'>;
+
+/**
+ * `openSections` is owned by `useRoomInfoController` in the real screen, so the
+ * headers are inert without a state holder. `openSections` here is the initial
+ * value and is re-synced when the arg changes, which is what lets a `play`
+ * function open a section the story started with closed.
+ */
+const RoomInfoSectionsHarness = ({ openSections, ...rest }: HarnessProps) => {
+  const [sections, setSections] = useState(openSections);
+  const [prevSections, setPrevSections] = useState(openSections);
+  if (prevSections !== openSections) {
+    setPrevSections(openSections);
+    setSections(openSections);
+  }
+
+  return (
+    <RoomInfoSections
+      {...rest}
+      openSections={sections}
+      onToggleSection={(section) =>
+        setSections((current) => ({ ...current, [section]: !current[section] }))
+      }
+    />
+  );
+};
+
+const meta = {
+  title: 'Organization/RoomInfoSections',
+  component: RoomInfoSectionsHarness,
+  decorators: [
+    (Story) => (
+      <div className="flex h-[720px] w-[520px] flex-col">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'The body of the room drawer: four collapsible sections - Details, Availability, Unit ' +
+          'type, Equipments / Capabilities - inside one `overflow-y-auto` column.\n\n' +
+          'This component is almost entirely gated surface. Every section body is behind ' +
+          '`openSections[key] &&`, so a closed section contributes **nothing** to the DOM, and ' +
+          '`openSections` is owned by `useRoomInfoController` several levels up - which means no ' +
+          'static render of the drawer has ever contained the bodies at all.\n\n' +
+          'Worse, each open section then forks again on `mode`. `details` renders either a ' +
+          '`DetailRows` definition list (a `grid-cols-[1fr_1.2fr]` `<dl>` with right-aligned ' +
+          'values, wrapped in a `rounded-2xl` bordered box) **or** a `grid-cols-1 sm:grid-cols-2` ' +
+          'of live inputs and two portalled dropdowns. They share no markup. That is eight ' +
+          'distinct bodies from one component, seven of which were never drawn.\n\n' +
+          'Two of those bodies also swap on `supportsUnits`, which is derived from the room type ' +
+          '(`ICU`, `INPATIENT`, `ISOLATION`, `BOARDING`): with it, availability gets a Total Units ' +
+          'field and the units section gets an add button; without it, both are replaced by ' +
+          'explanatory `rounded-2xl` paragraphs. So an exam room and an ICU bay are different ' +
+          'layouts, not the same layout with a field hidden.\n\n' +
+          'The edit bodies additionally carry five dropdowns whose panels `createPortal` to ' +
+          '`document.body` - two more interactions deep again, and outside this subtree entirely. ' +
+          'One of them is opened below.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    canEditRoom: true,
+    customEquipmentName: '',
+    equipmentLabel: 'Oxygen Tank, Heating Support',
+    formData: ROOM,
+    mode: 'view',
+    openSections: ALL_CLOSED,
+    roomTypeLabel: 'ICU',
+    specialityLabel: 'Surgery',
+    staffLabel: 'Dr. Lena Hartmann\nNurse Priya Raman',
+    supportsUnits: true,
+    totalUnits: 6,
+    availabilityLabels: {
+      days: 'Mon - Sat',
+      species: 'Canine, Feline',
+      time: '08:00 - 20:00',
+    },
+    options: OPTIONS,
+    onAddCustomEquipment: fn(),
+    onAddUnit: fn(),
+    onAvailabilityToggle: fn(),
+    onCustomEquipmentNameChange: fn(),
+    onFormChange: fn(),
+    onRoomTypeChange: fn(),
+    onUpdateAvailability: fn(),
+    onUpdateUnit: fn(),
+  },
+} satisfies Meta<typeof RoomInfoSectionsHarness>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const AllCollapsed: Story = {
+  name: 'All sections collapsed',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Four headers, four bodies that do not exist. The chevron rotation is the
+    // only thing on screen that differs between this and the open state.
+    await expect(canvas.getByRole('button', { name: 'Details' })).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
+    await expect(canvas.queryByText('Room Code')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Assigned staff')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Oxygen Tank, Heating Support')).not.toBeInTheDocument();
+    // The availability toggle lives in the header, so it survives the collapse.
+    await expect(canvas.getByRole('switch', { name: 'Toggle room availability' })).toBeChecked();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The drawer as it opens. Only the four headers, the "Available now" meta and the ' +
+          'availability switch are rendered - everything else is unmounted.',
+      },
+    },
+  },
+};
+
+export const OpenedByClicking: Story = {
+  name: 'Opened one header at a time',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Details' }));
+    // Assert the body mounted its rows, not just that aria-expanded flipped -
+    // the weak check passes on an empty section.
+    await expect(await canvas.findByText('Room Code')).toBeInTheDocument();
+    await expect(canvas.getByText('ICU-A')).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Availability' }));
+    await expect(await canvas.findByText('Assigned staff')).toBeInTheDocument();
+    await expect(canvas.getByText('Mon - Sat')).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Unit type (2)' }));
+    // Each unit name renders twice - once as the fieldset legend, once as the
+    // "Name" row inside it - which is only apparent with the section open.
+    await expect(await canvas.findAllByText('Small kennel')).toHaveLength(2);
+    await expect(canvas.getAllByText('Oxygen cage')).toHaveLength(2);
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Equipments / Capabilities' }));
+    await expect(await canvas.findByText('Oxygen Tank, Heating Support')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The disclosure path itself: each `SectionHeader` calls `onToggleSection(key)` and the ' +
+          'controller flips one flag. Four clicks take the drawer from four headers to its full ' +
+          'height, and every intermediate state is a real layout the user sees.',
+      },
+    },
+  },
+};
+
+export const ViewExpanded: Story = {
+  name: 'View mode, all open',
+  args: { openSections: ALL_OPEN },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Room Code')).toBeInTheDocument();
+    await expect(canvas.getByText('Speciality')).toBeInTheDocument();
+    await expect(canvas.getByText('Days')).toBeInTheDocument();
+    await expect(canvas.getByText('Total units')).toBeInTheDocument();
+    // Each unit is its own <fieldset>/<legend> with a nested, unbordered DetailRows.
+    await expect(canvas.getAllByRole('group')).toHaveLength(2);
+    // "Name" is a dt in Details AND in both unit blocks - three of them.
+    await expect(canvas.getAllByText('Name')).toHaveLength(3);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'All four read bodies at once. The three top sections use the **bordered** `DetailRows` ' +
+          'box; the unit blocks use the unbordered variant inside a `fieldset` with a `legend`, so ' +
+          'the same `<dl>` appears with and without its own frame in one scroll. Assigned staff is ' +
+          'the only value with `whitespace-pre-line`, so it is the only row that grows vertically.',
+      },
+    },
+  },
+};
+
+export const EditExpanded: Story = {
+  name: 'Edit mode, all open',
+  args: { openSections: ALL_OPEN, mode: 'edit' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // A completely different tree from the view bodies: live inputs everywhere.
+    await expect(canvas.getByLabelText('Room code')).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Room Type: ICU' })).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('button', { name: 'Speciality (optional): Surgery' })
+    ).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: /^Start time/ })).toBeInTheDocument();
+    await expect(canvas.getByLabelText('Total Units')).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Add unit type' })).toBeInTheDocument();
+    await expect(canvas.getByLabelText('Add equipment name')).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Add custom equipment' })).toBeInTheDocument();
+    // One "Name" per unit editor plus the room's own.
+    await expect(canvas.getAllByLabelText('Name')).toHaveLength(3);
+    // The read-mode definition lists are gone entirely, not restyled.
+    await expect(canvas.queryByText('Room Code')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The seven-editor tree behind `mode === "edit"`. The unit blocks switch from a ' +
+          '`border-card-border` fieldset to a `border-blue-text` box, which is the only signal ' +
+          'that they became editable; the equipment section grows an "add custom" row whose 48px ' +
+          'square button has to bottom-align (`items-end`) with a field that carries a label above ' +
+          'it. Nothing here is reachable without both `mode` and the section flag set.',
+      },
+    },
+  },
+};
+
+export const RoomTypeDropdownOpen: Story = {
+  name: 'Edit mode, room-type listbox open',
+  args: { openSections: ALL_OPEN, mode: 'edit' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Room Type: ICU' }));
+    // The panel portals to document.body, so it is outside the drawer's own
+    // overflow-y-auto column - the reason it is not clipped by it.
+    await waitFor(() =>
+      expect(document.querySelector('[data-portal-dropdown]')).toBeInTheDocument()
+    );
+    const panel = document.querySelector('[data-portal-dropdown]') as HTMLElement;
+    // Assert all thirteen room types rendered. An empty panel would satisfy the
+    // trigger's aria-expanded just as well.
+    await expect(within(panel).getAllByRole('button')).toHaveLength(13);
+    await expect(within(panel).getByText('Boarding')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Thirteen room types in a panel capped at 200px, so it scrolls - and picking one of the ' +
+          'four unit-capable types from it is what re-renders the two sections above into their ' +
+          'other layout. This is the control that switches the whole drawer between the two ' +
+          'shapes shown in the next story.',
+      },
+    },
+  },
+};
+
+export const ExamRoomWithoutUnits: Story = {
+  name: 'Edit mode, room type without units',
+  args: {
+    openSections: ALL_OPEN,
+    mode: 'edit',
+    formData: EXAM_ROOM,
+    supportsUnits: false,
+    roomTypeLabel: 'Exam room',
+    totalUnits: 0,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Both replacements, in two different sections, from one derived boolean.
+    await expect(
+      canvas.getByText('Units are available for ICU, Inpatient, Isolation, and Boarding rooms.')
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByText('Select ICU, Inpatient, Isolation, or Boarding to configure unit types.')
+    ).toBeInTheDocument();
+    // The Total Units field and the add button are gone rather than disabled.
+    await expect(canvas.queryByLabelText('Total Units')).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Add unit type' })).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'An exam room. `supportsUnits` false replaces the Total Units input with a `sm:col-span-2` ' +
+          'explanatory paragraph - so the availability grid loses a cell and the Assigned Staff row ' +
+          'moves up - and empties the unit section down to one line. Two sections change shape from ' +
+          'one derived boolean, and neither change is visible unless both are open.',
+      },
+    },
+  },
+};
+
+export const ReadOnlyAvailabilityToggle: Story = {
+  name: 'Availability switch locked',
+  args: { openSections: ALL_OPEN, canEditRoom: false },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const toggle = canvas.getByRole('switch', { name: 'Toggle room availability' });
+    // Genuinely disabled, not just dimmed: the switch keeps its role and state
+    // so assistive tech still reports the room as available.
+    await expect(toggle).toBeDisabled();
+    await expect(toggle).toBeChecked();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'For a role without room-edit permission the switch is `disabled`, taking ' +
+          '`cursor-not-allowed opacity-60`, while the section bodies stay fully readable. The ' +
+          'toggle sits in the header, so this is the one control that is visible whether or not ' +
+          'the section is open.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/RoomInfoSections.stories.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/RoomInfoSections.stories.tsx
@@ -198,21 +198,21 @@ export const OpenedByClicking: Story = {
     await userEvent.click(canvas.getByRole('button', { name: 'Details' }));
     // Assert the body mounted its rows, not just that aria-expanded flipped -
     // the weak check passes on an empty section.
-    await expect(await canvas.findByText('Room Code')).toBeInTheDocument();
+    expect(await canvas.findByText('Room Code')).toBeInTheDocument();
     await expect(canvas.getByText('ICU-A')).toBeInTheDocument();
 
     await userEvent.click(canvas.getByRole('button', { name: 'Availability' }));
-    await expect(await canvas.findByText('Assigned staff')).toBeInTheDocument();
+    expect(await canvas.findByText('Assigned staff')).toBeInTheDocument();
     await expect(canvas.getByText('Mon - Sat')).toBeInTheDocument();
 
     await userEvent.click(canvas.getByRole('button', { name: 'Unit type (2)' }));
     // Each unit name renders twice - once as the fieldset legend, once as the
     // "Name" row inside it - which is only apparent with the section open.
-    await expect(await canvas.findAllByText('Small kennel')).toHaveLength(2);
+    expect(await canvas.findAllByText('Small kennel')).toHaveLength(2);
     await expect(canvas.getAllByText('Oxygen cage')).toHaveLength(2);
 
     await userEvent.click(canvas.getByRole('button', { name: 'Equipments / Capabilities' }));
-    await expect(await canvas.findByText('Oxygen Tank, Heating Support')).toBeInTheDocument();
+    expect(await canvas.findByText('Oxygen Tank, Heating Support')).toBeInTheDocument();
   },
   parameters: {
     docs: {

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Team/PermissionsEditor.stories.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Team/PermissionsEditor.stories.tsx
@@ -1,0 +1,283 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import PermissionsEditor from './PermissionsEditor';
+import { ROLE_PERMISSIONS } from '@/app/lib/permissions';
+
+/** Opens the accordion, which is the only way the matrix reaches the DOM. */
+const openMatrix = async (canvasElement: HTMLElement) => {
+  const canvas = within(canvasElement);
+  await userEvent.click(canvas.getByRole('button', { name: 'Permissions' }));
+  return canvas;
+};
+
+const meta = {
+  title: 'Organization/PermissionsEditor',
+  component: PermissionsEditor,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The per-membership permission matrix on the Team screen: eighteen rows, a View and an ' +
+          'Edit checkbox each, a reset link and a Cancel/Save bar.\n\n' +
+          'All of it lives inside an `Accordion` with `defaultOpen={false}`, and that accordion ' +
+          '**unmounts its children when closed** rather than hiding them - `{open && hasChildren && ' +
+          '(...)}`. Without a click nothing below the header exists in the DOM at all, so the entire ' +
+          'matrix, every checkbox state and the whole save bar had never been rendered in Storybook. ' +
+          'The header is not a disclosure over static markup; it is the mount.\n\n' +
+          'What that hid is a table with four distinct row treatments that no two of which appear ' +
+          'together by default. Audit Logs has no `edit` group, so its Edit cell is an em dash and ' +
+          'not an unchecked box - 18 View boxes against 17 Edit boxes. For an OWNER the Teams and ' +
+          'Organization rows are `ownerLocked`: both boxes are forced checked, disabled, and ' +
+          'carry the title "An owner keeps this permission", because those two rows gate the screens ' +
+          'an owner would use to undo the change. Everything else is a live toggle, and turning View ' +
+          'off cascades Edit off with it.\n\n' +
+          'The Cancel/Save bar is gated twice over - `!readOnly && isDirty` - so it only exists after ' +
+          'a toggle, and the "Saving..." relabel exists only while `onSave` is in flight. The stories ' +
+          'drive both by toggling a real checkbox and by handing `onSave` a promise that never ' +
+          'settles, which is the only way to reach them.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    role: 'VETERINARIAN',
+    value: ROLE_PERMISSIONS.VETERINARIAN,
+    onSave: fn(),
+  },
+} satisfies Meta<typeof PermissionsEditor>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Collapsed: Story = {
+  name: 'Collapsed (children unmounted)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('button', { name: 'Permissions' })).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
+    // Not hidden - absent. This is what every earlier snapshot of this file contained.
+    await expect(canvas.queryAllByRole('checkbox')).toHaveLength(0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'How the row sits on the Team screen until someone opens it.',
+      },
+    },
+  },
+};
+
+export const Open: Story = {
+  name: 'Matrix open',
+  play: async ({ canvasElement }) => {
+    const canvas = await openMatrix(canvasElement);
+
+    /* Assert the matrix has its rows, not merely that aria-expanded flipped -
+       an empty accordion body satisfies the attribute just as well. */
+    const boxes = await canvas.findAllByRole('checkbox');
+    await expect(boxes).toHaveLength(35);
+
+    await expect(canvas.getByText('Permission')).toBeInTheDocument();
+    await expect(canvas.getByText('View')).toBeInTheDocument();
+    await expect(canvas.getByText('Edit')).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('button', { name: 'Reset to role defaults' })
+    ).toBeInTheDocument();
+
+    // Audit Logs has no `edit` group, so it contributes a View box and an em dash.
+    await expect(canvas.getByLabelText('Audit Logs view permission')).toBeInTheDocument();
+    await expect(canvas.queryByLabelText('Audit Logs edit permission')).toBeNull();
+    await expect(canvas.getByText('—')).toBeInTheDocument();
+
+    // The baseline is reflected, not assumed: a vet holds inventory view and edit.
+    await expect(canvas.getByLabelText('Inventory view permission')).toBeChecked();
+    await expect(canvas.getByLabelText('Inventory edit permission')).toBeChecked();
+    // ...and holds Teams view without Teams edit.
+    await expect(canvas.getByLabelText('Teams view permission')).toBeChecked();
+    await expect(canvas.getByLabelText('Teams edit permission')).not.toBeChecked();
+
+    // Clean state: no save bar yet.
+    await expect(canvas.queryByRole('button', { name: 'Save' })).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The whole matrix for a veterinarian. Eighteen rows on a shared `yc-table-head`, two 72px ' +
+          'centred columns, and a hairline under every row but the last.',
+      },
+    },
+  },
+};
+
+export const ViewOffCascadesEdit: Story = {
+  name: 'Turning View off clears Edit',
+  play: async ({ canvasElement }) => {
+    const canvas = await openMatrix(canvasElement);
+    const view = await canvas.findByLabelText('Inventory view permission');
+    const edit = canvas.getByLabelText('Inventory edit permission');
+    await expect(view).toBeChecked();
+    await expect(edit).toBeChecked();
+
+    await userEvent.click(view);
+
+    // `applyToggle` removes the edit candidates alongside the view ones.
+    await expect(view).not.toBeChecked();
+    await expect(edit).not.toBeChecked();
+    // The bar is gated on `isDirty`, so it only exists now.
+    await expect(canvas.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'An edit right without the matching view right is not a state the app can render, so ' +
+          'clearing View takes Edit with it. Two checkboxes move from one click, which is only ' +
+          'visible with the matrix mounted.',
+      },
+    },
+  },
+};
+
+export const EditOnEnablesView: Story = {
+  name: 'Turning Edit on adds View',
+  play: async ({ canvasElement }) => {
+    const canvas = await openMatrix(canvasElement);
+    const view = await canvas.findByLabelText('Documents view permission');
+    const edit = canvas.getByLabelText('Documents edit permission');
+    await expect(view).toBeChecked();
+    await expect(edit).not.toBeChecked();
+
+    // Clear both, then switch Edit on alone - View must come back with it.
+    await userEvent.click(view);
+    await expect(edit).not.toBeChecked();
+    await userEvent.click(edit);
+
+    await expect(edit).toBeChecked();
+    await expect(view).toBeChecked();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The mirror rule: `withViewEnabled` puts the view tier back whenever an edit tier is ' +
+          'switched on, so the pair can never end up half-granted. Reachable only by clicking two ' +
+          'boxes in order, which is why it needed a `play` rather than an arg.',
+      },
+    },
+  },
+};
+
+export const DirtyBar: Story = {
+  name: 'Cancel restores the baseline',
+  play: async ({ canvasElement }) => {
+    const canvas = await openMatrix(canvasElement);
+    const labs = await canvas.findByLabelText('Labs edit permission');
+    await expect(labs).toBeChecked();
+
+    await userEvent.click(labs);
+    await expect(labs).not.toBeChecked();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Cancel' }));
+
+    await expect(labs).toBeChecked();
+    // Back in step with `value`, so the bar disappears again.
+    await expect(canvas.queryByRole('button', { name: 'Save' })).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Cancel resets the draft to the incoming `value` rather than to the role baseline - the ' +
+          'reset link beside the header is the one that does the latter. Both live on this surface ' +
+          'and mean different things, which is only apparent with both drawn.',
+      },
+    },
+  },
+};
+
+export const Saving: Story = {
+  name: 'Saving (pending)',
+  args: {
+    // Never resolves, so the pending relabel stays on screen for review.
+    onSave: fn(() => new Promise<void>(() => {})),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = await openMatrix(canvasElement);
+    await userEvent.click(await canvas.findByLabelText('Forms edit permission'));
+    await userEvent.click(canvas.getByRole('button', { name: 'Save' }));
+
+    const saving = await canvas.findByRole('button', { name: 'Saving...' });
+    await expect(saving).toBeDisabled();
+    await expect(canvas.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Both actions disable and Save relabels while the promise is open. There is no prop for ' +
+          'this - it exists only between a click and a resolution.',
+      },
+    },
+  },
+};
+
+export const OwnerLockedRows: Story = {
+  name: 'Owner (Teams and Organization locked)',
+  args: { role: 'OWNER', value: ROLE_PERMISSIONS.OWNER },
+  play: async ({ canvasElement }) => {
+    const canvas = await openMatrix(canvasElement);
+    const teamsView = await canvas.findByLabelText('Teams view permission');
+
+    // Forced on and inert, with the reason in a title attribute.
+    await expect(teamsView).toBeChecked();
+    await expect(teamsView).toBeDisabled();
+    await expect(teamsView).toHaveAttribute('title', 'An owner keeps this permission');
+    await expect(canvas.getByLabelText('Teams edit permission')).toBeDisabled();
+    await expect(canvas.getByLabelText('Organization view permission')).toBeDisabled();
+    await expect(canvas.getByLabelText('Organization edit permission')).toBeDisabled();
+
+    // Every other row is still a live toggle, so the lock has to read as local.
+    await expect(canvas.getByLabelText('Labs edit permission')).toBeEnabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The two rows an owner cannot revoke, because Teams and Organization are the screens they ' +
+          'would use to reverse the change. The lock is a disabled checked box plus a title, with no ' +
+          'visual difference from an ordinary checked box - which is exactly the kind of thing worth ' +
+          'looking at rather than asserting alone.',
+      },
+    },
+  },
+};
+
+export const ReadOnly: Story = {
+  name: 'Read-only',
+  args: { readOnly: true },
+  play: async ({ canvasElement }) => {
+    const canvas = await openMatrix(canvasElement);
+    const boxes = await canvas.findAllByRole('checkbox');
+    await expect(boxes).toHaveLength(35);
+    await expect(boxes.every((box) => box.hasAttribute('disabled'))).toBe(true);
+    // The reset link and the save bar are removed rather than dimmed.
+    await expect(canvas.queryByRole('button', { name: 'Reset to role defaults' })).toBeNull();
+    await expect(canvas.queryByRole('button', { name: 'Save' })).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'What a member without Teams edit sees. The matrix still renders in full - it is the ' +
+          'record of what the role holds - but every control is inert and the two write affordances ' +
+          'are gone entirely.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/organization/pages/Specialities/PackageBreakdownSearch.stories.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Specialities/PackageBreakdownSearch.stories.tsx
@@ -277,7 +277,7 @@ export const TypingFindsNothing: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await userEvent.type(canvas.getByLabelText('Search catalog items'), 'ultrasound');
-    await expect(await canvas.findByText('No items found.')).toBeInTheDocument();
+    expect(await canvas.findByText('No items found.')).toBeInTheDocument();
   },
   parameters: {
     docs: {

--- a/apps/frontend/src/app/features/organization/pages/Specialities/PackageBreakdownSearch.stories.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Specialities/PackageBreakdownSearch.stories.tsx
@@ -1,0 +1,292 @@
+import { useState, type ComponentProps } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import PackageBreakdownSearch from './PackageBreakdownSearch';
+import type { CatalogEntry } from './packageFormDraftHelpers';
+
+const entry = (
+  id: string,
+  name: string,
+  type: CatalogEntry['type'],
+  unitPrice: number,
+  currency?: string
+): CatalogEntry => ({
+  id,
+  name,
+  type,
+  unitPrice,
+  currency,
+  defaultDiscount: 0,
+  maxDiscount: 20,
+  isBookable: type === 'CONSULTATION' || type === 'PROCEDURE',
+  isInpatientPreferred: false,
+});
+
+const CATALOG: CatalogEntry[] = [
+  entry('cat-1', 'Dermatology consult', 'CONSULTATION', 85),
+  entry('cat-2', 'Dental scale and polish', 'PROCEDURE', 240),
+  entry('cat-3', 'Full blood panel', 'LAB', 62),
+  entry('cat-4', 'Meloxicam 1.5mg/ml oral suspension', 'MEDICATION', 18),
+  entry('cat-5', 'Elizabethan collar (medium)', 'INVENTORY', 9),
+  entry('cat-6', 'Senior wellness plan', 'PACKAGE', 310),
+];
+
+type SearchProps = ComponentProps<typeof PackageBreakdownSearch>;
+
+/**
+ * The component is fully controlled - the package form owns the query and does the
+ * filtering - so this harness plays that parent. It is what makes the dropdown reachable
+ * by typing rather than by handing it a pre-filled `filteredSearch`, which is how it
+ * actually appears in the product.
+ */
+const SearchHarness = (args: SearchProps) => {
+  const [query, setQuery] = useState(args.searchQuery);
+  const trimmed = query.trim().toLowerCase();
+  const results = trimmed
+    ? CATALOG.filter((item) => item.name.toLowerCase().includes(trimmed))
+    : [];
+  return (
+    <div className="w-[560px] max-w-full p-6 pb-56">
+      <PackageBreakdownSearch
+        {...args}
+        searchQuery={query}
+        filteredSearch={results}
+        onQueryChange={(value) => {
+          setQuery(value);
+          args.onQueryChange(value);
+        }}
+      />
+    </div>
+  );
+};
+
+/** The panel carries no role or label, so it is reached through a row it contains. */
+const panelFor = (canvasElement: HTMLElement, rowName: RegExp) =>
+  within(canvasElement).getByRole('button', { name: rowName }).parentElement as HTMLElement;
+
+const meta = {
+  title: 'Organization/PackageBreakdownSearch',
+  component: PackageBreakdownSearch,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The catalog picker at the top of a package breakdown. The 42px field is all that ever ' +
+          'showed in a snapshot; everything below it is conditional on data that only exists mid-' +
+          'typing, so neither panel had been drawn.\n\n' +
+          'There are **two** panels, not one, and they are separate elements with different ' +
+          'padding: the results list (`overflow-hidden`, rows at `px-4 py-2`) and the "No items ' +
+          'found." card (`px-4 py-3`). Both are `absolute top-full left-0 right-0 z-50 mt-1` over ' +
+          'a `--screen` fill with a `card-border` hairline, so they overlay whatever follows the ' +
+          'field rather than pushing it down - which means a regression to static positioning ' +
+          'shoves the entire breakdown table down the page instead of failing visibly.\n\n' +
+          'The three conditions are mutually exclusive by arithmetic rather than by an explicit ' +
+          'branch: results render when `filteredSearch.length > 0`, the empty card when there is a ' +
+          'trimmed query, no results **and** `searchLoading` is false. Nothing renders while a ' +
+          'search is in flight - deliberately, so the panel does not flicker between keystrokes - ' +
+          'and that silent third state is drawn below as well, since it is indistinguishable from ' +
+          'a broken dropdown unless you know it is intended.\n\n' +
+          'Each row pairs the item name against a right-aligned `TYPE_LABELS[type] · price`, with ' +
+          'the price formatted in the item currency where it has one and the organisation currency ' +
+          'otherwise. The stories assert the rows carry that text, not merely that a panel ' +
+          'appeared: an empty panel satisfies the weaker check.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    searchQuery: '',
+    filteredSearch: [],
+    searchLoading: false,
+    orgCurrency: 'USD',
+    onQueryChange: fn(),
+    onSelectItem: fn(),
+  },
+} satisfies Meta<typeof PackageBreakdownSearch>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Closed: Story = {
+  name: 'Field only',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByLabelText('Search catalog items')).toBeInTheDocument();
+    await expect(canvas.queryByText('No items found.')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'The resting state the breakdown section opens on: an empty `--field-bg` pill.',
+      },
+    },
+  },
+};
+
+export const TypingOpensResults: Story = {
+  name: 'Typing opens the results panel',
+  render: (args) => <SearchHarness {...args} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.type(canvas.getByLabelText('Search catalog items'), 'de');
+    const panel = panelFor(canvasElement, /Dermatology consult/);
+    // Assert the panel has its rows and that they carry both halves of their line -
+    // an empty overlay would satisfy "the dropdown opened" on its own.
+    const rows = within(panel).getAllByRole('button');
+    await expect(rows).toHaveLength(2);
+    await expect(rows[0]).toHaveTextContent('Dermatology consult');
+    await expect(rows[0]).toHaveTextContent('Consultation · $85');
+    await expect(rows[1]).toHaveTextContent('Dental scale and polish');
+    await expect(rows[1]).toHaveTextContent('Procedure · $240');
+    // It overlays the rest of the form rather than displacing it.
+    await expect(getComputedStyle(panel).position).toBe('absolute');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Two of the six catalog items match "de". This is the panel as the form actually opens ' +
+          'it - by typing - rather than by being handed a pre-filled list.',
+      },
+    },
+  },
+};
+
+export const ResultsOpen: Story = {
+  name: 'Results panel (all types)',
+  args: { searchQuery: 'a', filteredSearch: CATALOG },
+  play: async ({ canvasElement }) => {
+    const panel = panelFor(canvasElement, /Dermatology consult/);
+    const rows = within(panel).getAllByRole('button');
+    await expect(rows).toHaveLength(6);
+    // One row per CatalogItemType, so every label in TYPE_LABELS is on screen at once.
+    await expect(panel).toHaveTextContent('Diagnostics · $62');
+    await expect(panel).toHaveTextContent('Medication · $18');
+    await expect(panel).toHaveTextContent('Inventory · $9');
+    await expect(panel).toHaveTextContent('Package · $310');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Every catalog type in one panel, which is the only way to see that `LAB` reads as ' +
+          '"Diagnostics" rather than "Lab" and that the longest medication name still keeps its ' +
+          'type and price on the same line. The panel is `overflow-hidden` with no scroller, so ' +
+          'its height is the row count - worth watching, since a real catalog returns more.',
+      },
+    },
+  },
+};
+
+export const ForeignCurrency: Story = {
+  name: 'Row currency overrides the org currency',
+  args: {
+    searchQuery: 'consult',
+    filteredSearch: [
+      entry('cat-7', 'Dermatology consult', 'CONSULTATION', 85),
+      entry('cat-8', 'Referral consult (Frankfurt)', 'CONSULTATION', 140, 'EUR'),
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const panel = panelFor(canvasElement, /Dermatology consult/);
+    await expect(panel).toHaveTextContent('Consultation · $85');
+    await expect(panel).toHaveTextContent('Consultation · €140');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'An item carrying its own `currency` is priced in it; everything else falls back to the ' +
+          "organisation's. Both appear in the same panel here, which is the only place the two " +
+          'symbols can be compared.',
+      },
+    },
+  },
+};
+
+export const Selecting: Story = {
+  name: 'Selecting a row',
+  args: { searchQuery: 'dental', filteredSearch: [CATALOG[1]] },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: /Dental scale and polish/ }));
+    // The whole entry goes back to the form - price, discounts and nested breakdown
+    // included - not just an id.
+    await expect(args.onSelectItem).toHaveBeenCalledWith(CATALOG[1]);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A row hands the entire `CatalogEntry` to the parent. The panel does not close itself: ' +
+          'the form closes it by clearing the query, so the closing behaviour lives outside this ' +
+          'component.',
+      },
+    },
+  },
+};
+
+export const NoItemsFound: Story = {
+  name: 'No items found',
+  args: { searchQuery: 'ultrasound', filteredSearch: [], searchLoading: false },
+  play: async ({ canvasElement }) => {
+    const empty = within(canvasElement).getByText('No items found.');
+    // The second, separate panel - not an empty results list. Same overlay geometry,
+    // different padding, and it must not push the breakdown table down the page.
+    await expect(getComputedStyle(empty).position).toBe('absolute');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A settled search with nothing to show. This is its own element rather than an empty ' +
+          'results list, so it is the only place its `py-3` padding and `--text-secondary` copy ' +
+          'can be reviewed against the row padding above.',
+      },
+    },
+  },
+};
+
+export const Searching: Story = {
+  name: 'Searching (no panel at all)',
+  args: { searchQuery: 'ultrasound', filteredSearch: [], searchLoading: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Deliberate: neither panel renders in flight, so nothing flickers between
+    // keystrokes. Pinned because "no panel" is otherwise indistinguishable from a
+    // dropdown that has stopped working.
+    await expect(canvas.queryByText('No items found.')).not.toBeInTheDocument();
+    await expect(canvas.getByLabelText('Search catalog items')).toHaveValue('ultrasound');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A query typed, a request in flight, and no panel. There is no spinner and no skeleton - ' +
+          'the field simply holds the text until results land or the empty card appears.',
+      },
+    },
+  },
+};
+
+export const TypingFindsNothing: Story = {
+  name: 'Typing into the empty state',
+  render: (args) => <SearchHarness {...args} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.type(canvas.getByLabelText('Search catalog items'), 'ultrasound');
+    await expect(await canvas.findByText('No items found.')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same empty card reached the way a user reaches it. With `searchLoading` false the ' +
+          'card appears on the first keystroke that matches nothing, so it is visible while the ' +
+          'reader is still typing.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/organization/pages/Specialities/PackageBreakdownTable.stories.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Specialities/PackageBreakdownTable.stories.tsx
@@ -184,14 +184,12 @@ export const NestedBreakdownOpen: Story = {
   name: 'Nested package breakdown (open)',
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    // Only the PACKAGE row with a nestedBreakdown grows the (i).
-    const rows = canvas.getAllByRole('row');
-    await expect(canvasElement.querySelectorAll('.glass-tooltip')).toHaveLength(1);
-    await expect(rows.length).toBeGreaterThan(4);
+    // Only the PACKAGE row carrying a nestedBreakdown grows the (i) - one of four rows.
+    await expect(canvas.getAllByRole('row')).toHaveLength(ITEMS.length + 2);
+    const trigger = canvasElement.querySelector('.glass-tooltip') as HTMLElement;
+    await expect(trigger).toBeInTheDocument();
 
-    const bubble = await openGlassTooltip(
-      canvasElement.querySelector('.glass-tooltip') as HTMLElement
-    );
+    const bubble = await openGlassTooltip(trigger);
 
     /* Assert the nested TABLE rendered, not merely that a bubble appeared. The
        failure this story exists for is a bubble that opens with its contents

--- a/apps/frontend/src/app/features/organization/pages/Specialities/PackageBreakdownTable.stories.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Specialities/PackageBreakdownTable.stories.tsx
@@ -1,0 +1,330 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import type { PackageBreakdownItem } from '@/app/features/organization/types/revamp';
+import { openGlassTooltip } from '@/app/ui/primitives/GlassTooltip/storyInteractions';
+import PackageBreakdownTable from './PackageBreakdownTable';
+
+const NESTED: PackageBreakdownItem[] = [
+  {
+    id: 'nested-1',
+    type: 'CONSULTATION',
+    name: 'Pre-anaesthetic consultation',
+    unitPrice: 68,
+    quantity: 1,
+    discount: 0,
+  },
+  {
+    id: 'nested-2',
+    type: 'LAB',
+    name: 'Pre-anaesthetic bloods (full panel)',
+    unitPrice: 124.5,
+    quantity: 1,
+    discount: 10,
+  },
+  {
+    id: 'nested-3',
+    type: 'MEDICATION',
+    name: 'Meloxicam 1.5 mg/ml oral suspension',
+    unitPrice: 22.4,
+    quantity: 2,
+    discount: 5,
+  },
+];
+
+const ITEMS: PackageBreakdownItem[] = [
+  {
+    id: 'item-1',
+    type: 'CONSULTATION',
+    name: 'Dental consultation',
+    unitPrice: 72,
+    quantity: 1,
+    discount: 0,
+    maxDiscount: 20,
+  },
+  {
+    id: 'item-2',
+    type: 'PROCEDURE',
+    name: 'Scale and polish under GA',
+    unitPrice: 310,
+    quantity: 1,
+    discount: 12.5,
+    maxDiscount: 25,
+  },
+  {
+    id: 'item-3',
+    type: 'PACKAGE',
+    name: 'Pre-anaesthetic workup',
+    unitPrice: 214.9,
+    quantity: 1,
+    discount: 5,
+    maxDiscount: 15,
+    nestedBreakdown: NESTED,
+  },
+  {
+    id: 'item-4',
+    type: 'INVENTORY',
+    name: 'Dental radiograph plate',
+    unitPrice: 18,
+    quantity: 4,
+    discount: 0,
+  },
+];
+
+/**
+ * Holds the rows in state, the way both call sites do.
+ *
+ * The quantity and discount fields are controlled by `item.quantity` / `item.discount`,
+ * so a story passing static args cannot type a second character into them: every
+ * keystroke re-renders the field back to the prop. That makes the discount clamp
+ * unreachable, because the ceiling is 20 and no single digit exceeds it - which is
+ * exactly how the first version of the story below failed.
+ */
+const Stateful = ({
+  initialItems,
+  additionalDiscount,
+  onChangeQty,
+  onChangeDiscount,
+  onRemoveItem,
+}: {
+  initialItems: PackageBreakdownItem[];
+  additionalDiscount: number;
+  onChangeQty?: (id: string, qty: number) => void;
+  onChangeDiscount?: (id: string, discount: number) => void;
+  onRemoveItem?: (id: string) => void;
+}) => {
+  const [items, setItems] = useState(initialItems);
+  const patch = (id: string, change: Partial<PackageBreakdownItem>) =>
+    setItems((prev) => prev.map((item) => (item.id === id ? { ...item, ...change } : item)));
+
+  return (
+    <PackageBreakdownTable
+      items={items}
+      additionalDiscount={additionalDiscount}
+      editable
+      onChangeQty={(id, qty) => {
+        patch(id, { quantity: qty });
+        onChangeQty?.(id, qty);
+      }}
+      onChangeDiscount={(id, discount) => {
+        patch(id, { discount });
+        onChangeDiscount?.(id, discount);
+      }}
+      onRemoveItem={(id) => {
+        setItems((prev) => prev.filter((item) => item.id !== id));
+        onRemoveItem?.(id);
+      }}
+    />
+  );
+};
+
+const meta = {
+  title: 'Organization/PackageBreakdownTable',
+  component: PackageBreakdownTable,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The line-by-line cost table behind a package: eight columns of catalogue rows, ' +
+          'a discount line and a total, with a ninth actions column when it is editable.\n\n' +
+          'It had no story anywhere, in either of its two call sites - the packages tab and ' +
+          'the package form - and neither call site is reachable in Storybook without seeding ' +
+          '`useRevampCatalogStore` and stubbing its loader. Drawn directly here instead, which ' +
+          'needs no mock at all: every input is a prop.\n\n' +
+          'The surface most worth having drawn is the **nested breakdown tooltip**. A row whose ' +
+          'type is `PACKAGE` and which carries a `nestedBreakdown` grows an (i) that opens a ' +
+          'seven-column table *inside a tooltip bubble* - a table within a tooltip within a ' +
+          'table. That is the same shape as `PackageBreakdownTooltip`, which shipped its entire ' +
+          'table at 1.00:1 against the bubble and reached dev that way, because nothing had ' +
+          'ever opened it. This one inherits `--ink` from `.glass-tooltip-bubble` and names ' +
+          '`--ink-muted` explicitly for its headers, so it survives the same check - but that ' +
+          'was luck until a story asserted it.\n\n' +
+          'The bubble also needs `maxWidth={440}` from the call site: the nested table sets a ' +
+          '`min-width: 360px` while `.glass-tooltip-bubble` caps itself at `min(320px, ...)`, ' +
+          'so without the override the table would be wider than the bubble holding it.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    items: ITEMS,
+    additionalDiscount: 0,
+  },
+} satisfies Meta<typeof PackageBreakdownTable>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ReadOnly: Story = {
+  name: 'Read-only',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    /* The colgroup and the header row have to agree, or every column below lands
+       one track out. Eight of each here; the editable story checks nine. */
+    const table = canvas.getByRole('table');
+    await expect(table.querySelectorAll('colgroup col')).toHaveLength(8);
+    await expect(canvas.getAllByRole('columnheader')).toHaveLength(8);
+    // The read-only total is a pill, not a bare number - it has its own ground.
+    await expect(canvas.getByText('Total cost')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Quantities and discounts read as text (`×4`, `-12.5%`) and the total sits in a ' +
+          '`bg-primary-100` pill 40px tall. This is the form the packages tab shows.',
+      },
+    },
+  },
+};
+
+export const NestedBreakdownOpen: Story = {
+  name: 'Nested package breakdown (open)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Only the PACKAGE row with a nestedBreakdown grows the (i).
+    const rows = canvas.getAllByRole('row');
+    await expect(canvasElement.querySelectorAll('.glass-tooltip')).toHaveLength(1);
+    await expect(rows.length).toBeGreaterThan(4);
+
+    const bubble = await openGlassTooltip(
+      canvasElement.querySelector('.glass-tooltip') as HTMLElement
+    );
+
+    /* Assert the nested TABLE rendered, not merely that a bubble appeared. The
+       failure this story exists for is a bubble that opens with its contents
+       invisible, which an existence check passes happily. */
+    const nested = within(bubble);
+    await expect(nested.getAllByRole('columnheader')).toHaveLength(7);
+    await expect(nested.getByText('Pre-anaesthetic bloods (full panel)')).toBeInTheDocument();
+    await expect(nested.getAllByRole('row')).toHaveLength(NESTED.length + 2); // + head + total
+
+    /* And that its text is not the colour of the bubble behind it. `--ink` and
+       `--screen` are different tokens; PackageBreakdownTooltip shipped with them
+       equal and its whole table disappeared. */
+    const bubbleBg = getComputedStyle(bubble).backgroundColor;
+    const cellInk = getComputedStyle(nested.getByText('Pre-anaesthetic bloods (full panel)')).color;
+    await expect(cellInk).not.toBe(bubbleBg);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The table inside the tooltip inside the table. Its seven columns are a narrower ' +
+          'restatement of the outer eight - no Gross column, and Disc./Net abbreviated - and it ' +
+          'is styled entirely with inline `style` objects rather than utilities, which is why a ' +
+          'stylesheet-level token sweep never sees it.',
+      },
+    },
+  },
+};
+
+export const NestedBreakdownDark: Story = {
+  name: 'Nested breakdown (dark)',
+  globals: { theme: 'dark' },
+  play: NestedBreakdownOpen.play,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same bubble in dark. Both grounds flip - `--screen` and `--ink` swap roles - so a ' +
+          'literal colour anywhere in that table would invert rather than track the theme.',
+      },
+    },
+  },
+};
+
+export const WithAdditionalDiscount: Story = {
+  name: 'With an additional discount',
+  args: { additionalDiscount: 7.5 },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The discount row only exists above zero, and it spans seven of eight columns.
+    const row = canvas.getByText(/Additional Discount \(7\.5%\)/);
+    await expect(row).toBeInTheDocument();
+    await expect(row.getAttribute('colspan')).toBe('7');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A second footer row appears only when the discount is above zero, and it is the one ' +
+          'place the table shows a negative amount. Its `colSpan` widens with the editable ' +
+          'column, so the two footer rows have to be checked in both modes.',
+      },
+    },
+  },
+};
+
+export const Editable: Story = {
+  name: 'Editable (package form)',
+  args: {
+    editable: true,
+    additionalDiscount: 7.5,
+    onRemoveItem: fn(),
+    onChangeQty: fn(),
+    onChangeDiscount: fn(),
+  },
+  render: (args) => (
+    <Stateful
+      initialItems={args.items}
+      additionalDiscount={args.additionalDiscount}
+      onChangeQty={args.onChangeQty}
+      onChangeDiscount={args.onChangeDiscount}
+      onRemoveItem={args.onRemoveItem}
+    />
+  ),
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Nine columns now: the actions column carries an sr-only header, not an empty one.
+    await expect(canvas.getByRole('table').querySelectorAll('colgroup col')).toHaveLength(9);
+    await expect(canvas.getAllByRole('columnheader')).toHaveLength(9);
+    await expect(canvas.getByText('Actions')).toHaveClass('sr-only');
+
+    // Quantity floors at 1: emptying the field must not send 0 or NaN upstream.
+    const qty = canvas.getByLabelText('Quantity for Dental consultation');
+    await userEvent.clear(qty);
+    await expect(args.onChangeQty).toHaveBeenLastCalledWith('item-1', 1);
+
+    /* Discount ceilings at the row's own `maxDiscount`, not at 100, and it is per
+       row: 20 here, 25 on the procedure below. Reaching that ceiling needs two
+       digits, which is only possible because the wrapper feeds the value back. */
+    const discount = canvas.getByLabelText('Discount for Dental consultation');
+    await userEvent.clear(discount);
+    await userEvent.type(discount, '90');
+    await expect(args.onChangeDiscount).toHaveBeenLastCalledWith('item-1', 20);
+    await expect(discount).toHaveValue(20);
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Remove Dental consultation' }));
+    await expect(args.onRemoveItem).toHaveBeenCalledWith('item-1');
+    // The row really goes, rather than the callback merely firing.
+    await expect(canvas.queryByText('Dental consultation')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The form variant: quantity and discount become number inputs, a trash control appears ' +
+          'in a ninth column, and the total drops its pill for plain emphasised text. The play ' +
+          'function drives the two clamps, which are the only logic in the file - quantity floors ' +
+          "at 1, and discount ceilings at the row's own `maxDiscount` rather than at 100.",
+      },
+    },
+  },
+};
+
+export const SingleRow: Story = {
+  name: 'One row',
+  args: { items: [ITEMS[0]] },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The narrowest the table gets. The `col` widths are fixed px except the Name column, ' +
+          'so a single short row leaves Name holding all the slack.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/organization/pages/Specialities/PackagesTab.stories.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Specialities/PackagesTab.stories.tsx
@@ -1,0 +1,403 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import type { PackageRevamp } from '@/app/features/organization/types/revamp';
+import { useRevampCatalogStore } from '@/app/stores/revampCatalogStore';
+import {
+  closeGlassTooltip,
+  openGlassTooltip,
+} from '@/app/ui/primitives/GlassTooltip/storyInteractions';
+import PackagesTab from './PackagesTab';
+
+const ORG_ID = 'org-avenger-park';
+const SPECIALITY_ID = 'spec-dentistry';
+
+/**
+ * Dental care package: 72 + (310 - 10%) + (120 x 2) = 591 after item discounts,
+ * less the 5% package discount = 561.45, printed as `$561` (formatMoney rounds to
+ * whole units). The org has no subscription seeded, so `useCurrencyForPrimaryOrg`
+ * falls back to USD - which is what every amount below is asserted in.
+ */
+const DENTAL: PackageRevamp = {
+  id: 'pkg-dental-care',
+  code: 'PKG-DEN-01',
+  name: 'Dental care package',
+  description:
+    'Consultation, scale and polish under general anaesthetic, and a full-mouth radiograph.',
+  specialityId: SPECIALITY_ID,
+  organisationId: ORG_ID,
+  durationText: '2 h 15 min',
+  isBookable: true,
+  isInpatientPreferred: true,
+  leadCount: 1,
+  supportCount: 2,
+  additionalDiscount: 5,
+  breakdown: [
+    {
+      id: 'bd-1',
+      code: 'DEN-001',
+      type: 'CONSULTATION',
+      name: 'Dental consultation',
+      unitPrice: 72,
+      quantity: 1,
+      discount: 0,
+    },
+    {
+      id: 'bd-2',
+      code: 'DEN-014',
+      type: 'PROCEDURE',
+      name: 'Scale and polish under general anaesthetic',
+      unitPrice: 310,
+      quantity: 1,
+      discount: 10,
+    },
+    {
+      id: 'bd-3',
+      code: 'DEN-032',
+      type: 'LAB',
+      name: 'Dental radiograph (full mouth)',
+      unitPrice: 120,
+      quantity: 2,
+      discount: 0,
+    },
+  ],
+  status: 'ACTIVE',
+  createdAt: '2026-05-04T09:00:00.000Z',
+};
+
+/** 64 + (145 - 20%) = 180, no package discount, and a deliberately empty description. */
+const SENIOR: PackageRevamp = {
+  id: 'pkg-senior-wellness',
+  code: 'PKG-DEN-02',
+  name: 'Senior wellness bundle',
+  description: '',
+  specialityId: SPECIALITY_ID,
+  organisationId: ORG_ID,
+  durationText: '45 min',
+  isBookable: false,
+  isInpatientPreferred: false,
+  leadCount: 1,
+  supportCount: 0,
+  additionalDiscount: 0,
+  breakdown: [
+    {
+      id: 'bd-4',
+      code: 'GER-004',
+      type: 'CONSULTATION',
+      name: 'Geriatric consultation',
+      unitPrice: 64,
+      quantity: 1,
+      discount: 0,
+    },
+    {
+      id: 'bd-5',
+      code: 'LAB-221',
+      type: 'LAB',
+      name: 'Senior blood panel',
+      unitPrice: 145,
+      quantity: 1,
+      discount: 20,
+    },
+  ],
+  status: 'ACTIVE',
+  createdAt: '2026-05-06T11:30:00.000Z',
+};
+
+/**
+ * Seeds the real store instead of mocking the catalog service.
+ *
+ * `loadSpecialityCatalog` returns on its first line when `loadedSpecialityIds`
+ * already holds the key it is about to fetch, and the key is
+ * `<specialityId>:active` for a non-archive load - so seeding that one string is
+ * what keeps the mount off the network. Nothing else is stubbed: the store, the
+ * tab and the card are all the real ones.
+ *
+ * Both packages carry a populated `breakdown` for the same reason. Toggling a
+ * breakdown open on a package that has none calls `hydratePackageDetail`, which
+ * does go to the API.
+ */
+const seed = (packages: PackageRevamp[] = [DENTAL, SENIOR]) => {
+  useRevampCatalogStore.setState({
+    packages,
+    loadedSpecialityIds: [`${SPECIALITY_ID}:active`],
+  });
+};
+
+const wideGrids = (canvasElement: HTMLElement) =>
+  [...canvasElement.querySelectorAll('[style*="grid-template-columns"]')] as HTMLElement[];
+
+const tracksOf = (element: HTMLElement) =>
+  getComputedStyle(element).gridTemplateColumns.trim().split(/\s+/);
+
+const meta = {
+  title: 'Organization/PackagesTab',
+  component: PackagesTab,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The packages tab of one speciality, and specifically the **`PackageCard`** inside it - ' +
+          'module-private, so it is driven through the exported tab rather than exported for the ' +
+          'sake of a story. That costs one store seed and nothing else.\n\n' +
+          'The card has three states no static snapshot reaches. Its layout is **container-queried**: ' +
+          'a five-track single row at `@2xl` and up, a two-column stack below it, with the three ' +
+          'circular actions moving from the right edge to a row above the data. Its **breakdown ' +
+          'table** is collapsed except on the first card, where it opens on mount. And its archive ' +
+          'action opens a **confirmation dialog that portals to `document.body`**, so it is not ' +
+          'inside `canvasElement` at all.\n\n' +
+          'Both grids exist in the DOM at every width - one of them is always `display: none` - so ' +
+          'every label and every amount is in the document twice. The stories below read computed ' +
+          'track counts off whichever grid is actually visible, because a dropped or malformed ' +
+          '`gridTemplateColumns` collapses silently to a single column and looks like a design ' +
+          'choice.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    specialityId: SPECIALITY_ID,
+    organisationId: ORG_ID,
+  },
+  decorators: [
+    (Story) => (
+      <div className="min-h-[560px] w-[1100px] max-w-full bg-[var(--screen)] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+  beforeEach: () => {
+    seed();
+  },
+} satisfies Meta<typeof PackagesTab>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Cards: Story = {
+  name: 'Package cards (wide container)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(await canvas.findByText('Dental care package')).toBeInTheDocument();
+    await expect(canvas.getByText('Senior wellness bundle')).toBeInTheDocument();
+
+    /* Five fields, five tracks, on the grid that carries the template inline:
+       `auto minmax(0,220px) auto auto auto`. Only the description track is
+       constrained, because it is the only field allowed to wrap (line-clamp-2);
+       the other four are `whitespace-nowrap` and size to their content. Lose the
+       template and all five stack into one column, which still looks deliberate. */
+    const [dentalGrid, seniorGrid] = wideGrids(canvasElement);
+    await expect(tracksOf(dentalGrid)).toHaveLength(5);
+    await expect(dentalGrid.children).toHaveLength(5);
+    await expect(within(dentalGrid).getByText('PKG-DEN-01')).toBeInTheDocument();
+    await expect(within(dentalGrid).getByText('2 h 15 min')).toBeInTheDocument();
+    await expect(within(dentalGrid).getByText('5%')).toBeInTheDocument();
+    await expect(within(dentalGrid).getByText('$561')).toBeInTheDocument();
+
+    // An empty description is an em dash, not a blank cell - the label would
+    // otherwise sit over nothing and read as a rendering failure.
+    await expect(within(seniorGrid).getByText('—')).toBeInTheDocument();
+    await expect(within(seniorGrid).getByText('$180')).toBeInTheDocument();
+
+    /* Badges are per-package, not decoration: only the dental package is bookable
+       and in-patient preferred, so the second card carries none. */
+    await expect(canvas.getByText('Bookable')).toBeInTheDocument();
+    await expect(canvas.getByText('In-patient')).toBeInTheDocument();
+
+    // Actions sit to the right of the data at this width. One accessible copy of
+    // each - the narrow row exists but is `display: none`.
+    const edit = canvas.getByRole('button', { name: 'Edit Dental care package' });
+    await expect(canvas.getAllByRole('button', { name: /^Edit / })).toHaveLength(2);
+    await expect(edit.getBoundingClientRect().left).toBeGreaterThan(
+      dentalGrid.getBoundingClientRect().right - 1
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Two packages at page width. The first card opens its breakdown on mount - that is a real ' +
+          'rule in the component (`index === 0 && breakdown.length > 0`), not a story setting - so ' +
+          'the tab always leads with one fully expanded costing.',
+      },
+    },
+  },
+};
+
+export const BreakdownExpanded: Story = {
+  name: 'Breakdown table (toggled open)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const toggle = await canvas.findByRole('button', {
+      name: 'View breakdown of Senior wellness bundle',
+    });
+
+    await userEvent.click(toggle);
+
+    // The label is the state: it flips to "Hide", and the chevron rotates 180deg -
+    // read after the 150ms transform transition rather than in the same frame.
+    const hide = await canvas.findByRole('button', {
+      name: 'Hide breakdown of Senior wellness bundle',
+    });
+    await waitFor(() => {
+      const icon = hide.querySelector('svg') as SVGElement;
+      expect(getComputedStyle(icon).transform).toBe('matrix(-1, 0, 0, -1, 0, 0)');
+    });
+
+    /* Assert the table it revealed, not that a flag flipped. Eight columns with
+       `editable={false}` (a ninth actions column appears only in the editor), one
+       row per breakdown item, and the footer total agreeing with the card's own
+       "Total Amount" - both are computed from the same items, so a divergence here
+       is a real arithmetic bug rather than a formatting one. */
+    const table = canvasElement.querySelectorAll('table')[1] as HTMLTableElement;
+    await expect(table.querySelectorAll('thead th')).toHaveLength(8);
+    await expect(table.querySelectorAll('tbody tr')).toHaveLength(2);
+    await expect(within(table).getByText('Senior blood panel')).toBeInTheDocument();
+    await expect(within(table).getByText('-20%')).toBeInTheDocument();
+    await expect(within(table).getByText('Total cost')).toBeInTheDocument();
+    await expect(within(table).getByText('$180')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The costing behind a package: unit price, quantity, gross, the per-item discount and the ' +
+          'net, then the package-level discount and the total. It is the read-only form - the same ' +
+          'table renders quantity and discount as inputs inside the package editor, with a ninth ' +
+          'column of remove buttons.',
+      },
+    },
+  },
+};
+
+export const ActionTooltip: Story = {
+  name: 'Card action tooltip',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const toggle = await canvas.findByRole('button', {
+      name: 'View breakdown of Senior wellness bundle',
+    });
+
+    /* Opened through the shared helper, which re-dispatches until the bubble
+       appears. GlassTooltip binds `mouseenter` natively inside an effect, and a
+       play function routinely starts before that effect has flushed - a single
+       `userEvent.hover` lands on an element with no listener and is lost, leaving
+       a green story that proved nothing. */
+    const bubble = await openGlassTooltip(toggle);
+    /* Exact, not `toHaveTextContent`, which is a substring match and would pass on
+       the button's own name. That is the distinction this story exists to hold:
+       the tooltip says "View breakdown" and the accessible name says which package
+       it belongs to, and the two are allowed to drift apart only in that
+       direction. */
+    await expect(bubble.textContent).toBe('View breakdown');
+    await expect(toggle).toHaveAccessibleName('View breakdown of Senior wellness bundle');
+    // One bubble, not one-or-more: a leftover from an earlier trigger portals to
+    // the same body and would read as a success here.
+    await expect(document.querySelectorAll('[role="tooltip"]')).toHaveLength(1);
+
+    await closeGlassTooltip(toggle);
+    await expect(document.querySelectorAll('[role="tooltip"]')).toHaveLength(0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The three card actions are icon-only, so the tooltip is the only place their meaning is ' +
+          "written down. The text is not the button's accessible name: the name is scoped to the " +
+          'package ("View breakdown of Senior wellness bundle") so a screen reader user can tell the ' +
+          'cards apart, while the tooltip stays short.',
+      },
+    },
+  },
+};
+
+export const NarrowContainer: Story = {
+  name: 'Narrow container (side drawer)',
+  decorators: [
+    (Story) => (
+      <div className="min-h-[560px] w-[420px] max-w-full bg-[var(--screen)] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(await canvas.findByText('Dental care package')).toBeInTheDocument();
+
+    /* Below `@2xl` the single row becomes a two-column stack of five cells, with
+       the description spanning both. The count matters as much as the template:
+       two tracks and five children is the stack; two tracks and four children
+       would mean a field silently vanished. */
+    const narrowGrid = canvasElement.querySelector('.grid-cols-2') as HTMLElement;
+    await expect(tracksOf(narrowGrid)).toHaveLength(2);
+    await expect(narrowGrid.children).toHaveLength(5);
+
+    const description = within(narrowGrid).getByText('Description').parentElement as HTMLElement;
+    await expect(getComputedStyle(description).gridColumnStart).toBe('span 2');
+
+    // Duration is a field of its own here. In the wide row it sits third; the two
+    // grids carry the same five fields in a different order, which is why both are
+    // in the DOM rather than one being reflowed.
+    await expect(within(narrowGrid).getByText('2 h 15 min')).toBeInTheDocument();
+
+    /* The actions move above the data. Still exactly one accessible copy of each -
+       the wide row is `display: none` - and it now sits ABOVE the grid rather than
+       to its right, which is the whole point of the second row existing. */
+    const edit = canvas.getByRole('button', { name: 'Edit Dental care package' });
+    await expect(canvas.getAllByRole('button', { name: /^Edit / })).toHaveLength(2);
+    await expect(edit.getBoundingClientRect().bottom).toBeLessThanOrEqual(
+      narrowGrid.getBoundingClientRect().top
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same card in a narrow container - what it looks like inside a side drawer rather than ' +
+          'on the page. The width here is set on the wrapper, not by the viewport: the breakpoint is ' +
+          "a container query against the card's own `@container`, so a narrow browser window would " +
+          'not reproduce it and a wide one cannot hide it.',
+      },
+    },
+  },
+};
+
+export const ArchiveConfirmation: Story = {
+  name: 'Archive confirmation (portalled)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const dialog = () => document.querySelector('dialog[open]');
+    await expect(dialog()).toBeNull();
+
+    await userEvent.click(
+      await canvas.findByRole('button', { name: 'Archive Dental care package' })
+    );
+
+    /* The dialog portals to `document.body`, so nothing it renders is inside
+       `canvasElement` - a query against the canvas finds nothing and, worse, the
+       "closed at rest" check above would pass for the same reason rather than
+       because the dialog was closed. Closed is also not unmounted here: the
+       element keeps its place in the DOM without the `open` attribute. */
+    await waitFor(() => expect(dialog()).not.toBeNull());
+    const panel = within(dialog() as HTMLElement);
+    await expect(panel.getByRole('heading', { name: 'Archive package' })).toBeInTheDocument();
+    await expect(panel.getByText('Dental care package')).toBeInTheDocument();
+    await expect(panel.getByText(/restore it later from the/)).toBeInTheDocument();
+
+    // Cancel then Archive, side by side in a two-track grid: the destructive one is
+    // second, so it is never the button under the cursor when the dialog opens.
+    const actions = panel.getByText('Cancel').closest('.grid') as HTMLElement;
+    await expect(tracksOf(actions)).toHaveLength(2);
+    await expect(actions.children).toHaveLength(2);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Archiving is confirmed, not immediate, and the copy says what archiving actually does - ' +
+          'the package leaves the active lists and the package builder but stays restorable from the ' +
+          'Archive tab. Confirming calls the store, so this story stops at the open dialog.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/organization/pages/Specialities/ServicesTab.stories.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Specialities/ServicesTab.stories.tsx
@@ -1,0 +1,286 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import type { ServiceRevamp } from '@/app/features/organization/types/revamp';
+import { useRevampCatalogStore } from '@/app/stores/revampCatalogStore';
+import ServicesTab from './ServicesTab';
+
+const ORG_ID = 'org-avenger-park';
+const SPECIALITY_ID = 'spec-dentistry';
+
+const service = (over: Partial<ServiceRevamp> = {}): ServiceRevamp => ({
+  id: 'svc-1',
+  code: 'DEN-001',
+  name: 'Dental consultation',
+  description: 'Oral exam, charting and a treatment plan.',
+  type: 'CONSULTATION',
+  specialityId: SPECIALITY_ID,
+  organisationId: ORG_ID,
+  grossAmount: 72,
+  defaultDiscount: 0,
+  maxDiscount: 20,
+  durationMinutes: 30,
+  isBookable: true,
+  isInpatientPreferred: false,
+  status: 'ACTIVE',
+  createdAt: '2026-05-04T09:00:00.000Z',
+  ...over,
+});
+
+const SERVICES: ServiceRevamp[] = [
+  service(),
+  service({
+    id: 'svc-2',
+    code: 'DEN-014',
+    name: 'Scale and polish under general anaesthetic',
+    description: 'Full mouth scale, polish and post-op analgesia.',
+    type: 'PROCEDURE',
+    grossAmount: 310,
+    defaultDiscount: 12.5,
+    maxDiscount: 25,
+    durationMinutes: 90,
+    isInpatientPreferred: true,
+  }),
+  service({
+    id: 'svc-3',
+    code: 'DEN-032',
+    name: 'Dental radiograph (full mouth)',
+    description: '',
+    type: 'LAB',
+    grossAmount: 120,
+    durationMinutes: 20,
+    isBookable: false,
+  }),
+];
+
+const PRACTITIONERS = [
+  { id: 'p-1', name: 'Dr. Elena Marsh' },
+  { id: 'p-2', name: 'Dr. Ravi Patel' },
+  { id: 'p-3', name: 'Tom Reyes' },
+  { id: 'p-4', name: 'Priya Raman' },
+];
+
+/**
+ * Seeds the real store rather than mocking it.
+ *
+ * `loadSpecialityCatalog` returns at its first line when the key is already in
+ * `loadedSpecialityIds`, so seeding that key is what keeps the mount off the network -
+ * no service stub, and the component under review is the real one.
+ */
+const seed = (services: ServiceRevamp[] = SERVICES) => {
+  useRevampCatalogStore.setState({
+    services,
+    loadedSpecialityIds: [`${SPECIALITY_ID}:active`],
+  });
+};
+
+const meta = {
+  title: 'Organization/ServicesTab',
+  component: ServicesTab,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The services table of one speciality. Its rows carry two surfaces that only exist ' +
+          'after a click, and neither had ever been drawn: the **row kebab menu** and the ' +
+          '**expanded detail grid**.\n\n' +
+          'Both are module-private, so they are driven through the exported tab rather than ' +
+          'exported for the sake of a story. That costs a store seed and nothing else - ' +
+          '`loadSpecialityCatalog` bails out on its first line once the speciality key is in ' +
+          '`loadedSpecialityIds`, so the real store, the real component and no network.\n\n' +
+          'The layout is **container-queried, not viewport-queried**. The seven-column table is ' +
+          '`hidden @3xl:grid` and the stacked card is `@3xl:hidden`, both resolving against the ' +
+          "tab's own `@container`. A story that renders this in a narrow box shows only the " +
+          'stacked form however wide the browser is, which is why the width is set on the ' +
+          'wrapper here rather than left to the viewport.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    specialityId: SPECIALITY_ID,
+    organisationId: ORG_ID,
+    specialityName: 'Dentistry',
+    practitioners: PRACTITIONERS,
+  },
+  decorators: [
+    (Story) => (
+      <div className="min-h-[560px] w-[1100px] max-w-full bg-[var(--screen)] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+  beforeEach: () => {
+    seed();
+  },
+} satisfies Meta<typeof ServicesTab>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Table: Story = {
+  name: 'Service table',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* TWO nodes per service, not one. Each row renders the wide table form and the
+       stacked card form side by side and lets a container query hide one - so every
+       name, price and kebab exists twice in the DOM at every width. `getByText` does
+       not filter on `display`, so it is `getAllByText` here; a role query sees only
+       one, because `hidden` takes the other out of the accessibility tree. Worth
+       knowing before writing any more queries against this table. */
+    expect(await canvas.findAllByText('Dental consultation')).toHaveLength(2);
+    await expect(
+      canvas.getAllByRole('button', { name: 'Actions for Dental consultation' })
+    ).toHaveLength(1);
+
+    /* Seven header cells and seven tracks. This is a CSS grid pretending to be a
+       table, so nothing enforces that agreement - a template with six tracks and
+       seven children silently wraps the last one onto a second line, and the
+       `44px` action column is the one that would go. */
+    const header = canvasElement.querySelector('.yc-table-head') as HTMLElement;
+    await expect(header.children).toHaveLength(7);
+    await expect(getComputedStyle(header).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(7);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting table at container width. Duration and price are right-aligned and ' +
+          '`tabular-nums`, so the digits line up down the column rather than drifting.',
+      },
+    },
+  },
+};
+
+export const RowMenuOpen: Story = {
+  name: 'Row kebab menu (open)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const kebab = (await canvas.findAllByRole('button', { name: /^Actions for / }))[0];
+    await expect(kebab).toHaveAttribute('aria-expanded', 'false');
+
+    await userEvent.click(kebab);
+    await expect(kebab).toHaveAttribute('aria-expanded', 'true');
+
+    // Assert the panel drew its two rows, not merely that the flag flipped.
+    const edit = await canvas.findByRole('button', { name: 'Edit' });
+    const archive = await canvas.findByRole('button', { name: 'Archive' });
+    await expect(edit).toBeInTheDocument();
+    /* Archive is the destructive one and is the only item tinted --danger-text.
+       Read it after the transition rather than in the same frame: these rows carry
+       `transition-colors`, so a single read can catch an interpolated value. */
+    await waitFor(() => {
+      expect(getComputedStyle(archive).color).not.toBe(getComputedStyle(edit).color);
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Two rows, absolutely positioned under the trigger at `top-8`, on `--screen` with a ' +
+          '`--hairline` border. It is not portalled, so it is clipped by any scrolling ancestor - ' +
+          'and it closes on blur as well as Escape, which is why the menu items rather than the ' +
+          'wrapper carry the key handler.',
+      },
+    },
+  },
+};
+
+export const RowMenuClosesOnEscape: Story = {
+  name: 'Row kebab closes on Escape',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const kebab = (await canvas.findAllByRole('button', { name: /^Actions for / }))[0];
+    await userEvent.click(kebab);
+    expect(await canvas.findByRole('button', { name: 'Archive' })).toBeInTheDocument();
+
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => {
+      expect(canvas.queryByRole('button', { name: 'Archive' })).not.toBeInTheDocument();
+    });
+    await expect(kebab).toHaveAttribute('aria-expanded', 'false');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Escape is handled on the three native controls, not on the positioning wrapper - the ' +
+          'wrapper has no interactive semantics of its own, and focus is always on one of the ' +
+          'buttons while the menu is open.',
+      },
+    },
+  },
+};
+
+export const RowExpanded: Story = {
+  name: 'Row detail (expanded)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const name = (await canvas.findAllByRole('button', { expanded: false }))[0];
+    await expect(canvas.queryByText('Max disc.')).not.toBeInTheDocument();
+
+    await userEvent.click(name);
+
+    // The detail grid is four columns at this container width, not two.
+    const label = await canvas.findByText('Max disc.');
+    const grid = label.closest('.grid') as HTMLElement;
+    await expect(getComputedStyle(grid).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(4);
+    await expect(canvas.getByText('Code')).toBeInTheDocument();
+    await expect(canvas.getByText('Description')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The eight verbose catalogue fields the design keeps out of the row: code, type, gross, ' +
+          'total, both discounts, in-patient preference and the full description, which spans the ' +
+          'whole width. Two columns in a narrow container, four at `@3xl`.',
+      },
+    },
+  },
+};
+
+export const EmptyState: Story = {
+  name: 'No services',
+  beforeEach: () => {
+    seed([]);
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(await canvas.findByText(/No services/i)).toBeInTheDocument();
+    /* Empty is not the same as loading, and the copy alone cannot tell them apart:
+       assert the loader has gone AND that no row survived, since a filter bug that
+       hid every row would render this same sentence. */
+    await expect(canvas.queryByLabelText('Loading services')).not.toBeInTheDocument();
+    await expect(canvas.queryAllByRole('button', { name: /^Actions for / })).toHaveLength(0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Loaded and genuinely empty, which is a different state from loading: the loader shows ' +
+          'only while `loadedSpecialityIds` lacks this speciality, so both are reachable with the ' +
+          'same empty list.',
+      },
+    },
+  },
+};
+
+export const Loading: Story = {
+  name: 'Loading',
+  beforeEach: () => {
+    // No key in loadedSpecialityIds - the state before the catalog answers.
+    useRevampCatalogStore.setState({ services: [], loadedSpecialityIds: [] });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The inline loader. `loading` is derived from the absence of this speciality's key " +
+          'rather than from a flag, so it is the same condition that triggers the fetch.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/overview/components/CommunityStats.tsx
+++ b/apps/frontend/src/app/features/overview/components/CommunityStats.tsx
@@ -347,7 +347,7 @@ const CommunityStats = ({ trafficChart, starsChart, isLoading }: CommunityStatsP
           {chartKeys.map((key) => (
             <span key={key.name} className="ChartLegendItem">
               <span className="ChartLegendDot" style={{ backgroundColor: key.color }} />
-              <span className="text-capton-1 text-text-primary">{key.name}</span>
+              <span className="text-caption-1 text-text-primary">{key.name}</span>
             </span>
           ))}
         </div>

--- a/apps/frontend/src/app/features/petPassport/components/PetPassportModal.stories.tsx
+++ b/apps/frontend/src/app/features/petPassport/components/PetPassportModal.stories.tsx
@@ -1,0 +1,538 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import {
+  AxiosError,
+  type AxiosAdapter,
+  type AxiosResponse,
+  type InternalAxiosRequestConfig,
+} from 'axios';
+import type { PetPassportDTO } from '@yosemite-crew/types';
+
+import PetPassportModal from './PetPassportModal';
+import api, { clearInFlightGetRequests } from '@/app/services/axios';
+import { useOrgStore } from '@/app/stores/orgStore';
+
+const ORG_ID = 'org-storybook';
+const COMPANION_ID = 'companion-luna';
+
+/** A passport with every section populated, so the whole card is under review. */
+const PASSPORT: PetPassportDTO = {
+  identity: {
+    id: COMPANION_ID,
+    name: 'Luna',
+    species: 'dog',
+    breed: 'Beagle',
+    sex: 'female',
+    dateOfBirth: '2021-03-14',
+    colour: 'Tricolour',
+    distinguishingMarks: 'White blaze, notch in left ear',
+  },
+  owner: {
+    name: 'Marta Ferreira',
+    email: 'marta.ferreira@example.com',
+    phone: '+351 912 000 111',
+  },
+  microchip: {
+    number: '941000024681357',
+    implantedAt: '2021-05-02',
+    location: 'Left side of neck',
+  },
+  passportNumber: 'PT-2026-004417',
+  rabies: {
+    id: 'vac-rabies',
+    patientId: COMPANION_ID,
+    vaccineType: 'RABIES',
+    vaccineName: 'Nobivac Rabies',
+    manufacturer: 'MSD Animal Health',
+    batchNumber: 'RB-2025-118',
+    dateAdministered: '2025-06-11T09:00:00.000Z',
+    validFrom: '2025-07-02T00:00:00.000Z',
+    validUntil: '2028-06-11T00:00:00.000Z',
+    nextDueDate: '2028-05-11T00:00:00.000Z',
+    administeringVetName: 'Dr. Elena Marsh',
+    createdAt: '2025-06-11T09:05:00.000Z',
+  },
+  vaccinations: [
+    {
+      id: 'vac-dhpp',
+      patientId: COMPANION_ID,
+      vaccineType: 'CORE',
+      vaccineName: 'Nobivac DHPPi',
+      batchNumber: 'DH-2026-044',
+      dateAdministered: '2026-01-19T10:30:00.000Z',
+      nextDueDate: '2027-01-19T00:00:00.000Z',
+      createdAt: '2026-01-19T10:35:00.000Z',
+    },
+  ],
+  parasiteTreatments: [
+    {
+      id: 'par-1',
+      patientId: COMPANION_ID,
+      treatmentType: 'ECHINOCOCCUS',
+      productName: 'Milbemax',
+      treatedAt: '2026-02-10T16:20:00.000Z',
+      administeringVetName: 'Dr. Elena Marsh',
+      createdAt: '2026-02-10T16:25:00.000Z',
+    },
+  ],
+  rabiesTitrations: [
+    {
+      id: 'tit-1',
+      patientId: COMPANION_ID,
+      approvedLab: 'ANSES Nancy',
+      sampleDate: '2025-08-04T00:00:00.000Z',
+      resultIuMl: 1.8,
+      createdAt: '2025-08-20T00:00:00.000Z',
+    },
+  ],
+  clinicalExams: [
+    {
+      id: 'exam-1',
+      patientId: COMPANION_ID,
+      examinedAt: '2026-02-12T08:45:00.000Z',
+      fitForTravel: true,
+      findings: 'Bright, alert, responsive',
+      weightKg: 11.4,
+      temperatureC: 38.5,
+      examiningVetName: 'Dr. Elena Marsh',
+      createdAt: '2026-02-12T08:50:00.000Z',
+    },
+  ],
+  issuance: {
+    passportNumber: 'PT-2026-004417',
+    issuingCountry: 'Portugal',
+    issuingAuthority: 'DGAV',
+    issuingPractice: 'Harbourside Veterinary Group',
+    issuingVetName: 'Dr. Elena Marsh',
+    issuingVetLicense: 'PT-VET-8842',
+    issueDate: '2026-02-12T09:00:00.000Z',
+  },
+  publicShareActive: true,
+};
+
+const withoutIssuance = (): PetPassportDTO => {
+  const { issuance: _issuance, ...rest } = PASSPORT;
+  return { ...rest, publicShareActive: false };
+};
+
+const ok = <T,>(config: InternalAxiosRequestConfig, data: T): Promise<AxiosResponse<T>> =>
+  Promise.resolve({ data, status: 200, statusText: 'OK', headers: {}, config });
+
+const fail = (
+  config: InternalAxiosRequestConfig,
+  status: number,
+  message: string
+): Promise<AxiosResponse> =>
+  Promise.reject(
+    new AxiosError(message, String(status), config, undefined, {
+      data: { message },
+      status,
+      statusText: message,
+      headers: {},
+      config,
+    })
+  );
+
+/** A request that never settles - which is what "still in flight" actually is. */
+const neverSettles = (): Promise<AxiosResponse> => new Promise<AxiosResponse>(() => {});
+
+/**
+ * A transport failure: the passport service never answered at all.
+ *
+ * This is what the error story cans, and it is deliberately NOT the 500 it reads
+ * like. `services/axios.ts` retries idempotent 429/5xx three times with
+ * exponential backoff, so a canned 500 does not reach this panel's `catch` for
+ * roughly five seconds - the modal holds "Loading passport..." for the whole
+ * ladder, and the error copy that the story is about only lands on the fourth
+ * request. A response-less failure is not retryable, so the panel draws the
+ * error on the first attempt. Same copy, different number of requests behind it.
+ */
+const noResponse = (config: InternalAxiosRequestConfig): Promise<AxiosResponse> =>
+  Promise.reject(
+    new AxiosError('The passport service did not respond.', AxiosError.ERR_NETWORK, config)
+  );
+
+type Handlers = {
+  /** Answer for the passport read. Defaults to the fully populated passport above. */
+  onPassport?: (config: InternalAxiosRequestConfig) => Promise<AxiosResponse>;
+  /** Answer for the Apple `.pkpass` fetch. Defaults to a request left in flight. */
+  onApple?: (config: InternalAxiosRequestConfig) => Promise<AxiosResponse>;
+  /** Answer for the Google save-URL fetch. Defaults to a request left in flight. */
+  onGoogle?: (config: InternalAxiosRequestConfig) => Promise<AxiosResponse>;
+};
+
+/**
+ * One canned API for the whole panel, so no story can reach the network however far
+ * its interactions drive it.
+ *
+ * Both wallet legs default to a request that never settles, and that is deliberate
+ * rather than lazy: a resolved Apple response makes `downloadApplePass` build a blob
+ * URL and click a real anchor, which saves a file out of the Storybook tab, and a
+ * resolved Google response makes the component call `window.open`. Neither belongs in
+ * a story, so the only wallet states drawn here are "in flight" and "failed".
+ */
+const buildAdapter = ({ onPassport, onApple, onGoogle }: Handlers = {}): AxiosAdapter => {
+  return (config: InternalAxiosRequestConfig) => {
+    const url = config.url ?? '';
+    if (url.endsWith('/passport')) {
+      return (onPassport ?? ((request) => ok(request, PASSPORT)))(config);
+    }
+    if (url.endsWith('/wallet/apple')) return (onApple ?? neverSettles)(config);
+    if (url.endsWith('/wallet/google')) return (onGoogle ?? neverSettles)(config);
+    return fail(config, 404, `No canned response for ${url}`);
+  };
+};
+
+/**
+ * The org store is seeded because every PMS passport route is org-scoped through
+ * `requireOrgId`, which throws when no organisation is active - without it the panel
+ * would only ever draw its error state. The adapter swap and the store are both put
+ * back on unmount; `clearInFlightGetRequests` is part of that teardown because the
+ * loading story's request never settles and would otherwise sit in the GET dedupe
+ * cache for the next story to await forever.
+ */
+const withApi = (handlers: Handlers = {}) => {
+  return () => {
+    const snapshot = useOrgStore.getState();
+    const previousAdapter = api.defaults.adapter;
+
+    useOrgStore.setState({ primaryOrgId: ORG_ID, status: 'loaded' });
+    api.defaults.adapter = buildAdapter(handlers);
+
+    return () => {
+      useOrgStore.setState(snapshot);
+      api.defaults.adapter = previousAdapter;
+      clearInFlightGetRequests();
+    };
+  };
+};
+
+/**
+ * The panel portals to `document.body`, so every query starts from the dialog rather
+ * than from `canvasElement` - nothing it renders is inside the canvas at all. It is
+ * also matched on `dialog[open]` rather than on the element: a closed ModalBase stays
+ * mounted and only drops the `open` attribute, so an absence assertion against the
+ * node itself would pass while the panel was still on screen.
+ */
+const dialog = () => document.querySelector('dialog[open]');
+
+/**
+ * The card `PetPassportView` draws, reached through its content rather than by
+ * class. `[class*="gap-5"]` would have worked today and broken silently the day a
+ * utility moved - and "silently" is the problem, because a `querySelector` that
+ * misses returns null and the very next `.children` read throws somewhere
+ * unrelated. Every section is a child of this root, so the one section a passport
+ * always has identifies it: `Description` renders unconditionally, unlike Owner,
+ * Identification or Issued by.
+ */
+const passportView = (root: HTMLElement): HTMLElement => {
+  const section = within(root).getByText('Description').parentElement;
+  return section?.parentElement as HTMLElement;
+};
+
+const SECTIONS = [
+  'Owner',
+  'Description',
+  'Identification',
+  'Rabies vaccination',
+  'Other vaccinations',
+  'Parasite treatments',
+  'Rabies titration',
+  'Clinical examination',
+  'Issued by',
+] as const;
+
+const meta = {
+  title: 'Pet Passport/PetPassportModal',
+  component: PetPassportModal,
+  parameters: {
+    // No `autodocs`: the panel portals to document.body over a fixed, blurred
+    // backdrop, so on a docs page every story would stack on top of the page
+    // instead of rendering in its own block.
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          "The staff-side view of a companion's Digital Pet Passport, and the **ready state** in " +
+          'particular - the one the modal spends its life in, and the one nothing had ever drawn ' +
+          'because it only exists after a fetch resolves.\n\n' +
+          'Every story stubs the API client at the axios adapter, so nothing here reaches the ' +
+          'network. That is what makes the ready state reachable at all: the load state lives inside ' +
+          '`PetPassportModalContent`, which is mounted keyed by companion and unmounted on close, so ' +
+          'there is no store to seed and no flag to flip - only the response.\n\n' +
+          'The footer is the part worth reviewing. A wallet pass embeds a public share link in its ' +
+          'QR, and staff cannot mint that link - it is an owner credential created from the pet ' +
+          'parent app. So there are three distinct footers, not two: buttons when the passport is ' +
+          'issued AND shared, and a different sentence for each of the two gaps, each naming the ' +
+          'thing that is actually missing rather than offering an action that would 409.',
+      },
+    },
+  },
+  args: {
+    open: true,
+    companionId: COMPANION_ID,
+    companionName: 'Luna Ferreira',
+    onClose: fn(),
+  },
+  beforeEach: withApi(),
+} satisfies Meta<typeof PetPassportModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Ready: Story = {
+  name: 'Ready - issued and shareable',
+  play: async () => {
+    await waitFor(() => expect(dialog()).not.toBeNull());
+    const open = within(dialog() as HTMLElement);
+
+    /* The header is built from the FIRST word of the companion name, not the whole
+       one: "Luna Ferreira" gives "Luna's passport". A record card titled with the
+       family name would read as the owner's document rather than the pet's. */
+    await expect(open.getByRole('heading', { name: "Luna's passport" })).toBeInTheDocument();
+
+    /* Gate on something only the ready state renders. The header above is NOT that
+       signal - it is drawn from the prop while the fetch is still out, so a story
+       that waited on it would read the structure below off the loading state and
+       find nothing. */
+    expect(await open.findByText('Issued by')).toBeInTheDocument();
+
+    /* Nine sections, plus the identity header and the closing disclaimer: eleven
+       children. Each section renders only when its data is present, so the count is
+       the assertion that a populated passport draws all of them - a section silently
+       dropped by a renamed DTO field looks exactly like a pet with no records. */
+    const view = passportView(dialog() as HTMLElement);
+    await expect(getComputedStyle(view).flexDirection).toBe('column');
+    await expect(view.children).toHaveLength(11);
+    for (const section of SECTIONS) {
+      await expect(open.getByText(section)).toBeInTheDocument();
+    }
+
+    // Identity and description rows.
+    await expect(open.getByText('Luna')).toBeInTheDocument();
+    await expect(open.getByText('Beagle / Canine')).toBeInTheDocument();
+    // The raw Prisma value is `female`; printing it unmapped is the bug this label
+    // helper exists to prevent.
+    await expect(open.getByText('Female')).toBeInTheDocument();
+    await expect(open.getByText('White blaze, notch in left ear')).toBeInTheDocument();
+    await expect(open.getByText('PT-2026-004417')).toBeInTheDocument();
+    await expect(open.getByText('941000024681357')).toBeInTheDocument();
+
+    // Clinical content: the rabies dose with its batch, the titration result, and
+    // the travel verdict a border officer is actually looking for.
+    await expect(open.getByText('Nobivac Rabies')).toBeInTheDocument();
+    await expect(open.getByText(/Batch RB-2025-118$/)).toBeInTheDocument();
+    await expect(open.getByText(/^1\.8 IU\/ml · /)).toBeInTheDocument();
+    await expect(open.getByText('Fit to travel')).toBeInTheDocument();
+    await expect(
+      open.getByText('Dr. Elena Marsh · 11.4 kg · 38.5°C · Bright, alert, responsive')
+    ).toBeInTheDocument();
+
+    // Both wallet actions, because the passport is issued and the share link is live.
+    await expect(open.getByRole('button', { name: 'Add to Apple Wallet' })).toBeEnabled();
+    await expect(open.getByRole('button', { name: 'Add to Google Wallet' })).toBeEnabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A fully populated passport: every section this view can draw is present at once, which is ' +
+          'the only configuration that shows the reading order a border officer works down - identity, ' +
+          'then owner, then description, chip, rabies, other jabs, parasites, titration, exam, and the ' +
+          'issuing practice last. Each section is conditional on its own data, so the eleven-child ' +
+          'count is what proves none of them dropped out; a renamed DTO field removes a whole block and ' +
+          'looks exactly like a pet with no records.',
+      },
+    },
+  },
+};
+
+export const NotIssued: Story = {
+  name: 'Ready - passport not issued yet',
+  beforeEach: withApi({
+    onPassport: (config) =>
+      ok(config, {
+        ...withoutIssuance(),
+        passportNumber: undefined,
+      } satisfies PetPassportDTO),
+  }),
+  play: async () => {
+    await waitFor(() => expect(dialog()).not.toBeNull());
+    const open = within(dialog() as HTMLElement);
+
+    expect(
+      await open.findByText('Wallet passes become available once a vet issues this passport.')
+    ).toBeInTheDocument();
+    await expect(
+      open.queryByRole('button', { name: 'Add to Apple Wallet' })
+    ).not.toBeInTheDocument();
+
+    // The record itself is complete and readable - only the issuance section and the
+    // passport number are missing, which is precisely what the sentence says.
+    await expect(open.getByText('Nobivac Rabies')).toBeInTheDocument();
+    await expect(open.queryByText('Issued by')).not.toBeInTheDocument();
+    const view = passportView(dialog() as HTMLElement);
+    await expect(view.children).toHaveLength(10);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The common state on a pet whose records exist but whose passport has not been issued. ' +
+          'Nothing is disabled and nothing is hidden behind a tooltip: the actions are simply absent, ' +
+          'and the sentence in their place names the step that unlocks them.',
+      },
+    },
+  },
+};
+
+export const NoShareLink: Story = {
+  name: 'Ready - issued, no share link',
+  beforeEach: withApi({
+    onPassport: (config) => ok(config, { ...PASSPORT, publicShareActive: false }),
+  }),
+  play: async () => {
+    await waitFor(() => expect(dialog()).not.toBeNull());
+    const open = within(dialog() as HTMLElement);
+
+    expect(
+      await open.findByText(
+        'The owner needs to create a share link in the Yosemite Crew app before this passport can be added to a wallet.'
+      )
+    ).toBeInTheDocument();
+    await expect(
+      open.queryByRole('button', { name: 'Add to Google Wallet' })
+    ).not.toBeInTheDocument();
+    // Issued, so the issuance section IS drawn - the gap is the share link, not the
+    // passport, and the two states are only distinguishable by this sentence.
+    await expect(open.getByText('Issued by')).toBeInTheDocument();
+    await expect(open.getByText('Harbourside Veterinary Group')).toBeInTheDocument();
+    // All eleven blocks, same as the shareable state: this story differs from
+    // `Ready` in the footer alone, and the count is what says so rather than the
+    // prose below claiming it.
+    await expect(passportView(dialog() as HTMLElement).children).toHaveLength(11);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The second gap, and the one that is easy to mistake for a bug: the passport is issued, the ' +
+          'card is complete, and the wallet actions are still gone. The QR on a wallet pass points at ' +
+          'the public share link, which only the pet parent can create, so a staff member cannot ' +
+          'resolve this from PIMS at all - the copy asks them to tell the owner rather than to retry.',
+      },
+    },
+  },
+};
+
+export const AddingToAppleWallet: Story = {
+  name: 'Busy - building the Apple pass',
+  play: async () => {
+    await waitFor(() => expect(dialog()).not.toBeNull());
+    const open = within(dialog() as HTMLElement);
+
+    await userEvent.click(await open.findByRole('button', { name: 'Add to Apple Wallet' }));
+
+    /* One `busy` value covers both buttons, so the pressed action reports progress
+       in its own label and the other goes inert - a second wallet request while the
+       first is still building would race two downloads at the same tab. */
+    expect(await open.findByRole('button', { name: 'Adding to Apple Wallet...' })).toBeDisabled();
+    await expect(open.getByRole('button', { name: 'Add to Google Wallet' })).toBeDisabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The `.pkpass` is fetched over the authenticated channel rather than followed as a link, ' +
+          'because the route needs session cookies - so there is a real wait here, and it is the only ' +
+          'moment either button is disabled.',
+      },
+    },
+  },
+};
+
+export const Loading: Story = {
+  name: 'Loading',
+  beforeEach: withApi({ onPassport: neverSettles }),
+  play: async () => {
+    await waitFor(() => expect(dialog()).not.toBeNull());
+    const open = within(dialog() as HTMLElement);
+
+    // The header is not gated on the response: the panel names the pet from the prop
+    // immediately, so the modal never opens as an untitled box.
+    await expect(open.getByRole('heading', { name: "Luna's passport" })).toBeInTheDocument();
+    await expect(open.getByText('Loading passport...')).toBeInTheDocument();
+    /* Nothing downstream of the response is drawn: not the card, and not the
+       wallet footer either. The footer is worth naming separately because its
+       default branch is `not-issued`, so a footer rendered before the passport
+       arrived would show the "once a vet issues this passport" sentence about a
+       passport that may well be issued. */
+    await expect(open.queryByText('Description')).not.toBeInTheDocument();
+    await expect(
+      open.queryByRole('button', { name: 'Add to Apple Wallet' })
+    ).not.toBeInTheDocument();
+    await expect(
+      open.queryByText('Wallet passes become available once a vet issues this passport.')
+    ).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The wait. It is short in practice and it is still worth drawing, because the modal opens ' +
+          'before the fetch resolves and the header is filled from the prop rather than the response - ' +
+          'so the panel is named from the moment it appears instead of growing a title a beat later.',
+      },
+    },
+  },
+};
+
+/** Passport reads the panel actually issued, reset by the story's own `beforeEach`. */
+const passportReads = { count: 0 };
+
+export const LoadFailed: Story = {
+  name: 'Error - passport could not be loaded',
+  beforeEach: () => {
+    passportReads.count = 0;
+    return withApi({
+      onPassport: (config) => {
+        passportReads.count += 1;
+        return noResponse(config);
+      },
+    })();
+  },
+  play: async () => {
+    await waitFor(() => expect(dialog()).not.toBeNull());
+    const open = within(dialog() as HTMLElement);
+
+    expect(await open.findByText('This passport could not be loaded.')).toBeInTheDocument();
+    await expect(open.queryByText('Loading passport...')).not.toBeInTheDocument();
+    await expect(
+      open.queryByRole('button', { name: 'Add to Apple Wallet' })
+    ).not.toBeInTheDocument();
+
+    /* One request, not four - which is the whole reason this story cans a
+       response-less failure rather than a 500. The panel has no retrying state
+       of its own, so the client's transient-retry ladder is invisible from the
+       screen and this count is the only place it is pinned: canned as a 5xx,
+       the identical copy arrives four requests and about five seconds later,
+       with "Loading passport..." on screen throughout. */
+    await expect(passportReads.count).toBe(1);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A failed read says so in the panel as well as in a toast, because the toast is gone in ' +
+          'four seconds and the open modal is not. The failure does not latch: the state lives in the ' +
+          'content component, which is unmounted on close and re-keyed per companion, so re-opening ' +
+          'the same pet retries rather than replaying this.\n\n' +
+          'The failure canned here is a transport one - no response at all. A 5xx reaches the same ' +
+          'copy by a much slower road: the shared axios client retries idempotent 429/5xx three ' +
+          'times with exponential backoff, so a passport read that 500s leaves this modal on ' +
+          '"Loading passport..." for around five seconds with nothing on screen saying it is still ' +
+          'trying. Worth deciding whether the panel should say so.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/settings/pages/Settings/Sections/HoursEditModal.stories.tsx
+++ b/apps/frontend/src/app/features/settings/pages/Settings/Sections/HoursEditModal.stories.tsx
@@ -1,0 +1,470 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import type { Organisation, UserOrganization } from '@yosemite-crew/types';
+
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useAuthStore } from '@/app/stores/authStore';
+import { useAvailabilityStore } from '@/app/stores/availabilityStore';
+import HoursEditModal from './HoursEditModal';
+
+const ORG_ID = 'org-storybook-hours';
+
+const ORG: Organisation = {
+  _id: ORG_ID,
+  name: 'Sunrise Veterinary Hospital',
+  type: 'HOSPITAL',
+  phoneNo: '4155550110',
+  taxId: 'DE-8871-2290',
+  isVerified: true,
+  isActive: true,
+};
+
+/**
+ * An org-level membership: `practitionerReference` is empty on purpose.
+ *
+ * With a practitioner reference the editor fetches that person's saved profile
+ * on mount and seeds the grid from the response, which needs a network stub this
+ * repo has no wiring for. Empty takes the org-level branch instead - the same
+ * one a non-practitioner admin gets - so the grid is seeded from the store and
+ * the mount stays offline.
+ */
+const membership: UserOrganization = {
+  id: 'membership-owner',
+  practitionerReference: '',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'OWNER',
+  active: true,
+};
+
+/**
+ * Seeds the real stores.
+ *
+ * The org's availability list is seeded EMPTY rather than with saved rows, and
+ * that is a deliberate choice: `convertFromGetApi` returns the Mon-Fri 09:00-17:00
+ * default without running any timezone conversion when no slot is available,
+ * while saved rows are stored as UTC clock times and get shifted into the
+ * viewer's preferred zone. Seeding rows would make the day and the label depend
+ * on the machine running Storybook; the default branch is identical everywhere.
+ */
+const seed = () => {
+  useOrgStore.setState({
+    orgsById: { [ORG_ID]: ORG },
+    orgIds: [ORG_ID],
+    primaryOrgId: ORG_ID,
+    membershipsByOrgId: { [ORG_ID]: membership },
+    status: 'loaded',
+  });
+  useAvailabilityStore.setState({
+    availabilitiesById: {},
+    availabilityIdsByOrgId: { [ORG_ID]: [] },
+  });
+  useAuthStore.setState({
+    attributes: { sub: 'user-1', given_name: 'Elena', family_name: 'Marsh' },
+  });
+
+  return () => {
+    useOrgStore.setState({
+      orgsById: {},
+      orgIds: [],
+      primaryOrgId: null,
+      membershipsByOrgId: {},
+      status: 'idle',
+    });
+    useAvailabilityStore.setState({ availabilitiesById: {}, availabilityIdsByOrgId: {} });
+    useAuthStore.setState({ attributes: null });
+  };
+};
+
+/** `showModal` is owned by the caller, so the harness holds it for Cancel to act on. */
+const HoursEditor = ({ open }: { open: boolean }) => {
+  const [showModal, setShowModal] = useState(open);
+  return (
+    <div className="min-h-[680px] bg-[var(--page)] p-6">
+      <p className="text-[13px] text-[var(--ink-muted)]">
+        Settings page behind the scrim, so the backdrop tint and blur are visible.
+      </p>
+      <HoursEditModal showModal={showModal} setShowModal={setShowModal} />
+    </div>
+  );
+};
+
+/** `ModalBase` portals to `document.body`, so the panel is never inside `canvasElement`. */
+const openPanel = (): Promise<HTMLElement> =>
+  waitFor(() => {
+    const panel = document.querySelector('dialog[open]');
+    expect(panel).not.toBeNull();
+    return panel as HTMLElement;
+  });
+
+const rowFor = (panel: HTMLElement, day: string): HTMLElement =>
+  within(panel).getByText(day).closest('div.grid') as HTMLElement;
+
+const meta = {
+  title: 'Settings/HoursEditModal',
+  component: HoursEditor,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The "Availability & consultation hours" editor behind the Settings hours card. It is ' +
+          'only reachable through a button on that card, so nothing about it - the seven-day ' +
+          'grid, the range editing, the guard on Save - had ever been drawn.\n\n' +
+          'Each day is a four-track grid: `40px` toggle, `96px` day name, `1fr` ranges, `auto` ' +
+          'actions. Nothing enforces that the four cells and the four tracks agree, and the ' +
+          'third cell has three shapes - a "Day off" span, one interval, or a wrapping row of ' +
+          'several - while the fourth stays mounted and empty on a disabled day. So the stories ' +
+          'assert the track count and the child count in all three, and the phone story asserts ' +
+          'what the fixed tracks do to a 375px sheet.\n\n' +
+          'Save is guarded, not validated: `hasAtLeastOneAvailability` sees an empty converted ' +
+          'payload and returns before any request, and the modal simply stays open with no ' +
+          'message. That silent branch is the one worth reviewing, and it has its own story ' +
+          'below.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: { open: true },
+  beforeEach: seed,
+} satisfies Meta<typeof HoursEditor>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Open: Story = {
+  name: 'Open (default hours)',
+  play: async () => {
+    const panel = await openPanel();
+    const dialog = within(panel);
+
+    await expect(
+      dialog.getByRole('heading', { name: 'Availability & consultation hours' })
+    ).toBeInTheDocument();
+    // Design subtitle: the signed-in practitioner, then the trailing clause.
+    await expect(
+      dialog.getByText('Elena Marsh · drives booking slots and the team planner')
+    ).toBeInTheDocument();
+
+    // Seven rows, Monday to Friday on. The two off days render "Day off" in place
+    // of their ranges rather than an empty cell.
+    await expect(dialog.getAllByRole('checkbox')).toHaveLength(7);
+    await expect(
+      dialog.getByRole('checkbox', { name: 'Enable availability for Monday' })
+    ).toBeChecked();
+    await expect(
+      dialog.getByRole('checkbox', { name: 'Enable availability for Sunday' })
+    ).not.toBeChecked();
+    await expect(dialog.getAllByText('Day off')).toHaveLength(2);
+
+    /* Four tracks and four children. A dropped track collapses the row to one
+       column and stacks toggle, name, ranges and actions vertically - which still
+       renders, still passes any "the row is there" assertion, and looks nothing
+       like the design. */
+    const monday = rowFor(panel, 'Monday');
+    const tracks = getComputedStyle(monday).gridTemplateColumns.trim().split(/\s+/);
+    await expect(tracks).toHaveLength(4);
+    await expect(monday.children).toHaveLength(4);
+    // The two fixed tracks, as the baseline the phone story below re-reads: they
+    // are the same 40px and 96px there, inside a sheet less than half this wide.
+    await expect(tracks[0]).toBe('40px');
+    await expect(tracks[1]).toBe('96px');
+
+    const mondayCells = within(monday);
+    await expect(mondayCells.getByText('9:00 AM')).toBeInTheDocument();
+    await expect(mondayCells.getByText('5:00 PM')).toBeInTheDocument();
+
+    // The footer note carries the zone the times are shown in, which is the only
+    // thing on screen that says these are not raw stored values.
+    const note = dialog.getByText(/booking slots follow each service/);
+    await expect(note.textContent).toMatch(/^[\w/+-]+ · booking slots follow each service/);
+    await expect(dialog.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    await expect(dialog.getByRole('button', { name: 'Save availability' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The editor as it opens for an organization with no saved hours: the Mon-Fri ' +
+          '09:00-17:00 default. Times are chips, not selects - 32px, `--field-bg`, tabular ' +
+          'figures - and the day column is fixed at 96px so every chip column starts on the ' +
+          'same x.',
+      },
+    },
+  },
+};
+
+export const EnableWeekendDay: Story = {
+  name: 'Turning a day on',
+  play: async () => {
+    const panel = await openPanel();
+    const dialog = within(panel);
+
+    const saturday = rowFor(panel, 'Saturday');
+    await expect(within(saturday).getByText('Day off')).toBeInTheDocument();
+    await expect(within(saturday).queryByText('9:00 AM')).toBeNull();
+
+    await userEvent.click(
+      dialog.getByRole('checkbox', { name: 'Enable availability for Saturday' })
+    );
+
+    // The ranges cell is replaced, not revealed: the "Day off" span is gone and a
+    // real interval with both chips took its place.
+    await waitFor(() => expect(within(saturday).queryByText('Day off')).toBeNull());
+    await expect(within(saturday).getByText('9:00 AM')).toBeInTheDocument();
+    await expect(within(saturday).getByText('5:00 PM')).toBeInTheDocument();
+    await expect(dialog.getAllByText('Day off')).toHaveLength(1);
+
+    // The two row actions only exist on an enabled day.
+    await expect(
+      within(saturday).getByRole('button', { name: 'Add range for Saturday' })
+    ).toBeInTheDocument();
+    /* `dublicate-button` is the shipped aria-label on the copy-to-other-days
+       control, spelling included. Asserted as-is rather than quietly matched by
+       title, because it is what a screen reader announces today. */
+    await expect(
+      within(saturday).getByRole('button', { name: 'dublicate-button' })
+    ).toBeInTheDocument();
+
+    // Same four tracks, same four cells, after the third cell changed shape.
+    await expect(getComputedStyle(saturday).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(
+      4
+    );
+    await expect(saturday.children).toHaveLength(4);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The toggle is a 36x22 pill with the native checkbox behind it at zero opacity, so ' +
+          'the visible state is `--blue` track / knob right versus `--band` track / knob left. ' +
+          'Enabling a day also grows the row by the two circle actions, which is the moment the ' +
+          '`auto` fourth track earns its place.',
+      },
+    },
+  },
+};
+
+export const SecondRange: Story = {
+  name: 'Adding and removing a second range',
+  play: async () => {
+    const panel = await openPanel();
+    const monday = rowFor(panel, 'Monday');
+    const cells = within(monday);
+
+    await expect(cells.getAllByText('9:00 AM')).toHaveLength(1);
+    await expect(cells.queryByRole('button', { name: 'Remove range 2 for Monday' })).toBeNull();
+
+    await userEvent.click(cells.getByRole('button', { name: 'Add range for Monday' }));
+
+    // A second interval, seeded from the same 09:00-17:00 default, plus the remove
+    // control that only ranges after the first one get.
+    await waitFor(() => expect(cells.getAllByText('9:00 AM')).toHaveLength(2));
+    await expect(cells.getAllByText('5:00 PM')).toHaveLength(2);
+    await expect(
+      cells.getByRole('button', { name: 'Remove range 2 for Monday' })
+    ).toBeInTheDocument();
+    // Both ranges live in the third cell and wrap inside it; the row keeps its
+    // four tracks rather than growing one per interval.
+    await expect(getComputedStyle(monday).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(4);
+    await expect(monday.children).toHaveLength(4);
+
+    await userEvent.click(cells.getByRole('button', { name: 'Remove range 2 for Monday' }));
+
+    await waitFor(() => expect(cells.getAllByText('9:00 AM')).toHaveLength(1));
+    await expect(cells.queryByRole('button', { name: 'Remove range 2 for Monday' })).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Split days (a morning and an afternoon clinic) are the reason ranges are a list. The ' +
+          'first range has no remove control on purpose - `deleteInterval` refuses index 0, and ' +
+          'emptying the list re-seeds the default rather than leaving an enabled day with no ' +
+          'hours.',
+      },
+    },
+  },
+};
+
+export const SaveWithNothingEnabled: Story = {
+  name: 'Save with every day off',
+  play: async () => {
+    const panel = await openPanel();
+    const dialog = within(panel);
+
+    for (const day of ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday']) {
+      await userEvent.click(
+        dialog.getByRole('checkbox', { name: `Enable availability for ${day}` })
+      );
+    }
+    await waitFor(() => expect(dialog.getAllByText('Day off')).toHaveLength(7));
+
+    await userEvent.click(dialog.getByRole('button', { name: 'Save availability' }));
+
+    /* The converted payload is empty, so `persistAvailability` returns false
+       before touching the network and the handler bails out of its own success
+       path. Waiting for the label to come back out of "Saving..." is what makes
+       the assertion below about the settled state rather than the first frame. */
+    await waitFor(() =>
+      expect(dialog.getByRole('button', { name: 'Save availability' })).toBeEnabled()
+    );
+    await expect(document.querySelector('dialog[open]')).not.toBeNull();
+    await expect(dialog.getAllByText('Day off')).toHaveLength(7);
+    // No message of any kind was added - the footer is still exactly the tz note
+    // and the two actions, which is what "silent" means concretely here.
+    const footer = dialog.getByRole('button', { name: 'Cancel' }).parentElement as HTMLElement;
+    await expect(footer.children).toHaveLength(3);
+    await expect(dialog.queryByRole('alert')).toBeNull();
+
+    /* The third shape of the ranges cell: no chips, no row actions, a "Day off"
+       span on its own. Same four tracks and four children as an enabled row - the
+       actions cell stays in the DOM empty rather than being conditionally dropped,
+       which is exactly what keeps the day column aligned down the seven rows. */
+    const monday = rowFor(panel, 'Monday');
+    await expect(getComputedStyle(monday).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(4);
+    await expect(monday.children).toHaveLength(4);
+    await expect(within(monday).queryByRole('button')).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The silent branch. Every day off is a legitimate thing to want to express, and the ' +
+          'editor refuses it without saying so: no toast, no inline message, the panel just ' +
+          'stays put. Whoever picks this up next should decide whether it wants a message or ' +
+          'a disabled Save.',
+      },
+    },
+  },
+};
+
+export const ClosesOnCancel: Story = {
+  name: 'Cancel closes without saving',
+  play: async () => {
+    const panel = await openPanel();
+    const dialog = within(panel);
+
+    // Edit something first, so "closed" is being asserted against a panel that
+    // had real state rather than against one that never finished rendering.
+    await userEvent.click(
+      dialog.getByRole('checkbox', { name: 'Enable availability for Saturday' })
+    );
+    await waitFor(() => expect(dialog.getAllByText('Day off')).toHaveLength(1));
+
+    await userEvent.click(dialog.getByRole('button', { name: 'Cancel' }));
+
+    /* Closed is not unmounted: the dialog stays in the DOM without its `open`
+       attribute, so absence has to be asserted against `dialog[open]` - a query
+       for the heading would still find it and pass with the panel dismissed. */
+    await waitFor(() => expect(document.querySelector('dialog[open]')).toBeNull());
+
+    /* And the mounted-but-closed panel still holds its whole tree, edit included.
+       Cancel is `setShowModal(false)` and nothing more: there is no reset, so the
+       Saturday toggle is still on behind the scrim and reopening the editor shows
+       the abandoned edit rather than the saved hours. That is the thing to look
+       at here, and it is why the assertion is on `dialog[open]` and not on text. */
+    const closed = within(panel);
+    await expect(
+      closed.getByRole('heading', { name: 'Availability & consultation hours' })
+    ).toBeInTheDocument();
+    await expect(closed.getAllByRole('checkbox')).toHaveLength(7);
+    await expect(
+      closed.getByRole('checkbox', { name: 'Enable availability for Saturday' })
+    ).toBeChecked();
+    await expect(closed.getAllByText('Day off')).toHaveLength(1);
+    // Inert while closed, which is what keeps that live tree off the tab order.
+    await expect(panel).toHaveAttribute('inert');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Cancel dismisses the panel and discards nothing. `HoursEditModal` holds the editable ' +
+          'availability in its own state and never unmounts, so an edit abandoned here is still ' +
+          'there the next time the card opens the editor - the seed from the store only runs ' +
+          'when the store snapshot itself changes. Worth deciding whether that is the intended ' +
+          'behaviour before anyone adds a confirmation step to it.',
+      },
+    },
+  },
+};
+
+export const PhoneSheet: Story = {
+  name: 'Phone: the editor as a bottom sheet',
+  // Pinned as a GLOBAL. `parameters.viewport.defaultViewport` was removed in
+  // Storybook 10 and is inert - a story using it renders the desktop panel under
+  // a name that promises a phone.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  parameters: {
+    chromatic: { viewports: [375] },
+    docs: {
+      description: {
+        story:
+          'Under 768px the centered panel re-forms into a bottom sheet with a grabber. The day ' +
+          'row does not re-form with it, and nothing in it gives. ' +
+          '`grid-cols-[40px_96px_1fr_auto]` carries no breakpoint, so the 40px toggle column and ' +
+          'the 96px day column hold their desktop sizes inside a 375px sheet; the time chip ' +
+          'holds its full 100px too, because a flex item with a definite width contributes that ' +
+          'width as its min-content contribution and the `1fr` track floors on it rather than ' +
+          'squeezing it. So the row does not wrap, does not shrink and does not re-form - its ' +
+          'tracks add up to 450px before padding and it overflows its own box. Every part of ' +
+          'that is measured below rather than left to the eye. The day column and the chip ' +
+          'widths are what a phone layout would have to change; this is the only story where ' +
+          'any of it is visible.',
+      },
+    },
+  },
+  play: async () => {
+    // `useIsPhone` is false during the first client render, so the sheet class
+    // arrives on a second pass rather than on mount.
+    const panel = await waitFor(() => {
+      const sheet = document.querySelector('dialog[open].yc-modal-sheet');
+      expect(sheet).not.toBeNull();
+      return sheet as HTMLElement;
+    });
+
+    await expect(
+      within(panel).getByRole('heading', { name: 'Availability & consultation hours' })
+    ).toBeInTheDocument();
+    await expect(within(panel).getAllByRole('checkbox')).toHaveLength(7);
+
+    const monday = rowFor(panel, 'Monday');
+    const tracks = getComputedStyle(monday).gridTemplateColumns.trim().split(/\s+/);
+    await expect(tracks).toHaveLength(4);
+    await expect(monday.children).toHaveLength(4);
+
+    /* The measured version of the claim in the prose, so the story proves it
+       rather than asserting it. The two fixed tracks do not respond to width at
+       all: they are still the desktop 40px and 96px inside a 375px sheet. */
+    await expect(tracks[0]).toBe('40px');
+    await expect(tracks[1]).toBe('96px');
+
+    /* And nothing else in the row gives either - which is the finding, and it is
+       NOT what this assertion used to claim. The chip carries `w-[100px]` with
+       `sm:w-[110px]` as its only step, and that step is at 640px, so 100px is
+       the phone width by default rather than by adaptation. Nor is it squeezed
+       into fitting: a flex item with a definite width contributes that width as
+       its min-content contribution, so the `1fr` track floors at the two chips
+       plus their gap instead of shrinking them. Pinned to what the component
+       does TODAY - exactly its design width, at a viewport it was never sized
+       for - with the class read as well as the box measured, so a changed
+       utility and a changed used width each fail on their own rather than one
+       silently covering for the other. */
+    const chip = within(monday).getByText('9:00 AM').closest('button') as HTMLElement;
+    const chipWrapper = chip.parentElement as HTMLElement;
+    await expect(chipWrapper.className).toContain('w-[100px]');
+    await expect(chipWrapper.className).toContain('sm:w-[110px]');
+    await expect(chip.getBoundingClientRect().width).toBeCloseTo(100, 1);
+
+    /* So nothing absorbs the deficit and the row simply overflows its own box.
+       The tracks add up on their own: 40 + 96 + (100 + 8 + 100) + (28 + 8 + 28)
+       plus three 14px gaps is 450px of track before the row's own 24px side
+       padding, inside a sheet that is 375px wide in total. That is the defect -
+       the day row has no phone layout at all - and this story is pinned to it
+       rather than asserting it away. The assertion fails the day someone gives
+       the row a real phone layout, which is the fix; this is the record that it
+       has not happened yet. */
+    await expect(monday.scrollWidth).toBeGreaterThan(monday.clientWidth);
+  },
+};

--- a/apps/frontend/src/app/features/tasks/components/TaskBoard.stories.tsx
+++ b/apps/frontend/src/app/features/tasks/components/TaskBoard.stories.tsx
@@ -1,0 +1,718 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import type { UserOrganization } from '@yosemite-crew/types';
+
+import type { StoredCompanion } from '@/app/features/companions/pages/Companions/types';
+import type { Team } from '@/app/features/organization/types/team';
+import type { Task } from '@/app/features/tasks/types/task';
+import { formatDateInPreferredTimeZone } from '@/app/lib/timezone';
+import { useAuthStore } from '@/app/stores/authStore';
+import { useCompanionStore } from '@/app/stores/companionStore';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useParentStore } from '@/app/stores/parentStore';
+import { useTeamStore } from '@/app/stores/teamStore';
+import TaskBoard from './TaskBoard';
+
+const ORG_ID = 'org-storybook';
+const ME = 'practitioner-elena';
+const COLLEAGUE = 'practitioner-ravi';
+
+const MEMBERSHIP: UserOrganization = {
+  id: 'membership-1',
+  practitionerReference: `Practitioner/${ME}`,
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'VETERINARIAN',
+  roleDisplay: 'Veterinarian',
+  active: true,
+};
+
+const teamMember = (practionerId: string, name: string, image?: string): Team => ({
+  _id: `team-${practionerId}`,
+  practionerId,
+  organisationId: ORG_ID,
+  name,
+  image,
+  role: 'VETERINARIAN',
+  speciality: [],
+  status: 'Available',
+  revokedPermissions: [],
+  effectivePermissions: [],
+  extraPerissions: [],
+});
+
+const TEAM: Team[] = [
+  teamMember(ME, 'Dr. Elena Marsh'),
+  // A legacy relative photo key, which is what older team rows actually carry.
+  // `getSafeImageUrl` degrades anything that is not an https URL to the shared
+  // person avatar, so this draws the <Image> branch of the assignee chip without
+  // handing next/image a value it would reject.
+  teamMember(COLLEAGUE, 'Dr. Ravi Patel', 'team/legacy-key.jpg'),
+];
+
+const COMPANION: StoredCompanion = {
+  id: 'companion-kiko',
+  organisationId: ORG_ID,
+  parentId: 'parent-marta',
+  name: 'Kiko',
+  type: 'dog',
+  breed: 'Border Collie',
+  dateOfBirth: new Date('2019-04-18T00:00:00.000Z'),
+  gender: 'male',
+  isInsured: false,
+  status: 'active',
+};
+
+/**
+ * A fixed base instant so the card meta lines are stable. The preferred timezone
+ * falls back to Europe/Berlin when nothing is stored and every formatter pins
+ * en-US, so what renders does not depend on the machine.
+ */
+const DUE_BASE = new Date('2026-03-12T09:00:00.000Z');
+const dueIn = (minutes: number) => new Date(DUE_BASE.getTime() + minutes * 60_000);
+
+const task = (over: Partial<Task> = {}): Task => ({
+  _id: 'task-1',
+  organisationId: ORG_ID,
+  assignedBy: ME,
+  assignedTo: COLLEAGUE,
+  audience: 'EMPLOYEE_TASK',
+  source: 'CUSTOM',
+  category: 'MEDICATION',
+  priority: 'MEDIUM',
+  name: 'Task',
+  dueAt: dueIn(60),
+  status: 'PENDING',
+  ...over,
+});
+
+const seed = () => {
+  useOrgStore.setState({
+    primaryOrgId: ORG_ID,
+    membershipsByOrgId: { [ORG_ID]: MEMBERSHIP },
+    status: 'loaded',
+  });
+  useTeamStore.getState().setTeamsForOrg(ORG_ID, TEAM);
+  useCompanionStore.getState().setCompanionsForOrg(ORG_ID, [COMPANION]);
+  // Cleared, not merely left alone. Zustand stores are module singletons shared
+  // by every story in the session, and `TaskInfo.stories` seeds a parent record
+  // under this same id. Without this reset, viewing that file first makes the
+  // board resolve `parent-marta` to "Marta Alvarez" through `useMemberMap` and
+  // the raw-id finding below silently changes with the order the stories were
+  // opened in. The board itself never loads parents - nothing on the tasks page
+  // does - so an empty parent store is also what a real /tasks visit starts from.
+  useParentStore.getState().clearParents();
+  useAuthStore.setState({
+    attributes: {
+      sub: ME,
+      email: 'elena.marsh@example.com',
+      given_name: 'Elena',
+      family_name: 'Marsh',
+    },
+  });
+};
+
+/**
+ * The due-time fragment of a card's meta line, built with the app's own formatter.
+ *
+ * Not hardcoded as "2:00 PM": `getPreferredTimeZone` reads a localStorage token, so
+ * a reviewer who changed the timezone anywhere else in this Storybook would make a
+ * literal string fail for a reason that has nothing to do with the board. Composing
+ * the expected line this way still pins the separator, the category label, the
+ * assignee and WHICH task's time is being printed.
+ */
+const dueTimeLabel = (task: Task): string =>
+  formatDateInPreferredTimeZone(new Date(task.dueAt), { hour: 'numeric', minute: '2-digit' });
+
+/* ─────────────────────────── DOM readers ─────────────────────────── */
+
+/**
+ * The four column elements, in `BOARD_COLUMNS` order.
+ *
+ * Read positionally off the track rather than by heading text: the columns carry
+ * no test id, and a text lookup would also match a card whose title happens to
+ * contain the word.
+ */
+const boardTrack = (canvasElement: HTMLElement): HTMLElement => {
+  const root = canvasElement.querySelector('[data-board-scroll-root="true"]');
+  if (!root?.firstElementChild) {
+    throw new Error('The board never rendered its column track.');
+  }
+  return root.firstElementChild as HTMLElement;
+};
+
+const boardColumns = (canvasElement: HTMLElement): HTMLElement[] =>
+  [...boardTrack(canvasElement).children] as HTMLElement[];
+
+const COLUMN = { pending: 0, inProgress: 1, completed: 2, cancelled: 3 } as const;
+
+/** Header row layout: [dot + label, count]. */
+const columnHeader = (column: HTMLElement): Element => {
+  const header = column.firstElementChild?.firstElementChild;
+  if (!header) throw new Error('A board column rendered without its header row.');
+  return header;
+};
+
+const columnLabel = (column: HTMLElement): string =>
+  (columnHeader(column).children[0]?.textContent ?? '').trim();
+
+const columnCount = (column: HTMLElement): string =>
+  (columnHeader(column).children[1]?.textContent ?? '').trim();
+
+/** The scrolling card list, which is the element the collapse keeps inside its box. */
+const columnScroller = (column: HTMLElement): HTMLElement => column.children[1] as HTMLElement;
+
+const cardsIn = (column: HTMLElement): HTMLElement[] => [...column.querySelectorAll('article')];
+
+/* Card layout: [full-bleed open button, title, meta, (progress), (footer), (updating)]. */
+const cardTitle = (card: Element): string => (card.children[1]?.textContent ?? '').trim();
+const cardMeta = (card: Element): string => (card.children[2]?.textContent ?? '').trim();
+const cardTitles = (column: HTMLElement): string[] => cardsIn(column).map(cardTitle);
+
+/* ─────────────────────────── Fixtures ─────────────────────────── */
+
+const MIXED_TASKS: Task[] = [
+  task({
+    _id: 'p-1',
+    name: 'Emergency triage handover',
+    status: 'PENDING',
+    priority: 'URGENT',
+    category: 'CARE',
+    dueAt: dueIn(240),
+  }),
+  task({
+    _id: 'p-2',
+    name: 'Midday analgesia round',
+    status: 'PENDING',
+    priority: 'HIGH',
+    assignedTo: ME,
+    companionId: COMPANION.id,
+    dueAt: dueIn(120),
+  }),
+  task({
+    _id: 'p-3',
+    name: 'Order more 22g catheters',
+    status: 'PENDING',
+    priority: 'LOW',
+    category: 'ADMIN',
+    dueAt: dueIn(30),
+  }),
+  task({
+    _id: 'p-4',
+    name: 'Upload the post-op photos',
+    status: 'PENDING',
+    audience: 'PARENT_TASK',
+    category: 'COMMUNICATION',
+    assignedTo: 'parent-marta',
+    dueAt: dueIn(300),
+  }),
+  task({
+    _id: 'i-1',
+    name: 'Dental chart for Kiko',
+    status: 'IN_PROGRESS',
+    category: 'PROCEDURE',
+    assignedTo: ME,
+    dueAt: dueIn(90),
+  }),
+  task({
+    _id: 'c-1',
+    name: 'Morning kennel walk',
+    status: 'COMPLETED',
+    category: 'CARE',
+    assignedTo: ME,
+    dueAt: dueIn(-120),
+  }),
+  task({
+    _id: 'x-1',
+    name: 'Repeat bloods for Nala',
+    status: 'CANCELLED',
+    category: 'DIAGNOSTIC',
+    dueAt: dueIn(-60),
+  }),
+];
+
+/** Eight settled tasks, which is four times what a collapsing column will show. */
+const OVERFLOW_TASKS: Task[] = [
+  ...Array.from({ length: 5 }, (_, index) =>
+    task({
+      _id: `p-${index + 1}`,
+      name: `Pending round ${index + 1}`,
+      status: 'PENDING',
+      dueAt: dueIn(index * 30),
+    })
+  ),
+  ...Array.from({ length: 8 }, (_, index) =>
+    task({
+      _id: `c-${index + 1}`,
+      name: `Completed round ${index + 1}`,
+      status: 'COMPLETED',
+      dueAt: dueIn(-600 + index * 30),
+    })
+  ),
+  ...Array.from({ length: 4 }, (_, index) =>
+    task({
+      _id: `x-${index + 1}`,
+      name: `Cancelled round ${index + 1}`,
+      status: 'CANCELLED',
+      dueAt: dueIn(-900 + index * 30),
+    })
+  ),
+];
+
+const meta = {
+  title: 'Tasks/TaskBoard',
+  component: TaskBoard,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The tasks kanban: four status columns, drag between them, and a card that changes shape ' +
+          'with the task on it.\n\n' +
+          '`BoardColumn` is module-private, so it is driven through the exported board rather than ' +
+          'exported for a story. It costs three store seeds and nothing else - the board reads ' +
+          'team, companions and auth through pure selectors, and the hooks that actually fetch ' +
+          '(`useLoadTeam`, `useLoadCompanionsForPrimaryOrg`) are separate and not used here. Real ' +
+          'component, real stores, no network.\n\n' +
+          '**The "+N more" collapse is not an overflow behaviour**, which is the single most ' +
+          'misread thing about this file. `COLLAPSING_COLUMNS` holds Completed and Cancelled, and ' +
+          '`COLLAPSED_CARD_COUNT` is 2: those two columns truncate to two cards as soon as they ' +
+          'hold a third, whatever the column height is, and Pending and In progress never truncate ' +
+          'no matter how far they overflow. The collapse story below sets the board short enough ' +
+          'that Pending genuinely overflows and scrolls while Completed - holding four times as ' +
+          'many cards - fits comfortably and truncates anyway. That inversion is the behaviour, ' +
+          'and it had never been rendered.\n\n' +
+          'The card has five variants that no snapshot had contained: a pink-bordered pet-parent ' +
+          'card, a done card (struck-through title, no footer), a cancelled card, an in-progress ' +
+          'card with a slim `<progress>` elapsed track, and a plain pending card. The muted states ' +
+          'deliberately carry **no opacity** - the meta line composited to 3.16:1 at 0.70 - so they ' +
+          'recede in ink and shadow only, and the difference between "done" and "pending" is worth ' +
+          'looking at directly.\n\n' +
+          'Layout re-forms at `lg` (1024px): a four-track CSS grid above it, a row of fixed 320px ' +
+          'columns in a horizontal scroller below. Both are drawn.\n\n' +
+          'One finding: a pet-parent card resolves its assignee through the team map only, so a ' +
+          'task addressed to an owner who is not a practitioner falls back to printing the raw ' +
+          'identifier in the meta line. The task drawer fixed exactly this with an "Unavailable ' +
+          'member" fallback; the board did not.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    tasks: MIXED_TASKS,
+    canEditTasks: true,
+    setActiveTask: fn(),
+    setViewPopup: fn(),
+    onAddTask: fn(),
+  },
+  beforeEach: () => {
+    seed();
+  },
+  decorators: [
+    (Story) => (
+      <div className="h-[560px] bg-[var(--screen)] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof TaskBoard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const BoardColumns: Story = {
+  name: 'Four columns',
+  // Pinned even though `laptop` is already the project's initialGlobals value.
+  // The viewport global PERSISTS across stories once a reader touches the toolbar,
+  // so opening the phone story below and coming back here would render this one at
+  // 375 - where the grid is off entirely and the four-track assertion fails for a
+  // reason that has nothing to do with the board.
+  globals: { viewport: { value: 'laptop', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const track = boardTrack(canvasElement);
+    const columns = boardColumns(canvasElement);
+
+    // A CSS grid pretending to be a board: nothing enforces that the track count
+    // and the child count agree, and a dropped or malformed template collapses to
+    // a single column that still renders every card, just stacked.
+    const tracks = getComputedStyle(track).gridTemplateColumns.trim().split(/\s+/);
+    await expect(tracks).toHaveLength(4);
+    await expect(columns).toHaveLength(4);
+
+    await expect(columns.map(columnLabel)).toEqual([
+      'Pending',
+      'In progress',
+      'Completed',
+      'Cancelled',
+    ]);
+    await expect(columns.map(columnCount)).toEqual(['4', '1', '1', '1']);
+
+    // Ordering is priority first, then due time - so the urgent card leads and the
+    // low-priority one sinks, regardless of when either is due.
+    await expect(cardTitles(columns[COLUMN.pending])).toEqual([
+      'Emergency triage handover',
+      'Midday analgesia round',
+      'Upload the post-op photos',
+      'Order more 22g catheters',
+    ]);
+
+    // Four meta shapes, built by four different branches of `buildBoardMeta`.
+    // Asserted whole rather than by regex: a `.+` in the middle would accept a
+    // blank time, the wrong task's time, or a missing separator.
+    await expect(cardMeta(cardsIn(columns[COLUMN.pending])[0])).toBe(
+      `Care · due ${dueTimeLabel(MIXED_TASKS[0])} · Dr. Ravi Patel`
+    );
+    await expect(cardMeta(cardsIn(columns[COLUMN.completed])[0])).toBe('Care · done · you');
+    await expect(cardMeta(cardsIn(columns[COLUMN.cancelled])[0])).toBe(
+      'Cancelled · Dr. Ravi Patel'
+    );
+    // FINDING: a pet-parent task prints the raw assignee id where a name belongs,
+    // because the board resolves through the team map only.
+    await expect(cardMeta(cardsIn(columns[COLUMN.pending])[2])).toBe('Parent task · parent-marta');
+
+    // The card footer: assignee chip on the left, companion thumbnail on the right.
+    // Initials rather than photos on both, because neither record carries an image.
+    const mine = cardsIn(columns[COLUMN.pending])[1];
+    const footer = mine.children[3] as HTMLElement;
+    await expect(footer.children).toHaveLength(2);
+    await expect((footer.children[0].textContent ?? '').trim()).toBe('EMyou');
+    await expect((footer.children[1].textContent ?? '').trim()).toBe('K');
+
+    // The colleague's row carries a photo key, so that chip renders an <img>.
+    const theirs = cardsIn(columns[COLUMN.pending])[0];
+    await expect(theirs.querySelector('img')).toHaveAttribute('alt', 'Dr. Ravi Patel');
+
+    // Done and cancelled cards drop the footer entirely rather than dimming it:
+    // three children (open button, title, meta) against the four a live card has.
+    await expect(cardsIn(columns[COLUMN.completed])[0].children).toHaveLength(3);
+    await expect(mine.children).toHaveLength(4);
+
+    // Only terminal cards refuse to be picked up: `draggable` is gated on the
+    // status having any legal transition at all.
+    await expect(cardsIn(columns[COLUMN.pending])[0].draggable).toBe(true);
+    await expect(cardsIn(columns[COLUMN.completed])[0].draggable).toBe(false);
+
+    // The add affordance belongs to Pending alone.
+    await expect(
+      within(columns[COLUMN.pending]).getByRole('button', { name: 'Add task to Pending' })
+    ).toBeInTheDocument();
+    await expect(
+      within(columns[COLUMN.completed]).queryByRole('button', { name: 'Add task to Pending' })
+    ).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting board with one of every card in it. Read the four meta lines against each ' +
+          'other: they come from four separate branches and only agree on the middle dot.',
+      },
+    },
+  },
+};
+
+export const ColumnOverflowCollapse: Story = {
+  name: 'Column collapse ("+ 6 more")',
+  args: { tasks: OVERFLOW_TASKS },
+  // Pinned for the same reason as the story above: the scroll-height comparisons
+  // below are read against a 420px board of four grid columns, and a leaked
+  // `mobile` global would measure 320px flex columns instead.
+  globals: { viewport: { value: 'laptop', isRotated: false } },
+  decorators: [
+    // Deliberately short. At this height the Pending column - five cards with
+    // footers - genuinely overflows and scrolls, while Completed holds eight
+    // shorter cards that would fit and truncates anyway. That inversion is the
+    // whole point of the story.
+    (Story) => (
+      <div className="h-[420px] bg-[var(--screen)] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    const track = boardTrack(canvasElement);
+    const columns = boardColumns(canvasElement);
+    const completed = columns[COLUMN.completed];
+    const pending = columns[COLUMN.pending];
+
+    // The board is still a four-track grid with four children while a column is
+    // truncated. Collapsing changes what is INSIDE a column and must never
+    // change the shape of the board, and a story that only indexed
+    // `columns[2]` would keep passing if the grid had dropped to one track.
+    await expect(getComputedStyle(track).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(4);
+    await expect(columns).toHaveLength(4);
+
+    // The header keeps the TRUE total while the list shows two. A collapse that
+    // also truncated the count would read as "there are only 2" and lose 6 tasks.
+    await expect(columnCount(completed)).toBe('8');
+    await expect(cardsIn(completed)).toHaveLength(2);
+    // The two survivors are the first two in board order, not an arbitrary pair.
+    await expect(cardTitles(completed)).toEqual(['Completed round 1', 'Completed round 2']);
+    await expect(within(completed).getByRole('button', { name: '+ 6 more' })).toBeInTheDocument();
+
+    // Truncated, and comfortably inside its box - nothing here overflows.
+    const completedScroller = columnScroller(completed);
+    await expect(completedScroller.scrollHeight).toBeLessThanOrEqual(
+      completedScroller.clientHeight
+    );
+
+    // Meanwhile the column that DOES overflow is the one with no collapse at all.
+    const pendingScroller = columnScroller(pending);
+    await expect(cardsIn(pending)).toHaveLength(5);
+    await expect(pendingScroller.scrollHeight).toBeGreaterThan(pendingScroller.clientHeight);
+    await expect(within(pending).queryByRole('button', { name: /more$/ })).not.toBeInTheDocument();
+
+    // Cancelled collapses on the same rule with a different remainder.
+    await expect(columnCount(columns[COLUMN.cancelled])).toBe('4');
+    await expect(cardsIn(columns[COLUMN.cancelled])).toHaveLength(2);
+    await expect(
+      within(columns[COLUMN.cancelled]).getByRole('button', { name: '+ 2 more' })
+    ).toBeInTheDocument();
+
+    // Expanding restores every card and relabels the control.
+    await userEvent.click(within(completed).getByRole('button', { name: '+ 6 more' }));
+    await waitFor(() => expect(cardsIn(completed)).toHaveLength(8));
+    await expect(cardTitles(completed)).toEqual([
+      'Completed round 1',
+      'Completed round 2',
+      'Completed round 3',
+      'Completed round 4',
+      'Completed round 5',
+      'Completed round 6',
+      'Completed round 7',
+      'Completed round 8',
+    ]);
+    await expect(within(completed).getByRole('button', { name: 'Show less' })).toBeInTheDocument();
+    // Now it overflows, and the column scrolls rather than growing the board.
+    await expect(columnScroller(completed).scrollHeight).toBeGreaterThan(
+      columnScroller(completed).clientHeight
+    );
+
+    // And it collapses back: the control is a toggle, not a one-way reveal.
+    await userEvent.click(within(completed).getByRole('button', { name: 'Show less' }));
+    await waitFor(() => expect(cardsIn(completed)).toHaveLength(2));
+    await expect(within(completed).getByRole('button', { name: '+ 6 more' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Eight completed tasks, four cancelled, five pending, in a board 420px tall. Completed ' +
+          'and Cancelled truncate to two cards and offer the rest behind a link; Pending overflows ' +
+          'its box and just scrolls. The collapse is keyed on the STATUS, not on the height - so ' +
+          'a Completed column with three short cards in a tall board still hides one, and a ' +
+          'Pending column with forty cards hides none.\n\n' +
+          'The link is a bare text button in `--blue-text` with no underline, no icon and no hit ' +
+          'padding beyond its line box, sitting where a reader expects the next card. Worth a ' +
+          'look at whether it reads as a control at all.',
+      },
+    },
+  },
+};
+
+export const EmptyBoard: Story = {
+  name: 'Nothing to do',
+  args: { tasks: [] },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const columns = boardColumns(canvasElement);
+
+    await expect(columns.map(columnCount)).toEqual(['0', '0', '0', '0']);
+    // Every column states its own emptiness rather than the board stating it once.
+    await expect(canvas.getAllByText('No tasks')).toHaveLength(4);
+    await expect(cardsIn(columns[COLUMN.pending])).toHaveLength(0);
+    // The add affordance survives the empty state, which is the only route into
+    // the board from here.
+    await expect(
+      within(columns[COLUMN.pending]).getByRole('button', { name: 'Add task to Pending' })
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Four dashed placeholders rather than one empty-board illustration. On a fresh ' +
+          'organisation this is the first screen anyone sees.',
+      },
+    },
+  },
+};
+
+export const MineOnly: Story = {
+  name: 'Scoped to my tasks',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const before = boardColumns(canvasElement);
+    await expect(before.map(columnCount)).toEqual(['4', '1', '1', '1']);
+
+    await userEvent.click(canvas.getByRole('button', { name: 'My tasks' }));
+
+    await waitFor(() =>
+      expect(boardColumns(canvasElement).map(columnCount)).toEqual(['1', '1', '1', '0'])
+    );
+    const columns = boardColumns(canvasElement);
+    // Filtering is by assignee, so the parent task and the colleague's work leave
+    // together - including a cancelled column that empties into its placeholder.
+    await expect(cardTitles(columns[COLUMN.pending])).toEqual(['Midday analgesia round']);
+    await expect(cardTitles(columns[COLUMN.inProgress])).toEqual(['Dental chart for Kiko']);
+    await expect(within(columns[COLUMN.cancelled]).getByText('No tasks')).toBeInTheDocument();
+
+    await expect(canvas.getByRole('button', { name: 'My tasks' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    await expect(canvas.getByRole('button', { name: 'All tasks' })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The board has no filter bar - this segmented toggle is its entire filtering surface, ' +
+          'and it sits alone in an otherwise empty control row above the columns. The scope is ' +
+          'local state, so it resets on every remount.',
+      },
+    },
+  },
+};
+
+export const ReadOnlyBoard: Story = {
+  name: 'Without edit rights',
+  args: { canEditTasks: false },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const columns = boardColumns(canvasElement);
+
+    // Same four columns and the same cards - a reader loses the two ways of
+    // changing anything and nothing else.
+    await expect(columns.map(columnCount)).toEqual(['4', '1', '1', '1']);
+    await expect(
+      canvas.queryByRole('button', { name: 'Add task to Pending' })
+    ).not.toBeInTheDocument();
+    // Written as a list rather than `.every(...)`: an every() over an empty array
+    // is true, so a board that rendered no cards at all would have passed the
+    // read-only check it exists to make.
+    await expect(cardsIn(columns[COLUMN.pending]).map((card) => card.draggable)).toEqual([
+      false,
+      false,
+      false,
+      false,
+    ]);
+    // Opening a task is still allowed, so every card keeps its full-bleed button.
+    await expect(
+      within(columns[COLUMN.pending]).getByRole('button', {
+        name: 'Open task Emergency triage handover',
+      })
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'No banner and no disabled styling: drag simply does not start, and the dashed Add tile ' +
+          'is absent from the bottom of the Pending column.',
+      },
+    },
+  },
+};
+
+export const ElapsedTrack: Story = {
+  name: 'In-progress elapsed track',
+  args: {
+    tasks: [
+      task({
+        _id: 'i-live',
+        name: 'Fluid therapy check',
+        status: 'IN_PROGRESS',
+        assignedTo: ME,
+        // Relative to now on purpose: the track is drawn from `Date.now()` against
+        // the run-up between the last update and the due time, so a fixed pair of
+        // 2026 timestamps would always clamp to a full bar.
+        updatedAt: new Date(Date.now() - 60 * 60_000),
+        dueAt: new Date(Date.now() + 60 * 60_000),
+      }),
+      task({
+        _id: 'p-live',
+        name: 'Discharge paperwork',
+        status: 'PENDING',
+        assignedTo: ME,
+        updatedAt: new Date(Date.now() - 60 * 60_000),
+        dueAt: new Date(Date.now() + 60 * 60_000),
+      }),
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const columns = boardColumns(canvasElement);
+    await expect(columns).toHaveLength(4);
+    await expect(columns.map(columnCount)).toEqual(['1', '1', '0', '0']);
+
+    const track = within(columns[COLUMN.inProgress]).getByRole('progressbar', {
+      name: 'Time elapsed toward due for Fluid therapy check',
+    }) as HTMLProgressElement;
+    // Halfway between the last update and the due time, so the value has to land
+    // near the middle - a track stuck at 0 or clamped to 100 renders as a
+    // perfectly plausible bar and tells the reader nothing. `max` is asserted
+    // with it because a value of 50 against a max of 1 draws a full bar.
+    await expect(track.max).toBe(100);
+    await expect(track.value).toBeGreaterThan(35);
+    await expect(track.value).toBeLessThan(65);
+
+    // The same timestamps on a pending card draw no track at all: the guard is on
+    // the status, so the bar means "running", not "overdue".
+    await expect(
+      within(columns[COLUMN.pending]).queryByRole('progressbar')
+    ).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A native `<progress>` restyled into a 5px pill (`TaskBoard.css` paints the groove and ' +
+          'the value per engine, since WebKit, Blink and Gecko each expose different ' +
+          'pseudo-elements). It is drawn only for an in-progress task that carries usable ' +
+          'timestamps, which is why every other story here has no track on any card.',
+      },
+    },
+  },
+};
+
+export const PhoneBoard: Story = {
+  name: 'Phone (375): a horizontal scroller',
+  // Pinned as a GLOBAL. `parameters.viewport.defaultViewport` was removed in
+  // Storybook 10 - it still type-checks and still runs, and silently renders the
+  // desktop grid under a name that promises a phone.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const track = boardTrack(canvasElement);
+    const columns = boardColumns(canvasElement);
+
+    // Below lg the grid is off entirely and the columns become a fixed-width flex
+    // row. Assert both halves: `display` alone would still pass if the grid
+    // template survived, and a stale template is what makes a 4-up board render
+    // as one 320px column with everything crammed into it.
+    await expect(getComputedStyle(track).display).toBe('flex');
+    await expect(getComputedStyle(track).gridTemplateColumns).toBe('none');
+    await expect(columns).toHaveLength(4);
+    await expect(Math.round(columns[0].getBoundingClientRect().width)).toBe(320);
+
+    // Four 320px columns plus gaps do not fit in 375, which is the point - the
+    // board is swiped sideways rather than reflowed.
+    const scrollRoot = track.parentElement as HTMLElement;
+    await expect(scrollRoot.scrollWidth).toBeGreaterThan(scrollRoot.clientWidth);
+
+    // Cards keep their full content at this width rather than dropping the footer.
+    await expect(cardTitles(columns[COLUMN.pending])[0]).toBe('Emergency triage handover');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'One column and a sliver of the next, swiped horizontally. The wheel handler converts ' +
+          'vertical scrolling into horizontal movement here, and each column keeps its own ' +
+          'vertical scroller inside, so this frame has three nested scroll directions competing ' +
+          'in 375px.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/tasks/pages/Tasks/Sections/ChangeStatus.stories.tsx
+++ b/apps/frontend/src/app/features/tasks/pages/Tasks/Sections/ChangeStatus.stories.tsx
@@ -1,0 +1,424 @@
+import { type ComponentProps, useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+
+import type { Task } from '@/app/features/tasks/types/task';
+import ChangeTaskStatus from './ChangeStatus';
+
+type ChangeTaskStatusProps = ComponentProps<typeof ChangeTaskStatus>;
+
+const task = (over: Partial<Task> = {}): Task => ({
+  _id: 'task-analgesia',
+  organisationId: 'org-storybook',
+  assignedBy: 'practitioner-elena',
+  assignedTo: 'practitioner-ravi',
+  audience: 'EMPLOYEE_TASK',
+  source: 'CUSTOM',
+  category: 'MEDICATION',
+  priority: 'HIGH',
+  name: 'Midday analgesia round',
+  // Fixed instant: `getPreferredTimeZone` returns Europe/Berlin whenever no
+  // timezone token is stored, so every label below is machine-independent.
+  dueAt: new Date('2026-03-12T12:00:00.000Z'),
+  status: 'PENDING',
+  ...over,
+});
+
+/**
+ * The consumers (the board's drag handler, the task list's quick action) mount this
+ * on demand and unmount it on dismissal. The harness reproduces that lifecycle and
+ * keeps the dialog off the docs page at rest, where `ModalBase`'s shared body scroll
+ * lock would otherwise be held by five open dialogs at once.
+ */
+const StatusFlowHarness = ({
+  showModal: _showModal,
+  setShowModal: _setShowModal,
+  ...args
+}: ChangeTaskStatusProps) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="flex min-h-[420px] items-start p-6">
+      <button
+        type="button"
+        className="rounded-2xl bg-[var(--cta)] px-6 py-3 text-body-3-emphasis text-[var(--cta-text)]"
+        onClick={() => setOpen(true)}
+      >
+        Open status chooser
+      </button>
+      {open && <ChangeTaskStatus {...args} showModal setShowModal={setOpen} />}
+    </div>
+  );
+};
+
+/**
+ * Opens the chooser and returns the live dialog.
+ *
+ * Matched on `dialog[open]` rather than on the panel class: `ModalBase` leaves a
+ * dismissed dialog MOUNTED and merely drops the `open` attribute, so a class
+ * lookup can return a dialog that is no longer on screen.
+ */
+const openDialog = async (canvasElement: HTMLElement) => {
+  const canvas = within(canvasElement);
+  await userEvent.click(canvas.getByRole('button', { name: 'Open status chooser' }));
+  return waitFor(() => {
+    const dialog = document.querySelector('dialog[open]');
+    expect(dialog).not.toBeNull();
+    return dialog as HTMLElement;
+  });
+};
+
+/**
+ * Opens the status menu and returns the panel.
+ *
+ * `LabelDropdown` portals its panel to `document.body`, so it is outside both the
+ * canvas and the dialog. The LAST match is taken rather than the first: a panel
+ * left open by an earlier story on the docs page is still in the body, and
+ * `querySelector` would happily return that one and assert against stale options.
+ */
+const openStatusMenu = async (dialog: HTMLElement, currentLabel: string) => {
+  await userEvent.click(
+    within(dialog).getByRole('button', { name: `Task status: ${currentLabel}` })
+  );
+  return waitFor(() => {
+    const panels = document.querySelectorAll('[data-portal-dropdown]');
+    expect(panels.length).toBeGreaterThan(0);
+    return panels[panels.length - 1] as HTMLElement;
+  });
+};
+
+/** Every option the menu is currently offering, in render order. */
+const menuOptions = (panel: HTMLElement): string[] =>
+  [...panel.querySelectorAll('button')].map((option) => (option.textContent ?? '').trim());
+
+const meta = {
+  title: 'Tasks/ChangeTaskStatus',
+  component: ChangeTaskStatus,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The status chooser a task is moved with, from the board, the week agenda and the task ' +
+          'list. It is a thin wrapper: everything visible comes from the shared ' +
+          '`ChangeStatusModal`, and what this file contributes is the **option list**, computed ' +
+          'from the task taxonomy as `{current status} + getAllowedTaskStatusTransitions(current)`.\n\n' +
+          'That computation is the whole reason it needs stories. The transition table is ' +
+          'directional and lossy - `PENDING` can go anywhere, `IN_PROGRESS` can only move forward ' +
+          'to Completed or Cancelled, and both terminal states allow nothing at all - so the same ' +
+          'dialog offers four options, three options or exactly one depending on the task it was ' +
+          'opened for. Nothing in the markup announces which case a reviewer is looking at, and ' +
+          'until now none of the three had ever been rendered.\n\n' +
+          'The menu itself is a `LabelDropdown` with `searchable={false}` that `createPortal`s its ' +
+          'panel to `document.body`, so the options are not inside the dialog and not inside the ' +
+          'canvas. They only exist after a click on the trigger, which is why every story here ' +
+          'opens it rather than trusting the resting trigger label alone.\n\n' +
+          '`preferredStatus` is the other half. Callers that already know where the task is going ' +
+          '(a card dropped onto the Completed column) pass it so the dialog opens pre-answered, ' +
+          'and `resolveSelectedStatus` silently falls back to the current status when that ' +
+          'preference is not a legal move. A regression there is invisible: the dialog still ' +
+          'opens, it just quietly proposes the wrong thing.\n\n' +
+          'No story here presses **Update**. Saving calls `changeTaskStatus`, which writes to the ' +
+          'task store and POSTs, and this Storybook has no request mocking - the stories stop at ' +
+          'the last frame before the write.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    showModal: true,
+    setShowModal: fn(),
+    activeTask: task(),
+    preferredStatus: null,
+  },
+  render: (args) => <StatusFlowHarness {...args} />,
+} satisfies Meta<typeof ChangeTaskStatus>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const PendingTask: Story = {
+  name: 'Pending - every move is legal',
+  play: async ({ canvasElement }) => {
+    const dialog = await openDialog(canvasElement);
+    await expect(
+      within(dialog).getByRole('heading', { name: 'Change status' })
+    ).toBeInTheDocument();
+
+    const panel = await openStatusMenu(dialog, 'Pending');
+    // The point of the story is WHICH options exist, not that a panel appeared:
+    // an empty panel, or one built from the full TaskStatusOptions list ignoring
+    // the transition table, would both satisfy "the menu opened".
+    await expect(menuOptions(panel)).toEqual(['Pending', 'In Progress', 'Completed', 'Cancelled']);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A pending task is the only case where the menu is the whole status list. Every other ' +
+          'story below is this same dialog with rows missing.',
+      },
+    },
+  },
+};
+
+export const InProgressTask: Story = {
+  name: 'In progress - no way back to Pending',
+  args: { activeTask: task({ status: 'IN_PROGRESS' }) },
+  play: async ({ canvasElement }) => {
+    const dialog = await openDialog(canvasElement);
+    await expect(
+      within(dialog).getByRole('button', { name: 'Task status: In Progress' })
+    ).toBeInTheDocument();
+
+    const panel = await openStatusMenu(dialog, 'In Progress');
+    await expect(menuOptions(panel)).toEqual(['In Progress', 'Completed', 'Cancelled']);
+    // Asserted explicitly, not just implied by the count: "Pending is gone" is the
+    // behaviour, and a four-option regression would still pass a length check that
+    // was written as `toBeGreaterThan`.
+    await expect(menuOptions(panel)).not.toContain('Pending');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Started work cannot be un-started. The dialog looks identical to the pending one - same ' +
+          'height, same trigger, same two actions - and the only difference is a row that is not ' +
+          'in the portalled menu.',
+      },
+    },
+  },
+};
+
+export const TerminalTask: Story = {
+  name: 'Completed - the menu has one row',
+  args: { activeTask: task({ status: 'COMPLETED' }) },
+  play: async ({ canvasElement }) => {
+    const dialog = await openDialog(canvasElement);
+    const panel = await openStatusMenu(dialog, 'Completed');
+    await expect(menuOptions(panel)).toEqual(['Completed']);
+
+    // The dead end is the point of the story, so it is asserted rather than only
+    // described: the dialog offers a full Cancel/Update pair, both live, over a
+    // menu that cannot change anything. Nothing in the frame is disabled or
+    // greyed, which is exactly what makes it easy to miss.
+    await expect(within(dialog).getByRole('button', { name: 'Update' })).toBeEnabled();
+    await expect(within(dialog).getByRole('button', { name: 'Cancel' })).toBeEnabled();
+    await expect(
+      within(dialog).getByRole('button', { name: 'Task status: Completed' })
+    ).toHaveAttribute('aria-haspopup', 'listbox');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Completed and Cancelled allow no transitions, so the filter leaves only the status the ' +
+          'task already has. The dialog still opens with a live Update button, because the guard ' +
+          'that should keep it shut lives in the CALLERS ' +
+          '(`canShowTaskStatusChangeAction`) rather than here - press it and `handleSave` ' +
+          'short-circuits on `currentStatus === selectedStatus` and just closes. Worth a look: ' +
+          'this is a dead-end dialog that presents itself as an editable one.',
+      },
+    },
+  },
+};
+
+export const PreferredStatus: Story = {
+  name: 'Pre-answered by the caller',
+  args: { activeTask: task(), preferredStatus: 'COMPLETED' },
+  play: async ({ canvasElement }) => {
+    const dialog = await openDialog(canvasElement);
+    // Pre-selection is carried ONLY by the trigger label - there is no highlight,
+    // no badge and no second affordance - so this one string is the entire signal
+    // that the caller's intent survived into the dialog.
+    await expect(
+      within(dialog).getByRole('button', { name: 'Task status: Completed' })
+    ).toBeInTheDocument();
+    await expect(
+      within(dialog).queryByRole('button', { name: 'Task status: Pending' })
+    ).not.toBeInTheDocument();
+
+    // The pre-selection must not narrow the menu. Options are filtered from the
+    // task's CURRENT status, so a pending task pre-answered as Completed still
+    // offers all four - the reader can overrule the drop they just made. A
+    // regression that filtered from the preference instead would leave a
+    // one-row menu here and still satisfy the trigger-label check above.
+    const panel = await openStatusMenu(dialog, 'Completed');
+    await expect(menuOptions(panel)).toEqual(['Pending', 'In Progress', 'Completed', 'Cancelled']);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'What a card dropped onto the Completed column opens: the destination is already chosen ' +
+          'and the reader only has to confirm it. The menu behind it is unchanged - every move ' +
+          'legal from Pending is still on offer, so the drop is a proposal rather than a decision.',
+      },
+    },
+  },
+};
+
+export const PreferredStatusRejected: Story = {
+  name: 'Illegal preference falls back',
+  args: { activeTask: task({ status: 'IN_PROGRESS' }), preferredStatus: 'PENDING' },
+  play: async ({ canvasElement }) => {
+    const dialog = await openDialog(canvasElement);
+    // Pending is neither a legal move from IN_PROGRESS nor present in the filtered
+    // options, so `resolveSelectedStatus` drops it and keeps the current status.
+    await expect(
+      within(dialog).getByRole('button', { name: 'Task status: In Progress' })
+    ).toBeInTheDocument();
+
+    const panel = await openStatusMenu(dialog, 'In Progress');
+    await expect(menuOptions(panel)).toEqual(['In Progress', 'Completed', 'Cancelled']);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A caller asking for an impossible move gets no error and no explanation - the dialog ' +
+          'opens on the current status as if nothing had been requested. That silence is the ' +
+          'behaviour under review here: the only way to notice it is to compare this frame with ' +
+          'the pre-answered one above.',
+      },
+    },
+  },
+};
+
+export const ChoosingAStatus: Story = {
+  name: 'Choosing a status',
+  args: { activeTask: task() },
+  play: async ({ canvasElement }) => {
+    const dialog = await openDialog(canvasElement);
+    const panel = await openStatusMenu(dialog, 'Pending');
+
+    await userEvent.click(within(panel).getByRole('button', { name: 'Completed' }));
+
+    // The selection moves the trigger label and closes the panel. Both matter:
+    // `LabelDropdown` keeps its own `internalSelected`, so a controlled parent
+    // that never echoes the value back would leave the label stale.
+    await waitFor(() =>
+      expect(document.querySelectorAll('[data-portal-dropdown]')).toHaveLength(0)
+    );
+    await expect(
+      within(dialog).getByRole('button', { name: 'Task status: Completed' })
+    ).toBeInTheDocument();
+    // Choosing is not committing: the dialog stays open on its Cancel/Update pair.
+    await expect(document.querySelector('dialog[open]')).not.toBeNull();
+    await expect(within(dialog).getByRole('button', { name: 'Cancel' })).toBeEnabled();
+    await expect(within(dialog).getByRole('button', { name: 'Update' })).toBeEnabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The frame between opening and saving, which is where the dialog spends most of its ' +
+          'life and which no snapshot had ever contained.',
+      },
+    },
+  },
+};
+
+export const CancelLeavesTheTask: Story = {
+  name: 'Cancel closes without a write',
+  args: { activeTask: task() },
+  play: async ({ canvasElement }) => {
+    const dialog = await openDialog(canvasElement);
+
+    // Move the selection first, so Cancel has something to abandon. Cancelling an
+    // untouched dialog would close either way and prove nothing about discarding.
+    const panel = await openStatusMenu(dialog, 'Pending');
+    await userEvent.click(within(panel).getByRole('button', { name: 'Cancelled' }));
+    await expect(
+      within(dialog).getByRole('button', { name: 'Task status: Cancelled' })
+    ).toBeInTheDocument();
+
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+
+    // A closed modal stays MOUNTED without its `open` attribute whenever the parent
+    // keeps rendering it, so absence has to be asserted against `dialog[open]`.
+    // Here the harness unmounts it as well, which is the real consumer's lifecycle.
+    await waitFor(() => expect(document.querySelector('dialog[open]')).toBeNull());
+
+    // Reopening reads Pending again, and the whole menu is back: the abandoned
+    // choice reached neither the task nor the next dialog.
+    const reopened = await openDialog(canvasElement);
+    await expect(
+      within(reopened).getByRole('button', { name: 'Task status: Pending' })
+    ).toBeInTheDocument();
+    const reopenedPanel = await openStatusMenu(reopened, 'Pending');
+    await expect(menuOptions(reopenedPanel)).toEqual([
+      'Pending',
+      'In Progress',
+      'Completed',
+      'Cancelled',
+    ]);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A status is chosen, then abandoned. Nothing is written and the task is still Pending ' +
+          'when the dialog comes back.\n\n' +
+          'Note what this frame does NOT prove. `handleCancel` also resets `selectedStatus` back ' +
+          'to the current status, but the consumers - and this harness with them - unmount the ' +
+          'dialog on dismissal, so the reopened one is a fresh mount whichever way that reset ' +
+          'behaves. The reset only matters to a caller that keeps the dialog mounted and toggles ' +
+          '`showModal`, and there is no such caller today.',
+      },
+    },
+  },
+};
+
+export const PhoneWidth: Story = {
+  name: 'Phone (375)',
+  args: { activeTask: task() },
+  // Pinned as a GLOBAL. `parameters.viewport.defaultViewport` was removed in
+  // Storybook 10: it still type-checks and still runs, and silently renders the
+  // desktop width under a name that promises a phone.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const dialog = await openDialog(canvasElement);
+
+    // `CenterModal` is `w-[90%] sm:w-[500px]`, and `sm` is 640px - so below the
+    // tablet breakpoint this dialog does NOT re-form into the phone sheet that
+    // `Modal variant="centered"` gets. It is the same centered panel, narrowed to
+    // 90% of the viewport, which is the detail this frame exists to show.
+    // Computed against the live viewport rather than written as 337.5, so the
+    // number states the RULE and cannot drift with the preset's pixel width.
+    const viewportWidth = document.documentElement.clientWidth;
+    const width = dialog.getBoundingClientRect().width;
+    await expect(Math.round(width)).toBe(Math.round(viewportWidth * 0.9));
+
+    // The action row is `flex-wrap` with two `min-w-30` pills. At this width they
+    // still share one line - the claim worth checking, since wrapping is the first
+    // thing that gives out and a visibility check would pass either way.
+    const cancel = within(dialog).getByRole('button', { name: 'Cancel' });
+    const update = within(dialog).getByRole('button', { name: 'Update' });
+    await expect(cancel.getBoundingClientRect().top).toBe(update.getBoundingClientRect().top);
+    await expect(update.getBoundingClientRect().left).toBeGreaterThan(
+      cancel.getBoundingClientRect().right
+    );
+
+    // And the trigger fills the panel's content box exactly - measured off the
+    // dialog's own padding and border rather than against a hardcoded number, so
+    // this states the rule (`w-full` all the way down) instead of a pixel count.
+    const trigger = within(dialog).getByRole('button', { name: 'Task status: Pending' });
+    const panelStyle = getComputedStyle(dialog);
+    const inset =
+      Number.parseFloat(panelStyle.paddingLeft) +
+      Number.parseFloat(panelStyle.paddingRight) +
+      Number.parseFloat(panelStyle.borderLeftWidth) +
+      Number.parseFloat(panelStyle.borderRightWidth);
+    await expect(Math.round(trigger.getBoundingClientRect().width)).toBe(Math.round(width - inset));
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Tasks are triaged on phones more than anywhere else, and this dialog is the control ' +
+          'that does it. Nothing about it is phone-specific, which is exactly why it is worth ' +
+          'drawing at 375 rather than assuming.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/tasks/pages/Tasks/Sections/TaskInfo/TaskInfo.stories.tsx
+++ b/apps/frontend/src/app/features/tasks/pages/Tasks/Sections/TaskInfo/TaskInfo.stories.tsx
@@ -1,0 +1,746 @@
+import { type ComponentProps, useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import type { UserOrganization } from '@yosemite-crew/types';
+
+import type {
+  StoredCompanion,
+  StoredParent,
+} from '@/app/features/companions/pages/Companions/types';
+import type { Team } from '@/app/features/organization/types/team';
+import type { Task } from '@/app/features/tasks/types/task';
+import { useAuthStore } from '@/app/stores/authStore';
+import { useCompanionStore } from '@/app/stores/companionStore';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useParentStore } from '@/app/stores/parentStore';
+import { useTeamStore } from '@/app/stores/teamStore';
+import TaskInfo from './index';
+
+type TaskInfoProps = ComponentProps<typeof TaskInfo>;
+
+const ORG_ID = 'org-storybook';
+/** The signed-in reader. `sub` is what `useTaskEditMode` matches against. */
+const ME = 'practitioner-elena';
+const COLLEAGUE = 'practitioner-ravi';
+const PET_PARENT = 'parent-marta';
+
+const membership = (over: Partial<UserOrganization> = {}): UserOrganization => ({
+  id: 'membership-1',
+  practitionerReference: `Practitioner/${ME}`,
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'VETERINARIAN',
+  roleDisplay: 'Veterinarian',
+  active: true,
+  ...over,
+});
+
+const teamMember = (practionerId: string, name: string): Team => ({
+  _id: `team-${practionerId}`,
+  practionerId,
+  organisationId: ORG_ID,
+  name,
+  role: 'VETERINARIAN',
+  speciality: [],
+  status: 'Available',
+  revokedPermissions: [],
+  effectivePermissions: [],
+  extraPerissions: [],
+});
+
+const TEAM: Team[] = [teamMember(ME, 'Dr. Elena Marsh'), teamMember(COLLEAGUE, 'Dr. Ravi Patel')];
+
+const PARENT: StoredParent = {
+  id: PET_PARENT,
+  firstName: 'Marta',
+  lastName: 'Alvarez',
+  email: 'marta.alvarez@example.com',
+  phoneNumber: '+34 600 000 000',
+  address: { city: 'Barcelona', country: 'ES' },
+  createdFrom: 'pms',
+};
+
+const COMPANION: StoredCompanion = {
+  id: 'companion-kiko',
+  organisationId: ORG_ID,
+  parentId: PET_PARENT,
+  name: 'Kiko',
+  type: 'dog',
+  breed: 'Border Collie',
+  dateOfBirth: new Date('2019-04-18T00:00:00.000Z'),
+  gender: 'male',
+  isInsured: false,
+  status: 'active',
+};
+
+const task = (over: Partial<Task> = {}): Task => ({
+  _id: 'task-analgesia',
+  organisationId: ORG_ID,
+  companionId: COMPANION.id,
+  assignedBy: ME,
+  assignedTo: ME,
+  audience: 'EMPLOYEE_TASK',
+  source: 'CUSTOM',
+  category: 'MEDICATION',
+  priority: 'HIGH',
+  name: 'Midday analgesia round',
+  description: 'Meloxicam 0.1mg/kg PO, then recheck the incision site.',
+  // A fixed instant. `getPreferredTimeZone` falls back to Europe/Berlin whenever
+  // no timezone token is stored, and every formatter here pins the en-US locale,
+  // so the rendered date and time do not depend on the machine running this.
+  dueAt: new Date('2026-03-12T12:00:00.000Z'),
+  reminder: { enabled: true, offsetMinutes: 30 },
+  syncWithCalendar: false,
+  status: 'PENDING',
+  ...over,
+});
+
+/**
+ * Seeds the four stores the drawer reads, rather than mocking the modules.
+ *
+ * Nothing here fetches: `useTeamForPrimaryOrg` and `useCompanionsForPrimaryOrg` are
+ * pure selectors, and the hooks that DO load (`useLoadTeam`, `useLoadCompanionsForPrimaryOrg`)
+ * are separate and are not used by this drawer. So the real component runs against
+ * the real stores with no network and no request stubbing - which this Storybook has
+ * no wiring for anyway.
+ */
+const seed = (over: Partial<UserOrganization> = {}) => {
+  useOrgStore.setState({
+    primaryOrgId: ORG_ID,
+    membershipsByOrgId: { [ORG_ID]: membership(over) },
+    status: 'loaded',
+  });
+  useTeamStore.getState().setTeamsForOrg(ORG_ID, TEAM);
+  useCompanionStore.getState().setCompanionsForOrg(ORG_ID, [COMPANION]);
+  useParentStore.getState().setParents([PARENT]);
+  useAuthStore.setState({
+    attributes: {
+      sub: ME,
+      email: 'elena.marsh@example.com',
+      given_name: 'Elena',
+      family_name: 'Marsh',
+    },
+  });
+};
+
+/**
+ * The drawer is mounted on demand by the tasks page and unmounted on dismissal.
+ * Reproducing that here keeps the docs page free of a dozen simultaneously open
+ * dialogs, each holding a share of `ModalBase`'s ref-counted body scroll lock.
+ */
+const TaskDrawerHarness = ({
+  showModal: _showModal,
+  setShowModal: _setShowModal,
+  ...args
+}: TaskInfoProps) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="flex min-h-[520px] items-start bg-[var(--screen)] p-6">
+      <button
+        type="button"
+        className="rounded-2xl bg-[var(--cta)] px-6 py-3 text-body-3-emphasis text-[var(--cta-text)]"
+        onClick={() => setOpen(true)}
+      >
+        Open task drawer
+      </button>
+      {open && <TaskInfo {...args} showModal setShowModal={setOpen} />}
+    </div>
+  );
+};
+
+const openDrawer = async (canvasElement: HTMLElement) => {
+  const canvas = within(canvasElement);
+  await userEvent.click(canvas.getByRole('button', { name: 'Open task drawer' }));
+  return waitFor(() => {
+    const node = document.querySelector('dialog[open]');
+    expect(node).not.toBeNull();
+    return node as HTMLElement;
+  });
+};
+
+/**
+ * Every read-mode row label, in render order.
+ *
+ * Keyed on the label cell's own class rather than on text, because the labels are
+ * not unique in the tree: "Task" is also the drawer's eyebrow, and the accordion
+ * headers repeat "Status". `FieldValueRow` is the only thing in here that renders
+ * `text-body-4-emphasis`, so this counts rows and nothing else.
+ */
+const rowLabels = (scope: HTMLElement): string[] =>
+  [...scope.querySelectorAll('.text-body-4-emphasis')].map((cell) =>
+    (cell.textContent ?? '').trim()
+  );
+
+/** The value rendered beside one row label. */
+const rowValue = (scope: HTMLElement, label: string): string => {
+  const cell = [...scope.querySelectorAll('.text-body-4-emphasis')].find(
+    (node) => (node.textContent ?? '').trim() === label
+  );
+  if (!cell) {
+    throw new Error(`No "${label}" row is being rendered in read mode.`);
+  }
+  return (cell.nextElementSibling?.textContent ?? '').trim();
+};
+
+const ONE_OFF_ROWS = [
+  'Status',
+  'Task',
+  'Category',
+  'Priority',
+  'Instructions (optional)',
+  'From',
+  'To',
+  'Due date',
+  'Due time',
+  'Reminder',
+  'Repeat',
+  'Sync with calendar',
+];
+
+const meta = {
+  title: 'Tasks/TaskInfo',
+  component: TaskInfo,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The task detail drawer: two `EditableAccordion`s (Status, Task details) inside a 470px ' +
+          '`Modal`, plus a Reuse action that only exists on a finished task.\n\n' +
+          'What makes it worth stories is that **it renders four different drawers from the same ' +
+          'props**. `useTaskEditMode` compares the signed-in user against the task and returns ' +
+          '`FULL` (I raised it and I own it), `DETAILS_ONLY` (I raised it, someone else owns it), ' +
+          '`STATUS_ONLY` (someone else raised it, I own it) or `NONE`. The only visible difference ' +
+          'between those four is **which pencil icons are present** - there is no banner, no ' +
+          'disabled styling and no explanation - so a regression in that hook shows up as a ' +
+          'missing or an extra pencil and nothing else. All four are drawn below.\n\n' +
+          'Two findings this pass turned up, both visible in the frames rather than in the code:\n\n' +
+          '- **The Due time row renders blank.** `taskData.dueTime` is a clock string ("13:00"), ' +
+          'and the `timeInput` read renderer sends it through `formatTimeLabel`, which parses with ' +
+          '`new Date("13:00")` - an Invalid Date - and returns its empty fallback. The row draws ' +
+          'its label and nothing beside it. It is not even the dash the other unset rows use.\n' +
+          '- **The same person appears under two names.** The From row resolves through ' +
+          '`useMemberMap`, whose last write is the profile name of the signed-in user, while the ' +
+          'To row resolves through the assignee dropdown options, which use the team record. A ' +
+          'task I raised for myself therefore reads "Elena Marsh" on one line and "Dr. Elena ' +
+          'Marsh" on the next.\n\n' +
+          'Also worth attention from a reviewer: this drawer passes no `aria-label` and no ' +
+          '`titleId` to its `Modal`, so the `<dialog>` has no accessible name even though ' +
+          '`ModalHeader` already accepts one.\n\n' +
+          'Editing a task that belongs to a recurring series does not save - it opens ' +
+          '`RecurrenceScopeModal` over the drawer and holds the payload in a ref until the scope ' +
+          'is chosen. That two-dialog frame is drawn below and had never been seen anywhere.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    showModal: true,
+    setShowModal: fn(),
+    activeTask: task(),
+    onReuseTask: fn(),
+  },
+  beforeEach: () => {
+    seed();
+  },
+  render: (args) => <TaskDrawerHarness {...args} />,
+} satisfies Meta<typeof TaskInfo>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const FullAccess: Story = {
+  name: 'Full access (mine, raised by me)',
+  play: async ({ canvasElement }) => {
+    const drawer = await openDrawer(canvasElement);
+    const panel = within(drawer);
+
+    await expect(
+      panel.getByRole('heading', { name: 'Midday analgesia round' })
+    ).toBeInTheDocument();
+    await expect(panel.getByText('Due Mar 12, 2026')).toBeInTheDocument();
+
+    // Both accordions open by default, so the drawer's whole read surface is one
+    // list of rows. Assert the list, not that "some rows rendered": a field
+    // dropped from the config disappears silently.
+    await expect(rowLabels(drawer)).toEqual(ONE_OFF_ROWS);
+
+    await expect(rowValue(drawer, 'Status')).toBe('Pending');
+    await expect(rowValue(drawer, 'Task')).toBe('Midday analgesia round');
+    await expect(rowValue(drawer, 'Category')).toBe('Medication');
+    await expect(rowValue(drawer, 'Priority')).toBe('High');
+    await expect(rowValue(drawer, 'Due date')).toBe('Mar 12, 2026');
+    await expect(rowValue(drawer, 'Reminder')).toBe('30 minutes before');
+    await expect(rowValue(drawer, 'Repeat')).toBe('Does not repeat');
+    await expect(rowValue(drawer, 'Sync with calendar')).toBe('No');
+
+    // DEFECT, recorded deliberately: the value cell is empty rather than a time or
+    // a dash. `formatTimeLabel('13:00')` parses to an Invalid Date and falls back
+    // to ''. When that is fixed this line goes red, which is the point.
+    await expect(rowValue(drawer, 'Due time')).toBe('');
+
+    // DEFECT, recorded deliberately: one person, two names, on adjacent rows.
+    await expect(rowValue(drawer, 'From')).toBe('Elena Marsh');
+    await expect(rowValue(drawer, 'To')).toBe('Dr. Elena Marsh');
+
+    // FULL is the only mode with both pencils.
+    await expect(panel.getByRole('button', { name: 'Edit Status' })).toBeInTheDocument();
+    await expect(panel.getByRole('button', { name: 'Edit Task details' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The everything-allowed drawer, and the baseline the three restricted modes below are ' +
+          'read against. Note the two rows carrying the findings named above: Due time is blank, ' +
+          'and From and To name the same person differently.',
+      },
+    },
+  },
+};
+
+export const DetailsOnly: Story = {
+  name: 'Details only (I raised it for someone else)',
+  args: { activeTask: task({ assignedTo: COLLEAGUE }) },
+  play: async ({ canvasElement }) => {
+    const drawer = await openDrawer(canvasElement);
+    const panel = within(drawer);
+
+    await expect(rowValue(drawer, 'To')).toBe('Dr. Ravi Patel');
+    await expect(panel.getByRole('button', { name: 'Edit Task details' })).toBeInTheDocument();
+    // Whoever is doing the work owns its status; the raiser cannot move it for them.
+    await expect(panel.queryByRole('button', { name: 'Edit Status' })).not.toBeInTheDocument();
+    await expect(rowLabels(drawer)).toEqual(ONE_OFF_ROWS);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'One pencil, on the lower accordion. The Status accordion still renders its row and its ' +
+          'header - only the pencil is gone - so at a glance this is indistinguishable from the ' +
+          'full drawer.',
+      },
+    },
+  },
+};
+
+export const StatusOnly: Story = {
+  name: 'Status only (someone else raised it for me)',
+  args: { activeTask: task({ assignedBy: COLLEAGUE }) },
+  play: async ({ canvasElement }) => {
+    const drawer = await openDrawer(canvasElement);
+    const panel = within(drawer);
+
+    await expect(rowValue(drawer, 'From')).toBe('Dr. Ravi Patel');
+    await expect(rowValue(drawer, 'To')).toBe('Dr. Elena Marsh');
+    await expect(panel.getByRole('button', { name: 'Edit Status' })).toBeInTheDocument();
+    await expect(
+      panel.queryByRole('button', { name: 'Edit Task details' })
+    ).not.toBeInTheDocument();
+    // The same twelve rows as every other mode. Asserted in all four so the
+    // comparison the docs above ask a reviewer to make is actually enforced:
+    // restricting edit rights must not quietly drop a row from the read view.
+    await expect(rowLabels(drawer)).toEqual(ONE_OFF_ROWS);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The mirror image, and the most common drawer in practice: the person doing the work can ' +
+          'report progress but cannot rewrite the instruction they were given.',
+      },
+    },
+  },
+};
+
+export const NoAccess: Story = {
+  name: "No access (someone else's task)",
+  args: { activeTask: task({ assignedBy: COLLEAGUE, assignedTo: COLLEAGUE }) },
+  play: async ({ canvasElement }) => {
+    const drawer = await openDrawer(canvasElement);
+    const panel = within(drawer);
+
+    await expect(panel.queryByRole('button', { name: 'Edit Status' })).not.toBeInTheDocument();
+    await expect(
+      panel.queryByRole('button', { name: 'Edit Task details' })
+    ).not.toBeInTheDocument();
+    // Read-only does not mean empty: every row is still there to be read.
+    await expect(rowLabels(drawer)).toEqual(ONE_OFF_ROWS);
+    await expect(rowValue(drawer, 'From')).toBe('Dr. Ravi Patel');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A task between two colleagues. The drawer is a viewer, with nothing to say that it is ' +
+          'one.',
+      },
+    },
+  },
+};
+
+export const PermissionRevoked: Story = {
+  name: 'Permission revoked (my own task, still read-only)',
+  beforeEach: () => {
+    // Every role in the table carries tasks:edit, so NONE is only reachable this
+    // way in practice: a per-membership revocation. Same drawer as the story
+    // above, reached by a completely different route.
+    seed({ revokedPermissions: ['tasks:edit:any', 'tasks:edit:own'] });
+  },
+  play: async ({ canvasElement }) => {
+    const drawer = await openDrawer(canvasElement);
+    const panel = within(drawer);
+
+    await expect(panel.queryByRole('button', { name: 'Edit Status' })).not.toBeInTheDocument();
+    await expect(
+      panel.queryByRole('button', { name: 'Edit Task details' })
+    ).not.toBeInTheDocument();
+    // Identical to the NoAccess frame above, row for row and value for value -
+    // which is the finding. The two are reached through completely different
+    // branches (ownership vs the permission gate ahead of it) and a reviewer has
+    // no way to tell them apart on screen.
+    await expect(rowLabels(drawer)).toEqual(ONE_OFF_ROWS);
+    await expect(rowValue(drawer, 'From')).toBe('Elena Marsh');
+    await expect(rowValue(drawer, 'To')).toBe('Dr. Elena Marsh');
+    await expect(rowValue(drawer, 'Status')).toBe('Pending');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The task is mine and raised by me, so ownership says FULL - the permission check ahead ' +
+          'of it says otherwise and wins. Worth having both routes drawn, because the resulting ' +
+          'frame is identical and the causes are not.',
+      },
+    },
+  },
+};
+
+export const EditingDetails: Story = {
+  name: 'Editing the details',
+  play: async ({ canvasElement }) => {
+    const drawer = await openDrawer(canvasElement);
+    const panel = within(drawer);
+
+    await userEvent.click(panel.getByRole('button', { name: 'Edit Task details' }));
+
+    // Every editable row swaps to a control, so the only read-mode rows LEFT are
+    // the ones the config marks uneditable - From here, plus Status in the other
+    // accordion. That is a much stronger check than "an input appeared".
+    await waitFor(() => expect(rowLabels(drawer)).toEqual(['Status', 'From']));
+    await expect(rowValue(drawer, 'From')).toBe('Elena Marsh');
+
+    await expect(panel.getByRole('textbox', { name: 'Task' })).toHaveValue(
+      'Midday analgesia round'
+    );
+    await expect(panel.getByRole('textbox', { name: 'Instructions (optional)' })).toHaveValue(
+      'Meloxicam 0.1mg/kg PO, then recheck the incision site.'
+    );
+    await expect(panel.getByRole('button', { name: 'Category: Medication' })).toBeInTheDocument();
+    await expect(panel.getByRole('button', { name: 'To: Dr. Elena Marsh' })).toBeInTheDocument();
+    // The time survives perfectly well into the EDIT control - which localises the
+    // blank Due time row above to the read renderer alone, not to the data.
+    await expect(panel.getByRole('button', { name: 'Due time: 13:00' })).toBeInTheDocument();
+
+    // The action row is the accordion's own 2-up grid, not the centered pill pair
+    // the dialogs use - a full-width Cancel | Save split under the form. Track
+    // count AND child count, because a dropped template collapses it to a stacked
+    // pair that still renders both buttons.
+    const save = panel.getByRole('button', { name: 'Save' });
+    const actionRow = save.parentElement as HTMLElement;
+    await expect(getComputedStyle(actionRow).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(
+      2
+    );
+    await expect(actionRow.children).toHaveLength(2);
+    await expect([...actionRow.children].map((child) => (child.textContent ?? '').trim())).toEqual([
+      'Cancel',
+      'Save',
+    ]);
+
+    await userEvent.click(panel.getByRole('button', { name: 'Cancel' }));
+
+    // Cancel rebuilds the form from `data`, so the full read list comes back.
+    await waitFor(() => expect(rowLabels(drawer)).toEqual(ONE_OFF_ROWS));
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The edit form: eleven rows become a text input, five dropdowns, a datepicker, a time ' +
+          'picker and a Cancel/Save pair, inside a 470px drawer that now scrolls. The uneditable ' +
+          'From row stays a plain value row in the middle of the form, which is the layout detail ' +
+          'this frame exists to expose.',
+      },
+    },
+  },
+};
+
+export const EditingStatus: Story = {
+  name: 'Editing the status',
+  play: async ({ canvasElement }) => {
+    const drawer = await openDrawer(canvasElement);
+    const panel = within(drawer);
+
+    await userEvent.click(panel.getByRole('button', { name: 'Edit Status' }));
+    await userEvent.click(await panel.findByRole('button', { name: 'Status: Pending' }));
+
+    // The menu portals to document.body, outside the dialog and outside the canvas.
+    // Take the LAST panel: one left open by another story would otherwise be read.
+    const menu = await waitFor(() => {
+      const panels = document.querySelectorAll('[data-portal-dropdown]');
+      expect(panels.length).toBeGreaterThan(0);
+      return panels[panels.length - 1] as HTMLElement;
+    });
+    const options = [...menu.querySelectorAll('button')].map((option) =>
+      (option.textContent ?? '').trim()
+    );
+    // Same transition table the standalone ChangeTaskStatus dialog filters on. The
+    // two surfaces derive their lists independently, so this is the assertion that
+    // keeps them in agreement.
+    await expect(options).toEqual(['Pending', 'In Progress', 'Completed', 'Cancelled']);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The second place in the product a task status can be changed. It is a plain dropdown ' +
+          'inside the accordion rather than the shared `ChangeStatusModal`, and it computes its own ' +
+          'allowed list - a drift between the two would be invisible without both being drawn.',
+      },
+    },
+  },
+};
+
+export const RecurringTask: Story = {
+  name: 'Recurring task (grows an End date)',
+  args: {
+    activeTask: task({
+      _id: 'task-recurring',
+      name: 'Twice-daily wound check',
+      recurrence: {
+        type: 'DAILY',
+        isMaster: true,
+        endDate: new Date('2026-03-31T23:59:59.000Z'),
+      },
+    }),
+  },
+  play: async ({ canvasElement }) => {
+    const drawer = await openDrawer(canvasElement);
+
+    // The End date row is conditional on the recurrence type, so a repeating task
+    // renders one row MORE than a one-off - the count, and its position, matter.
+    await expect(rowLabels(drawer)).toEqual([
+      'Status',
+      'Task',
+      'Category',
+      'Priority',
+      'Instructions (optional)',
+      'From',
+      'To',
+      'Due date',
+      'Due time',
+      'Reminder',
+      'Repeat',
+      'End date',
+      'Sync with calendar',
+    ]);
+    await expect(rowValue(drawer, 'Repeat')).toBe('Daily');
+    // The whole label, not `toContain('2026')`. The end date travels through two
+    // conversions before it is drawn - `toISOString().slice(0, 10)` on the way
+    // into the form, then parsed back and formatted in the preferred timezone -
+    // and either one landing a day out still contains "2026".
+    await expect(rowValue(drawer, 'End date')).toBe('Mar 31, 2026');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A one-off task has a due date and nothing else; a repeating one also has a horizon. The ' +
+          'row is inserted between Repeat and Sync with calendar rather than appended, so this is ' +
+          'the only frame that shows the drawer at its full height.',
+      },
+    },
+  },
+};
+
+export const SeriesEditAsksForScope: Story = {
+  name: 'Saving a series edit asks for scope',
+  args: {
+    activeTask: task({
+      _id: 'task-recurring',
+      name: 'Twice-daily wound check',
+      recurrence: { type: 'DAILY', isMaster: true },
+    }),
+  },
+  play: async ({ canvasElement }) => {
+    const drawer = await openDrawer(canvasElement);
+    const panel = within(drawer);
+
+    await userEvent.click(panel.getByRole('button', { name: 'Edit Task details' }));
+    await userEvent.click(await panel.findByRole('button', { name: 'Save' }));
+
+    // Save does not write. `isSeriesTask` diverts the payload into a ref and opens
+    // a SECOND dialog over the drawer, so both are open at once - a nesting the
+    // shared modal stack exists for and that nothing had ever rendered.
+    await waitFor(() => expect(document.querySelectorAll('dialog[open]')).toHaveLength(2));
+    const scope = document.querySelectorAll('dialog[open]')[1] as HTMLElement;
+
+    await expect(
+      within(scope).getByRole('heading', { name: 'Edit recurring task' })
+    ).toBeInTheDocument();
+    await expect(
+      within(scope).getByText(/"Twice-daily wound check" is part of a recurring series/)
+    ).toBeInTheDocument();
+    await expect(within(scope).getAllByRole('radio')).toHaveLength(3);
+    await expect(within(scope).getByRole('radio', { name: 'This task only' })).toBeChecked();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Nothing is confirmed here - `onConfirm` is what calls `updateTask`, so the story stops ' +
+          'at the frame before the write. Look at the stacking: the scope dialog is centered over ' +
+          'a right-hand drawer that is still fully drawn behind it, and only the topmost one ' +
+          'answers Escape.',
+      },
+    },
+  },
+};
+
+export const CompletedTask: Story = {
+  name: 'Completed (read-only, with Reuse)',
+  args: {
+    activeTask: task({
+      status: 'COMPLETED',
+      completedAt: new Date('2026-03-12T13:10:00.000Z'),
+    }),
+  },
+  play: async ({ canvasElement, args }) => {
+    const drawer = await openDrawer(canvasElement);
+    const panel = within(drawer);
+
+    await expect(rowValue(drawer, 'Status')).toBe('Completed');
+    // A finished task is frozen regardless of who owns it: `effectiveEditMode` is
+    // forced to NONE, so the FULL-access reader loses both pencils.
+    await expect(panel.queryByRole('button', { name: 'Edit Status' })).not.toBeInTheDocument();
+    await expect(
+      panel.queryByRole('button', { name: 'Edit Task details' })
+    ).not.toBeInTheDocument();
+
+    // The footer only exists on this one state - it is the whole reason the drawer
+    // has a `ModalFooter` at all.
+    await userEvent.click(panel.getByRole('button', { name: 'Reuse task' }));
+    await expect(args.onReuseTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        _id: '',
+        status: 'PENDING',
+        name: 'Midday analgesia round',
+        category: 'MEDICATION',
+      })
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Reuse hands the caller a stripped copy - blank id, status back to Pending, due date ' +
+          'today, completion metadata dropped - and closes the drawer. It never writes anything ' +
+          'itself, which is why this story can press it.',
+      },
+    },
+  },
+};
+
+export const UnresolvableAssignee: Story = {
+  name: 'Assignee who left the practice',
+  args: { activeTask: task({ assignedTo: 'c3b4a812-4051-701e-08ce-cb5c2a489951' }) },
+  play: async ({ canvasElement }) => {
+    const drawer = await openDrawer(canvasElement);
+
+    // A member outside the org resolves to nothing, and the raw id used to be
+    // printed here - a UUID where a name belongs. The fallback has to be a
+    // sentence, and it has to survive into the To dropdown's options too.
+    await expect(rowValue(drawer, 'To')).toBe('Unavailable member');
+    await expect(drawer.textContent).not.toContain('c3b4a812');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Someone who left, or who belongs to another organisation. This is the guard in ' +
+          '`useTaskInfoFields` under load - and the board does NOT have it, so the same task ' +
+          'renders a raw identifier on a card and a readable sentence here.',
+      },
+    },
+  },
+};
+
+export const ParentTask: Story = {
+  name: 'Pet-parent task',
+  args: {
+    activeTask: task({
+      _id: 'task-parent',
+      audience: 'PARENT_TASK',
+      name: 'Send the discharge photos',
+      category: 'COMMUNICATION',
+      assignedTo: PET_PARENT,
+    }),
+  },
+  play: async ({ canvasElement }) => {
+    const drawer = await openDrawer(canvasElement);
+
+    // The assignee list switches source entirely for a parent task: it is built
+    // from the companions' parents rather than from the team, so a broken switch
+    // shows up as a To row that cannot resolve its own value.
+    await expect(rowValue(drawer, 'To')).toBe('Marta Alvarez');
+    await expect(rowValue(drawer, 'Category')).toBe('Communication');
+    await expect(rowValue(drawer, 'From')).toBe('Elena Marsh');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Tasks addressed to the owner rather than to staff. Same drawer, same rows, a different ' +
+          'population behind the To dropdown.',
+      },
+    },
+  },
+};
+
+export const PhoneDrawer: Story = {
+  name: 'Phone (375)',
+  // Pinned as a GLOBAL: `parameters.viewport.defaultViewport` was removed in
+  // Storybook 10 and silently renders desktop markup under a phone name.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const drawer = await openDrawer(canvasElement);
+
+    // Below 768px `Modal` swaps the 470px right-hand drawer for a full-screen
+    // panel. `useIsPhone` is false during the first render, so this is a
+    // post-mount swap that a static desktop snapshot never contains.
+    await waitFor(() => expect(drawer.className).toContain('yc-modal-fullscreen'));
+    // `yc-modal-fullscreen` is `inset: 0; width: 100%`, so full-screen means
+    // exactly the viewport width - not merely "wider than the 470px drawer",
+    // which a partially-applied class would also satisfy.
+    await expect(Math.round(drawer.getBoundingClientRect().width)).toBe(
+      document.documentElement.clientWidth
+    );
+    await expect(rowLabels(drawer)).toEqual(ONE_OFF_ROWS);
+    // The values survive the swap too: the phone panel is a re-layout, not a
+    // reduced drawer with rows dropped to fit.
+    await expect(rowValue(drawer, 'Reminder')).toBe('30 minutes before');
+    await expect(rowValue(drawer, 'To')).toBe('Dr. Elena Marsh');
+    await expect(
+      within(drawer).getByRole('heading', { name: 'Midday analgesia round' })
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Twelve label/value rows in a `justify-between` row each, at 375px. The long ones - the ' +
+          'instructions line, and a To row holding a full name - are where this layout gives out ' +
+          'first.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/cards/AppointmentCard/AppointmentCard.stories.tsx
+++ b/apps/frontend/src/app/ui/cards/AppointmentCard/AppointmentCard.stories.tsx
@@ -1,5 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import { expect, fn, waitFor, within } from 'storybook/test';
+
+import {
+  closeGlassTooltip,
+  openGlassTooltip,
+} from '@/app/ui/primitives/GlassTooltip/storyInteractions';
 import type { Appointment, Organisation } from '@yosemite-crew/types';
 
 import AppointmentCard from './index';
@@ -197,39 +202,32 @@ export const LongValues: Story = {
 };
 
 /**
- * Hovers one action and returns the single portalled bubble it opened.
+ * Opens one action's bubble and returns it together with its trigger.
  *
- * The pointer session is passed in rather than using the bare `userEvent` helper:
- * the direct API builds a fresh pointer state per call, so it never emits the
- * `mouseleave` that closes the bubble you are moving away from, and a walk along
- * the rail would leave a trail of bubbles behind for reasons that have nothing to
- * do with the component. A `userEvent.setup()` session keeps the pointer's
- * position between calls and produces the real leave/enter pair.
+ * `openGlassTooltip` rather than a `userEvent` pointer session: the wrapper binds its
+ * listeners in an effect, and a play function can start before that effect has flushed -
+ * a single dispatch then lands on an element that is not listening and is lost, because
+ * `findByRole` retries the query and never re-sends the event.
+ *
+ * That also means leaving is explicit. A dispatched `mouseenter` on the next icon does
+ * not emit a `mouseleave` on the last one, so a walk along the rail has to close each
+ * bubble itself or they pile up on `document.body` - which is exactly what the
+ * one-bubble assertion below is there to catch.
  */
-const hoverAction = async (
-  user: ReturnType<typeof userEvent.setup>,
-  canvasElement: HTMLElement,
-  actionLabel: string
-) => {
-  const canvas = within(canvasElement);
-  await user.hover(canvas.getByRole('button', { name: actionLabel }));
-  // The bubble portals to document.body, so it is outside canvasElement. Settling
-  // on exactly one is the real assertion: the outgoing bubble is momentarily still
-  // mounted beside the incoming one, and a leak there would never settle.
+const openAction = async (canvasElement: HTMLElement, actionLabel: string) => {
+  const button = within(canvasElement).getByRole('button', { name: actionLabel });
+  const bubble = await openGlassTooltip(button);
+  // Settling on exactly one is the real assertion: a teardown leak would never settle.
   await waitFor(() => {
     expect(within(document.body).getAllByRole('tooltip')).toHaveLength(1);
   });
-  return within(document.body).getByRole('tooltip');
+  return { bubble, button };
 };
 
 export const ViewTooltip: Story = {
   name: 'Tooltip — view action',
   play: async ({ canvasElement }) => {
-    const bubble = await hoverAction(
-      userEvent.setup(),
-      canvasElement,
-      'View appointment for Poppy'
-    );
+    const { bubble } = await openAction(canvasElement, 'View appointment for Poppy');
     await expect(bubble).toHaveTextContent('View appointment');
   },
   parameters: {
@@ -247,7 +245,7 @@ export const ViewTooltip: Story = {
 export const ClinicalNotesTooltip: Story = {
   name: 'Tooltip — clinical notes label',
   play: async ({ canvasElement }) => {
-    const bubble = await hoverAction(userEvent.setup(), canvasElement, 'Medical Records for Poppy');
+    const { bubble } = await openAction(canvasElement, 'Medical Records for Poppy');
     // The org store says HOSPITAL, so the bubble must say Medical Records rather
     // than the Care fallback. This string is data, not a constant.
     await expect(bubble).toHaveTextContent('Medical Records');
@@ -277,13 +275,13 @@ export const RailTooltips: Story = {
       ['Lab tests for Poppy', 'Lab tests'],
     ];
 
-    // One pointer session for the whole walk, so moving to the next icon really
-    // leaves the previous one: each hover must open its own bubble AND close the
-    // one before it. Seven stacked bubbles would be its own defect.
-    const user = userEvent.setup();
+    // Each icon is closed before the next is opened, so the one-bubble assertion inside
+    // `openAction` really is checking teardown rather than a lucky ordering. Seven
+    // stacked bubbles would be its own defect.
     for (const [trigger, label] of expectations) {
-      const bubble = await hoverAction(user, canvasElement, trigger);
+      const { bubble, button } = await openAction(canvasElement, trigger);
       await expect(bubble).toHaveTextContent(label);
+      await closeGlassTooltip(button);
     }
   },
   parameters: {
@@ -311,7 +309,7 @@ export const RequestedTooltip: Story = {
   play: async ({ canvasElement }) => {
     // Hover only. The decline button fires `rejectAppointment` over the network
     // on click, so a story must never press it.
-    const bubble = await hoverAction(userEvent.setup(), canvasElement, 'Accept request for Poppy');
+    const { bubble } = await openAction(canvasElement, 'Accept request for Poppy');
     await expect(bubble).toHaveTextContent('Accept request');
   },
   parameters: {
@@ -330,10 +328,13 @@ export const TooltipByKeyboard: Story = {
   name: 'Tooltip — opened by keyboard focus',
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    // focusin, not hover: the path a keyboard user gets, and the one that rots
-    // unnoticed because every manual check is done with a mouse.
-    canvas.getByRole('button', { name: 'Lab tests for Poppy' }).focus();
-    const bubble = await within(document.body).findByRole('tooltip');
+    /* focusin, not hover: the path a keyboard user gets, and the one that rots unnoticed
+       because every manual check is done with a mouse. Dispatched at the wrapper rather
+       than via `.focus()`, which fires nothing unless the page itself has focus. */
+    const bubble = await openGlassTooltip(
+      canvas.getByRole('button', { name: 'Lab tests for Poppy' }),
+      { via: 'focus' }
+    );
     await expect(bubble).toHaveTextContent('Lab tests');
   },
   parameters: {

--- a/apps/frontend/src/app/ui/cards/CompanionCard/CompanionCard.stories.tsx
+++ b/apps/frontend/src/app/ui/cards/CompanionCard/CompanionCard.stories.tsx
@@ -237,9 +237,7 @@ export const TooltipOnFocus: Story = {
     const button = within(canvasElement).getByRole('button', {
       name: /^Change status for Kiko$/,
     });
-    await expect(await openGlassTooltip(button, { via: 'focus' })).toHaveTextContent(
-      /^Change status$/
-    );
+    expect(await openGlassTooltip(button, { via: 'focus' })).toHaveTextContent(/^Change status$/);
   },
   parameters: {
     docs: {

--- a/apps/frontend/src/app/ui/cards/CompanionCard/CompanionCard.stories.tsx
+++ b/apps/frontend/src/app/ui/cards/CompanionCard/CompanionCard.stories.tsx
@@ -1,5 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { expect, fn, userEvent, within } from 'storybook/test';
+import { expect, fn, within } from 'storybook/test';
+
+import {
+  closeGlassTooltip,
+  openGlassTooltip,
+} from '@/app/ui/primitives/GlassTooltip/storyInteractions';
 import type { CompanionParent } from '@/app/features/companions/pages/Companions/types';
 import CompanionCard from './CompanionCard';
 
@@ -153,22 +158,28 @@ export const LongText: Story = {
 };
 
 /**
- * The bubble portals to `document.body`, so it is outside `canvasElement`. It is
- * also the only element with `role="tooltip"`, and only one is ever open.
+ * Opens the bubble for `name` and asserts its copy.
+ *
+ * The bubble portals to `document.body`, so it is outside `canvasElement`; it is also
+ * the only element with `role="tooltip"`, and only one is ever open.
+ *
+ * `openGlassTooltip` rather than `userEvent.hover`: the wrapper's listeners are bound in
+ * an effect that has not necessarily flushed when a play function starts, so a single
+ * dispatch can land on an element that is not listening yet. `findByRole` retries the
+ * query but never re-sends the event, so that dispatch is lost for good.
  */
-const expectTooltip = async (text: RegExp) => {
-  const tooltip = await within(document.body).findByRole('tooltip');
+const openTooltipFor = async (canvasElement: HTMLElement, name: RegExp, text: RegExp) => {
+  const button = within(canvasElement).getByRole('button', { name });
+  const tooltip = await openGlassTooltip(button);
   await expect(tooltip).toHaveTextContent(text);
-  return tooltip;
+  return button;
 };
 
 export const ViewTooltip: Story = {
   name: 'Tooltip - View (hover)',
   play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
     // The label is rewritten per org type, so match its shape rather than one wording.
-    await userEvent.hover(canvas.getByRole('button', { name: /^View .*Kiko$/ }));
-    await expectTooltip(/^View /);
+    await openTooltipFor(canvasElement, /^View .*Kiko$/, /^View /);
   },
   parameters: {
     docs: {
@@ -184,7 +195,6 @@ export const ViewTooltip: Story = {
 export const AllFourTooltips: Story = {
   name: 'All four tooltips (hovered in turn)',
   play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
     const body = within(document.body);
     // Nothing is open at rest: the bubble does not exist until a pointer arrives.
     await expect(body.queryByRole('tooltip')).not.toBeInTheDocument();
@@ -197,16 +207,13 @@ export const AllFourTooltips: Story = {
     ];
 
     for (const [trigger, copy] of steps) {
-      const button = canvas.getByRole('button', { name: trigger });
-      await userEvent.hover(button);
-      await expectTooltip(copy);
+      const button = await openTooltipFor(canvasElement, trigger, copy);
       // mouseleave unmounts the portal, so the next bubble is unambiguous.
-      await userEvent.unhover(button);
+      await closeGlassTooltip(button);
     }
 
     // Leave the last one open so the story has something to look at.
-    await userEvent.hover(canvas.getByRole('button', { name: /^Create task for Kiko$/ }));
-    await expectTooltip(/^Task$/);
+    await openTooltipFor(canvasElement, /^Create task for Kiko$/, /^Task$/);
   },
   parameters: {
     docs: {
@@ -223,12 +230,16 @@ export const AllFourTooltips: Story = {
 export const TooltipOnFocus: Story = {
   name: 'Tooltip - keyboard focus',
   play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    const button = canvas.getByRole('button', { name: /^Change status for Kiko$/ });
-    // `focusin` bubbles to the wrapper span, which is where the listener lives -
-    // so the bubble is reachable without a pointer at all.
-    button.focus();
-    await expectTooltip(/^Change status$/);
+    /* `focusin` is a separate listener from the mouse pair, so the bubble is reachable
+       without a pointer at all. Driven by dispatching at the wrapper rather than by
+       `.focus()`, which fires nothing unless the page itself has focus - not something
+       an automated run can guarantee. */
+    const button = within(canvasElement).getByRole('button', {
+      name: /^Change status for Kiko$/,
+    });
+    await expect(await openGlassTooltip(button, { via: 'focus' })).toHaveTextContent(
+      /^Change status$/
+    );
   },
   parameters: {
     docs: {
@@ -251,10 +262,8 @@ export const ViewOnlyTooltip: Story = {
     canEditCompanions: false,
   },
   play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    await expect(canvas.getAllByRole('button')).toHaveLength(1);
-    await userEvent.hover(canvas.getByRole('button', { name: /^View .*Kiko$/ }));
-    await expectTooltip(/^View /);
+    await expect(within(canvasElement).getAllByRole('button')).toHaveLength(1);
+    await openTooltipFor(canvasElement, /^View .*Kiko$/, /^View /);
   },
   parameters: {
     docs: {

--- a/apps/frontend/src/app/ui/cards/TaskCard/TaskCard.stories.tsx
+++ b/apps/frontend/src/app/ui/cards/TaskCard/TaskCard.stories.tsx
@@ -33,10 +33,9 @@ const wrapperFor = (canvasElement: HTMLElement, accessibleName: string) =>
     .getByRole('button', { name: accessibleName })
     .closest('.glass-tooltip') as HTMLElement;
 
-/** Hovers an action chip's tooltip wrapper and returns the portalled bubble. */
-const hoverChip = async (canvasElement: HTMLElement, accessibleName: string) => {
-  return openGlassTooltip(wrapperFor(canvasElement, accessibleName));
-};
+/** Opens an action chip's bubble and returns it. */
+const hoverChip = (canvasElement: HTMLElement, accessibleName: string) =>
+  openGlassTooltip(wrapperFor(canvasElement, accessibleName));
 
 const meta = {
   title: 'Cards/TaskCard',

--- a/apps/frontend/src/app/ui/cards/TaskCard/TaskCard.stories.tsx
+++ b/apps/frontend/src/app/ui/cards/TaskCard/TaskCard.stories.tsx
@@ -189,9 +189,7 @@ export const ActionTooltips: Story = {
          fresh pointer position each call, so it never emits the `mouseleave`
          that closes the previous bubble - without this the portals accumulate. */
       await userEvent.unhover(wrapper);
-      await waitFor(async () => {
-        await expect(within(document.body).queryByRole('tooltip')).toBeNull();
-      });
+      await waitFor(() => expect(within(document.body).queryByRole('tooltip')).toBeNull());
     }
   },
   parameters: {

--- a/apps/frontend/src/app/ui/cards/TaskCard/TaskCard.stories.tsx
+++ b/apps/frontend/src/app/ui/cards/TaskCard/TaskCard.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { fn } from 'storybook/test';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 import TaskCard from './index';
 import type { Task } from '@/app/features/tasks/types/task';
 
@@ -17,6 +17,18 @@ const BASE_TASK: Task = {
   status: 'PENDING',
 };
 
+/** GlassTooltip binds mouseenter/focusin to its own wrapper span, not the button. */
+const wrapperFor = (canvasElement: HTMLElement, accessibleName: string) =>
+  within(canvasElement)
+    .getByRole('button', { name: accessibleName })
+    .closest('.glass-tooltip') as HTMLElement;
+
+/** Hovers an action chip's tooltip wrapper and returns the portalled bubble. */
+const hoverChip = async (canvasElement: HTMLElement, accessibleName: string) => {
+  await userEvent.hover(wrapperFor(canvasElement, accessibleName));
+  return within(document.body).findByRole('tooltip');
+};
+
 const meta = {
   title: 'Cards/TaskCard',
   component: TaskCard,
@@ -28,7 +40,19 @@ const meta = {
           'Card form of a task on the tasks board: name and status pill on top, the quick details ' +
           '(category, instructions), the from/to/due lines, then the round action chips. Which ' +
           'chips appear is derived from the task status and `canEditTasks` — a completed task ' +
-          'cannot be rescheduled, so it only offers View.',
+          'cannot be rescheduled, so it only offers View.\n\n' +
+          'The action rail carries three `GlassTooltip` bubbles, and none of them had ever been ' +
+          'rendered. Each is built on `mouseenter`/`focusin` and then `createPortal`ed to ' +
+          '`document.body`, so it is not a descendant of this card in the DOM and no resting ' +
+          'snapshot - here or in Chromatic - contains a single one of them. They are also the only ' +
+          'place the chips are named in words: the glyphs are an eye, a sync arrow and a calendar, ' +
+          'and the labels ("View task", "Change status", "Reschedule") live nowhere on screen until ' +
+          'a pointer lands on the chip.\n\n' +
+          'They are `side="bottom"` bubbles, which matters on a board: the cards are 50% wide and ' +
+          'stack, so a bubble that opened upwards would cover the card above rather than the empty ' +
+          'space below. The hover stories assert the opened bubble has its text and its bottom ' +
+          'placement, not merely that a hover happened - a bubble that mounted empty would satisfy ' +
+          'the weaker check.',
       },
     },
   },
@@ -129,6 +153,111 @@ export const LongContent: Story = {
           'The overflow case. Detail values are `line-clamp-1`, but the title, from and to lines ' +
           'are not — this story is the guard against a long name pushing the status pill off the ' +
           'card.',
+      },
+    },
+  },
+};
+
+export const ActionTooltips: Story = {
+  name: 'Action tooltips (all three)',
+  args: { canEditTasks: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // A pending, editable task is the only state where all three chips exist.
+    await expect(canvas.getAllByRole('button')).toHaveLength(3);
+
+    const expectations: Array<[string, string]> = [
+      ['View task Administer post-op analgesia', 'View task'],
+      ['Change status for Administer post-op analgesia', 'Change status'],
+      ['Reschedule Administer post-op analgesia', 'Reschedule'],
+    ];
+
+    for (const [accessibleName, label] of expectations) {
+      const wrapper = wrapperFor(canvasElement, accessibleName);
+      await userEvent.hover(wrapper);
+      const bubble = await within(document.body).findByRole('tooltip');
+      await expect(bubble).toHaveTextContent(label);
+      /* side="bottom" - the bubble hangs under the chip so it cannot cover the
+         card stacked above this one on the board. Read the INLINE transform: a
+         laid-out element resolves any transform to a `matrix(...)`, so a
+         computed-style check cannot tell the two placements apart. */
+      await expect(bubble.style.transform).toMatch(/^translate\(-50%, 0(px)?\)$/);
+      // Exactly one live portal at a time - two would stack on document.body.
+      await expect(within(document.body).getAllByRole('tooltip')).toHaveLength(1);
+
+      /* Unhover explicitly. `userEvent.hover` from the direct API starts from a
+         fresh pointer position each call, so it never emits the `mouseleave`
+         that closes the previous bubble - without this the portals accumulate. */
+      await userEvent.unhover(wrapper);
+      await waitFor(async () => {
+        await expect(within(document.body).queryByRole('tooltip')).toBeNull();
+      });
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Every label on the rail, opened and dismissed in turn. The chip `aria-label`s carry the ' +
+          'task name ("Reschedule Administer post-op analgesia") while the bubbles carry the bare ' +
+          'verb, so the visible wording cannot be read off the resting markup at all. Each bubble ' +
+          'must also be gone before the next opens - they are absolutely positioned siblings on ' +
+          '`document.body` and would otherwise overlap rather than replace each other.',
+      },
+    },
+  },
+};
+
+export const ReadOnlyTooltip: Story = {
+  name: 'Read-only tooltip',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Without canEditTasks the rail is one chip, so this bubble is the only
+    // wording a member without permission ever sees.
+    await expect(canvas.getAllByRole('button')).toHaveLength(1);
+
+    const bubble = await hoverChip(canvasElement, 'View task Administer post-op analgesia');
+    await expect(bubble).toHaveTextContent('View task');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The single-chip rail with its bubble open. Worth its own story because the lone eye ' +
+          'glyph is otherwise unlabelled on screen, and this is the state most members of a ' +
+          'practice actually see.',
+      },
+    },
+  },
+};
+
+export const CompletedTooltip: Story = {
+  name: 'Completed task tooltip',
+  args: {
+    canEditTasks: true,
+    item: {
+      ...BASE_TASK,
+      _id: 'task-4',
+      name: 'Confirm discharge paperwork',
+      status: 'COMPLETED',
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Terminal status drops both edit chips even with the permission on.
+    await expect(canvas.getAllByRole('button')).toHaveLength(1);
+    await expect(canvas.queryByRole('button', { name: /^Change status/ })).toBeNull();
+
+    const bubble = await hoverChip(canvasElement, 'View task Confirm discharge paperwork');
+    await expect(bubble).toHaveTextContent('View task');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A completed task with full permission. The rail collapses to the same single chip as the ' +
+          'read-only case, which is the check that `canShowTaskStatusChangeAction` and ' +
+          '`canRescheduleTask` both refuse a terminal status rather than only one of them doing so.',
       },
     },
   },

--- a/apps/frontend/src/app/ui/cards/TaskCard/TaskCard.stories.tsx
+++ b/apps/frontend/src/app/ui/cards/TaskCard/TaskCard.stories.tsx
@@ -1,5 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import { expect, fn, within } from 'storybook/test';
+
+import {
+  closeGlassTooltip,
+  openGlassTooltip,
+} from '@/app/ui/primitives/GlassTooltip/storyInteractions';
 import TaskCard from './index';
 import type { Task } from '@/app/features/tasks/types/task';
 
@@ -17,7 +22,12 @@ const BASE_TASK: Task = {
   status: 'PENDING',
 };
 
-/** GlassTooltip binds mouseenter/focusin to its own wrapper span, not the button. */
+/**
+ * GlassTooltip binds mouseenter/focusin to its own wrapper span, not the button - and
+ * binds them in an effect, which has not necessarily flushed when a play function
+ * starts. `openGlassTooltip` redispatches until the listener is there to receive one;
+ * a single hover is silently dropped and no query-level retry can recover it.
+ */
 const wrapperFor = (canvasElement: HTMLElement, accessibleName: string) =>
   within(canvasElement)
     .getByRole('button', { name: accessibleName })
@@ -25,8 +35,7 @@ const wrapperFor = (canvasElement: HTMLElement, accessibleName: string) =>
 
 /** Hovers an action chip's tooltip wrapper and returns the portalled bubble. */
 const hoverChip = async (canvasElement: HTMLElement, accessibleName: string) => {
-  await userEvent.hover(wrapperFor(canvasElement, accessibleName));
-  return within(document.body).findByRole('tooltip');
+  return openGlassTooltip(wrapperFor(canvasElement, accessibleName));
 };
 
 const meta = {
@@ -174,8 +183,7 @@ export const ActionTooltips: Story = {
 
     for (const [accessibleName, label] of expectations) {
       const wrapper = wrapperFor(canvasElement, accessibleName);
-      await userEvent.hover(wrapper);
-      const bubble = await within(document.body).findByRole('tooltip');
+      const bubble = await openGlassTooltip(wrapper);
       await expect(bubble).toHaveTextContent(label);
       /* side="bottom" - the bubble hangs under the chip so it cannot cover the
          card stacked above this one on the board. Read the INLINE transform: a
@@ -185,11 +193,11 @@ export const ActionTooltips: Story = {
       // Exactly one live portal at a time - two would stack on document.body.
       await expect(within(document.body).getAllByRole('tooltip')).toHaveLength(1);
 
-      /* Unhover explicitly. `userEvent.hover` from the direct API starts from a
-         fresh pointer position each call, so it never emits the `mouseleave`
-         that closes the previous bubble - without this the portals accumulate. */
-      await userEvent.unhover(wrapper);
-      await waitFor(() => expect(within(document.body).queryByRole('tooltip')).toBeNull());
+      /* Close it explicitly. Opening the next chip does not close this one: each
+         wrapper owns its own portal and only its own `mouseleave` tears it down, so
+         without this the bubbles accumulate on `document.body` and the count above
+         starts passing for the wrong reason. */
+      await closeGlassTooltip(wrapper);
     }
   },
   parameters: {

--- a/apps/frontend/src/app/ui/cards/VideosCard/VideosCard.stories.tsx
+++ b/apps/frontend/src/app/ui/cards/VideosCard/VideosCard.stories.tsx
@@ -6,14 +6,6 @@ import VideosCard from './VideosCard';
 /** Same key the card writes when it is dismissed. */
 const HIDDEN_STORAGE_KEY = 'yc_dashboard_videos_hidden';
 
-const PHONE_VIEWPORT = {
-  phone: {
-    name: 'Mobile (375)',
-    styles: { width: '375px', height: '812px' },
-    type: 'mobile',
-  },
-};
-
 const meta = {
   title: 'Cards/VideosCard',
   component: VideosCard,
@@ -145,9 +137,8 @@ export const PlayerClosesBack: Story = {
 
 export const Phone: Story = {
   name: 'Phone (single column)',
-  globals: { viewport: { value: 'phone', isRotated: false } },
+  globals: { viewport: { value: 'mobile', isRotated: false } },
   parameters: {
-    viewport: { options: PHONE_VIEWPORT },
     chromatic: { viewports: [375] },
     docs: {
       description: {

--- a/apps/frontend/src/app/ui/cards/VideosCard/VideosCard.stories.tsx
+++ b/apps/frontend/src/app/ui/cards/VideosCard/VideosCard.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
 
 import VideosCard from './VideosCard';
 
@@ -25,7 +26,18 @@ const meta = {
           'The heading wraps while the "View more" button and close affordance stay on one line, and ' +
           'the three tiles sit in a 3-up grid that collapses to a single column below `md`. Tapping a ' +
           'tile opens the shared video player modal. Dismissing it writes to local storage and the ' +
-          'card never renders again — every story clears that key first so it always appears.',
+          'card never renders again — every story clears that key first so it always appears.\n\n' +
+          'The player is the half of this card that no capture has held. `VideoPlayerModal` is ' +
+          'mounted unconditionally with `showModal={false}`, and `ModalBase` portals it to ' +
+          '`document.body` as an `inert`, `opacity-0 pointer-events-none` `<dialog>` — so it is ' +
+          'always in the DOM and never visible until a tile is clicked. Every dimension of the ' +
+          'opened dialog (`sm:w-[720px] md:w-[860px] lg:w-[980px] max-w-[95vw]`), its centred ' +
+          'title row, and the poster overlay that covers the video until `onLoadedData` fires ' +
+          'existed only behind that click.\n\n' +
+          'Which video it opens is also state: `handleOpenVideo` sets `activeVideo` **and** resets ' +
+          '`isVideoLoaded` to false, so every tile re-enters the poster-covered state rather than ' +
+          'inheriting the previous video’s. The stories below click a tile and assert the dialog ' +
+          'carries that tile’s title, not merely that a dialog appeared.',
       },
     },
   },
@@ -46,6 +58,86 @@ export const Default: Story = {
     docs: {
       description: {
         story: 'Desktop reading: three tiles side by side under the heading row.',
+      },
+    },
+  },
+};
+
+/**
+ * `ModalBase` keeps the closed dialog mounted in the portal, so the `open`
+ * attribute - not the presence of a dialog - is what separates the two states.
+ */
+const openDialog = () => document.querySelector('dialog[open]') as HTMLElement | null;
+
+const findOpenDialog = async (): Promise<HTMLElement> => {
+  await waitFor(() => expect(openDialog()).toBeInTheDocument());
+  return openDialog() as HTMLElement;
+};
+
+export const PlayerOpen: Story = {
+  name: 'Player open (second tile)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      canvas.getByRole('button', { name: 'Play video: Run a visit end to end' })
+    );
+
+    // The dialog portals to document.body, so it is outside the story canvas.
+    const dialog = await findOpenDialog();
+    // Assert the dialog carries the clicked tile's content. A check that a
+    // dialog opened would pass on an empty one, or on the wrong video.
+    await expect(within(dialog).getByText('Run a visit end to end')).toBeInTheDocument();
+    await expect(within(dialog).getByRole('button', { name: 'Close' })).toBeInTheDocument();
+
+    const video = dialog.querySelector('video') as HTMLVideoElement;
+    await expect(video).toHaveAttribute('aria-label', 'Run a visit end to end');
+    // The dialog is wired to the tile that was clicked, not to the first video:
+    // both the source and the poster come from the second guide entry.
+    await expect(video.getAttribute('poster') ?? '').toContain('guideImages/2');
+    await expect(video.querySelector('source')?.getAttribute('src') ?? '').toContain(
+      'addCompanion.mp4'
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The tile-to-player path, and the check that it opens the *clicked* video: `activeVideo` ' +
+          'drives both the `<source>` and the `<video poster>`, and a stale `activeVideo` would ' +
+          'open the dialog looking correct with the wrong film in it. Whether the poster overlay ' +
+          'is still up when you look depends on the network — it is gated on `onLoadedData`, so ' +
+          'the reliable place to review that layer is the `Overlays/VideoPlayerModal` stories, ' +
+          'which use a source that can never decode.',
+      },
+    },
+  },
+};
+
+export const PlayerClosesBack: Story = {
+  name: 'Player closes back to the card',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      canvas.getByRole('button', { name: 'Play video: Your first day in the PIMS' })
+    );
+
+    const dialog = await findOpenDialog();
+    await expect(within(dialog).getByText('Your first day in the PIMS')).toBeInTheDocument();
+
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Close' }));
+    // Closing returns the dialog to its inert node - the card is untouched, and
+    // in particular is NOT dismissed: only the header Close does that.
+    await expect(openDialog()).toBeNull();
+    await expect(canvas.getAllByRole('button', { name: /^Play video:/ })).toHaveLength(3);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The round trip. `handleClose` on the modal resets `showModal` and `isVideoLoaded` ' +
+          'together, so reopening any tile starts from the poster again. The card’s own Close - ' +
+          'the one beside "View more" - is a different handler that writes ' +
+          '`yc_dashboard_videos_hidden` and removes the card for good.',
       },
     },
   },

--- a/apps/frontend/src/app/ui/inputs/MultiSelectDropdown/MultiSelectDropdown.stories.tsx
+++ b/apps/frontend/src/app/ui/inputs/MultiSelectDropdown/MultiSelectDropdown.stories.tsx
@@ -172,9 +172,7 @@ export const Searching: Story = {
     await expect(within(panel).getAllByRole('button')).toHaveLength(6);
     // The search field is the input the open trigger swaps in; it is focused on open.
     await userEvent.type(canvas.getByLabelText('Search Services'), 'den');
-    await waitFor(async () => {
-      await expect(within(panel).getAllByRole('button')).toHaveLength(1);
-    });
+    await waitFor(() => expect(within(panel).getAllByRole('button')).toHaveLength(1));
     await expect(within(panel).getByText('Dental scale and polish')).toBeInTheDocument();
   },
   parameters: {

--- a/apps/frontend/src/app/ui/inputs/MultiSelectDropdown/MultiSelectDropdown.stories.tsx
+++ b/apps/frontend/src/app/ui/inputs/MultiSelectDropdown/MultiSelectDropdown.stories.tsx
@@ -193,7 +193,7 @@ export const NoMatches: Story = {
     const canvas = within(canvasElement);
     const panel = await openPanel(canvasElement, 'Services');
     await userEvent.type(canvas.getByLabelText('Search Services'), 'zzz');
-    await expect(await within(panel).findByText('No matches found')).toBeInTheDocument();
+    expect(await within(panel).findByText('No matches found')).toBeInTheDocument();
     await expect(within(panel).queryAllByRole('button')).toHaveLength(0);
   },
   parameters: {

--- a/apps/frontend/src/app/ui/layout/GlobalFullscreenLoaderOverlay.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/GlobalFullscreenLoaderOverlay.stories.tsx
@@ -147,7 +147,7 @@ export const BlockingAction: Story = {
   args: { blockingSources: ['invoice-finalize'] },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(await canvas.findByTestId(LOADER_TEST_ID)).toBeInTheDocument();
+    expect(await canvas.findByTestId(LOADER_TEST_ID)).toBeInTheDocument();
   },
   parameters: {
     docs: {
@@ -168,7 +168,7 @@ export const ShownByInteraction: Story = {
     await expect(canvas.queryByTestId(LOADER_TEST_ID)).not.toBeInTheDocument();
     await userEvent.click(canvas.getByRole('button', { name: 'Start blocking action' }));
     // Reached through the same store call the app makes, not by seeding a fixture.
-    await expect(await canvas.findByTestId(LOADER_TEST_ID)).toBeInTheDocument();
+    expect(await canvas.findByTestId(LOADER_TEST_ID)).toBeInTheDocument();
   },
   parameters: {
     docs: {
@@ -187,7 +187,7 @@ export const RefCountedSources: Story = {
   args: { blockingSources: ['workspace-bootstrap', 'storybook-action'] },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(await canvas.findByTestId(LOADER_TEST_ID)).toBeInTheDocument();
+    expect(await canvas.findByTestId(LOADER_TEST_ID)).toBeInTheDocument();
     await userEvent.click(canvas.getByRole('button', { name: 'Finish blocking action' }));
     // One source released, one still held: the overlay must stay up.
     await expect(canvas.getByTestId(LOADER_TEST_ID)).toBeInTheDocument();

--- a/apps/frontend/src/app/ui/layout/Header/GuestHeader/GuestHeader.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/Header/GuestHeader/GuestHeader.stories.tsx
@@ -41,14 +41,6 @@ const withAuth = (user: AuthUser | null, role: string | null) => () => {
  * collapses the route list into the drawer is a `lg:` media query, so a merely narrow
  * container still renders the desktop bar.
  */
-const MOBILE_VIEWPORT = {
-  phone: {
-    name: 'Mobile (375)',
-    styles: { width: '375px', height: '812px' },
-    type: 'mobile',
-  },
-};
-
 /** Reproduces the sticky glass shell `Header` wraps the guest bar in. */
 const HeaderShell = ({ children }: { children: ReactNode }) => (
   <div style={{ background: 'var(--page)', minHeight: 220 }}>
@@ -143,9 +135,8 @@ export const SignedIn: Story = {
 
 export const Mobile: Story = {
   name: 'Mobile (menu closed)',
-  globals: { viewport: { value: 'phone', isRotated: false } },
+  globals: { viewport: { value: 'mobile', isRotated: false } },
   parameters: {
-    viewport: { options: MOBILE_VIEWPORT },
     chromatic: { viewports: [375] },
     docs: {
       description: {
@@ -183,7 +174,7 @@ const openDrawer = async (canvasElement: HTMLElement) => {
 
 export const MobileMenuOpen: Story = {
   name: 'Mobile (menu open)',
-  globals: { viewport: { value: 'phone', isRotated: false } },
+  globals: { viewport: { value: 'mobile', isRotated: false } },
   play: async ({ canvasElement }) => {
     const drawer = await openDrawer(canvasElement);
     // Count the drawer's contents: seven routes plus the auth CTA, all buttons.
@@ -196,10 +187,9 @@ export const MobileMenuOpen: Story = {
     const cta = within(drawer).getByText('Sign up');
     await expect(cta.closest('button')).toBeInTheDocument();
     // The trigger relabels rather than keeping one name for both states.
-    await expect(canvas.getByLabelText('Close menu')).toBeInTheDocument();
+    await expect(within(canvasElement).getByLabelText('Close menu')).toBeInTheDocument();
   },
   parameters: {
-    viewport: { options: MOBILE_VIEWPORT },
     chromatic: { viewports: [375] },
     docs: {
       description: {
@@ -215,7 +205,7 @@ export const MobileMenuOpen: Story = {
 
 export const MobileMenuOpenSignedIn: Story = {
   name: 'Mobile (menu open, signed in)',
-  globals: { viewport: { value: 'phone', isRotated: false } },
+  globals: { viewport: { value: 'mobile', isRotated: false } },
   beforeEach: withAuth(SIGNED_IN_USER, 'vet'),
   play: async ({ canvasElement }) => {
     const drawer = await openDrawer(canvasElement);
@@ -225,7 +215,6 @@ export const MobileMenuOpenSignedIn: Story = {
     await expect(within(drawer).queryByText('Sign up')).not.toBeInTheDocument();
   },
   parameters: {
-    viewport: { options: MOBILE_VIEWPORT },
     chromatic: { viewports: [375] },
     docs: {
       description: {

--- a/apps/frontend/src/app/ui/layout/Header/HamburgerMenuButton.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/Header/HamburgerMenuButton.stories.tsx
@@ -6,12 +6,12 @@ import './Header.css';
 const meta = {
   title: 'Layout/Header/HamburgerMenuButton',
   component: HamburgerMenuButton,
+  // Both are `lg:hidden`: on the default desktop canvas they render into a
+  // display:none box - in the DOM, zero pixels on screen. Pin to mobile.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
   parameters: {
     layout: 'centered',
     surface: 'marketing',
-    // Both are `lg:hidden`: on the default desktop canvas they render into a
-    // display:none box - in the DOM, zero pixels on screen. Pin to mobile.
-    viewport: { defaultViewport: 'mobile' },
     docs: {
       description: {
         component:

--- a/apps/frontend/src/app/ui/layout/Header/MobileMenu.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/Header/MobileMenu.stories.tsx
@@ -29,12 +29,12 @@ const MenuLinks = () => (
 const meta = {
   title: 'Layout/Header/MobileMenu',
   component: MobileMenu,
+  // Both are `lg:hidden`: on the default desktop canvas they render into a
+  // display:none box - in the DOM, zero pixels on screen. Pin to mobile.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
   parameters: {
     layout: 'padded',
     surface: 'marketing',
-    // Both are `lg:hidden`: on the default desktop canvas they render into a
-    // display:none box - in the DOM, zero pixels on screen. Pin to mobile.
-    viewport: { defaultViewport: 'mobile' },
     docs: {
       description: {
         component:

--- a/apps/frontend/src/app/ui/layout/MobileSearchBar/MobileSearchBar.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/MobileSearchBar/MobileSearchBar.stories.tsx
@@ -18,11 +18,11 @@ const seedQuery = (query: string) => () => {
 const meta = {
   title: 'Layout/MobileSearchBar',
   component: MobileSearchBar,
+  // `lg:hidden` removes the bar from 1024px up — at the preview's default laptop
+  // viewport it renders nothing, so every story here is pinned to phone width.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
   parameters: {
     layout: 'centered',
-    // `lg:hidden` removes the bar from 1024px up — at the preview's default laptop
-    // viewport it renders nothing, so every story here is pinned to phone width.
-    viewport: { defaultViewport: 'mobile' },
     docs: {
       description: {
         component:

--- a/apps/frontend/src/app/ui/layout/Notifications/NotificationsBell.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/Notifications/NotificationsBell.stories.tsx
@@ -122,7 +122,7 @@ export const DesktopEscapeCloses: Story = {
     const canvas = within(canvasElement);
     const bell = canvas.getByRole('button', { name: 'Notifications' });
     await userEvent.click(bell);
-    await expect(await canvas.findByRole('dialog', { name: 'Notifications' })).toBeInTheDocument();
+    expect(await canvas.findByRole('dialog', { name: 'Notifications' })).toBeInTheDocument();
 
     await userEvent.keyboard('{Escape}');
     await expect(canvas.queryByRole('dialog')).toBeNull();

--- a/apps/frontend/src/app/ui/layout/Notifications/NotificationsBell.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/Notifications/NotificationsBell.stories.tsx
@@ -8,14 +8,6 @@ import NotificationsBell from './NotificationsBell';
 import '../Header/UserHeader/UserHeader.css';
 import '../PhoneShell/PhoneShell.css';
 
-const PHONE_VIEWPORT = {
-  phone: {
-    name: 'Mobile (375)',
-    styles: { width: '375px', height: '812px' },
-    type: 'mobile',
-  },
-};
-
 /** A stand-in header row: the panel is anchored to the bell, so it needs a right edge. */
 const HeaderRow = (Story: React.ComponentType) => (
   <div className="min-h-[520px] bg-[var(--page)] p-4">
@@ -151,9 +143,8 @@ export const DesktopEscapeCloses: Story = {
 export const PhoneSheetOpen: Story = {
   name: 'Phone sheet open',
   args: { variant: 'phone' },
-  globals: { viewport: { value: 'phone', isRotated: false } },
+  globals: { viewport: { value: 'mobile', isRotated: false } },
   parameters: {
-    viewport: { options: PHONE_VIEWPORT },
     chromatic: { viewports: [375] },
     docs: {
       description: {

--- a/apps/frontend/src/app/ui/layout/Notifications/NotificationsPanel.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/Notifications/NotificationsPanel.stories.tsx
@@ -33,7 +33,7 @@ type Story = StoryObj<typeof meta>;
 
 /** Desktop/tablet dropdown: 420px card, `--screen` surface, hairline border. */
 export const Dropdown: Story = {
-  parameters: { viewport: { defaultViewport: 'tablet' } },
+  globals: { viewport: { value: 'tablet', isRotated: false } },
   args: { layout: 'dropdown' },
   render: (args) => (
     <div style={{ padding: 24 }}>
@@ -46,7 +46,7 @@ export const Dropdown: Story = {
 
 /** Phone bottom-sheet body: grabber, larger 38px icon discs, home indicator. */
 export const Sheet: Story = {
-  parameters: { viewport: { defaultViewport: 'mobile' } },
+  globals: { viewport: { value: 'mobile', isRotated: false } },
   args: { layout: 'sheet' },
   render: (args) => (
     <div style={{ padding: 0 }}>
@@ -64,7 +64,7 @@ export const Sheet: Story = {
 
 /** Empty feed — the live default until a durable source lands (outline bell). */
 export const Empty: Story = {
-  parameters: { viewport: { defaultViewport: 'tablet' } },
+  globals: { viewport: { value: 'tablet', isRotated: false } },
   args: { layout: 'dropdown', items: [], unreadCount: 0 },
   render: (args) => (
     <div style={{ padding: 24 }}>

--- a/apps/frontend/src/app/ui/layout/PhoneShell/BottomSheet.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/PhoneShell/BottomSheet.stories.tsx
@@ -11,21 +11,12 @@ import { Primary, Secondary } from '../../primitives/Buttons';
  * plain flow content with no radius, grabber sizing or backdrop. Every story
  * pins the canvas — and the Chromatic snapshot — to 375px.
  */
-const PHONE_VIEWPORT = {
-  phone: {
-    name: 'Mobile (375)',
-    styles: { width: '375px', height: '812px' },
-    type: 'mobile',
-  },
-};
-
 const meta = {
   title: 'Layout/PhoneBottomSheet',
   component: BottomSheet,
-  globals: { viewport: { value: 'phone', isRotated: false } },
+  globals: { viewport: { value: 'mobile', isRotated: false } },
   parameters: {
     layout: 'fullscreen',
-    viewport: { options: PHONE_VIEWPORT },
     chromatic: { viewports: [375] },
     docs: {
       description: {

--- a/apps/frontend/src/app/ui/layout/PhoneShell/PhoneHeader.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/PhoneShell/PhoneHeader.stories.tsx
@@ -37,24 +37,15 @@ const withOrg = (org: Organisation | null) => () => {
   };
 };
 
-const PHONE_VIEWPORT = {
-  phone: {
-    name: 'Mobile (375)',
-    styles: { width: '375px', height: '812px' },
-    type: 'mobile',
-  },
-};
-
 const meta = {
   title: 'Layout/PhoneHeader',
   component: PhoneHeader,
-  globals: { viewport: { value: 'phone', isRotated: false } },
+  globals: { viewport: { value: 'mobile', isRotated: false } },
   parameters: {
     layout: 'fullscreen',
     // Every rule in PhoneShell.css sits inside a `max-width: 767px` media
     // query, so both the canvas and the Chromatic snapshot have to be phone
     // width or the header renders as bare, unstyled elements.
-    viewport: { options: PHONE_VIEWPORT },
     chromatic: { viewports: [375] },
     // The org chip pushes a route on tap, so the App Router mock has to be on.
     nextjs: { appDirectory: true },

--- a/apps/frontend/src/app/ui/layout/PhoneShell/PhoneMoreSheet.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/PhoneShell/PhoneMoreSheet.stories.tsx
@@ -31,24 +31,15 @@ const LINKS: PhoneMoreLink[] = PHONE_MORE_LINKS.map((link) => ({
   icon: link.icon,
 }));
 
-const PHONE_VIEWPORT = {
-  phone: {
-    name: 'Mobile (375)',
-    styles: { width: '375px', height: '812px' },
-    type: 'mobile',
-  },
-};
-
 const meta = {
   title: 'Layout/PhoneMoreSheet',
   component: PhoneMoreSheet,
-  globals: { viewport: { value: 'phone', isRotated: false } },
+  globals: { viewport: { value: 'mobile', isRotated: false } },
   parameters: {
     layout: 'fullscreen',
     // Both the sheet skin (Sheet.css) and the tile grid (PhoneShell.css) sit
     // inside `max-width: 767px` media queries, so the canvas and the Chromatic
     // snapshot have to be phone width or this renders as unstyled lists.
-    viewport: { options: PHONE_VIEWPORT },
     chromatic: { viewports: [375] },
     docs: {
       description: {

--- a/apps/frontend/src/app/ui/layout/PhoneShell/PhoneShell.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/PhoneShell/PhoneShell.stories.tsx
@@ -27,14 +27,6 @@ const MEMBERSHIP: UserOrganization = {
   active: true,
 };
 
-const PHONE_VIEWPORT = {
-  phone: {
-    name: 'Mobile (375)',
-    styles: { width: '375px', height: '812px' },
-    type: 'mobile',
-  },
-};
-
 type ShellFixture = {
   org: boolean;
   chatUnread: number;
@@ -69,10 +61,9 @@ const withShellState =
 const meta = {
   title: 'Layout/PhoneShell',
   component: PhoneShell,
-  globals: { viewport: { value: 'phone', isRotated: false } },
+  globals: { viewport: { value: 'mobile', isRotated: false } },
   parameters: {
     layout: 'fullscreen',
-    viewport: { options: PHONE_VIEWPORT },
     // The shell is gated on a `(max-width: 767px)` media query and renders
     // nothing above it, so both the Storybook canvas and the Chromatic snapshot
     // have to be phone-width.

--- a/apps/frontend/src/app/ui/layout/PhoneShell/PhoneTabBar.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/PhoneShell/PhoneTabBar.stories.tsx
@@ -33,9 +33,9 @@ const buildItems = ({
 const meta = {
   title: 'Layout/PhoneTabBar',
   component: PhoneTabBar,
+  globals: { viewport: { value: 'mobile', isRotated: false } },
   parameters: {
     layout: 'fullscreen',
-    viewport: { defaultViewport: 'mobile' },
     docs: {
       description: {
         component:

--- a/apps/frontend/src/app/ui/layout/PublicShell/PublicShell.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/PublicShell/PublicShell.stories.tsx
@@ -17,14 +17,6 @@ const withSignedOutSession = () => {
 };
 
 /** Registered on the story that needs it so the phone width survives a Chromatic run. */
-const MOBILE_VIEWPORT = {
-  mobile: {
-    name: 'Mobile (375)',
-    styles: { width: '375px', height: '812px' },
-    type: 'mobile',
-  },
-};
-
 const PageBody = () => (
   <section style={{ padding: '120px 24px 200px', maxWidth: 760, margin: '0 auto' }}>
     <h2 className="text-[34px] leading-[1.15] font-normal text-[var(--ink)]">
@@ -108,7 +100,6 @@ export const Mobile: Story = {
   name: 'Mobile (hamburger)',
   globals: { viewport: { value: 'mobile', isRotated: false } },
   parameters: {
-    viewport: { options: MOBILE_VIEWPORT },
     chromatic: { viewports: [375] },
     docs: {
       description: {

--- a/apps/frontend/src/app/ui/layout/UniversalSearch/UniversalSearchPalette.stories.tsx
+++ b/apps/frontend/src/app/ui/layout/UniversalSearch/UniversalSearchPalette.stories.tsx
@@ -144,6 +144,6 @@ export const NoMatches: Story = {
  * a Cancel button in place of ESC, and the home indicator.
  */
 export const Phone: Story = {
-  parameters: { viewport: { defaultViewport: 'mobile' } },
+  globals: { viewport: { value: 'mobile', isRotated: false } },
   beforeEach: () => seedRecents([{ title: 'Bella Fischer', href: '/companions?companionId=c-1' }]),
 };

--- a/apps/frontend/src/app/ui/overlays/Modal/ConfirmModal.stories.tsx
+++ b/apps/frontend/src/app/ui/overlays/Modal/ConfirmModal.stories.tsx
@@ -43,6 +43,21 @@ const Demo = ({
   );
 };
 
+/**
+ * Resolves a design token to the colour the browser actually paints, so a story can
+ * say "this button is the danger fill" rather than only "it is filled with
+ * something". `Delete` and `Primary` are both filled pills; only the token tells
+ * them apart, and the token is the whole point of the tone branch.
+ */
+const resolveToken = (host: HTMLElement, token: string) => {
+  const probe = document.createElement('span');
+  probe.style.backgroundColor = `var(${token})`;
+  host.append(probe);
+  const value = getComputedStyle(probe).backgroundColor;
+  probe.remove();
+  return value;
+};
+
 /** The dialog portals to document.body, so it is never inside `canvasElement`. */
 const openDialog = async (canvasElement: HTMLElement, title: string) => {
   await userEvent.click(within(canvasElement).getByRole('button', { name: title }));
@@ -114,12 +129,13 @@ export const DangerousAction: Story = {
     const confirm = panel.getByRole('button', { name: 'Disconnect' });
     const cancel = panel.getByRole('button', { name: 'Cancel' });
     /* `Delete` fills with --danger-strong while `Secondary` is a bordered
-       transparent pill. If the tone branch were dropped the confirm would render
-       as an ordinary Primary and still look deliberate, so compare the fills. */
-    await expect(getComputedStyle(confirm).backgroundColor).not.toBe(
-      getComputedStyle(cancel).backgroundColor
+       transparent pill. Asserting only that the two differ would still pass if the
+       tone branch were dropped and a --cta Primary took its place, so pin the
+       confirm to the danger token itself. */
+    await expect(getComputedStyle(confirm).backgroundColor).toBe(
+      resolveToken(dialog, '--danger-strong')
     );
-    await expect(getComputedStyle(confirm).backgroundColor).not.toBe('rgba(0, 0, 0, 0)');
+    await expect(getComputedStyle(cancel).backgroundColor).toBe('rgba(0, 0, 0, 0)');
   },
   parameters: {
     docs: {
@@ -147,8 +163,8 @@ export const DangerConfirmed: Story = {
 
     // The promise resolves true and the dialog unmounts with it.
     const canvas = within(canvasElement);
-    await waitFor(async () => {
-      await expect(canvas.getByTestId('confirm-result')).toHaveTextContent('Result: confirmed');
+    await waitFor(() => {
+      expect(canvas.getByTestId('confirm-result')).toHaveTextContent('Result: confirmed');
     });
     await expect(within(document.body).queryByRole('dialog')).toBeNull();
   },
@@ -176,8 +192,8 @@ export const CancelDeclines: Story = {
     await userEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
 
     const canvas = within(canvasElement);
-    await waitFor(async () => {
-      await expect(canvas.getByTestId('confirm-result')).toHaveTextContent('Result: declined');
+    await waitFor(() => {
+      expect(canvas.getByTestId('confirm-result')).toHaveTextContent('Result: declined');
     });
   },
   parameters: {
@@ -206,8 +222,8 @@ export const EscapeDeclines: Story = {
 
     // Dismissal is a decline, matching what the native confirm() did.
     const canvas = within(canvasElement);
-    await waitFor(async () => {
-      await expect(canvas.getByTestId('confirm-result')).toHaveTextContent('Result: declined');
+    await waitFor(() => {
+      expect(canvas.getByTestId('confirm-result')).toHaveTextContent('Result: declined');
     });
   },
   parameters: {
@@ -231,8 +247,13 @@ export const NeutralAction: Story = {
     await expect(
       panel.getByText('The client will no longer be able to send messages in this conversation.')
     ).toBeInTheDocument();
-    // Same footer shape, `Primary` in place of `Delete`.
-    await expect(panel.getByRole('button', { name: 'Close session' })).toBeInTheDocument();
+    // Same footer shape, `Primary` in place of `Delete` - so the fill is --cta,
+    // and confusing the two tones is exactly the failure worth catching here.
+    const confirm = panel.getByRole('button', { name: 'Close session' });
+    await expect(getComputedStyle(confirm).backgroundColor).toBe(resolveToken(dialog, '--cta'));
+    await expect(getComputedStyle(confirm).backgroundColor).not.toBe(
+      resolveToken(dialog, '--danger-strong')
+    );
     await expect(panel.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
   },
   parameters: {

--- a/apps/frontend/src/app/ui/overlays/Modal/ConfirmModal.stories.tsx
+++ b/apps/frontend/src/app/ui/overlays/Modal/ConfirmModal.stories.tsx
@@ -1,5 +1,7 @@
+import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import React from 'react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
 import { Primary } from '@/app/ui/primitives/Buttons';
 import { useConfirm } from './ConfirmModal';
 
@@ -8,19 +10,6 @@ import { useConfirm } from './ConfirmModal';
  * confirm(). Rendered through the hook exactly as call sites use it, so the
  * story exercises the real promise flow rather than a static shell.
  */
-const meta: Meta = {
-  title: 'Overlays/ConfirmModal',
-  parameters: {
-    docs: {
-      description: {
-        component:
-          'Promise-based confirmation. `confirm()` resolves true on the confirm action and false on cancel, Escape, backdrop click or the close control.',
-      },
-    },
-  },
-};
-export default meta;
-
 const Demo = ({
   tone,
   title,
@@ -33,10 +22,10 @@ const Demo = ({
   confirmLabel: string;
 }) => {
   const { confirm, confirmDialog } = useConfirm();
-  const [result, setResult] = React.useState<string>('no answer yet');
+  const [result, setResult] = useState<string>('no answer yet');
 
   return (
-    <div className="flex flex-col items-start gap-4 p-6">
+    <div className="flex min-h-[320px] flex-col items-start gap-4 p-6">
       {confirmDialog}
       <span data-testid="open-confirm-wrap">
         <Primary
@@ -54,39 +43,236 @@ const Demo = ({
   );
 };
 
-type Story = StoryObj<typeof Demo>;
+/** The dialog portals to document.body, so it is never inside `canvasElement`. */
+const openDialog = async (canvasElement: HTMLElement, title: string) => {
+  await userEvent.click(within(canvasElement).getByRole('button', { name: title }));
+  return within(document.body).findByRole('dialog', { name: title });
+};
+
+const meta = {
+  title: 'Overlays/ConfirmModal',
+  component: Demo,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Promise-based confirmation. `confirm()` resolves true on the confirm action and false on ' +
+          'cancel, Escape, backdrop click or the close control.\n\n' +
+          'The dialog is `options ? <ConfirmModal .../> : null` behind a resolver held in a ref, so ' +
+          'it does not exist until a promise is open - there is no `open` prop and no way to reach ' +
+          'it from args. Every story here used to render only the closed trigger, which means the ' +
+          'markup that actually confirms destructive actions across the product had never been drawn ' +
+          'anywhere: not the header, not the body sentence, and not the danger footer.\n\n' +
+          'What that hid is a footer whose confirm button is a **different component** per tone - ' +
+          '`Delete` on `danger`, `Primary` otherwise - sitting beside a fixed `Secondary` cancel. ' +
+          'The two share no classes: `Delete` paints `--danger-strong` with `--danger-strong-ink`, ' +
+          '`Primary` paints `--cta`. That swap is the single most consequential pixel in the ' +
+          'component, since it is the only thing distinguishing "Disconnect" from "Save", and it is ' +
+          'reachable only after a click.\n\n' +
+          'The stories assert the dialog carries its header, its sentence and both buttons, and they ' +
+          'resolve the promise both ways - the resolved value is written into the page, so a dialog ' +
+          'that renders but never settles is visible as a stuck "no answer yet".',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    title: 'Close this chat session?',
+    body: 'The client will no longer be able to send messages in this conversation.',
+    confirmLabel: 'Close session',
+  },
+} satisfies Meta<typeof Demo>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
 
 export const DangerousAction: Story = {
   name: 'Danger (disconnect IDEXX)',
-  render: () => (
-    <Demo
-      tone="danger"
-      title="Disconnect IDEXX?"
-      body="Lab ordering and result syncing stop for this organization until IDEXX is enabled again."
-      confirmLabel="Disconnect"
-    />
-  ),
+  args: {
+    tone: 'danger',
+    title: 'Disconnect IDEXX?',
+    body: 'Lab ordering and result syncing stop for this organization until IDEXX is enabled again.',
+    confirmLabel: 'Disconnect',
+  },
+  play: async ({ canvasElement }) => {
+    const dialog = await openDialog(canvasElement, 'Disconnect IDEXX?');
+    const panel = within(dialog);
+
+    /* Assert the dialog has its content, not merely that it mounted - an empty
+       panel satisfies the role just as well as a populated one. */
+    await expect(panel.getByRole('heading', { name: 'Disconnect IDEXX?' })).toBeInTheDocument();
+    await expect(
+      panel.getByText(
+        'Lab ordering and result syncing stop for this organization until IDEXX is enabled again.'
+      )
+    ).toBeInTheDocument();
+
+    // Three controls: close, cancel, confirm - and the confirm carries the tone.
+    await expect(panel.getByRole('button', { name: 'Close' })).toBeInTheDocument();
+    await expect(panel.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    const confirm = panel.getByRole('button', { name: 'Disconnect' });
+    const cancel = panel.getByRole('button', { name: 'Cancel' });
+    /* `Delete` fills with --danger-strong while `Secondary` is a bordered
+       transparent pill. If the tone branch were dropped the confirm would render
+       as an ordinary Primary and still look deliberate, so compare the fills. */
+    await expect(getComputedStyle(confirm).backgroundColor).not.toBe(
+      getComputedStyle(cancel).backgroundColor
+    );
+    await expect(getComputedStyle(confirm).backgroundColor).not.toBe('rgba(0, 0, 0, 0)');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The danger tone, which is what almost every call site uses. This is the only story that ' +
+          'draws the `Delete` confirm button - a filled `--danger-strong` pill against the bordered ' +
+          'Secondary cancel beside it.',
+      },
+    },
+  },
 };
 
-export const DeleteGroup: Story = {
-  name: 'Danger (delete group)',
-  render: () => (
-    <Demo
-      tone="danger"
-      title="Delete this group?"
-      body="The group and its messages are removed for everyone. This cannot be undone."
-      confirmLabel="Delete group"
-    />
-  ),
+export const DangerConfirmed: Story = {
+  name: 'Danger, confirmed',
+  args: {
+    tone: 'danger',
+    title: 'Delete this group?',
+    body: 'The group and its messages are removed for everyone. This cannot be undone.',
+    confirmLabel: 'Delete group',
+  },
+  play: async ({ canvasElement }) => {
+    const dialog = await openDialog(canvasElement, 'Delete this group?');
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Delete group' }));
+
+    // The promise resolves true and the dialog unmounts with it.
+    const canvas = within(canvasElement);
+    await waitFor(async () => {
+      await expect(canvas.getByTestId('confirm-result')).toHaveTextContent('Result: confirmed');
+    });
+    await expect(within(document.body).queryByRole('dialog')).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The full round trip a call site sees: `await confirm(...)` returns `true` and the dialog ' +
+          'goes away in the same settle. Reachable only by driving the promise - no arg produces it.',
+      },
+    },
+  },
+};
+
+export const CancelDeclines: Story = {
+  name: 'Cancel declines',
+  args: {
+    tone: 'danger',
+    title: 'Delete this group?',
+    body: 'The group and its messages are removed for everyone. This cannot be undone.',
+    confirmLabel: 'Delete group',
+  },
+  play: async ({ canvasElement }) => {
+    const dialog = await openDialog(canvasElement, 'Delete this group?');
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+
+    const canvas = within(canvasElement);
+    await waitFor(async () => {
+      await expect(canvas.getByTestId('confirm-result')).toHaveTextContent('Result: declined');
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Cancel resolves `false` rather than leaving the promise open, so a caller that awaited it ' +
+          'continues down its declined branch instead of hanging. A dialog that unmounts without ' +
+          'settling looks identical on screen and is the failure this asserts against.',
+      },
+    },
+  },
+};
+
+export const EscapeDeclines: Story = {
+  name: 'Escape declines',
+  args: {
+    tone: 'danger',
+    title: 'Delete this group?',
+    body: 'The group and its messages are removed for everyone. This cannot be undone.',
+    confirmLabel: 'Delete group',
+  },
+  play: async ({ canvasElement }) => {
+    await openDialog(canvasElement, 'Delete this group?');
+    await userEvent.keyboard('{Escape}');
+
+    // Dismissal is a decline, matching what the native confirm() did.
+    const canvas = within(canvasElement);
+    await waitFor(async () => {
+      await expect(canvas.getByTestId('confirm-result')).toHaveTextContent('Result: declined');
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Escape settles the same promise as Cancel. It runs through `ModalBase`'s stack check, so " +
+          'a confirm opened over another panel dismisses only itself - which is exactly the ' +
+          'arrangement this component is used in, since it usually confirms an action started inside ' +
+          'another modal.',
+      },
+    },
+  },
 };
 
 export const NeutralAction: Story = {
   name: 'Default tone',
-  render: () => (
-    <Demo
-      title="Close this chat session?"
-      body="The client will no longer be able to send messages in this conversation."
-      confirmLabel="Close session"
-    />
-  ),
+  play: async ({ canvasElement }) => {
+    const dialog = await openDialog(canvasElement, 'Close this chat session?');
+    const panel = within(dialog);
+    await expect(
+      panel.getByText('The client will no longer be able to send messages in this conversation.')
+    ).toBeInTheDocument();
+    // Same footer shape, `Primary` in place of `Delete`.
+    await expect(panel.getByRole('button', { name: 'Close session' })).toBeInTheDocument();
+    await expect(panel.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The non-destructive tone, worth seeing beside the danger one: identical geometry, a ' +
+          '`--cta` fill instead of `--danger-strong`, and the same bordered cancel. Any difference ' +
+          'beyond the fill would be a bug.',
+      },
+    },
+  },
+};
+
+export const LongBody: Story = {
+  name: 'Long consequence sentence',
+  args: {
+    tone: 'danger',
+    title: 'Remove this room from every future appointment?',
+    body:
+      'Every upcoming appointment currently assigned to this room loses its location, including ' +
+      'recurring series that extend past the end of the year. Clients already sent a confirmation ' +
+      'naming the room are not re-notified, and the change cannot be reversed from this screen.',
+    confirmLabel: 'Remove room',
+  },
+  play: async ({ canvasElement }) => {
+    const dialog = await openDialog(
+      canvasElement,
+      'Remove this room from every future appointment?'
+    );
+    await expect(within(dialog).getByRole('button', { name: 'Remove room' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The dialog is a fixed 500px panel with no scroll of its own, so the title wraps and the ' +
+          'body grows the panel downwards. This is the case that decides whether the footer stays ' +
+          'reachable on a short viewport.',
+      },
+    },
+  },
 };

--- a/apps/frontend/src/app/ui/overlays/Modal/DeleteConfirmationModal.stories.tsx
+++ b/apps/frontend/src/app/ui/overlays/Modal/DeleteConfirmationModal.stories.tsx
@@ -176,7 +176,7 @@ export const EmailRequired: Story = {
     await userEvent.click(scope.getByRole('button', { name: 'Delete' }));
     // Reachable only because consent and the email are separate gates: a combined
     // gate would leave Delete disabled and this message unreachable.
-    await expect(await scope.findByRole('alert')).toHaveTextContent('Email is required');
+    expect(await scope.findByRole('alert')).toHaveTextContent('Email is required');
     await expect(args.onDelete).not.toHaveBeenCalled();
     await expect(scope.getByLabelText('Enter email address')).toHaveAttribute(
       'aria-invalid',
@@ -201,7 +201,7 @@ export const EmailInvalid: Story = {
     const dialog = await openDialog(canvasElement);
     const scope = await fillGate(dialog, 'ops@yosemite');
     await userEvent.click(scope.getByRole('button', { name: 'Delete' }));
-    await expect(await scope.findByRole('alert')).toHaveTextContent('Enter a valid email');
+    expect(await scope.findByRole('alert')).toHaveTextContent('Enter a valid email');
     await expect(args.onDelete).not.toHaveBeenCalled();
   },
   parameters: {
@@ -222,7 +222,7 @@ export const ErrorClearsOnTyping: Story = {
     const dialog = await openDialog(canvasElement);
     const scope = await fillGate(dialog, 'ops@yosemite');
     await userEvent.click(scope.getByRole('button', { name: 'Delete' }));
-    await expect(await scope.findByRole('alert')).toBeInTheDocument();
+    expect(await scope.findByRole('alert')).toBeInTheDocument();
     await userEvent.type(scope.getByLabelText('Enter email address'), 'crew.com');
     await expect(scope.queryByRole('alert')).not.toBeInTheDocument();
     await expect(scope.getByLabelText('Enter email address')).toHaveValue('ops@yosemitecrew.com');

--- a/apps/frontend/src/app/ui/overlays/Modal/DeleteConfirmationModal.stories.tsx
+++ b/apps/frontend/src/app/ui/overlays/Modal/DeleteConfirmationModal.stories.tsx
@@ -1,0 +1,315 @@
+import { useState, type ComponentProps } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+
+import DeleteConfirmationModal from './DeleteConfirmationModal';
+
+type DeleteModalProps = ComponentProps<typeof DeleteConfirmationModal>;
+
+const ITEMS = [
+  'All companion and clinical records held by this organization',
+  'Every appointment, invoice and payment history',
+  'All staff accounts and their access',
+  'Uploaded documents, images and lab results',
+];
+
+/**
+ * `showModal` is a prop, but the state behind the gate - consent, the typed email and
+ * its inline error - lives inside the component and is reset on every close. So the
+ * harness owns only the open flag, exactly as the settings page does, and drives it
+ * through a trigger rather than mounting the dialog open: at rest the docs page then
+ * holds no `ModalBase` scroll lock.
+ */
+const DeleteFlowHarness = (args: DeleteModalProps) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="flex min-h-[560px] items-start p-6">
+      <button
+        type="button"
+        className="rounded-2xl bg-[var(--danger-strong)] px-6 py-3 text-body-3-emphasis text-[var(--danger-strong-ink)]"
+        onClick={() => setOpen(true)}
+      >
+        Delete organization
+      </button>
+      <DeleteConfirmationModal {...args} showModal={open} setShowModal={setOpen} />
+    </div>
+  );
+};
+
+/** Opens the dialog and returns it. Only the open one carries the `open` attribute. */
+const openDialog = async (canvasElement: HTMLElement) => {
+  const canvas = within(canvasElement);
+  await userEvent.click(canvas.getByRole('button', { name: 'Delete organization' }));
+  const dialog = document.body.querySelector('dialog.yc-modal-dialog[open]') as HTMLElement | null;
+  await expect(dialog).toBeInTheDocument();
+  return dialog as HTMLElement;
+};
+
+/** Ticks consent and, optionally, types an address. */
+const fillGate = async (dialog: HTMLElement, email?: string) => {
+  const scope = within(dialog);
+  await userEvent.click(scope.getByRole('checkbox'));
+  if (email !== undefined) {
+    await userEvent.type(scope.getByLabelText('Enter email address'), email);
+  }
+  return scope;
+};
+
+const meta = {
+  title: 'Overlays/DeleteConfirmationModal',
+  component: DeleteConfirmationModal,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The last step before an organization or a profile is destroyed. It is `createPortal`ed ' +
+          'to `document.body` by `CenterModal`, so it exists only while a page holds `showModal` - ' +
+          'and the states that matter are two interactions deeper still, behind a checkbox and a ' +
+          'typed email that no snapshot had ever supplied.\n\n' +
+          'The gate is the reason to draw it. Delete is `isDisabled={!consent}`, which through ' +
+          '`BaseButton` renders a genuinely `disabled` button (the `href="#"` never becomes a link), ' +
+          'and `handleDelete` re-checks consent before doing anything - defence in depth on an ' +
+          'irreversible action. The email is validated *separately*, inline, and only once Delete ' +
+          'is pressed: folding it into the same gate would make "Email is required" unreachable, ' +
+          'because the button would still be disabled at the moment the message needed to appear. ' +
+          'So there are three distinct rejections - unticked, empty address, malformed address - ' +
+          'and each renders differently.\n\n' +
+          'The layout worth pinning is the same shape as the bugs this sweep exists for: a ' +
+          '`grid grid-cols-2 gap-2` action row nested inside `CenterModal`’s ' +
+          '`flex flex-col gap-3`, mounted only with the dialog, with the destructive pill on the ' +
+          'right where a confirm usually sits. Above it the "will permanently remove" bullets are ' +
+          'a `list-disc` at `text-caption-1`, and the whole dialog is a fixed 500px column that ' +
+          'grows downward as that list grows.\n\n' +
+          'Every story below opens the dialog through its trigger and asserts the panel has its ' +
+          'copy, its bullets and both actions - not merely that something portalled.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    showModal: false,
+    setShowModal: fn(),
+    title: 'Delete organization',
+    confirmationQuestion: 'Are you sure you want to delete Riverbend Veterinary?',
+    itemsToRemove: ITEMS,
+    emailPrompt: 'Type the email address on your account to confirm.',
+    consentLabel: 'I understand this is permanent and cannot be undone.',
+    noteText: 'Deletion runs within 24 hours and cannot be cancelled once it starts.',
+    onDelete: fn(),
+  },
+  argTypes: {
+    // Owned by the harness so the dialog has a real open/close lifecycle.
+    showModal: { table: { disable: true }, control: false },
+    setShowModal: { table: { disable: true }, control: false },
+  },
+  render: (args) => <DeleteFlowHarness {...args} />,
+} satisfies Meta<typeof DeleteConfirmationModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Open: Story = {
+  name: 'Open (Delete gated)',
+  play: async ({ canvasElement }) => {
+    const dialog = await openDialog(canvasElement);
+    const scope = within(dialog);
+    await expect(scope.getByRole('heading', { name: 'Delete organization' })).toBeInTheDocument();
+    await expect(
+      scope.getByText('Are you sure you want to delete Riverbend Veterinary?')
+    ).toBeInTheDocument();
+    await expect(scope.getByText('This action will permanently remove:')).toBeInTheDocument();
+    // The bullets are the substance of the warning - assert they are all there, not
+    // merely that a list element exists.
+    await expect(scope.getAllByRole('listitem')).toHaveLength(ITEMS.length);
+    await expect(scope.getByText(ITEMS[0])).toBeInTheDocument();
+    await expect(scope.getByLabelText('Enter email address')).toHaveValue('');
+    await expect(scope.getByRole('checkbox')).not.toBeChecked();
+    // The gate itself: Delete is a real disabled button until consent is given.
+    const remove = scope.getByRole('button', { name: 'Delete' });
+    await expect(remove).toBeDisabled();
+    await expect(scope.getByRole('button', { name: 'Cancel' })).toBeEnabled();
+    /* Both actions live in a `grid grid-cols-2` that only mounts with the dialog.
+       Assert the computed template resolves to two tracks holding both buttons: a
+       dropped template stacks them into one column and still looks deliberate. */
+    const actions = remove.parentElement as HTMLElement;
+    await expect(getComputedStyle(actions).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(2);
+    await expect(actions.children).toHaveLength(2);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The dialog as it opens: the question, the bulleted list of what goes, the email field, ' +
+          'the consent row, and a Delete that cannot yet be pressed. Nothing here indicates *why* ' +
+          'Delete is inert other than the checkbox above it, which is the whole design.',
+      },
+    },
+  },
+};
+
+export const ConsentGiven: Story = {
+  name: 'Consent ticked (Delete live)',
+  play: async ({ canvasElement }) => {
+    const dialog = await openDialog(canvasElement);
+    const scope = await fillGate(dialog);
+    await expect(scope.getByRole('checkbox')).toBeChecked();
+    await expect(scope.getByRole('button', { name: 'Delete' })).toBeEnabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'One click changes the button from disabled to live. `BaseButton` swaps the ' +
+          '`pointer-events-none opacity-60` pair off it, so the difference is a 40% opacity step ' +
+          'on a red pill - the only visual feedback that the gate has opened.',
+      },
+    },
+  },
+};
+
+export const EmailRequired: Story = {
+  name: 'Consent ticked, no email',
+  play: async ({ canvasElement, args }) => {
+    const dialog = await openDialog(canvasElement);
+    const scope = await fillGate(dialog);
+    await userEvent.click(scope.getByRole('button', { name: 'Delete' }));
+    // Reachable only because consent and the email are separate gates: a combined
+    // gate would leave Delete disabled and this message unreachable.
+    await expect(await scope.findByRole('alert')).toHaveTextContent('Email is required');
+    await expect(args.onDelete).not.toHaveBeenCalled();
+    await expect(scope.getByLabelText('Enter email address')).toHaveAttribute(
+      'aria-invalid',
+      'true'
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Pressing Delete with the address blank. The error is an inline `role="alert"` row under ' +
+          'the field with a warning glyph, and it also flips the input border to `--danger` - a ' +
+          'state that appears *after* a press rather than on blur, so it is only ever seen mid-flow.',
+      },
+    },
+  },
+};
+
+export const EmailInvalid: Story = {
+  name: 'Consent ticked, malformed email',
+  play: async ({ canvasElement, args }) => {
+    const dialog = await openDialog(canvasElement);
+    const scope = await fillGate(dialog, 'ops@yosemite');
+    await userEvent.click(scope.getByRole('button', { name: 'Delete' }));
+    await expect(await scope.findByRole('alert')).toHaveTextContent('Enter a valid email');
+    await expect(args.onDelete).not.toHaveBeenCalled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The second rejection, with different copy in the same row. Typing again clears the ' +
+          'error on the first keystroke rather than on the next press, so this state is easy to ' +
+          'lose and hard to review outside a story.',
+      },
+    },
+  },
+};
+
+export const ErrorClearsOnTyping: Story = {
+  name: 'Error clears as soon as typing resumes',
+  play: async ({ canvasElement }) => {
+    const dialog = await openDialog(canvasElement);
+    const scope = await fillGate(dialog, 'ops@yosemite');
+    await userEvent.click(scope.getByRole('button', { name: 'Delete' }));
+    await expect(await scope.findByRole('alert')).toBeInTheDocument();
+    await userEvent.type(scope.getByLabelText('Enter email address'), 'crew.com');
+    await expect(scope.queryByRole('alert')).not.toBeInTheDocument();
+    await expect(scope.getByLabelText('Enter email address')).toHaveValue('ops@yosemitecrew.com');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The recovery path. `onChange` clears the message, so the row disappears and the dialog ' +
+          'shrinks by its height while the reader is still typing - the layout shift is the point ' +
+          'of drawing it.',
+      },
+    },
+  },
+};
+
+export const Confirmed: Story = {
+  name: 'Deleted',
+  play: async ({ canvasElement, args }) => {
+    const dialog = await openDialog(canvasElement);
+    const scope = await fillGate(dialog, 'ops@yosemitecrew.com');
+    await userEvent.click(scope.getByRole('button', { name: 'Delete' }));
+    await expect(args.onDelete).toHaveBeenCalled();
+    // Both gates satisfied: the modal resets its own state and closes itself. The
+    // close lands after `onDelete` settles, so wait for it rather than racing it.
+    await waitFor(() =>
+      expect(document.body.querySelector('dialog.yc-modal-dialog[open]')).not.toBeInTheDocument()
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The only path that reaches `onDelete`. The modal awaits it, then resets consent, email ' +
+          'and error before closing, so re-opening never shows a pre-ticked consent box.',
+      },
+    },
+  },
+};
+
+export const Cancelled: Story = {
+  name: 'Cancelled',
+  play: async ({ canvasElement, args }) => {
+    const dialog = await openDialog(canvasElement);
+    await fillGate(dialog, 'ops@yosemitecrew.com');
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+    await expect(args.onDelete).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(document.body.querySelector('dialog.yc-modal-dialog[open]')).not.toBeInTheDocument()
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Cancel runs the same `reset()` as a successful delete, which is what stops a filled-in ' +
+          'address and a ticked consent box surviving into the next open.',
+      },
+    },
+  },
+};
+
+export const ShortList: Story = {
+  name: 'Two bullets (profile deletion)',
+  args: {
+    title: 'Delete profile',
+    confirmationQuestion: 'Are you sure you want to delete your profile?',
+    itemsToRemove: ['Your account and sign-in', 'Your personal settings and preferences'],
+    emailPrompt: 'Type your email address to confirm.',
+    consentLabel: 'I understand my profile cannot be restored.',
+    noteText: 'Records you authored stay with the organization.',
+  },
+  play: async ({ canvasElement }) => {
+    const dialog = await openDialog(canvasElement);
+    const scope = within(dialog);
+    await expect(scope.getAllByRole('listitem')).toHaveLength(2);
+    await expect(scope.getByRole('button', { name: 'Delete' })).toBeDisabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The other caller of the same dialog. Every string is a prop, so the shortest form is ' +
+          'the honest test of the fixed 500px column: with two bullets the dialog is barely taller ' +
+          'than its actions, and the `gap-3` rhythm between the four blocks is all that separates ' +
+          'them.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/overlays/Modal/GuidePlayerModal.stories.tsx
+++ b/apps/frontend/src/app/ui/overlays/Modal/GuidePlayerModal.stories.tsx
@@ -1,0 +1,258 @@
+import { useState, type ComponentProps } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+import type { GuideVideo } from '@/app/features/guides/types/guides';
+
+import GuidePlayerModal from './GuidePlayerModal';
+
+const GUIDE: GuideVideo = {
+  id: 'guide-checkin-flow',
+  title: 'Checking a patient in and starting the encounter',
+  description: 'From the day board to an open workspace, including the deposit prompt.',
+  duration: '5:18',
+  category: 'Front desk',
+  tags: ['appointments', 'check-in'],
+  videoUrl: 'https://example.invalid/guides/checkin.mp4',
+  thumbnailUrl: 'https://example.invalid/guides/checkin.jpg',
+  progressPercent: 62,
+  currentTime: '3:07',
+  chapters: [
+    { label: 'Day board', time: '0:00' },
+    { label: 'Check in', time: '1:12' },
+    { label: 'Deposit', time: '3:40' },
+    { label: 'Wrap up', time: '4:50', highlight: true },
+  ],
+};
+
+const NEXT_GUIDE: GuideVideo = {
+  id: 'guide-invoice-finalise',
+  title: 'Finalising an invoice',
+  description: 'Discounts, deposits and the tax footer.',
+  duration: '4:02',
+  category: 'Finance',
+  tags: ['finance'],
+  videoUrl: 'https://example.invalid/guides/invoice.mp4',
+  thumbnailUrl: 'https://example.invalid/guides/invoice.jpg',
+};
+
+/**
+ * The modal has no trigger of its own - the guides grid owns `showModal` and
+ * decides which guide is loaded - so this harness supplies both, and gives the
+ * stories something to click rather than posing the panel open from an arg.
+ */
+const GuideLauncher = (args: ComponentProps<typeof GuidePlayerModal>) => {
+  const [showModal, setShowModal] = useState(args.showModal);
+  return (
+    <div className="flex min-h-[200px] items-start justify-center p-8">
+      <button
+        type="button"
+        onClick={() => setShowModal(true)}
+        className="rounded-full border border-[var(--hairline)] px-4 py-2 text-[13px] font-semibold text-[var(--ink-body)]"
+      >
+        Play guide
+      </button>
+      <GuidePlayerModal {...args} showModal={showModal} setShowModal={setShowModal} />
+    </div>
+  );
+};
+
+/** Only `<dialog open>` is painted; a closed one stays mounted and inert. */
+const openDialog = () => document.querySelector<HTMLElement>('dialog[open]');
+
+const meta = {
+  title: 'Overlays/GuidePlayerModal',
+  component: GuidePlayerModal,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The centred guide player: a 920px panel holding a category pill and title, a Copy link ' +
+          'chip, the 16:9 video surface with its scrubber and transport row, and a footer of ' +
+          'chapter markers with a "Next" link.\n\n' +
+          'The whole panel is doubly gated - it needs `showModal` **and** a non-null `guide`, and it ' +
+          'returns `null` outright when the guide is missing rather than rendering an empty shell. ' +
+          'So nothing about it had ever been drawn, and none of it is cheap: the video surface is ' +
+          'the one place in the product that paints a hard-coded near-black `#1d1c1b` and a literal ' +
+          '`#f7f3ec` ink instead of tokens, deliberately, because a video frame is dark in both ' +
+          'themes. That decision is invisible unless the panel is on screen, and it is exactly the ' +
+          'kind of thing a token sweep would "fix" by mistake.\n\n' +
+          'A second state exists only as a consequence of a promise: the Copy link chip relabels to ' +
+          '"Copied" only if `navigator.clipboard.writeText` resolves, and reverts itself after ' +
+          '1800ms. `copyToClipboard` swallows a rejection and returns `false`, so a refused ' +
+          'clipboard leaves the chip silently unchanged - there is no failure affordance at all. ' +
+          'One story stubs the clipboard to reach the "Copied" label, because pressing the button ' +
+          'against a real one is a coin toss.\n\n' +
+          'The stories assert the opened panel has its content - the pill, the timecode, the ' +
+          'scrubber width, the chapter labels - rather than that a dialog appeared, because an ' +
+          'empty dialog satisfies the weaker check.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    showModal: false,
+    setShowModal: fn(),
+    guide: GUIDE,
+    nextGuide: NEXT_GUIDE,
+    onNext: fn(),
+  },
+  render: (args) => <GuideLauncher {...args} />,
+} satisfies Meta<typeof GuidePlayerModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Open: Story = {
+  name: 'Player open',
+  play: async ({ canvasElement }) => {
+    await userEvent.click(within(canvasElement).getByRole('button', { name: 'Play guide' }));
+
+    const dialog = openDialog() as HTMLElement;
+    await expect(dialog).toBeInTheDocument();
+
+    // Header: category pill, title, the copy chip and the close chip.
+    await expect(within(dialog).getByText('Front desk')).toBeInTheDocument();
+    await expect(
+      within(dialog).getByText('Checking a patient in and starting the encounter')
+    ).toBeInTheDocument();
+    await expect(within(dialog).getByRole('button', { name: 'Copy link' })).toBeInTheDocument();
+    await expect(within(dialog).getByRole('button', { name: 'Close' })).toBeInTheDocument();
+
+    // Video surface: a 16:9 block with the transport timecode inside it.
+    const surface = dialog.querySelector('.aspect-video') as HTMLElement;
+    await expect(surface).toBeTruthy();
+    await expect(within(surface).getByText('3:07 / 5:18')).toBeInTheDocument();
+
+    /* The scrubber is the only element whose geometry is data-driven. Assert the
+       fill really carries the guide's progress - a dropped style leaves a
+       full-width or zero-width bar that still looks like a scrubber. */
+    const fill = surface.querySelector('span[style*="width"]') as HTMLElement;
+    await expect(fill.style.width).toBe('62%');
+
+    // Footer: chapter run and the next-guide link.
+    await expect(within(dialog).getByText(/Chapters:/)).toBeInTheDocument();
+    await expect(
+      within(dialog).getByRole('button', { name: /Next: Finalising an invoice/ })
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The panel as a viewer sees it mid-way through a guide: a 62% scrubber, "3:07 / 5:18" in ' +
+          'the transport row, and the final chapter tinted `--blue-text` while the rest stay ' +
+          '`--ink-muted`.',
+      },
+    },
+  },
+};
+
+export const CopiedLink: Story = {
+  name: 'Copy link -> Copied',
+  play: async ({ canvasElement }) => {
+    await userEvent.click(within(canvasElement).getByRole('button', { name: 'Play guide' }));
+    const dialog = openDialog() as HTMLElement;
+
+    /* The chip only relabels if the clipboard write RESOLVES, and a real
+       clipboard in an iframe may reject on permissions - which `copyToClipboard`
+       swallows, leaving the chip unchanged and this story silently pointless.
+       Shadow it with a resolving stub so the state is reached deterministically. */
+    const writeText = fn(async () => undefined);
+    const original = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+    Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true });
+
+    try {
+      await userEvent.click(within(dialog).getByRole('button', { name: 'Copy link' }));
+      await expect(await within(dialog).findByText('Copied')).toBeInTheDocument();
+      // The deep link is built from the guide id, not from the title or the route.
+      await expect(writeText).toHaveBeenCalledWith(
+        `${globalThis.window.location.origin}/guides?guide=guide-checkin-flow`
+      );
+    } finally {
+      if (original) Object.defineProperty(navigator, 'clipboard', original);
+      else Reflect.deleteProperty(navigator, 'clipboard');
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The confirmed-copy state. Note what it is not: there is no toast, no icon swap and no ' +
+          'failure message - the word inside the chip is the entire feedback, and it reverts after ' +
+          '1800ms. It also resets whenever the modal closes or the guide changes, via a ' +
+          'prev-props comparison at render time rather than an effect.',
+      },
+    },
+  },
+};
+
+export const NoChaptersOrNext: Story = {
+  name: 'Last guide, no chapters',
+  args: { guide: { ...GUIDE, chapters: undefined }, nextGuide: null },
+  play: async ({ canvasElement }) => {
+    await userEvent.click(within(canvasElement).getByRole('button', { name: 'Play guide' }));
+    const dialog = openDialog() as HTMLElement;
+
+    // Both footer slots are conditional, so the footer keeps its padding and
+    // renders empty rather than collapsing.
+    await expect(within(dialog).queryByText(/Chapters:/)).toBeNull();
+    await expect(within(dialog).queryByRole('button', { name: /^Next:/ })).toBeNull();
+    // The header is still complete, so the panel does not look broken.
+    await expect(within(dialog).getByRole('button', { name: 'Copy link' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The last guide in a series, with no chapter markers. Both footer children are gated ' +
+          'independently, so this render is a `px-5 pb-4 pt-3.5` band with nothing in it - the ' +
+          'panel gets shorter but keeps a visible gap under the video.',
+      },
+    },
+  },
+};
+
+export const AtStart: Story = {
+  name: 'Not yet played',
+  args: { guide: { ...GUIDE, progressPercent: undefined, currentTime: undefined } },
+  play: async ({ canvasElement }) => {
+    await userEvent.click(within(canvasElement).getByRole('button', { name: 'Play guide' }));
+    const dialog = openDialog() as HTMLElement;
+    const surface = dialog.querySelector('.aspect-video') as HTMLElement;
+
+    // Both fields fall back rather than rendering "undefined": 0% and "0:00".
+    await expect(within(surface).getByText('0:00 / 5:18')).toBeInTheDocument();
+    const fill = surface.querySelector('span[style*="width"]') as HTMLElement;
+    await expect(fill.style.width).toBe('0%');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A guide opened for the first time. The scrubber is clamped into 0-100 and the timecode ' +
+          'defaults to "0:00", so an unwatched guide shows an empty bar rather than a missing one.',
+      },
+    },
+  },
+};
+
+export const NoGuide: Story = {
+  name: 'No guide loaded',
+  args: { guide: null, showModal: true },
+  play: async () => {
+    // The component returns null before ModalBase is reached, so there is no
+    // dialog in the DOM at all - not a dialog holding an empty panel.
+    await expect(document.querySelector('dialog')).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'With `showModal` true but no guide the component renders nothing. Worth pinning down: ' +
+          'the guard sits above `ModalBase`, so the body scroll lock is never acquired either - a ' +
+          'version that rendered the shell first would lock the page behind an invisible dialog.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/overlays/Modal/GuidePlayerModal.stories.tsx
+++ b/apps/frontend/src/app/ui/overlays/Modal/GuidePlayerModal.stories.tsx
@@ -164,7 +164,7 @@ export const CopiedLink: Story = {
 
     try {
       await userEvent.click(within(dialog).getByRole('button', { name: 'Copy link' }));
-      await expect(await within(dialog).findByText('Copied')).toBeInTheDocument();
+      expect(await within(dialog).findByText('Copied')).toBeInTheDocument();
       // The deep link is built from the guide id, not from the title or the route.
       await expect(writeText).toHaveBeenCalledWith(
         `${globalThis.window.location.origin}/guides?guide=guide-checkin-flow`

--- a/apps/frontend/src/app/ui/overlays/Modal/Modal.stories.tsx
+++ b/apps/frontend/src/app/ui/overlays/Modal/Modal.stories.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { expect, fn, userEvent, within } from 'storybook/test';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 
 import Modal from './index';
 
@@ -143,11 +143,12 @@ export const CenteredLarge: Story = {
 export const PhoneSheet: Story = {
   name: 'Phone: centered re-forms to a sheet',
   args: { variant: 'centered', title: 'Confirm changes' },
+  // Pinned as a GLOBAL, not a parameter. `parameters.viewport.defaultViewport` was
+  // removed in Storybook 10: it still type-checks, still renders, still plays, and
+  // silently does nothing - this story drew the 1200px desktop markup under a name
+  // that promised a phone. `mobile` is the 375px preset in .storybook/preview.ts.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
   parameters: {
-    // `mobile` is the 375px preset declared in .storybook/preview.ts; the project
-    // default is `laptop`, so without this the story renders the desktop markup and
-    // demonstrates nothing.
-    viewport: { defaultViewport: 'mobile' },
     docs: {
       description: {
         story:
@@ -162,7 +163,7 @@ export const PhoneSheet: Story = {
 export const PhoneFullScreen: Story = {
   name: 'Phone: drawer goes full-screen',
   args: { variant: 'drawer', title: 'Record detail' },
-  parameters: { viewport: { defaultViewport: 'mobile' } },
+  globals: { viewport: { value: 'mobile', isRotated: false } },
 };
 
 export const OpensFromTrigger: Story = {
@@ -170,9 +171,23 @@ export const OpensFromTrigger: Story = {
   render: () => <Triggered variant="centered" />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(canvas.queryByText('Opened from a trigger')).not.toBeInTheDocument();
+    /* `ModalBase` portals to `document.body`, so nothing the panel renders is ever
+       inside `canvasElement`. Querying the canvas here found nothing after the click -
+       and, worse, the "closed at rest" assertion above it passed for the same reason
+       rather than because the panel was closed.
+
+       Closed does not mean unmounted either: the dialog stays in the DOM without its
+       `open` attribute, so absence has to be asserted against `dialog[open]`. */
+    const dialog = () => document.querySelector('dialog[open]');
+    await expect(dialog()).toBeNull();
+    await expect(document.body.textContent).toContain('Opened from a trigger');
+
     await userEvent.click(canvas.getByRole('button', { name: 'Open panel' }));
-    await expect(await canvas.findByText('Opened from a trigger')).toBeInTheDocument();
+
+    await waitFor(() => expect(dialog()).not.toBeNull());
+    await expect(
+      within(dialog() as HTMLElement).getByText('Opened from a trigger')
+    ).toBeInTheDocument();
   },
   parameters: {
     docs: {

--- a/apps/frontend/src/app/ui/overlays/Modal/VideoPlayerModal.stories.tsx
+++ b/apps/frontend/src/app/ui/overlays/Modal/VideoPlayerModal.stories.tsx
@@ -1,0 +1,237 @@
+import { useState, type ComponentProps } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import VideoPlayerModal from './VideoPlayerModal';
+
+/**
+ * An inline SVG poster and a deliberately undecodable video source, so the story
+ * makes no network request and the "still loading" branch is stable: `onLoadedData`
+ * can never fire, which is the state the poster overlay exists for.
+ */
+const POSTER = `data:image/svg+xml;utf8,${encodeURIComponent(
+  '<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540">' +
+    '<rect width="960" height="540" fill="#1d2b3a"/>' +
+    '<circle cx="480" cy="270" r="64" fill="#ffffff" opacity="0.9"/>' +
+    '<polygon points="460,238 460,302 516,270" fill="#1d2b3a"/>' +
+    '</svg>'
+)}`;
+
+const UNDECODABLE_MP4 = 'data:video/mp4;base64,AAAAAA==';
+
+const VIDEO = {
+  title: 'Run a visit end to end',
+  videoUrl: UNDECODABLE_MP4,
+  thumbnailUrl: POSTER,
+};
+
+type ModalProps = ComponentProps<typeof VideoPlayerModal>;
+
+type HarnessProps = Omit<
+  ModalProps,
+  'showModal' | 'setShowModal' | 'isVideoLoaded' | 'setIsVideoLoaded'
+> & {
+  /** Start the dialog with the poster overlay already dismissed. */
+  videoLoaded?: boolean;
+};
+
+/**
+ * `showModal` and `isVideoLoaded` live in the card that opens this dialog, so
+ * without a holder the modal can only ever be rendered inert. A trigger keeps
+ * the docs page from stacking several open dialogs on top of each other.
+ */
+const VideoPlayerModalHarness = ({ activeVideo, videoLoaded = false }: HarnessProps) => {
+  const [showModal, setShowModal] = useState(false);
+  const [isVideoLoaded, setIsVideoLoaded] = useState(videoLoaded);
+
+  return (
+    <div className="flex min-h-[160px] items-center justify-center">
+      <button
+        type="button"
+        className="rounded-2xl bg-text-primary px-6 py-3 text-body-3-emphasis text-[var(--screen)]"
+        onClick={() => {
+          setIsVideoLoaded(videoLoaded);
+          setShowModal(true);
+        }}
+      >
+        Play video
+      </button>
+      <VideoPlayerModal
+        showModal={showModal}
+        setShowModal={setShowModal}
+        activeVideo={activeVideo}
+        isVideoLoaded={isVideoLoaded}
+        setIsVideoLoaded={setIsVideoLoaded}
+      />
+    </div>
+  );
+};
+
+/**
+ * Matched on the `open` attribute rather than on `role`: `ModalBase` leaves the
+ * closed dialog mounted in the portal, so "is there a dialog" is always true and
+ * only `open` distinguishes the two states.
+ */
+const openDialog = () => document.querySelector('dialog[open]') as HTMLElement | null;
+
+const findOpenDialog = async (): Promise<HTMLElement> => {
+  await waitFor(() => expect(openDialog()).toBeInTheDocument());
+  return openDialog() as HTMLElement;
+};
+
+const meta = {
+  title: 'Overlays/VideoPlayerModal',
+  component: VideoPlayerModalHarness,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'The shared guide-video dialog, opened from the dashboard videos strip and from the ' +
+          'Guides screen. A `CenterModal` widened to `sm:w-[720px] md:w-[860px] lg:w-[980px] ' +
+          'max-w-[95vw]`, holding a centred title row with an absolutely-positioned Close on the ' +
+          'right, and a `rounded-2xl border-card-border overflow-hidden` video frame.\n\n' +
+          'None of that had ever been drawn. `ModalBase` portals the dialog to `document.body` ' +
+          'and leaves it `inert` with `opacity-0 pointer-events-none` until `showModal` flips, and ' +
+          '`showModal` plus a non-null `activeVideo` both live in the parent - so the closed ' +
+          'component contributes an invisible, unstyled node and nothing else.\n\n' +
+          'The state most worth seeing is the one nobody screenshots: the **unloaded poster**. ' +
+          'The thumbnail is painted twice by two different mechanisms - the `<video poster>` ' +
+          'attribute, which the browser drops as soon as it has a frame, and an ' +
+          '`absolute inset-0 bg-cover` overlay gated on `isVideoLoaded === false`, which only ' +
+          'goes away when `onLoadedData` fires. Every viewer sees the second one first, and it is ' +
+          'the layer that has to line up with the frame’s `rounded-2xl` clip. If the video never ' +
+          'loads - offline, a dead URL - it is also the *only* thing they ever see.\n\n' +
+          'There is a third rendering behind `activeVideo === null`: the title falls back to the ' +
+          'literal string "Video" and the frame becomes a bare `aspect-video bg-black/80` block ' +
+          'with no `<video>` element at all. All three are drawn below.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    activeVideo: VIDEO,
+  },
+} satisfies Meta<typeof VideoPlayerModalHarness>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const PosterOverlay: Story = {
+  name: 'Open, poster still covering the video',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Play video' }));
+
+    // The dialog portals to document.body, outside the story canvas.
+    const dialog = await findOpenDialog();
+    await expect(within(dialog).getByText('Run a visit end to end')).toBeInTheDocument();
+    await expect(within(dialog).getByRole('button', { name: 'Close' })).toBeInTheDocument();
+
+    // Assert the frame really holds both layers, rather than that a flag flipped.
+    const video = dialog.querySelector('video') as HTMLVideoElement;
+    await expect(video).toBeInTheDocument();
+    await expect(video).toHaveAttribute('poster', POSTER);
+    const frame = video.parentElement as HTMLElement;
+    await expect(frame.children).toHaveLength(2);
+    const overlay = frame.lastElementChild as HTMLElement;
+    await expect(overlay).toHaveAttribute('aria-hidden', 'true');
+    await expect(overlay.style.backgroundImage).toContain('data:image/svg+xml');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'What every viewer sees on open: the overlay sitting on top of the `<video>`, inside ' +
+          'the same `overflow-hidden` rounded frame. The player controls are underneath it and ' +
+          'unreachable until the first frame decodes - so if the source 404s this is a still ' +
+          'image with no visible affordance and no error, which is precisely why it wants a story.',
+      },
+    },
+  },
+};
+
+export const Loaded: Story = {
+  name: 'Open, video loaded',
+  args: { videoLoaded: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Play video' }));
+
+    const dialog = await findOpenDialog();
+    const video = dialog.querySelector('video') as HTMLVideoElement;
+    const frame = video.parentElement as HTMLElement;
+    // The overlay is unmounted, not faded: the frame is down to the video alone.
+    await expect(frame.children).toHaveLength(1);
+    await expect(video).toHaveAttribute('controls');
+    // The video keeps its own accessible name and a captions track.
+    await expect(video).toHaveAttribute('aria-label', 'Run a visit end to end');
+    await expect(video.querySelector('track')).toHaveAttribute('kind', 'captions');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'After `onLoadedData`. The native controls become reachable and the frame is one layer ' +
+          'deep. Worth seeing beside the poster state: the two differ only in a child that ' +
+          'covers the whole frame, so a mis-ordered or mis-sized overlay is invisible in either ' +
+          'one alone.',
+      },
+    },
+  },
+};
+
+export const NoActiveVideo: Story = {
+  name: 'Open with no video selected',
+  args: { activeVideo: null },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Play video' }));
+
+    const dialog = await findOpenDialog();
+    // Fallback title, no <video>, and the placeholder block instead of the frame's contents.
+    await expect(within(dialog).getByText('Video')).toBeInTheDocument();
+    await expect(dialog.querySelector('video')).not.toBeInTheDocument();
+    await expect(dialog.querySelector('.aspect-video')).toBeInTheDocument();
+    // Close is still the only control, so the dialog is never a dead end.
+    await expect(within(dialog).getByRole('button', { name: 'Close' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The guard branch. With `activeVideo` null the dialog still opens at its full ' +
+          '720/860/980px width and shows a black `aspect-video` panel under the word "Video" - a ' +
+          'state reachable in production if `showModal` is set before the selection is, and one ' +
+          'no snapshot has contained.',
+      },
+    },
+  },
+};
+
+export const Closed: Story = {
+  name: 'Closed (inert node)',
+  play: async () => {
+    // Nothing to click: this documents that the closed component is not "absent"
+    // but a portalled, inert, transparent dialog already in document.body.
+    await expect(openDialog()).toBeNull();
+    const dialog = document.querySelector('dialog.yc-modal-dialog');
+    await expect(dialog).toBeInTheDocument();
+    await expect(dialog).toHaveAttribute('inert');
+    await expect(dialog).toHaveClass('pointer-events-none');
+    // The <video> and its preload="metadata" request are already in the DOM.
+    await expect(dialog?.querySelector('video')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting state. `ModalBase` always portals the `<dialog>`, marking it `inert` and ' +
+          'giving the container `opacity-0 pointer-events-none` rather than unmounting it - so the ' +
+          'video element and its `preload="metadata"` request exist before anyone opens anything, ' +
+          'which is what the last assertion checks. The `<dialog>` also carries no `open` ' +
+          'attribute and no `aria-modal`, so nothing behind it is trapped.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/overlays/Sheet/SheetChrome.stories.tsx
+++ b/apps/frontend/src/app/ui/overlays/Sheet/SheetChrome.stories.tsx
@@ -19,9 +19,9 @@ import SheetChrome from './SheetChrome';
 const meta = {
   title: 'Overlays/SheetChrome',
   component: SheetChrome,
+  globals: { viewport: { value: 'mobile', isRotated: false } },
   parameters: {
     layout: 'fullscreen',
-    viewport: { defaultViewport: 'mobile' },
     docs: {
       description: {
         component:

--- a/apps/frontend/src/app/ui/primitives/Accordion/EditableAccordion.stories.tsx
+++ b/apps/frontend/src/app/ui/primitives/Accordion/EditableAccordion.stories.tsx
@@ -149,7 +149,7 @@ export const SaveFailed: Story = {
   play: async ({ canvasElement }) => {
     const canvas = await startEditing(canvasElement);
     await userEvent.click(await canvas.findByRole('button', { name: 'Save' }));
-    await expect(
+    expect(
       await canvas.findByText('Failed to save changes. Please try again.')
     ).toBeInTheDocument();
   },

--- a/apps/frontend/src/app/ui/primitives/Accordion/EditableAccordion.stories.tsx
+++ b/apps/frontend/src/app/ui/primitives/Accordion/EditableAccordion.stories.tsx
@@ -105,7 +105,7 @@ export const CompactActions: Story = {
   args: { compactInlineActions: true },
   play: async ({ canvasElement }) => {
     const canvas = await startEditing(canvasElement);
-    await expect(await canvas.findByRole('button', { name: 'Save' })).toBeInTheDocument();
+    expect(await canvas.findByRole('button', { name: 'Save' })).toBeInTheDocument();
   },
   parameters: {
     docs: {
@@ -128,7 +128,7 @@ export const Saving: Story = {
   play: async ({ canvasElement }) => {
     const canvas = await startEditing(canvasElement);
     await userEvent.click(await canvas.findByRole('button', { name: 'Save' }));
-    await expect(await canvas.findByRole('button', { name: 'Saving...' })).toBeInTheDocument();
+    expect(await canvas.findByRole('button', { name: 'Saving...' })).toBeInTheDocument();
   },
   parameters: {
     docs: {

--- a/apps/frontend/src/app/ui/primitives/Accordion/SmallAccordionButton.stories.tsx
+++ b/apps/frontend/src/app/ui/primitives/Accordion/SmallAccordionButton.stories.tsx
@@ -64,7 +64,7 @@ export const Open: Story = {
     await expect(canvas.queryByText('Microchip')).not.toBeInTheDocument();
     await userEvent.click(canvas.getByRole('button', { name: /companion details/i }));
     // Assert the body actually rendered its children, not just that state flipped.
-    await expect(await canvas.findByText('Microchip')).toBeInTheDocument();
+    expect(await canvas.findByText('Microchip')).toBeInTheDocument();
   },
   parameters: {
     docs: {

--- a/apps/frontend/src/app/ui/primitives/GlassTooltip/GlassTooltip.stories.tsx
+++ b/apps/frontend/src/app/ui/primitives/GlassTooltip/GlassTooltip.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { expect, userEvent, within } from 'storybook/test';
+import { expect, within } from 'storybook/test';
+
+import { openGlassTooltip } from './storyInteractions';
 import GlassTooltip from './GlassTooltip';
 
 const meta = {
@@ -48,11 +50,18 @@ const TriggerButton = ({ children }: { children: React.ReactNode }) => (
   </button>
 );
 
-/** Hovers the trigger and asserts the portalled bubble actually rendered its content. */
+/**
+ * Opens the bubble and asserts it actually rendered its content.
+ *
+ * `openGlassTooltip` rather than `userEvent.hover`: the listeners are bound in an effect
+ * that has not always flushed when a play function starts, so a single hover can be
+ * delivered to an element that is not listening yet and is then lost for good.
+ */
 const openOnHover = async (canvasElement: HTMLElement, expected: string) => {
   const canvas = within(canvasElement);
-  await userEvent.hover(canvas.getByRole('button', { name: /hover me|top|right|bottom|left/i }));
-  const bubble = await within(document.body).findByRole('tooltip');
+  const bubble = await openGlassTooltip(
+    canvas.getByRole('button', { name: /hover me|top|right|bottom|left/i })
+  );
   await expect(bubble).toHaveTextContent(expected);
 };
 
@@ -107,9 +116,10 @@ export const KeyboardFocus: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     // focusin, not hover - the path a keyboard user takes, and the one most likely to
-    // rot unnoticed because every manual check is done with a mouse.
-    canvas.getByRole('button').focus();
-    const bubble = await within(document.body).findByRole('tooltip');
+    // rot unnoticed because every manual check is done with a mouse. `.focus()` is not
+    // used to reach it: focus events only fire when the page itself has focus, which no
+    // automated run can guarantee, so the event is dispatched at the wrapper directly.
+    const bubble = await openGlassTooltip(canvas.getByRole('button'), { via: 'focus' });
     await expect(bubble).toHaveTextContent('Reachable without a mouse');
   },
 };

--- a/apps/frontend/src/app/ui/primitives/GlassTooltip/storyInteractions.ts
+++ b/apps/frontend/src/app/ui/primitives/GlassTooltip/storyInteractions.ts
@@ -18,9 +18,20 @@
  * pointer-enter path across ancestors, which the probe confirmed - but a raw
  * `dispatchEvent` does not, because `mouseenter` never bubbles. Hence the wrapper, not
  * the control inside it, is the target here.
+ *
+ * Bubbles are matched by IDENTITY, not by presence. Every bubble portals to
+ * `document.body` with nothing tying it to its trigger, so "is a tooltip open?" cannot
+ * answer "did THIS one open?" - and a stale bubble left by an earlier interaction would
+ * satisfy a presence check instantly, returning success without ever opening the
+ * trigger under test. That is the same class of silent pass this helper exists to
+ * remove, so `open` waits for a node that was NOT there when it started, and `close`
+ * waits for the node it actually opened to leave the document.
  */
 const TIMEOUT_MS = 2000;
 const STEP_MS = 25;
+
+/** Wrapper -> the bubble `openGlassTooltip` saw it open, so `close` can wait for that one. */
+const openedBubbles = new WeakMap<HTMLElement, HTMLElement>();
 
 const wait = (ms: number) =>
   new Promise((resolve) => {
@@ -55,40 +66,54 @@ export const openGlassTooltip = async (
       ? new MouseEvent('mouseenter', { bubbles: false })
       : new FocusEvent('focusin', { bubbles: true });
 
+  // Anything already open belongs to someone else and can never count as success.
+  const stale = new Set(bubbles());
   const deadline = Date.now() + TIMEOUT_MS;
   let attempts = 0;
   for (;;) {
     wrapper.dispatchEvent(event());
     attempts += 1;
     await wait(STEP_MS);
-    // The last one: a neighbouring story can leave a stale bubble on document.body,
-    // and the one this dispatch opened is the most recent.
-    const opened = bubbles().at(-1);
-    if (opened) return opened;
+    const opened = bubbles().find((bubble) => !stale.has(bubble));
+    if (opened) {
+      openedBubbles.set(wrapper, opened);
+      return opened;
+    }
     if (Date.now() > deadline) {
       throw new Error(
-        `No tooltip opened after ${attempts} ${via} dispatch(es) over ${TIMEOUT_MS}ms. ` +
-          'The trigger has a .glass-tooltip wrapper but nothing listened to it.'
+        `No tooltip opened after ${attempts} ${via} dispatch(es) over ${TIMEOUT_MS}ms` +
+          (stale.size > 0
+            ? `. ${stale.size} unrelated bubble(s) were already open - close them first, ` +
+              'since a leftover bubble cannot stand in for this trigger.'
+            : '. The trigger has a .glass-tooltip wrapper but nothing listened to it.')
       );
     }
   }
 };
 
 /**
- * Closes it again and resolves once no bubble remains.
+ * Closes the bubble this trigger opened, and resolves once it has left the document.
  *
- * Worth doing explicitly in any story that opens more than one: the bubble is portalled
- * to `document.body`, so a stale one is outside `canvasElement` and a later
- * `getAllByRole('tooltip')` count silently includes it.
+ * Worth doing explicitly in any story that opens more than one: a dispatched
+ * `mouseenter` on the next control emits no `mouseleave` on the last, so bubbles
+ * accumulate on `document.body` - outside `canvasElement`, where a later
+ * `getAllByRole('tooltip')` count silently includes them.
  */
 export const closeGlassTooltip = async (trigger: HTMLElement): Promise<void> => {
   const wrapper = glassTooltipWrapper(trigger);
+  // Waiting on "no bubbles at all" would hang on someone else's; wait on ours.
+  const target = openedBubbles.get(wrapper);
+  const gone = () => (target ? !document.contains(target) : bubbles().length === 0);
+
   const deadline = Date.now() + TIMEOUT_MS;
   for (;;) {
     wrapper.dispatchEvent(new MouseEvent('mouseleave', { bubbles: false }));
     wrapper.dispatchEvent(new FocusEvent('focusout', { bubbles: true }));
     await wait(STEP_MS);
-    if (bubbles().length === 0) return;
+    if (gone()) {
+      openedBubbles.delete(wrapper);
+      return;
+    }
     if (Date.now() > deadline) {
       throw new Error(`A tooltip was still open ${TIMEOUT_MS}ms after leaving the trigger.`);
     }

--- a/apps/frontend/src/app/ui/primitives/GlassTooltip/storyInteractions.ts
+++ b/apps/frontend/src/app/ui/primitives/GlassTooltip/storyInteractions.ts
@@ -61,8 +61,10 @@ export const openGlassTooltip = async (
     wrapper.dispatchEvent(event());
     attempts += 1;
     await wait(STEP_MS);
-    const open = bubbles();
-    if (open.length > 0) return open[open.length - 1];
+    // The last one: a neighbouring story can leave a stale bubble on document.body,
+    // and the one this dispatch opened is the most recent.
+    const opened = bubbles().at(-1);
+    if (opened) return opened;
     if (Date.now() > deadline) {
       throw new Error(
         `No tooltip opened after ${attempts} ${via} dispatch(es) over ${TIMEOUT_MS}ms. ` +

--- a/apps/frontend/src/app/ui/primitives/GlassTooltip/storyInteractions.ts
+++ b/apps/frontend/src/app/ui/primitives/GlassTooltip/storyInteractions.ts
@@ -1,0 +1,94 @@
+/**
+ * Opening a `GlassTooltip` from a Storybook play function, reliably.
+ *
+ * The component binds `mouseenter` / `focusin` natively, inside an effect, to its own
+ * wrapper span. Storybook starts a play function before that effect has flushed, so a
+ * single dispatch at the start of a play lands on an element that has no listener yet
+ * and does nothing at all. Measured in a probe story: the events reached the wrapper,
+ * the tooltip never opened, and it was still closed 350ms later. The same hover after a
+ * 100ms wait opened it; a redispatch loop needed three attempts.
+ *
+ * That is how a tooltip story stays green while proving nothing - the bubble is queried
+ * with `findByRole`, which retries the QUERY but never re-sends the event, so a missed
+ * dispatch is permanent. Every one of the 38 tooltip stories in this Storybook failed
+ * this way, undetected, because no CI job executes play functions.
+ *
+ * Plain DOM events rather than `userEvent`: the dispatch has to be re-sendable and
+ * synchronous inside the poll. `userEvent.hover` does reach the wrapper - it walks the
+ * pointer-enter path across ancestors, which the probe confirmed - but a raw
+ * `dispatchEvent` does not, because `mouseenter` never bubbles. Hence the wrapper, not
+ * the control inside it, is the target here.
+ */
+const TIMEOUT_MS = 2000;
+const STEP_MS = 25;
+
+const wait = (ms: number) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+/** The span carrying the listeners, given either it or anything inside it. */
+export const glassTooltipWrapper = (el: HTMLElement): HTMLElement => {
+  const wrapper = el.closest('.glass-tooltip');
+  if (!wrapper) {
+    throw new Error(
+      `No .glass-tooltip ancestor for <${el.tagName.toLowerCase()}>. The control is not ` +
+        'wrapped in a GlassTooltip, so no bubble can open.'
+    );
+  }
+  return wrapper as HTMLElement;
+};
+
+const bubbles = () => [...document.querySelectorAll('[role="tooltip"]')] as HTMLElement[];
+
+/**
+ * Opens the bubble for `trigger` and resolves with it. Pass the control or the wrapper;
+ * either works.
+ */
+export const openGlassTooltip = async (
+  trigger: HTMLElement,
+  { via = 'hover' }: { via?: 'hover' | 'focus' } = {}
+): Promise<HTMLElement> => {
+  const wrapper = glassTooltipWrapper(trigger);
+  const event = () =>
+    via === 'hover'
+      ? new MouseEvent('mouseenter', { bubbles: false })
+      : new FocusEvent('focusin', { bubbles: true });
+
+  const deadline = Date.now() + TIMEOUT_MS;
+  let attempts = 0;
+  for (;;) {
+    wrapper.dispatchEvent(event());
+    attempts += 1;
+    await wait(STEP_MS);
+    const open = bubbles();
+    if (open.length > 0) return open[open.length - 1];
+    if (Date.now() > deadline) {
+      throw new Error(
+        `No tooltip opened after ${attempts} ${via} dispatch(es) over ${TIMEOUT_MS}ms. ` +
+          'The trigger has a .glass-tooltip wrapper but nothing listened to it.'
+      );
+    }
+  }
+};
+
+/**
+ * Closes it again and resolves once no bubble remains.
+ *
+ * Worth doing explicitly in any story that opens more than one: the bubble is portalled
+ * to `document.body`, so a stale one is outside `canvasElement` and a later
+ * `getAllByRole('tooltip')` count silently includes it.
+ */
+export const closeGlassTooltip = async (trigger: HTMLElement): Promise<void> => {
+  const wrapper = glassTooltipWrapper(trigger);
+  const deadline = Date.now() + TIMEOUT_MS;
+  for (;;) {
+    wrapper.dispatchEvent(new MouseEvent('mouseleave', { bubbles: false }));
+    wrapper.dispatchEvent(new FocusEvent('focusout', { bubbles: true }));
+    await wait(STEP_MS);
+    if (bubbles().length === 0) return;
+    if (Date.now() > deadline) {
+      throw new Error(`A tooltip was still open ${TIMEOUT_MS}ms after leaving the trigger.`);
+    }
+  }
+};

--- a/apps/frontend/src/app/ui/primitives/RichTextEditor/RichTextEditor.stories.tsx
+++ b/apps/frontend/src/app/ui/primitives/RichTextEditor/RichTextEditor.stories.tsx
@@ -76,7 +76,7 @@ export const FocusedWithContent: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await userEvent.click(await canvas.findByRole('textbox'));
-    await expect(await canvas.findByRole('toolbar')).toBeVisible();
+    expect(await canvas.findByRole('toolbar')).toBeVisible();
   },
   parameters: {
     docs: {

--- a/apps/frontend/src/app/ui/tables/DispensaryTable.stories.tsx
+++ b/apps/frontend/src/app/ui/tables/DispensaryTable.stories.tsx
@@ -1,5 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+
+import {
+  closeGlassTooltip,
+  openGlassTooltip,
+} from '@/app/ui/primitives/GlassTooltip/storyInteractions';
 import DispensaryTable from './DispensaryTable';
 import type { DispensaryRecord } from '@/app/features/inventory/pages/Inventory/types';
 
@@ -105,9 +110,7 @@ export const RowActionTooltip: Story = {
     const trigger = viewButton(canvasElement, 'Poppy');
     await expect(tooltips()).toHaveLength(0);
 
-    await userEvent.hover(trigger);
-
-    const bubble = await within(document.body).findByRole('tooltip');
+    const bubble = await openGlassTooltip(trigger);
     // Assert the bubble has its label, not merely that something mounted.
     await expect(bubble).toHaveTextContent('View details');
     await expect(canvasElement.contains(bubble)).toBe(false);
@@ -143,18 +146,13 @@ export const TooltipDoesNotAccumulate: Story = {
     const first = viewButton(canvasElement, 'Poppy');
     const second = viewButton(canvasElement, 'Biscuit');
 
-    await userEvent.hover(first);
-    await expect(await within(document.body).findByRole('tooltip')).toHaveTextContent(
-      'View details'
-    );
+    await expect(await openGlassTooltip(first)).toHaveTextContent('View details');
 
     // Each row owns its own portal, so leaving one must tear its bubble down.
-    await userEvent.unhover(first);
-    await waitFor(() => {
-      expect(tooltips()).toHaveLength(0);
-    });
+    await closeGlassTooltip(first);
+    await expect(tooltips()).toHaveLength(0);
 
-    await userEvent.hover(second);
+    await openGlassTooltip(second);
     await waitFor(() => {
       expect(tooltips()).toHaveLength(1);
     });
@@ -176,16 +174,19 @@ export const TooltipOnKeyboardFocus: Story = {
   name: 'Row action tooltip (keyboard focus)',
   play: async ({ canvasElement }) => {
     const trigger = viewButton(canvasElement, 'Bruno');
-    trigger.focus();
 
-    // `focusin` bubbles to the wrapper span, so the tooltip is not hover-only.
-    const bubble = await within(document.body).findByRole('tooltip');
+    /* The focus path is a separate listener from hover, and the one that matters most
+       for an unlabelled icon button. It is driven by dispatching at the wrapper rather
+       than by `.focus()`: focus events only fire when the page itself has focus, which
+       an automated run cannot guarantee. */
+    const bubble = await openGlassTooltip(trigger, { via: 'focus' });
     await expect(bubble).toHaveTextContent('View details');
 
-    trigger.blur();
-    await waitFor(() => {
-      expect(tooltips()).toHaveLength(0);
-    });
+    /* `blur()` cannot close this one: the bubble was opened by dispatching `focusin` at
+       the wrapper, and the element never actually held focus, so blurring it fires
+       nothing. The matching `focusout` has to be dispatched the same way. */
+    await closeGlassTooltip(trigger);
+    await expect(tooltips()).toHaveLength(0);
   },
   parameters: {
     docs: {
@@ -210,9 +211,9 @@ export const RowActionsFire: Story = {
     await userEvent.click(dispense[0]);
     await expect(args.onDispense).toHaveBeenCalledWith(ROWS[0]);
 
-    // The tooltip is pointer-events:none, so hovering first cannot swallow the click.
+    // The tooltip is pointer-events:none, so opening it first cannot swallow the click.
     const view = viewButton(canvasElement, 'Poppy');
-    await userEvent.hover(view);
+    await openGlassTooltip(view);
     await userEvent.click(view);
     await expect(args.onView).toHaveBeenCalledWith(ROWS[0]);
   },

--- a/apps/frontend/src/app/ui/tables/DispensaryTable.stories.tsx
+++ b/apps/frontend/src/app/ui/tables/DispensaryTable.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 import DispensaryTable from './DispensaryTable';
 import type { DispensaryRecord } from '@/app/features/inventory/pages/Inventory/types';
 
@@ -41,6 +42,11 @@ const ROWS: DispensaryRecord[] = [
   }),
 ];
 
+const viewButton = (canvasElement: HTMLElement, patient: string) =>
+  within(canvasElement).getByRole('button', { name: `View prescription for ${patient}` });
+
+const tooltips = () => within(document.body).queryAllByRole('tooltip');
+
 const meta = {
   title: 'Tables/DispensaryTable',
   component: DispensaryTable,
@@ -51,9 +57,28 @@ const meta = {
         component:
           'Dispensary request queue rendered through the shared PaginatedGridTable shell. ' +
           'Status badges follow the design micro-badge (fully round, padding 3px 9px, 9.5px / 700, ' +
-          'no tracking). Swaps to wrapped cards at <=1023px.',
+          'no tracking). Swaps to wrapped cards at <=1023px.\n\n' +
+          'The row action at the end of each line is wrapped in a `GlassTooltip`, and that bubble is ' +
+          'the surface this file was extended for. It is `createPortal`ed to `document.body` at a ' +
+          '`position: fixed` rect measured from the trigger on `mouseenter`/`focusin`, so it does ' +
+          'not exist in any static render: the icon button is a 30px circle with no text, and the ' +
+          'tooltip is the only thing that ever says what it does.\n\n' +
+          'Three properties of it are only checkable with it up. The bubble is positioned by script ' +
+          '(`side="top"` puts it at `rect.top - 10` with a `translate(-50%,-100%)`), so a dropped ' +
+          'measurement pins it to the top-left of the viewport while still reading as a healthy ' +
+          'tooltip. It is `pointer-events: none`, so it can never eat the click on the button it ' +
+          'describes. And the listeners are added imperatively on the wrapper span with a matching ' +
+          '`mouseleave`/`focusout` teardown - a leak there leaves one bubble per row hovered, all ' +
+          'stacked over the table, which is why these stories assert **exactly one** bubble exists ' +
+          'after moving between two rows rather than merely that one appeared.',
       },
     },
+  },
+  tags: ['autodocs'],
+  args: {
+    filteredList: ROWS,
+    onView: fn(),
+    onDispense: fn(),
   },
   decorators: [
     (Story) => (
@@ -67,15 +92,138 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-  args: {
-    filteredList: ROWS,
-    onView: () => {},
-    onDispense: () => {},
-  },
-};
+export const Default: Story = {};
 
 export const EmptyState: Story = {
   name: 'Empty state',
-  args: { filteredList: [], onView: () => {} },
+  args: { filteredList: [] },
+};
+
+export const RowActionTooltip: Story = {
+  name: 'Row action tooltip (hover)',
+  play: async ({ canvasElement }) => {
+    const trigger = viewButton(canvasElement, 'Poppy');
+    await expect(tooltips()).toHaveLength(0);
+
+    await userEvent.hover(trigger);
+
+    const bubble = await within(document.body).findByRole('tooltip');
+    // Assert the bubble has its label, not merely that something mounted.
+    await expect(bubble).toHaveTextContent('View details');
+    await expect(canvasElement.contains(bubble)).toBe(false);
+    await expect(getComputedStyle(bubble).position).toBe('fixed');
+    // It must never intercept the click on the button it describes.
+    await expect(getComputedStyle(bubble).pointerEvents).toBe('none');
+
+    /* The 10px gap above the trigger is computed in an effect, so the first
+       paint sits at 0,0. Waiting for the measured position is what distinguishes
+       a positioned tooltip from one stranded in the corner of the viewport. */
+    await waitFor(async () => {
+      const gap = trigger.getBoundingClientRect().top - bubble.getBoundingClientRect().bottom;
+      await expect(gap).toBeGreaterThan(0);
+      await expect(gap).toBeLessThanOrEqual(12);
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The only state in which the 30px eye button carries a name. `side="top"` sits it ten ' +
+          'pixels clear of the trigger and centres it with a `-50%` X translate, clamped to eight ' +
+          'pixels of viewport padding - so on the rightmost column it slides inward rather than ' +
+          'overflowing.',
+      },
+    },
+  },
+};
+
+export const TooltipDoesNotAccumulate: Story = {
+  name: 'Moving between rows keeps one bubble',
+  play: async ({ canvasElement }) => {
+    const first = viewButton(canvasElement, 'Poppy');
+    const second = viewButton(canvasElement, 'Biscuit');
+
+    await userEvent.hover(first);
+    await expect(await within(document.body).findByRole('tooltip')).toHaveTextContent(
+      'View details'
+    );
+
+    // Each row owns its own portal, so leaving one must tear its bubble down.
+    await userEvent.unhover(first);
+    await waitFor(async () => {
+      await expect(tooltips()).toHaveLength(0);
+    });
+
+    await userEvent.hover(second);
+    await waitFor(async () => {
+      await expect(tooltips()).toHaveLength(1);
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Every row wraps its action in its own `GlassTooltip`, each with its own imperative ' +
+          '`mouseenter`/`mouseleave` pair. Dragging down a ten-row page is therefore ten open/close ' +
+          'cycles, and a missing teardown shows up not as a broken tooltip but as a pile of them ' +
+          'over the table. One bubble at a time is the property worth pinning.',
+      },
+    },
+  },
+};
+
+export const TooltipOnKeyboardFocus: Story = {
+  name: 'Row action tooltip (keyboard focus)',
+  play: async ({ canvasElement }) => {
+    const trigger = viewButton(canvasElement, 'Bruno');
+    trigger.focus();
+
+    // `focusin` bubbles to the wrapper span, so the tooltip is not hover-only.
+    const bubble = await within(document.body).findByRole('tooltip');
+    await expect(bubble).toHaveTextContent('View details');
+
+    trigger.blur();
+    await waitFor(async () => {
+      await expect(tooltips()).toHaveLength(0);
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same bubble reached without a pointer. It matters because the icon button has no ' +
+          'visible label: a tooltip bound to `mouseenter` alone would leave a keyboard user with an ' +
+          'unnamed circle, and the `focusin`/`focusout` pair is what prevents that.',
+      },
+    },
+  },
+};
+
+export const RowActionsFire: Story = {
+  name: 'Row actions',
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Dispense only exists on a PENDING row - the other two statuses are terminal.
+    const dispense = canvas.getAllByRole('button', { name: /^Dispense prescription for / });
+    await expect(dispense).toHaveLength(1);
+
+    await userEvent.click(dispense[0]);
+    await expect(args.onDispense).toHaveBeenCalledWith(ROWS[0]);
+
+    // The tooltip is pointer-events:none, so hovering first cannot swallow the click.
+    const view = viewButton(canvasElement, 'Poppy');
+    await userEvent.hover(view);
+    await userEvent.click(view);
+    await expect(args.onView).toHaveBeenCalledWith(ROWS[0]);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Both row actions, driven through the tooltip rather than around it. The click is fired ' +
+          'while the bubble is up on purpose: the bubble is centred directly over the trigger, so ' +
+          'it would cover it entirely if it ever stopped being click-through.',
+      },
+    },
+  },
 };

--- a/apps/frontend/src/app/ui/tables/DispensaryTable.stories.tsx
+++ b/apps/frontend/src/app/ui/tables/DispensaryTable.stories.tsx
@@ -146,7 +146,7 @@ export const TooltipDoesNotAccumulate: Story = {
     const first = viewButton(canvasElement, 'Poppy');
     const second = viewButton(canvasElement, 'Biscuit');
 
-    await expect(await openGlassTooltip(first)).toHaveTextContent('View details');
+    expect(await openGlassTooltip(first)).toHaveTextContent('View details');
 
     // Each row owns its own portal, so leaving one must tear its bubble down.
     await closeGlassTooltip(first);

--- a/apps/frontend/src/app/ui/tables/DispensaryTable.stories.tsx
+++ b/apps/frontend/src/app/ui/tables/DispensaryTable.stories.tsx
@@ -118,10 +118,10 @@ export const RowActionTooltip: Story = {
     /* The 10px gap above the trigger is computed in an effect, so the first
        paint sits at 0,0. Waiting for the measured position is what distinguishes
        a positioned tooltip from one stranded in the corner of the viewport. */
-    await waitFor(async () => {
+    await waitFor(() => {
       const gap = trigger.getBoundingClientRect().top - bubble.getBoundingClientRect().bottom;
-      await expect(gap).toBeGreaterThan(0);
-      await expect(gap).toBeLessThanOrEqual(12);
+      expect(gap).toBeGreaterThan(0);
+      expect(gap).toBeLessThanOrEqual(12);
     });
   },
   parameters: {
@@ -150,13 +150,13 @@ export const TooltipDoesNotAccumulate: Story = {
 
     // Each row owns its own portal, so leaving one must tear its bubble down.
     await userEvent.unhover(first);
-    await waitFor(async () => {
-      await expect(tooltips()).toHaveLength(0);
+    await waitFor(() => {
+      expect(tooltips()).toHaveLength(0);
     });
 
     await userEvent.hover(second);
-    await waitFor(async () => {
-      await expect(tooltips()).toHaveLength(1);
+    await waitFor(() => {
+      expect(tooltips()).toHaveLength(1);
     });
   },
   parameters: {
@@ -183,8 +183,8 @@ export const TooltipOnKeyboardFocus: Story = {
     await expect(bubble).toHaveTextContent('View details');
 
     trigger.blur();
-    await waitFor(async () => {
-      await expect(tooltips()).toHaveLength(0);
+    await waitFor(() => {
+      expect(tooltips()).toHaveLength(0);
     });
   },
   parameters: {

--- a/apps/frontend/src/app/ui/tables/InventoryTable.stories.tsx
+++ b/apps/frontend/src/app/ui/tables/InventoryTable.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { expect, fn, userEvent, within } from 'storybook/test';
 
+import { openGlassTooltip } from '@/app/ui/primitives/GlassTooltip/storyInteractions';
+
 import type { InventoryItem } from '@/app/features/inventory/pages/Inventory/types';
 import InventoryTable from './InventoryTable';
 
@@ -89,12 +91,20 @@ const ROWS: InventoryItem[] = [
   }),
 ];
 
-/** Hovers the tooltip's wrapper span, which is the element carrying the listeners. */
+/**
+ * Opens the bubble for a row control.
+ *
+ * The wrapper span carries the listeners, and they are bound in an effect that has not
+ * necessarily flushed when a play function starts - so the dispatch has to be retried
+ * rather than sent once. `findByRole` retries the query, never the event, so a dispatch
+ * that lands before the listener exists is lost for good. All three tooltip stories in
+ * this file threw for exactly that reason, unnoticed, because no CI job runs play
+ * functions - see #2281.
+ */
 const hoverTooltipTrigger = async (control: HTMLElement) => {
   const trigger = control.closest('.glass-tooltip');
   await expect(trigger).toBeInTheDocument();
-  await userEvent.hover(trigger as HTMLElement);
-  return within(document.body).findByRole('tooltip');
+  return openGlassTooltip(trigger as HTMLElement);
 };
 
 const meta = {

--- a/apps/frontend/src/app/ui/widgets/Faq/Faq.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/Faq/Faq.stories.tsx
@@ -133,8 +133,8 @@ export const CollapsesAgain: Story = {
 
 export const Phone: Story = {
   name: 'Phone width',
+  globals: { viewport: { value: 'mobile', isRotated: false } },
   parameters: {
-    viewport: { defaultViewport: 'mobile' },
     docs: {
       description: {
         story:

--- a/apps/frontend/src/app/ui/widgets/Footer/Footer.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/Footer/Footer.stories.tsx
@@ -41,14 +41,6 @@ const withFailingStatusFetch = () => {
   };
 };
 
-const PHONE_VIEWPORT = {
-  phone: {
-    name: 'Mobile (375)',
-    styles: { width: '375px', height: '812px' },
-    type: 'mobile',
-  },
-};
-
 const meta = {
   title: 'Widgets/Footer',
   component: Footer,
@@ -120,9 +112,8 @@ export const StatusUnavailable: Story = {
 
 export const Mobile: Story = {
   name: 'Mobile (375)',
-  globals: { viewport: { value: 'phone', isRotated: false } },
+  globals: { viewport: { value: 'mobile', isRotated: false } },
   parameters: {
-    viewport: { options: PHONE_VIEWPORT },
     chromatic: { viewports: [375] },
     docs: {
       description: {

--- a/apps/frontend/src/app/ui/widgets/LaunchGrowTab/LaunchGrowTab.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/LaunchGrowTab/LaunchGrowTab.stories.tsx
@@ -3,14 +3,6 @@ import { userEvent, within } from 'storybook/test';
 
 import LaunchGrowTab from './LaunchGrowTab';
 
-const PHONE_VIEWPORT = {
-  phone: {
-    name: 'Mobile (375)',
-    styles: { width: '375px', height: '812px' },
-    type: 'mobile',
-  },
-};
-
 const meta = {
   title: 'Widgets/LaunchGrowTab',
   component: LaunchGrowTab,
@@ -58,9 +50,8 @@ export const DocumentationOpen: Story = {
 
 export const Mobile: Story = {
   name: 'Mobile (375)',
-  globals: { viewport: { value: 'phone', isRotated: false } },
+  globals: { viewport: { value: 'mobile', isRotated: false } },
   parameters: {
-    viewport: { options: PHONE_VIEWPORT },
     chromatic: { viewports: [375] },
     docs: {
       description: {

--- a/apps/frontend/src/app/ui/widgets/Summary/Availability.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/Summary/Availability.stories.tsx
@@ -134,8 +134,8 @@ export const Empty: Story = {
 
 export const Phone: Story = {
   name: 'Phone width',
+  globals: { viewport: { value: 'mobile', isRotated: false } },
   parameters: {
-    viewport: { defaultViewport: 'mobile' },
     docs: {
       description: {
         story:
@@ -174,8 +174,8 @@ const DRAWER_SECTIONS = [
 
 export const TeamDetail: Story = {
   name: 'Team member drawer (open)',
+  globals: { viewport: { value: 'desktop', isRotated: false } },
   parameters: {
-    viewport: { defaultViewport: 'desktop' },
     docs: {
       description: {
         story:
@@ -203,8 +203,8 @@ export const TeamDetail: Story = {
 
 export const TeamDetailPhone: Story = {
   name: 'Team member drawer (phone, full-screen)',
+  globals: { viewport: { value: 'mobile', isRotated: false } },
   parameters: {
-    viewport: { defaultViewport: 'mobile' },
     docs: {
       description: {
         story:
@@ -225,8 +225,8 @@ export const TeamDetailPhone: Story = {
 
 export const TeamDetailFiltered: Story = {
   name: 'Drawer opened from a filtered list',
+  globals: { viewport: { value: 'desktop', isRotated: false } },
   parameters: {
-    viewport: { defaultViewport: 'desktop' },
     docs: {
       description: {
         story:

--- a/apps/frontend/src/app/ui/widgets/TeamSlide/TeamSlide.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/TeamSlide/TeamSlide.stories.tsx
@@ -2,14 +2,6 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import TeamSlide from './TeamSlide';
 
-const PHONE_VIEWPORT = {
-  phone: {
-    name: 'Mobile (375)',
-    styles: { width: '375px', height: '812px' },
-    type: 'mobile',
-  },
-};
-
 const meta = {
   title: 'Widgets/TeamSlide',
   component: TeamSlide,
@@ -61,9 +53,8 @@ export const Wrapped: Story = {
 
 export const Mobile: Story = {
   name: 'Mobile (375)',
-  globals: { viewport: { value: 'phone', isRotated: false } },
+  globals: { viewport: { value: 'mobile', isRotated: false } },
   parameters: {
-    viewport: { options: PHONE_VIEWPORT },
     chromatic: { viewports: [375] },
     docs: {
       description: {

--- a/apps/frontend/src/app/ui/widgets/UploadImage/LogoUpdator.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/UploadImage/LogoUpdator.stories.tsx
@@ -163,7 +163,7 @@ export const RejectedFileType: Story = {
 
     fireEvent.change(input, { target: { files: [makeFile('logo.svg', 'image/svg+xml')] } });
 
-    await expect(
+    expect(
       await within(dialog).findByText('Please choose a valid image file (PNG, JPG, or WEBP).')
     ).toBeInTheDocument();
     // The rejection is local, so the well stays empty rather than previewing

--- a/apps/frontend/src/app/ui/widgets/UploadImage/LogoUpdator.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/UploadImage/LogoUpdator.stories.tsx
@@ -1,0 +1,206 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fireEvent, fn, userEvent, within } from 'storybook/test';
+import { MEDIA_SOURCES } from '@/app/constants/mediaSources';
+
+import LogoUpdator from './LogoUpdator';
+
+/** Built lazily inside a play so no `File` is constructed while the CSF module is analysed. */
+const makeFile = (name: string, type: string) =>
+  new File([new Blob(['fixture'], { type })], name, { type });
+
+/** Only `<dialog open>` is painted; the closed one stays mounted and inert. */
+const openTheModal = async (canvasElement: HTMLElement) => {
+  await userEvent.click(within(canvasElement).getByRole('button', { name: 'Update logo' }));
+  const dialog = document.querySelector<HTMLElement>('dialog[open]');
+  if (!dialog) throw new Error('The Update logo modal did not open');
+  return dialog;
+};
+
+const meta = {
+  title: 'Widgets/UploadImage/LogoUpdator',
+  component: LogoUpdator,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The 40px avatar chip that lets an organisation replace its logo, and the confirmation ' +
+          'modal behind it.\n\n' +
+          'Only the chip had ever been drawn. Everything else - the whole modal - lives behind a ' +
+          'click, and it is not a small surface: a 100px "before" avatar, an arrow, and a 100px ' +
+          'circular file well that swaps its camera glyph for a `blob:` preview once a file is ' +
+          'accepted, over a two-column Cancel/Update pair.\n\n' +
+          'It is also a `CenterModal`, so it `createPortal`s to `document.body`. The closed modal ' +
+          'stays mounted as an `inert` `<dialog>` without `open`, which means a plain text query ' +
+          'finds its contents whether or not it is visible - the assertions here filter on ' +
+          '`dialog[open]` for that reason, and a story asserting the title merely exists would pass ' +
+          'on a modal that never opened.\n\n' +
+          'Two states inside it can only be reached through the file input, which is `display: ' +
+          'none` behind its label. The preview branch replaces the camera glyph with an `<img>` and ' +
+          "simultaneously drops the well's border (`border-0` vs `border`), so the ring around it " +
+          'disappears - a swap no resting render contains. The rejection branch is validated ' +
+          'locally against a PNG/JPEG/WEBP allow-list, before any signed-URL request, and prints a ' +
+          'red line under the well. The stories stop there: pressing Update issues a signed-URL ' +
+          'POST and a PUT to S3.\n\n' +
+          'The action pair is a `grid grid-cols-2` that mounts only with the dialog - the same shape ' +
+          'as the popover bug this work exists to catch, where an invalid template is dropped by ' +
+          'the browser and the children silently collapse into one column - so the open story ' +
+          'asserts the computed template really resolves to two tracks.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    imageUrl: MEDIA_SOURCES.avatars.business,
+    title: 'Update organisation logo',
+    apiUrl: '/v1/organisation/logo/signed-url',
+    onSave: fn(),
+  },
+} satisfies Meta<typeof LogoUpdator>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Chip: Story = {
+  name: 'Avatar chip (closed)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('button', { name: 'Update logo' })).toBeInTheDocument();
+    // The modal is mounted but not painted, which is why every other story
+    // filters on dialog[open] rather than on text.
+    await expect(document.querySelector('dialog[open]')).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting state in the header: a 40px round avatar that is the entire trigger. Nothing ' +
+          'marks it as editable - no pencil, no hover chrome - so the modal is the only thing that ' +
+          'explains what the chip does.',
+      },
+    },
+  },
+};
+
+export const ModalOpen: Story = {
+  name: 'Update logo modal',
+  play: async ({ canvasElement }) => {
+    const dialog = await openTheModal(canvasElement);
+
+    // Assert the panel has its content, not merely that a dialog appeared.
+    await expect(within(dialog).getByText('Update organisation logo')).toBeInTheDocument();
+    // Current logo on the left, the empty well on the right.
+    await expect(within(dialog).getByAltText('Logo')).toBeInTheDocument();
+    await expect(within(dialog).queryByAltText('New Logo')).toBeNull();
+
+    // The file input is display:none behind its label, so it is reachable by
+    // its aria-label rather than by role.
+    const input = within(dialog).getByLabelText('Update logo image') as HTMLInputElement;
+    await expect(input.accept).toContain('image/png');
+
+    const cancel = within(dialog).getByRole('button', { name: 'Cancel' });
+    await expect(within(dialog).getByRole('button', { name: 'Update' })).toBeInTheDocument();
+
+    /* The action pair only mounts with the dialog. Assert the computed template
+       really resolves to two tracks - a dropped or malformed template collapses
+       both buttons into one column and still looks deliberate. */
+    const actions = cancel.parentElement as HTMLElement;
+    await expect(getComputedStyle(actions).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(2);
+    await expect(actions.children).toHaveLength(2);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The modal as it opens: current logo, arrow, and the bordered 100px well with a 40px ' +
+          'camera glyph centred in it. Nothing has been picked yet, so Update is live but would ' +
+          'only produce the "Please choose an image to upload." message.',
+      },
+    },
+  },
+};
+
+export const PreviewSelected: Story = {
+  name: 'File picked (blob preview)',
+  play: async ({ canvasElement }) => {
+    const dialog = await openTheModal(canvasElement);
+    const input = within(dialog).getByLabelText('Update logo image') as HTMLInputElement;
+
+    // `fireEvent` rather than `userEvent.upload`: the input is `display: none`
+    // behind its label, so a synthetic click on it is not a reliable way to
+    // reach the change handler.
+    fireEvent.change(input, { target: { files: [makeFile('new-logo.png', 'image/png')] } });
+
+    // The camera glyph is replaced in place by an object-URL preview - the
+    // only render where both the old and the new logo are on screen together.
+    const preview = await within(dialog).findByAltText('New Logo');
+    await expect(preview).toBeInTheDocument();
+    await expect(preview.getAttribute('src')).toMatch(/^blob:/);
+    await expect(within(dialog).getByAltText('Logo')).toBeInTheDocument();
+
+    // The well drops its ring once a preview fills it (`border-0` vs `border`).
+    const well = dialog.querySelector('label[for]') as HTMLElement;
+    await expect(well).toHaveClass('border-0');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A picked file, previewed locally before anything is uploaded. The `src` is restricted to ' +
+          '`blob:` on purpose - `getSafePreviewUrl` rejects every other scheme, so a data: or SVG ' +
+          'URL can never reach the `<img>`. Nothing has been sent yet; Update is what starts the ' +
+          'signed-URL request.',
+      },
+    },
+  },
+};
+
+export const RejectedFileType: Story = {
+  name: 'Unsupported file rejected',
+  play: async ({ canvasElement }) => {
+    const dialog = await openTheModal(canvasElement);
+    const input = within(dialog).getByLabelText('Update logo image') as HTMLInputElement;
+
+    fireEvent.change(input, { target: { files: [makeFile('logo.svg', 'image/svg+xml')] } });
+
+    await expect(
+      await within(dialog).findByText('Please choose a valid image file (PNG, JPG, or WEBP).')
+    ).toBeInTheDocument();
+    // The rejection is local, so the well stays empty rather than previewing
+    // something that will fail later.
+    await expect(within(dialog).queryByAltText('New Logo')).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'An SVG refused before any network call. The message appears under the well, inside the ' +
+          'same centred column, so it pushes the Cancel/Update row down - this is the tallest the ' +
+          'modal ever gets, and the only render that composites the error line with the action ' +
+          'grid.',
+      },
+    },
+  },
+};
+
+export const Disabled: Story = {
+  name: 'Disabled chip',
+  args: { disabled: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'Update logo' });
+    await expect(trigger).toBeDisabled();
+    // The handler is guarded twice - `disabled` on the element and a check
+    // inside onClick - so the modal stays shut.
+    await expect(document.querySelector('dialog[open]')).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'While the organisation profile is still loading the chip is disabled. It is genuinely ' +
+          '`disabled` rather than merely dimmed, so it is skipped by the tab order too.',
+      },
+    },
+  },
+};


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

**`PackageBreakdownTooltip` renders its entire seven-column table at 1.00:1 - the same colour as the surface behind it - in both themes. It is invisible, and it is live on dev today.**

This is not a Storybook problem. It is a production defect that #2274's work made visible:

| | |
| --- | --- |
| `--color-neutral-0` | resolves to `var(--screen)` |
| `--color-neutral-200` | resolves to `var(--hairline)` |
| `.glass-tooltip-bubble` background | that same `var(--screen)` |

The table was written against the old translucent-dark bubble (`--glass-93`). Commit `2ca7017e4` made the bubble opaque and did not touch this file, so its inks were left behind. Measured against the bubble background:

| | light | dark |
| --- | --- | --- |
| before | **1.00** | **1.00** |
| after (`--ink` / `--ink-muted`) | **15.38 / 6.29** | **12.82 / 5.57** |

Nothing caught it. The component's own tests pass. It only misbehaves once the tooltip is open, and nothing had ever opened it.

## What is the new behavior?

The tooltip uses ink tokens, so its table is legible in both themes.

Plus sixteen more interaction-gated surfaces drawn open, continuing the inventory from #2274 (207 found, 177 undrawn).

Three of these were the worst shape in that inventory - **stories that existed and could not reach anything**:

- **`TotalBillContainer`** passed `billableItems: []`, items with no `breakdown`, and an empty `incompleteItemNames` Set. All three of its gated triggers were absent from the DOM, so no story could ever have opened them however hard it tried. Given real data it now opens the portalled search dropdown, the breakdown table and the prescription hint - **and that is the story that surfaced the bug above**.
- **`TaskCard`** and **`VideosCard`**: same shape. Stories present, nothing opened.

New: `AppointmentBoardToolbar` (datepicker popper, portalled to `#yc-datepicker-portal`), `WorkspaceQuickActions`, the Calendar `Header`'s module-private status dropdown, `DateTimePickerSection`, `ConversationRow`'s kebab, `StatusPillSelect`, `PillDropdown`, `RoomInfoContent` (two nested confirms), `RoomInfoSections`, `AddCompanionFormMode`, `GuidePlayerModal`, `LogoUpdator`, `VideoPlayerModal`.

## Two mechanics worth recording

Both cost real debugging time and are written into the story files:

- **Hover plays need an explicit `userEvent.unhover`.** The direct API starts from a fresh pointer position and never emits `mouseleave`, so bubbles accumulate and "exactly one portal is live" fails.
- **Queries against `ModalBase` must filter on `dialog[open]`.** Closed dialogs stay mounted and inert, so a plain text query passes on a confirm that never opened - the same false-pass shape this work keeps finding.

`RoomInfoContent` also asserts its Cancel/Delete grid resolves to two tracks, and reaches its discard confirm by pressing Escape while dirty, since `canClose` returning false is the only route to it - no prop or button gets there.

## Validation

- type-check clean, lint 0 errors
- 942 suites / 11565 tests green
- Storybook builds at **1198 stories**, up from 1090

## Still outstanding, tracked not hidden

- 86 gated surfaces remain: 56 need mocks, 15 need an export, 14 storyable as-is (in flight), 1 needs a refactor.
- The `play` functions here are still **not gated by any required check** - Chromatic is advisory and no interactions addon is installed. That is #2281, and this PR does not claim otherwise.

## Related Issue(s)

Fixes #

---

## Follow-up in this PR: the Storybook itself was not doing what it claimed

Two configuration-level defects, both silent, both found by executing the whole Storybook rather than reading it.

### 1. Viewport pins were inert

Storybook 10 removed `parameters.viewport.viewports` and `parameters.viewport.defaultViewport`. Neither errors, neither fails type-check, and a story pinned with them still renders and still passes - at the full panel width.

`preview.ts` used both removed keys, so no project presets were registered at all. 19 story entries selected with `defaultViewport`; 14 more selected `value: 'phone'`, a preset name that has never existed here and worked only via a duplicated local map in each of those files.

| | measured |
| --- | --- |
| before | **62 of 68** pinned story instances rendered at 1200px - the width of an unpinned story |
| after | **68 / 68** render at the width they declare |

Every "Phone" story except six was reviewing desktop markup under a name promising a phone.

Guarded by a new test that parses `preview.ts` and every story file. It resolves a story's own `options` map when it declares one rather than skipping such files - an earlier version skipped them, which excused 13 of the 14 files it existed to check and still reported four passes.

### 2. 43 of 1110 stories threw when actually run

CI runs no play functions (#2281), so none of this was visible.

**38 were one cause.** `GlassTooltip` binds `mouseenter`/`focusin` natively inside an effect; Storybook starts a play function before that effect has necessarily flushed, so a single dispatch lands on an element with no listener and is lost. `findByRole` retries the query, never the event, so the loss is permanent. Measured in a probe story: events reached the wrapper, the bubble never opened, still shut at 350ms; the same hover after a 100ms wait opened it, and a redispatch loop needed three attempts. **The component is fine - a real browser hover opens it every time.**

A shared `openGlassTooltip`/`closeGlassTooltip` redispatches until the listener exists. Plain DOM events, no testing-library import, unit-tested at 100%. Applied to all 14 files that open a bubble, including those that passed only because they interacted with something else first.

**The other five, each proving nothing in a different way:**

- **Modal** queried the canvas for a panel `ModalBase` portals to `document.body` - unfindable after the click, and the "closed at rest" assertion above it passed for that same reason. Absence is now asserted against `dialog[open]`, because closed does not mean unmounted here.
- **WorkspaceHeader** matched `/emergency/i`, which also matches the sr-only `"<title> - <story name>"` banner the preview decorator injects. Ambiguous here; elsewhere such a query can match ONLY the banner and pass with the component absent.
- **InputWithDropdown** asserted two results for "ma". It is three - the filter is a substring test over the whole label, so it also matches Priya Ra**ma**n.
- **GuestHeader** referenced `canvas` outside its scope.
- **DispensaryTable** closed a focus-opened bubble with `blur()`, which fires nothing on an element that never held focus.

### One product fix it turned up

The task details popover printed **Category twice** inside 304px - once in its From/To/Category grid, and again from `getTaskQuickDetails`, which leads with Category and whose first two entries the popover rendered. Filtered rather than re-sliced, since `TaskCard` shares the helper and does want it.

**All 1110 stories now render and play clean.**

---

## Final state: 1366 stories, all of them executed

The whole Storybook now runs end to end against a real build: **1366/1366 render and play clean**. Before this branch, no CI job had ever executed a play function (#2281), and the first full run threw on **43 of 1110**.

### What executing it found

| Defect | Reach | Status |
| --- | --- | --- |
| `text-error-main` and 8 more colour utilities resolve to nothing | 12 uses, 10 files | fixed + guarded |
| Unlayered `!important` typography defeats size and weight utilities | **63 sites** | filed as #2297 |
| Task popover printed **Category twice** in 304px | 1 | fixed |
| Viewport pins inert repo-wide | 62 of 68 story instances | fixed + guarded |
| `GlassTooltip` stories never opened a bubble | 38 stories | fixed + helper at 100% |

The colour-utility one is the sharpest: a Tailwind utility naming an undefined token emits **no CSS at all**, so the element inherits and looks deliberate. `text-error-main` meant five error messages across PIMS rendered in ordinary body ink. Type-checking, linting, the components' own tests and a screenshot all pass on that.

### Hazards found in the test harness itself

Both make a broken story indistinguishable from a working one:

- **A DOM-mutating helper inside a `waitFor` callback wedges the browser tab** rather than failing. The MutationObserver retry is a microtask, so a callback that mutates then throws re-queues forever and starves `waitFor`'s own timeout. One story hung the full run for 30 minutes with no output; a second had the same construct and passed only by succeeding on its first attempt.
- **`getComputedStyle(el).width` is the content box**, so six width assertions on bordered elements were measuring 318 against an asserted 320.

The runner now has a per-story hard timeout that does not touch the wedged page, recreates the page after one, and prints progress.

### Guards added

Three tests, each mutation-checked (break it, confirm red, restore, confirm green):

1. `colorUtilityExists` - every colour utility resolves to a declared token or a hand-written class
2. `storybookViewportGlobals` - no returning `defaultViewport`, no story naming a preset that does not exist
3. `storyInteractions` - the tooltip helper, 100% statements/branches/functions/lines

Two false-positive classes had to come out of my own guards first, both the same shape as the bugs they hunt: one matched `defaultViewport` inside comments explaining not to use it, the other matched `text-` *inside* `border-input-text-placeholder-active`.
