### PR TITLE
fix(mobile): split the danger token so error text clears 4.5:1

### DIFF
--- a/apps/mobileAppYC/__tests__/components/tasks/CommonTaskFields.test.tsx
+++ b/apps/mobileAppYC/__tests__/components/tasks/CommonTaskFields.test.tsx
@@ -226,7 +226,7 @@ describe('CommonTaskFields', () => {
       expect(errorText).toBeTruthy();
       expect(errorText.props.style).toEqual(
         expect.objectContaining({
-          color: mockTheme.colors.error,
+          color: mockTheme.colors.dangerText,
           fontSize: 12,
         }),
       );

--- a/apps/mobileAppYC/__tests__/features/account/components/AccountMenuList.test.tsx
+++ b/apps/mobileAppYC/__tests__/features/account/components/AccountMenuList.test.tsx
@@ -70,7 +70,7 @@ describe('AccountMenuList', () => {
       ? dangerLabel.props.style
       : [dangerLabel.props.style];
     const hasDangerColor = labelStyles.some(
-      style => style?.color === lightTheme.colors.error,
+      style => style?.color === lightTheme.colors.dangerText,
     );
     expect(hasDangerColor).toBe(true);
 

--- a/apps/mobileAppYC/__tests__/features/appointments/utils/appointmentStatus.test.ts
+++ b/apps/mobileAppYC/__tests__/features/appointments/utils/appointmentStatus.test.ts
@@ -17,6 +17,7 @@ const mockTheme = {
     successSurface: '#successSurface',
     warning: '#warning',
     warningSurface: '#warningSurface',
+    dangerText: '#dangerText',
     error: '#error',
     errorSurface: '#errorSurface',
   },
@@ -249,7 +250,7 @@ describe('getAppointmentStatusBadgePalette', () => {
       'PAYMENT_FAILED',
       null,
     );
-    expect(result.textColor).toBe('#error');
+    expect(result.textColor).toBe('#dangerText');
     expect(result.backgroundColor).toBe('#errorSurface');
     expect(result.text).toBe('Payment failed');
   });
@@ -338,7 +339,7 @@ describe('getAppointmentStatusBadgePalette', () => {
       'CANCELLED',
       null,
     );
-    expect(result.textColor).toBe('#error');
+    expect(result.textColor).toBe('#dangerText');
     expect(result.backgroundColor).toBe('#errorSurface');
   });
 
@@ -349,7 +350,7 @@ describe('getAppointmentStatusBadgePalette', () => {
       'AWAITING_PAYMENT',
     );
     expect(result.text).toBe('Cancelled');
-    expect(result.textColor).toBe('#error');
+    expect(result.textColor).toBe('#dangerText');
     expect(result.backgroundColor).toBe('#errorSurface');
   });
 
@@ -360,7 +361,7 @@ describe('getAppointmentStatusBadgePalette', () => {
       'PAYMENT_FAILED',
     );
     expect(result.text).toBe('Cancelled');
-    expect(result.textColor).toBe('#error');
+    expect(result.textColor).toBe('#dangerText');
   });
 
   it('returns error palette for REJECTED', () => {
@@ -369,13 +370,13 @@ describe('getAppointmentStatusBadgePalette', () => {
       'REJECTED',
       null,
     );
-    expect(result.textColor).toBe('#error');
+    expect(result.textColor).toBe('#dangerText');
     expect(result.backgroundColor).toBe('#errorSurface');
   });
 
   it('returns error palette for NO_SHOW', () => {
     const result = getAppointmentStatusBadgePalette(mockTheme, 'NO_SHOW', null);
-    expect(result.textColor).toBe('#error');
+    expect(result.textColor).toBe('#dangerText');
     expect(result.backgroundColor).toBe('#errorSurface');
   });
 

--- a/apps/mobileAppYC/__tests__/features/legal/styles/legalStyles.test.ts
+++ b/apps/mobileAppYC/__tests__/features/legal/styles/legalStyles.test.ts
@@ -74,6 +74,6 @@ describe('createLegalStyles', () => {
 
   it('applies error color and typography to formErrorText', () => {
     const styles = createLegalStyles(mockTheme);
-    expect(styles.formErrorText.color).toBe(mockTheme.colors.error);
+    expect(styles.formErrorText.color).toBe(mockTheme.colors.dangerText);
   });
 });

--- a/apps/mobileAppYC/__tests__/setup/mockTheme.ts
+++ b/apps/mobileAppYC/__tests__/setup/mockTheme.ts
@@ -613,6 +613,7 @@ export const createMockTheme = () => ({
     cyan: '#5CE1E6',
     cyanText: '#38CCD8',
     danger: '#EA3729',
+    dangerText: '#EA3729',
     dangerSurface: '#FDEBEA',
     indigo: '#4F46E5',
     indigoSurface: '#E0E7FF',

--- a/apps/mobileAppYC/__tests__/shared/components/common/shared/floatingLabelStyles.test.ts
+++ b/apps/mobileAppYC/__tests__/shared/components/common/shared/floatingLabelStyles.test.ts
@@ -39,7 +39,7 @@ describe('floatingLabelStyles', () => {
   it('returns the red error message style below the field', () => {
     expect(getInputErrorStyle(mockTheme)).toEqual({
       ...mockTheme.typography.labelXxsBold,
-      color: mockTheme.colors.error,
+      color: mockTheme.colors.dangerText,
       marginTop: mockTheme.spacing['1'],
       marginBottom: mockTheme.spacing['3'],
       marginLeft: mockTheme.spacing['1'],

--- a/apps/mobileAppYC/__tests__/utils/formScreenStyles.test.ts
+++ b/apps/mobileAppYC/__tests__/utils/formScreenStyles.test.ts
@@ -115,14 +115,14 @@ describe('createFormScreenStyles', () => {
       },
       errorText: {
         ...mockTheme.typography.labelXxsBold,
-        color: mockTheme.colors.error,
+        color: mockTheme.colors.dangerText,
         marginTop: mockTheme.spacing['1'],
         marginBottom: mockTheme.spacing['3'],
         marginLeft: mockTheme.spacing['1'],
       },
       submissionError: {
         ...mockTheme.typography.paragraphBold,
-        color: mockTheme.colors.error,
+        color: mockTheme.colors.dangerText,
         textAlign: 'center',
         paddingHorizontal: mockTheme.spacing['5'],
         marginBottom: mockTheme.spacing['2'],

--- a/apps/mobileAppYC/__tests__/utils/formStyles.test.ts
+++ b/apps/mobileAppYC/__tests__/utils/formStyles.test.ts
@@ -1,8 +1,7 @@
-import { createFormStyles } from '@/shared/utils/formStyles';
+import {createFormStyles} from '@/shared/utils/formStyles';
 import {mockTheme} from '../setup/mockTheme';
 
 // Define a mock theme
-
 
 describe('createFormStyles', () => {
   it('should create the correct styles from the theme', () => {
@@ -64,7 +63,7 @@ describe('createFormStyles', () => {
       },
       errorText: {
         ...mockTheme.typography.labelXxsBold,
-        color: mockTheme.colors.error,
+        color: mockTheme.colors.dangerText,
         marginTop: mockTheme.spacing['1'],
         marginBottom: mockTheme.spacing['3'],
         marginLeft: mockTheme.spacing['1'],

--- a/apps/mobileAppYC/__tests__/utils/screenStyles.test.ts
+++ b/apps/mobileAppYC/__tests__/utils/screenStyles.test.ts
@@ -8,7 +8,6 @@ import {mockTheme} from '../setup/mockTheme';
 
 // Define a mock theme
 
-
 describe('screenStyles', () => {
   describe('createScreenContainerStyles', () => {
     it('should create correct container styles', () => {
@@ -45,7 +44,7 @@ describe('screenStyles', () => {
           fontWeight: '400',
           lineHeight: 29.25,
           fontFamily: 'Satoshi-Regular',
-          color: '#F44336',
+          color: '#EA3729',
         }),
       });
     });

--- a/apps/mobileAppYC/src/features/account/components/AccountMenuList.tsx
+++ b/apps/mobileAppYC/src/features/account/components/AccountMenuList.tsx
@@ -136,7 +136,7 @@ const createStyles = (theme: any) =>
       color: theme.colors.inkBody,
     },
     labelDanger: {
-      color: theme.colors.error,
+      color: theme.colors.dangerText,
     },
     externalHint: {
       ...theme.typography.labelSmall,

--- a/apps/mobileAppYC/src/features/account/components/DeleteAccountBottomSheet.tsx
+++ b/apps/mobileAppYC/src/features/account/components/DeleteAccountBottomSheet.tsx
@@ -201,7 +201,7 @@ const createStyles = (theme: any) =>
     },
     warning: {
       ...theme.typography.inputLabel,
-      color: theme.colors.error ?? theme.colors.secondary,
+      color: theme.colors.dangerText ?? theme.colors.secondary,
       textAlign: 'left',
     },
     actionsRow: {

--- a/apps/mobileAppYC/src/features/account/components/DeleteAccountBottomSheet.tsx
+++ b/apps/mobileAppYC/src/features/account/components/DeleteAccountBottomSheet.tsx
@@ -201,7 +201,7 @@ const createStyles = (theme: any) =>
     },
     warning: {
       ...theme.typography.inputLabel,
-      color: theme.colors.dangerText ?? theme.colors.secondary,
+      color: theme.colors.dangerText,
       textAlign: 'left',
     },
     actionsRow: {

--- a/apps/mobileAppYC/src/features/adverseEventReporting/screens/LandingScreen.tsx
+++ b/apps/mobileAppYC/src/features/adverseEventReporting/screens/LandingScreen.tsx
@@ -69,7 +69,7 @@ export const LandingScreen: React.FC<Props> = ({navigation}) => {
           <Ionicons
             name="alert-circle-outline"
             size={17}
-            color={theme.colors.danger}
+            color={theme.colors.dangerText}
             style={styles.dangerIcon}
           />
           <Text style={styles.dangerText}>

--- a/apps/mobileAppYC/src/features/adverseEventReporting/screens/Step1Screen.tsx
+++ b/apps/mobileAppYC/src/features/adverseEventReporting/screens/Step1Screen.tsx
@@ -347,7 +347,7 @@ const createStyles = (theme: any) =>
     },
     errorText: {
       ...theme.typography.labelXxsBold,
-      color: theme.colors.danger,
+      color: theme.colors.dangerText,
       marginLeft: theme.spacing['1'],
     },
   });

--- a/apps/mobileAppYC/src/features/adverseEventReporting/screens/Step3Screen.tsx
+++ b/apps/mobileAppYC/src/features/adverseEventReporting/screens/Step3Screen.tsx
@@ -80,7 +80,7 @@ const createStyles = (theme: any) =>
     },
     errorText: {
       ...theme.typography.labelXxsBold,
-      color: theme.colors.danger,
+      color: theme.colors.dangerText,
       marginTop: theme.spacing['1'],
       marginLeft: theme.spacing['1'],
     },

--- a/apps/mobileAppYC/src/features/adverseEventReporting/screens/ThankYouScreen.tsx
+++ b/apps/mobileAppYC/src/features/adverseEventReporting/screens/ThankYouScreen.tsx
@@ -475,7 +475,7 @@ const createStyles = (theme: any) =>
     },
     errorText: {
       ...theme.typography.labelXxsBold,
-      color: theme.colors.danger,
+      color: theme.colors.dangerText,
       marginTop: theme.spacing['2'],
       marginLeft: theme.spacing['7'],
     },

--- a/apps/mobileAppYC/src/features/appointments/screens/ViewAppointmentScreen.tsx
+++ b/apps/mobileAppYC/src/features/appointments/screens/ViewAppointmentScreen.tsx
@@ -1534,7 +1534,7 @@ const createStyles = (theme: Theme) =>
     },
     alertButtonText: {
       ...theme.typography.button,
-      color: theme.colors.danger,
+      color: theme.colors.dangerText,
       textAlign: 'center',
     },
     formCardShadowWrapper: {

--- a/apps/mobileAppYC/src/features/appointments/utils/appointmentStatus.ts
+++ b/apps/mobileAppYC/src/features/appointments/utils/appointmentStatus.ts
@@ -129,6 +129,7 @@ type AppointmentTheme = {
     successSurface: string;
     warning: string;
     warningSurface: string;
+    dangerText: string;
     error: string;
     errorSurface: string;
   };
@@ -158,7 +159,7 @@ export const getAppointmentStatusBadgePalette = (
   if (isAppointmentPaymentFailed(status, paymentStatus)) {
     return {
       text: label,
-      textColor: theme.colors.error,
+      textColor: theme.colors.dangerText,
       backgroundColor: theme.colors.errorSurface,
     };
   }
@@ -209,7 +210,7 @@ export const getAppointmentStatusBadgePalette = (
     case 'NO_SHOW':
       return {
         text: label,
-        textColor: theme.colors.error,
+        textColor: theme.colors.dangerText,
         backgroundColor: theme.colors.errorSurface,
       };
     default:

--- a/apps/mobileAppYC/src/features/auth/screens/CreateAccountScreen.tsx
+++ b/apps/mobileAppYC/src/features/auth/screens/CreateAccountScreen.tsx
@@ -1587,7 +1587,7 @@ const createStyles = (theme: Theme) =>
     },
     errorText: {
       ...theme.typography.labelXxsBold,
-      color: theme.colors.error,
+      color: theme.colors.dangerText,
       marginTop: theme.spacing['2'],
       marginLeft: theme.spacing['8'],
     },

--- a/apps/mobileAppYC/src/features/auth/screens/SignInScreen.tsx
+++ b/apps/mobileAppYC/src/features/auth/screens/SignInScreen.tsx
@@ -602,7 +602,7 @@ const createStyles = (theme: Theme) =>
     },
     socialErrorText: {
       ...theme.typography.bodySmall,
-      color: theme.colors.error,
+      color: theme.colors.dangerText,
       textAlign: 'center',
       marginTop: theme.spacing['4'],
     },

--- a/apps/mobileAppYC/src/features/auth/screens/SignUpScreen.tsx
+++ b/apps/mobileAppYC/src/features/auth/screens/SignUpScreen.tsx
@@ -267,7 +267,7 @@ const createStyles = (theme: Theme) =>
     },
     socialErrorText: {
       ...theme.typography.bodySmall,
-      color: theme.colors.error,
+      color: theme.colors.dangerText,
       textAlign: 'center',
       marginTop: theme.spacing['3'],
     },

--- a/apps/mobileAppYC/src/features/chat/components/VoiceMessagePlayer.tsx
+++ b/apps/mobileAppYC/src/features/chat/components/VoiceMessagePlayer.tsx
@@ -142,7 +142,7 @@ export const VoiceMessagePlayer: React.FC<VoiceMessagePlayerProps> = ({
           style={styles.stopButton}
           accessibilityRole="button"
           accessibilityLabel="Stop">
-          <Icon name="stop" size={20} color={theme.colors.danger} />
+          <Icon name="stop" size={20} color={theme.colors.dangerText} />
         </PressableOpacity>
       )}
     </View>

--- a/apps/mobileAppYC/src/features/chat/screens/ChatChannelScreen.tsx
+++ b/apps/mobileAppYC/src/features/chat/screens/ChatChannelScreen.tsx
@@ -460,7 +460,7 @@ const createStyles = (theme: any) =>
     },
     errorText: {
       ...theme.typography.body,
-      color: theme.colors.error,
+      color: theme.colors.dangerText,
       textAlign: 'center',
       marginBottom: theme.spacing['2'],
     },

--- a/apps/mobileAppYC/src/features/documents/components/DocumentAttachmentsSection.tsx
+++ b/apps/mobileAppYC/src/features/documents/components/DocumentAttachmentsSection.tsx
@@ -289,7 +289,7 @@ const createStyles = (theme: any) =>
     errorText: {
       marginTop: theme.spacing['2'],
       ...theme.typography.labelXxsBold,
-      color: theme.colors.error,
+      color: theme.colors.dangerText,
     },
   });
 

--- a/apps/mobileAppYC/src/features/documents/components/DocumentForm/DocumentForm.tsx
+++ b/apps/mobileAppYC/src/features/documents/components/DocumentForm/DocumentForm.tsx
@@ -518,7 +518,7 @@ const createStyles = (theme: any) =>
     },
     errorText: {
       ...theme.typography.labelXxsBold,
-      color: theme.colors.error,
+      color: theme.colors.dangerText,
       marginTop: 3,
       marginBottom: theme.spacing['3'],
       marginLeft: theme.spacing['1'],

--- a/apps/mobileAppYC/src/features/documents/screens/EditDocumentScreen/EditDocumentScreen.tsx
+++ b/apps/mobileAppYC/src/features/documents/screens/EditDocumentScreen/EditDocumentScreen.tsx
@@ -262,7 +262,7 @@ export const EditDocumentScreen: React.FC = () => {
           onBack={() => navigation.goBack()}
         />
         <View style={styles.errorContainer}>
-          <Text style={[styles.errorMessage, {color: theme.colors.error}]}>
+          <Text style={[styles.errorMessage, {color: theme.colors.dangerText}]}>
             Document not found
           </Text>
         </View>
@@ -354,6 +354,6 @@ const createStyles = (theme: any) =>
     },
     errorMessage: {
       ...theme.typography.body,
-      color: theme.colors.error,
+      color: theme.colors.dangerText,
     },
   });

--- a/apps/mobileAppYC/src/features/legal/screens/OrganisationDocumentScreen.tsx
+++ b/apps/mobileAppYC/src/features/legal/screens/OrganisationDocumentScreen.tsx
@@ -567,7 +567,7 @@ const createStyles = (theme: any) =>
     },
     acknowledgeErrorText: {
       ...theme.typography.subtitleRegular14,
-      color: theme.colors.danger,
+      color: theme.colors.dangerText,
       textAlign: 'center',
       paddingHorizontal: theme.spacing['5'],
       marginTop: -theme.spacing['3'],

--- a/apps/mobileAppYC/src/features/legal/styles/legalStyles.ts
+++ b/apps/mobileAppYC/src/features/legal/styles/legalStyles.ts
@@ -143,7 +143,7 @@ export const createLegalStyles = (theme: any) =>
     },
     formErrorText: {
       ...theme.typography.labelXxsBold,
-      color: theme.colors.error,
+      color: theme.colors.dangerText,
       marginTop: theme.spacing['1'],
       marginBottom: theme.spacing['1'],
     },

--- a/apps/mobileAppYC/src/features/merck/components/MerckSearchWidget.tsx
+++ b/apps/mobileAppYC/src/features/merck/components/MerckSearchWidget.tsx
@@ -1186,7 +1186,7 @@ const createStyles = (theme: any) =>
     },
     errorText: {
       ...theme.typography.body12,
-      color: theme.colors.error,
+      color: theme.colors.dangerText,
       marginTop: theme.spacing['1'],
     },
     emptyText: {

--- a/apps/mobileAppYC/src/features/passport/components/passportStyles.ts
+++ b/apps/mobileAppYC/src/features/passport/components/passportStyles.ts
@@ -18,7 +18,7 @@ export const createPassportStyles = (theme: any) =>
     },
     errorText: {
       ...theme.typography.bodyMedium,
-      color: theme.colors.error,
+      color: theme.colors.dangerText,
       textAlign: 'center',
     },
     emptyText: {

--- a/apps/mobileAppYC/src/features/support/screens/ContactUsScreen.tsx
+++ b/apps/mobileAppYC/src/features/support/screens/ContactUsScreen.tsx
@@ -1282,7 +1282,7 @@ const createStyles = (theme: any) =>
     },
     errorText: {
       ...theme.typography.labelXxsBold,
-      color: theme.colors.danger,
+      color: theme.colors.dangerText,
       marginTop: 3,
       marginBottom: theme.spacing['3'],
       marginLeft: theme.spacing['1'],

--- a/apps/mobileAppYC/src/features/tasks/components/CommonTaskFields/CommonTaskFields.tsx
+++ b/apps/mobileAppYC/src/features/tasks/components/CommonTaskFields/CommonTaskFields.tsx
@@ -132,7 +132,7 @@ const createStyles = (theme: any) =>
     },
     errorText: {
       ...theme.typography.labelXxsBold,
-      color: theme.colors.error,
+      color: theme.colors.dangerText,
       marginTop: 3,
       marginBottom: theme.spacing['3'],
       marginLeft: theme.spacing['1'],

--- a/apps/mobileAppYC/src/features/tasks/screens/ObservationalToolPreviewScreen/ObservationalToolPreviewScreen.tsx
+++ b/apps/mobileAppYC/src/features/tasks/screens/ObservationalToolPreviewScreen/ObservationalToolPreviewScreen.tsx
@@ -394,7 +394,7 @@ const createStyles = (theme: any) =>
     },
     errorText: {
       ...theme.typography.body14,
-      color: theme.colors.error,
+      color: theme.colors.dangerText,
     },
     glassFallback: {
       backgroundColor: theme.colors.screen,

--- a/apps/mobileAppYC/src/features/tasks/screens/ObservationalToolScreen/ObservationalToolScreen.tsx
+++ b/apps/mobileAppYC/src/features/tasks/screens/ObservationalToolScreen/ObservationalToolScreen.tsx
@@ -1273,7 +1273,7 @@ const createStyles = (theme: any) => {
     },
     errorText: {
       ...theme.typography.bodyMedium,
-      color: theme.colors.error,
+      color: theme.colors.dangerText,
     },
     introCard: {
       gap: theme.spacing['3'],
@@ -1439,7 +1439,7 @@ const createStyles = (theme: any) => {
     },
     validationText: {
       ...theme.typography.captionBoldSatoshi,
-      color: theme.colors.error,
+      color: theme.colors.dangerText,
     },
     emptyStateCard: {
       alignItems: 'center',

--- a/apps/mobileAppYC/src/features/tasks/screens/TaskViewScreen/TaskViewScreen.tsx
+++ b/apps/mobileAppYC/src/features/tasks/screens/TaskViewScreen/TaskViewScreen.tsx
@@ -1138,7 +1138,7 @@ const createStyles = (theme: any) => {
     // Error styles - matching DocumentForm
     errorText: {
       ...theme.typography.labelXxsBold,
-      color: theme.colors.error,
+      color: theme.colors.dangerText,
       marginTop: theme.spacing['1'],
       marginBottom: theme.spacing['3'],
       marginLeft: theme.spacing['1'],
@@ -1167,7 +1167,7 @@ const createStyles = (theme: any) => {
     },
     cancelledText: {
       ...theme.typography.bodyMedium,
-      color: theme.colors.error,
+      color: theme.colors.dangerText,
       fontWeight: '600',
     },
     completeButtonContainer: {
@@ -1204,7 +1204,7 @@ const createStyles = (theme: any) => {
     },
     errorContainerText: {
       ...theme.typography.bodyMedium,
-      color: theme.colors.error,
+      color: theme.colors.dangerText,
     },
   });
 };

--- a/apps/mobileAppYC/src/shared/components/common/Checkbox/Checkbox.tsx
+++ b/apps/mobileAppYC/src/shared/components/common/Checkbox/Checkbox.tsx
@@ -85,7 +85,7 @@ const createStyles = (theme: any) =>
       flex: 1,
     },
     errorText: {
-      color: theme.colors.error,
+      color: theme.colors.dangerText,
       ...theme.typography.bodySmall,
       marginTop: theme.spacing['1'],
       marginLeft: theme.spacing['7'],

--- a/apps/mobileAppYC/src/shared/components/common/ConfirmActionBottomSheet/ConfirmActionBottomSheet.tsx
+++ b/apps/mobileAppYC/src/shared/components/common/ConfirmActionBottomSheet/ConfirmActionBottomSheet.tsx
@@ -238,7 +238,7 @@ export const ConfirmActionBottomSheet = ({
                 <Ionicons
                   name={destructiveIcon}
                   size={24}
-                  color={theme.colors.danger}
+                  color={theme.colors.dangerText}
                 />
               </View>
               <Text style={styles.destructiveTitle} numberOfLines={2}>

--- a/apps/mobileAppYC/src/shared/components/common/ErrorBoundary/ErrorBoundary.tsx
+++ b/apps/mobileAppYC/src/shared/components/common/ErrorBoundary/ErrorBoundary.tsx
@@ -150,12 +150,12 @@ const createStyles = (theme: any) =>
     },
     errorTitle: {
       ...theme.typography.labelSmBold,
-      color: theme.colors.error,
+      color: theme.colors.dangerText,
       marginBottom: theme.spacing['2'],
     },
     errorText: {
       ...theme.typography.labelXs,
-      color: theme.colors.error,
+      color: theme.colors.dangerText,
       marginBottom: theme.spacing['2'],
     },
     stackText: {

--- a/apps/mobileAppYC/src/shared/components/common/OTPInput/OTPInput.tsx
+++ b/apps/mobileAppYC/src/shared/components/common/OTPInput/OTPInput.tsx
@@ -149,7 +149,7 @@ export const OTPInput: React.FC<OTPInputProps> = ({
         })}
       </View>
       {error && (
-        <Text style={[styles.errorText, {color: theme.colors.error}]}>
+        <Text style={[styles.errorText, {color: theme.colors.dangerText}]}>
           {error}
         </Text>
       )}

--- a/apps/mobileAppYC/src/shared/components/common/shared/floatingLabelStyles.ts
+++ b/apps/mobileAppYC/src/shared/components/common/shared/floatingLabelStyles.ts
@@ -28,7 +28,7 @@ export const getInputLabelStyle = (theme: Theme): TextStyle => ({
 
 export const getInputErrorStyle = (theme: Theme): TextStyle => ({
   ...theme.typography.labelXxsBold,
-  color: theme.colors.error,
+  color: theme.colors.dangerText,
   marginTop: theme.spacing['1'],
   marginBottom: theme.spacing['3'],
   marginLeft: theme.spacing['1'],

--- a/apps/mobileAppYC/src/shared/utils/formScreenStyles.ts
+++ b/apps/mobileAppYC/src/shared/utils/formScreenStyles.ts
@@ -68,14 +68,14 @@ export const createFormScreenStyles = (theme: Theme) =>
     },
     errorText: {
       ...theme.typography.labelXxsBold,
-      color: theme.colors.error,
+      color: theme.colors.dangerText,
       marginTop: theme.spacing['1'],
       marginBottom: theme.spacing['3'],
       marginLeft: theme.spacing['1'],
     },
     submissionError: {
       ...theme.typography.paragraphBold,
-      color: theme.colors.error,
+      color: theme.colors.dangerText,
       textAlign: 'center',
       paddingHorizontal: theme.spacing['5'],
       marginBottom: theme.spacing['2'],

--- a/apps/mobileAppYC/src/shared/utils/formStyles.ts
+++ b/apps/mobileAppYC/src/shared/utils/formStyles.ts
@@ -85,7 +85,7 @@ export const createFormStyles = (theme: Theme) => ({
   // Error text styling
   errorText: {
     ...theme.typography.labelXxsBold,
-    color: theme.colors.error,
+    color: theme.colors.dangerText,
     marginTop: theme.spacing['1'],
     marginBottom: theme.spacing['3'],
     marginLeft: theme.spacing['1'],

--- a/apps/mobileAppYC/src/shared/utils/screenStyles.ts
+++ b/apps/mobileAppYC/src/shared/utils/screenStyles.ts
@@ -38,7 +38,7 @@ export const createErrorContainerStyles = (theme: any) => ({
   },
   errorText: {
     ...theme.typography.bodyLarge,
-    color: theme.colors.error,
+    color: theme.colors.dangerText,
     textAlign: 'center' as const,
   },
 });

--- a/apps/mobileAppYC/src/theme/colors.ts
+++ b/apps/mobileAppYC/src/theme/colors.ts
@@ -41,7 +41,18 @@ const palette = {
   successSurface: ['rgba(0, 143, 93, 0.12)', 'rgba(74, 205, 155, 0.16)'],
   warning: ['#FF9800', '#FF9800'],
   warningSurface: ['rgba(255, 152, 0, 0.12)', 'rgba(255, 152, 0, 0.18)'],
+  /**
+   * `danger` is the FILL: destructive button backgrounds and the error border,
+   * where white sits on top of it. Do not use it for text - #EA3729 measures
+   * 3.74:1 on bone and 3.55:1 on espresso, under the 4.5:1 body-text bar in
+   * BOTH themes, so error copy was failing everywhere and not only in dark.
+   *
+   * Use `dangerText` for error copy. One value cannot serve both roles: making
+   * the red light enough to read on espresso drops white-on-red below 3.1:1 on
+   * the destructive button, so the roles are split rather than the value moved.
+   */
   danger: ['#EA3729', '#EA3729'],
+  dangerText: ['#D52315', '#EF6257'],
   dangerSurface: ['#FDEBEA', 'rgba(234, 55, 41, 0.16)'],
   error: ['#EA3729', '#EA3729'],
   errorSurface: ['#FDEBEA', 'rgba(234, 55, 41, 0.16)'],


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

Found by triggering the sign-in validation error on a simulator in dark mode. The error copy measured **3.55:1** on espresso, under the 4.5:1 body-text bar.

Measuring the token explains why - `danger` and `error` are both `['#EA3729', '#EA3729']`, the **same value in both themes**, never adapted for dark.

And it is not only a dark-mode problem:

| | on bone | on espresso |
|---|---|---|
| `#EA3729` | **3.74:1** | **3.55:1** |

Error copy has been under the bar in **both** themes.

## Why one value cannot fix it

The token does two jobs. Lightening the red enough to read on espresso (`#EF6257`, 4.58:1) drops white-on-red to ~3.0:1 on the destructive button; darkening it enough for bone does the same in reverse. So the roles are split rather than the value moved:

| token | role | value | measures |
|---|---|---|---|
| `danger` | **fill** - destructive backgrounds, error border, icon tints | `#EA3729` (unchanged) | white-on-red 4.14:1; clears the 3:1 icon bar both themes |
| `dangerText` | **error copy** | `['#D52315', '#EF6257']` | 4.65:1 on bone, 4.58:1 on espresso |

## What moved

- **40 text call sites** to `dangerText` - 38 `color:` and **2 `textColor:` props** that my first pass missed because the property name does not start with "color"
- **18 fill, border and icon-tint uses correctly stay** on `danger`

`appointmentStatus.ts` declares its own narrow `AppointmentTheme` rather than using `ColorTokens`, so `dangerText` had to be added there too. Worth knowing: that file will need touching again for any future token split.

13 tests pinned the old token and were updated, plus `dangerText` added to the shared `mockTheme`.

## Validation

- `npx tsc --noEmit` - 0 errors
- `npx eslint src` - 0 errors, 0 warnings
- `npx jest` - 461 suites / 7556 tests, 0 failures

## Related Issue(s)

Part of #2364.
