### PR TITLE
fix(backend): stop a prefetched GET from unsubscribing marketing recipients

### DIFF
--- a/apps/backend/src/controllers/app/marketing-unsubscribe.controller.ts
+++ b/apps/backend/src/controllers/app/marketing-unsubscribe.controller.ts
@@ -3,19 +3,48 @@ import { z } from "zod";
 import {
   InvalidMarketingUnsubscribeTokenError,
   MarketingUnsubscribeConfigError,
+  readMarketingUnsubscribeToken,
   unsubscribeMarketingEmail,
 } from "src/services/marketing-unsubscribe.service";
+import { escapeHtml } from "src/utils/email-templates";
 import logger from "src/utils/logger";
 
 const UnsubscribeQuerySchema = z.object({
   token: z.string().min(1),
 });
 
-const successPage = `<!doctype html>
+const page = (title: string, inner: string) => `<!doctype html>
 <html lang="en">
-<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Unsubscribed</title></head>
-<body><main><h1>You have been unsubscribed</h1><p>You will no longer receive marketing emails from us.</p></main></body>
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>${title}</title></head>
+<body><main>${inner}</main></body>
 </html>`;
+
+/**
+ * GET confirms and mutates nothing.
+ *
+ * Mail providers, link scanners and security products fetch every URL in a
+ * delivered message before a human sees it. While GET performed the
+ * unsubscribe, merely delivering a marketing email could set `UnsubscribeAll`
+ * on the recipient's SES contact and silently stop all further marketing mail.
+ * The state change now happens only on POST, which those scanners do not issue.
+ * This is the same reason RFC 8058 one-click unsubscribe is specified as a POST.
+ */
+const confirmPage = (token: string) =>
+  page(
+    "Unsubscribe",
+    `<h1>Unsubscribe from marketing emails?</h1>
+<p>This stops marketing emails. Transactional messages about your account, such as appointment confirmations, are unaffected.</p>
+<form method="POST">
+  <input type="hidden" name="token" value="${escapeHtml(token)}" />
+  <button type="submit">Yes, unsubscribe me</button>
+</form>`,
+  );
+
+const successPage = page(
+  "Unsubscribed",
+  `<h1>You have been unsubscribed</h1>
+<p>You will no longer receive marketing emails from us. Transactional messages about your account are unaffected.</p>`,
+);
 
 const handleError = (error: unknown, res: Response): Response => {
   if (
@@ -33,16 +62,37 @@ const handleError = (error: unknown, res: Response): Response => {
 };
 
 export const MarketingUnsubscribeController = {
+  // Not async: this handler only reads and renders. Having no await is the point
+  // rather than an oversight.
+  confirm(this: void, req: Request, res: Response): Response {
+    try {
+      const { token } = UnsubscribeQuerySchema.parse(req.query);
+      // Validate the token so a broken link fails here rather than after the
+      // recipient has clicked through, but do not write anything.
+      readMarketingUnsubscribeToken(token);
+      return res
+        .status(200)
+        .set("Content-Type", "text/html; charset=utf-8")
+        .send(confirmPage(token));
+    } catch (error) {
+      return handleError(error, res);
+    }
+  },
+
   async unsubscribe(
     this: void,
     req: Request,
     res: Response,
   ): Promise<Response> {
     try {
-      const { token } = UnsubscribeQuerySchema.parse(req.query);
+      // The token arrives in the form body when the confirmation page posts it,
+      // and in the query string for a direct API call.
+      const body = req.body as { token?: unknown } | undefined;
+      const source = typeof body?.token === "string" ? body : req.query;
+      const { token } = UnsubscribeQuerySchema.parse(source);
       await unsubscribeMarketingEmail(token);
 
-      if (req.method === "GET") {
+      if (req.accepts(["html", "json"]) === "html") {
         return res
           .status(200)
           .set("Content-Type", "text/html; charset=utf-8")

--- a/apps/backend/src/routers/marketing-unsubscribe.router.ts
+++ b/apps/backend/src/routers/marketing-unsubscribe.router.ts
@@ -3,7 +3,10 @@ import { MarketingUnsubscribeController } from "src/controllers/app/marketing-un
 
 const router = Router();
 
-router.get("/unsubscribe", MarketingUnsubscribeController.unsubscribe);
+// GET only confirms; POST performs the unsubscribe. Mail providers and link
+// scanners fetch every URL in a delivered message, so a mutating GET would let
+// delivery alone unsubscribe the recipient.
+router.get("/unsubscribe", MarketingUnsubscribeController.confirm);
 router.post("/unsubscribe", MarketingUnsubscribeController.unsubscribe);
 
 export default router;

--- a/apps/backend/test/controllers/app/marketing-unsubscribe.controller.test.ts
+++ b/apps/backend/test/controllers/app/marketing-unsubscribe.controller.test.ts
@@ -1,4 +1,5 @@
 const unsubscribeMarketingEmail = jest.fn();
+const readMarketingUnsubscribeToken = jest.fn();
 let InvalidTokenError: new () => Error;
 let ConfigError: new () => Error;
 
@@ -9,15 +10,24 @@ jest.mock("../../../src/services/marketing-unsubscribe.service", () => {
   ConfigError = MarketingUnsubscribeConfigError;
   return {
     unsubscribeMarketingEmail,
+    readMarketingUnsubscribeToken,
     InvalidMarketingUnsubscribeTokenError,
     MarketingUnsubscribeConfigError,
   };
 });
 
+import type { Request, Response } from "express";
 import { MarketingUnsubscribeController } from "../../../src/controllers/app/marketing-unsubscribe.controller";
 
+type MockResponse = {
+  status: jest.Mock;
+  set: jest.Mock;
+  json: jest.Mock;
+  send: jest.Mock;
+};
+
 const response = () => {
-  const res: any = {};
+  const res = {} as MockResponse;
   res.status = jest.fn(() => res);
   res.set = jest.fn(() => res);
   res.json = jest.fn(() => res);
@@ -25,69 +35,127 @@ const response = () => {
   return res;
 };
 
+// The controller only touches the four methods stubbed above, so the mocks are
+// cast at the call site rather than reconstructing all of Express's types.
+const asRes = (r: MockResponse) => r as unknown as Response;
+const asReq = (o: Record<string, unknown>) => o as unknown as Request;
+
 describe("MarketingUnsubscribeController", () => {
-  beforeEach(() => jest.clearAllMocks());
-
-  it("returns an HTML confirmation for email links", async () => {
-    const res = response();
-    await MarketingUnsubscribeController.unsubscribe(
-      { method: "GET", query: { token: "signed-token" } } as any,
-      res,
-    );
-
-    expect(unsubscribeMarketingEmail).toHaveBeenCalledWith("signed-token");
-    expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.send).toHaveBeenCalledWith(
-      expect.stringContaining("unsubscribed"),
-    );
+  beforeEach(() => {
+    jest.clearAllMocks();
+    readMarketingUnsubscribeToken.mockReturnValue("person@example.com");
+    unsubscribeMarketingEmail.mockResolvedValue(undefined);
   });
 
-  it("supports one-click POST requests", async () => {
-    const res = response();
-    await MarketingUnsubscribeController.unsubscribe(
-      { method: "POST", query: { token: "signed-token" } } as any,
-      res,
-    );
+  describe("GET (confirm)", () => {
+    it("renders a confirmation and unsubscribes nobody", () => {
+      // Mail providers and link scanners fetch every URL in a delivered message.
+      // While GET performed the unsubscribe, delivery alone could set
+      // UnsubscribeAll on the recipient's contact.
+      const res = response();
+      MarketingUnsubscribeController.confirm(
+        asReq({ method: "GET", query: { token: "signed-token" } }),
+        asRes(res),
+      );
 
-    expect(res.json).toHaveBeenCalledWith({
-      message: "Successfully unsubscribed.",
+      expect(unsubscribeMarketingEmail).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(200);
+      const html = res.send.mock.calls[0][0] as string;
+      expect(html).toContain('<form method="POST">');
+      expect(html).toContain("Unsubscribe from marketing emails?");
+    });
+
+    it("rejects a request without a token", () => {
+      const res = response();
+      MarketingUnsubscribeController.confirm(
+        asReq({ method: "GET", query: {} }),
+        asRes(res),
+      );
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(unsubscribeMarketingEmail).not.toHaveBeenCalled();
+    });
+
+    it("rejects an invalid signed token before the recipient clicks", () => {
+      readMarketingUnsubscribeToken.mockImplementation(() => {
+        throw new InvalidTokenError();
+      });
+      const res = response();
+      MarketingUnsubscribeController.confirm(
+        asReq({ method: "GET", query: { token: "bad-token" } }),
+        asRes(res),
+      );
+      expect(res.status).toHaveBeenCalledWith(400);
     });
   });
 
-  it("rejects requests without a token", async () => {
-    const res = response();
-    await MarketingUnsubscribeController.unsubscribe(
-      { method: "GET", query: {} } as any,
-      res,
-    );
-
-    expect(res.status).toHaveBeenCalledWith(400);
-  });
-
-  it("rejects an invalid signed token", async () => {
-    unsubscribeMarketingEmail.mockRejectedValueOnce(new InvalidTokenError());
-    const res = response();
-
-    await MarketingUnsubscribeController.unsubscribe(
-      { method: "GET", query: { token: "bad-token" } } as any,
-      res,
-    );
-
-    expect(res.status).toHaveBeenCalledWith(400);
-  });
-
-  it.each([new ConfigError(), new Error("SES unavailable")])(
-    "returns 500 when SES unsubscribe fails",
-    async (error) => {
-      unsubscribeMarketingEmail.mockRejectedValueOnce(error);
+  describe("POST (unsubscribe)", () => {
+    it("unsubscribes from the form body and returns HTML to a browser", async () => {
       const res = response();
-
       await MarketingUnsubscribeController.unsubscribe(
-        { method: "POST", query: { token: "signed-token" } } as any,
-        res,
+        asReq({
+          method: "POST",
+          body: { token: "signed-token" },
+          query: {},
+          accepts: () => "html",
+        }),
+        asRes(res),
       );
 
-      expect(res.status).toHaveBeenCalledWith(500);
-    },
-  );
+      expect(unsubscribeMarketingEmail).toHaveBeenCalledWith("signed-token");
+      expect(res.send).toHaveBeenCalledWith(
+        expect.stringContaining("unsubscribed"),
+      );
+    });
+
+    it("supports one-click POST with the token in the query string", async () => {
+      const res = response();
+      await MarketingUnsubscribeController.unsubscribe(
+        asReq({
+          method: "POST",
+          body: {},
+          query: { token: "signed-token" },
+          accepts: () => "json",
+        }),
+        asRes(res),
+      );
+
+      expect(unsubscribeMarketingEmail).toHaveBeenCalledWith("signed-token");
+      expect(res.json).toHaveBeenCalledWith({
+        message: "Successfully unsubscribed.",
+      });
+    });
+
+    it("rejects an invalid signed token", async () => {
+      unsubscribeMarketingEmail.mockRejectedValueOnce(new InvalidTokenError());
+      const res = response();
+      await MarketingUnsubscribeController.unsubscribe(
+        asReq({
+          method: "POST",
+          body: { token: "bad-token" },
+          query: {},
+          accepts: () => "json",
+        }),
+        asRes(res),
+      );
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    it.each([new ConfigError(), new Error("SES unavailable")])(
+      "returns 500 when SES unsubscribe fails",
+      async (error) => {
+        unsubscribeMarketingEmail.mockRejectedValueOnce(error);
+        const res = response();
+        await MarketingUnsubscribeController.unsubscribe(
+          asReq({
+            method: "POST",
+            body: { token: "signed-token" },
+            query: {},
+            accepts: () => "json",
+          }),
+          asRes(res),
+        );
+        expect(res.status).toHaveBeenCalledWith(500);
+      },
+    );
+  });
 });

--- a/apps/backend/test/routers/marketing-unsubscribe.router.test.ts
+++ b/apps/backend/test/routers/marketing-unsubscribe.router.test.ts
@@ -1,23 +1,44 @@
 import type { Router } from "express";
 
+const confirm = jest.fn();
 const unsubscribe = jest.fn();
 
 jest.mock("../../src/controllers/app/marketing-unsubscribe.controller", () => ({
-  MarketingUnsubscribeController: { unsubscribe },
+  MarketingUnsubscribeController: { confirm, unsubscribe },
 }));
 
 const router = jest.requireActual(
   "../../src/routers/marketing-unsubscribe.router",
 ).default as Router;
 
+type Layer = {
+  route?: {
+    path: string;
+    methods: Record<string, boolean>;
+    stack: { handle: unknown }[];
+  };
+};
+
+const handlerFor = (method: string) => {
+  const layer = (router as unknown as { stack: Layer[] }).stack.find(
+    (l) => l.route?.path === "/unsubscribe" && Boolean(l.route.methods[method]),
+  );
+  expect(layer).toBeDefined();
+  return layer!.route!.stack[0].handle;
+};
+
 describe("marketing-unsubscribe.router", () => {
-  it.each(["get", "post"])("exposes the public %s endpoint", (method) => {
-    const route = (router as any).stack.find(
-      (layer: any) =>
-        layer.route?.path === "/unsubscribe" &&
-        Boolean(layer.route.methods[method]),
-    );
-    expect(route).toBeDefined();
-    expect(route.route.stack[0].handle).toBe(unsubscribe);
+  it("routes GET to the read-only confirmation handler", () => {
+    // The split is the security property: a mutating GET would let a mail
+    // scanner's prefetch unsubscribe the recipient.
+    expect(handlerFor("get")).toBe(confirm);
+  });
+
+  it("routes POST to the handler that performs the unsubscribe", () => {
+    expect(handlerFor("post")).toBe(unsubscribe);
+  });
+
+  it("does not route GET to the mutating handler", () => {
+    expect(handlerFor("get")).not.toBe(unsubscribe);
   });
 });


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [ ] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

`GET /v1/email-preferences/unsubscribe?token=...` performs the unsubscribe immediately. The handler calls `unsubscribeMarketingEmail(token)` on both verbs, and that sets `UnsubscribeAll: true` on the recipient's SES contact.

Mail providers, link scanners and security products fetch every URL in a delivered message before a human sees it. So **delivering a marketing email can be enough to unsubscribe the recipient from all marketing mail** - no click, and afterwards there is no way to tell an accidental unsubscribe from a real one.

The existing test encoded the behaviour rather than questioning it: `"returns an HTML confirmation for email links"` asserted that a GET had already unsubscribed the address.

## What is the new behavior?

GET confirms, POST performs.

- `GET` renders a confirmation page and writes nothing. The token is still verified there, so a broken link fails before the recipient clicks rather than after.
- `POST` performs the unsubscribe. Genuine one-click clients keep working, because RFC 8058 one-click unsubscribe is itself a POST - the same reasoning this fix follows.
- The token is accepted from the form body as well as the query string, so the confirmation page can post it back.

## Impact area

Backend only. No schema change, no migration, no frontend change. The public route keeps its path and both verbs; only which handler each verb reaches changes.

**Behaviour change worth calling out:** a recipient who previously landed on "You have been unsubscribed" straight from the email link now sees a confirmation page with one button first. That is the point of the fix, but it is a visible change to the flow.

## Validation performed

- 30 tests pass across the three `marketing-unsubscribe` suites.
- The routing guarantee is **mutation-tested**: pointing `GET` back at the mutating handler fails two tests, so the tests hold the property rather than merely being green.
- Two tests were corrected rather than added: the controller test that asserted a GET unsubscribes now asserts it does not, and the router test that only checked both verbs were mounted (which stayed green whichever handler they pointed at) now pins each verb to its handler.
- `type-check` and `lint` clean.
- Note on scanning: the local Aikido MCP could not run its SAST rules (`unable to find a config ... opengrep_rules`), and running opengrep directly against the full rule set timed out locally. The secrets scan ran clean, and gitleaks plus secretlint passed in the pre-commit hook. **The Aikido CI gate on this PR is therefore the authoritative security check** rather than a local pass.

## Related Issue(s)

No issue yet. Same defect and same fix as the care-reminder opt-out path in #2419, found while building that one. This is the older and wider-reaching instance, because the SES suppression is global rather than scoped to one practice.