### PR TITLE
fix(mobile): neutralise credential-shaped fixtures in doctor self-test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,6 +151,7 @@ git branch -D your-branch-name
 - Staged changes are scanned locally in `pre-commit` with Secretlint and the repo staged-secret scanner. If `gitleaks` is installed locally, the hook also runs `gitleaks protect --staged --redact`.
 - GitHub Actions also scans for secrets using Gitleaks.
 - If you accidentally commit a secret, rotate it immediately and open a security report per [SECURITY.md](./SECURITY.md).
+- Keep test and example fixtures low-entropy and obviously fake (`abcdef1234567890`, `not-a-real-key`, `Bearer YOUR_JWT_TOKEN`). A fixture written to look like a live credential is indistinguishable from one to a scanner, and this repo is public: readers and their tooling see the value, not the comment next to it. Assemble the value from parts if a realistic shape is genuinely needed.
 
 ## Need Help
 

--- a/scripts/mobile/doctor.mjs
+++ b/scripts/mobile/doctor.mjs
@@ -379,10 +379,19 @@ if (process.argv.includes('--self-test')) {
   }
   // Real config must not be condemned: that is the opposite failure and would
   // tell someone their working setup is broken.
+  //
+  // The value halves are low-entropy and assembled here rather than written as
+  // credential-shaped literals. A previous version spelled out a Google-shaped
+  // Maps key, which GitHub secret scanning could not tell from a live one and
+  // reported as alert #5. PLACEHOLDER only matches template markers, so the
+  // realism of the value bought this check nothing; the KEY=value and JSON
+  // shapes below are what it actually exercises. Same treatment as the IDEXX
+  // fixture in apps/backend/test/services/integration.service.test.ts.
+  const setByDeveloper = ['set', 'by', 'the', 'developer'].join('-');
   const filled = [
-    '{"project_info":{"project_id":"yosemite-crew"},"api_key":"AIzaSyReal"}',
+    `{"project_info":{"project_id":"yosemite-crew"},"api_key":"${setByDeveloper}"}`,
     '<resources><string name="app_name">Yosemite Crew</string></resources>',
-    'MAPS_API_KEY=AIzaSyRealLookingKey123',
+    `MAPS_API_KEY=${setByDeveloper}`,
   ];
   // The app-config vocabulary is pinned the same way: it must catch the
   // variables.ts templates and must not condemn the real values.


### PR DESCRIPTION
## PR Checklist

- [x] I have read the [CONTRIBUTING](../blob/dev/CONTRIBUTING.md) guide
- [x] Commit messages follow the Conventional Commits format
- [x] Changes are scoped and documented

## What is the current behavior?

`scripts/mobile/doctor.mjs --self-test` pins the `PLACEHOLDER` vocabulary in both directions: the shipped config templates must be flagged, and realistic filled-in config must not be. To make the negative case look convincing, two of its samples were written as credential-shaped literals - a Google-shaped Maps key and an `api_key` value.

GitHub secret scanning cannot tell a well-made decoy from a live credential and opened secret-scanning alert #5 on the Maps line (generic `password` detector; the provider-specific Google detector did not match it, and the literal is 23 characters against Google's 39, so it was never a usable key).

The repository is public, so the practical cost is not the alert. It is that any external reader, scanner or AI review sees a hardcoded API key in the tree and has no reason to read the comment beside it before drawing a conclusion.

## What is the new behavior?

Both samples now build their value from a low-entropy assembled string, keeping the `KEY=value` and JSON shapes that the check actually exercises.

`PLACEHOLDER` matches only template markers (`YOUR_`, `CHANGE_ME`, `REPLACE_ME`, `<UPPER>`), so the realism of the value never contributed anything to the assertion - the shapes did, and they are unchanged. This mirrors the neutralisation already applied to the IDEXX fixture in `apps/backend/test/services/integration.service.test.ts`.

`CONTRIBUTING.md` gains the convention under "Security and Secret Hygiene" so the next fixture does not reintroduce the problem.

Verification:

- `node scripts/mobile/doctor.mjs --self-test` passes, exit 0.
- Mutation check: substituting a template marker into the fixture makes the run report `FALSE POSITIVE on 2 realistic config sample(s)` and exit 1. Both samples flow through the assertion, so the pass is meaningful rather than vacuous.
- Gitleaks and Secretlint are both clean on the changed files. Neither flagged the original line either - gitleaks' entropy bar is above 23 characters and secretlint's preset carries no generic rule - which is why only the server-side scanner caught it.

## Related Issue(s)

Closes secret-scanning alert #5 (false positive, already dismissed).
