### PR TITLE
refactor(backend): build both unsubscribe surfaces from one factory

### DIFF
--- a/apps/backend/src/controllers/app/care-reminder-opt-out.controller.ts
+++ b/apps/backend/src/controllers/app/care-reminder-opt-out.controller.ts
@@ -1,5 +1,3 @@
-import type { Request, Response } from "express";
-import { z } from "zod";
 import {
   CareReminderOptOutConfigError,
   InvalidCareReminderOptOutTokenError,
@@ -7,29 +5,13 @@ import {
   unsubscribeFromCareReminders,
 } from "src/services/care-reminder-opt-out.service";
 import { escapeHtml } from "src/utils/email-templates";
-import logger from "src/utils/logger";
+import {
+  createUnsubscribeController,
+  unsubscribePage,
+} from "./shared/unsubscribe-controller";
 
-const UnsubscribeQuerySchema = z.object({
-  token: z.string().min(1),
-});
-
-const page = (title: string, inner: string) => `<!doctype html>
-<html lang="en">
-<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>${title}</title></head>
-<body><main>${inner}</main></body>
-</html>`;
-
-/**
- * GET renders a confirmation and mutates nothing.
- *
- * Mail providers, link scanners and security products fetch every URL in a
- * message before a human ever sees it. If GET persisted the opt-out, simply
- * delivering the reminder could unsubscribe the recipient. The state change
- * therefore happens only on POST, which those scanners do not issue - the same
- * reason RFC 8058 one-click unsubscribe is specified as a POST.
- */
 const confirmPage = (token: string) =>
-  page(
+  unsubscribePage(
     "Stop care reminders",
     `<h1>Stop receiving care reminders?</h1>
 <p>This stops care reminders from this practice only. Reminders from any other practice that cares for your companion are unaffected, and your appointment confirmations still apply.</p>
@@ -39,67 +21,19 @@ const confirmPage = (token: string) =>
 </form>`,
   );
 
-const successPage = page(
+const successPage = unsubscribePage(
   "Reminders stopped",
   `<h1>You have been unsubscribed</h1>
 <p>You will no longer receive care reminders from this practice. Reminders from any other practice that cares for your companion are unaffected, and your appointment confirmations still apply.</p>`,
 );
 
-const handleError = (error: unknown, res: Response): Response => {
-  if (
-    error instanceof z.ZodError ||
-    error instanceof InvalidCareReminderOptOutTokenError
-  ) {
-    return res.status(400).json({ message: "Invalid unsubscribe link." });
-  }
-  if (error instanceof CareReminderOptOutConfigError) {
-    logger.error("Care reminder opt-out configuration is invalid.", { error });
-  } else {
-    logger.error("Failed to record care reminder opt-out.", { error });
-  }
-  return res.status(500).json({ message: "Unable to unsubscribe right now." });
-};
-
-export const CareReminderOptOutController = {
-  // Not async: this handler only reads and renders, and having no await is the
-  // point rather than an oversight.
-  confirm(this: void, req: Request, res: Response): Response {
-    try {
-      const { token } = UnsubscribeQuerySchema.parse(req.query);
-      // Validate the token so a broken link fails here rather than after the
-      // recipient has clicked through, but do not write anything.
-      readCareReminderOptOutToken(token);
-      return res
-        .status(200)
-        .set("Content-Type", "text/html; charset=utf-8")
-        .send(confirmPage(token));
-    } catch (error) {
-      return handleError(error, res);
-    }
-  },
-
-  async unsubscribe(
-    this: void,
-    req: Request,
-    res: Response,
-  ): Promise<Response> {
-    try {
-      // The token arrives in the form body when the confirmation page posts it,
-      // and in the query string for a direct API call.
-      const body = req.body as { token?: unknown } | undefined;
-      const source = typeof body?.token === "string" ? body : req.query;
-      const { token } = UnsubscribeQuerySchema.parse(source);
-      await unsubscribeFromCareReminders(token);
-
-      if (req.accepts(["html", "json"]) === "html") {
-        return res
-          .status(200)
-          .set("Content-Type", "text/html; charset=utf-8")
-          .send(successPage);
-      }
-      return res.status(200).json({ message: "Successfully unsubscribed." });
-    } catch (error) {
-      return handleError(error, res);
-    }
-  },
-};
+export const CareReminderOptOutController = createUnsubscribeController({
+  readToken: readCareReminderOptOutToken,
+  unsubscribe: unsubscribeFromCareReminders,
+  InvalidTokenError: InvalidCareReminderOptOutTokenError,
+  ConfigError: CareReminderOptOutConfigError,
+  configErrorMessage: "Care reminder opt-out configuration is invalid.",
+  failureMessage: "Failed to record care reminder opt-out.",
+  confirmPage,
+  successPage,
+});

--- a/apps/backend/src/controllers/app/marketing-unsubscribe.controller.ts
+++ b/apps/backend/src/controllers/app/marketing-unsubscribe.controller.ts
@@ -1,5 +1,3 @@
-import type { Request, Response } from "express";
-import { z } from "zod";
 import {
   InvalidMarketingUnsubscribeTokenError,
   MarketingUnsubscribeConfigError,
@@ -7,30 +5,13 @@ import {
   unsubscribeMarketingEmail,
 } from "src/services/marketing-unsubscribe.service";
 import { escapeHtml } from "src/utils/email-templates";
-import logger from "src/utils/logger";
+import {
+  createUnsubscribeController,
+  unsubscribePage,
+} from "./shared/unsubscribe-controller";
 
-const UnsubscribeQuerySchema = z.object({
-  token: z.string().min(1),
-});
-
-const page = (title: string, inner: string) => `<!doctype html>
-<html lang="en">
-<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>${title}</title></head>
-<body><main>${inner}</main></body>
-</html>`;
-
-/**
- * GET confirms and mutates nothing.
- *
- * Mail providers, link scanners and security products fetch every URL in a
- * delivered message before a human sees it. While GET performed the
- * unsubscribe, merely delivering a marketing email could set `UnsubscribeAll`
- * on the recipient's SES contact and silently stop all further marketing mail.
- * The state change now happens only on POST, which those scanners do not issue.
- * This is the same reason RFC 8058 one-click unsubscribe is specified as a POST.
- */
 const confirmPage = (token: string) =>
-  page(
+  unsubscribePage(
     "Unsubscribe",
     `<h1>Unsubscribe from marketing emails?</h1>
 <p>This stops marketing emails. Transactional messages about your account, such as appointment confirmations, are unaffected.</p>
@@ -40,67 +21,19 @@ const confirmPage = (token: string) =>
 </form>`,
   );
 
-const successPage = page(
+const successPage = unsubscribePage(
   "Unsubscribed",
   `<h1>You have been unsubscribed</h1>
 <p>You will no longer receive marketing emails from us. Transactional messages about your account are unaffected.</p>`,
 );
 
-const handleError = (error: unknown, res: Response): Response => {
-  if (
-    error instanceof z.ZodError ||
-    error instanceof InvalidMarketingUnsubscribeTokenError
-  ) {
-    return res.status(400).json({ message: "Invalid unsubscribe link." });
-  }
-  if (error instanceof MarketingUnsubscribeConfigError) {
-    logger.error("Marketing unsubscribe configuration is invalid.", { error });
-  } else {
-    logger.error("Failed to unsubscribe SES marketing contact.", { error });
-  }
-  return res.status(500).json({ message: "Unable to unsubscribe right now." });
-};
-
-export const MarketingUnsubscribeController = {
-  // Not async: this handler only reads and renders. Having no await is the point
-  // rather than an oversight.
-  confirm(this: void, req: Request, res: Response): Response {
-    try {
-      const { token } = UnsubscribeQuerySchema.parse(req.query);
-      // Validate the token so a broken link fails here rather than after the
-      // recipient has clicked through, but do not write anything.
-      readMarketingUnsubscribeToken(token);
-      return res
-        .status(200)
-        .set("Content-Type", "text/html; charset=utf-8")
-        .send(confirmPage(token));
-    } catch (error) {
-      return handleError(error, res);
-    }
-  },
-
-  async unsubscribe(
-    this: void,
-    req: Request,
-    res: Response,
-  ): Promise<Response> {
-    try {
-      // The token arrives in the form body when the confirmation page posts it,
-      // and in the query string for a direct API call.
-      const body = req.body as { token?: unknown } | undefined;
-      const source = typeof body?.token === "string" ? body : req.query;
-      const { token } = UnsubscribeQuerySchema.parse(source);
-      await unsubscribeMarketingEmail(token);
-
-      if (req.accepts(["html", "json"]) === "html") {
-        return res
-          .status(200)
-          .set("Content-Type", "text/html; charset=utf-8")
-          .send(successPage);
-      }
-      return res.status(200).json({ message: "Successfully unsubscribed." });
-    } catch (error) {
-      return handleError(error, res);
-    }
-  },
-};
+export const MarketingUnsubscribeController = createUnsubscribeController({
+  readToken: readMarketingUnsubscribeToken,
+  unsubscribe: unsubscribeMarketingEmail,
+  InvalidTokenError: InvalidMarketingUnsubscribeTokenError,
+  ConfigError: MarketingUnsubscribeConfigError,
+  configErrorMessage: "Marketing unsubscribe configuration is invalid.",
+  failureMessage: "Failed to unsubscribe SES marketing contact.",
+  confirmPage,
+  successPage,
+});

--- a/apps/backend/src/controllers/app/shared/unsubscribe-controller.ts
+++ b/apps/backend/src/controllers/app/shared/unsubscribe-controller.ts
@@ -1,0 +1,108 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import logger from "src/utils/logger";
+
+const UnsubscribeQuerySchema = z.object({
+  token: z.string().min(1),
+});
+
+export const unsubscribePage = (
+  title: string,
+  inner: string,
+) => `<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>${title}</title></head>
+<body><main>${inner}</main></body>
+</html>`;
+
+type UnsubscribeControllerConfig = {
+  /**
+   * Validates the token WITHOUT writing anything, so a broken link fails on the
+   * confirmation page rather than after the recipient has clicked through.
+   */
+  readToken: (token: string) => unknown;
+  unsubscribe: (token: string) => Promise<unknown>;
+  /** Thrown for a token that is malformed, expired or not ours -> 400. */
+  InvalidTokenError: new (...args: never[]) => Error;
+  /** Thrown when the server is misconfigured -> 500, logged differently. */
+  ConfigError: new (...args: never[]) => Error;
+  configErrorMessage: string;
+  failureMessage: string;
+  confirmPage: (token: string) => string;
+  successPage: string;
+};
+
+/**
+ * The two unsubscribe surfaces - care reminders and marketing email - are the
+ * same handler over different tokens, services and copy, so they are built
+ * from one factory rather than written twice.
+ *
+ * The GET/POST split is the load-bearing part and belongs here so neither
+ * surface can lose it: mail providers, link scanners and security products
+ * fetch every URL in a delivered message before a human sees it, so a GET that
+ * persisted the opt-out would let mere delivery unsubscribe the recipient. The
+ * state change happens only on POST, which those scanners do not issue - the
+ * same reason RFC 8058 one-click unsubscribe is specified as a POST.
+ */
+export const createUnsubscribeController = (
+  config: UnsubscribeControllerConfig,
+) => {
+  const handleError = (error: unknown, res: Response): Response => {
+    if (
+      error instanceof z.ZodError ||
+      error instanceof config.InvalidTokenError
+    ) {
+      return res.status(400).json({ message: "Invalid unsubscribe link." });
+    }
+    if (error instanceof config.ConfigError) {
+      logger.error(config.configErrorMessage, { error });
+    } else {
+      logger.error(config.failureMessage, { error });
+    }
+    return res
+      .status(500)
+      .json({ message: "Unable to unsubscribe right now." });
+  };
+
+  return {
+    // Not async: this handler only reads and renders, and having no await is
+    // the point rather than an oversight.
+    confirm(this: void, req: Request, res: Response): Response {
+      try {
+        const { token } = UnsubscribeQuerySchema.parse(req.query);
+        config.readToken(token);
+        return res
+          .status(200)
+          .set("Content-Type", "text/html; charset=utf-8")
+          .send(config.confirmPage(token));
+      } catch (error) {
+        return handleError(error, res);
+      }
+    },
+
+    async unsubscribe(
+      this: void,
+      req: Request,
+      res: Response,
+    ): Promise<Response> {
+      try {
+        // The token arrives in the form body when the confirmation page posts
+        // it, and in the query string for a direct API call.
+        const body = req.body as { token?: unknown } | undefined;
+        const source = typeof body?.token === "string" ? body : req.query;
+        const { token } = UnsubscribeQuerySchema.parse(source);
+        await config.unsubscribe(token);
+
+        if (req.accepts(["html", "json"]) === "html") {
+          return res
+            .status(200)
+            .set("Content-Type", "text/html; charset=utf-8")
+            .send(config.successPage);
+        }
+        return res.status(200).json({ message: "Successfully unsubscribed." });
+      } catch (error) {
+        return handleError(error, res);
+      }
+    },
+  };
+};


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [ ] There is an issue for the bug/feature this PR is for. (Found while unblocking the dev to main promotion.)
- [x] All existing tests and lints pass.

## What is the current behavior?

The care-reminder opt-out and marketing unsubscribe controllers landed within a day of each other (#2419, #2421) and are the same handler written twice: same query schema, same HTML shell, same GET-confirms/POST-mutates split, same error mapping. Only the token reader, the unsubscribe action, the two error classes, the log messages and the page copy differ.

Sonar measures 20 duplicated lines in each. That puts new-code duplication at 0.1% against the repo's 0% ceiling, which fails the `sonar-thresholds` gate and blocks the dev to main promotion (#2417). The Sonar quality gate itself passes; it is the stricter in-house check that does not.

## What is the new behavior?

Both are built from `createUnsubscribeController`, configured with the parts that genuinely differ.

The GET/POST split moves into the factory deliberately rather than incidentally. It is the load-bearing part of these endpoints: mail providers, link scanners and security products fetch every URL in a delivered message before a human sees it, so a GET that persisted the opt-out would let mere delivery unsubscribe the recipient. Keeping it in one place means neither surface can lose it independently.

## Validation performed

- All 54 tests across both controllers and the router pass untouched - no test changes were needed, which is the point.
- Full backend suite: 427 suites, 10,283 tests.
- Type-check and lint clean.

## Related Issue(s)

Fixes #
