### PR TITLE
chore(repo): promote dev to main

### DIFF
--- a/apps/desktop/scripts/apply-fuses.js
+++ b/apps/desktop/scripts/apply-fuses.js
@@ -60,6 +60,11 @@ exports.default = async function applyElectronFuses(context) {
     // Local splash/welcome/offline pages load via file:// and need standard
     // file-protocol privileges to render in a packaged build.
     [FuseV1Options.GrantFileProtocolExtraPrivileges]: true,
+    // Added in @electron/fuses 2.1. `strictlyRequireAllFuses` above means a new
+    // fuse fails the build rather than defaulting silently, which is why the
+    // v0.1.0-beta.4 tag could not produce installers. `true` is the upstream
+    // default, so the packaged runtime behaves as it did before the bump.
+    [FuseV1Options.WasmTrapHandlers]: true,
   });
   patchMacInfoPlist(context);
 };

--- a/apps/desktop/tests/apply-fuses.test.ts
+++ b/apps/desktop/tests/apply-fuses.test.ts
@@ -1,0 +1,45 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * `apply-fuses.js` sets `strictlyRequireAllFuses: true`, so @electron/fuses
+ * refuses to build when a fuse is left unconfigured. That is the right default,
+ * but the failure only surfaced at release time: the 2.1 bump added
+ * `WasmTrapHandlers`, and the v0.1.0-beta.4 tag failed on both runners after the
+ * signed-build jobs had already been approved and started.
+ *
+ * This turns it into a PR-time failure. The fuse list is read from the INSTALLED
+ * package rather than hardcoded, so a bump that adds another fuse fails here.
+ * It is read as text because @electron/fuses is ESM-only and this suite is CJS.
+ */
+describe('apply-fuses', () => {
+  const desktopRoot = path.join(__dirname, '..');
+  const source = fs.readFileSync(path.join(desktopRoot, 'scripts', 'apply-fuses.js'), 'utf8');
+  const fuseTypes = fs.readFileSync(
+    path.join(desktopRoot, 'node_modules', '@electron', 'fuses', 'dist', 'config.d.ts'),
+    'utf8'
+  );
+
+  const declaredFuses = (): string[] => {
+    const block = /export declare enum FuseV1Options \{([^}]*)\}/.exec(fuseTypes);
+    if (!block) throw new Error('FuseV1Options enum not found in @electron/fuses types');
+    return [...block[1].matchAll(/^\s*([A-Za-z0-9]+)\s*=/gm)].map((m) => m[1]);
+  };
+
+  it('reads a non-empty fuse list from the installed package', () => {
+    // Guards the regex above: if it ever matches nothing, the completeness
+    // assertion below would pass vacuously.
+    expect(declaredFuses().length).toBeGreaterThanOrEqual(8);
+  });
+
+  it('configures every fuse the installed @electron/fuses knows about', () => {
+    const missing = declaredFuses().filter((name) => !source.includes(`FuseV1Options.${name}`));
+    expect(missing).toEqual([]);
+  });
+
+  it('still requires all fuses explicitly', () => {
+    // If this is relaxed the check above stops meaning anything: an
+    // unconfigured fuse would take its default silently instead of failing.
+    expect(source).toContain('strictlyRequireAllFuses: true');
+  });
+});


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

The desktop release is unbuildable. Tagging `v0.1.0-beta.4` failed on both runners:

```
⨯ strictlyRequireAllFuses: Missing explicit configuration for fuse WasmTrapHandlers
```

`@electron/fuses` 2.1 added a ninth fuse. `apply-fuses.js` sets `strictlyRequireAllFuses: true`, so the packager refuses to build rather than letting an unconfigured fuse take its default. Nothing checked the config against the package until the packager ran, so the gap only appeared after both signed-build jobs had been approved and started.

## What is the new behavior?

Promotes #2316. `WasmTrapHandlers` is set to `true`, the upstream default documented in the package README, so the packaged runtime is unchanged.

A new test reads the fuse list from the **installed** `@electron/fuses` types and asserts `apply-fuses.js` covers all of them, so the next bump that adds a fuse fails in a pull request rather than at release time.

## Impact area

`apps/desktop` only. One line of packaging config and one new test file. No runtime source changes.

## Validation performed

- All checks green on #2316, approved by aupyay
- `npx jest apply-fuses` - 3 passed
- Mutation checks, each independently red: removing the fuse line, and flipping `strictlyRequireAllFuses` to `false`
- All 9 fuses verified configured against the installed package

## Related Issue(s)

Unblocks the desktop `v0.1.0-beta.4` release. Separately, the `release` environment's deployment tag policies were `desktop-v*` and `mobile-v*` while PR #2077 moved desktop tags to plain `v*`, so environment protection rejected the tag before any build ran. A `v*` policy has been added.
