### PR TITLE
chore(repo): promote dev to main

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -252,9 +252,25 @@ jobs:
           echo "PROFILE_UUID=$PROFILE_UUID" >> "$GITHUB_ENV"
           echo "SIGNING_IDENTITY=$IDENTITY" >> "$GITHUB_ENV"
 
+      # CocoaPods fails intermittently in pnpm monorepos with
+      # "ArgumentError - pathname contains null byte". It is not deterministic:
+      # the same commit installed cleanly on the previous run and failed on the
+      # next. Retrying costs a couple of minutes; not retrying costs a whole
+      # tagged release, because the tag has to be deleted and re-cut.
+      # Podfile.lock is left alone so resolution stays reproducible.
       - name: Install pods
         working-directory: apps/mobileAppYC/ios
-        run: pod install
+        run: |
+          for attempt in 1 2 3; do
+            if pod install; then
+              exit 0
+            fi
+            echo "::warning::pod install failed on attempt ${attempt}, retrying"
+            rm -rf Pods
+            sleep 10
+          done
+          echo "pod install failed three times; this is no longer the known flake." >&2
+          exit 1
 
       # The key is written BEFORE the archive, not just before the upload. The
       # project sets DEVELOPMENT_TEAM but no CODE_SIGN_STYLE, so Xcode signs

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -236,16 +236,33 @@ jobs:
           # Manual signing needs the profile's own name, and the name is inside
           # the CMS envelope rather than the filename. Reading it here means the
           # archive never has to ask Apple which profile to use.
+          # A .mobileprovision is a CMS envelope wrapping a plist, and the decode
+          # can carry bytes past the plist. Anything read out of it is scrubbed of
+          # NUL and control characters before it goes near the environment: a NUL
+          # reaching GITHUB_ENV corrupts every later step, and Ruby then fails with
+          # "ArgumentError - pathname contains null byte" somewhere unrelated, which
+          # is exactly how this presented as a CocoaPods flake.
+          clean() { LC_ALL=C tr -d '\000-\037' | LC_ALL=C sed 's/[[:space:]]*$//'; }
+
           security cms -D -i "$PROFILE" > "${RUNNER_TEMP}/profile.plist"
-          PROFILE_NAME=$(/usr/libexec/PlistBuddy -c 'Print :Name' "${RUNNER_TEMP}/profile.plist")
-          PROFILE_UUID=$(/usr/libexec/PlistBuddy -c 'Print :UUID' "${RUNNER_TEMP}/profile.plist")
-          IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN" | sed -n '1s/.*"\(.*\)".*/\1/p')
+          PROFILE_NAME=$(/usr/libexec/PlistBuddy -c 'Print :Name' "${RUNNER_TEMP}/profile.plist" | clean)
+          PROFILE_UUID=$(/usr/libexec/PlistBuddy -c 'Print :UUID' "${RUNNER_TEMP}/profile.plist" | clean)
+          IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN" | sed -n '1s/.*"\(.*\)".*/\1/p' | clean)
           rm -f "${RUNNER_TEMP}/profile.plist"
 
           if [ -z "$PROFILE_NAME" ] || [ -z "$IDENTITY" ]; then
             echo "Could not read the provisioning profile name or the signing identity." >&2
             exit 1
           fi
+          # Refuse anything with a newline as well. GITHUB_ENV is line based, so a
+          # newline in a value silently turns the rest into a separate variable.
+          for pair in "PROFILE_NAME=$PROFILE_NAME" "PROFILE_UUID=$PROFILE_UUID" "SIGNING_IDENTITY=$IDENTITY"; do
+            if [ "$(printf '%s' "$pair" | wc -l | tr -d ' ')" != "0" ]; then
+              echo "A signing value contains a newline; refusing to write it to the environment." >&2
+              exit 1
+            fi
+          done
+
           echo "Signing as: $IDENTITY"
           echo "Profile:    $PROFILE_NAME ($PROFILE_UUID)"
           echo "PROFILE_NAME=$PROFILE_NAME" >> "$GITHUB_ENV"


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

The iOS leg fails at `pod install`:

```
ArgumentError - pathname contains null byte
```

That is a real, documented CocoaPods behaviour in pnpm monorepos, and it is what this looked like at first. It is not what happened here. It is a regression from the manual signing change:

| run | import-step change | `pod install` |
| --- | --- | --- |
| `e65a50739` | no | succeeded |
| `372648309` | yes | failed twice |

## What is the new behavior?

Promotes #2331.

A `.mobileprovision` is a CMS envelope wrapping a plist, and the decode can carry bytes past the plist. Those values went straight into `GITHUB_ENV`, which every later step inherits, so a stray NUL corrupts the environment for the whole job. CocoaPods is Ruby, and Ruby raises exactly `pathname contains null byte` when a path string contains one. The failure lands in a step with nothing to do with signing, which is why it read as unrelated flakiness.

- NUL and control characters are stripped from everything read out of the profile and the keychain.
- A value containing a newline is refused outright: `GITHUB_ENV` is line based, so a newline silently turns the remainder into another variable.
- The `pod install` retry is kept, demoted to what it actually is. The intermittent CocoaPods bug is real; it just was not this. A retry on a tagged release is cheap, since recovery otherwise means deleting and re-cutting the tag.

## Impact area

`.github/workflows/mobile-release.yml`, iOS job only. No application code.

## Validation performed

- Filter tested against a value carrying a NUL, a control byte and trailing whitespace: control bytes removed, value intact
- Newline guard tested both ways: rejects a two-line value, accepts a normal one
- `project.pbxproj` ruled out as a cause first: `plutil -lint` clean, no null bytes, only `16 -> 17` on two lines
- All checks green on #2331, approved by aupyay

## Related Issue(s)

Continues unblocking mobile v1.6.0. Android already builds and uploads build 17 to the Play internal track; iOS has not yet reached the archive, so the manual signing change from #2328 is still unexercised.
