### PR TITLE
fix(repo): pin @types/react so builds stop failing at random

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,8 @@
       "path-to-regexp@0.1.12": "0.1.13",
       "path-to-regexp@8.3.0": "8.4.2",
       "@babel/plugin-transform-modules-systemjs": "7.29.4",
+      "@types/react": "19.2.18",
+      "@types/react-dom": "19.2.3",
       "fast-xml-builder": "1.2.1",
       "postcss": "8.5.26",
       "uuid@<11.1.1": "11.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,8 @@ overrides:
   path-to-regexp@0.1.12: 0.1.13
   path-to-regexp@8.3.0: 8.4.2
   '@babel/plugin-transform-modules-systemjs': 7.29.4
+  '@types/react': 19.2.18
+  '@types/react-dom': 19.2.3
   fast-xml-builder: 1.2.1
   postcss: 8.5.26
   uuid@<11.1.1: 11.1.1
@@ -496,7 +498,7 @@ importers:
         version: 3.30.0(@tiptap/core@3.30.0)
       '@tiptap/react':
         specifier: ^3.30.0
-        version: 3.30.0(@floating-ui/dom@1.8.0)(@tiptap/core@3.30.0)(@tiptap/pm@3.30.0)(@types/react-dom@19.2.3)(@types/react@19.2.11)(react-dom@19.2.4)(react@19.2.4)
+        version: 3.30.0(@floating-ui/dom@1.8.0)(@tiptap/core@3.30.0)(@tiptap/pm@3.30.0)(@types/react-dom@19.2.3)(@types/react@19.2.18)(react-dom@19.2.4)(react@19.2.4)
       '@tiptap/starter-kit':
         specifier: ^3.30.0
         version: 3.30.0
@@ -541,13 +543,13 @@ importers:
         version: 11.1.0(react-dom@19.2.4)(react@19.2.4)
       recharts:
         specifier: ^3.10.1
-        version: 3.10.1(@types/react@19.2.11)(react-dom@19.2.4)(react-is@19.2.8)(react@19.2.4)(redux@5.0.1)
+        version: 3.10.1(@types/react@19.2.18)(react-dom@19.2.4)(react-is@19.2.8)(react@19.2.4)(redux@5.0.1)
       stream-chat:
         specifier: ^9.50.3
         version: 9.51.0
       stream-chat-react:
         specifier: ^13.14.6
-        version: 13.14.6(@types/react@19.2.11)(react-dom@19.2.4)(react@19.2.4)(stream-chat@9.51.0)(typescript@5.9.3)
+        version: 13.14.6(@types/react@19.2.18)(react-dom@19.2.4)(react@19.2.4)(stream-chat@9.51.0)(typescript@5.9.3)
       supertokens-web-js:
         specifier: ^0.16.0
         version: 0.16.0
@@ -556,7 +558,7 @@ importers:
         version: 13.15.26
       zustand:
         specifier: ^5.0.14
-        version: 5.0.14(@types/react@19.2.11)(react@19.2.4)
+        version: 5.0.14(@types/react@19.2.18)(react@19.2.4)
     devDependencies:
       '@axe-core/playwright':
         specifier: ^4.13.0
@@ -572,13 +574,13 @@ importers:
         version: 10.5.7(storybook@10.5.7)
       '@storybook/addon-docs':
         specifier: ^10.5.7
-        version: 10.5.7(@types/react-dom@19.2.3)(@types/react@19.2.11)(storybook@10.5.7)(vite@7.3.5)
+        version: 10.5.7(@types/react-dom@19.2.3)(@types/react@19.2.18)(storybook@10.5.7)(vite@7.3.5)
       '@storybook/nextjs-vite':
         specifier: ^10.5.7
-        version: 10.5.7(@babel/core@7.29.6)(@types/react-dom@19.2.3)(@types/react@19.2.11)(next@15.5.21)(react-dom@19.2.4)(react@19.2.4)(storybook@10.5.7)(typescript@5.9.3)(vite@7.3.5)
+        version: 10.5.7(@babel/core@7.29.6)(@types/react-dom@19.2.3)(@types/react@19.2.18)(next@15.5.21)(react-dom@19.2.4)(react@19.2.4)(storybook@10.5.7)(typescript@5.9.3)(vite@7.3.5)
       '@storybook/react':
         specifier: ^10.5.7
-        version: 10.5.7(@types/react-dom@19.2.3)(@types/react@19.2.11)(react-dom@19.2.4)(react@19.2.4)(storybook@10.5.7)(typescript@5.9.3)
+        version: 10.5.7(@types/react-dom@19.2.3)(@types/react@19.2.18)(react-dom@19.2.4)(react@19.2.4)(storybook@10.5.7)(typescript@5.9.3)
       '@tailwindcss/postcss':
         specifier: ^4.3.3
         version: 4.3.3
@@ -590,7 +592,7 @@ importers:
         version: 7.0.1(@testing-library/dom@10.4.1)
       '@testing-library/react':
         specifier: ^16.3.2
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3)(@types/react@19.2.11)(react-dom@19.2.4)(react@19.2.4)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3)(@types/react@19.2.18)(react-dom@19.2.4)(react@19.2.4)
       '@types/jest':
         specifier: ^30.0.0
         version: 30.0.0
@@ -601,14 +603,14 @@ importers:
         specifier: ^26
         version: 26.2.0
       '@types/react':
-        specifier: ^19.1.1
-        version: 19.2.11
+        specifier: 19.2.18
+        version: 19.2.18
       '@types/react-datepicker':
         specifier: ^7.0.0
         version: 7.0.0(react-dom@19.2.4)(react@19.2.4)
       '@types/react-dom':
-        specifier: ^19.1.1
-        version: 19.2.3(@types/react@19.2.11)
+        specifier: 19.2.3
+        version: 19.2.3(@types/react@19.2.18)
       '@yosemite-crew/design-tokens':
         specifier: workspace:^
         version: link:../../packages/design-tokens
@@ -650,7 +652,7 @@ importers:
         version: 8.5.26
       storybook:
         specifier: ^10.5.7
-        version: 10.5.7(@types/react@19.2.11)(prettier@3.9.6)(react@19.2.4)
+        version: 10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.4)
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3
@@ -932,7 +934,7 @@ importers:
         specifier: ^30.0.0
         version: 30.0.0
       '@types/react':
-        specifier: ^19.1.4
+        specifier: 19.2.18
         version: 19.2.18
       '@types/react-native-vector-icons':
         specifier: ^6.4.18
@@ -5109,7 +5111,7 @@ packages:
   /@docsearch/core@4.7.0(@types/react@19.2.18)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-p/9xVKmPDj3FPvMfPf5naVO3Ej8SCbcUugGvx1+8GgkuBNbqxqN2Irx3WLBv8VY0jH7XpRwKWdlmjXLZsmTLsg==}
     peerDependencies:
-      '@types/react': '>= 16.8.0 < 20.0.0'
+      '@types/react': 19.2.18
       react: '>= 16.8.0 < 20.0.0'
       react-dom: '>= 16.8.0 < 20.0.0'
     peerDependenciesMeta:
@@ -5132,7 +5134,7 @@ packages:
   /@docsearch/react@4.7.0(@algolia/client-search@5.56.0)(@types/react@19.2.18)(algoliasearch@5.56.0)(react-dom@18.3.1)(react@18.3.1)(search-insights@2.17.3):
     resolution: {integrity: sha512-x6oedjJ8O8/pIDBsMo5Orca3/6cQCz616/CwthVe68l43mqnj2lrJ9kFQITBqy8hMsS3nWeBWFoVO5dJ1DCFKA==}
     peerDependencies:
-      '@types/react': '>= 16.8.0 < 20.0.0'
+      '@types/react': 19.2.18
       react: '>= 16.8.0 < 20.0.0'
       react-dom: '>= 16.8.0 < 20.0.0'
       search-insights: '>= 1 < 3'
@@ -7910,7 +7912,7 @@ packages:
   /@gorhom/bottom-sheet@5.1.8(@types/react@19.2.18)(react-native-gesture-handler@2.32.0)(react-native-reanimated@4.2.3)(react-native@0.81.6)(react@19.1.4):
     resolution: {integrity: sha512-QuYIVjn3K9bW20n5bgOSjvxBYoWG4YQXiLGOheEAMgISuoT6sMcA270ViSkkb0fenPxcIOwzCnFNuxmr739T9A==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.2.18
       '@types/react-native': '*'
       react: '*'
       react-native: '*'
@@ -7934,7 +7936,7 @@ packages:
   /@gorhom/bottom-sheet@5.2.14(@types/react@19.2.18)(react-native-gesture-handler@2.32.0)(react-native-reanimated@4.2.3)(react-native@0.81.6)(react@19.1.4):
     resolution: {integrity: sha512-uLQFlDjp9z+jrOFcMSEldPqL5JdaXL3vXOh+juhwoNvXgTsEorJLjHTugXu+YccAG/0KJnShzKCrb71MHBsvJg==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.2.18
       '@types/react-native': '*'
       react: '*'
       react-native: '*'
@@ -9050,27 +9052,27 @@ packages:
       - supports-color
     dev: false
 
-  /@mdx-js/react@3.1.1(@types/react@19.2.11)(react@19.1.4):
-    resolution: {integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==}
-    peerDependencies:
-      '@types/react': '>=16'
-      react: '>=16'
-    dependencies:
-      '@types/mdx': 2.0.13
-      '@types/react': 19.2.11
-      react: 19.1.4
-    dev: true
-
   /@mdx-js/react@3.1.1(@types/react@19.2.18)(react@18.3.1):
     resolution: {integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==}
     peerDependencies:
-      '@types/react': '>=16'
+      '@types/react': 19.2.18
       react: '>=16'
     dependencies:
       '@types/mdx': 2.0.13
       '@types/react': 19.2.18
       react: 18.3.1
     dev: false
+
+  /@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.1.4):
+    resolution: {integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==}
+    peerDependencies:
+      '@types/react': 19.2.18
+      react: '>=16'
+    dependencies:
+      '@types/mdx': 2.0.13
+      '@types/react': 19.2.18
+      react: 19.1.4
+    dev: true
 
   /@modelcontextprotocol/sdk@1.26.0(zod@3.25.76):
     resolution: {integrity: sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==}
@@ -11029,7 +11031,7 @@ packages:
     resolution: {integrity: sha512-goxnVoJIZmnu5Qm3tLaNIj1NtKJ4k1i1yfnJmDGjnSHgvNrYeh1q6Dwk3dFmTSIg+R4DOJ09oIGv98Fugr4wZg==}
     engines: {node: '>= 20.19.4'}
     peerDependencies:
-      '@types/react': ^19.1.4
+      '@types/react': 19.2.18
       react: '*'
       react-native: '*'
     peerDependenciesMeta:
@@ -11056,7 +11058,7 @@ packages:
     resolution: {integrity: sha512-1RrZl3a7iCoAS2SGaRLjJPIn8bg/GLNXzqkIB2lufXcJsftu1umNLRIi17ZoDRejAWSd2pUfUtQBASo4R2mw4Q==}
     engines: {node: '>= 20.19.4'}
     peerDependencies:
-      '@types/react': ^19.1.4
+      '@types/react': 19.2.18
       react: '*'
       react-native: '*'
     peerDependenciesMeta:
@@ -11242,7 +11244,7 @@ packages:
       '@standard-schema/utils': 0.3.0
       immer: 11.1.15
       react: 19.2.4
-      react-redux: 9.3.0(@types/react@19.2.11)(react@19.2.4)(redux@5.0.1)
+      react-redux: 9.3.0(@types/react@19.2.18)(react@19.2.4)(redux@5.0.1)
       redux: 5.0.1
       redux-thunk: 3.1.0(redux@5.0.1)
       reselect: 5.2.0
@@ -11726,26 +11728,26 @@ packages:
     dependencies:
       '@storybook/global': 5.0.0
       axe-core: 4.12.1
-      storybook: 10.5.7(@types/react@19.2.11)(prettier@3.9.6)(react@19.2.4)
+      storybook: 10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.4)
     dev: true
 
-  /@storybook/addon-docs@10.5.7(@types/react-dom@19.2.3)(@types/react@19.2.11)(storybook@10.5.7)(vite@7.3.5):
+  /@storybook/addon-docs@10.5.7(@types/react-dom@19.2.3)(@types/react@19.2.18)(storybook@10.5.7)(vite@7.3.5):
     resolution: {integrity: sha512-KNARJfjICaizinsR3INMEiipZm1ObYo+xw+E26gteu50Bcy2dIZUtk5uHY5XdtardU3AXX6yRXoBZ2HCY3lbHA==}
     peerDependencies:
-      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      '@types/react': 19.2.18
       storybook: ^10.5.7
     peerDependenciesMeta:
       '@types/react':
         optional: true
     dependencies:
-      '@mdx-js/react': 3.1.1(@types/react@19.2.11)(react@19.1.4)
+      '@mdx-js/react': 3.1.1(@types/react@19.2.18)(react@19.1.4)
       '@storybook/csf-plugin': 10.5.7(storybook@10.5.7)(vite@7.3.5)
       '@storybook/icons': 2.1.0(react@19.1.4)
-      '@storybook/react-dom-shim': 10.5.7(@types/react-dom@19.2.3)(@types/react@19.2.11)(react-dom@19.2.4)(react@19.1.4)(storybook@10.5.7)
-      '@types/react': 19.2.11
+      '@storybook/react-dom-shim': 10.5.7(@types/react-dom@19.2.3)(@types/react@19.2.18)(react-dom@19.2.4)(react@19.1.4)(storybook@10.5.7)
+      '@types/react': 19.2.18
       react: 19.1.4
       react-dom: 19.2.4(react@19.1.4)
-      storybook: 10.5.7(@types/react@19.2.11)(prettier@3.9.6)(react@19.2.4)
+      storybook: 10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.4)
       ts-dedent: 2.3.0
     transitivePeerDependencies:
       - '@types/react-dom'
@@ -11762,7 +11764,7 @@ packages:
       vite: 7.3.5
     dependencies:
       '@storybook/csf-plugin': 10.5.7(storybook@10.5.7)(vite@7.3.5)
-      storybook: 10.5.7(@types/react@19.2.11)(prettier@3.9.6)(react@19.2.4)
+      storybook: 10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.4)
       ts-dedent: 2.3.0
       vite: 7.3.5(@types/node@26.2.0)
     transitivePeerDependencies:
@@ -11789,7 +11791,7 @@ packages:
       webpack:
         optional: true
     dependencies:
-      storybook: 10.5.7(@types/react@19.2.11)(prettier@3.9.6)(react@19.2.4)
+      storybook: 10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.4)
       unplugin: 2.3.11
       vite: 7.3.5(@types/node@26.2.0)
     dev: true
@@ -11814,11 +11816,11 @@ packages:
       react: 19.2.4
     dev: true
 
-  /@storybook/nextjs-vite@10.5.7(@babel/core@7.29.6)(@types/react-dom@19.2.3)(@types/react@19.2.11)(next@15.5.21)(react-dom@19.2.4)(react@19.2.4)(storybook@10.5.7)(typescript@5.9.3)(vite@7.3.5):
+  /@storybook/nextjs-vite@10.5.7(@babel/core@7.29.6)(@types/react-dom@19.2.3)(@types/react@19.2.18)(next@15.5.21)(react-dom@19.2.4)(react@19.2.4)(storybook@10.5.7)(typescript@5.9.3)(vite@7.3.5):
     resolution: {integrity: sha512-C18hocSNj9fe5ovWVPiszxDMGe+lPrMs6TW85GJJ3AUPpvSUNP9yFjzp+HF5g8rL5VoShzi1WG04lHni6Fpxkg==}
     peerDependencies:
-      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.3
       next: 15.5.21
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -11834,14 +11836,14 @@ packages:
         optional: true
     dependencies:
       '@storybook/builder-vite': 10.5.7(storybook@10.5.7)(vite@7.3.5)
-      '@storybook/react': 10.5.7(@types/react-dom@19.2.3)(@types/react@19.2.11)(react-dom@19.2.4)(react@19.2.4)(storybook@10.5.7)(typescript@5.9.3)
-      '@storybook/react-vite': 10.5.7(@types/react-dom@19.2.3)(@types/react@19.2.11)(react-dom@19.2.4)(react@19.2.4)(storybook@10.5.7)(typescript@5.9.3)(vite@7.3.5)
-      '@types/react': 19.2.11
-      '@types/react-dom': 19.2.3(@types/react@19.2.11)
+      '@storybook/react': 10.5.7(@types/react-dom@19.2.3)(@types/react@19.2.18)(react-dom@19.2.4)(react@19.2.4)(storybook@10.5.7)(typescript@5.9.3)
+      '@storybook/react-vite': 10.5.7(@types/react-dom@19.2.3)(@types/react@19.2.18)(react-dom@19.2.4)(react@19.2.4)(storybook@10.5.7)(typescript@5.9.3)(vite@7.3.5)
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.3(@types/react@19.2.18)
       next: 15.5.21(@babel/core@7.29.6)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.4)(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      storybook: 10.5.7(@types/react@19.2.11)(prettier@3.9.6)(react@19.2.4)
+      storybook: 10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.4)
       styled-jsx: 5.1.6(@babel/core@7.29.6)(react@19.2.4)
       typescript: 5.9.3
       vite: 7.3.5(@types/node@26.2.0)
@@ -11855,11 +11857,11 @@ packages:
       - webpack
     dev: true
 
-  /@storybook/react-dom-shim@10.5.7(@types/react-dom@19.2.3)(@types/react@19.2.11)(react-dom@19.2.4)(react@19.1.4)(storybook@10.5.7):
+  /@storybook/react-dom-shim@10.5.7(@types/react-dom@19.2.3)(@types/react@19.2.18)(react-dom@19.2.4)(react@19.1.4)(storybook@10.5.7):
     resolution: {integrity: sha512-lxOkyh+wu/MiBXvYQHjZfD+DRKOa4bHBzbuGuiHXnHXmdOcTRdcrQTsoeN2FPtfugmmOG66cZUEgDwNX+k5eRA==}
     peerDependencies:
-      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.3
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       storybook: ^10.5.7
@@ -11869,18 +11871,18 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@types/react': 19.2.11
-      '@types/react-dom': 19.2.3(@types/react@19.2.11)
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.3(@types/react@19.2.18)
       react: 19.1.4
       react-dom: 19.2.4(react@19.1.4)
-      storybook: 10.5.7(@types/react@19.2.11)(prettier@3.9.6)(react@19.2.4)
+      storybook: 10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.4)
     dev: true
 
-  /@storybook/react-dom-shim@10.5.7(@types/react-dom@19.2.3)(@types/react@19.2.11)(react-dom@19.2.4)(react@19.2.4)(storybook@10.5.7):
+  /@storybook/react-dom-shim@10.5.7(@types/react-dom@19.2.3)(@types/react@19.2.18)(react-dom@19.2.4)(react@19.2.4)(storybook@10.5.7):
     resolution: {integrity: sha512-lxOkyh+wu/MiBXvYQHjZfD+DRKOa4bHBzbuGuiHXnHXmdOcTRdcrQTsoeN2FPtfugmmOG66cZUEgDwNX+k5eRA==}
     peerDependencies:
-      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.3
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       storybook: ^10.5.7
@@ -11890,14 +11892,14 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@types/react': 19.2.11
-      '@types/react-dom': 19.2.3(@types/react@19.2.11)
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.3(@types/react@19.2.18)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      storybook: 10.5.7(@types/react@19.2.11)(prettier@3.9.6)(react@19.2.4)
+      storybook: 10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.4)
     dev: true
 
-  /@storybook/react-vite@10.5.7(@types/react-dom@19.2.3)(@types/react@19.2.11)(react-dom@19.2.4)(react@19.2.4)(storybook@10.5.7)(typescript@5.9.3)(vite@7.3.5):
+  /@storybook/react-vite@10.5.7(@types/react-dom@19.2.3)(@types/react@19.2.18)(react-dom@19.2.4)(react@19.2.4)(storybook@10.5.7)(typescript@5.9.3)(vite@7.3.5):
     resolution: {integrity: sha512-eEo3eVa2pvqrzQukKxAzx7YvswDAA1s6k/y+tdMxmRvWyHX6QEOsb9Tda6wcVaa7c8BeJM7Ggq+289cRMTH6Iw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -11912,14 +11914,14 @@ packages:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@7.3.5)
       '@rollup/pluginutils': 5.4.0
       '@storybook/builder-vite': 10.5.7(storybook@10.5.7)(vite@7.3.5)
-      '@storybook/react': 10.5.7(@types/react-dom@19.2.3)(@types/react@19.2.11)(react-dom@19.2.4)(react@19.2.4)(storybook@10.5.7)(typescript@5.9.3)
+      '@storybook/react': 10.5.7(@types/react-dom@19.2.3)(@types/react@19.2.18)(react-dom@19.2.4)(react@19.2.4)(storybook@10.5.7)(typescript@5.9.3)
       empathic: 2.0.1
       magic-string: 0.30.21
       react: 19.2.4
       react-docgen: 8.0.3
       react-dom: 19.2.4(react@19.2.4)
       resolve: 1.22.12
-      storybook: 10.5.7(@types/react@19.2.11)(prettier@3.9.6)(react@19.2.4)
+      storybook: 10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.4)
       tsconfig-paths: 4.2.0
       typescript: 5.9.3
       vite: 7.3.5(@types/node@26.2.0)
@@ -11932,11 +11934,11 @@ packages:
       - webpack
     dev: true
 
-  /@storybook/react@10.5.7(@types/react-dom@19.2.3)(@types/react@19.2.11)(react-dom@19.2.4)(react@19.2.4)(storybook@10.5.7)(typescript@5.9.3):
+  /@storybook/react@10.5.7(@types/react-dom@19.2.3)(@types/react@19.2.18)(react-dom@19.2.4)(react@19.2.4)(storybook@10.5.7)(typescript@5.9.3):
     resolution: {integrity: sha512-uFvty2MMdFXzW5PcQe1JqDAZkz6cQq7q/9G/cbGVnBEvP6zsOVeL+bmrQ0/WBlFQN0Ko9+ZoCTvaQ9s65zBa5g==}
     peerDependencies:
-      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.3
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       storybook: ^10.5.7
@@ -11950,14 +11952,14 @@ packages:
         optional: true
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 10.5.7(@types/react-dom@19.2.3)(@types/react@19.2.11)(react-dom@19.2.4)(react@19.2.4)(storybook@10.5.7)
-      '@types/react': 19.2.11
-      '@types/react-dom': 19.2.3(@types/react@19.2.11)
+      '@storybook/react-dom-shim': 10.5.7(@types/react-dom@19.2.3)(@types/react@19.2.18)(react-dom@19.2.4)(react@19.2.4)(storybook@10.5.7)
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.3(@types/react@19.2.18)
       react: 19.2.4
       react-docgen: 8.0.3
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
       react-dom: 19.2.4(react@19.2.4)
-      storybook: 10.5.7(@types/react@19.2.11)(prettier@3.9.6)(react@19.2.4)
+      storybook: 10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.4)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -12446,7 +12448,7 @@ packages:
     resolution: {integrity: sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==}
     engines: {node: '>=12'}
     peerDependencies:
-      '@types/react': ^16.9.0 || ^17.0.0
+      '@types/react': 19.2.18
       react: ^16.9.0 || ^17.0.0
       react-dom: ^16.9.0 || ^17.0.0
       react-test-renderer: ^16.9.0 || ^17.0.0
@@ -12487,13 +12489,13 @@ packages:
       redent: 3.0.0
     dev: true
 
-  /@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3)(@types/react@19.2.11)(react-dom@19.2.4)(react@19.2.4):
+  /@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3)(@types/react@19.2.18)(react-dom@19.2.4)(react@19.2.4):
     resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
     engines: {node: '>=18'}
     peerDependencies:
       '@testing-library/dom': ^10.0.0
-      '@types/react': ^18.0.0 || ^19.0.0
-      '@types/react-dom': ^18.0.0 || ^19.0.0
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.3
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
@@ -12504,8 +12506,8 @@ packages:
     dependencies:
       '@babel/runtime': 7.28.6
       '@testing-library/dom': 10.4.1
-      '@types/react': 19.2.11
-      '@types/react-dom': 19.2.3(@types/react@19.2.11)
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.3(@types/react@19.2.18)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     dev: true
@@ -12799,20 +12801,20 @@ packages:
       prosemirror-view: 1.42.2
     dev: false
 
-  /@tiptap/react@3.30.0(@floating-ui/dom@1.8.0)(@tiptap/core@3.30.0)(@tiptap/pm@3.30.0)(@types/react-dom@19.2.3)(@types/react@19.2.11)(react-dom@19.2.4)(react@19.2.4):
+  /@tiptap/react@3.30.0(@floating-ui/dom@1.8.0)(@tiptap/core@3.30.0)(@tiptap/pm@3.30.0)(@types/react-dom@19.2.3)(@types/react@19.2.18)(react-dom@19.2.4)(react@19.2.4):
     resolution: {integrity: sha512-v4yMEd52RWajwPrIujFRm4tvG/esNgBY3lE2BHq0d1S636y6UXLt85DluNcf7B2R1CD3/Jknek6Bl3GIS8qA6g==}
     peerDependencies:
       '@tiptap/core': 3.30.0
       '@tiptap/pm': 3.30.0
-      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-      '@types/react-dom': ^17.0.0 || ^18.0.0 || ^19.0.0
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.3
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
     dependencies:
       '@tiptap/core': 3.30.0(@tiptap/pm@3.30.0)
       '@tiptap/pm': 3.30.0
-      '@types/react': 19.2.11
-      '@types/react-dom': 19.2.3(@types/react@19.2.11)
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.3(@types/react@19.2.18)
       '@types/use-sync-external-store': 0.0.6
       fast-equals: 5.4.1
       react: 19.2.4
@@ -13376,12 +13378,12 @@ packages:
       - react-dom
     dev: true
 
-  /@types/react-dom@19.2.3(@types/react@19.2.11):
+  /@types/react-dom@19.2.3(@types/react@19.2.18):
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
-      '@types/react': ^19.2.0
+      '@types/react': 19.2.18
     dependencies:
-      '@types/react': 19.2.11
+      '@types/react': 19.2.18
 
   /@types/react-native-vector-icons@6.4.18:
     resolution: {integrity: sha512-YGlNWb+k5laTBHd7+uZowB9DpIK3SXUneZqAiKQaj1jnJCZM0x71GDim5JCTMi4IFkhc9m8H/Gm28T5BjyivUw==}
@@ -13423,11 +13425,6 @@ packages:
     resolution: {integrity: sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ==}
     dependencies:
       '@types/react': 19.2.18
-
-  /@types/react@19.2.11:
-    resolution: {integrity: sha512-tORuanb01iEzWvMGVGv2ZDhYZVeRMrw453DCSAIn/5yvcSVnMoUMTyf33nQJLahYEnv9xqrTNbgz4qY5EfSh0g==}
-    dependencies:
-      csstype: 3.2.3
 
   /@types/react@19.2.18:
     resolution: {integrity: sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==}
@@ -26831,15 +26828,15 @@ packages:
       webpack: 5.109.2(postcss@8.5.26)
     dev: false
 
-  /react-markdown@9.1.0(@types/react@19.2.11)(react@19.2.4):
+  /react-markdown@9.1.0(@types/react@19.2.18)(react@19.2.4):
     resolution: {integrity: sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw==}
     peerDependencies:
-      '@types/react': '>=18'
+      '@types/react': 19.2.18
       react: '>=18'
     dependencies:
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
-      '@types/react': 19.2.11
+      '@types/react': 19.2.18
       devlop: 1.1.0
       hast-util-to-jsx-runtime: 2.3.6
       html-url-attributes: 3.0.1
@@ -27303,7 +27300,7 @@ packages:
     engines: {node: '>= 20.19.4'}
     hasBin: true
     peerDependencies:
-      '@types/react': ^19.1.4
+      '@types/react': 19.2.18
       react: ^19.1.4
     peerDependenciesMeta:
       '@types/react':
@@ -27367,29 +27364,10 @@ packages:
       react-fast-compare: 3.2.2
     dev: false
 
-  /react-redux@9.3.0(@types/react@19.2.11)(react@19.2.4)(redux@5.0.1):
-    resolution: {integrity: sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==}
-    peerDependencies:
-      '@types/react': ^18.2.25 || ^19
-      react: ^18.0 || ^19
-      redux: ^5.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      redux:
-        optional: true
-    dependencies:
-      '@types/react': 19.2.11
-      '@types/use-sync-external-store': 0.0.6
-      react: 19.2.4
-      redux: 5.0.1
-      use-sync-external-store: 1.6.0(react@19.2.4)
-    dev: false
-
   /react-redux@9.3.0(@types/react@19.2.18)(react@19.1.4)(redux@5.0.1):
     resolution: {integrity: sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==}
     peerDependencies:
-      '@types/react': ^18.2.25 || ^19
+      '@types/react': 19.2.18
       react: ^18.0 || ^19
       redux: ^5.0.0
     peerDependenciesMeta:
@@ -27403,6 +27381,25 @@ packages:
       react: 19.1.4
       redux: 5.0.1
       use-sync-external-store: 1.6.0(react@19.1.4)
+    dev: false
+
+  /react-redux@9.3.0(@types/react@19.2.18)(react@19.2.4)(redux@5.0.1):
+    resolution: {integrity: sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==}
+    peerDependencies:
+      '@types/react': 19.2.18
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+    dependencies:
+      '@types/react': 19.2.18
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.2.4
+      redux: 5.0.1
+      use-sync-external-store: 1.6.0(react@19.2.4)
     dev: false
 
   /react-refresh@0.14.2:
@@ -27476,7 +27473,7 @@ packages:
       scheduler: 0.26.0
     dev: true
 
-  /react-textarea-autosize@8.5.9(@types/react@19.2.11)(react@19.2.4):
+  /react-textarea-autosize@8.5.9(@types/react@19.2.18)(react@19.2.4):
     resolution: {integrity: sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -27484,8 +27481,8 @@ packages:
     dependencies:
       '@babel/runtime': 7.29.7
       react: 19.2.4
-      use-composed-ref: 1.4.0(@types/react@19.2.11)(react@19.2.4)
-      use-latest: 1.3.0(@types/react@19.2.11)(react@19.2.4)
+      use-composed-ref: 1.4.0(@types/react@19.2.18)(react@19.2.4)
+      use-latest: 1.3.0(@types/react@19.2.18)(react@19.2.4)
     transitivePeerDependencies:
       - '@types/react'
     dev: false
@@ -27602,7 +27599,7 @@ packages:
       tslib: 2.8.1
     dev: true
 
-  /recharts@3.10.1(@types/react@19.2.11)(react-dom@19.2.4)(react-is@19.2.8)(react@19.2.4)(redux@5.0.1):
+  /recharts@3.10.1(@types/react@19.2.18)(react-dom@19.2.4)(react-is@19.2.8)(react@19.2.4)(redux@5.0.1):
     resolution: {integrity: sha512-QXFrvt6IVcw7eeZCoyXTwkIJAX3Dv1nyVhMicXJ47GsGDDpcN8z6o644DibE9XjpBTThtsomLKnTV6lc+cVFUA==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -27619,7 +27616,7 @@ packages:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       react-is: 19.2.8
-      react-redux: 9.3.0(@types/react@19.2.11)(react@19.2.4)(redux@5.0.1)
+      react-redux: 9.3.0(@types/react@19.2.18)(react@19.2.4)(redux@5.0.1)
       reselect: 5.2.0
       tiny-invariant: 1.3.3
       use-sync-external-store: 1.6.0(react@19.2.4)
@@ -29019,11 +29016,11 @@ packages:
       internal-slot: 1.1.0
     dev: true
 
-  /storybook@10.5.7(@types/react@19.2.11)(prettier@3.9.6)(react@19.2.4):
+  /storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.4):
     resolution: {integrity: sha512-oiKvWIwIoOhFP1i6dASYyMXwPHKEtVZMshqSB7EvIVYjWRh0l9H7gHEt1z4Gh2rLGFMekWdsm4s94rvwpR7gkg==}
     hasBin: true
     peerDependencies:
-      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      '@types/react': 19.2.18
       prettier: ^2 || ^3
       vite-plus: ^0.1.15 || ^0.2.0
     peerDependenciesMeta:
@@ -29039,7 +29036,7 @@ packages:
       '@testing-library/dom': 10.4.1
       '@testing-library/jest-dom': 6.9.1
       '@testing-library/user-event': 14.6.4(@testing-library/dom@10.4.1)
-      '@types/react': 19.2.11
+      '@types/react': 19.2.18
       '@vitest/expect': 3.2.4
       '@vitest/spy': 3.2.4
       '@webcontainer/env': 1.1.1
@@ -29194,7 +29191,7 @@ packages:
       - utf-8-validate
     dev: false
 
-  /stream-chat-react@13.14.6(@types/react@19.2.11)(react-dom@19.2.4)(react@19.2.4)(stream-chat@9.51.0)(typescript@5.9.3):
+  /stream-chat-react@13.14.6(@types/react@19.2.18)(react-dom@19.2.4)(react@19.2.4)(stream-chat@9.51.0)(typescript@5.9.3):
     resolution: {integrity: sha512-MLkEt+rpZDkdGV1IZlzDwj6e/Z749v9LTvvT/fPfBuXlWg7JAD/O3EiA7Rr5ex9D/MF+foumpnR2fYifdLzwJQ==}
     peerDependencies:
       '@breezystack/lamejs': ^1.2.7
@@ -29234,9 +29231,9 @@ packages:
       react-dropzone: 14.4.1(react@19.2.4)
       react-fast-compare: 3.2.2
       react-image-gallery: 1.2.12(react@19.2.4)
-      react-markdown: 9.1.0(@types/react@19.2.11)(react@19.2.4)
+      react-markdown: 9.1.0(@types/react@19.2.18)(react@19.2.4)
       react-player: 2.10.1(react@19.2.4)
-      react-textarea-autosize: 8.5.9(@types/react@19.2.11)(react@19.2.4)
+      react-textarea-autosize: 8.5.9(@types/react@19.2.18)(react@19.2.4)
       react-virtuoso: 2.19.1(react-dom@19.2.4)(react@19.2.4)
       remark-gfm: 4.0.1
       stream-chat: 9.51.0
@@ -30870,7 +30867,7 @@ packages:
       punycode: 1.3.2
       querystring: 0.2.0
 
-  /use-composed-ref@1.4.0(@types/react@19.2.11)(react@19.2.4):
+  /use-composed-ref@1.4.0(@types/react@19.2.18)(react@19.2.4):
     resolution: {integrity: sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==}
     peerDependencies:
       '@types/react': '*'
@@ -30879,11 +30876,11 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@types/react': 19.2.11
+      '@types/react': 19.2.18
       react: 19.2.4
     dev: false
 
-  /use-isomorphic-layout-effect@1.2.1(@types/react@19.2.11)(react@19.2.4):
+  /use-isomorphic-layout-effect@1.2.1(@types/react@19.2.18)(react@19.2.4):
     resolution: {integrity: sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==}
     peerDependencies:
       '@types/react': '*'
@@ -30892,7 +30889,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@types/react': 19.2.11
+      '@types/react': 19.2.18
       react: 19.2.4
     dev: false
 
@@ -30904,7 +30901,7 @@ packages:
       react: 19.1.4
     dev: false
 
-  /use-latest@1.3.0(@types/react@19.2.11)(react@19.2.4):
+  /use-latest@1.3.0(@types/react@19.2.18)(react@19.2.4):
     resolution: {integrity: sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==}
     peerDependencies:
       '@types/react': '*'
@@ -30913,9 +30910,9 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@types/react': 19.2.11
+      '@types/react': 19.2.18
       react: 19.2.4
-      use-isomorphic-layout-effect: 1.2.1(@types/react@19.2.11)(react@19.2.4)
+      use-isomorphic-layout-effect: 1.2.1(@types/react@19.2.18)(react@19.2.4)
     dev: false
 
   /use-sync-external-store@1.6.0(react@19.1.4):
@@ -31070,7 +31067,7 @@ packages:
       magic-string: 0.30.21
       module-alias: 2.3.4
       next: 15.5.21(@babel/core@7.29.6)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.4)(react@19.2.4)
-      storybook: 10.5.7(@types/react@19.2.11)(prettier@3.9.6)(react@19.2.4)
+      storybook: 10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.4)
       ts-dedent: 2.3.0
       vite: 7.3.5(@types/node@26.2.0)
       vite-tsconfig-paths: 5.1.4(typescript@5.9.3)(vite@7.3.5)
@@ -31996,11 +31993,11 @@ packages:
   /zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  /zustand@5.0.14(@types/react@19.2.11)(react@19.2.4):
+  /zustand@5.0.14(@types/react@19.2.18)(react@19.2.4):
     resolution: {integrity: sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==}
     engines: {node: '>=12.20.0'}
     peerDependencies:
-      '@types/react': '>=18.0.0'
+      '@types/react': 19.2.18
       immer: 11.1.15
       react: '>=18.0.0'
       use-sync-external-store: '>=1.2.0'
@@ -32014,7 +32011,7 @@ packages:
       use-sync-external-store:
         optional: true
     dependencies:
-      '@types/react': 19.2.11
+      '@types/react': 19.2.18
       react: 19.2.4
     dev: false
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

Builds fail at random, on diffs that cannot possibly have caused them.

The dev-to-main promotion #2383 went red on a commit whose **only changed file was `.github/dependabot.yml`** - a block of YAML comments:

```
ChatMessage.tsx:123:7
Type '.../@types+react@19.2.11/...Ref<HTMLButtonElement>' is not assignable
  to type 'React.Ref<HTMLButtonElement>'.
  Two different types with this name exist, but they are unrelated.
```

Re-running the **same SHA** passed, which proves the tree was never broken and dependency resolution was the only variable.

"Two different types with this name exist" means two copies of the same `@types` package. Both were in the lockfile, because the two workspaces declared ranges that resolved apart:

| workspace | declares | resolved |
| --- | --- | --- |
| `apps/frontend` | `^19.1.1` | 19.2.11 |
| `apps/mobileAppYC` | `^19.1.4` | 19.2.18 |

Two versions across separate apps is normally harmless. It is not harmless here: the frontend build sees its own copy and the hoisted one, and a ref type crossing between them has no common identity. Which copy wins is decided per install.

This is worse than a one-off red build. It can strike **any** PR, and the natural response is to bisect a diff that is not at fault.

## What is the new behavior?

Pins `@types/react` and `@types/react-dom` in `pnpm.overrides`, alongside the dozen entries already there. One version in the lockfile means there is no lottery left to lose.

## Validation performed

Verified rather than assumed, since the failure this fixes is intermittent and "it passed once" proves nothing:

- The lockfile now contains **exactly one** `@types/react` (19.2.18), and **both importers resolve to it** - checked by parsing the importer blocks, not by eye.
- The frontend moves 19.2.11 -> 19.2.18, so all three React workspaces were re-checked:
  - `apps/frontend`: `tsc --noEmit` 0 errors, **and `next build` exit 0** - the build runs its own type pass, and that is the gate that was failing, so tsc alone would not have been sufficient evidence
  - `apps/mobileAppYC`: 0 errors
  - `apps/desktop`: 0 errors

## A note on what this does not prove

Green CI here does not by itself demonstrate the fix works, because the failure was intermittent and CI was usually green anyway. The argument is structural: with one version in the lockfile there is no second copy for a type to disagree with. The verification above is what supports that claim.

## Impact area

Repo tooling and types. No application code changed.
