### PR TITLE
fix(desktop): configure the WasmTrapHandlers fuse

### DIFF
--- a/apps/desktop/scripts/apply-fuses.js
+++ b/apps/desktop/scripts/apply-fuses.js
@@ -60,6 +60,11 @@ exports.default = async function applyElectronFuses(context) {
     // Local splash/welcome/offline pages load via file:// and need standard
     // file-protocol privileges to render in a packaged build.
     [FuseV1Options.GrantFileProtocolExtraPrivileges]: true,
+    // Added in @electron/fuses 2.1. `strictlyRequireAllFuses` above means a new
+    // fuse fails the build rather than defaulting silently, which is why the
+    // v0.1.0-beta.4 tag could not produce installers. `true` is the upstream
+    // default, so the packaged runtime behaves as it did before the bump.
+    [FuseV1Options.WasmTrapHandlers]: true,
   });
   patchMacInfoPlist(context);
 };

--- a/apps/desktop/tests/apply-fuses.test.ts
+++ b/apps/desktop/tests/apply-fuses.test.ts
@@ -1,0 +1,45 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * `apply-fuses.js` sets `strictlyRequireAllFuses: true`, so @electron/fuses
+ * refuses to build when a fuse is left unconfigured. That is the right default,
+ * but the failure only surfaced at release time: the 2.1 bump added
+ * `WasmTrapHandlers`, and the v0.1.0-beta.4 tag failed on both runners after the
+ * signed-build jobs had already been approved and started.
+ *
+ * This turns it into a PR-time failure. The fuse list is read from the INSTALLED
+ * package rather than hardcoded, so a bump that adds another fuse fails here.
+ * It is read as text because @electron/fuses is ESM-only and this suite is CJS.
+ */
+describe('apply-fuses', () => {
+  const desktopRoot = path.join(__dirname, '..');
+  const source = fs.readFileSync(path.join(desktopRoot, 'scripts', 'apply-fuses.js'), 'utf8');
+  const fuseTypes = fs.readFileSync(
+    path.join(desktopRoot, 'node_modules', '@electron', 'fuses', 'dist', 'config.d.ts'),
+    'utf8'
+  );
+
+  const declaredFuses = (): string[] => {
+    const block = /export declare enum FuseV1Options \{([^}]*)\}/.exec(fuseTypes);
+    if (!block) throw new Error('FuseV1Options enum not found in @electron/fuses types');
+    return [...block[1].matchAll(/^\s*([A-Za-z0-9]+)\s*=/gm)].map((m) => m[1]);
+  };
+
+  it('reads a non-empty fuse list from the installed package', () => {
+    // Guards the regex above: if it ever matches nothing, the completeness
+    // assertion below would pass vacuously.
+    expect(declaredFuses().length).toBeGreaterThanOrEqual(8);
+  });
+
+  it('configures every fuse the installed @electron/fuses knows about', () => {
+    const missing = declaredFuses().filter((name) => !source.includes(`FuseV1Options.${name}`));
+    expect(missing).toEqual([]);
+  });
+
+  it('still requires all fuses explicitly', () => {
+    // If this is relaxed the check above stops meaning anything: an
+    // unconfigured fuse would take its default silently instead of failing.
+    expect(source).toContain('strictlyRequireAllFuses: true');
+  });
+});


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

The desktop release is unbuildable. Tagging `v0.1.0-beta.4` produced this on both runners:

```
⨯ strictlyRequireAllFuses: Missing explicit configuration for fuse WasmTrapHandlers  failedTask=build
```

`@electron/fuses` 2.1 added a ninth fuse, `WasmTrapHandlers`. `apps/desktop/scripts/apply-fuses.js` sets `strictlyRequireAllFuses: true`, which is correct: an unconfigured fuse fails the build rather than silently taking a default. But nothing checked the config against the package until the packager ran, so the gap only appeared at release time, after both signed-build jobs had been approved and started.

## What is the new behavior?

`WasmTrapHandlers` is set to `true`. That is the upstream default and the value the package's own README documents ("Enables V8 signal handlers to trap Out of Bounds memory access from WebAssembly"), so the packaged runtime behaves exactly as it did before the bump.

A test now reads the fuse list out of the **installed** `@electron/fuses` type definitions and asserts `apply-fuses.js` covers every one. The list is not hardcoded, so the next bump that adds a fuse fails in a pull request rather than at release time. It reads the types as text because `@electron/fuses` is ESM only (`"type": "module"`, single `./dist/index.js` export) while this suite is CJS, so neither a normal nor a deep import works under ts-jest.

The suite has three assertions rather than one: a guard that the enum regex matched something, the completeness check, and a check that `strictlyRequireAllFuses` is still `true`. Without the first, a regex that stopped matching would make the completeness check pass vacuously. Without the third, relaxing the strict flag would quietly make the whole thing meaningless.

## Impact area

`apps/desktop` only. No runtime source changes: one line of packaging configuration and one new test file.

## Validation performed

- `npx jest apply-fuses` - 3 passed
- Mutation checks, both independently red:
  - removing the `WasmTrapHandlers` line (the exact v0.1.0-beta.4 failure) - 1 failed
  - flipping `strictlyRequireAllFuses` to `false` - 1 failed
- Verified against the installed package that all 9 fuses are now configured, none missing
- Full monorepo pre-push gate: lint and type-check clean

## Related Issue(s)

Unblocks the desktop v0.1.0-beta.4 release. A separate finding from the same attempt: the `release` environment's deployment tag policies were `desktop-v*` and `mobile-v*`, but PR #2077 changed desktop tags to plain `v*` for electron-updater semver compatibility, so every desktop release since then would have been rejected by environment protection. A `v*` tag policy has been added.
