### PR TITLE
fix(mobile): make the TestFlight upload say why it cannot authenticate

### DIFF
--- a/.github/workflows/asc-key-check.yml
+++ b/.github/workflows/asc-key-check.yml
@@ -1,0 +1,31 @@
+# Answers one question on demand: does the App Store Connect API key in the
+# release environment still authenticate?
+#
+# The iOS release job spends about forty minutes building before it ever
+# touches App Store Connect, so a credential problem costs a full build to
+# observe. This asks the API directly and finishes in seconds.
+name: App Store Connect key check
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Check the App Store Connect key
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v3.6.0
+
+      - name: Ask App Store Connect
+        env:
+          KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_KEY_BASE64 }}
+        run: |
+          KEY_PATH="${RUNNER_TEMP}/AuthKey.p8"
+          echo "$KEY_BASE64" | base64 -d > "$KEY_PATH"
+          ASC_KEY_PATH="$KEY_PATH" ruby scripts/ci/asc-key-check.rb

--- a/.github/workflows/asc-key-check.yml
+++ b/.github/workflows/asc-key-check.yml
@@ -19,6 +19,8 @@ jobs:
     environment: release
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v3.6.0
+        with:
+          persist-credentials: false
 
       - name: Ask App Store Connect
         env:

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -301,6 +301,16 @@ jobs:
           KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
           KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_KEY_BASE64 }}
         run: |
+          # A secret pasted with a trailing newline is invisible in the log,
+          # because Actions masks the value either way. It reaches the key
+          # filename and the JWT that altool signs, and comes back as nothing
+          # more specific than "Failed to authenticate for session".
+          KEY_ID=$(printf '%s' "$KEY_ID" | LC_ALL=C tr -d '[:space:]')
+          if [ -z "$KEY_ID" ]; then
+            echo "APP_STORE_CONNECT_KEY_ID is empty." >&2
+            exit 1
+          fi
+
           mkdir -p ~/.appstoreconnect/private_keys
           KEY_PATH=~/.appstoreconnect/private_keys/AuthKey_${KEY_ID}.p8
           echo "$KEY_BASE64" | base64 -d > "$KEY_PATH"
@@ -311,6 +321,7 @@ jobs:
             exit 1
           fi
           echo "ASC_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
+          echo "ASC_KEY_ID=$KEY_ID" >> "$GITHUB_ENV"
 
       # Manual signing, deliberately. Automatic signing asks App Store Connect to
       # resolve a profile, which returned 401 on listTeams.action and then hunted
@@ -359,11 +370,16 @@ jobs:
 
       - name: Upload to TestFlight
         env:
-          KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
           ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
         run: |
+          ISSUER_ID=$(printf '%s' "$ISSUER_ID" | LC_ALL=C tr -d '[:space:]')
+          if [ -z "$ISSUER_ID" ]; then
+            echo "APP_STORE_CONNECT_ISSUER_ID is empty." >&2
+            exit 1
+          fi
+
           xcrun altool --upload-app -f "${RUNNER_TEMP}/export/mobileAppYC.ipa" \
-            -t ios --apiKey "$KEY_ID" --apiIssuer "$ISSUER_ID"
+            -t ios --apiKey "$ASC_KEY_ID" --apiIssuer "$ISSUER_ID"
 
       - name: Remove restored secrets
         if: always()

--- a/scripts/ci/asc-key-check.rb
+++ b/scripts/ci/asc-key-check.rb
@@ -1,0 +1,96 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Asks App Store Connect whether the API key in the release environment still
+# authenticates, and prints only the verdict.
+#
+# `altool --upload-app` fails with "Failed to authenticate for session" and
+# nothing else, which is indistinguishable from a network problem, a bad
+# archive or a revoked key. The same credentials had already returned 401 from
+# listTeams.action during automatic signing. This calls the API directly so the
+# answer is a status code rather than a guess.
+#
+# Nothing secret is printed: the key id and issuer id are described by shape,
+# never by value, and the token is never echoed.
+
+require 'base64'
+require 'json'
+require 'net/http'
+require 'openssl'
+require 'uri'
+
+def shape(raw)
+  value = raw.strip
+  return 'empty' if value.empty?
+
+  kind =
+    if value.match?(/\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/) then 'uuid'
+    elsif value.match?(/\A[A-Z0-9]+\z/) then 'uppercase alphanumeric'
+    else 'mixed'
+    end
+  # A secret pasted with a trailing newline reaches the JWT and fails
+  # authentication with no hint of why, so surface the difference.
+  extra = raw.length - value.length
+  padding = extra.zero? ? '' : ", surrounded by #{extra} whitespace character#{'s' unless extra == 1}"
+  "#{value.length} characters, #{kind}#{padding}"
+end
+
+raw_key_id = ENV.fetch('KEY_ID', '')
+raw_issuer_id = ENV.fetch('ISSUER_ID', '')
+key_id = raw_key_id.strip
+issuer_id = raw_issuer_id.strip
+key_pem = File.read(ENV.fetch('ASC_KEY_PATH'))
+
+puts "key id:    #{shape(raw_key_id)}   (expected 10 characters, uppercase alphanumeric)"
+puts "issuer id: #{shape(raw_issuer_id)}   (expected 36 characters, uuid)"
+puts "key file:  #{key_pem.include?('BEGIN PRIVATE KEY') ? 'PEM private key' : 'NOT a PEM private key'}"
+puts
+
+key = OpenSSL::PKey::EC.new(key_pem)
+
+def b64(data)
+  Base64.urlsafe_encode64(data).delete('=')
+end
+
+# ES256 wants a raw 64 byte r||s signature. OpenSSL hands back DER, so unpack
+# it and left pad each half; a short r or s otherwise shifts the whole thing.
+def es256(key, message)
+  der = key.sign(OpenSSL::Digest.new('SHA256'), message)
+  r, s = OpenSSL::ASN1.decode(der).value.map { |part| part.value.to_s(2) }
+  r.rjust(32, "\x00") + s.rjust(32, "\x00")
+end
+
+issued = Time.now.to_i
+header = {alg: 'ES256', kid: key_id, typ: 'JWT'}
+payload = {iss: issuer_id, iat: issued, exp: issued + 300, aud: 'appstoreconnect-v1'}
+signing_input = "#{b64(JSON.dump(header))}.#{b64(JSON.dump(payload))}"
+token = "#{signing_input}.#{b64(es256(key, signing_input))}"
+
+uri = URI('https://api.appstoreconnect.apple.com/v1/apps?limit=1')
+request = Net::HTTP::Get.new(uri)
+request['Authorization'] = "Bearer #{token}"
+response = Net::HTTP.start(uri.host, uri.port, use_ssl: true) { |http| http.request(request) }
+
+puts "GET /v1/apps -> HTTP #{response.code}"
+
+if response.code == '200'
+  apps = JSON.parse(response.body).fetch('data', [])
+  puts "the key authenticates; it can see #{apps.length} app on this page"
+  exit 0
+end
+
+begin
+  JSON.parse(response.body).fetch('errors', []).each do |error|
+    puts "  #{error['code']}: #{error['title']}"
+    puts "  #{error['detail']}" if error['detail']
+  end
+rescue JSON::ParserError
+  puts '  the response was not JSON'
+end
+
+puts
+puts 'The key does not authenticate. This is fixed in App Store Connect, not here:'
+puts 'Users and Access > Integrations > App Store Connect API. Check that the key is'
+puts 'active, that its role can upload builds, and that the issuer id on that page'
+puts 'matches APP_STORE_CONNECT_ISSUER_ID.'
+exit 1

--- a/scripts/ci/asc-key-check.rb
+++ b/scripts/ci/asc-key-check.rb
@@ -92,5 +92,6 @@ puts
 puts 'The key does not authenticate. This is fixed in App Store Connect, not here:'
 puts 'Users and Access > Integrations > App Store Connect API. Check that the key is'
 puts 'active, that its role can upload builds, and that the issuer id on that page'
-puts 'matches APP_STORE_CONNECT_ISSUER_ID.'
+puts 'matches the one this job just used, which comes from the release environment'
+puts 'secret APP_STORE_CONNECT_ISSUER_ID and arrives here as ISSUER_ID.'
 exit 1


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

The iOS release now archives and exports a signed IPA:

```
** ARCHIVE SUCCEEDED **
Exported mobileAppYC to: [redacted: local path]
** EXPORT SUCCEEDED **
```

The upload is the last thing standing:

```
ERROR: Unable to upload archive. Failed to authenticate for session:
  Error Domain=ITunesConnectionAuthenticationErrorDomain Code=-26000
  "Failure to authenticate." (-1011)
```

`altool` says nothing beyond that. The same credentials had already returned 401 from `listTeams.action` during the automatic signing attempt, so this is about the App Store Connect API key rather than the archive. What it does not say is which part is wrong, and the iOS job builds for about forty minutes before it reaches that point, so every guess costs a full build.

## What is the new behavior?

Two changes, both aimed at the next attempt not being another guess.

**Whitespace is stripped from the key id and the issuer id.** Actions masks a secret whether or not it was pasted with a trailing newline, so the difference never shows in a log. The key id reaches a filename and a JWT header, the issuer id reaches the JWT payload, and either one carrying a newline fails authentication in exactly this shape. This may be the whole problem; it is cheap either way.

**A dispatchable check asks App Store Connect directly.** It mints the same ES256 token altool would, calls `GET /v1/apps`, and prints the status code with the error code and title Apple returns. It also prints the length and shape of each identifier, and how much surrounding whitespace each carries. It never prints a value.

If the check comes back 200 the credentials are fine and the problem is elsewhere. If it comes back 401 the fix is in App Store Connect, under Users and Access, and no change here will help.

## Impact area

`.github/workflows/mobile-release.yml`, one new dispatch only workflow, one new script. No application code.

## Validation performed

- The script was run end to end against Apple with a throwaway P-256 key: it mints the token, reaches the API, and reports `HTTP 401 NOT_AUTHORIZED` with Apple's own message rather than raising. The DER to raw signature conversion is the part most likely to be silently wrong, and a malformed signature would have failed differently
- Whitespace reporting was checked both ways: a clean value reports no padding, and values carrying 1 and 4 characters report them
- No positive control was possible, because that needs a working key. That is what the check exists to find out

## Related Issue(s)

Continues unblocking mobile v1.6.0.
