### PR TITLE
test(ci): cover the API deploy git-sync against a real remote

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -59,6 +59,10 @@ jobs:
     # the unit-test job; without this guard it would also start a real deploy, with
     # an empty `environment` input, on every PR that touches scripts/deploy.
     if: github.event_name == 'workflow_dispatch'
+    # The tests gate the deploy rather than running beside it. Without this the two
+    # jobs start together on a dispatch, and a broken ref-sync change could reach a
+    # live host while its own suite was still going red in parallel.
+    needs: git-sync-tests
     name: Deploy API (${{ inputs.environment }})
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -49,6 +49,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Run deploy git-sync tests
         run: ./scripts/deploy/tests/git-sync.test.sh
 
@@ -118,14 +120,20 @@ jobs:
           TARGET_REF="${REF:-$DEFAULT_REF}"
           echo "Deploying $TARGET_REF to $HOST ($REPO)"
 
-          # Ship the script from THIS checkout rather than trusting whatever
-          # version happens to be on the box.
-          scp -i ~/.ssh/deploy_key -o StrictHostKeyChecking=yes \
-            scripts/deploy/api-deploy.sh "ubuntu@$HOST:/tmp/api-deploy.sh"
+          # Ship the whole deploy directory from THIS checkout rather than
+          # trusting whatever version happens to be on the box. The directory,
+          # not just the entry script: api-deploy.sh sources lib/git-sync.sh
+          # relative to its own location, so copying the one file would leave it
+          # looking for a helper that is not there and exit before preflight.
+          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=yes "ubuntu@$HOST" \
+            "rm -rf /tmp/yc-deploy && mkdir -p /tmp/yc-deploy"
+
+          scp -r -i ~/.ssh/deploy_key -o StrictHostKeyChecking=yes \
+            scripts/deploy/. "ubuntu@$HOST:/tmp/yc-deploy/"
 
           ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=yes \
             -o ServerAliveInterval=30 "ubuntu@$HOST" \
-            "chmod +x /tmp/api-deploy.sh && /tmp/api-deploy.sh '$REPO' '$PM2_TARGET' '$TARGET_REF'"
+            "chmod +x /tmp/yc-deploy/api-deploy.sh && /tmp/yc-deploy/api-deploy.sh '$REPO' '$PM2_TARGET' '$TARGET_REF'"
 
       - name: Verify from outside
         shell: bash

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -11,6 +11,13 @@ name: Deploy API
 # someone makes, not a side effect of merging. What this removes is the drift and
 # the laptop, not the judgement.
 on:
+  # The deploy itself stays manual (see below). The unit tests for its git-sync
+  # step do not: they are the only thing standing between a refspec edit and a
+  # deploy that stops on a ref-lock error, which is how this script first failed.
+  pull_request:
+    paths:
+      - 'scripts/deploy/**'
+      - '.github/workflows/deploy-api.yml'
   workflow_dispatch:
     inputs:
       environment:
@@ -31,11 +38,25 @@ permissions:
 # between `git checkout` and `pm2 restart` leaves the box on new source with an
 # old bundle.
 concurrency:
-  group: deploy-api-${{ inputs.environment }}
+  # Keyed by event as well as host: a PR running the unit tests must not queue
+  # behind a deploy, and two PRs must not serialise against each other.
+  group: deploy-api-${{ github.event_name }}-${{ inputs.environment || github.ref }}
   cancel-in-progress: false
 
 jobs:
+  git-sync-tests:
+    name: git-sync unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Run deploy git-sync tests
+        run: ./scripts/deploy/tests/git-sync.test.sh
+
   deploy:
+    # Only ever on an explicit dispatch. The pull_request trigger above exists for
+    # the unit-test job; without this guard it would also start a real deploy, with
+    # an empty `environment` input, on every PR that touches scripts/deploy.
+    if: github.event_name == 'workflow_dispatch'
     name: Deploy API (${{ inputs.environment }})
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/scripts/deploy/api-deploy.sh
+++ b/scripts/deploy/api-deploy.sh
@@ -39,8 +39,17 @@ SMOKE_PORT="${4:-8099}"
 
 NODE_BIN="${NODE_BIN:-$HOME/.nvm/versions/node/v22.21.1/bin}"
 
+# lib/ has to travel WITH this script. Copying api-deploy.sh alone leaves this
+# looking for a helper that is not on the box, and bash exits before preflight
+# with a bare "No such file or directory" - so say what is actually wrong.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ ! -r "$SCRIPT_DIR/lib/git-sync.sh" ]; then
+  echo "missing $SCRIPT_DIR/lib/git-sync.sh" >&2
+  echo "Copy the whole scripts/deploy directory to the host, not just this file." >&2
+  exit 1
+fi
 # shellcheck source=lib/git-sync.sh
-. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/git-sync.sh"
+. "$SCRIPT_DIR/lib/git-sync.sh"
 export PATH="$NODE_BIN:$PATH"
 export NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=2048}"
 

--- a/scripts/deploy/api-deploy.sh
+++ b/scripts/deploy/api-deploy.sh
@@ -38,6 +38,9 @@ GIT_REF="${3:?git ref required}"
 SMOKE_PORT="${4:-8099}"
 
 NODE_BIN="${NODE_BIN:-$HOME/.nvm/versions/node/v22.21.1/bin}"
+
+# shellcheck source=lib/git-sync.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/git-sync.sh"
 export PATH="$NODE_BIN:$PATH"
 export NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=2048}"
 
@@ -56,18 +59,11 @@ cp apps/backend/.env "/tmp/api-env-before-$STAMP" 2>/dev/null || true
 echo "backups: /tmp/api-dist-before-$STAMP.tgz  /tmp/api-env-before-$STAMP"
 
 say "checkout $GIT_REF"
-# --prune is load-bearing. A remote branch named `fix` had been deleted upstream
-# while the box still held refs/remotes/origin/fix, so every refs/remotes/origin/fix/*
-# the fetch tried to create failed to lock, the whole fetch failed, and the deploy
-# stopped at "couldn't find remote ref". Pruning clears the deleted parent ref first.
-#
-# The ref is accepted as either `dev` or `origin/dev`; `git rev-parse` below adds the
-# remote itself, and passing the qualified form asked the remote for a branch called
-# `origin/dev`, which does not exist.
-GIT_REF="${GIT_REF#origin/}"
-git fetch --quiet --prune origin "$GIT_REF" || git fetch --quiet --prune origin
-git checkout --detach "$(git rev-parse "origin/$GIT_REF" 2>/dev/null || echo "$GIT_REF")" --quiet
-git rev-parse --short HEAD
+# Fetch and checkout live in lib/git-sync.sh so their two failure modes - a stale
+# parent ref breaking the whole fetch, and a qualified `origin/dev` being sent to
+# the remote as a branch name - are covered by tests/git-sync.test.sh against a
+# real remote, rather than only being found on a live box.
+deploy_git_sync "$REPO_DIR" "$GIT_REF"
 
 say "install"
 pnpm install --frozen-lockfile

--- a/scripts/deploy/lib/git-sync.sh
+++ b/scripts/deploy/lib/git-sync.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Move a deploy checkout onto a requested ref.
+#
+# Extracted from api-deploy.sh so the two failure modes below can be tested
+# against a real remote instead of only being discovered on a live box.
+#
+# deploy_git_sync <repo-dir> <git-ref>
+#
+# Echoes the resolved short SHA. Returns non-zero if the ref cannot be resolved -
+# the caller runs under `set -e`, and a deploy that cannot find its ref must stop
+# rather than build whatever happens to be checked out.
+
+deploy_git_sync() {
+  local repo_dir="${1:?repo dir required}"
+  local git_ref="${2:?git ref required}"
+
+  cd "$repo_dir" || return 1
+
+  # Accept `dev` or `origin/dev`. The remote is added back below, so passing the
+  # qualified form asked the remote for a branch literally named `origin/dev`,
+  # which does not exist, and the deploy stopped at "couldn't find remote ref".
+  git_ref="${git_ref#origin/}"
+
+  # Prune first, on its own, every time.
+  #
+  # When a remote branch is deleted upstream the box keeps its remote-tracking
+  # ref. If a branch is later created UNDER that name - `fix` deleted, then
+  # `fix/passport-under-health` created - git cannot write
+  # refs/remotes/origin/fix/* while a ref still sits at refs/remotes/origin/fix.
+  # Every child fails to lock and takes the whole fetch down with it, including
+  # the unrelated ref the deploy actually wanted. That is what stopped the first
+  # real run of this script.
+  #
+  # This is a separate step rather than `fetch --prune` because a fetch that
+  # names a single refspec only prunes within that refspec: `fetch --prune
+  # origin dev` succeeds while leaving the dead parent in place, so the box stays
+  # armed for the next caller that needs a full fetch. Clearing it unconditionally
+  # repairs the checkout instead of stepping around it.
+  git remote prune origin >/dev/null 2>&1 || true
+
+  git fetch --quiet --prune origin "$git_ref" || git fetch --quiet --prune origin
+
+  local resolved
+  resolved="$(git rev-parse --verify --quiet "origin/$git_ref" \
+    || git rev-parse --verify --quiet "$git_ref")" || {
+    echo "could not resolve '$git_ref' (or 'origin/$git_ref') after fetch" >&2
+    return 1
+  }
+
+  git checkout --detach "$resolved" --quiet
+  git rev-parse --short HEAD
+}

--- a/scripts/deploy/tests/git-sync.test.sh
+++ b/scripts/deploy/tests/git-sync.test.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+#
+# Regression tests for deploy_git_sync, run against a real temporary remote.
+#
+# Both cases below actually happened on the dev API box and deployed nothing
+# while the deploy step still looked like it had run. Neither is expressible as
+# a unit test with a mocked git - they are refspec and ref-locking semantics, so
+# the test builds a bare remote and a clone and drives real git.
+#
+# Usage: scripts/deploy/tests/git-sync.test.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$HERE/../lib/git-sync.sh"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+
+ok() { printf '  ok   %s\n' "$1"; PASS=$((PASS + 1)); }
+no() { printf '  FAIL %s\n     %s\n' "$1" "$2"; FAIL=$((FAIL + 1)); }
+
+check() { # check <name> <expected> <actual>
+  if [ "$2" = "$3" ]; then ok "$1"; else no "$1" "expected '$2', got '$3'"; fi
+}
+
+git_quiet() { git -c init.defaultBranch=main -c user.email=t@t -c user.name=t "$@"; }
+
+# A bare remote with a `dev` branch, plus a `fix` branch that is later deleted and
+# replaced by branches nested under that same name.
+setup_remote() {
+  local remote="$WORK/remote.git" seed="$WORK/seed"
+  rm -rf "$remote" "$seed"
+  git_quiet init --quiet --bare "$remote"
+  git_quiet clone --quiet "$remote" "$seed" 2>/dev/null
+  (
+    cd "$seed"
+    echo one > file.txt
+    git_quiet add file.txt
+    git_quiet commit --quiet -m "one"
+    git_quiet push --quiet origin HEAD:refs/heads/dev
+    git_quiet push --quiet origin HEAD:refs/heads/fix
+  )
+  # Point the bare repo's HEAD at a branch that exists, so a clone lands on a
+  # commit. Without this the default HEAD names a branch that was never pushed,
+  # clones come up empty, and `rev-parse HEAD` has nothing to read.
+  git_quiet -C "$remote" symbolic-ref HEAD refs/heads/dev
+  echo "$remote"
+}
+
+# A working copy that has already fetched, so it holds refs/remotes/origin/fix.
+setup_clone() {
+  local remote="$1" clone="$WORK/clone"
+  rm -rf "$clone"
+  git_quiet clone --quiet "$remote" "$clone" 2>/dev/null
+  (cd "$clone" && git_quiet fetch --quiet origin)
+  echo "$clone"
+}
+
+advance_dev() { # advance_dev <remote> -> echoes the new full sha
+  local remote="$1" bump="$WORK/bump"
+  rm -rf "$bump"
+  git_quiet clone --quiet --branch dev "$remote" "$bump" 2>/dev/null
+  (
+    cd "$bump"
+    echo two >> file.txt
+    git_quiet add file.txt
+    git_quiet commit --quiet -m "two"
+    git_quiet push --quiet origin HEAD:refs/heads/dev
+    git rev-parse HEAD
+  )
+}
+
+echo "deploy_git_sync"
+
+# ---------------------------------------------------------------------------
+# 1. The failure as it actually happened, which needs BOTH conditions at once.
+#
+#    A single-refspec fetch (`git fetch origin dev`) never tries to create
+#    refs/remotes/origin/fix/*, so a stale parent ref alone does not break it.
+#    What broke the box was the qualified ref: `git fetch origin origin/dev` asks
+#    the remote for a branch that does not exist, fails, and falls through to the
+#    full `git fetch origin` - and THAT is the fetch the stale parent ref kills.
+#
+#    Testing the two conditions separately is why the first version of this file
+#    passed with --prune removed.
+# ---------------------------------------------------------------------------
+REMOTE="$(setup_remote)"
+CLONE="$(setup_clone "$REMOTE")"
+(
+  cd "$WORK/seed"
+  git_quiet push --quiet origin --delete fix
+  git_quiet push --quiet origin HEAD:refs/heads/fix/passport-under-health
+)
+WANT="$(advance_dev "$REMOTE")"
+
+# Preconditions, or the test proves nothing.
+if git -C "$CLONE" show-ref --verify --quiet refs/remotes/origin/fix; then
+  ok "precondition: clone holds the stale refs/remotes/origin/fix"
+else
+  no "precondition: clone holds the stale refs/remotes/origin/fix" "ref absent"
+fi
+if git -C "$CLONE" fetch origin >/dev/null 2>&1; then
+  no "precondition: a plain fetch is broken by the stale ref" "plain fetch succeeded"
+else
+  ok "precondition: a plain fetch is broken by the stale ref"
+fi
+
+GOT="$(deploy_git_sync "$CLONE" origin/dev 2>/dev/null || echo SYNC_FAILED)"
+check "recovers when the fallback fetch hits a stale parent ref" \
+  "$(git -C "$CLONE" rev-parse --short "$WANT")" "$GOT"
+check "checks out the requested commit, not whatever was there" \
+  "$WANT" "$(git -C "$CLONE" rev-parse HEAD)"
+
+# The dead parent must be GONE, not merely stepped around. A single-refspec
+# fetch can succeed while leaving it in place, which leaves the checkout armed
+# for the next caller that needs a full fetch.
+if git -C "$CLONE" show-ref --verify --quiet refs/remotes/origin/fix; then
+  no "clears the stale parent ref rather than working around it" "ref still present"
+else
+  ok "clears the stale parent ref rather than working around it"
+fi
+if git -C "$CLONE" fetch origin >/dev/null 2>&1; then
+  ok "a plain fetch works again afterwards"
+else
+  no "a plain fetch works again afterwards" "still broken"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. The bare form resolves without asking the remote for a branch that cannot
+#    exist. The qualified form still WORKS without the normalisation, because
+#    the rev-parse fallback below covers it - what the normalisation buys is not
+#    spending a doomed fetch first, so that is what is asserted.
+# ---------------------------------------------------------------------------
+REMOTE="$(setup_remote)"
+CLONE="$(setup_clone "$REMOTE")"
+WANT="$(advance_dev "$REMOTE")"
+
+ERRS="$(deploy_git_sync "$CLONE" origin/dev 2>&1 >/dev/null || true)"
+check "qualified form lands on the requested commit" \
+  "$WANT" "$(git -C "$CLONE" rev-parse HEAD)"
+if printf '%s' "$ERRS" | grep -q "couldn't find remote ref"; then
+  no "qualified form does not ask the remote for 'origin/dev'" "$ERRS"
+else
+  ok "qualified form does not ask the remote for 'origin/dev'"
+fi
+
+REMOTE="$(setup_remote)"
+CLONE="$(setup_clone "$REMOTE")"
+WANT="$(advance_dev "$REMOTE")"
+check "bare form lands on the same commit" \
+  "$(git -C "$CLONE" rev-parse --short "$WANT")" \
+  "$(deploy_git_sync "$CLONE" dev 2>/dev/null || echo SYNC_FAILED)"
+
+# ---------------------------------------------------------------------------
+# 3. An unresolvable ref must fail, not silently build whatever is checked out.
+# ---------------------------------------------------------------------------
+REMOTE="$(setup_remote)"
+CLONE="$(setup_clone "$REMOTE")"
+BEFORE="$(git -C "$CLONE" rev-parse HEAD)"
+
+if deploy_git_sync "$CLONE" no-such-branch >/dev/null 2>&1; then
+  no "fails on an unresolvable ref" "returned success"
+else
+  ok "fails on an unresolvable ref"
+fi
+check "leaves the checkout untouched when the ref cannot be resolved" \
+  "$BEFORE" "$(git -C "$CLONE" rev-parse HEAD)"
+
+echo
+echo "  $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Follows up the Codex P1 on #2446: that change altered deploy behaviour with no automated coverage, and both paths turn on git refspec and ref-locking semantics a mocked git would not reproduce.

Fetch and checkout move to `scripts/deploy/lib/git-sync.sh` so `scripts/deploy/tests/git-sync.test.sh` can drive them against a real bare remote and clone.

## Writing the tests changed the fix

The first version of this test asserted the two conditions separately, and **passed with `--prune` removed**. A fetch naming a single refspec never tries to create `refs/remotes/origin/fix/*`, so a stale parent ref alone does not block it. The box failed only when both conditions held at once: the qualified ref made the first fetch fail, and the fallback full fetch is what the stale parent killed.

That also showed `--prune` on the fetch was the wrong shape. A single-refspec prune does not remove the dead parent, so #2446 stepped around the landmine and left it armed for the next caller needing a full fetch. Pruning is now its own unconditional step, and the test asserts the ref is **gone** and a plain fetch works again afterwards.

## Coverage

11 assertions, including two preconditions that fail loudly if the fixture stops reproducing the bug:

```
ok   precondition: clone holds the stale refs/remotes/origin/fix
ok   precondition: a plain fetch is broken by the stale ref
ok   recovers when the fallback fetch hits a stale parent ref
ok   checks out the requested commit, not whatever was there
ok   clears the stale parent ref rather than working around it
ok   a plain fetch works again afterwards
ok   qualified form lands on the requested commit
ok   qualified form does not ask the remote for 'origin/dev'
ok   bare form lands on the same commit
ok   fails on an unresolvable ref
ok   leaves the checkout untouched when the ref cannot be resolved
```

**Mutation-checked**, all three caught:

| Mutation | Result |
| --- | --- |
| unconditional prune removed | 2 fail |
| `origin/` normalisation dropped | 1 fail |
| rev-parse failure guard replaced with a HEAD fallback | 1 fail |

## Workflow

`deploy-api.yml` gains a `pull_request` trigger scoped to `scripts/deploy/**`, and the `deploy` job is now guarded with `if: github.event_name == 'workflow_dispatch'`. Without that guard the new trigger would have started a **real deploy, with an empty `environment` input, on every PR** touching `scripts/deploy`. Concurrency is keyed by event so PR runs do not queue behind a deploy.

Closes the P1 on #2446.