### PR TITLE
fix(mobile): stop dark-mode primary buttons rendering pure white

### DIFF
--- a/apps/mobileAppYC/src/shared/components/common/LiquidGlassButton/LiquidGlassButton.tsx
+++ b/apps/mobileAppYC/src/shared/components/common/LiquidGlassButton/LiquidGlassButton.tsx
@@ -170,11 +170,17 @@ const buildFallbackSurfaceStyle = ({
   shadowIntensity: GlassButtonProps['shadowIntensity'];
   themeShadows: any;
 }): ViewStyle => {
-  // For white-ish buttons, use pure white (not translucent)
+  // A light tint means "paint this opaque", not "paint this white". The old
+  // branch snapped any tint above 0.9 luminance to pure #FFFFFF, which threw
+  // the caller's colour away. The espresso theme's `cta` is #F2ECE1 - a warm
+  // cream measuring 0.928 - so every primary button in dark mode rendered as
+  // harsh pure white instead of the design system's cream. Light mode was
+  // unaffected because its `cta` is #302F2E, far below the threshold.
+  //
+  // isWhiteOrLightColor still decides the LABEL colour further down, where
+  // "is this background light enough to need dark text" is the right question.
   let backgroundColor: string;
-  if (isWhiteOrLightColor(tintColor)) {
-    backgroundColor = colors.white;
-  } else if (tintColor) {
+  if (tintColor) {
     backgroundColor = tintColor;
   } else {
     /* istanbul ignore next -- resolvedTintColor is always defined; else is unreachable */


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

**Every primary button in dark mode paints `#FFFFFF` instead of the design system's cream.** Found while walking the app on a simulator in dark mode: the Send OTP button sampled as `rgb(255,255,255)`, while the token it is passed - `cta` - is `#F2ECE1` on espresso.

The cause is in `buildFallbackSurfaceStyle`:

```ts
if (isWhiteOrLightColor(tintColor)) {
  backgroundColor = colors.white;      // <- discards the caller's colour
} else if (tintColor) {
  backgroundColor = tintColor;
}
```

`isWhiteOrLightColor` returns true above **0.9** luminance. `#F2ECE1` measures **0.928**. So the tint was thrown away and replaced with pure white.

The comment above it - *"For white-ish buttons, use pure white (not translucent)"* - shows the intent was **opacity**, but the implementation also changed the hue.

**Light mode never hit this.** Its `cta` is `#302F2E` at 0.185 luminance, far below the threshold, so it took the branch that keeps the tint. That is why this survived: the bug is invisible in the theme most development happens in.

## What is the new behavior?

The background branch now honours the caller's tint, staying opaque either way. `isWhiteOrLightColor` is still used further down to decide the **label** colour, where *"is this background light enough to need dark text"* is exactly the right question - that logic is untouched.

**Verified on device:** the button now measures `rgb(242,236,225)` = `#F2ECE1`.

## Scope

`LiquidGlassButton` is the shared primary button, so this affects every dark-mode CTA in the app - not just the auth screens where I happened to notice it.

## Validation

- `npx tsc --noEmit` - 0 errors
- `npx eslint src` - 0 errors, 0 warnings
- `npx jest` - 461 suites / 7556 tests, 0 failures
- Sampled before and after on an iPhone 15 Pro simulator in dark mode

## Related Issue(s)

Part of #2364.
