### PR TITLE
fix(frontend): authorise the theme pre-paint script under the strict CSP

### DIFF
--- a/apps/frontend/src/app/(routes)/(public)/layout.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/layout.tsx
@@ -1,20 +1,10 @@
 import '@/app/features/marketing/site/marketing.css';
 
+import { PRE_PAINT_SCRIPT } from '@/app/ui/theme/prePaintScript';
+
 interface PublicLayoutProps {
   children: React.ReactNode;
 }
-
-/**
- * Resolve the theme before the marketing content paints so dark mode never
- * flashes. Reads the explicit choice (localStorage 'yc-theme') else the OS
- * preference and stamps `data-theme` on <html>.
- *
- * Public routes use a non-strict CSP (unsafe-inline allowed), so this inline
- * script needs no nonce; it lives here rather than the root layout to stay off
- * the nonce-CSP app routes, which use ThemeScript instead.
- */
-const PRE_PAINT_SCRIPT =
-  "(function(){try{var s=localStorage.getItem('yc-theme');var d=s?s==='dark':matchMedia('(prefers-color-scheme:dark)').matches;document.documentElement.setAttribute('data-theme',d?'dark':'light');}catch(e){}})();";
 
 /**
  * The public surface renders its own chrome per page: marketing pages use

--- a/apps/frontend/src/app/__tests__/ui/theme/prePaintScript.test.ts
+++ b/apps/frontend/src/app/__tests__/ui/theme/prePaintScript.test.ts
@@ -1,0 +1,55 @@
+import { createHash } from 'node:crypto';
+
+import { buildContentSecurityPolicy, PRE_PAINT_SCRIPT_CSP_HASH } from '@/securityHeaders';
+import { PRE_PAINT_SCRIPT } from '@/app/ui/theme/prePaintScript';
+
+const sha256Base64 = (input: string) => createHash('sha256').update(input, 'utf8').digest('base64');
+
+describe('pre-paint script CSP hash', () => {
+  // The hash lives in securityHeaders.ts and the script in prePaintScript.ts,
+  // because securityHeaders must stay import-free: next.config.ts loads it
+  // through plain Node, outside webpack's alias resolution, so an `@/` import
+  // there breaks the config load. This test is what keeps the two in step -
+  // editing the script without updating the hash would silently re-block the
+  // theme script, which is the bug this fixed.
+  it('matches a freshly computed sha256 of the script it authorises', () => {
+    expect(PRE_PAINT_SCRIPT_CSP_HASH).toBe(`'sha256-${sha256Base64(PRE_PAINT_SCRIPT)}'`);
+  });
+
+  it('is expressed as a quoted CSP source, not a bare digest', () => {
+    expect(PRE_PAINT_SCRIPT_CSP_HASH).toMatch(/^'sha256-[A-Za-z0-9+/]+=*'$/);
+  });
+});
+
+describe('buildContentSecurityPolicy script-src', () => {
+  const scriptSrc = (csp: string) =>
+    csp
+      .split(';')
+      .map((d) => d.trim())
+      .find((d) => d.startsWith('script-src ')) ?? '';
+
+  it('authorises the pre-paint script by hash on the strict CSP', () => {
+    const directive = scriptSrc(
+      buildContentSecurityPolicy({ nonce: 'abc', allowInlineScripts: false })
+    );
+    expect(directive).toContain(PRE_PAINT_SCRIPT_CSP_HASH);
+    expect(directive).toContain("'nonce-abc'");
+  });
+
+  // The regression guard that matters most. Per the CSP spec, a hash or nonce
+  // makes the browser IGNORE 'unsafe-inline'. The public marketing pages are
+  // statically prerendered and depend on 'unsafe-inline' for their framework
+  // inline scripts, so leaking the hash into the permissive variant would break
+  // hydration across the whole marketing site while every unit test still passed.
+  it('never puts the hash on the permissive CSP, which would disable unsafe-inline', () => {
+    const directive = scriptSrc(buildContentSecurityPolicy({ allowInlineScripts: true }));
+    expect(directive).toContain("'unsafe-inline'");
+    expect(directive).not.toContain(PRE_PAINT_SCRIPT_CSP_HASH);
+    expect(directive).not.toContain('sha256-');
+  });
+
+  it('does not emit a nonce source on the permissive CSP either', () => {
+    const directive = scriptSrc(buildContentSecurityPolicy({ allowInlineScripts: true }));
+    expect(directive).not.toContain('nonce-');
+  });
+});

--- a/apps/frontend/src/app/ui/theme/ThemeScript.tsx
+++ b/apps/frontend/src/app/ui/theme/ThemeScript.tsx
@@ -1,5 +1,7 @@
 import { headers } from 'next/headers';
 
+import { PRE_PAINT_SCRIPT } from '@/app/ui/theme/prePaintScript';
+
 const NONCE_HEADER = 'x-nonce';
 
 /**
@@ -11,9 +13,6 @@ const NONCE_HEADER = 'x-nonce';
  * inline script is tagged with that request's nonce rather than relying on
  * 'unsafe-inline'. Marketing/public routes use their own inline variant.
  */
-const PRE_PAINT_SCRIPT =
-  "(function(){try{var s=localStorage.getItem('yc-theme');var d=s?s==='dark':matchMedia('(prefers-color-scheme:dark)').matches;document.documentElement.setAttribute('data-theme',d?'dark':'light');}catch(e){}})();";
-
 export default async function ThemeScript() {
   const nonce = (await headers()).get(NONCE_HEADER) ?? undefined;
   // The browser strips the nonce attribute from the DOM after applying the CSP,

--- a/apps/frontend/src/app/ui/theme/prePaintScript.ts
+++ b/apps/frontend/src/app/ui/theme/prePaintScript.ts
@@ -22,5 +22,20 @@
  * call `headers()` - which would make every marketing page render dynamically
  * and defeat static generation.
  */
+/**
+ * The `catch` is deliberately empty, and must stay that way.
+ *
+ * The two things that can throw here are `localStorage.getItem` (private
+ * browsing, or cookies disabled) and `matchMedia` (very old browsers). Both are
+ * expected environment conditions rather than defects, and neither is
+ * actionable: the correct response is to leave `data-theme` unset and let the
+ * default theme apply, which is exactly what an empty catch does.
+ *
+ * Do not log here. This runs inline before paint on every document, so a
+ * `console.warn` would fire on every navigation for anyone browsing privately -
+ * noise about something they cannot fix - and would add bytes to a script that
+ * is inlined into every page. Any edit to the string below also changes its CSP
+ * hash; see PRE_PAINT_SCRIPT_CSP_HASH in securityHeaders.ts.
+ */
 export const PRE_PAINT_SCRIPT =
   "(function(){try{var s=localStorage.getItem('yc-theme');var d=s?s==='dark':matchMedia('(prefers-color-scheme:dark)').matches;document.documentElement.setAttribute('data-theme',d?'dark':'light');}catch(e){}})();";

--- a/apps/frontend/src/app/ui/theme/prePaintScript.ts
+++ b/apps/frontend/src/app/ui/theme/prePaintScript.ts
@@ -1,0 +1,26 @@
+/**
+ * The theme pre-paint script, and the CSP hash that authorises it.
+ *
+ * This runs before the app paints so dark mode never flashes: it reads the
+ * explicit choice (localStorage `yc-theme`), else the OS preference, and stamps
+ * `data-theme` on `<html>`.
+ *
+ * It is inlined by two different layouts, which is why the source lives here
+ * rather than in either of them:
+ *
+ *  - `(routes)/(app)/layout.tsx` renders it through `ThemeScript`, which tags it
+ *    with the request's nonce.
+ *  - `(routes)/(public)/layout.tsx` inlines it directly, with no nonce, because
+ *    public pages are statically prerendered and so have no per-request nonce to
+ *    give it.
+ *
+ * The second case is the awkward one. A handful of `(public)` routes - the
+ * credential and payment pages - opt into the strict nonce CSP via
+ * `STRICT_CSP_PATH_PREFIXES`, and on those the nonce-less copy was blocked
+ * outright, so the theme could not resolve before paint. Authorising it by hash
+ * fixes that without a nonce, and therefore without forcing the public layout to
+ * call `headers()` - which would make every marketing page render dynamically
+ * and defeat static generation.
+ */
+export const PRE_PAINT_SCRIPT =
+  "(function(){try{var s=localStorage.getItem('yc-theme');var d=s?s==='dark':matchMedia('(prefers-color-scheme:dark)').matches;document.documentElement.setAttribute('data-theme',d?'dark':'light');}catch(e){}})();";

--- a/apps/frontend/src/securityHeaders.ts
+++ b/apps/frontend/src/securityHeaders.ts
@@ -3,6 +3,18 @@ export type SecurityHeader = {
   value: string;
 };
 
+/**
+ * `sha256-` of the theme pre-paint script in `app/ui/theme/prePaintScript.ts`,
+ * as a CSP source expression.
+ *
+ * Declared here rather than imported, because `next.config.ts` loads this module
+ * through plain Node, outside webpack's path-alias resolution - any `@/` import
+ * added here breaks the config load. `__tests__/ui/theme/prePaintScript.test.ts`
+ * recomputes the digest from the actual script and fails if the two drift, so
+ * the duplication cannot rot silently.
+ */
+export const PRE_PAINT_SCRIPT_CSP_HASH = "'sha256-XyPqeG9vavwdIhaDFng+KuhYQvKDNsRmr3Xyy6ISj5E='";
+
 export const DEFAULT_DOCUMENSO_HOST = 'https://ds.yosemitecrew.com';
 
 // Single source of truth for the MSD/Merck manual hosts: isAllowedMerckUrl gates
@@ -87,6 +99,15 @@ export const buildContentSecurityPolicy = ({
       "script-src 'self'",
       nonceSource,
       allowInlineScripts ? "'unsafe-inline'" : undefined,
+      // The theme pre-paint script is inlined by the public layout with no
+      // nonce, because public pages are statically prerendered. On the handful
+      // of public routes that opt into the strict CSP it was blocked outright,
+      // so authorise it by hash there.
+      //
+      // Strict variant ONLY. Per the CSP spec a hash makes the browser ignore
+      // 'unsafe-inline', so adding this to the permissive variant would disable
+      // inline scripts across the static marketing pages and break hydration.
+      allowInlineScripts ? undefined : PRE_PAINT_SCRIPT_CSP_HASH,
       isDevelopment ? "'unsafe-eval'" : undefined,
       'https://js.stripe.com',
       'https://*.js.stripe.com',


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

Every page on the strict nonce CSP logs a blocked inline script, and the script being blocked is the theme pre-paint - the one that stamps `data-theme` on `<html>` before first paint. So those pages cannot resolve the theme early and flash the wrong one in dark mode. It is not only console noise.

Two layouts inline that script. `(app)/layout.tsx` renders it through `ThemeScript`, which tags it with the request nonce. `(public)/layout.tsx` inlines its own copy with no nonce, because public pages are statically prerendered and have no per-request nonce to give it.

That is fine while a public route stays on the permissive CSP. But the credential and payment routes opt into the strict CSP via `STRICT_CSP_PATH_PREFIXES` while still living under `(public)` - `/signin`, `/signup`, `/verify-email`, `/reset-password`, `/forgot-password`, `/payment-status`, `/developers/signin`, `/developers/signup` - and there the nonce-less copy is blocked outright. Every other inline script on those pages carries the nonce correctly.

## What is the new behavior?

Authorises the script by hash on the strict CSP.

A hash needs no per-request value, so the public layout does not have to call `headers()`. That matters: doing so would make every marketing page render dynamically and defeat static generation, which is the regression recorded against #1797.

Also dedupes the script, which was declared twice, into `app/ui/theme/prePaintScript.ts`.

## The two traps, and how each is guarded

**1. The hash must never reach the permissive CSP.** Per the CSP spec a hash or nonce makes the browser ignore `'unsafe-inline'`. The static marketing pages depend on `'unsafe-inline'` for their framework inline scripts, so leaking the hash into the permissive variant would break hydration across the marketing site while every unit test still passed. A test asserts the permissive `script-src` contains `'unsafe-inline'` and no `sha256-` at all.

**2. `securityHeaders.ts` must stay import-free.** `next.config.ts` loads it through plain Node, outside webpack's alias resolution, so an `@/` import there breaks the config load entirely. I hit this: adding the import failed every jest run with `Cannot find module './src/app/ui/theme/prePaintScript'` sourced from `next.config.compiled.js`. The hash therefore stays declared in `securityHeaders.ts`, and a test recomputes the digest from the actual script and fails on drift, so the split cannot rot silently.

## Validation performed

- New suite `__tests__/ui/theme/prePaintScript.test.ts`. **Mutation-checked all three guards**: corrupting the hash fails it, editing the script without updating the hash fails it, and leaking the hash into the permissive CSP fails it. Restored state passes 5/5.
- **Static generation confirmed preserved against a real build**, since that is the failure mode a unit test cannot see. `/pricing`, `/privacy-policy`, `/terms-and-conditions` and `/trust-center` all still build as `○ (Static)`; the strict-CSP auth routes remain `ƒ`, as they already force dynamic rendering.
- The build also confirms `next.config.ts` still loads, which is the direct check on trap 2.
- **Full frontend suite**: 950 suites, 11620 tests, all passing. Run directly via `jest --ci` rather than through the pnpm script - `pnpm run test:unit -- --ci` forwards `--ci` as a test-name pattern, matches nothing, and exits without running anything, which looks identical to a pass in piped output.
- `tsc --noEmit` clean, `pnpm --filter frontend run lint` 0 errors (1 pre-existing warning in an unrelated test file).

## Impact area

Web app (apps/frontend). Security headers and two layouts. No backend, schema, env or dependency change.

## Related Issue(s)

Fixes #2384
