### PR TITLE
fix(mobile): stop body text using ink tokens that fail WCAG on the bone ground

### DIFF
--- a/apps/mobileAppYC/__tests__/features/tasks/screens/TaskViewScreen/components/ViewField.test.tsx
+++ b/apps/mobileAppYC/__tests__/features/tasks/screens/TaskViewScreen/components/ViewField.test.tsx
@@ -87,7 +87,7 @@ describe('ViewField Components', () => {
       const labelStyle = StyleSheet.flatten(
         getByText('Test Label').props.style,
       );
-      expect(labelStyle.color).toBe(mockTheme.colors.inkFaint);
+      expect(labelStyle.color).toBe(mockTheme.colors.inkMuted);
     });
   });
 

--- a/apps/mobileAppYC/__tests__/styles/screenHeaderStyles.test.ts
+++ b/apps/mobileAppYC/__tests__/styles/screenHeaderStyles.test.ts
@@ -43,7 +43,7 @@ describe('createScreenHeaderStyles', () => {
 
     expect(styles.headerSubtitle).toEqual({
       ...mockTheme.typography.body12,
-      color: mockTheme.colors.inkFaint,
+      color: mockTheme.colors.inkMuted,
       textAlign: 'center',
       marginTop: 1,
     });

--- a/apps/mobileAppYC/__tests__/theme/inkRampContrast.test.ts
+++ b/apps/mobileAppYC/__tests__/theme/inkRampContrast.test.ts
@@ -1,0 +1,67 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import {colors, colorsDark} from '@/theme';
+
+const luminance = (hex: string): number => {
+  const h = hex.replace('#', '');
+  const parts = [0, 2, 4].map(i => parseInt(h.slice(i, i + 2), 16) / 255);
+  const lin = parts.map(v =>
+    v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4),
+  );
+  return 0.2126 * lin[0] + 0.7152 * lin[1] + 0.0722 * lin[2];
+};
+
+const contrast = (a: string, b: string): number => {
+  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+  return (hi + 0.05) / (lo + 0.05);
+};
+
+describe('ink ramp contrast', () => {
+  it('inkMuted carries body text in both themes', () => {
+    expect(contrast(colors.inkMuted, colors.screen)).toBeGreaterThanOrEqual(
+      4.5,
+    );
+    expect(
+      contrast(colorsDark.inkMuted, colorsDark.screen),
+    ).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it('inkFaint clears the 3:1 bar for icons and large type', () => {
+    expect(contrast(colors.inkFaint, colors.screen)).toBeGreaterThanOrEqual(3);
+    expect(
+      contrast(colorsDark.inkFaint, colorsDark.screen),
+    ).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe('ink ramp usage', () => {
+  const SRC = path.join(__dirname, '..', '..', 'src');
+
+  const walk = (dir: string, out: string[] = []): string[] => {
+    for (const e of fs.readdirSync(dir, {withFileTypes: true})) {
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) walk(full, out);
+      else if (/\.tsx?$/.test(e.name)) out.push(full);
+    }
+    return out;
+  };
+
+  // inkFaint2 measures 2.26:1 on the light ground - below the 4.5:1 text bar
+  // AND below the 3:1 UI bar. The two allowed exceptions are a disabled
+  // control (WCAG 1.4.3 exempts inactive controls) and the splash, whose copy
+  // sits over video rather than over a themed ground.
+  const ALLOWED = [
+    path.join('auth', 'screens', 'OTPVerificationScreen.tsx'),
+    path.join('customSplashScreen', 'customSplash.tsx'),
+  ];
+
+  it('inkFaint2 is not used outside the documented exceptions', () => {
+    const offenders = walk(SRC)
+      .filter(f => !f.includes(`${path.sep}theme${path.sep}`))
+      .filter(f => !ALLOWED.some(a => f.endsWith(a)))
+      .filter(f => /\binkFaint2\b/.test(fs.readFileSync(f, 'utf8')))
+      .map(f => f.slice(f.indexOf(`src${path.sep}`)));
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/apps/mobileAppYC/src/features/account/components/AccountMenuList.tsx
+++ b/apps/mobileAppYC/src/features/account/components/AccountMenuList.tsx
@@ -146,7 +146,7 @@ const createStyles = (theme: any) =>
     arrow: {
       width: theme.spacing['4'],
       height: theme.spacing['4'],
-      tintColor: theme.colors.inkFaint2,
+      tintColor: theme.colors.inkFaint,
       resizeMode: 'contain',
     },
     arrowDanger: {

--- a/apps/mobileAppYC/src/features/account/screens/AccountScreen.tsx
+++ b/apps/mobileAppYC/src/features/account/screens/AccountScreen.tsx
@@ -785,7 +785,7 @@ const createStyles = (theme: any) => {
     },
     versionText: {
       ...theme.typography.body12,
-      color: theme.colors.inkFaint2,
+      color: theme.colors.inkMuted,
       textAlign: 'center',
       marginTop: theme.spacing['2'],
     },

--- a/apps/mobileAppYC/src/features/adverseEventReporting/components/AERBusinessSelectCard.tsx
+++ b/apps/mobileAppYC/src/features/adverseEventReporting/components/AERBusinessSelectCard.tsx
@@ -175,7 +175,7 @@ const createStyles = (theme: any) =>
     },
     meta: {
       ...theme.typography.caption,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
       marginTop: theme.spacing['1'],
     },
     checkChip: {

--- a/apps/mobileAppYC/src/features/adverseEventReporting/components/AERLayout.tsx
+++ b/apps/mobileAppYC/src/features/adverseEventReporting/components/AERLayout.tsx
@@ -145,7 +145,7 @@ const createStyles = (theme: any) =>
     },
     progressCounter: {
       ...theme.typography.subtitleBold12,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
     },
     buttonContainer: {
       marginTop: theme.spacing['4'],

--- a/apps/mobileAppYC/src/features/adverseEventReporting/screens/Step4Screen.tsx
+++ b/apps/mobileAppYC/src/features/adverseEventReporting/screens/Step4Screen.tsx
@@ -159,7 +159,7 @@ const createStyles = (theme: any) =>
     },
     summaryLabel: {
       ...theme.typography.body13,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
       flex: 1,
     },
     summaryValue: {

--- a/apps/mobileAppYC/src/features/appUpdate/components/AppUpdateBottomSheet.tsx
+++ b/apps/mobileAppYC/src/features/appUpdate/components/AppUpdateBottomSheet.tsx
@@ -240,7 +240,7 @@ const createStyles = (theme: Theme) =>
     versionLine: {
       ...theme.typography.body12,
       fontSize: 12.5,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
       fontVariant: ['tabular-nums'],
     },
     changelog: {

--- a/apps/mobileAppYC/src/features/appointments/components/MapDiscovery/ClinicMapPin.tsx
+++ b/apps/mobileAppYC/src/features/appointments/components/MapDiscovery/ClinicMapPin.tsx
@@ -1,23 +1,33 @@
 import React, {useMemo} from 'react';
 import {View, Text, StyleSheet} from 'react-native';
 import {colors} from '@/theme';
+import type {ColorTokens} from '@/theme';
 import type {VetBusiness, BusinessCategory} from '../../types';
 
 export interface ClinicMapPinProps {
   business: VetBusiness;
   isSelected: boolean;
+  /**
+   * Active palette. Defaults to the light one so the pin stays a pure
+   * presentational component - useTheme is redux-backed, and reaching into the
+   * store from a leaf rendered inside a Marker would couple it to a Provider
+   * for the sake of one colour. MapDiscoveryView already holds the theme and
+   * passes it down.
+   */
+  palette?: ColorTokens;
 }
 
-// Pins are drawn on the light map style, so the light palette is the right
-// one. These used the stale #247AED from the unbuilt design-tokens package
-// plus three stock Material swatches with no relationship to warm bone.
-const CATEGORY_COLORS: Record<BusinessCategory, string> = {
-  hospital: colors.blue,
-  groomer: colors.success,
-  breeder: colors.warning,
-  boarder: colors.violet,
-  pet_center: colors.cyanText,
-};
+// Category colours come from the ACTIVE theme, not the light palette. The map
+// itself now has an espresso variant, and several of these tokens differ
+// between themes - violet is #7C3AED on bone but #C4B5FD on espresso - so
+// pinning them to the light values would put dark pins on a dark map.
+const categoryColors = (c: ColorTokens): Record<BusinessCategory, string> => ({
+  hospital: c.blue,
+  groomer: c.success,
+  breeder: c.warning,
+  boarder: c.violet,
+  pet_center: c.cyanText,
+});
 
 const CATEGORY_SYMBOLS: Record<BusinessCategory, string> = {
   hospital: '🏥',
@@ -39,8 +49,12 @@ const buildRatingLabel = (business: VetBusiness): string => {
   return CATEGORY_SYMBOLS[business.category] ?? '•';
 };
 
-const ClinicMapPin: React.FC<ClinicMapPinProps> = ({business, isSelected}) => {
-  const pinColor = CATEGORY_COLORS[business.category] ?? colors.blue;
+const ClinicMapPin: React.FC<ClinicMapPinProps> = ({
+  business,
+  isSelected,
+  palette = colors,
+}) => {
+  const pinColor = categoryColors(palette)[business.category] ?? palette.blue;
   const ratingLabel = useMemo(() => buildRatingLabel(business), [business]);
   const displayName = useMemo(
     () => truncateName(business.name),
@@ -86,12 +100,12 @@ const styles = StyleSheet.create({
     borderColor: 'rgba(255, 255, 255, 0.35)',
   },
   bubbleSelected: {
-    borderColor: colors.white,
+    borderColor: '#FFFFFF',
     borderWidth: 2,
     boxShadow: '0px 2px 4px rgba(0,0,0,0.4)',
   },
   name: {
-    color: colors.white,
+    color: '#FFFFFF',
     fontSize: 10,
     fontWeight: '700',
     letterSpacing: -0.2,

--- a/apps/mobileAppYC/src/features/appointments/components/MapDiscovery/ClusterMapPin.tsx
+++ b/apps/mobileAppYC/src/features/appointments/components/MapDiscovery/ClusterMapPin.tsx
@@ -1,45 +1,56 @@
 import React from 'react';
 import {View, Text, StyleSheet} from 'react-native';
+import {useMemo} from 'react';
 import {colors} from '@/theme';
+import type {ColorTokens} from '@/theme';
 
 interface ClusterMapPinProps {
   count: number;
+  /** Active palette; light by default. See ClinicMapPin for why not useTheme. */
+  palette?: ColorTokens;
 }
 
-const ClusterMapPin: React.FC<ClusterMapPinProps> = ({count}) => (
-  <View collapsable={false} style={styles.outer}>
-    <View style={styles.inner}>
-      <Text style={styles.label}>{count}</Text>
+const ClusterMapPin: React.FC<ClusterMapPinProps> = ({
+  count,
+  palette = colors,
+}) => {
+  const styles = useMemo(() => createStyles(palette), [palette]);
+  return (
+    <View collapsable={false} style={styles.outer}>
+      <View style={styles.inner}>
+        <Text style={styles.label}>{count}</Text>
+      </View>
     </View>
-  </View>
-);
+  );
+};
 
-const styles = StyleSheet.create({
-  outer: {
-    width: 48,
-    height: 48,
-    borderRadius: 24,
-    backgroundColor: colors.blueGlow,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  inner: {
-    width: 34,
-    height: 34,
-    borderRadius: 17,
-    backgroundColor: colors.blue,
-    justifyContent: 'center',
-    alignItems: 'center',
-    borderWidth: 2,
-    borderColor: colors.white,
-    boxShadow: `0px 2px 6px ${colors.blueShadow}`,
-  },
-  label: {
-    color: colors.white,
-    fontSize: 13,
-    fontWeight: '700',
-    lineHeight: 16,
-  },
-});
+const createStyles = (c: ColorTokens) =>
+  StyleSheet.create({
+    outer: {
+      width: 48,
+      height: 48,
+      borderRadius: 24,
+      backgroundColor: c.blueGlow,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    inner: {
+      width: 34,
+      height: 34,
+      borderRadius: 17,
+      backgroundColor: c.blue,
+      justifyContent: 'center',
+      alignItems: 'center',
+      borderWidth: 2,
+      borderColor: c.white,
+      boxShadow: `0px 2px 6px ${c.blueShadow}`,
+    },
+    label: {
+      color: c.white,
+      fontSize: 13,
+      fontWeight: '700',
+      lineHeight: 16,
+    },
+  });
 
 export default ClusterMapPin;

--- a/apps/mobileAppYC/src/features/appointments/components/MapDiscovery/ClusterMapPin.tsx
+++ b/apps/mobileAppYC/src/features/appointments/components/MapDiscovery/ClusterMapPin.tsx
@@ -1,8 +1,6 @@
-import React from 'react';
+import React, {useMemo} from 'react';
 import {View, Text, StyleSheet} from 'react-native';
-import {useMemo} from 'react';
-import {colors} from '@/theme';
-import type {ColorTokens} from '@/theme';
+import {colors, type ColorTokens} from '@/theme';
 
 interface ClusterMapPinProps {
   count: number;

--- a/apps/mobileAppYC/src/features/appointments/components/MapDiscovery/MapDiscoveryView.tsx
+++ b/apps/mobileAppYC/src/features/appointments/components/MapDiscovery/MapDiscoveryView.tsx
@@ -28,7 +28,7 @@ import type {NativeStackNavigationProp} from '@react-navigation/native-stack';
 import type {AppointmentStackParamList} from '@/navigation/types';
 import type {VetBusiness, BusinessCategory} from '../../types';
 import type {UserLocation} from '../../hooks/useLocationPermission';
-import {YC_MAP_STYLE} from '../../utils/mapStyle';
+import {mapStyleFor} from '../../utils/mapStyle';
 import {clusterClinics} from '../../utils/clusterClinics';
 import {useTheme} from '@/hooks';
 import {Header} from '@/shared/components/common/Header/Header';
@@ -131,7 +131,8 @@ const MapDiscoveryView: React.FC<MapDiscoveryViewProps> = ({
   onSearchBarLayout,
 }) => {
   const {t} = useTranslation();
-  const {theme} = useTheme();
+  const {theme, isDark} = useTheme();
+  const mapStyle = useMemo(() => mapStyleFor(isDark), [isDark]);
   const styles = useMemo(() => createStyles(theme), [theme]);
   const insets = useSafeAreaInsets();
 
@@ -282,7 +283,7 @@ const MapDiscoveryView: React.FC<MapDiscoveryViewProps> = ({
         style={StyleSheet.absoluteFill}
         provider={PROVIDER_GOOGLE}
         initialRegion={initialRegion}
-        customMapStyle={YC_MAP_STYLE}
+        customMapStyle={mapStyle}
         showsUserLocation={hasLocationPermission}
         showsMyLocationButton={false}
         showsCompass={false}

--- a/apps/mobileAppYC/src/features/appointments/components/MapDiscovery/MapDiscoveryView.tsx
+++ b/apps/mobileAppYC/src/features/appointments/components/MapDiscovery/MapDiscoveryView.tsx
@@ -298,7 +298,7 @@ const MapDiscoveryView: React.FC<MapDiscoveryViewProps> = ({
                 key={item.id}
                 coordinate={{latitude: item.lat, longitude: item.lng}}
                 tracksViewChanges={false}>
-                <ClusterMapPin count={item.count} />
+                <ClusterMapPin count={item.count} palette={theme.colors} />
               </Marker>
             );
           }
@@ -312,6 +312,7 @@ const MapDiscoveryView: React.FC<MapDiscoveryViewProps> = ({
               onPress={() => handlePinPress(clinic.id)}>
               <ClinicMapPin
                 business={clinic}
+                palette={theme.colors}
                 isSelected={clinic.id === selectedClinicId}
               />
             </Marker>

--- a/apps/mobileAppYC/src/features/appointments/screens/MyAppointmentsScreen.tsx
+++ b/apps/mobileAppYC/src/features/appointments/screens/MyAppointmentsScreen.tsx
@@ -785,7 +785,7 @@ const createStyles = (theme: Theme) =>
     },
     groupTitle: {
       ...theme.typography.eyebrow,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
     },
     segmentContainer: {
       marginTop: theme.spacing['1'],
@@ -840,7 +840,7 @@ const createStyles = (theme: Theme) =>
     },
     ratingLoadingText: {
       ...theme.typography.body12,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
     },
     pastStatusWrapper: {
       flexDirection: 'row',

--- a/apps/mobileAppYC/src/features/appointments/screens/ViewAppointmentScreen.tsx
+++ b/apps/mobileAppYC/src/features/appointments/screens/ViewAppointmentScreen.tsx
@@ -1509,7 +1509,7 @@ const createStyles = (theme: Theme) =>
     },
     emptyDocsText: {
       ...theme.typography.body12,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
     },
     actionsContainer: {
       gap: theme.spacing['2.5'],
@@ -1588,7 +1588,7 @@ const createStyles = (theme: Theme) =>
     },
     formMeta: {
       ...theme.typography.body12,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
     },
     formStatusBadge: {
       paddingHorizontal: theme.spacing['3'],
@@ -1600,7 +1600,7 @@ const createStyles = (theme: Theme) =>
     },
     formDescription: {
       ...theme.typography.body12,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
     },
     formAnswers: {
       gap: theme.spacing['2'],
@@ -1617,7 +1617,7 @@ const createStyles = (theme: Theme) =>
     },
     answerLabel: {
       ...theme.typography.body12,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
     },
     answerValue: {
       ...theme.typography.body13,

--- a/apps/mobileAppYC/src/features/appointments/utils/mapStyle.ts
+++ b/apps/mobileAppYC/src/features/appointments/utils/mapStyle.ts
@@ -1,4 +1,3 @@
-import {colors} from '@/theme';
 type Styler = Record<string, string | number>;
 
 const r = (featureType: string, elementType: string, ...stylers: Styler[]) => ({
@@ -7,31 +6,107 @@ const r = (featureType: string, elementType: string, ...stylers: Styler[]) => ({
   stylers,
 });
 
-export const YC_MAP_STYLE = [
-  r('landscape', 'geometry', {color: '#F5F7FA'}),
-  r('landscape.man_made', 'geometry', {color: '#F0F4FA'}),
-  r('landscape.natural', 'geometry', {color: '#EDF4EE'}),
-  r('water', 'geometry', {color: '#C8DCF0'}),
-  r('water', 'labels.text.fill', {color: colors.blue}),
-  r('road.local', 'geometry', {color: colors.white}),
-  r('road.local', 'geometry.stroke', {color: '#EAEAEA'}, {weight: 1}),
-  r('road.arterial', 'geometry', {color: '#F5F8FF'}),
-  r('road.arterial', 'geometry.stroke', {color: '#D4E3F8'}, {weight: 1}),
-  r('road.arterial', 'labels.text.fill', {color: '#747473'}),
-  r('road.highway', 'geometry', {color: '#E9F2FD'}),
-  r('road.highway', 'geometry.stroke', {color: colors.blue}, {weight: 1.5}),
-  r('road.highway', 'labels.text.fill', {color: '#1A5FBD'}),
-  r('road.highway', 'labels.text.stroke', {color: colors.white}, {weight: 2}),
-  r('poi', 'geometry', {color: '#EEF2F8'}),
+/**
+ * Warm-bone map palette.
+ *
+ * The previous style was a cool blue-grey set - every surface measured R-B
+ * negative (landscape -5, poi -10, highway fill -20, water -40) while every app
+ * surface measures R-B positive (screen +11, inset +21, hairline +22). The map
+ * therefore read as a different product embedded in the app.
+ *
+ * These values keep each feature's ORIGINAL LIGHTNESS, so the figure/ground
+ * relationships that make a map legible are untouched - roads still sit lighter
+ * than land, water and parks still sit darker. Only the hue moves, onto the
+ * bone family. Water stays cool on purpose: it has to read as water.
+ */
+const MAP_LIGHT = {
+  land: '#F7F5F1',
+  landBuilt: '#F3F0EA',
+  landNatural: '#EFF1E9',
+  poi: '#F2EFE9',
+  transit: '#F2EFE9',
+  water: '#D2DEE7',
+  park: '#DEE7D6',
+  road: '#FFFFFF',
+  arterial: '#FBFAF7',
+  highway: '#F1EDE4',
+  roadStroke: '#E9E4DB',
+  labelMuted: '#7A7266',
+  labelInk: '#302F2E',
+  labelHalo: '#FFFFFF',
+  highwayStroke: '#257BED',
+  highwayLabel: '#1657C9',
+  waterLabel: '#257BED',
+  parkLabel: '#008F5D',
+} as const;
+
+/**
+ * Espresso counterpart. Dark maps invert the figure/ground: land goes dark and
+ * roads go LIGHTER than land, otherwise the road network disappears. Label
+ * haloes flip to the dark ground for the same reason. Hues stay in the warm
+ * bone family, and the accents move to their espresso token values, which are
+ * the lighter tints - the light-theme blue and green are too dark to read here.
+ */
+const MAP_DARK = {
+  land: '#2A241D',
+  landBuilt: '#322B22',
+  landNatural: '#2B2F26',
+  poi: '#332C23',
+  transit: '#332C23',
+  water: '#1E2A33',
+  park: '#2C3A2C',
+  road: '#453C31',
+  arterial: '#4E4437',
+  highway: '#584B3C',
+  roadStroke: '#40362B',
+  labelMuted: '#A89E90',
+  labelInk: '#E6DDD0',
+  labelHalo: '#241F19',
+  highwayStroke: '#8FB6F5',
+  highwayLabel: '#8FB6F5',
+  waterLabel: '#8FB6F5',
+  parkLabel: '#2BBD86',
+} as const;
+
+type MapPalette = Record<keyof typeof MAP_LIGHT, string>;
+
+const build = (MAP: MapPalette) => [
+  r('landscape', 'geometry', {color: MAP.land}),
+  r('landscape.man_made', 'geometry', {color: MAP.landBuilt}),
+  r('landscape.natural', 'geometry', {color: MAP.landNatural}),
+  r('water', 'geometry', {color: MAP.water}),
+  r('water', 'labels.text.fill', {color: MAP.waterLabel}),
+  r('road.local', 'geometry', {color: MAP.road}),
+  r('road.local', 'geometry.stroke', {color: MAP.roadStroke}, {weight: 1}),
+  r('road.arterial', 'geometry', {color: MAP.arterial}),
+  r('road.arterial', 'geometry.stroke', {color: MAP.roadStroke}, {weight: 1}),
+  r('road.arterial', 'labels.text.fill', {color: MAP.labelMuted}),
+  r('road.highway', 'geometry', {color: MAP.highway}),
+  r(
+    'road.highway',
+    'geometry.stroke',
+    {color: MAP.highwayStroke},
+    {weight: 1.5},
+  ),
+  r('road.highway', 'labels.text.fill', {color: MAP.highwayLabel}),
+  r('road.highway', 'labels.text.stroke', {color: MAP.labelHalo}, {weight: 2}),
+  r('poi', 'geometry', {color: MAP.poi}),
   r('poi', 'labels', {visibility: 'off'}),
-  r('poi.park', 'geometry', {color: '#D4EDDA'}),
-  r('poi.park', 'labels.text.fill', {color: colors.success}),
+  r('poi.park', 'geometry', {color: MAP.park}),
+  r('poi.park', 'labels.text.fill', {color: MAP.parkLabel}),
   r('poi.park', 'labels', {visibility: 'simplified'}),
-  r('transit', 'geometry', {color: '#E9F2FD'}),
-  r('transit.station', 'labels.text.fill', {color: '#747473'}),
-  r('administrative', 'geometry.stroke', {color: '#EAEAEA'}, {weight: 1}),
-  r('administrative.locality', 'labels.text.fill', {color: colors.inkBody}),
-  r('administrative.neighborhood', 'labels.text.fill', {color: '#747473'}),
-  r('all', 'labels.text.fill', {color: colors.inkBody}),
-  r('all', 'labels.text.stroke', {color: colors.white}, {weight: 2}),
+  r('transit', 'geometry', {color: MAP.transit}),
+  r('transit.station', 'labels.text.fill', {color: MAP.labelMuted}),
+  r('administrative', 'geometry.stroke', {color: MAP.roadStroke}, {weight: 1}),
+  r('administrative.locality', 'labels.text.fill', {color: MAP.labelInk}),
+  r('administrative.neighborhood', 'labels.text.fill', {color: MAP.labelMuted}),
+  r('all', 'labels.text.fill', {color: MAP.labelInk}),
+  r('all', 'labels.text.stroke', {color: MAP.labelHalo}, {weight: 2}),
 ];
+
+export const YC_MAP_STYLE = build(MAP_LIGHT);
+export const YC_MAP_STYLE_DARK = build(MAP_DARK);
+
+/** Pick the map style matching the active theme. */
+export const mapStyleFor = (isDark: boolean) =>
+  isDark ? YC_MAP_STYLE_DARK : YC_MAP_STYLE;

--- a/apps/mobileAppYC/src/features/auth/screens/OTPVerificationScreen.tsx
+++ b/apps/mobileAppYC/src/features/auth/screens/OTPVerificationScreen.tsx
@@ -526,7 +526,7 @@ const createStyles = (theme: Theme) =>
     },
     resendText: {
       ...theme.typography.bodySmall,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
     },
     resendButton: {
       paddingHorizontal: theme.spacing['2'],
@@ -538,7 +538,7 @@ const createStyles = (theme: Theme) =>
     },
     countdownText: {
       ...theme.typography.bodyMedium,
-      color: theme.colors.inkFaint2,
+      color: theme.colors.inkMuted,
     },
     demoInputContainer: {
       width: '100%',

--- a/apps/mobileAppYC/src/features/auth/screens/SignInScreen.tsx
+++ b/apps/mobileAppYC/src/features/auth/screens/SignInScreen.tsx
@@ -582,7 +582,7 @@ const createStyles = (theme: Theme) =>
     dividerText: {
       marginHorizontal: theme.spacing['4'],
       ...theme.typography.bodySmall,
-      color: theme.colors.inkFaint2,
+      color: theme.colors.inkMuted,
     },
     socialButtons: {
       flexDirection: 'row',

--- a/apps/mobileAppYC/src/features/auth/screens/SignUpScreen.tsx
+++ b/apps/mobileAppYC/src/features/auth/screens/SignUpScreen.tsx
@@ -247,7 +247,7 @@ const createStyles = (theme: Theme) =>
     },
     dividerText: {
       ...theme.typography.bodySmall,
-      color: theme.colors.inkFaint2,
+      color: theme.colors.inkMuted,
     },
     socialButton: {
       flexDirection: 'row',
@@ -277,7 +277,7 @@ const createStyles = (theme: Theme) =>
     },
     terms: {
       ...theme.typography.bodySmall,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
       textAlign: 'center',
       paddingHorizontal: theme.spacing['6'],
       marginBottom: theme.spacing['4'],

--- a/apps/mobileAppYC/src/features/chat/components/VoiceMessagePlayer.tsx
+++ b/apps/mobileAppYC/src/features/chat/components/VoiceMessagePlayer.tsx
@@ -185,7 +185,7 @@ const createStyles = (theme: any) =>
     },
     timeText: {
       ...theme.typography.labelSmall,
-      color: theme.colors.inkFaint2,
+      color: theme.colors.inkMuted,
     },
     stopButton: {
       width: theme.spacing['8'],

--- a/apps/mobileAppYC/src/features/chat/screens/ChatChannelScreen.tsx
+++ b/apps/mobileAppYC/src/features/chat/screens/ChatChannelScreen.tsx
@@ -431,7 +431,7 @@ const createHeaderStyles = (theme: any) =>
     },
     subtitle: {
       ...theme.typography.caption,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
     },
     typingStatus: {
       ...theme.typography.captionBold,

--- a/apps/mobileAppYC/src/features/coParent/screens/CoParentProfileScreen/CoParentProfileScreen.tsx
+++ b/apps/mobileAppYC/src/features/coParent/screens/CoParentProfileScreen/CoParentProfileScreen.tsx
@@ -409,7 +409,7 @@ const createStyles = (theme: Theme) =>
     },
     detailLabel: {
       ...theme.typography.bodySmall,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
     },
     detailValue: {
       ...theme.typography.labelSmallBold,
@@ -468,7 +468,7 @@ const createStyles = (theme: Theme) =>
     },
     companionBreed: {
       ...theme.typography.bodySmall,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
     },
     sendButtonContainer: {
       paddingHorizontal: theme.spacing['5'],
@@ -477,7 +477,7 @@ const createStyles = (theme: Theme) =>
     },
     errorText: {
       ...theme.typography.body,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
     },
   });
 

--- a/apps/mobileAppYC/src/features/companion/screens/AddCompanionScreen.tsx
+++ b/apps/mobileAppYC/src/features/companion/screens/AddCompanionScreen.tsx
@@ -1330,7 +1330,7 @@ const createStyles = (theme: any) =>
     },
     speciesSubtitle: {
       ...theme.typography.body13,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
       marginTop: 1,
     },
     speciesCheck: {

--- a/apps/mobileAppYC/src/features/companion/screens/ProfileOverviewScreen.tsx
+++ b/apps/mobileAppYC/src/features/companion/screens/ProfileOverviewScreen.tsx
@@ -587,7 +587,7 @@ export const ProfileOverviewScreen: React.FC<Props> = ({route, navigation}) => {
                         <Ionicons
                           name="chevron-forward"
                           size={15}
-                          color={theme.colors.inkFaint2}
+                          color={theme.colors.inkFaint}
                         />
                       </>
                     )}

--- a/apps/mobileAppYC/src/features/documents/screens/DocumentPreviewScreen/DocumentPreviewScreen.tsx
+++ b/apps/mobileAppYC/src/features/documents/screens/DocumentPreviewScreen/DocumentPreviewScreen.tsx
@@ -479,7 +479,7 @@ const createStyles = (theme: any) => {
     },
     metaText: {
       ...theme.typography.body12,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
     },
     syncedPill: {
       flexDirection: 'row',

--- a/apps/mobileAppYC/src/features/documents/screens/DocumentSearchScreen/DocumentSearchScreen.tsx
+++ b/apps/mobileAppYC/src/features/documents/screens/DocumentSearchScreen/DocumentSearchScreen.tsx
@@ -318,7 +318,7 @@ export const DocumentSearchScreen: React.FC = () => {
                     <Ionicons
                       name="chevron-forward"
                       size={15}
-                      color={theme.colors.inkFaint2}
+                      color={theme.colors.inkFaint}
                     />
                   </View>
                 ))}
@@ -402,7 +402,7 @@ const createStyles = (theme: any) => {
     },
     resultsCount: {
       ...theme.typography.body12,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
       marginBottom: theme.spacing['2'],
     },
     resultsContainer: {
@@ -447,7 +447,7 @@ const createStyles = (theme: any) => {
     },
     resultMeta: {
       ...theme.typography.body12,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
       marginTop: theme.spacing['0'],
     },
     highlight: {
@@ -460,7 +460,7 @@ const createStyles = (theme: any) => {
     },
     recentHeader: {
       ...theme.typography.eyebrow,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
     },
     recentChips: {
       flexDirection: 'row' as const,

--- a/apps/mobileAppYC/src/features/expenses/components/ExpenseCard/ExpenseCard.tsx
+++ b/apps/mobileAppYC/src/features/expenses/components/ExpenseCard/ExpenseCard.tsx
@@ -260,7 +260,7 @@ const createStyles = (theme: any) =>
     },
     meta: {
       fontSize: 12.5,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
       marginTop: 2,
     },
     amountColumn: {

--- a/apps/mobileAppYC/src/features/expenses/screens/ExpensePreviewScreen/ExpensePreviewScreen.tsx
+++ b/apps/mobileAppYC/src/features/expenses/screens/ExpensePreviewScreen/ExpensePreviewScreen.tsx
@@ -643,7 +643,7 @@ const createStyles = (theme: any) =>
     },
     heroDate: {
       ...theme.typography.body13,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
       textAlign: 'center',
     },
     badgeRow: {
@@ -682,7 +682,7 @@ const createStyles = (theme: any) =>
     },
     detailLabel: {
       ...theme.typography.body13,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
     },
     detailValue: {
       ...theme.typography.body14,

--- a/apps/mobileAppYC/src/features/expenses/screens/ExpensesListScreen/ExpensesListScreen.tsx
+++ b/apps/mobileAppYC/src/features/expenses/screens/ExpensesListScreen/ExpensesListScreen.tsx
@@ -241,7 +241,7 @@ const createStyles = (theme: any) =>
     },
     listHeading: {
       ...theme.typography.eyebrow,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
       marginTop: theme.spacing['4'],
       marginBottom: theme.spacing['2'],
     },

--- a/apps/mobileAppYC/src/features/expenses/screens/ExpensesMainScreen/ExpensesMainScreen.tsx
+++ b/apps/mobileAppYC/src/features/expenses/screens/ExpensesMainScreen/ExpensesMainScreen.tsx
@@ -331,7 +331,7 @@ const createStyles = (theme: any) =>
     },
     sectionTitle: {
       ...theme.typography.eyebrow,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
     },
     cardsContainer: {
       gap: theme.spacing['3'],

--- a/apps/mobileAppYC/src/features/forms/screens/AppointmentFormScreen.tsx
+++ b/apps/mobileAppYC/src/features/forms/screens/AppointmentFormScreen.tsx
@@ -1101,7 +1101,7 @@ const createStyles = (theme: any) => {
       ...theme.typography.subtitleBold12,
       fontSize: 12.5,
       fontWeight: '700',
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
     },
     progressWrap: {
       paddingHorizontal: theme.spacing['5'],

--- a/apps/mobileAppYC/src/features/forms/screens/FormSigningScreen.tsx
+++ b/apps/mobileAppYC/src/features/forms/screens/FormSigningScreen.tsx
@@ -356,7 +356,7 @@ const createStyles = (theme: any) =>
     },
     summaryMeta: {
       ...theme.typography.body13,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
     },
     infoBanner: {
       flexDirection: 'row',
@@ -384,7 +384,7 @@ const createStyles = (theme: any) =>
     noteText: {
       ...theme.typography.caption,
       lineHeight: 17,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
       flex: 1,
     },
     leadingIcon: {
@@ -412,7 +412,7 @@ const createStyles = (theme: any) =>
     },
     footnote: {
       ...theme.typography.caption,
-      color: theme.colors.inkFaint2,
+      color: theme.colors.inkMuted,
       textAlign: 'center',
     },
   });

--- a/apps/mobileAppYC/src/features/legal/screens/OrganisationDocumentScreen.tsx
+++ b/apps/mobileAppYC/src/features/legal/screens/OrganisationDocumentScreen.tsx
@@ -496,7 +496,7 @@ const createStyles = (theme: any) =>
     sheetPageIndicator: {
       fontFamily: theme.typography.SATOSHI_MEDIUM,
       fontSize: 10.5,
-      color: theme.colors.inkFaint2,
+      color: theme.colors.inkMuted,
     },
     sheetDocTitle: {
       fontFamily: theme.typography.SATOSHI_BOLD,

--- a/apps/mobileAppYC/src/features/linkedBusinesses/components/LinkedBusinessCard.tsx
+++ b/apps/mobileAppYC/src/features/linkedBusinesses/components/LinkedBusinessCard.tsx
@@ -302,7 +302,7 @@ const createStyles = (theme: any) =>
     },
     meta: {
       ...theme.typography.body12,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
     },
     footer: {
       flexDirection: 'row',
@@ -316,7 +316,7 @@ const createStyles = (theme: any) =>
     },
     chipText: {
       ...theme.typography.body12,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
     },
     actionButtons: {
       flexDirection: 'column',

--- a/apps/mobileAppYC/src/features/linkedBusinesses/screens/BusinessAddScreen.tsx
+++ b/apps/mobileAppYC/src/features/linkedBusinesses/screens/BusinessAddScreen.tsx
@@ -707,7 +707,7 @@ const createStyles = (theme: any) => {
     },
     businessMeta: {
       ...theme.typography.caption,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
     },
     businessWebsite: {
       ...theme.typography.caption,
@@ -728,7 +728,7 @@ const createStyles = (theme: any) => {
     },
     sectionLabel: {
       ...theme.typography.eyebrow,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
     },
     companionRow: {
       flexDirection: 'row',

--- a/apps/mobileAppYC/src/features/linkedBusinesses/screens/BusinessSearchScreen.tsx
+++ b/apps/mobileAppYC/src/features/linkedBusinesses/screens/BusinessSearchScreen.tsx
@@ -750,7 +750,7 @@ const createStyles = (theme: any) => {
     },
     sectionTitle: {
       ...theme.typography.eyebrow,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
       marginBottom: theme.spacing['3'],
     },
     loadingContainer: {

--- a/apps/mobileAppYC/src/features/merck/components/MerckSearchWidget.tsx
+++ b/apps/mobileAppYC/src/features/merck/components/MerckSearchWidget.tsx
@@ -1418,7 +1418,7 @@ const createStyles = (theme: any) =>
       alignItems: 'center',
       justifyContent: 'center',
       gap: theme.spacing['2'],
-      backgroundColor: 'rgba(255, 255, 255, 0.96)',
+      backgroundColor: theme.colors.cardOverlay,
     },
     readerLoaderGif: {
       width: 88,

--- a/apps/mobileAppYC/src/features/notifications/components/NotificationCard/NotificationCard.tsx
+++ b/apps/mobileAppYC/src/features/notifications/components/NotificationCard/NotificationCard.tsx
@@ -230,7 +230,7 @@ export const NotificationCard: React.FC<NotificationCardProps> = ({
                   <Ionicons
                     name="checkmark-circle-outline"
                     size={15}
-                    color={theme.colors.inkFaint2}
+                    color={theme.colors.inkFaint}
                   />
                   <Text style={styles.actionButtonText}>Mark as read</Text>
                 </PressableOpacity>
@@ -244,7 +244,7 @@ export const NotificationCard: React.FC<NotificationCardProps> = ({
                   <Ionicons
                     name="archive-outline"
                     size={15}
-                    color={theme.colors.inkFaint2}
+                    color={theme.colors.inkFaint}
                   />
                   <Text style={styles.actionButtonText}>Archive</Text>
                 </PressableOpacity>
@@ -306,7 +306,7 @@ const createStyles = (theme: any) =>
     },
     actionButtonText: {
       ...theme.typography.body12,
-      color: theme.colors.inkFaint2,
+      color: theme.colors.inkMuted,
     },
     iconDragging: {
       opacity: 0.7,
@@ -341,7 +341,7 @@ const createStyles = (theme: any) =>
     },
     time: {
       ...theme.typography.body12,
-      color: theme.colors.inkFaint2,
+      color: theme.colors.inkMuted,
     },
     avatarContainer: {
       flexShrink: 0,

--- a/apps/mobileAppYC/src/features/notifications/screens/NotificationsScreen/NotificationsScreen.tsx
+++ b/apps/mobileAppYC/src/features/notifications/screens/NotificationsScreen/NotificationsScreen.tsx
@@ -353,7 +353,7 @@ const createStyles = (theme: any) => {
     },
     sectionHeader: {
       ...theme.typography.eyebrow,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
       marginTop: theme.spacing['2'],
       marginBottom: theme.spacing['2'],
     },

--- a/apps/mobileAppYC/src/features/payments/screens/PaymentInvoiceScreen.tsx
+++ b/apps/mobileAppYC/src/features/payments/screens/PaymentInvoiceScreen.tsx
@@ -1986,7 +1986,7 @@ const createStyles = (theme: any) =>
     },
     breakdownNote: {
       ...theme.typography.body12,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
       marginTop: theme.spacing['2'],
     },
     termsCard: {
@@ -2024,7 +2024,7 @@ const createStyles = (theme: any) =>
     },
     securityNoteText: {
       ...theme.typography.body12,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
       textAlign: 'center',
       flexShrink: 1,
     },
@@ -2077,7 +2077,7 @@ const breakdownStyles = (theme: any) =>
       color: theme.colors.inkBody,
     },
     labelSubtle: {
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
     },
     labelHighlight: {
       ...theme.typography.titleSmall,

--- a/apps/mobileAppYC/src/features/payments/screens/PaymentSuccessScreen.tsx
+++ b/apps/mobileAppYC/src/features/payments/screens/PaymentSuccessScreen.tsx
@@ -289,7 +289,7 @@ const createStyles = (theme: any) =>
     },
     detailLabel: {
       ...theme.typography.body14,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
       flexShrink: 0,
     },
     detailValue: {
@@ -327,7 +327,7 @@ const createStyles = (theme: any) =>
       color: theme.colors.blueText,
     },
     receiptButtonTextDisabled: {
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
     },
   });
 

--- a/apps/mobileAppYC/src/features/preferences/screens/PreferencesScreen.tsx
+++ b/apps/mobileAppYC/src/features/preferences/screens/PreferencesScreen.tsx
@@ -226,13 +226,13 @@ const createStyles = (theme: Theme) =>
     },
     caption: {
       ...theme.typography.body12,
-      color: theme.colors.inkFaint2,
+      color: theme.colors.inkMuted,
       marginTop: theme.spacing['2'],
       marginLeft: theme.spacing['1'],
     },
     footnote: {
       ...theme.typography.body12,
-      color: theme.colors.inkFaint2,
+      color: theme.colors.inkMuted,
       textAlign: 'center',
       paddingHorizontal: theme.spacing['5'],
       paddingTop: theme.spacing['4'],

--- a/apps/mobileAppYC/src/features/support/screens/FAQScreen.tsx
+++ b/apps/mobileAppYC/src/features/support/screens/FAQScreen.tsx
@@ -446,7 +446,7 @@ const createStyles = (theme: any) => {
       height: theme.spacing['4'],
       marginLeft: theme.spacing['2'],
       resizeMode: 'contain',
-      tintColor: theme.colors.inkFaint2,
+      tintColor: theme.colors.inkFaint,
     },
     glassButtonDark: {
       minWidth: 100,

--- a/apps/mobileAppYC/src/features/tasks/components/MedicationFormSection/MedicationFormSection.tsx
+++ b/apps/mobileAppYC/src/features/tasks/components/MedicationFormSection/MedicationFormSection.tsx
@@ -283,7 +283,7 @@ const createMedicationStyles = (theme: any) =>
     },
     doseMeta: {
       ...theme.typography.bodySmall,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
       fontVariant: ['tabular-nums'],
     },
     addDoseRow: {

--- a/apps/mobileAppYC/src/features/tasks/components/TaskCard/TaskCard.tsx
+++ b/apps/mobileAppYC/src/features/tasks/components/TaskCard/TaskCard.tsx
@@ -648,7 +648,7 @@ const createStyles = (theme: any) =>
     },
     meta: {
       fontSize: 12.5,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
     },
     trailing: {
       alignItems: 'flex-end',

--- a/apps/mobileAppYC/src/features/tasks/components/TaskTypeBottomSheet/TaskTypeBottomSheet.tsx
+++ b/apps/mobileAppYC/src/features/tasks/components/TaskTypeBottomSheet/TaskTypeBottomSheet.tsx
@@ -443,7 +443,7 @@ const createStyles = (theme: any, listBottomInset: number) =>
     },
     categoryHeader: {
       ...theme.typography.eyebrow,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
     },
     subcategoryGroup: {
       gap: theme.spacing['2'],
@@ -463,7 +463,7 @@ const createStyles = (theme: any, listBottomInset: number) =>
     },
     subsubcategoryHeader: {
       ...theme.typography.labelXxsBold,
-      color: theme.colors.inkFaint2,
+      color: theme.colors.inkMuted,
       textTransform: 'uppercase',
       letterSpacing: 0.5,
     },

--- a/apps/mobileAppYC/src/features/tasks/screens/ObservationalToolPreviewScreen/ObservationalToolPreviewScreen.tsx
+++ b/apps/mobileAppYC/src/features/tasks/screens/ObservationalToolPreviewScreen/ObservationalToolPreviewScreen.tsx
@@ -383,7 +383,7 @@ const createStyles = (theme: any) =>
     },
     footer: {
       ...theme.typography.caption,
-      color: theme.colors.inkFaint2,
+      color: theme.colors.inkMuted,
       textAlign: 'center',
       paddingTop: theme.spacing['1'],
       paddingBottom: theme.spacing['5'],

--- a/apps/mobileAppYC/src/features/tasks/screens/ObservationalToolScreen/ObservationalToolScreen.tsx
+++ b/apps/mobileAppYC/src/features/tasks/screens/ObservationalToolScreen/ObservationalToolScreen.tsx
@@ -1484,7 +1484,7 @@ const createStyles = (theme: any) => {
     },
     stepMeta: {
       ...theme.typography.labelXxsBold,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
       letterSpacing: 1,
     },
     stepHeading: {
@@ -1592,7 +1592,7 @@ const createStyles = (theme: any) => {
     },
     stepFooterNote: {
       ...theme.typography.body13,
-      color: theme.colors.inkFaint2,
+      color: theme.colors.inkMuted,
       textAlign: 'center',
     },
     stepActions: {

--- a/apps/mobileAppYC/src/features/tasks/screens/TaskViewScreen/TaskViewScreen.tsx
+++ b/apps/mobileAppYC/src/features/tasks/screens/TaskViewScreen/TaskViewScreen.tsx
@@ -1092,7 +1092,7 @@ const createStyles = (theme: any) => {
     },
     doseMeta: {
       ...theme.typography.body13,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
       fontVariant: ['tabular-nums'],
     },
     // Toggle rows (warm-bone overrides of the shared form styles)

--- a/apps/mobileAppYC/src/features/tasks/screens/TaskViewScreen/components/ViewField.tsx
+++ b/apps/mobileAppYC/src/features/tasks/screens/TaskViewScreen/components/ViewField.tsx
@@ -95,7 +95,7 @@ const createStyles = (theme: Theme) =>
     },
     label: {
       ...theme.typography.bodySmall,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
     },
     value: {
       ...theme.typography.labelSmallBold,

--- a/apps/mobileAppYC/src/features/tasks/screens/TasksMainScreen/TasksMainScreen.tsx
+++ b/apps/mobileAppYC/src/features/tasks/screens/TasksMainScreen/TasksMainScreen.tsx
@@ -524,7 +524,7 @@ const createTaskScreenStyles = (theme: Theme) => ({
   },
   categoryTitle: {
     ...theme.typography.eyebrow,
-    color: theme.colors.inkFaint,
+    color: theme.colors.inkMuted,
   },
   emptyCard: {
     backgroundColor: theme.colors.screen,
@@ -601,6 +601,6 @@ const createSummaryStyles = (theme: any) =>
     },
     summaryMeta: {
       ...theme.typography.caption,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
     },
   });

--- a/apps/mobileAppYC/src/shared/components/common/CategoryTile/CategoryTile.tsx
+++ b/apps/mobileAppYC/src/shared/components/common/CategoryTile/CategoryTile.tsx
@@ -89,7 +89,7 @@ export const CategoryTile: React.FC<CategoryTileProps> = ({
       <Ionicons
         name="chevron-forward"
         size={16}
-        color={theme.colors.inkFaint2}
+        color={theme.colors.inkFaint}
       />
     </PressableOpacity>
   );
@@ -136,7 +136,7 @@ const createStyles = (theme: any) =>
     },
     subtitle: {
       fontSize: 12.5,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
       marginTop: 1,
     },
     countBadge: {

--- a/apps/mobileAppYC/src/shared/components/common/DocumentCard/DocumentCard.tsx
+++ b/apps/mobileAppYC/src/shared/components/common/DocumentCard/DocumentCard.tsx
@@ -157,7 +157,7 @@ const createStyles = (theme: any) =>
     },
     meta: {
       fontSize: 12.5,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
       marginTop: 1,
     },
     syncedPill: {

--- a/apps/mobileAppYC/src/shared/components/common/RatingStars/RatingStars.tsx
+++ b/apps/mobileAppYC/src/shared/components/common/RatingStars/RatingStars.tsx
@@ -33,9 +33,7 @@ export const RatingStars: React.FC<{
                 {width: size, height: size},
                 // Pink = companion moment (hearts / ratings).
                 {
-                  tintColor: filled
-                    ? theme.colors.pink
-                    : theme.colors.inkFaint2,
+                  tintColor: filled ? theme.colors.pink : theme.colors.inkFaint,
                 },
               ]}
               resizeMode="contain"

--- a/apps/mobileAppYC/src/shared/components/common/YearlySpendCard/YearlySpendCard.tsx
+++ b/apps/mobileAppYC/src/shared/components/common/YearlySpendCard/YearlySpendCard.tsx
@@ -149,7 +149,7 @@ const createStyles = (theme: any) =>
     },
     label: {
       ...theme.typography.caption,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
     },
     amount: {
       ...theme.typography.amountHero,

--- a/apps/mobileAppYC/src/shared/styles/screenHeaderStyles.ts
+++ b/apps/mobileAppYC/src/shared/styles/screenHeaderStyles.ts
@@ -44,7 +44,7 @@ export const createScreenHeaderStyles = (
   },
   headerSubtitle: {
     ...theme.typography.body12,
-    color: theme.colors.inkFaint,
+    color: theme.colors.inkMuted,
     textAlign: 'center',
     marginTop: 1,
   },

--- a/apps/mobileAppYC/src/theme/colors.ts
+++ b/apps/mobileAppYC/src/theme/colors.ts
@@ -75,6 +75,30 @@ const palette = {
   inkBody: ['#302F2E', '#E6DDD0'],
   inkSoft: ['#423F3C', '#CABFB0'],
   inkMuted: ['#5C5956', '#A89E90'],
+  /**
+   * INK RAMP CONTRAST RULE - read before using inkFaint or inkFaint2.
+   *
+   * Measured against `screen` (#F7F3EC light / #2F271E dark):
+   *
+   *   token        light            dark
+   *   inkMuted     6.29:1  passes   5.57:1  passes
+   *   inkFaint     3.12:1  FAILS    4.81:1  passes
+   *   inkFaint2    2.26:1  FAILS    3.84:1  FAILS
+   *
+   * So on the light ground `inkMuted` is the FAINTEST token that may carry body
+   * text. `inkFaint` clears the 3:1 bar, so it is fine for icons, borders and
+   * large display type (>=18pt, or >=14pt bold) but not for body copy.
+   * `inkFaint2` clears neither bar and must not carry text or a UI affordance;
+   * it is left for disabled controls, which WCAG 1.4.3 exempts, and for copy
+   * sitting over media rather than over a themed ground.
+   *
+   * Darkening the two faint tokens to pass is NOT the fix. Both would land near
+   * #75_6D_67, collapsing a five-step ramp into three - there is not enough
+   * luminance range between bone and black to fit five distinct steps that all
+   * clear 4.5:1. The ramp is fine; the usage rule is what was missing.
+   *
+   * Guarded by __tests__/theme/inkRampContrast.test.ts.
+   */
   inkFaint: ['#8F8984', '#9D9285'],
   inkFaint2: ['#A9A39E', '#8B8173'],
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

Measuring every ink token against `screen` in both themes shows the **light** ground is the worse of the two:

| token | light | | dark | |
|---|---|---|---|---|
| `inkMuted` | 6.29:1 | passes | 5.57:1 | passes |
| `inkFaint` | **3.12:1** | **fails** | 4.81:1 | passes |
| `inkFaint2` | **2.26:1** | **fails** | **3.84:1** | **fails** |

`inkFaint` was carrying text at **63 call sites** and `inkFaint2` at **15**, all below the 4.5:1 AA bar on light. `inkFaint2` is the worse case: at 2.26:1 it clears neither the 4.5:1 text bar nor the 3:1 bar for icons and affordances, so its icon tints were failing too.

## What is the new behavior?

**Darkening the tokens is not the fix, and that is the substance of this PR.** To pass, both would have to land near `#756D67` - nearly the same colour - collapsing a five-step ink ramp into three. There is not enough luminance range between `#F7F3EC` and black to fit five perceptually distinct steps that all clear 4.5:1.

The ramp is fine. What was missing was a rule about which step may carry text:

| token | may be used for |
|---|---|
| `inkMuted` | the faintest token that may carry **body text** |
| `inkFaint` | icons, borders and **large display type** only (>=18pt, or >=14pt bold) |
| `inkFaint2` | neither - disabled controls and copy over media only |

Applied:

- **66 text call sites** moved to `inkMuted`
- **8 icon tints** moved off `inkFaint2` to `inkFaint`, which clears the 3:1 bar
- **4 `inkFaint` text sites stayed**, because they are set in large serif display type (`serifTitleSmall`, `emptyStateTitle`) where 3.12:1 is the correct bar
- **2 `inkFaint2` uses stayed**: a disabled Verify button, which WCAG 1.4.3 explicitly exempts as an inactive control, and splash copy that sits over video rather than over a themed ground

Two existing tests pinned the old token and were updated. One was already named *"styles the label with the muted ink token"* while asserting `inkFaint`, so its name now matches what it checks.

## The guard, and why it can be trusted

`__tests__/theme/inkRampContrast.test.ts` asserts the ratios and scans `src` for `inkFaint2` outside the two documented exceptions.

**Mutation-checked**, because a guard that has never failed proves nothing: adding a probe `inkFaint2` usage to `Badge.tsx` turns it red and names the offending file; removing the probe turns it green again.

## Validation

- `npx tsc --noEmit` - 0 errors
- `npx eslint src` - 0 errors, 0 warnings
- `npx jest` - 462 suites / 7559 tests, 0 failures

## Note on visual review

This changes the rendered weight of text at 66 call sites, and I could not walk those screens - the simulator input grant is unavailable in this session. The change is mechanical and type-checked, and every site moves in the same direction (fainter to less faint), but it is worth a look on device before merging.

## Related Issue(s)

Part of #2364.
