### PR TITLE
fix(repo): move fixture emails off real freemail domains

### DIFF
--- a/apps/frontend/src/app/__tests__/pages/Finance/Sections/InvoiceBilledTo.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Finance/Sections/InvoiceBilledTo.test.tsx
@@ -30,7 +30,7 @@ describe('InvoiceBilledTo', () => {
     storedParent = {
       firstName: 'Lena',
       lastName: 'Hartmann',
-      email: 'lena@mail.de',
+      email: 'lena@example.com',
       phoneNumber: '+49 171 555 0192',
       address: { addressLine: 'Bergstrasse 14', city: 'Garmisch', postalCode: '82467' },
     };
@@ -39,16 +39,16 @@ describe('InvoiceBilledTo', () => {
 
     expect(screen.getByText('Lena Hartmann')).toBeInTheDocument();
     expect(screen.getByText('Bergstrasse 14, 82467 Garmisch')).toBeInTheDocument();
-    expect(screen.getByText('lena@mail.de · +49 171 555 0192')).toBeInTheDocument();
+    expect(screen.getByText('lena@example.com · +49 171 555 0192')).toBeInTheDocument();
   });
 
   it('falls back to the appointment companion parent when no stored parent exists', () => {
-    appointmentCompanion = { parent: { name: 'Martha Ellis', email: 'martha@mail.de' } };
+    appointmentCompanion = { parent: { name: 'Martha Ellis', email: 'martha@example.com' } };
 
     render(<InvoiceBilledTo appointment={appointment} />);
 
     expect(screen.getByText('Martha Ellis')).toBeInTheDocument();
-    expect(screen.getByText('martha@mail.de')).toBeInTheDocument();
+    expect(screen.getByText('martha@example.com')).toBeInTheDocument();
   });
 
   it('renders an honest empty state when no billing contact is available', () => {
@@ -57,7 +57,7 @@ describe('InvoiceBilledTo', () => {
   });
 
   it('has no axe accessibility violations', async () => {
-    storedParent = { firstName: 'Lena', email: 'lena@mail.de' };
+    storedParent = { firstName: 'Lena', email: 'lena@example.com' };
     const { container } = render(<InvoiceBilledTo parentId="p1" />);
     const results = await axe(container);
     expect(results).toHaveNoViolations();

--- a/apps/frontend/src/app/__tests__/pages/Finance/Sections/InvoicePaymentLedger.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Finance/Sections/InvoicePaymentLedger.test.tsx
@@ -50,7 +50,7 @@ describe('InvoicePaymentLedger', () => {
         invoice={makeInvoice({ stripeReceiptUrl: 'https://stripe.test/r/1' })}
         currency="USD"
         payerName="Lena Hartmann"
-        payerEmail="lena@mail.de"
+        payerEmail="lena@example.com"
       />
     );
 
@@ -63,7 +63,7 @@ describe('InvoicePaymentLedger', () => {
       'href',
       'https://stripe.test/r/1'
     );
-    expect(screen.getByText('Receipt sent to lena@mail.de')).toBeInTheDocument();
+    expect(screen.getByText('Receipt sent to lena@example.com')).toBeInTheDocument();
   });
 
   it('treats a paidAt timestamp as settled even when status is not paid', () => {
@@ -131,7 +131,7 @@ describe('InvoicePaymentLedger', () => {
         invoice={makeInvoice({ stripeReceiptUrl: 'https://stripe.test/r/1' })}
         currency="USD"
         payerName="Lena Hartmann"
-        payerEmail="lena@mail.de"
+        payerEmail="lena@example.com"
       />
     );
     const results = await axe(container);

--- a/apps/mobileAppYC/src/features/appointments/mocks.ts
+++ b/apps/mobileAppYC/src/features/appointments/mocks.ts
@@ -149,7 +149,7 @@ export const mockInvoices: Invoice[] = [
     invoiceNumber: 'BDY024474',
     invoiceDate: new Date().toISOString(),
     billedToName: 'Miss. Pika Martin, Mr. Sky B',
-    billedToEmail: 'monthompson@gmail.com',
+    billedToEmail: 'monthompson@example.com',
     image: Images.documentIcon,
   },
 ];


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

A privacy sweep of the repo found three test/mock fixtures using email addresses on real, deliverable freemail domains: `lena@mail.de` and `martha@mail.de` in two frontend Finance section tests, and `monthompson@gmail.com` in the mobile appointments invoice mock. Addresses on real providers can belong to actual people, and secret/PII scanners flag them.

## What is the new behavior?

All three fixtures now use the RFC 2606 reserved `example.com` domain (`lena@example.com`, `martha@example.com`, `monthompson@example.com`). Assertions were updated to match. No runtime code changed.

Validation: targeted Jest run for `InvoiceBilledTo` and `InvoicePaymentLedger` passes (2 suites, 11 tests); Aikido scan of the changed files is clean. The mobile change is mock data only - no mobile test references that address.

## Related Issue(s)

None - small hygiene fix from a repo-wide privacy sweep.
