### PR TITLE
fix(backend): enforce co-parent permissions on the server

### DIFF
--- a/apps/backend/src/middlewares/companion-access.ts
+++ b/apps/backend/src/middlewares/companion-access.ts
@@ -1,0 +1,100 @@
+import type { NextFunction, Request, Response } from "express";
+import { prisma } from "src/config/prisma";
+import { findParentIdForAuthUser } from "src/services/shared/parent-identity";
+
+/**
+ * Co-parent permissions, enforced on the server.
+ *
+ * `ParentPatient.permissions` is set when a co-parent invite is accepted and
+ * toggled by the primary parent afterwards. Until this middleware existed it
+ * was read ONLY by the mobile client, which used it to gate screens - so the
+ * switches a primary parent set were a UI convention, not an authorisation
+ * boundary. Any co-parent holding a valid session could call the API directly
+ * and reach a feature that had been switched off for them. Production has a
+ * co-parent with `expenses: false, appointments: false` today.
+ *
+ * The keys deliberately match the ones the app already gates on
+ * (`guardFeature('documents', ...)` and friends), so the server enforces the
+ * same model the product already describes rather than inventing a second one.
+ *
+ * Shape of the decision:
+ *   - PRIMARY parents bypass. The permission set exists to describe what a
+ *     primary parent has DELEGATED; it never constrains them.
+ *   - CO_PARENT must hold the flag, strictly `=== true`. A missing key, a
+ *     non-boolean, or a malformed permissions blob denies - this is an
+ *     authorisation check, so anything it cannot read is a no.
+ *   - No link at all is a 404, not a 403, matching the existing convention on
+ *     parent-facing routes: a uniform "not found" so the endpoint cannot be
+ *     used to discover which patient ids exist.
+ */
+export type CompanionFeature =
+  | "appointments"
+  | "chatWithVet"
+  | "companionProfile"
+  | "documents"
+  | "emergencyBasedPermissions"
+  | "expenses"
+  | "tasks";
+
+const FEATURE_LABELS: Record<CompanionFeature, string> = {
+  appointments: "appointments",
+  chatWithVet: "chat with vet",
+  companionProfile: "companion profile",
+  documents: "documents",
+  emergencyBasedPermissions: "emergency actions",
+  expenses: "expenses",
+  tasks: "tasks",
+};
+
+const isGranted = (
+  permissions: unknown,
+  feature: CompanionFeature,
+): boolean => {
+  if (!permissions || typeof permissions !== "object") return false;
+  return (permissions as Record<string, unknown>)[feature] === true;
+};
+
+export const requireCompanionPermission =
+  (feature: CompanionFeature, paramName = "patientId") =>
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const patientId = (req.params as Record<string, string | undefined>)[
+        paramName
+      ];
+      const userId = (req as Request & { userId?: string | null }).userId;
+
+      if (!patientId || !userId) {
+        return res.status(404).json({ message: "Companion not found." });
+      }
+
+      const parentId = await findParentIdForAuthUser(userId);
+      if (!parentId) {
+        return res.status(404).json({ message: "Companion not found." });
+      }
+
+      const link = await prisma.parentPatient.findFirst({
+        where: {
+          patientId,
+          parentId,
+          status: "ACTIVE",
+          role: { in: ["PRIMARY", "CO_PARENT"] },
+        },
+        select: { role: true, permissions: true },
+      });
+
+      if (!link) {
+        return res.status(404).json({ message: "Companion not found." });
+      }
+
+      if (link.role === "PRIMARY" || isGranted(link.permissions, feature)) {
+        return next();
+      }
+
+      // Worded so the app can show it as-is; it already says the same thing.
+      return res.status(403).json({
+        message: `Ask the primary parent to enable ${FEATURE_LABELS[feature]} access for you.`,
+      });
+    } catch (error) {
+      return next(error);
+    }
+  };

--- a/apps/backend/src/middlewares/companion-access.ts
+++ b/apps/backend/src/middlewares/companion-access.ts
@@ -63,6 +63,19 @@ export const requireCompanionPermission =
       ];
       const userId = (req as Request & { userId?: string | null }).userId;
 
+      // Load-bearing, and it must stay BEFORE the query.
+      //
+      // Prisma omits an `undefined` field from `where` rather than matching
+      // nothing, so `{ patientId: undefined, parentId }` silently becomes
+      // `{ parentId }` - a filter that matches this parent's link to ANY
+      // patient and would hand back a link, and therefore access. A route
+      // mounted with the wrong param name would do exactly that.
+      //
+      // CodeQL flags this as js/user-controlled-bypass because a user-supplied
+      // value guards an authorisation decision. The direction is inverted: the
+      // falsy branch DENIES, and the value is used to look the permission up,
+      // never to decide whether to check it. Removing this guard is the
+      // vulnerability; having it is the fix.
       if (!patientId || !userId) {
         return res.status(404).json({ message: "Companion not found." });
       }

--- a/apps/backend/src/routers/appointment.router.ts
+++ b/apps/backend/src/routers/appointment.router.ts
@@ -6,6 +6,7 @@ import {
   withAppointmentOrgPermissions,
   withOrgPermissions,
 } from "src/middlewares/rbac";
+import { requireCompanionPermission } from "src/middlewares/companion-access";
 
 const router = Router();
 
@@ -34,6 +35,7 @@ router.post(
 router.get(
   "/mobile/companion/:patientId",
   requireMobileAuth,
+  requireCompanionPermission("appointments", "patientId"),
   AppointmentController.listByCompanion,
 );
 

--- a/apps/backend/src/routers/companion-organisation.router.ts
+++ b/apps/backend/src/routers/companion-organisation.router.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { CompanionOrganisationController } from "../controllers/app/companion-organisation.controller";
 import { requireWebAuth, requireMobileAuth } from "src/middlewares/auth";
 import { withOrgPermissions, requirePermission } from "src/middlewares/rbac";
+import { requireCompanionPermission } from "src/middlewares/companion-access";
 
 const router = Router();
 
@@ -42,6 +43,7 @@ router.delete(
 router.get(
   "/:patientId",
   requireMobileAuth,
+  requireCompanionPermission("appointments", "patientId"),
   CompanionOrganisationController.getLinksForCompanionByOrganisationType,
 );
 

--- a/apps/backend/src/routers/document.router.ts
+++ b/apps/backend/src/routers/document.router.ts
@@ -6,6 +6,7 @@ import {
   withOrgPermissions,
   requirePermission,
 } from "src/middlewares/rbac";
+import { requireCompanionPermission } from "src/middlewares/companion-access";
 
 const router = Router();
 
@@ -22,18 +23,21 @@ router.post(
 router.get(
   "/mobile/search/:patientId",
   requireMobileAuth,
+  requireCompanionPermission("documents", "patientId"),
   DocumentController.searchDocumentMobile,
 );
 
 router.post(
   "/mobile/:patientId",
   requireMobileAuth,
+  requireCompanionPermission("documents", "patientId"),
   DocumentController.createDocument,
 );
 
 router.get(
   "/mobile/:patientId",
   requireMobileAuth,
+  requireCompanionPermission("documents", "patientId"),
   DocumentController.listDocumentsForParent,
 );
 
@@ -70,6 +74,7 @@ router.delete(
 router.get(
   "/search/:patientId",
   requireMobileAuth,
+  requireCompanionPermission("documents", "patientId"),
   DocumentController.searchDocument,
 );
 

--- a/apps/backend/src/routers/expense.router.ts
+++ b/apps/backend/src/routers/expense.router.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { ExpenseController } from "../controllers/app/expense.controller";
 import { requireMobileAuth } from "src/middlewares/auth";
+import { requireCompanionPermission } from "src/middlewares/companion-access";
 
 const router = Router();
 
@@ -19,12 +20,14 @@ router.get("/:expenseId", requireMobileAuth, ExpenseController.getExpenseById);
 router.get(
   "/companion/:patientId/list",
   requireMobileAuth,
+  requireCompanionPermission("expenses", "patientId"),
   ExpenseController.getExpensesByCompanion,
 );
 
 router.get(
   "/companion/:patientId/summary",
   requireMobileAuth,
+  requireCompanionPermission("expenses", "patientId"),
   ExpenseController.getExpenseSummary,
 );
 

--- a/apps/backend/src/routers/parent-companion.router.ts
+++ b/apps/backend/src/routers/parent-companion.router.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import { ParentCompanionController } from "src/controllers/app/parent-companion.controller";
+import { requireCompanionPermission } from "src/middlewares/companion-access";
 import { requireMobileAuth } from "../middlewares/auth"; // for parents
 
 export const router = Router();
@@ -12,6 +13,7 @@ router.get(
 router.get(
   "/companion/:patientId",
   requireMobileAuth,
+  requireCompanionPermission("companionProfile", "patientId"),
   ParentCompanionController.getLinksForCompanion,
 );
 router.patch(

--- a/apps/backend/src/routers/pet-passport.router.ts
+++ b/apps/backend/src/routers/pet-passport.router.ts
@@ -3,6 +3,7 @@ import { requireWebAuth, requireMobileAuth } from "src/middlewares/auth";
 import { withOrgPermissions, requirePermission } from "src/middlewares/rbac";
 import { PetPassportController } from "src/controllers/web/pet-passport.controller";
 import { PassportConsentController } from "src/controllers/web/passport-consent.controller";
+import { requireCompanionPermission } from "src/middlewares/companion-access";
 
 const router = Router();
 
@@ -93,18 +94,21 @@ router.get(
 router.get(
   "/mobile/companion/:patientId",
   requireMobileAuth,
+  requireCompanionPermission("companionProfile", "patientId"),
   PetPassportController.getPassportForParent,
 );
 
 router.get(
   "/mobile/companion/:patientId/wallet/apple",
   requireMobileAuth,
+  requireCompanionPermission("companionProfile", "patientId"),
   PetPassportController.getApplePassForParent,
 );
 
 router.get(
   "/mobile/companion/:patientId/wallet/google",
   requireMobileAuth,
+  requireCompanionPermission("companionProfile", "patientId"),
   PetPassportController.getGooglePassForParent,
 );
 
@@ -113,6 +117,7 @@ router.get(
 router.delete(
   "/mobile/companion/:patientId/share-link",
   requireMobileAuth,
+  requireCompanionPermission("companionProfile", "patientId"),
   PetPassportController.revokePublicToken,
 );
 

--- a/apps/backend/src/routers/task.router.ts
+++ b/apps/backend/src/routers/task.router.ts
@@ -10,6 +10,7 @@ import {
   withOrgPermissions,
   withTaskOrgPermissions,
 } from "src/middlewares/rbac";
+import { requireCompanionPermission } from "src/middlewares/companion-access";
 
 const router = Router();
 
@@ -34,6 +35,7 @@ router.post(
 router.get(
   "/mobile/companion/:patientId",
   requireMobileAuth,
+  requireCompanionPermission("tasks", "patientId"),
   TaskController.listForCompanion,
 );
 

--- a/apps/backend/test/middlewares/companion-access.test.ts
+++ b/apps/backend/test/middlewares/companion-access.test.ts
@@ -1,0 +1,141 @@
+import type { NextFunction, Request, Response } from "express";
+
+jest.mock("src/config/prisma", () => ({
+  prisma: { parentPatient: { findFirst: jest.fn() } },
+}));
+jest.mock("src/services/shared/parent-identity", () => ({
+  findParentIdForAuthUser: jest.fn(),
+}));
+
+import { prisma } from "src/config/prisma";
+import { findParentIdForAuthUser } from "src/services/shared/parent-identity";
+import { requireCompanionPermission } from "src/middlewares/companion-access";
+
+const findFirst = (
+  prisma as unknown as {
+    parentPatient: { findFirst: jest.Mock };
+  }
+).parentPatient.findFirst;
+const findParent = findParentIdForAuthUser as jest.Mock;
+
+const runMiddleware = async (
+  feature: Parameters<typeof requireCompanionPermission>[0] = "documents",
+  { patientId = "pat-1", userId = "provider-user-1" } = {},
+) => {
+  const req = { params: { patientId }, userId } as unknown as Request;
+  const json = jest.fn();
+  const res = { status: jest.fn(() => ({ json })) } as unknown as Response;
+  const next = jest.fn() as NextFunction;
+  await requireCompanionPermission(feature)(req, res, next);
+  return { res, json, next };
+};
+
+const ALL_FALSE = {
+  appointments: false,
+  chatWithVet: false,
+  companionProfile: false,
+  documents: false,
+  emergencyBasedPermissions: false,
+  expenses: false,
+  tasks: false,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  findParent.mockResolvedValue("par-1");
+});
+
+describe("requireCompanionPermission", () => {
+  it("lets a PRIMARY parent through whatever the permissions say", async () => {
+    // The permission set describes what a primary parent has DELEGATED. It is
+    // not a constraint on them, so an all-false blob must not lock them out of
+    // their own companion.
+    findFirst.mockResolvedValue({ role: "PRIMARY", permissions: ALL_FALSE });
+
+    const { next, res } = await runMiddleware("documents");
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("lets a co-parent through when the flag is granted", async () => {
+    findFirst.mockResolvedValue({
+      role: "CO_PARENT",
+      permissions: { ...ALL_FALSE, documents: true },
+    });
+
+    const { next } = await runMiddleware("documents");
+
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("403s a co-parent whose flag is off", async () => {
+    // This is the hole. Production has a co-parent with expenses:false and
+    // appointments:false whose restrictions the API ignored entirely.
+    findFirst.mockResolvedValue({ role: "CO_PARENT", permissions: ALL_FALSE });
+
+    const { res, json, next } = await runMiddleware("expenses");
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(json).toHaveBeenCalledWith({
+      message: "Ask the primary parent to enable expenses access for you.",
+    });
+  });
+
+  it.each([
+    ["a missing key", { documents: true }],
+    ["a non-boolean truthy value", { expenses: "yes" }],
+    ["null", null],
+    ["a non-object", "granted"],
+  ])("denies a co-parent on %s", async (_label, permissions) => {
+    // An authorisation check denies anything it cannot read as an explicit
+    // grant. `=== true` and nothing looser.
+    findFirst.mockResolvedValue({ role: "CO_PARENT", permissions });
+
+    const { res, next } = await runMiddleware("expenses");
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  // 404 rather than 403 for these: the existing parent-facing convention is a
+  // uniform "not found" so the endpoint cannot be used to discover which
+  // patient ids exist.
+  it("404s when there is no link at all", async () => {
+    findFirst.mockResolvedValue(null);
+    const { res, json } = await runMiddleware();
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(json).toHaveBeenCalledWith({ message: "Companion not found." });
+  });
+
+  it("404s when the caller has no parent record", async () => {
+    findParent.mockResolvedValue(null);
+    const { res } = await runMiddleware();
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(findFirst).not.toHaveBeenCalled();
+  });
+
+  it("404s an unauthenticated caller without touching the database", async () => {
+    // `null`, not `undefined` - a default parameter treats undefined as absent
+    // and would quietly hand the middleware a valid user instead.
+    const { res } = await runMiddleware("documents", {
+      userId: null as unknown as string,
+    });
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(findParent).not.toHaveBeenCalled();
+  });
+
+  it("only considers ACTIVE links in a parent role", async () => {
+    findFirst.mockResolvedValue({ role: "PRIMARY", permissions: ALL_FALSE });
+    await runMiddleware("tasks");
+    expect(findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: "ACTIVE",
+          role: { in: ["PRIMARY", "CO_PARENT"] },
+        }),
+      }),
+    );
+  });
+});

--- a/apps/backend/test/middlewares/companion-access.test.ts
+++ b/apps/backend/test/middlewares/companion-access.test.ts
@@ -126,6 +126,21 @@ describe("requireCompanionPermission", () => {
     expect(findParent).not.toHaveBeenCalled();
   });
 
+  // Prisma omits an undefined `where` field rather than matching nothing, so
+  // `{ patientId: undefined, parentId }` would match this parent's link to ANY
+  // patient and grant access. The guard must therefore run BEFORE the query,
+  // not merely produce a 404 afterwards.
+  it("denies a missing patient id without ever reaching the database", async () => {
+    const { res, next } = await runMiddleware("documents", {
+      patientId: null as unknown as string,
+    });
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(findParent).not.toHaveBeenCalled();
+    expect(findFirst).not.toHaveBeenCalled();
+  });
+
   it("only considers ACTIVE links in a parent role", async () => {
     findFirst.mockResolvedValue({ role: "PRIMARY", permissions: ALL_FALSE });
     await runMiddleware("tasks");

--- a/apps/backend/test/routers/pet-passport.router.test.ts
+++ b/apps/backend/test/routers/pet-passport.router.test.ts
@@ -134,14 +134,19 @@ describe("pet-passport.router", () => {
     expect(requirePermission).toHaveBeenCalledWith("passport:attest:any");
   });
 
-  it("exposes the pet-parent passport + wallet routes behind mobile auth only", () => {
+  it("exposes the pet-parent passport + wallet routes behind mobile auth and the co-parent gate", () => {
+    // Three handlers now: mobile auth, the co-parent permission check, and the
+    // controller. The point of the original assertion still holds and is what
+    // is checked below - no staff session, no ORG permission gate on a parent's
+    // own view. requireCompanionPermission is neither of those; it enforces the
+    // delegation the primary parent already set, which until it existed was
+    // read only by the mobile client.
     const MOB = "/mobile/companion/:patientId";
     for (const path of [MOB, `${MOB}/wallet/apple`, `${MOB}/wallet/google`]) {
       const route = findRoute(path, "get");
-      expect(route?.stack).toHaveLength(2);
+      expect(route?.stack).toHaveLength(3);
       const handles = route?.stack.map((l) => l.handle);
       expect(handles).toContain(requireMobileAuth);
-      // No staff session and no org permission gate on the parent's own view.
       expect(handles).not.toContain(requireWebAuth);
     }
   });


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

`ParentPatient.permissions` is written when a co-parent invite is accepted and toggled by the primary parent afterwards - and it is read **only by the mobile client**, which uses it to gate screens (`guardFeature('documents', ...)` and friends).

Nothing on the server reads it. Parent-facing routes gate on role and status alone, so any co-parent holding a valid session can call the API directly and reach a feature the primary parent switched off. The switches are a UI convention, not an authorisation boundary.

**This is live, not hypothetical.** Production has a co-parent today with:

```json
{"expenses": false, "appointments": false, "emergencyBasedPermissions": false, ...}
```

whose restrictions the API ignores entirely.

## What is the new behavior?

`requireCompanionPermission` enforces the **same model the product already describes** - the keys match exactly what the app gates on - rather than inventing a second one. Applied to the 14 mobile routes that carry a patient id:

| feature | routes |
| --- | --- |
| `appointments` | appointment listing, clinic access |
| `documents` | 4 document routes |
| `expenses` | list, summary |
| `tasks` | companion task list |
| `companionProfile` | companion profile, and the 4 passport/wallet routes |

The passport maps to `companionProfile` because that is how the app already reaches it - `ProfileOverview` sits behind `guardFeature('companionProfile')`. **Whether the passport deserves its own key is a product decision**, and a reasonable one to make later; this PR deliberately matches existing behaviour rather than quietly widening or narrowing it.

Three decisions worth stating explicitly:

- **PRIMARY parents bypass.** The permission set describes what a primary parent has *delegated*. It is not a constraint on them, and an all-false blob must not lock someone out of their own companion.
- **A co-parent needs the flag strictly `=== true`.** A missing key, a truthy non-boolean, or a malformed blob denies. This is an authorisation check, so anything it cannot read as an explicit grant is a no.
- **No link is 404, not 403**, matching the existing convention on parent-facing routes so the endpoint cannot be used to discover which patient ids exist.

## What this does *not* cover

Routes keyed on a **resource** id rather than a patient id - `GET /expense/:expenseId`, `GET /task/:taskId` - still enforce parent scope but not the feature flag, because the patient is on the resource rather than the path. That is a narrower hole (you must already know the id) and closing it means either a per-resource lookup in the middleware or a shared assertion inside each service. Left as follow-up on #2423 rather than half-done here.

The three `parent-companion` management routes (permissions, promote, remove) are deliberately untouched: they already require the caller to hold the **primary** link via `ensurePrimaryLinkExists`, which is the stronger check.

## Validation performed

- Backend suite: 429 suites, 10,304 tests. Type-check and lint clean.
- 11 middleware tests covering PRIMARY bypass, granted, denied, and four malformed-permission shapes.
- Mutation-checked twice: letting any co-parent through fails five tests; loosening `=== true` to a truthy check fails one.
- One existing router test asserted the old handler count on the passport routes. Updated to the new shape - its actual intent (no staff session, no *org* permission gate on a parent's own view) still holds and is still asserted.

## Related Issue(s)

Fixes #2423
