### PR TITLE
fix(frontend): release org-switch loader on same-route redirect

### DIFF
--- a/apps/frontend/src/app/__tests__/components/DataTable/OrganizationList.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/DataTable/OrganizationList.test.tsx
@@ -5,7 +5,7 @@ import OrganizationList from '@/app/ui/tables/OrganizationList';
 import { useOrgStore } from '@/app/stores/orgStore';
 import { useRouter } from 'next/navigation';
 import { resolveOrgScopedRedirect } from '@/app/lib/postAuthRedirect';
-import { startRouteLoader, stopRouteLoader } from '@/app/lib/routeLoader';
+import { isCurrentRoute, startRouteLoader, stopRouteLoader } from '@/app/lib/routeLoader';
 import { OrgWithMembership } from '@/app/features/organization/types/org';
 
 jest.mock('next/navigation', () => ({
@@ -23,6 +23,7 @@ jest.mock('@/app/lib/postAuthRedirect', () => ({
 jest.mock('@/app/lib/routeLoader', () => ({
   startRouteLoader: jest.fn(),
   stopRouteLoader: jest.fn(),
+  isCurrentRoute: jest.fn(),
 }));
 
 const mockShow = jest.fn();
@@ -107,5 +108,29 @@ describe('OrganizationList', () => {
     await waitFor(() => expect(mockHide).toHaveBeenCalledWith('org-switch'));
     expect(stopRouteLoader).toHaveBeenCalled();
     expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('leaves both loaders running when the redirect navigates away', async () => {
+    (resolveOrgScopedRedirect as jest.Mock).mockResolvedValue('/appointments');
+    (isCurrentRoute as jest.Mock).mockReturnValue(false);
+    render(<OrganizationList orgs={[verifiedOrg]} />);
+
+    fireEvent.click(screen.getByTestId('org-card-Verified Corp'));
+
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/appointments'));
+    expect(mockHide).not.toHaveBeenCalled();
+    expect(stopRouteLoader).not.toHaveBeenCalled();
+  });
+
+  it('releases both loaders when the redirect targets the current route', async () => {
+    (resolveOrgScopedRedirect as jest.Mock).mockResolvedValue('/organizations');
+    (isCurrentRoute as jest.Mock).mockReturnValue(true);
+    render(<OrganizationList orgs={[verifiedOrg]} />);
+
+    fireEvent.click(screen.getByTestId('org-card-Verified Corp'));
+
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/organizations'));
+    expect(mockHide).toHaveBeenCalledWith('org-switch');
+    expect(stopRouteLoader).toHaveBeenCalled();
   });
 });

--- a/apps/frontend/src/app/__tests__/ui/layout/RouteLoaderOverlay.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/layout/RouteLoaderOverlay.test.tsx
@@ -21,6 +21,13 @@ jest.mock('@/app/stores/routeLoaderStore', () => ({
   useRouteLoaderStore: jest.fn(),
 }));
 
+const mockHide = jest.fn();
+jest.mock('@/app/stores/fullscreenLoaderStore', () => ({
+  useFullscreenLoaderStore: {
+    getState: jest.fn(() => ({ hide: mockHide })),
+  },
+}));
+
 describe('RouteLoaderOverlay', () => {
   const store = { isLoading: false };
 
@@ -79,6 +86,7 @@ describe('RouteLoaderOverlay', () => {
     });
 
     expect(stopRouteLoader).toHaveBeenCalled();
+    expect(mockHide).toHaveBeenCalledWith('org-switch');
     store.isLoading = false;
   });
 });

--- a/apps/frontend/src/app/lib/routeLoader.ts
+++ b/apps/frontend/src/app/lib/routeLoader.ts
@@ -7,3 +7,16 @@ export const startRouteLoader = () => {
 export const stopRouteLoader = () => {
   useRouteLoaderStore.getState().stop();
 };
+
+/**
+ * RouteLoaderOverlay releases the org-switch loader when the pathname or query
+ * changes. Pushing the route we are already on fires neither, so callers have to
+ * release it themselves.
+ */
+export const isCurrentRoute = (route: string) => {
+  const next = new URL(route, globalThis.window.location.origin);
+  return (
+    next.pathname === globalThis.window.location.pathname &&
+    next.search === globalThis.window.location.search
+  );
+};

--- a/apps/frontend/src/app/ui/layout/Header/UserHeader/UserHeader.tsx
+++ b/apps/frontend/src/app/ui/layout/Header/UserHeader/UserHeader.tsx
@@ -22,26 +22,13 @@ import { getSafeImageUrl } from '@/app/lib/urls';
 import Search from '@/app/ui/inputs/Search';
 import { useSearchStore } from '@/app/stores/searchStore';
 import { useResolvedMerckIntegrationForPrimaryOrg } from '@/app/hooks/useMerckIntegration';
-import { startRouteLoader, stopRouteLoader } from '@/app/lib/routeLoader';
+import { isCurrentRoute, startRouteLoader, stopRouteLoader } from '@/app/lib/routeLoader';
 import { useFullscreenLoaderStore } from '@/app/stores/fullscreenLoaderStore';
 import { resolveOrgScopedRedirect } from '@/app/lib/postAuthRedirect';
 import { useCompanionTerminologyText } from '@/app/hooks/useCompanionTerminologyText';
 import { ThemeToggle } from '@/app/ui/theme';
 import NotificationsBell from '@/app/ui/layout/Notifications/NotificationsBell';
 import './UserHeader.css';
-
-/**
- * RouteLoaderOverlay releases the org-switch loader when the pathname or query
- * changes. Pushing the route we are already on fires neither, so callers have to
- * release it themselves.
- */
-const isCurrentRoute = (route: string) => {
-  const next = new URL(route, globalThis.window.location.origin);
-  return (
-    next.pathname === globalThis.window.location.pathname &&
-    next.search === globalThis.window.location.search
-  );
-};
 
 const shouldHideSearch = (pathname: string): boolean =>
   pathname.startsWith('/chat') ||

--- a/apps/frontend/src/app/ui/layout/RouteLoaderOverlay.tsx
+++ b/apps/frontend/src/app/ui/layout/RouteLoaderOverlay.tsx
@@ -66,6 +66,7 @@ const RouteLoaderOverlay = () => {
     if (!isLoading) return;
     const timeout = globalThis.window.setTimeout(() => {
       stopRouteLoader();
+      useFullscreenLoaderStore.getState().hide('org-switch');
     }, 15000);
 
     return () => {

--- a/apps/frontend/src/app/ui/tables/OrganizationList.tsx
+++ b/apps/frontend/src/app/ui/tables/OrganizationList.tsx
@@ -6,7 +6,7 @@ import OrgCard from '@/app/ui/cards/OrgCard/OrgCard';
 import { useOrgStore } from '@/app/stores/orgStore';
 import { OrgWithMembership } from '@/app/features/organization/types/org';
 import { resolveOrgScopedRedirect } from '@/app/lib/postAuthRedirect';
-import { startRouteLoader, stopRouteLoader } from '@/app/lib/routeLoader';
+import { isCurrentRoute, startRouteLoader, stopRouteLoader } from '@/app/lib/routeLoader';
 import { useFullscreenLoaderStore } from '@/app/stores/fullscreenLoaderStore';
 
 type OrganizationListProps = {
@@ -27,6 +27,10 @@ const OrganizationList = ({ orgs }: OrganizationListProps) => {
       const role = org.membership?.roleDisplay ?? org.membership?.roleCode;
       const nextRoute = await resolveOrgScopedRedirect({ orgId: id, fallbackRole: role });
       router.push(nextRoute);
+      if (isCurrentRoute(nextRoute)) {
+        hide('org-switch');
+        stopRouteLoader();
+      }
     } catch {
       hide('org-switch');
       stopRouteLoader();


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

When a user switches organizations, the fullscreen "org-switch" loader and the
route loader are displayed while the post-auth redirect is resolved. The
RouteLoaderOverlay only releases these loaders when the pathname or query
changes. When the resolved redirect points at the route the user is already on,
`router.push` triggers no navigation, so neither loader is ever released and the
fullscreen loader stays up indefinitely.

## What is the new behavior?

The org-switch loader is now released on the success path when the redirect
targets the current route.

- Moved `isCurrentRoute` out of `UserHeader` into `lib/routeLoader.ts` so it can
  be shared, and imported it in `UserHeader` and `OrganizationList`.
- In `OrganizationList`, after pushing the resolved redirect, both the org-switch
  fullscreen loader and the route loader are released when `isCurrentRoute`
  returns true (the navigation would otherwise be a no-op).
- As a safety net, the RouteLoaderOverlay 15s timeout now also hides the
  org-switch fullscreen loader in addition to stopping the route loader.

Impact area: frontend org-switch flow (`OrganizationList`, `UserHeader`,
`RouteLoaderOverlay`, `lib/routeLoader.ts`).

Tests added/updated:
- `OrganizationList`: same-route release path and navigate-away path
  (`isCurrentRoute` true/false), with `isCurrentRoute` mocked.
- `RouteLoaderOverlay`: added a `fullscreenLoaderStore` mock and asserted
  `hide('org-switch')` fires on the 15s timeout.

## Validation performed

- `npx tsc --noemit`: exit 0.
- `pnpm --filter frontend run lint`: exit 0 (one pre-existing warning in an
  untouched file).
- Targeted tests: 39/39 pass.
- Coverage on touched files: 99.2% statements, 89.11% branches, 100% functions,
  99.2% lines.

Not manually exercised in a browser; verification was type-check, lint, and the
targeted test suite only.

## Related Issue(s)

Fixes #2388

Closes #2388
