### PR TITLE
fix(mobile): make the wallet button labels visible in dark mode

### DIFF
--- a/apps/mobileAppYC/__tests__/theme/ctaOnSecondaryContrast.test.ts
+++ b/apps/mobileAppYC/__tests__/theme/ctaOnSecondaryContrast.test.ts
@@ -1,0 +1,50 @@
+import {colors, colorsDark} from '@/theme';
+
+/**
+ * Buttons tinted `secondary` must label themselves with `ctaText`.
+ *
+ * `secondary` flips with the theme (near-black in light, bone in dark) while
+ * `white` is a fixed literal, so a white label on one of these buttons is
+ * legible in light and invisible in dark. That shipped on the passport wallet
+ * buttons at 1.18:1 and went unseen only because the screen was unreachable.
+ */
+const toRgb = (hex: string): [number, number, number] => {
+  const h = hex.replace('#', '');
+  return [
+    parseInt(h.slice(0, 2), 16),
+    parseInt(h.slice(2, 4), 16),
+    parseInt(h.slice(4, 6), 16),
+  ];
+};
+
+const relativeLuminance = (hex: string): number => {
+  const channel = (value: number) => {
+    const v = value / 255;
+    return v <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4;
+  };
+  const [r, g, b] = toRgb(hex);
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+};
+
+const contrast = (a: string, b: string): number => {
+  const la = relativeLuminance(a);
+  const lb = relativeLuminance(b);
+  return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+};
+
+describe('ctaText pairs with the secondary tint in both themes', () => {
+  it.each([
+    ['light', colors],
+    ['dark', colorsDark],
+  ])('clears 4.5:1 in %s mode', (_theme, palette) => {
+    expect(contrast(palette.ctaText, palette.secondary)).toBeGreaterThanOrEqual(
+      4.5,
+    );
+  });
+
+  it('white would fail in dark mode, which is why the token matters', () => {
+    // Pins the reason rather than just the outcome: if someone reaches for
+    // `white` again on one of these buttons, this is the number they get.
+    expect(contrast(colorsDark.white, colorsDark.secondary)).toBeLessThan(1.5);
+  });
+});

--- a/apps/mobileAppYC/src/features/passport/components/passportStyles.ts
+++ b/apps/mobileAppYC/src/features/passport/components/passportStyles.ts
@@ -64,7 +64,13 @@ export const createPassportStyles = (theme: any) =>
     },
     walletButtonText: {
       ...theme.typography.buttonSmall,
-      color: theme.colors.white,
+      // ctaText, not white. These buttons are tinted `secondary`, which flips
+      // with the theme - near-black in light, bone in dark - so a fixed white
+      // label reads 13.36:1 in light and 1.18:1 in dark, i.e. invisible. Nobody
+      // caught it because the passport screen was unreachable until the parent
+      // scope lookup was fixed. ctaText flips with `secondary` and pairs at
+      // 13.36:1 / 14.40:1.
+      color: theme.colors.ctaText,
     },
     identityName: {
       ...theme.typography.h4,


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [ ] There is an issue for the bug/feature this PR is for. (Found verifying the passport end to end after the backend fix landed.)
- [x] All existing tests and lints pass.

## What is the current behavior?

"Add to Apple Wallet" and "Add to Google Wallet" are white text on a `secondary`-tinted button.

`secondary` flips with the theme - `#302F2E` in light, `#F2ECE1` in dark - while `white` is a fixed literal. So the labels measure 13.36:1 in light and **1.18:1 in dark**: invisible. Measured on device, not derived from tokens.

Nobody had seen this because the passport screen was unreachable. The parent scope lookup 404ed for every user (#2420), so these buttons never rendered for anyone. Fixing that is what exposed this.

## What is the new behavior?

`ctaText` is the token that flips together with `secondary` - `#FFFFFF` light, `#201C18` dark - and is already used at 82 call sites for exactly this pairing. The labels now measure 13.36:1 in light and 14.40:1 in dark.

Cross-referencing every component that tints a button with `secondary` against every use of `colors.white`, this was the only place in the app doing it, so the fix is one line rather than a sweep.

## Validation performed

- Measured on the live app in both themes by scanning a band through the button and reading the raw RGB.
- New guard test asserts the `ctaText`/`secondary` pairing clears 4.5:1 in both themes, and separately pins what `white` would score, so the next person to reach for it gets the number rather than a bare failure.
- 17 suites / 156 tests in the touched areas pass; type-check and lint clean.

## Note

Separately from this: both wallet endpoints currently return `501 Apple/Google Wallet is not configured` on production, because none of `APPLE_PASS_TYPE_ID`, `APPLE_TEAM_ID`, `APPLE_PASS_P12_BASE64`, `APPLE_PASS_P12_PASSWORD`, `APPLE_WWDR_BASE64`, `GOOGLE_WALLET_ISSUER_ID`, `GOOGLE_WALLET_SA_EMAIL` or `GOOGLE_WALLET_SA_PRIVATE_KEY` are set there. The app handles that correctly with a "Wallet pass unavailable" alert. That is provisioning, not code, and is not addressed here.

## Related Issue(s)

Fixes #
