### PR TITLE
fix(backend): actually apply the chat upload blocklist

### DIFF
--- a/apps/backend/src/config/stream-upload-policy.ts
+++ b/apps/backend/src/config/stream-upload-policy.ts
@@ -115,6 +115,25 @@ export const MAX_UPLOAD_SIZE_BYTES = 25 * 1024 * 1024;
  * best-effort: a failure is logged but never blocks server startup, since the
  * app can still run (uploads simply fall back to Stream's default policy).
  */
+/**
+ * Stream requires each blocked extension to carry a leading dot.
+ *
+ * Its API validates `blocked_file_extensions` with a `startswith` tag, so a
+ * bare "exe" fails and - because every entry is validated - the WHOLE
+ * updateAppSettings call is rejected. The failure is caught and logged rather
+ * than thrown, so for as long as this was wrong the policy silently never
+ * applied on any environment: chat uploads were unrestricted at the Stream
+ * level while the code described this as the authoritative control.
+ *
+ * Verified against the live Stream app: ["exe","dll"] is rejected,
+ * [".exe",".dll"] is accepted.
+ *
+ * The dot is added HERE rather than in BLOCKED_UPLOAD_EXTENSIONS because that
+ * list is mirrored by the web composer (features/chat/lib/uploadSafety.ts),
+ * which matches against a bare extension parsed from the filename.
+ */
+const toStreamExtension = (extension: string): string => `.${extension}`;
+
 export const configureStreamUploadPolicy = async (): Promise<void> => {
   const key = process.env.STREAM_API_KEY;
   const secret = process.env.STREAM_API_SECRET;
@@ -124,7 +143,7 @@ export const configureStreamUploadPolicy = async (): Promise<void> => {
   }
 
   const uploadConfig = {
-    blocked_file_extensions: BLOCKED_UPLOAD_EXTENSIONS,
+    blocked_file_extensions: BLOCKED_UPLOAD_EXTENSIONS.map(toStreamExtension),
     blocked_mime_types: BLOCKED_UPLOAD_MIME_TYPES,
     size_limit: MAX_UPLOAD_SIZE_BYTES,
   };
@@ -146,7 +165,7 @@ export const configureStreamUploadPolicy = async (): Promise<void> => {
   // that, so a future edit that smuggles one in fails the suite rather than
   // silently blocking customer photos again.
   const imageUploadConfig = {
-    blocked_file_extensions: BLOCKED_UPLOAD_EXTENSIONS,
+    blocked_file_extensions: BLOCKED_UPLOAD_EXTENSIONS.map(toStreamExtension),
     blocked_mime_types: BLOCKED_UPLOAD_MIME_TYPES,
     size_limit: MAX_UPLOAD_SIZE_BYTES,
   };

--- a/apps/backend/test/config/stream-upload-policy.test.ts
+++ b/apps/backend/test/config/stream-upload-policy.test.ts
@@ -36,7 +36,7 @@ describe("configureStreamUploadPolicy", () => {
     expect(mockUpdateAppSettings).toHaveBeenCalledTimes(1);
     const arg = mockUpdateAppSettings.mock.calls[0][0];
     expect(arg.file_upload_config.blocked_file_extensions).toEqual(
-      BLOCKED_UPLOAD_EXTENSIONS,
+      BLOCKED_UPLOAD_EXTENSIONS.map((extension) => `.${extension}`),
     );
     expect(arg.file_upload_config.blocked_mime_types).toEqual(
       BLOCKED_UPLOAD_MIME_TYPES,
@@ -52,13 +52,13 @@ describe("configureStreamUploadPolicy", () => {
 
     const arg = mockUpdateAppSettings.mock.calls[0][0];
     expect(arg.image_upload_config.blocked_file_extensions).toEqual(
-      BLOCKED_UPLOAD_EXTENSIONS,
+      BLOCKED_UPLOAD_EXTENSIONS.map((extension) => `.${extension}`),
     );
     expect(arg.image_upload_config.blocked_mime_types).toEqual(
       BLOCKED_UPLOAD_MIME_TYPES,
     );
     expect(arg.image_upload_config.blocked_file_extensions).toEqual(
-      expect.arrayContaining(["html", "js", "exe", "jar", "hta"]),
+      expect.arrayContaining([".html", ".js", ".exe", ".jar", ".hta"]),
     );
     expect(arg.image_upload_config.size_limit).toBe(MAX_UPLOAD_SIZE_BYTES);
   });
@@ -97,6 +97,25 @@ describe("configureStreamUploadPolicy", () => {
     expect(BLOCKED_UPLOAD_MIME_TYPES).toEqual(
       expect.arrayContaining(["application/x-msdownload", "image/svg+xml"]),
     );
+  });
+
+  // Stream validates every entry with a `startswith` tag, so ONE bare
+  // extension rejects the entire updateAppSettings call - and the failure is
+  // caught and logged, not thrown. That is how a bare list shipped and the
+  // policy silently never applied on any environment while the code called it
+  // the authoritative control. Verified live: ["exe"] rejected, [".exe"] accepted.
+  it("sends every blocked extension with the leading dot Stream requires", async () => {
+    await configureStreamUploadPolicy();
+
+    const arg = mockUpdateAppSettings.mock.calls[0][0];
+    for (const config of [arg.file_upload_config, arg.image_upload_config]) {
+      expect(config.blocked_file_extensions.length).toBe(
+        BLOCKED_UPLOAD_EXTENSIONS.length,
+      );
+      for (const extension of config.blocked_file_extensions) {
+        expect(extension.startsWith(".")).toBe(true);
+      }
+    }
   });
 
   it("skips when Stream credentials are missing", async () => {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [ ] There is an issue for the bug/feature this PR is for. (Found while deploying the dev API box; the boot log was the only symptom.)
- [x] All existing tests and lints pass.

## What is the current behavior?

**The chat upload blocklist has never applied, on any environment - including production.**

Stream validates `blocked_file_extensions` with a `startswith` tag: every entry must carry a leading dot. The list is sent bare (`"exe"`, `"dll"`), so Stream rejects the entire `updateAppSettings` call - one invalid entry fails all 64. The rejection is caught and logged rather than thrown, so the only symptom is a single error line at boot:

```
Failed to apply Stream chat upload policy StreamChat error code 4: UpdateApp failed with error:
"file_upload_config.blocked_file_extensions[0] ... failed on the 'startswith' tag"
```

Confirmed present in **both** `devapi` and `api` (production) pm2 logs.

This leaves the control **absent, not degraded**. The module's own documentation calls it "the authoritative control", "enforced by Stream's servers for EVERY client", and explicitly notes the web composer's matching list is "UX, not a control". So a holder of a valid Stream token could upload `.exe` / `.html` / `.js` / `.jar` through the file **or** image endpoint and share the resulting trusted-CDN URL - precisely the delivery path the policy exists to close.

## What is the new behavior?

Extensions are dotted where the Stream payload is built.

Verified empirically against the live Stream app rather than inferred from the error text:

| payload | result |
| --- | --- |
| `["exe","dll"]` | REJECTED - the exact error seen in both environments |
| `[".exe",".dll"]` | **ACCEPTED** |

The dot is added at the point of use rather than in `BLOCKED_UPLOAD_EXTENSIONS`, because that list is mirrored by the web composer (`features/chat/lib/uploadSafety.ts`), which matches a bare extension parsed from the filename. Changing the shared constant would have broken the frontend check.

## Validation performed

- Full backend suite: 427 suites, 10,285 tests. Type-check and lint clean.
- New guard test asserts every entry sent to Stream starts with a dot and that the count still matches, on both `file_upload_config` and `image_upload_config`.
- Mutation-checked: removing the dot again fails three tests.

## Note

The `catch` that swallows this is deliberate - a Stream outage should not take the API down at boot - and is left as-is. The guard test is what prevents the format regressing. Worth considering separately whether a failed security-control application should alarm rather than only log, since that is why this went unnoticed.

## Related Issue(s)

Fixes #
