### PR TITLE
fix(repo): clear the five Sonar issues blocking the promotion gate

### DIFF
--- a/apps/backend/src/services/template.service.ts
+++ b/apps/backend/src/services/template.service.ts
@@ -1299,9 +1299,12 @@ export const TemplateService = {
         }
       }
 
-      const bestMatch = matches.sort((left, right) =>
+      // Sort a copy: `matches` is reused below, and sorting in place made the
+      // ranking depend on how many times this ran.
+      const rankedMatches = [...matches].sort((left, right) =>
         compareResolverMatches(left.matched, right.matched),
-      )[0];
+      );
+      const bestMatch = rankedMatches[0];
 
       if (!bestMatch) {
         return null;

--- a/apps/backend/src/utils/escape-like.ts
+++ b/apps/backend/src/utils/escape-like.ts
@@ -20,7 +20,7 @@ export function escapeLikePattern(value: string): string {
     throw new TypeError("Expected a string");
   }
 
-  return value.replace(/[\\%_]/g, "\\$&");
+  return value.replace(/[\\%_]/g, String.raw`\$&`);
 }
 
 export default escapeLikePattern;

--- a/apps/frontend/src/app/features/forms/pages/Forms/index.tsx
+++ b/apps/frontend/src/app/features/forms/pages/Forms/index.tsx
@@ -147,7 +147,9 @@ const Forms = () => {
   }, [activeFormId, filteredList, formsById]);
 
   const serviceOptions = useMemo(() => {
-    const specialityNameById = new Map(
+    // Annotated: inferred from a string[][] the entries widen to any, so
+    // `.get()` came back as any and the label below stringified an object.
+    const specialityNameById = new Map<string, string>(
       orgSpecialities.map((speciality) => [
         String(speciality.id ?? ''),
         toPrimitiveString(speciality.name),

--- a/apps/mobileAppYC/__tests__/features/appointments/screens/ViewAppointmentScreen.test.tsx
+++ b/apps/mobileAppYC/__tests__/features/appointments/screens/ViewAppointmentScreen.test.tsx
@@ -682,6 +682,46 @@ describe('ViewAppointmentScreen', () => {
       ).toBe('—');
     });
 
+    it('survives hostile answer shapes instead of crashing the screen', () => {
+      // Answers are submitted data. Nesting deep enough to overflow the stack
+      // must truncate rather than throw.
+      let deepArray: any = ['leaf'];
+      for (let i = 0; i < 500; i += 1) {
+        deepArray = [deepArray];
+      }
+      expect(() =>
+        formatAppointmentFormValue(
+          {id: 'deep', type: 'text'} as any,
+          deepArray,
+        ),
+      ).not.toThrow();
+      expect(
+        formatAppointmentFormValue(
+          {id: 'deep', type: 'text'} as any,
+          deepArray,
+        ),
+      ).toBe('…');
+
+      // A circular object makes JSON.stringify throw, and this path now takes
+      // objects the old fallback never serialised.
+      const circular: any = {name: 'loop'};
+      circular.self = circular;
+      expect(() =>
+        formatAppointmentFormValue({id: 'circ', type: 'text'} as any, circular),
+      ).not.toThrow();
+      expect(
+        formatAppointmentFormValue({id: 'circ', type: 'text'} as any, circular),
+      ).toBe('…');
+
+      // The same guards apply on the raw-answer fallback path.
+      expect(() =>
+        getAppointmentFormAnswerRows({
+          form: {},
+          submission: {answers: {deep: deepArray, circ: circular}},
+        } as any),
+      ).not.toThrow();
+    });
+
     it('resolves appointment form actions for each form state', () => {
       expect(
         getAppointmentFormAction({

--- a/apps/mobileAppYC/__tests__/features/appointments/screens/ViewAppointmentScreen.test.tsx
+++ b/apps/mobileAppYC/__tests__/features/appointments/screens/ViewAppointmentScreen.test.tsx
@@ -827,6 +827,34 @@ describe('ViewAppointmentScreen', () => {
       ).toEqual([
         {id: 'extra_note', label: 'Extra note', value: 'Orphaned answer'},
       ]);
+
+      // Answers with no matching schema field go through the same formatter as
+      // the schema-driven rows. They used to be stringified with a template
+      // literal here, so an object answer reached the screen as
+      // "[object Object]" and an attachment lost its url.
+      expect(
+        getAppointmentFormAnswerRows({
+          form: {},
+          submission: {
+            answers: {
+              vitals: {weight: '12kg'},
+              attachment: {url: 'https://example.com/scan.pdf'},
+              tags: ['urgent', 'recheck'],
+              nested: [{a: 1}, 'plain'],
+              empty_list: [],
+            },
+          },
+        } as any),
+      ).toEqual([
+        {id: 'vitals', label: 'Vitals', value: '{"weight":"12kg"}'},
+        {
+          id: 'attachment',
+          label: 'Attachment',
+          value: 'https://example.com/scan.pdf',
+        },
+        {id: 'tags', label: 'Tags', value: 'urgent, recheck'},
+        {id: 'nested', label: 'Nested', value: '{"a":1}, plain'},
+      ]);
     });
   });
 

--- a/apps/mobileAppYC/__tests__/features/appointments/screens/ViewAppointmentScreen.test.tsx
+++ b/apps/mobileAppYC/__tests__/features/appointments/screens/ViewAppointmentScreen.test.tsx
@@ -665,6 +665,13 @@ describe('ViewAppointmentScreen', () => {
           foo: 'bar',
         }),
       ).toBe('{"foo":"bar"}');
+      // A non-string url is not a url. Coercing it would just print
+      // "[object Object]" one level down, so it serialises instead.
+      expect(
+        formatAppointmentFormValue({id: 'weird-url', type: 'file'} as any, {
+          url: {href: 'https://example.com/x.pdf'},
+        }),
+      ).toBe('{"url":{"href":"https://example.com/x.pdf"}}');
       expect(
         formatAppointmentFormValue({id: 'raw', type: 'text'} as any, 42),
       ).toBe('42');

--- a/apps/mobileAppYC/src/features/appointments/screens/ViewAppointmentScreen.helpers.ts
+++ b/apps/mobileAppYC/src/features/appointments/screens/ViewAppointmentScreen.helpers.ts
@@ -154,16 +154,28 @@ export const formatAppointmentDateTime = (apt: any) => {
  * array members keeps nested values readable instead of repeating that bug one
  * level down.
  */
-const formatAnswerValue = (value: unknown): string => {
+const MAX_ANSWER_DEPTH = 4;
+
+const formatAnswerValue = (value: unknown, depth = 0): string => {
   if (Array.isArray(value)) {
-    return value.map(item => formatAnswerValue(item)).join(', ');
+    if (depth >= MAX_ANSWER_DEPTH) {
+      return '…';
+    }
+    return value.map(item => formatAnswerValue(item, depth + 1)).join(', ');
   }
   if (typeof value === 'object' && value !== null) {
     const url = (value as {url?: unknown}).url;
     if (url) {
       return String(url);
     }
-    return JSON.stringify(value);
+    try {
+      // Answers are submitted data, so they can be circular or nested deeply
+      // enough to overflow the stack. JSON.stringify throws on both, and this
+      // path now takes objects the old fallback never passed to it.
+      return JSON.stringify(value) ?? '';
+    } catch {
+      return '…';
+    }
   }
   return String(value);
 };

--- a/apps/mobileAppYC/src/features/appointments/screens/ViewAppointmentScreen.helpers.ts
+++ b/apps/mobileAppYC/src/features/appointments/screens/ViewAppointmentScreen.helpers.ts
@@ -145,6 +145,29 @@ export const formatAppointmentDateTime = (apt: any) => {
   return {dateTimeLabel};
 };
 
+/**
+ * Render one answer value as text.
+ *
+ * Shared by the schema-driven rows and the raw-answer fallback below. Both used
+ * to stringify independently and the fallback did it with a template literal,
+ * so an object answer reached the screen as "[object Object]". Recursing for
+ * array members keeps nested values readable instead of repeating that bug one
+ * level down.
+ */
+const formatAnswerValue = (value: unknown): string => {
+  if (Array.isArray(value)) {
+    return value.map(item => formatAnswerValue(item)).join(', ');
+  }
+  if (typeof value === 'object' && value !== null) {
+    const url = (value as {url?: unknown}).url;
+    if (url) {
+      return String(url);
+    }
+    return JSON.stringify(value);
+  }
+  return String(value);
+};
+
 export const formatAppointmentFormValue = (
   field: FormField,
   value: any,
@@ -162,16 +185,7 @@ export const formatAppointmentFormValue = (
   if (field.type === 'richtext') {
     return stripHtmlToPlainText(value) || '—';
   }
-  if (Array.isArray(value)) {
-    return value.map(v => `${v}`).join(', ') || '—';
-  }
-  if (typeof value === 'object') {
-    if ('url' in value && value.url) {
-      return String(value.url);
-    }
-    return JSON.stringify(value);
-  }
-  return `${value}`;
+  return formatAnswerValue(value) || '—';
 };
 
 export const getAppointmentFormAction = (
@@ -239,16 +253,18 @@ export const getAppointmentFormAnswerRows = (
       fieldTypeById.get(key) === 'richtext' && typeof val === 'string'
         ? stripHtmlToPlainText(val)
         : val;
-    return resolvedVal !== undefined &&
-      resolvedVal !== null &&
-      `${resolvedVal}`.trim() !== ''
-      ? [
+    if (resolvedVal === undefined || resolvedVal === null) {
+      return [];
+    }
+    const text = formatAnswerValue(resolvedVal);
+    return text.trim() === ''
+      ? []
+      : [
           {
             id: key,
             label: capitalize(key.replaceAll('_', ' ')),
-            value: `${resolvedVal}`,
+            value: text,
           },
-        ]
-      : [];
+        ];
   });
 };

--- a/apps/mobileAppYC/src/features/appointments/screens/ViewAppointmentScreen.helpers.ts
+++ b/apps/mobileAppYC/src/features/appointments/screens/ViewAppointmentScreen.helpers.ts
@@ -164,9 +164,12 @@ const formatAnswerValue = (value: unknown, depth = 0): string => {
     return value.map(item => formatAnswerValue(item, depth + 1)).join(', ');
   }
   if (typeof value === 'object' && value !== null) {
+    // Only a string url is a url. Coercing an arbitrary value here just moved
+    // the "[object Object]" one level down, which is what this whole change
+    // set out to remove; anything else falls through to the serialiser below.
     const url = (value as {url?: unknown}).url;
-    if (url) {
-      return String(url);
+    if (typeof url === 'string' && url !== '') {
+      return url;
     }
     try {
       // Answers are submitted data, so they can be circular or nested deeply


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

The push of #2287 to `main` turned CI red. Three Sonar legs failed - backend, frontend and mobile - and with them `CI Required`.

The bar in `scripts/ci/sonar-thresholds.mjs` holds every leg to 95% coverage, zero duplication and zero open issues. Coverage and duplication were already met everywhere:

| project | coverage | duplication | violations |
| --- | --- | --- | --- |
| Backend | 96.2% | 0.0% | **2** |
| Frontend | 97.8% | 0.0% | **1** |
| MobileAppYC | 98.1% | 0.0% | **2** |
| Desktop | 96.4% | 0.0% | 0 |

So the failure was entirely the `--issues 0` floor: five open issues, all introduced by the 265 commits in the promotion. Desktop was already clean and is untouched here.

One of the five is a real user-visible bug rather than a style nit, described below.

## What is the new behavior?

**Backend**

- `escape-like.ts` (`typescript:S7780`) used `"\\$&"` as the replacement string. Now `String.raw` \`\$&\`, which produces the identical three characters. Verified against the previous implementation over ten inputs including `100%`, `a_c`, `Jean-Luc` and `a%b_c\d`: zero differences, and a deliberately wrong implementation differs, so the comparison actually bites.
- `template.service.ts` (`typescript:S4043`) sorted `matches` in place and read `[0]` off the result. `matches` is used again afterwards, so the ranking depended on how many times the block had already run. It now sorts a copy in its own statement.

**Frontend**

- `Forms/index.tsx` (`typescript:S6551`): the speciality `Map` was built from a `string[][]` rather than tuples, so the entries widened to `any` and `.get()` returned `any`, which is why the label was flagged as stringifying an object. Annotating it `Map<string, string>` restores the real type.

**Mobile - this one is an actual bug**

- `ViewAppointmentScreen.helpers.ts` (`typescript:S6551` x2): the raw-answer fallback stringified with a template literal, while the schema-driven rows went through `formatAppointmentFormValue`, which already handles arrays, `{url}` attachments and plain objects. An answer with no matching schema field therefore reached the screen as `[object Object]`, and an attachment lost its url entirely.

  Both paths now share one `formatAnswerValue` helper, which recurses into arrays so nested values do not reproduce the same bug one level down. `formatAppointmentFormValue` delegates to it, removing the duplicated conversion.

## Impact area

`apps/backend`, `apps/frontend`, `apps/mobileAppYC`. No schema, API surface, or auth changes. The only behaviour change a user can see is the mobile fix: object and array answers now render their contents instead of `[object Object]`.

Note `formatAppointmentFormValue('')` now returns `'—'` where it returned `''`. Its single production call site filters both values identically (`r.value !== '—' && r.value !== ''`), so nothing downstream changes.

## Validation performed

- Frontend: `type-check` clean, `eslint` clean on the touched file, **645 tests across 40 suites pass**
- Backend: **87 tests across 3 suites pass** (`escape-like`, `template.service`)
- Mobile: **103 tests pass**, `eslint` clean on both touched files
- Backend `type-check` and `eslint` counts are identical to `dev` (412 type errors, 294 lint problems). Both are pre-existing and caused by unbuilt workspace packages in a fresh worktree; the one apparently new type error is the same error shifted from line 1465 to 1468 by the three lines this PR adds.
- Mutation check on the mobile fix: restoring the old template-literal stringification turns the new test red, and restoring the fix makes all 103 pass again.

## Related Issue(s)

No tracking issue - this unblocks the `dev` to `main` promotion, which is currently red on `CI Required`.
