### PR TITLE
fix(mobile): put the onboarding dot on the pet-parent accent and balance the copy

### DIFF
--- a/apps/mobileAppYC/src/features/onboarding/screens/OnboardingScreen.tsx
+++ b/apps/mobileAppYC/src/features/onboarding/screens/OnboardingScreen.tsx
@@ -443,7 +443,13 @@ const createStyles = (theme: Theme) =>
       marginBottom: theme.spacing['5'],
     },
     dot: {height: 7, borderRadius: theme.borderRadius.full},
-    dotActive: {width: 22, backgroundColor: theme.colors.blue},
+    // Pink is the pet-parent audience accent (design system: "Pet parents
+    // only. Not for clinic chrome."). Blue is the structural accent for links,
+    // focus rings and active nav - this dot is neither, it is brand expression
+    // on the most expressive surface in the app, directly under the pink
+    // script line, so blue was fighting the composition. pinkDeep rather than
+    // pink because the brand pink is only 1.86:1 on the bone ground.
+    dotActive: {width: 22, backgroundColor: theme.colors.pinkDeep},
     dotIdle: {width: 7, backgroundColor: theme.colors.divider},
     ctaButton: {
       width: '100%',

--- a/apps/mobileAppYC/src/features/onboarding/screens/OnboardingScreen.tsx
+++ b/apps/mobileAppYC/src/features/onboarding/screens/OnboardingScreen.tsx
@@ -429,13 +429,28 @@ const createStyles = (theme: Theme) =>
       ...theme.typography.onboardingHeadline,
       color: theme.colors.ink,
       textAlign: 'center',
+      // React Native has no text-wrap: balance. At the full 345pt content width
+      // "Every companion has a story." breaks after "a", orphaning "story." on
+      // a line of its own. Constraining the measure moves the break onto the
+      // phrase boundary instead. The other two leads are short enough that this
+      // does not reach them.
+      maxWidth: 288,
     },
     subtitle: {
       ...theme.typography.body,
       color: theme.colors.inkMuted,
       textAlign: 'center',
       marginTop: theme.spacing['3'],
-      maxWidth: 300,
+      // Tuned against all three slides on an iPhone 15 Pro. 330 orphaned
+      // "thread." on slide 2; 262 and 272 orphaned "own." on slide 1. 288 is
+      // the one value that leaves no single-word last line on any slide.
+      //
+      // Slide 1 still breaks after the conjunction ("visits, doses and /
+      // documents"), which is the weakest point in that sentence. No width
+      // fixes it: line 2 without "and" is wider than line 1 with it, so any
+      // measure narrow enough to push "and" down also forces a third line.
+      // That one needs a copy edit, not a layout change.
+      maxWidth: 288,
     },
     dots: {
       flexDirection: 'row',

--- a/apps/mobileAppYC/src/shared/components/common/InkAnnotation/InkAnnotation.tsx
+++ b/apps/mobileAppYC/src/shared/components/common/InkAnnotation/InkAnnotation.tsx
@@ -89,12 +89,19 @@ const polylineLength = (pts: number[][]): number => {
 };
 
 const buildCircle = (w: number, h: number): Geometry => {
-  const padX = Math.max(14, w * 0.09);
-  const padY = Math.max(11, h * 0.26);
+  // The ring has to clear the glyph box at its CORNERS, not just at the axes,
+  // and an ellipse is at its tightest exactly where descenders sit - below the
+  // baseline, off-centre. With the previous radii the corner test
+  // (w/2/rx)^2 + (h/2/ry)^2 came to ~1.41, comfortably outside 1, so the stroke
+  // cut through the descender of the "p" in "Keep it whole." These radii leave
+  // roughly 7pt of clearance there instead of 3pt, without the ring ballooning
+  // away from the word.
+  const padX = Math.max(16, w * 0.1);
+  const padY = Math.max(13, h * 0.3);
   const cx = padX + w / 2;
   const cy = padY + h / 2;
-  const rx = w / 2 + Math.max(9, w * 0.06);
-  const ry = h / 2 + Math.max(6, h * 0.14);
+  const rx = w / 2 + Math.max(12, w * 0.08);
+  const ry = h / 2 + Math.max(10, h * 0.24);
   const start = -Math.PI * 0.6; // begin upper-right
   const end = start + Math.PI * 2 * 1.09; // overshoot ~1.09 turns so it crosses over
   const N = 46;

--- a/apps/mobileAppYC/src/theme/colors.ts
+++ b/apps/mobileAppYC/src/theme/colors.ts
@@ -20,6 +20,11 @@ const palette = {
   navActive: ['#1657C9', '#8FB6F5'],
   navActiveBg: ['rgba(37, 123, 237, 0.11)', 'rgba(143, 182, 245, 0.13)'],
   pink: ['#FF90D4', '#FF90D4'],
+  // Solid pink for UI components on the light ground. The brand pink measures
+  // only 1.86:1 against `screen` (#F7F3EC), well under the 3:1 WCAG 1.4.11 bar
+  // for a state indicator, so a light surface needs this deepened rose (3.47:1)
+  // while the espresso theme can use the true brand pink (7.13:1) as-is.
+  pinkDeep: ['#DB4A9B', '#FF90D4'],
   pinkGlow: ['rgba(244, 121, 190, 0.12)', 'rgba(244, 121, 190, 0.22)'],
   cyan: ['#5CE1E6', '#5CE1E6'],
   cyanText: ['#38CCD8', '#5CE1E6'],


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

Follow-on to #2403, which replaced the onboarding and splash footage. Reviewing the copy over the new video surfaced four defects on the onboarding carousel - one palette, three typographic. All were found by looking at the rendered screen, not by reading the code.

## What is the new behavior?

**1. The progress dot used the clinic accent.** `dotActive` was `theme.colors.blue`. The design system reserves blue for structure - "links, focus rings, active nav, the one accent PIMS uses" - and names pink the pet-parent accent: "Pet parents only. Not for clinic chrome." Onboarding is the most brand-expressive surface in the pet-parent app and the dot sits directly under the pink script line, so cold blue was the one element fighting the composition.

Not the brand pink directly, though:

| colour | vs bone `#F7F3EC` | 3:1 bar (WCAG 1.4.11) |
|---|---|---|
| blue `#257BED` (was) | 3.70:1 | pass |
| brand pink `#FF90D4` | **1.86:1** | **fail** |
| `pinkDeep` `#DB4A9B` (now) | 3.47:1 | pass |

Swapping straight to `--pink` would have been prettier and *less* legible than the blue it replaced. This adds a `pinkDeep` token: the deepened rose on light, and the true brand pink on espresso, where the dark ground already gives it 7.13:1.

**2. The ink ring cut through descenders.** An ellipse is tightest exactly where descenders sit - below the baseline, off the vertical axis - and the ring must clear the glyph box at its *corners*, not just on the axes. With the old radii the corner test `(w/2/rx)^2 + (h/2/ry)^2` came to about **1.41**, well outside 1, so the stroke crossed the "p" of "Keep it whole." with roughly 3pt of clearance. It now leaves about 7pt.

This is four numeric constants. **The draw-on animation is untouched** - `progress`, `withTiming`, `PEN_EASING`, the stroke-dash reveal and the hand-drawn radius wobble are all exactly as they were, and the path length recalculates from the new radii so the timing still lands.

**3. The headline orphaned a word.** React Native has no `text-wrap: balance`, so at the full 345pt content measure "Every companion has a story." broke after "a" and left "story." alone. Constraining the lead to 288pt moves the break onto the phrase boundary. Slides 2 and 3 have short leads and are unaffected.

**4. The subtitle measure orphaned last lines.** 288pt is the one value leaving no single-word last line on any slide - 330 orphaned "thread." on slide 2, and 262 and 272 orphaned "own." on slide 1.

## Deliberately not fixed

Slide 1's subtitle still breaks after the conjunction ("visits, doses and / documents"), the weakest point in that sentence. **No measure fixes it**: line 2 without "and" is wider than line 1 with it, so any measure narrow enough to push the conjunction down also forces a third line and a fresh orphan. Verified at 262, 272, 278, 288 and 330. That one needs a copy edit, not a layout change.

## Worth raising upstream

The shared design system has exactly one pink, and at 1.86:1 it cannot be used as a solid for any UI component on the light ground. That is a gap in the token set, not a mistake in this screen - every pet-parent surface needing a pink control will hit it.

## Validation

- `npx tsc --noEmit` - 0 errors
- `npx eslint` on both touched files - 0 errors, 0 warnings
- `npx jest` - 12 suites / 100 tests, 0 failures
- Rendered on an iPhone 15 Pro simulator and checked on **all three slides** for each candidate measure. Screenshots in `[redacted: local path]`.

## Related Issue(s)

Part of #2361.
