### PR TITLE
fix(mobile): darken blueText and stop fill tokens carrying link text

### DIFF
--- a/apps/mobileAppYC/__tests__/features/appointments/utils/appointmentStatus.test.ts
+++ b/apps/mobileAppYC/__tests__/features/appointments/utils/appointmentStatus.test.ts
@@ -12,6 +12,7 @@ const mockTheme = {
   colors: {
     secondary: '#secondary',
     primary: '#primary',
+    blueText: '#blueText',
     primaryTint: '#primaryTint',
     success: '#success',
     successSurface: '#successSurface',
@@ -318,7 +319,7 @@ describe('getAppointmentStatusBadgePalette', () => {
       'REQUESTED',
       null,
     );
-    expect(result.textColor).toBe('#primary');
+    expect(result.textColor).toBe('#blueText');
     expect(result.backgroundColor).toBe('#primaryTint');
   });
 

--- a/apps/mobileAppYC/__tests__/screens/__snapshots__/EmptyScreens.snapshot.test.tsx.snap
+++ b/apps/mobileAppYC/__tests__/screens/__snapshots__/EmptyScreens.snapshot.test.tsx.snap
@@ -146,7 +146,7 @@ exports[`Empty Screen Snapshots EmptyDocumentsScreen should render correctly 1`]
       >
         <Text
           accessibilityLabel="folder-open-outline"
-          color="#257BED"
+          color="#1162CE"
           size={44}
           testID="icon-folder-open-outline"
         >

--- a/apps/mobileAppYC/__tests__/screens/__snapshots__/PlaceholderScreens.snapshot.test.tsx.snap
+++ b/apps/mobileAppYC/__tests__/screens/__snapshots__/PlaceholderScreens.snapshot.test.tsx.snap
@@ -199,7 +199,7 @@ exports[`Placeholder Screens Snapshots TasksMainScreen should render correctly 1
       >
         <Text
           accessibilityLabel="checkbox-outline"
-          color="#257BED"
+          color="#1162CE"
           size={42}
           testID="icon-checkbox-outline"
         >

--- a/apps/mobileAppYC/__tests__/setup/mockTheme.ts
+++ b/apps/mobileAppYC/__tests__/setup/mockTheme.ts
@@ -546,7 +546,7 @@ export const createMockTheme = () => ({
   },
   colors: {
     // Matches the actual theme colors from src/theme/colors.ts
-    primary: '#247AED',
+    primary: '#257BED',
     primaryDark: '#E55A2B',
     primaryLight: '#FF8A65',
     primaryGlass: 'rgba(36, 122, 237, 0.92)',
@@ -561,7 +561,7 @@ export const createMockTheme = () => ({
     surface: '#FFFFFF',
     text: '#302F2E',
     textSecondary: '#747473',
-    textTertiary: '#247AED',
+    textTertiary: '#257BED',
     onPrimary: '#FEF8F4',
     border: '#EAEAEA',
     borderMuted: 'rgba(234, 234, 234, 0.9)',

--- a/apps/mobileAppYC/src/features/account/components/DeleteAccountBottomSheet.tsx
+++ b/apps/mobileAppYC/src/features/account/components/DeleteAccountBottomSheet.tsx
@@ -190,7 +190,7 @@ const createStyles = (theme: any) =>
     },
     noteLabel: {
       ...theme.typography.inputLabel,
-      color: theme.colors.primary,
+      color: theme.colors.blueText,
       textAlign: 'left',
     },
     noteBody: {

--- a/apps/mobileAppYC/src/features/appointments/components/BookingSummaryCard/BookingSummaryCard.tsx
+++ b/apps/mobileAppYC/src/features/appointments/components/BookingSummaryCard/BookingSummaryCard.tsx
@@ -208,7 +208,7 @@ const createStyles = (theme: any) =>
     },
     badgeText: {
       ...theme.typography.subtitleBold14,
-      color: theme.colors.primary,
+      color: theme.colors.blueText,
     },
   });
 

--- a/apps/mobileAppYC/src/features/appointments/components/CalendarMonthStrip/CalendarMonthStrip.tsx
+++ b/apps/mobileAppYC/src/features/appointments/components/CalendarMonthStrip/CalendarMonthStrip.tsx
@@ -226,13 +226,13 @@ const createStyles = (theme: any) =>
       marginBottom: theme.spacing['1'],
       textAlign: 'center',
     },
-    dateDaySelected: {color: theme.colors.primary, fontWeight: '500'},
+    dateDaySelected: {color: theme.colors.blueText, fontWeight: '500'},
     dateNumber: {
       ...theme.typography.h6Clash,
       color: theme.colors.textSecondary,
       textAlign: 'center',
     },
-    dateNumberSelected: {color: theme.colors.primary, fontWeight: '500'},
+    dateNumberSelected: {color: theme.colors.blueText, fontWeight: '500'},
     marker: {
       position: 'absolute',
       bottom: 6,

--- a/apps/mobileAppYC/src/features/appointments/components/CalendarRow/CalendarRow.tsx
+++ b/apps/mobileAppYC/src/features/appointments/components/CalendarRow/CalendarRow.tsx
@@ -110,7 +110,7 @@ const createStyles = (theme: any) =>
     },
     dayToday: {},
     dayText: {...theme.typography.caption, color: theme.colors.textSecondary},
-    dayTextActive: {color: theme.colors.primary},
+    dayTextActive: {color: theme.colors.blueText},
     dayNum: {...theme.typography.labelXxsBold, color: theme.colors.text},
   });
 

--- a/apps/mobileAppYC/src/features/appointments/components/accordionSectionStyles.ts
+++ b/apps/mobileAppYC/src/features/appointments/components/accordionSectionStyles.ts
@@ -49,7 +49,7 @@ export const createAccordionSectionStyles = (theme: any) => ({
   },
   chipText: {
     ...theme.typography.subtitleBold12,
-    color: theme.colors.primary,
+    color: theme.colors.blueText,
   },
   selectButton: {
     width: '100%' as const,

--- a/apps/mobileAppYC/src/features/appointments/screens/BookingFormScreen.tsx
+++ b/apps/mobileAppYC/src/features/appointments/screens/BookingFormScreen.tsx
@@ -92,7 +92,7 @@ export const BookingFormScreen: React.FC = () => {
     (business?.name ?? '').trim().length > 0 ? business?.name : 'the clinic';
   const linkStyle = {
     ...theme.typography.paragraphBold,
-    color: theme.colors.primary,
+    color: theme.colors.blueText,
   };
   const {
     handleOpenTerms: handleOpenAppTerms,

--- a/apps/mobileAppYC/src/features/appointments/screens/EditAppointmentScreen.tsx
+++ b/apps/mobileAppYC/src/features/appointments/screens/EditAppointmentScreen.tsx
@@ -460,7 +460,7 @@ export const EditAppointmentScreen: React.FC = () => {
   const agreements = useMemo(() => {
     const linkStyle = {
       ...theme.typography.paragraphBold,
-      color: theme.colors.primary,
+      color: theme.colors.blueText,
     };
     return buildAgreements({
       businessDisplayName,
@@ -479,7 +479,7 @@ export const EditAppointmentScreen: React.FC = () => {
     openBusinessPrivacy,
     openBusinessTerms,
     theme.typography.paragraphBold,
-    theme.colors.primary,
+    theme.colors.blueText,
   ]);
   const submitLabel = getRescheduleButtonLabel();
   const submitState = getRescheduleButtonState({

--- a/apps/mobileAppYC/src/features/appointments/utils/appointmentStatus.ts
+++ b/apps/mobileAppYC/src/features/appointments/utils/appointmentStatus.ts
@@ -125,6 +125,7 @@ type AppointmentTheme = {
     secondary: string;
     primary: string;
     primaryTint: string;
+    blueText: string;
     success: string;
     successSurface: string;
     warning: string;
@@ -194,7 +195,7 @@ export const getAppointmentStatusBadgePalette = (
     case 'REQUESTED':
       return {
         text: label,
-        textColor: theme.colors.primary,
+        textColor: theme.colors.blueText,
         backgroundColor: theme.colors.primaryTint,
       };
     case 'RESCHEDULED':

--- a/apps/mobileAppYC/src/features/coParent/screens/EditCoParentScreen/EditCoParentScreen.tsx
+++ b/apps/mobileAppYC/src/features/coParent/screens/EditCoParentScreen/EditCoParentScreen.tsx
@@ -791,7 +791,7 @@ const createStyles = (theme: any) =>
       textAlign: 'justify',
     },
     noteLabel: {
-      color: theme.colors.primary,
+      color: theme.colors.blueText,
     },
     noteMessage: {
       color: theme.colors.placeholder,

--- a/apps/mobileAppYC/src/features/documents/components/DocumentForm/DocumentForm.tsx
+++ b/apps/mobileAppYC/src/features/documents/components/DocumentForm/DocumentForm.tsx
@@ -532,7 +532,7 @@ const createStyles = (theme: any) =>
       textAlign: 'justify',
     },
     noteLabel: {
-      color: theme.colors.primary,
+      color: theme.colors.blueText,
     },
     noteMessage: {
       color: theme.colors.placeholder,

--- a/apps/mobileAppYC/src/features/expenses/screens/ExpensePreviewScreen/ExpensePreviewScreen.tsx
+++ b/apps/mobileAppYC/src/features/expenses/screens/ExpensePreviewScreen/ExpensePreviewScreen.tsx
@@ -118,7 +118,7 @@ const PaymentActions = ({
     <View style={styles.paymentButtonContainer}>
       {loadingPayment ? (
         <View style={styles.loadingContainer}>
-          <ActivityIndicator size="small" color={theme.colors.primary} />
+          <ActivityIndicator size="small" color={theme.colors.blueText} />
         </View>
       ) : (
         <LiquidGlassButton
@@ -411,7 +411,7 @@ export const ExpensePreviewScreen: React.FC = () => {
     badges.push({
       text: 'External expense',
       backgroundColor: theme.colors.infoSurface,
-      textColor: theme.colors.primary,
+      textColor: theme.colors.blueText,
     });
   } else if (isPendingPayment) {
     badges.push({

--- a/apps/mobileAppYC/src/features/home/screens/HomeScreen/HomeScreen.tsx
+++ b/apps/mobileAppYC/src/features/home/screens/HomeScreen/HomeScreen.tsx
@@ -1818,7 +1818,7 @@ const createStyles = (theme: any) =>
 
     viewMoreText: {
       ...theme.typography.labelXxsBold,
-      color: theme.colors.primary,
+      color: theme.colors.blueText,
     },
     viewMoreButton: {
       alignSelf: 'flex-start',
@@ -1873,6 +1873,6 @@ const createStyles = (theme: any) =>
     },
     requestedBadgeText: {
       ...theme.typography.labelSmallBold,
-      color: theme.colors.primary,
+      color: theme.colors.blueText,
     },
   });

--- a/apps/mobileAppYC/src/features/legal/screens/OrganisationDocumentScreen.tsx
+++ b/apps/mobileAppYC/src/features/legal/screens/OrganisationDocumentScreen.tsx
@@ -238,7 +238,7 @@ export const OrganisationDocumentScreen: React.FC<Props> = ({
   if (loading) {
     stateContent = (
       <View style={[styles.statusCard, styles.centerContent]}>
-        <ActivityIndicator size="small" color={theme.colors.primary} />
+        <ActivityIndicator size="small" color={theme.colors.blueText} />
         <Text style={styles.statusTitle}>
           Loading {baseTitle.toLowerCase()}…
         </Text>

--- a/apps/mobileAppYC/src/features/linkedBusinesses/components/CompanionProfileImage.tsx
+++ b/apps/mobileAppYC/src/features/linkedBusinesses/components/CompanionProfileImage.tsx
@@ -96,7 +96,7 @@ const createStyles = (theme: any) =>
     },
     avatarInitial: {
       ...theme.typography.h4,
-      color: theme.colors.primary,
+      color: theme.colors.blueText,
     },
     profileName: {
       ...theme.typography.h4,

--- a/apps/mobileAppYC/src/features/payments/screens/PaymentInvoiceScreen.tsx
+++ b/apps/mobileAppYC/src/features/payments/screens/PaymentInvoiceScreen.tsx
@@ -1294,7 +1294,7 @@ const buildInvoiceContent = ({
   if (shouldShowLoadingNotice) {
     return (
       <View style={styles.loadingBox}>
-        <ActivityIndicator size="small" color={theme.colors.primary} />
+        <ActivityIndicator size="small" color={theme.colors.blueText} />
         <Text style={styles.loadingText}>
           {getLocalizedText(
             'payments.preparingPaymentDetails',
@@ -1907,7 +1907,7 @@ const createStyles = (theme: any) =>
     },
     missingBadgeText: {
       ...theme.typography.labelXxsBold,
-      color: theme.colors.primary,
+      color: theme.colors.blueText,
     },
     missingTitle: {
       ...theme.typography.h4,

--- a/apps/mobileAppYC/src/features/support/screens/ContactUsScreen.tsx
+++ b/apps/mobileAppYC/src/features/support/screens/ContactUsScreen.tsx
@@ -1319,7 +1319,7 @@ const createStyles = (theme: any) =>
     },
     uploadLabel: {
       ...theme.typography.labelSmall,
-      color: theme.colors.primary,
+      color: theme.colors.blueText,
     },
     button: {
       width: '100%',

--- a/apps/mobileAppYC/src/features/tasks/components/AssignTaskBottomSheet/AssignTaskBottomSheet.tsx
+++ b/apps/mobileAppYC/src/features/tasks/components/AssignTaskBottomSheet/AssignTaskBottomSheet.tsx
@@ -157,7 +157,7 @@ export const AssignTaskBottomSheet = ({
     const avatarTextStyle = {
       ...theme.typography.bodyLarge,
       fontWeight: '700' as const,
-      color: theme.colors.primary,
+      color: theme.colors.blueText,
     };
     const nameTextStyle = {
       ...theme.typography.bodyMedium,

--- a/apps/mobileAppYC/src/features/tasks/components/CalendarSyncBottomSheet/CalendarSyncBottomSheet.tsx
+++ b/apps/mobileAppYC/src/features/tasks/components/CalendarSyncBottomSheet/CalendarSyncBottomSheet.tsx
@@ -198,7 +198,7 @@ export const CalendarSyncBottomSheet = ({
     };
     const statusTextStyle = {
       ...theme.typography.labelSmall,
-      color: theme.colors.primary,
+      color: theme.colors.blueText,
       fontStyle: 'italic' as const,
       marginTop: theme.spacing['1'],
     };

--- a/apps/mobileAppYC/src/features/tasks/components/shared/TaskMonthDateSelector.tsx
+++ b/apps/mobileAppYC/src/features/tasks/components/shared/TaskMonthDateSelector.tsx
@@ -269,7 +269,7 @@ const createStyles = (theme: any) =>
       textAlign: 'center',
     },
     dayNameSelected: {
-      color: theme.colors.primary,
+      color: theme.colors.blueText,
       fontWeight: '500',
     },
     dayNameToday: {
@@ -284,12 +284,12 @@ const createStyles = (theme: any) =>
       textAlign: 'center',
     },
     dayNumberSelected: {
-      color: theme.colors.primary,
+      color: theme.colors.blueText,
       fontWeight: '500',
     },
     dayNumberToday: {
       fontWeight: '500',
-      color: theme.colors.primary,
+      color: theme.colors.blueText,
     },
     dayNumberDisabled: {
       color: theme.colors.textSecondary,

--- a/apps/mobileAppYC/src/features/tasks/screens/ObservationalToolScreen/ObservationalToolScreen.tsx
+++ b/apps/mobileAppYC/src/features/tasks/screens/ObservationalToolScreen/ObservationalToolScreen.tsx
@@ -1411,7 +1411,7 @@ const createStyles = (theme: any) => {
       borderRadius: theme.borderRadius.full,
       backgroundColor: theme.colors.primaryTint,
       ...theme.typography.labelXxsBold,
-      color: theme.colors.primary,
+      color: theme.colors.blueText,
     },
     providerSubtitle: {
       ...theme.typography.body12,

--- a/apps/mobileAppYC/src/shared/components/common/AppointmentCard/AppointmentCard.tsx
+++ b/apps/mobileAppYC/src/shared/components/common/AppointmentCard/AppointmentCard.tsx
@@ -276,7 +276,7 @@ const createStyles = (theme: any) =>
     note: {...theme.typography.labelSmall, color: theme.colors.placeholder},
     noteLabel: {
       ...theme.typography.labelSmallBold,
-      color: theme.colors.primary,
+      color: theme.colors.blueText,
     },
     buttonContainer: {gap: theme.spacing['4']}, // Reduced gap to bring sections closer
     inlineButtons: {

--- a/apps/mobileAppYC/src/shared/components/common/AvatarGroup/AvatarGroup.tsx
+++ b/apps/mobileAppYC/src/shared/components/common/AvatarGroup/AvatarGroup.tsx
@@ -169,7 +169,7 @@ const createStyles = (
     },
     avatarInitial: {
       ...theme.typography.titleSmall,
-      color: theme.colors.primary,
+      color: theme.colors.blueText,
       fontWeight: '700',
     },
     avatarFirst: {

--- a/apps/mobileAppYC/src/shared/components/common/CompanionSelector/CompanionSelector.tsx
+++ b/apps/mobileAppYC/src/shared/components/common/CompanionSelector/CompanionSelector.tsx
@@ -317,7 +317,7 @@ const createStyles = (theme: any) =>
     },
     companionAvatarInitial: {
       ...theme.typography.titleMedium,
-      color: theme.colors.primary,
+      color: theme.colors.blueText,
       fontWeight: '700',
     },
     companionName: {
@@ -328,7 +328,7 @@ const createStyles = (theme: any) =>
     },
     companionMeta: {
       ...theme.typography.labelXxsBold,
-      color: theme.colors.primary,
+      color: theme.colors.blueText,
     },
     addCompanionItem: {
       alignItems: 'center',
@@ -356,7 +356,7 @@ const createStyles = (theme: any) =>
     },
     addCompanionLabel: {
       ...theme.typography.labelXxsBold,
-      color: theme.colors.primary,
+      color: theme.colors.blueText,
       textAlign: 'center',
     },
   });

--- a/apps/mobileAppYC/src/shared/components/common/PillSelector/PillSelector.tsx
+++ b/apps/mobileAppYC/src/shared/components/common/PillSelector/PillSelector.tsx
@@ -212,7 +212,7 @@ const createStyles = (theme: any, pillSpacing?: number) =>
       textAlign: 'center',
     },
     pillTextActive: {
-      color: theme.colors.primary,
+      color: theme.colors.blueText,
     },
     badge: {
       minWidth: 20,

--- a/apps/mobileAppYC/src/shared/components/common/ProfileImagePicker/ProfileImagePicker.tsx
+++ b/apps/mobileAppYC/src/shared/components/common/ProfileImagePicker/ProfileImagePicker.tsx
@@ -331,7 +331,7 @@ export const ProfileImagePicker = ({
           <View style={styles.placeholderContainer}>
             {fallbackText ? (
               <Text
-                style={[styles.fallbackText, {color: theme.colors.primary}]}>
+                style={[styles.fallbackText, {color: theme.colors.blueText}]}>
                 {fallbackText}
               </Text>
             ) : (

--- a/apps/mobileAppYC/src/shared/components/common/TileSelector/TileSelector.tsx
+++ b/apps/mobileAppYC/src/shared/components/common/TileSelector/TileSelector.tsx
@@ -92,7 +92,7 @@ const createStyles = (theme: any) =>
       fontWeight: '500',
     },
     labelSelected: {
-      color: theme.colors.primary,
+      color: theme.colors.blueText,
       fontWeight: '600',
     },
   });

--- a/apps/mobileAppYC/src/shared/components/common/ViewMoreButton/ViewMoreButton.tsx
+++ b/apps/mobileAppYC/src/shared/components/common/ViewMoreButton/ViewMoreButton.tsx
@@ -55,6 +55,6 @@ const createStyles = (theme: any) =>
     },
     text: {
       ...theme.typography.labelXxsBold,
-      color: theme.colors.primary,
+      color: theme.colors.blueText,
     },
   });

--- a/apps/mobileAppYC/src/shared/components/forms/AddressFields.tsx
+++ b/apps/mobileAppYC/src/shared/components/forms/AddressFields.tsx
@@ -105,7 +105,7 @@ export const AddressFields: React.FC<AddressFieldsProps> = ({
                   <View style={styles.suggestionLoader}>
                     <ActivityIndicator
                       size="small"
-                      color={theme.colors.primary}
+                      color={theme.colors.blueText}
                     />
                   </View>
                 );

--- a/apps/mobileAppYC/src/shared/utils/formStyles.ts
+++ b/apps/mobileAppYC/src/shared/utils/formStyles.ts
@@ -78,7 +78,7 @@ export const createFormStyles = (theme: Theme) => ({
 
   // Reminder pill text when selected
   reminderPillTextSelected: {
-    color: theme.colors.primary,
+    color: theme.colors.blueText,
     fontWeight: '600',
   } as TextStyle,
 

--- a/apps/mobileAppYC/src/theme/colors.ts
+++ b/apps/mobileAppYC/src/theme/colors.ts
@@ -15,7 +15,15 @@ type ColorPair = readonly [light: string, dark: string];
 const palette = {
   // --- Interactive accents (blue = interaction, pink = companion) ---
   blue: ['#257BED', '#257BED'],
-  blueText: ['#257BED', '#8FB6F5'],
+  /**
+   * Blue as TEXT. `blue` / `primary` are the FILL - links, focus rings and
+   * active nav painted as a surface - and at #257BED they measure only 3.70:1
+   * on bone, under the 4.5:1 body-text bar. The espresso value was already
+   * fine (7.12:1); it was the light one that had been left equal to the fill.
+   *
+   * Do not use `blue` or `primary` for text. Use this.
+   */
+  blueText: ['#1162CE', '#8FB6F5'],
   blueSoft: ['#E6F2FF', 'rgba(143, 182, 245, 0.16)'],
   navActive: ['#1657C9', '#8FB6F5'],
   navActiveBg: ['rgba(37, 123, 237, 0.11)', 'rgba(143, 182, 245, 0.13)'],


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

Third instance of the same shape, after the ink ramp (#2407) and danger (#2410): **a token that reads fine on espresso and fails on bone.**

`blueText` was `['#257BED', '#8FB6F5']`. The espresso value was already right at 7.12:1; the light value had simply been left equal to `blue` - the **fill** - and measures **3.70:1** on bone, under the 4.5:1 body-text bar.

Links, *Add photo*, *Why we ask for age verification* and 48 other places were below it.

## What is the new behavior?

| | before | after |
|---|---|---|
| light | `#257BED` 3.70:1 | `#1162CE` **5.18:1** |
| dark | `#8FB6F5` 7.12:1 | unchanged |

Chosen with headroom rather than sitting exactly on the bar.

**37 text call sites were reading `primary` or `blue` directly** - the fill tokens - and moved to `blueText`. Those two stay as fills for focus rings, active nav and surfaces, matching the design system, which calls blue *"the structural accent: links, focus, active nav"*.

## Two things worth recording

**`appointmentStatus.ts` needed `blueText` adding to its narrow `AppointmentTheme`** - exactly as predicted when `dangerText` went in. Any future token split will hit that file again; it is the one place that redeclares the palette instead of using `ColorTokens`.

**PillSelector and TileSelector tests were pinning `#247AED`** - the stale brand blue from the unbuilt design-tokens package that #2364 removed from source. The mocks were never updated, so those assertions had been comparing against a value the app stopped using. Refreshed to `#257BED`.

Two snapshots updated; the only delta is the blue.

## Validation

- `npx tsc --noEmit` - 0 errors
- `npx eslint src` - 0 errors, 0 warnings
- `npx jest` - 461 suites / 7556 tests, 0 failures

## Related Issue(s)

Part of #2364.