### PR TITLE
fix(mobile): build the iOS release with the iOS 26 SDK

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -179,6 +179,10 @@ jobs:
     # React Native 0.81 requires Xcode >= 16.1 (min_xcode_version_supported in
     # react-native/scripts/cocoapods/helpers.rb). The macos-14 image ships 15.x,
     # so `pod install` aborted with "Please upgrade XCode" before any build ran.
+    #
+    # This image defaults to Xcode 16.4, which is no longer enough to upload.
+    # It also carries Xcode 26, so the Select Xcode step below picks one rather
+    # than moving the image out from under a signing path that works.
     runs-on: macos-15
     environment: release
     steps:
@@ -189,6 +193,35 @@ jobs:
           # compromised third-party action could read it. That matters more
           # in this workflow than most, since it also handles signing secrets.
           persist-credentials: false
+
+      # App Store Connect refuses anything built with an older SDK:
+      #
+      #   SDK version issue. This app was built with the iOS 18.5 SDK. All iOS
+      #   and iPadOS apps must be built with the iOS 26 SDK or later, included
+      #   in Xcode 26 or later
+      #
+      # It refuses it at upload rather than at build, so without this the job
+      # archives, exports and signs correctly and then throws the result away
+      # on the last step, forty minutes in. Selecting the toolchain first means
+      # a wrong one fails in seconds instead.
+      #
+      # 26.3 is the newest Xcode on this image, and is pinned rather than
+      # inherited because image defaults move without a workflow edit. It is
+      # also deliberately not the newest Xcode that exists: from 26.4 the
+      # compiler miscompiles Firebase's `async let` in release builds, and this
+      # app is on FirebaseAuth 12.8.0, below the version that works around it.
+      # That one would ship rather than fail the build.
+      - name: Select Xcode
+        run: |
+          sudo xcode-select -s /Applications/Xcode_26.3.app
+          xcodebuild -version
+          SDK=$(xcrun --sdk iphoneos --show-sdk-version)
+          echo "iphoneos SDK: ${SDK}"
+          if [ "${SDK%%.*}" -lt 26 ]; then
+            echo "Selected Xcode carries the iOS ${SDK} SDK; uploads need 26 or later." >&2
+            exit 1
+          fi
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

The App Store Connect credential now works. The key check in the job reports:

```
GET /v1/apps -> HTTP 200
the key authenticates; it can see 1 app on this page
```

The upload fails for a different reason:

```
status=409, code=STATE_ERROR.VALIDATION_ERROR
SDK version issue. This app was built with the iOS 18.5 SDK. All iOS and iPadOS
apps must be built with the iOS 26 SDK or later, included in Xcode 26 or later,
in order to be uploaded to App Store Connect or submitted for distribution.
```

Apple has required this of every upload since 28 April 2026, TestFlight included. `macos-15` defaults to Xcode 16.4, which carries the iOS 18.5 SDK, and nothing in the job ever selected anything else: no `xcode-select`, no `DEVELOPER_DIR`, no setup action.

Note where this lands. The archive, the export and the signing all succeed, and the result is thrown away on the last step, forty minutes in.

## What is the new behavior?

A `Select Xcode` step, first in the job:

```yaml
sudo xcode-select -s /Applications/Xcode_26.3.app
```

The same image already ships Xcode 26.0.1, 26.1.1, 26.2 and 26.3 alongside the 16.4 default, so this selects one rather than moving to a different image and re-testing a signing path that took several attempts to get right.

Pinned rather than inherited: image defaults move without a workflow edit, and `/Applications/Xcode.app` on this image is a symlink to 16.4, so selecting it would be a silent no-op that reproduces exactly the failure being fixed.

Deliberately not the newest Xcode that exists. From 26.4 the compiler miscompiles Firebase's `async let` in release builds, and this app is on FirebaseAuth 12.8.0, below the version that works around it. That one would ship rather than fail the build.

The step also asserts the SDK it actually got. A wrong toolchain then costs ten seconds instead of the forty minutes it takes to reach the upload.

## Impact area

`.github/workflows/mobile-release.yml`, iOS job only. No application code, no Podfile change, no `ExportOptions.plist` change.

## Validation performed

- The Xcode inventory is read from the runner image manifest itself, `images/macos/macos-15-Readme.md`: Xcode 26.3 is build 17C529 at `/Applications/Xcode_26.3.app`, carrying SDK `iphoneos26.2`, and 16.4 is the default carrying `iphoneos18.5`. That is exactly the SDK in the rejection
- The version comparison was run against `18.5`, `26.0`, `26.2` and `9.0`: rejects the first and last, accepts the middle two
- The YAML parses, the iOS job gains one step, and the Android job is untouched at eleven
- Checked before assuming they were problems: the Podfile already forces `CLANG_CXX_LANGUAGE_STANDARD = 'c++17'` on the `fmt` target, which is what keeps fmt 11.0.2 compiling on newer clang; the app's deployment target is 15.1, inside the supported range; `Podfile.lock` and the image agree on CocoaPods 1.17.0; `stripe-react-native` is 0.61.0, the release carrying the Xcode 26 enum fix

What is not verified is the build itself, because nothing here can compile a React Native app against a new toolchain without running it. The likeliest failure is a Swift pod under Xcode 26's explicit modules, which reads as `redefinition of module` or `failed to build module ... from its module interface`, and is fixed by adding `SWIFT_ENABLE_EXPLICIT_MODULES = 'NO'` to the Podfile's existing `post_install` loop. That is left out on purpose: adding it blind means never learning whether it was needed.

## Related Issue(s)

Continues unblocking mobile v1.6.0. Android already ships from this tag, build 29 on the internal track.
