### PR TITLE
chore(repo): promote dev to main

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -179,6 +179,10 @@ jobs:
     # React Native 0.81 requires Xcode >= 16.1 (min_xcode_version_supported in
     # react-native/scripts/cocoapods/helpers.rb). The macos-14 image ships 15.x,
     # so `pod install` aborted with "Please upgrade XCode" before any build ran.
+    #
+    # This image defaults to Xcode 16.4, which is no longer enough to upload.
+    # It also carries Xcode 26, so the Select Xcode step below picks one rather
+    # than moving the image out from under a signing path that works.
     runs-on: macos-15
     environment: release
     steps:
@@ -189,6 +193,35 @@ jobs:
           # compromised third-party action could read it. That matters more
           # in this workflow than most, since it also handles signing secrets.
           persist-credentials: false
+
+      # App Store Connect refuses anything built with an older SDK:
+      #
+      #   SDK version issue. This app was built with the iOS 18.5 SDK. All iOS
+      #   and iPadOS apps must be built with the iOS 26 SDK or later, included
+      #   in Xcode 26 or later
+      #
+      # It refuses it at upload rather than at build, so without this the job
+      # archives, exports and signs correctly and then throws the result away
+      # on the last step, forty minutes in. Selecting the toolchain first means
+      # a wrong one fails in seconds instead.
+      #
+      # 26.3 is the newest Xcode on this image, and is pinned rather than
+      # inherited because image defaults move without a workflow edit. It is
+      # also deliberately not the newest Xcode that exists: from 26.4 the
+      # compiler miscompiles Firebase's `async let` in release builds, and this
+      # app is on FirebaseAuth 12.8.0, below the version that works around it.
+      # That one would ship rather than fail the build.
+      - name: Select Xcode
+        run: |
+          sudo xcode-select -s /Applications/Xcode_26.3.app
+          xcodebuild -version
+          SDK=$(xcrun --sdk iphoneos --show-sdk-version)
+          echo "iphoneos SDK: ${SDK}"
+          if [ "${SDK%%.*}" -lt 26 ]; then
+            echo "Selected Xcode carries the iOS ${SDK} SDK; uploads need 26 or later." >&2
+            exit 1
+          fi
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

The App Store Connect key authenticates now (`GET /v1/apps -> HTTP 200`), and the upload fails on the SDK instead:

```
409 STATE_ERROR.VALIDATION_ERROR
This app was built with the iOS 18.5 SDK. All iOS and iPadOS apps must be built
with the iOS 26 SDK or later, included in Xcode 26 or later
```

Apple has required this of every upload since 28 April 2026, TestFlight included. `macos-15` defaults to Xcode 16.4 and nothing in the job selected anything else.

## What is the new behavior?

Promotes #2343. A `Select Xcode` step runs first and picks `/Applications/Xcode_26.3.app`, which the same image already carries, then asserts the SDK it got. Nothing else changes: no new image, no Podfile change, no `ExportOptions.plist` change.

26.3 rather than the newest that exists, because from 26.4 the compiler miscompiles Firebase's `async let` in release builds and this app is on FirebaseAuth 12.8.0, below the version that works around it.

## Impact area

`.github/workflows/mobile-release.yml`, iOS job only. No application code.

## Validation performed

- Xcode inventory read from the runner image manifest, not assumed: 26.3 is build 17C529 carrying `iphoneos26.2`, and the 16.4 default carries `iphoneos18.5`, which is the SDK named in the rejection
- The version guard was exercised against `18.5`, `26.0`, `26.2`, `9.0`: rejects the first and last
- YAML parses; the iOS job gains one step and the Android job is untouched
- All checks green on #2343, approved by aupyay

The build against the new toolchain is the part that cannot be verified without running it. Android already ships from this tag: build 29 is on the internal track.

## Related Issue(s)

Continues unblocking mobile v1.6.0.
