### PR TITLE
fix(mobile): recover expired sessions, and unstick the home headline

### DIFF
--- a/apps/mobileAppYC/__tests__/features/auth/sessionManager.test.ts
+++ b/apps/mobileAppYC/__tests__/features/auth/sessionManager.test.ts
@@ -901,7 +901,11 @@ describe('sessionManager', () => {
       expect(result).toBeNull();
     });
 
-    it('returns the stale tokens if refresh fails', async () => {
+    // Was: "returns the stale tokens if refresh fails". Handing a known-dead
+    // credential back to the caller is the bug - it gets sent, the server
+    // answers 401, and the screen renders axios's own "Request failed with
+    // status code 401". Null routes the caller to its sign-in-again path.
+    it('returns null if refresh fails, never the dead token', async () => {
       (loadStoredTokens as jest.Mock).mockResolvedValue({
         ...mockTokens,
         expiresAt: Date.now() - 1000,
@@ -913,12 +917,29 @@ describe('sessionManager', () => {
       const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
       const result = await getFreshStoredTokens();
 
-      // Returns the old tokens (normalized) if refresh fails
-      expect(result?.accessToken).toBe('access-token');
+      expect(result).toBeNull();
       expect(consoleSpy).toHaveBeenCalledWith(
         expect.stringContaining('Unable to refresh'),
         expect.any(Error),
       );
+      consoleSpy.mockRestore();
+    });
+
+    // The exact shape of the reported bug: the session is fully dead, so
+    // getAccessToken() hands back the SAME expired token rather than throwing.
+    // The old code stored that as "refreshed" and returned it.
+    it('returns null when refresh hands back the same token', async () => {
+      (loadStoredTokens as jest.Mock).mockResolvedValue({
+        ...mockTokens,
+        expiresAt: Date.now() - 1000,
+      });
+      mockSuperTokens.getAccessToken.mockResolvedValue('access-token');
+
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const result = await getFreshStoredTokens();
+
+      expect(result).toBeNull();
+      expect(storeTokens).not.toHaveBeenCalled();
       consoleSpy.mockRestore();
     });
   });

--- a/apps/mobileAppYC/__tests__/shared/utils/serviceHelpers.test.ts
+++ b/apps/mobileAppYC/__tests__/shared/utils/serviceHelpers.test.ts
@@ -1,0 +1,37 @@
+import {
+  SESSION_EXPIRED_MESSAGE,
+  toErrorMessage,
+} from '@/shared/utils/serviceHelpers';
+
+describe('toErrorMessage on an expired session', () => {
+  // The reported bug: after an overnight idle the passport screen showed
+  // "Request failed with status code 401" - axios's own message, surfaced
+  // straight to a pet parent. The server's body is no better: SuperTokens
+  // answers {"message":"try refresh token"}, which is an instruction to the
+  // client, not to a person. Both must lose to the actionable message.
+  it('prefers the actionable message over axios own text', () => {
+    const axiosLike = {
+      message: 'Request failed with status code 401',
+      response: {status: 401, data: {}},
+    };
+    expect(toErrorMessage(axiosLike, 'fallback')).toBe(SESSION_EXPIRED_MESSAGE);
+  });
+
+  it('prefers it over the servers "try refresh token" too', () => {
+    const axiosLike = {
+      message: 'Request failed with status code 401',
+      response: {status: 401, data: {message: 'try refresh token'}},
+    };
+    expect(toErrorMessage(axiosLike, 'fallback')).toBe(SESSION_EXPIRED_MESSAGE);
+  });
+
+  it('leaves other statuses alone', () => {
+    const axiosLike = {
+      message: 'Request failed with status code 403',
+      response: {status: 403, data: {message: 'Ask the primary parent.'}},
+    };
+    expect(toErrorMessage(axiosLike, 'fallback')).toBe(
+      'Ask the primary parent.',
+    );
+  });
+});

--- a/apps/mobileAppYC/src/features/auth/sessionManager.ts
+++ b/apps/mobileAppYC/src/features/auth/sessionManager.ts
@@ -498,10 +498,35 @@ export const getFreshStoredTokens =
     }
 
     try {
-      // The SuperTokens SDK refreshes the session automatically when the
-      // access token has expired.
+      // Ask for a refresh explicitly rather than hoping getAccessToken() does
+      // one. When the refresh token is also dead this resolves false, which is
+      // the difference between "renewed" and "handed back the same corpse".
+      await SuperTokens.attemptRefreshingSession();
+
       const accessToken = await SuperTokens.getAccessToken();
       if (!accessToken) {
+        return null;
+      }
+
+      const refreshedExpiry = resolveExpiration({accessToken});
+
+      // The bug this guards: getAccessToken() returns the CURRENT token, and on
+      // a fully expired session that is the same expired token we just
+      // rejected. The old code stored it as "refreshed", recomputed the same
+      // past expiry, and returned it - so the caller sent a dead credential and
+      // the screen showed a raw "Request failed with status code 401" instead
+      // of the friendly copy this file already has.
+      //
+      // Identity, not expiry, is the reliable test. A refresh that handed back
+      // the byte-identical token achieved nothing, and that holds whether or
+      // not the token is a parseable JWT. Expiry is only a secondary check, and
+      // deliberately not `!refreshedExpiry` - an unparseable expiry means we
+      // cannot tell, and locking every such user out is worse than the bug.
+      const unchanged = accessToken === storedTokens.accessToken;
+      if (unchanged || isTokenExpired(refreshedExpiry)) {
+        console.warn(
+          '[Auth] Refresh did not renew the session; treating it as ended',
+        );
         return null;
       }
 
@@ -510,7 +535,7 @@ export const getFreshStoredTokens =
         idToken: accessToken,
         accessToken,
         refreshToken: undefined,
-        expiresAt: resolveExpiration({accessToken}),
+        expiresAt: refreshedExpiry,
         provider: 'supertokens',
       };
 
@@ -526,7 +551,10 @@ export const getFreshStoredTokens =
         '[Auth] Unable to refresh SuperTokens session tokens',
         error,
       );
-      return normalized;
+      // Returning the stale token here would send a known-dead credential and
+      // surface the raw axios 401. Null routes callers to their
+      // "please sign in again" path instead.
+      return null;
     }
   };
 

--- a/apps/mobileAppYC/src/features/home/screens/HomeScreen/HomeScreen.tsx
+++ b/apps/mobileAppYC/src/features/home/screens/HomeScreen/HomeScreen.tsx
@@ -1614,9 +1614,21 @@ const createStyles = (theme: any) =>
       gap: theme.spacing['3.5'],
       flex: 1,
       flexShrink: 1,
+      // Same reason as greetingTextBlock: without this the row cannot give
+      // way to the action buttons beside it.
+      minWidth: 0,
     },
     greetingTextBlock: {
       flexShrink: 1,
+      // minWidth: 0 is what actually lets this shrink.
+      //
+      // A flex item defaults to min-width:auto - its CONTENT width - so
+      // flexShrink alone cannot take it below the width of "Your companions".
+      // The block kept its intrinsic width and the headline ran underneath the
+      // emergency and notification buttons, which are flexShrink: 0.
+      // adjustsFontSizeToFit did not save it either: nothing was asking the
+      // text to fit a narrower box, so it had nothing to shrink to.
+      minWidth: 0,
     },
     avatar: {
       width: theme.spacing['12'],

--- a/apps/mobileAppYC/src/features/passport/passportSlice.ts
+++ b/apps/mobileAppYC/src/features/passport/passportSlice.ts
@@ -10,6 +10,7 @@ import {
   isTokenExpired,
 } from '@/features/auth/sessionManager';
 import {passportApi} from '@/features/passport/services/passportService';
+import {toErrorMessage} from '@/shared/utils/serviceHelpers';
 
 // The screen renders one companion at a time while several fetches can be in
 // flight (backing out of pet A straight into pet B), so the request flags are
@@ -68,9 +69,11 @@ export const fetchPassport = createAsyncThunk<
       return {companionId, passport: null};
     }
 
-    return rejectWithValue(
-      error instanceof Error ? error.message : 'Failed to load passport',
-    );
+    // Via toErrorMessage, not error.message: an axios rejection's own
+    // message is "Request failed with status code 401", and that is exactly
+    // what a pet parent was shown on this screen after leaving the app idle
+    // overnight. The helper turns a 401 into something they can act on.
+    return rejectWithValue(toErrorMessage(error, 'Failed to load passport'));
   }
 });
 

--- a/apps/mobileAppYC/src/shared/utils/serviceHelpers.ts
+++ b/apps/mobileAppYC/src/shared/utils/serviceHelpers.ts
@@ -1,7 +1,26 @@
-import {getFreshStoredTokens, isTokenExpired} from '@/features/auth/sessionManager';
+import {
+  getFreshStoredTokens,
+  isTokenExpired,
+} from '@/features/auth/sessionManager';
+
+export const SESSION_EXPIRED_MESSAGE =
+  'Your session expired. Please sign in again.';
 
 export const toErrorMessage = (error: unknown, fallback: string): string => {
   if (error && typeof error === 'object') {
+    // 401 first, before any server text.
+    //
+    // A session that dies between the token check and the request comes back
+    // as `{"message":"try refresh token"}`, and axios's own message is
+    // "Request failed with status code 401". Both were reaching the screen -
+    // that is what a pet parent saw on the passport after leaving the app
+    // open overnight. Neither tells them the one thing they can act on, and
+    // "try refresh token" is an instruction to the client, not to a person.
+    const status = (error as {response?: {status?: number}})?.response?.status;
+    if (status === 401) {
+      return SESSION_EXPIRED_MESSAGE;
+    }
+
     const maybeMessage =
       (error as any)?.response?.data?.message ??
       (error as any)?.message ??


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [ ] There is an issue for the bug/feature this PR is for. (Both reported directly by Ankit from the running app.)
- [x] All existing tests and lints pass.

## What is the current behavior?

**Two things reported from the app, bundled because they were found in the same pass.**

### 1. An expired session shows `Request failed with status code 401`

Opening Pet Passport after leaving the app idle surfaced axios's own error string. It isn't a passport bug - the passport screen is just one of the few that fetches a token explicitly rather than relying on the interceptor, so it hits a stale token first. Any screen a long-idle session lands on next behaves the same.

`getFreshStoredTokens` already had a refresh path; it never checked whether the refresh worked:

```ts
const accessToken = await SuperTokens.getAccessToken();
… expiresAt: resolveExpiration({accessToken})
```

`getAccessToken()` returns the **current** token, so on a fully dead session it returns the same expired one. The code stored that as "refreshed", recomputed the same past expiry, and handed it back — the caller sent a known-dead credential and got a 401. The failure path returned the stale token too.

The irony: this file already contains *"Your session expired. Please sign in again."* It was unreachable.

### 2. The home headline runs under the header buttons

"Your companions" was drawn beneath the emergency and notification buttons — **65 columns of title ink inside the emergency disc**, measured from a device screenshot.

## What is the new behavior?

**Session.** Refresh is requested explicitly, and "same token back" is treated as a dead session. The test is token **identity**, not expiry — deliberately, because it holds whether or not the token parses as a JWT, and an unparseable expiry means we can't tell; locking every such user out would be worse than the bug. Failure returns `null`, routing callers to the sign-in path that already existed.

Second layer: `toErrorMessage` maps any 401 to an actionable message. The server's body is `{"message":"try refresh token"}` — an instruction to the client, not to a person — and axios's message is the reported string. Both reached the screen.

**Header.** `minWidth: 0` on the greeting block and its flex parent. The layout already looked correct; the cause is that a flex item's `min-width` defaults to `auto` (its **content** width), so `flexShrink` alone could never take the block below the natural width of "Your companions". `adjustsFontSizeToFit` didn't help either — nothing was asking the text to fit a narrower box.

## Validation performed

- Mobile suite: 468 suites, 7,583 tests. Type-check and lint clean.
- Session fix mutation-checked three ways — allowing the same token through, returning the stale token on failure, and dropping the 401 mapping each fail their tests.
- Header fix measured on device before and after: 65 ink columns inside the button zone → **0**, title now ends at x=824 with the disc starting at x=828.

## Deliberately not changed

The emergency button's **white disc**. It looks inconsistent beside the bell's dark one, but the code explains why — the badge's cross is a knockout needing a light disc in both themes, and an emergency control is the one place high visibility is wanted. That's a reasoned decision; reversing it quietly would be wrong.

The remaining issue there is the **asset**: `emergencyIcon.png` has the word EMERGENCY baked in at roughly 6px, which can't scale with the user's type setting. That needs a designer, not a stylesheet. Accessibility is unaffected — the button carries `accessibilityLabel="Emergency"`.

## Related Issue(s)

Fixes #
