### PR TITLE
fix(mobile): preserve underlying social sign-in error in useSocialAuth

### DIFF
--- a/apps/mobileAppYC/__tests__/hooks/useSocialAuth.test.ts
+++ b/apps/mobileAppYC/__tests__/hooks/useSocialAuth.test.ts
@@ -3,6 +3,7 @@ import {DeviceEventEmitter} from 'react-native'; // Import comes first
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {useSocialAuth} from '@/features/auth/hooks/useSocialAuth';
 import {signInWithSocialProvider} from '@/features/auth/services/socialAuth';
+import {capturePostHogEvent} from '@/shared/services/posthogAnalytics';
 import {
   PENDING_PROFILE_STORAGE_KEY,
   PENDING_PROFILE_UPDATED_EVENT,
@@ -35,6 +36,14 @@ jest.mock('react-native', () => ({
 }));
 const mockedDeviceEventEmitter = DeviceEventEmitter as jest.Mocked<
   typeof DeviceEventEmitter
+>;
+
+// Mock PostHog analytics
+jest.mock('@/shared/services/posthogAnalytics', () => ({
+  capturePostHogEvent: jest.fn(),
+}));
+const mockedCapturePostHogEvent = capturePostHogEvent as jest.MockedFunction<
+  typeof capturePostHogEvent
 >;
 
 // --- Mock Data ---
@@ -251,21 +260,42 @@ describe('useSocialAuth', () => {
   it('should throw generic error message on a generic error', async () => {
     const error = new Error('Generic fail');
     mockedSignInWithSocialProvider.mockRejectedValue(error);
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
     const {result} = renderHook(() => useSocialAuth(defaultProps));
 
-    await expect(
-      act(async () => {
+    let thrown: unknown;
+    try {
+      await act(async () => {
         await result.current.handleSocialAuth('google');
-      }),
-    ).rejects.toThrow(genericErrorMessage);
+      });
+    } catch (caught) {
+      thrown = caught;
+    }
 
+    // Still surfaces the generic message to the caller
+    expect((thrown as Error).message).toBe(genericErrorMessage);
     expect(mockOnStart).toHaveBeenCalledTimes(1);
     expect(mockOnNewProfile).not.toHaveBeenCalled();
     expect(mockOnExistingProfile).not.toHaveBeenCalled();
 
+    // Underlying error is preserved for debugging
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[useSocialAuth] Social sign-in failed',
+      error,
+    );
+    expect(mockedCapturePostHogEvent).toHaveBeenCalledWith(
+      'social_sign_in_failed',
+      expect.objectContaining({provider: 'google', code: 'unknown'}),
+    );
+    expect((thrown as Error & {cause?: unknown}).cause).toBe(error);
+
     // Check final state
     expect(result.current.activeProvider).toBeNull();
     expect(result.current.isSocialLoading).toBe(false);
+
+    consoleErrorSpy.mockRestore();
   });
 
   it('should throw cancelled error message if error code is "auth/cancelled"', async () => {

--- a/apps/mobileAppYC/__tests__/services/posthogAnalytics.test.ts
+++ b/apps/mobileAppYC/__tests__/services/posthogAnalytics.test.ts
@@ -2,9 +2,11 @@ const mockScreen = jest.fn().mockResolvedValue(undefined);
 const mockOptIn = jest.fn().mockResolvedValue(undefined);
 const mockOptOut = jest.fn().mockResolvedValue(undefined);
 const mockReset = jest.fn();
+const mockCapture = jest.fn();
 
 jest.mock('posthog-react-native', () =>
   jest.fn().mockImplementation(() => ({
+    capture: mockCapture,
     optIn: mockOptIn,
     optOut: mockOptOut,
     reset: mockReset,
@@ -211,6 +213,43 @@ describe('posthogAnalytics', () => {
 
     expect(() => resetPostHog()).not.toThrow();
     expect(mockReset).not.toHaveBeenCalled();
+  });
+
+  it('captures an event with properties through PostHog', () => {
+    const {
+      capturePostHogEvent,
+    } = require('../../src/shared/services/posthogAnalytics');
+
+    capturePostHogEvent('social_sign_in_failed', {
+      provider: 'google',
+      code: 'unknown',
+    });
+
+    expect(mockCapture).toHaveBeenCalledWith('social_sign_in_failed', {
+      provider: 'google',
+      code: 'unknown',
+    });
+  });
+
+  it('captures an event without properties through PostHog', () => {
+    const {
+      capturePostHogEvent,
+    } = require('../../src/shared/services/posthogAnalytics');
+
+    capturePostHogEvent('app_opened');
+
+    expect(mockCapture).toHaveBeenCalledWith('app_opened', undefined);
+  });
+
+  it('capturePostHogEvent does nothing when client is null', () => {
+    mockEnabled = false;
+    const {
+      capturePostHogEvent,
+    } = require('../../src/shared/services/posthogAnalytics');
+
+    capturePostHogEvent('social_sign_in_failed', {provider: 'google'});
+
+    expect(mockCapture).not.toHaveBeenCalled();
   });
 
   it('getPostHogClient initializes and returns the client', () => {

--- a/apps/mobileAppYC/src/features/auth/hooks/useSocialAuth.ts
+++ b/apps/mobileAppYC/src/features/auth/hooks/useSocialAuth.ts
@@ -9,6 +9,7 @@ import {
   signInWithSocialProvider,
   type SocialProvider,
 } from '@/features/auth/services/socialAuth';
+import {capturePostHogEvent} from '@/shared/services/posthogAnalytics';
 import type {AuthStackParamList} from '@/navigation/AuthNavigator';
 
 type SocialAuthResult = Awaited<ReturnType<typeof signInWithSocialProvider>>;
@@ -108,7 +109,14 @@ export const useSocialAuth = ({
         if (isAccountExists) {
           throw new Error(message || DEFAULT_ACCOUNT_EXISTS_MESSAGE);
         }
-        throw new Error(genericErrorMessage);
+        console.error('[useSocialAuth] Social sign-in failed', rawError);
+        capturePostHogEvent('social_sign_in_failed', {
+          provider,
+          code: error?.code ?? 'unknown',
+        });
+        const wrapped = new Error(genericErrorMessage);
+        (wrapped as Error & {cause?: unknown}).cause = rawError;
+        throw wrapped;
       } finally {
         updateActiveProvider(null);
       }

--- a/apps/mobileAppYC/src/shared/services/posthogAnalytics.ts
+++ b/apps/mobileAppYC/src/shared/services/posthogAnalytics.ts
@@ -76,6 +76,18 @@ export const setPostHogTrackingEnabled = async (enabled: boolean) => {
   await client.optOut();
 };
 
+export const capturePostHogEvent = (
+  event: string,
+  properties?: Record<string, unknown>,
+) => {
+  const client = getPostHogClient();
+  if (!client) {
+    return;
+  }
+
+  client.capture(event, properties as Parameters<typeof client.capture>[1]);
+};
+
 export const resetPostHog = () => {
   posthogClient?.reset();
 };


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

In `useSocialAuth`, the generic catch branch collapsed every non-cancelled, non-account-exists failure into a single generic Error string. The underlying social sign-in error was thrown away entirely, so there was no log, no analytics signal, and no way to see the real cause when a sign-in broke in the field.

## What is the new behavior?

The generic catch branch now preserves the original error while still surfacing the same generic message to the caller:

- Logs the raw error with `console.error('[useSocialAuth] Social sign-in failed', rawError)`.
- Emits a PostHog `social_sign_in_failed` event carrying only `{provider, code}` (code falls back to `'unknown'`), so no sensitive error contents are sent.
- Throws a wrapped Error that keeps the original error on its `.cause` property, so downstream handlers retain the full context.

Supporting change: added an exported `capturePostHogEvent(event, properties?)` helper in `posthogAnalytics` that no-ops when the PostHog client is unavailable, and used it here instead of touching the client directly.

Tests:
- Extended the generic-error case in `useSocialAuth.test.ts` to assert the `console.error` call, the PostHog event, the preserved `.cause`, and that the surfaced message is unchanged.
- Added `posthogAnalytics.test.ts` cases for capturing with properties, without properties, and the null-client no-op.

## Impact area

`apps/mobileAppYC` only. No user-facing behavior change: the caller still receives the same generic error message. Adds a new PostHog event and a console error log on the failure path.

## Validation performed

- Type-check clean.
- Lint clean.
- 12/12 `useSocialAuth` tests pass.

Note: the added `posthogAnalytics` tests were not separately reported in the work summary; only the `useSocialAuth` suite result (12/12) was confirmed.

## Related Issue(s)

Fixes #2358

Closes #2358
