### PR TITLE
chore(repo): promote dev to main

### DIFF
--- a/apps/backend/src/services/marketing-discord.service.ts
+++ b/apps/backend/src/services/marketing-discord.service.ts
@@ -1,5 +1,8 @@
 import logger from "src/utils/logger";
 
+// First code to return a count wins. "SwM6mX85KD" is the raw invite and never
+// expires; the "yosemitecrew" vanity slug is a dead ("Unknown Invite") fallback
+// kept only in case the guild regains the boost level a vanity URL requires.
 const DISCORD_INVITE_CODES = ["SwM6mX85KD", "yosemitecrew"];
 const DISCORD_USER_AGENT = "DiscordBot (https://www.yosemitecrew.com, 1.0)";
 const DISCORD_CACHE_TTL_MS = 5 * 60 * 1000;

--- a/apps/backend/src/utils/email-templates.ts
+++ b/apps/backend/src/utils/email-templates.ts
@@ -172,7 +172,7 @@ const renderBaseEmail = (
                               </p>
                               <p style="margin:0 0 6px 0; font-size:14px;">
                                 <a
-                                  href=""https://discord.gg/yosemitecrew"
+                                  href="https://discord.gg/SwM6mX85KD"
                                   target="_blank"
                                   style="color:#2b2b2b; text-decoration:none;"
                                 >

--- a/apps/frontend/src/app/__tests__/components/Footer.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Footer.test.tsx
@@ -92,7 +92,7 @@ describe('Footer Component', () => {
 
     const discordLink = screen.getByRole('link', { name: 'Discord' });
     expect(discordLink).toBeInTheDocument();
-    expect(discordLink).toHaveAttribute('href', 'https://discord.gg/yosemitecrew');
+    expect(discordLink).toHaveAttribute('href', 'https://discord.gg/SwM6mX85KD');
 
     const aboutUsLink = screen.getByRole('link', { name: 'About us' });
     expect(aboutUsLink).toBeInTheDocument();

--- a/apps/frontend/src/app/__tests__/features/marketing/site/assets.test.ts
+++ b/apps/frontend/src/app/__tests__/features/marketing/site/assets.test.ts
@@ -1,4 +1,8 @@
-import { GITHUB_STAR_CTA_STYLE, ctaBandContainerStyle } from '@/app/features/marketing/site/assets';
+import {
+  DISCORD_INVITE_URL,
+  GITHUB_STAR_CTA_STYLE,
+  ctaBandContainerStyle,
+} from '@/app/features/marketing/site/assets';
 
 describe('marketing site shared styles', () => {
   it('exposes the solid GitHub CTA style as a light pill', () => {
@@ -16,5 +20,18 @@ describe('marketing site shared styles', () => {
     expect(style.flexDirection).toBe('column');
     expect(style.alignItems).toBe('center');
     expect(style.textAlign).toBe('center');
+  });
+});
+
+describe('marketing site community links', () => {
+  // The `yosemitecrew` vanity invite stopped resolving once the guild lost the
+  // boost level a vanity URL requires, which silently broke the Discord link in
+  // the footer, on Contact us and on About. The raw invite code never expires,
+  // so it is the one the site publishes. Note that the dead vanity URL still
+  // 301s, so only resolving it through Discord's API reveals it is invalid -
+  // pin the value here instead.
+  it('publishes the non-expiring raw Discord invite, not the vanity slug', () => {
+    expect(DISCORD_INVITE_URL).toBe('https://discord.gg/SwM6mX85KD');
+    expect(DISCORD_INVITE_URL).not.toContain('discord.gg/yosemitecrew');
   });
 });

--- a/apps/frontend/src/app/__tests__/pages/About.marketing.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/About.marketing.test.tsx
@@ -62,7 +62,7 @@ jest.mock('@/app/features/marketing/site', () => {
     useGithubContributors: () => mockGithubContributors,
     ABOUT_ORIGIN_PHOTO: '/images/marketing/about-origin.webp',
     GITHUB_REPO_URL: 'https://github.com/YosemiteCrew/Yosemite-Crew',
-    DISCORD_INVITE_URL: 'https://discord.gg/yosemitecrew',
+    DISCORD_INVITE_URL: 'https://discord.gg/SwM6mX85KD',
   };
 });
 

--- a/apps/frontend/src/app/__tests__/pages/ContactusPage.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/ContactusPage.test.tsx
@@ -9,7 +9,7 @@ jest.mock('@/app/features/marketing/site', () => ({
   useMagnet: () => ({ current: null }),
   HeroGlow: () => null,
   InkAnnotate: ({ children }: { children: React.ReactNode }) => children,
-  DISCORD_INVITE_URL: 'https://discord.gg/yosemitecrew',
+  DISCORD_INVITE_URL: 'https://discord.gg/SwM6mX85KD',
 }));
 
 jest.mock('@/app/services/axios', () => ({
@@ -38,7 +38,7 @@ describe('ContactusPage', () => {
     const discord = screen.getByText('Join the Discord').closest('a');
     expect(discord).toHaveAttribute('target', '_blank');
     expect(discord).toHaveAttribute('rel', 'noopener noreferrer');
-    expect(discord).toHaveAttribute('href', 'https://discord.gg/yosemitecrew');
+    expect(discord).toHaveAttribute('href', 'https://discord.gg/SwM6mX85KD');
   });
 
   it('should switch to and render the "Complaint" form when selected', () => {

--- a/apps/frontend/src/app/__tests__/pages/Insights.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Insights.test.tsx
@@ -63,7 +63,7 @@ jest.mock('@/app/features/marketing/site', () => {
     CountUp: ({ value }: any) => R.createElement('span', null, value),
     InkAnnotate: ({ children }: any) => children,
     GITHUB_REPO_URL: 'https://github.com/YosemiteCrew/Yosemite-Crew',
-    DISCORD_INVITE_URL: 'https://discord.gg/yosemitecrew',
+    DISCORD_INVITE_URL: 'https://discord.gg/SwM6mX85KD',
     useGithubStats: () => stats,
     useLatestRelease: () => release,
     useRepoInsights: () => repo,

--- a/apps/frontend/src/app/api/community/discord-members/route.ts
+++ b/apps/frontend/src/app/api/community/discord-members/route.ts
@@ -21,10 +21,13 @@ import { NextResponse } from 'next/server';
  */
 
 // Both codes resolve to the same guild. Order matters: the first one to return a
-// count wins. The raw invite code is primary - it is what the READMEs, dev-docs
-// and issue templates publish, and it does not expire. The `yosemitecrew` vanity
-// slug (used by the site footer and marketing assets) is only the fallback,
-// because a vanity URL stops resolving if the guild loses its boost level.
+// count wins. The raw invite code is primary - it is what the site, READMEs,
+// dev-docs and issue templates publish, and it does not expire. The
+// `yosemitecrew` vanity slug is a last-resort fallback only, and is currently
+// DEAD ("Unknown Invite"): a vanity URL stops resolving once the guild loses its
+// boost level, which is exactly what took the site's Discord link down. Kept
+// here so the count survives if the vanity URL is ever restored - never publish
+// it as a link.
 const DISCORD_INVITE_CODES = ['SwM6mX85KD', 'yosemitecrew'];
 
 // Discord requires a descriptive User-Agent on API calls and rate-limits or

--- a/apps/frontend/src/app/features/marketing/site/assets.ts
+++ b/apps/frontend/src/app/features/marketing/site/assets.ts
@@ -6,7 +6,7 @@ export const CDN_BASE = 'https://d2il6osz49gpup.cloudfront.net';
 
 export const GITHUB_REPO_URL = 'https://github.com/YosemiteCrew/Yosemite-Crew';
 export const GITHUB_API_REPO = 'https://api.github.com/repos/YosemiteCrew/Yosemite-Crew';
-export const DISCORD_INVITE_URL = 'https://discord.gg/yosemitecrew';
+export const DISCORD_INVITE_URL = 'https://discord.gg/SwM6mX85KD';
 export const LINKEDIN_URL = 'https://www.linkedin.com/company/yosemitecrew';
 export const INSTAGRAM_URL = 'https://www.instagram.com/yosemite_crew';
 export const X_URL = 'https://x.com/yosemitecrew';

--- a/apps/frontend/src/app/ui/widgets/Footer/Footer.tsx
+++ b/apps/frontend/src/app/ui/widgets/Footer/Footer.tsx
@@ -25,7 +25,7 @@ const footerLinks = [
   {
     title: 'Community',
     links: [
-      { label: 'Discord', href: 'https://discord.gg/yosemitecrew' },
+      { label: 'Discord', href: 'https://discord.gg/SwM6mX85KD' },
       {
         label: 'GitHub',
         href: 'https://github.com/YosemiteCrew/Yosemite-Crew',


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

`main` publishes a dead Discord invite. The vanity slug `discord.gg/yosemitecrew` stopped resolving when the guild lost the boost level a vanity URL requires, so Discord answers it with `Unknown Invite` (code 10006). Every visitor clicking Discord in the footer, on Contact us or on About lands on an invalid-invite screen.

The same dead link, plus a doubled-quote bug that emptied the `href` entirely, shipped in the transactional email footer.

## What is the new behavior?

Promotes the fix in #2346 to `main`.

`main` was level with `dev` when this promotion was opened, so this ships exactly one change and nothing else rides along:

- `fix(frontend): point the site Discord links at the non-expiring invite`
- `fix(backend): repair the Discord link in the transactional email footer`

Every published Discord link now uses the raw invite `SwM6mX85KD`, which does not expire and is already what the READMEs, dev-docs, issue templates and legal pages use.

## Deployment notes

- No database migrations.
- The frontend half goes live on merge via the Amplify webhook in `cd-frontend.yaml`, and is self-contained: it changes a URL constant, and depends on no new API route. There is no frontend-ahead-of-API hazard in this promotion.
- The backend half (the email footer) is inert until the API box is hand-deployed, since no workflow deploys it. The email link stays broken, exactly as it is today, until that happens. Nothing regresses in the meantime.

## Related Issue(s)

Fixes #2345
