### PR TITLE
ci(repo): reconcile the public roadmap board with the tracker automatically

### DIFF
--- a/.github/workflows/roadmap.yml
+++ b/.github/workflows/roadmap.yml
@@ -1,0 +1,122 @@
+name: Roadmap
+
+# The public roadmap board (https://github.com/orgs/YosemiteCrew/projects/6) was
+# hand-curated, so it stopped being curated. By 2026-08-22 it held 388 items of
+# which 387 were already closed, and exactly one of the 79 open issues was on it.
+# Nobody decided that; it is just what happens to a board that only changes when
+# someone remembers.
+#
+# This runs the reconciliation on every issue event so the board is a projection
+# of the tracker rather than a parallel copy of it, plus daily so that facts which
+# change without an issue event - a linked PR opening, an item ageing past the
+# archive window - are still picked up.
+on:
+  issues:
+    types: [opened, closed, reopened, labeled, unlabeled, assigned, unassigned, transferred]
+  schedule:
+    # After the nightly CI settles, before European working hours.
+    - cron: '0 5 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Report what would change without writing to the board.
+        required: false
+        default: false
+        type: boolean
+      archive_after_days:
+        description: Archive completed items whose issue closed this many days ago.
+        required: false
+        default: '30'
+        type: string
+
+# A label sweep across a backlog fires dozens of issue events in a few seconds.
+# Collapse them: the sync reads whole-board state every run, so the last one wins
+# and the intermediate runs have nothing unique to contribute.
+concurrency:
+  group: roadmap-sync
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  sync:
+    name: Reconcile the roadmap board
+    # A fork has no access to the org project and no reason to try.
+    if: github.repository_owner == 'YosemiteCrew'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+
+      # Deliberately a hard failure rather than a skip. A roadmap sync that
+      # quietly does nothing looks identical to one that is working, which is the
+      # failure mode this whole workflow exists to prevent.
+      - name: Check the token is present
+        env:
+          ROADMAP_TOKEN: ${{ secrets.ROADMAP_TOKEN }}
+        run: |
+          if [ -z "${ROADMAP_TOKEN}" ]; then
+            echo "::error::ROADMAP_TOKEN is not set. The roadmap board is an ORGANISATION project, and the built-in GITHUB_TOKEN cannot write to one regardless of its permissions block. Create a fine-grained PAT with organisation permission 'Projects: Read and write' plus repository permission 'Issues: Read', and save it as the repository secret ROADMAP_TOKEN."
+            exit 1
+          fi
+
+      - name: Sync the board
+        env:
+          ROADMAP_TOKEN: ${{ secrets.ROADMAP_TOKEN }}
+          ROADMAP_OWNER: ${{ github.repository_owner }}
+          ROADMAP_REPO: ${{ github.event.repository.name }}
+          # Passed through the environment rather than interpolated into the
+          # script body, so a workflow input can never become shell syntax.
+          ARCHIVE_AFTER_DAYS: ${{ inputs.archive_after_days || '30' }}
+          DRY_RUN: ${{ inputs.dry_run && 'true' || '' }}
+        run: |
+          set -euo pipefail
+          case "${ARCHIVE_AFTER_DAYS}" in
+            ''|*[!0-9]*) echo "::error::archive_after_days must be a whole number of days"; exit 1 ;;
+          esac
+          ARGS=(--archive-after-days "${ARCHIVE_AFTER_DAYS}" --json)
+          if [ -n "${DRY_RUN}" ]; then ARGS=(--dry-run "${ARGS[@]}"); fi
+          node scripts/roadmap/sync.mjs "${ARGS[@]}" > roadmap-sync.json
+          node -e '
+            const r = require("./roadmap-sync.json");
+            const s = r.summary;
+            const lines = [
+              "## Roadmap sync",
+              "",
+              `Board: ${s.project}${s.dryRun ? " (dry run)" : ""}`,
+              "",
+              "| | |",
+              "|---|---|",
+              `| Open issues | ${s.openIssues} |`,
+              `| Added to board | ${s.added} |`,
+              `| Archived | ${s.archived} |`,
+              `| Field updates | ${s.fieldUpdates} |`,
+              `| Uncategorised | ${s.uncategorised} |`,
+            ];
+            if (r.actions.uncategorised.length) {
+              lines.push("", "### Needs a human", "");
+              for (const u of r.actions.uncategorised) lines.push(`- ${u}`);
+            }
+            if (r.actions.skipped.length) {
+              lines.push("", "### Skipped", "");
+              for (const u of r.actions.skipped) lines.push(`- ${u}`);
+            }
+            require("node:fs").appendFileSync(process.env.GITHUB_STEP_SUMMARY, lines.join("\n") + "\n");
+          '
+
+      - name: Upload the sync report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: roadmap-sync
+          path: roadmap-sync.json
+          if-no-files-found: ignore
+          retention-days: 14

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "check:secrets": "secretlint \"**/*\" --maskSecrets",
     "check:staged-secrets": "node scripts/check-staged-secrets.js",
     "check:overrides": "node scripts/ci/check-override-advisories.mjs",
-    "test:scripts": "node --test scripts/ci/*.test.mjs scripts/security/*.test.mjs",
+    "test:scripts": "node --test scripts/ci/*.test.mjs scripts/security/*.test.mjs scripts/roadmap/*.test.mjs",
     "doctor": "pnpm exec react-doctor",
     "security:sbom": "./scripts/security/supply-chain.sh sbom",
     "security:scan": "./scripts/security/supply-chain.sh scan",

--- a/scripts/roadmap/classify.mjs
+++ b/scripts/roadmap/classify.mjs
@@ -1,0 +1,223 @@
+// Decide where an issue belongs on the public roadmap board, from evidence that
+// already exists on the issue.
+//
+// Why this exists:
+//
+// The org roadmap (https://github.com/orgs/YosemiteCrew/projects/6) rotted into
+// an archive. On 2026-08-22 it held 388 items of which 387 were already closed,
+// the newest of those closed on 2026-07-14, and exactly one of the 79 open issues
+// was on the board at all. A board that only lists finished work is worse than no
+// board: it is a public page promising "upcoming launches" that shows none.
+//
+// The fix is to stop hand-curating it. Everything here is derived from the issue,
+// so the board cannot drift from the tracker again. Classification lives in its
+// own module, with no network access, so it can be unit tested - the sync engine
+// in sync.mjs is then a thin, boring transport around these decisions.
+//
+// Precedence rule: PRODUCT SURFACE WINS. A chore scoped to the mobile app is
+// still Mobile App work to a reader of the roadmap; only genuinely cross-cutting
+// work (runtime, CI, dependency and performance sweeps that span every app) falls
+// through to Platform & Infra. Sorting maintenance into an infra bucket is what
+// makes roadmaps read as though no product work is happening.
+
+// Category option names. These must match the single-select options on the board;
+// sync.mjs resolves them by name and refuses to run if one is missing, so a
+// rename here fails loudly instead of silently dropping items into no column.
+export const CATEGORIES = {
+  MOBILE: 'Mobile App',
+  PMS: 'Web PMS',
+  DESKTOP: 'Desktop App',
+  DEVPLATFORM: 'Developer Platform',
+  SUPERADMIN: 'Super Admin',
+  PLATFORM: 'Platform & Infra',
+  GROWTH: 'Growth',
+  SPIKE: 'Spike',
+};
+
+export const STATUSES = {
+  NOT_STARTED: 'Not Started',
+  IN_PROGRESS: 'In Progress',
+  UNDER_TESTING: 'Under Testing',
+  COMPLETED: 'Completed',
+};
+
+export const PRIORITIES = {
+  URGENT: 'Urgent',
+  HIGH: 'High',
+  NORMAL: 'Normal',
+  LOW: 'Low',
+};
+
+// The conventional-commit scope in a title, e.g. "fix(mobile): ..." -> "mobile".
+// Titles in this repo are commitlint-enforced on PRs and followed by hand on
+// issues, so the scope is the single most reliable signal available.
+export const scopeOf = (title = '') => {
+  const m = /^[a-z]+\(([a-z0-9\-.]+)\)!?:/i.exec(title.trim());
+  return m ? m[1].toLowerCase() : null;
+};
+
+// The bug template (.github/ISSUE_TEMPLATE/bug_report.yml) asks for an affected
+// area in prose, so it is free text rather than a fixed enum. Read it as a hint,
+// never as an authority.
+export const affectedAreaOf = (body = '') => {
+  const m = /###\s*Affected area\s*\r?\n+\s*(.+)/i.exec(body || '');
+  return m ? m[1].trim() : null;
+};
+
+const has = (labels, name) =>
+  (labels || []).some((l) => String(l).toLowerCase() === name.toLowerCase());
+
+// Count workspace path mentions in the body. An issue that names apps/frontend
+// four times and apps/backend twice is frontend work with a backend edge, not the
+// other way round, and the argmax says so without anyone having to label it.
+const pathEvidence = (body = '') => {
+  const b = body || '';
+  const count = (re) => (b.match(re) || []).length;
+  return {
+    [CATEGORIES.MOBILE]: count(/apps\/mobileAppYC|react-native|Podfile|\bios\/|\bandroid\//gi),
+    [CATEGORIES.PMS]: count(/apps\/frontend/g),
+    [CATEGORIES.DESKTOP]: count(/apps\/desktop/g),
+    [CATEGORIES.SUPERADMIN]: count(/superadmin/gi),
+    [CATEGORIES.PLATFORM]: count(/apps\/backend/g),
+  };
+};
+
+/**
+ * Decide a category, and say why.
+ *
+ * Returns { category, reason }. category is null when nothing in the issue
+ * justifies a guess - sync.mjs leaves those uncategorised and reports them, on
+ * the principle that an empty cell a human can see beats a wrong cell nobody
+ * checks.
+ */
+export function classifyCategory({ title = '', body = '', labels = [] } = {}) {
+  const scope = scopeOf(title);
+  const area = (affectedAreaOf(body) || '').toLowerCase();
+  const t = title.toLowerCase();
+
+  // 1. Growth is a different kind of work entirely and is labelled explicitly.
+  if (has(labels, 'Marketing') || has(labels, 'Sales')) {
+    return { category: CATEGORIES.GROWTH, reason: 'Marketing/Sales label' };
+  }
+
+  // 2. Surface labels are a human's explicit statement about which product this
+  //    touches. Nothing derived should ever outrank one - an earlier draft let a
+  //    keyword match on the body beat the `App` label and filed a companion-app
+  //    backlog under Developer Platform.
+  if (has(labels, 'Superadmin'))
+    return { category: CATEGORIES.SUPERADMIN, reason: 'Superadmin label' };
+  if (has(labels, 'App')) return { category: CATEGORIES.MOBILE, reason: 'App label' };
+  if (has(labels, 'PMS')) return { category: CATEGORIES.PMS, reason: 'PMS label' };
+
+  // 3. Developer platform work predates the label set, so it is recognised by
+  //    name. Matched against the TITLE only: bodies mention MCP, API keys and
+  //    federation in passing far too often for a body match to mean anything.
+  if (scope === 'mcp') return { category: CATEGORIES.DEVPLATFORM, reason: 'scope(mcp)' };
+  if (
+    /developer portal|\bmcp\b|metered billing|api keys|activitypub|federation|public data api|developer platform/i.test(
+      title
+    )
+  ) {
+    return { category: CATEGORIES.DEVPLATFORM, reason: 'developer platform keyword in title' };
+  }
+
+  // 4. Desktop before frontend: "fix(frontend): desktop week calendar" is a
+  //    viewport, not the Electron app. Only an explicit desktop scope or area
+  //    counts, never the word "desktop" in a sentence.
+  if (scope === 'desktop' || /\bdesktop app\b|electron/i.test(area)) {
+    return { category: CATEGORIES.DESKTOP, reason: 'desktop scope/area' };
+  }
+
+  // 5. Conventional-commit scope, then the bug template's affected area.
+  if (scope === 'mobile') return { category: CATEGORIES.MOBILE, reason: 'scope(mobile)' };
+  if (scope === 'frontend') return { category: CATEGORIES.PMS, reason: 'scope(frontend)' };
+  if (/\bmobile\b/.test(area))
+    return { category: CATEGORIES.MOBILE, reason: 'affected area: mobile' };
+  if (/web app|frontend \(pims\)|\bpims\b/.test(area)) {
+    return { category: CATEGORIES.PMS, reason: 'affected area: web' };
+  }
+
+  // 6. Repo-wide toolchain work. A chore, ci, test or perf change scoped to the
+  //    whole repo is infrastructure by definition, and its body is full of
+  //    per-app examples that would otherwise capture it for whichever app got
+  //    listed most. Decide it here, before any path evidence is consulted.
+  const repoWideToolchain =
+    /^(chore|ci|test|perf|build|refactor)\((repo|deps|deps-dev|ci|tooling)\)/i.test(title.trim());
+  if (
+    repoWideToolchain ||
+    has(labels, 'CI/CD') ||
+    has(labels, 'Cloud') ||
+    has(labels, 'security') ||
+    has(labels, 'engineering') ||
+    has(labels, 'automation')
+  ) {
+    return { category: CATEGORIES.PLATFORM, reason: 'repo-wide toolchain or engineering label' };
+  }
+
+  // 7. Everything else: let the body's workspace paths speak, but only when they
+  //    speak clearly. A single stray "android/" in a TypeScript upgrade is noise,
+  //    so a winner must have at least two mentions and double the runner-up.
+  const ev = pathEvidence(body);
+  const ranked = Object.entries(ev).sort((a, b) => b[1] - a[1]);
+  const [top, second] = ranked;
+  if (top && top[1] >= 2 && top[1] >= (second?.[1] || 0) * 2) {
+    return { category: top[0], reason: `path evidence: ${top[0]} x${top[1]}` };
+  }
+
+  if (
+    has(labels, 'Backend') ||
+    scope === 'backend' ||
+    scope === 'repo' ||
+    scope === 'auth' ||
+    scope === 'api'
+  ) {
+    return { category: CATEGORIES.PLATFORM, reason: 'backend/repo scope' };
+  }
+  if (/\bbackend\b|runtime|node 2\d/.test(t)) {
+    return { category: CATEGORIES.PLATFORM, reason: 'title keyword: backend/runtime' };
+  }
+
+  return { category: null, reason: 'no usable signal' };
+}
+
+/**
+ * Priority from the labels a human already applied.
+ *
+ * Kept crude on purpose. The board lets a human override any cell, and sync.mjs
+ * never overwrites a value that is already set, so this only has to produce a
+ * sane starting point for a brand new issue.
+ */
+export function classifyPriority({ labels = [], title = '' } = {}) {
+  if (has(labels, 'security')) return PRIORITIES.URGENT;
+  // A bug that blocks signup or launch is not the same as a contrast nit, and
+  // the QA sweeps say so in the title.
+  if (
+    has(labels, 'bug') &&
+    /blocking every|cannot be created|dead end|never reach|404s|crash/i.test(title)
+  ) {
+    return PRIORITIES.URGENT;
+  }
+  if (has(labels, 'bug')) return PRIORITIES.HIGH;
+  if (has(labels, 'future-scope')) return PRIORITIES.LOW;
+  return PRIORITIES.NORMAL;
+}
+
+/**
+ * Status from the issue's own state.
+ *
+ * The tracker is the source of truth for "is this done", which is exactly the
+ * fact the old board got wrong on four items. Everything softer than that -
+ * whether open work has actually started - is inferred, and sync.mjs treats the
+ * inference as a default rather than an instruction.
+ */
+export function classifyStatus({ state, assignees = [], linkedPrs = [] } = {}) {
+  if (state === 'CLOSED' || state === 'MERGED') return STATUSES.COMPLETED;
+  const openPrs = linkedPrs.filter((p) => p.state === 'OPEN');
+  // A PR that is out of draft is code waiting on review or QA, not code being
+  // written. That is the distinction the board's "Under Testing" column exists
+  // to show, and it is the column nobody ever moved an item into by hand.
+  if (openPrs.some((p) => !p.isDraft)) return STATUSES.UNDER_TESTING;
+  if (openPrs.length > 0) return STATUSES.IN_PROGRESS;
+  if (assignees.length > 0) return STATUSES.IN_PROGRESS;
+  return STATUSES.NOT_STARTED;
+}

--- a/scripts/roadmap/classify.test.mjs
+++ b/scripts/roadmap/classify.test.mjs
@@ -1,0 +1,171 @@
+// What is pinned here is the PRECEDENCE between signals, because that is where
+// every real misclassification came from. Each case below is an issue that was
+// actually filed wrong by an earlier draft of this classifier, kept as a
+// regression test so the ordering cannot be casually rearranged.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  CATEGORIES,
+  PRIORITIES,
+  STATUSES,
+  classifyCategory,
+  classifyPriority,
+  classifyStatus,
+  scopeOf,
+  affectedAreaOf,
+} from './classify.mjs';
+
+const cat = (o) => classifyCategory(o).category;
+
+test('conventional-commit scope is read from the title', () => {
+  assert.equal(scopeOf('fix(mobile): thing'), 'mobile');
+  assert.equal(scopeOf('feat(repo)!: thing'), 'repo');
+  assert.equal(scopeOf('Upgrade the backend runtime'), null);
+});
+
+test('the bug template affected area is read from the body', () => {
+  assert.equal(affectedAreaOf('### Affected area\n\nMobile app\n\n### What'), 'Mobile app');
+  assert.equal(affectedAreaOf('no template here'), null);
+});
+
+// #2008 was filed under Developer Platform because its body mentions MCP in
+// passing. A surface label is a human being explicit and must win.
+test('a surface label beats a developer-platform keyword in the body', () => {
+  assert.equal(
+    cat({
+      title: 'Consolidated backlog: unimplemented companion-app modules',
+      body: 'Some of this would later be exposed over MCP and the public data api.',
+      labels: ['enhancement', 'App'],
+    }),
+    CATEGORIES.MOBILE
+  );
+});
+
+// #1992: a single stray "android/" in a TypeScript upgrade sent a repo-wide
+// chore to Mobile App.
+test('a repo-wide toolchain chore is infra, whatever paths its body lists', () => {
+  assert.equal(
+    cat({
+      title: 'chore(repo): migrate to TypeScript 7 and @types/node 26',
+      body: 'Touches android/ and apps/frontend and apps/backend.',
+      labels: [],
+    }),
+    CATEGORIES.PLATFORM
+  );
+});
+
+// #2355: body listed seven mobile peer-dependency examples.
+test('a repo-wide ci change is infra even when its examples are all mobile', () => {
+  assert.equal(
+    cat({
+      title: 'ci(repo): fail on unmet peer dependencies instead of only warning',
+      body: 'apps/mobileAppYC react-native react-native react-native ios/ android/ Podfile',
+      labels: [],
+    }),
+    CATEGORIES.PLATFORM
+  );
+});
+
+// #1868: "desktop" here is a viewport, not the Electron app.
+test('the word desktop in a frontend title does not mean the desktop app', () => {
+  assert.equal(
+    cat({
+      title: 'fix(frontend): desktop week calendar anchors day columns',
+      body: '',
+      labels: [],
+    }),
+    CATEGORIES.PMS
+  );
+});
+
+test('an explicit desktop scope does mean the desktop app', () => {
+  assert.equal(
+    cat({
+      title: 'test(desktop): window state does not persist',
+      body: '',
+      labels: ['engineering'],
+    }),
+    CATEGORIES.DESKTOP
+  );
+});
+
+// #2284: the area read "Auth (packages/auth), mobile Sign in with Apple", which
+// never contains the exact phrase "mobile app".
+test('an affected area naming mobile counts even without the word app', () => {
+  assert.equal(
+    cat({
+      title: 'fix(auth): sign in with apple fails on android',
+      body: '### Affected area\n\nAuth (packages/auth), mobile Sign in with Apple\n',
+      labels: ['bug'],
+    }),
+    CATEGORIES.MOBILE
+  );
+});
+
+// #1672 had only `enhancement` and `engineering` and fell through to no category
+// at all, which would have left it invisible on the board.
+test('an engineering label lands cross-cutting work in Platform & Infra', () => {
+  assert.equal(
+    cat({
+      title: 'Provider-independent authentication boundary (epic)',
+      body: '',
+      labels: ['enhancement', 'engineering'],
+    }),
+    CATEGORIES.PLATFORM
+  );
+});
+
+test('growth work is separated from product work', () => {
+  assert.equal(
+    cat({ title: 'Launch campaign', body: '', labels: ['Marketing'] }),
+    CATEGORIES.GROWTH
+  );
+});
+
+test('an unrecognisable issue is left uncategorised rather than guessed', () => {
+  const { category } = classifyCategory({ title: 'Something vague', body: '', labels: [] });
+  assert.equal(category, null);
+});
+
+test('status follows the tracker, not the board', () => {
+  assert.equal(classifyStatus({ state: 'CLOSED' }), STATUSES.COMPLETED);
+  assert.equal(classifyStatus({ state: 'MERGED' }), STATUSES.COMPLETED);
+  assert.equal(classifyStatus({ state: 'OPEN' }), STATUSES.NOT_STARTED);
+});
+
+test('a ready pull request means the work is waiting on review, not being written', () => {
+  assert.equal(
+    classifyStatus({ state: 'OPEN', linkedPrs: [{ state: 'OPEN', isDraft: false }] }),
+    STATUSES.UNDER_TESTING
+  );
+  assert.equal(
+    classifyStatus({ state: 'OPEN', linkedPrs: [{ state: 'OPEN', isDraft: true }] }),
+    STATUSES.IN_PROGRESS
+  );
+  assert.equal(
+    classifyStatus({ state: 'OPEN', assignees: [{ login: 'someone' }] }),
+    STATUSES.IN_PROGRESS
+  );
+  // A merged PR on a still-open issue does not close it, so it is not done.
+  assert.equal(
+    classifyStatus({ state: 'OPEN', linkedPrs: [{ state: 'MERGED', isDraft: false }] }),
+    STATUSES.NOT_STARTED
+  );
+});
+
+test('priority starts from the labels a human already applied', () => {
+  assert.equal(classifyPriority({ labels: ['security'] }), PRIORITIES.URGENT);
+  assert.equal(classifyPriority({ labels: ['future-scope'] }), PRIORITIES.LOW);
+  assert.equal(classifyPriority({ labels: ['bug'], title: 'contrast is low' }), PRIORITIES.HIGH);
+  assert.equal(classifyPriority({ labels: [] }), PRIORITIES.NORMAL);
+});
+
+test('a bug that stops people using the product outranks a cosmetic bug', () => {
+  assert.equal(
+    classifyPriority({
+      labels: ['bug'],
+      title: 'Email verification link 404s, blocking every new signup',
+    }),
+    PRIORITIES.URGENT
+  );
+});

--- a/scripts/roadmap/sync.mjs
+++ b/scripts/roadmap/sync.mjs
@@ -191,23 +191,176 @@ const fieldValue = (item, name) => {
   return null;
 };
 
-async function main() {
+// Load the board and prove it still has the shape this script expects. Option
+// ids are resolved by NAME every run: updateProjectV2Field regenerates every
+// option id whenever the option set is edited, so a cached id is a time bomb.
+async function loadBoard() {
   const project = (await gql(PROJECT_QUERY, { owner: OWNER, number: PROJECT_NUMBER })).organization
     .projectV2;
   if (!project) throw new Error(`No project #${PROJECT_NUMBER} on ${OWNER}`);
 
   const fields = new Map(project.fields.nodes.filter(Boolean).map((f) => [f.name, f]));
-  const need = ['Status', 'Category', 'Priority', 'Start date', 'End date'];
-  const missing = need.filter((n) => !fields.has(n));
+  const missing = ['Status', 'Category', 'Priority', 'Start date', 'End date'].filter(
+    (n) => !fields.has(n)
+  );
   if (missing.length) throw new Error(`Board is missing fields: ${missing.join(', ')}`);
 
-  // Resolve option ids up front and fail loudly on a rename, rather than
-  // silently skipping every item that maps to the missing option.
-  const optionId = (fieldName, optionName) => {
-    const f = fields.get(fieldName);
-    const o = (f.options || []).find((x) => x.name === optionName);
-    return o ? o.id : null;
+  const optionId = (fieldName, optionName) =>
+    (fields.get(fieldName).options || []).find((x) => x.name === optionName)?.id ?? null;
+
+  return { project, fields, optionId };
+}
+
+// The two field writers, bound to one board and one action log. Both are no-ops
+// against the API under --dry-run but still record what they would have done, so
+// a dry run's report is directly comparable with the live run that follows it.
+function makeWriters({ project, fields, optionId, actions }) {
+  const setSelect = async (item, fieldName, optionName, ref) => {
+    const oid = optionId(fieldName, optionName);
+    if (!oid) {
+      actions.skipped.push(`${ref}: no "${optionName}" option on ${fieldName}`);
+      return;
+    }
+    if (!DRY_RUN) {
+      await gql(SET_SELECT, {
+        projectId: project.id,
+        itemId: item.id,
+        fieldId: fields.get(fieldName).id,
+        optionId: oid,
+      });
+    }
+    actions.updated.push(`${ref}: ${fieldName} -> ${optionName}`);
   };
+
+  const setDate = async (item, fieldName, isoDate, ref) => {
+    if (!DRY_RUN) {
+      await gql(SET_DATE, {
+        projectId: project.id,
+        itemId: item.id,
+        fieldId: fields.get(fieldName).id,
+        date: isoDate.slice(0, 10),
+      });
+    }
+    actions.updated.push(`${ref}: ${fieldName} -> ${isoDate.slice(0, 10)}`);
+  };
+
+  return { setSelect, setDate };
+}
+
+// Put every open issue on the board. Under --dry-run nothing is added, so the
+// caller's `live` array is left untouched and callers must not assume the new
+// items exist.
+async function addMissingIssues({ project, openIssues, byContentId, live, actions }) {
+  for (const issue of openIssues) {
+    if (byContentId.has(issue.id)) continue;
+    actions.added.push(`#${issue.number} ${issue.title}`);
+    if (DRY_RUN) continue;
+    const res = await gql(ADD_ITEM, { projectId: project.id, contentId: issue.id });
+    const item = {
+      id: res.addProjectV2ItemById.item.id,
+      fieldValues: { nodes: [] },
+      content: issue,
+    };
+    byContentId.set(issue.id, item);
+    live.push(item);
+  }
+}
+
+// Fill in what the board does not know about one open issue.
+//
+// Empty cells only, with one exception: an OPEN issue sitting in Completed is
+// corrected. That specific lie is the reason this script exists, so it outranks
+// the general rule that a human's edit is left alone.
+async function reconcileIssue({ issue, item, setSelect, setDate, actions }) {
+  const ref = `#${issue.number}`;
+  const labels = (issue.labels?.nodes || []).map((l) => l.name);
+
+  if (!fieldValue(item, 'Category')) {
+    const { category, reason } = classifyCategory({
+      title: issue.title,
+      body: issue.body,
+      labels,
+    });
+    if (category) await setSelect(item, 'Category', category, ref);
+    else actions.uncategorised.push(`${ref} ${issue.title.slice(0, 70)} (${reason})`);
+  }
+
+  if (!fieldValue(item, 'Priority')) {
+    await setSelect(item, 'Priority', classifyPriority({ labels, title: issue.title }), ref);
+  }
+
+  // The roadmap view is a timeline. Without a start date an item does not plot at
+  // all, which is why the board's ROADMAP_LAYOUT view had been rendering empty.
+  if (!fieldValue(item, 'Start date')) {
+    await setDate(item, 'Start date', issue.createdAt, ref);
+  }
+
+  const current = fieldValue(item, 'Status');
+  if (!current || current === STATUSES.COMPLETED) {
+    const derived = classifyStatus({
+      state: issue.state,
+      assignees: issue.assignees?.nodes || [],
+      linkedPrs: (issue.closedByPullRequestsReferences?.nodes || []).map((p) => ({
+        state: p.state,
+        isDraft: p.isDraft,
+      })),
+    });
+    await setSelect(item, 'Status', derived, ref);
+  }
+}
+
+// Retire finished work so the board stays a roadmap and not an archive. Recent
+// completions are stamped Completed with an end date and kept visible; older ones
+// are archived. GitHub retains archived items, so this loses nothing.
+async function retireCompleted({ project, live, cutoff, setSelect, setDate, actions }) {
+  for (const item of live) {
+    const c = item.content;
+    if (!c?.closedAt) continue;
+
+    if (Date.parse(c.closedAt) > cutoff) {
+      if (fieldValue(item, 'Status') !== STATUSES.COMPLETED) {
+        await setSelect(item, 'Status', STATUSES.COMPLETED, `#${c.number}`);
+      }
+      if (!fieldValue(item, 'End date')) {
+        await setDate(item, 'End date', c.closedAt, `#${c.number}`);
+      }
+      continue;
+    }
+
+    if (!DRY_RUN) await gql(ARCHIVE_ITEM, { projectId: project.id, itemId: item.id });
+    actions.archived.push(`#${c.number} (closed ${c.closedAt.slice(0, 10)})`);
+  }
+}
+
+function report({ summary, actions }) {
+  if (AS_JSON) {
+    stdout.write(`${JSON.stringify({ summary, actions }, null, 2)}\n`);
+    return;
+  }
+  log(`\nRoadmap sync ${DRY_RUN ? '(dry run)' : ''} -> ${summary.project}`);
+  log(
+    `  board items ${summary.boardItemsBefore} (${summary.liveItemsBefore} live)  open issues ${summary.openIssues}`
+  );
+  log(
+    `  added ${summary.added}  archived ${summary.archived}  field updates ${summary.fieldUpdates}`
+  );
+  for (const a of actions.added.slice(0, 100)) log(`    + ${a}`);
+  if (actions.archived.length) {
+    log(`  archived (closed over ${ARCHIVE_AFTER_DAYS}d ago): ${actions.archived.length}`);
+  }
+  if (actions.uncategorised.length) {
+    log(`\n  NEEDS A HUMAN - no category could be derived:`);
+    for (const u of actions.uncategorised) log(`    ? ${u}`);
+  }
+  if (actions.skipped.length) {
+    log(`\n  SKIPPED:`);
+    for (const s of actions.skipped) log(`    ! ${s}`);
+  }
+  log('');
+}
+
+async function main() {
+  const { project, fields, optionId } = await loadBoard();
 
   const [items, openIssues] = await Promise.all([
     paginate(
@@ -219,156 +372,47 @@ async function main() {
   ]);
 
   const live = items.filter((i) => !i.isArchived);
+  // Snapshot before anything mutates `live`. Deriving this afterwards by
+  // subtracting the added count is wrong under --dry-run, where the additions are
+  // counted but never pushed.
+  const liveItemsBefore = live.length;
   const byContentId = new Map(live.filter((i) => i.content?.id).map((i) => [i.content.id, i]));
 
   const actions = { added: [], archived: [], updated: [], uncategorised: [], skipped: [] };
-  const cutoff = Date.now() - ARCHIVE_AFTER_DAYS * 86400000;
+  const { setSelect, setDate } = makeWriters({ project, fields, optionId, actions });
 
-  const setSelect = async (item, fieldName, optionName, issueRef) => {
-    const oid = optionId(fieldName, optionName);
-    if (!oid) {
-      actions.skipped.push(`${issueRef}: no "${optionName}" option on ${fieldName}`);
-      return;
-    }
-    if (!DRY_RUN) {
-      await gql(SET_SELECT, {
-        projectId: project.id,
-        itemId: item.id,
-        fieldId: fields.get(fieldName).id,
-        optionId: oid,
-      });
-    }
-    actions.updated.push(`${issueRef}: ${fieldName} -> ${optionName}`);
-  };
+  await addMissingIssues({ project, openIssues, byContentId, live, actions });
 
-  const setDate = async (item, fieldName, isoDate, issueRef) => {
-    if (!DRY_RUN) {
-      await gql(SET_DATE, {
-        projectId: project.id,
-        itemId: item.id,
-        fieldId: fields.get(fieldName).id,
-        date: isoDate.slice(0, 10),
-      });
-    }
-    actions.updated.push(`${issueRef}: ${fieldName} -> ${isoDate.slice(0, 10)}`);
-  };
-
-  // 1. Add missing open issues.
-  for (const issue of openIssues) {
-    if (byContentId.has(issue.id)) continue;
-    if (DRY_RUN) {
-      actions.added.push(`#${issue.number} ${issue.title}`);
-      continue;
-    }
-    const res = await gql(ADD_ITEM, { projectId: project.id, contentId: issue.id });
-    const newItem = {
-      id: res.addProjectV2ItemById.item.id,
-      fieldValues: { nodes: [] },
-      content: issue,
-    };
-    byContentId.set(issue.id, newItem);
-    live.push(newItem);
-    actions.added.push(`#${issue.number} ${issue.title}`);
-  }
-
-  // 2 and 3. Reconcile fields for every open issue on the board.
   for (const issue of openIssues) {
     const item = byContentId.get(issue.id);
-    if (!item) continue;
-    const ref = `#${issue.number}`;
-    const labels = (issue.labels?.nodes || []).map((l) => l.name);
-
-    if (!fieldValue(item, 'Category')) {
-      const { category, reason } = classifyCategory({
-        title: issue.title,
-        body: issue.body,
-        labels,
-      });
-      if (category) await setSelect(item, 'Category', category, ref);
-      else actions.uncategorised.push(`${ref} ${issue.title.slice(0, 70)} (${reason})`);
-    }
-
-    if (!fieldValue(item, 'Priority')) {
-      await setSelect(item, 'Priority', classifyPriority({ labels, title: issue.title }), ref);
-    }
-
-    // The roadmap view is a timeline; without a start date an item does not plot
-    // at all, which is why the existing ROADMAP_LAYOUT view has been empty.
-    if (!fieldValue(item, 'Start date')) {
-      await setDate(item, 'Start date', issue.createdAt, ref);
-    }
-
-    const current = fieldValue(item, 'Status');
-    const derived = classifyStatus({
-      state: issue.state,
-      assignees: issue.assignees?.nodes || [],
-      linkedPrs: (issue.closedByPullRequestsReferences?.nodes || []).map((p) => ({
-        state: p.state,
-        isDraft: p.isDraft,
-      })),
-    });
-    // An open issue sitting in Completed is the exact lie this script exists to
-    // stop, so that one gets corrected even though it is a human-set value.
-    if (!current || current === STATUSES.COMPLETED) {
-      await setSelect(item, 'Status', derived, ref);
-    }
+    // Absent only under --dry-run, where the add above was not performed.
+    if (item) await reconcileIssue({ issue, item, setSelect, setDate, actions });
   }
 
-  // 4. Retire finished work so the board stays a roadmap and not an archive.
-  for (const item of live) {
-    const c = item.content;
-    if (!c || !c.closedAt) continue;
-    if (Date.parse(c.closedAt) > cutoff) {
-      // Recently finished: make sure it reads as done before it ages out.
-      if (fieldValue(item, 'Status') !== STATUSES.COMPLETED) {
-        await setSelect(item, 'Status', STATUSES.COMPLETED, `#${c.number}`);
-      }
-      if (!fieldValue(item, 'End date')) {
-        await setDate(item, 'End date', c.closedAt, `#${c.number}`);
-      }
-      continue;
-    }
-    if (!DRY_RUN) {
-      await gql(ARCHIVE_ITEM, { projectId: project.id, itemId: item.id });
-    }
-    actions.archived.push(`#${c.number} (closed ${c.closedAt.slice(0, 10)})`);
-  }
+  await retireCompleted({
+    project,
+    live,
+    cutoff: Date.now() - ARCHIVE_AFTER_DAYS * 86400000,
+    setSelect,
+    setDate,
+    actions,
+  });
 
-  const summary = {
-    project: project.url,
-    dryRun: DRY_RUN,
-    boardItemsBefore: items.length,
-    liveItemsBefore: live.length - actions.added.length,
-    openIssues: openIssues.length,
-    added: actions.added.length,
-    archived: actions.archived.length,
-    fieldUpdates: actions.updated.length,
-    uncategorised: actions.uncategorised.length,
-    skipped: actions.skipped.length,
-  };
-
-  if (AS_JSON) {
-    stdout.write(`${JSON.stringify({ summary, actions }, null, 2)}\n`);
-    return;
-  }
-
-  log(`\nRoadmap sync ${DRY_RUN ? '(dry run)' : ''} -> ${project.url}`);
-  log(`  board items ${items.length} (${live.length} live)  open issues ${openIssues.length}`);
-  log(
-    `  added ${actions.added.length}  archived ${actions.archived.length}  field updates ${actions.updated.length}`
-  );
-  for (const a of actions.added.slice(0, 100)) log(`    + ${a}`);
-  if (actions.archived.length)
-    log(`  archived (closed over ${ARCHIVE_AFTER_DAYS}d ago): ${actions.archived.length}`);
-  if (actions.uncategorised.length) {
-    log(`\n  NEEDS A HUMAN - no category could be derived:`);
-    for (const u of actions.uncategorised) log(`    ? ${u}`);
-  }
-  if (actions.skipped.length) {
-    log(`\n  SKIPPED:`);
-    for (const s of actions.skipped) log(`    ! ${s}`);
-  }
-  log('');
+  report({
+    summary: {
+      project: project.url,
+      dryRun: DRY_RUN,
+      boardItemsBefore: items.length,
+      liveItemsBefore,
+      openIssues: openIssues.length,
+      added: actions.added.length,
+      archived: actions.archived.length,
+      fieldUpdates: actions.updated.length,
+      uncategorised: actions.uncategorised.length,
+      skipped: actions.skipped.length,
+    },
+    actions,
+  });
 }
 
 main().catch((err) => {

--- a/scripts/roadmap/sync.mjs
+++ b/scripts/roadmap/sync.mjs
@@ -247,20 +247,24 @@ function makeWriters({ project, fields, optionId, actions }) {
   return { setSelect, setDate };
 }
 
-// Put every open issue on the board. Under --dry-run nothing is added, so the
-// caller's `live` array is left untouched and callers must not assume the new
-// items exist.
+// Put every open issue on the board.
+//
+// Under --dry-run no item is created on GitHub, but one is still tracked in
+// memory with no field values, so the reconcile pass that follows reports the
+// writes a live run would make. Skipping that bookkeeping would make a dry run
+// silently omit field updates for exactly the issues it is about to add, which
+// is the opposite of what a dry run is for.
 async function addMissingIssues({ project, openIssues, byContentId, live, actions }) {
   for (const issue of openIssues) {
     if (byContentId.has(issue.id)) continue;
     actions.added.push(`#${issue.number} ${issue.title}`);
-    if (DRY_RUN) continue;
-    const res = await gql(ADD_ITEM, { projectId: project.id, contentId: issue.id });
-    const item = {
-      id: res.addProjectV2ItemById.item.id,
-      fieldValues: { nodes: [] },
-      content: issue,
-    };
+
+    const id = DRY_RUN
+      ? `dry-run:${issue.number}`
+      : (await gql(ADD_ITEM, { projectId: project.id, contentId: issue.id })).addProjectV2ItemById
+          .item.id;
+
+    const item = { id, fieldValues: { nodes: [] }, content: issue };
     byContentId.set(issue.id, item);
     live.push(item);
   }
@@ -384,9 +388,13 @@ async function main() {
   await addMissingIssues({ project, openIssues, byContentId, live, actions });
 
   for (const issue of openIssues) {
-    const item = byContentId.get(issue.id);
-    // Absent only under --dry-run, where the add above was not performed.
-    if (item) await reconcileIssue({ issue, item, setSelect, setDate, actions });
+    await reconcileIssue({
+      issue,
+      item: byContentId.get(issue.id),
+      setSelect,
+      setDate,
+      actions,
+    });
   }
 
   await retireCompleted({

--- a/scripts/roadmap/sync.mjs
+++ b/scripts/roadmap/sync.mjs
@@ -1,0 +1,377 @@
+#!/usr/bin/env node
+// Keep the public roadmap board honest, automatically.
+//
+// Usage:
+//   node scripts/roadmap/sync.mjs --dry-run
+//   node scripts/roadmap/sync.mjs
+//   node scripts/roadmap/sync.mjs --archive-after-days 30 --json
+//
+// Requires a token with the `project` scope in GITHUB_TOKEN or ROADMAP_TOKEN.
+// The Actions GITHUB_TOKEN cannot write to an ORGANISATION project no matter how
+// its permissions block is written, so the workflow passes a PAT instead. That is
+// a GitHub limitation, not an oversight here.
+//
+// What it does, every run:
+//   1. Adds every open issue in the repo that is missing from the board.
+//   2. Fills empty Category/Priority/Start date cells from the issue itself.
+//   3. Forces Status to match the tracker when the tracker is unambiguous
+//      (closed -> Completed, reopened -> back to an open status).
+//   4. Archives items whose issue closed more than --archive-after-days ago.
+//
+// What it deliberately does NOT do: overwrite a Category, Priority or open Status
+// that a human has already set. The board is meant to be editable; an automation
+// that reverts your edit overnight trains everyone to stop editing. Only facts
+// the tracker owns - is it closed, when was it opened - are enforced.
+//
+// Step 4 is the part that stops the rot. The board reached 388 items / 387 closed
+// because nothing ever left it. Completed work stays visible for a month so a
+// reader can see recent shipping, then archives - archived items are retained by
+// GitHub and can be restored, so no history is lost.
+import { argv, env, exit, stdout, stderr } from 'node:process';
+import {
+  CATEGORIES,
+  STATUSES,
+  classifyCategory,
+  classifyPriority,
+  classifyStatus,
+} from './classify.mjs';
+
+const OWNER = env.ROADMAP_OWNER || 'YosemiteCrew';
+const REPO = env.ROADMAP_REPO || 'Yosemite-Crew';
+const PROJECT_NUMBER = Number(env.ROADMAP_PROJECT_NUMBER || 6);
+const API = 'https://api.github.com/graphql';
+
+const arg = (name, fallback = null) => {
+  const i = argv.indexOf(`--${name}`);
+  if (i === -1) return fallback;
+  const next = argv[i + 1];
+  return next && !next.startsWith('--') ? next : true;
+};
+const DRY_RUN = Boolean(arg('dry-run', false));
+const AS_JSON = Boolean(arg('json', false));
+const ARCHIVE_AFTER_DAYS = Number(arg('archive-after-days', 30));
+
+const token = env.ROADMAP_TOKEN || env.GITHUB_TOKEN;
+if (!token) {
+  stderr.write('roadmap-sync: no ROADMAP_TOKEN or GITHUB_TOKEN in the environment\n');
+  exit(2);
+}
+
+const log = (msg) => {
+  if (!AS_JSON) stdout.write(`${msg}\n`);
+};
+
+async function gql(query, variables = {}) {
+  const res = await fetch(API, {
+    method: 'POST',
+    headers: {
+      authorization: `bearer ${token}`,
+      'content-type': 'application/json',
+      'user-agent': 'yosemite-roadmap-sync',
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+  if (!res.ok) {
+    throw new Error(`GitHub GraphQL HTTP ${res.status}: ${(await res.text()).slice(0, 400)}`);
+  }
+  const body = await res.json();
+  if (body.errors?.length) {
+    // INSUFFICIENT_SCOPES is the failure everyone hits first, so name the cure.
+    const scopeError = body.errors.find((e) => e.type === 'INSUFFICIENT_SCOPES');
+    if (scopeError) {
+      throw new Error(
+        `GitHub rejected the call for missing scopes. The token needs the \`project\` scope. ${scopeError.message}`
+      );
+    }
+    throw new Error(`GitHub GraphQL: ${body.errors.map((e) => e.message).join('; ')}`);
+  }
+  return body.data;
+}
+
+// Page through any connection without hand-rolling a cursor loop per query.
+async function paginate(query, variables, pick) {
+  const out = [];
+  let cursor = null;
+  for (;;) {
+    const data = await gql(query, { ...variables, cursor });
+    const conn = pick(data);
+    out.push(...conn.nodes);
+    if (!conn.pageInfo.hasNextPage) return out;
+    cursor = conn.pageInfo.endCursor;
+  }
+}
+
+const PROJECT_QUERY = `
+query($owner:String!, $number:Int!) {
+  organization(login:$owner) {
+    projectV2(number:$number) {
+      id title url
+      fields(first:50) {
+        nodes {
+          ... on ProjectV2FieldCommon { id name dataType }
+          ... on ProjectV2SingleSelectField { id name options { id name } }
+        }
+      }
+    }
+  }
+}`;
+
+const ITEMS_QUERY = `
+query($owner:String!, $number:Int!, $cursor:String) {
+  organization(login:$owner) {
+    projectV2(number:$number) {
+      items(first:100, after:$cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id isArchived
+          fieldValues(first:30) {
+            nodes {
+              ... on ProjectV2ItemFieldSingleSelectValue { name field { ... on ProjectV2FieldCommon { name } } }
+              ... on ProjectV2ItemFieldTextValue { text field { ... on ProjectV2FieldCommon { name } } }
+              ... on ProjectV2ItemFieldDateValue { date field { ... on ProjectV2FieldCommon { name } } }
+            }
+          }
+          content {
+            ... on Issue { id number state closedAt }
+            ... on PullRequest { id number state closedAt }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+// Open issues, with the linked PRs that tell us whether work has actually begun.
+const OPEN_ISSUES_QUERY = `
+query($owner:String!, $repo:String!, $cursor:String) {
+  repository(owner:$owner, name:$repo) {
+    issues(first:50, after:$cursor, states:[OPEN], orderBy:{field:CREATED_AT, direction:ASC}) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        id number title body state createdAt
+        labels(first:20) { nodes { name } }
+        assignees(first:10) { nodes { login } }
+        closedByPullRequestsReferences(first:10, includeClosedPrs:false) {
+          nodes { number state isDraft }
+        }
+      }
+    }
+  }
+}`;
+
+const ADD_ITEM = `
+mutation($projectId:ID!, $contentId:ID!) {
+  addProjectV2ItemById(input:{projectId:$projectId, contentId:$contentId}) { item { id } }
+}`;
+
+const ARCHIVE_ITEM = `
+mutation($projectId:ID!, $itemId:ID!) {
+  archiveProjectV2Item(input:{projectId:$projectId, itemId:$itemId}) { item { id } }
+}`;
+
+const SET_SELECT = `
+mutation($projectId:ID!, $itemId:ID!, $fieldId:ID!, $optionId:String!) {
+  updateProjectV2ItemFieldValue(input:{
+    projectId:$projectId, itemId:$itemId, fieldId:$fieldId,
+    value:{singleSelectOptionId:$optionId}
+  }) { projectV2Item { id } }
+}`;
+
+const SET_DATE = `
+mutation($projectId:ID!, $itemId:ID!, $fieldId:ID!, $date:Date!) {
+  updateProjectV2ItemFieldValue(input:{
+    projectId:$projectId, itemId:$itemId, fieldId:$fieldId, value:{date:$date}
+  }) { projectV2Item { id } }
+}`;
+
+const fieldValue = (item, name) => {
+  for (const n of item.fieldValues?.nodes || []) {
+    if (n?.field?.name === name) return n.name ?? n.text ?? n.date ?? null;
+  }
+  return null;
+};
+
+async function main() {
+  const project = (await gql(PROJECT_QUERY, { owner: OWNER, number: PROJECT_NUMBER })).organization
+    .projectV2;
+  if (!project) throw new Error(`No project #${PROJECT_NUMBER} on ${OWNER}`);
+
+  const fields = new Map(project.fields.nodes.filter(Boolean).map((f) => [f.name, f]));
+  const need = ['Status', 'Category', 'Priority', 'Start date', 'End date'];
+  const missing = need.filter((n) => !fields.has(n));
+  if (missing.length) throw new Error(`Board is missing fields: ${missing.join(', ')}`);
+
+  // Resolve option ids up front and fail loudly on a rename, rather than
+  // silently skipping every item that maps to the missing option.
+  const optionId = (fieldName, optionName) => {
+    const f = fields.get(fieldName);
+    const o = (f.options || []).find((x) => x.name === optionName);
+    return o ? o.id : null;
+  };
+
+  const [items, openIssues] = await Promise.all([
+    paginate(
+      ITEMS_QUERY,
+      { owner: OWNER, number: PROJECT_NUMBER },
+      (d) => d.organization.projectV2.items
+    ),
+    paginate(OPEN_ISSUES_QUERY, { owner: OWNER, repo: REPO }, (d) => d.repository.issues),
+  ]);
+
+  const live = items.filter((i) => !i.isArchived);
+  const byContentId = new Map(live.filter((i) => i.content?.id).map((i) => [i.content.id, i]));
+
+  const actions = { added: [], archived: [], updated: [], uncategorised: [], skipped: [] };
+  const cutoff = Date.now() - ARCHIVE_AFTER_DAYS * 86400000;
+
+  const setSelect = async (item, fieldName, optionName, issueRef) => {
+    const oid = optionId(fieldName, optionName);
+    if (!oid) {
+      actions.skipped.push(`${issueRef}: no "${optionName}" option on ${fieldName}`);
+      return;
+    }
+    if (!DRY_RUN) {
+      await gql(SET_SELECT, {
+        projectId: project.id,
+        itemId: item.id,
+        fieldId: fields.get(fieldName).id,
+        optionId: oid,
+      });
+    }
+    actions.updated.push(`${issueRef}: ${fieldName} -> ${optionName}`);
+  };
+
+  const setDate = async (item, fieldName, isoDate, issueRef) => {
+    if (!DRY_RUN) {
+      await gql(SET_DATE, {
+        projectId: project.id,
+        itemId: item.id,
+        fieldId: fields.get(fieldName).id,
+        date: isoDate.slice(0, 10),
+      });
+    }
+    actions.updated.push(`${issueRef}: ${fieldName} -> ${isoDate.slice(0, 10)}`);
+  };
+
+  // 1. Add missing open issues.
+  for (const issue of openIssues) {
+    if (byContentId.has(issue.id)) continue;
+    if (DRY_RUN) {
+      actions.added.push(`#${issue.number} ${issue.title}`);
+      continue;
+    }
+    const res = await gql(ADD_ITEM, { projectId: project.id, contentId: issue.id });
+    const newItem = {
+      id: res.addProjectV2ItemById.item.id,
+      fieldValues: { nodes: [] },
+      content: issue,
+    };
+    byContentId.set(issue.id, newItem);
+    live.push(newItem);
+    actions.added.push(`#${issue.number} ${issue.title}`);
+  }
+
+  // 2 and 3. Reconcile fields for every open issue on the board.
+  for (const issue of openIssues) {
+    const item = byContentId.get(issue.id);
+    if (!item) continue;
+    const ref = `#${issue.number}`;
+    const labels = (issue.labels?.nodes || []).map((l) => l.name);
+
+    if (!fieldValue(item, 'Category')) {
+      const { category, reason } = classifyCategory({
+        title: issue.title,
+        body: issue.body,
+        labels,
+      });
+      if (category) await setSelect(item, 'Category', category, ref);
+      else actions.uncategorised.push(`${ref} ${issue.title.slice(0, 70)} (${reason})`);
+    }
+
+    if (!fieldValue(item, 'Priority')) {
+      await setSelect(item, 'Priority', classifyPriority({ labels, title: issue.title }), ref);
+    }
+
+    // The roadmap view is a timeline; without a start date an item does not plot
+    // at all, which is why the existing ROADMAP_LAYOUT view has been empty.
+    if (!fieldValue(item, 'Start date')) {
+      await setDate(item, 'Start date', issue.createdAt, ref);
+    }
+
+    const current = fieldValue(item, 'Status');
+    const derived = classifyStatus({
+      state: issue.state,
+      assignees: issue.assignees?.nodes || [],
+      linkedPrs: (issue.closedByPullRequestsReferences?.nodes || []).map((p) => ({
+        state: p.state,
+        isDraft: p.isDraft,
+      })),
+    });
+    // An open issue sitting in Completed is the exact lie this script exists to
+    // stop, so that one gets corrected even though it is a human-set value.
+    if (!current || current === STATUSES.COMPLETED) {
+      await setSelect(item, 'Status', derived, ref);
+    }
+  }
+
+  // 4. Retire finished work so the board stays a roadmap and not an archive.
+  for (const item of live) {
+    const c = item.content;
+    if (!c || !c.closedAt) continue;
+    if (Date.parse(c.closedAt) > cutoff) {
+      // Recently finished: make sure it reads as done before it ages out.
+      if (fieldValue(item, 'Status') !== STATUSES.COMPLETED) {
+        await setSelect(item, 'Status', STATUSES.COMPLETED, `#${c.number}`);
+      }
+      if (!fieldValue(item, 'End date')) {
+        await setDate(item, 'End date', c.closedAt, `#${c.number}`);
+      }
+      continue;
+    }
+    if (!DRY_RUN) {
+      await gql(ARCHIVE_ITEM, { projectId: project.id, itemId: item.id });
+    }
+    actions.archived.push(`#${c.number} (closed ${c.closedAt.slice(0, 10)})`);
+  }
+
+  const summary = {
+    project: project.url,
+    dryRun: DRY_RUN,
+    boardItemsBefore: items.length,
+    liveItemsBefore: live.length - actions.added.length,
+    openIssues: openIssues.length,
+    added: actions.added.length,
+    archived: actions.archived.length,
+    fieldUpdates: actions.updated.length,
+    uncategorised: actions.uncategorised.length,
+    skipped: actions.skipped.length,
+  };
+
+  if (AS_JSON) {
+    stdout.write(`${JSON.stringify({ summary, actions }, null, 2)}\n`);
+    return;
+  }
+
+  log(`\nRoadmap sync ${DRY_RUN ? '(dry run)' : ''} -> ${project.url}`);
+  log(`  board items ${items.length} (${live.length} live)  open issues ${openIssues.length}`);
+  log(
+    `  added ${actions.added.length}  archived ${actions.archived.length}  field updates ${actions.updated.length}`
+  );
+  for (const a of actions.added.slice(0, 100)) log(`    + ${a}`);
+  if (actions.archived.length)
+    log(`  archived (closed over ${ARCHIVE_AFTER_DAYS}d ago): ${actions.archived.length}`);
+  if (actions.uncategorised.length) {
+    log(`\n  NEEDS A HUMAN - no category could be derived:`);
+    for (const u of actions.uncategorised) log(`    ? ${u}`);
+  }
+  if (actions.skipped.length) {
+    log(`\n  SKIPPED:`);
+    for (const s of actions.skipped) log(`    ! ${s}`);
+  }
+  log('');
+}
+
+main().catch((err) => {
+  stderr.write(`roadmap-sync failed: ${err.message}\n`);
+  exit(1);
+});


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

The public roadmap board, https://github.com/orgs/YosemiteCrew/projects/6, is maintained by hand, so it stopped being maintained. Measured on 2026-08-22:

| | |
|---|---|
| Items on the board | 388 |
| Already closed or merged | 387 |
| Open issues in the repo | 79 |
| Open issues on the board | 1 |
| Most recent completion on it | 2026-07-14 |
| Items carrying a start date | 0 |

Four items sat in "Not Started" while their issues were closed (#1002, #1007, #1014, #1040), and the "Company roadmap" timeline view rendered nothing at all, because a timeline needs a start date and no item had one.

The decay was gradual: 135 items closed in September 2025, 31 in June 2026, 7 in July 2026, then nothing. Nobody decided to stop.

The effect is a public page promising "upcoming launches with mobile app and PMS platform" that shows only finished 2025 work, while the 79 things actually being built are invisible.

## What is the new behavior?

The board is now derived from the tracker rather than kept in parallel with it.

**`scripts/roadmap/classify.mjs`** decides Category, Priority and Status from evidence already on the issue: labels, the conventional-commit scope in the title, the bug template's "Affected area", and the workspace paths named in the body. It has no network access, so it is unit tested directly.

The precedence rules matter more than the rules themselves, and each one is pinned by a regression test taken from an issue an earlier draft filed wrongly:

- A surface label beats a keyword found in the body. #2008 carries the `App` label and mentions MCP in passing; it is mobile work.
- A repo-wide `chore`/`ci`/`test`/`perf` is infrastructure whatever paths its body lists. #1992 was pulled into Mobile App by a single stray `android/`; #2355 by seven mobile examples in a peer-dependency check.
- "desktop" in a frontend title is a viewport, not the Electron app (#1868). Only an explicit `desktop` scope means the desktop app (#2252).
- An issue nothing can place is reported as needing a human rather than filed wrongly.

**`scripts/roadmap/sync.mjs`** reconciles the board: adds open issues that are missing, fills empty Category / Priority / Start date cells, forces Status where the tracker is unambiguous, and archives items whose issue closed more than 30 days ago. It is dependency-free and has a `--dry-run` mode.

Two properties are deliberate:

- **Human edits survive.** Category, Priority and any open Status are only written when the cell is empty. An automation that reverts your edit overnight teaches everyone to stop editing. Only facts the tracker owns are enforced, plus the one lie this exists to stop: an open issue sitting in Completed.
- **Finished work leaves.** The board reached 387 closed items because nothing ever left it. Completions stay visible for 30 days, then archive. GitHub retains archived items, so no history is lost.

**`.github/workflows/roadmap.yml`** runs it on issue events, nightly at 05:00 UTC, and on demand. Bursts collapse through a `roadmap-sync` concurrency group, since every run reads whole-board state and the last one wins.

## Board state after the first reconciliation

Already applied, so this PR only makes it repeatable:

| Category | Open issues |
|---|---|
| Mobile App | 34 |
| Web PMS | 24 |
| Platform & Infra | 13 |
| Developer Platform | 5 |
| Super Admin | 2 |
| Desktop App | 1 |

79 live items, all open, every one with a Category, Priority, Status and Start date. 387 stale items archived. Zero uncategorised.

Two Category options were added for work that previously had nowhere to go: `Platform & Infra` and `Desktop App`. Surface labels were applied to the 28 open issues that had none, so classification reads facts instead of guessing; only three issues now rest on a heuristic at all, and all three are correct.

## Test plan

- [x] 15 unit tests over the classifier, one per real misclassification, run by `pnpm test:scripts`.
- [x] Mutation check: removing the surface-label precedence fails a test, disabling the repo-wide toolchain rule fails a test. Restoring both returns 15/15, so the suite is not passing vacuously.
- [x] `--dry-run` against the live board predicted 78 adds and 387 archives; the live run performed exactly that.
- [x] Workflow input guard rejects `abc`, `30; rm -rf /`, `$(whoami)` and empty, accepts `30` and `7`.
- [x] Aikido SAST and secrets scan clean.

Two pre-existing failures in `test:scripts` (`check-override-advisories`, `check-peer-deps`) are `Cannot find module 'semver'` in a fresh worktree with no `node_modules`. Unrelated to this change; the roadmap suite is dependency-free.

## Dependencies & risks

**One manual step is required before the automation can run.** The board is an organisation project, and the built-in Actions `GITHUB_TOKEN` cannot write to one regardless of its permissions block. The workflow needs a fine-grained PAT saved as the repository secret `ROADMAP_TOKEN`, with organisation permission `Projects: Read and write` and repository permission `Issues: Read`.

The workflow fails loudly when that secret is missing rather than skipping, because a roadmap sync that quietly does nothing looks exactly like one that is working.

Archiving is reversible; GitHub retains archived project items.

## Related Issue(s)

Fixes #2393
