### PR TITLE
chore(repo): promote dev to main

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -1,0 +1,135 @@
+name: Deploy API
+
+# The two API hosts are hand-provisioned and NOTHING deployed them: no workflow
+# in this repo touched api.yosemitecrew.com or devapi.yosemitecrew.com, so a
+# green main said nothing about what was running. On 2026-08-23 the dev box was
+# found 254 commits and six migrations behind while main had been green for days,
+# and every production fix that week needed a hand-deploy from someone's laptop.
+#
+# Deliberately manual (workflow_dispatch, not push). These hosts run migrations
+# against the live database and there is no blue/green, so a deploy is a decision
+# someone makes, not a side effect of merging. What this removes is the drift and
+# the laptop, not the judgement.
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Which API host to deploy.
+        required: true
+        type: choice
+        options: [dev, production]
+      ref:
+        description: Git ref to deploy. Defaults to the branch this is run from.
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+# One deploy per host at a time. Two concurrent runs would race the same repo
+# checkout and pm2 process; never cancel a running one, because a deploy killed
+# between `git checkout` and `pm2 restart` leaves the box on new source with an
+# old bundle.
+concurrency:
+  group: deploy-api-${{ inputs.environment }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy API (${{ inputs.environment }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: ${{ inputs.environment }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Resolve target
+        id: target
+        shell: bash
+        env:
+          ENVIRONMENT: ${{ inputs.environment }}
+          INPUT_REF: ${{ inputs.ref }}
+        run: |
+          set -euo pipefail
+          if [ "$ENVIRONMENT" = "production" ]; then
+            echo "host=63.181.54.147"                       >> "$GITHUB_OUTPUT"
+            echo "repo=/home/ubuntu/Yosemite-Crew"          >> "$GITHUB_OUTPUT"
+            echo "pm2=yosemite-backend"                     >> "$GITHUB_OUTPUT"
+            echo "default_ref=main"                         >> "$GITHUB_OUTPUT"
+          else
+            echo "host=63.179.216.42"                       >> "$GITHUB_OUTPUT"
+            echo "repo=/home/ubuntu/fix/Yosemite-Crew"      >> "$GITHUB_OUTPUT"
+            echo "pm2=1"                                    >> "$GITHUB_OUTPUT"
+            echo "default_ref=dev"                          >> "$GITHUB_OUTPUT"
+          fi
+          echo "ref=${INPUT_REF:-}" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy over SSH
+        shell: bash
+        env:
+          SSH_KEY: ${{ secrets.API_DEPLOY_SSH_KEY }}
+          HOST: ${{ steps.target.outputs.host }}
+          REPO: ${{ steps.target.outputs.repo }}
+          PM2_TARGET: ${{ steps.target.outputs.pm2 }}
+          REF: ${{ steps.target.outputs.ref }}
+          DEFAULT_REF: ${{ steps.target.outputs.default_ref }}
+          # Passed as an env var rather than interpolated into the script below.
+          # A ${{ }} expression inside `run:` is substituted before the shell
+          # sees it, so context values become part of the command text - the
+          # template-injection shape, regardless of how constrained the input
+          # looks today.
+          ENVIRONMENT: ${{ inputs.environment }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SSH_KEY:-}" ]; then
+            echo "API_DEPLOY_SSH_KEY is not set for the '$ENVIRONMENT' environment." >&2
+            echo "Add it as an environment secret before using this workflow." >&2
+            exit 1
+          fi
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H "$HOST" >> ~/.ssh/known_hosts 2>/dev/null
+
+          TARGET_REF="${REF:-$DEFAULT_REF}"
+          echo "Deploying $TARGET_REF to $HOST ($REPO)"
+
+          # Ship the script from THIS checkout rather than trusting whatever
+          # version happens to be on the box.
+          scp -i ~/.ssh/deploy_key -o StrictHostKeyChecking=yes \
+            scripts/deploy/api-deploy.sh "ubuntu@$HOST:/tmp/api-deploy.sh"
+
+          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=yes \
+            -o ServerAliveInterval=30 "ubuntu@$HOST" \
+            "chmod +x /tmp/api-deploy.sh && /tmp/api-deploy.sh '$REPO' '$PM2_TARGET' '$TARGET_REF'"
+
+      - name: Verify from outside
+        shell: bash
+        env:
+          ENVIRONMENT: ${{ inputs.environment }}
+        run: |
+          set -euo pipefail
+          if [ "$ENVIRONMENT" = "production" ]; then
+            BASE="https://api.yosemitecrew.com"
+          else
+            BASE="https://devapi.yosemitecrew.com"
+          fi
+          code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 "$BASE/health")"
+          echo "$BASE/health -> $code"
+          [ "$code" = "200" ] || { echo "health check failed after deploy" >&2; exit 1; }
+
+          # Status alone proves little: Express answers 404 for a route that was
+          # never mounted AND for one that ran and found nothing. The body is
+          # what distinguishes them - JSON means a real handler ran.
+          body="$(curl -s --max-time 20 "$BASE/v1/pet-passport/mobile/companion/probe" | head -c 80)"
+          echo "auth-gated route -> $body"
+          case "$body" in
+            \{*) echo "route mounted ✅" ;;
+            *) echo "expected a JSON body from a mounted route, got HTML" >&2; exit 1 ;;
+          esac
+      - name: Always clean up the key
+        if: always()
+        run: rm -f ~/.ssh/deploy_key

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import rateLimit from "express-rate-limit";
 import fileUpload from "express-fileupload";
+import { getControlReports, hasFailedControl } from "./config/startup-controls";
 import { registerRoutes } from "./routers";
 import { StripeController } from "./controllers/web/stripe.controller";
 import { FinanceController } from "./controllers/app/finance.controller";
@@ -178,6 +179,25 @@ export function createApp() {
   registerRoutes(app); // all routes in 1 place
 
   app.get("/health", (_, res) => res.status(200).json({ status: "ok" }));
+
+  // Startup controls, reported separately from liveness.
+  //
+  // /health answers 200 for a process that booted with a security control
+  // silently absent - which is exactly what happened with the Stream upload
+  // blocklist, on every environment, for as long as its format was wrong. This
+  // route makes "failed to apply" visible from outside without anyone reading a
+  // log, and returns 503 so a monitor can alarm on it.
+  //
+  // Deliberately unauthenticated and deliberately thin: control NAMES and
+  // states only, never configuration values, so it is safe for an external
+  // uptime check to poll.
+  app.get("/health/controls", (_, res) => {
+    const degraded = hasFailedControl();
+    return res.status(degraded ? 503 : 200).json({
+      status: degraded ? "degraded" : "ok",
+      controls: getControlReports(),
+    });
+  });
 
   if (superTokensEnabled) {
     registerSuperTokensErrorHandler(app);

--- a/apps/backend/src/config/startup-controls.ts
+++ b/apps/backend/src/config/startup-controls.ts
@@ -1,0 +1,57 @@
+/**
+ * A record of whether each security control actually applied at boot.
+ *
+ * The Stream chat upload blocklist failed to apply on every environment,
+ * production included, for as long as its extension format was wrong. Nothing
+ * noticed, because the only trace was one error line in a log nobody reads: the
+ * process started fine, `/health` returned 200, and the control the code called
+ * "the authoritative control" was simply absent.
+ *
+ * A control that FAILS TO APPLY must not look the same as one that was never
+ * asked to. Anything registered here shows up on /health/controls, so a monitor
+ * can see the difference from outside without anyone reading a log.
+ *
+ * This deliberately does not stop the boot. A Stream outage should not take the
+ * API down - it should be VISIBLE.
+ */
+export type ControlState = "applied" | "failed" | "skipped";
+
+export type ControlReport = {
+  name: string;
+  state: ControlState;
+  /** Why it is skipped or failed. Never include credentials or response bodies. */
+  detail?: string;
+  at: string;
+};
+
+const reports = new Map<string, ControlReport>();
+
+export const recordControl = (
+  name: string,
+  state: ControlState,
+  detail?: string,
+): void => {
+  reports.set(name, {
+    name,
+    state,
+    ...(detail ? { detail } : {}),
+    at: new Date().toISOString(),
+  });
+};
+
+export const getControlReports = (): ControlReport[] =>
+  [...reports.values()].sort((a, b) => a.name.localeCompare(b.name));
+
+/**
+ * `failed` is the only state that should page someone.
+ *
+ * `skipped` is a deployment fact, not a fault - an environment without Stream
+ * credentials genuinely has nothing to configure, and treating that as an
+ * incident would train people to ignore this endpoint, which is the failure
+ * mode it exists to fix.
+ */
+export const hasFailedControl = (): boolean =>
+  [...reports.values()].some((report) => report.state === "failed");
+
+/** Test seam only. */
+export const resetControlsForTest = (): void => reports.clear();

--- a/apps/backend/src/config/stream-upload-policy.ts
+++ b/apps/backend/src/config/stream-upload-policy.ts
@@ -1,6 +1,7 @@
 // src/config/stream-upload-policy.ts
 import { StreamChat } from "stream-chat";
 import logger from "src/utils/logger";
+import { recordControl } from "./startup-controls";
 
 /**
  * File extensions that can carry executable or browser-active content. These are
@@ -139,6 +140,7 @@ export const configureStreamUploadPolicy = async (): Promise<void> => {
   const secret = process.env.STREAM_API_SECRET;
   if (!key || !secret) {
     logger.warn("Skipping Stream upload policy: credentials missing");
+    recordControl("stream-upload-policy", "skipped", "credentials missing");
     return;
   }
 
@@ -187,7 +189,15 @@ export const configureStreamUploadPolicy = async (): Promise<void> => {
         ? "Stream chat upload policy + malware-scan webhook configured"
         : "Stream chat upload policy applied: malware-prone types blocked",
     );
+    recordControl("stream-upload-policy", "applied");
   } catch (err) {
     logger.error("Failed to apply Stream chat upload policy", err);
+    // Recorded, not rethrown: a Stream outage should not stop the API booting.
+    // But it must stop being invisible - see startup-controls.ts.
+    recordControl(
+      "stream-upload-policy",
+      "failed",
+      "updateAppSettings rejected",
+    );
   }
 };

--- a/apps/backend/test/config/startup-controls.test.ts
+++ b/apps/backend/test/config/startup-controls.test.ts
@@ -1,0 +1,54 @@
+import {
+  getControlReports,
+  hasFailedControl,
+  recordControl,
+  resetControlsForTest,
+} from "src/config/startup-controls";
+
+describe("startup controls", () => {
+  beforeEach(() => resetControlsForTest());
+
+  it("reports nothing before any control registers", () => {
+    expect(getControlReports()).toEqual([]);
+    expect(hasFailedControl()).toBe(false);
+  });
+
+  it("distinguishes applied, skipped and failed", () => {
+    recordControl("a-applied", "applied");
+    recordControl("b-skipped", "skipped", "credentials missing");
+    recordControl("c-failed", "failed", "rejected");
+
+    const states = Object.fromEntries(
+      getControlReports().map((r) => [r.name, r.state]),
+    );
+    expect(states).toEqual({
+      "a-applied": "applied",
+      "b-skipped": "skipped",
+      "c-failed": "failed",
+    });
+  });
+
+  // The distinction this whole module exists for: a control that FAILED to
+  // apply must not read the same as one that was never asked to. An environment
+  // without Stream credentials has nothing to configure; one whose
+  // updateAppSettings was rejected has an absent security control.
+  it("alarms on failed but not on skipped", () => {
+    recordControl("stream-upload-policy", "skipped", "credentials missing");
+    expect(hasFailedControl()).toBe(false);
+
+    recordControl("stream-upload-policy", "failed", "rejected");
+    expect(hasFailedControl()).toBe(true);
+  });
+
+  it("keeps only the latest state per control", () => {
+    recordControl("x", "failed");
+    recordControl("x", "applied");
+    expect(getControlReports()).toHaveLength(1);
+    expect(hasFailedControl()).toBe(false);
+  });
+
+  it("never carries a detail unless one was given", () => {
+    recordControl("no-detail", "applied");
+    expect(getControlReports()[0]).not.toHaveProperty("detail");
+  });
+});

--- a/apps/backend/test/config/stream-upload-policy.test.ts
+++ b/apps/backend/test/config/stream-upload-policy.test.ts
@@ -12,6 +12,10 @@ import {
   BLOCKED_UPLOAD_MIME_TYPES,
   MAX_UPLOAD_SIZE_BYTES,
 } from "src/config/stream-upload-policy";
+import {
+  getControlReports,
+  resetControlsForTest,
+} from "src/config/startup-controls";
 import { StreamChat } from "stream-chat";
 
 const origKey = process.env.STREAM_API_KEY;
@@ -116,6 +120,46 @@ describe("configureStreamUploadPolicy", () => {
         expect(extension.startsWith(".")).toBe(true);
       }
     }
+  });
+
+  // The whole point of the registry: these three outcomes must be
+  // distinguishable from outside the process. Before it existed, a rejected
+  // updateAppSettings and a successfully applied policy both left /health
+  // answering 200.
+  describe("reports its outcome to the startup control registry", () => {
+    beforeEach(() => resetControlsForTest());
+
+    it("records applied on success", async () => {
+      await configureStreamUploadPolicy();
+      expect(getControlReports()).toEqual([
+        expect.objectContaining({
+          name: "stream-upload-policy",
+          state: "applied",
+        }),
+      ]);
+    });
+
+    it("records failed when Stream rejects the update", async () => {
+      mockUpdateAppSettings.mockRejectedValue(new Error("rejected"));
+      await configureStreamUploadPolicy();
+      expect(getControlReports()).toEqual([
+        expect.objectContaining({
+          name: "stream-upload-policy",
+          state: "failed",
+        }),
+      ]);
+    });
+
+    it("records skipped, not failed, when credentials are absent", async () => {
+      delete process.env.STREAM_API_KEY;
+      await configureStreamUploadPolicy();
+      expect(getControlReports()).toEqual([
+        expect.objectContaining({
+          name: "stream-upload-policy",
+          state: "skipped",
+        }),
+      ]);
+    });
   });
 
   it("skips when Stream credentials are missing", async () => {

--- a/scripts/deploy/api-deploy.sh
+++ b/scripts/deploy/api-deploy.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+#
+# Deploy the API to one of the two hand-provisioned boxes.
+#
+# No workflow deployed these hosts until this script existed, which is why the
+# dev box was found 254 commits and six migrations behind on 2026-08-23 while
+# main had been green for days. "Merged" said nothing about what was running.
+#
+# Every step below exists because skipping it has actually broken something:
+#
+#   PATH first        pm2 restart --update-env replaces the process environment
+#                     with the CALLING shell's. Over SSH that resolves `node` to
+#                     the system v18, and the app dies at boot on an ESM require
+#                     that looks like a dependency bug. Export the nvm bin first.
+#
+#   heap + swap       tsc is OOM-killed on the 1.9 GB dev box. Swap alone is not
+#                     enough - @yosemite-crew/auth still aborts with exit 134,
+#                     "Ineffective mark-compacts near heap limit" - so the V8 old
+#                     space is raised explicitly too.
+#
+#   clean tsbuildinfo A stale tsconfig.tsbuildinfo makes tsc report success and
+#                     rebuild NOTHING. That shipped a backend bundled against a
+#                     types/dist that predated a changed form.ts. Exit code 0 is
+#                     not evidence; the freshness count below is.
+#
+#   per-package build The root build fans out to Next and Electron and OOMs.
+#
+#   smoke on a spare  pm2 says "online" for a process that is crash-looping, and
+#   port BEFORE pm2   an immediate port check races the boot. Boot the new bundle
+#                     somewhere harmless first; only cut over if it answers.
+#
+# Usage: api-deploy.sh <repo-dir> <pm2-target> <git-ref> [smoke-port]
+set -euo pipefail
+
+REPO_DIR="${1:?repo dir required}"
+PM2_TARGET="${2:?pm2 process name or id required}"
+GIT_REF="${3:?git ref required}"
+SMOKE_PORT="${4:-8099}"
+
+NODE_BIN="${NODE_BIN:-$HOME/.nvm/versions/node/v22.21.1/bin}"
+export PATH="$NODE_BIN:$PATH"
+export NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=2048}"
+
+say() { printf '\n=== %s ===\n' "$1"; }
+
+cd "$REPO_DIR"
+
+say "preflight"
+node -v
+ROLLBACK_SHA="$(git rev-parse HEAD)"
+echo "rollback sha: $ROLLBACK_SHA"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+echo "$ROLLBACK_SHA" > "/tmp/api-rollback-$STAMP.txt"
+tar czf "/tmp/api-dist-before-$STAMP.tgz" apps/backend/dist packages/*/dist 2>/dev/null || true
+cp apps/backend/.env "/tmp/api-env-before-$STAMP" 2>/dev/null || true
+echo "backups: /tmp/api-dist-before-$STAMP.tgz  /tmp/api-env-before-$STAMP"
+
+say "checkout $GIT_REF"
+git fetch --quiet origin "$GIT_REF" || git fetch --quiet origin
+git checkout --detach "$(git rev-parse "origin/$GIT_REF" 2>/dev/null || echo "$GIT_REF")" --quiet
+git rev-parse --short HEAD
+
+say "install"
+pnpm install --frozen-lockfile
+
+say "prisma client + migrations"
+pnpm --filter @yosemite-crew/database run prisma:generate
+pnpm --filter @yosemite-crew/database run prisma:deploy
+
+say "build packages"
+BUILD_START="$(date '+%Y-%m-%d %H:%M:%S')"
+sleep 1
+for pkg in types fhirtypes fhir lib database auth; do
+  # Remove the incremental state, or a stale tsbuildinfo silently skips the build.
+  rm -rf "packages/$pkg/dist" \
+         "packages/$pkg/tsconfig.build.tsbuildinfo" \
+         "packages/$pkg/tsconfig.tsbuildinfo" 2>/dev/null || true
+  printf '  %-12s ' "$pkg"
+  pnpm --filter "@yosemite-crew/$pkg" run build >"/tmp/build-$pkg.log" 2>&1 \
+    && echo ok || { echo FAILED; tail -20 "/tmp/build-$pkg.log"; exit 1; }
+done
+printf '  %-12s ' backend
+pnpm --filter backend run build >/tmp/build-backend.log 2>&1 \
+  && echo ok || { echo FAILED; tail -30 /tmp/build-backend.log; exit 1; }
+
+say "freshness (exit 0 is not evidence a build produced anything)"
+for pkg in types fhirtypes fhir lib database auth; do
+  fresh="$(find "packages/$pkg/dist" -type f -newermt "$BUILD_START" 2>/dev/null | wc -l | tr -d ' ')"
+  total="$(find "packages/$pkg/dist" -type f 2>/dev/null | wc -l | tr -d ' ')"
+  printf '  %-12s %s/%s rebuilt\n' "$pkg" "$fresh" "$total"
+  if [ "$fresh" = "0" ] && [ "$total" != "0" ]; then
+    echo "  ERROR: $pkg produced no new files - stale incremental state" >&2
+    exit 1
+  fi
+done
+test -s apps/backend/dist/index.js || { echo "backend bundle missing" >&2; exit 1; }
+
+say "smoke boot on :$SMOKE_PORT"
+cd apps/backend
+rm -f /tmp/api-smoke.log
+PORT="$SMOKE_PORT" nohup node dist/index.js >/tmp/api-smoke.log 2>&1 &
+SMOKE_PID=$!
+trap 'kill "$SMOKE_PID" 2>/dev/null || true' EXIT
+sleep 25
+CODE="$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "http://127.0.0.1:$SMOKE_PORT/health" || echo 000)"
+echo "  /health -> $CODE"
+# An app-level JSON body proves Express reached a real handler; Express's own
+# HTML 404 on a bogus path proves the probe was not just hitting a catch-all.
+echo "  real route : $(curl -s --max-time 10 "http://127.0.0.1:$SMOKE_PORT/v1/pet-passport/mobile/companion/probe" | head -c 60)"
+echo "  bogus route: $(curl -s --max-time 10 "http://127.0.0.1:$SMOKE_PORT/v1/definitely-not-a-route" | head -c 30)"
+grep -iE 'ERR_REQUIRE_ESM|Cannot find module|FATAL ERROR' /tmp/api-smoke.log | head -5 || true
+kill "$SMOKE_PID" 2>/dev/null || true
+trap - EXIT
+sleep 2
+if [ "$CODE" != "200" ]; then
+  echo "smoke boot failed - NOT cutting over. Rollback sha: $ROLLBACK_SHA" >&2
+  exit 1
+fi
+
+say "cutover"
+pm2 restart "$PM2_TARGET" --update-env
+pm2 save
+# pm2 reporting "online" is not the same as serving, and checking the port
+# immediately races the boot. Give it time, then check what is actually true.
+sleep 30
+pm2 describe "$PM2_TARGET" | grep -iE 'status|node.js version' || true
+ss -ltn 2>/dev/null | grep -q ':8080' \
+  && echo "  listening on 8080" \
+  || { echo "  NOTHING LISTENING on 8080 - roll back to $ROLLBACK_SHA" >&2; exit 1; }
+
+say "done"
+echo "deployed $(git -C "$REPO_DIR" rev-parse --short HEAD)  (rollback: $ROLLBACK_SHA)"


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] All existing tests and lints pass.

## What is the current behavior?

`main` is behind `dev` by #2433, which closes the gap that produced most of the day's incidents: **nothing in this repo deployed the API**, so a green `main` said nothing about what was running.

## What is the new behavior?

Promotes #2433: a committed deploy script for both API hosts, a `workflow_dispatch` workflow that runs it, and `/health/controls` so a security control that fails to apply stops being invisible.

## Deploy state at time of raising

Backend already deployed to `a1098ba6b` on **both** hosts - and deployed *by the script being promoted*, which is the only honest way to ship a deploy script.

```
freshness   types 71/71, fhirtypes 58/58, fhir 5/5,
            lib 135/135, database 12/12, auth 60/60
smoke :8099 /health 200, JSON on a real route, HTML on a bogus one
cutover     listening on 8080
```

Both environments now answer:

```
GET /health/controls
{"status":"ok","controls":[{"name":"stream-upload-policy","state":"applied",...}]}
```

That line read `Failed to apply` on production this morning, with nothing watching.

## Before the workflow can be used

Add `API_DEPLOY_SSH_KEY` as an environment secret for `dev` and `production`. Until then the script is runnable by hand and the workflow fails with a clear message rather than half-deploying.

## Related Issue(s)

Fixes #
