### PR TITLE
fix(backend): give staff wallet passes a practice-scoped token

### DIFF
--- a/apps/backend/src/controllers/web/pet-passport.controller.ts
+++ b/apps/backend/src/controllers/web/pet-passport.controller.ts
@@ -238,16 +238,25 @@ const parentPassport = (
  * member the cross-practice records the consent filter withholds from their own
  * passport view. The owner creates the link from the mobile app first.
  */
-const staffShareToken = async (patientId: string): Promise<string> => {
-  const token = await PetPassportService.getExistingPublicToken(patientId);
-  if (!token) {
-    throw new PetPassportServiceError(
-      "This passport has no active public share link. The pet's owner must create one from the app before a wallet pass can be issued.",
-      409,
-    );
-  }
-  return token;
-};
+/**
+ * The credential a staff wallet pass carries.
+ *
+ * Deliberately NOT the owner's public token. That one resolves with "owner"
+ * scope - every practice's records, no consent gate - so embedding it here
+ * would let a practice read, through a pass it generated itself, the
+ * cross-practice history the consent filter withholds from its passport view.
+ * The practice token is bound to this organisation and resolves with
+ * "practice" scope, so the pass shows exactly what the issuing staff member
+ * can already see.
+ *
+ * It also removes the old 409: staff no longer need the owner to have created
+ * a public link before a pass can be issued.
+ */
+const staffWalletToken = async (
+  patientId: string,
+  organisationId: string,
+): Promise<string> =>
+  PetPassportService.getOrCreatePracticeWalletToken(patientId, organisationId);
 
 /** Streams a signed .pkpass for an already-assembled passport. */
 const applePassResponse = async (
@@ -404,7 +413,7 @@ export const PetPassportController = {
     run: async ({ params, res }) =>
       applePassResponse(
         await orgPassport(params),
-        await staffShareToken(params.patientId),
+        await staffWalletToken(params.patientId, params.organisationId),
         res,
       ),
   }),
@@ -415,7 +424,7 @@ export const PetPassportController = {
     run: async ({ params, res }) =>
       googlePassResponse(
         await orgPassport(params),
-        await staffShareToken(params.patientId),
+        await staffWalletToken(params.patientId, params.organisationId),
         res,
       ),
   }),

--- a/apps/backend/src/services/pet-passport.service.ts
+++ b/apps/backend/src/services/pet-passport.service.ts
@@ -615,7 +615,7 @@ export const PetPassportService = {
       return row.practiceWalletToken;
     }
     // Reissued after a revoke rather than reused, so a revoked pass stays dead.
-    const token = randomBytes(32).toString("base64url");
+    const token = generatePublicToken();
     await prisma.petPassport.update({
       where: { id: row.id },
       data: {

--- a/apps/backend/src/services/pet-passport.service.ts
+++ b/apps/backend/src/services/pet-passport.service.ts
@@ -580,6 +580,54 @@ export const PetPassportService = {
   },
 
   /**
+   * The token a STAFF wallet pass carries.
+   *
+   * Distinct from `publicToken` on purpose. The public one resolves with
+   * "owner" scope - every practice's records, no consent gate - so handing it
+   * to a practice session would let staff read, via their own pass, the
+   * cross-practice history the consent filter withholds from their passport
+   * view. This one is bound to the passport row's organisation and resolves
+   * with "practice" scope, so it grants no more than the caller already has.
+   *
+   * That is also why minting here is safe while `getExistingPublicToken` never
+   * mints: a practice creating a credential no wider than its own session is
+   * not an escalation, and staff must be able to issue a pass without waiting
+   * for the owner to create a public link first.
+   */
+  async getOrCreatePracticeWalletToken(
+    patientId: string,
+    organisationId: string,
+  ): Promise<string> {
+    const row = await prisma.petPassport.findFirst({
+      where: { patientId, organisationId },
+      orderBy: { issueDate: "desc" },
+      select: {
+        id: true,
+        passportNumber: true,
+        practiceWalletToken: true,
+        practiceWalletTokenRevokedAt: true,
+      },
+    });
+    if (!row?.passportNumber) {
+      throw new PetPassportServiceError("Passport not found.", 404);
+    }
+    if (row.practiceWalletToken && !row.practiceWalletTokenRevokedAt) {
+      return row.practiceWalletToken;
+    }
+    // Reissued after a revoke rather than reused, so a revoked pass stays dead.
+    const token = randomBytes(32).toString("base64url");
+    await prisma.petPassport.update({
+      where: { id: row.id },
+      data: {
+        practiceWalletToken: token,
+        practiceWalletTokenIssuedAt: new Date(),
+        practiceWalletTokenRevokedAt: null,
+      },
+    });
+    return token;
+  },
+
+  /**
    * Kills the circulating public link. Any wallet pass already carrying it
    * stops verifying, which is the intended effect of a revoke.
    */
@@ -618,18 +666,48 @@ export const PetPassportService = {
     if (!rawToken) {
       throw new PetPassportServiceError("Passport not found.", 404);
     }
-    const row = await prisma.petPassport.findFirst({
+    // Two credentials resolve here and they are NOT equivalent. The owner's
+    // public token is owner-initiated and shows every practice's records; a
+    // practice wallet token was minted by one practice and must stay inside
+    // that practice's consent boundary. Scope is decided by which column
+    // matched, never by anything the caller supplies.
+    const owned = await prisma.petPassport.findFirst({
       where: { publicToken: rawToken, publicTokenRevokedAt: null },
       orderBy: { issueDate: "desc" },
       select: { patientId: true, organisationId: true, passportNumber: true },
     });
     // Only a formally issued passport resolves: passportNumber is what issuance
     // sets, so a row without one is not a document anyone should verify.
-    if (!row?.passportNumber) {
+    if (owned) {
+      if (!owned.passportNumber) {
+        throw new PetPassportServiceError("Passport not found.", 404);
+      }
+      // The public QR is owner-initiated, so it shows the pet's full record
+      // across every practice (no per-practice consent gate).
+      return assemblePassport(
+        owned.patientId,
+        owned.organisationId,
+        false,
+        "owner",
+      );
+    }
+
+    const practice = await prisma.petPassport.findFirst({
+      where: {
+        practiceWalletToken: rawToken,
+        practiceWalletTokenRevokedAt: null,
+      },
+      orderBy: { issueDate: "desc" },
+      select: { patientId: true, organisationId: true, passportNumber: true },
+    });
+    if (!practice?.passportNumber) {
       throw new PetPassportServiceError("Passport not found.", 404);
     }
-    // The public QR is owner-initiated, so it shows the pet's full record across
-    // every practice (no per-practice consent gate).
-    return assemblePassport(row.patientId, row.organisationId, false, "owner");
+    return assemblePassport(
+      practice.patientId,
+      practice.organisationId,
+      false,
+      "practice",
+    );
   },
 };

--- a/apps/backend/test/controllers/web/pet-passport.controller.test.ts
+++ b/apps/backend/test/controllers/web/pet-passport.controller.test.ts
@@ -35,6 +35,7 @@ jest.mock("../../../src/services/pet-passport.service", () => {
       getPublicPassportByToken: jest.fn(),
       ensurePublicToken: jest.fn(),
       getExistingPublicToken: jest.fn(),
+      getOrCreatePracticeWalletToken: jest.fn(),
       issuePublicToken: jest.fn(),
       revokePublicToken: jest.fn(),
     },
@@ -99,6 +100,9 @@ describe("PetPassportController", () => {
     jest.clearAllMocks();
     service.ensurePublicToken.mockResolvedValue("share-token-abc" as never);
     // Staff pass builders read an already-live token and never mint one.
+    service.getOrCreatePracticeWalletToken.mockResolvedValue(
+      "practice-token" as never,
+    );
     service.getExistingPublicToken.mockResolvedValue(
       "share-token-abc" as never,
     );
@@ -689,25 +693,48 @@ describe("PetPassportController", () => {
       expect(statusMock).toHaveBeenCalledWith(501);
     });
 
-    it("never mints a public share token from a staff session", async () => {
-      // The token resolves the public passport with "owner" scope, bypassing
-      // the cross-practice consent filter that constrains the same staff
-      // member's own passport view - and creates a durable public credential
-      // the owner never authorised. Staff must reuse a live one or get a 409.
-      service.getPassport.mockResolvedValue(passportDto as never);
-      service.getExistingPublicToken.mockResolvedValue(null as never);
-      await PetPassportController.getApplePass(authed(), res as Response);
-      expect(statusMock).toHaveBeenCalledWith(409);
-      expect(service.ensurePublicToken).not.toHaveBeenCalled();
-      expect(wallet.buildApplePass).not.toHaveBeenCalled();
-    });
-
-    it("builds the staff pass from an already-live token", async () => {
+    it("never puts the owner's public token in a staff pass", async () => {
+      // The public token resolves with "owner" scope, which shows every
+      // practice's records with no consent gate. Embedding it here would let a
+      // practice read, through a pass it generated itself, the cross-practice
+      // history the consent filter withholds from its own passport view.
       service.getPassport.mockResolvedValue(passportDto as never);
       wallet.buildApplePass.mockResolvedValue(Buffer.from("pk") as never);
+
       await PetPassportController.getApplePass(authed(), res as Response);
-      expect(service.getExistingPublicToken).toHaveBeenCalledWith("pat-1");
+
+      expect(service.getExistingPublicToken).not.toHaveBeenCalled();
       expect(service.ensurePublicToken).not.toHaveBeenCalled();
+      expect(wallet.buildApplePass).toHaveBeenCalledWith(
+        passportDto,
+        "practice-token",
+      );
+    });
+
+    it("builds the staff pass from a practice token scoped to the caller's org", async () => {
+      service.getPassport.mockResolvedValue(passportDto as never);
+      wallet.buildApplePass.mockResolvedValue(Buffer.from("pk") as never);
+
+      await PetPassportController.getApplePass(authed(), res as Response);
+
+      expect(service.getOrCreatePracticeWalletToken).toHaveBeenCalledWith(
+        "pat-1",
+        "org-1",
+      );
+    });
+
+    it("no longer requires the owner to have created a public link first", async () => {
+      // This used to answer 409 when no public link existed, which blocked
+      // staff from issuing a pass at the desk. The practice token is theirs to
+      // mint, so there is nothing to wait for.
+      service.getPassport.mockResolvedValue(passportDto as never);
+      service.getExistingPublicToken.mockResolvedValue(null as never);
+      wallet.buildApplePass.mockResolvedValue(Buffer.from("pk") as never);
+
+      await PetPassportController.getApplePass(authed(), res as Response);
+
+      expect(statusMock).not.toHaveBeenCalledWith(409);
+      expect(wallet.buildApplePass).toHaveBeenCalled();
     });
 
     it("falls back to a default filename for a nameless companion", async () => {

--- a/apps/backend/test/services/pet-passport.service.test.ts
+++ b/apps/backend/test/services/pet-passport.service.test.ts
@@ -724,3 +724,57 @@ describe("PetPassportService.getPassportForParent", () => {
     expect(passport.identity.name).toBe("Doggy");
   });
 });
+
+describe("PetPassportService token scope split", () => {
+  const issued = {
+    patientId: "pat-1",
+    organisationId: "org-1",
+    passportNumber: "GB-YC-1",
+  };
+
+  it("resolves the owner's public token across every practice", async () => {
+    prismaMock.petPassport.findFirst.mockResolvedValueOnce(issued);
+
+    await PetPassportService.getPublicPassportByToken("owner-token");
+
+    const where = prismaMock.encounter.findMany.mock.calls[0][0].where;
+    expect(where.organisationId).toBeUndefined();
+  });
+
+  it("confines a practice wallet token to its own consent boundary", async () => {
+    // This is the whole point of the second token. If a practice token ever
+    // resolved with owner scope, a practice could read the cross-practice
+    // history its own passport view withholds - through a pass it minted.
+    prismaMock.petPassport.findFirst
+      .mockResolvedValueOnce(null) // not the owner's public token
+      .mockResolvedValueOnce(issued); // matched on practiceWalletToken
+
+    await PetPassportService.getPublicPassportByToken("practice-token");
+
+    const where = prismaMock.encounter.findMany.mock.calls[0][0].where;
+    expect(where.organisationId).toBeDefined();
+    expect(where.organisationId.in).toContain("org-1");
+  });
+
+  it("looks the practice token up only after the public one misses, and excludes revoked", async () => {
+    prismaMock.petPassport.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(issued);
+
+    await PetPassportService.getPublicPassportByToken("practice-token");
+
+    const second = prismaMock.petPassport.findFirst.mock.calls[1][0].where;
+    expect(second.practiceWalletToken).toBe("practice-token");
+    expect(second.practiceWalletTokenRevokedAt).toBeNull();
+  });
+
+  it("404s when neither token matches", async () => {
+    prismaMock.petPassport.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
+
+    await expect(
+      PetPassportService.getPublicPassportByToken("nothing"),
+    ).rejects.toMatchObject({ statusCode: 404 });
+  });
+});

--- a/apps/backend/test/services/pet-passport.service.test.ts
+++ b/apps/backend/test/services/pet-passport.service.test.ts
@@ -778,3 +778,98 @@ describe("PetPassportService token scope split", () => {
     ).rejects.toMatchObject({ statusCode: 404 });
   });
 });
+
+describe("PetPassportService.getOrCreatePracticeWalletToken", () => {
+  const issuedRow = {
+    id: "pp-1",
+    passportNumber: "GB-YC-1",
+    practiceWalletToken: null,
+    practiceWalletTokenRevokedAt: null,
+  };
+
+  it("scopes the passport lookup to the caller's organisation", async () => {
+    prismaMock.petPassport.findFirst.mockResolvedValue({
+      ...issuedRow,
+      practiceWalletToken: "live-token",
+    });
+
+    await PetPassportService.getOrCreatePracticeWalletToken("pat-1", "org-1");
+
+    const where = prismaMock.petPassport.findFirst.mock.calls[0][0].where;
+    expect(where).toMatchObject({
+      patientId: "pat-1",
+      organisationId: "org-1",
+    });
+  });
+
+  it("reuses a live token so regenerating a pass keeps issued ones working", async () => {
+    prismaMock.petPassport.findFirst.mockResolvedValue({
+      ...issuedRow,
+      practiceWalletToken: "live-token",
+    });
+
+    const token = await PetPassportService.getOrCreatePracticeWalletToken(
+      "pat-1",
+      "org-1",
+    );
+
+    expect(token).toBe("live-token");
+    expect(prismaMock.petPassport.update).not.toHaveBeenCalled();
+  });
+
+  it("mints on first use, which staff may do because it grants no more than their session", async () => {
+    prismaMock.petPassport.findFirst.mockResolvedValue(issuedRow);
+
+    const token = await PetPassportService.getOrCreatePracticeWalletToken(
+      "pat-1",
+      "org-1",
+    );
+
+    expect(typeof token).toBe("string");
+    expect(token.length).toBeGreaterThan(20);
+    const update = prismaMock.petPassport.update.mock.calls[0][0];
+    expect(update.where).toEqual({ id: "pp-1" });
+    expect(update.data.practiceWalletToken).toBe(token);
+    expect(update.data.practiceWalletTokenRevokedAt).toBeNull();
+  });
+
+  it("reissues rather than reusing after a revoke, so a revoked pass stays dead", async () => {
+    prismaMock.petPassport.findFirst.mockResolvedValue({
+      ...issuedRow,
+      practiceWalletToken: "old-token",
+      practiceWalletTokenRevokedAt: new Date("2026-08-01T00:00:00.000Z"),
+    });
+
+    const token = await PetPassportService.getOrCreatePracticeWalletToken(
+      "pat-1",
+      "org-1",
+    );
+
+    expect(token).not.toBe("old-token");
+    expect(
+      prismaMock.petPassport.update.mock.calls[0][0].data
+        .practiceWalletTokenRevokedAt,
+    ).toBeNull();
+  });
+
+  it("404s when no passport row exists for this organisation", async () => {
+    prismaMock.petPassport.findFirst.mockResolvedValue(null);
+
+    await expect(
+      PetPassportService.getOrCreatePracticeWalletToken("pat-1", "org-1"),
+    ).rejects.toMatchObject({ statusCode: 404 });
+    expect(prismaMock.petPassport.update).not.toHaveBeenCalled();
+  });
+
+  it("404s when the passport was never formally issued", async () => {
+    prismaMock.petPassport.findFirst.mockResolvedValue({
+      ...issuedRow,
+      passportNumber: null,
+    });
+
+    await expect(
+      PetPassportService.getOrCreatePracticeWalletToken("pat-1", "org-1"),
+    ).rejects.toMatchObject({ statusCode: 404 });
+    expect(prismaMock.petPassport.update).not.toHaveBeenCalled();
+  });
+});

--- a/packages/database/prisma/migrations/20260819090000_add_pet_passport_practice_wallet_token/migration.sql
+++ b/packages/database/prisma/migrations/20260819090000_add_pet_passport_practice_wallet_token/migration.sql
@@ -1,0 +1,22 @@
+-- Staff wallet passes get their own practice-scoped token.
+--
+-- Staff pass builders previously embedded the OWNER's `publicToken`. That token
+-- resolves with "owner" scope, which shows the pet's records from every practice
+-- with no consent gate, so a practice could read through its own wallet pass the
+-- cross-practice history that the consent filter withholds from its passport
+-- view. Requiring the owner to have created the link first limited who could
+-- trigger it, but did not change what the token granted once handed over.
+--
+-- This token is bound to the passport row's organisation and resolves with
+-- "practice" scope, so it grants no more than the staff member already has.
+-- That is why a staff session may mint it, while `publicToken` stays owner-only.
+--
+-- Stored rather than hashed, for the same reason as `publicToken`: it is baked
+-- into the QR of passes already on devices, so it must be readable back.
+
+ALTER TABLE "PetPassport" ADD COLUMN IF NOT EXISTS "practiceWalletToken" TEXT;
+ALTER TABLE "PetPassport" ADD COLUMN IF NOT EXISTS "practiceWalletTokenIssuedAt" TIMESTAMP(3);
+ALTER TABLE "PetPassport" ADD COLUMN IF NOT EXISTS "practiceWalletTokenRevokedAt" TIMESTAMP(3);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "PetPassport_practiceWalletToken_key"
+  ON "PetPassport"("practiceWalletToken");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -594,6 +594,20 @@ model PetPassport {
   publicToken       String?       @unique
   publicTokenIssuedAt DateTime?
   publicTokenRevokedAt DateTime?
+  // Staff-facing wallet passes carry THIS token, never `publicToken`.
+  //
+  // The owner's public token resolves with "owner" scope, which shows every
+  // practice's records with no consent gate. Handing that value to a practice
+  // session would give staff, through their own wallet pass, the cross-practice
+  // history the consent filter deliberately withholds from their passport view.
+  //
+  // This one is bound to the passport row's own organisation and resolves with
+  // "practice" scope, so it grants strictly less than the staff member already
+  // has. Minting it from a staff session is therefore safe, unlike the public
+  // token, which only the owner may create.
+  practiceWalletToken       String?       @unique
+  practiceWalletTokenIssuedAt DateTime?
+  practiceWalletTokenRevokedAt DateTime?
   createdAt         DateTime      @default(now())
   updatedAt         DateTime      @updatedAt
 


### PR DESCRIPTION
## What changed

Staff wallet passes now carry a new `practiceWalletToken` instead of the owner's `publicToken`. The new token is bound to the passport row's organisation and resolves with `"practice"` scope, so the pass shows exactly what the issuing staff member can already see.

Implements option (b) from the discussion on #2287. Reported by Codex.

## The problem

`staffShareToken()` fetched the owner's `publicToken` and embedded it in the pass barcode. That token resolves at the public verification route with `"owner"` scope, which applies **no** organisation filter - the pet's records from every practice.

So a staff member with `companions:view:any` could generate a pass, read the token out of `pass.json` or the Google Wallet JWT, and use it to see the cross-practice history that the consent filter deliberately withholds from their own passport view: microchip plus every signed vaccination, treatment, titration and exam record.

**The author had already seen half of this.** The doc comment on `getExistingPublicToken` says it never mints, precisely so a practice session cannot create a durable public credential the owner never authorised, and it names the owner-scope consequence explicitly. But not minting only limited who could *trigger* the disclosure. It did not change what the token *granted* once handed over. Any pet whose owner had created a public link was exposed.

## The fix

A second credential on `PetPassport`:

```prisma
practiceWalletToken          String?   @unique
practiceWalletTokenIssuedAt  DateTime?
practiceWalletTokenRevokedAt DateTime?
```

`PetPassport` rows already carry `organisationId`, so a row is already per-practice. The token inherits that boundary for free.

`getPublicPassportByToken` now decides scope by **which column matched**, never by anything the caller supplies:

| matched column | scope | records shown |
| --- | --- | --- |
| `publicToken` | `owner` | every practice, no consent gate |
| `practiceWalletToken` | `practice` | issuing org plus consented orgs |
| neither | - | same 404 as before |

Because the practice token grants no more than the caller's own session, a staff session may mint it. `publicToken` stays owner-only, unchanged.

## Behaviour change

The `409 "This passport has no active public share link..."` is gone. Staff previously could not issue a pass until the owner created a public link from the app. The practice token is theirs to mint, so there is nothing to wait for.

Two controller tests asserting the old design are rewritten: one now asserts the owner's token is never read for a staff pass, one asserts the practice token is requested for the caller's own org. A third was added for the removed 409.

## Validation performed

- **Full backend suite: 410 suites, 9696 tests, all pass.**
- `tsc`: 0 errors.
- New service tests assert the scope split on its observable effect - an owner token produces no `organisationId` filter on the encounter query, a practice token produces one containing the issuing org.
- **Mutation-checked.** Flipping the practice branch to `"owner"` scope fails exactly the consent-boundary test, so that test detects the regression it exists to prevent rather than passing alongside it.

## Urgency

The exposure is latent, not live: both wallet builders throw `WalletNotConfiguredError` (501) without the Apple and Google credentials, and those are not set on any box. **This should land before wallet credentials are provisioned anywhere**, which is part of the pending hand-deploy work.

## Migration

`20260819090000_add_pet_passport_practice_wallet_token` - three nullable columns plus a unique index, all `IF NOT EXISTS`, no backfill, no data movement. Existing passes keep working: `publicToken` is untouched and still resolves with owner scope for owner-initiated QRs.