### PR TITLE
chore(repo): promote dev to main

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -147,7 +147,14 @@ jobs:
           YC_RELEASE_STORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           YC_RELEASE_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
           YC_RELEASE_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
-        run: ./gradlew bundleRelease --no-daemon
+        run: |
+          # Every run of this workflow gets its own version code. Play rejects
+          # a repeat, and recovering from that means re-cutting the tag, which
+          # is how the release ends up chasing its own tail. The base sits
+          # above the highest code already published by hand.
+          VERSION_CODE=$(( 20 + GITHUB_RUN_NUMBER ))
+          echo "Building version code ${VERSION_CODE}"
+          ./gradlew bundleRelease --no-daemon "-PversionCodeOverride=${VERSION_CODE}"
 
       - name: Upload to Play internal track
         uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5 # v1.1.5

--- a/apps/mobileAppYC/android/app/build.gradle
+++ b/apps/mobileAppYC/android/app/build.gradle
@@ -143,7 +143,10 @@ android {
         applicationId "com.mobileappyc"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 18
+        // CI passes versionCodeOverride. Play refuses a version code it has
+        // already seen, so re-cutting a release tag has to produce a new one;
+        // the literal below is what a local build gets.
+        versionCode(project.hasProperty('versionCodeOverride') ? project.versionCodeOverride.toInteger() : 18)
         versionName "1.6.0"
         manifestPlaceholders = [
             MAPS_API_KEY: localProperties['MAPS_API_KEY'] ?: System.getenv('MAPS_API_KEY') ?: ''


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

The Android version code is a literal in `build.gradle`, and Play accepts a code once. Every iOS fix in this release meant re-cutting `mobile-v1.6.0`, which reran Android against a code Play already had:

```
##[error]Version code 17 has already been used.
```

Bumping the literal buys exactly one more attempt. This release has spent 17 and 18 that way.

## What is the new behavior?

Promotes #2339. CI derives the version code from the workflow run number, which is unique and monotonic, so repeated attempts at one release each get their own code. The literal stays for local builds; only CI overrides it.

## Impact area

`apps/mobileAppYC/android/app/build.gradle` and the Android job's build step. No application code, and `versionName` is unchanged.

## Validation performed

Ran against the real project and read the generated `BuildConfig`:

| invocation | `VERSION_CODE` |
| --- | --- |
| `./gradlew :app:generateReleaseBuildConfig -PversionCodeOverride=27` | `27` |
| `./gradlew :app:generateReleaseBuildConfig` | `18` |

The second row is the one that makes the first mean anything: a change that ignored the property would look the same without it.

All checks green on #2339, approved by aupyay.

## Related Issue(s)

Continues unblocking mobile v1.6.0. The iOS leg now archives, exports and signs; what remains there is an App Store Connect credential, which no change in this repository can fix.
