### PR TITLE
chore(repo): promote dev to main

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -169,7 +169,10 @@ jobs:
     name: iOS (TestFlight)
     if: github.event_name == 'push' || inputs.platform == 'both' || inputs.platform == 'ios'
     needs: preflight
-    runs-on: macos-14
+    # React Native 0.81 requires Xcode >= 16.1 (min_xcode_version_supported in
+    # react-native/scripts/cocoapods/helpers.rb). The macos-14 image ships 15.x,
+    # so `pod install` aborted with "Please upgrade XCode" before any build ran.
+    runs-on: macos-15
     environment: release
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@
 </div>
 <br>
 
-https://github.com/user-attachments/assets/443272f1-5177-4ef5-a598-fe238bf0b97e
+
+https://github.com/user-attachments/assets/a8b186be-bff6-4204-bfb4-4bd3e6e7c996
 
 
 <br>

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@
 </div>
 <br>
 
-https://github.com/user-attachments/assets/5c01ce0a-2c84-4200-85b5-96eff488e113
+https://github.com/user-attachments/assets/443272f1-5177-4ef5-a598-fe238bf0b97e
+
 
 <br>
 

--- a/apps/mobileAppYC/android/build.gradle
+++ b/apps/mobileAppYC/android/build.gradle
@@ -5,7 +5,15 @@ buildscript {
         compileSdkVersion = 36
         targetSdkVersion = 36
         ndkVersion = "27.1.12297006"
+        // Pinned to what React Native 0.81 uses. Raising it here does NOT change the
+        // compiler: @react-native/gradle-plugin is an included build whose own catalog
+        // pins kotlin 2.1.20, and that wins for the modules RN applies the plugin to.
+        // Verified by setting this to 2.3.10 and watching the compile still report 2.1.
         kotlinVersion = "2.1.20"
+        // stripe-react-native defaults this to the floating range "23.1.+". The lockfile
+        // resolves it, so the version only moves when someone relocks, which is what
+        // 61b25145d did for stripe 0.61. Pinning it makes that movement explicit.
+        stripeVersion = "23.1.0"
     }
     repositories {
         google()
@@ -24,5 +32,17 @@ apply plugin: "com.facebook.react.rootproject"
 allprojects {
     dependencyLocking {
         lockAllConfigurations()
+    }
+
+    // stripe-react-native 0.61 requires com.stripe:stripe-android 23.x, whose classes
+    // carry Kotlin 2.3 metadata. React Native 0.81 pins the Kotlin plugin to 2.1.20 via
+    // its included build, and a 2.1 compiler reads metadata only up to 2.2, so
+    // :stripe_stripe-react-native:compileReleaseKotlin failed with "Incompatible classes
+    // were found in dependencies". The metadata is newer than the reader, not
+    // incompatible in substance, which is the case this flag exists for.
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+        compilerOptions {
+            freeCompilerArgs.add("-Xskip-metadata-version-check")
+        }
     }
 }


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

The `mobile-v1.6.0` tag failed on both runners. Preflight passed and the deployment was approved, so both jobs reached a real build before dying, for two unrelated reasons.

- **iOS**: `pod install` aborted with `[!] Invalid Podfile file: Please upgrade XCode.` React Native 0.81 requires Xcode >= 16.1 and the `macos-14` image ships 15.x.
- **Android**: `:stripe_stripe-react-native:compileReleaseKotlin` failed with `Incompatible classes were found in dependencies`. stripe-react-native 0.61 needs `com.stripe:stripe-android` 23.x, whose classes carry Kotlin 2.3 metadata, while React Native 0.81 pins the Kotlin plugin to 2.1.20 and a 2.1 compiler reads metadata only up to 2.2.

## What is the new behavior?

Promotes #2318. iOS moves to `macos-15`. Android skips the Kotlin metadata version check, after two other routes were tried against a local reproduction and each failed for a different reason (raising `kotlinVersion` has no effect because RN's included build pins it; dropping stripe-android to 22.0.0 breaks on 23.x-only APIs). `stripeVersion` is also pinned, since stripe-react-native otherwise defaults it to the floating range `23.1.+`.

## Impact area

`apps/mobileAppYC/android/build.gradle` and the iOS job's runner image. No application source changes.

## Validation performed

Local reproduction of the CI failure, then the fix, on the exact task that failed: `BUILD FAILED` with CI's error before, `BUILD SUCCESSFUL` after. The `:app:` module cannot be compiled locally because `processReleaseGoogleServices` needs the `google-services.json` CI restores from a secret, so CI is the first full-build proof.

All checks green on #2318, approved by aupyay.

## Related Issue(s)

Unblocks the mobile v1.6.0 release. Both platforms are at 1.6.0 / build 16.
