### PR TITLE
chore(repo): promote dev to main

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -289,12 +289,13 @@ jobs:
           echo "pod install failed three times; this is no longer the known flake." >&2
           exit 1
 
-      # The key is written BEFORE the archive, not just before the upload. The
-      # project sets DEVELOPMENT_TEAM but no CODE_SIGN_STYLE, so Xcode signs
-      # automatically, and `-allowProvisioningUpdates` needs an authenticated
-      # App Store Connect session to fetch a profile. Without one the archive
-      # failed with "No Accounts: Add a new account in Accounts settings" and
-      # "No profiles for 'com.yosemitecrew.mobile' were found".
+      # altool authenticates with this key on the upload. It is written here,
+      # ahead of the archive, because the archive used to sign automatically and
+      # `-allowProvisioningUpdates` needs an authenticated App Store Connect
+      # session to fetch a profile; without one it failed with "No Accounts: Add
+      # a new account in Accounts settings". The archive now signs manually and
+      # no longer needs the session, but the ordering is kept so the key is in
+      # place for every step that follows.
       - name: Provide the App Store Connect API key
         env:
           KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
@@ -316,6 +317,22 @@ jobs:
       # for an "iOS App Development" profile that a distribution archive should
       # never want. The certificate and the distribution profile are both already
       # installed above, so nothing needs to be fetched at build time.
+      # Signing is written into the app target instead of being passed to
+      # xcodebuild. Command line build settings reach every target in the
+      # workspace, and a Pods framework cannot carry a provisioning profile, so
+      # the archive failed with "FirebaseCoreExtension does not support
+      # provisioning profiles" on targets that have nothing to sign.
+      - name: Point the app target at the release profile
+        working-directory: apps/mobileAppYC/ios
+        env:
+          DEVELOPMENT_TEAM: '9TZWPYQ45S'
+        run: |
+          if ! ruby -rxcodeproj -e 'nil' 2>/dev/null; then
+            gem install xcodeproj --no-document
+          fi
+          ruby "${GITHUB_WORKSPACE}/scripts/ci/ios-manual-signing.rb" \
+            mobileAppYC.xcodeproj mobileAppYC Release
+
       - name: Archive and export IPA
         working-directory: apps/mobileAppYC/ios
         run: |
@@ -323,10 +340,6 @@ jobs:
             -scheme mobileAppYC \
             -configuration Release \
             -archivePath "${RUNNER_TEMP}/mobileAppYC.xcarchive" \
-            CODE_SIGN_STYLE=Manual \
-            CODE_SIGN_IDENTITY="$SIGNING_IDENTITY" \
-            PROVISIONING_PROFILE_SPECIFIER="$PROFILE_NAME" \
-            DEVELOPMENT_TEAM=9TZWPYQ45S \
             archive
 
           # The committed ExportOptions.plist asks for automatic signing and cannot

--- a/apps/mobileAppYC/android/app/build.gradle
+++ b/apps/mobileAppYC/android/app/build.gradle
@@ -143,7 +143,7 @@ android {
         applicationId "com.mobileappyc"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 17
+        versionCode 18
         versionName "1.6.0"
         manifestPlaceholders = [
             MAPS_API_KEY: localProperties['MAPS_API_KEY'] ?: System.getenv('MAPS_API_KEY') ?: ''

--- a/scripts/ci/ios-manual-signing.rb
+++ b/scripts/ci/ios-manual-signing.rb
@@ -1,0 +1,64 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Applies manual signing to the iOS app target, and only to that target.
+#
+# The obvious way to sign a release is to pass CODE_SIGN_STYLE and friends to
+# xcodebuild on the command line. That does not work here: command line build
+# settings apply to every target in the workspace, including the Pods project,
+# and a static library or framework cannot carry a provisioning profile:
+#
+#   error: FirebaseCoreExtension does not support provisioning profiles, but
+#   provisioning profile Yosemite Crew App Store has been manually specified.
+#
+# Writing the settings into the one target that ships means the Pods targets
+# keep whatever CocoaPods gave them. The profile name lives inside a secret, so
+# it cannot be committed to the project file; this runs on CI just before the
+# archive and leaves the checked in project untouched in a normal checkout.
+
+require 'xcodeproj'
+
+project_path, target_name, configuration_name = ARGV
+abort 'usage: ios-manual-signing.rb <project.xcodeproj> <target> <configuration>' unless configuration_name
+
+identity = ENV.fetch('SIGNING_IDENTITY')
+profile = ENV.fetch('PROFILE_NAME')
+team = ENV.fetch('DEVELOPMENT_TEAM')
+
+%w[SIGNING_IDENTITY PROFILE_NAME DEVELOPMENT_TEAM].each do |name|
+  abort "#{name} is empty" if ENV.fetch(name).strip.empty?
+end
+
+project = Xcodeproj::Project.open(project_path)
+
+target = project.targets.find { |candidate| candidate.name == target_name }
+abort "no target named #{target_name} in #{project_path}" unless target
+
+configuration = target.build_configurations.find { |candidate| candidate.name == configuration_name }
+abort "target #{target_name} has no #{configuration_name} configuration" unless configuration
+
+settings = configuration.build_settings
+settings['CODE_SIGN_STYLE'] = 'Manual'
+settings['DEVELOPMENT_TEAM'] = team
+settings['PROVISIONING_PROFILE_SPECIFIER'] = profile
+settings['CODE_SIGN_IDENTITY'] = identity
+# The project level configuration sets an sdk conditional identity. A plain
+# target level CODE_SIGN_IDENTITY does not reliably beat it, so set the same
+# conditional the project uses.
+settings['CODE_SIGN_IDENTITY[sdk=iphoneos*]'] = identity
+
+project.save
+
+puts "#{target_name} / #{configuration_name}:"
+%w[CODE_SIGN_STYLE DEVELOPMENT_TEAM PROVISIONING_PROFILE_SPECIFIER CODE_SIGN_IDENTITY CODE_SIGN_IDENTITY[sdk=iphoneos*]].each do |key|
+  puts "  #{key} = #{settings[key]}"
+end
+
+other_targets = project.targets.reject { |candidate| candidate.name == target_name }
+other_targets.each do |candidate|
+  candidate.build_configurations.each do |other|
+    next unless other.build_settings['PROVISIONING_PROFILE_SPECIFIER']
+
+    abort "#{candidate.name} / #{other.name} also specifies a provisioning profile"
+  end
+end


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

Two things stand between the release tag and a green run.

The iOS archive fails on every pod:

```
Pods.xcodeproj: error: FirebaseCoreExtension does not support provisioning profiles.
```

Build settings passed to `xcodebuild` on the command line apply to every target in the workspace, the Pods project included, and a framework has no bundle to sign.

The Android leg builds fine and then stops at the upload:

```
Version code 17 has already been used.
```

Build 17 reached the internal track on the first tag run. Re-cutting the tag reruns the Android leg, and Play will not take a version code twice.

## What is the new behavior?

Promotes #2333.

- Signing goes into the app target's `Release` configuration just before the archive, applied by `scripts/ci/ios-manual-signing.rb`. The Pods targets keep what CocoaPods gave them. The profile name lives inside the encrypted profile, so it cannot be committed; a normal checkout stays as it is.
- The Android version code moves to 18.

## Impact area

`.github/workflows/mobile-release.yml`, one new CI script, and the Android version code. No application code, and no change to the checked in Xcode project.

## Validation performed

- Script run against a copy of the real `mobileAppYC.xcodeproj`: exactly four added lines, all inside the app target's `Release` block, `Debug` and the project level configurations untouched, `plutil -lint` clean
- The script aborts on a missing target, a missing configuration, an empty signing value, or another target that specifies a profile
- The Android diagnosis is from the run log, not inferred: the build step succeeded and the upload step is where it stopped
- All checks green on #2333, approved by aupyay

## Related Issue(s)

Continues unblocking mobile v1.6.0.
