### PR TITLE
chore(repo): promote dev to main

### DIFF
--- a/apps/backend/src/services/document.service.ts
+++ b/apps/backend/src/services/document.service.ts
@@ -29,8 +29,14 @@ const COMPANION_DOCUMENT_CATEGORIES = new Set([
 // subcategory under HEALTH and HYGIENE_MAINTENANCE, so both are accepted here;
 // omitting them rejected a value the UI let the user choose.
 const VALID_CATEGORY_SUBCATEGORIES: Record<string, Set<string>> = {
-  ADMIN: new Set(["PASSPORT", "CERTIFICATES", "INSURANCE"]),
+  ADMIN: new Set(["CERTIFICATES", "INSURANCE"]),
   HEALTH: new Set([
+    // A pet passport is a health record, not paperwork: it carries the
+    // vaccination, parasite-treatment and rabies-titration history a vet
+    // signs. It sat under ADMIN beside insurance, which is also where PIMS
+    // could never reach it - the web picker only ever offers HEALTH and
+    // HYGIENE_MAINTENANCE.
+    "PASSPORT",
     "SURGERY_OR_PROCEDURE",
     "PRESCRIPTION",
     "VACCINATION",

--- a/apps/backend/test/services/document.service.test.ts
+++ b/apps/backend/test/services/document.service.test.ts
@@ -407,7 +407,7 @@ describe("DocumentService", () => {
     } as any);
     mockedPrisma.document.update.mockResolvedValueOnce({
       ...baseRow,
-      category: "ADMIN",
+      category: "HEALTH",
       subcategory: "PASSPORT",
       syncedFromPms: true,
       attachments: baseRow.attachments,
@@ -416,7 +416,7 @@ describe("DocumentService", () => {
     const updated = await DocumentService.update(
       uuidDocumentId,
       {
-        category: "admin",
+        category: "health",
         subcategory: "passport",
         attachments: [{ key: "k-2", mimeType: "application/pdf", size: 5 }],
       },
@@ -426,7 +426,7 @@ describe("DocumentService", () => {
     expect(mockedPrisma.document.update).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
-          category: "ADMIN",
+          category: "HEALTH",
           subcategory: "PASSPORT",
           pmsVisible: true,
         }),
@@ -449,7 +449,7 @@ describe("DocumentService", () => {
         actorId: "pms-1",
       }),
     );
-    expect(updated.category).toBe("ADMIN");
+    expect(updated.category).toBe("HEALTH");
   });
 
   it("clears the subcategory when the update sets it to null", async () => {
@@ -639,7 +639,7 @@ describe("DocumentService", () => {
   // server-side set stopped accepting one, the upload failed with a 400 on a
   // choice the UI had offered the user.
   it.each([
-    ["ADMIN", "PASSPORT"],
+    ["HEALTH", "PASSPORT"],
     ["ADMIN", "CERTIFICATES"],
     ["ADMIN", "INSURANCE"],
     ["HEALTH", "SURGERY_OR_PROCEDURE"],
@@ -677,6 +677,26 @@ describe("DocumentService", () => {
       ).resolves.toBeDefined();
     },
   );
+
+  it("no longer accepts a passport under ADMIN", async () => {
+    // A passport is a health record - it carries the vaccination, parasite
+    // treatment and rabies titration history a vet signs - not paperwork like
+    // insurance. Filing it under ADMIN also put it out of PIMS's reach
+    // entirely: the web picker only ever offers HEALTH and
+    // HYGIENE_MAINTENANCE, so no clinic could file or find one.
+    await expect(
+      DocumentService.create(
+        {
+          patientId: uuidPatientId,
+          category: "ADMIN",
+          subcategory: "PASSPORT",
+          title: "Doc",
+          attachments: [{ key: "k-1", mimeType: "image/png" }],
+        },
+        { parentId: uuidParentId },
+      ),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
 
   it("rejects invalid inputs", async () => {
     await expect(

--- a/apps/frontend/src/app/__tests__/types/companionDocuments.test.ts
+++ b/apps/frontend/src/app/__tests__/types/companionDocuments.test.ts
@@ -33,6 +33,9 @@ describe('companionDocuments types', () => {
   describe('HealthCategoryOptions', () => {
     it('matches the approved health subcategory list', () => {
       expect(HealthCategoryOptions).toEqual([
+        // A passport is a health record, not admin paperwork. It used to sit
+        // under ADMIN, which PIMS never offers, so no clinic could file one.
+        { label: 'Passport', value: 'PASSPORT' },
         { label: 'Surgery/ Procedure', value: 'SURGERY_OR_PROCEDURE' },
         { label: 'Prescription', value: 'PRESCRIPTION' },
         { label: 'Vaccination', value: 'VACCINATION' },

--- a/apps/frontend/src/app/features/documents/types/companionDocuments.ts
+++ b/apps/frontend/src/app/features/documents/types/companionDocuments.ts
@@ -12,6 +12,7 @@ export const CategoryOptions: Option[] = makeOptions([
 ]);
 
 export const HealthCategoryOptions: Option[] = makeOptions([
+  ['Passport', 'PASSPORT'],
   ['Surgery/ Procedure', 'SURGERY_OR_PROCEDURE'],
   ['Prescription', 'PRESCRIPTION'],
   ['Vaccination', 'VACCINATION'],
@@ -54,6 +55,7 @@ export type VisitType = 'HOSPITAL' | 'GROOMER' | 'BOARDER' | 'BREEDER' | 'SHOP' 
 export type Category = 'HEALTH' | 'HYGIENE_MAINTENANCE';
 
 export type HealthSubcategory =
+  | 'PASSPORT'
   | 'SURGERY_OR_PROCEDURE'
   | 'PRESCRIPTION'
   | 'VACCINATION'

--- a/apps/mobileAppYC/src/features/documents/constants.ts
+++ b/apps/mobileAppYC/src/features/documents/constants.ts
@@ -6,13 +6,12 @@ export const DOCUMENT_CATEGORIES: DocumentCategory[] = [
   {
     id: 'admin',
     label: 'Admin',
-    description: 'Passport, certificates, insurance',
+    description: 'Certificates, insurance',
     icon: Images.adminIcon,
     iconTint: 'avatarVioletBg',
     isSynced: false,
     fileCount: 0,
     subcategories: [
-      {id: S.PASSPORT, label: 'Passport', fileCount: 0},
       {
         id: S.CERTIFICATES,
         label:
@@ -25,12 +24,13 @@ export const DOCUMENT_CATEGORIES: DocumentCategory[] = [
   {
     id: 'health',
     label: 'Health',
-    description: 'Prescriptions, labs, vaccinations',
+    description: 'Passport, prescriptions, labs, vaccinations',
     icon: Images.healthIconCategory,
     iconTint: 'blueSoft',
     isSynced: true,
     fileCount: 0,
     subcategories: [
+      {id: S.PASSPORT, label: 'Passport', fileCount: 0},
       {id: S.SURGERY_PROCEDURE, label: 'Surgery/ Procedure', fileCount: 0},
       {id: S.PRESCRIPTION, label: 'Prescription', fileCount: 0},
       {id: S.VACCINATION, label: 'Vaccination', fileCount: 0},

--- a/apps/mobileAppYC/src/features/documents/subcategoryIds.ts
+++ b/apps/mobileAppYC/src/features/documents/subcategoryIds.ts
@@ -1,9 +1,9 @@
 export const SUBCATEGORY_IDS = {
   // admin
-  PASSPORT: 'passport',
   CERTIFICATES: 'certificates',
   INSURANCE: 'insurance',
   // health
+  PASSPORT: 'passport',
   SURGERY_PROCEDURE: 'surgery-procedure',
   PRESCRIPTION: 'prescription',
   VACCINATION: 'vaccination',

--- a/packages/database/prisma/migrations/20260823150000_move_passport_documents_to_health/migration.sql
+++ b/packages/database/prisma/migrations/20260823150000_move_passport_documents_to_health/migration.sql
@@ -1,0 +1,12 @@
+-- A pet passport is a health record, not paperwork: it carries the
+-- vaccination, parasite-treatment and rabies-titration history a vet signs.
+-- It was filed under ADMIN beside insurance and certificates, which also put
+-- it out of reach of PIMS entirely -- the web picker only ever offers HEALTH
+-- and HYGIENE_MAINTENANCE, so no clinic could ever file or find one.
+--
+-- The subcategory is unchanged; only the parent category moves. Idempotent:
+-- re-running matches nothing once applied.
+UPDATE "Document"
+SET category = 'HEALTH'
+WHERE category = 'ADMIN'
+  AND subcategory = 'PASSPORT';


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] All existing tests and lints pass.

## What is the current behavior?

`main` is one commit behind `dev`. The gap is #2428: the pet passport was filed under `ADMIN`, beside insurance and pedigree papers, which also put it out of PIMS's reach entirely - the web picker only ever offers `HEALTH` and `HYGIENE_MAINTENANCE`.

## What is the new behavior?

Promotes #2428 to `main`.

## Deploy state at time of raising

The backend is **already hand-deployed** to `b5b698061` (the head of this promotion), so merging cannot ship a frontend against an API that lacks its routes:

- Migration `20260823150000_move_passport_documents_to_health` applied to production and verified independently against the database - the one affected row now reads `HEALTH/PASSPORT`, none remain under `ADMIN`.
- Built artifact grepped both ways, smoke-booted on a spare port before pm2 was touched, Node confirmed still on 22.21.1.

## Validation performed

Verified against the **live production API**, not only unit tests:

- `HEALTH/PASSPORT` -> 201 accepted
- `ADMIN/PASSPORT` -> 400 `Invalid subcategory 'PASSPORT' for category 'ADMIN'`
- `ADMIN/CERTIFICATES` -> 201 and `HEALTH/VACCINATION` -> 201, confirming neighbouring pairs are unaffected
- All three test documents read back with the correct categories, then were deleted; the database shows zero leftovers

On device: Documents now shows **Admin - "Certificates, insurance"** and **Health - "Passport, prescriptions, labs, vaccinations"**, with Passport leading the Health subcategory list under its own icon.

Also checked that legacy documents carrying the retired `HOSPITAL_VISITS` subcategory still render - `CategoryDetailScreen` buckets unknown subcategories into an extra tile rather than dropping them, so nothing became invisible.

## Related Issue(s)

Fixes #
