### PR TITLE
fix(mobile): finish the blue drift cleanup the hex sweep missed

### DIFF
--- a/apps/mobileAppYC/src/features/appointments/components/MapDiscovery/ClusterMapPin.tsx
+++ b/apps/mobileAppYC/src/features/appointments/components/MapDiscovery/ClusterMapPin.tsx
@@ -19,7 +19,7 @@ const styles = StyleSheet.create({
     width: 48,
     height: 48,
     borderRadius: 24,
-    backgroundColor: 'rgba(36, 122, 237, 0.18)',
+    backgroundColor: colors.blueGlow,
     justifyContent: 'center',
     alignItems: 'center',
   },
@@ -32,7 +32,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     borderWidth: 2,
     borderColor: colors.white,
-    boxShadow: '0px 2px 6px rgba(36,122,237,0.4)',
+    boxShadow: `0px 2px 6px ${colors.blueShadow}`,
   },
   label: {
     color: colors.white,

--- a/apps/mobileAppYC/src/theme/colors.ts
+++ b/apps/mobileAppYC/src/theme/colors.ts
@@ -26,6 +26,13 @@ const palette = {
   // while the espresso theme can use the true brand pink (7.13:1) as-is.
   pinkDeep: ['#DB4A9B', '#FF90D4'],
   pinkGlow: ['rgba(244, 121, 190, 0.12)', 'rgba(244, 121, 190, 0.22)'],
+  // rgba forms of `blue` (#257BED = 37,123,237). These exist as tokens because
+  // the map cluster pin previously hard-coded rgba(36,122,237,...) - the stale
+  // #247AED from the unbuilt design-tokens package - for its halo and shadow.
+  // A hex sweep does not match an rgba() literal, so the pin kept rendering
+  // two different blues at once after the rest of the drift was cleaned up.
+  blueGlow: ['rgba(37, 123, 237, 0.18)', 'rgba(37, 123, 237, 0.26)'],
+  blueShadow: ['rgba(37, 123, 237, 0.40)', 'rgba(37, 123, 237, 0.50)'],
   cyan: ['#5CE1E6', '#5CE1E6'],
   cyanText: ['#38CCD8', '#5CE1E6'],
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

#2364 reconciled two circulating brand blues onto `colors.blue`. That sweep matched `#RRGGBB` literals, and **an `rgba()` literal does not match that shape**, so the map cluster pin kept two of them:

```ts
backgroundColor: 'rgba(36, 122, 237, 0.18)',    // halo
boxShadow: '0px 2px 6px rgba(36,122,237,0.4)',  // shadow
```

`36,122,237` is `#247AED` - the stale value from the unbuilt design-tokens package. So after the cleanup, the cluster pin was still rendering the *new* blue in its inner disc and the *old* blue in the halo and shadow around it. That is precisely the defect the issue was raised to remove, surviving inside the component the fix had already touched.

This was found by decoding every `rgba()` literal in `src` back to hex and comparing against the known-stale values, instead of grepping for hex a second time. These two were the only ones left.

## What is the new behavior?

Adds `blueGlow` and `blueShadow` as rgba forms of `#257BED`, following the existing `pinkGlow` precedent, and points the cluster pin at them so the two representations cannot drift apart again.

## Validation

- `npx tsc --noEmit` - 0 errors
- `npx eslint` on both touched files - 0 errors, 0 warnings
- `npx jest` - 12 suites / 92 tests, 0 failures

Rendered on an iPhone 15 Pro simulator through a throwaway harness: five `ClinicMapPin` categories in both selected and unselected states, plus `ClusterMapPin` at counts 3, 12 and 99. All five category colours remain clearly distinguishable from one another, which is what matters for pins on a map.

The harness was needed because the real map requires a Google Maps key this machine does not have. That leaves one thing genuinely unverified: `mapStyle.ts` also moved water labels and the highway stroke from `#247AED` to `colors.blue`, and those only appear on a live map. Every other substitution in #2364 preserved its exact rendered value, so there is nothing else to look at.

## Related Issue(s)

Fixes #2364
