### PR TITLE
fix(mobile): stop forms judging a field before the user has left it

### DIFF
--- a/apps/mobileAppYC/src/features/auth/screens/CreateAccountScreen.tsx
+++ b/apps/mobileAppYC/src/features/auth/screens/CreateAccountScreen.tsx
@@ -256,7 +256,7 @@ export const CreateAccountScreen: React.FC<CreateAccountScreenProps> = ({
     control,
     handleSubmit,
     register,
-    formState: {errors},
+    formState: {errors, touchedFields},
     trigger,
     setValue,
     setError,
@@ -276,7 +276,12 @@ export const CreateAccountScreen: React.FC<CreateAccountScreenProps> = ({
       country: defaultAddressValues.country,
       acceptTerms: false,
     },
-    mode: 'onChange',
+    // onTouched, not onChange: validating every keystroke told people their
+    // own name "must be at least 2 characters" after the first letter. The
+    // field is judged when they leave it, and only then re-checked as they
+    // type, so a correction still updates live.
+    mode: 'onTouched',
+    reValidateMode: 'onChange',
   });
 
   useReactEffect(() => {
@@ -557,15 +562,19 @@ export const CreateAccountScreen: React.FC<CreateAccountScreenProps> = ({
   const handleStep1FieldChange = useCallback(
     (field: keyof typeof step1Data, value: any) => {
       setStep1Data(prev => ({...prev, [field]: value}));
-      setValue(field, value, {shouldValidate: true});
+      // Only re-validate a field the user has already left once. An
+      // unconditional shouldValidate re-introduces validate-on-every-keystroke
+      // and silently overrides the form's onTouched mode, which is what made
+      // the first letter of a name show "must be at least 2 characters".
+      setValue(field, value, {shouldValidate: Boolean(touchedFields[field])});
     },
-    [setValue],
+    [setValue, touchedFields],
   );
 
   const handleStep2FieldChange = useCallback(
     (field: keyof typeof step2Data, value: any) => {
       setStep2Data(prev => ({...prev, [field]: value}));
-      setValue(field, value, {shouldValidate: true});
+      setValue(field, value, {shouldValidate: Boolean(touchedFields[field])});
       if (
         field === 'address' ||
         field === 'stateProvince' ||
@@ -576,7 +585,7 @@ export const CreateAccountScreen: React.FC<CreateAccountScreenProps> = ({
         clearErrors(field);
       }
     },
-    [clearErrors, setValue],
+    [clearErrors, setValue, touchedFields],
   );
 
   const handleAddressFieldChange = useCallback(

--- a/apps/mobileAppYC/src/features/coParent/screens/AddCoParentScreen/AddCoParentScreen.tsx
+++ b/apps/mobileAppYC/src/features/coParent/screens/AddCoParentScreen/AddCoParentScreen.tsx
@@ -79,7 +79,12 @@ export const AddCoParentScreen: React.FC<Props> = ({navigation}) => {
       email: '',
       phoneNumber: '',
     },
-    mode: 'onChange',
+    // onTouched, not onChange: validating every keystroke told people their
+    // own name "must be at least 2 characters" after the first letter. The
+    // field is judged when they leave it, and only then re-checked as they
+    // type, so a correction still updates live.
+    mode: 'onTouched',
+    reValidateMode: 'onChange',
   });
 
   const handleSendInvite = useCallback(

--- a/apps/mobileAppYC/src/features/companion/screens/AddCompanionScreen.tsx
+++ b/apps/mobileAppYC/src/features/companion/screens/AddCompanionScreen.tsx
@@ -211,7 +211,12 @@ export const AddCompanionScreen: React.FC<AddCompanionScreenProps> = ({
       origin: null,
       profileImage: null,
     },
-    mode: 'onChange',
+    // onTouched, not onChange: validating every keystroke told people their
+    // own name "must be at least 2 characters" after the first letter. The
+    // field is judged when they leave it, and only then re-checked as they
+    // type, so a correction still updates live.
+    mode: 'onTouched',
+    reValidateMode: 'onChange',
   });
 
   const getFieldError = (field: keyof FormData) => errors[field]?.message;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

Typing the **first letter of your own name** into Create account produces *"First name must be at least 2 characters"*, in red, under the field. Every keystroke is validated, so the form tells people they are wrong while they are still answering.

Three forms ran `mode: 'onChange'` - Create account, Add co-parent, Add companion. **No form in the app used `onTouched` or `onBlur`.**

## What is the new behavior?

`mode: 'onTouched'` with `reValidateMode: 'onChange'` - a field is judged when the user leaves it, and only then re-checked as they type, so a correction still clears the error live.

## The part worth reading

**That change alone did nothing.** Both field-change handlers also call:

```ts
setValue(field, value, {shouldValidate: true})
```

An explicit `shouldValidate` **overrides the form's `mode` completely**, so the mode change was inert. I only caught it because I re-checked on the simulator and the error still fired on the first character - the code change looked correct and did nothing.

They now pass `shouldValidate: Boolean(touchedFields[field])`, so the two mechanisms agree instead of one silently defeating the other.

## Validation

- `npx tsc --noEmit` - 0 errors
- `npx eslint src` - 0 errors, 0 warnings
- `npx jest` - 462 suites / 7559 tests, 0 failures
- **Verified on an iPhone 15 Pro simulator**: typing one character now shows a focus ring and no error

## Related Issue(s)

Part of #2364.