### PR TITLE
fix(frontend): drop dead !important typography weight overrides

### DIFF
--- a/apps/frontend/src/app/__tests__/styles/typographyImportantGuard.test.ts
+++ b/apps/frontend/src/app/__tests__/styles/typographyImportantGuard.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Guard: font-weight utilities must stay able to override the typography classes.
+ *
+ * globals.css used to carry an unlayered `.text-caption-2` twin plus unlayered
+ * `.text-caption-3` / mobile-heading overrides that all used `font-weight: ... !important`.
+ * In Tailwind v4 an unlayered rule beats the utilities layer regardless of !important, so
+ * `font-bold` on a `text-caption-2` label (QuickActionsModal) silently did nothing. jsdom
+ * does not apply globals.css, so a getComputedStyle render test cannot catch this - it is
+ * asserted here against the source itself.
+ *
+ * If this fails: keep these overrides inside `@layer components` and drop `!important` from
+ * every font-weight declaration. Size/line-height/family may keep !important for the
+ * responsive mobile behavior.
+ */
+import { readFileSync } from 'fs';
+import path from 'path';
+
+const CSS_PATH = path.join(__dirname, '..', '..', 'globals.css');
+const css = readFileSync(CSS_PATH, 'utf8');
+
+/**
+ * Walk the braces up to `index` and report the nearest still-open `@layer <name>`.
+ * A plain `{` (or `@media {`) pushes `null` so nesting depth stays correct; the topmost
+ * non-null entry is the layer the target sits inside.
+ */
+const enclosingLayer = (source: string, index: number): string | null => {
+  const stack: (string | null)[] = [];
+  for (let i = 0; i < index; i++) {
+    const ch = source[i];
+    if (ch === '{') {
+      const match = /@layer\s+([\w-]+)\s*$/.exec(source.slice(0, i));
+      stack.push(match ? match[1] : null);
+    } else if (ch === '}') {
+      stack.pop();
+    }
+  }
+  return stack.filter((name) => name !== null).at(-1) ?? null;
+};
+
+describe('typography !important guard', () => {
+  it('has no font-weight declaration marked !important', () => {
+    const matches = css.match(/font-weight:[^;]*!important/g) ?? [];
+    expect(matches).toEqual([]);
+  });
+
+  it('keeps exactly one .text-caption-2 block', () => {
+    const matches = css.match(/\.text-caption-2\s*\{/g) ?? [];
+    expect(matches).toHaveLength(1);
+  });
+
+  it('nests .text-caption-3 inside @layer components', () => {
+    const index = css.indexOf('.text-caption-3');
+    expect(index).toBeGreaterThan(-1);
+    expect(enclosingLayer(css, index)).toBe('components');
+  });
+
+  it('nests the mobile typography media block inside @layer components', () => {
+    const index = css.indexOf('@media screen and (max-width: 768px)');
+    expect(index).toBeGreaterThan(-1);
+    expect(enclosingLayer(css, index)).toBe('components');
+  });
+});

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -1456,57 +1456,52 @@ input[type='number'] {
   }
 }
 
-/* Typography overrides outside @layer — beats Bootstrap's unlayered element resets on button/input.
-   Bootstrap loads after globals.css but @layer styles lose to unlayered styles regardless of
-   specificity. These rules use !important so they win on button elements too. */
-.text-caption-2 {
-  font-size: 0.75rem !important;
-  font-weight: 500 !important;
-  line-height: 1.125rem;
-  letter-spacing: -0.24px;
-}
-
-/* Caption - 10px/0.625rem - DS micro-badge type: status pills, compact labels.
-   ALL-CAPS 10px / 700 / 0.08em per the design system Badge convention. */
-.text-caption-3 {
-  font-family: var(--font-satoshi);
-  font-size: 0.625rem !important;
-  font-weight: 700 !important;
-  line-height: 1;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-/* Mobile responsive typography - applies to all heading/display classes */
-@media screen and (max-width: 768px) {
-  .text-display-1,
-  .text-display-2,
-  .text-heading-1,
-  .text-heading-2 {
-    font-family: var(--font-satoshi) !important;
-    font-size: 1.5rem !important;
-    font-weight: 500 !important;
-    line-height: 1.875rem !important;
-    letter-spacing: -0.48px;
+/* These typography overrides live in @layer components so font-* weight utilities (utilities
+   layer) can still win over the base weight here. font-size, line-height and font-family keep
+   !important so the responsive mobile sizing and the satoshi/newsreader family stay authoritative. */
+@layer components {
+  /* Caption - 10px/0.625rem - DS micro-badge type: status pills, compact labels.
+     ALL-CAPS 10px / 700 / 0.08em per the design system Badge convention. */
+  .text-caption-3 {
+    font-family: var(--font-satoshi);
+    font-size: 0.625rem !important;
+    font-weight: 700;
+    line-height: 1;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
   }
 
-  .text-heading-3,
-  .text-body-2,
-  .text-body-3,
-  .text-body-4 {
-    font-family: var(--font-satoshi) !important;
-    font-size: 1rem !important;
-    font-weight: 400 !important;
-    line-height: 1.5rem !important;
-    letter-spacing: -0.32px;
-  }
+  /* Mobile responsive typography - applies to all heading/display classes */
+  @media screen and (max-width: 768px) {
+    .text-display-1,
+    .text-display-2,
+    .text-heading-1,
+    .text-heading-2 {
+      font-family: var(--font-satoshi) !important;
+      font-size: 1.5rem !important;
+      font-weight: 500;
+      line-height: 1.875rem !important;
+      letter-spacing: -0.48px;
+    }
 
-  .text-body-3-emphasis {
-    font-family: var(--font-satoshi) !important;
-    font-size: 1rem !important;
-    font-weight: 500 !important;
-    line-height: 1.5rem !important;
-    letter-spacing: -0.32px;
+    .text-heading-3,
+    .text-body-2,
+    .text-body-3,
+    .text-body-4 {
+      font-family: var(--font-satoshi) !important;
+      font-size: 1rem !important;
+      font-weight: 400;
+      line-height: 1.5rem !important;
+      letter-spacing: -0.32px;
+    }
+
+    .text-body-3-emphasis {
+      font-family: var(--font-satoshi) !important;
+      font-size: 1rem !important;
+      font-weight: 500;
+      line-height: 1.5rem !important;
+      letter-spacing: -0.32px;
+    }
   }
 }
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

In `apps/frontend/src/app/globals.css`, several typography classes were
defined outside any `@layer` and set `font-weight: ... !important`. In
Tailwind v4 an unlayered rule beats the utilities layer regardless of
specificity or `!important`, so font-weight utilities could not override
them. As a result `font-bold` on a `text-caption-2` label (the
QuickActionsModal repro) silently did nothing. A dead unlayered
`.text-caption-2` twin also shadowed the intended caption style.

## What is the new behavior?

- Removed the dead unlayered `.text-caption-2` block.
- Moved the remaining `.text-caption-3` rule and the `max-width: 768px`
  mobile heading/body/display overrides into `@layer components`, so
  font-weight utilities in the utilities layer can win.
- Dropped `!important` from font-weight declarations only; the weight values
  themselves are unchanged. `font-size`, `line-height` and `font-family` keep
  `!important` so responsive mobile sizing and the satoshi/newsreader family
  stay authoritative.
- Added a source-level Jest guard
  (`src/app/__tests__/styles/typographyImportantGuard.test.ts`) asserting no
  `font-weight` `!important` remains, exactly one `.text-caption-2` block
  exists, and both `.text-caption-3` and the 768px media block are enclosed in
  `@layer components`. jsdom does not load globals.css, so the invariant is
  asserted against the CSS source rather than via `getComputedStyle`.

Impact area: `apps/frontend` global typography styles.

Validation performed:
- `npx tsc --noemit` clean.
- Lint clean (1 pre-existing unrelated warning).
- Guard test 4/4 passing.
- Visual rendering in a browser was not verified.

## Related Issue(s)

Fixes #2297

Closes #2297
