### PR TITLE
feat(backend): mirror public contact submissions into the SuperAdmin panel

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -104,3 +104,14 @@ GOOGLE_WALLET_SA_PRIVATE_KEY=""
 # Logo: square >=660x660 PNG. Hero: wide banner (~1032x336) for a passport-cover look.
 PUBLIC_WALLET_LOGO_URL="https://raw.githubusercontent.com/YosemiteCrew/Yosemite-Crew/main/apps/mobileAppYC/src/assets/images/yosemite-logo-1024.png"
 PUBLIC_WALLET_HERO_URL=""
+
+# --- SuperAdmin panel contact mirror ---------------------------------------
+# Best-effort forward of public contact-us submissions into the SuperAdmin
+# panel's CRM intake (its /api/contact route). Leave both empty to disable
+# mirroring; the submission is always stored in our own database regardless.
+# Both /contact-us and /accessibility/report post to the same endpoint, so this
+# one setting mirrors both forms.
+# URL is the full intake endpoint, e.g. "https://<superadmin-host>/api/contact".
+# The key must match CONTACT_INTAKE_KEY configured on the SuperAdmin side.
+SUPERADMIN_CONTACT_INTAKE_URL=""
+SUPERADMIN_CONTACT_INTAKE_KEY=""

--- a/apps/backend/src/controllers/app/contact-us.controller.ts
+++ b/apps/backend/src/controllers/app/contact-us.controller.ts
@@ -16,6 +16,7 @@ import {
 import { AuthenticatedRequest } from "src/middlewares/auth";
 import { AuthUserMobileService } from "src/services/authUserMobile.service";
 import { type ContactType, type ContactStatus } from "src/models/contect-us";
+import { SuperadminContactService } from "src/services/superadmin-contact.service";
 
 const resolveMobileUserId = (req: Request): string | undefined => {
   const authReq = req as AuthenticatedRequest;
@@ -158,6 +159,12 @@ export const ContactController = {
       };
 
       const doc = await ContactService.createWebRequest(payload);
+
+      // Mirror the stored submission into the SuperAdmin panel's CRM.
+      // Fire-and-forget: the panel being down or unconfigured must never
+      // fail the visitor's submission - our database already holds it.
+      void SuperadminContactService.forwardWebContact(payload);
+
       const id = doc.id;
       res.status(201).json({ id });
     } catch (err) {

--- a/apps/backend/src/services/superadmin-contact.service.ts
+++ b/apps/backend/src/services/superadmin-contact.service.ts
@@ -1,0 +1,50 @@
+import logger from "src/utils/logger";
+import type { CreateWebContactRequestInput } from "src/services/contact-us.service";
+
+// Give the panel a few seconds and no more: the forward runs off the request
+// path, but an unbounded hang would pin the event loop's socket pool for
+// nothing when the panel is unreachable.
+const FORWARD_TIMEOUT_MS = 5_000;
+
+/**
+ * Best-effort mirror of public contact-us submissions into the SuperAdmin
+ * panel's CRM intake. The panel's /api/contact accepts the contact-web body
+ * VERBATIM (it maps fullName/type/phone itself), authenticated by a shared
+ * secret in the x-contact-key header, so no field mapping happens here.
+ *
+ * Two public forms reach this path, not one: /contact-us and the accessibility
+ * report at /accessibility/report both POST to /v1/contact-us/contact-web, so
+ * both are mirrored by this single forward.
+ *
+ * The product database remains the source of truth for the submission - a
+ * missing or failing forward loses nothing and must never surface to the
+ * visitor. Unconfigured (either env var absent) means mirroring is off.
+ */
+export const SuperadminContactService = {
+  async forwardWebContact(
+    payload: CreateWebContactRequestInput,
+  ): Promise<void> {
+    const url = process.env.SUPERADMIN_CONTACT_INTAKE_URL;
+    const key = process.env.SUPERADMIN_CONTACT_INTAKE_KEY;
+    if (!url || !key) return;
+
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-contact-key": key },
+        body: JSON.stringify(payload),
+        signal: AbortSignal.timeout(FORWARD_TIMEOUT_MS),
+      });
+
+      if (!response.ok) {
+        logger.warn("SuperAdmin contact intake rejected the forward", {
+          status: response.status,
+        });
+      }
+    } catch (error) {
+      logger.error("Failed to forward contact submission to SuperAdmin", {
+        error,
+      });
+    }
+  },
+};

--- a/apps/backend/test/controllers/contact-us.controller.test.ts
+++ b/apps/backend/test/controllers/contact-us.controller.test.ts
@@ -4,6 +4,7 @@ import {
   ContactServiceError,
 } from "../../src/services/contact-us.service";
 import { AuthUserMobileService } from "../../src/services/authUserMobile.service";
+import { SuperadminContactService } from "../../src/services/superadmin-contact.service";
 import {
   ATTACHMENT_MIME_TYPES,
   generatePresignedUrl,
@@ -23,6 +24,12 @@ jest.mock("../../src/services/contact-us.service", () => {
     },
   };
 });
+
+jest.mock("../../src/services/superadmin-contact.service", () => ({
+  SuperadminContactService: {
+    forwardWebContact: jest.fn(),
+  },
+}));
 
 jest.mock("../../src/services/authUserMobile.service", () => ({
   AuthUserMobileService: {
@@ -194,6 +201,9 @@ describe("ContactController", () => {
   });
 
   describe("createWeb", () => {
+    const mockedForward =
+      SuperadminContactService.forwardWebContact as jest.Mock;
+
     it("creates a web contact request", async () => {
       mockedContactService.createWebRequest.mockResolvedValueOnce({
         id: "contact-web-1",
@@ -224,6 +234,49 @@ describe("ContactController", () => {
       );
       expect(res.status).toHaveBeenCalledWith(201);
       expect(res.json).toHaveBeenCalledWith({ id: "contact-web-1" });
+    });
+
+    it("mirrors the submission to the SuperAdmin panel", async () => {
+      mockedContactService.createWebRequest.mockResolvedValueOnce({
+        id: "contact-web-2",
+      });
+      const body = {
+        type: "GENERAL_ENQUIRY",
+        source: "PMS_WEB",
+        message: "Help",
+        fullName: "Web User",
+        email: "web@user.com",
+        phone: "1234567890",
+      };
+      const res = createResponse();
+
+      await ContactController.createWeb({ body } as any, res as any);
+
+      expect(mockedForward).toHaveBeenCalledWith(expect.objectContaining(body));
+    });
+
+    it("does not mirror a submission that was never stored", async () => {
+      mockedContactService.createWebRequest.mockRejectedValueOnce(
+        new ContactServiceError("invalid", 422),
+      );
+      const res = createResponse();
+
+      await ContactController.createWeb(
+        {
+          body: {
+            type: "GENERAL_ENQUIRY",
+            source: "PMS_WEB",
+            message: "Help",
+            email: "web@user.com",
+          },
+        } as any,
+        res as any,
+      );
+
+      // Our database is the source of truth: if the write failed there is
+      // nothing to mirror, and forwarding anyway would put a record in the
+      // panel that exists nowhere else.
+      expect(mockedForward).not.toHaveBeenCalled();
     });
 
     it("handles ContactServiceError responses", async () => {

--- a/apps/backend/test/services/superadmin-contact.service.test.ts
+++ b/apps/backend/test/services/superadmin-contact.service.test.ts
@@ -1,0 +1,113 @@
+const warnMock = jest.fn();
+const errorMock = jest.fn();
+
+jest.mock("../../src/utils/logger", () => ({
+  __esModule: true,
+  default: {
+    error: errorMock,
+    info: jest.fn(),
+    warn: warnMock,
+    debug: jest.fn(),
+  },
+}));
+
+import { SuperadminContactService } from "../../src/services/superadmin-contact.service";
+import type { CreateWebContactRequestInput } from "../../src/services/contact-us.service";
+
+const makeResponse = (ok = true, status = 200) =>
+  ({ ok, status }) as unknown as Response;
+
+const PAYLOAD = {
+  type: "GENERAL_ENQUIRY",
+  source: "WEB",
+  message: "my dog ate the invoice",
+  fullName: "Ada Lovelace",
+  email: "ada@example.com",
+  phone: "+441234567890",
+} as unknown as CreateWebContactRequestInput;
+
+describe("SuperadminContactService.forwardWebContact", () => {
+  const originalEnv = process.env;
+  const originalFetch = globalThis.fetch;
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+    fetchMock = jest.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    globalThis.fetch = originalFetch;
+  });
+
+  const configure = () => {
+    process.env.SUPERADMIN_CONTACT_INTAKE_URL =
+      "https://panel.example.com/api/contact";
+    process.env.SUPERADMIN_CONTACT_INTAKE_KEY = "shared-secret";
+  };
+
+  it("does nothing when the URL is unset", async () => {
+    process.env.SUPERADMIN_CONTACT_INTAKE_KEY = "shared-secret";
+    delete process.env.SUPERADMIN_CONTACT_INTAKE_URL;
+    await SuperadminContactService.forwardWebContact(PAYLOAD);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(warnMock).not.toHaveBeenCalled();
+    expect(errorMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the key is unset", async () => {
+    process.env.SUPERADMIN_CONTACT_INTAKE_URL =
+      "https://panel.example.com/api/contact";
+    delete process.env.SUPERADMIN_CONTACT_INTAKE_KEY;
+    await SuperadminContactService.forwardWebContact(PAYLOAD);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(errorMock).not.toHaveBeenCalled();
+  });
+
+  it("posts the payload verbatim with the shared key and a timeout", async () => {
+    configure();
+    fetchMock.mockResolvedValue(makeResponse());
+    await SuperadminContactService.forwardWebContact(PAYLOAD);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://panel.example.com/api/contact");
+    expect(init.method).toBe("POST");
+    expect(init.headers).toMatchObject({
+      "content-type": "application/json",
+      "x-contact-key": "shared-secret",
+    });
+    // Verbatim: the panel maps fullName/type/phone itself, so nothing is
+    // reshaped here and a field added to the form flows through untouched.
+    expect(JSON.parse(init.body as string)).toEqual(PAYLOAD);
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("warns but resolves when the panel rejects the forward", async () => {
+    configure();
+    fetchMock.mockResolvedValue(makeResponse(false, 401));
+    await expect(
+      SuperadminContactService.forwardWebContact(PAYLOAD),
+    ).resolves.toBeUndefined();
+    expect(warnMock).toHaveBeenCalledWith(
+      "SuperAdmin contact intake rejected the forward",
+      { status: 401 },
+    );
+  });
+
+  it("logs but resolves when the request itself fails", async () => {
+    configure();
+    const error = new Error("ECONNREFUSED");
+    fetchMock.mockRejectedValue(error);
+    await expect(
+      SuperadminContactService.forwardWebContact(PAYLOAD),
+    ).resolves.toBeUndefined();
+    expect(errorMock).toHaveBeenCalledWith(
+      "Failed to forward contact submission to SuperAdmin",
+      { error },
+    );
+  });
+});


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

Public contact submissions are stored in our own database and forwarded nowhere,
so the team has no CRM view of them in the SuperAdmin panel.

Two public forms are affected, not one. `/contact-us` and `/accessibility/report`
both post to `POST /v1/contact-us/contact-web`, so both land in
`ContactController.createWeb`, which stores the submission and returns.

## What is the new behavior?

`SuperadminContactService.forwardWebContact` posts the submission to the panel's
`/api/contact`, and `createWeb` calls it immediately after the write succeeds.
Because both forms share the endpoint, this single forward mirrors both.

The design is deliberately defensive in four ways:

- **Fire and forget.** The call is `void`-ed rather than awaited. The visitor's
  submission must not fail because the panel is down, and our database already
  holds the record.
- **Only what was actually stored.** The forward sits after
  `createWebRequest` resolves, so a failed write mirrors nothing. Forwarding
  regardless would put a record in the panel that exists nowhere else.
- **Off unless configured.** Absent `SUPERADMIN_CONTACT_INTAKE_URL` or
  `SUPERADMIN_CONTACT_INTAKE_KEY` means an immediate return, with no fetch and no
  log noise.
- **Bounded.** A 5 second `AbortSignal.timeout`. The forward is off the request
  path, but an unbounded hang would still pin a socket for nothing when the panel
  is unreachable.

The body is sent **verbatim**. The panel's intake accepts the contact-web shape
and maps `fullName`/`type`/`phone` itself, so no field mapping happens here and a
field added to the form flows through untouched. This was checked against the
panel's route rather than assumed.

A non-ok response warns, a thrown request logs at error, and both resolve.

## Related Issue(s)

Fixes #2348

## Validation performed

- `npx jest test/services/superadmin-contact.service.test.ts test/controllers/contact-us.controller.test.ts` - 26 tests, all passing.
- Five service cases: unconfigured URL, unconfigured key, happy path (asserting
  the URL, both headers, a verbatim body and that `init.signal` is an
  `AbortSignal`), non-ok response, and a rejected request.
- Two new controller cases: the mirror **is** called with the payload on the
  success path, and **is not** called when `createWebRequest` throws.
- `npx tsc --noEmit` reports nothing in either file I touched.
- Lint: the backend has pre-existing failures from unbuilt workspace packages
  (`@yosemite-crew/auth`, `@yosemite-crew/database`). I verified this rather than
  assuming: `npx eslint src/controllers/app/contact-us.controller.ts` reports
  **11 errors before my change and 11 after**, the same set with shifted line
  numbers. The new service file lints clean.

## Deploy note

Set `SUPERADMIN_CONTACT_INTAKE_URL` and `SUPERADMIN_CONTACT_INTAKE_KEY` on the
backend, and the same secret as `CONTACT_INTAKE_KEY` on the panel. Until then the
mirror is inert and the site behaves exactly as it does today.
