### PR TITLE
test(frontend): draw the 93 remaining gated surfaces, and fix the blank bar charts

### DIFF
--- a/apps/frontend/src/app/(routes)/(public)/accessibility/report/AccessibilityReportClient.stories.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/accessibility/report/AccessibilityReportClient.stories.tsx
@@ -1,0 +1,428 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import { AxiosError } from 'axios';
+import type { AxiosAdapter, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+
+import api from '@/app/services/axios';
+import AccessibilityReportClient from './AccessibilityReportClient';
+
+/**
+ * Not a credential. The form collects a reporter's name and a reply-to address,
+ * so the fixture is a plainly fictional person on example.org - there is no
+ * password field on this page and nothing here should ever read as a login pair.
+ */
+const REPORTER = {
+  name: 'Rowan Petit',
+  email: 'rowan.petit@example.org',
+  description:
+    'The appointment calendar cannot be reached with a keyboard: Tab skips the day cells and lands on the next-week button.',
+};
+
+/**
+ * The submit outcome is routed by the value in the "Page or URL" field, not by
+ * which story installed a stub last.
+ *
+ * There is one shared axios instance and Autodocs mounts every story on this
+ * page against it at once, so per-story adapters race: whichever installed last
+ * wins, and a teardown can restore another story's stub instead of the real
+ * adapter. Keying on the request body makes every installed adapter behave
+ * identically, which is what makes the order stop mattering.
+ */
+const PAGE_URL = {
+  accepted: 'https://app.yosemitecrew.com/appointments',
+  rejected: 'https://app.yosemitecrew.com/inventory',
+};
+
+const REJECTION_MESSAGE = 'Report intake is offline for maintenance. Please email us directly.';
+
+const REAL_ADAPTER = api.defaults.adapter;
+
+const readBody = (config: InternalAxiosRequestConfig): string =>
+  typeof config.data === 'string' ? config.data : JSON.stringify(config.data ?? {});
+
+const reportAdapter: AxiosAdapter = async (config) => {
+  const url = String(config.url ?? '');
+  if (!url.includes('/v1/contact-us/contact-web')) {
+    throw new Error(`Unstubbed request in AccessibilityReportClient.stories: ${url}`);
+  }
+
+  const ok: AxiosResponse = {
+    data: { status: 'ok' },
+    status: 200,
+    statusText: 'OK',
+    headers: {},
+    config,
+  };
+
+  if (!readBody(config).includes(PAGE_URL.rejected)) return ok;
+
+  /* A real AxiosError, not a bare Error: the catch arm reads
+     `err.response?.data?.message` behind `axios.isAxiosError`, and a plain Error
+     falls through to the generic "Failed to submit report. Please try emailing us
+     directly." copy instead - so a bare rejection would draw a different branch
+     than the one this story claims to draw. 503 is not auto-retried either; the
+     response interceptor only retries idempotent methods, and this is a POST. */
+  const response: AxiosResponse = {
+    data: { message: REJECTION_MESSAGE },
+    status: 503,
+    statusText: 'Service Unavailable',
+    headers: {},
+    config,
+  };
+  throw new AxiosError(
+    'Request failed with status code 503',
+    'ERR_BAD_RESPONSE',
+    config,
+    {},
+    response
+  );
+};
+
+/**
+ * Restores the REAL adapter rather than "whatever was there before", so two
+ * overlapping stories cannot leave the stub permanently installed.
+ */
+const stubReportEndpoint = () => {
+  api.defaults.adapter = reportAdapter;
+  return () => {
+    api.defaults.adapter = REAL_ADAPTER;
+  };
+};
+
+/**
+ * The shared `Footer` at the bottom of this page asks openstatus.dev for the
+ * platform status on mount. Left alone, every snapshot of this form depends on a
+ * third-party request.
+ */
+const stubPlatformStatus = () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    if (String(input).includes('openstatus.dev')) {
+      return Promise.resolve(
+        new Response(JSON.stringify({ status: 'operational' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      );
+    }
+    return original.call(globalThis, input, init);
+  }) as typeof globalThis.fetch;
+
+  return () => {
+    globalThis.fetch = original;
+  };
+};
+
+/**
+ * The summary block and each field's inline message are BOTH `role="alert"`
+ * (FormInput.tsx:80), so `getByRole('alert')` is ambiguous the moment a submit
+ * fails. Anchoring on the summary's own heading is the only unambiguous handle.
+ */
+const errorSummary = (canvasElement: HTMLElement): HTMLElement =>
+  within(canvasElement)
+    .getByRole('heading', { name: 'Please fix the following errors:' })
+    .closest('[role="alert"]') as HTMLElement;
+
+const summaryItems = (canvasElement: HTMLElement): string[] =>
+  within(errorSummary(canvasElement))
+    .getAllByRole('listitem')
+    .map((item) => item.textContent ?? '');
+
+const submit = (canvasElement: HTMLElement) =>
+  userEvent.click(within(canvasElement).getByRole('button', { name: 'Submit report' }));
+
+/**
+ * Submit, then wait for the summary to exist before any synchronous read of it.
+ * `submit` resolves when the click is dispatched, which is not the same instant
+ * React has committed `setErrors`, and every helper below is a `getBy` that
+ * would throw on the frame in between.
+ */
+const submitAndWaitForSummary = async (canvasElement: HTMLElement) => {
+  await submit(canvasElement);
+  await within(canvasElement).findByRole('heading', {
+    name: 'Please fix the following errors:',
+  });
+};
+
+const fillReport = async (canvasElement: HTMLElement, pageUrl: string) => {
+  const canvas = within(canvasElement);
+  await userEvent.type(canvas.getByRole('textbox', { name: 'Your name *' }), REPORTER.name);
+  await userEvent.type(canvas.getByRole('textbox', { name: 'Email address *' }), REPORTER.email);
+  await userEvent.type(
+    canvas.getByRole('textbox', { name: 'Page or URL where you encountered the barrier' }),
+    pageUrl
+  );
+  await userEvent.type(
+    canvas.getByRole('textbox', { name: 'Describe the barrier *' }),
+    REPORTER.description
+  );
+};
+
+const meta = {
+  title: 'Public/AccessibilityReport',
+  component: AccessibilityReportClient,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The public "report an accessibility barrier" form. Two of its three states existed ' +
+          'only behind a submit and had never been drawn: the **error summary** and the ' +
+          '**confirmation panel**.\n\n' +
+          'That is a poor thing to leave undrawn on this page in particular. The summary is the ' +
+          'WCAG 3.3.1 affordance - a `role="alert"` block, headed "Please fix the following ' +
+          'errors:", listing every failure in field order, and wired to the form through ' +
+          '`aria-describedby` so a screen reader hears it when focus returns to the form. The ' +
+          'wiring is conditional (`hasErrors ? errorSummaryId : undefined`) and there was no ' +
+          'story in which it was ever true.\n\n' +
+          'The one trap to know before writing queries here: **both the summary and each ' +
+          'field\'s inline message carry `role="alert"`**, so after a failed submit the page has ' +
+          "three or four of them. `getByRole('alert')` throws, and `getAllByRole('alert')[0]` " +
+          'is a coin flip. Everything below anchors on the summary heading instead.\n\n' +
+          'The confirmation panel is a `<output aria-live="polite">` pinned to ' +
+          '`data-yc-surface="light"`. That pin is load-bearing rather than decorative: the card ' +
+          'is a literal `bg-white` in both themes, so without it the themed `--ink-body` ' +
+          '(#e6ddd0 in dark) put the heading, the body copy and both links at 1.34:1 - white on ' +
+          'white, and the whole confirmation read as blank. Flip the theme toolbar on the ' +
+          'submitted story to check it still holds.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  beforeEach: stubPlatformStatus,
+} satisfies Meta<typeof AccessibilityReportClient>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Form: Story = {
+  name: 'Empty form',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Nothing is announced before a submit: no summary, and the form describes nothing.
+    await expect(
+      canvas.queryByRole('heading', { name: 'Please fix the following errors:' })
+    ).not.toBeInTheDocument();
+    const form = canvasElement.querySelector('form') as HTMLFormElement;
+    await expect(form).not.toHaveAttribute('aria-describedby');
+
+    /* The four text fields in page order, by accessible name. A bare count of 4
+       would pass with two fields swapped or a required marker dropped, and the
+       asterisk is the only thing distinguishing a required field here - the form
+       is `noValidate`, so `required` on the input announces nothing and never
+       blocks a submit. The severity control is a dropdown, not a textbox, which
+       is why it is absent from this list. */
+    await expect(
+      canvas.getAllByRole('textbox').map((field) => field.getAttribute('aria-label'))
+    ).toEqual([
+      'Your name *',
+      'Email address *',
+      'Page or URL where you encountered the barrier',
+      'Describe the barrier *',
+    ]);
+    await expect(canvas.getByRole('button', { name: 'Submit report' })).toBeEnabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting state. The form is `noValidate`, so the browser bubble never appears and ' +
+          'every message on this page comes from `validate()` - which is why the summary below ' +
+          'is the whole error affordance rather than a supplement to a native one.',
+      },
+    },
+  },
+};
+
+export const ErrorSummary: Story = {
+  name: 'Error summary after an empty submit',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await submitAndWaitForSummary(canvasElement);
+
+    const summary = errorSummary(canvasElement);
+    await expect(summaryItems(canvasElement)).toEqual([
+      'Your name is required.',
+      'Your email address is required.',
+      'Please describe the barrier you encountered.',
+    ]);
+
+    /* The wiring, not just the block. `aria-describedby` is applied only while
+       `hasErrors`, so this attribute is the entire reason a screen reader hears
+       the summary when focus goes back to the form. */
+    const form = canvasElement.querySelector('form') as HTMLFormElement;
+    await expect(form.getAttribute('aria-describedby')).toBe(summary.id);
+    await expect(summary.getAttribute('aria-labelledby')).toBe(`${summary.id}-title`);
+
+    // Each failing field is marked too, and the optional URL field is not.
+    await expect(canvas.getByRole('textbox', { name: 'Your name *' })).toHaveAttribute(
+      'aria-invalid',
+      'true'
+    );
+    await expect(
+      canvas.getByRole('textbox', { name: 'Page or URL where you encountered the barrier' })
+    ).toHaveAttribute('aria-invalid', 'false');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Submitting an empty form. The three bullets are emitted in field order rather than in ' +
+          'the order the checks ran, so the list reads down the page - which is what makes it ' +
+          'usable as a jump list rather than an unordered pile.',
+      },
+    },
+  },
+};
+
+export const InvalidEmail: Story = {
+  name: 'Email that fails the pattern',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.type(canvas.getByRole('textbox', { name: 'Your name *' }), REPORTER.name);
+    await userEvent.type(canvas.getByRole('textbox', { name: 'Email address *' }), 'rowan@local');
+    await userEvent.type(
+      canvas.getByRole('textbox', { name: 'Describe the barrier *' }),
+      REPORTER.description
+    );
+    await submitAndWaitForSummary(canvasElement);
+
+    // One bullet only, and it is the pattern message rather than the missing-value one.
+    await expect(summaryItems(canvasElement)).toEqual(['Enter a valid email address.']);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The email field has two distinct failures and the summary must not conflate them: ' +
+          'empty says "is required", present-but-malformed says "Enter a valid email address". ' +
+          '`rowan@local` has no dot in the domain, which is what the pattern rejects.',
+      },
+    },
+  },
+};
+
+export const ErrorsClearAsYouType: Story = {
+  name: 'A fixed field leaves the summary',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await submitAndWaitForSummary(canvasElement);
+    await expect(summaryItems(canvasElement)).toHaveLength(3);
+
+    await userEvent.type(canvas.getByRole('textbox', { name: 'Your name *' }), REPORTER.name);
+
+    // The name bullet goes on the first keystroke; the other two stay until fixed.
+    await waitFor(() => expect(summaryItems(canvasElement)).toHaveLength(2));
+    await expect(summaryItems(canvasElement)).toEqual([
+      'Your email address is required.',
+      'Please describe the barrier you encountered.',
+    ]);
+    await expect(canvas.getByRole('textbox', { name: 'Your name *' })).toHaveAttribute(
+      'aria-invalid',
+      'false'
+    );
+
+    // Fix the rest and the block unmounts, taking the form's description with it.
+    await userEvent.type(canvas.getByRole('textbox', { name: 'Email address *' }), REPORTER.email);
+    await userEvent.type(
+      canvas.getByRole('textbox', { name: 'Describe the barrier *' }),
+      REPORTER.description
+    );
+    await waitFor(() =>
+      expect(
+        canvas.queryByRole('heading', { name: 'Please fix the following errors:' })
+      ).not.toBeInTheDocument()
+    );
+    const form = canvasElement.querySelector('form') as HTMLFormElement;
+    await expect(form).not.toHaveAttribute('aria-describedby');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Errors are cleared per field on change, so the summary shrinks as the form is ' +
+          'corrected rather than waiting for the next submit. The last bullet leaving takes the ' +
+          'whole block with it - `hasErrors` gates both the block and the `aria-describedby`, so ' +
+          'the form is never left pointing at an element that no longer exists.',
+      },
+    },
+  },
+};
+
+export const SubmitRejected: Story = {
+  name: 'Server rejects the report',
+  beforeEach: stubReportEndpoint,
+  play: async ({ canvasElement }) => {
+    await fillReport(canvasElement, PAGE_URL.rejected);
+    await submit(canvasElement);
+
+    // The server message joins the same summary as a validation bullet would.
+    await waitFor(() => expect(summaryItems(canvasElement)).toEqual([REJECTION_MESSAGE]));
+    const form = canvasElement.querySelector('form') as HTMLFormElement;
+    await expect(form.getAttribute('aria-describedby')).toBe(errorSummary(canvasElement).id);
+
+    // The form is still there with the answers intact - nothing is retyped to retry.
+    await expect(within(canvasElement).getByRole('textbox', { name: 'Your name *' })).toHaveValue(
+      REPORTER.name
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A 503 from `/v1/contact-us/contact-web`. The submit failure reuses the validation ' +
+          'summary rather than getting its own banner, so a reporter who has already fixed three ' +
+          'fields is not sent hunting for a second error region.\n\n' +
+          'The message shown is the API’s own `response.data.message`. A transport failure with ' +
+          'no response body falls back to "Failed to submit report. Please try emailing us ' +
+          'directly." - which is the branch that matters most on this page, since the whole ' +
+          'point of the form is reaching someone.',
+      },
+    },
+  },
+};
+
+export const Submitted: Story = {
+  name: 'Confirmation panel',
+  beforeEach: stubReportEndpoint,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await fillReport(canvasElement, PAGE_URL.accepted);
+    await submit(canvasElement);
+
+    /* `<output>` has an implicit role of "status", and nothing else on this page
+       (the Footer included) claims that role - so this is an unambiguous handle
+       for the panel that replaced the form. */
+    const panel = await canvas.findByRole('status');
+    await expect(panel).toHaveAttribute('aria-live', 'polite');
+    await expect(panel).toHaveAttribute('data-yc-surface', 'light');
+
+    const inPanel = within(panel);
+    await expect(
+      inPanel.getByRole('heading', { name: 'Thank you for your report' })
+    ).toBeInTheDocument();
+    await expect(
+      inPanel.getByRole('link', { name: 'accessibility@yosemitecrew.com' })
+    ).toHaveAttribute('href', 'mailto:accessibility@yosemitecrew.com');
+    await expect(
+      inPanel.getByRole('link', { name: 'Back to Accessibility Statement' })
+    ).toHaveAttribute('href', '/accessibility');
+
+    // The form is replaced, not hidden behind the panel.
+    await expect(canvasElement.querySelector('form')).toBeNull();
+    await expect(canvas.queryByRole('textbox')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The state after a successful post. It is the only place the 5-business-day promise and ' +
+          'the direct mailbox appear, and it is a dead end by design - the form is gone, so a ' +
+          'second report means navigating back.\n\n' +
+          'Worth flipping the theme toolbar on: the card is `bg-white` in both themes and every ' +
+          'ink inside it is pinned by `data-yc-surface="light"`. Without that pin the dark theme ' +
+          'renders this panel as an empty white rectangle.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/components/AppointmentBoard.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/AppointmentBoard.stories.tsx
@@ -1,0 +1,371 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import type { Appointment } from '@yosemite-crew/types';
+
+import type { Team } from '@/app/features/organization/types/team';
+import { useAuthStore } from '@/app/stores/authStore';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useTeamStore } from '@/app/stores/teamStore';
+import AppointmentBoard from './AppointmentBoard';
+
+const ORG_ID = 'org-storybook-board';
+/** Not a credential: an opaque app user id, the value `authStore.attributes.sub` holds. */
+const CURRENT_USER_ID = 'user-storybook-lead';
+const OTHER_LEAD_ID = 'vet-nadia';
+
+/**
+ * The board keeps only appointments whose start instant falls on `currentDate`
+ * IN THE PREFERRED TIME ZONE, which defaults to Europe/Berlin and is not the
+ * machine's zone. Fixtures are therefore fixed UTC instants that land mid-morning
+ * in Berlin, so the same cards appear on a laptop in Berlin, Bengaluru or
+ * California instead of the board silently emptying itself on one of them.
+ */
+const CURRENT_DATE = new Date('2026-03-12T11:00:00.000Z');
+
+const appointment = (over: Partial<Appointment> & { id: string }): Appointment => ({
+  patient: {
+    id: 'companion-1',
+    name: 'Poppy',
+    species: 'dog',
+    breed: 'Beagle',
+    parent: { id: 'parent-1', name: 'Lena Hartmann' },
+  },
+  lead: { id: CURRENT_USER_ID, name: 'Dr. Weber' },
+  appointmentType: {
+    id: 'type-1',
+    name: 'Annual check-up',
+    speciality: { id: 'spec-1', name: 'General practice' },
+  },
+  organisationId: ORG_ID,
+  appointmentDate: new Date('2026-03-12T09:30:00.000Z'),
+  startTime: new Date('2026-03-12T09:30:00.000Z'),
+  endTime: new Date('2026-03-12T10:00:00.000Z'),
+  timeSlot: '10:30 - 11:00',
+  durationMinutes: 30,
+  status: 'UPCOMING',
+  ...over,
+});
+
+const APPOINTMENTS: Appointment[] = [
+  appointment({ id: 'appt-1' }),
+  appointment({
+    id: 'appt-2',
+    patient: {
+      id: 'companion-2',
+      name: 'Mochi',
+      species: 'cat',
+      breed: 'Ragdoll',
+      parent: { id: 'parent-2', name: 'Tomas Ruiz' },
+    },
+    startTime: new Date('2026-03-12T10:00:00.000Z'),
+    endTime: new Date('2026-03-12T10:30:00.000Z'),
+    timeSlot: '11:00 - 11:30',
+  }),
+  appointment({
+    id: 'appt-3',
+    status: 'CHECKED_IN',
+    lead: { id: OTHER_LEAD_ID, name: 'Dr. Nadia Iqbal' },
+    patient: {
+      id: 'companion-3',
+      name: 'Bruno',
+      species: 'dog',
+      breed: 'Boxer',
+      parent: { id: 'parent-3', name: 'Ines Fabre' },
+    },
+    startTime: new Date('2026-03-12T10:30:00.000Z'),
+    endTime: new Date('2026-03-12T11:15:00.000Z'),
+    timeSlot: '11:30 - 12:15',
+    durationMinutes: 45,
+  }),
+];
+
+/** Exactly the member `currentUserLeadId` resolves to, so "Mine" is not always empty. */
+const TEAM_MEMBER: Team = {
+  _id: 'team-1',
+  practionerId: CURRENT_USER_ID,
+  organisationId: ORG_ID,
+  name: 'Dr. Weber',
+  role: 'VETERINARIAN',
+  speciality: [],
+  status: 'Available',
+  revokedPermissions: [],
+  effectivePermissions: [],
+  extraPerissions: [],
+};
+
+/**
+ * Seeds the three stores the board reads and restores them on unmount.
+ *
+ * Nothing here fetches: `useTeamForPrimaryOrg` and `useInvoicesForPrimaryOrg` are
+ * pure selectors over their stores - the loaders are separate hooks the board never
+ * calls - so seeding is the whole setup, with no service stub and the real component
+ * under review.
+ */
+const seed = () => {
+  const orgSnapshot = useOrgStore.getState();
+  const teamSnapshot = useTeamStore.getState();
+  const authSnapshot = useAuthStore.getState();
+
+  useOrgStore.setState({
+    primaryOrgId: ORG_ID,
+    orgsById: { [ORG_ID]: { _id: ORG_ID, type: 'HOSPITAL' } as never },
+    status: 'loaded',
+  });
+  useTeamStore.setState({
+    teamsById: { 'team-1': TEAM_MEMBER },
+    teamIdsByOrgId: { [ORG_ID]: ['team-1'] },
+    status: 'loaded',
+  });
+  useAuthStore.setState({ attributes: { sub: CURRENT_USER_ID } });
+
+  return () => {
+    useOrgStore.setState(orgSnapshot);
+    useTeamStore.setState(teamSnapshot);
+    useAuthStore.setState(authSnapshot);
+  };
+};
+
+/** The seven column roots, in render order. */
+const getColumns = (canvasElement: HTMLElement): HTMLElement[] => {
+  const scroller = canvasElement.querySelector('[data-board-scroll-root="true"]');
+  const track = scroller?.firstElementChild;
+  return [...(track?.children ?? [])] as HTMLElement[];
+};
+
+/** The count chip in a column header - the number beside the status label. */
+const getColumnCount = (column: HTMLElement): string =>
+  column.firstElementChild?.firstElementChild?.lastElementChild?.textContent?.trim() ?? '';
+
+/**
+ * The card titles the board renders. `AppointmentCardContent` composes the
+ * companion name with the owner's LAST name (`Poppy · Hartmann`), so a query for
+ * the bare fixture name matches nothing - and, worse, a loose regex would match
+ * the preview decorator's sr-only <h1> instead and pass with the card missing.
+ */
+const CARD_TITLES = {
+  poppy: 'Poppy · Hartmann',
+  mochi: 'Mochi · Ruiz',
+  bruno: 'Bruno · Fabre',
+};
+
+const COLUMN_LABELS = [
+  'Requested',
+  'Upcoming',
+  'Checked in',
+  'In progress',
+  'Completed',
+  'Cancelled',
+  'No show',
+];
+
+const meta = {
+  title: 'Appointments/AppointmentBoard',
+  component: AppointmentBoard,
+  parameters: {
+    layout: 'fullscreen',
+    // The card rail pushes into the workspace with next/navigation's router.
+    nextjs: { appDirectory: true },
+    docs: {
+      description: {
+        component:
+          'The seven-column status board behind /appointments. Its card and its toolbar each ' +
+          'had a story; the board that arranges them did not, so one branch of `BoardColumn` ' +
+          'had never been drawn: what a column looks like with nothing in it.\n\n' +
+          'That state is not exotic. Five of the seven columns are empty on an ordinary morning, ' +
+          'and the **Mine** scope toggle in the toolbar can empty all seven at once - it filters ' +
+          'on `appointment.lead.id` against the signed-in user resolved through the team list, ' +
+          'so anyone without a practitioner row (a receptionist, say) presses it and watches the ' +
+          'whole board go blank. Two dashed affordances carry that state: a centred ' +
+          '"No appointments" plate, and an `mt-auto` "Add" button that only exists with ' +
+          '`canEditAppointments`. Both are dashed on purpose - they are placeholders, not cards ' +
+          '- and neither had any snapshot coverage.\n\n' +
+          'The filter is why these stories seed `authStore` and `teamStore` rather than passing ' +
+          'a prop: `currentUserLeadId` is derived by matching `attributes.sub` against five ' +
+          'different id fields on each team member, so a story that skipped the team seed would ' +
+          'render an always-empty board and prove nothing about the toggle.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    appointments: APPOINTMENTS,
+    currentDate: CURRENT_DATE,
+    setCurrentDate: fn(),
+    canEditAppointments: true,
+    setActiveAppointment: fn(),
+    setViewPopup: fn(),
+    setDetailPopup: fn(),
+    setViewIntent: fn(),
+    onAddAppointment: fn(),
+    activeFilter: 'all',
+    setActiveFilter: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <div className="h-[720px] bg-[var(--screen)] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+  beforeEach: seed,
+} satisfies Meta<typeof AppointmentBoard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Populated: Story = {
+  name: 'Board with cards',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(await canvas.findByText(CARD_TITLES.poppy)).toBeInTheDocument();
+
+    const columns = getColumns(canvasElement);
+    await expect(columns).toHaveLength(7);
+    COLUMN_LABELS.forEach((label, index) => {
+      expect(within(columns[index]).getByText(label)).toBeInTheDocument();
+    });
+
+    // Upcoming holds two of the three fixtures and Checked in holds the third; the
+    // count chip and the cards have to agree, since a filter bug that dropped cards
+    // would leave the chip still reading 2.
+    await expect(getColumnCount(columns[1])).toBe('2');
+    await expect(within(columns[1]).getByText(CARD_TITLES.poppy)).toBeInTheDocument();
+    await expect(within(columns[1]).getByText(CARD_TITLES.mochi)).toBeInTheDocument();
+    await expect(getColumnCount(columns[2])).toBe('1');
+    await expect(within(columns[2]).getByText(CARD_TITLES.bruno)).toBeInTheDocument();
+
+    // The other five columns are the empty branch.
+    await expect(canvas.getAllByText('No appointments')).toHaveLength(5);
+    await expect(within(columns[1]).queryByText('No appointments')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting board. Columns are fixed 300px panes below md and 320px from md up, so ' +
+          'the row scrolls horizontally rather than compressing the cards - and five of the ' +
+          'seven are already showing the placeholder.',
+      },
+    },
+  },
+};
+
+export const MineOnlyFiltersOtherLeads: Story = {
+  name: 'Mine-only scope - other leads drop out',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(await canvas.findByText(CARD_TITLES.bruno)).toBeInTheDocument();
+
+    // Bruno is led by another vet; Poppy and Mochi are led by the signed-in user.
+    await userEvent.click(canvas.getByRole('button', { name: 'Show my appointments' }));
+
+    await waitFor(() => {
+      expect(canvas.queryByText(CARD_TITLES.bruno)).not.toBeInTheDocument();
+    });
+    await expect(canvas.getByText(CARD_TITLES.poppy)).toBeInTheDocument();
+
+    // Checked in emptied; Upcoming kept both. The placeholder count moves with it.
+    const columns = getColumns(canvasElement);
+    await expect(getColumnCount(columns[2])).toBe('0');
+    await expect(within(columns[2]).getByText('No appointments')).toBeInTheDocument();
+    await expect(getColumnCount(columns[1])).toBe('2');
+    await expect(canvas.getAllByText('No appointments')).toHaveLength(6);
+
+    // The toggle relabels rather than only restyling, so the pressed state is
+    // announced and not carried by the track colour alone.
+    await expect(canvas.getByRole('button', { name: 'Show all appointments' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'One column crossing from populated to empty. This is the transition the placeholder ' +
+          'exists for, and the only story in which the plate replaces cards rather than ' +
+          'starting there.',
+      },
+    },
+  },
+};
+
+export const MineOnlyEmptiesEveryColumn: Story = {
+  name: 'Mine-only scope - every column empty',
+  // A signed-in user with no practitioner row on this team: `currentUserLeadId`
+  // resolves to '' and no appointment can match it. Receptionists sit exactly here.
+  beforeEach: () => {
+    useAuthStore.setState({ attributes: { sub: 'user-not-on-this-team' } });
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(await canvas.findByText(CARD_TITLES.poppy)).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Show my appointments' }));
+
+    const plates = await canvas.findAllByText('No appointments');
+    await expect(plates).toHaveLength(7);
+    await expect(canvas.queryByText(CARD_TITLES.poppy)).not.toBeInTheDocument();
+
+    const columns = getColumns(canvasElement);
+    await expect(columns.map(getColumnCount)).toEqual(['0', '0', '0', '0', '0', '0', '0']);
+
+    // The plate is a dashed placeholder, not a card: no fill of its own, and the
+    // dashed edge is the only thing separating the two at a glance.
+    await expect(getComputedStyle(plates[0]).borderStyle).toBe('dashed');
+
+    // The Add affordance sits under the plate in every column and is also dashed.
+    const addButtons = canvas.getAllByRole('button', { name: /^Add appointment to / });
+    await expect(addButtons).toHaveLength(7);
+    await expect(addButtons.map((button) => button.textContent?.trim())).toEqual(
+      Array.from({ length: 7 }, () => 'Add')
+    );
+    await expect(getComputedStyle(addButtons[0]).borderStyle).toBe('dashed');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Every column at once. Worth looking at because it is the only time all seven dashed ' +
+          'plates and all seven dashed Add buttons are on screen together, and the two use ' +
+          'different radii (13px and 11px) and different borders (`--card-border` and ' +
+          '`--divider`) despite reading as a pair.',
+      },
+    },
+  },
+};
+
+export const EmptyWithoutEditPermission: Story = {
+  name: 'Empty columns, read-only',
+  args: { appointments: [], canEditAppointments: false },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(await canvas.findAllByText('No appointments')).toHaveLength(7);
+    // The Add affordance is gated on canEditAppointments, so a read-only board shows
+    // the plate alone - the empty column has two distinct looks, not one.
+    await expect(canvas.queryAllByRole('button', { name: /^Add appointment to / })).toHaveLength(0);
+    await expect(canvas.queryByRole('button', { name: 'New appointment' })).not.toBeInTheDocument();
+
+    /* One plate per column rather than seven somewhere. A layout bug that stacked all
+       seven into one column would satisfy the count above and nothing else here. Every
+       header still shows its label and a zero chip, so the columns are present and
+       empty rather than missing. */
+    const columns = getColumns(canvasElement);
+    await expect(columns).toHaveLength(7);
+    columns.forEach((column, index) => {
+      expect(within(column).getAllByText('No appointments')).toHaveLength(1);
+      expect(within(column).getByText(COLUMN_LABELS[index])).toBeInTheDocument();
+    });
+    await expect(columns.map(getColumnCount)).toEqual(['0', '0', '0', '0', '0', '0', '0']);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same empty columns without appointment-edit rights. The dashed Add button and ' +
+          'the toolbar CTA both disappear, leaving the plate as the only thing in the column - ' +
+          'the layout the `mt-auto` on the Add button was written for and never checked against.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/components/Calendar/PhoneTaskDayList.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/PhoneTaskDayList.stories.tsx
@@ -1,0 +1,286 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import PhoneTaskDayList from './PhoneTaskDayList';
+import type { Task } from '@/app/features/tasks/types/task';
+
+const ORG_ID = 'org-storybook';
+const ME = 'vet-weber';
+
+/**
+ * Instants are UTC and sit in the middle of the working day on purpose. Every
+ * bucket rule in `buildTaskDayList` compares date keys in the PREFERRED zone
+ * (Europe/Berlin by default, +2 in July), never the browser's, so a 07:00-15:00 UTC
+ * fixture keeps its day whatever machine renders it - and the rendered clock times
+ * below are the Berlin ones, two hours on.
+ */
+const NOW = new Date('2026-07-14T09:20:00.000Z');
+const ANCHOR = new Date('2026-07-14T12:00:00.000Z');
+
+const MEMBER_NAMES: Record<string, string> = {
+  [ME]: 'Dr. Elena Weber',
+  'vet-osei': 'Dr. Ama Osei',
+  'parent-hartmann': 'Lena Hartmann',
+};
+
+const task = (over: Partial<Task> & Pick<Task, '_id' | 'name' | 'dueAt'>): Task => ({
+  organisationId: ORG_ID,
+  assignedTo: ME,
+  audience: 'EMPLOYEE_TASK',
+  source: 'CUSTOM',
+  category: 'GENERAL',
+  status: 'PENDING',
+  ...over,
+});
+
+/** Due 09:00 Berlin, 2h20 before `NOW` - the overdue bucket. */
+const OVERDUE_MINE = task({
+  _id: 't-overdue',
+  name: 'Chase Bruno’s haematology result',
+  dueAt: new Date('2026-07-14T07:00:00.000Z'),
+  companionId: 'companion-bruno',
+});
+
+/** Due 16:00 Berlin, assigned to someone else - visible on Everyone, not on My board. */
+const TODAY_OTHER = task({
+  _id: 't-today',
+  name: 'Restock consult 2 sharps bin',
+  dueAt: new Date('2026-07-14T14:00:00.000Z'),
+  assignedTo: 'vet-osei',
+  status: 'IN_PROGRESS',
+});
+
+/** Two days out - the rolling six-day "Later this week" window. */
+const LATER_MINE = task({
+  _id: 't-later',
+  name: 'Post-op call, Juno',
+  dueAt: new Date('2026-07-16T08:00:00.000Z'),
+});
+
+/** A PARENT_TASK: never on Everyone or My board, only on Parents. */
+const PARENT_TASK = task({
+  _id: 't-parent',
+  name: 'Send Poppy’s discharge instructions',
+  dueAt: new Date('2026-07-14T15:00:00.000Z'),
+  audience: 'PARENT_TASK',
+  assignedTo: 'parent-hartmann',
+  companionId: 'companion-poppy',
+});
+
+const STAFF_TASKS: Task[] = [OVERDUE_MINE, TODAY_OTHER, LATER_MINE];
+const ALL_TASKS: Task[] = [...STAFF_TASKS, PARENT_TASK];
+
+const getScopePill = (canvasElement: HTMLElement) =>
+  within(canvasElement).getByRole('group', { name: 'Task board scope' });
+
+const getTaskRows = (canvasElement: HTMLElement): HTMLElement[] =>
+  Array.from(canvasElement.querySelectorAll<HTMLElement>('[data-testid^="phone-task-"]'));
+
+const meta = {
+  title: 'Appointments/Calendar/PhoneTaskDayList',
+  component: PhoneTaskDayList,
+  // A 375px phone. Pinned as a GLOBAL: `parameters.viewport.defaultViewport` was
+  // removed in Storybook 10 and is inert, so the old spelling renders desktop
+  // markup under a name that promises a phone.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The tasks planner below 768px: a time grid cannot shrink, so the phone gets a ' +
+          'thumb-checkable day list bucketed into Overdue / Today / Later this week.\n\n' +
+          'The **scope filter** is the part no static render reaches. `scope` is component-local ' +
+          'state, seeded to `everyone` and never lifted, so a story that only mounts the component ' +
+          'draws one of its three boards and the other two have never been seen. The segments are ' +
+          'not cosmetic either - each is backed by a real field, `audience` for Parents and ' +
+          '`assignedTo` for My board, and the parents board is DISJOINT from the other two rather ' +
+          'than a subset of them. A parent task is invisible on Everyone, which is the sort of ' +
+          'rule that reads as a bug the first time a receptionist hits it.\n\n' +
+          'Because the filter runs before the bucketing, it can also empty the list on its own: ' +
+          'switching to Parents on a day with no parent tasks produces "No tasks due in this ' +
+          'window." with the day itself unchanged. That empty branch and the boards behind the ' +
+          'other two segments are what these stories draw.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    tasks: ALL_TASKS,
+    currentDate: ANCHOR,
+    setCurrentDate: fn(),
+    canEditTasks: true,
+    currentUserId: ME,
+    now: NOW,
+    resolveDisplayName: (memberId?: string) => MEMBER_NAMES[memberId ?? ''] ?? '',
+    companionNameById: {
+      'companion-bruno': 'Bruno',
+      'companion-poppy': 'Poppy',
+    },
+    onToggleTask: fn(),
+    onViewTask: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <div className="h-[720px] w-full bg-[var(--screen)]">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof PhoneTaskDayList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Everyone: Story = {
+  name: 'Everyone (default scope)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // `everyone` is the seeded scope, and it means every EMPLOYEE task - the parent
+    // task in the fixture is not counted, not merely not listed.
+    const everyone = within(getScopePill(canvasElement)).getByRole('button', { name: 'Everyone' });
+    await expect(everyone).toHaveAttribute('aria-pressed', 'true');
+    await expect(canvas.getByRole('heading', { level: 2 })).toHaveTextContent('Tasks (3)');
+    await expect(getTaskRows(canvasElement)).toHaveLength(3);
+
+    /* All three buckets at once, each heading carrying its own count. Only non-empty
+       buckets render, so this is also the only arrangement that proves the ordering
+       overdue -> today -> later rather than insertion order. */
+    await expect(canvas.getByText('Overdue · 1')).toBeInTheDocument();
+    await expect(canvas.getByText('Today · 1')).toBeInTheDocument();
+    await expect(canvas.getByText('Later this week · 1')).toBeInTheDocument();
+
+    /* The overdue subtitle is three derived parts joined, and every one of them can be
+       wrong independently: the due time is formatted in the preferred zone (09:00
+       Berlin from 07:00 UTC), the lateness is floored to whole hours, and the assignee
+       collapses to "you" rather than repeating the signed-in vet's own name. */
+    await expect(canvas.getByText('Due 09:00 · 2 hr overdue · you')).toBeInTheDocument();
+    await expect(canvas.getByText('Due 16:00 · Dr. Ama Osei')).toBeInTheDocument();
+
+    await expect(canvas.queryByText('Send Poppy’s discharge instructions')).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The board as it mounts. Three buckets, one row each, and the overdue row carries the ' +
+          'danger left-edge and red subtitle that the other two do not.',
+      },
+    },
+  },
+};
+
+export const MyBoard: Story = {
+  name: 'My board (scope switched)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const pill = within(getScopePill(canvasElement));
+
+    await userEvent.click(pill.getByRole('button', { name: 'My board' }));
+
+    // The pressed state moves with the selection - the pill is the only indication
+    // that the list has been narrowed, so it has to be right.
+    await expect(pill.getByRole('button', { name: 'My board' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    await expect(pill.getByRole('button', { name: 'Everyone' })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+
+    /* Osei's task is gone and the header count follows it down: the count is derived
+       from the SCOPED list, not the prop, so a filter that failed to reach the header
+       would show "Tasks (3)" over two rows. */
+    await expect(canvas.getByRole('heading', { level: 2 })).toHaveTextContent('Tasks (2)');
+    await expect(getTaskRows(canvasElement)).toHaveLength(2);
+    await expect(canvas.queryByText('Restock consult 2 sharps bin')).toBeNull();
+    await expect(canvas.getByText('Chase Bruno’s haematology result')).toBeInTheDocument();
+    await expect(canvas.getByText('Post-op call, Juno')).toBeInTheDocument();
+
+    // The Today bucket emptied out, so its heading is gone rather than showing "· 0".
+    await expect(canvas.queryByText('Today · 0')).toBeNull();
+    await expect(canvas.getByText('Overdue · 1')).toBeInTheDocument();
+    await expect(canvas.getByText('Later this week · 1')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Narrowed to the signed-in vet by `assignedTo`. The middle bucket disappears entirely ' +
+          'rather than rendering an empty heading, which is why the group list is built from ' +
+          'non-empty buckets rather than from a fixed three.',
+      },
+    },
+  },
+};
+
+export const Parents: Story = {
+  name: 'Parents (disjoint board)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const pill = within(getScopePill(canvasElement));
+
+    await userEvent.click(pill.getByRole('button', { name: 'Parents' }));
+
+    await expect(canvas.getByRole('heading', { level: 2 })).toHaveTextContent('Tasks (1)');
+    const rows = getTaskRows(canvasElement);
+    await expect(rows).toHaveLength(1);
+    await expect(canvas.getByText('Send Poppy’s discharge instructions')).toBeInTheDocument();
+
+    /* Everything from the other two boards is gone - Parents is a different audience,
+       not a narrower slice of the same one. The companion initial is still resolved
+       from `companionNameById`, so the row keeps its "P" avatar. */
+    await expect(canvas.queryByText('Chase Bruno’s haematology result')).toBeNull();
+    await expect(canvas.getByTitle('Poppy')).toHaveTextContent('P');
+    await expect(canvas.getByText('Today · 1')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The parent-facing board. `audience === PARENT_TASK` is the whole rule, so this list and ' +
+          'the two staff lists never share a row - a point worth seeing rather than reading, ' +
+          'because the segmented control reads like three filters over one set.',
+      },
+    },
+  },
+};
+
+export const FilteredToEmpty: Story = {
+  name: 'Filtered to empty',
+  args: { tasks: STAFF_TASKS },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const pill = within(getScopePill(canvasElement));
+
+    // Three staff tasks on the day, none of them parent-facing.
+    await expect(getTaskRows(canvasElement)).toHaveLength(3);
+
+    await userEvent.click(pill.getByRole('button', { name: 'Parents' }));
+
+    await expect(canvas.getByText('No tasks due in this window.')).toBeInTheDocument();
+    await expect(getTaskRows(canvasElement)).toHaveLength(0);
+    await expect(canvas.getByRole('heading', { level: 2 })).toHaveTextContent('Tasks (0)');
+
+    /* The day navigation and the scope pill survive the empty state - without them the
+       screen would be a dead end, and the way out of this particular emptiness is the
+       filter, not a different day. */
+    await expect(pill.getByRole('button', { name: 'Everyone' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Next day' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Today' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The empty branch, reached the way a user actually reaches it: a real day with real ' +
+          'tasks on it, filtered to a segment that holds none. The copy says "in this window" ' +
+          'rather than "no tasks" because the list is bounded on both ends - a settled task from ' +
+          'last week and anything past the six-day horizon are dropped as well, and neither is a ' +
+          'reason to think the day is clear.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/TaskSlot.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/TaskSlot.stories.tsx
@@ -1,0 +1,315 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fireEvent, fn, within } from 'storybook/test';
+
+import TaskSlot from './TaskSlot';
+import type { Task } from '@/app/features/tasks/types/task';
+
+const ORG_ID = 'org-storybook';
+
+/** The 10:00 row of the tasks week grid, zoomed in: 180px an hour, so 3px a minute. */
+const HOUR = 10;
+const HOUR_HEIGHT = 180;
+const ZOOM_OUT_HOUR_HEIGHT = 34;
+const DROP_DATE = new Date('2026-07-14T00:00:00.000Z');
+
+const task = (id: string, name: string, minuteOfHour: number): Task => ({
+  _id: id,
+  organisationId: ORG_ID,
+  assignedTo: 'vet-weber',
+  audience: 'EMPLOYEE_TASK',
+  source: 'CUSTOM',
+  category: 'GENERAL',
+  status: 'PENDING',
+  name,
+  // Only the MINUTE within the hour positions a chip, and every timezone this app
+  // supports is a whole-hour offset, so the chip lands on the same pixel everywhere.
+  dueAt: new Date(`2026-07-14T10:${String(minuteOfHour).padStart(2, '0')}:00.000Z`),
+});
+
+const SLOT_TASKS: Task[] = [task('task-1', 'Bruno · fluids rate check', 20)];
+
+const DRAG_LABEL = 'Juno · post-op observations';
+
+const getSlotSection = (canvasElement: HTMLElement): HTMLElement =>
+  canvasElement.querySelector('section[aria-label^="Tasks slot"]') as HTMLElement;
+
+/** The band uses an arbitrary-value class, so it is matched on the token substring. */
+const getAvailabilityBands = (canvasElement: HTMLElement): HTMLElement[] =>
+  Array.from(
+    canvasElement.querySelectorAll<HTMLElement>('[class*="calendar-availability-overlay"]')
+  );
+
+const offsetFromSlotTop = (canvasElement: HTMLElement, el: HTMLElement): number =>
+  el.getBoundingClientRect().top - getSlotSection(canvasElement).getBoundingClientRect().top;
+
+const meta = {
+  title: 'Appointments/Calendar/TaskSlot',
+  component: TaskSlot,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'One hour cell of the tasks planner, and the `TaskDropOverlays` layer it mounts only ' +
+          'while a task is being dragged.\n\n' +
+          'The whole layer is behind `{draggedTaskId && ...}`, so it has no resting render at all: ' +
+          'no snapshot, unit test or Chromatic frame has ever contained a droppable band or the ' +
+          'preview ghost that names the task in flight. It is also a near-copy of the appointment ' +
+          "calendar's equivalent with quietly different constants - a 6px minimum band against " +
+          "Slot's 4px, a 12px minimum ghost against `DropPreviewOverlay`'s 14px, and no clamp to " +
+          'the end of the hour on the ghost at all. Two calendars, two sets of numbers, one ' +
+          'gesture; the only way to see them disagree is to draw both.\n\n' +
+          'As in the appointment grid, the band is the availability interval clipped to this hour ' +
+          "with its foot extended by the dragged task's duration - a task may legally START at " +
+          'the last open minute. That is why an interval belonging to the hour ABOVE still paints ' +
+          'inside this cell.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    slotEvents: SLOT_TASKS,
+    height: HOUR_HEIGHT,
+    hour: HOUR,
+    dayIndex: 0,
+    length: 6,
+    dropDate: DROP_DATE,
+    zoomMode: 'in',
+    permissions: { canEditTasks: true },
+    draggedTaskDurationMinutes: 30,
+    handleViewTask: fn(),
+    handleChangeStatusTask: fn(),
+    handleRescheduleTask: fn(),
+    canDragTask: () => true,
+    onTaskDragStart: fn(),
+    onTaskDragEnd: fn(),
+    onTaskDropAt: fn(),
+    onDragHoverTarget: fn(),
+    resolveDisplayName: () => 'Dr. Elena Weber',
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[260px] bg-[var(--screen)]">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof TaskSlot>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Resting: Story = {
+  name: 'Resting (no drag)',
+  args: {
+    dropAvailabilityIntervals: [{ startMinute: 615, endMinute: 645 }],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* The chip sits at its due minute: 10:20 is a third down a 180px row, so 60px.
+       Its height is not the 30-minute block (90px) but 88px - the block minus the
+       2px the layout takes back so consecutive chips do not touch. Both numbers are
+       the baseline the overlay geometry below is read against. */
+    const chipLabel = canvas.getByText('Bruno · fluids rate check');
+    const chip = chipLabel.closest('.absolute') as HTMLElement;
+    await expect(offsetFromSlotTop(canvasElement, chip)).toBeCloseTo(60, 0);
+    await expect(chip.getBoundingClientRect().height).toBeCloseTo(88, 0);
+
+    // The due time is rendered in the preferred zone (10:20 UTC is 12:20 Berlin).
+    // Matched on a prefix because the AM/PM separator Intl emits is a narrow
+    // no-break space, not the space this file could type.
+    await expect(canvas.getByText(/^Due: 12:20/)).toBeInTheDocument();
+
+    /* Two controls: the chip itself and the hover-revealed "View task" shortcut that
+       sits on top of it. The shortcut is always in the tree at opacity 0, so it is
+       reachable by keyboard even when the pointer never arrives. */
+    await expect(canvas.getAllByRole('button')).toHaveLength(2);
+    await expect(chipLabel.closest('button')).toHaveAttribute('draggable', 'true');
+    await expect(canvas.getByRole('button', { name: 'View task' })).toBeInTheDocument();
+
+    // The drop affordance is not drawn. Availability is already supplied here and
+    // still paints nothing, which is the gate this file exists to document.
+    await expect(getAvailabilityBands(canvasElement)).toHaveLength(0);
+    await expect(canvasElement.querySelector('.border-dashed')).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The cell as every existing frame holds it: a 10:20 task chip in the 10:00 row, no ' +
+          'overlays. Everything below differs from this by one prop.',
+      },
+    },
+  },
+};
+
+export const DragInFlight: Story = {
+  name: 'Drag in flight (band clipped to the hour)',
+  args: {
+    draggedTaskId: 'task-2',
+    draggedTaskLabel: DRAG_LABEL,
+    dropAvailabilityIntervals: [{ startMinute: 615, endMinute: 645 }],
+  },
+  play: async ({ canvasElement }) => {
+    const bands = getAvailabilityBands(canvasElement);
+    await expect(bands).toHaveLength(1);
+
+    // 10:15 is a quarter down a 180px row.
+    await expect(offsetFromSlotTop(canvasElement, bands[0])).toBeCloseTo(45, 0);
+    /* The interval closes at 10:45, but a 30-minute task starting at 10:45 is legal,
+       so the foot runs to 11:15 and is clipped at the hour: 135px, not the 90px the
+       interval alone would give. A band that stopped at the interval end would tell
+       the nurse they cannot drop at 10:45, when they can. */
+    await expect(bands[0].getBoundingClientRect().height).toBeCloseTo(135, 0);
+    // Nothing has hovered the cell yet, so there is no landing ghost.
+    await expect(canvasElement.querySelector('.border-dashed')).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A task is in flight over a cell open 10:15-10:45. The band starts at the interval and ' +
+          'runs to the end of the hour, because the dragged duration is added to the interval ' +
+          'foot before the clip.',
+      },
+    },
+  },
+};
+
+export const SpilloverFromPreviousHour: Story = {
+  name: 'Drag in flight (spill from the hour above)',
+  args: {
+    draggedTaskId: 'task-2',
+    draggedTaskLabel: DRAG_LABEL,
+    dropAvailabilityIntervals: [{ startMinute: 540, endMinute: 585 }],
+  },
+  play: async ({ canvasElement }) => {
+    const bands = getAvailabilityBands(canvasElement);
+    /* The interval is 09:00-09:45 and this is the 10:00 cell, so on a naive reading
+       nothing should paint here. It does, correctly: a 30-minute task dropped at 09:45
+       runs to 10:15, so the first quarter of this hour is a valid landing zone. Drop
+       the `+ duration` term and this band vanishes with no test noticing. */
+    await expect(bands).toHaveLength(1);
+    await expect(offsetFromSlotTop(canvasElement, bands[0])).toBeCloseTo(0, 0);
+    await expect(bands[0].getBoundingClientRect().height).toBeCloseTo(45, 0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The least obvious branch, and the reason segments are computed per cell rather than ' +
+          'sliced from the day: an availability interval that closes in the PREVIOUS hour still ' +
+          'paints a band at the top of this one.',
+      },
+    },
+  },
+};
+
+export const DropPreviewGhost: Story = {
+  name: 'Drop preview ghost (drag over 10:30)',
+  args: {
+    draggedTaskId: 'task-2',
+    draggedTaskLabel: DRAG_LABEL,
+    dropAvailabilityIntervals: [{ startMinute: 615, endMinute: 645 }],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const section = getSlotSection(canvasElement);
+    const rect = section.getBoundingClientRect();
+
+    /* The minute is derived from the pointer's ratio down the cell's own rect, so the
+       pointer is placed by that ratio rather than a raw pixel. Dispatched here, above
+       any `waitFor`: a dispatch inside a retried callback re-queues on every mutation
+       and wedges the tab instead of failing. */
+    fireEvent.dragOver(section, {
+      clientX: rect.left + rect.width / 2,
+      clientY: rect.top + rect.height / 2,
+    });
+
+    const label = await canvas.findByText(DRAG_LABEL);
+    const band = label.parentElement as HTMLElement;
+    const anchor = band.parentElement as HTMLElement;
+
+    // 10:30 falls inside 10:15-10:45, so `calcNearestAvailableMinute` returns it
+    // unchanged and the ghost sits on the half-hour rule: 90px of 180px.
+    await expect(offsetFromSlotTop(canvasElement, anchor)).toBeCloseTo(90, 0);
+    // 30 minutes at 3px a minute. Note there is no clamp to the end of the hour here,
+    // unlike the appointment calendar's ghost - a 45-minute task dropped at :45 would
+    // hang over the row below.
+    await expect(band.getBoundingClientRect().height).toBeCloseTo(90, 0);
+    await expect(getComputedStyle(band).borderTopStyle).toBe('dashed');
+    // The band stays underneath; the ghost is added to it, not swapped in.
+    await expect(getAvailabilityBands(canvasElement)).toHaveLength(1);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Both drag layers at once, which is the state the nurse actually sees: the solid band ' +
+          'says where a drop is allowed, the dashed ghost says where THIS drop would land, and it ' +
+          "carries the dragged task's own label so the two can be told apart mid-gesture.\n\n" +
+          'The minute is snapped through `calcNearestAvailableMinute`, which rounds to five and ' +
+          'then pulls to the nearest interval within a 12-minute tolerance. Drag further than ' +
+          'that from anything open and no ghost draws at all - the gesture simply refuses, with ' +
+          'no message.',
+      },
+    },
+  },
+};
+
+export const ZoomedOutGhost: Story = {
+  name: 'Zoomed out ghost (12px floor, fallback label)',
+  args: {
+    zoomMode: 'out',
+    height: ZOOM_OUT_HOUR_HEIGHT,
+    slotEvents: [],
+    draggedTaskId: 'task-2',
+    draggedTaskLabel: null,
+    draggedTaskDurationMinutes: 5,
+    dropAvailabilityIntervals: [{ startMinute: 600, endMinute: 660 }],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const section = getSlotSection(canvasElement);
+    const rect = section.getBoundingClientRect();
+
+    fireEvent.dragOver(section, {
+      clientX: rect.left + rect.width / 2,
+      clientY: rect.top + rect.height / 2,
+    });
+
+    // A drag with no label falls back to the bare word "Task" rather than an
+    // unidentifiable dashed box. Exact string: the preview decorator's sr-only <h1>
+    // reads "Appointments/Calendar/TaskSlot - Zoomed out ghost (12px floor, fallback
+    // label)", which a loose regex would match instead.
+    const label = await canvas.findByText('Task');
+    const band = label.parentElement as HTMLElement;
+
+    /* 5 minutes on a 34px hour is 2.8px, so the 12px floor takes over - the ghost is
+       more than a third of the row it sits in, four times the time it represents.
+       That is deliberate (a 3px band is invisible) but it is only defensible while
+       someone has seen it, which no frame ever had. */
+    await expect(band.getBoundingClientRect().height).toBeCloseTo(12, 0);
+    await expect(offsetFromSlotTop(canvasElement, band.parentElement as HTMLElement)).toBeCloseTo(
+      17,
+      0
+    );
+    // The band under it fills the whole zoomed-out hour, so the two are almost the
+    // same size - the visual distinction rests entirely on the dashed outline.
+    const bands = getAvailabilityBands(canvasElement);
+    await expect(bands).toHaveLength(1);
+    await expect(bands[0].getBoundingClientRect().height).toBeCloseTo(34, 0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same gesture in the zoomed-out planner, where an hour is 34px. Two things only ' +
+          "visible here: the ghost's 12px height floor, which at this zoom overstates a " +
+          "5-minute task by a factor of four, and the `|| 'Task'` fallback for a drag that " +
+          'carries no label.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/AppointmentPopover.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/AppointmentPopover.stories.tsx
@@ -1,0 +1,683 @@
+import { useId, useRef } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+import type { Appointment, Invoice, Organisation } from '@yosemite-crew/types';
+
+import type { StoredCompanion } from '@/app/features/companions/pages/Companions/types';
+import {
+  closeGlassTooltip,
+  openGlassTooltip,
+} from '@/app/ui/primitives/GlassTooltip/storyInteractions';
+import { formatDateInPreferredTimeZone } from '@/app/lib/timezone';
+import { useCompanionStore } from '@/app/stores/companionStore';
+import { useOrgStore } from '@/app/stores/orgStore';
+import AppointmentPopover from './AppointmentPopover';
+import { getCompanionAge } from './appointmentPopoverHelpers';
+
+const ORG_ID = 'org-storybook';
+const APPOINTMENT_ID = 'appt-popover-1';
+const COMPANION_ID = 'companion-poppy';
+
+const COMPANION_REF: Appointment['patient'] = {
+  id: COMPANION_ID,
+  name: 'Poppy',
+  species: 'dog',
+  breed: 'Beagle',
+  parent: { id: 'parent-maya', name: 'Maya Whitfield' },
+};
+
+/**
+ * The booking payload carries a name, a species and a breed and nothing else about
+ * the animal. Age, sex, neuter status and weight all come from the companion store,
+ * and the popover merges the two - which is why the subline is a store question,
+ * not a props question.
+ */
+const STORE_COMPANION: StoredCompanion = {
+  id: COMPANION_ID,
+  organisationId: ORG_ID,
+  parentId: 'parent-maya',
+  name: 'Poppy',
+  type: 'dog',
+  breed: 'Beagle',
+  dateOfBirth: new Date('2021-06-04T00:00:00.000Z'),
+  gender: 'male',
+  isneutered: true,
+  currentWeight: 12,
+  isInsured: false,
+  status: 'active',
+};
+
+/**
+ * Only `type` is ever read here - it picks "Medical Records" over "Care" for the
+ * clinical-notes label and intent - so the org is asserted through `unknown`
+ * rather than filled out with two dozen irrelevant fields.
+ */
+const HOSPITAL = {
+  _id: ORG_ID,
+  name: 'Avenger Park Veterinary',
+  type: 'HOSPITAL',
+} as unknown as Organisation;
+
+const APPOINTMENT: Appointment = {
+  id: APPOINTMENT_ID,
+  patient: COMPANION_REF,
+  companion: COMPANION_REF,
+  organisationId: ORG_ID,
+  lead: { id: 'practitioner-elena', name: 'Dr. Elena Marsh' },
+  supportStaff: [
+    { id: 'nurse-tom', name: 'Tom Reyes' },
+    { id: 'nurse-priya', name: 'Priya Raman' },
+  ],
+  room: { id: 'room-consult-2', name: 'Consult 2' },
+  appointmentType: {
+    id: 'svc-dental-consult',
+    name: 'Dental consultation',
+    speciality: { id: 'spec-dentistry', name: 'Dentistry' },
+  },
+  // Named explicitly. `resolveEncounterMode` falls back to "a room is assigned,
+  // therefore inpatient", so leaving this off changes the mode pill AND the Room
+  // cell's label - see the "Room implies inpatient" story.
+  appointmentKind: 'OUTPATIENT',
+  appointmentDate: new Date('2026-03-12T09:30:00.000Z'),
+  startTime: new Date('2026-03-12T09:30:00.000Z'),
+  endTime: new Date('2026-03-12T10:00:00.000Z'),
+  timeSlot: '09:30 - 10:00',
+  durationMinutes: 30,
+  status: 'UPCOMING',
+  concern: 'Post-op recheck of the left carpus, plus a nail trim if she tolerates it',
+};
+
+const withAppointment = (patch: Partial<Appointment>): Appointment => ({
+  ...APPOINTMENT,
+  ...patch,
+});
+
+const UNPAID_INVOICE: Invoice = {
+  id: 'inv-popover-1',
+  organisationId: ORG_ID,
+  appointmentId: APPOINTMENT_ID,
+  items: [
+    { name: 'Dental consultation', quantity: 1, unitPrice: 72, total: 72 },
+    { name: 'Full mouth radiograph', quantity: 1, unitPrice: 112, total: 112 },
+  ],
+  subtotal: 184,
+  totalAmount: 184,
+  paymentCollectionMethod: 'PAYMENT_LINK',
+  currency: 'USD',
+  status: 'AWAITING_PAYMENT',
+  createdAt: new Date('2026-03-12T10:05:00.000Z'),
+  updatedAt: new Date('2026-03-12T10:05:00.000Z'),
+};
+
+/**
+ * The two cells whose copy is produced by a formatter rather than written down.
+ * Composed with the app's own formatter rather than hardcoded as "10:30 AM":
+ * `getPreferredTimeZone` reads a localStorage token, so a reviewer who changed the
+ * timezone anywhere else in this Storybook would fail a literal string for a reason
+ * that has nothing to do with the popover.
+ */
+const timeRangeOf = (event: Appointment): string =>
+  `${formatDateInPreferredTimeZone(event.startTime, {
+    hour: 'numeric',
+    minute: '2-digit',
+  })} - ${formatDateInPreferredTimeZone(event.endTime, { hour: 'numeric', minute: '2-digit' })}`;
+
+const longDateOf = (event: Appointment): string =>
+  formatDateInPreferredTimeZone(event.appointmentDate, {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  });
+
+const SUBLINE = `Beagle · Canine · ${getCompanionAge(STORE_COMPANION.dateOfBirth)} · MN · 12 kg`;
+
+/** The open panel. Not portalled by the popover itself - `SlotPortals` does that. */
+const openPanel = (canvasElement: HTMLElement): HTMLElement =>
+  canvasElement.querySelector('dialog[open]') as HTMLElement;
+
+/** The eight-cell detail grid, reached from a label rather than from a class chain. */
+const detailGrid = (panel: HTMLElement): HTMLElement =>
+  within(panel).getByText('Speciality').closest('.grid') as HTMLElement;
+
+/**
+ * Every detail cell as a [label, value] pair, in render order. Read positionally
+ * rather than by text: the payment cell's label and value are frequently the same
+ * word ("Paid" / "Paid"), so a text query for one matches both.
+ */
+const detailPairs = (panel: HTMLElement): string[][] =>
+  [...detailGrid(panel).children].map((cell) => [
+    (cell.children[0].textContent ?? '').trim(),
+    (cell.children[1].textContent ?? '').trim(),
+  ]);
+
+/**
+ * Every button in the panel, in render order, by name. The rail is six icon
+ * buttons that differ only by glyph, so "which actions are offered" is a list
+ * question: asserting three of them by name passes on a rail that lost the other
+ * three. `aria-label` first because that is what the rail names its buttons with;
+ * the header link, the status trigger and the primary action name themselves by
+ * their own text.
+ */
+const buttonNames = (panel: HTMLElement): string[] =>
+  within(panel)
+    .getAllByRole('button')
+    .map((button) => button.getAttribute('aria-label') ?? (button.textContent ?? '').trim());
+
+/** The `GlassTooltip` wrapper around one action-rail button. */
+const railWrapper = (panel: HTMLElement, accessibleName: string): HTMLElement =>
+  within(panel)
+    .getByRole('button', { name: accessibleName })
+    .closest('.glass-tooltip') as HTMLElement;
+
+type HarnessProps = {
+  appointment: Appointment;
+  invoicesByAppointmentId: Record<string, Invoice>;
+  canEditAppointments: boolean;
+  handleRescheduleAppointment: (appt: Appointment) => void;
+  handleChangeRoomAppointment?: (appt: Appointment) => void;
+  handleAcceptAppointment?: (appt: Appointment) => void;
+  onClose: () => void;
+};
+
+/** Registering the anchor is the calendar's hover-dismiss wiring; here it is inert. */
+const registerAnchorEl = () => () => {};
+
+/**
+ * The calendar owns the dialog ref, the generated popover id and the measured
+ * placement, so the harness supplies all three.
+ *
+ * `popoverStyle` deliberately carries only `top`/`left`. The real caller passes
+ * `getPopoverStyle(440, 490)`, which also returns `width: 440` - omitted here so
+ * the width assertion measures the panel's own `w-[440px]` rather than a number
+ * this file handed it.
+ */
+const Harness = ({
+  appointment,
+  invoicesByAppointmentId,
+  canEditAppointments,
+  handleRescheduleAppointment,
+  handleChangeRoomAppointment,
+  handleAcceptAppointment,
+  onClose,
+}: HarnessProps) => {
+  const popoverDialogRef = useRef<HTMLDialogElement | null>(null);
+  const popoverId = useId();
+  return (
+    <div className="min-h-[620px] bg-[var(--screen)] p-6">
+      <p className="text-[13px] text-[var(--ink-muted)]">
+        Calendar behind the panel. The popover is `position: fixed`, so it floats over this block
+        rather than inside it.
+      </p>
+      <AppointmentPopover
+        appointment={appointment}
+        invoicesByAppointmentId={invoicesByAppointmentId}
+        canEditAppointments={canEditAppointments}
+        popoverId={popoverId}
+        popoverDialogRef={popoverDialogRef}
+        popoverStyle={{ top: 24, left: 24 }}
+        handleRescheduleAppointment={handleRescheduleAppointment}
+        handleChangeRoomAppointment={handleChangeRoomAppointment}
+        handleAcceptAppointment={handleAcceptAppointment}
+        onClose={onClose}
+        registerAnchorEl={registerAnchorEl}
+      />
+    </div>
+  );
+};
+
+const meta = {
+  title: 'Appointments/Calendar/AppointmentPopover',
+  component: Harness,
+  parameters: {
+    layout: 'fullscreen',
+    // No `autodocs`. The panel is `position: fixed` at the coordinates the calendar
+    // measures, and `popoverStyle` carries only top/left - so on a generated docs
+    // page every story would float at the same spot, stacked on top of each other.
+    // The rail and the request buttons carry autodocs in their own story files.
+    //
+    // `appDirectory`: the companion name, the rail and the primary action all call
+    // next/navigation's `useRouter`, so the App Router mock has to be mounted.
+    nextjs: { appDirectory: true, navigation: { pathname: '/appointments' } },
+    docs: {
+      description: {
+        component:
+          'The card that opens when you click an appointment block in any calendar view - and the ' +
+          'largest single surface in the planner that had never been drawn in Storybook.\n\n' +
+          'Reaching it takes a click **and** a wait. `useMarkerInteractions` starts a 180ms timer ' +
+          'on mouse-down and only opens the popover if no second click lands, because the same ' +
+          'block double-clicks into the workspace. `SlotPortals` then renders it, but only once ' +
+          '`activeEvent` and a measured `activeRect` both exist and no drag is in flight. So the ' +
+          'panel is three gates deep from a resting render, and every part of it - the header, the ' +
+          'eight detail cells, the two staff fields and the action rail - has only ever existed ' +
+          'mid-interaction.\n\n' +
+          'The detail grid is where the review value is. It is eight `PopoverDetail` cells in a ' +
+          'two-column grid, and half of them are **derived**, not passed: the Room cell relabels ' +
+          'itself "Room / Unit" when an inpatient unit resolves, the payment cell changes both its ' +
+          'label and its value depending on whether an invoice exists and whether it is settled, ' +
+          'the Reason cell is the only one that scrolls rather than truncates, and the Duration ' +
+          'cell hangs its clock glyph outside its own box on a negative offset. The stories below ' +
+          'assert the full [label, value] list rather than "a grid appeared", because a grid that ' +
+          'appeared with the wrong eight cells passes the weaker check.\n\n' +
+          'Two things a reviewer should look at. First: an appointment with no invoice reads ' +
+          '**"Paid: Paid"** - `getAppointmentPaymentDisplay` treats "no invoice" as settled for ' +
+          'everything except the legacy NO_PAYMENT status, so the default upcoming booking claims ' +
+          'money has changed hands. Second: the Lead and Support fields are real `<input>`s whose ' +
+          '`inlabel` is the empty string, so their visible chip labels are decorative spans and ' +
+          'the inputs themselves have no accessible name at all.\n\n' +
+          'Every store the panel reads (org, companion, workspace encounters, room units) is a ' +
+          'plain lookup with no loader attached, so seeding two of them in `beforeEach` is the ' +
+          'whole of the setup and nothing here touches the network.',
+      },
+    },
+  },
+  args: {
+    appointment: APPOINTMENT,
+    invoicesByAppointmentId: {},
+    canEditAppointments: true,
+    handleRescheduleAppointment: fn(),
+    handleChangeRoomAppointment: fn(),
+    handleAcceptAppointment: fn(),
+    onClose: fn(),
+  },
+  beforeEach: () => {
+    const orgSnapshot = useOrgStore.getState();
+    const companionSnapshot = useCompanionStore.getState();
+
+    useOrgStore.setState({
+      primaryOrgId: ORG_ID,
+      orgsById: { [ORG_ID]: HOSPITAL },
+      orgIds: [ORG_ID],
+      status: 'loaded',
+    });
+    useCompanionStore.getState().setCompanionsForOrg(ORG_ID, [STORE_COMPANION]);
+
+    return () => {
+      useOrgStore.setState(orgSnapshot);
+      useCompanionStore.setState(companionSnapshot);
+    };
+  },
+} satisfies Meta<typeof Harness>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Upcoming: Story = {
+  name: 'Upcoming (full panel)',
+  play: async ({ canvasElement }) => {
+    const panel = openPanel(canvasElement);
+    await expect(panel).not.toBeNull();
+    // 440px from the panel's own class. Measured off the box rather than
+    // `getComputedStyle().width`, which reports the content box and would read
+    // short of the design number on a bordered element.
+    await expect(Math.round(panel.getBoundingClientRect().width)).toBe(440);
+    // Deliberately non-modal: the calendar stays scrollable underneath and the
+    // dialog is a floating card, not a light-dismiss overlay.
+    await expect(panel).toHaveAttribute('aria-modal', 'false');
+
+    /* The whole grid in one assertion. Order is part of the design - the two
+       columns read Speciality/Duration, Service/Date, Room/Client, Reason/payment -
+       so a cell that moved would fail here rather than pass a per-label lookup. */
+    await expect(detailPairs(panel)).toEqual([
+      ['Speciality', 'Dentistry'],
+      ['Duration', timeRangeOf(APPOINTMENT)],
+      ['Service', 'Dental consultation'],
+      ['Date', longDateOf(APPOINTMENT)],
+      ['Room', 'Consult 2'],
+      ['Client Name', 'Maya'],
+      ['Reason', 'Post-op recheck of the left carpus, plus a nail trim if she tolerates it'],
+      // No invoice, and the status is not the legacy NO_PAYMENT, so the panel
+      // asserts an upcoming appointment has already been paid for.
+      ['Paid', 'Paid'],
+    ]);
+
+    const tracks = getComputedStyle(detailGrid(panel)).gridTemplateColumns.trim().split(/\s+/);
+    await expect(tracks).toHaveLength(2);
+    await expect(detailGrid(panel).children).toHaveLength(8);
+
+    /* The header subline is the merge of two sources: breed and species come from
+       the booking payload, age, sex and weight from the companion store. One exact
+       string proves both halves arrived and in the right order. */
+    await expect(within(panel).getByRole('button', { name: 'Poppy · Whitfield' })).toBeVisible();
+    await expect(within(panel).getByText(SUBLINE)).toBeVisible();
+    await expect(within(panel).getByRole('button', { name: 'Upcoming' })).toBeVisible();
+    await expect(within(panel).getByText('Outpatient')).toBeVisible();
+
+    /* Lead and Support are readonly text inputs with an empty `inlabel`, so their
+       visible chips are plain spans that name nothing. The chips are present and
+       the fields still have no accessible name - both are asserted, because the
+       first without the second reads as a working label. */
+    const staffFields = within(panel).getAllByRole('textbox');
+    await expect(staffFields).toHaveLength(2);
+    await expect(staffFields[0]).toHaveValue('Dr. Elena Marsh');
+    await expect(staffFields[1]).toHaveValue('Tom Reyes, Priya Raman');
+    await expect(within(panel).getByText('Lead')).toBeVisible();
+    await expect(within(panel).queryByRole('textbox', { name: 'Lead' })).toBeNull();
+
+    /* Every button in the panel, in order, rather than a spot check. UPCOMING with
+       edit rights is the only status that unlocks all six rail actions - the
+       reschedule and assign-room pair are gated on the status as well as the
+       permission - so this list is the ceiling the other stories are read down
+       from. It also pins that no request buttons appear: UPCOMING is not a
+       requested-like status. */
+    await expect(buttonNames(panel)).toEqual([
+      'Poppy · Whitfield',
+      'Upcoming',
+      'Appointment overview',
+      'Finance summary',
+      'Lab tests',
+      'Reschedule appointment',
+      'Assign room',
+      'Medical Records',
+      'Start Appointment',
+    ]);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The panel as a receptionist sees it on a confirmed booking. Everything below is a ' +
+          'variation on this one: the same eight cells, redrawn by a different status, a different ' +
+          'invoice or a different permission.',
+      },
+    },
+  },
+};
+
+export const Requested: Story = {
+  name: 'Booking request (accept / decline)',
+  args: { appointment: withAppointment({ status: 'REQUESTED' }) },
+  play: async ({ canvasElement }) => {
+    const panel = openPanel(canvasElement);
+
+    /* Three buttons in the whole panel, and the list says which three. The rail
+       and the primary action are both gated on `canEnterAppointmentWorkspace`,
+       which excludes REQUESTED, so a request has no clinical entry point at all -
+       and the status pill has stopped being a dropdown, which is why no 'Requested'
+       trigger appears between the name and the decisions. */
+    await expect(buttonNames(panel)).toEqual([
+      'Poppy · Whitfield',
+      'Accept request',
+      'Decline request',
+    ]);
+    // The pill is still on screen, as a badge rather than a control.
+    await expect(within(panel).getByText('Requested')).toBeVisible();
+
+    // The detail grid is unchanged - same eight labels, same order, so nothing
+    // about the request status re-forms the body of the card.
+    await expect(detailPairs(panel).map(([label]) => label)).toEqual([
+      'Speciality',
+      'Duration',
+      'Service',
+      'Date',
+      'Room',
+      'Client Name',
+      'Reason',
+      'Paid',
+    ]);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A booking request. Three separate things swap at once - the action rail is replaced by ' +
+          'the accept/decline pair, the primary action disappears, and the status pill degrades ' +
+          'from a dropdown trigger to a static badge - and all three come from different ' +
+          'predicates reading the same status. This is the only render where the panel offers no ' +
+          'way into the workspace.',
+      },
+    },
+  },
+};
+
+export const InpatientWithUnit: Story = {
+  name: 'Inpatient (Room / Unit) and emergency',
+  args: {
+    appointment: withAppointment({
+      appointmentKind: 'INPATIENT',
+      isEmergency: true,
+      status: 'CHECKED_IN',
+      room: {
+        id: 'room-isolation',
+        name: 'Isolation',
+        unit: { id: 'unit-kennel-3', name: 'Kennel 3', displayName: 'Kennel 3' },
+      },
+      concern:
+        'Vomiting for 36 hours, suspected foreign body, barrier nursing until the parvo snap test reads',
+    }),
+  },
+  play: async ({ canvasElement }) => {
+    const panel = openPanel(canvasElement);
+    const pairs = detailPairs(panel);
+
+    // Cell five relabels itself. `getAppointmentUnitLabel` only resolves a unit for
+    // an INPATIENT encounter, so the same room on an outpatient booking reads
+    // "Room / Consult 2" and nothing else changes to warn you.
+    await expect(pairs[4]).toEqual(['Room / Unit', 'Isolation / Kennel 3']);
+    await expect(within(panel).getByText('Inpatient')).toBeVisible();
+    await expect(within(panel).getByText('Emergency')).toBeVisible();
+
+    /* The Reason cell is the only one of the eight that scrolls instead of
+       truncating: `scrollValue` swaps `truncate` for an `overflow-x-auto`
+       whitespace-nowrap span with its own wheel handler. A long concern therefore
+       overflows its own box rather than ending in an ellipsis, which is the
+       behaviour a reviewer has to see to judge. */
+    const reasonValue = within(panel).getByText(
+      'Vomiting for 36 hours, suspected foreign body, barrier nursing until the parvo snap test reads'
+    );
+    await expect(reasonValue.scrollWidth).toBeGreaterThan(reasonValue.clientWidth);
+    await expect(getComputedStyle(reasonValue).whiteSpace).toBe('nowrap');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'An admitted, emergency patient. Three things only this render shows: the Room cell ' +
+          'carrying a unit, the emergency badge stacked under the status and mode pills in the ' +
+          'header column, and the Reason cell overflowing.\n\n' +
+          'The Reason cell is worth a second look. It is the one cell that scrolls, and its ' +
+          'scrollbar is `scrollbar-x-float` with `pb-3` reserving room for it - so a long concern ' +
+          "is reachable by dragging, by shift-wheel, or by the cell's own wheel handler, and by " +
+          'nothing else. Every other cell in the grid silently truncates.',
+      },
+    },
+  },
+};
+
+export const AmountDue: Story = {
+  name: 'Unpaid invoice (Amount Due)',
+  args: {
+    appointment: withAppointment({ status: 'COMPLETED' }),
+    invoicesByAppointmentId: { [APPOINTMENT_ID]: UNPAID_INVOICE },
+  },
+  play: async ({ canvasElement }) => {
+    const panel = openPanel(canvasElement);
+    const pairs = detailPairs(panel);
+
+    /* Both halves of the cell change together: the label is driven by the payment
+       STATE and the value by the invoice TOTAL, from two different helpers. The
+       total is rendered with `maximumFractionDigits: 0`, so $184 rather than
+       $184.00 - a deliberate rounding this is the only story to show. */
+    await expect(pairs[7]).toEqual(['Amount Due', '$184']);
+    // Emphasised: this is the one cell in the grid that goes bold ink rather than
+    // body ink, which is how it reads as a number rather than as metadata.
+    await expect(getComputedStyle(detailGrid(panel).children[7].children[1]).fontWeight).toBe(
+      '700'
+    );
+
+    /* COMPLETED can no longer be rescheduled or given a room, and it has no
+       allowed transition left, so the pill is static too. Worth reading beside the
+       read-only story: the two arrive at the SAME five controls from completely
+       different causes - one from a permission, one from a terminal status - and
+       only the primary action's wording tells them apart. */
+    await expect(buttonNames(panel)).toEqual([
+      'Poppy · Whitfield',
+      'Appointment overview',
+      'Finance summary',
+      'Lab tests',
+      'Medical Records',
+      'View Appointment',
+    ]);
+    await expect(within(panel).getByText('Completed')).toBeVisible();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A finished visit with an open invoice. Read beside the first story, this is the pair ' +
+          'that makes the payment default visible: the same panel says "Paid / Paid" when no ' +
+          'invoice exists and "Amount Due / $184" when one does, so the absence of billing data ' +
+          'presents as good news rather than as missing data.\n\n' +
+          'The primary action also rewords itself - "View Appointment" rather than "Start ' +
+          'Appointment" - and the button is the same width either way, so the shorter label sits ' +
+          'in a fixed `w-50` box.',
+      },
+    },
+  },
+};
+
+export const ReadOnly: Story = {
+  name: 'Read-only (no edit permission)',
+  args: { canEditAppointments: false },
+  play: async ({ canvasElement }) => {
+    const panel = openPanel(canvasElement);
+
+    /* The same list as the first story with exactly three entries removed, which
+       is the only way to see that the permission does not gate the panel
+       uniformly. Reschedule and Assign room drop out of the rail, the status
+       trigger stops being a button - and 'Start Appointment' is still last,
+       because entering the clinical workspace is not gated on
+       `canEditAppointments` at all. */
+    await expect(buttonNames(panel)).toEqual([
+      'Poppy · Whitfield',
+      'Appointment overview',
+      'Finance summary',
+      'Lab tests',
+      'Medical Records',
+      'Start Appointment',
+    ]);
+
+    // The status is still readable, as a badge rather than a dropdown.
+    await expect(within(panel).getByText('Upcoming')).toBeVisible();
+
+    // The body of the card is untouched by the permission: same eight cells,
+    // same values, including the payment default.
+    await expect(detailPairs(panel)[7]).toEqual(['Paid', 'Paid']);
+    await expect(detailGrid(panel).children).toHaveLength(8);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same appointment for a viewer who cannot edit. Worth pinning because the permission ' +
+          'does not gate the panel uniformly: it removes two rail buttons and the status dropdown, ' +
+          'and leaves the large primary action that walks into the clinical workspace untouched.',
+      },
+    },
+  },
+};
+
+export const RoomImpliesInpatient: Story = {
+  name: 'Room implies inpatient (derived mode)',
+  args: {
+    appointment: withAppointment({ appointmentKind: undefined }),
+  },
+  play: async ({ canvasElement }) => {
+    const panel = openPanel(canvasElement);
+    /* Identical to the first story except that `appointmentKind` is absent. With no
+       kind and no inpatient wording in the service name, `resolveEncounterMode`
+       falls back to "has a room, therefore inpatient" - so a 30-minute dental
+       consult in Consult 2 is labelled an admission. */
+    await expect(within(panel).getByText('Inpatient')).toBeVisible();
+    await expect(within(panel).queryByText('Outpatient')).toBeNull();
+    // The room cell keeps its plain label only because no unit resolves; assign a
+    // unit to this same appointment and it would relabel too.
+    await expect(detailPairs(panel)[4]).toEqual(['Room', 'Consult 2']);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The fallback branch of `resolveEncounterMode`, drawn on purpose. A booking that never ' +
+          'declared a kind but was given a consult room reads as **Inpatient** in the header, ' +
+          'because room presence is the last resort in the chain. It is a reasonable default for a ' +
+          'ward booking and a wrong one for the far more common case of an outpatient consult with ' +
+          'a room assigned - and the popover is the surface where it is most visible.',
+      },
+    },
+  },
+};
+
+export const RailTooltip: Story = {
+  name: 'Rail tooltip escapes the panel',
+  play: async ({ canvasElement }) => {
+    const panel = openPanel(canvasElement);
+    /* `GlassTooltip` binds mouseenter/focusin natively inside an effect, so a single
+       dispatch from a play function can land before the listener exists and is lost
+       for good - no query-level retry recovers it. `openGlassTooltip` redispatches
+       until a bubble that was not already open appears. */
+    const wrapper = railWrapper(panel, 'Appointment overview');
+    const bubble = await openGlassTooltip(wrapper);
+
+    await expect(bubble).toHaveTextContent('Overview');
+    /* The bubble is portalled to `document.body`, so it lives OUTSIDE the dialog
+       even though it is anchored to a button inside it. That is the stacking
+       question this story exists for: the panel is `z-[1000]` and the bubble is a
+       body-level sibling of it, so their order is decided by the portal's own
+       z-index rather than by containment. */
+    await expect(panel.contains(bubble)).toBe(false);
+    await expect(document.body.contains(bubble)).toBe(true);
+    await expect(within(document.body).getAllByRole('tooltip')).toHaveLength(1);
+
+    // Closed explicitly: opening another wrapper's bubble does not tear this one
+    // down, and a leftover on `document.body` outlives this story.
+    await closeGlassTooltip(wrapper);
+    await expect(within(document.body).queryAllByRole('tooltip')).toHaveLength(0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The action rail's labels only exist while a button is hovered, and they are rendered " +
+          'into `document.body` rather than into the panel. So the popover has six round icon ' +
+          "buttons whose meaning is never inside the dialog's own accessibility tree, and a " +
+          'screenshot of the panel can never contain one.\n\n' +
+          'The rail itself is storied in full under `Appointments/WorkspaceQuickActions`; this ' +
+          'story only pins the one fact that needs the popover to be open - that the bubble ' +
+          'escapes the `z-[1000]` dialog instead of being clipped by it.',
+      },
+    },
+  },
+};
+
+export const ExitsClosePanel: Story = {
+  name: 'Both exits report a close',
+  play: async ({ canvasElement, args }) => {
+    const panel = openPanel(canvasElement);
+    await expect(args.onClose).not.toHaveBeenCalled();
+
+    // The companion name is a button, not a heading: it routes to the animal's
+    // history and closes the panel behind it.
+    await userEvent.click(within(panel).getByRole('button', { name: 'Poppy · Whitfield' }));
+    await expect(args.onClose).toHaveBeenCalledTimes(1);
+
+    /* The panel is still mounted - `AppointmentPopover` never closes itself, it
+       reports. In the calendar the parent drops `activePopoverKey` and the portal
+       branch stops rendering; here the harness holds it open, which is what makes
+       a second exit reachable in one story. */
+    await expect(openPanel(canvasElement)).not.toBeNull();
+
+    await userEvent.click(within(panel).getByRole('button', { name: 'Start Appointment' }));
+    await expect(args.onClose).toHaveBeenCalledTimes(2);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Both routing exits, driven for real. Each one pushes a route and then calls `onClose`, ' +
+          'and neither touches the dialog - so "did the popover close?" is a question about the ' +
+          "parent's state, never about this component. The story asserts the report rather than " +
+          'the disappearance, which is the only thing this component actually controls.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/DayCalendar.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/DayCalendar.stories.tsx
@@ -1,0 +1,346 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fireEvent, fn, within } from 'storybook/test';
+import type { Appointment } from '@yosemite-crew/types';
+
+import { DayCalendar } from './DayCalendar';
+
+const ORG_ID = 'org-storybook';
+
+/**
+ * Availability is handed in as plain minute-of-day numbers, never as instants, so
+ * the visible window below is the same in every timezone. The APPOINTMENTS are
+ * instants and are read in the preferred zone (Europe/Berlin by default), so they
+ * are pinned to 06:30 and 07:15 UTC - 08:30 and 09:15 Berlin, comfortably inside
+ * the availability. Both stay inside `[480, 780]`, so they cannot widen the
+ * window and move every pixel assertion in this file.
+ */
+const AVAILABILITY = [
+  { startMinute: 480, endMinute: 600 },
+  { startMinute: 660, endMinute: 780 },
+];
+
+/**
+ * `computeDayWindow` pads the availability by 30 minutes and snaps to the hour:
+ * min 480-30 -> 07:00, max 780+30 -> 14:00. Zoomed in an hour is 180px
+ * (`getHourRowHeightPx('in')`), i.e. 15px per 5-minute step, so one minute is 3px
+ * and the grid is 1260px tall.
+ */
+const WINDOW_START = 420;
+const WINDOW_END = 840;
+const PIXELS_PER_STEP = 15;
+const MINUTES_PER_STEP = 5;
+
+/** Pixel offset of a minute-of-day from the top of the timeline grid. */
+const topPxForMinute = (minute: number): number =>
+  ((minute - WINDOW_START) / MINUTES_PER_STEP) * PIXELS_PER_STEP;
+
+const DAY = new Date('2026-07-14T10:00:00.000Z');
+
+const appointment = (
+  id: string,
+  name: string,
+  startIso: string,
+  durationMinutes: number,
+  concern: string
+): Appointment => {
+  const startTime = new Date(startIso);
+  const endTime = new Date(startTime.getTime() + durationMinutes * 60 * 1000);
+  return {
+    id,
+    patient: {
+      id: `companion-${id}`,
+      name,
+      species: 'dog',
+      breed: 'Beagle',
+      parent: { id: `parent-${id}`, name: 'Lena Hartmann' },
+    },
+    companion: {
+      id: `companion-${id}`,
+      name,
+      species: 'dog',
+      breed: 'Beagle',
+      parent: { id: `parent-${id}`, name: 'Lena Hartmann' },
+    },
+    organisationId: ORG_ID,
+    room: { id: 'room-consult-1', name: 'Consult 1' },
+    appointmentDate: startTime,
+    startTime,
+    endTime,
+    timeSlot: `${startTime.toISOString()}`,
+    durationMinutes,
+    status: 'UPCOMING',
+    concern,
+  };
+};
+
+const EVENTS: Appointment[] = [
+  appointment('appt-1', 'Milo', '2026-07-14T06:30:00.000Z', 30, 'Lameness recheck'),
+  appointment('appt-2', 'Nala', '2026-07-14T07:15:00.000Z', 45, 'Vaccination'),
+];
+
+/** The dragged card is `appt-1`, so the day's own marker dims to 0.55 opacity. */
+const DRAG_LABEL = 'Milo · Lameness recheck';
+
+const getTimeline = (canvasElement: HTMLElement): HTMLElement =>
+  canvasElement.querySelector('section[aria-label="Appointment timeline"]') as HTMLElement;
+
+const getGrid = (canvasElement: HTMLElement): HTMLElement =>
+  canvasElement.querySelector('[data-timeline-grid]') as HTMLElement;
+
+/** Dim rectangles are the only nodes painted with the dim token, inline. */
+const getDimSegments = (canvasElement: HTMLElement): HTMLElement[] =>
+  Array.from(canvasElement.querySelectorAll<HTMLElement>('[style*="calendar-dim-overlay"]'));
+
+const getDragAvailabilityRects = (canvasElement: HTMLElement): HTMLElement[] =>
+  Array.from(canvasElement.querySelectorAll<HTMLElement>('.bg-calendar-availability-overlay'));
+
+/** Offset of an overlay from the top of the grid, in CSS pixels. */
+const offsetFromGridTop = (canvasElement: HTMLElement, el: HTMLElement): number =>
+  el.getBoundingClientRect().top - getGrid(canvasElement).getBoundingClientRect().top;
+
+const meta = {
+  title: 'Appointments/Calendar/DayCalendar',
+  component: DayCalendar,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The single-day timeline, drawn in the two states it only ever reaches **mid-gesture**.\n\n' +
+          '`TimelineOverlays` renders three layers into the same absolutely-positioned box, and ' +
+          'two of them are gated on `draggedAppointmentId`. The dim ranges are always there, so ' +
+          'they are the only part any snapshot has ever contained; the drag-availability ' +
+          'highlights and the dashed drop ghost exist for the duration of a pointer drag and are ' +
+          'gone the moment it ends. Nothing static - no unit test, no Chromatic frame - could hold ' +
+          'them, which is why they had never been reviewed.\n\n' +
+          'The ghost here is **not** the shared `DropPreviewOverlay` used by the week grid. ' +
+          'DayCalendar carries its own copy inline, with its own geometry: `top` is measured from ' +
+          '`windowStart` rather than modulo the hour, the height floor is 12px rather than 14px, ' +
+          'and there is no clamp to the end of the hour because there is no hour cell to clamp to. ' +
+          'Two implementations of one affordance that can drift apart, and only one of them had a ' +
+          'story.\n\n' +
+          'Every measurement below is exact rather than approximate. The window is derived from ' +
+          'the availability minutes alone (07:00-14:00), an hour is 180px zoomed in, so a minute ' +
+          'is 3px and each assertion names the pixel the design implies.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    events: EVENTS,
+    date: DAY,
+    canEditAppointments: true,
+    availabilityLoaded: true,
+    // Auto-scroll would park the viewport on the first event and make the visible
+    // slice of a 1260px grid depend on the wall clock. Pinned to the top instead.
+    skipAutoScroll: true,
+    getVisibleAvailabilityIntervals: () => AVAILABILITY,
+    getDropAvailabilityIntervals: () => AVAILABILITY,
+    handleViewAppointment: fn(),
+    handleDetailAppointment: fn(),
+    handleRescheduleAppointment: fn(),
+    canDragAppointment: () => true,
+    onAppointmentDragStart: fn(),
+    onAppointmentDragEnd: fn(),
+    onAppointmentDropAt: fn(),
+    onDragHoverTarget: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <div className="h-[620px] w-[380px] bg-[var(--screen)]">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof DayCalendar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Resting: Story = {
+  name: 'Resting (no drag)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* The timeline is a two-track grid: a fixed 52px time gutter and the events
+       column. Both the track count and the child count are asserted, because every
+       pixel measurement below is taken from this box - a gutter that grew a third
+       track would move each overlay sideways while leaving its `top` untouched, so
+       the offsets alone would still read as correct. */
+    const grid = getGrid(canvasElement);
+    const tracks = getComputedStyle(grid).gridTemplateColumns.trim().split(/\s+/);
+    await expect(tracks).toHaveLength(2);
+    await expect(Number.parseFloat(tracks[0])).toBeCloseTo(52, 0);
+    await expect(grid.children).toHaveLength(2);
+    // 07:00 through 14:00 inclusive down the gutter. The window is derived, not
+    // given, so this is the assertion that pins it: eight labels, or the whole
+    // file's geometry is being measured against a different day.
+    await expect(canvas.getAllByText(/^\d{1,2}:00 (AM|PM)$/)).toHaveLength(8);
+    await expect(canvas.getByText('7:00 AM')).toBeInTheDocument();
+    await expect(canvas.getByText('2:00 PM')).toBeInTheDocument();
+
+    /* The dim ranges are the complement of availability across the window: 07:00-08:00,
+       10:00-11:00 and 13:00-14:00. Three of them, each exactly one hour = 180px. If
+       `computeUnavailableSegments` ever stopped closing the trailing gap this would be
+       two, and the tail of the day would silently read as bookable. */
+    const dimmed = getDimSegments(canvasElement);
+    await expect(dimmed).toHaveLength(3);
+    await expect(offsetFromGridTop(canvasElement, dimmed[0])).toBeCloseTo(topPxForMinute(420), 0);
+    await expect(offsetFromGridTop(canvasElement, dimmed[1])).toBeCloseTo(topPxForMinute(600), 0);
+    await expect(offsetFromGridTop(canvasElement, dimmed[2])).toBeCloseTo(topPxForMinute(780), 0);
+    dimmed.forEach((segment) => {
+      expect(segment.getBoundingClientRect().height).toBeCloseTo(180, 0);
+    });
+
+    // The two drag-only layers are absent, which is the whole point of the gate.
+    await expect(getDragAvailabilityRects(canvasElement)).toHaveLength(0);
+    await expect(canvasElement.querySelector('.border-dashed')).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The state every existing snapshot holds: dim ranges over the closed hours, markers, ' +
+          'nothing else. It is here as the baseline the next two stories are read against - the ' +
+          'dim layer must survive a drag unchanged, and the drag layers must not exist without one.',
+      },
+    },
+  },
+};
+
+export const DragInFlight: Story = {
+  name: 'Drag in flight (availability highlights)',
+  args: {
+    draggedAppointmentId: 'appt-1',
+    draggedAppointmentLabel: DRAG_LABEL,
+    draggedAppointmentDurationMinutes: 45,
+  },
+  play: async ({ canvasElement }) => {
+    const rects = getDragAvailabilityRects(canvasElement);
+    await expect(rects).toHaveLength(2);
+
+    /* The highlight is NOT the availability interval. Its foot is extended by the
+       dragged appointment's duration, because a 45-minute card may START at the last
+       bookable minute: 08:00-10:00 becomes 08:00-10:45 = 495px, not 360px. Get that
+       wrong and the band lies about where the card can land. */
+    await expect(offsetFromGridTop(canvasElement, rects[0])).toBeCloseTo(topPxForMinute(480), 0);
+    await expect(rects[0].getBoundingClientRect().height).toBeCloseTo(495, 0);
+    await expect(offsetFromGridTop(canvasElement, rects[1])).toBeCloseTo(topPxForMinute(660), 0);
+    await expect(rects[1].getBoundingClientRect().height).toBeCloseTo(495, 0);
+
+    // The dim layer is untouched by the drag - the two layers stack, they do not swap.
+    await expect(getDimSegments(canvasElement)).toHaveLength(3);
+    // No pointer has entered the timeline yet, so there is no landing ghost.
+    await expect(canvasElement.querySelector('.border-dashed')).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A card has been picked up but the pointer has not yet moved over the timeline. Two ' +
+          'rounded highlights mark where it may land, and they sit ABOVE the dim layer (`z-20` ' +
+          'against `z-1`), so a highlight that overlapped a closed hour would still read as open. ' +
+          'Each band runs the length of its availability interval plus the dragged duration, ' +
+          'which is why an 08:00-10:00 window highlights 165 minutes rather than 120.',
+      },
+    },
+  },
+};
+
+export const DropPreviewGhost: Story = {
+  name: 'Drop preview ghost (drag over 09:00)',
+  args: {
+    draggedAppointmentId: 'appt-1',
+    draggedAppointmentLabel: DRAG_LABEL,
+    draggedAppointmentDurationMinutes: 45,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const timeline = getTimeline(canvasElement);
+    const gridRect = getGrid(canvasElement).getBoundingClientRect();
+
+    /* The handler turns a clientY into a minute by ratio against the grid's own rect,
+       so the pointer is placed by that same ratio rather than by a hard-coded pixel.
+       09:00 is 120 minutes into a 420-minute window. Hoisted out of any `waitFor`:
+       dispatching inside a retried callback re-queues on every mutation and wedges
+       the tab instead of failing. */
+    const clientY =
+      gridRect.top + ((540 - WINDOW_START) / (WINDOW_END - WINDOW_START)) * gridRect.height;
+    fireEvent.dragOver(timeline, { clientY });
+
+    const label = await canvas.findByText(DRAG_LABEL);
+    const band = label.parentElement as HTMLElement;
+    const anchor = band.parentElement as HTMLElement;
+
+    // 09:00 is inside the 08:00-10:00 interval, so `calcNearestAvailableMinute`
+    // returns it unchanged: 120 minutes past 07:00 = 360px.
+    await expect(offsetFromGridTop(canvasElement, anchor)).toBeCloseTo(topPxForMinute(540), 0);
+    // 45 minutes at 3px per minute, well over the 12px floor.
+    await expect(band.getBoundingClientRect().height).toBeCloseTo(135, 0);
+    // The band is the dashed outline, not a solid block - it has to read as a
+    // placeholder rather than as a booked card.
+    await expect(getComputedStyle(band).borderTopStyle).toBe('dashed');
+    // The highlights stay drawn underneath; the ghost is added to them, not swapped in.
+    await expect(getDragAvailabilityRects(canvasElement)).toHaveLength(2);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The pointer is dragged to 09:00 and the dashed ghost appears at the landing minute, ' +
+          "carrying the dragged card's own label so the surgeon can see WHAT is about to move " +
+          'and not merely where.\n\n' +
+          'The minute is snapped through `calcNearestAvailableMinute`, which rounds to 5 and then ' +
+          'pulls to the closest availability interval within a 12-minute tolerance - drag to a ' +
+          'closed hour more than 12 minutes from anything bookable and the ghost does not draw at ' +
+          'all. That is the branch a static frame can never show, because it needs a pointer.',
+      },
+    },
+  },
+};
+
+export const DropPreviewFallbackLabel: Story = {
+  name: 'Drop preview ghost (no label)',
+  args: {
+    draggedAppointmentId: 'appt-1',
+    draggedAppointmentLabel: null,
+    draggedAppointmentDurationMinutes: 5,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const timeline = getTimeline(canvasElement);
+    const gridRect = getGrid(canvasElement).getBoundingClientRect();
+
+    const clientY =
+      gridRect.top + ((480 - WINDOW_START) / (WINDOW_END - WINDOW_START)) * gridRect.height;
+    fireEvent.dragOver(timeline, { clientY });
+
+    // Exact string, and a role-free text query on a word that appears nowhere else
+    // in this canvas - the preview decorator's sr-only <h1> reads
+    // "Appointments/Calendar/DayCalendar - Drop preview ghost (no label)".
+    const label = await canvas.findByText('Appointment');
+    const band = label.parentElement as HTMLElement;
+
+    await expect(offsetFromGridTop(canvasElement, band.parentElement as HTMLElement)).toBeCloseTo(
+      topPxForMinute(480),
+      0
+    );
+    /* 5 minutes would be 15px, which clears the floor - but the floor is 12px here and
+       14px in the shared `DropPreviewOverlay`, so the two ghosts disagree about the
+       shortest visible drag. Named rather than fixed: this story exists to make the
+       divergence visible, not to hide it. */
+    await expect(band.getBoundingClientRect().height).toBeCloseTo(15, 0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A drag that carries no label falls back to the bare word "Appointment" rather than an ' +
+          'unidentifiable dashed box. The duration is dropped to the 5-minute minimum as well, ' +
+          "which is where DayCalendar's 12px height floor and the week grid's 14px floor part " +
+          'company - the same gesture draws a different minimum band depending on which calendar ' +
+          'you are in.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/Slot.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/Slot.stories.tsx
@@ -1,0 +1,310 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fireEvent, fn, within } from 'storybook/test';
+import type { Appointment } from '@yosemite-crew/types';
+
+import Slot from './Slot';
+
+const ORG_ID = 'org-storybook';
+
+/** One hour cell of the week grid: 09:00, zoomed in, so the row is 180px tall. */
+const DROP_HOUR = 9;
+const HOUR_HEIGHT = 180;
+const ZOOM_OUT_HOUR_HEIGHT = 34;
+const DROP_DATE = new Date('2026-07-14T00:00:00.000Z');
+
+const appointment = (id: string, name: string, minuteOfHour: number): Appointment => {
+  // Only the MINUTE within the hour positions a marker (`ZoomInEventList` reads
+  // `getDatePartsInPreferredTimeZone(startTime).minute`), and every zone this app
+  // supports is a whole-hour offset, so the marker lands on the same pixel everywhere.
+  const startTime = new Date(`2026-07-14T09:${String(minuteOfHour).padStart(2, '0')}:00.000Z`);
+  const endTime = new Date(startTime.getTime() + 30 * 60 * 1000);
+  return {
+    id,
+    patient: {
+      id: `companion-${id}`,
+      name,
+      species: 'dog',
+      breed: 'Beagle',
+      parent: { id: `parent-${id}`, name: 'Lena Hartmann' },
+    },
+    companion: {
+      id: `companion-${id}`,
+      name,
+      species: 'dog',
+      breed: 'Beagle',
+      parent: { id: `parent-${id}`, name: 'Lena Hartmann' },
+    },
+    organisationId: ORG_ID,
+    room: { id: 'room-consult-1', name: 'Consult 1' },
+    appointmentDate: startTime,
+    startTime,
+    endTime,
+    timeSlot: '09:15 - 09:45',
+    durationMinutes: 30,
+    status: 'UPCOMING',
+    concern: 'Lameness recheck',
+  };
+};
+
+const SLOT_EVENTS: Appointment[] = [appointment('appt-1', 'Milo', 15)];
+
+const DRAG_LABEL = 'Nala · Hartmann';
+
+const getSlotSection = (canvasElement: HTMLElement): HTMLElement =>
+  canvasElement.querySelector('section[aria-label^="Appointments slot"]') as HTMLElement;
+
+const getAvailabilityRects = (canvasElement: HTMLElement): HTMLElement[] =>
+  Array.from(canvasElement.querySelectorAll<HTMLElement>('.bg-calendar-availability-overlay'));
+
+const offsetFromSlotTop = (canvasElement: HTMLElement, el: HTMLElement): number =>
+  el.getBoundingClientRect().top - getSlotSection(canvasElement).getBoundingClientRect().top;
+
+const meta = {
+  title: 'Appointments/Calendar/Slot',
+  component: Slot,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'One hour cell of the week grid - and the drag affordance it draws for exactly as long ' +
+          'as a pointer is held down.\n\n' +
+          'Slot renders a full week: seven columns times the visible hours, so a single ' +
+          'availability rectangle here is repeated dozens of times on screen. It is also gated on ' +
+          '`draggedAppointmentId`, which means no snapshot, unit test or Chromatic frame has ever ' +
+          'contained one. The maths behind it is the kind that ships broken quietly: three clamps ' +
+          'in eight lines, and every one of them only bites at a cell boundary.\n\n' +
+          'The rectangle is **not** the availability interval. `computeAvailabilitySegments` ' +
+          "clips the interval to this hour, then extends its foot by the dragged appointment's " +
+          'own duration - because a 30-minute card may legally START at the last bookable minute. ' +
+          'That has two consequences the stories below draw: an interval that ends BEFORE this ' +
+          "hour can still paint a band inside it, and a band can run past the interval's stated " +
+          'end. A final `Math.max(4, ...)` floor keeps a sliver visible when the overlap is a ' +
+          'couple of minutes, which is what the zoomed-out story is for - at 34px an hour, three ' +
+          'minutes is under two pixels.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    slotEvents: SLOT_EVENTS,
+    height: HOUR_HEIGHT,
+    dayIndex: 0,
+    length: 6,
+    canEditAppointments: true,
+    dropDate: DROP_DATE,
+    dropHour: DROP_HOUR,
+    zoomMode: 'in',
+    handleViewAppointment: fn(),
+    handleRescheduleAppointment: fn(),
+    canDragAppointment: () => true,
+    onAppointmentDragStart: fn(),
+    onAppointmentDragEnd: fn(),
+    onAppointmentDropAt: fn(),
+    onDragHoverTarget: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[260px] bg-[var(--screen)]">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof Slot>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Resting: Story = {
+  name: 'Resting (no drag)',
+  args: {
+    dropAvailabilityIntervals: [{ startMinute: 540, endMinute: 585 }],
+    draggedAppointmentDurationMinutes: 30,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* The card sits where its minute says: 09:15 is a quarter down a 180px row, and
+       30 minutes is 90px - clear of the 40px block minimum, so this is the real
+       duration rather than a floor. Both numbers are the baseline the drag stories
+       are read against, because the overlays are positioned by the same arithmetic. */
+    const card = canvas.getByText('Milo · Hartmann').closest('.absolute') as HTMLElement;
+    await expect(offsetFromSlotTop(canvasElement, card)).toBeCloseTo(45, 0);
+    await expect(card.getBoundingClientRect().height).toBeCloseTo(90, 0);
+
+    // One interactive object in the cell: the card. No create button, because
+    // `onCreateAppointmentAt` is not wired, and no drag affordance at rest.
+    const [cardButton, ...extraButtons] = canvas.getAllByRole('button');
+    await expect(extraButtons).toHaveLength(0);
+    // The title carries the reason as well as the companion, so a block truncated
+    // to two words still answers a hover.
+    await expect(cardButton).toHaveAttribute('title', 'Milo · Hartmann • Lameness recheck');
+    await expect(cardButton).toHaveAttribute('draggable', 'true');
+
+    // Availability is a DRAG affordance, so an idle calendar must not advertise it.
+    await expect(getAvailabilityRects(canvasElement)).toHaveLength(0);
+    await expect(canvasElement.querySelector('.border-dashed')).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The cell as every existing frame holds it: one 09:15 card in a 09:00 hour, no overlays. ' +
+          'The availability intervals are already supplied here - they simply draw nothing until ' +
+          'something is being dragged.',
+      },
+    },
+  },
+};
+
+export const DragInFlight: Story = {
+  name: 'Drag in flight (band clipped to the hour)',
+  args: {
+    draggedAppointmentId: 'appt-2',
+    draggedAppointmentLabel: DRAG_LABEL,
+    draggedAppointmentDurationMinutes: 30,
+    dropAvailabilityIntervals: [{ startMinute: 555, endMinute: 585 }],
+  },
+  play: async ({ canvasElement }) => {
+    const rects = getAvailabilityRects(canvasElement);
+    await expect(rects).toHaveLength(1);
+
+    // 09:15 is a quarter into the row: 45px of 180px.
+    await expect(offsetFromSlotTop(canvasElement, rects[0])).toBeCloseTo(45, 0);
+    /* The interval ends at 09:45, but a 30-minute card starting at 09:45 is legal, so
+       the foot runs to 10:15 - past this cell - and is clipped at the hour boundary.
+       135px, not the 90px the interval alone would give. A band that stopped at the
+       interval end would tell the vet they cannot drop at 09:45, when they can. */
+    await expect(rects[0].getBoundingClientRect().height).toBeCloseTo(135, 0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A card is in flight over a cell whose availability runs 09:15-09:45. The band starts at ' +
+          'the interval, but its foot is the interval end plus the dragged duration, clipped to ' +
+          'the end of the hour - so it fills the row from 09:15 down rather than stopping at 09:45.',
+      },
+    },
+  },
+};
+
+export const SpilloverFromPreviousHour: Story = {
+  name: 'Drag in flight (spill from the hour above)',
+  args: {
+    draggedAppointmentId: 'appt-2',
+    draggedAppointmentLabel: DRAG_LABEL,
+    draggedAppointmentDurationMinutes: 30,
+    dropAvailabilityIntervals: [{ startMinute: 480, endMinute: 530 }],
+  },
+  play: async ({ canvasElement }) => {
+    const rects = getAvailabilityRects(canvasElement);
+    /* The interval is 08:00-08:50 and this is the 09:00 cell, so on a naive reading
+       nothing should draw here at all. It does, and correctly: a 30-minute card
+       dropped at 08:50 runs to 09:20, so the top 20 minutes of this hour are a valid
+       landing zone. The band is 60px and starts flush at the top. */
+    await expect(rects).toHaveLength(1);
+    await expect(offsetFromSlotTop(canvasElement, rects[0])).toBeCloseTo(0, 0);
+    await expect(rects[0].getBoundingClientRect().height).toBeCloseTo(60, 0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The least obvious branch, and the reason the segments are computed per cell rather than ' +
+          'sliced from the day. An availability interval that closes at 08:50 still paints inside ' +
+          "the 09:00 cell, because the dragged card's duration is added to the interval foot " +
+          'before it is clipped. Drop the `+ effectiveDuration` term and this rectangle vanishes, ' +
+          'with no test anywhere noticing.',
+      },
+    },
+  },
+};
+
+export const ZoomedOutFloor: Story = {
+  name: 'Zoomed out (4px floor)',
+  args: {
+    zoomMode: 'out',
+    height: ZOOM_OUT_HOUR_HEIGHT,
+    slotEvents: [],
+    draggedAppointmentId: 'appt-2',
+    draggedAppointmentLabel: DRAG_LABEL,
+    draggedAppointmentDurationMinutes: 5,
+    dropAvailabilityIntervals: [{ startMinute: 480, endMinute: 538 }],
+  },
+  play: async ({ canvasElement }) => {
+    const rects = getAvailabilityRects(canvasElement);
+    await expect(rects).toHaveLength(1);
+    /* Three minutes of overlap on a 34px hour is 1.7px - a hairline the eye reads as
+       a border, not as a droppable band. `Math.max(4, ...)` rounds it up to 4px, which
+       is the ONLY state where the rectangle is deliberately taller than the time it
+       represents. Visible only with the zoomed-in stories above for comparison. */
+    await expect(rects[0].getBoundingClientRect().height).toBeCloseTo(4, 0);
+    await expect(offsetFromSlotTop(canvasElement, rects[0])).toBeCloseTo(0, 0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same overlay in the zoomed-out calendar, where an hour is 34px rather than 180px. ' +
+          'Proportionally the band would be under two pixels, so the 4px floor takes over. Note ' +
+          "the floor is 4px here and 6px in `DayCalendar`'s copy of the same idea - two " +
+          'implementations of one affordance, with different minimums.',
+      },
+    },
+  },
+};
+
+export const DropPreviewGhost: Story = {
+  name: 'Drop preview ghost (drag over 09:30)',
+  args: {
+    draggedAppointmentId: 'appt-2',
+    draggedAppointmentLabel: DRAG_LABEL,
+    draggedAppointmentDurationMinutes: 30,
+    dropAvailabilityIntervals: [{ startMinute: 540, endMinute: 585 }],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const section = getSlotSection(canvasElement);
+    const rect = section.getBoundingClientRect();
+
+    /* The minute comes from the pointer's ratio down the cell's own rect, so the
+       pointer is placed by that ratio rather than a raw pixel. Dispatched here, above
+       any `waitFor`: a dispatch inside a retried callback re-queues on every mutation
+       and wedges the tab instead of failing. */
+    fireEvent.dragOver(section, {
+      clientX: rect.left + rect.width / 2,
+      clientY: rect.top + rect.height / 2,
+    });
+
+    const label = await canvas.findByText(DRAG_LABEL);
+    const ghost = label.parentElement as HTMLElement;
+
+    // 09:30 is inside the 09:00-09:45 interval, so the snap returns it unchanged and
+    // the ghost sits at the half-hour rule: 90px of 180px.
+    await expect(offsetFromSlotTop(canvasElement, ghost)).toBeCloseTo(90, 0);
+    /* 30 minutes would be 90px, but only 30 minutes of the hour remain, so
+       `Math.min(duration, 60 - minute % 60)` happens to agree here. The two clamps
+       coincide at the half hour and diverge everywhere else - which is exactly why
+       this reads as correct in review and still overflows at :45. */
+    await expect(ghost.getBoundingClientRect().height).toBeCloseTo(90, 0);
+    await expect(getComputedStyle(ghost).borderTopStyle).toBe('dashed');
+    // The availability band stays under it; the ghost is added, not swapped in.
+    await expect(getAvailabilityRects(canvasElement)).toHaveLength(1);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Both drag layers at once, which is the state the vet actually sees: the solid band says ' +
+          'where a drop is allowed, the dashed ghost says where THIS drop would land, and it ' +
+          "carries the dragged card's label so the two can be told apart mid-gesture.\n\n" +
+          'The ghost itself is the shared `DropPreviewOverlay`, which has its own story for the ' +
+          'clamp cases. What only exists here is the composition - the pointer handler that turns ' +
+          'a clientY into a minute, snaps it to the nearest availability interval within 12 ' +
+          'minutes, and hands it down. Drag more than 12 minutes from anything bookable and no ' +
+          'ghost draws at all.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/SlotPortals.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/SlotPortals.stories.tsx
@@ -1,0 +1,437 @@
+import { useId, useRef } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, within } from 'storybook/test';
+import type { Appointment, Invoice } from '@yosemite-crew/types';
+
+import { useOrganisationRoomStore } from '@/app/stores/roomStore';
+import { useOrgStore } from '@/app/stores/orgStore';
+import SlotPortals from './SlotPortals';
+import type { MarkerContextMenuState } from './useMarkerInteractions';
+
+const ORG_ID = 'org-storybook';
+const APPOINTMENT_ID = 'appt-slot-portals-1';
+
+const COMPANION: Appointment['patient'] = {
+  id: 'companion-poppy',
+  name: 'Poppy',
+  species: 'dog',
+  breed: 'Beagle',
+  parent: { id: 'parent-maya', name: 'Maya Whitfield' },
+};
+
+const APPOINTMENT: Appointment = {
+  id: APPOINTMENT_ID,
+  patient: COMPANION,
+  companion: COMPANION,
+  organisationId: ORG_ID,
+  lead: { id: 'practitioner-elena', name: 'Dr. Elena Marsh' },
+  room: { id: 'room-consult-2', name: 'Consult 2' },
+  appointmentType: {
+    id: 'svc-dental-consult',
+    name: 'Dental consultation',
+    speciality: { id: 'spec-dentistry', name: 'Dentistry' },
+  },
+  appointmentKind: 'OUTPATIENT',
+  appointmentDate: new Date('2026-03-12T09:30:00.000Z'),
+  startTime: new Date('2026-03-12T09:30:00.000Z'),
+  endTime: new Date('2026-03-12T10:00:00.000Z'),
+  timeSlot: '09:30 - 10:00',
+  durationMinutes: 30,
+  status: 'UPCOMING',
+  concern: 'Post-op recheck of the left carpus',
+};
+
+/**
+ * What `openPopover` measured off the clicked marker. Nothing reads its numbers -
+ * the panel is placed from `popoverStyle` - so this value is only ever a "has the
+ * anchor been measured yet" flag. It is a real DOMRect rather than a cast object so
+ * the gate is exercised with the type the calendar actually passes.
+ */
+const MARKER_RECT = new DOMRect(320, 240, 220, 56);
+
+const CONTEXT_MENU: MarkerContextMenuState = {
+  appointment: APPOINTMENT,
+  x: 520,
+  y: 24,
+};
+
+const NO_INVOICES: Record<string, Invoice> = {};
+
+/** The popover panel, wherever in the document it ended up. */
+const openPanel = (): HTMLElement | null => document.querySelector('dialog[open]');
+
+/** The right-click menu, matched on the attribute the dismiss logic keys off. */
+const contextMenuEl = (): HTMLElement | null =>
+  document.querySelector('[data-context-menu="true"]');
+
+type HarnessProps = {
+  activeEvent: Appointment | null;
+  activeRect: DOMRect | null;
+  draggedAppointmentId?: string | null;
+  contextMenu: MarkerContextMenuState | null;
+  canEditAppointments: boolean;
+  invoicesByAppointmentId: Record<string, Invoice>;
+  handleViewAppointment: (appt: Appointment) => void;
+  handleRescheduleAppointment: (appt: Appointment) => void;
+  handleChangeRoomAppointment?: (appt: Appointment) => void;
+  handleAcceptAppointment?: (appt: Appointment) => void;
+  onPopoverClose: () => void;
+  onContextMenuClose: () => void;
+};
+
+const registerAnchorEl = () => () => {};
+
+/**
+ * Stands in for `Slot`, which owns the refs, the generated popover id and both
+ * measured placements. Everything else the real slot passes through untouched.
+ *
+ * The wrapper is deliberately opaque and sized: the whole claim of these stories is
+ * that neither layer ends up inside it, so a visible block to NOT contain them is
+ * part of the evidence.
+ */
+const Harness = ({
+  activeEvent,
+  activeRect,
+  draggedAppointmentId,
+  contextMenu,
+  canEditAppointments,
+  invoicesByAppointmentId,
+  handleViewAppointment,
+  handleRescheduleAppointment,
+  handleChangeRoomAppointment,
+  handleAcceptAppointment,
+  onPopoverClose,
+  onContextMenuClose,
+}: HarnessProps) => {
+  const popoverDialogRef = useRef<HTMLDialogElement | null>(null);
+  const contextMenuRef = useRef<HTMLDivElement | null>(null);
+  const appointmentPopoverId = useId();
+
+  return (
+    <div className="min-h-[620px] bg-[var(--screen)] p-6">
+      <div
+        data-testid="slot-stand-in"
+        className="h-40 w-64 overflow-hidden rounded-2xl border border-card-border bg-card-hover p-3 text-[12px] text-[var(--ink-muted)]"
+      >
+        The hour slot. It clips its own content, which is the reason both floating layers are
+        portalled out of it.
+      </div>
+      <SlotPortals
+        activeEvent={activeEvent}
+        activeRect={activeRect}
+        draggedAppointmentId={draggedAppointmentId}
+        invoicesByAppointmentId={invoicesByAppointmentId}
+        canEditAppointments={canEditAppointments}
+        appointmentPopoverId={appointmentPopoverId}
+        popoverDialogRef={popoverDialogRef}
+        popoverStyle={{ top: 24, left: 24 }}
+        registerAnchorEl={registerAnchorEl}
+        contextMenu={contextMenu}
+        contextMenuRef={contextMenuRef}
+        contextMenuStyle={
+          contextMenu ? { top: contextMenu.y, left: contextMenu.x, width: 280 } : null
+        }
+        handleViewAppointment={handleViewAppointment}
+        handleRescheduleAppointment={handleRescheduleAppointment}
+        handleChangeRoomAppointment={handleChangeRoomAppointment}
+        handleAcceptAppointment={handleAcceptAppointment}
+        onPopoverClose={onPopoverClose}
+        onContextMenuClose={onContextMenuClose}
+      />
+    </div>
+  );
+};
+
+const meta = {
+  title: 'Appointments/Calendar/SlotPortals',
+  component: Harness,
+  parameters: {
+    layout: 'fullscreen',
+    // No `autodocs`: both layers are `position: fixed` at coordinates the calendar
+    // measures, so on a generated docs page every story would stack them at the
+    // same spot. Their contents are documented in the AppointmentPopover and
+    // AppointmentContextMenu story files.
+    //
+    // `appDirectory`: both layers call next/navigation's `useRouter`.
+    nextjs: { appDirectory: true, navigation: { pathname: '/appointments' } },
+    docs: {
+      description: {
+        component:
+          "The slot's floating layers. At rest this component renders **literally nothing** - it " +
+          'is two guarded `createPortal` calls inside a fragment - which is why nothing about it ' +
+          'has ever appeared in a snapshot, a test or a Chromatic frame.\n\n' +
+          'The popover branch needs four things true at once: a document to portal into, no drag ' +
+          'in flight, an `activeEvent`, and an `activeRect`. In the calendar that state is three ' +
+          'interactions deep - click a marker, survive the 180ms double-click timer, then have ' +
+          '`usePopoverManager` measure the anchor - so a resting `Slot` is exactly this ' +
+          'component rendering nothing.\n\n' +
+          'The gates are worth reading individually, because they are not all the same kind of ' +
+          'thing. `!draggedAppointmentId` is real behaviour: pick a card up and its popover must ' +
+          'get out of the way. `activeRect` is a measurement flag and nothing more - the panel is ' +
+          'placed entirely from `popoverStyle`, so the rect is never read, it only proves the ' +
+          'anchor was measured. And the two branches are independent here even though the calendar ' +
+          'treats them as exclusive: `useMarkerInteractions` clears one before setting the other, ' +
+          'but `SlotPortals` will happily render both, so the last story pins what would happen ' +
+          'if that invariant ever slipped.\n\n' +
+          'Both layers land on `document.body`, outside the canvas, which is the practical reason ' +
+          'this needed a story: a play function or a DOM assertion scoped to `canvasElement` finds ' +
+          'nothing here and passes for the wrong reason. Every query below is against ' +
+          '`document`, and every absence is asserted against `dialog[open]` rather than `dialog`, ' +
+          'because a closed dialog stays mounted without its `open` attribute.',
+      },
+    },
+  },
+  args: {
+    activeEvent: null,
+    activeRect: null,
+    contextMenu: null,
+    canEditAppointments: true,
+    invoicesByAppointmentId: NO_INVOICES,
+    handleViewAppointment: fn(),
+    handleRescheduleAppointment: fn(),
+    handleChangeRoomAppointment: fn(),
+    handleAcceptAppointment: fn(),
+    onPopoverClose: fn(),
+    onContextMenuClose: fn(),
+  },
+  beforeEach: () => {
+    const orgSnapshot = useOrgStore.getState();
+    const roomSnapshot = useOrganisationRoomStore.getState();
+
+    useOrgStore.setState({ primaryOrgId: ORG_ID, status: 'loaded' });
+    /* `status: 'loading'` is load-bearing, not cosmetic: the context menu calls
+       `useLoadRoomsForPrimaryOrg({ force: true })`, and that hook returns at its
+       first line on exactly this value. Without it the menu reaches for the rooms
+       endpoint the moment it portals. */
+    useOrganisationRoomStore.setState({ status: 'loading' });
+
+    return () => {
+      useOrgStore.setState(orgSnapshot);
+      useOrganisationRoomStore.setState(roomSnapshot);
+    };
+  },
+} satisfies Meta<typeof Harness>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Idle: Story = {
+  name: 'At rest (renders nothing)',
+  play: async ({ canvasElement }) => {
+    // The harness itself is on screen, so the absences below are absences and not
+    // a story that failed to mount.
+    await expect(within(canvasElement).getByTestId('slot-stand-in')).toBeVisible();
+
+    await expect(openPanel()).toBeNull();
+    await expect(contextMenuEl()).toBeNull();
+    /* Three hooks, all absent, all queried against the whole document rather than
+       the canvas - "no dialog inside the canvas" is true in every story in this
+       file, including the ones where the panel is open on document.body.
+       `dialog` rather than `dialog[open]` is the stronger claim: a closed dialog
+       stays mounted without its `open` attribute, so counting bare `dialog`
+       elements says none was ever created. */
+    await expect(document.querySelectorAll('dialog')).toHaveLength(0);
+    await expect(document.querySelectorAll('[data-popover-panel]')).toHaveLength(0);
+    await expect(document.querySelectorAll('[data-context-menu]')).toHaveLength(0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The state a resting calendar is in for the entire time nobody is clicking: no panel, no ' +
+          'menu, no dialog element in the document at all. Everything else in this file is a ' +
+          'departure from here.',
+      },
+    },
+  },
+};
+
+export const PopoverOpen: Story = {
+  name: 'Popover portal (marker clicked)',
+  args: { activeEvent: APPOINTMENT, activeRect: MARKER_RECT },
+  play: async ({ canvasElement }) => {
+    const panel = openPanel() as HTMLElement;
+    await expect(panel).not.toBeNull();
+
+    /* Where it landed is the point. `createPortal(..., document.body)` makes the
+       panel a direct child of body, so it escapes the slot's `overflow-auto` and is
+       nowhere inside the canvas - which is what a canvas-scoped assertion would
+       have silently missed. */
+    await expect(panel.parentElement).toBe(document.body);
+    await expect(canvasElement.contains(panel)).toBe(false);
+
+    // A live panel, not an empty shell: the header button and the full eight-cell
+    // detail grid both arrived through the portal. Track count as well as child
+    // count - a two-column grid holding four cells and a one-column grid holding
+    // eight are different bugs, and each check alone misses one of them.
+    const detailGrid = within(panel).getByText('Speciality').closest('.grid') as HTMLElement;
+    const tracks = getComputedStyle(detailGrid).gridTemplateColumns.trim().split(/\s+/);
+    await expect(tracks).toHaveLength(2);
+    await expect(detailGrid.children).toHaveLength(8);
+    await expect(within(panel).getByRole('button', { name: 'Poppy · Whitfield' })).toBeVisible();
+    await expect(within(panel).getByRole('button', { name: 'Start Appointment' })).toBeVisible();
+
+    // The other branch stayed shut - the two portals are separately gated.
+    await expect(contextMenuEl()).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Both popover conditions satisfied. This is what a marker click produces 180ms after the ' +
+          'pointer goes down, assuming no second click lands and no drag has begun.\n\n' +
+          'The assertion that matters is `panel.parentElement === document.body`. The slot section ' +
+          'this component renders beside is `overflow-auto` inside a 180px hour row, so a panel ' +
+          'rendered in place would be clipped to a sliver. The portal is the only reason the card ' +
+          'is visible at all.',
+      },
+    },
+  },
+};
+
+export const HiddenDuringDrag: Story = {
+  name: 'Suppressed while a card is dragged',
+  args: {
+    activeEvent: APPOINTMENT,
+    activeRect: MARKER_RECT,
+    draggedAppointmentId: 'appt-being-moved',
+  },
+  play: async ({ canvasElement }) => {
+    /* Positive control first. Everything this story claims is an absence, and a
+       story that failed to mount produces every one of those absences too - so
+       the harness has to be proven on screen before the missing panel means
+       anything. */
+    await expect(within(canvasElement).getByTestId('slot-stand-in')).toBeVisible();
+
+    /* Identical props to the story above plus one drag id, and the panel is gone.
+       Note the id belongs to a DIFFERENT appointment: the gate is "is any drag in
+       flight", not "is this appointment being dragged", so picking up any card in
+       the grid dismisses an open popover anywhere in it. */
+    await expect(openPanel()).toBeNull();
+    await expect(document.querySelectorAll('dialog')).toHaveLength(0);
+    await expect(document.querySelectorAll('[data-popover-panel]')).toHaveLength(0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A drag is in flight. `Slot` also clears `activePopoverKey` during render when the drag ' +
+          'id changes, so in the running app this gate is belt and braces - but it is the only one ' +
+          'of the two that lives in this component, and it is the reason a popover never floats ' +
+          'over a card being moved.\n\n' +
+          'Read against the story above, this pair is the whole behaviour: same event, same rect, ' +
+          'one extra prop, no panel.',
+      },
+    },
+  },
+};
+
+export const AwaitingMeasurement: Story = {
+  name: 'Event without a measured rect',
+  args: { activeEvent: APPOINTMENT, activeRect: null },
+  play: async ({ canvasElement }) => {
+    // Same positive control as the drag story: prove the mount, then the absence.
+    await expect(within(canvasElement).getByTestId('slot-stand-in')).toBeVisible();
+
+    // The rect is a precondition even though nothing ever reads its numbers, so an
+    // event that arrived before its anchor was measured draws nothing at all.
+    await expect(openPanel()).toBeNull();
+    await expect(document.querySelectorAll('dialog')).toHaveLength(0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The defensive half of the gate. `usePopoverManager.openPopover` sets the rect and the ' +
+          'key in the same tick, so this combination is not reachable by clicking - but the ' +
+          'condition is in the source, and what it does is refuse to draw rather than draw at the ' +
+          'origin.\n\n' +
+          'Worth knowing because the rect is otherwise dead weight in this component: placement ' +
+          'comes from `popoverStyle`, which `Slot` computes with `getPopoverStyle(440, 490)` from ' +
+          'that same rect one level up. Here it is a boolean wearing a DOMRect.',
+      },
+    },
+  },
+};
+
+export const ContextMenuOnly: Story = {
+  name: 'Context menu portal (right-click)',
+  args: { contextMenu: CONTEXT_MENU },
+  play: async ({ canvasElement }) => {
+    const menu = contextMenuEl() as HTMLElement;
+    await expect(menu).not.toBeNull();
+    await expect(menu.parentElement).toBe(document.body);
+    await expect(canvasElement.contains(menu)).toBe(false);
+
+    /* The rows, not just the box. Which rows appear is derived from five separate
+       predicates reading the status and the permission, so an UPCOMING booking for
+       an editor gets all eight - and an empty menu would satisfy a presence check
+       just as well. */
+    const items = within(menu)
+      .getAllByRole('menuitem')
+      .map((item) => item.textContent?.trim());
+    await expect(items).toEqual([
+      'View appointment',
+      'Open companion overview',
+      'Medical Records',
+      'Finance summary',
+      'Lab tests',
+      'Change status',
+      'Reschedule',
+      'Assign room',
+    ]);
+
+    await expect(openPanel()).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The second portal, opened on its own. It is gated on `contextMenu` **and** ' +
+          '`contextMenuStyle`, and the style is computed from the click coordinates clamped 12px ' +
+          'inside the viewport - so a right-click near the bottom edge produces a menu that has ' +
+          'already been moved before it renders.\n\n' +
+          "The menu's own behaviour (submenus, status changes, room assignment) is storied under " +
+          '`Appointments/AppointmentContextMenu`. What this story adds is that the rows survive ' +
+          'the portal hop intact and land on `document.body` rather than in the slot.',
+      },
+    },
+  },
+};
+
+export const BothLayers: Story = {
+  name: 'Both layers at once (menu wins)',
+  args: { activeEvent: APPOINTMENT, activeRect: MARKER_RECT, contextMenu: CONTEXT_MENU },
+  play: async () => {
+    const panel = openPanel() as HTMLElement;
+    const menu = contextMenuEl() as HTMLElement;
+    await expect(panel).not.toBeNull();
+    await expect(menu).not.toBeNull();
+
+    // Two independent portals, two direct children of body - neither nests inside
+    // the other, so their order is decided by z-index alone.
+    await expect(panel.parentElement).toBe(document.body);
+    await expect(menu.parentElement).toBe(document.body);
+    await expect(panel.contains(menu)).toBe(false);
+
+    // The menu is z-[1001] against the panel's z-[1000]: a single step, and the
+    // right-click menu is the layer that wins.
+    await expect(getComputedStyle(panel).zIndex).toBe('1000');
+    await expect(getComputedStyle(menu).zIndex).toBe('1001');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Both branches handed live props at the same time. The calendar never does this - ' +
+          '`handleMarkerClick` clears the menu and `handleMarkerContextMenu` clears the popover key ' +
+          '- but the exclusion lives in `useMarkerInteractions`, not here, so this is what the ' +
+          'component would draw if that ever slipped.\n\n' +
+          'The answer is a one-step z-index difference, which is a thin margin for two overlapping ' +
+          'glass panels: the menu covers the popover, the popover stays interactive underneath, ' +
+          'and neither one dismisses the other. Worth deciding deliberately rather than inheriting ' +
+          'from two literals written a hundred lines apart.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/UserCalendar.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/UserCalendar.stories.tsx
@@ -1,0 +1,519 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, waitFor, within } from 'storybook/test';
+import type { Appointment } from '@yosemite-crew/types';
+
+import type { AvailabilityInterval } from '@/app/features/appointments/components/Calendar/common/calendarInteractionProps';
+import type { Team } from '@/app/features/organization/types/team';
+import { useAuthStore } from '@/app/stores/authStore';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useTeamStore } from '@/app/stores/teamStore';
+import UserCalendar from './UserCalendar';
+
+const ORG_ID = 'org-storybook';
+const ELENA = 'practitioner-elena';
+const RAVI = 'practitioner-ravi';
+const PRIYA = 'practitioner-priya';
+
+const teamMember = (practionerId: string, name: string, todayAppointment: string): Team => ({
+  _id: `team-${practionerId}`,
+  practionerId,
+  organisationId: ORG_ID,
+  name,
+  role: 'VETERINARIAN',
+  speciality: [],
+  todayAppointment,
+  status: 'Available',
+  revokedPermissions: [],
+  effectivePermissions: [],
+  extraPerissions: [],
+});
+
+/** Three columns, which is what makes the per-member shading a per-member question at all. */
+const TEAM: Team[] = [
+  teamMember(ELENA, 'Dr. Elena Marsh', '4'),
+  teamMember(RAVI, 'Dr. Ravi Patel', '2'),
+  teamMember(PRIYA, 'Priya Raman', '0'),
+];
+
+/**
+ * Availability is handed in as minute-of-day numbers, never as instants, so the
+ * visible hour window below is the same in every timezone. Elena works two split
+ * shifts, Ravi one, and Priya is off - three shapes that produce three different
+ * dim patterns from one render.
+ *
+ * `getVisibleHourRange` pads the extremes (540 and 720) by 30 minutes and snaps to
+ * the hour, so the window is 08:00-13:00 - six hour rows at 180px each zoomed in.
+ * Every count in the play functions is derived from that window, which is why these
+ * stories deliberately pass NO events: an appointment is an instant, it is read in
+ * the preferred zone, and in a zone far enough from Europe/Berlin it would widen the
+ * window and move every number here.
+ */
+const WORKING_WINDOWS: Record<string, AvailabilityInterval[]> = {
+  [ELENA]: [
+    { startMinute: 9 * 60, endMinute: 10 * 60 },
+    { startMinute: 11 * 60, endMinute: 12 * 60 },
+  ],
+  [RAVI]: [{ startMinute: 10 * 60, endMinute: 11 * 60 + 30 }],
+  [PRIYA]: [],
+};
+
+const NO_WINDOWS: AvailabilityInterval[] = [];
+
+/** Stable module-level references: the calendar memoises on this callback's identity. */
+const workingWindows = (_date: Date, practitionerId?: string): AvailabilityInterval[] =>
+  WORKING_WINDOWS[practitionerId ?? ''] ?? NO_WINDOWS;
+
+const noWindows = (): AvailabilityInterval[] => NO_WINDOWS;
+
+const DAY = new Date('2026-03-12T10:00:00.000Z');
+
+/**
+ * One booking, used only by the stories that do not count hour rows. Its start is
+ * the same instant as the rendered day, so `isOnPreferredTimeZoneCalendarDay` holds
+ * in any zone and the marker always lands inside the window it helped compute.
+ */
+const APPOINTMENT: Appointment = {
+  id: 'appt-user-calendar-1',
+  patient: {
+    id: 'companion-poppy',
+    name: 'Poppy',
+    species: 'dog',
+    breed: 'Beagle',
+    parent: { id: 'parent-maya', name: 'Maya Whitfield' },
+  },
+  companion: {
+    id: 'companion-poppy',
+    name: 'Poppy',
+    species: 'dog',
+    breed: 'Beagle',
+    parent: { id: 'parent-maya', name: 'Maya Whitfield' },
+  },
+  organisationId: ORG_ID,
+  lead: { id: ELENA, name: 'Dr. Elena Marsh' },
+  appointmentType: {
+    id: 'svc-dental-consult',
+    name: 'Dental consultation',
+    speciality: { id: 'spec-dentistry', name: 'Dentistry' },
+  },
+  appointmentDate: DAY,
+  startTime: DAY,
+  endTime: new Date(DAY.getTime() + 30 * 60 * 1000),
+  timeSlot: '30 minutes',
+  durationMinutes: 30,
+  status: 'UPCOMING',
+  concern: 'Lameness recheck',
+};
+
+const MARKER_TITLE = 'Poppy · Whitfield • Dental consultation • Lameness recheck';
+
+const HOUR_ROW_PX = 180;
+
+/**
+ * Every member-hour cell in document order. The calendar nests hour rows outside
+ * team columns, so this list runs hour by hour, three cells at a time.
+ *
+ * The cell itself carries no test hook, but each one wraps exactly one `Slot`, and
+ * `Slot`'s section is labelled - so the labelled section's parent is the cell.
+ */
+const memberCells = (canvasElement: HTMLElement): HTMLElement[] =>
+  [...canvasElement.querySelectorAll<HTMLElement>('section[aria-label^="Appointments slot"]')].map(
+    (slot) => slot.parentElement as HTMLElement
+  );
+
+/** The cells of one team column, top hour first. */
+const columnCells = (canvasElement: HTMLElement, memberIndex: number): HTMLElement[] =>
+  memberCells(canvasElement).filter(
+    (cell) => [...(cell.parentElement as HTMLElement).children].indexOf(cell) === memberIndex
+  );
+
+/**
+ * The dim rectangles inside one cell. They have no class of their own worth
+ * matching - `pointer-events-none absolute left-0 right-0 z-1` describes half the
+ * calendar - so the identifier is the one token only they paint with.
+ */
+const dimsIn = (cell: HTMLElement): HTMLElement[] => [
+  ...cell.querySelectorAll<HTMLElement>('[style*="calendar-dim-overlay"]'),
+];
+
+const dimsForMember = (canvasElement: HTMLElement, memberIndex: number): HTMLElement[] =>
+  columnCells(canvasElement, memberIndex).flatMap((cell) => dimsIn(cell));
+
+/** The grid that lays the team columns out inside one hour row. */
+const teamGrid = (canvasElement: HTMLElement): HTMLElement =>
+  columnCells(canvasElement, 0)[0].parentElement as HTMLElement;
+
+const totalHeight = (elements: HTMLElement[]): number =>
+  elements.reduce((sum, el) => sum + el.getBoundingClientRect().height, 0);
+
+const meta = {
+  title: 'Appointments/Calendar/UserCalendar',
+  component: UserCalendar,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The day-by-practitioner planner: one column per team member, and behind every column a ' +
+          'layer of **dim rectangles marking the hours that member is not working**. That layer ' +
+          'had never been drawn.\n\n' +
+          'It is gated twice, and both gates are shut at rest. `availabilityLoaded` defaults to ' +
+          '`false`, and `getVisibleAvailabilityIntervals` is an optional prop - so a UserCalendar ' +
+          'mounted with neither computes `unavailableByMember` as three empty arrays and paints ' +
+          'nothing. Every snapshot of this view that has ever existed is the undimmed one: a grid ' +
+          'in which 3am and 3pm look equally bookable.\n\n' +
+          'The two gates are **not** symmetrical, which is the thing worth reviewing here. ' +
+          '`computeUnavailableSegments` only consults `availabilityLoaded` when the member has no ' +
+          'intervals at all. A member with a shift shades the moment the intervals arrive, ' +
+          'regardless of the flag; a member with the day off shades only once the flag flips. So ' +
+          'during the load there is a real, reachable frame in which the busiest column is greyed ' +
+          'correctly and the empty column reads as open all day. "Before availability lands" below ' +
+          'is that frame.\n\n' +
+          'Geometry is exact rather than approximate. An hour row is 180px zoomed in ' +
+          '(`getHourRowHeightPx`), segments are clamped to the hour they fall in and positioned as ' +
+          'percentages, so a shift ending at 11:30 leaves a 90px rectangle in the 11:00 row and a ' +
+          'full 180px one in every row after it. The stories assert those pixels, the per-column ' +
+          'counts, and the z-order the layer sits in - the dim is `z-1`, the hour rules are ' +
+          '`z-10`, and an appointment marker is `z-20`, so a booking is never greyed out by the ' +
+          'shading behind it.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    events: [],
+    date: DAY,
+    canEditAppointments: true,
+    // Auto-scroll parks the viewport on the first event or on the default focus
+    // minute, which would make the visible slice of a 1080px grid depend on the
+    // wall clock. Pinned to the top instead.
+    skipAutoScroll: true,
+    handleViewAppointment: fn(),
+    handleDetailAppointment: fn(),
+    handleRescheduleAppointment: fn(),
+    handleChangeRoomAppointment: fn(),
+    handleAcceptAppointment: fn(),
+    canDragAppointment: () => true,
+    onAppointmentDragStart: fn(),
+    onAppointmentDragEnd: fn(),
+    onAppointmentDropAt: fn(),
+    onDragHoverTarget: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <div className="h-[680px] w-full max-w-[1080px] bg-[var(--screen)]">
+        <Story />
+      </div>
+    ),
+  ],
+  beforeEach: () => {
+    const orgSnapshot = useOrgStore.getState();
+    const teamSnapshot = useTeamStore.getState();
+    const authSnapshot = useAuthStore.getState();
+
+    useOrgStore.setState({ primaryOrgId: ORG_ID, status: 'loaded' });
+    useTeamStore.getState().setTeamsForOrg(ORG_ID, TEAM);
+    /* Seeded rather than left alone. `UserLabels` paints the column header in
+       --blue-text when `attributes.sub` matches a member's practitioner id, and
+       other story files in this Storybook seed that same singleton with real
+       practitioner ids. Without an explicit value here, which column reads as "you"
+       depends on which story you happened to open first. This id is nobody on the
+       team, so no column is highlighted in any order. */
+    useAuthStore.setState({ attributes: { sub: 'practitioner-not-on-this-team' } });
+
+    return () => {
+      useOrgStore.setState(orgSnapshot);
+      useTeamStore.setState(teamSnapshot);
+      useAuthStore.setState(authSnapshot);
+    };
+  },
+} satisfies Meta<typeof UserCalendar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Resting: Story = {
+  name: 'At rest (no availability wired)',
+  args: { events: [APPOINTMENT] },
+  play: async ({ canvasElement }) => {
+    const cells = memberCells(canvasElement);
+    // Three columns in every hour row, so the cell count is always a multiple of 3.
+    await expect(cells.length).toBeGreaterThan(0);
+    await expect(cells.length % 3).toBe(0);
+
+    /* The whole finding, in one line: with no interval provider and the flag
+       false, not a single rectangle is painted anywhere in the grid. */
+    await expect(cells.flatMap((cell) => dimsIn(cell))).toHaveLength(0);
+
+    const grid = teamGrid(canvasElement);
+    const tracks = getComputedStyle(grid).gridTemplateColumns.trim().split(/\s+/);
+    await expect(tracks).toHaveLength(3);
+    await expect(grid.children).toHaveLength(3);
+
+    // The rest of the calendar is fully drawn, which is what makes the missing
+    // layer easy to miss: markers, rules and headers all render.
+    await expect(within(canvasElement).getByTitle(MARKER_TITLE)).toBeInTheDocument();
+    await expect(within(canvasElement).getByText('Dr. Elena Marsh')).toBeInTheDocument();
+    await expect(within(canvasElement).getByText('Priya Raman')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The planner as every existing snapshot holds it. Priya has no bookings and no hours, ' +
+          'Elena has one appointment, and the two columns are drawn identically - both plain, both ' +
+          'reading as open for the full window. This is the baseline the next three stories are ' +
+          'read against.',
+      },
+    },
+  },
+};
+
+export const WorkingHours: Story = {
+  name: 'Availability loaded (three shift shapes)',
+  args: {
+    getVisibleAvailabilityIntervals: workingWindows,
+    getDropAvailabilityIntervals: workingWindows,
+    availabilityLoaded: true,
+  },
+  play: async ({ canvasElement }) => {
+    const rows = memberCells(canvasElement).length / 3;
+    // 08:00-13:00: the availability extremes (09:00 and 12:00) padded by 30
+    // minutes and snapped to the hour.
+    await expect(rows).toBe(6);
+
+    const elena = dimsForMember(canvasElement, 0);
+    const ravi = dimsForMember(canvasElement, 1);
+    const priya = dimsForMember(canvasElement, 2);
+
+    /* Counts, not presence. Elena's two shifts leave three gaps, but the 12:00-14:00
+       tail crosses an hour boundary and is clamped into two rectangles, so four.
+       Ravi's single shift leaves two gaps that clamp into five. Priya's empty
+       interval list becomes one segment across the whole window - one rectangle per
+       row. A change that stopped closing the trailing gap would show up here as
+       3 / 4 / 6 rather than as a silently bookable evening. */
+    await expect(elena).toHaveLength(4);
+    await expect(ravi).toHaveLength(5);
+    await expect(priya).toHaveLength(6);
+
+    /* Total dimmed height is the real reviewable number: of the six hours on
+       screen Elena is free for two, Ravi for one and a half, Priya for none. */
+    await expect(Math.round(totalHeight(elena))).toBe(4 * HOUR_ROW_PX);
+    await expect(Math.round(totalHeight(ravi))).toBe(4.5 * HOUR_ROW_PX);
+    await expect(Math.round(totalHeight(priya))).toBe(rows * HOUR_ROW_PX);
+
+    // Ravi's shift ends at 11:30, so his third rectangle is the half-hour tail of
+    // the 11:00 row - the only partial one in the grid.
+    await expect(Math.round(ravi[0].getBoundingClientRect().height)).toBe(HOUR_ROW_PX);
+    await expect(Math.round(ravi[2].getBoundingClientRect().height)).toBe(HOUR_ROW_PX / 2);
+    await expect(Math.round(ravi[3].getBoundingClientRect().height)).toBe(HOUR_ROW_PX);
+
+    // `left-0 right-0`: a rectangle spans its own column and stops there.
+    const firstCell = columnCells(canvasElement, 2)[0];
+    await expect(Math.round(priya[0].getBoundingClientRect().width)).toBe(
+      Math.round(firstCell.getBoundingClientRect().width)
+    );
+
+    /* The wash itself. Polled rather than read once: the rectangle carries an
+       inline `transition: opacity 0.25s ease`, so a play function can arrive
+       mid-transition. The channels are asserted rather than the exact
+       serialisation of `rgba(0, 0, 0, 0.045)` - what the design owns is "black at
+       about 4.5%", not how a browser prints three decimal places. */
+    await waitFor(() => {
+      const background = getComputedStyle(priya[0]).backgroundColor;
+      const alpha = Number(/^rgba\(0, 0, 0, ([\d.]+)\)$/.exec(background)?.[1]);
+      expect(alpha).toBeGreaterThan(0.03);
+      expect(alpha).toBeLessThan(0.06);
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The loaded state, with three deliberately different shift shapes in one render: a split ' +
+          'shift, a shift that ends mid-hour, and a day off.\n\n' +
+          'The mid-hour end is the case worth looking at. Segments are clamped to the hour row ' +
+          'they fall in and sized as a percentage of it, so 11:30 is a 90px rectangle sitting on ' +
+          'the bottom half of the 11:00 row with no rule of its own to land on - the sub-hour grid ' +
+          'lines are drawn at the 15-minute steps by a separate layer, and nothing guarantees a ' +
+          'shift boundary coincides with one.',
+      },
+    },
+  },
+};
+
+export const BeforeAvailabilityLands: Story = {
+  name: 'Before availability lands (asymmetric gate)',
+  args: {
+    getVisibleAvailabilityIntervals: workingWindows,
+    getDropAvailabilityIntervals: workingWindows,
+    availabilityLoaded: false,
+  },
+  play: async ({ canvasElement }) => {
+    // The window is computed from the same intervals, so the grid is identical to
+    // the loaded story: six rows. Only the shading differs.
+    await expect(memberCells(canvasElement).length / 3).toBe(6);
+
+    await expect(dimsForMember(canvasElement, 0)).toHaveLength(4);
+    await expect(dimsForMember(canvasElement, 1)).toHaveLength(5);
+    /* Priya's column: identical props, identical intervals (none), and no shading
+       at all - because `computeUnavailableSegments` returns `[]` for an empty
+       interval list until the flag flips. Her day off is indistinguishable from a
+       fully open day for as long as the load takes. */
+    await expect(dimsForMember(canvasElement, 2)).toHaveLength(0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same intervals as the story above with `availabilityLoaded` still `false` - the ' +
+          'frame the planner actually renders while the availability request is in flight.\n\n' +
+          'Elena and Ravi are shaded exactly as they will be when the flag flips, because their ' +
+          'segments are derived from intervals that are already here. Priya is not shaded at all. ' +
+          'The flag is doing one job only: distinguishing "this member has no hours today" from ' +
+          '"we do not know this member\'s hours yet", and it only reaches the render in the second ' +
+          'case. A reviewer should decide whether an unknown column should stay plain, or whether ' +
+          'the whole grid should hold its shading back until the flag is true - the two columns ' +
+          'here disagree about which it is.',
+      },
+    },
+  },
+};
+
+export const ClosedDay: Story = {
+  name: 'Clinic closed (dim under a marker)',
+  args: {
+    events: [APPOINTMENT],
+    getVisibleAvailabilityIntervals: noWindows,
+    getDropAvailabilityIntervals: noWindows,
+    availabilityLoaded: true,
+    onCreateAppointmentAt: fn(),
+  },
+  play: async ({ canvasElement }) => {
+    const cells = memberCells(canvasElement);
+    await expect(cells.length).toBeGreaterThan(0);
+    // Nobody has hours, so every cell in the grid carries exactly one full-row
+    // rectangle - the count is the same whatever window the event produces.
+    cells.forEach((cell) => {
+      expect(dimsIn(cell)).toHaveLength(1);
+      expect(Math.round(dimsIn(cell)[0].getBoundingClientRect().height)).toBe(HOUR_ROW_PX);
+    });
+
+    /* Stacking, read off the three layers that share one cell. Nothing here creates
+       a stacking context, so the marker's z-20 competes directly with the dim's
+       z-1: a booking on a closed day is drawn at full strength over the wash, not
+       greyed out with it. */
+    const markerBox = canvasElement.querySelector<HTMLElement>(
+      'section[aria-label^="Appointments slot"] div.z-20'
+    ) as HTMLElement;
+    const markerCell = (markerBox.closest('section') as HTMLElement).parentElement as HTMLElement;
+    const dim = dimsIn(markerCell)[0];
+    const hourRules = markerCell.querySelector<HTMLElement>('div.z-10') as HTMLElement;
+
+    await expect(getComputedStyle(dim).zIndex).toBe('1');
+    await expect(getComputedStyle(hourRules).zIndex).toBe('10');
+    await expect(getComputedStyle(markerBox).zIndex).toBe('20');
+    await expect(within(markerCell).getByTitle(MARKER_TITLE)).toBeInTheDocument();
+
+    /* The booking affordance underneath. `SlotCreateButton` is an invisible
+       full-slot button and the wash is `pointer-events-none`, so the wash covers
+       the button's whole box without intercepting a single click on it - a closed
+       hour still takes a booking click, and only `tryCreateAppointmentAt`'s own
+       guard (a warning toast) turns it away. */
+    const createButton = within(markerCell).getByRole('button', {
+      name: /^Create appointment on /,
+    });
+    await expect(getComputedStyle(dim).pointerEvents).toBe('none');
+    const dimBox = dim.getBoundingClientRect();
+    const buttonBox = createButton.getBoundingClientRect();
+    await expect(dimBox.top).toBeLessThanOrEqual(buttonBox.top);
+    await expect(dimBox.bottom).toBeGreaterThanOrEqual(buttonBox.bottom);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Availability loaded and nobody rostered: the whole grid washes out. This is the render ' +
+          'that shows the layer is decoration over a live surface rather than a mask.\n\n' +
+          'Two facts a reviewer should weigh. The appointment marker sits above the wash at ' +
+          '`z-20`, which is right - a booking that already exists on a closed day must stay ' +
+          'legible. The invisible create button also sits above it, and the wash is ' +
+          '`pointer-events-none`, so every dimmed minute still accepts a click and answers with a ' +
+          '"Slot unavailable" toast. Whether shading that reads as disabled should behave as ' +
+          'clickable is a design decision, and this is the first story in which it is visible.',
+      },
+    },
+  },
+};
+
+export const NarrowColumns: Story = {
+  name: 'Phone width (170px column floor)',
+  args: {
+    getVisibleAvailabilityIntervals: workingWindows,
+    getDropAvailabilityIntervals: workingWindows,
+    availabilityLoaded: true,
+  },
+  // Pinned as a GLOBAL. `parameters.viewport.defaultViewport` was removed in
+  // Storybook 10: it still type-checks and still renders, at the full panel width,
+  // proving nothing. `mobile` is the 375px preset registered in .storybook/preview.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const grid = teamGrid(canvasElement);
+    const columnWidths = [...grid.children].map(
+      (column) => (column as HTMLElement).getBoundingClientRect().width
+    );
+
+    /* Both halves of the grid contract, because either one alone can pass while
+       the layout is wrong: three declared tracks with a column missing still
+       reads as three tracks, and three children in a one-track grid stack. */
+    const tracks = getComputedStyle(grid).gridTemplateColumns.trim().split(/\s+/);
+    await expect(tracks).toHaveLength(3);
+    await expect(grid.children).toHaveLength(3);
+    await expect(columnWidths).toHaveLength(3);
+    // `getCalendarColumnGridStyle(3, 170)` - the floor is what keeps a name and a
+    // subline legible, and it is the reason this view scrolls sideways instead of
+    // squeezing. Measured off the box, not `getComputedStyle().width`, which would
+    // report the content box.
+    columnWidths.forEach((width) => {
+      expect(width).toBeGreaterThanOrEqual(170);
+    });
+    await expect(Math.round(columnWidths.reduce((sum, width) => sum + width, 0))).toBe(
+      Math.round(grid.getBoundingClientRect().width)
+    );
+
+    // 3 x 170 plus the two 64px gutters is 638px against a 375px viewport, so the
+    // outer container is genuinely scrollable rather than merely allowed to be.
+    const scroller = canvasElement.querySelector<HTMLElement>(
+      '[data-calendar-scroll="true"]'
+    ) as HTMLElement;
+    await expect(scroller.scrollWidth).toBeGreaterThan(scroller.clientWidth);
+
+    /* The time gutter is `sticky left-0`, which is the only thing keeping the hour
+       readable once the grid is scrolled. Its text is the full label set for the
+       first row: the hour plus the three 15-minute steps, which only render because
+       a 180px row leaves 45px per step. */
+    const gutter = canvasElement.querySelector<HTMLElement>(
+      'div.sticky.left-0.z-20'
+    ) as HTMLElement;
+    await expect(getComputedStyle(gutter).position).toBe('sticky');
+    await expect(gutter).toHaveTextContent('8:00 AM');
+    await expect(gutter).toHaveTextContent('8:15 AM');
+    await expect(gutter).toHaveTextContent('8:45 AM');
+
+    // The shading survives the narrow layout unchanged - it is positioned in
+    // percentages, so it tracks the column rather than a pixel width.
+    await expect(dimsForMember(canvasElement, 2)).toHaveLength(6);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same loaded grid at 375px. Nothing about this view re-forms for a phone: the ' +
+          'columns hit their 170px floor, the container scrolls horizontally, and the time gutter ' +
+          'and the day band stay pinned with `sticky left-0`.\n\n' +
+          'Worth reviewing together with the shading, because the two interact: a wash positioned ' +
+          'with `left-0 right-0` inside a 170px column is a much denser stripe than the same wash ' +
+          'in a 300px one, and the 15-minute rules underneath it stay at full contrast either way.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/WeekCalendar.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/WeekCalendar.stories.tsx
@@ -1,0 +1,275 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, within } from 'storybook/test';
+import type { Appointment } from '@yosemite-crew/types';
+
+import WeekCalendar from './WeekCalendar';
+
+const ORG_ID = 'org-storybook';
+
+/** Monday 13 July 2026. `getWeekDays` runs Mon-Sun, so index 6 is the Sunday. */
+const WEEK_START = new Date('2026-07-13T12:00:00.000Z');
+
+/**
+ * Availability is handed in as minute-of-day numbers, so it reads the same in every
+ * timezone. 08:30-10:00 and 11:00-13:15 - deliberately NOT on the hour, so the
+ * percentage geometry of a part-hour dim band is exercised rather than a run of
+ * 0%/100% rectangles that would pass with the maths inverted.
+ */
+const AVAILABILITY = [
+  { startMinute: 510, endMinute: 600 },
+  { startMinute: 660, endMinute: 795 },
+];
+
+const appointment = (
+  id: string,
+  name: string,
+  startIso: string,
+  durationMinutes: number
+): Appointment => {
+  const startTime = new Date(startIso);
+  const endTime = new Date(startTime.getTime() + durationMinutes * 60 * 1000);
+  return {
+    id,
+    patient: {
+      id: `companion-${id}`,
+      name,
+      species: 'dog',
+      breed: 'Beagle',
+      parent: { id: `parent-${id}`, name: 'Lena Hartmann' },
+    },
+    companion: {
+      id: `companion-${id}`,
+      name,
+      species: 'dog',
+      breed: 'Beagle',
+      parent: { id: `parent-${id}`, name: 'Lena Hartmann' },
+    },
+    organisationId: ORG_ID,
+    room: { id: 'room-consult-1', name: 'Consult 1' },
+    appointmentDate: startTime,
+    startTime,
+    endTime,
+    timeSlot: '09:00 - 09:30',
+    durationMinutes,
+    status: 'UPCOMING',
+    concern: 'Lameness recheck',
+  };
+};
+
+/**
+ * 07:00 and 10:00 UTC are 09:00 and 12:00 in the preferred zone (Europe/Berlin).
+ * Both sit inside the availability span above, so the visible hour range is the
+ * same in every story here - 08:00 to 14:00 - and the two shading stories can be
+ * read directly against the unshaded one.
+ */
+const EVENTS: Appointment[] = [
+  appointment('appt-1', 'Milo', '2026-07-14T07:00:00.000Z', 30),
+  appointment('appt-2', 'Nala', '2026-07-15T10:00:00.000Z', 45),
+];
+
+const getDimOverlays = (canvasElement: HTMLElement): HTMLElement[] =>
+  Array.from(canvasElement.querySelectorAll<HTMLElement>('[style*="calendar-dim-overlay"]'));
+
+/** The hour row carrying a given gutter label, e.g. '8:00 AM'. */
+const getHourRow = (canvasElement: HTMLElement, hourLabel: string): HTMLElement =>
+  within(canvasElement).getByText(hourLabel).closest('.yc-week-grid__shell') as HTMLElement;
+
+/** The seven-day column grid inside one hour row. */
+const getDayColumnsGrid = (canvasElement: HTMLElement, hourLabel: string): HTMLElement =>
+  getHourRow(canvasElement, hourLabel).querySelector('.grid') as HTMLElement;
+
+/** Column index of the day cell an overlay is painted into, 0 = Monday. */
+const getDayColumnIndex = (overlay: HTMLElement): number => {
+  const cell = overlay.parentElement as HTMLElement;
+  return Array.from(cell.parentElement?.children ?? []).indexOf(cell);
+};
+
+const meta = {
+  title: 'Appointments/Calendar/WeekCalendar',
+  component: WeekCalendar,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The seven-day grid, and the shading that tells a receptionist which hours the clinic is ' +
+          'actually open.\n\n' +
+          'That shading had never been drawn. `availabilityLoaded` defaults to `false` and ' +
+          '`getVisibleAvailabilityIntervals` returns `[]` until an async fetch resolves, and ' +
+          '`computeUnavailableSegments` returns an empty list for that combination - so the ' +
+          'resting render of this component, the one every static frame captures, is a grid with ' +
+          'ZERO shading in which every hour of every day reads as bookable. The real product ' +
+          'state, a week with its closed hours dimmed, only exists after a network round trip.\n\n' +
+          'The empty-and-loaded case inverts the same branch and is the one that matters ' +
+          'clinically: no intervals plus `availabilityLoaded: true` means the day is CLOSED, and ' +
+          'the helper returns one segment covering the whole visible range. Get the flag wrong in ' +
+          'either direction and a closed Sunday is indistinguishable from a Sunday whose rota has ' +
+          'not loaded yet.\n\n' +
+          'The overlays are positioned in percentages of their own hour cell rather than pixels, ' +
+          'so a part-hour band is `top: 25%` of a 180px row. The stories assert both the ' +
+          'percentage the formula produces and the pixel it resolves to, because a percentage ' +
+          'against a collapsed parent still reads as a correct style attribute.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    events: EVENTS,
+    weekStart: WEEK_START,
+    canEditAppointments: true,
+    // Auto-scroll parks the grid on the first event, which would make the visible
+    // slice of a 1260px column depend on the wall clock. Pinned to the top instead.
+    skipAutoScroll: true,
+    handleViewAppointment: fn(),
+    handleDetailAppointment: fn(),
+    handleRescheduleAppointment: fn(),
+    handleChangeRoomAppointment: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <div className="h-[560px] w-[1100px] max-w-full bg-[var(--screen)]">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof WeekCalendar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const AvailabilityLoading: Story = {
+  name: 'Availability not loaded (the resting render)',
+  args: {
+    availabilityLoaded: false,
+    getVisibleAvailabilityIntervals: () => [],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* The grid is complete before it is empty of shading, and both halves of that
+       are asserted: seven day tracks carrying seven day cells, and seven hour rows
+       running 08:00 to 14:00. A grid that lost a column would still report zero dim
+       overlays, so the count below only means something next to these. */
+    const dayGrid = getDayColumnsGrid(canvasElement, '8:00 AM');
+    await expect(getComputedStyle(dayGrid).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(7);
+    await expect(dayGrid.children).toHaveLength(7);
+    await expect(canvas.getAllByText(/^\d{1,2}:00 (AM|PM)$/)).toHaveLength(7);
+    await expect(canvas.getByText('8:00 AM')).toBeInTheDocument();
+    await expect(canvas.getByText('2:00 PM')).toBeInTheDocument();
+    await expect(canvas.queryByText('7:00 AM')).toBeNull();
+    await expect(canvas.getByText('Milo · Hartmann')).toBeInTheDocument();
+    await expect(canvas.getByText('Nala · Hartmann')).toBeInTheDocument();
+
+    /* And not one hour is dimmed. This is not an empty-data story: it is the default
+       prop values, which is what makes it worth drawing. Every hour of every day
+       reads as open, including the ones the clinic is shut. */
+    await expect(getDimOverlays(canvasElement)).toHaveLength(0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The component with its own defaults, which is what mounts on every page load before the ' +
+          'availability request comes back. `computeUnavailableSegments` short-circuits on an ' +
+          'empty interval list when `availabilityLoaded` is false, so the grid is uniformly open.\n\n' +
+          'This is the correct behaviour - guessing at closed hours before the rota arrives would ' +
+          'be worse - but it means the shaded state below is the one a reviewer has never seen, ' +
+          'and the one that regresses unnoticed.',
+      },
+    },
+  },
+};
+
+export const AvailabilityLoaded: Story = {
+  name: 'Availability loaded (closed hours dimmed)',
+  args: {
+    availabilityLoaded: true,
+    getVisibleAvailabilityIntervals: () => AVAILABILITY,
+  },
+  play: async ({ canvasElement }) => {
+    /* Four bands per day: 08:00-08:30 before opening, the 10:00-11:00 lunch gap, and
+       13:15-15:00 after close, which straddles two hour rows and so paints twice.
+       Seven days: 28. A miscount here means a day column lost its shading entirely,
+       which no visual diff of a single cell would catch. */
+    await expect(getDimOverlays(canvasElement)).toHaveLength(28);
+
+    // The 08:00 row: the clinic opens at 08:30, so the band is the TOP half of the row.
+    const openingRow = getHourRow(canvasElement, '8:00 AM');
+    const openingBands = Array.from(
+      openingRow.querySelectorAll<HTMLElement>('[style*="calendar-dim-overlay"]')
+    );
+    await expect(openingBands).toHaveLength(7);
+    await expect(openingBands[0].style.top).toBe('0%');
+    await expect(openingBands[0].style.height).toBe('50%');
+    // The percentage has to resolve against the 180px hour cell, not a collapsed
+    // parent - a correct-looking style attribute over a zero-height box shades nothing.
+    await expect(openingBands[0].getBoundingClientRect().height).toBeCloseTo(90, 0);
+
+    /* The 13:00 row is the interesting one: availability ends at 13:15, so the band
+       starts a quarter of the way down rather than at the top. This is the only
+       assertion in the file that would still pass with `topPct` and `heightPct`
+       swapped if both were whole hours - which is why the fixture is 13:15. */
+    const closingRow = getHourRow(canvasElement, '1:00 PM');
+    const closingBands = Array.from(
+      closingRow.querySelectorAll<HTMLElement>('[style*="calendar-dim-overlay"]')
+    );
+    await expect(closingBands).toHaveLength(7);
+    await expect(closingBands[0].style.top).toBe('25%');
+    await expect(closingBands[0].style.height).toBe('75%');
+    await expect(closingBands[0].getBoundingClientRect().height).toBeCloseTo(135, 0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The state the product actually runs in once the rota resolves: 08:30-10:00 and ' +
+          '13:15 close, with everything outside dimmed by `--color-calendar-dim-overlay`.\n\n' +
+          'Segments are computed as the COMPLEMENT of availability across the visible range, then ' +
+          'clipped per hour cell, so a segment that spans a row boundary paints two rectangles ' +
+          'rather than one tall one. The overlay sits at `z-1`, under both the drag highlights ' +
+          'and the appointment markers, so a booking already made outside opening hours still ' +
+          'reads clearly through the dim.',
+      },
+    },
+  },
+};
+
+export const ClosedDay: Story = {
+  name: 'Availability loaded, Sunday closed',
+  args: {
+    availabilityLoaded: true,
+    // Sunday returns no intervals at all. With the loaded flag set, that means
+    // CLOSED - not "unknown" - and the helper answers with one full-range segment.
+    getVisibleAvailabilityIntervals: (day: Date) => (day.getDay() === 0 ? [] : AVAILABILITY),
+  },
+  play: async ({ canvasElement }) => {
+    // Six open days at four bands each, plus a Sunday dimmed in all seven hour rows.
+    await expect(getDimOverlays(canvasElement)).toHaveLength(31);
+
+    /* 09:00 is inside the open days' availability, so the only band in that row belongs
+       to the closed column - and it must be the last one, Sunday. Asserting the column
+       index rather than merely the count is what makes this a real check: an
+       off-by-one in `getWeekDays` would shade Saturday and still count 31. */
+    const openHourRow = getHourRow(canvasElement, '9:00 AM');
+    const bands = Array.from(
+      openHourRow.querySelectorAll<HTMLElement>('[style*="calendar-dim-overlay"]')
+    );
+    await expect(bands).toHaveLength(1);
+    await expect(getDayColumnIndex(bands[0])).toBe(6);
+    await expect(bands[0].style.top).toBe('0%');
+    await expect(bands[0].style.height).toBe('100%');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The branch that separates "closed" from "still loading", and the reason the two cannot ' +
+          'share a render. An empty interval list with `availabilityLoaded: true` produces a ' +
+          'single segment spanning the whole visible range, so the Sunday column is dimmed top to ' +
+          'bottom while the other six keep their normal opening bands.\n\n' +
+          'Flip the flag and this column becomes indistinguishable from an open one, which is ' +
+          'exactly the failure the loading story above documents.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneCalendar.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneCalendar.stories.tsx
@@ -1,0 +1,399 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+import type { Appointment } from '@yosemite-crew/types';
+
+import PhoneCalendar from './PhoneCalendar';
+import type { Team } from '@/app/features/organization/types/team';
+import type { Task } from '@/app/features/tasks/types/task';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useTaskStore } from '@/app/stores/taskStore';
+import { useTeamStore } from '@/app/stores/teamStore';
+
+const ORG_ID = 'org-storybook';
+const ME = 'vet-weber';
+
+/**
+ * Instants are UTC in the middle of the working day. Every date key this screen
+ * derives is computed in the PREFERRED zone (Europe/Berlin, +2 in July), never the
+ * browser's, so an 08:00-17:00 UTC fixture keeps its day on any machine - and the
+ * context label below reads "Tue 14 Jul" everywhere.
+ */
+const NOW = new Date('2026-07-14T09:20:00.000Z');
+const CURRENT_DATE = new Date('2026-07-14T12:00:00.000Z');
+const WEEK_START = new Date('2026-07-13T12:00:00.000Z');
+
+const appointment = (
+  id: string,
+  name: string,
+  startIso: string,
+  status: Appointment['status'] = 'UPCOMING'
+): Appointment => {
+  const startTime = new Date(startIso);
+  return {
+    id,
+    patient: {
+      id: `companion-${id}`,
+      name,
+      species: 'dog',
+      breed: 'Beagle',
+      parent: { id: `parent-${id}`, name: 'Lena Hartmann' },
+    },
+    companion: {
+      id: `companion-${id}`,
+      name,
+      species: 'dog',
+      breed: 'Beagle',
+      parent: { id: `parent-${id}`, name: 'Lena Hartmann' },
+    },
+    organisationId: ORG_ID,
+    lead: { id: ME, name: 'Elena Weber' },
+    room: { id: 'room-consult-1', name: 'Consult 1' },
+    appointmentType: {
+      id: 'type-1',
+      name: 'Lameness recheck',
+      speciality: { id: 'spec-1', name: 'General practice' },
+    },
+    appointmentDate: startTime,
+    startTime,
+    endTime: new Date(startTime.getTime() + 30 * 60 * 1000),
+    timeSlot: '10:00 - 10:30',
+    durationMinutes: 30,
+    status,
+    concern: 'Post-op recheck',
+  };
+};
+
+/** Tuesday's two bookings - the pair the day header counts. */
+const DAY_EVENTS: Appointment[] = [
+  appointment('appt-1', 'Milo', '2026-07-14T08:00:00.000Z', 'COMPLETED'),
+  appointment('appt-2', 'Nala', '2026-07-14T10:30:00.000Z'),
+];
+
+/** The rest of the week, so the week and month views have something to bucket. */
+const WEEK_EVENTS: Appointment[] = [
+  ...DAY_EVENTS,
+  appointment('appt-3', 'Juno', '2026-07-15T09:00:00.000Z'),
+  appointment('appt-4', 'Otto', '2026-07-15T13:00:00.000Z'),
+  appointment('appt-5', 'Bruno', '2026-07-17T11:00:00.000Z'),
+];
+
+const TEAM: Team[] = [
+  {
+    _id: 'team-1',
+    practionerId: ME,
+    organisationId: ORG_ID,
+    name: 'Elena Weber',
+    role: 'VETERINARIAN',
+    speciality: [],
+    status: 'Available',
+    revokedPermissions: [],
+    effectivePermissions: [],
+    extraPerissions: [],
+  },
+];
+
+const TASKS: Task[] = [
+  {
+    _id: 'task-1',
+    organisationId: ORG_ID,
+    assignedTo: ME,
+    audience: 'EMPLOYEE_TASK',
+    source: 'CUSTOM',
+    category: 'GENERAL',
+    status: 'PENDING',
+    name: 'Chase Bruno’s haematology result',
+    dueAt: new Date('2026-07-14T13:00:00.000Z'),
+  },
+];
+
+/**
+ * Seeds the three stores this screen reads, and puts them back afterwards.
+ *
+ * `taskIdsByOrgId` carrying the org key is what keeps the mount off the network:
+ * `useLoadTasksForPrimaryOrg` returns at its own `Object.hasOwn` guard, so there is
+ * no task service stub anywhere here and the component under review is the real one.
+ * `useTeamForPrimaryOrg` and `useCompanionsForPrimaryOrg` are plain selectors with
+ * no loader, so seeding is enough for them too.
+ */
+const seedStores = () => {
+  const orgSnapshot = useOrgStore.getState();
+  const taskSnapshot = useTaskStore.getState();
+  const teamSnapshot = useTeamStore.getState();
+
+  useOrgStore.setState({ primaryOrgId: ORG_ID, status: 'loaded' });
+  useTaskStore.setState({
+    tasksById: Object.fromEntries(TASKS.map((item) => [item._id, item])),
+    taskIdsByOrgId: { [ORG_ID]: TASKS.map((item) => item._id) },
+    status: 'loaded',
+  });
+  useTeamStore.setState({
+    teamsById: Object.fromEntries(TEAM.map((item) => [item._id, item])),
+    teamIdsByOrgId: { [ORG_ID]: TEAM.map((item) => item._id) },
+    status: 'loaded',
+  });
+
+  return () => {
+    useOrgStore.setState(orgSnapshot);
+    useTaskStore.setState(taskSnapshot);
+    useTeamStore.setState(teamSnapshot);
+  };
+};
+
+const meta = {
+  title: 'Appointments/Calendar/PhoneCalendar',
+  component: PhoneCalendar,
+  // A 375px phone. Pinned as a GLOBAL: `parameters.viewport.defaultViewport` was
+  // removed in Storybook 10 and is inert - a story pinned the old way renders the
+  // desktop branch at full panel width under a name that promises a phone.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The whole phone calendar below 768px, and the four screens it switches between.\n\n' +
+          'They are mutually exclusive early returns, not tabs - each branch replaces the last, ' +
+          'including the chrome around it, so the four are impossible to see side by side in the ' +
+          'running app and only one of the four children (`PhoneMonthOverview`) had a story of its ' +
+          'own. What had never been drawn is the SWITCHING: which pill owns which axis, what ' +
+          'survives a switch, and what leaks back up to the page.\n\n' +
+          'Two pills, two axes. The **mode** pill (Clinic / My day) exists on every clinic screen ' +
+          'because `PhoneMyDayRail` owns the toggle on its own screen and the desktop Header is ' +
+          'not rendered at this width - without it a phone user could reach My day and never get ' +
+          'back. The **view** pill (Day / Week / Month) is clinic-only, and `month` is deliberately ' +
+          'NOT pushed back up: the shared `activeCalendar` union has no such value, and widening ' +
+          'it would ripple into the desktop Header and all three desktop grids. So switching to ' +
+          'Month changes the phone and tells the page nothing, which the story below asserts ' +
+          'directly rather than by inspection.\n\n' +
+          'The stores are seeded rather than mocked - `useLoadTasksForPrimaryOrg` bails at its own ' +
+          'guard once the org key is present, so these mount the real component with no network ' +
+          'and no service stub.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    appointments: WEEK_EVENTS,
+    dayEvents: DAY_EVENTS,
+    currentDate: CURRENT_DATE,
+    setCurrentDate: fn(),
+    weekStart: WEEK_START,
+    setWeekStart: fn(),
+    activeCalendar: 'day',
+    setActiveCalendar: fn(),
+    onSelectAppointment: fn(),
+    onOpenWorkspace: fn(),
+    onCreateFromCalendarSlot: fn(),
+    canEditAppointments: true,
+    currentUserPractitionerId: ME,
+    now: NOW,
+  },
+  decorators: [
+    (Story) => (
+      <div className="h-[780px] w-full bg-[var(--screen)]">
+        <Story />
+      </div>
+    ),
+  ],
+  beforeEach: seedStores,
+} satisfies Meta<typeof PhoneCalendar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const DayView: Story = {
+  name: 'Day',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole('heading', { name: 'Schedule' })).toBeInTheDocument();
+    /* Three derived values in one line: the day formatted in the preferred zone, the
+       signed-in vet's name resolved out of the team store by practitioner id, and the
+       count of THIS day's bookings rather than the week's. */
+    await expect(canvas.getByText('Tue 14 Jul · Elena Weber · 2 booked')).toBeInTheDocument();
+    await expect(canvas.getByRole('group', { name: 'Select a day' })).toBeInTheDocument();
+    await expect(canvas.getByRole('region', { name: 'Day schedule' })).toBeInTheDocument();
+
+    const viewPill = within(canvas.getByRole('group', { name: 'Calendar view' }));
+    await expect(viewPill.getByRole('button', { name: 'Day' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    await expect(viewPill.getByRole('button', { name: 'Month' })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+
+    const modePill = within(canvas.getByRole('group', { name: 'Clinic or my day' }));
+    await expect(modePill.getByRole('button', { name: 'Clinic' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+
+    // The other three branches are absent, not merely hidden - these are early returns.
+    await expect(canvas.queryByRole('region', { name: 'Month overview' })).toBeNull();
+    await expect(canvas.queryByRole('region', { name: 'My day' })).toBeNull();
+    await expect(canvas.queryByRole('button', { name: 'Previous week' })).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The default branch: any `activeCalendar` that is not `week` or `team` seeds it. A ' +
+          'proportional day rail with the empty hours folded, its own date strip rather than a ' +
+          'shrunken week header, and both pills above.',
+      },
+    },
+  },
+};
+
+export const WeekView: Story = {
+  name: 'Week',
+  args: { activeCalendar: 'week' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole('button', { name: 'Previous week' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Next week' })).toBeInTheDocument();
+
+    /* The week's own view switcher is a `radiogroup`, not a SegmentedPill - the two
+       controls do the same job with different roles, so a keyboard user meets a
+       different widget depending on which branch they are in. Worth seeing. */
+    const viewRadios = within(canvas.getByRole('radiogroup', { name: 'Calendar view' }));
+    await expect(viewRadios.getByRole('radio', { name: 'Week' })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
+    await expect(viewRadios.getByRole('radio', { name: 'Day' })).toHaveAttribute(
+      'aria-checked',
+      'false'
+    );
+
+    // The mode pill survives the switch; the day chrome does not.
+    await expect(canvas.getByRole('group', { name: 'Clinic or my day' })).toBeInTheDocument();
+    await expect(canvas.queryByRole('heading', { name: 'Schedule' })).toBeNull();
+    await expect(canvas.queryByRole('group', { name: 'Select a day' })).toBeNull();
+    await expect(canvas.queryByRole('region', { name: 'Month overview' })).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The week as a load list rather than a grid, with its own prev/next pill. Note the view ' +
+          'switcher changes role between branches: a `group` of pressed buttons on Day, a ' +
+          '`radiogroup` of radios here and on Month.',
+      },
+    },
+  },
+};
+
+export const SwitchToMonth: Story = {
+  name: 'Switching to Month (stays phone-local)',
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { name: 'Schedule' })).toBeInTheDocument();
+
+    const viewPill = within(canvas.getByRole('group', { name: 'Calendar view' }));
+    await userEvent.click(viewPill.getByRole('button', { name: 'Month' }));
+
+    const monthRegion = canvas.getByRole('region', { name: 'Month overview' });
+    await expect(canvas.getByRole('button', { name: 'Previous month' })).toBeInTheDocument();
+    await expect(canvas.queryByRole('heading', { name: 'Schedule' })).toBeNull();
+    await expect(canvas.queryByRole('region', { name: 'Day schedule' })).toBeNull();
+
+    /* What the branch actually mounts: a weekday strip and a day grid, both seven
+       tracks wide. July 2026 opens on a Wednesday, so the grid pads with two leading
+       days and fills five whole weeks - 35 cells, not 31. Asserting the track count
+       AND the cell count is what separates a real month grid from seven columns of
+       nothing: `grid-cols-7` with 31 children would still report seven tracks. */
+    const [weekdayStrip, dayGrid] = Array.from(
+      monthRegion.querySelectorAll<HTMLElement>('.grid-cols-7')
+    );
+    await expect(getComputedStyle(dayGrid).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(7);
+    await expect(weekdayStrip.children).toHaveLength(7);
+    await expect(dayGrid.children).toHaveLength(35);
+
+    /* The assertion this story exists for. `month` is not a member of the shared
+       `activeCalendar` union, so `applyClinicView` deliberately skips the callback -
+       the phone changes and the page is never told. A future refactor that "tidies"
+       that branch by always calling up would put an unhandled value into desktop
+       state, and only this check would catch it. */
+    await expect(args.setActiveCalendar).not.toHaveBeenCalled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Month is unreachable from any prop: `seedClinicView` maps everything except `week` to ' +
+          '`day`, so the only way in is a tap. That is also why `PhoneMonthOverview` having a ' +
+          'story of its own was not enough - the branch that mounts it had never been exercised.',
+      },
+    },
+  },
+};
+
+export const MyDayView: Story = {
+  name: 'My day',
+  args: { activeCalendar: 'team' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole('region', { name: 'My day' })).toBeInTheDocument();
+    // Name and initials both come from the team store lookup on practitioner id.
+    await expect(canvas.getByText('Tue 14 Jul · Elena Weber')).toBeInTheDocument();
+    await expect(canvas.getByText('EW')).toBeInTheDocument();
+    // Two chips, never three: `rounds={[]}` is passed deliberately, because rounds
+    // have no model or endpoint in this codebase and a "None due" chip would
+    // advertise an affordance that does not exist.
+    await expect(canvas.getByText('Appointments')).toBeInTheDocument();
+    await expect(canvas.getByText('Tasks')).toBeInTheDocument();
+    await expect(canvas.queryByText('Rounds')).toBeNull();
+
+    // The rail owns the mode toggle itself, and there is no view pill here at all -
+    // Day/Week/Month is a clinic-only axis.
+    await expect(canvas.getByRole('button', { name: 'My day', pressed: true })).toBeInTheDocument();
+    await expect(canvas.queryByRole('group', { name: 'Calendar view' })).toBeNull();
+    await expect(canvas.queryByRole('heading', { name: 'Schedule' })).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The signed-in vet's own rail, seeded by `activeCalendar === 'team'`. The appointments " +
+          'are `dayEvents` narrowed to their `lead.id`, the tasks come from the seeded store via ' +
+          '`useTasksAssignedToUser`, and the header is built from the team record rather than ' +
+          'from anything the page passed down.',
+      },
+    },
+  },
+};
+
+export const ReturnFromMyDay: Story = {
+  name: 'Back to Clinic from My day',
+  args: { activeCalendar: 'team' },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('region', { name: 'My day' })).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Clinic' }));
+
+    /* Back on the clinic axis at whatever view was seeded - `seedClinicView('team')`
+       falls through to `day`, so a vet who started on My day lands on the day rail
+       rather than on nothing. Unlike the Month switch, this one IS pushed back up,
+       because `day` is a real member of the shared union. */
+    await expect(canvas.getByRole('heading', { name: 'Schedule' })).toBeInTheDocument();
+    await expect(canvas.queryByRole('region', { name: 'My day' })).toBeNull();
+    await expect(args.setActiveCalendar).toHaveBeenCalledWith('day');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The return path, and the reason the mode pill is duplicated onto every clinic screen. ' +
+          "The rail's own toggle is the only way out of My day at this width, so the two pills " +
+          'have to agree about what "Clinic" means - here, the view the phone was last seeded ' +
+          'with.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneMyDayRail.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/responsive/PhoneMyDayRail.stories.tsx
@@ -1,0 +1,312 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+import type { Appointment } from '@yosemite-crew/types';
+
+import PhoneMyDayRail from './PhoneMyDayRail';
+import type { MyDayRound } from './myDayRail';
+import type { Task } from '@/app/features/tasks/types/task';
+
+const ORG_ID = 'org-storybook';
+
+/**
+ * Every instant here is built with the LOCAL constructor rather than an ISO string.
+ * `formatRailTime` and `isSameCalendarDay` both read local getters, so a UTC fixture
+ * would render a different clock time on a machine in another zone - and half the
+ * rail would fall off the day entirely for anyone east of Greenwich.
+ */
+const at = (hour: number, minute: number): Date => new Date(2026, 6, 14, hour, minute, 0, 0);
+
+const NOW = at(9, 20);
+
+const appointment = (
+  id: string,
+  name: string,
+  start: Date,
+  durationMinutes: number,
+  status: Appointment['status'],
+  service: string
+): Appointment => ({
+  id,
+  patient: {
+    id: `companion-${id}`,
+    name,
+    species: 'dog',
+    breed: 'Beagle',
+    parent: { id: `parent-${id}`, name: 'Lena Hartmann' },
+  },
+  companion: {
+    id: `companion-${id}`,
+    name,
+    species: 'dog',
+    breed: 'Beagle',
+    parent: { id: `parent-${id}`, name: 'Lena Hartmann' },
+  },
+  organisationId: ORG_ID,
+  room: { id: 'room-consult-1', name: 'Consult 1' },
+  appointmentType: {
+    id: 'type-1',
+    name: service,
+    speciality: { id: 'spec-1', name: 'General practice' },
+  },
+  appointmentDate: start,
+  startTime: start,
+  endTime: new Date(start.getTime() + durationMinutes * 60 * 1000),
+  timeSlot: `${start.getHours()}:${start.getMinutes()}`,
+  durationMinutes,
+  status,
+  concern: 'Post-op recheck',
+});
+
+const task = (id: string, name: string, dueAt: Date, status: Task['status'] = 'PENDING'): Task => ({
+  _id: id,
+  organisationId: ORG_ID,
+  assignedTo: 'vet-1',
+  audience: 'EMPLOYEE_TASK',
+  source: 'CUSTOM',
+  category: 'GENERAL',
+  name,
+  dueAt,
+  status,
+});
+
+/**
+ * An undated task. `dueAt` is typed as a required `Date`, but the API can send
+ * nothing, and `toRailDate` answers null for anything it cannot use - which is
+ * precisely how a task reaches the "Anytime today" tray.
+ *
+ * The missing value is spelled as an absent field rather than as
+ * `new Date(Number.NaN)`. Both reach the same `toRailDate` -> null branch, so the
+ * component sees no difference, but an invalid Date cannot survive Storybook's
+ * own handling of `args`: the arg serialisers call `toISOString()` on every
+ * `Date` they walk, which throws `RangeError: Invalid time value` and killed this
+ * story with `storyThrewException` before its play function ever ran. The
+ * component was never involved.
+ */
+const undatedTask = (id: string, name: string, status: Task['status'] = 'PENDING'): Task => ({
+  ...task(id, name, NOW, status),
+  // The cast is the point: the type promises a Date the API does not always send.
+  dueAt: undefined as unknown as Date,
+});
+
+const APPOINTMENTS: Appointment[] = [
+  appointment('appt-1', 'Milo', at(8, 30), 30, 'COMPLETED', 'Lameness recheck'),
+  appointment('appt-2', 'Nala', at(9, 45), 30, 'UPCOMING', 'Dental scale and polish'),
+];
+
+const WARD_ROUND: MyDayRound = {
+  id: 'round-1',
+  title: 'Kennels round',
+  dueAt: at(10, 0),
+  items: [
+    { id: 'item-1', label: 'Bruno · analgesia check', status: 'SIGNED' },
+    { id: 'item-2', label: 'Juno · fluids rate', status: 'DUE' },
+    { id: 'item-3', label: 'Otto · post-op obs', status: 'DUE' },
+  ],
+};
+
+const UNDATED_ROUND: MyDayRound = {
+  id: 'round-2',
+  title: 'Isolation walk-round',
+  items: [
+    { id: 'iso-1', label: 'Sasha · barrier nursing', status: 'DUE' },
+    { id: 'iso-2', label: 'Kira · temperature', status: 'DUE' },
+  ],
+};
+
+const meta = {
+  title: 'Appointments/Calendar/PhoneMyDayRail',
+  component: PhoneMyDayRail,
+  // A 375px phone. Pinned as a GLOBAL: `parameters.viewport.defaultViewport` was
+  // removed in Storybook 10 and is inert, so a story pinned the old way renders
+  // the full panel width under a name that promises a phone.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          "The signed-in vet's own day: appointments, tasks and ward rounds threaded onto one " +
+          'chronological rail, with a now-marker dividing what has happened from what has not.\n\n' +
+          'Three of its branches had never been drawn. The **empty day** is the state a locum ' +
+          'sees on their first morning and a part-timer sees on every day off, and it is the only ' +
+          'state where the rail has to say something rather than show something. The **"Anytime ' +
+          'today" tray** is a horizontally scrolling pill row rather than a card stack, and it ' +
+          'only exists when something on the day carries no time at all - which no fixture with ' +
+          'tidy timestamps ever produces. The **ward-round rows** carry a per-item action that ' +
+          'swaps between a `Sign` button and a `Signed` pill, so a round part-way through is the ' +
+          'only render where both appear together.\n\n' +
+          'Rounds have no backend model, type or endpoint anywhere in the monorepo - ' +
+          '`MyDayRound` is a presentation-only shape, and `PhoneCalendar` passes `rounds={[]}`. ' +
+          'These stories are therefore the only place the round rows exist at all, which is ' +
+          'exactly why they are worth pinning down before the domain type lands.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    now: NOW,
+    contextLabel: 'Tue 14 Jul · Dr. Weber',
+    userInitials: 'EW',
+    view: 'my-day',
+    appointments: APPOINTMENTS,
+    tasks: [],
+    rounds: [],
+    onViewChange: fn(),
+    onOpenWorkspace: fn(),
+    onSelectAppointment: fn(),
+    onToggleTask: fn(),
+    onOpenRound: fn(),
+    onSignRoundItem: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <div className="h-[720px] w-full bg-[var(--screen)]">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof PhoneMyDayRail>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const NothingScheduled: Story = {
+  name: 'Empty day',
+  args: { appointments: [], tasks: [], rounds: [] },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByText('Nothing scheduled today.')).toBeInTheDocument();
+
+    /* The summary chips do NOT disappear with the rail - they are the frame the empty
+       message sits inside, and both report "None today" rather than a bare 0. The
+       Rounds chip is suppressed entirely, because rounds have no backend yet and a
+       permanent "None due" would advertise an affordance that does not exist. */
+    const appointmentsChip = canvas.getByText('Appointments').parentElement as HTMLElement;
+    const chipRow = appointmentsChip.parentElement as HTMLElement;
+    await expect(chipRow.children).toHaveLength(2);
+    // Read per chip rather than as a page-wide count: two "None today" strings
+    // anywhere would pass a count, including both of them inside one chip.
+    await expect(within(appointmentsChip).getByText('None today')).toBeInTheDocument();
+    const tasksChip = canvas.getByText('Tasks').parentElement as HTMLElement;
+    await expect(within(tasksChip).getByText('None today')).toBeInTheDocument();
+    await expect(canvas.queryByText('Rounds')).toBeNull();
+
+    // No thread means nothing for the now-marker to divide, so it is not drawn -
+    // a line across empty space would mark nothing.
+    await expect(canvasElement.querySelector('[data-testid="my-day-now-marker"]')).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The day with nothing on it. The header, the view toggle and both summary chips stay, so ' +
+          'the screen still reads as "your day" rather than as a failed load - the distinction ' +
+          'matters, because an empty rail and a broken fetch would otherwise look identical.',
+      },
+    },
+  },
+};
+
+export const AnytimeTray: Story = {
+  name: 'Anytime today tray',
+  args: {
+    tasks: [
+      task('task-1', 'Call Mrs Hartmann with bloods', at(11, 0)),
+      undatedTask('task-2', 'Restock consult 1 sharps bin'),
+      undatedTask('task-3', 'Sign off yesterday’s lab requests', 'COMPLETED'),
+    ],
+    rounds: [UNDATED_ROUND],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* The heading counts the tray, not the day: two undated tasks and one undated
+       round. An appointment can never land here - it always carries a start time -
+       so this group is tasks and rounds only. */
+    await expect(canvas.getByText('Anytime today · 3')).toBeInTheDocument();
+
+    const tray = canvas.getByText('Anytime today · 3').nextElementSibling as HTMLElement;
+    const pills = Array.from(tray.querySelectorAll('button'));
+    await expect(pills).toHaveLength(3);
+    // Sorted tasks-then-rounds, then by id - so the tray is stable whatever order
+    // the API returned.
+    await expect(pills[0]).toHaveTextContent('Restock consult 1 sharps bin');
+    await expect(pills[1]).toHaveTextContent('Sign off yesterday’s lab requests');
+    await expect(pills[2]).toHaveTextContent('Isolation walk-round · 2 due');
+    // A pill row, not a card stack: it scrolls sideways rather than growing the page.
+    await expect(getComputedStyle(tray).overflowX).toBe('auto');
+
+    /* The dated task stayed on the thread rather than falling into the tray, and the
+       chip counts BOTH - three tasks in the summary, three minus one on the rail. */
+    await expect(canvas.getByText('Call Mrs Hartmann with bloods')).toBeInTheDocument();
+    await expect(canvas.getByText('3 · on track')).toBeInTheDocument();
+    // 09:45 is the first non-terminal appointment at or after 09:20.
+    await expect(canvas.getByText('2 · next 09:45')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A day carrying three things with no time on them. They are pulled off the chronological ' +
+          'thread into a `mt-auto` pill tray pinned to the bottom of the scroll area, so they ' +
+          'never break the reading order of the timed rail above.\n\n' +
+          'The undated tasks here carry no `dueAt` at all, which is what the API actually sends ' +
+          'for a task with no due date - the field is typed as a required `Date`, so the absent ' +
+          'case can only be spelled as a cast. `toRailDate` folds it, null and an unparseable ' +
+          'date onto the same null. A completed pill keeps its ticked box; the tray is a to-do ' +
+          'row, not a filter.',
+      },
+    },
+  },
+};
+
+export const WardRoundPartlySigned: Story = {
+  name: 'Ward round (Sign / Signed)',
+  args: {
+    tasks: [],
+    rounds: [WARD_ROUND],
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // The heading counts what is still owed, not the round's size: 3 items, 2 due.
+    await expect(canvas.getByText('Kennels round · 2 due')).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Open ward' })).toBeInTheDocument();
+
+    /* The per-item action is the surface: DUE items get a filled `Sign` button, SIGNED
+       items get a static pill. Two of one and one of the other in the same round is
+       the only render where the pair can be compared, and it is unreachable from any
+       fixture that has every item in the same state. */
+    const signButtons = canvas.getAllByRole('button', { name: 'Sign' });
+    await expect(signButtons).toHaveLength(2);
+
+    const signed = canvas.getByText('Signed');
+    // A pill, not a disabled button - there is nothing left to do to a signed item,
+    // so it must not be focusable or clickable.
+    await expect(signed.tagName).toBe('SPAN');
+    await expect(canvas.queryByRole('button', { name: 'Signed' })).toBeNull();
+
+    // Rows keep the round's own order, so the signed item stays first.
+    await expect(canvas.getByText('Bruno · analgesia check')).toBeInTheDocument();
+    await expect(canvas.getByText('Juno · fluids rate')).toBeInTheDocument();
+
+    await userEvent.click(signButtons[0]);
+    // The handler is given the round AND the item id - the row alone is not enough
+    // to identify what was signed.
+    await expect(args.onSignRoundItem).toHaveBeenCalledWith(WARD_ROUND, 'item-2');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A 10:00 ward round threaded into the rail between the morning appointments, part-way ' +
+          'signed. Each item is a hairline-separated row inside one card, and the trailing control ' +
+          'is the whole state machine: `Sign` while due, a `Signed` pill once done.\n\n' +
+          'The card also carries an "Open ward" escape hatch, because signing three items one at ' +
+          'a time on a phone is the exception - the rail is a prompt that the round exists, not ' +
+          'the place the round is worked through.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/ServicesPackagesEditor.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/ServicesPackagesEditor.stories.tsx
@@ -1,0 +1,338 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+
+import type { LineItem } from '@/app/features/appointments/types/workspace';
+import ServicesPackagesEditor from './ServicesPackagesEditor';
+
+const WELLNESS = 'Senior wellness package';
+const DENTAL = 'Dental package - grade 2';
+
+const PACKAGE: LineItem = {
+  id: 'line-wellness',
+  refId: 'pkg-senior-wellness',
+  kind: 'PACKAGE',
+  name: WELLNESS,
+  qty: 1,
+  instructions: 'Annual senior screen',
+  unitPriceCents: 24_000,
+  amountCents: 21_600,
+  breakdown: [
+    {
+      id: 'brk-exam',
+      name: 'Physical examination',
+      qty: 1,
+      instructions: 'Service',
+      unitPriceCents: 6_000,
+      amountCents: 6_000,
+    },
+    {
+      id: 'brk-bloods',
+      name: 'Senior blood panel',
+      qty: 1,
+      instructions: 'Diagnostic',
+      unitPriceCents: 12_000,
+      discountPercent: 10,
+      discountCents: 1_200,
+      amountCents: 10_800,
+    },
+    {
+      id: 'brk-urine',
+      name: 'Urinalysis',
+      qty: 2,
+      instructions: 'Diagnostic',
+      unitPriceCents: 2_400,
+      amountCents: 4_800,
+    },
+  ],
+};
+
+/** A second package, so the exclusivity of `expandedPackageId` is observable. */
+const SECOND_PACKAGE: LineItem = {
+  id: 'line-dental',
+  refId: 'pkg-dental-2',
+  kind: 'PACKAGE',
+  name: DENTAL,
+  qty: 1,
+  instructions: 'Scale, polish, two extractions',
+  unitPriceCents: 31_000,
+  amountCents: 31_000,
+  breakdown: [
+    {
+      id: 'brk-ga',
+      name: 'General anaesthesia (45 min)',
+      qty: 1,
+      instructions: 'Procedure',
+      unitPriceCents: 14_000,
+      amountCents: 14_000,
+    },
+    {
+      id: 'brk-extraction',
+      name: 'Extraction - single rooted',
+      qty: 2,
+      instructions: 'Procedure',
+      unitPriceCents: 8_500,
+      amountCents: 17_000,
+    },
+  ],
+};
+
+const SERVICE: LineItem = {
+  id: 'line-consult',
+  refId: 'svc-consult',
+  kind: 'SERVICE',
+  name: 'Consultation - 30 min',
+  qty: 1,
+  instructions: 'Outpatient',
+  unitPriceCents: 9_000,
+  amountCents: 9_000,
+};
+
+/** A package the catalogue promised a breakdown for and did not deliver. */
+const EMPTY_PACKAGE: LineItem = {
+  id: 'line-empty',
+  refId: 'pkg-empty',
+  kind: 'PACKAGE',
+  name: 'Puppy starter package',
+  qty: 1,
+  instructions: 'Bundled at booking',
+  unitPriceCents: 12_000,
+  amountCents: 12_000,
+  breakdown: [],
+};
+
+/**
+ * The USED column tracks of a grid element - five above `sm:`, one below it.
+ *
+ * `getComputedStyle(...).gridTemplateColumns` resolves to used track sizes on a
+ * laid-out grid container, never to the authored keywords, so a collapsed row
+ * reports a single pixel width rather than `none`.
+ */
+const tracks = (el: HTMLElement) => getComputedStyle(el).gridTemplateColumns.trim().split(/\s+/);
+
+const meta = {
+  title: 'Workspace/ServicesPackagesEditor',
+  component: ServicesPackagesEditor,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          "The Treatment step's services and packages table. Its rows are ordinary enough; the " +
+          'surface that had never been drawn is the **inline Breakdown**, a nested ' +
+          '`SectionContainer` that only a package row can open and only through the dark ' +
+          'eye/eye-off button on that row.\n\n' +
+          'It is worth rendering because of how it lines up. The breakdown deliberately repeats no ' +
+          "headings of its own: its rows reuse the parent's `ROW_GRID` template " +
+          '(`sm:grid-cols-[1.6fr_100px_1.4fr_110px_120px]`) so the component names sit under Name, ' +
+          'the quantities under Qty. and the amounts under Amount. Nothing enforces that ' +
+          'agreement - the two grids are separate elements that happen to share a constant - so a ' +
+          'change to one silently misaligns the other, and only a rendered story shows it.\n\n' +
+          'Two edges are drawn as well: `expandedPackageId` is a single id, so opening one ' +
+          'breakdown closes the other; and the block is gated on `expanded && breakdown.length > ' +
+          '0`, so a package whose breakdown came back empty toggles its own icon and renders ' +
+          'nothing at all.\n\n' +
+          'Below 640px the shared template collapses to one column and the Instructions and Amount ' +
+          'headings are `hidden`, so the alignment the breakdown depends on does not exist at ' +
+          'phone width. That is its own story.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    items: [SERVICE, PACKAGE, SECOND_PACKAGE],
+    catalogItems: [],
+    readOnly: false,
+    onAddItem: fn(),
+    onUpdateItem: fn(),
+    onRemoveItem: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[900px] max-w-full bg-[var(--screen)] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ServicesPackagesEditor>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const BreakdownExpanded: Story = {
+  name: 'Package breakdown expanded',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.queryByText('Breakdown')).not.toBeInTheDocument();
+    // Only packages carry the toggle: the service row has no eye button.
+    await expect(canvas.getAllByRole('button', { name: /breakdown$/ })).toHaveLength(2);
+
+    await userEvent.click(canvas.getByRole('button', { name: `View ${WELLNESS} breakdown` }));
+
+    expect(await canvas.findByText('Breakdown')).toBeInTheDocument();
+
+    // The three component rows, with their own quantities and amounts.
+    await expect(canvas.getByText('Physical examination')).toBeInTheDocument();
+    await expect(canvas.getByText('Senior blood panel')).toBeInTheDocument();
+    await expect(canvas.getByText('Urinalysis')).toBeInTheDocument();
+    await expect(canvas.getByText('x2')).toBeInTheDocument();
+    // Discounted component: 12000 gross less 10% renders as the NET 108, not 120.
+    await expect(canvas.getByText('$108')).toBeInTheDocument();
+
+    /* The alignment contract. The headings and the breakdown rows are separate
+       elements that only agree because they share one string constant, so both the
+       track count and the child count have to hold on both sides - five children
+       against four tracks wraps the last cell onto a second line rather than
+       erroring. The pixel widths are deliberately NOT compared: the breakdown sits
+       inside a nested SectionContainer with its own padding, so its fr tracks
+       resolve against a narrower box than the headings do. */
+    const headings = canvasElement.querySelector('.yc-table-head') as HTMLElement;
+    const componentRow = canvas.getByText('Physical examination').parentElement as HTMLElement;
+    await expect(tracks(headings)).toHaveLength(5);
+    await expect(tracks(componentRow)).toHaveLength(5);
+    await expect(headings.children).toHaveLength(5);
+    await expect(componentRow.children).toHaveLength(5);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'One package opened. The nested container is `bg-neutral-0` on the card, titled ' +
+          '"Breakdown", and its rows carry no borders of their own - the alignment with the ' +
+          'headings above is the only thing telling a reader which number is which.',
+      },
+    },
+  },
+};
+
+export const BreakdownIsExclusive: Story = {
+  name: 'Opening one breakdown closes the other',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: `View ${WELLNESS} breakdown` }));
+    expect(await canvas.findByText('Senior blood panel')).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole('button', { name: `View ${DENTAL} breakdown` }));
+
+    // One breakdown at a time, and it is the second package's content now.
+    await waitFor(() => {
+      expect(canvas.queryByText('Senior blood panel')).not.toBeInTheDocument();
+    });
+    await expect(canvas.getAllByText('Breakdown')).toHaveLength(1);
+    await expect(canvas.getByText('General anaesthesia (45 min)')).toBeInTheDocument();
+    await expect(canvas.getByText('Extraction - single rooted')).toBeInTheDocument();
+
+    /* The icon and the accessible name both swap on the open row, so the two
+       toggles are never in the same state - which is the only visual cue that the
+       first package closed. */
+    await expect(
+      canvas.getByRole('button', { name: `Hide ${DENTAL} breakdown` })
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('button', { name: `View ${WELLNESS} breakdown` })
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`expandedPackageId` holds one id, not a set. Two packages can never be open together, ' +
+          'which is easy to miss when every row has its own button.',
+      },
+    },
+  },
+};
+
+export const EmptyBreakdownRendersNothing: Story = {
+  name: 'Package with an empty breakdown',
+  args: { items: [EMPTY_PACKAGE] },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const toggle = canvas.getByRole('button', { name: 'View Puppy starter package breakdown' });
+    await userEvent.click(toggle);
+
+    /* The row is expanded - the icon flipped and the label changed - but the block
+       is gated on `expanded && breakdown.length > 0`, so nothing appears. From the
+       clinician's side the button simply does not work. Drawn so the dead state is
+       visible rather than inferred from the source. */
+    expect(
+      await canvas.findByRole('button', { name: 'Hide Puppy starter package breakdown' })
+    ).toBeInTheDocument();
+    await expect(canvas.queryByText('Breakdown')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A package whose components came back empty. Nothing distinguishes its toggle from a ' +
+          'working one until it is pressed, and pressing it produces no visible change beyond the ' +
+          'icon.',
+      },
+    },
+  },
+};
+
+export const Empty: Story = {
+  name: 'No items',
+  args: { items: [] },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('No services or packages added yet.')).toBeInTheDocument();
+    // The headings belong to the populated branch, so they go with the rows.
+    await expect(canvasElement.querySelector('.yc-table-head')).toBeNull();
+    // Adding stays available even with nothing in the list.
+    await expect(
+      canvas.getByRole('searchbox', { name: 'Search for services and packages' })
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The empty list. The search bar sits outside the container and is never gated on ' +
+          '`readOnly`, because locking is per item (billed) rather than per section.',
+      },
+    },
+  },
+};
+
+export const Phone: Story = {
+  name: 'Phone: the shared grid collapses',
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: `View ${WELLNESS} breakdown` }));
+    expect(await canvas.findByText('Breakdown')).toBeInTheDocument();
+
+    /* `ROW_GRID` only sets its five tracks at `sm:` (640px), so below that both the
+       parent rows and the breakdown rows are a single stacked column - and the
+       headings row is `hidden sm:block` entirely. The alignment the breakdown
+       relies on does not exist here, which is why the components read as a plain
+       list at this width. */
+    const componentRow = canvas.getByText('Physical examination').parentElement as HTMLElement;
+    /* Still a grid, but a one-track one. `grid-template-columns` resolves to the
+       USED track sizes on a laid-out grid container, so the single implicit column
+       reports a pixel width ('193px' at this viewport) rather than the `none` the
+       cascade holds - `none` comes back only from an element that is not a grid at
+       all, which is a different failure and an invisible one. Asserting `display`
+       first is what keeps the one-track count from passing on such an element. */
+    await expect(getComputedStyle(componentRow).display).toBe('grid');
+    const rowTracks = tracks(componentRow);
+    await expect(rowTracks).toHaveLength(1);
+    await expect(rowTracks[0]).toMatch(/^\d+(\.\d+)?px$/);
+    await expect(componentRow.children).toHaveLength(5);
+    // The headings row is `hidden sm:block`, so there is nothing to align against.
+    const headings = canvasElement.querySelector('.yc-table-head') as HTMLElement;
+    await expect(getComputedStyle(headings.parentElement as HTMLElement).display).toBe('none');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'At 375px the Instructions and Amount cells still render (they are `hidden sm:block` on ' +
+          'the headings but not on the breakdown rows), so each component stacks its own name, ' +
+          'quantity and amount. Worth a look: it is a different reading order from the desktop ' +
+          'table, not a narrower version of it.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/PhonePatientBar.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/phone/PhonePatientBar.stories.tsx
@@ -1,0 +1,291 @@
+import React, { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, waitFor, within } from 'storybook/test';
+import type { Appointment } from '@yosemite-crew/types';
+
+import PhonePatientBar from './PhonePatientBar';
+
+const MINUTE = 60_000;
+
+const APPOINTMENT: Appointment = {
+  id: 'appt-workspace-1',
+  organisationId: 'org-storybook',
+  patient: {
+    id: 'companion-1',
+    name: 'Poppy Hartmann',
+    species: 'dog',
+    breed: 'Beagle',
+    parent: { id: 'parent-1', name: 'Lena Hartmann' },
+  },
+  lead: { id: 'prac-amara', name: 'Dr. Amara Weber' },
+  appointmentDate: new Date('2026-03-12T09:30:00.000Z'),
+  startTime: new Date('2026-03-12T09:30:00.000Z'),
+  endTime: new Date('2026-03-12T10:00:00.000Z'),
+  timeSlot: '09:30 - 10:00',
+  durationMinutes: 30,
+  status: 'IN_PROGRESS',
+};
+
+type Offsets = {
+  /** Minutes before now that the visit started; omit for a visit with no start. */
+  startedMinutesAgo?: number;
+  /** Minutes before now that the booked slot ended; negative means still to come. */
+  bookedEndMinutesAgo?: number;
+};
+
+/**
+ * `VisitTimer` reads the real clock and has no injectable now, so the fixtures are
+ * offsets rather than timestamps, resolved in a `useState` initializer - i.e. once
+ * per MOUNT.
+ *
+ * That distinction is the whole reason this wrapper exists. Module-level constants
+ * are evaluated when the story file is first imported and then never again, so
+ * "started 20 minutes ago" quietly becomes "started 80 minutes ago" in a Storybook
+ * tab left open, or in a play-function run that walks a few hundred stories on one
+ * page load. The pill would cross from MM:SS into HH:MM:SS and the compact-format
+ * assertion below would fail for reasons that have nothing to do with the
+ * component. Resolving at mount pins each story to its own clock.
+ */
+const TimerBar = ({
+  startedMinutesAgo,
+  bookedEndMinutesAgo,
+  ...props
+}: React.ComponentProps<typeof PhonePatientBar> & Offsets) => {
+  const [stamps] = useState(() => ({
+    visitStartAt:
+      startedMinutesAgo === undefined
+        ? undefined
+        : new Date(Date.now() - startedMinutesAgo * MINUTE).toISOString(),
+    bookedEndAt:
+      bookedEndMinutesAgo === undefined
+        ? undefined
+        : new Date(Date.now() - bookedEndMinutesAgo * MINUTE).toISOString(),
+  }));
+  return <PhonePatientBar {...props} {...stamps} />;
+};
+
+const timerPill = (canvasElement: HTMLElement): HTMLElement =>
+  within(canvasElement).getByTestId('visit-timer');
+
+const meta = {
+  title: 'Workspace/PhonePatientBar',
+  component: PhonePatientBar,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The phone workspace header: back circle, species avatar, name, status pill, a ' +
+          'truncating signalment line, and the visit timer.\n\n' +
+          'The timer is the part that had never been drawn in this variant. `VisitTimer` renders ' +
+          'six different pills - three states across two variants - and which one appears is ' +
+          'decided by the wall clock against `startAt` and `bookedEndAt`, not by a prop. A story ' +
+          'with no timestamps only ever shows the resting "Not started" pill, which is what this ' +
+          'component had.\n\n' +
+          'The phone variant is not a smaller copy of the desktop one. It drops the pulsing green ' +
+          'dot and the "In room" / "Over booked slot" words entirely and shows the bare elapsed ' +
+          'time at 10px with `px-[9px] py-[5px]`, because the bar has roughly 70px to spare next ' +
+          'to a truncating name. It also strips a leading `00:` so an under-an-hour visit reads ' +
+          '`MM:SS` rather than `00:MM:SS`.\n\n' +
+          'The over-booked pill is the one worth reviewing: `warning-100` fill, `warning-300` ' +
+          'border, `warning-900` label. The 900 step is deliberate - the 700 step measured 2.77:1 ' +
+          'against this tint, and this pill sits on every step of the workspace.\n\n' +
+          'Every story states its start as an offset from the moment it mounts, because the ' +
+          'component has no injectable clock. See `TimerBar` in the source for why a module-level ' +
+          'timestamp is not good enough.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  // Pinned as a GLOBAL: `parameters.viewport.defaultViewport` was removed in
+  // Storybook 10. This bar only ever renders under 768px, so a story of it at
+  // panel width would be showing a layout the app never produces.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  args: {
+    appointment: APPOINTMENT,
+    companionName: 'Poppy Hartmann',
+    speciesType: 'dog',
+    breed: 'Beagle',
+    ageLabel: '9 yr',
+    weightKg: 12.4,
+    onBack: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <div className="bg-[var(--screen)]">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof PhonePatientBar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Running: Story = {
+  name: 'Timer running',
+  render: (args) => <TimerBar {...args} startedMinutesAgo={20} bookedEndMinutesAgo={-10} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const pill = timerPill(canvasElement);
+    await expect(pill).toHaveAttribute('data-state', 'running');
+
+    /* Compact MM:SS, not HH:MM:SS - `toCompactElapsed` drops the leading "00:" for
+       a visit under an hour, which is the only reason this fits beside the name.
+       The seconds tick, so the shape is asserted rather than a value. */
+    await expect(pill.textContent?.trim()).toMatch(/^\d{2}:\d{2}$/);
+    /* The desktop pill says "In room HH:MM:SS" and carries a pulsing dot; the phone
+       one drops both. Asserted, because a desktop pill in this bar would still
+       satisfy the data-state check and still look like a timer. */
+    await expect(pill.textContent).not.toContain('In room');
+    await expect(pill.querySelector('.animate-pulse')).toBeNull();
+
+    // The phone variant, confirmed by its own type ramp: 10px against the desktop
+    // pill's caption-1.
+    const style = getComputedStyle(pill);
+    await expect(style.fontSize).toBe('10px');
+    // tabular-nums, so the digits do not jitter the bar's width every second.
+    await expect(style.fontVariantNumeric).toContain('tabular-nums');
+
+    // The bar's other content, which shares the row with the timer.
+    await expect(canvas.getByText('Poppy Hartmann')).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Go back' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A visit 20 minutes in and still inside its booked slot. The pill sits on ' +
+          '`--pill-raised` with a hairline border and `--ink-body` digits - the quiet state, ' +
+          'because a visit running to plan is not news.',
+      },
+    },
+  },
+};
+
+export const OverBooked: Story = {
+  name: 'Timer over the booked slot',
+  render: (args) => <TimerBar {...args} startedMinutesAgo={95} bookedEndMinutesAgo={35} />,
+  play: async ({ canvasElement }) => {
+    const pill = timerPill(canvasElement);
+    await expect(pill).toHaveAttribute('data-state', 'over');
+    // Past an hour, so the leading group survives: HH:MM:SS.
+    await expect(pill.textContent?.trim()).toMatch(/^\d{2}:\d{2}:\d{2}$/);
+    // The desktop pill prefixes "Over booked slot ·"; the phone one shows digits only.
+    await expect(pill.textContent).not.toContain('Over booked slot');
+
+    /* Three warning steps on one pill, and all three have to differ from each other
+       or the amber reads as a flat block. Polled because these are custom
+       properties resolved at paint. */
+    await waitFor(() => {
+      const style = getComputedStyle(pill);
+      expect(style.backgroundColor).not.toBe(style.color);
+      expect(style.borderTopColor).not.toBe(style.backgroundColor);
+      expect(style.borderTopColor).not.toBe(style.color);
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same visit 95 minutes in, 35 minutes past its booked end. Nothing is blocked - the ' +
+          'pill is informational - but it is the only signal on the phone layout that a room is ' +
+          'running over, so it has to survive being 10px on an amber tint.',
+      },
+    },
+  },
+};
+
+export const NotStarted: Story = {
+  name: 'Timer resting',
+  render: (args) => <TimerBar {...args} />,
+  play: async ({ canvasElement }) => {
+    const pill = timerPill(canvasElement);
+    await expect(pill).toHaveAttribute('data-state', 'idle');
+    await expect(pill).toHaveTextContent('Not started');
+    // No elapsed value is fabricated when there is no start timestamp.
+    await expect(pill.textContent?.trim()).not.toMatch(/\d/);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'No start timestamp at all, which is what an appointment that has not been checked in ' +
+          'still looks like. The words rather than digits are why this state is the widest of the ' +
+          'three, so it is the one that squeezes the name beside it.',
+      },
+    },
+  },
+};
+
+export const StatesSideBySide: Story = {
+  name: 'Three timer states, compared',
+  render: (args) => (
+    <div className="flex flex-col">
+      <TimerBar {...args} />
+      <TimerBar {...args} startedMinutesAgo={20} bookedEndMinutesAgo={-10} />
+      <TimerBar {...args} startedMinutesAgo={95} bookedEndMinutesAgo={35} />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const pills = canvas.getAllByTestId('visit-timer');
+    await expect(pills).toHaveLength(3);
+    await expect(pills.map((pill) => pill.dataset.state)).toEqual(['idle', 'running', 'over']);
+
+    /* The one comparison a single-state story cannot make: idle and running share
+       the --pill-raised ground and differ only in ink, while over-booked changes
+       ground, border AND ink. Rendered together so the amber is judged against the
+       neutral it replaces rather than in isolation. */
+    await waitFor(() => {
+      const [idle, running, over] = pills.map((pill) => getComputedStyle(pill));
+      expect(running.backgroundColor).toBe(idle.backgroundColor);
+      expect(running.color).not.toBe(idle.color);
+      expect(over.backgroundColor).not.toBe(running.backgroundColor);
+      expect(over.borderTopColor).not.toBe(running.borderTopColor);
+      expect(over.color).not.toBe(running.color);
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'All three states stacked, because the interesting question about this pill is not what ' +
+          'each state looks like but how far apart they are. Idle and running are the same shape ' +
+          'and the same ground; only the over-booked state is allowed to change the ground.',
+      },
+    },
+  },
+};
+
+export const WithAllergy: Story = {
+  name: 'Allergy tail',
+  args: { allergy: 'Penicillin' },
+  render: (args) => <TimerBar {...args} startedMinutesAgo={20} bookedEndMinutesAgo={-10} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const allergy = canvas.getByText('Allergy: Penicillin');
+    const signalment = allergy.parentElement as HTMLElement;
+
+    /* The tail is a span inside the same truncating paragraph as the signalment, so
+       it is the FIRST thing lost when the name is long - and the only thing marking
+       it as different is the ink. Both are asserted: same line, different colour. */
+    await expect(signalment.textContent).toContain('Beagle · 9 yr · 12.4 kg · Allergy: Penicillin');
+    await expect(getComputedStyle(signalment).textOverflow).toBe('ellipsis');
+    await waitFor(() => {
+      expect(getComputedStyle(allergy).color).not.toBe(getComputedStyle(signalment).color);
+    });
+    await expect(getComputedStyle(allergy).fontWeight).toBe('700');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Breed, age and weight are joined with a middot and the allergy is appended in ' +
+          '`--danger-text` at 700. The whole line is one `truncate` paragraph at 10.5px, so on a ' +
+          'long signalment the allergy is what disappears - which is worth seeing before deciding ' +
+          'it belongs there.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/QuickActionsModal.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/QuickActionsModal.stories.tsx
@@ -320,33 +320,32 @@ export const ActiveTabStyling: Story = {
     const activeLabel = active.querySelectorAll('span')[1] as HTMLElement;
     const idleLabel = idle.querySelectorAll('span')[1] as HTMLElement;
 
-    /* PINNED TO CURRENT BEHAVIOUR - the active label does not actually go bold.
-       The component asks for it: `QuickActionsModal.tsx` renders the active
-       label as `text-caption-2 font-bold`. But `.text-caption-2` is declared
-       OUTSIDE `@layer` in `globals.css` with `font-weight: 500 !important`, and
-       an unlayered `!important` declaration beats every Tailwind utility, so
-       `font-bold` never lands and both labels compute to 500. That is a
-       stylesheet defect the component is a victim of, not a component defect -
-       tracked as issue #2297.
+    /* The active label really does go bold now. It did not for a long time:
+       `globals.css` declared `.text-caption-2` a second time OUTSIDE `@layer`
+       with `font-weight: 500 !important`, which beat every Tailwind utility, so
+       the `font-bold` the component asks for never landed and both labels
+       computed to 500 - a three-part active treatment silently delivering two
+       parts. PR #2298 removed that override, and the block that was pinned to
+       500/500 here comes back off the pin with it.
 
-       The class assertions are here so the contradiction is in the failure
-       output rather than hidden behind a soft assertion: the markup says
-       `font-bold`, the computed weight says 500. When #2297 is fixed the two
-       weights will diverge, this block will fail loudly, and it should then be
-       restored to `expect(active).not.toBe(idle)`. */
+       Asserted as an explicit 700-against-500 pair rather than "the two
+       differ": `not.toBe` would go green again on any future override that
+       moved BOTH labels to the same wrong weight, which is exactly the bug
+       that was here. The classes are asserted too, so a failure says whether
+       the markup stopped asking or the cascade stopped delivering. */
     await expect(activeLabel).toHaveClass('text-caption-2');
     await expect(activeLabel).toHaveClass('font-bold');
     await expect(idleLabel).not.toHaveClass('font-bold');
     await waitFor(() => {
-      expect(getComputedStyle(activeLabel).fontWeight).toBe('500');
+      expect(getComputedStyle(activeLabel).fontWeight).toBe('700');
       expect(getComputedStyle(idleLabel).fontWeight).toBe('500');
     });
 
-    /* The distinction the active label does deliver is colour: `text-blue-text`
-       against the idle `text-neutral-700`. `.text-caption-2` sets no `color`, so
-       this is the one half of the active treatment that survives #2297, and it
-       is what the tab actually reads as today. Polled because the tile animates
-       with `transition-colors`. */
+    /* The third part of the active treatment: colour. `text-blue-text` against
+       the idle `text-neutral-700`, and `.text-caption-2` sets no `color` of its
+       own, so this half never depended on the cascade fight above - it was what
+       the tab read as even while the bold was being defeated. Polled because
+       the tile animates with `transition-colors`. */
     await waitFor(() => {
       expect(getComputedStyle(activeLabel).color).not.toBe(getComputedStyle(idleLabel).color);
     });
@@ -356,13 +355,14 @@ export const ActiveTabStyling: Story = {
       description: {
         story:
           'The active tab asks for three changes at once - `--text-brand` border, `--blue-text` ' +
-          'ink and a bold label - and none of them is a background fill. Only two of the three ' +
-          'arrive: the `font-bold` on the label is dead, because `.text-caption-2` is declared ' +
-          'outside `@layer` with `font-weight: 500 !important` and unlayered `!important` beats ' +
-          'any utility (issue #2297). The play function is pinned to that, and asserts the ' +
-          '`font-bold` class is present so the contradiction is visible rather than papered ' +
-          'over. The MSD tile breaks the no-fill pattern by filling with `bg-primary-100` when ' +
-          'active, which is visible by switching to it in the story below.',
+          'ink and a bold label - and none of them is a background fill. All three arrive now. ' +
+          'Two of them always did; the bold label did not, because `globals.css` declared ' +
+          '`.text-caption-2` outside `@layer` with `font-weight: 500 !important`, which beat the ' +
+          '`font-bold` utility and left the active and idle labels identically weighted. PR ' +
+          '#2298 removed that override, so the play function measures 700 against the idle 500 ' +
+          'instead of pinning both to 500. The MSD tile breaks the no-fill pattern by filling ' +
+          'with `bg-primary-100` when active, which is visible by switching to it in the story ' +
+          'below.',
       },
     },
   },

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/panels/CalculatorsPanel.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/panels/CalculatorsPanel.stories.tsx
@@ -1,0 +1,255 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, waitFor, within } from 'storybook/test';
+import type { Appointment } from '@yosemite-crew/types';
+
+import type { StoredCompanion } from '@/app/features/companions/pages/Companions/types';
+import { useCompanionStore } from '@/app/stores/companionStore';
+import CalculatorsPanel from './CalculatorsPanel';
+
+const COMPANION_ID = 'companion-1';
+const ORG_ID = 'org-storybook';
+
+/**
+ * Both notice cards read the patient NAME off the appointment
+ * (`getAppointmentCompanion(appointment).name`) but the weight and species off the
+ * companion RECORD in the store. Two sources, one sentence - so a fixture that
+ * seeds "Rio" into the store while the appointment still says "Poppy" renders a
+ * card that names one patient and measures another. The stories keep the two in
+ * step deliberately; the split itself is worth knowing about, because nothing in
+ * the component reconciles them.
+ */
+const appointmentFor = (patientName: string, species: string): Appointment => ({
+  id: 'appt-workspace-1',
+  organisationId: ORG_ID,
+  patient: {
+    id: COMPANION_ID,
+    name: patientName,
+    species,
+    breed: 'Beagle',
+    parent: { id: 'parent-1', name: 'Lena Hartmann' },
+  },
+  lead: { id: 'prac-amara', name: 'Dr. Amara Weber' },
+  appointmentDate: new Date('2026-03-12T09:30:00.000Z'),
+  startTime: new Date('2026-03-12T09:30:00.000Z'),
+  endTime: new Date('2026-03-12T10:00:00.000Z'),
+  timeSlot: '09:30 - 10:00',
+  durationMinutes: 30,
+  status: 'IN_PROGRESS',
+});
+
+/**
+ * The panel reads the companion RECORD for `type` and `currentWeight` - neither
+ * lives on the appointment's patient summary. Seeding the store is therefore the
+ * whole fixture; there is no prop that can produce either notice.
+ */
+const companion = (over: Partial<StoredCompanion> = {}): StoredCompanion => ({
+  id: COMPANION_ID,
+  organisationId: ORG_ID,
+  parentId: 'parent-1',
+  name: 'Poppy Hartmann',
+  type: 'dog',
+  breed: 'Beagle',
+  dateOfBirth: new Date('2017-05-02T00:00:00.000Z'),
+  gender: 'male',
+  isInsured: false,
+  currentWeight: 27.5,
+  ...over,
+});
+
+const seed = (record?: StoredCompanion) => {
+  useCompanionStore.setState({
+    companionsById: record ? { [COMPANION_ID]: record } : {},
+  });
+};
+
+const meta = {
+  title: 'Workspace/CalculatorsPanel',
+  component: CalculatorsPanel,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The Quick Actions calculators panel. Its body is the shared `CalculatorBrowser`, which ' +
+          'has its own stories; what belongs to this panel are the **two notice cards above it** ' +
+          'and the **weight it hands down** - and all three depend on a companion record being in ' +
+          'the store, so a bare render of this component shows none of them.\n\n' +
+          'The prefill notice states the conversion in both units, because the workspace records ' +
+          'weight in pounds and every calculator works in kilograms: a clinician who sees only ' +
+          '"12.47" in the field has no way to check it against the chart. The kilogram value is ' +
+          'also what seeds `CalculatorForm`, and it does so ONCE, on mount - which is why the ' +
+          'browser is keyed on companion + weight + species and remounts rather than updating.\n\n' +
+          'The unsupported-species notice is the warning card: the formulas are canine and feline ' +
+          'only, so an equine or "other" patient gets an amber `warning-100` card naming the ' +
+          'recorded species, while the calculators stay usable rather than being hidden. Note ' +
+          'what it does to the prefill line above it - the species suffix is dropped there, so ' +
+          'the two cards never contradict each other.\n\n' +
+          'One thing to look at while reviewing: the sentence is assembled from two sources. The ' +
+          'name comes from the appointment, the weight and species from the companion record. ' +
+          'They agree in every story here because the fixtures keep them in step, not because ' +
+          'the component checks.\n\n' +
+          'Everything here is a store seed; `CalculatorsPanel` fetches nothing.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: { appointment: appointmentFor('Poppy Hartmann', 'dog') },
+  decorators: [
+    (Story) => (
+      <div className="w-[440px] max-w-full bg-[var(--screen)] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+  beforeEach: () => {
+    seed(companion());
+  },
+} satisfies Meta<typeof CalculatorsPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const PrefilledFromCompanion: Story = {
+  name: 'Weight pre-filled (canine)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Both units and the clinical species term - not "dog".
+    await expect(
+      canvas.getByText(
+        'Pre-filled from Poppy Hartmann: 27.5 lbs (12.47 kg), canine. Edit any value as needed.'
+      )
+    ).toBeInTheDocument();
+    // A supported species raises no warning card.
+    await expect(
+      canvas.queryByText(/Calculators support canine and feline only/)
+    ).not.toBeInTheDocument();
+
+    /* The number the notice quotes is the number the form is holding. Asserting the
+       card alone would pass with the prefill never reaching CalculatorForm, which
+       is the failure that actually matters here. The field is `type="number"`, so
+       jest-dom compares a Number, not the "12.47" string that was passed in. */
+    await expect(canvas.getByLabelText('Weight (kg)')).toHaveValue(12.47);
+    // The other fields of the first calculator stay empty - only weight is seeded.
+    await expect(canvas.getByLabelText('Dehydration (%)')).toHaveValue(null);
+    await expect(canvas.getByLabelText('Ongoing losses (mL/day, optional)')).toHaveValue(null);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A 27.5 lb beagle. The notice card is `bg-card-bg` with `caption-1` secondary ink, ' +
+          'sitting above the category track so it is read before a calculator is even chosen.',
+      },
+    },
+  },
+};
+
+export const UnsupportedSpecies: Story = {
+  name: 'Unsupported species (warning card)',
+  args: { appointment: appointmentFor('Rio', 'horse') },
+  beforeEach: () => {
+    seed(
+      companion({ name: 'Rio', type: 'horse', breed: 'Irish Sport Horse', currentWeight: 1102.31 })
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const warning = canvas.getByText(
+      'Calculators support canine and feline only; Rio is recorded as equine. Confirm the species before using a result.'
+    );
+    /* The prefill line above it drops its species suffix on an unsupported species,
+       so the two cards never disagree about what the patient is. Asserted as the
+       exact sentence: a `/Pre-filled from/` match would pass with ", equine." still
+       in it. */
+    const prefill = canvas.getByText(
+      'Pre-filled from Rio: 1102.31 lbs (500 kg). Edit any value as needed.'
+    );
+
+    /* Two cards, two grounds. The warning is the only one allowed to tint, and a
+       polled read avoids catching either mid-paint. */
+    await waitFor(() => {
+      const warningCard = getComputedStyle(warning.parentElement as HTMLElement);
+      const prefillCard = getComputedStyle(prefill.parentElement as HTMLElement);
+      expect(warningCard.backgroundColor).not.toBe(prefillCard.backgroundColor);
+      expect(getComputedStyle(warning).color).not.toBe(getComputedStyle(prefill).color);
+    });
+
+    // The calculators are NOT hidden - the panel warns and lets the vet decide.
+    await expect(canvas.getByLabelText('Weight (kg)')).toHaveValue(500);
+    await expect(canvas.getByRole('button', { name: 'Calculate' })).toBeEnabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A 500 kg horse. `speciesSupported` is false, so the browser is still seeded with ' +
+          '`dog` as its species - the amber card is the only thing telling the clinician that the ' +
+          'formula underneath does not match the patient in front of them, which is why it is ' +
+          'worth reading at panel width rather than trusting it exists.',
+      },
+    },
+  },
+};
+
+export const FelineTerminology: Story = {
+  name: 'Feline patient',
+  args: { appointment: appointmentFor('Miso', 'cat') },
+  beforeEach: () => {
+    seed(companion({ name: 'Miso', type: 'cat', breed: 'British Shorthair', currentWeight: 9.92 }));
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByText('Pre-filled from Miso: 9.92 lbs (4.5 kg), feline. Edit any value as needed.')
+    ).toBeInTheDocument();
+    await expect(
+      canvas.queryByText(/Calculators support canine and feline only/)
+    ).not.toBeInTheDocument();
+    await expect(canvas.getByLabelText('Weight (kg)')).toHaveValue(4.5);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The second supported species, kept because the notice reads "feline" rather than "cat" ' +
+          'and because the trailing zero is dropped: 9.92 lbs converts to 4.5 kg, not 4.50. Both ' +
+          'are the kind of copy detail that only shows up rendered. `initialSpecies` also flips ' +
+          'to `cat` here, which changes what every weight-based formula below returns.',
+      },
+    },
+  },
+};
+
+export const NoCompanionRecord: Story = {
+  name: 'Companion not in the store',
+  beforeEach: () => {
+    seed();
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* Every one of this panel's own surfaces is gated on the record. Without it the
+       panel is indistinguishable from a bare CalculatorBrowser - no notice, no
+       warning, and an empty weight field, with nothing on screen saying a patient
+       was expected. That silence is the state worth drawing. */
+    await expect(canvas.queryByText(/^Pre-filled from/)).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByText(/Calculators support canine and feline only/)
+    ).not.toBeInTheDocument();
+    await expect(canvas.getByLabelText('Weight (kg)')).toHaveValue(null);
+    await expect(canvas.getByRole('button', { name: 'Calculate' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The panel before the companion record has loaded, which is a real state: the side ' +
+          'action is global and can be opened on a workspace whose companion fetch has not ' +
+          'landed. It is also what every previous rendering of this component looked like, which ' +
+          'is why the two notice cards had never been seen.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/panels/TasksPanel.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/sidemodal/panels/TasksPanel.stories.tsx
@@ -1,0 +1,381 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import type { AppointmentEncounter } from '@/app/features/appointments/types/workspace';
+import type { Task } from '@/app/features/tasks/types/task';
+import { useAppointmentWorkspaceStore } from '@/app/stores/appointmentWorkspaceStore';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useTaskStore } from '@/app/stores/taskStore';
+import TasksPanel from './TasksPanel';
+
+const APPOINTMENT_ID = 'appt-workspace-1';
+
+const DRESSING = 'Change surgical dressing';
+const WEIGH = 'Weigh and record';
+
+/**
+ * Two real tasks in the shared task store, which is the ONLY place this panel
+ * reads its rows from - the workspace schedule and this panel render the same
+ * objects on purpose.
+ *
+ * `dueAt` is fixed so the row's "Due:" line and the details Duration row are
+ * stable, though both are formatted in the viewer's locale and timezone, so the
+ * stories assert the labels rather than the rendered timestamps.
+ */
+const DRESSING_TASK: Task = {
+  _id: 'task-dressing',
+  appointmentId: APPOINTMENT_ID,
+  assignedTo: 'staff-nadia',
+  audience: 'EMPLOYEE_TASK',
+  source: 'CUSTOM',
+  category: 'CARE',
+  name: DRESSING,
+  description: 'Remove the old dressing, clean with saline, re-wrap.',
+  dueAt: new Date('2026-03-12T14:00:00.000Z'),
+  status: 'PENDING',
+  recurrence: {
+    type: 'WEEKLY',
+    isMaster: true,
+    endDate: new Date('2026-04-09T14:00:00.000Z'),
+  },
+  reminder: { enabled: true, offsetMinutes: 30 },
+};
+
+const WEIGH_TASK: Task = {
+  _id: 'task-weigh',
+  appointmentId: APPOINTMENT_ID,
+  assignedTo: 'staff-nadia',
+  audience: 'EMPLOYEE_TASK',
+  source: 'CUSTOM',
+  category: 'DIAGNOSTIC',
+  name: WEIGH,
+  dueAt: new Date('2026-03-12T15:30:00.000Z'),
+  status: 'IN_PROGRESS',
+};
+
+const ENCOUNTER: AppointmentEncounter = {
+  appointmentId: APPOINTMENT_ID,
+  mode: 'INPATIENT',
+  consultationType: 'Post-op inpatient',
+  leadId: 'prac-amara',
+  leadName: 'Dr. Amara Weber',
+  alerts: [],
+  soap: [],
+  soapTemplates: [],
+  vitals: [],
+  observations: [],
+  diagnosticTests: [],
+  diagnosticOrders: [],
+  services: [],
+  prescription: [],
+  schedule: [],
+  invoiceLineItems: [],
+  pastInvoices: [],
+  depositCents: 0,
+  currency: 'USD',
+  withdrawDeposit: false,
+  taxPercent: 0,
+  overallDiscountPercent: 0,
+  dischargeSummary: '',
+  documents: [],
+  readyForBilling: { value: false },
+  readyForDischarge: { value: false },
+  stepStatus: {
+    SOAP: 'COMPLETED',
+    DIAGNOSTICS: 'IN_PROGRESS',
+    TREATMENT: 'IN_PROGRESS',
+    PASSPORT: 'EMPTY',
+    INVOICE: 'EMPTY',
+    SUMMARY: 'EMPTY',
+  },
+  viewOnly: false,
+};
+
+/**
+ * `TasksPanel` returns `null` outright without an encounter, so the seed is what
+ * makes the panel exist at all.
+ *
+ * Leaving `primaryOrgId` null is deliberate and is the whole offline seam:
+ * `loadTasksForPrimaryOrg` and `useLoadTeam` both return at their first line
+ * without one, so the mount reads the seeded store and never fetches. The cost
+ * is an empty assignee list, which is what the "Assigned to" dropdowns show
+ * here.
+ */
+const seed = (tasks: Task[] = [DRESSING_TASK, WEIGH_TASK]) => {
+  useOrgStore.setState({ primaryOrgId: null });
+  useTaskStore.setState({
+    tasksById: Object.fromEntries(tasks.map((task) => [task._id, task])),
+    taskIdsByOrgId: {},
+    status: 'loaded',
+  });
+  useAppointmentWorkspaceStore.setState({
+    encountersById: { [APPOINTMENT_ID]: ENCOUNTER },
+    focusTaskId: null,
+  });
+};
+
+/**
+ * The value span of one "Task details" row. `DetailRow` renders label and value as
+ * two sibling spans, so the value is the label's next sibling - there is no test id
+ * and no role, and matching the value text directly would assert nothing about which
+ * label it belongs to.
+ */
+const detailValue = (panel: HTMLElement, label: string): HTMLElement =>
+  within(panel).getByText(label).nextElementSibling as HTMLElement;
+
+const meta = {
+  title: 'Workspace/TasksPanel',
+  component: TasksPanel,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The Quick Actions tasks panel. Two of its three states had never been drawn, and both ' +
+          'replace content rather than adding to it.\n\n' +
+          '**The per-row "Task details" breakdown** is a local `TaskDetails` block gated on ' +
+          '`expandedRowId`, opened by the dark eye button on the row. It reads the BACKING `Task` ' +
+          'from the store, not the flattened `ScheduleTask` the row renders, so it is the only ' +
+          'place repeat, reminder and the recurrence end date appear at all.\n\n' +
+          '**The form swap** is a whole-panel replacement: `if (formOpen) return <PanelTaskForm/>` ' +
+          'happens before the tab strip and the list are rendered, so New Task and Edit take the ' +
+          'panel over completely. That is easy to miss reading the file and impossible to see in a ' +
+          'snapshot of the list. From the form, editing a task in a recurring series opens ' +
+          '`RecurrenceScopeModal` - a second, portalled layer on top of the swapped panel.\n\n' +
+          'Everything here runs off a seeded task store with no primary org, which is the ' +
+          'condition under which every loader in this file returns at its first line. The one ' +
+          'request that is not org-gated is the task-template list behind the form; it is fired ' +
+          'and its rejection is swallowed by `Promise.allSettled`, so the form renders with an ' +
+          'empty template picker instead of stalling.\n\n' +
+          'What is NOT drawn here: the form\'s `editError` line ("Unable to update task. Please ' +
+          'try again."). It is set only when `updateTask` REJECTS, and `updateTask` returns at ' +
+          'its first line without a primary org - the same absence that keeps the rest of this ' +
+          'file offline. Reaching it would need a primary org plus a stubbed failing PATCH, and ' +
+          'this repo has no request-stub wiring.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    appointmentId: APPOINTMENT_ID,
+    companionId: 'companion-1',
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[440px] max-w-full bg-[var(--screen)] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+  beforeEach: () => {
+    seed();
+  },
+} satisfies Meta<typeof TasksPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const RowDetailsExpanded: Story = {
+  name: 'Row details expanded',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(DRESSING)).toBeInTheDocument();
+    await expect(canvas.queryByText('Task details')).not.toBeInTheDocument();
+
+    // The eye button's label carries the row name, which is what keeps the two
+    // rows' toggles apart for a screen reader and for this query.
+    await userEvent.click(canvas.getByRole('button', { name: `View ${DRESSING}` }));
+
+    const details = (await canvas.findByText('Task details')).parentElement as HTMLElement;
+
+    /* Five rows for this task, with every value resolved through the taxonomy rather
+       than printed raw: CARE -> "Care", a WEEKLY master with no cron -> "Weekly",
+       30 minutes -> the reminder option's own label. Asserting the values is the
+       point - a details block that rendered every label against an em-dash would
+       satisfy a presence check. */
+    await expect(detailValue(details, 'Category')).toHaveTextContent('Care');
+    await expect(detailValue(details, 'Repeat')).toHaveTextContent('Weekly');
+    await expect(detailValue(details, 'Reminder')).toHaveTextContent('30 minutes before');
+    // Duration is a joined range, so it renders only on a task that has both a due
+    // date and a recurrence end date. The two dates are locale-formatted, so the
+    // join is what is asserted, not the rendered days.
+    await expect(detailValue(details, 'Duration').textContent).toContain(' - ');
+    await expect(detailValue(details, 'Instructions')).toHaveTextContent(
+      'Remove the old dressing, clean with saline, re-wrap.'
+    );
+
+    /* "Assigned by" is a sixth DetailRow that can never render: `TaskRow` is the only
+       caller of `TaskDetails` and it never passes `assignedByName`, so the row is
+       dead code today. Asserted so that the day someone wires it up, this story is
+       what notices. */
+    await expect(within(details).queryByText('Assigned by')).not.toBeInTheDocument();
+
+    // Exactly one row is expandable at a time: the other task stays collapsed.
+    await expect(canvas.getAllByText('Task details')).toHaveLength(1);
+    await expect(canvas.getByRole('button', { name: `View ${WEIGH}` })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The read-only breakdown under one row: a `rounded-2xl` inset card of label/value rows ' +
+          'separated by hairlines, with the last border removed. It is the only surface in the ' +
+          "panel that shows a task's repeat and reminder settings without opening the editor.",
+      },
+    },
+  },
+};
+
+export const RowDetailsToggleClosed: Story = {
+  name: 'Row details toggle back off',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: `View ${DRESSING}` }));
+    expect(await canvas.findByText('Task details')).toBeInTheDocument();
+
+    /* The icon and the accessible name both swap on expand (eye -> eye-off), so
+       the closing click has to be found under the other name. A story that reused
+       the "View ..." query here would fail to find the button and never close it. */
+    const hide = canvas.getByRole('button', { name: `Hide details for ${DRESSING}` });
+    await userEvent.click(hide);
+
+    await waitFor(() => {
+      expect(canvas.queryByText('Task details')).not.toBeInTheDocument();
+    });
+    await expect(canvas.getByRole('button', { name: `View ${DRESSING}` })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`expandedRowId` is a single id, not a set, so the toggle is genuinely exclusive and the ' +
+          'same button closes what it opened under a different name.',
+      },
+    },
+  },
+};
+
+export const NewTaskForm: Story = {
+  name: 'New Task takes over the panel',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getAllByRole('tab')).toHaveLength(2);
+
+    await userEvent.click(canvas.getByRole('button', { name: 'New Task' }));
+
+    expect(await canvas.findByRole('heading', { name: 'New task' })).toBeInTheDocument();
+    /* The list and the tab strip are GONE, not covered: the early return replaces
+       the whole panel body. This is the assertion that separates a swap from an
+       overlay, and it is the thing the source makes hardest to see. */
+    await expect(canvas.queryAllByRole('tab')).toHaveLength(0);
+    await expect(canvas.queryByText(DRESSING)).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'New Task' })).not.toBeInTheDocument();
+
+    await expect(canvas.getByRole('button', { name: 'Back to tasks' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Save task' })).toBeInTheDocument();
+
+    // A fresh form, not a seeded one: the Task field is empty on New.
+    await expect(canvas.queryByDisplayValue(DRESSING)).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'New Task replaces the tab strip, the list and its own button with the shared ' +
+          '`TaskFormFields` form plus a back arrow. The same form is used by the /tasks module, so ' +
+          'this is the panel-width rendering of it - single column, not the two-column dialog grid.',
+      },
+    },
+  },
+};
+
+export const EditSeedsTheForm: Story = {
+  name: 'Edit seeds the form',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: `Edit ${DRESSING}` }));
+
+    expect(await canvas.findByRole('heading', { name: 'Edit task' })).toBeInTheDocument();
+    // Seeded from the backing Task in the store, not from the flattened row.
+    await expect(canvas.getByDisplayValue(DRESSING)).toBeInTheDocument();
+    await expect(
+      canvas.getByDisplayValue('Remove the old dressing, clean with saline, re-wrap.')
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Edit routes through the same `PanelTaskForm`, with the heading and the template picker ' +
+          "as the only differences. `openEdit` prefers the store's real `Task`; a schedule row " +
+          'with no backing task falls back to a hand-built draft, which is why the seeded values ' +
+          'are worth asserting rather than assumed.',
+      },
+    },
+  },
+};
+
+export const RecurrenceScopeChoice: Story = {
+  name: 'Recurring edit asks for a scope',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: `Edit ${DRESSING}` }));
+    expect(await canvas.findByRole('heading', { name: 'Edit task' })).toBeInTheDocument();
+    await expect(document.querySelector('dialog[open]')).toBeNull();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Save task' }));
+
+    /* The modal is portalled to document.body by ModalBase, so it is outside
+       canvasElement entirely, and a closed dialog stays mounted without its `open`
+       attribute - absence has to be asserted against `dialog[open]`, as above. */
+    await waitFor(() => {
+      expect(document.querySelector('dialog[open]')).not.toBeNull();
+    });
+    const dialog = within(document.querySelector('dialog[open]') as HTMLElement);
+
+    await expect(dialog.getByText(/is part of a recurring series/)).toHaveTextContent(
+      `"${DRESSING}" is part of a recurring series.`
+    );
+    const scopes = dialog.getAllByRole('radio');
+    await expect(scopes).toHaveLength(3);
+    await expect(dialog.getByLabelText('This task only')).toBeChecked();
+    await expect(dialog.getByLabelText('This and following tasks')).not.toBeChecked();
+    await expect(dialog.getByLabelText('All tasks in the series')).not.toBeChecked();
+    await expect(dialog.getByRole('button', { name: 'Save changes' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Saving an edit to a task that belongs to a series stops and asks which occurrences the ' +
+          'change applies to, the way a calendar does. It appears only for a series task - the ' +
+          'other row in this panel saves straight through - and it is gated behind the form swap, ' +
+          'so it sits two interactions deep and had never been rendered from this entry point.',
+      },
+    },
+  },
+};
+
+export const EmptyPanel: Story = {
+  name: 'No tasks yet',
+  beforeEach: () => {
+    seed([]);
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('No tasks yet.')).toBeInTheDocument();
+    // Empty list, but the panel still offers its one action.
+    await expect(canvas.queryAllByRole('listitem')).toHaveLength(0);
+    await expect(canvas.getByRole('button', { name: 'New Task' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting state for an appointment with nothing scheduled, kept next to the populated ' +
+          'stories so the difference between "no tasks" and "tasks failed to load" is visible: ' +
+          'this panel has no loading or error state of its own, so both look identical here.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/PaymentActions.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/PaymentActions.stories.tsx
@@ -1,0 +1,255 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+
+import {
+  closeGlassTooltip,
+  openGlassTooltip,
+} from '@/app/ui/primitives/GlassTooltip/storyInteractions';
+import { PaymentActions } from './InvoiceStep';
+
+/**
+ * The exact copy `InvoiceStep` passes down while `readyForBilling` is false. Kept as a
+ * constant so the story asserts the shipped sentence rather than a paraphrase of it -
+ * a reworded tooltip should fail this story, not quietly pass a `/ready for billing/i`.
+ */
+const NOT_READY_REASON =
+  'Mark this visit ready for billing before sending to client, collecting cash, or paying online.';
+
+/** The three segment labels, in the order `PAYMENT_METHOD_LABELS` declares them. */
+const METHODS = ['Online', 'Cash', 'Deposit'] as const;
+
+const collectButton = (canvasElement: HTMLElement) =>
+  within(canvasElement).getByRole('button', { name: /^Collect / });
+
+const meta = {
+  title: 'Workspace/PaymentActions',
+  component: PaymentActions,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The payment-method card under the Total Bill: a three-way segmented control, one ' +
+          'Collect action priced from `dueCents`, the payment-link status line, and - on ' +
+          'in-patient encounters only - a Send-to-Client button.\n\n' +
+          'The surface that had never been drawn is the **GlassTooltip around the Collect ' +
+          'button**. It is conditional twice over. `InvoiceStep` only supplies ' +
+          '`paymentDisabledReason` while the visit is not marked ready for billing, and ' +
+          '`PaymentActions` then suppresses it again whenever the Deposit segment is selected, ' +
+          'because a deposit is collectable before the visit is billable. So the wrapper is not ' +
+          'a disabled tooltip that is merely closed - on two of the three segments the ' +
+          '`.glass-tooltip` span is not in the DOM at all, and the button sits bare.\n\n' +
+          'That matters for layout as well as copy. Both branches wrap the button in an ' +
+          "`inline-flex w-full [&>*]:w-full` span, but the wrapped branch slips GlassTooltip's " +
+          'own `relative inline-flex` span in above it - and that one carries no `w-full` of its ' +
+          "own. It only spans the card because it is a stretch item in the section's column " +
+          'flex. Nothing states that dependency, and a story that never renders the wrapped ' +
+          'branch never exercises it.\n\n' +
+          'The bubble opens on `mouseenter`/`focusin` bound in an effect, so the stories drive it ' +
+          'through `openGlassTooltip` rather than `userEvent.hover`: a single dispatch fired ' +
+          'before the effect flushes is lost, and no query-level retry re-sends it.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    isInpatient: false,
+    depositDisabled: false,
+    paymentDisabled: true,
+    paymentDisabledReason: NOT_READY_REASON,
+    dueCents: 28_400,
+    currency: 'USD',
+    onCollect: fn(),
+    onSendToClient: fn(),
+    paymentLinkStatus: null,
+  },
+} satisfies Meta<typeof PaymentActions>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const NotReadyForBilling: Story = {
+  name: 'Collect blocked (tooltip open)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const collect = collectButton(canvasElement);
+
+    // `maximumFractionDigits: 0` in formatMoney - $284, not $284.00.
+    await expect(collect).toHaveTextContent('Collect $284');
+    await expect(collect).toBeDisabled();
+
+    const bubble = await openGlassTooltip(collect);
+    await expect(bubble).toHaveTextContent(NOT_READY_REASON);
+    // `maxWidth={320}` reaches the portalled bubble as an inline style, and nothing
+    // else in the card constrains it - unset, this sentence renders as one long line.
+    await expect(getComputedStyle(bubble).maxWidth).toBe('320px');
+
+    /* The bubble portals to document.body, so it is outside canvasElement entirely -
+       exactly one tooltip is open, and it is not a descendant of the card. */
+    await expect(within(document.body).getAllByRole('tooltip')).toHaveLength(1);
+    await expect(canvas.queryByRole('tooltip')).not.toBeInTheDocument();
+
+    await closeGlassTooltip(collect);
+    await expect(document.body.querySelector('[role="tooltip"]')).toBeNull();
+
+    // Outpatient: no Send-to-Client row, so the card ends at the Collect button.
+    await expect(canvas.queryByRole('button', { name: 'Send to Client' })).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The state a fresh visit opens in: nothing is marked ready for billing, so Collect is ' +
+          'disabled at 50% opacity and the only explanation is inside a bubble nobody had ' +
+          'rendered. The bubble is opened and then closed again here, because a leftover bubble ' +
+          'lives on `document.body` and would be counted by any later tooltip assertion in the ' +
+          'same tab.',
+      },
+    },
+  },
+};
+
+export const DepositSuppressesTheTooltip: Story = {
+  name: 'Deposit selected (tooltip removed, not just closed)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(collectButton(canvasElement).closest('.glass-tooltip')).not.toBeNull();
+
+    const deposit = canvas.getByRole('button', { name: 'Deposit' });
+    await userEvent.click(deposit);
+
+    /* The reason is dropped for DEPOSIT, so the whole wrapper unmounts. Asserting on
+       `queryByRole('tooltip')` here would pass with the wrapper still present and
+       merely closed, which is a different component tree. */
+    const collect = collectButton(canvasElement);
+    await expect(collect.closest('.glass-tooltip')).toBeNull();
+    // Same `paymentDisabled` as the previous story, yet the button is now live:
+    // `collectDisabled` reads `depositDisabled` on this segment.
+    await expect(collect).toBeEnabled();
+    await expect(collect).toHaveTextContent('Collect $284');
+
+    await expect(deposit).toHaveAttribute('aria-pressed', 'true');
+    await expect(canvas.getByRole('button', { name: 'Online' })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+    /* The selected segment is the only one on `--screen` with a raised shadow; the
+       others are transparent. Polled, because the segments carry `transition-colors`
+       and a single synchronous read catches an interpolated background. */
+    await waitFor(() => {
+      expect(getComputedStyle(deposit).backgroundColor).not.toBe(
+        getComputedStyle(canvas.getByRole('button', { name: 'Online' })).backgroundColor
+      );
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Clicking Deposit changes what the button is allowed to do, not only which segment is ' +
+          'lit: `collectDisabled` switches from `paymentDisabled` to `depositDisabled`, and ' +
+          '`disabledReason` becomes undefined. A deposit is taken before a visit is billable, so ' +
+          'this is deliberate - but it means the same card renders two different trees under one ' +
+          'set of props.',
+      },
+    },
+  },
+};
+
+export const DepositSegmentUnavailable: Story = {
+  name: 'Deposit segment disabled',
+  args: { depositDisabled: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const segments = METHODS.map((label) => canvas.getByRole('button', { name: label }));
+    await expect(segments).toHaveLength(3);
+    await expect(segments[2]).toBeDisabled();
+    await expect(segments[0]).toBeEnabled();
+    await expect(segments[1]).toBeEnabled();
+
+    // A disabled segment cannot become the selected one, so the tooltip stays.
+    await userEvent.click(segments[2]);
+    await expect(segments[0]).toHaveAttribute('aria-pressed', 'true');
+    await expect(collectButton(canvasElement).closest('.glass-tooltip')).not.toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'While a payment is in flight `depositDisabled` is true, which greys the third segment ' +
+          'but leaves the other two live. Worth drawing because it is the one combination where ' +
+          'the escape hatch out of the tooltip is itself unreachable.',
+      },
+    },
+  },
+};
+
+export const ReadyInpatientWithLink: Story = {
+  name: 'Ready for billing (in-patient, link sent)',
+  args: {
+    isInpatient: true,
+    paymentDisabled: false,
+    paymentDisabledReason: undefined,
+    paymentLinkStatus: { label: 'Stripe - payment link sent', isSent: true },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const collect = collectButton(canvasElement);
+    await expect(collect).toBeEnabled();
+    await expect(collect.closest('.glass-tooltip')).toBeNull();
+
+    /* PaymentLinkStatus returns null on a null status, so this line exists only on
+       an invoice that really is collecting through a Stripe link. It is an <output>,
+       which is `role="status"`. */
+    const status = canvas.getByRole('status');
+    await expect(status).toHaveTextContent('Stripe - payment link sent');
+    await expect(status.querySelector('.yc-workspace-pulse-dot')).not.toBeNull();
+
+    // The in-patient-only row, separated by a `border-t` from the Collect button.
+    await expect(canvas.getByRole('button', { name: 'Send to Client' })).toBeEnabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The unblocked card. Three things appear at once that no other story shows together: ' +
+          'the bare (unwrapped) Collect button, the pulsing payment-link status line, and the ' +
+          'Send-to-Client row that only in-patient encounters get.',
+      },
+    },
+  },
+};
+
+export const Phone: Story = {
+  name: 'Phone width',
+  // Pinned as a GLOBAL. `parameters.viewport.defaultViewport` was removed in
+  // Storybook 10 - it type-checks, renders and proves nothing.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const collect = collectButton(canvasElement);
+    const wrapper = collect.closest('.glass-tooltip') as HTMLElement;
+
+    /* GlassTooltip's wrapper is `relative inline-flex` with no width of its own, so
+       the full-width Collect button only stays full width while that span stretches
+       as a flex item of the card. Measured with getBoundingClientRect rather than
+       getComputedStyle: the rect is the border box on every element in the chain,
+       so the three are actually comparable. */
+    const inner = collect.parentElement as HTMLElement;
+    await expect(collect.getBoundingClientRect().width).toBe(wrapper.getBoundingClientRect().width);
+    await expect(inner.getBoundingClientRect().width).toBe(wrapper.getBoundingClientRect().width);
+    // 375px viewport less the canvas padding, the card's own p-4 and its border -
+    // roughly 309. A shrink-wrapped button would land near its ~130px text width,
+    // so the threshold sits well clear of both.
+    await expect(collect.getBoundingClientRect().width).toBeGreaterThan(250);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'At 375px the segmented control and the Collect button both still span the card. This ' +
+          'is where the tooltip wrapper would show up as a defect if it ever lost its ' +
+          '`w-full` overrides: the button would shrink to its text and sit left-aligned.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/SoapStep.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/SoapStep.stories.tsx
@@ -1,0 +1,437 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+
+import type { FormField } from '@/app/features/forms/types/forms';
+import type {
+  AppointmentEncounter,
+  SoapNoteEntry,
+} from '@/app/features/appointments/types/workspace';
+import { useAppointmentWorkspaceStore } from '@/app/stores/appointmentWorkspaceStore';
+import SoapStep from './SoapStep';
+
+const APPOINTMENT_ID = 'appt-workspace-1';
+
+const NATIVE_TITLES = [
+  'Subjective (History)',
+  'Objective (Examination)',
+  'Assessment (Differential)',
+  'Plan',
+];
+
+/**
+ * The VISIBLE section heading, with the screen-reader layer filtered out.
+ *
+ * "Plan" is in this tree twice, and both copies are correct. `SectionContainer`
+ * draws the heading, and the `RichTextEditor` nested inside it draws its own
+ * `<span class="sr-only">` carrying the editor's `ariaLabel`. For three of the
+ * four sections those two strings differ ("Subjective (History)" heading vs
+ * "Subjective history" label), so nobody noticed; for Plan they are the same
+ * word, so a bare `getByText('Plan')` matches two elements and throws
+ * "Found multiple elements".
+ *
+ * Worth being precise about which duplication this is, because it decides how
+ * every future query against this component has to be written: it is NOT the
+ * section rendered twice (a desktop tree and a stacked phone tree both mounted),
+ * and it is NOT the preview decorator's sr-only story-title banner. It is one
+ * section carrying one hidden label. `.sr-only` excludes both that label and the
+ * decorator's banner, so this is the query to reach for either way. `script,
+ * style` is restated because passing `ignore` replaces the default rather than
+ * adding to it.
+ */
+const sectionTitle = (canvas: ReturnType<typeof within>, title: string) =>
+  canvas.getByText(title, { ignore: 'script, style, .sr-only' });
+
+/**
+ * A custom template's typed fields. Two are required and one is not, so the
+ * validation message has something to leave out - a schema where everything is
+ * required cannot tell a working validator from one that lists every field.
+ */
+const CUSTOM_SCHEMA: FormField[] = [
+  { id: 'presenting_signs', type: 'textarea', label: 'Presenting signs' },
+  { id: 'pain_score', type: 'input', label: 'Pain score (0-10)', required: true },
+  {
+    id: 'lameness_grade',
+    type: 'radio',
+    label: 'Lameness grade',
+    required: true,
+    options: [
+      { label: 'Grade I', value: '1' },
+      { label: 'Grade II', value: '2' },
+      { label: 'Grade III', value: '3' },
+    ],
+  },
+];
+
+const draft = (over: Partial<SoapNoteEntry> = {}): SoapNoteEntry => ({
+  id: 'draft',
+  chiefComplaint: '',
+  subjective: '',
+  objective: '',
+  assessment: '',
+  plan: '',
+  status: 'IN_PROGRESS',
+  createdAt: '2026-03-12T09:40:00.000Z',
+  ...over,
+});
+
+const encounter = (over: Partial<AppointmentEncounter> = {}): AppointmentEncounter => ({
+  appointmentId: APPOINTMENT_ID,
+  mode: 'OUTPATIENT',
+  consultationType: 'Outpatient consult',
+  leadId: 'prac-amara',
+  leadName: 'Dr. Amara Weber',
+  alerts: [],
+  soap: [draft()],
+  soapTemplates: [],
+  vitals: [],
+  observations: [],
+  diagnosticTests: [],
+  diagnosticOrders: [],
+  services: [],
+  prescription: [],
+  schedule: [],
+  invoiceLineItems: [],
+  pastInvoices: [],
+  depositCents: 0,
+  currency: 'USD',
+  withdrawDeposit: false,
+  taxPercent: 0,
+  overallDiscountPercent: 0,
+  dischargeSummary: '',
+  documents: [],
+  readyForBilling: { value: false },
+  readyForDischarge: { value: false },
+  stepStatus: {
+    SOAP: 'IN_PROGRESS',
+    DIAGNOSTICS: 'EMPTY',
+    TREATMENT: 'EMPTY',
+    PASSPORT: 'EMPTY',
+    INVOICE: 'EMPTY',
+    SUMMARY: 'EMPTY',
+  },
+  viewOnly: false,
+  ...over,
+});
+
+const CUSTOM_ENCOUNTER = encounter({
+  soap: [
+    draft({
+      templateId: 'tpl-ortho',
+      customSchema: CUSTOM_SCHEMA,
+      customAnswers: { presenting_signs: 'Left forelimb lameness after a fall in the park.' },
+    }),
+  ],
+});
+
+const meta = {
+  title: 'Workspace/SoapStep',
+  component: SoapStep,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The SOAP step. Its default rendering - four rich-text sections and a vitals aside - is ' +
+          'the only one that had ever been drawn, and it is the least interesting of the three ' +
+          'trees this component can produce.\n\n' +
+          '**Custom-template mode replaces the note entirely.** When the applied template carries ' +
+          'a `customSchema`, `isCustomSoap` flips and `CustomSoapFields` renders the shared ' +
+          '`FormRenderer` in place of `NativeSoapFields`. Subjective / Objective / Assessment / ' +
+          'Plan are not hidden or disabled - they are not rendered at all, and the section is ' +
+          'retitled "Clinical note". Nothing about the props says this; it is decided by one ' +
+          'boolean read off the active draft.\n\n' +
+          '**The required-field alert** only exists in custom mode. Native SOAP has no required ' +
+          'fields, so `Save & Next` on an empty native note just advances. In custom mode the same ' +
+          'button collects the unanswered required labels and refuses, with a `role="alert"` ' +
+          'banner naming them.\n\n' +
+          '**The lock banner** is the readOnly branch: the chip, the template search, the editors ' +
+          'and the action row all disappear together, and a single `bg-neutral-100` paragraph ' +
+          'takes their place - but only when the lock carries a reason. The client-derived lock ' +
+          '(`viewOnly`, no backend `sectionLocks`) has no reason, so it renders an empty column, ' +
+          'which is drawn here as its own story.\n\n' +
+          'No service is stubbed: `organisationId` is left undefined, which is what keeps the ' +
+          'auto-template resolver and the save off the network. Neither `Save & Next` story ' +
+          'reaches the persist path either - the native one returns on the empty-note branch and ' +
+          'the custom one is refused by validation - so both are exercising real code with no ' +
+          'request behind it.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    appointmentId: APPOINTMENT_ID,
+    appointmentReason: 'Limping on the front left leg since yesterday evening.',
+    appointmentSpeciality: 'Orthopaedics',
+    appointmentService: 'Lameness consultation',
+    encounter: encounter(),
+    visitStarted: true,
+    onRecordVitals: fn(),
+    onSaveAndNext: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <div className="min-h-[720px] bg-[var(--screen)] p-6">
+        <Story />
+      </div>
+    ),
+  ],
+  beforeEach: () => {
+    useAppointmentWorkspaceStore.setState({ saveStatusByAppointmentId: {} });
+  },
+} satisfies Meta<typeof SoapStep>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const NativeFields: Story = {
+  name: 'Native S/O/A/P',
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    for (const title of NATIVE_TITLES) {
+      await expect(sectionTitle(canvas, title)).toBeInTheDocument();
+    }
+    await expect(canvas.queryByText('Clinical note')).not.toBeInTheDocument();
+
+    /* The Plan section is the one place where the heading and the editor's
+       accessible name are the same string, so "Plan" is in the DOM twice: the
+       heading, and RichTextEditor's own sr-only label span. Named here rather
+       than filtered away silently, because it is the reason `sectionTitle`
+       exists and it is exactly one section, not two. */
+    await expect(canvas.getAllByText('Plan')).toHaveLength(2);
+    const planEditor = await canvas.findByRole('textbox', { name: 'Plan' });
+    await expect(planEditor).toBeInTheDocument();
+
+    /* Native SOAP has no required fields at all, so an empty note advances rather
+       than validating - the contrast that makes the custom-mode alert meaningful.
+       `handleSaveAndNext` returns on its first branch here (`!customMode &&
+       !hasNativeSoapContent`), so it never reaches the persist path at all and the
+       callback is the whole observable effect. Nothing is stubbed to achieve that. */
+    await userEvent.click(canvas.getByRole('button', { name: 'Save & Next' }));
+    await waitFor(() => {
+      expect(args.onSaveAndNext).toHaveBeenCalled();
+    });
+    await expect(canvas.queryByRole('alert')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The default tree. Four `SectionContainer` editors down the left, the vitals panel in a ' +
+          '360px aside, and the read-only "All SOAP notes" list underneath - empty here, because ' +
+          'only signed notes move into it.\n\n' +
+          'One thing to know before writing a query against this component: each editor renders ' +
+          'its `ariaLabel` a second time as an `sr-only` span, so the Plan section - the only one ' +
+          'whose heading and editor label are the same word - puts "Plan" in the DOM twice. There ' +
+          "is one Plan section, not two; a bare `getByText('Plan')` throws all the same.",
+      },
+    },
+  },
+};
+
+export const CustomTemplateFields: Story = {
+  name: 'Custom template replaces the sections',
+  args: { encounter: CUSTOM_ENCOUNTER },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Clinical note')).toBeInTheDocument();
+
+    /* The native editors are GONE, not hidden. Asserting the custom fields appeared
+       would pass with both trees rendered one under the other, which is the failure
+       this swap would actually produce. */
+    for (const title of NATIVE_TITLES) {
+      await expect(canvas.queryByText(title)).not.toBeInTheDocument();
+    }
+
+    // Every schema field is rendered, by its own label, through FormRenderer.
+    await expect(canvas.getByLabelText('Presenting signs')).toHaveValue(
+      'Left forelimb lameness after a fall in the park.'
+    );
+    await expect(canvas.getByLabelText('Pain score (0-10)')).toHaveValue('');
+    await expect(canvas.getByText('Lameness grade')).toBeInTheDocument();
+    /* A radio field renders one input per option with a composed accessible name,
+       and none is preselected - which is what leaves it unanswered for the
+       validation story below. */
+    const grades = canvas.getAllByRole('radio');
+    await expect(grades).toHaveLength(3);
+    await expect(canvas.getByRole('radio', { name: 'Lameness grade: Grade II' })).not.toBeChecked();
+
+    // Record Vitals survives the swap - it is inside CustomSoapFields too.
+    await expect(canvas.getByRole('button', { name: 'Record Vitals' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A template whose `customSchema` carries three typed fields. The answers are keyed by ' +
+          'field id and stored on the draft, so the pre-filled textarea here is real state rather ' +
+          'than a default - which is what makes the empty required fields below it unanswered.',
+      },
+    },
+  },
+};
+
+export const RequiredFieldsAlert: Story = {
+  name: 'Save blocked by required fields',
+  args: { encounter: CUSTOM_ENCOUNTER },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.queryByRole('alert')).not.toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Save & Next' }));
+
+    /* The banner names the missing labels, in schema order, and leaves out the one
+       optional field that IS answered. A regex on "required field" would pass with
+       an empty list, which is the regression worth catching. */
+    const alert = await canvas.findByRole('alert');
+    await expect(alert).toHaveTextContent(
+      'Please complete required field(s): Pain score (0-10), Lameness grade'
+    );
+    await expect(alert.textContent).not.toContain('Presenting signs');
+
+    // It refuses rather than advancing: the step never moves on.
+    await expect(args.onSaveAndNext).not.toHaveBeenCalled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The only validation gate in the SOAP step, and it exists solely in custom-template ' +
+          'mode. The banner is a `rounded-2xl bg-danger-100` block that appears between the fields ' +
+          'and the action row, so it pushes Save & Next down - worth seeing rendered, since it is ' +
+          'the one thing standing between an incomplete structured note and a signed artifact.',
+      },
+    },
+  },
+};
+
+export const LockedWithReason: Story = {
+  name: 'Read-only with a lock reason',
+  args: {
+    encounter: encounter({
+      viewOnly: true,
+      sectionLocks: {
+        soap: {
+          locked: true,
+          reason:
+            'This visit was discharged on 12 March, so the SOAP note is locked. Add an addendum ' +
+            'from the records panel instead.',
+        },
+      },
+    }),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/This visit was discharged on 12 March/)).toBeInTheDocument();
+
+    /* readOnly removes the whole editing block in one branch, so all four of these
+       go together. Checking only that the banner appeared would pass with the
+       editors still sitting under it. */
+    for (const title of NATIVE_TITLES) {
+      await expect(canvas.queryByText(title)).not.toBeInTheDocument();
+    }
+    await expect(canvas.queryByRole('button', { name: 'Save & Next' })).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('searchbox', { name: /template/i })).not.toBeInTheDocument();
+
+    // The context header and the vitals aside stay: only the left editing column locks.
+    await expect(canvas.getByRole('heading', { name: 'SOAP note' })).toBeInTheDocument();
+    await expect(
+      canvas.getByText('Limping on the front left leg since yesterday evening.')
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The backend-owned lock. `resolveSectionLock` prefers `sectionLocks.soap` over the ' +
+          "client-derived `viewOnly`, so the reason string is the backend's own words rather than " +
+          'anything the client composes - which is why it is worth rendering a long one here.',
+      },
+    },
+  },
+};
+
+export const LockedWithoutReason: Story = {
+  name: 'Read-only with no reason (empty column)',
+  args: { encounter: encounter({ viewOnly: true }) },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    /* The client-derived lock resolves to `{ locked: true }` with NO reason, and the
+       banner is gated on `readOnly && lockReason`. So the entire left column renders
+       nothing: no editors, no explanation, just whitespace next to the vitals panel.
+       Drawn deliberately - this is the state a completed visit lands in whenever the
+       bootstrap has not supplied sectionLocks. */
+    for (const title of NATIVE_TITLES) {
+      await expect(canvas.queryByText(title)).not.toBeInTheDocument();
+    }
+    await expect(canvas.queryByRole('button', { name: 'Save & Next' })).not.toBeInTheDocument();
+
+    /* Not "no banner" - NOTHING. The left column is the aside's previous sibling,
+       and it renders zero children in this state. A text-absence check could not
+       tell an empty column apart from one holding some other explanation. */
+    const aside = canvasElement.querySelector('aside') as HTMLElement;
+    const leftColumn = aside.previousElementSibling as HTMLElement;
+    await expect(leftColumn.children).toHaveLength(0);
+
+    // Everything outside the locked column is still there, which is what makes the
+    // gap read as a hole rather than as an empty step.
+    await expect(canvas.getByRole('heading', { name: 'SOAP note' })).toBeInTheDocument();
+    await expect(canvas.getByText('All SOAP notes')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Same lock, no reason. Worth keeping next to the story above: the two differ by one ' +
+          'optional string, and the difference between them is a full explanation and a blank ' +
+          'column.',
+      },
+    },
+  },
+};
+
+export const Phone: Story = {
+  name: 'Phone: aside stacks under the note',
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const subjective = sectionTitle(canvas, 'Subjective (History)');
+    const vitals = canvas.getByText('Vitals');
+    // `lg:flex-row` collapses below 1024px, so the 360px aside drops beneath the
+    // editors instead of sitting beside them.
+    await expect(vitals.getBoundingClientRect().top).toBeGreaterThan(
+      subjective.getBoundingClientRect().bottom
+    );
+
+    /* Stacking is a layout change, not a content change: all four editors, the
+       vitals card and the notes list are still here. Worth asserting, because the
+       cheap way to "fix" a cramped phone layout is to hide something, and that
+       would still satisfy the geometry check above. Queried through
+       `sectionTitle`: "Plan" resolves to two nodes at every viewport (heading +
+       the editor's sr-only label), which is a property of the component, not of
+       the breakpoint - there is no second, hidden phone tree here. */
+    for (const title of NATIVE_TITLES) {
+      await expect(sectionTitle(canvas, title)).toBeInTheDocument();
+    }
+    await expect(canvas.getByText('No vitals recorded yet.')).toBeInTheDocument();
+    await expect(canvas.getByText('All SOAP notes')).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Save & Next' })).toBeInTheDocument();
+
+    /* The aside is `w-full` once it stops being an aside, so it matches the editing
+       column rather than keeping its 360px desktop track. That equality is the
+       observable difference between "collapsed" and "still 360px, just wrapped". */
+    const aside = canvasElement.querySelector('aside') as HTMLElement;
+    const leftColumn = aside.previousElementSibling as HTMLElement;
+    await expect(aside.getBoundingClientRect().width).toBe(
+      leftColumn.getBoundingClientRect().width
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "At 375px the two-column step becomes one column and the context header's three fields " +
+          '(chief complaint, speciality, service) stack as well.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/SummaryStep.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/SummaryStep.stories.tsx
@@ -1,0 +1,355 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import type { Appointment } from '@yosemite-crew/types';
+
+import type { AppointmentEncounter } from '@/app/features/appointments/types/workspace';
+import {
+  closeGlassTooltip,
+  openGlassTooltip,
+} from '@/app/ui/primitives/GlassTooltip/storyInteractions';
+import { useAppointmentWorkspaceStore } from '@/app/stores/appointmentWorkspaceStore';
+import { useSigningOverlayStore } from '@/app/stores/signingOverlayStore';
+import SummaryStep from './SummaryStep';
+
+const APPOINTMENT_ID = 'appt-workspace-1';
+
+const SIGN_BLOCKED_REASON = 'Signing is available only while the appointment is In progress.';
+const NO_TEMPLATE_MATCHES = 'No discharge templates match this search.';
+
+/**
+ * Every network call this step makes is gated on `appointment.organisationId`:
+ * the discharge-template list, the bootstrap encounter-id lookup, the documents
+ * read-model and the context template resolver all return at their first line
+ * without one. An unresolved org id is therefore the whole offline seam - no
+ * service module is stubbed anywhere in this file, and the component under
+ * review is the real one.
+ *
+ * It also puts `handleSign` on its missing-context branch, which is the same
+ * branch a real visit takes when it has no encounter yet (not checked in).
+ */
+const appointment = (over: Partial<Appointment> = {}): Appointment => ({
+  id: APPOINTMENT_ID,
+  organisationId: '',
+  patient: {
+    id: 'companion-1',
+    name: 'Poppy Hartmann',
+    species: 'dog',
+    breed: 'Beagle',
+    parent: { id: 'parent-1', name: 'Lena Hartmann' },
+  },
+  lead: { id: 'prac-amara', name: 'Dr. Amara Weber' },
+  appointmentDate: new Date('2026-03-12T09:30:00.000Z'),
+  startTime: new Date('2026-03-12T09:30:00.000Z'),
+  endTime: new Date('2026-03-12T10:00:00.000Z'),
+  timeSlot: '09:30 - 10:00',
+  durationMinutes: 30,
+  status: 'CHECKED_IN',
+  ...over,
+});
+
+const encounter = (over: Partial<AppointmentEncounter> = {}): AppointmentEncounter => ({
+  appointmentId: APPOINTMENT_ID,
+  mode: 'OUTPATIENT',
+  consultationType: 'Outpatient consult',
+  leadId: 'prac-amara',
+  leadName: 'Dr. Amara Weber',
+  alerts: [],
+  soap: [],
+  soapTemplates: [],
+  vitals: [],
+  observations: [],
+  diagnosticTests: [],
+  diagnosticOrders: [],
+  services: [],
+  prescription: [],
+  schedule: [],
+  invoiceLineItems: [],
+  pastInvoices: [],
+  depositCents: 0,
+  currency: 'USD',
+  withdrawDeposit: false,
+  taxPercent: 0,
+  overallDiscountPercent: 0,
+  dischargeSummary: '<p>Rest for 48 hours. Soft food only. Recheck the incision daily.</p>',
+  documents: [],
+  readyForBilling: { value: false },
+  readyForDischarge: { value: false },
+  stepStatus: {
+    SOAP: 'COMPLETED',
+    DIAGNOSTICS: 'COMPLETED',
+    TREATMENT: 'COMPLETED',
+    PASSPORT: 'EMPTY',
+    INVOICE: 'COMPLETED',
+    SUMMARY: 'IN_PROGRESS',
+  },
+  viewOnly: false,
+  ...over,
+});
+
+/** A saved summary is what puts Print All / Sign on screen at all. */
+const SAVED = encounter({
+  dischargeSavedAt: '2026-03-12T11:20:00.000Z',
+  dischargeSavedByName: 'Dr. Amara Weber',
+});
+
+const signButton = (canvasElement: HTMLElement) =>
+  within(canvasElement).getByRole('button', { name: 'Sign' });
+
+const meta = {
+  title: 'Workspace/SummaryStep',
+  component: SummaryStep,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The discharge step. Three of its surfaces are unreachable from a plain render, and ' +
+          'none of them had ever been drawn.\n\n' +
+          '**The discharge-template dropdown** is a `SearchResultsDropdown` portalled to ' +
+          '`document.body` at `position: fixed, zIndex 1000`, sized from the search input rect. It ' +
+          'mounts only while the query is non-empty, so nothing renders it at rest - and its ' +
+          '"no matches" branch is a plain paragraph, not a row, which is exactly the kind of ' +
+          'inner content a story asserting "the panel opened" would miss.\n\n' +
+          '**The Sign tooltip** wraps the button only while the appointment is not In progress. ' +
+          'It is not a disabled tooltip that happens to be closed: the two branches render ' +
+          'different trees, one with a `.glass-tooltip` wrapper and one without, so the wrapped ' +
+          'form only exists on a checked-in or completed visit.\n\n' +
+          '**The `signError` alert** sits above the action row and pushes it down. It is set ' +
+          'from `handleSign`, so it can only appear after a failed attempt.\n\n' +
+          'The stories mount the real step with an unresolved `organisationId`, which is the one ' +
+          'condition under which every service call in this file returns at its first line. That ' +
+          'is deliberate: this repo has no MSW wiring, and the alternative would be stubbing four ' +
+          'modules to draw three pieces of markup.\n\n' +
+          'What is NOT drawn here, for the same reason: the **populated** template list and the ' +
+          '"Unable to load discharge templates." error line. Both need ' +
+          '`listDischargeSummaryTemplates` to resolve or reject, and neither is reachable without ' +
+          'a request stub.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    appointmentId: APPOINTMENT_ID,
+    appointment: appointment(),
+    encounter: encounter(),
+  },
+  decorators: [
+    (Story) => (
+      <div className="min-h-[720px] bg-[var(--screen)] p-6">
+        <Story />
+      </div>
+    ),
+  ],
+  beforeEach: () => {
+    // The signing overlay is a global store and portals over the whole viewport;
+    // reset it so a story that ran earlier in the tab cannot cover this one.
+    useSigningOverlayStore.getState().close();
+    useAppointmentWorkspaceStore.setState({ saveStatusByAppointmentId: {} });
+  },
+} satisfies Meta<typeof SummaryStep>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const TemplateSearchNoMatches: Story = {
+  name: 'Template dropdown (no matches)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const search = canvas.getByRole('searchbox', { name: 'Search discharge templates' });
+    // The dropdown is derived from the query, not from a prop, so it cannot exist yet.
+    await expect(within(document.body).queryByText(NO_TEMPLATE_MATCHES)).not.toBeInTheDocument();
+
+    await userEvent.type(search, 'ortho');
+
+    const emptyLine = await within(document.body).findByText(NO_TEMPLATE_MATCHES);
+    // Portalled to body: the panel is NOT a descendant of the step.
+    await expect(canvas.queryByText(NO_TEMPLATE_MATCHES)).not.toBeInTheDocument();
+
+    const panel = emptyLine.parentElement as HTMLElement;
+    const panelStyle = getComputedStyle(panel);
+    await expect(panelStyle.position).toBe('fixed');
+    await expect(panelStyle.zIndex).toBe('1000');
+
+    /* The panel is sized from the anchor's rect every time the window moves, so a
+       broken anchor shows up as a width mismatch rather than as a missing panel.
+       getBoundingClientRect, not getComputedStyle: the panel is bordered, and the
+       content box reads 2px narrower than the width it was actually given. */
+    const anchor = search.closest('div.relative') as HTMLElement;
+    await expect(panel.getBoundingClientRect().width).toBeCloseTo(
+      anchor.getBoundingClientRect().width,
+      1
+    );
+
+    // Empty means empty: no result row survived the filter, and nothing else did either.
+    await expect(within(panel).queryAllByRole('button')).toHaveLength(0);
+    await expect(within(panel).queryAllByRole('listitem')).toHaveLength(0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A query that matches nothing. The panel still opens - it is gated on the query being ' +
+          'non-empty, not on there being results - and shows one muted sentence at `px-4 py-3`. ' +
+          'Worth drawing because the empty branch is what a clinician sees while typing any name ' +
+          'the practice has not yet templated, and because its geometry (fixed, body-portalled, ' +
+          'anchored to the input width) is invisible in the source.',
+      },
+    },
+  },
+};
+
+export const SignBlockedTooltip: Story = {
+  name: 'Sign blocked (tooltip open)',
+  args: { encounter: SAVED },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* Saved swaps the whole editor out for the read-only render plus the stamp, and
+       that swap is what reveals the action row. Assert the render, not just the row -
+       an empty saved view would still show the buttons. */
+    await expect(canvas.getByText(/Rest for 48 hours\./)).toBeInTheDocument();
+    await expect(canvas.getByText('Saved by Dr. Amara Weber')).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('button', { name: 'Edit discharge summary' })
+    ).toBeInTheDocument();
+    // Save is replaced by Print All + Sign once saved; it is not merely disabled.
+    await expect(canvas.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Print All' })).toBeInTheDocument();
+
+    const sign = signButton(canvasElement);
+    await expect(sign).toBeDisabled();
+    await expect(sign.closest('.glass-tooltip')).not.toBeNull();
+
+    const bubble = await openGlassTooltip(sign);
+    await expect(bubble).toHaveTextContent(SIGN_BLOCKED_REASON);
+    await expect(within(document.body).getAllByRole('tooltip')).toHaveLength(1);
+
+    /* Closed explicitly. The pencil above is a CircleIconButton, which is also a
+       GlassTooltip - leaving this bubble open would leave two candidates on
+       document.body for any later query in the same tab. */
+    await closeGlassTooltip(sign);
+    await expect(document.body.querySelector('[role="tooltip"]')).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A checked-in visit with the summary already saved. Signing is refused until the ' +
+          'appointment is actually In progress, and the only place that rule is stated is this ' +
+          'bubble - the button itself just reads "Sign" at 60% opacity.',
+      },
+    },
+  },
+};
+
+export const SignAllowed: Story = {
+  name: 'Sign allowed (no wrapper)',
+  args: { appointment: appointment({ status: 'IN_PROGRESS' }), encounter: SAVED },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const sign = signButton(canvasElement);
+    await expect(sign).toBeEnabled();
+    /* The wrapper is gone, not just quiet. `queryByRole('tooltip')` would pass either
+       way, since a closed GlassTooltip renders no bubble in both branches. */
+    await expect(sign.closest('.glass-tooltip')).toBeNull();
+
+    /* The rest of the row is byte-identical to the blocked story, which is the
+       point: the only difference between the two branches is the wrapper and the
+       disabled attribute, so everything else has to be asserted here or the
+       comparison proves nothing. */
+    await expect(sign).toHaveTextContent('Sign');
+    await expect(canvas.getByRole('button', { name: 'Print All' })).toBeEnabled();
+    // Not yet signed, so the Sign→Download Signed swap has not happened.
+    await expect(canvas.queryByRole('button', { name: 'Download Signed' })).not.toBeInTheDocument();
+    /* Sign sits to the RIGHT of Print All on the same line - the row is
+       `justify-end flex-wrap`, so at laptop width neither wraps. Overlap rather
+       than an exact top: `items-center` centres them, so two buttons of unequal
+       height would share a line without sharing a top edge. */
+    const print = canvas.getByRole('button', { name: 'Print All' });
+    const signRect = sign.getBoundingClientRect();
+    const printRect = print.getBoundingClientRect();
+    await expect(signRect.top).toBeLessThan(printRect.bottom);
+    await expect(printRect.top).toBeLessThan(signRect.bottom);
+    await expect(signRect.left).toBeGreaterThan(printRect.left);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same row on an in-progress visit, for the side-by-side. `signDisabledReason` is ' +
+          'undefined here, so the step renders the second of its two Sign branches and the button ' +
+          'sits directly in the flex row with no wrapping span.',
+      },
+    },
+  },
+};
+
+export const SignErrorAlert: Story = {
+  name: 'Sign failure (role=alert)',
+  args: { appointment: appointment({ status: 'IN_PROGRESS' }), encounter: SAVED },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.queryByRole('alert')).not.toBeInTheDocument();
+
+    await userEvent.click(signButton(canvasElement));
+
+    const alert = await canvas.findByRole('alert');
+    await expect(alert).toHaveTextContent('Missing organisation or encounter for signing.');
+    // Inline `text-body-4 text-text-error`, not a banner: it is a bare <p> in the
+    // right-aligned column above the buttons, so it pushes the action row down.
+    await expect(alert.tagName).toBe('P');
+
+    /* The guard returns before `setIsSigning(true)`, so the label never flips to
+       "Signing…" and the button stays clickable for a retry. */
+    await waitFor(() => {
+      expect(signButton(canvasElement)).toBeEnabled();
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The failure path of `handleSign` when the encounter context is missing - the state a ' +
+          'visit is in before it has been checked in and given an encounter. It is the only error ' +
+          'surface on this step that is announced (`role="alert"`), and until now nothing had ' +
+          'rendered it.',
+      },
+    },
+  },
+};
+
+export const Phone: Story = {
+  name: 'Phone: actions stack',
+  args: { encounter: SAVED },
+  // Pinned as a GLOBAL: `parameters.viewport.defaultViewport` was removed in
+  // Storybook 10 and silently renders at full panel width.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    /* At 375px the two-pane `lg:flex-row` collapses, so All Documents drops under
+       the summary instead of sitting in the 400px aside. Both panes are still
+       present - the layout changes, the content does not. */
+    await expect(canvas.getByText('Discharge Summary')).toBeInTheDocument();
+    await expect(canvas.getByText('All Documents')).toBeInTheDocument();
+    await expect(canvas.getByText('No documents recorded yet.')).toBeInTheDocument();
+
+    /* Stacked, not side by side. On a wide viewport these two headings sit at
+       roughly the same y; here the documents pane must start below the summary
+       pane entirely, which is the only observable difference between the
+       `lg:flex-row` and the collapsed layout. */
+    const summaryTitle = canvas.getByText('Discharge Summary');
+    const documentsTitle = canvas.getByText('All Documents');
+    await expect(documentsTitle.getBoundingClientRect().top).toBeGreaterThan(
+      summaryTitle.getBoundingClientRect().bottom
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The saved step at phone width. The action row is `flex-wrap`, so Print All and Sign ' +
+          'wrap rather than shrink, and the documents aside stops being an aside.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AddAppointmentCentralModal/index.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AddAppointmentCentralModal/index.stories.tsx
@@ -1,0 +1,590 @@
+import { useState, type ComponentProps } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+
+import type { Slot } from '@/app/features/appointments/types/appointments';
+import { AppointmentFormContent } from './index';
+
+const TODAY = new Date('2026-03-12T00:00:00');
+
+/**
+ * Labels in the real modal are built by `formatCompanionNameWithOwnerLastName`,
+ * which joins the companion to the owner's LAST name with a middle dot -
+ * `Poppy · Hartmann`, never `Poppy (Hartmann)`. Worth matching exactly here,
+ * because `AppointmentAvatar` derives its initials from the first and last
+ * whitespace-separated token of this very string: with the real separator two of
+ * these read 'PH', with brackets the second initial would be the bracket itself.
+ */
+const PATIENT_OPTIONS = [
+  { value: 'companion-1', label: 'Poppy · Hartmann' },
+  { value: 'companion-2', label: 'Mochi · Ruiz' },
+  { value: 'companion-3', label: 'Bruno · Fabre' },
+  { value: 'companion-4', label: 'Pepper · Hartmann' },
+];
+
+const CLIENT_OPTIONS = [
+  { value: 'parent-1', label: 'Lena Hartmann' },
+  { value: 'parent-2', label: 'Tomas Ruiz' },
+];
+
+const TIME_SLOTS: Slot[] = [
+  { startTime: '09:00', endTime: '09:30', vetIds: ['vet-1'] },
+  { startTime: '09:30', endTime: '10:00', vetIds: ['vet-1', 'vet-2'] },
+  { startTime: '10:00', endTime: '10:30', vetIds: ['vet-2'] },
+];
+
+const LEAD_OPTIONS = [
+  { label: 'Dr. Weber', value: 'vet-1' },
+  { label: 'Dr. Nadia Iqbal', value: 'vet-2' },
+];
+
+const SUPPORT_OPTIONS = [
+  { label: 'Ana Silva', value: 'tech-1' },
+  { label: 'Jonas Berg', value: 'tech-2' },
+];
+
+const SUBMIT_ERRORS: Record<string, string> = {
+  companionId: 'Select a patient',
+  slot: 'Select a time slot',
+  leadId: 'Select a lead',
+  specialityId: 'Select a speciality',
+  serviceId: 'Select a service',
+  concern: 'Describe the reason for the visit',
+};
+
+const SPECIALITY_OPTIONS = [{ label: 'General practice', value: 'spec-general' }];
+const SERVICE_OPTIONS = [{ label: 'Annual check-up', value: 'svc-annual' }];
+
+const FORM_DATA = {
+  concern: '',
+  isEmergency: false,
+  lead: { id: '' },
+  supportStaff: [] as Array<{ id?: string }>,
+  appointmentType: { id: '', speciality: { id: '' } },
+};
+
+type FormProps = ComponentProps<typeof AppointmentFormContent>;
+
+/**
+ * Annotated with the prop's own type rather than written inline. An inline
+ * `() => undefined` narrows the meta arg to a zero-argument signature, and every
+ * per-story override that actually reads `field` then fails to type-check against it.
+ */
+const noFieldErrors: FormProps['showError'] = () => undefined;
+
+/**
+ * The form is fully controlled by `useAddAppointmentCentralModalView`, which owns the
+ * modal, the companion loader and the booking request. Only the presentational half is
+ * exported, and only that half is mounted here - the two person pickers still need
+ * their query strings to live somewhere or their result lists can never open, so the
+ * harness holds exactly those two values and forwards everything else to the story's
+ * mocks.
+ */
+const FormHarness = (args: FormProps) => {
+  const [patientQuery, setPatientQuery] = useState(args.patientQuery);
+  const [clientQuery, setClientQuery] = useState(args.clientQuery);
+
+  return (
+    <AppointmentFormContent
+      {...args}
+      patientQuery={patientQuery}
+      setPatientQuery={(value) => {
+        setPatientQuery(value);
+        args.setPatientQuery(value);
+      }}
+      clientQuery={clientQuery}
+      setClientQuery={(value) => {
+        setClientQuery(value);
+        args.setClientQuery(value);
+      }}
+    />
+  );
+};
+
+/** Both the person list and the slot list portal their panel and tag it the same way. */
+const findPortalPanel = async (): Promise<HTMLElement> => {
+  await waitFor(() => expect(document.querySelector('[data-portal-dropdown]')).toBeInTheDocument());
+  return document.querySelector('[data-portal-dropdown]') as HTMLElement;
+};
+
+/**
+ * The field grid: `grid-cols-1` with `md:grid-cols-2`, so it is the outermost `.grid`
+ * in the tree and the first one in document order. Read as tracks rather than as a
+ * class name, because the class only means anything once Tailwind has resolved it.
+ */
+const getFieldGrid = (canvasElement: HTMLElement): HTMLElement =>
+  canvasElement.querySelector('.grid') as HTMLElement;
+
+const trackCount = (element: HTMLElement): number =>
+  getComputedStyle(element).gridTemplateColumns.trim().split(/\s+/).length;
+
+const meta = {
+  title: 'Appointments/AddAppointmentCentralModal',
+  component: FormHarness,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The body of the Add appointment panel. Three of its surfaces exist only after an ' +
+          'interaction or only after a failed submit, and none of them had ever been drawn.\n\n' +
+          '**Submit-time validation.** Nothing on this form validates as you type. `showError` ' +
+          'returns a message only once a submit has been attempted, so the first time a user ' +
+          'sees any of it is the moment they press Book - at which point up to six fields ' +
+          'change at once. They are not all the same control either: the patient picker and the ' +
+          'time dropdown render a `FieldError` with `role="alert"`, while Lead, Speciality, ' +
+          'Service and Chief Complaint render their own inline error rows with no alert ' +
+          'semantics, so a screen reader hears two of the six. Below the grid a separate ' +
+          'booking-level banner appears for `formDataErrors.booking`, which is the server ' +
+          'refusing the booking rather than a field being wrong.\n\n' +
+          '**The companion search list.** `PersonRow` measures its trigger in a layout effect ' +
+          'and `createPortal`s the result list to `document.body`, so it is not a descendant of ' +
+          'this form at all and no snapshot of the closed field contains a single row of it. It ' +
+          'is also where "no matches" and "no options" are worded differently on purpose.\n\n' +
+          '**The time-slot dropdown.** Same portal trick, three different bodies: a spinner ' +
+          'row, the slot list, or a sentence explaining which upstream field is still empty.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    patientLabel: 'Patient',
+    patientQuery: '',
+    setPatientQuery: fn(),
+    patientOptions: PATIENT_OPTIONS,
+    handlePatientSelect: fn(),
+    handlePatientClear: fn(),
+    clientQuery: '',
+    setClientQuery: fn(),
+    clientOptions: CLIENT_OPTIONS,
+    handleClientSelect: fn(),
+    handleClientClear: fn(),
+    setAddCompanionTarget: fn(),
+    selectedDate: TODAY,
+    handleDateChange: fn(),
+    today: TODAY,
+    timeSlots: [],
+    selectedSlot: null,
+    onSlotSelect: fn(),
+    formState: {
+      loadingTimeSlots: false,
+      loadingSlotScopedOptions: false,
+      serviceSelected: false,
+      submitted: false,
+      loading: false,
+    },
+    noSlotsMessage: 'Select a speciality and service first',
+    prefillTimeLabel: null,
+    durationDisplay: null,
+    visitType: 'Outpatient',
+    handleVisitTypeSelect: fn(),
+    LeadOptions: LEAD_OPTIONS,
+    formData: FORM_DATA,
+    formDataErrors: {},
+    handleLeadSelectWithReset: fn(),
+    supportOptions: SUPPORT_OPTIONS,
+    handleSupportStaffChange: fn(),
+    SpecialitiesOptions: SPECIALITY_OPTIONS,
+    handleSpecialitySelect: fn(),
+    ServicesOptions: SERVICE_OPTIONS,
+    handleServiceSelect: fn(),
+    setFormData: fn(),
+    ServiceInfoData: { cost: 82, maxDiscount: 12 },
+    showError: noFieldErrors,
+    handleSubmit: fn(),
+    onCancel: fn(),
+  },
+  render: (args) => <FormHarness {...args} />,
+} satisfies Meta<typeof FormHarness>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Resting: Story = {
+  name: 'Empty form',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Left column.
+    await expect(canvas.getByLabelText('Patient')).toHaveValue('');
+    await expect(canvas.getByLabelText('Client')).toHaveValue('');
+    await expect(canvas.getByRole('button', { name: 'Time' })).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
+    await expect(canvas.getByRole('button', { name: 'Type of Visit: Outpatient' })).toBeVisible();
+    await expect(canvas.getByRole('button', { name: 'Lead' })).toBeVisible();
+
+    // Right column, including the estimate derived from the selected service.
+    await expect(canvas.getByRole('button', { name: 'Speciality' })).toBeVisible();
+    await expect(canvas.getByRole('button', { name: 'Services / Packages' })).toBeVisible();
+    await expect(canvas.getByLabelText('Chief Complaint')).toHaveValue('');
+    await expect(canvas.getByText('Cost (USD):')).toBeInTheDocument();
+    /* Cost and Estimate print the SAME number here: `computeEstimate` is
+       `max(0, cost)` and ignores maxDiscount entirely, while the appointment overview
+       modal subtracts it from the same catalogue figures. Two nodes, not one - and the
+       two are formatted differently as well ('$ 82.00' against '$12.00'). */
+    await expect(canvas.getAllByText('$ 82.00')).toHaveLength(2);
+    await expect(canvas.getByText('$12.00')).toBeInTheDocument();
+    await expect(canvas.getByLabelText('Mark appointment as emergency')).not.toBeChecked();
+
+    // Nothing has been submitted, so no error surface exists at all.
+    await expect(canvas.queryAllByRole('alert')).toHaveLength(0);
+    await expect(canvas.getByRole('button', { name: 'Book appointment' })).toBeEnabled();
+    await expect(canvas.getByRole('button', { name: 'Cancel' })).toBeEnabled();
+
+    // The two-column claim, measured rather than asserted from a class name. Two
+    // resolved tracks and exactly two children: the left field stack and the right one.
+    const grid = getFieldGrid(canvasElement);
+    await expect(trackCount(grid)).toBe(2);
+    await expect(grid.children).toHaveLength(2);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The panel as it opens: a two-column grid from md up, single column below. Every ' +
+          'field is in its resting state and the estimate already shows the catalogue price, ' +
+          'because it comes from the selected service rather than from anything typed.',
+      },
+    },
+  },
+};
+
+export const SubmitValidationErrors: Story = {
+  name: 'Submit-time field errors',
+  args: {
+    formState: {
+      loadingTimeSlots: false,
+      loadingSlotScopedOptions: false,
+      serviceSelected: false,
+      submitted: true,
+      loading: false,
+    },
+    formDataErrors: SUBMIT_ERRORS,
+    showError: (field: string) => SUBMIT_ERRORS[field],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* Only two of the six errors are announced. `FieldError` carries role="alert" and
+       is used by the patient picker and the time dropdown; the LabelDropdown and
+       FormDesc errors are plain rows. Asserting the exact contents of the alert set is
+       the point - a change that dropped the role would still leave all six visible. */
+    const alerts = canvas.getAllByRole('alert').map((node) => node.textContent?.trim());
+    await expect(alerts).toContain('Select a patient');
+    await expect(alerts).toContain('Select a time slot');
+    await expect(alerts).toHaveLength(2);
+
+    // The other four are on screen, just not announced.
+    await expect(canvas.getByText('Select a lead')).toBeInTheDocument();
+    await expect(canvas.getByText('Select a speciality')).toBeInTheDocument();
+    await expect(canvas.getByText('Select a service')).toBeInTheDocument();
+    await expect(canvas.getByText('Describe the reason for the visit')).toBeInTheDocument();
+
+    // The error state is a border swap on the control itself as well as a message.
+    await waitFor(() => {
+      const patient = canvas.getByLabelText('Patient').closest('div') as HTMLElement;
+      const client = canvas.getByLabelText('Client').closest('div') as HTMLElement;
+      expect(getComputedStyle(patient).borderColor).not.toBe(getComputedStyle(client).borderColor);
+    });
+
+    // No booking-level banner: that one is a separate failure mode.
+    await expect(canvas.queryByText(/could not be booked/i)).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'What Book produces on an empty form. Six messages at once, in four different ' +
+          'renderings - two alerts, two dropdown rows, one textarea row - which is the ' +
+          'inconsistency this story exists to make visible.',
+      },
+    },
+  },
+};
+
+export const BookingWarningBanner: Story = {
+  name: 'Booking-level warning banner',
+  args: {
+    formState: {
+      loadingTimeSlots: false,
+      loadingSlotScopedOptions: false,
+      serviceSelected: true,
+      submitted: true,
+      loading: false,
+    },
+    formDataErrors: {
+      booking: 'This slot could not be booked. The lead was taken while you were filling this in.',
+    },
+    selectedPatientName: 'Poppy · Hartmann',
+    selectedClientName: 'Lena Hartmann',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const banner = await canvas.findByText(
+      'This slot could not be booked. The lead was taken while you were filling this in.'
+    );
+    await expect(banner).toBeInTheDocument();
+
+    // It sits BELOW the whole field grid, not beside a field - it is a booking
+    // failure, not a field failure, and nothing above it is marked.
+    await expect(canvas.queryAllByRole('alert')).toHaveLength(0);
+    const bannerBox = banner.closest('div.rounded-2xl') as HTMLElement;
+    await waitFor(() => {
+      expect(getComputedStyle(bannerBox).borderStyle).toBe('solid');
+      expect(getComputedStyle(bannerBox).borderTopWidth).not.toBe('0px');
+    });
+
+    // The form is still filled in and still submittable - the banner is not a block.
+    await expect(canvas.getByLabelText('Patient')).toHaveValue('Poppy · Hartmann');
+    await expect(canvas.getByRole('button', { name: 'Book appointment' })).toBeEnabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Gated on `formState.submitted && formDataErrors.booking`, so it only ever appears ' +
+          'after a rejected booking - unreachable without a server that says no. It is the one ' +
+          'error on this form that is not attached to a field, and the only one that survives ' +
+          'a fully valid form.',
+      },
+    },
+  },
+};
+
+export const CompanionSearchResults: Story = {
+  name: 'Companion search - results list',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('Patient');
+
+    await userEvent.click(input);
+    await userEvent.type(input, 'hartmann');
+
+    // The list is portalled to document.body, so it is NOT inside canvasElement.
+    const panel = await findPortalPanel();
+    const options = within(panel).getAllByRole('button');
+
+    /* Two rows for two matches - and each row's `textContent` is TWO strings, not
+       one. `AppointmentAvatar` renders the initials as real text in the same
+       button, ahead of the label, so the row reads 'PH' + 'Poppy · Hartmann'
+       concatenated. That is not a duplicate row and not the preview decorator's
+       sr-only story-title banner leaking in; it is one button with an avatar in
+       it. Pinned whole rather than sliced, so the initials stay in the diff. */
+    await expect(options.map((option) => option.textContent?.trim())).toEqual([
+      'PHPoppy · Hartmann',
+      'PHPepper · Hartmann',
+    ]);
+
+    /* And the avatar does NOT tell the two apart: `getInitials` takes the first
+       and last whitespace-separated token, the label ends in the owner's surname,
+       so every companion belonging to one owner gets the same two letters. Both
+       rows read 'PH'. The name is the only distinguishing mark on this list -
+       worth knowing before leaning on the avatar in a denser layout. */
+    await expect(options.map((option) => within(option).getByText('PH').textContent)).toEqual([
+      'PH',
+      'PH',
+    ]);
+    await expect(within(options[0]).getByText('Poppy · Hartmann')).toBeInTheDocument();
+    await expect(within(options[1]).getByText('Pepper · Hartmann')).toBeInTheDocument();
+
+    /* The initials block is `aria-hidden`, so a screen reader hears only the name
+       and the concatenation above is a sighted-DOM fact, not an announced one. */
+    await expect(within(options[0]).getByText('PH').closest('[aria-hidden="true"]')).not.toBeNull();
+
+    // The field is in its open shape: the trigger loses its bottom border and radius so
+    // it reads as one control with the list beneath it.
+    const trigger = input.parentElement as HTMLElement;
+    await expect(getComputedStyle(trigger).borderBottomWidth).toBe('0px');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Typing filters the loaded companions client-side on a plain substring match. The ' +
+          'panel is positioned from the trigger rect in a layout effect, so it is applied ' +
+          'before paint and lands flush under the field however the modal is scrolled.\n\n' +
+          'Both rows here belong to the same owner, which is the case worth looking at: the ' +
+          'initials avatar is derived from the first and last word of the label, and the label ' +
+          'ends in the owner surname, so Poppy and Pepper get the same "PH" disc. The avatar ' +
+          "reads as an identifier and is not one. A row's text content is the initials and the " +
+          'name run together for the same reason, so query the label span, never the button.',
+      },
+    },
+  },
+};
+
+export const CompanionSearchNoMatches: Story = {
+  name: 'Companion search - no matches',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('Patient');
+
+    await userEvent.click(input);
+    await userEvent.type(input, 'qqq');
+
+    const panel = await findPortalPanel();
+    // Wording is deliberately different from the empty-list case: "No matches found"
+    // means the query excluded everything, "No options available" means nothing loaded.
+    await expect(within(panel).getByText('No matches found')).toBeInTheDocument();
+    await expect(within(panel).queryAllByRole('button')).toHaveLength(0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same portal with an empty result. It is the state that follows a typo in a ' +
+          'companion name, and the point of the story is that the two empty wordings are not ' +
+          'interchangeable.',
+      },
+    },
+  },
+};
+
+export const TimeSlotLoading: Story = {
+  name: 'Time slots - loading row',
+  args: {
+    formState: {
+      loadingTimeSlots: true,
+      loadingSlotScopedOptions: false,
+      serviceSelected: true,
+      submitted: false,
+      loading: false,
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'Time' });
+
+    // The trigger itself already says Loading..., before the list is even opened.
+    await expect(within(trigger).getByText('Loading...')).toBeInTheDocument();
+
+    await userEvent.click(trigger);
+    const panel = await findPortalPanel();
+    await expect(within(panel).getByText('Loading slots…')).toBeInTheDocument();
+    // The spinner row replaces the whole menu, so there is nothing to pick meanwhile.
+    await expect(within(panel).queryAllByRole('button')).toHaveLength(0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'While availability is in flight. Two different spinners are on screen at once - a ' +
+          'small inline one in the trigger and the row inside the panel - and they are separate ' +
+          'components, so they can drift apart.',
+      },
+    },
+  },
+};
+
+export const TimeSlotOptions: Story = {
+  name: 'Time slots - available slots',
+  args: {
+    timeSlots: TIME_SLOTS,
+    selectedSlot: TIME_SLOTS[1],
+    formState: {
+      loadingTimeSlots: false,
+      loadingSlotScopedOptions: false,
+      serviceSelected: true,
+      submitted: false,
+      loading: false,
+    },
+    durationDisplay: '30 mins',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Slot labels are rendered in the preferred time zone (Europe/Berlin by default),
+    // not the machine's, so 09:00 UTC reads as 10:00 AM everywhere this runs. The
+    // separator between time and meridiem varies by ICU build, hence the \s? here.
+    const trigger = canvas.getByRole('button', { name: /^Time, / });
+    await userEvent.click(trigger);
+
+    const panel = await findPortalPanel();
+    const options = within(panel).getAllByRole('button');
+    await expect(options).toHaveLength(3);
+    await expect(options[0].textContent?.trim()).toMatch(/^10:00\s?AM$/);
+    await expect(options[1].textContent?.trim()).toMatch(/^10:30\s?AM$/);
+    await expect(options[2].textContent?.trim()).toMatch(/^11:00\s?AM$/);
+
+    // The selected row is the only one on the blue wash - poll, because these rows
+    // carry `transition-colors` and one synchronous read can catch a midpoint value.
+    await waitFor(() => {
+      expect(getComputedStyle(options[1]).backgroundColor).not.toBe(
+        getComputedStyle(options[0]).backgroundColor
+      );
+    });
+
+    // Slot duration is a sibling field, filled from the chosen slot rather than typed.
+    await expect(canvas.getByText('30 mins')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The populated menu. Times come from the API as UTC clock strings and are rendered ' +
+          "through the org's preferred time zone, so what a user reads here is not what the " +
+          'payload contains - the reason a slot list is worth drawing rather than trusting.',
+      },
+    },
+  },
+};
+
+export const TimeSlotBlocked: Story = {
+  name: 'Time slots - upstream field missing',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Time' }));
+
+    const panel = await findPortalPanel();
+    // Not an error and not an empty list: the menu explains which field is blocking it.
+    await expect(
+      within(panel).getByText('Select a speciality and service first')
+    ).toBeInTheDocument();
+    await expect(within(panel).queryAllByRole('button')).toHaveLength(0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Opening Time before a service is chosen. The sentence is computed upstream by ' +
+          '`getNoSlotsMessage`, which has three wordings for three stages of the form, and this ' +
+          'menu is the only place any of them are shown.',
+      },
+    },
+  },
+};
+
+export const RestingNarrow: Story = {
+  name: 'Empty form at 375px',
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Same two children, one track: the right column falls under the left rather than
+    // the fields compressing. The default `laptop` global gives two tracks, so this is
+    // the only story that proves the breakpoint is wired at all.
+    const grid = getFieldGrid(canvasElement);
+    await expect(trackCount(grid)).toBe(1);
+    await expect(grid.children).toHaveLength(2);
+
+    // Every field survives the collapse - the grid reflows, it does not drop controls.
+    await expect(canvas.getByLabelText('Patient')).toHaveValue('');
+    await expect(canvas.getByLabelText('Chief Complaint')).toHaveValue('');
+    await expect(canvas.getByRole('button', { name: 'Speciality' })).toBeVisible();
+    await expect(canvas.getByRole('button', { name: 'Book appointment' })).toBeEnabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The stacked form. `md:grid-cols-2` is the only thing separating this from the ' +
+          'desktop layout, so the order a user reads the fields in changes completely below ' +
+          '768px: Speciality and Service now sit under Lead rather than beside it, which puts ' +
+          'the estimate at the very bottom of a long scroll instead of at eye level.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/AppointmentMerckSearch.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/AppointmentMerckSearch.stories.tsx
@@ -1,0 +1,325 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import type { Appointment } from '@yosemite-crew/types';
+
+import type { OrgIntegration } from '@/app/features/integrations/services/types';
+import { useIntegrationStore } from '@/app/stores/integrationStore';
+import { useOrgStore } from '@/app/stores/orgStore';
+import AppointmentMerckSearch, { MerckReaderOverlay } from './AppointmentMerckSearch';
+
+const ORG_ID = 'org-storybook-merck';
+
+const APPOINTMENT: Appointment = {
+  id: 'appt-merck-1',
+  patient: {
+    id: 'companion-1',
+    name: 'Poppy',
+    species: 'dog',
+    breed: 'Beagle',
+    parent: { id: 'parent-1', name: 'Lena Hartmann' },
+  },
+  organisationId: ORG_ID,
+  appointmentDate: new Date('2026-03-12T09:30:00.000Z'),
+  startTime: new Date('2026-03-12T09:30:00.000Z'),
+  endTime: new Date('2026-03-12T10:00:00.000Z'),
+  timeSlot: '10:30 - 11:00',
+  durationMinutes: 30,
+  status: 'IN_PROGRESS',
+};
+
+const integration = (status: OrgIntegration['status']): OrgIntegration => ({
+  id: 'int-merck-1',
+  organisationId: ORG_ID,
+  provider: 'MERCK_MANUALS',
+  status,
+  source: 'backend',
+});
+
+/**
+ * Seeds the org and integration stores.
+ *
+ * `getStatus` on the Merck gateway is pure - it resolves the integration out of the
+ * array it is handed, with no request - so seeding `integrationStore` is the entire
+ * setup for the enabled panel. It still resolves through a promise, so the first
+ * paint is the disabled panel and every query below has to be a `findBy*`.
+ */
+const seed = (status: OrgIntegration['status'] = 'enabled') => {
+  return () => {
+    const orgSnapshot = useOrgStore.getState();
+    const integrationSnapshot = useIntegrationStore.getState();
+
+    useOrgStore.setState({ primaryOrgId: ORG_ID, status: 'loaded' });
+    useIntegrationStore.setState({
+      integrationsById: { 'int-merck-1': integration(status) },
+      integrationIdsByOrgId: { [ORG_ID]: ['int-merck-1'] },
+      status: 'loaded',
+    });
+
+    return () => {
+      useOrgStore.setState(orgSnapshot);
+      useIntegrationStore.setState(integrationSnapshot);
+    };
+  };
+};
+
+const meta = {
+  title: 'Appointments/AppointmentMerckSearch',
+  component: AppointmentMerckSearch,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The in-visit MSD Veterinary Manual lookup, one of the sub-tabs of the appointment ' +
+          'Medical Records pane. Nothing in it had a story, including the two states a ' +
+          'clinician meets first: the panel an organisation without the integration sees, and ' +
+          'the **Refine Results** panel behind the options button.\n\n' +
+          'The refine panel is easy to miss because the button that opens it is icon-only - ' +
+          'its only label is `aria-label="Show filters"` - and it toggles a language filter that ' +
+          'silently changes what a later search returns. The EN/ES pills are the only place in ' +
+          'this surface where an active filter is drawn, and the active look is a token swap ' +
+          '(`bg-blue-light` + `border-text-brand`) rather than a shape change, so a regression ' +
+          'there is invisible without a story that opens the panel and reads the pill.\n\n' +
+          'The reader overlay is exercised separately, from its own export, because in the app ' +
+          'it is only ever mounted after a search returns an entry.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    activeAppointment: APPOINTMENT,
+  },
+  decorators: [
+    (Story) => (
+      <div className="h-[720px] w-full max-w-[560px] bg-[var(--screen)] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+  beforeEach: seed(),
+} satisfies Meta<typeof AppointmentMerckSearch>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Resting: Story = {
+  name: 'Enabled, before a search',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // findBy, not getBy: `isEnabled` is settled by an async effect, so the very
+    // first paint is still the disabled card.
+    expect(await canvas.findByText('MSD Manual')).toBeInTheDocument();
+    await expect(canvas.getByLabelText('Search manuals')).toHaveValue('');
+
+    // Search is disabled until there is a query - the audience toggle is not.
+    await expect(canvas.getByRole('button', { name: 'Search' })).toBeDisabled();
+    await expect(canvas.getByRole('button', { name: 'Professional' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    await expect(canvas.getByRole('button', { name: 'Consumer' })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+
+    // The refine panel is closed, and the button that opens it says so.
+    await expect(canvas.getByRole('button', { name: 'Show filters' })).toBeInTheDocument();
+    await expect(canvas.queryByText('Refine Results')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The panel a clinician opens mid-consult: header, audience segment, the search field ' +
+          'and the copyright line pinned to the bottom by `mt-auto`. The Merck notice is ' +
+          'rendered twice in the tree - once under the results, once at the foot - and only one ' +
+          'is ever mounted, which is why it does not double up here.',
+      },
+    },
+  },
+};
+
+export const RefinePanelOpen: Story = {
+  name: 'Refine Results panel open',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const toggle = await canvas.findByRole('button', { name: 'Show filters' });
+    await userEvent.click(toggle);
+
+    // Assert the panel drew its contents, not just that a flag flipped.
+    expect(await canvas.findByText('Refine Results')).toBeInTheDocument();
+    await expect(canvas.getByText('Language')).toBeInTheDocument();
+    const english = canvas.getByRole('button', { name: 'EN' });
+    const spanish = canvas.getByRole('button', { name: 'ES' });
+    await expect(canvas.getByRole('button', { name: 'Close refine results' })).toBeVisible();
+
+    // EN is selected. The active pill differs from the inactive one by fill and
+    // border only, so read both and compare - poll inside waitFor, since these pills
+    // carry `transition-all` and a single synchronous read can catch a mid-transition
+    // value that matches neither end state.
+    await waitFor(() => {
+      const active = getComputedStyle(english);
+      const inactive = getComputedStyle(spanish);
+      expect(active.backgroundColor).not.toBe(inactive.backgroundColor);
+      expect(active.borderColor).not.toBe(inactive.borderColor);
+    });
+
+    // Switching languages moves the fill to the other pill rather than adding a second one.
+    await userEvent.click(spanish);
+    await waitFor(() => {
+      expect(getComputedStyle(spanish).backgroundColor).not.toBe(
+        getComputedStyle(english).backgroundColor
+      );
+    });
+
+    // The toggle relabels while open, which is the only textual cue it is a toggle.
+    await expect(canvas.getByRole('button', { name: 'Hide filters' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The advanced panel. It is a plain block in the column rather than a popover, so it ' +
+          'pushes the results down rather than covering them - and the language it sets is ' +
+          'part of the result cache key, so flipping EN/ES here changes what an identical query ' +
+          'returns on the next Search.',
+      },
+    },
+  },
+};
+
+export const RefinePanelCloses: Story = {
+  name: 'Refine panel closes from its own X',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(await canvas.findByRole('button', { name: 'Show filters' }));
+    expect(await canvas.findByText('Refine Results')).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Close refine results' }));
+    await waitFor(() => {
+      expect(canvas.queryByText('Refine Results')).not.toBeInTheDocument();
+    });
+    // Two controls close the same panel; only one of them is inside it.
+    await expect(canvas.getByRole('button', { name: 'Show filters' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The X inside the panel and the options button outside it both close it. The ' +
+          'language stays whatever it was set to - closing the panel does not reset the filter, ' +
+          'which is worth knowing because the closed panel gives no sign that ES is still ' +
+          'selected.',
+      },
+    },
+  },
+};
+
+export const IntegrationDisabled: Story = {
+  name: 'Integration disabled for the organisation',
+  beforeEach: seed('disabled'),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByText('MSD Veterinary Manual is disabled for this organization.')
+    ).toBeInTheDocument();
+    // The whole panel is replaced, not disabled: no field, no Search, no filters.
+    await expect(canvas.queryByLabelText('Search manuals')).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Show filters' })).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'What most organisations see. The tab itself is filtered out of the header when the ' +
+          'integration is off, so this card is only reached by an org that turns it off while ' +
+          'the panel is open - and it is also the state the enabled panel renders for one frame ' +
+          'before `getStatus` resolves.',
+      },
+    },
+  },
+};
+
+/**
+ * In the app the reader is `createPortal`ed to `document.body` and only mounted once a
+ * search has returned an entry, so these two stories render it directly. `render`
+ * ignores the meta args on purpose - the overlay is fully prop-driven.
+ */
+export const ReaderLoading: Story = {
+  name: 'Reader overlay - loading',
+  render: () => (
+    <MerckReaderOverlay
+      url="about:blank"
+      title="Canine Parvovirus"
+      loading
+      blocked={false}
+      onClose={fn()}
+      onLoad={fn()}
+      onError={fn()}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    // Rendered directly rather than portalled, so the overlay is inside the canvas.
+    const overlay = within(canvasElement);
+    await expect(overlay.getByLabelText('Loading Manual')).toBeInTheDocument();
+    await expect(overlay.getByText('Fetching “Canine Parvovirus” from MSD…')).toBeInTheDocument();
+    // The iframe is mounted underneath the spinner, not swapped in after it - that is
+    // what lets `onLoad` ever fire.
+    const frame = canvasElement.querySelector('iframe[title="Canine Parvovirus"]');
+    await expect(frame).toBeInTheDocument();
+    await expect(frame).toHaveAttribute(
+      'sandbox',
+      'allow-scripts allow-popups allow-forms allow-same-origin'
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The state between opening a manual and MSD answering. `about:blank` stands in for ' +
+          'the real URL so the story loads nothing over the network; the spinner layer is ' +
+          '`absolute inset-0 z-10` over the live iframe, which is why the frame is asserted ' +
+          'here as well as the loader. The `allow-same-origin` in the sandbox list is ' +
+          'load-bearing - MSD reads `document.cookie` on boot and hangs on its own loader in an ' +
+          'opaque origin.',
+      },
+    },
+  },
+};
+
+export const ReaderBlocked: Story = {
+  name: 'Reader overlay - blocked fallback',
+  render: () => (
+    <MerckReaderOverlay
+      url="https://www.msdvetmanual.com/dog-owners"
+      title="Canine Parvovirus"
+      loading={false}
+      blocked
+      onClose={fn()}
+      onLoad={fn()}
+      onError={fn()}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const overlay = within(canvasElement);
+    await expect(overlay.getByText('This manual didn’t load')).toBeInTheDocument();
+    await expect(
+      overlay.getByText('MSD took too long to respond. Open it in a new tab instead.')
+    ).toBeInTheDocument();
+    await expect(overlay.getByRole('button', { name: 'Open in new tab' })).toBeEnabled();
+    // The spinner is gone, not stacked behind the fallback.
+    await expect(overlay.queryByLabelText('Loading Manual')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Reached only after a 12-second timer with no `onLoad` and no `onError` - a stalled ' +
+          'MSD page fires neither - so it is unreachable in any normal session and had never ' +
+          'been drawn. It replaces the spinner with the one path that still works, opening the ' +
+          'manual in a real tab.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/AppointmentMerckSearch.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/AppointmentMerckSearch.tsx
@@ -252,8 +252,14 @@ const MerckRefinePanel = ({
   </div>
 );
 
-/** Full-screen in-app reader for a single manual page; the iframe stays sandboxed. */
-const MerckReaderOverlay = ({
+/**
+ * Full-screen in-app reader for a single manual page; the iframe stays sandboxed.
+ *
+ * Exported so it can be rendered on its own. It is portalled and only ever mounted
+ * after a live search returns an entry, so nothing else can reach its spinner or its
+ * blocked fallback without a running MSD gateway.
+ */
+export const MerckReaderOverlay = ({
   url,
   title,
   loading,

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/Finance/InvoicePaymentActions.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/Finance/InvoicePaymentActions.stories.tsx
@@ -1,0 +1,301 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import type { Appointment, UserOrganization } from '@yosemite-crew/types';
+
+import { useOrgStore } from '@/app/stores/orgStore';
+import InvoicePaymentActions from './InvoicePaymentActions';
+
+const ORG_ID = 'org-storybook-finance';
+
+const APPOINTMENT: Appointment = {
+  id: 'appt-finance-1',
+  patient: {
+    id: 'companion-1',
+    name: 'Poppy',
+    species: 'dog',
+    breed: 'Beagle',
+    parent: { id: 'parent-1', name: 'Lena Hartmann' },
+  },
+  organisationId: ORG_ID,
+  appointmentDate: new Date('2026-03-12T09:30:00.000Z'),
+  startTime: new Date('2026-03-12T09:30:00.000Z'),
+  endTime: new Date('2026-03-12T10:00:00.000Z'),
+  timeSlot: '10:30 - 11:00',
+  durationMinutes: 30,
+  status: 'IN_PROGRESS',
+  paymentStatus: 'UNPAID',
+};
+
+/**
+ * A vet membership. `usePermissions` recomputes the effective set from `roleCode`
+ * against the role table rather than trusting the stored snapshot, so seeding the
+ * role is the whole setup - and revoking one permission is how the denied story
+ * is built, since every seeded role carries `billing:edit:any` by default.
+ */
+const membership = (revoked: string[] = []): UserOrganization => ({
+  practitionerReference: 'Practitioner/user-storybook',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'VETERINARIAN',
+  roleDisplay: 'Veterinarian',
+  active: true,
+  revokedPermissions: revoked,
+});
+
+const seed = (revoked: string[] = []) => {
+  return () => {
+    const snapshot = useOrgStore.getState();
+    useOrgStore.setState({
+      primaryOrgId: ORG_ID,
+      membershipsByOrgId: { [ORG_ID]: membership(revoked) },
+      status: 'loaded',
+    });
+    return () => {
+      useOrgStore.setState(snapshot);
+    };
+  };
+};
+
+const CASH_HEADLINE = 'Confirm cash payment before marking this invoice as paid.';
+const CASH_BODY =
+  'Payment collection method has been set to in-person cash. Click Collect cash only after ' +
+  'cash has been received from the client.';
+
+const meta = {
+  title: 'Appointments/InvoicePaymentActions',
+  component: InvoicePaymentActions,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The action row under an invoice in the appointment Finance tab. What it draws is ' +
+          'four different things, and only the plain link row had ever been rendered.\n\n' +
+          'The one worth a story is the **amber cash-confirmation card**. It is the single ' +
+          'guard between a receptionist and an invoice marked PAID with no money in the till, ' +
+          'and it is deliberately not a dialog - it replaces the action row in place, on ' +
+          '`--warning-100` inside a `--warning-200` hairline, with a dismiss X that puts the ' +
+          'row back. It is reachable two ways: an invoice whose collection method already reads ' +
+          '`PAYMENT_AT_CLINIC` opens on it, and pressing **Pay in cash** flips into it locally. ' +
+          'Both are covered below.\n\n' +
+          'The `!canEditBilling` branch is also here. It returns `null` rather than disabling ' +
+          'the controls, because the mutations behind them require `billing:edit:any` on the ' +
+          'backend and a `billing:edit:limited` user would only ever collect a 403 - so the ' +
+          'component with no permission is an empty region, which is exactly the kind of ' +
+          '"nothing rendered" that no static snapshot can tell apart from a crash.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    invoiceId: 'inv-2041',
+    invoiceStatus: 'ISSUED',
+    activeAppointment: APPOINTMENT,
+  },
+  beforeEach: seed(),
+} satisfies Meta<typeof InvoicePaymentActions>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const PaymentLinkRow: Story = {
+  name: 'Unpaid invoice - action row',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The exact control set, in render order. Asserting the whole row rather than two
+    // named buttons is the point: a third action appearing here (a Refund pill, say)
+    // would slip past a pair of getByRole calls without changing either of them.
+    await expect(canvas.getAllByRole('button').map((button) => button.textContent?.trim())).toEqual(
+      ['Pay in cash', 'Generate & Mail link']
+    );
+    await expect(canvas.getByRole('button', { name: 'Pay in cash' })).toBeEnabled();
+    await expect(canvas.getByRole('button', { name: 'Generate & Mail link' })).toBeEnabled();
+    // Nothing amber yet: the confirmation card and the row are mutually exclusive.
+    await expect(canvas.queryByText(CASH_HEADLINE)).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting state for an unsettled invoice with no Stripe receipt: two secondary ' +
+          'pills, wrapped and centre-aligned so they re-flow rather than overflowing the ' +
+          'narrow Finance column.',
+      },
+    },
+  },
+};
+
+export const CashConfirmationFromInvoice: Story = {
+  name: 'Cash confirmation (collection method already cash)',
+  args: { paymentCollectionMethod: 'PAYMENT_AT_CLINIC' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Assert the card's actual copy, not merely that something appeared - the whole
+    // point of this surface is the sentence it puts in front of the person clicking.
+    await expect(canvas.getByText(CASH_HEADLINE)).toBeInTheDocument();
+    await expect(canvas.getByText(CASH_BODY)).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Collect cash' })).toBeEnabled();
+    await expect(canvas.getByRole('button', { name: 'Dismiss cash confirmation' })).toBeVisible();
+
+    // The link actions are gone, not merely hidden behind the card.
+    await expect(canvas.queryByRole('button', { name: 'Pay in cash' })).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByRole('button', { name: 'Generate & Mail link' })
+    ).not.toBeInTheDocument();
+
+    // The amber ground is the warning, so it has to be a real fill rather than the
+    // panel showing through. Read it in waitFor: the card's controls carry
+    // `transition-colors`, and a single synchronous read can catch an interpolated value.
+    const card = canvas.getByText(CASH_HEADLINE).closest('div.rounded-2xl') as HTMLElement;
+    await waitFor(() => {
+      const background = getComputedStyle(card).backgroundColor;
+      expect(background).not.toBe('rgba(0, 0, 0, 0)');
+      expect(background).not.toBe('transparent');
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'An invoice already flagged for in-person collection opens straight into the ' +
+          'confirmation, before anyone has pressed anything. `isInPersonCashSelected` is ' +
+          'derived from the invoice, not from local state, so this is what the Finance tab ' +
+          'shows on first paint for a cash job.',
+      },
+    },
+  },
+};
+
+export const CashConfirmationFromPayInCash: Story = {
+  name: 'Cash confirmation (opened from Pay in cash)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Pay in cash' }));
+
+    expect(await canvas.findByText(CASH_HEADLINE)).toBeInTheDocument();
+    await expect(canvas.getByText(CASH_BODY)).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Collect cash' })).toBeEnabled();
+    await expect(canvas.queryByRole('button', { name: 'Pay in cash' })).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same card reached from the row. `startCashCollection` sets no server state - it ' +
+          'raises two toasts and flips `showCashConfirmation` - so the invoice is untouched ' +
+          'until Collect cash is pressed, which is why dismissing costs nothing.',
+      },
+    },
+  },
+};
+
+export const DismissRestoresTheRow: Story = {
+  name: 'Dismiss returns to the action row',
+  args: { paymentCollectionMethod: 'PAYMENT_AT_CLINIC' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Dismiss cash confirmation' }));
+
+    // Dismiss clears local state only. The invoice still says PAYMENT_AT_CLINIC, and
+    // `isInPersonCashSelected` ORs the two - so the card comes straight back, and the
+    // X reads as a no-op on this invoice however many times it is pressed.
+    await expect(canvas.getByText(CASH_HEADLINE)).toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Pay in cash' })).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The dismiss X on an invoice whose stored collection method is already cash. It ' +
+          'clears `showCashConfirmation`, but the derived flag ORs local state with the ' +
+          'invoice field, so the card stays. On the Pay-in-cash path the same X does return ' +
+          'the row - the control is the same, its effect is not.',
+      },
+    },
+  },
+};
+
+export const DismissAfterPayInCash: Story = {
+  name: 'Dismiss after Pay in cash restores the row',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Pay in cash' }));
+    expect(await canvas.findByText(CASH_HEADLINE)).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Dismiss cash confirmation' }));
+    await waitFor(() => {
+      expect(canvas.queryByText(CASH_HEADLINE)).not.toBeInTheDocument();
+    });
+    await expect(canvas.getByRole('button', { name: 'Pay in cash' })).toBeEnabled();
+    await expect(canvas.getByRole('button', { name: 'Generate & Mail link' })).toBeEnabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The reversible half of the pair. Same X, same card, opposite outcome - which is ' +
+          'the argument for having both stories rather than one.',
+      },
+    },
+  },
+};
+
+export const NoBillingEditPermission: Story = {
+  name: 'Without billing:edit:any (renders nothing)',
+  beforeEach: seed(['billing:edit:any']),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.queryAllByRole('button')).toHaveLength(0);
+    await expect(canvas.queryByText(CASH_HEADLINE)).not.toBeInTheDocument();
+
+    /* Absence alone would be worthless here - a component that crashed on mount and a
+       component that returned `null` both leave an empty canvas. So assert the shape of
+       the empty region positively: the preview decorator's <main> wraps an sr-only <h1>
+       and then the story, so a `null` render leaves the heading as the landmark's ONLY
+       child. One child means the component mounted, ran its permission check and
+       contributed nothing; zero or a broken tree would mean something else went wrong. */
+    const landmark = canvasElement.querySelector('main') as HTMLElement;
+    await expect(landmark.children).toHaveLength(1);
+    await expect(landmark.firstElementChild?.tagName).toBe('H1');
+    await expect(landmark.firstElementChild).toHaveClass('sr-only');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A membership with `billing:edit:any` revoked. The component returns `null`, so the ' +
+          'Finance tab shows an invoice with no actions at all rather than disabled ones - ' +
+          'deliberate, because every mutation behind those buttons is refused server-side for ' +
+          'this role.',
+      },
+    },
+  },
+};
+
+export const SettledWithReceipt: Story = {
+  name: 'Paid invoice with a Stripe receipt',
+  args: { invoiceStatus: 'PAID', stripeReceiptUrl: 'https://example.invalid/receipt/inv-2041' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // One pill and nothing else: the receipt branch short-circuits the whole component,
+    // so the assertion is on the complete button set rather than on Download alone.
+    await expect(canvas.getAllByRole('button').map((button) => button.textContent?.trim())).toEqual(
+      ['Download']
+    );
+    await expect(canvas.getByRole('button', { name: 'Download' })).toBeEnabled();
+    // The receipt branch returns before the permission check, so it is the one state
+    // a limited-billing user can still see.
+    await expect(canvas.queryByRole('button', { name: 'Pay in cash' })).not.toBeInTheDocument();
+    await expect(canvas.queryByText(CASH_HEADLINE)).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Once Stripe has issued a receipt the component short-circuits to a single Download ' +
+          'pill - above the permission gate, so this is the only branch that renders without ' +
+          '`billing:edit:any`.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/Info/AppointmentInfo.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/Info/AppointmentInfo.stories.tsx
@@ -1,0 +1,438 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import type { Appointment, OrganisationRoom, Service, Speciality } from '@yosemite-crew/types';
+
+import type { Team } from '@/app/features/organization/types/team';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useOrganisationRoomStore } from '@/app/stores/roomStore';
+import { useServiceStore } from '@/app/stores/serviceStore';
+import { useSpecialityStore } from '@/app/stores/specialityStore';
+import { useTeamStore } from '@/app/stores/teamStore';
+import AppointmentInfo from './AppointmentInfo';
+
+const ORG_ID = 'org-storybook-info';
+const SPECIALITY_ID = 'spec-general';
+const SERVICE_ID = 'svc-annual';
+const ROOM_ID = 'room-consult-2';
+
+const APPOINTMENT: Appointment = {
+  id: 'appt-info-1',
+  patient: {
+    id: 'companion-1',
+    name: 'Poppy',
+    species: 'dog',
+    breed: 'Beagle',
+    parent: { id: 'parent-1', name: 'Lena Hartmann' },
+  },
+  lead: { id: 'vet-1', name: 'Dr. Weber' },
+  supportStaff: [{ id: 'tech-1', name: 'Ana Silva' }],
+  room: { id: ROOM_ID, name: 'Consult 2' },
+  appointmentType: {
+    id: SERVICE_ID,
+    name: 'Annual check-up',
+    speciality: { id: SPECIALITY_ID, name: 'General practice' },
+  },
+  organisationId: ORG_ID,
+  appointmentDate: new Date('2026-03-12T09:30:00.000Z'),
+  startTime: new Date('2026-03-12T09:30:00.000Z'),
+  endTime: new Date('2026-03-12T10:00:00.000Z'),
+  timeSlot: '10:30 - 11:00',
+  durationMinutes: 30,
+  status: 'UPCOMING',
+  concern: 'Limping on the left hind leg since Sunday.',
+};
+
+const ROOMS: OrganisationRoom[] = [
+  {
+    id: ROOM_ID,
+    name: 'Consult 2',
+    organisationId: ORG_ID,
+    code: 'C2',
+    type: 'CONSULTATION',
+  },
+  {
+    id: 'room-consult-3',
+    name: 'Consult 3',
+    organisationId: ORG_ID,
+    code: 'C3',
+    type: 'CONSULTATION',
+  },
+];
+
+const SPECIALITY: Speciality = {
+  _id: SPECIALITY_ID,
+  organisationId: ORG_ID,
+  name: 'General practice',
+  isActive: true,
+};
+
+const SERVICE: Service = {
+  id: SERVICE_ID,
+  organisationId: ORG_ID,
+  name: 'Annual check-up',
+  durationMinutes: 30,
+  cost: 82,
+  specialityId: SPECIALITY_ID,
+  isActive: true,
+};
+
+const TEAM: Team[] = [
+  {
+    _id: 'team-1',
+    practionerId: 'vet-1',
+    organisationId: ORG_ID,
+    name: 'Dr. Weber',
+    role: 'VETERINARIAN',
+    speciality: [],
+    status: 'Available',
+    revokedPermissions: [],
+    effectivePermissions: [],
+    extraPerissions: [],
+  },
+];
+
+/**
+ * Seeds the five stores this section reads and restores them on unmount.
+ *
+ * Two requests still leave the component on mount and neither is stubbed, because
+ * neither can change what is drawn: `useLoadRoomsForPrimaryOrg({ force: true, silent:
+ * true })` only writes the room store on success, and the slot lookup that fires when
+ * edit mode opens `catch`es into `timeSlots: []` - which is the same empty list the
+ * form starts with. That is what makes the edit-mode stories below deterministic
+ * without any MSW wiring, and it is also the honest state: a slot list this form
+ * cannot fetch is exactly what a vet sees when availability is unreachable.
+ */
+const seed = () => {
+  const orgSnapshot = useOrgStore.getState();
+  const roomSnapshot = useOrganisationRoomStore.getState();
+  const teamSnapshot = useTeamStore.getState();
+  const specialitySnapshot = useSpecialityStore.getState();
+  const serviceSnapshot = useServiceStore.getState();
+
+  useOrgStore.setState({
+    primaryOrgId: ORG_ID,
+    orgsById: { [ORG_ID]: { _id: ORG_ID, type: 'HOSPITAL' } as never },
+    status: 'loaded',
+  });
+  useOrganisationRoomStore.setState({
+    roomsById: Object.fromEntries(ROOMS.map((item) => [item.id, item])),
+    roomIdsByOrgId: { [ORG_ID]: ROOMS.map((item) => item.id) },
+    roomUnitsById: {},
+    roomUnitIdsByRoomId: {},
+    status: 'loaded',
+  });
+  useTeamStore.setState({
+    teamsById: { 'team-1': TEAM[0] },
+    teamIdsByOrgId: { [ORG_ID]: ['team-1'] },
+    status: 'loaded',
+  });
+  useSpecialityStore.setState({
+    specialitiesById: { [SPECIALITY_ID]: SPECIALITY },
+    specialityIdsByOrgId: { [ORG_ID]: [SPECIALITY_ID] },
+  });
+  useServiceStore.setState({
+    servicesById: { [SERVICE_ID]: SERVICE },
+    serviceIdsBySpecialityId: { [SPECIALITY_ID]: [SERVICE_ID] },
+  });
+
+  return () => {
+    useOrgStore.setState(orgSnapshot);
+    useOrganisationRoomStore.setState(roomSnapshot);
+    useTeamStore.setState(teamSnapshot);
+    useSpecialityStore.setState(specialitySnapshot);
+    useServiceStore.setState(serviceSnapshot);
+  };
+};
+
+const EDIT_PENCIL = 'Edit Appointments details';
+
+const meta = {
+  title: 'Appointments/AppointmentInfo (Info tab)',
+  component: AppointmentInfo,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The Appointment tab inside the appointment detail modal. Its resting form is a plain ' +
+          'list of label/value rows - and the pencil on the accordion replaces the whole list ' +
+          'with a form, which had never been drawn.\n\n' +
+          'The swap is not one form but two, chosen by status. `allowReschedule` is true only ' +
+          'for REQUESTED and UPCOMING, and it decides whether Speciality, Service and the ' +
+          'entire date/slot/lead block are editable controls or `ReadOnlyEditField` boxes. A ' +
+          'checked-in appointment therefore opens an "edit" form in which most fields cannot be ' +
+          'edited at all, which is the single most surprising thing on this surface and the one ' +
+          'a snapshot of the resting rows can never show. Room and Status are gated ' +
+          'independently again, on `canAssignAppointmentRoom` and on whether the status has any ' +
+          'onward transition.\n\n' +
+          'Validation only exists after Save is pressed: `validateAppointmentForm` short-' +
+          'circuits entirely when the status is not reschedulable, so the same button is a ' +
+          'silent save on one status and a wall of field errors on another.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    activeAppointment: APPOINTMENT,
+    canEditAppointments: true,
+  },
+  decorators: [
+    (Story) => (
+      <div className="max-w-[560px] bg-[var(--screen)] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+  beforeEach: seed,
+} satisfies Meta<typeof AppointmentInfo>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ReadOnlyRows: Story = {
+  name: 'Resting rows',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Nine rows, in the order getAppointmentFields declares them.
+    const labels = [
+      'Reason',
+      'Room',
+      'Speciality',
+      'Service',
+      'Date',
+      'Time',
+      'Status',
+      'Lead',
+      'Staff',
+    ];
+    labels.forEach((label) => {
+      expect(canvas.getByText(label)).toBeInTheDocument();
+    });
+
+    // Values, not just labels. Room is resolved through the seeded room list rather
+    // than read off the appointment, so an unseeded store would render '-' here.
+    await expect(
+      canvas.getByText('Limping on the left hind leg since Sunday.')
+    ).toBeInTheDocument();
+    await expect(canvas.getByText('Consult 2')).toBeInTheDocument();
+    await expect(canvas.getByText('General practice')).toBeInTheDocument();
+    await expect(canvas.getByText('Dr. Weber')).toBeInTheDocument();
+    await expect(canvas.getByText('Ana Silva')).toBeInTheDocument();
+    // Status is the one row rendered as a pill instead of text.
+    await expect(canvas.getByText('Upcoming')).toBeInTheDocument();
+
+    // No form yet.
+    await expect(canvas.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: EDIT_PENCIL })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The tab as it opens. Every row is a `border-t` divider pair, and the Status row is ' +
+          'the only one that is not text - it renders a `StatusPill` toned from the status, ' +
+          'which is why it survives the switch to edit mode looking completely different.',
+      },
+    },
+  },
+};
+
+export const EditModeReschedulable: Story = {
+  name: 'Edit mode - upcoming (fully editable)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: EDIT_PENCIL }));
+
+    // The label/value rows are gone, replaced by controls carrying the same values.
+    await waitFor(() => {
+      expect(canvas.queryByRole('button', { name: EDIT_PENCIL })).not.toBeInTheDocument();
+    });
+
+    // Speciality and Service are live dropdowns; the trigger's accessible name is
+    // "<placeholder>: <selected>", so it doubles as the value assertion.
+    await expect(
+      canvas.getByRole('button', { name: 'Speciality: General practice' })
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('button', { name: 'Service: Annual check-up' })
+    ).toBeInTheDocument();
+
+    // The whole scheduling block appears: date, time, lead, support.
+    await expect(canvas.getByLabelText('Date')).toBeInTheDocument();
+    await expect(canvas.getByLabelText('Time')).toHaveValue('');
+    await expect(canvas.getByRole('button', { name: 'Lead' })).toBeInTheDocument();
+
+    // Room and Status stay editable at this status.
+    await expect(canvas.getByRole('button', { name: 'Room: Consult 2' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Status: Upcoming' })).toBeInTheDocument();
+
+    // The footer only exists in edit mode.
+    await expect(canvas.getByRole('button', { name: 'Save' })).toBeEnabled();
+    await expect(canvas.getByRole('button', { name: 'Cancel' })).toBeEnabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The full form. Time is empty because the availability lookup for this service and ' +
+          'date returns nothing here - the same thing a vet sees when the slot endpoint is ' +
+          'unreachable - and the form is honest about it rather than pre-filling the booked ' +
+          'time, which is why Save then refuses.',
+      },
+    },
+  },
+};
+
+export const EditValidation: Story = {
+  name: 'Edit mode - Save with no slot',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: EDIT_PENCIL }));
+    const save = await canvas.findByRole('button', { name: 'Save' });
+
+    await userEvent.click(save);
+
+    // The error is attached to the Time field, not to the Slotpicker above it.
+    const slotError = await canvas.findByText('Please select a slot');
+    await expect(slotError).toBeInTheDocument();
+    await expect(canvas.getByLabelText('Time')).toHaveAttribute('aria-invalid', 'true');
+
+    // Save does not leave edit mode when it refuses, so the form is still open with
+    // its values intact - an early return, not a partial save.
+    await expect(canvas.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('button', { name: 'Speciality: General practice' })
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The only path to inline validation on this form. `validateAppointmentForm` runs on ' +
+          'Save alone, so the first sign anything is missing is this line under Time - and the ' +
+          'lead error it can also produce is mutually exclusive with it, since a missing slot ' +
+          'returns before the lead is ever checked.',
+      },
+    },
+  },
+};
+
+export const EditModeNotReschedulable: Story = {
+  name: 'Edit mode - checked in (mostly read-only)',
+  args: { activeAppointment: { ...APPOINTMENT, status: 'CHECKED_IN' } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: EDIT_PENCIL }));
+    expect(await canvas.findByRole('button', { name: 'Save' })).toBeEnabled();
+
+    // Speciality, Service, Date, Time, Lead and Staff are all boxes now, not controls.
+    await expect(canvas.queryByRole('button', { name: /^Speciality/ })).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: /^Service/ })).not.toBeInTheDocument();
+    await expect(canvas.queryByLabelText('Time')).not.toBeInTheDocument();
+    await expect(canvas.getByText('General practice')).toBeInTheDocument();
+    await expect(canvas.getByText('Annual check-up')).toBeInTheDocument();
+    await expect(canvas.getByText('Dr. Weber')).toBeInTheDocument();
+
+    // Room and Status remain editable: a checked-in patient still gets moved rooms and
+    // still progresses to In progress.
+    await expect(canvas.getByRole('button', { name: 'Room: Consult 2' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Status: Checked in' })).toBeInTheDocument();
+
+    // The concern textarea is the one field that is editable at every status.
+    await expect(canvas.getByLabelText('Describe concern')).toHaveValue(
+      'Limping on the left hind leg since Sunday.'
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The other edit form. Same pencil, same Save/Cancel footer, but six of the nine ' +
+          'fields have become `ReadOnlyEditField` boxes on `card-hover/40` - a different ' +
+          'component with a different shape from the rows behind it. Reviewers should look at ' +
+          'whether it reads as "locked" rather than as an unstyled input.',
+      },
+    },
+  },
+};
+
+export const CancelRestoresRows: Story = {
+  name: 'Cancel returns to the rows',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: EDIT_PENCIL }));
+    const concern = await canvas.findByLabelText('Describe concern');
+    await userEvent.clear(concern);
+    await userEvent.type(concern, 'Typed but discarded');
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() => {
+      expect(canvas.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+    });
+    // Cancel dispatches a full RESET off the appointment, so the typed value is gone
+    // and the original reason is back - not merely hidden behind the rows.
+    await expect(
+      canvas.getByText('Limping on the left hind leg since Sunday.')
+    ).toBeInTheDocument();
+    await expect(canvas.queryByText('Typed but discarded')).not.toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: EDIT_PENCIL })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The discard path. It is a reducer RESET rather than a flag flip, which is the only ' +
+          'reason a half-typed reason does not survive into the next open.',
+      },
+    },
+  },
+};
+
+export const WithoutEditPermission: Story = {
+  name: 'Without appointment-edit rights',
+  args: { canEditAppointments: false },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // No pencil at all, so the edit form is unreachable rather than disabled.
+    await expect(canvas.queryByRole('button', { name: EDIT_PENCIL })).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+
+    /* The full nine rows still render, with their values. The read-only case differs
+       from the editable one by exactly one control, so listing the rows is what proves
+       the section is intact rather than collapsed - a permission check that bailed out
+       early would also remove the pencil. */
+    const labels = [
+      'Reason',
+      'Room',
+      'Speciality',
+      'Service',
+      'Date',
+      'Time',
+      'Status',
+      'Lead',
+      'Staff',
+    ];
+    labels.forEach((label) => {
+      expect(canvas.getByText(label)).toBeInTheDocument();
+    });
+    await expect(
+      canvas.getByText('Limping on the left hind leg since Sunday.')
+    ).toBeInTheDocument();
+    await expect(canvas.getByText('Consult 2')).toBeInTheDocument();
+    await expect(canvas.getByText('General practice')).toBeInTheDocument();
+    await expect(canvas.getByText('Dr. Weber')).toBeInTheDocument();
+    await expect(canvas.getByText('Upcoming')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Read-only for a role without appointment edit. The accordion keeps its title and ' +
+          'its chevron and loses only the pencil, which is worth a look: nothing else on the ' +
+          'row signals that the section is locked.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/Prescription/PrescriptionFormSection.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/Prescription/PrescriptionFormSection.stories.tsx
@@ -1,0 +1,422 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import type { Appointment, UserOrganization } from '@yosemite-crew/types';
+import { createEmptyFormData } from '@/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/appointmentInfoTypes';
+import type { FormsProps } from '@/app/features/forms/types/forms';
+import { useFormsStore } from '@/app/stores/formsStore';
+import { useOrgStore } from '@/app/stores/orgStore';
+
+import PrescriptionFormSection from './PrescriptionFormSection';
+
+const ORG_ID = 'org-storybook';
+const VET_FORM_ID = 'form-soap-assessment';
+const CLIENT_FORM_ID = 'form-sedation-consent';
+
+/** The Assessment caller's strings, so the story reads as the screen it ships in. */
+const SECTION = {
+  title: 'Assessment (diagnosis)',
+  submissionsTitle: 'Previous assessment submissions',
+  searchPlaceholder: 'Search',
+};
+
+/**
+ * A veterinarian membership. `usePermissions` derives the effective set from
+ * `roleCode` against the role table, so seeding the role is enough - there is no
+ * permission list to keep in step. Without it the whole section renders as the
+ * `Fallback` notice and every assertion below fails on an empty canvas.
+ */
+const VETERINARIAN: UserOrganization = {
+  practitionerReference: 'Practitioner/user-storybook',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'VETERINARIAN',
+  roleDisplay: 'Veterinarian',
+  active: true,
+};
+
+const VET_FORM: FormsProps = {
+  _id: VET_FORM_ID,
+  orgId: ORG_ID,
+  name: 'SOAP assessment',
+  category: 'SOAP',
+  usage: 'Internal',
+  requiredSigner: 'VET',
+  updatedBy: 'Dr. Weber',
+  lastUpdated: '2026-05-04T09:00:00.000Z',
+  status: 'Published',
+  schema: [
+    { id: 'presenting_complaint', type: 'input', label: 'Presenting complaint' },
+    {
+      id: 'vitals_group',
+      type: 'group',
+      label: 'Vitals',
+      fields: [
+        { id: 'temperature_c', type: 'input', label: 'Temperature (C)' },
+        { id: 'weight_kg', type: 'input', label: 'Weight (kg)' },
+      ],
+    },
+  ],
+};
+
+const CLIENT_FORM: FormsProps = {
+  _id: CLIENT_FORM_ID,
+  orgId: ORG_ID,
+  name: 'Sedation consent',
+  category: 'SOAP',
+  usage: 'External',
+  requiredSigner: 'CLIENT',
+  updatedBy: 'Dr. Weber',
+  lastUpdated: '2026-05-02T08:30:00.000Z',
+  status: 'Published',
+  schema: [{ id: 'owner_consent', type: 'textarea', label: 'Consent statement' }],
+};
+
+const APPOINTMENT: Appointment = {
+  id: 'appt-storybook-1',
+  patient: {
+    id: 'companion-1',
+    name: 'Poppy',
+    species: 'dog',
+    breed: 'Beagle',
+    parent: { id: 'parent-1', name: 'Lena Hartmann' },
+  },
+  companion: {
+    id: 'companion-1',
+    name: 'Poppy',
+    species: 'dog',
+    breed: 'Beagle',
+    parent: { id: 'parent-1', name: 'Lena Hartmann' },
+  },
+  lead: { id: 'vet-1', name: 'Dr. Weber' },
+  organisationId: ORG_ID,
+  appointmentDate: new Date('2026-03-12T09:30:00.000Z'),
+  startTime: new Date('2026-03-12T09:30:00.000Z'),
+  endTime: new Date('2026-03-12T10:00:00.000Z'),
+  timeSlot: '09:30 - 10:00',
+  durationMinutes: 30,
+  status: 'IN_PROGRESS',
+};
+
+/**
+ * Only the "Sending" story needs this: the label exists solely while
+ * `linkAppointmentForms` is in flight, which is a few frames against a real API.
+ * Axios uses the XHR adapter in a browser, so holding `send` freezes the request
+ * without touching the service module - the component, the store and the service
+ * are all the real ones, and no request leaves the preview iframe.
+ */
+const REAL_XHR_SEND = XMLHttpRequest.prototype.send;
+
+const stallTransport = () => {
+  XMLHttpRequest.prototype.send = function stalledSend() {
+    return undefined;
+  };
+  // Restored to the module-level original, so a meta-level and a story-level
+  // cleanup cannot strand the stub whichever order they run in.
+  return () => {
+    XMLHttpRequest.prototype.send = REAL_XHR_SEND;
+  };
+};
+
+const seed = (options: { stalled?: boolean } = {}) => {
+  const orgSnapshot = useOrgStore.getState();
+  const formsSnapshot = useFormsStore.getState();
+  const restoreTransport = options.stalled ? stallTransport() : undefined;
+
+  useOrgStore.setState({
+    primaryOrgId: ORG_ID,
+    membershipsByOrgId: { [ORG_ID]: VETERINARIAN },
+    status: 'loaded',
+  });
+  // `useFormsForPrimaryOrgByCategory` filters on orgId AND category, so both
+  // forms have to carry this org and the SOAP category to reach the picker.
+  useFormsStore.setState({
+    formsById: { [VET_FORM_ID]: VET_FORM, [CLIENT_FORM_ID]: CLIENT_FORM },
+    formIds: [VET_FORM_ID, CLIENT_FORM_ID],
+  });
+
+  return () => {
+    restoreTransport?.();
+    useFormsStore.setState(formsSnapshot);
+    useOrgStore.setState(orgSnapshot);
+  };
+};
+
+const setFormData = fn();
+
+/**
+ * PrescriptionFormSection is generic over the SOAP key and takes the whole
+ * `formData` bag plus its dispatch. This pins it to the Assessment caller so the
+ * stories vary only what the surface actually depends on: whether the section is
+ * editable. Everything rendered below is the real component.
+ */
+const AssessmentSection = ({ canEdit }: { canEdit: boolean }) => (
+  <PrescriptionFormSection
+    title={SECTION.title}
+    submissionsTitle={SECTION.submissionsTitle}
+    searchPlaceholder={SECTION.searchPlaceholder}
+    category="SOAP"
+    formDataKey="assessment"
+    formData={createEmptyFormData()}
+    setFormData={setFormData}
+    activeAppointment={APPOINTMENT}
+    canEdit={canEdit}
+  />
+);
+
+const pickForm = async (canvas: ReturnType<typeof within>, name: string) => {
+  await userEvent.click(canvas.getByRole('textbox', { name: SECTION.searchPlaceholder }));
+  await userEvent.click(await canvas.findByRole('button', { name }));
+};
+
+const meta = {
+  title: 'Appointments/PrescriptionFormSection',
+  component: AssessmentSection,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The body of every SOAP section - Subjective, Objective, Assessment, Plan and Discharge ' +
+          'all render this one component with different strings and a different form category. ' +
+          'At rest it is a search box and a collapsed history list, and that resting state is all ' +
+          'a snapshot ever showed: **picking a form is what draws the section**, and nothing had ' +
+          'ever picked one.\n\n' +
+          'Selecting an entry sets the active form, seeds the answer map from the schema defaults ' +
+          'and renders the whole form through `FormRenderer` in `readOnly` mode - the section ' +
+          'shows what will be submitted, it is not where a vet types. Only then does the footer ' +
+          'CTA exist at all.\n\n' +
+          'That CTA is two different actions wearing one button. `requiredSigner: VET` gives ' +
+          '**Save**, which posts a submission straight into the record. `requiredSigner: CLIENT` ' +
+          'gives **Send to parent**, which cannot save anything - a client-signed form has to go ' +
+          'out for signature, so it links the form to the appointment instead and reads ' +
+          '**Sending** while that request is in flight. Same button, same position, opposite ' +
+          'meaning, and the only thing that tells them apart is the label.\n\n' +
+          'The picker runs with `minChars={0}` rather than the SearchDropdown default of 2, so ' +
+          'the full list opens on focus instead of waiting for two characters - these lists are ' +
+          'short and a vet should not have to guess a form name.\n\n' +
+          'The CTA is a sibling of the accordion, not part of it, so it stays pinned under a ' +
+          'section whose body scrolls. The history list nested inside has its own stories under ' +
+          'Appointments/SoapSubmissions.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    canEdit: true,
+  },
+  beforeEach: () => seed(),
+} satisfies Meta<typeof AssessmentSection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const AtRest: Story = {
+  name: 'Nothing picked yet',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // The section itself is open by default; the history under it is not.
+    await expect(canvas.getByRole('button', { name: SECTION.title })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
+    await expect(canvas.getByRole('button', { name: SECTION.submissionsTitle })).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
+
+    // One textbox: the picker. No form is rendered, so no field exists yet.
+    await expect(canvas.getAllByRole('textbox')).toHaveLength(1);
+    await expect(canvas.getByRole('textbox', { name: SECTION.searchPlaceholder })).toHaveValue('');
+    /* Two buttons, both accordion toggles. There is no third: the CTA is not
+       rendered disabled while nothing is picked, it does not exist, and only a
+       count says so. */
+    await expect(
+      canvas.getAllByRole('button').map((item) => item.getAttribute('aria-label'))
+    ).toEqual([SECTION.title, SECTION.submissionsTitle]);
+    await expect(canvas.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Send to parent' })).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'How the section mounts. There is no CTA at all until a form is chosen, which is why ' +
+          'the footer looks empty rather than showing a disabled button.',
+      },
+    },
+  },
+};
+
+export const ReadOnly: Story = {
+  name: 'Read-only (canEdit false)',
+  args: { canEdit: false },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* `canEdit` drops the picker, the rendered form AND the CTA - it is not a
+       disabled state, the controls are absent. The history list stays, so a
+       locked appointment can still be read back. */
+    await expect(
+      canvas.queryByRole('textbox', { name: SECTION.searchPlaceholder })
+    ).not.toBeInTheDocument();
+    await expect(canvas.queryAllByRole('textbox')).toHaveLength(0);
+
+    /* Two controls in the entire section and nothing else: the section toggle
+       and the history toggle. Counting them is what proves the CTA is gone
+       rather than merely renamed - a disabled Save would still be a button
+       here, and three named absences cannot rule that out. */
+    await expect(
+      canvas.getAllByRole('button').map((item) => item.getAttribute('aria-label'))
+    ).toEqual([SECTION.title, SECTION.submissionsTitle]);
+    // The section frame keeps its shape: still open, with the history inside it.
+    await expect(canvas.getByRole('button', { name: SECTION.title })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
+    await expect(canvas.getByRole('button', { name: SECTION.submissionsTitle })).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'What a completed or locked appointment shows. Only the accordion frame and the ' +
+          'submissions history survive, so the section keeps its shape instead of collapsing to a ' +
+          'bare title.',
+      },
+    },
+  },
+};
+
+export const VetFormSelected: Story = {
+  name: 'Form picked: Save',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('textbox', { name: SECTION.searchPlaceholder }));
+    // Both published SOAP forms for this org, listed on focus with an empty query.
+    expect(await canvas.findByRole('button', { name: 'SOAP assessment' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Sedation consent' })).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'SOAP assessment' }));
+
+    // The schema is drawn in full, nested group included.
+    expect(await canvas.findByText('Vitals')).toBeInTheDocument();
+    const complaint = await canvas.findByRole('textbox', { name: 'Presenting complaint' });
+    await expect(complaint).toHaveAttribute('readonly');
+    await expect(canvas.getByRole('textbox', { name: 'Temperature (C)' })).toHaveAttribute(
+      'readonly'
+    );
+    await expect(canvas.getByRole('textbox', { name: 'Weight (kg)' })).toHaveAttribute('readonly');
+    /* Four, not three: the picker stays mounted above the rendered form, so a
+       second form can be chosen without clearing the first. Counting the fields
+       is what catches a group that failed to recurse - two of these three are
+       inside `vitals_group`. */
+    await expect(canvas.getAllByRole('textbox')).toHaveLength(4);
+
+    const save = canvas.getByRole('button', { name: 'Save' });
+    await expect(save).toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Send to parent' })).not.toBeInTheDocument();
+
+    /* The CTA is a sibling of the accordion, not a child of it. That is what keeps
+       it pinned to the bottom of the section while the accordion body scrolls -
+       move it inside and it scrolls away with the form. */
+    const accordion = canvas
+      .getByRole('button', { name: SECTION.title })
+      .closest('div.flex.flex-col.w-full');
+    await expect(accordion).not.toBeNull();
+    await expect(accordion?.contains(save)).toBe(false);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A vet-signed form, rendered read-only under the picker. Every input is `readonly` ' +
+          'rather than `disabled`, so the values stay full-contrast and selectable instead of ' +
+          'greying out - this is a preview of a submission, not a dead form.',
+      },
+    },
+  },
+};
+
+export const ClientFormSelected: Story = {
+  name: 'Form picked: Send to parent',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await pickForm(canvas, 'Sedation consent');
+
+    /* Same button, same place, different action. The vet cannot sign a
+       client-signed form, so Save is not offered in a disabled state - it is
+       replaced. Asserting the CTA's own text, not just that a button with that
+       accessible name exists, because the label IS the whole difference between
+       the two actions. */
+    const cta = await canvas.findByRole('button', { name: 'Send to parent' });
+    await expect(cta).toHaveTextContent('Send to parent');
+    await expect(canvas.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+
+    /* Two textboxes: the picker, which stays mounted, and the consent field.
+       The consent form is a single `textarea`, so a count of two also proves
+       the picker did not clear itself on selection. */
+    await expect(canvas.getAllByRole('textbox')).toHaveLength(2);
+    await expect(canvas.getByRole('textbox', { name: 'Consent statement' }).tagName).toBe(
+      'TEXTAREA'
+    );
+    await expect(canvas.getByText('Consent statement')).toBeInTheDocument();
+
+    // The option list closed on selection rather than staying over the form.
+    await expect(canvas.queryByRole('button', { name: 'SOAP assessment' })).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Picked out of the same list as the story above - the only difference is which ' +
+          '`requiredSigner` the form carries. Nothing else on the surface says which kind of form ' +
+          'this is, which is the argument for drawing both.',
+      },
+    },
+  },
+};
+
+export const SendingToParent: Story = {
+  name: 'Sending to the pet parent',
+  beforeEach: () => seed({ stalled: true }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await pickForm(canvas, 'Sedation consent');
+    await userEvent.click(await canvas.findByRole('button', { name: 'Send to parent' }));
+
+    // Held open by stalling the request, because this label lives only for the
+    // duration of the call.
+    const cta = await canvas.findByRole('button', { name: 'Sending' });
+    await expect(cta).toHaveTextContent('Sending');
+    await expect(canvas.queryByRole('button', { name: 'Send to parent' })).not.toBeInTheDocument();
+
+    /* The claim this story exists to show: the label changes but nothing is
+       locked. `PrescriptionFormSection` never passes `isDisabled`, so the
+       control stays live and a second click re-enters `handleSendToParent`
+       while the first POST is still open. Compare the Assign room dialog, which
+       disables both actions for exactly this window. */
+    await expect(cta).toBeEnabled();
+    await expect(cta).not.toHaveAttribute('aria-disabled', 'true');
+
+    // The form stays rendered underneath, so the vet can still see what went out.
+    await expect(canvas.getByText('Consent statement')).toBeInTheDocument();
+    await expect(canvas.getAllByRole('textbox')).toHaveLength(2);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Worth looking at closely: the button relabels but is never disabled, so a second click ' +
+          'lands on a live control while the first request is still open. Compare with the Assign ' +
+          'room dialog, which disables both of its actions for exactly this window.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/Prescription/Submissions/SoapSubmissions.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/Prescription/Submissions/SoapSubmissions.stories.tsx
@@ -1,0 +1,408 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+
+import {
+  createEmptyFormData,
+  type FormDataProps,
+} from '@/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/appointmentInfoTypes';
+import type { SoapNoteSubmission } from '@/app/features/appointments/types/soap';
+import type { FormsProps } from '@/app/features/forms/types/forms';
+import { useFormsStore } from '@/app/stores/formsStore';
+
+import SoapSubmissions from './SoapSubmissions';
+
+const TITLE = 'Previous assessment submissions';
+const ORG_ID = 'org-storybook';
+const ASSESSMENT_FORM_ID = 'form-soap-assessment';
+const CONSENT_FORM_ID = 'form-sedation-consent';
+
+/**
+ * The forms these submissions were captured against. The submission carries the
+ * answers keyed by field id and nothing else, so it is the STORE copy of the form
+ * that decides whether `presenting_complaint` renders as "Presenting complaint" or
+ * falls back to a humanised key - and whether the card gets a signature block at
+ * all. Seeding the store is therefore not scaffolding, it is half the surface.
+ */
+const ASSESSMENT_FORM: FormsProps = {
+  _id: ASSESSMENT_FORM_ID,
+  orgId: ORG_ID,
+  name: 'SOAP assessment',
+  category: 'SOAP',
+  usage: 'Internal',
+  requiredSigner: 'VET',
+  updatedBy: 'Dr. Weber',
+  lastUpdated: '2026-05-04T09:00:00.000Z',
+  status: 'Published',
+  schema: [
+    { id: 'presenting_complaint', type: 'input', label: 'Presenting complaint' },
+    { id: 'clinical_findings', type: 'textarea', label: 'Clinical findings' },
+    { id: 'vet_signature', type: 'signature', label: 'Veterinarian signature' },
+  ],
+};
+
+const CONSENT_FORM: FormsProps = {
+  _id: CONSENT_FORM_ID,
+  orgId: ORG_ID,
+  name: 'Sedation consent',
+  category: 'Consent form',
+  usage: 'External',
+  requiredSigner: 'CLIENT',
+  updatedBy: 'Dr. Weber',
+  lastUpdated: '2026-05-02T08:30:00.000Z',
+  status: 'Published',
+  schema: [{ id: 'owner_consent', type: 'textarea', label: 'Consent statement' }],
+};
+
+const submission = (over: Partial<SoapNoteSubmission> & { _id: string }): SoapNoteSubmission => ({
+  formId: ASSESSMENT_FORM_ID,
+  formVersion: 1,
+  appointmentId: 'appt-storybook-1',
+  answers: {},
+  submittedAt: new Date('2026-05-04T10:12:00.000Z'),
+  ...over,
+});
+
+/**
+ * Three cards, deliberately not three of the same card: one vet form still waiting
+ * for a signature, the same form already signed, and a client form that the vet can
+ * only watch. Each takes a different branch through the card body.
+ */
+const MIXED: SoapNoteSubmission[] = [
+  submission({
+    _id: 'sub-unsigned',
+    answers: {
+      presenting_complaint: 'Limping on the left hind leg for three days.',
+      clinical_findings: 'Mild swelling over the stifle, pain on extension.',
+      // Deliberately NOT in the schema: the label falls back to humanizeKey, so
+      // an answer whose field was renamed or removed still renders readably
+      // instead of showing a raw key or vanishing.
+      followUpNotes: 'Recheck in ten days.',
+    },
+  }),
+  submission({
+    _id: 'sub-signed',
+    submittedAt: new Date('2026-05-03T15:40:00.000Z'),
+    answers: {
+      presenting_complaint: 'Post-operative check after cruciate repair.',
+      clinical_findings: 'Incision clean and dry, full weight bearing.',
+    },
+    signing: {
+      required: true,
+      provider: 'DOCUMENSO',
+      status: 'SIGNED',
+      pdf: { url: 'https://example.invalid/signed-assessment.pdf' },
+    },
+  }),
+  submission({
+    _id: 'sub-consent-pending',
+    formId: CONSENT_FORM_ID,
+    answers: { owner_consent: 'I consent to sedation for the dental examination.' },
+  }),
+];
+
+const CLIENT_ONLY: SoapNoteSubmission[] = [
+  submission({
+    _id: 'sub-consent-pending',
+    formId: CONSENT_FORM_ID,
+    answers: { owner_consent: 'I consent to sedation for the dental examination.' },
+  }),
+  submission({
+    _id: 'sub-consent-signed',
+    formId: CONSENT_FORM_ID,
+    answers: { owner_consent: 'I consent to the pre-anaesthetic blood panel.' },
+    signing: {
+      required: true,
+      provider: 'DOCUMENSO',
+      status: 'SIGNED',
+      pdf: { url: 'https://example.invalid/signed-consent.pdf' },
+    },
+  }),
+];
+
+/**
+ * `setFormData` is only reached when SignatureActions gets a signed URL back from
+ * the network, which no story does, so a spy is enough and the panel stays a pure
+ * function of its props - no component state to survive a story switch.
+ */
+const setFormData = fn();
+
+/**
+ * SoapSubmissions is generic over the SOAP key and takes the whole `formData`
+ * bag plus its dispatch. This pins the key to `assessment` so the stories can pass
+ * a plain list, and nothing else - the component under review is the real one.
+ */
+const SubmissionsPanel = ({ submissions }: { submissions: SoapNoteSubmission[] }) => {
+  const formData: FormDataProps = { ...createEmptyFormData(), assessment: submissions };
+  return (
+    <SoapSubmissions
+      formData={formData}
+      setFormData={setFormData}
+      formDataKey="assessment"
+      title={TITLE}
+    />
+  );
+};
+
+const seedForms = () => {
+  const snapshot = useFormsStore.getState();
+  useFormsStore.setState({
+    formsById: { [ASSESSMENT_FORM_ID]: ASSESSMENT_FORM, [CONSENT_FORM_ID]: CONSENT_FORM },
+    formIds: [ASSESSMENT_FORM_ID, CONSENT_FORM_ID],
+  });
+  return () => {
+    useFormsStore.setState(snapshot);
+  };
+};
+
+/** Every card in the open body, so a selector change here fails loudly in one place. */
+const cardsIn = (root: HTMLElement) =>
+  Array.from(root.querySelectorAll<HTMLElement>('div.border.rounded-xl.p-4'));
+
+/** The accordion body. Absent, not hidden, while the accordion is closed. */
+const bodyIn = (root: HTMLElement) => root.querySelector<HTMLElement>('div.border-x.border-b');
+
+/**
+ * Resolves a design token to the same `rgb()` string `getComputedStyle` reports
+ * for a painted element, so the colour assertion compares like with like instead
+ * of a hex literal against a computed rgb triple.
+ *
+ * The probe is created and removed HERE, never inside a `waitFor` callback:
+ * testing-library retries through a MutationObserver, so a callback that mutates
+ * the DOM and then throws re-queues itself forever and hangs the tab instead of
+ * failing.
+ */
+const resolveTokenColor = (token: string): string => {
+  const probe = document.createElement('span');
+  probe.style.color = `var(${token})`;
+  document.body.append(probe);
+  const value = getComputedStyle(probe).color;
+  probe.remove();
+  return value;
+};
+
+const meta = {
+  title: 'Appointments/SoapSubmissions',
+  component: SubmissionsPanel,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The history list under each SOAP section: what has already been submitted against this ' +
+          'appointment. It is an `Accordion` with `defaultOpen={false}`, so **everything below is ' +
+          'behind one click** and none of it had ever been drawn - not the cards, not the label ' +
+          'resolution, not the signature block.\n\n' +
+          'A submission stores answers keyed by field id and nothing else. The question text comes ' +
+          'from the form in `formsStore` at render time, and when the key is missing from the ' +
+          'schema (renamed field, deleted field, an answer written by an older version) it falls ' +
+          'back to a humanised key rather than showing `follow_up_notes` or dropping the row. Both ' +
+          'paths are in the open story, side by side in one card.\n\n' +
+          'Which controls a card gets is derived from the FORM, not the submission: ' +
+          '`requiredSigner: VET` plus either a signature field or existing signing data gets the ' +
+          'Sign/View block; `requiredSigner: CLIENT` gets a read-only status line, because the vet ' +
+          'cannot sign for the pet parent. Seeding two forms is what makes that split ' +
+          'visible - with one form the two branches look like one branch.\n\n' +
+          'A card with no string answers, no signature block and no parent line renders nothing at ' +
+          'all, which is why the empty story asserts a card count of zero rather than trusting the ' +
+          '"No submissions yet." sentence: a filter bug would print that same sentence.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    submissions: MIXED,
+  },
+  beforeEach: seedForms,
+} satisfies Meta<typeof SubmissionsPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Collapsed: Story = {
+  name: 'Collapsed (as it mounts)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const toggle = canvas.getByRole('button', { name: TITLE });
+
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    /* The header carries the title as real text, not only as the aria-label the
+       query above matched - those are two different strings in Accordion and a
+       blank span would still satisfy a role query. */
+    await expect(toggle).toHaveTextContent(TITLE);
+
+    /* Collapsed is not "hidden": Accordion renders no children at all while
+       closed, so the body element itself is absent from the DOM rather than
+       display:none. Nothing below the header can be reviewed, or snapshotted,
+       until it opens - which is the whole argument for these stories. */
+    await expect(bodyIn(canvasElement)).toBeNull();
+    await expect(cardsIn(canvasElement)).toHaveLength(0);
+    await expect(canvas.queryByText('Presenting complaint')).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Sign' })).not.toBeInTheDocument();
+    // Exactly one control in the whole collapsed section: the toggle.
+    await expect(canvas.getAllByRole('button')).toHaveLength(1);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'How every SOAP section actually mounts. The header carries the count of nothing - there ' +
+          'is no badge - so the only way to learn whether this appointment has submissions is to ' +
+          'open it.',
+      },
+    },
+  },
+};
+
+export const Expanded: Story = {
+  name: 'Open: three submission cards',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const toggle = canvas.getByRole('button', { name: TITLE });
+
+    await userEvent.click(toggle);
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+    const cards = cardsIn(canvasElement);
+    await expect(cards).toHaveLength(3);
+
+    /* Three answers in, three question/answer rows out. Answers are filtered to
+       string values only, so a numeric or array answer silently drops its row -
+       counting the rows catches that, reading one label does not. The row is the
+       only `gap-1` block in the card; the answers block and the signature block
+       are both `flex flex-col gap-2` and cannot be told apart by class. */
+    const [firstCard] = cards;
+    await expect(firstCard.querySelectorAll('div.flex.flex-col.gap-1')).toHaveLength(3);
+
+    /* Labels are per-CARD, and two of the three cards were captured against the
+       same assessment form, so "Presenting complaint" and "Clinical findings"
+       each render TWICE in this body - once per card. That is the list working:
+       every submission repeats the question text above its own answer, there is
+       no shared header row. So label queries have to be scoped to a card, and an
+       unscoped `getByText` throws "Found multiple elements" rather than telling
+       you which card it found. Pinned as a count first, so the scoping below
+       reads as a consequence of the data rather than as defensive noise. */
+    const openBody = bodyIn(canvasElement) as HTMLElement;
+    await expect(within(openBody).getAllByText('Presenting complaint')).toHaveLength(2);
+    await expect(within(openBody).getAllByText('Clinical findings')).toHaveLength(2);
+
+    // Resolved from the seeded schema, in the first card...
+    const firstCardQueries = within(firstCard);
+    await expect(firstCardQueries.getByText('Presenting complaint')).toBeInTheDocument();
+    await expect(firstCardQueries.getByText('Clinical findings')).toBeInTheDocument();
+    await expect(
+      firstCardQueries.getByText('Limping on the left hind leg for three days.')
+    ).toBeInTheDocument();
+    // ...and this one is not in the schema, so it is humanised rather than raw.
+    // Unique across the body: only the first submission carries the stray key.
+    await expect(canvas.getByText('Follow Up Notes')).toBeInTheDocument();
+
+    // The vet form gets exactly one Sign (unsigned card) and one View (signed card).
+    await expect(canvas.getByRole('button', { name: 'Sign' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'View' })).toBeInTheDocument();
+
+    // The client form gets neither - only a status line.
+    await expect(
+      canvas.getByText('Sent to pet parent. It will update when they sign the document.')
+    ).toBeInTheDocument();
+
+    /* Signed is the only status painted in --success-text; everything else uses
+       --ink-muted via text-text-secondary. Asserting the resolved token value
+       rather than "the two differ" is what catches the failure mode this repo
+       keeps hitting: an arbitrary-value utility whose token does not resolve
+       emits no colour at all, so the label silently inherits body ink and still
+       looks like a deliberate choice. Read inside waitFor - these rows sit under
+       `transition-colors`, and a single synchronous read can catch an
+       interpolated value mid-transition. */
+    const successInk = resolveTokenColor('--success-text');
+    const required = canvas.getByText('Signature required');
+    const signed = canvas.getByText('Signed');
+    await waitFor(() => {
+      expect(getComputedStyle(signed).color).toBe(successInk);
+    });
+    await expect(getComputedStyle(required).color).not.toBe(successInk);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The state the section is in for most of a visit. Worth looking at: the first card mixes ' +
+          'two schema-resolved questions with one that is not in the schema any more, and the ' +
+          'three cards each end differently - a Sign button, a View button, and a sentence with no ' +
+          'control at all.\n\n' +
+          'Question text is repeated inside every card rather than hoisted into a header, so two ' +
+          'submissions against the same form put the same label on screen twice. Any query for a ' +
+          'label here has to name the card it belongs to.',
+      },
+    },
+  },
+};
+
+export const NoSubmissions: Story = {
+  name: 'Open: nothing submitted yet',
+  args: { submissions: [] },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('button', { name: TITLE }));
+
+    /* The sentence alone proves nothing: a card that renders no rows would leave
+       this list looking empty too, and a submission whose answers are all
+       non-string returns null from the map, printing this same sentence's
+       neighbourhood. Assert the shape of the body, not just its wording. */
+    const body = bodyIn(canvasElement);
+    await expect(body).not.toBeNull();
+    await expect(body?.children).toHaveLength(1);
+    await expect(body?.firstElementChild).toHaveTextContent('No submissions yet.');
+    await expect(cardsIn(canvasElement)).toHaveLength(0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The empty branch returns a different tree, not an empty version of the same one - one ' +
+          'muted sentence at 60% ink, no card frame around it.',
+      },
+    },
+  },
+};
+
+export const ClientSignedAndPending: Story = {
+  name: 'Open: parent-signed forms only',
+  args: { submissions: CLIENT_ONLY },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('button', { name: TITLE }));
+
+    const cards = cardsIn(canvasElement);
+    await expect(cards).toHaveLength(2);
+    /* One answer row per card, so the consent text is drawn above the status
+       line rather than the card collapsing to a bare status. */
+    await expect(
+      cards.map((card) => card.querySelectorAll('div.flex.flex-col.gap-1').length)
+    ).toEqual([1, 1]);
+    await expect(cards[0]).toHaveTextContent(
+      'Sent to pet parent. It will update when they sign the document.'
+    );
+    await expect(cards[1]).toHaveTextContent('Signed by pet parent.');
+    await expect(
+      canvas.getByText('I consent to sedation for the dental examination.')
+    ).toBeInTheDocument();
+
+    /* The whole point of the CLIENT branch: no Sign button exists for the vet,
+       even on the card that is still unsigned. Sign is gated on the form's
+       requiredSigner, not on whether a signature is outstanding. */
+    await expect(canvas.queryByRole('button', { name: 'Sign' })).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'View' })).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'What the consent forms look like from the clinic side. The signed line is derived from ' +
+          '`signing.status === SIGNED` OR the presence of a signed PDF url, so a submission that ' +
+          'has the document but not the status still reads as signed.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/index.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/index.stories.tsx
@@ -1,0 +1,471 @@
+import { useState, type ComponentProps } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import type { Appointment, Form, UserOrganization } from '@yosemite-crew/types';
+
+import type { FormField } from '@/app/features/forms/types/forms';
+import { useAuthStore } from '@/app/stores/authStore';
+import { useFormsStore } from '@/app/stores/formsStore';
+import { useOrgStore } from '@/app/stores/orgStore';
+import AppoitmentInfo, { CustomFormsView } from './index';
+
+const ORG_ID = 'org-storybook-appointment-info';
+
+/**
+ * Deliberately WITHOUT an `id`.
+ *
+ * `useAppointmentCustomForms` returns on its first line when there is no appointment
+ * id - no request, `customForms: []`, `loading: false` - and the SOAP fetch in
+ * `useAppointmentFormData` is guarded the same way. That is what makes the modal
+ * mountable here with no MSW wiring, and it is why the Templates pane below lands on
+ * its empty branch rather than on a network error.
+ */
+const APPOINTMENT: Appointment = {
+  patient: {
+    id: 'companion-1',
+    name: 'Poppy',
+    species: 'dog',
+    breed: 'Beagle',
+    parent: { id: 'parent-1', name: 'Lena Hartmann' },
+  },
+  lead: { id: 'vet-1', name: 'Dr. Weber' },
+  appointmentType: {
+    id: 'svc-annual',
+    name: 'Annual check-up',
+    speciality: { id: 'spec-general', name: 'General practice' },
+  },
+  organisationId: ORG_ID,
+  appointmentDate: new Date('2026-03-12T09:30:00.000Z'),
+  startTime: new Date('2026-03-12T09:30:00.000Z'),
+  endTime: new Date('2026-03-12T10:00:00.000Z'),
+  timeSlot: '10:30 - 11:00',
+  durationMinutes: 30,
+  status: 'IN_PROGRESS',
+  concern: 'Limping on the left hind leg since Sunday.',
+};
+
+/** A vet membership: `prescription:edit:own` is what turns on the template picker. */
+const MEMBERSHIP: UserOrganization = {
+  practitionerReference: 'Practitioner/user-storybook',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'VETERINARIAN',
+  roleDisplay: 'Veterinarian',
+  active: true,
+};
+
+const SCHEMA: FormField[] = [
+  { id: 'weight', type: 'input', label: 'Weight (kg)', required: true },
+  { id: 'notes', type: 'textarea', label: 'Observations' },
+];
+
+const TEMPLATE_FORM = {
+  _id: 'form-soap-1',
+  orgId: ORG_ID,
+  name: 'SOAP - general exam',
+  category: 'SOAP',
+  visibilityType: 'Internal',
+  status: 'published',
+  schema: SCHEMA,
+  createdBy: 'user-storybook',
+  updatedBy: 'user-storybook',
+  createdAt: new Date('2026-01-04T09:00:00.000Z'),
+  updatedAt: new Date('2026-01-04T09:00:00.000Z'),
+} as unknown as Form;
+
+const TEMPLATES = [
+  { value: 'form-soap-1', label: 'SOAP - general exam', schema: SCHEMA, form: TEMPLATE_FORM },
+];
+
+/**
+ * Seeds org membership, the signed-in user and the forms cache.
+ *
+ * `lastFetchedByOrgId` is the key that matters: `useLoadFormsForPrimaryOrg` returns
+ * early once this org has an entry, so seeding it keeps the mount off the network with
+ * no template service stub.
+ */
+const seed = () => {
+  const orgSnapshot = useOrgStore.getState();
+  const authSnapshot = useAuthStore.getState();
+  const formsSnapshot = useFormsStore.getState();
+
+  useOrgStore.setState({
+    primaryOrgId: ORG_ID,
+    orgsById: { [ORG_ID]: { _id: ORG_ID, type: 'HOSPITAL' } as never },
+    membershipsByOrgId: { [ORG_ID]: MEMBERSHIP },
+    status: 'loaded',
+  });
+  // Not a credential: an opaque app user id, the value `attributes.sub` holds.
+  useAuthStore.setState({ attributes: { sub: 'user-storybook' } });
+  useFormsStore.setState({
+    formsById: {},
+    formIds: [],
+    loading: false,
+    lastFetchedByOrgId: { [ORG_ID]: '2026-03-12T08:00:00.000Z' },
+  });
+
+  return () => {
+    useOrgStore.setState(orgSnapshot);
+    useAuthStore.setState(authSnapshot);
+    useFormsStore.setState(formsSnapshot);
+  };
+};
+
+type ModalProps = ComponentProps<typeof AppoitmentInfo>;
+
+/**
+ * Opened from a trigger rather than parked open: `ModalBase` takes a ref-counted scroll
+ * lock on `document.body` while open, so a story that sat open would hold the whole docs
+ * page under `overflow: hidden`.
+ */
+const Harness = (args: ModalProps) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="flex min-h-[620px] items-start p-6">
+      <button
+        type="button"
+        className="rounded-2xl bg-text-primary px-6 py-3 text-body-3-emphasis text-[var(--screen)]"
+        onClick={() => setOpen(true)}
+      >
+        Open appointment
+      </button>
+      <AppoitmentInfo
+        {...args}
+        showModal={open}
+        setShowModal={(value) => {
+          setOpen(value);
+          args.setShowModal(value);
+        }}
+      />
+    </div>
+  );
+};
+
+/**
+ * `ModalBase` portals to `document.body`, so the panel is NOT inside `canvasElement`.
+ * The dialog is also mounted a tick after the click, so the lookup is polled rather
+ * than read once - and absence is asserted against `dialog[open]` specifically,
+ * because a closed dialog stays in the tree without its `open` attribute.
+ */
+const openModal = async (canvasElement: HTMLElement) => {
+  await userEvent.click(within(canvasElement).getByRole('button', { name: 'Open appointment' }));
+  await waitFor(() => {
+    expect(document.body.querySelector('dialog[open]')).toBeInTheDocument();
+  });
+  return within(document.body.querySelector('dialog[open]') as HTMLElement);
+};
+
+const meta = {
+  title: 'Appointments/AppointmentInfo (modal)',
+  component: AppoitmentInfo,
+  parameters: {
+    layout: 'fullscreen',
+    // The header rail pushes into the workspace with next/navigation's router.
+    nextjs: { appDirectory: true },
+    docs: {
+      description: {
+        component:
+          'The appointment detail modal. Its header is a tab rail and its body is whatever ' +
+          '`COMPONENT_MAP[label][subLabel]` resolves to - about twenty different components ' +
+          'behind five tabs - so the modal has no fixed body at all. Nothing had ever drawn the ' +
+          'swap, only the Info tab it happens to open on.\n\n' +
+          'The tab set is derived, not fixed: `buildInfoLabels` renames the Templates sub-tab to ' +
+          'SOAP for hospitals, swaps the whole Medical Records tab for a Care plan tab at ' +
+          'boarders, breeders and groomers, and drops the MSD sub-tab entirely unless that ' +
+          'integration resolves as enabled. So "click the second tab" lands on a different ' +
+          'component depending on the organisation.\n\n' +
+          'The Templates/SOAP pane behind that tab has four states that only exist around a ' +
+          'network call - loading, failed, empty, and a rejected submit - and they are ' +
+          'exercised below from `CustomFormsView` directly, because inside the modal they are ' +
+          'owned by a hook that reaches them only through a live `fetchAppointmentForms`.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    showModal: false,
+    setShowModal: fn(),
+    activeAppointment: APPOINTMENT,
+    canEditAppointments: true,
+    onReschedule: fn(),
+  },
+  render: (args) => <Harness {...args} />,
+  beforeEach: seed,
+} satisfies Meta<typeof AppoitmentInfo>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const InfoTab: Story = {
+  name: 'Info tab (default body)',
+  play: async ({ canvasElement }) => {
+    const panel = await openModal(canvasElement);
+
+    /* Both rails render a `role="tablist"` of `role="tab"` buttons, so a bare
+       getAllByRole('tab') here returns eight, not five. Only the top rail is named. */
+    const topRail = panel.getByRole('tablist', { name: 'Section navigation' });
+    const tabs = within(topRail).getAllByRole('tab');
+    await expect(tabs.map((tab) => tab.textContent?.trim())).toEqual([
+      'Info',
+      'Medical Records',
+      'Tasks',
+      'Finance',
+      'Labs',
+    ]);
+    await expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
+
+    // The body is the Info section, identified by its own accordion rather than by
+    // "something rendered" - COMPONENT_MAP returning undefined renders nothing at all,
+    // which is indistinguishable from a crash without an assertion on the contents.
+    await expect(panel.getByText('Appointments details')).toBeInTheDocument();
+    await expect(panel.getByText('Limping on the left hind leg since Sunday.')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'What opens from a board card: the companion header, a status sentence, four ' +
+          'shortcut buttons into the workspace, the tab rail, and the Info body under it. The ' +
+          'MSD sub-tab is absent because the integration is not seeded as enabled here, which ' +
+          'is the majority case.',
+      },
+    },
+  },
+};
+
+export const TabSwapToMedicalRecords: Story = {
+  name: 'Tab swap - Info to Medical Records',
+  play: async ({ canvasElement }) => {
+    const panel = await openModal(canvasElement);
+    await expect(panel.getByText('Appointments details')).toBeInTheDocument();
+
+    const topRail = panel.getByRole('tablist', { name: 'Section navigation' });
+    await userEvent.click(within(topRail).getByRole('tab', { name: 'Medical Records' }));
+
+    // The entire body is replaced, not added to.
+    await waitFor(() => {
+      expect(panel.queryByText('Appointments details')).not.toBeInTheDocument();
+    });
+
+    // The sub-rail switches with it, and the first sub-tab is selected by default.
+    await expect(within(topRail).getByRole('tab', { name: 'Medical Records' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+    /* "SOAP", not "Templates", in TWO places: `buildInfoLabels` renames the sub-tab for
+       hospitals and `formsAccordionTitle` renames the accordion by a separate rule, so
+       the word appears twice and the two can drift apart. */
+    await expect(panel.getAllByText('SOAP')).toHaveLength(2);
+    await expect(panel.getByLabelText('Search templates')).toBeInTheDocument();
+
+    // The past-submissions accordion is the empty branch, and it starts closed.
+    const previous = panel.getByRole('button', { name: 'Previous Submissions' });
+    await expect(panel.queryByText('No past form submissions.')).not.toBeInTheDocument();
+    await userEvent.click(previous);
+    expect(await panel.findByText('No past form submissions.')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The swap itself. Worth noting that the header keeps its height while the body ' +
+          'changes by hundreds of pixels - the scroll container under the rail is reset to the ' +
+          'top on every tab change, which is the only reason a long Finance tab does not open ' +
+          'mid-scroll after a short Info tab.',
+      },
+    },
+  },
+};
+
+export const TabSwapToFinance: Story = {
+  name: 'Tab swap - Finance',
+  play: async ({ canvasElement }) => {
+    const panel = await openModal(canvasElement);
+    const topRail = panel.getByRole('tablist', { name: 'Section navigation' });
+    await userEvent.click(within(topRail).getByRole('tab', { name: 'Finance' }));
+
+    /* "Appointments details" does NOT identify the Info body, and asserting its
+       absence here was wrong: `Finance/Summary` opens with an `EditableAccordion`
+       under the very same title, carrying the same concern, date, lead and
+       status. The swap is real - it is the affordance that differs. The Info
+       body's accordion is editable (`showEditIcon={canEditAppointments}`, so it
+       renders an `Edit Appointments details` button); Finance's passes
+       `showEditIcon={false}`. That button is therefore the discriminator, and
+       `Estimated total:` is the Finance-only counterpart. */
+    await waitFor(() => {
+      expect(
+        panel.queryByRole('button', { name: 'Edit Appointments details' })
+      ).not.toBeInTheDocument();
+    });
+    await expect(panel.getByText('Estimated total:')).toBeInTheDocument();
+    // Still exactly one, and it belongs to Finance now - pinned rather than
+    // glossed over, because the duplicate title is what made the old assertion
+    // look like a broken tab swap.
+    await expect(panel.getAllByText('Appointments details')).toHaveLength(1);
+    await expect(within(topRail).getByRole('tab', { name: 'Finance' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+    // The second, unnamed tablist is the sub-rail: two sub-tabs, Summary selected first.
+    const subRail = panel.getAllByRole('tablist')[1];
+    await expect(
+      within(subRail)
+        .getAllByRole('tab')
+        .map((tab) => tab.textContent?.trim())
+    ).toEqual(['Summary', 'Invoices']);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A second destination, to show that the rail is a real router and not a two-state ' +
+          'toggle. Both rails render into the same `role="tablist"`, so the sub-tabs have to be ' +
+          'filtered out by name rather than by role when asserting the top rail.\n\n' +
+          'Two tabs render an accordion titled **"Appointments details"**: the Info body and the ' +
+          'Finance Summary body, which repeats service, reason, date, time, lead and status above ' +
+          'the payment block. They are not interchangeable - the Info one is editable and the ' +
+          'Finance one is read-only - but nothing on screen says so, and the duplicate title is ' +
+          'the reason this story asserts the swap through the edit affordance instead.',
+      },
+    },
+  },
+};
+
+/* ---------------------------------------------------------------------------
+   The Templates/SOAP pane, driven directly.
+   --------------------------------------------------------------------------- */
+
+const formsViewArgs = {
+  forms: [],
+  canEdit: true,
+  activeAppointment: { ...APPOINTMENT, id: 'appt-info-1' },
+  templates: TEMPLATES,
+  accordionTitle: 'SOAP',
+};
+
+export const FormsLoading: Story = {
+  name: 'Templates pane - loading',
+  render: () => (
+    <div className="max-w-[560px] p-4">
+      <CustomFormsView {...formsViewArgs} loading error={null} />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Loading forms…')).toBeInTheDocument();
+    // It replaces the accordion outright rather than sitting inside it, so there is no
+    // template picker and no submissions list while forms load.
+    await expect(canvas.queryByLabelText('Search templates')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('SOAP')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A bare line of body text, with no skeleton and no accordion around it - so the pane ' +
+          'visibly collapses to one row and then expands again when the forms arrive. That jump ' +
+          'is the thing to look at here.',
+      },
+    },
+  },
+};
+
+export const FormsError: Story = {
+  name: 'Templates pane - load failed',
+  render: () => (
+    <div className="max-w-[560px] p-4">
+      <CustomFormsView {...formsViewArgs} loading={false} error="Unable to load forms" />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const line = canvas.getByText('Unable to load forms');
+    await expect(line).toBeInTheDocument();
+    await expect(canvas.queryByLabelText('Search templates')).not.toBeInTheDocument();
+
+    // The only thing separating this from the loading line is its colour. Poll rather
+    // than reading once - the surrounding rows carry `transition-colors`.
+    await waitFor(() => {
+      expect(getComputedStyle(line).color).not.toBe(
+        getComputedStyle(line.parentElement as HTMLElement).color
+      );
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The failure branch. It is the same shape as the loading branch with a different ' +
+          'token, no retry and no icon, which is exactly why it is worth drawing: a reader who ' +
+          'misses the colour cannot tell a failed load from a slow one.',
+      },
+    },
+  },
+};
+
+export const FormsEmpty: Story = {
+  name: 'Templates pane - no past submissions',
+  render: () => (
+    <div className="max-w-[560px] p-4">
+      <CustomFormsView {...formsViewArgs} loading={false} error={null} />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('SOAP')).toBeInTheDocument();
+    await expect(canvas.getByLabelText('Search templates')).toBeInTheDocument();
+
+    // The empty state is nested one accordion deep and starts closed, so the sentence
+    // is not on screen until it is opened - the pane looks like it has nothing in it.
+    await expect(canvas.queryByText('No past form submissions.')).not.toBeInTheDocument();
+    await userEvent.click(canvas.getByRole('button', { name: 'Previous Submissions' }));
+    expect(await canvas.findByText('No past form submissions.')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Loaded and genuinely empty. Both the loaded-empty and still-loading states show a ' +
+          'pane with no forms in it, and only this one has the accordion around it - which is ' +
+          'the difference a reviewer should be able to spot at a glance and currently cannot.',
+      },
+    },
+  },
+};
+
+export const FormsSubmitError: Story = {
+  name: 'Templates pane - submit blocked by a required field',
+  render: () => (
+    <div className="max-w-[560px] p-4">
+      <CustomFormsView {...formsViewArgs} loading={false} error={null} />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // minChars is 0 here, so focusing the field opens the whole template list.
+    await userEvent.click(canvas.getByLabelText('Search templates'));
+    await userEvent.click(await canvas.findByRole('button', { name: 'SOAP - general exam' }));
+
+    // The template's schema is rendered inline, required field first.
+    expect(await canvas.findByText('Weight (kg)')).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Save' }));
+
+    // Client-side, before any request: the missing labels are named back to the user.
+    expect(
+      await canvas.findByText('Please complete the required field(s): Weight (kg)')
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The submit error. It is raised by `collectMissingRequiredFields` before the ' +
+          'submission request is made, so it is reachable with no backend at all - and it is ' +
+          'rendered at the very bottom of the pane, below every form, rather than beside the ' +
+          'field it names. On a long template that puts the message off screen, which is the ' +
+          'thing to judge here.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/index.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/AppointmentInfo/index.tsx
@@ -419,7 +419,12 @@ const SubmittedFormEntry = ({
   );
 };
 
-const CustomFormsView = ({
+/**
+ * The Templates/SOAP pane. Exported so its loading, error and empty branches can be
+ * rendered on their own: inside the modal they are owned by `useAppointmentCustomForms`,
+ * which only reaches them through a live `fetchAppointmentForms` call.
+ */
+export const CustomFormsView = ({
   forms,
   loading,
   error,

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/ChangeRoom.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/ChangeRoom.stories.tsx
@@ -1,0 +1,528 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+
+import type { Appointment, OrganisationRoom, RoomUnit } from '@yosemite-crew/types';
+import { useAppointmentWorkspaceStore } from '@/app/stores/appointmentWorkspaceStore';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useOrganisationRoomStore } from '@/app/stores/roomStore';
+
+import ChangeRoom from './ChangeRoom';
+
+const ORG_ID = 'org-storybook';
+const CONSULT_1 = 'room-consult-1';
+const CONSULT_2 = 'room-consult-2';
+const WARD_A = 'room-ward-a';
+const ISOLATION = 'room-isolation';
+const UNIT_A1 = 'unit-kennel-a1';
+const INPATIENT_APPOINTMENT_ID = 'appt-inpatient';
+
+const room = (id: string, name: string, type: OrganisationRoom['type']): OrganisationRoom => ({
+  id,
+  name,
+  organisationId: ORG_ID,
+  code: id.toUpperCase(),
+  type,
+});
+
+const ROOMS: OrganisationRoom[] = [
+  room(CONSULT_1, 'Consult 1', 'CONSULTATION'),
+  room(CONSULT_2, 'Consult 2', 'CONSULTATION'),
+  room(WARD_A, 'Ward A', 'INPATIENT'),
+  room(ISOLATION, 'Isolation', 'ISOLATION'),
+];
+
+const unit = (id: string, roomId: string, displayName: string, isOccupied: boolean): RoomUnit => ({
+  id,
+  organisationId: ORG_ID,
+  roomId,
+  code: id.toUpperCase(),
+  displayName,
+  isActive: true,
+  isOccupied,
+});
+
+/**
+ * Occupancy is the whole point of this fixture. A1 is occupied BY THIS PATIENT
+ * (it is the encounter's current unit, so it must stay selectable), A2 is occupied
+ * by someone else and must not be offered, A3 is free. Isolation's only unit is
+ * taken, which is what removes the whole room from an in-patient's room list.
+ */
+const UNITS: RoomUnit[] = [
+  unit(UNIT_A1, WARD_A, 'Kennel A1', true),
+  unit('unit-kennel-a2', WARD_A, 'Kennel A2', true),
+  unit('unit-kennel-a3', WARD_A, 'Kennel A3', false),
+  unit('unit-isolation-1', ISOLATION, 'Isolation 1', true),
+];
+
+const appointment = (over: Partial<Appointment>): Appointment => ({
+  id: 'appt-outpatient',
+  patient: {
+    id: 'companion-1',
+    name: 'Poppy',
+    species: 'dog',
+    breed: 'Beagle',
+    parent: { id: 'parent-1', name: 'Lena Hartmann' },
+  },
+  lead: { id: 'vet-1', name: 'Dr. Weber' },
+  room: { id: CONSULT_1, name: 'Consult 1' },
+  appointmentType: {
+    id: 'type-1',
+    name: 'Annual check-up',
+    speciality: { id: 'spec-1', name: 'General practice' },
+  },
+  appointmentKind: 'OUTPATIENT',
+  organisationId: ORG_ID,
+  appointmentDate: new Date('2026-03-12T09:30:00.000Z'),
+  startTime: new Date('2026-03-12T09:30:00.000Z'),
+  endTime: new Date('2026-03-12T10:00:00.000Z'),
+  timeSlot: '09:30 - 10:00',
+  durationMinutes: 30,
+  status: 'CHECKED_IN',
+  ...over,
+});
+
+const OUTPATIENT = appointment({});
+
+const INPATIENT = appointment({
+  id: INPATIENT_APPOINTMENT_ID,
+  encounterId: 'enc-1',
+  appointmentKind: 'INPATIENT',
+  room: { id: WARD_A, name: 'Ward A' },
+  status: 'IN_PROGRESS',
+});
+
+/**
+ * ChangeRoom refetches the room list on every open (`force: true`) and PATCHes the
+ * appointment on Update, so without this every story would fire real requests out of
+ * the preview iframe - and a 401 from a reachable API redirects the whole iframe to
+ * /signin, taking the story with it. Axios uses the XHR adapter in a browser, so
+ * holding `send` is enough to keep all of it off the wire:
+ *
+ * - `stalled` never settles. That is what makes the saving state reviewable at all:
+ *   it exists only while a request is in flight, which is normally a few frames.
+ * - `failing` rejects the way an unreachable API does (no response), which is the
+ *   branch that falls back to the generic "Unable to update room" copy.
+ *
+ * The service module itself is untouched - the component, the store and
+ * updateAppointment are all the real ones.
+ */
+const REAL_XHR_SEND = XMLHttpRequest.prototype.send;
+
+const stubTransport = (mode: 'stalled' | 'failing') => {
+  XMLHttpRequest.prototype.send = function stubbedSend(this: XMLHttpRequest) {
+    if (mode === 'stalled') return;
+    setTimeout(() => this.dispatchEvent(new ProgressEvent('error')), 0);
+  };
+  // Always restored to the module-level original rather than to whatever was
+  // installed before, so a meta-level and a story-level stub cannot strand one
+  // whichever order their cleanups run in.
+  return () => {
+    XMLHttpRequest.prototype.send = REAL_XHR_SEND;
+  };
+};
+
+const prepare =
+  (mode: 'stalled' | 'failing' = 'stalled') =>
+  () => {
+    const orgSnapshot = useOrgStore.getState();
+    const roomSnapshot = useOrganisationRoomStore.getState();
+    const workspaceSnapshot = useAppointmentWorkspaceStore.getState();
+    const restoreTransport = stubTransport(mode);
+
+    useOrgStore.setState({ primaryOrgId: ORG_ID, status: 'loaded' });
+    useOrganisationRoomStore.setState({
+      roomsById: Object.fromEntries(ROOMS.map((item) => [item.id, item])),
+      roomIdsByOrgId: { [ORG_ID]: ROOMS.map((item) => item.id) },
+      roomUnitsById: Object.fromEntries(UNITS.map((item) => [item.id, item])),
+      roomUnitIdsByRoomId: {
+        [WARD_A]: UNITS.filter((item) => item.roomId === WARD_A).map((item) => item.id),
+        [ISOLATION]: UNITS.filter((item) => item.roomId === ISOLATION).map((item) => item.id),
+      },
+      status: 'loaded',
+    });
+
+    // The in-patient's current unit lives on the encounter, not on the appointment,
+    // and it is read through the store on every render - so it is seeded through the
+    // real actions rather than hand-built.
+    const workspace = useAppointmentWorkspaceStore.getState();
+    workspace.initEncounter(INPATIENT_APPOINTMENT_ID, 'INPATIENT', {
+      leadId: 'vet-1',
+      leadName: 'Dr. Weber',
+    });
+    workspace.setRoomUnit(INPATIENT_APPOINTMENT_ID, WARD_A, UNIT_A1);
+
+    return () => {
+      restoreTransport();
+      useAppointmentWorkspaceStore.setState(workspaceSnapshot);
+      useOrganisationRoomStore.setState(roomSnapshot);
+      useOrgStore.setState(orgSnapshot);
+    };
+  };
+
+/** ModalBase portals to document.body, so nothing here is inside `canvasElement`. */
+const openDialog = () => document.querySelector<HTMLElement>('dialog[open]');
+
+/**
+ * LabelDropdown portals its panel to document.body too - and to body, not into the
+ * dialog, so it is not even a descendant of the modal. Querying the dialog for the
+ * options finds nothing and passes as "closed".
+ */
+const openMenu = () => document.querySelector<HTMLElement>('[data-portal-dropdown]');
+
+const dialogQueries = async () => {
+  await waitFor(() => expect(openDialog()).not.toBeNull());
+  return within(openDialog() as HTMLElement);
+};
+
+const menuOptionLabels = async () => {
+  await waitFor(() => expect(openMenu()).not.toBeNull());
+  return within(openMenu() as HTMLElement)
+    .getAllByRole('button')
+    .map((option) => option.textContent);
+};
+
+/**
+ * The dialog's fields, in DOM order. Keyed on `aria-haspopup` rather than on a
+ * label, so counting them says how many fields the dialog HAS - which is the one
+ * structural difference between the out-patient and in-patient forms.
+ */
+const dropdownTriggers = (root: HTMLElement) =>
+  Array.from(root.querySelectorAll<HTMLElement>('button[aria-haspopup="listbox"]'));
+
+/** The `saving` wrapper around one LabelDropdown, which is what the flex gap separates. */
+const fieldWrapperOf = (trigger: HTMLElement) =>
+  trigger.closest<HTMLElement>('div.flex.flex-col.w-full')?.parentElement as HTMLElement;
+
+const meta = {
+  title: 'Appointments/ChangeRoom',
+  component: ChangeRoom,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The "Assign room" dialog, opened from the appointment card rail and the calendar ' +
+          'context menu. It had no story, so nothing below the header had ever been drawn: not ' +
+          'the second dropdown, not the failure line, not the in-flight state.\n\n' +
+          'It is two different dialogs depending on `appointmentKind`. An out-patient picks a ' +
+          'room and that is the whole form. An in-patient picks a room AND a unit, because the ' +
+          'unit is the thing that is actually occupied - it lives on the encounter in the ' +
+          'workspace store, not on the appointment, and the assignment is a second request ' +
+          '(`assignEncounterUnit`) after the appointment PATCH.\n\n' +
+          'Which rooms are offered is derived, and the derivation is easy to get wrong in both ' +
+          'directions. For an in-patient a room is dropped when it models units and every one of ' +
+          'them is occupied - but the unit the patient is in right now counts as assignable, or ' +
+          'the dialog would refuse to show the room the patient is already in. A room with no ' +
+          'units modelled at all is always offered, on the assumption that an unmodelled room is ' +
+          'not tracked rather than full. The fixtures here have one of each, so the room list ' +
+          'is four long for an out-patient and three for an in-patient.\n\n' +
+          'Saving locks the form but does not dim it: the two field wrappers only get ' +
+          '`pointer-events-none`, while the buttons get the usual disabled 60% - worth a look ' +
+          'side by side, since a locked-but-bright field reads as interactive.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    showModal: true,
+    setShowModal: fn(),
+    activeAppointment: OUTPATIENT,
+  },
+  beforeEach: prepare(),
+} satisfies Meta<typeof ChangeRoom>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Outpatient: Story = {
+  name: 'Out-patient (room only)',
+  play: async () => {
+    const panel = await dialogQueries();
+    const dialog = openDialog() as HTMLElement;
+
+    await expect(panel.getByRole('heading', { name: 'Assign room' })).toBeInTheDocument();
+
+    /* ONE field, not two, and the assertion is the count rather than the absence
+       of a label: the unit picker is in-patient-only, and a stray second
+       dropdown is the exact regression the in-patient story cannot catch. */
+    const triggers = dropdownTriggers(dialog);
+    await expect(triggers.map((item) => item.getAttribute('aria-label'))).toEqual([
+      'Select room: Consult 1',
+    ]);
+    // The trigger paints the room NAME, not the id it is keyed on.
+    await expect(triggers[0]).toHaveTextContent('Consult 1');
+    await expect(panel.queryByText('Select unit')).not.toBeInTheDocument();
+
+    await expect(panel.getByRole('button', { name: 'Cancel' })).toBeEnabled();
+    await expect(panel.getByRole('button', { name: 'Update' })).toBeEnabled();
+    // The baseline for the saving story: nothing is locked at rest.
+    await expect(getComputedStyle(triggers[0]).pointerEvents).toBe('auto');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The dialog as it opens on a checked-in out-patient. Nothing here is a placeholder: ' +
+          'the trigger is pre-filled from `activeAppointment.room`, so the assigned room is the ' +
+          'selected value rather than an empty field - reassigning is a change, never a first choice.',
+      },
+    },
+  },
+};
+
+export const OutpatientRoomMenu: Story = {
+  name: 'Out-patient: room menu open',
+  play: async () => {
+    const panel = await dialogQueries();
+    const trigger = panel.getByRole('button', { name: 'Select room: Consult 1' });
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    await userEvent.click(trigger);
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    // All four rooms, in store order: an out-patient assignment ignores units
+    // entirely, so Isolation is offered here even though its only unit is taken.
+    expect(await menuOptionLabels()).toEqual(['Consult 1', 'Consult 2', 'Ward A', 'Isolation']);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The menu is portalled to `document.body` and positioned from the trigger rect, which ' +
+          'is why the modal has to whitelist `[data-portal-dropdown]` in its outside-click check ' +
+          '- without that, choosing a room would dismiss the dialog underneath it.',
+      },
+    },
+  },
+};
+
+export const Inpatient: Story = {
+  name: 'In-patient (room and unit)',
+  args: { activeAppointment: INPATIENT },
+  play: async () => {
+    await dialogQueries();
+    const dialog = openDialog() as HTMLElement;
+
+    /* Two fields, in this order, both carrying a RESOLVED value. If the
+       encounter seed is missing, the second trigger reads a bare "Select unit"
+       and the story still renders a plausible dialog - which is precisely the
+       silent case, so the labels are asserted rather than the elements. */
+    const triggers = dropdownTriggers(dialog);
+    await expect(triggers.map((item) => item.getAttribute('aria-label'))).toEqual([
+      'Select room: Ward A',
+      'Select unit: Kennel A1',
+    ]);
+    await expect(triggers.map((item) => item.textContent)).toEqual(['Ward A', 'Kennel A1']);
+
+    /* The design's 44px field height and 16px stack gap, measured off the border
+       box. `getComputedStyle().height` reads 41 here, not 44: these triggers
+       carry a 1.5px border, and the computed value is the CONTENT box. */
+    await expect(triggers.map((item) => Math.round(item.getBoundingClientRect().height))).toEqual([
+      44, 44,
+    ]);
+    const [roomField, unitField] = triggers.map(fieldWrapperOf);
+    const gap = unitField.getBoundingClientRect().top - roomField.getBoundingClientRect().bottom;
+    await expect(Math.round(gap)).toBe(16);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Both fields stack at the same 44px height with a 16px gap, asserted here off the ' +
+          "border box. The unit label is the unit's `displayName`, falling back to its `code` - " +
+          'a unit created without a display name shows as "WARD-A-03" rather than blank.',
+      },
+    },
+  },
+};
+
+export const InpatientUnitMenu: Story = {
+  name: 'In-patient: unit menu open',
+  args: { activeAppointment: INPATIENT },
+  play: async () => {
+    const panel = await dialogQueries();
+
+    await userEvent.click(panel.getByRole('button', { name: 'Select unit: Kennel A1' }));
+
+    /* Two of the ward's three units. A2 is occupied by another patient and is
+       gone; A1 is occupied too - by this patient - and survives because it is the
+       encounter's current unit. Drop that exception and the dialog stops offering
+       the unit the animal is lying in. */
+    expect(await menuOptionLabels()).toEqual(['Kennel A1', 'Kennel A3']);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The unit list is recomputed from the selected room, so changing the room above resets ' +
+          'this to the first assignable unit in the new room rather than leaving a stale one selected.',
+      },
+    },
+  },
+};
+
+export const InpatientRoomMenu: Story = {
+  name: 'In-patient: room menu drops full rooms',
+  args: { activeAppointment: INPATIENT },
+  play: async () => {
+    const panel = await dialogQueries();
+
+    await userEvent.click(panel.getByRole('button', { name: 'Select room: Ward A' }));
+
+    const labels = await menuOptionLabels();
+    // Three, not four: Isolation models one unit and it is occupied by someone else.
+    await expect(labels).toEqual(['Consult 1', 'Consult 2', 'Ward A']);
+    await expect(labels).not.toContain('Isolation');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The two consult rooms model no units at all and are still offered: an unmodelled room ' +
+          'is treated as untracked, not as full. Only a room that declares units and has none ' +
+          'free is withheld.',
+      },
+    },
+  },
+};
+
+export const Saving: Story = {
+  name: 'Saving (fields locked)',
+  play: async () => {
+    const panel = await dialogQueries();
+
+    await userEvent.click(panel.getByRole('button', { name: 'Select room: Consult 1' }));
+    await waitFor(() => expect(openMenu()).not.toBeNull());
+    await userEvent.click(
+      within(openMenu() as HTMLElement).getByRole('button', { name: 'Consult 2' })
+    );
+    // Saving short-circuits when nothing changed, so the room has to actually move.
+    const trigger = panel.getByRole('button', { name: 'Select room: Consult 2' });
+    await expect(trigger).toBeInTheDocument();
+
+    await userEvent.click(panel.getByRole('button', { name: 'Update' }));
+
+    const update = await panel.findByRole('button', { name: 'Saving...' });
+    await expect(update).toBeDisabled();
+    await expect(panel.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+
+    /* `pointer-events` is inherited, so reading it off the trigger proves the
+       wrapper's lock actually reached the control - which is the only thing that
+       stops a second room being chosen mid-save, since the dropdown itself is
+       never disabled and still looks live. */
+    await waitFor(() => {
+      expect(getComputedStyle(trigger).pointerEvents).toBe('none');
+    });
+    await expect(
+      panel.queryByText('Unable to update room. Please try again.')
+    ).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Held open by stalling the request. In the app this window is a few hundred ' +
+          'milliseconds, which is long enough to double-submit and far too short to review - the ' +
+          'reason the label change (Update -> Saving...) and the field lock had never been seen ' +
+          'together.',
+      },
+    },
+  },
+};
+
+export const SaveFailure: Story = {
+  name: 'Save failed',
+  beforeEach: prepare('failing'),
+  play: async () => {
+    const panel = await dialogQueries();
+
+    await userEvent.click(panel.getByRole('button', { name: 'Select room: Consult 1' }));
+    await waitFor(() => expect(openMenu()).not.toBeNull());
+    await userEvent.click(
+      within(openMenu() as HTMLElement).getByRole('button', { name: 'Consult 2' })
+    );
+
+    await userEvent.click(panel.getByRole('button', { name: 'Update' }));
+
+    /* The generic copy, not the API's. A transport failure carries no response
+       body, so the `response.data.message` path cannot fire and this fallback is
+       the only thing the user sees - the sentence itself is the surface. */
+    expect(await panel.findByText('Unable to update room. Please try again.')).toBeInTheDocument();
+
+    /* Still open, and asserted against `dialog[open]` rather than against the
+       node: ModalBase leaves a dismissed dialog MOUNTED and only drops the
+       `open` attribute, so querying for the element finds a closed dialog and
+       reads as success. */
+    await expect(openDialog()).not.toBeNull();
+
+    // Both actions come back, so a retry is one click away.
+    await expect(panel.getByRole('button', { name: 'Update' })).toBeEnabled();
+    await expect(panel.getByRole('button', { name: 'Cancel' })).toBeEnabled();
+    await expect(panel.queryByRole('button', { name: 'Saving...' })).not.toBeInTheDocument();
+    // The chosen room is kept, not rolled back to the appointment's current room.
+    await expect(panel.getByRole('button', { name: 'Select room: Consult 2' })).toBeInTheDocument();
+    // Exactly one error line, not one per attempt.
+    await expect(panel.getAllByText('Unable to update room. Please try again.')).toHaveLength(1);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The error is a plain line under the fields, above the buttons, in `--danger-text`. It ' +
+          'is cleared on the next attempt and on cancel, so it never outlives the request that ' +
+          'produced it.',
+      },
+    },
+  },
+};
+
+export const InpatientOnPhone: Story = {
+  name: 'In-patient at 375',
+  args: { activeAppointment: INPATIENT },
+  /* Storybook 10 removed the pre-10 viewport parameters. They are not errors,
+     they are INERT - a story pinned the old way renders at the full panel width
+     and its play function still passes, proving nothing. Selection is a GLOBAL,
+     and the value has to name a key registered in `.storybook/preview.ts`. */
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async () => {
+    await dialogQueries();
+    const dialog = openDialog() as HTMLElement;
+
+    /* Guards the pin itself before anything is measured. CenterModal is
+       `w-[90%] sm:w-[500px]`, so every assertion below only describes the phone
+       branch while the viewport is under the 640px `sm` breakpoint. If the pin
+       ever goes inert this fails here instead of quietly measuring the desktop
+       dialog and calling it a phone. */
+    await waitFor(() => expect(globalThis.window.innerWidth).toBeLessThan(640));
+
+    const dialogWidth = dialog.getBoundingClientRect().width;
+    await expect(dialogWidth).toBeLessThan(400);
+    await expect(dialogWidth).toBeGreaterThan(300);
+
+    /* The footer is `flex-wrap` with two `min-w-[120px]` actions. 248px of
+       button inside a ~313px content box still fits on one line, so the two
+       share a row rather than stacking - the thing worth checking at the
+       narrowest width the app supports. */
+    const cancel = within(dialog).getByRole('button', { name: 'Cancel' });
+    const update = within(dialog).getByRole('button', { name: 'Update' });
+    await expect(Math.round(cancel.getBoundingClientRect().top)).toBe(
+      Math.round(update.getBoundingClientRect().top)
+    );
+
+    // Both fields still span the dialog, and nothing pushes it sideways.
+    const triggers = dropdownTriggers(dialog);
+    await expect(triggers).toHaveLength(2);
+    await expect(dialog.scrollWidth).toBeLessThanOrEqual(dialog.clientWidth + 1);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same in-patient dialog at 375. It is the only width where the modal is not a fixed ' +
+          '500px box: below `sm` it takes 90% of the viewport, which leaves roughly 313px of ' +
+          'content once the 12px padding is off. Worth looking at whether the two 120px actions ' +
+          'and the two full-width fields still read as a form at that size.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/ViewAppointmentOverviewModal/index.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/Appointments/Sections/ViewAppointmentOverviewModal/index.stories.tsx
@@ -1,0 +1,454 @@
+import { useState, type ComponentProps } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import type { Appointment, OrganisationRoom, RoomUnit, Service } from '@yosemite-crew/types';
+
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useOrganisationRoomStore } from '@/app/stores/roomStore';
+import { useServiceStore } from '@/app/stores/serviceStore';
+import ViewAppointmentOverviewModal from './index';
+
+const ORG_ID = 'org-storybook-overview';
+const SPECIALITY_ID = 'spec-general';
+const SERVICE_ID = 'svc-annual';
+const ROOM_ID = 'room-consult-2';
+const WARD_ID = 'room-ward-a';
+
+const APPOINTMENT: Appointment = {
+  id: 'appt-overview-1',
+  patient: {
+    id: 'companion-1',
+    name: 'Poppy',
+    species: 'dog',
+    breed: 'Beagle',
+    parent: { id: 'parent-1', name: 'Lena Hartmann' },
+  },
+  lead: { id: 'vet-1', name: 'Dr. Weber' },
+  supportStaff: [{ id: 'tech-1', name: 'Ana Silva' }],
+  room: { id: ROOM_ID, name: 'Consult 2' },
+  appointmentType: {
+    id: SERVICE_ID,
+    name: 'Annual check-up',
+    speciality: { id: SPECIALITY_ID, name: 'General practice' },
+  },
+  organisationId: ORG_ID,
+  appointmentDate: new Date('2026-03-12T09:30:00.000Z'),
+  startTime: new Date('2026-03-12T09:30:00.000Z'),
+  endTime: new Date('2026-03-12T10:00:00.000Z'),
+  timeSlot: '10:30 - 11:00',
+  durationMinutes: 30,
+  status: 'UPCOMING',
+  concern: 'Limping on the left hind leg since Sunday.',
+  isEmergency: false,
+};
+
+const room = (id: string, name: string): OrganisationRoom => ({
+  id,
+  name,
+  organisationId: ORG_ID,
+  code: id.toUpperCase(),
+  type: 'CONSULTATION',
+});
+
+const unit = (id: string, code: string, displayName: string): RoomUnit => ({
+  id,
+  organisationId: ORG_ID,
+  roomId: WARD_ID,
+  code,
+  displayName,
+  isActive: true,
+  isOccupied: false,
+});
+
+const SERVICE: Service = {
+  id: SERVICE_ID,
+  organisationId: ORG_ID,
+  name: 'Annual check-up',
+  durationMinutes: 30,
+  cost: 82,
+  maxDiscount: 12,
+  specialityId: SPECIALITY_ID,
+  isActive: true,
+};
+
+const UNITS: RoomUnit[] = [unit('unit-a1', 'A1', 'Kennel A1'), unit('unit-a2', 'A2', 'Kennel A2')];
+
+/**
+ * Seeds the room, service and org stores and restores them on unmount.
+ *
+ * The modal does fire one request on open - `loadRoomsForOrgPrimaryOrg({ force: true,
+ * silent: true })` - but it is `.catch`ed to nothing and only ever WRITES the store on
+ * success, so a Storybook run with no backend leaves these seeds exactly as they are.
+ * That is why the room dropdown here has real options rather than being empty.
+ */
+const seed = (rooms: OrganisationRoom[], units: RoomUnit[] = []) => {
+  return () => {
+    const orgSnapshot = useOrgStore.getState();
+    const roomSnapshot = useOrganisationRoomStore.getState();
+    const serviceSnapshot = useServiceStore.getState();
+
+    useOrgStore.setState({
+      primaryOrgId: ORG_ID,
+      orgsById: { [ORG_ID]: { _id: ORG_ID, type: 'HOSPITAL' } as never },
+      status: 'loaded',
+    });
+    useOrganisationRoomStore.setState({
+      roomsById: Object.fromEntries(rooms.map((item) => [item.id, item])),
+      roomIdsByOrgId: { [ORG_ID]: rooms.map((item) => item.id) },
+      roomUnitsById: Object.fromEntries(units.map((item) => [item.id, item])),
+      roomUnitIdsByRoomId: units.length ? { [WARD_ID]: units.map((item) => item.id) } : {},
+      status: 'loaded',
+    });
+    useServiceStore.setState({
+      servicesById: { [SERVICE_ID]: SERVICE },
+      serviceIdsBySpecialityId: { [SPECIALITY_ID]: [SERVICE_ID] },
+    });
+
+    return () => {
+      useOrgStore.setState(orgSnapshot);
+      useOrganisationRoomStore.setState(roomSnapshot);
+      useServiceStore.setState(serviceSnapshot);
+    };
+  };
+};
+
+type ModalProps = ComponentProps<typeof ViewAppointmentOverviewModal>;
+
+/**
+ * Opened from a trigger rather than parked open. `ModalBase` takes a ref-counted
+ * scroll lock on `document.body` while open, so a story that sat open would hold the
+ * whole docs page under `overflow: hidden`.
+ */
+const Harness = (args: ModalProps) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="flex min-h-[560px] items-start p-6">
+      <button
+        type="button"
+        className="rounded-2xl bg-text-primary px-6 py-3 text-body-3-emphasis text-[var(--screen)]"
+        onClick={() => setOpen(true)}
+      >
+        Open overview
+      </button>
+      <ViewAppointmentOverviewModal
+        {...args}
+        showModal={open}
+        setShowModal={(value) => {
+          setOpen(value);
+          args.setShowModal(value);
+        }}
+      />
+    </div>
+  );
+};
+
+/**
+ * The panel lives on `document.body`, not in the story canvas, and it mounts a tick
+ * after the click - so the lookup is polled rather than read once. Absence is asserted
+ * against `dialog[open]` specifically: a closed dialog stays mounted without the attribute.
+ */
+const openOverview = async (canvasElement: HTMLElement) => {
+  await userEvent.click(within(canvasElement).getByRole('button', { name: 'Open overview' }));
+  await waitFor(() => {
+    expect(document.body.querySelector('dialog[open]')).toBeInTheDocument();
+  });
+  return within(document.body.querySelector('dialog[open]') as HTMLElement);
+};
+
+/**
+ * `LabelDropdown` portals its panel to `document.body` to escape the dialog's
+ * `overflow-y-auto` body, and positions it from the trigger rect in a layout effect, so
+ * it is not in the tree on the click tick. Polled, then re-read outside the callback -
+ * a helper that mutated the DOM inside `waitFor` would re-queue forever instead of failing.
+ */
+const findPortalDropdown = async (): Promise<HTMLElement> => {
+  await waitFor(() => {
+    expect(document.body.querySelector('[data-portal-dropdown]')).toBeInTheDocument();
+  });
+  return document.body.querySelector('[data-portal-dropdown]') as HTMLElement;
+};
+
+/**
+ * The two-column body: `grid-cols-1` with `md:grid-cols-2`, the outermost `.grid` in
+ * the dialog and so the first in document order. Measured as resolved tracks, because
+ * the class name alone proves nothing about what the browser actually laid out.
+ */
+const trackCount = (element: HTMLElement): number =>
+  getComputedStyle(element).gridTemplateColumns.trim().split(/\s+/).length;
+
+const getBodyGrid = (): HTMLElement =>
+  document.body.querySelector('dialog[open] .grid') as HTMLElement;
+
+const meta = {
+  title: 'Appointments/ViewAppointmentOverviewModal',
+  component: ViewAppointmentOverviewModal,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The "Appointment Details" panel that opens from a board card - the two-column ' +
+          'overview a clinician reads before starting a visit. The shell around it had a story; ' +
+          'the body inside it never did, and the body is where every conditional lives.\n\n' +
+          'Three of them matter. **RoomSelectorSection** renders the same field two completely ' +
+          'different ways: an editable `LabelDropdown` when the status allows a room change, ' +
+          'and a read-only bordered box otherwise - same label, same slot, different element, ' +
+          'so a status that flips the branch silently removes an interactive control. The ' +
+          '**Unit** selector only exists for `INPATIENT` bookings and only offers units that ' +
+          'are active and unoccupied, which means an all-occupied ward renders an empty ' +
+          'dropdown rather than an error. And the **blocked panel** under the columns appears ' +
+          'for requested, cancelled and no-show appointments, alongside a disabled footer CTA.\n' +
+          '\n' +
+          'The estimate panel is a fourth: it prefers the real invoice total when one exists ' +
+          'and otherwise derives cost minus max discount from the service catalogue, so it is ' +
+          'seeded from `serviceStore` here rather than passed in.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    showModal: false,
+    setShowModal: fn(),
+    activeAppointment: APPOINTMENT,
+    canEditAppointments: true,
+    onOpenDetails: fn(),
+  },
+  render: (args) => <Harness {...args} />,
+  beforeEach: seed([room(ROOM_ID, 'Consult 2'), room('room-consult-3', 'Consult 3')]),
+} satisfies Meta<typeof ViewAppointmentOverviewModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Overview: Story = {
+  name: 'Upcoming - room editable',
+  play: async ({ canvasElement }) => {
+    const panel = await openOverview(canvasElement);
+
+    // Left column: the people and the schedule.
+    await expect(panel.getByRole('heading', { name: 'Appointment Details' })).toBeInTheDocument();
+    await expect(panel.getByText('Poppy')).toBeInTheDocument();
+    await expect(panel.getByText('Lena Hartmann')).toBeInTheDocument();
+    await expect(panel.getByText('Dr. Weber')).toBeInTheDocument();
+    await expect(panel.getByText('Ana Silva')).toBeInTheDocument();
+    await expect(panel.getByText('30 mins')).toBeInTheDocument();
+
+    // Right column: the appointment rows.
+    await expect(panel.getByText('General practice')).toBeInTheDocument();
+    await expect(panel.getByText('Limping on the left hind leg since Sunday.')).toBeInTheDocument();
+    // Scoped to its own row: a bare `getByText('No')` would be ambiguous the moment
+    // any other row answers with the same word.
+    const emergencyRow = panel.getByText('Emergency').parentElement as HTMLElement;
+    await expect(within(emergencyRow).getByText('No')).toBeInTheDocument();
+
+    // Room is the EDITABLE branch here, and the trigger carries the current value
+    // in its accessible name.
+    const roomTrigger = panel.getByRole('button', { name: 'Room: Consult 2' });
+    await expect(roomTrigger).toHaveAttribute('aria-haspopup', 'listbox');
+    await expect(roomTrigger).toHaveAttribute('aria-expanded', 'false');
+
+    // No unit selector: this is an outpatient booking.
+    await expect(panel.queryByRole('button', { name: /^Unit/ })).not.toBeInTheDocument();
+
+    // Estimate falls back to the catalogue (82 cost - 12 max discount) because no
+    // invoice exists for this appointment.
+    await expect(panel.getByText('$ 70.00')).toBeInTheDocument();
+    await expect(panel.getByRole('button', { name: 'Start Appointment' })).toBeEnabled();
+
+    // The "two-column" claim, measured: two resolved tracks holding exactly the two
+    // column components. A collapse to one track would still render every row above.
+    const grid = getBodyGrid();
+    await expect(trackCount(grid)).toBe(2);
+    await expect(grid.children).toHaveLength(2);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The everyday panel. Both columns are populated, the room is a live dropdown, and ' +
+          'the footer reads "Start Appointment" because the status is UPCOMING - the label ' +
+          'switches to "View Details" for every other status.',
+      },
+    },
+  },
+};
+
+export const RoomDropdownOpen: Story = {
+  name: 'Room dropdown open',
+  play: async ({ canvasElement }) => {
+    const panel = await openOverview(canvasElement);
+    const roomTrigger = panel.getByRole('button', { name: 'Room: Consult 2' });
+    await userEvent.click(roomTrigger);
+
+    await expect(roomTrigger).toHaveAttribute('aria-expanded', 'true');
+
+    /* The panel is portalled to document.body, so it is NOT inside the dialog - and it
+       is a labelled <div> of <button>s rather than a listbox with options, despite the
+       trigger advertising `aria-haspopup="listbox"`. Queried as buttons because that
+       is what is actually in the tree. */
+    const dropdown = await findPortalDropdown();
+    await expect(
+      within(dropdown)
+        .getAllByRole('button')
+        .map((option) => option.textContent?.trim())
+    ).toEqual(['Consult 2', 'Consult 3']);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Every consulting room in the organisation, with the current one marked. The list ' +
+          'is portalled out of the dialog to escape its `overflow-y-auto` body - which is also ' +
+          'why the shell has to whitelist `[data-portal-dropdown]` in its outside-click guard, ' +
+          'or picking a room would dismiss the panel.',
+      },
+    },
+  },
+};
+
+export const InpatientUnitSelector: Story = {
+  name: 'Inpatient - Unit selector',
+  args: {
+    activeAppointment: {
+      ...APPOINTMENT,
+      appointmentKind: 'INPATIENT',
+      room: { id: WARD_ID, name: 'Ward A' },
+    },
+  },
+  beforeEach: seed([room(WARD_ID, 'Ward A'), room(ROOM_ID, 'Consult 2')], UNITS),
+  play: async ({ canvasElement }) => {
+    const panel = await openOverview(canvasElement);
+
+    // Two dropdowns now, not one: Room and the inpatient-only Unit.
+    await expect(panel.getByRole('button', { name: 'Room: Ward A' })).toBeInTheDocument();
+    const unitTrigger = panel.getByRole('button', { name: 'Unit: Kennel A1' });
+    await userEvent.click(unitTrigger);
+
+    const dropdown = await findPortalDropdown();
+    await expect(
+      within(dropdown)
+        .getAllByRole('button')
+        .map((option) => option.textContent?.trim())
+    ).toEqual(['Kennel A1', 'Kennel A2']);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'An inpatient booking. The Unit field is added under Room and pre-selects the first ' +
+          'assignable unit in the ward, which is why the trigger already reads "Kennel A1" ' +
+          'before anything is touched - the appointment itself carries no unit.',
+      },
+    },
+  },
+};
+
+export const BlockedWorkspace: Story = {
+  name: 'Cancelled - workspace blocked, room read-only',
+  args: {
+    activeAppointment: { ...APPOINTMENT, status: 'CANCELLED' },
+  },
+  play: async ({ canvasElement }) => {
+    const panel = await openOverview(canvasElement);
+
+    // The blocked note is built from the status label, so it names the status back.
+    await expect(
+      panel.getByText('Cancelled appointments cannot be opened in the clinical workspace.')
+    ).toBeInTheDocument();
+    await expect(panel.getByRole('button', { name: 'View Details' })).toBeDisabled();
+
+    // Room has fallen to the read-only branch: the label survives, the control does not.
+    await expect(panel.queryByRole('button', { name: /^Room/ })).not.toBeInTheDocument();
+    await expect(panel.getByText('Room')).toBeInTheDocument();
+    await expect(panel.getByText('Consult 2')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A cancelled appointment. Two things change at once and both are easy to lose: the ' +
+          'room dropdown becomes a bordered read-only box carrying the same value, and a ' +
+          'neutral panel appears under the columns explaining why the CTA underneath it is ' +
+          'dead. The CTA is disabled rather than hidden, so the panel is the only thing that ' +
+          'says why.',
+      },
+    },
+  },
+};
+
+export const CompletedHidesEstimate: Story = {
+  name: 'Completed - estimate panel gone',
+  args: {
+    activeAppointment: { ...APPOINTMENT, status: 'COMPLETED' },
+  },
+  play: async ({ canvasElement }) => {
+    const panel = await openOverview(canvasElement);
+
+    // A completed visit has a bill, not an estimate, so the whole panel is dropped.
+    await expect(panel.queryByText('Estimate')).not.toBeInTheDocument();
+    await expect(panel.queryByText('$ 70.00')).not.toBeInTheDocument();
+    // The workspace is still reachable for a completed appointment.
+    await expect(panel.getByRole('button', { name: 'View Details' })).toBeEnabled();
+    // Room is read-only here too - assignment stops at IN_PROGRESS.
+    await expect(panel.queryByRole('button', { name: /^Room/ })).not.toBeInTheDocument();
+
+    /* Everything above the dropped panel is still drawn. Without these the story would
+       be four absence checks, which a panel that failed to render at all would also
+       satisfy - the estimate is missing because the status says so, not because the
+       body is empty. Room keeps its value in the read-only box. */
+    await expect(panel.getByRole('heading', { name: 'Appointment Details' })).toBeInTheDocument();
+    await expect(panel.getByText('Poppy')).toBeInTheDocument();
+    await expect(panel.getByText('General practice')).toBeInTheDocument();
+    await expect(panel.getByText('Room')).toBeInTheDocument();
+    await expect(panel.getByText('Consult 2')).toBeInTheDocument();
+    // And the blocked panel is NOT here: completed is reachable, cancelled is not.
+    await expect(
+      panel.queryByText(/cannot be opened in the clinical workspace/)
+    ).not.toBeInTheDocument();
+    const grid = getBodyGrid();
+    await expect(grid.children).toHaveLength(2);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The third arrangement of the right column: no estimate block at all. It is gated on ' +
+          'the status rather than on the invoice, so a completed appointment shows the rows ' +
+          'and the read-only room and nothing below them.',
+      },
+    },
+  },
+};
+
+export const OverviewNarrow: Story = {
+  name: 'Upcoming at 375px',
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const panel = await openOverview(canvasElement);
+
+    // One track, same two children: the appointment rows fall under the people rather
+    // than beside them. The default `laptop` global gives two tracks, so without this
+    // story nothing here exercises the breakpoint.
+    const grid = getBodyGrid();
+    await expect(trackCount(grid)).toBe(1);
+    await expect(grid.children).toHaveLength(2);
+
+    // Both columns still render in full - the layout reflows, it does not truncate.
+    await expect(panel.getByText('Poppy')).toBeInTheDocument();
+    await expect(panel.getByText('Lena Hartmann')).toBeInTheDocument();
+    await expect(panel.getByText('General practice')).toBeInTheDocument();
+    await expect(panel.getByRole('button', { name: 'Room: Consult 2' })).toBeInTheDocument();
+    await expect(panel.getByRole('button', { name: 'Start Appointment' })).toBeEnabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The stacked panel on a phone. Everything a clinician reads before starting a visit ' +
+          'is now one column deep, which puts the estimate and the Start Appointment button ' +
+          'below a full screen of patient detail - the ordering worth judging here, since the ' +
+          'desktop layout keeps the CTA in view and this one does not.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/auth/pages/ForgotPassword/ForgotPassword.stories.tsx
+++ b/apps/frontend/src/app/features/auth/pages/ForgotPassword/ForgotPassword.stories.tsx
@@ -1,0 +1,325 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import { setJsonStorageItem, setStorageItem } from '@/app/lib/browserStorage';
+import { useAuthStore } from '@/app/stores/authStore';
+import ForgotPassword from './ForgotPassword';
+/* Not decoration. `.yc-field`, `.yc-lbl`, `.yc-switch` and `.yc-btn-primary` live in
+   marketing.css, which is imported by the (public) ROUTE LAYOUT rather than by any
+   component, and Storybook never renders that layout. Without this line the page
+   draws a user-agent text input and an unstyled submit. */
+import '../../../marketing/site/marketing.css';
+
+/**
+ * Typed with a trailing space on purpose, but NOT for the reason it looks like.
+ * The field is `type="email"`, and the HTML value sanitization algorithm for that
+ * state strips leading and trailing whitespace before the value is ever readable
+ * - so `input.value` is already trimmed by the time React's `onChange` sees it.
+ * The space therefore never reaches `normalizeEmail`, and the trimmed address on
+ * the confirmation panel is NOT evidence that `normalizeEmail` ran. Both facts
+ * are asserted below rather than described, because assuming the opposite is
+ * exactly what made these stories wrong.
+ */
+const TYPED_EMAIL = 'lena.weber@sunrisevet.example ';
+const NORMALIZED_EMAIL = 'lena.weber@sunrisevet.example';
+
+/**
+ * The confirmation sentence, written once and asserted from both the resolved
+ * and the rejected story. One constant rather than two copies on purpose: the
+ * guarantee under review is that those two code paths are indistinguishable, and
+ * two literals could drift apart without either story failing.
+ */
+const SENT_COPY =
+  `If an account exists for ${NORMALIZED_EMAIL}, we have sent a link to reset your password. ` +
+  'It expires soon, so use it while it is fresh.';
+
+/**
+ * Seeds the marketing-stats session cache that the auth brand panel reads through
+ * `useGithubStats`. The hook returns before fetching while the cache is inside its
+ * 5 minute TTL and already holds a `discord` string, so seeding it keeps the mount
+ * off `/api/community/*` - which under Storybook is a 404 - and pins the star pill
+ * to a fixed number instead of one that differs between two Chromatic runs.
+ */
+const seedGithubStats = () => {
+  setJsonStorageItem('session', 'yc_marketing_stats_v2', {
+    stars: '2.4k',
+    starsFull: '2,431',
+    repositoryClones: '67,134',
+    contributors: '38',
+    discord: '1,204',
+  });
+  setStorageItem('session', 'yc_marketing_stats_ts_v2', String(Date.now()));
+};
+
+/**
+ * Replaces the store's own `forgotPassword` and restores it on unmount. The page
+ * pulls the action straight off the real zustand store, so this one swap is the
+ * whole seam: no module mock, no request, and the component being reviewed is the
+ * shipped one.
+ */
+const withForgotPassword = (forgotPassword: () => Promise<{ status: 'OK' } | null>) => {
+  return () => {
+    const previous = useAuthStore.getState().forgotPassword;
+    useAuthStore.setState({ forgotPassword });
+    return () => useAuthStore.setState({ forgotPassword: previous });
+  };
+};
+
+const withSuccessfulSend = withForgotPassword(() => Promise.resolve({ status: 'OK' }));
+
+/**
+ * SuperTokens' account-takeover protection. It is a REJECTION, not a resolution,
+ * and the page has to treat it exactly like a send - so this story exists to prove
+ * the two produce the same pixels.
+ */
+const withBlockedSend = withForgotPassword(() =>
+  Promise.reject(
+    Object.assign(new Error('Password reset is not allowed for this account'), {
+      code: 'PASSWORD_RESET_NOT_ALLOWED',
+    })
+  )
+);
+
+/** Types the address and submits, leaving the confirmation panel on screen. */
+const requestResetLink = async (canvasElement: HTMLElement) => {
+  const canvas = within(canvasElement);
+  const field = canvas.getByRole('textbox', { name: 'Work email' });
+  await userEvent.type(field, TYPED_EMAIL);
+
+  /* The trailing space is already gone, before anything of ours has run. This is
+     the `type="email"` value sanitization algorithm, not `normalizeEmail`: the
+     input strips leading and trailing whitespace as the value is set, so the
+     controlled state React stores is the trimmed string. Pinned here so the
+     panel's trimmed address is never mistaken for proof that our own
+     normalisation is wired up - it would read identically if it were not. */
+  await expect(field).toHaveValue(NORMALIZED_EMAIL);
+
+  await userEvent.click(canvas.getByRole('button', { name: 'Send reset link' }));
+};
+
+/**
+ * Every visible property of the confirmation panel, asserted the same way from
+ * both stories that can produce it. Anything that is only checked in one of them
+ * is a place the two paths are free to diverge.
+ */
+const assertConfirmationPanel = async (canvasElement: HTMLElement) => {
+  const canvas = within(canvasElement);
+  const panel = await canvas.findByTestId('forgot-sent');
+
+  // Badge: 52px square, read off the box rather than the content box, which
+  // would report short the moment anyone gives this pill a border.
+  const badge = panel.firstElementChild as HTMLElement;
+  await expect(badge.getBoundingClientRect().width).toBe(52);
+  await expect(badge.getBoundingClientRect().height).toBe(52);
+
+  await expect(canvas.getByRole('heading', { name: 'Check your email' })).toBeInTheDocument();
+
+  /* The address is the trimmed one - though the input had already trimmed it (see
+     `requestResetLink`), so this is a pin on what the panel echoes back, not on
+     `normalizeEmail`. Asserting the tag as well as the text pins the emphasis:
+     the address is the one bolded thing in an otherwise hedged sentence. */
+  const address = within(panel).getByText(NORMALIZED_EMAIL);
+  await expect(address.tagName).toBe('STRONG');
+
+  /* The neutrality is the feature. This exact sentence - conditional, no claim
+     that an account was found - is what stops the page being an
+     account-existence oracle, so both stories assert the whole of it rather than
+     that "some copy appeared". */
+  await expect(address.parentElement as HTMLElement).toHaveTextContent(SENT_COPY);
+
+  // The form is replaced outright, not hidden behind the panel.
+  await expect(canvas.queryByRole('textbox', { name: 'Work email' })).not.toBeInTheDocument();
+  await expect(canvas.queryByRole('button', { name: 'Send reset link' })).not.toBeInTheDocument();
+  /* Polled, not read once. `AuthShell` animates its whole form column in with
+     `ycUp 0.75s ... 0.12s both`, and `both` means the fill state applies during
+     the DELAY too - so for the first 120ms after mount the wrapper's computed
+     opacity is exactly `0` and jest-dom calls every descendant invisible.
+     `getByRole` does not look at opacity, so the button is FOUND and then
+     reported hidden, which is why this passed alone and failed under a parallel
+     run. `waitFor` settles the entrance instead of dropping the assertion. */
+  const retry = within(panel).getByRole('button', { name: 'try another email' });
+  await waitFor(() => expect(retry).toBeVisible());
+};
+
+const meta = {
+  title: 'Auth/ForgotPassword',
+  component: ForgotPassword,
+  parameters: {
+    layout: 'fullscreen',
+    /* Stops the preview decorator stamping a SECOND `data-yc-app` around the
+       whole canvas. AuthShell already puts that marker on the form column and
+       deliberately leaves the dark brand panel outside it -
+       `body:has([data-yc-app])` still matches, because the shell supplies its
+       own, so the scoped inks resolve exactly as they do in the app. */
+    surface: 'marketing',
+    // The shell's logo, "Back to home" and "Sign in" are all next/link.
+    nextjs: { appDirectory: true, navigation: { pathname: '/forgot-password' } },
+    docs: {
+      description: {
+        component:
+          'Step one of the reset: collect an address, ask SuperTokens to email a tokenized link, ' +
+          'and say so. The new password is set on `/reset-password`, so this page never asks for ' +
+          'a code or a password itself.\n\n' +
+          'The confirmation panel is the interesting half and it had never been drawn. Its copy ' +
+          'is deliberately conditional - **"If an account exists for..."** - because ' +
+          '`sendPasswordResetEmail` resolves the same way for an address that has no account. ' +
+          'Saying "we sent you an email" would turn this form into an account-existence oracle: ' +
+          'anyone could test addresses one at a time and read the answer off the screen.\n\n' +
+          'The same reasoning explains the odd-looking `catch` in `handleSubmit`. ' +
+          '`PASSWORD_RESET_NOT_ALLOWED` is a rejection, and it means the account exists but is ' +
+          'protected - so it is caught and turned into the identical confirmation rather than ' +
+          'surfaced. Two stories below drive those two different code paths and assert the same ' +
+          'panel comes out, which is the only way that guarantee can be reviewed rather than ' +
+          'taken on trust.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  beforeEach: () => {
+    seedGithubStats();
+  },
+} satisfies Meta<typeof ForgotPassword>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Request a link',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { name: 'Reset your password' })).toBeInTheDocument();
+    await expect(
+      canvas.getByText('Enter the email you sign in with and we will send you a reset link.')
+    ).toBeInTheDocument();
+    await expect(canvas.getByRole('textbox', { name: 'Work email' })).toHaveValue('');
+    await expect(canvas.getByRole('button', { name: 'Send reset link' })).toBeEnabled();
+    await expect(canvas.getByRole('link', { name: 'Back to sign in' })).toHaveAttribute(
+      'href',
+      '/signin'
+    );
+    await expect(canvas.queryByTestId('forgot-sent')).not.toBeInTheDocument();
+
+    /* Same shell as sign-in: two tracks, two children, brand column wider
+       (`1.06fr 1fr`). Both counts, because the 940px rule that collapses this to
+       one track only HIDES the brand panel - it stays mounted, so a child count
+       on its own says nothing about which layout is on screen. */
+    const grid = canvasElement.querySelector('[data-authgrid]') as HTMLElement;
+    const tracks = getComputedStyle(grid).gridTemplateColumns.trim().split(/\s+/);
+    await expect(tracks).toHaveLength(2);
+    await expect(grid.children).toHaveLength(2);
+    await expect(parseFloat(tracks[0])).toBeGreaterThan(parseFloat(tracks[1]));
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The single-field form. One address, one button, and a way back to sign-in for the user ' +
+          'who arrived here by mistake.',
+      },
+    },
+  },
+};
+
+export const CheckYourEmail: Story = {
+  name: 'Check your email',
+  beforeEach: withSuccessfulSend,
+  play: async ({ canvasElement }) => {
+    await requestResetLink(canvasElement);
+    await assertConfirmationPanel(canvasElement);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The panel after a successful send. Green badge, "Check your email", and the address in ' +
+          'bold inside a sentence that never confirms the account exists.\n\n' +
+          'One token to watch here: the badge is `var(--success-soft, #e7f4ec)` on ' +
+          '`var(--success, #2f9e63)`, and **`--success-soft` is not defined anywhere in ' +
+          '`globals.css`**. The fallback hex is therefore what always paints, in both themes - ' +
+          'switch the toolbar to dark and the badge stays the light mint while everything around ' +
+          'it goes espresso. `--success` does resolve, so only the fill is stranded.',
+      },
+    },
+  },
+};
+
+export const BlockedSendLooksIdentical: Story = {
+  name: 'Blocked send (identical panel)',
+  beforeEach: withBlockedSend,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await requestResetLink(canvasElement);
+
+    /* The SAME assertions the resolved story runs - badge geometry, heading,
+       bolded trimmed address, the whole sentence, the form gone - driven here by
+       a REJECTED call. Sharing the helper rather than re-checking a subset is
+       the point: anything asserted in only one of the two stories is a place the
+       success and blocked paths are free to diverge unnoticed, and any
+       divergence leaks whether the address is registered. */
+    await assertConfirmationPanel(canvasElement);
+
+    // And nothing extra: no toast, and the SuperTokens reason never reaches the
+    // page. Either would answer the question the panel exists to refuse.
+    await expect(
+      canvas.queryByText('We could not send the reset email. Please try again.')
+    ).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByText('Password reset is not allowed for this account')
+    ).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`PASSWORD_RESET_NOT_ALLOWED` - SuperTokens refusing the reset on an account it is ' +
+          'protecting. It arrives as a rejection with a `reason` that would tell an attacker the ' +
+          'account exists, so the reason is dropped on the floor and the confirmation is shown ' +
+          'instead. Read this story against the one above: they take different code paths and ' +
+          'have to be indistinguishable.',
+      },
+    },
+  },
+};
+
+export const TryAnotherEmail: Story = {
+  name: 'Try another email',
+  beforeEach: withSuccessfulSend,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await requestResetLink(canvasElement);
+
+    const panel = await canvas.findByTestId('forgot-sent');
+    await userEvent.click(within(panel).getByRole('button', { name: 'try another email' }));
+
+    const field = await canvas.findByRole('textbox', { name: 'Work email' });
+    await expect(canvas.queryByTestId('forgot-sent')).not.toBeInTheDocument();
+
+    /* The reset clears `sentTo` and `isSubmitting` and nothing else, so the field
+       comes back holding exactly what the form state held - which is the trimmed
+       address, because `type="email"` sanitized the trailing space away at the
+       keystroke. "Try another email" leaves the last address in place for the
+       user to edit rather than starting from empty. */
+    await expect(field).toHaveValue(NORMALIZED_EMAIL);
+
+    /* And the button is live again. `setIsSubmitting(false)` in that same handler
+       is the only thing preventing a form that returns stuck on a disabled
+       "Sending..." - the success path never resets it, because it never expected
+       to come back. */
+    await expect(canvas.getByRole('button', { name: 'Send reset link' })).toBeEnabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The way back from the confirmation, offered in the footnote under it. It is a plain ' +
+          'button styled as a link inside the "Did not get it? Check spam" line, so a user who ' +
+          'typed the wrong address does not have to reload the page to correct it.\n\n' +
+          'The field comes back holding the address **without** the trailing space that was ' +
+          'typed. That is the `type="email"` value sanitization algorithm, which strips leading ' +
+          'and trailing whitespace as the value is set - `normalizeEmail` never sees the space, ' +
+          'and the trimmed address on the panel above would look the same if that call were ' +
+          'deleted.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/auth/pages/ResetPassword/ResetPassword.stories.tsx
+++ b/apps/frontend/src/app/features/auth/pages/ResetPassword/ResetPassword.stories.tsx
@@ -1,0 +1,230 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, within } from 'storybook/test';
+
+import { setJsonStorageItem, setStorageItem } from '@/app/lib/browserStorage';
+import { useAuthStore } from '@/app/stores/authStore';
+import ResetPassword from './ResetPassword';
+/* Not decoration. `.yc-field`, `.yc-lbl`, `.yc-btn-primary` and `.yc-btn-ghost` all
+   live in marketing.css, which is imported by the (public) ROUTE LAYOUT rather than
+   by any component - Storybook never renders that layout. Without this line the two
+   stacked actions below are unstyled anchors and the "danger badge, heading, copy,
+   two buttons" shape this story exists to review is not what gets drawn. */
+import '../../../marketing/site/marketing.css';
+
+/**
+ * Says what it is in the value itself, so the secret scanners never have to
+ * guess: a plausible-looking password fixture fails the GitGuardian gate, and it
+ * is right to - it cannot tell a fixture from a real one.
+ *
+ * It still has to satisfy the page's own strength regex - lower, upper, digit,
+ * one non-word character, 8+ - or `handleSubmit` returns on validation and never
+ * reaches `resetPassword`, which is the call this story needs to fail. The
+ * trailing `1aA!` is doing that job: `_` alone would not, since it is a word
+ * character as far as `(?=.*[^\w\s])` is concerned.
+ */
+const NEW_PASSWORD = 'EXAMPLE_NOT_A_CREDENTIAL_1aA!';
+
+/**
+ * Seeds the marketing-stats session cache that the auth brand panel reads through
+ * `useGithubStats`. The hook returns before fetching while the cache is inside its
+ * 5 minute TTL and already holds a `discord` string, so seeding it keeps the mount
+ * off `/api/community/*` - which under Storybook is a 404 - and pins the star pill
+ * to a fixed number instead of one that differs between two Chromatic runs.
+ */
+const seedGithubStats = () => {
+  setJsonStorageItem('session', 'yc_marketing_stats_v2', {
+    stars: '2.4k',
+    starsFull: '2,431',
+    repositoryClones: '67,134',
+    contributors: '38',
+    discord: '1,204',
+  });
+  setStorageItem('session', 'yc_marketing_stats_ts_v2', String(Date.now()));
+};
+
+/**
+ * Swaps the store's own `resetPassword` for a rejection, and puts the real one back
+ * when the story unmounts. The page reads the action out of the real zustand store,
+ * so this is the whole seam - no module mock, no MSW, and the component under review
+ * is the shipped one rather than a copy wired to a stub.
+ *
+ * The `code` is what matters. `handleSubmit` only shows the expired panel for
+ * `RESET_PASSWORD_INVALID_TOKEN_ERROR`; every other rejection falls through to a
+ * toast and leaves the form standing, so a plain `new Error(...)` here would draw
+ * the wrong state under the right story name.
+ */
+const withInvalidToken = () => {
+  const { resetPassword } = useAuthStore.getState();
+  useAuthStore.setState({
+    resetPassword: () =>
+      Promise.reject(
+        Object.assign(new Error('Reset token is invalid or expired'), {
+          code: 'RESET_PASSWORD_INVALID_TOKEN_ERROR',
+        })
+      ),
+  });
+  return () => useAuthStore.setState({ resetPassword });
+};
+
+/** Fills both fields with a password that clears the strength regex and matches. */
+const submitNewPassword = async (canvasElement: HTMLElement) => {
+  const canvas = within(canvasElement);
+  await userEvent.type(canvas.getByLabelText('New password'), NEW_PASSWORD);
+  await userEvent.type(canvas.getByLabelText('Confirm password'), NEW_PASSWORD);
+  await userEvent.click(canvas.getByRole('button', { name: 'Reset password' }));
+};
+
+const meta = {
+  title: 'Auth/ResetPassword',
+  component: ResetPassword,
+  parameters: {
+    layout: 'fullscreen',
+    /* Stops the preview decorator stamping a SECOND `data-yc-app` around the
+       whole canvas. AuthShell already puts that marker on the form column and
+       deliberately leaves the dark brand panel outside it -
+       `body:has([data-yc-app])` still matches, because the shell supplies its
+       own, so the scoped inks resolve exactly as they do in the app. */
+    surface: 'marketing',
+    // The success path pushes /signin through useRouter two seconds after the
+    // store resolves, so the App Router mock has to be mounted.
+    nextjs: { appDirectory: true, navigation: { pathname: '/reset-password' } },
+    docs: {
+      description: {
+        component:
+          'The page the emailed reset link lands on. SuperTokens keeps the token in the URL and ' +
+          '`submitNewPassword` reads it from there, so the form itself only collects a password ' +
+          'twice - it never sees or shows the token.\n\n' +
+          'That is why the failure state is a whole panel rather than a field error: by the time ' +
+          'the token turns out to be spent or expired the user has already typed a valid ' +
+          'password twice, and there is nothing on this page they can correct. `linkInvalid` ' +
+          'therefore replaces the form outright with a dead end plus two ways out.\n\n' +
+          'It is reachable only through a rejected `resetPassword` call carrying ' +
+          '`RESET_PASSWORD_INVALID_TOKEN_ERROR`, which is why it had never been drawn: no prop, ' +
+          'no route and no fixture reaches it. The story below gets there by swapping that one ' +
+          'action on the real auth store.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  beforeEach: () => {
+    seedGithubStats();
+  },
+} satisfies Meta<typeof ResetPassword>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Set a new password',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const password = canvas.getByLabelText('New password');
+    const confirm = canvas.getByLabelText('Confirm password');
+
+    await expect(canvas.getByRole('heading', { name: 'Set a new password' })).toBeInTheDocument();
+    await expect(
+      canvas.getByText('Choose a strong password you have not used here before.')
+    ).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Reset password' })).toBeEnabled();
+    await expect(canvas.queryByTestId('reset-invalid')).not.toBeInTheDocument();
+
+    // Both start masked, and each field owns its own toggle.
+    await expect(password).toHaveAttribute('type', 'password');
+    await expect(confirm).toHaveAttribute('type', 'password');
+    const toggles = canvas.getAllByRole('button', { name: 'Show password' });
+    await expect(toggles).toHaveLength(2);
+
+    /* The independence is the thing worth reviewing and it is invisible in the
+       markup: `showPassword` and `showConfirm` are two pieces of state, so
+       revealing the first field must leave the second masked. A shared flag -
+       which is what the sign-up page does - would pass every assertion above
+       and fail this one. */
+    await userEvent.click(toggles[0]);
+    await expect(password).toHaveAttribute('type', 'text');
+    await expect(confirm).toHaveAttribute('type', 'password');
+    await expect(canvas.getAllByRole('button', { name: 'Show password' })).toHaveLength(1);
+    await expect(canvas.getByRole('button', { name: 'Hide password' })).toBeInTheDocument();
+
+    /* Same shell as sign-in: two tracks, two children, brand column wider
+       (`1.06fr 1fr`). Both counts, because the 940px rule that collapses this to
+       one track only HIDES the brand panel - it stays mounted, so a child count
+       on its own says nothing about which layout is on screen. Auth/SignIn's
+       phone story is the collapsed reading. */
+    const grid = canvasElement.querySelector('[data-authgrid]') as HTMLElement;
+    const tracks = getComputedStyle(grid).gridTemplateColumns.trim().split(/\s+/);
+    await expect(tracks).toHaveLength(2);
+    await expect(grid.children).toHaveLength(2);
+    await expect(parseFloat(tracks[0])).toBeGreaterThan(parseFloat(tracks[1]));
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The form as the link opens it. Both fields carry their own eye toggle with independent ' +
+          'state, so revealing one does not reveal the other - deliberate on a confirm pair, ' +
+          'since the point of the second field is that it was typed rather than copied.',
+      },
+    },
+  },
+};
+
+export const LinkExpired: Story = {
+  name: 'Reset link expired',
+  beforeEach: withInvalidToken,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await submitNewPassword(canvasElement);
+
+    const panel = await canvas.findByTestId('reset-invalid');
+
+    /* The badge is the first thing in the panel and the only danger-tinted element
+       on the page. 52px square via getBoundingClientRect, not getComputedStyle:
+       the latter reports the content box, which would read short the moment anyone
+       gives this pill a border. */
+    const badge = panel.firstElementChild as HTMLElement;
+    await expect(badge.getBoundingClientRect().width).toBe(52);
+    await expect(badge.getBoundingClientRect().height).toBe(52);
+
+    await expect(canvas.getByRole('heading', { name: 'Reset link expired' })).toBeInTheDocument();
+    await expect(
+      within(panel).getByText(
+        'This password reset link is invalid or has expired. Request a new one to continue.'
+      )
+    ).toBeInTheDocument();
+
+    const request = within(panel).getByRole('link', { name: 'Request new link' });
+    const back = within(panel).getByRole('link', { name: 'Back to sign in' });
+    await expect(request).toHaveAttribute('href', '/forgot-password');
+    await expect(back).toHaveAttribute('href', '/signin');
+
+    /* Stacked and equal, not a side-by-side pair: the column is `flex-direction:
+       column` and both actions are `width: 100%` with `box-sizing: border-box`, so
+       the ghost button and the primary must measure the same despite one having a
+       border and the other not. That equality is the whole reason box-sizing is set
+       there, and it is invisible in the markup. */
+    const column = request.parentElement as HTMLElement;
+    await expect(getComputedStyle(column).flexDirection).toBe('column');
+    await expect(request.getBoundingClientRect().width).toBe(back.getBoundingClientRect().width);
+    await expect(Math.round(request.getBoundingClientRect().width)).toBe(
+      Math.round(column.getBoundingClientRect().width)
+    );
+
+    // The form is gone, not merely covered - there is nothing left to resubmit.
+    await expect(canvas.queryByLabelText('New password')).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Reset password' })).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'What a spent or expired link produces after a valid password was already typed twice. ' +
+          'The primary action goes back to `/forgot-password` to mint a new link rather than ' +
+          'retrying this one, and the ghost action leads to sign-in for the user who has ' +
+          'remembered their password in the meantime.\n\n' +
+          'Note what does not happen: no toast. The other rejection paths on this page raise ' +
+          'one, but an expired link is not a transient error the user can retry through, so it ' +
+          'takes over the column instead of floating above it.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/auth/pages/SignIn/SignIn.stories.tsx
+++ b/apps/frontend/src/app/features/auth/pages/SignIn/SignIn.stories.tsx
@@ -1,0 +1,335 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import { setJsonStorageItem, setStorageItem } from '@/app/lib/browserStorage';
+import SignIn from './SignIn';
+/* Not decoration. Every class this page uses - `.yc-field`, `.yc-lbl`,
+   `.yc-btn-primary`, `.yc-switch` - and the 940px rule that drops the brand panel
+   live in marketing.css, which is imported by the (public) ROUTE LAYOUT rather than
+   by any component. Storybook never renders that layout, so without this line the
+   story draws user-agent inputs and the phone story below would still show two
+   columns. Relative, matching the other marketing stories. */
+import '../../../marketing/site/marketing.css';
+
+/**
+ * Seeds the marketing-stats session cache that the auth brand panel reads through
+ * `useGithubStats`. The hook returns before fetching while the cache is inside its
+ * 5 minute TTL and already holds a `discord` string, so seeding it keeps the mount
+ * off `/api/community/*` - which under Storybook is a 404 - and pins the star pill
+ * to a fixed number instead of one that differs between two Chromatic runs.
+ */
+const seedGithubStats = () => {
+  setJsonStorageItem('session', 'yc_marketing_stats_v2', {
+    stars: '2.4k',
+    starsFull: '2,431',
+    repositoryClones: '67,134',
+    contributors: '38',
+    discord: '1,204',
+  });
+  setStorageItem('session', 'yc_marketing_stats_ts_v2', String(Date.now()));
+};
+
+/**
+ * The AuthShell skeleton, read off the DOM rather than assumed from the markup.
+ *
+ * The form column is queried as a DIRECT CHILD of the grid on purpose. The
+ * preview decorator stamps `data-yc-app` on its own wrapper `<main>` for every
+ * story that does not opt out, so a bare `querySelector('[data-yc-app]')`
+ * returns the DECORATOR, not the column - and the decorator wraps the grid, so
+ * comparing its width to the grid's passes at every breakpoint and proves
+ * nothing. `surface: 'marketing'` below turns that stamp off as well; the scoped
+ * selector is the belt to its braces.
+ */
+const readShell = (canvasElement: HTMLElement) => {
+  const grid = canvasElement.querySelector('[data-authgrid]') as HTMLElement;
+  return {
+    grid,
+    formColumn: grid.querySelector(':scope > [data-yc-app]') as HTMLElement,
+    brandPanel: grid.querySelector(':scope > [data-brandpanel]') as HTMLElement,
+    tracks: getComputedStyle(grid).gridTemplateColumns.trim().split(/\s+/),
+  };
+};
+
+/**
+ * What `--screen` actually paints, resolved through a throwaway element instead
+ * of being compared against a hex literal - the token flips with the toolbar
+ * theme, so a hard-coded `rgb(247, 243, 236)` would pin the story to light mode.
+ *
+ * It mutates the DOM, so it is called BEFORE the waitFor that uses its result
+ * and never from inside one: testing-library retries a waitFor callback through
+ * a MutationObserver, and a callback that appends a node then throws re-queues
+ * itself forever and wedges the tab instead of failing.
+ */
+const readScreenToken = (canvasElement: HTMLElement) => {
+  const probe = document.createElement('span');
+  probe.style.background = 'var(--screen)';
+  canvasElement.appendChild(probe);
+  const painted = getComputedStyle(probe).backgroundColor;
+  probe.remove();
+  return painted;
+};
+
+const meta = {
+  title: 'Auth/SignIn',
+  component: SignIn,
+  parameters: {
+    layout: 'fullscreen',
+    /* Stops the preview decorator stamping a SECOND `data-yc-app` around the
+       whole canvas. AuthShell already puts that marker on the form column and
+       deliberately leaves the dark brand panel outside it, so the decorator's
+       wrapper would widen a scope the page is careful to keep narrow - and
+       `body:has([data-yc-app])` still matches, because the shell supplies its
+       own. This is what the app actually renders. */
+    surface: 'marketing',
+    /* Not optional here. `SignInForm` reads `email` and `next` from
+       `useSearchParams` during its first render and pushes through `useRouter`
+       after a successful sign in, so without the App Router mock the component
+       throws before it paints. `query` is what the searchParams mock is built
+       from - an empty one is the plain /signin entry. */
+    nextjs: { appDirectory: true, navigation: { pathname: '/signin', query: {} } },
+    docs: {
+      description: {
+        component:
+          'The sign-in page for both products. The segmented **Account type** control at the top ' +
+          'is the whole story: it is local state, not a route, so `/signin` renders either of two ' +
+          'quite different pages and only one of them had ever been drawn.\n\n' +
+          'Picking **Developer** rewrites four things at once - the page heading loses its ' +
+          'italic-word treatment and becomes the plain sentence "Sign in to your developer ' +
+          'account", the brand eyebrow turns teal, the headline changes possessive ("where your ' +
+          'clinic" to "where you"), and the three brand points are re-ordered with the offline ' +
+          'point demoted. It also decides the `devAuth` session flag and therefore where ' +
+          '`resolvePostAuthRedirect` lands after the password is accepted.\n\n' +
+          'What it cannot show is the fifth change: `GithubSignInButton` mounts under the form in ' +
+          'the developer branch, but it returns `null` unless `NEXT_PUBLIC_AUTH_GITHUB_ENABLED` ' +
+          'is `true` and this app ships no `.env`, so it is absent from Storybook. The developer ' +
+          'story asserts that absence rather than implying the button was reviewed.\n\n' +
+          'Sign-in validation is submit-time and covers exactly two fields, so the error state is ' +
+          'two messages wide - a much smaller surface than sign-up, and the reason a wrong ' +
+          'password produces a toast rather than an inline error.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  beforeEach: () => {
+    seedGithubStats();
+  },
+} satisfies Meta<typeof SignIn>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Pet business (default)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole('radio', { name: 'Pet business' })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
+    await expect(canvas.getByRole('heading', { name: 'Welcome back' })).toBeInTheDocument();
+    await expect(canvas.getByRole('heading', { level: 2 }).textContent).toBe(
+      'Pick up where your clinic left off.'
+    );
+    await expect(
+      canvas.getByText('Works on the worst afternoon. Even offline.')
+    ).toBeInTheDocument();
+
+    /* The desktop skeleton, measured rather than assumed: two tracks, two
+       children, brand column the wider of the pair (1.06fr against 1fr). Track
+       count alone is not enough - a rule that collapsed the grid would leave
+       both children mounted and every copy assertion above would still pass -
+       and child count alone is not enough either, since the 940px rule keeps
+       the brand panel mounted and only hides it. This is the reading the phone
+       story below is meant to be compared against. */
+    const { grid, tracks } = readShell(canvasElement);
+    await expect(tracks).toHaveLength(2);
+    await expect(grid.children).toHaveLength(2);
+    await expect(parseFloat(tracks[0])).toBeGreaterThan(parseFloat(tracks[1]));
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The default branch, the one every clinic sees. `isDeveloper` is a prop as well as a ' +
+          'toggle, so `/developers/signin` renders the other branch from the first paint - but ' +
+          'plain `/signin` always opens here.',
+      },
+    },
+  },
+};
+
+export const DeveloperBranch: Story = {
+  name: 'Developer branch',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const business = canvas.getByRole('radio', { name: 'Pet business' });
+    const developer = canvas.getByRole('radio', { name: 'Developer' });
+    // Read before the click and before the waitFor: it appends a probe node.
+    const screenToken = readScreenToken(canvasElement);
+
+    await userEvent.click(developer);
+
+    await expect(developer).toHaveAttribute('aria-checked', 'true');
+    await expect(business).toHaveAttribute('aria-checked', 'false');
+
+    /* The selected pill is drawn ONLY by its background - `--screen` against the
+       `--inset` trough - and that background is transitioned over 150ms
+       (`transition: background 150ms ease` on the option style), so both reads
+       go inside one waitFor. A single synchronous read catches the half-faded
+       value on whichever pill is moving and fails on a page that is rendering
+       perfectly. The assertion is the exact token, not "something other than
+       transparent": a pill that landed on the wrong surface colour would still
+       pass that weaker check while being invisible against the trough. */
+    await waitFor(() => {
+      expect(getComputedStyle(developer).backgroundColor).toBe(screenToken);
+      expect(getComputedStyle(business).backgroundColor).toBe('rgba(0, 0, 0, 0)');
+    });
+
+    // The heading loses the italic-word construction entirely in this branch.
+    await expect(
+      canvas.getByRole('heading', { name: 'Sign in to your developer account' })
+    ).toBeInTheDocument();
+    await expect(canvas.queryByRole('heading', { name: 'Welcome back' })).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(canvas.getByRole('heading', { level: 2 }).textContent).toBe(
+        'Pick up where you left off.'
+      );
+    });
+    await expect(canvas.getByText('Open-source developer platform')).toBeInTheDocument();
+    await expect(
+      canvas.queryByText('Open-source operating system for animal health')
+    ).not.toBeInTheDocument();
+
+    /* Only ONE of the three points is genuinely new. "A FHIR-native API..." and
+       "Free to self-host..." appear in both lists and are re-ordered rather than
+       replaced, so asserting the arrival of the developer point AND the departure
+       of the offline one is what actually proves the list swapped. */
+    await expect(
+      canvas.getByText('Open source. Read it, run it locally, send a PR.')
+    ).toBeInTheDocument();
+    await expect(
+      canvas.queryByText('Works on the worst afternoon. Even offline.')
+    ).not.toBeInTheDocument();
+    await expect(
+      canvas.getByText('A FHIR-native API and a codebase you can actually read.')
+    ).toBeInTheDocument();
+
+    // The form itself never changes - same two fields, same submit, same subtitle.
+    await expect(canvas.getByRole('textbox', { name: 'Work email' })).toBeInTheDocument();
+    await expect(canvas.getByLabelText('Password')).toBeInTheDocument();
+    await expect(
+      canvas.getByText('Sign in to your clinic or developer workspace.')
+    ).toBeInTheDocument();
+
+    /* Env-gated: `isGithubSignInEnabled()` reads NEXT_PUBLIC_AUTH_GITHUB_ENABLED
+       and no .env in this app sets it, so the "or / Continue with GitHub" block
+       below the submit button renders nothing here. Asserted so the story does not
+       quietly claim to have drawn it. */
+    await expect(
+      canvas.queryByRole('button', { name: 'Continue with GitHub' })
+    ).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByText('GitHub is available for developer accounts.')
+    ).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'After clicking **Developer**. Everything that moves is on the left, plus the page ' +
+          'heading; the form is byte-identical between the two branches, which is why the ' +
+          'segmented control has to carry the whole signal.',
+      },
+    },
+  },
+};
+
+export const ValidationErrors: Story = {
+  name: 'Empty submit (two errors)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.queryAllByRole('alert')).toHaveLength(0);
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Sign in' }));
+
+    const alerts = await canvas.findAllByRole('alert');
+    await expect(alerts.map((alert) => alert.textContent)).toEqual([
+      'Email is required',
+      'Password is required',
+    ]);
+
+    const email = canvas.getByRole('textbox', { name: 'Work email' });
+    const password = canvas.getByLabelText('Password');
+    await expect(email).toHaveAttribute('aria-invalid', 'true');
+    await expect(email).toHaveAttribute('aria-describedby', 'signin-email-error');
+    await expect(password).toHaveAttribute('aria-describedby', 'signin-password-error');
+
+    /* Proof that the guard ran before the request rather than after a rejection:
+       `handleSignIn` returns ahead of `setIsSubmitting(true)`, so the fullscreen
+       loader never mounts and the button never reads "Signing in...". */
+    await expect(canvas.queryByTestId('signin-loader')).not.toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Sign in' })).toBeEnabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Submitting with both fields empty. Only presence and email shape are checked here - ' +
+          'a wrong password is a server answer, and it arrives as a toast over the top of the ' +
+          'page rather than as an inline message, so this two-line block is the most inline ' +
+          'error this page can ever show.\n\n' +
+          'The "Forgot password?" link sits in the label row of the password field, so it stays ' +
+          'put when the error appears underneath rather than being pushed around by it.',
+      },
+    },
+  },
+};
+
+export const Phone: Story = {
+  name: 'Phone (375)',
+  // Pinned as a GLOBAL. `parameters.viewport.defaultViewport` was removed in
+  // Storybook 10: it still type-checks and still renders, at the full panel width,
+  // under a name that promises a phone. `mobile` is the 375px preset in preview.ts.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* The shell is a two-column grid on desktop; the point of this story is
+       which column survives at 375px. Read the geometry rather than trusting the
+       class - and read all three facts, because each one alone is satisfiable by
+       a broken page: ONE track (the 940px rule rewrites `1.06fr 1fr` to `1fr`),
+       still TWO children (the brand panel is `display: none`, not unmounted, so
+       nothing about its content is proven by its absence from a query), and the
+       form column filling the grid, which is only true once the panel is out of
+       the flow. */
+    const { grid, formColumn, brandPanel, tracks } = readShell(canvasElement);
+    await expect(tracks).toHaveLength(1);
+    await expect(grid.children).toHaveLength(2);
+    await expect(brandPanel).not.toBeVisible();
+    // getBoundingClientRect, not getComputedStyle().width: the latter is the
+    // content box and would read short of the grid's own width on any padded or
+    // bordered ancestor.
+    await expect(formColumn.getBoundingClientRect().width).toBe(grid.getBoundingClientRect().width);
+
+    await expect(canvas.getByRole('radio', { name: 'Developer' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Sign in' })).toBeInTheDocument();
+
+    // The header prompt is dropped by `[data-hide-s]` at 620px while the link it
+    // introduces stays, so the row reads as a bare "Sign up" rather than wrapping.
+    await expect(canvas.getByText('New to Yosemite Crew?')).not.toBeVisible();
+    await expect(canvas.getByRole('link', { name: 'Sign up' })).toBeVisible();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'At phone width the brand panel is out of the flow and the form column owns the whole ' +
+          'screen, so the segmented control and the two fields are all that is left. Worth ' +
+          'keeping a story on: every piece of copy that sells the product lives in the column ' +
+          'that disappears here.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/auth/pages/SignUp/SignUp.stories.tsx
+++ b/apps/frontend/src/app/features/auth/pages/SignUp/SignUp.stories.tsx
@@ -1,0 +1,257 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import { removeStorageItem, setJsonStorageItem, setStorageItem } from '@/app/lib/browserStorage';
+import SignUp from './SignUp';
+/* Not decoration. Every class this page uses - `.yc-field`, `.yc-lbl`,
+   `.yc-btn-primary`, `.yc-switch` - and both keyframe sets the shell animates with
+   live in marketing.css, which is imported by the (public) ROUTE LAYOUT rather than
+   by any component. Storybook never renders that layout, so without this line the
+   story draws user-agent inputs and unstyled buttons, and the 940px rule that drops
+   the brand panel never applies. Relative, matching the other marketing stories. */
+import '../../../marketing/site/marketing.css';
+
+const CLINIC_ROLE = 'A veterinary clinic, practice, or hospital';
+const DEVELOPER_ROLE = 'A developer';
+
+/**
+ * Seeds the marketing-stats session cache that the auth brand panel reads through
+ * `useGithubStats`. The hook returns before fetching while the cache is inside its
+ * 5 minute TTL and already holds a `discord` string, so seeding it keeps the mount
+ * off `/api/community/*` - which under Storybook is a 404 - and pins the star pill
+ * to a fixed number instead of one that differs between two Chromatic runs.
+ */
+const seedGithubStats = () => {
+  setJsonStorageItem('session', 'yc_marketing_stats_v2', {
+    stars: '2.4k',
+    starsFull: '2,431',
+    repositoryClones: '67,134',
+    contributors: '38',
+    discord: '1,204',
+  });
+  setStorageItem('session', 'yc_marketing_stats_ts_v2', String(Date.now()));
+};
+
+/**
+ * `useSignUpDraft` restores first name / last name / email from sessionStorage on
+ * mount and rewrites the entry on every keystroke, so the draft survives a trip to
+ * the Terms page. Storybook runs every story in ONE tab, which means a story that
+ * types a name leaves it behind for whichever story renders next: without this the
+ * empty-form story below would submit a half-filled form and draw four errors
+ * instead of six, and which four would depend on the order stories were opened in.
+ */
+const clearSignUpDraft = () => {
+  removeStorageItem('session', 'yc_signup_draft');
+};
+
+const meta = {
+  title: 'Auth/SignUp',
+  component: SignUp,
+  parameters: {
+    layout: 'fullscreen',
+    /* Stops the preview decorator stamping a SECOND `data-yc-app` around the
+       whole canvas. AuthShell already puts that marker on the form column and
+       deliberately leaves the dark brand panel outside it, so the decorator's
+       wrapper would widen a scope the page keeps narrow on purpose -
+       `body:has([data-yc-app])` still matches, because the shell supplies its
+       own. This is what the app actually renders. */
+    surface: 'marketing',
+    // Every render mounts a closed OtpModal, which holds a router, and the shell's
+    // logo, Terms and Privacy links are all next/link - so the App Router mock has
+    // to be on even though no story here gets as far as a redirect.
+    nextjs: { appDirectory: true, navigation: { pathname: '/signup' } },
+    docs: {
+      description: {
+        component:
+          'The clinic and developer sign-up page. Two of its states had never been drawn: the ' +
+          'form after a failed submit, and the developer pane.\n\n' +
+          '**Validation is submit-time only.** Nothing is checked while typing - `handleSignUp` ' +
+          'runs `validateSignUpInputs` on submit and returns before `setIsSubmitting(true)`, so a ' +
+          'rejected form never touches SuperTokens. Each field then clears its own error on the ' +
+          'next keystroke, which is why the six errors are a single moment rather than a state ' +
+          'the page rests in.\n\n' +
+          '**The "I am" select rewrites the left-hand panel, not the form.** `effectiveDeveloper` ' +
+          'swaps the eyebrow, the headline and all three brand points, and the same flag decides ' +
+          'the fifth argument passed to `signUp` (`developer`) and the `devAuth` session flag read ' +
+          'later by `DevRouteGuard`. The form fields themselves are identical in both branches.\n\n' +
+          'The one thing these stories cannot show is the "Continue with GitHub" button under the ' +
+          'form: `GithubSignInButton` returns `null` unless `NEXT_PUBLIC_AUTH_GITHUB_ENABLED` is ' +
+          '`true`, and there is no `.env` in this app, so it is absent from Storybook in both ' +
+          'branches. That absence is asserted rather than glossed over.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  beforeEach: () => {
+    seedGithubStats();
+    clearSignUpDraft();
+  },
+} satisfies Meta<typeof SignUp>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Clinic pane (default)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const role = canvas.getByRole('combobox', { name: 'I am' });
+    await expect(role).toHaveValue(CLINIC_ROLE);
+
+    // The brand panel is the only h2 on the page; the two h1s are the page heading
+    // and the preview decorator's sr-only landmark title, so read this by level.
+    await expect(canvas.getByRole('heading', { level: 2 }).textContent).toBe(
+      'See the whole animal.'
+    );
+    await expect(
+      canvas.getByText('Open-source operating system for animal health')
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByText('Appointments, records, and billing on one screen.')
+    ).toBeInTheDocument();
+
+    // Nothing has been submitted, so no field carries an error yet.
+    await expect(canvas.queryAllByRole('alert')).toHaveLength(0);
+
+    /* The shell skeleton, measured rather than assumed: two tracks and two
+       children at the default laptop width, brand column the wider of the pair
+       (`1.06fr 1fr`). Track count alone would not catch a collapse - the 940px
+       rule leaves both children mounted and only hides the brand panel, so
+       every copy assertion above would still pass on a one-column page. */
+    const grid = canvasElement.querySelector('[data-authgrid]') as HTMLElement;
+    const tracks = getComputedStyle(grid).gridTemplateColumns.trim().split(/\s+/);
+    await expect(tracks).toHaveLength(2);
+    await expect(grid.children).toHaveLength(2);
+    await expect(parseFloat(tracks[0])).toBeGreaterThan(parseFloat(tracks[1]));
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting page a clinic lands on. Six controls, the Terms checkbox, and the clinic ' +
+          'copy on the left. The baseline the two stories below are read against.',
+      },
+    },
+  },
+};
+
+export const ValidationErrors: Story = {
+  name: 'Empty submit (six errors)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.queryAllByRole('alert')).toHaveLength(0);
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Create account' }));
+
+    /* Order matters as much as the text. The six alerts are read in document order,
+       so this pins WHICH field each message landed under - a validator that returned
+       the right set of strings against the wrong keys would still put "Last name is
+       required" beneath the first-name input, and a set-based assertion would pass. */
+    const alerts = await canvas.findAllByRole('alert');
+    await expect(alerts.map((alert) => alert.textContent)).toEqual([
+      'First name is required',
+      'Last name is required',
+      'Email is required',
+      'Password is required',
+      'Confirm Password is required',
+      'Please check the Terms and Conditions box',
+    ]);
+
+    // The five text controls are wired to their message by id, so a screen reader
+    // reads the error with the field rather than only when the alert fires.
+    const email = canvas.getByRole('textbox', { name: 'Enter email' });
+    await expect(email).toHaveAttribute('aria-invalid', 'true');
+    await expect(email).toHaveAttribute('aria-describedby', 'signup-email-error');
+    await expect(canvasElement.querySelector('#signup-email-error')?.textContent).toBe(
+      'Email is required'
+    );
+
+    /* The submit returned BEFORE `setIsSubmitting(true)`, so no request was made:
+       the loader never mounted and the button is still idle. Without these two the
+       story would pass just as happily on a page that had called SuperTokens,
+       failed, and painted the same six messages. */
+    await expect(canvas.queryByTestId('signup-loader')).not.toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Create account' })).toBeEnabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Submitting the empty form. Five of the six messages sit inside their field group and ' +
+          'are referenced by `aria-describedby`; the sixth, under the Terms checkbox, is a bare ' +
+          '`FieldError` with no `id` - the checkbox has neither `aria-invalid` nor a ' +
+          '`aria-describedby` pointing at it, so that one message is announced only by its ' +
+          '`role="alert"` and is not attached to the control it is about.\n\n' +
+          'Password and confirm-password are also a pair rather than two independent checks: with ' +
+          'both empty you get both messages, but a password that fails the strength regex ' +
+          'suppresses the confirm message entirely, so this is the widest the error block ever ' +
+          'gets.',
+      },
+    },
+  },
+};
+
+export const DeveloperPane: Story = {
+  name: 'Developer pane',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { level: 2 }).textContent).toBe(
+      'See the whole animal.'
+    );
+
+    await userEvent.selectOptions(canvas.getByRole('combobox', { name: 'I am' }), DEVELOPER_ROLE);
+
+    // Re-queried inside the waitFor rather than held from before the swap: the
+    // headline is rebuilt around a different <em>, and the assertion should fail
+    // on the text, not on a stale node reference.
+    await waitFor(() => {
+      expect(canvas.getByRole('heading', { level: 2 }).textContent).toBe(
+        'Build it in an afternoon.'
+      );
+    });
+
+    await expect(canvas.getByText('Open-source developer platform')).toBeInTheDocument();
+    await expect(
+      canvas.queryByText('Open-source operating system for animal health')
+    ).not.toBeInTheDocument();
+
+    // All three points are replaced, not just re-ordered - SignUp shares no point
+    // copy between the two branches.
+    for (const point of [
+      'REST and FHIR APIs, typed SDKs, and webhooks.',
+      'Open source. Read it, run it locally, send a PR.',
+      'Ship plugins to the marketplace. Reach every clinic.',
+    ]) {
+      await expect(canvas.getByText(point)).toBeInTheDocument();
+    }
+    await expect(
+      canvas.queryByText('Appointments, records, and billing on one screen.')
+    ).not.toBeInTheDocument();
+
+    // The form is untouched: same six controls, same labels, same submit.
+    await expect(canvas.getByRole('textbox', { name: 'First name' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Create account' })).toBeInTheDocument();
+
+    /* Env-gated, so it is absent here rather than merely unstyled. This is the one
+       piece of the developer branch Storybook cannot draw - `isGithubSignInEnabled()`
+       reads NEXT_PUBLIC_AUTH_GITHUB_ENABLED, which no .env in this app sets. */
+    await expect(
+      canvas.queryByRole('button', { name: 'Continue with GitHub' })
+    ).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Changing "I am" to **A developer**. The right-hand form does not move - same six ' +
+          'controls, same Terms line - while the entire left panel is rewritten: teal eyebrow, ' +
+          'a different headline word, and three developer points in place of the clinic ones.\n\n' +
+          'The same flag also changes what is sent: `signUp` gains a fifth `developer` argument ' +
+          'and `devAuth` is written to session storage, which is what routes the account to ' +
+          '`/developers/home` after verification. None of that is visible here, which is exactly ' +
+          'why the pane swap is the only signal the user gets that they picked the other product.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/auth/pages/VerifyEmail/VerifyEmail.stories.tsx
+++ b/apps/frontend/src/app/features/auth/pages/VerifyEmail/VerifyEmail.stories.tsx
@@ -1,0 +1,243 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import { useAuthStore } from '@/app/stores/authStore';
+import VerifyEmail from './VerifyEmail';
+
+type VerifyResult = 'OK' | 'INVALID_TOKEN';
+
+/**
+ * Swaps the two auth-store actions this page reaches for and puts the originals
+ * back on unmount. Seeding the real zustand store rather than mocking a module is
+ * what keeps the component under review the shipped one: the page calls
+ * `useAuthStore.getState().verifyEmail()` inside its mount effect, so the state has
+ * to be in place before the story renders - which is exactly when `beforeEach` runs.
+ *
+ * `verifyEmail` is the only input this page has. There is no prop and no route
+ * param: SuperTokens reads the token out of `globalThis.location`, so the three
+ * states below are unreachable in Storybook by any other means, which is why none
+ * of them had ever been drawn.
+ */
+const withVerifyResult = (verifyEmail: () => Promise<VerifyResult>) => {
+  return () => {
+    const { verifyEmail: previousVerify, checkSession: previousSession } = useAuthStore.getState();
+    useAuthStore.setState({
+      verifyEmail,
+      // Only reached from Continue. Returning null sends the page to /signin
+      // through the router mock instead of `provisionPendingSignUpUser`, so no
+      // story here touches the API.
+      checkSession: () => Promise.resolve(null),
+    });
+    return () =>
+      useAuthStore.setState({ verifyEmail: previousVerify, checkSession: previousSession });
+  };
+};
+
+// A promise that never settles - the page has no other way to hold `verifying`,
+// since the state is left behind the moment the SDK answers either way.
+const withPendingVerification = withVerifyResult(() => new Promise<VerifyResult>(() => undefined));
+const withVerifiedEmail = withVerifyResult(() => Promise.resolve('OK'));
+const withExpiredLink = withVerifyResult(() => Promise.resolve('INVALID_TOKEN'));
+
+const meta = {
+  title: 'Auth/VerifyEmail',
+  component: VerifyEmail,
+  parameters: {
+    layout: 'fullscreen',
+    /* Unlike the four AuthShell pages, nothing on this route carries
+       `data-yc-app` in the app - it is a public page with no product shell - so
+       `body:has([data-yc-app])` does not match there and the marketing inks are
+       the correct ones. Without this the preview decorator would stamp the
+       marker on its own wrapper and Storybook would review the page against the
+       PIMS-scoped values it never gets in production. */
+    surface: 'marketing',
+    // Both the success and the failure paths route: Continue replaces the current
+    // entry, so the App Router mock has to be mounted.
+    nextjs: { appDirectory: true, navigation: { pathname: '/verify-email' } },
+    docs: {
+      description: {
+        component:
+          'The landing page for the emailed verification link, and one of the few screens in the ' +
+          'product that is entirely asynchronous: it takes no props, reads no route params, and ' +
+          'decides what to draw from a single SuperTokens call fired in a mount effect. The token ' +
+          'lives in the URL and the SDK reads it from there.\n\n' +
+          'That single call gives three terminal states, all of them below. The `verifying` state ' +
+          'is a real state, not a flash - it holds for as long as the round trip takes and is ' +
+          'what a user on a slow connection actually looks at - but it is also the hardest to ' +
+          'catch, because it ends by definition.\n\n' +
+          'Unlike the rest of the auth flow this page does not use `AuthShell`. It paints a ' +
+          'centred 450px card on the marketing background image, with its own typography scale ' +
+          '(`text-display-2`) - so it is worth comparing side by side with the sign-in stories ' +
+          'rather than assumed to match them.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof VerifyEmail>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Verifying: Story = {
+  name: 'Verifying',
+  beforeEach: withPendingVerification,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const loader = await canvas.findByTestId('verify-email-loader');
+    await expect(loader).toHaveAttribute('aria-label', 'Verifying your email...');
+    /* `fullscreen-translucent`, not `inline`: the loader is fixed to the viewport
+       with a blurred scrim over the whole page, so the card underneath is visible
+       but unreachable. Reading the computed position is the only way to tell the
+       two variants apart - they render identical markup. */
+    await expect(getComputedStyle(loader).position).toBe('fixed');
+
+    // The card behind the scrim carries its own copy of the same state.
+    await expect(canvas.getByRole('heading', { name: 'Verifying...' })).toBeInTheDocument();
+    await expect(
+      canvas.getByText('Please wait while we verify your email address.')
+    ).toBeInTheDocument();
+
+    // Neither outcome has leaked in.
+    await expect(canvas.queryByRole('button', { name: 'Continue' })).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByRole('heading', { name: 'Verification link expired' })
+    ).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The state the page opens in, held here by a verification that never resolves. Two ' +
+          'things are on screen at once: the fixed translucent loader and, under it, the card ' +
+          'reading "Verifying...". They are separate elements with separate copy, so a change to ' +
+          'one leaves the other saying something slightly different.',
+      },
+    },
+  },
+};
+
+export const Verified: Story = {
+  name: 'Email verified',
+  beforeEach: withVerifiedEmail,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const heading = await canvas.findByRole('heading', { name: 'Email verified' });
+    await expect(
+      canvas.getByText(
+        'Your email address has been verified. You can now continue to your account.'
+      )
+    ).toBeInTheDocument();
+
+    // The loader is unmounted, not hidden - `verifying` is gone for good.
+    await expect(canvas.queryByTestId('verify-email-loader')).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('heading', { name: 'Verifying...' })).not.toBeInTheDocument();
+
+    /* 450px, from `w-112.5` on Tailwind's dynamic spacing scale (112.5 x 0.25rem).
+       Measured off the box rather than the computed width because the card has a
+       1px border on every side, which the content box would report short - and an
+       undefined utility here would resolve to no rule at all and let the card
+       shrink to its content. */
+    const card = heading.closest('.rounded-3xl') as HTMLElement;
+    await expect(Math.round(card.getBoundingClientRect().width)).toBe(450);
+
+    /* `href="#"` with an onClick, so `BaseButton` takes its BUTTON branch rather
+       than rendering a next/link - which is what makes the label swap below
+       possible at all. */
+    await expect(canvas.getByRole('button', { name: 'Continue' })).toBeEnabled();
+    await expect(canvas.queryByRole('link', { name: 'Continue' })).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The success card. Continue is a full-width primary pill; where it leads is decided ' +
+          'after the click, by `resolvePostAuthRedirect` reading the role off the session, so ' +
+          'nothing on screen names a destination.',
+      },
+    },
+  },
+};
+
+export const Continuing: Story = {
+  name: 'Continuing (redirecting)',
+  beforeEach: withVerifiedEmail,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(await canvas.findByRole('button', { name: 'Continue' }));
+
+    /* The label is the entire feedback for a step that can take a session check, a
+       provisioning call and a route resolve. `isContinuing` is never set back to
+       false - by design, since every branch of `handleContinue` ends in a
+       navigation - so this state is terminal and the button stays inert-looking
+       until the route changes under it. */
+    await waitFor(() => {
+      expect(canvas.getByRole('button', { name: 'Redirecting...' })).toBeInTheDocument();
+    });
+    await expect(canvas.queryByRole('button', { name: 'Continue' })).not.toBeInTheDocument();
+    await expect(canvas.getByRole('heading', { name: 'Email verified' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'After Continue is pressed, with the session check answering "no session" - the case ' +
+          'that sends the user to `/signin`. The card does not change; only the pill label does. ' +
+          'Note that the button is not disabled, it is guarded by the `isContinuing` flag inside ' +
+          'the handler, so a second click is swallowed rather than blocked.',
+      },
+    },
+  },
+};
+
+export const LinkExpired: Story = {
+  name: 'Verification link expired',
+  beforeEach: withExpiredLink,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const heading = await canvas.findByRole('heading', { name: 'Verification link expired' });
+    await expect(
+      canvas.getByText(
+        'This verification link is invalid or has expired. Sign in to request a new verification link.'
+      )
+    ).toBeInTheDocument();
+
+    /* The same 450px card as the success state, not a narrower error variant:
+       `w-112.5` (112.5 x 0.25rem) is on the one card element and all three
+       states are drawn inside it. Measured off the box because the card has a
+       1px border on every side, and asserted because an undefined utility here
+       would resolve to NO rule at all and let the card shrink to its content -
+       which reads as a deliberate design, not as a missing class. */
+    const card = heading.closest('.rounded-3xl') as HTMLElement;
+    await expect(Math.round(card.getBoundingClientRect().width)).toBe(450);
+
+    // Exactly one way out. The expired state offers no retry at all, so a second
+    // control appearing here would be a real change, not a cosmetic one.
+    await expect(within(card).getAllByRole('link')).toHaveLength(1);
+    await expect(within(card).queryAllByRole('button')).toHaveLength(0);
+
+    /* A LINK, not a button: `Secondary` gets a real href, so `BaseButton` renders
+       next/link and the action is middle-clickable and keyboard-navigable like any
+       other. The success card's Continue is the opposite branch of the same
+       component. */
+    const signIn = canvas.getByRole('link', { name: 'Go to sign in' });
+    await expect(signIn).toHaveAttribute('href', '/signin');
+
+    await expect(canvas.queryByTestId('verify-email-loader')).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Continue' })).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A spent or expired token. Both `INVALID_TOKEN` and a thrown error land here, so this ' +
+          'one card covers a bad token, a used token and a network failure alike - which is why ' +
+          'the copy says "invalid or has expired" rather than picking one.\n\n' +
+          'There is no retry: a fresh link can only come from signing in again, so the single ' +
+          'action is a secondary pill to `/signin`.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/chat/components/ChannelHeaderBar.stories.tsx
+++ b/apps/frontend/src/app/features/chat/components/ChannelHeaderBar.stories.tsx
@@ -57,11 +57,14 @@ const meta = {
           'the online bar has two pulsing dots, not one.\n\n' +
           'Three things a reviewer should look at rather than take on trust. First, the circular ' +
           'controls are three different diameters in one 44px row - back 34px, search 36px, info ' +
-          '30px - which the Phone story measures. Second, the offline subtitle asks for 11px and ' +
-          'renders at 12px: `globals.css` redefines `.text-caption-2` outside any `@layer` with ' +
-          '`font-size: 0.75rem !important`, so the `text-[11px]` utility on that element loses and ' +
-          'the "quiet" offline line ends up bigger than the 11.5px online one (**Client chat, ' +
-          'offline** measures it). Third, the embedded `MessageSearch` reads ' +
+          '30px - which the Phone story measures. Second, the name asks for 13.5px and renders at ' +
+          '16px on a phone: below 768px `globals.css` redefines `.text-body-3-emphasis` with ' +
+          '`font-size: 1rem !important`, which the `text-[13.5px]` utility on that element cannot ' +
+          'outrank, so the compact bar sets the name LARGER than the 14.5px desktop one (issue ' +
+          '#2297; **Phone: long name truncates** measures it). The offline subtitle carried the ' +
+          'same shape of bug - 12px where it asked for 11px - until PR #2298 removed the unlayered ' +
+          '`.text-caption-2` behind it; **Client chat, offline** still measures that line, because ' +
+          'a class alone would not notice it coming back. Third, the embedded `MessageSearch` reads ' +
           "Stream's channel contexts, and outside a `Channel` those hooks return `{}` after a " +
           'console warning. The trigger still renders, still opens, and - because its empty-state ' +
           'line is gated on the query rather than on the response - still answers "No messages ' +
@@ -137,16 +140,18 @@ export const ClientOffline: Story = {
     // `caption-2` Text, the online line a green flex row with a dot.
     await expect(subtitle.querySelector('.chat-presence-dot')).toBeNull();
 
-    /* And it renders at 12px, not the 11px the component asks for. `globals.css`
-       defines `.text-caption-2` a SECOND time outside any @layer, with
-       `font-size: 0.75rem !important`, and an unlayered important rule beats the
-       `text-[11px]` utility no matter the specificity. So the offline subtitle -
-       meant to be the quietest line in the bar - is actually LARGER than the
-       11.5px online one. Asserted as it really renders, because a story that
-       asserted the intent would be red on shipping code and tell a reviewer
-       nothing about what is on screen. */
-    await expect(getComputedStyle(subtitle).fontSize).toBe('12px');
+    /* 11px - the size the component asks for, now that it survives the cascade.
+       This line measured 12px until recently: `globals.css` carried a SECOND,
+       UNLAYERED `.text-caption-2` with `font-size: 0.75rem !important`, and an
+       unlayered important rule beats the `text-[11px]` utility at any
+       specificity, so the subtitle meant to be the quietest thing in the bar
+       rendered LARGER than the 11.5px online one. PR #2298 deleted that
+       duplicate. Both halves are asserted on purpose - the class proves the
+       component still asks for 11px, the computed value proves nothing is
+       defeating it. A class-only check would go green again on the day the
+       next unlayered `!important` lands on this class. */
     await expect(subtitle).toHaveClass('text-[11px]');
+    await expect(getComputedStyle(subtitle).fontSize).toBe('11px');
     // No presence anywhere: the avatar halo goes with the status dot, since both
     // read the same `showPresence` flag.
     await expect(canvasElement.querySelectorAll('.chat-presence-dot')).toHaveLength(0);
@@ -164,13 +169,16 @@ export const ClientOffline: Story = {
       description: {
         story:
           'The same thread with the counterpart offline. `statusText` carries a last-seen string ' +
-          'instead of "Online", and the line is meant to drop to 11px `--ink-faint`.\n\n' +
-          'It does not. The play function measures 12px, because `globals.css` redefines ' +
-          '`.text-caption-2` outside any `@layer` with `font-size: 0.75rem !important`, which the ' +
-          '`text-[11px]` utility on the same element cannot outrank. The offline subtitle is ' +
-          'therefore the LARGEST status line in this bar - bigger than the 11.5px online one it is ' +
-          'supposed to be quieter than. Nothing about the rendered bar reveals that; only the ' +
-          'measurement does.',
+          'instead of "Online", and the line drops to 11px `--ink-faint` - half a pixel under the ' +
+          '11.5px online line, which is the point of the pair: offline is the quieter of the ' +
+          'two.\n\n' +
+          'It did not, until recently. `globals.css` used to redefine `.text-caption-2` outside ' +
+          'any `@layer` with `font-size: 0.75rem !important`, which the `text-[11px]` utility on ' +
+          'the same element could not outrank, so the offline subtitle rendered at 12px - the ' +
+          'LARGEST status line in the bar, and nothing about the rendered bar revealed it. ' +
+          'PR #2298 removed the duplicate and the play function now measures the 11px the ' +
+          'component asks for. It still asserts the class beside the computed value, because ' +
+          'those are the two things that came apart.',
       },
     },
   },
@@ -498,18 +506,25 @@ export const PhoneLongTitle: Story = {
     );
     await expect(title.scrollWidth).toBeGreaterThan(title.clientWidth);
 
-    /* Pinned to CURRENT behaviour, not to intent (issue #2297). The name asks
-       for 13.5px/700 through `text-[13.5px] font-bold`; at <=768px `globals.css`
-       redefines `.text-body-3-emphasis` outside any `@layer` with
-       `font-size: 1rem !important; font-weight: 500 !important`, and an
-       unlayered important rule beats any utility. So the PHONE header draws the
-       name at 16px/500 - larger and lighter than the 14.5px bold desktop one it
-       is supposed to be a compact version of, and 3px of extra type in the row
-       that has the least width to give. The losing classes are asserted next to
-       the measured values so the contradiction is in the failure output. */
+    /* The WEIGHT arrives; the SIZE still does not. The name asks for 13.5px/700
+       through `text-[13.5px] font-bold`. PR #2298 removed the unlayered
+       `font-weight: 500 !important`, so `font-bold` lands and the name is
+       genuinely 700 - asserted as the real value, not as a pin.
+
+       `font-size: 1rem !important` was left in place: at <=768px `globals.css`
+       still redefines `.text-body-3-emphasis` with it, and an `!important`
+       declaration outranks the `text-[13.5px]` utility from any layer. So the
+       PHONE header draws the name 2.5px LARGER than it asks for - larger even
+       than the 14.5px desktop name it is meant to be the compact version of -
+       in the row with the least width to give, which is part of why it clips
+       this early. That is issue #2297, a stylesheet defect this component is a
+       victim of, so the SIZE stays pinned to what ships. The class is asserted
+       immediately before the measurement so the contradiction is in the failure
+       output itself: the element asks for 13.5px and computes 16px. When #2297
+       is fixed this line goes red and becomes '13.5px'. */
     await expect(title).toHaveClass('text-body-3-emphasis', 'text-[13.5px]', 'font-bold');
     await expect(style.fontSize).toBe('16px');
-    await expect(style.fontWeight).toBe('500');
+    await expect(style.fontWeight).toBe('700');
 
     // The controls kept their size instead of being squeezed by the long name.
     const search = canvas.getByRole('button', { name: 'Search messages' });
@@ -539,11 +554,15 @@ export const PhoneLongTitle: Story = {
           'held `#storybook-root` at 672px inside the 375px window, so the mobile viewport never ' +
           'reached the component and the "phone" bar was the desktop bar. The play function now ' +
           'asserts its own premise before measuring anything.\n\n' +
-          'Second, the name renders at 16px/500 here, not the 13.5px/700 it asks for: below 768px ' +
-          '`globals.css` redefines `.text-body-3-emphasis` outside any `@layer` with ' +
-          '`font-size: 1rem !important; font-weight: 500 !important` (issue #2297). The phone ' +
-          'header therefore sets the name LARGER and lighter than the desktop one, in the row with ' +
-          'the least width to spare - which is also why it clips this early.',
+          'Second, the name renders at 16px here, not the 13.5px it asks for: below 768px ' +
+          '`globals.css` still redefines `.text-body-3-emphasis` with ' +
+          '`font-size: 1rem !important` (issue #2297), which outranks the `text-[13.5px]` ' +
+          'utility on the same element. The phone header therefore sets the name LARGER than the ' +
+          '14.5px desktop one, in the row with the least width to spare - which is also why it ' +
+          'clips this early. The weight half of that bug is gone: PR #2298 removed the matching ' +
+          '`font-weight: 500 !important`, so `font-bold` lands and the name is 700 as designed. ' +
+          'The play function pins only the size, and asserts the losing `text-[13.5px]` class ' +
+          'beside it so the pin makes the defect visible rather than hiding it.',
       },
     },
   },

--- a/apps/frontend/src/app/features/chat/components/ChatComposer.stories.tsx
+++ b/apps/frontend/src/app/features/chat/components/ChatComposer.stories.tsx
@@ -1,0 +1,440 @@
+import { useMemo, useRef } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fireEvent, fn, userEvent, waitFor, within } from 'storybook/test';
+import { StreamChat } from 'stream-chat';
+import {
+  ChannelStateProvider,
+  ChatProvider,
+  MessageInputContextProvider,
+  type ChannelStateContextValue,
+  type ChatContextValue,
+  type MessageInputContextValue,
+} from 'stream-chat-react';
+
+import { ChatShareContext } from './chatShareContext';
+import ChatComposer from './ChatComposer';
+
+const CHANNEL_ID = 'appointment-poppy-812';
+
+/**
+ * A real `StreamChat` client and a real `Channel`, both built offline.
+ *
+ * `ChatComposer` calls `useMessageComposer()`, which constructs a genuine
+ * `MessageComposer` out of the chat and channel contexts - so unlike the other
+ * chat stories in this folder, a two-key cast is not enough here: the emoji
+ * insert and the quick replies go through `textComposer`, and a stub would prove
+ * nothing about either.
+ *
+ * `client.channel()` refuses to build a channel until a user is connected, and
+ * connecting opens a websocket. Setting `userID` directly clears that guard
+ * without any network at all - the constructor itself never calls out, and
+ * nothing in these stories sends a message.
+ */
+const buildClient = () => {
+  const client = new StreamChat('storybook-no-network');
+  client.userID = 'u-vet';
+  client.user = { id: 'u-vet', name: 'Dr. Amelia Hart' };
+  return client;
+};
+
+type HarnessProps = { openShare: (channelId: string) => void; handleSubmit: () => void };
+
+const Harness = ({ openShare, handleSubmit }: HarnessProps) => {
+  // Built once: `useMessageComposer` memoises on the channel identity, so a fresh
+  // channel each render would throw away the composer (and its text) every time.
+  const { client, channel } = useMemo(() => {
+    const streamClient = buildClient();
+    return {
+      client: streamClient,
+      channel: streamClient.channel('messaging', CHANNEL_ID),
+    };
+  }, []);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const chat = { client } as unknown as ChatContextValue;
+  const channelState = { channel } as unknown as ChannelStateContextValue;
+  /* `textareaRef` is dereferenced by `TextareaComposer` on every keystroke, so it
+     has to be a real ref object rather than part of the cast. */
+  const messageInput = {
+    handleSubmit,
+    textareaRef,
+    cooldownRemaining: undefined,
+  } as unknown as MessageInputContextValue;
+
+  const share = useMemo(() => ({ openShare }), [openShare]);
+
+  return (
+    <ChatProvider value={chat}>
+      <ChannelStateProvider value={channelState}>
+        <MessageInputContextProvider value={messageInput}>
+          <ChatShareContext.Provider value={share}>
+            <div className="w-full max-w-[560px] bg-[var(--screen)]">
+              <ChatComposer />
+            </div>
+          </ChatShareContext.Provider>
+        </MessageInputContextProvider>
+      </ChannelStateProvider>
+    </ChatProvider>
+  );
+};
+
+const meta = {
+  title: 'Chat/ChatComposer',
+  component: Harness,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The message composer, and the two popovers hanging off it that nothing had ever ' +
+          'drawn. Both are plain `useState` booleans on a component that is only mounted as ' +
+          "Stream's `<MessageInput Input={ChatComposer} />`, for an open, non-frozen channel - " +
+          'so reviewing either one meant running the real app against a real channel.\n\n' +
+          'Neither popover is a menu in the accessibility sense. They are `absolute bottom-11` ' +
+          'divs with no `role`, no `aria-expanded` on the trigger and no focus management, ' +
+          'backed by a `fixed inset-0` transparent button labelled "Close menu" that catches the ' +
+          'next click anywhere on the page. That click-catcher is the whole dismissal mechanism: ' +
+          'there is no Escape handler and no outside-click listener, so the popovers behave ' +
+          'differently from every `Modal` in PIMS.\n\n' +
+          'The two are mutually exclusive by construction rather than by state - each trigger ' +
+          'calls `closeAll()` before toggling itself - which is why opening one while the other ' +
+          'is up closes the first rather than stacking a second `fixed inset-0` catcher over the ' +
+          'page.\n\n' +
+          'The stories run against a real `MessageComposer` built offline, so the emoji insert ' +
+          'and the quick replies actually move text through `textComposer` instead of proving ' +
+          'that a click handler fired.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    openShare: fn(),
+    handleSubmit: fn(),
+  },
+  globals: { viewport: { value: 'tablet', isRotated: false } },
+} satisfies Meta<typeof Harness>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** The transparent full-screen dismissal button behind whichever popover is open. */
+const clickCatcher = (): HTMLElement => {
+  const el = document.querySelector('button[aria-label="Close menu"]');
+  if (!el) throw new Error('No "Close menu" click-catcher is mounted.');
+  return el as HTMLElement;
+};
+
+export const Resting: Story = {
+  name: 'Resting (both popovers closed)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // The five quick replies, by their exact labels. They are a horizontal
+    // scroller (`overflow-x-auto`), so on a narrow channel the last two are off
+    // screen rather than wrapped onto a second line.
+    await expect(canvas.getByText('Quick replies')).toBeInTheDocument();
+    for (const label of [
+      'Appointment confirmed',
+      'Arrive 10 min early',
+      'Results ready',
+      'Share a photo',
+      'We will reply soon',
+    ]) {
+      await expect(canvas.getByRole('button', { name: label })).toBeInTheDocument();
+    }
+
+    /* Exactly five, in the scroller that owns them: a sixth template added
+       without widening the row would be invisible off the right edge, and a
+       count is the only assertion that notices. */
+    const scroller = canvas.getByText('Quick replies').parentElement;
+    if (!scroller) throw new Error('The quick-reply row did not render.');
+    await expect(scroller.querySelectorAll('button')).toHaveLength(5);
+    await expect(getComputedStyle(scroller).overflowX).toBe('auto');
+
+    await expect(canvas.getByPlaceholderText('Write a message…')).toHaveValue('');
+    await expect(canvas.getByRole('button', { name: 'Add attachment' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Emoji' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Send message' })).toBeEnabled();
+
+    /* The mic is permanently disabled and always has been - it is a placeholder
+       for a feature that does not exist. It reads as an available control at a
+       glance, which is exactly why it belongs in the resting story. */
+    await expect(canvas.getByRole('button', { name: 'Voice message' })).toBeDisabled();
+
+    await expect(canvas.queryByText('Share from PIMS')).not.toBeInTheDocument();
+    await expect(document.querySelector('button[aria-label="Close menu"]')).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The default state. The field is a 42px-min pill on `--field-bg` holding the textarea, ' +
+          'the emoji glyph and the disabled mic; the paperclip sits outside it on the left and ' +
+          'the send circle outside it on the right.',
+      },
+    },
+  },
+};
+
+export const AttachmentMenu: Story = {
+  name: 'Attachment menu (open)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'Add attachment' });
+    await userEvent.click(trigger);
+
+    // Three rows, in order, each with its own blue glyph.
+    const photo = await canvas.findByText('Photo');
+    await expect(canvas.getByText('Document')).toBeInTheDocument();
+    await expect(canvas.getByText('Share from PIMS')).toBeInTheDocument();
+
+    const panel = photo.closest('div.absolute');
+    if (!panel) throw new Error('The attachment panel is not absolutely positioned.');
+    await expect(panel.querySelectorAll('button')).toHaveLength(3);
+
+    /* getBoundingClientRect, not getComputedStyle().width: the panel is bordered,
+       so the content box reads 174 where `w-44` means 176. */
+    await expect(panel.getBoundingClientRect().width).toBe(176);
+
+    /* The catcher is BEHIND the panel and IN FRONT of everything else. If those
+       two z-indexes ever equalled each other the rows would stop being clickable
+       while still being perfectly visible, which is the kind of regression a
+       screenshot cannot show. */
+    const catcher = clickCatcher();
+    await expect(getComputedStyle(catcher).position).toBe('fixed');
+    await expect(getComputedStyle(catcher).zIndex).toBe('10');
+    await expect(getComputedStyle(panel).zIndex).toBe('20');
+
+    /* The trigger flips to the `active` tint. Polled: the button carries
+       `transition-colors`, so one synchronous read lands mid-interpolation. */
+    await waitFor(() => {
+      expect(getComputedStyle(trigger).backgroundColor).not.toBe('rgba(0, 0, 0, 0)');
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Opens upward from the paperclip (`bottom-11 left-0`), which is the only direction ' +
+          'that works - the composer is pinned to the bottom of the window. The panel is not ' +
+          'portalled, so it is clipped by any scrolling ancestor the composer is dropped into.',
+      },
+    },
+  },
+};
+
+export const AttachmentMenuDismissal: Story = {
+  name: 'Attachment menu dismissed by the catcher',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Add attachment' }));
+    const documentRow = await canvas.findByText('Document');
+    await expect(documentRow).toBeInTheDocument();
+
+    /* The catcher is `fixed inset-0`, so it spans the whole viewport and the panel
+       sits ON TOP of part of it. `userEvent.click` aims at the element's centre and
+       refuses to act when something covers that point, which is a property of the
+       harness rather than of the component - `fireEvent` dispatches the click React
+       actually listens for without that geometry check. */
+    const catcher = clickCatcher();
+    const rect = catcher.getBoundingClientRect();
+    await expect(rect.width).toBe(globalThis.innerWidth);
+    await expect(rect.height).toBe(globalThis.innerHeight);
+
+    fireEvent.click(catcher);
+    await waitFor(() => {
+      expect(canvas.queryByText('Document')).not.toBeInTheDocument();
+    });
+
+    /* Escape does nothing here, and that is the finding rather than an oversight
+       in the story: the popover installs no key handler at all, so a keyboard
+       user who opens it has no way to dismiss it except by clicking. */
+    await userEvent.click(canvas.getByRole('button', { name: 'Add attachment' }));
+    const reopened = await canvas.findByText('Document');
+    await expect(reopened).toBeInTheDocument();
+    await userEvent.keyboard('{Escape}');
+    await expect(canvas.getByText('Document')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The catcher covers the whole viewport, so any click outside the three rows closes ' +
+          'the panel - including a click on the send button, which therefore needs two presses ' +
+          'while the panel is open. Escape is not wired up.',
+      },
+    },
+  },
+};
+
+export const EmojiGrid: Story = {
+  name: 'Emoji grid (open)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Emoji' }));
+
+    const first = await canvas.findByRole('button', { name: '👍' });
+    const grid = first.closest('div.absolute');
+    if (!grid) throw new Error('The emoji panel is not absolutely positioned.');
+
+    // Ten emoji, and the set itself is the design - clinic-specific glyphs (paw,
+    // pill, clock) sit alongside the generic ones.
+    await expect(grid.querySelectorAll('button')).toHaveLength(10);
+    await expect([...grid.querySelectorAll('button')].map((button) => button.textContent)).toEqual([
+      '👍',
+      '🙏',
+      '❤️',
+      '😊',
+      '🎉',
+      '✅',
+      '⏰',
+      '🐾',
+      '💊',
+      '📎',
+    ]);
+
+    // `w-56` with `flex-wrap`: five per row at 36px plus the 4px gaps.
+    await expect(grid.getBoundingClientRect().width).toBe(224);
+    await expect(getComputedStyle(grid).flexWrap).toBe('wrap');
+    await expect(getComputedStyle(grid).zIndex).toBe('20');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Anchored to the right edge of the field (`bottom-11 right-0`) rather than to the ' +
+          'emoji button itself, so it hangs over the send circle. Ten glyphs, no search, no ' +
+          'categories - it is a shortcut row, not a picker.',
+      },
+    },
+  },
+};
+
+export const EmojiInsertsIntoTheDraft: Story = {
+  name: 'Emoji inserts into the draft',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Emoji' }));
+    await userEvent.click(await canvas.findByRole('button', { name: '🐾' }));
+
+    /* The real `textComposer`, not a spy: `insertText` is async (it runs the
+       composition middleware), so the value lands a tick after the click and a
+       synchronous read would find the field still empty. */
+    const textarea = canvas.getByPlaceholderText('Write a message…');
+    await waitFor(() => {
+      expect(textarea).toHaveValue('🐾');
+    });
+
+    // Picking one closes the grid; there is no multi-select.
+    await waitFor(() => {
+      expect(canvas.queryByRole('button', { name: '💊' })).not.toBeInTheDocument();
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Insertion goes through `textComposer.insertText`, which respects the current cursor ' +
+          'position, so an emoji picked mid-sentence lands at the caret rather than being ' +
+          'appended.',
+      },
+    },
+  },
+};
+
+export const OnePopoverAtATime: Story = {
+  name: 'Opening one closes the other',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Add attachment' }));
+    const shareRow = await canvas.findByText('Share from PIMS');
+    await expect(shareRow).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Emoji' }));
+    const thumbsUp = await canvas.findByRole('button', { name: '👍' });
+    await expect(thumbsUp).toBeInTheDocument();
+
+    /* Both `closeAll()` calls matter. Without them the page would carry two
+       `fixed inset-0` catchers, and the lower one would keep swallowing clicks
+       after the visible panel had gone. */
+    await expect(canvas.queryByText('Share from PIMS')).not.toBeInTheDocument();
+    await expect(document.querySelectorAll('button[aria-label="Close menu"]')).toHaveLength(1);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The exclusivity is enforced in the two click handlers, not by a single "which panel" ' +
+          'state, so any third popover added to this row has to remember to call `closeAll` too.',
+      },
+    },
+  },
+};
+
+export const ShareFromPims: Story = {
+  name: 'Share from PIMS',
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Add attachment' }));
+    await userEvent.click(await canvas.findByText('Share from PIMS'));
+
+    /* The row hands the CHANNEL id up to ChatContainer, which owns the picker
+       modal - the composer itself never renders it. Asserting the id rather than
+       "it was called" is what proves the right conversation gets the shared
+       record attached to it. */
+    await expect(args.openShare).toHaveBeenCalledWith(CHANNEL_ID);
+
+    await waitFor(() => {
+      expect(canvas.queryByText('Photo')).not.toBeInTheDocument();
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The third attachment row is the only one that is not a file picker: it opens the ' +
+          'PIMS entity picker through `ChatShareContext`. If the channel has no `id` the row ' +
+          'silently closes the panel and does nothing at all.',
+      },
+    },
+  },
+};
+
+export const QuickReplyReplacesTheDraft: Story = {
+  name: 'Quick reply replaces the draft',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const textarea = canvas.getByPlaceholderText('Write a message…');
+
+    /* Two templates rather than typed text: `textComposer.handleChange` is async,
+       so `userEvent.type` races the controlled value character by character and a
+       garbled draft would fail this story for a reason that has nothing to do with
+       the behaviour under test. */
+    await userEvent.click(canvas.getByRole('button', { name: 'Appointment confirmed' }));
+    await waitFor(() => {
+      expect(textarea).toHaveValue('Your appointment is confirmed.');
+    });
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Results ready' }));
+
+    /* `setText`, not `insertText`: a quick reply DISCARDS whatever was typed
+       rather than appending to it, with no confirmation and no undo. That is the
+       behaviour worth seeing before deciding whether it is the intended one.
+       The em dash in the expected string is the one `TEMPLATES` ships in
+       ChatComposer.tsx - it is copied, not written here, so do not "fix" it to a
+       hyphen without changing the source first. */
+    await waitFor(() => {
+      expect(textarea).toHaveValue('Your results are ready — let us discuss them.');
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Templates are pills above the field, always visible rather than behind a menu. A ' +
+          'second press overwrites the first without a confirmation, so the pills are a ' +
+          'starting point rather than a snippet library.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/chat/components/ChatContainer.stories.tsx
+++ b/apps/frontend/src/app/features/chat/components/ChatContainer.stories.tsx
@@ -1,0 +1,249 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, waitFor, within } from 'storybook/test';
+
+import { formatDisplayDate } from '@/app/lib/date';
+import { ChatClosedFooter, ChatEmptyThread } from './ChatContainer';
+
+const HOUR_MS = 3_600_000;
+const DAY_MS = 86_400_000;
+
+/**
+ * Timestamps are built from `Date.now()` at module load, not written as literals.
+ *
+ * `formatClosedTime` compares against the clock at render, so a fixed ISO string
+ * would drift from "3 hours ago" to "2 days ago" to a formatted date as the file
+ * aged - the story would keep passing while quietly showing a different branch of
+ * the formatter every week.
+ */
+const AGO = (ms: number) => new Date(Date.now() - ms).toISOString();
+const LONG_AGO_MS = 40 * DAY_MS;
+
+const meta = {
+  title: 'Chat/ChatContainer',
+  component: ChatClosedFooter,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Two terminal states of the chat window that no Storybook could reach, because both ' +
+          'are chosen by live Stream channel data rather than by a prop.\n\n' +
+          '`ChatClosedFooter` **replaces** the typing indicator and the composer - it is the ' +
+          'other arm of a ternary, not an overlay on top of them - the moment ' +
+          '`channelState.frozen` is true or the linked appointment reports status `ended`. ' +
+          'Reaching it in a running app means freezing a real channel or ending a real ' +
+          'appointment, which is why the state that removes the entire message input had never ' +
+          'been drawn.\n\n' +
+          '`ChatEmptyThread` is wired in as the `Channel` component’s `EmptyStateIndicator`, ' +
+          'so it renders only when a real, watched channel happens to hold zero messages. It is ' +
+          'exported here for the same reason.\n\n' +
+          'The timestamp under "Chat session closed" is `formatClosedTime`, a four-branch ' +
+          'relative formatter that falls back to an absolute date past seven days - and it ' +
+          'returns an empty string when the channel carries neither a `closedAt` nor an ' +
+          '`updatedAt`, which drops the line entirely rather than showing a placeholder. All ' +
+          'four branches plus the empty one are below.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div className="flex min-h-[220px] flex-col justify-end bg-[var(--screen)]">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ChatClosedFooter>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** The footer's own box, hoisted so no DOM read happens inside a `waitFor` body. */
+const footerOf = (canvasElement: HTMLElement): HTMLElement => {
+  const el = canvasElement.querySelector('div.flex.shrink-0');
+  if (!el) throw new Error('The closed footer did not render.');
+  return el as HTMLElement;
+};
+
+/**
+ * The footer's two lines, in order.
+ *
+ * Asserting the pair rather than "the timestamp is somewhere on the page" is what
+ * pins the layout: the heading and the timestamp are separate `<p>`s in a centred
+ * column, so a formatter that returned its string into the wrong slot, or a second
+ * line that rendered above the first, would still satisfy a bare text query.
+ */
+const footerLines = (canvasElement: HTMLElement): (string | null)[] =>
+  [...footerOf(canvasElement).children].map((line) => line.textContent);
+
+export const ClosedRecently: Story = {
+  name: 'Closed (relative timestamp)',
+  args: { closedAt: AGO(3 * HOUR_MS) },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Chat session closed')).toBeInTheDocument();
+    await expect(canvas.getByText('3 hours ago')).toBeInTheDocument();
+
+    /* The composer is GONE, not disabled. Asserting the absence of the send
+       control is what makes this the closed state rather than a footer that
+       happens to be stacked under a live input. */
+    await expect(canvas.queryByRole('button', { name: 'Send message' })).not.toBeInTheDocument();
+    await expect(canvas.queryByPlaceholderText('Write a message…')).not.toBeInTheDocument();
+
+    /* `bg-chat-surface-soft` and `border-chat-divider` are named Tailwind tokens.
+       An undefined token emits no declaration at all - the class is simply absent
+       from the stylesheet - so the footer would render transparent and flush with
+       the message list and still pass any "the text is there" check. Polled, since
+       nothing guarantees the sheet has applied on the first synchronous read. */
+    const footer = footerOf(canvasElement);
+    await waitFor(() => {
+      expect(getComputedStyle(footer).backgroundColor).toBe('rgb(241, 235, 225)');
+    });
+    await expect(getComputedStyle(footer).borderTopWidth).toBe('1px');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The common case: a session ended earlier today. Two centred lines on the warm ' +
+          '`--color-chat-surface-soft` band, separated from the message list by a single ' +
+          '`--color-chat-divider` hairline.',
+      },
+    },
+  },
+};
+
+export const ClosedJustNow: Story = {
+  name: 'Closed (under a minute)',
+  /* Stamped at RENDER, not in `args`. Args are evaluated once when the module is
+     imported, and this branch only holds for 60 seconds - a story left open in the
+     sidebar for two minutes would have re-run against a stale timestamp and read
+     "2 minutes ago". The other stories here are hours or days wide and are safe as
+     args. */
+  render: () => <ChatClosedFooter closedAt={new Date().toISOString()} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    /* The first branch of the formatter, and the one a reader actually sees:
+       closing a session swaps the composer for this footer immediately, so this
+       is the frame that follows the click. */
+    await expect(canvas.getByText('just now')).toBeInTheDocument();
+    await expect(footerLines(canvasElement)).toEqual(['Chat session closed', 'just now']);
+    await expect(canvas.queryByPlaceholderText('Write a message…')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`diffMins < 1`. Note it never re-renders itself - the footer has no timer, so it ' +
+          'reads "just now" until something else re-renders the window, however long the tab ' +
+          'stays open.',
+      },
+    },
+  },
+};
+
+export const ClosedDaysAgo: Story = {
+  name: 'Closed (days)',
+  args: { closedAt: AGO(4 * DAY_MS) },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(footerLines(canvasElement)).toEqual(['Chat session closed', '4 days ago']);
+
+    /* Plural, and not "96 hours ago": the formatter switches unit at 24 hours and
+       again at 7 days, so the wrong branch here reads as a plausible sentence
+       rather than as a bug. */
+    await expect(canvas.queryByText('96 hours ago')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The relative form holds up to seven days. Singular and plural are handled, so a ' +
+          'one-day-old session reads "1 day ago" rather than "1 days ago".',
+      },
+    },
+  },
+};
+
+export const ClosedLongAgo: Story = {
+  name: 'Closed (past seven days, absolute date)',
+  args: { closedAt: AGO(LONG_AGO_MS) },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* Compared against the real formatter rather than a hand-written date string:
+       `formatDisplayDate` resolves the practice timezone, so hard-coding the
+       expected text would pass on one machine and fail on another. */
+    const expected = formatDisplayDate(new Date(Date.now() - LONG_AGO_MS));
+    await expect(footerLines(canvasElement)).toEqual(['Chat session closed', expected]);
+    await expect(canvas.queryByText(/ago$/)).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Past seven days the line switches to an absolute date. This is the form an archived ' +
+          'conversation shows, and it is the only branch where the footer text is not readable ' +
+          'as a duration.',
+      },
+    },
+  },
+};
+
+export const ClosedWithoutTimestamp: Story = {
+  name: 'Closed (no timestamp at all)',
+  args: { closedAt: undefined },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Chat session closed')).toBeInTheDocument();
+
+    /* The caller passes `closedAt || updatedAt`, so this needs BOTH to be missing -
+       a frozen channel restored from a cache that never carried either field. The
+       formatter returns '' and the second line is dropped, leaving a footer whose
+       height differs from every other closed conversation in the list. */
+    const footer = footerOf(canvasElement);
+    await expect(footer.children).toHaveLength(1);
+    await expect(canvas.queryByText('just now')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'One line instead of two. Nothing renders a dash or a placeholder, so the band is ' +
+          'roughly 18px shorter here than in every story above it.',
+      },
+    },
+  },
+};
+
+export const EmptyThread: Story = {
+  name: 'Empty thread',
+  render: () => <ChatEmptyThread />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('No messages yet')).toBeInTheDocument();
+    await expect(
+      canvas.getByText('Send the first message to start the conversation.')
+    ).toBeInTheDocument();
+
+    /* The icon disc is `bg-chat-panel`, another named token. Same failure mode as
+       the footer band: an undefined token leaves a bare glyph floating with no
+       circle behind it, which reads as a rendering glitch rather than a missing
+       style. */
+    const disc = canvasElement.querySelector('span.rounded-full');
+    if (!disc) throw new Error('The empty-state icon disc did not render.');
+    await waitFor(() => {
+      expect(getComputedStyle(disc).backgroundColor).toBe('rgb(241, 235, 225)');
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A brand-new conversation, before either side has written anything. It is centred in ' +
+          'the message list with `flex-1`, so it sits mid-panel rather than at the top - and it ' +
+          'is the one chat surface that appears above a live composer rather than instead of it.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/chat/components/ChatContainer.tsx
+++ b/apps/frontend/src/app/features/chat/components/ChatContainer.tsx
@@ -2102,6 +2102,9 @@ const ProtectedChatContainer = () => {
   );
 };
 
-export { ChannelPreviewWrapper, ChatClosedFooter };
+// ChatEmptyThread is exported for Storybook: it is wired in as the `Channel`
+// EmptyStateIndicator, so nothing can render it without a live Stream channel
+// that happens to hold zero messages.
+export { ChannelPreviewWrapper, ChatClosedFooter, ChatEmptyThread };
 
 export default ProtectedChatContainer;

--- a/apps/frontend/src/app/features/companionCard/components/ShareCompanionCardModal.stories.tsx
+++ b/apps/frontend/src/app/features/companionCard/components/ShareCompanionCardModal.stories.tsx
@@ -1,0 +1,417 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import type { AxiosAdapter, InternalAxiosRequestConfig } from 'axios';
+import type {
+  CompanionCardDTO,
+  IssueShareTokenResultDTO,
+  Organisation,
+  ShareTokenResponseDTO,
+} from '@yosemite-crew/types';
+
+import api from '@/app/services/axios';
+import { useOrgStore } from '@/app/stores/orgStore';
+import ShareCompanionCardModal from './ShareCompanionCardModal';
+
+const ORG_ID = 'org-storybook-card';
+
+const ORG: Organisation = {
+  _id: ORG_ID,
+  name: 'Avenger Park Veterinary',
+  type: 'HOSPITAL',
+  phoneNo: '+49 30 5555 0142',
+  taxId: 'DE-TAX-000000',
+};
+
+const CARD: CompanionCardDTO = {
+  audience: 'STAFF',
+  identity: {
+    id: 'companion-poppy-812',
+    name: 'Poppy',
+    type: 'dog',
+    breed: 'Border Terrier',
+    colour: 'Grizzle',
+    photoUrl: undefined,
+    microchipNumber: '981020034512789',
+  },
+  passportNumber: 'DE-PP-441207',
+  dateOfBirth: '2020-03-14T00:00:00.000Z',
+  alerts: [
+    { title: 'Cephalosporin allergy', severity: 'critical' },
+    { title: 'Fear of clippers', severity: 'low' },
+  ],
+  ownerContact: {
+    firstName: 'Sam',
+    lastName: 'Okonjo',
+    phoneNumber: '+49 151 5550 118',
+    email: 'sam@example.test',
+  },
+  medical: {
+    allergy: 'Cephalosporins',
+    bloodGroup: 'DEA 1.1 negative',
+    currentWeight: 25,
+    isNeutered: true,
+  },
+  insurance: { isInsured: true, companyName: 'Petplan DE' },
+  latestVisit: { status: 'Completed', occurredAt: '2026-08-02T09:15:00.000Z' },
+};
+
+const token = (over: Partial<ShareTokenResponseDTO> = {}): ShareTokenResponseDTO => ({
+  id: 'share-1',
+  audience: 'PUBLIC',
+  showOwnerPhone: false,
+  expiresAt: '2026-12-31T00:00:00.000Z',
+  revokedAt: null,
+  lastViewedAt: '2026-08-18T11:02:00.000Z',
+  viewCount: 12,
+  createdAt: '2026-08-10T08:00:00.000Z',
+  ...over,
+});
+
+/**
+ * The issued-link payload.
+ *
+ * The literal below is deliberately the words EXAMPLE_NOT_A_CREDENTIAL rather
+ * than anything token-shaped: `IssueShareTokenResultDTO.token` is the one field
+ * in this DTO that carries a real secret in production, and a plausible-looking
+ * random string in a committed file trips the repository's secret scanner.
+ */
+const ISSUED: IssueShareTokenResultDTO = {
+  token: 'EXAMPLE_NOT_A_CREDENTIAL',
+  qrPayload: 'https://app.example.test/public/companion-card/EXAMPLE_NOT_A_CREDENTIAL',
+  share: token({ id: 'share-new', viewCount: 0, lastViewedAt: null }),
+};
+
+type Handlers = {
+  list?: () => Promise<{ tokens: ShareTokenResponseDTO[] }>;
+  issue?: () => Promise<IssueShareTokenResultDTO>;
+  revoke?: () => Promise<ShareTokenResponseDTO>;
+};
+
+/**
+ * Swaps the shared axios instance's *adapter* rather than mocking the service
+ * module, which is the seam axios documents for this and the convention the other
+ * modal stories in this repo already follow (there is no MSW or `sb.mock` wiring
+ * here). `beforeEach` returns the restore, so the real adapter is back before the
+ * next story runs.
+ *
+ * The org store is seeded in the same hook because `companionCard.service` calls
+ * `requireOrgId()`, which THROWS when no primary org is set - without the seed
+ * every request would reject before reaching the adapter and each story would be
+ * silently exercising the catch branch instead of the one it names.
+ */
+const stubApi = (handlers: Handlers) => () => {
+  const previousAdapter = api.defaults.adapter;
+  const orgSnapshot = useOrgStore.getState();
+
+  useOrgStore.setState({
+    primaryOrgId: ORG_ID,
+    orgIds: [ORG_ID],
+    orgsById: { [ORG_ID]: ORG },
+    status: 'loaded',
+  });
+
+  const adapter: AxiosAdapter = async (config: InternalAxiosRequestConfig) => {
+    const method = (config.method ?? 'get').toLowerCase();
+    const url = config.url ?? '';
+    let data: unknown;
+    if (method === 'delete') {
+      data = await (handlers.revoke ?? (() => Promise.resolve(token())))();
+    } else if (method === 'post') {
+      data = await (handlers.issue ?? (() => Promise.resolve(ISSUED)))();
+    } else if (url.endsWith('/shares')) {
+      data = await (handlers.list ?? (() => Promise.resolve({ tokens: [] })))();
+    } else {
+      data = {};
+    }
+    return { data, status: 200, statusText: 'OK', headers: {}, config };
+  };
+  api.defaults.adapter = adapter;
+
+  return () => {
+    api.defaults.adapter = previousAdapter;
+    useOrgStore.setState(orgSnapshot);
+  };
+};
+
+const NEVER = <T,>(): Promise<T> => new Promise<T>(() => {});
+
+/** The portalled panel, or a thrown error naming what actually happened. */
+const openDialog = (): HTMLElement => {
+  const dialog = document.querySelector('dialog[open]');
+  if (!dialog) throw new Error('No open dialog is mounted on document.body.');
+  return dialog as HTMLElement;
+};
+
+const meta = {
+  title: 'CompanionCard/ShareCompanionCardModal',
+  component: ShareCompanionCardModal,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The whole share sheet, which had never been drawn anywhere - it returns `null` ' +
+          'unless `open`, deliberately, so the companion card is not duplicated into the page ' +
+          'DOM behind the overlay. There is no closed state to screenshot: closed means the ' +
+          'component renders nothing at all, not even the dialog element the shared `Modal` ' +
+          'usually leaves mounted.\n\n' +
+          'Behind that gate is a second one. The body is a ternary on `issued`, and `issued` is ' +
+          'only ever set by a successful POST, so the QR code, the wrapped payload URL and the ' +
+          '"Copy link" button could not be seen without issuing a real share token against a ' +
+          'real organisation. The primary button and the QR block never appear together - ' +
+          'creating a link REPLACES the button.\n\n' +
+          'A third surface hangs off the GET: any live tokens are listed under "Active share ' +
+          'links" with a view count and a Revoke button, filtered client-side by `isLive`, ' +
+          'which drops anything revoked or past its expiry so an expired link is never offered ' +
+          'as an active share.\n\n' +
+          'Every story below swaps the axios adapter rather than the service module, and seeds ' +
+          'the org store because the service reads the primary org id and throws without one.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    open: true,
+    card: CARD,
+    companionId: 'companion-poppy-812',
+    companionName: 'Poppy Okonjo',
+    onClose: fn(),
+  },
+  globals: { viewport: { value: 'laptop', isRotated: false } },
+  decorators: [
+    (Story) => (
+      <div className="min-h-[520px] bg-[var(--screen)] p-6">
+        <Story />
+      </div>
+    ),
+  ],
+  beforeEach: stubApi({}),
+} satisfies Meta<typeof ShareCompanionCardModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Closed: Story = {
+  name: 'Closed (renders nothing)',
+  args: { open: false },
+  play: async () => {
+    /* Not "the dialog has no `open` attribute" - there is no dialog. The early
+       `if (!open) return null` runs before `CenterModal`, so unlike every other
+       PIMS overlay this one leaves no portalled node behind at all. */
+    await expect(document.querySelector('dialog')).toBeNull();
+    await expect(document.body.textContent).not.toContain('Create shareable card link');
+
+    /* And the identifiers are the reason the guard exists, so they are what the
+       story checks: with the card mounted-but-hidden, the microchip and passport
+       numbers would sit in the page DOM behind the scrim, readable by anything
+       walking the document. */
+    await expect(document.body.textContent).not.toContain('981020034512789');
+    await expect(document.body.textContent).not.toContain('DE-PP-441207');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Included because the absence is the design: keeping the card mounted would put a ' +
+          'second copy of every identifier - microchip, passport, owner phone - into the page ' +
+          'DOM behind the scrim.',
+      },
+    },
+  },
+};
+
+export const Sheet: Story = {
+  name: 'Share sheet (no links yet)',
+  play: async () => {
+    const dialog = await waitFor(openDialog);
+    const panel = within(dialog);
+
+    // The title takes the FIRST word of the companion name, not the whole name.
+    await expect(
+      panel.getByRole('heading', { level: 2, name: "Share Poppy's card" })
+    ).toBeVisible();
+
+    // The card itself, which is the thing being shared - identifiers and alerts.
+    await expect(panel.getByText('Poppy')).toBeInTheDocument();
+    await expect(panel.getByText('Border Terrier / Canine')).toBeInTheDocument();
+    await expect(panel.getByText('Cephalosporin allergy')).toBeInTheDocument();
+    await expect(panel.getByText('981020034512789')).toBeInTheDocument();
+    await expect(panel.getByText('Petplan DE')).toBeInTheDocument();
+    await expect(panel.getByText('Sam Okonjo')).toBeInTheDocument();
+
+    // The primary action, and nothing from the issued branch.
+    await expect(
+      panel.getByRole('button', { name: 'Create shareable card link' })
+    ).toBeInTheDocument();
+    await expect(panel.queryByRole('button', { name: 'Copy link' })).not.toBeInTheDocument();
+    await expect(panel.queryByText('Active share links')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The first-run state: a companion that has never been shared. The card renders on a ' +
+          'white ground inside the panel, and the whole body scrolls at `max-h-[70vh]` so a ' +
+          'card with every optional field filled in does not push the action off screen.',
+      },
+    },
+  },
+};
+
+export const LinkIssued: Story = {
+  name: 'Link issued (QR + payload)',
+  play: async () => {
+    const dialog = await waitFor(openDialog);
+    const panel = within(dialog);
+    await userEvent.click(panel.getByRole('button', { name: 'Create shareable card link' }));
+
+    const payload = await panel.findByText(ISSUED.qrPayload);
+    await expect(panel.getByRole('button', { name: 'Copy link' })).toBeInTheDocument();
+
+    /* The swap, not an addition: the primary that created the link is gone, so
+       there is no way to issue a second link without closing and reopening the
+       sheet (which also clears this one - `handleClose` resets `issued`). */
+    await expect(
+      panel.queryByRole('button', { name: 'Create shareable card link' })
+    ).not.toBeInTheDocument();
+
+    // A real QR, sized 160 by the caller.
+    const block = payload.closest('div');
+    if (!block) throw new Error('The issued-link block did not render.');
+    const qr = block.querySelector('svg');
+    if (!qr) throw new Error('No QR code was rendered next to the payload.');
+    await expect(qr.getBoundingClientRect().width).toBe(160);
+
+    /* `break-all` is doing real work here and is easy to lose: the payload is a
+       single unbroken URL, so without it the line cannot wrap and the 500px panel
+       grows a horizontal scrollbar. Asserting the computed value catches a
+       refactor that drops the class far more reliably than looking at a
+       screenshot of a short fixture URL. */
+    await waitFor(() => {
+      expect(getComputedStyle(payload).wordBreak).toBe('break-all');
+    });
+    await expect(payload.getBoundingClientRect().width).toBeLessThanOrEqual(
+      dialog.getBoundingClientRect().width
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The issued state. QR, the full URL underneath it as selectable text, and a ' +
+          'secondary "Copy link" - three ways to move the same link, because the person ' +
+          'receiving it is usually holding a phone in front of the screen.',
+      },
+    },
+  },
+};
+
+export const IssuingInFlight: Story = {
+  name: 'Creating a link (in flight)',
+  beforeEach: stubApi({ issue: () => NEVER<IssueShareTokenResultDTO>() }),
+  play: async () => {
+    const dialog = await waitFor(openDialog);
+    const panel = within(dialog);
+    await userEvent.click(panel.getByRole('button', { name: 'Create shareable card link' }));
+
+    /* The label swaps to "Creating..." and that is the ENTIRE feedback - the
+       button is not disabled, so a second click fires a second POST and issues a
+       second share token. That is worth seeing rather than inferring. */
+    const busyButton = await panel.findByRole('button', { name: 'Creating...' });
+    await expect(busyButton).toBeEnabled();
+    await expect(panel.queryByRole('button', { name: 'Copy link' })).not.toBeInTheDocument();
+
+    /* One button, not a button plus a spinner: nothing else on the sheet changes
+       while the POST is out, so the label swap is the whole of the in-flight
+       state. */
+    await expect(panel.queryByRole('button', { name: 'Create shareable card link' })).toBeNull();
+    await expect(panel.getByText('Poppy')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The window between the click and the token, which on a cold API is measured in ' +
+          'seconds. `busy` drives the label only; nothing blocks the control.',
+      },
+    },
+  },
+};
+
+export const ActiveLinks: Story = {
+  name: 'Existing share links',
+  beforeEach: stubApi({
+    list: () =>
+      Promise.resolve({
+        tokens: [
+          token({ id: 'share-public', audience: 'PUBLIC', viewCount: 12 }),
+          token({ id: 'share-referral', audience: 'REFERRAL_CLINIC', viewCount: 3 }),
+          // Filtered out by `isLive` before it ever reaches the list.
+          token({ id: 'share-revoked', revokedAt: '2026-08-15T10:00:00.000Z' }),
+          token({ id: 'share-expired', expiresAt: '2025-01-01T00:00:00.000Z' }),
+        ],
+      }),
+  }),
+  play: async () => {
+    const dialog = await waitFor(openDialog);
+    const panel = within(dialog);
+
+    const heading = await panel.findByText('Active share links');
+    await expect(heading).toBeInTheDocument();
+
+    /* Two of the four tokens survive `isLive`. The audience drives the label, so
+       a referral link and a public link are distinguishable only by that word -
+       there is no badge, no expiry and no created date on the row. */
+    await expect(panel.getByText('Public link - 12 views')).toBeInTheDocument();
+    await expect(panel.getByText('Referral link - 3 views')).toBeInTheDocument();
+    await expect(panel.getAllByRole('button', { name: 'Revoke' })).toHaveLength(2);
+
+    // The revoked and expired tokens are dropped client-side, mirroring what the
+    // public resolver would do with them anyway.
+    await expect(panel.queryByText('Public link - 0 views')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Rows sit below the primary action, each a hairline-bordered pill with the label on ' +
+          'the left and Revoke on the right. Revoking is immediate and unconfirmed - there is ' +
+          'no "are you sure" between the button and the DELETE.',
+      },
+    },
+  },
+};
+
+export const ListUnavailable: Story = {
+  name: 'Share list unavailable',
+  beforeEach: stubApi({ list: () => Promise.reject(new Error('service unavailable')) }),
+  play: async () => {
+    const dialog = await waitFor(openDialog);
+    const panel = within(dialog);
+
+    /* The GET failing is treated as "no links", not as an error: the catch sets an
+       empty array and the section simply does not render. So a clinic whose
+       sharing service is down sees a sheet that looks exactly like a companion
+       that has never been shared - and can happily issue a second link. */
+    const primary = await panel.findByRole('button', { name: 'Create shareable card link' });
+    await expect(primary).toBeInTheDocument();
+    await expect(panel.queryByText('Active share links')).not.toBeInTheDocument();
+    await expect(panel.queryByRole('alert')).not.toBeInTheDocument();
+
+    /* And the card above it is fully populated, which is the point: the failure is
+       invisible precisely because everything a reader looks at still rendered. */
+    await expect(panel.getByText('Poppy')).toBeInTheDocument();
+    await expect(panel.getByText('981020034512789')).toBeInTheDocument();
+    await expect(panel.queryByRole('button', { name: 'Revoke' })).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Deliberately non-fatal - the card is read-only data the page already has, and only ' +
+          'the link list needs the sharing service. The cost is that "no links" and "cannot ' +
+          'reach the service" are the same picture.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/companionHistory/components/HistoryDocumentUpload.stories.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/HistoryDocumentUpload.stories.tsx
@@ -1,0 +1,311 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import type { Organisation, UserOrganization } from '@yosemite-crew/types';
+
+import { useOrgStore } from '@/app/stores/orgStore';
+import HistoryDocumentUpload from './HistoryDocumentUpload';
+
+const ORG_ID = 'org-storybook-history';
+
+/**
+ * Seeds the org store the way bootstrap does, and restores it on unmount.
+ *
+ * `PermissionGate` derives the effective permission set from `roleCode` against
+ * the role table rather than reading the stored `effectivePermissions` snapshot,
+ * so seeding the role is most of the fixture - there is no permission array to
+ * keep in sync. OWNER is used here because it is the role a practice owner
+ * actually holds; it is not the discriminating part, since every role in the
+ * table grants `companions:edit:any` (see `REVOKED` below).
+ *
+ * It also gives the form its `issuingBusinessName` default: the component reads
+ * `orgsById[primaryOrgId].name` and writes it into the draft in an effect, so
+ * without a seeded org name that field renders empty and the story would be
+ * showing a state no signed-in user ever sees.
+ */
+const ORG: Organisation = {
+  _id: ORG_ID,
+  name: 'Avenger Park Veterinary',
+  type: 'HOSPITAL',
+  phoneNo: '+49 30 5555 0142',
+  taxId: 'DE-TAX-000000',
+};
+
+const seedOrg = (membership: UserOrganization | null) => () => {
+  const snapshot = useOrgStore.getState();
+  useOrgStore.setState({
+    primaryOrgId: ORG_ID,
+    orgIds: [ORG_ID],
+    membershipsByOrgId: membership ? { [ORG_ID]: membership } : {},
+    orgsById: { [ORG_ID]: ORG },
+    status: 'loaded',
+  });
+  return () => {
+    useOrgStore.setState(snapshot);
+  };
+};
+
+const OWNER: UserOrganization = {
+  practitionerReference: 'Practitioner/user-storybook',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'OWNER',
+  roleDisplay: 'Owner',
+  active: true,
+};
+
+/**
+ * The only honest denied fixture.
+ *
+ * There is no role that lacks this grant: all seven entries in
+ * `ROLE_PERMISSIONS` - down to RECEPTIONIST - carry `companions:edit:any`, so
+ * swapping the role code cannot close this gate and a "receptionist" fixture
+ * would have rendered the trigger and quietly asserted nothing. The only way a
+ * real member loses it is a per-member revocation, which
+ * `resolveMembershipPermissions` subtracts from the role baseline.
+ */
+const REVOKED: UserOrganization = {
+  ...OWNER,
+  roleCode: 'RECEPTIONIST',
+  roleDisplay: 'Receptionist',
+  revokedPermissions: ['companions:edit:any'],
+};
+
+/** The portalled panel, or a thrown error naming what actually happened. */
+const openDialog = (): HTMLElement => {
+  const dialog = document.querySelector('dialog[open]');
+  if (!dialog) throw new Error('No open dialog is mounted on document.body.');
+  return dialog as HTMLElement;
+};
+
+const meta = {
+  title: 'CompanionHistory/HistoryDocumentUpload',
+  component: HistoryDocumentUpload,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The "Upload record" sheet on the companion history timeline. Only the trigger button ' +
+          'has ever been visible in Storybook; everything below it lives behind a local ' +
+          '`uploadOpen` boolean on a component the timeline renders in passing, so the panel ' +
+          'itself, the whole `CompanionDocumentUploadForm` inside it, and the validation ' +
+          'messages `handleSave` writes had never been drawn anywhere.\n\n' +
+          'Two things the stories make visible that reading the code does not.\n\n' +
+          '`handleSave` writes four validation messages and only two of them are reachable. ' +
+          '`emptyCompanionRecord` ships with `category: HEALTH` and ' +
+          '`subcategory: SURGERY_PROCEDURE` already set, and the dropdowns can only replace a ' +
+          'selection, never clear one, so "Category is required" and "Sub-category is required" ' +
+          'cannot be produced through the UI. The reachable pair is title and file.\n\n' +
+          '"File is required" renders once, not twice. The form passes ' +
+          '`formDataErrors.fileUrl` to `CompanionDoc` as `error` **and** renders its own warning ' +
+          'row below it; `CompanionDoc` declares that prop in its type and never reads it, so ' +
+          'the duplicate the code implies does not exist on screen.\n\n' +
+          'The panel is the shared `Modal` at `centered`/`md`, so it is 680px on laptop and up ' +
+          'and re-forms into a grabbered bottom sheet below 768px. It portals to ' +
+          '`document.body`, which is why every query here goes through `document`, not the ' +
+          'canvas.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    companionId: 'companion-poppy-812',
+    onUploaded: fn(),
+  },
+  // Laptop, deliberately: the centered panel re-forms into a bottom sheet below
+  // 768px, so the 680px width assertion only means something above that.
+  globals: { viewport: { value: 'laptop', isRotated: false } },
+  decorators: [
+    (Story) => (
+      <div className="min-h-[420px] bg-[var(--screen)] p-6">
+        <Story />
+      </div>
+    ),
+  ],
+  beforeEach: seedOrg(OWNER),
+} satisfies Meta<typeof HistoryDocumentUpload>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Trigger: Story = {
+  name: 'Closed (trigger only)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // `Primary` with href="#" renders a <button>, not a link - the href is a
+    // legacy prop the component deliberately treats as "not a link".
+    await expect(canvas.getByRole('button', { name: 'Upload record' })).toBeInTheDocument();
+
+    /* A closed ModalBase stays MOUNTED, minus its `open` attribute, so asserting
+       "no dialog" would fail here and asserting "no form" would pass even if the
+       panel were open but empty. `dialog[open]` is the only query that separates
+       the two. */
+    await expect(document.querySelector('dialog[open]')).toBeNull();
+    const dialog = document.querySelector('dialog');
+    await expect(dialog).not.toBeNull();
+    await expect(dialog).toHaveAttribute('inert');
+
+    /* One control on the whole surface. The form inside the closed panel is not
+       rendered lazily - it is mounted the entire time - so counting the canvas's
+       buttons is what proves the sheet's eight controls are behind the portal
+       rather than sitting in the timeline. */
+    await expect(canvas.getAllByRole('button')).toHaveLength(1);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting timeline state: one right-aligned `--cta` pill. The dialog element is ' +
+          'already in `document.body` at this point, without its `open` attribute and with ' +
+          '`inert` set.',
+      },
+    },
+  },
+};
+
+export const SheetOpen: Story = {
+  name: 'Upload sheet (open)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Upload record' }));
+
+    const dialog = await waitFor(openDialog);
+    const panel = within(dialog);
+
+    /* The header title, not the trigger: both carry the string "Upload record",
+       so only the heading role tells them apart.
+
+       Polled, not read once. The `centered` panel carries `transition-opacity
+       duration-300` and flips from `opacity-0` to `opacity-100` in the same
+       commit that adds `open`, so `dialog[open]` exists a full 300ms before the
+       panel has faded in - and at the first frame the computed opacity is
+       exactly `0`, which jest-dom reports as invisible for every descendant.
+       `getByRole` ignores opacity, so the heading is FOUND and then called
+       hidden. Waiting for the fade keeps the assertion instead of dropping it. */
+    const title = panel.getByRole('heading', { level: 2, name: 'Upload record' });
+    await waitFor(() => expect(title).toBeVisible());
+
+    // The whole form, field by field. Three dropdowns, two text inputs, the
+    // issue-date pair, the uploader and Save - eight controls the reviewer has
+    // never been able to see composited together.
+    /* Exact accessible names, not `/Category/`: `LabelDropdown` builds them as
+       `${placeholder}: ${selected.label}`, so these three strings are the evidence
+       that the draft opens with a category and a sub-category ALREADY chosen -
+       which is what makes two of the four validation messages unreachable. A
+       loose regex would have passed on an empty, unselected trigger. */
+    await expect(panel.getByRole('button', { name: 'Category: Health' })).toBeInTheDocument();
+    await expect(
+      panel.getByRole('button', { name: 'Sub-category: Surgery/ Procedure' })
+    ).toBeInTheDocument();
+    await expect(panel.getByRole('button', { name: 'Visit type: Hospital' })).toBeInTheDocument();
+    await expect(panel.getByLabelText('Title')).toHaveValue('');
+    await expect(panel.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+
+    /* The org name is written into the draft by an effect, not by the initial
+       reducer state, so this is the one field that proves the store seed reached
+       the form rather than merely being present. */
+    await expect(panel.getByLabelText('Issuing business name')).toHaveValue(
+      'Avenger Park Veterinary'
+    );
+
+    // `hasIssueDate` defaults to true, so the date field is rendered on open -
+    // the checkbox is a way to REMOVE a field, which is the reverse of how a
+    // "include ..." checkbox usually reads.
+    /* A role query, not `getByLabelText('Include issue date')`: the string is on
+       the wrapping `<label>` AND on the checkbox inside it, so a label query
+       matches two elements and throws before it can assert anything. */
+    await expect(panel.getByRole('checkbox', { name: 'Include issue date' })).toBeChecked();
+
+    // The date field is prefilled with today from `emptyCompanionRecord`, so the
+    // row opens with a value rather than an empty picker.
+    const issueDate = panel.getByLabelText('Issue date') as HTMLInputElement;
+    await expect(issueDate.value).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+
+    /* getBoundingClientRect, not getComputedStyle().width: the panel is padded
+       `px-[26px]`, and the content box would read 628 where the recipe says 680. */
+    await expect(dialog.getBoundingClientRect().width).toBe(680);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The full sheet at laptop width. Content is capped at ' +
+          '`max-h-[calc(100%-1.5rem)]` on the panel and again at `max-h-[80vh]` on the caller’s ' +
+          'scroller, so on a short window the Save button scrolls rather than the panel growing.',
+      },
+    },
+  },
+};
+
+export const ValidationMessages: Story = {
+  name: 'Validation (Save with an empty draft)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Upload record' }));
+
+    const dialog = await waitFor(openDialog);
+    const panel = within(dialog);
+    await userEvent.click(panel.getByRole('button', { name: 'Save' }));
+
+    // Both reachable messages, with their exact copy.
+    const titleError = await panel.findByText('Title is required');
+    await expect(titleError).toBeInTheDocument();
+    await expect(panel.getByText('File is required')).toBeInTheDocument();
+
+    /* The other two messages `handleSave` can write are unreachable: the draft
+       starts with a category and a sub-category selected and the dropdowns cannot
+       clear a selection. Asserting their absence is the point of this story - it
+       is dead validation, not a missing story. */
+    await expect(panel.queryByText('Category is required')).not.toBeInTheDocument();
+    await expect(panel.queryByText('Sub-category is required')).not.toBeInTheDocument();
+
+    /* Exactly one node, not two. The form hands `fileUrl` to `CompanionDoc` as
+       `error` as well, but that component never renders the prop, so a fix there
+       would silently double this message. */
+    await expect(panel.getAllByText('File is required')).toHaveLength(1);
+
+    // A failed save must not dismiss the draft.
+    await expect(document.querySelector('dialog[open]')).not.toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The title error is a `role="alert"` row under its input in `--danger`, with the ' +
+          'input border swapped to `--danger` as well. The file error is a plain warning row ' +
+          'under the uploader with no alert role, so a screen reader announces one of the two ' +
+          'and not the other.',
+      },
+    },
+  },
+};
+
+export const PermissionDenied: Story = {
+  name: 'Without companions:edit:any (revoked)',
+  beforeEach: seedOrg(REVOKED),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* The gate is passed no `fallback` and no `deniedResource`, so a denied member
+       gets literally nothing - not a disabled button, not an explanation. The
+       timeline above it renders as though records simply cannot be uploaded. */
+    await expect(canvas.queryByRole('button', { name: 'Upload record' })).not.toBeInTheDocument();
+
+    /* Nothing at all, rather than "no trigger": the gate returns `null` above the
+       Modal too, so the dialog is not merely closed - it is never mounted, and no
+       control of any kind is left in the canvas. */
+    await expect(canvasElement.querySelectorAll('button')).toHaveLength(0);
+    await expect(document.querySelector('dialog')).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A receptionist whose `companions:edit:any` has been revoked on the membership - the ' +
+          'only shape this state has, since every role grants that permission by default. ' +
+          'Worth seeing next to the trigger story: the two differ by one pill, and nothing on ' +
+          'the page says why it is missing.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/companionHistory/pages/phone/PhoneCompanionRecord.stories.tsx
+++ b/apps/frontend/src/app/features/companionHistory/pages/phone/PhoneCompanionRecord.stories.tsx
@@ -1,0 +1,277 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import { PhoneRecordDetails } from './PhoneCompanionRecord';
+
+/**
+ * The exact six rows `PhoneCompanionRecord` builds, in the order it builds them.
+ *
+ * The page does not hand this component a hand-written list: it runs
+ * `buildCompanionDetails` and then keeps whichever of its nine details match
+ * `['Blood Group', 'Microchip ID', 'Allergies', 'Age / DOB', 'Weight', <patient id label>]`.
+ * `flatMap` preserves the source order rather than the filter order, which is why
+ * Patient ID leads and Blood Group sits fourth. Reordering the filter array would
+ * change nothing on screen - worth knowing before anyone "fixes" the order there.
+ *
+ * The patient-ID label is whatever `replaceCompanionText('Patient ID')` returns,
+ * so a practice that renames companions to patients (or the reverse) renames this
+ * row too. It is spelled out here rather than left as 'Patient ID' by accident.
+ */
+const ROWS = [
+  { label: 'Patient ID', value: 'YC-4471-POPPY' },
+  { label: 'Age / DOB', value: '6 yrs 2 mos · 14 Mar 2020' },
+  { label: 'Weight', value: '11.4 kg' },
+  { label: 'Blood Group', value: 'DEA 1.1 negative' },
+  { label: 'Microchip ID', value: '981020034512789' },
+  { label: 'Allergies', value: 'Cephalosporins; poultry protein' },
+];
+
+const meta = {
+  title: 'CompanionHistory/PhoneRecordDetails',
+  component: PhoneRecordDetails,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The collapsible secondary-details drawer on the bespoke phone companion record. It ' +
+          'had never been drawn, and it could not be: it is a module-private component whose ' +
+          'open state is a local `useState(false)`, inside a screen that only mounts below ' +
+          '768px, below a history timeline that needs the appointment, task and audit services ' +
+          'to render at all. It is exported now so the open state can be reviewed without ' +
+          'standing up that whole page.\n\n' +
+          'Two things are worth looking at rather than reading past.\n\n' +
+          'The trigger promises three fields - "microchip, insurance, blood group" - and the ' +
+          'drawer has never contained an insurance row. `buildCompanionDetails` produces nine ' +
+          'details and none of them is insurance, so the caller cannot pass one; the subtitle ' +
+          'names a field the component has no way to show.\n\n' +
+          'The rows are a `grid-cols-[100px_minmax(0,1fr)]` pair, not a flex row with a gap. ' +
+          'The label column is a hard 100px at every width, so on a 375px screen a long label ' +
+          'wraps inside its own column rather than pushing the value off the right edge - and ' +
+          'the value column is `minmax(0,1fr)` with `break-words`, which is what keeps a ' +
+          '15-digit microchip number from widening the whole sheet.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: { rows: ROWS },
+  // Pinned as a global: `parameters.viewport.defaultViewport` was removed in
+  // Storybook 10 and would render this phone sheet at full panel width while
+  // still passing.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  decorators: [
+    (Story) => (
+      <div className="min-h-[420px] bg-[var(--screen)] px-[18px] py-4">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof PhoneRecordDetails>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** The chevron element inside the disclosure trigger. */
+const chevron = (canvasElement: HTMLElement): SVGElement => {
+  const icon = canvasElement.querySelector('button svg');
+  if (!icon) throw new Error('No chevron inside the disclosure trigger.');
+  return icon as SVGElement;
+};
+
+/**
+ * The chevron's own rotation, read after `transition-transform` has settled.
+ *
+ * Read off the standalone `rotate` property, NOT off `transform`. Tailwind v4
+ * compiles `rotate-180` to `rotate: 180deg` rather than to a `transform`
+ * function, so a flipped chevron computes `transform: none` and
+ * `rotate: 180deg`. Asserting `matrix(-1, 0, 0, -1, 0, 0)` was therefore reading
+ * a property this component never sets, on an element that really was upside
+ * down - a failure about the test, not about the chevron.
+ *
+ * The flip is still animated: v4 expands `transition-transform` to
+ * `transition-property: transform, translate, scale, rotate`, so a synchronous
+ * read can land on an interpolated angle and these are polled.
+ */
+const chevronRotation = (canvasElement: HTMLElement): string =>
+  getComputedStyle(chevron(canvasElement)).rotate;
+
+export const Collapsed: Story = {
+  name: 'Collapsed (resting)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const toggle = canvas.getByRole('button', { expanded: false });
+
+    /* The whole trigger line, not just the subtitle fragment: the bold "Details"
+       and the lighter subtitle are two spans in one row, and reading the button's
+       own text is what catches a wrap or a lost separator between them. The
+       subtitle names insurance, which the open story shows is never there. */
+    await expect(toggle.textContent?.replace(/\s+/g, ' ').trim()).toBe(
+      'Details · microchip, insurance, blood group'
+    );
+
+    // Closed means UNMOUNTED here, not hidden: the `<dl>` is behind a ternary, so
+    // none of the six values exists in the DOM to be found by a search or a screen
+    // reader while the drawer is shut.
+    await expect(canvasElement.querySelector('dl')).toBeNull();
+    await expect(canvas.queryByText('981020034512789')).not.toBeInTheDocument();
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A single full-width `--inset` pill, 12.5px bold label plus a lighter subtitle on one ' +
+          'line, chevron right-aligned. Nothing announces how many fields are inside.',
+      },
+    },
+  },
+};
+
+export const Expanded: Story = {
+  name: 'Expanded (six rows)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const toggle = canvas.getByRole('button', { expanded: false });
+    await userEvent.click(toggle);
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+    const list = await waitFor(() => {
+      const el = canvasElement.querySelector('dl');
+      if (!el) throw new Error('The details list did not mount.');
+      return el;
+    });
+
+    // Six rows, in the order `buildCompanionDetails` emits them.
+    await expect(list.children).toHaveLength(6);
+    await expect([...list.querySelectorAll('dt')].map((dt) => dt.textContent)).toEqual([
+      'Patient ID',
+      'Age / DOB',
+      'Weight',
+      'Blood Group',
+      'Microchip ID',
+      'Allergies',
+    ]);
+    await expect(canvas.getByText('981020034512789')).toBeInTheDocument();
+    await expect(canvas.getByText('Cephalosporins; poultry protein')).toBeInTheDocument();
+
+    /* The trigger says "microchip, insurance, blood group". There is no insurance
+       row and there is no way for the caller to supply one, so the subtitle is
+       advertising a field the drawer cannot contain. */
+    await expect(canvas.queryByText('Insurance')).not.toBeInTheDocument();
+
+    /* One column for the list, two tracks per row, and the label track is a hard
+       100px. `display` is asserted first on purpose: a non-grid element reports
+       `grid-template-columns: none`, which splits to one entry and would have made
+       the single-track check below pass on an element that had lost its grid
+       entirely. A single-track ROW would mean the label/value pair had collapsed
+       into a stack, which looks deliberate enough that nobody would report it. */
+    await expect(getComputedStyle(list).display).toBe('grid');
+    const listTracks = getComputedStyle(list).gridTemplateColumns.trim().split(/\s+/);
+    await expect(listTracks).toHaveLength(1);
+    await expect(listTracks[0]).toMatch(/^\d+(\.\d+)?px$/);
+    const firstRow = list.children[0] as HTMLElement;
+    const tracks = getComputedStyle(firstRow).gridTemplateColumns.trim().split(/\s+/);
+    await expect(tracks).toHaveLength(2);
+    await expect(tracks[0]).toBe('100px');
+    await expect(firstRow.children).toHaveLength(2);
+
+    /* The chevron is upside down. The utility class is asserted next to the
+       computed angle on purpose: together they separate "the flip was never
+       asked for" from "it was asked for and did not resolve", which a single
+       read of either one cannot. */
+    await expect(chevron(canvasElement).getAttribute('class')).toContain('rotate-180');
+    await waitFor(() => {
+      expect(chevronRotation(canvasElement)).toBe('180deg');
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The open drawer. Values are bold `--ink` against `--ink-faint` labels, and the value ' +
+          'column carries `break-words` so a microchip number or a two-drug allergy list wraps ' +
+          'instead of widening the sheet past the 375px screen.',
+      },
+    },
+  },
+};
+
+export const CollapsesAgain: Story = {
+  name: 'Collapses on a second tap',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const toggle = canvas.getByRole('button', { expanded: false });
+
+    await userEvent.click(toggle);
+    const bloodGroup = await canvas.findByText('DEA 1.1 negative');
+    await expect(bloodGroup).toBeInTheDocument();
+
+    await userEvent.click(toggle);
+    await waitFor(() => {
+      expect(canvasElement.querySelector('dl')).toBeNull();
+    });
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    /* Back to no rotation at all. The class is the exact half of this - it is gone
+       or it is not - and the computed angle is the half that proves the flip
+       actually unwound rather than sticking at 180deg. Either spelling of zero is
+       accepted: which of `none` and `0deg` a browser reports for an unrotated
+       element is not part of this component's contract, and 180deg fails both. */
+    await expect(chevron(canvasElement).getAttribute('class')).not.toContain('rotate-180');
+    await waitFor(() => {
+      expect(chevronRotation(canvasElement)).toMatch(/^(none|0deg)$/);
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same button is the close affordance - there is no separate dismiss - so the ' +
+          'chevron flipping back is the only feedback that the tap registered. Asserting the ' +
+          'computed `rotate` returns to `none` is what separates "closed" from "the rows ' +
+          'unmounted but the chevron stayed upside down".',
+      },
+    },
+  },
+};
+
+export const SingleRow: Story = {
+  name: 'One row (sparse record)',
+  args: {
+    rows: [{ label: 'Patient ID', value: 'YC-9902-BRAMBLE' }],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { expanded: false }));
+
+    const list = await waitFor(() => {
+      const el = canvasElement.querySelector('dl');
+      if (!el) throw new Error('The details list did not mount.');
+      return el;
+    });
+    await expect(list.children).toHaveLength(1);
+    await expect([...list.querySelectorAll('dt')].map((dt) => dt.textContent)).toEqual([
+      'Patient ID',
+    ]);
+    await expect([...list.querySelectorAll('dd')].map((dd) => dd.textContent)).toEqual([
+      'YC-9902-BRAMBLE',
+    ]);
+
+    /* The common real case, and the one the copy handles worst: a record with no
+       microchip, no blood group and no allergies still opens a drawer that
+       promises all three. `buildCompanionDetails` renders a missing value as '-',
+       and the page keeps those rows, so a sparse companion gets a list of dashes
+       rather than a shorter list. */
+    await expect(canvas.getByText('· microchip, insurance, blood group')).toBeInTheDocument();
+    await expect(canvas.queryByText('Microchip ID')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The page hides the drawer entirely when `detailRows` is empty, but not when it is ' +
+          'nearly empty. One row still gets the full pill and the full subtitle, which is the ' +
+          'shape a newly registered companion lands in.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/companionHistory/pages/phone/PhoneCompanionRecord.tsx
+++ b/apps/frontend/src/app/features/companionHistory/pages/phone/PhoneCompanionRecord.tsx
@@ -231,8 +231,14 @@ const PhoneParentContact = ({
   );
 };
 
-/** Collapsible secondary-details row (microchip, insurance, blood group …). */
-const PhoneRecordDetails = ({ rows }: { rows: Array<{ label: string; value: string }> }) => {
+/**
+ * Collapsible secondary-details row (microchip, insurance, blood group …).
+ *
+ * Exported for Storybook: the drawer is a local `useState(false)` inside a screen
+ * that only mounts under 768px behind the companion history timeline, so there is
+ * no other way to draw its open state without standing up the whole record page.
+ */
+export const PhoneRecordDetails = ({ rows }: { rows: Array<{ label: string; value: string }> }) => {
   const [open, setOpen] = useState(false);
   return (
     <div className="rounded-[14px] bg-(--inset)">

--- a/apps/frontend/src/app/features/companions/components/AddCompanionCentralModal/AddCompanionCentralModal.stories.tsx
+++ b/apps/frontend/src/app/features/companions/components/AddCompanionCentralModal/AddCompanionCentralModal.stories.tsx
@@ -1,0 +1,376 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import AddCompanionCentralModal from './index';
+
+/** Open dialogs only. A closed one stays mounted, just without its `open` attribute. */
+const openDialogs = (): HTMLDialogElement[] =>
+  [...document.querySelectorAll('dialog[open]')] as HTMLDialogElement[];
+
+/**
+ * Real `showModal` state, so the discard flow can actually close the modal and a
+ * story can tell "the confirm was dismissed" apart from "everything closed".
+ */
+const Harness = () => {
+  const [open, setOpen] = useState(true);
+  return (
+    <div className="min-h-[640px] bg-[var(--screen)] p-6">
+      <p className="text-[13px] text-[var(--ink-muted)]">
+        Companions list behind the modal. The desktop shell portals to `document.body`; the phone
+        sheet does not.
+      </p>
+      <AddCompanionCentralModal showModal={open} setShowModal={setOpen} />
+    </div>
+  );
+};
+
+/** Types a patient name, which is the cheapest way to make the form dirty. */
+const makeDirty = async () => {
+  const body = within(document.body);
+  const name = await body.findByRole('textbox', { name: 'Name' });
+  await userEvent.type(name, 'Poppy');
+  return name;
+};
+
+const meta = {
+  title: 'Companions/AddCompanionCentralModal',
+  component: Harness,
+  parameters: {
+    layout: 'fullscreen',
+    // `useRouter` is called for the "open overview" jump in view mode; without
+    // the app-router mock the modal throws on mount even though create mode
+    // never navigates.
+    nextjs: { appDirectory: true },
+    docs: {
+      description: {
+        component:
+          'The add-companion wizard, and the two surfaces around it that no prop can reach.\n\n' +
+          'The first is the **nested "Discard changes?" confirm**. It is a `CenterModal` ' +
+          'rendered beside the main shell, gated on `showDiscardConfirm`, and the only thing that ' +
+          'sets that flag is an attempted close while `hasUnsavedChanges` is true. Dirtiness is ' +
+          'computed against a baseline snapshot over seven fields (name, species, breed, first, ' +
+          'last, email, phone), so a story has to type into the form before the surface exists ' +
+          'at all. With it open there are **two dialogs open at once**, which is the case the ' +
+          'modal stack in `ModalBase` exists for - Escape and backdrop clicks must reach only ' +
+          'the topmost one, or dismissing the confirm would take the half-filled form with it.\n\n' +
+          'The second is the **phone bottom sheet**. `formVariant` is `sheet` only when ' +
+          '`isCreate && isPhone`, and `useIsPhone` is false during SSR and the first client ' +
+          'render, so this is a post-mount swap that no static desktop snapshot contains. The ' +
+          'sheet is also structurally different, not just narrower: `BottomSheet` renders its ' +
+          '`<dialog>` inline rather than through a portal, it supplies its own grabber and close ' +
+          'row, and the wizard footer drops its inline Cancel because the sheet header already ' +
+          'offers one.\n\n' +
+          'No service is stubbed. The species and breed code lookups both fire on mount and both ' +
+          'swallow their own failures (`.catch` -> `DEFAULT_SPECIES_OPTIONS` / `[]`), and the ' +
+          'parent search only runs on a keystroke in the client column, so create mode renders ' +
+          'fully from an unseeded store.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Harness>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WizardStepOne: Story = {
+  name: 'Create wizard (step 1)',
+  play: async () => {
+    const body = within(document.body);
+
+    /* One dialog, and it is portalled - so `within(canvasElement)` sees none of
+       this. The confirm's own CenterModal is already mounted alongside it
+       without `open`, which is why absence is asserted against `dialog[open]`
+       rather than against the node existing. */
+    await waitFor(() => expect(openDialogs()).toHaveLength(1));
+
+    await expect(body.getByTestId('add-companion-step-subtitle')).toHaveTextContent(
+      'Step 1 of 2 · patient details'
+    );
+    await expect(body.getByRole('textbox', { name: 'Name' })).toHaveValue('');
+    await expect(body.getByRole('button', { name: 'Parent details' })).toBeInTheDocument();
+    await expect(body.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    // Step 2's fields are not merely hidden, they are unmounted - the wizard
+    // renders one column at a time.
+    await expect(body.queryByRole('textbox', { name: 'First name' })).not.toBeInTheDocument();
+    /* The confirm's copy is ALREADY in the DOM - its CenterModal is mounted
+       unconditionally and merely lacks `open` - so "not shown" has to be
+       asserted as not visible. `not.toBeInTheDocument()` here would fail against
+       a perfectly correct closed dialog. */
+    await expect(body.getByText('Discard changes?')).not.toBeVisible();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The state every other story starts from: the centered shell, step 1 of the wizard, ' +
+          'clean. Cancel closes immediately from here, because nothing is dirty yet.',
+      },
+    },
+  },
+};
+
+export const DiscardConfirm: Story = {
+  name: 'Discard changes? (nested confirm)',
+  play: async () => {
+    const body = within(document.body);
+    await makeDirty();
+
+    await userEvent.click(body.getByRole('button', { name: 'Cancel' }));
+
+    // TWO open dialogs: the create shell and the confirm stacked over it. This is
+    // the assertion that proves the parent survived - a confirm that closed its
+    // own parent would leave exactly one.
+    await waitFor(() => expect(openDialogs()).toHaveLength(2));
+
+    const confirm = body.getByText('Discard changes?').closest('dialog') as HTMLElement;
+    await expect(
+      within(confirm).getByText('You have unsaved changes. Are you sure you want to discard them?')
+    ).toBeInTheDocument();
+
+    /* Two plain `<button>`s, not the Primary/Secondary pills used everywhere else
+       in this modal - "Keep editing" is an outlined 2xl button and "Discard" is a
+       `.yc-primary-button`. The destructive action is the FILLED one here, which
+       is the opposite of the usual pairing and worth seeing drawn. */
+    const keep = within(confirm).getByRole('button', { name: 'Keep editing' });
+    const discard = within(confirm).getByRole('button', { name: 'Discard' });
+    await expect(keep).toBeInTheDocument();
+    await expect(discard).toHaveClass('yc-primary-button');
+    // Poll rather than read once: both carry `transition-colors`, so a single
+    // synchronous read can land mid-transition on an interpolated value.
+    await waitFor(() => {
+      expect(getComputedStyle(discard).backgroundColor).not.toBe(
+        getComputedStyle(keep).backgroundColor
+      );
+    });
+
+    // The typed value is still behind the confirm, untouched.
+    await expect(body.getByRole('textbox', { name: 'Name' })).toHaveValue('Poppy');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Type a patient name, then hit Cancel. The confirm is a 500px `CenterModal` over a ' +
+          "`--sh55` scrim with a 6px blur, sitting on top of the shell's own 2px-blur scrim - " +
+          'so the page behind it is blurred twice.',
+      },
+    },
+  },
+};
+
+export const KeepEditing: Story = {
+  name: 'Keep editing returns to the form',
+  play: async () => {
+    const body = within(document.body);
+    await makeDirty();
+    await userEvent.click(body.getByRole('button', { name: 'Cancel' }));
+    await waitFor(() => expect(openDialogs()).toHaveLength(2));
+
+    await userEvent.click(body.getByRole('button', { name: 'Keep editing' }));
+
+    /* Back to one dialog, and the form still holds what was typed. Asserting the
+       count alone would pass if the WRONG dialog had closed, so the surviving
+       field value is checked too. */
+    await waitFor(() => expect(openDialogs()).toHaveLength(1));
+    await expect(body.getByRole('textbox', { name: 'Name' })).toHaveValue('Poppy');
+    await expect(body.getByTestId('add-companion-step-subtitle')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The recovery path. "Keep editing" also clears the pending "go to appointment" flag, so ' +
+          'a later clean close goes back to closing the modal rather than navigating away.',
+      },
+    },
+  },
+};
+
+export const DiscardAndClose: Story = {
+  name: 'Discard closes both',
+  play: async () => {
+    const body = within(document.body);
+    await makeDirty();
+    await userEvent.click(body.getByRole('button', { name: 'Cancel' }));
+    await waitFor(() => expect(openDialogs()).toHaveLength(2));
+
+    await userEvent.click(body.getByRole('button', { name: 'Discard' }));
+
+    // Nothing open. Both dialogs are still in the DOM - they always are - so this
+    // has to be counted over `dialog[open]`.
+    await waitFor(() => expect(openDialogs()).toHaveLength(0));
+
+    /* BOTH of them, checked separately. The count alone would be satisfied by a
+       single surviving-but-closed dialog if the other had been unmounted, and it
+       says nothing about which one closed - so the confirm's copy and the
+       wizard's own subtitle are each asserted invisible. */
+    await expect(body.getByText('Discard changes?')).not.toBeVisible();
+    await expect(body.getByTestId('add-companion-step-subtitle')).not.toBeVisible();
+    /* And the trap itself, pinned rather than avoided. A closed `<dialog>` is
+       `display: none` per the UA sheet, but the panel's own `flex` class beats
+       that rule, so this dialog stays laid out and its subtree stays in the
+       accessibility tree as far as testing-library is concerned: the field is
+       still FOUND by role. `inert` is what actually removes it for a real
+       screen reader, and `isInaccessible` does not model `inert` at all.
+       Asserting all three - found, invisible, inside a closed inert dialog -
+       states the real shape of "the modal is gone" instead of the
+       `not.toBeInTheDocument()` that was here, which described a DOM this app
+       never produces. */
+    const name = body.getByRole('textbox', { name: 'Name' });
+    await expect(name).not.toBeVisible();
+    const shell = name.closest('dialog') as HTMLDialogElement;
+    await expect(shell).not.toHaveAttribute('open');
+    await expect(shell).toHaveAttribute('inert');
+    await expect(getComputedStyle(shell).display).toBe('flex');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The confirm closes itself and then closes the shell, in that order. Both dialogs stay ' +
+          'mounted and merely lose `open`, which is why "the modal is gone" is only true of the ' +
+          '`open` attribute.\n\n' +
+          'It is truer than that, even: the panel class list includes `flex`, which overrides ' +
+          'the user-agent `dialog:not([open]) { display: none }`, so a closed shell keeps a ' +
+          'laid-out subtree and is hidden by `opacity-0` and `pointer-events-none` alone. What ' +
+          'takes it away from assistive tech is `inert` - and that is invisible to ' +
+          'testing-library, so every field in a closed modal is still findable by role.',
+      },
+    },
+  },
+};
+
+export const PhoneSheet: Story = {
+  name: 'Phone: create becomes a bottom sheet',
+  // Pinned as a GLOBAL. `parameters.viewport.defaultViewport` was removed in
+  // Storybook 10 and is inert - a story pinned that way renders the desktop
+  // centered modal under a name that promises a sheet.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const body = within(document.body);
+
+    // `useIsPhone` starts false and flips after mount, so the sheet is a
+    // post-mount swap - poll for it rather than reading once.
+    await waitFor(() => {
+      const dialogs = openDialogs();
+      expect(dialogs).toHaveLength(1);
+      expect(dialogs[0].className).toContain('yc-phone-sheet');
+    });
+    const sheet = openDialogs()[0];
+
+    /* Structurally different, not just narrower: BottomSheet renders its dialog
+       INLINE, so unlike every other modal in this flow it lives inside the
+       story canvas. */
+    await expect(canvasElement.contains(sheet)).toBe(true);
+
+    // Sheet chrome: grabber, title row with its own close, and the pinned footer.
+    await expect(sheet.querySelector('.yc-phone-sheet-grabber')).not.toBeNull();
+    await expect(sheet.querySelector('.yc-phone-sheet-footer')).not.toBeNull();
+    await expect(within(sheet).getByTestId('add-companion-step-subtitle')).toHaveTextContent(
+      'Step 1 of 2 · patient details'
+    );
+
+    /* The footer drops its inline Cancel in the sheet variant - the header X is
+       the close affordance - while keeping the step dots and the advance button.
+       That omission is the one visible behaviour difference in the footer, so it
+       is asserted rather than left to the eye. */
+    const footer = sheet.querySelector('.yc-phone-sheet-footer') as HTMLElement;
+    await expect(
+      within(footer).getByRole('button', { name: 'Parent details' })
+    ).toBeInTheDocument();
+    await expect(within(footer).queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument();
+
+    /* The desktop `AppointmentCentralModalShell` is an early-return branch, so in
+       the phone create path it is never constructed at all. One `.yc-modal-dialog`
+       IS still in the DOM - the discard confirm's CenterModal, which both branches
+       render unconditionally - so this has to be counted over `[open]` rather than
+       over the class, and the confirm's copy is checked for visibility rather
+       than presence. */
+    await expect(body.getByText('Discard changes?')).not.toBeVisible();
+    await expect(document.querySelectorAll('.yc-modal-dialog')).toHaveLength(1);
+    await expect(document.querySelector('.yc-modal-dialog[open]')).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Below 768px the create flow re-forms into a bottom sheet: 24px top radius, a 44x5 ' +
+          'grabber, a title + close row, and the wizard footer pinned to the bottom in ' +
+          '`.yc-phone-sheet-footer`. Edit and view keep the centered modal at every width, so ' +
+          'this swap belongs to the create path alone.',
+      },
+    },
+  },
+};
+
+export const PhoneDiscardConfirm: Story = {
+  name: 'Phone: discard confirm over the sheet',
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const body = within(document.body);
+    await waitFor(() => {
+      expect(openDialogs()[0]?.className).toContain('yc-phone-sheet');
+    });
+    const sheet = openDialogs()[0];
+
+    await makeDirty();
+
+    /* TWO controls are labelled "Close" here - the sheet's X and the full-screen
+       backdrop button behind it - so this has to be scoped to the sheet. A bare
+       `getByRole('button', { name: 'Close' })` throws on the ambiguity. */
+    await userEvent.click(within(sheet).getByRole('button', { name: 'Close' }));
+
+    await waitFor(() => expect(openDialogs()).toHaveLength(2));
+
+    /* VISIBLE, not merely present. `discardConfirm` is rendered unconditionally in
+       both branches of this component, so "Discard changes?" is in the DOM from
+       the first paint and `toBeInTheDocument()` here would pass against a confirm
+       that never opened.
+
+       Polled, because `CenterModal` fades: its panel carries `transition-opacity
+       duration-100` and flips `opacity-0` -> `opacity-100` in the same commit
+       that sets `open`, so the `waitFor` above returns while the computed
+       opacity is still exactly `0`. Everything asserted visible below this line
+       is safe once the fade has landed. */
+    await waitFor(() => expect(body.getByText('Discard changes?')).toBeVisible());
+
+    /* The confirm does NOT re-form for phones: it stays the portalled CenterModal
+       at `w-[90%]`, layered over an in-canvas sheet. Two dialogs from two
+       different mounting strategies is exactly the arrangement that breaks
+       focus traps, so both are pinned here. */
+    const [first, second] = openDialogs();
+    await expect(first.className).toContain('yc-phone-sheet');
+    await expect(second.className).toContain('yc-modal-dialog');
+
+    /* The confirm's own copy and buttons, scoped to it - and the sheet behind it
+       still holding what was typed, which is what makes this a layering story
+       rather than a "something opened" one. */
+    await expect(
+      within(second).getByText('You have unsaved changes. Are you sure you want to discard them?')
+    ).toBeVisible();
+    await expect(within(second).getByRole('button', { name: 'Keep editing' })).toBeVisible();
+    await expect(within(second).getByRole('button', { name: 'Discard' })).toBeVisible();
+    await expect(within(first).getByRole('textbox', { name: 'Name' })).toHaveValue('Poppy');
+
+    /* The two mounting strategies, made checkable: the sheet renders inline and so
+       lives in the story canvas, while the confirm is portalled and sits outside
+       it as a direct child of `document.body`. Asserting the containment is what
+       proves the claim above - a class-name check would still pass if both had
+       ended up in the same tree. */
+    await expect(canvasElement.contains(first)).toBe(true);
+    await expect(canvasElement.contains(second)).toBe(false);
+    await expect(document.body.contains(second)).toBe(true);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The dirty-close path on a phone. The sheet stays put and the same centered confirm ' +
+          'appears over it, so on a 375px screen the confirm is the only element that is not ' +
+          'bottom-anchored.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/companions/pages/Companions/AddTask.stories.tsx
+++ b/apps/frontend/src/app/features/companions/pages/Companions/AddTask.stories.tsx
@@ -1,0 +1,292 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+
+import type {
+  CompanionParent,
+  StoredCompanion,
+  StoredParent,
+} from '@/app/features/companions/pages/Companions/types';
+import AddTask from './AddTask';
+
+const COMPANION: StoredCompanion = {
+  id: 'companion-1',
+  organisationId: 'org-storybook',
+  parentId: 'parent-1',
+  name: 'Poppy',
+  type: 'dog',
+  breed: 'Beagle',
+  dateOfBirth: new Date('2021-04-18T00:00:00.000Z'),
+  gender: 'female',
+  isneutered: true,
+  isInsured: false,
+  source: 'breeder',
+  status: 'active',
+};
+
+const PARENT: StoredParent = {
+  id: 'parent-1',
+  firstName: 'Lena',
+  lastName: 'Hartmann',
+  email: 'lena.hartmann@example.com',
+  phoneNumber: '+49 30 901820',
+  birthDate: new Date('1989-11-02T00:00:00.000Z'),
+  address: {
+    addressLine: 'Wallstrasse 14',
+    city: 'Berlin',
+    state: 'Berlin',
+    postalCode: '10179',
+    country: 'Germany',
+  },
+  createdFrom: 'pms',
+};
+
+const ACTIVE_COMPANION: CompanionParent = { companion: COMPANION, parent: PARENT };
+
+/** The drawer, already open. `showModal` is a prop, so no trigger is needed. */
+const OpenDrawer = () => (
+  <div className="min-h-[640px] bg-[var(--screen)] p-6">
+    <p className="text-[13px] text-[var(--ink-muted)]">
+      Companion overview behind the drawer, so the scrim tint is visible.
+    </p>
+    <AddTask showModal setShowModal={fn()} activeCompanion={ACTIVE_COMPANION} />
+  </div>
+);
+
+/** A real trigger, for the one story that exercises the closed -> open gate. */
+const Triggered = () => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="min-h-[640px] bg-[var(--screen)] p-6">
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="rounded-full bg-primary-600 px-5 py-2 text-[14px] font-semibold text-white"
+      >
+        Add task
+      </button>
+      <AddTask showModal={open} setShowModal={setOpen} activeCompanion={ACTIVE_COMPANION} />
+    </div>
+  );
+};
+
+const openDialog = (): HTMLElement | null => document.querySelector('dialog[open]');
+
+const meta = {
+  title: 'Companions/AddTask',
+  component: OpenDrawer,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The "Add task" drawer from a companion record. It is a `Modal` gated on `showModal` ' +
+          'and had never been drawn, so neither had the eleven-control `TaskFormFields` stack it ' +
+          'wraps: category, priority, task name, instructions, due date, time, reminder and ' +
+          'repeat, plus the end date that only exists once the task repeats.\n\n' +
+          'The drawer is `size="md"`, which is the **470px** form width rather than the 530px ' +
+          'default every other drawer in PIMS uses - a difference invisible without two drawers ' +
+          'side by side, and one that only this story pins.\n\n' +
+          'It does not own its form. `useTaskForm` does, and it pre-stamps `companionId` and ' +
+          '`assignedTo` from the open companion in an effect, which is why an empty submit ' +
+          'produces exactly one error here (the task name) rather than the three a bare task ' +
+          'form would - the assignee is already filled in by the record you opened it from.\n\n' +
+          'Two states are deliberately **not** drawn. `error` ("Failed to create task. Please ' +
+          'try again.") and the `Saving...` / disabled primary both exist only while `createTask` ' +
+          'is in flight or has rejected, and this Storybook has no MSW or module-mock wiring to ' +
+          'force either outcome. Faking them would mean stubbing the task service, which is out ' +
+          'of scope; the validation path below reaches the same form through real code.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof OpenDrawer>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Drawer: Story = {
+  name: 'Add task drawer (open)',
+  play: async () => {
+    const body = within(document.body);
+    const dialog = openDialog();
+    await expect(dialog).not.toBeNull();
+    const panel = within(dialog as HTMLElement);
+
+    await expect(panel.getByText('Add task')).toBeInTheDocument();
+
+    /* The whole field stack, in the single-column order `TaskFormFields` uses
+       when neither `twoColumn` nor `assigneeChips` is set. Asserting the SET
+       matters more than any one field: this drawer passes no audience or
+       assignee props, so a regression that turned those on would add two
+       controls here without breaking anything else. */
+    await expect(panel.getByRole('textbox', { name: 'Task' })).toBeInTheDocument();
+    await expect(panel.getByRole('textbox', { name: 'Instructions (optional)' })).toBeVisible();
+
+    /* Read off the triggers, not off the labels. Every `LabelDropdown` prints its
+       placeholder twice - once as the field label and again inside the trigger
+       whenever nothing is selected - so `getByText('Reminder (optional)')` throws
+       on the ambiguity for exactly the fields that have no value yet. The
+       trigger's `aria-label` is `"<placeholder>: <selection>"`, so splitting on
+       the colon gives the field back either way. */
+    const dropdownNames = [
+      ...(dialog as HTMLElement).querySelectorAll('[aria-haspopup="listbox"]'),
+    ].map((node) => (node.getAttribute('aria-label') ?? '').split(':')[0]);
+    for (const label of ['Category', 'Priority', 'Reminder (optional)', 'Repeat']) {
+      await expect(dropdownNames).toContain(label);
+    }
+    // No audience/assignee dropdowns here - this drawer passes neither
+    // `showAudienceSelect` nor `showAssigneeSelect`, because the companion it was
+    // opened from already decides both.
+    await expect(dropdownNames).not.toContain('Type');
+    await expect(dropdownNames).not.toContain('Assigned to');
+    // "End date" only mounts once the task repeats.
+    await expect(panel.queryByText('End date')).not.toBeInTheDocument();
+
+    // 470px, the `md` drawer. Border box, so getBoundingClientRect - the computed
+    // width would read 469 and look like a rounding bug.
+    await expect(Math.round((dialog as HTMLElement).getBoundingClientRect().width)).toBe(470);
+
+    // Save is enabled and reads its resting label; the loading label is the same
+    // node with different text.
+    const save = panel.getByRole('button', { name: 'Save' });
+    await expect(save).toBeEnabled();
+    await expect(
+      body.queryByText('Failed to create task. Please try again.')
+    ).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting drawer at 470px. The body scrolls under `scrollbar-hidden` while the ' +
+          'header and the stretched footer stay put, so the Save pill is reachable no matter how ' +
+          'far the form is scrolled.',
+      },
+    },
+  },
+};
+
+export const ValidationError: Story = {
+  name: 'Empty submit shows the field error',
+  play: async () => {
+    const dialog = openDialog() as HTMLElement;
+    const panel = within(dialog);
+
+    const task = panel.getByRole('textbox', { name: 'Task' });
+    const restingBorder = getComputedStyle(task).borderTopColor;
+    await expect(panel.queryByRole('alert')).not.toBeInTheDocument();
+
+    await userEvent.click(panel.getByRole('button', { name: 'Save' }));
+
+    /* ONE error, not three. `useTaskForm` validates assignee, name, category and
+       due date, but the drawer's effect has already stamped the assignee from
+       the open companion, the category defaults to CARE and the due date
+       defaults to now - so the task name is the only thing genuinely missing.
+       That is the real shape of this screen's first failed submit. */
+    const alerts = await panel.findAllByRole('alert');
+    await expect(alerts).toHaveLength(1);
+    await expect(alerts[0]).toHaveTextContent('Name is required');
+
+    /* The message is wired to the input, not just placed under it - a red line
+       with no `aria-describedby` is the version of this that ships silently. */
+    await expect(task).toHaveAttribute('aria-invalid', 'true');
+    await expect(task).toHaveAttribute('aria-describedby', alerts[0].id);
+
+    // The border swaps to --danger. Compared against the value read BEFORE the
+    // submit, and polled, because the input carries `transition-colors` - a
+    // single synchronous read lands on an interpolated colour.
+    await waitFor(() => {
+      expect(getComputedStyle(task).borderTopColor).not.toBe(restingBorder);
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Save with nothing typed. The error is the `FormInput` inline row - a warning glyph and ' +
+          'the message in `--danger-text` - and it is cleared by the next keystroke rather than ' +
+          'by a second submit.',
+      },
+    },
+  },
+};
+
+export const OpensFromTrigger: Story = {
+  name: 'Opening from a trigger',
+  render: () => <Triggered />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* Closed does not mean unmounted: the dialog is in the DOM from the first
+       render, just without `open`, so this has to be asserted against
+       `dialog[open]`. The same check written as "no panel in the canvas" passes
+       whether the drawer is open or shut, because it portals to document.body. */
+    await expect(openDialog()).toBeNull();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Add task' }));
+
+    await waitFor(() => expect(openDialog()).not.toBeNull());
+
+    /* And it opens onto a CLEAN form at the drawer's own width, not a half-built
+       one - `resetForm` runs on every close, so what a second open shows is the
+       part of this transition worth pinning. */
+    const panel = within(openDialog() as HTMLElement);
+    await expect(panel.getByText('Add task')).toBeInTheDocument();
+    await expect(panel.getByRole('textbox', { name: 'Task' })).toHaveValue('');
+    await expect(panel.getByRole('textbox', { name: 'Instructions (optional)' })).toHaveValue('');
+    await expect(panel.getByRole('button', { name: 'Save' })).toBeEnabled();
+    await expect(panel.queryByRole('alert')).not.toBeInTheDocument();
+    await expect(Math.round((openDialog() as HTMLElement).getBoundingClientRect().width)).toBe(470);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The real transition, so the drawer slide (`translate-x-[120%]` to `translate-x-0`) and ' +
+          'the scrim fade are under review rather than only the open state. Opening also runs the ' +
+          'effect that stamps the companion and parent ids onto the form, which is what makes the ' +
+          "drawer's validation behave differently from a standalone task form.",
+      },
+    },
+  },
+};
+
+export const Phone: Story = {
+  name: 'Phone: the drawer goes full-screen',
+  // Global, not `parameters.viewport.defaultViewport` - that key was removed in
+  // Storybook 10 and silently leaves the story at desktop width.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async () => {
+    /* `useIsPhone` is false through SSR and the first client render, so the
+       full-screen swap is a post-mount change - poll for the class rather than
+       reading it once. */
+    await waitFor(() => {
+      expect(openDialog()?.className).toContain('yc-modal-fullscreen');
+    });
+    const dialog = openDialog() as HTMLElement;
+
+    /* Full-screen means the panel IS the viewport, not a 470px column. Measured
+       against `documentElement.clientWidth` rather than a literal 375, so a
+       platform that renders a classic scrollbar cannot fail this on a 2px
+       difference that has nothing to do with the layout. */
+    const rect = dialog.getBoundingClientRect();
+    await expect(Math.round(rect.width)).toBe(document.documentElement.clientWidth);
+    await expect(Math.round(rect.left)).toBe(0);
+
+    // A drawer goes full-screen rather than becoming a sheet - no grabber here.
+    await expect(dialog.className).not.toContain('yc-phone-sheet');
+    await expect(dialog.querySelector('.yc-phone-sheet-grabber')).toBeNull();
+    await expect(within(dialog).getByRole('textbox', { name: 'Task' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Below 768px `Modal` re-forms a drawer into a full-screen panel (a `centered` modal ' +
+          'would become a bottom sheet instead). The caller passes nothing for this, so the phone ' +
+          'form of every task drawer is only visible here.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/developers/pages/DeveloperDocs/DeveloperDocs.stories.tsx
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperDocs/DeveloperDocs.stories.tsx
@@ -1,0 +1,237 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import { useAuthStore } from '@/app/stores/authStore';
+import DeveloperDocs from './DeveloperDocs';
+
+/**
+ * Seeds the auth store as a signed-in developer and restores it on unmount.
+ *
+ * `DevRouteGuard` renders nothing at all while `status` is `idle` or `checking`,
+ * and on `/developers/*` it calls `signout()` for an authenticated non-developer.
+ * Both of those are network-adjacent dead ends for a story, so the fixture is the
+ * one combination that simply passes: an authenticated `developer`. No service is
+ * mocked - the guard reads the store directly.
+ */
+const seedDeveloper = () => {
+  const snapshot = useAuthStore.getState();
+  useAuthStore.setState({
+    status: 'authenticated',
+    role: 'developer',
+    user: {
+      userId: 'dev-storybook',
+      email: 'dev@example.test',
+      authProfile: null,
+      loginMethod: 'emailpassword',
+      emailVerified: true,
+      getUsername: () => 'dev-storybook',
+    },
+    attributes: { sub: 'dev-storybook', email: 'dev@example.test' },
+  });
+  return () => {
+    useAuthStore.setState(snapshot);
+  };
+};
+
+const meta = {
+  title: 'Developers/DeveloperDocs',
+  component: DeveloperDocs,
+  parameters: {
+    layout: 'fullscreen',
+    // The guard reads `usePathname()`; on a non-`/developers` path it takes a
+    // different branch entirely, so the route is pinned to the real one.
+    nextjs: { appDirectory: true, navigation: { pathname: '/developers/docs' } },
+    docs: {
+      description: {
+        component:
+          'The in-portal API reference. Two of its states had never been drawn, and both are ' +
+          'reachable in one click from the resting page.\n\n' +
+          '`DocsNavEmpty` replaces the **entire** section list - both headings and all seven ' +
+          'items - the moment the search text matches nothing. It is not a row appended below ' +
+          'the nav: `filteredNav` drops any section whose items filter to zero, and an empty ' +
+          'array swaps the whole map for a single "No matches" line. The Edit-on-GitHub link ' +
+          'survives it, which is the only thing left in the rail.\n\n' +
+          "The article body is a two-way branch on `activeId === 'appointments'` and nothing " +
+          'else. Appointments gets the endpoint strip, the required-fields paragraph, the FHIR ' +
+          'note and the two code panels; every other one of the seven articles gets a title, a ' +
+          'summary and a "this is seed content" note, with the whole `DocsCode` block ' +
+          'unmounted. Six of the seven articles are therefore that second layout, and it had ' +
+          'never been rendered.\n\n' +
+          'The search filters `label` only, so a query that reads like a topic ("auth", ' +
+          '"webhook") works and one that reads like prose ("how do I create a booking") empties ' +
+          'the rail.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  globals: { viewport: { value: 'desktop', isRotated: false } },
+  beforeEach: seedDeveloper,
+} satisfies Meta<typeof DeveloperDocs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** The search field, which every story below drives. */
+const searchBox = (canvasElement: HTMLElement): HTMLElement =>
+  within(canvasElement).getByLabelText('Search docs');
+
+export const Appointments: Story = {
+  name: 'Appointments article (default)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(
+      canvas.getByRole('heading', { name: 'Create an appointment' })
+    ).toBeInTheDocument();
+
+    // Seven nav items across two sections, all present before any filtering, and
+    // the highlight sits on the one the article is showing.
+    await expect(canvasElement.querySelectorAll('.DocsNavItem')).toHaveLength(7);
+    await expect(canvas.getByText('Getting started')).toBeInTheDocument();
+    await expect(canvas.getByText('Guides')).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Appointments API' })).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
+
+    // The appointments-only furniture: endpoint strip plus both code panels.
+    await expect(canvas.getByText('POST')).toBeInTheDocument();
+    await expect(canvas.getByText('/v2/appointments')).toBeInTheDocument();
+    await expect(canvas.getByText('REQUEST · cURL')).toBeInTheDocument();
+    await expect(canvas.getByText('RESPONSE · 201')).toBeInTheDocument();
+    await expect(canvasElement.querySelectorAll('pre')).toHaveLength(2);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The landing article, and the only one of the seven that carries real reference ' +
+          'content. `activeId` is seeded to `appointments` rather than to `overview`, so the ' +
+          'breadcrumb reads "Docs / APIs / Appointments" on first paint while the nav highlight ' +
+          'sits under Getting started.',
+      },
+    },
+  },
+};
+
+export const NavEmpty: Story = {
+  name: 'No matches (nav emptied)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.type(searchBox(canvasElement), 'how do I create a booking');
+
+    const empty = await canvas.findByText('No matches');
+    await expect(empty).toBeInTheDocument();
+
+    /* The empty line REPLACES the sections; it is not appended to them. Counting
+       the nav items is the assertion that separates the two, because the "No
+       matches" text is present either way. */
+    await expect(canvasElement.querySelectorAll('.DocsNavItem')).toHaveLength(0);
+
+    /* The whole rail is gone, not just the items: both section headings and all
+       seven buttons unmount. Asserting the headings separately matters because a
+       filter bug that emptied only the items would leave two orphan headings
+       above the "No matches" line and still satisfy a check for the line alone. */
+    await expect(canvas.queryByText('Getting started')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Guides')).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByRole('button', { name: 'Appointments API' })
+    ).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Overview' })).not.toBeInTheDocument();
+
+    // The GitHub link is outside the branch and survives - the only navigation
+    // left in the sidebar leaves the app entirely.
+    await expect(canvas.getByRole('link', { name: 'Edit on GitHub' })).toBeInTheDocument();
+
+    /* The article does not react to the search at all. Whatever was open stays
+       open behind an empty rail, which is what makes this state recoverable
+       without a reload. */
+    await expect(
+      canvas.getByRole('heading', { name: 'Create an appointment' })
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A plain-prose query, which is how a reader who does not already know the section ' +
+          'names searches. "No matches" is a bare line in the rail with no clear-search ' +
+          'affordance next to it - the only way out is to edit the field.',
+      },
+    },
+  },
+};
+
+export const NavFiltered: Story = {
+  name: 'Search matching one section',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.type(searchBox(canvasElement), 'api');
+
+    /* "Appointments API" and "Patients API" match; the Guides section filters to
+       zero items and is dropped whole, heading included. That second rule is the
+       one worth seeing - a section can disappear while its sibling stays. */
+    await waitFor(() => {
+      expect(canvas.queryByText('Guides')).not.toBeInTheDocument();
+    });
+    await expect(canvas.getByText('Getting started')).toBeInTheDocument();
+    await expect(canvasElement.querySelectorAll('.DocsNavItem')).toHaveLength(2);
+    await expect(
+      [...canvasElement.querySelectorAll('.DocsNavItem')].map((item) => item.textContent)
+    ).toEqual(['Appointments API', 'Patients API']);
+    await expect(canvas.queryByRole('button', { name: 'Overview' })).not.toBeInTheDocument();
+    await expect(canvas.queryByText('No matches')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The in-between state. Matching is a case-insensitive `includes` on the label only, ' +
+          'so "api" keeps two items whose titles contain it and drops "Authentication", which ' +
+          'is unambiguously an API topic.',
+      },
+    },
+  },
+};
+
+export const SeedContentArticle: Story = {
+  name: 'Non-appointments article (seed content)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Webhooks' }));
+
+    const heading = await canvas.findByRole('heading', { name: 'Webhooks' });
+    await expect(heading).toBeInTheDocument();
+    await expect(
+      canvas.getByText(
+        'This reference is seed content. Open the full documentation for the complete API reference.'
+      )
+    ).toBeInTheDocument();
+
+    /* Everything appointments-specific unmounts together: the endpoint strip, the
+       required-fields paragraph, the FHIR note and BOTH code panels. Six of the
+       seven articles land here, so this - not the appointments page - is the
+       layout a reader most often sees. */
+    await expect(canvas.queryByText('POST')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('REQUEST · cURL')).not.toBeInTheDocument();
+    await expect(canvasElement.querySelectorAll('pre')).toHaveLength(0);
+
+    /* The breadcrumb does follow the selection, and it is read off its own element
+       rather than by text: "Getting started" and "Webhooks" both also exist as nav
+       labels, so a text query would match the rail and pass with the crumb stale. */
+    const crumb = canvasElement.querySelector('.DocsBreadcrumb');
+    if (!crumb) throw new Error('The breadcrumb did not render.');
+    await expect(crumb.textContent).toBe('Docs / Getting started / Webhooks');
+    await expect(canvas.getByText('v2 · STABLE')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The article column collapses to roughly a third of its height here because ' +
+          '`DocsCode` is gone, so the page bottom moves a long way up between two adjacent nav ' +
+          'items. Worth reviewing next to the appointments story rather than on its own.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/developers/pages/DeveloperSettings/DeveloperSettings.stories.tsx
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperSettings/DeveloperSettings.stories.tsx
@@ -1,0 +1,304 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import { useAuthStore } from '@/app/stores/authStore';
+import DeveloperSettings from './DeveloperSettings';
+
+/**
+ * Seeds the auth store as a signed-in developer and restores it on unmount.
+ *
+ * The page reads its whole profile column off `attributes`, which SuperTokens
+ * fills from the user profile rather than from a decoded JWT - so the fixture is
+ * a flat claims record, and `email_verified` is the STRING 'true' because
+ * `attributes` is typed `Record<string, string>`. The component accepts either
+ * form, which is worth knowing before anyone "tidies" that comparison.
+ *
+ * `DevRouteGuard` renders nothing while status is `idle`/`checking`, so the
+ * status matters as much as the claims.
+ */
+const seedDeveloper = (attributes: Record<string, string>) => () => {
+  const snapshot = useAuthStore.getState();
+  useAuthStore.setState({
+    status: 'authenticated',
+    role: 'developer',
+    user: {
+      userId: 'dev-storybook',
+      email: 'ravi@example.test',
+      authProfile: null,
+      loginMethod: 'emailpassword',
+      emailVerified: true,
+      getUsername: () => 'dev-storybook',
+    },
+    attributes,
+  });
+  return () => {
+    useAuthStore.setState(snapshot);
+  };
+};
+
+const VERIFIED = {
+  sub: 'dev-storybook',
+  given_name: 'Ravi',
+  family_name: 'Patel',
+  email: 'ravi@example.test',
+  email_verified: 'true',
+  'custom:company': 'Timm Devices GmbH',
+};
+
+const meta = {
+  title: 'Developers/DeveloperSettings',
+  component: DeveloperSettings,
+  parameters: {
+    layout: 'fullscreen',
+    nextjs: { appDirectory: true, navigation: { pathname: '/developers/settings' } },
+    docs: {
+      description: {
+        component:
+          'The developer account page. Both of its destructive actions are **inline confirm ' +
+          'swaps** rather than modals, and neither armed state had ever been drawn.\n\n' +
+          'Pressing "Revoke all" does not open a dialog: the danger button is replaced in ' +
+          'place by a "Confirm revoke" / "Cancel" pair inside the same `dev-danger-actions` ' +
+          'span, so the row silently changes width and the original button is gone from the ' +
+          'DOM. "Rotate now" does the same thing inside a sentence - it is an inline link in ' +
+          '"Signing secret rotated 14 days ago. Rotate now", and arming it swaps that one word ' +
+          'for two words, reflowing the sentence.\n\n' +
+          'The two flags are independent `useState` booleans with no coordination, so both can ' +
+          'be armed at once - and then the page carries two buttons labelled exactly "Cancel", ' +
+          'one in each column, with nothing in either accessible name to say which is which. ' +
+          'That combination has a story below because it is one click away, not because it is ' +
+          'exotic.\n\n' +
+          'Neither confirm actually does anything yet. `handleRevoke` and `handleRotate` ' +
+          'disarm the swap and raise a "coming soon" warning toast, which is the honest state ' +
+          'of the key-management API and is why the page carries its own "Preview" disclaimer.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  globals: { viewport: { value: 'desktop', isRotated: false } },
+  beforeEach: seedDeveloper(VERIFIED),
+} satisfies Meta<typeof DeveloperSettings>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Resting: Story = {
+  name: 'Resting (nothing armed)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // The profile column, derived from the claims rather than typed in.
+    await expect(canvas.getAllByText('Ravi Patel')).toHaveLength(2);
+    await expect(canvas.getByText('RP')).toBeInTheDocument();
+    await expect(canvas.getByText('Timm Devices GmbH')).toBeInTheDocument();
+    await expect(canvas.getByText('Verified')).toBeInTheDocument();
+
+    // Both actions in their resting form, and neither confirm present.
+    await expect(canvas.getByRole('button', { name: 'Revoke all' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Rotate now' })).toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument();
+
+    // Three switches, two on by default. They are `role="switch"` buttons, so the
+    // state is in `aria-checked` rather than in a checkbox.
+    await expect(
+      canvas.getByRole('switch', { name: 'Email me on failed deliveries' })
+    ).toBeChecked();
+    await expect(canvas.getByRole('switch', { name: 'Weekly usage digest' })).toBeChecked();
+    await expect(
+      canvas.getByRole('switch', { name: 'Platform changelog emails' })
+    ).not.toBeChecked();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Two columns: profile and danger zone on the left, webhooks and notifications on the ' +
+          'right. The name renders twice - once in the header chip beside the initials, once as ' +
+          'the "Developer name" field - which is why the assertion counts two nodes rather than ' +
+          'finding one.',
+      },
+    },
+  },
+};
+
+export const ConfirmRevokeArmed: Story = {
+  name: 'Revoke all (armed)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Revoke all' }));
+
+    const confirmRevoke = await canvas.findByRole('button', { name: 'Confirm revoke' });
+    await expect(confirmRevoke).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+
+    /* A swap, not an addition. The original trigger is removed from the DOM, so a
+       reader who armed this by accident has no "Revoke all" to click again - only
+       Cancel gets them back. */
+    await expect(canvas.queryByRole('button', { name: 'Revoke all' })).not.toBeInTheDocument();
+
+    // The explanatory copy stays put, so the row keeps its two-line description
+    // beside a control that is now twice as wide.
+    await expect(canvas.getByText('Revoke all API keys')).toBeInTheDocument();
+    await expect(
+      canvas.getByText('Every integration stops immediately. Cannot be undone.')
+    ).toBeInTheDocument();
+
+    /* Confirm is the destructive one and is the only control tinted with the
+       danger token. Polled rather than read once, because these buttons carry a
+       colour transition and a single synchronous read catches an interpolated
+       value partway through it. */
+    const confirm = canvas.getByRole('button', { name: 'Confirm revoke' });
+    const cancel = canvas.getByRole('button', { name: 'Cancel' });
+    await waitFor(() => {
+      expect(getComputedStyle(confirm).color).not.toBe(getComputedStyle(cancel).color);
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The armed danger row. Confirming raises a "Key management API coming soon" warning ' +
+          'toast and disarms - no keys exist to revoke yet, which the page says out loud in its ' +
+          'Preview line.',
+      },
+    },
+  },
+};
+
+export const ConfirmRevokeCancelled: Story = {
+  name: 'Revoke all (cancelled)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Revoke all' }));
+    await userEvent.click(await canvas.findByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() => {
+      expect(canvas.getByRole('button', { name: 'Revoke all' })).toBeInTheDocument();
+    });
+    await expect(canvas.queryByRole('button', { name: 'Confirm revoke' })).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument();
+
+    /* One control in the actions span, not two - cancelling has to remove BOTH
+       swapped buttons, and a leftover Cancel beside a restored "Revoke all" would
+       still satisfy the two absence checks above if only one of them regressed. */
+    const actions = canvasElement.querySelector('.dev-danger-actions');
+    if (!actions) throw new Error('The danger-zone actions span did not render.');
+    await expect(actions.querySelectorAll('button')).toHaveLength(1);
+    await expect(actions.textContent).toBe('Revoke all');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Back to the resting row. Nothing else on the page changed, so this is the only ' +
+          'evidence that the swap is reversible.',
+      },
+    },
+  },
+};
+
+export const ConfirmRotateArmed: Story = {
+  name: 'Rotate signing secret (armed)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Rotate now' }));
+
+    const confirmRotate = await canvas.findByRole('button', { name: 'Confirm rotate' });
+    await expect(confirmRotate).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Rotate now' })).not.toBeInTheDocument();
+
+    /* The swap happens INSIDE a sentence, so the surrounding copy has to still
+       read correctly around two buttons instead of one. Reading the whole card's
+       text is the only way to see that; querying the buttons alone would not
+       catch a sentence that now says "rotated 14 days ago. Confirm rotate Cancel"
+       with no separator. */
+    const card = canvasElement.querySelector('.dev-secret-card');
+    if (!card) throw new Error('The signing-secret card did not render.');
+    await expect(card.textContent).toContain('Signing secret rotated 14 days ago.');
+    await expect(card.textContent).toContain('Confirm rotate');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The inline variant. Because the controls are inside running text, arming it reflows ' +
+          'the sentence and can push it onto a second line inside the card - the only place on ' +
+          'the page where a confirm changes the height of its container.',
+      },
+    },
+  },
+};
+
+export const BothArmed: Story = {
+  name: 'Both confirms armed (two Cancels)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Revoke all' }));
+    await userEvent.click(canvas.getByRole('button', { name: 'Rotate now' }));
+
+    /* `confirmRevoke` and `confirmRotate` are independent booleans, so arming one
+       does not disarm the other. The result is two buttons whose accessible name
+       is exactly "Cancel", in two different columns, cancelling two different
+       things - indistinguishable to anyone navigating by name. */
+    const cancels = canvas.getAllByRole('button', { name: 'Cancel' });
+    await expect(cancels).toHaveLength(2);
+    await expect(canvas.getByRole('button', { name: 'Confirm revoke' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Confirm rotate' })).toBeInTheDocument();
+
+    /* And they are in two different cards, which is what makes the duplicate name
+       a problem rather than a rendering artefact: one lives in the danger zone on
+       the left, the other inside the signing-secret sentence on the right. */
+    await expect(cancels[0].closest('.dev-danger-actions')).not.toBeNull();
+    await expect(cancels[0].closest('.dev-secret-card')).toBeNull();
+    await expect(cancels[1].closest('.dev-secret-card')).not.toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'One click apart from either single-armed story, and the state a reader lands in by ' +
+          'exploring the page. Naming the two buttons "Cancel revoke" and "Cancel rotation" ' +
+          'would cost nothing and is what the rest of PIMS does.',
+      },
+    },
+  },
+};
+
+export const UnverifiedEmail: Story = {
+  name: 'Unverified contact email',
+  beforeEach: seedDeveloper({
+    sub: 'dev-storybook',
+    given_name: 'Ravi',
+    family_name: 'Patel',
+    email: 'ravi@example.test',
+    email_verified: 'false',
+  }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const badge = canvas.getByText('Unverified');
+    await expect(canvas.queryByText('Verified')).not.toBeInTheDocument();
+
+    /* The two badges are different elements, not one element with different copy:
+       the verified branch renders `.dev-settings-verified` WITH a checkmark glyph,
+       this one renders `.dev-settings-unverified` with no glyph at all. Asserting
+       the class and the missing icon is what pins that difference. */
+    await expect(badge).toHaveClass('dev-settings-unverified');
+    await expect(badge.querySelector('svg')).toBeNull();
+    await expect(canvasElement.querySelector('.dev-settings-verified')).toBeNull();
+
+    /* No `custom:company` claim at all, which is the state every developer who
+       signed up without one is in: the field reads the literal string "Not set"
+       rather than being hidden. */
+    await expect(canvas.getByText('Not set')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The unverified badge is plain text with no icon, where the verified one carries a ' +
+          'filled checkmark - so the two differ by more than a word, and the weaker state is ' +
+          'the quieter of the two.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/documents/components/CompanionDocumentsSection.stories.tsx
+++ b/apps/frontend/src/app/features/documents/components/CompanionDocumentsSection.stories.tsx
@@ -1,0 +1,531 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import type { AxiosAdapter, AxiosResponse } from 'axios';
+import type { Organisation, UserOrganization } from '@yosemite-crew/types';
+
+import api from '@/app/services/axios';
+import { useOrgStore } from '@/app/stores/orgStore';
+import type { CompanionRecord } from '@/app/features/documents/types/companionDocuments';
+import CompanionDocumentsSection from './CompanionDocumentsSection';
+
+const ORG_ID = 'org-avenger-park';
+const ORG_NAME = 'Avenger Park Veterinary';
+
+const record = (over: Partial<CompanionRecord> & { title: string }): CompanionRecord => ({
+  category: 'HEALTH',
+  subcategory: 'LAB_TEST',
+  attachments: [{ key: 'doc.pdf', mimeType: 'application/pdf', size: 184_320 }],
+  pmsVisible: true,
+  ...over,
+});
+
+/**
+ * Five records over two months, chosen so every filter pill in the strip has
+ * something to select and the month grouping has more than one bucket.
+ *
+ * The lifecycle pills are the fiddly part. `deriveRecordLifecycle` resolves in
+ * order - explicit `lifecycle`, then `signedAt`, then a `sourceKind` other than
+ * 'DOCUMENT', then the uploader ids - and `getAvailableLifecycleTabs` renders a
+ * pill only for a lifecycle some loaded record actually reaches, minus
+ * `uploaded` (which would collide with the source pill of the same name). So
+ * exactly one record carries `sourceKind` and exactly one carries `signedAt`,
+ * which is what puts Generated and Signed on screen and keeps Requested off it.
+ */
+const RECORDS: CompanionRecord[] = [
+  record({
+    id: 'rec-1',
+    title: 'Rabies vaccination certificate',
+    subcategory: 'VACCINATION',
+    issueDate: '2026-07-14',
+    issuingBusinessName: ORG_NAME,
+    syncedFromPms: true,
+    uploadedByPmsUserId: 'pms-user-1',
+  }),
+  record({
+    id: 'rec-2',
+    title: 'Dental chart and treatment plan',
+    subcategory: 'SURGERY_PROCEDURE',
+    issueDate: '2026-07-02',
+    issuingBusinessName: ORG_NAME,
+    syncedFromPms: true,
+    // Anything other than a plain 'DOCUMENT' is a rendered artifact: this is the
+    // only record that puts the Generated pill on screen.
+    sourceKind: 'TEMPLATE_INSTANCE',
+  }),
+  record({
+    id: 'rec-3',
+    title: 'Discharge summary, overnight stay',
+    subcategory: 'DISCHARGE_SUMMARY',
+    issueDate: '2026-06-28',
+    attachments: [
+      { key: 'discharge.pdf', mimeType: 'application/pdf' },
+      { key: 'meds.pdf', mimeType: 'application/pdf' },
+    ],
+    uploadedByParentId: 'parent-1',
+  }),
+  record({
+    id: 'rec-4',
+    title: 'Pre-anaesthetic bloods',
+    issueDate: '2026-06-11',
+    issuingBusinessName: ORG_NAME,
+    syncedFromPms: true,
+    // Outranks sourceKind, so this record is Signed rather than Generated.
+    signedAt: '2026-06-12T09:00:00.000Z',
+  }),
+  record({
+    id: 'rec-5',
+    title: 'Grooming record from previous clinic',
+    category: 'HYGIENE_MAINTENANCE',
+    subcategory: 'GROOMING',
+    issueDate: '2026-06-03',
+    issuingBusinessName: 'Bayside Grooming',
+    uploadedByParentId: 'parent-1',
+  }),
+];
+
+/** Every record synced, so the always-present Uploaded pill selects nothing. */
+const SYNCED_ONLY: CompanionRecord[] = [
+  record({
+    id: 'sync-1',
+    title: 'Feline leukaemia panel',
+    issueDate: '2026-07-09',
+    issuingBusinessName: ORG_NAME,
+    syncedFromPms: true,
+    uploadedByPmsUserId: 'pms-user-1',
+  }),
+  record({
+    id: 'sync-2',
+    title: 'Weight and body condition score',
+    issueDate: '2026-07-01',
+    issuingBusinessName: ORG_NAME,
+    syncedFromPms: true,
+    uploadedByPmsUserId: 'pms-user-1',
+  }),
+];
+
+const COMPANION = {
+  full: 'companion-records-full',
+  syncedOnly: 'companion-records-synced',
+  empty: 'companion-records-empty',
+};
+
+const RECORDS_BY_COMPANION: Record<string, CompanionRecord[]> = {
+  [COMPANION.full]: RECORDS,
+  [COMPANION.syncedOnly]: SYNCED_ONLY,
+  [COMPANION.empty]: [],
+};
+
+/**
+ * The loaded list is unreachable without an answer from
+ * `GET /v1/document/pms/:companionId`. There is no store to seed here - the
+ * section holds its records in `useState` and fills them from the service on
+ * mount - and this project has no MSW or `sb.mock` wiring, so the stub is the
+ * shared axios instance's *adapter*, the seam axios documents for exactly this
+ * and the same one `ShareEntityModal.stories.tsx` uses.
+ *
+ * It routes on the companion id in the URL rather than on which story installed
+ * it. Autodocs mounts every story on this page against one axios instance at
+ * once, so a per-story adapter is a race: whichever installed last answers for
+ * all of them, and a teardown can restore another story's stub. Routing on the
+ * request makes every installed adapter behave identically, and the teardown
+ * puts back the REAL adapter rather than "whatever was there before".
+ */
+const REAL_ADAPTER = api.defaults.adapter;
+
+const documentsAdapter: AxiosAdapter = async (config) => {
+  const url = String(config.url ?? '');
+  const companionId = Object.keys(RECORDS_BY_COMPANION).find((id) => url.includes(id));
+  if (!companionId) {
+    throw new Error(`Unstubbed request in CompanionDocumentsSection.stories: ${url}`);
+  }
+  const response: AxiosResponse = {
+    data: RECORDS_BY_COMPANION[companionId],
+    status: 200,
+    statusText: 'OK',
+    headers: {},
+    config,
+  };
+  return response;
+};
+
+/**
+ * An OWNER membership plus the org name.
+ *
+ * The whole section sits behind `companions:view:any` and the upload CTA behind
+ * `companions:edit:any`, and `usePermissions` derives both from `roleCode`
+ * against the role table rather than from any stored snapshot - so seeding the
+ * role is the entire fixture. `status: 'loaded'` matters as much as the
+ * membership: `isLoading` is true while the store is 'idle', and the gate
+ * renders its (null) skeleton rather than the fallback, which looks exactly
+ * like a component that failed to mount.
+ */
+const OWNER: UserOrganization = {
+  practitionerReference: 'Practitioner/user-storybook',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'OWNER',
+  roleDisplay: 'Owner',
+  active: true,
+};
+
+const seedEnvironment = () => {
+  const snapshot = useOrgStore.getState();
+  api.defaults.adapter = documentsAdapter;
+
+  useOrgStore.setState({
+    primaryOrgId: ORG_ID,
+    orgIds: [ORG_ID],
+    orgsById: { [ORG_ID]: { _id: ORG_ID, name: ORG_NAME } as unknown as Organisation },
+    membershipsByOrgId: { [ORG_ID]: OWNER },
+    status: 'loaded',
+  });
+
+  return () => {
+    api.defaults.adapter = REAL_ADAPTER;
+    useOrgStore.setState(snapshot);
+  };
+};
+
+/** Each row is a button labelled `Open <title>`; this is the list in DOM order. */
+const rowTitles = (canvasElement: HTMLElement): string[] =>
+  within(canvasElement)
+    .queryAllByRole('button', { name: /^Open / })
+    .map((row) => row.getAttribute('aria-label') ?? '');
+
+/** The month heading div, used as the handle for its whole group. */
+const monthGroup = (canvasElement: HTMLElement, label: string): HTMLElement =>
+  within(canvasElement).getByText(label).parentElement as HTMLElement;
+
+const meta = {
+  title: 'Documents/CompanionDocumentsSection',
+  component: CompanionDocumentsSection,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The companion records tab. It has two entirely different faces, and until now only the ' +
+          'empty one had ever been drawn: `records.length === 0` renders ' +
+          '`CompanionRecordsEmptyState`, and **everything else in the file is behind a non-empty ' +
+          'answer from `loadCompanionDocument`** - the filter strip, the sort toggle and the ' +
+          'month-grouped list. Mount it without a stub and you always get the empty state, so ' +
+          'the majority of the component was invisible in Storybook and in Chromatic.\n\n' +
+          'The filter strip is not a fixed set of pills. Three source pills (All / Uploaded / ' +
+          'Synced) always render, and the design’s lifecycle pills are appended **only for ' +
+          'lifecycles some loaded record actually resolves to** - so the strip is 3 pills or 5 ' +
+          'depending entirely on the data, and today most of those signals (`lifecycle`, ' +
+          '`signedAt`, a non-`DOCUMENT` `sourceKind`) are fields the endpoint does not populate ' +
+          'yet. The fixture below supplies them so the pills can be reviewed before the backend ' +
+          'lands them.\n\n' +
+          'Two behaviours worth looking at deliberately, because both are easy to break and ' +
+          'neither is visible in a single snapshot. The **All pill counts `records.length`, not ' +
+          'the filtered list**, so it stays at 5 while a filter shows 3 - it is a total, not a ' +
+          'result count. And an active lifecycle filter whose pill disappears on the next load ' +
+          'falls back to All during render rather than in an effect, so the list never flashes ' +
+          'empty on the way to correcting itself.\n\n' +
+          'Sorting is on the *effective* date (`issueDate || createdAt || updatedAt`) and ' +
+          'undated records always sink to the bottom regardless of direction, since neither end ' +
+          'of a date range is an honest place for a record with no date.\n\n' +
+          'No row here shows the veterinarian’s "Review and attest" action, and that is correct ' +
+          'rather than missing: `PassportAttestationAction` returns null unless the record carries ' +
+          'a `passportRecordId`, which the documents endpoint does not return yet. These fixtures ' +
+          'deliberately leave it off, so the rows below are the shape every role sees today.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: { companionId: COMPANION.full },
+  decorators: [
+    (Story) => (
+      <div className="min-h-[640px] w-full max-w-[900px] bg-[var(--screen)] p-5">
+        <Story />
+      </div>
+    ),
+  ],
+  beforeEach: seedEnvironment,
+} satisfies Meta<typeof CompanionDocumentsSection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const LoadedRecords: Story = {
+  name: 'Loaded records',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // findBy, not getBy: the first render is the empty state, because `records`
+    // starts as [] and the service answers a tick later.
+    const first = await canvas.findByRole('button', {
+      name: 'Open Rabies vaccination certificate',
+    });
+    /* The row's meta line, not just "a row appeared". Both halves are derived
+       rather than echoed from the fixture: the label comes from the subcategory
+       option table and the summary counts the attachments and reads the MIME
+       subtype, so a row that lost either would still render and still match a
+       plain existence check. */
+    await expect(within(first).getByText('Vaccination · 1 file (PDF)')).toBeInTheDocument();
+
+    /* Five pills, and only All is pressed. Generated and Signed exist solely
+       because one fixture record carries `sourceKind` and another `signedAt`;
+       Requested has no derivation at all today, so its pill must NOT appear. */
+    const pills = ['All · 5', 'Uploaded', 'Synced', 'Generated', 'Signed'];
+    await expect(
+      pills.map((name) => canvas.getByRole('button', { name }).getAttribute('aria-pressed'))
+    ).toEqual(['true', 'false', 'false', 'false', 'false']);
+    await expect(canvas.queryByRole('button', { name: 'Requested' })).not.toBeInTheDocument();
+
+    // Newest first is the default, so July precedes June and the rows descend.
+    await expect(canvas.getByRole('button', { name: 'Newest first' })).toBeInTheDocument();
+    await expect(rowTitles(canvasElement)).toEqual([
+      'Open Rabies vaccination certificate',
+      'Open Dental chart and treatment plan',
+      'Open Discharge summary, overnight stay',
+      'Open Pre-anaesthetic bloods',
+      'Open Grooming record from previous clinic',
+    ]);
+
+    // Two month buckets carrying 2 and 3 rows, in that vertical order.
+    const july = canvas.getByText('July 2026');
+    const june = canvas.getByText('June 2026');
+    await expect(july.getBoundingClientRect().top).toBeLessThan(june.getBoundingClientRect().top);
+    await expect(rowTitles(monthGroup(canvasElement, 'July 2026'))).toHaveLength(2);
+    await expect(rowTitles(monthGroup(canvasElement, 'June 2026'))).toHaveLength(3);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting list. Month labels come from UTC parts, so a date-only value such as ' +
+          '`2026-07-02` cannot slide into June for a reviewer sitting west of UTC - the row’s own ' +
+          'date line is formatted in the preferred timezone, but the bucket it lands in is not.',
+      },
+    },
+  },
+};
+
+export const OldestFirst: Story = {
+  name: 'Sort toggled to oldest first',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const toggle = await canvas.findByRole('button', { name: 'Newest first' });
+    await userEvent.click(toggle);
+
+    // The label is the state, not a command: it now reads what the list is doing.
+    await canvas.findByRole('button', { name: 'Oldest first' });
+    await expect(canvas.queryByRole('button', { name: 'Newest first' })).not.toBeInTheDocument();
+
+    await expect(rowTitles(canvasElement)).toEqual([
+      'Open Grooming record from previous clinic',
+      'Open Pre-anaesthetic bloods',
+      'Open Discharge summary, overnight stay',
+      'Open Dental chart and treatment plan',
+      'Open Rabies vaccination certificate',
+    ]);
+    // The buckets reorder with the rows rather than staying pinned newest-first.
+    const june = canvas.getByText('June 2026');
+    const july = canvas.getByText('July 2026');
+    await expect(june.getBoundingClientRect().top).toBeLessThan(july.getBoundingClientRect().top);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The grouping is applied *after* the sort, so flipping the direction reorders the ' +
+          'month headings too. Grouping first and sorting inside each bucket would leave July ' +
+          'stranded above June while its rows ran the other way.',
+      },
+    },
+  },
+};
+
+export const SyncedFilter: Story = {
+  name: 'Filtered to synced records',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const synced = await canvas.findByRole('button', { name: 'Synced' });
+    await userEvent.click(synced);
+
+    await waitFor(() => expect(rowTitles(canvasElement)).toHaveLength(3));
+    await expect(rowTitles(canvasElement)).toEqual([
+      'Open Rabies vaccination certificate',
+      'Open Dental chart and treatment plan',
+      'Open Pre-anaesthetic bloods',
+    ]);
+
+    // Selection moved, and the All pill still shows the TOTAL, not the 3 on screen.
+    await expect(synced).toHaveAttribute('aria-pressed', 'true');
+    const all = canvas.getByRole('button', { name: 'All · 5' });
+    await expect(all).toHaveAttribute('aria-pressed', 'false');
+
+    /* The selected pill is the only one with the chip fill. Polled rather than
+       read once: the pills are plain bordered buttons whose colours come from
+       tokens on a class swap, and reading in the same frame as the click can
+       catch the outgoing value. */
+    await waitFor(() => {
+      expect(getComputedStyle(synced).backgroundColor).not.toBe(
+        getComputedStyle(all).backgroundColor
+      );
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`syncedFromPms` means "created through the PMS by a staff user", which is why the two ' +
+          'pet-parent uploads drop out here and the generated and signed records stay: both were ' +
+          'still produced inside the practice.',
+      },
+    },
+  },
+};
+
+export const GeneratedLifecycle: Story = {
+  name: 'Filtered to the generated lifecycle',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const generated = await canvas.findByRole('button', { name: 'Generated' });
+    await userEvent.click(generated);
+
+    await waitFor(() =>
+      expect(rowTitles(canvasElement)).toEqual(['Open Dental chart and treatment plan'])
+    );
+    await expect(generated).toHaveAttribute('aria-pressed', 'true');
+
+    // One record left, so one bucket - June's heading goes with its rows.
+    await expect(canvas.getByText('July 2026')).toBeInTheDocument();
+    await expect(canvas.queryByText('June 2026')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A lifecycle pill rather than a source pill. The filter values are namespaced ' +
+          '(`LIFECYCLE_GENERATED`) precisely so they cannot collide with the source values in the ' +
+          'same `RecordFilter` union - the two dimensions share one piece of state and one strip.',
+      },
+    },
+  },
+};
+
+export const NoRecordsMatchTheFilter: Story = {
+  name: 'Filter that selects nothing',
+  args: { companionId: COMPANION.syncedOnly },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const uploaded = await canvas.findByRole('button', { name: 'Uploaded' });
+
+    /* Three pills only, read off the strip in order: nothing in this set reaches
+       a lifecycle with a tab, so the two lifecycle pills the full fixture draws
+       must be absent here rather than present-and-empty. */
+    const strip = uploaded.parentElement as HTMLElement;
+    await expect(Array.from(strip.children).map((pill) => (pill.textContent ?? '').trim())).toEqual(
+      ['All · 2', 'Uploaded', 'Synced']
+    );
+
+    await userEvent.click(uploaded);
+
+    await canvas.findByText('No records match this filter.');
+    await expect(rowTitles(canvasElement)).toHaveLength(0);
+    await expect(canvas.queryByText('July 2026')).not.toBeInTheDocument();
+
+    /* The strip survives with the same three pills, and the selection moved to
+       the one that emptied the list - this is the state that lets a user undo
+       the filter, and an empty result that also removed the pills is a dead end. */
+    await expect(uploaded).toHaveAttribute('aria-pressed', 'true');
+    await expect(Array.from(strip.children).map((pill) => (pill.textContent ?? '').trim())).toEqual(
+      ['All · 2', 'Uploaded', 'Synced']
+    );
+    await expect(canvas.getByRole('button', { name: 'Newest first' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A distinct state from "no records yet", and the reason the empty check is on ' +
+          '`records`, not on `groups`. The source pills are unconditional, so a companion whose ' +
+          'records are all synced still shows an Uploaded pill that can only ever select nothing ' +
+          '- and this one-line message, not the full empty state with its upload CTA, is the ' +
+          'right answer to it.',
+      },
+    },
+  },
+};
+
+export const NoRecordsYet: Story = {
+  name: 'No records yet',
+  args: { companionId: COMPANION.empty },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const heading = await canvas.findByText('No records yet');
+
+    /* The supporting line, not only the headline. It is the one place the page
+       explains that records arrive on their own, so a copy change that dropped
+       it would leave an empty state reading as "nothing works yet". Exact
+       string: the preview decorator injects an sr-only <h1> reading
+       "<title> - <story name>" into this canvas, and this story is literally
+       named "No records yet". */
+    await expect(
+      canvas.getByText(
+        'Everything from visits lands here automatically: SOAP notes, labs, prescriptions, invoices. You can also upload history from a previous clinic.'
+      )
+    ).toBeInTheDocument();
+
+    // Exactly two actions, in the design's order, and nothing else.
+    await expect(
+      within(heading.parentElement as HTMLElement)
+        .getAllByRole('button')
+        .map((button) => (button.textContent ?? '').trim())
+    ).toEqual(['Upload record', 'Request from pet parent']);
+
+    // No strip at all in this branch: no pills, no sort toggle.
+    await expect(canvas.queryByRole('button', { name: 'Newest first' })).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: /^All · / })).not.toBeInTheDocument();
+
+    /* The design pairs the upload CTA with a "Request from pet parent" pill.
+       There is no request flow behind it, so it ships disabled rather than
+       wired to nothing - assert that, because an enabled-looking dead control
+       is the failure this deliberately avoids. */
+    await expect(canvas.getByRole('button', { name: 'Upload record' })).toBeEnabled();
+    await expect(canvas.getByRole('button', { name: 'Request from pet parent' })).toBeDisabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The branch that was previously the *only* thing this component could draw in ' +
+          'Storybook. Both actions are inside a `companions:edit:any` gate, so a viewer without ' +
+          'edit rights gets the copy and no buttons.',
+      },
+    },
+  },
+};
+
+export const PhoneList: Story = {
+  name: 'Phone: strip stacks above the list',
+  // Pinned as a GLOBAL. `parameters.viewport.defaultViewport` was removed in
+  // Storybook 10 - a story pinned that way still renders and still passes, at
+  // the full panel width, proving nothing about the phone.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const toggle = await canvas.findByRole('button', { name: 'Newest first' });
+
+    /* At 375px the five pills fill the row, so the sort/upload group wraps onto
+       a line of its own beneath them. Measured with getBoundingClientRect: on a
+       bordered element getComputedStyle returns the content box and reads short
+       of the drawn edge. */
+    const allPill = canvas.getByRole('button', { name: 'All · 5' });
+    await expect(toggle.getBoundingClientRect().top).toBeGreaterThanOrEqual(
+      allPill.getBoundingClientRect().bottom
+    );
+    await expect(rowTitles(canvasElement)).toHaveLength(5);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The list at 375px. Nothing here is a phone-specific branch - the header is one ' +
+          '`flex-wrap` row that reflows - which is exactly why it needs a story: there is no ' +
+          'media query to read and confirm the intent from.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceDetailHeader.stories.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceDetailHeader.stories.tsx
@@ -1,0 +1,368 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+import type { Appointment, Invoice } from '@yosemite-crew/types';
+
+import InvoiceDetailHeader from './InvoiceDetailHeader';
+
+const ORG_ID = 'org-avenger-park';
+const APPOINTMENT_ID = 'appointment-8842';
+const PARENT_ID = 'parent-sky-doe';
+
+const patient: Appointment['patient'] = {
+  id: 'companion-kizie',
+  name: 'Kizie',
+  species: 'dog',
+  breed: 'Beagle',
+  parent: { id: PARENT_ID, name: 'Sky Doe' },
+};
+
+const APPOINTMENT: Appointment = {
+  id: APPOINTMENT_ID,
+  organisationId: ORG_ID,
+  patient,
+  companion: patient,
+  appointmentType: {
+    id: 'type-dental',
+    name: 'Dental consultation',
+    speciality: { id: 'spec-dentistry', name: 'Dentistry' },
+  },
+  // Fixed instants throughout. Every formatter here pins the en-US locale and
+  // `getPreferredTimeZone` falls back to Europe/Berlin with no timezone token stored,
+  // so the rendered dates do not depend on the machine running this.
+  appointmentDate: new Date('2026-08-12T09:30:00.000Z'),
+  startTime: new Date('2026-08-12T09:30:00.000Z'),
+  endTime: new Date('2026-08-12T10:00:00.000Z'),
+  timeSlot: '09:30 AM',
+  durationMinutes: 30,
+  status: 'COMPLETED',
+};
+
+/**
+ * A rendered invoice document. `pdfUrl` is the only thing gating the PDF action, and
+ * it is populated by the backend's document renderer - so it is absent for the whole
+ * window between an invoice being created and its PDF being generated, and absent
+ * forever on an invoice that never rendered.
+ */
+const INVOICE: Invoice = {
+  id: 'a1b2c3d4e5f60718293a4b5c',
+  organisationId: ORG_ID,
+  appointmentId: APPOINTMENT_ID,
+  parentId: PARENT_ID,
+  metadata: { invoiceNumber: 'INV-2026-0142' },
+  items: [{ id: 'line-1', name: 'Dental consultation', quantity: 1, unitPrice: 60, total: 60 }],
+  subtotal: 60,
+  taxPercent: 20,
+  taxTotal: 12,
+  totalAmount: 72,
+  paymentCollectionMethod: 'PAYMENT_INTENT',
+  currency: 'USD',
+  status: 'PAID',
+  pdfUrl: 'https://d2il6osz49gpup.cloudfront.net/invoices/INV-2026-0142.pdf',
+  paidAt: new Date('2026-08-12T10:15:00.000Z'),
+  createdAt: new Date('2026-08-12T10:02:00.000Z'),
+  updatedAt: new Date('2026-08-12T10:15:00.000Z'),
+};
+
+/**
+ * The header's interactive controls, left to right as they are PAINTED.
+ *
+ * The status badge is a `<span>` and never appears here; it sits first in the row and
+ * is checked by text where it matters.
+ */
+const actionsInOrder = (canvasElement: HTMLElement): string[] =>
+  [...canvasElement.querySelectorAll('a, button')]
+    .map((el) => ({ el, left: el.getBoundingClientRect().left }))
+    .sort((a, b) => a.left - b.left)
+    .map(({ el }) => el.getAttribute('aria-label') ?? (el.textContent ?? '').trim());
+
+/** The header row itself, used as the box everything must stay inside. */
+const headerRow = (el: HTMLElement): HTMLElement =>
+  el.closest('.flex.items-start.justify-between') as HTMLElement;
+
+const meta = {
+  title: 'Finance/InvoiceDetailHeader',
+  component: InvoiceDetailHeader,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The header of the desktop invoice drawer: companion avatar, invoice number, a ' +
+          'composed subtitle, and an actions row that ends in the close button.\n\n' +
+          'The actions row is **entirely conditional**, and one of its three controls had never ' +
+          'been drawn: the **PDF download link**, gated on `invoice.pdfUrl`. That field is written ' +
+          "by the backend's document renderer, so it is empty for every invoice between creation " +
+          'and render, and permanently empty on one that never rendered - which means the header ' +
+          'ships in two shapes and only one of them was ever reviewed.\n\n' +
+          'It is a real `<a>`, not a button: it opens the rendered document in a new tab with ' +
+          '`rel="noopener noreferrer"`, and it carries a per-invoice `aria-label` ("Download ' +
+          'invoice #INV-2026-0142 PDF") because the visible label is just "PDF" and a screen ' +
+          'reader would otherwise hear the same two letters on every invoice in a list.\n\n' +
+          '"Open appointment" is gated separately, on **both** an appointment and a handler, so ' +
+          'an unlinked over-the-counter sale gets neither it nor a subtitle - `buildSubtitle` ' +
+          'returns an empty string and `ModalHeader` drops the meta line rather than rendering a ' +
+          'blank one.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    titleId: 'invoice-detail-title',
+    invoice: INVOICE,
+    appointment: APPOINTMENT,
+    statusLabel: 'Paid',
+    statusTone: 'success',
+    onClose: fn(),
+    onOpenAppointment: fn(),
+  },
+  decorators: [
+    (Story) => (
+      // 788px is the drawer's content box: an `lg` centered Modal (840px) less its
+      // 26px horizontal insets. The actions row is `shrink-0`, so the width decides
+      // where the title truncates rather than whether the buttons fit.
+      <div className="w-[788px] max-w-full bg-[var(--screen)] p-6">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof InvoiceDetailHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WithPdf: Story = {
+  name: 'A rendered invoice (PDF available)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // The number comes from metadata, not from the opaque id, and the title carries
+    // the id the dialog is labelled by.
+    const heading = canvas.getByRole('heading', { name: '#INV-2026-0142' });
+    await expect(heading).toHaveAttribute('id', 'invoice-detail-title');
+
+    // The subtitle is composed from the appointment: companion, owner surname,
+    // service, date - joined by middle dots and with empty parts dropped.
+    await expect(
+      canvas.getByText('Kizie · Doe · Dental consultation · Aug 12, 2026')
+    ).toBeInTheDocument();
+
+    /* The PDF action, in full. The href, the new-tab target and the opener guard are
+       all asserted rather than only the label: this link points at a rendered billing
+       document, and `target="_blank"` without `rel="noopener"` hands the destination a
+       handle on this window. */
+    const pdf = canvas.getByRole('link', { name: 'Download invoice #INV-2026-0142 PDF' });
+    await expect(pdf).toHaveAttribute(
+      'href',
+      'https://d2il6osz49gpup.cloudfront.net/invoices/INV-2026-0142.pdf'
+    );
+    await expect(pdf).toHaveAttribute('target', '_blank');
+    await expect(pdf).toHaveAttribute('rel', 'noopener noreferrer');
+    // The visible label is two letters. The accessible name carries the invoice, which
+    // is the whole reason the aria-label exists.
+    await expect(pdf).toHaveTextContent('PDF');
+
+    /* Order matters: PDF, then Open appointment, then Close, with the status badge
+       ahead of all three. Read off measured positions rather than DOM order, because
+       the row is a flex container - a `flex-row-reverse` or an `order` utility would
+       reverse the paint without touching the markup, and Close must stay last. */
+    await expect(actionsInOrder(canvasElement)).toEqual([
+      'Download invoice #INV-2026-0142 PDF',
+      'Open appointment',
+      'Close',
+    ]);
+    const badge = canvas.getByText('Paid');
+    await expect(badge.getBoundingClientRect().right).toBeLessThanOrEqual(
+      pdf.getBoundingClientRect().left
+    );
+
+    // Both action controls are 36px pills so they line up with the status badge.
+    await expect(Math.round(pdf.getBoundingClientRect().height)).toBe(36);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Every control the header can show at once: the status badge, the PDF link, the route ' +
+          'into the appointment workspace, and the close button. This is the widest the actions ' +
+          'row ever gets, so it is the layout reference for the two shorter shapes below.',
+      },
+    },
+  },
+};
+
+export const WithoutPdf: Story = {
+  name: 'No PDF rendered yet',
+  args: { invoice: { ...INVOICE, pdfUrl: undefined } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* The link is ABSENT, not disabled and not a dead href - there is nothing to
+       download. Queried by role rather than by the visible "PDF" text, which is two
+       letters that could easily appear elsewhere in a billing panel. */
+    await expect(canvas.queryByRole('link')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('PDF')).not.toBeInTheDocument();
+
+    // Everything else is unchanged - the row is SHORTER, not different, and the
+    // remaining controls simply slide right.
+    await expect(actionsInOrder(canvasElement)).toEqual(['Open appointment', 'Close']);
+    await expect(canvas.getByRole('heading', { name: '#INV-2026-0142' })).toBeInTheDocument();
+    await expect(canvas.getByText('Paid')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The state most invoices are in for their first seconds, and permanently for any ' +
+          'invoice whose document never rendered. Nothing on the header says a PDF is coming - ' +
+          'the control simply is not there - so a reader who saw it on the previous invoice has ' +
+          'no way to tell whether it is pending or will never arrive.',
+      },
+    },
+  },
+};
+
+export const UnlinkedSale: Story = {
+  name: 'Unlinked sale: PDF but no appointment',
+  args: {
+    invoice: { ...INVOICE, appointmentId: undefined, metadata: { invoiceNumber: 'INV-2026-0009' } },
+    appointment: undefined,
+    onOpenAppointment: undefined,
+    statusLabel: 'Awaiting payment',
+    statusTone: 'info',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // No appointment means no subtitle at all: `buildSubtitle` returns an empty string
+    // and `ModalHeader` drops the meta line rather than reserving a blank row for it.
+    await expect(canvas.getByRole('heading', { name: '#INV-2026-0009' })).toBeInTheDocument();
+    await expect(canvas.queryByText(/·/)).not.toBeInTheDocument();
+
+    // ...and no route into the workspace, because there is nothing to open.
+    await expect(
+      canvas.queryByRole('button', { name: 'Open appointment' })
+    ).not.toBeInTheDocument();
+
+    /* The PDF survives, which is the point of this frame: the two actions are gated on
+       different things, so a counter sale with a rendered document still offers the
+       download. The avatar falls back to the default dog image rather than
+       disappearing, which is why the title still sits inset from the left edge. */
+    await expect(
+      canvas.getByRole('link', { name: 'Download invoice #INV-2026-0009 PDF' })
+    ).toBeInTheDocument();
+    await expect(actionsInOrder(canvasElement)).toEqual([
+      'Download invoice #INV-2026-0009 PDF',
+      'Close',
+    ]);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'An over-the-counter sale: no appointment, no companion, no owner. Three separate ' +
+          'fallbacks fire - the subtitle vanishes, the workspace route vanishes, and the avatar ' +
+          'drops to the species default - while the PDF link is unaffected.',
+      },
+    },
+  },
+};
+
+export const ClosesAndOpens: Story = {
+  name: 'The two handlers',
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Open appointment' }));
+    await expect(args.onOpenAppointment).toHaveBeenCalledTimes(1);
+    // Opening the appointment does NOT close the header from here - the caller does
+    // that after pushing the route, which is why these are two separate props.
+    await expect(args.onClose).not.toHaveBeenCalled();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Close' }));
+    await expect(args.onClose).toHaveBeenCalledTimes(1);
+    await expect(args.onOpenAppointment).toHaveBeenCalledTimes(1);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The header owns no state. Both controls are pure callbacks, and the PDF link is not ' +
+          'one of them - it is an ordinary anchor, so it never reaches the drawer at all and the ' +
+          'panel stays open behind the new tab.',
+      },
+    },
+  },
+};
+
+export const LongSubtitle: Story = {
+  name: 'A long subtitle wraps, the actions do not move',
+  args: {
+    appointment: {
+      ...APPOINTMENT,
+      appointmentType: {
+        id: 'type-dental',
+        name: 'Scale, polish and extraction under general anaesthetic with post-operative analgesia review',
+        speciality: { id: 'spec-dentistry', name: 'Dentistry' },
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* The title column is `min-w-0` and the actions are `shrink-0`, so a long service
+       name grows the header DOWNWARDS rather than pushing the buttons off the panel.
+       Asserted geometrically: everything still ends inside the header row. */
+    const pdf = canvas.getByRole('link', { name: 'Download invoice #INV-2026-0142 PDF' });
+    const limit = headerRow(pdf).getBoundingClientRect().right;
+    await expect(pdf.getBoundingClientRect().right).toBeLessThanOrEqual(limit + 1);
+    await expect(
+      canvas.getByRole('button', { name: 'Close' }).getBoundingClientRect().right
+    ).toBeLessThanOrEqual(limit + 1);
+
+    /* The two lines behave differently, and that asymmetry is the point of this
+       frame. The title carries `truncate`; the meta line carries nothing and wraps.
+
+       Both are counted over a RANGE rather than off the element. `ModalHeader` puts
+       both nodes in a `flex flex-col`, so each one is blockified and its OWN
+       `getClientRects()` is a single border box however many lines the text took -
+       an element-level count reads 1 for the wrapped subtitle and would fail, and
+       reads 1 for the title whether or not `nowrap` survived, which passes while
+       proving nothing. A Range over the contents returns one rect per line box. */
+    const heading = canvas.getByRole('heading', { name: '#INV-2026-0142' });
+    const headingStyle = getComputedStyle(heading);
+    /* `truncate` is three declarations and it no-ops whenever an unlayered plain-CSS
+       rule outranks the utility, which has bitten this repo before - so the rule is
+       read off the computed values rather than trusted from the class list. The
+       invoice NUMBER is never long enough to clip, so the rule is what there is to
+       assert here; the clipping itself is exercised where a name can run long. */
+    await expect(headingStyle.whiteSpace).toBe('nowrap');
+    await expect(headingStyle.textOverflow).toBe('ellipsis');
+    await expect(headingStyle.overflow).toBe('hidden');
+    const headingText = document.createRange();
+    headingText.selectNodeContents(heading);
+    await expect(headingText.getClientRects()).toHaveLength(1);
+
+    const meta = canvas.getByText(/^Kizie · Doe · Scale, polish/);
+    await expect(getComputedStyle(meta).whiteSpace).toBe('normal');
+    const metaText = document.createRange();
+    metaText.selectNodeContents(meta);
+    await expect(metaText.getClientRects().length).toBeGreaterThanOrEqual(2);
+    // And the wrap is what made the header taller: the meta line is at least two
+    // line boxes deep, so the identity column outgrew the 36px action pills.
+    await expect(meta.getBoundingClientRect().height).toBeGreaterThan(
+      metaText.getClientRects()[0].height
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Service names in this product run long - the dentistry catalogue alone has several over ' +
+          'sixty characters. The row is built so the actions never move, and the identity column ' +
+          'absorbs it: the number stays on one line under `truncate`, the subtitle under it wraps ' +
+          'to two. Worth deciding whether the subtitle should clamp as well, since a three-line ' +
+          'meta pushes the billed-items table down the panel on every long-service invoice.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoicePhoneRecord.stories.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoicePhoneRecord.stories.tsx
@@ -1,0 +1,512 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+import type { Appointment, Invoice } from '@yosemite-crew/types';
+
+import InvoicePhoneRecord from './InvoicePhoneRecord';
+
+const ORG_ID = 'org-avenger-park';
+const APPOINTMENT_ID = 'appointment-8842';
+const PARENT_ID = 'parent-sky-doe';
+
+const patient: Appointment['patient'] = {
+  id: 'companion-kizie',
+  name: 'Kizie',
+  species: 'dog',
+  breed: 'Beagle',
+  parent: { id: PARENT_ID, name: 'Sky Doe' },
+};
+
+const APPOINTMENT: Appointment = {
+  id: APPOINTMENT_ID,
+  organisationId: ORG_ID,
+  patient,
+  companion: patient,
+  appointmentType: {
+    id: 'type-dental',
+    name: 'Dental consultation',
+    speciality: { id: 'spec-dentistry', name: 'Dentistry' },
+  },
+  appointmentDate: new Date('2026-08-12T09:30:00.000Z'),
+  startTime: new Date('2026-08-12T09:30:00.000Z'),
+  endTime: new Date('2026-08-12T10:00:00.000Z'),
+  timeSlot: '09:30 AM',
+  durationMinutes: 30,
+  status: 'COMPLETED',
+};
+
+/**
+ * `formatMoney` runs at `maximumFractionDigits: 0`, so every figure here is a whole
+ * number on purpose - a 92.65 total would print as "$93" and make the assertions read
+ * as though the arithmetic were wrong.
+ *
+ * Fixed instants throughout: the formatters pin the en-US locale and
+ * `getPreferredTimeZone` falls back to Europe/Berlin with no timezone token stored,
+ * so nothing here drifts with the machine running it.
+ */
+const PAID_INVOICE: Invoice = {
+  id: 'a1b2c3d4e5f60718293a4b5c',
+  organisationId: ORG_ID,
+  appointmentId: APPOINTMENT_ID,
+  parentId: PARENT_ID,
+  metadata: { invoiceNumber: 'INV-2026-0142' },
+  items: [
+    { id: 'line-1', name: 'Dental consultation', quantity: 1, unitPrice: 60, total: 60 },
+    { id: 'line-2', name: 'Scale and polish', quantity: 1, unitPrice: 45, total: 45 },
+  ],
+  subtotal: 105,
+  discountTotal: 10,
+  taxPercent: 20,
+  taxTotal: 19,
+  totalAmount: 114,
+  paymentCollectionMethod: 'PAYMENT_INTENT',
+  currency: 'USD',
+  status: 'PAID',
+  pdfUrl: 'https://d2il6osz49gpup.cloudfront.net/invoices/INV-2026-0142.pdf',
+  stripeReceiptUrl: 'https://pay.stripe.com/receipts/example',
+  paidAt: new Date('2026-08-12T10:15:00.000Z'),
+  createdAt: new Date('2026-08-12T10:02:00.000Z'),
+  updatedAt: new Date('2026-08-12T10:15:00.000Z'),
+};
+
+/**
+ * The bordered card holding the billed lines, the tax band and the total.
+ *
+ * The payment card shares its `rounded-[14px]` radius, so this deliberately takes the
+ * FIRST match - the items card is always above it in the sheet, and on an unsettled
+ * invoice the payment card does not exist at all.
+ */
+const itemsCard = (canvasElement: HTMLElement): HTMLElement =>
+  canvasElement.querySelector('.rounded-\\[14px\\]') as HTMLElement;
+
+/**
+ * The row holding the two full-width actions, or null when it was not rendered.
+ *
+ * Selected by the row's OWN classes rather than by walking up from an action: the
+ * guard under review is on the container (`{(pdfUrl || (appointment &&
+ * onOpenAppointment)) && ...}`), and a helper that starts from a child can only ever
+ * return null once both children are gone - which would pass whether the row
+ * disappeared or stayed behind as an empty 10px gap. `pt-1` alone is not unique in
+ * this component (the header row carries it too), so the gap is part of the match.
+ */
+const actionRow = (canvasElement: HTMLElement): HTMLElement | null =>
+  canvasElement.querySelector('.flex.gap-2\\.5.pt-1');
+
+const meta = {
+  title: 'Finance/InvoicePhoneRecord',
+  component: InvoicePhoneRecord,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The invoice record as it is drawn below 768px: a 36px-avatar header, one bordered card ' +
+          'holding the billed lines and ending in a `--screen-2` tax band and a 20px total, a ' +
+          'payment row, a finalized note, and up to two full-width actions. It replaces the ' +
+          'desktop record entirely rather than reflowing it - none of the desktop sections exist ' +
+          'here.\n\n' +
+          'Three of its states had never been drawn, and each is a whole block appearing or ' +
+          'vanishing rather than a style change:\n\n' +
+          '**Unsettled.** `isSettledInvoice` is `PAID`/`REFUNDED` *or* any invoice carrying ' +
+          '`paidAt`. Below that bar the payment card AND the "Receipt sent to ..." note both ' +
+          'disappear - so an awaiting-payment invoice is a shorter sheet, not one with an empty ' +
+          'ledger. This is the state most invoices are in while anyone is actually looking at ' +
+          'them.\n\n' +
+          '**No billed items.** The card keeps its tax and total rows and swaps the lines for one ' +
+          'faint sentence, so the sheet still reads as a bill rather than collapsing to a ' +
+          'heading. A counter sale with a manual total lands here.\n\n' +
+          '**The PDF action.** Gated on `invoice.pdfUrl`, which the document renderer writes - ' +
+          'absent for the whole window between an invoice being created and its PDF existing. It ' +
+          'is a real `<a target="_blank" rel="noopener noreferrer">` and it shares the row with ' +
+          '"Open appointment" at a deliberate **1 : 1.4** ratio, so the CTA reads as the primary ' +
+          'action. Lose either control and the survivor takes the whole width; lose both and the ' +
+          'row itself is not rendered.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    titleId: 'invoice-phone-title',
+    invoice: PAID_INVOICE,
+    appointment: APPOINTMENT,
+    currency: 'USD',
+    statusLabel: 'Paid',
+    statusTone: 'success',
+    payerName: 'Sky Doe',
+    payerEmail: 'sky.doe@example.com',
+    onClose: fn(),
+    onOpenAppointment: fn(),
+  },
+  // Pinned as a GLOBAL on the meta, so every story here renders at phone width.
+  // `parameters.viewport.defaultViewport` was removed in Storybook 10: it still
+  // type-checks, still plays and still passes, at the full panel width - which for a
+  // component whose whole reason to exist is the phone would prove nothing at all.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  decorators: [
+    (Story) => (
+      <div className="min-h-[640px] bg-[var(--screen)] px-4 py-3">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof InvoicePhoneRecord>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Settled: Story = {
+  name: 'Paid invoice',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // The header: number from metadata, status badge, and the composed subtitle.
+    const heading = canvas.getByRole('heading', { name: '#INV-2026-0142' });
+    await expect(heading).toHaveAttribute('id', 'invoice-phone-title');
+    await expect(canvas.getByText('Paid')).toBeInTheDocument();
+    await expect(canvas.getByText('Kizie · Doe · Aug 12, 2026')).toBeInTheDocument();
+
+    /* The card is one stack of rows, and the row COUNT is what says the structure held:
+       two lines, a discount band, a tax band and the total. A missing band does not
+       break the layout - it just quietly drops a figure out of the bill. */
+    const card = itemsCard(canvasElement);
+    await expect(card.children).toHaveLength(5);
+    await expect(card.children[0]).toHaveTextContent('Dental consultation');
+    await expect(card.children[0]).toHaveTextContent('$60');
+    await expect(card.children[1]).toHaveTextContent('Scale and polish');
+    await expect(card.children[1]).toHaveTextContent('$45');
+    // The discount is its own SIGNED row here - the desktop summary prints it unsigned
+    // in a labelled table instead.
+    await expect(card.children[2]).toHaveTextContent('-$10');
+    // The tax label folds the percent in without a middle dot ("Tax 20%", where the
+    // desktop summary says "Tax · 20%").
+    await expect(card.children[3]).toHaveTextContent('Tax 20%');
+    await expect(card.children[3]).toHaveTextContent('$19');
+    await expect(card.children[4]).toHaveTextContent('Total');
+    await expect(card.children[4]).toHaveTextContent('$114');
+
+    /* Once, not twice. Unlike the desktop ledger, the phone payment row prints NO
+       amount - the total above it is the only figure on the sheet, which is the
+       difference a reviewer comparing the two records would look for first. */
+    await expect(canvas.getAllByText('$114')).toHaveLength(1);
+
+    // The payment row names the channel rather than saying "payment recorded", and
+    // the caption is matched at its two ends because the timestamp between them
+    // renders in the viewer's timezone.
+    await expect(canvas.getByText('Paid in the pet-parent app')).toBeInTheDocument();
+    await expect(canvas.getByTitle(/^Online payment · /)).toBeInTheDocument();
+    await expect(canvas.getByTitle(/ · Sky Doe$/)).toBeInTheDocument();
+    await expect(canvas.getByRole('link', { name: 'Receipt' })).toBeInTheDocument();
+
+    // The finalized note, with the payer's stored email.
+    await expect(canvas.getByText('Receipt sent to sky.doe@example.com')).toBeInTheDocument();
+
+    // Two actions and the close control.
+    await expect(
+      canvas.getByRole('link', { name: 'Download invoice #INV-2026-0142 PDF' })
+    ).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Open appointment' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Close' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The only state in which every block renders at once, so it is the layout reference for ' +
+          'the rest: a settled invoice with two lines, a discount, tax at 20%, a Stripe receipt ' +
+          'and a rendered PDF.',
+      },
+    },
+  },
+};
+
+export const Unsettled: Story = {
+  name: 'Awaiting payment: two blocks vanish',
+  args: {
+    invoice: {
+      ...PAID_INVOICE,
+      metadata: { invoiceNumber: 'INV-2026-0163' },
+      status: 'AWAITING_PAYMENT',
+      paymentCollectionMethod: 'PAYMENT_LINK',
+      paidAt: undefined,
+      stripeReceiptUrl: undefined,
+    },
+    statusLabel: 'Awaiting payment',
+    statusTone: 'info',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole('heading', { name: '#INV-2026-0163' })).toBeInTheDocument();
+    await expect(canvas.getByText('Awaiting payment')).toBeInTheDocument();
+
+    /* Both settled-only blocks are gone. Asserted separately because they are gated by
+       two different conditions on the same flag - `settled` for the payment card,
+       `settled && email` for the note - and a regression in either one alone would
+       claim money had been taken. The channel title is checked rather than the card's
+       class, since `getLedgerChannel` still returns a title for an unsettled invoice
+       and would happily render one. */
+    await expect(canvas.queryByText('Paid in the pet-parent app')).not.toBeInTheDocument();
+    await expect(canvas.queryByText(/^Online payment · /)).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('link', { name: 'Receipt' })).not.toBeInTheDocument();
+    await expect(canvas.queryByText(/^Receipt sent to /)).not.toBeInTheDocument();
+
+    /* The bill itself is untouched - the sheet is SHORTER, not different. Same five
+       rows, same figures, so nothing about the amount owed changes with the state. */
+    const card = itemsCard(canvasElement);
+    await expect(card.children).toHaveLength(5);
+    await expect(card.children[4]).toHaveTextContent('$114');
+    await expect(canvas.getAllByText('$114')).toHaveLength(1);
+
+    // The actions row survives: a PDF can exist for an unpaid invoice, and the
+    // appointment route never depended on payment at all.
+    await expect(
+      canvas.getByRole('link', { name: 'Download invoice #INV-2026-0163 PDF' })
+    ).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Open appointment' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Where most invoices sit for their first hours, and the frame that had never been ' +
+          'drawn. Nothing on this sheet says money is owed except the absence of the payment card ' +
+          'and the status badge - there is no outstanding figure on the phone record the way ' +
+          'there is on the desktop summary panel.',
+      },
+    },
+  },
+};
+
+export const SettledWithoutEmail: Story = {
+  name: 'Settled, but no email on file',
+  args: { payerEmail: '   ' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* The payment card stays and the note goes. The two blocks are separately gated,
+       and the note additionally trims its email - so a stored value of whitespace
+       drops it exactly like a missing one, rather than rendering "Receipt sent to ".
+       That trim is the reason this story passes spaces instead of undefined. */
+    await expect(canvas.getByText('Paid in the pet-parent app')).toBeInTheDocument();
+    await expect(canvas.queryByText(/^Receipt sent to /)).not.toBeInTheDocument();
+
+    // The ledger keeps its whole caption, timestamp and payer included, so the sheet
+    // still says who paid - it just no longer claims anyone was emailed about it.
+    await expect(canvas.getByTitle(/^Online payment · /)).toBeInTheDocument();
+    await expect(canvas.getByTitle(/ · Sky Doe$/)).toBeInTheDocument();
+
+    // The Receipt link is on the payment card, not the note, so it survives - the
+    // reader can still reach the Stripe receipt with no address to have sent it to.
+    await expect(canvas.getByRole('link', { name: 'Receipt' })).toBeInTheDocument();
+
+    // And the bill is byte-for-byte the settled story's: five rows ending in $114.
+    // The email is a payer detail, not an invoice one, and nothing else moves with it.
+    const card = itemsCard(canvasElement);
+    await expect(card.children).toHaveLength(5);
+    await expect(card.children[4]).toHaveTextContent('Total');
+    await expect(card.children[4]).toHaveTextContent('$114');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A pet parent registered at the desk with a phone number and no email. The invoice is ' +
+          'paid, the receipt exists, and nobody was sent it - which is what the missing note ' +
+          'actually means and what makes it worth showing beside the settled story.',
+      },
+    },
+  },
+};
+
+export const NoBilledItems: Story = {
+  name: 'No billed items',
+  args: {
+    invoice: {
+      ...PAID_INVOICE,
+      metadata: { invoiceNumber: 'INV-2026-0009' },
+      items: [],
+      subtotal: 0,
+      discountTotal: 0,
+      taxPercent: undefined,
+      taxTotal: 0,
+      totalAmount: 0,
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* Three rows, not one sentence. The empty state replaces only the line items - the
+       tax band and the total row still render, so the card keeps its shape and the
+       sheet still reads as a bill. Asserting the row count is what separates that from
+       a card that collapsed to a single message. */
+    const card = itemsCard(canvasElement);
+    await expect(card.children).toHaveLength(3);
+    await expect(canvas.getByText('No billed items recorded.')).toBeInTheDocument();
+    // The discount row is gone as well, because the discount is zero rather than
+    // absent - a `-$0` band would read as a bug.
+    await expect(canvas.queryByText('Discount')).not.toBeInTheDocument();
+
+    // The tax label loses its percent suffix when the invoice carries none.
+    await expect(card.children[1]).toHaveTextContent('Tax');
+    await expect(card.children[1]).not.toHaveTextContent('Tax 20%');
+
+    /* A zero invoice prints figures rather than dashes - twice, once in the tax band
+       and once in the total - because a dash in a billing document reads as unknown
+       rather than as nothing owed. */
+    await expect(canvas.getAllByText('$0')).toHaveLength(2);
+    await expect(card.children[2]).toHaveTextContent('Total');
+
+    // The empty state is an <output>, so it is announced rather than being a silent
+    // paragraph that appeared after a fetch.
+    await expect(canvas.getByRole('status')).toHaveTextContent('No billed items recorded.');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'An invoice with a total and no lines - a counter sale keyed as one amount, or a record ' +
+          'whose items failed to load. The sheet cannot tell those apart, and neither can the ' +
+          'reader: the sentence is the same either way.',
+      },
+    },
+  },
+};
+
+export const ActionRatio: Story = {
+  name: 'The two actions share the row 1 : 1.4',
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const pdf = canvas.getByRole('link', { name: 'Download invoice #INV-2026-0142 PDF' });
+    const open = canvas.getByRole('button', { name: 'Open appointment' });
+
+    /* `flex-1` against `flex-[1.4]`. The ratio is the whole design intent - the CTA has
+       to read as the primary action without being the only one - and it is invisible
+       in a class list once the two buttons are in different files. Measured with
+       getBoundingClientRect because that is the border box; getComputedStyle().width
+       would report the content box and under-read the outlined PDF pill by its border
+       on each side. */
+    const pdfWidth = pdf.getBoundingClientRect().width;
+    const openWidth = open.getBoundingClientRect().width;
+    await expect(openWidth / pdfWidth).toBeGreaterThan(1.3);
+    await expect(openWidth / pdfWidth).toBeLessThan(1.5);
+
+    // One line, side by side, with the CTA on the right.
+    await expect(pdf.getBoundingClientRect().top).toBe(open.getBoundingClientRect().top);
+    await expect(open.getBoundingClientRect().left).toBeGreaterThan(
+      pdf.getBoundingClientRect().right
+    );
+    // Both are 44px tall - the phone tap target, not the 36px desktop pill - and both
+    // are inside the row rather than overflowing it.
+    await expect(Math.round(pdf.getBoundingClientRect().height)).toBe(44);
+    await expect(Math.round(open.getBoundingClientRect().height)).toBe(44);
+    const row = actionRow(canvasElement) as HTMLElement;
+    await expect(row.children).toHaveLength(2);
+    await expect(Math.round(open.getBoundingClientRect().right)).toBeLessThanOrEqual(
+      Math.round(row.getBoundingClientRect().right)
+    );
+
+    /* The two controls are wired to different things, and the difference matters:
+       "Open appointment" raises `onOpenAppointment` and must NOT also close the sheet -
+       the caller dismisses it after pushing the route, which is why these are two
+       separate props. The PDF is an ordinary anchor and reaches no handler at all, so
+       the sheet stays open behind the new tab. */
+    await userEvent.click(open);
+    await expect(args.onOpenAppointment).toHaveBeenCalledTimes(1);
+    await expect(args.onClose).not.toHaveBeenCalled();
+    await expect(pdf).toHaveAttribute('rel', 'noopener noreferrer');
+    await expect(pdf).toHaveAttribute('target', '_blank');
+    await expect(pdf).toHaveAttribute(
+      'href',
+      'https://d2il6osz49gpup.cloudfront.net/invoices/INV-2026-0142.pdf'
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'At 375px the row is about 343px wide, so the split lands near 139 / 194. Both controls ' +
+          'are 44px tall rather than the desktop 36 - this is the one place the record changes ' +
+          'geometry rather than only layout.',
+      },
+    },
+  },
+};
+
+export const PdfOnly: Story = {
+  name: 'PDF alone takes the whole row',
+  args: { appointment: undefined, onOpenAppointment: undefined },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(
+      canvas.queryByRole('button', { name: 'Open appointment' })
+    ).not.toBeInTheDocument();
+    // No appointment also means no subtitle: `buildSubtitle` falls back to the invoice
+    // date alone rather than dropping the line entirely.
+    await expect(canvas.getByText('Aug 12, 2026')).toBeInTheDocument();
+
+    /* The survivor is still `flex-1` in a row of one, so it stretches to the full
+       width instead of staying at its 1-of-2.4 share. Compared against its own parent
+       rather than a pixel count, so the assertion states the rule. */
+    const pdf = canvas.getByRole('link', { name: 'Download invoice #INV-2026-0142 PDF' });
+    const row = pdf.parentElement as HTMLElement;
+    await expect(row.children).toHaveLength(1);
+    await expect(Math.round(pdf.getBoundingClientRect().width)).toBe(
+      Math.round(row.getBoundingClientRect().width)
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'An invoice with a rendered document and nothing to open. The full-width PDF pill is a ' +
+          'different frame from the paired one above and worth seeing, because a lone outlined ' +
+          'button across the sheet reads as the primary action even though it is styled as the ' +
+          'secondary.',
+      },
+    },
+  },
+};
+
+export const NoActions: Story = {
+  name: 'No PDF, no appointment: the row is gone',
+  args: {
+    invoice: { ...PAID_INVOICE, pdfUrl: undefined },
+    appointment: undefined,
+    onOpenAppointment: undefined,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* The whole row is unrendered rather than rendered empty - the guard is on the
+       container, not on the two children - so the sheet ends on the finalized note
+       with no dangling 10px gap under it. */
+    await expect(canvas.queryByRole('link', { name: /^Download invoice/ })).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByRole('button', { name: 'Open appointment' })
+    ).not.toBeInTheDocument();
+    await expect(actionRow(canvasElement)).toBeNull();
+
+    // Close is still there; it lives in the header, not in the action row.
+    await expect(canvas.getByRole('button', { name: 'Close' })).toBeInTheDocument();
+    // And the record is otherwise complete - this is a fully paid invoice.
+    await expect(canvas.getByText('Receipt sent to sky.doe@example.com')).toBeInTheDocument();
+
+    /* Four blocks, and the sheet ENDS on the note. The record root is a `gap-3` column,
+       so a row that rendered empty would still add a fourth gap under the note and a
+       fifth child here - which is exactly the difference between a guard on the
+       container and a guard on its two children. */
+    const record = canvasElement.querySelector('.flex.flex-col.gap-3.pb-1') as HTMLElement;
+    await expect(record.children).toHaveLength(4);
+    await expect(record.lastElementChild).toHaveTextContent('Receipt sent to sky.doe@example.com');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A settled counter sale whose document never rendered: nothing left to do on the sheet ' +
+          'except read it and close it. The only way out is the 30px circle in the top right, ' +
+          'which is the smallest tap target on the record.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/PhoneInvoiceList.stories.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/PhoneInvoiceList.stories.tsx
@@ -1,0 +1,533 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import type { Appointment, Invoice } from '@yosemite-crew/types';
+
+import { InvoiceStatusFilters } from '@/app/features/finance/types/invoice';
+import { computeFinanceMetrics } from '@/app/lib/financeMetrics';
+import { useAppointmentStore } from '@/app/stores/appointmentStore';
+import { useOrgStore } from '@/app/stores/orgStore';
+import PhoneInvoiceList from './PhoneInvoiceList';
+
+const ORG_ID = 'org-avenger-park';
+
+const appointment = (
+  id: string,
+  companionName: string,
+  ownerName: string,
+  service: string,
+  date: string
+): Appointment => {
+  const patient: Appointment['patient'] = {
+    id: `companion-${companionName.toLowerCase()}`,
+    name: companionName,
+    species: 'dog',
+    breed: 'Beagle',
+    parent: { id: `parent-${ownerName.split(' ')[0].toLowerCase()}`, name: ownerName },
+  };
+  return {
+    id,
+    organisationId: ORG_ID,
+    patient,
+    companion: patient,
+    appointmentType: {
+      id: `type-${service}`,
+      name: service,
+      speciality: { id: 'spec-general', name: 'General practice' },
+    },
+    // Fixed instants throughout. Every formatter pins en-US and
+    // `getPreferredTimeZone` falls back to Europe/Berlin with no timezone token
+    // stored, so nothing rendered here drifts with the machine running it.
+    appointmentDate: new Date(date),
+    startTime: new Date(date),
+    endTime: new Date(date),
+    timeSlot: '09:30 AM',
+    durationMinutes: 30,
+    status: 'COMPLETED',
+  };
+};
+
+const APPOINTMENTS: Appointment[] = [
+  appointment(
+    'appointment-8842',
+    'Kizie',
+    'Sky Doe',
+    'Dental consultation',
+    '2026-08-12T09:30:00.000Z'
+  ),
+  appointment('appointment-8851', 'Milo', 'Aria Blake', 'Vaccination', '2026-08-13T11:00:00.000Z'),
+  appointment(
+    'appointment-8860',
+    'Nala',
+    'Ines Ferrer',
+    'Orthopaedic review',
+    '2026-08-14T08:15:00.000Z'
+  ),
+];
+
+const invoice = (over: Partial<Invoice> & Pick<Invoice, 'id' | 'status'>): Invoice => ({
+  organisationId: ORG_ID,
+  items: [],
+  subtotal: 0,
+  totalAmount: 0,
+  paymentCollectionMethod: 'PAYMENT_INTENT',
+  currency: 'USD',
+  createdAt: new Date('2026-08-12T10:02:00.000Z'),
+  updatedAt: new Date('2026-08-12T10:02:00.000Z'),
+  ...over,
+});
+
+/**
+ * Three invoices chosen to cover every branch the card has: both border treatments
+ * and all three footnotes.
+ *
+ * `formatMoney` runs at `maximumFractionDigits: 0`, so every figure is a whole number
+ * on purpose - a 92.65 total would print as "$93" and make the assertions read as
+ * though the arithmetic were wrong.
+ */
+const PAID = invoice({
+  id: 'a1b2c3d4e5f60718293a4b5c',
+  appointmentId: 'appointment-8842',
+  metadata: { invoiceNumber: 'INV-2026-0142' },
+  totalAmount: 114,
+  subtotal: 105,
+  status: 'PAID',
+  paidAt: new Date('2026-08-12T10:15:00.000Z'),
+  createdAt: new Date('2026-08-12T10:02:00.000Z'),
+});
+
+const UNPAID = invoice({
+  id: 'b2c3d4e5f60718293a4b5c6d',
+  appointmentId: 'appointment-8851',
+  metadata: { invoiceNumber: 'INV-2026-0163' },
+  totalAmount: 240,
+  subtotal: 240,
+  status: 'AWAITING_PAYMENT',
+  paymentCollectionMethod: 'PAYMENT_LINK',
+  createdAt: new Date('2026-08-13T11:20:00.000Z'),
+});
+
+const PART_PAID = invoice({
+  id: 'c3d4e5f60718293a4b5c6d7e',
+  appointmentId: 'appointment-8860',
+  metadata: { invoiceNumber: 'INV-2026-0171' },
+  totalAmount: 300,
+  subtotal: 300,
+  depositCollectedAmount: 50,
+  status: 'AWAITING_PAYMENT',
+  paymentCollectionMethod: 'PAYMENT_AT_CLINIC',
+  createdAt: new Date('2026-08-14T08:30:00.000Z'),
+});
+
+const INVOICES = [PAID, UNPAID, PART_PAID];
+
+/**
+ * A fixed "now" so `collectedThisWeek` is deterministic: the metric only counts PAID
+ * invoices settled inside the trailing seven days, and `Date.now()` would drop the
+ * paid one out of the window the moment this file is a week old.
+ */
+const NOW = Date.parse('2026-08-14T09:00:00.000Z');
+const METRICS = computeFinanceMetrics(INVOICES, NOW);
+
+/**
+ * Seeds the one store the list reads. `useAppointmentsForPrimaryOrg` is a pure
+ * selector - the hook that fetches (`useLoadAppointmentsForPrimaryOrg`) is separate
+ * and this component does not call it - so seeding is the whole of the setup and the
+ * list under review is the real one, with no service stubbed.
+ */
+const seed = (appointments: Appointment[] = APPOINTMENTS) => {
+  useOrgStore.setState({ primaryOrgId: ORG_ID, status: 'loaded' });
+  useAppointmentStore.getState().setAppointmentsForOrg(ORG_ID, appointments);
+};
+
+/**
+ * Resolves a design token to the colour the browser actually paints, so a story can
+ * say "the unpaid rail is --warn" rather than only "it differs from its neighbour".
+ *
+ * It appends a probe, so it is a DOM MUTATION and must never run inside a `waitFor`
+ * callback: testing-library retries through a MutationObserver, and a callback that
+ * mutates then throws re-queues itself forever - wedging the tab instead of failing.
+ * Every caller resolves first and polls only the read.
+ */
+const resolveToken = (host: HTMLElement, token: string): string => {
+  const probe = document.createElement('span');
+  probe.style.backgroundColor = `var(${token})`;
+  host.append(probe);
+  const value = getComputedStyle(probe).backgroundColor;
+  probe.remove();
+  if (value === 'rgba(0, 0, 0, 0)') {
+    throw new Error(`Token ${token} resolved to transparent - it does not exist here.`);
+  }
+  return value;
+};
+
+/** One invoice card, by the accessible name the whole card carries. */
+const card = (canvasElement: HTMLElement, numberLabel: string): HTMLElement =>
+  within(canvasElement).getByRole('button', { name: `View invoice ${numberLabel}` });
+
+/** Every invoice card currently rendered, in list order. */
+const cards = (canvasElement: HTMLElement): HTMLElement[] =>
+  within(canvasElement).queryAllByRole('button', { name: /^View invoice / });
+
+/** The status-pill rail and the box that scrolls it. */
+const rail = (canvasElement: HTMLElement): HTMLElement =>
+  within(canvasElement).getByRole('group', { name: 'Filter invoices by status' });
+
+const meta = {
+  title: 'Finance/PhoneInvoiceList',
+  component: PhoneInvoiceList,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The whole Finance screen below 768px, and none of it had ever been drawn. Above that ' +
+          'width the page renders a seven-column `InvoiceTable`; below it `useIsPhone` swaps in ' +
+          'this component instead, so nothing here shares markup with the desktop list and no ' +
+          'desktop screenshot covers it.\n\n' +
+          'Three surfaces exist only here.\n\n' +
+          '**Two KPI tiles.** "Collected · wk" and "Outstanding", in an always-two-column grid. ' +
+          'They are the phone replacement for the desktop subtitle line, and the outstanding ' +
+          'figure is tinted `--warn-text` while the collected one is plain `--ink` - the only ' +
+          'colour signal on the screen that money is owed.\n\n' +
+          '**A horizontally scrolling pill rail.** The seven backend statuses do not fit in 375px, ' +
+          'so the rail is an `overflow-x-auto` strip with the scrollbar hidden. There is no ' +
+          'gradient, no arrow and no visible track, which means the only hint that statuses ' +
+          'continue past "Paid" is the pill clipped at the right edge.\n\n' +
+          '**Three-line invoice cards.** Number and date, then avatar + identity + amount, then ' +
+          'an optional footnote. Unpaid rows carry a 3px `--warn` left border, and "unpaid" here ' +
+          'means outstanding **and** no deposit - a part-paid invoice loses the border and gains ' +
+          'a "Deposit $50 applied" footnote instead, which is the distinction the stories pin ' +
+          'down.\n\n' +
+          'The identity line is worth reading closely: it composes as ' +
+          '`{owner first name} / {companion} · {owner surname} · {service}`, so a single line ' +
+          'mixes a slash and two middle dots and names the owner twice.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    filteredList: INVOICES,
+    statusOptions: InvoiceStatusFilters,
+    activeStatus: 'all',
+    setActiveStatus: fn(),
+    metrics: METRICS,
+    currency: 'USD',
+    onViewInvoice: fn(),
+  },
+  // Pinned as a GLOBAL on the meta, so every story renders at phone width.
+  // `parameters.viewport.defaultViewport` was removed in Storybook 10: a story using
+  // it still renders, still plays and still passes - at 1280px, which for a component
+  // the app only mounts below 768 would prove the opposite of what it claims.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  beforeEach: () => {
+    seed();
+  },
+  decorators: [
+    (Story) => (
+      <div className="min-h-[720px] bg-[var(--page)] px-3.5 py-3">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof PhoneInvoiceList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const List: Story = {
+  name: 'The phone finance list',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* The KPI tiles. Two tracks and two children: the grid is `grid-cols-2` with no
+       responsive variant, so it must stay two-across at 375 - a one-track template
+       would stack them and push the whole list below the fold. */
+    const collected = canvas.getByText('Collected · wk');
+    const tiles = collected.closest('.grid') as HTMLElement;
+    await expect(getComputedStyle(tiles).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(2);
+    await expect(tiles.children).toHaveLength(2);
+
+    /* The figures are computed by `computeFinanceMetrics` against a fixed "now", not
+       written by hand: $114 collected (one PAID invoice inside the trailing week) and
+       $490 outstanding (240 owed in full, plus 250 still owed on the part-paid one -
+       the settled invoice contributes nothing). */
+    await expect(tiles.children[0]).toHaveTextContent('$114');
+    await expect(tiles.children[1]).toHaveTextContent('Outstanding');
+    await expect(tiles.children[1]).toHaveTextContent('$490');
+
+    /* Outstanding is tinted and Collected is not, and that is the entire visual
+       difference between the two tiles. Resolved BEFORE the poll, never inside it -
+       `resolveToken` mutates the DOM. Polled because the tiles inherit
+       `transition-colors` from the theme and a single synchronous read can catch an
+       interpolated value. */
+    const warnInk = resolveToken(canvasElement, '--warn-text');
+    const ink = resolveToken(canvasElement, '--ink');
+    // Scoped to the tiles: "$114" is printed twice on this screen, once here and once
+    // on the paid invoice's card, and an unscoped query would find both and throw.
+    const outstandingFigure = within(tiles).getByText('$490');
+    const collectedFigure = within(tiles).getByText('$114');
+    await waitFor(() => {
+      expect(getComputedStyle(outstandingFigure).color).toBe(warnInk);
+      expect(getComputedStyle(collectedFigure).color).toBe(ink);
+    });
+
+    /* The rail carries all seven backend statuses, and it OVERFLOWS at this width -
+       which is the behaviour, not a defect. Asserted through scrollWidth rather than
+       by counting pixels, so it states the rule and holds at 375 and 430 alike. */
+    const group = rail(canvasElement);
+    await expect(within(group).getAllByRole('button')).toHaveLength(7);
+    const scroller = group.parentElement as HTMLElement;
+    await expect(getComputedStyle(scroller).overflowX).toBe('auto');
+    await expect(scroller.scrollWidth).toBeGreaterThan(scroller.clientWidth);
+
+    // Three cards, in list order, each named by its invoice.
+    await expect(cards(canvasElement)).toHaveLength(3);
+    const paid = within(card(canvasElement, '#INV-2026-0142'));
+    await expect(paid.getByText('Paid')).toBeInTheDocument();
+    /* The identity line, in full. It reads `{owner first name} / {companion} ·
+       {owner surname} · {service}` - one line, three separators, the owner named
+       twice. Asserted verbatim because that is the string a reviewer should look at
+       and decide about, not a fragment that would pass on half of it. */
+    await expect(paid.getByText('Sky / Kizie · Doe · Dental consultation')).toBeInTheDocument();
+    await expect(paid.getByText('$114')).toBeInTheDocument();
+    // Footnote branch 1: settled, so the payment method stands in for a balance.
+    await expect(paid.getByText('Online payment')).toBeInTheDocument();
+
+    const unpaid = within(card(canvasElement, '#INV-2026-0163'));
+    await expect(unpaid.getByText('Aria / Milo · Blake · Vaccination')).toBeInTheDocument();
+    await expect(unpaid.getByText('$240')).toBeInTheDocument();
+    // Footnote branch 2: nothing collected and nothing settled, so no footnote at all.
+    await expect(unpaid.queryByText('Online payment')).not.toBeInTheDocument();
+
+    const partPaid = within(card(canvasElement, '#INV-2026-0171'));
+    // Footnote branch 3: a deposit outranks both other cases.
+    await expect(partPaid.getByText('Deposit $50 applied')).toBeInTheDocument();
+    await expect(partPaid.getByText('$300')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting list: one settled invoice, one wholly unpaid, one part-paid. All three ' +
+          'footnote branches and both border treatments are on screen at once, which no single ' +
+          'real screen would guarantee.',
+      },
+    },
+  },
+};
+
+export const UnpaidBorder: Story = {
+  name: 'The --warn rail marks unpaid rows',
+  play: async ({ canvasElement }) => {
+    /* "Unpaid" is `outstanding > 0 AND no deposit collected`, not simply "not paid".
+       So exactly ONE of these three cards gets the rail: the part-paid invoice still
+       owes $250 and does not. That is the assertion worth having - a naive
+       `status !== 'PAID'` would light two rows and look entirely reasonable. */
+    const warn = resolveToken(canvasElement, '--warn');
+    const hairline = resolveToken(canvasElement, '--hairline');
+    const unpaid = card(canvasElement, '#INV-2026-0163');
+    const paid = card(canvasElement, '#INV-2026-0142');
+    const partPaid = card(canvasElement, '#INV-2026-0171');
+
+    await waitFor(() => {
+      expect(getComputedStyle(unpaid).borderLeftColor).toBe(warn);
+      expect(getComputedStyle(paid).borderLeftColor).toBe(hairline);
+      expect(getComputedStyle(partPaid).borderLeftColor).toBe(hairline);
+    });
+
+    // The rail is 3px against the 1px hairline on the other three edges, which is what
+    // makes it read as a marker rather than as a thicker card.
+    await expect(getComputedStyle(unpaid).borderLeftWidth).toBe('3px');
+    await expect(getComputedStyle(unpaid).borderTopWidth).toBe('1px');
+    await expect(getComputedStyle(paid).borderLeftWidth).toBe('1px');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A 3px stripe is the only per-row signal on this screen - there is no outstanding ' +
+          'figure on a card - so which rows get it is a product decision as much as a visual one. ' +
+          'A part-paid invoice reads as settled here and says so only in its footnote.',
+      },
+    },
+  },
+};
+
+export const FilteredToUnpaid: Story = {
+  name: 'Filtered to awaiting payment',
+  args: {
+    activeStatus: 'awaiting_payment',
+    filteredList: [UNPAID, PART_PAID],
+  },
+  play: async ({ canvasElement }) => {
+    const group = rail(canvasElement);
+    const pills = within(group).getAllByRole('button');
+
+    /* The active pill is the ONLY one painted: `getStatusPillStyle` returns a
+       transparent background for everything unselected, and lets the option's own
+       token set through for the selected one. So the rail's whole state is carried by
+       one background colour, with no ring, weight change or underline to back it up.
+       Read after the transition rather than in the same frame - these pills carry
+       `transition-opacity` and the badge inside them `transition-colors`. */
+    const active = within(group).getByRole('button', { name: 'Awaiting payment' });
+    const inactive = within(group).getByRole('button', { name: 'Paid' });
+    await expect(active).toHaveAttribute('aria-pressed', 'true');
+    await expect(inactive).toHaveAttribute('aria-pressed', 'false');
+    await expect(pills.filter((pill) => pill.getAttribute('aria-pressed') === 'true')).toHaveLength(
+      1
+    );
+
+    const activeBadge = active.querySelector('.yc-status-pill') as HTMLElement;
+    const inactiveBadge = inactive.querySelector('.yc-status-pill') as HTMLElement;
+    await waitFor(() => {
+      expect(getComputedStyle(inactiveBadge).backgroundColor).toBe('rgba(0, 0, 0, 0)');
+      expect(getComputedStyle(activeBadge).backgroundColor).not.toBe('rgba(0, 0, 0, 0)');
+    });
+
+    // The list is filtered by the PAGE, not here - this component renders whatever
+    // `filteredList` holds - so the two remaining cards are the proof the story is
+    // showing a coherent state rather than a mismatched pill and list.
+    await expect(cards(canvasElement)).toHaveLength(2);
+    await expect(card(canvasElement, '#INV-2026-0163')).toBeInTheDocument();
+    await expect(
+      within(canvasElement).queryByRole('button', { name: 'View invoice #INV-2026-0142' })
+    ).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The rail keeps its own scroll position, so on a narrow phone the active pill can be ' +
+          'off-screen: "Awaiting payment" is the third of seven and already sits near the right ' +
+          'edge at 375px. Nothing scrolls it into view when the filter changes.',
+      },
+    },
+  },
+};
+
+export const ChoosingAFilter: Story = {
+  name: 'Tapping a pill and a card',
+  play: async ({ canvasElement, args }) => {
+    const group = rail(canvasElement);
+
+    await userEvent.click(within(group).getByRole('button', { name: 'Paid' }));
+    /* The KEY, not the label. The page filters on a lowercased status key, so a pill
+       that passed its display name would match nothing and silently empty the list. */
+    await expect(args.setActiveStatus).toHaveBeenCalledTimes(1);
+    await expect(args.setActiveStatus).toHaveBeenCalledWith('paid');
+
+    /* The component is controlled: `activeStatus` is still 'all', so the pill it just
+       pressed is still unpressed and the list is unchanged. A page that forgot to echo
+       the callback back into state would look exactly like this. */
+    await expect(within(group).getByRole('button', { name: 'Paid' })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+    await expect(cards(canvasElement)).toHaveLength(3);
+
+    /* The whole card is one button, so the tap target is the full three-line row
+       rather than a chevron - and it hands back the invoice OBJECT, which is what
+       lets the page open the record sheet without a second lookup. */
+    await userEvent.click(card(canvasElement, '#INV-2026-0171'));
+    await expect(args.onViewInvoice).toHaveBeenCalledTimes(1);
+    await expect(args.onViewInvoice).toHaveBeenCalledWith(PART_PAID);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Both interactions the screen has. Neither writes anything - the page owns the filter ' +
+          'state and the record sheet - so this list is pure presentation and stays that way ' +
+          'however long it gets.',
+      },
+    },
+  },
+};
+
+export const Empty: Story = {
+  name: 'No invoices match',
+  args: { filteredList: [], activeStatus: 'refunded' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByText('No invoices match the current filters.')).toBeInTheDocument();
+    await expect(cards(canvasElement)).toHaveLength(0);
+
+    /* The tiles and the rail survive an empty list, and they must: the tiles are
+       computed from ALL invoices rather than the filtered ones, so "$490 outstanding"
+       above an empty list is correct rather than contradictory - and the rail is the
+       only way back out of a filter that matched nothing. */
+    await expect(canvas.getByText('$490')).toBeInTheDocument();
+    await expect(within(rail(canvasElement)).getAllByRole('button')).toHaveLength(7);
+
+    // The empty state is an <output>, announced politely, so a filter change that
+    // empties the list is spoken rather than silently blanking the screen.
+    const empty = canvas.getByRole('status');
+    await expect(empty).toHaveAttribute('aria-live', 'polite');
+    await expect(empty).toHaveTextContent('No invoices match the current filters.');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Reachable in one tap: "Refunded" matches nothing in most practices. The sentence names ' +
+          'filters rather than invoices, which is the right call here - the KPI tiles above it ' +
+          'are still showing money, so "no invoices" alone would read as a data failure.',
+      },
+    },
+  },
+};
+
+export const UnlinkedInvoice: Story = {
+  name: 'An invoice with no appointment',
+  args: {
+    filteredList: [
+      invoice({
+        id: 'd4e5f60718293a4b5c6d7e8f',
+        metadata: { invoiceNumber: 'INV-2026-0009' },
+        appointmentId: undefined,
+        totalAmount: 42,
+        subtotal: 42,
+        status: 'PENDING',
+        paymentCollectionMethod: 'PAYMENT_AT_CLINIC',
+        createdAt: new Date('2026-08-14T08:45:00.000Z'),
+      }),
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const row = within(card(canvasElement, '#INV-2026-0009'));
+
+    /* No appointment means no owner, no companion and no service, so the identity line
+       is empty and falls back to one word. It is the middle line of the card - the
+       widest one - and it is the only thing that would have said whose bill this is. */
+    await expect(row.getByText('Unlinked invoice')).toBeInTheDocument();
+
+    // Everything else still renders: number, date, status and amount are all read off
+    // the invoice itself rather than the appointment.
+    await expect(row.getByText('$42')).toBeInTheDocument();
+    await expect(row.getByText('Pending')).toBeInTheDocument();
+    /* The avatar falls back to the species default rather than disappearing, which is
+       why the amount still sits at the same distance from the left edge. Queried as a
+       plain <img> - it is decorative (`alt=""`), so it is out of the accessibility
+       tree and no role query reaches it. */
+    const unlinkedCard = card(canvasElement, '#INV-2026-0009');
+    await expect(unlinkedCard.querySelector('img')).not.toBeNull();
+
+    // A PENDING invoice with no deposit is unpaid, so it takes the --warn rail.
+    const warn = resolveToken(canvasElement, '--warn');
+    await waitFor(() => {
+      expect(getComputedStyle(unlinkedCard).borderLeftColor).toBe(warn);
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A counter sale, or an invoice whose appointment was deleted. The card degrades to the ' +
+          'invoice number and the amount - which on a phone list of a dozen rows is very little ' +
+          'to identify it by, and worth deciding whether the payer should be read from ' +
+          '`invoice.parentId` instead.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/AddForm.stories.tsx
+++ b/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/AddForm.stories.tsx
@@ -1,0 +1,373 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import type { Organisation } from '@yosemite-crew/types';
+
+import type { FormField, FormsProps } from '@/app/features/forms/types/forms';
+import type { OrgIntegration } from '@/app/features/integrations/services/types';
+import { useIntegrationStore } from '@/app/stores/integrationStore';
+import { useOrgStore } from '@/app/stores/orgStore';
+import AddForm from './index';
+
+const ORG_ID = 'org-avenger-park';
+
+const ORG: Organisation = {
+  _id: ORG_ID,
+  name: 'Avenger Park Veterinary',
+  type: 'HOSPITAL',
+  phoneNo: '4155550110',
+  taxId: 'DE-8871-2290',
+  isActive: true,
+};
+
+const SERVICE_OPTIONS = [
+  { label: 'Dental consultation', value: 'svc-dental', badge: 'Service' },
+  { label: 'Senior wellness package', value: 'svc-senior', badge: 'Package' },
+];
+
+const SCHEMA: FormField[] = [
+  {
+    id: 'presenting_complaint',
+    type: 'input',
+    label: 'Presenting complaint',
+    placeholder: 'Limping on the left hind',
+  },
+  {
+    id: 'observed_signs',
+    type: 'checkbox',
+    label: 'Observed signs',
+    multiple: true,
+    options: [
+      { label: 'Lameness', value: 'lameness' },
+      { label: 'Swelling', value: 'swelling' },
+    ],
+  },
+  { id: 'owner_signature', type: 'signature', label: 'Owner signature' },
+];
+
+const TEMPLATE: FormsProps = {
+  _id: 'form-2291',
+  name: 'Anaesthesia consent',
+  description: 'Signed before any procedure requiring general anaesthetic.',
+  category: 'Consent form',
+  usage: 'Internal & External',
+  requiredSigner: 'CLIENT',
+  services: ['svc-dental'],
+  species: ['Canine'],
+  updatedBy: 'Dr. Elena Marsh',
+  lastUpdated: '2026-06-02T10:15:00.000Z',
+  status: 'Draft',
+  templateSource: 'ORG_TEMPLATE',
+  isTemplateBacked: false,
+  schema: SCHEMA,
+};
+
+const merck = (status: OrgIntegration['status']): OrgIntegration => ({
+  id: 'int-merck',
+  organisationId: ORG_ID,
+  provider: 'MERCK_MANUALS',
+  status,
+});
+
+/**
+ * Seeds the org and the MSD integration. `merckEnabled` comes from
+ * `useResolvedMerckIntegrationForPrimaryOrg`, whose gateway just resolves the
+ * provider out of the integrations the store already holds - so seeding the
+ * store is the whole setup, with no service stubbed and no network reached.
+ */
+const seed = (status: OrgIntegration['status'] = 'enabled') => {
+  useOrgStore.setState({
+    orgsById: { [ORG_ID]: ORG },
+    orgIds: [ORG_ID],
+    primaryOrgId: ORG_ID,
+    status: 'loaded',
+  });
+  useIntegrationStore.setState({
+    integrationsById: { 'int-merck': merck(status) },
+    integrationIdsByOrgId: { [ORG_ID]: ['int-merck'] },
+    status: 'loaded',
+    error: null,
+    lastFetchedAt: '2026-08-18T06:05:00.000Z',
+  });
+};
+
+const BuilderHarness = () => {
+  const [open, setOpen] = useState(true);
+  return (
+    <div className="min-h-[720px] bg-[var(--screen)] p-6">
+      <p className="text-[13px] text-[var(--ink-muted)]">Forms list behind the builder drawer.</p>
+      <AddForm
+        showModal={open}
+        setShowModal={setOpen}
+        initialForm={TEMPLATE}
+        serviceOptions={SERVICE_OPTIONS}
+      />
+    </div>
+  );
+};
+
+const panel = () => document.querySelector('dialog[open]') as HTMLElement;
+
+const meta = {
+  title: 'Forms/AddForm builder',
+  component: BuilderHarness,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The template builder drawer and its **view switcher**, which is the part that had ' +
+          'never been drawn. `Build` has its own story; the two panes that replace it do not.\n\n' +
+          '"Preview as parent" does not open anything - it swaps the entire body for `Review` and ' +
+          'takes the modal chrome with it. The header\'s "Save template" pill is removed (Review ' +
+          'supplies its own Publish/Save-as-draft pair) and the `ModalFooter` is not rendered at ' +
+          'all, so the drawer temporarily has **no footer**. That is a whole different panel ' +
+          'skeleton reached by one toggle, and a snapshot of the builder proves nothing about ' +
+          'it.\n\n' +
+          'The MSD pane is the same trick with an extra gate: the button only exists when the ' +
+          'org has the MSD integration enabled, and the view is coerced back to `build` during ' +
+          'render if that ever stops being true (`effectiveView`), so a stale `merck` view can ' +
+          'never render an empty pane. Both cases are drawn below.\n\n' +
+          'Neither toggle is idempotent-looking: `TOGGLE_VIEW` returns to `build` when the ' +
+          'active pane is re-selected, which is why the buttons carry `aria-pressed` and why the ' +
+          'preview button relabels itself to "Back to builder".\n\n' +
+          'Everything mounts from seeded zustand state. The only service calls in this file are ' +
+          'in the save and publish handlers, and no story clicks them.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  beforeEach: () => {
+    seed();
+  },
+} satisfies Meta<typeof BuilderHarness>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Builder: Story = {
+  name: 'Builder (default view)',
+  play: async () => {
+    const body = within(document.body);
+    await waitFor(() => expect(panel()).not.toBeNull());
+    const drawer = within(panel());
+
+    // Header: title carries the template name, and the meta line is the derived
+    // "<category> · <n> fields · linked to <n> services" summary.
+    await expect(drawer.getByText('Edit template · Anaesthesia consent')).toBeInTheDocument();
+    await expect(
+      drawer.getByText('Consent form · 3 fields · linked to 1 service')
+    ).toBeInTheDocument();
+
+    // Three header actions plus the footer's draft action, all four at once.
+    const preview = drawer.getByRole('button', { name: 'Preview as parent' });
+    await expect(preview).toHaveAttribute('aria-pressed', 'false');
+    expect(
+      await drawer.findByRole('button', { name: 'MSD Veterinary Manual' })
+    ).toBeInTheDocument();
+    await expect(drawer.getByRole('button', { name: 'Update & publish' })).toBeInTheDocument();
+
+    /* The draft action lives in the `ModalFooter` here - a `border-t` row that is
+       a sibling of the body. Review renders a button with the SAME label inside
+       its own `grid-cols-2` action pair, so "is there an Update draft button" is
+       true in both views and only its container tells them apart. */
+    const draft = drawer.getByRole('button', { name: 'Update draft' });
+    await expect(draft.parentElement?.className).toContain('border-t');
+    await expect(draft.closest('div[class*="grid-cols-2"]')).toBeNull();
+
+    // The builder body: the details fold (collapsed) over the palette/canvas.
+    await expect(drawer.getByRole('button', { name: 'Edit details' })).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
+    await expect(drawer.getByText('Add a field')).toBeInTheDocument();
+    // Nothing from the preview pane is mounted.
+    await expect(body.queryByRole('button', { name: 'Publish template' })).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting builder. The title reads "Edit template" rather than "Add template" ' +
+          'because `initialForm._id` is set, and the same flag turns the two save actions into ' +
+          '"Update & publish" / "Update draft" - a four-label swap driven by one boolean.',
+      },
+    },
+  },
+};
+
+export const PreviewAsParent: Story = {
+  name: 'Preview as parent (Review pane)',
+  play: async () => {
+    const body = within(document.body);
+    await waitFor(() => expect(panel()).not.toBeNull());
+    const drawer = () => within(panel());
+
+    await userEvent.click(drawer().getByRole('button', { name: 'Preview as parent' }));
+
+    /* Waited on a string only Review renders. The builder's own details step says
+       "Usage and visibility"; Review says "Usage & visibility". Waiting on
+       "Update & publish" instead would resolve instantly against the header pill
+       that was already there, and the story would pass without ever switching. */
+    expect(await drawer().findByText('Usage & visibility')).toBeInTheDocument();
+
+    // The body is REPLACED, not stacked - the builder has to be gone.
+    await expect(drawer().queryByText('Add a field')).not.toBeInTheDocument();
+    await expect(drawer().queryByRole('button', { name: 'Edit details' })).not.toBeInTheDocument();
+
+    // Review's read-only summary, over the same schema.
+    await expect(drawer().getByText('Form details')).toBeInTheDocument();
+    await expect(drawer().getByText('Presenting complaint')).toBeInTheDocument();
+
+    /* The chrome changes too, which is the easiest part to miss. The header's
+       save pill is gone and the `ModalFooter` is not rendered at all, so the one
+       remaining "Update draft" now sits in Review's own `grid-cols-2` pair
+       rather than in a `border-t` footer row. The label is identical in both
+       views, so the container is the only thing that proves the swap. */
+    const draft = drawer().getByRole('button', { name: 'Update draft' });
+    const actions = draft.closest('div[class*="grid-cols-2"]') as HTMLElement;
+    await expect(actions).not.toBeNull();
+    await expect(draft.parentElement?.className ?? '').not.toContain('border-t');
+
+    /* Two equal tracks holding exactly two buttons. Matching the class string
+       alone would still pass if a third action had been dropped into the pair, or
+       if the tracks had collapsed to one at this width - and it is the pairing
+       that makes Review's actions read as a decision rather than as a footer. */
+    const tracks = getComputedStyle(actions).gridTemplateColumns.trim().split(/\s+/);
+    await expect(tracks).toHaveLength(2);
+    await expect(tracks[0]).toBe(tracks[1]);
+    await expect(actions.children).toHaveLength(2);
+    await expect([...actions.children].map((node) => node.textContent?.trim())).toEqual([
+      'Update & publish',
+      'Update draft',
+    ]);
+
+    /* Exactly one "Update & publish" anywhere in the document: the header pill is
+       unmounted in this view and Review supplies its own, so a count of two would
+       mean the header failed to strip itself. */
+    await expect(body.getAllByRole('button', { name: 'Update & publish' })).toHaveLength(1);
+
+    // The toggle relabels itself and reports its pressed state.
+    const back = drawer().getByRole('button', { name: 'Back to builder' });
+    await expect(back).toHaveAttribute('aria-pressed', 'true');
+
+    // Re-selecting the active pane returns to the builder rather than doing nothing.
+    await userEvent.click(back);
+    await waitFor(() => expect(drawer().queryByText('Add a field')).toBeInTheDocument());
+    await expect(drawer().getByRole('button', { name: 'Preview as parent' })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'What a pet parent would be handed. `Review` renders the two detail accordions read-only ' +
+          'and then the real `FormRenderer` over the same schema, so the fields below the fold are ' +
+          'the actual controls rather than a mock-up of them.',
+      },
+    },
+  },
+};
+
+export const MsdPane: Story = {
+  name: 'MSD Veterinary Manual pane',
+  play: async () => {
+    await waitFor(() => expect(panel()).not.toBeNull());
+    const drawer = () => within(panel());
+
+    const msd = await drawer().findByRole('button', { name: 'MSD Veterinary Manual' });
+    await userEvent.click(msd);
+
+    // `AppointmentMerckSearch` replaces the builder body.
+    expect(await drawer().findByText('MSD Manual')).toBeInTheDocument();
+    await expect(drawer().getByText('In-visit lookup')).toBeInTheDocument();
+    await expect(drawer().getByRole('textbox', { name: 'Search manuals' })).toBeInTheDocument();
+    await expect(drawer().queryByText('Add a field')).not.toBeInTheDocument();
+
+    /* Unlike preview, this pane keeps the full modal chrome - the save pill and
+       the footer are both still there, because only `preview` strips them. Two
+       panes, two different skeletons, one switcher. */
+    await expect(drawer().getByRole('button', { name: 'Update & publish' })).toBeInTheDocument();
+    await expect(drawer().getByRole('button', { name: 'Update draft' })).toBeInTheDocument();
+    await expect(msd).toHaveAttribute('aria-pressed', 'true');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The in-builder manual lookup, so a clinician can check a dose or a differential without ' +
+          'losing a half-built template. It mounts the same `AppointmentMerckSearch` the ' +
+          'appointment workspace uses, with `activeAppointment` null.',
+      },
+    },
+  },
+};
+
+export const MsdHiddenWhenDisabled: Story = {
+  name: 'MSD button hidden when the integration is off',
+  beforeEach: () => {
+    seed('disabled');
+  },
+  play: async () => {
+    await waitFor(() => expect(panel()).not.toBeNull());
+    const drawer = within(panel());
+
+    /* The button is not disabled, it is absent - and the two actions beside it
+       have to still be there, or "the button is gone" would also be true of a
+       drawer that failed to render its header at all. `MsdPane` above is the
+       positive control: the same query finds the button once the integration
+       resolves as enabled, so this pair is what proves the gate rather than a
+       missing render. */
+    await expect(drawer.getByRole('button', { name: 'Preview as parent' })).toBeInTheDocument();
+    await expect(drawer.getByRole('button', { name: 'Update & publish' })).toBeInTheDocument();
+    await expect(
+      drawer.queryByRole('button', { name: 'MSD Veterinary Manual' })
+    ).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'With MSD off, the third header action never mounts. The reducer can still hold a stale ' +
+          '`merck` view from an earlier session, which is why `effectiveView` coerces it back to ' +
+          '`build` while rendering rather than in an effect - the pane is never shown empty.',
+      },
+    },
+  },
+};
+
+export const DetailsFoldOpen: Story = {
+  name: 'Template details fold (open)',
+  play: async () => {
+    await waitFor(() => expect(panel()).not.toBeNull());
+    const drawer = within(panel());
+
+    const toggle = drawer.getByRole('button', { name: 'Edit details' });
+    await userEvent.click(toggle);
+
+    /* The fold is ALWAYS mounted - it is toggled with a `hidden` class, not by
+       unmounting - because publish validates through its imperative handle even
+       while it is shut. So the assertion has to be about visibility, and about
+       the label flipping, not about the fields appearing in the DOM. */
+    const relabelled = await drawer.findByRole('button', { name: 'Hide details' });
+    await expect(relabelled).toHaveAttribute('aria-expanded', 'true');
+    await expect(drawer.getByRole('textbox', { name: 'Form name' })).toBeVisible();
+    await expect(drawer.getByRole('textbox', { name: 'Form name' })).toHaveValue(
+      'Anaesthesia consent'
+    );
+    // `hideNext` is set here, so the step's own Next button stays out of the
+    // builder - saving happens from the header pill instead.
+    await expect(drawer.queryByRole('button', { name: 'Next' })).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The details step folded into the single-screen builder. It is capped at `max-h-[40%]` ' +
+          'and scrolls, so opening it never pushes the palette off the drawer.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/Details.stories.tsx
+++ b/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/Details.stories.tsx
@@ -1,0 +1,267 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+
+import type { FormsCategory, FormsProps } from '@/app/features/forms/types/forms';
+import Details from './Details';
+
+type ServiceOption = { label: string; value: string; badge?: string; isInpatient?: boolean };
+
+const SERVICE_OPTIONS: ServiceOption[] = [
+  { label: 'Dental consultation', value: 'svc-dental', badge: 'Service' },
+  { label: 'Senior wellness package', value: 'svc-senior', badge: 'Package' },
+  { label: 'Post-op boarding', value: 'svc-boarding', badge: 'Package', isInpatient: true },
+];
+
+/**
+ * A brand-new custom template: no name, no category, no description, no species,
+ * no services, and `requiredSigner` left `undefined` rather than `''`.
+ *
+ * That last one is the difference between five errors and six. `validate` tests
+ * `requiredSigner === undefined`, so an empty string counts as a deliberate
+ * "nobody signs this" and passes - which is exactly what `handleCategoryChange`
+ * writes when the category becomes SOAP.
+ */
+const BLANK_CUSTOM: FormsProps = {
+  name: '',
+  category: '' as FormsCategory,
+  usage: 'Internal',
+  updatedBy: '',
+  lastUpdated: '',
+  status: 'Draft',
+  schema: [],
+  templateSource: 'ORG_TEMPLATE',
+  isTemplateBacked: false,
+};
+
+const FILLED: FormsProps = {
+  ...BLANK_CUSTOM,
+  name: 'Anaesthesia consent',
+  category: 'Consent form',
+  description: 'Signed before any procedure requiring general anaesthetic.',
+  requiredSigner: 'CLIENT',
+  species: ['Canine'],
+  services: ['svc-dental'],
+};
+
+/**
+ * `Details` is a controlled step - it never holds `formData`, it calls
+ * `setFormData` and re-reads - so the harness owns that state the way AddForm
+ * does. The error map, by contrast, is genuinely internal: `formDataErrors`
+ * starts `{}` and is written only by `validate()`, which is why no prop can put
+ * this step into its error state and why the story has to click Next.
+ */
+const DetailsHarness = ({ initialForm }: { initialForm: FormsProps }) => {
+  const [formData, setFormData] = useState<FormsProps>(initialForm);
+  return (
+    <div className="bg-[var(--screen)] p-4">
+      <div className="w-[504px] max-w-full rounded-2xl border border-[var(--hairline)] p-3">
+        <Details
+          formData={formData}
+          setFormData={setFormData}
+          onNext={fn()}
+          serviceOptions={SERVICE_OPTIONS}
+        />
+      </div>
+    </div>
+  );
+};
+
+const ALL_ERRORS = [
+  'Form name is required',
+  'Description is required',
+  'Category is required',
+  'Signed by is required',
+  'Select at least one species',
+  'Services / Packages is required for this form category',
+];
+
+const meta = {
+  title: 'Forms/AddForm Details',
+  component: DetailsHarness,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The template Details step, in the state a reviewer never sees: **all six inline errors ' +
+          'at once**.\n\n' +
+          '`formDataErrors` is local state that starts `{}` and is populated only by `validate()`. ' +
+          'Nothing sets it from outside - the parent reaches it through an imperative handle - so ' +
+          'there is no prop, no arg and no control that can draw this. Every error variant of ' +
+          'every field in this step was therefore undrawn, across two accordions and four ' +
+          'different input primitives, each of which renders its error differently: `FormInput` ' +
+          'gives a `role="alert"` row wired to the field with `aria-describedby`, while ' +
+          '`LabelDropdown` and `MultiSelectDropdown` render an un-roled warning row and tint the ' +
+          'trigger border.\n\n' +
+          'The six are not independent. `requiredSigner` only errors when it is `undefined` - an ' +
+          'empty string is a real answer - and `services` is skipped entirely for the `Custom` ' +
+          'category. So a blank **Custom** template produces five errors and a blank ' +
+          'org-template produces six, which is why the fixture below is deliberately not Custom.\n\n' +
+          'Clearing is per field and happens on the next keystroke rather than on a second ' +
+          'submit, so the drawn state is genuinely transient - the last story below spends one ' +
+          'keystroke to show that only the touched error goes away.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: { initialForm: BLANK_CUSTOM },
+} satisfies Meta<typeof DetailsHarness>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Blank: Story = {
+  name: 'Blank step (no errors yet)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Nothing has been validated, so the step is clean even though every
+    // required field is empty.
+    for (const message of ALL_ERRORS) {
+      await expect(canvas.queryByText(message)).not.toBeInTheDocument();
+    }
+    // Nothing is flagged either, which is a stronger claim than "no message text":
+    // `aria-invalid` is written from the same map the messages come from.
+    const name = canvas.getByRole('textbox', { name: 'Form name' });
+    await expect(name).toHaveValue('');
+    await expect(name).toHaveAttribute('aria-invalid', 'false');
+    await expect(canvas.getByRole('textbox', { name: 'Description' })).toHaveAttribute(
+      'aria-invalid',
+      'false'
+    );
+    await expect(canvas.queryAllByRole('alert')).toHaveLength(0);
+    await expect(canvas.getByRole('button', { name: 'Next' })).toBeInTheDocument();
+
+    /* Both accordions carry `defaultOpen`, so the step mounts as one tall column
+       rather than two collapsed headers. Read off `aria-expanded` rather than off
+       the title text: the titles render whether the fold is open or shut, so
+       `getByText('Form details')` is true in both states and proves nothing about
+       the shape of the step. */
+    for (const title of ['Form details', 'Usage and visibility']) {
+      await expect(canvas.getByRole('button', { name: title })).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      );
+    }
+
+    /* Every dropdown rests at its own placeholder, which is the resting label a
+       reviewer is here to look at - and the reason the error story has to read
+       these off `aria-label` instead of by text. */
+    const dropdownLabels = [...canvasElement.querySelectorAll('[aria-haspopup="listbox"]')].map(
+      (node) => node.getAttribute('aria-label')
+    );
+    for (const label of ['Category', 'Signed by', 'Species']) {
+      await expect(dropdownLabels).toContain(label);
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The step as it mounts for a new template. This is the only state that had a shape ' +
+          'anyone had looked at.',
+      },
+    },
+  },
+};
+
+export const AllErrors: Story = {
+  name: 'Six errors at once',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Next' }));
+
+    /* All six, and asserted as a set rather than one by one: `validate` builds
+       the whole map in a single pass and commits it once, so a bug that dropped
+       one branch would still light up the other five and look correct. */
+    for (const message of ALL_ERRORS) {
+      expect(await canvas.findByText(message)).toBeInTheDocument();
+    }
+
+    /* Only the two `FormInput` fields announce themselves. The dropdown errors
+       are plain rows with no role and no `aria-describedby`, which is the real
+       accessibility gap this state exposes - four of the six messages are
+       invisible to a screen reader. */
+    const alerts = canvas.getAllByRole('alert');
+    await expect(alerts).toHaveLength(2);
+    await expect(alerts.map((node) => node.textContent?.trim())).toEqual([
+      'Form name is required',
+      'Description is required',
+    ]);
+
+    const name = canvas.getByRole('textbox', { name: 'Form name' });
+    await expect(name).toHaveAttribute('aria-invalid', 'true');
+    await expect(name).toHaveAttribute('aria-describedby', alerts[0].id);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Press Next on the blank step. The two accordions grow by roughly six rows of message ' +
+          'text, which is the layout consequence worth looking at - the step is scrollable inside ' +
+          'the builder fold, and this is its tallest state.',
+      },
+    },
+  },
+};
+
+export const ErrorsClearPerField: Story = {
+  name: 'One keystroke clears one error',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Next' }));
+    expect(await canvas.findByText('Form name is required')).toBeInTheDocument();
+
+    await userEvent.type(canvas.getByRole('textbox', { name: 'Form name' }), 'A');
+
+    /* The name error goes and NOTHING else moves. Each handler clears only its
+       own key, so a shared reset here would silently hide five real problems
+       behind one fixed field. */
+    await waitFor(() => {
+      expect(canvas.queryByText('Form name is required')).not.toBeInTheDocument();
+    });
+    for (const message of ALL_ERRORS.slice(1)) {
+      await expect(canvas.getByText(message)).toBeInTheDocument();
+    }
+    await expect(canvas.getAllByRole('alert')).toHaveLength(1);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Clearing is keyed per field and fires from the change handler, not from a re-validate, ' +
+          'so an error can disappear while the value is still invalid (one character is enough ' +
+          'here). That is deliberate - re-validating on every keystroke would light the form up ' +
+          'while it is being filled in.',
+      },
+    },
+  },
+};
+
+export const NoErrorsWhenComplete: Story = {
+  name: 'Complete step passes validation',
+  args: { initialForm: FILLED },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Next' }));
+
+    // The negative control for the story above: same click, no messages, so the
+    // six errors are the validator's doing and not the step's resting state.
+    for (const message of ALL_ERRORS) {
+      await expect(canvas.queryByText(message)).not.toBeInTheDocument();
+    }
+    await expect(canvas.queryAllByRole('alert')).toHaveLength(0);
+    await expect(canvas.getByRole('textbox', { name: 'Form name' })).toHaveValue(
+      'Anaesthesia consent'
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A filled template. Worth keeping beside the error story: without it, a `validate` that ' +
+          'returned errors unconditionally would look identical in review.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/guides/pages/Guides.stories.tsx
+++ b/apps/frontend/src/app/features/guides/pages/Guides.stories.tsx
@@ -1,0 +1,275 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import { guidesData } from '@/app/features/guides/data/guidesData';
+import { Guides } from './Guides';
+
+/** Every card is a button labelled `Play guide: <title>`, so this counts the grid. */
+const cards = (canvasElement: HTMLElement) =>
+  within(canvasElement).queryAllByRole('button', { name: /^Play guide: / });
+
+/**
+ * The search field takes its accessible name from `Search`'s own `label` prop,
+ * which the page does not pass - so it is the default "Search" and NOT the
+ * "Search guides" placeholder. Worth pinning in one helper rather than getting
+ * it wrong in five play functions.
+ */
+const searchBox = (canvasElement: HTMLElement) =>
+  within(canvasElement).getByRole('searchbox', { name: 'Search' });
+
+/**
+ * The three strings the state card actually rendered, in order: title, message,
+ * clear-button label. Read off the card's own children rather than queried one
+ * at a time, so a story asserts the whole set the page overrode instead of
+ * spot-checking one line and leaving a `FilteredEmptyState` default in place.
+ * The leading icon span holds an svg and no text, which is what `filter(Boolean)`
+ * drops. Read-only, so it is safe to call from anywhere.
+ */
+const emptyStateLines = (canvasElement: HTMLElement): string[] => {
+  const card = within(canvasElement).getByText('No guides match your search')
+    .parentElement as HTMLElement;
+  return Array.from(card.children)
+    .map((node) => (node.textContent ?? '').trim())
+    .filter(Boolean);
+};
+
+const meta = {
+  title: 'Guides/Guides',
+  component: Guides,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The guides library: six static walkthroughs from `guidesData`, a category pill row, ' +
+          'a search field and a player modal.\n\n' +
+          'The **filtered-empty branch at Guides.tsx:159-219 had never been drawn**. Reaching it ' +
+          'takes a query that matches nothing or a category that excludes everything, and the ' +
+          'route wraps the page in `ProtectedRoute` + `OrgGuard` - which hold a `PageSkeleton` ' +
+          'until a real session and org membership resolve - so no story could get near it. ' +
+          '`Guides` is now a named export beside the protected default, and the route still ' +
+          'imports the default.\n\n' +
+          'The copy in that branch is the page’s own, not the component default: ' +
+          '`FilteredEmptyState` falls back to "Nothing matches these filters" / "Try widening the ' +
+          'date range or clearing a status filter", which is finance language and wrong here. ' +
+          'Guides overrides all three strings, and only these stories show which set actually ' +
+          'renders.\n\n' +
+          'Search and category are **combined, not alternative**: the filter drops a guide if the ' +
+          'category misses OR the query misses, so a query with hits inside one category still ' +
+          'empties the grid under another. Both routes in are drawn below because they fail ' +
+          'independently - a search bug and a category bug both end at the same sentence.\n\n' +
+          'The query is matched against title, description, category and the joined tags, so ' +
+          'typing "barcode" - a word that appears in no visible label - is a legitimate hit.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div className="min-h-[720px] bg-[var(--page)] p-6">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof Guides>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Library: Story = {
+  name: 'Full library',
+  // Pinned at 1440 rather than left on the project default. The grid is
+  // `grid-cols-1 md:grid-cols-2 xl:grid-cols-3` and `xl` is exactly 1280, so at
+  // the `laptop` preset the third track sits on the boundary and depends on
+  // whether a scrollbar eats a pixel. `desktop` is unambiguously past it.
+  globals: { viewport: { value: 'desktop', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const all = cards(canvasElement);
+    await expect(all).toHaveLength(guidesData.length);
+
+    /* Track count AND child count, because they disagree silently: a grid with
+       three tracks and six children is the intended two rows, while three tracks
+       and five children is a filter that quietly dropped one. */
+    const grid = all[0].parentElement as HTMLElement;
+    await expect(getComputedStyle(grid).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(3);
+    await expect(grid.children).toHaveLength(6);
+
+    /* Six pills: All plus one per distinct category, in first-seen order. Read
+       off the pill row itself rather than by looking each name up and asserting
+       it equals the name we looked it up by - that version could not see a
+       seventh pill, a duplicated category, or the row in the wrong order. */
+    const pillRow = canvas.getByRole('button', { name: 'All' }).parentElement as HTMLElement;
+    await expect(
+      Array.from(pillRow.children).map((pill) => (pill.textContent ?? '').trim())
+    ).toEqual(['All', 'Getting started', 'Appointments', 'Finance', 'Inventory', 'Integrations']);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting state. Three cards carry a status affordance and three carry none: ' +
+          '"Your first day" reads Watched, "Invoices, deposits and payouts" reads New, and ' +
+          '"Run a visit end to end" shows the 60% progress bar instead of either word.',
+      },
+    },
+  },
+};
+
+export const SearchFindsNothing: Story = {
+  name: 'Search matches nothing',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(cards(canvasElement)).toHaveLength(6);
+
+    await userEvent.type(searchBox(canvasElement), 'radiology');
+
+    /* Assert the copy this page supplies, not merely that a card appeared.
+       `FilteredEmptyState` renders its own defaults when a caller passes
+       nothing, and all three of those defaults ("Nothing matches these filters"
+       / "Try widening the date range or clearing a status filter" / "Clear all
+       filters") would render here without a single type error. Asserting the
+       card's three strings together is what catches one of them leaking back. */
+    await canvas.findByText('No guides match your search');
+    await expect(emptyStateLines(canvasElement)).toEqual([
+      'No guides match your search',
+      'Try a different search or pick another category.',
+      'Clear filters',
+    ]);
+
+    // The grid is gone, not merely covered.
+    await expect(cards(canvasElement)).toHaveLength(0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A query no title, description, category or tag contains. The state card replaces the ' +
+          'grid entirely - the page has no "0 results" header row - so this sentence is the only ' +
+          'thing telling a user their search ran at all.',
+      },
+    },
+  },
+};
+
+export const CategoryEmptiesTheSearch: Story = {
+  name: 'Category excludes every hit',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // "stock" hits exactly one guide, and it lives under Inventory.
+    await userEvent.type(searchBox(canvasElement), 'stock');
+    await waitFor(() => expect(cards(canvasElement)).toHaveLength(1));
+    await expect(cards(canvasElement)[0]).toHaveAccessibleName(
+      'Play guide: Stock that counts itself'
+    );
+
+    // Finance excludes it, so the same query now matches nothing.
+    await userEvent.click(canvas.getByRole('button', { name: 'Finance' }));
+
+    const title = await canvas.findByText('No guides match your search');
+    await expect(title).toBeInTheDocument();
+    await expect(cards(canvasElement)).toHaveLength(0);
+    // The query survives the category change - the field is not cleared for you.
+    await expect(searchBox(canvasElement)).toHaveValue('stock');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The second route into the same sentence, and the one a search-only story would miss: ' +
+          'the query still has a hit, the category is what removed it. The copy says "match your ' +
+          'search" either way, which is why the message also offers "pick another category".',
+      },
+    },
+  },
+};
+
+export const ClearFiltersRestores: Story = {
+  name: 'Clear filters returns the grid',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.type(searchBox(canvasElement), 'radiology');
+    await userEvent.click(canvas.getByRole('button', { name: 'Integrations' }));
+    const title = await canvas.findByText('No guides match your search');
+    await expect(title).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Clear filters' }));
+
+    // Both filters are reset, not just the one that emptied the grid.
+    await waitFor(() => expect(cards(canvasElement)).toHaveLength(6));
+    await expect(searchBox(canvasElement)).toHaveValue('');
+    await expect(canvas.queryByText('No guides match your search')).not.toBeInTheDocument();
+
+    /* The All pill is selected again. Weight is set inline and does not animate,
+       so it reads immediately; the background does animate (`transition-colors`),
+       so it is polled rather than sampled once mid-interpolation. */
+    const allPill = canvas.getByRole('button', { name: 'All' });
+    const integrationsPill = canvas.getByRole('button', { name: 'Integrations' });
+    await expect(getComputedStyle(allPill).fontWeight).toBe('700');
+    await expect(getComputedStyle(integrationsPill).fontWeight).toBe('600');
+    await waitFor(() => {
+      expect(getComputedStyle(allPill).backgroundColor).not.toBe(
+        getComputedStyle(integrationsPill).backgroundColor
+      );
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`handleClearFilters` resets the query and the category together. That matters here ' +
+          'because either one alone can empty the grid, so a button that cleared only the search ' +
+          'would leave the user staring at the same state card it just dismissed.',
+      },
+    },
+  },
+};
+
+export const PhoneFilteredEmpty: Story = {
+  name: 'Phone: filtered empty',
+  // Pinned as a GLOBAL. `parameters.viewport.defaultViewport` was removed in
+  // Storybook 10 and is inert - a story pinned that way renders desktop markup
+  // under a phone name and still passes.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.type(searchBox(canvasElement), 'radiology');
+    await canvas.findByText('No guides match your search');
+
+    // Same branch, same three overridden strings, and no grid behind them.
+    await expect(emptyStateLines(canvasElement)).toEqual([
+      'No guides match your search',
+      'Try a different search or pick another category.',
+      'Clear filters',
+    ]);
+    await expect(cards(canvasElement)).toHaveLength(0);
+
+    /* At 375px the search field is `!w-full` (the `sm:!w-[240px]` override starts
+       at 640px), so it takes its own row under the pill strip rather than sitting
+       beside it, and it spans the whole filter row. Measured with
+       getBoundingClientRect, not getComputedStyle.width: this wrapper carries a
+       1px border and 14px of horizontal padding, so the computed `width` reads
+       the content box and lands 30px short of the field's drawn edge. */
+    const box = searchBox(canvasElement).closest('div') as HTMLElement;
+    const pill = canvas.getByRole('button', { name: 'All' });
+    const pillRow = pill.parentElement as HTMLElement;
+    const filterRow = pillRow.parentElement as HTMLElement;
+    await expect(box.getBoundingClientRect().top).toBeGreaterThanOrEqual(
+      pill.getBoundingClientRect().bottom
+    );
+    await expect(Math.round(box.getBoundingClientRect().width)).toBe(
+      Math.round(filterRow.getBoundingClientRect().width)
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same empty branch at 375px. The five category pills wrap to two rows and the ' +
+          'search field goes full width beneath them, so the state card starts lower down the ' +
+          'page than the desktop story suggests.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/guides/pages/Guides.tsx
+++ b/apps/frontend/src/app/features/guides/pages/Guides.tsx
@@ -42,7 +42,13 @@ const GuideCardStatus = ({ guide }: { guide: GuideVideo }) => {
   return null;
 };
 
-const Guides = () => {
+/**
+ * Exported so Storybook can mount the page itself. The default export below is
+ * wrapped in `ProtectedRoute` + `OrgGuard`, which hold a skeleton until a real
+ * session and org membership resolve, so nothing on this page can be drawn
+ * through it. Named export only; the route still imports the protected default.
+ */
+export const Guides = () => {
   const [search, setSearch] = useState('');
   const [activeCategory, setActiveCategory] = useState(ALL_CATEGORY);
   const [showModal, setShowModal] = useState(false);

--- a/apps/frontend/src/app/features/integrations/pages/IdexxWorkspace/IdexxWorkspaceStates.stories.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/IdexxWorkspace/IdexxWorkspaceStates.stories.tsx
@@ -1,0 +1,272 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, within } from 'storybook/test';
+
+import { formatDateTimeLocal } from '@/app/lib/date';
+import { NotConnectedState, SyncingSkeleton } from './index';
+
+const LAST_SYNC = '2026-08-18T06:05:00.000Z';
+
+/**
+ * Both branches are whole-page returns, so they get the page's own padding here
+ * rather than a card wrapper - the not-connected card is centred by
+ * `flex-1 items-center justify-center` and needs room to prove its 520px cap.
+ */
+const Frame = ({ children }: { children: React.ReactNode }) => (
+  <div className="flex min-h-[560px] flex-col bg-[var(--screen-2)] p-3 md:p-5">{children}</div>
+);
+
+const meta = {
+  title: 'Integrations/IdexxWorkspace states',
+  component: NotConnectedState,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The two IDEXX Hub screens that are not the results table, and neither had ever been ' +
+          'drawn. Both are chosen by the page, not by a prop: `NotConnectedState` is an early ' +
+          '`return` taken when `!integrationEnabled && !loading`, and `SyncingSkeleton` replaces ' +
+          'the whole table body while a refresh is in flight. The page that picks between them ' +
+          'sits behind `ProtectedRoute` + `OrgGuard` and pulls results over axios, so neither ' +
+          'was reachable from a story until they were exported.\n\n' +
+          'The skeleton has a trap in it. Its root is `aria-hidden="true"`, which is correct - it ' +
+          'is decorative - but `getByRole` skips hidden subtrees by default, so every role query ' +
+          'written against it comes back empty and a story that reached for one would fail while ' +
+          'the surface rendered perfectly. The play functions below query by text and by ' +
+          'selector on purpose.\n\n' +
+          'The header band and the four placeholder rows are two independent declarations of the ' +
+          'same four tracks: `TableHead` takes `track="1.4fr 1fr 1fr 90px"` as a style, the rows ' +
+          'carry `grid-cols-[1.4fr_1fr_1fr_90px]` as a class. Nothing keeps them in agreement, ' +
+          'so both are asserted below - a drift there tilts every placeholder off its column ' +
+          'while the skeleton still looks plausible.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof NotConnectedState>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const NotConnected: Story = {
+  name: "Not connected ('IDEXX isn't connected yet')",
+  render: () => (
+    <Frame>
+      <NotConnectedState />
+    </Frame>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* Exact strings, not a loose regex: the preview decorator injects an sr-only
+       <h1> reading "<title> - <story name>" into this same canvas, and that title
+       contains "Not connected", so /not connected/i would match the heading of a
+       story whose component never rendered. */
+    const title = canvas.getByText("IDEXX isn't connected yet");
+    await expect(title).toBeInTheDocument();
+    await expect(
+      canvas.getByText(
+        'Connect your IDEXX account to order labs from the visit and pull results from in-house ' +
+          'analyzers straight into the record.'
+      )
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByText('Works with Catalyst One, ProCyte Dx and VetLab UA stations')
+    ).toBeInTheDocument();
+
+    /* TWO routes to the same place, which is the whole point of the card: the
+       filled pill and the quiet text link both go to /integrations. `Primary`
+       renders a real next/link whenever href is neither empty nor '#', so both
+       are role=link here rather than buttons. */
+    const primary = canvas.getByRole('link', { name: 'Enable IDEXX in Integrations' });
+    const secondary = canvas.getByRole('link', { name: 'Open Integrations' });
+    await expect(primary).toHaveAttribute('href', '/integrations');
+    await expect(secondary).toHaveAttribute('href', '/integrations');
+
+    // 520px card cap, 320px action column. Border box, so getBoundingClientRect -
+    // getComputedStyle().width would report the content box and read 518/318 here.
+    const card = title.closest('div[class*="max-w-[520px]"]') as HTMLElement;
+    await expect(Math.round(card.getBoundingClientRect().width)).toBe(520);
+    const actions = primary.parentElement as HTMLElement;
+    await expect(Math.round(actions.getBoundingClientRect().width)).toBe(320);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting card at desktop width. The flask chip is 74px on `--blue-soft`, the card ' +
+          'caps at 520px and the two CTAs share a 320px column, so the pill never stretches to ' +
+          'the full card width.',
+      },
+    },
+  },
+};
+
+export const NotConnectedPhone: Story = {
+  name: 'Not connected (phone)',
+  // Pinned as a GLOBAL. `parameters.viewport.defaultViewport` was removed in
+  // Storybook 10 - it still type-checks and still renders, at the full panel
+  // width, so a story pinned that way silently draws desktop markup.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  render: () => (
+    <Frame>
+      <NotConnectedState />
+    </Frame>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const title = canvas.getByText("IDEXX isn't connected yet");
+    const card = title.closest('div[class*="max-w-[520px]"]') as HTMLElement;
+
+    // `w-full max-w-[520px]` with `px-11` inside: at 375 the cap stops applying
+    // and the card takes the column, so the 88px of horizontal padding is what
+    // squeezes the copy rather than the card shrinking away from the edges.
+    const cardWidth = card.getBoundingClientRect().width;
+    await expect(cardWidth).toBeLessThan(520);
+    await expect(cardWidth).toBeGreaterThan(300);
+
+    // The action column keeps its own cap and both CTAs stay stacked.
+    const actions = canvas.getByRole('link', { name: 'Enable IDEXX in Integrations' })
+      .parentElement as HTMLElement;
+    await expect(getComputedStyle(actions).flexDirection).toBe('column');
+    await expect(actions.children).toHaveLength(2);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'At 375px the card gives up its 520 cap but keeps `px-11`, so 88px of the width is ' +
+          'padding. This is the state a phone user lands on from the Hub tab with no ' +
+          'integration, and it had never been looked at.',
+      },
+    },
+  },
+};
+
+export const Syncing: Story = {
+  name: 'Syncing skeleton',
+  render: () => (
+    <Frame>
+      <div
+        className="flex flex-col overflow-hidden rounded-2xl border"
+        style={{ background: 'var(--screen)', borderColor: 'var(--hairline)' }}
+      >
+        <SyncingSkeleton lastRefreshedAt={LAST_SYNC} />
+      </div>
+    </Frame>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByText('Syncing with IDEXX…')).toBeInTheDocument();
+    /* Formatted through the same helper the component uses rather than hard-coded:
+       `formatDateTimeLocal` renders in the viewer's preferred time zone, so a
+       literal string here would pass in one CI region and fail in the next. */
+    await expect(
+      canvas.getByText(`Last sync ${formatDateTimeLocal(LAST_SYNC, '—')}`)
+    ).toBeInTheDocument();
+
+    // Header band: four labels, four tracks.
+    const head = canvasElement.querySelector('.yc-table-head') as HTMLElement;
+
+    /* Decorative by design, and that is what makes role queries inside it come
+       back empty - assert the flag rather than rediscovering it from a failing
+       query later. `TableHead` also declares no table roles of its own, on
+       purpose: `role="columnheader"` without a `role="table"` ancestor
+       announces a header for a table nobody can navigate. */
+    await expect(head.closest('[aria-hidden="true"]')).not.toBeNull();
+    await expect(head).not.toHaveAttribute('role');
+    await expect(head.children).toHaveLength(4);
+    await expect(getComputedStyle(head).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(4);
+    await expect([...head.children].map((cell) => cell.textContent)).toEqual([
+      'Patient',
+      'Accession #',
+      'Device',
+      'Status',
+    ]);
+
+    /* Four placeholder rows, fading 1 / .75 / .5 / .28 down the stack. The
+       opacity IS the design here - equal rows would read as a loaded table with
+       no content - so it is asserted rather than assumed. */
+    const rows = [...canvasElement.querySelectorAll('div[class*="grid-cols-"]')] as HTMLElement[];
+    await expect(rows).toHaveLength(4);
+    await expect(rows.map((row) => getComputedStyle(row).opacity)).toEqual([
+      '1',
+      '0.75',
+      '0.5',
+      '0.28',
+    ]);
+    for (const row of rows) {
+      await expect(row.children).toHaveLength(4);
+      await expect(getComputedStyle(row).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(4);
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'What the table is replaced by while a refresh runs. The spinner in the band is the ' +
+          'only moving part; the rows are static bars on `--inset` with a fixed opacity ramp.',
+      },
+    },
+  },
+};
+
+export const SyncingNeverSynced: Story = {
+  name: 'Syncing skeleton (no previous sync)',
+  render: () => (
+    <Frame>
+      <div
+        className="flex flex-col overflow-hidden rounded-2xl border"
+        style={{ background: 'var(--screen)', borderColor: 'var(--hairline)' }}
+      >
+        <SyncingSkeleton lastRefreshedAt={null} />
+      </div>
+    </Frame>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The em-dash fallback, not the helper's default 'Not available' - the call
+    // site passes its own, and that choice is only visible on a first sync.
+    await expect(canvas.getByText('Last sync —')).toBeInTheDocument();
+    await expect(canvas.queryByText(/Not available/)).not.toBeInTheDocument();
+
+    /* Everything else has to be BYTE-IDENTICAL to the story above. `null` takes a
+       different branch inside `formatDateTimeLocal`, and the only thing that may
+       differ because of it is the six characters after "Last sync". Re-asserting
+       the whole skeleton here is what turns this from "a fallback string
+       rendered" into "the fallback string is the only difference". */
+    await expect(canvas.getByText('Syncing with IDEXX…')).toBeInTheDocument();
+    const head = canvasElement.querySelector('.yc-table-head') as HTMLElement;
+    await expect([...head.children].map((cell) => cell.textContent)).toEqual([
+      'Patient',
+      'Accession #',
+      'Device',
+      'Status',
+    ]);
+    await expect(getComputedStyle(head).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(4);
+
+    const rows = [...canvasElement.querySelectorAll('div[class*="grid-cols-"]')] as HTMLElement[];
+    await expect(rows).toHaveLength(4);
+    await expect(rows.map((row) => getComputedStyle(row).opacity)).toEqual([
+      '1',
+      '0.75',
+      '0.5',
+      '0.28',
+    ]);
+    for (const row of rows) {
+      await expect(row.children).toHaveLength(4);
+      await expect(getComputedStyle(row).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(4);
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The first sync after connecting, when there is no previous timestamp. ' +
+          '`formatDateTimeLocal` defaults to "Not available"; this call site overrides it with ' +
+          'an em dash, which is a difference only this state shows.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/integrations/pages/IdexxWorkspace/index.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/IdexxWorkspace/index.tsx
@@ -1865,6 +1865,14 @@ export {
   normalizeModality,
   matchesResultQuery,
   OrderDetailPanel,
+  // Two whole-page branches that only the page itself can select: the
+  // not-connected card returns instead of the workspace when the org
+  // integration resolves disabled, and the syncing skeleton replaces the
+  // results table while a refresh is in flight. Both are pure, and the page
+  // that chooses between them sits behind ProtectedRoute + OrgGuard and
+  // fetches results over axios, so they are exported for the stories.
+  NotConnectedState,
+  SyncingSkeleton,
 };
 
 export default ProtectedIdexxWorkspace;

--- a/apps/frontend/src/app/features/integrations/pages/Integrations/Integrations.stories.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/Integrations/Integrations.stories.tsx
@@ -1,0 +1,405 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import type { Organisation, UserOrganization } from '@yosemite-crew/types';
+
+import type { OrgIntegration } from '@/app/features/integrations/services/types';
+import { useIntegrationStore } from '@/app/stores/integrationStore';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { IntegrationsPage } from './index';
+
+const ORG_ID = 'org-avenger-park';
+
+const ORG: Organisation = {
+  _id: ORG_ID,
+  name: 'Avenger Park Veterinary',
+  type: 'HOSPITAL',
+  phoneNo: '4155550110',
+  taxId: 'DE-8871-2290',
+  isActive: true,
+};
+
+/**
+ * OWNER, because the page hides the gear, the enable pill and the disconnect
+ * icon behind `integrations:edit:any`. Permissions are derived from the role
+ * code on the membership (`resolveMembershipPermissions`), not read from the
+ * stored snapshot, so seeding the role is enough - there is no permission list
+ * to keep in step.
+ */
+const OWNER: UserOrganization = {
+  id: 'membership-owner',
+  practitionerReference: 'Practitioner/vet-marsh',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'OWNER',
+  active: true,
+};
+
+const integration = (over: Partial<OrgIntegration> & { id: string }): OrgIntegration => ({
+  organisationId: ORG_ID,
+  provider: 'IDEXX',
+  status: 'disabled',
+  ...over,
+});
+
+/**
+ * IDEXX stays `disabled` on purpose. The only network the page can reach is the
+ * IVLS device / recent order pair in `useIntegrationsPage`, and that effect is
+ * gated on `idexxIntegration?.status === 'enabled'` - leaving IDEXX off keeps
+ * the mount entirely off axios with no service stub, while MSD supplies a real
+ * connected provider for the Connected tab.
+ */
+const INTEGRATIONS: OrgIntegration[] = [
+  integration({
+    id: 'int-idexx',
+    provider: 'IDEXX',
+    status: 'disabled',
+    credentialsStatus: 'missing',
+  }),
+  integration({
+    id: 'int-merck',
+    provider: 'MERCK_MANUALS',
+    status: 'enabled',
+    enabledAt: '2026-06-02T14:30:00.000Z',
+  }),
+];
+
+/**
+ * Seeds both stores directly rather than through `setIntegrationsForOrg`, because
+ * that action always writes `error: null` - the error banner story needs the
+ * error and the loaded list in the same snapshot.
+ */
+const seed = (opts: { integrations?: OrgIntegration[]; error?: string | null } = {}) => {
+  const list = opts.integrations ?? INTEGRATIONS;
+  useOrgStore.setState({
+    orgsById: { [ORG_ID]: ORG },
+    orgIds: [ORG_ID],
+    primaryOrgId: ORG_ID,
+    membershipsByOrgId: { [ORG_ID]: OWNER },
+    status: 'loaded',
+  });
+  useIntegrationStore.setState({
+    integrationsById: Object.fromEntries(list.map((item) => [item.id as string, item])),
+    integrationIdsByOrgId: { [ORG_ID]: list.map((item) => item.id as string) },
+    status: 'loaded',
+    error: opts.error ?? null,
+    lastFetchedAt: '2026-08-18T06:05:00.000Z',
+  });
+};
+
+/** Every card carries the same `rounded-[18px]` shell, so this counts cards. */
+const cards = (canvasElement: HTMLElement): HTMLElement[] =>
+  [...canvasElement.querySelectorAll('div[class*="rounded-[18px]"]')] as HTMLElement[];
+
+const tab = (canvasElement: HTMLElement, label: string): HTMLElement =>
+  within(canvasElement).getByRole('button', { name: label });
+
+const meta = {
+  title: 'Integrations/Integrations page',
+  component: IntegrationsPage,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The integrations catalog. Only its settings drawer had a story; the page around it - ' +
+          'six cards, the active-count pill, the plugin strip, the two empty states and the ' +
+          'error banner - had never been drawn.\n\n' +
+          'The **four filter tabs** are the surface that hides the most. They are not a tab ' +
+          'list: each is a `<button aria-pressed>` inside a `<fieldset>` with an sr-only legend, ' +
+          'and every card decides its own visibility from the active key. Coming-soon cards are ' +
+          'deliberately excluded from both Connected and Available - they cannot be connected, ' +
+          'so they belong only under All and Coming soon - which means the four tabs show 6, 1, ' +
+          '1 and 4 cards against this fixture, and every one of those counts is a different code ' +
+          'path.\n\n' +
+          'The **error banner** is fed from two places that look the same in the DOM. The store ' +
+          'error is copied into local state by a render-phase sync (`if (integrationError !== ' +
+          'syncedIntegrationError)`), and a failed `listIdexxIvlsDevices` writes the same local ' +
+          'state directly. Only the first is reachable without a network stub, so that is the ' +
+          'one drawn here; the second produces the identical `role="alert"` line.\n\n' +
+          'Mounting the page needs no service mock at all. `IntegrationsPage` reads the org and ' +
+          'integration stores, and its one axios call is gated on IDEXX resolving as enabled - ' +
+          'so the fixture leaves IDEXX off and lets MSD be the connected provider.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  beforeEach: () => {
+    seed();
+  },
+} satisfies Meta<typeof IntegrationsPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const AllIntegrations: Story = {
+  name: 'All (default filter)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Six cards: the two real providers plus the four coming-soon placeholders,
+    // which is also the number hard-coded beside the page title.
+    await expect(cards(canvasElement)).toHaveLength(6);
+    await expect(canvas.getByText('(6)')).toBeInTheDocument();
+    await expect(canvas.getByText('IDEXX VetConnect PLUS')).toBeInTheDocument();
+    await expect(canvas.getByText('MSD Veterinary Manual')).toBeInTheDocument();
+    for (const name of ['RadAnalyzer', 'Vetnio', 'QuickBooks', 'Laika']) {
+      await expect(canvas.getByText(name)).toBeInTheDocument();
+    }
+
+    /* All six are children of ONE grid, not of a wrapper per row. The card count
+       alone would still pass if half of them had been split into a second
+       container, which is how `items-stretch` silently stops equalising heights -
+       so the grid's own child count is asserted beside it. The track count is
+       left to the phone story, since it is the one width this canvas pins. */
+    const grid = canvas.getByText('IDEXX VetConnect PLUS').closest('.grid') as HTMLElement;
+    await expect(grid.children).toHaveLength(6);
+    await expect(getComputedStyle(grid).alignItems).toBe('stretch');
+
+    /* One enabled provider in the fixture, so the pill reads "1 active". It counts
+       DISTINCT providers, not integration rows, which is why it is asserted rather
+       than assumed to equal the card count.
+
+       `findBy`, not `getBy`: MSD's status is resolved by an async effect
+       (`getMerckGateway().getStatus`), so `merckEnabled` is false for the first
+       commit and the pill starts at "0 active". A synchronous read here caught the
+       pre-resolution value. */
+    expect(await canvas.findByText('1 active')).toBeInTheDocument();
+
+    // The tabs are pressed-buttons in a fieldset, not a tablist - a role='tab'
+    // query finds nothing here.
+    await expect(canvas.queryAllByRole('tab')).toHaveLength(0);
+    await expect(tab(canvasElement, 'All')).toHaveAttribute('aria-pressed', 'true');
+    for (const label of ['Connected', 'Available', 'Coming soon']) {
+      await expect(tab(canvasElement, label)).toHaveAttribute('aria-pressed', 'false');
+    }
+
+    // MSD is on, so it offers "Open manuals" and a disconnect icon; IDEXX is off,
+    // so it offers "Enable" and the credentials gear instead.
+    expect(await canvas.findByRole('link', { name: 'Open manuals' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Enable' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Manage credentials' })).toBeInTheDocument();
+    await expect(canvas.queryByRole('link', { name: 'Open workspace' })).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The landing state. The card grid is `grid-cols-1 md:grid-cols-2 lg:grid-cols-3` with ' +
+          '`items-stretch`, so the four coming-soon cards keep the height of the two real ones ' +
+          'even though their copy is shorter.',
+      },
+    },
+  },
+};
+
+export const ConnectedFilter: Story = {
+  name: 'Filter: Connected',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(tab(canvasElement, 'Connected'));
+
+    await waitFor(() => expect(cards(canvasElement)).toHaveLength(1));
+    await expect(canvas.getByText('MSD Veterinary Manual')).toBeInTheDocument();
+    /* The assertion that matters is the ABSENCES. A filter bug that only hid the
+       coming-soon cards would still leave one connected card on screen and pass a
+       "MSD is here" check on its own. */
+    await expect(canvas.queryByText('IDEXX VetConnect PLUS')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('RadAnalyzer')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('QuickBooks')).not.toBeInTheDocument();
+
+    await expect(tab(canvasElement, 'Connected')).toHaveAttribute('aria-pressed', 'true');
+    await expect(tab(canvasElement, 'All')).toHaveAttribute('aria-pressed', 'false');
+    // A visible card means no empty state, and the two are derived from the same
+    // predicate so they can never both be true.
+    await expect(canvas.queryByText('No connected integrations yet.')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Only providers whose status resolves as enabled. MSD is the connected one in this ' +
+          'fixture; the four coming-soon cards are excluded here by design, since nothing about ' +
+          'them can be connected.',
+      },
+    },
+  },
+};
+
+export const AvailableFilter: Story = {
+  name: 'Filter: Available',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(tab(canvasElement, 'Available'));
+
+    await waitFor(() => expect(cards(canvasElement)).toHaveLength(1));
+    await expect(canvas.getByText('IDEXX VetConnect PLUS')).toBeInTheDocument();
+    await expect(canvas.queryByText('MSD Veterinary Manual')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Laika')).not.toBeInTheDocument();
+    // Available is the exact complement of Connected over the two real providers.
+    await expect(canvas.getByRole('button', { name: 'Enable' })).toBeInTheDocument();
+    await expect(canvas.queryByRole('link', { name: 'Open manuals' })).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The mirror of Connected: providers that exist but are switched off. Over the two real ' +
+          'providers the two tabs partition the set, so a card that appears in both, or in ' +
+          'neither, is a bug.',
+      },
+    },
+  },
+};
+
+export const ComingSoonFilter: Story = {
+  name: 'Filter: Coming soon',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(tab(canvasElement, 'Coming soon'));
+
+    await waitFor(() => expect(cards(canvasElement)).toHaveLength(4));
+    await expect(canvas.getAllByText('Coming soon')).toHaveLength(5); // 4 pills + the tab label
+    await expect(canvas.getAllByText('Notify me')).toHaveLength(4);
+    await expect(canvas.queryByText('IDEXX VetConnect PLUS')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('MSD Veterinary Manual')).not.toBeInTheDocument();
+
+    /* "Notify me" is a `<span>`, not a control - the placeholder cards have no
+       action wired up yet. Asserting the tag keeps a future change from turning
+       them into buttons that do nothing. */
+    for (const label of canvas.getAllByText('Notify me')) {
+      await expect(label.tagName).toBe('SPAN');
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The four placeholder cards. Their CTA is a styled `<span>` rather than a button, so ' +
+          'nothing here is focusable - the only interactive elements left on the page are the ' +
+          'filter tabs and the title tooltip.',
+      },
+    },
+  },
+};
+
+export const LoadError: Story = {
+  name: 'Store error banner',
+  beforeEach: () => {
+    seed({ error: 'Unable to load integrations at the moment.' });
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const alert = await canvas.findByRole('alert');
+    await expect(alert).toHaveTextContent('Unable to load integrations at the moment.');
+
+    /* The banner is ADDITIVE - it sits between the header and the card grid and
+       replaces nothing. A story that only asserted the alert appeared would pass
+       just as happily if the error had blanked the catalog. */
+    await expect(cards(canvasElement)).toHaveLength(6);
+    await expect(canvas.getByText('IDEXX VetConnect PLUS')).toBeInTheDocument();
+    expect(await canvas.findByText('1 active')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The store-level load failure, copied into the local banner by the render-phase sync ' +
+          'in `useIntegrationsPage`. The same line is what a failed `listIdexxIvlsDevices` ' +
+          'writes, so this is the shape of both - only the message differs ("Unable to load ' +
+          'linked IDEXX devices."). That second producer needs the lab route to reject, which ' +
+          'this Storybook has no way to force, so it is not drawn separately.',
+      },
+    },
+  },
+};
+
+export const EmptyConnected: Story = {
+  name: 'Connected, with nothing connected',
+  beforeEach: () => {
+    seed({ integrations: [] });
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(tab(canvasElement, 'Connected'));
+
+    const empty = await canvas.findByText('No connected integrations yet.');
+    /* An `<output>`, which is what makes this a live region rather than a
+       paragraph a screen reader never revisits. The tag is the behaviour here, so
+       it is asserted rather than left in the prose - swapping it for a `<div>`
+       would look identical and announce nothing. The `status` role is IMPLICIT,
+       carried by the element rather than by an attribute, so it has to be reached
+       with a role query - `toHaveAttribute('role', 'status')` fails against
+       perfectly correct markup. */
+    await expect(empty.tagName).toBe('OUTPUT');
+    await expect(canvas.getByRole('status')).toBe(empty);
+    await expect(cards(canvasElement)).toHaveLength(0);
+    // Nothing enabled anywhere, so the header pill drops to zero as well.
+    await expect(canvas.getByText('0 active')).toBeInTheDocument();
+    await expect(
+      canvas.queryByText('No available integrations right now.')
+    ).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'With no integration rows at all, Connected has nothing to show. The empty line is an ' +
+          '`<output>`, so it is announced as a live region rather than as static text, and it is ' +
+          'derived from card visibility - it can never render beside a card.',
+      },
+    },
+  },
+};
+
+export const PhoneLayout: Story = {
+  name: 'Phone: header stack at 375px',
+  // Global, not `parameters.viewport.defaultViewport` - that key was removed in
+  // Storybook 10 and leaves the story at full panel width without a warning.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(cards(canvasElement)).toHaveLength(6);
+
+    /* One column at 375px: the grid is grid-cols-1 until md. Both halves matter -
+       one track and six children means six full-width rows, whereas one track and
+       (say) three children would be a filter bug wearing a layout bug's clothes. */
+    const grid = canvas.getByText('IDEXX VetConnect PLUS').closest('.grid') as HTMLElement;
+    const tracks = getComputedStyle(grid).gridTemplateColumns.trim().split(/\s+/);
+    await expect(tracks).toHaveLength(1);
+    await expect(grid.children).toHaveLength(6);
+    // The single track fills the column rather than collapsing to content width.
+    await expect(Math.round(parseFloat(tracks[0]))).toBe(
+      Math.round(grid.getBoundingClientRect().width)
+    );
+
+    /* The four tabs sit in a `flex-wrap` fieldset rather than a scroller, so the
+       thing to check at 375px is that none of them is pushed past the canvas
+       edge. Asserting "they wrapped onto two lines" would be a bet on the exact
+       pill widths; asserting "nothing is clipped" is the property the layout
+       actually owes. */
+    const tabs = ['All', 'Connected', 'Available', 'Coming soon'].map((label) =>
+      tab(canvasElement, label)
+    );
+    const fieldset = tabs[0].closest('fieldset') as HTMLElement;
+    await expect(getComputedStyle(fieldset).flexWrap).toBe('wrap');
+    const canvasRight = canvasElement.getBoundingClientRect().right;
+    for (const node of tabs) {
+      await expect(node.getBoundingClientRect().right).toBeLessThanOrEqual(canvasRight);
+    }
+    // And the page itself never scrolls sideways.
+    await expect(document.documentElement.scrollWidth).toBeLessThanOrEqual(
+      document.documentElement.clientWidth
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'At 375px the card grid drops to one column and the filter row re-flows under the ' +
+          'title. Worth pinning because the tabs share an `ml-auto` flex group with the ' +
+          'active-count pill, which is the arrangement most likely to push a pill off a narrow ' +
+          'screen.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
@@ -1286,7 +1286,13 @@ const IntegrationCards = ({
   );
 };
 
-const IntegrationsPage = () => {
+/**
+ * Exported for `Integrations.stories.tsx`. The page itself reads only zustand
+ * (org + integration stores) and fetches nothing unless IDEXX resolves as
+ * enabled, so it mounts from seeded state alone; the default export wraps it in
+ * `ProtectedRoute` + `OrgGuard`, which a story cannot satisfy.
+ */
+export const IntegrationsPage = () => {
   const s = useIntegrationsPage();
   const { showNoConnected, showNoAvailable } = getIntegrationEmptyState(
     s.integrationStatus,

--- a/apps/frontend/src/app/features/integrations/pages/MerckManuals/MerckReaderPortal.stories.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/MerckManuals/MerckReaderPortal.stories.tsx
@@ -1,0 +1,375 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+
+import type { MerckAudience } from '@/app/features/integrations/services/types';
+import { MerckReaderPortal } from './index';
+
+/**
+ * A real msdvetmanual.com deep link, because `isAllowedMerckUrl` is the gate the
+ * page applies before it ever opens this overlay - a placeholder URL would draw a
+ * reader the product could never reach. The framed document itself is MSD's, so
+ * it will not render in an offline CI run; that is precisely the condition the
+ * blocked story below covers.
+ */
+const READER_URL =
+  'https://www.msdvetmanual.com/digestive-system/diseases-of-the-stomach-and-intestines-in-large-animals?media=hybrid';
+const READER_TITLE = 'Diseases of the stomach and intestines in large animals';
+const FOOTER_NOTICE = "Content © MSD Veterinary Manual · displayed under your clinic's integration";
+
+type PortalProps = React.ComponentProps<typeof MerckReaderPortal>;
+
+const baseArgs = {
+  readerOpen: true,
+  readerUrl: READER_URL,
+  readerTitle: READER_TITLE,
+  readerLoading: false,
+  readerBlocked: false,
+  audience: 'PROV' as MerckAudience,
+  copied: null,
+  onCopyUrl: fn(),
+  setReaderOpen: fn(),
+  setReaderLoading: fn(),
+  setReaderBlocked: fn(),
+} satisfies PortalProps;
+
+/** The overlay's own root, portalled to `document.body`. */
+const overlay = (): HTMLElement =>
+  document.querySelector('[data-merck-reader-overlay="true"]') as HTMLElement;
+
+/**
+ * Held as a constant so the close story can assert it by exact string. A loose
+ * regex would work here too, but the preview decorator drops an sr-only <h1>
+ * reading "<title> - <story name>" into the same canvas, and exact strings are
+ * the habit that keeps a text query from matching it instead.
+ */
+const BEHIND_COPY =
+  'Search results behind the reader. The overlay is fixed inset-0 z-10000, so nothing here is ' +
+  'reachable while it is open.';
+
+/**
+ * A page behind the overlay, so the `--sh55` scrim and the `backdrop-blur-sm`
+ * have something to sit over. The reader is `fixed inset-0`, so this is
+ * decoration for the eye rather than layout the component depends on.
+ */
+const Behind = () => (
+  <div className="min-h-[560px] bg-[var(--screen)] p-6">
+    <p className="text-[13px] text-[var(--ink-muted)]">{BEHIND_COPY}</p>
+  </div>
+);
+
+/** Real state for the close button, so one story can exercise the dismissal. */
+const ClosableReader = (props: PortalProps) => {
+  const [open, setOpen] = useState(true);
+  return (
+    <>
+      <Behind />
+      <MerckReaderPortal {...props} readerOpen={open} setReaderOpen={setOpen} />
+    </>
+  );
+};
+
+const meta = {
+  title: 'Integrations/MerckReaderPortal',
+  component: MerckReaderPortal,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The full-screen MSD reader. It is the surface the whole MSD Manuals integration exists ' +
+          'to deliver, and it had never been drawn - it only appears after a live search returns ' +
+          'a result and the clinician opens one, from a page behind `ProtectedRoute` + ' +
+          '`OrgGuard`.\n\n' +
+          'It has **three internal states over one shell**, and only one of them is the manual. ' +
+          '`readerBlocked` swaps the whole body for `MerckReaderFallback` and the iframe is not ' +
+          'mounted at all; `readerLoading` keeps the iframe mounted and lays the branded loader ' +
+          'over it; neither flag leaves the manual visible. The chrome - title, audience pill, ' +
+          'copy-URL, open-in-new-tab, close, and the copyright footer - is identical in all ' +
+          'three, which is what makes the differences easy to miss in review.\n\n' +
+          'It `createPortal`s to `document.body`, so nothing it renders is inside `canvasElement`. ' +
+          'Every query below goes through `within(document.body)` or the ' +
+          '`[data-merck-reader-overlay]` root; a canvas-scoped query finds nothing and, worse, ' +
+          'an absence check written that way passes whether the overlay is open or not.\n\n' +
+          'The iframe carries `sandbox="allow-scripts allow-popups allow-forms allow-same-origin"`. ' +
+          '`allow-same-origin` looks like the one to drop and is the one that must stay: MSD reads ' +
+          '`document.cookie` on boot and throws in an opaque origin, which strands the frame on ' +
+          "MSD's own loader forever. The attribute is asserted verbatim below so a well-meant " +
+          'tightening shows up as a failed story rather than as a hung reader.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: baseArgs,
+  render: (args) => (
+    <>
+      <Behind />
+      <MerckReaderPortal {...args} />
+    </>
+  ),
+} satisfies Meta<typeof MerckReaderPortal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Loaded: Story = {
+  name: 'Loaded manual (iframe)',
+  play: async () => {
+    const body = within(document.body);
+    const root = overlay();
+    await expect(root).not.toBeNull();
+
+    // Chrome: title, audience pill, and the three header controls.
+    await expect(within(root).getByText(READER_TITLE)).toBeInTheDocument();
+    await expect(within(root).getByText('PROFESSIONAL')).toBeInTheDocument();
+    await expect(body.getByRole('button', { name: 'Copy manual URL' })).toBeInTheDocument();
+    await expect(body.getByRole('link', { name: 'Open in new tab' })).toHaveAttribute(
+      'href',
+      READER_URL
+    );
+    await expect(body.getByRole('button', { name: 'Close Merck reader' })).toBeInTheDocument();
+    await expect(within(root).getByText(FOOTER_NOTICE)).toBeInTheDocument();
+
+    /* The frame itself. Its CONTENT is MSD's and is not ours to assert, so the
+       attributes are what this story protects - the src the page validated, the
+       referrer policy, and the sandbox string whose `allow-same-origin` is
+       load-bearing. */
+    const frame = root.querySelector('iframe') as HTMLIFrameElement;
+    await expect(frame).not.toBeNull();
+    await expect(frame).toHaveAttribute('src', READER_URL);
+    await expect(frame).toHaveAttribute('title', READER_TITLE);
+    await expect(frame).toHaveAttribute('referrerpolicy', 'strict-origin');
+    await expect(frame.getAttribute('sandbox')).toBe(
+      'allow-scripts allow-popups allow-forms allow-same-origin'
+    );
+
+    // Neither of the two covering states is up.
+    await expect(body.queryByTestId('merck-reader-loader')).not.toBeInTheDocument();
+    await expect(body.queryByText('This manual didn’t load')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting reader. The panel is `size-full max-h-[95vh] max-w-7xl` over a `--sh55` ' +
+          'scrim with a 4px blur, and the frame fills everything between the header band and the ' +
+          'copyright footer.',
+      },
+    },
+  },
+};
+
+export const Loading: Story = {
+  name: 'Fetching from MSD',
+  args: { readerLoading: true },
+  play: async () => {
+    const body = within(document.body);
+    const root = overlay();
+
+    const loader = body.getByTestId('merck-reader-loader');
+    await expect(loader).toBeInTheDocument();
+    await expect(loader).toHaveAttribute('aria-label', 'Loading Manual');
+    // Curly quotes around the title, matching the component - a straight-quote
+    // string here would miss and the story would report the loader absent.
+    await expect(body.getByText(`Fetching “${READER_TITLE}” from MSD…`)).toBeInTheDocument();
+
+    /* The iframe is STILL MOUNTED underneath. That is the whole design of this
+       state - the loader is an overlay, not a replacement - and it is why
+       `onLoad` can fire and clear the flag. A story that only checked the loader
+       had appeared would look the same if the frame had been unmounted. */
+    const frame = root.querySelector('iframe') as HTMLIFrameElement;
+    await expect(frame).not.toBeNull();
+    await expect(frame).toHaveAttribute('src', READER_URL);
+
+    /* And it is COVERED, which is the property that makes this state readable.
+       Taken off the frame's own previous sibling rather than off a `.absolute`
+       ancestor lookup, so the node under test is the cover the component renders
+       and not whichever wrapper happens to be positioned. Asserting its computed
+       position would only restate the class it was selected by; the assertions
+       that carry information are that it is exactly the frame's size and that it
+       paints an opaque ground, because a transparent or half-height cover leaves
+       MSD's half-drawn page showing through the spinner. */
+    const cover = frame.previousElementSibling as HTMLElement;
+    await expect(cover.contains(loader)).toBe(true);
+    const coverRect = cover.getBoundingClientRect();
+    const frameRect = frame.getBoundingClientRect();
+    await expect(Math.round(coverRect.width)).toBe(Math.round(frameRect.width));
+    await expect(Math.round(coverRect.height)).toBe(Math.round(frameRect.height));
+    await expect(Math.round(coverRect.top)).toBe(Math.round(frameRect.top));
+    // Poll: the panel carries transitions, so a single synchronous read of a
+    // colour can land on an interpolated value.
+    await waitFor(() => {
+      expect(getComputedStyle(cover).backgroundColor).not.toBe('rgba(0, 0, 0, 0)');
+    });
+    await expect(Number(getComputedStyle(cover).zIndex)).toBeGreaterThan(0);
+
+    // Header chrome stays usable while the manual loads.
+    await expect(body.getByRole('button', { name: 'Copy manual URL' })).toBeInTheDocument();
+    await expect(body.getByRole('button', { name: 'Close Merck reader' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'While the frame is in flight. A 12s timer runs alongside this state and flips it to ' +
+          'the blocked card, because a stalled MSD page fires neither `onLoad` nor `onError` - ' +
+          'so this state is bounded and never the last thing a user sees.',
+      },
+    },
+  },
+};
+
+export const Blocked: Story = {
+  name: 'Blocked / timed out',
+  args: { readerBlocked: true },
+  play: async () => {
+    const body = within(document.body);
+    const root = overlay();
+
+    await expect(body.getByText('This manual didn’t load')).toBeInTheDocument();
+    await expect(
+      body.getByText(
+        `MSD Veterinary Manual took too long to respond. Open “${READER_TITLE}” in a new tab to ` +
+          'read the full content.'
+      )
+    ).toBeInTheDocument();
+
+    /* The iframe is GONE, not hidden. `readerBlocked` picks the fallback instead
+       of the fragment holding the frame, so there is no second request sitting
+       behind this card retrying forever. */
+    await expect(root.querySelector('iframe')).toBeNull();
+
+    /* Two escape hatches to the same URL now: the header link and the fallback's
+       own button. Both must survive, because this card is what a clinician is
+       left with when framing is refused. */
+    const links = body.getAllByRole('link', { name: 'Open in new tab' });
+    await expect(links).toHaveLength(2);
+    for (const link of links) {
+      await expect(link).toHaveAttribute('href', READER_URL);
+      await expect(link).toHaveAttribute('target', '_blank');
+      await expect(link).toHaveAttribute('rel', 'noreferrer');
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'What a refused frame or a 12s stall lands on. MSD sends `X-Frame-Options` on some ' +
+          'pages, so this is not an edge case - it is the ordinary outcome for part of the ' +
+          'catalog, and it is the state most likely to be seen in a CI snapshot.',
+      },
+    },
+  },
+};
+
+export const PetParentAudience: Story = {
+  name: 'Pet-parent audience pill',
+  args: { audience: 'PAT' },
+  play: async () => {
+    const root = overlay();
+    /* The audience is carried by ONE pill and nothing else in the shell changes,
+       so the label is the entire difference between the two audiences - and the
+       professional copy behind it is what must not be handed to a pet parent. */
+    const pill = within(root).getByText('PET PARENT');
+    await expect(pill).toBeVisible();
+    await expect(within(root).queryByText('PROFESSIONAL')).not.toBeInTheDocument();
+
+    /* "Nothing else changes" is the claim, so it gets asserted rather than
+       described: the pill is the title row's last child, and the URL the frame
+       is pointed at is the same one `PROV` would have been given. The audience
+       chooses the wording MSD returns, not the document - so a build that swapped
+       the frame along with the pill would be the bug this catches. */
+    const titleRow = pill.parentElement as HTMLElement;
+    await expect(titleRow.lastElementChild).toBe(pill);
+    await expect(within(titleRow).getByText(READER_TITLE)).toBeVisible();
+    await expect(root.querySelector('iframe')).toHaveAttribute('src', READER_URL);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`PAT` swaps the pill to "PET PARENT" on `--blue-soft`; `PROV` reads "PROFESSIONAL" on ' +
+          'the upcoming-status tokens. Same shell, same frame, one word of difference - which is ' +
+          'why it is worth a story of its own.',
+      },
+    },
+  },
+};
+
+export const CopiedState: Story = {
+  name: 'Copy URL confirmed',
+  args: { copied: READER_URL },
+  play: async () => {
+    const body = within(document.body);
+    const root = overlay();
+    // The label swaps IN PLACE rather than showing a toast, so "Copy manual URL"
+    // must be gone, not merely joined by "Copied!" - and the confirmed button has
+    // to still be the same node in the same header slot.
+    const copied = body.getByRole('button', { name: 'Copied!' });
+    await expect(copied).toBeVisible();
+    await expect(body.queryByRole('button', { name: 'Copy manual URL' })).not.toBeInTheDocument();
+
+    /* The action row is unchanged around it: copy, open-in-new-tab, close, in that
+       order. A swap that rebuilt the row instead of the label would still satisfy
+       the two checks above. */
+    const actions = copied.parentElement as HTMLElement;
+    await expect(actions.children).toHaveLength(3);
+    await expect(actions.firstElementChild).toBe(copied);
+    await expect(within(actions).getByRole('link', { name: 'Open in new tab' })).toHaveAttribute(
+      'href',
+      READER_URL
+    );
+    await expect(within(actions).getByRole('button', { name: 'Close Merck reader' })).toBeVisible();
+    // The manual itself is untouched - copying a URL does not reload the frame.
+    await expect(root.querySelector('iframe')).toHaveAttribute('src', READER_URL);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The confirmation is keyed on the URL, not on a boolean, so copying a different manual ' +
+          "in the same session does not light up this one's button.",
+      },
+    },
+  },
+};
+
+export const Closes: Story = {
+  name: 'Closing removes the overlay',
+  render: (args) => <ClosableReader {...args} />,
+  play: async () => {
+    const body = within(document.body);
+    await expect(overlay()).not.toBeNull();
+
+    await userEvent.click(body.getByRole('button', { name: 'Close Merck reader' }));
+
+    /* `readerOpen` false returns `null` BEFORE the portal call, so the overlay is
+       genuinely unmounted rather than left in the DOM without a flag the way a
+       `<dialog>` would be. Asserting on the overlay root rather than on its text
+       is what makes the difference visible. */
+    await waitFor(() => expect(overlay()).toBeNull());
+    await expect(body.queryByText(READER_TITLE)).not.toBeInTheDocument();
+
+    /* The whole subtree goes with it, frame included - an overlay hidden rather
+       than unmounted would leave MSD's page loading in the background, still
+       running its scripts, for the rest of the session. The chrome is checked
+       separately from the root because `readerOpen` guards the `return null`,
+       while a future scrim-fade would be the change that leaves one behind. */
+    await expect(
+      body.queryByRole('button', { name: 'Close Merck reader' })
+    ).not.toBeInTheDocument();
+    await expect(body.queryByRole('link', { name: 'Open in new tab' })).not.toBeInTheDocument();
+    // And the page underneath is back, not left behind a stranded scrim.
+    await expect(body.getByText(BEHIND_COPY)).toBeVisible();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The close button is the only dismissal the reader offers - there is no scrim click and ' +
+          'no Escape handler, which is deliberate for a frame the user may have scrolled deep ' +
+          'into.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/integrations/pages/MerckManuals/index.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/MerckManuals/index.tsx
@@ -576,7 +576,14 @@ const MerckReaderFallback = ({
   </div>
 );
 
-const MerckReaderPortal = ({
+/**
+ * Exported for `MerckReaderPortal.stories.tsx`. The overlay is presentation only -
+ * every piece of state arrives as a prop - but the page that owns those props
+ * sits behind `ProtectedRoute` + `OrgGuard` and only reaches this surface after a
+ * live MSD search, so the three reader states are unreachable from the page in a
+ * story. Rendering it directly is the only way to draw them.
+ */
+export const MerckReaderPortal = ({
   readerOpen,
   readerUrl,
   readerTitle,

--- a/apps/frontend/src/app/features/inventory/components/AddInventory/ImageUploadField.stories.tsx
+++ b/apps/frontend/src/app/features/inventory/components/AddInventory/ImageUploadField.stories.tsx
@@ -1,0 +1,273 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import { MEDIA_SOURCES } from '@/app/constants/mediaSources';
+import ImageUploadField from './ImageUploadField';
+
+const ORG_ID = 'org-storybook-inventory';
+
+/** A real object on the shared asset CDN, so the filled story shows actual pixels. */
+const CDN_IMAGE = MEDIA_SOURCES.avatars.dog;
+
+/** What the field actually stores once an upload finishes: the bare S3 key. */
+const STORED_KEY = 'inventory/items/meloxicam-15mgml.jpg';
+
+const ORG_CDN_PREFIX = 'https://d2kyjiikho62xx.cloudfront.net/';
+
+/**
+ * `value` is owned by the form, so the harness holds it - that is what lets the
+ * Remove control actually clear the field instead of firing into a spy.
+ */
+const Field = ({
+  initialValue = '',
+  organisationId,
+}: {
+  initialValue?: string;
+  organisationId?: string;
+}) => {
+  const [value, setValue] = useState(initialValue);
+  return (
+    <div className="w-[420px] max-w-full bg-[var(--screen)] p-4">
+      <ImageUploadField
+        label="Product image (optional)"
+        value={value}
+        organisationId={organisationId}
+        onChange={setValue}
+      />
+    </div>
+  );
+};
+
+const fileInput = (canvasElement: HTMLElement): HTMLInputElement =>
+  canvasElement.querySelector('input[type="file"]') as HTMLInputElement;
+
+const pngFile = () => new File(['not-a-real-png'], 'meloxicam.png', { type: 'image/png' });
+
+const meta = {
+  title: 'Inventory/ImageUploadField',
+  component: Field,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'The product-image field in the Add product drawer. Only its empty state had ever ' +
+          'been reachable: everything after a file is chosen lives behind internal state with ' +
+          'no prop behind it.\n\n' +
+          'The field has four shapes. **Empty** is a 140px hairline-bordered drop button with ' +
+          'a cloud glyph. **Filled** is a 140px `object-cover` frame with a round remove ' +
+          'control at the top right. **Uploading** is that same frame over a local `blob:` ' +
+          'preview with a `--neutral-0/60` scrim and the remove control withdrawn, so nothing ' +
+          'can be removed mid-flight. **Error** adds a `text-caption-1` (14px) ' +
+          '`--text-error` line under the frame - the same size as the label above it, and two ' +
+          'points larger than the 12px every other field error in the drawer uses, so it is ' +
+          'worth deciding which of the two is the intended house size.\n\n' +
+          'Two details are only visible with the stories side by side. The value the field ' +
+          'holds is an **S3 key**, not a URL - `getSafeOrgImageUrl` expands it onto the org ' +
+          'CDN on every render, and rejects anything that is neither a key nor an https URL - ' +
+          'so a story that passes a ready-made URL is testing a different code path from the ' +
+          'one the form uses. And the placeholder carries its own `Uploading…` label that can ' +
+          'never render, because a blob preview is always set before `isUploading` is, which ' +
+          'always makes `displayUrl` non-empty; it is annotated as unreachable in the source ' +
+          'rather than removed.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: { initialValue: '', organisationId: ORG_ID },
+} satisfies Meta<typeof Field>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Empty: Story = {
+  name: 'Empty',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const placeholder = canvas.getByText('Upload image').closest('button') as HTMLElement;
+    await expect(placeholder).toBeEnabled();
+    await expect(within(placeholder).getByText('PNG, JPG, WebP · Max 2 MB')).toBeInTheDocument();
+    // The 140px drop target the filled frame has to match, on the border box.
+    await expect(placeholder.getBoundingClientRect().height).toBeGreaterThanOrEqual(140);
+
+    await expect(canvas.queryByRole('img')).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Remove image' })).not.toBeInTheDocument();
+
+    /* The copy promises PNG/JPG/WebP and 2 MB. Only the first half is enforced, and
+       only by the picker: `accept` is asserted here because it is the whole of the
+       client-side guard, and there is no size check anywhere in the component - the
+       "Max 2 MB" half of that line is a claim the field does not keep. */
+    const input = fileInput(canvasElement);
+    await expect(input.accept).toBe('image/png,image/jpeg,image/webp');
+    await expect(input).toHaveAttribute('aria-label', 'Product image (optional)');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The only state anything could previously draw. The native file input is hidden and ' +
+          'the visible control is a button that clicks it by id, so the picker opens from a ' +
+          'styled 140px target rather than from a browser-chrome "Choose file".',
+      },
+    },
+  },
+};
+
+export const Filled: Story = {
+  name: 'Filled',
+  args: { initialValue: CDN_IMAGE },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const image = canvas.getByRole('img', { name: 'Product image' });
+    await expect(decodeURIComponent(image.getAttribute('src') ?? '')).toContain(CDN_IMAGE);
+    // The frame crops rather than letterboxes: 140px tall, full width, object-cover.
+    await expect(image.getBoundingClientRect().height).toBeCloseTo(140, 0);
+    await expect(getComputedStyle(image).objectFit).toBe('cover');
+
+    // The remove control only exists when nothing is in flight.
+    const remove = canvas.getByRole('button', { name: 'Remove image' });
+    await expect(canvas.queryByText('Uploading…')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Upload image')).not.toBeInTheDocument();
+
+    await userEvent.click(remove);
+
+    /* Removing calls `onChange('')`, and the harness owns `value`, so this asserts
+       the field really returned to empty rather than that a spy was called. */
+    await waitFor(() => expect(canvas.getByText('Upload image')).toBeInTheDocument());
+    await expect(canvas.queryByRole('img')).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Remove image' })).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'An image already on the product. The remove control is a 28px circle on a ' +
+          '`--neutral-0/90` disc, floated over the top-right of the frame rather than placed ' +
+          'below it, so it overlaps whatever the picture happens to be - worth checking ' +
+          'against a light-topped photo.',
+      },
+    },
+  },
+};
+
+export const FilledFromStoredKey: Story = {
+  name: 'Filled from a stored S3 key',
+  args: { initialValue: STORED_KEY },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* The contract that matters: what the form stores is a key, and the field turns
+       it into an org-CDN URL on every render. Asserting the expansion is the point of
+       this story - the object itself is a placeholder path, so the frame draws empty. */
+    const image = canvas.getByRole('img', { name: 'Product image' });
+    await expect(decodeURIComponent(image.getAttribute('src') ?? '')).toContain(
+      `${ORG_CDN_PREFIX}${STORED_KEY}`
+    );
+    await expect(canvas.getByRole('button', { name: 'Remove image' })).toBeInTheDocument();
+    await expect(canvas.queryByText('Upload image')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'What a saved product actually renders. `onChange` is called with the S3 key the ' +
+          'presign step returns, so this - not a ready-made https URL - is the value the field ' +
+          "holds for the rest of the form's life.\n\n" +
+          'The path here points at no real object, so the frame is an empty 140px box with a ' +
+          'remove control on it. That is also exactly what a live product with a deleted or ' +
+          'mistyped key looks like: there is no broken-image or retry affordance.',
+      },
+    },
+  },
+};
+
+export const OrganisationNotLoaded: Story = {
+  name: 'Error: organisation not loaded',
+  args: { organisationId: undefined },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.upload(fileInput(canvasElement), pngFile());
+
+    // The guard runs before any preview is made, so the frame never appears: the
+    // placeholder stays and an error line is added under it.
+    // The query is awaited on its own line; double-awaiting a findBy inside an
+    // assertion fails the PR gate.
+    const message = await canvas.findByText('Organisation not loaded. Please try again.');
+    await expect(message).toBeVisible();
+    /* The size is the point of the error line, not its presence. It is
+       `text-caption-1`, which is 14px - the same size as this field's own label, and
+       two points larger than the `text-caption-2` (12px) every other field error in
+       this drawer uses. */
+    await expect(getComputedStyle(message).fontSize).toBe('14px');
+
+    // The placeholder is untouched: no frame, no preview, no in-flight copy.
+    await expect(canvas.getByText('Upload image')).toBeInTheDocument();
+    await expect(canvas.queryByRole('img')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Uploading…')).not.toBeInTheDocument();
+    // The picker was cleared, so a retry starts from an empty input.
+    await expect(fileInput(canvasElement).value).toBe('');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The one failure the field can reach without the network, and a real one: the drawer ' +
+          'renders before the org store settles, so a fast picker click lands here. The error ' +
+          'is a 14px line under a placeholder that looks untouched, and the input has already ' +
+          'been cleared, so the next attempt starts from scratch with no hint that retrying is ' +
+          'what to do.',
+      },
+    },
+  },
+};
+
+export const UploadInFlight: Story = {
+  name: 'Uploading, then failing',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.upload(fileInput(canvasElement), pngFile());
+
+    /* The in-flight frame, asserted synchronously rather than through `findBy`.
+       `handleFileChange` sets the blob preview and `isUploading` BEFORE its first
+       await, and the await is a real XHR - which cannot settle inside the microtask
+       flush `userEvent` performs - so this state is committed and still standing here.
+       A retrying query would be no safer: if the state had already passed, no amount
+       of polling brings it back. */
+    const image = canvas.getByRole('img', { name: 'Product image' });
+    await expect(image.getAttribute('src')?.startsWith('blob:')).toBe(true);
+    await expect(canvas.getByText('Uploading…')).toBeInTheDocument();
+    // Removal is withdrawn mid-flight, so nothing can be cleared while a PUT is out.
+    await expect(canvas.queryByRole('button', { name: 'Remove image' })).not.toBeInTheDocument();
+
+    /* Then it settles. There is no stub for the presigned-URL call in this repo, so
+       the terminal state here is the failure one; the generous timeout is because a
+       real request is being waited on rather than a state machine. */
+    await waitFor(() => expect(canvas.queryByText('Uploading…')).not.toBeInTheDocument(), {
+      timeout: 15000,
+    });
+    await expect(canvas.getByText('Upload failed. Please try again.')).toBeInTheDocument();
+    await expect(canvas.getByText('Upload image')).toBeInTheDocument();
+    await expect(canvas.queryByRole('img')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The whole post-selection sequence in one story, because the two halves cannot be ' +
+          'separated without a request stub - and this repo has no MSW or module-mock wiring.\n\n' +
+          'The in-flight half is the one nothing had drawn: the local `blob:` preview goes up ' +
+          'immediately, so the frame is filled with the real picture before a byte has left, ' +
+          'and the scrim plus the withdrawn remove control are the only thing saying it is not ' +
+          'saved yet. If that upload then fails, the picture is revoked and thrown away and ' +
+          'the field drops back to the empty placeholder with one line of red under it - the ' +
+          'chosen file is gone and has to be picked again. Worth deciding whether a failed ' +
+          'upload should keep the preview and offer a retry.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/inventory/components/AddInventory/index.stories.tsx
+++ b/apps/frontend/src/app/features/inventory/components/AddInventory/index.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { expect, fn, userEvent, within } from 'storybook/test';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 
 import AddInventory from './index';
 
@@ -12,6 +12,70 @@ const chooseOption = async (triggerName: string, optionName: string) => {
   const listbox = document.querySelector('[data-portal-dropdown]');
   await expect(listbox).toBeInTheDocument();
   await userEvent.click(within(listbox as HTMLElement).getByRole('button', { name: optionName }));
+};
+
+const textbox = (name: string) => panel().getByRole('textbox', { name });
+
+const clickButton = async (name: string) => {
+  await userEvent.click(panel().getByRole('button', { name }));
+};
+
+/**
+ * The right-hand chip of a read-only Stock Control field, read off the label's
+ * sibling. Stock's derived numbers are not inputs - they are `placeholder :` text
+ * followed by a pill - so they need a different query from every other field here.
+ */
+const readonlyChip = (label: string): string =>
+  panel().getByText(`${label} :`).nextElementSibling?.textContent ?? '';
+
+/** Basic Details is the only gate between section 1 and section 2. */
+const completeBasicDetails = async () => {
+  await userEvent.type(textbox('Item name'), 'Meloxicam 1.5 mg/ml');
+  await chooseOption('Category', 'Medicine');
+};
+
+/**
+ * Clinical Details validates four fields for a HOSPITAL item that is not marked
+ * `Non-drug`, and the drug path is taken on purpose. Choosing `Non-drug` would clear
+ * the step in a single click, but it also HIDES drug-only fields in three later
+ * sections (`tracking` in Batch, `withdrawlPeriod` in Stock), so every section below
+ * would be drawn a field short of what a medicine actually shows.
+ */
+const completeClinicalDetailsAsDrug = async () => {
+  await userEvent.type(textbox('Generic name'), 'Meloxicam');
+  await chooseOption('Item type', 'Drug');
+  await userEvent.type(textbox('Strength'), '1.5');
+  await chooseOption('Form', 'Injection');
+  await chooseOption('Administration route', 'Injectable');
+};
+
+/* The walks below go through the real Next button rather than seeding state, because
+   the gates ARE the subject: a section reached any other way would be a section no
+   user can reach. */
+const goToBatch = async () => {
+  await completeBasicDetails();
+  await clickButton('Next');
+  await completeClinicalDetailsAsDrug();
+  await clickButton('Next');
+};
+
+const goToStock = async () => {
+  await goToBatch();
+  await userEvent.type(textbox('Batch quantity'), '12');
+  await clickButton('Next');
+};
+
+const goToPricing = async () => {
+  await goToStock();
+  await userEvent.type(textbox('Reorder point'), '5');
+  await clickButton('Next');
+};
+
+const goToVendor = async () => {
+  await goToPricing();
+  await userEvent.type(textbox('Unit cost'), '10');
+  await userEvent.type(textbox('Selling price'), '25');
+  await clickButton('Next');
 };
 
 const meta = {
@@ -32,8 +96,8 @@ const meta = {
           'lived behind a click that no story made.\n\n' +
           'The tab strip is not free navigation. `goToStep` validates the section you are ' +
           'leaving before any forward move, so a tab click can be refused; and the pill for a ' +
-          'section carries a status glyph afterwards - a check for `valid`, an alert triangle for ' +
-          '`error`. The two states are deliberately different **shapes**, not just different ' +
+          'section carries a status glyph afterwards - a check for `valid`, an alert triangle ' +
+          'for `error`. The two states are deliberately different **shapes**, not just different ' +
           'hues, because `--success` and `--danger` differ by 0.0005 in relative luminance and ' +
           'were indistinguishable in greyscale. That pair of glyphs cannot appear until a ' +
           'validation has actually run, so it had never been drawn either.\n\n' +
@@ -77,7 +141,35 @@ export const BasicDetails: Story = {
     await expect(drawer.getByRole('textbox', { name: 'Item name' })).toBeInTheDocument();
     await expect(drawer.getByRole('button', { name: 'Category' })).toBeInTheDocument();
     await expect(drawer.getByRole('switch', { name: 'Visible in Inventory' })).toBeChecked();
-    await expect(drawer.getByRole('button', { name: 'Next' })).toBeInTheDocument();
+    // Four text fields for a hospital item, against the groomer story's two.
+    await expect(drawer.getAllByRole('textbox')).toHaveLength(4);
+
+    /* The single two-up row in this section, and the pair that shares it. */
+    const categoryRow = drawer
+      .getByRole('button', { name: 'Category' })
+      .closest('.grid') as HTMLElement;
+    await expect(
+      getComputedStyle(categoryRow).gridTemplateColumns.trim().split(/\s+/)
+    ).toHaveLength(2);
+    await expect(categoryRow.children).toHaveLength(2);
+    await expect(
+      within(categoryRow).getByRole('button', { name: 'Sub category' })
+    ).toBeInTheDocument();
+
+    /* The footer pair. This is the `grid grid-cols-1 sm:grid-cols-2` nesting the
+       component docs call out: it shipped this branch with a template that resolved
+       to one track, which stacks Clear over Next full-width and still renders both
+       buttons - so a "the Next button is there" check passes on the broken layout.
+       Both the track count and the child count are asserted. */
+    const next = drawer.getByRole('button', { name: 'Next' });
+    const footer = next.closest('.grid') as HTMLElement;
+    /* Polled, not read once: the template resolves after the stylesheet applies, and a
+       synchronous read on the first frame sees `none` and fails intermittently. */
+    await waitFor(() => {
+      expect(getComputedStyle(footer).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(2);
+      expect(footer.children).toHaveLength(2);
+    });
+    await expect(within(footer).getByRole('button', { name: 'Clear' })).toBeInTheDocument();
   },
   parameters: {
     docs: {
@@ -85,7 +177,11 @@ export const BasicDetails: Story = {
         story:
           'The drawer as it opens. Basic Details is the only section any previous render could ' +
           'reach, and it is the only one with a `headerSlot` - the Visible in Inventory switch, ' +
-          'which sits above the fields rather than inside the grid.',
+          'which sits above the fields rather than inside the grid.\n\n' +
+          'The Clear/Next footer is measured here rather than merely found. It is the ' +
+          '`grid grid-cols-1 sm:grid-cols-2` that shipped broken on this branch, and a ' +
+          'collapsed template stacks the two buttons full-width without removing either of ' +
+          'them, so nothing short of reading the computed track list catches it.',
       },
     },
   },
@@ -112,10 +208,10 @@ export const ValidationBlocksTheStep: Story = {
     docs: {
       description: {
         story:
-          'The refusal path. Two inline errors appear at once - one under a text input, one under ' +
-          'a select - and the Basic Details pill grows an alert triangle. Both messages add a ' +
-          'row beneath their control, so the whole form below them shifts down; nothing in a ' +
-          'clean render shows that.',
+          'The refusal path. Two inline errors appear at once - one under a text input, one ' +
+          'under a select - and the Basic Details pill grows an alert triangle. Both messages ' +
+          'add a row beneath their control, so the whole form below them shifts down; nothing ' +
+          'in a clean render shows that.',
       },
     },
   },
@@ -138,8 +234,32 @@ export const ClinicalDetails: Story = {
     await expect(drawer.getByRole('textbox', { name: 'Generic name' })).toBeInTheDocument();
     await expect(drawer.getByRole('button', { name: 'Item type' })).toBeInTheDocument();
     await expect(drawer.queryByRole('textbox', { name: 'Item name' })).not.toBeInTheDocument();
-    // The section left behind is now stamped complete.
-    await expect(drawer.getByRole('img', { name: 'Section complete' })).toBeInTheDocument();
+
+    /* Item type shares a row with Drug schedule, and the row is the two-up grid the
+       design specifies. Track count and child count both, since a template that
+       collapsed to one track would still render both dropdowns, just stacked. */
+    const typeRow = drawer
+      .getByRole('button', { name: 'Item type' })
+      .closest('.grid') as HTMLElement;
+    /* Polled, not read once: the template resolves after the stylesheet applies, and a
+       synchronous read on the first frame sees `none` and fails intermittently. */
+    await waitFor(() => {
+      expect(getComputedStyle(typeRow).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(2);
+      expect(typeRow.children).toHaveLength(2);
+    });
+    await expect(
+      within(typeRow).getByRole('button', { name: 'Drug schedule' })
+    ).toBeInTheDocument();
+
+    // Exactly one section is stamped: the one that was validated on the way out.
+    await waitFor(() =>
+      expect(drawer.getAllByRole('img', { name: 'Section complete' })).toHaveLength(1)
+    );
+    await expect(drawer.queryByRole('img', { name: 'Section has errors' })).not.toBeInTheDocument();
+
+    // Mid-form, so the CTA is still Next rather than the terminal Save.
+    await expect(drawer.getByRole('button', { name: 'Next' })).toBeInTheDocument();
+    await expect(drawer.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
   },
   parameters: {
     docs: {
@@ -161,18 +281,452 @@ export const GroomerFields: Story = {
     const drawer = panel();
     // Same shell, a different field list - the config is keyed by business type.
     await expect(drawer.getByRole('textbox', { name: 'Item name' })).toBeInTheDocument();
-    await expect(drawer.getByRole('button', { name: 'Coat type' })).toBeInTheDocument();
-    await expect(drawer.getByRole('button', { name: 'Fragrance type' })).toBeInTheDocument();
+
+    /* The whole field list, counted. The hospital section is 4 text fields (Item
+       name, Brand, SKU, Description) beside 2 dropdowns; the groomer section
+       inverts that into 2 text fields and 8 dropdowns, which is why the two are
+       different heights rather than the same form with a couple of labels swapped.
+       A per-field existence check would pass on either. */
+    await expect(drawer.getAllByRole('textbox')).toHaveLength(2);
     await expect(drawer.queryByRole('textbox', { name: 'SKU (optional)' })).not.toBeInTheDocument();
+    await expect(
+      drawer.queryByRole('textbox', { name: 'Brand (optional)' })
+    ).not.toBeInTheDocument();
+    for (const name of [
+      'Category',
+      'Sub category',
+      'Department',
+      'Product use',
+      'Coat type',
+      'Fragrance type',
+      'Allergen free',
+      'Companion size',
+    ]) {
+      await expect(drawer.getByRole('button', { name })).toBeInTheDocument();
+    }
+
+    /* Three two-up rows here against the hospital section's one, and a `grid-cols-2`
+       that resolved to a single track would stack all six of those dropdowns
+       vertically while every query above still passed. Both the track count and the
+       child count are asserted, because either alone can be right while the row is
+       wrong. */
+    const coatRow = drawer
+      .getByRole('button', { name: 'Coat type' })
+      .closest('.grid') as HTMLElement;
+    /* Polled, not read once: the template resolves after the stylesheet applies, and a
+       synchronous read on the first frame sees `none` and fails intermittently. */
+    await waitFor(() => {
+      expect(getComputedStyle(coatRow).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(2);
+      expect(coatRow.children).toHaveLength(2);
+    });
+    // The pairing itself, not just that two things share a row.
+    await expect(within(coatRow).getByRole('button', { name: 'Product use' })).toBeInTheDocument();
+
+    // The header switch is business-type-agnostic: it is on the section, not the config.
+    await expect(drawer.getByRole('switch', { name: 'Visible in Inventory' })).toBeChecked();
   },
   parameters: {
     docs: {
       description: {
         story:
-          'The same drawer for a grooming business. Basic Details gains Coat type, Fragrance type ' +
-          'and Product use, and loses the hospital SKU field - so the two-column grid packs ' +
-          'differently and the section is taller. Worth a snapshot beside the hospital story, ' +
-          'since only one of them can be checked by looking at the default.',
+          'The same drawer for a grooming business. Basic Details gains Coat type, Fragrance ' +
+          'type, Allergen free, Product use, Department and Companion size, and loses Brand and ' +
+          'the hospital SKU - so a section that was four text inputs and one two-up row becomes ' +
+          'two text inputs and three two-up rows, and the section is taller. Worth a snapshot ' +
+          'beside the hospital story, since only one of them can be checked by looking at the ' +
+          'default.',
+      },
+    },
+  },
+};
+
+export const BatchAndExpiry: Story = {
+  name: 'Third section (Batch and expiry)',
+  play: async () => {
+    const drawer = panel();
+    await goToBatch();
+
+    await expect(drawer.getByRole('tab', { name: 'Batch and expiry' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+    // The section body is an Accordion, open by default; its toggle carries the title.
+    await expect(drawer.getByRole('button', { name: 'Batch and expiry' })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
+
+    /* One card, and it is already numbered: this section is a repeater even when
+       there is a single batch, which is why the card is bordered and titled while
+       every other section is a bare field stack. */
+    await expect(drawer.getAllByText(/^Batch \d+$/)).toHaveLength(1);
+    await expect(drawer.getByText('Batch 1')).toBeInTheDocument();
+    await expect(drawer.queryByRole('button', { name: 'Remove' })).not.toBeInTheDocument();
+
+    // Its own five fields. `Regulatory tracking ID` is drug-only and is here because
+    // the walk marked the item a Drug; a Non-drug item renders four.
+    await expect(drawer.getByRole('textbox', { name: 'Batch/ Lot number' })).toBeInTheDocument();
+    await expect(drawer.getByRole('textbox', { name: 'Batch quantity' })).toBeInTheDocument();
+    await expect(drawer.getByRole('textbox', { name: 'Barcode' })).toBeInTheDocument();
+    await expect(
+      drawer.getByRole('textbox', { name: 'Regulatory tracking ID' })
+    ).toBeInTheDocument();
+    await expect(
+      drawer.getByRole('button', { name: 'Expiring warning before' })
+    ).toBeInTheDocument();
+    // Dates are buttons that open a calendar, not text inputs.
+    await expect(
+      drawer.getByRole('button', { name: 'Manufacturing date, toggle calendar' })
+    ).toBeInTheDocument();
+    await expect(
+      drawer.getByRole('button', { name: 'Expiry date, toggle calendar' })
+    ).toBeInTheDocument();
+
+    /* The two-up rows. Nothing enforces that a `grid-cols-2` and its children agree,
+       and a template that resolved to one track would stack the pair vertically -
+       still rendering, still passing any "the field is there" check, and looking
+       nothing like the design. */
+    const firstRow = drawer
+      .getByRole('textbox', { name: 'Batch/ Lot number' })
+      .closest('.grid') as HTMLElement;
+    /* Polled, not read once: the template resolves after the stylesheet applies, and a
+       synchronous read on the first frame sees `none` and fails intermittently. */
+    await waitFor(() => {
+      expect(getComputedStyle(firstRow).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(2);
+      expect(firstRow.children).toHaveLength(2);
+    });
+
+    // Mid-form: still Next, with the two sections behind it stamped complete.
+    await expect(drawer.getByRole('button', { name: 'Next' })).toBeInTheDocument();
+    await waitFor(() =>
+      expect(drawer.getAllByRole('img', { name: 'Section complete' })).toHaveLength(2)
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Section three, reached the way a user reaches it: Basic Details satisfied, then ' +
+          'Clinical Details satisfied as a medicine. Both gates matter to what is on screen ' +
+          'here - marking the item `Non-drug` back on section two removes the Regulatory ' +
+          'tracking ID field from this card entirely, so the same section has two shapes.',
+      },
+    },
+  },
+};
+
+export const BatchRepeater: Story = {
+  name: 'Adding and removing a batch',
+  play: async () => {
+    const drawer = panel();
+    await goToBatch();
+
+    await userEvent.type(drawer.getByRole('textbox', { name: 'Batch quantity' }), '12');
+    await clickButton('Add another batch');
+
+    // A second card with its own copy of every field, and a Remove on BOTH - that
+    // control does not exist while there is only one batch.
+    await waitFor(() => expect(drawer.getAllByText(/^Batch \d+$/)).toHaveLength(2));
+    await expect(drawer.getByText('Batch 2')).toBeInTheDocument();
+    await expect(drawer.getAllByRole('textbox', { name: 'Barcode' })).toHaveLength(2);
+    await expect(drawer.getAllByRole('button', { name: 'Remove' })).toHaveLength(2);
+
+    const quantities = drawer.getAllByRole('textbox', { name: 'Batch quantity' });
+    await expect(quantities[0]).toHaveValue('12');
+    await expect(quantities[1]).toHaveValue('');
+    await userEvent.type(quantities[1], '8');
+
+    /* The repeater is not a display list: every batch edit recomputes the Stock
+       Control totals through `calculateBatchTotals`, so on-hand is the SUM of the
+       cards and is not editable anywhere. Asserting it from the next section is the
+       only way to see that wiring at all. */
+    await clickButton('Next');
+    await expect(readonlyChip('On hand stock')).toBe('20');
+    await expect(readonlyChip('Available stock (dispensable)')).toBe('20');
+
+    /* Backwards through the strip is ungated - `goToStep` only validates on a forward
+       move - so the batches can be edited again without satisfying Stock Control.
+       Matched loosely: leaving the section stamped it complete, so its pill now
+       announces "Batch and expiry Section complete" rather than its bare name. */
+    await userEvent.click(drawer.getByRole('tab', { name: /^Batch and expiry/ }));
+    await waitFor(() => expect(drawer.getAllByText(/^Batch \d+$/)).toHaveLength(2));
+
+    /* Removing the SECOND card must leave the FIRST card's value behind. Removal is
+       by index, and an off-by-one would keep the wrong batch while the count still
+       looked right - which is exactly the kind of bug a count-only assertion misses. */
+    await userEvent.click(drawer.getAllByRole('button', { name: 'Remove' })[1]);
+    await waitFor(() => expect(drawer.getAllByText(/^Batch \d+$/)).toHaveLength(1));
+    await expect(drawer.getByRole('textbox', { name: 'Batch quantity' })).toHaveValue('12');
+    await expect(drawer.queryByRole('button', { name: 'Remove' })).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The `onAddBatch` repeater. A product arrives in lots with different expiry dates, ' +
+          'so Batch and expiry is the one section that repeats - a full-width "Add another ' +
+          'batch" secondary button under a stack of bordered cards.\n\n' +
+          'Two things are worth watching here. The card title is derived from the array index ' +
+          'rather than from any identity, so removing a middle batch renumbers everything ' +
+          'below it. And on-hand stock is a computed sum of the cards, which means the number ' +
+          'a reader sees in Stock Control can only be changed from this section.',
+      },
+    },
+  },
+};
+
+export const StockControl: Story = {
+  name: 'Fourth section (Stock Control)',
+  play: async () => {
+    const drawer = panel();
+    await goToStock();
+
+    await expect(drawer.getByRole('tab', { name: 'Stock Control' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+
+    // Editable fields.
+    await expect(
+      drawer.getByRole('textbox', { name: 'Allocated stock (optional)' })
+    ).toBeInTheDocument();
+    await expect(drawer.getByRole('textbox', { name: 'Max stock' })).toBeInTheDocument();
+    await expect(drawer.getByRole('textbox', { name: 'Reorder point' })).toBeInTheDocument();
+    await expect(
+      drawer.getByRole('textbox', { name: 'Reorder quantity (optional)' })
+    ).toBeInTheDocument();
+    await expect(drawer.getByRole('button', { name: 'ABC Class' })).toBeInTheDocument();
+    // Drug-only, and hospital-only respectively.
+    await expect(
+      drawer.getByRole('button', { name: 'Withdrawal period (optional)' })
+    ).toBeInTheDocument();
+    await expect(drawer.getByRole('button', { name: 'Stock unit type' })).toBeInTheDocument();
+    await expect(drawer.getByRole('textbox', { name: 'Unit qnt' })).toBeInTheDocument();
+
+    /* The two derived fields, carried in from the single batch quantity typed on the
+       way here. They are pills, not inputs - there is no way to type an on-hand
+       figure into this section, which is the design decision this story records. */
+    await expect(readonlyChip('On hand stock')).toBe('12');
+    await expect(readonlyChip('Available stock (dispensable)')).toBe('12');
+    await expect(drawer.queryByRole('textbox', { name: 'On hand stock' })).not.toBeInTheDocument();
+
+    /* `stockLocationOptions` replaces the built-in nine-entry list entirely when the
+       caller passes one, which is how the drawer picks up a clinic's real rooms. The
+       override is asserted by using it, so a silently-ignored prop fails here. */
+    /* The dropdown is opened and its option list asserted, because that is what the
+       `stockLocationOptions` override is for: three entries, not the built-in nine.
+
+       What is NOT asserted here is the trigger's label after choosing. The trigger
+       carries the value in both its `aria-label` ("Stock location: <value>") and its
+       text, but neither could be shown to update from inside this harness - the query
+       finds no updated name after the click, and repeated probing did not establish
+       whether the drawer re-parents the trigger or the selection simply does not reach
+       it. Asserting a value I could not verify would be worse than admitting the gap,
+       so the story stops at the option list and this comment records what is missing.
+       Worth returning to: if the selection genuinely does not stick, that is a defect. */
+    await userEvent.click(drawer.getByRole('button', { name: 'Stock location' }));
+    /* Waited for, not read once. The panel is portalled, so it appears a frame after the
+       click - a synchronous read gets `null` and `within(null)` throws a confusing
+       "expected container to be an Element" instead of a useful failure. */
+    await waitFor(() => expect(document.querySelector('[data-portal-dropdown]')).not.toBeNull());
+    const listbox = document.querySelector('[data-portal-dropdown]') as HTMLElement;
+    await expect(within(listbox).getAllByRole('button')).toHaveLength(3);
+    await expect(
+      within(listbox).getByRole('button', { name: 'Main pharmacy' })
+    ).toBeInTheDocument();
+    await expect(within(listbox).getByRole('button', { name: 'Theatre' })).toBeInTheDocument();
+
+    // Choosing an option at least dismisses the portal, which is observable.
+    await userEvent.click(within(listbox).getByRole('button', { name: 'Theatre' }));
+    await waitFor(() => expect(document.querySelector('[data-portal-dropdown]')).toBeNull());
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Section four. It is the only section that mixes editable fields with read-only ' +
+          'derived ones, and the derived pair sits at the bottom in a two-up row so the ' +
+          'numbers read together.\n\n' +
+          'Reorder point is the single required field here, which is easy to miss on a screen ' +
+          'of nine controls - and it is the one that stops a Save from the last tab.',
+      },
+    },
+  },
+};
+
+export const Pricing: Story = {
+  name: 'Fifth section (Pricing)',
+  play: async () => {
+    const drawer = panel();
+    await goToPricing();
+
+    await expect(drawer.getByRole('tab', { name: 'Pricing' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+    await expect(drawer.getByRole('textbox', { name: 'Unit cost' })).toBeInTheDocument();
+    await expect(drawer.getByRole('textbox', { name: 'Selling price' })).toBeInTheDocument();
+    await expect(drawer.getByRole('textbox', { name: 'Max. discount %' })).toBeInTheDocument();
+    await expect(drawer.getByRole('textbox', { name: 'Tax (%)' })).toBeInTheDocument();
+
+    await userEvent.type(drawer.getByRole('textbox', { name: 'Unit cost' }), '10');
+    await userEvent.type(drawer.getByRole('textbox', { name: 'Selling price' }), '25');
+
+    /* The summary block under the fields is the point of this section, and every
+       number in it is derived: profit from the two prices, margin from profit over
+       selling, and stock value from the batch quantity carried in from section three
+       times the unit cost. Asserting the values rather than the labels is what makes
+       this a check on the arithmetic and the currency formatting, not on the layout. */
+    await waitFor(() =>
+      expect(drawer.getByText('Gross profit per unit :').nextElementSibling).toHaveTextContent(
+        '$15'
+      )
+    );
+    await expect(drawer.getByText('Margin :').nextElementSibling).toHaveTextContent('60%');
+    await expect(drawer.getByText('Total stock value')).toBeInTheDocument();
+    await expect(drawer.getByText('on-hand stock x unit cost')).toBeInTheDocument();
+    // 12 on hand at a unit cost of 10.
+    await expect(drawer.getByText('$120')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Section five, with its summary block filled. Profit and margin are badge pills ' +
+          'inline in a sentence; total stock value is a bordered box with a floating caption, ' +
+          'so the three read as one derived group under four inputs.\n\n' +
+          'They are formatted with `Intl.NumberFormat` and an item currency that the payload ' +
+          'deliberately never sends - the server derives it from the org billing settings - so ' +
+          'the drawer always shows USD regardless of where the clinic is. Worth deciding ' +
+          'whether that is acceptable before this goes in front of a non-US clinic.',
+      },
+    },
+  },
+};
+
+export const VendorAndSave: Story = {
+  name: 'Sixth section: the CTA becomes Save',
+  // A promise that never settles, so the in-flight state is a resting state here
+  // rather than a frame to be raced for.
+  args: { onSubmit: fn(() => new Promise<void>(() => {})) },
+  play: async ({ args }) => {
+    const drawer = panel();
+    await goToVendor();
+
+    await expect(drawer.getByRole('tab', { name: 'Vendor details' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+    await expect(drawer.getByRole('button', { name: 'Vendor type' })).toBeInTheDocument();
+    await expect(drawer.getByRole('textbox', { name: 'Vendor name' })).toBeInTheDocument();
+    // Hospital-only: the other business types drop the licence field.
+    await expect(drawer.getByRole('textbox', { name: 'License number' })).toBeInTheDocument();
+    await expect(drawer.getByRole('button', { name: 'Payment terms' })).toBeInTheDocument();
+
+    // The terminal CTA. Same button, same place, different word - the only signal
+    // that this section commits the whole form rather than advancing.
+    await expect(drawer.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+    await expect(drawer.queryByRole('button', { name: 'Next' })).not.toBeInTheDocument();
+    // Five checks behind it: every section that was left through Next was validated
+    // on the way out. Vendor details has no glyph, because nothing has validated it.
+    await waitFor(() =>
+      expect(drawer.getAllByRole('img', { name: 'Section complete' })).toHaveLength(5)
+    );
+
+    await userEvent.click(drawer.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() =>
+      expect(drawer.getByRole('button', { name: 'Saving...' })).toBeInTheDocument()
+    );
+    await expect(drawer.getByRole('button', { name: 'Saving...' })).toBeDisabled();
+    // Clear is disabled with it, so a half-submitted form cannot be reset underneath
+    // the request.
+    await expect(drawer.getByRole('button', { name: 'Clear' })).toBeDisabled();
+
+    /* One payload carrying all six sections. This is the assertion the drawer exists
+       for: the derived on-hand from Batch, the required Reorder point from Stock and
+       the two prices all arrive together, in the shapes the API expects (strings). */
+    await expect(args.onSubmit).toHaveBeenCalledTimes(1);
+    await expect(args.onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        basicInfo: expect.objectContaining({
+          name: 'Meloxicam 1.5 mg/ml',
+          category: 'Medicine',
+        }),
+        classification: expect.objectContaining({ genericName: 'Meloxicam', itemType: 'Drug' }),
+        stock: expect.objectContaining({ current: '12', reorderLevel: '5' }),
+        pricing: expect.objectContaining({ purchaseCost: '10', selling: '25' }),
+      })
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The end of the walk, and the only place the drawer can be committed. `Saving...` ' +
+          'is held open here by an `onSubmit` that never resolves, so the disabled pair is a ' +
+          'state to look at rather than a frame between two renders.\n\n' +
+          'The label is the only thing that changes: same position, same size, same colour as ' +
+          'Next. Someone tabbing quickly through six sections gets no other warning that this ' +
+          'press is the one that writes.',
+      },
+    },
+  },
+};
+
+export const SaveBouncesBack: Story = {
+  name: 'Save with skipped sections bounces back',
+  play: async ({ args }) => {
+    const drawer = panel();
+    await completeBasicDetails();
+
+    /* The strip is not a guard. `goToStep` validates only the section being LEFT, so
+       one click from a valid Basic Details jumps five sections forward and none of
+       the four in between is ever seen, let alone filled. */
+    await userEvent.click(drawer.getByRole('tab', { name: 'Vendor details' }));
+    await waitFor(() =>
+      expect(drawer.getByRole('tab', { name: 'Vendor details' })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      )
+    );
+    await expect(drawer.getByRole('textbox', { name: 'Vendor name' })).toBeInTheDocument();
+    await expect(drawer.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+
+    await userEvent.click(drawer.getByRole('button', { name: 'Save' }));
+
+    /* `validateAll` walks the sections in order and stops at the first failure, then
+       moves the drawer there - so the reader is thrown back four sections to a form
+       they have never seen, with all four medicine fields flagged at once. */
+    await waitFor(() =>
+      expect(drawer.getByRole('tab', { name: /^Clinical Details/ })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      )
+    );
+    await expect(drawer.getByText('Generic name is required')).toBeInTheDocument();
+    await expect(drawer.getByText('Strength is required')).toBeInTheDocument();
+    await expect(drawer.getByText('Form is required')).toBeInTheDocument();
+    await expect(drawer.getByText('Administration route is required')).toBeInTheDocument();
+    await expect(drawer.getByRole('img', { name: 'Section has errors' })).toBeInTheDocument();
+
+    // Nothing was submitted, and the CTA is a mid-form Next again.
+    await expect(args.onSubmit).not.toHaveBeenCalled();
+    await expect(drawer.getByRole('button', { name: 'Next' })).toBeInTheDocument();
+    await expect(drawer.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The failure mode the tab strip makes reachable. Because a forward jump only ' +
+          'validates the section being left, Save can be pressed with four sections never ' +
+          'opened - and the drawer answers by teleporting backwards with no message ' +
+          'explaining the move.\n\n' +
+          'Stock Control is silently in the same state (Reorder point is required and empty); ' +
+          'it just never gets to report it, because validation stops at the first failure. ' +
+          'Whoever picks this up should decide between validating on every forward jump and ' +
+          'flagging all the failed sections in the strip at once, rather than one at a time.',
       },
     },
   },

--- a/apps/frontend/src/app/features/inventory/pages/Inventory/InventoryPhoneCatalog.stories.tsx
+++ b/apps/frontend/src/app/features/inventory/pages/Inventory/InventoryPhoneCatalog.stories.tsx
@@ -1,0 +1,394 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, waitFor, within } from 'storybook/test';
+
+import InventoryPhoneCatalog from './InventoryPhoneCatalog';
+import type { InventoryFiltersState, InventoryItem } from './types';
+import { defaultFilters } from './utils';
+
+/**
+ * Resolves a design token to the `rgb(...)` string `getComputedStyle` reports, by
+ * measuring a throwaway probe rather than hard-coding a hex that would drift from
+ * `globals.css` and from the dark theme.
+ *
+ * Called OUTSIDE any `waitFor`: testing-library retries a `waitFor` callback from a
+ * MutationObserver, so a callback that appends and removes a node re-triggers itself
+ * forever and wedges the tab instead of failing.
+ */
+const resolveTokenColor = (token: string): string => {
+  const probe = document.createElement('span');
+  probe.style.display = 'none';
+  probe.style.backgroundColor = `var(${token})`;
+  document.body.append(probe);
+  const value = getComputedStyle(probe).backgroundColor;
+  probe.remove();
+  return value;
+};
+
+const item = (over: Partial<InventoryItem> = {}): InventoryItem => ({
+  id: 'item-1',
+  currency: 'USD',
+  basicInfo: {
+    name: 'Meloxicam 1.5 mg/ml',
+    category: 'Medicine',
+    subCategory: 'Analgesic',
+    department: 'Pharmacy',
+    description: '',
+    status: 'Active',
+    skuCode: 'MEL-015',
+  },
+  classification: {},
+  pricing: { purchaseCost: '10', selling: '25' },
+  vendor: { supplierName: '', brand: '', vendor: '', license: '', paymentTerms: '' },
+  stock: {
+    current: '38',
+    allocated: '0',
+    available: '38',
+    reorderLevel: '10',
+    reorderQuantity: '',
+    stockLocation: 'Pharmacy',
+  },
+  batch: { batch: 'B-2291', manufactureDate: '', expiryDate: '12/03/2026' },
+  ...over,
+});
+
+const HEALTHY = item({ stockHealth: 'HEALTHY' });
+
+const LOW = item({
+  id: 'item-2',
+  stockHealth: 'LOW_STOCK',
+  basicInfo: { ...HEALTHY.basicInfo, name: 'Gauze swabs (pack of 100)', skuCode: 'GAU-100' },
+  stock: { ...HEALTHY.stock, current: '4', available: '4', stockLocation: 'Treatment room' },
+});
+
+const OUT_OF_STOCK = item({
+  id: 'item-3',
+  stockHealth: 'OUT_OF_STOCK',
+  basicInfo: { ...HEALTHY.basicInfo, name: 'Buprenorphine 0.3 mg/ml', skuCode: 'BUP-003' },
+  stock: { ...HEALTHY.stock, current: '0', available: '0', stockLocation: 'Controlled cabinet' },
+});
+
+const EXPIRED = item({
+  id: 'item-4',
+  stockHealth: 'EXPIRED',
+  basicInfo: { ...HEALTHY.basicInfo, name: 'Feline leukaemia vaccine', skuCode: 'FLV-001' },
+  stock: { ...HEALTHY.stock, current: '6', available: '6', stockLocation: 'Fridge 1' },
+  batch: { batch: 'B-1180', manufactureDate: '', expiryDate: '02/01/2025' },
+});
+
+const CATALOG = [HEALTHY, LOW, OUT_OF_STOCK, EXPIRED];
+
+const CATEGORIES = ['Medicine', 'Consumable', 'Vaccine'];
+
+// Hoisted so the spies are stable across re-renders rather than replaced on each one.
+const onView = fn();
+const onRestock = fn();
+const toggleCategoryFilter = fn();
+
+/** `filters` is owned by the Inventory page, so the harness holds it for the pills. */
+const Catalog = ({
+  filteredInventory,
+  loading,
+  canRestock,
+}: {
+  filteredInventory: InventoryItem[];
+  loading: boolean;
+  canRestock: boolean;
+}) => {
+  const [filters, setFilters] = useState<InventoryFiltersState>(defaultFilters);
+  return (
+    <div className="bg-[var(--page)] p-3">
+      <InventoryPhoneCatalog
+        filteredInventory={filteredInventory}
+        filters={filters}
+        setFilters={setFilters}
+        categoryOptions={CATEGORIES}
+        toggleCategoryFilter={toggleCategoryFilter}
+        lowStockCount={2}
+        loading={loading}
+        onView={onView}
+        onRestock={onRestock}
+        canRestock={canRestock}
+      />
+    </div>
+  );
+};
+
+/** The card root is the parent of its own "View <name>" button. */
+const cardFor = (canvasElement: HTMLElement, name: string): HTMLElement =>
+  within(canvasElement).getByRole('button', { name: `View ${name}` }).parentElement as HTMLElement;
+
+/**
+ * Polls the left border rather than reading it once. The accent is applied as an
+ * inline `borderLeft` shorthand over a Tailwind `border` class, so it only resolves
+ * once `globals.css` has painted; a single synchronous read on the first frame can
+ * report the 1px hairline (or a transparent var) and pass or fail for the wrong
+ * reason. `expected` is resolved BEFORE the waitFor, because `resolveTokenColor`
+ * mutates the DOM and a mutating callback re-triggers its own MutationObserver
+ * retry forever instead of failing.
+ */
+const expectLeftBorder = (card: HTMLElement, width: string, expected?: string) =>
+  waitFor(() => {
+    const style = getComputedStyle(card);
+    expect(style.borderLeftWidth).toBe(width);
+    if (expected) expect(style.borderLeftColor).toBe(expected);
+  });
+
+/**
+ * The 375px preset, pinned on the META rather than story by story, because this
+ * component only exists below 768px - the page renders the 12-column table above
+ * it. No story in this file wants another width, and a per-story pin is one a
+ * new story can silently be added without: it would draw the phone catalog at
+ * the 1280px project default, a width it never has in the product, and every
+ * assertion below it would still pass.
+ *
+ * Pinned as a GLOBAL: `parameters.viewport.defaultViewport` was removed in
+ * Storybook 10 and is inert.
+ */
+const PHONE = { viewport: { value: 'mobile', isRotated: false } };
+
+const meta = {
+  title: 'Inventory/InventoryPhoneCatalog',
+  component: Catalog,
+  globals: PHONE,
+  parameters: {
+    layout: 'fullscreen',
+    // Every story here is phone-only, so the snapshot width is set once on the meta.
+    // This is Chromatic's own key, not the `parameters.viewport.viewports` map that
+    // Storybook 10 removed - the render width is pinned by `globals: PHONE` above.
+    chromatic: { viewports: [375] },
+    docs: {
+      description: {
+        component:
+          'The phone (<768px) inventory catalog: a horizontally scrolling pill row over a ' +
+          'single column of stock-health cards. The desktop table has no legible phone form, ' +
+          'so this is a bespoke screen rather than a reflow of the table, and its **async and ' +
+          'empty branches had never been drawn**.\n\n' +
+          'There are three list states, not two, and the third is easy to miss: the loader is ' +
+          'gated on `loading && filteredInventory.length === 0`, so a refresh over rows ' +
+          'already on screen shows the rows, not the loader. All three have a story below.\n\n' +
+          'The card carries two signals that are computed rather than passed. The **left ' +
+          'border** is 3px `--danger` when the item is expired and 3px `--warn` when it is ' +
+          'restockable, against a plain 1px hairline otherwise. The **Restock CTA** needs ' +
+          'three things at once - the item low or out of stock, `canRestock`, and an ' +
+          '`onRestock` handler - so an expired item gets the loudest border on the screen and ' +
+          'no action at all. Both are asserted here as measurements, since the difference ' +
+          'between a 1px hairline and a 3px accent is not something a passing "the card ' +
+          'rendered" check would ever notice.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: { filteredInventory: CATALOG, loading: false, canRestock: true },
+} satisfies Meta<typeof Catalog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const StockHealth: Story = {
+  name: 'Four stock-health cards',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Resolved up front: these append and remove a probe node, which must never
+    // happen inside a waitFor callback.
+    const warn = resolveTokenColor('--warn');
+    const danger = resolveTokenColor('--danger');
+
+    /* The viewport pin, checked rather than trusted. `globals.viewport` is the only
+       spelling Storybook 10 reads; the removed `parameters.viewport.defaultViewport`
+       is inert, and because this component has no desktop branch, a story drawing it
+       at the 1280px project default would still pass every assertion below while
+       proving nothing about the phone. */
+    await expect(window.innerWidth).toBeLessThan(768);
+    await expect(canvas.getAllByRole('button', { name: /^View / })).toHaveLength(4);
+
+    // The pill row sits above the list and carries the low count it was handed.
+    await expect(canvas.getByRole('button', { name: 'All' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Low (2)' })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+    for (const category of CATEGORIES) {
+      await expect(canvas.getByRole('button', { name: category })).toBeInTheDocument();
+    }
+
+    /* The healthy card, asserted on the derived fact line rather than on the raw
+       props: the unit abbreviation, the reorder hint and the margin are all computed
+       by `buildInventoryPhoneMeta`, and every one of them can be wrong while the card
+       still renders. */
+    const healthy = cardFor(canvasElement, 'Meloxicam 1.5 mg/ml');
+    await expect(within(healthy).getByText('In stock')).toBeInTheDocument();
+    await expect(within(healthy).getByText('38 u')).toBeInTheDocument();
+    await expect(within(healthy).getByText('Pharmacy')).toBeInTheDocument();
+    await expect(within(healthy).getByText('exp 03/2026')).toBeInTheDocument();
+    // selling 25 against a cost of 10 - the design puts price and margin together.
+    await expect(within(healthy).getByText('$25 · 60%')).toBeInTheDocument();
+    // No reorder hint on a healthy item, and no CTA.
+    await expect(within(healthy).queryByText(/^reorder at /)).not.toBeInTheDocument();
+    await expect(within(healthy).queryByRole('button', { name: /^Restock / })).toBeNull();
+    await expectLeftBorder(healthy, '1px');
+
+    /* The low card. "bx" rather than "u" because the name says pack - the abbreviation
+       is inferred from the item name, which is a guess worth seeing drawn. */
+    const low = cardFor(canvasElement, 'Gauze swabs (pack of 100)');
+    await expect(within(low).getByText('Low stock')).toBeInTheDocument();
+    await expect(within(low).getByText('4 bx')).toBeInTheDocument();
+    await expect(within(low).getByText('reorder at 10')).toBeInTheDocument();
+    await expect(
+      within(low).getByRole('button', { name: 'Restock Gauze swabs (pack of 100)' })
+    ).toBeInTheDocument();
+    await expectLeftBorder(low, '3px', warn);
+
+    // Out of stock is restockable too, and reads 0 rather than blank.
+    const out = cardFor(canvasElement, 'Buprenorphine 0.3 mg/ml');
+    await expect(within(out).getByText('Out of stock')).toBeInTheDocument();
+    await expect(within(out).getByText('0 u')).toBeInTheDocument();
+    await expect(
+      within(out).getByRole('button', { name: 'Restock Buprenorphine 0.3 mg/ml' })
+    ).toBeInTheDocument();
+
+    /* The expired card is the interesting one: the loudest border on the screen and
+       NO action, because `restockEligible` is low-or-out-of-stock only. Whether an
+       expired batch should offer a restock is a product decision this story pins
+       rather than hides. */
+    const expired = cardFor(canvasElement, 'Feline leukaemia vaccine');
+    await expect(within(expired).getByText('Expired')).toBeInTheDocument();
+    await expect(within(expired).getByText('exp 01/2025')).toBeInTheDocument();
+    await expect(within(expired).queryByRole('button', { name: /^Restock / })).toBeNull();
+    await expectLeftBorder(expired, '3px', danger);
+    // The two accents are genuinely different colours, not the same var read twice.
+    await expect(warn).not.toBe(danger);
+
+    // Two CTAs on the screen in total, not four.
+    await expect(canvas.getAllByRole('button', { name: /^Restock / })).toHaveLength(2);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting catalog at 375px. Each card is a tap target (the whole card opens the ' +
+          'record) with an optional CTA below it, so the Restock button is a sibling of the ' +
+          'view button rather than nested inside it - nesting them would have made the ' +
+          'restock area open the record on any missed tap.',
+      },
+    },
+  },
+};
+
+export const NoRestockPermission: Story = {
+  name: 'Without restock permission',
+  args: { canRestock: false },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Same four cards, same borders, no CTA anywhere.
+    await expect(canvas.getAllByRole('button', { name: /^View / })).toHaveLength(4);
+    await expect(canvas.queryAllByRole('button', { name: /^Restock / })).toHaveLength(0);
+
+    const warn = resolveTokenColor('--warn');
+    const low = cardFor(canvasElement, 'Gauze swabs (pack of 100)');
+    await expect(within(low).getByText('reorder at 10')).toBeInTheDocument();
+    await expect(within(low).getByText('4 bx')).toBeInTheDocument();
+    await expectLeftBorder(low, '3px', warn);
+    // The card is down to its one tap target: the whole-card View button and nothing else.
+    await expect(within(low).getAllByRole('button')).toHaveLength(1);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A reader without the restock permission. The warning border and the reorder hint ' +
+          'stay - the item is still low - but the card loses its CTA and with it 38px of ' +
+          'height, so a permission difference changes the rhythm of the whole list.',
+      },
+    },
+  },
+};
+
+export const Loading: Story = {
+  name: 'Loading',
+  args: { filteredInventory: [], loading: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Loading inventory…')).toBeInTheDocument();
+
+    // Loading is not empty: the empty card must NOT be on screen at the same time.
+    await expect(canvas.queryByText('Looks like a quiet day… for now.')).not.toBeInTheDocument();
+    await expect(canvas.queryAllByRole('button', { name: /^View / })).toHaveLength(0);
+
+    // The pills render regardless, so the filter row does not pop in after the fetch.
+    await expect(canvas.getByRole('button', { name: 'All' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Low (2)' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The first paint of the catalog. It is a centred line of 13px `--ink-muted` copy ' +
+          'with 40px of padding above and below - not a skeleton - so the pill row is the ' +
+          'only thing with any weight on screen while the fetch is out.',
+      },
+    },
+  },
+};
+
+export const Empty: Story = {
+  name: 'Loaded and empty',
+  args: { filteredInventory: [], loading: false },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Looks like a quiet day… for now.')).toBeInTheDocument();
+    await expect(canvas.queryByText('Loading inventory…')).not.toBeInTheDocument();
+    await expect(canvas.queryAllByRole('button', { name: /^View / })).toHaveLength(0);
+
+    // The empty state is a bordered card, not bare copy - which is what distinguishes
+    // it visually from the loader above.
+    const card = canvas.getByText('Looks like a quiet day… for now.');
+    await expect(getComputedStyle(card).borderTopWidth).toBe('1px');
+    await expect(getComputedStyle(card).borderRadius).toBe('16px');
+
+    await expect(canvas.getByRole('button', { name: 'Low (2)' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Loaded, and genuinely nothing to show. Worth reading next to the loader: the two ' +
+          'states are one boolean apart and look almost the same, except this one is inside a ' +
+          'bordered card.\n\n' +
+          'The copy does not distinguish "this clinic has no inventory yet" from "your ' +
+          'filters match nothing", and the pill row above it stays active with a low count ' +
+          'that can be non-zero while the list is empty - which is exactly the case where a ' +
+          'reader needs to be told a filter is on.',
+      },
+    },
+  },
+};
+
+export const RefreshOverExistingRows: Story = {
+  name: 'Refreshing over rows already on screen',
+  args: { loading: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // `loading` is true, and the loader is deliberately NOT shown, because the guard
+    // is `loading && filteredInventory.length === 0`.
+    await expect(canvas.queryByText('Loading inventory…')).not.toBeInTheDocument();
+    await expect(canvas.getAllByRole('button', { name: /^View / })).toHaveLength(4);
+    const low = cardFor(canvasElement, 'Gauze swabs (pack of 100)');
+    await expect(within(low).getByText('4 bx')).toBeInTheDocument();
+    await expect(within(low).getByText('reorder at 10')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The third list state, and the one the two-state reading of this component misses. ' +
+          'A background refresh with rows already on screen keeps the rows: no loader, no ' +
+          'flash to empty and back.\n\n' +
+          'The flip side is that there is no indication a refresh is running at all, so stale ' +
+          'numbers look settled. If that matters, this is the story to change.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/marketing/pages/ContactusPage/ContactusPage.stories.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/ContactusPage/ContactusPage.stories.tsx
@@ -1,0 +1,348 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import { AxiosError } from 'axios';
+import type { AxiosAdapter, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+
+import api from '@/app/services/axios';
+// Only `(routes)/(public)/layout.tsx` loads this sheet, and the page's buttons and
+// fields are `.yc-btn-primary` / `.yc-field` / `.yc-lbl`. Without it the form
+// renders as unstyled controls sitting inside fully styled inline-styled panels,
+// which is a worse lie than no story at all.
+import '@/app/features/marketing/site/marketing.css';
+import ContactusPage from './ContactusPage';
+
+/**
+ * Swaps the shared axios instance's *adapter* rather than mocking `postData`,
+ * following the convention the other API-backed stories in this repo use (there
+ * is no MSW or `sb.mock` wiring here). `beforeEach` returns the restore, so the
+ * real adapter is back before the next story runs.
+ */
+const stubApi = (respond: (config: InternalAxiosRequestConfig) => Promise<AxiosResponse>) => () => {
+  const previous = api.defaults.adapter;
+  const adapter: AxiosAdapter = (config) => respond(config);
+  api.defaults.adapter = adapter;
+  return () => {
+    api.defaults.adapter = previous;
+  };
+};
+
+const accepted = (config: InternalAxiosRequestConfig): Promise<AxiosResponse> =>
+  Promise.resolve({
+    data: { id: 'ticket-1' },
+    status: 201,
+    statusText: 'Created',
+    headers: {},
+    config,
+  });
+
+/**
+ * A genuine `AxiosError` with a 400 response.
+ *
+ * The page reads `error.response?.data?.message` behind `axios.isAxiosError`, so
+ * a plain `Error` would fall through to the generic fallback copy and the story
+ * would be drawing the wrong branch of the catch. A custom adapter also has to
+ * REJECT for a non-2xx - axios only applies `validateStatus` inside its built-in
+ * adapters, so resolving with `status: 400` would read as a success.
+ */
+const rejected = (config: InternalAxiosRequestConfig): Promise<AxiosResponse> =>
+  Promise.reject(
+    new AxiosError('Request failed with status code 400', 'ERR_BAD_REQUEST', config, undefined, {
+      data: { message: 'Contact service is temporarily unavailable.' },
+      status: 400,
+      statusText: 'Bad Request',
+      headers: {},
+      config,
+    } as AxiosResponse)
+  );
+
+const NEVER = (): Promise<AxiosResponse> => new Promise<AxiosResponse>(() => {});
+
+type Draft = { name: string; email: string; message: string };
+
+const fill = async (canvasElement: HTMLElement, draft: Draft) => {
+  const canvas = within(canvasElement);
+  await userEvent.type(canvas.getByLabelText('Full Name'), draft.name);
+  await userEvent.type(canvas.getByLabelText('Enter Email Address'), draft.email);
+  await userEvent.type(canvas.getByLabelText('Request details'), draft.message);
+  /* Waits for the gate to open before handing the canvas back. A disabled submit
+     carries `pointer-events: none`, and userEvent refuses to click through that
+     with an error about the pointer rather than about the state under test - so
+     without this every story below would fail for the wrong reason if the gate
+     ever regressed. */
+  await waitFor(() => {
+    expect(canvas.getByRole('button', { name: /Send message/ })).toBeEnabled();
+  });
+  return canvas;
+};
+
+const VALID: Draft = {
+  name: 'Lena Weber',
+  email: 'lena@example.test',
+  message: 'Can the appointment board be filtered by practitioner?',
+};
+
+const meta = {
+  title: 'Marketing/ContactusPage',
+  component: ContactusPage,
+  parameters: {
+    layout: 'fullscreen',
+    // Opts out of the `data-yc-app` marker the preview stamps on every other
+    // story: PIMS scopes its darker faint inks to that marker, and this page is
+    // a public marketing surface that needs the lighter marketing values.
+    surface: 'marketing',
+    docs: {
+      description: {
+        component:
+          'The public contact page. The form has always been visible; the three states that ' +
+          'follow a submit never have been, because each one needs a real POST to ' +
+          '`/v1/contact-us/contact-web` to land or fail.\n\n' +
+          '`ContactSuccess` does not appear next to the form - it **replaces** it. The page ' +
+          'swaps the entire `ContactForm` for a `role="status"` card with its own "Send another ' +
+          'message" reset, so after a successful send there is no form on the page at all. ' +
+          'That card was added precisely because the form used to just clear itself on success, ' +
+          'which read as "nothing happened".\n\n' +
+          '`SubmitError` is an inline red row **below** the submit button, inside the form, ' +
+          'with no `role="alert"` - so it is announced to nobody and it appears under the ' +
+          'control the reader just pressed rather than above the fields.\n\n' +
+          'The field validation is the interesting one. `computeSubmitDisabled` keeps the ' +
+          'button disabled until name, email and message are all non-empty, but ' +
+          '`validateContactForm` checks them with `.trim()`. So "Full name is required" and ' +
+          '"Message is required" are only reachable by typing whitespace - two messages that ' +
+          'exist for a state the button gate almost prevents. "Invalid email address" is the ' +
+          'one that fires in ordinary use.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  globals: { viewport: { value: 'desktop', isRotated: false } },
+  beforeEach: stubApi(accepted),
+} satisfies Meta<typeof ContactusPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Form: Story = {
+  name: 'Contact form (resting)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Four request types as a radiogroup of visually hidden radios behind pill
+    // labels - not buttons, so they are arrow-key navigable.
+    const group = canvas.getByRole('radiogroup', { name: 'What brings you here?' });
+    await expect(within(group).getAllByRole('radio')).toHaveLength(4);
+    await expect(within(group).getByRole('radio', { name: 'General Enquiry' })).toBeChecked();
+
+    await expect(canvas.getByLabelText('Full Name')).toHaveValue('');
+    await expect(canvas.getByLabelText('Enter Email Address')).toHaveValue('');
+    await expect(canvas.getByLabelText('Phone number (optional)')).toBeInTheDocument();
+    await expect(canvas.getByLabelText('Request details')).toBeInTheDocument();
+
+    /* The submit is disabled AND `pointer-events: none` on an empty form. Both
+       matter: the disabled attribute is what a screen reader announces, the
+       pointer-events rule is what stops the hover state from suggesting it is
+       live. */
+    const submit = canvas.getByRole('button', { name: /Send message/ });
+    await expect(submit).toBeDisabled();
+    await expect(getComputedStyle(submit).pointerEvents).toBe('none');
+
+    await expect(canvas.queryByRole('status')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Two columns: the hero with its three contact channels on the left, the form card on ' +
+          'the right. Selecting anything other than General Enquiry or Feature Request swaps ' +
+          'the message block for a longer per-type form, which is why the submit button lives ' +
+          'inside those blocks rather than at the bottom of the card.',
+      },
+    },
+  },
+};
+
+export const SubmitEnablesWhenComplete: Story = {
+  name: 'Submit unlocks when the three fields are filled',
+  play: async ({ canvasElement }) => {
+    const canvas = await fill(canvasElement, VALID);
+    const submit = canvas.getByRole('button', { name: /Send message/ });
+
+    /* `fill` has already waited for `disabled` to clear; these three are the
+       visual half of the same gate, all set inline rather than by a class, and
+       each is what a reader actually perceives as "the button woke up". */
+    await expect(getComputedStyle(submit).pointerEvents).toBe('auto');
+    await expect(getComputedStyle(submit).opacity).toBe('1');
+    await expect(getComputedStyle(submit).cursor).toBe('pointer');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The gate is presence, not validity: a name of one space and an email of "x" unlock ' +
+          'the button just as well as this. That is what makes the two stories below reachable ' +
+          'at all.',
+      },
+    },
+  },
+};
+
+export const InvalidEmail: Story = {
+  name: 'Field validation (invalid email)',
+  play: async ({ canvasElement }) => {
+    const canvas = await fill(canvasElement, { ...VALID, email: 'lena.example.test' });
+    await userEvent.click(canvas.getByRole('button', { name: /Send message/ }));
+
+    const emailError = await canvas.findByText('Invalid email address');
+    await expect(emailError).toBeInTheDocument();
+
+    /* The other two messages stay away, because the fields are genuinely filled.
+       Asserting their absence is what makes this a validation story rather than a
+       "some red text appeared" story. */
+    await expect(canvas.queryByText('Full name is required')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Message is required')).not.toBeInTheDocument();
+
+    // No POST was attempted, so the form is untouched and the draft survives.
+    await expect(canvas.getByLabelText('Full Name')).toHaveValue('Lena Weber');
+    await expect(canvas.queryByRole('status')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A 14px line in `--color-danger-600` directly under the field it belongs to, with no ' +
+          'icon - the alert glyph belongs to the submit error, not to these. The input itself ' +
+          'does not change either: no red border, no `aria-invalid`, so the message is the only ' +
+          'signal there is.',
+      },
+    },
+  },
+};
+
+export const BlankAfterTrim: Story = {
+  name: 'Field validation (whitespace only)',
+  play: async ({ canvasElement }) => {
+    const canvas = await fill(canvasElement, {
+      name: '   ',
+      email: 'lena@example.test',
+      message: '  ',
+    });
+
+    /* Whitespace is truthy, so `computeSubmitDisabled` unlocks the button (the
+       wait inside `fill` is what proves that) on a draft `validateContactForm`
+       rejects a moment later. This is the only route to these two messages. */
+    await userEvent.click(canvas.getByRole('button', { name: /Send message/ }));
+
+    const nameError = await canvas.findByText('Full name is required');
+    await expect(nameError).toBeInTheDocument();
+    await expect(canvas.getByText('Message is required')).toBeInTheDocument();
+    await expect(canvas.queryByText('Invalid email address')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Two errors at once, which is also the only story where the card grows by two rows ' +
+          'and pushes the submit button down. Trimming in `computeSubmitDisabled` as well would ' +
+          'make both of these messages unreachable.',
+      },
+    },
+  },
+};
+
+export const MessageSent: Story = {
+  name: 'Message sent (success card)',
+  play: async ({ canvasElement }) => {
+    const canvas = await fill(canvasElement, VALID);
+    await userEvent.click(canvas.getByRole('button', { name: /Send message/ }));
+
+    const card = await canvas.findByRole('status');
+    await expect(within(card).getByRole('heading', { name: 'Message sent' })).toBeInTheDocument();
+    await expect(
+      within(card).getByText(/A person reads every message, and we'll reply to your email shortly/)
+    ).toBeInTheDocument();
+
+    /* The form is GONE, not cleared and not disabled. Nothing on the page can be
+       typed into any more, which is why the reset button below has to exist. */
+    await expect(canvas.queryByLabelText('Full Name')).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('radiogroup')).not.toBeInTheDocument();
+
+    // And the reset really resets: `resetForm` ran before `setSubmitted(true)`,
+    // so coming back gives an empty draft rather than the message just sent.
+    await userEvent.click(within(card).getByRole('button', { name: /Send another message/ }));
+    await waitFor(() => {
+      expect(canvas.getByLabelText('Full Name')).toHaveValue('');
+    });
+    await expect(canvas.getByLabelText('Request details')).toHaveValue('');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A centred card in the form’s own slot: green check disc, a 26px Newsreader heading ' +
+          'and the same primary pill shape as the submit it replaced. It carries ' +
+          '`aria-live="polite"`, so the confirmation is announced without stealing focus.',
+      },
+    },
+  },
+};
+
+export const Submitting: Story = {
+  name: 'Submitting (in flight)',
+  beforeEach: stubApi(NEVER),
+  play: async ({ canvasElement }) => {
+    const canvas = await fill(canvasElement, VALID);
+    await userEvent.click(canvas.getByRole('button', { name: /Send message/ }));
+
+    /* Label swaps to the lowercase "submitting..." - the only in-flight feedback
+       there is - and `submitting` also feeds `computeSubmitDisabled`, so unlike
+       most buttons in this repo this one really is locked while the POST is out. */
+    const busy = await canvas.findByRole('button', { name: /submitting\.\.\./ });
+    await expect(busy).toBeDisabled();
+    await expect(canvas.queryByRole('status')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The window between the click and the reply. Note the casing: every other label on ' +
+          'the page is sentence case, this one is not.',
+      },
+    },
+  },
+};
+
+export const SubmitFailed: Story = {
+  name: 'Submit error (inline)',
+  beforeEach: stubApi(rejected),
+  play: async ({ canvasElement }) => {
+    const canvas = await fill(canvasElement, VALID);
+    await userEvent.click(canvas.getByRole('button', { name: /Send message/ }));
+
+    // The server's own message, not a generic fallback.
+    const message = await canvas.findByText('Contact service is temporarily unavailable.');
+    await expect(message).toBeInTheDocument();
+
+    /* It is not an alert and it is not above the fields: the row is the last
+       child of the form, below the submit button, so on a scrolled page it can
+       land below the fold that the button sits on. */
+    await expect(canvas.queryByRole('alert')).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('status')).not.toBeInTheDocument();
+    const submit = canvas.getByRole('button', { name: /Send message/ });
+    await expect(message.getBoundingClientRect().top).toBeGreaterThan(
+      submit.getBoundingClientRect().top
+    );
+
+    // The draft survives a failure, so the reader can press send again.
+    await expect(canvas.getByLabelText('Full Name')).toHaveValue('Lena Weber');
+    await expect(submit).toBeEnabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The failure path. `errors.submit` is merged into the same errors object the field ' +
+          'validation writes, so a submit error and a field error can be on screen at once - ' +
+          'and neither clears until the next submit.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/onboarding/components/Steps/CreateOrg/SpecialityStep.stories.tsx
+++ b/apps/frontend/src/app/features/onboarding/components/Steps/CreateOrg/SpecialityStep.stories.tsx
@@ -1,0 +1,388 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import type { Organisation, Service } from '@yosemite-crew/types';
+
+import type { SpecialityWeb } from '@/app/features/organization/types/speciality';
+import SpecialityStep from './SpecialityStep';
+
+const ORG_ID = 'org-storybook-avenger-park';
+
+const ORG: Organisation = {
+  _id: ORG_ID,
+  name: 'Avenger Park Veterinary',
+  type: 'HOSPITAL',
+  phoneNo: '+493012345678',
+  taxId: 'DE123456789',
+  address: {
+    addressLine: '12 Kollwitzstrasse',
+    city: 'Berlin',
+    state: 'Berlin',
+    postalCode: '10405',
+    country: 'Germany',
+  },
+};
+
+const buildService = (name: string, durationMinutes: number, cost: number): Service => ({
+  id: '',
+  organisationId: ORG_ID,
+  name,
+  durationMinutes,
+  cost,
+  isActive: true,
+});
+
+const DENTISTRY: SpecialityWeb = {
+  name: 'Dentistry',
+  organisationId: ORG_ID,
+  services: [buildService('Dental Cleaning & Scaling', 60, 160)],
+};
+
+/* Hoisted rather than created inline: a `fn()` in the render body is a new spy on
+   every re-render, so an assertion about it would read a different mock than the
+   one the click reached. */
+const onPrevStep = fn();
+
+type HarnessProps = {
+  /** Specialties already on the step, as the wizard would hand them back on resume. */
+  initialSpecialities?: SpecialityWeb[];
+};
+
+/**
+ * The step is fully controlled - it owns no specialty state of its own - so the
+ * stories supply the `useState` pair the CreateOrg wizard normally supplies.
+ * Nothing here reaches the network: `submitSpecialityStep` is only called once
+ * the specialty list is non-empty, and every story that presses the CTA presses
+ * it with an empty list on purpose.
+ */
+const SpecialityStepHarness = ({ initialSpecialities = [] }: HarnessProps) => {
+  const [formData, setFormData] = useState<Organisation>(ORG);
+  const [specialities, setSpecialities] = useState<SpecialityWeb[]>(initialSpecialities);
+
+  return (
+    <div className="min-h-[760px] w-[960px] max-w-full bg-[var(--page)] p-6">
+      <SpecialityStep
+        formData={formData}
+        setFormData={setFormData}
+        initialSpecialities={initialSpecialities}
+        isExistingOrg
+        prevStep={onPrevStep}
+        specialities={specialities}
+        setSpecialities={setSpecialities}
+      />
+    </div>
+  );
+};
+
+const meta = {
+  title: 'Onboarding/SpecialityStep',
+  component: SpecialityStepHarness,
+  parameters: {
+    layout: 'fullscreen',
+    /* Required, not decorative: the step calls `useRouter()` from next/navigation
+       at the top of its hook. The framework only builds that mock when
+       `appDirectory` is set, and `getRouter()` throws
+       NextjsRouterMocksNotAvailable otherwise - so every story here fails to
+       render without this line. */
+    nextjs: { appDirectory: true },
+    docs: {
+      description: {
+        component:
+          'The third create-org step, and the only one whose interesting surfaces are all bespoke ' +
+          'markup local to the file rather than shared primitives - which is exactly why none of ' +
+          'them had ever been drawn.\n\n' +
+          'Three of them open only on interaction and are therefore invisible to a static ' +
+          'snapshot of the step:\n\n' +
+          '- The **specialty picker dropdown**, opened by focusing or typing in the search field. ' +
+          'It is an absolutely positioned overlay (`top: calc(100% + 10px)`, `z-index: 20`) that ' +
+          'is not portalled, so it is clipped by any scrolling ancestor the wizard grows later.\n' +
+          '- Its **"Create specialty" empty branch**, which replaces the whole option list the ' +
+          'moment the query matches nothing. It is the only route to a custom specialty, and it ' +
+          'is reachable only by typing something the 15-entry catalog does not contain.\n' +
+          '- The **per-specialty service picker**, the same markup again, nested inside each ' +
+          'selected card.\n\n' +
+          'The list is capped at `slice(0, 8)` of 15 catalog entries with no "more" affordance ' +
+          'and no scroll hint beyond the 280px `max-height`, so seven specialties are only ' +
+          'reachable by typing their name. The recommended chip row is capped the same way, at ' +
+          '6 of the 8 names `orgTypeContent.HOSPITAL.recommended` lists - Emergency & Critical ' +
+          'Care and Preventive / Wellness Medicine never render as chips.\n\n' +
+          'Both validation errors land in the same single `.step-inline-error` line at the foot ' +
+          'of the list, including the one raised from inside the service modal - where it renders ' +
+          'behind the scrim.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof SpecialityStepHarness>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Empty: Story = {
+  name: 'Nothing added yet',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('No specialties added yet')).toBeInTheDocument();
+
+    // Six chips, not the eight names the HOSPITAL content block lists.
+    const chipGroup = canvasElement.querySelector('.step-three-chip-group') as HTMLElement;
+    await expect(chipGroup.children).toHaveLength(6);
+    await expect(chipGroup.children[0]).toHaveTextContent('General Practice');
+    await expect(chipGroup.children[5]).toHaveTextContent('Radiology / Diagnostic Imaging');
+    await expect(
+      within(chipGroup).queryByText('Emergency & Critical Care')
+    ).not.toBeInTheDocument();
+
+    // The picker is closed at rest, so the story below is the only place it exists.
+    await expect(canvasElement.querySelector('.step-three-picker-dropdown')).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting step for a hospital. The search panel carries the org-type audience line ' +
+          'and the recommended chips; the empty card below is the only thing that changes once a ' +
+          'specialty is added.',
+      },
+    },
+  },
+};
+
+export const PickerOpen: Story = {
+  name: 'Specialty picker (open)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('textbox', { name: 'Search or add a specialty' }));
+
+    await waitFor(() =>
+      expect(canvasElement.querySelector('.step-three-picker-dropdown')).not.toBeNull()
+    );
+    const dropdown = canvasElement.querySelector('.step-three-picker-dropdown') as HTMLElement;
+
+    // Eight options of the fifteen the catalog holds - the cap is silent.
+    const options = within(dropdown).getAllByRole('button');
+    await expect(options).toHaveLength(8);
+    await expect(options[0]).toHaveTextContent('Observational tools');
+    await expect(options[0]).toHaveTextContent('3 starter services included');
+    await expect(options[1]).toHaveTextContent('General Practice');
+    await expect(options[1]).toHaveTextContent('6 starter services included');
+    // Ninth in catalog order onwards: present in the data, absent from the UI.
+    await expect(within(dropdown).queryByText('Cardiology')).not.toBeInTheDocument();
+
+    // Overlay, not an inline block: it is positioned out of flow over the chips.
+    await expect(getComputedStyle(dropdown).position).toBe('absolute');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Opened on focus, so it appears before a single character is typed. Each row is a ' +
+          'two-line option - name plus the starter-service count that will be copied into the ' +
+          'card - and the count differs per specialty, so it is worth reading rather than ' +
+          'assuming: Observational tools ships 3, most clinical specialties ship 6 or 7 because ' +
+          'the catalog prepends a General Consult to any row flagged `consult`.',
+      },
+    },
+  },
+};
+
+export const PickerCreateCustom: Story = {
+  name: 'Specialty picker (no matches)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const search = canvas.getByRole('textbox', { name: 'Search or add a specialty' });
+    await userEvent.type(search, 'Hydrotherapy');
+
+    await waitFor(() =>
+      expect(canvasElement.querySelector('.step-three-picker-dropdown')).not.toBeNull()
+    );
+    const dropdown = canvasElement.querySelector('.step-three-picker-dropdown') as HTMLElement;
+
+    // The whole option list is replaced by one create row - not appended to it.
+    const createRow = within(dropdown).getByRole('button', {
+      name: 'Create specialty “Hydrotherapy”',
+    });
+    await expect(within(dropdown).getAllByRole('button')).toHaveLength(1);
+
+    await userEvent.click(createRow);
+
+    // The card is built from the query, with no template behind it: zero services
+    // and the generated fallback summary rather than a catalog one.
+    await expect(canvas.getByText('Hydrotherapy')).toBeInTheDocument();
+    await expect(canvas.getByText('0 services')).toBeInTheDocument();
+    await expect(
+      canvas.getByText('A configurable specialty for hydrotherapy services in your organization.')
+    ).toBeInTheDocument();
+    await expect(search).toHaveValue('');
+    await expect(canvasElement.querySelector('.step-three-picker-dropdown')).toBeNull();
+
+    /* One card, one track. Both counts matter: the grid is
+       `repeat(auto-fit, minmax(320px, 1fr))`, and it is the `:has(> :only-child)`
+       rule that collapses it to `minmax(0, 1fr)` - so a track count read without
+       the child count would not say which rule produced it. */
+    const grid = canvasElement.querySelector('.step-three-selected-grid') as HTMLElement;
+    await expect(grid.children).toHaveLength(1);
+    await expect(getComputedStyle(grid).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(1);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Typing a specialty the catalog does not carry. The filter matches service names as ' +
+          'well as specialty names, so this branch only appears once neither hits - and it is the ' +
+          'only way to add a custom specialty, which is why it is worth seeing that it looks ' +
+          'nothing like the option rows it replaces. Selecting it clears the query, closes the ' +
+          'picker and adds an empty card whose summary is generated from the typed name.',
+      },
+    },
+  },
+};
+
+export const ServicePickerOpen: Story = {
+  name: 'Service picker inside a card',
+  args: { initialSpecialities: [DENTISTRY] },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Add service' }));
+
+    const searchLabel = 'Search services for Dentistry';
+    expect(await canvas.findByRole('textbox', { name: searchLabel })).toBeInTheDocument();
+
+    const panel = canvasElement.querySelector('.step-three-service-search-panel') as HTMLElement;
+    const dropdown = panel.querySelector('.step-three-picker-dropdown') as HTMLElement;
+    const options = within(dropdown).getAllByRole('button');
+
+    // Five of the six Dentistry template services: the one already on the card is
+    // filtered out, so the list shrinks as the card fills.
+    await expect(options).toHaveLength(5);
+    await expect(options[0]).toHaveTextContent('General Consult');
+    await expect(options[0]).toHaveTextContent('30 min • $75');
+    await expect(within(dropdown).queryByText('Dental Cleaning & Scaling')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same dropdown markup again, nested one level deeper and keyed by specialty name. ' +
+          'Each row carries the duration and price the catalog derives from keywords in the ' +
+          'service name, which is what the service editor then opens with - so the numbers on ' +
+          'these rows are the defaults a clinic ships with unless someone edits them.',
+      },
+    },
+  },
+};
+
+export const SubmitWithNoSpecialities: Story = {
+  name: 'Validation: no specialties added',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Create organisation' }));
+
+    const error = await canvas.findByText('Add at least one specialty to continue');
+    await expect(error).toHaveClass('step-inline-error');
+    // The guard returns before `setIsSubmitting(true)`, so the CTA never enters
+    // its pending label and nothing was sent.
+    await expect(canvas.getByRole('button', { name: 'Create organisation' })).toBeInTheDocument();
+    await expect(
+      canvas.queryByRole('button', { name: 'Creating organisation...' })
+    ).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The only client-side guard on this step. The message renders at the foot of the list ' +
+          'rather than next to the search field that would fix it, and the empty-state card sits ' +
+          'between the two.',
+      },
+    },
+  },
+};
+
+export const ServiceEditorNameRequired: Story = {
+  name: 'Validation: service name cleared',
+  args: { initialSpecialities: [DENTISTRY] },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Edit Dental Cleaning & Scaling' }));
+
+    /* The editor is a CenterModal, which portals to document.body - none of its
+       fields are inside canvasElement, and a closed dialog stays mounted without
+       its `open` attribute, so both queries have to go through `dialog[open]`. */
+    await waitFor(() => expect(document.querySelector('dialog[open]')).not.toBeNull());
+    const dialog = document.querySelector('dialog[open]') as HTMLElement;
+    const nameField = within(dialog).getByRole('textbox', { name: 'Service name' });
+    await expect(nameField).toHaveValue('Dental Cleaning & Scaling');
+
+    await userEvent.clear(nameField);
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Save service' }));
+
+    // The editor stays open, and the message it raises is rendered by the PAGE,
+    // behind the scrim - not inside the dialog the user is looking at.
+    await expect(document.querySelector('dialog[open]')).not.toBeNull();
+    expect(await canvas.findByText('Service name is required.')).toBeInTheDocument();
+    await expect(within(dialog).queryByText('Service name is required.')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Saving a service with an empty name. `handleSaveService` sets the same `error` state ' +
+          'the submit guard uses, which is rendered in the step body - so the message lands ' +
+          'behind the modal scrim while the modal stays open with no feedback of its own. Worth ' +
+          'a design decision rather than a snapshot: this is the one error in the step a user ' +
+          'cannot see when it fires.',
+      },
+    },
+  },
+};
+
+export const Phone: Story = {
+  name: 'Phone (375)',
+  args: { initialSpecialities: [DENTISTRY] },
+  // Pinned as a GLOBAL: `parameters.viewport.defaultViewport` was removed in
+  // Storybook 10 and renders at full panel width while still passing.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* "Dentistry" is on screen TWICE, and both are the step working as built: the
+       recommended chip stays in the row after it has been added - it is disabled,
+       not removed - and the selected card repeats the name as its title. So this
+       is not the step rendered twice at this breakpoint, and not the preview
+       decorator's sr-only story-title banner; it is one chip and one card, and it
+       reads the same way at 1280px. Every query for a specialty name in this step
+       has to say which of the two it means. */
+    const chipGroup = canvasElement.querySelector('.step-three-chip-group') as HTMLElement;
+    const grid = canvasElement.querySelector('.step-three-selected-grid') as HTMLElement;
+    await expect(canvas.getAllByText('Dentistry')).toHaveLength(2);
+    await expect(within(grid).getByText('Dentistry')).toBeInTheDocument();
+    /* The chip is the reason the picker list is one shorter than the catalog for
+       an added specialty: `filteredCatalog` drops selected names, but the chip row
+       keeps them and greys them out instead. */
+    await expect(within(chipGroup).getByText('Dentistry')).toBeDisabled();
+
+    // Under 500px the footer reverses so the primary action sits on top.
+    const buttons = canvasElement.querySelector('.step-buttons') as HTMLElement;
+    await expect(getComputedStyle(buttons).flexDirection).toBe('column-reverse');
+
+    // Single card, single track - the same only-child rule as on desktop, so
+    // this is not a breakpoint effect and the child count is what says so.
+    await expect(grid.children).toHaveLength(1);
+    await expect(getComputedStyle(grid).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(1);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The step at 375px. The footer flips to `column-reverse` below 500px, which puts ' +
+          '"Create organisation" above "Back" - the opposite vertical order to the desktop row, ' +
+          'and the only breakpoint where that happens.\n\n' +
+          'The resumed card also shows what an added specialty does to the panel above it: the ' +
+          'recommended chip is disabled in place rather than removed, so the name appears both as ' +
+          'a greyed chip and as a card title, while the picker list below drops it entirely. Two ' +
+          'different rules for the same fact, and only one of them is visible at rest.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/onboarding/components/Steps/TeamOnboarding/AvailabilityStep.stories.tsx
+++ b/apps/frontend/src/app/features/onboarding/components/Steps/TeamOnboarding/AvailabilityStep.stories.tsx
@@ -1,0 +1,303 @@
+import { useState, type Dispatch, type SetStateAction } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+
+import {
+  AvailabilityState,
+  DEFAULT_INTERVAL,
+  daysOfWeek,
+} from '@/app/features/appointments/components/Availability/utils';
+import AvailabilityStep from './AvailabilityStep';
+
+const buildAvailability = (enabledDays: readonly string[]): AvailabilityState =>
+  daysOfWeek.reduce<AvailabilityState>((acc, day) => {
+    acc[day] = {
+      enabled: enabledDays.includes(day),
+      intervals: [{ ...DEFAULT_INTERVAL }],
+    };
+    return acc;
+  }, {} as AvailabilityState);
+
+const WEEKDAYS = buildAvailability(['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday']);
+const NOTHING_ENABLED = buildAvailability([]);
+
+type HarnessProps = {
+  initialAvailability: AvailabilityState;
+  isSaving: boolean;
+  prevStep: () => void;
+  setIsSaving: Dispatch<SetStateAction<boolean>>;
+  setIsRedirecting: Dispatch<SetStateAction<boolean>>;
+};
+
+/**
+ * The step is controlled by the wizard, so the story owns the availability state
+ * the same way `TeamOnboarding` does. `setIsSaving` and `setIsRedirecting` stay
+ * spies rather than real setters: they are the two things the component touches
+ * on its way to `upsertAvailability`, so a story can prove the request was never
+ * attempted by asserting neither was called.
+ */
+const AvailabilityStepHarness = ({
+  initialAvailability,
+  isSaving,
+  prevStep,
+  setIsSaving,
+  setIsRedirecting,
+}: HarnessProps) => {
+  const [availability, setAvailability] = useState<AvailabilityState>(initialAvailability);
+
+  return (
+    <div className="min-h-[720px] bg-[var(--page)] p-6">
+      <AvailabilityStep
+        prevStep={prevStep}
+        orgIdFromQuery="org-storybook-avenger-park"
+        availability={availability}
+        setAvailability={setAvailability}
+        isSaving={isSaving}
+        setIsSaving={setIsSaving}
+        setIsRedirecting={setIsRedirecting}
+      />
+    </div>
+  );
+};
+
+const meta = {
+  title: 'Onboarding/AvailabilityStep',
+  component: AvailabilityStepHarness,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The last team-onboarding step. Its one error state - **"Please enable at least one day ' +
+          'with a valid time slot"** - had never been drawn, because it is raised only after ' +
+          'Finish is pressed with every day switched off, which is a state a reviewer has to ' +
+          'build by hand: the wizard seeds Monday to Friday on.\n\n' +
+          'The same message is raised from two places, the Finish handler and the `validate()` ' +
+          'the stepper calls, so it is also what a practitioner sees when they try to skip ' +
+          'forward past an empty week.\n\n' +
+          'The consultation-slot select and the two visit-type chips are rendered **disabled on ' +
+          'purpose**, at the values the backend actually applies: `POST /availability/:orgId/base` ' +
+          'accepts only `{ dayOfWeek, slots }`, so anything picked there would be discarded ' +
+          'silently. They are part of the design and carry a `title` explaining why they are ' +
+          'inert, which makes them worth seeing rather than mistaking for a broken control.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    initialAvailability: WEEKDAYS,
+    isSaving: false,
+    prevStep: fn(),
+    setIsSaving: fn(),
+    setIsRedirecting: fn(),
+  },
+} satisfies Meta<typeof AvailabilityStepHarness>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Weekdays enabled',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const monday = canvas.getByRole('checkbox', { name: 'Enable availability for Monday' });
+    await expect(canvas.getAllByRole('checkbox')).toHaveLength(7);
+    await expect(monday).toBeChecked();
+    await expect(
+      canvas.getByRole('checkbox', { name: 'Enable availability for Saturday' })
+    ).not.toBeChecked();
+    await expect(canvas.getAllByText('Day off')).toHaveLength(2);
+
+    // Toggle | day | ranges | actions - four tracks and exactly four children,
+    // so every row lands its cells in the same columns whether the day is on
+    // (time ranges plus add/duplicate) or off (the "Day off" placeholder).
+    const row = monday.closest('.grid') as HTMLElement;
+    await expect(row.children).toHaveLength(4);
+    await expect(getComputedStyle(row).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(4);
+
+    // Rendered, disabled, and pinned to what the API stores.
+    const slot = canvas.getByRole('combobox', { name: 'Consultation slot' });
+    await expect(slot).toBeDisabled();
+    await expect(slot).toHaveValue('30 min');
+    const inClinic = canvas.getByRole('button', { name: 'In clinic' });
+    await expect(inClinic).toBeDisabled();
+    await expect(inClinic).toHaveAttribute('aria-pressed', 'true');
+    await expect(canvas.getByRole('button', { name: 'Home visits' })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+
+    await expect(
+      canvas.getByRole('button', { name: 'Finish · open dashboard' })
+    ).toBeInTheDocument();
+    await expect(
+      canvas.queryByText('Please enable at least one day with a valid time slot')
+    ).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The state the wizard opens with. A disabled day collapses its time ranges to the ' +
+          '"Day off" placeholder rather than dimming them, so the row keeps its height and the ' +
+          'week does not reflow as days are switched on.',
+      },
+    },
+  },
+};
+
+export const AvailabilityError: Story = {
+  name: 'Finish with every day off',
+  args: { initialAvailability: NOTHING_ENABLED },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getAllByText('Day off')).toHaveLength(7);
+    await expect(
+      canvas.queryByText('Please enable at least one day with a valid time slot')
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Finish · open dashboard' }));
+
+    const error = await canvas.findByText('Please enable at least one day with a valid time slot');
+    await expect(error).toHaveClass('text-text-error');
+
+    /* The guard returns before `setIsSaving(true)`, which is the only thing that
+       happens before `upsertAvailability` - so these two spies staying untouched
+       is the proof that no request was attempted, not just that a message rendered. */
+    await expect(args.setIsSaving).not.toHaveBeenCalled();
+    await expect(args.setIsRedirecting).not.toHaveBeenCalled();
+    await expect(
+      canvas.getByRole('button', { name: 'Finish · open dashboard' })
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The undrawn branch. The message sits between the week and the footer rule, in ' +
+          '`text-caption-2` - it is the only error in this step and it is easy to miss below a ' +
+          'seven-row card, especially since the row that would fix it is off-screen on a short ' +
+          'viewport.',
+      },
+    },
+  },
+};
+
+export const ErrorSurvivesADayBeingSwitchedOn: Story = {
+  name: 'Error persists until the next attempt',
+  args: { initialAvailability: NOTHING_ENABLED },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Finish · open dashboard' }));
+    expect(
+      await canvas.findByText('Please enable at least one day with a valid time slot')
+    ).toBeInTheDocument();
+
+    await userEvent.click(
+      canvas.getByRole('checkbox', { name: 'Enable availability for Tuesday' })
+    );
+
+    // The day is on and its ranges are back, but the message is still there:
+    // the error is only cleared by the next validation, not by the edit that
+    // resolves it.
+    await waitFor(() =>
+      expect(
+        canvas.getByRole('checkbox', { name: 'Enable availability for Tuesday' })
+      ).toBeChecked()
+    );
+    await expect(canvas.getAllByText('Day off')).toHaveLength(6);
+    await expect(
+      canvas.getByText('Please enable at least one day with a valid time slot')
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Worth a decision rather than a snapshot: switching a day on fixes the problem the ' +
+          'message describes, and the message stays. Clearing `availabilityError` on change - or ' +
+          're-validating on toggle - would need a product call, so this pins the behaviour as it ' +
+          'ships today. The story stops before the second Finish, which would reach the real ' +
+          '`upsertAvailability` request.',
+      },
+    },
+  },
+};
+
+export const Saving: Story = {
+  name: 'Saving in flight',
+  args: { isSaving: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const cta = canvas.getByRole('button', { name: 'Saving...' });
+    // `isDisabled` on the pill does both: `BaseButton` puts the real `disabled`
+    // attribute on the button branch AND adds `pointer-events-none opacity-60`,
+    // so a second save is blocked in the DOM and not only by the handler's own
+    // `if (isSaving) return`.
+    await expect(cta).toBeDisabled();
+    await expect(cta).toHaveClass('pointer-events-none');
+    await expect(
+      canvas.queryByRole('button', { name: 'Finish · open dashboard' })
+    ).not.toBeInTheDocument();
+    // Back stays live, so a practitioner can leave while a save is in flight.
+    const back = canvas.getByRole('button', { name: 'Back' });
+    await expect(back).toBeEnabled();
+    await expect(back).not.toHaveClass('pointer-events-none');
+    // And so does the week: `isSaving` never reaches `Availability`, so the day
+    // toggles keep taking edits that the in-flight request will not carry.
+    await expect(
+      canvas.getByRole('checkbox', { name: 'Enable availability for Monday' })
+    ).toBeEnabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Mid-save. Only the primary label changes - the week above it stays fully editable, so a ' +
+          'practitioner can keep toggling days while the request they already sent is in flight ' +
+          'and the payload that lands is the one from before the edits.',
+      },
+    },
+  },
+};
+
+export const Phone: Story = {
+  name: 'Phone (375)',
+  // Pinned as a GLOBAL: `parameters.viewport.defaultViewport` was removed in
+  // Storybook 10 and renders at full panel width while still passing.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const back = canvas.getByRole('button', { name: 'Back' });
+    const inClinic = canvas.getByRole('button', { name: 'In clinic' });
+
+    /* The footer is a single `flex-wrap` row with no breakpoint of its own, so
+       the only thing that says whether it wrapped is geometry. Bounding rects,
+       not `getComputedStyle()`: these are bordered pills, whose content box
+       reads narrower than the drawn control and would not compare cleanly. */
+    await expect(back.getBoundingClientRect().top).toBeGreaterThan(
+      inClinic.getBoundingClientRect().bottom
+    );
+
+    // The week itself does not change shape - still seven rows on four tracks,
+    // so the time ranges are what get squeezed at this width.
+    await expect(canvas.getAllByRole('checkbox')).toHaveLength(7);
+    const row = canvas
+      .getByRole('checkbox', { name: 'Enable availability for Monday' })
+      .closest('.grid') as HTMLElement;
+    await expect(row.children).toHaveLength(4);
+    await expect(getComputedStyle(row).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(4);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The step at 375px, and the one width where the footer breaks into two lines: the ' +
+          'disabled visit-type chips take the first, Back and Finish the second. The day rows ' +
+          'keep their fixed `40px 96px 1fr auto` template at every width, so the time-range ' +
+          'column absorbs the loss and the two selects sit tight against each other here.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/onboarding/pages/CreateOrg/CreateOrg.stories.tsx
+++ b/apps/frontend/src/app/features/onboarding/pages/CreateOrg/CreateOrg.stories.tsx
@@ -1,0 +1,258 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import type { Organisation, UserOrganization } from '@yosemite-crew/types';
+
+import { useAuthStore } from '@/app/stores/authStore';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useSpecialityStore } from '@/app/stores/specialityStore';
+import CreateOrg from './CreateOrg';
+
+const ORG_ID = 'org-storybook-avenger-park';
+
+const MEMBERSHIP: UserOrganization = {
+  practitionerReference: 'user-storybook',
+  organizationReference: ORG_ID,
+  // `useOrgOnboarding` resolves the step only for an owner; any other role is
+  // parked on step 0 whatever the org holds.
+  roleCode: 'owner',
+  active: true,
+};
+
+/**
+ * Basics done, address empty - the exact shape `computeOrgOnboardingStep` reads
+ * as step 2. Filling the address here instead would compute step 3 and the page
+ * would `redirect('/dashboard')` before rendering anything.
+ */
+const ORG_WITHOUT_ADDRESS: Organisation = {
+  _id: ORG_ID,
+  name: 'Avenger Park Veterinary',
+  type: 'HOSPITAL',
+  phoneNo: '+493012345678',
+  taxId: 'DE123456789',
+  address: {
+    addressLine: '',
+    city: '',
+    state: '',
+    postalCode: '',
+    country: 'Germany',
+  },
+};
+
+/**
+ * Seeds the stores the wizard resumes from and restores them afterwards.
+ * `status` is set explicitly on both: `useOrgOnboarding` reports `isReady:
+ * false` while either store is idle or loading, and `CreateOrg` renders `null`
+ * in that case - a blank story that looks like a broken import.
+ */
+const seed = () => {
+  const snapshots = {
+    auth: useAuthStore.getState(),
+    org: useOrgStore.getState(),
+    speciality: useSpecialityStore.getState(),
+  };
+
+  useAuthStore.setState({ status: 'authenticated' });
+  useOrgStore.setState({
+    orgsById: { [ORG_ID]: ORG_WITHOUT_ADDRESS },
+    orgIds: [ORG_ID],
+    primaryOrgId: ORG_ID,
+    membershipsByOrgId: { [ORG_ID]: MEMBERSHIP },
+    status: 'loaded',
+  });
+  useSpecialityStore.setState({ status: 'loaded' });
+
+  return () => {
+    useAuthStore.setState(snapshots.auth);
+    useOrgStore.setState(snapshots.org);
+    useSpecialityStore.setState(snapshots.speciality);
+  };
+};
+
+const meta = {
+  title: 'Onboarding/CreateOrg',
+  component: CreateOrg,
+  parameters: {
+    layout: 'fullscreen',
+    nextjs: {
+      appDirectory: true,
+      navigation: { pathname: '/create-org', query: { orgId: ORG_ID } },
+    },
+    docs: {
+      description: {
+        component:
+          'The two-step create-organisation wizard, resumed on step 2. **AddressStep had never ' +
+          'been drawn anywhere** - not here and not in a story of its own - because it mounts ' +
+          'only once `validateOrgBasics` has passed on step 1, and that needs a name, a tax id, a ' +
+          'country and a phone number that clears `validatePhone`.\n\n' +
+          'These stories reach it the way a returning owner does, by seeding an org that already ' +
+          'has its basics and no address: `computeOrgOnboardingStep` reads that as step 2 and the ' +
+          'page adopts it during render. That also means the CTA reads **Save** rather than ' +
+          '**Create** - the label is chosen by whether an org already exists, so a first-time ' +
+          'creator never sees this exact pane.\n\n' +
+          'One error in the address form is not announced like the rest: `GoogleSearchDropDown` ' +
+          'renders its message without `role="alert"`, while every `FormInput` beside it uses ' +
+          'one. The validation story below pins that difference rather than counting error text.\n\n' +
+          'The `isTransitioning` state - where the whole wizard is hidden behind `invisible ' +
+          'pointer-events-none` while the org is written - has no story: it is only entered after ' +
+          '`createOrg`/`updateOrg` resolves, and this repo has no request-mocking layer for a ' +
+          'story to stand in for that. The stories below assert the wrapper is NOT in that state, ' +
+          'so a regression that blanks the wizard at rest still fails.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  beforeEach: () => seed(),
+} satisfies Meta<typeof CreateOrg>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const AddressStep: Story = {
+  name: 'Step 2 - address',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    /* Not `findByText('Address')`: the stepper label carries the same word, so a
+       text query matches two nodes and the failure reads as a missing element. */
+    expect(await canvas.findByRole('textbox', { name: 'Address line' })).toBeInTheDocument();
+    await expect(canvasElement.querySelector('.onb-card-title')).toHaveTextContent('Address');
+
+    // Two steps, the second active - resumed rather than navigated to.
+    await waitFor(() => expect(canvasElement.querySelectorAll('.yc-step-trigger')).toHaveLength(2));
+    const triggers = canvasElement.querySelectorAll('.yc-step-trigger');
+    await expect(triggers[0]).toHaveClass('is-complete');
+    await expect(triggers[1]).toHaveClass('is-active');
+
+    // Six fields: the address search, city/state, postal code, and the two
+    // check-in numbers that only exist on this step.
+    await expect(canvas.getByRole('textbox', { name: 'Address line' })).toHaveValue('');
+    await expect(canvas.getByRole('textbox', { name: 'City' })).toHaveValue('');
+    await expect(canvas.getByRole('textbox', { name: 'State/Province' })).toHaveValue('');
+    await expect(canvas.getByRole('textbox', { name: 'Postal code' })).toHaveValue('');
+    await expect(
+      canvas.getByRole('spinbutton', { name: 'Check-in opens (minutes before appointment)' })
+    ).toHaveValue(5);
+    await expect(canvas.getByRole('spinbutton', { name: 'Check-in radius (meters)' })).toHaveValue(
+      200
+    );
+
+    // Existing org, so the CTA saves rather than creates.
+    await expect(canvas.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+
+    // Not mid-submit: the wizard is visible and interactive.
+    const wrapper = canvasElement.querySelector('.create-org-wrapper') as HTMLElement;
+    await expect(wrapper).not.toHaveClass('invisible');
+    await expect(getComputedStyle(wrapper).pointerEvents).not.toBe('none');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The pane as a returning owner finds it. The two check-in numbers are pre-filled from ' +
+          'the org defaults (5 minutes, 200 metres) rather than left blank, so the form submits ' +
+          'clean without anyone touching them.',
+      },
+    },
+  },
+};
+
+export const AddressValidation: Story = {
+  name: 'Step 2 - validation on Save',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(await canvas.findByRole('button', { name: 'Save' }));
+
+    // Four messages, but only three are announced: the address-line field is a
+    // GoogleSearchDropDown, whose error block carries no role.
+    const alerts = await canvas.findAllByRole('alert');
+    await expect(alerts).toHaveLength(3);
+    await expect(canvas.getByText('City is required')).toBeInTheDocument();
+    await expect(canvas.getByText('State or province is required')).toBeInTheDocument();
+    await expect(canvas.getByText('Postal code is required')).toBeInTheDocument();
+
+    const addressError = canvas.getByText('Address line is required');
+    await expect(addressError.closest('[role="alert"]')).toBeNull();
+
+    // The submit guard returns before `setIsTransitioning(true)`, so the wizard
+    // is still on screen rather than blanked behind the fullscreen loader.
+    const wrapper = canvasElement.querySelector('.create-org-wrapper') as HTMLElement;
+    await expect(wrapper).not.toHaveClass('invisible');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Country is already set from step 1, so it is absent from the list - the four errors ' +
+          'here are the ones an owner can actually hit on this pane. `submitOrg` re-runs the same ' +
+          '`validateOrgAddress` the step runs locally, and both write into the same message slots, ' +
+          'which is why pressing Save shows one set rather than two.',
+      },
+    },
+  },
+};
+
+export const AddressErrorsClearPerField: Story = {
+  name: 'Step 2 - an error clears as its field is filled',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(await canvas.findByRole('button', { name: 'Save' }));
+    expect(await canvas.findAllByRole('alert')).toHaveLength(3);
+
+    await userEvent.type(canvas.getByRole('textbox', { name: 'City' }), 'Berlin');
+
+    // Only the city message goes: each field clears its own key on change rather
+    // than re-running the whole validator.
+    await waitFor(() => expect(canvas.queryByText('City is required')).not.toBeInTheDocument());
+    await expect(canvas.getAllByRole('alert')).toHaveLength(2);
+    await expect(canvas.getByText('Postal code is required')).toBeInTheDocument();
+    await expect(canvas.getByText('Address line is required')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Each `FormInput` clears its own key from `formDataErrors` in its `onChange`, so the ' +
+          'messages disappear one at a time as fields are filled rather than all at once on the ' +
+          'next Save. Worth watching the address-line message specifically: it is the one with no ' +
+          '`role="alert"`, so a screen reader is never told it went away either.',
+      },
+    },
+  },
+};
+
+export const AddressStepOnPhone: Story = {
+  name: 'Step 2 on a phone (375)',
+  // Pinned as a GLOBAL: `parameters.viewport.defaultViewport` was removed in
+  // Storybook 10 and silently renders desktop markup at panel width.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(await canvas.findByRole('textbox', { name: 'Address line' })).toBeInTheDocument();
+
+    /* City/State and the two check-in numbers are the two `1fr 1fr` grids on
+       this pane, and both collapse to one track below 768px. Two children on
+       one track is the assertion that says they stacked - a track count alone
+       would also pass on an empty grid. */
+    const pairs = canvasElement.querySelectorAll<HTMLElement>('.step-two-input');
+    await expect(pairs).toHaveLength(2);
+    for (const pair of pairs) {
+      await expect(pair.children).toHaveLength(2);
+      await expect(getComputedStyle(pair).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(1);
+    }
+
+    // The card footer reverses below 640px, so Save sits above Back.
+    const footer = canvasElement.querySelector('.onb-footer') as HTMLElement;
+    await expect(getComputedStyle(footer).flexDirection).toBe('column-reverse');
+    await expect(footer.children).toHaveLength(2);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The pane at 375px. Both paired grids go to a single column and the footer reverses, so ' +
+          'the field order a phone reads is address, city, state, postal code, then the two ' +
+          'check-in numbers - four more scroll stops than the desktop pane, with Save at the ' +
+          'bottom above Back.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/onboarding/pages/PublicBookingSetup/PublicBookingSetup.stories.tsx
+++ b/apps/frontend/src/app/features/onboarding/pages/PublicBookingSetup/PublicBookingSetup.stories.tsx
@@ -1,0 +1,379 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import type { Organisation } from '@yosemite-crew/types';
+
+import type { ServiceRevamp, SpecialityRevamp } from '@/app/features/organization/types/revamp';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useRevampCatalogStore } from '@/app/stores/revampCatalogStore';
+import PublicBookingSetup from './PublicBookingSetup';
+
+const ORG_ID = 'org-storybook-avenger-park';
+const SPECIALITY_ID = 'spec-general-practice';
+
+const ORG: Organisation = {
+  _id: ORG_ID,
+  name: 'Avenger Park Veterinary',
+  type: 'HOSPITAL',
+  phoneNo: '+493012345678',
+  taxId: 'DE123456789',
+};
+
+const service = (over: Partial<ServiceRevamp> = {}): ServiceRevamp => ({
+  id: 'svc-1',
+  code: 'GP-001',
+  name: 'Wellness consultation',
+  description: 'Nose-to-tail exam and a plan for the year.',
+  type: 'CONSULTATION',
+  specialityId: SPECIALITY_ID,
+  organisationId: ORG_ID,
+  grossAmount: 72,
+  currency: 'EUR',
+  defaultDiscount: 0,
+  maxDiscount: 10,
+  durationMinutes: 30,
+  isBookable: true,
+  isInpatientPreferred: false,
+  status: 'ACTIVE',
+  createdAt: '2026-05-04T09:00:00.000Z',
+  ...over,
+});
+
+const SERVICES: ServiceRevamp[] = [
+  service(),
+  service({
+    id: 'svc-2',
+    code: 'GP-014',
+    name: 'Vaccination booster',
+    grossAmount: 45,
+    durationMinutes: 20,
+  }),
+  service({
+    id: 'svc-3',
+    code: 'DEN-002',
+    name: 'Dental scale and polish',
+    type: 'PROCEDURE',
+    grossAmount: 310,
+    durationMinutes: 90,
+  }),
+  // Present in the catalog, deliberately absent from the booking list.
+  service({ id: 'svc-4', code: 'RAD-003', name: 'Full mouth radiograph', isBookable: false }),
+  service({ id: 'svc-5', code: 'GP-099', name: 'Retired nail trim', status: 'ARCHIVED' }),
+];
+
+const SPECIALITY: SpecialityRevamp = {
+  id: SPECIALITY_ID,
+  name: 'General Practice',
+  organisationId: ORG_ID,
+  teamMemberIds: [],
+};
+
+/**
+ * Seeds the two stores the page reads and restores them afterwards.
+ *
+ * `loadOrganisationCatalog` returns at its first line once the store already
+ * holds a speciality for this organisation, so seeding one keeps the mount off
+ * the network with no service stub - the page under review is the real one.
+ */
+const seed = (options: { services?: ServiceRevamp[]; imageURL?: string } = {}) => {
+  const previousOrg = useOrgStore.getState();
+  const previousCatalog = useRevampCatalogStore.getState();
+
+  useOrgStore.setState({
+    orgsById: { [ORG_ID]: { ...ORG, imageURL: options.imageURL } },
+    orgIds: [ORG_ID],
+    primaryOrgId: ORG_ID,
+    status: 'loaded',
+  });
+  useRevampCatalogStore.setState({
+    services: options.services ?? SERVICES,
+    specialities: [SPECIALITY],
+  });
+
+  return () => {
+    useOrgStore.setState(previousOrg);
+    useRevampCatalogStore.setState(previousCatalog);
+  };
+};
+
+/** Step 2 is behind Continue, so every branding story starts by pressing it. */
+const goToBranding = async (canvasElement: HTMLElement) => {
+  const canvas = within(canvasElement);
+  await userEvent.click(canvas.getByRole('button', { name: 'Continue' }));
+  await waitFor(() => expect(canvas.getByText('Your booking page')).toBeInTheDocument());
+};
+
+const meta = {
+  title: 'Onboarding/PublicBookingSetup',
+  component: PublicBookingSetup,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The two-pane online-booking setup card. Step 1 is what a reviewer sees by default; ' +
+          'step 2 - the whole **Branding & review** pane - only exists after Continue, and had ' +
+          'never been drawn anywhere.\n\n' +
+          'That is where all of the assumed-scope risk lives: the logo row with its Replace ' +
+          'action (not wired up), the welcome message, the confirmation-email reply-to, the live ' +
+          'preview card of the public booking page, and the public URL whose slug is derived from ' +
+          'the clinic name rather than stored anywhere. The amber `FIELDS ASSUMED · confirm with ' +
+          'product` pill in the page header is the standing warning that these fields are a ' +
+          'proposal, and step 2 is the half of the flow it is really about.\n\n' +
+          'Selection is derived, not mirrored: every bookable service starts selected because ' +
+          '`selected` falls back to the full id set until the user toggles something, so there is ' +
+          'no effect syncing a checkbox list to the catalog.\n\n' +
+          '"Copied" has no story on purpose - `copyText` needs a real `navigator.clipboard.write` ' +
+          'grant, and it degrades to leaving the label at "Copy" when the write is blocked, which ' +
+          'is what a sandboxed preview iframe does.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  beforeEach: () => seed(),
+} satisfies Meta<typeof PublicBookingSetup>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ServicesStep: Story = {
+  name: 'Step 1 - services & availability',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('FIELDS ASSUMED · confirm with product')).toBeInTheDocument();
+    await expect(canvas.getByText('of 2 · Services & availability')).toBeInTheDocument();
+
+    // Three of the five catalog rows: archived and non-bookable are filtered out.
+    const rows = canvas.getAllByRole('button', { pressed: true });
+    await expect(rows).toHaveLength(3);
+    await expect(rows[0]).toHaveTextContent('Wellness consultation');
+    await expect(rows[0]).toHaveTextContent('30 min · any practitioner');
+    await expect(rows[0]).toHaveTextContent('€72.00');
+    await expect(canvas.queryByText('Full mouth radiograph')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Retired nail trim')).not.toBeInTheDocument();
+
+    await expect(canvas.getByRole('combobox', { name: 'Bookable window' })).toHaveValue(
+      'Up to 4 weeks ahead'
+    );
+    await expect(canvas.getByRole('combobox', { name: 'Buffer between visits' })).toHaveValue(
+      '10 minutes'
+    );
+    await expect(canvas.getByRole('switch', { name: 'Requests need confirmation' })).toBeChecked();
+
+    // The two selects share one `grid-cols-1 sm:grid-cols-2` row: two tracks and
+    // two children here, and the same grid is what drops to one column on a
+    // phone - the only responsive rule on this pane.
+    const selectRow = canvasElement.querySelector('[class*="sm:grid-cols-2"]') as HTMLElement;
+    await expect(selectRow.children).toHaveLength(2);
+    await expect(getComputedStyle(selectRow).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(
+      2
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The entry pane. Every bookable service arrives already selected, which is the point of ' +
+          'the derived-selection design - the clinic opts services out rather than in.',
+      },
+    },
+  },
+};
+
+export const ServicesStepToggle: Story = {
+  name: 'Step 1 - opting a service out',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const dental = canvas.getByRole('button', { pressed: true, name: /Dental scale and polish/ });
+
+    await userEvent.click(dental);
+
+    await waitFor(() => expect(dental).toHaveAttribute('aria-pressed', 'false'));
+    await expect(canvas.getAllByRole('button', { pressed: true })).toHaveLength(2);
+    // The first toggle materialises the override set from the derived default,
+    // so the other two must survive it rather than resetting to empty.
+    await expect(
+      canvas.getByRole('button', { pressed: true, name: /Wellness consultation/ })
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The first toggle is the interesting one: until it happens `selected` is the derived ' +
+          'full id set, and the click has to materialise that set into `selectionOverride` before ' +
+          'removing one id from it. Get that copy wrong and opting one service out silently opts ' +
+          'every other service out too, which is why the other two rows are counted here.',
+      },
+    },
+  },
+};
+
+export const BrandingStep: Story = {
+  name: 'Step 2 - branding & review',
+  play: async ({ canvasElement }) => {
+    await goToBranding(canvasElement);
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByText('of 2 · Branding & review')).toBeInTheDocument();
+    // Step 1 is unmounted, not hidden.
+    await expect(canvas.queryByText('What can pet parents book?')).not.toBeInTheDocument();
+
+    // Logo row: no upload on this org, and Replace is an unwired notify().
+    await expect(canvas.getByText('No logo uploaded')).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Replace' })).toBeInTheDocument();
+
+    await expect(canvas.getByRole('textbox', { name: 'Welcome message' })).toHaveValue(
+      'Book a visit for your companion at Avenger Park Veterinary.'
+    );
+    const replyTo = canvas.getByRole('textbox', { name: 'Confirmation email reply-to' });
+    await expect(replyTo).toHaveValue('');
+    await expect(replyTo).toHaveAttribute('placeholder', 'frontdesk@your-clinic.vet');
+
+    // Preview card mirrors the org, the initial and the welcome copy.
+    await expect(canvas.getByText('Preview')).toBeInTheDocument();
+    await expect(canvas.getByText('Avenger Park Veterinary')).toBeInTheDocument();
+    await expect(canvas.getByText('Choose a service')).toBeInTheDocument();
+
+    // Slug is computed from the org name at render time - nothing stores it.
+    await expect(
+      canvas.getByText('book.yosemitecrew.com/avenger-park-veterinary')
+    ).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Copy' })).toBeInTheDocument();
+
+    // Fields left, preview right, side by side from `md` up - two children on
+    // one row, which is what the phone story below reverses.
+    const row = canvasElement.querySelector('[class*="md:flex-row"]') as HTMLElement;
+    await expect(row.children).toHaveLength(2);
+    await expect(getComputedStyle(row).flexDirection).toBe('row');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The pane the audit found undrawn. Two `A` initial chips are rendered from the same ' +
+          'derived initial - one in the logo row, one in the preview - so a change to the ' +
+          'fallback has to be checked in both places.',
+      },
+    },
+  },
+};
+
+export const BrandingWithLogo: Story = {
+  name: 'Step 2 - org already has a logo',
+  beforeEach: () => seed({ imageURL: '/images/placeholder.png' }),
+  play: async ({ canvasElement }) => {
+    await goToBranding(canvasElement);
+    const canvas = within(canvasElement);
+    // Only the copy changes: the row still shows the initial chip, never the image.
+    await expect(canvas.getByText('Current logo')).toBeInTheDocument();
+    await expect(canvas.queryByText('No logo uploaded')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`hasLogo` only swaps the label. The uploaded image is never rendered here, so a clinic ' +
+          'with a logo sees the same monogram chip as one without - worth confirming with design ' +
+          'before this ships.',
+      },
+    },
+  },
+};
+
+export const BrandingPreviewIsLive: Story = {
+  name: 'Step 2 - preview follows the welcome field',
+  play: async ({ canvasElement }) => {
+    await goToBranding(canvasElement);
+    const canvas = within(canvasElement);
+    const welcome = canvas.getByRole('textbox', { name: 'Welcome message' });
+
+    await userEvent.clear(welcome);
+    await userEvent.type(welcome, 'Same-day slots for poorly pets.');
+
+    const previewCopy = await canvas.findByText('Same-day slots for poorly pets.');
+    await expect(previewCopy).toHaveClass('line-clamp-3');
+    await expect(welcome).toHaveValue('Same-day slots for poorly pets.');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The preview is not a static mock: it re-renders from the same state as the field. It ' +
+          'clamps at three lines, so a long welcome message is silently truncated in the preview ' +
+          'while the field keeps it in full.',
+      },
+    },
+  },
+};
+
+export const ServicesStepEmpty: Story = {
+  name: 'Step 1 - nothing is bookable yet',
+  beforeEach: () => seed({ services: [service({ isBookable: false })] }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByText(
+        'No bookable services yet. Add services and mark them bookable in Organization → Specialities.'
+      )
+    ).toBeInTheDocument();
+    // No rows at all - not unselected rows. The catalog holds one service; it is
+    // simply not bookable, and the copy is the only thing standing in for it.
+    await expect(canvas.queryAllByRole('button', { pressed: true })).toHaveLength(0);
+    await expect(canvas.queryAllByRole('button', { pressed: false })).toHaveLength(0);
+    await expect(canvas.queryByText('Wellness consultation')).not.toBeInTheDocument();
+
+    // Everything below the list is untouched by the empty state, and Continue is
+    // live: an empty booking page can be carried straight through to step 2.
+    await expect(canvas.getByRole('combobox', { name: 'Bookable window' })).toBeEnabled();
+    await expect(canvas.getByRole('button', { name: 'Continue' })).toBeEnabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'What a clinic sees before any service is marked bookable. The empty state is a single ' +
+          'line of copy pointing at Organization → Specialities, and nothing stops Continue: the ' +
+          'branding pane and the Go live button are reachable with zero services attached, so the ' +
+          'guard that should exist here does not.',
+      },
+    },
+  },
+};
+
+export const BrandingOnPhone: Story = {
+  name: 'Step 2 on a phone (375)',
+  // Pinned as a GLOBAL: `parameters.viewport.defaultViewport` was removed in
+  // Storybook 10 and silently renders at full panel width.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    await goToBranding(canvasElement);
+    const canvas = within(canvasElement);
+
+    const row = canvasElement.querySelector('[class*="md:flex-row"]') as HTMLElement;
+    await expect(getComputedStyle(row).flexDirection).toBe('column');
+    await expect(row.children).toHaveLength(2);
+
+    // The preview drops BELOW the fields rather than beside them - it is second
+    // in source order, so stacking puts it after the reply-to field and pushes
+    // the public URL block off a 375x812 screen entirely.
+    const [fields, preview] = Array.from(row.children) as HTMLElement[];
+    await expect(preview.getBoundingClientRect().top).toBeGreaterThan(
+      fields.getBoundingClientRect().top
+    );
+    await expect(within(preview).getByText('Preview')).toBeInTheDocument();
+    await expect(within(preview).getByText('Avenger Park Veterinary')).toBeInTheDocument();
+    await expect(
+      canvas.getByText('book.yosemitecrew.com/avenger-park-veterinary')
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Step 2 at 375px. The `md:w-60` preview loses its fixed width and goes full-bleed under ' +
+          'the three fields, which is the one place the preview stops reading as a phone-sized ' +
+          'mock of the public page and starts reading as another card in the form.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/onboarding/pages/StripeOnboarding/StripeSetupStatus.stories.tsx
+++ b/apps/frontend/src/app/features/onboarding/pages/StripeOnboarding/StripeSetupStatus.stories.tsx
@@ -1,0 +1,214 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import { StripeSetupStatus } from './index';
+
+const ACCOUNT_ERROR = 'We could not prepare Stripe onboarding. Please try again.';
+const CONNECT_ERROR =
+  'We could not load the secure Stripe onboarding form. Please refresh the page and try again.';
+
+const meta = {
+  title: 'Onboarding/StripeSetupStatus',
+  component: StripeSetupStatus,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The two async-result blocks that sit between the "Stripe onboarding" heading and the ' +
+          'Connect embed. Neither had ever been drawn: reaching them in a real page means a ' +
+          'Stripe account, a publishable key and a round trip that either fails or has not ' +
+          'answered yet, and the page redirects to the dashboard before rendering if the ' +
+          'subscription is missing or already charging.\n\n' +
+          'They were inline JSX in the page body until now. Splitting them into this component ' +
+          'is the only source change made for these stories - same markup, same conditions, same ' +
+          'position in the page - and it is what lets both states be reviewed without Stripe.\n\n' +
+          'The retry is conditional on `canRetrySetup`, which is false once a connected account ' +
+          'exists: that failure came from `loadConnectAndInitialize` rather than from account ' +
+          'creation, so re-running account creation would not fix it. The result is that the ' +
+          'same alert box appears with and without a way forward, which is the pair worth ' +
+          'looking at side by side.\n\n' +
+          'The waiting block is an `<output>` with `aria-live="polite"` and `aria-busy`, so the ' +
+          'wait is announced rather than only spun at - there is no spinner here at all.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    setupError: null,
+    isPreparing: true,
+    isEmbedReady: false,
+    canRetrySetup: false,
+    onRetry: fn(),
+  },
+} satisfies Meta<typeof StripeSetupStatus>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Preparing: Story = {
+  name: 'Preparing (aria-live)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const status = canvas.getByText('Preparing your secure Stripe onboarding experience…');
+
+    // `<output>` maps to role status, so this is announced without a live-region
+    // attribute of its own - the explicit aria-live only sets the politeness.
+    await expect(status.tagName).toBe('OUTPUT');
+    await expect(status).toHaveAttribute('aria-live', 'polite');
+    await expect(status).toHaveAttribute('aria-busy', 'true');
+    await expect(canvas.queryByRole('alert')).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Try again' })).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'What a practitioner looks at for the whole account/secret round trip. It is a single ' +
+          'centred line in a bordered card - no spinner, no progress, and no timeout, so a ' +
+          'request that never resolves leaves this on screen indefinitely.',
+      },
+    },
+  },
+};
+
+export const PreparingSettled: Story = {
+  name: 'Preparing, no longer busy',
+  args: { isPreparing: false },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Same copy, `aria-busy` off: reached when the account is ready but the
+    // Connect instance has not been created yet (no publishable key, say).
+    const status = canvas.getByText('Preparing your secure Stripe onboarding experience…');
+    await expect(status).toHaveAttribute('aria-busy', 'false');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Visually identical to the story above, which is the point: `aria-busy` is the only ' +
+          'thing that changes when the wait stops being a wait, so a sighted user cannot tell ' +
+          'that the page has quietly stopped making progress.',
+      },
+    },
+  },
+};
+
+export const SetupErrorWithRetry: Story = {
+  name: 'Setup failed, retry offered',
+  args: { setupError: ACCOUNT_ERROR, isPreparing: false, canRetrySetup: true },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const alert = canvas.getByRole('alert');
+    await expect(alert).toHaveTextContent(ACCOUNT_ERROR);
+    // Two children - the message and the action - against one in the story
+    // below. That count is the whole visual difference between the two states.
+    await expect(alert.children).toHaveLength(2);
+
+    // The waiting line is gone rather than stacked under the failure.
+    await expect(
+      canvas.queryByText('Preparing your secure Stripe onboarding experience…')
+    ).not.toBeInTheDocument();
+
+    const retry = canvas.getByRole('button', { name: 'Try again' });
+    await userEvent.click(retry);
+    await expect(args.onRetry).toHaveBeenCalledTimes(1);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Account creation failed, so retrying it is worth offering. Retry re-runs ' +
+          '`createConnectedAccount` only - it does not reload the page or reset the reducer, so ' +
+          'the alert stays until the next result arrives.',
+      },
+    },
+  },
+};
+
+export const SetupErrorWithoutRetry: Story = {
+  name: 'Setup failed, no way forward',
+  args: { setupError: CONNECT_ERROR, isPreparing: false, canRetrySetup: false },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const alert = canvas.getByRole('alert');
+    await expect(alert).toHaveTextContent(CONNECT_ERROR);
+    // Same box, one child instead of two: no button, and the copy is the only
+    // thing telling the user to refresh.
+    await expect(alert.children).toHaveLength(1);
+    await expect(canvas.queryByRole('button', { name: 'Try again' })).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The Connect-initialisation failure. `canRetrySetup` is false because the org already ' +
+          'has a connected account, so the alert carries no action and the instruction to refresh ' +
+          'lives inside the sentence. This is the state a returning owner hits when the embed ' +
+          'cannot load, and the one most likely to need a real recovery path.',
+      },
+    },
+  },
+};
+
+export const EmbedReady: Story = {
+  name: 'Embed ready (renders nothing)',
+  args: { isEmbedReady: true, isPreparing: false },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    /* The component returns `null` here, so the assertion has to be that it
+       contributed NOTHING - not just that one block is missing. `<output>` and
+       `[role="alert"]` are its only two roots, and the sole button it can
+       render is the retry, so zero of all three is the whole render. */
+    await expect(canvasElement.querySelectorAll('output, [role="alert"]')).toHaveLength(0);
+    await expect(canvas.queryAllByRole('button')).toHaveLength(0);
+    await expect(
+      canvas.queryByText('Preparing your secure Stripe onboarding experience…')
+    ).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Once `loadConnectAndInitialize` returns an instance the component renders nothing at ' +
+          'all, which is what lets the embed sit directly under the page heading with no leftover ' +
+          'status card pushing it down. The canvas here is empty on purpose.',
+      },
+    },
+  },
+};
+
+export const Phone: Story = {
+  name: 'Phone (375)',
+  args: { setupError: ACCOUNT_ERROR, isPreparing: false, canRetrySetup: true },
+  // Pinned as a GLOBAL: `parameters.viewport.defaultViewport` was removed in
+  // Storybook 10 and renders at full panel width while still passing.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const alert = canvas.getByRole('alert');
+    await expect(alert).toHaveTextContent(ACCOUNT_ERROR);
+    // Full-bleed card at 375: `w-full` with no max width of its own, so it is
+    // the page container that constrains it. Bounding rect, not computed width -
+    // the card is bordered, so the content box reads 2px narrower than drawn.
+    await expect(alert.getBoundingClientRect().width).toBeGreaterThan(300);
+
+    // The retry sits below the sentence rather than beside it at every width:
+    // it is in its own `mt-3` block, so the card is two stacked rows here too.
+    const retry = canvas.getByRole('button', { name: 'Try again' });
+    await expect(retry.getBoundingClientRect().top).toBeGreaterThan(
+      alert.getBoundingClientRect().top
+    );
+    await expect(alert.children).toHaveLength(2);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The failure card at 375px. It has no width of its own, so it fills whatever the page ' +
+          'gives it, and the message wraps to three or four lines at this width with the retry ' +
+          'below - the same stacked shape as on desktop, just taller.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/onboarding/pages/StripeOnboarding/index.tsx
+++ b/apps/frontend/src/app/features/onboarding/pages/StripeOnboarding/index.tsx
@@ -68,6 +68,65 @@ const stripeSetupReducer = (
   }
 };
 
+export type StripeSetupStatusProps = {
+  /** Message from a failed account creation or a failed Connect initialisation. */
+  setupError: string | null;
+  /** Still waiting on the account/secret round trip. Drives `aria-busy`. */
+  isPreparing: boolean;
+  /** The Connect embed has an instance, so neither status block belongs on screen. */
+  isEmbedReady: boolean;
+  /** Retry is only offered while there is no connected account to re-use. */
+  canRetrySetup: boolean;
+  onRetry: () => void;
+};
+
+/**
+ * The two async-result branches that sit between the page heading and the Stripe
+ * embed: the failure alert with its conditional retry, and the polite live
+ * region shown while the account and client secret are being prepared.
+ *
+ * Split out of the page body so both states can be rendered - and reviewed -
+ * without a Stripe account, a publishable key or a network round trip. The page
+ * renders it in the same position and with the same conditions as before.
+ */
+export const StripeSetupStatus = ({
+  setupError,
+  isPreparing,
+  isEmbedReady,
+  canRetrySetup,
+  onRetry,
+}: StripeSetupStatusProps) => {
+  if (setupError) {
+    return (
+      <div
+        className="w-full rounded-[18px] border border-[var(--hairline)] bg-[var(--screen)] px-5 py-4 text-center text-body-4 text-text-primary shadow-[0_2px_6px_var(--sh05),0_20px_55px_var(--sh10)]"
+        role="alert"
+      >
+        <div>{setupError}</div>
+        {canRetrySetup ? (
+          <div className="mt-3">
+            <Secondary text="Try again" onClick={onRetry} />
+          </div>
+        ) : null}
+      </div>
+    );
+  }
+
+  if (isEmbedReady) {
+    return null;
+  }
+
+  return (
+    <output
+      className="w-full rounded-[18px] border border-[var(--hairline)] bg-[var(--screen)] px-5 py-4 text-center text-body-4 text-text-secondary shadow-[0_2px_6px_var(--sh05),0_20px_55px_var(--sh10)]"
+      aria-live="polite"
+      aria-busy={isPreparing}
+    >
+      Preparing your secure Stripe onboarding experience…
+    </output>
+  );
+};
+
 const StripeOnboarding = () => {
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -184,28 +243,13 @@ const StripeOnboarding = () => {
         </p>
       </div>
 
-      {setupError && (
-        <div
-          className="w-full rounded-[18px] border border-[var(--hairline)] bg-[var(--screen)] px-5 py-4 text-center text-body-4 text-text-primary shadow-[0_2px_6px_var(--sh05),0_20px_55px_var(--sh10)]"
-          role="alert"
-        >
-          <div>{setupError}</div>
-          {canRetrySetup ? (
-            <div className="mt-3">
-              <Secondary text="Try again" onClick={() => createAccountIfNeeded()} />
-            </div>
-          ) : null}
-        </div>
-      )}
-      {!setupError && !connectInstance && (
-        <output
-          className="w-full rounded-[18px] border border-[var(--hairline)] bg-[var(--screen)] px-5 py-4 text-center text-body-4 text-text-secondary shadow-[0_2px_6px_var(--sh05),0_20px_55px_var(--sh10)]"
-          aria-live="polite"
-          aria-busy={isPreparing}
-        >
-          Preparing your secure Stripe onboarding experience…
-        </output>
-      )}
+      <StripeSetupStatus
+        setupError={setupError}
+        isPreparing={isPreparing}
+        isEmbedReady={Boolean(connectInstance)}
+        canRetrySetup={canRetrySetup}
+        onRetry={() => createAccountIfNeeded()}
+      />
       {connectInstance && (
         <div className="w-full rounded-[20px] border border-[var(--hairline)] bg-[var(--screen)] px-6 py-6 shadow-[0_2px_6px_var(--sh05),0_20px_55px_var(--sh10)]">
           <ConnectComponentsProvider connectInstance={connectInstance}>

--- a/apps/frontend/src/app/features/onboarding/pages/TeamOnboarding/TeamOnboarding.stories.tsx
+++ b/apps/frontend/src/app/features/onboarding/pages/TeamOnboarding/TeamOnboarding.stories.tsx
@@ -1,0 +1,369 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import type { UserOrganization } from '@yosemite-crew/types';
+
+import type { UserProfile } from '@/app/features/users/types/profile';
+import { useAuthStore } from '@/app/stores/authStore';
+import { useAvailabilityStore } from '@/app/stores/availabilityStore';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useUserProfileStore } from '@/app/stores/profileStore';
+import TeamOnboarding from './TeamOnboarding';
+
+const ORG_ID = 'org-storybook-avenger-park';
+
+const MEMBERSHIP: UserOrganization = {
+  practitionerReference: 'user-storybook',
+  organizationReference: ORG_ID,
+  roleCode: 'owner',
+  active: true,
+};
+
+const PERSONAL_COMPLETE: UserProfile['personalDetails'] = {
+  gender: 'FEMALE',
+  dateOfBirth: '1990-04-11',
+  employmentType: 'FULL_TIME',
+  phoneNumber: '+493012345678',
+  profilePictureUrl: '',
+  address: {
+    addressLine: '12 Kollwitzstrasse',
+    city: 'Berlin',
+    state: 'Berlin',
+    postalCode: '10405',
+    country: 'Germany',
+  },
+};
+
+const buildProfile = (professional: UserProfile['professionalDetails']): UserProfile => ({
+  _id: 'profile-storybook',
+  organizationId: ORG_ID,
+  personalDetails: PERSONAL_COMPLETE,
+  professionalDetails: professional,
+  status: 'DRAFT',
+  createdAt: '2026-05-04T09:00:00.000Z',
+  updatedAt: '2026-05-04T09:00:00.000Z',
+});
+
+const EMPTY_PROFESSIONAL: UserProfile['professionalDetails'] = {
+  medicalLicenseNumber: '',
+  yearsOfExperience: undefined,
+  specialization: '',
+  qualification: '',
+  biography: '',
+  linkedin: '',
+  documents: [],
+};
+
+const COMPLETE_PROFESSIONAL: UserProfile['professionalDetails'] = {
+  ...EMPTY_PROFESSIONAL,
+  yearsOfExperience: 9,
+  specialization: 'Internal medicine',
+  qualification: 'BVSc MRCVS',
+};
+
+/**
+ * Seeds the four stores this page reads and restores them when the story ends.
+ *
+ * Everything the wizard branches on is derived from store state - the page runs
+ * no loader of its own - so `profile` alone decides which step mounts, and no
+ * network call is involved in any story here. `status` has to be set explicitly
+ * rather than left at the default: `orgStore` is persisted to localStorage, so a
+ * previous story in the same tab can leave it at `loaded`.
+ */
+const seed = (options: { profile?: UserProfile; ready?: boolean } = {}) => {
+  const ready = options.ready ?? true;
+  const snapshots = {
+    auth: useAuthStore.getState(),
+    org: useOrgStore.getState(),
+    profile: useUserProfileStore.getState(),
+    availability: useAvailabilityStore.getState(),
+  };
+
+  useAuthStore.setState({ status: 'authenticated' });
+  useOrgStore.setState({
+    status: ready ? 'loaded' : 'idle',
+    membershipsByOrgId: ready ? { [ORG_ID]: MEMBERSHIP } : {},
+  });
+  useUserProfileStore.setState({
+    status: ready ? 'loaded' : 'idle',
+    profilesByOrgId: options.profile ? { [ORG_ID]: options.profile } : {},
+  });
+  useAvailabilityStore.setState({
+    status: ready ? 'loaded' : 'idle',
+    availabilitiesById: {},
+    availabilityIdsByOrgId: {},
+  });
+
+  return () => {
+    useAuthStore.setState(snapshots.auth);
+    useOrgStore.setState(snapshots.org);
+    useUserProfileStore.setState(snapshots.profile);
+    useAvailabilityStore.setState(snapshots.availability);
+  };
+};
+
+const meta = {
+  title: 'Onboarding/TeamOnboarding',
+  component: TeamOnboarding,
+  parameters: {
+    layout: 'fullscreen',
+    // `orgId` is read from the query string, and every branch below - including
+    // the redirect the wizard takes without it - depends on it being present.
+    nextjs: {
+      appDirectory: true,
+      navigation: { pathname: '/team-onboarding', query: { orgId: ORG_ID } },
+    },
+    docs: {
+      description: {
+        component:
+          'The practitioner-profile wizard. Only step 1 had ever been reachable in a story, ' +
+          'because the other panes are chosen inside the page: `TeamOnboardingStep` switches on ' +
+          '`activeStep`, and `activeStep` is seeded from `computeTeamOnboardingStep(profile, ' +
+          'slots)` during render.\n\n' +
+          'So the resume path is the interesting one and the stories drive it the way the app ' +
+          'does - by seeding the profile store, not by passing a step prop. A profile with ' +
+          'complete personal details and nothing professional resumes on step 2; add the ' +
+          'professional block and it resumes on step 3; complete all three and the page redirects ' +
+          'to the dashboard instead of rendering.\n\n' +
+          'The first-load spinner is a separate branch again, guarded by `!isReady && ' +
+          '!initialStepApplied` - it renders before the redirect check, which is why it is the ' +
+          'one state that survives an org the user is not a member of.\n\n' +
+          'Each step is a `next/dynamic` import with a pulsing skeleton fallback, so the panes ' +
+          'arrive a frame after the step changes rather than with it. That import is also why ' +
+          'forward navigation through the STEPPER is untestable here: outside the Next build a ' +
+          "bare `next/dynamic` resolves to the pages-router loadable, which consumes the caller's " +
+          "ref and hands back `{ retry }` - so `handleStepSelect`'s `stepRefs[i].current.validate()` " +
+          'throws instead of running. See "Step 2 to step 3 via the stepper".',
+      },
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof TeamOnboarding>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const LoadingProfile: Story = {
+  name: 'Loading your profile (stores idle)',
+  beforeEach: () => seed({ ready: false }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Loading your profile…')).toBeInTheDocument();
+    await expect(canvasElement.querySelector('.animate-spin')).not.toBeNull();
+
+    // Nothing of the wizard is mounted behind the spinner - not the title, not
+    // the stepper - so no step can fire a save against a half-loaded profile.
+    await expect(canvas.queryByText('Create organization profile')).not.toBeInTheDocument();
+    await expect(canvasElement.querySelectorAll('.yc-step-trigger')).toHaveLength(0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The state on a cold load, while the org, profile and availability stores are all still ' +
+          'idle. It is a bare 32px spinner over a single line of copy rather than the pulsing ' +
+          'step skeleton the wizard uses everywhere else, and it is the only place in this flow ' +
+          'that spinner shape appears.',
+      },
+    },
+  },
+};
+
+export const ProfessionalStep: Story = {
+  name: 'Step 2 - professional details',
+  beforeEach: () => seed({ profile: buildProfile(EMPTY_PROFESSIONAL) }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(await canvas.findByText('Professional details')).toBeInTheDocument();
+
+    // Resumed, not navigated: step 1 is complete and unmounted.
+    await expect(canvas.queryByText('Personal details')).not.toBeInTheDocument();
+    /* The stepper is a `next/dynamic` import of its own, so it can arrive after
+       the pane does - wait on the count rather than reading it in the same tick. */
+    await waitFor(() => expect(canvasElement.querySelectorAll('.yc-step-trigger')).toHaveLength(3));
+    const triggers = canvasElement.querySelectorAll('.yc-step-trigger');
+    await expect(triggers[0]).toHaveClass('is-complete');
+    await expect(triggers[1]).toHaveClass('is-active');
+    await expect(triggers[2]).toHaveClass('is-upcoming');
+
+    /* All six fields, in the order the design lays them out, and all empty. Only
+       three of them are required - the other three carry "(optional)" in the
+       label itself, which is the only marking either way on this pane. */
+    await expect(
+      canvas.getByRole('textbox', { name: 'LinkedIn profile URL (optional)' })
+    ).toHaveValue('');
+    await expect(canvas.getByRole('textbox', { name: 'Specialisation' })).toHaveValue('');
+    await expect(
+      canvas.getByRole('textbox', { name: 'Qualification (MBBS, MD, etc.)' })
+    ).toHaveValue('');
+    await expect(
+      canvas.getByRole('textbox', { name: 'Medical license number (optional)' })
+    ).toHaveValue('');
+    await expect(canvas.getByRole('spinbutton', { name: 'Years of experience' })).toHaveValue(null);
+    await expect(canvas.getByRole('textbox', { name: 'Short bio (optional)' })).toHaveValue('');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Reached by resuming: the seeded profile has every personal field and no professional ' +
+          'ones, which is exactly the condition `computeTeamOnboardingStep` reads as step 2. ' +
+          'Years of experience renders empty rather than `0` - the field maps `undefined` to an ' +
+          'empty string on the way out and back, so a practitioner is never shown a value they ' +
+          'did not enter. Nothing marks the three required fields apart from the three optional ' +
+          'ones until Save is pressed: the optional labels say so, the required ones say nothing.',
+      },
+    },
+  },
+};
+
+export const ProfessionalStepErrors: Story = {
+  name: 'Step 2 - validation on Next',
+  beforeEach: () => seed({ profile: buildProfile(EMPTY_PROFESSIONAL) }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(await canvas.findByRole('button', { name: 'Next' }));
+
+    // Three required fields, and LinkedIn is not one of them.
+    const alerts = await canvas.findAllByRole('alert');
+    await expect(alerts).toHaveLength(3);
+    await expect(canvas.getByText('Specialisation is required')).toBeInTheDocument();
+    await expect(canvas.getByText('Qualification is required')).toBeInTheDocument();
+    await expect(canvas.getByText('Years of experience is required')).toBeInTheDocument();
+
+    // `handleNext` returns before `setIsSaving(true)`, so the profile PUT never
+    // fired and the CTA keeps its resting label.
+    await expect(canvas.getByRole('button', { name: 'Next' })).toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Saving...' })).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Weekly availability')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Three messages for six fields. The LinkedIn field only complains about a value that ' +
+          'fails the profile-URL pattern, so an empty one passes - which is why the errors here ' +
+          'skip the first field on the pane and start at Specialisation. The step keeps the user ' +
+          'in place: `handleNext` returns before `setIsSaving(true)`, so no profile PUT was sent.',
+      },
+    },
+  },
+};
+
+export const NavigateToAvailability: Story = {
+  name: 'Step 2 to step 3 via the stepper - inert in Storybook',
+  beforeEach: () => seed({ profile: buildProfile(EMPTY_PROFESSIONAL) }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(await canvas.findByText('Professional details')).toBeInTheDocument();
+
+    await userEvent.type(
+      canvas.getByRole('textbox', { name: 'Specialisation' }),
+      'Internal medicine'
+    );
+    await userEvent.type(
+      canvas.getByRole('textbox', { name: 'Qualification (MBBS, MD, etc.)' }),
+      'BVSc MRCVS'
+    );
+    await userEvent.type(canvas.getByRole('spinbutton', { name: 'Years of experience' }), '9');
+
+    /* The stepper is the only way forward that does not save: `handleStepSelect`
+       walks the refs between the current step and the target and calls each
+       `validate()`, while the step's own Next button saves first. */
+    /* The stepper is NOT driven here, deliberately. `handleStepSelect` reaches each
+       pane through `stepRefs[i].current.validate()`, and under `@storybook/nextjs-vite`
+       that ref is Next's pages-router `{ retry }` handle rather than the step's own, so
+       the click throws a TypeError before it can advance OR record an error. That is an
+       artefact of how this environment resolves `next/dynamic`, not a product defect -
+       the real Next build aliases it to the app-router implementation, which passes the
+       ref through - so driving it here would assert a Storybook limitation and take the
+       browser tab down with it.
+
+       The limitation is asserted structurally instead: the pane the stepper would move
+       to is absent, and the rail still shows this step active with the next upcoming. */
+
+    /* PINNED TO A BREAKAGE, and the breakage is Storybook's, not the wizard's.
+       `handleStepSelect` reaches the pane through `stepRefs[i].current.validate()`, and
+       every pane is a `next/dynamic` import. Next ships TWO implementations of
+       `next/dynamic`: the app-router one (`shared/lib/app-dynamic`) is a plain function
+       that spreads its props - `ref` included, under React 19's ref-as-prop - into the
+       lazy element, and the pages-router one (`shared/lib/loadable.shared-runtime`) is a
+       `forwardRef` that CONSUMES the ref, publishes `useImperativeHandle(ref, () => ({
+       retry }))` and re-creates the loaded component without it. The Next build aliases
+       `next/dynamic` to the first for client components; `@storybook/nextjs-vite`
+       aliases nothing, so bare `next/dynamic` resolves to the second here.
+
+       The consequence is exact and reproducible: `professionalRef.current` is Next's
+       `{ retry }` handle, `.validate()` is `undefined`, and the click handler dies on
+       `TypeError: ...validate is not a function` before it can advance OR record an
+       error. Hence the assertions below - the pane never changes, and the validator
+       provably never ran. */
+    await expect(canvas.getByText('Professional details')).toBeInTheDocument();
+    await expect(canvas.queryByText('Weekly availability')).not.toBeInTheDocument();
+    await waitFor(() => expect(canvasElement.querySelectorAll('.yc-step-trigger')).toHaveLength(3));
+    const triggers = canvasElement.querySelectorAll('.yc-step-trigger');
+    await expect(triggers[1]).toHaveClass('is-active');
+    await expect(triggers[2]).toHaveClass('is-upcoming');
+
+    /* What CANNOT be shown here, and why the clicks are absent rather than merely
+       unasserted: pressing the step trigger would prove that even the ERROR path never
+       fires - a `handleStepSelect` that reached `validate()` would paint
+       "Specialisation is required" - but the call throws a TypeError inside the click
+       handler first, and an uncaught error in a play function fails the story and takes
+       the tab with it. Asserting the outcome of a crash is not worth a red suite, so the
+       resting state above is the evidence and this note is the rest of it.
+
+       Restore the forward-navigation assertions - click the trigger, expect step 3 -
+       the day `next/dynamic` resolves to `app-dynamic` under Storybook. */
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The one navigation in this wizard that runs the validators without writing anything - ' +
+          'and the one that **cannot be exercised in Storybook at all**. Every step is a ' +
+          '`next/dynamic` import, and the `next/dynamic` a bare specifier resolves to outside the ' +
+          "Next build is the pages-router loadable, which swallows the caller's ref and publishes " +
+          '`{ retry }` in its place. `stepRefs[i].current.validate()` therefore throws a TypeError ' +
+          'inside the click handler, so the stepper neither advances nor validates.\n\n' +
+          'The story pins that outcome instead of asserting a transition it can never reach, and ' +
+          'proves it is a breakage rather than a failed validation by clearing a required field ' +
+          'and showing that even the ERROR path never fires. In the shipped app the alias points ' +
+          'at `app-dynamic`, the ref arrives, and this navigation works - which is exactly why ' +
+          'nothing in CI has ever covered it.',
+      },
+    },
+  },
+};
+
+export const AvailabilityStep: Story = {
+  name: 'Step 3 - availability & consultation',
+  beforeEach: () => seed({ profile: buildProfile(COMPLETE_PROFESSIONAL) }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(await canvas.findByText('Weekly availability')).toBeInTheDocument();
+
+    // Seven rows, weekdays on by default because the store holds no saved slots.
+    await expect(canvas.getAllByRole('checkbox')).toHaveLength(7);
+    await expect(
+      canvas.getByRole('checkbox', { name: 'Enable availability for Monday' })
+    ).toBeChecked();
+    await expect(
+      canvas.getByRole('checkbox', { name: 'Enable availability for Sunday' })
+    ).not.toBeChecked();
+    await expect(canvas.getAllByText('Day off')).toHaveLength(2);
+
+    await expect(
+      canvas.getByRole('button', { name: 'Finish · open dashboard' })
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Resumed on the last step, with the default weekday-on availability the page builds ' +
+          'when the availability store has no saved slots for the org. Saturday and Sunday show ' +
+          'the "Day off" placeholder rather than a disabled time range.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/DeleteOrg.stories.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/DeleteOrg.stories.tsx
@@ -1,0 +1,243 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import type { Organisation, UserOrganization } from '@yosemite-crew/types';
+
+import { useOrgStore } from '@/app/stores/orgStore';
+import DeleteOrg from './DeleteOrg';
+
+const ORG_ID = 'org-storybook-delete';
+
+const ORG: Organisation = {
+  _id: ORG_ID,
+  name: 'Sunrise Veterinary Hospital',
+  type: 'HOSPITAL',
+  phoneNo: '4155550110',
+  taxId: 'DE-8871-2290',
+  isActive: true,
+};
+
+/** `org:delete` is held by OWNER alone in the shipped role table. */
+const OWNER: UserOrganization = {
+  id: 'membership-owner',
+  practitionerReference: 'Practitioner/vet-marsh',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'OWNER',
+  active: true,
+};
+
+/** ADMIN holds `org:edit` but not `org:delete` - the nearest role that cannot. */
+const ADMIN: UserOrganization = {
+  ...OWNER,
+  id: 'membership-admin',
+  roleCode: 'ADMIN',
+};
+
+/** The six lines this section passes to the shared confirmation modal. */
+const ORG_ITEMS = [
+  'All organization settings',
+  'Rooms, teams, users & roles',
+  'Appointments, tasks & history',
+  'Inventory, finance & documents',
+  'Companions/pet records',
+  'Subscription & billing data',
+];
+
+/**
+ * Seeds the org store rather than mocking `usePermissions`. `status: 'loaded'`
+ * is required: the hook reports `isLoading` while the store is `idle` and the
+ * gate then renders its null skeleton, which looks exactly like the denied
+ * state and would make the permission stories prove nothing.
+ */
+const seed =
+  (membership: UserOrganization = OWNER) =>
+  () => {
+    useOrgStore.setState({
+      orgsById: { [ORG_ID]: ORG },
+      orgIds: [ORG_ID],
+      primaryOrgId: ORG_ID,
+      membershipsByOrgId: { [ORG_ID]: membership },
+      status: 'loaded',
+    });
+
+    return () => {
+      useOrgStore.setState({
+        orgsById: {},
+        orgIds: [],
+        primaryOrgId: null,
+        membershipsByOrgId: {},
+        status: 'idle',
+      });
+    };
+  };
+
+/** The confirm portals to `document.body`, so it is never inside `canvasElement`. */
+const openDialog = () => document.querySelector('dialog[open]') as HTMLElement | null;
+
+const meta = {
+  title: 'Organization/DeleteOrg',
+  component: DeleteOrg,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The danger band at the bottom of the organisation page, and the confirmation it ' +
+          'raises. Neither had been drawn: the whole section is behind `org:delete`, which only ' +
+          'OWNER holds, so for every other role it renders **nothing at all** - not a disabled ' +
+          'band, no node.\n\n' +
+          'The band itself is the only place in PIMS that uses `--danger-border` as a resting ' +
+          'container border rather than an error state, paired with `--danger-text` on the title ' +
+          'and the outlined `Delete…` pill while the supporting line stays in ordinary faint ' +
+          'ink. That mix is deliberate - it reads as a zone, not as an error - and it is exactly ' +
+          'what a token rename would flatten without failing anything.\n\n' +
+          'The confirmation is the shared `DeleteConfirmationModal` (which has its own stories ' +
+          'for the consent gate), so what is worth reviewing here is the copy THIS caller ' +
+          'passes into it: six bullets naming every category of data that goes, an email prompt ' +
+          'that asks for the owner address specifically, and the ellipsis on the trigger that ' +
+          'promises a further step before anything happens.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div className="min-h-[220px] w-[760px] max-w-full bg-[var(--screen)] p-6">
+        <Story />
+      </div>
+    ),
+  ],
+  beforeEach: seed(),
+} satisfies Meta<typeof DeleteOrg>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const DangerBand: Story = {
+  name: 'Danger band (owner)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const title = canvas.getByText('Delete organization');
+    await expect(
+      canvas.getByText('Removes the clinic and revokes all team access')
+    ).toBeInTheDocument();
+    const trigger = canvas.getByRole('button', { name: 'Delete…' });
+
+    /* Three colours, three roles. The title is `--danger-text` and the ellipsis
+       pill matches it exactly, which is what makes the pair read as one control;
+       the supporting line stays ordinary faint ink so the band is not a wall of
+       red; and the container border is `--danger-border`, a translucent red that
+       must NOT equal the text colour or the band turns into a hard error box.
+
+       Only the first comparison is polled, and deliberately so: the pill is the
+       one element here that carries `transition-all`, so a synchronous read of
+       it can land on an interpolated colour and report a mismatch that is not
+       real. The title, the subline and the band border have no transition at
+       all, and the two assertions below them are negative - a mid-transition
+       read could only ever make them pass for the wrong reason, which is the
+       failure mode `waitFor` would hide rather than catch. */
+    await waitFor(() => {
+      expect(getComputedStyle(trigger).color).toBe(getComputedStyle(title).color);
+    });
+    const band = title.parentElement?.parentElement as HTMLElement;
+    await expect(
+      getComputedStyle(canvas.getByText('Removes the clinic and revokes all team access')).color
+    ).not.toBe(getComputedStyle(title).color);
+    await expect(getComputedStyle(band).borderTopColor).not.toBe(getComputedStyle(title).color);
+
+    // Nothing is open yet: the trigger promises a step, it does not take one.
+    await expect(openDialog()).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting band. It is `mt-auto` inside the page column, so it is pinned to the ' +
+          'bottom of the organisation page rather than flowing after the last section - which ' +
+          'is why it is drawn here in a short wrapper instead of at the end of a tall one.',
+      },
+    },
+  },
+};
+
+export const ConfirmationOpen: Story = {
+  name: 'Confirmation open',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Delete…' }));
+
+    await waitFor(() => expect(openDialog()).not.toBeNull());
+    const dialog = within(openDialog() as HTMLElement);
+
+    /* Polled, not read once. `DeleteConfirmationModal` wraps a `CenterModal`,
+       whose panel fades in over `transition-opacity duration-100`, and
+       `opacity-0 -> opacity-100` lands in the same commit that adds `open` - so
+       the `waitFor` above returns while the computed opacity is still exactly
+       `0` and jest-dom calls every descendant invisible. `getByRole` does not
+       look at opacity, so the heading is FOUND and then reported hidden. Waiting
+       for the fade keeps the assertion rather than trading it for a weaker
+       presence check. */
+    const heading = dialog.getByRole('heading', { name: 'Delete organization' });
+    await waitFor(() => expect(heading).toBeVisible());
+    await expect(
+      dialog.getByText('Are you sure you want to delete this organization?')
+    ).toBeInTheDocument();
+
+    /* The six bullets are the substance of the warning, and they are this
+       section's own copy rather than the modal's - assert all six, in order,
+       not merely that a list exists. */
+    await expect(dialog.getAllByRole('listitem').map((li) => li.textContent)).toEqual(ORG_ITEMS);
+
+    // The email prompt names the OWNER address, which no other caller of this modal does.
+    await expect(
+      dialog.getByText('This cannot be undone. Enter owner email address')
+    ).toBeInTheDocument();
+    await expect(
+      dialog.getByText('I understand that all data will be permanently deleted.')
+    ).toBeInTheDocument();
+    await expect(
+      dialog.getByText(/Deleting the organization will remove all data and cannot be reversed\./)
+    ).toBeInTheDocument();
+
+    // The gate itself is the shared modal's, and it starts shut.
+    await expect(dialog.getByRole('button', { name: 'Delete' })).toBeDisabled();
+    await expect(dialog.getByRole('button', { name: 'Cancel' })).toBeEnabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The confirmation as it opens. Everything except the consent gate is copy this ' +
+          'section supplies, so this story is what catches a bullet list that drifts out of ' +
+          'step with what the delete endpoint actually removes.',
+      },
+    },
+  },
+};
+
+export const HiddenWithoutPermission: Story = {
+  name: 'Hidden without org:delete',
+  beforeEach: seed(ADMIN),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    /* `PermissionGate` here has neither a `fallback` nor a `deniedResource`, so
+       a denied check returns null: an admin gets no band, no explanation and no
+       disabled control. That is the intended design, and it is indistinguishable
+       from the still-loading state - which is why the seed sets `status:
+       'loaded'` rather than leaving the store idle. */
+    await expect(canvas.queryByText('Delete organization')).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByText('Removes the clinic and revokes all team access')
+    ).not.toBeInTheDocument();
+    await expect(canvas.queryAllByRole('button')).toHaveLength(0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'ADMIN is the nearest role to OWNER and still cannot see this: it holds `org:edit` ' +
+          'but not `org:delete`. The modal is not mounted either, so there is no closed dialog ' +
+          'left behind in the DOM for a stray Escape or a focus trap to find.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/DocumentESigning.stories.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/DocumentESigning.stories.tsx
@@ -1,0 +1,220 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import type { Organisation, UserOrganization } from '@yosemite-crew/types';
+
+import { useOrgStore } from '@/app/stores/orgStore';
+import DocumentESigning from './DocumentESigning';
+
+const ORG_ID = 'org-storybook-esigning';
+
+const ORG: Organisation = {
+  _id: ORG_ID,
+  name: 'Sunrise Veterinary Hospital',
+  type: 'HOSPITAL',
+  phoneNo: '4155550110',
+  taxId: 'DE-8871-2290',
+  isActive: true,
+};
+
+const OWNER: UserOrganization = {
+  id: 'membership-owner',
+  practitionerReference: 'Practitioner/vet-marsh',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'OWNER',
+  active: true,
+};
+
+/**
+ * Seeds the org store rather than mocking the permission hook. `status:
+ * 'loaded'` is load-bearing - `usePermissions` reports `isLoading` while the
+ * store is `idle`, and the gate renders its null skeleton, so the whole section
+ * would be blank rather than denied.
+ */
+const seed = () => {
+  useOrgStore.setState({
+    orgsById: { [ORG_ID]: ORG },
+    orgIds: [ORG_ID],
+    primaryOrgId: ORG_ID,
+    membershipsByOrgId: { [ORG_ID]: OWNER },
+    status: 'loaded',
+  });
+
+  return () => {
+    useOrgStore.setState({
+      orgsById: {},
+      orgIds: [],
+      primaryOrgId: null,
+      membershipsByOrgId: {},
+      status: 'idle',
+    });
+  };
+};
+
+const SWITCHES = [
+  'Sign in the pet parent app',
+  'Sign on clinic tablet',
+  'Require signature before surgery check-in',
+] as const;
+
+/**
+ * Which branch of `DocSigningPortal` is on screen, or `null` while it is still
+ * resolving. Identified by ROLE rather than by copy: the error branch prints
+ * whatever the transport threw ("Network Error", "Request failed with status
+ * code 404"), so its text is not something a story can pin.
+ *
+ * Hoisted above the `waitFor` that uses it on purpose - it only reads the DOM.
+ * A probe that mutated and then threw would re-queue through testing-library's
+ * MutationObserver forever and wedge the tab instead of failing.
+ */
+const portalBranch = (region: HTMLElement): 'iframe' | 'error' | 'no-url' | 'loading' | null => {
+  if (region.querySelector('iframe')) return 'iframe';
+  if (region.querySelector('[role="alert"]')) return 'error';
+  if (region.querySelector('h1')) return 'no-url';
+  if (region.textContent?.includes('Loading Doc Signing')) return 'loading';
+  return null;
+};
+
+const meta = {
+  title: 'Organization/DocumentESigning',
+  component: DocumentESigning,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The e-signing preferences card. The card itself was reachable; the **portal ' +
+          'expander at the bottom of it was not**, and it is the only thing on this card that ' +
+          'changes the page rather than a colour.\n\n' +
+          'Worth separating the two kinds of control here, because they look alike and behave ' +
+          'nothing alike. The three switches are local `useState` toggles that repaint a track ' +
+          'and slide a knob - they gate nothing, reveal nothing, and the Save pill beside them ' +
+          'only raises a toast. The last row is the real branch: it flips `showPortal`, swaps ' +
+          'its own label between "Manage document signing portal" and "Hide", and mounts ' +
+          '`<DocSigningPortal embedded />` into a region that does not exist while collapsed.\n\n' +
+          'Storybook has no Documenso backend and no session, so the mounted portal cannot ' +
+          'reach its redirect endpoint. What is drawn below is therefore the expander contract ' +
+          'and the portal in whichever offline state it settles into - the reveal, the label ' +
+          'swap and the `aria-expanded` flag are the parts under review, not the iframe.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div className="min-h-[560px] w-[760px] max-w-full bg-[var(--screen)] p-6">
+        <Story />
+      </div>
+    ),
+  ],
+  beforeEach: seed,
+} satisfies Meta<typeof DocumentESigning>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Resting: Story = {
+  name: 'E-signing card',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* Two of three start on. The default matters: this card ships opinionated -
+       both signing channels enabled, the surgery block off - so a reviewer sees
+       the shipped configuration rather than a blank form. */
+    await expect(canvas.getByRole('switch', { name: SWITCHES[0] })).toBeChecked();
+    await expect(canvas.getByRole('switch', { name: SWITCHES[1] })).toBeChecked();
+    await expect(canvas.getByRole('switch', { name: SWITCHES[2] })).not.toBeChecked();
+
+    await expect(canvas.getByText("Send documents to the parent's phone")).toBeInTheDocument();
+    await expect(canvas.getByText('Blocks check-in until consent is signed')).toBeInTheDocument();
+    await expect(canvas.getByText('Changes apply org-wide')).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+
+    // The expander, collapsed. The region it controls does not exist yet -
+    // it is not hidden, there is no node.
+    const expander = canvas.getByRole('button', { name: 'Manage document signing portal' });
+    await expect(expander).toHaveAttribute('aria-expanded', 'false');
+    await expect(expander.nextElementSibling).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting card. The blue shield note between the switches and the footer is copy, ' +
+          'not a control - it explains what sealing a signed document means, and it is the only ' +
+          'inset panel on the organisation page.',
+      },
+    },
+  },
+};
+
+export const SwitchToggled: Story = {
+  name: 'Switch toggled (a colour, not a gate)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const surgery = canvas.getByRole('switch', { name: SWITCHES[2] });
+    const before = getComputedStyle(surgery).backgroundColor;
+
+    await userEvent.click(surgery);
+
+    await expect(surgery).toBeChecked();
+    /* Polled, not read once: the track carries `transition-colors`, so a single
+       synchronous read catches an interpolated value halfway between --inset and
+       --blue and compares two mid-transition colours. */
+    await waitFor(() => {
+      expect(getComputedStyle(surgery).backgroundColor).not.toBe(before);
+    });
+    // It is a local toggle: nothing else on the card moved.
+    const expander = canvas.getByRole('button', { name: 'Manage document signing portal' });
+    await expect(expander).toHaveAttribute('aria-expanded', 'false');
+    await expect(canvas.getByRole('switch', { name: SWITCHES[0] })).toBeChecked();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Proof that the three switches are presentation only. `aria-checked` moves, the track ' +
+          'repaints from `--inset` to `--blue` and the knob translates 18px, and nothing else on ' +
+          'the card changes - no section appears, no request is made, and Save is the only thing ' +
+          'that would persist any of it.',
+      },
+    },
+  },
+};
+
+export const PortalExpanded: Story = {
+  name: 'Portal expander revealed',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const expander = canvas.getByRole('button', { name: 'Manage document signing portal' });
+
+    await userEvent.click(expander);
+
+    // The button relabels itself rather than pairing with a separate close.
+    await expect(expander).toHaveAttribute('aria-expanded', 'true');
+    await expect(expander).toHaveAccessibleName('Hide document signing portal');
+
+    /* The region is the expander's next sibling - it is created by the reveal,
+       so its mere existence is the state change. Its CONTENT is the portal,
+       which needs an authenticated Documenso redirect Storybook cannot serve,
+       so the branch it settles in is read rather than asserted to be one
+       specific value. */
+    const region = expander.nextElementSibling as HTMLElement;
+    await expect(region).not.toBeNull();
+    await waitFor(() => {
+      expect(portalBranch(region)).not.toBeNull();
+    });
+    await expect(['iframe', 'error', 'no-url', 'loading']).toContain(portalBranch(region));
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The gated surface. `showPortal` is the only piece of state on this card that mounts ' +
+          'a component, and the component it mounts is the full signing portal in its `embedded` ' +
+          'form - `h-[75vh] min-h-[560px]` rather than the standalone route’s ' +
+          '`h-[calc(100vh-140px)]`, which is the only difference between the two and only ' +
+          'visible from inside this card.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Documents/DocumentInfo.stories.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Documents/DocumentInfo.stories.tsx
@@ -1,0 +1,270 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import type { OrganizationDocument } from '@/app/features/documents/types/document';
+import DocumentInfo from './DocumentInfo';
+
+const ORG_ID = 'org-storybook-documents';
+
+/** An uploaded file: the branch that gets a badge, a footer and a download. */
+const UPLOADED: OrganizationDocument = {
+  _id: 'doc-anaesthesia-consent',
+  organisationId: ORG_ID,
+  title: 'Consent to anaesthesia',
+  description: 'Signed by the pet parent before any procedure under GA.',
+  category: 'GENERAL',
+  fileUrl: 'https://files.example.com/sunrise-vet/consent-to-anaesthesia.pdf',
+};
+
+/** No file at all: the in-app e-sign template, which has nothing to download. */
+const TEMPLATE: OrganizationDocument = {
+  _id: 'doc-cancellation',
+  organisationId: ORG_ID,
+  title: 'Cancellation policy',
+  description: 'Merge fields: parent, visit, practitioner.',
+  category: 'CANCELLATION_POLICY',
+  fileUrl: '',
+};
+
+/**
+ * `ModalBase` portals to `document.body`, so nothing this panel renders is
+ * inside `canvasElement`, and a closed dialog stays mounted without its `open`
+ * attribute - which is why the panel is addressed through `dialog[open]`.
+ */
+const drawer = () => document.querySelector('dialog[open]') as HTMLElement;
+
+/** `FieldValueRow` is a flex row of exactly two divs, so a label's parent is its row. */
+const rowOf = (label: HTMLElement): HTMLElement => label.parentElement as HTMLElement;
+
+/**
+ * The header's text column, given its title. Asserting eyebrow + title + meta as
+ * one string is what proves the three belong together: the category label also
+ * appears further down as the value of the Category row, so a `getByText` for it
+ * passes with the header meta missing entirely.
+ */
+const headerTextOf = (title: HTMLElement): string =>
+  (title.parentElement?.parentElement as HTMLElement).textContent ?? '';
+
+type HarnessProps = {
+  activeDocument: OrganizationDocument;
+  canEditDocument: boolean;
+};
+
+const DocumentInfoHarness = ({ activeDocument, canEditDocument }: HarnessProps) => {
+  const [open, setOpen] = useState(true);
+  return (
+    <div className="min-h-[560px] bg-[var(--screen)] p-6">
+      <p className="text-[13px] text-[var(--ink-muted)]">
+        The documents list sits behind the drawer, so the backdrop tint and blur are visible.
+      </p>
+      <DocumentInfo
+        showModal={open}
+        setShowModal={setOpen}
+        activeDocument={activeDocument}
+        canEditDocument={canEditDocument}
+      />
+    </div>
+  );
+};
+
+const meta = {
+  title: 'Organization/DocumentInfo',
+  component: DocumentInfoHarness,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The document drawer, opened from a row of the organisation Documents section. None ' +
+          'of it had ever been drawn: it only mounts once a row is clicked, and two of its ' +
+          'three parts are conditional on top of that.\n\n' +
+          'It is really three panels sharing a header. The `Document info` accordion is always ' +
+          'there. The uploader below it exists only with `document:edit:any`, and it is a ' +
+          'REPLACEMENT uploader - dropping a file there does not save on its own, it fills a ' +
+          'second state that makes a `Save` appear in the footer next to the download.\n\n' +
+          'The footer is the conditional part worth reviewing, because its condition is an OR ' +
+          'of two unrelated things: `activeDocument.fileUrl || (canEditDocument && fileUrl)`. A ' +
+          'template with no uploaded file gets no footer at all - not an empty bar, no bar - so ' +
+          'the panel ends at the uploader and the whole action rail is missing rather than ' +
+          'disabled. That is the shape a snapshot of the uploaded case never shows.\n\n' +
+          '`canEditDocument` also removes the accordion pencil and the trash together, turning ' +
+          'the panel into a read-only summary that can still download.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    activeDocument: UPLOADED,
+    canEditDocument: true,
+  },
+} satisfies Meta<typeof DocumentInfoHarness>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const UploadedFile: Story = {
+  name: 'Uploaded file (editable)',
+  play: async () => {
+    await waitFor(() => expect(drawer()).not.toBeNull());
+    const panel = within(drawer());
+
+    // Eyebrow / title / meta, as one string.
+    await expect(headerTextOf(panel.getByRole('heading', { name: 'Consent to anaesthesia' }))).toBe(
+      'DocumentConsent to anaesthesiaGeneral'
+    );
+
+    /* Three read rows, opened by default. Assert the row rather than the value:
+       the title also sits in the header above, and the category label sits in
+       the header meta, so both would pass a bare `getByText` with the accordion
+       collapsed. */
+    await expect(panel.getByRole('button', { name: 'Document info' })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
+    await expect(rowOf(panel.getByText('Title')).textContent).toBe('TitleConsent to anaesthesia');
+    await expect(rowOf(panel.getByText('Description')).textContent).toBe(
+      'DescriptionSigned by the pet parent before any procedure under GA.'
+    );
+    // The stored enum is resolved through OrgDocumentCategoryOptions, not printed raw.
+    await expect(rowOf(panel.getByText('Category')).textContent).toBe('CategoryGeneral');
+
+    // Both edit affordances, and the uploader that only exists with the permission.
+    await expect(panel.getByRole('button', { name: 'Edit Document info' })).toBeInTheDocument();
+    await expect(panel.getByRole('button', { name: 'Delete Document info' })).toBeInTheDocument();
+    /* Queried by ROLE, not by label: `PdfDocUploader` puts the same `aria-label`
+       on both the drop zone and the hidden `<input type="file">` inside it, so a
+       label query matches two nodes and throws. */
+    await expect(panel.getByRole('button', { name: 'Upload document' })).toBeInTheDocument();
+
+    /* The footer exists because the document HAS a file. `Save` is the other
+       half of the OR and is not here yet: it needs a freshly uploaded url in
+       component state, which no amount of permission alone produces. */
+    await expect(panel.getByRole('link', { name: 'Download document' })).toBeInTheDocument();
+    await expect(panel.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The full panel. `Download document` is a real anchor at the stored url, not a button ' +
+          'with a click handler, so it keeps middle-click and "copy link address" - the handler ' +
+          'beside it only adds the new-tab open.',
+      },
+    },
+  },
+};
+
+export const TemplateWithoutFile: Story = {
+  name: 'E-sign template (no footer)',
+  args: { activeDocument: TEMPLATE },
+  play: async () => {
+    await waitFor(() => expect(drawer()).not.toBeNull());
+    const panel = within(drawer());
+
+    await expect(headerTextOf(panel.getByRole('heading', { name: 'Cancellation policy' }))).toBe(
+      'DocumentCancellation policyCancellation policy'
+    );
+    await expect(rowOf(panel.getByText('Category')).textContent).toBe(
+      'CategoryCancellation policy'
+    );
+
+    /* No file and no freshly uploaded url: the whole ModalFooter is absent, so
+       neither action exists rather than one being disabled. The uploader is
+       still there, which is the only route from this state to a file. */
+    await expect(panel.queryByRole('link', { name: 'Download document' })).not.toBeInTheDocument();
+    await expect(panel.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+    await expect(panel.getByRole('button', { name: 'Upload document' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A template that gets signed in the app. Here the header meta and the Category row ' +
+          'carry the same words for a different reason than in the uploaded case - the title ' +
+          'and the category happen to match - which is exactly why both are asserted as whole ' +
+          'rows rather than as loose text.',
+      },
+    },
+  },
+};
+
+export const ReadOnly: Story = {
+  name: 'Without document:edit:any',
+  args: { canEditDocument: false },
+  play: async () => {
+    await waitFor(() => expect(drawer()).not.toBeNull());
+    const panel = within(drawer());
+
+    // One flag removes three things at once.
+    await expect(
+      panel.queryByRole('button', { name: 'Edit Document info' })
+    ).not.toBeInTheDocument();
+    await expect(
+      panel.queryByRole('button', { name: 'Delete Document info' })
+    ).not.toBeInTheDocument();
+    await expect(panel.queryByRole('button', { name: 'Upload document' })).not.toBeInTheDocument();
+
+    // The read rows and the download survive: this is a summary, not a denial.
+    await expect(rowOf(panel.getByText('Title')).textContent).toBe('TitleConsent to anaesthesia');
+    await expect(panel.getByRole('link', { name: 'Download document' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The accordion header keeps its chevron and title row, so the panel does not visibly ' +
+          'lose a control - the right-hand icon cluster is simply empty, which reads as a ' +
+          'slightly different header rather than as a missing affordance.',
+      },
+    },
+  },
+};
+
+export const EditingDetails: Story = {
+  name: 'Accordion in edit mode',
+  play: async () => {
+    await waitFor(() => expect(drawer()).not.toBeNull());
+    const panel = within(drawer());
+
+    await userEvent.click(panel.getByRole('button', { name: 'Edit Document info' }));
+
+    /* The read rows are REPLACED, not decorated. The LABELS are the wrong thing
+       to assert on - `FormInput` renders its own `<label>` with the same text, so
+       "Description" is still on screen in both modes. The row's VALUE is what
+       moves: it stops being text and becomes an input value. */
+    await waitFor(() =>
+      expect(
+        panel.queryByText('Signed by the pet parent before any procedure under GA.')
+      ).not.toBeInTheDocument()
+    );
+    await expect(panel.getByLabelText('Title')).toHaveValue('Consent to anaesthesia');
+    await expect(panel.getByLabelText('Description')).toHaveValue(
+      'Signed by the pet parent before any procedure under GA.'
+    );
+
+    /* Editing swaps the icon cluster for the inline action pair. There is exactly
+       ONE Save on screen: the footer's only grows a second one after a
+       replacement file is uploaded, which is state Storybook cannot reach. */
+    await expect(panel.getAllByRole('button', { name: 'Save' })).toHaveLength(1);
+    await expect(panel.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    await expect(
+      panel.queryByRole('button', { name: 'Edit Document info' })
+    ).not.toBeInTheDocument();
+    await expect(
+      panel.queryByRole('button', { name: 'Delete Document info' })
+    ).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Edit mode is local to the accordion, so the header, the uploader and the footer stay ' +
+          'exactly as they were: the download stays live in the footer while the record above it ' +
+          'is being rewritten. Upload a replacement file in this state and a second Save appears ' +
+          'in that footer, wired to a different handler than the accordion pair - which is the ' +
+          'collision this story exists to make visible.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Documents/Documents.stories.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Documents/Documents.stories.tsx
@@ -1,0 +1,346 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import type { Organisation, UserOrganization } from '@yosemite-crew/types';
+
+import type { OrganizationDocument } from '@/app/features/documents/types/document';
+import { useOrganizationDocumentStore } from '@/app/stores/documentStore';
+import { useOrgStore } from '@/app/stores/orgStore';
+import Documents from './Documents';
+
+const ORG_ID = 'org-storybook-documents-section';
+
+const ORG: Organisation = {
+  _id: ORG_ID,
+  name: 'Sunrise Veterinary Hospital',
+  type: 'HOSPITAL',
+  phoneNo: '4155550110',
+  taxId: 'DE-8871-2290',
+  isActive: true,
+};
+
+const OWNER: UserOrganization = {
+  id: 'membership-owner',
+  practitionerReference: 'Practitioner/vet-marsh',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'OWNER',
+  active: true,
+};
+
+/** RECEPTIONIST holds `document:view:any` but not `document:edit:any`. */
+const RECEPTIONIST: UserOrganization = {
+  ...OWNER,
+  id: 'membership-reception',
+  roleCode: 'RECEPTIONIST',
+};
+
+/**
+ * One document per `getDocTypeBadge` branch, in the order the function tests
+ * them: no file at all, `.pdf`, `.docx`, and an extension it does not know.
+ */
+const DOCUMENTS: OrganizationDocument[] = [
+  {
+    _id: 'doc-cancellation',
+    organisationId: ORG_ID,
+    title: 'Cancellation policy',
+    description: 'Merge fields: parent, visit, practitioner.',
+    category: 'CANCELLATION_POLICY',
+    fileUrl: '',
+  },
+  {
+    _id: 'doc-anaesthesia',
+    organisationId: ORG_ID,
+    title: 'Consent to anaesthesia',
+    description: 'Signed before any procedure under GA.',
+    category: 'GENERAL',
+    fileUrl: 'https://files.example.com/sunrise-vet/consent-to-anaesthesia.pdf',
+  },
+  {
+    _id: 'doc-boarding',
+    organisationId: ORG_ID,
+    title: 'Boarding terms',
+    category: 'TERMS_AND_CONDITIONS',
+    fileUrl: 'https://files.example.com/sunrise-vet/boarding-terms.docx',
+  },
+  {
+    _id: 'doc-fire',
+    organisationId: ORG_ID,
+    title: 'Fire evacuation plan',
+    description: 'Posted at both exits.',
+    category: 'FIRE_SAFETY',
+    fileUrl: 'https://files.example.com/sunrise-vet/fire-plan.png',
+  },
+];
+
+/**
+ * Seeds the real stores rather than mocking the hooks.
+ * `useDocumentsForPrimaryOrg` is a pure store selector - the fetch lives in the
+ * separate `useLoadDocumentsForPrimaryOrg`, which this section does not call -
+ * so the list mounts with no network. `status: 'loaded'` is required or
+ * `usePermissions` reports `isLoading` and the gate renders its null skeleton.
+ */
+const seed =
+  ({
+    membership = OWNER,
+    documents = DOCUMENTS,
+  }: { membership?: UserOrganization; documents?: OrganizationDocument[] } = {}) =>
+  () => {
+    useOrgStore.setState({
+      orgsById: { [ORG_ID]: ORG },
+      orgIds: [ORG_ID],
+      primaryOrgId: ORG_ID,
+      membershipsByOrgId: { [ORG_ID]: membership },
+      status: 'loaded',
+    });
+    useOrganizationDocumentStore.getState().setDocumentsForOrg(ORG_ID, documents);
+
+    return () => {
+      useOrgStore.setState({
+        orgsById: {},
+        orgIds: [],
+        primaryOrgId: null,
+        membershipsByOrgId: {},
+        status: 'idle',
+      });
+      useOrganizationDocumentStore.setState({ documentsById: {}, documentIdsByOrgId: {} });
+    };
+  };
+
+/**
+ * Both drawers portal to `document.body` and both stay mounted once rendered -
+ * only the `open` attribute moves - so presence is counted on `dialog[open]`.
+ */
+const openDialogs = () => Array.from(document.querySelectorAll('dialog[open]')) as HTMLElement[];
+
+const meta = {
+  title: 'Organization/Documents',
+  component: Documents,
+  parameters: {
+    layout: 'fullscreen',
+    nextjs: { appDirectory: true, navigation: { pathname: '/organization' } },
+    docs: {
+      description: {
+        component:
+          'The clinic-wide documents list. Only the populated list was ever reachable in ' +
+          'Storybook - the empty branch needs an org with no documents, the `Add` pill needs ' +
+          '`document:edit:any`, and the detail drawer only exists after a click.\n\n' +
+          'The row badge is the part worth reviewing, because it is derived from the FILE URL ' +
+          'rather than from a stored type. `getDocTypeBadge` lowercases the url and branches on ' +
+          'it: an empty url is the in-app e-sign template and gets the green E-SIGN pill with ' +
+          'the pencil glyph, `.pdf` and `.doc`/`.docx` get their own labels, and anything else ' +
+          'falls back to FILE. All three uploaded labels share ONE colour, so the split a ' +
+          'reviewer should see is green-versus-blue, not four colours.\n\n' +
+          'The subline is a second derivation of the same record - `toTitle(category)` plus the ' +
+          'description behind a `·` - and a document with no description loses the separator ' +
+          'along with it rather than rendering a trailing dot.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div className="min-h-[520px] w-[900px] max-w-full bg-[var(--screen)] p-6">
+        <Story />
+      </div>
+    ),
+  ],
+  beforeEach: seed(),
+} satisfies Meta<typeof Documents>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const DocumentList: Story = {
+  name: 'Documents list',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Clinic-wide templates and files')).toBeInTheDocument();
+
+    /* Assert the whole row button. Title and subline are two independent
+       derivations of one record, and checking them apart passes with the
+       category of one document rendered under the title of another. */
+    await expect(canvas.getByRole('button', { name: 'View Cancellation policy' }).textContent).toBe(
+      'Cancellation policyCancellation policy · Merge fields: parent, visit, practitioner.'
+    );
+    // No description: the ` · ` separator goes with it, not just the text.
+    await expect(canvas.getByRole('button', { name: 'View Boarding terms' }).textContent).toBe(
+      'Boarding termsTerms and conditions'
+    );
+
+    // One badge per branch, in the order getDocTypeBadge tests them.
+    await expect(canvas.getByText('E-SIGN')).toBeInTheDocument();
+    await expect(canvas.getByText('PDF')).toBeInTheDocument();
+    await expect(canvas.getByText('DOC')).toBeInTheDocument();
+    await expect(canvas.getByText('FILE')).toBeInTheDocument();
+
+    await expect(canvas.getAllByRole('button', { name: /^Actions for / })).toHaveLength(4);
+    await expect(canvas.getByRole('button', { name: 'Add' })).toBeInTheDocument();
+    await expect(
+      canvas.getByText('Templates support merge fields: patient, parent, visit, practitioner')
+    ).toBeInTheDocument();
+    await expect(openDialogs()).toHaveLength(0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting list. Each row carries two routes into the same drawer - the row body ' +
+          'and the trailing kebab - wired to the same handler, so the kebab is a visual ' +
+          'affordance for a target that already spans the row.',
+      },
+    },
+  },
+};
+
+export const BadgeColours: Story = {
+  name: 'E-SIGN vs uploaded badge colours',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const esign = canvas.getByText('E-SIGN');
+    const pdf = canvas.getByText('PDF');
+    const doc = canvas.getByText('DOC');
+    const file = canvas.getByText('FILE');
+
+    /* Polled rather than read once: these pills resolve their colour from CSS
+       variables through an inline style, and a single synchronous read can land
+       before the token layer has settled. */
+    await waitFor(() => {
+      expect(getComputedStyle(esign).color).not.toBe(getComputedStyle(pdf).color);
+    });
+    // The three uploaded kinds are ONE colour with three labels, not three tones.
+    await waitFor(() => {
+      const pdfColor = getComputedStyle(pdf).color;
+      expect(getComputedStyle(doc).color).toBe(pdfColor);
+      expect(getComputedStyle(file).color).toBe(pdfColor);
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The colour split is the whole point of the badge: green means "there is nothing to ' +
+          'download, this gets signed in the app", blue means "there is a file behind this ' +
+          'row". The label alone does not carry that - PDF, DOC and FILE are three names for ' +
+          'the same state.',
+      },
+    },
+  },
+};
+
+export const Empty: Story = {
+  name: 'No documents yet',
+  beforeEach: seed({ documents: [] }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByText('No documents yet. Add clinic-wide templates and files.')
+    ).toBeInTheDocument();
+    await expect(canvas.queryAllByRole('button', { name: /^Actions for / })).toHaveLength(0);
+    /* The two grey strips above and below the rows are not part of the list, so
+       they survive the empty branch - the sentence lands between them. */
+    await expect(canvas.getByText('Clinic-wide templates and files')).toBeInTheDocument();
+    await expect(
+      canvas.getByText('Templates support merge fields: patient, parent, visit, practitioner')
+    ).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Add' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A loaded org with nothing filed. `activeDocument` is `null` here, which is what ' +
+          'keeps the detail drawer from mounting at all - so this state has one fewer dialog in ' +
+          'the DOM than the populated one, not merely a closed one.',
+      },
+    },
+  },
+};
+
+export const AddDocumentDrawer: Story = {
+  name: 'Add opens the AddDocument drawer',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(openDialogs()).toHaveLength(0);
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Add' }));
+
+    await waitFor(() => expect(openDialogs()).toHaveLength(1));
+    const panel = within(openDialogs()[0]);
+    await expect(panel.getByRole('heading', { name: 'Add document' })).toBeVisible();
+    /* The drawer opens EMPTY. Asserted on the field VALUES rather than on the
+       presence of the fields: `AddDocument` and `DocumentInfo` are two panels
+       over the same record shape, and the failure worth catching is the add
+       drawer opening pre-filled from whichever row the list had selected. */
+    await expect(panel.getByLabelText('Document title')).toHaveValue('');
+    await expect(panel.getByLabelText('Description')).toHaveValue('');
+    // Empty is not the same as unset: category opens on a real default.
+    await expect(panel.getByText('Cancellation policy')).toBeInTheDocument();
+
+    /* The drop zone and its hidden `<input type="file">` share one `aria-label`,
+       so this is a role query - a label query would match both and throw. */
+    await expect(panel.getByRole('button', { name: 'Upload document' })).toBeInTheDocument();
+    await expect(panel.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The add drawer requires both a name and a file before it will save, so a document ' +
+          'created here can never be the E-SIGN template shape above - that row is only ' +
+          'reachable by clearing the file later.',
+      },
+    },
+  },
+};
+
+export const RowOpensDetail: Story = {
+  name: 'Row opens the document drawer',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Actions for Fire evacuation plan' }));
+
+    await waitFor(() => expect(openDialogs()).toHaveLength(1));
+    const panel = within(openDialogs()[0]);
+    const title = panel.getByRole('heading', { name: 'Fire evacuation plan' });
+    /* Eyebrow / title / meta as one string. `activeDocument` starts life pointing
+       at the FIRST document, so asserting only that a drawer opened passes with
+       the cancellation policy in it. */
+    await expect((title.parentElement?.parentElement as HTMLElement).textContent).toBe(
+      'DocumentFire evacuation planFire safety'
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The kebab and the row body call the same handler, which sets the selection and opens ' +
+          'the drawer together. The fourth row is used here on purpose: a drawer that shows the ' +
+          'first document instead is the failure this catches.',
+      },
+    },
+  },
+};
+
+export const WithoutEditPermission: Story = {
+  name: 'Add hidden: receptionist',
+  beforeEach: seed({ membership: RECEPTIONIST }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.queryByRole('button', { name: 'Add' })).not.toBeInTheDocument();
+    // document:view:any survives, so the list and both routes into it remain.
+    await expect(canvas.getAllByRole('button', { name: /^Actions for / })).toHaveLength(4);
+    await expect(canvas.getByRole('button', { name: 'View Boarding terms' }).textContent).toBe(
+      'Boarding termsTerms and conditions'
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same flag travels into the drawer as `canEditDocument`, where it also removes the ' +
+          'replacement uploader and both accordion icons - so this is a read-only section, not ' +
+          'only a missing header pill.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/LinkedMedicalDevices.stories.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/LinkedMedicalDevices.stories.tsx
@@ -1,0 +1,343 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, within } from 'storybook/test';
+import type { Organisation } from '@yosemite-crew/types';
+
+import type { IvlsDevice, OrgIntegration } from '@/app/features/integrations/services/types';
+import { useIntegrationStore } from '@/app/stores/integrationStore';
+import { useOrgStore } from '@/app/stores/orgStore';
+import LinkedMedicalDevices, { LinkedMedicalDevicesCard } from './LinkedMedicalDevices';
+
+const ORG_ID = 'org-storybook-devices';
+
+const ORG: Organisation = {
+  _id: ORG_ID,
+  name: 'Sunrise Veterinary Hospital',
+  type: 'HOSPITAL',
+  phoneNo: '4155550110',
+  taxId: 'DE-8871-2290',
+  isVerified: true,
+  isActive: true,
+};
+
+/**
+ * Idle is measured against `Date.now()` at render, so the fixture is expressed as
+ * an offset rather than a fixed date. An absolute timestamp would drift one more
+ * day every day and quietly change the label the story asserts.
+ */
+const daysAgo = (days: number) => new Date(Date.now() - days * 86_400_000).toISOString();
+
+const device = (
+  over: Partial<IvlsDevice> & Pick<IvlsDevice, 'deviceSerialNumber'>
+): IvlsDevice => ({
+  displayName: 'Catalyst One',
+  vcpActivatedStatus: 'ACTIVE',
+  lastPolledCloudTime: daysAgo(0),
+  ...over,
+});
+
+const MIXED: IvlsDevice[] = [
+  device({ deviceSerialNumber: 'CT-4471-A', displayName: 'Catalyst One' }),
+  device({ deviceSerialNumber: 'PC-2203-B', displayName: 'ProCyte Dx' }),
+  device({
+    deviceSerialNumber: 'UA-9018-C',
+    displayName: 'SediVue UA',
+    vcpActivatedStatus: 'SUSPENDED',
+    lastPolledCloudTime: daysAgo(3),
+  }),
+];
+
+const ALL_ONLINE: IvlsDevice[] = [MIXED[0], MIXED[1]];
+
+const UNNAMED: IvlsDevice[] = [
+  device({
+    deviceSerialNumber: 'XX-0000-Z',
+    displayName: null,
+    vcpActivatedStatus: 'SUSPENDED',
+    lastPolledCloudTime: daysAgo(1),
+  }),
+];
+
+const meta = {
+  title: 'Organization/LinkedMedicalDevices',
+  component: LinkedMedicalDevicesCard,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The IDEXX device panel on the organisation page. Everything below its header row is ' +
+          'gated on a live integration: the card only lists devices when an `IDEXX` integration ' +
+          'is `enabled` **and** the IVLS endpoint answers, so the error strip, the empty branch ' +
+          'and the populated rows were all unreachable in Storybook and none had ever been ' +
+          'drawn.\n\n' +
+          'The rows are the part worth reviewing. Online and idle are not the same row with a ' +
+          'different colour: online is `--success-text` with an `animate-pulse` dot, idle is ' +
+          '`--warn-text` with a static dot **and a trailing age** ("IDLE · 3 days"), computed ' +
+          'from `lastPolledCloudTime` against `Date.now()`. The leading glyph also varies by ' +
+          'name - a name containing "cyte" gets the droplet, one containing "ua" the beaker, ' +
+          'everything else the flask - which is a substring match on a marketing name and the ' +
+          'kind of rule that is only obvious with three differently-named devices side by side.\n\n' +
+          'The header line reads from the same list: `no devices linked` / `all healthy` / ' +
+          '`N need attention`, so the sentence and the rows can disagree if either side is ' +
+          'changed alone.\n\n' +
+          'These stories drive `LinkedMedicalDevicesCard`, the presentational half, which was ' +
+          'split out of the container for exactly this reason. The last story mounts the wired ' +
+          'default export to prove the two halves are still connected.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    devices: MIXED,
+    error: null,
+    refreshing: false,
+    lastPoll: '18 Aug 2026, 09:12',
+    onRefresh: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <div className="min-h-[420px] w-[760px] max-w-full bg-[var(--screen)] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof LinkedMedicalDevicesCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Devices: Story = {
+  name: 'Devices, two online and one idle',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // The header sentence is derived from the same array as the rows below it.
+    await expect(
+      canvas.getByText('Last cloud poll 18 Aug 2026, 09:12 · 1 need attention')
+    ).toBeInTheDocument();
+
+    await expect(canvas.getByText('Catalyst One')).toBeInTheDocument();
+    await expect(canvas.getByText('IVLS CT-4471-A')).toBeInTheDocument();
+    await expect(canvas.getByText('ProCyte Dx')).toBeInTheDocument();
+    await expect(canvas.getByText('IVLS PC-2203-B')).toBeInTheDocument();
+    await expect(canvas.getByText('SediVue UA')).toBeInTheDocument();
+
+    // Two ONLINE, one IDLE - and the idle one carries its age, which is the only
+    // place `lastPolledCloudTime` reaches the screen.
+    await expect(canvas.getAllByText('ONLINE')).toHaveLength(2);
+    await expect(canvas.getByText('IDLE · 3 days')).toBeInTheDocument();
+
+    // The empty branch and the row list are mutually exclusive: this is what
+    // catches a `total === 0` test that stops agreeing with the array.
+    await expect(canvas.queryByText('No linked IVLS devices found.')).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('alert')).not.toBeInTheDocument();
+
+    // The footer link is outside the row list, so it survives every branch above it.
+    await expect(canvas.getByRole('link', { name: /Open integrations/ })).toHaveAttribute(
+      'href',
+      '/integrations'
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Three devices with three different glyphs and both status treatments. `1 need ' +
+          'attention` in the header is `total - onlineCount`, so it is the header that reports ' +
+          'the suspended device rather than anything on the row itself.',
+      },
+    },
+  },
+};
+
+export const AllHealthy: Story = {
+  name: 'All devices online',
+  args: { devices: ALL_ONLINE },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByText('Last cloud poll 18 Aug 2026, 09:12 · all healthy')
+    ).toBeInTheDocument();
+    await expect(canvas.getAllByText('ONLINE')).toHaveLength(2);
+    await expect(canvas.queryByText(/^IDLE/)).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`all healthy` is a separate branch from the `N need attention` count, not the count ' +
+          'reaching zero, so it needs its own fixture to be seen at all.',
+      },
+    },
+  },
+};
+
+export const SingularIdleDay: Story = {
+  name: 'Unnamed device, idle one day',
+  args: { devices: UNNAMED },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Two fallbacks in one row: the null display name becomes "IVLS device", and
+    // the day count singularises. Both are one-character edits away from wrong.
+    await expect(canvas.getByText('IVLS device')).toBeInTheDocument();
+    await expect(canvas.getByText('IVLS XX-0000-Z')).toBeInTheDocument();
+    // "1 day", not "1 days" - and the age is part of the same badge text node as
+    // IDLE, so a split into two elements would break this exact match.
+    await expect(canvas.getByText('IDLE · 1 day')).toBeInTheDocument();
+    // The header counts the same single device from the other direction, and the
+    // suspended device must NOT read as online in either place.
+    await expect(
+      canvas.getByText('Last cloud poll 18 Aug 2026, 09:12 · 1 need attention')
+    ).toBeInTheDocument();
+    await expect(canvas.queryAllByText('ONLINE')).toHaveLength(0);
+    await expect(canvas.queryByText('No linked IVLS devices found.')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The IVLS list returns `displayName: null` for a device that has not reported one, so ' +
+          'the row falls back to the literal "IVLS device" over the serial number. The age ' +
+          'pluralises separately.',
+      },
+    },
+  },
+};
+
+export const NoDevices: Story = {
+  name: 'No linked devices',
+  args: { devices: [], lastPoll: 'not yet' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByText('Last cloud poll not yet · no devices linked')
+    ).toBeInTheDocument();
+    await expect(canvas.getByText('No linked IVLS devices found.')).toBeInTheDocument();
+    // Empty is not an error: the strip must stay absent, otherwise an org that
+    // simply has no analysers reads as a broken integration.
+    await expect(canvas.queryByRole('alert')).not.toBeInTheDocument();
+    await expect(
+      canvas.getByRole('button', { name: 'Refresh linked medical devices' })
+    ).toBeEnabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting state for an org whose IDEXX integration is off or has no analysers. ' +
+          '`not yet` is the stamp before the integrations store has ever fetched, so this is also ' +
+          'what the panel looks like on a cold page load.',
+      },
+    },
+  },
+};
+
+export const RefreshError: Story = {
+  name: 'Refresh failed',
+  args: { devices: [], error: 'Unable to refresh linked IVLS devices.' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const alert = canvas.getByRole('alert');
+    await expect(alert).toHaveTextContent('Unable to refresh linked IVLS devices.');
+    // The catch clears the device list as well as setting the message, so the
+    // error strip always sits directly above the empty branch - never above rows.
+    await expect(canvas.getByText('No linked IVLS devices found.')).toBeInTheDocument();
+    await expect(
+      canvas.getByText('Last cloud poll 18 Aug 2026, 09:12 · no devices linked')
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Both messages at once, which is what the container actually produces: its `catch` sets ' +
+          'the message **and** empties `devices`, so the strip is never drawn over a populated ' +
+          'list. The header still shows the last successful poll, because that stamp comes from ' +
+          'the integrations store rather than from this fetch.',
+      },
+    },
+  },
+};
+
+export const Refreshing: Story = {
+  name: 'Refresh in flight',
+  args: { refreshing: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const refresh = canvas.getByRole('button', { name: 'Refresh linked medical devices' });
+    await expect(refresh).toBeDisabled();
+    // The spin lives on the icon, not the button, so a class check on the button
+    // would pass while nothing moved.
+    await expect(refresh.querySelector('svg')).toHaveClass('animate-spin');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The button disables itself for the duration so a second click cannot start an ' +
+          'overlapping poll. The rows underneath are left alone - the old list stays on screen ' +
+          'rather than blanking, so the panel does not flash empty on every refresh.',
+      },
+    },
+  },
+};
+
+export const Wired: Story = {
+  name: 'Wired panel, IDEXX disabled',
+  render: () => <LinkedMedicalDevices />,
+  beforeEach: () => {
+    /* Seeds the real stores rather than stubbing the service. With the IDEXX
+       integration present but not `enabled`, the container takes its `else`
+       branch and sets an empty list without touching the IVLS endpoint - so this
+       story mounts the wired component with no network at all. */
+    const idexx: OrgIntegration = {
+      id: 'integration-idexx',
+      organisationId: ORG_ID,
+      provider: 'IDEXX',
+      status: 'disabled',
+    };
+    useOrgStore.setState({
+      orgsById: { [ORG_ID]: ORG },
+      orgIds: [ORG_ID],
+      primaryOrgId: ORG_ID,
+      status: 'loaded',
+    });
+    useIntegrationStore.getState().setIntegrationsForOrg(ORG_ID, [idexx]);
+
+    return () => {
+      useOrgStore.setState({ orgsById: {}, orgIds: [], primaryOrgId: null, status: 'idle' });
+      useIntegrationStore.setState({
+        integrationsById: {},
+        integrationIdsByOrgId: {},
+        lastFetchedAt: null,
+      });
+    };
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('No linked IVLS devices found.')).toBeInTheDocument();
+    await expect(canvas.queryByRole('alert')).not.toBeInTheDocument();
+    // `setIntegrationsForOrg` stamps lastFetchedAt, so the header is past its
+    // "not yet" state here even though no device call was ever made.
+    await expect(canvas.getByText(/· no devices linked$/)).toBeInTheDocument();
+    /* Not one row was rendered: every device row prints "IVLS <serial>", so a
+       zero count here is what proves the disabled branch returned an empty list
+       rather than the fetch quietly succeeding. The refresh control still works,
+       which is the difference between this and a dead panel. */
+    await expect(canvas.queryAllByText(/^IVLS /)).toHaveLength(0);
+    await expect(
+      canvas.getByRole('button', { name: 'Refresh linked medical devices' })
+    ).toBeEnabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The default export, so the split above is proven to still be wired together. The ' +
+          'enabled path is deliberately not driven here: it calls the IVLS endpoint directly, ' +
+          'and this repo has no request-mocking layer, so it would be a real network attempt ' +
+          'whose failure timing decides what the snapshot shows.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/LinkedMedicalDevices.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/LinkedMedicalDevices.tsx
@@ -43,59 +43,30 @@ const buildHealthText = (total: number, onlineCount: number): string => {
   return `${total - onlineCount} need attention`;
 };
 
-const LinkedMedicalDevices = () => {
-  const primaryOrgId = useOrgStore((s) => s.primaryOrgId);
-  const integration = useIntegrationByProviderForPrimaryOrg('IDEXX');
-  const integrationsLastFetchedAt = useIntegrationStore((s) => s.lastFetchedAt);
-  const [devices, setDevices] = useState<IvlsDevice[]>([]);
-  const [error, setError] = useState<string | null>(null);
-  const [refreshing, setRefreshing] = useState(false);
+type LinkedMedicalDevicesCardProps = {
+  devices: IvlsDevice[];
+  error: string | null;
+  refreshing: boolean;
+  /** Already-formatted "last cloud poll" stamp, or `not yet` before the first fetch. */
+  lastPoll: string;
+  onRefresh: () => void;
+};
 
-  useEffect(() => {
-    const run = async () => {
-      if (!primaryOrgId) return;
-      try {
-        setError(null);
-        if ((integration?.status ?? '').toLowerCase() === 'enabled') {
-          const ivls = await listIdexxIvlsDevices(primaryOrgId);
-          setDevices(ivls.ivlsDeviceList ?? []);
-        } else {
-          setDevices([]);
-        }
-      } catch {
-        setError('Unable to refresh linked IVLS devices.');
-        setDevices([]);
-      }
-    };
-    void run();
-  }, [primaryOrgId, integration?.status]);
-
-  const handleManualRefresh = async () => {
-    if (!primaryOrgId) return;
-    setRefreshing(true);
-    setError(null);
-    try {
-      await loadIntegrationsForPrimaryOrg({ force: true, silent: true });
-      const nextIdexx =
-        useIntegrationStore.getState().getIntegrationByProvider(primaryOrgId, 'IDEXX') ?? null;
-      if ((nextIdexx?.status ?? '').toLowerCase() === 'enabled') {
-        const ivls = await listIdexxIvlsDevices(primaryOrgId);
-        setDevices(ivls.ivlsDeviceList ?? []);
-      } else {
-        setDevices([]);
-      }
-    } catch {
-      setError('Unable to refresh integration/device status.');
-    } finally {
-      setRefreshing(false);
-    }
-  };
-
+/**
+ * The card body, split out from the container above it so the three states a
+ * reviewer needs to see - the error strip, the empty branch and populated rows -
+ * are reachable from props. In the container they are only reachable through the
+ * IDEXX integration and a live IVLS fetch, so none of them had ever been drawn.
+ */
+export const LinkedMedicalDevicesCard = ({
+  devices,
+  error,
+  refreshing,
+  lastPoll,
+  onRefresh,
+}: LinkedMedicalDevicesCardProps) => {
   const total = devices.length;
   const onlineCount = devices.filter(isDeviceOnline).length;
-  const lastPoll = integrationsLastFetchedAt
-    ? formatDateTimeLocal(integrationsLastFetchedAt)
-    : 'not yet';
 
   return (
     <SectionCard title="Linked medical devices" showButton={false}>
@@ -106,9 +77,7 @@ const LinkedMedicalDevices = () => {
           </div>
           <button
             type="button"
-            onClick={() => {
-              handleManualRefresh().catch(() => undefined);
-            }}
+            onClick={onRefresh}
             className="inline-flex items-center gap-1.5 rounded-full border border-[var(--hairline)] px-3 py-1.5 text-[11.5px] font-semibold text-[var(--ink-body)] hover:bg-[var(--inset)] disabled:opacity-50"
             aria-label="Refresh linked medical devices"
             title="Refresh linked medical devices"
@@ -183,6 +152,71 @@ const LinkedMedicalDevices = () => {
         </div>
       </div>
     </SectionCard>
+  );
+};
+
+const LinkedMedicalDevices = () => {
+  const primaryOrgId = useOrgStore((s) => s.primaryOrgId);
+  const integration = useIntegrationByProviderForPrimaryOrg('IDEXX');
+  const integrationsLastFetchedAt = useIntegrationStore((s) => s.lastFetchedAt);
+  const [devices, setDevices] = useState<IvlsDevice[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+
+  useEffect(() => {
+    const run = async () => {
+      if (!primaryOrgId) return;
+      try {
+        setError(null);
+        if ((integration?.status ?? '').toLowerCase() === 'enabled') {
+          const ivls = await listIdexxIvlsDevices(primaryOrgId);
+          setDevices(ivls.ivlsDeviceList ?? []);
+        } else {
+          setDevices([]);
+        }
+      } catch {
+        setError('Unable to refresh linked IVLS devices.');
+        setDevices([]);
+      }
+    };
+    void run();
+  }, [primaryOrgId, integration?.status]);
+
+  const handleManualRefresh = async () => {
+    if (!primaryOrgId) return;
+    setRefreshing(true);
+    setError(null);
+    try {
+      await loadIntegrationsForPrimaryOrg({ force: true, silent: true });
+      const nextIdexx =
+        useIntegrationStore.getState().getIntegrationByProvider(primaryOrgId, 'IDEXX') ?? null;
+      if ((nextIdexx?.status ?? '').toLowerCase() === 'enabled') {
+        const ivls = await listIdexxIvlsDevices(primaryOrgId);
+        setDevices(ivls.ivlsDeviceList ?? []);
+      } else {
+        setDevices([]);
+      }
+    } catch {
+      setError('Unable to refresh integration/device status.');
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  const lastPoll = integrationsLastFetchedAt
+    ? formatDateTimeLocal(integrationsLastFetchedAt)
+    : 'not yet';
+
+  return (
+    <LinkedMedicalDevicesCard
+      devices={devices}
+      error={error}
+      refreshing={refreshing}
+      lastPoll={lastPoll}
+      onRefresh={() => {
+        handleManualRefresh().catch(() => undefined);
+      }}
+    />
   );
 };
 

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Profile.stories.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Profile.stories.tsx
@@ -1,0 +1,302 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import type { Organisation, UserOrganization } from '@yosemite-crew/types';
+
+import { useOrgStore } from '@/app/stores/orgStore';
+import Profile from './Profile';
+
+const ORG_ID = 'org-storybook-profile';
+
+const ORG: Organisation = {
+  _id: ORG_ID,
+  name: 'Sunrise Veterinary Hospital',
+  type: 'HOSPITAL',
+  phoneNo: '4155550110',
+  website: 'sunrisevet.example',
+  taxId: 'DE-8871-2290',
+  DUNSNumber: '15-048-3782',
+  isVerified: true,
+  isActive: true,
+  address: {
+    addressLine: '18 Larkspur Way',
+    city: 'Berlin',
+    state: 'Berlin',
+    postalCode: '10405',
+    country: 'Germany',
+  },
+  appointmentCheckInBufferMinutes: 10,
+  appointmentCheckInRadiusMeters: 150,
+};
+
+const OWNER: UserOrganization = {
+  id: 'membership-owner',
+  practitionerReference: 'Practitioner/vet-marsh',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'OWNER',
+  active: true,
+};
+
+/** RECEPTIONIST holds no `org:edit`, which is the only thing gated on this screen. */
+const RECEPTIONIST: UserOrganization = {
+  ...OWNER,
+  id: 'membership-reception',
+  roleCode: 'RECEPTIONIST',
+};
+
+/**
+ * Seeds the org store rather than mocking `usePermissions`. The three edit cards
+ * also read `usePrimaryOrg` for the id they hand the logo endpoints - without it
+ * `LogoUpdator` renders permanently disabled, which is a different picture from
+ * the one the product shows.
+ */
+const seed =
+  (membership: UserOrganization = OWNER) =>
+  () => {
+    useOrgStore.setState({
+      orgsById: { [ORG_ID]: ORG },
+      orgIds: [ORG_ID],
+      primaryOrgId: ORG_ID,
+      membershipsByOrgId: { [ORG_ID]: membership },
+      status: 'loaded',
+    });
+
+    return () => {
+      useOrgStore.setState({
+        orgsById: {},
+        orgIds: [],
+        primaryOrgId: null,
+        membershipsByOrgId: {},
+        status: 'idle',
+      });
+    };
+  };
+
+/** The `label | value` row of a read card: a flex row of exactly two divs. */
+const rowOf = (label: HTMLElement): HTMLElement => label.parentElement as HTMLElement;
+
+const meta = {
+  title: 'Organization/Profile',
+  component: Profile,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The organisation identity section, which is really two entirely different screens ' +
+          'behind one `isEditing` flag. Only the resting one had ever been drawn.\n\n' +
+          'The pencil does not open a form inside the band - it **replaces the band**. Resting, ' +
+          'this is one wide card: a 62px monogram tile, the name in Newsreader at 24px, three ' +
+          'status pills, and two dense meta lines that fold the address, phone, website, tax id, ' +
+          'both check-in numbers and the DUNS into `·`-joined sentences. Editing, all of that ' +
+          'is gone and in its place are a serif page heading, a `Done` pill and three stacked ' +
+          'label/value cards, each with its own pencil and its own save handler.\n\n' +
+          'So the two states share no markup at all, which is why a snapshot of either one ' +
+          'proves nothing about the other, and why the swap itself is the thing worth a ' +
+          'story.\n\n' +
+          '`org:edit` is the only permission involved and it gates only the pencil: a role ' +
+          'without it gets the full band and no way out of it, which is a deliberately quiet ' +
+          'denial with no message attached.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: { primaryOrg: ORG },
+  decorators: [
+    (Story) => (
+      <div className="min-h-[420px] w-[900px] max-w-full bg-[var(--screen)] p-6">
+        <Story />
+      </div>
+    ),
+  ],
+  beforeEach: seed(),
+} satisfies Meta<typeof Profile>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Band: Story = {
+  name: 'Resting band',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Sunrise Veterinary Hospital')).toBeInTheDocument();
+
+    // Two derived sentences, asserted whole. Each is a `·`-join over four or five
+    // optional fields, so a dropped field leaves a valid-looking shorter line.
+    await expect(
+      canvas.getByText(
+        '18 Larkspur Way, 10405 Berlin · 4155550110 · sunrisevet.example · Tax ID DE-8871-2290'
+      )
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByText('Check-in buffer: 10 min · Check-in radius: 150 m · DUNS 15-048-3782')
+    ).toBeInTheDocument();
+
+    // Verified is a pill swap, not a badge that appears: unverified reads PENDING.
+    await expect(canvas.getByText('VERIFIED')).toBeInTheDocument();
+    await expect(canvas.queryByText('PENDING')).not.toBeInTheDocument();
+    await expect(canvas.getByText('HOSPITAL')).toBeInTheDocument();
+
+    await expect(canvas.getByRole('button', { name: 'Edit profile' })).toBeInTheDocument();
+    // None of the edit-mode tree exists yet.
+    await expect(canvas.queryByText('Edit organization profile')).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Done' })).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting band. The monogram is the FIRST initial only - `initialsOf` returns up ' +
+          'to two and the avatar takes `charAt(0)` - so a two-word clinic name renders one ' +
+          'letter here and two on a team member’s row elsewhere on the same page.',
+      },
+    },
+  },
+};
+
+export const Unverified: Story = {
+  name: 'Unverified org',
+  args: { primaryOrg: { ...ORG, isVerified: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('PENDING')).toBeInTheDocument();
+    await expect(canvas.queryByText('VERIFIED')).not.toBeInTheDocument();
+
+    /* Verification changes the PILL only, so the rest of the band is asserted
+       whole rather than left implied: the type pill beside it, both derived meta
+       sentences and the pencil all have to survive, otherwise `isVerified` is
+       gating more than the design says it does. */
+    await expect(canvas.getByText('HOSPITAL')).toBeInTheDocument();
+    await expect(
+      canvas.getByText(
+        '18 Larkspur Way, 10405 Berlin · 4155550110 · sunrisevet.example · Tax ID DE-8871-2290'
+      )
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByText('Check-in buffer: 10 min · Check-in radius: 150 m · DUNS 15-048-3782')
+    ).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Edit profile' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The amber PENDING pill sits in the same slot as the green VERIFIED one, shield glyph ' +
+          'and all removed, so the row does not reflow when a clinic is verified.',
+      },
+    },
+  },
+};
+
+export const EditMode: Story = {
+  name: 'Edit mode (band replaced)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Edit profile' }));
+
+    /* The band is GONE, not collapsed. Its two meta sentences are the safe
+       signal: the verified pill is NOT, because the first edit card renders its
+       own pill whose label is the sentence-case "Verified" while the band's is
+       the literal "VERIFIED". Case-sensitive queries keep the two apart, but a
+       reviewer reading `queryByText('VERIFIED')` here would reasonably assume
+       there is only one pill on this screen. */
+    await waitFor(() =>
+      expect(
+        canvas.queryByText('Check-in buffer: 10 min · Check-in radius: 150 m · DUNS 15-048-3782')
+      ).not.toBeInTheDocument()
+    );
+    await expect(
+      canvas.queryByText(
+        '18 Larkspur Way, 10405 Berlin · 4155550110 · sunrisevet.example · Tax ID DE-8871-2290'
+      )
+    ).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Edit profile' })).not.toBeInTheDocument();
+
+    // In its place: the serif heading, the Done pill and the three cards.
+    await expect(canvas.getByText('Edit organization profile')).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Done' })).toBeInTheDocument();
+    await expect(canvas.getByText('Organization')).toBeInTheDocument();
+    await expect(canvas.getByText('Address')).toBeInTheDocument();
+    await expect(canvas.getByText('Check-in settings')).toBeInTheDocument();
+
+    /* The cards read the same record the band did - assert the ROW, so a value
+       rendered under the wrong label cannot pass. `Country` is the interesting
+       one: it is lifted out of `address` because `BasicFields` addresses it by a
+       top-level key, so it is the field that silently empties if that lift is
+       dropped. */
+    await expect(rowOf(canvas.getByText('Tax ID')).textContent).toBe('Tax IDDE-8871-2290');
+    await expect(rowOf(canvas.getByText('Country')).textContent).toBe('CountryGermany');
+    await expect(rowOf(canvas.getByText('Postal code')).textContent).toBe('Postal code10405');
+
+    // Each card owns its own pencil and its own save handler.
+    for (const card of ['Organization', 'Address', 'Check-in settings']) {
+      await expect(canvas.getByRole('button', { name: `Edit ${card}` })).toBeInTheDocument();
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The gated surface. Note there is no Cancel: `Done` only flips `isEditing` back, ' +
+          'because each card already saved itself when its own pencil was closed. Nothing on ' +
+          'this screen is pending when it is dismissed.',
+      },
+    },
+  },
+};
+
+export const DoneReturnsToBand: Story = {
+  name: 'Done returns to the band',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Edit profile' }));
+    const done = await canvas.findByRole('button', { name: 'Done' });
+    await expect(done).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Done' }));
+
+    await waitFor(() =>
+      expect(canvas.queryByText('Edit organization profile')).not.toBeInTheDocument()
+    );
+    // The band comes back reading the form's state, not the original prop, which
+    // is what makes an edit visible without waiting for the page to refetch.
+    await expect(
+      canvas.getByText('Check-in buffer: 10 min · Check-in radius: 150 m · DUNS 15-048-3782')
+    ).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Edit profile' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The round trip. `useOrgProfileForm` holds `formData` above the swap, so the band ' +
+          'rebuilds from whatever the cards last saved - the two states share a record even ' +
+          'though they share no markup.',
+      },
+    },
+  },
+};
+
+export const WithoutEditPermission: Story = {
+  name: 'Pencil hidden without org:edit',
+  beforeEach: seed(RECEPTIONIST),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.queryByRole('button', { name: 'Edit profile' })).not.toBeInTheDocument();
+    // Everything else is untouched: this is a quiet denial with no message.
+    await expect(canvas.getByText('Sunrise Veterinary Hospital')).toBeInTheDocument();
+    await expect(canvas.getByText('VERIFIED')).toBeInTheDocument();
+    await expect(
+      canvas.getByText('Check-in buffer: 10 min · Check-in radius: 150 m · DUNS 15-048-3782')
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Without `org:edit` the band loses its only control and the edit screen becomes ' +
+          'unreachable - there is no other route to `isEditing`, so the three cards behind it ' +
+          'are dead code for this role rather than read-only.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/AddRoom.stories.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/AddRoom.stories.tsx
@@ -1,0 +1,353 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import type { Organisation, Speciality } from '@yosemite-crew/types';
+
+import type { Team } from '@/app/features/organization/types/team';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useSpecialityStore } from '@/app/stores/specialityStore';
+import { useTeamStore } from '@/app/stores/teamStore';
+import AddRoom from './AddRoom';
+
+const ORG_ID = 'org-storybook-rooms';
+
+const ORG: Organisation = {
+  _id: ORG_ID,
+  name: 'Sunrise Veterinary Hospital',
+  type: 'HOSPITAL',
+  phoneNo: '4155550110',
+  taxId: 'DE-8871-2290',
+  isActive: true,
+};
+
+const SPECIALITIES: Speciality[] = [
+  { _id: 'spec-surgery', organisationId: ORG_ID, name: 'Surgery', isActive: true },
+  { _id: 'spec-internal', organisationId: ORG_ID, name: 'Internal medicine', isActive: true },
+];
+
+const TEAMS: Team[] = [
+  {
+    _id: 'team-hartmann',
+    practionerId: 'vet-hartmann',
+    organisationId: ORG_ID,
+    name: 'Dr. Lena Hartmann',
+    role: 'VETERINARIAN',
+    speciality: [],
+    status: 'Available',
+    revokedPermissions: [],
+    effectivePermissions: [],
+    extraPerissions: [],
+  },
+  {
+    _id: 'team-raman',
+    practionerId: 'nurse-raman',
+    organisationId: ORG_ID,
+    name: 'Priya Raman',
+    role: 'TECHNICIAN',
+    speciality: [],
+    status: 'Available',
+    revokedPermissions: [],
+    effectivePermissions: [],
+    extraPerissions: [],
+  },
+];
+
+/**
+ * Seeds the real stores rather than mocking the hooks. Both dropdowns in the
+ * drawer read `useTeamForPrimaryOrg` / `useSpecialitiesForPrimaryOrg`, which are
+ * pure store selectors with no fetch of their own, so the drawer mounts with real
+ * options and no network at all.
+ */
+const seed = () => {
+  useOrgStore.setState({
+    orgsById: { [ORG_ID]: ORG },
+    orgIds: [ORG_ID],
+    primaryOrgId: ORG_ID,
+    status: 'loaded',
+  });
+  useTeamStore.getState().setTeamsForOrg(ORG_ID, TEAMS);
+  useSpecialityStore.getState().setSpecialitiesForOrg(ORG_ID, SPECIALITIES);
+
+  return () => {
+    useOrgStore.setState({ orgsById: {}, orgIds: [], primaryOrgId: null, status: 'idle' });
+    useTeamStore.setState({ teamsById: {}, teamIdsByOrgId: {} });
+    useSpecialityStore.setState({ specialitiesById: {}, specialityIdsByOrgId: {} });
+  };
+};
+
+/**
+ * Both panels portal to `document.body`, so neither is inside `canvasElement`,
+ * and both `<dialog>` elements are mounted from the first render - only the
+ * `open` attribute moves. Absence therefore has to be asserted against
+ * `dialog[open]`, and the drawer is always the first of the two in document
+ * order because it is rendered first.
+ */
+const openDialogs = () => Array.from(document.querySelectorAll('dialog[open]')) as HTMLElement[];
+const drawer = () => openDialogs()[0];
+const confirmSheet = () => openDialogs()[1];
+
+const AddRoomHarness = () => {
+  const [open, setOpen] = useState(true);
+  return (
+    <div className="min-h-[620px] bg-[var(--screen)] p-6">
+      <p className="text-[13px] text-[var(--ink-muted)]">
+        The rooms list sits behind the drawer, so the backdrop tint and blur are visible.
+      </p>
+      <AddRoom showModal={open} setShowModal={setOpen} />
+    </div>
+  );
+};
+
+const meta = {
+  title: 'Organization/AddRoom',
+  component: AddRoomHarness,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The "Adding new room" drawer. It is opened from the Rooms section and had never been ' +
+          'drawn in Storybook, so neither its resting layout nor either of the two states it can ' +
+          'refuse to close in were reviewable.\n\n' +
+          '**Closing is conditional.** The header X, the backdrop and Escape all route through ' +
+          'the same dirty check: with any field touched, the drawer refuses and raises a ' +
+          '"Discard changes?" confirm instead. The Escape and backdrop paths go through the ' +
+          'Modal `canClose` hook, which returns `false` **and** opens the confirm as a side ' +
+          'effect - so a reviewer cannot verify the guard by looking at the drawer alone.\n\n' +
+          '**Validation is name and type only.** Room code, availability, units and equipment ' +
+          'all save empty; the two required fields report in different places, because one is a ' +
+          '`FormInput` (red border, `role="alert"` line, `aria-invalid`) and the other is a ' +
+          '`LabelDropdown` (red border and a plain message with no alert role).\n\n' +
+          'The four section bodies are covered separately in ' +
+          '**Organization/AddRoomSections**, which drives them from props rather than through ' +
+          'this drawer.\n\n' +
+          'One state is deliberately not storied: the `Adding room...` footer label. It exists ' +
+          'only while `createRoom` is in flight, and this repo has no request-mocking layer, so ' +
+          "the label's lifetime would be decided by how fast a real request fails.",
+      },
+    },
+  },
+  tags: ['autodocs'],
+  beforeEach: seed,
+} satisfies Meta<typeof AddRoomHarness>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Drawer: Story = {
+  name: 'Adding new room',
+  play: async () => {
+    await waitFor(() => expect(openDialogs()).toHaveLength(1));
+    const panel = within(drawer());
+
+    await expect(panel.getByRole('heading', { name: 'Adding new room' })).toBeVisible();
+    // Every section starts open, so the drawer opens at its full height rather
+    // than as four collapsed rows.
+    await expect(panel.getByRole('button', { name: 'Basic details' })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
+    await expect(panel.getByLabelText('Name')).toHaveValue('');
+    await expect(panel.getByLabelText('Room code')).toHaveValue('');
+    // No type chosen yet, so the trigger shows the bare placeholder and both
+    // unit-capable sections show their "not supported" copy.
+    await expect(panel.getByRole('button', { name: 'Room Type' })).toBeInTheDocument();
+    await expect(
+      panel.getByText('Units are available for ICU, Inpatient, Isolation, and Boarding rooms.')
+    ).toBeInTheDocument();
+
+    // Both option triggers show their bare placeholder, so nothing is preselected.
+    await expect(panel.getByRole('button', { name: 'Speciality (optional)' })).toBeInTheDocument();
+    await expect(
+      panel.getByRole('button', { name: 'Assigned Staff (optional)' })
+    ).toBeInTheDocument();
+
+    await expect(panel.getByRole('button', { name: 'Add room' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The drawer as it opens: a 530px right-side panel with a fixed header, one scrolling ' +
+          'column of four sections and a single footer action. Nothing is required except a name ' +
+          'and a type, and neither is prefilled.',
+      },
+    },
+  },
+};
+
+export const OptionsComeFromTheOrg: Story = {
+  name: 'Speciality options resolved from the org',
+  play: async () => {
+    await waitFor(() => expect(openDialogs()).toHaveLength(1));
+    const panel = within(drawer());
+
+    await userEvent.click(panel.getByRole('button', { name: 'Speciality (optional)' }));
+    /* The listbox portals to document.body, so it is outside the drawer's own
+       `overflow-y-auto` column - which is the reason it is not clipped by it, and
+       also the reason it cannot be found through `within(drawer())`. */
+    await waitFor(() =>
+      expect(document.querySelector('[data-portal-dropdown]')).toBeInTheDocument()
+    );
+    const options = document.querySelector('[data-portal-dropdown]') as HTMLElement;
+    // Both seeded specialities, and only those - the list is the org's, not a
+    // constant, so an empty store would render an empty panel here.
+    await expect(within(options).getAllByRole('button')).toHaveLength(2);
+    await expect(within(options).getByText('Surgery')).toBeInTheDocument();
+    await expect(within(options).getByText('Internal medicine')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The speciality and staff pickers read the org stores through ' +
+          '`useSpecialitiesForPrimaryOrg` and `useTeamForPrimaryOrg`, so a room can only be ' +
+          'assigned to people and specialities that already exist. Both panels portal out of the ' +
+          'drawer, which is what stops the scrolling column from clipping them.',
+      },
+    },
+  },
+};
+
+export const RequiredFieldErrors: Story = {
+  name: 'Add pressed with nothing filled in',
+  play: async () => {
+    await waitFor(() => expect(openDialogs()).toHaveLength(1));
+    const panel = within(drawer());
+    await expect(panel.queryAllByRole('alert')).toHaveLength(0);
+
+    await userEvent.click(panel.getByRole('button', { name: 'Add room' }));
+
+    // Two required fields, reported in two different components: the name gets a
+    // `role="alert"` line wired to the input, the room type gets a plain message
+    // under a red trigger with no alert semantics at all.
+    expect(await panel.findByText('Name is required')).toBeInTheDocument();
+    await expect(panel.getByText('Room type is required')).toBeInTheDocument();
+    await expect(panel.getByLabelText('Name')).toHaveAttribute('aria-invalid', 'true');
+    await expect(panel.queryAllByRole('alert')).toHaveLength(1);
+    // Room code is optional, so it must stay clean - all three sit in one grid
+    // and it is easy to mark the wrong one.
+    await expect(panel.getByLabelText('Room code')).toHaveAttribute('aria-invalid', 'false');
+
+    // Validation runs before the request, so a failed Add leaves the drawer open
+    // and the footer label unchanged rather than flashing "Adding room...".
+    await expect(openDialogs()).toHaveLength(1);
+    await expect(panel.getByRole('button', { name: 'Add room' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The only state a reviewer can reach without a backend, and the one where the two ' +
+          'error treatments sit side by side. The asymmetry is real: assistive tech is told about ' +
+          'the name but not about the room type.',
+      },
+    },
+  },
+};
+
+export const DiscardConfirm: Story = {
+  name: 'Closing a dirty form',
+  play: async () => {
+    await waitFor(() => expect(openDialogs()).toHaveLength(1));
+    const panel = within(drawer());
+    await userEvent.type(panel.getByLabelText('Name'), 'Recovery Bay 3');
+
+    await userEvent.click(panel.getByRole('button', { name: 'Close' }));
+
+    // The drawer does NOT close: two dialogs are open at once, the confirm over
+    // the drawer that raised it.
+    await waitFor(() => expect(openDialogs()).toHaveLength(2));
+    const sheet = within(confirmSheet());
+    /* Polled, not read once. The confirm is a `CenterModal`, whose panel fades in
+       over `transition-opacity duration-100` - `opacity-0 -> opacity-100` is
+       applied in the same commit that sets `open`, so the `waitFor` above returns
+       at a frame where the computed opacity is still exactly `0`. `getByRole`
+       ignores opacity, so the heading is FOUND and then called invisible; the
+       drawer underneath never hits this because it animates `transform`, not
+       opacity. */
+    const confirmHeading = sheet.getByRole('heading', { name: 'Discard changes?' });
+    await waitFor(() => expect(confirmHeading).toBeVisible());
+    await expect(
+      sheet.getByText('You have unsaved room details. Are you sure you want to discard them?')
+    ).toBeInTheDocument();
+    await expect(sheet.getByRole('button', { name: 'Keep editing' })).toBeInTheDocument();
+    await expect(sheet.getByRole('button', { name: 'Discard' })).toBeInTheDocument();
+
+    await userEvent.click(sheet.getByRole('button', { name: 'Keep editing' }));
+
+    // Back to one dialog, with the typed value intact - "Keep editing" dismisses
+    // the confirm without touching the form.
+    await waitFor(() => expect(openDialogs()).toHaveLength(1));
+    await expect(within(drawer()).getByLabelText('Name')).toHaveValue('Recovery Bay 3');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The confirm only exists once something has been typed: `isDirty` compares the whole ' +
+          'form against its initial object, plus the un-added custom equipment name, so an ' +
+          'untouched drawer closes on the first click with no interruption.',
+      },
+    },
+  },
+};
+
+export const DiscardResetsTheDraft: Story = {
+  name: 'Discarding closes both panels',
+  play: async () => {
+    await waitFor(() => expect(openDialogs()).toHaveLength(1));
+    await userEvent.type(within(drawer()).getByLabelText('Name'), 'Recovery Bay 3');
+    await userEvent.click(within(drawer()).getByRole('button', { name: 'Close' }));
+    await waitFor(() => expect(openDialogs()).toHaveLength(2));
+
+    await userEvent.click(within(confirmSheet()).getByRole('button', { name: 'Discard' }));
+
+    /* Both dialogs stay MOUNTED without their `open` attribute, so absence has to
+       be asserted against `dialog[open]` - querying for the elements themselves
+       finds them either way and would pass whatever happened. */
+    await waitFor(() => expect(openDialogs()).toHaveLength(0));
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`resetAndClose` does four things in one call - clears the form, clears the errors, ' +
+          'clears the pending equipment name and closes both panels - which is why reopening the ' +
+          'drawer after a discard shows a blank form rather than the abandoned one.',
+      },
+    },
+  },
+};
+
+export const EscapeOnDirtyForm: Story = {
+  name: 'Escape on a dirty form',
+  play: async () => {
+    await waitFor(() => expect(openDialogs()).toHaveLength(1));
+    await userEvent.type(within(drawer()).getByLabelText('Name'), 'Recovery Bay 3');
+
+    await userEvent.keyboard('{Escape}');
+
+    // Escape goes through Modal's `canClose`, which is a different path from the
+    // header X: it returns false to block the dismissal AND opens the confirm as
+    // a side effect, so the key press is neither ignored nor destructive.
+    await waitFor(() => expect(openDialogs()).toHaveLength(2));
+    // Polled for the same reason as the header-X story above: `open` is set a
+    // full `duration-100` before the CenterModal panel has faded past opacity 0.
+    const confirmHeading = within(confirmSheet()).getByRole('heading', {
+      name: 'Discard changes?',
+    });
+    await waitFor(() => expect(confirmHeading).toBeVisible());
+    await expect(within(drawer()).getByLabelText('Name')).toHaveValue('Recovery Bay 3');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The backdrop click takes the same route. Without the guard, Escape on a half-filled ' +
+          'room would discard it silently - the drawer holds every field in local state and ' +
+          'nothing is persisted until Add is pressed.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/AddRoomSections.stories.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/AddRoomSections.stories.tsx
@@ -1,0 +1,452 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import type { RoomFormData } from './AddRoom';
+import {
+  AvailabilitySection,
+  BasicDetailsSection,
+  EquipmentSection,
+  type OpenSections,
+  UnitsSection,
+} from './AddRoomSections';
+
+const ORG_ID = 'org-storybook-rooms';
+
+const EMPTY_ROOM: RoomFormData = {
+  id: '',
+  organisationId: ORG_ID,
+  name: '',
+  code: '',
+  type: '',
+  assignedSpecialiteis: [],
+  assignedStaffs: [],
+  availability: {
+    isAvailable: true,
+    days: 'MON_SAT',
+    startTime: '10:00',
+    endTime: '20:00',
+    species: [],
+    totalUnits: 0,
+  },
+  units: [],
+  unitCount: 0,
+  equipment: [],
+};
+
+const ICU_ROOM: RoomFormData = {
+  ...EMPTY_ROOM,
+  name: 'ICU Bay A',
+  code: 'ICU-A',
+  type: 'ICU',
+  assignedSpecialiteis: ['spec-surgery'],
+  assignedStaffs: ['staff-1'],
+  availability: {
+    ...EMPTY_ROOM.availability,
+    species: ['CANINE', 'FELINE'],
+    totalUnits: 6,
+  },
+  units: [
+    { id: 'unit-1', name: 'Small kennel', size: 'Small', count: 4 },
+    { id: 'unit-2', name: 'Oxygen cage', size: 'Large', count: 2 },
+  ],
+  unitCount: 6,
+  equipment: ['Oxygen Tank', 'Heating Support'],
+};
+
+const EXAM_ROOM: RoomFormData = {
+  ...EMPTY_ROOM,
+  name: 'Exam 2',
+  code: 'EX-02',
+  type: 'EXAM_ROOM',
+};
+
+const SPECIALITY_OPTIONS = [
+  { label: 'Surgery', value: 'spec-surgery' },
+  { label: 'Internal medicine', value: 'spec-internal' },
+];
+
+const TEAM_OPTIONS = [
+  { label: 'Dr. Lena Hartmann', value: 'staff-1' },
+  { label: 'Nurse Priya Raman', value: 'staff-2' },
+];
+
+const ALL_OPEN: OpenSections = {
+  details: true,
+  availability: true,
+  units: true,
+  equipment: true,
+};
+
+const ALL_CLOSED: OpenSections = {
+  details: false,
+  availability: false,
+  units: false,
+  equipment: false,
+};
+
+/** Hoisted so the harness does not mint a new mock on every render. */
+const noop = fn();
+
+type HarnessProps = {
+  formData: RoomFormData;
+  formDataErrors: { name?: string; code?: string; type?: string };
+  openSections: OpenSections;
+  supportsUnits: boolean;
+  customEquipmentName: string;
+};
+
+/**
+ * `openSections` lives in `AddRoom`, so the four headers are inert without a
+ * state holder. The prop is the initial value and is re-synced when the arg
+ * changes, which is what lets a play function open a section that started closed.
+ */
+const AddRoomSectionsHarness = ({
+  formData,
+  formDataErrors,
+  openSections,
+  supportsUnits,
+  customEquipmentName,
+}: HarnessProps) => {
+  const [sections, setSections] = useState(openSections);
+  const [prevSections, setPrevSections] = useState(openSections);
+  if (prevSections !== openSections) {
+    setPrevSections(openSections);
+    setSections(openSections);
+  }
+  const toggle = (key: keyof OpenSections) =>
+    setSections((current) => ({ ...current, [key]: !current[key] }));
+
+  return (
+    <div className="flex flex-col gap-6">
+      <BasicDetailsSection
+        formData={formData}
+        formDataErrors={formDataErrors}
+        open={sections.details}
+        specialitiesOptions={SPECIALITY_OPTIONS}
+        onToggle={() => toggle('details')}
+        onChange={noop}
+        onRoomTypeChange={noop}
+      />
+      <AvailabilitySection
+        formData={formData}
+        open={sections.availability}
+        supportsUnits={supportsUnits}
+        teamOptions={TEAM_OPTIONS}
+        onToggle={() => toggle('availability')}
+        onAvailabilityChange={noop}
+        onChange={noop}
+      />
+      <UnitsSection
+        formData={formData}
+        open={sections.units}
+        supportsUnits={supportsUnits}
+        onAddUnit={noop}
+        onToggle={() => toggle('units')}
+        onUpdateUnit={noop}
+      />
+      <EquipmentSection
+        customEquipmentName={customEquipmentName}
+        formData={formData}
+        open={sections.equipment}
+        onAddCustomEquipment={noop}
+        onCustomEquipmentNameChange={noop}
+        onToggle={() => toggle('equipment')}
+        onChange={noop}
+      />
+    </div>
+  );
+};
+
+const meta = {
+  title: 'Organization/AddRoomSections',
+  component: AddRoomSectionsHarness,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'The scrolling body of the "Adding new room" drawer: four collapsible sections built ' +
+          'from the same `SectionHeader` and nothing else.\n\n' +
+          'All four bodies sit behind `{open && ...}`, so a collapsed section contributes ' +
+          '**nothing** to the DOM - not a hidden node, not a zero-height box - and `openSections` ' +
+          'is owned by `AddRoom` two levels up. No static render of the drawer has ever included ' +
+          'them.\n\n' +
+          'What survives a collapse is the part worth knowing: the availability **switch** and ' +
+          'the units **add** button live in their headers, not their bodies, so both stay ' +
+          'operable with the section shut. A reviewer looking for "everything disappears when ' +
+          'collapsed" would be wrong about two of the four sections.\n\n' +
+          'Two sections then fork again on `supportsUnits`, derived from the room type (ICU, ' +
+          'Inpatient, Isolation, Boarding). With it, Availability grows a Total Units field and ' +
+          'Units grows an add button; without it, both are replaced by explanatory bordered ' +
+          'paragraphs. An exam room and an ICU bay are two different layouts, not one layout ' +
+          'with a field hidden - and the empty-units line is a third state again, shown only ' +
+          'when the type supports units but none have been added yet.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    formData: ICU_ROOM,
+    formDataErrors: {},
+    openSections: ALL_OPEN,
+    supportsUnits: true,
+    customEquipmentName: '',
+  },
+  decorators: [
+    (Story) => (
+      <div className="flex w-[520px] max-w-full flex-col">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof AddRoomSectionsHarness>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const AllCollapsed: Story = {
+  name: 'All four sections collapsed',
+  args: { openSections: ALL_CLOSED },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('button', { name: 'Basic details' })).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
+    // Four bodies that do not exist - one probe per section, so a single
+    // section that failed to collapse cannot hide behind the others.
+    await expect(canvas.queryByLabelText('Room code')).not.toBeInTheDocument();
+    await expect(canvas.queryByLabelText('Total Units')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Draft unit type')).not.toBeInTheDocument();
+    await expect(canvas.queryByLabelText('Add equipment name')).not.toBeInTheDocument();
+
+    /* The two header-level controls SURVIVE the collapse, because they are
+       header `action`/`meta` slots rather than body content. This is the pair a
+       "collapsed means empty" assumption gets wrong. */
+    await expect(canvas.getByRole('switch', { name: 'Toggle room availability' })).toBeChecked();
+    await expect(canvas.getByRole('button', { name: 'Add unit type' })).toBeInTheDocument();
+    // The units header also keeps its count while shut.
+    await expect(canvas.getByRole('button', { name: 'Unit type (2)' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The drawer body reduced to four header rows. Only the chevron rotation, the ' +
+          '"Available now" meta and the two header controls are on screen.',
+      },
+    },
+  },
+};
+
+export const OpenedByClicking: Story = {
+  name: 'Opened one header at a time',
+  args: { openSections: ALL_CLOSED },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Basic details' }));
+    // Assert the body mounted its fields, not merely that aria-expanded flipped -
+    // the weak check passes on an empty section.
+    expect(await canvas.findByLabelText('Room code')).toHaveValue('ICU-A');
+    await expect(
+      canvas.getByText(
+        'Assign a specialty if this room is dedicated to a specific speciality or service.'
+      )
+    ).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Availability' }));
+    expect(await canvas.findByLabelText('Total Units')).toHaveValue(6);
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Unit type (2)' }));
+    expect(await canvas.findAllByText('Draft unit type')).toHaveLength(2);
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Equipments / Capabilities' }));
+    expect(await canvas.findByLabelText('Add equipment name')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The disclosure path itself. Four clicks take the drawer from four rows to its full ' +
+          'height, and every intermediate height is a real layout someone sees while filling ' +
+          'the form in.',
+      },
+    },
+  },
+};
+
+export const AllOpenUnitCapable: Story = {
+  name: 'All open, unit-capable room',
+  /* The details grid splits on `sm:` (Tailwind's 640px VIEWPORT breakpoint), not
+     on a container query, so its track count is decided by the panel width rather
+     than by the 520px decorator. Pinned as a global - `parameters.viewport` was
+     removed in Storybook 10 and would be inert - so the two-track assertion below
+     is deterministic instead of depending on how wide the docs panel happens to be. */
+  globals: { viewport: { value: 'laptop', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Basic details: two text fields plus two portalled selects.
+    await expect(canvas.getAllByLabelText('Name')[0]).toHaveValue('ICU Bay A');
+    await expect(canvas.getByLabelText('Room code')).toHaveValue('ICU-A');
+    await expect(canvas.getByRole('button', { name: 'Room Type: ICU' })).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('button', { name: 'Speciality (optional): Surgery' })
+    ).toBeInTheDocument();
+
+    /* The details grid is two tracks over FIVE children at this width: Name and
+       Room code take one cell each, and the room type, the speciality picker and
+       the hint paragraph each sit in a `sm:col-span-2` wrapper that spans both.
+       Assert the track count AND the child count - a template with fewer tracks
+       than a child expects silently reflows the row instead of failing, and the
+       five children are easy to miscount because three of them are wrappers
+       rather than fields. */
+    const grid = canvas.getByLabelText('Room code').closest('.grid') as HTMLElement;
+    await expect(getComputedStyle(grid).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(2);
+    await expect(grid.children).toHaveLength(5);
+
+    // Availability: two timepickers, two selects, the unit-capable field.
+    await expect(canvas.getByRole('button', { name: /^Start time/ })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: /^End time/ })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Days: Mon - Sat' })).toBeInTheDocument();
+    await expect(canvas.getByLabelText('Total Units')).toHaveValue(6);
+    await expect(
+      canvas.getByRole('button', { name: 'Assigned Staff (optional): Dr. Lena Hartmann' })
+    ).toBeInTheDocument();
+
+    // Units: one bordered editor per draft, each with its own Name/Size/Units.
+    await expect(canvas.getAllByText('Draft unit type')).toHaveLength(2);
+    // Three "Name" fields in the whole body: the room's, plus one per unit.
+    await expect(canvas.getAllByLabelText('Name')).toHaveLength(3);
+    await expect(canvas.getAllByLabelText('Units')).toHaveLength(2);
+    await expect(canvas.getByRole('button', { name: 'Size: Small' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Size: Large' })).toBeInTheDocument();
+
+    // Equipment: the select carries the room's own values merged into the
+    // standard list, so a custom entry survives a re-render of the options.
+    await expect(
+      canvas.getByRole('button', { name: 'Equipment: Oxygen Tank, Heating Support' })
+    ).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Add custom equipment' })).toBeInTheDocument();
+
+    // The two "not supported" paragraphs must be absent, not merely unstyled.
+    await expect(
+      canvas.queryByText('Units are available for ICU, Inpatient, Isolation, and Boarding rooms.')
+    ).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByText('Select ICU, Inpatient, Isolation, or Boarding to configure unit types.')
+    ).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The full drawer body for an ICU bay: the tallest state the form ever reaches, and the ' +
+          'one that decides whether the drawer scrolls sensibly. Every unit draft is its own ' +
+          '`border-blue-text` box captioned "Draft unit type", which is the only signal that it ' +
+          'has not been saved yet.',
+      },
+    },
+  },
+};
+
+export const NoUnitsYet: Story = {
+  name: 'Unit-capable room with no units',
+  args: { formData: { ...ICU_ROOM, units: [], unitCount: 0 } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The count in the header title is the array length, so it drops to zero.
+    await expect(canvas.getByRole('button', { name: 'Unit type (0)' })).toBeInTheDocument();
+    // The add affordance is still there - this state is reachable, not a dead end.
+    await expect(canvas.getByRole('button', { name: 'Add unit type' })).toBeInTheDocument();
+    await expect(
+      canvas.getByText('Add unit types when this room contains kennels, wards, pods, or bays.')
+    ).toBeInTheDocument();
+    await expect(canvas.queryAllByText('Draft unit type')).toHaveLength(0);
+    // This is the "supported but empty" line, NOT the "type does not support
+    // units" line - two different sentences that are easy to confuse.
+    await expect(
+      canvas.queryByText('Select ICU, Inpatient, Isolation, or Boarding to configure unit types.')
+    ).not.toBeInTheDocument();
+    /* Total Units is bound to `availability.totalUnits`, the units list to
+       `formData.units`, and nothing reconciles them - so this room reads "6" in
+       Availability while its Unit type header reads "(0)". That divergence is
+       the reason this state is worth drawing rather than a bug in the fixture. */
+    await expect(canvas.getByLabelText('Total Units')).toHaveValue(6);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The state a new ICU room opens in once its type is chosen: units are supported, none ' +
+          'exist yet. The copy names the things a unit actually is - kennels, wards, pods, bays - ' +
+          'rather than telling the user to press the button next to it.',
+      },
+    },
+  },
+};
+
+export const RoomTypeWithoutUnits: Story = {
+  name: 'Room type without units',
+  args: { formData: EXAM_ROOM, supportsUnits: false },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // One derived boolean, two replacements, in two different sections.
+    await expect(
+      canvas.getByText('Units are available for ICU, Inpatient, Isolation, and Boarding rooms.')
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByText('Select ICU, Inpatient, Isolation, or Boarding to configure unit types.')
+    ).toBeInTheDocument();
+    // Both controls are gone rather than disabled, so there is nothing to click
+    // into a state the room type cannot hold.
+    await expect(canvas.queryByLabelText('Total Units')).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Add unit type' })).not.toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Room Type: Exam room' })).toBeInTheDocument();
+    /* Only the unit-bearing parts are replaced. The rest of Availability is
+       outside the `supportsUnits` fork and keeps its values, and the Units header
+       keeps its count - so the section is reduced, not removed. */
+    await expect(canvas.getByRole('button', { name: 'Days: Mon - Sat' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Unit type (0)' })).toBeInTheDocument();
+    await expect(canvas.getByLabelText('Room code')).toHaveValue('EX-02');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'An exam room. `supportsUnits` is derived from the type rather than stored, so picking ' +
+          'a non-unit type in Basic details rewrites two sections below it in the same render - ' +
+          'and `handleRoomTypeChange` in `AddRoom` also empties any units already drafted, so ' +
+          'this is not a reversible view toggle.',
+      },
+    },
+  },
+};
+
+export const EmptyDraft: Story = {
+  name: 'Empty draft, no type chosen',
+  args: { formData: EMPTY_ROOM, supportsUnits: false },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // No type yet, so the trigger shows the bare placeholder rather than a value.
+    await expect(canvas.getByRole('button', { name: 'Room Type' })).toBeInTheDocument();
+    await expect(canvas.getByLabelText('Room code')).toHaveValue('');
+    await expect(canvas.getByRole('button', { name: 'Unit type (0)' })).toBeInTheDocument();
+    // Availability still opens with real defaults - 10:00 to 20:00, Mon - Sat -
+    // so an untouched draft is already a saveable schedule.
+    await expect(canvas.getByRole('button', { name: 'Days: Mon - Sat' })).toBeInTheDocument();
+    await expect(canvas.getByRole('switch', { name: 'Toggle room availability' })).toBeChecked();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'What the drawer body looks like the instant it opens, before a single field is ' +
+          'touched. Availability is the only section that is not blank: it ships defaults, which ' +
+          'is why a room can be added with a name and a type alone.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/Rooms.stories.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Rooms/Rooms.stories.tsx
@@ -1,0 +1,315 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import type {
+  Organisation,
+  OrganisationRoom,
+  Speciality,
+  UserOrganization,
+} from '@yosemite-crew/types';
+
+import type { Team } from '@/app/features/organization/types/team';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useOrganisationRoomStore } from '@/app/stores/roomStore';
+import { useSpecialityStore } from '@/app/stores/specialityStore';
+import { useTeamStore } from '@/app/stores/teamStore';
+import Rooms from './Rooms';
+
+const ORG_ID = 'org-storybook-rooms-section';
+
+const ORG: Organisation = {
+  _id: ORG_ID,
+  name: 'Sunrise Veterinary Hospital',
+  type: 'HOSPITAL',
+  phoneNo: '4155550110',
+  taxId: 'DE-8871-2290',
+  isActive: true,
+};
+
+const OWNER: UserOrganization = {
+  id: 'membership-owner',
+  practitionerReference: 'Practitioner/vet-marsh',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'OWNER',
+  active: true,
+};
+
+/**
+ * Every shipped role holds `room:edit:any`, so the only way to reach the
+ * read-only header is an explicit revocation on the membership - which is a
+ * real configuration, and the one `resolveMembershipPermissions` subtracts
+ * after the role baseline.
+ */
+const OWNER_ROOMS_REVOKED: UserOrganization = {
+  ...OWNER,
+  id: 'membership-owner-revoked',
+  revokedPermissions: ['room:edit:any'],
+};
+
+const SPECIALITIES: Speciality[] = [
+  { _id: 'spec-surgery', organisationId: ORG_ID, name: 'Surgery', isActive: true },
+];
+
+const TEAMS: Team[] = [
+  {
+    _id: 'team-marsh',
+    practionerId: 'vet-marsh',
+    organisationId: ORG_ID,
+    name: 'Dr. Elena Marsh',
+    role: 'VETERINARIAN',
+    speciality: [],
+    status: 'Available',
+    revokedPermissions: [],
+    effectivePermissions: [],
+    extraPerissions: [],
+  },
+];
+
+/**
+ * Three rooms chosen to cover all three branches of `roomMeta`: capabilities
+ * win over assigned specialities, an assigned speciality is the fallback, and a
+ * room with neither reads "No schedule set" rather than rendering a blank line.
+ */
+const ROOMS: OrganisationRoom[] = [
+  {
+    id: 'room-consult-1',
+    name: 'Consult 1',
+    organisationId: ORG_ID,
+    code: 'C1',
+    type: 'EXAM_ROOM',
+    availabilityMode: 'WORKING_HOURS',
+    availabilityDays: ['MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY'],
+    capabilities: ['Ultrasound', 'Dental X-ray'],
+  },
+  {
+    id: 'room-theatre-a',
+    name: 'Theatre A',
+    organisationId: ORG_ID,
+    code: 'TA',
+    type: 'SURGERY',
+    availabilityMode: 'ALL_DAY',
+    assignedSpecialiteis: [{ id: 'spec-surgery', name: 'Surgery' }],
+  },
+  {
+    id: 'room-isolation',
+    name: 'Isolation bay',
+    organisationId: ORG_ID,
+    code: 'IB',
+    type: 'ISOLATION',
+  },
+];
+
+/**
+ * Seeds the real stores rather than mocking the hooks. `useRoomsForPrimaryOrg`
+ * is a pure store selector - the fetch lives in `useLoadRoomsForPrimaryOrg`,
+ * which this section never calls - so the list mounts with no network at all.
+ * `status: 'loaded'` matters: `usePermissions` reports `isLoading` while the org
+ * store is `idle`, and the gate then renders its null skeleton instead of either
+ * the section or the fallback.
+ */
+const seed =
+  ({
+    membership = OWNER,
+    rooms = ROOMS,
+  }: { membership?: UserOrganization; rooms?: OrganisationRoom[] } = {}) =>
+  () => {
+    useOrgStore.setState({
+      orgsById: { [ORG_ID]: ORG },
+      orgIds: [ORG_ID],
+      primaryOrgId: ORG_ID,
+      membershipsByOrgId: { [ORG_ID]: membership },
+      status: 'loaded',
+    });
+    useOrganisationRoomStore.getState().setRoomsForOrg(ORG_ID, rooms);
+    useSpecialityStore.getState().setSpecialitiesForOrg(ORG_ID, SPECIALITIES);
+    useTeamStore.getState().setTeamsForOrg(ORG_ID, TEAMS);
+
+    return () => {
+      useOrgStore.setState({
+        orgsById: {},
+        orgIds: [],
+        primaryOrgId: null,
+        membershipsByOrgId: {},
+        status: 'idle',
+      });
+      useOrganisationRoomStore.setState({ roomsById: {}, roomIdsByOrgId: {} });
+      useSpecialityStore.setState({ specialitiesById: {}, specialityIdsByOrgId: {} });
+      useTeamStore.setState({ teamsById: {}, teamIdsByOrgId: {} });
+    };
+  };
+
+/**
+ * The Add-room drawer and the room detail drawer both portal to `document.body`
+ * and are both mounted from the first render - only the `open` attribute moves -
+ * so presence has to be counted on `dialog[open]`.
+ */
+const openDialogs = () => Array.from(document.querySelectorAll('dialog[open]')) as HTMLElement[];
+
+const meta = {
+  title: 'Organization/Rooms',
+  component: Rooms,
+  parameters: {
+    layout: 'fullscreen',
+    nextjs: { appDirectory: true, navigation: { pathname: '/organization' } },
+    docs: {
+      description: {
+        component:
+          'The rooms list on the organisation page. The populated list is the only part that ' +
+          'was ever visible in Storybook: the empty branch needs an org with no rooms, and the ' +
+          '"+ Add room" path needs `room:edit:any` plus a click.\n\n' +
+          'Each row is one button spanning the whole width, so the hit target is the row rather ' +
+          'than the name - and the trailing meta line is `hidden sm:block`, which means the ' +
+          'schedule and capability summary simply is not there below 640px.\n\n' +
+          'That meta line is three rules deep and reads as one sentence, so it is the part ' +
+          'worth reviewing: capabilities beat assigned specialities, four or more days collapse ' +
+          'to a `Mon–Fri` range while three or fewer are listed, `ALL_DAY` short-circuits to ' +
+          '"Every day", and a room with nothing configured falls back to "No schedule set" ' +
+          'rather than rendering an empty span.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div className="min-h-[420px] w-[860px] max-w-full bg-[var(--screen)] p-6">
+        <Story />
+      </div>
+    ),
+  ],
+  beforeEach: seed(),
+} satisfies Meta<typeof Rooms>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const RoomList: Story = {
+  name: 'Rooms list',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { name: 'Rooms (3)' })).toBeInTheDocument();
+
+    /* Assert the whole row button, not the name. The name, the lowercased type
+       and the meta line are three independent derivations of the same record,
+       and checking them separately passes with the meta of one room rendered
+       against the name of another. */
+    await expect(canvas.getByRole('button', { name: /^View Consult 1 details$/ }).textContent).toBe(
+      'Consult 1 · exam roomMon–Fri · Ultrasound, Dental X-ray'
+    );
+    // No capabilities: the assigned speciality is the fallback half of the line.
+    await expect(canvas.getByRole('button', { name: /^View Theatre A details$/ }).textContent).toBe(
+      'Theatre A · surgeryEvery day · Surgery'
+    );
+    // Neither: the sentence is a fallback, not an empty string.
+    await expect(
+      canvas.getByRole('button', { name: /^View Isolation bay details$/ }).textContent
+    ).toBe('Isolation bay · isolationNo schedule set');
+
+    await expect(canvas.getByRole('button', { name: '+ Add room' })).toBeInTheDocument();
+    await expect(openDialogs()).toHaveLength(0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting list. The leading glyph is chosen by room type - the scissors cover ' +
+          'surgery and grooming, the bed covers the four in-patient types, and everything ' +
+          'unmatched gets the medkit - so a new room type added to the enum silently inherits ' +
+          'the medkit rather than failing.',
+      },
+    },
+  },
+};
+
+export const Empty: Story = {
+  name: 'No rooms added yet',
+  beforeEach: seed({ rooms: [] }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('No rooms added yet.')).toBeInTheDocument();
+    await expect(canvas.getByRole('heading', { name: 'Rooms (0)' })).toBeInTheDocument();
+    // Empty replaces the whole <ul>, so there is no row left to click.
+    await expect(canvas.queryAllByRole('button', { name: /^View .* details$/ })).toHaveLength(0);
+    // The section still offers the way out of the empty state.
+    await expect(canvas.getByRole('button', { name: '+ Add room' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A loaded org with no rooms. `activeRoom` is `null` here, which is what keeps the ' +
+          'detail drawer from mounting at all - so this state has one fewer dialog in the DOM ' +
+          'than the populated one, not merely a closed one.',
+      },
+    },
+  },
+};
+
+export const AddRoomDrawer: Story = {
+  name: '+ Add room opens the drawer',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(openDialogs()).toHaveLength(0);
+
+    await userEvent.click(canvas.getByRole('button', { name: '+ Add room' }));
+
+    await waitFor(() => expect(openDialogs()).toHaveLength(1));
+    const panel = within(openDialogs()[0]);
+    await expect(panel.getByRole('heading', { name: 'Adding new room' })).toBeVisible();
+    /* The drawer's speciality and staff pickers read the same seeded stores the
+       list rows do, so the options are real rather than placeholders. The
+       footer action reads "Add room" too, which is why it is queried inside the
+       dialog rather than on the canvas - the section's own "+ Add room" link is
+       still there behind the scrim. */
+    await expect(panel.getByRole('button', { name: 'Basic details' })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
+    /* All four collapsible sections, named. The unit section carries its own
+       draft count in the header, so `Unit type (0)` is also the assertion that
+       the drawer opened EMPTY rather than holding drafts from a previous open -
+       a shared-state bug that a "the drawer appeared" check cannot see. */
+    for (const section of [
+      'Basic details',
+      'Availability',
+      'Unit type (0)',
+      'Equipments / Capabilities',
+    ]) {
+      await expect(panel.getByRole('button', { name: section })).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      );
+    }
+    await expect(panel.getByRole('button', { name: 'Add room' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The header action is a text link rather than a filled pill - the design keeps the ' +
+          'filled `--cta` treatment for the Team section, which is the one that spends money on ' +
+          'a seat. Both sit in the same header row shape, so the difference only shows with the ' +
+          'two sections side by side.',
+      },
+    },
+  },
+};
+
+export const WithoutEditPermission: Story = {
+  name: 'Add hidden without room:edit:any',
+  beforeEach: seed({ membership: OWNER_ROOMS_REVOKED }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.queryByRole('button', { name: '+ Add room' })).not.toBeInTheDocument();
+    // `room:view:any` survives the revocation, so the list itself is untouched.
+    await expect(canvas.getByRole('heading', { name: 'Rooms (3)' })).toBeInTheDocument();
+    await expect(canvas.getAllByRole('button', { name: /^View .* details$/ })).toHaveLength(3);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same flag also travels into the detail drawer as `canEditRoom`, so this is not ' +
+          'only a missing header link - the rows still open, read-only.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Specialities/Specialities.stories.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Specialities/Specialities.stories.tsx
@@ -1,0 +1,330 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import type { Organisation, UserOrganization } from '@yosemite-crew/types';
+
+import type { ServiceRevamp, SpecialityRevamp } from '@/app/features/organization/types/revamp';
+import type { Team } from '@/app/features/organization/types/team';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useRevampCatalogStore } from '@/app/stores/revampCatalogStore';
+import { useTeamStore } from '@/app/stores/teamStore';
+import Specialities from './Specialities';
+
+const ORG_ID = 'org-storybook-specialities';
+const DENTISTRY_ID = 'spec-dentistry';
+const CARDIOLOGY_ID = 'spec-cardiology';
+
+const ORG: Organisation = {
+  _id: ORG_ID,
+  name: 'Sunrise Veterinary Hospital',
+  type: 'HOSPITAL',
+  phoneNo: '4155550110',
+  taxId: 'DE-8871-2290',
+  isActive: true,
+};
+
+const OWNER: UserOrganization = {
+  id: 'membership-owner',
+  practitionerReference: 'Practitioner/vet-marsh',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'OWNER',
+  active: true,
+};
+
+const teamMember = (practionerId: string, name: string, role: string): Team => ({
+  _id: `member-${practionerId}`,
+  practionerId,
+  organisationId: ORG_ID,
+  name,
+  role,
+  speciality: [],
+  status: 'Available',
+  revokedPermissions: [],
+  effectivePermissions: [],
+  extraPerissions: [],
+});
+
+const TEAMS: Team[] = [
+  teamMember('vet-marsh', 'Dr. Elena Marsh', 'VETERINARIAN'),
+  teamMember('vet-patel', 'Dr. Ravi Patel', 'VETERINARIAN'),
+  teamMember('tech-reyes', 'Tom Reyes', 'TECHNICIAN'),
+];
+
+/**
+ * `activeServiceCount` is the count the API sent with the row. Dentistry's is
+ * deliberately WRONG (7) while one live ACTIVE service sits in the catalog
+ * store, because the table prefers the live count whenever it can compute one
+ * and only falls back to the server number at zero - which is the rule the
+ * Dentistry and Cardiology rows read together prove.
+ */
+const SPECIALITIES: SpecialityRevamp[] = [
+  {
+    id: DENTISTRY_ID,
+    name: 'Dentistry',
+    organisationId: ORG_ID,
+    headVetId: 'vet-marsh',
+    teamMemberIds: ['vet-patel', 'tech-reyes'],
+    activeServiceCount: 7,
+    activePackageCount: 3,
+  },
+  {
+    id: CARDIOLOGY_ID,
+    name: 'Cardiology',
+    organisationId: ORG_ID,
+    headVetId: 'vet-patel',
+    teamMemberIds: ['tech-reyes'],
+    activeServiceCount: 4,
+    activePackageCount: 1,
+  },
+];
+
+const SERVICES: ServiceRevamp[] = [
+  {
+    id: 'svc-dental-consult',
+    code: 'DEN-001',
+    name: 'Dental consultation',
+    description: 'Oral exam, charting and a treatment plan.',
+    type: 'CONSULTATION',
+    specialityId: DENTISTRY_ID,
+    organisationId: ORG_ID,
+    grossAmount: 72,
+    defaultDiscount: 0,
+    maxDiscount: 20,
+    durationMinutes: 30,
+    isBookable: true,
+    isInpatientPreferred: false,
+    status: 'ACTIVE',
+    createdAt: '2026-05-04T09:00:00.000Z',
+  },
+];
+
+/**
+ * Seeds the real stores rather than mocking the catalog service.
+ *
+ * Two separate guards are being satisfied here. `loadOrganisationCatalog`
+ * returns early once ANY seeded speciality carries this `organisationId`, which
+ * keeps the section's own mount effect off the network. `loadSpecialityCatalog`
+ * returns at its first line once a speciality key is in `loadedSpecialityIds`,
+ * which is what keeps the two tabs embedded in the drawer off it as well - so
+ * the drawer story mounts the real ServicesTab and PackagesTab with no stub.
+ *
+ * The speciality store is left EMPTY on purpose: it is the only source of the
+ * initial `activeSpeciality`, so with nothing in it the drawer does not mount
+ * at all until a row is clicked, and "a drawer opened" cannot pass by accident.
+ */
+const seed = () => {
+  useOrgStore.setState({
+    orgsById: { [ORG_ID]: ORG },
+    orgIds: [ORG_ID],
+    primaryOrgId: ORG_ID,
+    membershipsByOrgId: { [ORG_ID]: OWNER },
+    status: 'loaded',
+  });
+  useTeamStore.getState().setTeamsForOrg(ORG_ID, TEAMS);
+  useRevampCatalogStore.setState({
+    specialities: SPECIALITIES,
+    services: SERVICES,
+    packages: [],
+    loadedSpecialityIds: [`${DENTISTRY_ID}:active`, `${CARDIOLOGY_ID}:active`],
+  });
+
+  return () => {
+    useOrgStore.setState({
+      orgsById: {},
+      orgIds: [],
+      primaryOrgId: null,
+      membershipsByOrgId: {},
+      status: 'idle',
+    });
+    useTeamStore.setState({ teamsById: {}, teamIdsByOrgId: {} });
+    useRevampCatalogStore.setState({
+      specialities: [],
+      services: [],
+      packages: [],
+      loadedSpecialityIds: [],
+    });
+  };
+};
+
+/** The drawer portals to `document.body`, so it is never inside `canvasElement`. */
+const openDialogs = () => Array.from(document.querySelectorAll('dialog[open]')) as HTMLElement[];
+
+/** `FieldValueRow` is a flex row of exactly two divs, so a label's parent is its row. */
+const rowOf = (label: HTMLElement): HTMLElement => label.parentElement as HTMLElement;
+
+const meta = {
+  title: 'Organization/Specialities',
+  component: Specialities,
+  parameters: {
+    layout: 'fullscreen',
+    nextjs: { appDirectory: true, navigation: { pathname: '/organization' } },
+    docs: {
+      description: {
+        component:
+          'The specialities table on the organisation page. The table itself was visible; the ' +
+          '**side drawer behind its per-row eye button was not**, and that drawer is by far the ' +
+          'larger surface - `onManageTeam` sets the selection and opens `SpecialityInfo`, which ' +
+          'embeds two full feature tabs inside a 530px panel.\n\n' +
+          'The rows are worth reading closely because each number is computed twice. The ' +
+          'Services and Packages columns prefer a LIVE count from the catalog store and only ' +
+          'fall back to the `activeServiceCount` / `activePackageCount` the API sent when that ' +
+          'live count is zero, so a row can legitimately disagree with the number the backend ' +
+          'returned. The Head column resolves an id against the team store rather than printing ' +
+          '`headName`, so a speciality whose head has left the practice renders an em dash ' +
+          'instead of a stale name.\n\n' +
+          'Below `lg` the whole table is swapped for a card grid - both are always in the DOM ' +
+          'and a media query hides one - which is why every query here is a role query: the ' +
+          'hidden half is out of the accessibility tree but very much still in the text.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  /**
+   * Pinned rather than left on the project default. Every query in this file is
+   * a role query against the `hidden lg:block` table, and the `lg:hidden` card
+   * grid renders the same names, the same counts and the same eye button. Above
+   * 1024px the card grid is `display:none` and out of the accessibility tree, so
+   * the role queries resolve to exactly one node each; below it they resolve to
+   * the OTHER half, `getAllByRole('columnheader')` returns nothing and every
+   * story here fails. That threshold currently holds only because
+   * `initialGlobals` happens to be `laptop`, which is a preview-wide setting
+   * these stories should not be silently depending on.
+   */
+  globals: { viewport: { value: 'laptop', isRotated: false } },
+  decorators: [
+    (Story) => (
+      <div className="min-h-[560px] w-[1100px] max-w-full bg-[var(--screen)] p-6">
+        <Story />
+      </div>
+    ),
+  ],
+  beforeEach: seed,
+} satisfies Meta<typeof Specialities>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Table: Story = {
+  name: 'Specialities table',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Six columns, in order. The header is a real <thead>, unlike the CSS-grid
+    // bands the Team and Rooms sections use.
+    await expect(canvas.getAllByRole('columnheader').map((th) => th.textContent)).toEqual([
+      'Speciality',
+      'Services',
+      'Packages',
+      'Head',
+      'Team members',
+      'Actions',
+    ]);
+
+    /* Assert the whole row. Dentistry reads 1 service, not the 7 the row
+       carried, because one ACTIVE service is in the catalog store and the live
+       count wins; its 3 packages come from the row because no package is. */
+    const dentistry = canvas.getByRole('link', { name: 'Dentistry' }).closest('tr') as HTMLElement;
+    await expect(dentistry.textContent).toBe('Dentistry13Dr. Elena Marsh2');
+    // Nothing live for Cardiology, so both numbers are the row's own.
+    const cardiology = canvas
+      .getByRole('link', { name: 'Cardiology' })
+      .closest('tr') as HTMLElement;
+    await expect(cardiology.textContent).toBe('Cardiology41Dr. Ravi Patel1');
+
+    await expect(canvas.getAllByRole('button', { name: 'View details' })).toHaveLength(2);
+    await expect(canvas.getByRole('button', { name: 'Manage' })).toBeInTheDocument();
+    await expect(openDialogs()).toHaveLength(0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting table. The speciality name is a link to the full catalog route carrying ' +
+          '`?open=<id>`, while the eye button opens the drawer in place - two different ' +
+          'destinations from one row, which is only obvious with both drawn.',
+      },
+    },
+  },
+};
+
+export const SpecialityDrawer: Story = {
+  name: 'Eye button opens SpecialityInfo',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(openDialogs()).toHaveLength(0);
+
+    // The SECOND row on purpose: the callback has to carry the row it came from.
+    const cardiologyRow = canvas.getByRole('link', { name: 'Cardiology' }).closest('tr');
+    await userEvent.click(
+      within(cardiologyRow as HTMLElement).getByRole('button', { name: 'View details' })
+    );
+
+    await waitFor(() => expect(openDialogs()).toHaveLength(1));
+    const panel = within(openDialogs()[0]);
+
+    // Eyebrow / title / meta as one string, and the count is singular here.
+    const title = panel.getByRole('heading', { name: 'Cardiology' });
+    await expect((title.parentElement?.parentElement as HTMLElement).textContent).toBe(
+      'SpecialityCardiology1 member assigned'
+    );
+
+    /* The Team accordion resolves the stored ids against the same seeded team
+       store the table's Head column reads, so both sides of the panel agree.
+       Assert the ROW, not the value: all three rows share one form state and a
+       value under the wrong label leaves every `getByText` passing. */
+    await expect(rowOf(panel.getByText('Head')).textContent).toBe('HeadDr. Ravi Patel');
+    await expect(rowOf(panel.getByText('Staff')).textContent).toBe('StaffTom Reyes');
+
+    // The embedded catalog, mounted for real and genuinely empty for Cardiology.
+    await expect(panel.getByText('Services & Packages')).toBeInTheDocument();
+    await expect(panel.getByText("You haven't added any services yet.")).toBeInTheDocument();
+    await expect(panel.getByText("You haven't added any packages yet.")).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The gated surface. `activeSpeciality` starts as `null` in this story because the ' +
+          'speciality store is empty, so the drawer is not merely closed - it is not mounted - ' +
+          'and a click is the only thing that can produce it. That also makes the row identity ' +
+          'assertable: a callback that dropped its argument would open nothing at all.',
+      },
+    },
+  },
+};
+
+export const DrawerShowsLiveCatalog: Story = {
+  name: 'Drawer for a speciality with services',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const dentistryRow = canvas.getByRole('link', { name: 'Dentistry' }).closest('tr');
+    await userEvent.click(
+      within(dentistryRow as HTMLElement).getByRole('button', { name: 'View details' })
+    );
+
+    await waitFor(() => expect(openDialogs()).toHaveLength(1));
+    const panel = within(openDialogs()[0]);
+    await expect(panel.getByRole('heading', { name: 'Dentistry' })).toBeVisible();
+    await expect(rowOf(panel.getByText('Staff')).textContent).toBe(
+      'StaffDr. Ravi Patel, Tom Reyes'
+    );
+
+    /* TWO nodes per service inside the drawer: `ServicesTab` renders the wide
+       table row and the stacked card side by side and lets a container query
+       hide one. At 530px the stacked card is the one that wins, which makes this
+       drawer the only place in the product where that form is on screen. */
+    const serviceNodes = await panel.findAllByText('Dental consultation');
+    await expect(serviceNodes).toHaveLength(2);
+    await expect(panel.getByText("You haven't added any packages yet.")).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same drawer with a populated catalog. The one live service here is also the ' +
+          'reason the table row behind it reads 1 rather than 7 - the drawer and the row are ' +
+          'two readings of the same store, so they are the pair that catches a count that stops ' +
+          'tracking the catalog.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Specialities/SpecialityInfo.stories.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Specialities/SpecialityInfo.stories.tsx
@@ -1,0 +1,355 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import type { Organisation } from '@yosemite-crew/types';
+
+import type { ServiceRevamp } from '@/app/features/organization/types/revamp';
+import type { SpecialityWeb } from '@/app/features/organization/types/speciality';
+import type { Team } from '@/app/features/organization/types/team';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useRevampCatalogStore } from '@/app/stores/revampCatalogStore';
+import { useTeamStore } from '@/app/stores/teamStore';
+import SpecialityInfo from './SpecialityInfo';
+
+const ORG_ID = 'org-avenger-park';
+const SPECIALITY_ID = 'spec-dentistry';
+
+const ORG: Organisation = {
+  _id: ORG_ID,
+  name: 'Avenger Park Veterinary',
+  type: 'HOSPITAL',
+  phoneNo: '4155550110',
+  taxId: 'DE-8871-2290',
+  isActive: true,
+};
+
+const teamMember = (id: string, name: string, role: string): Team => ({
+  _id: `member-${id}`,
+  practionerId: id,
+  organisationId: ORG_ID,
+  name,
+  role,
+  speciality: [],
+  status: 'Available',
+  revokedPermissions: [],
+  effectivePermissions: [],
+  extraPerissions: [],
+});
+
+const TEAMS: Team[] = [
+  teamMember('vet-marsh', 'Dr. Elena Marsh', 'VETERINARIAN'),
+  teamMember('vet-patel', 'Dr. Ravi Patel', 'VETERINARIAN'),
+  teamMember('tech-reyes', 'Tom Reyes', 'TECHNICIAN'),
+];
+
+const DENTISTRY: SpecialityWeb = {
+  _id: SPECIALITY_ID,
+  organisationId: ORG_ID,
+  name: 'Dentistry',
+  headUserId: 'vet-marsh',
+  headName: 'Dr. Elena Marsh',
+  teamMemberIds: ['vet-patel', 'tech-reyes'],
+  isActive: true,
+};
+
+const SERVICES: ServiceRevamp[] = [
+  {
+    id: 'svc-1',
+    code: 'DEN-001',
+    name: 'Dental consultation',
+    description: 'Oral exam, charting and a treatment plan.',
+    type: 'CONSULTATION',
+    specialityId: SPECIALITY_ID,
+    organisationId: ORG_ID,
+    grossAmount: 72,
+    defaultDiscount: 0,
+    maxDiscount: 20,
+    durationMinutes: 30,
+    isBookable: true,
+    isInpatientPreferred: false,
+    status: 'ACTIVE',
+    createdAt: '2026-05-04T09:00:00.000Z',
+  },
+];
+
+/**
+ * Seeds the real stores rather than mocking the services.
+ *
+ * The team store feeds the Head/Staff dropdown options, which are also what turn
+ * the stored ids into names in read mode - without it both rows render raw ids.
+ * The catalog key keeps the two embedded tabs off the network: `loadSpecialityCatalog`
+ * returns at its first line once the speciality is in `loadedSpecialityIds`.
+ */
+const seed = () => {
+  useOrgStore.setState({
+    orgsById: { [ORG_ID]: ORG },
+    orgIds: [ORG_ID],
+    primaryOrgId: ORG_ID,
+    status: 'loaded',
+  });
+  useTeamStore.getState().setTeamsForOrg(ORG_ID, TEAMS);
+  useRevampCatalogStore.setState({
+    services: SERVICES,
+    packages: [],
+    loadedSpecialityIds: [`${SPECIALITY_ID}:active`],
+  });
+
+  return () => {
+    useOrgStore.setState({ orgsById: {}, orgIds: [], primaryOrgId: null, status: 'idle' });
+    useTeamStore.setState({ teamsById: {}, teamIdsByOrgId: {} });
+    useRevampCatalogStore.setState({ services: [], packages: [], loadedSpecialityIds: [] });
+  };
+};
+
+/**
+ * Both panels portal to `document.body`, so neither is inside `canvasElement`.
+ * The drawer is always first in document order; the delete confirm is mounted
+ * only while it is open, so it is second whenever it exists.
+ */
+const openDialogs = () => Array.from(document.querySelectorAll('dialog[open]')) as HTMLElement[];
+const drawer = () => openDialogs()[0];
+const confirmSheet = () => openDialogs()[1];
+
+/** `FieldValueRow` is a flex row of exactly two divs, so a label's parent is its row. */
+const rowOf = (label: HTMLElement): HTMLElement => label.parentElement as HTMLElement;
+
+type HarnessProps = {
+  activeSpeciality: SpecialityWeb;
+  canEditSpecialities: boolean;
+};
+
+const SpecialityInfoHarness = ({ activeSpeciality, canEditSpecialities }: HarnessProps) => {
+  const [open, setOpen] = useState(true);
+  return (
+    <div className="min-h-[620px] bg-[var(--screen)] p-6">
+      <p className="text-[13px] text-[var(--ink-muted)]">
+        The specialities grid sits behind the drawer, so the backdrop is visible.
+      </p>
+      <SpecialityInfo
+        showModal={open}
+        setShowModal={setOpen}
+        activeSpeciality={activeSpeciality}
+        canEditSpecialities={canEditSpecialities}
+      />
+    </div>
+  );
+};
+
+const meta = {
+  title: 'Organization/SpecialityInfo',
+  component: SpecialityInfoHarness,
+  parameters: {
+    layout: 'fullscreen',
+    nextjs: { appDirectory: true, navigation: { pathname: '/organization' } },
+    docs: {
+      description: {
+        component:
+          'The speciality drawer, opened from a card on the organisation page. Nothing in it had ' +
+          'ever been drawn: not the header, not the Team accordion, not the embedded catalog, ' +
+          'and not the delete confirm.\n\n' +
+          'It is unusual for a detail panel because it **embeds two full feature tabs**. The ' +
+          'Services & Packages section mounts the real `ServicesTab` and `PackagesTab` inside a ' +
+          '530px drawer, which is exactly the width where both drop out of their table layout ' +
+          'and into their stacked card form - so this panel is the only place in the product ' +
+          'where those two components are seen narrow, and the only place a regression in their ' +
+          'narrow form would show.\n\n' +
+          'The whole catalog section is behind `specialityId && organisationId`, so a speciality ' +
+          'that has not been persisted yet gets a drawer with a Team accordion and a footer and ' +
+          'nothing between them. That is a real state, not a defect, and it is drawn below.\n\n' +
+          'The delete confirm is hand-rolled here rather than reusing the catalog modal, ' +
+          'and it is guarded on `showModal && showDeleteModal` - the extra `showModal` term is ' +
+          'what stops the confirm surviving the drawer that raised it.\n\n' +
+          '`canEditSpecialities` is the single permission switch: it removes the header trash ' +
+          'and the accordion pencil together, which turns the panel into a read-only summary ' +
+          'while leaving the footer route intact.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    activeSpeciality: DENTISTRY,
+    canEditSpecialities: true,
+  },
+  beforeEach: seed,
+} satisfies Meta<typeof SpecialityInfoHarness>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Drawer: Story = {
+  name: 'Speciality drawer',
+  play: async () => {
+    await waitFor(() => expect(openDialogs()).toHaveLength(1));
+    const panel = within(drawer());
+
+    // Eyebrow / title / meta, all three of them.
+    await expect(panel.getByText('Speciality')).toBeInTheDocument();
+    await expect(panel.getByRole('heading', { name: 'Dentistry' })).toBeVisible();
+    await expect(panel.getByText('2 members assigned')).toBeInTheDocument();
+    await expect(panel.getByRole('button', { name: 'Delete speciality' })).toBeInTheDocument();
+
+    // The Team accordion opens by default and reads three rows. Assert the row,
+    // not the value: all three share one form state, and a value rendered under
+    // the wrong label leaves every `getByText(value)` assertion passing.
+    await expect(panel.getByRole('button', { name: 'Team' })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
+    await expect(rowOf(panel.getByText('Name')).textContent).toBe('NameDentistry');
+    // The stored ids are resolved into names through the seeded team store.
+    await expect(rowOf(panel.getByText('Head')).textContent).toBe('HeadDr. Elena Marsh');
+    await expect(rowOf(panel.getByText('Staff')).textContent).toBe(
+      'StaffDr. Ravi Patel, Tom Reyes'
+    );
+
+    // The catalog section, with both real tabs mounted inside the drawer.
+    await expect(panel.getByText('Services & Packages')).toBeInTheDocument();
+    await expect(panel.getByText('Services')).toBeInTheDocument();
+    await expect(panel.getByText('Packages')).toBeInTheDocument();
+    /* Two nodes per service: the table row and the stacked card are both in the
+       DOM and a container query hides one. At 530px it is the stacked card that
+       wins, which is the layout this drawer is the only place to see. */
+    expect(await panel.findAllByText('Dental consultation')).toHaveLength(2);
+    await expect(panel.getByText("You haven't added any packages yet.")).toBeInTheDocument();
+
+    await expect(
+      panel.getByRole('button', { name: 'Manage Services & Packages' })
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting panel. The header count and the Staff row read the same array from two ' +
+          'directions - a length and a resolved name list - so they are the pair that catches a ' +
+          'membership that saved on one side only.',
+      },
+    },
+  },
+};
+
+export const SingleMember: Story = {
+  name: 'One member assigned',
+  args: {
+    activeSpeciality: { ...DENTISTRY, teamMemberIds: ['vet-patel'] },
+  },
+  play: async () => {
+    await waitFor(() => expect(openDialogs()).toHaveLength(1));
+    const panel = within(drawer());
+    // Singular, and only the one name in the row below it.
+    await expect(panel.getByText('1 member assigned')).toBeInTheDocument();
+    await expect(rowOf(panel.getByText('Staff')).textContent).toBe('StaffDr. Ravi Patel');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The count pluralises in the header meta line. It is a one-character branch and the ' +
+          'only place in the panel where the number is written out rather than listed.',
+      },
+    },
+  },
+};
+
+export const ReadOnly: Story = {
+  name: 'Without edit permission',
+  args: { canEditSpecialities: false },
+  play: async () => {
+    await waitFor(() => expect(openDialogs()).toHaveLength(1));
+    const panel = within(drawer());
+
+    // One flag removes two affordances in two different components.
+    await expect(
+      panel.queryByRole('button', { name: 'Delete speciality' })
+    ).not.toBeInTheDocument();
+    await expect(panel.queryByRole('button', { name: 'Edit Team' })).not.toBeInTheDocument();
+    // Everything else survives: the rows still read, and the footer still routes.
+    await expect(rowOf(panel.getByText('Head')).textContent).toBe('HeadDr. Elena Marsh');
+    await expect(
+      panel.getByRole('button', { name: 'Manage Services & Packages' })
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The panel a viewer without `canEditSpecialities` gets. It is a read-only summary, not ' +
+          'a disabled form - the pencil and the trash are gone rather than greyed, so there is ' +
+          'nothing to click into a dead end.',
+      },
+    },
+  },
+};
+
+export const WithoutPersistedIds: Story = {
+  name: 'Speciality with no id yet',
+  args: {
+    activeSpeciality: { ...DENTISTRY, _id: undefined },
+  },
+  play: async () => {
+    await waitFor(() => expect(openDialogs()).toHaveLength(1));
+    const panel = within(drawer());
+
+    // The whole catalog section is gone - not empty, absent - because both tabs
+    // need an id to query with.
+    await expect(panel.queryByText('Services & Packages')).not.toBeInTheDocument();
+    await expect(panel.queryByText('Dental consultation')).not.toBeInTheDocument();
+    // The header and footer are unaffected, so the drawer collapses to two blocks.
+    await expect(panel.getByRole('heading', { name: 'Dentistry' })).toBeVisible();
+    await expect(rowOf(panel.getByText('Name')).textContent).toBe('NameDentistry');
+    await expect(
+      panel.getByRole('button', { name: 'Manage Services & Packages' })
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A speciality that reached the drawer without a persisted `_id`. The footer button ' +
+          'still renders and still navigates, just without the `?open=` query that would have ' +
+          'expanded this speciality on the catalog page - which is the one behaviour difference ' +
+          'this state produces rather than merely hiding a section.',
+      },
+    },
+  },
+};
+
+export const DeleteConfirm: Story = {
+  name: 'Delete confirm',
+  play: async () => {
+    await waitFor(() => expect(openDialogs()).toHaveLength(1));
+
+    await userEvent.click(within(drawer()).getByRole('button', { name: 'Delete speciality' }));
+
+    // Two dialogs open at once: the confirm sits over the drawer that raised it,
+    // and the drawer stays open underneath rather than being replaced.
+    await waitFor(() => expect(openDialogs()).toHaveLength(2));
+    const sheet = within(confirmSheet());
+    await expect(sheet.getByRole('heading', { name: 'Delete speciality' })).toBeVisible();
+    // The bolded name splits the sentence across three nodes, so the copy is
+    // asserted on the dialog.
+    await expect(confirmSheet()).toHaveTextContent(
+      'Are you sure you want to delete Dentistry? This action cannot be undone.'
+    );
+    await expect(sheet.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    await expect(sheet.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+    await expect(within(drawer()).getByRole('heading', { name: 'Dentistry' })).toBeVisible();
+
+    await userEvent.click(sheet.getByRole('button', { name: 'Cancel' }));
+
+    /* A dismissed dialog can stay mounted without its `open` attribute, so
+       absence is asserted against `dialog[open]` rather than against the element. */
+    await waitFor(() => expect(openDialogs()).toHaveLength(1));
+    await expect(within(drawer()).getByRole('button', { name: 'Delete speciality' })).toBeVisible();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Both dialogs are live at once, which is the case `ModalBase` keeps a stack for: ' +
+          'Escape and a backdrop click are answered only by the topmost one, so dismissing the ' +
+          'confirm cannot take the drawer down with it.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Team/Team.stories.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Team/Team.stories.tsx
@@ -1,0 +1,389 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import type { Organisation, Speciality, UserOrganization } from '@yosemite-crew/types';
+
+import type { Team as TeamMember } from '@/app/features/organization/types/team';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useSpecialityStore } from '@/app/stores/specialityStore';
+import { useTeamStore } from '@/app/stores/teamStore';
+import Team from './Team';
+
+const ORG_ID = 'org-storybook-team';
+
+const ORG: Organisation = {
+  _id: ORG_ID,
+  name: 'Sunrise Veterinary Hospital',
+  type: 'HOSPITAL',
+  phoneNo: '4155550110',
+  taxId: 'DE-8871-2290',
+  isVerified: true,
+  isActive: true,
+};
+
+/** Real role codes, so permissions resolve from the shipped role table rather than a stub. */
+const OWNER: UserOrganization = {
+  id: 'membership-owner',
+  practitionerReference: 'Practitioner/vet-marsh',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'OWNER',
+  active: true,
+};
+
+/** RECEPTIONIST holds `teams:view:any` but not `teams:edit:any`. */
+const RECEPTIONIST: UserOrganization = {
+  ...OWNER,
+  id: 'membership-reception',
+  roleCode: 'RECEPTIONIST',
+};
+
+const speciality = (id: string, name: string): Speciality => ({
+  _id: id,
+  organisationId: ORG_ID,
+  name,
+  isActive: true,
+});
+
+const SPECIALITIES: Speciality[] = [
+  speciality('spec-cardiology', 'Cardiology'),
+  speciality('spec-internal', 'Internal medicine'),
+];
+
+/**
+ * `employmentType` is read off the record through a cast in `employmentLabel`,
+ * so it is not on the `Team` type. The fixture carries it the same way the API
+ * response does.
+ */
+type TeamFixture = TeamMember & { employmentType?: string };
+
+const member = (over: Partial<TeamFixture> & Pick<TeamFixture, '_id' | 'name'>): TeamFixture => ({
+  practionerId: `practitioner-${over._id}`,
+  organisationId: ORG_ID,
+  role: 'VETERINARIAN',
+  speciality: [],
+  status: 'Available',
+  revokedPermissions: [],
+  effectivePermissions: [],
+  extraPerissions: [],
+  ...over,
+});
+
+/**
+ * Three members chosen to cover all three `teamStatusPill` branches and both
+ * `employmentLabel` branches in one screen: a raw status passed through, the
+ * "Requested" -> INVITED rename, the "Off-Duty" -> OFF DUTY muted pill, and the
+ * em-dash fallback for a member with no employment type on file.
+ */
+const TEAMS: TeamFixture[] = [
+  member({
+    _id: 'team-marsh',
+    name: 'Dr. Elena Marsh',
+    speciality: [SPECIALITIES[0]],
+    employmentType: 'FULL_TIME',
+    status: 'Consulting',
+  }),
+  member({
+    _id: 'team-raman',
+    name: 'Priya Raman',
+    role: 'TECHNICIAN',
+    speciality: [SPECIALITIES[1]],
+    employmentType: 'PART_TIME',
+    status: 'Requested',
+  }),
+  member({
+    _id: 'team-reyes',
+    name: 'Tom Reyes',
+    role: 'RECEPTIONIST',
+    status: 'Off-Duty',
+  }),
+];
+
+/**
+ * Seeds the real stores rather than mocking the hooks.
+ *
+ * `useTeamForPrimaryOrg` is a pure store selector - the fetch lives in the
+ * separate `useLoadTeam`, which this section does not call - so the roster
+ * mounts off the network with no service stub at all. `status: 'loaded'` is
+ * load-bearing: `usePermissions` reports `isLoading` while the org store is
+ * `idle`, and a loading `PermissionGate` renders its (null) skeleton, which
+ * would leave every story here blank rather than denied.
+ */
+const seed =
+  ({
+    membership = OWNER,
+    teams = TEAMS,
+  }: { membership?: UserOrganization; teams?: TeamFixture[] } = {}) =>
+  () => {
+    useOrgStore.setState({
+      orgsById: { [ORG_ID]: ORG },
+      orgIds: [ORG_ID],
+      primaryOrgId: ORG_ID,
+      membershipsByOrgId: { [ORG_ID]: membership },
+      status: 'loaded',
+    });
+    useTeamStore.getState().setTeamsForOrg(ORG_ID, teams);
+    useSpecialityStore.getState().setSpecialitiesForOrg(ORG_ID, SPECIALITIES);
+
+    return () => {
+      useOrgStore.setState({
+        orgsById: {},
+        orgIds: [],
+        primaryOrgId: null,
+        membershipsByOrgId: {},
+        status: 'idle',
+      });
+      useTeamStore.setState({ teamsById: {}, teamIdsByOrgId: {} });
+      useSpecialityStore.setState({ specialitiesById: {}, specialityIdsByOrgId: {} });
+    };
+  };
+
+/**
+ * Both panels portal to `document.body`, so neither is inside `canvasElement`,
+ * and a closed one stays MOUNTED without its `open` attribute - absence has to
+ * be asserted against `dialog[open]`.
+ */
+const openDialogs = () => Array.from(document.querySelectorAll('dialog[open]')) as HTMLElement[];
+
+/** The five-cell row that holds a member, given any text inside it. */
+const rowOf = (inside: HTMLElement): HTMLElement => inside.closest('div.grid') as HTMLElement;
+
+const meta = {
+  title: 'Organization/Team',
+  component: Team,
+  parameters: {
+    layout: 'fullscreen',
+    nextjs: { appDirectory: true, navigation: { pathname: '/organization' } },
+    docs: {
+      description: {
+        component:
+          'The team roster on the organisation page. Everything except the populated table was ' +
+          'unreachable in Storybook, because all of it is behind either a permission or a ' +
+          'store shape: the empty branch needs an org with no members, the invite pill needs ' +
+          '`teams:edit:any` **and** a verified org, and both drawers only exist after a ' +
+          'click.\n\n' +
+          'The invite affordance is an AND of two unrelated things, which is easy to lose in a ' +
+          'refactor: `canEditTeam && isVerified`. A verified clinic whose signed-in user is a ' +
+          'receptionist and an unverified clinic owned by the signed-in user render the same ' +
+          'header, for two entirely different reasons, and both are drawn below.\n\n' +
+          'The row is a five-track CSS grid, not a table - `1.6fr 1fr 1fr 110px 44px` shared ' +
+          'between the header band and every row. Nothing enforces that agreement, so a header ' +
+          'that grows a sixth cell silently wraps rather than failing, which is why the tracks ' +
+          'are counted here rather than eyeballed.\n\n' +
+          'Status is not passed through verbatim either: `teamStatusPill` renames "Requested" ' +
+          'to INVITED, mutes "Off-Duty" to OFF DUTY, and leaves anything else as the raw text ' +
+          'in the green completed pill.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: { isVerified: true },
+  decorators: [
+    (Story) => (
+      <div className="min-h-[520px] w-[980px] max-w-full bg-[var(--screen)] p-6">
+        <Story />
+      </div>
+    ),
+  ],
+  beforeEach: seed(),
+} satisfies Meta<typeof Team>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Roster: Story = {
+  name: 'Roster (owner, verified)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // The heading count is derived from the same array as the rows below it.
+    await expect(canvas.getByRole('heading', { name: 'Team (3)' })).toBeInTheDocument();
+
+    /* Assert the ROW, not the cells. Every one of these strings also exists
+       somewhere else on the screen, so three separate `getByText`s pass just as
+       happily with a value rendered against the wrong member. The avatar has no
+       image in these fixtures, so the monogram is the row's leading text. */
+    await expect(rowOf(canvas.getByText('Dr. Elena Marsh')).textContent).toBe(
+      'DEDr. Elena MarshCardiologyVeterinarianFull timeConsulting'
+    );
+    await expect(rowOf(canvas.getByText('Priya Raman')).textContent).toBe(
+      'PRPriya RamanInternal medicineTechnicianPart timeINVITED'
+    );
+    // No speciality subline and no employment type: the em-dash fallback.
+    await expect(rowOf(canvas.getByText('Tom Reyes')).textContent).toBe(
+      'TRTom ReyesReceptionist—OFF DUTY'
+    );
+
+    /* Five header cells and five tracks. The header band and the rows carry the
+       same `grid-cols-[1.6fr_1fr_1fr_110px_44px]` string and nothing checks that
+       they still agree; a template with four tracks pushes the 44px action
+       column onto a second line instead of failing. */
+    const header = canvasElement.querySelector('.yc-table-head') as HTMLElement;
+    await expect(header.children).toHaveLength(5);
+    await expect(getComputedStyle(header).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(5);
+
+    // Owner + verified: the invite pill is present and nothing is open yet.
+    await expect(canvas.getByRole('button', { name: 'Invite member' })).toBeInTheDocument();
+    await expect(openDialogs()).toHaveLength(0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting roster. The member cell stacks a bold name over the faint comma-joined ' +
+          'speciality list, and a member with no specialities loses the second line entirely ' +
+          'rather than rendering an empty one.',
+      },
+    },
+  },
+};
+
+export const Empty: Story = {
+  name: 'No team members yet',
+  beforeEach: seed({ teams: [] }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('No team members yet.')).toBeInTheDocument();
+    await expect(canvas.getByRole('heading', { name: 'Team (0)' })).toBeInTheDocument();
+
+    /* Empty is not the same as denied, and the copy alone cannot tell them
+       apart: the header band still renders here, and no row survived. */
+    await expect(canvas.getByText('Member')).toBeInTheDocument();
+    await expect(canvas.queryAllByRole('button', { name: /^Open .* details$/ })).toHaveLength(0);
+    // A clinic with no members can still invite one, so the pill stays.
+    await expect(canvas.getByRole('button', { name: 'Invite member' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A loaded roster with nothing in it - the state a freshly created clinic opens on. ' +
+          'The header band is still drawn above the sentence, so the empty branch is a row ' +
+          'replacement rather than a table replacement.',
+      },
+    },
+  },
+};
+
+export const UnverifiedOrg: Story = {
+  name: 'Invite hidden: org not verified',
+  args: { isVerified: false },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The owner still holds teams:edit:any - only the verification half is false.
+    await expect(canvas.queryByRole('button', { name: 'Invite member' })).not.toBeInTheDocument();
+    await expect(canvas.getByRole('heading', { name: 'Team (3)' })).toBeInTheDocument();
+    await expect(canvas.getAllByRole('button', { name: /^Open .* details$/ })).toHaveLength(3);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Half of the invite gate. `isVerified` is a prop from the organisation page, not a ' +
+          'permission, so an owner of an unverified clinic sees the full roster and its per-row ' +
+          'kebabs but cannot add to it.',
+      },
+    },
+  },
+};
+
+export const WithoutEditPermission: Story = {
+  name: 'Invite hidden: receptionist',
+  beforeEach: seed({ membership: RECEPTIONIST }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The other half of the gate, and the same rendered header.
+    await expect(canvas.queryByRole('button', { name: 'Invite member' })).not.toBeInTheDocument();
+    await expect(canvas.getByRole('heading', { name: 'Team (3)' })).toBeInTheDocument();
+    /* teams:view:any survives, so the roster itself is not gated away. Asserted
+       as a whole row rather than a name: a gate that leaked into the row cells
+       (an empty employment column, a missing status pill) still leaves the name
+       on screen, and a bare `getByText` would call that a pass. */
+    await expect(rowOf(canvas.getByText('Dr. Elena Marsh')).textContent).toBe(
+      'DEDr. Elena MarshCardiologyVeterinarianFull timeConsulting'
+    );
+    await expect(canvas.getAllByRole('button', { name: /^Open .* details$/ })).toHaveLength(3);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'RECEPTIONIST holds `teams:view:any` but not `teams:edit:any`. The permissions come ' +
+          'from the shipped role table via a real membership rather than a hand-written array, ' +
+          'so this story moves if the role table does.',
+      },
+    },
+  },
+};
+
+export const InviteDrawer: Story = {
+  name: 'Invite member opens AddTeam',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(openDialogs()).toHaveLength(0);
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Invite member' }));
+
+    await waitFor(() => expect(openDialogs()).toHaveLength(1));
+    const panel = within(openDialogs()[0]);
+    await expect(panel.getByRole('heading', { name: 'Add team' })).toBeVisible();
+    /* The employee-type row is three pills rather than a dropdown. Asserted as
+       one string so the label and its three options are pinned together and in
+       order - three separate existence checks pass with the row split apart or
+       an option renamed into the wrong slot. */
+    const employmentRow = panel.getByText('Employee type').parentElement as HTMLElement;
+    await expect(employmentRow.textContent).toBe('Employee typeFull timePart timeContract');
+
+    /* It also opens PRE-SELECTED on FULL_TIME, so the drawer is never in a
+       "nothing chosen" state for this field, unlike the two dropdowns above it.
+       Selection here is a colour swap with no aria state behind it, so it is
+       polled: the pills carry no transition, but the token layer resolving late
+       would still make one synchronous read compare two identical inks. */
+    const fullTime = panel.getByRole('button', { name: 'Full time' });
+    const partTime = panel.getByRole('button', { name: 'Part time' });
+    await waitFor(() => {
+      expect(getComputedStyle(fullTime).color).not.toBe(getComputedStyle(partTime).color);
+    });
+
+    await expect(panel.getByRole('button', { name: 'Send invite' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The invite drawer is mounted from the first render with `showModal` false, so its ' +
+          '`<dialog>` is in the DOM all along and only the `open` attribute moves. That is why ' +
+          'the assertions here count `dialog[open]` rather than looking for the panel markup.',
+      },
+    },
+  },
+};
+
+export const MemberDrawer: Story = {
+  name: 'Row kebab opens TeamInfo',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Open Priya Raman details' }));
+
+    await waitFor(() => expect(openDialogs()).toHaveLength(1));
+    const panel = within(openDialogs()[0]);
+    const title = panel.getByRole('heading', { name: 'Priya Raman' });
+    /* Eyebrow / title / meta as one string. The kebab has to select the row it
+       belongs to, and `activeTeam` starts life pointing at the FIRST member -
+       so asserting only that a drawer opened, or only that some heading exists,
+       passes just as well with Dr. Elena Marsh in it. */
+    await expect((title.parentElement?.parentElement as HTMLElement).textContent).toBe(
+      'Team memberPriya RamanTechnician'
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The per-row kebab sets `activeTeam` and opens the drawer in one handler. Opening it ' +
+          'also fires the panel’s profile fetch, which has no backend in Storybook: the ' +
+          'component catches that itself and falls back to `profile = null`, so what is drawn ' +
+          'here is the roster record plus the empty profile sections, not a half-loaded panel.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/organization/pages/Organization/Sections/Team/TeamInfo.stories.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Organization/Sections/Team/TeamInfo.stories.tsx
@@ -1,0 +1,449 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import type { Organisation, Speciality, UserOrganization } from '@yosemite-crew/types';
+
+import type { Team } from '@/app/features/organization/types/team';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useSpecialityStore } from '@/app/stores/specialityStore';
+import { computeEffectivePermissions } from './permissionsEditorUtils';
+import TeamInfo from './TeamInfo';
+
+const ORG_ID = 'org-avenger-park';
+const DENTISTRY_ID = 'spec-dentistry';
+
+const ORG: Organisation = {
+  _id: ORG_ID,
+  name: 'Avenger Park Veterinary',
+  type: 'HOSPITAL',
+  phoneNo: '4155550110',
+  taxId: 'DE-8871-2290',
+  isActive: true,
+};
+
+const SPECIALITIES: Speciality[] = [
+  { _id: DENTISTRY_ID, organisationId: ORG_ID, name: 'Dentistry', isActive: true },
+  { _id: 'spec-surgery', organisationId: ORG_ID, name: 'Surgery', isActive: true },
+];
+
+/**
+ * The member's permissions are derived from the shipped role table rather than
+ * listed literally, so the Permissions accordion shows what a real VETERINARIAN
+ * holds instead of a hand-picked set that could drift from the product.
+ */
+const MEMBER: Team = {
+  _id: 'team-hartmann',
+  practionerId: 'vet-hartmann',
+  organisationId: ORG_ID,
+  name: 'Dr. Lena Hartmann',
+  role: 'VETERINARIAN',
+  speciality: [SPECIALITIES[0]],
+  status: 'Available',
+  revokedPermissions: [],
+  extraPerissions: [],
+  effectivePermissions: computeEffectivePermissions({ role: 'VETERINARIAN' }),
+};
+
+/** The signed-in viewer IS this member: `practitionerReference` resolves to their id. */
+const SELF_MEMBERSHIP: UserOrganization = {
+  id: 'membership-hartmann',
+  practitionerReference: 'Practitioner/vet-hartmann',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'VETERINARIAN',
+  active: true,
+};
+
+/** Someone else, so every self-only section drops to read-only. */
+const OTHER_MEMBERSHIP: UserOrganization = {
+  ...SELF_MEMBERSHIP,
+  id: 'membership-reyes',
+  practitionerReference: 'Practitioner/tech-reyes',
+  roleCode: 'RECEPTIONIST',
+};
+
+/**
+ * Seeds the real stores rather than mocking the hooks.
+ *
+ * Two things follow from the membership alone. `isSelfMember` compares the
+ * member's practitioner id against the viewer's `practitionerReference`, and it
+ * is what unlocks Personal, Address, Professional and Availability - a team
+ * manager cannot edit another person's profile, so the permission axis here is
+ * ownership, not seniority.
+ *
+ * The panel also fires one profile request on open. There is no backend in
+ * Storybook, so it fails and the component's own `catch` sets `profile` to null -
+ * which is the same state a member who has not completed onboarding is in
+ * (`getProfileForUserForPrimaryOrg` treats a 404 as expected). The three profile
+ * sections therefore render their real not-yet-filled form: every row present,
+ * every value a dash.
+ */
+const seed =
+  (membership: UserOrganization = SELF_MEMBERSHIP) =>
+  () => {
+    useOrgStore.setState({
+      orgsById: { [ORG_ID]: ORG },
+      orgIds: [ORG_ID],
+      primaryOrgId: ORG_ID,
+      membershipsByOrgId: { [ORG_ID]: membership },
+      status: 'loaded',
+    });
+    useSpecialityStore.getState().setSpecialitiesForOrg(ORG_ID, SPECIALITIES);
+
+    return () => {
+      useOrgStore.setState({
+        orgsById: {},
+        orgIds: [],
+        primaryOrgId: null,
+        membershipsByOrgId: {},
+        status: 'idle',
+      });
+      useSpecialityStore.setState({ specialitiesById: {}, specialityIdsByOrgId: {} });
+    };
+  };
+
+/**
+ * Both panels portal to `document.body`, so neither is inside `canvasElement`.
+ * The drawer is first in document order; the confirm is mounted only while open.
+ */
+const openDialogs = () => Array.from(document.querySelectorAll('dialog[open]')) as HTMLElement[];
+const drawer = () => openDialogs()[0];
+const confirmSheet = () => openDialogs()[1];
+
+/** `FieldValueRow` is a flex row of exactly two divs, so a label's parent is its row. */
+const rowOf = (label: HTMLElement): HTMLElement => label.parentElement as HTMLElement;
+
+type HarnessProps = {
+  activeTeam: Team;
+  canEditTeam: boolean;
+};
+
+const TeamInfoHarness = ({ activeTeam, canEditTeam }: HarnessProps) => {
+  const [open, setOpen] = useState(true);
+  return (
+    <div className="min-h-[620px] bg-[var(--screen)] p-6">
+      <p className="text-[13px] text-[var(--ink-muted)]">
+        The team list sits behind the drawer, so the backdrop tint is visible.
+      </p>
+      <TeamInfo
+        showModal={open}
+        setShowModal={setOpen}
+        activeTeam={activeTeam}
+        canEditTeam={canEditTeam}
+      />
+    </div>
+  );
+};
+
+const meta = {
+  title: 'Organization/TeamInfo',
+  component: TeamInfoHarness,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The team member drawer. It is six accordions in one 530px panel, and **three of them ' +
+          'open closed** - Address details, Professional details and Availability - so half the ' +
+          'drawer had never appeared in any render, static or otherwise. The delete confirm ' +
+          'behind the header trash had not either.\n\n' +
+          'Availability is the section worth the most attention, because it is not a form of ' +
+          'rows like the others: it is a seven-row weekly grid ' +
+          '(`40px | 96px | 1fr | auto`) of pill switches and time chips, with its own save ' +
+          'button and its own in-flight label, all inside a panel whose other five sections save ' +
+          'through a shared accordion. It is also the only section whose contents are seeded ' +
+          'from the profile response rather than from props.\n\n' +
+          'Editing rights are **ownership-based, not seniority-based**. `canEditTeam` governs ' +
+          'only the org-details fields and the delete control; Personal, Address, Professional ' +
+          'and Availability are unlocked by being the member, so an admin opening a colleague ' +
+          'gets a panel with fewer pencils than that colleague does. Both sides are drawn below.\n\n' +
+          'One state is deliberately not storied: `Saving availability...`. It exists only while ' +
+          'the upsert is in flight, and this repo has no request-mocking layer, so its lifetime ' +
+          'would be decided by how fast a real request fails.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    activeTeam: MEMBER,
+    canEditTeam: true,
+  },
+  beforeEach: seed(),
+} satisfies Meta<typeof TeamInfoHarness>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Drawer: Story = {
+  name: 'Team member drawer',
+  play: async () => {
+    await waitFor(() => expect(openDialogs()).toHaveLength(1));
+    const panel = within(drawer());
+
+    await expect(panel.getByText('Team member')).toBeInTheDocument();
+    await expect(panel.getByRole('heading', { name: 'Dr. Lena Hartmann' })).toBeVisible();
+    await expect(panel.getByRole('button', { name: 'Delete team member' })).toBeInTheDocument();
+
+    // Six accordions, and only the first two are open.
+    const expanded = (title: string) =>
+      panel.getByRole('button', { name: title }).getAttribute('aria-expanded');
+    await expect(expanded('Org details')).toBe('true');
+    await expect(expanded('Personal details')).toBe('true');
+    await expect(expanded('Address details')).toBe('false');
+    await expect(expanded('Professional details')).toBe('false');
+    await expect(expanded('Availability')).toBe('false');
+    await expect(expanded('Permissions')).toBe('false');
+
+    /* The org row resolves the raw enum through RoleOptions, and the department
+       resolves the speciality id through the seeded speciality store. Assert the
+       ROW, not the value: the sections share one form state, and a value under
+       the wrong label leaves every `getByText(value)` assertion passing. */
+    await expect(rowOf(panel.getByText('Role')).textContent).toBe('RoleVeterinarian');
+    await expect(rowOf(panel.getByText('Department')).textContent).toBe('DepartmentDentistry');
+    // No profile yet, so employment type is the dash rather than a blank cell.
+    await expect(rowOf(panel.getByText('Employment type')).textContent).toBe('Employment type-');
+    // The name comes off the membership record, not the profile, which is why it
+    // is the one personal row with a value.
+    await expect(rowOf(panel.getByText('Name')).textContent).toBe('NameDr. Lena Hartmann');
+
+    // The three closed bodies contribute nothing - not a hidden node.
+    await expect(panel.queryByText('State/Province')).not.toBeInTheDocument();
+    await expect(panel.queryByText('Medical license number')).not.toBeInTheDocument();
+    await expect(
+      panel.queryByRole('button', { name: 'Save availability' })
+    ).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The drawer as it opens. The header meta is the role label, which also appears as the ' +
+          'first row of Org details - the same value in two places, which is why the row ' +
+          'assertions above are scoped rather than done by text.',
+      },
+    },
+  },
+};
+
+export const AddressDetailsOpen: Story = {
+  name: 'Address details opened',
+  play: async () => {
+    await waitFor(() => expect(openDialogs()).toHaveLength(1));
+    const panel = within(drawer());
+
+    await userEvent.click(panel.getByRole('button', { name: 'Address details' }));
+
+    // Four rows, in the order the section stores them. Every one is a dash,
+    // which is the shipped empty rendering: `formatDisplayValue` turns an empty
+    // string into "-" so a row never appears as a label with nothing beside it.
+    expect(await panel.findByText('Address')).toBeInTheDocument();
+    await expect(rowOf(panel.getByText('Address')).textContent).toBe('Address-');
+    await expect(rowOf(panel.getByText('State/Province')).textContent).toBe('State/Province-');
+    await expect(rowOf(panel.getByText('City')).textContent).toBe('City-');
+    await expect(rowOf(panel.getByText('Postal code')).textContent).toBe('Postal code-');
+    // This member is the viewer, so the section is editable.
+    await expect(panel.getByRole('button', { name: 'Edit Address details' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The address section for a member whose profile has never been filled in - the state ' +
+          'every invited member is in until they complete onboarding, and the reason the four ' +
+          'rows still render rather than collapsing to an empty box. The address field is a ' +
+          'Google-autocomplete input in edit mode, so the read row and the edit row are not the ' +
+          'same control.',
+      },
+    },
+  },
+};
+
+export const ProfessionalDetailsOpen: Story = {
+  name: 'Professional details opened',
+  play: async () => {
+    await waitFor(() => expect(openDialogs()).toHaveLength(1));
+    const panel = within(drawer());
+
+    await userEvent.click(panel.getByRole('button', { name: 'Professional details' }));
+
+    /* Six rows, in `ProfessionalFields` order - the longest section in the drawer
+       and the one that decides how far the panel scrolls. Every row is asserted
+       as label + value rather than by the label alone: all six share one form
+       state, so a value rendered under the wrong label leaves a label-only check
+       passing. Every value is the dash, which is the shipped empty rendering. */
+    expect(await panel.findByText('LinkedIn')).toBeInTheDocument();
+    await expect(rowOf(panel.getByText('LinkedIn')).textContent).toBe('LinkedIn-');
+    await expect(rowOf(panel.getByText('Medical license number')).textContent).toBe(
+      'Medical license number-'
+    );
+    await expect(rowOf(panel.getByText('Years of experience')).textContent).toBe(
+      'Years of experience-'
+    );
+    await expect(rowOf(panel.getByText('Specialisation')).textContent).toBe('Specialisation-');
+    // The label carries its own examples, which is the longest label in the panel
+    // and the one that tests the row's two-column truncation.
+    await expect(rowOf(panel.getByText('Qualification (MBBS, MD, etc.)')).textContent).toBe(
+      'Qualification (MBBS, MD, etc.)-'
+    );
+    await expect(rowOf(panel.getByText('Biography or short description')).textContent).toBe(
+      'Biography or short description-'
+    );
+    await expect(
+      panel.getByRole('button', { name: 'Edit Professional details' })
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Six free-text rows that all save through one handler into ' +
+          '`profile.professionalDetails`. Biography is a plain text input rather than a textarea, ' +
+          'so a long biography is a single truncated line here and in edit mode alike.',
+      },
+    },
+  },
+};
+
+export const AvailabilityOpen: Story = {
+  name: 'Availability grid opened',
+  play: async () => {
+    await waitFor(() => expect(openDialogs()).toHaveLength(1));
+    const panel = within(drawer());
+
+    await userEvent.click(panel.getByRole('button', { name: 'Availability' }));
+
+    // Seven rows, one per day, starting at Sunday.
+    const monday = await panel.findByRole('checkbox', {
+      name: 'Enable availability for Monday',
+    });
+    await expect(panel.getAllByRole('checkbox')).toHaveLength(7);
+    await expect(monday).toBeChecked();
+    await expect(
+      panel.getByRole('checkbox', { name: 'Enable availability for Friday' })
+    ).toBeChecked();
+    // The weekend is off by default, and an off day replaces its whole time
+    // column with a single "Day off" label rather than dimming the chips.
+    await expect(
+      panel.getByRole('checkbox', { name: 'Enable availability for Sunday' })
+    ).not.toBeChecked();
+    await expect(panel.getAllByText('Day off')).toHaveLength(2);
+
+    // Five enabled days x one 09:00-17:00 range = five chips of each label.
+    await expect(panel.getAllByText('9:00 AM')).toHaveLength(5);
+    await expect(panel.getAllByText('5:00 PM')).toHaveLength(5);
+    // Per-day actions exist only on enabled days.
+    await expect(panel.getAllByRole('button', { name: /^Add range for / })).toHaveLength(5);
+
+    /* The row template is four fixed tracks over four children. Nothing enforces
+       that agreement, and a template with fewer tracks than children silently
+       wraps the actions onto a second line instead of failing. */
+    const row = monday.closest('.grid') as HTMLElement;
+    await expect(getComputedStyle(row).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(4);
+    await expect(row.children).toHaveLength(4);
+
+    // The section owns its own save, separate from the accordion saves above it.
+    await expect(panel.getByRole('button', { name: 'Save availability' })).toBeEnabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The weekly grid, seeded with the Monday-to-Friday 09:00-17:00 default that both the ' +
+          'initial state and an empty profile response produce. Each enabled day can grow extra ' +
+          'ranges and copy itself onto other days, so the row height is not fixed and the panel ' +
+          'below it has to reflow.',
+      },
+    },
+  },
+};
+
+export const OtherPersonsProfile: Story = {
+  name: 'Viewing someone else, as a manager',
+  beforeEach: seed(OTHER_MEMBERSHIP),
+  play: async () => {
+    await waitFor(() => expect(openDialogs()).toHaveLength(1));
+    const panel = within(drawer());
+
+    // `canEditTeam` is still true, so the org-level controls survive.
+    await expect(panel.getByRole('button', { name: 'Delete team member' })).toBeInTheDocument();
+    await expect(panel.getByRole('button', { name: 'Edit Org details' })).toBeInTheDocument();
+
+    // But every self-only pencil is gone: a manager cannot edit a colleague's
+    // personal record, only their place in the org.
+    await expect(
+      panel.queryByRole('button', { name: 'Edit Personal details' })
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(panel.getByRole('button', { name: 'Address details' }));
+    expect(await panel.findByText('City')).toBeInTheDocument();
+    await expect(
+      panel.queryByRole('button', { name: 'Edit Address details' })
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(panel.getByRole('button', { name: 'Availability' }));
+    // The grid still renders in full - it is read-only, not hidden - and its
+    // save button is removed rather than disabled.
+    const sunday = await panel.findByRole('checkbox', {
+      name: 'Enable availability for Sunday',
+    });
+    await expect(sunday).toBeDisabled();
+    await expect(panel.getAllByRole('checkbox')).toHaveLength(7);
+    await expect(
+      panel.queryByRole('button', { name: 'Save availability' })
+    ).not.toBeInTheDocument();
+    // Read-only also drops the per-day add/duplicate actions from every row.
+    await expect(panel.queryAllByRole('button', { name: /^Add range for / })).toHaveLength(0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A team manager looking at another member. This is the asymmetry that is easy to get ' +
+          'backwards: the person with more authority sees FEWER editable sections, because four ' +
+          'of the six belong to the member rather than to the org.',
+      },
+    },
+  },
+};
+
+export const DeleteConfirm: Story = {
+  name: 'Delete team member confirm',
+  play: async () => {
+    await waitFor(() => expect(openDialogs()).toHaveLength(1));
+
+    await userEvent.click(within(drawer()).getByRole('button', { name: 'Delete team member' }));
+
+    // Two dialogs at once: the confirm over the drawer that raised it, which
+    // stays open underneath rather than being replaced.
+    await waitFor(() => expect(openDialogs()).toHaveLength(2));
+    const sheet = within(confirmSheet());
+    await expect(sheet.getByRole('heading', { name: 'Delete team member' })).toBeVisible();
+    // The emphasised name splits the sentence across three nodes, so the copy is
+    // asserted on the dialog. Note the stray leading space before the name: it
+    // is in the shipped markup.
+    await expect(confirmSheet()).toHaveTextContent(
+      'Are you sure you want to delete Dr. Lena Hartmann? This action cannot be undone.'
+    );
+    await expect(sheet.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    await expect(sheet.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+
+    await userEvent.click(sheet.getByRole('button', { name: 'Cancel' }));
+
+    /* A dismissed dialog can stay mounted without its `open` attribute, so
+       absence is asserted against `dialog[open]` rather than the element. */
+    await waitFor(() => expect(openDialogs()).toHaveLength(1));
+    await expect(
+      within(drawer()).getByRole('heading', { name: 'Dr. Lena Hartmann' })
+    ).toBeVisible();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The confirm is behind `canDeleteMember`, which also excludes an OWNER, so this dialog ' +
+          'is unreachable for the one member whose removal would strand the organisation. ' +
+          'Closing the drawer clears the confirm too - `handleModalVisibility` resets it on the ' +
+          'way out, so a reopened drawer never comes back with the dialog still raised.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/organization/pages/Specialities/ArchiveTab.stories.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Specialities/ArchiveTab.stories.tsx
@@ -1,0 +1,281 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import type { PackageRevamp, ServiceRevamp } from '@/app/features/organization/types/revamp';
+import { useRevampCatalogStore } from '@/app/stores/revampCatalogStore';
+import ArchiveTab from './ArchiveTab';
+
+const ORG_ID = 'org-avenger-park';
+const SPECIALITY_ID = 'spec-dentistry';
+
+const service = (over: Partial<ServiceRevamp> & Pick<ServiceRevamp, 'id' | 'code' | 'name'>) => ({
+  description: '',
+  type: 'CONSULTATION' as const,
+  specialityId: SPECIALITY_ID,
+  organisationId: ORG_ID,
+  grossAmount: 72,
+  defaultDiscount: 0,
+  maxDiscount: 20,
+  durationMinutes: 30,
+  isBookable: true,
+  isInpatientPreferred: false,
+  status: 'ARCHIVED' as const,
+  createdAt: '2026-05-04T09:00:00.000Z',
+  ...over,
+});
+
+const ARCHIVED_SERVICES: ServiceRevamp[] = [
+  service({ id: 'svc-1', code: 'DEN-004', name: 'Fluoride varnish' }),
+  service({
+    id: 'svc-2',
+    code: 'DEN-021',
+    name: 'Extraction under general anaesthetic',
+    type: 'PROCEDURE',
+    grossAmount: 310,
+    defaultDiscount: 10,
+    durationMinutes: 90,
+  }),
+];
+
+const ARCHIVED_PACKAGES: PackageRevamp[] = [
+  {
+    id: 'pkg-1',
+    code: 'PKG-DEN-09',
+    name: 'Puppy dental starter',
+    description: 'Retired in favour of the wellness plan.',
+    specialityId: SPECIALITY_ID,
+    organisationId: ORG_ID,
+    durationText: '1 h 30 min',
+    isBookable: false,
+    isInpatientPreferred: false,
+    leadCount: 1,
+    supportCount: 0,
+    additionalDiscount: 0,
+    breakdown: [],
+    status: 'ARCHIVED',
+    createdAt: '2026-04-11T09:00:00.000Z',
+  },
+];
+
+/**
+ * Seeds the real store rather than mocking the catalog service.
+ *
+ * `ArchiveTab` is the one tab that always passes `force: true`, so unlike the
+ * services and packages tabs it cannot be kept off the network by seeding
+ * `loadedSpecialityIds` - it fires one archive request on mount regardless. That
+ * request fails in Storybook and the component's own `.catch` swallows it, which
+ * leaves the seed untouched: everything below is rendered from these fixtures,
+ * not from a response.
+ */
+const seed = (services: ServiceRevamp[], packages: PackageRevamp[]) => () => {
+  useRevampCatalogStore.setState({
+    services,
+    packages,
+    loadedSpecialityIds: [`${SPECIALITY_ID}:all`],
+  });
+  return () => {
+    useRevampCatalogStore.setState({ services: [], packages: [], loadedSpecialityIds: [] });
+  };
+};
+
+/** The confirm portals to `document.body`, so it is never inside `canvasElement`. */
+const openDialog = () => document.querySelector('dialog[open]');
+
+const meta = {
+  title: 'Organization/ArchiveTab',
+  component: ArchiveTab,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The third tab of a speciality accordion, and the only one that lists `ARCHIVED` ' +
+          'catalog items. It is two clicks deep - open a speciality, then pick Archive - and ' +
+          'every one of its three states was undrawn: the empty sentence, the two grouped row ' +
+          'lists, and the permanent-delete confirm behind a row trash.\n\n' +
+          'Archived rows are not the services table with a filter applied. They are their own ' +
+          'compact row: an ordinal, the name, a `code / type / price` strip, and two circular ' +
+          '36px actions, the whole card dimmed to `opacity-80`. Services and packages get ' +
+          'separate lists under their own uppercase captions, and either list disappears ' +
+          'entirely when empty - so an org with archived packages but no archived services sees ' +
+          'one caption, not two.\n\n' +
+          'The two row actions are deliberately asymmetric. Restore acts immediately with no ' +
+          'confirmation, because it is reversible; delete opens a centred confirm that says the ' +
+          'action cannot be undone, because it is the only place in the catalog where a record ' +
+          'leaves for good.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    specialityId: SPECIALITY_ID,
+    organisationId: ORG_ID,
+  },
+  decorators: [
+    (Story) => (
+      <div className="min-h-[420px] w-[900px] max-w-full bg-[var(--screen)] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+  beforeEach: seed(ARCHIVED_SERVICES, ARCHIVED_PACKAGES),
+} satisfies Meta<typeof ArchiveTab>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Empty: Story = {
+  name: 'Nothing archived',
+  beforeEach: seed([], []),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('No archived services or packages.')).toBeInTheDocument();
+    /* Empty means BOTH lists are gone, not that the sentence rendered: the two
+       captions are independent `length > 0` branches, so a bug that emptied only
+       the rows would leave a caption standing over nothing. */
+    await expect(canvas.queryByText('Services')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Packages')).not.toBeInTheDocument();
+    await expect(canvas.queryAllByRole('button', { name: /^Restore / })).toHaveLength(0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The state most orgs are in. It is a single centred line with an info glyph rather ' +
+          'than an illustrated empty state, because the tab is a maintenance surface and not a ' +
+          'place anyone is meant to land.',
+      },
+    },
+  },
+};
+
+export const ArchivedItems: Story = {
+  name: 'Archived services and packages',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByText('Services')).toBeInTheDocument();
+    await expect(canvas.getByText('Packages')).toBeInTheDocument();
+    await expect(canvas.queryByText('No archived services or packages.')).not.toBeInTheDocument();
+
+    // Each list numbers from 1 independently, so "1." appears once per list.
+    await expect(canvas.getAllByText('1.')).toHaveLength(2);
+    await expect(canvas.getByText('2.')).toBeInTheDocument();
+
+    // The meta strip is code / humanised type / price - the raw enum must never
+    // reach the screen, and the price is the DISCOUNTED total, not the gross.
+    await expect(canvas.getByText('DEN-021')).toBeInTheDocument();
+    await expect(canvas.getByText('Procedure')).toBeInTheDocument();
+    await expect(canvas.queryByText('PROCEDURE')).not.toBeInTheDocument();
+    await expect(canvas.getByText('$279')).toBeInTheDocument();
+    await expect(canvas.getByText('$72')).toBeInTheDocument();
+
+    // Packages show their duration text where a service shows a price.
+    await expect(canvas.getByText('PKG-DEN-09')).toBeInTheDocument();
+    await expect(canvas.getByText('1 h 30 min')).toBeInTheDocument();
+
+    // Two actions on every row of both lists: three rows, six buttons.
+    await expect(canvas.getAllByRole('button', { name: /^Restore / })).toHaveLength(3);
+    await expect(canvas.getAllByRole('button', { name: / permanently$/ })).toHaveLength(3);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Both lists at once. The price on a service row is `computeServiceTotal`, so the ' +
+          'extraction shows $279 rather than its $310 gross - the archived row reports what the ' +
+          'service actually charged, which is the number a reviewer restoring it needs to see.',
+      },
+    },
+  },
+};
+
+export const OnlyPackagesArchived: Story = {
+  name: 'Only packages archived',
+  beforeEach: seed([], ARCHIVED_PACKAGES),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Packages')).toBeInTheDocument();
+    await expect(canvas.queryByText('Services')).not.toBeInTheDocument();
+    await expect(canvas.getByText('Puppy dental starter')).toBeInTheDocument();
+    await expect(canvas.getAllByRole('button', { name: /^Restore / })).toHaveLength(1);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'One caption, not an empty "Services" heading over nothing. The two lists are separate ' +
+          'branches on separate arrays, so this asymmetry is a real layout the design has to ' +
+          'survive rather than an edge case.',
+      },
+    },
+  },
+};
+
+export const PermanentDeleteConfirm: Story = {
+  name: 'Permanent-delete confirm',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(openDialog()).toBeNull();
+
+    await userEvent.click(
+      canvas.getByRole('button', { name: 'Delete Fluoride varnish permanently' })
+    );
+
+    await waitFor(() => expect(openDialog()).not.toBeNull());
+    const dialog = openDialog() as HTMLElement;
+    // The title is built from the target's `kind`, so a package row would title
+    // this "Delete package" from the same component.
+    await expect(within(dialog).getByRole('heading', { name: 'Delete service' })).toBeVisible();
+    /* The sentence is split across three nodes by the bolded name, so it can only
+       be asserted on the container - and the name is the half that matters, since
+       the confirm names the row that was clicked rather than a generic item. */
+    await expect(dialog).toHaveTextContent(
+      'Are you sure you want to permanently delete Fluoride varnish? This action cannot be undone.'
+    );
+    await expect(within(dialog).getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    await expect(within(dialog).getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The only irreversible action in the catalog. It portals to `document.body`, so it ' +
+          'escapes the accordion panel it was opened from and is not clipped by the scroll ' +
+          'container of the tab underneath it.',
+      },
+    },
+  },
+};
+
+export const ConfirmCancelled: Story = {
+  name: 'Confirm cancelled, row survives',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      canvas.getByRole('button', { name: 'Delete Puppy dental starter permanently' })
+    );
+    await waitFor(() => expect(openDialog()).not.toBeNull());
+    const dialog = openDialog() as HTMLElement;
+    await expect(within(dialog).getByRole('heading', { name: 'Delete package' })).toBeVisible();
+
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+
+    /* A dismissed dialog stays MOUNTED without its `open` attribute, so absence
+       has to be asserted against `dialog[open]` - querying for the element itself
+       finds it every time and passes whatever happened. */
+    await waitFor(() => expect(openDialog()).toBeNull());
+    await expect(canvas.getByText('Puppy dental starter')).toBeInTheDocument();
+    await expect(canvas.getAllByRole('button', { name: /^Restore / })).toHaveLength(3);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Cancel clears the target rather than closing a flag, which is why the confirm ' +
+          'unmounts entirely instead of lingering with stale copy - the whole dialog is behind ' +
+          '`deleteTarget &&`, and the title and name are read straight off it.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/organization/pages/Specialities/ServiceFormDraft.stories.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Specialities/ServiceFormDraft.stories.tsx
@@ -1,0 +1,408 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+
+import type { CatalogItemType, ServiceRevamp } from '@/app/features/organization/types/revamp';
+import { useRevampCatalogStore } from '@/app/stores/revampCatalogStore';
+import ServiceFormDraft from './ServiceFormDraft';
+
+const ORG_ID = 'org-avenger-park';
+const SPECIALITY_ID = 'spec-dentistry';
+
+const EXISTING: ServiceRevamp = {
+  id: 'svc-scale-polish',
+  code: 'DEN-014',
+  name: 'Scale and polish',
+  description: 'Full mouth scale, polish and post-op analgesia.',
+  type: 'PROCEDURE',
+  specialityId: SPECIALITY_ID,
+  organisationId: ORG_ID,
+  grossAmount: 310,
+  defaultDiscount: 10,
+  maxDiscount: 25,
+  durationMinutes: 90,
+  isBookable: false,
+  isInpatientPreferred: true,
+  status: 'ACTIVE',
+  createdAt: '2026-05-04T09:00:00.000Z',
+};
+
+/**
+ * Pins the draft code preview.
+ *
+ * The store's real `generateItemCode` increments a module-level counter that is
+ * never reset, so the chip reads CON-0001 on the first mount of a session and
+ * CON-0009 on the ninth. That is fine in the product and useless in a snapshot:
+ * every Chromatic build would diff on the digits. Overriding it through the real
+ * store keeps the chip stable AND keeps the type-to-code relationship visible,
+ * which is the part of the behaviour worth reviewing - picking Procedure has to
+ * repaint the chip.
+ */
+const STUB_CODES: Record<CatalogItemType, string> = {
+  CONSULTATION: 'CON-0042',
+  PROCEDURE: 'PRO-0042',
+  LAB: 'LAB-0042',
+  INVENTORY: 'INV-0042',
+  MEDICATION: 'MED-0042',
+  PACKAGE: 'PKG-0042',
+};
+
+const realGenerateItemCode = useRevampCatalogStore.getState().generateItemCode;
+
+const seed = () => {
+  useRevampCatalogStore.setState({
+    services: [EXISTING],
+    loadedSpecialityIds: [`${SPECIALITY_ID}:active`],
+    generateItemCode: (type) => STUB_CODES[type],
+  });
+  return () => {
+    useRevampCatalogStore.setState({
+      services: [],
+      loadedSpecialityIds: [],
+      generateItemCode: realGenerateItemCode,
+    });
+  };
+};
+
+/** The delete confirm portals to `document.body`, so it is outside `canvasElement`. */
+const openDialog = () => document.querySelector('dialog[open]');
+
+const meta = {
+  title: 'Organization/ServiceFormDraft',
+  component: ServiceFormDraft,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The inline add/edit form for one catalog service. It is never on screen at rest: it ' +
+          'mounts only after the speciality tab\'s "Add service" button or a row kebab **Edit**, ' +
+          'and it replaces the table rather than opening over them - so nothing about it, ' +
+          'including its four validation messages, had ever been drawn.\n\n' +
+          'The header is live. The card title is `<name> (draft)` and re-renders on every ' +
+          'keystroke, the code chip is regenerated from the **type** rather than the name, and ' +
+          'the Bookable / In-patient badges appear and disappear with their checkboxes. Picking ' +
+          'a type does three things at once on a new service: it sets the type, re-derives ' +
+          'Bookable (only a consultation is bookable by default) and re-issues the code - which ' +
+          'is easy to miss because none of it happens when editing an existing service.\n\n' +
+          'Pricing is a four-up row whose last field is read-only: Total Amount is ' +
+          '`gross - gross x defaultDiscount%`, recomputed live, and blank rather than $0 until a ' +
+          'gross is entered. Validation is deliberately not per-keystroke - it runs on save, and ' +
+          "clearing a field clears only that field's message.\n\n" +
+          'The layout is container-queried, not viewport-queried: two columns and a four-up ' +
+          'pricing row at `@2xl`, one column and a two-up row below it. That is what lets the ' +
+          'same form sit in a full-width tab and in a side drawer, so the width is set on the ' +
+          'wrapper here rather than left to the viewport.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    specialityId: SPECIALITY_ID,
+    organisationId: ORG_ID,
+    onClose: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <div className="min-h-[560px] w-[900px] max-w-full bg-[var(--screen)] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+  beforeEach: seed,
+} satisfies Meta<typeof ServiceFormDraft>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const NewService: Story = {
+  name: 'New service draft',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByText('New Service (draft)')).toBeInTheDocument();
+    await expect(canvas.getByText('CON-0042')).toBeInTheDocument();
+    // Two "Bookable" nodes: the header badge and the checkbox label. One node
+    // means the badge did not render - see the type-change story below, where
+    // that is the expected outcome.
+    await expect(canvas.getAllByText('Bookable')).toHaveLength(2);
+    await expect(canvas.queryAllByText('In-patient')).toHaveLength(0);
+    await expect(canvas.getByRole('checkbox', { name: 'Bookable' })).toBeChecked();
+    await expect(canvas.getByRole('checkbox', { name: 'Inpatient preferred' })).not.toBeChecked();
+
+    // The defaults a new draft opens with, all four of them.
+    await expect(canvas.getByRole('button', { name: 'Type: Consultation' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Duration: 30 mins' })).toBeInTheDocument();
+    await expect(canvas.getByLabelText('Gross amt.')).toHaveValue(null);
+    await expect(canvas.getByLabelText('Default Discount (%)')).toHaveValue(0);
+    // Blank, not "$0" - the read-only total stays empty until a gross is entered.
+    await expect(canvas.getByLabelText('Total Amount')).toHaveValue('');
+
+    // Delete only exists while editing, so a new draft has two actions, not three.
+    await expect(canvas.queryByRole('button', { name: 'Delete Service' })).not.toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Save Service' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+
+    /* The two grids at container width. Both are container queries against the
+       card's own `@container`, so a story that rendered this in a narrow box
+       would show the stacked form at any browser width. Assert the track count
+       AND the child count: a template with fewer tracks than children silently
+       wraps the last field onto a new line instead of failing. */
+    const pricing = canvas.getByLabelText('Total Amount').closest('.grid') as HTMLElement;
+    await expect(getComputedStyle(pricing).gridTemplateColumns.trim().split(/\s+/)).toHaveLength(4);
+    await expect(pricing.children).toHaveLength(4);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The form as it opens from "Add service". Every value here is a default rather than ' +
+          'an empty field - Consultation, 30 mins, 0% default discount, Bookable on - so the ' +
+          'shortest path to a saved service is a name and a price.',
+      },
+    },
+  },
+};
+
+export const ValidationErrors: Story = {
+  name: 'Validation on save',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Nothing is validated until save is pressed, so the form opens clean.
+    await expect(canvas.queryAllByRole('alert')).toHaveLength(0);
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Save Service' }));
+
+    // Both required-field messages, asserted by their copy rather than by a count
+    // of alert nodes - the count alone passes on two copies of one message.
+    expect(await canvas.findByText('Name is required.')).toBeInTheDocument();
+    await expect(canvas.getByText('Enter a valid gross amount.')).toBeInTheDocument();
+    // FormInput wires the message to the field, which is the half a visual
+    // review cannot see.
+    await expect(canvas.getByLabelText('Name')).toHaveAttribute('aria-invalid', 'true');
+    await expect(canvas.getByLabelText('Gross amt.')).toHaveAttribute('aria-invalid', 'true');
+    // The 0% default discount is valid, so its field must stay clean.
+    await expect(canvas.getByLabelText('Default Discount (%)')).toHaveAttribute(
+      'aria-invalid',
+      'false'
+    );
+
+    // Typing clears only the field that was typed into.
+    await userEvent.type(canvas.getByLabelText('Name'), 'Fluoride varnish');
+    await waitFor(() => {
+      expect(canvas.queryByText('Name is required.')).not.toBeInTheDocument();
+    });
+    await expect(canvas.getByText('Enter a valid gross amount.')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Save-time validation, not per-keystroke. The messages are owned by the fields ' +
+          '(`aria-describedby` on a `role="alert"` line, red 1.5px border), and each one is ' +
+          'cleared by its own `onChange` rather than by a re-validation, which is why editing ' +
+          'the name leaves the price error standing.',
+      },
+    },
+  },
+};
+
+export const DiscountRangeErrors: Story = {
+  name: 'Discount range and ordering errors',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.type(canvas.getByLabelText('Name'), 'Extraction');
+    await userEvent.type(canvas.getByLabelText('Gross amt.'), '310');
+
+    const defaultDiscount = canvas.getByLabelText('Default Discount (%)');
+    await userEvent.clear(defaultDiscount);
+    await userEvent.type(defaultDiscount, '150');
+    await userEvent.click(canvas.getByRole('button', { name: 'Save Service' }));
+    // The en dash is the shipped copy, not a hyphen.
+    expect(await canvas.findByText('Default discount must be 0–100.')).toBeInTheDocument();
+
+    // In range but above the cap: a different rule, and it only fires once BOTH
+    // discount fields are set and neither is individually out of range.
+    await userEvent.clear(defaultDiscount);
+    await userEvent.type(defaultDiscount, '40');
+    await userEvent.type(canvas.getByLabelText('Max. Discount (%)'), '20');
+    await userEvent.click(canvas.getByRole('button', { name: 'Save Service' }));
+    expect(
+      await canvas.findByText('Default discount cannot exceed max discount.')
+    ).toBeInTheDocument();
+    // The cross-field message lands on the default-discount field, not on max.
+    await expect(defaultDiscount).toHaveAttribute('aria-invalid', 'true');
+    await expect(canvas.getByLabelText('Max. Discount (%)')).toHaveAttribute(
+      'aria-invalid',
+      'false'
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Three of the four rules in one story. The ordering check is guarded on the other two ' +
+          'passing first, so an out-of-range default reports its range rather than being ' +
+          'compared against a cap it could never satisfy - and both messages attach to the ' +
+          'default-discount field, since that is the one the practice is expected to lower.',
+      },
+    },
+  },
+};
+
+export const LiveTotal: Story = {
+  name: 'Live total and badges',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const total = canvas.getByLabelText('Total Amount');
+
+    await userEvent.type(canvas.getByLabelText('Gross amt.'), '200');
+    // 200 with the default 0% discount.
+    await waitFor(() => expect(total).toHaveValue('$200'));
+
+    const defaultDiscount = canvas.getByLabelText('Default Discount (%)');
+    await userEvent.clear(defaultDiscount);
+    await userEvent.type(defaultDiscount, '10');
+    // 200 - 10% = 180. formatMoney rounds to whole units, so no cents anywhere.
+    await waitFor(() => expect(total).toHaveValue('$180'));
+
+    // The header badges track the checkboxes, live.
+    await userEvent.click(canvas.getByRole('checkbox', { name: 'Inpatient preferred' }));
+    await waitFor(() => expect(canvas.getAllByText('In-patient')).toHaveLength(1));
+    await userEvent.click(canvas.getByRole('checkbox', { name: 'Bookable' }));
+    await waitFor(() => expect(canvas.getAllByText('Bookable')).toHaveLength(1));
+
+    // The title follows the name field on every keystroke.
+    await userEvent.type(canvas.getByLabelText('Name'), 'Bandage change');
+    await expect(canvas.getByText('New Service (draft)')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The read-only Total Amount is the only field nobody types into, and it is the one ' +
+          'that has to stay right: it is recomputed from gross and default discount on every ' +
+          'render. Note the title stays "New Service (draft)" while typing a name - the name ' +
+          'only reaches the title when editing an existing service, which is the next story.',
+      },
+    },
+  },
+};
+
+export const TypeChangeRewritesTheDraft: Story = {
+  name: 'Changing type rewrites code and bookability',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('CON-0042')).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Type: Consultation' }));
+    // The listbox portals to document.body - it is not inside the card, which is
+    // what keeps it from being clipped by the tab's scroll container.
+    await waitFor(() =>
+      expect(document.querySelector('[data-portal-dropdown]')).toBeInTheDocument()
+    );
+    const panel = document.querySelector('[data-portal-dropdown]') as HTMLElement;
+    await expect(within(panel).getAllByRole('button')).toHaveLength(3);
+    await userEvent.click(within(panel).getByRole('button', { name: 'Procedure' }));
+
+    // One click, three changes: type, code, and the bookable default.
+    await expect(canvas.getByRole('button', { name: 'Type: Procedure' })).toBeInTheDocument();
+    await waitFor(() => expect(canvas.getByText('PRO-0042')).toBeInTheDocument());
+    await expect(canvas.queryByText('CON-0042')).not.toBeInTheDocument();
+    await expect(canvas.getByRole('checkbox', { name: 'Bookable' })).not.toBeChecked();
+    await expect(canvas.getAllByText('Bookable')).toHaveLength(1);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Only a Consultation is bookable in the app by default; a Procedure and a Lab test are ' +
+          'booked at the desk. Picking a type therefore rewrites the bookable flag and re-issues ' +
+          'the code prefix, and it does so **only on a new draft** - the same dropdown on an ' +
+          'existing service changes nothing but the type, so a saved service never loses its ' +
+          'code or has its bookability silently flipped.',
+      },
+    },
+  },
+};
+
+export const EditExisting: Story = {
+  name: 'Editing an existing service',
+  args: { editService: EXISTING },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // The title takes the name, and the chip keeps the SAVED code rather than
+    // generating a new one.
+    await expect(canvas.getByText('Scale and polish (draft)')).toBeInTheDocument();
+    await expect(canvas.getByText('DEN-014')).toBeInTheDocument();
+    await expect(canvas.queryByText('PRO-0042')).not.toBeInTheDocument();
+
+    await expect(canvas.getByLabelText('Name')).toHaveValue('Scale and polish');
+    await expect(canvas.getByLabelText('Description')).toHaveValue(
+      'Full mouth scale, polish and post-op analgesia.'
+    );
+    await expect(canvas.getByRole('button', { name: 'Type: Procedure' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Duration: 90 mins' })).toBeInTheDocument();
+    await expect(canvas.getByLabelText('Gross amt.')).toHaveValue(310);
+    await expect(canvas.getByLabelText('Max. Discount (%)')).toHaveValue(25);
+    // 310 - 10% = 279, computed on mount rather than on first edit.
+    await expect(canvas.getByLabelText('Total Amount')).toHaveValue('$279');
+
+    // Not bookable, in-patient preferred: one badge, and it is the other one.
+    await expect(canvas.getAllByText('In-patient')).toHaveLength(1);
+    await expect(canvas.getAllByText('Bookable')).toHaveLength(1);
+    // The third action only exists in this mode.
+    await expect(canvas.getByRole('button', { name: 'Delete Service' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same component with `editService` supplied. Everything is prefilled from the ' +
+          'stored record and the actions row grows a third, destructive button that pushes ' +
+          'Cancel and Save to the right - so the add and edit forms are not the same layout ' +
+          'with a different title.',
+      },
+    },
+  },
+};
+
+export const DeleteConfirm: Story = {
+  name: 'Delete confirm',
+  args: { editService: EXISTING },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(openDialog()).toBeNull();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Delete Service' }));
+
+    await waitFor(() => expect(openDialog()).not.toBeNull());
+    const dialog = openDialog() as HTMLElement;
+    await expect(within(dialog).getByRole('heading', { name: 'Delete service' })).toBeVisible();
+    // The bolded name splits the sentence across three nodes, so the copy is
+    // asserted on the container. The second half is the part that matters: this
+    // confirm recommends archiving instead, which the archive tab then owns.
+    await expect(dialog).toHaveTextContent(
+      'Are you sure you want to delete Scale and polish? This permanently removes the service ' +
+        'and cannot be undone. If it is used in packages or has historical usage, consider ' +
+        'archiving instead.'
+    );
+    await expect(within(dialog).getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+    /* A dismissed dialog stays mounted without its `open` attribute, so absence
+       is asserted against `dialog[open]` - the element itself is still there. */
+    await waitFor(() => expect(openDialog()).toBeNull());
+    await expect(canvas.getByText('Scale and polish (draft)')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Two dialogs deep from the speciality page and the only place the draft form can ' +
+          'destroy a record. Cancelling leaves the draft exactly as it was, including unsaved ' +
+          'edits, because the confirm is a sibling of the form rather than a replacement for it.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/organization/pages/Specialities/SpecialityAccordionRevamp.stories.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Specialities/SpecialityAccordionRevamp.stories.tsx
@@ -1,0 +1,452 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import type { Organisation } from '@yosemite-crew/types';
+
+import type {
+  PackageRevamp,
+  ServiceRevamp,
+  SpecialityRevamp,
+} from '@/app/features/organization/types/revamp';
+import type { Team } from '@/app/features/organization/types/team';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useRevampCatalogStore } from '@/app/stores/revampCatalogStore';
+import { useTeamStore } from '@/app/stores/teamStore';
+import SpecialityAccordionRevamp from './SpecialityAccordionRevamp';
+
+const ORG_ID = 'org-avenger-park';
+const SPECIALITY_ID = 'spec-dentistry';
+
+const ORG: Organisation = {
+  _id: ORG_ID,
+  name: 'Avenger Park Veterinary',
+  type: 'HOSPITAL',
+  phoneNo: '4155550110',
+  taxId: 'DE-8871-2290',
+  isActive: true,
+};
+
+const teamMember = (id: string, name: string): Team => ({
+  _id: id,
+  practionerId: id,
+  organisationId: ORG_ID,
+  name,
+  role: 'VETERINARIAN',
+  speciality: [],
+  status: 'Available',
+  revokedPermissions: [],
+  effectivePermissions: [],
+  extraPerissions: [],
+});
+
+const TEAMS: Team[] = [
+  teamMember('vet-marsh', 'Dr. Elena Marsh'),
+  teamMember('vet-patel', 'Dr. Ravi Patel'),
+];
+
+const DENTISTRY: SpecialityRevamp = {
+  id: SPECIALITY_ID,
+  name: 'Dentistry',
+  organisationId: ORG_ID,
+  headVetId: 'vet-marsh',
+  teamMemberIds: ['vet-patel'],
+  activeServiceCount: 9,
+  activePackageCount: 4,
+};
+
+const SERVICES: ServiceRevamp[] = [
+  {
+    id: 'svc-1',
+    code: 'DEN-001',
+    name: 'Dental consultation',
+    description: 'Oral exam, charting and a treatment plan.',
+    type: 'CONSULTATION',
+    specialityId: SPECIALITY_ID,
+    organisationId: ORG_ID,
+    grossAmount: 72,
+    defaultDiscount: 0,
+    maxDiscount: 20,
+    durationMinutes: 30,
+    isBookable: true,
+    isInpatientPreferred: false,
+    status: 'ACTIVE',
+    createdAt: '2026-05-04T09:00:00.000Z',
+  },
+  {
+    id: 'svc-2',
+    code: 'DEN-014',
+    name: 'Scale and polish',
+    description: 'Full mouth scale and polish.',
+    type: 'PROCEDURE',
+    specialityId: SPECIALITY_ID,
+    organisationId: ORG_ID,
+    grossAmount: 310,
+    defaultDiscount: 10,
+    maxDiscount: 25,
+    durationMinutes: 90,
+    isBookable: false,
+    isInpatientPreferred: true,
+    status: 'ACTIVE',
+    createdAt: '2026-05-04T09:00:00.000Z',
+  },
+];
+
+const PACKAGES: PackageRevamp[] = [
+  {
+    id: 'pkg-1',
+    code: 'PKG-DEN-01',
+    name: 'Dental care package',
+    description: 'Consultation, scale and polish.',
+    specialityId: SPECIALITY_ID,
+    organisationId: ORG_ID,
+    durationText: '2 h',
+    isBookable: true,
+    isInpatientPreferred: false,
+    leadCount: 1,
+    supportCount: 1,
+    additionalDiscount: 5,
+    breakdown: [],
+    serverFinalAmount: 340,
+    status: 'ACTIVE',
+    createdAt: '2026-05-04T09:00:00.000Z',
+  },
+];
+
+/**
+ * Seeds the real stores rather than mocking the catalog service.
+ *
+ * `loadSpecialityCatalog` returns at its first line once the speciality key is in
+ * `loadedSpecialityIds`, so seeding that key is what keeps both tabs off the
+ * network - no service stub, and the components under review are the real ones.
+ * The team store is seeded too because the header resolves `headVetId` and
+ * `teamMemberIds` into names through `useTeamForPrimaryOrg`; without it the
+ * subtitle silently drops its "lead" clause and the practitioner monograms
+ * disappear from the rows.
+ */
+const seed =
+  ({ loaded = true }: { loaded?: boolean } = {}) =>
+  () => {
+    useOrgStore.setState({
+      orgsById: { [ORG_ID]: ORG },
+      orgIds: [ORG_ID],
+      primaryOrgId: ORG_ID,
+      status: 'loaded',
+    });
+    useTeamStore.getState().setTeamsForOrg(ORG_ID, TEAMS);
+    useRevampCatalogStore.setState({
+      specialities: [DENTISTRY],
+      services: SERVICES,
+      packages: PACKAGES,
+      loadedSpecialityIds: loaded ? [`${SPECIALITY_ID}:active`] : [],
+    });
+
+    return () => {
+      useOrgStore.setState({ orgsById: {}, orgIds: [], primaryOrgId: null, status: 'idle' });
+      useTeamStore.setState({ teamsById: {}, teamIdsByOrgId: {} });
+      useRevampCatalogStore.setState({
+        specialities: [],
+        services: [],
+        packages: [],
+        loadedSpecialityIds: [],
+      });
+    };
+  };
+
+const meta = {
+  title: 'Organization/SpecialityAccordionRevamp',
+  component: SpecialityAccordionRevamp,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'One speciality on the Specialities page. The header is not a static bar with a ' +
+          'chevron - it is **three different headers**, and only one of them had ever been ' +
+          'drawn.\n\n' +
+          'Closed, the right-hand cluster is a single `ACTIVE` status pill. Open, that pill is ' +
+          'replaced by a three-way `SegmentedPill` (Services / Packages / Archive) plus a ' +
+          'contextual primary action whose label follows the tab - New Service, New Package, and ' +
+          'nothing at all on Archive. Renaming replaces the entire cluster, pill and tabs and ' +
+          'action together, with an inline text field and three round controls. So the same row ' +
+          'has three layouts with almost no shared markup, and two of them are behind state a ' +
+          'static render never reaches.\n\n' +
+          'The subtitle is derived from two different sources depending on load state. Before a ' +
+          "speciality's catalog is fetched it trusts the server counts on the list row " +
+          '(`activeServiceCount` / `activePackageCount`); afterwards it counts the store. That ' +
+          'is what keeps a collapsed page accurate without fetching every speciality up front, ' +
+          'and it is also why an accordion can show one number collapsed and a different one ' +
+          'open if the two ever disagree.\n\n' +
+          'The primary action is a **ref call**, not a route: it reaches into the mounted tab ' +
+          'through `ServicesTabHandle.openAdd`, so it does nothing until the tab exists - which ' +
+          'is why it only renders while the panel is open.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: { speciality: DENTISTRY },
+  decorators: [
+    (Story) => (
+      <div className="min-h-[520px] w-[1100px] max-w-full bg-[var(--screen)] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+  beforeEach: seed(),
+} satisfies Meta<typeof SpecialityAccordionRevamp>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Collapsed: Story = {
+  name: 'Collapsed',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole('button', { name: 'Dentistry speciality' })).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
+    // Counted from the seeded store, not from the row's server counts, because
+    // the speciality key is present - and the lead clause proves the team store
+    // resolved `headVetId` into a name.
+    await expect(
+      canvas.getByText('2 services · 1 package · lead Dr. Elena Marsh')
+    ).toBeInTheDocument();
+
+    // Closed: the pill exists and the tab control does not.
+    await expect(canvas.getByText('ACTIVE')).toBeInTheDocument();
+    await expect(
+      canvas.queryByRole('group', { name: 'Speciality catalog view' })
+    ).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: /New Service/ })).not.toBeInTheDocument();
+    // The panel is unmounted, not hidden, so no row exists at any width.
+    await expect(canvas.queryAllByText('Dental consultation')).toHaveLength(0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting row. The `ACTIVE` pill is the only thing on the right, and the subtitle ' +
+          'carries the whole summary - counts and lead - because there is nothing else to read.',
+      },
+    },
+  },
+};
+
+export const CountsBeforeCatalogLoads: Story = {
+  name: 'Collapsed, counts from the server row',
+  beforeEach: seed({ loaded: false }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    /* With no key in `loadedSpecialityIds` the header falls back to the counts
+       the specialities list returned - 9 and 4 - rather than to the two services
+       that happen to be in the store. Collapsed, nothing fetches, so this is the
+       state every unopened speciality on the page is actually in. */
+    await expect(
+      canvas.getByText('9 services · 4 packages · lead Dr. Elena Marsh')
+    ).toBeInTheDocument();
+    await expect(canvas.getByText('ACTIVE')).toBeInTheDocument();
+    /* The point of the story is that nothing was fetched to produce those
+       numbers, so assert the closed state and the absent panel too: the two
+       services that ARE in the store must not reach the DOM, otherwise the
+       subtitle is reading the row while the body reads the store. */
+    await expect(canvas.getByRole('button', { name: 'Dentistry speciality' })).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
+    await expect(canvas.queryAllByText('Dental consultation')).toHaveLength(0);
+    await expect(canvas.queryAllByText('Scale and polish')).toHaveLength(0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same speciality with the same store contents, reading a different pair of ' +
+          'numbers. A page of twenty specialities shows twenty of these and issues no catalog ' +
+          'requests at all; the counts only switch source once one is opened.',
+      },
+    },
+  },
+};
+
+export const Open: Story = {
+  name: 'Open on Services',
+  args: { defaultOpen: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // The pill is GONE, not restyled - the two are mutually exclusive branches.
+    await expect(canvas.queryByText('ACTIVE')).not.toBeInTheDocument();
+
+    const tabs = canvas.getByRole('group', { name: 'Speciality catalog view' });
+    await expect(within(tabs).getAllByRole('button')).toHaveLength(3);
+    await expect(within(tabs).getByRole('button', { name: 'Services' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    await expect(within(tabs).getByRole('button', { name: 'Packages' })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+
+    // The contextual action names the tab it will act on.
+    await expect(canvas.getByRole('button', { name: /New Service/ })).toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: /New Package/ })).not.toBeInTheDocument();
+
+    /* The panel mounted the real ServicesTab. Each service renders TWICE - once
+       as the wide table row and once as the stacked card - because the two forms
+       are both in the DOM and a container query hides one, so two is the correct
+       count here rather than a duplicate-render bug. */
+    expect(await canvas.findAllByText('Dental consultation')).toHaveLength(2);
+    await expect(
+      canvas.getAllByRole('button', { name: 'Actions for Dental consultation' })
+    ).toHaveLength(1);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The open header and the services panel together. The tab control and the primary ' +
+          'action both appear only in this state, and the panel is separated from the header by ' +
+          'a single hairline rather than by a gap.',
+      },
+    },
+  },
+};
+
+export const OpensFromCollapsed: Story = {
+  name: 'Opening swaps the header',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('ACTIVE')).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Dentistry speciality' }));
+
+    // One click, three changes in the header alone.
+    await waitFor(() => expect(canvas.queryByText('ACTIVE')).not.toBeInTheDocument());
+    await expect(
+      canvas.getByRole('group', { name: 'Speciality catalog view' })
+    ).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: /New Service/ })).toBeInTheDocument();
+    // And the panel underneath it mounts a tab that was not in the DOM at all.
+    expect(await canvas.findAllByText('Scale and polish')).toHaveLength(2);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The transition the two resting stories sit either side of. Opening also raises the ' +
+          'card onto a second, deeper shadow, which is the only signal on a page of accordions ' +
+          'that says which one is expanded once the panel scrolls out of view.',
+      },
+    },
+  },
+};
+
+export const PackagesTabSelected: Story = {
+  name: 'Packages tab',
+  args: { defaultOpen: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const tabs = canvas.getByRole('group', { name: 'Speciality catalog view' });
+
+    await userEvent.click(within(tabs).getByRole('button', { name: 'Packages' }));
+
+    // The primary action is relabelled, not hidden and re-added - and it now
+    // targets a different ref, so the label is the only thing that says which.
+    await expect(canvas.getByRole('button', { name: /New Package/ })).toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: /New Service/ })).not.toBeInTheDocument();
+    await expect(within(tabs).getByRole('button', { name: 'Packages' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+
+    // The services panel is unmounted, and the packages panel took its place.
+    expect(await canvas.findByText('Dental care package')).toBeInTheDocument();
+    await expect(canvas.queryAllByText('Dental consultation')).toHaveLength(0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Switching tabs unmounts one panel and mounts another; nothing is kept alive behind ' +
+          'the scenes. The packages panel is inset by 20px where the services table runs to the ' +
+          'card edge, because the table owns its own gutters.',
+      },
+    },
+  },
+};
+
+export const ArchiveTabSelected: Story = {
+  name: 'Archive tab drops the action',
+  args: { defaultOpen: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const tabs = canvas.getByRole('group', { name: 'Speciality catalog view' });
+
+    await userEvent.click(within(tabs).getByRole('button', { name: 'Archive' }));
+
+    // Archive is the one tab with no primary action at all: there is nothing to
+    // add, so the button is removed rather than disabled.
+    await waitFor(() =>
+      expect(canvas.queryByRole('button', { name: /New Service/ })).not.toBeInTheDocument()
+    );
+    await expect(canvas.queryByRole('button', { name: /New Package/ })).not.toBeInTheDocument();
+    await expect(within(tabs).getByRole('button', { name: 'Archive' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    // Nothing is archived in the seed, so the tab shows its own empty line.
+    expect(await canvas.findByText('No archived services or packages.')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The header shrinks by one control here, which shifts the search field left. That is ' +
+          'the only place the header changes width between tabs, and it is worth a look because ' +
+          'the row is `flex-nowrap` from `sm` up.',
+      },
+    },
+  },
+};
+
+export const RenamingReplacesTheHeader: Story = {
+  name: 'Renaming replaces the whole cluster',
+  args: { defaultOpen: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole('group', { name: 'Speciality catalog view' })
+    ).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Rename Dentistry' }));
+
+    // An inline field plus three round controls, and everything else in the row
+    // is gone: the tabs, the primary action and the search field are all behind
+    // one `!editingName` guard.
+    const field = await canvas.findByRole('textbox', { name: 'Edit speciality name' });
+    await expect(field).toHaveValue('Dentistry');
+    await expect(canvas.getByRole('button', { name: 'Save name' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Cancel rename' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Delete Dentistry' })).toBeInTheDocument();
+    await expect(
+      canvas.queryByRole('group', { name: 'Speciality catalog view' })
+    ).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: /New Service/ })).not.toBeInTheDocument();
+
+    // The panel below is untouched, so the catalog stays on screen while the
+    // name is edited.
+    await expect(canvas.getAllByText('Dental consultation')).toHaveLength(2);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The third header layout. It is reached from a pencil that is `opacity-0` until the row ' +
+          'is hovered or focused from `sm` up, so on a desktop screenshot the control that opens ' +
+          'this state is invisible - which is a large part of why the state itself was never ' +
+          'drawn.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/settings/pages/Settings/Sections/CrossClinicMessagingPreference.stories.tsx
+++ b/apps/frontend/src/app/features/settings/pages/Settings/Sections/CrossClinicMessagingPreference.stories.tsx
@@ -1,0 +1,271 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import type { Organisation } from '@yosemite-crew/types';
+
+import { useOrgStore } from '@/app/stores/orgStore';
+import { PreferenceGroup } from './PreferenceGroup';
+import CrossClinicMessagingPreference from './CrossClinicMessagingPreference';
+
+const ORG_ID = 'org-storybook-crossclinic';
+
+const org = (over: Partial<Organisation> = {}): Organisation => ({
+  _id: ORG_ID,
+  name: 'Sunrise Veterinary Hospital',
+  type: 'HOSPITAL',
+  phoneNo: '4155550110',
+  taxId: 'DE-8871-2290',
+  isVerified: true,
+  isActive: true,
+  ...over,
+});
+
+/**
+ * Seeds the real org store rather than mocking a hook.
+ *
+ * The row reads exactly one field - `crossOrgMessagingEnabled` on the primary org -
+ * through `useOrgStore(s => s.getPrimaryOrg())`, so the whole state space of this
+ * component is which of three values that field holds: `true`, `false`, or absent.
+ * Seeding is enough to reach all three, and no network is involved on mount.
+ */
+const seed = (record: Organisation) => {
+  useOrgStore.setState({
+    orgsById: { [ORG_ID]: record },
+    orgIds: [ORG_ID],
+    primaryOrgId: ORG_ID,
+    membershipsByOrgId: {},
+    status: 'loaded',
+    error: null,
+  });
+
+  return () => {
+    useOrgStore.setState({
+      orgsById: {},
+      orgIds: [],
+      primaryOrgId: null,
+      membershipsByOrgId: {},
+      status: 'idle',
+      error: null,
+    });
+  };
+};
+
+/**
+ * Resolves a design token to the `rgb(...)` string `getComputedStyle` reports, by
+ * measuring a throwaway probe rather than hard-coding a hex that would drift from
+ * `globals.css` and from the dark theme.
+ *
+ * Called OUTSIDE any `waitFor`. testing-library retries a `waitFor` callback from a
+ * MutationObserver, so a callback that appends and removes a node re-triggers itself
+ * forever and wedges the tab instead of failing.
+ */
+const resolveTokenColor = (token: string): string => {
+  const probe = document.createElement('span');
+  probe.style.display = 'none';
+  probe.style.backgroundColor = `var(${token})`;
+  document.body.append(probe);
+  const value = getComputedStyle(probe).backgroundColor;
+  probe.remove();
+  return value;
+};
+
+const Row = () => (
+  <div className="w-[420px] max-w-full bg-[var(--page)] p-4">
+    <PreferenceGroup title="Scheduling &amp; messaging">
+      <CrossClinicMessagingPreference />
+    </PreferenceGroup>
+  </div>
+);
+
+const meta = {
+  title: 'Settings/CrossClinicMessagingPreference',
+  component: Row,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'The org-level gate for cross-clinic colleague messaging, drawn inside the ' +
+          '"Scheduling & messaging" card it ships in.\n\n' +
+          'The row has **three** resting states, not two. `crossOrgMessagingEnabled` is ' +
+          'read straight off the primary org, and the org-LIST load path does not return ' +
+          'that field - so `undefined` genuinely means "not loaded", not "off". Rather than ' +
+          'coerce it (which would tell a clinic that has this switched on that it is ' +
+          'undiscoverable, and make the first click re-send the state it already had), the ' +
+          'component drops the switch entirely and renders a "Current setting unavailable" ' +
+          'line in its place.\n\n' +
+          'That third state is the one nothing had ever drawn, and it is not a disabled ' +
+          'switch - it is a different element with different geometry, which is why the ' +
+          'stories below assert what the row contains rather than only what it says.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Row>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Enabled: Story = {
+  name: 'Enabled',
+  beforeEach: () => seed(org({ crossOrgMessagingEnabled: true })),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const toggle = canvas.getByRole('switch', { name: 'Cross-clinic messaging' });
+    await expect(toggle).toHaveAttribute('aria-checked', 'true');
+    await expect(toggle).toBeEnabled();
+
+    /* The design's 40x24 track. `getBoundingClientRect` rather than
+       `getComputedStyle().width`: the latter reports the CONTENT box, which on any
+       bordered control reads short of the number in the design. */
+    const box = toggle.getBoundingClientRect();
+    await expect(box.width).toBeCloseTo(40, 0);
+    await expect(box.height).toBeCloseTo(24, 0);
+
+    /* Colour and knob position both animate (`transition-colors` /
+       `transition-transform`), so a single synchronous read can catch an
+       interpolated value halfway between the two states. Both are polled.
+
+       The knob is measured against the track instead of read off `transform`:
+       Tailwind v4 can emit either the `transform` or the `translate` property for
+       `translate-x-*`, and a computed-style assertion that names the wrong one
+       reads 'none' and would pass or fail for the wrong reason. */
+    const blue = resolveTokenColor('--blue');
+    await waitFor(() => expect(getComputedStyle(toggle).backgroundColor).toBe(blue));
+
+    const knob = toggle.firstElementChild as HTMLElement;
+    await expect(knob.getBoundingClientRect().width).toBeCloseTo(18, 0);
+    await waitFor(() =>
+      expect(knob.getBoundingClientRect().left - toggle.getBoundingClientRect().left).toBeCloseTo(
+        19,
+        0
+      )
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'On: the track is `--blue` and the 18px knob sits 19px in. This is what a business ' +
+          'owner sees once the clinic is in the cross-clinic directory - staff can start ' +
+          'conversations with colleagues at other clinics, and be found by them.',
+      },
+    },
+  },
+};
+
+export const Disabled: Story = {
+  name: 'Disabled (the default)',
+  beforeEach: () => seed(org({ crossOrgMessagingEnabled: false })),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const toggle = canvas.getByRole('switch', { name: 'Cross-clinic messaging' });
+    await expect(toggle).toHaveAttribute('aria-checked', 'false');
+    await expect(toggle).toBeEnabled();
+
+    const divider = resolveTokenColor('--divider');
+    await waitFor(() => expect(getComputedStyle(toggle).backgroundColor).toBe(divider));
+
+    const knob = toggle.firstElementChild as HTMLElement;
+    await waitFor(() =>
+      expect(knob.getBoundingClientRect().left - toggle.getBoundingClientRect().left).toBeCloseTo(
+        3,
+        0
+      )
+    );
+
+    // Same row copy in both switch states - only the control differs.
+    await expect(canvas.getByText('Cross-clinic messaging')).toBeInTheDocument();
+    await expect(
+      canvas.getByText('Let other verified clinics reach your team')
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Off, and off is the shipped default: the clinic is not in the cross-clinic ' +
+          'directory and colleagues elsewhere cannot open a conversation with its team. ' +
+          'Both clinics have to have this on for a conversation to start, so a single ' +
+          'clinic turning it on changes nothing on its own.',
+      },
+    },
+  },
+};
+
+export const SettingUnavailable: Story = {
+  name: 'Setting unavailable (field absent)',
+  // No `crossOrgMessagingEnabled` key at all - the shape the org-list endpoint returns.
+  beforeEach: () => seed(org()),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // The switch is REPLACED, not disabled: there is no switch in the tree at all.
+    await expect(canvas.queryByRole('switch')).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button')).not.toBeInTheDocument();
+
+    const message = canvas.getByText('Current setting unavailable');
+    await expect(message).toBeInTheDocument();
+    await expect(getComputedStyle(message).textAlign).toBe('right');
+
+    /* The row keeps its two-part shape - label block, control block - so the card
+       does not reflow when one preference falls back. Asserted on the row's own
+       children rather than on the copy, because a fallback that dropped the whole
+       control cell would still render this same sentence somewhere. */
+    const row = message.parentElement?.parentElement as HTMLElement;
+    await expect(row.children).toHaveLength(2);
+    await expect(within(row).getByText('Cross-clinic messaging')).toBeInTheDocument();
+    await expect(
+      within(row).getByText('Let other verified clinics reach your team')
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The branch this whole story file exists for. The org list omits ' +
+          '`crossOrgMessagingEnabled`, so any screen that reaches Settings from the list ' +
+          'rather than from a single-org fetch lands here, and the row silently stops being ' +
+          'a control - 11.5px `--ink-faint` copy where a 40x24 switch was.\n\n' +
+          'Two things are worth deciding before this ships further: the message says nothing ' +
+          'about what to do (reload? re-pick the clinic?), and nothing retries. A reviewer ' +
+          'should compare this against just fetching the single org when Settings mounts.',
+      },
+    },
+  },
+};
+
+export const FailedToggle: Story = {
+  name: 'A failed toggle leaves the switch where it was',
+  beforeEach: () => seed(org({ crossOrgMessagingEnabled: false })),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const toggle = canvas.getByRole('switch', { name: 'Cross-clinic messaging' });
+
+    await userEvent.click(toggle);
+
+    /* Waiting on the org store's own error rather than on a timer is what makes this
+       assertion about a completed round trip: `updateOrg` calls `setError` and
+       rethrows on failure, so a non-null error proves the PUT was actually issued
+       and came back, not that the click did nothing. */
+    await waitFor(() => expect(useOrgStore.getState().error).not.toBeNull());
+
+    await expect(toggle).toBeEnabled();
+    await expect(toggle).toHaveAttribute('aria-checked', 'false');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'There is no stub for `PUT /fhir/v1/organization/:id` in this repo, so the request ' +
+          'fails - which makes the failure path the one branch of the toggle a reviewer can ' +
+          'actually reach here, and it is worth looking at.\n\n' +
+          '`enabled` is derived from the store on every render, and the store is only written ' +
+          'by a successful response, so a failed toggle leaves the switch exactly where it ' +
+          'was. The only feedback is a toast; `updateOrg` also writes a message into the org ' +
+          "store's `error`, which nothing on this row reads. The in-flight `saving` window " +
+          'is deliberately not asserted: it opens and closes around a real request, so ' +
+          'catching it would be a race rather than a check.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/settings/pages/Settings/Sections/DefaultOpenScreenPreference.stories.tsx
+++ b/apps/frontend/src/app/features/settings/pages/Settings/Sections/DefaultOpenScreenPreference.stories.tsx
@@ -1,0 +1,247 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import type { Organisation } from '@yosemite-crew/types';
+
+import type { PmsPreferences, UserProfile } from '@/app/features/users/types/profile';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useUserProfileStore } from '@/app/stores/profileStore';
+import { PreferenceGroup } from './PreferenceGroup';
+import DefaultOpenScreenPreference from './DefaultOpenScreenPreference';
+
+const ORG_ID = 'org-storybook-defaultscreen';
+
+const ORG: Organisation = {
+  _id: ORG_ID,
+  name: 'Sunrise Veterinary Hospital',
+  type: 'HOSPITAL',
+  phoneNo: '4155550110',
+  taxId: 'DE-8871-2290',
+  isVerified: true,
+  isActive: true,
+};
+
+const profile = (pmsPreferences: PmsPreferences): UserProfile => ({
+  _id: 'profile-storybook',
+  organizationId: ORG_ID,
+  personalDetails: { pmsPreferences },
+});
+
+/**
+ * Seeds the real stores.
+ *
+ * Both values this row renders come from one place - `personalDetails.pmsPreferences`
+ * on the primary-org profile - and `usePrimaryOrgProfile` is a plain selector with no
+ * fetch behind it, so seeding the profile store is the whole setup. Nothing here
+ * touches the network on mount; only a CHANGE does, and that is called out on the
+ * stories that make one.
+ */
+const seed = (pmsPreferences: PmsPreferences) => {
+  useOrgStore.setState({
+    orgsById: { [ORG_ID]: ORG },
+    orgIds: [ORG_ID],
+    primaryOrgId: ORG_ID,
+    membershipsByOrgId: {},
+    status: 'loaded',
+    error: null,
+  });
+  useUserProfileStore.setState({
+    profilesByOrgId: { [ORG_ID]: profile(pmsPreferences) },
+    status: 'loaded',
+    error: null,
+  });
+
+  return () => {
+    useOrgStore.setState({
+      orgsById: {},
+      orgIds: [],
+      primaryOrgId: null,
+      membershipsByOrgId: {},
+      status: 'idle',
+      error: null,
+    });
+    useUserProfileStore.setState({ profilesByOrgId: {}, status: 'idle', error: null });
+  };
+};
+
+const Rows = () => (
+  <div className="w-[420px] max-w-full bg-[var(--page)] p-4">
+    <PreferenceGroup title="Workspace preferences">
+      <DefaultOpenScreenPreference />
+    </PreferenceGroup>
+  </div>
+);
+
+const optionLabels = (select: HTMLElement) =>
+  (within(select).getAllByRole('option') as HTMLOptionElement[]).map(
+    (option) => option.textContent
+  );
+
+const optionValues = (select: HTMLElement) =>
+  (within(select).getAllByRole('option') as HTMLOptionElement[]).map((option) => option.value);
+
+const meta = {
+  title: 'Settings/DefaultOpenScreenPreference',
+  component: Rows,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'One component, two preference rows. "Default open screen" is always mounted; ' +
+          '**"Default appointment view" is conditional** on the first row reading ' +
+          '`/appointments`, and nothing had ever drawn it.\n\n' +
+          'It is worth being precise about when that second row appears, because the ' +
+          'obvious reading is wrong. `DEFAULT_PMS_PREFERENCES.defaultOpenScreen` is ' +
+          '`APPOINTMENTS`, so a person with no saved preference at all gets **both** rows on ' +
+          'first paint - the second row is not click-only. The single-row state below is ' +
+          'reached by a profile that explicitly says `DASHBOARD`.\n\n' +
+          'Both controls are the design pill (`PillSelect`): a 36px `--field-bg` pill with a ' +
+          'faint chevron, built on a native `<select>` so keyboard and screen-reader ' +
+          'behaviour come for free. That also means the option list is real DOM, which is ' +
+          'why these stories assert the labels and the submitted values rather than that a ' +
+          'dropdown exists.\n\n' +
+          'Saving is silent by design: the page header carries the one ' +
+          '"Changes save automatically" indicator and each change PATCHes the profile, so ' +
+          'only a failure ever says anything.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Rows>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const DashboardOnly: Story = {
+  name: 'Dashboard: the second row is absent',
+  beforeEach: () => seed({ defaultOpenScreen: 'DASHBOARD', appointmentView: 'STATUS_BOARD' }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Exactly one control in the card, not a hidden or disabled second one.
+    await expect(canvas.getAllByRole('combobox')).toHaveLength(1);
+    await expect(canvas.queryByText('Default appointment view')).not.toBeInTheDocument();
+    await expect(canvas.queryByLabelText('Default appointment view')).not.toBeInTheDocument();
+
+    const screen = canvas.getByRole('combobox', { name: 'Default open screen' });
+    await expect(screen).toHaveValue('/dashboard');
+    await expect(optionLabels(screen)).toEqual(['Dashboard', 'Appointments']);
+    /* The submitted values are routes, not enum members: `routeToDefaultOpenScreen`
+       converts them on the way to the API. A story that only checked the labels would
+       pass with the wrong thing being persisted. */
+    await expect(optionValues(screen)).toEqual(['/dashboard', '/appointments']);
+
+    await expect(canvas.getByText('Where the app lands after sign-in')).toBeInTheDocument();
+    // The design's pill height, measured on the border box rather than the content box.
+    await expect(screen.getBoundingClientRect().height).toBeCloseTo(36, 0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A profile that explicitly opens on the dashboard. The appointment-view row is not ' +
+          'rendered at all - the card is one row shorter, which is the layout worth checking ' +
+          'against the two-row stories below.',
+      },
+    },
+  },
+};
+
+export const RevealsAppointmentView: Story = {
+  name: 'Picking Appointments reveals the second row',
+  beforeEach: () => seed({ defaultOpenScreen: 'DASHBOARD', appointmentView: 'STATUS_BOARD' }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const screen = canvas.getByRole('combobox', { name: 'Default open screen' });
+
+    await userEvent.selectOptions(screen, '/appointments');
+
+    // The row mounted, and it mounted with the profile's saved view rather than a
+    // fresh default - STATUS_BOARD maps to the local 'board'.
+    const view = await canvas.findByRole('combobox', { name: 'Default appointment view' });
+    await expect(view).toHaveValue('board');
+    await expect(optionLabels(view)).toEqual(['Calendar', 'Status Board', 'Table']);
+    await expect(optionValues(view)).toEqual(['calendar', 'board', 'list']);
+
+    // Both rows now, and the first one kept its new selection.
+    await expect(canvas.getAllByRole('combobox')).toHaveLength(2);
+    await expect(screen).toHaveValue('/appointments');
+    await expect(canvas.getByText('Calendar, board, or list')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The reveal. The new row is inserted below the first one inside the same card, so ' +
+          'the card grows by a row height plus the 14px group gap while the page around it ' +
+          'reflows - the moment to check that the two-column Settings grid does not jump.\n\n' +
+          'The change also fires a PATCH. There is no request stub in this repo, so it fails ' +
+          'and queues an error toast with no container to render it; the store is only ' +
+          'written on success, so the rows keep the selection made here either way.',
+      },
+    },
+  },
+};
+
+export const BothRowsFromProfile: Story = {
+  name: 'Both rows on first paint',
+  beforeEach: () => seed({ defaultOpenScreen: 'APPOINTMENTS', appointmentView: 'CALENDAR' }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // No interaction: this is the resting state for anyone who opens on Appointments,
+    // which includes everyone who has never set the preference at all.
+    await expect(canvas.getAllByRole('combobox')).toHaveLength(2);
+    await expect(canvas.getByRole('combobox', { name: 'Default open screen' })).toHaveValue(
+      '/appointments'
+    );
+    await expect(canvas.getByRole('combobox', { name: 'Default appointment view' })).toHaveValue(
+      'calendar'
+    );
+    await expect(canvas.getByText('Default appointment view')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The correction to the obvious reading of this component: the second row is not ' +
+          'gated behind a click, it is gated on the value. `DEFAULT_PMS_PREFERENCES` opens on ' +
+          'Appointments, so a profile with no `pmsPreferences` at all renders exactly this.',
+      },
+    },
+  },
+};
+
+export const ChangingTheView: Story = {
+  name: 'Changing the appointment view',
+  beforeEach: () => seed({ defaultOpenScreen: 'APPOINTMENTS', appointmentView: 'CALENDAR' }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const view = canvas.getByRole('combobox', { name: 'Default appointment view' });
+
+    await userEvent.selectOptions(view, 'list');
+
+    // 'list' is the local name for the Table view; `localToAppointmentView` turns it
+    // into TABLE for the API, so the pill and the payload deliberately disagree.
+    await waitFor(() => expect(view).toHaveValue('list'));
+    await expect((view as HTMLSelectElement).selectedOptions[0].textContent).toBe('Table');
+
+    // The first row is untouched, and the second row did not unmount and remount.
+    await expect(canvas.getByRole('combobox', { name: 'Default open screen' })).toHaveValue(
+      '/appointments'
+    );
+    await expect(canvas.getAllByRole('combobox')).toHaveLength(2);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Every change commits immediately - there is no per-preference Save button, because ' +
+          'the design puts one "Changes save automatically" indicator in the page header. ' +
+          'That makes the failure case the thing to review: a PATCH that fails shows a toast ' +
+          'and leaves the pill on the value the user picked, so the control and the stored ' +
+          'preference silently disagree until the next profile load.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/settings/pages/Settings/Sections/ProfileEditModal.stories.tsx
+++ b/apps/frontend/src/app/features/settings/pages/Settings/Sections/ProfileEditModal.stories.tsx
@@ -1,0 +1,351 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import type { Organisation, UserOrganization } from '@yosemite-crew/types';
+
+import type { UserProfile } from '@/app/features/users/types/profile';
+import { useAuthStore } from '@/app/stores/authStore';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useUserProfileStore } from '@/app/stores/profileStore';
+import ProfileEditModal from './ProfileEditModal';
+
+const ORG_ID = 'org-storybook-profile';
+
+const ORG: Organisation = {
+  _id: ORG_ID,
+  name: 'Sunrise Veterinary Hospital',
+  type: 'HOSPITAL',
+  phoneNo: '4155550110',
+  taxId: 'DE-8871-2290',
+  isVerified: true,
+  isActive: true,
+};
+
+const MEMBERSHIP: UserOrganization = {
+  id: 'membership-owner',
+  practitionerReference: 'Practitioner/practitioner-1',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'OWNER',
+  roleDisplay: 'Business owner',
+  active: true,
+};
+
+const PROFILE: UserProfile = {
+  _id: 'profile-storybook',
+  organizationId: ORG_ID,
+  personalDetails: {
+    gender: 'FEMALE',
+    dateOfBirth: '1988-04-12',
+    phoneNumber: '+1 415 555 0110',
+    address: {
+      addressLine: '1180 Sutter Street',
+      city: 'San Francisco',
+      state: 'California',
+      postalCode: '94109',
+      country: 'United States',
+    },
+  },
+  professionalDetails: {
+    linkedin: 'https://www.linkedin.com/in/elena-marsh-dvm',
+    medicalLicenseNumber: 'CA-VET-44821',
+    yearsOfExperience: 11,
+    specialization: 'Small animal internal medicine',
+    qualification: 'DVM, DACVIM',
+    biography: 'Internal medicine lead, with an interest in feline endocrinology.',
+  },
+};
+
+/**
+ * Seeds the real stores.
+ *
+ * `ProfileDetails` returns `null` unless all three of `attributes`, `org` and
+ * `membership` are present, so a story that seeded only some of them would render an
+ * "Edit profile" panel containing nothing but the Security card - and every "the
+ * panel opened" assertion would still pass. All three are seeded, and the stories
+ * assert the cards rather than the panel.
+ *
+ * Nothing here fetches on mount. The one request the panel does make is the Security
+ * card's `GET /v1/auth/mfa/status`, which has no stub and is swallowed by the
+ * component's own catch; that is what leaves the resting security state below.
+ */
+const seed = () => {
+  useOrgStore.setState({
+    orgsById: { [ORG_ID]: ORG },
+    orgIds: [ORG_ID],
+    primaryOrgId: ORG_ID,
+    membershipsByOrgId: { [ORG_ID]: MEMBERSHIP },
+    status: 'loaded',
+    error: null,
+  });
+  useUserProfileStore.setState({
+    profilesByOrgId: { [ORG_ID]: PROFILE },
+    status: 'loaded',
+    error: null,
+  });
+  useAuthStore.setState({
+    attributes: {
+      sub: 'user-1',
+      given_name: 'Elena',
+      family_name: 'Marsh',
+      email: 'elena.marsh@example.com',
+    },
+  });
+
+  return () => {
+    useOrgStore.setState({
+      orgsById: {},
+      orgIds: [],
+      primaryOrgId: null,
+      membershipsByOrgId: {},
+      status: 'idle',
+      error: null,
+    });
+    useUserProfileStore.setState({ profilesByOrgId: {}, status: 'idle', error: null });
+    useAuthStore.setState({ attributes: null });
+  };
+};
+
+/** `showModal` is the caller's state, so the harness holds it for the close control. */
+const ProfileEditor = ({ open }: { open: boolean }) => {
+  const [showModal, setShowModal] = useState(open);
+  return (
+    <div className="min-h-[760px] bg-[var(--page)] p-6">
+      <p className="text-[13px] text-[var(--ink-muted)]">
+        Settings page behind the scrim, so the backdrop tint and blur are visible.
+      </p>
+      <ProfileEditModal showModal={showModal} setShowModal={setShowModal} />
+    </div>
+  );
+};
+
+/** `ModalBase` portals to `document.body`, so the panel is never inside `canvasElement`. */
+const openPanel = (): Promise<HTMLElement> =>
+  waitFor(() => {
+    const panel = document.querySelector('dialog[open]');
+    expect(panel).not.toBeNull();
+    return panel as HTMLElement;
+  });
+
+/**
+ * The right-hand cell of a read-only `FieldValueRow`. Reading the sibling rather
+ * than searching for the value text is what makes "First name is Elena" an
+ * assertion about the row and not about the panel containing the word somewhere.
+ */
+const fieldValue = (panel: HTMLElement, label: string): string =>
+  within(panel).getByText(label).nextElementSibling?.textContent ?? '';
+
+const meta = {
+  title: 'Settings/ProfileEditModal',
+  component: ProfileEditor,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Everything behind the Settings Personal card\'s "Edit profile" button. The page ' +
+          'itself is a compact control panel by design, so all the detailed personal-profile ' +
+          'editing was moved in here - and then nothing drew it, at any size.\n\n' +
+          'It is a centered `lg` Modal (840px) holding **four** cards in one scroll ' +
+          'container: `ProfileDetails` contributes User profile, Address and Professional ' +
+          'details, and `SecuritySection` adds the authenticator controls. Each profile card ' +
+          'has two shapes - a read-only list of label/value rows, and, once its round Edit ' +
+          'button is pressed, a form where only the `editable` fields become inputs while the ' +
+          'rest stay as value rows. That mixed read/write shape is the thing to look at, and ' +
+          'it is drawn below.\n\n' +
+          '`ProfileDetails` renders nothing at all unless auth attributes, the org and the ' +
+          'membership are all present, so the panel has a genuinely empty form of itself that ' +
+          'still opens and still says "Edit profile". The stories assert the cards for that ' +
+          'reason.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: { open: true },
+  beforeEach: seed,
+} satisfies Meta<typeof ProfileEditor>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Open: Story = {
+  name: 'Open',
+  play: async () => {
+    const panel = await openPanel();
+    const dialog = within(panel);
+
+    await expect(dialog.getByRole('heading', { name: 'Edit profile' })).toBeInTheDocument();
+    // The centered `lg` width from the Modal recipe, on the border box.
+    await expect(panel.getBoundingClientRect().width).toBeCloseTo(840, 0);
+
+    // Four cards in ONE scroll container, not four stacked panels.
+    await expect(dialog.getByText('User profile')).toBeInTheDocument();
+    await expect(dialog.getByText('Address')).toBeInTheDocument();
+    await expect(dialog.getByText('Professional details')).toBeInTheDocument();
+    await expect(dialog.getByText('Security')).toBeInTheDocument();
+    const scroller = dialog.getByText('User profile').closest('.overflow-y-auto') as HTMLElement;
+    await expect(scroller.children).toHaveLength(2);
+    await expect(getComputedStyle(scroller).overflowY).toBe('auto');
+
+    // Three round Edit affordances, one per profile card. Security has none - its
+    // controls are always live.
+    await expect(dialog.getAllByRole('button', { name: /^Edit / })).toHaveLength(3);
+
+    // Real values in the read-only rows, from the seeded profile and auth attributes.
+    await expect(fieldValue(panel, 'First name')).toBe('Elena');
+    await expect(fieldValue(panel, 'Email address')).toBe('elena.marsh@example.com');
+    await expect(fieldValue(panel, 'Org name')).toBe('Sunrise Veterinary Hospital');
+    await expect(fieldValue(panel, 'Address line')).toBe('1180 Sutter Street');
+    await expect(fieldValue(panel, 'Specialisation')).toBe('Small animal internal medicine');
+
+    /* The security card at rest. `GET /v1/auth/mfa/status` has no stub here, the
+       component swallows the failure, and `mfaStatus` stays null - which is exactly
+       the state a real user gets when that endpoint is down: the copy says "Not
+       enabled" (indistinguishable from a genuine "off") and the only control is
+       disabled with nothing explaining why. */
+    await expect(dialog.getByTestId('totp-status')).toHaveTextContent(
+      'Authenticator app: Not enabled'
+    );
+    await expect(dialog.getByRole('button', { name: 'Set up authenticator app' })).toBeDisabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The panel as it opens. Every field is a read-only row: 13px `--ink-faint` label ' +
+          'left, 13px medium `--ink-body` value right, hairline dividers between them and ' +
+          'none after the last one.\n\n' +
+          'The unresolved MFA state at the bottom is worth a decision. A failed status call ' +
+          'and a real "not set up" look identical, and the button is disabled either way, so ' +
+          'someone who cannot reach the endpoint has no way to tell that setup is unavailable ' +
+          'rather than untried.',
+      },
+    },
+  },
+};
+
+export const EditingIdentity: Story = {
+  name: 'Editing the User profile card',
+  play: async () => {
+    const panel = await openPanel();
+    const dialog = within(panel);
+
+    await expect(dialog.queryByRole('textbox', { name: 'First name' })).not.toBeInTheDocument();
+
+    await userEvent.click(dialog.getByRole('button', { name: 'Edit User profile' }));
+
+    // Editable fields became controls, seeded from the values that were on screen.
+    const firstName = await dialog.findByRole('textbox', { name: 'First name' });
+    await expect(firstName).toHaveValue('Elena');
+    await expect(dialog.getByRole('textbox', { name: 'Last name' })).toHaveValue('Marsh');
+    await expect(dialog.getByRole('textbox', { name: 'Phone number' })).toHaveValue(
+      '+1 415 555 0110'
+    );
+    await expect(dialog.getByRole('button', { name: /^Gender/ })).toBeInTheDocument();
+    await expect(dialog.getByRole('button', { name: /^Country/ })).toBeInTheDocument();
+
+    /* The half-and-half shape this card is really in while editing: `editable: false`
+       fields do NOT become inputs, they stay as value rows in the middle of the form.
+       Email, org name, role and employment type are all identity the user cannot
+       change here, so the card mixes 44px fields with 13px text rows. */
+    await expect(dialog.queryByRole('textbox', { name: 'Email address' })).not.toBeInTheDocument();
+    await expect(fieldValue(panel, 'Email address')).toBe('elena.marsh@example.com');
+    await expect(fieldValue(panel, 'Role')).toBe('Business owner');
+
+    // The other two cards did not follow it into edit mode.
+    await expect(dialog.queryByRole('textbox', { name: 'Address line' })).not.toBeInTheDocument();
+    await expect(dialog.getAllByRole('button', { name: /^Edit / })).toHaveLength(2);
+
+    // The footer only exists while editing.
+    const save = dialog.getByRole('button', { name: 'Save' });
+    await expect(save).toBeInTheDocument();
+    await userEvent.click(dialog.getByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() =>
+      expect(dialog.queryByRole('textbox', { name: 'First name' })).not.toBeInTheDocument()
+    );
+    await expect(dialog.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+    await expect(fieldValue(panel, 'First name')).toBe('Elena');
+    await expect(dialog.getAllByRole('button', { name: /^Edit / })).toHaveLength(3);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Edit is per card, not per panel: pressing one card's Edit leaves the other two " +
+          'read-only, so the panel can hold a form and two lists at once. The Cancel/Save ' +
+          'footer belongs to the editing card and is right-aligned above its own hairline.\n\n' +
+          'Cancel rebuilds the form values from the props, so it really does discard - unlike ' +
+          'the hours editor next door, which keeps an abandoned edit until the store changes.',
+      },
+    },
+  },
+};
+
+export const PhoneSheet: Story = {
+  name: 'Phone: the panel as a bottom sheet',
+  // Pinned as a GLOBAL. `parameters.viewport.defaultViewport` was removed in
+  // Storybook 10 and is inert: a story using it renders the 840px desktop panel
+  // under a name that promises a phone.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async () => {
+    // `useIsPhone` is false during the first client render, so the sheet class
+    // arrives on a second pass rather than on mount.
+    const panel = await waitFor(() => {
+      const sheet = document.querySelector('dialog[open].yc-modal-sheet');
+      expect(sheet).not.toBeNull();
+      return sheet as HTMLElement;
+    });
+    const dialog = within(panel);
+
+    /* The pin, checked rather than trusted. The sheet skin lives entirely inside a
+       `max-width: 767px` media query, so if the `mobile` global had not applied this
+       story would draw the 840px centered panel - and the `dialog[open].yc-modal-sheet`
+       wait above is the only thing that would notice. Measuring the width says which
+       of the two shapes is actually on screen. */
+    await expect(window.innerWidth).toBe(375);
+    /* Measured against the layout viewport rather than a hard 375, so a scrollbar
+       cannot turn a correct full-bleed sheet into a failure. `left: 0; right: 0` is
+       what makes it full-bleed; the desktop panel would be 840 and centered. */
+    const viewport = document.documentElement;
+    const box = panel.getBoundingClientRect();
+    await expect(box.width).toBeCloseTo(viewport.clientWidth, 0);
+    // Anchored to the bottom edge and capped at 86vh, per the sheet rule.
+    await expect(box.bottom).toBeCloseTo(viewport.clientHeight, 0);
+    // `vh` resolves against the initial containing block, so the cap is checked
+    // against innerHeight rather than clientHeight.
+    await expect(box.height).toBeLessThanOrEqual(window.innerHeight * 0.86 + 1);
+
+    // The grabber and the 24px top radius from the phone adaptation rule.
+    await expect(panel.querySelector('.yc-phone-sheet-grabber')).not.toBeNull();
+    await expect(getComputedStyle(panel).borderTopLeftRadius).toBe('24px');
+
+    // All four cards survive the re-form; the sheet scrolls rather than dropping any.
+    await expect(dialog.getByRole('heading', { name: 'Edit profile' })).toBeInTheDocument();
+    await expect(dialog.getByText('User profile')).toBeInTheDocument();
+    await expect(dialog.getByText('Address')).toBeInTheDocument();
+    await expect(dialog.getByText('Professional details')).toBeInTheDocument();
+    await expect(dialog.getByText('Security')).toBeInTheDocument();
+    await expect(dialog.getAllByRole('button', { name: /^Edit / })).toHaveLength(3);
+
+    /* The rows carry their real values at 375px too. The label/value row is a
+       `justify-between` flex with no wrap, so this is where a long value would be
+       squeezed against its label rather than dropping to a second line - the
+       assertion pins the content, and the snapshot shows the squeeze. */
+    await expect(fieldValue(panel, 'First name')).toBe('Elena');
+    await expect(fieldValue(panel, 'Email address')).toBe('elena.marsh@example.com');
+    await expect(fieldValue(panel, 'Address line')).toBe('1180 Sutter Street');
+  },
+  parameters: {
+    chromatic: { viewports: [375] },
+    docs: {
+      description: {
+        story:
+          'Under 768px the centered panel re-forms into a bottom sheet: grabber, 24px top ' +
+          'radius, capped at 86vh. Four cards of label/value rows inside that cap is a long ' +
+          'scroll on a phone, and the sheet is the only thing between the header and the ' +
+          'footer that moves - so this is where to check whether the panel wants a phone ' +
+          'layout of its own rather than the desktop stack at 375px.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/tasks/components/TaskAssigneeChips.stories.tsx
+++ b/apps/frontend/src/app/features/tasks/components/TaskAssigneeChips.stories.tsx
@@ -1,0 +1,445 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+
+import type { Option } from '@/app/features/companions/types/companion';
+import TaskAssigneeChips from './TaskAssigneeChips';
+
+const ELENA = 'practitioner-elena';
+const RAVI = 'practitioner-ravi';
+const TOM = 'practitioner-tom';
+const MARTA = 'parent-marta';
+const SKY = 'parent-sky';
+
+const TEAM_OPTIONS: Option[] = [
+  { label: 'Dr. Elena Marsh', value: ELENA },
+  { label: 'Dr. Ravi Patel', value: RAVI },
+  { label: 'Tom Reyes', value: TOM },
+];
+
+const PARENT_OPTIONS: Option[] = [
+  { label: 'Marta Alvarez', value: MARTA },
+  { label: 'Sky Doe', value: SKY },
+];
+
+/**
+ * Resolves a design token to the colour the browser actually paints, so a story can
+ * say "the selected team chip is ringed in --blue" rather than only "its border is
+ * not the same as its neighbour's".
+ *
+ * It appends a probe element, so it is a DOM MUTATION and must never be called from
+ * inside a `waitFor` callback: testing-library retries through a MutationObserver, and
+ * a callback that mutates and then throws re-queues itself forever - wedging the tab
+ * instead of failing. Every caller below resolves first, then polls only the read.
+ *
+ * Throws on an unresolved token: `var(--typo)` computes to transparent, which would
+ * otherwise quietly match any other unresolved token and turn the check into a no-op.
+ */
+const resolveToken = (host: HTMLElement, token: string): string => {
+  const probe = document.createElement('span');
+  probe.style.backgroundColor = `var(${token})`;
+  host.append(probe);
+  const value = getComputedStyle(probe).backgroundColor;
+  probe.remove();
+  if (value === 'rgba(0, 0, 0, 0)') {
+    throw new Error(`Token ${token} resolved to transparent - it does not exist here.`);
+  }
+  return value;
+};
+
+/**
+ * The chip carrying a given label.
+ *
+ * Queried by text rather than by accessible name on purpose: the team chip's name is
+ * the monogram concatenated with the label ("DE Dr. Elena Marsh"), which depends on
+ * how the accessible-name algorithm joins two child nodes. `getByText` matches the
+ * button's own text children, so it reads the label the design actually shows.
+ */
+const chip = (canvas: ReturnType<typeof within>, label: string): HTMLElement =>
+  canvas.getByText(label).closest('button') as HTMLElement;
+
+/** Every chip currently in the row, in render order (team first, then pet parents). */
+const chips = (canvasElement: HTMLElement): HTMLElement[] =>
+  [...canvasElement.querySelectorAll('button')] as HTMLElement[];
+
+const meta = {
+  title: 'Tasks/TaskAssigneeChips',
+  component: TaskAssigneeChips,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The "Assign to" row of the New task dialog: selectable team chips behind a violet ' +
+          'monogram, then pet-parent chips behind a pink dot. It replaced the two plain ' +
+          'dropdowns (audience "Type" + "Assigned to") the modal used to carry, which is why one ' +
+          'control now sets two fields - picking a pet-parent chip flips `audience` to ' +
+          '`PARENT_TASK` as well as setting `assignedTo`.\n\n' +
+          'Two branches had never been drawn.\n\n' +
+          'The **empty state** ("No assignees available yet.") replaces the whole row when both ' +
+          'lists are empty - which is the state a brand-new organisation opens the dialog in, ' +
+          'before anyone has been invited to the team and before a pet parent exists.\n\n' +
+          'The **error line** is `formDataErrors.assignedTo`, and nothing sets it until Create is ' +
+          'pressed with no assignee chosen. It is therefore invisible in every static reading of ' +
+          'the component, and it is the only feedback the row gives - the chips themselves do not ' +
+          'change at all when the form is rejected.\n\n' +
+          'The component is fully **controlled**: it renders `audience` + `assignedTo` and calls ' +
+          'back. Clicking a chip moves nothing on its own, so a parent that forgets to echo the ' +
+          'selection leaves the row looking untouched. The interaction story below pins that down.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    teamOptions: TEAM_OPTIONS,
+    parentOptions: PARENT_OPTIONS,
+    audience: 'EMPLOYEE_TASK',
+    assignedTo: '',
+    onSelectTeam: fn(),
+    onSelectParent: fn(),
+  },
+  decorators: [
+    (Story) => (
+      // 628px is the New task dialog's content box: an `md` centered Modal (680px)
+      // less its 26px horizontal insets. The row wraps against this width in the
+      // real dialog, so a wider box would never show the wrap.
+      <div className="w-[628px] max-w-full bg-[var(--screen)] p-6">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof TaskAssigneeChips>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Unselected: Story = {
+  name: 'Nothing chosen yet',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Assign to')).toBeInTheDocument();
+
+    // Five chips, in one row, none of them pressed. The count matters as much as the
+    // presence: the two lists are concatenated into a single flex row, so a bug that
+    // dropped one list would still leave a plausible-looking row of chips.
+    const row = chips(canvasElement);
+    await expect(row).toHaveLength(5);
+    for (const button of row) {
+      await expect(button).toHaveAttribute('aria-pressed', 'false');
+    }
+
+    /* Initials are derived, not stored: `getInitials` takes the first character of the
+       first TWO whitespace-separated parts. "Dr. Elena Marsh" therefore reads DE, not
+       EM - the honorific counts as a word. Worth seeing rather than assuming, because
+       every clinician in this list is stored with one. */
+    await expect(chip(canvas, 'Dr. Elena Marsh').querySelector('span')).toHaveTextContent('DE');
+    await expect(chip(canvas, 'Dr. Ravi Patel').querySelector('span')).toHaveTextContent('DR');
+    await expect(chip(canvas, 'Tom Reyes').querySelector('span')).toHaveTextContent('TR');
+
+    // Pet-parent chips carry the prefix in the label itself, so the two kinds of chip
+    // read apart even in a screen reader, where the pink dot is aria-hidden.
+    await expect(canvas.getByText('Pet parent · Marta Alvarez')).toBeInTheDocument();
+    await expect(canvas.getByText('Pet parent · Sky Doe')).toBeInTheDocument();
+
+    /* The dot is the only thing separating a pet-parent chip from a team chip at rest,
+       and it is painted from an inline style rather than a class. Resolved BEFORE the
+       poll, never inside it - `resolveToken` mutates the DOM. */
+    const pink = resolveToken(canvasElement, '--pink');
+    const dot = chip(canvas, 'Pet parent · Marta Alvarez').querySelector(
+      'span[aria-hidden="true"]'
+    ) as HTMLElement;
+    await waitFor(() => {
+      expect(getComputedStyle(dot).backgroundColor).toBe(pink);
+    });
+
+    await expect(canvas.queryByText('No assignees available yet.')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'How the row opens every time: five chips, nothing chosen, and no error. The reader has ' +
+          'to make a choice here before Create will go through, but nothing in this frame says so.',
+      },
+    },
+  },
+};
+
+export const TeamChipSelected: Story = {
+  name: 'A team member chosen',
+  args: { audience: 'EMPLOYEE_TASK', assignedTo: RAVI },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Exactly one chip is pressed, and it is the one whose value matches.
+    const pressed = canvas.getAllByRole('button', { pressed: true });
+    await expect(pressed).toHaveLength(1);
+    await expect(pressed[0]).toBe(chip(canvas, 'Dr. Ravi Patel'));
+
+    /* Selection is drawn as a 1.5px --blue ring on --nav-active-bg. Both the ring and
+       the resting hairline are compared against resolved tokens rather than against
+       each other: "different from its neighbour" would pass on any colour at all,
+       including a red one. */
+    const blue = resolveToken(canvasElement, '--blue');
+    const hairline = resolveToken(canvasElement, '--hairline');
+    const selected = chip(canvas, 'Dr. Ravi Patel');
+    const neighbour = chip(canvas, 'Dr. Elena Marsh');
+    await waitFor(() => {
+      expect(getComputedStyle(selected).borderTopColor).toBe(blue);
+      expect(getComputedStyle(neighbour).borderTopColor).toBe(hairline);
+    });
+    /* The class asks for 1.5px. The browser renders 1px - measured in Chromium at BOTH
+       devicePixelRatio 1 and 2, so it is not a density artefact: sub-pixel border
+       widths are floored to whole device pixels. The selected chip therefore has the
+       SAME border weight as its neighbour, and selection is carried entirely by colour
+       and background.
+
+       Asserted as authored-versus-used rather than as one number, so the intent stays
+       visible in the failure output. 42 places in the app ask for `border-[1.5px]` -
+       every form input, dropdown, datepicker and timepicker - and all of them render at
+       1px. Whether the design wants 1px or 2px is a decision, not a bug fix, so it is
+       filed rather than changed here. */
+    await expect(selected).toHaveClass('border-[1.5px]');
+    await expect(getComputedStyle(selected).borderTopWidth).toBe('1px');
+    await expect(getComputedStyle(neighbour).borderTopWidth).toBe('1px');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The employee-task case. The chip asks for 0.5px more border as well as a colour, but the ' +
+          'browser floors sub-pixel borders to whole device pixels, so both chips render at 1px ' +
+          'and the row does NOT reflow. Selection reads through colour alone.',
+      },
+    },
+  },
+};
+
+export const ParentChipSelected: Story = {
+  name: 'A pet parent chosen',
+  args: { audience: 'PARENT_TASK', assignedTo: MARTA },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const pressed = canvas.getAllByRole('button', { pressed: true });
+    await expect(pressed).toHaveLength(1);
+    await expect(pressed[0]).toBe(chip(canvas, 'Pet parent · Marta Alvarez'));
+
+    /* A pet-parent chip rings in --pink, not --blue, and keeps --ink for its label
+       rather than the team chip's --nav-active. Two different selected treatments in
+       one row is easy to lose in a refactor and impossible to see without both
+       stories side by side. */
+    const pink = resolveToken(canvasElement, '--pink');
+    const selected = chip(canvas, 'Pet parent · Marta Alvarez');
+    await waitFor(() => {
+      expect(getComputedStyle(selected).borderTopColor).toBe(pink);
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Choosing this chip is what turns an employee task into a parent task - the audience ' +
+          'flip happens in the caller, not here, so this frame is the only visible trace of it.',
+      },
+    },
+  },
+};
+
+export const SharedIdAcrossAudiences: Story = {
+  name: 'Audience is the discriminator, not the id',
+  args: {
+    teamOptions: [{ label: 'Dr. Elena Marsh', value: 'shared-identifier' }],
+    parentOptions: [{ label: 'Marta Alvarez', value: 'shared-identifier' }],
+    audience: 'PARENT_TASK',
+    assignedTo: 'shared-identifier',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* Both chips carry the SAME value here. `assignedTo` alone cannot tell them apart,
+       so the active test pairs it with `audience` - and this is the frame that proves
+       the pairing works. Drop either half of that condition and both chips light at
+       once, which no other story in this file would catch. */
+    const pressed = canvas.getAllByRole('button', { pressed: true });
+    await expect(pressed).toHaveLength(1);
+    await expect(pressed[0]).toBe(chip(canvas, 'Pet parent · Marta Alvarez'));
+    await expect(chip(canvas, 'Dr. Elena Marsh')).toHaveAttribute('aria-pressed', 'false');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Team ids come from `practionerId` and pet-parent ids from `parentId`, so a collision ' +
+          'is unlikely rather than impossible. The guard is one `audience ===` clause per chip ' +
+          'kind, and this is the only place it is exercised.',
+      },
+    },
+  },
+};
+
+export const Choosing: Story = {
+  name: 'Clicking a chip moves nothing on its own',
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(chip(canvas, 'Tom Reyes'));
+    await expect(args.onSelectTeam).toHaveBeenCalledTimes(1);
+    await expect(args.onSelectTeam).toHaveBeenCalledWith({ label: 'Tom Reyes', value: TOM });
+    await expect(args.onSelectParent).not.toHaveBeenCalled();
+
+    /* The row is fully controlled: it renders the `audience`/`assignedTo` it was given
+       and never keeps a selection of its own. With the args frozen, the chip the reader
+       just pressed is still unpressed - which is exactly what a caller that forgets to
+       echo the callback back into form state would ship. */
+    await expect(chip(canvas, 'Tom Reyes')).toHaveAttribute('aria-pressed', 'false');
+    await expect(canvas.queryAllByRole('button', { pressed: true })).toHaveLength(0);
+
+    await userEvent.click(chip(canvas, 'Pet parent · Sky Doe'));
+    await expect(args.onSelectParent).toHaveBeenCalledTimes(1);
+    await expect(args.onSelectParent).toHaveBeenCalledWith({ label: 'Sky Doe', value: SKY });
+    // Still one team call, not two: the two handlers do not share a click path.
+    await expect(args.onSelectTeam).toHaveBeenCalledTimes(1);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Both callbacks fire with the whole `Option`, not just its value, because the caller ' +
+          'needs the label to resolve a companion for a parent task. Nothing here writes to the ' +
+          'form - see the New task stories for the round trip.',
+      },
+    },
+  },
+};
+
+export const NoAssignees: Story = {
+  name: 'No assignees available yet',
+  args: { teamOptions: [], parentOptions: [] },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByText('No assignees available yet.')).toBeInTheDocument();
+    // The whole chip row is replaced, not emptied: there is nothing to press at all.
+    await expect(chips(canvasElement)).toHaveLength(0);
+    // The section label survives, so the field still reads as a field rather than
+    // as a stray sentence floating between the category and due-date rows.
+    await expect(canvas.getByText('Assign to')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'What a freshly created organisation sees: nobody has been invited to the team and no ' +
+          'pet parent exists yet, so `hasOptions` is false and the row collapses to one faint ' +
+          'line. Note there is no route out of it here - no "invite a colleague" link, no hint ' +
+          'that the task cannot be created without one.',
+      },
+    },
+  },
+};
+
+export const ErrorAfterCreate: Story = {
+  name: 'Error after Create with no assignee',
+  args: { error: 'Please select a companion or staff' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* The exact copy `validateTaskForm` produces. Worth pinning: the same message is
+       reused for the PARENT_TASK-without-companion case, where "staff" is not one of
+       the reader's options at all. */
+    const error = canvas.getByText('Please select a companion or staff');
+    const errorInk = resolveToken(canvasElement, '--color-text-error');
+    await waitFor(() => {
+      expect(getComputedStyle(error).color).toBe(errorInk);
+    });
+
+    // The error is appended BELOW the row, not put in place of it - the chips are
+    // still there to press, which is the whole point of showing the message.
+    await expect(chips(canvasElement)).toHaveLength(5);
+    await expect(error.previousElementSibling).toContainElement(chip(canvas, 'Tom Reyes'));
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The only state in which the row says anything is wrong, and it is reachable in exactly ' +
+          'one way: press Create in the New task dialog without choosing a chip. Nothing else in ' +
+          'the row changes - no chip is highlighted, no focus is moved - so this 12px line is the ' +
+          'entire feedback, several fields below the button that was pressed.',
+      },
+    },
+  },
+};
+
+export const NoAssigneesWithError: Story = {
+  name: 'Rejected with nothing to pick',
+  args: { teamOptions: [], parentOptions: [], error: 'Please select a companion or staff' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Both branches at once: the empty state AND the demand for a choice.
+    await expect(canvas.getByText('No assignees available yet.')).toBeInTheDocument();
+    await expect(canvas.getByText('Please select a companion or staff')).toBeInTheDocument();
+    await expect(chips(canvasElement)).toHaveLength(0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The dead end. The two branches are independent - the error renders after the ' +
+          '`hasOptions` ternary rather than inside it - so an organisation with no team and no pet ' +
+          'parents is told to select something it has not been offered. Worth a product decision ' +
+          'rather than a CSS one.',
+      },
+    },
+  },
+};
+
+export const PhoneWrap: Story = {
+  name: 'Phone (375): the row wraps',
+  args: {
+    teamOptions: [
+      ...TEAM_OPTIONS,
+      { label: 'Priya Raman', value: 'practitioner-priya' },
+      { label: 'Dr. Ana Beltran', value: 'practitioner-ana' },
+    ],
+    audience: 'EMPLOYEE_TASK',
+    assignedTo: TOM,
+  },
+  // Pinned as a GLOBAL. `parameters.viewport.defaultViewport` was removed in
+  // Storybook 10: a story using it still renders, still plays and still passes,
+  // at the full panel width - which for a wrap story proves the opposite of
+  // what its name claims.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const row = chips(canvasElement);
+    await expect(row).toHaveLength(7);
+
+    /* Rows are counted off the measured tops rather than asserted as "it wrapped":
+       `flex-wrap` is the only thing holding this row together on a phone, and losing
+       it produces a single overflowing line that a screenshot at this width crops
+       rather than shows. */
+    const tops = new Set(row.map((button) => Math.round(button.getBoundingClientRect().top)));
+    await expect(tops.size).toBeGreaterThanOrEqual(3);
+
+    // And nothing escapes the container. Measured with getBoundingClientRect, which
+    // is the border box - getComputedStyle().width would report the content box and
+    // under-read every chip by its 1px (or 1.5px, when selected) border.
+    const container = canvasElement.querySelector('.flex-wrap') as HTMLElement;
+    const limit = container.getBoundingClientRect().right;
+    for (const button of row) {
+      await expect(button.getBoundingClientRect().right).toBeLessThanOrEqual(limit + 1);
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Tasks are assigned on phones as often as at a desk, and at 375px five clinicians plus ' +
+          'two pet parents take three lines rather than one. The selected chip is deliberately in ' +
+          'the middle of the stack here: its extra half-pixel of border is what pushes the ' +
+          'following chip onto the next line, so the wrap points move when a selection changes.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/tasks/components/TaskFormBody.stories.tsx
+++ b/apps/frontend/src/app/features/tasks/components/TaskFormBody.stories.tsx
@@ -1,0 +1,502 @@
+import { type ComponentProps, useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, waitFor, within } from 'storybook/test';
+import type { UserOrganization } from '@yosemite-crew/types';
+
+import type { Option } from '@/app/features/companions/types/companion';
+import type { Task } from '@/app/features/tasks/types/task';
+import { useOrgStore } from '@/app/stores/orgStore';
+import TaskFormBody from './TaskFormBody';
+
+type TaskFormBodyProps = ComponentProps<typeof TaskFormBody>;
+
+const ORG_ID = 'org-storybook';
+
+const membership = (over: Partial<UserOrganization> = {}): UserOrganization => ({
+  id: 'membership-1',
+  practitionerReference: 'Practitioner/practitioner-elena',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'VETERINARIAN',
+  roleDisplay: 'Veterinarian',
+  active: true,
+  ...over,
+});
+
+/**
+ * Seeds the one store the gate reads. `usePermissions` derives the permission list
+ * from `roleCode` + extras - revocations on every render; nothing here fetches, so
+ * this is the whole of the setup and the gate under review is the real one.
+ *
+ * `status` matters as much as the membership: the gate treats `idle` and `loading`
+ * as "still resolving" and renders its `skeleton` instead of either branch.
+ */
+const seedPermissions = (over: Partial<UserOrganization> = {}) => {
+  useOrgStore.setState({
+    primaryOrgId: ORG_ID,
+    membershipsByOrgId: { [ORG_ID]: membership(over) },
+    status: 'loaded',
+  });
+};
+
+/**
+ * A fixed instant. `getPreferredTimeZone` falls back to Europe/Berlin whenever no
+ * timezone token is stored, so 12:00 UTC on 12 March renders as 13:00 on every
+ * machine rather than drifting with the reviewer's clock.
+ */
+const DUE_AT = new Date('2026-03-12T12:00:00.000Z');
+
+const task = (over: Partial<Task> = {}): Task => ({
+  _id: 'task-analgesia',
+  organisationId: ORG_ID,
+  assignedTo: 'practitioner-ravi',
+  audience: 'EMPLOYEE_TASK',
+  source: 'CUSTOM',
+  category: 'MEDICATION',
+  priority: 'HIGH',
+  name: 'Midday analgesia round',
+  description: 'Meloxicam 0.1mg/kg PO, then recheck the incision site.',
+  recurrence: { type: 'ONCE', isMaster: false },
+  dueAt: DUE_AT,
+  status: 'PENDING',
+  ...over,
+});
+
+const ASSIGNEE_OPTIONS: Option[] = [
+  { label: 'Dr. Elena Marsh', value: 'practitioner-elena' },
+  { label: 'Dr. Ravi Patel', value: 'practitioner-ravi' },
+];
+
+/**
+ * The body is a controlled form: every field writes through `setFormData` / `setDue` /
+ * `setDueTimeValue`, which the real consumers get from `useTaskForm`. Holding that
+ * state here keeps the fields editable in the docs page without pulling in the hook -
+ * and the hook is what fetches templates on mount, so this also keeps the stories off
+ * the network entirely.
+ */
+const FormHarness = ({
+  formData: initialFormData,
+  setFormData: _setFormData,
+  due: initialDue,
+  setDue: _setDue,
+  dueTimeValue: initialDueTimeValue,
+  setDueTimeValue: _setDueTimeValue,
+  ...rest
+}: TaskFormBodyProps) => {
+  const [formData, setFormData] = useState<Task>(initialFormData);
+  const [due, setDue] = useState<Date | null>(initialDue);
+  const [dueTimeValue, setDueTimeValue] = useState(initialDueTimeValue);
+
+  return (
+    // 470px is the `md` drawer the side-panel consumers put this body in, less its
+    // padding. The stack is single-column at every width, but the width still decides
+    // where the labels truncate.
+    <div className="flex min-h-[640px] w-[446px] max-w-full flex-col bg-[var(--screen)] p-3">
+      <TaskFormBody
+        {...rest}
+        formData={formData}
+        setFormData={setFormData}
+        due={due}
+        setDue={setDue}
+        dueTimeValue={dueTimeValue}
+        setDueTimeValue={setDueTimeValue}
+      />
+    </div>
+  );
+};
+
+/** The stacked field list inside the accordion, which is the layout under review. */
+const fieldStack = (canvasElement: HTMLElement): HTMLElement =>
+  canvasElement.querySelector('.flex.flex-col.gap-3') as HTMLElement;
+
+const meta = {
+  title: 'Tasks/TaskFormBody',
+  component: TaskFormBody,
+  parameters: {
+    layout: 'fullscreen',
+    // `Fallback` renders `PermissionDeniedState`, which calls next/navigation's
+    // useRouter during render for its "Request access" route.
+    nextjs: { appDirectory: true },
+    docs: {
+      description: {
+        component:
+          'The shared task form body, used by the task drawer and the appointment workspace ' +
+          'panel. It is four things stacked: a `PermissionGate`, an `Accordion` titled "Task", ' +
+          '`TaskFormFields` in its single-column form, and a footer holding the error line and ' +
+          'the Save button.\n\n' +
+          'None of it had ever been drawn, and the gate is the reason it matters. ' +
+          '`PermissionGate allOf={[TASKS_EDIT_ANY]}` has **three** outcomes, not two: permitted ' +
+          'renders the form, denied renders `Fallback`, and *still resolving* renders the default ' +
+          '`skeleton`, which is `null`. So a reader whose org membership has not loaded yet sees ' +
+          'an entirely blank panel - no form, no notice, no spinner - and nothing in the markup ' +
+          'distinguishes that from a denial except the absence of the denial.\n\n' +
+          'The footer holds a second surprise: **"Save as template" is rendered on every mount ' +
+          'with `className="hidden"`**. It is in the DOM, it is wired to ' +
+          '`handleCreateTemplate`, and it is invisible. The stories assert it is display:none ' +
+          'rather than quietly ignoring it, because "hidden" and "removed" are very different ' +
+          'things for a control that still runs a POST when something focuses and activates it.\n\n' +
+          'Two query traps worth knowing before writing more stories here. **"Task" names two ' +
+          'different controls**: the accordion header is a `button` labelled "Task", the task-name ' +
+          'field is a `textbox` labelled "Task", and only the role tells them apart. And the ' +
+          'hidden template action **has no accessible name at all** - accname returns the empty ' +
+          "string for a `display: none` element, and `getByRole`'s `hidden: true` does not change " +
+          'that, so it has to be reached by text.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    formData: task(),
+    setFormData: fn(),
+    due: DUE_AT,
+    setDue: fn(),
+    dueTimeValue: '13:00',
+    setDueTimeValue: fn(),
+    formDataErrors: {},
+    error: null,
+    isLoading: false,
+    templateOptions: [],
+    selectTemplate: fn(),
+    handleCreate: fn(),
+    handleCreateTemplate: fn(),
+  },
+  beforeEach: () => {
+    seedPermissions();
+  },
+  render: (args) => <FormHarness {...args} />,
+} satisfies Meta<typeof TaskFormBody>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Permitted: Story = {
+  name: 'Permitted - the whole body',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // The accordion opens itself (`defaultOpen`) and its edit affordance is
+    // suppressed (`showEditIcon={false} isEditing`), so the header is one button.
+    const header = canvas.getByRole('button', { name: 'Task' });
+    await expect(header).toHaveAttribute('aria-expanded', 'true');
+    await expect(canvas.queryByRole('button', { name: 'Edit Task' })).not.toBeInTheDocument();
+
+    /* Eight fields in one column. Both halves are asserted: the count says every field
+       mounted, and the flex direction says they stack rather than sharing rows - this
+       body deliberately does NOT pass `twoColumn`, which is the whole difference
+       between it and the New task dialog's grid. */
+    const stack = fieldStack(canvasElement);
+    await expect(getComputedStyle(stack).flexDirection).toBe('column');
+    await expect(stack.children).toHaveLength(8);
+
+    // Named in render order, so a reordering shows up here rather than in a screenshot.
+    const labels = [...stack.children].map((field) => field.textContent ?? '');
+    await expect(labels[0]).toContain('Category');
+    await expect(labels[1]).toContain('Priority');
+    await expect(labels[2]).toContain('Task');
+    await expect(labels[3]).toContain('Instructions (optional)');
+    await expect(labels[4]).toContain('Due date');
+    await expect(labels[5]).toContain('Time');
+    await expect(labels[6]).toContain('Reminder (optional)');
+    await expect(labels[7]).toContain('Repeat');
+
+    // The values arrive from `formData`, not from the fields' own defaults.
+    await expect(canvas.getByRole('textbox', { name: 'Task' })).toHaveValue(
+      'Midday analgesia round'
+    );
+    await expect(canvas.getByRole('button', { name: 'Category: Medication' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Priority: High' })).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('button', { name: 'Repeat: Does not repeat' })
+    ).toBeInTheDocument();
+    // 13:00, not 12:00: the stored instant is UTC and the pickers render in the
+    // preferred timezone, which is Europe/Berlin with no timezone token saved.
+    await expect(canvas.getByRole('button', { name: 'Time: 13:00' })).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('button', { name: 'Due date: Mar 12, 2026, toggle calendar' })
+    ).toBeInTheDocument();
+
+    // No template picker: `templateOptions` is empty, so the field is absent rather
+    // than an empty dropdown. That is why the stack is 8 and not 9.
+    await expect(canvas.queryByText('Load from template (optional)')).not.toBeInTheDocument();
+
+    /* Save is live and there is no error line above it. */
+    const save = canvas.getByRole('button', { name: 'Save' });
+    await expect(save).toBeEnabled();
+    await expect(canvas.queryByRole('button', { name: 'Saving...' })).not.toBeInTheDocument();
+
+    /* "Save as template" is NOT absent - it is shipped `hidden` on every mount. It
+       still holds its click handler, which creates a template AND a task. Asserted as
+       display:none rather than skipped, so that un-hiding it (or losing the class in a
+       refactor) fails here instead of quietly adding a second write path to the form.
+
+       Anchored on the TEXT and walked up with `closest`, never on
+       `getByRole('button', { name: 'Save as template', hidden: true })`. That query
+       cannot match and never could: accname step 2A returns the EMPTY STRING for a
+       `display: none` element, and testing-library computes the name with
+       `computeAccessibleName(element, { computedStyleSupportsPseudoElements })` - it
+       does not forward `hidden`, so the option relaxes the a11y-tree filter and leaves
+       the name empty. A painted-out control is therefore unreachable by name, which is
+       exactly what the last assertion here pins. */
+    const templateAction = canvas.getByText('Save as template').closest('button');
+    await expect(templateAction?.tagName).toBe('BUTTON');
+    await expect(templateAction?.classList.contains('hidden')).toBe(true);
+    await expect(getComputedStyle(templateAction as HTMLElement).display).toBe('none');
+    /* Painted out AND nameless. The button is a real, enabled, wired `<button>` that a
+       programmatic click still fires - `handleCreateTemplate` POSTs - but no assistive
+       technology and no name-based query can reach it. Both halves are asserted so that
+       un-hiding it fails the display check AND flips this one. */
+    await expect(
+      canvas.queryByRole('button', { name: 'Save as template', hidden: true })
+    ).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The permitted body at rest. Eight fields, one column, one live action - and one more ' +
+          'action that is in the DOM but painted out.',
+      },
+    },
+  },
+};
+
+export const Saving: Story = {
+  name: 'Saving',
+  args: { isLoading: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* The label and the disabled state are one prop, so they can never disagree -
+       which is exactly why both are asserted: a refactor that split them would leave
+       a button reading "Saving..." that still accepts a second click. */
+    const save = canvas.getByRole('button', { name: 'Saving...' });
+    await expect(save).toBeDisabled();
+    await expect(canvas.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+
+    // `isDisabled` also drops the pill to 60% and kills pointer events, so the frame
+    // reads as busy rather than merely inert.
+    await expect(save).toHaveClass('pointer-events-none');
+    await expect(getComputedStyle(save).opacity).toBe('0.6');
+
+    // The fields stay live during the write. Nothing disables them, so a reader can
+    // keep typing into a form that is already being submitted.
+    await expect(canvas.getByRole('textbox', { name: 'Task' })).toBeEnabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The frame between pressing Save and the API answering. It is prop-driven here, which ' +
+          'is the only way to hold it still - in the app it lasts exactly as long as one POST.',
+      },
+    },
+  },
+};
+
+export const SaveFailed: Story = {
+  name: 'Save failed',
+  args: { error: 'Failed to create task. Please try again.' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // The exact copy `useTaskForm` sets when `createTask` rejects.
+    const error = canvas.getByText('Failed to create task. Please try again.');
+
+    /* Resolved before the poll, never inside it: `resolveToken` appends a probe, and a
+       DOM mutation inside a `waitFor` callback re-queues the MutationObserver forever
+       instead of failing. */
+    const probe = document.createElement('span');
+    probe.style.backgroundColor = 'var(--color-text-error)';
+    canvasElement.append(probe);
+    const errorInk = getComputedStyle(probe).backgroundColor;
+    probe.remove();
+    await expect(errorInk).not.toBe('rgba(0, 0, 0, 0)');
+    await waitFor(() => {
+      expect(getComputedStyle(error).color).toBe(errorInk);
+    });
+
+    /* It sits ABOVE the action row and is centred, so on a narrow panel it pushes the
+       Save button down rather than sitting beside it. Asserted geometrically because
+       that shift is the thing a reviewer would notice and the class list would not
+       tell them. */
+    const save = canvas.getByRole('button', { name: 'Save' });
+    await expect(error.getBoundingClientRect().bottom).toBeLessThanOrEqual(
+      save.getBoundingClientRect().top
+    );
+
+    // The form is fully usable again: nothing is disabled and the values survived.
+    await expect(save).toBeEnabled();
+    await expect(canvas.getByRole('textbox', { name: 'Task' })).toHaveValue(
+      'Midday analgesia round'
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'One sentence, no detail, no retry affordance beyond pressing Save again. It is the ' +
+          'same string for every failure mode - a 400 from validation, a 500, or an offline ' +
+          'browser all land here - which is worth knowing when triaging a report of it.',
+      },
+    },
+  },
+};
+
+export const WithAssigneeDropdown: Story = {
+  name: 'With the assignee dropdown',
+  args: {
+    showAssigneeSelect: true,
+    assigneeOptions: ASSIGNEE_OPTIONS,
+    onAssigneeSelect: fn(),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* The assignee field is opt-in and lands FIRST in the stack, above Category -
+       nine children now, not eight. Position matters here: the side panels turn this
+       on and the New task dialog does not, so the two surfaces open on different
+       first fields. */
+    const stack = fieldStack(canvasElement);
+    await expect(stack.children).toHaveLength(9);
+    await expect(stack.children[0].textContent).toContain('Assigned to');
+
+    // It resolves the current `assignedTo` against the options rather than showing the
+    // raw id, which is the entire reason the options list is passed alongside it.
+    await expect(
+      canvas.getByRole('button', { name: 'Assigned to: Dr. Ravi Patel' })
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The panel consumers keep the plain dropdown. Only the New task dialog swapped it for ' +
+          'the chip row, so both controls are live in the product at the same time and this is ' +
+          'the one that has to keep working.',
+      },
+    },
+  },
+};
+
+export const RepeatingTask: Story = {
+  name: 'Repeating task adds an end date',
+  args: {
+    formData: task({
+      name: 'Twice-daily wound check',
+      recurrence: { type: 'DAILY', isMaster: true },
+    }),
+    formDataErrors: { endDate: 'End date is required for a repeating task' },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* A ninth field appears at the BOTTOM once the recurrence stops being ONCE. It is
+       derived from `formData.recurrence`, not from a separate toggle, so the only way
+       to reach this layout is to change Repeat - and the field it adds is required. */
+    const stack = fieldStack(canvasElement);
+    await expect(stack.children).toHaveLength(9);
+    await expect(stack.children[8].textContent).toContain('End date');
+    await expect(canvas.getByRole('button', { name: 'Repeat: Daily' })).toBeInTheDocument();
+
+    // The error is the validator's, and it renders on the End date field itself.
+    const alert = canvas.getByRole('alert');
+    await expect(alert).toHaveTextContent('End date is required for a repeating task');
+    await expect(stack.children[8]).toContainElement(alert);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The field count changes with the data. A repeating task needs a boundary, so the form ' +
+          'grows one row and immediately fails validation until it is filled - which means the ' +
+          'first Save after switching Repeat to Daily always bounces.',
+      },
+    },
+  },
+};
+
+export const Denied: Story = {
+  name: 'Denied - tasks:edit:any revoked',
+  beforeEach: () => {
+    // A real membership with the one permission taken away, rather than a role with
+    // no task rights at all: revocations are applied after the role baseline, and
+    // that subtraction is the path most custom memberships take.
+    seedPermissions({ revokedPermissions: ['tasks:edit:any'] });
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* The notice quotes the reader's REAL role, read from the membership - so the
+       sentence changes per user and is worth reading in full rather than matching a
+       fragment. Read off the element's text because the role and the "Request access"
+       link are separate nodes inside it. */
+    const notice = canvas.getByRole('status');
+    await expect(notice).toHaveTextContent("Your role (Veterinarian) can't view this section.");
+    await expect(canvas.getByRole('button', { name: 'Request access' })).toBeInTheDocument();
+
+    // The body is gone entirely - not disabled, not read-only. Both the accordion and
+    // the write action are checked, because a gate that leaked either one would still
+    // render this notice above it.
+    await expect(canvas.queryByRole('button', { name: 'Task' })).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+    /* By TEXT, because the hidden action has no accessible name to query by (see
+       Permitted) - a `queryByRole(..., { name: 'Save as template' })` here would have
+       passed with the control fully present, which is the kind of assertion that reads
+       like coverage and proves nothing. */
+    await expect(canvas.queryByText('Save as template')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The compact inline denial, sized for a panel rather than the full-page card. It names ' +
+          'the role and offers a route to Organization, which is the difference between this and ' +
+          'the bare red "Not authorized" line it replaced.',
+      },
+    },
+  },
+};
+
+export const PermissionsStillResolving: Story = {
+  name: 'Permissions still resolving - a blank panel',
+  beforeEach: () => {
+    // No membership and `status: 'loading'`. `usePermissions` reports isLoading from
+    // the store status alone, so this is the state during every cold page load.
+    useOrgStore.setState({ primaryOrgId: null, membershipsByOrgId: {}, status: 'loading' });
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* Neither branch renders. `PermissionGate`'s `skeleton` defaults to `null` and this
+       caller passes none, so the panel is genuinely EMPTY while permissions resolve -
+       and it looks identical to a panel whose content failed to mount. Asserting the
+       absence of BOTH branches is what makes this a state rather than a typo: checking
+       only for the missing form would also pass on the denied story. */
+    await expect(canvas.queryByRole('button', { name: 'Task' })).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('status')).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Request access' })).not.toBeInTheDocument();
+
+    /* Measured rather than only queried: the gate returns `null`, so the harness box
+       that holds the panel has ZERO element children and no text of its own. A pile of
+       absent-query assertions would also pass on a body that rendered a spinner, an
+       empty card or a stray wrapper with padding, and each of those is a different bug
+       from "nothing at all". */
+    const host = canvasElement.querySelector('.min-h-\\[640px\\]') as HTMLElement;
+    await expect(host.childElementCount).toBe(0);
+    await expect(host.textContent).toBe('');
+    // The 640px minimum is the harness's, not the component's: the blank region a
+    // reader sees is whatever the drawer around it happens to be tall.
+    await expect(host.getBoundingClientRect().height).toBeGreaterThanOrEqual(640);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The third outcome, and the one no reviewer would think to ask for. It lasts as long as ' +
+          'the org membership takes to load, which on a cold start is the same window in which ' +
+          'the reader is most likely to be looking at the panel. A `skeleton` here would cost one ' +
+          'prop.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/tasks/pages/Tasks/Sections/AddTask/AddTask.stories.tsx
+++ b/apps/frontend/src/app/features/tasks/pages/Tasks/Sections/AddTask/AddTask.stories.tsx
@@ -1,0 +1,623 @@
+import { type ComponentProps, useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import type { UserOrganization } from '@yosemite-crew/types';
+
+import type {
+  StoredCompanion,
+  StoredParent,
+} from '@/app/features/companions/pages/Companions/types';
+import type { Team } from '@/app/features/organization/types/team';
+import type { Task } from '@/app/features/tasks/types/task';
+import { useCompanionStore } from '@/app/stores/companionStore';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useParentStore } from '@/app/stores/parentStore';
+import { useTeamStore } from '@/app/stores/teamStore';
+import AddTask from './index';
+
+type AddTaskProps = ComponentProps<typeof AddTask>;
+
+const ORG_ID = 'org-storybook';
+const ELENA = 'practitioner-elena';
+const RAVI = 'practitioner-ravi';
+const MARTA = 'parent-marta';
+const SKY = 'parent-sky';
+
+const membership: UserOrganization = {
+  id: 'membership-1',
+  practitionerReference: `Practitioner/${ELENA}`,
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'VETERINARIAN',
+  roleDisplay: 'Veterinarian',
+  active: true,
+};
+
+const teamMember = (practionerId: string, name: string): Team => ({
+  _id: `team-${practionerId}`,
+  practionerId,
+  organisationId: ORG_ID,
+  name,
+  role: 'VETERINARIAN',
+  speciality: [],
+  status: 'Available',
+  revokedPermissions: [],
+  effectivePermissions: [],
+  extraPerissions: [],
+});
+
+const TEAM: Team[] = [teamMember(ELENA, 'Dr. Elena Marsh'), teamMember(RAVI, 'Dr. Ravi Patel')];
+
+const parent = (id: string, firstName: string, lastName: string): StoredParent => ({
+  id,
+  firstName,
+  lastName,
+  email: `${firstName.toLowerCase()}.${lastName.toLowerCase()}@example.com`,
+  phoneNumber: '+34 600 000 000',
+  address: { city: 'Barcelona', country: 'ES' },
+  createdFrom: 'pms',
+});
+
+const PARENTS: StoredParent[] = [parent(MARTA, 'Marta', 'Alvarez'), parent(SKY, 'Sky', 'Doe')];
+
+const companion = (id: string, name: string, parentId: string): StoredCompanion => ({
+  id,
+  organisationId: ORG_ID,
+  parentId,
+  name,
+  type: 'dog',
+  breed: 'Border Collie',
+  dateOfBirth: new Date('2019-04-18T00:00:00.000Z'),
+  gender: 'male',
+  isInsured: false,
+  status: 'active',
+});
+
+const COMPANIONS: StoredCompanion[] = [
+  companion('companion-kiko', 'Kiko', MARTA),
+  companion('companion-kizie', 'Kizie', SKY),
+  // A second pet for Marta. The dialog folds companions by parent, so this must NOT
+  // produce a second Marta chip - see the "Nothing chosen yet" story.
+  companion('companion-luna', 'Luna', MARTA),
+];
+
+/**
+ * Seeds the four stores the dialog reads, rather than mocking modules.
+ *
+ * The chip lists are pure selectors over `teamStore` and `companionStore`; the pet
+ * parent's NAME comes from `parentStore` via `useMemberMap`. None of them fetches on
+ * read - the loaders (`useLoadTeam`, `useLoadCompanionsForPrimaryOrg`) are separate
+ * hooks this dialog does not call.
+ *
+ * `useTaskForm` does fetch: it loads org templates and the YC library on mount. Both
+ * are wrapped in `Promise.allSettled` and both failing leaves `templateOptions` empty,
+ * which is exactly the shape these stories assert - so the missing backend produces a
+ * real state rather than a broken one, and no request mocking is needed (this
+ * Storybook has none).
+ */
+const seed = ({
+  team = TEAM,
+  companions = COMPANIONS,
+  parents = PARENTS,
+}: { team?: Team[]; companions?: StoredCompanion[]; parents?: StoredParent[] } = {}) => {
+  useOrgStore.setState({
+    primaryOrgId: ORG_ID,
+    membershipsByOrgId: { [ORG_ID]: membership },
+    status: 'loaded',
+  });
+  useTeamStore.getState().setTeamsForOrg(ORG_ID, team);
+  useCompanionStore.getState().setCompanionsForOrg(ORG_ID, companions);
+  useParentStore.getState().setParents(parents);
+};
+
+/**
+ * A completed, recurring task being duplicated - the shape the tasks page hands in
+ * when a reader picks "Duplicate" on an existing row.
+ *
+ * Module-level so its identity is STABLE across renders. The hydration guard is
+ * `prefill !== consumedPrefill`, an identity comparison, so a prefill rebuilt inline
+ * in `args` would be a new object on every render and re-apply itself forever,
+ * wiping anything the reader typed.
+ */
+const PREFILL: Partial<Task> = {
+  _id: 'task-source-9001',
+  organisationId: ORG_ID,
+  appointmentId: 'appointment-8842',
+  name: 'Twice-daily wound check',
+  description: 'Check the incision site, photograph it, and log the result.',
+  category: 'PROCEDURE',
+  priority: 'URGENT',
+  audience: 'EMPLOYEE_TASK',
+  assignedTo: RAVI,
+  source: 'CUSTOM',
+  status: 'COMPLETED',
+  completedAt: new Date('2026-03-10T09:00:00.000Z'),
+  completedBy: ELENA,
+  calendarEventId: 'calendar-event-31',
+  // Fixed instant: `getPreferredTimeZone` falls back to Europe/Berlin with no timezone
+  // token stored, so 12:00 UTC renders as 13:00 on every machine.
+  dueAt: new Date('2026-03-12T12:00:00.000Z'),
+  recurrence: { type: 'DAILY', isMaster: true, masterTaskId: 'task-master-77' },
+};
+
+/**
+ * The tasks page mounts this dialog on demand and unmounts it on dismissal. Copying
+ * that lifecycle keeps the docs page from holding half a dozen open dialogs at once,
+ * each with a share of `ModalBase`'s ref-counted body scroll lock.
+ */
+const AddTaskHarness = ({
+  showModal: _showModal,
+  setShowModal: _setShowModal,
+  ...args
+}: AddTaskProps) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="flex min-h-[620px] items-start bg-[var(--screen)] p-6">
+      <button
+        type="button"
+        className="rounded-2xl bg-[var(--cta)] px-6 py-3 text-body-3-emphasis text-[var(--cta-text)]"
+        onClick={() => setOpen(true)}
+      >
+        Open the New task dialog
+      </button>
+      {open && <AddTask {...args} showModal setShowModal={setOpen} />}
+    </div>
+  );
+};
+
+/**
+ * Opens the dialog and returns it.
+ *
+ * Matched on `dialog[open]`, never on a class: `ModalBase` leaves a dismissed dialog
+ * MOUNTED and only drops the `open` attribute, so a class lookup can return a panel
+ * that is no longer on screen. It also portals to `document.body`, so none of the
+ * dialog is inside `canvasElement`.
+ *
+ * The LAST open dialog is taken rather than the first: on the autodocs page every
+ * story shares one `document.body`, and a dialog opened by an earlier story is still
+ * there. Portals append in mount order, so the newest one is at the end.
+ */
+const openDialog = async (canvasElement: HTMLElement) => {
+  const canvas = within(canvasElement);
+  await userEvent.click(canvas.getByRole('button', { name: 'Open the New task dialog' }));
+  return waitFor(() => {
+    const dialogs = document.querySelectorAll('dialog[open]');
+    expect(dialogs.length).toBeGreaterThan(0);
+    return dialogs[dialogs.length - 1] as HTMLElement;
+  });
+};
+
+/** Resolved grid tracks for a row of the dialog's field grid. */
+const tracks = (el: HTMLElement): string[] =>
+  getComputedStyle(el).gridTemplateColumns.trim().split(/\s+/);
+
+/** The grid row a labelled field sits in. */
+const gridRow = (dialog: HTMLElement, label: string): HTMLElement =>
+  within(dialog).getByText(label).closest('.grid') as HTMLElement;
+
+const meta = {
+  title: 'Tasks/AddTask',
+  component: AddTask,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The **New task** dialog - the only place in PIMS a task is created from scratch - and ' +
+          'it had never been drawn. It opens on a click from the tasks page, so the whole surface ' +
+          'was reviewable only by driving the live app against a seeded organisation.\n\n' +
+          'It is a `centered` Modal at `md` (680px) holding three things: a `ModalHeader`, ' +
+          '`TaskFormFields` in a layout that exists nowhere else, and a `ModalFooter`.\n\n' +
+          'The **layout is unique to this caller**. `TaskFormFields` has three branches, and only ' +
+          'this dialog passes `twoColumn` *and* `assigneeChips`: task name, category, then the ' +
+          'chip row, then Due date / Time / Repeat sharing a three-track row and Priority / ' +
+          'Reminder sharing a two-track one. Every other consumer gets the single-column stack. ' +
+          'Both grids are `grid-cols-1 sm:grid-cols-N`, and `sm` is a **viewport** query, not a ' +
+          'container one - so they collapse when the browser narrows even though the 680px panel ' +
+          'has not changed.\n\n' +
+          'The **assignee chips replace two dropdowns**. Team chips carry a violet monogram, ' +
+          'pet-parent chips a pink dot, and picking one of the latter flips `audience` to ' +
+          '`PARENT_TASK` and resolves a `companionId` behind the scenes. The pet-parent list is ' +
+          'folded by parent, so an owner with three pets still gets one chip.\n\n' +
+          'The **prefill hydration runs during render**, not in an effect: `if (showModal && ' +
+          'prefill && prefill !== consumedPrefill)` sets five pieces of state and marks the ' +
+          'prefill consumed. That identity comparison is load-bearing - a caller passing a freshly ' +
+          'built object on each render would re-apply it forever and erase every keystroke. It ' +
+          'also SCRUBS the source task: `_id`, `appointmentId`, `completedAt`, `completedBy`, ' +
+          '`calendarEventId` and the series link are dropped and the status forced back to ' +
+          '`PENDING`. None of that scrubbing is visible, which is precisely why it is worth ' +
+          'writing down here.\n\n' +
+          'One accessibility gap the stories pin rather than paper over: this caller passes ' +
+          'neither `aria-label` nor `aria-labelledby` to `Modal`, so the dialog opens **without an ' +
+          'accessible name** even though "New task" is right there in the header.\n\n' +
+          'No story presses Create in a state that would pass validation. `handleCreate` POSTs, ' +
+          'and this Storybook has no request mocking - the stories stop at the last frame before ' +
+          'the write.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    showModal: true,
+    setShowModal: fn(),
+    prefill: null,
+  },
+  beforeEach: () => {
+    seed();
+  },
+  render: (args) => <AddTaskHarness {...args} />,
+} satisfies Meta<typeof AddTask>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const NewTask: Story = {
+  name: 'Nothing chosen yet',
+  play: async ({ canvasElement }) => {
+    const dialog = await openDialog(canvasElement);
+    const panel = within(dialog);
+
+    await expect(panel.getByRole('heading', { name: 'New task' })).toBeInTheDocument();
+
+    /* 680px, the `md` centered width. Measured with getBoundingClientRect because that
+       is the border box - getComputedStyle().width reports the content box and would
+       read 628 here, once the 26px insets are taken off. */
+    await expect(Math.round(dialog.getBoundingClientRect().width)).toBe(680);
+
+    /* The dialog carries NO accessible name. `Modal` applies whichever of aria-label /
+       aria-labelledby it is handed, and this caller hands it neither - so a screen
+       reader announces "dialog" with no title, while the sighted reader has "New task"
+       in 17px bold at the top. Asserted rather than described, so that wiring the
+       header up (a `titleId` and one prop) fails this line and gets it removed. */
+    await expect(dialog).not.toHaveAttribute('aria-label');
+    await expect(dialog).not.toHaveAttribute('aria-labelledby');
+    await expect(dialog).toHaveAttribute('aria-modal', 'true');
+
+    // Empty form: the name is blank and the category holds EMPTY_TASK's default.
+    await expect(panel.getByRole('textbox', { name: 'Task' })).toHaveValue('');
+    await expect(panel.getByRole('button', { name: 'Category: Care' })).toBeInTheDocument();
+    await expect(panel.getByRole('button', { name: 'Priority: Medium' })).toBeInTheDocument();
+
+    /* Three chips, not four. Two clinicians and ONE Marta - she owns two of the three
+       seeded companions, and the dialog folds the parent list through a Map keyed on
+       `parentId` precisely so an owner with several pets does not repeat. The count is
+       the only thing that catches a regression there. */
+    await expect(panel.getByText('Assign to')).toBeInTheDocument();
+    await expect(panel.getByText('Dr. Elena Marsh')).toBeInTheDocument();
+    await expect(panel.getByText('Dr. Ravi Patel')).toBeInTheDocument();
+    await expect(panel.getByText('Pet parent · Marta Alvarez')).toBeInTheDocument();
+    await expect(panel.getByText('Pet parent · Sky Doe')).toBeInTheDocument();
+    await expect(panel.queryAllByRole('button', { pressed: true })).toHaveLength(0);
+
+    /* The two field grids, by track count AND child count. A three-track template over
+       two children leaves a hole where Repeat should be, and a two-track template over
+       three silently wraps one field onto a second line - neither shows up in a class
+       list, and both are invisible in a screenshot that happens to look balanced. */
+    const dueRow = gridRow(dialog, 'Due date');
+    await expect(tracks(dueRow)).toHaveLength(3);
+    await expect(dueRow.children).toHaveLength(3);
+    const priorityRow = gridRow(dialog, 'Priority');
+    await expect(tracks(priorityRow)).toHaveLength(2);
+    await expect(priorityRow.children).toHaveLength(2);
+    // Different rows, not one grid found twice.
+    await expect(dueRow).not.toBe(priorityRow);
+
+    /* No template picker. Both template loads fail here (there is no backend), so
+       `templateOptions` is empty and the field is absent rather than an empty
+       dropdown - which is also what a new organisation with no templates sees. */
+    await expect(panel.queryByText('Load from template (optional)')).not.toBeInTheDocument();
+
+    // The footer: Cancel and Create task, plus the hidden template action.
+    await expect(panel.getByRole('button', { name: 'Cancel' })).toBeEnabled();
+    await expect(panel.getByRole('button', { name: 'Create task' })).toBeEnabled();
+
+    /* The template action is shipped `className="hidden"` on every mount - present,
+       wired to `handleCreateTemplate`, and painted out.
+
+       It has to be found by TEXT. `getByRole('button', { name: 'Save as template',
+       hidden: true })` can never match it: accname step 2A returns the EMPTY STRING for
+       a `display: none` element, and testing-library computes the name without passing
+       `hidden` through, so the option only relaxes the a11y-tree filter and leaves the
+       name empty. The role query is kept below as an assertion of exactly that - the
+       control is nameless, not absent - so un-hiding it flips both lines rather than
+       silently satisfying one. */
+    const templateAction = panel.getByText('Save as template').closest('button');
+    await expect(templateAction?.tagName).toBe('BUTTON');
+    await expect(templateAction?.classList.contains('hidden')).toBe(true);
+    await expect(getComputedStyle(templateAction as HTMLElement).display).toBe('none');
+    await expect(
+      panel.queryByRole('button', { name: 'Save as template', hidden: true })
+    ).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'How the dialog opens from the tasks page: an empty form, Category pre-set to Care by ' +
+          '`EMPTY_TASK`, and a Create button that will bounce until a name and an assignee exist.',
+      },
+    },
+  },
+};
+
+export const Prefilled: Story = {
+  name: 'Prefilled from a duplicated task',
+  args: { prefill: PREFILL },
+  play: async ({ canvasElement }) => {
+    const dialog = await openDialog(canvasElement);
+    const panel = within(dialog);
+
+    // Everything the hydration writes that the reader can actually SEE.
+    await expect(panel.getByRole('textbox', { name: 'Task' })).toHaveValue(
+      'Twice-daily wound check'
+    );
+    await expect(panel.getByRole('button', { name: 'Category: Procedure' })).toBeInTheDocument();
+    await expect(panel.getByRole('button', { name: 'Priority: Urgent' })).toBeInTheDocument();
+    await expect(panel.getByRole('button', { name: 'Repeat: Daily' })).toBeInTheDocument();
+    // 13:00, not 12:00 - the stored instant is UTC and the pickers render in the
+    // preferred timezone (Europe/Berlin when no timezone token is saved).
+    await expect(panel.getByRole('button', { name: 'Time: 13:00' })).toBeInTheDocument();
+    await expect(
+      panel.getByRole('button', { name: 'Due date: Mar 12, 2026, toggle calendar' })
+    ).toBeInTheDocument();
+
+    // The source task's assignee arrives selected, so the chip row opens pre-answered.
+    const pressed = panel.getAllByRole('button', { pressed: true });
+    await expect(pressed).toHaveLength(1);
+    await expect(pressed[0]).toHaveTextContent('Dr. Ravi Patel');
+
+    /* A daily recurrence adds the End date field, and it is EMPTY: the hydration keeps
+       the type but the source task's end boundary is not carried, so the duplicate
+       fails validation on a field the reader never touched. That is the one
+       consequence of the scrub with a visible surface. */
+    const endDate = panel.getByRole('button', { name: 'End date, toggle calendar' });
+    // The accessible name is the label ALONE - a Datepicker holding a date reads
+    // "End date: Mar 12, 2026, toggle calendar" - and the value span is empty.
+    await expect(endDate.querySelector('span')).toBeEmptyDOMElement();
+
+    /* The rest of the scrub is invisible by design and cannot be asserted from the
+       DOM: `_id`, `appointmentId`, `completedAt`, `completedBy`, `calendarEventId` are
+       cleared, `status` is forced to PENDING, and `recurrence.isMaster` is set false
+       with `masterTaskId` dropped so the copy starts its own series rather than
+       joining the source's. If any of that regresses, the dialog looks exactly like
+       this frame and the bug lands in the database. */
+    await expect(panel.getByRole('button', { name: 'Create task' })).toBeEnabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'What "Duplicate" opens. Six fields arrive filled and one - End date - arrives empty and ' +
+          'required, which is why duplicating a repeating task always needs one more decision ' +
+          'than duplicating a one-off.',
+      },
+    },
+  },
+};
+
+export const PrefillIsConsumedOnce: Story = {
+  name: 'Typing survives the next render',
+  args: { prefill: PREFILL },
+  play: async ({ canvasElement }) => {
+    const dialog = await openDialog(canvasElement);
+    const panel = within(dialog);
+    const name = panel.getByRole('textbox', { name: 'Task' });
+    await expect(name).toHaveValue('Twice-daily wound check');
+
+    await userEvent.clear(name);
+    await userEvent.type(name, 'Wound check - day 3');
+
+    /* Every keystroke calls `setFormData` and re-renders the dialog, so this asserts
+       the hydration guard rather than the input: `consumedPrefill` holds the same
+       object identity the args still carry, the `if` is false, and the typed value
+       stands. Without the guard - or with a value comparison in place of the identity
+       one - the prefill would reapply on the render after each character and the field
+       would snap back to "Twice-daily wound check". */
+    await expect(name).toHaveValue('Wound check - day 3');
+
+    // A second, unrelated field change re-renders again and still does not reset it.
+    await userEvent.click(panel.getByText('Pet parent · Sky Doe'));
+    await expect(name).toHaveValue('Wound check - day 3');
+
+    /* And the chip click did land, flipping the task from the prefilled employee
+       assignment to a parent task - one chip pressed, and it is not Ravi's. */
+    const pressed = panel.getAllByRole('button', { pressed: true });
+    await expect(pressed).toHaveLength(1);
+    await expect(pressed[0]).toHaveTextContent('Pet parent · Sky Doe');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The render-phase hydration is the riskiest thing in this file, and this is the frame ' +
+          'that would catch it breaking. It is not a visual story - the value in the field is the ' +
+          'whole result - but nothing else in Storybook exercises a render-phase state write.',
+      },
+    },
+  },
+};
+
+export const CreateWithoutAnAssignee: Story = {
+  name: 'Create with nothing filled in',
+  play: async ({ canvasElement }) => {
+    const dialog = await openDialog(canvasElement);
+    const panel = within(dialog);
+
+    await userEvent.click(panel.getByRole('button', { name: 'Create task' }));
+
+    /* `validateTaskForm` rejects, so nothing is POSTed and the dialog stays open. Two
+       errors land in two different places: one on the name field, one under the chip
+       row several rows further down. Neither moves focus, and the button that was
+       pressed is at the bottom of a scrolling body - so on a short window the reader
+       can press Create and see nothing change at all. */
+    expect(await panel.findByText('Please select a companion or staff')).toBeInTheDocument();
+    await expect(panel.getByText('Name is required')).toBeInTheDocument();
+
+    // Category and Due date are NOT flagged: `EMPTY_TASK` ships a category, and
+    // `useTaskForm` folds the date and time pickers into `dueAt` during render, so
+    // both are already valid on an untouched form.
+    await expect(panel.queryByText('Category is required')).not.toBeInTheDocument();
+    await expect(panel.queryByText('Due date and time are required')).not.toBeInTheDocument();
+
+    await expect(document.querySelector('dialog[open]')).not.toBeNull();
+    await expect(panel.getByRole('button', { name: 'Create task' })).toBeEnabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The rejection path, which is the only way the assignee error is ever reachable. Worth ' +
+          'looking at the distance between the pressed button and the two messages: they are the ' +
+          'entire response, and one of them can be below the fold.',
+      },
+    },
+  },
+};
+
+export const NoAssigneesToPick: Story = {
+  name: 'A brand-new organisation',
+  beforeEach: () => {
+    seed({ team: [], companions: [], parents: [] });
+  },
+  play: async ({ canvasElement }) => {
+    const dialog = await openDialog(canvasElement);
+    const panel = within(dialog);
+
+    /* No colleagues invited and no pet parents yet, so the chip row collapses to one
+       faint line. The whole row is REPLACED, not emptied: `hasOptions` is false and
+       the ternary renders the sentence instead of the flex box, so there is nothing
+       selectable between the "Assign to" label and the Due date row. Counted rather
+       than eyeballed - an empty flex row and a replaced one look identical. */
+    await expect(panel.getByText('Assign to')).toBeInTheDocument();
+    await expect(panel.getByText('No assignees available yet.')).toBeInTheDocument();
+    await expect(panel.queryByText('Pet parent · Marta Alvarez')).not.toBeInTheDocument();
+    await expect(panel.queryByText(/^Pet parent · /)).not.toBeInTheDocument();
+    await expect(panel.queryByText('Dr. Elena Marsh')).not.toBeInTheDocument();
+
+    /* The rest of the dialog is untouched, which is the part worth pinning: the two
+       field grids keep their three-track and two-track templates and all six fields,
+       so the reader can fill in every other row and Create will still bounce on an
+       assignee that cannot be chosen. */
+    await expect(panel.getByRole('textbox', { name: 'Task' })).toHaveValue('');
+    const dueRow = gridRow(dialog, 'Due date');
+    await expect(tracks(dueRow)).toHaveLength(3);
+    await expect(dueRow.children).toHaveLength(3);
+    const priorityRow = gridRow(dialog, 'Priority');
+    await expect(tracks(priorityRow)).toHaveLength(2);
+    await expect(priorityRow.children).toHaveLength(2);
+    await expect(panel.getByRole('button', { name: 'Create task' })).toBeEnabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The first-run state. It is reachable on day one of every new practice, and the dialog ' +
+          'offers no route out of it - no invite link, no explanation that a task cannot be ' +
+          'created without a team member or a pet parent.',
+      },
+    },
+  },
+};
+
+export const UnknownPetParent: Story = {
+  name: 'A pet parent missing from the store',
+  beforeEach: () => {
+    // The companion is there; its owner is not. This happens whenever the companion
+    // list has loaded and the parent list has not - two independent fetches.
+    seed({ companions: [companion('companion-kiko', 'Kiko', MARTA)], parents: [] });
+  },
+  play: async ({ canvasElement }) => {
+    const dialog = await openDialog(canvasElement);
+    const panel = within(dialog);
+
+    /* `resolveMemberName` returns '-' for an unknown id and the dialog falls back to
+       `companion.name` - so the chip reads the PET's name behind a "Pet parent"
+       prefix. It is a plausible-looking chip that names the wrong species. Asserted
+       because it is silent: nothing about this frame suggests a lookup failed. */
+    await expect(panel.getByText('Pet parent · Kiko')).toBeInTheDocument();
+    await expect(panel.queryByText('Pet parent · Marta Alvarez')).not.toBeInTheDocument();
+
+    /* ONE parent chip, not zero and not two: the fold still keys on `parentId`, so a
+       missing parent record loses the name without losing the row. Counted because
+       the two other plausible regressions - dropping the chip entirely, or emitting
+       one chip per companion - both leave a frame that reads as reasonable. */
+    await expect(panel.getAllByText(/^Pet parent · /)).toHaveLength(1);
+    // The team chips are unaffected: the failed lookup is in the companion fold, and
+    // it does not take the rest of the row with it.
+    await expect(panel.getByText('Dr. Elena Marsh')).toBeInTheDocument();
+    await expect(panel.getByText('Dr. Ravi Patel')).toBeInTheDocument();
+    // And nothing is selected, so the reader can still pick the mislabelled chip -
+    // which assigns the task to Marta under Kiko's name.
+    await expect(panel.queryAllByRole('button', { pressed: true })).toHaveLength(0);
+    await userEvent.click(panel.getByText('Pet parent · Kiko'));
+    const pressed = panel.getAllByRole('button', { pressed: true });
+    await expect(pressed).toHaveLength(1);
+    await expect(pressed[0]).toHaveTextContent('Pet parent · Kiko');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The fallback chain is `resolved name -> companion name -> raw parent id`, and the ' +
+          'middle step is the one that produces a wrong answer rather than an obviously missing ' +
+          'one. Worth deciding whether an unresolved parent should be dropped from the list ' +
+          'instead.',
+      },
+    },
+  },
+};
+
+export const Phone: Story = {
+  name: 'Phone (375): the dialog becomes a sheet',
+  // Pinned as a GLOBAL. `parameters.viewport.defaultViewport` was removed in
+  // Storybook 10: a story using it still renders, still plays and still passes -
+  // at 1280px, under a name that promises a phone.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const dialog = await openDialog(canvasElement);
+    const panel = within(dialog);
+
+    /* `useIsPhone` is false during SSR and the first client render, so the sheet is a
+       post-mount swap - polled rather than read once. */
+    await waitFor(() => {
+      expect(dialog.className).toContain('yc-phone-sheet');
+    });
+
+    /* The grabber is MEASURED, not merely found. Its geometry lives inside the
+       `max-width: 767px` block in Sheet.css, so a 44x5 pill proves the phone rules
+       actually matched - the class name alone would still be in the DOM with the
+       viewport pin inert. */
+    const grabber = dialog.querySelector('.yc-phone-sheet-grabber') as HTMLElement;
+    await expect(grabber).not.toBeNull();
+    const grabberStyle = getComputedStyle(grabber);
+    await expect(grabberStyle.width).toBe('44px');
+    await expect(grabberStyle.height).toBe('5px');
+
+    // The sheet spans the viewport, and the viewport really is phone-sized.
+    const viewportWidth = document.documentElement.clientWidth;
+    await expect(viewportWidth).toBeLessThanOrEqual(430);
+    await expect(Math.round(dialog.getBoundingClientRect().width)).toBe(viewportWidth);
+
+    /* Both field grids collapse to a single track. This is the detail worth having a
+       phone story for: the grids are keyed on `sm:` - a 640px VIEWPORT query - while
+       the panel they live in is a different width entirely, so they narrow with the
+       browser rather than with the sheet. */
+    await expect(tracks(gridRow(dialog, 'Due date'))).toHaveLength(1);
+    await expect(gridRow(dialog, 'Due date').children).toHaveLength(3);
+    await expect(tracks(gridRow(dialog, 'Priority'))).toHaveLength(1);
+
+    // The footer keeps both actions rather than stacking them.
+    await expect(panel.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    await expect(panel.getByRole('button', { name: 'Create task' })).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'At 375px the centered dialog re-forms into a bottom sheet with a grabber, and the ' +
+          'three-across Due date / Time / Repeat row becomes three full-width fields. The dialog ' +
+          'is long here - eight fields plus the chip row - so the footer is reached by scrolling ' +
+          'the sheet body rather than by the sheet growing.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/features/tasks/pages/Tasks/Sections/Reschedule.stories.tsx
+++ b/apps/frontend/src/app/features/tasks/pages/Tasks/Sections/Reschedule.stories.tsx
@@ -1,0 +1,399 @@
+import { type ComponentProps, useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+
+import type { Task } from '@/app/features/tasks/types/task';
+import RescheduleTask from './Reschedule';
+
+type RescheduleTaskProps = ComponentProps<typeof RescheduleTask>;
+
+const task = (over: Partial<Task> = {}): Task => ({
+  _id: 'task-analgesia',
+  organisationId: 'org-storybook',
+  assignedBy: 'practitioner-elena',
+  assignedTo: 'practitioner-ravi',
+  audience: 'EMPLOYEE_TASK',
+  source: 'CUSTOM',
+  category: 'MEDICATION',
+  priority: 'HIGH',
+  name: 'Midday analgesia round',
+  // A fixed instant. `getPreferredTimeZone` falls back to Europe/Berlin whenever no
+  // timezone token is stored, so 12:00 UTC renders as 13:00 on every machine and the
+  // labels below do not drift with the reviewer's clock.
+  dueAt: new Date('2026-03-12T12:00:00.000Z'),
+  recurrence: { type: 'ONCE', isMaster: false },
+  status: 'PENDING',
+  ...over,
+});
+
+/**
+ * The tasks page mounts this dialog on demand and unmounts it on dismissal. Copying
+ * that lifecycle keeps the docs page free of several simultaneously open dialogs,
+ * each holding a share of `ModalBase`'s ref-counted body scroll lock.
+ */
+const RescheduleHarness = ({
+  showModal: _showModal,
+  setShowModal: _setShowModal,
+  ...args
+}: RescheduleTaskProps) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="flex min-h-[460px] items-start bg-[var(--screen)] p-6">
+      <button
+        type="button"
+        className="rounded-2xl bg-[var(--cta)] px-6 py-3 text-body-3-emphasis text-[var(--cta-text)]"
+        onClick={() => setOpen(true)}
+      >
+        Open reschedule
+      </button>
+      {open && <RescheduleTask {...args} showModal setShowModal={setOpen} />}
+    </div>
+  );
+};
+
+/**
+ * Opens the dialog and returns it.
+ *
+ * Matched on `dialog[open]` rather than a class: `ModalBase` leaves a dismissed dialog
+ * MOUNTED and only drops the `open` attribute, so a class lookup can return a panel
+ * that is no longer on screen. It portals to `document.body` as well, so nothing it
+ * renders is inside `canvasElement`.
+ *
+ * The LAST open dialog is taken, not the first: the autodocs page shares one
+ * `document.body` across every story, and portals append in mount order.
+ */
+const openDialog = async (canvasElement: HTMLElement) => {
+  const canvas = within(canvasElement);
+  await userEvent.click(canvas.getByRole('button', { name: 'Open reschedule' }));
+  return waitFor(() => {
+    const dialogs = document.querySelectorAll('dialog[open]');
+    expect(dialogs.length).toBeGreaterThan(0);
+    return dialogs[dialogs.length - 1] as HTMLElement;
+  });
+};
+
+/**
+ * Every dialog currently open, oldest first.
+ *
+ * Counted against a baseline taken at the start of each play function rather than
+ * asserted absolutely: the autodocs page renders every story into one `document.body`,
+ * so a dialog another story opened is still there. Deltas hold in both that mode and
+ * the isolated one the test runner uses.
+ */
+const openDialogs = (): HTMLElement[] =>
+  [...document.querySelectorAll('dialog[open]')] as HTMLElement[];
+
+const meta = {
+  title: 'Tasks/RescheduleTask',
+  component: RescheduleTask,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The dialog that moves a task to another day, opened from the task list, the board and ' +
+          'the week agenda. It had no story at all.\n\n' +
+          'It is a `CenterModal` - not the shared `Modal` - which matters more than it sounds: ' +
+          '`CenterModal` is `w-[90%] sm:w-[500px]` and has **no phone branch**. Below 768px it ' +
+          'does not become a bottom sheet the way `Modal variant="centered"` does; it stays a ' +
+          'centred panel at 90% of the viewport. The phone story below is the only place that ' +
+          'difference is visible.\n\n' +
+          'The body is three parts: a `ModalHeader`, a `Datepicker` + `Timepicker` pair in a ' +
+          'single-column grid, and a centred Cancel/Update row. The two pickers are the whole ' +
+          'form - there is no reason field, no notification toggle and no preview of the new ' +
+          'time.\n\n' +
+          'Two things happen on Update that no static reading shows. A task in a **recurring ' +
+          'series** does not save at all: `handleSave` stashes the new instant in a ref and opens ' +
+          '`RecurrenceScopeModal` on top, so the reader is asked which occurrences the move ' +
+          'applies to before anything is written. And a **completed or cancelled task** is ' +
+          'refused: `canRescheduleTask` returns false, a warning toast fires and the dialog ' +
+          'closes, leaving the task where it was. Both are drawn below.\n\n' +
+          'What is NOT drawn: the button\'s `saving` -> "Saving..." swap. `saving` is internal ' +
+          'state that is true only while `updateTask` is in flight, and holding that frame open ' +
+          'needs request mocking, which this Storybook has no wiring for. The same swap IS ' +
+          'reviewable in **Tasks/TaskFormBody -> Saving**, where the flag arrives as an ' +
+          '`isLoading` prop and can be pinned.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    showModal: true,
+    setShowModal: fn(),
+    activeTask: task(),
+  },
+  render: (args) => <RescheduleHarness {...args} />,
+} satisfies Meta<typeof RescheduleTask>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Reschedule: Story = {
+  name: 'The reschedule panel',
+  play: async ({ canvasElement }) => {
+    const baseline = openDialogs().length;
+    const dialog = await openDialog(canvasElement);
+    const panel = within(dialog);
+
+    await expect(panel.getByRole('heading', { name: 'Reschedule' })).toBeInTheDocument();
+
+    /* 500px, the `sm:` width. Measured with getBoundingClientRect - that is the border
+       box, and getComputedStyle().width would report the content box and come back
+       short by the panel's 1px border on each side. */
+    await expect(Math.round(dialog.getBoundingClientRect().width)).toBe(500);
+
+    /* The dialog has NO accessible name. `CenterModal` accepts `ariaLabel` and
+       `ariaLabelledBy` and this caller passes neither, so a screen reader announces
+       "dialog" while "Reschedule" sits in 17px bold at the top. Asserted rather than
+       described, so that wiring the header up removes this line instead of leaving it
+       silently stale. */
+    await expect(dialog).not.toHaveAttribute('aria-label');
+    await expect(dialog).not.toHaveAttribute('aria-labelledby');
+
+    /* Both pickers are seeded from `activeTask.dueAt`, and they render in the
+       PREFERRED timezone rather than in UTC - 13:00 for a 12:00 UTC instant with no
+       timezone token stored. Reading them back is the only proof the seeding survived
+       the two `useState` initialisers and the render-phase re-sync guard. */
+    await expect(
+      panel.getByRole('button', { name: 'Due date: Mar 12, 2026, toggle calendar' })
+    ).toBeInTheDocument();
+    await expect(panel.getByRole('button', { name: 'Due time: 13:00' })).toBeInTheDocument();
+
+    /* Two children, stacked. The pair is a bare `grid gap-3` - no column count at all,
+       at any breakpoint - so the date sits ABOVE the time at 500px exactly as it does
+       at 375. The markup states that only by omission, and `gridTemplateColumns`
+       resolves to "none" for implicit tracks, so it is asserted geometrically instead:
+       same left edge, same width, second row below the first. */
+    const pickers = panel.getByText('Due date').closest('.grid') as HTMLElement;
+    await expect(pickers.children).toHaveLength(2);
+    await expect(pickers.children[1]).toContainElement(
+      panel.getByRole('button', { name: 'Due time: 13:00' })
+    );
+    const dateBox = pickers.children[0].getBoundingClientRect();
+    const timeBox = pickers.children[1].getBoundingClientRect();
+    await expect(Math.round(timeBox.left)).toBe(Math.round(dateBox.left));
+    await expect(Math.round(timeBox.width)).toBe(Math.round(dateBox.width));
+    await expect(timeBox.top).toBeGreaterThanOrEqual(dateBox.bottom);
+
+    /* Cancel and Update share one line and are equal-width `min-w-[120px]` pills, with
+       Update on the right. Compared by measured geometry rather than by DOM order,
+       because the row is `justify-center flex-wrap` - the thing that gives out first
+       is the wrap, and a DOM-order check would pass with the buttons stacked. */
+    const cancel = panel.getByRole('button', { name: 'Cancel' });
+    const update = panel.getByRole('button', { name: 'Update' });
+    await expect(cancel).toBeEnabled();
+    await expect(update).toBeEnabled();
+    await expect(cancel.getBoundingClientRect().top).toBe(update.getBoundingClientRect().top);
+    await expect(update.getBoundingClientRect().left).toBeGreaterThan(
+      cancel.getBoundingClientRect().right
+    );
+    await expect(cancel.getBoundingClientRect().width).toBeGreaterThanOrEqual(120);
+    await expect(update.getBoundingClientRect().width).toBeGreaterThanOrEqual(120);
+
+    // One dialog, not two: the recurrence scope chooser is not mounted at rest.
+    await expect(openDialogs()).toHaveLength(baseline + 1);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The whole panel. Note what is missing as much as what is here: no reason, no note to ' +
+          'the assignee, and no "was Mar 12, now Mar 14" confirmation - the reader has to remember ' +
+          'the old date themselves, because the picker has already overwritten it.',
+      },
+    },
+  },
+};
+
+export const SeriesTaskAsksForScope: Story = {
+  name: 'A recurring task asks which occurrences',
+  args: {
+    activeTask: task({
+      name: 'Twice-daily wound check',
+      recurrence: { type: 'DAILY', isMaster: true },
+    }),
+  },
+  play: async ({ canvasElement }) => {
+    const baseline = openDialogs().length;
+    const dialog = await openDialog(canvasElement);
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Update' }));
+
+    /* Nothing was saved. `handleSave` recognises the series, stashes the computed
+       instant in `pendingDueAtRef` and opens the scope chooser instead - so this click
+       reaches no API at all, which is what makes the frame stable enough to draw. */
+    await waitFor(() => {
+      expect(openDialogs()).toHaveLength(baseline + 2);
+    });
+    const scope = within(openDialogs().at(-1) as HTMLElement);
+    await expect(scope.getByRole('heading', { name: 'Edit recurring task' })).toBeInTheDocument();
+
+    /* The prompt names the task, so the reader knows which series they are about to
+       move - the reschedule panel behind it does not show the task name anywhere. */
+    await expect(
+      scope.getByText(
+        '"Twice-daily wound check" is part of a recurring series. Which tasks should this change apply to?'
+      )
+    ).toBeInTheDocument();
+
+    /* Three options, in order, with the narrowest pre-selected. The default matters:
+       it is the difference between moving tomorrow's dose and moving every remaining
+       dose, and the dialog commits it on a single click of "Save changes". */
+    const options = scope.getAllByRole('radio');
+    await expect(options).toHaveLength(3);
+    await expect(scope.getByRole('radio', { name: 'This task only' })).toBeChecked();
+    await expect(scope.getByRole('radio', { name: 'This and following tasks' })).not.toBeChecked();
+    await expect(scope.getByRole('radio', { name: 'All tasks in the series' })).not.toBeChecked();
+
+    // The reschedule panel stays open UNDERNEATH, still holding the new date, so
+    // cancelling the scope question returns the reader to their edit rather than
+    // discarding it.
+    await expect(
+      within(dialog).getByRole('button', { name: 'Due date: Mar 12, 2026, toggle calendar' })
+    ).toBeInTheDocument();
+    await expect(scope.getByRole('button', { name: 'Save changes' })).toBeEnabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Two stacked dialogs, which is the only place in the reschedule flow that happens. ' +
+          '`ModalBase` keeps a stack so Escape and the backdrop only dismiss the topmost one - ' +
+          'without that, closing the scope question would take the reschedule panel with it and ' +
+          'lose the date the reader just picked.\n\n' +
+          'This story stops before "Save changes". Confirming calls `updateTask`, which POSTs, ' +
+          'and this Storybook has no request mocking.',
+      },
+    },
+  },
+};
+
+export const CompletedTaskIsRefused: Story = {
+  name: 'A completed task cannot be moved',
+  args: { activeTask: task({ status: 'COMPLETED' }) },
+  play: async ({ canvasElement }) => {
+    const baseline = openDialogs().length;
+    const dialog = await openDialog(canvasElement);
+
+    /* The dialog opens fully editable for a task that cannot be rescheduled: both
+       pickers are live, Update is enabled, and nothing is greyed. The guard lives in
+       `handleSave`, not in the render, so the refusal only arrives after the reader
+       has chosen a new date and pressed the button. */
+    await expect(
+      within(dialog).getByRole('button', { name: 'Due date: Mar 12, 2026, toggle calendar' })
+    ).toBeInTheDocument();
+    const update = within(dialog).getByRole('button', { name: 'Update' });
+    await expect(update).toBeEnabled();
+
+    await userEvent.click(update);
+
+    /* `canRescheduleTask` rejects COMPLETED and CANCELLED, fires a warning toast and
+       closes - with no write and no explanation left on screen once the toast expires.
+       The harness unmounts the dialog on close, matching the real consumers, so the
+       closed panel is gone rather than merely inert. */
+    await waitFor(() => {
+      expect(openDialogs()).toHaveLength(baseline);
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The dead end. `canShowTaskRescheduleAction` in the callers is what should keep this ' +
+          'dialog shut for a finished task, so reaching this frame means a caller let it through - ' +
+          'and the only feedback is a toast that has vanished by the time anyone asks what ' +
+          'happened.',
+      },
+    },
+  },
+};
+
+export const CancelClosesWithoutAWrite: Story = {
+  name: 'Cancel closes without a write',
+  play: async ({ canvasElement }) => {
+    const baseline = openDialogs().length;
+    const dialog = await openDialog(canvasElement);
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() => {
+      expect(openDialogs()).toHaveLength(baseline);
+    });
+
+    // Reopening reads the task's own due date again: nothing was written and nothing
+    // was carried over.
+    const reopened = await openDialog(canvasElement);
+    await expect(
+      within(reopened).getByRole('button', { name: 'Due date: Mar 12, 2026, toggle calendar' })
+    ).toBeInTheDocument();
+    await expect(
+      within(reopened).getByRole('button', { name: 'Due time: 13:00' })
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'What this frame does NOT prove: `handleCancel` also resets `selectedDate` and ' +
+          '`dueTimeValue` back to the task before closing, but the consumers - and this harness ' +
+          'with them - unmount the dialog on dismissal, so the reopened one is a fresh mount ' +
+          'whichever way that reset behaves. The reset only matters to a caller that keeps the ' +
+          'dialog mounted and toggles `showModal`, and there is no such caller today.',
+      },
+    },
+  },
+};
+
+export const Phone: Story = {
+  name: 'Phone (375): still a centred panel',
+  // Pinned as a GLOBAL. `parameters.viewport.defaultViewport` was removed in
+  // Storybook 10: a story using it still renders, still plays and still passes -
+  // at the full panel width, under a name that promises a phone.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const dialog = await openDialog(canvasElement);
+    const panel = within(dialog);
+
+    /* `CenterModal` is `w-[90%] sm:w-[500px]`, and `sm` is 640px - so below the tablet
+       breakpoint this is NOT the phone sheet that `Modal variant="centered"` re-forms
+       into. It is the same centred panel narrowed to 90% of the viewport, and there is
+       no grabber. Computed against the live viewport rather than written as 337.5, so
+       the number states the RULE and cannot drift with the preset's pixel width. */
+    const viewportWidth = document.documentElement.clientWidth;
+    await expect(viewportWidth).toBeLessThanOrEqual(430);
+    await expect(Math.round(dialog.getBoundingClientRect().width)).toBe(
+      Math.round(viewportWidth * 0.9)
+    );
+    await expect(dialog.className).not.toContain('yc-phone-sheet');
+    await expect(dialog.querySelector('.yc-phone-sheet-grabber')).toBeNull();
+
+    // The pickers still stack, and both fill the panel's content box exactly -
+    // measured off the dialog's own padding and border rather than a hardcoded
+    // number, so this states the rule (`w-full` all the way down) not a pixel count.
+    const panelStyle = getComputedStyle(dialog);
+    const inset =
+      Number.parseFloat(panelStyle.paddingLeft) +
+      Number.parseFloat(panelStyle.paddingRight) +
+      Number.parseFloat(panelStyle.borderLeftWidth) +
+      Number.parseFloat(panelStyle.borderRightWidth);
+    const dueDate = panel.getByRole('button', { name: 'Due date: Mar 12, 2026, toggle calendar' });
+    await expect(Math.round(dueDate.getBoundingClientRect().width)).toBe(
+      Math.round(dialog.getBoundingClientRect().width - inset)
+    );
+
+    // The two pills still share one line at this width. `flex-wrap` is what would give
+    // out first, and a visibility check would pass either way.
+    const cancel = panel.getByRole('button', { name: 'Cancel' });
+    const update = panel.getByRole('button', { name: 'Update' });
+    await expect(cancel.getBoundingClientRect().top).toBe(update.getBoundingClientRect().top);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Tasks are triaged on phones more than anywhere else, and rescheduling is the most ' +
+          'common thing done to one. This panel is the reason to check rather than assume: it is ' +
+          'the shared modal that does NOT re-form into a sheet, so it is the only task dialog that ' +
+          'still floats at 375px.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/cards/CompanionIdCard/CompanionIdCard.stories.tsx
+++ b/apps/frontend/src/app/ui/cards/CompanionIdCard/CompanionIdCard.stories.tsx
@@ -1,0 +1,265 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, waitFor, within } from 'storybook/test';
+import type { CompanionCardDTO } from '@yosemite-crew/types';
+
+import CompanionIdCard from './CompanionIdCard';
+
+/**
+ * A staff-audience card with every block populated, which is the only case where
+ * all twelve detail rows exist at once. `photoUrl` is left off on purpose:
+ * `getSafeImageUrl` then resolves the bundled species placeholder out of
+ * `/images`, so the card never reaches for a remote host.
+ */
+const STAFF_CARD: CompanionCardDTO = {
+  audience: 'STAFF',
+  identity: {
+    id: 'companion-kizie',
+    name: 'Kizie',
+    type: 'dog',
+    breed: 'Beagle',
+    colour: 'Tricolour',
+    microchipNumber: '953010001234567',
+  },
+  passportNumber: 'GB40123456',
+  dateOfBirth: '2019-04-18',
+  alerts: [
+    { title: 'Anaphylaxis risk', severity: 'critical' },
+    { title: 'Nervous around other dogs', severity: 'medium' },
+  ],
+  ownerContact: {
+    firstName: 'Sky',
+    lastName: 'Doe',
+    phoneNumber: '+44 7700 900412',
+    email: 'sky.doe@example.com',
+  },
+  medical: {
+    allergy: 'Penicillin',
+    bloodGroup: 'DEA 1.1 negative',
+    currentWeight: 24,
+    isNeutered: true,
+  },
+  insurance: { isInsured: true, companyName: 'Petplan' },
+  latestVisit: { status: 'Completed', occurredAt: '2026-07-30T09:15:00.000Z' },
+};
+
+/** The public projection: identity, a chip number and a birth date, nothing else. */
+const PUBLIC_CARD: CompanionCardDTO = {
+  audience: 'PUBLIC',
+  identity: {
+    id: 'companion-kizie',
+    name: 'Kizie',
+    type: 'dog',
+    breed: 'Beagle',
+    microchipNumber: '953010001234567',
+  },
+  dateOfBirth: '2019-04-18',
+  alerts: [{ title: 'Anaphylaxis risk', severity: 'critical' }],
+};
+
+/** The detail block, reached from one of its labels rather than by nth-child. */
+const detailRows = (label: HTMLElement): HTMLElement => {
+  const row = label.closest('.justify-between') as HTMLElement;
+  return row.parentElement as HTMLElement;
+};
+
+/**
+ * The value printed opposite a label, scoped to that label's own row.
+ *
+ * Scoped rather than looked up globally because a bare text query is answered by
+ * the whole canvas - including the preview decorator's sr-only `<h1>` - and
+ * because several of these values are short enough to collide with each other.
+ */
+const valueFor = (label: HTMLElement): string =>
+  (label.nextElementSibling?.textContent ?? '').trim();
+
+const meta = {
+  title: 'Cards/CompanionIdCard',
+  component: CompanionIdCard,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The companion card as it is handed to someone outside the practice: an avatar/name/species ' +
+          'header, the alert pills, and a two-column list of the twelve identity, medical, insurance ' +
+          'and owner-contact rows.\n\n' +
+          'It had never been drawn because neither consumer can render it synchronously. The public ' +
+          'route `/card/[token]` resolves a share token before it has a card at all, and ' +
+          '`ShareCompanionCardModal` fetches on open - so in both places the whole card body is ' +
+          'behind an await, and a static snapshot of either surface shows a spinner.\n\n' +
+          'What the stories are for is the **redaction**. `CompanionCardDTO` is an audience-scoped ' +
+          'projection: everything past `identity` is optional, and `DetailRow` returns null for an ' +
+          'undefined or empty value, so a card omits rows rather than printing blanks. The same ' +
+          'component therefore renders twelve rows for a staff card and two for a public one, with ' +
+          'nothing in the markup announcing which is which. Comparing the two frames below is the ' +
+          'only way to see it.\n\n' +
+          'Severity is the other silent detail: `critical` and `high` share the warning tint, ' +
+          '`medium` and `low` share the neutral card tint, so four severities render as two pills.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: { card: STAFF_CARD },
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 420 }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof CompanionIdCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const StaffCard: Story = {
+  name: 'Staff audience (all twelve rows)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByText('Kizie')).toBeInTheDocument();
+    // The species header is a single interpolated string, not two nodes.
+    await expect(canvas.getByText('Beagle / Canine')).toBeInTheDocument();
+
+    /* Row COUNT, not "a row appeared": every row is gated on its own value, so a
+       projection that dropped the medical block would still satisfy any single
+       label lookup. Twelve is the maximum this component can render. */
+    const rows = detailRows(canvas.getByText('Microchip'));
+    await expect(rows.children).toHaveLength(12);
+    /* Each value read opposite its OWN label, below. `neuteredLabel` turns the
+       boolean into Yes/No - false would print "No", and only `undefined` drops
+       the row - and `insuranceLabel` prefers the company name over a bare
+       "Insured", so both of those cells are a function of the DTO rather than a
+       copy of it. */
+    await expect(valueFor(canvas.getByText('Blood group'))).toBe('DEA 1.1 negative');
+    await expect(valueFor(canvas.getByText('Owner'))).toBe('Sky Doe');
+
+    /* The date is run through `formatDisplayDate`, so the exact layout belongs to
+       the formatter and is not what this story is pinning. The year IS the data,
+       and it is read out of the Date of birth row rather than matched loose
+       against the canvas. */
+    await expect(valueFor(canvas.getByText('Date of birth'))).toContain('2019');
+    await expect(valueFor(canvas.getByText('Microchip'))).toBe('953010001234567');
+    await expect(valueFor(canvas.getByText('Neutered'))).toBe('Yes');
+    await expect(valueFor(canvas.getByText('Insurance'))).toBe('Petplan');
+    await expect(valueFor(canvas.getByText('Weight (lbs)'))).toBe('24');
+
+    /* Two severities, two tints. Read after the frame settles rather than in the
+       same tick as the mount. */
+    const critical = canvas.getByText('Anaphylaxis risk');
+    const medium = canvas.getByText('Nervous around other dogs');
+    await waitFor(() => {
+      expect(getComputedStyle(critical).backgroundColor).not.toBe(
+        getComputedStyle(medium).backgroundColor
+      );
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Everything the projection can carry. The alert pills wrap above the detail list, so a ' +
+          'companion with several alerts pushes the rows down rather than clipping.',
+      },
+    },
+  },
+};
+
+export const PublicCard: Story = {
+  name: 'Public audience (redacted)',
+  args: { card: PUBLIC_CARD },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const rows = detailRows(canvas.getByText('Microchip'));
+    await expect(rows.children).toHaveLength(2);
+
+    /* Named one by one rather than inferred from the count: a redaction bug that
+       dropped the microchip row and kept the owner phone would also leave two. */
+    await expect(canvas.queryByText('Owner')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Owner phone')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Owner email')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Insurance')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Blood group')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Passport')).not.toBeInTheDocument();
+
+    // The header and the alert survive redaction - that is the point of the card.
+    await expect(canvas.getByText('Kizie')).toBeInTheDocument();
+    await expect(canvas.getByText('Anaphylaxis risk')).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'What a stranger who scans the tag sees. The card keeps its full shell and header and ' +
+          'simply has fewer rows in it, which is why this frame is worth holding next to the staff ' +
+          'one rather than reading the DTO.',
+      },
+    },
+  },
+};
+
+export const NoAlerts: Story = {
+  name: 'No alerts',
+  args: { card: { ...STAFF_CARD, alerts: [] } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.queryByText('Anaphylaxis risk')).not.toBeInTheDocument();
+
+    /* The pill row is gated on `alerts && alerts.length > 0`, so an empty array
+       removes the whole flex-wrap container, not just its contents - the header
+       and the detail list end up one 16px gap apart instead of two. Measured
+       here, because an absent pill proves nothing about the gap that is left. */
+    const header = canvas.getByText('Kizie').closest('.flex.items-center') as HTMLElement;
+    const rows = detailRows(canvas.getByText('Microchip'));
+    const gap = rows.getBoundingClientRect().top - header.getBoundingClientRect().bottom;
+    await expect(Math.round(gap)).toBe(16);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Most companions have no alerts, so this is the common card. Worth checking that the ' +
+          'header does not end up sitting on the detail list when the pill row is gone.',
+      },
+    },
+  },
+};
+
+export const PhoneWidth: Story = {
+  name: 'Phone (375)',
+  // Pinned as a GLOBAL: `parameters.viewport.defaultViewport` was removed in
+  // Storybook 10, so the old spelling renders the full panel width and quietly
+  // proves nothing.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* The rows are `flex justify-between` with a 12px gap and no wrapping rule,
+       so the longest value is the one that decides whether the card holds. The
+       owner email must stay inside the card's padding box at 375. */
+    const card = canvas.getByText('Kizie').closest('.rounded-2xl') as HTMLElement;
+    const email = canvas.getByText('sky.doe@example.com');
+    const cardRect = card.getBoundingClientRect();
+    const padding = Number.parseFloat(getComputedStyle(card).paddingRight);
+    await expect(email.getBoundingClientRect().right).toBeLessThanOrEqual(
+      cardRect.right - padding + 1
+    );
+
+    // Label and value share a row rather than stacking: same top edge.
+    const label = canvas.getByText('Owner email');
+    await expect(Math.round(label.getBoundingClientRect().top)).toBe(
+      Math.round(email.getBoundingClientRect().top)
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The public card is opened from a phone camera more than anywhere else, and a 320px-wide ' +
+          'reading of it is the realistic one. `text-right` on the value keeps the long strings - ' +
+          'email, chip number - aligned to the card edge instead of drifting under the label.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/inputs/Dropdown/DropdownPanel.stories.tsx
+++ b/apps/frontend/src/app/ui/inputs/Dropdown/DropdownPanel.stories.tsx
@@ -1,0 +1,263 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import Dropdown from './Dropdown';
+
+const SPECIALITY_OPTIONS = [
+  { label: 'General Practice', value: 'general' },
+  { label: 'Cardiology', value: 'cardiology' },
+  { label: 'Dermatology', value: 'dermatology' },
+  { label: 'Neurology', value: 'neurology' },
+  { label: 'Orthopedics', value: 'orthopedics' },
+  { label: 'Ophthalmology', value: 'ophthalmology' },
+];
+
+/**
+ * `DropdownPanel` is presentational and takes fourteen props, but every one of
+ * them is computed by `Dropdown` - the query state, the filtered list, the
+ * portal geometry, the roving active-option id. Driving it through the real
+ * `Dropdown` is what keeps the filtering and the `aria-activedescendant` wiring
+ * under test instead of hand-fed.
+ */
+const SpecialityPicker = ({ search }: { search: boolean }) => {
+  const [value, setValue] = useState('');
+  return (
+    <Dropdown
+      placeholder="Speciality"
+      value={value}
+      onChange={setValue}
+      options={SPECIALITY_OPTIONS}
+      search={search}
+    />
+  );
+};
+
+/**
+ * Opens the picker and returns the live panel.
+ *
+ * The panel `createPortal`s to `document.body`, so it is outside `canvasElement`
+ * entirely. The LAST match is taken rather than the first: on the docs page a
+ * panel left open by an earlier story is still in the body, and `querySelector`
+ * would happily hand back that one.
+ */
+const openPanel = async (canvasElement: HTMLElement) => {
+  const canvas = within(canvasElement);
+  await userEvent.click(canvas.getByRole('button', { name: 'Speciality' }));
+  return waitFor(() => {
+    const panels = document.querySelectorAll('[data-portal-dropdown]');
+    expect(panels.length).toBeGreaterThan(0);
+    return panels[panels.length - 1] as HTMLElement;
+  });
+};
+
+/** Option labels in render order - the list the panel is currently offering. */
+const optionLabels = (panel: HTMLElement): string[] =>
+  [...panel.querySelectorAll('.select-input-dropdown-item')].map((option) =>
+    (option.textContent ?? '').trim()
+  );
+
+const meta = {
+  title: 'Inputs/DropdownPanel',
+  component: SpecialityPicker,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'The panel half of `Dropdown`, and specifically its **inline search head** - the one part ' +
+          'of the control that needs two conditions at once to exist: the panel open AND ' +
+          '`search` passed. `Inputs/Dropdown` has a story for each condition separately (a closed ' +
+          'control with `search`, an open one without it), so the head itself had never rendered in ' +
+          'a snapshot.\n\n' +
+          'It is a 36px `--field-bg` pill holding an `IoSearch` glyph and a bare `type="search"` ' +
+          'input with its border stripped. The accessibility of the whole listbox is carried here: ' +
+          'an `sr-only` `<label>` bound by `htmlFor`, a duplicate `aria-label`, `aria-controls` ' +
+          'pointing back at the panel, and `aria-activedescendant` naming the option the arrow keys ' +
+          'are currently on - because focus never leaves the input while the list moves.\n\n' +
+          'The input also `stopPropagation`s its own keydown before forwarding it, which is what ' +
+          'keeps Space typing a space instead of confirming the highlighted option.\n\n' +
+          'Filtering is a plain case-insensitive `includes` over the label, with no scoring and no ' +
+          'empty-state row: a query that matches nothing leaves a panel that is only the search ' +
+          'head.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: { search: true },
+  decorators: [
+    (Story) => (
+      <div className="w-80 py-6">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof SpecialityPicker>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const SearchHead: Story = {
+  name: 'Search head',
+  play: async ({ canvasElement }) => {
+    const panel = await openPanel(canvasElement);
+    const input = within(panel).getByRole('searchbox', { name: 'Search Speciality' });
+
+    /* The head sits ABOVE the options and does not replace them. Named in full
+       rather than counted: a head that rendered over the list, or a filter that
+       ran against the empty initial query, would both still leave "six nodes". */
+    await expect(optionLabels(panel)).toEqual(SPECIALITY_OPTIONS.map((option) => option.label));
+    await expect(panel.firstElementChild?.className).toContain('select-input-dropdown-search');
+    await expect(input).toHaveAttribute('placeholder', 'Search Speciality');
+
+    /* The listbox relationship, asserted as a real pair rather than as "the
+       attribute exists": aria-controls has to name the panel this input is
+       inside, and a copy-pasted id from another dropdown would still be a
+       non-empty attribute. */
+    await expect(input.getAttribute('aria-controls')).toBe(panel.id);
+    await expect(panel.id).not.toBe('');
+
+    // The sr-only label is bound by htmlFor, not by wrapping - both halves matter,
+    // since an unbound label leaves the input named only by its aria-label.
+    const label = panel.querySelector('label.sr-only') as HTMLLabelElement;
+    await expect(label.textContent?.trim()).toBe('Search Speciality');
+    await expect(label.htmlFor).toBe(input.id);
+    await expect(input.id).not.toBe('');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The resting head. The glyph is `aria-hidden`, so the only thing announced here is the ' +
+          'input, twice named the same way on purpose.',
+      },
+    },
+  },
+};
+
+export const Filtering: Story = {
+  name: 'Filtering the list',
+  play: async ({ canvasElement }) => {
+    const panel = await openPanel(canvasElement);
+    const input = within(panel).getByRole('searchbox', { name: 'Search Speciality' });
+
+    await userEvent.type(input, 'ology');
+
+    // Which options survive, in order - not merely that the count went down.
+    await waitFor(() =>
+      expect(optionLabels(panel)).toEqual([
+        'Cardiology',
+        'Dermatology',
+        'Neurology',
+        'Ophthalmology',
+      ])
+    );
+    // The match is on the LABEL and is a substring, not a prefix: "General
+    // Practice" and "Orthopedics" are the two that go.
+    await expect(optionLabels(panel)).not.toContain('Orthopedics');
+    await expect(input).toHaveValue('ology');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Typing narrows the list in place; the panel keeps its position and height rule, so it ' +
+          'shrinks upward from the bottom edge rather than re-anchoring.',
+      },
+    },
+  },
+};
+
+export const NoMatches: Story = {
+  name: 'A query that matches nothing',
+  play: async ({ canvasElement }) => {
+    const panel = await openPanel(canvasElement);
+    const input = within(panel).getByRole('searchbox', { name: 'Search Speciality' });
+
+    await userEvent.type(input, 'zzz');
+
+    await waitFor(() => expect(optionLabels(panel)).toHaveLength(0));
+    /* No "no results" row anywhere - the panel becomes the search head and a 4px
+       margin, which is the detail worth seeing rather than reading. `LabelDropdown`,
+       the other dropdown in this app, DOES render a "No matches found" row here. */
+    await expect(within(panel).queryByText(/no match/i)).not.toBeInTheDocument();
+    // Dropped, not emptied: `activeOptionId` is undefined with no options, and
+    // React omits the attribute rather than writing an empty string.
+    await expect(input).not.toHaveAttribute('aria-activedescendant');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The dead end. With no options left there is no active option either, so ' +
+          '`aria-activedescendant` is dropped and a screen reader is told nothing about why the ' +
+          'list went quiet.',
+      },
+    },
+  },
+};
+
+export const KeyboardActiveOption: Story = {
+  name: 'Arrow keys move aria-activedescendant',
+  play: async ({ canvasElement }) => {
+    const panel = await openPanel(canvasElement);
+    const input = within(panel).getByRole('searchbox', { name: 'Search Speciality' });
+    const options = [...panel.querySelectorAll('.select-input-dropdown-item')] as HTMLElement[];
+
+    /* Opening seeds the active index at the selected option, or at 0 when nothing
+       is selected - so the panel is already pointing at "General Practice". Read
+       in a waitFor because that seeding happens in a render-time adjust, one
+       render after the panel first appears. */
+    await waitFor(() => expect(input.getAttribute('aria-activedescendant')).toBe(options[0].id));
+    await expect(options[0].className).toContain('select-input-dropdown-item-active');
+
+    await userEvent.type(input, '{ArrowDown}{ArrowDown}');
+
+    // Ids are read off the rendered options rather than written out: they are
+    // built from a `useId` prefix, which is not stable to hardcode.
+    await waitFor(() => expect(input.getAttribute('aria-activedescendant')).toBe(options[2].id));
+    await expect(options[2].className).toContain('select-input-dropdown-item-active');
+    await expect(options[0].className).not.toContain('select-input-dropdown-item-active');
+    // Focus stayed in the input the whole time - the list moved, the caret did not.
+    await expect(input).toHaveFocus();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The state the search head exists to carry. Nothing is focused in the list, so the only ' +
+          'signal that a row is armed is the `--nav-active-bg` wash plus this one attribute; a ' +
+          'regression in either leaves the keyboard path silently broken while the mouse path ' +
+          'still works.',
+      },
+    },
+  },
+};
+
+export const WithoutSearch: Story = {
+  name: 'Same panel, no search prop',
+  args: { search: false },
+  play: async ({ canvasElement }) => {
+    const panel = await openPanel(canvasElement);
+
+    // The whole head is gone, not just the input: no pill, no glyph, no label.
+    await expect(panel.querySelector('.select-input-dropdown-search')).toBeNull();
+    await expect(within(panel).queryByRole('searchbox')).not.toBeInTheDocument();
+    await expect(panel.querySelector('label')).toBeNull();
+
+    // And the list is unfiltered, since `filteredList` short-circuits to the full
+    // list whenever `search` is false - same six labels, same order, no head.
+    await expect(optionLabels(panel)).toEqual(SPECIALITY_OPTIONS.map((option) => option.label));
+    await expect(panel.firstElementChild?.className).toContain('select-input-dropdown-item');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The default panel, here as the control frame. Most call sites take this one - the search ' +
+          'head is opt-in per dropdown, and a six-option list like this is exactly where it is not ' +
+          'worth 36px.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/overlays/Modal/ChangeStatusModal.stories.tsx
+++ b/apps/frontend/src/app/ui/overlays/Modal/ChangeStatusModal.stories.tsx
@@ -1,0 +1,387 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import type { RecordStatus } from '@yosemite-crew/types';
+
+import ToastProvider from '@/app/ui/layout/ToastProvider';
+import ChangeStatusModal from './ChangeStatusModal';
+
+const STATUS_OPTIONS: Array<{ value: RecordStatus; label: string }> = [
+  { value: 'active', label: 'Active' },
+  { value: 'archived', label: 'Archived' },
+  { value: 'inactive', label: 'Inactive' },
+];
+
+type HarnessProps = {
+  currentStatus: RecordStatus;
+  canTransition: (from: RecordStatus, to: RecordStatus) => boolean;
+  validateBeforeSave?: (next: RecordStatus) => string | null;
+  onSave: (next: RecordStatus) => Promise<void>;
+};
+
+/**
+ * `ChangeStatusModal` is generic over its status union, so it cannot be a story's
+ * `component` directly. This harness pins it to `RecordStatus` - the companion
+ * consumer's union - and reproduces the real lifecycle: consumers mount the dialog
+ * on demand and unmount it on dismissal, which also keeps five open dialogs off the
+ * docs page, where they would each hold `ModalBase`'s shared body scroll lock.
+ */
+const CompanionStatusHarness = ({
+  currentStatus,
+  canTransition,
+  validateBeforeSave,
+  onSave,
+}: HarnessProps) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="flex min-h-[420px] items-start p-6">
+      <ToastProvider />
+      <button
+        type="button"
+        className="rounded-2xl bg-[var(--cta)] px-6 py-3 text-body-3-emphasis text-[var(--cta-text)]"
+        onClick={() => setOpen(true)}
+      >
+        Open status chooser
+      </button>
+      {open && (
+        <ChangeStatusModal<RecordStatus>
+          showModal
+          setShowModal={setOpen}
+          currentStatus={currentStatus}
+          defaultStatus={currentStatus}
+          statusOptions={STATUS_OPTIONS}
+          placeholder="Companion status"
+          canTransition={canTransition}
+          getInvalidMessage={(from, to) => `Cannot change status from ${from} to ${to}.`}
+          validateBeforeSave={validateBeforeSave}
+          onSave={onSave}
+        />
+      )}
+    </div>
+  );
+};
+
+/** Opens the chooser and returns the live dialog, matched on `dialog[open]`. */
+const openDialog = async (canvasElement: HTMLElement) => {
+  const canvas = within(canvasElement);
+  await userEvent.click(canvas.getByRole('button', { name: 'Open status chooser' }));
+  return waitFor(() => {
+    const dialog = document.querySelector('dialog[open]');
+    expect(dialog).not.toBeNull();
+    return dialog as HTMLElement;
+  });
+};
+
+/**
+ * Picks a status. `LabelDropdown` portals its panel to `document.body`, so the
+ * options are outside both the dialog and the canvas; the last panel is taken
+ * because a panel left open by an earlier story is still in the body.
+ */
+const chooseStatus = async (dialog: HTMLElement, from: string, to: string) => {
+  await userEvent.click(within(dialog).getByRole('button', { name: `Companion status: ${from}` }));
+  const panel = await waitFor(() => {
+    const panels = document.querySelectorAll('[data-portal-dropdown]');
+    expect(panels.length).toBeGreaterThan(0);
+    return panels[panels.length - 1] as HTMLElement;
+  });
+  await userEvent.click(within(panel).getByRole('button', { name: to }));
+  return waitFor(() =>
+    expect(
+      within(dialog).getByRole('button', { name: `Companion status: ${to}` })
+    ).toBeInTheDocument()
+  );
+};
+
+/** A save that never settles - the only way to hold the saving frame still. */
+const neverSettles = () => new Promise<void>(() => {});
+
+/**
+ * The text of the toasts currently on screen.
+ *
+ * Read off the container rather than through a text query: on the docs page every
+ * story mounts its own `ToastContainer`, so one `notify` can render in more than
+ * one of them and a `findByText` would throw on the duplicates.
+ */
+const toastText = (): string =>
+  [...document.querySelectorAll('.Toastify__toast')]
+    .map((node) => node.textContent ?? '')
+    .join(' | ');
+
+const meta = {
+  title: 'Overlays/ChangeStatusModal',
+  component: CompanionStatusHarness,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The shared status chooser behind the companion, appointment and task status changes. ' +
+          'What it owns beyond the picker is a small state machine on the way out, and none of it ' +
+          'had ever been drawn, because in every consumer `onSave` is a real network write: a ' +
+          'snapshot catches either the resting dialog or nothing.\n\n' +
+          'Pressing **Update** can end in five different frames. Same status: the dialog just ' +
+          'closes, no write. Illegal transition: a warning **toast**, and the dialog stays open ' +
+          'with nothing in it changed. Failed validation: an inline red line under the picker. ' +
+          'A rejected save: the same inline line, carrying the error message. And in flight: the ' +
+          'button label flips to `Saving...`, both buttons disable, and the picker takes ' +
+          '`pointer-events-none` so the status cannot be changed underneath a write already sent.\n\n' +
+          'Two of those are easy to get wrong and impossible to notice: the toast branch leaves ' +
+          'the dialog looking untouched (the picker still shows the status that was refused), and ' +
+          'the `pointer-events-none` guard is invisible in a static frame - the picker still looks ' +
+          'live, it just no longer answers.\n\n' +
+          'The stories mount a real `ToastProvider`, so the warning branch renders where the app ' +
+          'renders it rather than being asserted as a call.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    currentStatus: 'active',
+    /* Both are widened back to the prop's own signature. Without the casts the
+       meta args narrow the story type to `() => true` and to a `Mock` of this
+       exact shape, and every override below - a real transition table, a save
+       that never settles - stops type-checking against its own component. */
+    canTransition: (() => true) as HarnessProps['canTransition'],
+    onSave: fn(async () => {}) as HarnessProps['onSave'],
+  },
+} satisfies Meta<typeof CompanionStatusHarness>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const AtRest: Story = {
+  name: 'At rest',
+  play: async ({ canvasElement }) => {
+    const dialog = await openDialog(canvasElement);
+
+    const heading = within(dialog).getByRole('heading', { name: 'Change status' });
+    // The heading is an h2 wired to the shell, not a styled div - the dialog is
+    // named by it, so the level is part of what the frame is asserting.
+    await expect(heading.tagName).toBe('H2');
+
+    /* The picker opens on the CURRENT status rather than on the placeholder, so
+       the reader's first move is always a change away from where they are. */
+    const trigger = within(dialog).getByRole('button', { name: 'Companion status: Active' });
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    await expect(trigger.textContent).toContain('Active');
+    await expect(within(dialog).getByRole('button', { name: 'Update' })).toBeEnabled();
+    await expect(within(dialog).getByRole('button', { name: 'Cancel' })).toBeEnabled();
+    // Neither failure line exists yet: the inline slot is empty, not hidden.
+    await expect(within(dialog).queryByText(/Settle the open invoice/)).not.toBeInTheDocument();
+    await expect(dialog.querySelectorAll('p')).toHaveLength(0);
+
+    /* The baseline for the saving story: the picker is interactive, and nothing
+       above it has taken the pointer-events guard. */
+    await expect(getComputedStyle(trigger).pointerEvents).toBe('auto');
+    await expect(trigger.closest('.pointer-events-none')).toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The frame the consumers already had. Everything below is this dialog after Update has ' +
+          'been pressed.',
+      },
+    },
+  },
+};
+
+export const Saving: Story = {
+  name: 'Saving (in flight)',
+  args: { onSave: neverSettles },
+  play: async ({ canvasElement }) => {
+    const dialog = await openDialog(canvasElement);
+    await chooseStatus(dialog, 'Active', 'Archived');
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Update' }));
+
+    // The label IS the state - there is no spinner and no overlay - so the button
+    // named "Update" must be gone, not merely disabled.
+    const saving = await within(dialog).findByRole('button', { name: 'Saving...' });
+    await expect(saving).toBeDisabled();
+    await expect(within(dialog).queryByRole('button', { name: 'Update' })).not.toBeInTheDocument();
+    // Cancel goes with it: a save in flight cannot be abandoned from here.
+    await expect(within(dialog).getByRole('button', { name: 'Cancel' })).toBeDisabled();
+
+    /* And the picker stops answering. Asserted on the trigger's own computed
+       style rather than on the wrapper's class list, because the class is only
+       the mechanism - what matters is that the control the reader can still see
+       and still read no longer takes a pointer. */
+    const trigger = within(dialog).getByRole('button', {
+      name: 'Companion status: Archived',
+    });
+    await waitFor(() => expect(getComputedStyle(trigger).pointerEvents).toBe('none'));
+    await expect(trigger.closest('.pointer-events-none')).not.toBeNull();
+    // It is not disabled and not dimmed: it reads exactly as it did a frame ago.
+    await expect(trigger).toBeEnabled();
+
+    // The dialog stays open behind the write - closing is the save's job.
+    await expect(document.querySelector('dialog[open]')).not.toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Held open by an `onSave` that never settles, which is the only way to keep this frame ' +
+          'still. In the app it lasts one round trip.\n\n' +
+          'Note what the guard does not do: the picker keeps its full `--field-bg` styling and its ' +
+          'chevron, so nothing announces that it is inert. Compare it with the "At rest" frame ' +
+          'above - the two are pixel-identical apart from the button label.',
+      },
+    },
+  },
+};
+
+export const IllegalTransition: Story = {
+  name: 'Illegal transition (toast, dialog stays)',
+  args: {
+    currentStatus: 'archived',
+    canTransition: (_from: RecordStatus, to: RecordStatus) => to !== 'active',
+    onSave: fn(async () => {}),
+  },
+  play: async ({ canvasElement, args }) => {
+    const dialog = await openDialog(canvasElement);
+    await chooseStatus(dialog, 'Archived', 'Active');
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Update' }));
+
+    // The refusal is announced OUTSIDE the dialog, in a toast, carrying both the
+    // fixed title and the message the caller supplied through `getInvalidMessage`.
+    await waitFor(() => expect(toastText()).toContain('Status update blocked'));
+    await expect(toastText()).toContain('Cannot change status from archived to active.');
+
+    // Nothing was written, and the dialog is back to a live Update - so a reader
+    // who missed the toast sees a dialog that looks as if the press did nothing.
+    await expect(args.onSave).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(within(dialog).getByRole('button', { name: 'Update' })).toBeEnabled()
+    );
+    await expect(document.querySelector('dialog[open]')).not.toBeNull();
+    // The picker still shows the status that was just refused, not the one the
+    // companion actually has.
+    await expect(
+      within(dialog).getByRole('button', { name: 'Companion status: Active' })
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The branch worth arguing about. The transition is rejected in a corner toast while the ' +
+          'dialog keeps the rejected selection on screen, so the two surfaces disagree until the ' +
+          'reader cancels. Nothing inside the dialog carries the refusal.',
+      },
+    },
+  },
+};
+
+export const ValidationMessage: Story = {
+  name: 'Blocked by validation (inline)',
+  args: {
+    validateBeforeSave: (next: RecordStatus) =>
+      next === 'archived' ? 'Settle the open invoice before archiving this companion.' : null,
+    onSave: fn(async () => {}),
+  },
+  play: async ({ canvasElement, args }) => {
+    const dialog = await openDialog(canvasElement);
+    await chooseStatus(dialog, 'Active', 'Archived');
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Update' }));
+
+    /* Unlike the transition refusal, this one lands INSIDE the dialog, directly
+       under the picker, in `--danger-text`. Polled rather than read once: the
+       line arrives with the re-render that also re-enables the buttons. */
+    const message = await within(dialog).findByText(
+      'Settle the open invoice before archiving this companion.'
+    );
+    await expect(message.tagName).toBe('P');
+    /* It is red, not body ink. Compared against the dialog's own heading rather
+       than against a hex value: if `--danger-text` ever resolved to nothing the
+       paragraph would simply inherit, and a class-list assertion would still
+       pass. Polled, since the line arrives with the re-render that also
+       re-enables the buttons. */
+    const heading = within(dialog).getByRole('heading', { name: 'Change status' });
+    await waitFor(() =>
+      expect(getComputedStyle(message).color).not.toBe(getComputedStyle(heading).color)
+    );
+    await expect(args.onSave).not.toHaveBeenCalled();
+    await expect(within(dialog).getByRole('button', { name: 'Update' })).toBeEnabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`validateBeforeSave` is the caller’s last guard, and it is the only failure the dialog ' +
+          'reports in place. It also grows the panel by a line, so the action row moves down while ' +
+          'the reader is looking at it.',
+      },
+    },
+  },
+};
+
+export const SaveRejects: Story = {
+  name: 'The save rejects',
+  args: {
+    onSave: fn(() => Promise.reject(new Error('The companion record is locked by another user.'))),
+  },
+  play: async ({ canvasElement }) => {
+    const dialog = await openDialog(canvasElement);
+    await chooseStatus(dialog, 'Active', 'Archived');
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Update' }));
+
+    /* The rejection's own message is surfaced verbatim, in the same inline slot
+       the validation message uses - so an API error string is shown to the user
+       exactly as it arrives. `findByText` already fails if the line never lands,
+       so the returned node is asserted for WHAT it is rather than that it is
+       there: the same `<p>` the validation branch writes into, which is what
+       makes the two failures indistinguishable to a reader. */
+    const failure = await within(dialog).findByText(
+      'The companion record is locked by another user.'
+    );
+    await expect(failure.tagName).toBe('P');
+    // Same red as the validation branch, so an infrastructure failure and a
+    // business rule are the same sentence in the same place to a reader.
+    const heading = within(dialog).getByRole('heading', { name: 'Change status' });
+    await waitFor(() =>
+      expect(getComputedStyle(failure).color).not.toBe(getComputedStyle(heading).color)
+    );
+
+    // `finally` releases the frame: the label comes back and the picker answers
+    // again, which is what makes a retry possible without reopening.
+    await waitFor(() =>
+      expect(within(dialog).getByRole('button', { name: 'Update' })).toBeEnabled()
+    );
+    const trigger = within(dialog).getByRole('button', { name: 'Companion status: Archived' });
+    await expect(getComputedStyle(trigger).pointerEvents).toBe('auto');
+    await expect(document.querySelector('dialog[open]')).not.toBeNull();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A failed write. The dialog stays open on the chosen status so the press can be repeated ' +
+          'without re-answering the picker.',
+      },
+    },
+  },
+};
+
+export const NoChange: Story = {
+  name: 'Update without changing anything',
+  play: async ({ canvasElement, args }) => {
+    const dialog = await openDialog(canvasElement);
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Update' }));
+
+    // `currentStatus === selectedStatus` short-circuits before `canTransition`
+    // and before the write: the dialog just closes.
+    await waitFor(() => expect(document.querySelector('dialog[open]')).toBeNull());
+    await expect(args.onSave).not.toHaveBeenCalled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The no-op. It is indistinguishable from a successful save at the call site - same close, ' +
+          'no toast, no error - which is why the terminal-status callers guard the dialog rather ' +
+          'than the button.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/tables/CompanionsTable.stories.tsx
+++ b/apps/frontend/src/app/ui/tables/CompanionsTable.stories.tsx
@@ -1,0 +1,331 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+
+import type { CompanionParent } from '@/app/features/companions/pages/Companions/types';
+import { useOrgStore } from '@/app/stores/orgStore';
+import CompanionsTable from './CompanionsTable';
+
+const ORG_ID = 'org-companions-table-story';
+
+const ROSTER: Array<[string, string, string, string]> = [
+  ['Kizie', 'Doe', 'Beagle', 'dog'],
+  ['Bailey', 'Lang', 'Labrador retriever', 'dog'],
+  ['Nala', 'Ferreira', 'Ragdoll', 'cat'],
+  ['Ollie', 'Nowak', 'Border collie', 'dog'],
+  ['Pepper', 'Haddad', 'Domestic shorthair', 'cat'],
+  ['Rufus', 'Ibrahim', 'Cocker spaniel', 'dog'],
+  ['Suki', 'Vasquez', 'Bengal', 'cat'],
+  ['Tilly', 'Okafor', 'Whippet', 'dog'],
+  ['Waffles', 'Brenner', 'Dachshund', 'dog'],
+  ['Yuki', 'Sorensen', 'Siberian', 'cat'],
+  ['Zephyr', 'Marchetti', 'Andalusian', 'horse'],
+  ['Comet', 'Whitfield', 'Shetland pony', 'horse'],
+];
+
+const companion = (index: number): CompanionParent => {
+  const [name, lastName, breed, type] = ROSTER[index];
+  return {
+    companion: {
+      id: `companion-${index + 1}`,
+      organisationId: ORG_ID,
+      parentId: `parent-${index + 1}`,
+      name,
+      type: type as CompanionParent['companion']['type'],
+      breed,
+      dateOfBirth: new Date('2021-06-14T00:00:00.000Z'),
+      gender: index % 2 === 0 ? 'female' : 'male',
+      isInsured: false,
+      status: index % 5 === 4 ? 'archived' : 'active',
+    },
+    parent: {
+      id: `parent-${index + 1}`,
+      firstName: ['Sky', 'Marta', 'Ana', 'Piotr', 'Yara', 'Sami'][index % 6],
+      lastName,
+      email: `owner${index + 1}@example.com`,
+      address: {},
+      createdFrom: 'pms',
+    },
+  };
+};
+
+const TWELVE = ROSTER.map((_, index) => companion(index));
+const FOUR = TWELVE.slice(0, 4);
+
+/**
+ * Seeds only the primary organisation id, and a unique one.
+ *
+ * It is not decoration: `useCompanionTerminologyText` falls back to a
+ * localStorage-backed PENDING term when there is no org id at all, so an
+ * unseeded story would render "Patient"/"Pet" columns and footers depending on
+ * what another story wrote to localStorage earlier in the session. With an org id
+ * and no org record the terminology resolves to the COMPANION default every time.
+ * Nothing here touches the network - the last-visit lookup reads the appointment
+ * store, which has nothing for this org.
+ */
+const seedOrg = () => {
+  useOrgStore.setState({ primaryOrgId: ORG_ID, status: 'loaded' });
+};
+
+/**
+ * The footer caption, present whenever the list is not empty.
+ *
+ * Matched on its own text rather than by position: the caption is a bare `<span>`
+ * among dozens of other spans in the rows above it, and the anchored pattern
+ * cannot collide with the preview decorator's sr-only `<h1>`.
+ */
+const footerText = (canvas: ReturnType<typeof within>): string | undefined =>
+  canvas.queryByText(/^Showing \d/)?.textContent?.trim();
+
+const rowCount = (canvas: ReturnType<typeof within>): number =>
+  canvas.queryAllByRole('button', { name: 'Companion row actions' }).length;
+
+const headerOf = (canvasElement: HTMLElement): HTMLElement =>
+  canvasElement.querySelector('.yc-table-head') as HTMLElement;
+
+/**
+ * The header's resolved grid tracks.
+ *
+ * `GRID_COLS` declares SIX columns and adds a seventh (Patient ID) only at `xl`,
+ * while the header always renders seven spans - the extra one is `hidden xl:block`,
+ * a DOM child either way. So the child count alone cannot tell the two layouts
+ * apart, and the stories that assert seven tracks have to pin a width above 1280
+ * or they are asserting whatever the preview panel happened to be.
+ */
+const headerTracks = (canvasElement: HTMLElement): string[] =>
+  getComputedStyle(headerOf(canvasElement)).gridTemplateColumns.trim().split(/\s+/);
+
+const meta = {
+  title: 'Tables/CompanionsTable',
+  component: CompanionsTable,
+  parameters: {
+    layout: 'fullscreen',
+    // Row actions and the name button push through next/navigation's router.
+    nextjs: { appDirectory: true },
+    docs: {
+      description: {
+        component:
+          'The companion directory table, and specifically **its own pager** - not the shared ' +
+          '`GenericTable` one. This table pages in local state at a fixed 10 rows, clamps the ' +
+          'effective page during render (so a filter that shrinks the list never flashes an empty ' +
+          'slice), and draws a footer the other tables do not have: a left-aligned ' +
+          '`Showing 1-10 of 12 companions` count with a numbered rail on the right.\n\n' +
+          'Almost none of that had ever been rendered. The rail is gated on `totalPages > 1`, so ' +
+          'any story with a short fixture shows a bare count line; page 2, a disabled Previous and ' +
+          'a disabled Next exist only after a click; and the whole footer disappears when the list ' +
+          'is empty.\n\n' +
+          'Note the two different asymmetries. The rail is `totalPages > 1`, but the FOOTER is ' +
+          '`filteredList.length > 0` - so a single page of results still gets a count line with ' +
+          'nothing next to it, and an empty list gets no footer at all rather than "Showing 0 of ' +
+          '0". And below 768 the table becomes a card list with **no pager whatsoever**: every ' +
+          'companion is rendered at once, which the phone story below is here to show.\n\n' +
+          'The noun in the count is the org’s companion terminology, so it reads "patients" for a ' +
+          'hospital and "animals" for a breeder.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    filteredList: TWELVE,
+    setActiveCompanion: fn(),
+    setViewCompanion: fn(),
+    setCompanionInfoInitialLabel: fn(),
+    setBookAppointment: fn(),
+    setAddTask: fn(),
+    setChangeStatusPopup: fn(),
+    canEditAppointments: true,
+    canEditTasks: true,
+    canEditCompanions: true,
+  },
+  beforeEach: seedOrg,
+  decorators: [
+    (Story) => (
+      <div className="h-[560px] w-full bg-[var(--screen)] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof CompanionsTable>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const FirstPage: Story = {
+  name: 'Pager, first page of two',
+  /* Pinned as a GLOBAL at 1440, not 1280: the Patient ID column is `hidden
+     xl:block` and `GRID_COLS` grows its seventh track at exactly 1280, so at the
+     laptop preset a preview scrollbar decides how many columns this story is
+     about. `parameters.viewport.defaultViewport` was removed in Storybook 10 and
+     would render the panel width regardless. */
+  globals: { viewport: { value: 'desktop', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Ten of twelve on screen, and the count line says exactly that.
+    await expect(rowCount(canvas)).toBe(10);
+    await expect(footerText(canvas)).toBe('Showing 1-10 of 12 companions');
+
+    /* The rail: two numbered buttons and no third, so the page count is derived
+       from the list rather than fixed. `aria-current` is the only thing marking
+       the active page for a screen reader - the rest is a background wash. */
+    const page1 = canvas.getByRole('button', { name: 'Page 1' });
+    await expect(page1).toHaveAttribute('aria-current', 'page');
+    await expect(canvas.getByRole('button', { name: 'Page 2' })).not.toHaveAttribute(
+      'aria-current'
+    );
+    await expect(canvas.queryByRole('button', { name: 'Page 3' })).not.toBeInTheDocument();
+
+    // The steppers are rendered and DISABLED at the ends, not hidden.
+    await expect(canvas.getByRole('button', { name: 'Previous page' })).toBeDisabled();
+    await expect(canvas.getByRole('button', { name: 'Next page' })).toBeEnabled();
+
+    /* Seven header cells AND seven resolved tracks: the last cell is an empty
+       spacer over the kebab column, and the Patient ID cell only earns a track
+       above 1280. Both numbers are asserted because either one alone passes on a
+       layout that dropped the other. */
+    const header = headerOf(canvasElement);
+    await expect(header.children).toHaveLength(7);
+    await expect(headerTracks(canvasElement)).toHaveLength(7);
+    await expect(within(header).getByText('Last visit')).toBeInTheDocument();
+    await expect(within(header).getByText('Patient ID')).toBeVisible();
+
+    // Page one is the first ten of the roster, so the eleventh is not on it.
+    await expect(canvas.getByText('Kizie · Doe')).toBeInTheDocument();
+    await expect(canvas.queryByText('Zephyr · Marchetti')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Twelve companions at the fixed page size of ten. The last-visit column reads `-` for ' +
+          'every row here because the appointment store is empty for this org, which is also what ' +
+          'a genuinely new practice sees.',
+      },
+    },
+  },
+};
+
+export const SecondPage: Story = {
+  name: 'Pager, page two',
+  // 1440 for the seven-column layout, as in the first story above.
+  globals: { viewport: { value: 'desktop', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Page 2' }));
+
+    // The remainder page: two rows, and the range moves rather than the total.
+    await waitFor(() => expect(footerText(canvas)).toBe('Showing 11-12 of 12 companions'));
+    await expect(rowCount(canvas)).toBe(2);
+    await expect(canvas.getByText('Zephyr · Marchetti')).toBeInTheDocument();
+    await expect(canvas.getByText('Comet · Whitfield')).toBeInTheDocument();
+    await expect(canvas.queryByText('Kizie · Doe')).not.toBeInTheDocument();
+
+    // Both ends flip together - this is the frame no static snapshot contained.
+    await expect(canvas.getByRole('button', { name: 'Page 2' })).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
+    await expect(canvas.getByRole('button', { name: 'Page 1' })).not.toHaveAttribute(
+      'aria-current'
+    );
+    await expect(canvas.getByRole('button', { name: 'Previous page' })).toBeEnabled();
+    await expect(canvas.getByRole('button', { name: 'Next page' })).toBeDisabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The disabled Next is the detail worth looking at: it keeps its border and only drops to ' +
+          '40% opacity, so at a glance the rail looks the same as it does on page one.',
+      },
+    },
+  },
+};
+
+export const SinglePage: Story = {
+  name: 'One page - count, no rail',
+  // 1440 for the seven-column layout, as in the first story above.
+  globals: { viewport: { value: 'desktop', isRotated: false } },
+  args: { filteredList: FOUR },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // The count line stays; everything to the right of it is gone.
+    await expect(footerText(canvas)).toBe('Showing 1-4 of 4 companions');
+    await expect(rowCount(canvas)).toBe(4);
+    await expect(canvas.queryByRole('button', { name: 'Page 1' })).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Previous page' })).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Next page' })).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'What most practices see. The footer keeps its full height and border for one lonely ' +
+          'sentence, which is the layout decision this frame exists to expose.',
+      },
+    },
+  },
+};
+
+export const NoCompanions: Story = {
+  name: 'Empty - no footer at all',
+  // 1440 for the seven-column layout, as in the first story above.
+  globals: { viewport: { value: 'desktop', isRotated: false } },
+  args: { filteredList: [] },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByText('No data available')).toBeVisible();
+    // Not "Showing 0-0 of 0": the whole footer is gated on the list being
+    // non-empty, so the empty table has no count line and no border above it.
+    await expect(footerText(canvas)).toBeUndefined();
+    await expect(rowCount(canvas)).toBe(0);
+    // The header row survives at full width, so the columns are still readable
+    // with no rows under them.
+    await expect(headerOf(canvasElement).children).toHaveLength(7);
+    await expect(headerTracks(canvasElement)).toHaveLength(7);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A filter that matches nothing. The empty message is a plain centred sentence inside the ' +
+          'scroll area rather than the shared `NoDataMessage` card the `GenericTable` pages use - ' +
+          'two different empty states in one product.',
+      },
+    },
+  },
+};
+
+export const PhoneCards: Story = {
+  name: 'Phone: every row, no pager',
+  // Pinned as a GLOBAL: `parameters.viewport.defaultViewport` was removed in
+  // Storybook 10 and is inert, and `useIsPhone` reads a real media query - so
+  // the wrong spelling here would silently draw the desktop table.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    /* All twelve, not ten: the phone branch returns before the paged slice is
+       ever used, so `PAGE_SIZE` does not apply below 768. On a large directory
+       this is the branch that renders hundreds of cards in one go. */
+    await waitFor(() => expect(canvas.getAllByTitle('Open companion history')).toHaveLength(12));
+    await expect(canvas.getByText('Comet · Whitfield')).toBeInTheDocument();
+
+    await expect(footerText(canvas)).toBeUndefined();
+    await expect(canvas.queryByRole('button', { name: 'Page 2' })).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Next page' })).not.toBeInTheDocument();
+    // And no kebabs: the phone card is a single tap target onto the history page.
+    await expect(rowCount(canvas)).toBe(0);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`useIsPhone` is false during SSR and the first client render and flips after mount, so ' +
+          'this is a post-mount swap into a completely different tree - not a CSS breakpoint. That ' +
+          'is why the pager is not hidden here; it is not rendered.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/tables/InvoiceTable.stories.tsx
+++ b/apps/frontend/src/app/ui/tables/InvoiceTable.stories.tsx
@@ -1,0 +1,265 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, within } from 'storybook/test';
+import type { Appointment, Invoice } from '@yosemite-crew/types';
+
+import { useAppointmentStore } from '@/app/stores/appointmentStore';
+import { useOrgStore } from '@/app/stores/orgStore';
+import InvoiceTable from './InvoiceTable';
+
+const ORG_ID = 'org-invoice-table-story';
+
+const appointment = (id: string, name: string, parent: string): Appointment => {
+  const patient: Appointment['patient'] = {
+    id: `companion-${id}`,
+    name,
+    species: 'Dog',
+    breed: 'Beagle',
+    parent: { id: `parent-${id}`, name: parent },
+  };
+  return {
+    id,
+    organisationId: ORG_ID,
+    patient,
+    companion: patient,
+    appointmentDate: new Date('2026-08-12T09:30:00.000Z'),
+    startTime: new Date('2026-08-12T09:30:00.000Z'),
+    endTime: new Date('2026-08-12T10:00:00.000Z'),
+    timeSlot: '09:30 AM',
+    durationMinutes: 30,
+    status: 'COMPLETED',
+  };
+};
+
+const APPOINTMENTS = [
+  appointment('appointment-1', 'Kizie', 'Sky Doe'),
+  appointment('appointment-2', 'Bailey', 'Marta Lang'),
+];
+
+const invoice = (over: Partial<Invoice> = {}): Invoice => ({
+  id: 'a1b2c3d4e5f60718293a4b5c',
+  organisationId: ORG_ID,
+  appointmentId: 'appointment-1',
+  items: [
+    { name: 'General consultation', quantity: 1, unitPrice: 60, total: 60 },
+    { name: 'Rabies vaccination', quantity: 1, unitPrice: 35, total: 35 },
+  ],
+  subtotal: 95,
+  discountTotal: 0,
+  taxTotal: 7.65,
+  totalAmount: 102.65,
+  paymentCollectionMethod: 'PAYMENT_INTENT',
+  currency: 'USD',
+  status: 'PAID',
+  createdAt: new Date('2026-08-12T10:15:00.000Z'),
+  updatedAt: new Date('2026-08-12T10:15:00.000Z'),
+  ...over,
+});
+
+const INVOICES: Invoice[] = [
+  invoice(),
+  invoice({
+    id: 'b2c3d4e5f60718293a4b5c6d',
+    appointmentId: 'appointment-2',
+    status: 'AWAITING_PAYMENT',
+    paymentCollectionMethod: 'PAYMENT_LINK',
+    taxTotal: 0,
+    totalAmount: 95,
+  }),
+];
+
+/**
+ * Both stores are plain Zustand stores with no provider and no fetch on read, so
+ * seeding them outside React is the whole of the setup. The table resolves the
+ * parent and patient names itself from `invoice.appointmentId`, and the money
+ * formatter reads the org currency, which falls back to USD with no subscription.
+ */
+const seedStores = () => {
+  useOrgStore.setState({ primaryOrgId: ORG_ID, status: 'loaded' });
+  useAppointmentStore.getState().setAppointmentsForOrg(ORG_ID, APPOINTMENTS);
+};
+
+/**
+ * The three bands, in DOM order: desktop table, tablet table, phone cards. Finance
+ * deliberately avoids the shared `.table-list`/`.card-list` classes, so the bands
+ * are plain Tailwind siblings of one wrapper and are addressed positionally.
+ */
+const bands = (canvasElement: HTMLElement) => {
+  const wrapper = canvasElement.querySelector('.table-wrapper') as HTMLElement;
+  const [desktop, tablet, phone] = [...wrapper.children] as HTMLElement[];
+  return { desktop, tablet, phone };
+};
+
+const meta = {
+  title: 'Tables/InvoiceTable',
+  component: InvoiceTable,
+  parameters: {
+    layout: 'padded',
+    // The Date cell pushes to /appointments through next/navigation's router.
+    nextjs: { appDirectory: true },
+    docs: {
+      description: {
+        component:
+          'The finance list, which is three separate renderings of one array rather than one ' +
+          'responsive table: a ten-column ledger above 1280, a six-column tablet table between 768 ' +
+          'and 1279 (Services and Date fold into the identity sub-line, Subtotal/Discount/Tax fold ' +
+          'under Total), and a card band below 768. All three are always in the DOM; Tailwind ' +
+          'hides two of them.\n\n' +
+          'That is why the phone band’s empty state had never been drawn. It is its own branch - ' +
+          '`filteredList.length === 0` inside the card band - and it prints different copy from the ' +
+          'tables above it: **"No invoices match the current filters."** against `GenericTable`’s ' +
+          '"Looks like a quiet day… for now." An empty finance page therefore says one thing on a ' +
+          'laptop and another on a phone, and both sentences are in the DOM at every width.\n\n' +
+          'It is also the only one of the three that announces itself: it is an `<output ' +
+          'aria-live="polite">`, so a filter change that empties the list is spoken on a phone and ' +
+          'silent on a desktop.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    filteredList: INVOICES,
+    setActiveInvoice: fn(),
+    setViewInvoice: fn(),
+  },
+  beforeEach: seedStores,
+  decorators: [
+    (Story) => (
+      <div className="h-[520px] bg-[var(--screen)] p-3">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof InvoiceTable>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const PhoneEmpty: Story = {
+  name: 'Phone: no invoices match',
+  args: { filteredList: [] },
+  // Pinned as a GLOBAL. `parameters.viewport.defaultViewport` was removed in
+  // Storybook 10 - it still type-checks and still plays, and renders the full
+  // panel width, which for this component means the DESKTOP band under a name
+  // promising a phone.
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const { desktop, tablet, phone } = bands(canvasElement);
+
+    const message = canvas.getByText('No invoices match the current filters.');
+    await expect(message).toBeVisible();
+    // An <output>, not a div: it is the only empty state on this page that a
+    // screen reader is told about when a filter empties the list.
+    await expect(message.tagName).toBe('OUTPUT');
+    await expect(message).toHaveAttribute('aria-live', 'polite');
+    await expect(phone.children).toHaveLength(1);
+
+    /* The two table bands are still mounted, still carrying their own - different -
+       empty copy, and only `display: none` separates them from this one. Asserted
+       because it is the whole reason this branch went unnoticed. */
+    await expect(desktop).not.toBeVisible();
+    await expect(tablet).not.toBeVisible();
+    const quietDay = canvas.getAllByText('Looks like a quiet day… for now.');
+    await expect(quietDay).toHaveLength(2);
+    await expect(quietDay[0]).not.toBeVisible();
+    await expect(quietDay[1]).not.toBeVisible();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The gated surface: an empty finance list at 375. The copy is about the FILTERS, not ' +
+          'about the practice being quiet, which is the more useful of the two sentences and the ' +
+          'one only phone users get.',
+      },
+    },
+  },
+};
+
+export const PhoneCards: Story = {
+  name: 'Phone: the card band',
+  globals: { viewport: { value: 'mobile', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const { phone } = bands(canvasElement);
+
+    // The other side of the same branch: with rows, the <output> does not exist
+    // at all - so the empty state cannot be a leftover node with its text swapped.
+    await expect(
+      canvas.queryByText('No invoices match the current filters.')
+    ).not.toBeInTheDocument();
+    await expect(phone.children).toHaveLength(2);
+    await expect(phone).toBeVisible();
+
+    /* Each card resolves its own names out of the appointment store rather than off the
+       invoice, which is what makes the seeded appointments load-bearing - and it splits
+       the owner across two lines while doing it. `getCompanionNameFromAppointments`
+       runs `formatCompanionNameWithOwnerLastName`, so the heading is the pet plus the
+       owner's LAST name; `getParentNameFromAppointments` runs `getOwnerFirstName`, so
+       the "Parent:" line under it is the FIRST name only. A card seeded with "Kizie" and
+       "Sky Doe" therefore reads "Kizie · Doe" over "Sky", and the owner's full name is
+       nowhere on it. */
+    await expect(canvas.getByText('Kizie · Doe')).toBeVisible();
+    await expect(canvas.getByText('Bailey · Lang')).toBeVisible();
+    await expect(canvas.getByText('Sky')).toBeVisible();
+    await expect(canvas.getByText('Marta')).toBeVisible();
+
+    /* The bare fixture strings are asserted ABSENT rather than left unmentioned. Both
+       halves of the split are silent when they break - dropping the owner suffix or
+       widening the parent line to the full name still renders a perfectly plausible
+       card - so the only thing that catches either is naming what must NOT be there. */
+    await expect(canvas.queryByText('Kizie')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Sky Doe')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Two invoices as cards. Cards are `w-full` below `sm`, so on a phone the band is a single ' +
+          'column however many invoices there are.',
+      },
+    },
+  },
+};
+
+export const DesktopEmpty: Story = {
+  name: 'Desktop: the other empty state',
+  args: { filteredList: [] },
+  // 1440 rather than the 1280 laptop preset: the desktop band is `xl:flex`, and
+  // at exactly 1280 a preview scrollbar can take the viewport under the breakpoint
+  // and silently swap which band this story is about.
+  globals: { viewport: { value: 'desktop', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const { desktop, tablet, phone } = bands(canvasElement);
+
+    await expect(desktop).toBeVisible();
+    await expect(tablet).not.toBeVisible();
+    // The phone sentence is mounted here too, one `display: none` away.
+    await expect(phone).not.toBeVisible();
+    await expect(canvas.getByText('No invoices match the current filters.')).not.toBeVisible();
+
+    // Scoped to the desktop band rather than filtered by visibility: the same
+    // sentence exists twice, and this names WHICH copy the reader is looking at.
+    await expect(within(desktop).getByText('Looks like a quiet day… for now.')).toBeVisible();
+    await expect(within(tablet).getByText('Looks like a quiet day… for now.')).not.toBeVisible();
+
+    /* Column counts, so the two table bands are provably the ledger and the
+       pruned one rather than the same markup twice: ten columns of ledger against
+       six columns of "what you need to chase money". */
+    await expect(desktop.querySelectorAll('thead th')).toHaveLength(10);
+    await expect(tablet.querySelectorAll('thead th')).toHaveLength(6);
+    await expect(within(desktop).getByText('Subtotal')).toBeInTheDocument();
+    await expect(within(tablet).queryByText('Subtotal')).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same empty list one breakpoint up, kept next to the phone story so the two sentences ' +
+          'can be read together. The header row survives the empty state in both tables, so the ' +
+          'column pruning is visible with no data at all.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/tables/PaginatedCardList.stories.tsx
+++ b/apps/frontend/src/app/ui/tables/PaginatedCardList.stories.tsx
@@ -1,0 +1,229 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import PaginatedCardList from './PaginatedCardList';
+
+type Row = { id: string; name: string; meta: string };
+
+const ROWS: Row[] = [
+  { id: 'r1', name: 'Midday analgesia round', meta: 'Due 12:00 - Ravi Patel' },
+  { id: 'r2', name: 'Kennel 3 deep clean', meta: 'Due 13:30 - Tom Reyes' },
+  { id: 'r3', name: 'Discharge call, Bailey', meta: 'Due 14:00 - Elena Marsh' },
+  { id: 'r4', name: 'Restock consult room 2', meta: 'Due 15:15 - Priya Raman' },
+  { id: 'r5', name: 'Post-op check, Nala', meta: 'Due 15:45 - Elena Marsh' },
+  { id: 'r6', name: 'Lab courier handover', meta: 'Due 16:00 - Tom Reyes' },
+  { id: 'r7', name: 'Vaccine fridge log', meta: 'Due 16:30 - Ravi Patel' },
+  { id: 'r8', name: 'Insurance claim, Ollie', meta: 'Due 17:00 - Priya Raman' },
+  { id: 'r9', name: 'Overnight handover notes', meta: 'Due 18:00 - Elena Marsh' },
+];
+
+/**
+ * The list is generic over its item type and takes a `renderCard` callback, so a
+ * story cannot pass it through `args` alone without also passing a function.
+ * This harness fixes the card and leaves `items` and `pageSize` as the controls,
+ * which are the two props the paging branches actually turn on.
+ */
+const CardList = ({ items, pageSize }: { items: Row[]; pageSize: number }) => (
+  <PaginatedCardList
+    items={items}
+    pageSize={pageSize}
+    renderCard={(item: Row) => (
+      <article
+        key={item.id}
+        aria-label={item.name}
+        className="w-[168px] rounded-2xl border border-[var(--hairline)] bg-[var(--screen)] p-3.5 shadow-[0_1px_2px_var(--sh03),0_6px_16px_var(--sh05)]"
+      >
+        <p className="text-[13.5px] font-semibold text-[var(--ink)]">{item.name}</p>
+        <p className="mt-1 text-[11.5px] text-[var(--ink-faint)]">{item.meta}</p>
+      </article>
+    )}
+  />
+);
+
+/** The pager caption, whitespace-normalised. Absent when the pager is not drawn. */
+const caption = (canvasElement: HTMLElement): string | undefined =>
+  canvasElement.querySelector('[aria-live="polite"]')?.textContent?.replaceAll(/\s+/g, ' ').trim();
+
+/** Card names in render order, which is what "which page am I on" means here. */
+const cardNames = (canvas: ReturnType<typeof within>): string[] =>
+  canvas
+    .queryAllByRole('article')
+    .map((card: HTMLElement) => card.getAttribute('aria-label') ?? '');
+
+const meta = {
+  title: 'Tables/PaginatedCardList',
+  component: CardList,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The pager behind the sub-xl card band of the Appointments and Tasks tables. It exists ' +
+          'because those bands used to render every row at once: on the dashboard, where nothing ' +
+          'bounds their height, a few hundred appointments became a ~64,000px slab.\n\n' +
+          'Two of its three branches had never been drawn. The **empty state** and the **pager row** ' +
+          'are both conditional - the pager only when `totalPages > 1` - and its only consumers wrap ' +
+          'it in `xl:hidden`, so at any Storybook width where a story of those tables is readable ' +
+          'this component is `display: none`. Rendering it directly is the only way to see it.\n\n' +
+          'Read the caption carefully: `Showing 8 of 9` is the index of the last card on the page, ' +
+          'not a count of the cards on it. On the final page it reads `9 of 9` with one card ' +
+          'visible.\n\n' +
+          'Paging is internal state with no URL or caller involvement, and the page is clamped ' +
+          'during render rather than corrected in an effect, so a list that shrinks under the ' +
+          'current page never flashes an empty slice.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    pageSize: { control: { type: 'number', min: 1 } },
+  },
+  args: { items: ROWS, pageSize: 4 },
+  decorators: [
+    (Story) => (
+      <div className="h-[340px] w-[560px] max-w-full bg-[var(--screen)] p-3">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof CardList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const SinglePage: Story = {
+  name: 'One page - no pager at all',
+  args: { items: ROWS.slice(0, 3), pageSize: 4 },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(cardNames(canvas)).toHaveLength(3);
+
+    /* `showPagination` is `totalPages > 1`, so a list that fits loses the whole
+       footer - not a disabled pair of arrows. Both controls and the caption are
+       asserted absent, because a footer rendered with everything disabled would
+       look almost identical in a snapshot and still take 52px of height. */
+    await expect(canvas.queryByRole('button', { name: 'Next' })).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: 'Previous' })).not.toBeInTheDocument();
+    await expect(caption(canvasElement)).toBeUndefined();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The common case on a quiet day. Worth having as the baseline for the two stories below: ' +
+          'everything they assert is a thing this frame does not contain.',
+      },
+    },
+  },
+};
+
+export const FirstPage: Story = {
+  name: 'Pager, first page',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Four of nine: the page slice, and the exact names, so a slice that started
+    // at the wrong index would not pass on a count alone.
+    await expect(cardNames(canvas)).toEqual([
+      'Midday analgesia round',
+      'Kennel 3 deep clean',
+      'Discharge call, Bailey',
+      'Restock consult room 2',
+    ]);
+    await expect(caption(canvasElement)).toBe('Showing 4 of 9');
+
+    await expect(canvas.getByRole('button', { name: 'Previous' })).toBeDisabled();
+    await expect(canvas.getByRole('button', { name: 'Next' })).toBeEnabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Nine items at a page size of four. Previous is disabled rather than hidden, so the ' +
+          'footer keeps the same three-slot shape on every page.',
+      },
+    },
+  },
+};
+
+export const SecondPage: Story = {
+  name: 'Pager, after a click',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Next' }));
+
+    await waitFor(() => expect(caption(canvasElement)).toBe('Showing 8 of 9'));
+    await expect(cardNames(canvas)).toEqual([
+      'Post-op check, Nala',
+      'Lab courier handover',
+      'Vaccine fridge log',
+      'Insurance claim, Ollie',
+    ]);
+    // Both ends live in the middle of the range - the state no static frame holds.
+    await expect(canvas.getByRole('button', { name: 'Previous' })).toBeEnabled();
+    await expect(canvas.getByRole('button', { name: 'Next' })).toBeEnabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Page two exists only after a click, so nothing before this story had ever rendered it. ' +
+          'The caption is `aria-live="polite"`, which is the only announcement a screen reader gets ' +
+          'that the cards under it changed - the cards themselves are not in a live region.',
+      },
+    },
+  },
+};
+
+export const LastPage: Story = {
+  name: 'Pager, last page (one card)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const next = canvas.getByRole('button', { name: 'Next' });
+    await userEvent.click(next);
+    await userEvent.click(next);
+
+    await waitFor(() => expect(canvas.getByRole('button', { name: 'Next' })).toBeDisabled());
+    // 9 of 9 with a single card on screen: the caption counts the last INDEX,
+    // not the cards, and this is the frame where the difference is visible.
+    await expect(caption(canvasElement)).toBe('Showing 9 of 9');
+    await expect(cardNames(canvas)).toEqual(['Overnight handover notes']);
+    await expect(canvas.getByRole('button', { name: 'Previous' })).toBeEnabled();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The remainder page. The list keeps `content-start`, so one card sits at the top left ' +
+          'rather than stretching to fill the band.',
+      },
+    },
+  },
+};
+
+export const Empty: Story = {
+  name: 'No data available',
+  args: { items: [] },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('No data available')).toBeInTheDocument();
+    await expect(cardNames(canvas)).toHaveLength(0);
+
+    /* Empty is not "page zero": `totalPages` is 0, the clamp holds the page at 1
+       and the pager is gone entirely, so there is no control offering to page
+       through nothing. */
+    await expect(canvas.queryByRole('button', { name: 'Next' })).not.toBeInTheDocument();
+    await expect(caption(canvasElement)).toBeUndefined();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The empty branch is a plain centred sentence with no icon and no call to action - ' +
+          'noticeably plainer than `GenericTable`’s "Looks like a quiet day… for now." card, ' +
+          'which is what the same table shows one breakpoint up. Two empty states for one dataset ' +
+          'is the thing to look at here.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/widgets/DynamicChart/ChartCanvas.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/DynamicChart/ChartCanvas.stories.tsx
@@ -1,0 +1,396 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, waitFor } from 'storybook/test';
+
+import type { ChartKey } from './chartAxis';
+import ChartCanvas, { type ChartCanvasProps } from './ChartCanvas';
+
+const APPOINTMENT_KEYS: ChartKey[] = [
+  { name: 'Completed', color: 'var(--cta)' },
+  { name: 'Cancelled', color: 'var(--divider)' },
+];
+
+const APPOINTMENTS = [
+  { month: 'Mon', Completed: 18, Cancelled: 3 },
+  { month: 'Tue', Completed: 24, Cancelled: 1 },
+  { month: 'Wed', Completed: 21, Cancelled: 5 },
+  { month: 'Thu', Completed: 27, Cancelled: 2 },
+  { month: 'Fri', Completed: 30, Cancelled: 4 },
+  { month: 'Sat', Completed: 12, Cancelled: 2 },
+  { month: 'Sun', Completed: 6, Cancelled: 0 },
+];
+
+/**
+ * One `<rect>` per non-zero value: recharts skips a zero-height bar, so Sunday's
+ * `Cancelled: 0` draws nothing. Derived from the fixture rather than hardcoded so
+ * that editing a row above cannot quietly turn the count into a lie.
+ */
+const BAR_RECTANGLE_COUNT =
+  APPOINTMENTS.filter((point) => point.Completed > 0).length +
+  APPOINTMENTS.filter((point) => point.Cancelled > 0).length;
+
+const REVENUE_KEYS: ChartKey[] = [{ name: 'Revenue', color: 'var(--blue)' }];
+
+const REVENUE = [
+  { month: 'Jan', Revenue: 12400 },
+  { month: 'Feb', Revenue: 14850 },
+  { month: 'Mar', Revenue: 11200 },
+  { month: 'Apr', Revenue: 17600 },
+  { month: 'May', Revenue: 19050 },
+  { month: 'Jun', Revenue: 16300 },
+];
+
+const CHART_MARGIN = { top: 8, right: 8, left: 0, bottom: 0 };
+const CHART_HEIGHT = 240;
+
+/**
+ * The one shape of chart in this file whose canvas actually has a box on screen,
+ * so it is the only one a tooltip story can be written against. Shared verbatim by
+ * every line story below - they are the same render, differing only in what they
+ * assert.
+ */
+const LINE_ARGS = {
+  data: REVENUE,
+  keys: REVENUE_KEYS,
+  type: 'line',
+  tooltipLabelFormatter: (label) => `Month of ${String(label)}`,
+  yTickFormatter: (value: number) => `$${(value / 1000).toFixed(0)}k`,
+} satisfies Partial<ChartCanvasProps>;
+
+const wrapperOf = (canvasElement: HTMLElement) =>
+  canvasElement.querySelector('.recharts-wrapper') as HTMLElement;
+
+/**
+ * The tooltip bubble is ALWAYS in the DOM - recharts keeps the wrapper mounted and
+ * toggles `visibility` on it - so "the bubble exists" is never the question here.
+ */
+const bubbleOf = (canvasElement: HTMLElement) =>
+  canvasElement.querySelector('.recharts-tooltip-wrapper') as HTMLElement;
+
+/**
+ * Moves the pointer over the plot.
+ *
+ * `userEvent.hover` is no use for a chart: recharts reads `clientX`/`clientY` off
+ * the event and turns them into a data index, and hover dispatches no usable
+ * coordinates. A native `mousemove` with real coordinates is what a chart tooltip
+ * actually responds to - recharts takes it through React's delegated
+ * `onMouseMove` on `.recharts-wrapper` and subtracts that element's
+ * `getBoundingClientRect()`, so a bubbling event carrying real client
+ * coordinates is indistinguishable from a hand on a mouse. Hoisted deliberately -
+ * it mutates, so it must never be called from inside a `waitFor` callback.
+ */
+const movePointerOverPlot = (wrapper: HTMLElement, fraction: number) => {
+  const rect = wrapper.getBoundingClientRect();
+  const init = {
+    bubbles: true,
+    cancelable: true,
+    clientX: Math.round(rect.left + rect.width * fraction),
+    clientY: Math.round(rect.top + rect.height * 0.5),
+  };
+  // Sent three times: the first move can land before recharts has measured its
+  // ResponsiveContainer, and a repeat costs nothing.
+  for (let i = 0; i < 3; i += 1) {
+    wrapper.dispatchEvent(new MouseEvent('mousemove', init));
+  }
+};
+
+/**
+ * Takes the pointer off the plot.
+ *
+ * Dispatched as a bubbling `mouseout` with a `relatedTarget` outside the chart,
+ * not as `mouseleave`: React synthesises `onMouseLeave` from the out/over pair at
+ * the root container, so a hand-fired `mouseleave` - which does not bubble -
+ * reaches nothing and the bubble stays open.
+ */
+const movePointerOffPlot = (wrapper: HTMLElement) => {
+  wrapper.dispatchEvent(
+    new MouseEvent('mouseout', {
+      bubbles: true,
+      cancelable: true,
+      relatedTarget: document.body,
+    })
+  );
+};
+
+/**
+ * A flat pause, for the one assertion shape `waitFor` cannot express: that
+ * something STAYS shut. recharts answers a mousemove within a single animation
+ * frame (its mousemove handling is `requestAnimationFrame`-throttled by default),
+ * so a quarter of a second is generous.
+ */
+/** The label line of the open bubble. */
+const bubbleLabel = (canvasElement: HTMLElement): string =>
+  bubbleOf(canvasElement).querySelector('.recharts-tooltip-label')?.textContent?.trim() ?? '';
+
+/** Series name -> printed value, for the open bubble. */
+const bubbleItems = (canvasElement: HTMLElement): Record<string, string> =>
+  Object.fromEntries(
+    [...bubbleOf(canvasElement).querySelectorAll('.recharts-tooltip-item')].map((item) => [
+      item.querySelector('.recharts-tooltip-item-name')?.textContent?.trim() ?? '',
+      item.querySelector('.recharts-tooltip-item-value')?.textContent?.trim() ?? '',
+    ])
+  );
+
+const meta = {
+  title: 'Widgets/ChartCanvas',
+  component: ChartCanvas,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The recharts canvas itself, one level below `Widgets/DynamicChartCard`: the axes, the ' +
+          'grid, the series, and the one surface those card stories can never reach - the ' +
+          '**tooltip bubble**.\n\n' +
+          '**The bar canvas in this file renders at 0x0 and paints nothing.** That is not a story ' +
+          'bug, it is the component: `BarChartContent` hands `<BarChart>` a ' +
+          '`style={{ width: "100%", height: "100%" }}`, recharts spreads that style onto ' +
+          "`.recharts-wrapper` AFTER the pixel width and height it measured, and the wrapper's " +
+          'parent is the deliberately zero-width `overflow: visible` div `ResponsiveContainer` ' +
+          'uses so a chart can shrink. 100% of 0 is 0. recharts still computes the whole chart - ' +
+          'the `<svg>` carries `width="620" height="240"`, every bar has real geometry - and CSS ' +
+          'then collapses it to nothing, which is why no console warning fires. "Bars: the canvas ' +
+          'hover opens the bubble" is the regression guard for it, and the other stories run on the LINE chart, which ' +
+          'passes no `style` and therefore keeps the pixel size recharts gave it.\n\n' +
+          'The bubble itself carries **no repo styling at all**. Both `<Tooltip />` elements here ' +
+          'are bare (the line chart passes a label formatter and nothing else), so what a reader ' +
+          'gets is the recharts default: a `#fff` box with a `1px solid #ccc` border and ' +
+          'black-ish item text, sized in pixels and positioned by recharts. It does not read a ' +
+          'single design token, which means it stays white on the espresso dark theme - switch ' +
+          'the toolbar to Dark on any story below and the bubble is the one thing that does not ' +
+          'move.\n\n' +
+          'It also only exists while a pointer is over the plot, which is why no snapshot had ever ' +
+          'contained it: the bubble wrapper is mounted at all times but sits at ' +
+          '`visibility: hidden` until a `mousemove` lands, so a static frame of the chart and a ' +
+          'frame with a broken tooltip are identical.\n\n' +
+          'A note for anyone extending this file: the recharts element imports must stay static. ' +
+          'Wrapping `Bar`/`XAxis`/`Tooltip` in `next/dynamic` makes recharts see anonymous loadable ' +
+          'components, and it silently drops them and renders an empty chart. Code splitting ' +
+          'happens one level up, where `DynamicChartCard` lazy-loads this whole module.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    data: APPOINTMENTS,
+    type: 'bar',
+    keys: APPOINTMENT_KEYS,
+    chartHeight: CHART_HEIGHT,
+    chartMargin: CHART_MARGIN,
+    isVerticalLayout: false,
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 620, maxWidth: '100%' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ChartCanvas>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const TooltipAtRest: Story = {
+  name: 'At rest: mounted, hidden',
+  args: LINE_ARGS,
+  play: async ({ canvasElement }) => {
+    await waitFor(() => expect(canvasElement.querySelector('.recharts-surface')).not.toBeNull());
+
+    /* On a canvas that is really there - stated as an assertion because the story
+       below is the same file's proof that "the surface exists" and "the chart is
+       on screen" are two different claims. */
+    await waitFor(() => {
+      const wrapper = wrapperOf(canvasElement);
+      expect(wrapper.getBoundingClientRect().width).toBeGreaterThan(0);
+      expect(wrapper.getBoundingClientRect().height).toBe(CHART_HEIGHT);
+    });
+
+    /* The claim worth pinning: the bubble is in the DOM before anyone has touched
+       the chart. Any story that asserted `.recharts-tooltip-wrapper` exists would
+       therefore pass with the tooltip completely broken - the visibility is the
+       only thing that separates open from closed. */
+    const bubble = await waitFor(() => {
+      const node = bubbleOf(canvasElement);
+      expect(node).not.toBeNull();
+      return node;
+    });
+    await expect(getComputedStyle(bubble).visibility).toBe('hidden');
+    // And it never eats a click meant for the chart underneath it.
+    await expect(getComputedStyle(bubble).pointerEvents).toBe('none');
+    await expect(bubble.textContent?.trim()).toBe('');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The frame every existing chart story shows, held here on purpose as the thing the ' +
+          'stories below are different from: a chart with a real box, and a bubble mounted inside ' +
+          'it with nothing in it. On the line chart, because the bar canvas has no box to show ' +
+          'at rest - see the story below.',
+      },
+    },
+  },
+};
+
+export const BarTooltip: Story = {
+  name: 'Bars: hover opens the bubble',
+  play: async ({ canvasElement }) => {
+    await waitFor(() => expect(canvasElement.querySelector('.recharts-surface')).not.toBeNull());
+
+    const container = canvasElement.querySelector('.recharts-responsive-container') as HTMLElement;
+    const wrapper = wrapperOf(canvasElement);
+    const surface = canvasElement.querySelector('.recharts-surface') as SVGSVGElement;
+
+    /* recharts measured the room and laid out every bar in it. */
+    await waitFor(() => {
+      expect(container.getBoundingClientRect().height).toBe(CHART_HEIGHT);
+      expect(canvasElement.querySelectorAll('.recharts-bar')).toHaveLength(APPOINTMENT_KEYS.length);
+      expect(canvasElement.querySelectorAll('.recharts-bar-rectangle')).toHaveLength(
+        BAR_RECTANGLE_COUNT
+      );
+    });
+
+    /* THE REGRESSION GUARD. This canvas used to lay out at 0x0 while those bar
+       rectangles sat inside it, so every bar chart in the product - the dashboard
+       default, since `DynamicChartCard`'s `type` defaults to 'bar' - painted an empty
+       rectangle. The cause was a `style={{ width: '100%', height: '100%' }}` on
+       `<BarChart>`: recharts spreads a caller's style LAST over the pixel size it
+       measured, and `ResponsiveContainer` deliberately gives its inner div `width: 0`
+       (its documented shrink trick - the chart is meant to overflow it). 100% of 0 is
+       0, the SVG clipped at its own edge, and nothing warned, because recharts believed
+       the chart was 620x240.
+
+       Assert the BOX, not just the bars: bars in a zero-size box are exactly what the
+       defect looked like. If that style ever returns, this fails here. */
+    await waitFor(() => {
+      expect(wrapper.getBoundingClientRect().width).toBeGreaterThan(0);
+      expect(wrapper.getBoundingClientRect().height).toBe(CHART_HEIGHT);
+      expect(surface.getBoundingClientRect().width).toBeGreaterThan(0);
+    });
+    await expect(wrapper.style.width).not.toBe('100%');
+
+    /* And with a real box there is a real plot area, so a pointer position maps to a
+       data index and the bubble opens - the surface this story was written for and
+       could not reach while the canvas was collapsed. */
+    movePointerOverPlot(wrapper, 0.5);
+    await waitFor(() =>
+      expect(getComputedStyle(bubbleOf(canvasElement)).visibility).toBe('visible')
+    );
+    const items = bubbleItems(canvasElement);
+    await expect(Object.keys(items).length).toBeGreaterThan(0);
+    await expect(bubbleLabel(canvasElement)).not.toBe('');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The bar canvas with its tooltip open. This story previously pinned a defect: the ' +
+          'wrapper and the SVG laid out at 0x0 while thirteen bar rectangles sat inside them, so ' +
+          'every bar chart in the product rendered as a blank frame. The `style` prop that caused ' +
+          'it is gone from `BarChartContent`, and the box assertions above are what keep it gone - ' +
+          'a chart can have all of its bars and still show nothing.',
+      },
+    },
+  },
+};
+
+export const LineTooltipWithFormatter: Story = {
+  name: 'Line: label through a formatter',
+  args: LINE_ARGS,
+  play: async ({ canvasElement }) => {
+    await waitFor(() => expect(canvasElement.querySelector('.recharts-surface')).not.toBeNull());
+    const wrapper = wrapperOf(canvasElement);
+
+    /* The control for the story above: same component, same ResponsiveContainer,
+       and a real box - because `LineChartContent` passes no `style` prop, so the
+       pixel width and height recharts wrote onto the wrapper survive. If someone
+       ever copies the bar chart's `style` across, this line fails first. */
+    await waitFor(() => {
+      expect(wrapper.getBoundingClientRect().width).toBeGreaterThan(0);
+      expect(wrapper.getBoundingClientRect().height).toBe(CHART_HEIGHT);
+    });
+
+    movePointerOverPlot(wrapper, 0.5);
+
+    await waitFor(() =>
+      expect(getComputedStyle(bubbleOf(canvasElement)).visibility).toBe('visible')
+    );
+
+    // `tooltipLabelFormatter` is the ONE hook this file gives a caller over the
+    // bubble, and it touches the label only - so the label is prefixed while the
+    // value below it is still the raw, unformatted number, `yTickFormatter`
+    // notwithstanding. That asymmetry is the point of this story.
+    const label = bubbleLabel(canvasElement);
+    await expect(label).toMatch(/^Month of /);
+    const month = label.replace('Month of ', '');
+    const datum = REVENUE.find((point) => point.month === month);
+    await expect(datum).toBeDefined();
+    await expect(bubbleItems(canvasElement)).toEqual({ Revenue: String(datum?.Revenue) });
+
+    /* The unstyled part, asserted rather than described: recharts writes these as
+       inline styles, so they win over every token in the design system and the
+       bubble reads the same in dark mode. Polled rather than read once - the
+       content element is re-rendered as the payload lands, and a single
+       synchronous read can catch the frame before it carries its own style. */
+    await waitFor(() => {
+      const content = bubbleOf(canvasElement).querySelector(
+        '.recharts-default-tooltip'
+      ) as HTMLElement;
+      expect(getComputedStyle(content).backgroundColor).toBe('rgb(255, 255, 255)');
+      expect(getComputedStyle(content).borderColor).toBe('rgb(204, 204, 204)');
+    });
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The revenue trend, and the only chart shape in this file that reaches the screen. The ' +
+          'Y ticks are formatted to `$12k` by `yTickFormatter`, and the tooltip prints `12400` - ' +
+          'two different renderings of one number, a step apart on the same chart. The white box ' +
+          'and grey border are recharts defaults, asserted here rather than described.',
+      },
+    },
+  },
+};
+
+export const TooltipClosesOnLeave: Story = {
+  name: 'Leaving the plot closes it',
+  args: LINE_ARGS,
+  play: async ({ canvasElement }) => {
+    await waitFor(() => expect(canvasElement.querySelector('.recharts-surface')).not.toBeNull());
+    const wrapper = wrapperOf(canvasElement);
+    await waitFor(() => expect(wrapper.getBoundingClientRect().width).toBeGreaterThan(0));
+
+    movePointerOverPlot(wrapper, 0.35);
+    await waitFor(() =>
+      expect(getComputedStyle(bubbleOf(canvasElement)).visibility).toBe('visible')
+    );
+    const openLabel = bubbleLabel(canvasElement);
+    await expect(openLabel).toMatch(/^Month of /);
+    await expect(REVENUE.some((point) => `Month of ${point.month}` === openLabel)).toBe(true);
+
+    movePointerOffPlot(wrapper);
+
+    /* Hidden again rather than unmounted. Going inactive also drops the payload -
+       recharts substitutes an empty one, so `DefaultTooltipContent` renders no
+       item rows and the label collapses to an empty `<p>` - which means the
+       closed bubble is byte-for-byte the resting bubble from the first story, and
+       neither the visibility nor the emptied content can be checked alone. */
+    await waitFor(() =>
+      expect(getComputedStyle(bubbleOf(canvasElement)).visibility).toBe('hidden')
+    );
+    await waitFor(() => expect(bubbleItems(canvasElement)).toEqual({}));
+    await expect(bubbleOf(canvasElement).textContent?.trim()).toBe('');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The close path, on the line chart - the bar canvas has no plot to leave. The wrapper ' +
+          'keeps a `transform` transition while it is active, but nothing animates `visibility`, ' +
+          'so there is no fade and no delay - on a dashboard of several charts the bubble ' +
+          'disappears the instant the pointer crosses a card edge.',
+      },
+    },
+  },
+};

--- a/apps/frontend/src/app/ui/widgets/DynamicChart/ChartCanvas.tsx
+++ b/apps/frontend/src/app/ui/widgets/DynamicChart/ChartCanvas.tsx
@@ -158,14 +158,16 @@ const BarChartContent = ({
   barSize,
   compactMonthAxis,
 }: BarChartContentProps) => (
-  <BarChart
-    data={data}
-    layout={layout}
-    style={{ height: '100%', maxHeight: '100%', width: '100%', maxWidth: '100%' }}
-    margin={chartMargin}
-    width={width}
-    height={height}
-  >
+  /* No `style` here, deliberately, and it must stay that way. `ResponsiveContainer`
+     gives its inner div `width: 0` on purpose (recharts' own shrink trick - the chart
+     is meant to overflow it at the pixel size recharts measured), and recharts spreads
+     a caller's `style` LAST over that measured size. So `width: '100%'` resolved to
+     100% of 0px: the wrapper and the SVG both laid out at 0x0 while 13 bar rectangles
+     sat inside them, and every bar chart in the product - the dashboard default, since
+     DynamicChartCard's `type` defaults to 'bar' - painted nothing at all. Nothing
+     warned, because recharts believed the chart was 620x240. LineChart never passed a
+     style and never had the problem. */
+  <BarChart data={data} layout={layout} margin={chartMargin} width={width} height={height}>
     {!hideYAxis && <CartesianGrid strokeDasharray="4 4" vertical={false} />}
     <XAxis
       dataKey={isVerticalLayout ? undefined : 'month'}

--- a/apps/frontend/src/app/ui/widgets/Summary/AppointmentTask.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/Summary/AppointmentTask.stories.tsx
@@ -1,0 +1,465 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import type { Appointment, UserOrganization } from '@yosemite-crew/types';
+
+import type { Task } from '@/app/features/tasks/types/task';
+import type { Team } from '@/app/features/organization/types/team';
+import { useAppointmentStore } from '@/app/stores/appointmentStore';
+import { useFormsStore } from '@/app/stores/formsStore';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useTaskStore } from '@/app/stores/taskStore';
+import { useTeamStore } from '@/app/stores/teamStore';
+import AppointmentTask from './AppointmentTask';
+
+const ORG_ID = 'org-schedule-widget-story';
+const ELENA = 'practitioner-elena';
+const RAVI = 'practitioner-ravi';
+
+/**
+ * A receptionist membership. `usePermissions` derives the effective set from
+ * `roleCode` against the role table, so seeding the role is enough - and this
+ * widget is wrapped in a `PermissionGate` requiring both `appointments:view:any`
+ * and `tasks:view:any`, so without it the story renders nothing at all.
+ */
+const MEMBERSHIP: UserOrganization = {
+  practitionerReference: `Practitioner/${ELENA}`,
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'RECEPTIONIST',
+  roleDisplay: 'Receptionist',
+  active: true,
+};
+
+const member = (id: string, name: string): Team => ({
+  _id: id,
+  practionerId: id,
+  organisationId: ORG_ID,
+  name,
+  role: 'VETERINARIAN',
+  speciality: [],
+  status: 'Available',
+  revokedPermissions: [],
+  effectivePermissions: [],
+  extraPerissions: [],
+});
+
+const TEAM: Team[] = [member(ELENA, 'Dr. Elena Marsh'), member(RAVI, 'Dr. Ravi Patel')];
+
+const appointment = (id: string, name: string, parent: string, hour: string): Appointment => {
+  const patient: Appointment['patient'] = {
+    id: `companion-${id}`,
+    name,
+    species: 'Dog',
+    breed: 'Beagle',
+    parent: { id: `parent-${id}`, name: parent },
+  };
+  return {
+    id,
+    organisationId: ORG_ID,
+    patient,
+    companion: patient,
+    appointmentType: {
+      id: 'svc-annual',
+      name: 'Annual check-up',
+      speciality: { id: 'spec-general', name: 'General practice' },
+    },
+    appointmentDate: new Date(`2026-08-19T${hour}:00.000Z`),
+    startTime: new Date(`2026-08-19T${hour}:00.000Z`),
+    endTime: new Date(`2026-08-19T${hour}:00.000Z`),
+    timeSlot: '09:30 AM',
+    durationMinutes: 30,
+    status: 'UPCOMING',
+    concern: 'Annual boosters and a weight check.',
+  };
+};
+
+const APPOINTMENTS: Appointment[] = [
+  appointment('appointment-1', 'Kizie', 'Sky Doe', '09:30'),
+  appointment('appointment-2', 'Bailey', 'Marta Lang', '10:15'),
+  appointment('appointment-3', 'Nala', 'Ana Ferreira', '11:00'),
+];
+
+const task = (over: Partial<Task> & Pick<Task, '_id' | 'name' | 'status'>): Task => ({
+  organisationId: ORG_ID,
+  assignedBy: ELENA,
+  assignedTo: RAVI,
+  audience: 'EMPLOYEE_TASK',
+  source: 'CUSTOM',
+  category: 'MEDICATION',
+  description: 'Recorded against the inpatient chart.',
+  dueAt: new Date('2026-08-19T12:00:00.000Z'),
+  ...over,
+});
+
+const TASKS: Task[] = [
+  task({ _id: 'task-1', name: 'Midday analgesia round', status: 'PENDING' }),
+  task({
+    _id: 'task-2',
+    name: 'Kennel 3 deep clean',
+    status: 'IN_PROGRESS',
+    category: 'HUSBANDRY',
+    description: 'Between the morning and afternoon lists.',
+  }),
+  task({
+    _id: 'task-3',
+    name: 'Discharge call, Bailey',
+    status: 'COMPLETED',
+    category: 'COMMUNICATION',
+    description: 'Confirm the owner collected the take-home meds.',
+  }),
+  task({
+    _id: 'task-4',
+    name: 'Vaccine fridge log',
+    status: 'PENDING',
+    category: 'COMPLIANCE',
+    description: 'Twice-daily temperature reading.',
+  }),
+];
+
+/**
+ * Seeds the five stores the widget reads, so the mount is offline.
+ *
+ * The team seed is load-bearing twice over: `useLoadTeam` bails out on its first
+ * line once the org key exists (no request), and the Tasks table resolves its
+ * From/To columns through the same store, so without it those cells print raw
+ * practitioner ids. The forms seed silences `useLoadFormsForPrimaryOrg` in the
+ * detail modal.
+ *
+ * Two requests are still attempted and caught, both from modals that are mounted
+ * CLOSED behind the widget: `AppointmentInfo` fetches the selected appointment's
+ * forms (guarded by the appointment id, not by `showModal`), and `Reschedule`
+ * asks for slots for its appointment type. Both fail into their own catch blocks
+ * inside dialogs nobody opens here, and neither touches the surface under review.
+ */
+const seedStores = () => {
+  useOrgStore.setState({
+    primaryOrgId: ORG_ID,
+    membershipsByOrgId: { [ORG_ID]: MEMBERSHIP },
+    status: 'loaded',
+  });
+  useTeamStore.getState().setTeamsForOrg(ORG_ID, TEAM);
+  useAppointmentStore.getState().setAppointmentsForOrg(ORG_ID, APPOINTMENTS);
+  useTaskStore.getState().setTasksForOrg(ORG_ID, TASKS);
+  useFormsStore.setState({ lastFetchedByOrgId: { [ORG_ID]: '2026-08-19T00:00:00.000Z' } });
+};
+
+/**
+ * The one visible table. Only one of the two tables is rendered at a time, but the
+ * matching `PaginatedCardList` is always rendered beside it (hidden above 1280),
+ * so every task name exists twice in the DOM - queries have to be scoped to the
+ * table or they see both.
+ */
+const table = (canvasElement: HTMLElement) => canvasElement.querySelector('table') as HTMLElement;
+
+const columnLabels = (canvasElement: HTMLElement): string[] =>
+  [...table(canvasElement).querySelectorAll('thead th')].map((cell) =>
+    (cell.textContent ?? '').trim()
+  );
+
+/**
+ * Blocks until nothing in the document has fired a `scroll` event for `quietMs`.
+ *
+ * This is not flake padding, it is a workaround for the defect the
+ * `DismissedByAnUnrelatedScroll` block below asserts on purpose.
+ * `useFilterDropdownDismiss` closes the status panel on EVERY scroll event captured at
+ * the window, with no check that the scrolled node could move the panel's anchor - and
+ * this widget mounts a `Reschedule` dialog CLOSED behind itself, whose `Slotpicker`
+ * runs a `behavior: 'smooth'` `scrollTo` on its date strip when its slot request
+ * settles. That animation streams a scroll event every ~17ms for ~700ms, so a panel
+ * opened inside that window is shut about 15ms later, from a subtree nobody can see.
+ */
+const waitForScrollQuiet = async (quietMs = 250, timeoutMs = 4000) => {
+  let last = performance.now();
+  const onScroll = () => {
+    last = performance.now();
+  };
+  globalThis.window.addEventListener('scroll', onScroll, true);
+  try {
+    const deadline = performance.now() + timeoutMs;
+    while (performance.now() - last < quietMs && performance.now() < deadline) {
+      await new Promise((resolve) => {
+        globalThis.setTimeout(resolve, 60);
+      });
+    }
+  } finally {
+    globalThis.window.removeEventListener('scroll', onScroll, true);
+  }
+};
+
+/** The status-filter panel portals to `document.body`, outside the canvas. */
+const openStatusFilter = async (canvas: ReturnType<typeof within>, current: string) => {
+  await waitForScrollQuiet();
+  await userEvent.click(canvas.getByRole('button', { name: current }));
+  return waitFor(() => {
+    const panels = document.querySelectorAll('.yc-glass-overlay');
+    expect(panels.length).toBeGreaterThan(0);
+    return panels[panels.length - 1] as HTMLElement;
+  });
+};
+
+/**
+ * Option NAMES in the status panel.
+ *
+ * The trailing check is stripped: `StatusOptionButtons` renders the tick as a
+ * third `<span>` inside the same button as the label, so the selected row's
+ * `textContent` is "All\u2713" and a raw read never matches the option list it is
+ * being compared against. `checkedStatus` below asserts the tick separately, so
+ * dropping it here loses nothing.
+ */
+const statusOptions = (panel: HTMLElement): string[] =>
+  [...panel.querySelectorAll('button')].map((option) =>
+    (option.textContent ?? '').replaceAll('\u2713', '').trim()
+  );
+
+/** The single option carrying the tick, i.e. the one the filter is currently on. */
+const checkedStatus = (panel: HTMLElement): string[] =>
+  [...panel.querySelectorAll('button')]
+    .filter((option) => (option.textContent ?? '').includes('\u2713'))
+    .map((option) => (option.textContent ?? '').replaceAll('\u2713', '').trim());
+
+const meta = {
+  title: 'Widgets/Summary/AppointmentTask',
+  component: AppointmentTask,
+  parameters: {
+    layout: 'fullscreen',
+    nextjs: { appDirectory: true },
+    docs: {
+      description: {
+        component:
+          'The Schedule widget on the dashboard, which is really two widgets behind one segmented ' +
+          'pill. Only the Appointments side had ever been drawn.\n\n' +
+          'Switching to **Tasks** swaps three things at once, none of which is a filter over the ' +
+          'same rows: a different table (eight task columns for ten appointment ones), a different ' +
+          'status set in the filter control (Pending/In progress/Completed/Cancelled, against the ' +
+          'appointment lifecycle of Requested/Upcoming/Checked in/...), and a different footer link ' +
+          '(`/tasks` rather than `/appointments`). The heading count and the "Showing n of n" line ' +
+          'follow the active side too.\n\n' +
+          'The swap also resets state that is easy to forget: `resetActiveTableState` puts the ' +
+          'status filter back to All and closes any open appointment popup, so a reader who ' +
+          'filtered Appointments to "Cancelled" and pressed Tasks does not land on a Tasks list ' +
+          'silently filtered by a status tasks do not have.\n\n' +
+          'Both tables run at the dashboard `small` page size of five, and the footer caption is ' +
+          'hard-coded to that same five - it reports `Showing 5 of 12`, not the row count the ' +
+          'auto-fitting table may actually have drawn.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  beforeEach: seedStores,
+  decorators: [
+    (Story) => (
+      <div className="h-[620px] w-full bg-[var(--screen)] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof AppointmentTask>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const AppointmentsHalf: Story = {
+  name: 'Appointments (the default half)',
+  /* Pinned to 1440 as a GLOBAL, not a parameter - `parameters.viewport` selection
+     was removed in Storybook 10 and is inert. 1440 rather than the 1280 laptop
+     default because `.table-list` is hidden at `max-width: 1279.98px` while the
+     card band is `xl:hidden` (min-width 1280): at exactly 1280 a preview
+     scrollbar decides which of the two markups these stories assert against. */
+  globals: { viewport: { value: 'desktop', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole('button', { name: 'Appointments' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    await expect(canvas.getByRole('button', { name: 'Tasks' })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+
+    // The count in the heading is the APPOINTMENT count on this side.
+    await expect(canvas.getByRole('heading', { level: 2 }).textContent?.trim()).toBe(
+      'Schedule (3)'
+    );
+    await expect(columnLabels(canvasElement)).toContain('Date/Time');
+    await expect(columnLabels(canvasElement)).toContain('Lead');
+    /* "Kizie · Doe", not "Kizie". Every companion name in PIMS goes through
+       `formatCompanionNameWithOwnerLastName`, which appends the owner's LAST name - so
+       the seeded pair ("Kizie", "Sky Doe") renders as one composed string and the bare
+       fixture name never appears on its own. Both are asserted, because a regression
+       that drops the suffix would still satisfy a substring match. */
+    await expect(within(table(canvasElement)).getByText('Kizie · Doe')).toBeInTheDocument();
+    await expect(within(table(canvasElement)).queryByText('Kizie')).not.toBeInTheDocument();
+
+    await expect(canvas.getByText(/^Showing \d+ of \d+$/).textContent).toBe('Showing 3 of 3');
+    await expect(canvas.getByRole('link', { name: /Open appointments/ })).toHaveAttribute(
+      'href',
+      '/appointments'
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The side the dashboard opens on, kept here as the frame every assertion in the Tasks ' +
+          'story is measured against.',
+      },
+    },
+  },
+};
+
+export const TasksHalf: Story = {
+  name: 'Tasks (the undrawn half)',
+  globals: { viewport: { value: 'desktop', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Tasks' }));
+
+    /* The whole column set is replaced, not filtered. Asserted as an exact list,
+       because a swap that rendered the Tasks DATA into the appointment columns
+       would still satisfy any single-header lookup. */
+    await waitFor(() =>
+      expect(columnLabels(canvasElement)).toEqual([
+        'Task',
+        'Description',
+        'Category',
+        'From',
+        'To',
+        'Due date',
+        'Status',
+        'Actions',
+      ])
+    );
+
+    const taskTable = within(table(canvasElement));
+    await expect(taskTable.getByText('Midday analgesia round')).toBeInTheDocument();
+    // From/To resolve through the team store rather than printing practitioner
+    // ids, which is the one thing the seeded team is visible in.
+    await expect(taskTable.getAllByText('Dr. Ravi Patel')).toHaveLength(4);
+    // The composed name the appointments table would have drawn (see AppointmentsHalf).
+    // Querying the bare fixture name here would pass on BOTH tables and prove nothing.
+    await expect(taskTable.queryByText('Kizie · Doe')).not.toBeInTheDocument();
+
+    // The heading, the caption and the link all follow the active side.
+    await expect(canvas.getByRole('heading', { level: 2 }).textContent?.trim()).toBe(
+      'Schedule (4)'
+    );
+    await expect(canvas.getByText(/^Showing \d+ of \d+$/).textContent).toBe('Showing 4 of 4');
+    await expect(canvas.getByRole('link', { name: /Open tasks/ })).toHaveAttribute(
+      'href',
+      '/tasks'
+    );
+    await expect(canvas.queryByRole('link', { name: /Open appointments/ })).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The Tasks table at the dashboard `small` page size. It is a wider table than the ' +
+          'appointment one in practice - Description is a two-line clamp and the action rail needs ' +
+          '176px - so this is also where the widget is most likely to need a horizontal scroll.',
+      },
+    },
+  },
+};
+
+export const TaskStatusFilters: Story = {
+  name: 'Tasks: the status set swaps too',
+  globals: { viewport: { value: 'desktop', isRotated: false } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // The appointment lifecycle first, so the two lists can be compared.
+    const appointmentPanel = await openStatusFilter(canvas, 'All statuses');
+    await expect(statusOptions(appointmentPanel)).toEqual([
+      'All',
+      'Requested',
+      'Upcoming',
+      'Checked in',
+      'In progress',
+      'Completed',
+      'Cancelled',
+      'No show',
+    ]);
+    // Nothing is filtered yet, so the tick is on All - which is also the baseline
+    // the reset below has to come back to.
+    await expect(checkedStatus(appointmentPanel)).toEqual(['All']);
+
+    /* Pressing Tasks is itself the outside click that dismisses the panel - the
+       dropdown closes on any mousedown outside the trigger, and has no Escape
+       handler at all. Waiting for it to go is what keeps the reopen below from
+       toggling the trigger shut instead. */
+    await userEvent.click(canvas.getByRole('button', { name: 'Tasks' }));
+    await waitFor(() => expect(document.body.contains(appointmentPanel)).toBe(false));
+    const taskPanel = await openStatusFilter(canvas, 'All statuses');
+    await expect(statusOptions(taskPanel)).toEqual([
+      'All',
+      'Pending',
+      'In progress',
+      'Completed',
+      'Cancelled',
+    ]);
+    /* Back on All rather than on whatever the appointment side was: this is
+       `resetActiveTableState` doing its job, and it is the assertion that would
+       catch a Tasks list silently filtered by a status tasks do not have. */
+    await expect(checkedStatus(taskPanel)).toEqual(['All']);
+
+    /* DismissedByAnUnrelatedScroll - THE DEFECT, asserted rather than only worked
+       around. `useFilterDropdownDismiss` registers `scroll` on the window with
+       `capture: true` and calls `setOpen(false)` for every event it sees, without
+       checking that the scrolled node is an ancestor of the trigger or of the panel. So
+       a scroll in a subtree that cannot move this panel by a single pixel still shuts
+       it. `document.body` is used here because it makes the demonstration
+       deterministic - a capturing window listener receives the event on its way down,
+       and body is provably not an ancestor of a `position: fixed` portal anchored to the
+       trigger.
+
+       In the product it arrives unprompted. This widget mounts a `Reschedule` dialog
+       CLOSED behind itself; its `Slotpicker` centres the selected date with
+       `strip.scrollTo({ behavior: 'smooth' })` as soon as the slot request settles, and
+       that animation fires ~40 scroll events over ~700ms. A reader who opens the status
+       filter in that window watches it close under their cursor for no visible reason,
+       from a dialog they never opened. `waitForScrollQuiet` above exists only so the
+       rest of this story survives it.
+
+       This block should FAIL - and be deleted - the day the dismissal is scoped to
+       scrolls that can actually move the panel. */
+    await expect(document.body.contains(taskPanel)).toBe(true);
+    document.body.dispatchEvent(new Event('scroll'));
+    await waitFor(() => expect(document.body.contains(taskPanel)).toBe(false));
+
+    // And it filters the list it belongs to: one of the four tasks is completed.
+    const reopenedPanel = await openStatusFilter(canvas, 'All statuses');
+    await expect(checkedStatus(reopenedPanel)).toEqual(['All']);
+    await userEvent.click(within(reopenedPanel).getByText('Completed'));
+    await waitFor(() =>
+      expect(canvas.getByText(/^Showing \d+ of \d+$/).textContent).toBe('Showing 1 of 1')
+    );
+    const taskTable = within(table(canvasElement));
+    await expect(taskTable.getByText('Discharge call, Bailey')).toBeInTheDocument();
+    await expect(taskTable.queryByText('Midday analgesia round')).not.toBeInTheDocument();
+    // The heading count is the FULL task count, not the filtered one - the two
+    // numbers on this widget mean different things.
+    await expect(canvas.getByRole('heading', { level: 2 }).textContent?.trim()).toBe(
+      'Schedule (4)'
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Four appointment statuses have no task equivalent and vice versa, so this control is a ' +
+          'different control on each side of the pill even though it never moves or changes shape. ' +
+          'The trigger reads "All statuses" in both cases, which is the only label a reader sees ' +
+          'before opening it.\n\n' +
+          '**This story also pins a live defect.** `useFilterDropdownDismiss` closes the panel on ' +
+          'any `scroll` captured at the window, whoever fired it. The `Reschedule` dialog this ' +
+          'widget mounts CLOSED behind itself smooth-scrolls its `Slotpicker` date strip for about ' +
+          '700ms once its slot request settles, and every frame of that animation slams the status ' +
+          'filter shut - so on the dashboard the control is unusable for the first second after the ' +
+          'widget settles, and intermittently after that. The story asserts the dismissal is ' +
+          'unscoped instead of waiting the bug out silently.',
+      },
+    },
+  },
+};


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

**Every bar chart in PIMS renders as a blank rectangle - including the dashboard, where `bar` is the default chart type.**

`BarChartContent` passes `style={{ width: '100%', height: '100%' }}` to `<BarChart>`. recharts spreads a caller's `style` LAST over the pixel size it measured, and `ResponsiveContainer` deliberately gives its inner div `width: 0` (its documented shrink trick - the chart is meant to overflow it at its own size). 100% of 0 is 0.

Measured against a real build:

| | wrapper | svg surface | bar rectangles |
| --- | --- | --- | --- |
| before | **0x0** | **0x0** | 13 |
| after | 578x300 | 620x240 | 13 |

Thirteen bars laid out correctly inside a box with no area. Nothing warned - recharts believed the chart was 620x240, so its own "width and height should be greater than 0" guard never fired. `LineChart` passes no style and was never affected, which is exactly why only the bar stories failed.

The previous batch (#2292) closed the triage list, not the codebase. That list came from an audit that never checked whether a revealed surface already had its own story, so it over-reported blocked surfaces - and, being scoped to what it had already flagged, under-reported everything else.

## What is the new behavior?

The style is gone from `BarChartContent`, and the story that pinned the defect is rewritten as the bubble story it was meant to be. It asserts the **box** as well as the bars, because a chart can have every bar and still show nothing.

A fresh scan found 161 components with a gated-surface pattern and no story of their own. An independent audit - with an adversarial pass re-checking every "already covered" and "no real gate" claim against the actual story file - resolved them to:

| Verdict | Count |
| --- | --- |
| **Genuinely undrawn gated surface** | **93** |
| Pattern matched, no real gate | 35 |
| Real but not worth drawing | 21 |
| Covered via a parent or its own story | 11 |

**All 93 are now drawn. Storybook goes 1366 -> 1853 stories, and 1853/1853 render and play clean against a real build.**

### Product files touched

Ten. Eight are a single `export` plus a comment saying why. Two are refactors, both verified behaviour-preserving before acceptance:

- `StripeOnboarding` extracts `StripeSetupStatus` - branch logic maps onto the old inline conditions, classes and ARIA byte-identical.
- `LinkedMedicalDevices` splits container from card - effect body and refresh handler byte-identical after normalising, user-visible string set unchanged.

33 tests across the two pass; 1347 tests across the wider touched areas pass.

### Recorded, not changed - both are decisions rather than bug fixes

- **`border-[1.5px]` renders as 1px.** Measured in Chromium at devicePixelRatio 1 AND 2 - sub-pixel border widths are floored to whole device pixels. 42 places ask for it (every form input, dropdown, datepicker, timepicker), so the "heavier" selected border is identical to the resting hairline everywhere. Noted on #2297.
- **The TeamOnboarding stepper cannot be exercised in Storybook.** `@storybook/nextjs-vite` resolves `next/dynamic` to the pages-router loadable, which consumes the caller's ref and publishes `{ retry }`, so `stepRefs[i].current.validate()` throws. An environment artefact, not a product defect - the real Next build aliases to `app-dynamic`. The story documents it and does NOT drive the click, rather than asserting the outcome of a crash.

### The pinning strategy proved itself mid-flight

#2298 landed on dev while this branch was being built and removed the `!important` font-weight overrides. Four stories pinned to the OLD broken values began failing **inverted** - `expected '700' to be '500'`, `expected '11px' to be '12px'`. They failed because the bug was fixed. A story asserting only "the class is present" would have sailed straight through.

## Impact area

`apps/frontend` - Storybook coverage across appointments, organization, onboarding, auth, tasks, finance, settings, inventory, integrations, chat, forms and the shared `ui` layer; plus one product fix in `ui/widgets/DynamicChart/ChartCanvas.tsx`.

## Validation performed

- `npx tsc --noemit` clean; `pnpm --filter frontend run lint` clean (1 pre-existing warning).
- Storybook built and **every story executed** - not merely rendered - via a Playwright runner listening on `playFunctionThrewException`.
- **The suite was run three times, not once.** Two runs were clean at 1853/1853. One failed two arbitrary stories - including a pre-existing one - with an identical error carrying a minified axe-core symbol, i.e. the a11y addon walking the DOM while a play function mutates it. That is harness contention rather than the stories, and it is named here rather than hidden behind a single green run.
- The bar-chart fix is verified by measurement (table above), not by inspection.

Nothing in CI executes play functions yet (#2281), which is why none of this was catchable by a green build.
