### PR TITLE
fix(ci): prune stale remote refs before the API deploy fetch

### DIFF
--- a/scripts/deploy/api-deploy.sh
+++ b/scripts/deploy/api-deploy.sh
@@ -56,7 +56,16 @@ cp apps/backend/.env "/tmp/api-env-before-$STAMP" 2>/dev/null || true
 echo "backups: /tmp/api-dist-before-$STAMP.tgz  /tmp/api-env-before-$STAMP"
 
 say "checkout $GIT_REF"
-git fetch --quiet origin "$GIT_REF" || git fetch --quiet origin
+# --prune is load-bearing. A remote branch named `fix` had been deleted upstream
+# while the box still held refs/remotes/origin/fix, so every refs/remotes/origin/fix/*
+# the fetch tried to create failed to lock, the whole fetch failed, and the deploy
+# stopped at "couldn't find remote ref". Pruning clears the deleted parent ref first.
+#
+# The ref is accepted as either `dev` or `origin/dev`; `git rev-parse` below adds the
+# remote itself, and passing the qualified form asked the remote for a branch called
+# `origin/dev`, which does not exist.
+GIT_REF="${GIT_REF#origin/}"
+git fetch --quiet --prune origin "$GIT_REF" || git fetch --quiet --prune origin
 git checkout --detach "$(git rev-parse "origin/$GIT_REF" 2>/dev/null || echo "$GIT_REF")" --quiet
 git rev-parse --short HEAD
 


### PR DESCRIPTION
## What changed

`scripts/deploy/api-deploy.sh` now fetches with `--prune`, and accepts the git ref as either `dev` or `origin/dev`.

## Why

The first real use of the script deployed nothing. It stopped here:

```
=== checkout origin/dev ===
fatal: couldn't find remote ref origin/dev
```

Two independent causes:

**A stale parent ref broke the whole fetch.** A remote branch named `fix` had been deleted upstream, but the box still held `refs/remotes/origin/fix`. Git cannot create `refs/remotes/origin/fix/*` while a ref exists at that exact path, so all ~30 `fix/...` branches failed to lock:

```
error: cannot lock ref 'refs/remotes/origin/fix/passport-under-health':
  'refs/remotes/origin/fix' exists; cannot create ...
```

Those failures fail the fetch as a whole, so the fallback `git fetch origin` died too. `--prune` removes the deleted parent ref before creating the children.

**The ref argument was only accepted bare.** `git rev-parse "origin/$GIT_REF"` adds the remote itself, so passing `origin/dev` asked the remote for a branch literally named `origin/dev`. Both forms are now accepted.

## Worth recording

The failed run reported **exit 0**. That was the invoking pipeline's `tail`, not the script: `set -e` had aborted correctly and the status was masked by `ssh ... | tail`. The script's own header already says exit code 0 is not evidence; this is the same lesson one level up, in how it is called.

## Validation

- `bash -n` clean.
- Root cause cleared on the dev box (`git update-ref -d refs/remotes/origin/fix` + prune), after which `git fetch origin dev` resolves `origin/dev` correctly.
- Re-ran the deploy end to end with the corrected ref: checkout, install, prisma generate and `migrate deploy` (145 migrations, none pending), package builds.