### PR TITLE
chore(repo): promote dev to main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,13 +109,32 @@ jobs:
     if: needs.core.outputs.frontend == 'true'
     uses: ./.github/workflows/frontend-quality.yml
 
+  mobile-version:
+    name: Mobile version preflight
+    # mobile-release.yml runs this same check, but only once a release tag has
+    # been pushed, which is the worst moment to learn the answer: the tag is
+    # already cut and the run dies before it builds anything. It reads two
+    # files and takes seconds, so run it on pull requests too.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+
+      - run: node scripts/mobile/version.mjs --check
+
   ci-required:
     name: CI Required
     # Not yet a required status check on either ruleset. It is published now so
     # its behaviour can be observed before it is made required; the runbook in
     # docs/ci/required-checks-migration.md covers that switchover.
     if: always()
-    needs: [core, test, migration, sonar, frontend-quality]
+    needs: [core, test, migration, sonar, frontend-quality, mobile-version]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/apps/mobileAppYC/android/app/build.gradle
+++ b/apps/mobileAppYC/android/app/build.gradle
@@ -143,10 +143,7 @@ android {
         applicationId "com.mobileappyc"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        // CI passes versionCodeOverride. Play refuses a version code it has
-        // already seen, so re-cutting a release tag has to produce a new one;
-        // the literal below is what a local build gets.
-        versionCode(project.hasProperty('versionCodeOverride') ? project.versionCodeOverride.toInteger() : 18)
+        versionCode 18
         versionName "1.6.0"
         manifestPlaceholders = [
             MAPS_API_KEY: localProperties['MAPS_API_KEY'] ?: System.getenv('MAPS_API_KEY') ?: ''
@@ -227,6 +224,18 @@ dependencies {
     } else {
         implementation jscFlavor
     }
+}
+
+// Play refuses a version code it has already accepted, so re-cutting a release
+// tag has to produce a new one. CI passes versionCodeOverride for that.
+//
+// The assignment is here rather than inside defaultConfig on purpose: the
+// literal above has to stay a literal, because scripts/mobile/version.mjs both
+// reads and rewrites it with a `versionCode <number>` pattern, and a ternary in
+// its place stops the release preflight dead with "could not read
+// versionCode/versionName from build.gradle".
+if (project.hasProperty('versionCodeOverride')) {
+    android.defaultConfig.versionCode = project.versionCodeOverride.toInteger()
 }
 
 // Bundle the react-native-vector-icons glyph fonts used by the warm-bone UI


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

`main` carries a regression from #2339 that only appears once a release tag exists:

```
version: could not read versionCode/versionName from build.gradle
```

Preflight fails, both platform jobs skip, nothing is built, and recovery means cutting the tag again. #2339 moved the Android version code into a ternary; Gradle reads that fine, `scripts/mobile/version.mjs` does not, and the release runs the script first.

## What is the new behavior?

Promotes #2341. The literal returns to `defaultConfig` and the override moves below the `android` block, so the line the script reads and rewrites is untouched. CI also runs `version.mjs --check` on pull requests, which is where this should have been caught.

## Impact area

`apps/mobileAppYC/android/app/build.gradle` and a new job in `ci.yaml`. No application code.

## Validation performed

| | result |
| --- | --- |
| `node scripts/mobile/version.mjs --check` | passes, reads `versionCode 18` / `versionName 1.6.0` |
| `./gradlew :app:generateReleaseBuildConfig -PversionCodeOverride=27` | `VERSION_CODE = 27` |
| `./gradlew :app:generateReleaseBuildConfig` | `VERSION_CODE = 18` |
| new `Mobile version preflight` job on #2341 | passes in 14s |

The failure was reproduced locally on `dev` before the fix, so this is measured against something observed rather than assumed.

All checks green on #2341, approved by aupyay.

## Related Issue(s)

Continues unblocking mobile v1.6.0. The App Store Connect credential has been replaced and verified directly against the API: `GET /v1/apps` returns 200, where the previous material returned 401.
