### PR TITLE
chore(repo): guard @babel/preset-env against the Babel 8 major

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -150,6 +150,21 @@ updates:
       # unnoticed on 2026-08-09). Unfreeze alongside @babel/core.
       - dependency-name: '@babel/runtime'
         update-types: ['version-update:semver-major']
+      # @babel/preset-env 8 is blocked by the same Babel-8-too-early constraint
+      # and is the one that actually slipped through. The two entries above name
+      # @babel/core and @babel/runtime, so preset-env was free to move: it went
+      # to ^8.0.2 in a bulk bump on 2026-07-15 and sat in apps/mobileAppYC until
+      # #2379 pulled it back to ^7.29.6 on 2026-08-22. The constraint is "nothing
+      # from Babel 8 while the app is on React Native 0.81", not "these two
+      # packages", so guard the family rather than the package that broke first.
+      # Unfreeze alongside @babel/core.
+      #
+      # Not listed here: @babel/plugin-transform-modules-systemjs. It is a
+      # pnpm.overrides entry rather than a declared dependency, and dependabot
+      # does not raise updates for overridden packages, so an ignore for it would
+      # never match anything.
+      - dependency-name: '@babel/preset-env'
+        update-types: ['version-update:semver-major']
       # eslint 10 is blocked in two workspaces at once (#2180), so the repo
       # stays on 9 until both clear:
       #   frontend - eslint-config-next 15.x loads @rushstack/eslint-patch,


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The ignore list freezes `@babel/core` and `@babel/runtime` at 7 for the "React Native 0.81 cannot take Babel 8" constraint, but it names packages rather than the constraint. `@babel/preset-env` was never covered, so it was free to move to 8 - and it did.

It went to `^8.0.2` in a bulk dependabot bump on **2026-07-15** and sat in `apps/mobileAppYC` for over a month, until #2379 pulled it back to `^7.29.6` on 2026-08-22.

`@react-native/babel-preset` (0.81.6, which declares `@babel/core: ^7.25.2`) asserts Babel `"^7.0.0-0"` at load time and throws for **every mobile file**, so nothing else in the repo could absorb it. As it stands, dependabot is free to re-raise preset-env 8 and undo the #2379 fix.

## What is the new behavior?

Adds `@babel/preset-env` to the same major freeze, with a comment recording how it slipped through, so the entry is not removed later as redundant.

Guards the family rather than the package that broke first, which is the same failure mode as the `react-native-screens` pin that dependabot re-proposed 22 minutes after merge.

## Deliberately not included

`@babel/plugin-transform-modules-systemjs`, the only other `@babel` entry in the repo. It lives in `pnpm.overrides` rather than being a declared dependency, and dependabot does not raise updates for overridden packages, so an ignore for it would never match anything. That reasoning is in the file so nobody adds it later "for symmetry".

## Timing - this needs to ride the promotion

Dependabot reads this file from the **default branch**, so merging to `dev` alone is inert. It is intended to ride the open dev-to-main promotion (#2383) rather than take effect on merge here.

Checked before editing: `dependabot.yml` is currently **byte-identical on dev and main**, so promoting keeps them in step rather than adding drift.

## Validation performed

Re-parsed the YAML after the edit, since a malformed `dependabot.yml` fails silently rather than erroring: 3 update entries, 20 ignore entries, and `@babel/core`, `@babel/runtime`, `@babel/preset-env` all present.

## Impact area

Repo tooling only. No application code.
