### PR TITLE
fix(repo): replace the dead Discord vanity invite on the site and in emails

### DIFF
--- a/apps/backend/src/services/marketing-discord.service.ts
+++ b/apps/backend/src/services/marketing-discord.service.ts
@@ -1,5 +1,8 @@
 import logger from "src/utils/logger";
 
+// First code to return a count wins. "SwM6mX85KD" is the raw invite and never
+// expires; the "yosemitecrew" vanity slug is a dead ("Unknown Invite") fallback
+// kept only in case the guild regains the boost level a vanity URL requires.
 const DISCORD_INVITE_CODES = ["SwM6mX85KD", "yosemitecrew"];
 const DISCORD_USER_AGENT = "DiscordBot (https://www.yosemitecrew.com, 1.0)";
 const DISCORD_CACHE_TTL_MS = 5 * 60 * 1000;

--- a/apps/backend/src/utils/email-templates.ts
+++ b/apps/backend/src/utils/email-templates.ts
@@ -172,7 +172,7 @@ const renderBaseEmail = (
                               </p>
                               <p style="margin:0 0 6px 0; font-size:14px;">
                                 <a
-                                  href=""https://discord.gg/yosemitecrew"
+                                  href="https://discord.gg/SwM6mX85KD"
                                   target="_blank"
                                   style="color:#2b2b2b; text-decoration:none;"
                                 >

--- a/apps/frontend/src/app/__tests__/components/Footer.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Footer.test.tsx
@@ -92,7 +92,7 @@ describe('Footer Component', () => {
 
     const discordLink = screen.getByRole('link', { name: 'Discord' });
     expect(discordLink).toBeInTheDocument();
-    expect(discordLink).toHaveAttribute('href', 'https://discord.gg/yosemitecrew');
+    expect(discordLink).toHaveAttribute('href', 'https://discord.gg/SwM6mX85KD');
 
     const aboutUsLink = screen.getByRole('link', { name: 'About us' });
     expect(aboutUsLink).toBeInTheDocument();

--- a/apps/frontend/src/app/__tests__/features/marketing/site/assets.test.ts
+++ b/apps/frontend/src/app/__tests__/features/marketing/site/assets.test.ts
@@ -1,4 +1,8 @@
-import { GITHUB_STAR_CTA_STYLE, ctaBandContainerStyle } from '@/app/features/marketing/site/assets';
+import {
+  DISCORD_INVITE_URL,
+  GITHUB_STAR_CTA_STYLE,
+  ctaBandContainerStyle,
+} from '@/app/features/marketing/site/assets';
 
 describe('marketing site shared styles', () => {
   it('exposes the solid GitHub CTA style as a light pill', () => {
@@ -16,5 +20,18 @@ describe('marketing site shared styles', () => {
     expect(style.flexDirection).toBe('column');
     expect(style.alignItems).toBe('center');
     expect(style.textAlign).toBe('center');
+  });
+});
+
+describe('marketing site community links', () => {
+  // The `yosemitecrew` vanity invite stopped resolving once the guild lost the
+  // boost level a vanity URL requires, which silently broke the Discord link in
+  // the footer, on Contact us and on About. The raw invite code never expires,
+  // so it is the one the site publishes. Note that the dead vanity URL still
+  // 301s, so only resolving it through Discord's API reveals it is invalid -
+  // pin the value here instead.
+  it('publishes the non-expiring raw Discord invite, not the vanity slug', () => {
+    expect(DISCORD_INVITE_URL).toBe('https://discord.gg/SwM6mX85KD');
+    expect(DISCORD_INVITE_URL).not.toContain('discord.gg/yosemitecrew');
   });
 });

--- a/apps/frontend/src/app/__tests__/pages/About.marketing.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/About.marketing.test.tsx
@@ -62,7 +62,7 @@ jest.mock('@/app/features/marketing/site', () => {
     useGithubContributors: () => mockGithubContributors,
     ABOUT_ORIGIN_PHOTO: '/images/marketing/about-origin.webp',
     GITHUB_REPO_URL: 'https://github.com/YosemiteCrew/Yosemite-Crew',
-    DISCORD_INVITE_URL: 'https://discord.gg/yosemitecrew',
+    DISCORD_INVITE_URL: 'https://discord.gg/SwM6mX85KD',
   };
 });
 

--- a/apps/frontend/src/app/__tests__/pages/ContactusPage.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/ContactusPage.test.tsx
@@ -9,7 +9,7 @@ jest.mock('@/app/features/marketing/site', () => ({
   useMagnet: () => ({ current: null }),
   HeroGlow: () => null,
   InkAnnotate: ({ children }: { children: React.ReactNode }) => children,
-  DISCORD_INVITE_URL: 'https://discord.gg/yosemitecrew',
+  DISCORD_INVITE_URL: 'https://discord.gg/SwM6mX85KD',
 }));
 
 jest.mock('@/app/services/axios', () => ({
@@ -38,7 +38,7 @@ describe('ContactusPage', () => {
     const discord = screen.getByText('Join the Discord').closest('a');
     expect(discord).toHaveAttribute('target', '_blank');
     expect(discord).toHaveAttribute('rel', 'noopener noreferrer');
-    expect(discord).toHaveAttribute('href', 'https://discord.gg/yosemitecrew');
+    expect(discord).toHaveAttribute('href', 'https://discord.gg/SwM6mX85KD');
   });
 
   it('should switch to and render the "Complaint" form when selected', () => {

--- a/apps/frontend/src/app/__tests__/pages/Insights.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Insights.test.tsx
@@ -63,7 +63,7 @@ jest.mock('@/app/features/marketing/site', () => {
     CountUp: ({ value }: any) => R.createElement('span', null, value),
     InkAnnotate: ({ children }: any) => children,
     GITHUB_REPO_URL: 'https://github.com/YosemiteCrew/Yosemite-Crew',
-    DISCORD_INVITE_URL: 'https://discord.gg/yosemitecrew',
+    DISCORD_INVITE_URL: 'https://discord.gg/SwM6mX85KD',
     useGithubStats: () => stats,
     useLatestRelease: () => release,
     useRepoInsights: () => repo,

--- a/apps/frontend/src/app/api/community/discord-members/route.ts
+++ b/apps/frontend/src/app/api/community/discord-members/route.ts
@@ -21,10 +21,13 @@ import { NextResponse } from 'next/server';
  */
 
 // Both codes resolve to the same guild. Order matters: the first one to return a
-// count wins. The raw invite code is primary - it is what the READMEs, dev-docs
-// and issue templates publish, and it does not expire. The `yosemitecrew` vanity
-// slug (used by the site footer and marketing assets) is only the fallback,
-// because a vanity URL stops resolving if the guild loses its boost level.
+// count wins. The raw invite code is primary - it is what the site, READMEs,
+// dev-docs and issue templates publish, and it does not expire. The
+// `yosemitecrew` vanity slug is a last-resort fallback only, and is currently
+// DEAD ("Unknown Invite"): a vanity URL stops resolving once the guild loses its
+// boost level, which is exactly what took the site's Discord link down. Kept
+// here so the count survives if the vanity URL is ever restored - never publish
+// it as a link.
 const DISCORD_INVITE_CODES = ['SwM6mX85KD', 'yosemitecrew'];
 
 // Discord requires a descriptive User-Agent on API calls and rate-limits or

--- a/apps/frontend/src/app/features/marketing/site/assets.ts
+++ b/apps/frontend/src/app/features/marketing/site/assets.ts
@@ -6,7 +6,7 @@ export const CDN_BASE = 'https://d2il6osz49gpup.cloudfront.net';
 
 export const GITHUB_REPO_URL = 'https://github.com/YosemiteCrew/Yosemite-Crew';
 export const GITHUB_API_REPO = 'https://api.github.com/repos/YosemiteCrew/Yosemite-Crew';
-export const DISCORD_INVITE_URL = 'https://discord.gg/yosemitecrew';
+export const DISCORD_INVITE_URL = 'https://discord.gg/SwM6mX85KD';
 export const LINKEDIN_URL = 'https://www.linkedin.com/company/yosemitecrew';
 export const INSTAGRAM_URL = 'https://www.instagram.com/yosemite_crew';
 export const X_URL = 'https://x.com/yosemitecrew';

--- a/apps/frontend/src/app/ui/widgets/Footer/Footer.tsx
+++ b/apps/frontend/src/app/ui/widgets/Footer/Footer.tsx
@@ -25,7 +25,7 @@ const footerLinks = [
   {
     title: 'Community',
     links: [
-      { label: 'Discord', href: 'https://discord.gg/yosemitecrew' },
+      { label: 'Discord', href: 'https://discord.gg/SwM6mX85KD' },
       {
         label: 'GitHub',
         href: 'https://github.com/YosemiteCrew/Yosemite-Crew',


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The Discord link published across the marketing site is a dead invite. The site uses the `yosemitecrew` vanity slug, which Discord now answers with `{"message": "Unknown Invite", "code": 10006}`. Anyone clicking Discord in the footer, on Contact us or on About lands on an invalid-invite screen.

A vanity URL only resolves while the guild holds the boost level it requires. `discord-members/route.ts` already carried a comment warning about exactly this, and it is what happened.

Two things made it easy to miss:

- The dead `.gg` URL still returns a 301, so an HTTP status check looks healthy. Only resolving the code through Discord's API shows it is invalid.
- The specs for About, Contact us and Insights mock `assets.ts`, so they assert their own mock rather than the real constant.

Separately, the community link in the transactional email footer read `href=""https://discord.gg/yosemitecrew"`. The doubled quote closed the attribute immediately, so the rendered href was empty and the link was inert regardless of the invite code.

This was reported by an inbound prospect evaluating the platform.

## What is the new behavior?

Every published Discord link now uses the raw invite `SwM6mX85KD`, which does not expire and is already what the READMEs, dev-docs, issue templates and legal pages use. The site no longer contradicts its own documentation.

- `assets.ts` - `DISCORD_INVITE_URL`, consumed by SiteFooter, ContactusPage and About
- `Footer.tsx` - had hardcoded the URL instead of using the shared constant, so it needed fixing separately
- `email-templates.ts` - correct invite plus the quoting fix, so the link in outgoing email works at all

Regression cover: a new case in `assets.test.ts` pins the constant. A mutation check (reintroducing the vanity slug) confirmed that this new test and `Footer.test.tsx` genuinely fail, while the three mock-based specs pass either way, which is why the constant needed its own guard.

The member count is untouched and was never affected: both `route.ts` and `marketing-discord.service.ts` try the raw invite first. Their comments are updated to record that the vanity slug is dead and must not be published as a link.

Validation run locally: frontend and backend `type-check` both clean, scoped eslint clean, and the affected suites pass (frontend 5 suites / 38 tests, backend 3 suites / 51 tests). The pre-push hook completed all 17 monorepo lint and type-check tasks.

Possible follow-up, not in this PR: a CI link check that resolves published invite codes through the Discord API, so a dead community link is caught before a prospect finds it.

## Related Issue(s)

Fixes #2345
