### PR TITLE
fix(mobile): authenticate the iOS archive to App Store Connect

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -236,28 +236,57 @@ jobs:
         working-directory: apps/mobileAppYC/ios
         run: pod install
 
+      # The key is written BEFORE the archive, not just before the upload. The
+      # project sets DEVELOPMENT_TEAM but no CODE_SIGN_STYLE, so Xcode signs
+      # automatically, and `-allowProvisioningUpdates` needs an authenticated
+      # App Store Connect session to fetch a profile. Without one the archive
+      # failed with "No Accounts: Add a new account in Accounts settings" and
+      # "No profiles for 'com.yosemitecrew.mobile' were found".
+      - name: Provide the App Store Connect API key
+        env:
+          KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_KEY_BASE64 }}
+        run: |
+          mkdir -p ~/.appstoreconnect/private_keys
+          KEY_PATH=~/.appstoreconnect/private_keys/AuthKey_${KEY_ID}.p8
+          echo "$KEY_BASE64" | base64 -d > "$KEY_PATH"
+          # A truncated or mis-encoded secret otherwise surfaces as an opaque
+          # signing failure several minutes into the archive.
+          if ! grep -q "BEGIN PRIVATE KEY" "$KEY_PATH"; then
+            echo "APP_STORE_CONNECT_KEY_BASE64 did not decode to a PEM private key." >&2
+            exit 1
+          fi
+          echo "ASC_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
+
       - name: Archive and export IPA
         working-directory: apps/mobileAppYC/ios
+        env:
+          KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
         run: |
           xcodebuild -workspace mobileAppYC.xcworkspace \
             -scheme mobileAppYC \
             -configuration Release \
             -archivePath "${RUNNER_TEMP}/mobileAppYC.xcarchive" \
             -allowProvisioningUpdates \
+            -authenticationKeyPath "$ASC_KEY_PATH" \
+            -authenticationKeyID "$KEY_ID" \
+            -authenticationKeyIssuerID "$ISSUER_ID" \
             archive
           xcodebuild -exportArchive \
             -archivePath "${RUNNER_TEMP}/mobileAppYC.xcarchive" \
             -exportOptionsPlist ExportOptions.plist \
-            -exportPath "${RUNNER_TEMP}/export"
+            -exportPath "${RUNNER_TEMP}/export" \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath "$ASC_KEY_PATH" \
+            -authenticationKeyID "$KEY_ID" \
+            -authenticationKeyIssuerID "$ISSUER_ID"
 
       - name: Upload to TestFlight
         env:
           KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
           ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
-          KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_KEY_BASE64 }}
         run: |
-          mkdir -p ~/.appstoreconnect/private_keys
-          echo "$KEY_BASE64" | base64 -d > ~/.appstoreconnect/private_keys/AuthKey_${KEY_ID}.p8
           xcrun altool --upload-app -f "${RUNNER_TEMP}/export/mobileAppYC.ipa" \
             -t ios --apiKey "$KEY_ID" --apiIssuer "$ISSUER_ID"
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

With the runner image corrected in #2318, the iOS job got past `pod install` for the first time and failed at the next real step:

```
error: No Accounts: Add a new account in Accounts settings. (in target 'mobileAppYC')
error: No profiles for 'com.yosemitecrew.mobile' were found
** ARCHIVE FAILED **
```

`apps/mobileAppYC/ios/mobileAppYC.xcodeproj` sets `DEVELOPMENT_TEAM` but no `CODE_SIGN_STYLE`, so signing is **automatic**, and `ExportOptions.plist` asks for `signingStyle: automatic` as well. Automatic signing resolves a provisioning profile through an App Store Connect session, and a CI runner has no Apple ID to provide one. `-allowProvisioningUpdates` was already on the command, but it had nothing to authenticate with.

The key that solves this was already in the job, written one step too late: only **Upload to TestFlight** set it up, well after the archive had already failed.

## What is the new behavior?

The App Store Connect API key is written in its own step **before** the archive, and both `xcodebuild` invocations authenticate with it:

```
-authenticationKeyPath  "$ASC_KEY_PATH"
-authenticationKeyID    "$KEY_ID"
-authenticationKeyIssuerID "$ISSUER_ID"
```

`Upload to TestFlight` now reuses that key instead of writing it a second time, and the existing `Remove restored secrets` step already deletes `~/.appstoreconnect/private_keys`, so cleanup is unchanged.

The new step also checks the decoded key is a PEM private key. A truncated or mis-encoded secret otherwise surfaces as an opaque signing failure several minutes into the archive, which is the slowest possible place to learn it.

No new secrets: `APP_STORE_CONNECT_KEY_ID`, `APP_STORE_CONNECT_ISSUER_ID` and `APP_STORE_CONNECT_KEY_BASE64` are the same three the job already used.

## Impact area

`.github/workflows/mobile-release.yml`, iOS job only. No application code, no Android changes.

## Validation performed

- Workflow YAML parses, and step order confirmed: `Provide the App Store Connect API key` now precedes `Archive and export IPA`
- The failure it addresses is quoted verbatim from run 32301928839
- The same run proves the rest of the pipeline works: **Android built and uploaded to the Play internal track successfully**, so this is the last step between the tag and TestFlight

Genuine limitation: this cannot be verified locally. Signing needs the certificate, profile and API key that live in the `release` environment, so CI is the only place it can run. That is also why the defect survived until a tag was cut.

## Related Issue(s)

Third in the sequence unblocking mobile v1.6.0, after the runner image and the Kotlin metadata mismatch in #2318.
