### PR TITLE
fix(mobile): unblock the release build on both platforms

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -169,7 +169,10 @@ jobs:
     name: iOS (TestFlight)
     if: github.event_name == 'push' || inputs.platform == 'both' || inputs.platform == 'ios'
     needs: preflight
-    runs-on: macos-14
+    # React Native 0.81 requires Xcode >= 16.1 (min_xcode_version_supported in
+    # react-native/scripts/cocoapods/helpers.rb). The macos-14 image ships 15.x,
+    # so `pod install` aborted with "Please upgrade XCode" before any build ran.
+    runs-on: macos-15
     environment: release
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/apps/mobileAppYC/android/build.gradle
+++ b/apps/mobileAppYC/android/build.gradle
@@ -5,7 +5,15 @@ buildscript {
         compileSdkVersion = 36
         targetSdkVersion = 36
         ndkVersion = "27.1.12297006"
+        // Pinned to what React Native 0.81 uses. Raising it here does NOT change the
+        // compiler: @react-native/gradle-plugin is an included build whose own catalog
+        // pins kotlin 2.1.20, and that wins for the modules RN applies the plugin to.
+        // Verified by setting this to 2.3.10 and watching the compile still report 2.1.
         kotlinVersion = "2.1.20"
+        // stripe-react-native defaults this to the floating range "23.1.+". The lockfile
+        // resolves it, so the version only moves when someone relocks, which is what
+        // 61b25145d did for stripe 0.61. Pinning it makes that movement explicit.
+        stripeVersion = "23.1.0"
     }
     repositories {
         google()
@@ -24,5 +32,17 @@ apply plugin: "com.facebook.react.rootproject"
 allprojects {
     dependencyLocking {
         lockAllConfigurations()
+    }
+
+    // stripe-react-native 0.61 requires com.stripe:stripe-android 23.x, whose classes
+    // carry Kotlin 2.3 metadata. React Native 0.81 pins the Kotlin plugin to 2.1.20 via
+    // its included build, and a 2.1 compiler reads metadata only up to 2.2, so
+    // :stripe_stripe-react-native:compileReleaseKotlin failed with "Incompatible classes
+    // were found in dependencies". The metadata is newer than the reader, not
+    // incompatible in substance, which is the case this flag exists for.
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+        compilerOptions {
+            freeCompilerArgs.add("-Xskip-metadata-version-check")
+        }
     }
 }


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

The `mobile-v1.6.0` tag failed on both runners. Preflight passed and the deployment was approved, so both jobs reached a real build before dying, for two unrelated reasons.

**iOS** aborted in `pod install`, before any compilation:

```
[!] Invalid `Podfile` file: Please upgrade XCode.
```

React Native 0.81 requires Xcode >= 16.1 (`min_xcode_version_supported` in `react-native/scripts/cocoapods/helpers.rb`). The job runs `macos-14`, which ships Xcode 15.x.

**Android** failed compiling Stripe:

```
e: Incompatible classes were found in dependencies.
Execution failed for task ':stripe_stripe-react-native:compileReleaseKotlin'.
```

`@stripe/stripe-react-native` 0.61 pulls `com.stripe:stripe-android` 23.x, whose classes carry Kotlin **2.3** metadata. React Native 0.81 pins the Kotlin plugin to **2.1.20**, and a 2.1 compiler reads metadata only up to 2.2. The lockfile shows where it came in: `61b25145d fix(mobile): relock android dependencies for stripe 0.61`. Nothing ran the Android *release* build afterwards, so it surfaced at tag time.

## What is the new behavior?

**iOS** runs on `macos-15`.

**Android** skips the Kotlin metadata version check. Three routes were tried against a local reproduction of the exact failing task:

| route | result |
| --- | --- |
| Raise `kotlinVersion` to 2.3.10 | **No effect.** `@react-native/gradle-plugin` is an included build pinning `kotlin = "2.1.20"` in its own catalog, and that wins for the modules RN applies the plugin to. The compile still reported 2.1. |
| Drop `stripe-android` to 22.0.0 (kotlin-stdlib 2.1.10) | **Fails differently.** stripe-react-native 0.61 uses 23.x APIs: unresolved references to `CardFundingFilteringPrivatePreview`, `CardFundingType`, `allowedCardFundingTypes`. |
| `-Xskip-metadata-version-check` | **Works.** This is the case the flag exists for: the metadata is newer than the reader, not incompatible in substance. |

Also pins `stripeVersion`, which stripe-react-native otherwise defaults to the floating range `23.1.+`.

## Impact area

`apps/mobileAppYC/android/build.gradle` and the iOS job's runner image. No application source changes. The Kotlin flag is set on all modules via `allprojects` rather than only Stripe, because the same mismatch will appear for any dependency that ships ahead of RN's pinned compiler.

## Validation performed

Local reproduction of the CI failure, then the fix, on the exact task that failed:

- Before: `e: ... Class 'com.stripe.android.view.BecsDebitWidget' was compiled with an incompatible version of Kotlin. The actual metadata version is 2.3.0, but the compiler version 2.1.0 can read versions up to 2.2.0`
- After: `BUILD SUCCESSFUL`

Both discarded routes above were also run to failure rather than reasoned about, which is how the included-build pin and the 23.x API dependency were established.

The `:app:` module cannot be compiled locally: `processReleaseGoogleServices` needs the `google-services.json` that CI restores from a secret. CI is the first place the full release build can run.

## Related Issue(s)

Unblocks the mobile v1.6.0 release. Both platforms are at 1.6.0 / build 16 and preflight already passes.
