### PR TITLE
fix(backend,database): add opt-out and unsubscribe to care reminder emails

### DIFF
--- a/apps/backend/src/controllers/app/care-reminder-opt-out.controller.ts
+++ b/apps/backend/src/controllers/app/care-reminder-opt-out.controller.ts
@@ -3,19 +3,47 @@ import { z } from "zod";
 import {
   CareReminderOptOutConfigError,
   InvalidCareReminderOptOutTokenError,
+  readCareReminderOptOutToken,
   unsubscribeFromCareReminders,
 } from "src/services/care-reminder-opt-out.service";
+import { escapeHtml } from "src/utils/email-templates";
 import logger from "src/utils/logger";
 
 const UnsubscribeQuerySchema = z.object({
   token: z.string().min(1),
 });
 
-const successPage = `<!doctype html>
+const page = (title: string, inner: string) => `<!doctype html>
 <html lang="en">
-<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Reminders stopped</title></head>
-<body><main><h1>You have been unsubscribed</h1><p>You will no longer receive care reminders from this practice. Reminders from any other practice that cares for your companion are unaffected, and your appointment confirmations still apply.</p></main></body>
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>${title}</title></head>
+<body><main>${inner}</main></body>
 </html>`;
+
+/**
+ * GET renders a confirmation and mutates nothing.
+ *
+ * Mail providers, link scanners and security products fetch every URL in a
+ * message before a human ever sees it. If GET persisted the opt-out, simply
+ * delivering the reminder could unsubscribe the recipient. The state change
+ * therefore happens only on POST, which those scanners do not issue - the same
+ * reason RFC 8058 one-click unsubscribe is specified as a POST.
+ */
+const confirmPage = (token: string) =>
+  page(
+    "Stop care reminders",
+    `<h1>Stop receiving care reminders?</h1>
+<p>This stops care reminders from this practice only. Reminders from any other practice that cares for your companion are unaffected, and your appointment confirmations still apply.</p>
+<form method="POST">
+  <input type="hidden" name="token" value="${escapeHtml(token)}" />
+  <button type="submit">Yes, stop these reminders</button>
+</form>`,
+  );
+
+const successPage = page(
+  "Reminders stopped",
+  `<h1>You have been unsubscribed</h1>
+<p>You will no longer receive care reminders from this practice. Reminders from any other practice that cares for your companion are unaffected, and your appointment confirmations still apply.</p>`,
+);
 
 const handleError = (error: unknown, res: Response): Response => {
   if (
@@ -33,16 +61,39 @@ const handleError = (error: unknown, res: Response): Response => {
 };
 
 export const CareReminderOptOutController = {
+  // Not async: this handler only reads and renders, and having no await is the
+  // point rather than an oversight.
+  confirm(this: void, req: Request, res: Response): Response {
+    try {
+      const { token } = UnsubscribeQuerySchema.parse(req.query);
+      // Validate the token so a broken link fails here rather than after the
+      // recipient has clicked through, but do not write anything.
+      readCareReminderOptOutToken(token);
+      return res
+        .status(200)
+        .set("Content-Type", "text/html; charset=utf-8")
+        .send(confirmPage(token));
+    } catch (error) {
+      return handleError(error, res);
+    }
+  },
+
   async unsubscribe(
     this: void,
     req: Request,
     res: Response,
   ): Promise<Response> {
     try {
-      const { token } = UnsubscribeQuerySchema.parse(req.query);
+      // The token arrives in the form body when the confirmation page posts it,
+      // and in the query string for a direct API call.
+      const source =
+        typeof (req.body as { token?: unknown } | undefined)?.token === "string"
+          ? (req.body as { token: string })
+          : req.query;
+      const { token } = UnsubscribeQuerySchema.parse(source);
       await unsubscribeFromCareReminders(token);
 
-      if (req.method === "GET") {
+      if (req.accepts(["html", "json"]) === "html") {
         return res
           .status(200)
           .set("Content-Type", "text/html; charset=utf-8")

--- a/apps/backend/src/controllers/app/care-reminder-opt-out.controller.ts
+++ b/apps/backend/src/controllers/app/care-reminder-opt-out.controller.ts
@@ -1,0 +1,56 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import {
+  CareReminderOptOutConfigError,
+  InvalidCareReminderOptOutTokenError,
+  unsubscribeFromCareReminders,
+} from "src/services/care-reminder-opt-out.service";
+import logger from "src/utils/logger";
+
+const UnsubscribeQuerySchema = z.object({
+  token: z.string().min(1),
+});
+
+const successPage = `<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Reminders stopped</title></head>
+<body><main><h1>You have been unsubscribed</h1><p>You will no longer receive care reminders from this practice. Reminders from any other practice that cares for your companion are unaffected, and your appointment confirmations still apply.</p></main></body>
+</html>`;
+
+const handleError = (error: unknown, res: Response): Response => {
+  if (
+    error instanceof z.ZodError ||
+    error instanceof InvalidCareReminderOptOutTokenError
+  ) {
+    return res.status(400).json({ message: "Invalid unsubscribe link." });
+  }
+  if (error instanceof CareReminderOptOutConfigError) {
+    logger.error("Care reminder opt-out configuration is invalid.", { error });
+  } else {
+    logger.error("Failed to record care reminder opt-out.", { error });
+  }
+  return res.status(500).json({ message: "Unable to unsubscribe right now." });
+};
+
+export const CareReminderOptOutController = {
+  async unsubscribe(
+    this: void,
+    req: Request,
+    res: Response,
+  ): Promise<Response> {
+    try {
+      const { token } = UnsubscribeQuerySchema.parse(req.query);
+      await unsubscribeFromCareReminders(token);
+
+      if (req.method === "GET") {
+        return res
+          .status(200)
+          .set("Content-Type", "text/html; charset=utf-8")
+          .send(successPage);
+      }
+      return res.status(200).json({ message: "Successfully unsubscribed." });
+    } catch (error) {
+      return handleError(error, res);
+    }
+  },
+};

--- a/apps/backend/src/controllers/app/care-reminder-opt-out.controller.ts
+++ b/apps/backend/src/controllers/app/care-reminder-opt-out.controller.ts
@@ -86,10 +86,8 @@ export const CareReminderOptOutController = {
     try {
       // The token arrives in the form body when the confirmation page posts it,
       // and in the query string for a direct API call.
-      const source =
-        typeof (req.body as { token?: unknown } | undefined)?.token === "string"
-          ? (req.body as { token: string })
-          : req.query;
+      const body = req.body as { token?: unknown } | undefined;
+      const source = typeof body?.token === "string" ? body : req.query;
       const { token } = UnsubscribeQuerySchema.parse(source);
       await unsubscribeFromCareReminders(token);
 

--- a/apps/backend/src/routers/care-reminder-opt-out.router.ts
+++ b/apps/backend/src/routers/care-reminder-opt-out.router.ts
@@ -1,0 +1,12 @@
+import { Router } from "express";
+import { CareReminderOptOutController } from "src/controllers/app/care-reminder-opt-out.controller";
+
+const router = Router();
+
+// Public and unauthenticated by design: the recipient follows this link from an
+// email client and is not signed in. The encrypted token is the only credential,
+// and it authorises exactly one action for one address at one practice.
+router.get("/unsubscribe", CareReminderOptOutController.unsubscribe);
+router.post("/unsubscribe", CareReminderOptOutController.unsubscribe);
+
+export default router;

--- a/apps/backend/src/routers/care-reminder-opt-out.router.ts
+++ b/apps/backend/src/routers/care-reminder-opt-out.router.ts
@@ -6,7 +6,11 @@ const router = Router();
 // Public and unauthenticated by design: the recipient follows this link from an
 // email client and is not signed in. The encrypted token is the only credential,
 // and it authorises exactly one action for one address at one practice.
-router.get("/unsubscribe", CareReminderOptOutController.unsubscribe);
+//
+// GET only confirms; POST performs the opt-out. Mail providers and link scanners
+// fetch every URL in a delivered message, so a mutating GET would let delivery
+// alone unsubscribe someone.
+router.get("/unsubscribe", CareReminderOptOutController.confirm);
 router.post("/unsubscribe", CareReminderOptOutController.unsubscribe);
 
 export default router;

--- a/apps/backend/src/routers/index.ts
+++ b/apps/backend/src/routers/index.ts
@@ -127,6 +127,7 @@ import { medicalCertificateRouter } from "./medical-certificate.router";
 import { patientFlagRouter } from "./patient-flag.router";
 import { inventoryCountRouter } from "./inventory-count.router";
 import { clinicNoteRouter } from "./clinic-note.router";
+import careReminderOptOutRouter from "./care-reminder-opt-out.router";
 import marketingUnsubscribeRouter from "./marketing-unsubscribe.router";
 import marketingRouter from "./marketing.router";
 import activityPubRouter from "./activitypub.router";
@@ -265,5 +266,6 @@ export function registerRoutes(app: Express) {
   app.use(`/v1/super-admin`, superAdminRouter);
   app.use(`/v1/catalog`, catalogRouter);
   app.use(`/v1/email-preferences`, marketingUnsubscribeRouter);
+  app.use(`/v1/reminder-preferences`, careReminderOptOutRouter);
   app.use(`/ap`, activityPubRouter);
 }

--- a/apps/backend/src/services/care-reminder-opt-out.service.ts
+++ b/apps/backend/src/services/care-reminder-opt-out.service.ts
@@ -108,8 +108,8 @@ export const readCareReminderOptOutToken = (
     if (sealed.length <= 16) {
       throw new InvalidCareReminderOptOutTokenError();
     }
-    const tag = sealed.subarray(sealed.length - 16);
-    const ciphertext = sealed.subarray(0, sealed.length - 16);
+    const tag = sealed.subarray(-16);
+    const ciphertext = sealed.subarray(0, -16);
     const decipher = createDecipheriv("aes-256-gcm", deriveTokenKey(), iv);
     decipher.setAuthTag(tag);
     decoded = Buffer.concat([

--- a/apps/backend/src/services/care-reminder-opt-out.service.ts
+++ b/apps/backend/src/services/care-reminder-opt-out.service.ts
@@ -1,0 +1,214 @@
+import {
+  createCipheriv,
+  createDecipheriv,
+  createHmac,
+  randomBytes,
+} from "node:crypto";
+import { prisma } from "src/config/prisma";
+import { stripTrailingSlash } from "src/utils/strip-trailing-slash";
+import type { CareReminderOptOutChannel } from "@prisma/client";
+
+/**
+ * Opt-out plumbing for care reminders.
+ *
+ * Care reminders are sent to pet parents who never signed up for them directly:
+ * the practice creates the reminder and we mail the address on file. Under GDPR
+ * Art. 21 the recipient can object at any time, and an unsubscribe mechanism is
+ * required by CAN-SPAM for anything that is not purely transactional. Neither
+ * existed on this path, so every send needs both a suppression check and a link.
+ *
+ * Why this is separate from `marketing-unsubscribe.service`: that one writes to an
+ * SES contact list and suppresses *marketing* mail globally. Objecting to one
+ * practice's vaccination reminders is a different decision from leaving a mailing
+ * list, and a parent whose animals are seen by two practices must be able to stop
+ * one without silencing the other. The state therefore lives in our own table,
+ * scoped by organisation, and does not depend on SES contact-list configuration.
+ *
+ * The token deliberately reuses `MARKETING_UNSUBSCRIBE_SECRET` (so no new secret
+ * has to be provisioned before this can ship) but derives a different key from it.
+ * Domain separation via the info string means a marketing token cannot be replayed
+ * against this endpoint, or the reverse.
+ */
+
+const TOKEN_SEPARATOR = ".";
+const TOKEN_VERSION = "v1";
+const IV_BYTES = 12;
+const KEY_DERIVATION_INFO = "care-reminder-opt-out-token-v1";
+
+export class CareReminderOptOutConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CareReminderOptOutConfigError";
+  }
+}
+
+export class InvalidCareReminderOptOutTokenError extends Error {
+  constructor() {
+    super("The unsubscribe link is invalid.");
+    this.name = "InvalidCareReminderOptOutTokenError";
+  }
+}
+
+const requireEnvironmentValue = (name: string): string => {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    throw new CareReminderOptOutConfigError(`${name} is not configured.`);
+  }
+  return value;
+};
+
+export const normalizeOptOutEmail = (email: string): string =>
+  email.trim().toLowerCase();
+
+const deriveTokenKey = (): Buffer =>
+  createHmac("sha256", requireEnvironmentValue("MARKETING_UNSUBSCRIBE_SECRET"))
+    .update(KEY_DERIVATION_INFO)
+    .digest();
+
+export interface CareReminderOptOutTokenPayload {
+  organisationId: string;
+  email: string;
+}
+
+export const createCareReminderOptOutToken = (
+  payload: CareReminderOptOutTokenPayload,
+): string => {
+  const iv = randomBytes(IV_BYTES);
+  const cipher = createCipheriv("aes-256-gcm", deriveTokenKey(), iv);
+  const plaintext = JSON.stringify({
+    o: payload.organisationId,
+    e: normalizeOptOutEmail(payload.email),
+  });
+  const ciphertext = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]);
+  const sealed = Buffer.concat([ciphertext, cipher.getAuthTag()]);
+
+  return [
+    TOKEN_VERSION,
+    iv.toString("base64url"),
+    sealed.toString("base64url"),
+  ].join(TOKEN_SEPARATOR);
+};
+
+export const readCareReminderOptOutToken = (
+  token: string,
+): CareReminderOptOutTokenPayload => {
+  const parts = token.split(TOKEN_SEPARATOR);
+  if (parts.length !== 3 || parts[0] !== TOKEN_VERSION) {
+    throw new InvalidCareReminderOptOutTokenError();
+  }
+
+  let decoded: string;
+  try {
+    const iv = Buffer.from(parts[1], "base64url");
+    const sealed = Buffer.from(parts[2], "base64url");
+    // The GCM tag is the trailing 16 bytes; anything shorter cannot carry one.
+    if (sealed.length <= 16) {
+      throw new InvalidCareReminderOptOutTokenError();
+    }
+    const tag = sealed.subarray(sealed.length - 16);
+    const ciphertext = sealed.subarray(0, sealed.length - 16);
+    const decipher = createDecipheriv("aes-256-gcm", deriveTokenKey(), iv);
+    decipher.setAuthTag(tag);
+    decoded = Buffer.concat([
+      decipher.update(ciphertext),
+      decipher.final(),
+    ]).toString("utf8");
+  } catch (error) {
+    // A config error means the server is misconfigured, not that the caller sent a
+    // bad link, so it must not be flattened into "invalid token".
+    if (error instanceof CareReminderOptOutConfigError) throw error;
+    throw new InvalidCareReminderOptOutTokenError();
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(decoded);
+  } catch {
+    throw new InvalidCareReminderOptOutTokenError();
+  }
+
+  const record = parsed as { o?: unknown; e?: unknown };
+  if (typeof record.o !== "string" || typeof record.e !== "string") {
+    throw new InvalidCareReminderOptOutTokenError();
+  }
+
+  return { organisationId: record.o, email: record.e };
+};
+
+export const buildCareReminderUnsubscribeUrl = (
+  payload: CareReminderOptOutTokenPayload,
+): string => {
+  const apiUrl = stripTrailingSlash(requireEnvironmentValue("PUBLIC_API_URL"));
+  const token = createCareReminderOptOutToken(payload);
+  return `${apiUrl}/v1/reminder-preferences/unsubscribe?token=${encodeURIComponent(token)}`;
+};
+
+/**
+ * True when this address has objected to reminders on `channel` for this practice.
+ * An `ALL` row suppresses every channel.
+ */
+export const isOptedOutOfCareReminders = async (params: {
+  organisationId: string;
+  email: string;
+  channel: Exclude<CareReminderOptOutChannel, "ALL">;
+}): Promise<boolean> => {
+  const match = await prisma.careReminderOptOut.findFirst({
+    where: {
+      organisationId: params.organisationId,
+      email: normalizeOptOutEmail(params.email),
+      channel: { in: [params.channel, "ALL"] },
+    },
+    select: { id: true },
+  });
+  return match !== null;
+};
+
+export const recordCareReminderOptOut = async (params: {
+  organisationId: string;
+  email: string;
+  channel?: CareReminderOptOutChannel;
+  parentId?: string | null;
+  source?: string;
+}): Promise<void> => {
+  const email = normalizeOptOutEmail(params.email);
+  const channel = params.channel ?? "ALL";
+
+  // Idempotent: clicking the same link twice, or a mail client prefetching it,
+  // must not fail. The unique key is (organisationId, email, channel).
+  await prisma.careReminderOptOut.upsert({
+    where: {
+      organisationId_email_channel: {
+        organisationId: params.organisationId,
+        email,
+        channel,
+      },
+    },
+    update: {
+      parentId: params.parentId ?? undefined,
+      source: params.source ?? undefined,
+    },
+    create: {
+      organisationId: params.organisationId,
+      email,
+      channel,
+      parentId: params.parentId ?? null,
+      source: params.source ?? "unsubscribe-link",
+    },
+  });
+};
+
+export const unsubscribeFromCareReminders = async (
+  token: string,
+): Promise<CareReminderOptOutTokenPayload> => {
+  const payload = readCareReminderOptOutToken(token);
+  await recordCareReminderOptOut({
+    organisationId: payload.organisationId,
+    email: payload.email,
+    channel: "ALL",
+    source: "unsubscribe-link",
+  });
+  return payload;
+};

--- a/apps/backend/src/services/care-reminder-opt-out.service.ts
+++ b/apps/backend/src/services/care-reminder-opt-out.service.ts
@@ -146,24 +146,38 @@ export const buildCareReminderUnsubscribeUrl = (
   return `${apiUrl}/v1/reminder-preferences/unsubscribe?token=${encodeURIComponent(token)}`;
 };
 
+export interface CareReminderSuppression {
+  email: boolean;
+  push: boolean;
+}
+
 /**
- * True when this address has objected to reminders on `channel` for this practice.
- * An `ALL` row suppresses every channel.
+ * Which channels this address has objected to for this practice. An `ALL` row
+ * suppresses every channel.
+ *
+ * Resolved for every channel in one query, and deliberately called before any
+ * channel is delivered: the unsubscribe flow stores `ALL` and tells the recipient
+ * that reminders from the practice have stopped, so checking only the email
+ * channel would keep pushing at someone who was promised silence.
  */
-export const isOptedOutOfCareReminders = async (params: {
+export const resolveCareReminderSuppression = async (params: {
   organisationId: string;
   email: string;
-  channel: Exclude<CareReminderOptOutChannel, "ALL">;
-}): Promise<boolean> => {
-  const match = await prisma.careReminderOptOut.findFirst({
+}): Promise<CareReminderSuppression> => {
+  const rows = await prisma.careReminderOptOut.findMany({
     where: {
       organisationId: params.organisationId,
       email: normalizeOptOutEmail(params.email),
-      channel: { in: [params.channel, "ALL"] },
     },
-    select: { id: true },
+    select: { channel: true },
   });
-  return match !== null;
+
+  const channels = new Set(rows.map((row) => row.channel));
+  const all = channels.has("ALL");
+  return {
+    email: all || channels.has("EMAIL"),
+    push: all || channels.has("PUSH"),
+  };
 };
 
 export const recordCareReminderOptOut = async (params: {

--- a/apps/backend/src/services/care-reminder.service.ts
+++ b/apps/backend/src/services/care-reminder.service.ts
@@ -105,6 +105,81 @@ const assertReminder = async (id: string, organisationId: string) => {
   return reminder;
 };
 
+/**
+ * Everything that can refuse the send, resolved before any channel is delivered.
+ *
+ * Kept separate from delivery for two reasons: it is the only part that can
+ * legally block the send, and doing it first means an operational failure cannot
+ * leave one channel delivered and the other not. Both failures throw rather than
+ * returning quietly, because `send` marks the reminder SENT on return and only a
+ * PENDING reminder can be sent again, so a transient problem would otherwise
+ * consume a reminder that was never delivered.
+ */
+const resolveDeliveryPlan = async (
+  reminder: Awaited<ReturnType<typeof assertReminder>>,
+  ownerEmail: string | null,
+): Promise<{
+  suppression: CareReminderSuppression;
+  unsubscribeUrl: string | null;
+}> => {
+  // With no address on file there is no key to look an objection up by, so push
+  // is the only channel and it proceeds. Worth knowing when reading suppression
+  // numbers: an opt-out is recorded against an email address.
+  if (!ownerEmail) {
+    return { suppression: { email: false, push: false }, unsubscribeUrl: null };
+  }
+
+  let suppression: CareReminderSuppression;
+  try {
+    suppression = await resolveCareReminderSuppression({
+      organisationId: reminder.organisationId,
+      email: ownerEmail,
+    });
+  } catch (err: unknown) {
+    logger.error(
+      "Care reminder not sent: opt-out lookup failed, cannot prove consent",
+      { reminderId: reminder.id, err },
+    );
+    throw new CareReminderError(
+      "Unable to verify reminder preferences right now.",
+      503,
+    );
+  }
+
+  if (suppression.email) {
+    return { suppression, unsubscribeUrl: null };
+  }
+
+  try {
+    return {
+      suppression,
+      unsubscribeUrl: buildCareReminderUnsubscribeUrl({
+        organisationId: reminder.organisationId,
+        email: ownerEmail,
+      }),
+    };
+  } catch (err: unknown) {
+    logger.error(
+      "Care reminder not sent: unsubscribe link could not be built (check PUBLIC_API_URL and MARKETING_UNSUBSCRIBE_SECRET)",
+      { reminderId: reminder.id, err },
+    );
+    throw new CareReminderError(
+      "Reminder delivery is not configured correctly.",
+      503,
+    );
+  }
+};
+
+const buildReminderEmailBody = (body: string, unsubscribeUrl: string) =>
+  // `body` carries the companion name and the reminder's free-text custom
+  // message, so it must be escaped before it lands in email markup.
+  `<p>${escapeHtml(body)}</p>` +
+  `<p>Book an appointment through the app or contact your clinic directly.</p>` +
+  `<hr /><p style="font-size:12px;color:#5c5956">` +
+  `You are receiving this because your companion is registered with this practice. ` +
+  `<a href="${escapeHtml(unsubscribeUrl)}">Stop receiving care reminders from this practice</a>.` +
+  `</p>`;
+
 const dispatchNotification = async (
   reminder: Awaited<ReturnType<typeof assertReminder>>,
   patientName: string,
@@ -116,98 +191,48 @@ const dispatchNotification = async (
     reminder.customMessage ??
     `${patientName} is due for ${typeLabel}. Please book an appointment at your earliest convenience.`;
 
-  // Everything that can refuse the send is resolved BEFORE any channel is
-  // delivered, so an operational failure cannot leave one channel sent and the
-  // reminder half-delivered. Both checks throw rather than skipping quietly:
-  // `send` marks the reminder SENT on return, and only a PENDING reminder can be
-  // sent again, so returning here would burn the reminder permanently on what is
-  // really a transient config or database problem.
-  let suppression: CareReminderSuppression = { email: false, push: false };
-  let unsubscribeUrl: string | null = null;
+  const { suppression, unsubscribeUrl } = await resolveDeliveryPlan(
+    reminder,
+    ownerEmail,
+  );
 
-  if (ownerEmail) {
-    try {
-      suppression = await resolveCareReminderSuppression({
-        organisationId: reminder.organisationId,
-        email: ownerEmail,
-      });
-    } catch (err: unknown) {
-      logger.error(
-        "Care reminder not sent: opt-out lookup failed, cannot prove consent",
-        { reminderId: reminder.id, err },
-      );
-      throw new CareReminderError(
-        "Unable to verify reminder preferences right now.",
-        503,
-      );
-    }
+  const suppressed = (channel: "push" | "email") =>
+    logger.info(`Care reminder ${channel} suppressed: recipient opted out`, {
+      reminderId: reminder.id,
+      organisationId: reminder.organisationId,
+    });
 
-    if (!suppression.email) {
-      try {
-        unsubscribeUrl = buildCareReminderUnsubscribeUrl({
-          organisationId: reminder.organisationId,
-          email: ownerEmail,
-        });
-      } catch (err: unknown) {
-        logger.error(
-          "Care reminder not sent: unsubscribe link could not be built (check PUBLIC_API_URL and MARKETING_UNSUBSCRIBE_SECRET)",
-          { reminderId: reminder.id, err },
-        );
-        throw new CareReminderError(
-          "Reminder delivery is not configured correctly.",
-          503,
-        );
-      }
-    }
-  }
-
-  // With no address on file there is no key to look an objection up by, so push
-  // is the only channel and it proceeds. Worth knowing when reading suppression
-  // numbers: an opt-out is recorded against an email address.
-  if (ownerUserId && !suppression.push) {
-    const payload = NotificationTemplates.Care.CARE_REMINDER(
-      patientName,
-      typeLabel,
-    );
-    await NotificationService.sendToUser(ownerUserId, payload).catch(
-      (err: unknown) => {
+  if (ownerUserId) {
+    if (suppression.push) {
+      suppressed("push");
+    } else {
+      await NotificationService.sendToUser(
+        ownerUserId,
+        NotificationTemplates.Care.CARE_REMINDER(patientName, typeLabel),
+      ).catch((err: unknown) => {
         logger.error("Care reminder push notification failed", {
           reminderId: reminder.id,
           err,
         });
-      },
-    );
-  } else if (ownerUserId) {
-    logger.info("Care reminder push suppressed: recipient opted out", {
-      reminderId: reminder.id,
-      organisationId: reminder.organisationId,
-    });
+      });
+    }
   }
 
-  if (ownerEmail && !suppression.email && unsubscribeUrl) {
-    await sendEmail({
-      to: ownerEmail,
-      subject: `Care reminder for ${patientName}`,
-      // `body` carries the companion name and the reminder's free-text custom
-      // message, so it must be escaped before it lands in email markup.
-      htmlBody:
-        `<p>${escapeHtml(body)}</p>` +
-        `<p>Book an appointment through the app or contact your clinic directly.</p>` +
-        `<hr /><p style="font-size:12px;color:#5c5956">` +
-        `You are receiving this because your companion is registered with this practice. ` +
-        `<a href="${escapeHtml(unsubscribeUrl)}">Stop receiving care reminders from this practice</a>.` +
-        `</p>`,
-    }).catch((err: unknown) => {
-      logger.error("Care reminder email failed", {
-        reminderId: reminder.id,
-        err,
+  if (ownerEmail) {
+    if (suppression.email || !unsubscribeUrl) {
+      suppressed("email");
+    } else {
+      await sendEmail({
+        to: ownerEmail,
+        subject: `Care reminder for ${patientName}`,
+        htmlBody: buildReminderEmailBody(body, unsubscribeUrl),
+      }).catch((err: unknown) => {
+        logger.error("Care reminder email failed", {
+          reminderId: reminder.id,
+          err,
+        });
       });
-    });
-  } else if (ownerEmail) {
-    logger.info("Care reminder email suppressed: recipient opted out", {
-      reminderId: reminder.id,
-      organisationId: reminder.organisationId,
-    });
+    }
   }
 };
 

--- a/apps/backend/src/services/care-reminder.service.ts
+++ b/apps/backend/src/services/care-reminder.service.ts
@@ -4,6 +4,10 @@ import { AuditTrailService } from "./audit-trail.service";
 import { NotificationService } from "./notification.service";
 import { NotificationTemplates } from "src/utils/notificationTemplates";
 import { sendEmail } from "src/utils/email";
+import {
+  buildCareReminderUnsubscribeUrl,
+  isOptedOutOfCareReminders,
+} from "./care-reminder-opt-out.service";
 import logger from "src/utils/logger";
 import type { Prisma } from "@prisma/client";
 import {
@@ -127,12 +131,59 @@ const dispatchNotification = async (
   }
 
   if (ownerEmail) {
+    // Suppression and the unsubscribe link are both required before this mail can
+    // legally go out (GDPR Art. 21 objection, CAN-SPAM unsubscribe). Both failure
+    // modes below therefore skip the send rather than mailing anyway: a missed
+    // reminder is a service gap, mailing someone who objected is a breach.
+    let optedOut: boolean;
+    try {
+      optedOut = await isOptedOutOfCareReminders({
+        organisationId: reminder.organisationId,
+        email: ownerEmail,
+        channel: "EMAIL",
+      });
+    } catch (err: unknown) {
+      logger.error(
+        "Care reminder email skipped: opt-out lookup failed, cannot prove consent",
+        { reminderId: reminder.id, err },
+      );
+      return;
+    }
+
+    if (optedOut) {
+      logger.info("Care reminder email suppressed: recipient opted out", {
+        reminderId: reminder.id,
+        organisationId: reminder.organisationId,
+      });
+      return;
+    }
+
+    let unsubscribeUrl: string;
+    try {
+      unsubscribeUrl = buildCareReminderUnsubscribeUrl({
+        organisationId: reminder.organisationId,
+        email: ownerEmail,
+      });
+    } catch (err: unknown) {
+      logger.error(
+        "Care reminder email skipped: unsubscribe link could not be built (check PUBLIC_API_URL and MARKETING_UNSUBSCRIBE_SECRET)",
+        { reminderId: reminder.id, err },
+      );
+      return;
+    }
+
     await sendEmail({
       to: ownerEmail,
       subject: `Care reminder for ${patientName}`,
       // `body` carries the companion name and the reminder's free-text custom
       // message, so it must be escaped before it lands in email markup.
-      htmlBody: `<p>${escapeHtml(body)}</p><p>Book an appointment through the app or contact your clinic directly.</p>`,
+      htmlBody:
+        `<p>${escapeHtml(body)}</p>` +
+        `<p>Book an appointment through the app or contact your clinic directly.</p>` +
+        `<hr /><p style="font-size:12px;color:#5c5956">` +
+        `You are receiving this because your companion is registered with this practice. ` +
+        `<a href="${escapeHtml(unsubscribeUrl)}">Stop receiving care reminders from this practice</a>.` +
+        `</p>`,
     }).catch((err: unknown) => {
       logger.error("Care reminder email failed", {
         reminderId: reminder.id,

--- a/apps/backend/src/services/care-reminder.service.ts
+++ b/apps/backend/src/services/care-reminder.service.ts
@@ -6,7 +6,8 @@ import { NotificationTemplates } from "src/utils/notificationTemplates";
 import { sendEmail } from "src/utils/email";
 import {
   buildCareReminderUnsubscribeUrl,
-  isOptedOutOfCareReminders,
+  resolveCareReminderSuppression,
+  type CareReminderSuppression,
 } from "./care-reminder-opt-out.service";
 import logger from "src/utils/logger";
 import type { Prisma } from "@prisma/client";
@@ -115,7 +116,55 @@ const dispatchNotification = async (
     reminder.customMessage ??
     `${patientName} is due for ${typeLabel}. Please book an appointment at your earliest convenience.`;
 
-  if (ownerUserId) {
+  // Everything that can refuse the send is resolved BEFORE any channel is
+  // delivered, so an operational failure cannot leave one channel sent and the
+  // reminder half-delivered. Both checks throw rather than skipping quietly:
+  // `send` marks the reminder SENT on return, and only a PENDING reminder can be
+  // sent again, so returning here would burn the reminder permanently on what is
+  // really a transient config or database problem.
+  let suppression: CareReminderSuppression = { email: false, push: false };
+  let unsubscribeUrl: string | null = null;
+
+  if (ownerEmail) {
+    try {
+      suppression = await resolveCareReminderSuppression({
+        organisationId: reminder.organisationId,
+        email: ownerEmail,
+      });
+    } catch (err: unknown) {
+      logger.error(
+        "Care reminder not sent: opt-out lookup failed, cannot prove consent",
+        { reminderId: reminder.id, err },
+      );
+      throw new CareReminderError(
+        "Unable to verify reminder preferences right now.",
+        503,
+      );
+    }
+
+    if (!suppression.email) {
+      try {
+        unsubscribeUrl = buildCareReminderUnsubscribeUrl({
+          organisationId: reminder.organisationId,
+          email: ownerEmail,
+        });
+      } catch (err: unknown) {
+        logger.error(
+          "Care reminder not sent: unsubscribe link could not be built (check PUBLIC_API_URL and MARKETING_UNSUBSCRIBE_SECRET)",
+          { reminderId: reminder.id, err },
+        );
+        throw new CareReminderError(
+          "Reminder delivery is not configured correctly.",
+          503,
+        );
+      }
+    }
+  }
+
+  // With no address on file there is no key to look an objection up by, so push
+  // is the only channel and it proceeds. Worth knowing when reading suppression
+  // numbers: an opt-out is recorded against an email address.
+  if (ownerUserId && !suppression.push) {
     const payload = NotificationTemplates.Care.CARE_REMINDER(
       patientName,
       typeLabel,
@@ -128,50 +177,14 @@ const dispatchNotification = async (
         });
       },
     );
+  } else if (ownerUserId) {
+    logger.info("Care reminder push suppressed: recipient opted out", {
+      reminderId: reminder.id,
+      organisationId: reminder.organisationId,
+    });
   }
 
-  if (ownerEmail) {
-    // Suppression and the unsubscribe link are both required before this mail can
-    // legally go out (GDPR Art. 21 objection, CAN-SPAM unsubscribe). Both failure
-    // modes below therefore skip the send rather than mailing anyway: a missed
-    // reminder is a service gap, mailing someone who objected is a breach.
-    let optedOut: boolean;
-    try {
-      optedOut = await isOptedOutOfCareReminders({
-        organisationId: reminder.organisationId,
-        email: ownerEmail,
-        channel: "EMAIL",
-      });
-    } catch (err: unknown) {
-      logger.error(
-        "Care reminder email skipped: opt-out lookup failed, cannot prove consent",
-        { reminderId: reminder.id, err },
-      );
-      return;
-    }
-
-    if (optedOut) {
-      logger.info("Care reminder email suppressed: recipient opted out", {
-        reminderId: reminder.id,
-        organisationId: reminder.organisationId,
-      });
-      return;
-    }
-
-    let unsubscribeUrl: string;
-    try {
-      unsubscribeUrl = buildCareReminderUnsubscribeUrl({
-        organisationId: reminder.organisationId,
-        email: ownerEmail,
-      });
-    } catch (err: unknown) {
-      logger.error(
-        "Care reminder email skipped: unsubscribe link could not be built (check PUBLIC_API_URL and MARKETING_UNSUBSCRIBE_SECRET)",
-        { reminderId: reminder.id, err },
-      );
-      return;
-    }
-
+  if (ownerEmail && !suppression.email && unsubscribeUrl) {
     await sendEmail({
       to: ownerEmail,
       subject: `Care reminder for ${patientName}`,
@@ -189,6 +202,11 @@ const dispatchNotification = async (
         reminderId: reminder.id,
         err,
       });
+    });
+  } else if (ownerEmail) {
+    logger.info("Care reminder email suppressed: recipient opted out", {
+      reminderId: reminder.id,
+      organisationId: reminder.organisationId,
     });
   }
 };

--- a/apps/backend/test/controllers/app/care-reminder-opt-out.controller.test.ts
+++ b/apps/backend/test/controllers/app/care-reminder-opt-out.controller.test.ts
@@ -1,0 +1,165 @@
+const unsubscribeFromCareReminders = jest.fn();
+const readCareReminderOptOutToken = jest.fn();
+let InvalidTokenError: new () => Error;
+let ConfigError: new (m: string) => Error;
+
+jest.mock("src/services/care-reminder-opt-out.service", () => {
+  class InvalidCareReminderOptOutTokenError extends Error {}
+  class CareReminderOptOutConfigError extends Error {}
+  InvalidTokenError = InvalidCareReminderOptOutTokenError;
+  ConfigError = CareReminderOptOutConfigError;
+  return {
+    unsubscribeFromCareReminders,
+    readCareReminderOptOutToken,
+    InvalidCareReminderOptOutTokenError,
+    CareReminderOptOutConfigError,
+  };
+});
+
+jest.mock("src/utils/logger", () => ({ error: jest.fn(), info: jest.fn() }));
+
+import type { Request, Response } from "express";
+import { CareReminderOptOutController } from "src/controllers/app/care-reminder-opt-out.controller";
+
+type MockResponse = {
+  status: jest.Mock;
+  set: jest.Mock;
+  json: jest.Mock;
+  send: jest.Mock;
+};
+
+const response = () => {
+  const res = {} as MockResponse;
+  res.status = jest.fn(() => res);
+  res.set = jest.fn(() => res);
+  res.json = jest.fn(() => res);
+  res.send = jest.fn(() => res);
+  return res;
+};
+
+// The controller only touches the four methods stubbed above, so the mocks are
+// cast at the call site rather than reconstructing all of Express's types.
+const asRes = (r: MockResponse) => r as unknown as Response;
+const asReq = (o: Record<string, unknown>) => o as unknown as Request;
+
+describe("CareReminderOptOutController", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    readCareReminderOptOutToken.mockReturnValue({
+      organisationId: "org-1",
+      email: "person@example.com",
+    });
+    unsubscribeFromCareReminders.mockResolvedValue({
+      organisationId: "org-1",
+      email: "person@example.com",
+    });
+  });
+
+  describe("GET (confirm)", () => {
+    it("renders a confirmation and records nothing", async () => {
+      // The whole point of the split: mail providers and link scanners fetch
+      // every URL in a delivered message, so a mutating GET would let delivery
+      // alone unsubscribe the recipient.
+      const res = response();
+      await CareReminderOptOutController.confirm(
+        asReq({ method: "GET", query: { token: "tok" } }),
+        asRes(res),
+      );
+
+      expect(unsubscribeFromCareReminders).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(200);
+      const html = res.send.mock.calls[0][0] as string;
+      expect(html).toContain('<form method="POST">');
+      expect(html).toContain("Stop receiving care reminders?");
+    });
+
+    it("validates the token so a broken link fails before the click", async () => {
+      readCareReminderOptOutToken.mockImplementation(() => {
+        throw new InvalidTokenError();
+      });
+      const res = response();
+      await CareReminderOptOutController.confirm(
+        asReq({ method: "GET", query: { token: "bad" } }),
+        asRes(res),
+      );
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    it("rejects a missing token", async () => {
+      const res = response();
+      await CareReminderOptOutController.confirm(
+        asReq({ method: "GET", query: {} }),
+        asRes(res),
+      );
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(unsubscribeFromCareReminders).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("POST (unsubscribe)", () => {
+    it("records the opt-out from the form body and returns HTML to a browser", async () => {
+      const res = response();
+      await CareReminderOptOutController.unsubscribe(
+        asReq({
+          method: "POST",
+          body: { token: "tok" },
+          query: {},
+          accepts: () => "html",
+        }),
+        asRes(res),
+      );
+
+      expect(unsubscribeFromCareReminders).toHaveBeenCalledWith("tok");
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.send.mock.calls[0][0]).toContain("You have been unsubscribed");
+    });
+
+    it("accepts the token from the query string for a direct API call", async () => {
+      const res = response();
+      await CareReminderOptOutController.unsubscribe(
+        asReq({
+          method: "POST",
+          body: {},
+          query: { token: "tok" },
+          accepts: () => "json",
+        }),
+        asRes(res),
+      );
+
+      expect(unsubscribeFromCareReminders).toHaveBeenCalledWith("tok");
+      expect(res.json).toHaveBeenCalledWith({
+        message: "Successfully unsubscribed.",
+      });
+    });
+
+    it("returns 400 for an invalid token", async () => {
+      unsubscribeFromCareReminders.mockRejectedValue(new InvalidTokenError());
+      const res = response();
+      await CareReminderOptOutController.unsubscribe(
+        asReq({
+          method: "POST",
+          body: { token: "bad" },
+          query: {},
+          accepts: () => "json",
+        }),
+        asRes(res),
+      );
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    it("returns 500 for a server misconfiguration rather than blaming the link", async () => {
+      unsubscribeFromCareReminders.mockRejectedValue(new ConfigError("nope"));
+      const res = response();
+      await CareReminderOptOutController.unsubscribe(
+        asReq({
+          method: "POST",
+          body: { token: "tok" },
+          query: {},
+          accepts: () => "json",
+        }),
+        asRes(res),
+      );
+      expect(res.status).toHaveBeenCalledWith(500);
+    });
+  });
+});

--- a/apps/backend/test/services/care-reminder-opt-out.service.test.ts
+++ b/apps/backend/test/services/care-reminder-opt-out.service.test.ts
@@ -3,7 +3,7 @@ import {
   createCareReminderOptOutToken,
   CareReminderOptOutConfigError,
   InvalidCareReminderOptOutTokenError,
-  isOptedOutOfCareReminders,
+  resolveCareReminderSuppression,
   normalizeOptOutEmail,
   readCareReminderOptOutToken,
   recordCareReminderOptOut,
@@ -14,14 +14,14 @@ import { prisma } from "src/config/prisma";
 jest.mock("src/config/prisma", () => ({
   prisma: {
     careReminderOptOut: {
-      findFirst: jest.fn(),
+      findMany: jest.fn(),
       upsert: jest.fn(),
     },
   },
 }));
 
 const pm = prisma as unknown as {
-  careReminderOptOut: { findFirst: jest.Mock; upsert: jest.Mock };
+  careReminderOptOut: { findMany: jest.Mock; upsert: jest.Mock };
 };
 
 describe("care-reminder-opt-out.service", () => {
@@ -29,7 +29,7 @@ describe("care-reminder-opt-out.service", () => {
     jest.clearAllMocks();
     process.env.MARKETING_UNSUBSCRIBE_SECRET = "test-secret";
     process.env.PUBLIC_API_URL = "https://api.example.com/";
-    pm.careReminderOptOut.findFirst.mockResolvedValue(null);
+    pm.careReminderOptOut.findMany.mockResolvedValue([]);
     pm.careReminderOptOut.upsert.mockResolvedValue({});
   });
 
@@ -128,35 +128,44 @@ describe("care-reminder-opt-out.service", () => {
     });
   });
 
-  describe("isOptedOutOfCareReminders", () => {
-    it("is false when no row matches", async () => {
+  describe("resolveCareReminderSuppression", () => {
+    it("suppresses nothing when there are no rows", async () => {
       await expect(
-        isOptedOutOfCareReminders({
+        resolveCareReminderSuppression({
           organisationId: "org-1",
           email: "person@example.com",
-          channel: "EMAIL",
         }),
-      ).resolves.toBe(false);
+      ).resolves.toEqual({ email: false, push: false });
     });
 
-    it("matches the requested channel or an ALL row, scoped to the practice", async () => {
-      pm.careReminderOptOut.findFirst.mockResolvedValue({ id: "row-1" });
-
+    it("an ALL row suppresses every channel", async () => {
+      pm.careReminderOptOut.findMany.mockResolvedValue([{ channel: "ALL" }]);
       await expect(
-        isOptedOutOfCareReminders({
+        resolveCareReminderSuppression({
           organisationId: "org-1",
-          email: " Person@Example.com ",
-          channel: "EMAIL",
+          email: "person@example.com",
         }),
-      ).resolves.toBe(true);
+      ).resolves.toEqual({ email: true, push: true });
+    });
 
-      expect(pm.careReminderOptOut.findFirst).toHaveBeenCalledWith(
+    it("a channel row suppresses only that channel", async () => {
+      pm.careReminderOptOut.findMany.mockResolvedValue([{ channel: "EMAIL" }]);
+      await expect(
+        resolveCareReminderSuppression({
+          organisationId: "org-1",
+          email: "person@example.com",
+        }),
+      ).resolves.toEqual({ email: true, push: false });
+    });
+
+    it("scopes the lookup to the practice and normalises the address", async () => {
+      await resolveCareReminderSuppression({
+        organisationId: "org-1",
+        email: " Person@Example.com ",
+      });
+      expect(pm.careReminderOptOut.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: {
-            organisationId: "org-1",
-            email: "person@example.com",
-            channel: { in: ["EMAIL", "ALL"] },
-          },
+          where: { organisationId: "org-1", email: "person@example.com" },
         }),
       );
     });

--- a/apps/backend/test/services/care-reminder-opt-out.service.test.ts
+++ b/apps/backend/test/services/care-reminder-opt-out.service.test.ts
@@ -1,0 +1,216 @@
+import {
+  buildCareReminderUnsubscribeUrl,
+  createCareReminderOptOutToken,
+  CareReminderOptOutConfigError,
+  InvalidCareReminderOptOutTokenError,
+  isOptedOutOfCareReminders,
+  normalizeOptOutEmail,
+  readCareReminderOptOutToken,
+  recordCareReminderOptOut,
+  unsubscribeFromCareReminders,
+} from "src/services/care-reminder-opt-out.service";
+import { prisma } from "src/config/prisma";
+
+jest.mock("src/config/prisma", () => ({
+  prisma: {
+    careReminderOptOut: {
+      findFirst: jest.fn(),
+      upsert: jest.fn(),
+    },
+  },
+}));
+
+const pm = prisma as unknown as {
+  careReminderOptOut: { findFirst: jest.Mock; upsert: jest.Mock };
+};
+
+describe("care-reminder-opt-out.service", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.MARKETING_UNSUBSCRIBE_SECRET = "test-secret";
+    process.env.PUBLIC_API_URL = "https://api.example.com/";
+    pm.careReminderOptOut.findFirst.mockResolvedValue(null);
+    pm.careReminderOptOut.upsert.mockResolvedValue({});
+  });
+
+  describe("token", () => {
+    it("round-trips organisation and normalised email through the URL", () => {
+      const url = buildCareReminderUnsubscribeUrl({
+        organisationId: "org-1",
+        email: "  Person@Example.COM ",
+      });
+      const token = new URL(url).searchParams.get("token");
+
+      expect(url).toContain("/v1/reminder-preferences/unsubscribe");
+      expect(readCareReminderOptOutToken(token!)).toEqual({
+        organisationId: "org-1",
+        email: "person@example.com",
+      });
+    });
+
+    it("does not leak the address into the URL", () => {
+      const url = buildCareReminderUnsubscribeUrl({
+        organisationId: "org-1",
+        email: "person@example.com",
+      });
+      expect(url).not.toContain("person@example.com");
+      expect(url).not.toContain("org-1");
+    });
+
+    it("rejects a tampered ciphertext", () => {
+      const token = createCareReminderOptOutToken({
+        organisationId: "org-1",
+        email: "person@example.com",
+      });
+      const [version, iv, sealed] = token.split(".");
+      // Flip a character inside the sealed payload rather than appending one:
+      // base64url decoding silently drops a trailing incomplete group, so
+      // `token + "x"` can decode to the identical bytes and prove nothing.
+      const flipped =
+        sealed.slice(0, 4) + (sealed[4] === "A" ? "B" : "A") + sealed.slice(5);
+      expect(() =>
+        readCareReminderOptOutToken([version, iv, flipped].join(".")),
+      ).toThrow(InvalidCareReminderOptOutTokenError);
+    });
+
+    it("rejects a token sealed for a different practice's key material", () => {
+      const token = createCareReminderOptOutToken({
+        organisationId: "org-1",
+        email: "person@example.com",
+      });
+      process.env.MARKETING_UNSUBSCRIBE_SECRET = "a-different-secret";
+      expect(() => readCareReminderOptOutToken(token)).toThrow(
+        InvalidCareReminderOptOutTokenError,
+      );
+    });
+
+    it.each([
+      ["wrong version", "v9.aaaa.bbbb"],
+      ["too few parts", "v1.aaaa"],
+      ["truncated payload that cannot hold a GCM tag", "v1.YWFhYQ.YWFh"],
+    ])("rejects a malformed token (%s)", (_label, token) => {
+      expect(() => readCareReminderOptOutToken(token)).toThrow(
+        InvalidCareReminderOptOutTokenError,
+      );
+    });
+
+    it("does not accept a marketing token (domain separation)", () => {
+      // Same secret, different derivation info, so the marketing key must not open
+      // a reminder token and vice versa.
+      const { createMarketingUnsubscribeToken } = jest.requireActual<
+        typeof import("src/services/marketing-unsubscribe.service")
+      >("src/services/marketing-unsubscribe.service");
+      const marketingToken =
+        createMarketingUnsubscribeToken("person@example.com");
+      expect(() => readCareReminderOptOutToken(marketingToken)).toThrow(
+        InvalidCareReminderOptOutTokenError,
+      );
+    });
+
+    it("surfaces a config error rather than calling it an invalid link", () => {
+      delete process.env.MARKETING_UNSUBSCRIBE_SECRET;
+      expect(() =>
+        createCareReminderOptOutToken({
+          organisationId: "org-1",
+          email: "person@example.com",
+        }),
+      ).toThrow(CareReminderOptOutConfigError);
+    });
+
+    it("requires PUBLIC_API_URL to build a link", () => {
+      delete process.env.PUBLIC_API_URL;
+      expect(() =>
+        buildCareReminderUnsubscribeUrl({
+          organisationId: "org-1",
+          email: "person@example.com",
+        }),
+      ).toThrow(CareReminderOptOutConfigError);
+    });
+  });
+
+  describe("isOptedOutOfCareReminders", () => {
+    it("is false when no row matches", async () => {
+      await expect(
+        isOptedOutOfCareReminders({
+          organisationId: "org-1",
+          email: "person@example.com",
+          channel: "EMAIL",
+        }),
+      ).resolves.toBe(false);
+    });
+
+    it("matches the requested channel or an ALL row, scoped to the practice", async () => {
+      pm.careReminderOptOut.findFirst.mockResolvedValue({ id: "row-1" });
+
+      await expect(
+        isOptedOutOfCareReminders({
+          organisationId: "org-1",
+          email: " Person@Example.com ",
+          channel: "EMAIL",
+        }),
+      ).resolves.toBe(true);
+
+      expect(pm.careReminderOptOut.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            organisationId: "org-1",
+            email: "person@example.com",
+            channel: { in: ["EMAIL", "ALL"] },
+          },
+        }),
+      );
+    });
+  });
+
+  describe("recordCareReminderOptOut", () => {
+    it("upserts so a repeated click or a prefetching mail client cannot fail", async () => {
+      await recordCareReminderOptOut({
+        organisationId: "org-1",
+        email: "Person@Example.com",
+      });
+
+      expect(pm.careReminderOptOut.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            organisationId_email_channel: {
+              organisationId: "org-1",
+              email: "person@example.com",
+              channel: "ALL",
+            },
+          },
+          create: expect.objectContaining({
+            organisationId: "org-1",
+            email: "person@example.com",
+            channel: "ALL",
+            source: "unsubscribe-link",
+          }),
+        }),
+      );
+    });
+  });
+
+  it("unsubscribeFromCareReminders records ALL for the token's practice", async () => {
+    const token = createCareReminderOptOutToken({
+      organisationId: "org-7",
+      email: "person@example.com",
+    });
+
+    await expect(unsubscribeFromCareReminders(token)).resolves.toEqual({
+      organisationId: "org-7",
+      email: "person@example.com",
+    });
+
+    expect(pm.careReminderOptOut.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({
+          organisationId: "org-7",
+          channel: "ALL",
+        }),
+      }),
+    );
+  });
+
+  it("normalizeOptOutEmail trims and lower-cases", () => {
+    expect(normalizeOptOutEmail("  MiXeD@Case.COM  ")).toBe("mixed@case.com");
+  });
+});

--- a/apps/backend/test/services/care-reminder.service.test.ts
+++ b/apps/backend/test/services/care-reminder.service.test.ts
@@ -20,7 +20,7 @@ jest.mock("src/config/prisma", () => ({
     patient: { findUnique: jest.fn() },
     parentPatient: { findFirst: jest.fn() },
     parent: { findUnique: jest.fn() },
-    careReminderOptOut: { findFirst: jest.fn(), upsert: jest.fn() },
+    careReminderOptOut: { findMany: jest.fn(), upsert: jest.fn() },
   },
 }));
 
@@ -51,7 +51,7 @@ const pm = prisma as unknown as {
   patient: { findUnique: jest.Mock };
   parentPatient: { findFirst: jest.Mock };
   parent: { findUnique: jest.Mock };
-  careReminderOptOut: { findFirst: jest.Mock; upsert: jest.Mock };
+  careReminderOptOut: { findMany: jest.Mock; upsert: jest.Mock };
 };
 
 const DUE = new Date("2026-07-15T10:00:00Z");
@@ -91,7 +91,7 @@ beforeEach(() => {
   (NotificationService.sendToUser as jest.Mock).mockResolvedValue(undefined);
   (sendEmail as jest.Mock).mockResolvedValue(undefined);
   // No opt-out by default, and the unsubscribe link needs both of these to build.
-  pm.careReminderOptOut.findFirst.mockResolvedValue(null);
+  pm.careReminderOptOut.findMany.mockResolvedValue([]);
   process.env.MARKETING_UNSUBSCRIBE_SECRET = "test-secret";
   process.env.PUBLIC_API_URL = "https://api.example.com";
   pm.careReminder.findFirst.mockResolvedValue(makeReminder());
@@ -307,37 +307,61 @@ describe("CareReminderService.send", () => {
     expect(body).toContain("Stop receiving care reminders");
   });
 
-  it("suppresses the email when the recipient has opted out, but still pushes", async () => {
-    pm.careReminderOptOut.findFirst.mockResolvedValue({ id: "optout-1" });
+  it("suppresses the email when the recipient opted out of email, but still pushes", async () => {
+    pm.careReminderOptOut.findMany.mockResolvedValue([{ channel: "EMAIL" }]);
     await CareReminderService.send("reminder-1", "org-1");
     expect(sendEmail).not.toHaveBeenCalled();
     expect(NotificationService.sendToUser).toHaveBeenCalled();
   });
 
-  it("scopes the opt-out lookup to the sending practice and the email channel", async () => {
+  it("an ALL opt-out suppresses the push as well as the email", async () => {
+    // The unsubscribe flow stores ALL and tells the recipient reminders have
+    // stopped, so continuing to push would break that promise.
+    pm.careReminderOptOut.findMany.mockResolvedValue([{ channel: "ALL" }]);
     await CareReminderService.send("reminder-1", "org-1");
-    expect(pm.careReminderOptOut.findFirst).toHaveBeenCalledWith(
+    expect(sendEmail).not.toHaveBeenCalled();
+    expect(NotificationService.sendToUser).not.toHaveBeenCalled();
+  });
+
+  it("scopes the suppression lookup to the sending practice", async () => {
+    await CareReminderService.send("reminder-1", "org-1");
+    expect(pm.careReminderOptOut.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: {
-          organisationId: "org-1",
-          email: "owner@example.com",
-          channel: { in: ["EMAIL", "ALL"] },
-        },
+        where: { organisationId: "org-1", email: "owner@example.com" },
       }),
     );
   });
 
-  it("fails closed: skips the email when the opt-out lookup errors", async () => {
-    // Mailing someone who may have objected is worse than missing a reminder.
-    pm.careReminderOptOut.findFirst.mockRejectedValue(new Error("db down"));
-    await CareReminderService.send("reminder-1", "org-1");
+  it("stays retryable when the opt-out lookup errors: nothing sent, not marked SENT", async () => {
+    // Returning quietly here would let `send` mark the reminder SENT, and only a
+    // PENDING reminder can be sent again, so a transient database problem would
+    // burn the reminder permanently.
+    pm.careReminderOptOut.findMany.mockRejectedValue(new Error("db down"));
+    await expect(
+      CareReminderService.send("reminder-1", "org-1"),
+    ).rejects.toBeInstanceOf(CareReminderError);
     expect(sendEmail).not.toHaveBeenCalled();
+    expect(NotificationService.sendToUser).not.toHaveBeenCalled();
+    expect(pm.careReminder.update).not.toHaveBeenCalled();
   });
 
-  it("fails closed: skips the email when no unsubscribe link can be built", async () => {
+  it("stays retryable when no unsubscribe link can be built", async () => {
     delete process.env.PUBLIC_API_URL;
-    await CareReminderService.send("reminder-1", "org-1");
+    await expect(
+      CareReminderService.send("reminder-1", "org-1"),
+    ).rejects.toBeInstanceOf(CareReminderError);
     expect(sendEmail).not.toHaveBeenCalled();
+    expect(pm.careReminder.update).not.toHaveBeenCalled();
+  });
+
+  it("does not send the push before the suppression check resolves", async () => {
+    // Ordering matters: if push went first, a failed lookup would leave the
+    // reminder half-delivered and a retry would duplicate the push.
+    pm.careReminderOptOut.findMany.mockRejectedValue(new Error("db down"));
+    await CareReminderService.send("reminder-1", "org-1").catch(
+      () => undefined,
+    );
+    expect(NotificationService.sendToUser).not.toHaveBeenCalled();
   });
 
   it("still transitions to SENT when no parent found", async () => {

--- a/apps/backend/test/services/care-reminder.service.test.ts
+++ b/apps/backend/test/services/care-reminder.service.test.ts
@@ -20,6 +20,7 @@ jest.mock("src/config/prisma", () => ({
     patient: { findUnique: jest.fn() },
     parentPatient: { findFirst: jest.fn() },
     parent: { findUnique: jest.fn() },
+    careReminderOptOut: { findFirst: jest.fn(), upsert: jest.fn() },
   },
 }));
 
@@ -50,6 +51,7 @@ const pm = prisma as unknown as {
   patient: { findUnique: jest.Mock };
   parentPatient: { findFirst: jest.Mock };
   parent: { findUnique: jest.Mock };
+  careReminderOptOut: { findFirst: jest.Mock; upsert: jest.Mock };
 };
 
 const DUE = new Date("2026-07-15T10:00:00Z");
@@ -88,6 +90,10 @@ beforeEach(() => {
   (AuditTrailService.recordSafely as jest.Mock).mockResolvedValue(undefined);
   (NotificationService.sendToUser as jest.Mock).mockResolvedValue(undefined);
   (sendEmail as jest.Mock).mockResolvedValue(undefined);
+  // No opt-out by default, and the unsubscribe link needs both of these to build.
+  pm.careReminderOptOut.findFirst.mockResolvedValue(null);
+  process.env.MARKETING_UNSUBSCRIBE_SECRET = "test-secret";
+  process.env.PUBLIC_API_URL = "https://api.example.com";
   pm.careReminder.findFirst.mockResolvedValue(makeReminder());
   pm.careReminder.create.mockResolvedValue(makeReminder());
   pm.careReminder.createMany.mockResolvedValue({ count: 3 });
@@ -292,6 +298,46 @@ describe("CareReminderService.send", () => {
     await CareReminderService.send("reminder-1", "org-1");
     expect(sendEmail).not.toHaveBeenCalled();
     expect(NotificationService.sendToUser).toHaveBeenCalled();
+  });
+
+  it("includes an unsubscribe link in the email body", async () => {
+    await CareReminderService.send("reminder-1", "org-1");
+    const body = (sendEmail as jest.Mock).mock.calls[0][0].htmlBody as string;
+    expect(body).toContain("/v1/reminder-preferences/unsubscribe");
+    expect(body).toContain("Stop receiving care reminders");
+  });
+
+  it("suppresses the email when the recipient has opted out, but still pushes", async () => {
+    pm.careReminderOptOut.findFirst.mockResolvedValue({ id: "optout-1" });
+    await CareReminderService.send("reminder-1", "org-1");
+    expect(sendEmail).not.toHaveBeenCalled();
+    expect(NotificationService.sendToUser).toHaveBeenCalled();
+  });
+
+  it("scopes the opt-out lookup to the sending practice and the email channel", async () => {
+    await CareReminderService.send("reminder-1", "org-1");
+    expect(pm.careReminderOptOut.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          organisationId: "org-1",
+          email: "owner@example.com",
+          channel: { in: ["EMAIL", "ALL"] },
+        },
+      }),
+    );
+  });
+
+  it("fails closed: skips the email when the opt-out lookup errors", async () => {
+    // Mailing someone who may have objected is worse than missing a reminder.
+    pm.careReminderOptOut.findFirst.mockRejectedValue(new Error("db down"));
+    await CareReminderService.send("reminder-1", "org-1");
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  it("fails closed: skips the email when no unsubscribe link can be built", async () => {
+    delete process.env.PUBLIC_API_URL;
+    await CareReminderService.send("reminder-1", "org-1");
+    expect(sendEmail).not.toHaveBeenCalled();
   });
 
   it("still transitions to SENT when no parent found", async () => {

--- a/packages/database/prisma/migrations/20260823090000_add_care_reminder_opt_out/migration.sql
+++ b/packages/database/prisma/migrations/20260823090000_add_care_reminder_opt_out/migration.sql
@@ -1,0 +1,22 @@
+-- CreateEnum
+CREATE TYPE "CareReminderOptOutChannel" AS ENUM ('EMAIL', 'PUSH', 'ALL');
+
+-- CreateTable
+CREATE TABLE "CareReminderOptOut" (
+    "id" TEXT NOT NULL,
+    "organisationId" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "channel" "CareReminderOptOutChannel" NOT NULL DEFAULT 'ALL',
+    "parentId" TEXT,
+    "source" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "CareReminderOptOut_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CareReminderOptOut_organisationId_email_channel_key" ON "CareReminderOptOut"("organisationId", "email", "channel");
+
+-- CreateIndex
+CREATE INDEX "CareReminderOptOut_organisationId_email_idx" ON "CareReminderOptOut"("organisationId", "email");

--- a/packages/database/prisma/migrations/20260823090000_add_care_reminder_opt_out/migration.sql
+++ b/packages/database/prisma/migrations/20260823090000_add_care_reminder_opt_out/migration.sql
@@ -20,3 +20,18 @@ CREATE UNIQUE INDEX "CareReminderOptOut_organisationId_email_channel_key" ON "Ca
 
 -- CreateIndex
 CREATE INDEX "CareReminderOptOut_organisationId_email_idx" ON "CareReminderOptOut"("organisationId", "email");
+
+-- Enable row level security, matching 20260818090000_enable_row_level_security.
+--
+-- That migration enables RLS by looping over every table in `public`, which makes
+-- it idempotent but only covers tables that existed when it ran. This table is
+-- created by a later migration, so it would ship with RLS off and the CI check
+-- ("Check row level security is enabled on every public table") fails on it -
+-- which is exactly how this was caught.
+--
+-- Enabling with no policy is the intended default: the API connects as the owning
+-- role and bypasses RLS, so Prisma queries are unaffected, while Supabase's
+-- PostgREST surface to the `anon` and `authenticated` keys is denied by default.
+-- That matters more than usual here, because this table maps an email address to
+-- the practice it belongs to.
+ALTER TABLE "CareReminderOptOut" ENABLE ROW LEVEL SECURITY;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -3691,6 +3691,38 @@ model CareReminder {
   @@map("CareReminder")
 }
 
+/// Suppression list for care-reminder sends. A pet parent can object to further
+/// reminders (GDPR Art. 21) from a specific practice without affecting the other
+/// practices that care for the same animal, so the list is scoped by organisation
+/// and keyed by the address the reminder is actually delivered to.
+///
+/// `channel` is granular rather than a single boolean because the delivery layer
+/// grows: opting out of email must not silently mute an in-app push the parent
+/// still wants. `ALL` suppresses every channel.
+enum CareReminderOptOutChannel {
+  EMAIL
+  PUSH
+  ALL
+}
+
+model CareReminderOptOut {
+  id             String                    @id @default(uuid())
+  organisationId String
+  /// Lower-cased and trimmed before write. The recipient is identified by address
+  /// because that is what the send path resolves, and a parent may have no user row.
+  email          String
+  channel        CareReminderOptOutChannel @default(ALL)
+  parentId       String?
+  /// How the opt-out was captured, e.g. "unsubscribe-link" or "staff".
+  source         String?
+  createdAt      DateTime                  @default(now())
+  updatedAt      DateTime                  @updatedAt
+
+  @@unique([organisationId, email, channel])
+  @@index([organisationId, email])
+  @@map("CareReminderOptOut")
+}
+
 enum ProblemStatus {
   ACTIVE
   INACTIVE


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [ ] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

`CareReminderService` mails pet parents with no consent check and no unsubscribe link.

`apps/backend/src/services/care-reminder.service.ts` calls `sendEmail` directly. A search of that file for `optout`, `unsubscribe`, `consent` or `suppress` returns nothing, and the rendered body is two paragraphs with no footer. The recipient never subscribed - the practice creates the reminder and we mail the address on file - so there is currently no way for them to object and no way to stop it.

This is an exposure rather than a missing feature:

- **GDPR Art. 21** gives the recipient an unconditional right to object to this kind of processing.
- **CAN-SPAM** requires an unsubscribe mechanism on anything that is not purely transactional.

The only unsubscribe machinery in the repo is `marketing-unsubscribe.service.ts`, which is not wired to this path.

## What is the new behavior?

A per-practice opt-out, and a send path that honours it.

- New `CareReminderOptOut` model (`organisationId`, `email`, `channel`) plus `CareReminderOptOutChannel` enum (`EMAIL` / `PUSH` / `ALL`), with one additive migration.
- New `care-reminder-opt-out.service.ts`: encrypted token, suppression lookup, idempotent upsert.
- New public route `GET|POST /v1/reminder-preferences/unsubscribe`, unauthenticated by design because the recipient follows it from an email client and is not signed in. The token is the only credential and authorises exactly one action for one address at one practice.
- `dispatchNotification` now checks suppression before mailing and appends an unsubscribe footer.

### Design decisions worth reviewing

**Scoped per practice, not globally.** A parent whose animals are seen by two practices must be able to stop one without silencing the other.

**Deliberately not folded into `marketing-unsubscribe.service`.** That writes to an SES contact list and suppresses marketing mail everywhere, which is a different decision from declining one clinic's vaccination reminders. Keeping this state in our own table also means it works without SES contact-list configuration.

**`channel` is an enum, not a boolean**, so opting out of email does not silently mute an in-app push the parent still wants, and so the SMS channel has somewhere to land later. `ALL` suppresses everything.

**Token reuses `MARKETING_UNSUBSCRIBE_SECRET` but derives a separate key from it** (different HKDF-style info string). Nothing new has to be provisioned before this can ship, and a marketing token still cannot be replayed against this endpoint or the reverse - there is a test asserting exactly that. The address is encrypted rather than signed, so the link can pass through logs and referrer headers without disclosing who it belongs to.

**Both failure paths skip the send rather than mailing anyway.** If the opt-out lookup errors we cannot prove consent; if the unsubscribe URL cannot be built the mail would be non-compliant. A missed reminder is a service gap, mailing someone who objected is a breach. Both log at error level with the config keys named.

## Impact area

Backend and database. One additive migration, no backfill, no data change. Push notifications are unaffected. No frontend or mobile change.

**Config note:** the footer needs `PUBLIC_API_URL` and `MARKETING_UNSUBSCRIBE_SECRET`. Where they are absent the reminder email is skipped and logged rather than sent without a link - so any environment currently sending these mails needs both set.

## Validation performed

- **91 tests pass** across the three care-reminder suites (`--testPathPatterns=care-reminder`).
- **Both new behaviours were mutation-tested**, so the tests are known to catch a regression rather than merely being green:
  - neutering the suppression branch fails the opt-out test;
  - removing the footer fails the unsubscribe-link test.
  - A first attempt at the tamper test was also caught this way: `token + "x"` does not tamper anything, because base64url decoding drops a trailing incomplete group. The test now flips a character inside the sealed payload instead.
- `prisma validate` passes; the migration is additive (one `CREATE TYPE`, one `CREATE TABLE`, two indexes) and will be exercised by the migration CI stage.
- Backend `type-check` and `lint` clean; Aikido scan clean; gitleaks and secretlint clean via pre-commit.

## Related Issue(s)

No issue yet. Found while re-verifying the back-office gap analysis against `dev`.