### PR TITLE
fix(backend): scope companion and expense by-id routes to the caller

### DIFF
--- a/apps/backend/src/middlewares/companion-access.ts
+++ b/apps/backend/src/middlewares/companion-access.ts
@@ -26,6 +26,11 @@ import { findParentIdForAuthUser } from "src/services/shared/parent-identity";
  *   - No link at all is a 404, not a 403, matching the existing convention on
  *     parent-facing routes: a uniform "not found" so the endpoint cannot be
  *     used to discover which patient ids exist.
+ *
+ * Two ways in. `requireCompanionPermission` is for routes that carry the
+ * patient id in the path. `requireCompanionPermissionForResource` is for routes
+ * keyed by a resource id (an expense, an invoice) where the companion has to be
+ * read off the row first - see the resolvers at the bottom of this file.
  */
 export type CompanionFeature =
   | "appointments"
@@ -36,6 +41,23 @@ export type CompanionFeature =
   | "expenses"
   | "medicalRecords"
   | "tasks";
+
+/**
+ * What a resolver concluded about the row behind a resource id.
+ *
+ * `allow` exists for rows that belong to the caller directly and have no
+ * companion to check against - an invoice raised against a parent rather than a
+ * patient. It is a deliberate, narrow escape hatch: a resolver may only return
+ * it after proving ownership itself, which is why resolvers are handed the
+ * caller's `parentId`.
+ */
+export type CompanionResourceScope =
+  { kind: "patient"; patientId: string } | { kind: "allow" } | { kind: "deny" };
+
+export type CompanionResourceResolver = (
+  req: Request,
+  parentId: string,
+) => Promise<CompanionResourceScope>;
 
 const FEATURE_LABELS: Record<CompanionFeature, string> = {
   appointments: "appointments",
@@ -56,60 +78,126 @@ const isGranted = (
   return (permissions as Record<string, unknown>)[feature] === true;
 };
 
+const notFound = (res: Response) =>
+  res.status(404).json({ message: "Companion not found." });
+
+const enforce = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+  feature: CompanionFeature,
+  resolve: CompanionResourceResolver,
+) => {
+  try {
+    const userId = (req as Request & { userId?: string | null }).userId;
+    if (!userId) return notFound(res);
+
+    const parentId = await findParentIdForAuthUser(userId);
+    if (!parentId) return notFound(res);
+
+    const scope = await resolve(req, parentId);
+    if (scope.kind === "deny") return notFound(res);
+    if (scope.kind === "allow") return next();
+
+    // Load-bearing, and it must stay BEFORE the query.
+    //
+    // Prisma omits an `undefined` field from `where` rather than matching
+    // nothing, so `{ patientId: undefined, parentId }` silently becomes
+    // `{ parentId }` - a filter that matches this parent's link to ANY
+    // patient and would hand back a link, and therefore access. A route
+    // mounted with the wrong param name, or a resolver reading a column that
+    // turned out to be null, would do exactly that. The type says this is a
+    // string; the check is here because the cost of being wrong is a bypass.
+    //
+    // CodeQL flags this as js/user-controlled-bypass because a user-supplied
+    // value guards an authorisation decision. The direction is inverted: the
+    // falsy branch DENIES, and the value is used to look the permission up,
+    // never to decide whether to check it. Removing this guard is the
+    // vulnerability; having it is the fix.
+    if (!scope.patientId) return notFound(res);
+
+    const link = await prisma.parentPatient.findFirst({
+      where: {
+        patientId: scope.patientId,
+        parentId,
+        status: "ACTIVE",
+        role: { in: ["PRIMARY", "CO_PARENT"] },
+      },
+      select: { role: true, permissions: true },
+    });
+
+    if (!link) return notFound(res);
+
+    if (link.role === "PRIMARY" || isGranted(link.permissions, feature)) {
+      return next();
+    }
+
+    // Worded so the app can show it as-is; it already says the same thing.
+    return res.status(403).json({
+      message: `Ask the primary parent to enable ${FEATURE_LABELS[feature]} access for you.`,
+    });
+  } catch (error) {
+    return next(error);
+  }
+};
+
 export const requireCompanionPermission =
   (feature: CompanionFeature, paramName = "patientId") =>
-  async (req: Request, res: Response, next: NextFunction) => {
-    try {
-      const patientId = (req.params as Record<string, string | undefined>)[
-        paramName
-      ];
-      const userId = (req as Request & { userId?: string | null }).userId;
+  (req: Request, res: Response, next: NextFunction) => {
+    // Same guard as the one inside `enforce`, hoisted so a route mounted with
+    // the wrong param name is denied before it costs a query. See the comment
+    // there for why a falsy id must never reach a `where` clause.
+    const patientId = (req.params as Record<string, string | undefined>)[
+      paramName
+    ]?.trim();
+    if (!patientId) return notFound(res);
 
-      // Load-bearing, and it must stay BEFORE the query.
-      //
-      // Prisma omits an `undefined` field from `where` rather than matching
-      // nothing, so `{ patientId: undefined, parentId }` silently becomes
-      // `{ parentId }` - a filter that matches this parent's link to ANY
-      // patient and would hand back a link, and therefore access. A route
-      // mounted with the wrong param name would do exactly that.
-      //
-      // CodeQL flags this as js/user-controlled-bypass because a user-supplied
-      // value guards an authorisation decision. The direction is inverted: the
-      // falsy branch DENIES, and the value is used to look the permission up,
-      // never to decide whether to check it. Removing this guard is the
-      // vulnerability; having it is the fix.
-      if (!patientId || !userId) {
-        return res.status(404).json({ message: "Companion not found." });
-      }
-
-      const parentId = await findParentIdForAuthUser(userId);
-      if (!parentId) {
-        return res.status(404).json({ message: "Companion not found." });
-      }
-
-      const link = await prisma.parentPatient.findFirst({
-        where: {
-          patientId,
-          parentId,
-          status: "ACTIVE",
-          role: { in: ["PRIMARY", "CO_PARENT"] },
-        },
-        select: { role: true, permissions: true },
-      });
-
-      if (!link) {
-        return res.status(404).json({ message: "Companion not found." });
-      }
-
-      if (link.role === "PRIMARY" || isGranted(link.permissions, feature)) {
-        return next();
-      }
-
-      // Worded so the app can show it as-is; it already says the same thing.
-      return res.status(403).json({
-        message: `Ask the primary parent to enable ${FEATURE_LABELS[feature]} access for you.`,
-      });
-    } catch (error) {
-      return next(error);
-    }
+    return enforce(req, res, next, feature, async () => ({
+      kind: "patient",
+      patientId,
+    }));
   };
+
+export const requireCompanionPermissionForResource =
+  (feature: CompanionFeature, resolve: CompanionResourceResolver) =>
+  (req: Request, res: Response, next: NextFunction) =>
+    enforce(req, res, next, feature, resolve);
+
+/**
+ * Expenses are keyed by a bare id, and the id space is shared: the route serves
+ * both `ExternalExpense` (a parent-recorded cost) and `Invoice` (raised by a
+ * practice), because `getExpenseById` falls through from one to the other.
+ * Both have to be resolved here or the fall-through becomes the bypass.
+ *
+ * An invoice may have no `patientId` - it can be raised against the parent
+ * directly - and there is no companion to authorise against in that case, so
+ * ownership is checked in place instead.
+ */
+export const resolveExpenseCompanion: CompanionResourceResolver = async (
+  req,
+  parentId,
+) => {
+  const expenseId = (
+    req.params as Record<string, string | undefined>
+  ).expenseId?.trim();
+  if (!expenseId) return { kind: "deny" };
+
+  const expense = await prisma.externalExpense.findUnique({
+    where: { id: expenseId },
+    select: { patientId: true },
+  });
+  if (expense?.patientId) {
+    return { kind: "patient", patientId: expense.patientId };
+  }
+
+  const invoice = await prisma.invoice.findUnique({
+    where: { id: expenseId },
+    select: { patientId: true, parentId: true },
+  });
+  if (!invoice) return { kind: "deny" };
+  if (invoice.patientId) {
+    return { kind: "patient", patientId: invoice.patientId };
+  }
+
+  return invoice.parentId === parentId ? { kind: "allow" } : { kind: "deny" };
+};

--- a/apps/backend/src/routers/companion.router.ts
+++ b/apps/backend/src/routers/companion.router.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { CompanionController } from "../controllers/app/companion.controller";
 import { requireMobileAuth, requireWebAuth } from "src/middlewares/auth";
 import { withOrgPermissions, requirePermission } from "src/middlewares/rbac";
+import { requireCompanionPermission } from "src/middlewares/companion-access";
 
 const router = Router();
 
@@ -11,9 +12,19 @@ const router = Router();
 
 router.post("/", requireMobileAuth, CompanionController.createCompanionMobile);
 
-router.get("/:id", requireMobileAuth, CompanionController.getCompanionById);
+router.get(
+  "/:id",
+  requireMobileAuth,
+  requireCompanionPermission("companionProfile", "id"),
+  CompanionController.getCompanionById,
+);
 
-router.put("/:id", requireMobileAuth, CompanionController.updateCompanion);
+router.put(
+  "/:id",
+  requireMobileAuth,
+  requireCompanionPermission("companionProfile", "id"),
+  CompanionController.updateCompanion,
+);
 
 router.delete("/:id", requireMobileAuth, CompanionController.deleteCompanion);
 

--- a/apps/backend/src/routers/expense.router.ts
+++ b/apps/backend/src/routers/expense.router.ts
@@ -1,21 +1,43 @@
 import { Router } from "express";
 import { ExpenseController } from "../controllers/app/expense.controller";
 import { requireMobileAuth } from "src/middlewares/auth";
-import { requireCompanionPermission } from "src/middlewares/companion-access";
+import {
+  requireCompanionPermission,
+  requireCompanionPermissionForResource,
+  resolveExpenseCompanion,
+} from "src/middlewares/companion-access";
 
 const router = Router();
 
+// The by-id routes are keyed by an expense id, not a patient id, so the
+// companion is read off the row before the permission is checked.
+const requireExpenseAccess = requireCompanionPermissionForResource(
+  "expenses",
+  resolveExpenseCompanion,
+);
+
 router.post("/", requireMobileAuth, ExpenseController.createExpense);
 
-router.patch("/:expenseId", requireMobileAuth, ExpenseController.updateExpense);
+router.patch(
+  "/:expenseId",
+  requireMobileAuth,
+  requireExpenseAccess,
+  ExpenseController.updateExpense,
+);
 
 router.delete(
   "/:expenseId",
   requireMobileAuth,
+  requireExpenseAccess,
   ExpenseController.deleteExpense,
 );
 
-router.get("/:expenseId", requireMobileAuth, ExpenseController.getExpenseById);
+router.get(
+  "/:expenseId",
+  requireMobileAuth,
+  requireExpenseAccess,
+  ExpenseController.getExpenseById,
+);
 
 router.get(
   "/companion/:patientId/list",

--- a/apps/backend/test/middlewares/companion-access.test.ts
+++ b/apps/backend/test/middlewares/companion-access.test.ts
@@ -1,7 +1,11 @@
 import type { NextFunction, Request, Response } from "express";
 
 jest.mock("src/config/prisma", () => ({
-  prisma: { parentPatient: { findFirst: jest.fn() } },
+  prisma: {
+    parentPatient: { findFirst: jest.fn() },
+    externalExpense: { findUnique: jest.fn() },
+    invoice: { findUnique: jest.fn() },
+  },
 }));
 jest.mock("src/services/shared/parent-identity", () => ({
   findParentIdForAuthUser: jest.fn(),
@@ -9,7 +13,11 @@ jest.mock("src/services/shared/parent-identity", () => ({
 
 import { prisma } from "src/config/prisma";
 import { findParentIdForAuthUser } from "src/services/shared/parent-identity";
-import { requireCompanionPermission } from "src/middlewares/companion-access";
+import {
+  requireCompanionPermission,
+  requireCompanionPermissionForResource,
+  resolveExpenseCompanion,
+} from "src/middlewares/companion-access";
 
 const findFirst = (
   prisma as unknown as {
@@ -17,6 +25,27 @@ const findFirst = (
   }
 ).parentPatient.findFirst;
 const findParent = findParentIdForAuthUser as jest.Mock;
+const expenseFindUnique = (
+  prisma as unknown as { externalExpense: { findUnique: jest.Mock } }
+).externalExpense.findUnique;
+const invoiceFindUnique = (
+  prisma as unknown as { invoice: { findUnique: jest.Mock } }
+).invoice.findUnique;
+
+const runExpenseMiddleware = async ({
+  expenseId = "exp-1",
+  userId = "provider-user-1",
+} = {}) => {
+  const req = { params: { expenseId }, userId } as unknown as Request;
+  const json = jest.fn();
+  const res = { status: jest.fn(() => ({ json })) } as unknown as Response;
+  const next = jest.fn() as NextFunction;
+  await requireCompanionPermissionForResource(
+    "expenses",
+    resolveExpenseCompanion,
+  )(req, res, next);
+  return { res, json, next };
+};
 
 const runMiddleware = async (
   feature: Parameters<typeof requireCompanionPermission>[0] = "documents",
@@ -180,5 +209,120 @@ describe("requireCompanionPermission", () => {
         }),
       }),
     );
+  });
+});
+
+describe("requireCompanionPermissionForResource (expenses)", () => {
+  beforeEach(() => {
+    expenseFindUnique.mockResolvedValue(null);
+    invoiceFindUnique.mockResolvedValue(null);
+  });
+
+  it("closes the cross-parent read: an expense on someone else's companion is a 404", async () => {
+    // The regression this guard exists for. Before it, `GET /expense/:id`
+    // resolved the row by id alone and handed it back to any signed-in parent.
+    // The caller here holds a session but no link to the expense's companion,
+    // so the link lookup finds nothing and the answer must be a bare 404 -
+    // never a 403, which would confirm the id belongs to someone.
+    expenseFindUnique.mockResolvedValue({ patientId: "someone-elses-pet" });
+    findFirst.mockResolvedValue(null);
+
+    const { next, res, json } = await runExpenseMiddleware();
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(json).toHaveBeenCalledWith({ message: "Companion not found." });
+    expect(findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          patientId: "someone-elses-pet",
+          parentId: "par-1",
+        }),
+      }),
+    );
+  });
+
+  it("checks the permission against the companion named on the expense", async () => {
+    expenseFindUnique.mockResolvedValue({ patientId: "pat-9" });
+    findFirst.mockResolvedValue({
+      role: "CO_PARENT",
+      permissions: { ...ALL_FALSE, expenses: true },
+    });
+
+    const { next, res } = await runExpenseMiddleware();
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("denies a co-parent whose expenses switch is off", async () => {
+    expenseFindUnique.mockResolvedValue({ patientId: "pat-9" });
+    findFirst.mockResolvedValue({ role: "CO_PARENT", permissions: ALL_FALSE });
+
+    const { next, res } = await runExpenseMiddleware();
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it("falls through to the invoice table, since the route serves both", async () => {
+    // `getExpenseById` reads ExternalExpense first and Invoice second. If the
+    // resolver stopped at the first table the fall-through would be the bypass.
+    invoiceFindUnique.mockResolvedValue({
+      patientId: "pat-7",
+      parentId: "par-1",
+    });
+    findFirst.mockResolvedValue({ role: "PRIMARY", permissions: ALL_FALSE });
+
+    const { next } = await runExpenseMiddleware();
+
+    expect(invoiceFindUnique).toHaveBeenCalled();
+    expect(findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ patientId: "pat-7" }),
+      }),
+    );
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("allows an invoice raised against the parent with no companion on it", async () => {
+    // Nothing to check a companion permission against, so ownership is the
+    // whole decision and the resolver proves it before saying yes.
+    invoiceFindUnique.mockResolvedValue({ patientId: null, parentId: "par-1" });
+
+    const { next, res } = await runExpenseMiddleware();
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+    expect(findFirst).not.toHaveBeenCalled();
+  });
+
+  it("denies a companion-less invoice belonging to another parent", async () => {
+    invoiceFindUnique.mockResolvedValue({
+      patientId: null,
+      parentId: "another-parent",
+    });
+
+    const { next, res } = await runExpenseMiddleware();
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(findFirst).not.toHaveBeenCalled();
+  });
+
+  it("denies an id that matches no row, without querying permissions", async () => {
+    const { next, res } = await runExpenseMiddleware({ expenseId: "nope" });
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(findFirst).not.toHaveBeenCalled();
+  });
+
+  it("denies a blank expense id", async () => {
+    const { next, res } = await runExpenseMiddleware({ expenseId: "   " });
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(expenseFindUnique).not.toHaveBeenCalled();
   });
 });

--- a/apps/backend/test/routers/companion.router.test.ts
+++ b/apps/backend/test/routers/companion.router.test.ts
@@ -4,6 +4,8 @@ const requireWebAuth = jest.fn((_req, _res, next) => next());
 const requireMobileAuth = jest.fn((_req, _res, next) => next());
 const withOrgPermissionsMiddleware = jest.fn((_req, _res, next) => next());
 const requirePermissionMiddleware = jest.fn((_req, _res, next) => next());
+const companionGuard = jest.fn((_req, _res, next) => next());
+const requireCompanionPermission = jest.fn();
 
 const CompanionController = {
   createCompanionMobile: jest.fn(),
@@ -24,6 +26,13 @@ jest.mock("../../src/middlewares/auth", () => ({
 jest.mock("../../src/middlewares/rbac", () => ({
   withOrgPermissions: () => withOrgPermissionsMiddleware,
   requirePermission: () => requirePermissionMiddleware,
+}));
+
+jest.mock("../../src/middlewares/companion-access", () => ({
+  requireCompanionPermission: (...args: unknown[]) => {
+    requireCompanionPermission(...args);
+    return companionGuard;
+  },
 }));
 
 jest.mock("../../src/controllers/app/companion.controller", () => ({
@@ -83,6 +92,46 @@ describe("companion.router", () => {
   it("keeps the mobile routes on mobile auth", () => {
     expect(
       findRoute("/:id", "get")?.stack.map((layer) => layer.handle),
-    ).toEqual([requireMobileAuth, CompanionController.getCompanionById]);
+    ).toEqual([
+      requireMobileAuth,
+      companionGuard,
+      CompanionController.getCompanionById,
+    ]);
+  });
+
+  /**
+   * `Patient` rows are not scoped to a parent in the schema, and the handlers
+   * behind these two routes look the row up by id alone - `getById` runs a bare
+   * `findUnique`, and `update` writes with a bare `where: { id }`. Mobile auth
+   * on its own therefore let any signed-in parent read, and overwrite, any of
+   * the companions in the product. The guard is what supplies the ownership
+   * test, so its presence is the assertion.
+   */
+  it.each([
+    ["get", "read"],
+    ["put", "overwrite"],
+  ] as const)(
+    "gates %s /:id so a parent cannot %s another's companion",
+    (method) => {
+      const handles = findRoute("/:id", method)?.stack.map((l) => l.handle);
+      expect(handles).toContain(requireMobileAuth);
+      expect(handles).toContain(companionGuard);
+      expect(requireCompanionPermission).toHaveBeenCalledWith(
+        "companionProfile",
+        "id",
+      );
+    },
+  );
+
+  it("leaves delete to the service, which resolves the link itself", () => {
+    // CompanionService.delete already resolves the parent, finds the link and
+    // rejects a non-PRIMARY caller, including the role-specific behaviour the
+    // permission blob does not describe. Adding the blanket guard here would
+    // second-guess that with a coarser rule.
+    const handles = findRoute("/:id", "delete")?.stack.map((l) => l.handle);
+    expect(handles).toEqual([
+      requireMobileAuth,
+      CompanionController.deleteCompanion,
+    ]);
   });
 });

--- a/apps/backend/test/routers/expense.router.test.ts
+++ b/apps/backend/test/routers/expense.router.test.ts
@@ -1,0 +1,98 @@
+import type { Router } from "express";
+
+const requireMobileAuth = jest.fn((_req, _res, next) => next());
+const companionGuard = jest.fn((_req, _res, next) => next());
+const resourceGuard = jest.fn((_req, _res, next) => next());
+const requireCompanionPermission = jest.fn(() => companionGuard);
+const requireCompanionPermissionForResource = jest.fn(() => resourceGuard);
+const resolveExpenseCompanion = jest.fn();
+
+const ExpenseController = {
+  createExpense: jest.fn(),
+  updateExpense: jest.fn(),
+  deleteExpense: jest.fn(),
+  getExpenseById: jest.fn(),
+  getExpensesByCompanion: jest.fn(),
+  getExpenseSummary: jest.fn(),
+};
+
+jest.mock("../../src/middlewares/auth", () => ({ requireMobileAuth }));
+jest.mock("../../src/middlewares/companion-access", () => ({
+  requireCompanionPermission,
+  requireCompanionPermissionForResource,
+  resolveExpenseCompanion,
+}));
+jest.mock("../../src/controllers/app/expense.controller", () => ({
+  ExpenseController,
+}));
+
+const router = jest.requireActual("../../src/routers/expense.router")
+  .default as Router;
+
+type Layer = {
+  route?: {
+    path: string;
+    methods: Record<string, boolean>;
+    stack: Array<{ handle: unknown }>;
+  };
+};
+
+const findRoute = (path: string, method: string) =>
+  ((router as unknown as { stack: Layer[] }).stack ?? []).find(
+    (entry) =>
+      entry.route?.path === path && Boolean(entry.route?.methods?.[method]),
+  )?.route;
+
+describe("expense.router", () => {
+  /**
+   * These assert the middleware is MOUNTED, which the middleware's own unit
+   * tests cannot do. Deleting the guard from a route leaves every test in
+   * companion-access.test.ts green while reopening the hole it was written for:
+   * `/:expenseId` resolved the row by id alone, so any signed-in parent could
+   * read, edit, or delete another parent's expense.
+   */
+  it.each([
+    ["get", "reading"],
+    ["patch", "editing"],
+    ["delete", "deleting"],
+  ])("guards %s /:expenseId (%s another parent's expense)", (method) => {
+    const route = findRoute("/:expenseId", method);
+    expect(route).toBeDefined();
+    expect(route?.stack).toHaveLength(3);
+    const handles = route?.stack.map((l) => l.handle);
+    expect(handles).toContain(requireMobileAuth);
+    expect(handles).toContain(resourceGuard);
+  });
+
+  it("resolves the companion off the expense row, for the expenses feature", () => {
+    // The id in the path is an expense, not a patient, so the patient-param
+    // form of the guard would have nothing to read and must not be used here.
+    expect(requireCompanionPermissionForResource).toHaveBeenCalledWith(
+      "expenses",
+      resolveExpenseCompanion,
+    );
+  });
+
+  it("keeps the patient-param guard on the companion list and summary", () => {
+    for (const path of [
+      "/companion/:patientId/list",
+      "/companion/:patientId/summary",
+    ]) {
+      const route = findRoute(path, "get");
+      expect(route?.stack).toHaveLength(3);
+      expect(route?.stack.map((l) => l.handle)).toContain(companionGuard);
+    }
+    expect(requireCompanionPermission).toHaveBeenCalledWith(
+      "expenses",
+      "patientId",
+    );
+  });
+
+  it("leaves create unguarded by a companion check, since it has no id yet", () => {
+    // Ownership on create comes from the authenticated parent in the body path,
+    // not from a row that does not exist yet.
+    const route = findRoute("/", "post");
+    expect(route?.stack).toHaveLength(2);
+    expect(route?.stack.map((l) => l.handle)).toContain(requireMobileAuth);
+  });
+});


### PR DESCRIPTION
## What changed

Closes the mobile routes that are keyed by a **resource id** rather than a patient id. The list and summary routes beside them were already guarded in #2423's first pass; these were missed because the guard reads the patient from the path and these carry an expense or companion id instead.

| Route | Before | After |
| --- | --- | --- |
| `GET/PATCH/DELETE /expense/:expenseId` | `requireMobileAuth` only | + companion guard, resolved off the row |
| `GET/PUT /companion/:id` | `requireMobileAuth` only | + `companionProfile` guard |

## Why

Neither the handler nor the service put the caller in the query.

**Expenses** — `ExpenseService.getExpenseById` / `updateExpense` / `deleteExpense` all run `findFirst({ where: { id: expenseId } })`, and `ExpenseController` passes the path param straight through. No parent, no patient, no ownership assertion at any layer. The read also falls through to `Invoice`, so it covers practice-raised invoices as well as parent-recorded costs.

**Companions** — `CompanionService.getById` is a bare `findUnique({ where: { id } })`, and `update` writes with a bare `where: { id }`. `Patient` rows are not parent-scoped in the schema (the relationship lives on `ParentPatient`), so mobile auth alone was the only thing between a signed-in parent and every companion in the product. That is **37 rows today, readable and overwritable**, including the alerts blob.

The ids are UUIDs, so this is not trivially enumerable — but that is obscurity, not access control, and `DELETE` is destructive.

`CompanionService.getByName` directly below `getById` already carries a comment explaining that `Patient` is not org-scoped and therefore needs an explicit scope. `getById` never got the same treatment.

## How

`requireCompanionPermission` is refactored so the decision it makes is shared, and a second entry point takes a resolver:

```ts
requireCompanionPermissionForResource("expenses", resolveExpenseCompanion)
```

The resolver reads the companion off the row and returns one of `patient` / `allow` / `deny`. It is handed the caller's `parentId` so an invoice raised against a parent with no patient on it can be authorised by direct ownership instead of being denied — `allow` is narrow and only returned after the resolver has proved ownership itself.

The param path keeps its fail-fast check, so a route mounted with the wrong param name is still denied before it costs a query.

## Audited and deliberately not changed

Each of these was checked and already scopes its by-id reads:

- **Documents** — `loadDocumentForRequester` requires a parent or org, and `assertParentCanUpdateDocument` calls `assertParentCanAccessCompanion`.
- **Tasks** — the mobile branch of `getById` requires `createdBy === parentId || assignedTo === parentId`.
- **Appointments** — scoped; `patient` is a Json column with no id to resolve against.
- **`DELETE /companion/:id`** — `CompanionService.delete` resolves the parent, finds the link, and rejects a non-PRIMARY caller, including role-specific behaviour the permission blob does not describe. A blanket guard here would second-guess it with a coarser rule.

## Filed separately

`GET /companion/org/:id` (PMS) carries `requireWebAuth` but no `withOrgPermissions()` / `requirePermission`, unlike its `PUT` sibling. Same class of gap on the staff side. Fixing it needs a product decision — whether a vet may read a companion not linked to their organisation, which `PatientOrganisation` would answer — so it is not bundled into this change.

## Validation

- Full backend suite: **430 suites, 10,324 tests, all passing**.
- `tsc --noEmit` clean; eslint clean on the linted paths.
- Aikido SAST + secrets scan on the changed files: no findings.
- **Mutation-checked**, four ways:
  - resolver forced to always `allow` → 5 tests fail
  - `deny` treated as `allow` in the shared decision → 3 tests fail
  - guard deleted from the expense router → **initially passed all 22 middleware tests**, which is exactly how this regresses; router-level wiring tests were added and now catch it (3 fail)
  - guard deleted from the companion router → 2 fail

The wiring tests are the point of the third one: the middleware's own suite cannot tell whether the middleware is mounted.

## Impact

A co-parent whose `expenses` or `companionProfile` switch is off now gets a 403 on these routes where they previously succeeded. That is the intended enforcement and matches what the app already shows them.
