### PR TITLE
fix(lib): block prototype pollution via caller-controlled property names

### DIFF
--- a/apps/backend/test/utils/sanitize.test.ts
+++ b/apps/backend/test/utils/sanitize.test.ts
@@ -126,3 +126,51 @@ describe("Sanitize Utils", () => {
     });
   });
 });
+
+describe("sanitizeInput prototype pollution", () => {
+  afterEach(() => {
+    // Fail loudly if a test above actually polluted the global prototype.
+    delete (Object.prototype as Record<string, unknown>).polluted;
+  });
+
+  it("does not copy __proto__ from a JSON-parsed payload", () => {
+    // JSON.parse creates __proto__ as an OWN property, so Object.keys returns
+    // it. Assigning it onto a {} literal would invoke the prototype setter.
+    const payload = JSON.parse('{"__proto__":{"polluted":"yes"},"name":"ok"}');
+
+    const result = sanitizeInput(payload) as Record<string, unknown>;
+
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+    expect(result.name).toBe("ok");
+  });
+
+  it("drops constructor and prototype keys too", () => {
+    const payload = JSON.parse(
+      '{"constructor":{"x":1},"prototype":{"y":2},"keep":"z"}',
+    );
+
+    const result = sanitizeInput(payload) as Record<string, unknown>;
+
+    expect(Object.keys(result)).toEqual(["keep"]);
+  });
+
+  it("strips them at any nesting depth", () => {
+    const payload = JSON.parse(
+      '{"outer":{"__proto__":{"polluted":"yes"},"inner":"kept"}}',
+    );
+
+    const result = sanitizeInput(payload) as Record<
+      string,
+      Record<string, unknown>
+    >;
+
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    expect(Object.keys(result.outer)).toEqual(["inner"]);
+    // The load-bearing assertion. Without the guard, `sanitized["__proto__"] =`
+    // sets the inner object's PROTOTYPE rather than adding a key, so the
+    // Object.keys check above still reads ["inner"] and proves nothing.
+    expect(Object.getPrototypeOf(result.outer)).toBe(Object.prototype);
+    expect(result.outer.polluted).toBeUndefined();
+  });
+});

--- a/apps/frontend/src/app/__tests__/types/formPrototypePollution.test.ts
+++ b/apps/frontend/src/app/__tests__/types/formPrototypePollution.test.ts
@@ -46,3 +46,40 @@ describe('fromFHIRQuestionnaireResponse prototype pollution', () => {
     expect(Object.keys(submission.answers)).toEqual(['real']);
   });
 });
+
+describe('fromFHIRQuestionnaireResponse SAFE_LINK_ID allowlist', () => {
+  const withLinkId = (linkId: string) =>
+    JSON.parse(
+      JSON.stringify({
+        resourceType: 'QuestionnaireResponse',
+        status: 'completed',
+        item: [{ linkId, answer: [{ valueString: 'v' }] }],
+      })
+    );
+
+  // FHIR linkIds are frequently URL-ish or dotted, so the allowlist has to admit
+  // these or real questionnaires would silently lose answers.
+  it.each([
+    'simple',
+    'snake_case_is_fine_after_the_first_char',
+    'kebab-case',
+    'dotted.path.id',
+    'ns:scoped',
+    'http://example.org/Questionnaire/1#item',
+    'medications_med_12_price',
+    '0-leading-digit',
+  ])('accepts the legitimate linkId %s', (linkId) => {
+    const submission = fromFHIRQuestionnaireResponse(withLinkId(linkId));
+    expect(submission.answers[linkId]).toBe('v');
+  });
+
+  // Rejected because the first character class excludes `_`, which is what makes
+  // the regex reject __proto__ without needing a denylist.
+  it.each(['_leading-underscore', 'has space', 'bad id with spaces!', 'ünicode'])(
+    'rejects the malformed linkId %s',
+    (linkId) => {
+      const submission = fromFHIRQuestionnaireResponse(withLinkId(linkId));
+      expect(Object.keys(submission.answers)).toEqual([]);
+    }
+  );
+});

--- a/apps/frontend/src/app/__tests__/types/formPrototypePollution.test.ts
+++ b/apps/frontend/src/app/__tests__/types/formPrototypePollution.test.ts
@@ -1,0 +1,48 @@
+import { fromFHIRQuestionnaireResponse } from '@yosemite-crew/types';
+
+/**
+ * linkId comes from an externally submitted FHIR QuestionnaireResponse, so it
+ * reaches the answers object as a caller-chosen property name.
+ */
+describe('fromFHIRQuestionnaireResponse prototype pollution', () => {
+  afterEach(() => {
+    delete (Object.prototype as Record<string, unknown>).polluted;
+  });
+
+  /**
+   * The answer is a valueAttachment on purpose. answerToValue returns a plain
+   * STRING for valueString, and assigning a string to `__proto__` is a silent
+   * no-op in JS, so a string payload cannot demonstrate the bug. valueAttachment
+   * returns an object, which is what actually invokes the prototype setter.
+   */
+  const responseWith = (linkId: string) =>
+    JSON.parse(
+      JSON.stringify({
+        resourceType: 'QuestionnaireResponse',
+        status: 'completed',
+        item: [
+          {
+            linkId,
+            answer: [{ valueAttachment: { url: 'x', title: 'polluted' } }],
+          },
+          { linkId: 'real', answer: [{ valueString: 'kept' }] },
+        ],
+      })
+    );
+
+  it('ignores a __proto__ linkId instead of rewriting the prototype', () => {
+    const submission = fromFHIRQuestionnaireResponse(responseWith('__proto__'));
+
+    // The load-bearing assertion: without the guard the assignment invokes the
+    // prototype setter, so a key-count check alone would still look correct.
+    expect(Object.getPrototypeOf(submission.answers)).toBe(Object.prototype);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    expect(submission.answers.real).toBe('kept');
+  });
+
+  it.each(['constructor', 'prototype'])('ignores a %s linkId', (linkId) => {
+    const submission = fromFHIRQuestionnaireResponse(responseWith(linkId));
+
+    expect(Object.keys(submission.answers)).toEqual(['real']);
+  });
+});

--- a/packages/lib/src/utils/sanitize.ts
+++ b/packages/lib/src/utils/sanitize.ts
@@ -3,6 +3,18 @@ import validator from 'validator';
 
 const { escape, stripLow, trim } = validator;
 
+/**
+ * Keys that must never be copied from caller-supplied input onto a plain object.
+ *
+ * `JSON.parse('{"__proto__": {...}}')` produces an OWN property named
+ * `__proto__`, and `Object.keys` returns it. Assigning it back onto a `{}`
+ * literal invokes the prototype setter rather than creating a property, so a
+ * recursive copy that trusts its key list rewrites the prototype of the object
+ * it is building. Skipping is preferred over `Object.create(null)` here: the
+ * result is handed to callers that expect an ordinary object.
+ */
+const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
 export const sanitizeInput = (value: any): any => {
   if (typeof value === 'string') {
     return escape(stripLow(trim(value)));
@@ -13,6 +25,7 @@ export const sanitizeInput = (value: any): any => {
   if (typeof value === 'object' && value !== null) {
     const sanitized: Record<string, any> = {};
     for (const key of Object.keys(value)) {
+      if (UNSAFE_KEYS.has(key)) continue;
       sanitized[key] = sanitizeInput(value[key]);
     }
     return sanitized;

--- a/packages/lib/src/utils/sanitize.ts
+++ b/packages/lib/src/utils/sanitize.ts
@@ -23,12 +23,21 @@ export const sanitizeInput = (value: any): any => {
     return value.map((element) => sanitizeInput(element));
   }
   if (typeof value === 'object' && value !== null) {
-    const sanitized: Record<string, any> = {};
-    for (const key of Object.keys(value)) {
-      if (UNSAFE_KEYS.has(key)) continue;
-      sanitized[key] = sanitizeInput(value[key]);
-    }
-    return sanitized;
+    // Object.fromEntries uses CreateDataProperty, so it can never invoke the
+    // `__proto__` setter the way `obj[key] = ...` does. UNSAFE_KEYS still
+    // filters first, so the dangerous keys are dropped rather than relocated
+    // onto the result as own properties where a downstream Object.assign would
+    // re-arm them.
+    //
+    // Note for reviewers: this also removes the CodeQL sink, and the
+    // js/remote-property-injection alert on this line goes quiet because there
+    // is no longer a property write, NOT because the Set guard was recognised.
+    // A denylist is the wrong polarity for that query and never clears it.
+    return Object.fromEntries(
+      Object.keys(value)
+        .filter((key) => !UNSAFE_KEYS.has(key))
+        .map((key) => [key, sanitizeInput(value[key])])
+    );
   }
   return value;
 };

--- a/packages/types/src/form.ts
+++ b/packages/types/src/form.ts
@@ -818,7 +818,34 @@ const buildFieldLookup = (fields?: FormField[]): Record<string, FormField> => {
  * used as a property name unchecked: writing `__proto__` onto a `{}` literal
  * invokes the prototype setter instead of adding a key, which would let a
  * submitted questionnaire reshape the answers object every later reader sees.
+ *
+ * BOTH guards are load-bearing, for different reasons. Do not collapse them.
+ *
+ * SAFE_LINK_ID is an anchored, wildcard-free allowlist. Its first character
+ * class excludes `_`, so it rejects `__proto__` on its own, and it is the only
+ * shape CodeQL's js/remote-property-injection accepts as a sanitizer: every
+ * membership guard that query knows (Set.has, Array.includes, !==, switch,
+ * hasOwnProperty) blocks taint only in the branch where the test is TRUE, so a
+ * DENYLIST is always the wrong polarity and can never clear the alert. The
+ * anchors are mandatory, and `.`, `\w`, `\S` or any inverted class such as
+ * `[^_]` would disqualify the regex; keep it literal.
+ *
+ * UNSAFE_LINK_IDS still blocks `constructor` and `prototype`, which the regex
+ * admits. On a `{}` literal those two create ordinary own properties rather
+ * than replacing the prototype, so they are shadowing risks, not pollution,
+ * but no consumer of `answers` should have to defend against them.
+ *
+ * The TAIL class is deliberately wide. FHIR types linkId as a plain string, not
+ * an id, so implementers legitimately use URIs like
+ * `http://example.org/Questionnaire/1#item`. A tight class would silently drop
+ * those answers, and silent data loss on an inbound clinical payload is worse
+ * than a permissive tail: the anti-pollution property lives entirely in the
+ * FIRST class, which admits no `_`.
+ *
+ * Never add `_` to the first class "to be permissive": that silences CodeQL
+ * while re-admitting `__proto__`, which is the exact trap this shape avoids.
  */
+const SAFE_LINK_ID = /^[A-Za-z0-9][A-Za-z0-9._:/#?=&@~+,;%-]*$/;
 const UNSAFE_LINK_IDS = new Set(['__proto__', 'constructor', 'prototype']);
 
 const collectAnswersFromItems = (
@@ -830,7 +857,7 @@ const collectAnswersFromItems = (
     if (it.answer?.length) {
       const field = lookup[it.linkId];
       const val = answerToValue(it.answer, field);
-      if (val !== undefined && !UNSAFE_LINK_IDS.has(it.linkId)) {
+      if (val !== undefined && !UNSAFE_LINK_IDS.has(it.linkId) && SAFE_LINK_ID.test(it.linkId)) {
         acc[it.linkId] = val;
       }
     }

--- a/packages/types/src/form.ts
+++ b/packages/types/src/form.ts
@@ -67,12 +67,7 @@ export interface GroupField extends BaseField {
 }
 
 export type FormField =
-  | InputField
-  | ChoiceField
-  | BooleanField
-  | DateField
-  | SignatureField
-  | GroupField;
+  InputField | ChoiceField | BooleanField | DateField | SignatureField | GroupField;
 
 export interface FormSchema {
   fields: FormField[];
@@ -411,8 +406,7 @@ const getFormDateExtensionValue = (ex: Extension[] | undefined, url: string): st
 
 const parseFieldType = (item: QuestionnaireItem): FieldType => {
   const ext = getFieldExtension(item.extension, FIELD_TYPE_EXTENSION_URL)?.valueString as
-    | FieldType
-    | undefined;
+    FieldType | undefined;
 
   if (ext) return ext;
 
@@ -508,11 +502,9 @@ export const fromFHIRQuestionnaire = (q: Questionnaire): Form => {
     name: q.title || q.name || '',
     category: getFormExtensionValue(ex, FORM_CATEGORY_EXTENSION_URL) || q.code?.[0]?.code || '',
     businessType: getFormExtensionValue(ex, FORM_BUSINESS_TYPE_URL) as
-      | Form['businessType']
-      | undefined,
+      Form['businessType'] | undefined,
     requiredSigner: getFormExtensionValue(ex, FORM_REQUIRED_SIGNER_URL) as
-      | Form['requiredSigner']
-      | undefined,
+      Form['requiredSigner'] | undefined,
     description: q.description,
     visibilityType:
       (getFormExtensionValue(ex, FORM_VISIBILITY_URL) as Form['visibilityType']) || 'Internal',
@@ -821,6 +813,14 @@ const buildFieldLookup = (fields?: FormField[]): Record<string, FormField> => {
   return map;
 };
 
+/**
+ * linkId arrives from an external FHIR QuestionnaireResponse, so it cannot be
+ * used as a property name unchecked: writing `__proto__` onto a `{}` literal
+ * invokes the prototype setter instead of adding a key, which would let a
+ * submitted questionnaire reshape the answers object every later reader sees.
+ */
+const UNSAFE_LINK_IDS = new Set(['__proto__', 'constructor', 'prototype']);
+
 const collectAnswersFromItems = (
   items: QuestionnaireResponseItem[] | undefined,
   lookup: Record<string, FormField>,
@@ -830,7 +830,9 @@ const collectAnswersFromItems = (
     if (it.answer?.length) {
       const field = lookup[it.linkId];
       const val = answerToValue(it.answer, field);
-      if (val !== undefined) acc[it.linkId] = val;
+      if (val !== undefined && !UNSAFE_LINK_IDS.has(it.linkId)) {
+        acc[it.linkId] = val;
+      }
     }
     if (it.item?.length) collectAnswersFromItems(it.item, lookup, acc);
   });


### PR DESCRIPTION
Fixes the two real findings from the eleven high-severity CodeQL alerts blocking the dev-to-main promotion (#2287). The other nine are dismissed with reasoning; see the table at the bottom.

## The bug

Two places copy a caller-supplied string onto a plain object as a **property name**:

```ts
sanitized[key] = sanitizeInput(value[key])   // key from Object.keys(input)
acc[it.linkId] = val                         // linkId from a FHIR payload
```

`JSON.parse('{"__proto__":{...}}')` creates `__proto__` as an **own** property, so `Object.keys` returns it, and assigning it back onto a `{}` literal invokes the prototype setter rather than adding a key.

Both sit on external input: `sanitizeInput` runs over request bodies across the backend, and `fromFHIRQuestionnaireResponse` parses externally submitted QuestionnaireResponses. Both now skip `__proto__`, `constructor` and `prototype`.

## Severity note that changes how you should read `form.ts`

`answerToValue` returns a plain **string** for `valueString`, and assigning a string to `__proto__` is a silent no-op in JavaScript. The exploitable shape needs an **object-valued** answer, which `valueAttachment` produces:

```json
{ "linkId": "__proto__", "answer": [{ "valueAttachment": { "url": "x" } }] }
```

I mention it because my first test used `valueString` and **passed with the guard removed**. It proved nothing. The committed test uses `valueAttachment`.

The same trap caught the sanitize nesting test: it asserted `Object.keys(...)` on the inner object, which reads identically either way, because the polluting assignment adds no key at all. It now asserts the prototype directly.

## Validation

- **Mutation-checked, both.** Removing each guard fails all three of that guard's tests. Restored, green.
- Backend: 410 suites, 9708 tests.
- Frontend (`types/` + `form`): 71 suites, 1086 tests.
- `tsc` clean on backend and frontend.
- `packages/lib` rebuilt before running the backend suite, since the backend consumes it through `dist`.

## Disposition of all eleven alerts

| alert | rule | disposition |
| --- | --- | --- |
| 1308, 1309 | `js/remote-property-injection` | **Fixed here** |
| 1310-1313 | `js/insecure-temporary-file` | Dismissed, false positive. `os.tmpdir()` appears nowhere in `apps/desktop/src`; these write under Electron `userData`. |
| 1302, 1303 | `js/user-controlled-bypass` | Dismissed, false positive. The bypassed path returns a fixed `{status:'ok'}` literal; server binds `127.0.0.1`; strict equality so `/health?x=1` still needs the token. |
| 1304, 1305 | `js/file-system-race` | Dismissed, won't fix. Desktop backup stats-then-reads a zip it just wrote; the other is a build-time codegen script. No untrusted party in the window. |
| 1307 | `js/regex/missing-regexp-anchor` | Dismissed, used in tests. Test-only regex, never applied to a URL. |

Once this merges and CodeQL re-runs on `dev`, the high-severity count should reach zero and #2287 stops being blocked by the `code_scanning` rule.