### PR TITLE
fix(mobile): tint FloatingTabBar glass pill with nav wash for contrast

### DIFF
--- a/apps/mobileAppYC/__tests__/navigation/FloatingTabBar.test.tsx
+++ b/apps/mobileAppYC/__tests__/navigation/FloatingTabBar.test.tsx
@@ -488,6 +488,40 @@ describe('FloatingTabBar', () => {
       ).not.toThrow();
     });
 
+    it('tints the sliding pill glass with the pale nav wash, not the solid blue', () => {
+      const props: any = createProps(0);
+      const {getAllByRole, queryAllByTestId} = render(
+        <Provider store={store}>
+          <FloatingTabBar {...props} />
+        </Provider>,
+      );
+
+      const tabs = getAllByRole('button');
+      fireEvent(tabs[0], 'layout', {
+        nativeEvent: {layout: {x: 0, width: 100}},
+      });
+      fireEvent(tabs[1], 'layout', {
+        nativeEvent: {layout: {x: 100, width: 100}},
+      });
+
+      const glassViews = queryAllByTestId('liquid-glass-view');
+      expect(glassViews).toHaveLength(2);
+
+      // The sliding pill must use the pale navActiveBg wash the active
+      // #1657C9 label/icon were tuned against for contrast.
+      expect(
+        glassViews.some(
+          v => v.props.tintColor === mockTheme.colors.navActiveBg,
+        ),
+      ).toBe(true);
+
+      // Regression guard: no glass view may fall back to the low-contrast
+      // solid blue (#257BED) pill.
+      expect(
+        glassViews.some(v => v.props.tintColor === mockTheme.colors.blue),
+      ).toBe(false);
+    });
+
     it('falls back to a width of 0 when the active tab has no recorded layout', () => {
       const routes = [
         {key: 'r0', name: 'HomeStack'},

--- a/apps/mobileAppYC/src/navigation/FloatingTabBar.tsx
+++ b/apps/mobileAppYC/src/navigation/FloatingTabBar.tsx
@@ -184,7 +184,7 @@ export const FloatingTabBar: React.FC<BottomTabBarProps> = props => {
           <LiquidGlassView
             style={styles.pillGlass}
             effect="clear"
-            tintColor={theme.colors.blue}
+            tintColor={theme.colors.navActiveBg}
             colorScheme="light"
             interactive
           />


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

On iOS 26, the FloatingTabBar sliding pill renders through the Liquid Glass
path, and its LiquidGlassView was tinted with `theme.colors.blue` (solid
#257BED). The active label and icon use `navActive` #1657C9, colors that
were tuned for contrast against the non-glass path's pale wash, not against
a solid blue fill. As a result the active label did not read cleanly against
the glass pill.

## What is the new behavior?

The sliding-pill `LiquidGlassView` tint changes from `theme.colors.blue` to
`theme.colors.navActiveBg` (the pale nav wash), so the glass pill matches the
background the active #1657C9 label and icon were tuned against, restoring
contrast between the active label and its pill.

A regression test in `FloatingTabBar.test.tsx` asserts that, after layout, one
of the two rendered glass views is tinted with `navActiveBg` and that no glass
view falls back to the solid `blue` tint.

Impact area: `apps/mobileAppYC` navigation (FloatingTabBar) on the iOS 26
Liquid Glass path only. No change to the non-glass fallback.

Validation performed:
- Type-check clean.
- Lint clean.
- The new regression test passes when run directly.
- The full mobile suite (7528 tests) passed; note the `--testPathPatterns`
  filter was swallowed by pnpm, so the entire suite ran rather than the
  targeted file.

Not verified: an iOS 26 Release simulator build to confirm the rendered
contrast reaches >=4.5:1 on device.

Deferred (pending design sign-off): the bar-scrim bleed-through and the shared
`inkFaint` inactive-label token are left unchanged in this PR.

## Related Issue(s)

Fixes #2367

Closes #2367
