### PR TITLE
fix(frontend): serve the emailed /auth/verify-email link instead of 404

### DIFF
--- a/apps/frontend/src/app/(routes)/(public)/auth/reset-password/page.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/auth/reset-password/page.tsx
@@ -1,26 +1,18 @@
 import { redirect } from 'next/navigation';
 
-type SearchParams = Record<string, string | string[] | undefined>;
+import {
+  buildForwardedAuthLink,
+  type AuthLinkSearchParams,
+} from '@/app/features/auth/lib/authLinkForwarding';
 
 /**
- * SuperTokens emails the password reset link under the backend's websiteBasePath
- * (default `/auth`), i.e. `/auth/reset-password?token=...`. The reset UI lives at the
- * canonical `/reset-password`, so forward here while preserving the token and any
- * other query params. This is a server-side redirect (no client-side navigation);
- * submitNewPassword reads the token from the final URL, so nothing is lost.
+ * SuperTokens emails the password reset link as `/auth/reset-password?token=...`.
+ * Forward it to the canonical `/reset-password`, preserving the token, which
+ * `submitNewPassword` reads from the final URL. See `authLinkForwarding` for why
+ * this route has to exist at all.
  */
 export default async function Page({
   searchParams,
-}: Readonly<{ searchParams: Promise<SearchParams> }>) {
-  const params = await searchParams;
-  const query = new URLSearchParams();
-  for (const [key, value] of Object.entries(params)) {
-    if (Array.isArray(value)) {
-      if (value[0] != null) query.set(key, value[0]);
-    } else if (value != null) {
-      query.set(key, value);
-    }
-  }
-  const qs = query.toString();
-  redirect(qs ? `/reset-password?${qs}` : '/reset-password');
+}: Readonly<{ searchParams: Promise<AuthLinkSearchParams> }>) {
+  redirect(buildForwardedAuthLink('/reset-password', await searchParams));
 }

--- a/apps/frontend/src/app/(routes)/(public)/auth/verify-email/page.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/auth/verify-email/page.tsx
@@ -1,42 +1,17 @@
 import { redirect } from 'next/navigation';
 
-type SearchParams = Record<string, string | string[] | undefined>;
+import {
+  buildForwardedAuthLink,
+  type AuthLinkSearchParams,
+} from '@/app/features/auth/lib/authLinkForwarding';
 
 /**
- * SuperTokens emails the verification link under the backend's websiteBasePath
- * (`AUTH_WEBSITE_BASE_PATH`, `/auth` in every environment), i.e.
- * `/auth/verify-email?token=...`. The verification UI lives at the canonical
- * `/verify-email`, so forward here while preserving the token and any other
- * query params.
- *
- * Without this route the emailed link 404s. That is not cosmetic:
- * `EmailVerification.init` runs with `mode: 'REQUIRED'`, so a new account cannot
- * be used until it is verified - a 404 here blocks every signup at the last
- * step, after the form has already succeeded. Reported from production by a
- * prospect who could sign up but never get in.
- *
- * This mirrors the sibling `auth/reset-password` route, which forwards the reset
- * link for the same reason. Keep the two in step: any future SuperTokens link
- * that is emailed under `/auth/*` needs a shim like this, because the emailed
- * path and the app's route are decided in different places.
- *
- * Deliberately a server-side redirect (no client-side navigation): VerifyEmail
- * reads the token from the final URL, so nothing is lost. Being a pure redirect
- * it renders no markup, which is why - like auth/reset-password - it is absent
- * from STRICT_CSP_PATH_PREFIXES in middleware.ts.
+ * SuperTokens emails the verification link as `/auth/verify-email?token=...`.
+ * Forward it to the canonical `/verify-email`, preserving the token. See
+ * `authLinkForwarding` for why this route has to exist at all.
  */
 export default async function Page({
   searchParams,
-}: Readonly<{ searchParams: Promise<SearchParams> }>) {
-  const params = await searchParams;
-  const query = new URLSearchParams();
-  for (const [key, value] of Object.entries(params)) {
-    if (Array.isArray(value)) {
-      if (value[0] != null) query.set(key, value[0]);
-    } else if (value != null) {
-      query.set(key, value);
-    }
-  }
-  const qs = query.toString();
-  redirect(qs ? `/verify-email?${qs}` : '/verify-email');
+}: Readonly<{ searchParams: Promise<AuthLinkSearchParams> }>) {
+  redirect(buildForwardedAuthLink('/verify-email', await searchParams));
 }

--- a/apps/frontend/src/app/(routes)/(public)/auth/verify-email/page.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/auth/verify-email/page.tsx
@@ -1,0 +1,42 @@
+import { redirect } from 'next/navigation';
+
+type SearchParams = Record<string, string | string[] | undefined>;
+
+/**
+ * SuperTokens emails the verification link under the backend's websiteBasePath
+ * (`AUTH_WEBSITE_BASE_PATH`, `/auth` in every environment), i.e.
+ * `/auth/verify-email?token=...`. The verification UI lives at the canonical
+ * `/verify-email`, so forward here while preserving the token and any other
+ * query params.
+ *
+ * Without this route the emailed link 404s. That is not cosmetic:
+ * `EmailVerification.init` runs with `mode: 'REQUIRED'`, so a new account cannot
+ * be used until it is verified - a 404 here blocks every signup at the last
+ * step, after the form has already succeeded. Reported from production by a
+ * prospect who could sign up but never get in.
+ *
+ * This mirrors the sibling `auth/reset-password` route, which forwards the reset
+ * link for the same reason. Keep the two in step: any future SuperTokens link
+ * that is emailed under `/auth/*` needs a shim like this, because the emailed
+ * path and the app's route are decided in different places.
+ *
+ * Deliberately a server-side redirect (no client-side navigation): VerifyEmail
+ * reads the token from the final URL, so nothing is lost. Being a pure redirect
+ * it renders no markup, which is why - like auth/reset-password - it is absent
+ * from STRICT_CSP_PATH_PREFIXES in middleware.ts.
+ */
+export default async function Page({
+  searchParams,
+}: Readonly<{ searchParams: Promise<SearchParams> }>) {
+  const params = await searchParams;
+  const query = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (Array.isArray(value)) {
+      if (value[0] != null) query.set(key, value[0]);
+    } else if (value != null) {
+      query.set(key, value);
+    }
+  }
+  const qs = query.toString();
+  redirect(qs ? `/verify-email?${qs}` : '/verify-email');
+}

--- a/apps/frontend/src/app/__tests__/(routes)/auth/verify-email/page.test.tsx
+++ b/apps/frontend/src/app/__tests__/(routes)/auth/verify-email/page.test.tsx
@@ -1,0 +1,46 @@
+import Page from '@/app/(routes)/(public)/auth/verify-email/page';
+
+const redirectMock = jest.fn();
+jest.mock('next/navigation', () => ({
+  redirect: (url: string) => redirectMock(url),
+}));
+
+describe('Auth verify-email redirect route', () => {
+  beforeEach(() => {
+    redirectMock.mockClear();
+  });
+
+  it('forwards to /verify-email preserving the verification token query', async () => {
+    await Page({
+      searchParams: Promise.resolve({
+        token: 'abc123',
+        tenantId: 'public',
+        rid: 'emailverification',
+      }),
+    });
+    expect(redirectMock).toHaveBeenCalledWith(
+      '/verify-email?token=abc123&tenantId=public&rid=emailverification'
+    );
+  });
+
+  it('forwards to /verify-email when there is no query', async () => {
+    await Page({ searchParams: Promise.resolve({}) });
+    expect(redirectMock).toHaveBeenCalledWith('/verify-email');
+  });
+
+  it('takes the first value of a repeated query param and skips empty ones', async () => {
+    await Page({
+      searchParams: Promise.resolve({ token: ['first', 'second'], empty: undefined }),
+    });
+    expect(redirectMock).toHaveBeenCalledWith('/verify-email?token=first');
+  });
+
+  // The token is the whole point of the link: a redirect that dropped it would
+  // still return 200 and still look fixed, while leaving the account unverified.
+  it('never forwards without the token that was supplied', async () => {
+    await Page({ searchParams: Promise.resolve({ token: 'tok_9f3a' }) });
+    const target = redirectMock.mock.calls[0][0] as string;
+    expect(target.startsWith('/verify-email?')).toBe(true);
+    expect(new URLSearchParams(target.split('?')[1]).get('token')).toBe('tok_9f3a');
+  });
+});

--- a/apps/frontend/src/app/__tests__/features/auth/authLinkForwarding.test.ts
+++ b/apps/frontend/src/app/__tests__/features/auth/authLinkForwarding.test.ts
@@ -1,0 +1,49 @@
+import { buildForwardedAuthLink } from '@/app/features/auth/lib/authLinkForwarding';
+
+describe('buildForwardedAuthLink', () => {
+  it('preserves the token and every other query param', () => {
+    expect(
+      buildForwardedAuthLink('/verify-email', {
+        token: 'abc123',
+        tenantId: 'public',
+        rid: 'emailverification',
+      })
+    ).toBe('/verify-email?token=abc123&tenantId=public&rid=emailverification');
+  });
+
+  it('returns the bare destination when there is no query', () => {
+    expect(buildForwardedAuthLink('/reset-password', {})).toBe('/reset-password');
+  });
+
+  it('takes the first value of a repeated param', () => {
+    expect(buildForwardedAuthLink('/verify-email', { token: ['first', 'second'] })).toBe(
+      '/verify-email?token=first'
+    );
+  });
+
+  it('drops an undefined param rather than serialising it', () => {
+    expect(buildForwardedAuthLink('/verify-email', { token: 'abc', empty: undefined })).toBe(
+      '/verify-email?token=abc'
+    );
+  });
+
+  it('drops a repeated param whose first value is missing', () => {
+    expect(buildForwardedAuthLink('/verify-email', { token: 'abc', stray: [] })).toBe(
+      '/verify-email?token=abc'
+    );
+  });
+
+  // The token is the whole point of the link. A forward that silently dropped or
+  // mangled it would still produce a valid-looking URL and a 200, while leaving
+  // the account unverified.
+  it('percent-encodes a token that contains URL-significant characters', () => {
+    const target = buildForwardedAuthLink('/verify-email', { token: 'a+b/c=d&e' });
+    expect(new URLSearchParams(target.split('?')[1]).get('token')).toBe('a+b/c=d&e');
+  });
+
+  it('keeps the destination and the query separate', () => {
+    expect(
+      buildForwardedAuthLink('/verify-email', { token: 't' }).startsWith('/verify-email?')
+    ).toBe(true);
+  });
+});

--- a/apps/frontend/src/app/features/auth/lib/authLinkForwarding.ts
+++ b/apps/frontend/src/app/features/auth/lib/authLinkForwarding.ts
@@ -1,0 +1,46 @@
+/**
+ * Forwarding for the auth links SuperTokens puts in emails.
+ *
+ * SuperTokens builds every emailed link from the backend's websiteBasePath
+ * (`AUTH_WEBSITE_BASE_PATH`, `/auth` in every environment), so a reset link
+ * arrives as `/auth/reset-password?token=...` and a verification link as
+ * `/auth/verify-email?token=...`. The UI for both lives one level up, at the
+ * canonical `/reset-password` and `/verify-email`. Each emailed path therefore
+ * needs a route that forwards to its canonical page, or the link 404s.
+ *
+ * That is not cosmetic for verification: `EmailVerification.init` runs with
+ * `mode: 'REQUIRED'`, so a missing route blocks signup at the final step, after
+ * the form has already succeeded.
+ *
+ * The emailed path and the app's route are decided in different places - one in
+ * the backend's SuperTokens config, one by the filesystem - with nothing tying
+ * them together, so this is easy to get wrong twice. Keeping the forwarding in
+ * one place means the next `/auth/*` link needs only a four-line route.
+ */
+
+export type AuthLinkSearchParams = Record<string, string | string[] | undefined>;
+
+/**
+ * Build the canonical URL to forward an emailed auth link to, preserving the
+ * token and every other query param.
+ *
+ * A repeated param keeps its first value, and empty ones are dropped, so the
+ * forwarded URL is always well formed even if the mail client mangles the link.
+ */
+export const buildForwardedAuthLink = (
+  destination: string,
+  params: AuthLinkSearchParams
+): string => {
+  const query = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(params)) {
+    if (Array.isArray(value)) {
+      if (value[0] != null) query.set(key, value[0]);
+    } else if (value != null) {
+      query.set(key, value);
+    }
+  }
+
+  const qs = query.toString();
+  return qs ? `${destination}?${qs}` : destination;
+};


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The email verification link sent to every new user 404s, so no new account can complete signup on production or dev.

SuperTokens builds the link from the backend's `websiteBasePath` (`AUTH_WEBSITE_BASE_PATH`, `/auth` in every environment), so the emailed link is `/auth/verify-email?token=...`. The verification UI lives at the canonical `/verify-email`, and nothing was serving the emailed path.

`EmailVerification.init` runs with `mode: 'REQUIRED'`, so an account is unusable until verified. The signup form succeeds and the user is then stopped dead at the final step.

The sibling `auth/reset-password` route already forwards the reset link for exactly this reason, and its docstring spells out the trap. Email verification was simply never given the same treatment.

## What is the new behavior?

Adds `apps/frontend/src/app/(routes)/(public)/auth/verify-email/page.tsx`, mirroring `auth/reset-password`: a server-side redirect to `/verify-email` that preserves the token and any other query params.

Being a pure redirect it renders no markup, so like `auth/reset-password` it stays out of `STRICT_CSP_PATH_PREFIXES` in `middleware.ts`.

## Validation performed

- New suite `__tests__/(routes)/auth/verify-email/page.test.tsx`, 4 cases, mirroring the reset-password suite and adding one that asserts the token survives the redirect.
- **Mutation-checked**, because a redirect test that passes for the wrong reason is worthless here. Pointing the redirect at `/auth/verify-email` fails 4/4; dropping the query string fails 3/4; restoring passes 4/4.
- **Route registration verified against a real build**, not just the unit test. The unit test imports the page module directly, so it would still pass if the file sat in the wrong directory and the URL kept 404ing. The production build's route table now lists the shim beside its sibling:

```
├ ƒ /auth/reset-password    170 B    106 kB
├ ƒ /auth/verify-email      170 B    106 kB
```

- `tsc --noEmit` clean; `pnpm --filter frontend run lint` 0 errors (1 pre-existing warning in an unrelated test file).

## Impact area

Web app (apps/frontend). No backend, schema or env change: the route is added to match the link the backend already sends.

## Related Issue(s)

Fixes #2381
