### PR TITLE
fix(mobile): repair onboarding last-slide spacer, sign-in tap, and dots

### DIFF
--- a/apps/mobileAppYC/__tests__/features/onboarding/screens/OnboardingScreen.test.tsx
+++ b/apps/mobileAppYC/__tests__/features/onboarding/screens/OnboardingScreen.test.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import {mockTheme} from '../setup/mockTheme';
-import {render, fireEvent, screen, act} from '@testing-library/react-native';
+import {
+  render,
+  fireEvent,
+  screen,
+  act,
+  within,
+} from '@testing-library/react-native';
 import {OnboardingScreen} from '../../../../src/features/onboarding/screens/OnboardingScreen';
 import {AccessibilityInfo, FlatList, StyleSheet} from 'react-native';
 
@@ -84,6 +90,69 @@ describe('OnboardingScreen', () => {
     render(<OnboardingScreen onComplete={onComplete} />);
     fireEvent.press(screen.getAllByText('Sign in')[0]);
     expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the last-slide top-bar spacer as an invisible layout placeholder', () => {
+    render(<OnboardingScreen onComplete={jest.fn()} />);
+    const spacerStyle = StyleSheet.flatten(
+      screen.getByTestId('onboarding-topbar-spacer').props.style,
+    );
+    // Same 40x40 footprint as the glass button but with no fill or border, so
+    // it holds the back chevron left-anchored without painting a blob.
+    expect(spacerStyle.backgroundColor).toBeUndefined();
+    expect(spacerStyle.borderWidth).toBeUndefined();
+  });
+
+  it('exposes "Sign in" as a pressable button with a hit slop that finishes onboarding', () => {
+    const onComplete = jest.fn();
+    render(<OnboardingScreen onComplete={onComplete} />);
+    const signIn = screen.getAllByLabelText('Sign in')[0];
+    expect(signIn.props.accessibilityRole).toBe('button');
+    expect(signIn.props.hitSlop).toBeDefined();
+    fireEvent.press(signIn);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('anchors the page dots in the bottom block alongside the "Get started" CTA', () => {
+    render(<OnboardingScreen onComplete={jest.fn()} />);
+
+    // The dots now live in the fixed-height bottom block next to "Get started".
+    // Their nearest shared ancestor with that CTA is that bottom block, which -
+    // unlike the old layout where the dots hung under the variable-height top
+    // block - must NOT contain the slide's subtitle. That exclusion proves the
+    // dots moved down and stop shifting between swipes.
+    const cta = screen.getByLabelText('Get started');
+    const ctaAncestors = new Set<unknown>();
+    for (let node = cta.parent; node; node = node.parent) {
+      ctaAncestors.add(node);
+    }
+
+    // For each slide's dots, the nearest ancestor it shares with the final CTA.
+    // Only the final slide's dots share the tight bottom block; the others share
+    // just the outer list container.
+    const sharedBlocks = screen.getAllByTestId('onboarding-dots').map(dots => {
+      for (let node = dots.parent; node; node = node.parent) {
+        if (ctaAncestors.has(node)) {
+          return node;
+        }
+      }
+      return null;
+    });
+
+    const coLocated = sharedBlocks.some(block => {
+      if (!block) {
+        return false;
+      }
+      const scoped = within(block);
+      return (
+        scoped.queryByLabelText('Get started') !== null &&
+        scoped.queryByText(
+          'Real openings at your linked clinic, records that travel with you, bills settled in two taps.',
+        ) === null
+      );
+    });
+
+    expect(coLocated).toBe(true);
   });
 
   it('calls onComplete when "Get started" (last slide) is pressed', () => {

--- a/apps/mobileAppYC/src/features/onboarding/screens/OnboardingScreen.tsx
+++ b/apps/mobileAppYC/src/features/onboarding/screens/OnboardingScreen.tsx
@@ -196,7 +196,10 @@ export const OnboardingScreen: React.FC<OnboardingScreenProps> = ({
                   <Text style={styles.skipText}>{t('onboarding.skip')}</Text>
                 </PressableOpacity>
               ) : (
-                <View style={styles.glassCircle} />
+                <View
+                  style={styles.topBarSpacer}
+                  testID="onboarding-topbar-spacer"
+                />
               )}
             </View>
           </SafeAreaView>
@@ -239,8 +242,10 @@ export const OnboardingScreen: React.FC<OnboardingScreenProps> = ({
                 </View>
 
                 <Text style={styles.subtitle}>{item.subtitle}</Text>
+              </View>
 
-                <View style={styles.dots}>
+              <View style={styles.contentBottom}>
+                <View style={styles.dots} testID="onboarding-dots">
                   {SLIDES.map((slide, dotIndex) => (
                     <View
                       key={slide.id}
@@ -253,9 +258,7 @@ export const OnboardingScreen: React.FC<OnboardingScreenProps> = ({
                     />
                   ))}
                 </View>
-              </View>
 
-              <View style={styles.contentBottom}>
                 <PressableOpacity
                   style={styles.ctaButton}
                   onPress={() => goNext(index)}
@@ -268,9 +271,15 @@ export const OnboardingScreen: React.FC<OnboardingScreenProps> = ({
                   <Text style={styles.signInMuted}>
                     {t('onboarding.alreadyHaveAccount')}
                   </Text>
-                  <Text style={styles.signInLink} onPress={onComplete}>
-                    {t('onboarding.signIn')}
-                  </Text>
+                  <PressableOpacity
+                    onPress={onComplete}
+                    hitSlop={{top: 10, bottom: 10, left: 10, right: 10}}
+                    accessibilityRole="button"
+                    accessibilityLabel={t('onboarding.signIn')}>
+                    <Text style={styles.signInLink}>
+                      {t('onboarding.signIn')}
+                    </Text>
+                  </PressableOpacity>
                 </View>
               </View>
             </ScrollView>
@@ -353,6 +362,7 @@ const createStyles = (theme: Theme) =>
       alignItems: 'center',
       justifyContent: 'center',
     },
+    topBarSpacer: {width: 40, height: 40},
     chevron: {
       fontSize: 26,
       lineHeight: 28,
@@ -430,7 +440,7 @@ const createStyles = (theme: Theme) =>
     dots: {
       flexDirection: 'row',
       gap: theme.spacing['2'],
-      marginTop: theme.spacing['5'],
+      marginBottom: theme.spacing['5'],
     },
     dot: {height: 7, borderRadius: theme.borderRadius.full},
     dotActive: {width: 22, backgroundColor: theme.colors.blue},


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

On the onboarding last slide:

- The top-bar slot where Skip appears on earlier slides rendered a filled glass circle, leaving a stray blob in the top bar.
- "Sign in" was a plain Text with an onPress handler, which gave a small tap target and no button accessibility semantics.
- The page dots were positioned in the variable-height content block above the CTA, so they shifted vertically as the slide content changed between swipes.

## What is the new behavior?

In `apps/mobileAppYC/src/features/onboarding/screens/OnboardingScreen.tsx`:

- The final-slide top-bar placeholder is now an invisible 40x40 spacer (`styles.topBarSpacer`, testID `onboarding-topbar-spacer`) with no background or border, so it holds the layout without painting a blob.
- "Sign in" is wrapped in a `PressableOpacity` with a 10px `hitSlop`, `accessibilityRole="button"`, and an `accessibilityLabel`, and it still calls `onComplete` on press.
- The page dots (testID `onboarding-dots`) moved into the fixed-height `contentBottom` block, directly above the "Get started" CTA, and their spacing changed from `marginTop` to `marginBottom` so they no longer jump between slides.

Three regression tests were added to `OnboardingScreen.test.tsx` covering the spacer, the pressable Sign in target, and the dots co-location with the CTA.

Impact area: mobile app (`apps/mobileAppYC`) onboarding flow only.

Validation performed: type-check clean, lint clean, and 15/15 targeted tests pass via `pnpm --filter mobileAppYC run test OnboardingScreen`. Visual rendering was not verified in a running app or simulator.

## Related Issue(s)

Fixes #2362

Closes #2362
