### PR TITLE
test(mobile): cover the new-code gaps flagged by the Sonar report

### DIFF
--- a/apps/mobileAppYC/__tests__/features/appointments/screens/MyAppointmentsEmptyScreen.test.tsx
+++ b/apps/mobileAppYC/__tests__/features/appointments/screens/MyAppointmentsEmptyScreen.test.tsx
@@ -6,8 +6,14 @@ import MyAppointmentsEmptyScreen from '@/features/appointments/screens/MyAppoint
 import {setSelectedCompanion} from '@/features/companion';
 
 const mockNavigate = jest.fn();
+// The companion CTA hops to a sibling stack via getParent(), so the navigation
+// double needs it: without getParent the handler throws instead of navigating.
+const mockParentNavigate = jest.fn();
 jest.mock('@react-navigation/native', () => ({
-  useNavigation: () => ({navigate: mockNavigate}),
+  useNavigation: () => ({
+    navigate: mockNavigate,
+    getParent: () => ({navigate: mockParentNavigate}),
+  }),
 }));
 
 jest.mock('@/hooks', () => ({
@@ -113,6 +119,25 @@ describe('MyAppointmentsEmptyScreen', () => {
     // Booking needs a companion, so the CTA points there instead of vanishing.
     expect(queryByText('Book an appointment')).toBeNull();
     expect(getByText('Add a companion')).toBeTruthy();
+  });
+
+  // Asserting the CTA renders is not enough: before this, the screen offered no
+  // action at all with no companion, so the value is in where pressing it goes.
+  it('sends the companion CTA to AddCompanion on the home stack', () => {
+    jest
+      .spyOn(Redux, 'useSelector')
+      .mockImplementation((selectorFn: any) =>
+        selectorFn({companion: {companions: [], selectedCompanionId: null}}),
+      );
+
+    const {getByText} = render(<MyAppointmentsEmptyScreen />);
+    fireEvent.press(getByText('Add a companion'));
+
+    expect(mockParentNavigate).toHaveBeenCalledWith('HomeStack', {
+      screen: 'AddCompanion',
+    });
+    // It must cross to the parent, not push onto the appointments stack.
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 
   it('renders the companion selector and add button when companions exist', () => {

--- a/apps/mobileAppYC/__tests__/features/appointments/utils/chatActivation.test.ts
+++ b/apps/mobileAppYC/__tests__/features/appointments/utils/chatActivation.test.ts
@@ -87,6 +87,24 @@ describe('chatActivation', () => {
       expect(body).toContain('"minutes":12');
     });
 
+    // `hours` is optional on the countdown shape, and the copy interpolates it
+    // directly. Without the ?? 0 fallback an absent value renders the body as
+    // "unlocks in undefined hours", so pin the fallback rather than the field.
+    it('renders zero hours when the countdown omits the hours field', () => {
+      (ChatTiming.isChatActive as jest.Mock).mockReturnValue(false);
+      (ChatTiming.getTimeUntilChatActivation as jest.Mock).mockReturnValue({
+        minutes: 4,
+        seconds: 10,
+      });
+
+      handleChatActivation(mockConfig);
+
+      const [, body] = (Alert.alert as jest.Mock).mock.calls[0];
+      expect(body).toContain('"hours":0');
+      expect(body).toContain('"minutes":4');
+      expect(body).not.toContain('undefined');
+    });
+
     it('offers no bypass button', () => {
       (ChatTiming.isChatActive as jest.Mock).mockReturnValue(false);
       (ChatTiming.getTimeUntilChatActivation as jest.Mock).mockReturnValue({

--- a/apps/mobileAppYC/__tests__/features/auth/services/tokenStorage.test.ts
+++ b/apps/mobileAppYC/__tests__/features/auth/services/tokenStorage.test.ts
@@ -397,6 +397,33 @@ describe('tokenStorage', () => {
       await expect(loadStoredTokens()).resolves.toBeNull();
     });
 
+    // The fallback read is the last thing standing between a signed-in user and
+    // a signed-out state, so it must not throw its own failure up the stack: a
+    // rejected read has to degrade to "no tokens", not crash the caller.
+    it('returns null and warns when the fallback read itself throws', async () => {
+      (Keychain.getGenericPassword as jest.Mock).mockResolvedValue(false);
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      // Swap the implementation by hand rather than with spyOn: AsyncStorage's
+      // jest mock backs getItem with an in-memory store, and mockRestore leaves
+      // a bare stub behind that returns undefined for every later test.
+      const originalGetItem = AsyncStorage.getItem;
+      (AsyncStorage as unknown as {getItem: unknown}).getItem = jest
+        .fn()
+        .mockRejectedValue(new Error('storage unavailable'));
+
+      try {
+        await expect(loadStoredTokens()).resolves.toBeNull();
+        expect(warnSpy).toHaveBeenCalledWith(
+          'Unable to read fallback auth tokens',
+          expect.any(Error),
+        );
+      } finally {
+        (AsyncStorage as unknown as {getItem: unknown}).getItem =
+          originalGetItem;
+        warnSpy.mockRestore();
+      }
+    });
+
     it('falls back when the Keychain record cannot be parsed', async () => {
       (Keychain.getGenericPassword as jest.Mock).mockResolvedValue(
         keychainRecord('not-json'),

--- a/apps/mobileAppYC/__tests__/features/home/screens/HomeScreen/HomeScreen.test.tsx
+++ b/apps/mobileAppYC/__tests__/features/home/screens/HomeScreen/HomeScreen.test.tsx
@@ -63,11 +63,15 @@ jest.mock('@/features/tasks', () => ({
   markTaskStatus: jest.fn(payload => ({type: 'tasks/markStatus', payload})),
 }));
 
+// Stable across renders so the loader-timeout test can assert on them; the
+// previous inline jest.fn()s were recreated on every call and could never be.
+const mockShowLoader = jest.fn();
+const mockHideLoader = jest.fn();
 jest.mock('@/context/GlobalLoaderContext', () => {
   return {
     useGlobalLoader: () => ({
-      showLoader: jest.fn(),
-      hideLoader: jest.fn(),
+      showLoader: mockShowLoader,
+      hideLoader: mockHideLoader,
       isLoading: false,
     }),
     GlobalLoaderProvider: ({children}: any) => <>{children}</>,
@@ -596,6 +600,36 @@ describe('HomeScreen', () => {
       expect(deriveHomeGreetingName('Christopherrrrrr').displayName).toBe(
         'Christopherrr...',
       );
+    });
+  });
+
+  // The loader is an opaque full-screen modal with no dismiss control, and the
+  // readiness gate waits on six requests with no failure branch. Without the
+  // ceiling, one request that never settles strands the user with no way out but
+  // force quitting, so the timeout is the only thing standing between a slow
+  // network and an unusable app.
+  describe('Loader timeout', () => {
+    it('releases the loader after the ceiling even when the data never becomes ready', () => {
+      mockHideLoader.mockClear();
+      // An appointments request that is still in flight and never hydrates keeps
+      // isHomeDataReady false, so the effect arms the timeout rather than hiding
+      // the loader immediately. That is the stuck-request case the ceiling is for.
+      const store = createStore({
+        appointments: {upcoming: [], loading: true, hydratedCompanions: {}},
+      });
+
+      render(
+        <Provider store={store}>
+          <HomeScreen navigation={mockNavigationProp} route={{} as any} />
+        </Provider>,
+      );
+
+      mockHideLoader.mockClear();
+      act(() => {
+        jest.advanceTimersByTime(12_000);
+      });
+
+      expect(mockHideLoader).toHaveBeenCalled();
     });
   });
 

--- a/apps/mobileAppYC/__tests__/features/tasks/screens/TasksListScreen/TasksListScreen.test.tsx
+++ b/apps/mobileAppYC/__tests__/features/tasks/screens/TasksListScreen/TasksListScreen.test.tsx
@@ -11,11 +11,16 @@ const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
 const mockRouteParams = {category: 'health'};
 
+// The companion CTA hops to a sibling stack via getParent(), so the navigation
+// double needs it: without getParent the handler throws instead of navigating.
+const mockParentNavigate = jest.fn();
+
 jest.mock('@react-navigation/native', () => {
   return {
     useNavigation: () => ({
       navigate: mockNavigate,
       goBack: mockGoBack,
+      getParent: () => ({navigate: mockParentNavigate}),
     }),
     useRoute: () => ({
       params: mockRouteParams,
@@ -414,6 +419,30 @@ describe('TasksListScreen', () => {
 
     const {queryByTestId} = render(<TasksListScreen />);
     expect(queryByTestId('header-add-btn')).toBeNull();
+  });
+
+  // Tasks hang off a companion, so with none there is nothing to add a task to.
+  // The screen used to just say the list was empty and offer no way forward, so
+  // what matters is where the replacement CTA actually goes.
+  it('sends the empty-state CTA to AddCompanion on the home stack when there are no companions', () => {
+    // The CTA lives in the list's empty component, so the task list has to be
+    // empty as well as the companion list - otherwise the rows render instead.
+    mockUseSelector.mockImplementation((cb: any) =>
+      cb({
+        ...mockState,
+        mockTasks: [],
+        companion: {companions: [], selectedCompanionId: null},
+      }),
+    );
+
+    const {getByText} = render(<TasksListScreen />);
+    fireEvent.press(getByText('Add a companion'));
+
+    expect(mockParentNavigate).toHaveBeenCalledWith('HomeStack', {
+      screen: 'AddCompanion',
+    });
+    // It must cross to the parent, not push AddTask onto the tasks stack.
+    expect(mockNavigate).not.toHaveBeenCalledWith('AddTask', expect.anything());
   });
 
   it('navigates to AddTask with the selected date prefilled when the header add button is pressed', () => {

--- a/apps/mobileAppYC/__tests__/shared/services/chatTiming.test.ts
+++ b/apps/mobileAppYC/__tests__/shared/services/chatTiming.test.ts
@@ -1,0 +1,136 @@
+import {
+  formatAppointmentTime,
+  getTimeUntilChatActivation,
+  isChatActive,
+} from '../../../src/shared/services/chatTiming';
+
+// Every helper reads `new Date()`, so the window assertions are only meaningful
+// with the clock pinned. Fixed at a UTC noon so the local-time formatting below
+// cannot straddle a date boundary in the runner's timezone.
+const NOW = new Date('2026-08-22T12:00:00Z');
+
+describe('chatTiming', () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(NOW);
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    jest.useRealTimers();
+  });
+
+  describe('isChatActive', () => {
+    // The guard exists because an unparseable timestamp would otherwise compare
+    // NaN dates and silently report chat as locked forever.
+    it('returns false and warns when the timestamp cannot be parsed', () => {
+      expect(isChatActive('not-a-timestamp')).toBe(false);
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[ChatTiming] Invalid appointment time:',
+        'not-a-timestamp',
+      );
+    });
+
+    it('is active inside the window, from activation until 30 minutes after', () => {
+      // appointment in 4 minutes, default 5 minute activation -> already open
+      expect(isChatActive('2026-08-22T12:04:00Z')).toBe(true);
+      // appointment 29 minutes ago -> still inside the +30 minute tail
+      expect(isChatActive('2026-08-22T11:31:00Z')).toBe(true);
+    });
+
+    it('is inactive before activation and after the window closes', () => {
+      // appointment in 6 minutes, activation is 5 minutes before -> not yet
+      expect(isChatActive('2026-08-22T12:06:00Z')).toBe(false);
+      // appointment 31 minutes ago -> window closed
+      expect(isChatActive('2026-08-22T11:29:00Z')).toBe(false);
+    });
+
+    it('honours a custom activation window', () => {
+      // 30 minutes out is closed at the default 5, open at 60
+      expect(isChatActive('2026-08-22T12:30:00Z')).toBe(false);
+      expect(isChatActive('2026-08-22T12:30:00Z', 60)).toBe(true);
+    });
+
+    // The helper appends `Z` when absent, so a bare timestamp must be read as
+    // UTC rather than drifting with the runner's timezone.
+    it('treats a timestamp without a Z suffix as UTC', () => {
+      expect(isChatActive('2026-08-22T12:04:00')).toBe(
+        isChatActive('2026-08-22T12:04:00Z'),
+      );
+    });
+  });
+
+  describe('formatAppointmentTime', () => {
+    it('returns the input unchanged and warns when it cannot be parsed', () => {
+      expect(formatAppointmentTime('nonsense')).toBe('nonsense');
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[ChatTiming] Invalid appointment time for formatting:',
+        'nonsense',
+      );
+    });
+
+    it('labels a same-day appointment as Today', () => {
+      expect(formatAppointmentTime('2026-08-22T15:30:00Z')).toMatch(
+        /^Today at /,
+      );
+    });
+
+    it('spells out the date for an appointment on another day', () => {
+      const formatted = formatAppointmentTime('2026-09-01T15:30:00Z');
+      expect(formatted).not.toMatch(/^Today at /);
+      expect(formatted).toMatch(/ at /);
+    });
+
+    it('treats a timestamp without a Z suffix as UTC', () => {
+      expect(formatAppointmentTime('2026-08-22T15:30:00')).toBe(
+        formatAppointmentTime('2026-08-22T15:30:00Z'),
+      );
+    });
+  });
+
+  describe('getTimeUntilChatActivation', () => {
+    it('returns null and warns when the timestamp cannot be parsed', () => {
+      expect(getTimeUntilChatActivation('¯\\_(ツ)_/¯')).toBeNull();
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[ChatTiming] Invalid appointment time for countdown:',
+        '¯\\_(ツ)_/¯',
+      );
+    });
+
+    it('returns null once activation has already been reached', () => {
+      // appointment in 4 minutes with a 5 minute activation -> already unlocked
+      expect(getTimeUntilChatActivation('2026-08-22T12:04:00Z')).toBeNull();
+    });
+
+    // The hours split exists because a flat minute count read as "unlocks in
+    // 1439m" for a next-day appointment.
+    it('splits the remainder into hours, minutes and seconds', () => {
+      // activation is 5 minutes before, so 2h 5m 30s out -> 2h 0m 30s remaining
+      expect(getTimeUntilChatActivation('2026-08-22T14:05:30Z')).toEqual({
+        hours: 2,
+        minutes: 0,
+        seconds: 30,
+      });
+    });
+
+    it('keeps minutes as the remainder rather than the total', () => {
+      // 1 day and 5 minutes out -> 24h remaining, not 1445 minutes
+      const result = getTimeUntilChatActivation('2026-08-23T12:05:00Z');
+      expect(result).toEqual({hours: 24, minutes: 0, seconds: 0});
+      expect(result?.minutes).toBeLessThan(60);
+    });
+
+    it('honours a custom activation window', () => {
+      // 30 minutes out: already unlocked at 60, still counting down at 5
+      expect(getTimeUntilChatActivation('2026-08-22T12:30:00Z', 60)).toBeNull();
+      expect(getTimeUntilChatActivation('2026-08-22T12:30:00Z', 5)).toEqual({
+        hours: 0,
+        minutes: 25,
+        seconds: 0,
+      });
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

Coverage on new code for `mobileAppYC` sat at **92.3%** across six files.

Worth being precise about the gate, because the number is alarming and the gates are not: SonarCloud's `new_coverage` condition fails below **80**, and the 95% bar in `sonar-thresholds.mjs` reads **whole-project** metrics, which are at 98.1%. So neither gate was failing.

The uncovered lines were still worth having. Every one of them was an error path or a fallback - the code that only ever runs once something has already gone wrong, and therefore the code least likely to be exercised by hand.

## What is the new behavior?

Coverage on those files is now **96.96% statements / 97.51% lines**, with five of the six at 100%.

Targeted by intersecting the lines the diff adds against the lines jest reports uncovered, rather than by chasing whole-file percentages, so the work lands on the lines Sonar actually measures.

| File | Before | After | What was uncovered |
| --- | --- | --- | --- |
| `chatTiming.ts` | 60.0% | **100%** | had no test file at all |
| `chatActivation.ts` | 83.3% | **100%** | the `hours ?? 0` fallback |
| `tokenStorage.ts` | 92.6% | **100%** | the fallback read's `catch` |
| `MyAppointmentsEmptyScreen.tsx` | 92.9% | **100%** | the companion CTA handler |
| `TasksListScreen.tsx` | 92.9% | **100%** | the companion CTA handler |
| `HomeScreen.tsx` | - | 703-704 covered | the loader timeout ceiling |

Notes on the more interesting ones:

- **`chatTiming.ts`** had no test file, which is why it was lowest. The new suite covers all three invalid-timestamp guards, the activation window edges, custom activation minutes, the hours/minutes split, and the implicit-UTC handling for a timestamp with no `Z` suffix.
- **`tokenStorage.ts`**: the fallback read is the last thing standing between a signed-in user and a signed-out state, so it must degrade to "no tokens" rather than throw.
- **The two companion CTAs**: asserting they render was never the point - both screens previously offered no action at all without a companion, so the value is in asserting where pressing them goes. Both needed `getParent` on the navigation double, which is exactly why those handlers were unreachable from tests.
- **`HomeScreen.tsx`**: the loader is an opaque full-screen modal with no dismiss control, so that timeout is the only thing between a request that never settles and an app the user can only force quit.

## Validation performed

Test-only: **no production code changed.**

- Full mobile suite: **462 suites, 7565 tests, all passing** (run as `jest --ci` directly; `pnpm run test -- --ci` forwards `--ci` as a test-name pattern, matches nothing, and exits without running anything).
- `tsc --noEmit` clean, `eslint` clean on all six files.

## Two things worth recording for whoever hits them next

**AsyncStorage's jest mock is backed by an in-memory store, and `spyOn().mockRestore()` does not restore it** - it leaves a bare stub returning `undefined`, which broke two unrelated tests later in the same file. The token fallback test swaps the implementation by hand and restores it in a `finally` instead.

**HomeScreen's loader mocks were inline `jest.fn()`s recreated on every call**, so no test could ever assert on them. They are now module-level.

## Impact area

Mobile app tests only.
