### PR TITLE
fix(backend): harden fetchRemoteActor URL validation against SSRF

### DIFF
--- a/apps/backend/src/services/activitypub.service.ts
+++ b/apps/backend/src/services/activitypub.service.ts
@@ -146,6 +146,33 @@ export async function resolveWebFinger(resource: string) {
 const MAX_ACTOR_DOCUMENT_BYTES = 256 * 1024;
 
 /**
+ * Validate and normalise a remote actor URL before it is fetched or used to
+ * bind the fetched document's origin. Rejects anything that is not a plain
+ * http(s) URL and rejects path traversal sequences.
+ */
+function buildValidatedActorUrl(rawUrl: string): string {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new Error(`Invalid actor URL: ${rawUrl}`);
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error(`Invalid actor URL protocol: ${rawUrl}`);
+  }
+  // new URL() collapses path dot-segments (e.g. `/a/../b` becomes `/b`), so the
+  // normalised href would never expose a traversal sequence - we must inspect
+  // the raw pre-query string to reject it. The check is scoped to the path only:
+  // `/../` or a `%2e%2e` inside a query or fragment value is legitimate opaque
+  // data (e.g. `?next=/../page`) and must not cause an over-rejection.
+  const rawPath = rawUrl.split(/[?#]/, 1)[0];
+  if (rawPath.includes("/../") || /\/%2e%2e\//i.test(rawPath)) {
+    throw new Error(`Invalid actor URL path: ${rawUrl}`);
+  }
+  return url.href;
+}
+
+/**
  * `forceRefresh` bypasses the 24h cache. Needed because a remote instance that
  * rotates its ActivityPub signing key would otherwise have every signed request
  * rejected until the cached copy expired - see the retry in verifyInboundRequest.
@@ -162,7 +189,8 @@ export async function fetchRemoteActor(
     return cached;
   }
 
-  await assertPublicHttpsUrl(uri);
+  const validatedUri = buildValidatedActorUrl(uri);
+  await assertPublicHttpsUrl(validatedUri);
 
   const resp = await axios.get<{
     id: string;
@@ -171,7 +199,7 @@ export async function fetchRemoteActor(
     endpoints?: { sharedInbox?: string };
     publicKey: { id: string; publicKeyPem: string };
     "yc:licenseToken"?: string;
-  }>(uri, {
+  }>(validatedUri, {
     headers: { Accept: AP_CONTENT_TYPE },
     timeout: 10_000,
     maxRedirects: 0,
@@ -190,7 +218,7 @@ export async function fetchRemoteActor(
   // declare an id and key hosted on the same origin it is served from.
   // Without this, any public host could serve a document claiming another
   // instance's actor id (with its own key) and impersonate that instance.
-  const fetchedOrigin = new URL(uri).origin;
+  const fetchedOrigin = new URL(validatedUri).origin;
   let declaredActorOrigin: string;
   let declaredKeyOrigin: string;
   try {
@@ -208,7 +236,7 @@ export async function fetchRemoteActor(
     );
   }
 
-  const instanceHost = new URL(uri).host;
+  const instanceHost = new URL(validatedUri).host;
   const now = new Date();
 
   const remote = {

--- a/apps/backend/test/services/activitypub.service.test.ts
+++ b/apps/backend/test/services/activitypub.service.test.ts
@@ -439,6 +439,52 @@ describe("fetchRemoteActor", () => {
       /malformed id or key/,
     );
   });
+
+  it("rejects dot-segments in the path before any network call", async () => {
+    prisma.aPRemoteActor.findUnique.mockResolvedValue(null);
+
+    await expect(
+      svc.fetchRemoteActor("https://remote.example/ap/../secret"),
+    ).rejects.toThrow(/Invalid actor URL path/);
+    await expect(
+      svc.fetchRemoteActor("https://remote.example/ap/%2e%2e/secret"),
+    ).rejects.toThrow(/Invalid actor URL path/);
+
+    expect(assertPublicHttpsUrl).not.toHaveBeenCalled();
+    expect(mockAxios.get).not.toHaveBeenCalled();
+  });
+
+  it("accepts dot-segments inside the query and fetches", async () => {
+    prisma.aPRemoteActor.findUnique.mockResolvedValue(null);
+    mockAxios.get.mockResolvedValue({ data: remoteDoc() });
+    prisma.aPRemoteActor.upsert.mockResolvedValue({ uri: REMOTE });
+
+    const withQuery = `${REMOTE}?next=/../page`;
+    await svc.fetchRemoteActor(withQuery);
+
+    expect(assertPublicHttpsUrl).toHaveBeenCalledWith(withQuery);
+    expect(mockAxios.get).toHaveBeenCalledWith(withQuery, expect.anything());
+  });
+
+  it("rejects a malformed actor URL", async () => {
+    prisma.aPRemoteActor.findUnique.mockResolvedValue(null);
+
+    await expect(svc.fetchRemoteActor("not a valid url")).rejects.toThrow(
+      /Invalid actor URL/,
+    );
+    expect(assertPublicHttpsUrl).not.toHaveBeenCalled();
+    expect(mockAxios.get).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-http(s) protocol", async () => {
+    prisma.aPRemoteActor.findUnique.mockResolvedValue(null);
+
+    await expect(
+      svc.fetchRemoteActor("ftp://remote.example/actor"),
+    ).rejects.toThrow(/Invalid actor URL protocol/);
+    expect(assertPublicHttpsUrl).not.toHaveBeenCalled();
+    expect(mockAxios.get).not.toHaveBeenCalled();
+  });
 });
 
 // ─── Collections ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [ ] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

`fetchRemoteActor` in the ActivityPub service passed the raw incoming
actor URL straight to `assertPublicHttpsUrl`, `axios.get`, and the
origin/host derivations. The SSRF guard covered host reachability, but
the URL string itself was not validated for protocol or path traversal
sequences before use.

## What is the new behavior?

Adds a `buildValidatedActorUrl` helper that runs before any network
activity in `fetchRemoteActor`:

- Rejects URLs that fail to parse.
- Rejects any non-http(s) protocol.
- Rejects path traversal sequences (`/../` and encoded `/%2e%2e/`).

The dot-segment check is scoped to the pre-query path only. `new URL()`
collapses path dot-segments, so the normalised href never exposes a
traversal sequence and the raw pre-query string is inspected directly.
Scoping to the path avoids over-rejecting a legitimate `/../` or
`%2e%2e` that appears inside a query or fragment value (for example
`?next=/../page`).

The validated href is then threaded through the whole function: passed
to `assertPublicHttpsUrl`, used as the `axios.get` target, and used to
derive both the fetched origin and the instance host, so every
downstream use works from the same validated value.

Adds four tests: path dot-segments (plain and `%2e%2e`) reject before
any network call, dot-segments inside the query are accepted and
fetched, a malformed URL rejects, and a non-http(s) protocol rejects.

Impact area: `apps/backend` ActivityPub federation (SSRF hardening).
No API surface or schema changes.

Validation performed: backend tests pass (92/92), type-check clean,
lint clean. No manual/end-to-end federation run was performed.

## Related Issue(s)

Fixes #

