### PR TITLE
fix(repo): file the pet passport under Health, never under Admin

### DIFF
--- a/apps/backend/src/services/document.service.ts
+++ b/apps/backend/src/services/document.service.ts
@@ -29,8 +29,14 @@ const COMPANION_DOCUMENT_CATEGORIES = new Set([
 // subcategory under HEALTH and HYGIENE_MAINTENANCE, so both are accepted here;
 // omitting them rejected a value the UI let the user choose.
 const VALID_CATEGORY_SUBCATEGORIES: Record<string, Set<string>> = {
-  ADMIN: new Set(["PASSPORT", "CERTIFICATES", "INSURANCE"]),
+  ADMIN: new Set(["CERTIFICATES", "INSURANCE"]),
   HEALTH: new Set([
+    // A pet passport is a health record, not paperwork: it carries the
+    // vaccination, parasite-treatment and rabies-titration history a vet
+    // signs. It sat under ADMIN beside insurance, which is also where PIMS
+    // could never reach it - the web picker only ever offers HEALTH and
+    // HYGIENE_MAINTENANCE.
+    "PASSPORT",
     "SURGERY_OR_PROCEDURE",
     "PRESCRIPTION",
     "VACCINATION",

--- a/apps/backend/test/services/document.service.test.ts
+++ b/apps/backend/test/services/document.service.test.ts
@@ -407,7 +407,7 @@ describe("DocumentService", () => {
     } as any);
     mockedPrisma.document.update.mockResolvedValueOnce({
       ...baseRow,
-      category: "ADMIN",
+      category: "HEALTH",
       subcategory: "PASSPORT",
       syncedFromPms: true,
       attachments: baseRow.attachments,
@@ -416,7 +416,7 @@ describe("DocumentService", () => {
     const updated = await DocumentService.update(
       uuidDocumentId,
       {
-        category: "admin",
+        category: "health",
         subcategory: "passport",
         attachments: [{ key: "k-2", mimeType: "application/pdf", size: 5 }],
       },
@@ -426,7 +426,7 @@ describe("DocumentService", () => {
     expect(mockedPrisma.document.update).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
-          category: "ADMIN",
+          category: "HEALTH",
           subcategory: "PASSPORT",
           pmsVisible: true,
         }),
@@ -449,7 +449,7 @@ describe("DocumentService", () => {
         actorId: "pms-1",
       }),
     );
-    expect(updated.category).toBe("ADMIN");
+    expect(updated.category).toBe("HEALTH");
   });
 
   it("clears the subcategory when the update sets it to null", async () => {
@@ -639,7 +639,7 @@ describe("DocumentService", () => {
   // server-side set stopped accepting one, the upload failed with a 400 on a
   // choice the UI had offered the user.
   it.each([
-    ["ADMIN", "PASSPORT"],
+    ["HEALTH", "PASSPORT"],
     ["ADMIN", "CERTIFICATES"],
     ["ADMIN", "INSURANCE"],
     ["HEALTH", "SURGERY_OR_PROCEDURE"],
@@ -677,6 +677,26 @@ describe("DocumentService", () => {
       ).resolves.toBeDefined();
     },
   );
+
+  it("no longer accepts a passport under ADMIN", async () => {
+    // A passport is a health record - it carries the vaccination, parasite
+    // treatment and rabies titration history a vet signs - not paperwork like
+    // insurance. Filing it under ADMIN also put it out of PIMS's reach
+    // entirely: the web picker only ever offers HEALTH and
+    // HYGIENE_MAINTENANCE, so no clinic could file or find one.
+    await expect(
+      DocumentService.create(
+        {
+          patientId: uuidPatientId,
+          category: "ADMIN",
+          subcategory: "PASSPORT",
+          title: "Doc",
+          attachments: [{ key: "k-1", mimeType: "image/png" }],
+        },
+        { parentId: uuidParentId },
+      ),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
 
   it("rejects invalid inputs", async () => {
     await expect(

--- a/apps/frontend/src/app/__tests__/types/companionDocuments.test.ts
+++ b/apps/frontend/src/app/__tests__/types/companionDocuments.test.ts
@@ -33,6 +33,9 @@ describe('companionDocuments types', () => {
   describe('HealthCategoryOptions', () => {
     it('matches the approved health subcategory list', () => {
       expect(HealthCategoryOptions).toEqual([
+        // A passport is a health record, not admin paperwork. It used to sit
+        // under ADMIN, which PIMS never offers, so no clinic could file one.
+        { label: 'Passport', value: 'PASSPORT' },
         { label: 'Surgery/ Procedure', value: 'SURGERY_OR_PROCEDURE' },
         { label: 'Prescription', value: 'PRESCRIPTION' },
         { label: 'Vaccination', value: 'VACCINATION' },

--- a/apps/frontend/src/app/features/documents/types/companionDocuments.ts
+++ b/apps/frontend/src/app/features/documents/types/companionDocuments.ts
@@ -12,6 +12,7 @@ export const CategoryOptions: Option[] = makeOptions([
 ]);
 
 export const HealthCategoryOptions: Option[] = makeOptions([
+  ['Passport', 'PASSPORT'],
   ['Surgery/ Procedure', 'SURGERY_OR_PROCEDURE'],
   ['Prescription', 'PRESCRIPTION'],
   ['Vaccination', 'VACCINATION'],
@@ -54,6 +55,7 @@ export type VisitType = 'HOSPITAL' | 'GROOMER' | 'BOARDER' | 'BREEDER' | 'SHOP' 
 export type Category = 'HEALTH' | 'HYGIENE_MAINTENANCE';
 
 export type HealthSubcategory =
+  | 'PASSPORT'
   | 'SURGERY_OR_PROCEDURE'
   | 'PRESCRIPTION'
   | 'VACCINATION'

--- a/apps/mobileAppYC/src/features/documents/constants.ts
+++ b/apps/mobileAppYC/src/features/documents/constants.ts
@@ -6,13 +6,12 @@ export const DOCUMENT_CATEGORIES: DocumentCategory[] = [
   {
     id: 'admin',
     label: 'Admin',
-    description: 'Passport, certificates, insurance',
+    description: 'Certificates, insurance',
     icon: Images.adminIcon,
     iconTint: 'avatarVioletBg',
     isSynced: false,
     fileCount: 0,
     subcategories: [
-      {id: S.PASSPORT, label: 'Passport', fileCount: 0},
       {
         id: S.CERTIFICATES,
         label:
@@ -25,12 +24,13 @@ export const DOCUMENT_CATEGORIES: DocumentCategory[] = [
   {
     id: 'health',
     label: 'Health',
-    description: 'Prescriptions, labs, vaccinations',
+    description: 'Passport, prescriptions, labs, vaccinations',
     icon: Images.healthIconCategory,
     iconTint: 'blueSoft',
     isSynced: true,
     fileCount: 0,
     subcategories: [
+      {id: S.PASSPORT, label: 'Passport', fileCount: 0},
       {id: S.SURGERY_PROCEDURE, label: 'Surgery/ Procedure', fileCount: 0},
       {id: S.PRESCRIPTION, label: 'Prescription', fileCount: 0},
       {id: S.VACCINATION, label: 'Vaccination', fileCount: 0},

--- a/apps/mobileAppYC/src/features/documents/subcategoryIds.ts
+++ b/apps/mobileAppYC/src/features/documents/subcategoryIds.ts
@@ -1,9 +1,9 @@
 export const SUBCATEGORY_IDS = {
   // admin
-  PASSPORT: 'passport',
   CERTIFICATES: 'certificates',
   INSURANCE: 'insurance',
   // health
+  PASSPORT: 'passport',
   SURGERY_PROCEDURE: 'surgery-procedure',
   PRESCRIPTION: 'prescription',
   VACCINATION: 'vaccination',

--- a/packages/database/prisma/migrations/20260823150000_move_passport_documents_to_health/migration.sql
+++ b/packages/database/prisma/migrations/20260823150000_move_passport_documents_to_health/migration.sql
@@ -1,0 +1,12 @@
+-- A pet passport is a health record, not paperwork: it carries the
+-- vaccination, parasite-treatment and rabies-titration history a vet signs.
+-- It was filed under ADMIN beside insurance and certificates, which also put
+-- it out of reach of PIMS entirely -- the web picker only ever offers HEALTH
+-- and HYGIENE_MAINTENANCE, so no clinic could ever file or find one.
+--
+-- The subcategory is unchanged; only the parent category moves. Idempotent:
+-- re-running matches nothing once applied.
+UPDATE "Document"
+SET category = 'HEALTH'
+WHERE category = 'ADMIN'
+  AND subcategory = 'PASSPORT';


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [ ] There is an issue for the bug/feature this PR is for. (Raised directly by Ankit while reviewing the passport surfaces.)
- [x] All existing tests and lints pass.

## What is the current behavior?

The pet passport is filed under **ADMIN**, beside insurance, certificates and pedigree papers.

Two things are wrong with that.

It is not what a passport is. The document carries the vaccination, parasite-treatment and rabies-titration history a vet signs and attests - exactly the records the passport screen renders. That is a health record, not paperwork.

More concretely, it made the passport **unreachable from PIMS**. The web picker in `companionDocuments.ts` only ever offers `HEALTH` and `HYGIENE_MAINTENANCE`; `ADMIN` is not an option a clinic can select at all. So while `PASSPORT` lived under `ADMIN`, no vet could file a passport document or find one that a parent had filed. Mobile was the only surface that could see the category.

The app's own passport screen already contradicted the taxonomy: `PassportScreen.tsx` files its "Your uploads" under `health` / `vaccination` and reads them back on that filter.

## What is the new behavior?

`PASSPORT` moves to `HEALTH` in all four places that define the taxonomy:

- `apps/backend/src/services/document.service.ts` - the authoritative category/subcategory map that validates every upload
- `apps/mobileAppYC/.../documents/constants.ts` and `subcategoryIds.ts`, with both category descriptions corrected ("Certificates, insurance" / "Passport, prescriptions, labs, vaccinations")
- `apps/frontend/.../companionDocuments.ts` - PIMS now offers **Passport** under Health, so a clinic can file one

Existing rows move with a migration - 3 on dev, 1 on production. Only the parent category changes; the subcategory is untouched and the statement is idempotent.

## Validation performed

- Backend: 427 suites, 10,283 tests. Mobile: 467 suites, 7,579 tests. Frontend type-check clean and the companionDocuments suites pass.
- The taxonomy table test now asserts `HEALTH/PASSPORT`, and a new test pins that `ADMIN` rejects it. Mutation-checked by putting `PASSPORT` back under `ADMIN` and confirming that test alone fails.
- Row counts confirmed against both databases before writing the migration.

## Related Issue(s)

Fixes #
