### PR TITLE
fix(mobile): stop passing render callbacks straight to .map

### DIFF
--- a/apps/mobileAppYC/src/features/appointments/screens/ViewAppointmentScreen.tsx
+++ b/apps/mobileAppYC/src/features/appointments/screens/ViewAppointmentScreen.tsx
@@ -1311,7 +1311,7 @@ export const ViewAppointmentScreen: React.FC = () => {
                   return <ActivityIndicator />;
                 }
                 if (appointmentForms.length > 0) {
-                  return appointmentForms.map(renderFormCard);
+                  return appointmentForms.map(entry => renderFormCard(entry));
                 }
                 return (
                   <Text style={styles.emptyDocsText}>

--- a/apps/mobileAppYC/src/features/tasks/components/TaskTypeBottomSheet/TaskTypeBottomSheet.tsx
+++ b/apps/mobileAppYC/src/features/tasks/components/TaskTypeBottomSheet/TaskTypeBottomSheet.tsx
@@ -223,7 +223,7 @@ export const TaskTypeBottomSheet = ({
           {subsubcat.subsubcategory.label}
         </Text>
         <View style={styles.pillsContainer}>
-          {subsubcat.children.map(renderPillButton)}
+          {subsubcat.children.map(child => renderPillButton(child))}
         </View>
       </View>
     ),
@@ -251,10 +251,14 @@ export const TaskTypeBottomSheet = ({
           )}
 
           {hasSubsubcategories ? (
-            <View>{subcat.subsubcategories!.map(renderSubsubcategory)}</View>
+            <View>
+              {subcat.subsubcategories!.map(subsubcat =>
+                renderSubsubcategory(subsubcat),
+              )}
+            </View>
           ) : (
             <View style={styles.pillsContainer}>
-              {subcat.children?.map(renderPillButton)}
+              {subcat.children?.map(child => renderPillButton(child))}
             </View>
           )}
         </View>

--- a/apps/mobileAppYC/src/shared/components/common/PillSelector/PillSelector.tsx
+++ b/apps/mobileAppYC/src/shared/components/common/PillSelector/PillSelector.tsx
@@ -158,14 +158,16 @@ export const PillSelector: React.FC<PillSelectorProps> = ({
         showsHorizontalScrollIndicator={false}
         contentContainerStyle={[styles.scrollContent, contentStyle]}
         style={[styles.container, containerStyle]}>
-        <View style={styles.scrollRow}>{options.map(renderOption)}</View>
+        <View style={styles.scrollRow}>
+          {options.map(option => renderOption(option))}
+        </View>
       </ScrollView>
     );
   }
 
   return (
     <View style={[styles.container, styles.staticContainer, containerStyle]}>
-      {options.map(renderOption)}
+      {options.map(option => renderOption(option))}
     </View>
   );
 };


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [ ] There is an issue for the bug/feature this PR is for. (Sonar findings surfaced on the dev to main promotion, #2417.)
- [x] All existing tests and lints pass.

## What is the current behavior?

`.map` calls its callback with `(element, index, array)`, so `subsubcat.children.map(renderPillButton)` hands the render function an index and the whole array as well as the item.

Sonar reports two of these as **Bug / Major** on `TaskTypeBottomSheet.tsx` (L226, L254).

To be accurate about severity: none of these is a live defect today. Every one of the render functions declares exactly one parameter, so the extra arguments are discarded and the UI is correct. What the rule is protecting against is the next edit - the moment any of these functions gains a second parameter, `.map` starts silently filling it with the index, and the failure is invisible at the call site.

## What is the new behavior?

Each call site passes only the element.

Five in total, not the two reported. Sweeping the codebase for the same pattern found a third instance in `TaskTypeBottomSheet` a few lines below the reported ones, one in `ViewAppointmentScreen`, and two in `PillSelector`. A grep for `.map(renderX)` now returns nothing.

## Validation performed

- Full mobile suite: 466 suites, 7,576 tests.
- Type-check and lint clean.
- Behaviour is unchanged by construction, and the touched components' own suites (TaskType, PillSelector, ViewAppointment - 166 tests) pass untouched.

## Related Issue(s)

Fixes #
