### PR TITLE
fix(repo): unblock commits on next.js route paths, and cut the passport blur

### DIFF
--- a/apps/frontend/src/app/(routes)/(share)/passport/[id]/PassportClient.tsx
+++ b/apps/frontend/src/app/(routes)/(share)/passport/[id]/PassportClient.tsx
@@ -50,7 +50,10 @@ const PassportClient = ({ id }: PassportClientProps) => {
           border: '1px solid var(--hairline-soft)',
           boxShadow: '0 6px 20px var(--sh10)',
           color: 'var(--ink-body)',
-          backdropFilter: 'blur(24px)',
+          // 8px, not 24px: backdrop blur cost scales with radius and this sits on a
+          // fixed element, so it composites on every scroll of the passport page.
+          // --glass-93 is 93% opaque, so almost none of the blur was visible anyway.
+          backdropFilter: 'blur(8px)',
         }}
       >
         {theme === 'dark' ? <IoSunnyOutline /> : <IoMoonOutline />}

--- a/lint-staged.config.cjs
+++ b/lint-staged.config.cjs
@@ -1,4 +1,13 @@
 const quote = (file) => `"${file.replaceAll('"', '\\"')}"`;
+
+// secretlint globs its own arguments, so shell quoting alone is not enough: a
+// Next.js route path like `(share)/passport/[id]/X.tsx` reaches its matcher as
+// a pattern, `[id]` reads as a character class, and nothing matches. When EVERY
+// staged file is inside such a directory secretlint exits "Not found target
+// files" and the whole pre-commit hook fails, so a commit touching only dynamic
+// route files could never be made. Escaping the metacharacters makes the path
+// literal again. eslint and prettier take paths literally and need only `quote`.
+const globQuote = (file) => quote(file.replace(/[()[\]{}*?!]/g, (ch) => `\\${ch}`));
 const isMobilePath = (file) =>
   file.startsWith('apps/mobileAppYC/') || file.includes('/apps/mobileAppYC/');
 const isFrontendPath = (file) =>
@@ -91,5 +100,5 @@ module.exports = {
     `prettier --write ${files.map(quote).join(' ')}`,
   ],
   '**/*.{js,jsx,ts,tsx,mjs,cjs,json,md,yml,yaml,env,txt,sh,swift,plist,properties,gradle,kt,kts,java,xml}':
-    (files) => [`secretlint --maskSecrets ${files.map(quote).join(' ')}`],
+    (files) => [`secretlint --maskSecrets ${files.map(globQuote).join(' ')}`],
 };


### PR DESCRIPTION
Two changes. The first is why the second could not be committed without it.

## 1. The pre-commit hook could not accept a Next.js route-path commit

A commit touching **only** files inside a route group or dynamic segment could not be made at all.

`secretlint` globs its own arguments, so the shell quoting in `lint-staged.config.cjs` was not enough. A path like:

```
apps/frontend/src/app/(routes)/(share)/passport/[id]/PassportClient.tsx
```

reaches secretlint's matcher as a **pattern**: `[id]` reads as a character class matching one of `i` or `d`, `(share)` as a group, and nothing matches the literal file.

This survived unnoticed because it only bites when **every** staged file sits under such a directory. Any commit that also touched a normal path had at least one argument resolve, so secretlint was satisfied. With a single route-path file it exits `Not found target files` and takes the whole hook down, and `--no-verify` is forbidden by CONTRIBUTING, so there was no way through.

Escapes glob metacharacters for the secretlint invocation only. `eslint` and `prettier` take their paths literally and keep plain quoting.

Verified both directions:

| invocation | result |
| --- | --- |
| unescaped `[id]` path | `Error: Not found target files` |
| escaped `\[id\]` path | exit 0 |

I hit this while making change 2, which touches exactly one file, inside `[id]`.

## 2. Passport theme toggle: `blur(24px)` to `blur(8px)`

The last React Doctor warning on the promotion diff (`no-large-animated-blur`), and the reason its score sat at **84/100**.

`backdrop-filter` cost scales with the radius, and this one sits on a `fixed` element, so it recomposites on every scroll of the public passport page - the surface most likely to be opened on a phone, by an owner or a border officer.

Why 8px is safe here rather than a judgement call:

- `blur(24px)` appears **exactly once** in the whole frontend, on this element. It is not a design-system value.
- There is no blur token; the codebase already uses `blur(8px)` in seven places.
- The button's background is `--glass-93`, which is 93% opaque, so almost none of the blur was visible through it at any radius.

## Validation

- React Doctor: `(routes)/(share)/passport` now scans **100 / 100**, was the one remaining warning on #2287.
- `pnpm --filter frontend run type-check` clean.
- 182 tests across 17 suites pass.
- Pre-commit hook exercised by this PR's own commit, which is the case that previously failed.

## Note

The commit carries both changes rather than being split. They landed together because the hook fix is what allowed the blur file to be staged at all, and separating them would leave a commit that cannot be checked out and committed on its own.