### PR TITLE
fix(mobile): make the Apple mark visible in dark mode

### DIFF
--- a/apps/mobileAppYC/src/features/auth/screens/SignInScreen.tsx
+++ b/apps/mobileAppYC/src/features/auth/screens/SignInScreen.tsx
@@ -28,11 +28,18 @@ import {isValidEmail} from '@/shared/constants/constants';
 import type {Theme} from '@/theme';
 
 // The Facebook and Apple marks ship as white glyphs, which measured ~1.06:1
-// on the cream button. Both brands permit a solid mark on a light ground:
-// Apple in black, Facebook in its brand blue. Google's is multicolour and must
+// on the cream button, so both are tinted. Google's is multicolour and must
 // never be tinted.
+//
+// Facebook's brand blue clears the 3:1 bar on BOTH grounds (3.83:1 cream,
+// 3.47:1 espresso) so it is fixed. Apple's cannot be: black measures 18.99:1
+// on cream but 1.43:1 on espresso, well under the 3:1 bar for a meaningful
+// graphic - the mark was effectively invisible in dark mode. Apple's own Sign
+// in with Apple guidelines call for the black mark on light backgrounds and
+// the white one on dark, which is what this does.
 const FACEBOOK_BRAND_BLUE = '#1877F2';
-const APPLE_MARK_BLACK = '#000000';
+const APPLE_MARK_ON_LIGHT = '#000000';
+const APPLE_MARK_ON_DARK = '#FFFFFF';
 
 const socialIconStyles = StyleSheet.create({
   icon: {
@@ -44,11 +51,8 @@ const socialIconStyles = StyleSheet.create({
     height: 22,
     tintColor: FACEBOOK_BRAND_BLUE,
   },
-  appleIcon: {
-    width: 22,
-    height: 22,
-    tintColor: APPLE_MARK_BLACK,
-  },
+  appleIconLight: {width: 22, height: 22, tintColor: APPLE_MARK_ON_LIGHT},
+  appleIconDark: {width: 22, height: 22, tintColor: APPLE_MARK_ON_DARK},
 });
 
 const GoogleIcon = () => (
@@ -67,10 +71,12 @@ const FacebookIcon = () => (
   />
 );
 
-const AppleIcon = () => (
+const AppleIcon = ({isDark}: {isDark: boolean}) => (
   <Image
     source={Images.appleIcon}
-    style={socialIconStyles.appleIcon}
+    style={
+      isDark ? socialIconStyles.appleIconDark : socialIconStyles.appleIconLight
+    }
     resizeMode="contain"
   />
 );
@@ -215,6 +221,7 @@ const useOTPHandler = (
 
 const SocialAuthSection: React.FC<{
   theme: Theme;
+  isDark: boolean;
   styles: any;
   isSocialLoading: boolean;
   activeProvider: SocialProvider | null;
@@ -225,6 +232,7 @@ const SocialAuthSection: React.FC<{
   onCreateAccountPress: () => void;
 }> = ({
   theme,
+  isDark,
   styles,
   isSocialLoading,
   activeProvider,
@@ -275,7 +283,7 @@ const SocialAuthSection: React.FC<{
         {activeProvider === 'apple' ? (
           <ActivityIndicator size="small" color={theme.colors.inkMuted} />
         ) : (
-          <AppleIcon />
+          <AppleIcon isDark={isDark} />
         )}
       </PressableOpacity>
     </View>
@@ -299,7 +307,7 @@ export const SignInScreen: React.FC<SignInScreenProps> = ({
   navigation,
   route,
 }) => {
-  const {theme} = useTheme();
+  const {theme, isDark} = useTheme();
   const styles = createStyles(theme);
   const {login} = useAuth();
   const allowReviewLogin = AUTH_FEATURE_FLAGS.enableReviewLogin === true;
@@ -464,6 +472,7 @@ export const SignInScreen: React.FC<SignInScreenProps> = ({
         {!isKeyboardVisible && (
           <SocialAuthSection
             theme={theme}
+            isDark={isDark}
             styles={styles}
             isSocialLoading={isSocialLoading}
             activeProvider={activeProvider}
@@ -582,7 +591,7 @@ const createStyles = (theme: Theme) =>
     dividerText: {
       marginHorizontal: theme.spacing['4'],
       ...theme.typography.bodySmall,
-      color: theme.colors.inkFaint2,
+      color: theme.colors.inkMuted,
     },
     socialButtons: {
       flexDirection: 'row',

--- a/apps/mobileAppYC/src/features/auth/screens/SignUpScreen.tsx
+++ b/apps/mobileAppYC/src/features/auth/screens/SignUpScreen.tsx
@@ -1,5 +1,5 @@
 import React, {useState, useMemo} from 'react';
-import {View, Text, StyleSheet, Image} from 'react-native';
+import {View, Text, StyleSheet, Image, type ImageStyle} from 'react-native';
 import {PressableOpacity} from '@/shared/components/common/PressableOpacity/PressableOpacity';
 import {SafeArea} from '@/shared/components/common';
 import {useTheme, useSocialAuth, type SocialProvider} from '@/hooks';
@@ -16,6 +16,18 @@ const appleMarkStyles = StyleSheet.create({
   onLight: {tintColor: '#000000'},
   onDark: {tintColor: '#FFFFFF'},
 });
+
+/** Brand marks ship as white glyphs, so each needs a tint over the button. */
+const resolveMarkTint = (
+  themedTint: boolean | undefined,
+  tint: string | undefined,
+  isDark: boolean,
+): ImageStyle | null => {
+  if (themedTint) {
+    return isDark ? appleMarkStyles.onDark : appleMarkStyles.onLight;
+  }
+  return tint ? {tintColor: tint} : null;
+};
 const LOGO = require('../../../assets/images/yosemite-logo-1024.png');
 
 type SignUpScreenProps = NativeStackScreenProps<AuthStackParamList, 'SignUp'>;
@@ -40,9 +52,9 @@ const socialButtons: {
     provider: 'apple',
     label: 'Sign up with Apple',
     icon: Images.appleIcon,
-    // Resolved per theme below: black measures 18.99:1 on the cream button but
-    // only 1.43:1 on espresso, under the 3:1 bar for a meaningful graphic.
-    tint: undefined,
+    // No fixed tint: black measures 18.99:1 on the cream button but only
+    // 1.43:1 on espresso, under the 3:1 bar for a meaningful graphic, so this
+    // one resolves per theme via themedTint.
     themedTint: true,
   },
 ];
@@ -144,13 +156,7 @@ export const SignUpScreen: React.FC<SignUpScreenProps> = ({navigation}) => {
                 source={icon}
                 style={[
                   styles.buttonIcon,
-                  themedTint
-                    ? isDark
-                      ? appleMarkStyles.onDark
-                      : appleMarkStyles.onLight
-                    : tint
-                      ? {tintColor: tint}
-                      : null,
+                  resolveMarkTint(themedTint, tint, isDark),
                 ]}
                 resizeMode="contain"
               />

--- a/apps/mobileAppYC/src/features/auth/screens/SignUpScreen.tsx
+++ b/apps/mobileAppYC/src/features/auth/screens/SignUpScreen.tsx
@@ -9,6 +9,13 @@ import type {NativeStackScreenProps} from '@react-navigation/native-stack';
 import type {AuthStackParamList} from '@/navigation/AuthNavigator';
 import type {Theme} from '@/theme';
 
+// Apple's mark cannot use one fixed colour: black measures 18.99:1 on the
+// cream button but 1.43:1 on espresso, under the 3:1 bar for a meaningful
+// graphic. Apple's own guidelines call for black on light and white on dark.
+const appleMarkStyles = StyleSheet.create({
+  onLight: {tintColor: '#000000'},
+  onDark: {tintColor: '#FFFFFF'},
+});
 const LOGO = require('../../../assets/images/yosemite-logo-1024.png');
 
 type SignUpScreenProps = NativeStackScreenProps<AuthStackParamList, 'SignUp'>;
@@ -18,6 +25,7 @@ const socialButtons: {
   label: string;
   icon: number;
   tint?: string;
+  themedTint?: boolean;
 }[] = [
   {provider: 'google', label: 'Sign up with Google', icon: Images.googleIcon},
   {
@@ -32,12 +40,15 @@ const socialButtons: {
     provider: 'apple',
     label: 'Sign up with Apple',
     icon: Images.appleIcon,
-    tint: '#000000',
+    // Resolved per theme below: black measures 18.99:1 on the cream button but
+    // only 1.43:1 on espresso, under the 3:1 bar for a meaningful graphic.
+    tint: undefined,
+    themedTint: true,
   },
 ];
 
 export const SignUpScreen: React.FC<SignUpScreenProps> = ({navigation}) => {
-  const {theme} = useTheme();
+  const {theme, isDark} = useTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
   const {login} = useAuth();
   const [socialError, setSocialError] = useState('');
@@ -120,7 +131,7 @@ export const SignUpScreen: React.FC<SignUpScreenProps> = ({navigation}) => {
             <View style={styles.dividerLine} />
           </View>
 
-          {socialButtons.map(({provider, label, icon, tint}) => (
+          {socialButtons.map(({provider, label, icon, tint, themedTint}) => (
             <PressableOpacity
               key={provider}
               onPress={() => attemptSocialAuth(provider)}
@@ -131,7 +142,16 @@ export const SignUpScreen: React.FC<SignUpScreenProps> = ({navigation}) => {
               accessibilityState={{disabled: isSocialLoading}}>
               <Image
                 source={icon}
-                style={[styles.buttonIcon, tint ? {tintColor: tint} : null]}
+                style={[
+                  styles.buttonIcon,
+                  themedTint
+                    ? isDark
+                      ? appleMarkStyles.onDark
+                      : appleMarkStyles.onLight
+                    : tint
+                      ? {tintColor: tint}
+                      : null,
+                ]}
                 resizeMode="contain"
               />
               <Text style={styles.socialButtonText}>
@@ -247,7 +267,7 @@ const createStyles = (theme: Theme) =>
     },
     dividerText: {
       ...theme.typography.bodySmall,
-      color: theme.colors.inkFaint2,
+      color: theme.colors.inkMuted,
     },
     socialButton: {
       flexDirection: 'row',
@@ -277,7 +297,7 @@ const createStyles = (theme: Theme) =>
     },
     terms: {
       ...theme.typography.bodySmall,
-      color: theme.colors.inkFaint,
+      color: theme.colors.inkMuted,
       textAlign: 'center',
       paddingHorizontal: theme.spacing['6'],
       marginBottom: theme.spacing['4'],


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

Found by walking the app on a simulator in dark mode. The **Sign in / Sign up with Apple** buttons render a pure black glyph on the espresso ground.

Sampled off the device:

| | value | contrast |
|---|---|---|
| Apple glyph | `rgb(0,0,0)` | |
| button fill | `rgb(47,39,30)` | |
| | | **1.43:1** (bar is 3:1) |

The mark was effectively invisible, while Google's multicolour mark and Facebook's brand blue both read fine right beside it.

## Why it happened

This was a **light-mode fix that broke dark mode**. Both marks ship as white glyphs and measured ~1.06:1 on the cream button, so both were tinted dark. Facebook's brand blue happens to clear 3:1 on *both* grounds, so it can stay fixed. Black cannot:

| tint | on cream | on espresso |
|---|---|---|
| black `#000000` | 18.99:1 | **1.43:1** |
| white `#FFFFFF` | 1.11:1 | 14.69:1 |
| Facebook blue `#1877F2` | 3.83:1 | 3.47:1 |

## What is the new behavior?

The Apple mark resolves per theme: black on light, white on dark. That is also what Apple's own Sign in with Apple guidelines require - the black mark on light backgrounds, the white one on dark - so the previous state was a brand-guideline violation as well as a legibility one.

**Re-measured on device after the change: 14.69:1.**

The tints are static `StyleSheet` entries rather than inline objects, because the pre-commit hook runs eslint with `--max-warnings=0` and `react-native/no-inline-styles` fires on a computed `tintColor`.

## Validation

- `npx tsc --noEmit` - 0 errors
- `npx eslint src` - 0 errors, 0 warnings
- `npx jest` - 18 suites / 381 tests, 0 failures
- Before/after captured on an iPhone 15 Pro simulator in dark mode: `[redacted: local path]`

## Related Issue(s)

Part of #2364.
