### PR TITLE
fix(backend): gate parent wallet passes on primary-only token minting

### DIFF
--- a/apps/backend/src/controllers/web/pet-passport.controller.ts
+++ b/apps/backend/src/controllers/web/pet-passport.controller.ts
@@ -453,7 +453,10 @@ export const PetPassportController = {
     run: async ({ params, req, res }) =>
       applePassResponse(
         await parentPassport(params, req),
-        await PetPassportService.ensurePublicToken(params.patientId),
+        await PetPassportService.walletShareTokenForParent(
+          params.patientId,
+          req.userId ?? null,
+        ),
         res,
       ),
   }),
@@ -465,7 +468,10 @@ export const PetPassportController = {
     run: async ({ params, req, res }) =>
       googlePassResponse(
         await parentPassport(params, req),
-        await PetPassportService.ensurePublicToken(params.patientId),
+        await PetPassportService.walletShareTokenForParent(
+          params.patientId,
+          req.userId ?? null,
+        ),
         res,
       ),
   }),

--- a/apps/backend/src/services/pet-passport.service.ts
+++ b/apps/backend/src/services/pet-passport.service.ts
@@ -645,6 +645,52 @@ export const PetPassportService = {
   },
 
   /**
+   * The public token a PARENT wallet pass embeds.
+   *
+   * Minting an owner-scope public link is the primary parent's call: that token
+   * resolves with "owner" scope - every practice's records, no consent gate -
+   * so it is a durable credential only the owner should be able to create. A
+   * co-parent may embed a link the primary has already created, but never mint
+   * one, mirroring why staff pass builders reuse an existing token rather than
+   * forging a public credential the owner never authorised.
+   */
+  async walletShareTokenForParent(
+    patientId: string,
+    userId: string | null,
+  ): Promise<string> {
+    if (!userId) {
+      throw new PetPassportServiceError("Companion not found.", 404);
+    }
+    const parentId = await findParentIdForAuthUser(userId);
+    const link = parentId
+      ? await prisma.parentPatient.findFirst({
+          where: {
+            patientId,
+            parentId,
+            status: "ACTIVE",
+            role: { in: ["PRIMARY", "CO_PARENT"] },
+          },
+          select: { role: true },
+        })
+      : null;
+    // Uniform 404 so this cannot be used to probe which patient ids exist.
+    if (!link) {
+      throw new PetPassportServiceError("Companion not found.", 404);
+    }
+    if (link.role === "PRIMARY") {
+      return PetPassportService.ensurePublicToken(patientId);
+    }
+    const existing = await PetPassportService.getExistingPublicToken(patientId);
+    if (existing) {
+      return existing;
+    }
+    throw new PetPassportServiceError(
+      "No public share link exists for this passport.",
+      409,
+    );
+  },
+
+  /**
    * The token a STAFF wallet pass carries.
    *
    * Distinct from `publicToken` on purpose. The public one resolves with

--- a/apps/backend/test/controllers/web/pet-passport.controller.test.ts
+++ b/apps/backend/test/controllers/web/pet-passport.controller.test.ts
@@ -32,9 +32,11 @@ jest.mock("../../../src/services/pet-passport.service", () => {
     PetPassportService: {
       issuePassport: jest.fn(),
       getPassport: jest.fn(),
+      getPassportForParent: jest.fn(),
       getPublicPassportByToken: jest.fn(),
       ensurePublicToken: jest.fn(),
       getExistingPublicToken: jest.fn(),
+      walletShareTokenForParent: jest.fn(),
       getOrCreatePracticeWalletToken: jest.fn(),
       issuePublicToken: jest.fn(),
       revokePublicToken: jest.fn(),
@@ -104,6 +106,10 @@ describe("PetPassportController", () => {
       "practice-token" as never,
     );
     service.getExistingPublicToken.mockResolvedValue(
+      "share-token-abc" as never,
+    );
+    // Parent wallet routes embed a share link only the primary parent may mint.
+    service.walletShareTokenForParent.mockResolvedValue(
       "share-token-abc" as never,
     );
     jsonMock = jest.fn();
@@ -778,6 +784,84 @@ describe("PetPassportController", () => {
       service.getPassport.mockRejectedValue(new Error("boom"));
       await PetPassportController.getGooglePass(authed(), res as Response);
       expect(statusMock).toHaveBeenCalledWith(500);
+    });
+  });
+
+  describe("getApplePassForParent", () => {
+    it("streams the pass with the parent share token, never minting via ensurePublicToken", async () => {
+      service.getPassportForParent.mockResolvedValue(passportDto as never);
+      wallet.buildApplePass.mockResolvedValue(Buffer.from("pk") as never);
+
+      await PetPassportController.getApplePassForParent(
+        authed(),
+        res as Response,
+      );
+
+      expect(service.walletShareTokenForParent).toHaveBeenCalledWith(
+        "pat-1",
+        "user-1",
+      );
+      expect(service.ensurePublicToken).not.toHaveBeenCalled();
+      expect(wallet.buildApplePass).toHaveBeenCalledWith(
+        passportDto,
+        "share-token-abc",
+      );
+      expect(sendMock).toHaveBeenCalled();
+    });
+
+    it("409s when a co-parent has no primary-created share link to embed", async () => {
+      service.getPassportForParent.mockResolvedValue(passportDto as never);
+      service.walletShareTokenForParent.mockRejectedValue(
+        new PetPassportServiceError("no link", 409),
+      );
+
+      await PetPassportController.getApplePassForParent(
+        authed(),
+        res as Response,
+      );
+
+      expect(statusMock).toHaveBeenCalledWith(409);
+      expect(wallet.buildApplePass).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getGooglePassForParent", () => {
+    it("returns the save url with the parent share token, never minting via ensurePublicToken", async () => {
+      service.getPassportForParent.mockResolvedValue(passportDto as never);
+      wallet.buildGoogleSaveUrl.mockReturnValue("https://pay.google.com/x");
+
+      await PetPassportController.getGooglePassForParent(
+        authed(),
+        res as Response,
+      );
+
+      expect(service.walletShareTokenForParent).toHaveBeenCalledWith(
+        "pat-1",
+        "user-1",
+      );
+      expect(service.ensurePublicToken).not.toHaveBeenCalled();
+      expect(wallet.buildGoogleSaveUrl).toHaveBeenCalledWith(
+        passportDto,
+        "share-token-abc",
+      );
+      expect(jsonMock).toHaveBeenCalledWith({
+        saveUrl: "https://pay.google.com/x",
+      });
+    });
+
+    it("409s when a co-parent has no primary-created share link to embed", async () => {
+      service.getPassportForParent.mockResolvedValue(passportDto as never);
+      service.walletShareTokenForParent.mockRejectedValue(
+        new PetPassportServiceError("no link", 409),
+      );
+
+      await PetPassportController.getGooglePassForParent(
+        authed(),
+        res as Response,
+      );
+
+      expect(statusMock).toHaveBeenCalledWith(409);
+      expect(wallet.buildGoogleSaveUrl).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/backend/test/services/pet-passport.service.test.ts
+++ b/apps/backend/test/services/pet-passport.service.test.ts
@@ -734,6 +734,97 @@ describe("PetPassportService.getExistingPublicToken", () => {
   });
 });
 
+describe("PetPassportService.walletShareTokenForParent", () => {
+  // Minting an owner-scope public link is the primary parent's call; a
+  // co-parent may only embed a link the primary already created, never mint one.
+  it("404s an unauthenticated caller without touching the passport", async () => {
+    await expect(
+      PetPassportService.walletShareTokenForParent("pat-1", null),
+    ).rejects.toMatchObject({ statusCode: 404 });
+    expect(prismaMock.petPassport.update).not.toHaveBeenCalled();
+  });
+
+  it("404s a caller who is not the pet's parent without minting", async () => {
+    prismaMock.authUserMobile.findFirst.mockResolvedValue({
+      parentId: "par-1",
+    });
+    prismaMock.parentPatient.findFirst.mockResolvedValue(null);
+    await expect(
+      PetPassportService.walletShareTokenForParent("pat-1", "user-1"),
+    ).rejects.toMatchObject({ statusCode: 404 });
+    expect(prismaMock.petPassport.update).not.toHaveBeenCalled();
+  });
+
+  it("lets the PRIMARY parent mint a public token when none is live", async () => {
+    prismaMock.authUserMobile.findFirst.mockResolvedValue({
+      parentId: "par-1",
+    });
+    prismaMock.parentPatient.findFirst.mockResolvedValue({ role: "PRIMARY" });
+    prismaMock.petPassport.findFirst.mockResolvedValue({
+      id: "pp-1",
+      publicToken: null,
+      publicTokenRevokedAt: null,
+    });
+    prismaMock.petPassport.update.mockResolvedValue({});
+    const token = await PetPassportService.walletShareTokenForParent(
+      "pat-1",
+      "user-1",
+    );
+    expect(token).toHaveLength(43);
+    expect(prismaMock.petPassport.update).toHaveBeenCalled();
+  });
+
+  it("reuses a live token for the PRIMARY parent without minting", async () => {
+    prismaMock.authUserMobile.findFirst.mockResolvedValue({
+      parentId: "par-1",
+    });
+    prismaMock.parentPatient.findFirst.mockResolvedValue({ role: "PRIMARY" });
+    prismaMock.petPassport.findFirst.mockResolvedValue({
+      id: "pp-1",
+      publicToken: "live-token",
+      publicTokenRevokedAt: null,
+    });
+    const token = await PetPassportService.walletShareTokenForParent(
+      "pat-1",
+      "user-1",
+    );
+    expect(token).toBe("live-token");
+    expect(prismaMock.petPassport.update).not.toHaveBeenCalled();
+  });
+
+  it("hands a CO_PARENT the primary's live link without minting one", async () => {
+    prismaMock.authUserMobile.findFirst.mockResolvedValue({
+      parentId: "par-2",
+    });
+    prismaMock.parentPatient.findFirst.mockResolvedValue({ role: "CO_PARENT" });
+    prismaMock.petPassport.findFirst.mockResolvedValue({
+      publicToken: "live-token",
+      publicTokenRevokedAt: null,
+    });
+    const token = await PetPassportService.walletShareTokenForParent(
+      "pat-1",
+      "co-parent-user",
+    );
+    expect(token).toBe("live-token");
+    expect(prismaMock.petPassport.update).not.toHaveBeenCalled();
+  });
+
+  it("409s a CO_PARENT when the primary has created no public link", async () => {
+    prismaMock.authUserMobile.findFirst.mockResolvedValue({
+      parentId: "par-2",
+    });
+    prismaMock.parentPatient.findFirst.mockResolvedValue({ role: "CO_PARENT" });
+    prismaMock.petPassport.findFirst.mockResolvedValue({
+      publicToken: null,
+      publicTokenRevokedAt: null,
+    });
+    await expect(
+      PetPassportService.walletShareTokenForParent("pat-1", "co-parent-user"),
+    ).rejects.toMatchObject({ statusCode: 409 });
+    expect(prismaMock.petPassport.update).not.toHaveBeenCalled();
+  });
+});
+
 describe("PetPassportService.getPassportForParent", () => {
   // The caller's id is a PROVIDER id, so the parent is resolved through
   // AuthUser. Fixtures that put the provider id straight on


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [ ] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

The Apple and Google parent wallet-pass routes (`getApplePassForParent`,
`getGooglePassForParent`) called `PetPassportService.ensurePublicToken(patientId)`
directly. An owner-scope public passport token resolves with "owner" scope - every
practice's records, no consent gate - so it is a durable credential only the
primary owner should be able to create.

Because the routes minted that token for any caller who reached them, a co-parent
holding only a read grant could cause an owner-scope public token to be created,
forging a public share link the owner never authorized.

## What is the new behavior?

Added `PetPassportService.walletShareTokenForParent(patientId, userId)`, which
resolves the caller's ACTIVE `PRIMARY`/`CO_PARENT` link to the patient and gates
token behavior on role:

- Null `userId` or no matching ACTIVE parent link throws a uniform 404
  ("Companion not found."), which also avoids leaking which patient ids exist.
- A `PRIMARY` link mints (or reuses) the owner-scope public token via
  `ensurePublicToken`.
- A `CO_PARENT` link returns an already-live public token via
  `getExistingPublicToken` if one exists, and throws 409
  ("No public share link exists for this passport.") otherwise - it never mints
  a new one.

Both wallet routes now call `walletShareTokenForParent(params.patientId, req.userId ?? null)`
instead of `ensurePublicToken`.

Added service tests (404 on null userId, 404 on no link, PRIMARY mint and reuse,
CO_PARENT live-token reuse without update, CO_PARENT 409) and controller tests
(both wallet routes call `walletShareTokenForParent` and never `ensurePublicToken`,
stream/return on success, and surface the 409).

## Validation

- 99 targeted backend tests pass (service + controller).
- `tsc --noEmit` clean.
- Lint exit 0.

Not run: full backend suite, and end-to-end verification of the live wallet
routes was not performed.

## Related Issue(s)

Fixes #

