### PR TITLE
fix(mobile): put the map on the warm-bone palette and give it a dark theme

### DIFF
--- a/apps/mobileAppYC/src/features/appointments/components/MapDiscovery/ClinicMapPin.tsx
+++ b/apps/mobileAppYC/src/features/appointments/components/MapDiscovery/ClinicMapPin.tsx
@@ -1,23 +1,33 @@
 import React, {useMemo} from 'react';
 import {View, Text, StyleSheet} from 'react-native';
 import {colors} from '@/theme';
+import type {ColorTokens} from '@/theme';
 import type {VetBusiness, BusinessCategory} from '../../types';
 
 export interface ClinicMapPinProps {
   business: VetBusiness;
   isSelected: boolean;
+  /**
+   * Active palette. Defaults to the light one so the pin stays a pure
+   * presentational component - useTheme is redux-backed, and reaching into the
+   * store from a leaf rendered inside a Marker would couple it to a Provider
+   * for the sake of one colour. MapDiscoveryView already holds the theme and
+   * passes it down.
+   */
+  palette?: ColorTokens;
 }
 
-// Pins are drawn on the light map style, so the light palette is the right
-// one. These used the stale #247AED from the unbuilt design-tokens package
-// plus three stock Material swatches with no relationship to warm bone.
-const CATEGORY_COLORS: Record<BusinessCategory, string> = {
-  hospital: colors.blue,
-  groomer: colors.success,
-  breeder: colors.warning,
-  boarder: colors.violet,
-  pet_center: colors.cyanText,
-};
+// Category colours come from the ACTIVE theme, not the light palette. The map
+// itself now has an espresso variant, and several of these tokens differ
+// between themes - violet is #7C3AED on bone but #C4B5FD on espresso - so
+// pinning them to the light values would put dark pins on a dark map.
+const categoryColors = (c: ColorTokens): Record<BusinessCategory, string> => ({
+  hospital: c.blue,
+  groomer: c.success,
+  breeder: c.warning,
+  boarder: c.violet,
+  pet_center: c.cyanText,
+});
 
 const CATEGORY_SYMBOLS: Record<BusinessCategory, string> = {
   hospital: '🏥',
@@ -39,8 +49,12 @@ const buildRatingLabel = (business: VetBusiness): string => {
   return CATEGORY_SYMBOLS[business.category] ?? '•';
 };
 
-const ClinicMapPin: React.FC<ClinicMapPinProps> = ({business, isSelected}) => {
-  const pinColor = CATEGORY_COLORS[business.category] ?? colors.blue;
+const ClinicMapPin: React.FC<ClinicMapPinProps> = ({
+  business,
+  isSelected,
+  palette = colors,
+}) => {
+  const pinColor = categoryColors(palette)[business.category] ?? palette.blue;
   const ratingLabel = useMemo(() => buildRatingLabel(business), [business]);
   const displayName = useMemo(
     () => truncateName(business.name),
@@ -86,12 +100,12 @@ const styles = StyleSheet.create({
     borderColor: 'rgba(255, 255, 255, 0.35)',
   },
   bubbleSelected: {
-    borderColor: colors.white,
+    borderColor: '#FFFFFF',
     borderWidth: 2,
     boxShadow: '0px 2px 4px rgba(0,0,0,0.4)',
   },
   name: {
-    color: colors.white,
+    color: '#FFFFFF',
     fontSize: 10,
     fontWeight: '700',
     letterSpacing: -0.2,

--- a/apps/mobileAppYC/src/features/appointments/components/MapDiscovery/ClusterMapPin.tsx
+++ b/apps/mobileAppYC/src/features/appointments/components/MapDiscovery/ClusterMapPin.tsx
@@ -1,45 +1,56 @@
 import React from 'react';
 import {View, Text, StyleSheet} from 'react-native';
+import {useMemo} from 'react';
 import {colors} from '@/theme';
+import type {ColorTokens} from '@/theme';
 
 interface ClusterMapPinProps {
   count: number;
+  /** Active palette; light by default. See ClinicMapPin for why not useTheme. */
+  palette?: ColorTokens;
 }
 
-const ClusterMapPin: React.FC<ClusterMapPinProps> = ({count}) => (
-  <View collapsable={false} style={styles.outer}>
-    <View style={styles.inner}>
-      <Text style={styles.label}>{count}</Text>
+const ClusterMapPin: React.FC<ClusterMapPinProps> = ({
+  count,
+  palette = colors,
+}) => {
+  const styles = useMemo(() => createStyles(palette), [palette]);
+  return (
+    <View collapsable={false} style={styles.outer}>
+      <View style={styles.inner}>
+        <Text style={styles.label}>{count}</Text>
+      </View>
     </View>
-  </View>
-);
+  );
+};
 
-const styles = StyleSheet.create({
-  outer: {
-    width: 48,
-    height: 48,
-    borderRadius: 24,
-    backgroundColor: colors.blueGlow,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  inner: {
-    width: 34,
-    height: 34,
-    borderRadius: 17,
-    backgroundColor: colors.blue,
-    justifyContent: 'center',
-    alignItems: 'center',
-    borderWidth: 2,
-    borderColor: colors.white,
-    boxShadow: `0px 2px 6px ${colors.blueShadow}`,
-  },
-  label: {
-    color: colors.white,
-    fontSize: 13,
-    fontWeight: '700',
-    lineHeight: 16,
-  },
-});
+const createStyles = (c: ColorTokens) =>
+  StyleSheet.create({
+    outer: {
+      width: 48,
+      height: 48,
+      borderRadius: 24,
+      backgroundColor: c.blueGlow,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    inner: {
+      width: 34,
+      height: 34,
+      borderRadius: 17,
+      backgroundColor: c.blue,
+      justifyContent: 'center',
+      alignItems: 'center',
+      borderWidth: 2,
+      borderColor: c.white,
+      boxShadow: `0px 2px 6px ${c.blueShadow}`,
+    },
+    label: {
+      color: c.white,
+      fontSize: 13,
+      fontWeight: '700',
+      lineHeight: 16,
+    },
+  });
 
 export default ClusterMapPin;

--- a/apps/mobileAppYC/src/features/appointments/components/MapDiscovery/ClusterMapPin.tsx
+++ b/apps/mobileAppYC/src/features/appointments/components/MapDiscovery/ClusterMapPin.tsx
@@ -1,8 +1,6 @@
-import React from 'react';
+import React, {useMemo} from 'react';
 import {View, Text, StyleSheet} from 'react-native';
-import {useMemo} from 'react';
-import {colors} from '@/theme';
-import type {ColorTokens} from '@/theme';
+import {colors, type ColorTokens} from '@/theme';
 
 interface ClusterMapPinProps {
   count: number;

--- a/apps/mobileAppYC/src/features/appointments/components/MapDiscovery/MapDiscoveryView.tsx
+++ b/apps/mobileAppYC/src/features/appointments/components/MapDiscovery/MapDiscoveryView.tsx
@@ -28,7 +28,7 @@ import type {NativeStackNavigationProp} from '@react-navigation/native-stack';
 import type {AppointmentStackParamList} from '@/navigation/types';
 import type {VetBusiness, BusinessCategory} from '../../types';
 import type {UserLocation} from '../../hooks/useLocationPermission';
-import {YC_MAP_STYLE} from '../../utils/mapStyle';
+import {mapStyleFor} from '../../utils/mapStyle';
 import {clusterClinics} from '../../utils/clusterClinics';
 import {useTheme} from '@/hooks';
 import {Header} from '@/shared/components/common/Header/Header';
@@ -131,7 +131,8 @@ const MapDiscoveryView: React.FC<MapDiscoveryViewProps> = ({
   onSearchBarLayout,
 }) => {
   const {t} = useTranslation();
-  const {theme} = useTheme();
+  const {theme, isDark} = useTheme();
+  const mapStyle = useMemo(() => mapStyleFor(isDark), [isDark]);
   const styles = useMemo(() => createStyles(theme), [theme]);
   const insets = useSafeAreaInsets();
 
@@ -282,7 +283,7 @@ const MapDiscoveryView: React.FC<MapDiscoveryViewProps> = ({
         style={StyleSheet.absoluteFill}
         provider={PROVIDER_GOOGLE}
         initialRegion={initialRegion}
-        customMapStyle={YC_MAP_STYLE}
+        customMapStyle={mapStyle}
         showsUserLocation={hasLocationPermission}
         showsMyLocationButton={false}
         showsCompass={false}

--- a/apps/mobileAppYC/src/features/appointments/components/MapDiscovery/MapDiscoveryView.tsx
+++ b/apps/mobileAppYC/src/features/appointments/components/MapDiscovery/MapDiscoveryView.tsx
@@ -298,7 +298,7 @@ const MapDiscoveryView: React.FC<MapDiscoveryViewProps> = ({
                 key={item.id}
                 coordinate={{latitude: item.lat, longitude: item.lng}}
                 tracksViewChanges={false}>
-                <ClusterMapPin count={item.count} />
+                <ClusterMapPin count={item.count} palette={theme.colors} />
               </Marker>
             );
           }
@@ -312,6 +312,7 @@ const MapDiscoveryView: React.FC<MapDiscoveryViewProps> = ({
               onPress={() => handlePinPress(clinic.id)}>
               <ClinicMapPin
                 business={clinic}
+                palette={theme.colors}
                 isSelected={clinic.id === selectedClinicId}
               />
             </Marker>

--- a/apps/mobileAppYC/src/features/appointments/utils/mapStyle.ts
+++ b/apps/mobileAppYC/src/features/appointments/utils/mapStyle.ts
@@ -1,4 +1,3 @@
-import {colors} from '@/theme';
 type Styler = Record<string, string | number>;
 
 const r = (featureType: string, elementType: string, ...stylers: Styler[]) => ({
@@ -7,31 +6,107 @@ const r = (featureType: string, elementType: string, ...stylers: Styler[]) => ({
   stylers,
 });
 
-export const YC_MAP_STYLE = [
-  r('landscape', 'geometry', {color: '#F5F7FA'}),
-  r('landscape.man_made', 'geometry', {color: '#F0F4FA'}),
-  r('landscape.natural', 'geometry', {color: '#EDF4EE'}),
-  r('water', 'geometry', {color: '#C8DCF0'}),
-  r('water', 'labels.text.fill', {color: colors.blue}),
-  r('road.local', 'geometry', {color: colors.white}),
-  r('road.local', 'geometry.stroke', {color: '#EAEAEA'}, {weight: 1}),
-  r('road.arterial', 'geometry', {color: '#F5F8FF'}),
-  r('road.arterial', 'geometry.stroke', {color: '#D4E3F8'}, {weight: 1}),
-  r('road.arterial', 'labels.text.fill', {color: '#747473'}),
-  r('road.highway', 'geometry', {color: '#E9F2FD'}),
-  r('road.highway', 'geometry.stroke', {color: colors.blue}, {weight: 1.5}),
-  r('road.highway', 'labels.text.fill', {color: '#1A5FBD'}),
-  r('road.highway', 'labels.text.stroke', {color: colors.white}, {weight: 2}),
-  r('poi', 'geometry', {color: '#EEF2F8'}),
+/**
+ * Warm-bone map palette.
+ *
+ * The previous style was a cool blue-grey set - every surface measured R-B
+ * negative (landscape -5, poi -10, highway fill -20, water -40) while every app
+ * surface measures R-B positive (screen +11, inset +21, hairline +22). The map
+ * therefore read as a different product embedded in the app.
+ *
+ * These values keep each feature's ORIGINAL LIGHTNESS, so the figure/ground
+ * relationships that make a map legible are untouched - roads still sit lighter
+ * than land, water and parks still sit darker. Only the hue moves, onto the
+ * bone family. Water stays cool on purpose: it has to read as water.
+ */
+const MAP_LIGHT = {
+  land: '#F7F5F1',
+  landBuilt: '#F3F0EA',
+  landNatural: '#EFF1E9',
+  poi: '#F2EFE9',
+  transit: '#F2EFE9',
+  water: '#D2DEE7',
+  park: '#DEE7D6',
+  road: '#FFFFFF',
+  arterial: '#FBFAF7',
+  highway: '#F1EDE4',
+  roadStroke: '#E9E4DB',
+  labelMuted: '#7A7266',
+  labelInk: '#302F2E',
+  labelHalo: '#FFFFFF',
+  highwayStroke: '#257BED',
+  highwayLabel: '#1657C9',
+  waterLabel: '#257BED',
+  parkLabel: '#008F5D',
+} as const;
+
+/**
+ * Espresso counterpart. Dark maps invert the figure/ground: land goes dark and
+ * roads go LIGHTER than land, otherwise the road network disappears. Label
+ * haloes flip to the dark ground for the same reason. Hues stay in the warm
+ * bone family, and the accents move to their espresso token values, which are
+ * the lighter tints - the light-theme blue and green are too dark to read here.
+ */
+const MAP_DARK = {
+  land: '#2A241D',
+  landBuilt: '#322B22',
+  landNatural: '#2B2F26',
+  poi: '#332C23',
+  transit: '#332C23',
+  water: '#1E2A33',
+  park: '#2C3A2C',
+  road: '#453C31',
+  arterial: '#4E4437',
+  highway: '#584B3C',
+  roadStroke: '#40362B',
+  labelMuted: '#A89E90',
+  labelInk: '#E6DDD0',
+  labelHalo: '#241F19',
+  highwayStroke: '#8FB6F5',
+  highwayLabel: '#8FB6F5',
+  waterLabel: '#8FB6F5',
+  parkLabel: '#2BBD86',
+} as const;
+
+type MapPalette = Record<keyof typeof MAP_LIGHT, string>;
+
+const build = (MAP: MapPalette) => [
+  r('landscape', 'geometry', {color: MAP.land}),
+  r('landscape.man_made', 'geometry', {color: MAP.landBuilt}),
+  r('landscape.natural', 'geometry', {color: MAP.landNatural}),
+  r('water', 'geometry', {color: MAP.water}),
+  r('water', 'labels.text.fill', {color: MAP.waterLabel}),
+  r('road.local', 'geometry', {color: MAP.road}),
+  r('road.local', 'geometry.stroke', {color: MAP.roadStroke}, {weight: 1}),
+  r('road.arterial', 'geometry', {color: MAP.arterial}),
+  r('road.arterial', 'geometry.stroke', {color: MAP.roadStroke}, {weight: 1}),
+  r('road.arterial', 'labels.text.fill', {color: MAP.labelMuted}),
+  r('road.highway', 'geometry', {color: MAP.highway}),
+  r(
+    'road.highway',
+    'geometry.stroke',
+    {color: MAP.highwayStroke},
+    {weight: 1.5},
+  ),
+  r('road.highway', 'labels.text.fill', {color: MAP.highwayLabel}),
+  r('road.highway', 'labels.text.stroke', {color: MAP.labelHalo}, {weight: 2}),
+  r('poi', 'geometry', {color: MAP.poi}),
   r('poi', 'labels', {visibility: 'off'}),
-  r('poi.park', 'geometry', {color: '#D4EDDA'}),
-  r('poi.park', 'labels.text.fill', {color: colors.success}),
+  r('poi.park', 'geometry', {color: MAP.park}),
+  r('poi.park', 'labels.text.fill', {color: MAP.parkLabel}),
   r('poi.park', 'labels', {visibility: 'simplified'}),
-  r('transit', 'geometry', {color: '#E9F2FD'}),
-  r('transit.station', 'labels.text.fill', {color: '#747473'}),
-  r('administrative', 'geometry.stroke', {color: '#EAEAEA'}, {weight: 1}),
-  r('administrative.locality', 'labels.text.fill', {color: colors.inkBody}),
-  r('administrative.neighborhood', 'labels.text.fill', {color: '#747473'}),
-  r('all', 'labels.text.fill', {color: colors.inkBody}),
-  r('all', 'labels.text.stroke', {color: colors.white}, {weight: 2}),
+  r('transit', 'geometry', {color: MAP.transit}),
+  r('transit.station', 'labels.text.fill', {color: MAP.labelMuted}),
+  r('administrative', 'geometry.stroke', {color: MAP.roadStroke}, {weight: 1}),
+  r('administrative.locality', 'labels.text.fill', {color: MAP.labelInk}),
+  r('administrative.neighborhood', 'labels.text.fill', {color: MAP.labelMuted}),
+  r('all', 'labels.text.fill', {color: MAP.labelInk}),
+  r('all', 'labels.text.stroke', {color: MAP.labelHalo}, {weight: 2}),
 ];
+
+export const YC_MAP_STYLE = build(MAP_LIGHT);
+export const YC_MAP_STYLE_DARK = build(MAP_DARK);
+
+/** Pick the map style matching the active theme. */
+export const mapStyleFor = (isDark: boolean) =>
+  isDark ? YC_MAP_STYLE_DARK : YC_MAP_STYLE;

--- a/apps/mobileAppYC/src/features/merck/components/MerckSearchWidget.tsx
+++ b/apps/mobileAppYC/src/features/merck/components/MerckSearchWidget.tsx
@@ -1418,7 +1418,7 @@ const createStyles = (theme: any) =>
       alignItems: 'center',
       justifyContent: 'center',
       gap: theme.spacing['2'],
-      backgroundColor: 'rgba(255, 255, 255, 0.96)',
+      backgroundColor: theme.colors.cardOverlay,
     },
     readerLoaderGif: {
       width: 88,


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

The map was styled in a cool blue-grey palette while the rest of the app is warm bone, so it read as a different product embedded in the screen. Measuring R-B on every surface makes it unambiguous:

| map surface | R-B | | app surface | R-B |
|---|---|---|---|---|
| `landscape` `#F5F7FA` | **-5** | | `screen` `#F7F3EC` | **+11** |
| `poi` `#EEF2F8` | **-10** | | `inset` `#EAE2D5` | **+21** |
| `road.highway` `#E9F2FD` | **-20** | | `hairline` `#E5DCCF` | **+22** |
| `water` `#C8DCF0` | **-40** | | | |

Every map colour leaned blue. Every app colour leans warm.

Separately, the style was a **single static array built from the light palette**, so in dark mode the app rendered a bone-bright map inside an espresso screen. Dark mode is a real, reachable state - `useTheme` tracks `Appearance` - so this was a live defect, not a hypothetical.

## What is the new behavior?

**Warm-bone light palette.** Every neutral now sits on the bone hue. Crucially the values keep each feature's **original lightness**, so the figure/ground relationships that make a map legible are untouched: roads still sit lighter than land, water and parks still sit darker. Only the hue moved. Water stays deliberately cool - it has to read as water.

**An espresso variant, and a `mapStyleFor(isDark)` selector** memoised in `MapDiscoveryView` against the `isDark` that `useTheme` already exposes.

The dark palette is **not an inversion**. Dark maps have to flip figure and ground - land goes dark and roads go *lighter* than land, or the road network disappears - and label haloes flip with them. The accents move to their espresso token values, the lighter tints, because the light-theme blue (`#257BED`) and green (`#008F5D`) are too dark to read on that ground.

This also removes the last twelve hardcoded literals in the file. The palette is now two named blocks rather than colours scattered through 26 rules.

## Validation

- `npx tsc --noEmit` - 0 errors
- `npx eslint src/features/appointments` - 0 errors, 0 warnings
- `npx jest` - 5 suites / 97 tests, 0 failures

Both variants rendered on an iPhone 15 Pro simulator against **live Google tiles** over Berlin, chosen because it puts water, parkland and motorways on screen together. Screenshots in `[redacted: local path]`.

## Note on scope

Dark mode is only addressed *for the map* here. The map pins (`ClinicMapPin`, `ClusterMapPin`) still import the static light palette, so their category colours do not adapt - `violet` is `#7C3AED` on light but `#C4B5FD` on espresso, and the light value is the one that ships to both. That is a separate change and a wider audit is worth doing across the app.

## Related Issue(s)

Part of #2364.
