### PR TITLE
chore(repo): promote dev to main

### DIFF
--- a/.github/workflows/asc-key-check.yml
+++ b/.github/workflows/asc-key-check.yml
@@ -4,6 +4,12 @@
 # The iOS release job spends about forty minutes building before it ever
 # touches App Store Connect, so a credential problem costs a full build to
 # observe. This asks the API directly and finishes in seconds.
+#
+# The release environment currently allows deployments from release tags only,
+# so a dispatch on a branch is rejected before the job starts, with "Branch
+# main is not allowed to deploy to release". Add main to that environment's
+# deployment branch policy to use this. The iOS job runs the same check inline
+# in the meantime, which needs no such change but costs a build to reach.
 name: App Store Connect key check
 
 on:

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -368,6 +368,20 @@ jobs:
             -exportOptionsPlist "$EXPORT_PLIST" \
             -exportPath "${RUNNER_TEMP}/export"
 
+      # altool reports an authentication failure as "Failed to authenticate for
+      # session" and nothing else, which does not say whether the key is
+      # revoked, the issuer id is wrong, or the role cannot upload builds. This
+      # asks App Store Connect the same question directly and prints what it
+      # answers. It never fails the job: if the credentials are fine the upload
+      # is the real test, and if they are not the upload says so too, with less
+      # to go on.
+      - name: Check the App Store Connect key
+        continue-on-error: true
+        env:
+          KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+        run: ruby scripts/ci/asc-key-check.rb
+
       - name: Upload to TestFlight
         env:
           ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}

--- a/scripts/ci/asc-key-check.rb
+++ b/scripts/ci/asc-key-check.rb
@@ -13,7 +13,6 @@
 # Nothing secret is printed: the key id and issuer id are described by shape,
 # never by value, and the token is never echoed.
 
-require 'base64'
 require 'json'
 require 'net/http'
 require 'openssl'
@@ -48,8 +47,10 @@ puts
 
 key = OpenSSL::PKey::EC.new(key_pem)
 
+# pack rather than the base64 library, which stopped being a default gem in
+# Ruby 3.4 and is not worth a bundle here.
 def b64(data)
-  Base64.urlsafe_encode64(data).delete('=')
+  [data].pack('m0').tr('+/', '-_').delete('=')
 end
 
 # ES256 wants a raw 64 byte r||s signature. OpenSSL hands back DER, so unpack


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

The check added in #2335 cannot run from a branch. The App Store Connect secrets live in the `release` environment, and that environment's deployment policy lists three tag patterns and no branches:

```
Branch "main" is not allowed to deploy to release due to environment protection rules.
```

## What is the new behavior?

Promotes #2337.

The iOS job runs the same check inline, just before the upload, where the tag already satisfies the policy. It is `continue-on-error`, so it cannot turn a working release red. The dispatch only workflow stays and its header now says what has to change before it can be used: adding `main` to that environment's deployment branch policy, which is a decision about who can reach the signing secrets rather than something to slip into a build fix.

## Impact area

`.github/workflows/mobile-release.yml`, the dispatch workflow's comments, and the check script. No application code.

## Validation performed

- Script re-run end to end against Apple after dropping the `base64` require, with a throwaway P-256 key: unchanged behaviour, `HTTP 401 NOT_AUTHORIZED` with Apple's own message
- The rejection quoted above is from the dispatch attempt's run annotations
- All checks green on #2337, approved by aupyay

## Related Issue(s)

Continues unblocking mobile v1.6.0.
