### PR TITLE
chore(repo): promote dev to main

### DIFF
--- a/apps/backend/src/config/stream-upload-policy.ts
+++ b/apps/backend/src/config/stream-upload-policy.ts
@@ -115,6 +115,25 @@ export const MAX_UPLOAD_SIZE_BYTES = 25 * 1024 * 1024;
  * best-effort: a failure is logged but never blocks server startup, since the
  * app can still run (uploads simply fall back to Stream's default policy).
  */
+/**
+ * Stream requires each blocked extension to carry a leading dot.
+ *
+ * Its API validates `blocked_file_extensions` with a `startswith` tag, so a
+ * bare "exe" fails and - because every entry is validated - the WHOLE
+ * updateAppSettings call is rejected. The failure is caught and logged rather
+ * than thrown, so for as long as this was wrong the policy silently never
+ * applied on any environment: chat uploads were unrestricted at the Stream
+ * level while the code described this as the authoritative control.
+ *
+ * Verified against the live Stream app: ["exe","dll"] is rejected,
+ * [".exe",".dll"] is accepted.
+ *
+ * The dot is added HERE rather than in BLOCKED_UPLOAD_EXTENSIONS because that
+ * list is mirrored by the web composer (features/chat/lib/uploadSafety.ts),
+ * which matches against a bare extension parsed from the filename.
+ */
+const toStreamExtension = (extension: string): string => `.${extension}`;
+
 export const configureStreamUploadPolicy = async (): Promise<void> => {
   const key = process.env.STREAM_API_KEY;
   const secret = process.env.STREAM_API_SECRET;
@@ -124,7 +143,7 @@ export const configureStreamUploadPolicy = async (): Promise<void> => {
   }
 
   const uploadConfig = {
-    blocked_file_extensions: BLOCKED_UPLOAD_EXTENSIONS,
+    blocked_file_extensions: BLOCKED_UPLOAD_EXTENSIONS.map(toStreamExtension),
     blocked_mime_types: BLOCKED_UPLOAD_MIME_TYPES,
     size_limit: MAX_UPLOAD_SIZE_BYTES,
   };
@@ -146,7 +165,7 @@ export const configureStreamUploadPolicy = async (): Promise<void> => {
   // that, so a future edit that smuggles one in fails the suite rather than
   // silently blocking customer photos again.
   const imageUploadConfig = {
-    blocked_file_extensions: BLOCKED_UPLOAD_EXTENSIONS,
+    blocked_file_extensions: BLOCKED_UPLOAD_EXTENSIONS.map(toStreamExtension),
     blocked_mime_types: BLOCKED_UPLOAD_MIME_TYPES,
     size_limit: MAX_UPLOAD_SIZE_BYTES,
   };

--- a/apps/backend/test/config/stream-upload-policy.test.ts
+++ b/apps/backend/test/config/stream-upload-policy.test.ts
@@ -36,7 +36,7 @@ describe("configureStreamUploadPolicy", () => {
     expect(mockUpdateAppSettings).toHaveBeenCalledTimes(1);
     const arg = mockUpdateAppSettings.mock.calls[0][0];
     expect(arg.file_upload_config.blocked_file_extensions).toEqual(
-      BLOCKED_UPLOAD_EXTENSIONS,
+      BLOCKED_UPLOAD_EXTENSIONS.map((extension) => `.${extension}`),
     );
     expect(arg.file_upload_config.blocked_mime_types).toEqual(
       BLOCKED_UPLOAD_MIME_TYPES,
@@ -52,13 +52,13 @@ describe("configureStreamUploadPolicy", () => {
 
     const arg = mockUpdateAppSettings.mock.calls[0][0];
     expect(arg.image_upload_config.blocked_file_extensions).toEqual(
-      BLOCKED_UPLOAD_EXTENSIONS,
+      BLOCKED_UPLOAD_EXTENSIONS.map((extension) => `.${extension}`),
     );
     expect(arg.image_upload_config.blocked_mime_types).toEqual(
       BLOCKED_UPLOAD_MIME_TYPES,
     );
     expect(arg.image_upload_config.blocked_file_extensions).toEqual(
-      expect.arrayContaining(["html", "js", "exe", "jar", "hta"]),
+      expect.arrayContaining([".html", ".js", ".exe", ".jar", ".hta"]),
     );
     expect(arg.image_upload_config.size_limit).toBe(MAX_UPLOAD_SIZE_BYTES);
   });
@@ -97,6 +97,25 @@ describe("configureStreamUploadPolicy", () => {
     expect(BLOCKED_UPLOAD_MIME_TYPES).toEqual(
       expect.arrayContaining(["application/x-msdownload", "image/svg+xml"]),
     );
+  });
+
+  // Stream validates every entry with a `startswith` tag, so ONE bare
+  // extension rejects the entire updateAppSettings call - and the failure is
+  // caught and logged, not thrown. That is how a bare list shipped and the
+  // policy silently never applied on any environment while the code called it
+  // the authoritative control. Verified live: ["exe"] rejected, [".exe"] accepted.
+  it("sends every blocked extension with the leading dot Stream requires", async () => {
+    await configureStreamUploadPolicy();
+
+    const arg = mockUpdateAppSettings.mock.calls[0][0];
+    for (const config of [arg.file_upload_config, arg.image_upload_config]) {
+      expect(config.blocked_file_extensions.length).toBe(
+        BLOCKED_UPLOAD_EXTENSIONS.length,
+      );
+      for (const extension of config.blocked_file_extensions) {
+        expect(extension.startsWith(".")).toBe(true);
+      }
+    }
   });
 
   it("skips when Stream credentials are missing", async () => {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] All existing tests and lints pass.

## What is the current behavior?

`main` is one commit behind `dev`. The gap is #2431: the Stream chat upload blocklist had **never applied on any environment**, production included. Stream validates `blocked_file_extensions` with a `startswith` tag, the list was sent without leading dots, and the rejection was caught and logged rather than thrown - so the only symptom was one error line at boot.

## What is the new behavior?

Promotes #2431 to `main`.

## Deploy state at time of raising

The backend is **already hand-deployed** to `f7623984a` (this promotion's head) on production, so merging cannot ship a frontend against an API without its routes.

Verified after the restart, on **both** environments, by reading the policy back from Stream rather than trusting the log line:

```
file  blocked extensions: 64
image blocked extensions: 64
all dotted: true
blocked mime types: 23
blocks .exe/.html/.js/.jar: true
```

Boot log now reads `Stream chat upload policy applied: malware-prone types blocked` instead of `Failed to apply Stream chat upload policy`.

## Related Issue(s)

Fixes #
