### PR TITLE
fix(mobile): keep the version code readable to the release preflight

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,13 +109,32 @@ jobs:
     if: needs.core.outputs.frontend == 'true'
     uses: ./.github/workflows/frontend-quality.yml
 
+  mobile-version:
+    name: Mobile version preflight
+    # mobile-release.yml runs this same check, but only once a release tag has
+    # been pushed, which is the worst moment to learn the answer: the tag is
+    # already cut and the run dies before it builds anything. It reads two
+    # files and takes seconds, so run it on pull requests too.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+
+      - run: node scripts/mobile/version.mjs --check
+
   ci-required:
     name: CI Required
     # Not yet a required status check on either ruleset. It is published now so
     # its behaviour can be observed before it is made required; the runbook in
     # docs/ci/required-checks-migration.md covers that switchover.
     if: always()
-    needs: [core, test, migration, sonar, frontend-quality]
+    needs: [core, test, migration, sonar, frontend-quality, mobile-version]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/apps/mobileAppYC/android/app/build.gradle
+++ b/apps/mobileAppYC/android/app/build.gradle
@@ -143,10 +143,7 @@ android {
         applicationId "com.mobileappyc"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        // CI passes versionCodeOverride. Play refuses a version code it has
-        // already seen, so re-cutting a release tag has to produce a new one;
-        // the literal below is what a local build gets.
-        versionCode(project.hasProperty('versionCodeOverride') ? project.versionCodeOverride.toInteger() : 18)
+        versionCode 18
         versionName "1.6.0"
         manifestPlaceholders = [
             MAPS_API_KEY: localProperties['MAPS_API_KEY'] ?: System.getenv('MAPS_API_KEY') ?: ''
@@ -227,6 +224,18 @@ dependencies {
     } else {
         implementation jscFlavor
     }
+}
+
+// Play refuses a version code it has already accepted, so re-cutting a release
+// tag has to produce a new one. CI passes versionCodeOverride for that.
+//
+// The assignment is here rather than inside defaultConfig on purpose: the
+// literal above has to stay a literal, because scripts/mobile/version.mjs both
+// reads and rewrites it with a `versionCode <number>` pattern, and a ternary in
+// its place stops the release preflight dead with "could not read
+// versionCode/versionName from build.gradle".
+if (project.hasProperty('versionCodeOverride')) {
+    android.defaultConfig.versionCode = project.versionCodeOverride.toInteger()
 }
 
 // Bundle the react-native-vector-icons glyph fonts used by the warm-bone UI


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

#2339 is a regression, and it only shows up after a release tag is cut:

```
version: could not read versionCode/versionName from build.gradle
Process completed with exit code 1
```

Preflight fails, both platform jobs skip, and nothing gets built. Recovering means deleting the tag and cutting it again.

That PR moved the version code into a ternary inside `defaultConfig`. Gradle reads it perfectly well, which is why the check I ran passed. `scripts/mobile/version.mjs` does not: it matches `versionCode\s+(\d+)`, both to read the current version and to rewrite it on `--set` and `--bump`. My validation exercised Gradle and not the script that the release actually runs first.

## What is the new behavior?

The literal goes back into `defaultConfig`, and the override moves below the `android` block:

```gradle
if (project.hasProperty('versionCodeOverride')) {
    android.defaultConfig.versionCode = project.versionCodeOverride.toInteger()
}
```

Same single source of truth, and the line `version.mjs` reads and rewrites is untouched.

CI also runs `version.mjs --check` on pull requests now. The release workflow runs it at tag time, which is the worst moment to find out. It reads two files and takes seconds.

## Impact area

`apps/mobileAppYC/android/app/build.gradle` and a new job in `ci.yaml`. No application code.

## Validation performed

Both halves this time, against the real project:

| | result |
| --- | --- |
| `node scripts/mobile/version.mjs --check` | passes, reads `versionCode 18` / `versionName 1.6.0` |
| `./gradlew :app:generateReleaseBuildConfig -PversionCodeOverride=27` | `VERSION_CODE = 27` |
| `./gradlew :app:generateReleaseBuildConfig` | `VERSION_CODE = 18` |

The failing check was reproduced locally on `dev` first, so the fix is measured against a failure that was observed rather than assumed.

`:app:processReleaseMainManifest` cannot run locally: it needs `google-services.json`, which only exists on the runner. The manifest's version code comes from `defaultConfig.versionCode`, which is the property being set here, and that is the same property the uploads of codes 17 and 18 came from.

## Related Issue(s)

Continues unblocking mobile v1.6.0. The App Store Connect credential has been replaced and verified directly against the API: `GET /v1/apps` returns 200, where the previous material returned 401.
